### PR TITLE
Prune pipelineruns 

### DIFF
--- a/components/build/kustomization.yaml
+++ b/components/build/kustomization.yaml
@@ -1,6 +1,8 @@
 resources:
 - openshift-pipelines/
 - build-templates/ 
+- patch-operator/ 
+- patch-config/ 
 
 generatorOptions:
  disableNameSuffixHash: true

--- a/components/build/patch-config/0-namespace.yaml
+++ b/components/build/patch-config/0-namespace.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: locker-patch-tekton-ns
+  labels:  
+    argocd.argoproj.io/managed-by: openshift-gitops
+spec:
+  finalizers:
+  - kubernetes

--- a/components/build/patch-config/1-sa.yaml
+++ b/components/build/patch-config/1-sa.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: patch-tekton-config-sa
+  namespace: locker-patch-tekton-ns

--- a/components/build/patch-config/kustomization.yaml
+++ b/components/build/patch-config/kustomization.yaml
@@ -1,0 +1,16 @@
+resources:
+- 0-namespace.yaml
+- 1-sa.yaml
+- rb.yaml
+- role.yaml 
+- lock.yaml 
+
+
+# Skip applying the Tekton operands while the Tekton operator is being installed.
+# See more information about this option, here: 
+# https://argo-cd.readthedocs.io/en/stable/user-guide/sync-options/#skip-dry-run-for-new-custom-resources-types 
+commonAnnotations:
+  argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization

--- a/components/build/patch-config/lock.yaml
+++ b/components/build/patch-config/lock.yaml
@@ -1,0 +1,23 @@
+
+apiVersion: redhatcop.redhat.io/v1alpha1
+kind: ResourceLocker
+metadata:
+  name: patch-tekton-pruner-config 
+  namespace: locker-patch-tekton-ns
+spec:
+  serviceAccountRef:
+    name: patch-tekton-config-sa
+  patches:
+  - targetObjectRef:
+      apiVersion: operator.tekton.dev/v1alpha1
+      kind: TektonConfig
+      name: config  
+    patchTemplate: |
+      spec:
+        pruner:
+          keep: 10
+          schedule: 0/10 * * * *
+    patchType: application/merge-patch+json
+    id: patch-tekton-pruner-keep
+
+  

--- a/components/build/patch-config/rb.yaml
+++ b/components/build/patch-config/rb.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: patch-tekton-config-rb 
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: patch-tekton-config-role
+subjects:
+- kind: ServiceAccount
+  name: patch-tekton-config-sa
+  namespace: locker-patch-tekton-ns

--- a/components/build/patch-config/role.yaml
+++ b/components/build/patch-config/role.yaml
@@ -1,0 +1,9 @@
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: patch-tekton-config-role
+rules:
+- apiGroups: ["operator.tekton.dev/v1alpha1", "operator.tekton.dev"] 
+  resources: ["tektonconfig", "tektonconfigs"] 
+  verbs: [ "list", "get", "watch", "patch" ]

--- a/components/build/patch-operator/kustomization.yaml
+++ b/components/build/patch-operator/kustomization.yaml
@@ -1,0 +1,6 @@
+resources:
+- operator-group.yaml 
+- subscription.yaml 
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization

--- a/components/build/patch-operator/operator-group.yaml
+++ b/components/build/patch-operator/operator-group.yaml
@@ -1,0 +1,6 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: resource-locker-operator
+spec:
+  targetNamespaces: []

--- a/components/build/patch-operator/subscription.yaml
+++ b/components/build/patch-operator/subscription.yaml
@@ -1,0 +1,10 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: resource-locker-operator 
+spec:
+  channel: alpha
+  installPlanApproval: Automatic
+  name: resource-locker-operator
+  source: community-operators
+  sourceNamespace: openshift-marketplace


### PR DESCRIPTION
This pull request installs a patch to configure the Tekton pruner to keep only 10 pipelineruns per namespace. This is configured to run every 10 minutes.
A patch is used because adding the TektonConfig to gitops seems to put all the OpenShift pipelines resources under ArgodCD management. 

This ensures PipelineRuns don't build up on the staging cluster but will need to be updated to work with persisting pipeline runs. 

- the patch uses the resource-locker operator to set the TektonConfig params specifically 
```
      spec:
        pruner:
          keep: 10
          schedule: 0/10 * * * *
```