### PR TITLE
Add permission claim for ApplicationSnapshots to HAS APIExports

### DIFF
--- a/components/application-service/overlays/dev/apiexport.yaml
+++ b/components/application-service/overlays/dev/apiexport.yaml
@@ -17,6 +17,9 @@ spec:
     resource: applications
   - group: appstudio.redhat.com
     identityHash: application-api
+    resource: applicationsnapshots
+  - group: appstudio.redhat.com
+    identityHash: application-api
     resource: applicationsnapshotenvironmentbindings
   - group: appstudio.redhat.com
     identityHash: application-api

--- a/components/application-service/overlays/kcp-stable/apiexport.yaml
+++ b/components/application-service/overlays/kcp-stable/apiexport.yaml
@@ -17,6 +17,9 @@ spec:
     resource: applications
   - group: appstudio.redhat.com
     identityHash: 835cb978eda43fb9776eab29818632aab365fedac2ee8e137440be5e5ed10e1d
+    resource: applicationsnapshots
+  - group: appstudio.redhat.com
+    identityHash: 835cb978eda43fb9776eab29818632aab365fedac2ee8e137440be5e5ed10e1d
     resource: applicationsnapshotenvironmentbindings
   - group: appstudio.redhat.com
     identityHash: 835cb978eda43fb9776eab29818632aab365fedac2ee8e137440be5e5ed10e1d

--- a/components/application-service/overlays/kcp-unstable/apiexport.yaml
+++ b/components/application-service/overlays/kcp-unstable/apiexport.yaml
@@ -17,6 +17,9 @@ spec:
     resource: applications
   - group: appstudio.redhat.com
     identityHash: 676879883c7665b0b4a66256c3f86fbda6fa7e175f39f46f63cac75cdf7a6afa
+    resource: applicationsnapshots
+  - group: appstudio.redhat.com
+    identityHash: 676879883c7665b0b4a66256c3f86fbda6fa7e175f39f46f63cac75cdf7a6afa
     resource: applicationsnapshotenvironmentbindings
   - group: appstudio.redhat.com
     identityHash: 676879883c7665b0b4a66256c3f86fbda6fa7e175f39f46f63cac75cdf7a6afa


### PR DESCRIPTION
See https://issues.redhat.com/browse/DEVHAS-188

It appears the APIExports for HAS were missing the permissionclaim for the ApplicationSnapshot resource, so this PR adds it to all of the necessary APIExports for HAS in infra-deployments.

In my testing, I also noticed that KCP had issues handling APIExports that had updated permission claims:
```
    message: '1 unexpected and/or invalid permission claims (showing first 1): unexpected/invalid
      claim for applicationsnapshots.appstudio.redhat.com (identity "06dfd2f7d69f251dc79489f4438adc0efdff59c2ed27ae5f09ccd778319e6993")'
```

So a delete & re-create of the modified APIExports may be required for these changes to take effect.