### PR TITLE
grant cluster view to only stage members from redhat-appstudio-sre

### DIFF
--- a/components/authentication/everyone-can-view.yaml
+++ b/components/authentication/everyone-can-view.yaml
@@ -34,7 +34,7 @@ metadata:
 subjects:
 - kind: Group
   apiGroup: rbac.authorization.k8s.io
-  name: 'system:authenticated'
+  name: 'stage'
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -47,7 +47,7 @@ metadata:
 subjects:
 - kind: Group
   apiGroup: rbac.authorization.k8s.io
-  name: 'system:authenticated'
+  name: 'stage'
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/components/authentication/group-sync/github-redhat-appstudio-sre.yaml
+++ b/components/authentication/group-sync/github-redhat-appstudio-sre.yaml
@@ -1,0 +1,13 @@
+apiVersion: redhatcop.redhat.io/v1alpha1
+kind: GroupSync
+metadata:
+  name: github-redhat-appstudio-sre
+spec:
+  schedule: "*/15 * * * *"
+  providers:
+  - name: github
+    github:
+      organization: redhat-appstudio-sre
+      credentialsSecret:
+        name: github-redhat-appstudio-sre
+        namespace: group-sync-operator

--- a/components/authentication/group-sync/kustomization.yaml
+++ b/components/authentication/group-sync/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - github-redhat-appstudio.yaml
+- github-redhat-appstudio-sre.yaml
 - group-sync.yaml
 - namespaces.yaml
 - subscription.yaml


### PR DESCRIPTION
I configured a new GH app in the redhat-appstudio-sre repo - we use the `stage` team as the gate for authenticating users in the stage cluster