### PR TITLE
Add '--destroy' param to install-ckcp.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,8 +155,10 @@ The script creates file `/tmp/ckcp-admin.kubeconfig` which should be copied to l
 
 Usage:
 ```
-./hack/install-ckcp.sh
+./hack/install-ckcp.sh [--destroy]
 ```
+
+`--destroy` flag removes currently installed ckcp instance, deletes all kcp namespaces and removes Applications from ArgoCD.
 
 ### Setting Preview mode
 


### PR DESCRIPTION
`./hack/install-ckcp-sh --destroy` first deletes argoCD applications and ckcp and kcp namespaces. Useful for new ckcp creation and bootstraping the cluster.