### PR TITLE
Add johnmcollier to has-ci role

### DIFF
--- a/components/authentication/has-ci.yaml
+++ b/components/authentication/has-ci.yaml
@@ -7,6 +7,9 @@ subjects:
   - kind: User
     apiGroup: rbac.authorization.k8s.io
     name: sbose78
+  - kind: User
+    apiGroup: rbac.authorization.k8s.io
+    name: johnmcollier
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole


### PR DESCRIPTION
As discussed on Slack here: https://coreos.slack.com/archives/C02CTEB3MMF/p1638393026127200

Adding myself to the has-ci role binding so that I temporarily can create secrets in the HAS namespace