### PR TITLE
updates to scripts to support devfiles

### DIFF
--- a/hack/build/analyze-devfile.sh
+++ b/hack/build/analyze-devfile.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+fetch_file () { 
+  REPO=$1 
+  FILE=$2
+  OUT=$3
+  USER=$(echo $REPO | cut -d '/' -f 4)
+  PROJECT=$(echo $REPO | cut -d '/' -f 5)
+  for BRANCH in main master
+  do   
+    URL="https://raw.githubusercontent.com/$USER/$PROJECT/$BRANCH/$FILE" 
+    if curl  -H "Cache-Control: no-cache" --output $OUT --silent   --fail "$URL"; then
+        return;  
+    fi 
+  done  
+}   
+
+DEVFILE=$(mktemp)
+fetch_file $1 devfile.yaml $DEVFILE
+
+OLOOP_BUILD=$(mktemp)
+OLOOP_DEPLOY=$(mktemp)
+yq e '.components | with_entries(select(.[].name=="outerloop-build"))' $DEVFILE |  yq e '.[]' - > $OLOOP_BUILD
+yq e '.components | with_entries(select(.[].name=="outerloop-deploy"))' $DEVFILE | yq e '.[]' - > $OLOOP_DEPLOY
+
+DEV_DOCKERFILE="$(yq e '.image.dockerfile.uri' $OLOOP_BUILD)"
+DEV_DIRECTORY="$(yq e '.image.dockerfile.buildContext' $OLOOP_BUILD)"
+DEV_DEPLOY_FILE="$(yq e '.kubernetes.uri' $OLOOP_DEPLOY)"
+
+if [ -z "$DEV_DEPLOY_FILE" ] 
+then
+    echo "No deployment yaml in devfile, will use internal deployent yaml" 
+else 
+    DEPLOYFILE=$(mktemp)
+    fetch_file $1 $DEV_DEPLOY_FILE $DEPLOYFILE  
+    DEV_DEPLOY=$(cat $DEPLOYFILE | base64 -w 0)   
+fi 
+echo "Devfile Analysis:"
+echo "Dockerfile: $DEV_DOCKERFILE"  
+echo "BuildContext: $DEV_DIRECTORY"   
+echo "Deploy: $DEV_DEPLOY_FILE" 
+
+  
+  

--- a/hack/build/build-deploy.sh
+++ b/hack/build/build-deploy.sh
@@ -3,6 +3,7 @@ SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
   
 LOG=$(mktemp)
 $SCRIPTDIR/build.sh $1 $2| tee $LOG 
+cat $LOG
 BUILDNAME=$(cat $LOG | grep "pipelinerun.tekton.dev" | cut -d '/' -f 2 | cut -d ' ' -f 1)
 echo  
 echo  "Waiting for build  $BUILDNAME:"  

--- a/hack/build/build-quay.sh
+++ b/hack/build/build-quay.sh
@@ -1,106 +1,11 @@
 #!/bin/bash
 
-# This script demonstrates of how a client of the Build Service 
-# eg HAS Application can launch a Build
-# This Build launch conforms the Build Contract from the Build Service
-# see the spec <link> for more details
-# 
-# See templates/default-build.yaml for the sample build run
-
-
-# To launch a build a client will need to pass parameters
-# - spec.params[GITURL] the URL for REPO
-# - spec.params[IMAGE] for the IMAGE
-# - add bindings for the SPI to ensure access to the GITURL and the IMAGE registry
-# This script installs pipelines needed for the default build but this mechanism will change
-# The type of build is currently fixed at docker
-# An imported HAS Application will detect language and build type and map to a 
-# pipeline name which will be provided by the Build Service
-
 SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-
-GITREPO=$1 
-if [ -z "$GITREPO" ]
-then
-      echo Missing parameter Git URL to Build
-      exit -1 
-fi
 PIPELINE_NAME=$2   
 if [ -z "$PIPELINE_NAME" ]
 then
-      PIPELINE_NAME=$($SCRIPTDIR/repo-to-pipeline.sh $GITREPO) 
-      if [ "$PIPELINE_NAME" == "none" ]
-      then 
-            echo Pipeline name  $PIPELINE_NAME - exiting build 
-            exit 0
-      else 
-            echo Pipeline name computed from git repo $PIPELINE_NAME
-      fi
+      PIPELINE_NAME=auto
 fi 
