### PR TITLE
Contract team view permission for tekton-chains

### DIFF
--- a/components/authentication/view-build-service.yaml
+++ b/components/authentication/view-build-service.yaml
@@ -51,12 +51,26 @@ metadata:
   name: read-chains
   namespace: tekton-chains
 subjects:
+  # Build team members
   - kind: User
     name: sbose78 
   - kind: User
+    name: Michkov 
+  # Enterprise Contract team members
+  - kind: User
+    name: bcaton85
+  - kind: User
+    name: caugello
+  - kind: User
+    name: joejstuart
+  - kind: User
+    name: lcarva
+  - kind: User
+    name: robnester-rh
+  - kind: User
     name: simonbaird
   - kind: User
-    name: Michkov 
+    name: zregvart
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole


### PR DESCRIPTION
A followup from recently merged #172.

These are the current devs in the enterprise contract team. This
change allows team members permission to inspect the tekton chains
configuration and watch the chains controller logs, which should be
useful for troubleshooting and generally looking at chains in the
stage cluster.