### PR TITLE
fix: SPI init script default URL

### DIFF
--- a/.ci/oci-e2e-deployment.sh
+++ b/.ci/oci-e2e-deployment.sh
@@ -77,7 +77,7 @@ function createQuayPullSecrets() {
 function executeE2ETests() {
     # E2E instructions can be found: https://github.com/redhat-appstudio/e2e-tests
     # The e2e binary is included in Openshift CI test container from the dockerfile: https://github.com/redhat-appstudio/infra-deployments/blob/main/.ci/openshift-ci/Dockerfile
-    curl https://raw.githubusercontent.com/redhat-appstudio/e2e-tests/main/scripts/e2e-openshift-ci.sh | bash -s
+    curl https://raw.githubusercontent.com/redhat-appstudio/e2e-tests/pre-kcp/scripts/e2e-openshift-ci.sh | bash -s
 
     # The bin will be installed in tmp folder after executing e2e-openshift-ci.sh script
     ${WORKSPACE}/tmp/e2e-tests/bin/e2e-appstudio --ginkgo.timeout=90m --ginkgo.junit-report="${ARTIFACTS_DIR}"/e2e-report.xml -webhookConfigPath="./webhookConfig.yml" -config-suites="${WORKSPACE}/tmp/e2e-tests/tests/e2e-demos/config/default.yaml"
@@ -91,7 +91,7 @@ function prepareWebhookVariables() {
     export webhook_repositoryFullName=$REPO_OWNER/$REPO_NAME
     export webhook_pullNumber=$PULL_NUMBER
     # Rewrite variables in webhookConfig.yml
-    curl https://raw.githubusercontent.com/redhat-appstudio/e2e-tests/main/webhookConfig.yml | envsubst > webhookConfig.yml
+    curl https://raw.githubusercontent.com/redhat-appstudio/e2e-tests/pre-kcp/webhookConfig.yml | envsubst > webhookConfig.yml
 }
 
 installCITools
@@ -100,7 +100,7 @@ git remote add ${MY_GIT_FORK_REMOTE} https://github.com/redhat-appstudio-qe/infr
 
 # Initiate openshift ci users
 export KUBECONFIG_TEST="/tmp/kubeconfig"
-curl https://raw.githubusercontent.com/redhat-appstudio/e2e-tests/main/scripts/provision-openshift-user.sh | bash -s
+curl https://raw.githubusercontent.com/redhat-appstudio/e2e-tests/pre-kcp/scripts/provision-openshift-user.sh | bash -s
 export KUBECONFIG="${KUBECONFIG_TEST}"
 
 timeout --foreground 15m "$WORKSPACE"/hack/bootstrap-cluster.sh preview

--- a/hack/preview.sh
+++ b/hack/preview.sh
@@ -138,7 +138,7 @@ APPS=$(kubectl get apps -n openshift-gitops -o name)
 if echo $APPS | grep -q spi; then
   if [ "`oc get applications.argoproj.io spi -n openshift-gitops -o jsonpath='{.status.health.status} {.status.sync.status}'`" != "Healthy Synced" ]; then
     echo Initializing SPI
-    curl https://raw.githubusercontent.com/redhat-appstudio/e2e-tests/${E2E_TESTS_COMMIT_SHA:-main}/scripts/spi-e2e-setup.sh | bash -s
+    curl https://raw.githubusercontent.com/redhat-appstudio/e2e-tests/${E2E_TESTS_COMMIT_SHA:-pre-kcp}/scripts/spi-e2e-setup.sh | bash -s
   fi
 fi
 


### PR DESCRIPTION
`main` branch in e2e-tests repo no longer contains the script for SPI init