### PR TITLE
Add e2e binary to Openshift CI test container

### DIFF
--- a/.ci/openshift-ci/Dockerfile
+++ b/.ci/openshift-ci/Dockerfile
@@ -1,11 +1,19 @@
-FROM registry.ci.openshift.org/openshift/release:golang-1.15
+FROM quay.io/redhat-appstudio/e2e-tests:latest as e2e
+FROM registry.ci.openshift.org/openshift/release:golang-1.16
 
 SHELL ["/bin/bash", "-c"]
 
-# Install yq, kubectl
+# Get the appstudio e2e binary from https://github.com/redhat-appstudio/e2e-tests/blob/main/Dockerfile#L11
+COPY --from=e2e /root/e2e-appstudio /usr/local/bin
+
+# Install yq, kubectl, kustomize
 RUN yum install --assumeyes -d1 python3-pip  httpd-tools && \
     pip3 install --upgrade setuptools && \
     pip3 install yq && \
     curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl && \
     chmod +x ./kubectl && \
-    mv ./kubectl /usr/local/bin
+    mv ./kubectl /usr/local/bin && \
+    curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"  | bash && \
+    cp kustomize /usr/bin/ && \
+    chmod ug+x /usr/bin/kustomize && \
+    chmod +x /usr/local/bin/e2e-appstudio


### PR DESCRIPTION
This PR add the e2e framework binary from e2e tests container to the openshift ci test container and can be executed in every Openshift CI jobs.