-
-PIPELINE_RUN=$SCRIPTDIR/templates/default-build-bundle.yaml   
-
-$SCRIPTDIR/utils/install-pvc.sh $PIPELINE_NAME
-$SCRIPTDIR/utils/install-secrets.sh  
-
-APPNAME=$(basename $GITREPO) 
-IMAGE_FULL_TAG=$(git ls-remote $GITREPO HEAD)
-IMAGE_SHORT_TAG=${IMAGE_FULL_TAG:position:7}
-BUILD_TAG=$(date +"%Y-%m-%d-%H%M%S") 
-NS=$(oc config view --minify -o "jsonpath={..namespace}")
-
-# local bundle overide for dev purposes 
-BUNDLE=$(oc get cm build-pipelines-defaults -o=jsonpath='{.data.default_build_bundle}' 2> /dev/null)
-if [ -z "$BUNDLE" ]
-then
-      BUNDLE=$(oc get cm -n build-templates build-pipelines-defaults -o=jsonpath='{.data.default_build_bundle}')
-      if [ -z "$BUNDLE" ]
-      then
-            BUNDLE=$(yq -M e ".spec.pipelineRef.bundle"  $PIPELINE_RUN)
-            echo "Warning missing bundle name configmap in current namespace and build-templates, using default" 
-      fi 
-fi 
-
-oc get secret quay-registry-secret  2> /dev/null  > /dev/null 
-ERR=$?  
-if (( $ERR == 0 )); then    
-   echo "Using Secret: quay-registry-secret"
-   export QUAY_PATCH="keep-secrets" 
-else  
-   echo "Warning - No Registry Secrets installed, only internal registry repos will work."
-   export  QUAY_PATCH="registry-auth" 
-fi 
-oc get secret git-repo-secret   2> /dev/null  > /dev/null 
-ERR=$?  
-if (( $ERR == 0 )); then
-   echo "Using Secret: git-repo-secret"
-   export GIT_PATCH="keep-secrets" 
-else 
-   echo "Warning - No Git Secrets installed, only public git repos will work."
-   export  GIT_PATCH="git-auth" 
-fi   
- 
-IMG=quay.io/$MY_QUAY_USER/$APPNAME:$IMAGE_SHORT_TAG
-echo
-echo "Building $GITREPO"
-echo "Build Name: build-$BUILD_TAG"
-echo "Namespace: " $NS
-echo "Image: " $IMG
-echo "Bundle: " $BUNDLE
-echo "Pipeline: " $PIPELINE_NAME  
-
-PATCHQ=$(printf "del(.spec.workspaces[] | select (.name == \"%q\"))" "$QUAY_PATCH") 
-PATCHR=$(printf "del(.spec.workspaces[] | select (.name == \"%q\"))" "$GIT_PATCH") 
-
-APPLY=$(mktemp)
-yq -M e ".spec.params[0].value=\"$GITREPO\"" $PIPELINE_RUN | \
-  yq -M e ".spec.params[1].value=\"$IMG\"" - | \
-  yq -M e ".metadata.name=\"$PIPELINE_NAME-$BUILD_TAG\"" - | \
-  yq -M e ".spec.pipelineRef.name=\"$PIPELINE_NAME\"" - | \
-  yq -M e ".spec.pipelineRef.bundle=\"$BUNDLE\"" - | \
-  yq -M e ".spec.workspaces[0].subPath=\"pv-$PIPELINE_NAME-$BUILD_TAG\"" - | \
-  yq -M e "$PATCHR" - | yq -M e "$PATCHQ" - > $APPLY
-
-#cat $APPLY 
-oc apply -f $APPLY
+# build repo pipelinename quay/internal
+$SCRIPTDIR/build.sh $1 $PIPELINE_NAME quay
  

--- a/hack/build/build.sh
+++ b/hack/build/build.sh
@@ -25,30 +25,67 @@ then
       echo Missing parameter Git URL to Build
       exit -1 
 fi
