### PR TITLE
Add openshift CI test container to execute e2e

### DIFF
--- a/.ci/openshift-ci/Dockerfile
+++ b/.ci/openshift-ci/Dockerfile
@@ -1,0 +1,11 @@
+FROM registry.ci.openshift.org/openshift/release:golang-1.15
+
+SHELL ["/bin/bash", "-c"]
+
+# Install yq, kubectl
+RUN yum install --assumeyes -d1 python3-pip  httpd-tools && \
+    pip3 install --upgrade setuptools && \
+    pip3 install yq && \
+    curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl && \
+    chmod +x ./kubectl && \
+    mv ./kubectl /usr/local/bin


### PR DESCRIPTION
In openshift ci all the scripts are running inside of container. The current PR will setup the initial container with necessary tools to execute the `${ROOT_DIR}/.ci/oci-e2e-deployment.sh`.
