### PR TITLE
Fix typo in APIGroup for has-olm-pruner role

### DIFF
--- a/components/authentication/prune-olm-has.yaml
+++ b/components/authentication/prune-olm-has.yaml
@@ -9,18 +9,11 @@ rules:
       - get
       - delete
     apiGroups:
-      - 'operators.coreos.com/v1alpha1'
+      - 'operators.coreos.com'
     resources:
       - ClusterServiceVersion
       - Subscription
       - CatalogSource
-  - verbs:
-      - list
-      - get
-      - delete
-    apiGroups:
-      - 'operators.coreos.com/v1'
-    resources:
       - OperatorGroup
 ---
 kind: RoleBinding


### PR DESCRIPTION
Should be `operators.coreos.com` not `operators.coreos.com/v1alpha1`