### PR TITLE
Add role for viewing application-service namespace

### DIFF
--- a/components/authentication/kustomization.yaml
+++ b/components/authentication/kustomization.yaml
@@ -1,6 +1,7 @@
 resources:
 - view-build-service.yaml
 - view-gitops-service.yaml
+- view-has.yaml
 
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/components/authentication/view-has.yaml
+++ b/components/authentication/view-has.yaml
@@ -1,0 +1,12 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: read-has
+  namespace: application-service
+subjects:
+  - kind: User
+    name: johnmcollier
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: view


### PR DESCRIPTION
Adds a role for viewing the `application-service` namespace on the staging cluster. Adds myself as one of the users with the role.