### PR TITLE
Update PipelinesAsCode to v0.12

### DIFF
--- a/components/build/pipelines-as-code/kustomization.yaml
+++ b/components/build/pipelines-as-code/kustomization.yaml
@@ -1,6 +1,6 @@
 resources:
 - allow-argocd.yaml
-- https://github.com/openshift-pipelines/pipelines-as-code/releases/download/0.10.2/release.yaml
+- https://github.com/openshift-pipelines/pipelines-as-code/releases/download/v0.12.0/release.yaml
 
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization


### PR DESCRIPTION
v0.11 was skipped due to issues with updating status back to github using GitHub App.

@ralphbean @sbose78 @MatousJobanek This is not critical fix but we would like to verify that v0.12 is not having issues as v0.11.