### PR TITLE
Add SA, Role and RoleBindings for Internal Services Controller

### DIFF
--- a/argo-cd-apps/base/internal-services.yaml
+++ b/argo-cd-apps/base/internal-services.yaml
@@ -1,0 +1,34 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: internal-services
+  
+spec:
+  project: default
+
+  source:
+    path: components/internal-services
+    repoURL: https://github.com/redhat-appstudio/infra-deployments.git
+    targetRevision: main
+
+  destination:
+    namespace: internal-services
+    server: https://kubernetes.default.svc
+
+  syncPolicy:
+
+    # Comment this out if you want to manually trigger deployments (using the 
+    # Argo CD Web UI or Argo CD CLI), rather than automatically deploying on
+    # every new Git commit to your directory.
+    automated: 
+      prune: true
+      selfHeal: true
+
+    syncOptions:
+    - CreateNamespace=true
+
+    retry:
+      limit: 50 # number of failed sync attempt retries; unlimited number of attempts if less than 0
+      backoff:
+        duration: 15s # the amount to back off. Default unit is seconds, but could also be a duration (e.g. "2m", "1h")
+

--- a/argo-cd-apps/base/kustomization.yaml
+++ b/argo-cd-apps/base/kustomization.yaml
@@ -18,6 +18,7 @@ resources:
 - pipeline-service.yaml
 - build-templates.yaml
 - shared-resources.yaml
+- internal-services.yaml
 
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/components/authentication/internal-services.yaml
+++ b/components/authentication/internal-services.yaml
@@ -1,0 +1,16 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: internal-services
+  namespace: internal-services
+subjects:
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: Release team
+  - kind: User
+    apiGroup: rbac.authorization.k8s.io
+    name: Michkov
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: component-maintainer

--- a/components/authentication/kustomization.yaml
+++ b/components/authentication/kustomization.yaml
@@ -14,6 +14,7 @@ resources:
 - test-team.yaml
 - pact-broker.yaml
 - tekton-ci.yaml
+- internal-services.yaml
 
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/components/internal-services/OWNERS
+++ b/components/internal-services/OWNERS
@@ -1,0 +1,16 @@
+# See the OWNERS docs: https://go.k8s.io/owners
+
+approvers:
+- davidmogar
+- johnbieren
+- parasense
+- scoheb
+- theflockers
+
+
+reviewers:
+- davidmogar
+- johnbieren
+- parasense
+- scoheb
+- theflockers

--- a/components/internal-services/README.md
+++ b/components/internal-services/README.md
@@ -1,0 +1,10 @@
+As part of HACBS-1443, The Release team has developed an operator that is designed to run on a private, internal cluster
+provided by AppSRE. This is called the Internal Services Controller.
+
+Please see https://github.com/redhat-appstudio/book/blob/main/ADR/0003-interacting-with-internal-services.md
+
+This operator will reach out to a public *StoneSoup* cluster to watch for InternalRequest CRs and execute internal pipelines
+
+This folder permits the objects needed for the operator to watch the CRs (ServiceAccount, Role, RoleBindings)
+
+Once deployed, an admin can retrieve the token and securely provide it to the admins of the Internal Services Controller.

--- a/components/internal-services/internal_service_request_role.yaml
+++ b/components/internal-services/internal_service_request_role.yaml
@@ -1,0 +1,32 @@
+# permissions for end users to view applications.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: internal-service-request-role
+rules:
+  - apiGroups:
+      - appstudio.redhat.com
+    resources:
+      - internalrequests
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - appstudio.redhat.com
+    resources:
+      - internalrequests/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - appstudio.redhat.com
+    resources:
+      - internalrequests/status
+    verbs:
+      - get
+      - patch
+      - update

--- a/components/internal-services/internal_service_request_role_binding.yaml
+++ b/components/internal-services/internal_service_request_role_binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: internal-service-request-role-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: internal-service-request-role
+subjects:
+  - kind: ServiceAccount
+    name: internal-service-request-service-account
+    namespace: internal-services

--- a/components/internal-services/internal_service_request_service_account.yaml
+++ b/components/internal-services/internal_service_request_service_account.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: internal-service-request-service-account
+  namespace: internal-services
+

--- a/components/internal-services/internal_service_service_account_token.yaml
+++ b/components/internal-services/internal_service_service_account_token.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: internal-service-request-service-account-secret
+  annotations:
+    kubernetes.io/service-account.name: internal-service-request-service-account
+  namespace: internal-services
+type: kubernetes.io/service-account-token

--- a/components/internal-services/kustomization.yaml
+++ b/components/internal-services/kustomization.yaml
@@ -1,0 +1,10 @@
+resources:
+- internal_service_request_role.yaml
+- internal_service_request_role_binding.yaml
+- internal_service_request_service_account.yaml
+- internal_service_service_account_token.yaml
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: internal-services


### PR DESCRIPTION
- As part of HACBS-1443, we have developed an operator that will run on a private, internal cluster provided by AppSRE.
- This operator will reach out to the HACBS cluster to watch for InteralRequest CRs and execute internal pipelines.
- This PR created the objects needed for the operator to watch the CRs