### PR TITLE
Setup a tenant namespace for Red Hat ( HACBS )

### DIFF
--- a/components/authentication/tenants/kustomization.yaml
+++ b/components/authentication/tenants/kustomization.yaml
@@ -1,5 +1,6 @@
 resources:
 - shbose.yaml
+- redhat-namespace.yaml
 
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/components/authentication/tenants/redhat-namespace.yaml
+++ b/components/authentication/tenants/redhat-namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: redhat
+spec:
+  finalizers:
+  - kubernetes


### PR DESCRIPTION
This is a reversible change - we hope to manage tenants/orgs more efficiently in future. 