### PR TITLE
Build: Automate build of build-templates-bundle and appstudio-utils

### DIFF
--- a/components/build/.tekton/event-listener.yaml
+++ b/components/build/.tekton/event-listener.yaml
@@ -1,0 +1,12 @@
+apiVersion: triggers.tekton.dev/v1alpha1
+kind: EventListener
+metadata:
+  name: build-service
+spec:
+  serviceAccountName: pipeline
+  triggers:
+    - bindings:
+        - kind: ClusterTriggerBinding
+          ref: github-push
+      template:
+        ref: build-service

--- a/components/build/.tekton/kustomization.yaml
+++ b/components/build/.tekton/kustomization.yaml
@@ -1,0 +1,11 @@
+resources:
+- trigger-template.yaml
+- event-listener.yaml
+- webhook-route.yaml
+- serviceaccount.yaml
+- pvc.yaml
+
+namespace: build-templates
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization

--- a/components/build/.tekton/pvc.yaml
+++ b/components/build/.tekton/pvc.yaml
@@ -1,0 +1,35 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: app-studio-default-workspace
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+
+---
+# Use PVC for the first time to trigger PV assigment.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: bind-volume
+spec:
+  selector: {}
+  template:
+    metadata:
+      name: bind-volume
+    spec:
+      containers:
+        - name: bind-volume
+          image: registry.access.redhat.com/ubi8/ubi-minimal:latest
+          volumeMounts:
+            - name: bind
+              mountPath: /test
+      restartPolicy: Never
+      volumes:
+        - name: bind
+          persistentVolumeClaim:
+              claimName: app-studio-default-workspace

--- a/components/build/.tekton/serviceaccount.yaml
+++ b/components/build/.tekton/serviceaccount.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: pipeline
+secrets:
+  - name: redhat-appstudio-staginguser-pull-secret

--- a/components/build/.tekton/trigger-template.yaml
+++ b/components/build/.tekton/trigger-template.yaml
@@ -1,0 +1,94 @@
+apiVersion: triggers.tekton.dev/v1alpha1
+kind: TriggerTemplate
+metadata:
+  name: build-service
+spec:
+  params:
+    - name: git-revision
+    - name: git-commit-message
+    - name: git-repo-url
+    - name: git-repo-name
+    - name: content-type
+    - name: pusher-name
+  resourcetemplates:
+    - apiVersion: tekton.dev/v1beta1
+      kind: PipelineRun
+      metadata:
+        generateName: build-service-bundles-
+      spec:
+        params:
+          - name: git-url
+            value: 'https://github.com/redhat-appstudio/build-definitions'
+          - name: revision
+            value: $(tt.params.git-revision)
+        pipelineSpec:
+          params:
+            - description: 'Source Repository URL'
+              name: git-url
+              type: string
+            - description: 'Revision of the Source Repository'
+              name: revision
+              type: string
+            - description: 'Fully Qualified Output Image'
+              name: output-image
+              type: string
+          tasks:
+            - name: clone-repository
+              params:
+                - name: url
+                  value: $(params.git-url)
+                - name: revision
+                  value: "$(params.revision)"
+              taskRef:
+                kind: ClusterTask
+                name: git-clone
+              workspaces:
+                - name: output
+                  workspace: workspace
+            - name: build-bundles
+              runAfter:
+                - clone-repository
+              workspaces:
+                - name: source
+                  workspace: workspace
+              taskSpec:
+                workspaces:
+                  - name: source
+                steps:
+                  - name: build-bundles
+                    image: quay.io/redhat-appstudio/appstudio-utils:v0.1.6
+                    workingDir: $(workspaces.source.path)
+                    script: |
+                      #!/usr/bin/env bash
+                      MY_QUAY_USER=redhat-appstudio BUILD_TAG=$(params.revision) SKIP_BUILD=1 SKIP_INSTALL=1 hack/build-and-push.sh
+        workspaces:
+          - name: registry-auth
+            secret:
+              secretName: quay-registry-secret
+          - name: workspace
+            persistentVolumeClaim:
+              claimName: app-studio-default-workspace
+            subPath: application-service-$(tt.params.git-revision)
+
+    - apiVersion: tekton.dev/v1beta1
+      kind: PipelineRun
+      metadata:
+        generateName: build-service-utils-
+      spec:
+        params:
+          - name: git-url
+            value: 'https://github.com/redhat-appstudio/build-definitions'
+          - name: revision
+            value: $(tt.params.git-revision)
+          - name: output-image
+            value: 'quay.io/redhat-appstudio/appstudio-utils:$(tt.params.git-revision)'
+          - name: path-context
+            value: appstudio-utils
+        pipelineRef:
+          name: docker-build
+          bundle: quay.io/redhat-appstudio/build-templates-bundle:v0.1.6
+        workspaces:
+          - name: workspace
+            persistentVolumeClaim:
+              claimName: app-studio-default-workspace
+            subPath: appstudio-utils-$(tt.params.git-revision)

