### PR TITLE
support branches in dev mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ To enable development for a team or individual to test changes on your own clust
 There are a set of scripts that help with this, and minimize the changes needed in your forks.
 
 There is a development configuration in `overlays/development` which includes a kustomize overlay that can redirect the default components individual repositorys to your fork. 
+The script also supports branches automatically. If you work in a checked out branch, each of the components in the overlays will mapped to that branch by setting `targetRevision:`.  
 
 Steps:
 1) in your forked repository run `hack/development-mode.sh` and this will update the root application on the cluster and all of the git repo references in `argo-cd-apps/overlays/development/repo-overlay.yaml`

--- a/argo-cd-apps/overlays/development/repo-overlay.yaml
+++ b/argo-cd-apps/overlays/development/repo-overlay.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   source: # This will be replaced with a reference to your fork of this repo (see hack/patch-apps-for-dev.sh)
     repoURL: https://github.com/redhat-appstudio/infra-deployments.git
+    targetRevision: main
 ---
 apiVersion: argoproj.io/v1alpha1
 kind: Application
@@ -13,6 +14,7 @@ metadata:
 spec:
   source:
     repoURL: https://github.com/redhat-appstudio/infra-deployments.git
+    targetRevision: main
 ---
 apiVersion: argoproj.io/v1alpha1
 kind: Application
@@ -21,6 +23,7 @@ metadata:
 spec:
   source:
     repoURL: https://github.com/redhat-appstudio/infra-deployments.git
+    targetRevision: main
 ---
 apiVersion: argoproj.io/v1alpha1
 kind: Application
@@ -29,3 +32,4 @@ metadata:
 spec:
   source:
     repoURL: https://github.com/redhat-appstudio/infra-deployments.git
+    targetRevision: main

--- a/hack/development-mode.sh
+++ b/hack/development-mode.sh
@@ -3,9 +3,10 @@
 ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"/.. 
 
 REPO=$(git config --get remote.origin.url)
- 
-#set the local cluster to point to the current git repo and update the path to development
-$ROOT/hack/util-update-app-of-apps.sh $REPO development
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
+
+#set the local cluster to point to the current git repo and branch and update the path to development
+$ROOT/hack/util-update-app-of-apps.sh $REPO development $BRANCH 
 # reset the default repos in the development directory to be the current git repo
 # this needs to be pushed to your fork to be seen by argocd
-$ROOT/hack/util-set-development-repos.sh $REPO development
+$ROOT/hack/util-set-development-repos.sh $REPO development $BRANCH 

--- a/hack/upstream-mode.sh
+++ b/hack/upstream-mode.sh
@@ -9,7 +9,7 @@ ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"/..
 REPO=https://github.com/redhat-appstudio/infra-deployments.git
 
 #set the local cluster to point back to the upstream  
-$ROOT/hack/util-update-app-of-apps.sh $REPO staging
+$ROOT/hack/util-update-app-of-apps.sh $REPO staging main
 #reset the default content in the development directory to be the upstream
-$ROOT/hack/util-set-development-repos.sh $REPO development
+$ROOT/hack/util-set-development-repos.sh $REPO development main
  

--- a/hack/util-set-development-repos.sh
+++ b/hack/util-set-development-repos.sh
@@ -15,12 +15,20 @@ ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"/..
 MANIFEST=$ROOT/argo-cd-apps/app-of-apps/all-applications-staging.yaml
 GITURL=$1
 OVERLAYDIR=argo-cd-apps/overlays/$2  
-
+BRANCH=$3 
+if [ -z "$BRANCH" ]
+then
+      echo No Branch specified, setting all overlays targetRevisions to main  
+else  
+      echo Setting all overlays targetRevisions to $BRANCH  
+fi
 echo
 echo In dev mode, verify that argo-cd-apps/overlays/development includes a kustomization that points to this repo
 echo If you want to reset to the default upstream run the upstream-mode.sh script  
 
 PATCH="$(printf '.spec.source.repoURL="%q"' $GITURL)" 
+yq  e "$PATCH" $OVERLAYDIR/repo-overlay.yaml -i  
+PATCH="$(printf '.spec.source.targetRevision="%q"' $BRANCH)" 
 yq  e "$PATCH" $OVERLAYDIR/repo-overlay.yaml -i 
 
 echo

--- a/hack/util-set-development-repos.sh
+++ b/hack/util-set-development-repos.sh
@@ -18,9 +18,10 @@ OVERLAYDIR=argo-cd-apps/overlays/$2
 BRANCH=$3 
 if [ -z "$BRANCH" ]
 then
-      echo No Branch specified, setting all overlays targetRevisions to main  
+      echo No Branch specified, setting all overlays targetRevisions to main 
+      BRANCH=main 
 else  
-      echo Setting all overlays targetRevisions to $BRANCH  
+      echo Setting all overlays targetRevisions to $BRANCH 
 fi
 echo
 echo In dev mode, verify that argo-cd-apps/overlays/development includes a kustomization that points to this repo

--- a/hack/util-update-app-of-apps.sh
+++ b/hack/util-update-app-of-apps.sh
@@ -15,13 +15,25 @@ MANIFEST=$ROOT/argo-cd-apps/app-of-apps/all-applications-staging.yaml
 GITURL=$1
 OVERLAYDIR=argo-cd-apps/overlays/$2
 
+BRANCH=$3 
+if [ -z "$BRANCH" ]
+then
+      echo No Branch specified, setting app-of-apps to main  
+else  
+      echo Setting app-of-apps targetRevision to $BRANCH  
+fi
+
 PATCHREPO="$(printf '.spec.source.repoURL="%q"' $GITURL)" 
 PATCHOVERLAY="$(printf '.spec.source.path="%q"' $OVERLAYDIR)"  
+PATCHBRANCH="$(printf '.spec.source.targetRevision="%q"' $BRANCH)"  
 
 # the overlay content can be updated selectively per user in their fork
 # to replace the specific component they are evolving  
 
 echo
-echo "Setting the application repo to $GITURL overlay to $OVERLAYDIR"  
-yq  e "$PATCHOVERLAY" $MANIFEST | yq  e "$PATCHREPO" - | kubectl apply -f -
+echo "Setting the application repo to $GITURL, branch BRANCH in overlay $OVERLAYDIR"  
+yq  e "$PATCHOVERLAY" $MANIFEST | \
+ yq  e "$PATCHREPO" - | \
+ yq  e "$PATCHBRANCH" - | \
+ kubectl apply -f -
  


### PR DESCRIPTION
This PR updates the script to support branches in dev mode.
The overlay is updated to include a targetRevision which is updated to the branch active when the script is run.  

You can maintain multiple separate branches in forks and switch between them by checking out the branch and running the development mode script.  