### PR TITLE
view RoleBinding for enterprise-contract-service

### DIFF
--- a/components/authentication/view-build-service.yaml
+++ b/components/authentication/view-build-service.yaml
@@ -195,3 +195,16 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: view
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: read-enterprise-contract-service
+  namespace: enterprise-contract-service
+subjects:
+  - kind: Group
+    name: Enterprise Contract
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: view


### PR DESCRIPTION
Adds view RoleBinding for the enterprise-contract-service namespace and initially adds the Enterprise Contract group subject.