### PR TITLE
remove cache instance in jvm-build-service namespace

### DIFF
--- a/components/build/jvm-build-service/kustomization.yaml
+++ b/components/build/jvm-build-service/kustomization.yaml
@@ -1,7 +1,6 @@
 resources:
 - allow-argocd-to-manage.yaml
 - https://github.com/redhat-appstudio/jvm-build-service/deploy/crds/base?ref=345ea0982fc5f57ef55c3e7e689e460e70cd5313
-- https://github.com/redhat-appstudio/jvm-build-service/deploy/cache/base?ref=345ea0982fc5f57ef55c3e7e689e460e70cd5313
 - https://github.com/redhat-appstudio/jvm-build-service/deploy/operator/base?ref=345ea0982fc5f57ef55c3e7e689e460e70cd5313
 - .tekton/
 - namespace.yaml
@@ -12,12 +11,6 @@ resources:
 namespace: jvm-build-service
 
 images:
-- name: hacbs-jvm-cache
-  newName: quay.io/redhat-appstudio/hacbs-jvm-cache
-  newTag: 345ea0982fc5f57ef55c3e7e689e460e70cd5313
-- name: quay.io/QUAY_USERNAME/hacbs-jvm-cache
-  newName: quay.io/redhat-appstudio/hacbs-jvm-cache
-  newTag: 345ea0982fc5f57ef55c3e7e689e460e70cd5313
 - name: hacbs-jvm-operator
   newName: quay.io/redhat-appstudio/hacbs-jvm-controller
   newTag: 345ea0982fc5f57ef55c3e7e689e460e70cd5313
@@ -29,59 +22,6 @@ images:
   newTag: 345ea0982fc5f57ef55c3e7e689e460e70cd5313
 
 patches:
-- target:
-    kind: Deployment
-    name: hacbs-jvm-cache
-  patch: |-
-    - op: add
-      path: /spec/template/spec/containers/0/env/-
-      value:
-        name: QUARKUS_S3_ENDPOINT_OVERRIDE
-        value: "http://localstack:4572"
-    - op: add
-      path: /spec/template/spec/containers/0/env/-
-      value:
-        name: QUARKUS_S3_AWS_REGION
-        value: "us-east-1"
-    - op: add
-      path: /spec/template/spec/containers/0/env/-
-      value:
-        name: QUARKUS_S3_AWS_CREDENTIALS_STATIC_PROVIDER_ACCESS_KEY_ID
-        value: "accesskey"
-    - op: add
-      path: /spec/template/spec/containers/0/env/-
-      value:
-        name: QUARKUS_S3_AWS_CREDENTIALS_STATIC_PROVIDER_SECRET_ACCESS_KEY
-        value: "secretkey"
-    - op: add
-      path: /spec/template/spec/containers/0/env/-
-      value:
-        name: QUARKUS_S3_AWS_CREDENTIALS_TYPE
-        value: "static"
-    # Change strategy to Recreate since PVC is RWO
-    - op: replace
-      path: /spec/strategy
-      value:
-        type: Recreate
-    - op: add
-      path: /spec/template/spec/volumes
-      value:
-      - name: local-cache
-        persistentVolumeClaim:
-          claimName: local-cache
-    - op: add
-      path: /spec/template/spec/containers/0/volumeMounts
-      value:
-      - name: local-cache
-        mountPath: /deployments/cache
-    # reduce CPU request to be able to run on testing instance
-    - op: replace
-      path: /spec/template/spec/containers/0/resources/requests/cpu
-      value: 10m
-    # increase Memory limit
-    - op: replace
-      path: /spec/template/spec/containers/0/resources/limits/memory
-      value: 2Gi
 - target:
     kind: Deployment
     name: hacbs-jvm-operator

--- a/components/build/jvm-build-service/kustomization.yaml
+++ b/components/build/jvm-build-service/kustomization.yaml
@@ -1,6 +1,5 @@
 resources:
 - allow-argocd-to-manage.yaml
-
 - https://github.com/redhat-appstudio/jvm-build-service/deploy/crds/base?ref=505c85e3278cfb67fca6fd5a6b7c760f82e27d7b
 - https://github.com/redhat-appstudio/jvm-build-service/deploy/operator/base?ref=505c85e3278cfb67fca6fd5a6b7c760f82e27d7b
 - .tekton/


### PR DESCRIPTION
As part of the next step following the merging of https://github.com/redhat-appstudio/jvm-build-service/pull/105 and in particular what is noted in https://github.com/redhat-appstudio/jvm-build-service/blob/650846d2011d745b82c72cd59cf1e2398daeddfa/deploy/cache/base/deployment.yaml#L1-L3 we are removing the reference to the yaml that defines the jvm-build-service cache in the `jvm-build-service` namespace 


@Michkov @stuartwdouglas @phillip-kruger @brunoapimentel @psturc FYI