### PR TITLE
Add GitOps Service resources to staging cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,38 @@ SPI Vault instance has to be manually initialized. There is a script to help wit
 2) Clone SPI operator repo `git clone https://github.com/redhat-appstudio/service-provider-integration-operator && cd service-provider-integration-operator`
 3) run `vault-init.sh` script from repo root directory `./hack/vault-init.sh`
 
+#### Post-bootstrap GitOps Service Configuration
+
+GitOps service components will not be functional right after bootstrap. It requires manual configuration in order to work properly:
+
+1) `wget https://raw.githubusercontent.com/redhat-appstudio/managed-gitops/main/manifests/postgresql-staging/postgresql-staging-secret.yaml`
+
+2) Edit `postgresql-staging-secret.yaml`, and update the password field:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: gitops-postgresql-staging
+  labels:
+    app.kubernetes.io/name: postgresql
+    helm.sh/chart: postgresql-10.16.1
+    app.kubernetes.io/instance: gitops-postgresql-staging
+    app.kubernetes.io/managed-by: Helm
+  namespace: gitops
+type: Opaque
+data:
+  postgresql-password: "(your password here)" # Edit this line
+```
+
+*Note*: You will need to use a [Base 64 value](https://www.base64encode.org/) for the password field. (Note: this password is *not* required after this step, so you may safely discard it after editing the secret.)
+
+3) `kubectl apply -f postgresql-staging-secret.yaml`  to apply the Secret YAML.
+
+4) You may need to hit 'Synchronize' on the `gitops` application, in Argo CD, in order to trigger the updated Application deployment.
+    - (I'm not 100% sure if this is required, more data are needed, but it can't hurt! - @jgwest)
+
+
 ### Install Toolchain (Sandbox) Operators
 There are two scripts which you can use:
 - `./hack/sandbox-development-mode.sh` for development mode

--- a/components/gitops/kustomization.yaml
+++ b/components/gitops/kustomization.yaml
@@ -1,5 +1,5 @@
 resources:
-- backend/
+- staging/
 - .tekton/
 
 apiVersion: kustomize.config.k8s.io/v1beta1

--- a/components/gitops/staging/allow-argocd-to-manage.yaml
+++ b/components/gitops/staging/allow-argocd-to-manage.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: grant-argocd
+  namespace: gitops
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: admin
+subjects:
+- kind: ServiceAccount
+  name: openshift-gitops-argocd-application-controller
+  namespace: openshift-gitops

--- a/components/gitops/staging/argo-cd-namespace.yaml
+++ b/components/gitops/staging/argo-cd-namespace.yaml
@@ -2,5 +2,3 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: gitops-service-argocd
-#  labels:
-#    argocd.argoproj.io/managed-by: gitops-service-argocd 

--- a/components/gitops/staging/argo-cd-namespace.yaml
+++ b/components/gitops/staging/argo-cd-namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: gitops-service-argocd
+#  labels:
+#    argocd.argoproj.io/managed-by: gitops-service-argocd 

--- a/components/gitops/staging/argo-cd.yaml
+++ b/components/gitops/staging/argo-cd.yaml
@@ -1,0 +1,107 @@
+apiVersion: argoproj.io/v1alpha1
+kind: ArgoCD
+metadata:
+  finalizers:
+  - argoproj.io/finalizer
+  name: gitops-service-argocd
+  namespace: gitops-service-argocd
+spec:
+  applicationSet:
+    resources:
+      limits:
+        cpu: "1"
+        memory: 1Gi
+      requests:
+        cpu: 250m
+        memory: 128Mi
+  controller:
+    processors: {}
+    resources:
+      limits:
+        cpu: "1"
+        memory: 1Gi
+      requests:
+        cpu: 250m
+        memory: 256Mi
+    sharding: {}
+#  dex:
+#    enabled: false
+#    openShiftOAuth: false # true
+#    resources:
+#      limits:
+#        cpu: 500m
+#        memory: 256Mi
+#      requests:
+#        cpu: 250m
+#        memory: 128Mi
+  grafana:
+    enabled: false
+    ingress:
+      enabled: false
+    resources:
+      limits:
+        cpu: 500m
+        memory: 256Mi
+      requests:
+        cpu: 250m
+        memory: 128Mi
+    route:
+      enabled: false
+  ha:
+    enabled: false
+    resources:
+      limits:
+        cpu: 500m
+        memory: 256Mi
+      requests:
+        cpu: 250m
+        memory: 128Mi
+  initialSSHKnownHosts: {}
+  prometheus:
+    enabled: false
+    ingress:
+      enabled: false
+    route:
+      enabled: false
+  rbac:
+    policy: g, system:authenticated, role:admin
+    scopes: '[groups]'
+  redis:
+    resources:
+      limits:
+        cpu: 500m
+        memory: 256Mi
+      requests:
+        cpu: 250m
+        memory: 128Mi
+  repo:
+    resources:
+      limits:
+        cpu: "1"
+        memory: 1Gi
+      requests:
+        cpu: 250m
+        memory: 256Mi
+  server:
+    autoscale:
+      enabled: false
+    grpc:
+      ingress:
+        enabled: false
+    ingress:
+      enabled: false
+    resources:
+      limits:
+        cpu: 500m
+        memory: 256Mi
+      requests:
+        cpu: 125m
+        memory: 128Mi
+    route:
+      enabled: true
+      tls:
+        termination: reencrypt
+    service:
+      type: ""
+  tls:
+    ca: {}

--- a/components/gitops/staging/dbschema-config-map.yaml
+++ b/components/gitops/staging/dbschema-config-map.yaml
@@ -1,0 +1,241 @@
+apiVersion: v1
+data:
+  db-schema.sql: "\n-- ClusterCredentials contains the credentials required to access
+    a K8s cluster. \n-- The credentials may be in one of two forms:\n-- 1) Kubeconfig
+    state: Kubeconfig file, plus a reference to a specific context within the\n--
+    \    - This is the same content as can be found in your local '~/.kube/config'
+    file\n--     - This is what the user would initially provide via the Service/Web
+    UI/CLI\n--     - There may be (likely is) a better way of doing this, but this
+    works for now.\n-- 2) ServiceAccount state: A bearer token for a service account
+    on the target cluster\n--     - Same mechanism Argo CD users for accessing remote
+    clusters\n--\n-- You can tell which state the credentials are in, based on whether
+    'serviceaccount_bearer_token' is null. \n--\n-- It is the job of the cluster agent
+    to convert state 1 (kubeconfig) into a service account \n-- bearer token on the
+    target cluster (state 2).\n--     - This is the same operation as the `argocd
+    cluster add` command, and is the same\n--       technique used by Argo CD to interface
+    with remove clusters.\n--     - See https://github.com/argoproj/argo-cd/blob/a894d4b128c724129752bac9971c903ab6c650ba/cmd/argocd/commands/cluster.go#L116\nCREATE
+    TABLE ClusterCredentials (\n\t\n\t-- Primary key for the credentials (UID), is
+    a random UUID\n\tclustercredentials_cred_id VARCHAR (48) UNIQUE PRIMARY KEY,\n\n\t--
+    API URL for the cluster \n\t-- Example: https://api.ci-ln-dlfw0qk-f76d1.origin-ci-int-gce.dev.openshift.com:6443\n\thost
+    VARCHAR (512),\n\n\t-- State 1) kube_config containing a token to a service account
+    that has the permissions we need.\n\tkube_config VARCHAR (65000),\n\n\t-- State
+    1) The name of a context within the kube_config \n\tkube_config_context VARCHAR
+    (64),\n\n\t-- State 2) ServiceAccount bearer token from the target manager cluster\n\tserviceaccount_bearer_token
+    VARCHAR (128),\n\n\t-- State 2) The namespace of the ServiceAccount\n\tserviceaccount_ns
+    VARCHAR (128),\n\n\tseq_id serial\n);\n\n-- GitopsEngineCluster\n-- A cluster
+    that hosts Argo CD instances\n-- Note: I use the term GitOpsEngine to refer to
+    Argo CD, so as not to marry us to Argo CD at the database level.\nCREATE TABLE
+    GitopsEngineCluster (\n\n\t-- Primary key for the GitopsEngineCluster (UID), is
+    a random UUID\n\tgitopsenginecluster_id  VARCHAR (48) UNIQUE PRIMARY KEY,\n\t\n\tseq_id
+    serial, \n\n\t-- pointer to credentials for the cluster\n\t-- Foreign key to:
+    ClusterCredentials.clustercredentials_cred_id\n\tclustercredentials_id VARCHAR
+    (48) NOT NULL,\n\tCONSTRAINT fk_cluster_credential FOREIGN KEY(clustercredentials_id)
+    REFERENCES ClusterCredentials(clustercredentials_cred_id) ON DELETE NO ACTION
+    ON UPDATE NO ACTION\n\n);\n\n-- GitopsEngineInstance\n-- Represents an Argo CD
+    instance on a cluster; the specific cluster is pointed to by the enginecluster
+    field, and the\n-- namespace of the Argo CD install is listed here.\nCREATE TABLE
+    GitopsEngineInstance (\n\n\t-- Primary key for the GitopsEngineInstance (UID),
+    is a random UUID\n\tgitopsengineinstance_id VARCHAR (48) UNIQUE PRIMARY KEY,\n\n\tseq_id
+    serial,\n\n\t-- An Argo CD cluster may host multiple Argo CD instances; these
+    fields\n\t-- indicate which namespace this specific instance lives in (and uid
+    of the namespace)\n\tnamespace_name VARCHAR (48) NOT NULL,\n\tnamespace_uid VARCHAR
+    (48) NOT NULL,\n\n\t-- Reference to the Argo CD cluster containing the instance\n\t--
+    Foreign key to: GitopsEngineCluster.gitopsenginecluster_id\n\tenginecluster_id
+    VARCHAR(48) NOT NULL,\n\tCONSTRAINT fk_gitopsengine_cluster FOREIGN KEY (enginecluster_id)
+    REFERENCES GitopsEngineCluster(gitopsenginecluster_id) ON DELETE NO ACTION ON
+    UPDATE NO ACTION\n\t\n);\n\n\n-- ManagedEnvironment\n-- An environment (cluster)
+    that the user wants to deploy applications to, using Argo CD\nCREATE TABLE ManagedEnvironment
+    (\n\n\t-- Primary key for the ManagedEnvironment (UID), is a random UUID\n\tmanagedenvironment_id
+    VARCHAR (48) UNIQUE PRIMARY KEY,\n\tseq_id serial, \n\t\n\t-- human readable name\n\tname
+    VARCHAR ( 256 ) NOT NULL,\n\n\t-- pointer to credentials for the cluster\n\t--
+    Foreign key to: ClusterCredentials.clustercredentials_cred_id\n\tclustercredentials_id
+    VARCHAR (48) NOT NULL,\n\tCONSTRAINT fk_cluster_credential FOREIGN KEY (clustercredentials_id)
+    REFERENCES ClusterCredentials(clustercredentials_cred_id) ON DELETE NO ACTION
+    ON UPDATE NO ACTION\n);\n\n\n-- ClusterUser\n-- An individual user/customer\n--\n--
+    Note: This is basically placeholder: a real implementation would need to be way
+    more complex.\nCREATE TABLE ClusterUser (\n\t\n\t-- Primary key for the ClusterUser
+    (UID), is a random UUID\n\tclusteruser_id VARCHAR (48) PRIMARY KEY,\n\n\t-- A
+    generic string representing a user; this likely need to be replaced with a field\n\t--
+    more consistent with the user configuration we are operating within.\n\tuser_name
+    VARCHAR (256) NOT NULL UNIQUE,\n\n\tseq_id serial\n);\n\n\n\n-- ClusterAccess\n--\n--
+    This table answers the questions:\n-- - What managed clusters does a user have?\n--
+    - What argo cd instance is managing those clusters?\nCREATE TABLE ClusterAccess
+    (\n\n\t-- Describes whose cluster this is (UID)\n\t-- Foreign key to: ClusterUser.clusteruser_id\n\tclusteraccess_user_id
+    VARCHAR (48),\n\tCONSTRAINT fk_clusteruser_id FOREIGN KEY (clusteraccess_user_id)
+    REFERENCES ClusterUser(clusteruser_id) ON DELETE NO ACTION ON UPDATE NO ACTION,\n\n\t--
+    Describes which managed environment the user has access to (UID)\n\t-- Foreign
+    key to: ManagedEnvironment.managedenvironment_id\n\tclusteraccess_managed_environment_id
+    VARCHAR (48),\n\tCONSTRAINT fk_managedenvironment_id FOREIGN KEY (clusteraccess_managed_environment_id)
+    REFERENCES ManagedEnvironment(managedenvironment_id) ON DELETE NO ACTION ON UPDATE
+    NO ACTION,\n\n\t-- Which Argo CD instance is managing the cluster?\n\t-- Foreign
+    key to: GitopsEngineInstance.gitopsengineinstance_id\n\tclusteraccess_gitops_engine_instance_id
+    VARCHAR (48),\n\tCONSTRAINT fk_gitopsengineinstance_id FOREIGN KEY (clusteraccess_gitops_engine_instance_id)
+    REFERENCES GitopsEngineInstance(gitopsengineinstance_id) ON DELETE NO ACTION ON
+    UPDATE NO ACTION,\n\t\n\tseq_id serial,\n\t\n\t-- All fields of the cluster are
+    part of the primary key (not seq_uid), and in addition we have indexes\n\t-- below
+    for quickly locating a subset of the table.\n\tPRIMARY KEY(clusteraccess_user_id,
+    clusteraccess_managed_environment_id, clusteraccess_gitops_engine_instance_id)\n);\n--
+    Add an index on user_id+managed_cluster, and userid+gitops_manager_instance_Id\nCREATE
+    INDEX idx_userid_cluster ON ClusterAccess(clusteraccess_user_id, clusteraccess_managed_environment_id);\nCREATE
+    INDEX idx_userid_instance ON ClusterAccess(clusteraccess_user_id, clusteraccess_gitops_engine_instance_id);\n\n\n\n--
+    Operation\n-- Operations are used to by the backend to communicate database changes
+    to the cluster-agent.\n-- It is the reponsibility of the cluster agent to respond
+    to operations, to read the database\n-- to discover what database changes occurred,
+    and to ensure that Argo CD is consistent with\n-- the database state.\n-- \n--
+    See https://docs.google.com/document/d/1e1UwCbwK-Ew5ODWedqp_jZmhiZzYWaxEvIL-tqebMzo/edit#heading=h.9tzaobsoav27\n--
+    for description of Operation\nCREATE TABLE Operation (\n\t\n\t-- Primary key for
+    the Operation (UID), is a random UUID\n\toperation_id  VARCHAR (48) PRIMARY KEY,\n\n\tseq_id
+    serial,\n\n\t-- Specifies which Argo CD instance is this operation against\n\t--
+    Foreign key to: GitopsEngineInstance.gitopsengineinstance_id\n\tinstance_id VARCHAR(48)
+    NOT NULL,\n\tCONSTRAINT fk_gitopsengineinstance_id FOREIGN KEY (instance_id) REFERENCES
+    GitopsEngineInstance(gitopsengineinstance_id) ON DELETE NO ACTION ON UPDATE NO
+    ACTION,\n\n\t-- ID of the database resource that was modified (usually this field
+    contains a primary key of another database table )\n\tresource_id VARCHAR(48)
+    NOT NULL,\n\n\t-- The user that initiated the operation.\n\t-- Foreign key to:
+    ClusterUser.clusteruser_id\n\toperation_owner_user_id VARCHAR(48),\n\tCONSTRAINT
+    fk_clusteruser_id FOREIGN KEY (operation_owner_user_id) REFERENCES ClusterUser(clusteruser_id)
+    ON DELETE NO ACTION ON UPDATE NO ACTION,\n\n\t-- Resource type of the resource
+    that was modified\n\t-- This value lets the operation know which table contains
+    the resource.\n\t-- \n\t-- possible values:\n\t-- * ManagedEnvironment (specified
+    when we want Argo CD to C/R/U/D a user's cluster credentials)\n\t-- * GitopsEngineInstance
+    (specified to CRUD an Argo instance, for example to create a new namespace and
+    put Argo CD in it, then signal when it's done)\n\t-- * Application (user creates
+    a new Application via service/web UI)\n\t-- * SyncOperation (user wants a GitOps
+    engine sync operation performed)\n\tresource_type VARCHAR(32) NOT NULL,\n\n\t--
+    When the operation was created. Used for garbage collection, as operations should
+    be short lived.\n\tcreated_on TIMESTAMP NOT NULL,\n\n\t-- last_state_update is
+    set whenever state changes\n\t-- (initial value should be equal to created_on)\n\tlast_state_update
+    TIMESTAMP NOT NULL,\n\n\t-- possible values:\n\t-- * Waiting\n\t-- * In_Progress\n\t--
+    * Completed\n\t-- * Failed\n\tstate VARCHAR ( 30 ) NOT NULL,\n\t\n\t-- If there
+    is an error message from the operation, it is passed via this field.\n\thuman_readable_state
+    VARCHAR ( 1024 )\n\n);\n\n-- Application represents an Argo CD Application CR
+    within an Argo CD namespace.\nCREATE TABLE Application (\n\tapplication_id VARCHAR
+    ( 48 ) NOT NULL UNIQUE PRIMARY KEY,\n\n\t-- Name of the Application CR within
+    the namespace\n\tname VARCHAR ( 256 ) NOT NULL,\n\n\t-- resource_uid VARCHAR (
+    48 ) NOT NULL UNIQUE,\n\n\t-- '.spec' field of the Application CR\n\t-- Note:
+    Rather than converting individual JSON fields into SQL Table fields, we just pull
+    the whole spec field. \n\t-- In the future, it might be beneficial to pull out
+    SOME of the fields, to reduce CPU time spent on json parsing\n\tspec_field VARCHAR
+    ( 16384 ) NOT NULL,\n\n\t-- Which Argo CD instance it's hosted on\n\t-- Foreign
+    key to: GitopsEngineInstance.gitopsengineinstance_id\n\tengine_instance_inst_id
+    VARCHAR(48) NOT NULL,\n\tCONSTRAINT fk_gitopsengineinstance_id FOREIGN KEY (engine_instance_inst_id)
+    REFERENCES GitopsEngineInstance(gitopsengineinstance_id) ON DELETE NO ACTION ON
+    UPDATE NO ACTION,\n\n\t-- Which managed environment it is targetting\n\t-- Foreign
+    key to: ManagedEnvironment.managedenvironment_id\n\tmanaged_environment_id VARCHAR(48)
+    NOT NULL,\n\tCONSTRAINT fk_managedenvironment_id FOREIGN KEY (managed_environment_id)
+    REFERENCES ManagedEnvironment(managedenvironment_id) ON DELETE NO ACTION ON UPDATE
+    NO ACTION,\n\t\n\tseq_id serial\n\n);\n\n-- ApplicationState is the Argo CD health/sync
+    state of the Application\n-- (Redis may be better suited for this in the future)\nCREATE
+    TABLE ApplicationState (\n\n\t-- Foreign key to Application.application_id\n\tapplicationstate_application_id
+    \ VARCHAR ( 48 ) PRIMARY KEY,\n\tCONSTRAINT fk_app_id FOREIGN KEY (applicationstate_application_id)
+    REFERENCES Application(application_id) ON DELETE NO ACTION ON UPDATE NO ACTION,\n\n\t--
+    health field comes directly from Argo CD Application CR's .status.health field\n\t--
+    Possible values:\n\t-- * Healthy\n\t-- * Progressing\n\t-- * Degraded\n\t-- *
+    Suspended\n\t-- * Missing\n\t-- * Unknown (this is returned by Argo CD, but is
+    also used when Argo CD's health field is \"\")\n\thealth VARCHAR (30) NOT NULL,\n\n\t--
+    health field comes directly from Argo CD Application CR's .status.syncStatus field\n\t--
+    Possible values:\n\t-- * Synced\n\t-- * OutOfSync\n\t-- * Unknown (this is used
+    when Argo CD's status field is \"\")\n\tsync_status VARCHAR (30) NOT NULL\n\n);\n\n--
+    Represents the relationship from GitOpsDeployment CR in the API namespace (workspace),
+    to an Application table row.\n-- This means: if we see a change in a GitOpsDeployment
+    CR, we can easily find the corresponding database entry\n-- by looking for a DeploymentToApplicationMapping
+    that captures the relationship (and vice versa)\nCREATE TABLE DeploymentToApplicationMapping
+    (\n\t\n\t-- uid of our gitops deployment CR within the K8s namespace (or KCP control
+    plane)\n\tdeploymenttoapplicationmapping_uid_id VARCHAR(48) UNIQUE NOT NULL PRIMARY
+    KEY,\n\t\n\t-- name of the GitOpsDeployment CR in the API namespace (workspace)\n\tname
+    VARCHAR ( 256 ),\n\t-- name of the API namespace (workspace)\n\tnamespace VARCHAR
+    ( 96 ),\n\t-- uid of the API namespace (workspace)\n\tworkspace_uid VARCHAR (
+    48 ), \n\n\t-- The Application DB entry that corresponds to this GitOpsDeployment
+    CR\n\t-- (For example, deleting the GitOpsDeployment CR should delete the corresponding
+    Application DB table, and likewise\n\t-- should delete this table's entry)\n\t--
+    Foreign key to: Application.application_id\n\tapplication_id VARCHAR ( 48 ) NOT
+    NULL UNIQUE,\n\tCONSTRAINT fk_app_id FOREIGN KEY (application_id) REFERENCES Application(application_id)
+    ON DELETE NO ACTION ON UPDATE NO ACTION,\n\n\tseq_id serial\n\n);\n\n-- Represents
+    a generic relationship between: Kubernetes CR <->  Database table\n-- The Kubernetes
+    CR can be either in the workspace, or in/on a GitOpsEngine cluster namespace.\n--\n--
+    Example: when the cluster agent sees an Argo CD Application CR change within a
+    namespace, it needs a way\n-- to know which GitOpsEngineInstance database entries
+    corresponds to the Argo CD namespace.\n-- \n-- For this we would use:\n-- - kubernetes_resource_type:
+    Namespace\n-- - kubernetes_resource_uid: (uid of namespace)\n-- - db_relation_type:
+    GitOpsEngineInstance\n-- - db_relation_key: (primary key of gitops engine instance)\n--\n--
+    Later, we can query this table to determine 'Argo CD instance namespace' <=> 'GitopsEngineInstance
+    database row'\n--\n-- This is also useful for tracking the lifecycle between CRs
+    <-> database table.\nCREATE TABLE KubernetesToDBResourceMapping  (\n\n\t-- kubernetes
+    CR resource (example: Namespace)\n\t-- As of this writing (Jan 2022), Namespace
+    is the only supported value for this field.\n\t-- - See 'kubernetesresourcetodbresousemapping.go'
+    for latest list.\n\tkubernetes_resource_type VARCHAR(64) NOT NULL,\n\n\t-- UID
+    of the CR (from the .metadata.UID field)\n\tkubernetes_resource_uid  VARCHAR(64)
+    NOT NULL,\n\n\t-- name of database table\n\t-- As of this writing (Jan 2022),
+    ManagedEnvironment, GitopsEngineCluster, and GitopsEngineInstance are the only
+    supported values for this field.\n\t-- - See 'kubernetesresourcetodbresousemapping.go'
+    for latest list.\n\tdb_relation_type  VARCHAR(64) NOT NULL,\n\n\t-- primary key
+    of database table\n\tdb_relation_key  VARCHAR(64) NOT NULL,\n\n\tseq_id serial,\n\n\tPRIMARY
+    KEY(kubernetes_resource_type, kubernetes_resource_uid, db_relation_type, db_relation_key)\n\n);\n\nCREATE
+    INDEX idx_db_relation_uid ON KubernetesToDBResourceMapping(kubernetes_resource_type,
+    kubernetes_resource_uid, db_relation_type);\n-- Used by: GetDBResourceMappingForKubernetesResource\n\n--
+    Maps API custom resources on the workspace (such as GitOpsDeploymentSyncRun),
+    to a corresponding entry in the database.\n-- This allows us to quickly go from
+    API CR <-to-> Database entry, and also to identify database entries even when
+    the API CR has been\n-- deleted from the workspace.\nCREATE TABLE APICRToDatabaseMapping
+    \ (\n\n\t-- The custom resource type of the K8S custom resource being referenced
+    in the mapping\n\t-- As of this writing (Jan 2022), the only supported value for
+    this field is GitOpsDeploymentSyncRun.\n\t-- See APICRToDatabaseMapping_ResourceType_*
+    constants for latest list.\n\tapi_resource_type VARCHAR(64) NOT NULL,\n\t\n\t--
+    The UID (from .metadata.uid field) of the K8s resource\n\tapi_resource_uid VARCHAR(64)
+    NOT NULL,\n\t\n\t-- The name of the k8s resource (from .metadata.name field) of
+    the K8s resource\n\tapi_resource_name VARCHAR(256) NOT NULL,\n\n\t-- The namespace
+    containing the k8s resource\n\tapi_resource_namespace VARCHAR(256) NOT NULL,\n\t\n\t--
+    The UID (from .metadata.uid field) of the namespace containing the k8s resource\n\tapi_resource_workspace_uid
+    VARCHAR(64) NOT NULL,\n\n\t-- The name of the database table being referenced.
+    \n\t-- As of this writing (Jan 2022), the only supported value for this field
+    is SyncOperation.\n\t-- See APICRToDatabaseMapping_DBRelationType_ constants for
+    latest list.\n\tdb_relation_type VARCHAR(32) NOT NULL,\n\n\t-- The primary key
+    of the row in the database table being referenced.\n\tdb_relation_key VARCHAR(64)
+    NOT NULL,\n\n\tseq_id serial,\n\n\tPRIMARY KEY(api_resource_type, api_resource_uid,
+    db_relation_type, db_relation_key)\n\n);\n-- TODO: GITOPS-1702 - PERF - Add index
+    to APICRToDatabaseMapping to correspond to the access patterns we are using.\n\n--
+    Sync Operation tracks a sync request from the API, \nCREATE TABLE SyncOperation
+    (\n\n\t-- Primary key for the SyncOperation (UID), is a random UUID\n\tsyncoperation_id
+    \ VARCHAR(48) NOT NULL PRIMARY KEY,\n\n\t-- The target Application that is being
+    synchronized\n\t-- Foreign key to: Application.application_id\n\tapplication_id
+    VARCHAR(48),\n\tCONSTRAINT fk_so_app_id FOREIGN KEY (application_id) REFERENCES
+    Application(application_id) ON DELETE NO ACTION ON UPDATE NO ACTION,\n\n\t-- The
+    Operation which contains the state of the sync operation\n\t-- Foreign key to:
+    Operation.operation_id\n\toperation_id VARCHAR(48) NOT NULL,\n\t-- CONSTRAINT
+    fk_so_operation_id FOREIGN KEY (operation_id) REFERENCES Operation(operation_id)
+    ON DELETE NO ACTION ON UPDATE NO ACTION\n\n\t-- The 'gitopsDeploymentName' field
+    of the GitOpsDeploymentSyncRun CR\n\tdeployment_name VARCHAR(256) NOT NULL,\n\n\t--
+    The 'revisionID'  field of the GitOpsDeploymentSyncRun CR\n\trevision VARCHAR(256)
+    NOT NULL,\n\n\t-- Whether we want the SyncOperation to continue running, or to
+    be terminated.\n\t-- values: Running, Terminated\n\tdesired_state VARCHAR(16)
+    NOT NULL,\t\n\n\tseq_id serial\n\n);\n\n/*\n-------------------------------------------------------------------------------\n\nSchema
+    Design Guidelines:\n\n- All primary keys (PKs) should include the name of the
+    table, in the field name.\n    - Example:\n\t    - initial field name: infcluster_id\n\t\t-
+    table: GitopsEngineCluster\n\t\t- field name is thus: gitopsenginecluster_infcluster_id
+    \ \n\t\t    - (eg [table]_[initial file name])\n\t- Why? This makes it easy to
+    track usage of the PK, and refactor at a later date. \n    - Foreign keys (FKs)
+    to PKs do NOT need to include the table name\n\n- No other tables should use a
+    field with the same name as the PK of another table.\n\t- Why? This makes it easy
+    to track usage of the PK, and refactor at a later date. \n\n- Use UUIDs for table
+    PK, rather than seqids:\n\t- Why? Unlike seqids:\n\t    - UUIDS do not leak information
+    on # of users\n\t\t- UUIDs are not vulnerable to increment by one attacks\n\t\t-
+    Allows the contents of two RDBMS databases to be easily merged (no need to fix
+    all the seqids)\n\t\t- Give flexibility over underlying database store (Other
+    RDBMS-es, other DB technologies)\n\t\t- Prevents accidental erasure of table rows
+    (collisions between uuids is much less likely than between integers)\n\n- Name
+    case:\n    - For tables: CamelCase\n    - For fields: lowercase_snake_case\n\n-------------------------------------------------------------------------------\n\n\nForeign
+    key relationships between tables, as of this writing:\n(Tables entries must be
+    deleted in this order, from top to bottom, and created in reverse order)\n\nMiro
+    Diagram: https://miro.com/app/board/o9J_lgiqJAs=/?moveToWidget=3458764513858646837&cot=14\n\nApplicationState
+    ->  Application\n\nDeploymentToApplicationMapping -> Application\n\nOperation
+    -> ClusterUser\nOperation -> GitopsEngineInstance\n\nApplication -> ManagedEnviroment\nApplication
+    ->  GitopsEngineInstance\n\nClusterAccess -> ClusterUser\nClusterAccess -> ManagedEnvironment\nClusterAccess
+    -> GitopsEngineInstance\n\nGitopsEngineInstance -> GitopsEngineCluster\n\nGitopsEngineCluster
+    -> ClusterCredentials\nManagedEnvironment -> ClusterCredentials\n\n\nClusterCredentials
+    -> .\n\nClusterUser -> .\n\nKubernetesToDBResourceMapping -> .\n\n\n-------------------------------------------------------------------------------\n\nExtra
+    thoughts:\n\nNotes:\n\nseq_id is for debugging purposes only, and should not be
+    used as a key\n\n\n-------------------------------------------------------------------------------\n*/\n"
+kind: ConfigMap
+metadata:
+  name: gitops-service-dbschema
+  namespace: gitops

--- a/components/gitops/staging/job.yaml
+++ b/components/gitops/staging/job.yaml
@@ -1,13 +1,15 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
+  # generateName: apply-gitops-service-db-schema-
   name: apply-gitops-service-db-schema
   namespace: gitops
   annotations:
-    argocd.argoproj.io/hook: Sync
-    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+    argocd.argoproj.io/hook: PreSync
+    argocd.argoproj.io/hook-delete-policy: HookSucceeded
 spec:
-  ttlSecondsAfterFinished: 600
+  ttlSecondsAfterFinished: 3600
+
   template:
     spec:
       volumes:

--- a/components/gitops/staging/job.yaml
+++ b/components/gitops/staging/job.yaml
@@ -1,0 +1,47 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: apply-gitops-service-db-schema
+  namespace: gitops
+  annotations:
+    argocd.argoproj.io/hook: Sync
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+spec:
+  ttlSecondsAfterFinished: 600
+  template:
+    spec:
+      volumes:
+        - name: dbschema-volume
+          configMap:
+            name: gitops-service-dbschema
+      containers:
+      - name: psql
+        image: docker.io/bitnami/postgresql:11.14.0-debian-10-r2
+        command: ["/bin/bash","-c","PGPASSWORD=$POSTGRES_PASSWORD psql $POSTGRES_DB -U $POSTGRES_USER -q -f /etc/db-schema/db-schema.sql"]
+        volumeMounts:
+          - name: dbschema-volume
+            mountPath: "/etc/db-schema"
+            readOnly: true
+
+        env:
+          - name: POSTGRES_DB
+            value: postgresql://gitops-postgresql-staging:5432/postgres
+          - name: POSTGRESQL_PORT_NUMBER
+            value: "5432"
+          - name: POSTGRESQL_VOLUME_DIR
+            value: /bitnami/postgresql
+          - name: PGDATA
+            value: /bitnami/postgresql/data
+          - name: POSTGRES_USER
+            value: postgres
+          - name: POSTGRES_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                key: postgresql-password
+                name: gitops-postgresql-staging
+        
+#        envFrom:
+#          - configMapRef:
+#            name: postgres-config
+      restartPolicy: Never
+

--- a/components/gitops/staging/kustomization.yaml
+++ b/components/gitops/staging/kustomization.yaml
@@ -1,0 +1,38 @@
+
+resources:
+- allow-argocd-to-manage.yaml
+- argo-cd-namespace.yaml
+- argo-cd.yaml
+- dbschema-config-map.yaml
+- job.yaml
+- managed-gitops-backend-controller-manager-metrics-service.yaml
+- managed-gitops-backend-controller-manager_serviceaccount.yaml
+- managed-gitops-backend-deployment.yaml
+- managed-gitops-backend-leader-election-rolebinding.yaml
+- managed-gitops-backend-leader-election-role.yaml
+- managed-gitops-backend-manager-config.yaml
+- managed-gitops-backend-manager-rolebinding.yaml
+- managed-gitops-backend-manager-role.yaml
+- managed-gitops-backend-metrics-leader.yaml
+- managed-gitops-backend-proxy-rolebinding.yaml
+- managed-gitops-backend-proxy-role.yaml
+- managed-gitops-clusteragent-controller-manager-metrics-service.yaml
+- managed-gitops-clusteragent-controller-manager_serviceaccount.yaml
+- managed-gitops-clusteragent-deployment.yaml
+- managed-gitops-clusteragent-leader-election-rolebinding.yaml
+- managed-gitops-clusteragent-leader-election-role.yaml
+- managed-gitops-clusteragent-manager-config.yaml
+- managed-gitops-clusteragent-manager-rolebinding.yaml
+- managed-gitops-clusteragent-manager-role.yaml
+- managed-gitops-clusteragent-metrics-leader.yaml
+- managed-gitops-clusteragent-proxy-rolebinding.yaml
+- managed-gitops-clusteragent-proxy-role.yaml
+- managed-gitops.redhat.com_gitopsdeployments.yaml
+- managed-gitops.redhat.com_gitopsdeploymentsyncruns.yaml
+- managed-gitops.redhat.com_operations.yaml
+- postgresql-staging.yaml
+- routes.yaml
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+

--- a/components/gitops/staging/managed-gitops-backend-controller-manager-metrics-service.yaml
+++ b/components/gitops/staging/managed-gitops-backend-controller-manager-metrics-service.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    control-plane: controller-manager
+  name: managed-gitops-backend-controller-manager-metrics-service
+  namespace: gitops
+spec:
+  ports:
+  - name: https
+    port: 8443
+    protocol: TCP
+    targetPort: https
+  selector:
+    control-plane: controller-manager
+

--- a/components/gitops/staging/managed-gitops-backend-controller-manager_serviceaccount.yaml
+++ b/components/gitops/staging/managed-gitops-backend-controller-manager_serviceaccount.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: managed-gitops-backend-controller-manager
+  namespace: gitops
+

--- a/components/gitops/staging/managed-gitops-backend-deployment.yaml
+++ b/components/gitops/staging/managed-gitops-backend-deployment.yaml
@@ -44,7 +44,7 @@ spec:
               secretKeyRef:
                 name: gitops-postgresql-staging
                 key: postgresql-password
-        image: quay.io/jgwest-redhat/gitops-service:latest
+        image: quay.io/redhat-appstudio/gitops-service:239fd296f557024f0382c06d1a736183849808a1
         livenessProbe:
           httpGet:
             path: /healthz

--- a/components/gitops/staging/managed-gitops-backend-deployment.yaml
+++ b/components/gitops/staging/managed-gitops-backend-deployment.yaml
@@ -1,0 +1,73 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    control-plane: controller-manager
+  name: managed-gitops-backend-service
+  namespace: gitops
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      control-plane: controller-manager
+  template:
+    metadata:
+      labels:
+        control-plane: controller-manager
+    spec:
+      containers:
+      - args:
+        - --secure-listen-address=0.0.0.0:8443
+        - --upstream=http://127.0.0.1:8080/
+        - --logtostderr=true
+        - --v=10
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
+        name: kube-rbac-proxy
+        ports:
+        - containerPort: 8443
+          name: https
+          protocol: TCP
+      - args:
+        - --health-probe-bind-address=:8081
+        - --metrics-bind-address=127.0.0.1:8080
+        - --leader-elect
+        command:
+        - gitops-service-backend
+        env:
+          - name: ARGO_CD_NAMESPACE
+            value: gitops-service-argocd
+          - name: DB_ADDR
+            value: gitops-postgresql-staging.gitops
+          - name: DB_PASS
+            valueFrom:
+              secretKeyRef:
+                name: gitops-postgresql-staging
+                key: postgresql-password
+        image: quay.io/jgwest-redhat/gitops-service:latest
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        name: manager
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8081
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        resources:
+          limits:
+            cpu: 200m
+            memory: 100Mi
+          requests:
+            cpu: 100m
+            memory: 20Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+      securityContext:
+        runAsNonRoot: true
+      serviceAccountName: managed-gitops-backend-controller-manager
+      terminationGracePeriodSeconds: 10

--- a/components/gitops/staging/managed-gitops-backend-leader-election-role.yaml
+++ b/components/gitops/staging/managed-gitops-backend-leader-election-role.yaml
@@ -1,0 +1,39 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: managed-gitops-backend-leader-election-role
+  namespace: gitops
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+

--- a/components/gitops/staging/managed-gitops-backend-leader-election-rolebinding.yaml
+++ b/components/gitops/staging/managed-gitops-backend-leader-election-rolebinding.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: managed-gitops-backend-leader-election-rolebinding
+  namespace: gitops
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: managed-gitops-backend-leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: managed-gitops-backend-controller-manager
+  namespace: gitops
+

--- a/components/gitops/staging/managed-gitops-backend-manager-config.yaml
+++ b/components/gitops/staging/managed-gitops-backend-manager-config.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: v1
+data:
+  controller_manager_config.yaml: |
+    apiVersion: controller-runtime.sigs.k8s.io/v1alpha1
+    kind: ControllerManagerConfig
+    health:
+      healthProbeBindAddress: :8081
+    metrics:
+      bindAddress: 127.0.0.1:8080
+    webhook:
+      port: 9443
+    leaderElection:
+      leaderElect: true
+      resourceName: 5a3f596c.redhat.com
+kind: ConfigMap
+metadata:
+  name: managed-gitops-backend-manager-config
+  namespace: gitops
+

--- a/components/gitops/staging/managed-gitops-backend-manager-role.yaml
+++ b/components/gitops/staging/managed-gitops-backend-manager-role.yaml
@@ -1,0 +1,93 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: managed-gitops-backend-manager-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+    - namespaces
+  verbs:
+    - get
+    - watch
+    - list
+- apiGroups:
+  - ""
+  resources:
+    - pods
+    - services
+    - endpoints
+    - persistentvolumeclaims
+    - events
+    - configmaps
+    - secrets
+  verbs:
+    - '*'
+- apiGroups:
+  - argoproj.io
+  resources:
+  - applications
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - managed-gitops.redhat.com
+  resources:
+  - gitopsdeployments
+  - operations
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - managed-gitops.redhat.com
+  resources:
+  - gitopsdeployments/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - managed-gitops.redhat.com
+  resources:
+  - gitopsdeployments/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - managed-gitops.redhat.com
+  resources:
+  - gitopsdeploymentsyncruns
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - managed-gitops.redhat.com
+  resources:
+  - gitopsdeploymentsyncruns/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - managed-gitops.redhat.com
+  resources:
+  - gitopsdeploymentsyncruns/status
+  verbs:
+  - get
+  - patch
+  - update
+

--- a/components/gitops/staging/managed-gitops-backend-manager-rolebinding.yaml
+++ b/components/gitops/staging/managed-gitops-backend-manager-rolebinding.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: managed-gitops-backend-manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: managed-gitops-backend-manager-role
+subjects:
+- kind: ServiceAccount
+  name: managed-gitops-backend-controller-manager
+  namespace: gitops
+

--- a/components/gitops/staging/managed-gitops-backend-metrics-leader.yaml
+++ b/components/gitops/staging/managed-gitops-backend-metrics-leader.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: managed-gitops-backend-metrics-reader
+rules:
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get
+

--- a/components/gitops/staging/managed-gitops-backend-proxy-role.yaml
+++ b/components/gitops/staging/managed-gitops-backend-proxy-role.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: managed-gitops-backend-proxy-role
+rules:
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+

--- a/components/gitops/staging/managed-gitops-backend-proxy-rolebinding.yaml
+++ b/components/gitops/staging/managed-gitops-backend-proxy-rolebinding.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: managed-gitops-backend-proxy-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: managed-gitops-backend-proxy-role
+subjects:
+- kind: ServiceAccount
+  name: managed-gitops-backend-controller-manager
+  namespace: gitops
+

--- a/components/gitops/staging/managed-gitops-clusteragent-controller-manager-metrics-service.yaml
+++ b/components/gitops/staging/managed-gitops-clusteragent-controller-manager-metrics-service.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    control-plane: controller-manager
+  name: managed-gitops-clusteragent-controller-manager-metrics-service
+  namespace: gitops
+spec:
+  ports:
+  - name: https
+    port: 8443
+    protocol: TCP
+    targetPort: https
+  selector:
+    control-plane: controller-manager

--- a/components/gitops/staging/managed-gitops-clusteragent-controller-manager_serviceaccount.yaml
+++ b/components/gitops/staging/managed-gitops-clusteragent-controller-manager_serviceaccount.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: managed-gitops-clusteragent-controller-manager
+  namespace: gitops
+  

--- a/components/gitops/staging/managed-gitops-clusteragent-deployment.yaml
+++ b/components/gitops/staging/managed-gitops-clusteragent-deployment.yaml
@@ -44,7 +44,7 @@ spec:
               secretKeyRef:
                 name: gitops-postgresql-staging
                 key: postgresql-password
-        image: quay.io/jgwest-redhat/gitops-service:latest
+        image: quay.io/redhat-appstudio/gitops-service:239fd296f557024f0382c06d1a736183849808a1
         livenessProbe:
           httpGet:
             path: /healthz

--- a/components/gitops/staging/managed-gitops-clusteragent-deployment.yaml
+++ b/components/gitops/staging/managed-gitops-clusteragent-deployment.yaml
@@ -1,0 +1,73 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    control-plane: controller-manager
+  name: managed-gitops-clusteragent-service
+  namespace: gitops
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      control-plane: controller-manager
+  template:
+    metadata:
+      labels:
+        control-plane: controller-manager
+    spec:
+      containers:
+      - args:
+        - --secure-listen-address=0.0.0.0:8443
+        - --upstream=http://127.0.0.1:8080/
+        - --logtostderr=true
+        - --v=10
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
+        name: kube-rbac-proxy
+        ports:
+        - containerPort: 8443
+          name: https
+          protocol: TCP
+      - args:
+        - --health-probe-bind-address=:8081
+        - --metrics-bind-address=127.0.0.1:8080
+        - --leader-elect
+        command:
+        - gitops-service-cluster-agent
+        env:
+          - name: ARGO_CD_NAMESPACE
+            value: gitops-service-argocd
+          - name: DB_ADDR
+            value: gitops-postgresql-staging.gitops
+          - name: DB_PASS
+            valueFrom:
+              secretKeyRef:
+                name: gitops-postgresql-staging
+                key: postgresql-password
+        image: quay.io/jgwest-redhat/gitops-service:latest
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        name: manager
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8081
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        resources:
+          limits:
+            cpu: 200m
+            memory: 100Mi
+          requests:
+            cpu: 100m
+            memory: 20Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+      securityContext:
+        runAsNonRoot: true
+      serviceAccountName: managed-gitops-clusteragent-controller-manager
+      terminationGracePeriodSeconds: 10

--- a/components/gitops/staging/managed-gitops-clusteragent-leader-election-role.yaml
+++ b/components/gitops/staging/managed-gitops-clusteragent-leader-election-role.yaml
@@ -1,0 +1,38 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: managed-gitops-clusteragent-leader-election-role
+  namespace: gitops
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch

--- a/components/gitops/staging/managed-gitops-clusteragent-leader-election-rolebinding.yaml
+++ b/components/gitops/staging/managed-gitops-clusteragent-leader-election-rolebinding.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: managed-gitops-clusteragent-leader-election-rolebinding
+  namespace: gitops
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: managed-gitops-clusteragent-leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: managed-gitops-clusteragent-controller-manager
+  namespace: gitops

--- a/components/gitops/staging/managed-gitops-clusteragent-manager-config.yaml
+++ b/components/gitops/staging/managed-gitops-clusteragent-manager-config.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: v1
+data:
+  controller_manager_config.yaml: |
+    apiVersion: controller-runtime.sigs.k8s.io/v1alpha1
+    kind: ControllerManagerConfig
+    health:
+      healthProbeBindAddress: :8081
+    metrics:
+      bindAddress: 127.0.0.1:8080
+    webhook:
+      port: 9443
+    leaderElection:
+      leaderElect: true
+      resourceName: 5a3f596c.redhat.com
+kind: ConfigMap
+metadata:
+  name: managed-gitops-clusteragent-manager-config
+  namespace: gitops

--- a/components/gitops/staging/managed-gitops-clusteragent-manager-role.yaml
+++ b/components/gitops/staging/managed-gitops-clusteragent-manager-role.yaml
@@ -1,0 +1,92 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: managed-gitops-clusteragent-manager-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+    - namespaces
+  verbs:
+    - get
+    - watch
+    - list
+- apiGroups:
+  - ""
+  resources:
+    - pods
+    - services
+    - endpoints
+    - persistentvolumeclaims
+    - events
+    - configmaps
+    - secrets
+  verbs:
+    - '*'
+- apiGroups:
+  - argoproj.io
+  resources:
+  - applications
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - managed-gitops.redhat.com
+  resources:
+  - gitopsdeployments
+  - operations
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - managed-gitops.redhat.com
+  resources:
+  - gitopsdeployments/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - managed-gitops.redhat.com
+  resources:
+  - gitopsdeployments/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - managed-gitops.redhat.com
+  resources:
+  - gitopsdeploymentsyncruns
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - managed-gitops.redhat.com
+  resources:
+  - gitopsdeploymentsyncruns/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - managed-gitops.redhat.com
+  resources:
+  - gitopsdeploymentsyncruns/status
+  verbs:
+  - get
+  - patch
+  - update

--- a/components/gitops/staging/managed-gitops-clusteragent-manager-rolebinding.yaml
+++ b/components/gitops/staging/managed-gitops-clusteragent-manager-rolebinding.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: managed-gitops-clusteragent-manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: managed-gitops-clusteragent-manager-role
+subjects:
+- kind: ServiceAccount
+  name: managed-gitops-clusteragent-controller-manager
+  namespace: gitops

--- a/components/gitops/staging/managed-gitops-clusteragent-metrics-leader.yaml
+++ b/components/gitops/staging/managed-gitops-clusteragent-metrics-leader.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: managed-gitops-clusteragent-metrics-reader
+rules:
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get

--- a/components/gitops/staging/managed-gitops-clusteragent-proxy-role.yaml
+++ b/components/gitops/staging/managed-gitops-clusteragent-proxy-role.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: managed-gitops-clusteragent-proxy-role
+rules:
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create

--- a/components/gitops/staging/managed-gitops-clusteragent-proxy-rolebinding.yaml
+++ b/components/gitops/staging/managed-gitops-clusteragent-proxy-rolebinding.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: managed-gitops-clusteragent-proxy-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: managed-gitops-clusteragent-proxy-role
+subjects:
+- kind: ServiceAccount
+  name: managed-gitops-clusteragent-controller-manager
+  namespace: gitops

--- a/components/gitops/staging/managed-gitops.redhat.com_gitopsdeployments.yaml
+++ b/components/gitops/staging/managed-gitops.redhat.com_gitopsdeployments.yaml
@@ -1,0 +1,158 @@
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.6.1
+  creationTimestamp: null
+  name: gitopsdeployments.managed-gitops.redhat.com
+spec:
+  group: managed-gitops.redhat.com
+  names:
+    kind: GitOpsDeployment
+    listKind: GitOpsDeploymentList
+    plural: gitopsdeployments
+    singular: gitopsdeployment
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: GitOpsDeployment is the Schema for the gitopsdeployments API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: GitOpsDeploymentSpec defines the desired state of GitOpsDeployment
+            properties:
+              destination:
+                description: 'Destination is a reference to a target namespace/cluster
+                  to deploy to. This field may be empty: if it is empty, it is assumed
+                  that the destination is the same namespace as the GitOpsDeployment
+                  CR.'
+                properties:
+                  namespace:
+                    description: The namespace will only be set for namespace-scoped
+                      resources that have not set a value for .metadata.namespace
+                    type: string
+                type: object
+              source:
+                description: ApplicationSource contains all required information about
+                  the source of an application
+                properties:
+                  path:
+                    description: Path is a directory path within the Git repository,
+                      and is only valid for applications sourced from Git.
+                    type: string
+                  repoURL:
+                    description: RepoURL is the URL to the repository (Git or Helm)
+                      that contains the application manifests
+                    type: string
+                  targetRevision:
+                    description: TargetRevision defines the revision of the source
+                      to sync the application to. In case of Git, this can be commit,
+                      tag, or branch. If omitted, will equal to HEAD. In case of Helm,
+                      this is a semver tag for the Chart's version.
+                    type: string
+                required:
+                - repoURL
+                type: object
+              type:
+                description: "Two possible values: - Automated: whenever a new commit
+                  occurs in the GitOps repository, or the Argo CD Application is out
+                  of sync, Argo CD should be told to (re)synchronize. - Manual: Argo
+                  CD should never be told to resynchronize. Instead, synchronize operations
+                  will be triggered via GitOpsDeploymentSyncRun operations only. -
+                  See `GitOpsDeploymentSpecType*` \n Note: This is somewhat of a placeholder
+                  for more advanced logic that can be implemented in the future. For
+                  an example of this type of logic, see the 'syncPolicy' field of
+                  Argo CD Application."
+                type: string
+            required:
+            - source
+            - type
+            type: object
+          status:
+            description: GitOpsDeploymentStatus defines the observed state of GitOpsDeployment
+            properties:
+              conditions:
+                items:
+                  description: GitOpsDeploymentCondition contains details about an
+                    applicationset condition, which is usally an error or warning
+                  properties:
+                    lastTransitionTime:
+                      description: LastTransitionTime is the time the condition was
+                        last observed
+                      format: date-time
+                      type: string
+                    message:
+                      description: Message contains human-readable message indicating
+                        details about condition
+                      type: string
+                    reason:
+                      description: Single word camelcase representing the reason for
+                        the status eg ErrorOccurred
+                      type: string
+                    status:
+                      description: True/False/Unknown
+                      type: string
+                    type:
+                      description: Type is an applicationset condition type
+                      type: string
+                  required:
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              health:
+                description: Health contains information about the application's current
+                  health status
+                properties:
+                  message:
+                    description: Message is a human-readable informational message
+                      describing the health status
+                    type: string
+                  status:
+                    description: Status holds the status code of the application or
+                      resource
+                    type: string
+                type: object
+              sync:
+                description: SyncStatus contains information about the currently observed
+                  live and desired states of an application
+                properties:
+                  revision:
+                    description: Revision contains information about the revision
+                      the comparison has been performed to
+                    type: string
+                  status:
+                    description: Status is the sync state of the comparison
+                    type: string
+                required:
+                - status
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/components/gitops/staging/managed-gitops.redhat.com_gitopsdeploymentsyncruns.yaml
+++ b/components/gitops/staging/managed-gitops.redhat.com_gitopsdeploymentsyncruns.yaml
@@ -1,0 +1,94 @@
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.6.1
+  creationTimestamp: null
+  name: gitopsdeploymentsyncruns.managed-gitops.redhat.com
+spec:
+  group: managed-gitops.redhat.com
+  names:
+    kind: GitOpsDeploymentSyncRun
+    listKind: GitOpsDeploymentSyncRunList
+    plural: gitopsdeploymentsyncruns
+    singular: gitopsdeploymentsyncrun
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: GitOpsDeploymentSyncRun is the Schema for the gitopsdeploymentsyncruns
+          API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: GitOpsDeploymentSyncRunSpec defines the desired state of
+              GitOpsDeploymentSyncRun
+            properties:
+              gitopsDeploymentName:
+                type: string
+              revisionID:
+                type: string
+            required:
+            - gitopsDeploymentName
+            type: object
+          status:
+            description: GitOpsDeploymentSyncRunStatus defines the observed state
+              of GitOpsDeploymentSyncRun
+            properties:
+              conditions:
+                items:
+                  description: GitOpsDeploymentCondition contains details about an
+                    applicationset condition, which is usally an error or warning
+                  properties:
+                    lastTransitionTime:
+                      description: LastTransitionTime is the time the condition was
+                        last observed
+                      format: date-time
+                      type: string
+                    message:
+                      description: Message contains human-readable message indicating
+                        details about condition
+                      type: string
+                    reason:
+                      description: Single word camelcase representing the reason for
+                        the status eg ErrorOccurred
+                      type: string
+                    status:
+                      description: True/False/Unknown
+                      type: string
+                    type:
+                      description: Type is an applicationset condition type
+                      type: string
+                  required:
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/components/gitops/staging/managed-gitops.redhat.com_operations.yaml
+++ b/components/gitops/staging/managed-gitops.redhat.com_operations.yaml
@@ -1,0 +1,55 @@
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.6.1
+  creationTimestamp: null
+  name: operations.managed-gitops.redhat.com
+spec:
+  group: managed-gitops.redhat.com
+  names:
+    kind: Operation
+    listKind: OperationList
+    plural: operations
+    singular: operation
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Operation is the Schema for the operations API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: OperationSpec defines the desired state of Operation
+            properties:
+              operationID:
+                type: string
+            type: object
+          status:
+            description: OperationStatus defines the observed state of Operation
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/components/gitops/staging/postgresql-staging.yaml
+++ b/components/gitops/staging/postgresql-staging.yaml
@@ -1,0 +1,194 @@
+---
+# Source: postgresql/templates/svc-headless.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: gitops-postgresql-staging-headless
+  labels:
+    app.kubernetes.io/name: postgresql
+    helm.sh/chart: postgresql-10.16.1
+    app.kubernetes.io/instance: gitops-postgresql-staging
+    app.kubernetes.io/managed-by: Helm
+    # Use this annotation in addition to the actual publishNotReadyAddresses
+    # field below because the annotation will stop being respected soon but the
+    # field is broken in some versions of Kubernetes:
+    # https://github.com/kubernetes/kubernetes/issues/58662
+    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
+  namespace: gitops
+spec:
+  type: ClusterIP
+  clusterIP: None
+  # We want all pods in the StatefulSet to have their addresses published for
+  # the sake of the other Postgresql pods even before they're ready, since they
+  # have to be able to talk to each other in order to become ready.
+  publishNotReadyAddresses: true
+  ports:
+    - name: tcp-postgresql
+      port: 5432
+      targetPort: tcp-postgresql
+  selector:
+    app.kubernetes.io/name: postgresql
+    app.kubernetes.io/instance: gitops-postgresql-staging
+---
+# Source: postgresql/templates/svc.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: gitops-postgresql-staging
+  labels:
+    app.kubernetes.io/name: postgresql
+    helm.sh/chart: postgresql-10.16.1
+    app.kubernetes.io/instance: gitops-postgresql-staging
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+  namespace: gitops
+spec:
+  type: ClusterIP
+  ports:
+    - name: tcp-postgresql
+      port: 5432
+      targetPort: tcp-postgresql
+  selector:
+    app.kubernetes.io/name: postgresql
+    app.kubernetes.io/instance: gitops-postgresql-staging
+    role: primary
+---
+# Source: postgresql/templates/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: gitops-postgresql-staging-postgresql
+  labels:
+    app.kubernetes.io/name: postgresql
+    helm.sh/chart: postgresql-10.16.1
+    app.kubernetes.io/instance: gitops-postgresql-staging
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: primary
+  annotations:
+  namespace: gitops
+spec:
+  serviceName: gitops-postgresql-staging-headless
+  replicas: 1
+  updateStrategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: postgresql
+      app.kubernetes.io/instance: gitops-postgresql-staging
+      role: primary
+  template:
+    metadata:
+      name: gitops-postgresql-staging
+      labels:
+        app.kubernetes.io/name: postgresql
+        helm.sh/chart: postgresql-10.16.1
+        app.kubernetes.io/instance: gitops-postgresql-staging
+        app.kubernetes.io/managed-by: Helm
+        role: primary
+        app.kubernetes.io/component: primary
+    spec:      
+      affinity:
+        podAffinity:
+          
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/name: postgresql
+                    app.kubernetes.io/instance: gitops-postgresql-staging
+                    app.kubernetes.io/component: primary
+                namespaces:
+                  - "gitops"
+                topologyKey: kubernetes.io/hostname
+              weight: 1
+        nodeAffinity:
+          
+      automountServiceAccountToken: false
+      containers:
+        - name: gitops-postgresql-staging
+          image: docker.io/bitnami/postgresql:11.14.0-debian-10-r28
+          imagePullPolicy: "IfNotPresent"
+          resources:
+            requests:
+              cpu: 250m
+              memory: 256Mi
+          env:
+            - name: BITNAMI_DEBUG
+              value: "false"
+            - name: POSTGRESQL_PORT_NUMBER
+              value: "5432"
+            - name: POSTGRESQL_VOLUME_DIR
+              value: "/bitnami/postgresql"
+            - name: PGDATA
+              value: "/bitnami/postgresql/data"
+            - name: POSTGRES_USER
+              value: "postgres"
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: gitops-postgresql-staging
+                  key: postgresql-password
+            - name: POSTGRESQL_ENABLE_LDAP
+              value: "no"
+            - name: POSTGRESQL_ENABLE_TLS
+              value: "no"
+            - name: POSTGRESQL_LOG_HOSTNAME
+              value: "false"
+            - name: POSTGRESQL_LOG_CONNECTIONS
+              value: "false"
+            - name: POSTGRESQL_LOG_DISCONNECTIONS
+              value: "false"
+            - name: POSTGRESQL_PGAUDIT_LOG_CATALOG
+              value: "off"
+            - name: POSTGRESQL_CLIENT_MIN_MESSAGES
+              value: "error"
+            - name: POSTGRESQL_SHARED_PRELOAD_LIBRARIES
+              value: "pgaudit"
+          ports:
+            - name: tcp-postgresql
+              containerPort: 5432
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - exec pg_isready -U "postgres" -h 127.0.0.1 -p 5432
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+            successThreshold: 1
+            failureThreshold: 6
+          readinessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - -e
+                - |
+                  exec pg_isready -U "postgres" -h 127.0.0.1 -p 5432
+                  [ -f /opt/bitnami/postgresql/tmp/.initialized ] || [ -f /bitnami/postgresql/.initialized ]
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+            successThreshold: 1
+            failureThreshold: 6
+          volumeMounts:
+            - name: dshm
+              mountPath: /dev/shm
+            - name: data
+              mountPath: /bitnami/postgresql
+              subPath: 
+      volumes:
+        - name: dshm
+          emptyDir:
+            medium: Memory
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes:
+          - "ReadWriteOnce"
+        resources:
+          requests:
+            storage: "8Gi"

--- a/components/gitops/staging/routes.yaml
+++ b/components/gitops/staging/routes.yaml
@@ -1,0 +1,17 @@
+kind: Route
+apiVersion: route.openshift.io/v1
+metadata:
+  name: managed-gitops
+  namespace: gitops
+spec:
+  subdomain: managed-gitops
+  to:
+    kind: Service
+    name: managed-gitops
+    weight: 100
+  port:
+    targetPort: 8090
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect
+  wildcardPolicy: None


### PR DESCRIPTION
This PR:
- Onboards the GitOps Service onto the staging cluster, by adding the K8s resources of the GitOps Service to this repo
- This PR also introduces a new Argo CD instance under the `gitops-service-argocd` namespace, to be used by the GitOps Service for user workload deployment.
- The resources contained within this repository are a downstream version of the [upstream resources](https://github.com/redhat-appstudio/managed-gitops/tree/main/manifests).
- GitOps Service container image being deployed was built by AppStudio Staging Pipeline (eg dogfooding our AppStudio staging build process)