### PR TITLE
SVPI-61 - vault admin rolebinding

### DIFF
--- a/components/spi/kustomization.yaml
+++ b/components/spi/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
   - https://github.com/redhat-appstudio/service-provider-integration-scm-file-retriever/server/config/default?ref=381f7746b88019ea13d4aa42e71b01ac9bb2ec1e
   - scm_route.yaml
   - vault_role.yaml
+  - vault_rolebinding.yaml
 
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/components/spi/vault_rolebinding.yaml
+++ b/components/spi/vault_rolebinding.yaml
@@ -2,7 +2,6 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: spi-vault-admin
-  namespace: spi-system
 subjects:
   - kind: User
     name: skabashnyuk


### PR DESCRIPTION
In https://github.com/redhat-appstudio/infra-deployments/pull/118 I forgot to include RoleBinding to vault admin role in `kustomization.yaml`. In this PR, I've moved the actual RoleBinding into SPI component (it lives only in spi-system namespace) and include it in SPI `kustomization.yaml`.