### PR TITLE
Improve jvm-build-service integration

### DIFF
--- a/components/hacbs/jvm-build-service/base/kustomization.yaml
+++ b/components/hacbs/jvm-build-service/base/kustomization.yaml
@@ -1,31 +1,21 @@
 resources:
-- https://github.com/redhat-appstudio/jvm-build-service/deploy/kcp?ref=954c86b39a12820c7910c93b1e20b9b572232816
+- https://github.com/redhat-appstudio/jvm-build-service/deploy/kcp?ref=7d203d042f5ce4b49751fb9552cb71cab10ef757
+
+patchesStrategicMerge:
+- self-binding.yaml
 
 images:
 - name: hacbs-jvm-operator
   newName: quay.io/redhat-appstudio/hacbs-jvm-controller
-  newTag: 954c86b39a12820c7910c93b1e20b9b572232816
+  newTag: 7d203d042f5ce4b49751fb9552cb71cab10ef757
 
 namespace: jvm-build-service
 
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-patchesStrategicMerge:
-- |-
-  apiVersion: jvmbuildservice.io/v1alpha1
-  kind: SystemConfig
-  metadata:
-    name: cluster
-  $patch: delete
-- |-
-  apiVersion: apis.kcp.dev/v1alpha1
-  kind: APIBinding
-  metadata:
-    name: jvmbuildservice-binding
-  $patch: delete
-- |-
-  apiVersion: apis.kcp.dev/v1alpha1
-  kind: APIExport
-  metadata:
-    name: jvmbuildservice
+# Skip applying the jvmbuildservice operands while the jvm-build-service operator is being installed.
+# See more information about this option, here:
+# https://argo-cd.readthedocs.io/en/stable/user-guide/sync-options/#skip-dry-run-for-new-custom-resources-types
+commonAnnotations:
+  argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true

--- a/components/hacbs/jvm-build-service/base/self-binding.yaml
+++ b/components/hacbs/jvm-build-service/base/self-binding.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: apis.kcp.dev/v1alpha1
+kind: APIBinding
+metadata:
+  name: jvm-build-service
+spec:
+  reference:
+    workspace:
+      exportName: jvm-build-service
+  permissionClaims:
+  - group: ""
+    resource: secrets
+    state: Accepted
+  - group: ""
+    resource: serviceaccounts
+    state: Accepted
+  - group: ""
+    resource: events
+    state: Accepted

--- a/components/hacbs/jvm-build-service/overlays/dev/apiexport.yaml
+++ b/components/hacbs/jvm-build-service/overlays/dev/apiexport.yaml
@@ -1,21 +1,32 @@
+---
 apiVersion: apis.kcp.dev/v1alpha1
 kind: APIExport
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
   name: jvm-build-service
+  namespace: jvm-build-service
 spec:
+  latestResourceSchemas:
+  - v202209270158.artifactbuilds.jvmbuildservice.io
+  - v202209270158.dependencybuilds.jvmbuildservice.io
+  - v202209270158.rebuiltartifacts.jvmbuildservice.io
+  - v202209270158.systemconfigs.jvmbuildservice.io
+  - v202209270158.tektonwrappers.jvmbuildservice.io
+  - v202209270158.userconfigs.jvmbuildservice.io
   permissionClaims:
-    - group: ""
-      resource: "secrets"
-    - group: ""
-      resource: "serviceaccounts"
-    - group: ""
-      resource: "events"
-    - group: ""
-      resource: "services"
-      identityHash: pipeline-service
-    - group: "apps"
-      resource: "deployments"
-      identityHash: pipeline-service
-    - group: "tekton.dev"
-      resource: "pipelineruns"
-      identityHash: pipeline-service
+  - group: ""
+    resource: secrets
+  - group: ""
+    resource: serviceaccounts
+  - group: ""
+    resource: events
+  - group: ""
+    identityHash: pipeline-service
+    resource: services
+  - group: apps
+    identityHash: pipeline-service
+    resource: deployments
+  - group: tekton.dev
+    identityHash: pipeline-service
+    resource: pipelineruns

--- a/components/hacbs/jvm-build-service/overlays/dev/kustomization.yaml
+++ b/components/hacbs/jvm-build-service/overlays/dev/kustomization.yaml
@@ -2,4 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../base/
+
+patchesStrategicMerge:
   - apiexport.yaml

--- a/components/hacbs/jvm-build-service/overlays/kcp-stable/apiexport.yaml
+++ b/components/hacbs/jvm-build-service/overlays/kcp-stable/apiexport.yaml
@@ -1,21 +1,32 @@
+---
 apiVersion: apis.kcp.dev/v1alpha1
 kind: APIExport
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
   name: jvm-build-service
