### PR TITLE
allow overriding build-service config

### DIFF
--- a/hack/preview-template.env
+++ b/hack/preview-template.env
@@ -11,9 +11,14 @@ export MY_GIT_FORK_REMOTE=
 export MY_GITHUB_ORG=
 ### Personal API token with repo and delete_repo permission
 export MY_GITHUB_TOKEN=
-### Change of the image
+### Override Application service image
 export HAS_IMAGE_REPO=
 export HAS_IMAGE_TAG=
+### Override Build service image
+export BUILD_SERVICE_IMAGE_REPO=
+export BUILD_SERVICE_IMAGE_TAG=
+export BUILD_SERVICE_PR_OWNER=
+export BUILD_SERVICE_PR_SHA=
 
 ## Release service
 ### Change of the image

--- a/hack/preview.sh
+++ b/hack/preview.sh
@@ -80,6 +80,9 @@ if [ -n "$DOCKER_IO_AUTH" ]; then
     rm $AUTH
 fi
 
+[ -n "${BUILD_SERVICE_IMAGE_REPO}" ] && yq -i e "(.images.[] | select(.name==\"quay.io/redhat-appstudio/build-service\")) |=.newName=\"${BUILD_SERVICE_IMAGE_REPO}\"" $ROOT/components/build/build-service/kustomization.yaml
+[ -n "${BUILD_SERVICE_IMAGE_TAG}" ] && yq -i e "(.images.[] | select(.name==\"quay.io/redhat-appstudio/build-service\")) |=.newTag=\"${BUILD_SERVICE_IMAGE_TAG}\"" $ROOT/components/build/build-service/kustomization.yaml
+[[ -n "${BUILD_SERVICE_PR_OWNER}" && "${BUILD_SERVICE_PR_SHA}" ]] && yq -i e "(.resources[] | select(. ==\"*github.com/redhat-appstudio/build-service*\")) |= \"https://github.com/${BUILD_SERVICE_PR_OWNER}/build-service/config/default?ref=${BUILD_SERVICE_PR_SHA}\"" $ROOT/components/build/build-service/kustomization.yaml
 [ -n "${HAS_IMAGE_REPO}" ] && yq -i e "(.images.[] | select(.name==\"quay.io/redhat-appstudio/application-service\")) |=.newName=\"${HAS_IMAGE_REPO}\"" $ROOT/components/has/kustomization.yaml
 [ -n "${HAS_IMAGE_TAG}" ] && yq -i e "(.images.[] | select(.name==\"quay.io/redhat-appstudio/application-service\")) |=.newTag=\"${HAS_IMAGE_TAG}\"" $ROOT/components/has/kustomization.yaml
 [ -n "${RELEASE_IMAGE_REPO}" ] && yq -i e "(.images.[] | select(.name==\"quay.io/redhat-appstudio/release-service\")) |=.newName=\"${RELEASE_IMAGE_REPO}\"" $ROOT/components/release/kustomization.yaml


### PR DESCRIPTION
### JIRA
https://issues.redhat.com/browse/PLNSRVCE-185

### What
We need to be able to bootstrap a cluster with a specific version/commit of `build-service` in openshift-ci in order to run e2e tests against it (on a PR basis).

### Verification steps
After running this, you should have a custom image (`quay.io/psturc/build-service:[PLNSRVCE-185](https://issues.redhat.com//browse/PLNSRVCE-185)`) of `build-service` deployed on a cluster
```bash
export MY_GIT_FORK_REMOTE=<REPLACE-ME> MY_GITHUB_ORG=<REPLACE-ME> MY_GITHUB_TOKEN=<REPLACE-ME> BUILD_SERVICE_IMAGE_REPO=quay.io/psturc/build-service BUILD_SERVICE_IMAGE_TAG=PLNSRVCE-185 BUILD_SERVICE_PR_OWNER=psturc BUILD_SERVICE_PR_SHA=f372978f986771304d8b89b4078abdfcf3c5655e
./hack/bootstrap-cluster.sh preview
```
Verified:
```bash
➜  infra-deployments git:(PLNSRVCE-185) oc get pods -n build-service -o yaml | grep "quay.io/psturc"
      image: quay.io/psturc/build-service:PLNSRVCE-185
      image: quay.io/psturc/build-service:PLNSRVCE-185
      imageID: quay.io/psturc/build-service@sha256:e53c758fa1f7be9a0694658bef07fd768cca8852e1c70c8e07f61ad3ea53683d
```
See [this updated kustomize config](https://github.com/psturc/infra-deployments/commit/29d8e3a2e93b285d3e3ad00571387d1523c88631#diff-5c93bf47073dc33e77c2f62d49686f096901505d3c52a8f28c7c44457b07ed8c) after I ran the bootstrap script locally
