### PR TITLE
fix: naming of CRs & CRBs

### DIFF
--- a/components/authorization/cluster/everyone-view.yaml
+++ b/components/authorization/cluster/everyone-view.yaml
@@ -1,7 +1,7 @@
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: all-view
+  name: everyone-view
 subjects:
 - kind: Group
   apiGroup: rbac.authorization.k8s.io

--- a/components/authorization/cluster/kustomization.yaml
+++ b/components/authorization/cluster/kustomization.yaml
@@ -1,5 +1,5 @@
 resources:
-- all-view-everything.yaml
+- everyone-view.yaml
 
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/components/authorization/kcp/kustomization.yaml
+++ b/components/authorization/kcp/kustomization.yaml
@@ -1,6 +1,6 @@
 resources:
-- view-all.yaml
-- members-view.yaml
+- view-everything.yaml
+- members-view-everything.yaml
 
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/components/authorization/kcp/members-view-everything.yaml
+++ b/components/authorization/kcp/members-view-everything.yaml
@@ -1,13 +1,13 @@
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: members-view-all
+  name: members-view-everything
 subjects:
 - kind: User
-  name: rh-sso:jcollier
+  name: rh-sso:johnmcollier
 - kind: User
   name: rh-sso:mjobanek
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: view-all
+  name: view-everything

--- a/components/authorization/kcp/view-everything.yaml
+++ b/components/authorization/kcp/view-everything.yaml
@@ -1,7 +1,7 @@
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: view
+  name: view-everything
 rules:
 - apiGroups:
   - '*'


### PR DESCRIPTION
let's try to make the names more consistent and not to mix/confuse them:
* for cluster:
    * `all-view` -> `everyone-view` (saying that everyone has `view` role)
    * ` all-view-everything` -> `everyone-view` (to not confuse with the ClusterRole defined for kcp)
* for kcp:
    * the role is `view-everything` (because it grants permission to view everything)
    * analogically `members-view-all` -> `members-view-everything`

plus fixed the `jcollier` -> `johnmcollier`