### PR TITLE
fix(hack): do not fail setting secret if it doesn't exists yet

### DIFF
--- a/hack/util-set-github-org
+++ b/hack/util-set-github-org
@@ -8,5 +8,5 @@ sed -i "s/GITHUB_ORG=.*/GITHUB_ORG=\"$1\"/" $ROOT/components/has/kustomization.y
 if [ -n "$MY_GITHUB_TOKEN" ]; then
     echo
     echo "Setting gitHub token"
-    oc create -n application-service secret generic has-github-token --from-literal=token="$MY_GITHUB_TOKEN" --dry-run=client -o yaml | oc replace -f -
+    oc create -n application-service secret generic has-github-token --from-literal=token="$MY_GITHUB_TOKEN" --dry-run=client -o yaml | oc apply -f -
 fi


### PR DESCRIPTION
@Michkov - could you please review? Any specific reason for using `replace` here?