### PR TITLE
Use background pruning

### DIFF
--- a/argo-cd-apps/app-of-apps/all-applications.yaml
+++ b/argo-cd-apps/app-of-apps/all-applications.yaml
@@ -26,3 +26,4 @@ spec:
 
     syncOptions:
     - CreateNamespace=true
+    - PrunePropagationPolicy=background

--- a/argo-cd-apps/base/application-api.yaml
+++ b/argo-cd-apps/base/application-api.yaml
@@ -34,6 +34,7 @@ spec:
 
         syncOptions:
         - CreateNamespace=true
+        - PrunePropagationPolicy=background
 
         retry:
           limit: 50 # number of failed sync attempt retries; unlimited number of attempts if less than 0

--- a/argo-cd-apps/base/application-service.yaml
+++ b/argo-cd-apps/base/application-service.yaml
@@ -34,6 +34,7 @@ spec:
 
         syncOptions:
         - CreateNamespace=true
+        - PrunePropagationPolicy=background
 
         retry:
           limit: 50 # number of failed sync attempt retries; unlimited number of attempts if less than 0

--- a/argo-cd-apps/base/authorization-in-cluster.yaml
+++ b/argo-cd-apps/base/authorization-in-cluster.yaml
@@ -26,6 +26,7 @@ spec:
 
     syncOptions:
     - CreateNamespace=true
+    - PrunePropagationPolicy=background
 
     retry:
       limit: 50 # number of failed sync attempt retries; unlimited number of attempts if less than 0

--- a/argo-cd-apps/base/authorization-in-kcp.yaml
+++ b/argo-cd-apps/base/authorization-in-kcp.yaml
@@ -39,6 +39,7 @@ spec:
 
         syncOptions:
         - CreateNamespace=true
+        - PrunePropagationPolicy=background
 
         retry:
           limit: 50 # number of failed sync attempt retries; unlimited number of attempts if less than 0

--- a/argo-cd-apps/base/build-service.yaml
+++ b/argo-cd-apps/base/build-service.yaml
@@ -34,6 +34,7 @@ spec:
 
         syncOptions:
         - CreateNamespace=true
+        - PrunePropagationPolicy=background
 
         retry:
           limit: 50 # number of failed sync attempt retries; unlimited number of attempts if less than 0

--- a/argo-cd-apps/base/enterprise-contract.yaml
+++ b/argo-cd-apps/base/enterprise-contract.yaml
@@ -34,6 +34,7 @@ spec:
 
         syncOptions:
         - CreateNamespace=true
+        - PrunePropagationPolicy=background
 
         retry:
           limit: 50 # number of failed sync attempt retries; unlimited number of attempts if less than 0

--- a/argo-cd-apps/base/gitops-appstudio-service.yaml
+++ b/argo-cd-apps/base/gitops-appstudio-service.yaml
@@ -34,6 +34,7 @@ spec:
 
         syncOptions:
         - CreateNamespace=true
+        - PrunePropagationPolicy=background
 
         retry:
           limit: 50 # number of failed sync attempt retries; unlimited number of attempts if less than 0

--- a/argo-cd-apps/base/gitops-core-service.yaml
+++ b/argo-cd-apps/base/gitops-core-service.yaml
@@ -34,6 +34,7 @@ spec:
 
         syncOptions:
         - CreateNamespace=true
+        - PrunePropagationPolicy=background
 
         retry:
           limit: 50 # number of failed sync attempt retries; unlimited number of attempts if less than 0

--- a/argo-cd-apps/base/integration-service.yaml
+++ b/argo-cd-apps/base/integration-service.yaml
@@ -34,6 +34,7 @@ spec:
 
         syncOptions:
           - CreateNamespace=true
+          - PrunePropagationPolicy=background
 
         retry:
           limit: 50 # number of failed sync attempt retries; unlimited number of attempts if less than 0

--- a/argo-cd-apps/base/jvm-build-service.yaml
+++ b/argo-cd-apps/base/jvm-build-service.yaml
@@ -35,6 +35,7 @@ spec:
 
         syncOptions:
         - CreateNamespace=true
+        - PrunePropagationPolicy=background
 
         retry:
           limit: 50 # number of failed sync attempt retries; unlimited number of attempts if less than 0

--- a/argo-cd-apps/base/release-service.yaml
+++ b/argo-cd-apps/base/release-service.yaml
@@ -34,6 +34,7 @@ spec:
 
         syncOptions:
         - CreateNamespace=true
+        - PrunePropagationPolicy=background
 
         retry:
           limit: 50 # number of failed sync attempt retries; unlimited number of attempts if less than 0

--- a/argo-cd-apps/base/spi.yaml
+++ b/argo-cd-apps/base/spi.yaml
@@ -35,6 +35,7 @@ spec:
 
         syncOptions:
         - CreateNamespace=true
+        - PrunePropagationPolicy=background
 
         retry:
           limit: 50 # number of failed sync attempt retries; unlimited number of attempts if less than 0
@@ -68,6 +69,7 @@ spec:
 
     syncOptions:
       - CreateNamespace=true
+      - PrunePropagationPolicy=background
 
     retry:
       limit: 50 # number of failed sync attempt retries; unlimited number of attempts if less than 0


### PR DESCRIPTION
Default foreground prunning is creating finalizer foregroundDeletion which block removal of the resource in KCP environment. With background policy the resources are removed.