### PR TITLE
Add script to run e2e tests in Openshift CI

### DIFF
--- a/.ci/htpasswd
+++ b/.ci/htpasswd
@@ -1,0 +1,1 @@
+test-user:$2y$05$.Ft956evcxcUutJX4JGwSeP/o0yshap203G5hFkplc0KGD4Zk.RfW

--- a/.ci/oci-e2e-deployment.sh
+++ b/.ci/oci-e2e-deployment.sh
@@ -12,6 +12,9 @@ export APPLICATION_NAME="gitops"
 #Stop execution on any error
 trap "catchFinish" EXIT SIGINT
 
+command -v yq >/dev/null 2>&1 || { echo "yq is not installed. Aborting."; exit 1; }
+command -v kubectl >/dev/null 2>&1 || { echo "kubectl is not installed. Aborting."; exit 1; }
+
 function catchFinish() {
     JOB_EXIT_CODE=$?
     if [[ "$JOB_EXIT_CODE" != "0" ]]; then
@@ -24,17 +27,49 @@ function catchFinish() {
     exit $JOB_EXIT_CODE
 }
 
-function checkApplicationHealth() {
-    while [ "$(kubectl get application ${APPLICATION_NAME} -n ${APPLICATION_NAMESPACE} -o jsonpath='{.status.health.status}')" != "Healthy" ]; do
-        sleep 3
-        echo "[INFO] Waiting for AppStudio to be ready."
+function provideOpenshiftUser() {
+   htpasswd -c -B -b htpasswd test-user test-user
+   oc create secret generic htpass-secret --from-file=htpasswd=./htpasswd -n openshift-config
+   oc create -f - -o jsonpath='{.metadata.name}' <<EOF
+apiVersion: config.openshift.io/v1
+kind: OAuth
+metadata:
+  name: cluster
+spec:
+  identityProviders:
+  - name: htpasswd
+    mappingMethod: claim 
+    type: HTPasswd
+    htpasswd:
+      fileData:
+        name: htpass-secret
+EOF
+    oc adm policy add-cluster-role-to-user cluster-admin test-user
+
+    echo -e "[INFO] Waiting for htpasswd auth to be working up to 5 minutes"
+    CURRENT_TIME=$(date +%s)
+    ENDTIME=$(($CURRENT_TIME + 300))
+    while [ $(date +%s) -lt $ENDTIME ]; do
+        if oc login -u user -p user --insecure-skip-tls-verify=false; then
+            break
+        fi
+        sleep 10
     done
 }
 
-command -v yq >/dev/null 2>&1 || { echo "yq is not installed. Aborting."; exit 1; }
-command -v kubectl >/dev/null 2>&1 || { echo "kubectl is not installed. Aborting."; exit 1; }
+function downloadE2ERepo() {
+    git clone https://github.com/redhat-appstudio/e2e-tests.git
+}
+
+# Run the script: https://github.com/redhat-appstudio/e2e-tests/blob/main/scripts/run-tests-in-k8s.sh
+function runE2ETestsFramework() {
+   /bin/bash ./e2e-tests/scripts/run-tests-in-k8s.sh
+}
 
 /bin/bash "$WORKSPACE"/hack/bootstrap-cluster.sh
+provideOpenshiftUser
+downloadE2ERepo
 
-export -f checkApplicationHealth
-timeout --foreground 10m bash -c checkApplicationHealth
+# Execute the e2e tests
+export -f runE2ETestsFramework
+timeout --foreground 10m bash -c runE2ETestsFramework


### PR DESCRIPTION
The current PR change the openshift ci test scripts and add the ability to run the appstudio e2e framework in PRs-