### PR TITLE
View access for build-templates for the EC team

### DIFF
--- a/components/authentication/view-build-service.yaml
+++ b/components/authentication/view-build-service.yaml
@@ -40,6 +40,8 @@ subjects:
     name: Build team
   - kind: Group
     name: Test team
+  - kind: Group
+    name: Enterprise Contract
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole


### PR DESCRIPTION
This binds the view cluster role to the members of the `Enterprise Contract` GitHub Team on the `build-templates` namespace. We need this to be able to view the Tekton TaskRuns/PipelineRuns and logs run for the https://github.com/redhat-appstudio/build-definitions repository.