### PR TITLE
Allow argoCD manage tekton-pipelines namespace

### DIFF
--- a/components/build/tekton-results/allow-argocd-to-manage.yaml
+++ b/components/build/tekton-results/allow-argocd-to-manage.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: grant-argocd
+  namespace: tekton-pipelines
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: admin
+subjects:
+- kind: ServiceAccount
+  name: openshift-gitops-argocd-application-controller
+  namespace: openshift-gitops

--- a/components/build/tekton-results/kustomization.yaml
+++ b/components/build/tekton-results/kustomization.yaml
@@ -1,4 +1,5 @@
 resources:
+- allow-argocd-to-manage.yaml
 - tekton-pipelines-namespace.yaml
 - db-execution-configmap.yaml
 - https://github.com/tektoncd/results/releases/download/v0.4.0/release.yaml


### PR DESCRIPTION
Fix of #157 

@sbose78 is this enough? Or do you expect better fencing? Currently tekton-results define in tekton-pipelines these resources:
ClusterRole
ClusterRoleBinding
ConfigMap
Deployment
Job
Namespace
RoleBinding
Route
Service
ServiceAccount
StatefulSet


