### PR TITLE
Setup  secret propagation from AWS Secrets manager

### DIFF
--- a/argo-cd-apps/base/external-secrets.yaml
+++ b/argo-cd-apps/base/external-secrets.yaml
@@ -1,0 +1,33 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: "external-secrets"
+  
+spec:
+  project: default
+
+  source:
+    path: components/external-secrets
+    repoURL: https://github.com/redhat-appstudio/infra-deployments.git
+
+  destination:
+    namespace: external-secrets
+    server: https://kubernetes.default.svc
+
+  syncPolicy:
+
+    # Comment this out if you want to manually trigger deployments (using the 
+    # Argo CD Web UI or Argo CD CLI), rather than automatically deploying on
+    # every new Git commit to your directory.
+    automated: 
+      prune: true
+      selfHeal: true
+
+    syncOptions:
+    - CreateNamespace=true
+
+    retry:
+      limit: 50 # number of failed sync attempt retries; unlimited number of attempts if less than 0
+      backoff:
+        duration: 15s # the amount to back off. Default unit is seconds, but could also be a duration (e.g. "2m", "1h")
+

--- a/components/external-secrets/argo-cd-permissions.yaml
+++ b/components/external-secrets/argo-cd-permissions.yaml
@@ -1,0 +1,32 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: crd-manager
+  annotations:
+    argocd.argoproj.io/sync-wave: "-2"
+rules:
+  - verbs:
+      - patch
+      - get
+      - list
+      - get
+      - create
+    apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: grant-argocd-crd-permissions
+  annotations:
+    argocd.argoproj.io/sync-wave: "-2"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: crd-manager
+subjects:
+- kind: ServiceAccount
+  name: openshift-gitops-argocd-application-controller
+  namespace: openshift-gitops 

--- a/components/external-secrets/argocd-external-secret.yaml
+++ b/components/external-secrets/argocd-external-secret.yaml
@@ -1,0 +1,32 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: external-secret-manager
+  annotations:
+    argocd.argoproj.io/sync-wave: "-2"
+rules:
+  - verbs:
+      - patch
+      - get
+      - list
+      - get
+      - create
+    apiGroups:
+      - kubernetes-client.io
+    resources:
+      - externalsecrets
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: grant-argocd-external-secret-permissions
+  annotations:
+    argocd.argoproj.io/sync-wave: "-2"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: external-secret-manager
+subjects:
+- kind: ServiceAccount
+  name: openshift-gitops-argocd-application-controller
+  namespace: openshift-gitops 

--- a/components/external-secrets/deployment.yaml
+++ b/components/external-secrets/deployment.yaml
@@ -1,0 +1,66 @@
+---
+# Source: kubernetes-external-secrets/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: appstudio-kubernetes-external-secrets
+  namespace: "external-secrets"
+  labels:
+    app.kubernetes.io/name: kubernetes-external-secrets
+    helm.sh/chart: kubernetes-external-secrets-8.4.0
+    app.kubernetes.io/instance: appstudio
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: kubernetes-external-secrets
+      app.kubernetes.io/instance: appstudio
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: kubernetes-external-secrets
+        app.kubernetes.io/instance: appstudio
+    spec:
+      serviceAccountName: appstudio-kubernetes-external-secrets
+      containers:
+        - name: kubernetes-external-secrets
+          image: "ghcr.io/external-secrets/kubernetes-external-secrets:8.4.0"
+          ports:
+          - name: prometheus
+            containerPort: 3001
+          imagePullPolicy: IfNotPresent
+          resources: 
+           {}
+          env:
+          - name: "AKEYLESS_API_ENDPOINT"
+            value: "https://api.akeyless.io"
+          - name: "AWS_DEFAULT_REGION"
+            value: "us-east-2"
+          - name: "AWS_REGION"
+            value: "us-east-2"
+          - name: "LOG_LEVEL"
+            value: "info"
+          - name: "LOG_MESSAGE_KEY"
+            value: "msg"
+          - name: "METRICS_PORT"
+            value: "3001"
+          - name: "POLLER_INTERVAL_MILLISECONDS"
+            value: "10000"
+          - name: "VAULT_ADDR"
+            value: "http://127.0.0.1:8200"
+          - name: "WATCH_TIMEOUT"
+            value: "60000"
+          # Params for env vars populated from k8s secrets
+          - name: AWS_ACCESS_KEY_ID
+            valueFrom:
+              secretKeyRef:
+                name: "aws-credentials"
+                key: "id"
+          - name: AWS_SECRET_ACCESS_KEY
+            valueFrom:
+              secretKeyRef:
+                name: "aws-credentials"
+                key: "key"
+      securityContext:
+        runAsNonRoot: true

