### PR TITLE
Update HAS Pruner role to include listing of Snapshots/Bindings

### DIFF
--- a/components/authentication/prune-has.yaml
+++ b/components/authentication/prune-has.yaml
@@ -16,6 +16,14 @@ rules:
       - components
       - componentdetectionqueries
   - verbs:
+      - list
+      - get
+    apiGroups:
+      - 'appstudio.redhat.com'
+    resources:
+      - snapshots
+      - snapshotenvironmentbindings
+  - verbs:
       - create # allows addition of credentials only.
       - delete
       - list


### PR DESCRIPTION
Updates the existing has-pruner cluster role to include listing of snapshots & snapshotenvironmentbindings.