### PR TITLE
update build readme shared resoruces section to note PLNSRVCE-251 protection

### DIFF
--- a/components/build/README.md
+++ b/components/build/README.md
@@ -79,7 +79,7 @@ Available secrets:
 | Name | Source | Description | Access |
 | -- | -- | -- | -- |
 | test-team-snyk | test-teams-snyk secret in test-team namespace | Snyk token used by HACBS pipelines | users/serviceaccounts with edit role |
-| redhat-appstudio-user-workload | redhat-appstudio-user-workload secret in build-templates namespace | Quay secret allowing to push into default AppStudio repository | users/serviceaccounts with edit role |
+| redhat-appstudio-user-workload | redhat-appstudio-user-workload secret in build-templates namespace | Quay secret allowing to push into default AppStudio repository | users/serviceaccounts with edit role, but application-service and build-service both have protection that prevents one user to push to a different user's tag, and the default repository is protected from updates from other namespaces |
 | redhat-appstudio-staginguser | redhat-appstudio-staginguser secret in build-templates namespace | Quay secret allowing to push into component repositories in redhat-appstudio org | `pipeline` service accounts defined in [shared-resources-components.yaml](https://github.com/redhat-appstudio/infra-deployments/blob/main/components/build/shared-resources/shared-resources-components.yaml)|
 
 ### Repository secrets


### PR DESCRIPTION
It occurred to me @Michkov that some mention of the [PLNSRVCE-251](https://issues.redhat.com//browse/PLNSRVCE-251) protection in your recent README updates per [PLNSRVCE-535](https://issues.redhat.com//browse/PLNSRVCE-535) is warranted for completeness.

If you agree and we get to a consensus on the precise wording of the change, we can officially associate with 535