### PR TITLE
PLNSRVCE-255 - Create sharedSecret for infra-deployments-update task

### DIFF
--- a/components/build/shared-resources/infra-deployments-pr-creator.yaml
+++ b/components/build/shared-resources/infra-deployments-pr-creator.yaml
@@ -1,0 +1,8 @@
+apiVersion: sharedresource.openshift.io/v1alpha1
+kind: SharedSecret
+metadata:
+  name: infra-deployments-pr-creator
+spec:
+  secretRef:
+    name: infra-deployments-pr-creator
+    namespace: build-templates

--- a/components/build/shared-resources/kustomization.yaml
+++ b/components/build/shared-resources/kustomization.yaml
@@ -17,6 +17,7 @@ resources:
 - scc.yaml
 - shared-resources-components.yaml
 - redhat-appstudio-staginguser-secret.yaml
+- infra-deployments-pr-creator.yaml
 
 images:
 - name: \${NODE_DRIVER_REGISTRAR_IMAGE}

--- a/components/build/shared-resources/shared-resources-components.yaml
+++ b/components/build/shared-resources/shared-resources-components.yaml
@@ -10,6 +10,7 @@ rules:
       - sharedsecrets
     resourceNames:
       - redhat-appstudio-staginguser
+      - infra-deployments-pr-creator
     verbs:
       - use 
   - verbs:


### PR DESCRIPTION
SharedSecret for update-infra-deployments task in build-definitions.
Secret shared with AppStudio/HABCS services to be used for creating PR
in infra-deployments based on merged PR in service repository.