### PR TITLE
GitOps Service: remove Argo resource hooks on DB init job

### DIFF
--- a/components/gitops/staging/job.yaml
+++ b/components/gitops/staging/job.yaml
@@ -4,9 +4,9 @@ metadata:
   # generateName: apply-gitops-service-db-schema-
   name: apply-gitops-service-db-schema
   namespace: gitops
-  annotations:
-    argocd.argoproj.io/hook: PreSync
-    argocd.argoproj.io/hook-delete-policy: HookSucceeded
+#  annotations:
+#    argocd.argoproj.io/hook: PreSync
+#    argocd.argoproj.io/hook-delete-policy: HookSucceeded
 spec:
   ttlSecondsAfterFinished: 3600
 


### PR DESCRIPTION
This PR:
- Remove Argo CD resource hooks on the init job, which were preventing the sync from completing.