### PR TITLE
Added domain address for sso login

### DIFF
--- a/components/authorization/kcp/base/members-view-everything.yaml
+++ b/components/authorization/kcp/base/members-view-everything.yaml
@@ -26,7 +26,7 @@ subjects:
 - kind: User
   name: rh-sso:gbenhaim
 - kind: User
-  name: rh-sso:bkundu
+  name: rh-sso:bkundu@redhat.com
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole


### PR DESCRIPTION
SSO login takes `redhat.com` with the id. 

Signed-off-by: Bama Charan Kundu <bamachrn@gmail.com>