### PR TITLE
HACBS-228: Add support for boostrapping with rekor

### DIFF
--- a/argo-cd-apps/base/kustomization.yaml
+++ b/argo-cd-apps/base/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
 - spi.yaml
 - e2e-tests.yaml
 - cluster-registration.yaml
+- rekor.yaml
 
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/argo-cd-apps/base/rekor.yaml
+++ b/argo-cd-apps/base/rekor.yaml
@@ -1,0 +1,40 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: rekor
+
+spec:
+  project: default
+  source:
+    path: helm-charts/rekor
+    repoURL: 'https://github.com/sigstore/sigstore-helm-operator'
+    targetRevision: HEAD
+    helm:
+      valueFiles:
+        - values.yaml
+      values: |-
+        server:
+          ingress:
+            hostname: rekor-server.rekor.svc
+            annotations:
+              route.openshift.io/termination: "edge"
+
+  destination:
+    namespace: rekor
+    server: https://kubernetes.default.svc
+
+  syncPolicy:
+    # Comment this out if you want to manually trigger deployments (using the 
+    # Argo CD Web UI or Argo CD CLI), rather than automatically deploying on
+    # every new Git commit to your directory.
+    automated:
+      prune: true
+      selfHeal: true
+
+    syncOptions:
+      - CreateNamespace=true
+
+    retry:
+      limit: 50 # number of failed sync attempt retries; unlimited number of attempts if less than 0
+      backoff:
+        duration: 15s # the amount to back off. Default unit is seconds, but could also be a duration (e.g. "2m", "1h")

--- a/hack/bootstrap-cluster.sh
+++ b/hack/bootstrap-cluster.sh
@@ -116,7 +116,20 @@ echo
 echo "Setting Cluster Mode: ${MODE:-Upstream}"
 case $MODE in
     ""|"upstream")
-        kubectl apply -f $ROOT/argo-cd-apps/app-of-apps/all-applications-staging.yaml ;;
+        kubectl apply -f $ROOT/argo-cd-apps/app-of-apps/all-applications-staging.yaml
+        # Check if we have a tekton-chains namespace, and if so, remove any explicit transparency.url setting
+        # which might be left from running this script with the 'preview' flag to enable the cluster local 
+        # rekor instance. By default, chains will use the publicly accessible sandbox instance hosted by sigstore
+        # of rekor
+        # If, in the future, we're boostrapping to use a Red Hat internal rekor instance instead of the public,
+        # default sandbox instance hosted by sigstore we would want to reconsider this approach.
+        if kubectl get namespace tekton-chains; then
+          # Remove our transparency.url, if present, to ensure we're not using the cluster local rekor 
+          # which is only available in 'preview' mode. 
+          kubectl patch configmap/chains-config -n tekton-chains --type=json --patch '[{"op":"remove","path":"/data/transparency.url"}]'
+          kubectl delete pod -n tekton-chains -l app=tekton-chains-controller
+        fi
+        ;;
     "development")
         $ROOT/hack/development-mode.sh ;;
     "preview")

--- a/hack/chains/config.sh
+++ b/hack/chains/config.sh
@@ -67,7 +67,7 @@ case "$1" in
     ;;
 
   rekor-local )
-    REKOR_SERVER=$(kubectl get ingress -n rekor-server -o yaml|yq e '.items[.spec].spec.rules[.host].host' -)
+    REKOR_SERVER=$(kubectl get ingress -n rekor -o jsonpath='{.items[0].spec.rules[0].host}'
     $0 "transparency.url: \"https://$REKOR_SERVER\"" $2
 
     ;;

--- a/hack/preview.sh
+++ b/hack/preview.sh
@@ -32,6 +32,17 @@ if git rev-parse --verify $PREVIEW_BRANCH; then
 fi
 git checkout -b $PREVIEW_BRANCH
 
+# Set the domain for our rekor deployment. 
+# We add the modified rekor.yaml file and this will get pushed to our preview branch.
+# This shouldn't ever be updated in $MY_GIT_BRANCH.
+# If you know a better way to make this magic happen, contact rnester@redhat.com
+domain=$( kubectl get ingresses.config.openshift.io cluster --template={{.spec.domain}} )
+echo
+echo "Setting rekor server domain to: $domain"
+echo
+sed -i "s/rekor-server.rekor.svc/rekor.$domain/" $ROOT/argo-cd-apps/base/rekor.yaml
+git add $ROOT/argo-cd-apps/base/rekor.yaml && git commit -m "Set domain for rekor"
+
 # reset the default repos in the development directory to be the current git repo
 # this needs to be pushed to your fork to be seen by argocd
 $ROOT/hack/util-set-development-repos.sh $MY_GIT_REPO_URL development $PREVIEW_BRANCH
@@ -79,3 +90,23 @@ git checkout $MY_GIT_BRANCH
 
 #set the local cluster to point to the current git repo and branch and update the path to development
 $ROOT/hack/util-update-app-of-apps.sh $MY_GIT_REPO_URL development $PREVIEW_BRANCH
+
+# Wait to ensure that our rekor deployment is available by hitting the log API endpoint
+echo "Waiting for rekor server."
+while ! curl --fail --insecure --output /dev/null --silent "https://rekor.$domain/api/v1/log"; do
+  echo -n .
+  sleep 3
+done
+
+# Make sure we have a tekton-chains namespace
+echo "Checking to see if tekton-chains namespace exists"
+while ! kubectl get namespace tekton-chains &> /dev/null; do
+  echo -n .
+  sleep 3
+done
+
+echo "Setting chains to use cluster rekor server: https://rekor.$domain"
+kubectl patch configmap/chains-config -n tekton-chains --patch "{\"data\":{\"transparency.url\":\"https://rekor.$domain\"}}" --type=merge 
+# Delete the controller pod for chains to ensure that the configuration change gets picked up.
+echo "Restarting chains controller"
+kubectl delete pod -n tekton-chains -l app=tekton-chains-controller


### PR DESCRIPTION
This commit moves rekor into the bootstrap script. By default the rekor
service is not externally accessible outside the cluster.

When ran with the `preview` flag, the rekor server is configured with a
domain of the cluster in the form of `rekor.<domain>` and the
tekton-chains configmap is patched to use this value as the
`transparency.url` value.

After this PR is merged, executing the `boostrap-cluster.sh` script
again after having ran it with the `preview` flag will return the rekor
instance to not being externally accessible outside of the cluster.

Signed-off-by: Rob Nester <rnester@redhat.com>