### PR TITLE
Initial implementation of preview-ckcp and preview-cps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,3 @@
 hack/preview.env
-hack/ckcp-kubeconfig
-hack/cps-kubeconfig
 cosign.pub
 components/spi/config.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 hack/preview.env
+hack/ckcp-kubeconfig
 cosign.pub
 components/spi/config.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 hack/preview.env
 hack/ckcp-kubeconfig
+hack/cps-kubeconfig
 cosign.pub
 components/spi/config.yaml

--- a/README.md
+++ b/README.md
@@ -126,8 +126,8 @@ Preview mode works in a feature branch, apply script which creates new preview b
 
 Two preview modes are offered:
 
-- `preview-ckcp` deploys containerized KCP directly into your cluster and connects the cluster. Kubeconfig will be stored in `hack/ckcp-kubeconfig`
-- `preview-cps` connects to CPS instance. Before the mode is used the kubeconfig file `hack/cps-kubeconfig` must be created manually based on 'CSP onboarding document'
+- `preview-ckcp` deploys containerized KCP directly into your cluster and connects the cluster.
+- `preview-cps` connects to CPS instance. Before the mode is used the kubeconfig file must be created manually based on 'CSP onboarding document' and set `CPS_KUBECONFIG` variable in `hack/preview.env`
 
 Usage:
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,9 @@ Simply update the files under `components/(team-name)`, and open a PR with the c
 
 The prerequisites are:
 
