### PR TITLE
Update version pinning of tasks and new scripts 

### DIFF
--- a/components/build/build-templates/docker-build.yaml
+++ b/components/build/build-templates/docker-build.yaml
@@ -72,6 +72,17 @@ spec:
             echo "Build repository: $(params.git-url)" 
             echo "Generated Image is in : $(params.output-image)"  
             echo  
+            oc annotate pipelinerun $(context.pipelineRun.name) build.appstudio.io/repo=$(params.git-url)
+            oc annotate pipelinerun $(context.pipelineRun.name) build.appstudio.io/image=$(params.output-image)
+
+            echo "Output is in the following annotations:"
+            
+            echo "Build Repo is in 'build.appstudio.io/repo' "
+            echo 'oc get pr $(context.pipelineRun.name) -o jsonpath="{.metadata.annotations.build\.appstudio\.io/repo}"' 
+            
+            echo "Build Image is in 'build.appstudio.io/image' "
+            echo 'oc get pr $(context.pipelineRun.name) -o jsonpath="{.metadata.annotations.build\.appstudio\.io/image}"' 
+
             echo End Summary  
       workspaces:
         - name: manifest-dir 

--- a/components/build/build-templates/java-builder.yaml
+++ b/components/build/build-templates/java-builder.yaml
@@ -51,7 +51,7 @@ spec:
       workspaces:
         - name: output
           workspace: workspace
-    - name: s2i-java-1-5-0
+    - name: s2i-java
       params:
         - name: VERSION
           value: openjdk-11-ubi8
@@ -70,13 +70,13 @@ spec:
         - git-clone
       taskRef:
         kind: ClusterTask
-        name: s2i-java-1-5-0
+        name: s2i-java
       workspaces:
         - name: source
           workspace: workspace
     - name: show-summary
       runAfter:
-        - s2i-java-1-5-0 
+        - s2i-java 
       taskRef:
         kind: ClusterTask
         name: openshift-client
@@ -90,6 +90,17 @@ spec:
             echo "Build repository: $(params.git-url)" 
             echo "Generated Image is in : $(params.output-image)"  
             echo 
+            oc annotate pipelinerun $(context.pipelineRun.name) build.appstudio.io/repo=$(params.git-url)
+            oc annotate pipelinerun $(context.pipelineRun.name) build.appstudio.io/image=$(params.output-image)
+
+            echo "Output is in the following annotations:"
+            
+            echo "Build Repo is in 'build.appstudio.io/repo' "
+            echo 'oc get pr $(context.pipelineRun.name) -o jsonpath="{.metadata.annotations.build\.appstudio\.io/repo}"' 
+            
+            echo "Build Image is in 'build.appstudio.io/image' "
+            echo 'oc get pr $(context.pipelineRun.name) -o jsonpath="{.metadata.annotations.build\.appstudio\.io/image}"' 
+
             echo End Summary  
       workspaces:
         - name: manifest-dir 

--- a/components/build/build-templates/nodejs-builder.yaml
+++ b/components/build/build-templates/nodejs-builder.yaml
@@ -49,7 +49,7 @@ spec:
       name: path-context 
       type: string
   tasks:
-    - name: s2i-nodejs-1-5-0
+    - name: s2i-nodejs
       params:
         - name: VERSION
           value: 14-ubi8
@@ -63,14 +63,14 @@ spec:
           value: >-
             registry.redhat.io/rhel8/buildah@sha256:99cae35f40c7ec050fed3765b2b27e0b8bbea2aa2da7c16408e2ca13c60ff8ee
       runAfter:
-        - git-clone-1-5-0
+        - git-clone
       taskRef:
         kind: ClusterTask
-        name: s2i-nodejs-1-5-0
+        name: s2i-nodejs
       workspaces:
         - name: source
           workspace: workspace
-    - name: git-clone-1-5-0
+    - name: git-clone
       params:
         - name: url
           value: "$(params.git-url)"
@@ -91,13 +91,13 @@ spec:
           value: /tekton/home
       taskRef:
         kind: ClusterTask
-        name: git-clone-1-5-0
+        name: git-clone
       workspaces:
         - name: output
           workspace: workspace
     - name: show-summary
       runAfter:
-        - s2i-nodejs-1-5-0
+        - s2i-nodejs
       taskRef:
         kind: ClusterTask
         name: openshift-client
