### PR TITLE
Allow argocd to manage tekton-chains namespace

### DIFF
--- a/components/build/tekton-chains/allow-argocd-to-manage.yaml
+++ b/components/build/tekton-chains/allow-argocd-to-manage.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: grant-argocd
+  namespace: tekton-chains
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: admin
+subjects:
+- kind: ServiceAccount
+  name: openshift-gitops-argocd-application-controller
+  namespace: openshift-gitops

--- a/components/build/tekton-chains/kustomization.yaml
+++ b/components/build/tekton-chains/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
 # To list available releases:
 #  curl -s https://storage.googleapis.com/tekton-releases/ | xq | grep -E 'chains/.*/release.yaml'
 #
+- allow-argocd-to-manage.yaml
 - https://storage.googleapis.com/tekton-releases/chains/previous/v0.8.0/release.yaml
 - chains-certs.yaml
 


### PR DESCRIPTION
I'm not sure I know exactly why we need this, but I'm copying #158
as suggested by @Michkov.