--- a/components/build/.tekton/trigger-template.yaml
+++ b/components/build/.tekton/trigger-template.yaml
@@ -56,7 +56,7 @@ spec:
                   - name: source
                 steps:
                   - name: build-bundles
-                    image: quay.io/redhat-appstudio/appstudio-utils:v0.1.6
+                    image: quay.io/redhat-appstudio/appstudio-utils:748fdc355f0595119e5dd7aa08722288df2ed1aa
                     workingDir: $(workspaces.source.path)
                     script: |
                       #!/usr/bin/env bash
@@ -86,7 +86,7 @@ spec:
             value: appstudio-utils
         pipelineRef:
           name: docker-build
-          bundle: quay.io/redhat-appstudio/build-templates-bundle:v0.1.6
+          bundle: quay.io/redhat-appstudio/build-templates-bundle:748fdc355f0595119e5dd7aa08722288df2ed1aa
         workspaces:
           - name: workspace
             persistentVolumeClaim:

--- a/components/build/.tekton/webhook-route.yaml
+++ b/components/build/.tekton/webhook-route.yaml
@@ -1,0 +1,12 @@
+kind: Route
+apiVersion: route.openshift.io/v1
+metadata:
+  name: build-service
+spec:
+  to:
+    kind: Service
+    name: el-build-service
+    weight: 100
+  port:
+    targetPort: http-listener
+  wildcardPolicy: None

--- a/components/build/kustomization.yaml
+++ b/components/build/kustomization.yaml
@@ -2,6 +2,7 @@ resources:
 - openshift-pipelines/
 - build-templates/ 
 - pipelines-as-code/
+- .tekton/
 
 generatorOptions:
  disableNameSuffixHash: true
@@ -10,7 +11,7 @@ configMapGenerator:
 - name: build-pipelines-defaults
   namespace: build-templates
   literals:
-  - default_build_bundle=quay.io/redhat-appstudio/build-templates-bundle:v0.1.4
+  - default_build_bundle=quay.io/redhat-appstudio/build-templates-bundle:v0.1.5
 
 # Skip applying the Tekton operands while the Tekton operator is being installed.
 # See more information about this option, here:

--- a/components/build/kustomization.yaml
+++ b/components/build/kustomization.yaml
@@ -11,7 +11,7 @@ configMapGenerator:
 - name: build-pipelines-defaults
   namespace: build-templates
   literals:
-  - default_build_bundle=quay.io/redhat-appstudio/build-templates-bundle:v0.1.5
+  - default_build_bundle=quay.io/redhat-appstudio/build-templates-bundle:748fdc355f0595119e5dd7aa08722288df2ed1aa
 
 # Skip applying the Tekton operands while the Tekton operator is being installed.
 # See more information about this option, here:


### PR DESCRIPTION
- Add trigger-template which triggers pipelines for building images:
  - redhat-appstudio/build-templates-bundle
  - redhat-appstudio/appstudio-tasks
  - redhat-appstudio/appstudio-utils

Configuration needed on stage:
- [x] Create secret redhat-appstudio-staginguser-pull-secret in build-templates
- [x] Check/add write permission for robot account in quay.io for redhat-appstudio/build-templates-bundle
- [x] Check/add write permission for robot account in quay.io for redhat-appstudio/appstudio-tasks 
- [x] Check/add write permission for robot account in quay.io for redhat-appstudio/appstudio-utils
- [x] Set webhook in build-definitions to trigger the build workflow
