### PR TITLE
Specify yq version in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Simply update the files under `components/(team-name)`, and open a PR with the c
 
 The prerequisites are:
 
-- You must have `kubectl` (> v1.24), `oc`, `jq`, `openssl`, `realpath` and [`yq`](https://github.com/mikefarah/yq) installed.
+- You must have `kubectl` (> v1.24), `oc`, `jq`, `openssl`, `realpath` and [`yq`](https://github.com/mikefarah/yq) (> v4.27.0) installed.
 - [kubectl-kcp plugin](https://github.com/kcp-dev/kcp/releases)
 - [kubectl-oidc_login plugin](https://github.com/int128/kubelogin/releases) (only when connecting to CPS)
 - You must have `kubectl` and `oc` pointing to an existing OpenShift cluster, that you wish to deploy to. Alternatively, you can configure a local CodeReady Containers VM to deploy to.


### PR DESCRIPTION
Preview mode was failing for me because my yq version was out of date (v4.9.x), moving up to v4.27.x fixed things.

I'm sure preview mode works with older yq versions than just 4.27.x, but I figured it was most straightforward to specify the latest version.