### PR TITLE
Add a resource allow-list to gitops-service-argocd namespace

### DIFF
--- a/components/gitops/staging/argo-cd.yaml
+++ b/components/gitops/staging/argo-cd.yaml
@@ -6,6 +6,57 @@ metadata:
   name: gitops-service-argocd
   namespace: gitops-service-argocd
 spec:
+
+  resourceInclusions: |
+    - apiGroups:
+      - ""
+      kinds:
+      - "PersistentVolumeClaim"
+      - "PersistentVolume"
+      - "Secret"
+      - "ConfigMap"
+      - "Pod"
+      - "Endpoint"
+      - "Service"
+      - "ServiceAccounts"
+      clusters:
+      - "*"
+    - apiGroups:
+      - "apps"
+      kinds:
+      - "ReplicaSet"
+      - "StatefulSet"
+      - "DaemonSet"
+      - "Deployment"
+      clusters:
+      - "*"
+    - apiGroups:
+      - "discovery.k8s.io"
+      kinds:
+      - "EndpointSlice"
+      clusters:
+      - "*"
+    - apiGroups:
+      - "networking.k8s.io"
+      kinds:
+      - "Ingress"
+      - "IngressClass"
+      clusters:
+      - "*"
+    - apiGroups:
+      - "rbac.authorization.k8s.io"
+      kinds:
+      - "RoleBinding"
+      - "Role"
+      clusters:
+      - "*"
+    - apiGroups:
+      - "route.openshift.io"
+      kinds:
+      - "Route"
+      clusters:
+      - "*"
+
   applicationSet:
     resources:
       limits:


### PR DESCRIPTION
This PR:
- With the current configuration of the Argo CD instance on `gitops-service-argocd` namespace, Argo CD will register thousands of watches (one for each namespace with the `argocd.argoproj.io/managed-by: gitops-service-argocd` label) to the cluster.
- Argo CD registers a watch for each API resource, per namespace.
- Since OpenShift clusters have 250+ API resources, and there are 50+ user namespaces on the cluster, this is a lot of watches.
- This PR switches the Argo CD instance in the `gitops-service-argocd` namespace to a resource allow list, which should significantly reduce the number of watches.