### PR TITLE
add CI to gitops service

### DIFF
--- a/argo-cd-apps/base/gitops.yaml
+++ b/argo-cd-apps/base/gitops.yaml
@@ -9,7 +9,6 @@ spec:
   source:
     path: components/gitops
     repoURL: https://github.com/redhat-appstudio/infra-deployments.git
-
   destination:
     namespace: gitops
     server: https://kubernetes.default.svc

--- a/components/gitops/.tekton/event-listener.yaml
+++ b/components/gitops/.tekton/event-listener.yaml
@@ -1,0 +1,12 @@
+apiVersion: triggers.tekton.dev/v1alpha1
+kind: EventListener
+metadata:
+  name: gitops-service-cluster-agent
+spec:
+  serviceAccountName: pipeline
+  triggers:
+    - bindings:
+        - kind: ClusterTriggerBinding
+          ref: github-push
+      template:
+        ref: gitops-service-cluster-agent

--- a/components/gitops/.tekton/kustomization.yaml
+++ b/components/gitops/.tekton/kustomization.yaml
@@ -2,6 +2,7 @@ resources:
 - pipeline.yaml
 - trigger-template.yaml
 - event-listener.yaml
+- webhook-route.yaml
 
 # Skip applying the Tekton operands while the Tekton operator is being installed.
 # See more information about this option, here: 

--- a/components/gitops/.tekton/kustomization.yaml
+++ b/components/gitops/.tekton/kustomization.yaml
@@ -1,0 +1,13 @@
+resources:
+- pipeline.yaml
+- trigger-template.yaml
+- event-listener.yaml
+
+# Skip applying the Tekton operands while the Tekton operator is being installed.
+# See more information about this option, here: 
+# https://argo-cd.readthedocs.io/en/stable/user-guide/sync-options/#skip-dry-run-for-new-custom-resources-types 
+commonAnnotations:
+  argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization

--- a/components/gitops/.tekton/pipeline.yaml
+++ b/components/gitops/.tekton/pipeline.yaml
@@ -1,0 +1,86 @@
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: appstudio-dockerfile-builder
+spec:
+  params:
+    - description: Source Repository URL
+      name: git-url
+      type: string
+    - default: main
+      description: Git Revision
+      name: revision
+      type: string
+    - description: Output Image
+      name: output-image
+      type: string
+    - description: Context
+      name: context
+      type: string
+      default: .
+    - description: Path to the Dockerfile
+      name: dockerfile
+      type: string
+      default: Dockerfile
+  tasks:
+    - name: clone-repository
+      params:
+        - name: url
+          value: $(params.git-url)
+        - name: revision
+          value: $(params.revision)
+      taskRef:
+        kind: ClusterTask
+        name: git-clone
+      workspaces:
+        - name: output
+          workspace: workspace
+    - name: build-container
+      params:
+        - name: IMAGE
+          value: $(params.output-image)
+        - name: BUILDER_IMAGE
+          value: >-
+            registry.redhat.io/rhel8/buildah@sha256:99cae35f40c7ec050fed3765b2b27e0b8bbea2aa2da7c16408e2ca13c60ff8ee
+        - name: STORAGE_DRIVER
+          value: vfs
+        - name: DOCKERFILE
+          value: $(params.dockerfile)
+        - name: CONTEXT
+          value: $(params.context)
+        - name: TLSVERIFY
+          value: 'true'
+        - name: FORMAT
+          value: oci
+      runAfter:
+        - clone-repository
+      taskRef:
+        kind: ClusterTask
+        name: buildah
+      workspaces:
+        - name: source
+          workspace: workspace
+    - name: show-summary
+      params:
+        - name: SCRIPT
+          value: |
+            #!/usr/bin/env bash
+            echo  
+            echo Build Summary
+            echo "Build for git reposisory: $(params.git-url)" 
+            echo "Generated Image is in : $(params.output-image)"  
+            echo 
+            echo "Environment" 
+            oc get pipelines 
+            echo 
+            echo End Summary  
+      runAfter:
+        - build-container
+      taskRef:
+        kind: ClusterTask
+        name: openshift-client
+      workspaces:
+        - name: manifest-dir
+          workspace: workspace
+  workspaces:
+    - name: workspace

