### PR TITLE
Add bash scripts to demo chains signed taskrun verification

### DIFF
--- a/hack/chains/check-pipelinerun.sh
+++ b/hack/chains/check-pipelinerun.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+PIPELINERUN_NAME=$1
+
+# Preserve sanity while hacking
+set -ue
+
+if [[ -z $PIPELINERUN_NAME ]]; then
+  # Use the most recently created pipelinerun
+  # (Fixme: Would be better to exclude running pipelines)
+  PIPELINERUN_NAME=$(
+    kubectl get pipelinerun -o name --sort-by=.metadata.creationTimestamp |
+      tail -1 | cut -d/ -f2 )
+fi
+
+TASKRUN_NAMES=$(
+  kubectl get pipelinerun/$PIPELINERUN_NAME -o yaml |
+    yq e '.status.taskRuns | keys | .[]' - )
+
+for name in $TASKRUN_NAMES; do
+  echo -n "$name 🔗 "
+  $SCRIPTDIR/check-taskrun.sh $name --quiet
+done

--- a/hack/chains/check-taskrun.sh
+++ b/hack/chains/check-taskrun.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+TASKRUN_NAME=$1
+
+# Preserve sanity while hacking
+set -ue
+
+if [[ -z $TASKRUN_NAME ]]; then
+  # Use the most recently created taskrun
+  # (Fixme: Would be better to exclude running tasks)
+  TASKRUN_NAME=$(
+    kubectl get taskrun -o name --sort-by=.metadata.creationTimestamp |
+      tail -1 | cut -d/ -f2 )
+fi
+
+# Helper for jsonpath
+get-jsonpath() {
+  kubectl get taskrun/$TASKRUN_NAME -o jsonpath={.$1}
+}
+
+# Helper for reading chains values
+get-chainsval() {
+  get-jsonpath metadata.annotations.chains\\.tekton\\.dev/$1
+}
+
+# Fetch signature and payload
+TASKRUN_UID=$( get-jsonpath metadata.uid )
+SIGNATURE=$( get-chainsval signature-taskrun-$TASKRUN_UID )
+PAYLOAD=$( get-chainsval payload-taskrun-$TASKRUN_UID | base64 --decode )
+
+# Cosign wants files on disk afaict
+SIG_FILE=$( mktemp )
+PAYLOAD_FILE=$( mktemp )
+echo -n "$PAYLOAD" > $PAYLOAD_FILE
+echo -n "$SIGNATURE" > $SIG_FILE
+
+# Requires that you're authenticated with an account that can access
+# the signing-secret, i.e. kubeadmin but not developer
+SIG_KEY=k8s://tekton-chains/signing-secrets
+
+# If you have the public key locally because you created it
+# (Presumably real public keys can be published somewhere in future)
+#SIG_KEY=./cosign.pub
+
+title() {
+  echo
+  echo "🔗 ---- $* ----"
+}
+
+# Show details about this taskrun
+title Taskrun name
+echo $TASKRUN_NAME
+
+title Signature
+echo $SIGNATURE
+
+title Payload
+#echo "$PAYLOAD" | jq
+echo "$PAYLOAD" | yq e -P -
+
+# Keep going if the verify fails
+set +e
+
+# Now use cosign to verify the signed payload
+title Verification
+cosign verify-blob --key $SIG_KEY --signature $SIG_FILE $PAYLOAD_FILE
+
+# Clean up
+rm $SIG_FILE $PAYLOAD_FILE

--- a/hack/chains/check-taskrun.sh
+++ b/hack/chains/check-taskrun.sh
@@ -1,7 +1,10 @@
 #!/bin/bash
 
+SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
 TASKRUN_NAME=$1
 QUIET_OPT=$2
+SIG_KEY=$COSIGN_SIG_KEY
 
 # Preserve sanity while hacking
 set -ue
@@ -43,13 +46,15 @@ PAYLOAD_FILE=$( mktemp )
 echo -n "$PAYLOAD" > $PAYLOAD_FILE
 echo -n "$SIGNATURE" > $SIG_FILE
 
-# Requires that you're authenticated with an account that can access
-# the signing-secret, i.e. kubeadmin but not developer
-SIG_KEY=k8s://tekton-chains/signing-secrets
+if [[ -z $SIG_KEY ]]; then
+  # Requires that you're authenticated with an account that can access
+  # the signing-secret, i.e. kubeadmin but not developer
+  SIG_KEY=k8s://tekton-chains/signing-secrets
 
-# If you have the public key locally because you created it
-# (Presumably real public keys can be published somewhere in future)
-#SIG_KEY=./cosign.pub
+  # If you have the public key locally because you created it
+  # (Presumably real public keys can be published somewhere in future)
+  #SIG_KEY=$SCRIPTDIR/../../cosign.pub
+fi
 
 title() {
   $ECHO

--- a/hack/chains/check-taskrun.sh
+++ b/hack/chains/check-taskrun.sh
@@ -78,6 +78,10 @@ set +e
 # Now use cosign to verify the signed payload
 title Verification
 cosign verify-blob --key $SIG_KEY --signature $SIG_FILE $PAYLOAD_FILE
+COSIGN_EXIT_CODE=$?
 
 # Clean up
 rm $SIG_FILE $PAYLOAD_FILE
+
+# Use the exit code from cosign
+exit $COSIGN_EXIT_CODE

--- a/hack/chains/check-taskrun.sh
+++ b/hack/chains/check-taskrun.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 TASKRUN_NAME=$1
+QUIET_OPT=$2
 
 # Preserve sanity while hacking
 set -ue
@@ -11,6 +12,14 @@ if [[ -z $TASKRUN_NAME ]]; then
   TASKRUN_NAME=$(
     kubectl get taskrun -o name --sort-by=.metadata.creationTimestamp |
       tail -1 | cut -d/ -f2 )
+fi
+
+if [[ $QUIET_OPT == "--quiet" ]]; then
+  ECHO=:
+  QUIET=1
+else
+  ECHO=echo
+  QUIET=
 fi
 
 # Helper for jsonpath
@@ -43,20 +52,20 @@ SIG_KEY=k8s://tekton-chains/signing-secrets
 #SIG_KEY=./cosign.pub
 
 title() {
-  echo
-  echo "🔗 ---- $* ----"
+  $ECHO
+  $ECHO "🔗 ---- $* ----"
 }
 
 # Show details about this taskrun
 title Taskrun name
-echo $TASKRUN_NAME
+$ECHO $TASKRUN_NAME
 
 title Signature
-echo $SIGNATURE
+$ECHO $SIGNATURE
 
 title Payload
-#echo "$PAYLOAD" | jq
-echo "$PAYLOAD" | yq e -P -
+#[[ -z $QUIET ]] && echo "$PAYLOAD" | jq
+[[ -z $QUIET ]] && echo "$PAYLOAD" | yq e -P -
 
 # Keep going if the verify fails
 set +e


### PR DESCRIPTION
Following the example set by @jduimovich in hack/build, here are two scripts in hack/chains that demonstrate how to verify signed taskruns.

See commit messages for further explanations.

As mentioned in the first commit, this doesn't work unless chains is installed, but it could be useful while working on the chains configuration, so I think there's no harm in merging early and often.

See also https://docs.engineering.redhat.com/x/zzd-Dw which shows how it works.

JIRA: [HACBS-37](https://issues.redhat.com/browse/HACBS-37)