### PR TITLE
Latest SPI update v0.5.x

### DIFF
--- a/components/spi/kustomization.yaml
+++ b/components/spi/kustomization.yaml
@@ -18,7 +18,7 @@ images:
     newTag: sha-1b2b37e
   - name: quay.io/redhat-appstudio/service-provider-integration-oauth
     newName: quay.io/redhat-appstudio/service-provider-integration-oauth
-    # 0.5.7
+    # 0.5.7 
     newTag: sha-ea157da
   - name: quay.io/redhat-appstudio/service-provider-integration-scm-file-retriever-server
     newName:  quay.io/redhat-appstudio/service-provider-integration-scm-file-retriever-server

--- a/components/spi/kustomization.yaml
+++ b/components/spi/kustomization.yaml
@@ -14,12 +14,12 @@ kind: Kustomization
 images:
   - name:  quay.io/redhat-appstudio/service-provider-integration-operator
     newName: quay.io/redhat-appstudio/service-provider-integration-operator
-    # 0.5.4
-    newTag: sha-7abc780
+    # 0.5.5
+    newTag: sha-1b2b37e
   - name: quay.io/redhat-appstudio/service-provider-integration-oauth
     newName: quay.io/redhat-appstudio/service-provider-integration-oauth
-    # 0.5.6
-    newTag: sha-bc6979a
+    # 0.5.7
+    newTag: sha-ea157da
   - name: quay.io/redhat-appstudio/service-provider-integration-scm-file-retriever-server
     newName:  quay.io/redhat-appstudio/service-provider-integration-scm-file-retriever-server
     # 0.5.2.1


### PR DESCRIPTION
Include :
 - Split single Github graphql request into two https://github.com/redhat-appstudio/service-provider-integration-operator/pull/140
 - Token matching for Quay https://github.com/redhat-appstudio/service-provider-integration-operator/pull/128
 - Use UBI as our base image  https://github.com/redhat-appstudio/service-provider-integration-operator/pull/138
 - Change the base image to the latest ubi-minimal  https://github.com/redhat-appstudio/service-provider-integration-oauth/pull/99