### PR TITLE
Add verb for deleting secrets to user-ci-maintainer role

### DIFF
--- a/components/authentication/user-ci-maintainer.yaml
+++ b/components/authentication/user-ci-maintainer.yaml
@@ -15,6 +15,7 @@ rules:
   - verbs:
       - list
       - create # allows addition of credentials only.
+      - delete
     apiGroups:
       - ''
     resources:


### PR DESCRIPTION
Currently, the user-ci-maintainer role can only create secrets, but can't delete any ones that they have created. Updating the role to add the `delete` verb.