### PR TITLE
Bash script to copy the chains public sig key

### DIFF
--- a/hack/chains/copy-public-sig-key.sh
+++ b/hack/chains/copy-public-sig-key.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+#
+# Create a secret in your current namespace containing the chains
+# signing secret's public key.
+#
+# This means it can be accessible for use in tasks without requiring
+# permission to the full (protected) signing secret which includes
+# the private key.
+#
+# It's assumed you have access to the tekton-chains signing-secret
+# when you run this.
+#
+set -euo pipefail
+oc -n tekton-chains get secret signing-secrets -o json | jq '.data."cosign.pub" | @base64d' -r > cosign.pub
+oc create secret generic cosign-public-key --from-file=cosign.pub --dry-run=client -o yaml | oc apply -f-

--- a/hack/chains/create-signing-secret.sh
+++ b/hack/chains/create-signing-secret.sh
@@ -14,10 +14,6 @@
 SIG_KEY_DATA=$(kubectl get secret signing-secrets -n tekton-chains -o jsonpath='{.data}')
 [[ -n $SIG_KEY_DATA ]] && echo "Signing secret exists." && exit
 
-# Ensure the cosign.pub key file ends up in a consistent place, i.e. the
-# top level directory of this git repo
-cd "$( git rev-parse --show-toplevel )"
-
 # To make this run conveniently without user input let's create a random password
 RANDOM_PASS=$( head -c 12 /dev/urandom | base64 )
 

--- a/hack/chains/release-pipeline-with-ec-demo.sh
+++ b/hack/chains/release-pipeline-with-ec-demo.sh
@@ -105,7 +105,7 @@ spec:
 
 " | oc apply -f - > /dev/null
 
-oc get pipeline simple-release -o yaml | yq e '.spec'
+oc get pipeline simple-release -o yaml | yq e '.spec' -
 
 
 title "Verify Push Secret"

--- a/hack/chains/release-pipeline-with-ec-demo.sh
+++ b/hack/chains/release-pipeline-with-ec-demo.sh
@@ -12,8 +12,7 @@
 #
 #   2. Create a Secret named "cosign-public-key" with the "cosign.pub" attribute to house the
 #      public key to be used for verifying the signature of the image and its attestation:
-#      oc -n tekton-chains get secret signing-secrets -o json | jq '.data."cosign.pub" | @base64d' -r > cosign.pub
-#      oc create secret generic cosign-public-key --from-file=cosign.pub
+#      ./copy-public-sig-key.sh
 #
 #
 # Usage:


### PR DESCRIPTION
It copies it to a secret in your current project/namespace so it can
be used conveniently without requiring access to the secret in
tekton-chains which includes the protected secret key.

Inspired by:
https://github.com/redhat-appstudio/build-definitions/pull/56
https://github.com/redhat-appstudio/infra-deployments/pull/293