### PR TITLE
Add e2e framework tests execution to infra-deployments

### DIFF
--- a/.ci/oci-e2e-deployment.sh
+++ b/.ci/oci-e2e-deployment.sh
@@ -29,7 +29,7 @@ function catchFinish() {
 
 function waitAppStudioToBeReady() {
     while [ "$(kubectl get applications.argoproj.io ${APPLICATION_NAME} -n ${APPLICATION_NAMESPACE} -o jsonpath='{.status.health.status}')" != "Healthy" ]; do
-        sleep 2m
+        sleep 3m
         echo "[INFO] Waiting for AppStudio to be ready."
     done
 }

--- a/.ci/oci-e2e-deployment.sh
+++ b/.ci/oci-e2e-deployment.sh
@@ -7,7 +7,10 @@ set -u
 
 export WORKSPACE=$(dirname $(dirname $(readlink -f "$0")));
 export APPLICATION_NAMESPACE="openshift-gitops"
-export APPLICATION_NAME="gitops"
+export APPLICATION_NAME="all-components-staging"
+
+# Available openshift ci environments https://docs.ci.openshift.org/docs/architecture/step-registry/#available-environment-variables
+export ARTIFACTS_DIR=${ARTIFACT_DIR:-"/tmp/appstudio"}
 
 #Stop execution on any error
 trap "catchFinish" EXIT SIGINT
@@ -24,17 +27,25 @@ function catchFinish() {
     exit $JOB_EXIT_CODE
 }
 
-function checkApplicationHealth() {
-    while [ "$(kubectl get application ${APPLICATION_NAME} -n ${APPLICATION_NAMESPACE} -o jsonpath='{.status.health.status}')" != "Healthy" ]; do
-        sleep 3
+function waitAppStudioToBeReady() {
+    while [ "$(kubectl get applications.argoproj.io ${APPLICATION_NAME} -n ${APPLICATION_NAMESPACE} -o jsonpath='{.status.health.status}')" != "Healthy" ]; do
+        sleep 2m
         echo "[INFO] Waiting for AppStudio to be ready."
     done
 }
 
+function executeE2ETests() {
+    # E2E instructions can be found: https://github.com/redhat-appstudio/e2e-tests
+    # The e2e binary is included in Openshift CI test container from the dockerfile: https://github.com/redhat-appstudio/infra-deployments/blob/main/.ci/openshift-ci/Dockerfile
+    e2e-appstudio --ginkgo.junit-report="${ARTIFACTS_DIR}"/e2e-report.xml
+}
+
 command -v yq >/dev/null 2>&1 || { echo "yq is not installed. Aborting."; exit 1; }
 command -v kubectl >/dev/null 2>&1 || { echo "kubectl is not installed. Aborting."; exit 1; }
+command -v e2e-appstudio >/dev/null 2>&1 || { echo "e2e-appstudio bin is not installed. Please install it from: https://github.com/redhat-appstudio/e2e-tests."; exit 1; }
 
 /bin/bash "$WORKSPACE"/hack/bootstrap-cluster.sh
 
-export -f checkApplicationHealth
-timeout --foreground 10m bash -c checkApplicationHealth
+export -f waitAppStudioToBeReady
+timeout --foreground 10m bash -c waitAppStudioToBeReady
+executeE2ETests


### PR DESCRIPTION
Current PR change the openshift ci scripts to include the execution of e2e tests in every PR checks.
The e2e binary was included in previous PRs: https://github.com/redhat-appstudio/infra-deployments/pull/43

Related issue: https://issues.redhat.com/browse/RHDP-416