### PR TITLE
fix: Make development-mode agnostic to CWD

### DIFF
--- a/hack/util-set-development-repos.sh
+++ b/hack/util-set-development-repos.sh
@@ -28,15 +28,15 @@ echo In dev mode, verify that argo-cd-apps/overlays/development includes a kusto
 echo If you want to reset to the default upstream run the upstream-mode.sh script  
 
 PATCH="$(printf '.spec.source.repoURL="%q"' $GITURL)" 
-yq  e "$PATCH" $OVERLAYDIR/repo-overlay.yaml -i  
+yq  e "$PATCH" "$ROOT/$OVERLAYDIR/repo-overlay.yaml" -i  
 PATCH="$(printf '.spec.source.targetRevision="%q"' $BRANCH)" 
-yq  e "$PATCH" $OVERLAYDIR/repo-overlay.yaml -i 
+yq  e "$PATCH" "$ROOT/$OVERLAYDIR/repo-overlay.yaml" -i 
 
 echo
 echo The list of components which will be patched is
-yq  e '.metadata.name' $OVERLAYDIR/repo-overlay.yaml
+yq  e '.metadata.name' "$ROOT/$OVERLAYDIR/repo-overlay.yaml"
 
 echo
 echo Each component above is set to the following repositories
 echo if you do not see your component in the list, please send a PR update to $OVERLAYDIR/repo-overlay.yaml
-yq  e '.spec.source.repoURL' $OVERLAYDIR/repo-overlay.yaml
+yq  e '.spec.source.repoURL' "$ROOT/$OVERLAYDIR/repo-overlay.yaml"

--- a/hack/util-update-app-of-apps.sh
+++ b/hack/util-update-app-of-apps.sh
@@ -24,7 +24,7 @@ else
 fi
 
 PATCHREPO="$(printf '.spec.source.repoURL="%q"' $GITURL)" 
-PATCHOVERLAY="$(printf '.spec.source.path="%q"' $OVERLAYDIR)"  
+PATCHOVERLAY="$(printf '.spec.source.path="%q"' "$ROOT/$OVERLAYDIR")"  
 PATCHBRANCH="$(printf '.spec.source.targetRevision="%q"' $BRANCH)"  
 
 # the overlay content can be updated selectively per user in their fork


### PR DESCRIPTION
Running development-mode.sh from any other dir than the
root of the workspace was generating errors.

Signed-off-by: Romain Arnaud <rarnaud@redhat.com>