### PR TITLE
use one kcp kubeconfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Preview mode works in a feature branch, apply script which creates new preview b
 Two preview modes are offered:
 
 - `preview-ckcp` deploys containerized KCP directly into your cluster and connects the cluster.
-- `preview-cps` connects to CPS instance. Before the mode is used the kubeconfig file must be created manually based on 'CSP onboarding document' and set `CPS_KUBECONFIG` variable in `hack/preview.env`
+- `preview-cps` connects to CPS instance. Before the mode is used the kubeconfig file must be created manually based on 'CSP onboarding document' and set `KCP_KUBECONFIG` variable in `hack/preview.env`
 
 Usage:
 

--- a/hack/bootstrap.sh
+++ b/hack/bootstrap.sh
@@ -6,12 +6,12 @@ function extra_params() {
   case "$1" in
     -m|--mode)
       shift
-      MODE=$1
+      export MODE=$1
       shift
       ;;
     -sk|--skip-kcp)
       shift
-      SKIP_KCP=${1:-"true"}
+      export SKIP_KCP=${1:-"true"}
       shift
       ;;
     *)

--- a/hack/bootstrap.sh
+++ b/hack/bootstrap.sh
@@ -8,9 +8,6 @@ function extra_params() {
       shift
       MODE=$1
       shift
-      if echo $MODE | grep -q preview && [ -f $ROOT/hack/preview.env ]; then
-        source $ROOT/hack/preview.env
-      fi
       ;;
     -sk|--skip-kcp)
       shift
@@ -188,12 +185,6 @@ case $MODE in
         ;;
     "preview-cps")
         export ROOT_WORKSPACE='~'
-        if [ -f "$CPS_KUBECONFIG" ]; then
-          cp $CPS_KUBECONFIG $KCP_KUBECONFIG
-        else
-          echo "environment variable CPS_KUBECONFIG must be set and point to kubeconfig of CPS"
-          exit 1
-        fi
         KUBECONFIG=$KCP_KUBECONFIG kubectl config use kcp-stable-root
         $ROOT/hack/configure-kcp.sh -kn dev
         $ROOT/hack/preview.sh