--- a/components/external-secrets/kubernetes-client.io_externalsecrets_crd.yaml
+++ b/components/external-secrets/kubernetes-client.io_externalsecrets_crd.yaml
@@ -1,0 +1,240 @@
+---
+# Source: kubernetes-external-secrets/crds/kubernetes-client.io_externalsecrets_crd.yaml
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: externalsecrets.kubernetes-client.io
+  annotations:
+    # used in e2e testing
+    app.kubernetes.io/managed-by: helm
+    annotations:
+      argocd.argoproj.io/sync-wave: "-1"
+spec:
+  group: kubernetes-client.io
+  scope: Namespaced
+
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      schema:
+        openAPIV3Schema:
+          required:
+            - spec
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                controllerId:
+                  description: The ID of controller instance that manages this ExternalSecret.
+                    This is needed in case there is more than a KES controller instances within the cluster.
+                  type: string
+                type:
+                  type: string
+                  description: >-
+                    DEPRECATED: Use spec.template.type
+                template:
+                  description: Template which will be deep merged without mutating
+                    any existing fields. into generated secret, can be used to
+                    set for example annotations or type on the generated secret
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                backendType:
+                  description: >-
+                    Determines which backend to use for fetching secrets
+                  type: string
+                  enum:
+                    - secretsManager
+                    - systemManager
+                    - vault
+                    - azureKeyVault
+                    - gcpSecretsManager
+                    - alicloudSecretsManager
+                    - ibmcloudSecretsManager
+                    - akeyless
+                vaultRole:
+                  description: >-
+                    Used by: vault
+                  type: string
+                vaultMountPoint:
+                  description: >-
+                    Used by: vault
+                  type: string
+                kvVersion:
+                  description: Vault K/V version either 1 or 2, default = 2
+                  type: integer
+                  minimum: 1
+                  maximum: 2
+                keyVaultName:
+                  description: >-
+                    Used by: azureKeyVault
+                  type: string
+                dataFrom:
+                  type: array
+                  items:
+                    type: string
+                dataFromWithOptions:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      key:
+                        description: Secret key in backend
+                        type: string
+                      isBinary:
+                        description: >-
+                          Whether the backend secret shall be treated as binary data
+                          represented by a base64-encoded string. You must set this to true
+                          for any base64-encoded binary data in the backend - to ensure it
+                          is not encoded in base64 again. Default is false.
+                        type: boolean
+                      versionStage:
+                        description: >-
+                          Used by: alicloudSecretsManager, secretsManager
+                        type: string
+                      versionId:
+                        description: >-
+                          Used by: secretsManager
+                        type: string
+                    required:
+                    - key
+                data:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      key:
+                        description: Secret key in backend
+                        type: string
+                      name:
+                        description: Name set for this key in the generated secret
+                        type: string
+                      property:
+                        description: Property to extract if secret in backend is a JSON object
+                        type: string
+                      isBinary:
+                        description: >-
+                          Whether the backend secret shall be treated as binary data
+                          represented by a base64-encoded string. You must set this to true
+                          for any base64-encoded binary data in the backend - to ensure it
+                          is not encoded in base64 again. Default is false.
+                        type: boolean
+                      path:
+                        description: >-
+                          Path from SSM to scrape secrets
+                          This will fetch all secrets and use the key from the secret as variable name
+                        type: string
+                      recursive:
+                        description: Allow to recurse thru all child keys on a given path, default false
+                        type: boolean
+                      secretType:
+                        description: >-
+                          Used by: ibmcloudSecretsManager
+                          Type of secret - one of username_password, iam_credentials or arbitrary
+                        type: string
+                      version:
+                        description: >-
+                          Used by: gcpSecretsManager
+                        type: string
+                        x-kubernetes-int-or-string: true
+                      versionStage:
+                        description: >-
+                          Used by: alicloudSecretsManager, secretsManager
+                        type: string
+                      versionId:
+                        description: >-
+                          Used by: secretsManager
+                        type: string
+                    oneOf:
+                      - required:
+                          - key
+                          - name
+                      - required:
+                          - path
+                roleArn:
+                  type: string
+                  description: >-
+                    Used by: alicloudSecretsManager, secretsManager, systemManager
+                region:
+                  type: string
+                  description: >-
+                    Used by: secretsManager, systemManager
+                projectId:
+                  type: string
+                  description: >-
+                    Used by: gcpSecretsManager
+                keyByName:
+                  type: boolean
+                  description: >-
+                    Whether to interpret the key as a secret name (if true) or ID (the default).
+                    Used by: ibmcloudSecretsManager
+              oneOf:
+                - properties:
+                    backendType:
+                      enum:
+                        - secretsManager
+                        - systemManager
+                - properties:
+                    backendType:
+                      enum:
+                        - vault
+                - properties:
+                    backendType:
+                      enum:
+                        - azureKeyVault
+                  required:
+                    - keyVaultName
+                - properties:
+                    backendType:
+                      enum:
+                        - gcpSecretsManager
+                - properties:
+                    backendType:
+                      enum:
+                        - alicloudSecretsManager
+                - properties:
+                    backendType:
+                      enum:
+                        - ibmcloudSecretsManager
+                - properties:
+                    backendType:
+                      enum:
+                        - akeyless
+              anyOf:
+                - required:
+                    - data
+                - required:
+                    - dataFrom
+                - required:
+                    - dataFromWithOptions
+            status:
+              type: object
+              properties:
+                lastSync:
+                  type: string
+                status:
+                  type: string
+                observedGeneration:
+                  type: number
+      additionalPrinterColumns:
+        - jsonPath: .status.lastSync
+          name: Last Sync
+          type: date
+        - jsonPath: .status.status
+          name: status
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+
+  names:
+    shortNames:
+      - es
+    kind: ExternalSecret
+    plural: externalsecrets
+    singular: externalsecret
+

