### PR TITLE
increase the memory limit of the operator to overcome the operational problems on the staging cluster.

### DIFF
--- a/components/spi/kustomization.yaml
+++ b/components/spi/kustomization.yaml
@@ -35,6 +35,10 @@ patches:
       kind: ConfigMap
       name: shared-environment-config
     path: config-patch.json
+  - target:
+      kind: Deployment
+      name: spi-controller-manager
+    path: operator-limits-patch.json
 
 # we plan to use approle authentication, but it's not ready yet
 # with these dummy secrets, we're satisfying spi deployments, but they're not really used

--- a/components/spi/operator-limits-patch.json
+++ b/components/spi/operator-limits-patch.json
@@ -1,0 +1,8 @@
+[
+    {
+      "op": "replace",
+      "path": "/spec/template/spec/containers/0/resources/limits/memory",
+      "value": "1536Mi"
+    }
+  ]
+  


### PR DESCRIPTION
Trying to mitigate the problem reported in https://issues.redhat.com/browse/SVPI-261 that we think is probably caused by a large number of SPI-related resources in the cluster.

Note that this should be a `pre-kcp`-specific fix, because the recent versions of SPI should contain code to automatically clean up the stale, unused resources.