--- a/hack/flags.sh
+++ b/hack/flags.sh
@@ -9,9 +9,9 @@ user_help () {
   echo "options:"
   echo "-h,  --help                   Show this help info"
   echo "-kk, --kcp-kubeconfig         Kubeconfig pointing to the kcp instance."
-  ehco "                              Don't use in any of the preview modes - use only the preview.env file."
+  echo "                              Don't use in any of the preview modes - use only the preview.env file."
   echo "-ck, --cluster-kubeconfig     Kubeconfig pointing to the OpenShift cluster that will be used as a sync target."
-  ehco "                              Don't use in any of the preview modes - use only the preview.env file."
+  echo "                              Don't use in any of the preview modes - use only the preview.env file."
   echo "-rw, --root-workspace         Fully-qualified name of the kcp workspace that should be used as root (default is 'root')."
   echo "                              Don't use in the preview-cps mode - it uses the home workspace of the kcp user automatically."
   if [[ -n ${EXTRA_PARAMS} ]]

--- a/hack/flags.sh
+++ b/hack/flags.sh
@@ -8,9 +8,12 @@ user_help () {
   echo "${SCRIPT_DESC}"
   echo "options:"
   echo "-h,  --help                   Show this help info"
-  echo "-kk, --kcp-kubeconfig         Kubeconfig pointing to the kcp instance"
-  echo "-ck, --cluster-kubeconfig     Kubeconfig pointing to the OpenShift cluster that will be used as a sync target"
-  echo "-rw, --root-workspace         Fully-qualified name of the kcp workspace that should be used as root (default is 'root')"
+  echo "-kk, --kcp-kubeconfig         Kubeconfig pointing to the kcp instance."
+  ehco "                              Don't use in any of the preview modes - use only the preview.env file."
+  echo "-ck, --cluster-kubeconfig     Kubeconfig pointing to the OpenShift cluster that will be used as a sync target."
+  ehco "                              Don't use in any of the preview modes - use only the preview.env file."
+  echo "-rw, --root-workspace         Fully-qualified name of the kcp workspace that should be used as root (default is 'root')."
+  echo "                              Don't use in the preview-cps mode - it uses the home workspace of the kcp user automatically."
   if [[ -n ${EXTRA_PARAMS} ]]
   then
     ${EXTRA_HELP}
@@ -54,7 +57,21 @@ parse_flags() {
     esac
   done
 
-  if [[ -z ${KCP_KUBECONFIG} ]] || [[ -z ${CLUSTER_KUBECONFIG} ]]
+  if echo ${MODE} | grep -q preview
+  then
+    if [[ -n ${KCP_KUBECONFIG}${CLUSTER_KUBECONFIG} ]]
+    then
+      echo "ERROR: You cannot use the parameter --kcp-kubeconfig nor --cluster-kubeconfig in preview mode - use only the './hack/preview.env' file" >&2
+      exit 1
+    elif [[ -f ${ROOT}/hack/preview.env ]]
+    then
+      echo "Loading environment variables from ${ROOT}/hack/preview.env"
+      source ${ROOT}/hack/preview.env
+    else
+      echo "ERROR: No ${ROOT}/hack/preview.env was found" >&2
+      exit 1
+    fi
+  elif [[ -z ${KCP_KUBECONFIG} ]] || [[ -z ${CLUSTER_KUBECONFIG} ]]
   then
     echo "ERROR: Both parameters --kcp-kubeconfig and --cluster-kubeconfig are mandatory" >&2
     exit 1

--- a/hack/flags.sh
+++ b/hack/flags.sh
@@ -29,12 +29,12 @@ parse_flags() {
         ;;
       -kk|--kcp-kubeconfig)
         shift
-        export KCP_KUBECONFIG=$1
+        KCP_KUBECONFIG_FLAG=$1
         shift
         ;;
       -ck|--cluster-kubeconfig)
         shift
-        export CLUSTER_KUBECONFIG=$1
+        CLUSTER_KUBECONFIG_FLAG=$1
         shift
         ;;
       -rw|--root-workspace)
@@ -59,7 +59,7 @@ parse_flags() {
 
   if echo ${MODE} | grep -q preview
   then
-    if [[ -n ${KCP_KUBECONFIG}${CLUSTER_KUBECONFIG} ]]
+    if [[ -n ${KCP_KUBECONFIG_FLAG}${CLUSTER_KUBECONFIG_FLAG} ]]
     then
       echo "ERROR: You cannot use the parameter --kcp-kubeconfig nor --cluster-kubeconfig in preview mode - use only the './hack/preview.env' file" >&2
       exit 1
@@ -71,10 +71,13 @@ parse_flags() {
       echo "ERROR: No ${ROOT}/hack/preview.env was found" >&2
       exit 1
     fi
-  elif [[ -z ${KCP_KUBECONFIG} ]] || [[ -z ${CLUSTER_KUBECONFIG} ]]
+  elif [[ -z ${KCP_KUBECONFIG_FLAG} ]] || [[ -z ${CLUSTER_KUBECONFIG_FLAG} ]]
   then
     echo "ERROR: Both parameters --kcp-kubeconfig and --cluster-kubeconfig are mandatory" >&2
     exit 1
+  else
+    export KCP_KUBECONFIG=${KCP_KUBECONFIG_FLAG}
+    export CLUSTER_KUBECONFIG=${CLUSTER_KUBECONFIG_FLAG}
   fi
   export ROOT_WORKSPACE=${ROOT_WORKSPACE:-"root"}
 }

--- a/hack/preview-template.env
+++ b/hack/preview-template.env
@@ -16,13 +16,9 @@ export MY_GITHUB_TOKEN=
 ### Set cluster kubeconfig so it's not needed to pass it as parameter
 ### example: $HOME/.kube/config
 export CLUSTER_KUBECONFIG=
-### KCP cluster kubeconfig so it's not needed to pass it as parameter
-### This file is managed by preview script
-### example: $HOME/.kube/preview-kcp
-export KCP_KUBECONFIG=
-### Path to CPS kubeconfig which will be copied when using preview-cps mode
+### Path to CPS (or any other instance of kcp) kubeconfig so it's not needed to pass it as parameter
 ### example: $HOME/.kube/cps
-export CPS_KUBECONFIG=
+export KCP_KUBECONFIG=
 
 ## HAS enable github integration
 ### Override default Application service "image push" repository

--- a/hack/preview.sh
+++ b/hack/preview.sh
@@ -2,12 +2,8 @@
 
 ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"/..
 
-if [ -f $ROOT/hack/preview.env ]; then
-    source $ROOT/hack/preview.env
-fi
-
 source ${ROOT}/hack/flags.sh "The preview.sh enable preview mode used for development and testing on non-production clusters / kcp instances."
-parse_flags $@
+MODE=${MODE:-preview} parse_flags $@
 
 if [ -z "$MY_GIT_FORK_REMOTE" ]; then
     echo "Set MY_GIT_FORK_REMOTE environment to name of your fork remote"


### PR DESCRIPTION
Use only one kcp kubeconfig defined as a variable `KCP_KUBECONFIG`. 
The file is not overridden, nor copied anywhere - it's being used as it is. 
In the case of ckcp, the kubeconfig is taken from the running ckcp via a temp file.