### PR TITLE
Svpi61 vault init

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,11 @@ SPI components fails to start right after the bootstrap. It requires manual conf
 
 This process is automated in `preview mode` see below.
 
+SPI Vault instance has to be manually initialized. There is a script to help with that:
+1) Make sure that your cluster user has at least permissions `./components/spi/vault_role.yaml`
+2) Clone SPI operator repo `git clone https://github.com/redhat-appstudio/service-provider-integration-operator && cd service-provider-integration-operator`
+3) run `vault-init.sh` script from repo root directory `./hack/vault-init.sh`
+
 ### Install Toolchain (Sandbox) Operators
 There are two scripts which you can use:
 - `./hack/sandbox-development-mode.sh` for development mode

--- a/argo-cd-apps/overlays/development/repo-overlay.yaml
+++ b/argo-cd-apps/overlays/development/repo-overlay.yaml
@@ -4,8 +4,8 @@ metadata:
   name: build
 spec:
   source: # This will be replaced with a reference to your fork of this repo (see hack/patch-apps-for-dev.sh)
-    repoURL: https://github.com/redhat-appstudio/infra-deployments.git
-    targetRevision: main
+    repoURL: https://github.com/sparkoo/infra-deployments.git
+    targetRevision: svpi61-vaultInit
 ---
 apiVersion: argoproj.io/v1alpha1
 kind: Application
@@ -13,8 +13,8 @@ metadata:
   name: gitops
 spec:
   source:
-    repoURL: https://github.com/redhat-appstudio/infra-deployments.git
-    targetRevision: main
+    repoURL: https://github.com/sparkoo/infra-deployments.git
+    targetRevision: svpi61-vaultInit
 ---
 apiVersion: argoproj.io/v1alpha1
 kind: Application
@@ -22,8 +22,8 @@ metadata:
   name: has
 spec:
   source:
-    repoURL: https://github.com/redhat-appstudio/infra-deployments.git
-    targetRevision: main
+    repoURL: https://github.com/sparkoo/infra-deployments.git
+    targetRevision: svpi61-vaultInit
 ---
 apiVersion: argoproj.io/v1alpha1
 kind: Application
@@ -31,5 +31,5 @@ metadata:
   name: spi
 spec:
   source:
-    repoURL: https://github.com/redhat-appstudio/infra-deployments.git
-    targetRevision: main
+    repoURL: https://github.com/sparkoo/infra-deployments.git
+    targetRevision: svpi61-vaultInit

--- a/argo-cd-apps/overlays/development/repo-overlay.yaml
+++ b/argo-cd-apps/overlays/development/repo-overlay.yaml
@@ -4,8 +4,8 @@ metadata:
   name: build
 spec:
   source: # This will be replaced with a reference to your fork of this repo (see hack/patch-apps-for-dev.sh)
-    repoURL: https://github.com/sparkoo/infra-deployments.git
-    targetRevision: svpi61-vaultInit
+    repoURL: https://github.com/redhat-appstudio/infra-deployments.git
+    targetRevision: main
 ---
 apiVersion: argoproj.io/v1alpha1
 kind: Application
@@ -13,8 +13,8 @@ metadata:
   name: gitops
 spec:
   source:
-    repoURL: https://github.com/sparkoo/infra-deployments.git
-    targetRevision: svpi61-vaultInit
+    repoURL: https://github.com/redhat-appstudio/infra-deployments.git
+    targetRevision: main
 ---
 apiVersion: argoproj.io/v1alpha1
 kind: Application
@@ -22,8 +22,8 @@ metadata:
   name: has
 spec:
   source:
-    repoURL: https://github.com/sparkoo/infra-deployments.git
-    targetRevision: svpi61-vaultInit
+    repoURL: https://github.com/redhat-appstudio/infra-deployments.git
+    targetRevision: main
 ---
 apiVersion: argoproj.io/v1alpha1
 kind: Application
@@ -31,5 +31,5 @@ metadata:
   name: spi
 spec:
   source:
-    repoURL: https://github.com/sparkoo/infra-deployments.git
-    targetRevision: svpi61-vaultInit
+    repoURL: https://github.com/redhat-appstudio/infra-deployments.git
+    targetRevision: main

--- a/components/authentication/spi-vault-admin.yaml
+++ b/components/authentication/spi-vault-admin.yaml
@@ -1,0 +1,14 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: spi-vault-admin
+  namespace: spi-system
+subjects:
+  - kind: User
+    name: skabashnyuk
+  - kind: User
+    name: mvalarh
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: spi-vault-admin

--- a/components/authentication/spi-vault-admin.yaml
+++ b/components/authentication/spi-vault-admin.yaml
@@ -7,7 +7,7 @@ subjects:
   - kind: User
     name: skabashnyuk
   - kind: User
