### PR TITLE
Add overlay for e2e.

### DIFF
--- a/.ci/oci-e2e-deployment.sh
+++ b/.ci/oci-e2e-deployment.sh
@@ -99,7 +99,33 @@ createQuayPullSecrets
 
 git remote add ${MY_GIT_FORK_REMOTE} https://github.com/redhat-appstudio-qe/infra-deployments.git
 
-/bin/bash "$WORKSPACE"/hack/bootstrap-cluster.sh preview
+# Install sandbox operators
+/bin/bash "$WORKSPACE"/hack/sandbox-development-mode.sh
+
+# Patch sandbox config to use provided keycloak
+BASE_URL=$(oc get ingresses.config.openshift.io/cluster -o jsonpath={.spec.domain})
+RHSSO_URL="https://keycloak-appstudio-sso.$BASE_URL"
+
+oc patch ToolchainConfig/config -n toolchain-host-operator --type=merge --patch-file=/dev/stdin << EOF
+spec:
+  host:
+    registrationService:
+      auth:
+        authClientConfigRaw: '{
+                  "realm": "testrealm",
+                  "auth-server-url": "$RHSSO_URL/auth",
+                  "ssl-required": "nones",
+                  "resource": "sandbox-public",
+                  "clientId": "sandbox-public",
+                  "public-client": true
+                }'
+        authClientLibraryURL: $RHSSO_URL/auth/js/keycloak.js
+        authClientPublicKeysURL: $RHSSO_URL/auth/realms/testrealm/protocol/openid-connect/certs
+EOF
+
+#Install AppStudio
+/bin/bash "$WORKSPACE"/hack/bootstrap-cluster.sh e2e
+
 
 export -f waitAppStudioToBeReady
 export -f waitBuildToBeReady
@@ -107,6 +133,10 @@ export -f checkHASGithubOrg
 
 timeout --foreground 10m bash -c waitAppStudioToBeReady
 timeout --foreground 10m bash -c waitBuildToBeReady
+
+## Delete reg service deployment to restart it and download certs from keycloak.
+oc delete deployment/registration-service -n toolchain-host-operator
+
 # Just a sleep before starting the tests
 sleep 2m
 timeout --foreground 3m bash -c checkHASGithubOrg

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ See `hack/quicklab/README.md`
 
 ### Bootstrap App Studio
 Steps:
-1) Run `./hack/bootstrap-cluster.sh [$MODE]` which will bootstrap Argo CD (using OpenShift GitOps) and setup the Argo CD `Application` Custom Resources (CRs) for each component. This command will output the Argo CD Web UI route when it's finished. For upstream mode keep the $MODE empty or "upstream". For development mode and preview mode set `$MODE` to `development` or `preview`, the modes are described in section 'Development modes for your own clusters'.
+1) Run `./hack/bootstrap-cluster.sh [$MODE]` which will bootstrap Argo CD (using OpenShift GitOps) and setup the Argo CD `Application` Custom Resources (CRs) for each component. This command will output the Argo CD Web UI route when it's finished. For upstream mode keep the $MODE empty or "upstream". For development mode and preview mode set `$MODE` to `development`, `preview` or `e2e`, the modes are described in section 'Development modes for your own clusters'.
 2) Open the Argo CD Web UI to see the status of your deployments. You can use the route from the previous step and login using your OpenShift credentials (using the 'Login with OpenShift' button), or login to the OpenShift Console and navigate to Argo CD using the OpenShift Gitops menu in the Applications pulldown.
 ![OpenShift Gitops menu with Cluster Argo CD menu option](documentation/images/argo-cd-login.png?raw=true "OpenShift Gitops menu")
 3) If your deployment was successful, you should see several applications running, such as "all-components-staging", "gitops", and so on.
@@ -144,6 +144,7 @@ The script also supports branches automatically. If you work in a checked out br
 There are two workflows for develompent provided:
 1) Development mode - work in the feature branch, apply changes related to your fork, revert the changes when the work is done
 2) Preview mode - work in a feature branch, apply script which creates new preview branch and create additional commit with for customization
+3) e2e mode - Same as `preview` mode, but also installs RHSSO with preconfigured realm to be used with toolchain operators.
 
 ### Development mode
 

--- a/argo-cd-apps/overlays/e2e/kustomization.yaml
+++ b/argo-cd-apps/overlays/e2e/kustomization.yaml
@@ -1,0 +1,10 @@
+resources:
+- ../development
+- rhsso.yaml
+
+namespace: openshift-gitops
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+patchesStrategicMerge:
+  - repo-overlay.yaml

--- a/argo-cd-apps/overlays/e2e/repo-overlay.yaml
+++ b/argo-cd-apps/overlays/e2e/repo-overlay.yaml
@@ -1,0 +1,10 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: appstudio-sso
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  source: # This will be replaced with a reference to your fork of this repo (see hack/patch-apps-for-dev.sh)
+    repoURL: https://github.com/redhat-appstudio/infra-deployments.git
+    targetRevision: main

