### PR TITLE
PLNSRVCE-248: create shared secret redhat-appstudio-user-workload

### DIFF
--- a/components/build/shared-resources/add-user-workload-shared-secret-scc-clusterrole.yaml
+++ b/components/build/shared-resources/add-user-workload-shared-secret-scc-clusterrole.yaml
@@ -1,0 +1,23 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: add-user-workload-shared-secret-scc-clusterrole
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+rules:
+  - apiGroups:
+      - sharedresource.openshift.io
+    resources:
+      - sharedsecrets
+    resourceNames:
+      - redhat-appstudio-user-workload
+    verbs:
+      - use
+  - verbs:
+      - use
+    apiGroups:
+      - security.openshift.io
+    resources:
+      - securitycontextconstraints
+    resourceNames:
+      - csi-scc

--- a/components/build/shared-resources/kustomization.yaml
+++ b/components/build/shared-resources/kustomization.yaml
@@ -18,6 +18,8 @@ resources:
 - shared-resources-components.yaml
 - redhat-appstudio-staginguser-secret.yaml
 - infra-deployments-pr-creator.yaml
+- redhat-appstudio-user-workload-sharedsecret.yaml
+- add-user-workload-shared-secret-scc-clusterrole.yaml
 
 images:
 - name: \${NODE_DRIVER_REGISTRAR_IMAGE}

--- a/components/build/shared-resources/redhat-appstudio-user-workload-sharedsecret.yaml
+++ b/components/build/shared-resources/redhat-appstudio-user-workload-sharedsecret.yaml
@@ -1,0 +1,8 @@
+apiVersion: sharedresource.openshift.io/v1alpha1
+kind: SharedSecret
+metadata:
+  name: redhat-appstudio-user-workload
+spec:
+  secretRef:
+    name: redhat-appstudio-user-workload
+    namespace: build-templates


### PR DESCRIPTION
Let's see if I correctly interpreted your instructions @Michkov 

Running `export MODE=preview; ./hack/bootstrap-cluster.sh $MODE`, after that completes, I got the following:

```
gmontero ~/go/src/github.com/redhat-appstudio/infra-deployments  (jira-plnsrvce-248)$ oc get sharedsecret
NAME                             AGE
redhat-appstudio-staginguser     0s
redhat-appstudio-user-workload   0s
gmontero ~/go/src/github.com/redhat-appstudio/infra-deployments  (jira-plnsrvce-248)$ oc get clusterrole pipelines-scc-clusterrole -o yaml 
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRole
metadata:
  annotations:
    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"rbac.authorization.k8s.io/v1","kind":"ClusterRole","metadata":{"annotations":{"argocd.argoproj.io/sync-options":"SkipDryRunOnMissingResource=true"},"labels":{"app.kubernetes.io/instance":"build"},"name":"pipelines-scc-clusterrole"},"rules":[{"apiGroups":["security.openshift.io"],"resourceNames":["pipelines-scc"],"resources":["securitycontextconstraints"],"verbs":["use"]},{"apiGroups":["sharedresource.openshift.io"],"resourceNames":["redhat-appstudio-user-workload"],"resources":["sharedsecrets"],"verbs":["use"]},{"apiGroups":["security.openshift.io"],"resourceNames":["csi-scc"],"resources":["securitycontextconstraints"],"verbs":["use"]}]}
  creationTimestamp: "2022-05-10T16:39:31Z"
  labels:
    app.kubernetes.io/instance: build
  name: pipelines-scc-clusterrole
  ownerReferences:
  - apiVersion: operator.tekton.dev/v1alpha1
    blockOwnerDeletion: true
    controller: true
    kind: TektonInstallerSet
    name: rhosp-rbac-glsz9
    uid: 70e75267-7fc3-459e-b945-26c93beccdfe
  resourceVersion: "185568"
  uid: 807fc56d-fdfd-47da-b065-70092057efd0
rules:
- apiGroups:
  - security.openshift.io
  resourceNames:
  - pipelines-scc
  resources:
  - securitycontextconstraints
  verbs:
  - use
- apiGroups:
  - sharedresource.openshift.io
  resourceNames:
  - redhat-appstudio-user-workload
  resources:
  - sharedsecrets
  verbs:
  - use
- apiGroups:
  - security.openshift.io
  resourceNames:
  - csi-scc
  resources:
  - securitycontextconstraints
  verbs:
  - use
gmontero ~/go/src/github.com/redhat-appstudio/infra-deployments  (jira-plnsrvce-248)$
```