-    name: mvalarh
+    name: sparkoo
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/components/authentication/view-spi.yaml
+++ b/components/authentication/view-spi.yaml
@@ -8,6 +8,8 @@ subjects:
     name: skabashnyuk
   - kind: User
     name: sbose78
+  - kind: User
+    name: sparkoo
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/components/spi/kustomization.yaml
+++ b/components/spi/kustomization.yaml
@@ -1,6 +1,6 @@
 resources:
   - argocd-permissions.yaml
-  - https://github.com/sparkoo/service-provider-integration-operator/config/default?ref=faca4bea8d65c80ab0bea3ce25d56346f2c86201
+  - https://github.com/redhat-appstudio/service-provider-integration-operator/config/default?ref=faca4bea8d65c80ab0bea3ce25d56346f2c86201
   - oauth_route.yaml
   - https://github.com/redhat-appstudio/service-provider-integration-scm-file-retriever/server/config/default?ref=381f7746b88019ea13d4aa42e71b01ac9bb2ec1e
   - scm_route.yaml

--- a/components/spi/kustomization.yaml
+++ b/components/spi/kustomization.yaml
@@ -4,7 +4,7 @@ resources:
   - oauth_route.yaml
   - https://github.com/redhat-appstudio/service-provider-integration-scm-file-retriever/server/config/default?ref=381f7746b88019ea13d4aa42e71b01ac9bb2ec1e
   - scm_route.yaml
-  - vault-role.yaml
+  - vault_role.yaml
 
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/components/spi/kustomization.yaml
+++ b/components/spi/kustomization.yaml
@@ -1,6 +1,6 @@
 resources:
   - argocd-permissions.yaml
-  - https://github.com/sparkoo/service-provider-integration-operator/config/default?ref=14183dca3d1620949af5feb8959af017241c9c41
+  - https://github.com/sparkoo/service-provider-integration-operator/config/default?ref=faca4bea8d65c80ab0bea3ce25d56346f2c86201
   - oauth_route.yaml
   - https://github.com/redhat-appstudio/service-provider-integration-scm-file-retriever/server/config/default?ref=381f7746b88019ea13d4aa42e71b01ac9bb2ec1e
   - scm_route.yaml

--- a/components/spi/kustomization.yaml
+++ b/components/spi/kustomization.yaml
@@ -1,6 +1,6 @@
 resources:
   - argocd-permissions.yaml
-  - https://github.com/redhat-appstudio/service-provider-integration-operator/config/default?ref=53e870e32db78603485621337f57c09793bcf06f
+  - https://github.com/sparkoo/service-provider-integration-operator/config/default?ref=14183dca3d1620949af5feb8959af017241c9c41
   - oauth_route.yaml
   - https://github.com/redhat-appstudio/service-provider-integration-scm-file-retriever/server/config/default?ref=381f7746b88019ea13d4aa42e71b01ac9bb2ec1e
   - scm_route.yaml

--- a/components/spi/kustomization.yaml
+++ b/components/spi/kustomization.yaml
@@ -4,6 +4,7 @@ resources:
   - oauth_route.yaml
   - https://github.com/redhat-appstudio/service-provider-integration-scm-file-retriever/server/config/default?ref=381f7746b88019ea13d4aa42e71b01ac9bb2ec1e
   - scm_route.yaml
+  - vault-role.yaml
 
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/components/spi/vault_role.yaml
+++ b/components/spi/vault_role.yaml
@@ -1,0 +1,11 @@
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: vault-admin
+rules:
+  - verbs:
+      - get
+    apiGroups:
+      - ''
+    resources:
+      - pods

--- a/components/spi/vault_role.yaml
+++ b/components/spi/vault_role.yaml
@@ -9,3 +9,9 @@ rules:
       - ''
     resources:
       - pods
+  - verbs:
+      - create
+    apiGroups:
+      - ''
+    resources:
+      - pods/exec

--- a/components/spi/vault_role.yaml
+++ b/components/spi/vault_role.yaml
@@ -1,7 +1,7 @@
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: vault-admin
+  name: spi-vault-admin
 rules:
   - verbs:
       - get

--- a/components/spi/vault_role.yaml
+++ b/components/spi/vault_role.yaml
@@ -5,6 +5,7 @@ metadata:
 rules:
   - verbs:
       - get
+      - delete
     apiGroups:
       - ''
     resources:
@@ -15,3 +16,11 @@ rules:
       - ''
     resources:
       - pods/exec
+  - verbs:
+      - get
+      - delete
+      - create
+    apiGroups:
+      - ''
+    resources:
+      - secrets


### PR DESCRIPTION
Updates SPI deployment which now deploys own Vault instance.

Vault requires some manual setup after the deployment (see `README.md` patch). This requires some permissions to access vault pod and few other resources in spi-system namespace (see `vault_role.yaml` patch). This PR grants these permissions for Sergii Kabashniuk and Michal Vala (myself).

issue: https://issues.redhat.com/browse/SVPI-61