### PR TITLE
Create namespaces required by shbose tenant

### DIFF
--- a/components/authentication/tenants/shbose.yaml
+++ b/components/authentication/tenants/shbose.yaml
@@ -1,3 +1,9 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: shbose
+---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -79,6 +85,11 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: gitopsdeployment-manager
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: pdave
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
Without the namespaces, ArgoCD fails to sync the authentication app.

Signed-off-by: Luiz Carvalho <lucarval@redhat.com>