-PIPELINE_NAME=$2   
-if [ -z "$PIPELINE_NAME" ]
-then
-      PIPELINE_NAME=$($SCRIPTDIR/repo-to-pipeline.sh $GITREPO) 
-      if [ "$PIPELINE_NAME" == "none" ]
-      then 
-            echo Pipeline name  $PIPELINE_NAME - exiting build 
-            exit 0
-      else 
-            echo Pipeline name computed from git repo $PIPELINE_NAME
-      fi
-fi 
-
-PIPELINE_RUN=$SCRIPTDIR/templates/default-build-bundle.yaml   
-
-$SCRIPTDIR/utils/install-pvc.sh $PIPELINE_NAME
-
+# compute name and image tag gitrepo
 APPNAME=$(basename $GITREPO) 
 IMAGE_FULL_TAG=$(git ls-remote $GITREPO HEAD)
 IMAGE_SHORT_TAG=${IMAGE_FULL_TAG:position:7}
-BUILD_TAG=$(date +"%Y-%m-%d-%H%M%S") 
-NS=$(oc config view --minify -o "jsonpath={..namespace}")
 
-# local bundle overide for dev purposes 
+#build tag for readable build names instead of kubernetes generated names
+BUILD_TAG=$(date +"%Y-%m-%d-%H%M%S") 
+
+PIPELINE_NAME=$2  
+if [ -z "$PIPELINE_NAME" ] || [ "$PIPELINE_NAME" == "auto" ]
+then
+      PIPELINE_NAME=$($SCRIPTDIR/repo-to-pipeline.sh $GITREPO)
+      echo Pipeline name computed from git repo $PIPELINE_NAME
+fi 
+if [ "$PIPELINE_NAME" == "devfile-build" ]
+then   
+      source $SCRIPTDIR/analyze-devfile.sh  
+      PIPELINE_NAME=docker-build
+else 
+      DEV_DOCKERFILE=Dockerfile  
+      DEV_DIRECTORY="."   
+      DEV_DEPLOY=
+fi
+
+QUAY=$3   
+NS=$(oc config view --minify -o "jsonpath={..namespace}")
+if [ -z "$QUAY" ]
+then
+      #internal registry only        
+      IMG=image-registry.openshift-image-registry.svc:5000/$NS/$APPNAME:$IMAGE_SHORT_TAG
+      #filter out the secrets mounts as they are not needed 
+      export QUAY_PATCH="registry-auth" 
+      export GIT_PATCH="git-auth"  
+else   
+      if [ -z "$QUAY" ]
+      then
+            echo "missing Quay.io user in env MY_QUAY_USER"
+            exit 0
+      fi 
+      oc get secret quay-registry-secret  2> /dev/null  > /dev/null 
+      ERR=$?  
+      if (( $ERR == 0 )); then    
+            echo "Using Secret: quay-registry-secret"
+      else  
+            $SCRIPTDIR/utils/install-secrets.sh 
+      fi 
+      export QUAY_PATCH="keep-secrets" 
+      IMG=quay.io/$MY_QUAY_USER/$APPNAME:$IMAGE_SHORT_TAG
+fi 
+oc get secret git-repo-secret   2> /dev/null  > /dev/null 
+ERR=$?  
+if (( $ERR == 0 )); then
+      echo "Using Secret: git-repo-secret"
+      export GIT_PATCH="keep-secrets" 
+else 
+      echo "Warning - No Git Secrets installed, only public git repos will work."
+      export  GIT_PATCH="git-auth" 
+fi  
+$SCRIPTDIR/utils/install-pvc.sh $PIPELINE_NAME 
+ 
+PIPELINE_RUN=$SCRIPTDIR/templates/default-build-bundle.yaml   
 BUNDLE=$(oc get cm build-pipelines-defaults -o=jsonpath='{.data.default_build_bundle}' 2> /dev/null)
 if [ -z "$BUNDLE" ]
 then
@@ -58,42 +95,28 @@ then
             BUNDLE=$(yq -M e ".spec.pipelineRef.bundle"  $PIPELINE_RUN)
             echo "Warning missing bundle name configmap in current namespace and build-templates, using default" 
       fi 
