### PR TITLE
Unify code to use one preview mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Usage:
 ### Containerized KCP installation
 
 For testing purposes it is possible to use script for installation of containerized KCP directly into your OpenShift cluster.
-`hack/preview.env` must be set before running the command. Kubeconfig of containerized KCP will be stored in file pointed by KCP_KUBECONFIG environment variable.
+The script creates file `/tmp/ckcp-admin.kubeconfig` which should be copied to location defined by `KCP_KUBECONFIG` in `hack/preview.env`.
 
 Usage:
 ```

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ See [hack/quicklab/README.md](hack/quicklab/README.md)
 
 To boostrap AppStudio run:
 ```bash
-./hack/bootstrap.sh -kk [kubeconfig-pointing-to-kcp] -ck [kubeconfig-pointing-to-openshift] -rw [workspace-to-be-used-as-root] -m [mode|upstream,dev,preview-ckcp,preview-cps]
+./hack/bootstrap.sh -kk [kubeconfig-pointing-to-kcp] -ck [kubeconfig-pointing-to-openshift] -rw [workspace-to-be-used-as-root] -m [mode|upstream,dev,preview]
 ```
 which will:
 * Bootstrap Argo CD (using OpenShift GitOps) - it will output the Argo CD Web UI route when it's finished.
@@ -75,8 +75,7 @@ which will:
 
 #### Modes:
 * `upstream` (default) mode will expect access to both CPS instances `kcp-stable` and `kcp-unstable` - each of them should be represented by a kubeconfig context having the same name as the CPS instance.
-* `dev` mode will use one kcp instance as the deployment target - it can be any instance (either CPS or local kcp). The current kubeconfig context should point to it.
-* `preview-[ckcp,cps]` mode will enable preview mode used for development and testing on non-production clusters using the same deployment target as `dev` mode. See [Preview mode for your clusters](#preview-mode-for-your-clusters).
+* `preview` mode will enable preview mode used for development and testing on non-production clusters using cluster and KCP kubeconfig defined in `hack/preview.env`. See [Preview mode for your clusters](#preview-mode-for-your-clusters).
 
 #### Workspaces:
 If `-rw | --root-workspace` parameter is not specified, then by default, all workspaces are automatically created under the `root` workspace.
@@ -111,7 +110,7 @@ Even with 6 CPU cores, you will need to reduce the CPU resource requests for eac
 
 ## Preview mode for your clusters
 
-Once you bootstrap your environment without `-m preview-ckcp` or `-m preview-cps`, the root ArgoCD Application and all of the component applications will each point to the upstream repository. Or you can bootstrap cluster directly in mode which you need.
+Once you bootstrap your environment without `-m preview`, the root ArgoCD Application and all of the component applications will each point to the upstream repository. Or you can bootstrap cluster directly in mode which you need.
 
 To enable development for a team or individual to test changes on your own cluster, you need to replace the references to `https://github.com/redhat-appstudio/infra-deployments.git` with references to your own fork.
 
@@ -122,19 +121,25 @@ The script also supports branches automatically. If you work in a checked out br
 
 Preview mode works in a feature branch, apply script which creates new preview branch and create additional commit with customization.
 
-### Bootstrapping with Preview modes
+### Bootstrapping with Preview mode
 
-Two preview modes are offered:
-
-- `preview-ckcp` deploys containerized KCP directly into your cluster and connects the cluster.
-- `preview-cps` connects to CPS instance. Before the mode is used the kubeconfig file must be created manually based on 'CSP onboarding document' and set `CPS_KUBECONFIG` variable in `hack/preview.env`
+To set your cluster, connect it to KCP instance and deploy components with modifications from current branch it is possible to bootstrap the cluster in preview mode directly. Configure `hack/preview.env` before running `bootstrap.sh`.
 
 Usage:
 
 ```
-./hack/bootstrap.sh -m preview-ckcp
-or
-./hack/bootstrap.sh -m preview-cps
+./hack/bootstrap.sh -m preview
+```
+
+### Containerized KCP installation
+
+For testing purposes it is possible to use script for installation of containerized KCP directly into your OpenShift cluster.
+`hack/preview.env` must be set before running the command. Kubeconfig of containerized KCP will be stored in file pointed by KCP_KUBECONFIG environment variable.
+
+Usage:
+```
+./hack/install-ckcp.sh
+echo 'export KCP_INSECURE_CONNECTION=true' >> ./hack/preview.env
 ```
 
 ### Setting Preview mode

--- a/README.md
+++ b/README.md
@@ -139,7 +139,6 @@ For testing purposes it is possible to use script for installation of containeri
 Usage:
 ```
 ./hack/install-ckcp.sh
-echo 'export KCP_INSECURE_CONNECTION=true' >> ./hack/preview.env
 ```
 
 ### Setting Preview mode

