### PR TITLE
jvm-build-service: update version, enable pod deletion

### DIFF
--- a/components/build/jvm-build-service/kustomization.yaml
+++ b/components/build/jvm-build-service/kustomization.yaml
@@ -1,10 +1,10 @@
 resources:
 - allow-argocd-to-manage.yaml
-- https://github.com/redhat-appstudio/jvm-build-service/deploy/crds/base?ref=4a121b8cba42a5aafcd449e8777d687039eab442
-- https://github.com/redhat-appstudio/jvm-build-service/deploy/cache/base?ref=4a121b8cba42a5aafcd449e8777d687039eab442
-- https://github.com/redhat-appstudio/jvm-build-service/deploy/operator/base?ref=4a121b8cba42a5aafcd449e8777d687039eab442
-- https://raw.githubusercontent.com/redhat-appstudio/jvm-build-service/4a121b8cba42a5aafcd449e8777d687039eab442/deploy/base/run-maven-component-build-v0.1.yaml
-- https://raw.githubusercontent.com/redhat-appstudio/jvm-build-service/4a121b8cba42a5aafcd449e8777d687039eab442/deploy/base/lookup-artifact-location-v0.1.yaml
+- https://github.com/redhat-appstudio/jvm-build-service/deploy/crds/base?ref=efc1e58eb4c99b388b2cda0145ebf446248a723f
+- https://github.com/redhat-appstudio/jvm-build-service/deploy/cache/base?ref=efc1e58eb4c99b388b2cda0145ebf446248a723f
+- https://github.com/redhat-appstudio/jvm-build-service/deploy/operator/base?ref=efc1e58eb4c99b388b2cda0145ebf446248a723f
+- https://raw.githubusercontent.com/redhat-appstudio/jvm-build-service/efc1e58eb4c99b388b2cda0145ebf446248a723f/deploy/base/run-maven-component-build-v0.1.yaml
+- https://raw.githubusercontent.com/redhat-appstudio/jvm-build-service/efc1e58eb4c99b388b2cda0145ebf446248a723f/deploy/base/lookup-artifact-location-v0.1.yaml
 - .tekton/
 - namespace.yaml
 - localstack.yaml
@@ -15,13 +15,13 @@ namespace: jvm-build-service
 images:
 - name: hacbs-jvm-cache
   newName: quay.io/redhat-appstudio/hacbs-jvm-cache
-  newTag: 4a121b8cba42a5aafcd449e8777d687039eab442
+  newTag: efc1e58eb4c99b388b2cda0145ebf446248a723f
 - name: quay.io/QUAY_USERNAME/hacbs-jvm-cache
   newName: quay.io/redhat-appstudio/hacbs-jvm-cache
-  newTag: 4a121b8cba42a5aafcd449e8777d687039eab442
+  newTag: efc1e58eb4c99b388b2cda0145ebf446248a723f
 - name: hacbs-jvm-operator
   newName: quay.io/redhat-appstudio/hacbs-jvm-controller
-  newTag: 4a121b8cba42a5aafcd449e8777d687039eab442
+  newTag: efc1e58eb4c99b388b2cda0145ebf446248a723f
 
 patches:
 - target:
@@ -85,6 +85,12 @@ patches:
     - op: replace
       path: /spec/template/spec/containers/0/resources/requests/cpu
       value: 10m
+    # Enable removing of taskrun pods
+    - op: add
+      path: /spec/template/spec/containers/0/env/-
+      value:
+        name: JVM_DELETE_TASKRUN_PODS
+        value: "1"
 - target:
     kind: ClusterRoleBinding
     name: hacbs-jvm-operator
@@ -105,7 +111,7 @@ patches:
   patch: |-
     - op: replace
       path: /spec/steps/0/image
-      value: quay.io/redhat-appstudio/hacbs-jvm-build-request-processor:4a121b8cba42a5aafcd449e8777d687039eab442
+      value: quay.io/redhat-appstudio/hacbs-jvm-build-request-processor:efc1e58eb4c99b388b2cda0145ebf446248a723f
 - target:
     kind: ClusterTask
     name: run-maven-component-build
@@ -115,7 +121,7 @@ patches:
       value: http://hacbs-jvm-cache.jvm-build-service.svc.cluster.local
     - op: replace
       path: /spec/sidecars/0/image
-      value: quay.io/redhat-appstudio/hacbs-jvm-sidecar:4a121b8cba42a5aafcd449e8777d687039eab442
+      value: quay.io/redhat-appstudio/hacbs-jvm-sidecar:efc1e58eb4c99b388b2cda0145ebf446248a723f
     - op: add
       path: /spec/sidecars/0/env/-
       value:


### PR DESCRIPTION
Quota is applied on stage, limiting number of pods to 50. Enabling
taskrun pods removal using env variable.