### PR TITLE
openshift pipeline pruner

### DIFF
--- a/hack/build/prune-builds.sh
+++ b/hack/build/prune-builds.sh
@@ -1,15 +1,29 @@
 #!/bin/bash
 SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
-KEEP=$1 
-if [ -z "$KEEP" ] 
-then
-      KEEP=5  
-fi  
-tkn pr delete --keep $KEEP -f
-$SCRIPTDIR/utils/cleanup-pvc.sh  
+KEEP_LAST_N=10
+
+# Print the Pruning Configuration 
 ISADMIN=$(oc whoami)
-if [ $ISADMIN = "kubeadmin" ]; then 
+if [ "$ISADMIN" = "kubeadmin" ]; then 
+KEEP=$( oc get TektonConfig config -n openshift-pipelines -o 'jsonpath={.spec.pruner.keep}')
+#TODO - move this config to gitops
+if (( $KEEP_LAST_N != $KEEP )); then
+kubectl patch TektonConfig config -n openshift-pipelines -p '{"spec":{"pruner":{"keep":'$KEEP_LAST_N'}}}' --type=merge
+KEEP=$( oc get TektonConfig config -n openshift-pipelines -o 'jsonpath={.spec.pruner.keep}')
+fi
+echo
+echo "OpenShift Pipelines configured to prune to last $KEEP PipelineRuns"
+echo "Full Config:"
+oc get TektonConfig config -n openshift-pipelines -o 'jsonpath={.spec.pruner}' | jq
+fi 
+
+# Run the pvc internal GC 
+echo
+$SCRIPTDIR/utils/cleanup-pvc.sh  
+echo
+if [ "$ISADMIN" = "kubeadmin" ]; then 
+echo "Pruning Registry"
 oc adm prune images --confirm --registry-url  default-route-openshift-image-registry.apps-crc.testing
 fi 
 

--- a/hack/build/utils/cleanup-pvc.sh
+++ b/hack/build/utils/cleanup-pvc.sh
@@ -1,48 +1,12 @@
-#!/bin/bash
-PROJECT=$(oc config view --minify -o 'jsonpath={..namespace}')
+#!/bin/bash 
 
-cat > tmp-pipeline.yaml <<ENV-INLINE-PL-DECL
-apiVersion: tekton.dev/v1beta1
-kind: Pipeline
-metadata:
-  name: cleanup  
-spec: 
-  tasks: 
-    - name: cleanup 
-      taskRef:
-        kind: ClusterTask
-        name: cleanup-build-directories 
-      workspaces:
-        - name: source 
-          workspace: workspace
-  workspaces:
-    - name: workspace
-ENV-INLINE-PL-DECL
+LOG=$(mktemp)
+tkn clustertask start \
+  cleanup-build-directories \
+  --showlog \
+  -w name=source,claimName=app-studio-default-workspace | tee $LOG
 
-cat > tmp-cleanup.yaml <<ENV-INLINE-PR-DECL
-apiVersion: tekton.dev/v1beta1
-kind: PipelineRun
-metadata: 
-  name: cleanup
-spec: 
-  pipelineRef:
-    name: cleanup
-  workspaces:
-    - name: workspace
-      persistentVolumeClaim:
-        claimName: app-studio-default-workspace
-      subPath: "." 
-ENV-INLINE-PR-DECL
-
-oc apply -f tmp-pipeline.yaml   
-BUILD_TAG=$(date +"%Y-%m-%d-%H%M%S")
-PRNAME=cleanup-$BUILD_TAG
-yq -M e ".metadata.name=\"$PRNAME\"" tmp-cleanup.yaml   |  oc apply -f -
-  
-rm -rf tmp-cleanup.yaml tmp-pipeline.yaml 
-tkn pipelinerun logs $PRNAME -f
-tkn pipelinerun delete $PRNAME -f
-tkn pipeline delete cleanup -f
-
+NAME=$(grep "TaskRun started" $LOG  | cut -d ' ' -f 3) 
+oc delete taskrun $NAME
 
  


### PR DESCRIPTION
This PR makes the following changes 

- scripts to configured Openshift Pipelines to prune pipeline runs. 
- Use a taskrun to run ClusterTask which prunes PVC directories
 
- TODO -gitop'ify OSP config and use a cronjob to schedule taskruns
