### PR TITLE
downscale the unstable syncer to zero

### DIFF
--- a/components/kcp-syncer/kcp-unstable/appstudio-internal-syncer.yaml
+++ b/components/kcp-syncer/kcp-unstable/appstudio-internal-syncer.yaml
@@ -115,7 +115,7 @@ metadata:
   name: kcp-syncer-appstudio-internal-jbrk5z54
   namespace: kcp-syncer-kcp-unstable
 spec:
-  replicas: 1
+  replicas: 0
   strategy:
     type: Recreate
   selector:
@@ -170,7 +170,7 @@ metadata:
   name: kcp-dns-appstudio-internal-jbrk5z54
   namespace: kcp-syncer-kcp-unstable
 spec:
-  replicas: 1
+  replicas: 0
   strategy:
     type: Recreate
   selector:


### PR DESCRIPTION
there seems to be a problem with running two syncers in the same cluster at the same time - let's downscale the unstable syncer to zero for now