### PR TITLE
fix: ci: create shared secret

### DIFF
--- a/.ci/oci-e2e-deployment.sh
+++ b/.ci/oci-e2e-deployment.sh
@@ -14,6 +14,7 @@ export MY_GIT_FORK_REMOTE="qe"
 export MY_GITHUB_ORG="redhat-appstudio-qe"
 export MY_GITHUB_TOKEN="${GITHUB_TOKEN}"
 export E2E_APPLICATIONS_NAMESPACE=appstudio-e2e-test
+export SHARED_SECRET_NAMESPACE="build-templates"
 
 # Environment variable used to override the default "protected" image repository in HAS
 # https://github.com/redhat-appstudio/application-service/blob/6b9d21b8f835263b2e92f1e9343a1453caa2e561/gitops/generate_build.go#L50
@@ -63,10 +64,10 @@ function installCITools() {
 
 # Secrets used by pipelines to push component containers to quay.io
 function createQuayPullSecrets() {
+    echo -e "[INFO] Creating application-service related secrets in $SHARED_SECRET_NAMESPACE namespace"
+
     echo "$QUAY_TOKEN" | base64 --decode > docker.config
-    oc create namespace $E2E_APPLICATIONS_NAMESPACE --dry-run=client -o yaml | oc apply -f -
-    kubectl create secret docker-registry redhat-appstudio-registry-pull-secret -n  $E2E_APPLICATIONS_NAMESPACE --from-file=.dockerconfigjson=docker.config
-    kubectl create secret docker-registry redhat-appstudio-staginguser-pull-secret -n  $E2E_APPLICATIONS_NAMESPACE --from-file=.dockerconfigjson=docker.config
+    kubectl create secret docker-registry redhat-appstudio-user-workload -n $SHARED_SECRET_NAMESPACE --from-file=.dockerconfigjson=docker.config || true
     rm docker.config
 }
 
@@ -121,7 +122,6 @@ function prepareWebhookVariables() {
 }
 
 installCITools
-createQuayPullSecrets
 
 git remote add ${MY_GIT_FORK_REMOTE} https://github.com/redhat-appstudio-qe/infra-deployments.git
 
@@ -143,4 +143,5 @@ timeout --foreground 10m bash -c waitBuildToBeReady
 timeout --foreground 3m bash -c checkHASGithubOrg
 timeout --foreground 10m bash -c waitSPIToBeReady
 prepareWebhookVariables
+createQuayPullSecrets
 executeE2ETests

--- a/components/build/kustomization.yaml
+++ b/components/build/kustomization.yaml
@@ -18,7 +18,7 @@ configMapGenerator:
 - name: build-pipelines-defaults
   namespace: build-templates
   literals:
-  - default_build_bundle=quay.io/redhat-appstudio/build-templates-bundle:ad4c34b71d468a991450b0091cd96765471ed82d
+  - default_build_bundle=quay.io/redhat-appstudio/build-templates-bundle:0e0b28716550e1adc50443084adecec67f1748ef
 
 # Skip applying the Tekton operands while the Tekton operator is being installed.
 # See more information about this option, here:

--- a/hack/build/templates/default-build-bundle.yaml
+++ b/hack/build/templates/default-build-bundle.yaml
@@ -21,7 +21,7 @@ spec:
       value: .
   pipelineRef:
     name: PIPELINE_NAME_PLACEHOLDER  
-    bundle:  quay.io/redhat-appstudio/build-templates-bundle:ad4c34b71d468a991450b0091cd96765471ed82d
+    bundle:  quay.io/redhat-appstudio/build-templates-bundle:0e0b28716550e1adc50443084adecec67f1748ef
   workspaces:
     - name: workspace
       persistentVolumeClaim:


### PR DESCRIPTION
### What

Some tests no longer use the hardcoded `appstudio-e2e-test` namespace anymore (for creating apps, components, pipelines etc.).

This has caused that these tests started failing, because those namespaces don't contain the `redhat-appstudio-registry-pull-secret` secret used to authenticate when pushing the built image to quay.io.

To fix this, we need to create a shared secret that will be consumed by the pipelinerun created in any namespace on the cluster.

(The creation of the shared secret was added quite some time ago to [e2e-tests repository's CI scripts](https://github.com/redhat-appstudio/e2e-tests/blob/a0c27237bfee12e208b46c7ff88d3f5b7a3efbe5/scripts/install-appstudio-e2e-mode.sh#L64), but I haven't realized it needs to be updated here as well)