### PR TITLE
Allow integration-service to access shared secret

### DIFF
--- a/components/build/shared-resources/shared-resources-components.yaml
+++ b/components/build/shared-resources/shared-resources-components.yaml
@@ -60,5 +60,8 @@ subjects:
     namespace: enterprise-contract-service
   - kind: ServiceAccount
     name: pipeline
+    namespace: integration-service
+  - kind: ServiceAccount
+    name: pipeline
     namespace: jvm-build-service
     


### PR DESCRIPTION
Integration service need to have access to secret with quay robot
account credentials