### PR TITLE
Allow John to prune old HAS OLM resources

### DIFF
--- a/components/authentication/kustomization.yaml
+++ b/components/authentication/kustomization.yaml
@@ -13,6 +13,7 @@ resources:
 - build-ci.yaml
 - integration-ci.yaml
 - prune-has.yaml
+- prune-olm-has.yaml
 - e2e-tests-ci.yaml
 - view-e2e-tests.yaml
 - tenants/

--- a/components/authentication/prune-olm-has.yaml
+++ b/components/authentication/prune-olm-has.yaml
@@ -8,8 +8,6 @@ rules:
       - list
       - get
       - delete
-      - update
-      - patch
     apiGroups:
       - 'operators.coreos.com/v1alpha1'
     resources:
@@ -20,8 +18,6 @@ rules:
       - list
       - get
       - delete
-      - update
-      - patch
     apiGroups:
       - 'operators.coreos.com/v1'
     resources:

--- a/components/authentication/prune-olm-has.yaml
+++ b/components/authentication/prune-olm-has.yaml
@@ -1,0 +1,41 @@
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: has-olm-pruner
+rules:
+  - verbs:
+      - list
+      - get
+      - delete
+      - update
+      - patch
+    apiGroups:
+      - 'operators.coreos.com/v1alpha1'
+    resources:
+      - ClusterServiceVersion
+      - Subscription
+      - CatalogSource
+  - verbs:
+      - list
+      - get
+      - delete
+      - update
+      - patch
+    apiGroups:
+      - 'operators.coreos.com/v1'
+    resources:
+      - OperatorGroup
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: has-olm-pruner-rolebinding
+subjects:
+  - kind: User
+    apiGroup: rbac.authorization.k8s.io
+    name: johnmcollier
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: has-olm-pruner
+

--- a/components/authentication/prune-olm-has.yaml
+++ b/components/authentication/prune-olm-has.yaml
@@ -2,6 +2,7 @@ kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: has-olm-pruner
+  namespace: application-service
 rules:
   - verbs:
       - list
@@ -30,6 +31,7 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: has-olm-pruner-rolebinding
+  namespace: application-service
 subjects:
   - kind: User
     apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
There's some old OLM resources leftover from when we briefly deployed HAS as an OLM bundle. They're no longer needed, and seem to be orphaned from ArgoCD, so I'm adding a role to my stage user to allow myself to clean them up.