--- a/components/gitops/.tekton/trigger-template.yaml
+++ b/components/gitops/.tekton/trigger-template.yaml
@@ -38,5 +38,5 @@ spec:
                 resources:
                   requests:
                     storage: 10Mi
-                storageClassName: gp2
+                #storageClassName: gp2
                 volumeMode: Filesystem

--- a/components/gitops/.tekton/trigger-template.yaml
+++ b/components/gitops/.tekton/trigger-template.yaml
@@ -15,7 +15,6 @@ spec:
       kind: PipelineRun
       metadata:
         generateName: gitops-service-cluster-agent-
-        namespace: sbose-builds
       spec:
         params:
           - name: git-url

--- a/components/gitops/.tekton/trigger-template.yaml
+++ b/components/gitops/.tekton/trigger-template.yaml
@@ -1,0 +1,43 @@
+apiVersion: triggers.tekton.dev/v1alpha1
+kind: TriggerTemplate
+metadata:
+  name: gitops-service-cluster-agent
+spec:
+  params:
+    - name: git-revision
+    - name: git-commit-message
+    - name: git-repo-url
+    - name: git-repo-name
+    - name: content-type
+    - name: pusher-name
+  resourcetemplates:
+    - apiVersion: tekton.dev/v1beta1
+      kind: PipelineRun
+      metadata:
+        generateName: gitops-service-cluster-agent-
+        namespace: sbose-builds
+      spec:
+        params:
+          - name: git-url
+            value: 'https://github.com/redhat-appstudio/managed-gitops'
+          - name: revision
+            value: $(tt.params.git-revision)
+          - name: output-image
+            value: 'quay.io/redhat-appstudio/gitops-service:$(tt.params.git-revision)'
+          - name: context
+            value: cluster-agent
+          - name: dockerfile
+            value: cluster-agent/Dockerfile
+        pipelineRef:
+          name: appstudio-dockerfile-builder
+        workspaces:
+          - name: workspace
+            volumeClaimTemplate:
+              spec:
+                accessModes:
+                  - ReadWriteOnce
+                resources:
+                  requests:
+                    storage: 10Mi
+                storageClassName: gp2
+                volumeMode: Filesystem

--- a/components/gitops/.tekton/webhook-route.yaml
+++ b/components/gitops/.tekton/webhook-route.yaml
@@ -1,0 +1,12 @@
+kind: Route
+apiVersion: route.openshift.io/v1
+metadata:
+  name: gitops-service-cluster-agent
+spec:
+  to:
+    kind: Service
+    name: el-gitops-service-cluster-agent
+    weight: 100
+  port:
+    targetPort: http-listener
+  wildcardPolicy: None

--- a/components/gitops/backend/allow-argocd-to-manage.yaml
+++ b/components/gitops/backend/allow-argocd-to-manage.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: grant-argocd
+  namespace: gitops
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: admin
+subjects:
+- kind: ServiceAccount
+  name: openshift-gitops-argocd-application-controller
+  namespace: openshift-gitops

--- a/components/gitops/backend/kustomization.yaml
+++ b/components/gitops/backend/kustomization.yaml
@@ -1,4 +1,5 @@
 resources:
+- allow-argocd-to-manage.yaml
 - cm-backend-config-map.yaml
 #- depl-backend-sample.yaml
 #- serv-backend-sample.yaml

--- a/components/gitops/kustomization.yaml
+++ b/components/gitops/kustomization.yaml
@@ -1,5 +1,7 @@
 resources:
 - backend/
+- .tekton/
+
 
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization


### PR DESCRIPTION
## Why?
We got to dogfood our current tekton service and while doing so "dry run" what app studio would be creating for users' projects. 

## What
On push to any branch in the https://github.com/redhat-appstudio/managed-gitops repo, a new tekton build would be triggered in the staging cluster itself. An image tagged with the git sha would be pushed to Quay.

## How

* Emulated what App Studio would do: Pull a pipeline definition from the catalog into one's own namespace: components/gitops/.tekton/pipeline.yaml .  This would be same for every component.

* Created the "webhook" related objects.

## dependencies

For this to work, 
* I would be creating the image push `secret` on the cluster and linking the same from the pipeline sa. I've created a robot account in Quay for the same.
* To do the above, we need the https://github.com/redhat-appstudio/infra-deployments/pull/21 role.