### PR TITLE
PLNSRVCE-762: add IMAGE_TAG,IMAGE_REPO env vars to jvm bld svc

### DIFF
--- a/components/hacbs/jvm-build-service/base/kustomization.yaml
+++ b/components/hacbs/jvm-build-service/base/kustomization.yaml
@@ -4,6 +4,17 @@ resources:
 patchesStrategicMerge:
 - self-binding.yaml
 
+patches:
+  - patch: |-
+      - op: add
+        path: /spec/template/spec/containers/0/env/-
+        value:
+          name: IMAGE_TAG
+          value: b911059a17e1efdbc2ddb496604e673d0c491c43
+    target:
+      kind: Deployment
+      name: hacbs-jvm-operator
+
 images:
 - name: hacbs-jvm-operator
   newName: quay.io/redhat-appstudio/hacbs-jvm-controller

--- a/components/hacbs/jvm-build-service/base/kustomization.yaml
+++ b/components/hacbs/jvm-build-service/base/kustomization.yaml
@@ -1,5 +1,5 @@
 resources:
-- https://github.com/redhat-appstudio/jvm-build-service/deploy/kcp?ref=7d3e4b05319ef1584abbab1b9fa36c7072b685c8
+- https://github.com/redhat-appstudio/jvm-build-service/deploy/kcp?ref=6dfe2aa04bd48604d962fba24f542668428ae719
 
 patchesStrategicMerge:
 - self-binding.yaml
@@ -10,7 +10,7 @@ patches:
         path: /spec/template/spec/containers/0/env/-
         value:
           name: IMAGE_TAG
-          value: b911059a17e1efdbc2ddb496604e673d0c491c43
+          value: 6dfe2aa04bd48604d962fba24f542668428ae719
     target:
       kind: Deployment
       name: hacbs-jvm-operator
@@ -18,7 +18,7 @@ patches:
 images:
 - name: hacbs-jvm-operator
   newName: quay.io/redhat-appstudio/hacbs-jvm-controller
-  newTag: 7d3e4b05319ef1584abbab1b9fa36c7072b685c8
+  newTag: 6dfe2aa04bd48604d962fba24f542668428ae719
 
 namespace: jvm-build-service
 

--- a/components/hacbs/jvm-build-service/overlays/dev/kustomization.yaml
+++ b/components/hacbs/jvm-build-service/overlays/dev/kustomization.yaml
@@ -5,3 +5,14 @@ resources:
 
 patchesStrategicMerge:
   - apiexport.yaml
+
+patches:
+  - patch: |-
+      - op: add
+        path: /spec/template/spec/containers/0/env/-
+        value:
+          name: IMAGE_REPO
+          value: redhat-appstudio
+    target:
+      kind: Deployment
+      name: hacbs-jvm-operator


### PR DESCRIPTION
@Michkov I was able to verify this with https://github.com/redhat-appstudio/jvm-build-service/pull/313 

With these, I was able to get jvm build service "demo'able" on KCP per my recent messages in the team's slack channel and [PLNSRVCE-762](https://issues.redhat.com//browse/PLNSRVCE-762)

That said, I'm guessing this needs changes directed by you, and I'll add some disclaimers / questions as in line comments below to confirm/deny that

@stuartwdouglas FYI