-fi 
-
-oc get secret quay-registry-secret  2> /dev/null  > /dev/null 
-ERR=$?  
-if (( $ERR == 0 )); then    
-   echo "Using Secret: quay-registry-secret"
-   export QUAY_PATCH="keep-secrets" 
-else  
-   echo "Warning - No Registry Secrets installed, only internal registry repos will work."
-   export  QUAY_PATCH="registry-auth" 
-fi 
-oc get secret git-repo-secret   2> /dev/null  > /dev/null 
-ERR=$?  
-if (( $ERR == 0 )); then
-   echo "Using Secret: git-repo-secret"
-   export GIT_PATCH="keep-secrets" 
-else 
-   echo "Warning - No Git Secrets installed, only public git repos will work."
-   export  GIT_PATCH="git-auth" 
-fi   
+fi  
  
-IMG=image-registry.openshift-image-registry.svc:5000/$NS/$APPNAME:$IMAGE_SHORT_TAG
 echo
 echo "Building $GITREPO"
 echo "Build Name: build-$BUILD_TAG"
 echo "Namespace: " $NS
 echo "Image: " $IMG
 echo "Bundle: " $BUNDLE
-echo "Pipeline: " $PIPELINE_NAME  
+echo "Pipeline: " $PIPELINE_NAME 
+echo "Dockerfile: " $DEV_DOCKERFILE 
+echo "Directory: " $DEV_DIRECTORY 
 
 PATCHQ=$(printf "del(.spec.workspaces[] | select (.name == \"%q\"))" "$QUAY_PATCH") 
 PATCHR=$(printf "del(.spec.workspaces[] | select (.name == \"%q\"))" "$GIT_PATCH") 
+ 
 
 APPLY=$(mktemp)
 yq -M e ".spec.params[0].value=\"$GITREPO\"" $PIPELINE_RUN | \
   yq -M e ".spec.params[1].value=\"$IMG\"" - | \
+  yq -M e ".metadata.annotations.\"build.appstudio.openshift.io/deploy\"=\"$DEV_DEPLOY\"" - | \
+  yq -M e ".spec.params[2].value=\"$DEV_DOCKERFILE\"" - | \
+  yq -M e ".spec.params[3].value=\"$DEV_DIRECTORY\"" - | \
   yq -M e ".metadata.name=\"$PIPELINE_NAME-$BUILD_TAG\"" - | \
   yq -M e ".spec.pipelineRef.name=\"$PIPELINE_NAME\"" - | \
   yq -M e ".spec.pipelineRef.bundle=\"$BUNDLE\"" - | \

--- a/hack/build/m2-builds.sh
+++ b/hack/build/m2-builds.sh
@@ -5,29 +5,30 @@ SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 # Note: deploy is not part of the build service, it will be performed via Gitops service
 # This demo uses a direct deploy to demonstrate the build works. 
 
-DEPLOY=$1
-if [ -z "$DEPLOY" ]
-then
-      echo "Building all Milestone 2 Repos. add '-deploy' to commandline to auto deploy"
-else
-    if [ $DEPLOY = "-deploy" ]; then 
-        echo "Building and Deploying all Milestone 2 Repos." 
-    else 
-        echo "$DEPLOY invalid, ignored."
-    fi 
-fi
+echo "Building all Milestone 2 Repos. add '-deploy' to commandline to auto deploy"
+echo "Building all Milestone 2 Repos. add 'quay' to commandline to use quay repo"
+
+for PARAM in "$@"
+do  
+    if [ $PARAM = "-deploy" ]; then 
+        DEPLOY=-deploy
+    fi  
+    if [ $PARAM = "quay" ]; then 
+        REPO=quay
+    fi    
+done
 
 CMD=$SCRIPTDIR/build$DEPLOY.sh 
 
 # devfile based builds 
-$CMD https://github.com/devfile-samples/devfile-sample-java-springboot-basic
-$CMD https://github.com/nodeshift-starters/devfile-sample
-$CMD https://github.com/devfile-samples/devfile-sample-code-with-quarkus
-$CMD https://github.com/devfile-samples/devfile-sample-python-basic 
+$CMD https://github.com/devfile-samples/devfile-sample-java-springboot-basic auto $REPO
+$CMD https://github.com/nodeshift-starters/devfile-sample auto $REPO
+$CMD https://github.com/devfile-samples/devfile-sample-code-with-quarkus auto $REPO
+$CMD https://github.com/devfile-samples/devfile-sample-python-basic auto $REPO
 
 # auto-detect base builds
