### PR TITLE
development mode scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,31 @@ Steps:
 3) Log-in to the Web UI using your OpenShift credentials (using 'Login with OpenShift' button).
 3) View the Argo CD UI to see the status of deployments.
 
+## Development mode for your own clusters
+
+Once you bootstrap a cluster above, the root ArgoCD Application and all of the component applications will each point to the upstream repository.
+
+To enable development for a team or individual to test changes on your own cluster, you need to replace the references to `https://github.com/redhat-appstudio/infra-deployments.git` with references to your own fork.
+
+There are a set of scripts that help with this, and minimize the changes needed in your forks.
+
+There is a development configuration in `overlays/development` which includes a kustomize overlay that can redirect the default components individual repositorys to your fork. 
+
+Steps:
+1) in your forked repository run `hack/development-mode.sh` and this will update the root application on the cluster and all of the git repo references in `argo-cd-apps/overlays/development/repo-overlay.yaml`
+2) you will need to push the updated references in `argo-cd-apps/overlays/development/repo-overlay.yaml` to your fork. Argo will now sync all the changes from your fork into the cluster
+3) You can now make changes to your forked repository and test them via the gitops
+
+4) To submit changes back to the upstream make sure you do not include the modified file `argo-cd-apps/overlays/development/repo-overlay.yaml`. 
+
+One option to prevent accidentally including this modified file, you can run the script `hack/upstream-mode.sh` to reset everything including your cluster to `https://github.com/redhat-appstudio/infra-deployments.git` and match the upstream config. You can also checkout the current upstream 
+` git fetch upstream; git checkout upstream/main -- argo-cd-apps/overlays/development/repo-overlay.yaml` to ensure you have the original file.  
+
+After you commit your changes you can rerun to `hack/development-mode.sh` and reset your repo to point back to the fork. 
+
+Note running these scripts in a clone repo will have no effect as the repo will remain `https://github.com/redhat-appstudio/infra-deployments.git`
+
+ 
 ## FAQ
 
 Other questions? Ask on `#wg-developer-appstudio`.

--- a/argo-cd-apps/overlays/development/kustomization.yaml
+++ b/argo-cd-apps/overlays/development/kustomization.yaml
@@ -1,0 +1,10 @@
+resources:
+- ../../base
+
+namespace: openshift-gitops
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+patchesStrategicMerge:
+  - repo-overlay.yaml
+
+

--- a/argo-cd-apps/overlays/development/repo-overlay.yaml
+++ b/argo-cd-apps/overlays/development/repo-overlay.yaml
@@ -1,0 +1,31 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: build
+spec:
+  source: # This will be replaced with a reference to your fork of this repo (see hack/patch-apps-for-dev.sh)
+    repoURL: https://github.com/redhat-appstudio/infra-deployments.git
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: gitops
+spec:
+  source:
+    repoURL: https://github.com/redhat-appstudio/infra-deployments.git
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: authentication
+spec:
+  source:
+    repoURL: https://github.com/redhat-appstudio/infra-deployments.git
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: has
+spec:
+  source:
+    repoURL: https://github.com/redhat-appstudio/infra-deployments.git

--- a/hack/development-mode.sh
+++ b/hack/development-mode.sh
@@ -1,0 +1,11 @@
+
+#!/bin/bash
+ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"/.. 
+
+REPO=$(git config --get remote.origin.url)
+ 
+#set the local cluster to point to the current git repo and update the path to development
+$ROOT/hack/util-update-app-of-apps.sh $REPO development
+# reset the default repos in the development directory to be the current git repo
+# this needs to be pushed to your fork to be seen by argocd
+$ROOT/hack/util-set-development-repos.sh $REPO development

--- a/hack/upstream-mode.sh
+++ b/hack/upstream-mode.sh
@@ -1,0 +1,15 @@
+
+#!/bin/bash
+ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"/.. 
+
+# switch to known upstream and revert the development overlay to be the upstream repo
+# this prevents accidental pull requests referencing forked repos used in dev
+# note, could use $(git config --get remote.upstream.url) but hardcoded for now
+# not everyone may have an upstream set
+REPO=https://github.com/redhat-appstudio/infra-deployments.git
+
+#set the local cluster to point back to the upstream  
+$ROOT/hack/util-update-app-of-apps.sh $REPO staging
+#reset the default content in the development directory to be the upstream
+$ROOT/hack/util-set-development-repos.sh $REPO development
+ 

