### PR TITLE
Update sha for app service catalog

### DIFF
--- a/components/has/catalogsource.yaml
+++ b/components/has/catalogsource.yaml
@@ -5,6 +5,6 @@ metadata:
   namespace: openshift-marketplace
 spec:
   sourceType: grpc
-  image: quay.io/redhat-appstudio/application-service-catalog:sha-205925d
+  image: quay.io/redhat-appstudio/application-service-catalog:sha-0f7b9c8
   displayName: HAS Operator Catalog
   publisher: Red Hat


### PR DESCRIPTION
Signed-off-by: Maysun J Faisal <maysunaneek@gmail.com>

Updating the catalog image tag for onboarding the app service component operator that was merged https://github.com/redhat-appstudio/application-service/pull/18

This allows application service to have an `Application` & the `Component` custom resource