### PR TITLE
Force sync of chains-ca-cert secret

### DIFF
--- a/components/build/tekton-chains/chains-secrets-config.yaml
+++ b/components/build/tekton-chains/chains-secrets-config.yaml
@@ -105,7 +105,7 @@ spec:
               oc get secret router-ca -n openshift-ingress-operator -o jsonpath="{.data.tls\.crt}" | base64 -d > $INGRESS_CA
               SERVICE_CA=/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
               cat $TRUSTED_CA $KUBE_CA $INGRESS_CA $SERVICE_CA > /tmp/ca-certificates.crt
-              oc create secret generic chains-ca-cert --from-file=/tmp/ca-certificates.crt --dry-run=client -o yaml -n tekton-chains | oc apply --server-side=true -f -
+              oc create secret generic chains-ca-cert --from-file=/tmp/ca-certificates.crt --dry-run=client -o yaml -n tekton-chains | oc apply --force-conflicts --server-side=true -f -
           imagePullPolicy: Always
           name: patch-chains-certs
       dnsPolicy: ClusterFirst


### PR DESCRIPTION
The job chains-certs-configuration is expected to be the sole manager of
the chains-ca-cert secret. This is needed to ensure Chains can properly
access cluster-internal services like the integrated registry. As
recommended by the docs[0], use the --force-conflicts flag to ensure the
PostSync hook can properly update the CA secret used by Chains.

[0] https://kubernetes.io/docs/reference/using-api/server-side-apply/#conflicts

https://issues.redhat.com/browse/HACBS-1028

Signed-off-by: Luiz Carvalho <lucarval@redhat.com>