### PR TITLE
Delete PaC secret before creating a new one

### DIFF
--- a/hack/build/setup-pac-integration.sh
+++ b/hack/build/setup-pac-integration.sh
@@ -89,5 +89,8 @@ fi
 
 oc -n ${PAC_NAMESPACE} delete secret ${PAC_SECRET_NAME} &>/dev/null
 eval "oc -n '$PAC_NAMESPACE' create secret generic '$PAC_SECRET_NAME' $GITHUB_APP_DATA $GITHUB_WEBHOOK_DATA $GITLAB_WEBHOOK_DATA"
-eval "oc -n build-service create secret generic '$PAC_SECRET_NAME' $GITHUB_APP_DATA $GITHUB_WEBHOOK_DATA $GITLAB_WEBHOOK_DATA"
 echo "Configured ${PAC_SECRET_NAME} secret in ${PAC_NAMESPACE} namespace"
+
+oc -n build-service delete secret ${PAC_SECRET_NAME} &>/dev/null
+eval "oc -n build-service create secret generic '$PAC_SECRET_NAME' $GITHUB_APP_DATA $GITHUB_WEBHOOK_DATA $GITLAB_WEBHOOK_DATA"
+echo "Configured ${PAC_SECRET_NAME} secret in build-service namespace"


### PR DESCRIPTION
When rerun setup-for-integration.sh on a provisioned OpenShift cluster, it fails to create secret in build-service namespace due to the existing one. This patch deletes the existing secret in advance before creation.

Meanwhile, the code of deletion, creation and message report are grouped together for build-service namespace specifically.

Signed-off-by: Chenxiong Qi <cqi@redhat.com>