### PR TITLE
Move pruner configuration job under openshift-pipelines

### DIFF
--- a/components/build/openshift-pipelines/patch-tekton-config-rb.yaml
+++ b/components/build/openshift-pipelines/patch-tekton-config-rb.yaml
@@ -9,4 +9,4 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: patch-tekton-config
-    namespace: openshift-operators
+    namespace: openshift-pipelines

--- a/components/build/openshift-pipelines/patch-tekton-config-sa.yaml
+++ b/components/build/openshift-pipelines/patch-tekton-config-sa.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: patch-tekton-config
-  namespace: openshift-operators
+  namespace: openshift-pipelines

--- a/components/build/openshift-pipelines/pruner-configuration-job.yaml
+++ b/components/build/openshift-pipelines/pruner-configuration-job.yaml
@@ -2,10 +2,9 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: pruner-configuration
-  namespace: openshift-operators
+  namespace: openshift-pipelines
   annotations:
     argocd.argoproj.io/hook: PostSync
-    argocd.argoproj.io/hook-delete-policy: HookSucceeded
 spec:
   template:
     spec:
@@ -16,13 +15,13 @@ spec:
             - -c
             - |
               echo "Waiting for TektonConfig config to be present"
-              until oc get TektonConfig config -n openshift-operators
+              until oc get TektonConfig config
               do
                 sleep $SLEEP;
               done
  
               echo "Patching TektonConfig config patameters"
-              oc patch TektonConfig config -n openshift-pipelines -p '{"spec":{"pruner":{"keep": 10, "schedule": "0/10 * * * *"}}}' --type=merge
+              oc patch TektonConfig config -p '{"spec":{"pruner":{"keep": 10, "schedule": "0/10 * * * *"}}}' --type=merge
           imagePullPolicy: Always
           name: patch-tekton-config
           env:

--- a/components/build/tekton-results/ingress-annotation-job.yaml
+++ b/components/build/tekton-results/ingress-annotation-job.yaml
@@ -4,7 +4,6 @@ metadata:
   name: ingress-annotation
   annotations:
     argocd.argoproj.io/hook: PostSync
-    argocd.argoproj.io/hook-delete-policy: HookSucceeded
 spec:
   template:
     spec:


### PR DESCRIPTION
* Pruner configuration under openshift-pipelines
* Avoid deletion of sync jobs, rather use default policy