### PR TITLE
Wait for the pipeline service account in e2e demo

### DIFF
--- a/hack/chains/end-to-end-demo.sh
+++ b/hack/chains/end-to-end-demo.sh
@@ -87,6 +87,10 @@ echo "Here is the OpenShift console with the project:
 👉 $(oc whoami --show-console)/k8s/cluster/projects/demo
 "
 
+# wait for the pipeline service account to be created by the Tekton operator
+echo '⏳ Waiting for the pipeline service account to be created'
+while ! kubectl get serviceaccount pipeline > /dev/null 2>&1; do sleep 1; done
+
 echo "♾️ Setting up pipelines
 "
 kubectl apply -k "${BUILD_DEFINITIONS_DIR}/hack/test-build"


### PR DESCRIPTION
If the pipeline service account has not yet been created the `hach/chains/end-to-end-demo.sh` script will fail if it tries to link the `release-demo` Docker pull secret to it. This adds loop to wait until it has been created by the Tekton operator before proceeding with the demo.