### PR TITLE
Gives sbose and skabashnyuk a pipeline-maintainer role in spi-system namespace

### DIFF
--- a/components/authentication/spi-ci.yaml
+++ b/components/authentication/spi-ci.yaml
@@ -1,0 +1,14 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: spi-service-ci-maintainers
+  namespace: spi-system
+subjects:
+  - kind: User
+    name: skabashnyuk
+  - kind: User
+    name: sbose78
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: pipeline-maintainer


### PR DESCRIPTION
The goal of this pr is to give @skabashnyuk the ability to complete SPI installation on staging after https://github.com/redhat-appstudio/infra-deployments/pull/65. Before we will get an ability to store configuration as ExternalSecrets https://github.com/redhat-appstudio/infra-deployments/pull/46