### PR TITLE
Use the kubeadmin user when bootstrapping the cluster/Wait for Argo CD route to be up

### DIFF
--- a/hack/bootstrap-cluster.sh
+++ b/hack/bootstrap-cluster.sh
@@ -44,15 +44,21 @@ echo
 echo "Add parent Argo CD Application:"
 kubectl apply -f $ROOT/argo-cd-apps/app-of-apps/all-applications-staging.yaml
 
-ARGO_CD_ROUTE="$(kubectl get route/openshift-gitops-server -n openshift-gitops)"
+ARGO_CD_URL="https://$(kubectl get route/openshift-gitops-server -n openshift-gitops -o template --template={{.spec.host}})"
 
 echo
 echo "========================================================================="
 echo
-echo "Argo CD Route is:"
-echo "$ARGO_CD_ROUTE"
+echo "Argo CD URL is: $ARGO_CD_URL"
 echo
 echo "(NOTE: It may take a few moments for the route to become available)"
+echo
+echo -n "Waiting for the route: "
+while ! curl --fail --insecure --output /dev/null --silent "$ARGO_CD_URL"; do
+  echo -n .
+  sleep 3
+done
+echo "OK"
 echo
 echo "Login/password uses your OpenShift credentials ('Login with OpenShift' button)"
 echo

--- a/hack/bootstrap-cluster.sh
+++ b/hack/bootstrap-cluster.sh
@@ -2,6 +2,12 @@
 
 ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"/..
 
+if [ "$(oc auth can-i '*' '*' --all-namespaces)" != "yes" ]; then
+  echo
+  echo "[ERROR] User '$(oc whoami)' does not have the required 'cluster-admin' role." 1>&2
+  echo "Log into the cluster with a user with the required privileges (e.g. kubeadmin) and retry."
+  exit 1
+fi
 
 echo 
 echo "Installing the OpenShift GitOps operator subscription:"
@@ -38,11 +44,13 @@ echo
 echo "Add parent Argo CD Application:"
 kubectl apply -f $ROOT/argo-cd-apps/app-of-apps/all-applications-staging.yaml
 
+ARGO_CD_ROUTE="$(kubectl get route/openshift-gitops-server -n openshift-gitops)"
+
 echo
 echo "========================================================================="
 echo
 echo "Argo CD Route is:"
-kubectl get route/openshift-gitops-server -n openshift-gitops
+echo "$ARGO_CD_ROUTE"
 echo
 echo "(NOTE: It may take a few moments for the route to become available)"
 echo


### PR DESCRIPTION
The goal of this PR is to streamline the deployment by:

- ensuring the user is logged with the right account (as by default they'll be logged as `developer` if they followed the CRC install documentation)
- Give the user the URL to connect to instead of the route and wait for the URL to be reachable before exiting the script.