### PR TITLE
Apply pipeline-as-code for integration-service

### DIFF
--- a/components/integration/.tekton/kustomization.yaml
+++ b/components/integration/.tekton/kustomization.yaml
@@ -1,0 +1,13 @@
+resources:
+- serviceaccount.yaml
+- pvc.yaml
+- pipelines-as-code.yaml
+
+# Skip applying the Tekton operands while the Tekton operator is being installed.
+# See more information about this option, here:
+# https://argo-cd.readthedocs.io/en/stable/user-guide/sync-options/#skip-dry-run-for-new-custom-resources-types
+commonAnnotations:
+  argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization

--- a/components/integration/.tekton/pipelines-as-code.yaml
+++ b/components/integration/.tekton/pipelines-as-code.yaml
@@ -1,0 +1,6 @@
+apiVersion: pipelinesascode.tekton.dev/v1alpha1
+kind: Repository
+metadata:
+  name: integration-service-pac
+spec:
+  url: "https://github.com/redhat-appstudio/integration-service"

--- a/components/integration/.tekton/pvc.yaml
+++ b/components/integration/.tekton/pvc.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: app-studio-default-workspace
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi

--- a/components/integration/.tekton/serviceaccount.yaml
+++ b/components/integration/.tekton/serviceaccount.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: pipeline
+secrets:
+  - name: redhat-appstudio-staginguser-pull-secret


### PR DESCRIPTION
Signed-off-by: Jing Qi <jinqi@redhat.com>

This patch is to add pipeline-as-code yaml files for integration-service component