### PR TITLE
chore: adds required release-service CRD permissionclaims

### DIFF
--- a/components/hacbs/release-service/overlays/dev/apiexport.yaml
+++ b/components/hacbs/release-service/overlays/dev/apiexport.yaml
@@ -26,6 +26,9 @@ spec:
   - group: appstudio.redhat.com
     identityHash: application-api
     resource: applicationsnapshotenvironmentbindings
+  - group: appstudio.redhat.com
+    identityHash: enterprisecontract
+    resource: enterprisecontractpolicies
   - group: tekton.dev
     identityHash: pipeline-service
     resource: pipelineruns

--- a/components/hacbs/release-service/overlays/kcp-stable/apiexport.yaml
+++ b/components/hacbs/release-service/overlays/kcp-stable/apiexport.yaml
@@ -26,6 +26,9 @@ spec:
   - group: appstudio.redhat.com
     identityHash: 835cb978eda43fb9776eab29818632aab365fedac2ee8e137440be5e5ed10e1d
     resource: applicationsnapshotenvironmentbindings
+  - group: appstudio.redhat.com
+    identityHash: 1970940201b6a64f5a9daf4350678667503798e95d80f9516b90681870e9b1a9
+    resource: enterprisecontractpolicies
   - group: tekton.dev
     identityHash: 72b2990e51b1931e9fee86e67091b721a8c32f407d762fc847d9d2316a988b52
     resource: pipelineruns

--- a/components/hacbs/release-service/overlays/kcp-unstable/apiexport.yaml
+++ b/components/hacbs/release-service/overlays/kcp-unstable/apiexport.yaml
@@ -26,6 +26,9 @@ spec:
   - group: appstudio.redhat.com
     identityHash: 676879883c7665b0b4a66256c3f86fbda6fa7e175f39f46f63cac75cdf7a6afa
     resource: applicationsnapshotenvironmentbindings
+  - group: appstudio.redhat.com
+    identityHash: 602b281ac64fef721eed42c5fe85765a7fa496f87089abb980441b71d7f64f8f
+    resource: enterprisecontractpolicies
   - group: tekton.dev
     identityHash: pipeline-service
     resource: pipelineruns


### PR DESCRIPTION
- adds EnterpriseContractPolicy CRD permissionclaims to release-service kcp overlays.

Signed-off-by: Leandro Mendes <lmendes@redhat.com>