### PR TITLE
Enable the JVM cache in CI namespace

### DIFF
--- a/components/build/jvm-build-service/system-config.yaml
+++ b/components/build/jvm-build-service/system-config.yaml
@@ -10,4 +10,12 @@ data:
   builder-image.jdk8.image: quay.io/redhat-appstudio/hacbs-jdk8-builder:6d1b3dc2133be167babbef8bb7b52deab017648b
   builder-image.jdk11.image: quay.io/redhat-appstudio/hacbs-jdk11-builder:6d1b3dc2133be167babbef8bb7b52deab017648b
   builder-image.jdk17.image: quay.io/redhat-appstudio/hacbs-jdk17-builder:6d1b3dc2133be167babbef8bb7b52deab017648b
-
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: jvm-build-config
+  namespace: jvm-build-service
+data:
+  enable-rebuilds: "false"
+  maven-repository-300-jboss: "https://repository.jboss.org/nexus/content/groups/public/"


### PR DESCRIPTION
The CI for JVM build service is running in the jvm-build-service
namespace, we need to enable JVM support for this namespace to activate
the cache.