### PR TITLE
SPI OAuth service update v0.5.6

### DIFF
--- a/components/spi/kustomization.yaml
+++ b/components/spi/kustomization.yaml
@@ -18,8 +18,8 @@ images:
     newTag: sha-bcb63b7
   - name: quay.io/redhat-appstudio/service-provider-integration-oauth
     newName: quay.io/redhat-appstudio/service-provider-integration-oauth
-    # 0.5.5
-    newTag: sha-fbbfcdc
+    # 0.5.6
+    newTag: sha-bc6979a
   - name: quay.io/redhat-appstudio/service-provider-integration-scm-file-retriever-server
     newName:  quay.io/redhat-appstudio/service-provider-integration-scm-file-retriever-server
     # 0.5.2.1


### PR DESCRIPTION
Fixes for https://issues.redhat.com/browse/SVPI-113 [HAC-dev] no active oauth flow found for the state key  

- Alternative way to provide a k8s token as query parameter https://github.com/redhat-appstudio/service-provider-integration-oauth/pull/97