### PR TITLE
Fix staging rekor instance

### DIFF
--- a/argo-cd-apps/base/enterprise-contract.yaml
+++ b/argo-cd-apps/base/enterprise-contract.yaml
@@ -15,6 +15,8 @@ spec:
         - values.yaml
       values: |-
         server:
+          strategy:
+            type: Recreate
           ingress:
             hostname: rekor-server.enterprise-contract-service.svc
             annotations:


### PR DESCRIPTION
The Rekor Deployment specifies the access mode ReadWriteOnce for its
PVC. This access mode restricts the corresponding persistent volume from
being used by more than one Node at the same time.

This is usually not a problem. The Rekor Deployment specifies a single
replica (thus a single Node is used). However, when a new version of the
Deployment is being rolled out, there will be a brief period where two
pods will exist. One for the previous version of the Deployment, another
for the new version. If the two Pods are not scheduled on the same Node,
the newest Pod will not be able to start due to "Multi-Attach error",
causing a dead lock.

This commit changes the Deployment strategy to "Recreate" to ensure that
at most a single Pod exists.

A long-term solution would likely involve changing the access mode to
ReadWriteMany. However, since this is an immutable field, a new PVC and
PV must be created, requiring some data migration.

The following article describes the issue but for a different scenario:
https://docs.openshift.com/container-platform/4.10/support/troubleshooting/troubleshooting-storage-issues.html

https://issues.redhat.com/browse/HACBS-380

Signed-off-by: Luiz Carvalho <lucarval@redhat.com>