### PR TITLE
GitOps Service: Update location of Dockerfile in GitOps' Tekton trigger template

### DIFF
--- a/components/gitops/.tekton/trigger-template.yaml
+++ b/components/gitops/.tekton/trigger-template.yaml
@@ -24,9 +24,9 @@ spec:
           - name: output-image
             value: 'quay.io/redhat-appstudio/gitops-service:$(tt.params.git-revision)'
           - name: context
-            value: cluster-agent
+            value: .
           - name: dockerfile
-            value: cluster-agent/Dockerfile
+            value: Dockerfile
         pipelineRef:
           name: appstudio-dockerfile-builder
         workspaces:


### PR DESCRIPTION
We've switched from multiple Dockerfiles, one for each component, to a single Dockerfile for all components (as seen in Argo CD). This PR updates the corresponding references within the managed-gitops repo.