--- a/argo-cd-apps/overlays/e2e/rhsso.yaml
+++ b/argo-cd-apps/overlays/e2e/rhsso.yaml
@@ -1,0 +1,32 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: appstudio-sso
+
+spec:
+  project: default
+
+  source:
+    path: components/rhsso
+    repoURL: https://github.com/redhat-appstudio/infra-deployments.git
+  destination:
+    namespace: appstudio-sso
+    server: https://kubernetes.default.svc
+
+  syncPolicy:
+    # Comment this out if you want to manually trigger deployments (using the
+    # Argo CD Web UI or Argo CD CLI), rather than automatically deploying on
+    # every new Git commit to your directory.
+    automated:
+      prune: true
+      selfHeal: true
+
+    syncOptions:
+      - CreateNamespace=true
+
+    retry:
+      limit: -1 # number of failed sync attempt retries; unlimited number of attempts if less than 0
+      backoff:
+        duration: 10s # the amount to back off. Default unit is seconds, but could also be a duration (e.g. "2m", "1h")
+        factor: 2 # a factor to multiply the base duration after each failed retry
+        maxDuration: 3m # the maximum amount of time allowed for the backoff strategy

--- a/components/rhsso/keycloak-realm.yaml
+++ b/components/rhsso/keycloak-realm.yaml
@@ -1,0 +1,38 @@
+apiVersion: keycloak.org/v1alpha1
+kind: KeycloakRealm
+metadata:
+  name: testrealm
+  namespace: appstudio-sso
+spec:
+  instanceSelector:
+    matchLabels:
+      app.kubernetes.io/instance: appstudio-sso
+  realm:
+    clients:
+      - enabled: true
+        redirectUris:
+          - '*'
+        clientId: sandbox-public
+        name: sandbox-public
+        implicitFlowEnabled: false
+        publicClient: true
+        standardFlowEnabled: true
+        protocol: openid-connect
+        webOrigins:
+          - '*'
+        directAccessGrantsEnabled: false
+    displayName: Appstudio Realm
+    enabled: true
+    id: rh-sso
+    loginTheme: rh-sso
+    realm: testrealm
+    users:
+      - credentials:
+          - type: password
+            value: user1
+        email: user1@user.us
+        emailVerified: true
+        enabled: true
+        firstName: user1
+        id: user1
+        username: user1

--- a/components/rhsso/keycloak.yaml
+++ b/components/rhsso/keycloak.yaml
@@ -1,0 +1,9 @@
+apiVersion: keycloak.org/v1alpha1
+kind: Keycloak
+metadata:
+  name: appstudio-rhsso
+  namespace: appstudio-sso
+spec:
+  externalAccess:
+    enabled: true
+  instances: 1

--- a/components/rhsso/kustomization.yaml
+++ b/components/rhsso/kustomization.yaml
@@ -1,0 +1,11 @@
+resources:
+ - subscription.yaml
+ - operatorgroup.yaml
+ - keycloak.yaml
+ - keycloak-realm.yaml
+ 
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+commonAnnotations:
+  argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true

--- a/components/rhsso/operatorgroup.yaml
+++ b/components/rhsso/operatorgroup.yaml
@@ -1,0 +1,8 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: keycloak-operatorgroup
+  namespace: appstudio-sso
+spec:
+  targetNamespaces:
+    - appstudio-sso

--- a/components/rhsso/subscription.yaml
+++ b/components/rhsso/subscription.yaml
@@ -1,0 +1,11 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: appstudio-sso
+  namespace: appstudio-sso
+spec:
+  channel: stable
+  name: rhsso-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+  installPlanApproval: Automatic

--- a/hack/bootstrap-cluster.sh
+++ b/hack/bootstrap-cluster.sh
@@ -121,6 +121,8 @@ case $MODE in
         $ROOT/hack/development-mode.sh ;;
     "preview")
         $ROOT/hack/preview.sh ;;
+    "e2e")
+        $ROOT/hack/preview.sh e2e ;;
 esac
 
 ARGO_CD_ROUTE=$(kubectl get \

--- a/hack/preview.sh
+++ b/hack/preview.sh
@@ -2,6 +2,8 @@
 
 ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"/..
 
+OVERLAY=$1
+
 if [ -f $ROOT/hack/preview.env ]; then
     source $ROOT/hack/preview.env
 fi
@@ -36,9 +38,15 @@ git checkout -b $PREVIEW_BRANCH
 # this needs to be pushed to your fork to be seen by argocd
 $ROOT/hack/util-set-development-repos.sh $MY_GIT_REPO_URL development $PREVIEW_BRANCH
 
+
 # set the API server which SPI uses to authenticate users to empty string (by default) so that multi-cluster
 # setup is not needed
 $ROOT/hack/util-set-spi-api-server.sh "$SPI_API_SERVER"
+
+if [ -n "$OVERLAY" ]; then
+    echo "Configuring E2E overlay"
+    $ROOT/hack/util-set-development-repos.sh $MY_GIT_REPO_URL $OVERLAY $PREVIEW_BRANCH
+fi
 
 if [ -n "$MY_GITHUB_ORG" ]; then
     $ROOT/hack/util-set-github-org $MY_GITHUB_ORG
@@ -82,4 +90,4 @@ fi
 git checkout $MY_GIT_BRANCH
 
 #set the local cluster to point to the current git repo and branch and update the path to development
-$ROOT/hack/util-update-app-of-apps.sh $MY_GIT_REPO_URL development $PREVIEW_BRANCH
+$ROOT/hack/util-update-app-of-apps.sh $MY_GIT_REPO_URL $OVERLAY $PREVIEW_BRANCH


### PR DESCRIPTION
This PR adds new deployment mode - `e2e`. This mode is exactly the same as `preview`, but it also installs RHSSO with preconfigured realm to be used by toolchain operators instead of sso.redhat.com.

This PR also adds installation of toolchain operators in CI scripts & their configuration (to use the RHSSO installed by gitops on the same cluster).


Possible future work would be to run the tests using users from the keycloak realm (ideally through toolchain proxy) (currently we are running everything with kubeadmin).