### PR TITLE
feat: add scripts for installing Toolchain (Sandbox) operators

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,28 @@ Both of the scripts will:
 3. Print:
     - The landing-page URL that you can use for signing-up for the Sandbox environment that is running in your cluster.
     - Proxy URL. 
+    
+#### SSO
+
+In development mode, the Toolchain Operators are configured to use Keycloak instance that is internally used by the Sandbox team. If you want to reconfigure it to use your own Keycloak instance, you need to add a few parameters to `ToolchainConfig` resource in `toolchain-host-operator` namespace. 
+This is an example of the needed parameters and their values:
+```yaml
+spec:
+  host:
+    registrationService:
+      auth:
+        authClientConfigRaw: '{
+                  "realm": "sandbox-dev",
+                  "auth-server-url": "https://sso.devsandbox.dev/auth",
+                  "ssl-required": "none",
+                  "resource": "sandbox-public",
+                  "clientId": "sandbox-public",
+                  "public-client": true
+                }'
+        authClientLibraryURL: https://sso.devsandbox.dev/auth/js/keycloak.js
+        authClientPublicKeysURL: https://sso.devsandbox.dev/auth/realms/sandbox-dev/protocol/openid-connect/certs
+      registrationServiceURL: <The landing page URL>
+```  
 
 ### Optional: CodeReady Containers Post-Bootstrap Configuration
 Even with 6 CPU cores, you will need to reduce the CPU resource requests for each App Studio application. Either run `./hack/reduce-gitops-cpu-requests.sh` which will set resources.requests.cpu values to 50m or use `kubectl edit argocd/openshift-gitops -n openshift-gitops` to reduce the values to some other value. More details are in the FAQ below.

--- a/README.md
+++ b/README.md
@@ -66,6 +66,9 @@ There are two scripts which you can use:
 Both of the scripts will:
 1. Automatically reduce the resources.requests.cpu values in argocd/openshift-gitops resource.
 2. Install & configure the Toolchain (Sandbox) operators in the corresponding mode.
+3. Print:
+    - The landing-page URL that you can use for signing-up for the Sandbox environment that is running in your cluster.
+    - Proxy URL. 
 
 ### Optional: CodeReady Containers Post-Bootstrap Configuration
 Even with 6 CPU cores, you will need to reduce the CPU resource requests for each App Studio application. Either run `./hack/reduce-gitops-cpu-requests.sh` which will set resources.requests.cpu values to 50m or use `kubectl edit argocd/openshift-gitops -n openshift-gitops` to reduce the values to some other value. More details are in the FAQ below.

--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ Simply update the files under `components/(team-name)`, and open a PR with the c
 
 ### Required prerequisites
 The prerequisites are:
-- You must have `kubectl` and `kustomize` installed. 
-- You must have `kubectl` pointing to an existing OpenShift cluster, that you wish to deploy to.
+- You must have `kubectl`, `oc`, `jq` and `kustomize` installed. 
+- You must have `kubectl` and `oc` pointing to an existing OpenShift cluster, that you wish to deploy to.
 
 ### Optional: CodeReady Containers Setup
 If you don't already have a test OpenShift cluster available, CodeReady Containers is a popular option. It runs a small OpenShift cluster in a single VM on your local workstation.
@@ -58,8 +58,17 @@ Steps:
 ![OpenShift Gitops menu with Cluster Argo CD menu option](documentation/images/argo-cd-login.png?raw=true "OpenShift Gitops menu")
 3) If your deployment was successful, you should see several applications running, such as "all-components-staging", "gitops", and so on.
 
+### Install Toolchain (Sandbox) Operators
+There are two scripts which you can use:
+- `./hack/sandbox-development-mode.sh` for development mode
+- `./hack/sandbox-e2e-mode.sh` for E2E mode
+
+Both of the scripts will:
+1. Automatically reduce the resources.requests.cpu values in argocd/openshift-gitops resource.
+2. Install & configure the Toolchain (Sandbox) operators in the corresponding mode.
+
 ### Optional: CodeReady Containers Post-Bootstrap Configuration
-Even with 6 CPU cores, you will need to reduce the CPU resource requests for each App Studio application. Using `kubectl edit argocd/openshift-gitops -n openshift-gitops`, reduce the resources.requests.cpu values from 250m to 100m or less. More details are in the FAQ below.
+Even with 6 CPU cores, you will need to reduce the CPU resource requests for each App Studio application. Either run `./hack/reduce-gitops-cpu-requests.sh` which will set resources.requests.cpu values to 50m or use `kubectl edit argocd/openshift-gitops -n openshift-gitops` to reduce the values to some other value. More details are in the FAQ below.
 
 ## Development mode for your own clusters
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Simply update the files under `components/(team-name)`, and open a PR with the c
 
 ### Required prerequisites
 The prerequisites are:
