### PR TITLE
fix: update sed cmd for compatibility with mac os

### DIFF
--- a/hack/preview.sh
+++ b/hack/preview.sh
@@ -96,7 +96,7 @@ if [ -n "$DOCKER_IO_AUTH" ]; then
 fi
 
 rekor_server="rekor.$domain"
-sed -i "s/rekor-server.enterprise-contract-service.svc/$rekor_server/" $ROOT/argo-cd-apps/base/enterprise-contract.yaml
+sed -i.bak "s/rekor-server.enterprise-contract-service.svc/$rekor_server/" $ROOT/argo-cd-apps/base/enterprise-contract.yaml && rm $ROOT/argo-cd-apps/base/enterprise-contract.yaml.bak
 yq -i e ".data |= .\"transparency.url\"=\"https://$rekor_server\"" $ROOT/components/pipeline-service/tekton-chains/chains-config.yaml
 
 [ -n "${BUILD_SERVICE_IMAGE_REPO}" ] && yq -i e "(.images.[] | select(.name==\"quay.io/redhat-appstudio/build-service\")) |=.newName=\"${BUILD_SERVICE_IMAGE_REPO}\"" $ROOT/components/build-service/kustomization.yaml


### PR DESCRIPTION
fixes an issue seen on Mac OS
```
 sed -i "s/rekor-server.enterprise-contract-service.svc/rekor.apps.cluster-fqdv9.fqdv9.sandbox2624.opentlc.com/" .../infra-deployments/argo-cd-apps/base/enterprise-contract.yaml
sed: 1: "/...": unterminated substitute pattern
```