### PR TITLE
Gives Lukas Krejci view and spi-vault-admin  roles

### DIFF
--- a/components/authentication/view-spi.yaml
+++ b/components/authentication/view-spi.yaml
@@ -10,6 +10,8 @@ subjects:
     name: sbose78
   - kind: User
     name: sparkoo
+  - kind: User
+    name: metlos
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/components/spi/vault_rolebinding.yaml
+++ b/components/spi/vault_rolebinding.yaml
@@ -7,6 +7,8 @@ subjects:
     name: skabashnyuk
   - kind: User
     name: sparkoo
+  - kind: User
+    name: metlos
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role


### PR DESCRIPTION
Gives Lukas Krejci view and spi-vault-admin  roles. That is necessary to complete  `Use devsandbox proxy/kcp SSO token as auth token` https://issues.redhat.com/browse/SVPI-81 