### PR TITLE
SPI OAuth service update v0.5.5

### DIFF
--- a/components/spi/kustomization.yaml
+++ b/components/spi/kustomization.yaml
@@ -18,8 +18,8 @@ images:
     newTag: sha-bcb63b7
   - name: quay.io/redhat-appstudio/service-provider-integration-oauth
     newName: quay.io/redhat-appstudio/service-provider-integration-oauth
-    # 0.5.4
-    newTag: sha-0099de8
+    # 0.5.5
+    newTag: sha-fbbfcdc
   - name: quay.io/redhat-appstudio/service-provider-integration-scm-file-retriever-server
     newName:  quay.io/redhat-appstudio/service-provider-integration-scm-file-retriever-server
     # 0.5.2.1


### PR DESCRIPTION
Add session cookie configuration SameSite=None and Secure=true 
  https://github.com/redhat-appstudio/service-provider-integration-oauth/pull/92
Context https://issues.redhat.com/projects/SVPI/issues/SVPI-113 [HAC-dev] no active oauth flow found for the state key