### PR TITLE
Temporarily enable debug in gitops-service-argocd namespace

### DIFF
--- a/components/gitops/staging/argo-cd.yaml
+++ b/components/gitops/staging/argo-cd.yaml
@@ -1,0 +1,110 @@
+apiVersion: argoproj.io/v1alpha1
+kind: ArgoCD
+metadata:
+  finalizers:
+  - argoproj.io/finalizer
+  name: gitops-service-argocd
+  namespace: gitops-service-argocd
+spec:
+  applicationSet:
+    resources:
+      limits:
+        cpu: "1"
+        memory: 1Gi
+      requests:
+        cpu: 250m
+        memory: 128Mi
+  controller:
+    logLevel: "debug"
+    processors: {}
+    resources:
+      limits:
+        cpu: "1"
+        memory: 1Gi
+      requests:
+        cpu: 250m
+        memory: 256Mi
+    sharding: {}
+#  dex:
+#    enabled: false
+#    openShiftOAuth: false # true
+#    resources:
+#      limits:
+#        cpu: 500m
+#        memory: 256Mi
+#      requests:
+#        cpu: 250m
+#        memory: 128Mi
+  grafana:
+    enabled: false
+    ingress:
+      enabled: false
+    resources:
+      limits:
+        cpu: 500m
+        memory: 256Mi
+      requests:
+        cpu: 250m
+        memory: 128Mi
+    route:
+      enabled: false
+  ha:
+    enabled: false
+    resources:
+      limits:
+        cpu: 500m
+        memory: 256Mi
+      requests:
+        cpu: 250m
+        memory: 128Mi
+  initialSSHKnownHosts: {}
+  prometheus:
+    enabled: false
+    ingress:
+      enabled: false
+    route:
+      enabled: false
+  rbac:
+    policy: g, system:authenticated, role:admin
+    scopes: '[groups]'
+  redis:
+    resources:
+      limits:
+        cpu: 500m
+        memory: 256Mi
+      requests:
+        cpu: 250m
+        memory: 128Mi
+  repo:
+    logLevel: "debug"
+    resources:
+      limits:
+        cpu: "1"
+        memory: 1Gi
+      requests:
+        cpu: 250m
+        memory: 256Mi
+  server:
+    logLevel: "debug"
+    autoscale:
+      enabled: false
+    grpc:
+      ingress:
+        enabled: false
+    ingress:
+      enabled: false
+    resources:
+      limits:
+        cpu: 500m
+        memory: 256Mi
+      requests:
+        cpu: 125m
+        memory: 128Mi
+    route:
+      enabled: true
+      tls:
+        termination: reencrypt
+    service:
+      type: ""
+  tls:
+    ca: {}

--- a/components/gitops/staging/kustomization.yaml
+++ b/components/gitops/staging/kustomization.yaml
@@ -4,7 +4,8 @@ resources:
 - allow-argocd-to-manage.yaml
 - https://raw.githubusercontent.com/redhat-appstudio/managed-gitops/8c72ce9bc207c389e260a2808514083accbe42cf/manifests/appstudio-controller-rbac/appstudio-controller-rbac.yaml
 - https://raw.githubusercontent.com/redhat-appstudio/managed-gitops/8c72ce9bc207c389e260a2808514083accbe42cf/manifests/staging-cluster-resources/argo-cd-namespace.yaml
-- https://raw.githubusercontent.com/redhat-appstudio/managed-gitops/8c72ce9bc207c389e260a2808514083accbe42cf/manifests/staging-cluster-resources/argo-cd.yaml
+#- https://raw.githubusercontent.com/redhat-appstudio/managed-gitops/8c72ce9bc207c389e260a2808514083accbe42cf/manifests/staging-cluster-resources/argo-cd.yaml
+- argo-cd.yaml
 - dbschema-config-map.yaml
 - https://raw.githubusercontent.com/redhat-appstudio/managed-gitops/8c72ce9bc207c389e260a2808514083accbe42cf/manifests/database-init/job.yaml
 - https://raw.githubusercontent.com/redhat-appstudio/managed-gitops/8c72ce9bc207c389e260a2808514083accbe42cf/manifests/managed-gitops-appstudio-controller-deployment.yaml


### PR DESCRIPTION
This PR temporarily disables the `ArgoCD` resource in `gitops-service-argocd` namespace from our service repo, switching to a version with `logLevel: "debug"` enabled on the repo server, application controller, and API server. The contents is otherwise unchanged.