### PR TITLE
fix: Used SPI deployment with 200Mi memory limit for spi-operator

### DIFF
--- a/components/spi/kustomization.yaml
+++ b/components/spi/kustomization.yaml
@@ -1,5 +1,5 @@
 resources:
-  - https://github.com/redhat-appstudio/service-provider-integration-operator/config/default?ref=4f8d0b4d4e9980518f9a759f7683639e025bc32c
+  - https://github.com/redhat-appstudio/service-provider-integration-operator/config/default?ref=de85e79d454817293a89fadcb3f7601cc336b252
 
 
 apiVersion: kustomize.config.k8s.io/v1beta1


### PR DESCRIPTION
Attempt to fix CrashLoopBackOff on staging.
Now configuration points to the deployment with 200Mi memory limit (2 times more).
See https://github.com/redhat-appstudio/service-provider-integration-operator/commit/de85e79d454817293a89fadcb3f7601cc336b252
Error not reproduced on RHPDS.