--- a/hack/bootstrap.sh
+++ b/hack/bootstrap.sh
@@ -172,7 +172,7 @@ configure_kcp() {
     then
       kubectl config use ${1} --kubeconfig ${KCP_KUBECONFIG}
     fi
-    ${ROOT}/hack/configure-kcp.sh -kn ${1} --insecure ${3:-false}
+    ${ROOT}/hack/configure-kcp.sh -kn ${1}
   fi
 }
 
@@ -185,7 +185,7 @@ case $MODE in
         kubectl apply -f $ROOT/argo-cd-apps/app-of-apps/all-applications.yaml --kubeconfig ${CLUSTER_KUBECONFIG}
         ;;
     "preview")
-        configure_kcp dev "false" ${KCP_INSECURE_CONNECTION:-false}
+        configure_kcp dev "false"
         $ROOT/hack/preview.sh
         ;;
 esac

--- a/hack/bootstrap.sh
+++ b/hack/bootstrap.sh
@@ -41,23 +41,6 @@ if [ "$(oc auth can-i '*' '*' --all-namespaces --kubeconfig ${CLUSTER_KUBECONFIG
 fi
 
 echo
-echo "Checking KUBECONFIG files"
-if kubectl version -o yaml --kubeconfig ${CLUSTER_KUBECONFIG} | yq '.serverVersion.gitVersion' | grep -q kcp; then
-  echo CLUSTER_KUBECONFIG=${CLUSTER_KUBECONFIG} points to KCP not to cluster.
-  exit 1
-fi
-KCP_SERVER_VERSION=$(kubectl version -o yaml --kubeconfig ${KCP_KUBECONFIG} | yq '.serverVersion.gitVersion')
-if ! echo "$KCP_SERVER_VERSION" | grep -q kcp; then
-  echo KCP_KUBECONFIG=${KCP_KUBECONFIG} does not point to KCP cluster.
-  exit 1
-fi
-KCP_SERVER=$(echo $KCP_SERVER_VERSION | sed 's/.*kcp-v\(.*\)\..*/\1/')
-KCP_CLIENT=$(kubectl kcp --version | sed 's/.*kcp-v\(.*\)\..*/\1/')
-if [ "$KCP_SERVER" != "$KCP_CLIENT" ]; then
-  echo "KCP server version($KCP_SERVER) does not match kcp plugin version($KCP_CLIENT)"
-  exit 1
-fi
-echo
 echo "Installing the OpenShift GitOps operator subscription:"
 kubectl apply -f $ROOT/openshift-gitops/subscription-openshift-gitops.yaml --kubeconfig ${CLUSTER_KUBECONFIG}
 

--- a/hack/configure-kcp.sh
+++ b/hack/configure-kcp.sh
@@ -11,11 +11,6 @@ function extra_params() {
       KCP_INSTANCE_NAME=$1
       shift
       ;;
-    --insecure)
-      shift
-      INSECURE=$1
-      shift
-      ;;
     *)
      echo "ERROR: '$1' is not a recognized flag!" >&2
      user_help >&2
@@ -54,7 +49,7 @@ SYNC_TARGET=appstudio-internal
 if [[ -z "$(kubectl get synctargets.workload.kcp.dev ${SYNC_TARGET} --kubeconfig ${KCP_KUBECONFIG} 2>/dev/null)" ]]; then
   echo "Creating SyncTarget..."
   KUBECONFIG=${KCP_KUBECONFIG} kubectl kcp workload sync ${SYNC_TARGET} --syncer-image ghcr.io/kcp-dev/kcp/syncer:main --resources=services,routes.route.openshift.io -o /tmp/${SYNC_TARGET}-syncer.yaml
-  if [ "$INSECURE" == "true" ]; then
+  if grep -q "insecure-skip-tls-verify: true" ${KCP_KUBECONFIG}; then
     sed -i 's/certificate-authority-data: .*/insecure-skip-tls-verify: true/' /tmp/${SYNC_TARGET}-syncer.yaml
   fi
   kubectl apply -f /tmp/${SYNC_TARGET}-syncer.yaml --kubeconfig ${CLUSTER_KUBECONFIG}

