### PR TITLE
Remove sharedSecret from SPI config

### DIFF
--- a/components/spi/base/config.yaml
+++ b/components/spi/base/config.yaml
@@ -1,4 +1,3 @@
-sharedSecret: <shared-secret>
 serviceProviders:
   - type: GitHub
     clientId: <github-client-id>

--- a/hack/preview-template.env
+++ b/hack/preview-template.env
@@ -72,7 +72,6 @@ export RELEASE_RESOURCES=
 
 ## SPI integration
 ### Based on https://github.com/redhat-appstudio/service-provider-integration-operator#configuration
-export SHARED_SECRET= # Random string
 export SPI_TYPE= # GitHub
 export SPI_CLIENT_ID=
 export SPI_CLIENT_SECRET=

--- a/hack/preview.sh
+++ b/hack/preview.sh
@@ -59,8 +59,7 @@ VAULT_HOST="https://vault-spi-vault.apps.${CLUSTER_URL_HOST}"
 $ROOT/hack/util-patch-spi-config.sh $VAULT_HOST $SPI_BASE_URL "true"
 # configure the secrets and providers in SPI
 TMP_FILE=$(mktemp)
-yq e ".sharedSecret=\"${SHARED_SECRET:-$(openssl rand -hex 20)}\"" $ROOT/components/spi/base/config.yaml | \
-    yq e ".serviceProviders[0].type=\"${SPI_TYPE:-GitHub}\"" - | \
+yq e ".serviceProviders[0].type=\"${SPI_TYPE:-GitHub}\"" $ROOT/components/spi/base/config.yaml | \
     yq e ".serviceProviders[0].clientId=\"${SPI_CLIENT_ID:-app-client-id}\"" - | \
     yq e ".serviceProviders[0].clientSecret=\"${SPI_CLIENT_SECRET:-app-secret}\"" - > $TMP_FILE
 oc --kubeconfig ${KCP_KUBECONFIG}  create -n spi-system secret generic shared-configuration-file --from-file=config.yaml=$TMP_FILE --dry-run=client -o yaml | oc  --kubeconfig ${KCP_KUBECONFIG}  apply -f -


### PR DESCRIPTION
The sharedSecret is no longer a thing in SPI so we should not configure it here.