### PR TITLE
fix wait for reg. service in preview.sh

### DIFF
--- a/hack/preview.sh
+++ b/hack/preview.sh
@@ -264,7 +264,7 @@ if [ -n "$KEYCLOAK" ] && [ -n "$TOOLCHAIN" ]; then
   echo "Restarting toolchain registration service to pick up keycloak's certs."
   oc delete deployment/registration-service -n toolchain-host-operator
   # Wait for the new deployment to be available
-  timeout --foreground 5m bash  <<- EOF
+  timeout --foreground 5m bash  <<- "EOF"
 		while [[ "$(oc get deployment/registration-service -n toolchain-host-operator -o jsonpath='{.status.conditions[?(@.type=="Available")].status}')" != "True" ]]; do 
 			echo "Waiting for registration-service to be available again"
 			sleep 2


### PR DESCRIPTION
Before this fix, the condition in the heredoc in `while` was evaluated/executed just once and thus it never succeeded.
This fixes it.

Signed-off-by: Radim Hopp <rhopp@redhat.com>