### PR TITLE
Use upstream patched version of chains

### DIFF
--- a/components/build/tekton-chains/chains-controller-deployment.yaml
+++ b/components/build/tekton-chains/chains-controller-deployment.yaml
@@ -8,7 +8,12 @@ spec:
     spec:
       containers:
       - name: tekton-chains-controller
-        image: ghcr.io/hacbs-contract/chains/controller:cd2d8c2c9fea3902248dd811913e7ea4fa73d639
+        # Use a nightly-build image because the current latest version, 0.8.0, contains
+        # several bugs that make Chains unusable for our use case. Once version 0.9.0
+        # is published, change this reference to that. Contract team fork may be useful
+        # in future for testing features not yet upstream:
+        # image: ghcr.io/hacbs-contract/chains/controller@sha256...
+        image: gcr.io/tekton-nightly/github.com/tektoncd/chains/cmd/controller@sha256:9b4bef2e9d617dddfc0243b78db2ce8b0f176460bc408bd28e5b31cba79bdece
         volumeMounts:
         - mountPath: /etc/ssl/certs
           name: chains-ca-cert


### PR DESCRIPTION
Use a nightly-build image because the current latest version, 0.8.0,
contains several bugs that make Chains unusable for our use case. Once
version 0.9.0 is published, change this reference to that.

Signed-off-by: Luiz Carvalho <lucarval@redhat.com>