### PR TITLE
Avoid ArgoCD SharedResourceWarning on build app

### DIFF
--- a/components/build/pipelines-as-code/kustomization.yaml
+++ b/components/build/pipelines-as-code/kustomization.yaml
@@ -5,3 +5,5 @@ resources:
 
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+commonLabels:
+  app.kubernetes.io/instance: "build"


### PR DESCRIPTION
ArgoCD is setting `app.kubernetes.io/instance` to argoCD app - https://argo-cd.readthedocs.io/en/stable/faq/#why-is-my-app-out-of-sync-even-after-syncing.
Pipelines-as-code has it set directly in yaml to `default`. That's why
we can see warning in ArgoCD -> `CustomResourceDefinition/repositories.pipelinesascode.tekton.dev is part of applications build and default`