### PR TITLE
Disable rekor integration

### DIFF
--- a/components/build/tekton-chains/chains-config.yaml
+++ b/components/build/tekton-chains/chains-config.yaml
@@ -21,7 +21,6 @@ data:
   # For image signing iiuc
   artifacts.oci.storage: "oci"
 
-  # We might want to turn this off by default later so we aren't
-  # filling up rekor.sigstore.dev with garbage.
-  transparency.enabled: "true"
-  #transparency.url: "https://rekor.sigstore.dev"
+  # Rekor integration is disabled for now. It is planned to be re-introduced
+  # in the future.
+  transparency.enabled: "false"


### PR DESCRIPTION
This aligns with the current plan to not have Rekor enabled initially, but introduce it post-mvp phase.

Signed-off-by: Luiz Carvalho <lucarval@redhat.com>