### PR TITLE
Assign PVC by onetime job

### DIFF
--- a/components/gitops/.tekton/pvc.yaml
+++ b/components/gitops/.tekton/pvc.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -8,3 +9,27 @@ spec:
   resources:
     requests:
       storage: 1Gi
+
+---
+# Use PVC for the first time to trigger PV assigment.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: bind-volume
+spec:
+  selector: {}
+  template:
+    metadata:
+      name: bind-volume
+    spec:
+      containers:
+        - name: bind-volume
+          image: registry.access.redhat.com/ubi8/ubi-minimal:latest
+          volumeMounts:
+            - name: bind
+              mountPath: /test
+      restartPolicy: Never
+      volumes:
+        - name: bind
+          persistentVolumeClaim:
+              claimName: app-studio-default-workspace

--- a/components/has/.tekton/pvc.yaml
+++ b/components/has/.tekton/pvc.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -8,3 +9,27 @@ spec:
   resources:
     requests:
       storage: 1Gi
+
+---
+# Use PVC for the first time to trigger PV assigment.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: bind-volume
+spec:
+  selector: {}
+  template:
+    metadata:
+      name: bind-volume
+    spec:
+      containers:
+        - name: bind-volume
+          image: registry.access.redhat.com/ubi8/ubi-minimal:latest
+          volumeMounts:
+            - name: bind
+              mountPath: /test
+      restartPolicy: Never
+      volumes:
+        - name: bind
+          persistentVolumeClaim:
+              claimName: app-studio-default-workspace


### PR DESCRIPTION
Use newly created PVC in job to force PV assignement. On some cloud
providers the PV is assigned to PVC after PVC is being used.