-- You must have `kubectl`, `oc`, `jq`, `openssl`, `realpath` and [`yq`](https://github.com/mikefarah/yq) installed.
+- You must have `kubectl` (> v1.24), `oc`, `jq`, `openssl`, `realpath` and [`yq`](https://github.com/mikefarah/yq) installed.
+- [kubectl-kcp plugin](https://github.com/kcp-dev/kcp/releases)
+- [kubectl-oidc_login plugin](https://github.com/int128/kubelogin/releases) (only when connecting to CPS)
 - You must have `kubectl` and `oc` pointing to an existing OpenShift cluster, that you wish to deploy to. Alternatively, you can configure a local CodeReady Containers VM to deploy to.
 - You must have another `kubeconfig` pointing to an existing kcp instance, that you wish to deploy to. You can use either a CPS or a local kcp instance.
 - The script `./hack/setup/install-pre-req.sh` will install these prerequisites for you, if they're not already installed.
@@ -63,7 +65,7 @@ See [hack/quicklab/README.md](hack/quicklab/README.md)
 
 To boostrap AppStudio run:
 ```bash
-./hack/bootstrap.sh -kk [kubeconfig-pointing-to-kcp] -ck [kubeconfig-pointing-to-openshift] -rw [workspace-to-be-used-as-root] -m [mode|upstream,dev,preview]
+./hack/bootstrap.sh -kk [kubeconfig-pointing-to-kcp] -ck [kubeconfig-pointing-to-openshift] -rw [workspace-to-be-used-as-root] -m [mode|upstream,dev,preview-ckcp,preview-cps]
 ```
 which will:
 * Bootstrap Argo CD (using OpenShift GitOps) - it will output the Argo CD Web UI route when it's finished.
@@ -72,20 +74,20 @@ which will:
 * Setup the Argo CD `Application`/`ApplicationSet` Custom Resources (CRs) for each component.
 
 #### Modes:
-* `upstream` (default) mode will expect access to both CPS instances `kcp-stable` and `kcp-unstable` - each of them should be represented by a kubeconfig context having the same name as the CPS instance.  
-* `dev` mode will use one kcp instance as the deployment target - it can be any instance (either CPS or local kcp). The current kubeconfig context should point to it.  
-* `preview` mode will enable preview mode used for development and testing on non-production clusters using the same deployment target as `dev` mode. See [Preview mode for your clusters](#preview-mode-for-your-clusters).
+* `upstream` (default) mode will expect access to both CPS instances `kcp-stable` and `kcp-unstable` - each of them should be represented by a kubeconfig context having the same name as the CPS instance.
+* `dev` mode will use one kcp instance as the deployment target - it can be any instance (either CPS or local kcp). The current kubeconfig context should point to it.
+* `preview-[ckcp,cps]` mode will enable preview mode used for development and testing on non-production clusters using the same deployment target as `dev` mode. See [Preview mode for your clusters](#preview-mode-for-your-clusters).
 
 #### Workspaces:
-If `-rw | --root-workspace` parameter is not specified, then by default, all workspaces are automatically created under the `root` workspace.  
+If `-rw | --root-workspace` parameter is not specified, then by default, all workspaces are automatically created under the `root` workspace.
 There are two workspaces created per kcp instance:
-* `redhat-appstudio-internal-compute` - This is the workspace where the SyncTarget for the OpenShift workload cluster is configured. If the root workspace is different from `root`, then the name of the workspace is set to `compute` to work around [this issue](https://github.com/kcp-dev/kcp/issues/1843). (The name of the workspace can be overridden by setting the `COMPUTE_WORKSPACE` variable) 
-* `redhat-appstudio` - In this workspace ArgoCD deploys all kcp-related manifests from the infra-deployments repository. It's the place where all AppStudio components run. (The name of the workspace can be overridden by setting the `APPSTUDIO_WORSKPACE` variable)  
+* `redhat-appstudio-internal-compute` - This is the workspace where the SyncTarget for the OpenShift workload cluster is configured. If the root workspace is different from `root`, then the name of the workspace is set to `compute` to work around [this issue](https://github.com/kcp-dev/kcp/issues/1843). (The name of the workspace can be overridden by setting the `COMPUTE_WORKSPACE` variable)
+* `redhat-appstudio` - In this workspace ArgoCD deploys all kcp-related manifests from the infra-deployments repository. It's the place where all AppStudio components run. (The name of the workspace can be overridden by setting the `APPSTUDIO_WORKSPACE` variable)
 
 #### Configure kcp for upstream mode:
 If you decide to run the upstream mode, then the `bootstrap.sh` script tries to configure two instances of kcp: `kcp-stable` and `kcp-unstable`. However, `kcp-stable` instance may require different version of kubectl kcp plugin than the `kcp-unstable` one. This makes running the bootstrap script impossible for the upstream mode, because you cannot use two versions of the plugin at the same time.
 
-To work around the issue, you can skip the configuration of the kcp part by using `-sk | --skip-kcp parameter <true/false>`:  
+To work around the issue, you can skip the configuration of the kcp part by using `-sk | --skip-kcp parameter <true/false>`:
 ```bash
 ./hack/bootstrap.sh -sk true ...
 ```
@@ -109,7 +111,7 @@ Even with 6 CPU cores, you will need to reduce the CPU resource requests for eac
 
 ## Preview mode for your clusters
 
-Once you bootstrap your environment without `preview` argument, the root ArgoCD Application and all of the component applications will each point to the upstream repository. Or you can bootstrap cluster directly in mode which you need.
+Once you bootstrap your environment without `-m preview-ckcp` or `-m preview-cps`, the root ArgoCD Application and all of the component applications will each point to the upstream repository. Or you can bootstrap cluster directly in mode which you need.
 
 To enable development for a team or individual to test changes on your own cluster, you need to replace the references to `https://github.com/redhat-appstudio/infra-deployments.git` with references to your own fork.
 
@@ -119,6 +121,21 @@ There is a development configuration in `argo-cd-apps/overlays/development` whic
 The script also supports branches automatically. If you work in a checked out branch, each of the components in the overlays will mapped to that branch by setting `targetRevision:`.
 
 Preview mode works in a feature branch, apply script which creates new preview branch and create additional commit with customization.
+
+### Bootstrapping with Preview modes
+
+Two preview modes are offered:
+
+- `preview-ckcp` deploys containerized KCP directly into your cluster and connects the cluster. Kubeconfig will be stored in `hack/ckcp-kubeconfig`
+- `preview-cps` connects to CPS instance. Before the mode is used the kubeconfig file `hack/cps-kubeconfig` must be created manually based on 'CSP onboarding document'
+
+Usage:
+
+```
+./hack/bootstrap.sh -m preview-ckcp
+or
+./hack/bootstrap.sh -m preview-cps
+```
 
 ### Setting Preview mode
 

--- a/components/ckcp/cert-manager.yaml
+++ b/components/ckcp/cert-manager.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: openshift-cert-manager-operator
+  namespace: openshift-operators
+spec:
+  channel: tech-preview
+  installPlanApproval: Automatic
+  name: openshift-cert-manager-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace

--- a/components/ckcp/certs.yaml
+++ b/components/ckcp/certs.yaml
@@ -1,0 +1,78 @@
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: kcp-pki-bootstrap
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: kcp-ca
+spec:
+  isCA: true
+  commonName: kcp-ca
+  secretName: kcp-ca
+  privateKey:
+    algorithm: RSA
+    size: 2048
+  issuerRef:
+    name: kcp-pki-bootstrap
+    kind: Issuer
+    group: cert-manager.io
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: kcp-requestheader-client-ca
+spec:
+  isCA: true
+  commonName: kcp-requestheader-client-ca
+  secretName: kcp-requestheader-client-ca
+  privateKey:
+    algorithm: RSA
+    size: 2048
+  issuerRef:
+    name: kcp-pki-bootstrap
+    kind: Issuer
+    group: cert-manager.io
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: kcp-server-issuer
+spec:
+  ca:
+    secretName: kcp-ca
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: kcp-requestheader-client-issuer
+spec:
+  ca:
+    secretName: kcp-requestheader-client-ca
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: kcp
+spec:
+  secretName: kcp-cert
+  duration: 2160h0m0s # 90d
+  renewBefore: 360h0m0s # 15d
+  subject:
+    organizations:
+      - redhat
+  privateKey:
+    algorithm: RSA
+    encoding: PKCS1
+    size: 2048
+  usages:
+    - server auth
+  dnsNames:
+    - localhost
+    - $HOSTNAME
+  issuerRef:
+    name: kcp-server-issuer

--- a/components/ckcp/deployment.yaml
+++ b/components/ckcp/deployment.yaml
@@ -1,0 +1,65 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ckcp
+  labels:
+    app: kcp-in-a-pod
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kcp-in-a-pod
+  template:
+    metadata:
+      labels:
+        app: kcp-in-a-pod
+    spec:
+      containers:
+        - name: kcp
+          image: ghcr.io/kcp-dev/kcp:v0.7.10
+          ports:
+            - containerPort: 6443
+          command:
+            - /kcp
+          args:
+            - start
+            - --auto-publish-apis=true
+            - --tls-private-key-file=/etc/kcp/tls/server/tls.key
+            - --tls-cert-file=/etc/kcp/tls/server/tls.crt
+            - --requestheader-client-ca-file=/etc/kcp/tls/requestheader-client/ca.crt
+            - --requestheader-username-headers=X-Remote-User
+            - --requestheader-group-headers=X-Remote-Group
+            - --root-directory=/etc/kcp/config
+            - --run-virtual-workspaces=true
+            - --external-hostname=$(EXTERNAL_HOSTNAME):443
+            - --v=2
+          env:
+            - name: EXTERNAL_HOSTNAME
+              value: $HOSTNAME
+          resources:
+            limits:
+              memory: 2Gi
+            requests:
+              cpu: 100m
+              memory: 178Mi
+          volumeMounts:
+            - name: kcp-certs
+              mountPath: /etc/kcp/tls/server
+            - name: kcp-requestheader-client-ca
+              mountPath: /etc/kcp/tls/requestheader-client
+            - name: kubeconfig
+              mountPath: /etc/kcp/config
+      volumes:
+        - name: kcp-certs
+          secret:
+            secretName: kcp-cert
+        - name: kcp-requestheader-client-ca
+          secret:
+            secretName: kcp-requestheader-client-ca
+            items:
+              - key: ca.crt
+                path: ca.crt
+        - name: kubeconfig
+          persistentVolumeClaim:
+            claimName: kcp

--- a/components/ckcp/deployment.yaml
+++ b/components/ckcp/deployment.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: kcp
-          image: ghcr.io/kcp-dev/kcp:v0.7.10
+          image: ghcr.io/kcp-dev/kcp:v0.8.0
           ports:
             - containerPort: 6443
           command:

--- a/components/ckcp/kustomization.yaml
+++ b/components/ckcp/kustomization.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: ckcp
+
+resources:
+  - namespace.yaml
+  - pvc.yaml
+  - deployment.yaml
+  - service.yaml
+  - certs.yaml

--- a/components/ckcp/namespace.yaml
+++ b/components/ckcp/namespace.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    app.kubernetes.io/instance: ckcp
+  name: ckcp

--- a/components/ckcp/pvc.yaml
+++ b/components/ckcp/pvc.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: kcp
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Mi
+  volumeMode: Filesystem

--- a/components/ckcp/route.yaml
+++ b/components/ckcp/route.yaml
@@ -1,0 +1,13 @@
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: ckcp
+  namespace: ckcp
+spec:
+  to:
+    kind: Service
+    name: ckcp
+  port:
+    targetPort: kcp
+  tls:
+    termination: passthrough

--- a/components/ckcp/service.yaml
+++ b/components/ckcp/service.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ckcp
+  labels:
+    app: kcp-in-a-pod
+spec:
+  ports:
+    - name: kcp
+      protocol: TCP
+      port: 6443
+      targetPort: 6443
+  selector:
+    app: kcp-in-a-pod

--- a/hack/bootstrap.sh
+++ b/hack/bootstrap.sh
@@ -8,6 +8,12 @@ function extra_params() {
       shift
       MODE=$1
       shift
+      if echo $MODE | grep -q preview; then
+        if [ -z "$CLUSTER_KUBECONFIG" ]; then
+          export CLUSTER_KUBECONFIG=$HOME/.kube/config
+        fi
+        KCP_KUBECONFIG=placeholder
+      fi
       ;;
     -sk|--skip-kcp)
       shift
@@ -29,6 +35,10 @@ function extra_help() {
 
 source ${ROOT}/hack/flags.sh "The bootstrap.sh script installs and configures ArgoCD in Openshift cluster and configures service provider workspaces." extra_params extra_help
 parse_flags $@
+
+if [ -z "$CLUSTER_KUBECONFIG" ]; then
+  CLUSTER_KUBECONFIG=$HOME/.kube/config
+fi
 
 if [ "$(oc auth can-i '*' '*' --all-namespaces --kubeconfig ${CLUSTER_KUBECONFIG})" != "yes" ]; then
   echo
@@ -143,7 +153,6 @@ echo
 echo "========================================================================="
 echo
 
-
 configure_kcp() {
   if [[ "${SKIP_KCP}" == "true" ]]
   then
@@ -184,6 +193,10 @@ case $MODE in
         echo "These changes need to be pushed to your fork to be seen by argocd"
         $ROOT/hack/util-set-development-repos.sh ${MY_GIT_REPO_URL} development ${MY_GIT_BRANCH}
         ;;
-    "preview")
-        $ROOT/hack/preview.sh ;;
+    "preview-ckcp")
+        export KCP_KUBECONFIG=$ROOT/hack/ckcp-kubeconfig
+        $ROOT/hack/install-ckcp.sh
+        $ROOT/hack/configure-kcp.sh -kn dev --insecure true
+        $ROOT/hack/preview.sh
+        ;;
 esac

--- a/hack/bootstrap.sh
+++ b/hack/bootstrap.sh
@@ -160,7 +160,7 @@ configure_kcp() {
   else
     if [[ ${2} == "true" ]]
     then
-      kubectl config use ${1}
+      KUBECONFIG=$KCP_KUBECONFIG kubectl config use ${1}
     fi
     source ${ROOT}/hack/configure-kcp.sh -kn ${1}
   fi
@@ -192,6 +192,14 @@ case $MODE in
         echo "Resetting the default repos in the development directory to be the current git repo:"
         echo "These changes need to be pushed to your fork to be seen by argocd"
         $ROOT/hack/util-set-development-repos.sh ${MY_GIT_REPO_URL} development ${MY_GIT_BRANCH}
+        ;;
+    "preview-cps")
+        export KCP_KUBECONFIG=$ROOT/hack/cps-kubeconfig
+        export ROOT_WORKSPACE='~'
+        rm -f $ROOT/hack/ckcp-kubeconfig
+        KUBECONFIG=$KCP_KUBECONFIG kubectl config use kcp-stable-root
+        $ROOT/hack/configure-kcp.sh -kn dev
+        $ROOT/hack/preview.sh
         ;;
     "preview-ckcp")
         export KCP_KUBECONFIG=$ROOT/hack/ckcp-kubeconfig

--- a/hack/configure-kcp.sh
+++ b/hack/configure-kcp.sh
@@ -104,12 +104,21 @@ done
 echo " OK"
 echo
 
-APPSTUDIO_WORSKPACE=${APPSTUDIO_WORSKPACE:-"redhat-appstudio"}
-echo "Creating and accessing '${APPSTUDIO_WORSKPACE}' for AppStudio controllers:"
+APPSTUDIO_WORKSPACE=${APPSTUDIO_WORKSPACE:-"redhat-appstudio"}
+echo "Creating and accessing '${APPSTUDIO_WORKSPACE}' for AppStudio controllers:"
 KUBECONFIG=${KCP_KUBECONFIG} kubectl ws ${ROOT_WORKSPACE}
-KUBECONFIG=${KCP_KUBECONFIG} kubectl ws create ${APPSTUDIO_WORSKPACE} --ignore-existing --type root:universal || true
-REDHAT_APPSTUDIO_URL=$(KUBECONFIG=${KCP_KUBECONFIG} kubectl get workspaces ${APPSTUDIO_WORSKPACE} -o jsonpath='{.status.URL}')
-KUBECONFIG=${KCP_KUBECONFIG} kubectl ws ${APPSTUDIO_WORSKPACE}
+
+if [ "$ROOT_WORKSPACE" == "~" ]; then
+  CURRENT_WS=$(KUBECONFIG=${KCP_KUBECONFIG} kubectl ws . | cut -f2 -d'"')
+  COMPUTE_WORKSPACE_PATH=${CURRENT_WS}:${COMPUTE_WORKSPACE}
+else
+  COMPUTE_WORKSPACE_PATH=${ROOT_WORKSPACE}:${COMPUTE_WORKSPACE}
+fi
+
+
+KUBECONFIG=${KCP_KUBECONFIG} kubectl ws create ${APPSTUDIO_WORKSPACE} --ignore-existing --type root:universal || true
+REDHAT_APPSTUDIO_URL=$(KUBECONFIG=${KCP_KUBECONFIG} kubectl get workspaces ${APPSTUDIO_WORKSPACE} -o jsonpath='{.status.URL}')
+KUBECONFIG=${KCP_KUBECONFIG} kubectl ws ${APPSTUDIO_WORKSPACE}
 
 echo "Creating APIBinding '${SYNC_TARGET}' for the compute"
 cat <<EOF | kubectl apply --kubeconfig ${KCP_KUBECONFIG} -f -
@@ -121,7 +130,7 @@ spec:
   reference:
     workspace:
       exportName: kubernetes
-      path: ${ROOT_WORKSPACE}:${COMPUTE_WORKSPACE}
+      path: $COMPUTE_WORKSPACE_PATH
 EOF
 
 echo -n "Waiting for APIBinding '${SYNC_TARGET}' to be bound:"
@@ -132,15 +141,15 @@ done
 echo " OK"
 echo
 
-echo "Adding Role/RoleBindings for OpenShift GitOps in ${APPSTUDIO_WORSKPACE} workspace:"
+echo "Adding Role/RoleBindings for OpenShift GitOps in ${APPSTUDIO_WORKSPACE} workspace:"
 kubectl apply --kustomize $ROOT/openshift-gitops/in-kcp --kubeconfig ${KCP_KUBECONFIG}
 echo
 
-echo "Getting a token for argocd SA (in ${APPSTUDIO_WORSKPACE} workspace) - kubectl 1.24.x or newer needs to be used."
+echo "Getting a token for argocd SA (in ${APPSTUDIO_WORKSPACE} workspace) - kubectl 1.24.x or newer needs to be used."
 SA_TOKEN=$(kubectl create token argocd --duration 876000h -n controllers-argocd-manager --kubeconfig ${KCP_KUBECONFIG})
 echo
 
-echo "Creating ArgoCD secret representing '${APPSTUDIO_WORSKPACE}' workspace with URL '${REDHAT_APPSTUDIO_URL}' in the compute OpenShift cluster:"
+echo "Creating ArgoCD secret representing '${APPSTUDIO_WORKSPACE}' workspace with URL '${REDHAT_APPSTUDIO_URL}' in the compute OpenShift cluster:"
 cat <<EOF | kubectl apply --kubeconfig ${CLUSTER_KUBECONFIG} -f -
 apiVersion: v1
 kind: Secret

--- a/hack/configure-kcp.sh
+++ b/hack/configure-kcp.sh
@@ -26,6 +26,7 @@ function extra_params() {
 
 function extra_help() {
   echo "-kn, --kcp-name               The name of the kcp instance - eg. kcp-stable, kcp-unstable (default is 'dev')"
+  echo "--insecure                    Disable SSL check for KCP syncer when set to 'true'"
 }
 
 source ${ROOT}/hack/flags.sh "The configure-kcp.sh configures the kcp instance with the needed workspaces and a workload cluster. The current context of the kcp kubeconfig should point to the kcp instance." extra_params extra_help

--- a/hack/flags.sh
+++ b/hack/flags.sh
@@ -39,11 +39,6 @@ parse_flags() {
         export ROOT_WORKSPACE=$1
         shift
         ;;
-      -m|--mode)
-        shift
-        export MODE=$1
-        shift
-        ;;
       *)
         if [[ -n ${EXTRA_PARAMS} ]]
         then
@@ -59,7 +54,7 @@ parse_flags() {
     esac
   done
 
-  if [[ -z ${KCP_KUBECONFIG} ]] || [[ -z ${KCP_KUBECONFIG} ]]
+  if [[ -z ${KCP_KUBECONFIG} ]] || [[ -z ${CLUSTER_KUBECONFIG} ]]
   then
     echo "ERROR: Both parameters --kcp-kubeconfig and --cluster-kubeconfig are mandatory" >&2
     exit 1

--- a/hack/install-ckcp.sh
+++ b/hack/install-ckcp.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"/..
+
+oc apply -f $ROOT/components/ckcp/cert-manager.yaml
+oc apply -f $ROOT/components/ckcp/namespace.yaml
+oc apply -f $ROOT/components/ckcp/route.yaml
+
+URL=$(oc get route -n ckcp ckcp -o jsonpath={.spec.host})
+TMP_FILE=$(mktemp)
+oc kustomize $ROOT/components/ckcp | sed "s/\$HOSTNAME/$URL/" > $TMP_FILE
+while ! oc apply -f $TMP_FILE; do
+  sleep 10
+done
+rm $TMP_FILE
+
+while ! oc rsh -n ckcp deployment/ckcp ls /etc/kcp/config/admin.kubeconfig; do
+  sleep 10
+done
+oc rsh -n ckcp deployment/ckcp sed 's/certificate-authority-data: .*/insecure-skip-tls-verify: true/' /etc/kcp/config/admin.kubeconfig > $KCP_KUBECONFIG

--- a/hack/preview-template.env
+++ b/hack/preview-template.env
@@ -12,6 +12,18 @@ export MY_GITHUB_TOKEN=
 
 # Optional
 
+## Cluster and KCP config
+### Set cluster kubeconfig so it's not needed to pass it as parameter
+### example: $HOME/.kube/config
+export CLUSTER_KUBECONFIG=
+### KCP cluster kubeconfig so it's not needed to pass it as parameter
+### This file is managed by preview script
+### example: $HOME/.kube/preview-kcp
+export KCP_KUBECONFIG=
+### Path to CPS kubeconfig which will be copied when using preview-cps mode
+### example: $HOME/.kube/cps
+export CPS_KUBECONFIG=
+
 ## HAS enable github integration
 ### Override default Application service "image push" repository
 export HAS_DEFAULT_IMAGE_REPOSITORY=

--- a/hack/preview.sh
+++ b/hack/preview.sh
@@ -2,12 +2,17 @@
 
 ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"/..
 
-source ${ROOT}/hack/flags.sh "The preview.sh enable preview mode used for development and testing on non-production clusters / kcp instances."
-parse_flags $@
-
 if [ -f $ROOT/hack/preview.env ]; then
     source $ROOT/hack/preview.env
 fi
+
+CLUSTER_KUBECONFIG=$HOME/.kube/config
+if [ -z "$KCP_KUBECONFIG" ]; then
+    KCP_KUBECONFIG=$ROOT/hack/ckcp-kubeconfig
+fi
+
+source ${ROOT}/hack/flags.sh "The preview.sh enable preview mode used for development and testing on non-production clusters / kcp instances."
+parse_flags $@
 
 if [ -z "$MY_GIT_FORK_REMOTE" ]; then
     echo "Set MY_GIT_FORK_REMOTE environment to name of your fork remote"
@@ -58,7 +63,7 @@ git checkout $MY_GIT_BRANCH
 #set the local cluster to point to the current git repo and branch and update the path to development
 $ROOT/hack/util-update-app-of-apps.sh $MY_GIT_REPO_URL development $PREVIEW_BRANCH
 
-while [ "$(oc get applications.argoproj.io all-components-staging -n openshift-gitops -o jsonpath='{.status.health.status} {.status.sync.status}')" != "Healthy Synced" ]; do
+while [ "$(oc get applications.argoproj.io all-components -n openshift-gitops -o jsonpath='{.status.health.status} {.status.sync.status}')" != "Healthy Synced" ]; do
   sleep 5
 done
 

--- a/hack/preview.sh
+++ b/hack/preview.sh
@@ -6,15 +6,6 @@ if [ -f $ROOT/hack/preview.env ]; then
     source $ROOT/hack/preview.env
 fi
 
-CLUSTER_KUBECONFIG=$HOME/.kube/config
-if [ -z "$KCP_KUBECONFIG" ]; then
-    if [ -f $ROOT/hack/ckcp-kubeconfig ]; then
-        KCP_KUBECONFIG=$ROOT/hack/ckcp-kubeconfig
-    else
-        KCP_KUBECONFIG=$ROOT/hack/cps-kubeconfig
-    fi
-fi
-
 source ${ROOT}/hack/flags.sh "The preview.sh enable preview mode used for development and testing on non-production clusters / kcp instances."
 parse_flags $@
 

--- a/hack/preview.sh
+++ b/hack/preview.sh
@@ -8,7 +8,11 @@ fi
 
 CLUSTER_KUBECONFIG=$HOME/.kube/config
 if [ -z "$KCP_KUBECONFIG" ]; then
-    KCP_KUBECONFIG=$ROOT/hack/ckcp-kubeconfig
+    if [ -f $ROOT/hack/ckcp-kubeconfig ]; then
+        KCP_KUBECONFIG=$ROOT/hack/ckcp-kubeconfig
+    else
+        KCP_KUBECONFIG=$ROOT/hack/cps-kubeconfig
+    fi
 fi
 
 source ${ROOT}/hack/flags.sh "The preview.sh enable preview mode used for development and testing on non-production clusters / kcp instances."
@@ -80,7 +84,8 @@ while [ -n "$(oc get applications.argoproj.io -n openshift-gitops -o jsonpath='{
 done
 
 INTERVAL=10
-while :; do
+# Disabling check of healthy apps for now till envineronment is more stable
+while false; do
   STATE=$(kubectl get apps -n openshift-gitops --no-headers)
   NOT_DONE=$(echo "$STATE" | grep -v "Synced[[:blank:]]*Healthy")
   echo "$NOT_DONE"

--- a/hack/util-set-github-org
+++ b/hack/util-set-github-org
@@ -8,12 +8,13 @@ yq e -i "(.configMapGenerator[].literals[] | select(. == \"*GITHUB*\")) = \"GITH
 KUBECONFIG_PARAM=""
 if [[ -n ${KCP_KUBECONFIG} ]]
 then
+  echo $KCP_KUBECONFIG
   KUBECONFIG_PARAM="--kubeconfig ${KCP_KUBECONFIG}"
 fi
 
 if [ -n "$MY_GITHUB_TOKEN" ]; then
     echo
     echo "Setting gitHub token"
-    oc create namespace application-service --dry-run=client -o yaml --kubeconfig ${KUBECONFIG_PARAM} | oc apply --kubeconfig ${KUBECONFIG_PARAM} -f -
-    oc create -n application-service secret generic has-github-token --from-literal=token="$MY_GITHUB_TOKEN" --dry-run=client -o yaml --kubeconfig ${KUBECONFIG_PARAM} | oc apply --kubeconfig ${KUBECONFIG_PARAM} -f -
+    oc create namespace application-service --dry-run=client -o yaml | oc apply ${KUBECONFIG_PARAM} -f -
+    oc create -n application-service secret generic has-github-token --from-literal=token="$MY_GITHUB_TOKEN" --dry-run=client -o yaml | oc apply ${KUBECONFIG_PARAM} -f -
 fi


### PR DESCRIPTION
Adding two preview modes:
- preview-ckcp - creates containerized KCP inside target cluster, useful for e2e testing
- preview-cps - connects to CPS instance, requires to create `hack/cps-kubeconfig` manually

Usage:
```
./hack/bootstrap.sh -m preview-ckcp
or
./hack/bootstrap.sh -m preview-cps
```
And then for each change just run `./hack/preview.sh`