### PR TITLE
preview: generate missing APIExports

### DIFF
--- a/components/application-api/overlays/dev/apiexport.yaml
+++ b/components/application-api/overlays/dev/apiexport.yaml
@@ -1,4 +1,0 @@
-apiVersion: apis.kcp.dev/v1alpha1
-kind: APIExport
-metadata:
-  name: application-api

--- a/components/spi/overlays/dev/apiexport.yaml
+++ b/components/spi/overlays/dev/apiexport.yaml
@@ -1,4 +1,0 @@
-apiVersion: apis.kcp.dev/v1alpha1
-kind: APIExport
-metadata:
-  name: spi


### PR DESCRIPTION
APIExports are needed sooner then ArgoCD apps are applied. Generate placeholders to take IdentityHashes, ArgoCD updates them later