### PR TITLE
GitOps Service: Adopt latest GitOps Service commits

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,7 +299,49 @@ If you want to check all your repos to see which ones may build you can use this
 ./hack/build/utils/ls-all-my-repos.sh | xargs -n 1 ./hack/build/utils/check-repo.sh
 ```
 
-## FAQ
+# Invoking the API
+
+## GitOps Service
+
+Once the cluster is successfully bootstrapped, create a Namespace with the `argocd.argoproj.io/managed-by: gitops-service-argocd` label, for example:
+
+```yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: (your-user-name)
+  labels:
+    argocd.argoproj.io/managed-by: gitops-service-argocd
+```
+
+The `argocd.argoproj.io/managed-by: gitops-service-argocd` label gives 'permission' to Argo CD (specifically, the instance in `gitops-service-argocd`) to deploy to your namespace.
+
+You may now create `GitOpsDeployment` resources, which the GitOps Service will respond to, deploying resources to your namespace:
+```yaml
+apiVersion: managed-gitops.redhat.com/v1alpha1
+kind: GitOpsDeployment
+
+metadata:
+  name: gitops-depl
+  namespace: (your-user-name)
+
+spec:
+
+  # Application/component to deploy
+  source:
+    repoURL: https://github.com/redhat-appstudio/gitops-repository-template
+    path: environments/overlays/dev
+
+  # destination: {}  # destination is user namespace if empty
+
+  # Only 'automated' type is currently supported: changes to the GitOps repo immediately take effect (as soon as Argo CD detects them).
+  type: automated
+```
+
+
+See the [GitOps Service M2 Demo script for more details](https://github.com/redhat-appstudio/managed-gitops/tree/main/examples/m2-demo#run-the-demo).
+
+# FAQ
 
 Other questions? Ask on `#wg-developer-appstudio`.
 

--- a/components/gitops/staging/appstudio-controller-rbac.yaml
+++ b/components/gitops/staging/appstudio-controller-rbac.yaml
@@ -1,0 +1,205 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: appstudio-controller-controller-manager
+  namespace: gitops
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: appstudio-controller-leader-election-role
+  namespace: gitops
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: appstudio-controller-manager-role
+rules:
+- apiGroups:
+  - appstudio.redhat.com
+  resources:
+  - applications
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - appstudio.redhat.com
+  resources:
+  - applications/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - appstudio.redhat.com
+  resources:
+  - applications/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - managed-gitops.redhat.com
+  resources:
+  - gitopsdeployments
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - managed-gitops.redhat.com
+  resources:
+  - gitopsdeployments/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - managed-gitops.redhat.com
+  resources:
+  - gitopsdeployments/status
+  verbs:
+  - get
+  - patch
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: appstudio-controller-metrics-reader
+rules:
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: appstudio-controller-proxy-role
+rules:
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: appstudio-controller-leader-election-rolebinding
+  namespace: gitops
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: appstudio-controller-leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: appstudio-controller-controller-manager
+  namespace: gitops
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: appstudio-controller-manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: appstudio-controller-manager-role
+subjects:
+- kind: ServiceAccount
+  name: appstudio-controller-controller-manager
+  namespace: gitops
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: appstudio-controller-proxy-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: appstudio-controller-proxy-role
+subjects:
+- kind: ServiceAccount
+  name: appstudio-controller-controller-manager
+  namespace: gitops
+---
+apiVersion: v1
+data:
+  controller_manager_config.yaml: |
+    apiVersion: controller-runtime.sigs.k8s.io/v1alpha1
+    kind: ControllerManagerConfig
+    health:
+      healthProbeBindAddress: :8081
+    metrics:
+      bindAddress: 127.0.0.1:8080
+    webhook:
+      port: 9443
+    leaderElection:
+      leaderElect: true
+      resourceName: 53746cb8.redhat.com
+kind: ConfigMap
+metadata:
+  name: appstudio-controller-manager-config
+  namespace: gitops
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    control-plane: controller-manager
+  name: appstudio-controller-controller-manager-metrics-service
+  namespace: gitops
+spec:
+  ports:
+  - name: https
+    port: 8443
+    protocol: TCP
+    targetPort: https
+  selector:
+    control-plane: controller-manager

