### PR TITLE
Grant Enterprise Contract to view e2e namespace

### DIFF
--- a/components/authentication/view-e2e-tests.yaml
+++ b/components/authentication/view-e2e-tests.yaml
@@ -8,6 +8,8 @@ subjects:
     name: QE team
   - kind: Group
     name: HACBS QE
+  - kind: Group
+    name: Enterprise Contract
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole


### PR DESCRIPTION
This is to help us troubleshoot e2e tests.