### PR TITLE
cleanup moved to be an AppStudioutils cluster task

### DIFF
--- a/components/build/clustertasks/analyze-devfile.yaml
+++ b/components/build/clustertasks/analyze-devfile.yaml
@@ -16,7 +16,7 @@ spec:
     - name: source
   steps:
     - name: analyze-devfile
-      image: quay.io/redhat-appstudio/appstudio-utils:v0.1
+      image: quay.io/redhat-appstudio/appstudio-utils:v0.1.1
       script: |
         #!/usr/bin/env bash   
         { set +x ;} 2> /dev/null 

--- a/components/build/clustertasks/appstudio-utils.yaml
+++ b/components/build/clustertasks/appstudio-utils.yaml
@@ -14,7 +14,7 @@ spec:
       optional: true
   steps:
     - name: script 
-      image: quay.io/redhat-appstudio/appstudio-utils:v0.1
+      image: quay.io/redhat-appstudio/appstudio-utils:v0.1.1
       script: |
         { set +x ;} 2> /dev/null 
         echo "App Studio Utility Task $(context.task.name)"     

--- a/components/build/clustertasks/cleanup-build-directories.yaml
+++ b/components/build/clustertasks/cleanup-build-directories.yaml
@@ -1,0 +1,20 @@
+apiVersion: tekton.dev/v1beta1
+kind: ClusterTask
+metadata:
+  name: cleanup-build-directories
+spec:
+  description: >-
+    Utility to remove unused builds directories, with no corresponding build
+  results:
+    - name: status
+      description: Simple status line of storage usage saved and kept. 
+  workspaces:
+    - name: source
+  steps:
+    - name: cleanup-build-directories
+      image: quay.io/redhat-appstudio/appstudio-utils:v0.1.1
+      script: |
+        #!/usr/bin/env bash   
+        { set +x ;} 2> /dev/null 
+        echo "App Studio Utility Task $(context.task.name)"     
+        /appstudio-utils/util-scripts/$(context.task.name).sh  /tekton/results

--- a/components/build/clustertasks/image-exists.yaml
+++ b/components/build/clustertasks/image-exists.yaml
@@ -16,7 +16,7 @@ spec:
       optional: true
   steps:
     - name: test-image-exists 
-      image: quay.io/redhat-appstudio/appstudio-utils:v0.1
+      image: quay.io/redhat-appstudio/appstudio-utils:v0.1.1
       script: |
         #!/usr/bin/env bash   
         { set +x ;} 2> /dev/null 

--- a/components/build/clustertasks/kustomization.yaml
+++ b/components/build/clustertasks/kustomization.yaml
@@ -2,6 +2,7 @@ resources:
 - analyze-devfile.yaml
 - appstudio-utils.yaml
 - image-exists.yaml 
+- cleanup-build-directories.yaml
 
 
 # Skip applying the Tekton operands while the Tekton operator is being installed.

--- a/hack/build/utils/cleanup-pvc.sh
+++ b/hack/build/utils/cleanup-pvc.sh
@@ -11,23 +11,9 @@ spec:
     - name: cleanup 
       taskRef:
         kind: ClusterTask
-        name: openshift-client
-      params:
-        - name: SCRIPT 
-          value: |
-            #!/usr/bin/env bash  
-            echo "Cleanup PVC for non-existant PipelineRuns" 
-            echo "Pre-Cleanup Directories"
-            ls -al    
-            mkdir keep
-            kubectl get pipelineruns --no-headers -o custom-columns=":metadata.name" | xargs -n 1 -I {} mv pv-{} keep  2> /dev/null
-            rm -rf pv-*
-            mv keep/* .
-            rm -rf keep
-            echo "Post-Cleanup Directories"
-            ls -al    
+        name: cleanup-build-directories 
       workspaces:
-        - name: manifest-dir 
+        - name: source 
           workspace: workspace
   workspaces:
     - name: workspace


### PR DESCRIPTION
- Updated Cluster Tasks to include new cleanup-build-directories utility
- enables cleanup to be scheduled as a trigger/cron job (TODO)
- version update to new container with task contents to v0.1.1 (https://github.com/redhat-appstudio/build-definitions)

How to test 
- run a bunch of builds `./hack/build/m2-builds.sh`
- install pull request 
- run `./hack/build/utils/cleanup-pvc.sh` 
- nothing will be deleted
- delete one or more builds using `oc delete pr <pipelinename>`
- run `./hack/build/utils/cleanup-pvc.sh` and the directories in the share pv will be reclaimed 
- 