### PR TITLE
Avoid installation of multiple openshift-gitops for new clusters

### DIFF
--- a/openshift-gitops/subscription-openshift-gitops.yaml
+++ b/openshift-gitops/subscription-openshift-gitops.yaml
@@ -9,5 +9,3 @@ spec:
   name: openshift-gitops-operator
   source: redhat-operators
   sourceNamespace: openshift-marketplace
-  startingCSV: openshift-gitops-operator.v1.3.1
-


### PR DESCRIPTION
Set of startingCSV causes that the version is installed and then updated
version by version to newest.