### PR TITLE
add option to override HAS default image push repo

### DIFF
--- a/components/has/manager_resources_patch.yaml
+++ b/components/has/manager_resources_patch.yaml
@@ -15,4 +15,7 @@ spec:
           requests:
             cpu: 100m
             memory: 20Mi
+        env:
+          - name: IMAGE_REPOSITORY
+            value: ""
 

--- a/hack/preview-template.env
+++ b/hack/preview-template.env
@@ -11,6 +11,8 @@ export MY_GIT_FORK_REMOTE=
 export MY_GITHUB_ORG=
 ### Personal API token with repo and delete_repo permission
 export MY_GITHUB_TOKEN=
+### Override default Application service "image push" repository
+export HAS_DEFAULT_IMAGE_REPOSITORY=
 ### Override Application service image
 export HAS_IMAGE_REPO=
 export HAS_IMAGE_TAG=

--- a/hack/preview.sh
+++ b/hack/preview.sh
@@ -89,6 +89,7 @@ fi
 [ -n "${HAS_IMAGE_REPO}" ] && yq -i e "(.images.[] | select(.name==\"quay.io/redhat-appstudio/application-service\")) |=.newName=\"${HAS_IMAGE_REPO}\"" $ROOT/components/has/kustomization.yaml
 [ -n "${HAS_IMAGE_TAG}" ] && yq -i e "(.images.[] | select(.name==\"quay.io/redhat-appstudio/application-service\")) |=.newTag=\"${HAS_IMAGE_TAG}\"" $ROOT/components/has/kustomization.yaml
 [[ -n "${HAS_PR_OWNER}" && "${HAS_PR_SHA}" ]] && yq -i e "(.resources[] | select(. ==\"*github.com/redhat-appstudio/application-service*\")) |= \"https://github.com/${HAS_PR_OWNER}/application-service/config/default?ref=${HAS_PR_SHA}\"" $ROOT/components/has/kustomization.yaml
+[ -n "${HAS_DEFAULT_IMAGE_REPOSITORY}" ] && yq -i e "(.spec.template.spec.containers[].env[] | select(.name ==\"IMAGE_REPOSITORY\").value) |= \"${HAS_DEFAULT_IMAGE_REPOSITORY}\"" $ROOT/components/has/manager_resources_patch.yaml
 [ -n "${RELEASE_IMAGE_REPO}" ] && yq -i e "(.images.[] | select(.name==\"quay.io/redhat-appstudio/release-service\")) |=.newName=\"${RELEASE_IMAGE_REPO}\"" $ROOT/components/release/kustomization.yaml
 [ -n "${RELEASE_IMAGE_TAG}" ] && yq -i e "(.images.[] | select(.name==\"quay.io/redhat-appstudio/release-service\")) |=.newTag=\"${RELEASE_IMAGE_TAG}\"" $ROOT/components/release/kustomization.yaml
 [ -n "${RELEASE_RESOURCES}" ] && yq -i e "(.resources[] | select(.==\"https://github.com/redhat-appstudio/release-service/config/default?ref=*\")) |=.=\"${RELEASE_RESOURCES}\"" components/release/kustomization.yaml


### PR DESCRIPTION
### Why
https://issues.redhat.com/browse/PLNSRVCE-290

It would be useful to be able to override the default ["quay.io/redhat-appstudio/user-workload"](https://github.com/redhat-appstudio/application-service/blob/4dfb289796d77827420d591cc1a6c150c51992a4/main.go#L107) "image push" repo via env var, so e2e-tests could leverage that and test the repo protection with a custom repo URL.