### PR TITLE
Add brunoapimentel to view HAS

### DIFF
--- a/components/authentication/view-has.yaml
+++ b/components/authentication/view-has.yaml
@@ -12,6 +12,8 @@ subjects:
     name: maysunfaisal
   - kind: User
     name: Michkov
+  - kind: User
+    name: brunoapimentel
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole


### PR DESCRIPTION
This access is intended primarily to access HAS CI logs on Openshift.