### PR TITLE
PLNSRVCE-939: skip tekton-pruning on tekton-ci namespace

### DIFF
--- a/components/tekton-ci/kustomization.yaml
+++ b/components/tekton-ci/kustomization.yaml
@@ -1,4 +1,5 @@
 resources:
+- namespace.yaml
 - serviceaccount.yaml
 - pvc.yaml
 - repository.yaml

--- a/components/tekton-ci/namespace.yaml
+++ b/components/tekton-ci/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: tekton-ci
+  annotations:
+    operator.tekton.dev/prune.skip: "true"


### PR DESCRIPTION
PipelineRuns are being managed by PipelineAsCode annotation on PipelineRun.