### PR TITLE
Include spi-ci.yaml resource to kustomization.yaml

### DIFF
--- a/components/authentication/kustomization.yaml
+++ b/components/authentication/kustomization.yaml
@@ -3,6 +3,7 @@ resources:
 - view-gitops-service.yaml
 - view-has.yaml
 - view-spi.yaml
+- spi-ci.yaml
 - user-ci-maintainer.yaml
 - gitops-ci.yaml
 - has-ci.yaml


### PR DESCRIPTION
Include spi-ci.yaml resource to kustomization.yaml that was not added by mistake in https://github.com/redhat-appstudio/infra-deployments/pull/71