### PR TITLE
Allow Pending PVC caused by WaitForFirstConsumer strategy

### DIFF
--- a/components/build/.tekton/pvc.yaml
+++ b/components/build/.tekton/pvc.yaml
@@ -9,27 +9,3 @@ spec:
   resources:
     requests:
       storage: 1Gi
-
----
-# Use PVC for the first time to trigger PV assigment.
-apiVersion: batch/v1
-kind: Job
-metadata:
-  name: bind-volume
-spec:
-  selector: {}
-  template:
-    metadata:
-      name: bind-volume
-    spec:
-      containers:
-        - name: bind-volume
-          image: registry.access.redhat.com/ubi8/ubi-minimal:latest
-          volumeMounts:
-            - name: bind
-              mountPath: /test
-      restartPolicy: Never
-      volumes:
-        - name: bind
-          persistentVolumeClaim:
-              claimName: app-studio-default-workspace

--- a/components/e2e-tests/.tekton/pvc.yaml
+++ b/components/e2e-tests/.tekton/pvc.yaml
@@ -9,27 +9,3 @@ spec:
   resources:
     requests:
       storage: 1Gi
-
----
-# Use PVC for the first time to trigger PV assigment.
-apiVersion: batch/v1
-kind: Job
-metadata:
-  name: bind-volume
-spec:
-  selector: {}
-  template:
-    metadata:
-      name: bind-volume
-    spec:
-      containers:
-        - name: bind-volume
-          image: registry.access.redhat.com/ubi8/ubi-minimal:latest
-          volumeMounts:
-            - name: bind
-              mountPath: /test
-      restartPolicy: Never
-      volumes:
-        - name: bind
-          persistentVolumeClaim:
-            claimName: app-studio-default-workspace

--- a/components/gitops/.tekton/pvc.yaml
+++ b/components/gitops/.tekton/pvc.yaml
@@ -9,27 +9,3 @@ spec:
   resources:
     requests:
       storage: 1Gi
-
----
-# Use PVC for the first time to trigger PV assigment.
-apiVersion: batch/v1
-kind: Job
-metadata:
-  name: bind-volume
-spec:
-  selector: {}
-  template:
-    metadata:
-      name: bind-volume
-    spec:
-      containers:
-        - name: bind-volume
-          image: registry.access.redhat.com/ubi8/ubi-minimal:latest
-          volumeMounts:
-            - name: bind
-              mountPath: /test
-      restartPolicy: Never
-      volumes:
-        - name: bind
-          persistentVolumeClaim:
-              claimName: app-studio-default-workspace

--- a/components/has/.tekton/pvc.yaml
+++ b/components/has/.tekton/pvc.yaml
@@ -9,27 +9,3 @@ spec:
   resources:
     requests:
       storage: 1Gi
-
----
-# Use PVC for the first time to trigger PV assigment.
-apiVersion: batch/v1
-kind: Job
-metadata:
-  name: bind-volume
-spec:
-  selector: {}
-  template:
-    metadata:
-      name: bind-volume
-    spec:
-      containers:
-        - name: bind-volume
-          image: registry.access.redhat.com/ubi8/ubi-minimal:latest
-          volumeMounts:
-            - name: bind
-              mountPath: /test
-      restartPolicy: Never
-      volumes:
-        - name: bind
-          persistentVolumeClaim:
-              claimName: app-studio-default-workspace

--- a/components/spi/.tekton/pvc.yaml
+++ b/components/spi/.tekton/pvc.yaml
@@ -9,27 +9,3 @@ spec:
   resources:
     requests:
       storage: 1Gi
-
----
-# Use PVC for the first time to trigger PV assigment.
-apiVersion: batch/v1
-kind: Job
-metadata:
-  name: bind-volume
-spec:
-  selector: {}
-  template:
-    metadata:
-      name: bind-volume
-    spec:
-      containers:
-        - name: bind-volume
-          image: registry.access.redhat.com/ubi8/ubi-minimal:latest
-          volumeMounts:
-            - name: bind
-              mountPath: /test
-      restartPolicy: Never
-      volumes:
-        - name: bind
-          persistentVolumeClaim:
-              claimName: app-studio-default-workspace


### PR DESCRIPTION
PVC which are used by CI are not used until CI is triggered.
PVCs are created but not Bound due toStorageClass configuration
WaitForFirstConsumer. Allow Pending PVC to be marked as Healthy instead
of simulating first customer by job.