### PR TITLE
Fixed incorrect vault route url

### DIFF
--- a/components/spi/overlays/staging/config-patch.json
+++ b/components/spi/overlays/staging/config-patch.json
@@ -2,7 +2,7 @@
   {
     "op": "replace",
     "path": "/data/VAULTHOST",
-    "value": "https://spi-vault-spi-system.apps.appstudio-stage.x99m.p1.openshiftapps.com"
+    "value": "https://vault-spi-vault.apps.appstudio-stage.x99m.p1.openshiftapps.com"
   },
   {
     "op": "replace",


### PR DESCRIPTION
I accidentally forget to set the correct vault route. 
This is how it looks

<img width="1718" alt="Знімок екрана 2022-11-28 о 15 55 16" src="https://user-images.githubusercontent.com/1614429/204295399-b05916f0-cb3e-47e6-9a5c-22b7554321f9.png">
