### PR TITLE
EnterpriseContractPolicy CRD

### DIFF
--- a/argo-cd-apps/base/enterprise-contract.yaml
+++ b/argo-cd-apps/base/enterprise-contract.yaml
@@ -44,3 +44,32 @@ spec:
       limit: 50 # number of failed sync attempt retries; unlimited number of attempts if less than 0
       backoff:
         duration: 15s # the amount to back off. Default unit is seconds, but could also be a duration (e.g. "2m", "1h")
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: enterprise-contract
+
+spec:
+  project: default
+
+  source:
+    path: components/enterprise-contract
+    repoURL: https://github.com/redhat-appstudio/infra-deployments.git
+
+  destination:
+    server: https://kubernetes.default.svc
+
+  syncPolicy:
+
+    # Comment this out if you want to manually trigger deployments (using the
+    # Argo CD Web UI or Argo CD CLI), rather than automatically deploying on
+    # every new Git commit to your directory.
+    automated:
+      prune: true
+      selfHeal: true
+
+    retry:
+      limit: 50 # number of failed sync attempt retries; unlimited number of attempts if less than 0
+      backoff:
+        duration: 15s # the amount to back off. Default unit is seconds, but could also be a duration (e.g. "2m", "1h")

--- a/argo-cd-apps/overlays/development/repo-overlay.yaml
+++ b/argo-cd-apps/overlays/development/repo-overlay.yaml
@@ -85,3 +85,14 @@ spec:
   source:
     repoURL: https://github.com/redhat-appstudio/infra-deployments.git
     targetRevision: main
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: enterprise-contract
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  source:
+    repoURL: https://github.com/redhat-appstudio/infra-deployments.git
+    targetRevision: main

--- a/components/enterprise-contract/kustomization.yaml
+++ b/components/enterprise-contract/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- https://github.com/hacbs-contract/enterprise-contract-controller/config/crd?ref=69e8c88a50c471acca37a7eff68e9d129dad08e6


### PR DESCRIPTION
Cretes the EnterpriseContractPolicy CRD from the enterprise-contract-controller[1] repository.

Ref. https://issues.redhat.com/browse/HACBS-244

[1] https://github.com/hacbs-contract/enterprise-contract-controller