### PR TITLE
ensure pipeline sa always has the push secret specified

### DIFF
--- a/components/has/.tekton/kustomization.yaml
+++ b/components/has/.tekton/kustomization.yaml
@@ -3,6 +3,7 @@ resources:
 - trigger-template.yaml
 - event-listener.yaml
 - webhook-route.yaml
+- serviceaccount.yaml 
 
 # Skip applying the Tekton operands while the Tekton operator is being installed.
 # See more information about this option, here: 

--- a/components/has/.tekton/serviceaccount.yaml
+++ b/components/has/.tekton/serviceaccount.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: pipeline
+secrets:
+  - name: redhat-appstudio-staginguser-pull-secret


### PR DESCRIPTION
The pipline sa was manually patched previously to contain the quay.io push secret