### PR TITLE
PLNSRVCE-624: set hacbs tekton bundle key

### DIFF
--- a/components/build/README.md
+++ b/components/build/README.md
@@ -56,12 +56,18 @@ It can be overridden by configmap in working namespace:
 oc create configmap build-pipelines-defaults --from-literal default_build_bundle=$BUNDLE
 ```
 
-Switching to HACBS bundle:
-```
-HACBS_BUNDLE=$(oc get configmap -n build-templates -o jsonpath='{ .data.default_build_bundle }' build-pipelines-defaults | sed 's|/build-|/hacbs-|)
-oc delete configmap --ignore-not-found build-pipelines-defaults
-oc create configmap build-pipelines-defaults --from-literal default_build_bundle=$HACBS_BUNDLE
-```
+## HACBS enablement
+
+HACBS workflow can be set by creation of configmap `hacbs` in the user namespace.
+
+`oc create configmap hacbs` will:
+
+1. Always use Pipelines-as-Code
+2. Selects bundle from `hacbs_build_bundle` key in configmap `build-pipelines-defaults`
+
+### Stage Cluster integration prerequisites
+
+Before creating component in Stage cluster it's necessary install GitHub application [AppStudio Staging CI](https://github.com/apps/appstudio-staging-ci) into managed repository or into whole GitHub organization.
 
 ## Tekton Results integration
 

--- a/components/build/build-service/kustomization.yaml
+++ b/components/build/build-service/kustomization.yaml
@@ -1,6 +1,6 @@
 resources:
 - allow-argocd-to-manage.yaml
-- https://github.com/redhat-appstudio/build-service/config/default?ref=67eda581354ab640cffdf07265abf668892fcde0
+- https://github.com/redhat-appstudio/build-service/config/default?ref=b2290ae5b74c788dabc8b1efef7d8069a81d575c
 - .tekton/
 
 namespace: build-service
@@ -8,7 +8,7 @@ namespace: build-service
 images:
 - name: quay.io/redhat-appstudio/build-service
   newName: quay.io/redhat-appstudio/build-service
-  newTag: 67eda581354ab640cffdf07265abf668892fcde0
+  newTag: b2290ae5b74c788dabc8b1efef7d8069a81d575c
 
 
 apiVersion: kustomize.config.k8s.io/v1beta1

--- a/components/build/kustomization.yaml
+++ b/components/build/kustomization.yaml
@@ -18,6 +18,7 @@ configMapGenerator:
   namespace: build-templates
   literals:
   - default_build_bundle=quay.io/redhat-appstudio/build-templates-bundle:510fa6e99f1fa1f816c96354bbaf1ad155c6d9c3
+  - hacbs_build_bundle=quay.io/redhat-appstudio/hacbs-templates-bundle:510fa6e99f1fa1f816c96354bbaf1ad155c6d9c3
 
 # Skip applying the Tekton operands while the Tekton operator is being installed.
 # See more information about this option, here:

--- a/components/has/kustomization.yaml
+++ b/components/has/kustomization.yaml
@@ -1,7 +1,7 @@
 resources:
 - allow-argocd-to-manage.yaml
 - argocd-permissions.yaml
-- https://github.com/redhat-appstudio/application-service/config/default?ref=b1a0d1dde65cb6eb6aa34716207d1b48d8a6ce64
+- https://github.com/redhat-appstudio/application-service/config/default?ref=38a68245668f989e9393a5def7d6a7b1e41d1808
 - .tekton/
 
 
@@ -11,7 +11,7 @@ kind: Kustomization
 images:
 - name: quay.io/redhat-appstudio/application-service
   newName: quay.io/redhat-appstudio/application-service
-  newTag: b1a0d1dde65cb6eb6aa34716207d1b48d8a6ce64
+  newTag: 38a68245668f989e9393a5def7d6a7b1e41d1808
 
 configMapGenerator:
 - literals:


### PR DESCRIPTION
Set global hacbs tekton bundle so it can be used directly in hacbs
workflow.