### PR TITLE
added part-of label on spi-oauth-route

### DIFF
--- a/components/spi/oauth_route.yaml
+++ b/components/spi/oauth_route.yaml
@@ -2,6 +2,8 @@ apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
   name: spi-oauth-route
+  labels:
+    app.kubernetes.io/part-of: service-provider-integration-operator
 spec:
   port:
     targetPort: 8000


### PR DESCRIPTION
As part of https://issues.redhat.com/browse/SVPI-117 added `part-of` label on spi-oauth-route