### PR TITLE
Enable quay.io push demo oci attestation storage

### DIFF
--- a/hack/chains/README.md
+++ b/hack/chains/README.md
@@ -145,11 +145,10 @@ kubernetes secret for the bot.
 Since we're not using the internal registry, this demo should work without
 running the trust-local-cert.sh and setup-controller-certs.sh scripts.
 
-Note that quay.io doesn't currently support storing attestations, but see
-[PROJQUAY-3386](https://issues.redhat.com/browse/PROJQUAY-3386) which aims to
-change that.
+This uses the default configuration so there's no need to change the config if
+your Argo CD is in sync.
 
     ./gitops-sync.sh off
-    ./config.sh quay
+    ./config.sh default
     kubectl create -f your-downloaded-quay-secret.yml
     ./pipeline-quay-demo.sh quay.io/your-user/your-repo your-quay-secret-name

--- a/hack/chains/config.sh
+++ b/hack/chains/config.sh
@@ -55,23 +55,6 @@ case "$1" in
 
     ;;
 
-  quay )
-    # Currently quay.io doesn't support oci storage for
-    # attestations so fall back to tekton storage
-    #
-    # See https://issues.redhat.com/browse/PROJQUAY-3386
-    # Once that's done then quay can use the default config
-    # and we can delete this.
-    #
-    $0 '{
-      "artifacts.taskrun.format": "in-toto",
-      "artifacts.taskrun.storage": "tekton",
-      "artifacts.oci.storage": "oci",
-      "transparency.enabled": "true"
-      }' $2
-
-    ;;
-
   rekor-on )
     # (Needs to be a string not a boolean FYI)
     $0 'transparency.enabled: "true"' $2

--- a/hack/chains/pipeline-quay-demo.sh
+++ b/hack/chains/pipeline-quay-demo.sh
@@ -31,7 +31,7 @@ title "Image push secret name"
 echo $QUAY_SECRET_NAME
 
 title "Suggested config for this demo:"
-$SCRIPTDIR/config.sh quay --dry-run
+$SCRIPTDIR/config.sh default --dry-run
 
 title "Current config:"
 $SCRIPTDIR/config.sh


### PR DESCRIPTION
We no longer need to tweak the chains configuration
when using quay.io since it now supports storing attestations,
see https://issues.redhat.com/browse/PROJQUAY-3386