### PR TITLE
Add application-api component

### DIFF
--- a/argo-cd-apps/base/application-api.yaml
+++ b/argo-cd-apps/base/application-api.yaml
@@ -1,0 +1,34 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: application-api
+  
+spec:
+  project: default
+
+  source:
+    path: components/application-api
+    repoURL: https://github.com/redhat-appstudio/infra-deployments.git
+    targetRevision: main
+
+  destination:
+    namespace: application-api
+    server: https://kubernetes.default.svc
+
+  syncPolicy:
+
+    # Comment this out if you want to manually trigger deployments (using the 
+    # Argo CD Web UI or Argo CD CLI), rather than automatically deploying on
+    # every new Git commit to your directory.
+    automated: 
+      prune: true
+      selfHeal: true
+
+    syncOptions:
+    - CreateNamespace=true
+
+    retry:
+      limit: 50 # number of failed sync attempt retries; unlimited number of attempts if less than 0
+      backoff:
+        duration: 15s # the amount to back off. Default unit is seconds, but could also be a duration (e.g. "2m", "1h")
+

--- a/argo-cd-apps/base/kustomization.yaml
+++ b/argo-cd-apps/base/kustomization.yaml
@@ -2,6 +2,7 @@ resources:
 - gitops.yaml
 - build.yaml
 - authentication.yaml
+- application-api.yaml
 - has.yaml
 - release.yaml
 - integration.yaml

--- a/argo-cd-apps/overlays/development/repo-overlay.yaml
+++ b/argo-cd-apps/overlays/development/repo-overlay.yaml
@@ -34,6 +34,17 @@ spec:
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
+  name: application-api
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  source:
+    repoURL: https://github.com/redhat-appstudio/infra-deployments.git
+    targetRevision: main
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
   name: release
   finalizers:
     - resources-finalizer.argocd.argoproj.io

--- a/components/application-api/OWNERS
+++ b/components/application-api/OWNERS
@@ -1,0 +1,18 @@
+# See the OWNERS docs: https://go.k8s.io/owners
+
+approvers:
+- johnmcollier
+- yangcao77
+- maysunfaisal
+- kim-tsao
+- elsony
+- jgwest
+- drpaneas
+
+reviewers:
+- johnmcollier
+- yangcao77
+- maysunfaisal
+- kim-tsao
+- elsony
+- drpaneas

--- a/components/application-api/kustomization.yaml
+++ b/components/application-api/kustomization.yaml
@@ -1,0 +1,10 @@
+resources:
+- allow-argocd-to-manage.yaml
+- argocd-permissions.yaml
+- https://github.com/redhat-appstudio/application-api/config/crd?ref=77cba9006505d430248f863f81539cd8b39efaed
+
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: application-api

--- a/components/application-api/kustomization.yaml
+++ b/components/application-api/kustomization.yaml
@@ -6,5 +6,3 @@ resources:
 
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-
-namespace: application-api


### PR DESCRIPTION
Adds the application-api component as it was not present on the pre-kcp branch. 

Newer versions of the HAS and gitops components do not have the CRDs in their kustomize manifests, so it's necessary to add the application-api kustomize manifests in infra-deployments. As we had a separate component for application-api on the KCP-branch, I figure it makes sense to do so as well for the non-KCP branch.