### PR TITLE
Update triggers.tekton.dev API version from v1alpha1 to v1beta1

### DIFF
--- a/components/gitops/.tekton/event-listener.yaml
+++ b/components/gitops/.tekton/event-listener.yaml
@@ -1,4 +1,4 @@
-apiVersion: triggers.tekton.dev/v1alpha1
+apiVersion: triggers.tekton.dev/v1beta1
 kind: EventListener
 metadata:
   name: gitops-service-cluster-agent

--- a/components/gitops/.tekton/trigger-template.yaml
+++ b/components/gitops/.tekton/trigger-template.yaml
@@ -1,4 +1,4 @@
-apiVersion: triggers.tekton.dev/v1alpha1
+apiVersion: triggers.tekton.dev/v1beta1
 kind: TriggerTemplate
 metadata:
   name: gitops-service-cluster-agent

--- a/components/has/.tekton/event-listener.yaml
+++ b/components/has/.tekton/event-listener.yaml
@@ -1,4 +1,4 @@
-apiVersion: triggers.tekton.dev/v1alpha1
+apiVersion: triggers.tekton.dev/v1beta1
 kind: EventListener
 metadata:
   name: application-service

--- a/components/has/.tekton/trigger-template.yaml
+++ b/components/has/.tekton/trigger-template.yaml
@@ -1,4 +1,4 @@
-apiVersion: triggers.tekton.dev/v1alpha1
+apiVersion: triggers.tekton.dev/v1beta1
 kind: TriggerTemplate
 metadata:
   name: application-service


### PR DESCRIPTION
Signed-off-by: Mykola Morhun <mmorhun@redhat.com>

To be consistent with resources generation in application-service operator, we need to update `triggers.tekton.dev` API version from `v1alpha1` to `v1beta1`.