### PR TITLE
Override DEFAULT_PERSISTENT_VOLUME_CLAIM value

### DIFF
--- a/components/release/kustomization.yaml
+++ b/components/release/kustomization.yaml
@@ -13,6 +13,12 @@ images:
   newName: quay.io/redhat-appstudio/release-service
   newTag: be28c1b371f18a2d18215df3719c997de6ab3a4f
 
+configMapGenerator:
+- literals:
+  - DEFAULT_PERSISTENT_VOLUME_CLAIM="app-studio-default-workspace"
+  name: manager-properties
+  behavior: replace
+
 namespace: release-service
 
 patches:


### PR DESCRIPTION
The release operator will create PipelineRuns with a workspace. This variable contains the claim to use for that workspace. Another variable, DEFAULT_WORKSPACE_NAME controls the name of the default workspace. This variable is populated by the controller if not overridden here.

In case of DEFAULT_PERSISTENT_VOLUME_CLAIM not being overridden, the workspace will be not created.

Signed-off-by: David Moreno García <damoreno@redhat.com>