### PR TITLE
Disable pack-broker on development environments

### DIFF
--- a/argo-cd-apps/overlays/development/delete-applications.yaml
+++ b/argo-cd-apps/overlays/development/delete-applications.yaml
@@ -10,3 +10,9 @@ kind: Application
 metadata:
   name: quality-dashboard
 $patch: delete
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: hac-pact-broker
+$patch: delete


### PR DESCRIPTION
Pack-broker does not work out-of-box, it requires manual secret creation.