### PR TITLE
Development mode: Custom GitHub organization

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,26 @@ One option to prevent accidentally including this modified file, you can run the
 After you commit your changes you can rerun to `./hack/development-mode.sh` and reset your repo to point back to the fork. 
 
 Note running these scripts in a clone repo will have no effect as the repo will remain `https://github.com/redhat-appstudio/infra-deployments.git`
- 
+
+### Optional: Configure HAS GitHub Organization
+
+After deployment `has` application is failing to start. It's trying to connect to default github organization and credentials are not set.
+
+To run HAS in development mode, you need to set custom GitHub organization and token.
+
+Steps:
+1) Create organization in GitHub
+2) Create user token with permissions:
+    - `repo`
+    - `delete_repo`
+3) Set environment variables:
+    - `MY_GITHUB_ORG`
+    - `MY_GITHUB_TOKEN`
+4) Run `./hack/development-mode.sh`
+5) Push changes, trigger update in ArgoCD and delete `application-service-controller-manager` pod manually or run `oc rollout restart -n application-service deployment/application-service-controller-manager`
+
+Do not include GitHub Organization change in merge requests. You can reset organization back by running `./hack/util-set-github-org` without arguments. `./hack/upstream-mode.sh` also resets organization.
+
 # App Studio Build System
 
 The App Studio Build System is composed of the following components:
@@ -180,7 +199,7 @@ To deploy all the builds as they complete, add the `-deploy` option.
 ```
 You can also run the noop build `./hack/build/quick-noop-build.sh`, that executes in couple seconds to validate a working install.
  
-## Other Build utilties 
+## Other Build utilities
 
 The build type is identified via temporary hack until the Component Detection Query is available which maps files in your git repo to known build types. See `./hack/build/repo-to-pipeline.sh`  which will print the repo name and computed builder type.
 

--- a/components/has/kustomization.yaml
+++ b/components/has/kustomization.yaml
@@ -12,4 +12,10 @@ images:
   newName: quay.io/redhat-appstudio/application-service
   newTag: a7d0420d5c5a45f1240bf51618256194f2f5dfc4
 
+configMapGenerator:
+- literals:
+  - GITHUB_ORG=""
+  name: github-config
+  behavior: replace
+
 namespace: application-service

--- a/hack/development-mode.sh
+++ b/hack/development-mode.sh
@@ -1,12 +1,20 @@
-
 #!/bin/bash
+
 ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"/.. 
 
-REPO=$(git config --get remote.origin.url)
-BRANCH=$(git rev-parse --abbrev-ref HEAD)
+if [ -z "${MY_GIT_REPO_URL}" ]; then
+    MY_GIT_REPO_URL=$(git config --get remote.origin.url)
+fi
+if [ -z "${MY_GIT_BRANCH}" ]; then
+    MY_GIT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+fi
 
 #set the local cluster to point to the current git repo and branch and update the path to development
-$ROOT/hack/util-update-app-of-apps.sh $REPO development $BRANCH 
+$ROOT/hack/util-update-app-of-apps.sh $MY_GIT_REPO_URL development $MY_GIT_BRANCH
 # reset the default repos in the development directory to be the current git repo
 # this needs to be pushed to your fork to be seen by argocd
-$ROOT/hack/util-set-development-repos.sh $REPO development $BRANCH 
+$ROOT/hack/util-set-development-repos.sh $MY_GIT_REPO_URL development $MY_GIT_BRANCH
+
+if [ -n "$MY_GITHUB_ORG" ]; then
+    $ROOT/hack/util-set-github-org $MY_GITHUB_ORG
+fi

--- a/hack/upstream-mode.sh
+++ b/hack/upstream-mode.sh
@@ -12,4 +12,5 @@ REPO=https://github.com/redhat-appstudio/infra-deployments.git
 $ROOT/hack/util-update-app-of-apps.sh $REPO staging main
 #reset the default content in the development directory to be the upstream
 $ROOT/hack/util-set-development-repos.sh $REPO development main
- 
+#reset Application Service GitHub organization
+$ROOT/hack/util-set-github-org ""

--- a/hack/util-set-github-org
+++ b/hack/util-set-github-org
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"/..
+
+echo "Changing AppStudio Gitlab Org to \"$1\""
+sed -i "s/GITHUB_ORG=.*/GITHUB_ORG=\"$1\"/" $ROOT/components/has/kustomization.yaml
+
+if [ -n "$MY_GITHUB_TOKEN" ]; then
+    echo
+    echo "Setting gitHub token"
+    oc create -n application-service secret generic has-github-token --from-literal=token="$MY_GITHUB_TOKEN" --dry-run=client -o yaml | oc replace -f -
+fi


### PR DESCRIPTION
* Allow to set custom GitHub organization in development mode.
* Add arguments to ./hack/development-mode.sh for setting custom git
  repository.