### PR TITLE
make install-ckcp.sh independent of preview vars

### DIFF
--- a/hack/bootstrap.sh
+++ b/hack/bootstrap.sh
@@ -199,7 +199,10 @@ case $MODE in
         $ROOT/hack/preview.sh
         ;;
     "preview-ckcp")
-        KUBECONFIG=${CLUSTER_KUBECONFIG} $ROOT/hack/install-ckcp.sh
+        CKCP_KUBECONFIG=${CKCP_KUBECONFIG:-/tmp/ckcp-admin.kubeconfig}
+        KUBECONFIG=${CLUSTER_KUBECONFIG} CKCP_KUBECONFIG=${CKCP_KUBECONFIG} $ROOT/hack/install-ckcp.sh
+
+        export KCP_KUBECONFIG=${CKCP_KUBECONFIG}
         $ROOT/hack/configure-kcp.sh -kn dev --insecure true
         $ROOT/hack/preview.sh
         ;;

--- a/hack/install-ckcp.sh
+++ b/hack/install-ckcp.sh
@@ -17,4 +17,15 @@ rm $TMP_FILE
 while ! oc rsh -n ckcp deployment/ckcp ls /etc/kcp/config/admin.kubeconfig; do
   sleep 10
 done
-oc rsh -n ckcp deployment/ckcp sed 's/certificate-authority-data: .*/insecure-skip-tls-verify: true/' /etc/kcp/config/admin.kubeconfig > $KCP_KUBECONFIG
+
+CKCP_KUBECONFIG=${CKCP_KUBECONFIG:-/tmp/ckcp-admin.kubeconfig}
+oc rsh -n ckcp deployment/ckcp sed 's/certificate-authority-data: .*/insecure-skip-tls-verify: true/' /etc/kcp/config/admin.kubeconfig > ${CKCP_KUBECONFIG}
+
+echo
+echo "=========================================================================================="
+echo "ckcp admin kubeconfig was stored in ${CKCP_KUBECONFIG}. To use the kubeconfig run:"
+echo
+echo "export KUBECONFIG=${CKCP_KUBECONFIG}"
+echo
+echo "=========================================================================================="
+echo


### PR DESCRIPTION
With these changes:
* I can run `install-ckcp.sh` on its own independently of using the preview vars
* I can customize the target of the ckcp kubeconfig
* `bootstap.sh` script doesn't override the KCP_KUBECONFIG

I'm trying to avoid relying on two kcp kubeconfig variables `CPS_KUBECONFIG` & `KCP_KUBECONFIG` - I would love to use only one `KCP_KUBECONFIG` 