-$CMD https://github.com/jduimovich/single-container-app
-$CMD https://github.com/jduimovich/single-nodejs-app
-$CMD https://github.com/jduimovich/spring-petclinic  java-builder
+$CMD https://github.com/jduimovich/single-container-app auto $REPO
+$CMD https://github.com/jduimovich/single-nodejs-app auto $REPO
+$CMD https://github.com/jduimovich/spring-petclinic  java-builder $REPO
  
 echo "Run this to show running builds $SCRIPTDIR/ls-builds.sh"

--- a/hack/build/repo-to-pipeline.sh
+++ b/hack/build/repo-to-pipeline.sh
@@ -20,21 +20,16 @@ repo_marker_to_pipeline () {
   FILE=$2 
   PIPELINE=$3
   USER=$(echo $REPO | cut -d '/' -f 4)
-  PROJECT=$(echo $REPO | cut -d '/' -f 5)
-  BRANCH=main 
-  URL="https://raw.githubusercontent.com/$USER/$PROJECT/$BRANCH/$FILE" 
-  if curl  -H "Cache-Control: no-cache" --output /dev/null --silent --head --fail "$URL"; then
-    # echo "Marker  $URL  exists"
-    echo $PIPELINE
-    exit 0;  
-  fi 
-  BRANCH=master
-  URL="https://raw.githubusercontent.com/$USER/$PROJECT/$BRANCH/$FILE" 
-  if curl  -H "Cache-Control: no-cache" --output /dev/null --silent --head --fail "$URL"; then
-    # echo Marker "https://raw.githubusercontent.com/$USER/$PROJECT/$BRANCH/$FILE" exists
-    echo $PIPELINE
-    exit 0;  
-  fi  
+  PROJECT=$(echo $REPO | cut -d '/' -f 5) 
+  for BRANCH in main master
+  do    
+    URL="https://raw.githubusercontent.com/$USER/$PROJECT/$BRANCH/$FILE" 
+    if curl  -H "Cache-Control: no-cache" --output /dev/null --silent --head --fail "$URL"; then
+      # echo "Marker  $URL  exists"
+      echo $PIPELINE
+      exit 0;  
+    fi 
+  done 
 }   
 
 # need to understand dev files mapping 

--- a/hack/build/templates/default-build-bundle.yaml
+++ b/hack/build/templates/default-build-bundle.yaml
@@ -15,6 +15,10 @@ spec:
       value: GIT_URL_PLACEHOLDER 
     - name: output-image
       value: OUTPUT_IMAGE_PLACEHOLDER
+    - name: dockerfile
+      value: Dockerfile
+    - name: path-context
+      value: .
   pipelineRef:
     name: PIPELINE_NAME_PLACEHOLDER  
     bundle:  quay.io/redhat-appstudio/build-templates-bundle:93dac682ee16a08634d593b836758e1d4fa8d967

--- a/hack/build/utils/install-secrets.sh
+++ b/hack/build/utils/install-secrets.sh
@@ -31,12 +31,10 @@ stringData:
   .git-credentials: |
     https://<user>:<pass>@github.com
 GITSECRET
-
-oc delete secret -n $NS git-repo-secret   
+ 
 PATCH="$(printf '.stringData.".git-credentials"="https://%q:%q@github.com"' $MY_GITHUB_USER $MY_GITHUB_TOKEN)" 
 echo "$GITSECRET" | yq e $PATCH -  | oc apply -f -
-
-oc delete secret -n $NS quay-registry-secret
+ 
 oc create secret -n $NS  docker-registry quay-registry-secret \
   --docker-server="https://quay.io" \
   --docker-username=$MY_QUAY_USER \


### PR DESCRIPTION
This PR removes the need to have a devfile build pipeline as per this cleanup of https://github.com/redhat-appstudio/build-definitions/pull/36 

The processing of the devfile extract the location of the dockerfile, the path and the outterloop deployment from the devfile.yaml.  
- process devfiles outside pipelines as devfile-build pipeline is being removed
- configure quay deploy from build script by passing quay on the command line
CLI is compatible and is now build.sh <repo> <pipelinename / auto:optional> <quay:optional>