### PR TITLE
Create a pipline maintainer role

### DIFF
--- a/components/authentication/gitops-ci.yaml
+++ b/components/authentication/gitops-ci.yaml
@@ -1,0 +1,13 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: gitops-service-ci-maintainers
+  namespace: gitops
+subjects:
+  - kind: User
+    apiGroup: rbac.authorization.k8s.io
+    name: sbose78
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: pipeline-maintainer

--- a/components/authentication/has-ci.yaml
+++ b/components/authentication/has-ci.yaml
@@ -1,0 +1,13 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: gitops-service-ci-maintainers
+  namespace: application-service
+subjects:
+  - kind: User
+    apiGroup: rbac.authorization.k8s.io
+    name: sbose78
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: pipeline-maintainer

--- a/components/authentication/kustomization.yaml
+++ b/components/authentication/kustomization.yaml
@@ -4,6 +4,7 @@ resources:
 - view-has.yaml
 - user-ci-maintainer.yaml
 - gitops-ci.yaml
+- has-ci.yaml
 
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/components/authentication/kustomization.yaml
+++ b/components/authentication/kustomization.yaml
@@ -2,6 +2,8 @@ resources:
 - view-build-service.yaml
 - view-gitops-service.yaml
 - view-has.yaml
+- user-ci-maintainer.yaml
+- gitops-ci.yaml
 
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/components/authentication/user-ci-maintainer.yaml
+++ b/components/authentication/user-ci-maintainer.yaml
@@ -1,0 +1,20 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: pipeline-maintainer
+rules:
+  - verbs:
+      - edit
+      - get
+    apiGroups:
+      - ''
+    resources:
+      - serviceaccounts
+    resourceNames:
+      - pipeline # TODO: figure out how to 'gitops' this.
+  - verbs:
+      - create # allows addition of credentials only.
+    apiGroups:
+      - ''
+    resources:
+      - secrets


### PR DESCRIPTION
This role allows users to elevate themselves to the role of a CI maintainer without granting unnecessary privileges:
* create secrets ( eventually would be replaced by SPI generated content )
* modify the 'pipeline' service account : would enable specification of pull secrets.

This PR grants @sbose78 pipeline-maintainer in the following namespaces:
* application-service
* gitops