### PR TITLE
allow everyone bind all APIExports

### DIFF
--- a/argo-cd-apps/overlays/development/delete-applications.yaml
+++ b/argo-cd-apps/overlays/development/delete-applications.yaml
@@ -4,9 +4,3 @@ kind: Application
 metadata:
   name: authorization-in-cluster
 $patch: delete
----
-apiVersion: argoproj.io/v1alpha1
-kind: ApplicationSet
-metadata:
-  name: authorization-in-kcp
-$patch: delete

--- a/argo-cd-apps/overlays/development/repo-overlay.yaml
+++ b/argo-cd-apps/overlays/development/repo-overlay.yaml
@@ -1,3 +1,25 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: authorization-in-kcp
+spec:
+  generators:
+  - matrix:
+      generators:
+      - list:
+          elements:
+          - kcp-name: dev
+      - list:
+          elements:
+          - service: appstudio
+          - service: hacbs
+  template:
+    spec:
+      source:
+        repoURL: https://github.com/redhat-appstudio/infra-deployments.git
+        targetRevision: main
+---
 apiVersion: argoproj.io/v1alpha1
 kind: ApplicationSet
 metadata:

--- a/components/authorization/kcp/base/bind-apiexports.yaml
+++ b/components/authorization/kcp/base/bind-apiexports.yaml
@@ -5,7 +5,7 @@ metadata:
 rules:
 - apiGroups:
   - apis.kcp.dev
-  resourceNames:
-  - kubernetes
+  resources:
+  - apiexports
   verbs:
   - bind

--- a/components/authorization/kcp/base/bind-apiexports.yaml
+++ b/components/authorization/kcp/base/bind-apiexports.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: bind-apiexports
+rules:
+- apiGroups:
+  - apis.kcp.dev
+  resourceNames:
+  - kubernetes
+  verbs:
+  - bind

--- a/components/authorization/kcp/base/everyone-bind-apiexports.yaml
+++ b/components/authorization/kcp/base/everyone-bind-apiexports.yaml
@@ -1,0 +1,12 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: everyone-bind-apiexports
+subjects:
+- kind: Group
+  apiGroup: rbac.authorization.k8s.io
+  name: 'system:authenticated'
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: bind-apiexports

--- a/components/authorization/kcp/base/kustomization.yaml
+++ b/components/authorization/kcp/base/kustomization.yaml
@@ -1,6 +1,8 @@
 resources:
 - view-everything.yaml
 - members-view-everything.yaml
+- bind-apiexports.yaml
+- everyone-bind-apiexports.yaml
 
 
 apiVersion: kustomize.config.k8s.io/v1beta1


### PR DESCRIPTION
let's allow everyone bind all APIExports in the SP workspaces (for now) - to make testing in CPS easy and simple.

Reason: It's not possible to bind the APIExport of HAS. 
cc @johnmcollier 

