### PR TITLE
Add PaC for e2e-tests

### DIFF
--- a/components/build/shared-resources/shared-resources-components.yaml
+++ b/components/build/shared-resources/shared-resources-components.yaml
@@ -52,3 +52,6 @@ subjects:
   - kind: ServiceAccount
     name: pipeline
     namespace: release-service
+  - kind: ServiceAccount
+    name: pipeline
+    namespace: e2e-tests

--- a/components/e2e-tests/.tekton/kustomization.yaml
+++ b/components/e2e-tests/.tekton/kustomization.yaml
@@ -1,6 +1,7 @@
 resources:
   - event-listener.yaml
   - pvc.yaml
+  - pipelines-as-code.yaml
   - serviceaccount.yaml
   - trigger-template.yaml
   - webhook-route.yaml

--- a/components/e2e-tests/.tekton/pipelines-as-code.yaml
+++ b/components/e2e-tests/.tekton/pipelines-as-code.yaml
@@ -1,0 +1,7 @@
+apiVersion: pipelinesascode.tekton.dev/v1alpha1
+kind: Repository
+metadata:
+  name: e2e-tests-pac
+
+spec:
+  url: "https://github.com/redhat-appstudio/e2e-tests"


### PR DESCRIPTION
Tekton is adopted as a primary CI and CD ( images builds ) for e2e-tests