### PR TITLE
feat: Initial SPI components deployment

### DIFF
--- a/argo-cd-apps/base/kustomization.yaml
+++ b/argo-cd-apps/base/kustomization.yaml
@@ -3,6 +3,7 @@ resources:
 - build.yaml
 - authentication.yaml
 - has.yaml
+- spi.yaml
 
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/argo-cd-apps/base/spi.yaml
+++ b/argo-cd-apps/base/spi.yaml
@@ -1,0 +1,32 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: spi
+
+spec:
+  project: default
+
+  source:
+    path: components/spi
+    repoURL: https://github.com/redhat-appstudio/infra-deployments.git
+
+  destination:
+    namespace: spi-system
+    server: https://kubernetes.default.svc
+
+  syncPolicy:
+
+    # Comment this out if you want to manually trigger deployments (using the
+    # Argo CD Web UI or Argo CD CLI), rather than automatically deploying on
+    # every new Git commit to your directory.
+    automated:
+      prune: true
+      selfHeal: true
+
+    syncOptions:
+    - CreateNamespace=true
+
+    retry:
+      limit: 50 # number of failed sync attempt retries; unlimited number of attempts if less than 0
+      backoff:
+        duration: 15s # the amount to back off. Default unit is seconds, but could also be a duration (e.g. "2m", "1h")

--- a/argo-cd-apps/overlays/development/repo-overlay.yaml
+++ b/argo-cd-apps/overlays/development/repo-overlay.yaml
@@ -33,3 +33,12 @@ spec:
   source:
     repoURL: https://github.com/redhat-appstudio/infra-deployments.git
     targetRevision: main
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: spi
+spec:
+  source:
+    repoURL: https://github.com/redhat-appstudio/infra-deployments.git
+    targetRevision: main

--- a/components/spi/kustomization.yaml
+++ b/components/spi/kustomization.yaml
@@ -1,0 +1,16 @@
+resources:
+  - https://github.com/redhat-appstudio/service-provider-integration-operator/config/default?ref=d7a6475c6d948452cdc00941616024c9ef6607cc
+
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+images:
+  - name:  quay.io/redhat-appstudio/service-provider-integration-operator
+    newName: quay.io/redhat-appstudio/service-provider-integration-operator
+    newTag: v0.2.0
+  - name: quay.io/redhat-appstudio/service-provider-integration-oauth
+    newName: quay.io/redhat-appstudio/service-provider-integration-oauth
+    newTag: v0.2.0
+
+namespace: spi-system

--- a/components/spi/kustomization.yaml
+++ b/components/spi/kustomization.yaml
@@ -1,5 +1,5 @@
 resources:
-  - https://github.com/redhat-appstudio/service-provider-integration-operator/config/default?ref=d7a6475c6d948452cdc00941616024c9ef6607cc
+  - https://github.com/redhat-appstudio/service-provider-integration-operator/config/default?ref=4f8d0b4d4e9980518f9a759f7683639e025bc32c
 
 
 apiVersion: kustomize.config.k8s.io/v1beta1


### PR DESCRIPTION
## Service provider integration deployment 
## Details 
This is a initial deployment if SPI components
 - `service-provider-integration-operator` https://github.com/redhat-appstudio/service-provider-integration-operator
 - `service-provider-integration-oauth` https://github.com/redhat-appstudio/service-provider-integration-oauth

<img width="1676" alt="Знімок екрана 2021-12-30 о 10 42 52" src="https://user-images.githubusercontent.com/1614429/147742735-36d814db-fe1a-4691-9a61-513dc59f9482.png">
<img width="1147" alt="Знімок екрана 2021-12-30 о 12 10 39" src="https://user-images.githubusercontent.com/1614429/147742743-09ab04b0-2e4d-4dda-8d26-1e4c7c8bb1cc.png">
<img width="1130" alt="Знімок екрана 2021-12-30 о 12 11 10" src="https://user-images.githubusercontent.com/1614429/147742748-059b2779-8a81-4872-b1ec-30e56a76591a.png">


Now both components are at the initial stage of **SPI V2** implementation  https://docs.google.com/document/u/1/d/1Agp8WMn5uSyzJBin1JfbgCIlKbGt5ziHV_aF2wT5eKc/edit?usp=drive_web&ouid=110694458140179268052
 - `service-provider-integration-operator` provides CRDs https://docs.google.com/document/d/1ymo3DgBKdKAq0z1SNgM6PcOqpJyi4EDjO0HVBWPrYn4/edit
 - `service-provider-integration-oauth` implemented OAuth2 flow for Github.


## NOTICE
In this pr OAuth service configuration is represented as ` spi-oauth-config-xxx` and `spi-shared-secret` contains dummy data. In the future, it has to be replaced with some production-grade provider of secrets. See also https://github.com/redhat-appstudio/infra-deployments/pull/46