--- a/components/external-secrets/kustomization.yaml
+++ b/components/external-secrets/kustomization.yaml
@@ -1,0 +1,14 @@
+resources:
+- deployment.yaml
+- namespace.yaml
+- kubernetes-client.io_externalsecrets_crd.yaml
+- rbac.yaml
+- service.yaml
+- serviceaccount.yaml
+- argo-cd-permissions.yaml
+- argocd-external-secret.yaml
+
+
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization

--- a/components/external-secrets/namespace.yaml
+++ b/components/external-secrets/namespace.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: external-secrets
+  labels:  
+    argocd.argoproj.io/managed-by: openshift-gitops
+spec:
+  finalizers:
+  - kubernetes

--- a/components/external-secrets/rbac.yaml
+++ b/components/external-secrets/rbac.yaml
@@ -1,0 +1,66 @@
+---
+# Source: kubernetes-external-secrets/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: appstudio-kubernetes-external-secrets
+  labels:
+    app.kubernetes.io/name: kubernetes-external-secrets
+    helm.sh/chart: kubernetes-external-secrets-8.4.0
+    app.kubernetes.io/instance: appstudio
+    app.kubernetes.io/managed-by: Helm
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["create", "update", "get"]
+  - apiGroups: [""]
+    resources: ["namespaces"]
+    verbs: ["get", "watch", "list"]
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    resourceNames: ["externalsecrets.kubernetes-client.io"]
+    verbs: ["get", "update"]
+  - apiGroups: ["kubernetes-client.io"]
+    resources: ["externalsecrets"]
+    verbs: ["get", "watch", "list"]
+  - apiGroups: ["kubernetes-client.io"]
+    resources: ["externalsecrets/status"]
+    verbs: ["get", "update"]
+---
+# Source: kubernetes-external-secrets/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: appstudio-kubernetes-external-secrets
+  labels:
+    app.kubernetes.io/name: kubernetes-external-secrets
+    helm.sh/chart: kubernetes-external-secrets-8.4.0
+    app.kubernetes.io/instance: appstudio
+    app.kubernetes.io/managed-by: Helm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: appstudio-kubernetes-external-secrets
+subjects:
+  - name: appstudio-kubernetes-external-secrets
+    namespace: "external-secrets"
+    kind: ServiceAccount
+---
+# Source: kubernetes-external-secrets/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: appstudio-kubernetes-external-secrets-auth
+  labels:
+    app.kubernetes.io/name: kubernetes-external-secrets
+    helm.sh/chart: kubernetes-external-secrets-8.4.0
+    app.kubernetes.io/instance: appstudio
+    app.kubernetes.io/managed-by: Helm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:auth-delegator
+subjects:
+- name: appstudio-kubernetes-external-secrets
+  namespace: "external-secrets"
+  kind: ServiceAccount

