### PR TITLE
syntax fix in yaml for ClusterRoleBinding

### DIFF
--- a/components/build/build-templates/2-read-pipelines-binding.yaml
+++ b/components/build/build-templates/2-read-pipelines-binding.yaml
@@ -1,4 +1,3 @@
---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:


### PR DESCRIPTION
Extra text in yaml for pipelines role binding breaks the kustomize apply .

```Error: accumulating resources: accumulation err='accumulating resources from 'build-templates/': 'G:\Dev\infra-deployments\components\build\build-templates' must resolve to a file': recursed accumulation of path 'G:\Dev\infra-deployments\components\build\build-templates': accumulating resources: accumulation err='accumulating resources from '2-read-pipelines-binding.yaml': yaml: line 2: mapping values are not allowed in this context': got file '2-read-pipelines-binding.yaml', but 'G:\Dev\infra-deployments\components\build\build-templates\2-read-pipelines-binding.yaml' must be a directory to be a root```