### PR TITLE
fix: increase timeout for e2e

### DIFF
--- a/.ci/oci-e2e-deployment.sh
+++ b/.ci/oci-e2e-deployment.sh
@@ -80,7 +80,7 @@ function executeE2ETests() {
     curl https://raw.githubusercontent.com/redhat-appstudio/e2e-tests/main/scripts/e2e-openshift-ci.sh | bash -s
 
     # The bin will be installed in tmp folder after executing e2e-openshift-ci.sh script
-    ${WORKSPACE}/tmp/e2e-tests/bin/e2e-appstudio  --ginkgo.junit-report="${ARTIFACTS_DIR}"/e2e-report.xml -webhookConfigPath="./webhookConfig.yml" -config-suites="${WORKSPACE}/tmp/e2e-tests/tests/e2e-demos/config/default.yaml"
+    ${WORKSPACE}/tmp/e2e-tests/bin/e2e-appstudio --ginkgo.timeout=90m --ginkgo.junit-report="${ARTIFACTS_DIR}"/e2e-report.xml -webhookConfigPath="./webhookConfig.yml" -config-suites="${WORKSPACE}/tmp/e2e-tests/tests/e2e-demos/config/default.yaml"
 }
 
 function prepareWebhookVariables() {


### PR DESCRIPTION
### Why
Currently there's a 1h (default) timeout for running e2e. Since the number of tests is growing and takes more time to finish, we are sometimes hitting the limit. If that happens, tests get interrupted and a CI check is marked as failed.

This is a temporary solution until we enable parallel e2e test run for infra-deployments (which was already enabled for e2e-tests repo)