### PR TITLE
Add stump file for preview script to create apiexport

### DIFF
--- a/components/hacbs/enterprise-contract/overlays/dev/apiexport.yaml
+++ b/components/hacbs/enterprise-contract/overlays/dev/apiexport.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: apis.kcp.dev/v1alpha1
+kind: APIExport
+metadata:
+  name: enterprisecontract


### PR DESCRIPTION
Preview script requires to have apiexport for dev so that it can be created for getting identity hash and later updated by argoCD.