### PR TITLE
Allow to see openshift-operators namespace

### DIFF
--- a/components/authentication/view-build-service.yaml
+++ b/components/authentication/view-build-service.yaml
@@ -16,6 +16,21 @@ roleRef:
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
+  name: read-operators
+  namespace: openshift-operators
+subjects:
+  - kind: User
+    name: vdemeester
+  - kind: User
+    name: Michkov
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: view
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
   name: read-build-templates
   namespace: build-templates
 subjects:


### PR DESCRIPTION
Allow to vdemeester and Michkov see pods and logs in openshift-operators
namespace to inspect why Tekton pruner is not running.