### PR TITLE
fix: include view-spi.yaml to kustomization.yaml

### DIFF
--- a/components/authentication/kustomization.yaml
+++ b/components/authentication/kustomization.yaml
@@ -2,6 +2,7 @@ resources:
 - view-build-service.yaml
 - view-gitops-service.yaml
 - view-has.yaml
+- view-spi.yaml
 - user-ci-maintainer.yaml
 - gitops-ci.yaml
 - has-ci.yaml


### PR DESCRIPTION
In my previous pr https://github.com/redhat-appstudio/infra-deployments/pull/60 I forget to add include view-spi.yaml to kustomization.yaml. This pr fixes this error.