### PR TITLE
add release team to be able to get cosign pub key

### DIFF
--- a/components/authentication/view-build-service.yaml
+++ b/components/authentication/view-build-service.yaml
@@ -90,6 +90,8 @@ subjects:
     name: Build team
   - kind: Group
     name: Enterprise Contract
+  - kind: Group
+    name: Release team
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole


### PR DESCRIPTION
Part of ec-task setup involves getting the cosign pub key and adding it as a secret to the managed workspace.

```
cosign public-key --key k8s://tekton-chains/signing-secrets > "$tempDir/cosign.pub"
kubectl create secret generic $COSIGN_SECRET_NAME -n "$NAMESPACE" --from-file="$tempDir/cosign.pub"

```