### PR TITLE
change PaC to latest version 

### DIFF
--- a/components/build/pipelines-as-code/kustomization.yaml
+++ b/components/build/pipelines-as-code/kustomization.yaml
@@ -1,6 +1,6 @@
 resources:
 - allow-argocd.yaml
-- https://raw.githubusercontent.com/openshift-pipelines/pipelines-as-code/release-0.5.2/release-0.5.2.yaml
+- https://raw.githubusercontent.com/openshift-pipelines/pipelines-as-code/release-0.5.3/release-0.5.3.yaml
 
 
 apiVersion: kustomize.config.k8s.io/v1beta1


### PR DESCRIPTION
This change in the Pipelines-as-Code version is because the latest version doesn't give an error if there is a bundle in pipelineRef.

PR for the resolver: https://github.com/openshift-pipelines/pipelines-as-code/pull/427