### PR TITLE
Remove instructions for chains signing secret

### DIFF
--- a/hack/chains/README.md
+++ b/hack/chains/README.md
@@ -61,11 +61,6 @@ To return to using the default, public rekor instance:
 
    ./config.sh rekor-default
 
-### Create a key-pair signing secret for chains
-
-    cd hack/chains
-    ./create-signing-secret.sh
-
 
 ### Trust the cluster's SSL cert (optional)
 

--- a/hack/chains/create-signing-secret.sh
+++ b/hack/chains/create-signing-secret.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 ###
-### NB: There is hook that runs this after Gitops sync so you
+### NB: There is a hook that runs this after Gitops sync so you
 ### should not generally need to run this script manually.
 ### See components/build/tekton-chains/chains-secrets-config.yaml
 ###

--- a/hack/chains/create-signing-secret.sh
+++ b/hack/chains/create-signing-secret.sh
@@ -1,4 +1,9 @@
 #!/bin/bash
+###
+### NB: There is hook that runs this after Gitops sync so you
+### should not generally need to run this script manually.
+### See components/build/tekton-chains/chains-secrets-config.yaml
+###
 
 # Show a message and exit gracefully if cosign isn't installed
 ! which cosign >/dev/null 2>&1 &&\


### PR DESCRIPTION
The key pair secret will now be created automatically using a Gitops
hook, so no need to explain how to create one manually.