--- a/components/external-secrets/service.yaml
+++ b/components/external-secrets/service.yaml
@@ -1,0 +1,20 @@
+---
+# Source: kubernetes-external-secrets/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: appstudio-kubernetes-external-secrets
+  namespace: "external-secrets"
+  labels:
+    app.kubernetes.io/name: kubernetes-external-secrets
+    helm.sh/chart: kubernetes-external-secrets-8.4.0
+    app.kubernetes.io/instance: appstudio
+    app.kubernetes.io/managed-by: Helm
+spec:
+  selector:
+    app.kubernetes.io/name: kubernetes-external-secrets
+  ports:
+    - protocol: TCP
+      port: 3001
+      name: prometheus
+      targetPort: prometheus

--- a/components/external-secrets/serviceaccount.yaml
+++ b/components/external-secrets/serviceaccount.yaml
@@ -1,0 +1,12 @@
+---
+# Source: kubernetes-external-secrets/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: appstudio-kubernetes-external-secrets
+  namespace: "external-secrets"
+  labels:
+    app.kubernetes.io/name: kubernetes-external-secrets
+    helm.sh/chart: kubernetes-external-secrets-8.4.0
+    app.kubernetes.io/instance: appstudio
+    app.kubernetes.io/managed-by: Helm

--- a/components/gitops/.tekton/kustomization.yaml
+++ b/components/gitops/.tekton/kustomization.yaml
@@ -4,6 +4,7 @@ resources:
 - event-listener.yaml
 - webhook-route.yaml
 - serviceaccount.yaml
+- registry-push-secret.yaml
 
 # Skip applying the Tekton operands while the Tekton operator is being installed.
 # See more information about this option, here: 

--- a/components/gitops/.tekton/registry-push-secret.yaml
+++ b/components/gitops/.tekton/registry-push-secret.yaml
@@ -1,0 +1,11 @@
+apiVersion: kubernetes-client.io/v1
+kind: ExternalSecret
+metadata:
+  name: redhat-appstudio-staginguser-pull-secret
+spec:
+  backendType: secretsManager
+  template:
+    type: kubernetes.io/dockerconfigjson
+  data:
+    - key: stage/appstudio/gitops/ci/quay.io/redhat-appstudio/staginguser
+      name: .dockerconfigjson


### PR DESCRIPTION
_This is a test-able proposal_

- [x] Added manifests to install External Secrets. Generated from the official helm chart 
```
helm template --values values.yaml  --include-crds --output-dir ./output_dir external-secrets/kubernetes-external-secrets   
```
- [x] Added placeholder in the Deployment to take in AWS credentials from a secret ( yes, this has be manually added ) 
- [x] Add sample usage with use of Quay robot account credentials
- [ ] Add a demo video


## Why?

Addition of `Secret` manifests to a Git repo is problematic yet we need to declaratively specify something on Git that indicates that a `Secret` is to be placed on the cluster. This is what the `ExternalSecret` CRD enables us to do.

ExternalSecret can _interface_ with popular systems like AWS Secrets Manager, Vault, etc.

 ## How ?

* Install the ExternalSecrets Controller + CRD
* Configure the ExternalSecrets Controller to 'talk' to AWS using a specific access ID and access key. This cannot be done declaratively with Git ;)
* Grant permissions to specific actors in the system that would allow them create to `ExternalSecrets` because they can potentially pull sensitive information from AWS Secrets Manager. In our case, we've only allowed the cluster Argo CD to create this CR. Namespace members do not have the permissions to create the namespace-scoped External CR.
* Create a key/value pair named `stage/appstudio/gitops/ci/quay.io/redhat-appstudio/staginguser`  in AWS Secrets manager with`.dockerconfigjson` as the key and the dockerconfig string as the value.
* You are all set! Now go ahead create a referencing CR which you could happily commit to Git!

```
apiVersion: kubernetes-client.io/v1
kind: ExternalSecret
metadata:
  name: redhat-appstudio-staginguser-pull-secret
spec:
  backendType: secretsManager
  template:
    type: kubernetes.io/dockerconfigjson
  data:
    - key: stage/appstudio/gitops/ci/quay.io/redhat-appstudio/staginguser
      name: .dockerconfigjson
```
* Doing the above will create a `Secret` named `redhat-appstudio-staginguser-pull-secret` in the same namespace.

```
kind: Secret
apiVersion: v1
metadata:
  name: redhat-appstudio-staginguser-pull-secret
  namespace: gitops
data:
  .dockerconfigjson: .... 
type: kubernetes.io/dockerconfigjson
```


