### PR TITLE
manually get jvm build service cache mem fix into staging cluster

### DIFF
--- a/components/hacbs/jvm-build-service/base/kustomization.yaml
+++ b/components/hacbs/jvm-build-service/base/kustomization.yaml
@@ -1,5 +1,5 @@
 resources:
-- https://github.com/redhat-appstudio/jvm-build-service/deploy/kcp?ref=7d203d042f5ce4b49751fb9552cb71cab10ef757
+- https://github.com/redhat-appstudio/jvm-build-service/deploy/kcp?ref=243a385d392cf79db71556c86a951dbb415213
 
 patchesStrategicMerge:
 - self-binding.yaml
@@ -7,7 +7,7 @@ patchesStrategicMerge:
 images:
 - name: hacbs-jvm-operator
   newName: quay.io/redhat-appstudio/hacbs-jvm-controller
-  newTag: 7d203d042f5ce4b49751fb9552cb71cab10ef757
+  newTag: 243a385d392cf79db71556c86a951dbb415213
 
 namespace: jvm-build-service
 


### PR DESCRIPTION
manual alternative to https://github.com/redhat-appstudio/infra-deployments/pull/791

we need to get to 243a385d392cf79db71556c86a951dbb415213 to pick up cache mem leak fixes from @stuartwdouglas so that the PaC builds running on the staging cluster for jvm-build-service work more reliably, and we can more reliably get quay.io/redhat-appstudio image updates for changes after 243a385d392cf79db71556c86a951dbb415213

Per https://quay.io/repository/redhat-appstudio/hacbs-jvm-cache?tab=tags and https://quay.io/repository/redhat-appstudio/hacbs-jvm-build-request-processor?tab=tags there are tags for this level

Also FYI per https://github.com/redhat-appstudio/jvm-build-service/blob/243a385d392cf79db71556c86a951dbb4152139f/deploy/kcp/apiexport_jvmbuildservice.yaml the kcp api resource schema there matches what we currently have in infra-deployments for example https://github.com/redhat-appstudio/infra-deployments/blob/971fd91fb8dd510c3b7f3ebfca92a37c688b2477/components/hacbs/jvm-build-service/overlays/dev/apiexport.yaml

i.e. v202209270158

Lastly, the level we are moving from, 7d203d042f5ce4b49751fb9552cb71cab10ef757, does not include the mem leak fixes that culminated in https://github.com/redhat-appstudio/jvm-build-service/commit/ac09a788d20577ddb15b19728308317345b6565d

/assign @Michkov 
