### PR TITLE
Update GitOps Service to latest commit: 7e142808ef95f386f389348f39cef64a70ff670a

### DIFF
--- a/components/gitops/staging/kustomization.yaml
+++ b/components/gitops/staging/kustomization.yaml
@@ -40,7 +40,7 @@ resources:
 images:
   - name: \${COMMON_IMAGE}
     newName: quay.io/redhat-appstudio/gitops-service
-    newTag: 8388a0c91108fe0e4d8c66027655cc8a8da47895
+    newTag: 7e142808ef95f386f389348f39cef64a70ff670a
 
 # Replace ${ARGO_CD_NAMESPACE}
 patches:


### PR DESCRIPTION
This PR:
- Updates the common GitOps Service image to pull in the fix from https://github.com/redhat-appstudio/managed-gitops/pull/112