--- a/hack/util-set-development-repos.sh
+++ b/hack/util-set-development-repos.sh
@@ -1,0 +1,33 @@
+
+#!/bin/bash
+
+# Redirect the root app-of-apps to the users local git repo (usually a fork)
+# if that repo is a simple clone this replacement is a noop
+# if that repo is a fork, this repo will updated to the forked repo
+
+# This allows any component to be replaced via gitops via a kustomize base development directory
+# That directory needs to be modified in the users fork to replace replacing any components in their cluster
+# This will minimize the chance of error in pull requests to upstream which may accidentally include
+# references to the forked repo.
+# note, if accidental merges are accepted in the development directory, they will not affect staging. 
+
+ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"/..
+MANIFEST=$ROOT/argo-cd-apps/app-of-apps/all-applications-staging.yaml
+GITURL=$1
+OVERLAYDIR=argo-cd-apps/overlays/$2  
+
+echo
+echo In dev mode, verify that argo-cd-apps/overlays/development includes a kustomization that points to this repo
+echo If you want to reset to the default upstream run the upstream-mode.sh script  
+
+PATCH="$(printf '.spec.source.repoURL="%q"' $GITURL)" 
+yq  e "$PATCH" $OVERLAYDIR/repo-overlay.yaml -i 
+
+echo
+echo The list of components which will be patched is
+yq  e '.metadata.name' $OVERLAYDIR/repo-overlay.yaml
+
+echo
+echo Each component above is set to the following repositories
+echo if you do not see your component in the list, please send a PR update to $OVERLAYDIR/repo-overlay.yaml
+yq  e '.spec.source.repoURL' $OVERLAYDIR/repo-overlay.yaml

--- a/hack/util-update-app-of-apps.sh
+++ b/hack/util-update-app-of-apps.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# Redirect the root app-of-apps to the users local git repo (usually a fork)
+# if that repo is a simple clone this replacement is a noop
+# if that repo is a fork, this repo will updated to the forked repo
+
+# This allows any component to be replaced via gitops via a kustomize development directory
+# That directory needs to be modified in the users fork when replacing any components in their cluster
+# This will minimize the chance of error in pull requests to upstream which may accidentally include
+# references to the forked repo.
+# note, if accidental merges are accepted in the development directory, they will not affect staging. 
+
+ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"/..
+MANIFEST=$ROOT/argo-cd-apps/app-of-apps/all-applications-staging.yaml
+GITURL=$1
+OVERLAYDIR=argo-cd-apps/overlays/$2
+
+PATCHREPO="$(printf '.spec.source.repoURL="%q"' $GITURL)" 
+PATCHOVERLAY="$(printf '.spec.source.path="%q"' $OVERLAYDIR)"  
+
+# the overlay content can be updated selectively per user in their fork
+# to replace the specific component they are evolving  
+
+echo
+echo "Setting the application repo to $GITURL overlay to $OVERLAYDIR"  
+yq  e "$PATCHOVERLAY" $MANIFEST | yq  e "$PATCHREPO" - | kubectl apply -f -
+ 


### PR DESCRIPTION
This pr has a set of scripts and configurations that help with using this repository with your own cluster. 

Once you bootstrap, the root ArgoCD "app-of-apps", each of the component applications will each point to the upstream repository.  To enable development  test changes on your own cluster using the same gitops used to create staging, you replace the references to `https://github.com/redhat-appstudio/infra-deployments.git` with references to your own fork. The use of gitops means you can also easily share your config with others using the same bootstrap mechanism as staging. 

This PR includes a set of scripts that help with this, and minimize the changes needed in a fork. 
See the main README for usage instructions.
The usage of this PR required yq to update manifests see https://github.com/mikefarah/yq
 
The PR  
1) enables use of forks to test via gitops in dev environments
2) A script `hack/development-mode.sh` will update a single file in your fork to redirect gitops to that fork. This file must be committed to your fork. This uses kustomize overlays to map the repositories per component to your fork. You can also just replace a reference to your own component and keep the rest from upstream. As this file is committed back to your fork so care is needed not to include it in pull requests upstream however it accidentally included upstream, it will be "harmless" (default forks of upstream will use your fork until replace in dev mode) 
3) users can switch from dev mode back to upstream mode
4) Use of a separate overlay directory is intended to minimize the risk of a PR including accidental mods to staging and only one file is modified. 