### PR TITLE
Un-skip Enterprise Contract e2e tests

### DIFF
--- a/.ci/oci-e2e-deployment.sh
+++ b/.ci/oci-e2e-deployment.sh
@@ -80,7 +80,7 @@ function executeE2ETests() {
     curl https://raw.githubusercontent.com/redhat-appstudio/e2e-tests/main/scripts/e2e-openshift-ci.sh | bash -s
 
     # The bin will be installed in tmp folder after executing e2e-openshift-ci.sh script
-    ${WORKSPACE}/tmp/e2e-tests/bin/e2e-appstudio  --ginkgo.junit-report="${ARTIFACTS_DIR}"/e2e-report.xml -webhookConfigPath="./webhookConfig.yml" -config-suites="${WORKSPACE}/tmp/e2e-tests/tests/e2e-demos/config/default.yaml" --ginkgo.label-filter='!ec'
+    ${WORKSPACE}/tmp/e2e-tests/bin/e2e-appstudio  --ginkgo.junit-report="${ARTIFACTS_DIR}"/e2e-report.xml -webhookConfigPath="./webhookConfig.yml" -config-suites="${WORKSPACE}/tmp/e2e-tests/tests/e2e-demos/config/default.yaml"
 }
 
 function prepareWebhookVariables() {


### PR DESCRIPTION
Reverts the change in #549 as we have landed the fix in
redhat-appstudio/e2e-tests#158 for the issue that required skipping the
tests in the first place.