### PR TITLE
hard apps refresh when new kcp is configured

### DIFF
--- a/hack/configure-kcp.sh
+++ b/hack/configure-kcp.sh
@@ -34,7 +34,7 @@ echo
 
 COMPUTE_WORKSPACE=redhat-appstudio-internal-compute
 echo "Creating and accessing '${COMPUTE_WORKSPACE}' for compute:"
-KUBECONFIG=${KCP_KUBECONFIG} kubectl ws create ${COMPUTE_WORKSPACE} --type root:universal --ignore-existing
+KUBECONFIG=${KCP_KUBECONFIG} kubectl ws create ${COMPUTE_WORKSPACE} --type root:universal --ignore-existing || true
 KUBECONFIG=${KCP_KUBECONFIG} kubectl ws ${COMPUTE_WORKSPACE}
 echo
 
@@ -93,7 +93,7 @@ echo
 APPSTUDIO_WORSKPACE=redhat-appstudio
 echo "Creating and accessing '${APPSTUDIO_WORSKPACE}' for AppStudio controllers:"
 KUBECONFIG=${KCP_KUBECONFIG} kubectl ws ${ROOT_WORKSPACE}
-KUBECONFIG=${KCP_KUBECONFIG} kubectl ws create ${APPSTUDIO_WORSKPACE} --ignore-existing --type root:universal
+KUBECONFIG=${KCP_KUBECONFIG} kubectl ws create ${APPSTUDIO_WORSKPACE} --ignore-existing --type root:universal || true
 REDHAT_APPSTUDIO_URL=$(KUBECONFIG=${KCP_KUBECONFIG} kubectl get workspaces ${APPSTUDIO_WORSKPACE} -o jsonpath='{.status.URL}')
 KUBECONFIG=${KCP_KUBECONFIG} kubectl ws ${APPSTUDIO_WORSKPACE}
 
@@ -147,4 +147,10 @@ stringData:
       }
     }
 EOF
+
+echo
+echo "Triggering hard refresh of all Applications:"
+for APP in $(kubectl get apps -n openshift-gitops -o name --kubeconfig ${CLUSTER_KUBECONFIG}); do
+  kubectl patch ${APP} -n openshift-gitops --type merge -p='{"metadata": {"annotations":{"argocd.argoproj.io/refresh": "hard"}}}' --kubeconfig ${CLUSTER_KUBECONFIG}
+done
 


### PR DESCRIPTION
two fixes for `configure-kcp.sh` script
1. when running in CPS in `root` the admin doesn't have permission to create anything there - so we need to ignore any failures
2. when it configures a new cluster (via ArgoCD secret) pointing to the kcp workspace, we need to refresh the apps 