### PR TITLE
STONE-249 Enable direct access grants in dev keycloak realm

### DIFF
--- a/components/dev-sso/keycloak-realm.yaml
+++ b/components/dev-sso/keycloak-realm.yaml
@@ -19,7 +19,7 @@ spec:
         protocol: openid-connect
         webOrigins:
           - '*'
-        directAccessGrantsEnabled: false
+        directAccessGrantsEnabled: true
     displayName: Appstudio Realm
     enabled: true
     id: rh-sso


### PR DESCRIPTION
This is needed, because for using this keycloak in CI we need to be able to easily obtain token (skip the OAuth2 flow).
With this change it will be possible to use
```
curl -s -k -d 'client_id=sandbox-public' -d 'password=<PASSWORD>' -d 'username=<USERNAME>' -d 'grant_type=password' <KEYCLOAK_URL>/auth/realms/testrealm/protocol/openid-connect/token |jq -r .access_token
```

Signed-off-by: Radim Hopp <rhopp@redhat.com>