### PR TITLE
revert workspace type to `root:universal`

### DIFF
--- a/hack/create-user-workspace.sh
+++ b/hack/create-user-workspace.sh
@@ -43,7 +43,8 @@ fi
 
 USER_WORKSPACE=${USER_WORKSPACE:-"${SERVICE_NAME}"}
 echo "Creating & accessing ${SERVICE_NAME} workspace '${USER_WORKSPACE}':"
-kubectl ws create ${USER_WORKSPACE}  --ignore-existing --type ${CWT} --enter
+#kubectl ws create ${USER_WORKSPACE}  --ignore-existing --type ${CWT} --enter
+kubectl ws create ${USER_WORKSPACE}  --ignore-existing --type root:universal --enter
 
 kubectl kustomize ${ROOT}/apibindings/${SERVICE_NAME}/ | sed "s|\${APPSTUDIO_SP_WORKSPACE}|${APPSTUDIO_SP_WORKSPACE}|g;s|\${HACBS_SP_WORKSPACE}|${HACBS_SP_WORKSPACE}|g;s|\${PIPELINE_SERVICE_SP_WORKSPACE}|${PIPELINE_SERVICE_SP_WORKSPACE}|g" | \
   kubectl apply -f -


### PR DESCRIPTION
https://github.com/redhat-appstudio/infra-deployments/pull/865 introduced cluster workspace type support to the `create-user-workspace.sh` script.

As a result of this change, a user would encounter the following error when running this script:
```
▶ hack/create-user-workspace.sh appstudio
Accessing the home workspace:
Current workspace is "root:users:sp:yy:rh-sso-username".
Creating & accessing appstudio workspace 'appstudio':
Error: clusterworkspaces.tenancy.kcp.dev "appstudio" is forbidden: workspace type root:redhat-appstudio:appstudio does not exist
```

Revering the workspace type back to `root:universal` as was done previous to https://github.com/redhat-appstudio/infra-deployments/pull/865