### PR TITLE
Add Hybrid Application Service component

### DIFF
--- a/argo-cd-apps/base/has.yaml
+++ b/argo-cd-apps/base/has.yaml
@@ -1,0 +1,33 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: has
+  
+spec:
+  project: default
+
+  source:
+    path: components/has
+    repoURL: https://github.com/redhat-appstudio/infra-deployments.git
+
+  destination:
+    namespace: application-service
+    server: https://kubernetes.default.svc
+
+  syncPolicy:
+
+    # Comment this out if you want to manually trigger deployments (using the 
+    # Argo CD Web UI or Argo CD CLI), rather than automatically deploying on
+    # every new Git commit to your directory.
+    automated: 
+      prune: true
+      selfHeal: true
+
+    syncOptions:
+    - CreateNamespace=true
+
+    retry:
+      limit: 50 # number of failed sync attempt retries; unlimited number of attempts if less than 0
+      backoff:
+        duration: 15s # the amount to back off. Default unit is seconds, but could also be a duration (e.g. "2m", "1h")
+

--- a/argo-cd-apps/base/kustomization.yaml
+++ b/argo-cd-apps/base/kustomization.yaml
@@ -2,6 +2,7 @@ resources:
 - gitops.yaml
 - build.yaml
 - authentication.yaml
+- has.yaml
 
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/components/has/catalogsource.yaml
+++ b/components/has/catalogsource.yaml
@@ -1,0 +1,10 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: has-operator-catalog
+  namespace: openshift-marketplace
+spec:
+  sourceType: grpc
+  image: quay.io/redhat-appstudio/application-service-catalog:sha-205925d
+  displayName: HAS Operator Catalog
+  publisher: Red Hat

--- a/components/has/kustomization.yaml
+++ b/components/has/kustomization.yaml
@@ -1,0 +1,7 @@
+resources:
+- catalogsource.yaml
+- operatorgroup.yaml
+- subscription.yaml
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization

--- a/components/has/operatorgroup.yaml
+++ b/components/has/operatorgroup.yaml
@@ -1,0 +1,8 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: has-operator-group
+  namespace: openshift-operators
+spec:
+  targetNamespaces:
+  - application-service

--- a/components/has/operatorgroup.yaml
+++ b/components/has/operatorgroup.yaml
@@ -2,7 +2,4 @@ apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:
   name: has-operator-group
-  namespace: openshift-operators
-spec:
-  targetNamespaces:
-  - application-service
+  namespace: application-service

--- a/components/has/subscription.yaml
+++ b/components/has/subscription.yaml
@@ -1,0 +1,12 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: has-operator
+  namespace: application-service
+spec:
+  channel: alpha
+  installPlanApproval: Automatic
+  name: application-service
+  source: has-operator-catalog
+  sourceNamespace: openshift-marketplace
+  startingCSV: application-service.v0.0.1


### PR DESCRIPTION
This PR adds a component for HAS to the AppStudio staging environment.

In all, the following is done by this PR:
- `CatalogSource`, `OperatorGroup` and `Subscription` yaml files for the HAS operator added under `components/has`
   - The catalogsource points to `quay.io/redhat-appstudio/application-service-catalog:sha-4f97678`
   - The OperatorGroup targets the `application-service` namespace
   - The Subscription installs the `application-service.v0.0.1` OLM bundle into the `application-service` namespace
- An ArgoCD application resource (has.yaml) added under `argo-cd-apps/base` that references the aforementioned `has` component.

I've also verified on my own OCP cluster that running `kustomize build argo-cd-apps/overlays/staging | oc apply -f -` properly deploys HAS:

<img width="1452" alt="Screen Shot 2021-11-17 at 2 03 36 PM" src="https://user-images.githubusercontent.com/6880023/142265873-74f3d476-d7db-4baa-bee3-c5d66ac5ef7f.png">


<img width="1727" alt="Screen Shot 2021-11-17 at 2 04 13 PM" src="https://user-images.githubusercontent.com/6880023/142265876-975ad831-8ef0-4755-9939-a891a89de9ee.png">


This PR should not be merged until https://github.com/redhat-appstudio/application-service/pull/17 is merged, but I wanted to get this PR up now for review/comments.