### PR TITLE
Fix: Create missing namespace for tekton-resutls

### DIFF
--- a/components/build/tekton-results/kustomization.yaml
+++ b/components/build/tekton-results/kustomization.yaml
@@ -1,4 +1,5 @@
 resources:
+- tekton-pipelines-namespace.yaml
 - db-execution-configmap.yaml
 - https://github.com/tektoncd/results/releases/download/v0.4.0/release.yaml
 - route.yaml

--- a/components/build/tekton-results/tekton-pipelines-namespace.yaml
+++ b/components/build/tekton-results/tekton-pipelines-namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: tekton-pipelines


### PR DESCRIPTION
Quick fix of #136 