### PR TITLE
windows scripts for bootstrap and destroy

### DIFF
--- a/hack/bootstrap-cluster.cmd
+++ b/hack/bootstrap-cluster.cmd
@@ -1,0 +1,41 @@
+@echo off 
+
+set ROOT=%~dp0\..
+
+echo "Installing the OpenShift GitOps operator subscription:"
+kubectl apply -f %ROOT%/openshift-gitops/subscription-openshift-gitops.yaml
+
+echo.
+echo "Waiting for default project (and namespace) to exist:" 
+:L1
+choice /D N /T 1  > nul
+kubectl get appproject/default -n openshift-gitops 2>nul 
+if %ERRORLEVEL% == 1 goto :L1 
+
+echo.
+echo "Waiting for OpenShift GitOps Route:"
+:L2
+choice /D N /T 1  > nul
+kubectl get route/openshift-gitops-server -n openshift-gitops 2>nul 
+if %ERRORLEVEL% == 1 goto :L2
+ 
+echo.
+echo "Add Role/RoleBindings for OpenShift GitOps:"
+kustomize build %ROOT%/openshift-gitops/cluster-rbac | kubectl apply -f -
+ 
+echo.
+echo "Add parent Argo CD Application:"
+kubectl apply -f %ROOT%/argo-cd-apps/app-of-apps/all-applications-staging.yaml
+ 
+echo.
+echo "========================================================================="
+echo "Argo CD Route is:"
+kubectl get route/openshift-gitops-server -n openshift-gitops
+echo.
+echo "(NOTE: It may take a few moments for the route to become available)"
+echo.
+echo "Login/password uses your OpenShift credentials ('Login with OpenShift' button)"
+echo.
+
+
+

--- a/hack/destroy-cluster.cmd
+++ b/hack/destroy-cluster.cmd
@@ -1,0 +1,39 @@
+@echo off 
+set ROOT=%~dp0\..
+
+rem Remove resources in the reverse order from bootstrapping
+
+echo.
+echo "Remove Argo CD Applications:"
+kubectl delete -f %ROOT%/argo-cd-apps/app-of-apps/all-applications-staging.yaml
+rem kustomize build  %ROOT%/argo-cd-apps/overlays/staging | kubectl delete -f -
+
+echo.
+echo "Remove RBAC for OpenShift GitOps:"
+kustomize build %ROOT%/openshift-gitops/cluster-rbac | kubectl delete -f -
+
+echo.
+echo "Remove the OpenShift GitOps operator subscription:"
+kubectl delete -f %ROOT%/openshift-gitops/subscription-openshift-gitops.yaml
+
+echo. 
+echo "Removing GitOps operator and operands:"
+
+:L1 
+  kubectl patch argocd/openshift-gitops -n openshift-gitops -p "{\"metadata\":{\"finalizers\":null}}" --type=merge
+  kubectl delete csv/openshift-gitops-operator.v1.3.0 -n openshift-operators
+  kubectl delete csv/openshift-gitops-operator.v1.3.0 -n openshift-gitops
+  kubectl delete csv/openshift-gitops-operator.v1.3.1 -n openshift-operators
+  kubectl delete csv/openshift-gitops-operator.v1.3.1 -n openshift-gitops
+  kubectl delete namespace --timeout=30s openshift-gitops
+
+  kubectl get namespace/openshift-gitops
+  set RC=%ERRORLEVEL%
+  if %RC% == 1 goto :end  
+  echo %RC%
+goto :L1
+
+:end
+
+echo.
+echo "Complete."


### PR DESCRIPTION
I ported the bootstrap and destroy scripts to Windows for use with CRC. 

The scripts match the original scripts and were tested on:
```
CodeReady Containers version: 1.35.0+751824a9
OpenShift version: 4.9.5 (bundle installed at C:\Program Files\CodeReady Containers\crc_hyperv_4.9.5.crcbundle)
```