### PR TITLE
Remove kustomize command dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Simply update the files under `components/(team-name)`, and open a PR with the c
 
 ### Required prerequisites
 The prerequisites are:
-- You must have `kubectl`, `oc`, `jq`, `yq` and `kustomize` installed. 
+- You must have `kubectl`, `oc`, `jq and `yq` installed.
 - You must have `kubectl` and `oc` pointing to an existing OpenShift cluster, that you wish to deploy to.
 
 ### Optional: CodeReady Containers Setup

--- a/hack/destroy-cluster.sh
+++ b/hack/destroy-cluster.sh
@@ -8,11 +8,11 @@ TOOLCHAIN_E2E_TEMP_DIR=/tmp/toolchain-e2e
 echo
 echo "Remove Argo CD Applications:"
 kubectl delete -f $ROOT/argo-cd-apps/app-of-apps/all-applications-staging.yaml
-#kustomize build  $ROOT/argo-cd-apps/overlays/staging | kubectl delete -f -
+#kubectl -k $ROOT/argo-cd-apps/overlays/staging
 
 echo
 echo "Remove RBAC for OpenShift GitOps:"
-kustomize build $ROOT/openshift-gitops/cluster-rbac | kubectl delete -f -
+kubectl delete -k $ROOT/openshift-gitops/cluster-rbac
 
 echo 
 echo "Remove the OpenShift GitOps operator subscription:"


### PR DESCRIPTION
Kustomize command is integrated to kubectl/oc, it's not used as
standalone command anymore.