### PR TITLE
rm jvm-bld-srvc apibinding entries (allow populate from repo)

### DIFF
--- a/components/hacbs/jvm-build-service/base/self-binding.yaml
+++ b/components/hacbs/jvm-build-service/base/self-binding.yaml
@@ -8,12 +8,3 @@ spec:
     workspace:
       exportName: jvm-build-service
   permissionClaims:
-  - group: ""
-    resource: secrets
-    state: Accepted
-  - group: ""
-    resource: serviceaccounts
-    state: Accepted
-  - group: ""
-    resource: events
-    state: Accepted


### PR DESCRIPTION
@Michkov this fixes the 

```
  - lastTransitionTime: "2022-10-24T15:28:39Z"
    message: '1 unexpected and/or invalid permission claims (showing first 1): unexpected/invalid
      claim for serviceaccounts. (identity "")'
    reason: InvalidPermissionClaims
    severity: Error
    status: "False"
    type: PermissionClaimsValid
```
both you and I saw in CPS, local bootstraps, etc.

From my preview cluster with this branch:

```
gmontero ~ $ oc get apibinding jvm-build-service -o yaml
apiVersion: apis.kcp.dev/v1alpha1
kind: APIBinding
metadata:
  annotations:
    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
    kcp.dev/cluster: root:users:zu:yc:kcp-admin:redhat-hacbs
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"apis.kcp.dev/v1alpha1","kind":"APIBinding","metadata":{"annotations":{"argocd.argoproj.io/sync-options":"SkipDryRunOnMissingResource=true"},"labels":{"app.kubernetes.io/instance":"dev-jvm-build-service"},"name":"jvm-build-service"},"spec":{"permissionClaims":[{"group":"","resource":"secrets","state":"Accepted"},{"group":"","resource":"configmaps","state":"Accepted"},{"group":"","resource":"events","state":"Accepted"},{"group":"","resource":"resourcequotas","state":"Accepted"}],"reference":{"workspace":{"exportName":"jvm-build-service"}}}}
  creationTimestamp: "2022-10-24T15:28:39Z"
  finalizers:
  - apis.kcp.dev/apibinding-finalizer
  generation: 2
  labels:
    app.kubernetes.io/instance: dev-jvm-build-service
    claimed.internal.apis.kcp.dev/2ONSSUxeNFPLf9Z77qi63gRssmqFd8WZF6B6nN: LstvmbbzVDDOn90ZbhzSQO5U3DMCf88h1pZ
    internal.apis.kcp.dev/export: 2ONSSUxeNFPLf9Z77qi63gRssmqFd8WZF6B6nN
  name: jvm-build-service
  resourceVersion: "604511"
  uid: 15011c33-1371-4cc7-b52f-5325d630e3e8
spec:
  permissionClaims:
  - resource: secrets
    state: Accepted
  - resource: configmaps
    state: Accepted
  - resource: events
    state: Accepted
  - resource: resourcequotas
    state: Accepted
  reference:
    workspace:
      exportName: jvm-build-service
      path: root:users:zu:yc:kcp-admin:redhat-hacbs
status:
  appliedPermissionClaims:
  - resource: configmaps
  - resource: events
  - resource: resourcequotas
  - resource: secrets
  boundExport:
    workspace:
      exportName: jvm-build-service
      path: root:users:zu:yc:kcp-admin:redhat-hacbs
  boundResources:
  - group: jvmbuildservice.io
    resource: artifactbuilds
    schema:
      UID: 0edf45fa-b07a-48cd-8fe3-5a9f8c07b00c
      identityHash: 9a9f00ec366472826711f61ecbd997f7bedd3bca812c1d6047a5321f5897f60f
      name: v202210180116.artifactbuilds.jvmbuildservice.io
    storageVersions:
    - v1alpha1
  - group: jvmbuildservice.io
    resource: dependencybuilds
    schema:
      UID: ea6e1696-7a29-4418-a8c9-f10395eb488a
      identityHash: 9a9f00ec366472826711f61ecbd997f7bedd3bca812c1d6047a5321f5897f60f
      name: v202210180116.dependencybuilds.jvmbuildservice.io
    storageVersions:
    - v1alpha1
  - group: jvmbuildservice.io
    resource: rebuiltartifacts
    schema:
      UID: 470b30e3-ba14-49ce-b267-77a7520b19bc
      identityHash: 9a9f00ec366472826711f61ecbd997f7bedd3bca812c1d6047a5321f5897f60f
      name: v202210180116.rebuiltartifacts.jvmbuildservice.io
    storageVersions:
    - v1alpha1
  - group: jvmbuildservice.io
    resource: systemconfigs
    schema:
      UID: c6395efd-1010-4b3a-b566-87943d23afc5
      identityHash: 9a9f00ec366472826711f61ecbd997f7bedd3bca812c1d6047a5321f5897f60f
      name: v202210180116.systemconfigs.jvmbuildservice.io
    storageVersions:
    - v1alpha1
  - group: jvmbuildservice.io
    resource: tektonwrappers
    schema:
      UID: 7f334166-f335-4c76-8152-c2a32bccfe7f
      identityHash: 9a9f00ec366472826711f61ecbd997f7bedd3bca812c1d6047a5321f5897f60f
      name: v202210180116.tektonwrappers.jvmbuildservice.io
    storageVersions:
    - v1alpha1
  - group: jvmbuildservice.io
    resource: userconfigs
    schema:
      UID: 126020b7-5d8c-4ce7-86c1-80f710b448e9
      identityHash: 9a9f00ec366472826711f61ecbd997f7bedd3bca812c1d6047a5321f5897f60f
      name: v202210180116.userconfigs.jvmbuildservice.io
    storageVersions:
    - v1alpha1
  conditions:
  - lastTransitionTime: "2022-10-24T15:28:39Z"
    status: "True"
    type: Ready
  - lastTransitionTime: "2022-10-24T15:28:39Z"
    status: "True"
    type: APIExportValid
  - lastTransitionTime: "2022-10-24T15:28:39Z"
    status: "True"
    type: BindingUpToDate
  - lastTransitionTime: "2022-10-24T15:28:39Z"
    status: "True"
    type: InitialBindingCompleted
  - lastTransitionTime: "2022-10-24T15:28:39Z"
    status: "True"
    type: PermissionClaimsApplied
  - lastTransitionTime: "2022-10-24T16:01:10Z"
    status: "True"
    type: PermissionClaimsValid
  exportPermissionClaims:
  - resource: secrets
  - resource: configmaps
  - resource: events
  - resource: resourcequotas
  - group: tekton.dev
    identityHash: 8fafa3e1aa128f9b530cee3ba8e520716dad3e769dad89cab5f9b1e07eaf1214
    resource: pipelineruns
  phase: Bound
gmontero ~ $ 
```