### PR TITLE
Increase resources of ckcp, keep unresolved IdentityHash

### DIFF
--- a/components/ckcp/deployment.yaml
+++ b/components/ckcp/deployment.yaml
@@ -39,7 +39,7 @@ spec:
               value: $HOSTNAME
           resources:
             limits:
-              memory: 2Gi
+              memory: 4Gi
             requests:
               cpu: 100m
               memory: 178Mi

--- a/components/ckcp/pvc.yaml
+++ b/components/ckcp/pvc.yaml
@@ -8,5 +8,5 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 10Mi
+      storage: 5Gi
   volumeMode: Filesystem

--- a/hack/preview.sh
+++ b/hack/preview.sh
@@ -94,8 +94,9 @@ evaluate_apiexports() {
       fi
       if [ -z "$IDENTITY_HASH" ]; then
         echo Unknown IDENTITY_HASH for $REQUEST
+      else
+        sed -i "s/\b$REQUEST\b/$IDENTITY_HASH/g" $APIEXPORTFILE
       fi
-      sed -i "s/\b$REQUEST\b/$IDENTITY_HASH/g" $APIEXPORTFILE
     done
   done
 }


### PR DESCRIPTION
- Increase PVC size of ckcp to 5Gi
- Increase memory of ckcp to 4Gi
- Update identity hash only when it's resolved