--- a/hack/flags.sh
+++ b/hack/flags.sh
@@ -73,8 +73,10 @@ parse_flags() {
   fi
   KCP_SERVER=$(echo $KCP_SERVER_VERSION | sed 's/.*kcp-v\(.*\)\..*/\1/')
   KCP_CLIENT=$(kubectl kcp --version | sed 's/.*kcp-v\(.*\)\..*/\1/')
-  if echo $KCP_SERVER_VERSION | grep -q 'v0.0.0-master'; then
+  if echo "$KCP_SERVER_VERSION" | grep -q 'v0.0.0-master'; then
     echo "KCP server is self compiled, cannot check kubectl kcp plugin compatibility"
+  elif echo "$KCP_CLIENT" | grep -q 'v0.0.0-master'; then
+    echo "KCP kubectl plugin is self compiled, cannot check kubectl kcp plugin compatibility"
   elif [ "$KCP_SERVER" != "$KCP_CLIENT" ]; then
     echo "KCP server version($KCP_SERVER) does not match kcp plugin version($KCP_CLIENT)"
     exit 1

--- a/hack/flags.sh
+++ b/hack/flags.sh
@@ -67,7 +67,7 @@ parse_flags() {
     exit 1
   fi
   KCP_SERVER_VERSION=$(kubectl version -o yaml --kubeconfig ${KCP_KUBECONFIG} | yq '.serverVersion.gitVersion')
-  if ! echo "$KCP_SERVER_VERSION" | grep -q kcp; then
+  if ! echo "$KCP_SERVER_VERSION" | grep -q 'kcp\|v0.0.0-master'; then
     echo KCP_KUBECONFIG=${KCP_KUBECONFIG} does not point to KCP cluster.
     exit 1
   fi
@@ -75,8 +75,6 @@ parse_flags() {
   KCP_CLIENT=$(kubectl kcp --version | sed 's/.*kcp-v\(.*\)\..*/\1/')
   if echo "$KCP_SERVER_VERSION" | grep -q 'v0.0.0-master'; then
     echo "KCP server is self compiled, cannot check kubectl kcp plugin compatibility"
-  elif echo "$KCP_CLIENT" | grep -q 'v0.0.0-master'; then
-    echo "KCP kubectl plugin is self compiled, cannot check kubectl kcp plugin compatibility"
   elif [ "$KCP_SERVER" != "$KCP_CLIENT" ]; then
     echo "KCP server version($KCP_SERVER) does not match kcp plugin version($KCP_CLIENT)"
     exit 1

--- a/hack/install-ckcp.sh
+++ b/hack/install-ckcp.sh
@@ -36,7 +36,5 @@ echo "ckcp admin kubeconfig was stored in ${KCP_KUBECONFIG}. To use the kubeconf
 echo
 echo "export KUBECONFIG=${KCP_KUBECONFIG}"
 echo
-echo "Ensure that KCP_INSECURE_CONNECTION=true is set in 'hack/preview.env'"
-echo
 echo "=========================================================================================="
 echo

--- a/hack/preview-template.env
+++ b/hack/preview-template.env
@@ -4,6 +4,14 @@
 ## Example value: origin
 export MY_GIT_FORK_REMOTE=
 
+## Cluster and KCP config
+### Set cluster kubeconfig
+### example: $HOME/.kube/config
+export CLUSTER_KUBECONFIG=
+### Set KCP kubeconfig
+### example: $HOME/.kube/preview-kcp
+export KCP_KUBECONFIG=
+
 ## HAS enable github integration
 ### Your GITHUB organization where to manage repositories by HAS
 export MY_GITHUB_ORG=
@@ -13,16 +21,12 @@ export MY_GITHUB_TOKEN=
 # Optional
 
 ## Cluster and KCP config
-### Set cluster kubeconfig so it's not needed to pass it as parameter
-### example: $HOME/.kube/config
-export CLUSTER_KUBECONFIG=
-### KCP cluster kubeconfig so it's not needed to pass it as parameter
-### This file is managed by preview script
-### example: $HOME/.kube/preview-kcp
-export KCP_KUBECONFIG=
-### Path to CPS kubeconfig which will be copied when using preview-cps mode
-### example: $HOME/.kube/cps
-export CPS_KUBECONFIG=
+### KCP Workspace to deploy, default "~"
+### example: root:users:test
+export ROOT_WORKSPACE=
+### Insecure connection to KCP, default false
+### true or false
+export KCP_INSECURE_CONNECTION=
 
 ## HAS enable github integration
 ### Override default Application service "image push" repository

--- a/hack/preview-template.env
+++ b/hack/preview-template.env
@@ -22,7 +22,7 @@ export MY_GITHUB_TOKEN=
 
 ## Cluster and KCP config
 ### KCP Workspace to deploy, default "~"
-### example: root:users:test
+### example: root:test
 export ROOT_WORKSPACE=
 
 ## HAS enable github integration

--- a/hack/preview-template.env
+++ b/hack/preview-template.env
@@ -21,7 +21,8 @@ export MY_GITHUB_TOKEN=
 # Optional
 
 ## Cluster and KCP config
-### KCP Workspace to deploy, default "~"
+### KCP Workspace to deploy, default "root"
+### "~" can be used for home workspace
 ### example: root:test
 export ROOT_WORKSPACE=
 

--- a/hack/preview-template.env
+++ b/hack/preview-template.env
@@ -24,9 +24,6 @@ export MY_GITHUB_TOKEN=
 ### KCP Workspace to deploy, default "~"
 ### example: root:users:test
 export ROOT_WORKSPACE=
-### Insecure connection to KCP, default false
-### true or false
-export KCP_INSECURE_CONNECTION=
 
 ## HAS enable github integration
 ### Override default Application service "image push" repository


### PR DESCRIPTION
- Separate install-ckcp.sh from bootstrap.sh
- Use only KCP_KUBECONFIG and CLUSTER_KUBECONFIG directly
- Allow to define ROOT_WORKSPACE for default KCP workspace
- Add check of KCP client and KCP server version
- Add check of kubeconfig files