### PR TITLE
Handles CRC paths with spaces 

### DIFF
--- a/argo-cd-apps/overlays/staging/kustomization.yaml
+++ b/argo-cd-apps/overlays/staging/kustomization.yaml
@@ -2,8 +2,7 @@ resources:
 - ../../base
 
 namespace: openshift-gitops
-
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-
-
+patchesStrategicMerge:
+  - staging-labels.yaml 

--- a/argo-cd-apps/overlays/staging/staging-labels.yaml
+++ b/argo-cd-apps/overlays/staging/staging-labels.yaml
@@ -1,0 +1,119 @@
+# The following resources must be tagged according to https://source.redhat.com/groups/public/itpaas/mpwiki/user_managed_platform_required_resource_tagginglabeling:
+# Pods, Routes, Services, and PersistentVolumeClaims
+# Pods are tagged by their Pod Controller: 
+# Deployment, DeploymentConfig, CronJob, StatefulSet, or DaemonSet
+# Image tagging is recommended but not required. 
+# Images can have image labels provided as a build output when producing an image from a BuildConfig. 
+
+# To tag any resources created manually, use the CLI. For example: 
+# `oc label pvc $mypvcname paas.redhat.com/appcode=ASSH-001`
+
+# ${appcode } AppCode - A CMDB ID of the application. 
+# This is represented as the Kubernetes label key paas.redhat.com/appcode.
+# For our staging infrastucture, the code is ASSH-001.
+# TODO: how to set this variable for the rest of the file?
+appcode=ASSH-001
+
+apiVersion: argoproj.io/v1alpha1
+# Tag every service with metadata.labels.["paas.redhat.com/appcode"]
+kind: Service
+metadata:
+  labels:
+    paas.redhat.com/appcode: ${appcode}
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+---
+apiVersion: argoproj.io/v1alpha1
+# Tag every route with metadata.labels.["paas.redhat.com/appcode"]
+kind: Route
+metadata:
+  labels:
+    paas.redhat.com/appcode: ${appcode}
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+---
+apiVersion: argoproj.io/v1alpha1
+# Tag every Pod in a Deployment with spec.template.metadata.labels.["paas.redhat.com/appcode"]
+kind: Deployment
+metadata:
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  template:
+    metadata:
+      labels:
+        paas.redhat.com/appcode: ${appcode}
+---
+apiVersion: argoproj.io/v1alpha1
+# Tag every Pod in a DeploymentConfig with spec.template.metadata.labels.["paas.redhat.com/appcode"]
+kind: DeploymentConfig
+metadata:
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  template:
+    metadata:
+      labels:
+        paas.redhat.com/appcode: ${appcode}
+---
+apiVersion: argoproj.io/v1alpha1
+# Tag every Pod in a CronJob with spec.template.metadata.labels.["paas.redhat.com/appcode"]
+kind: CronJob
+metadata:
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  template:
+    metadata:
+      labels:
+        paas.redhat.com/appcode: ${appcode}
+---
+apiVersion: argoproj.io/v1alpha1
+# Tag every Pod in a StatefulSet with spec.template.metadata.labels.["paas.redhat.com/appcode"]
+kind: StatefulSet
+metadata:
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  template:
+    metadata:
+      labels:
+        paas.redhat.com/appcode: ${appcode}
+# For OpenShift 4.x also tag volume claims with volumeClaimTemplates[*].metadata.labels.["paas.redhat.com/appcode"]
+volumeClaimTemplates:
+- metadata:
+    labels:
+      paas.redhat.com/appcode: ${appcode}
+---
+apiVersion: argoproj.io/v1alpha1
+# Tag every Pod in a DaemonSet with spec.template.metadata.labels.["paas.redhat.com/appcode"]
+kind: DaemonSet
+metadata:
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  template:
+    metadata:
+      labels:
+        paas.redhat.com/appcode: ${appcode}
+---
+apiVersion: argoproj.io/v1alpha1
+# Tag every PersistentVolumeClaim with metadata.labels.["paas.redhat.com/appcode"]
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    paas.redhat.com/appcode: ${appcode}
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+---
+apiVersion: argoproj.io/v1alpha1
+kind: BuildConfig
+# Tag images by setting imageLabels when producing an image from a BuildConfig. 
+metadata:
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  output:
+    imageLabels:
+    - name: com.redhat.paas.appcode
+      value: ${appcode}

--- a/hack/setup/prepare-crc.sh
+++ b/hack/setup/prepare-crc.sh
@@ -45,20 +45,20 @@ fi
 done
 
 #Get CRC VMs configured in local machine
-$CRCBINARY setup
+"$CRCBINARY" setup
 #Set memory and CPU allowance for CRC
 echo "Memory allowance for CRC is set to $MEMORY MB"
 echo "CPU allowance for CRC is set to $CPUS"
-$CRCBINARY config set memory $MEMORY
-$CRCBINARY config set cpus $CPUS
+"$CRCBINARY" config set memory $MEMORY
+"$CRCBINARY" config set cpus $CPUS
 #enable netmetrices addons, to make sure member cluster has proper resources
-$CRCBINARY config set enable-cluster-monitoring true
+"$CRCBINARY" config set enable-cluster-monitoring true
 #Delete existing CRC cluster to apply the config updates
 if [ $DELETE_CLUSTER -eq 1 ]; then
     echo "Force delete for CRC is set, deleting the existing CRC cluster"
-    $CRCBINARY delete --force
+    "$CRCBINARY" delete --force
 else
-    $CRCBINARY delete
+    "$CRCBINARY" delete
 fi
 
 #TODO: Check the return value of delete command and go forward accordingly
@@ -66,10 +66,10 @@ fi
 #existing cluster
 
 #Start CRC with modified configs
-$CRCBINARY start
+"$CRCBINARY" start
 
 #Point local environment clients (kubectl and oc) to the CRC cluster
-eval $($CRCBINARY oc-env)
+eval $("$CRCBINARY" oc-env)
 kubectl config use-context crc-admin
 
 #Reduce cpu resource request for each AppStudio Application


### PR DESCRIPTION
The latest versions of CRC on Mac install it into a default path with spaces, i.e.
`/Applications/Red Hat OpenShift Local.app/Contents/Resources/crc`
So, we have to surround the the $CRCBINARY variable with quotes to fix errors like:
`./hack/setup/prepare-crc.sh: line 72: /Applications/Red: No such file or directory`