### PR TITLE
Move Argo CD specific permissions into the component(s) that need(s) it.

### DIFF
--- a/components/has/argocd-permissions.yaml
+++ b/components/has/argocd-permissions.yaml
@@ -2,7 +2,7 @@
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: crd-manager
+  name: crd-manager-for-has
 rules:
   - verbs:
       - patch
@@ -18,11 +18,11 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: grant-argocd-crd-permissions
+  name: grant-argocd-crd-permissions-for-has
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: crd-manager
+  name: crd-manager-for-has
 subjects:
 - kind: ServiceAccount
   name: openshift-gitops-argocd-application-controller

--- a/components/has/kustomization.yaml
+++ b/components/has/kustomization.yaml
@@ -1,5 +1,6 @@
 resources:
 - allow-argocd-to-manage.yaml
+- argocd-permissions.yaml
 - https://github.com/redhat-appstudio/application-service/config/default?ref=46684055dc75b2e05899d8d38cf209de17460ace
 - .tekton/
 

--- a/components/spi/argocd-permissions.yaml
+++ b/components/spi/argocd-permissions.yaml
@@ -1,0 +1,29 @@
+
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: crd-manager-for-spi
+rules:
+  - verbs:
+      - patch
+      - get
+      - list
+      - create
+      - get
+    apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: grant-argocd-crd-permissions-for-spi
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: crd-manager-for-spi
+subjects:
+- kind: ServiceAccount
+  name: openshift-gitops-argocd-application-controller
+  namespace: openshift-gitops 

--- a/components/spi/kustomization.yaml
+++ b/components/spi/kustomization.yaml
@@ -1,4 +1,5 @@
 resources:
+  - argocd-permissions.yaml
   - https://github.com/redhat-appstudio/service-provider-integration-operator/config/default?ref=c36682a4fd7dbac2e7303637e0cc4c5ff958cfd4
   - oauth_route.yaml
 


### PR DESCRIPTION
* `component/authentication` needs to be left out of the dev mode install.
* Move non-user specific rbac into components who need it even if that means there's repetition. 