### PR TITLE
ignore could not parse version error

### DIFF
--- a/hack/flags.sh
+++ b/hack/flags.sh
@@ -86,7 +86,7 @@ parse_flags() {
     echo CLUSTER_KUBECONFIG=${CLUSTER_KUBECONFIG} points to KCP not to cluster.
     exit 1
   fi
-  KCP_SERVER_VERSION=$(kubectl version -o yaml --kubeconfig ${KCP_KUBECONFIG} | yq '.serverVersion.gitVersion')
+  KCP_SERVER_VERSION=$(kubectl version -o yaml --kubeconfig ${KCP_KUBECONFIG} 2>/dev/null | yq '.serverVersion.gitVersion')
   if ! echo "$KCP_SERVER_VERSION" | grep -q 'kcp\|v0.0.0-master'; then
     echo KCP_KUBECONFIG=${KCP_KUBECONFIG} does not point to KCP cluster.
     exit 1


### PR DESCRIPTION
ignore 
```
error: could not parse pre-release/metadata (-master+$Format:%H$) in version "v0.0.0-master+$Format:%H$"
```
when running kcp locally 