### PR TITLE
SPI  on CPS/Stable

### DIFF
--- a/components/authorization/cluster/kcp-spi-namespace-admin.yaml
+++ b/components/authorization/cluster/kcp-spi-namespace-admin.yaml
@@ -10,16 +10,3 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: admin
----
-kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: kcp-1ry9c9jzxyzk-admin
-  namespace: kcp-1ry9c9jzxyzk
-subjects:
-  - kind: User
-    name: skabashnyuk
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: admin


### PR DESCRIPTION
 - Reconfigure  VAULTHOST to correct vault route on workload cluster
 - `BASEURL` to OAuth service on CPS/Stable



Context

<img width="1710" alt="Знімок екрана 2022-09-22 о 11 41 24" src="https://user-images.githubusercontent.com/1614429/191700615-394631f1-a8f3-4c37-ba9c-10664e704517.png">
<img width="792" alt="Знімок екрана 2022-09-22 о 11 41 16" src="https://user-images.githubusercontent.com/1614429/191700629-b9d84def-6e07-4d1e-9d09-421be5ca4f5c.png">