@@ -111,6 +111,17 @@ spec:
             echo "Build repository: $(params.git-url)" 
             echo "Generated Image is in : $(params.output-image)"  
             echo 
+            oc annotate pipelinerun $(context.pipelineRun.name) build.appstudio.io/repo=$(params.git-url)
+            oc annotate pipelinerun $(context.pipelineRun.name) build.appstudio.io/image=$(params.output-image)
+
+            echo "Output is in the following annotations:"
+            
+            echo "Build Repo is in 'build.appstudio.io/repo' "
+            echo 'oc get pr $(context.pipelineRun.name) -o jsonpath="{.metadata.annotations.build\.appstudio\.io/repo}"' 
+            
+            echo "Build Image is in 'build.appstudio.io/image' "
+            echo 'oc get pr $(context.pipelineRun.name) -o jsonpath="{.metadata.annotations.build\.appstudio\.io/image}"' 
+
             echo End Summary  
       workspaces:
         - name: manifest-dir 

--- a/components/build/build-templates/noop.yaml
+++ b/components/build/build-templates/noop.yaml
@@ -80,7 +80,19 @@ spec:
         - name: SCRIPT 
           value: |
             #!/usr/bin/env bash  
-            echo "Wait for other tasks done"   
+            echo "Noop Test, this step will wait for parallel tasks to be"    
+
+            oc annotate pipelinerun $(context.pipelineRun.name) build.appstudio.io/repo=none
+            oc annotate pipelinerun $(context.pipelineRun.name) build.appstudio.io/image=none
+
+            echo "Output is in the following annotations:"
+            
+            echo "Build Repo is in 'build.appstudio.io/repo' "
+            echo 'oc get pr $(context.pipelineRun.name) -o jsonpath="{.metadata.annotations.build\.appstudio\.io/repo}"' 
+            
+            echo "Build Image is in 'build.appstudio.io/image' "
+            echo 'oc get pr $(context.pipelineRun.name) -o jsonpath="{.metadata.annotations.build\.appstudio\.io/image}"' 
+
       runAfter:
         - task1 
         - task3

--- a/hack/build/build.sh
+++ b/hack/build/build.sh
@@ -64,7 +64,7 @@ yq -M e ".spec.params[0].value=\"$GITREPO\"" $PIPELINE_RUN | \
   yq -M e ".spec.params[1].value=\"$IMG\"" - | \
   yq -M e ".metadata.name=\"$PIPELINE_NAME-$BUILD_TAG\"" - | \
   yq -M e ".spec.pipelineRef.name=\"$PIPELINE_NAME\"" - | \
-  yq -M e ".spec.workspaces[0].subPath=\"$PIPELINE_NAME-$BUILD_TAG\"" - | \
+  yq -M e ".spec.workspaces[0].subPath=\"pv-$PIPELINE_NAME-$BUILD_TAG\"" - | \
   oc apply -f -
 
 echo

--- a/hack/build/cleanup-pvc.sh
+++ b/hack/build/cleanup-pvc.sh
@@ -7,7 +7,7 @@ kind: Pipeline
 metadata:
   name: cleanup  
 spec: 
-  tasks:
+  tasks: 
     - name: cleanup 
       taskRef:
         kind: ClusterTask
@@ -15,14 +15,17 @@ spec:
       params:
         - name: SCRIPT 
           value: |
