### PR TITLE
Allow John to exec into HAS pod for debugging

### DIFF
--- a/components/authentication/has-debug.yaml
+++ b/components/authentication/has-debug.yaml
@@ -1,0 +1,27 @@
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: has-debug
+  namespace: application-service
+rules:
+  - verbs:
+      - create
+    apiGroups:
+      - ''
+    resources:
+      - pods/exec
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: has-debug-rolebinding
+  namespace: application-service
+subjects:
+  - kind: User
+    apiGroup: rbac.authorization.k8s.io
+    name: johnmcollier
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: has-debug
+

--- a/components/authentication/kustomization.yaml
+++ b/components/authentication/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
 - gitops-ci.yaml
 - release-ci.yaml
 - has-ci.yaml
+- has-debug.yaml
 - build-ci.yaml
 - integration-ci.yaml
 - prune-has.yaml


### PR DESCRIPTION
HAS is getting OOMKilled for some unknown reason on staging, being able to **temporarily** exec into HAS will make debugging easier.

I'll remove this role & binding once I'm done.