### PR TITLE
Enable github groups sync

### DIFF
--- a/components/authentication/group-sync/github-redhat-appstudio.yaml
+++ b/components/authentication/group-sync/github-redhat-appstudio.yaml
@@ -3,6 +3,7 @@ kind: GroupSync
 metadata:
   name: github-redhat-appstudio
 spec:
+  schedule: "*/15 * * * *"
   providers:
   - name: github
     github:

--- a/components/authentication/group-sync/github-redhat-appstudio.yaml
+++ b/components/authentication/group-sync/github-redhat-appstudio.yaml
@@ -1,0 +1,12 @@
+apiVersion: redhatcop.redhat.io/v1alpha1
+kind: GroupSync
+metadata:
+  name: github-redhat-appstudio
+spec:
+  providers:
+  - name: github
+    github:
+      organization: redhat-appstudio
+      credentialsSecret:
+        name: github-redhat-appstudio
+        namespace: group-sync-operator

--- a/components/authentication/group-sync/group-sync-ci.yaml
+++ b/components/authentication/group-sync/group-sync-ci.yaml
@@ -1,0 +1,14 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: group-sync-operator-ci-maintainers
+  namespace: group-sync-operator
+subjects:
+  - kind: User
+    name: Michkov
+  - kind: User
+    name: sbose78
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: pipeline-maintainer

--- a/components/authentication/group-sync/kustomization.yaml
+++ b/components/authentication/group-sync/kustomization.yaml
@@ -7,3 +7,9 @@ resources:
 - subscription.yaml
 - view-group-sync.yaml
 namespace: group-sync-operator
+
+# Skip applying the Group-sync operands while the Tekton operator is being installed.
+# See more information about this option, here:
+# https://argo-cd.readthedocs.io/en/stable/user-guide/sync-options/#skip-dry-run-for-new-custom-resources-types
+commonAnnotations:
+  argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true

--- a/components/authentication/group-sync/kustomization.yaml
+++ b/components/authentication/group-sync/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- github-redhat-appstudio.yaml
+- group-sync-ci.yaml
+- namespaces.yaml
+- subscription.yaml
+- view-group-sync.yaml
+namespace: group-sync-operator

--- a/components/authentication/group-sync/namespaces.yaml
+++ b/components/authentication/group-sync/namespaces.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: group-sync-operator

--- a/components/authentication/group-sync/subscription.yaml
+++ b/components/authentication/group-sync/subscription.yaml
@@ -1,0 +1,18 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: group-sync-operator
+spec:
+  channel: alpha
+  installPlanApproval: Automatic
+  name: group-sync-operator
+  source: community-operators
+  sourceNamespace: openshift-marketplace
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: group-sync-operator
+spec:
+  targetNamespaces:
+    - group-sync-operator

--- a/components/authentication/group-sync/view-group-sync.yaml
+++ b/components/authentication/group-sync/view-group-sync.yaml
@@ -1,0 +1,14 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: view-group-sync
+  namespace: group-sync-operator
+subjects:
+  - kind: User
+    name: Michkov
+  - kind: User
+    name: sbose78
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: view

--- a/components/authentication/kustomization.yaml
+++ b/components/authentication/kustomization.yaml
@@ -16,6 +16,7 @@ resources:
 - tenants/
 - view-cluster-registration.yaml
 - cluster-registration-ci.yaml
+- group-sync/
 
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/components/authentication/view-build-service.yaml
+++ b/components/authentication/view-build-service.yaml
@@ -46,6 +46,10 @@ subjects:
     name: psturc
   - kind: User
     name: chmouel
+  - kind: Group
+    name: Build team
+  - kind: Group
+    name: Test team
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole


### PR DESCRIPTION
Sync teams from github org redhat-appstudio as groups in Openshift.

Post merge action:

- [ ] Create secret for connection with github app - `oc create secret generic github-redhat-appstudio --from-literal=appId=190760 --from-file=privateKey=appstudio-group-sync-operator.2022-04-13.private-key.pem`