+  namespace: jvm-build-service
 spec:
+  latestResourceSchemas:
+  - v202209270158.artifactbuilds.jvmbuildservice.io
+  - v202209270158.dependencybuilds.jvmbuildservice.io
+  - v202209270158.rebuiltartifacts.jvmbuildservice.io
+  - v202209270158.systemconfigs.jvmbuildservice.io
+  - v202209270158.tektonwrappers.jvmbuildservice.io
+  - v202209270158.userconfigs.jvmbuildservice.io
   permissionClaims:
-    - group: ""
-      resource: "secrets"
-    - group: ""
-      resource: "serviceaccounts"
-    - group: ""
-      resource: "events"
-    - group: ""
-      resource: "services"
-      identityHash: 72b2990e51b1931e9fee86e67091b721a8c32f407d762fc847d9d2316a988b52
-    - group: "apps"
-      resource: "deployments"
-      identityHash: 72b2990e51b1931e9fee86e67091b721a8c32f407d762fc847d9d2316a988b52
-    - group: "tekton.dev"
-      resource: "pipelineruns"
-      identityHash: 72b2990e51b1931e9fee86e67091b721a8c32f407d762fc847d9d2316a988b52
+  - group: ""
+    resource: secrets
+  - group: ""
+    resource: serviceaccounts
+  - group: ""
+    resource: events
+  - group: ""
+    identityHash: 72b2990e51b1931e9fee86e67091b721a8c32f407d762fc847d9d2316a988b52
+    resource: services
+  - group: apps
+    identityHash: 72b2990e51b1931e9fee86e67091b721a8c32f407d762fc847d9d2316a988b52
+    resource: deployments
+  - group: tekton.dev
+    identityHash: 72b2990e51b1931e9fee86e67091b721a8c32f407d762fc847d9d2316a988b52
+    resource: pipelineruns

--- a/components/hacbs/jvm-build-service/overlays/kcp-stable/kustomization.yaml
+++ b/components/hacbs/jvm-build-service/overlays/kcp-stable/kustomization.yaml
@@ -2,4 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../base/
+
+patchesStrategicMerge:
   - apiexport.yaml

--- a/components/hacbs/jvm-build-service/overlays/kcp-unstable/apiexport.yaml
+++ b/components/hacbs/jvm-build-service/overlays/kcp-unstable/apiexport.yaml
@@ -1,21 +1,32 @@
+---
 apiVersion: apis.kcp.dev/v1alpha1
 kind: APIExport
 metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
   name: jvm-build-service
+  namespace: jvm-build-service
 spec:
+  latestResourceSchemas:
+  - v202209270158.artifactbuilds.jvmbuildservice.io
+  - v202209270158.dependencybuilds.jvmbuildservice.io
+  - v202209270158.rebuiltartifacts.jvmbuildservice.io
+  - v202209270158.systemconfigs.jvmbuildservice.io
+  - v202209270158.tektonwrappers.jvmbuildservice.io
+  - v202209270158.userconfigs.jvmbuildservice.io
   permissionClaims:
-    - group: ""
-      resource: "secrets"
-    - group: ""
-      resource: "serviceaccounts"
-    - group: ""
-      resource: "events"
-    - group: ""
-      resource: "services"
-      identityHash: #find hash for apiexport that has services in kcp-unstable
-    - group: "apps"
-      resource: "deployments"
-      identityHash: #find hash for apiexport that has service in kcp-unstable
-    - group: "tekton.dev"
-      resource: "pipelineruns"
-      identityHash: #find hash for apiexport that has service in kcp-unstable
+  - group: ""
+    resource: secrets
+  - group: ""
+    resource: serviceaccounts
+  - group: ""
+    resource: events
+  - group: ""
+    identityHash: 72b2990e51b1931e9fee86e67091b721a8c32f407d762fc847d9d2316a988b52
+    resource: services
+  - group: apps
+    identityHash: 72b2990e51b1931e9fee86e67091b721a8c32f407d762fc847d9d2316a988b52
+    resource: deployments
+  - group: tekton.dev
+    identityHash: 72b2990e51b1931e9fee86e67091b721a8c32f407d762fc847d9d2316a988b52
+    resource: pipelineruns

--- a/components/hacbs/jvm-build-service/overlays/kcp-unstable/kustomization.yaml
+++ b/components/hacbs/jvm-build-service/overlays/kcp-unstable/kustomization.yaml
@@ -2,4 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../base/
+
+patchesStrategicMerge:
   - apiexport.yaml


### PR DESCRIPTION
- add self-binding to workspace to have SystemConfig CRD available
- set SkipDryRunOnMissingResource=true to wait on SystemConfig CRD
- use one APIExport