### PR TITLE
Set TEKTON_RESULTS creds for pipeline-service

### DIFF
--- a/hack/install-pipeline-service.sh
+++ b/hack/install-pipeline-service.sh
@@ -18,7 +18,7 @@ KUBECONFIG=$CLUSTER_KUBECONFIG $PIPELINE_SERVICE_DIR/images/access-setup/content
 
 $PIPELINE_SERVICE_DIR/images/cluster-setup/bin/install.sh
 
-$PIPELINE_SERVICE_DIR/images/kcp-registrar/register.sh --kcp-org $ROOT_WORKSPACE --kcp-workspace $PIPELINE_SERVICE_WORKSPACE --kcp-sync-tag v0.9.0
+$PIPELINE_SERVICE_DIR/images/kcp-registrar/bin/register.sh --kcp-org $ROOT_WORKSPACE --kcp-workspace $PIPELINE_SERVICE_WORKSPACE --kcp-sync-tag v0.9.0
 
 rm -rf "$PIPELINE_SERVICE_DIR"
 

--- a/hack/install-pipeline-service.sh
+++ b/hack/install-pipeline-service.sh
@@ -10,6 +10,7 @@ PIPELINE_SERVICE_DIR=$(mktemp -d)
 git clone --depth 1 https://github.com/openshift-pipelines/pipeline-service/ $PIPELINE_SERVICE_DIR
 export WORK_DIR="${PIPELINE_SERVICE_DIR}/gitops/sre/"
 export WORKSPACE_DIR=$WORK_DIR
+export TEKTON_RESULTS_DATABASE_USER=${TEKTON_RESULTS_DATABASE_USER:-"tekton-results"} TEKTON_RESULTS_DATABASE_PASSWORD=${TEKTON_RESULTS_DATABASE_PASSWORD:-"tekton-results"}
 
 KUBECONFIG=$KCP_KUBECONFIG $PIPELINE_SERVICE_DIR/images/access-setup/content/bin/setup_kcp.sh --kcp-workspace $PIPELINE_SERVICE_WORKSPACE --kcp-org $ROOT_WORKSPACE
 

--- a/hack/preview-template.env
+++ b/hack/preview-template.env
@@ -36,7 +36,11 @@ export PIPELINE_SERVICE_IDENTITY_HASH=
 ### By default it will not be deployed automatically.
 ### To deploy automatically set value to "true"
 export PIPELINE_SERVICE_LOCAL_DEPLOY=
-
+### Set Pipeline-service tekton-results DB auth
+### Default value "tekton-results"
+export TEKTON_RESULTS_DATABASE_USER=
+### Default value "tekton-results"
+export TEKTON_RESULTS_DATABASE_PASSWORD=
 
 ## HAS enable github integration
 ### Override default Application service "image push" repository


### PR DESCRIPTION
Script for installation of pipeline-service now requires TEKTON_RESULTS_DATABASE_USER and TEKTON_RESULTS_DATABASE_PASSWORD env