### PR TITLE
Add tags for gradle versions in the builder images

### DIFF
--- a/components/build/jvm-build-service/system-config.yaml
+++ b/components/build/jvm-build-service/system-config.yaml
@@ -8,11 +8,11 @@ data:
   image.cache: quay.io/redhat-appstudio/hacbs-jvm-cache:a4787c4c72c7f606515e19dc3057e79779b4f5a1
   builder-image.names: jdk11,jdk8,jdk17
   builder-image.jdk8.image: quay.io/redhat-appstudio/hacbs-jdk8-builder:a4787c4c72c7f606515e19dc3057e79779b4f5a1
-  builder-image.jdk8.tags: jdk:8,maven:3.8,gradle:7.5
   builder-image.jdk11.image: quay.io/redhat-appstudio/hacbs-jdk11-builder:a4787c4c72c7f606515e19dc3057e79779b4f5a1
-  builder-image.jdk11.tags: jdk:11,maven:3.8,gradle:7.5
   builder-image.jdk17.image: quay.io/redhat-appstudio/hacbs-jdk17-builder:a4787c4c72c7f606515e19dc3057e79779b4f5a1
-  builder-image.jdk17.tags: jdk:17,maven:3.8,gradle:7.5
+  builder-image.jdk8.tags: jdk:8,maven:3.8,gradle:7.4.2;6.9.2;5.6.4;4.10.3
+  builder-image.jdk11.tags: jdk:11,maven:3.8,gradle:7.4.2;6.9.2;5.6.4;4.10.3
+  builder-image.jdk17.tags: jdk:17,maven:3.8,gradle:7.4.2;6.9.2
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -23,3 +23,4 @@ data:
   enable-rebuilds: "false"
   maven-repository-300-jboss: "https://repository.jboss.org/nexus/content/groups/public/"
   maven-repository-301-gradle: "https://repo.gradle.org/artifactory/libs-releases"
+  maven-repository-302-gradleplugins: "https://plugins.gradle.org/m2"


### PR DESCRIPTION
This will be needed for https://github.com/redhat-appstudio/jvm-build-service/pull/212 to pass CI.

Once this is merged into infra-deployments we can change this to reference https://github.com/redhat-appstudio/jvm-build-service/pull/212/files#diff-8944c42fd2615afea6412ddd9d9d14643e29ee78ae8d5019364e396dcd70871dR11 to keep them in sync automatically.