-- You must have `kubectl`, `oc`, `jq` and `kustomize` installed. 
+- You must have `kubectl`, `oc`, `jq`, `yq` and `kustomize` installed. 
 - You must have `kubectl` and `oc` pointing to an existing OpenShift cluster, that you wish to deploy to.
 
 ### Optional: CodeReady Containers Setup

--- a/hack/destroy-cluster.sh
+++ b/hack/destroy-cluster.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"/..
+TOOLCHAIN_E2E_TEMP_DIR=/tmp/toolchain-e2e
 
 # Remove resources in the reverse order from bootstrapping
 
@@ -36,6 +37,12 @@ while : ; do
 
   echo $RC
 done
+
+echo
+echo "Remove Toolchain (Sandbox) Operators with the user data:"
+rm -rf ${TOOLCHAIN_E2E_TEMP_DIR} 2>/dev/null || true
+git clone --depth=1 https://github.com/codeready-toolchain/toolchain-e2e.git ${TOOLCHAIN_E2E_TEMP_DIR}
+make -C ${TOOLCHAIN_E2E_TEMP_DIR} appstudio-cleanup
 
 echo 
 echo "Complete."

--- a/hack/reduce-gitops-cpu-requests.sh
+++ b/hack/reduce-gitops-cpu-requests.sh
@@ -1,0 +1,17 @@
+
+#!/bin/bash
+
+OPENSHIFT_GITOPS=$(kubectl get argocd/openshift-gitops -n openshift-gitops -o json)
+
+echo
+echo "Reducing CPU resource requests in argocd/openshift-gitops:"
+
+PATCH="["
+for KEY in $(echo ${OPENSHIFT_GITOPS} | jq -r '.spec | keys[]');
+do
+	if [[ -n "$(echo ${OPENSHIFT_GITOPS} | jq -r ".spec.${KEY} | select(.resources.requests.cpu != null)" 2>/dev/null)" ]];
+	then
+	    PATCH+='{"op": "replace", "path": "/spec/'${KEY}'/resources/requests/cpu", "value": "50m"},'
+	fi
+done
+kubectl patch argocd/openshift-gitops -n openshift-gitops --type='json' -p "${PATCH}]"

--- a/hack/sandbox-development-mode.sh
+++ b/hack/sandbox-development-mode.sh
@@ -1,0 +1,13 @@
+
+#!/bin/bash
+
+ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"/..
+TOOLCHAIN_E2E_TEMP_DIR="/tmp/toolchain-e2e"
+
+$ROOT/hack/reduce-gitops-cpu-requests.sh
+
+echo
+echo "Installing the Toolchain (Sandbox) operators in dev environment:"
+rm -rf ${TOOLCHAIN_E2E_TEMP_DIR} 2>/dev/null || true
+git clone --depth=1 https://github.com/codeready-toolchain/toolchain-e2e.git ${TOOLCHAIN_E2E_TEMP_DIR}
+make -C ${TOOLCHAIN_E2E_TEMP_DIR} appstudio-dev-deploy-latest SHOW_CLEAN_COMMAND="make -C ${TOOLCHAIN_E2E_TEMP_DIR} appstudio-cleanup"

--- a/hack/sandbox-e2e-mode.sh
+++ b/hack/sandbox-e2e-mode.sh
@@ -1,0 +1,13 @@
+
+#!/bin/bash
+
+ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"/..
+TOOLCHAIN_E2E_TEMP_DIR="/tmp/toolchain-e2e"
+
+$ROOT/hack/reduce-gitops-cpu-requests.sh
+
+echo
+echo "Installing the Toolchain (Sandbox) operators in e2e environment:"
+rm -rf ${TOOLCHAIN_E2E_TEMP_DIR} 2>/dev/null || true
+git clone --depth=1 https://github.com/codeready-toolchain/toolchain-e2e.git ${TOOLCHAIN_E2E_TEMP_DIR}
+make -C ${TOOLCHAIN_E2E_TEMP_DIR} appstudio-e2e-deploy-latest SHOW_CLEAN_COMMAND="make -C ${TOOLCHAIN_E2E_TEMP_DIR} appstudio-cleanup"


### PR DESCRIPTION
Changes introduced in this PR:
* Two scripts for installing Toolchain (Sandbox) operators in two kinds of modes:
    * dev
    * e2e
*  Added part in `destroy-cluster.sh` script for cleaning up the Sandbox stuff
* New `reduce-gitops-cpu-requests.sh` which sets all `resource.request.cpu` values to `50m` in `argocd/openshift-gitops` resource. The reason is that with the default size of the dev cluster, I wasn't able to install Sandbox operators along with the GitOps stuff - there wasn't enough of CPU in the cluster. 
Both of the sandbox-related scripts call this "reduce" script automatically.
* Changes in the README - feel free to fix my poor grammar :sweat_smile: 