### PR TITLE
Use forked Tekton Chains image

### DIFF
--- a/components/build/tekton-chains/chains-controller-deployment.yaml
+++ b/components/build/tekton-chains/chains-controller-deployment.yaml
@@ -8,6 +8,7 @@ spec:
     spec:
       containers:
       - name: tekton-chains-controller
+        image: ghcr.io/hacbs-contract/chains/controller:cd2d8c2c9fea3902248dd811913e7ea4fa73d639
         volumeMounts:
         - mountPath: /etc/ssl/certs
           name: chains-ca-cert

--- a/components/build/tekton-chains/kustomization.yaml
+++ b/components/build/tekton-chains/kustomization.yaml
@@ -18,8 +18,8 @@ patchesStrategicMerge:
 # Remove runAsUser and runAsGroup from security context
 - security-context-fix.yaml
 
-# Mount the secrets volume
-- chains-controller-cert.yaml
+# Mount the secrets volume and use the forked image
+- chains-controller-deployment.yaml
 
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization


### PR DESCRIPTION
In a forked repository[1] we have fixes from unreleased Tekton Chains
version, until the nightly builds are available from upstream[2]. This
should unblock the end to end tests[3].

[1] https://github.com/hacbs-contract/chains
[2] see https://issues.redhat.com/browse/HACBS-263
[3] https://issues.redhat.com/browse/HACBS-278