### PR TITLE
update SPI

### DIFF
--- a/components/spi/kustomization.yaml
+++ b/components/spi/kustomization.yaml
@@ -1,6 +1,6 @@
 resources:
   - argocd-permissions.yaml
-  - https://github.com/sparkoo/service-provider-integration-operator/config/default?ref=fbff599c61ee996b3e54cc0c0c1d045e73eb6f66
+  - https://github.com/redhat-appstudio/service-provider-integration-operator/config/default?ref=bee68d736312be7af23176ccc588edca5b6bf612
   - oauth_route.yaml
   - https://github.com/redhat-appstudio/service-provider-integration-scm-file-retriever/server/config/default?ref=381f7746b88019ea13d4aa42e71b01ac9bb2ec1e
   - scm_route.yaml
@@ -13,11 +13,11 @@ kind: Kustomization
 
 images:
   - name:  quay.io/redhat-appstudio/service-provider-integration-operator
-    newName: quay.io/mvala/spi-operator
-    newTag: svpi61-vaultTokenStorage
+    newName: quay.io/redhat-appstudio/service-provider-integration-operator
+    newTag: 0.3.0
   - name: quay.io/redhat-appstudio/service-provider-integration-oauth
-    newName: quay.io/mvala/spi-oauth
-    newTag: svpi61-vaultTokenStorage
+    newName: quay.io/redhat-appstudio/service-provider-integration-operator
+    newTag: 0.3.0
   - name: quay.io/redhat-appstudio/service-provider-integration-scm-file-retriever-server
     newName:  quay.io/redhat-appstudio/service-provider-integration-scm-file-retriever-server
     newTag: 0.3.0

--- a/components/spi/kustomization.yaml
+++ b/components/spi/kustomization.yaml
@@ -1,6 +1,6 @@
 resources:
   - argocd-permissions.yaml
-  - https://github.com/redhat-appstudio/service-provider-integration-operator/config/default?ref=faca4bea8d65c80ab0bea3ce25d56346f2c86201
+  - https://github.com/sparkoo/service-provider-integration-operator/config/default?ref=742686b1b36a22dcc37e96553b3fb84864c43808
   - oauth_route.yaml
   - https://github.com/redhat-appstudio/service-provider-integration-scm-file-retriever/server/config/default?ref=381f7746b88019ea13d4aa42e71b01ac9bb2ec1e
   - scm_route.yaml

--- a/components/spi/kustomization.yaml
+++ b/components/spi/kustomization.yaml
@@ -16,7 +16,7 @@ images:
     newName: quay.io/redhat-appstudio/service-provider-integration-operator
     newTag: 0.3.0
   - name: quay.io/redhat-appstudio/service-provider-integration-oauth
-    newName: quay.io/redhat-appstudio/service-provider-integration-operator
+    newName: quay.io/redhat-appstudio/service-provider-integration-oauth
     newTag: 0.3.0
   - name: quay.io/redhat-appstudio/service-provider-integration-scm-file-retriever-server
     newName:  quay.io/redhat-appstudio/service-provider-integration-scm-file-retriever-server

--- a/components/spi/kustomization.yaml
+++ b/components/spi/kustomization.yaml
@@ -1,6 +1,6 @@
 resources:
   - argocd-permissions.yaml
-  - https://github.com/sparkoo/service-provider-integration-operator/config/default?ref=742686b1b36a22dcc37e96553b3fb84864c43808
+  - https://github.com/sparkoo/service-provider-integration-operator/config/default?ref=fbff599c61ee996b3e54cc0c0c1d045e73eb6f66
   - oauth_route.yaml
   - https://github.com/redhat-appstudio/service-provider-integration-scm-file-retriever/server/config/default?ref=381f7746b88019ea13d4aa42e71b01ac9bb2ec1e
   - scm_route.yaml

--- a/components/spi/kustomization.yaml
+++ b/components/spi/kustomization.yaml
@@ -13,11 +13,11 @@ kind: Kustomization
 
 images:
   - name:  quay.io/redhat-appstudio/service-provider-integration-operator
-    newName: quay.io/redhat-appstudio/service-provider-integration-operator
-    newTag: 0.2.3
+    newName: quay.io/mvala/spi-operator
+    newTag: svpi61-vaultTokenStorage
   - name: quay.io/redhat-appstudio/service-provider-integration-oauth
-    newName: quay.io/redhat-appstudio/service-provider-integration-oauth
-    newTag: 0.3.0
+    newName: quay.io/mvala/spi-oauth
+    newTag: svpi61-vaultTokenStorage
   - name: quay.io/redhat-appstudio/service-provider-integration-scm-file-retriever-server
     newName:  quay.io/redhat-appstudio/service-provider-integration-scm-file-retriever-server
     newTag: 0.3.0

--- a/components/spi/kustomization.yaml
+++ b/components/spi/kustomization.yaml
@@ -20,7 +20,7 @@ images:
     newTag: 0.4.0
   - name: quay.io/redhat-appstudio/service-provider-integration-scm-file-retriever-server
     newName:  quay.io/redhat-appstudio/service-provider-integration-scm-file-retriever-server
-    newTag: 0.3.0
+    newTag: 0.4.0
 
 namespace: spi-system
 

--- a/components/spi/kustomization.yaml
+++ b/components/spi/kustomization.yaml
@@ -14,10 +14,10 @@ kind: Kustomization
 images:
   - name:  quay.io/redhat-appstudio/service-provider-integration-operator
     newName: quay.io/redhat-appstudio/service-provider-integration-operator
-    newTag: 0.3.0
+    newTag: 0.4.0
   - name: quay.io/redhat-appstudio/service-provider-integration-oauth
     newName: quay.io/redhat-appstudio/service-provider-integration-oauth
-    newTag: 0.3.0
+    newTag: 0.4.0
   - name: quay.io/redhat-appstudio/service-provider-integration-scm-file-retriever-server
     newName:  quay.io/redhat-appstudio/service-provider-integration-scm-file-retriever-server
     newTag: 0.3.0


### PR DESCRIPTION
updates SPI to latest images and deployment reference. This brings couple of important changes like:
 - vault token storage
 - removing webhooks
 - new internal trigger CRD `spiaccesstokendataupdates.appstudio.redhat.com`
