### PR TITLE
Disable authorization on tekton-results-api

### DIFF
--- a/components/build/tekton-results/kustomization.yaml
+++ b/components/build/tekton-results/kustomization.yaml
@@ -9,8 +9,21 @@ resources:
 - ingress-annotation-rb.yaml
 - ingress-annotation-job.yaml
 
+images:
+- name: gcr.io/tekton-releases/github.com/tektoncd/results/cmd/api:v0.4.0
+  newName: quay.io/redhat-appstudio/tekton-results-no-auth
+  newTag: stable
+
 patchesStrategicMerge:
 - patch-postgres-redhat-statefulset.yaml
+
+patches:
+- path: patch-tekton-results-api-no-auth.yaml
+  target:
+    group: apps
+    version: v1
+    kind: Deployment
+    name: tekton-results-api
 
 namespace: tekton-pipelines
 

--- a/components/build/tekton-results/patch-tekton-results-api-no-auth.yaml
+++ b/components/build/tekton-results/patch-tekton-results-api-no-auth.yaml
@@ -1,0 +1,8 @@
+- op: add
+  path: /spec/template/spec/containers/0/env/-
+  value:
+    name: AUTHENTICATION
+    value: nop
+- op: replace
+  path: /spec/template/spec/containers/0/imagePullPolicy
+  value: Always

--- a/hack/build/set-tkn-results.sh
+++ b/hack/build/set-tkn-results.sh
@@ -1,14 +1,5 @@
 #!/bin/bash
 
-if ! oc auth can-i --list | grep 'results.results.tekton.dev' | grep -q get; then
-  echo You do not have permission to list records.results.tekton.dev in current namespace
-  echo
-  echo To get the permission you can run:
-  echo "  For namespace: kubectl create rolebinding tekton-results-debug --clusterrole=tekton-results-readonly --user=\$(oc whoami)"
-  echo "  Global permission: kubectl create clusterrolebinding tekton-results-debug --clusterrole=tekton-results-readonly --user=\$(oc whoami)"
-  exit 1
-fi
-
 if ! tkn results &>/dev/null; then
    echo Command 'tkn results' is not installed
    echo https://github.com/tektoncd/results/blob/main/tools/tkn-results/README.md
@@ -19,7 +10,6 @@ openssl s_client -showcerts -connect $URL:443 </dev/null 2>/dev/null | sed -n -e
 
 cat > ~/.config/tkn/results.yaml <<EOF
 address: $URL:443
-token: $(oc whoami --show-token)
 ssl:
     roots_file_path: $HOME/.config/tkn/cert.pem
 EOF


### PR DESCRIPTION
Using temporary image build from https://github.com/tektoncd/results/pull/170

When merged and released we should switch back to upstream.