--- a/components/gitops/staging/kustomization.yaml
+++ b/components/gitops/staging/kustomization.yaml
@@ -1,10 +1,12 @@
 
 resources:
 - allow-argocd-to-manage.yaml
+- appstudio-controller-rbac.yaml
 - argo-cd-namespace.yaml
 - argo-cd.yaml
 - dbschema-config-map.yaml
 - job.yaml
+- managed-gitops-appstudio-controller-deployment.yaml
 - managed-gitops-backend-controller-manager-metrics-service.yaml
 - managed-gitops-backend-controller-manager_serviceaccount.yaml
 - managed-gitops-backend-deployment.yaml

--- a/components/gitops/staging/managed-gitops-appstudio-controller-deployment.yaml
+++ b/components/gitops/staging/managed-gitops-appstudio-controller-deployment.yaml
@@ -1,10 +1,9 @@
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
     control-plane: controller-manager
-  name: managed-gitops-backend-service
+  name: appstudio-controller-controller-manager
   namespace: gitops
 spec:
   replicas: 1
@@ -13,6 +12,8 @@ spec:
       control-plane: controller-manager
   template:
     metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: manager
       labels:
         control-plane: controller-manager
     spec:
@@ -21,29 +22,26 @@ spec:
         - --secure-listen-address=0.0.0.0:8443
         - --upstream=http://127.0.0.1:8080/
         - --logtostderr=true
-        - --v=10
+        - --v=0
         image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
         name: kube-rbac-proxy
         ports:
         - containerPort: 8443
           name: https
           protocol: TCP
+        resources:
+          limits:
+            cpu: 500m
+            memory: 128Mi
+          requests:
+            cpu: 5m
+            memory: 64Mi
       - args:
         - --health-probe-bind-address=:8081
         - --metrics-bind-address=127.0.0.1:8080
         - --leader-elect
         command:
-        - gitops-service-backend
-        env:
-          - name: ARGO_CD_NAMESPACE
-            value: gitops-service-argocd
-          - name: DB_ADDR
-            value: gitops-postgresql-staging.gitops
-          - name: DB_PASS
-            valueFrom:
-              secretKeyRef:
-                name: gitops-postgresql-staging
-                key: postgresql-password
+        - appstudio-controller
         image: quay.io/redhat-appstudio/gitops-service:39630b97a060ebe2cadd2540d4675c6343f688e4
         livenessProbe:
           httpGet:
@@ -60,14 +58,14 @@ spec:
           periodSeconds: 10
         resources:
           limits:
-            cpu: 200m
-            memory: 100Mi
+            cpu: 500m
+            memory: 128Mi
           requests:
-            cpu: 100m
-            memory: 20Mi
+            cpu: 10m
+            memory: 64Mi
         securityContext:
           allowPrivilegeEscalation: false
       securityContext:
         runAsNonRoot: true
-      serviceAccountName: managed-gitops-backend-controller-manager
+      serviceAccountName: appstudio-controller-controller-manager
       terminationGracePeriodSeconds: 10

--- a/components/gitops/staging/managed-gitops-clusteragent-deployment.yaml
+++ b/components/gitops/staging/managed-gitops-clusteragent-deployment.yaml
@@ -44,7 +44,7 @@ spec:
               secretKeyRef:
                 name: gitops-postgresql-staging
                 key: postgresql-password
-        image: quay.io/redhat-appstudio/gitops-service:239fd296f557024f0382c06d1a736183849808a1
+        image: quay.io/redhat-appstudio/gitops-service:39630b97a060ebe2cadd2540d4675c6343f688e4
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
## This PR:
- Updates the GitOps service staging cluster to pick up the following items:
    - Add support for [GITOPSRVCE-97](https://issues.redhat.com/browse/GITOPSRVCE-97) [(PR)](https://github.com/redhat-appstudio/managed-gitops/pull/73): Create GitOpsDeployments for corresponding Application CR of AppStudio
    - Add support for [GITOPSRVCE-70](https://issues.redhat.com/browse/GITOPSRVCE-70) [(PR)](https://github.com/redhat-appstudio/managed-gitops/pull/68) Add 'health' and 'sync status' fields to GitOpsDeployment CR status field
- Updates the README.md with information on how folks can invoke the GitOps Service API from the staging cluster.
