### PR TITLE
Use upstream version of Tekton Chains - 0.13.0

### DIFF
--- a/components/build/tekton-chains/chains-controller-deployment.yaml
+++ b/components/build/tekton-chains/chains-controller-deployment.yaml
@@ -8,10 +8,6 @@ spec:
     spec:
       containers:
       - name: tekton-chains-controller
-        # Use a custom version of chains that contains support for pipelinerun attestations
-        image: ghcr.io/hacbs-contract/chains/controller:poc-tep-84-extras@sha256:a0da9f4c48c628097493a08304e04d82a3085631aad519790fefe1f72e249248
-        # To use a nightly build of chains if required:
-        # image: gcr.io/tekton-nightly/github.com/tektoncd/chains/cmd/controller@sha256...
         volumeMounts:
         - mountPath: /etc/ssl/certs
           name: chains-ca-cert

--- a/components/build/tekton-chains/kustomization.yaml
+++ b/components/build/tekton-chains/kustomization.yaml
@@ -7,7 +7,7 @@ resources:
 #  curl -s https://storage.googleapis.com/tekton-releases/ | xq | grep -E 'chains/.*/release.yaml'
 #
 - allow-argocd-to-manage.yaml
-- https://storage.googleapis.com/tekton-releases/chains/previous/v0.9.0/release.yaml
+- https://storage.googleapis.com/tekton-releases/chains/previous/v0.13.0/release.yaml
 - chains-secrets-config.yaml
 - tekton-chains-controller-shared-secrets-rolebinding.yaml
 


### PR DESCRIPTION
The changes in Tekton Chains required by the Pipeline Service have been merged upstream (PipelineRun Attestations). Use that version instead of a fork.

Signed-off-by: Luiz Carvalho <lucarval@redhat.com>