### PR TITLE
Connect Syncer to Local  CKCP via internal service

### DIFF
--- a/components/ckcp/certs.yaml
+++ b/components/ckcp/certs.yaml
@@ -74,5 +74,6 @@ spec:
   dnsNames:
     - localhost
     - $HOSTNAME
+    - ckcp.ckcp.svc.cluster.local
   issuerRef:
     name: kcp-server-issuer

--- a/hack/configure-kcp.sh
+++ b/hack/configure-kcp.sh
@@ -48,6 +48,14 @@ configure_compute_workspace() {
     if grep -q "insecure-skip-tls-verify: true" ${KCP_KUBECONFIG}; then
       sed -i 's/certificate-authority-data: .*/insecure-skip-tls-verify: true/' /tmp/${SYNC_TARGET}-syncer.yaml
     fi
+    if [[ "${CKCP_SYNCER_USE_INTERNAL_SERVICE}" == "true" ]]
+    then 
+      CKCP_INTERNAL_NAME=ckcp.ckcp.svc.cluster.local
+      CKCP_EXTERNAL_NAME=$(oc get route -n ckcp ckcp -o jsonpath={.spec.host} --kubeconfig ${CLUSTER_KUBECONFIG})
+      sed -i 's/certificate-authority-data: .*/insecure-skip-tls-verify: true/' /tmp/${SYNC_TARGET}-syncer.yaml
+      sed -i s/$CKCP_EXTERNAL_NAME:443/$CKCP_INTERNAL_NAME:6443/g /tmp/${SYNC_TARGET}-syncer.yaml
+      echo "CRC Mode: Patch ckcp from $CKCP_EXTERNAL_NAME:443 to $CKCP_INTERNAL_NAME:6443 "
+    fi  
     kubectl apply -f /tmp/${SYNC_TARGET}-syncer.yaml --kubeconfig ${CLUSTER_KUBECONFIG}
   fi
   

--- a/hack/flags.sh
+++ b/hack/flags.sh
@@ -67,6 +67,7 @@ parse_flags() {
     then
       echo "Loading environment variables from ${ROOT}/hack/preview.env"
       source ${ROOT}/hack/preview.env
+      $ROOT/hack/util-validate-preview-env.sh
     else
       echo "ERROR: No ${ROOT}/hack/preview.env was found" >&2
       exit 1

--- a/hack/preview-template.env
+++ b/hack/preview-template.env
@@ -16,6 +16,13 @@ export KCP_KUBECONFIG=
 ### example: root:test
 export ROOT_WORKSPACE=
 
+## CKCP local dev mode 
+### For clusters where CKCP is local, the syncer can use an internal service to reach it
+### Public IP clusters can leave this blank
+### This is required for dev mode CRC where the CKCP routes resolves to 127.0.0.1 and hence route to themselves
+### Set to true to use internal svc address/port see configure-kcp for implementation
+export CKCP_SYNCER_USE_INTERNAL_SERVICE=
+
 ## HAS enable github integration
 ### Your GITHUB organization where to manage repositories by HAS
 export MY_GITHUB_ORG=

--- a/hack/util-validate-preview-env.sh
+++ b/hack/util-validate-preview-env.sh
@@ -1,0 +1,22 @@
+
+ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"/..
+# compare template with preview.env
+# if any new or different exports
+# print a warning
+# If any new ENV vars are added to the template
+# users can tell they need to update their preview.env
+TEMPLATEENV=$(mktemp)
+YOURENV=$(mktemp)
+cat $ROOT/hack/preview-template.env | \
+    cut -d '=' -f 1 | \
+    grep -v "#" | grep "\S" | sort > $TEMPLATEENV
+cat $ROOT/hack/preview.env | \
+    cut -d '=' -f 1 | \
+    grep -v "#" | grep "\S" | sort > $YOURENV 
+echo "Comparing preview.env and preview-template.env"
+if diff $TEMPLATEENV $YOURENV; then
+    echo "preview.env and preview-template.env are consistent"
+else
+    echo "Warning preview.env has different exports than  preview-template.env"
+    echo "There may be new features you need to enable in preview mode."
+fi


### PR DESCRIPTION
This PR contains the following changes.

A new option CKCP_SYNCER_USE_INTERNAL_SERVICE  in preview mode will allow the syncer to connect to ckcp via the local kubernetes service instead of the public route. 
This is required when the local kube (CRC) has an IP of 127.0.0.1 as the syncer will try to connect to the public API endpoint and cannot reach it.

There is a new utility that warns if new vars are found in preview-template and not in preview.env so than when updates are made end users can easily know they may need to resolve their their preview.env files .
