### PR TITLE
Add role for pruning old HAS resources

### DIFF
--- a/components/authentication/prune-has.yaml
+++ b/components/authentication/prune-has.yaml
@@ -1,0 +1,43 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: has-pruner
+rules:
+  - verbs:
+      - list
+      - get
+      - delete
+      - update
+    apiGroups:
+      - 'appstudio.redhat.com'
+    resources:
+      - applications
+      - components
+      - componentdetectionqueries
+  - verbs:
+      - create # allows addition of credentials only.
+      - delete
+    apiGroups:
+      - ''
+    resources:
+      - secrets
+  - verbs:
+      - '*' # needed till we figure out how to cleanup workspaces.
+    apiGroups:
+      - 'tekton.dev'
+    resources:
+      - 'pipelineruns'
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: has-pruner-rolebinding
+subjects:
+  - kind: User
+    apiGroup: rbac.authorization.k8s.io
+    name: johnmcollier
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: has-pruner
+

--- a/components/authentication/prune-has.yaml
+++ b/components/authentication/prune-has.yaml
@@ -17,6 +17,7 @@ rules:
   - verbs:
       - create # allows addition of credentials only.
       - delete
+      - list
     apiGroups:
       - ''
     resources:


### PR DESCRIPTION
🪓 

Discussed on slack - HAS seems to be crashing on start up, as it tries to reconcile hundreds of resources at once, Shoubhik suggested clearing out any old HAS CRs that have been left behind, as a one-time measure.