### PR TITLE
Release-ci auth access for Michkov

### DIFF
--- a/components/authentication/release-ci.yaml
+++ b/components/authentication/release-ci.yaml
@@ -1,12 +1,15 @@
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: gitops-service-ci-maintainers
+  name: release-service-ci-maintainers
   namespace: release-service
 subjects:
   - kind: User
     apiGroup: rbac.authorization.k8s.io
     name: scoheb
+  - kind: User
+    apiGroup: rbac.authorization.k8s.io
+    name: Michkov
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/components/authentication/view-release.yaml
+++ b/components/authentication/view-release.yaml
@@ -4,8 +4,8 @@ metadata:
   name: read-release
   namespace: release-service
 subjects:
-  - kind: User
-    name: scoheb
+  - kind: Group
+    name: Release team
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole


### PR DESCRIPTION
To be able to set quay credentials for Pipelines-as-code pipelines