### PR TITLE
Convert ROOT_WORKSPACE='~' to full path in flags.sh

### DIFF
--- a/hack/configure-kcp.sh
+++ b/hack/configure-kcp.sh
@@ -104,13 +104,7 @@ EOF
 configure_service_provider_workspace() {
   echo "Creating and accessing '${SP_WORKSPACE_NAME}':"
   KUBECONFIG=${KCP_KUBECONFIG} kubectl ws ${ROOT_WORKSPACE}
-  
-  if [ "$ROOT_WORKSPACE" == "~" ]; then
-    CURRENT_WS=$(KUBECONFIG=${KCP_KUBECONFIG} kubectl ws . --short)
-    COMPUTE_WORKSPACE_PATH=${CURRENT_WS}:${COMPUTE_WORKSPACE}
-  else
-    COMPUTE_WORKSPACE_PATH=${ROOT_WORKSPACE}:${COMPUTE_WORKSPACE}
-  fi
+  COMPUTE_WORKSPACE_PATH=${ROOT_WORKSPACE}:${COMPUTE_WORKSPACE}
   
   KUBECONFIG=${KCP_KUBECONFIG} kubectl ws create ${SP_WORKSPACE_NAME} --ignore-existing --type root:universal || true
   SP_WORKSPACE_URL=$(KUBECONFIG=${KCP_KUBECONFIG} kubectl get workspaces ${SP_WORKSPACE_NAME} -o jsonpath='{.status.URL}')

--- a/hack/create-user-workspace.sh
+++ b/hack/create-user-workspace.sh
@@ -14,6 +14,7 @@ fi
 SERVICE_NAME=${1}
 
 ROOT_WORKSPACE=${ROOT_WORKSPACE:-"root"}
+HOME_WORKSPACE=${HOME_WORKSPACE:-"~"}
 APPSTUDIO_WORKSPACE=${APPSTUDIO_WORKSPACE:-"redhat-appstudio"}
 HACBS_WORKSPACE=${HACBS_WORKSPACE:-"redhat-hacbs"}
 PIPELINE_SERVICE_WORKSPACE=${PIPELINE_SERVICE_WORKSPACE:-"pipeline-service"}
@@ -23,12 +24,12 @@ then
   export KUBECONFIG=${KCP_KUBECONFIG}
 fi
 
-echo "Accessing the home workspace:"
-kubectl ws '~'
-
 if [ "${ROOT_WORKSPACE}" == "~" ]; then
   ROOT_WORKSPACE=$(kubectl ws . --short)
 fi
+
+echo "Accessing the home workspace:"
+kubectl ws $HOME_WORKSPACE
 
 APPSTUDIO_SP_WORKSPACE=${APPSTUDIO_SP_WORKSPACE:-${ROOT_WORKSPACE}:${APPSTUDIO_WORKSPACE}}
 HACBS_SP_WORKSPACE=${HACBS_SP_WORKSPACE:-${ROOT_WORKSPACE}:${HACBS_WORKSPACE}}

--- a/hack/create-user-workspace.sh
+++ b/hack/create-user-workspace.sh
@@ -25,7 +25,7 @@ then
 fi
 
 if [ "${ROOT_WORKSPACE}" == "~" ]; then
-  ROOT_WORKSPACE=$(kubectl ws . --short)
+  ROOT_WORKSPACE=$(kubectl ws '~' --short)
 fi
 
 echo "Accessing the home workspace:"

--- a/hack/flags.sh
+++ b/hack/flags.sh
@@ -81,6 +81,11 @@ parse_flags() {
   fi
   export ROOT_WORKSPACE=${ROOT_WORKSPACE:-"root"}
 
+  # Convert home ROOT_WORKSPACE to full path
+  if [ "$ROOT_WORKSPACE" == "~" ]; then
+    ROOT_WORKSPACE=$(KUBECONFIG=${KCP_KUBECONFIG} kubectl ws '~' --short)
+  fi
+
   # Check config files and version compatibility
   if kubectl version -o yaml --kubeconfig ${CLUSTER_KUBECONFIG} | yq '.serverVersion.gitVersion' | grep -q kcp; then
     echo CLUSTER_KUBECONFIG=${CLUSTER_KUBECONFIG} points to KCP not to cluster.

--- a/hack/install-pipeline-service.sh
+++ b/hack/install-pipeline-service.sh
@@ -11,10 +11,6 @@ git clone --depth 1 https://github.com/openshift-pipelines/pipeline-service/ $PI
 export WORK_DIR="${PIPELINE_SERVICE_DIR}/gitops/sre/"
 export WORKSPACE_DIR=$WORK_DIR
 
-if [ "$ROOT_WORKSPACE" == "~" ]; then
-  ROOT_WORKSPACE=$(KUBECONFIG=${KCP_KUBECONFIG} kubectl ws '~' --short)
-fi
-
 KUBECONFIG=$KCP_KUBECONFIG $PIPELINE_SERVICE_DIR/images/access-setup/content/bin/setup_kcp.sh --kcp-workspace pipeline-service --kcp-org $ROOT_WORKSPACE
 
 KUBECONFIG=$CLUSTER_KUBECONFIG $PIPELINE_SERVICE_DIR/images/access-setup/content/bin/setup_compute.sh

--- a/hack/preview.sh
+++ b/hack/preview.sh
@@ -45,8 +45,7 @@ else
 fi
 
 # Ensure that we are in redhat-appstudio workspace
-KUBECONFIG=${KCP_KUBECONFIG} kubectl ws ${ROOT_WORKSPACE}
-KUBECONFIG=${KCP_KUBECONFIG} kubectl ws redhat-appstudio
+KUBECONFIG=${KCP_KUBECONFIG} kubectl ws ${ROOT_WORKSPACE}:redhat-appstudio
 
 # Create preview branch for preview configuration
 PREVIEW_BRANCH=preview-${MY_GIT_BRANCH}${TEST_BRANCH_ID+-$TEST_BRANCH_ID}
@@ -117,11 +116,9 @@ evaluate_apiexports() {
 }
 APIEXPORTS=$(find -name '*apiexport*.yaml' | grep overlays/dev)
 evaluate_apiexports "$(echo $APIEXPORTS | grep -v '/hacbs/')"
-KUBECONFIG=${KCP_KUBECONFIG} kubectl ws ${ROOT_WORKSPACE}
-KUBECONFIG=${KCP_KUBECONFIG} kubectl ws redhat-hacbs
+KUBECONFIG=${KCP_KUBECONFIG} kubectl ws ${ROOT_WORKSPACE}:redhat-hacbs
 evaluate_apiexports "$(echo $APIEXPORTS | grep '/hacbs/')"
-KUBECONFIG=${KCP_KUBECONFIG} kubectl ws ${ROOT_WORKSPACE}
-KUBECONFIG=${KCP_KUBECONFIG} kubectl ws redhat-appstudio
+KUBECONFIG=${KCP_KUBECONFIG} kubectl ws ${ROOT_WORKSPACE}:redhat-appstudio
 
 if ! git diff --exit-code --quiet; then
     git commit -a -m "Preview mode, do not merge into main"


### PR DESCRIPTION
- Access workspaces directly, not needed to go via ROOT_WORKSPACE
- Allow to define HOME_WORKSPACE