### PR TITLE
Unset API_SERVER for SPI OAuth service

### DIFF
--- a/components/spi/base/kustomization.yaml
+++ b/components/spi/base/kustomization.yaml
@@ -13,11 +13,6 @@ images:
     newTag: b7ff5940bc332ec12b324424ece6a882f6f44a7c
 
 namespace: spi-system
-patches:
-  - target:
-      kind: ConfigMap
-      name: oauth-service-environment-config
-    path: oauth-service-config-patch.json
 
 patchesStrategicMerge:
   - delete-shared-configuration-file.yaml

--- a/components/spi/base/oauth-service-config-patch.json
+++ b/components/spi/base/oauth-service-config-patch.json
@@ -1,7 +1,0 @@
-[
-  {
-    "op": "add",
-    "path": "/data/API_SERVER",
-    "value": "https://api-toolchain-host-operator.apps.appstudio-stage.x99m.p1.openshiftapps.com:443"
-  }
-]


### PR DESCRIPTION
Previously for `pre_kcp` staging, we have to override  `API_SERVER` to point out the correct k8s endpoint where OAuth service can do proper `SelfSubjectAccessReview`. On kcp version we don't have to do that, k8s client should use autoconfiguration to discover proper endpoint.