### PR TITLE
fix: preview: wait for tekton components/resources

### DIFF
--- a/hack/preview.sh
+++ b/hack/preview.sh
@@ -159,7 +159,7 @@ while :; do
   echo "$NOT_DONE"
   if [ -z "$NOT_DONE" ]; then
      echo All Applications are synced and Healthy
-     exit 0
+     break
   else
      UNKNOWN=$(echo "$NOT_DONE" | grep Unknown | grep -v Progressing | cut -f1 -d ' ')
      if [ -n "$UNKNOWN" ]; then
@@ -186,4 +186,15 @@ while :; do
      echo Waiting $INTERVAL seconds for application sync
      sleep $INTERVAL
   fi
+done
+
+# Wait for all tekton components to be installed
+# The status of a tektonconfig CR should be "type: Ready, status: True" once the install is completed
+# More info: https://tekton.dev/docs/operator/tektonconfig/#tekton-config
+while :; do
+  STATE=$(oc get tektonconfig config -o json | jq -r '.status.conditions[] | select(.type == "Ready")')
+  [ "$(jq -r '.status' <<< "$STATE")" == "True" ] && echo All required tekton resources are installed and ready && break
+  echo Some tekton resources are not ready yet:
+  jq -r '.message' <<< "$STATE"
+  sleep $INTERVAL
 done


### PR DESCRIPTION
### What

Some of the [recent CI runs were failing](https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/redhat-appstudio_e2e-tests/177/pull-ci-redhat-appstudio-e2e-tests-main-redhat-appstudio-e2e/1562369417759690752) due to an error in E2E tests caused by an incomplete installation of tekton resources (tekton CRDs missing / pipeline SA did not get created in specified timeout in OpenShift test project)

This additional check should ensure that E2E tests won't be run until all required tekton resources are installed and ready