### PR TITLE
Return shared secret which is used by hacbs-service-core bundle

### DIFF
--- a/components/shared-resources/kustomization.yaml
+++ b/components/shared-resources/kustomization.yaml
@@ -20,6 +20,7 @@ resources:
 - redhat-appstudio-user-workload-sharedsecret.yaml
 - globally-shared-secrets-clusterrole.yaml
 - test-team-snyk-shared-secret.yaml
+- redhat-appstudio-staginguser-secret.yaml
 
 images:
 - name: \${NODE_DRIVER_REGISTRAR_IMAGE}

--- a/components/shared-resources/redhat-appstudio-staginguser-secret.yaml
+++ b/components/shared-resources/redhat-appstudio-staginguser-secret.yaml
@@ -1,0 +1,8 @@
+apiVersion: sharedresource.openshift.io/v1alpha1
+kind: SharedSecret
+metadata:
+  name: redhat-appstudio-staginguser
+spec:
+  secretRef:
+    name: noop
+    namespace: tekton-ci

--- a/components/shared-resources/shared-resources-components.yaml
+++ b/components/shared-resources/shared-resources-components.yaml
@@ -10,6 +10,7 @@ rules:
       - sharedsecrets
     resourceNames:
       - infra-deployments-pr-creator
+      - redhat-appstudio-staginguser-secret
     verbs:
       - use 
   - verbs:


### PR DESCRIPTION
Old pipelines are requiring to have shared secret available even if it's empty. Should not be needed when we switch to new bundles without shared-secret dependency.