-            #!/usr/bin/env bash 
-            echo "Pre-Cleanup PVC Root Contents"
-            ls -al
-            rm -rf .*
-            rm -rf ./*
-            rm -rf *build*
-            echo "Post-Cleanup PVC Root Contents"
-            ls -al 
+            #!/usr/bin/env bash  
+            echo "Cleanup PVC for non-existant PipelineRuns" 
+            echo "Pre-Cleanup Directories"
+            ls -al    
+            mkdir keep
+            kubectl get pipelineruns --no-headers -o custom-columns=":metadata.name" | xargs -n 1 -I {} mv pv-{} keep  2> /dev/null
+            rm -rf pv-*
+            mv keep/* .
+            rm -rf keep
+            echo "Post-Cleanup Directories"
+            ls -al    
       workspaces:
         - name: manifest-dir 
           workspace: workspace
@@ -46,10 +49,13 @@ spec:
 ENV-INLINE-PR-DECL
 
 oc apply -f tmp-pipeline.yaml   
-BUILD_TAG=$(date +"%Y-%m-%d-%H%M%S") 
-yq -M e ".metadata.name=\"cleanup-$BUILD_TAG\"" tmp-cleanup.yaml   |  oc apply -f -
-
-oc apply -f tmp-cleanup.yaml  
+BUILD_TAG=$(date +"%Y-%m-%d-%H%M%S")
+PRNAME=cleanup-$BUILD_TAG
+yq -M e ".metadata.name=\"$PRNAME\"" tmp-cleanup.yaml   |  oc apply -f -
+  
 rm -rf tmp-cleanup.yaml tmp-pipeline.yaml 
+tkn pipelinerun logs $PRNAME -f
+tkn pipelinerun delete $PRNAME -f
+
 
  

--- a/hack/build/deploy.sh
+++ b/hack/build/deploy.sh
@@ -1,0 +1,107 @@
+#!/bin/bash
+SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+#   deploy the image passed as first  parameter
+
+cat > $SCRIPTDIR/tmp.deployment.yaml <<DEPLOYMENT
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: REPLACE_ME_DEPLOY_NAME
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: REPLACE_ME_APP_LABEL
+  template:
+    metadata:
+      labels:
+        app: REPLACE_ME_APP_LABEL
+    spec: 
+      containers:
+        - name: container-image
+          image: REPLACE_ME_CONTAINER_IMAGENAME
+          resources:
+            limits:
+              cpu: "200m"
+              memory: "512Mi"
+            requests:
+              cpu: "100m"
+              memory: "512Mi"
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 8080
+          readinessProbe:
+            tcpSocket:
+              port: 8080
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          livenessProbe:
+            initialDelaySeconds: 10
+            periodSeconds: 5
+            httpGet:
+              path: /
+              port: 8080  
+DEPLOYMENT
+
+cat > $SCRIPTDIR/tmp.service.yaml <<SERVICE
+apiVersion: v1
+kind: Service
+metadata:
+  name: container-service 
+spec:
+  selector:
+    app: REPLACE_ME_SVC_APP_SELECTOR
+  ports:
+  - port: 8080
+    targetPort: 8080 
+SERVICE
+
+cat > $SCRIPTDIR/tmp.route.yaml <<ROUTE
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: REPLACE_ME_RT_NAME
+spec:
+  port:
+    targetPort: 8080
+  tls:
+    insecureEdgeTerminationPolicy: Redirect
+    termination: edge
+  to:
+    kind: Service
+    name: container-service
+    weight: 100
+ROUTE
+
+CONTAINER=$1 
+if [ -z "$CONTAINER" ]
+then
+      echo Missing CONTAINER Image URL to Run
+      exit -1 
+fi
+IMAGE=$(basename $CONTAINER)
+# route is just the base image name
+ROUTE=$(echo $IMAGE | cut -d ':' -f 1)
+
+echo running image $IMAGE at $ROUTE  
+
+APP=$ROUTE-app
+ 
+yq -M e ".metadata.name=\"$ROUTE-deployment\"" $SCRIPTDIR/tmp.deployment.yaml  | \
+ yq -M e ".spec.selector.matchLabels.app=\"$APP\"" - |  \
+ yq -M e ".spec.template.metadata.labels.app=\"$APP\"" - |  \
+ yq -M e ".spec.template.spec.containers[0].image=\"$CONTAINER\"" -  | \
+ oc apply -f -
+ 
+yq -M e ".metadata.name=\"$ROUTE-service\"" $SCRIPTDIR/tmp.service.yaml  | \
+ yq -M e ".spec.selector.app=\"$APP\"" -  |  \
+ oc apply -f - 
+ 
+yq -M e ".metadata.name=\"$ROUTE\"" $SCRIPTDIR/tmp.route.yaml  | \
+ yq -M e ".spec.to.name=\"$ROUTE-service\"" - |  \
+ oc apply -f -
+
+rm -rf $SCRIPTDIR/tmp.* 
+RT=$( oc get route $ROUTE  -o yaml | yq e '.spec.host' -)
+echo "Find your app at https://$RT"

--- a/hack/build/maintainance-loop.sh
+++ b/hack/build/maintainance-loop.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+# This script is representative of some of the maintainance needed on a workspace/pipelines
+# the PVC is shared, so the cleanup-pvc will rm each directory which has no active pipeline runes
+# the PipelineRuns pile up, so prune-pipelines will keep it trim
+ 
+
+while true
+do 
+$SCRIPTDIR/prune-pipelines 20 
+$SCRIPTDIR/cleanup-pvc.sh 
+sleep 60
+done

--- a/hack/build/package-bundle.sh
+++ b/hack/build/package-bundle.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+ROOT=$SCRIPTDIR/../..
+TEMPLATES=$ROOT/components/build/build-templates 
+
+echo "package all pipelines in build templates into bundle"
+echo "The namespace field needs to be removed"
+PARAMS=""
+mkdir $SCRIPTDIR/tmp 
+for i in $TEMPLATES/*.yaml ; do
+    KIND=$(yq e '.kind' $i) 
+    if [ $KIND = "Pipeline" ]; then 
+        echo "Found Pipeline in: $i"
+        filtered=$SCRIPTDIR/tmp/$(basename $i) 
+        yq e 'del(.metadata.namespace)' $i > $filtered
+        PARAMS="$PARAMS -f $filtered "
+    fi 
+done
+tkn bundle push quay.io/jduimovich0/bundle:appstudio $PARAMS
+rm -rf $SCRIPTDIR/tmp 

--- a/hack/build/poll-build.sh
+++ b/hack/build/poll-build.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+# Auto-detect changes for a repo and run the build for it when detected 
+SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+GITREPO=$1 
+if [ -z "$GITREPO" ]
+then
+      echo Missing parameter Git URL to Build
+      exit -1 
+fi
+PIPELINE_NAME=$2    
+LOG=$(mktemp)
+echo "No Builds Yet" >$LOG
+LAST_BUILT=$(git ls-remote  $GITREPO HEAD |  cut -f 1) 
+while : ; do 
+  clear 
+  CURRENT=$(git ls-remote  $GITREPO HEAD |  cut -f 1)
+  echo "$GITREPO"
+  echo "Last $LAST_BUILT current $CURRENT"
+   if [ $LAST_BUILT = "$CURRENT" ]; then 
+      echo Poll Nothing to Build $(date +"%Y-%m-%d-%H%M%S")
+      echo 
+      echo "Last Build Triggered:"
+      echo "---------------"
+      echo "LOG $LOG"
+      cat $LOG
+      echo "---------------"
+   else
+      echo "BUILD $GITREPO PNAME $PIPELINE_NAME" 
+      $SCRIPTDIR/build.sh "$GITREPO" $PIPELINE_NAME | tee $LOG
+      LAST_BUILT=$CURRENT
+      
+      BUILDNAME=$(cat $LOG | grep "pipelinerun.tekton.dev" | cut -d '/' -f 2 | cut -d ' ' -f 1)
+      echo  $BUILDNAME
+      echo "^^^^^^"
+      RESULT=$(oc get pr $BUILDNAME -o jsonpath="{.metadata.annotations.build\.appstudio\.io/repo}")
+      echo  $RESULT
+      echo "^^^^^^"
+      echo "Waiting for Build:"
+         while : ; do
+         IMAGE=$(oc get pr $BUILDNAME -o jsonpath="{.metadata.annotations.build\.appstudio\.io/image}")
+         if [ -z "$IMAGE" ] 
+         then
+               echo -n . 
+               sleep 5
+         else 
+               echo Image  ready 
+               $SCRIPTDIR/deploy.sh $IMAGE | tee -a $LOG
+               break
+         fi
+         done
+   fi
+   sleep 5
+done    

--- a/hack/build/test-known-build.sh
+++ b/hack/build/test-known-build.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )" 
 
-# this does a full build
+# Run a set of builds which are known to work
+# all can be deployed by deploy.sh 
+
+$SCRIPTDIR/build.sh https://github.com/jduimovich/single-nodejs-app noop
 $SCRIPTDIR/build.sh https://github.com/jduimovich/single-container-app
+$SCRIPTDIR/build.sh https://github.com/jduimovich/single-nodejs-app
+$SCRIPTDIR/build.sh https://github.com/jduimovich/spring-petclinic  java-builder
+
+
+ 


### PR DESCRIPTION
- Openshift Pipelines 1.6 caused pinned version 1-5-0 missing in 1.6 bug
-  update test to build all three container, node.js (container and nodejs) and springboot java  example
- update scripts to manage build, autobuild and cleanup of pipelineruns and storage
- update build and cleanup scripts to use pv- name 
- new deploy.sh to deploy build image examples to prove working builds
- WIP for bundling of tekton tasks from build templates instead of scraping from NS