### PR TITLE
fix: use yq for replacing github org in has tmpl

### DIFF
--- a/hack/util-set-github-org
+++ b/hack/util-set-github-org
@@ -3,7 +3,7 @@
 ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"/..
 
 echo "Changing AppStudio Gitlab Org to \"$1\""
-sed -i "s/GITHUB_ORG=.*/GITHUB_ORG=\"$1\"/" $ROOT/components/has/kustomization.yaml
+yq e -i "(.configMapGenerator[].literals[] | select(. == \"*GITHUB*\")) = \"GITHUB_ORG=$1\"" $ROOT/components/has/kustomization.yaml
 
 if [ -n "$MY_GITHUB_TOKEN" ]; then
     echo


### PR DESCRIPTION
### What

Using `sed` with `-i` flag on a Mac (BSD) [behaves differently than on a Linux machine (GNU)](https://stackoverflow.com/questions/4247068/sed-command-with-i-option-failing-on-mac-but-works-on-linux) and it fails when replacing the GITHUB_ORG in "has" kustomize template

Using `yq` solves this problem for both platforms

### To verify
1. Make sure you have `yq v4.x` installed
2. Run
```bash
# Bootstrap the cluster in 'preview' mode
export MY_GIT_FORK_REMOTE=<origin, or whatever points to your git remote> MY_GITHUB_ORG=<your github org> MY_GITHUB_TOKEN=<your github token with permissions "repo" and "delete_repo">
./hack/bootstrap-cluster.sh preview

# Give it couple of minutes until there are resources (pods, configmaps) created in application-service namespace
# And then test that the value of MY_GITHUB_ORG env var (defined above) got propagated to the configmap in application-service namespace
oc get configmap application-service-github-config -n application-service -o jsonpath={.data.GITHUB_ORG}
```