### PR TITLE
Updated authentication org and team for grafana

### DIFF
--- a/components/monitoring/grafana/base/grafana-app.yaml
+++ b/components/monitoring/grafana/base/grafana-app.yaml
@@ -107,8 +107,8 @@ spec:
         - --tls-cert-file=/etc/tls/private/tls.crt
         - --tls-key-file=/etc/tls/private/tls.key
         - --skip-auth-regex=^/metrics
-        - --github-org=codeready-toolchain-teams
-        - --github-team=observability
+        - --github-org=redhat-appstudio-sre
+        - --github-team=stage
         env:
         - name: OAUTH2_PROXY_CLIENT_ID
           valueFrom:


### PR DESCRIPTION
This PR fixes the current access failures in 
https://grafana-appstudio-workload-monitoring.apps.appstudio-stage.x99m.p1.openshiftapps.com

Signed-off-by: Bama Charan Kundu <bamachrn@gmail.com>