### PR TITLE
PLNSRVCE-658: <do not merge yet> readd kcp'ed jvm-build-service but leverages a bunch of simplifications over pre-kcp integration

### DIFF
--- a/argo-cd-apps/base/jvm-build-service.yaml
+++ b/argo-cd-apps/base/jvm-build-service.yaml
@@ -1,0 +1,42 @@
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: jvm-build-service
+spec:
+  generators:
+  - list:
+      elements:
+      - kcp-name: kcp-stable
+      - kcp-name: kcp-unstable
+  template:
+    metadata:
+      name: '{{kcp-name}}-has'
+    spec:
+      project: default
+
+      source:
+        path: components/jvm-build-service
+        repoURL: https://github.com/redhat-appstudio/infra-deployments.git
+        targetRevision: main
+
+      destination:
+        namespace: jvm-build-service
+        name: redhat-hacbs-workspace-{{kcp-name}}
+
+      syncPolicy:
+
+        # Comment this out if you want to manually trigger deployments (using the
+        # Argo CD Web UI or Argo CD CLI), rather than automatically deploying on
+        # every new Git commit to your directory.
+        automated:
+          prune: true
+          selfHeal: true
+
+        syncOptions:
+        - CreateNamespace=true
+
+        retry:
+          limit: 50 # number of failed sync attempt retries; unlimited number of attempts if less than 0
+          backoff:
+            duration: 15s # the amount to back off. Default unit is seconds, but could also be a duration (e.g. "2m", "1h")
+

--- a/argo-cd-apps/base/kustomization.yaml
+++ b/argo-cd-apps/base/kustomization.yaml
@@ -2,6 +2,7 @@ resources:
 - authorization-in-cluster.yaml
 - authorization-in-kcp.yaml
 - has.yaml
+- jvm-build-service.yaml
 
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/argo-cd-apps/overlays/development/repo-overlay.yaml
+++ b/argo-cd-apps/overlays/development/repo-overlay.yaml
@@ -1,7 +1,25 @@
+---
 apiVersion: argoproj.io/v1alpha1
 kind: ApplicationSet
 metadata:
   name: has
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  generators:
+    - list:
+        elements:
+          - kcp-name: dev
+  template:
+    spec:
+      source:
+        repoURL: https://github.com/redhat-appstudio/infra-deployments.git
+        targetRevision: main
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: jvm-build-service
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/components/jvm-build-service/OWNERS
+++ b/components/jvm-build-service/OWNERS
@@ -1,0 +1,11 @@
+# See the OWNERS docs: https://go.k8s.io/owners
+
+approvers:
+- gabemontero
+- stuartwdouglas
+- Michkov
+
+reviewers:
+- gabemontero
+- stuartwdouglas
+- Michkov

--- a/components/jvm-build-service/kustomization.yaml
+++ b/components/jvm-build-service/kustomization.yaml
@@ -1,0 +1,22 @@
+resources:
+- https://github.com/redhat-appstudio/jvm-build-service/deploy/kcp?ref=bc1ecfaf82f1edaef5b4d80e53d093e371048fb7
+
+images:
+- name: hacbs-jvm-operator
+  newName: quay.io/redhat-appstudio/hacbs-jvm-controller
+  newTag: e927aa1b0dcd479ce0ad4f4a62a87b3b1b7dc423
+
+namespace: jvm-build-service
+
+patches:
+  - target:
+      kind: Deployment
+      name: hacbs-jvm-operator
+    patch: |-
+      # reduce CPU request to be able to run on testing instance
+      - op: replace
+        path: /spec/template/spec/containers/0/resources/requests/cpu
+        value: 10m
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization


### PR DESCRIPTION
so while I cannot test yet with the known "pipelineruns missing from 'api-resources'" situation for us, I did some preliminary modeling of how jvm-build-service would add itself back in

In crafting the changes, and comparing with the pre-kcp branch, it motivated me to craft https://github.com/redhat-appstudio/jvm-build-service/pull/258 to simplify how we reference the 5 jvm-build-service images, where I believe I was able to remove the need for image ref specification in the system configmap and deployment env vars for the product flow, dev flow, and openshift ci flow.

That resulted in removing some of the kustomization operations in the pre-kcp branch.

I see staging as 
- get https://github.com/redhat-appstudio/jvm-build-service/pull/258 merged after sign off from @stuartwdouglas 
- track the various efforts with @Michkov  and the infra team so that we can get pipeline runs available and synch'ing in some form of apptudio kcp
- test https://github.com/redhat-appstudio/jvm-build-service/pull/236, get it working, then review/iterate with team / get it merged
- then come back to this PR


That said, if there is some obvious feedback on this PR reviewers want to provide while this is still in draft state, please do.