### PR TITLE
Install `skopeo-copy` task in the e2e demo

### DIFF
--- a/hack/chains/end-to-end-demo.sh
+++ b/hack/chains/end-to-end-demo.sh
@@ -137,4 +137,8 @@ kubectl create configmap ec-policy --from-file=policy.json=<(echo '{"non_blockin
 "${HACK_CHAINS_DIR}/copy-public-sig-key.sh"
 TASK_BUNDLE=quay.io/redhat-appstudio/appstudio-tasks:$(git ls-remote --heads https://github.com/redhat-appstudio/build-definitions.git refs/heads/main|cut -f 1)-2
 export TASK_BUNDLE
+
+# install skopeo-copy task if it's missing
+tkn task describe skopeo-copy >/dev/null 2>&1  || tkn hub install task skopeo-copy
+
 "${HACK_CHAINS_DIR}/release-pipeline-with-ec-demo.sh" "${BUILD_OUTPUT_IMAGE_REF}" "${RELEASE_OUTPUT_IMAGE_REF}"

--- a/hack/chains/release-pipeline-with-ec-demo.sh
+++ b/hack/chains/release-pipeline-with-ec-demo.sh
@@ -104,7 +104,6 @@ spec:
   - name: release
     taskRef:
       name: skopeo-copy
-      kind: ClusterTask
     params:
     - name: srcImageURL
       value: docker://\$(params.SRC_IMAGE_REF)


### PR DESCRIPTION
Seems that the `skopeo-copy` cluster task is no longer available. Or that is, none of the cluster tasks are available. This installs it via the Tekton Hub if it's not already present and switches to using the non-cluster task in the `release-pipeline-with-ec-demo.sh`.