### PR TITLE
fix: remapped spi-system view role to github's username of skabashnyuk

### DIFF
--- a/components/authentication/view-spi.yaml
+++ b/components/authentication/view-spi.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: spi-system
 subjects:
   - kind: User
-    name: skabashn
+    name: skabashnyuk
   - kind: User
     name: sbose78
 roleRef:


### PR DESCRIPTION
remapped spi-system view role to github's username of skabashnyuk

Context :
- https://github.com/redhat-appstudio/infra-deployments/pull/61
- https://github.com/redhat-appstudio/infra-deployments/pull/60

