### PR TITLE
fix: Used SPI deployment with 200Mi memory limit for spi-operator to avoid potential oom

### DIFF
--- a/components/spi/kustomization.yaml
+++ b/components/spi/kustomization.yaml
@@ -1,5 +1,5 @@
 resources:
-  - https://github.com/redhat-appstudio/service-provider-integration-operator/config/default?ref=de85e79d454817293a89fadcb3f7601cc336b252
+  - https://github.com/redhat-appstudio/service-provider-integration-operator/config/default?ref=ccc1d8a0b400aa3e47c10fa14040674252d3ae3d
 
 
 apiVersion: kustomize.config.k8s.io/v1beta1


### PR DESCRIPTION

Used SPI deployment (https://github.com/redhat-appstudio/service-provider-integration-operator/pull/57) with 200Mi memory limit for spi-operator to avoid potential oom. Commit set the latest changes in main branch https://github.com/redhat-appstudio/service-provider-integration-operator/commit/ccc1d8a0b400aa3e47c10fa14040674252d3ae3d


Here we can see a peek usage 95.6 that is very close to the limit.
<img width="1367" alt="Знімок екрана 2022-01-19 о 12 11 20" src="https://user-images.githubusercontent.com/1614429/150110514-7edeb35b-cd11-4db3-b6bc-3eb1898574a9.png">
Here we have on staging. It is clear that we need more then 100Mi
<img width="1366" alt="Знімок екрана 2022-01-19 о 12 19 42" src="https://user-images.githubusercontent.com/1614429/150111287-0d5c335d-aa87-4530-8b83-4177d0a686b7.png">


Commit https://github.com/redhat-appstudio/infra-deployments/pull/64 by mistake points to the changes in oauth-service deployment https://github.com/redhat-appstudio/service-provider-integration-operator/commit/de85e79d454817293a89fadcb3f7601cc336b252