### PR TITLE
fix end-to-end-demo.sh to use verify-enterprise-contract-v2

### DIFF
--- a/hack/chains/end-to-end-demo.sh
+++ b/hack/chains/end-to-end-demo.sh
@@ -131,11 +131,8 @@ echo "
 kubectl create secret docker-registry release-demo --from-file=.dockerconfigjson="${HOME}/.docker/config.json" --dry-run=client -o yaml | kubectl apply -f -
 oc secrets link pipeline release-demo --for=pull,mount
 
-# Enterprise Contract policy configuration
-kubectl create configmap ec-policy --from-file=policy.json=<(echo '{"non_blocking_checks":["not_useful","test:conftest-clair"]}'|jq .) 2>/dev/null || echo "ℹ️  Using existing Enterprise Contract policy configuration in ec-policy ConfigMap"
-
 "${HACK_CHAINS_DIR}/copy-public-sig-key.sh"
-TASK_BUNDLE=quay.io/redhat-appstudio/appstudio-tasks:$(git ls-remote --heads https://github.com/redhat-appstudio/build-definitions.git refs/heads/main|cut -f 1)-2
+TASK_BUNDLE=quay.io/redhat-appstudio/appstudio-tasks:$(git ls-remote --heads https://github.com/redhat-appstudio/build-definitions.git refs/heads/main|cut -f 1)-3
 export TASK_BUNDLE
 
 # install skopeo-copy task if it's missing


### PR DESCRIPTION
For https://github.com/redhat-appstudio/infra-deployments/blob/1f096e2721e3df056c492e96ab5346222312a551/hack/chains/end-to-end-demo.sh#L138 the output bundle task was TASK_BUNDLE=quay.io/redhat-appstudio/appstudio-tasks:3dddea8074c9fa13e7146e3c5c7d75e4bd8f7bb0-2
but when we use  verify-enterprise-contract-v2, task task.tekton.dev/verify-enterprise-contract-v2 should be in bundle quay.io/redhat-appstudio/appstudio-tasks:3dddea8074c9fa13e7146e3c5c7d75e4bd8f7bb0-3


$ tkn bundle list quay.io/redhat-appstudio/appstudio-tasks:3dddea8074c9fa13e7146e3c5c7d75e4bd8f7bb0-2
task.tekton.dev/s2i-java
task.tekton.dev/s2i-nodejs
task.tekton.dev/sanity-inspect-image
task.tekton.dev/sanity-label-check
task.tekton.dev/sast-go
task.tekton.dev/sast-java-sec-check
task.tekton.dev/sast-snyk-check
task.tekton.dev/summary
task.tekton.dev/update-infra-deployments
task.tekton.dev/utils-task

$ tkn bundle list quay.io/redhat-appstudio/appstudio-tasks:3dddea8074c9fa13e7146e3c5c7d75e4bd8f7bb0-3
task.tekton.dev/verify-enterprise-contract
task.tekton.dev/verify-enterprise-contract-v2


also delete ConfigMap, we are using EnterpriseContractPolicy resource for verify-enterprise-contract-v2  no more ConfigMap, and the creation of EnterpriseContractPolicy resource is defined in script: release-pipeline-with-ec-demo.sh which is already updated in the pr:https://github.com/redhat-appstudio/infra-deployments/pull/594
