### PR TITLE
Feature toggle Rekor

### DIFF
--- a/argo-cd-apps/base/enterprise-contract.yaml
+++ b/argo-cd-apps/base/enterprise-contract.yaml
@@ -1,77 +1,52 @@
-apiVersion: argoproj.io/v1alpha1
-kind: Application
-metadata:
-  name: rekor
-
-spec:
-  project: default
-  source:
-    path: helm-charts/rekor
-    repoURL: 'https://github.com/sigstore/sigstore-helm-operator'
-    targetRevision: "143b8d71fc861d7c7ac93a15d0fbd33654b75908"
-
-    helm:
-      valueFiles:
-        - values.yaml
-      values: |-
-        server:
-          strategy:
-            type: Recreate
-          ingress:
-            hostname: rekor-server.enterprise-contract-service.svc
-            annotations:
-              route.openshift.io/termination: "edge"
-        mysql:
-          auth:
-            password: "password"
-
-  destination:
-    namespace: enterprise-contract-service
-    server: https://kubernetes.default.svc
-
-  syncPolicy:
-    # Comment this out if you want to manually trigger deployments (using the
-    # Argo CD Web UI or Argo CD CLI), rather than automatically deploying on
-    # every new Git commit to your directory.
-    automated:
-      prune: true
-      selfHeal: true
-
-    syncOptions:
-      - CreateNamespace=true
-
-    retry:
-      limit: 50 # number of failed sync attempt retries; unlimited number of attempts if less than 0
-      backoff:
-        duration: 15s # the amount to back off. Default unit is seconds, but could also be a duration (e.g. "2m", "1h")
 ---
 apiVersion: argoproj.io/v1alpha1
-kind: Application
+kind: ApplicationSet
 metadata:
   name: enterprise-contract
-
+  namespace: openshift-gitops
 spec:
-  project: default
-
-  source:
-    path: components/enterprise-contract
-    repoURL: https://github.com/redhat-appstudio/infra-deployments.git
-    targetRevision: main
-
-  destination:
-    namespace: enterprise-contract-service
-    server: https://kubernetes.default.svc
-
+  generators:
+    - list:
+        elements:
+          # Determines which Rekor (Tekton Chains transparency log) variant will
+          # be used, can be:
+          #  * off      - transparency off
+          #  * local    - transparency on, with an in-cluster Rekor instance
+          #  * sigstore - transparency on, with Sigstore public Rekor instance
+          - rekor: local
   syncPolicy:
+    # Allows us to delete the "rekor" Application if "rekor" above is not "local"
+    preserveResourcesOnDeletion: false
+  template:
+    metadata:
+      name: enterprise-contract
 
-    # Comment this out if you want to manually trigger deployments (using the
-    # Argo CD Web UI or Argo CD CLI), rather than automatically deploying on
-    # every new Git commit to your directory.
-    automated:
-      prune: true
-      selfHeal: true
+    spec:
+      project: default
+      source:
+        # Uses the overlay specified by "rekor" generator property above, this
+        # will setup in-cluster Rekor (if set to "local"), and change the
+        # chains-config ConfigMap based on that setting
+        path: components/enterprise-contract/rekor-{{rekor}}
+        repoURL: https://github.com/redhat-appstudio/infra-deployments.git
+        targetRevision: main
+      destination:
+        namespace: openshift-gitops
+        server: https://kubernetes.default.svc
 
-    retry:
-      limit: 50 # number of failed sync attempt retries; unlimited number of attempts if less than 0
-      backoff:
-        duration: 15s # the amount to back off. Default unit is seconds, but could also be a duration (e.g. "2m", "1h")
+      syncPolicy:
+
+        # Comment this out if you want to manually trigger deployments (using the
+        # Argo CD Web UI or Argo CD CLI), rather than automatically deploying on
+        # every new Git commit to your directory.
+        automated:
+          prune: true
+          selfHeal: true
+
+        syncOptions:
+          - CreateNamespace=true
+
+        retry:
+          limit: 50 # number of failed sync attempt retries; unlimited number of attempts if less than 0
+          backoff:
+            duration: 15s # the amount to back off. Default unit is seconds, but could also be a duration (e.g. "2m", "1h")

--- a/argo-cd-apps/base/enterprise-contract.yaml
+++ b/argo-cd-apps/base/enterprise-contract.yaml
@@ -13,7 +13,7 @@ spec:
           #  * off      - transparency off
           #  * local    - transparency on, with an in-cluster Rekor instance
           #  * sigstore - transparency on, with Sigstore public Rekor instance
-          - rekor: local
+          - rekor: off
   syncPolicy:
     # Allows us to delete the "rekor" Application if "rekor" above is not "local"
     preserveResourcesOnDeletion: false

--- a/components/enterprise-contract/base/allow-argocd-to-manage.yaml
+++ b/components/enterprise-contract/base/allow-argocd-to-manage.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: grant-argocd
+  namespace: enterprise-contract-service
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: admin
+subjects:
+- kind: ServiceAccount
+  name: openshift-gitops-argocd-application-controller
+  namespace: openshift-gitops

--- a/components/enterprise-contract/base/chains-config.yaml
+++ b/components/enterprise-contract/base/chains-config.yaml
@@ -3,6 +3,9 @@ kind: ConfigMap
 metadata:
   name: chains-config
   namespace: tekton-chains
+  labels:
+    app.kubernetes.io/instance: default
+    app.kubernetes.io/part-of: tekton-chains
 
 data:
   # See https://tekton.dev/docs/chains/config/

--- a/components/enterprise-contract/base/kustomization.yaml
+++ b/components/enterprise-contract/base/kustomization.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - namespace.yaml
+  - chains-config.yaml
+  - allow-argocd-to-manage.yaml
+  - https://github.com/hacbs-contract/enterprise-contract-controller/config/crd?ref=b341f9ff77d2ae3e5c8297bafbf5d4d1eede7b33
+  # Kustomize does not allow github.com urls that reference a single-file. They must always reference
+  # a directory that contains a kustomization.yaml file. The directory /config/rbac does include a
+  # kustomization.yaml file but it includes many other RBAC changes that are not desirable here. Use
+  # a URL to the "raw" version of the file instead.
+  - https://raw.githubusercontent.com/hacbs-contract/enterprise-contract-controller/b341f9ff77d2ae3e5c8297bafbf5d4d1eede7b33/config/rbac/enterprisecontractpolicy_viewer_role.yaml
+  - https://raw.githubusercontent.com/hacbs-contract/enterprise-contract-controller/b341f9ff77d2ae3e5c8297bafbf5d4d1eede7b33/config/rbac/enterprisecontractpolicy_editor_role.yaml
+
+generatorOptions:
+  disableNameSuffixHash: true
+
+configMapGenerator:
+- name: ec-defaults
+  namespace: enterprise-contract-service
+  literals:
+  - verify_ec_task_bundle=quay.io/hacbs-contract/ec-task-bundle:741b8a1fd9a3e1019e494d5136000aefde10c590@sha256:eb0cd5e3978c372bc82a5e0ab34d7d4d9c74ef1d18d6ef424ea15d1c0e881d44
+
+images:
+- name: quay.io/redhat-appstudio/enterprise-contract-controller
+  newName: quay.io/redhat-appstudio/enterprise-contract-controller
+  newTag: b341f9ff77d2ae3e5c8297bafbf5d4d1eede7b33

--- a/components/enterprise-contract/base/namespace.yaml
+++ b/components/enterprise-contract/base/namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: enterprise-contract-service

--- a/components/enterprise-contract/rekor-local/chains-config.yaml
+++ b/components/enterprise-contract/rekor-local/chains-config.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: chains-config
+  namespace: tekton-chains
+
+data:
+  transparency.enabled: "true"
+  transparency.url: "http://rekor-server.rekor.svc.cluster.local"

--- a/components/enterprise-contract/rekor-local/kustomization.yaml
+++ b/components/enterprise-contract/rekor-local/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../base/
+  - rekor-namespace.yaml
+  - rekor.yaml
+
+patchesStrategicMerge:
+  - chains-config.yaml

--- a/components/enterprise-contract/rekor-local/rekor-namespace.yaml
+++ b/components/enterprise-contract/rekor-local/rekor-namespace.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: rekor
+  annotations:
+    # UID used by rekor deployment
+    openshift.io/sa.scc.uid-range: 65530-65535
+    openshift.io/sa.scc.mcs: s0:c26,c5

--- a/components/enterprise-contract/rekor-local/rekor.yaml
+++ b/components/enterprise-contract/rekor-local/rekor.yaml
@@ -1,0 +1,54 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: rekor
+  namespace: openshift-gitops
+
+spec:
+  project: default
+  source:
+    path: charts/rekor
+    repoURL: https://github.com/sigstore/helm-charts/
+    targetRevision: 46f53f756fa59760c251bf6bde98cac241096453
+
+    helm:
+      valueFiles:
+        - values.yaml
+      values: |-
+        createtree:
+          # forces creation of treeID, updates the rekor-config ConfigMap
+          # overwriting any existing treeID
+          force: true
+        server:
+          strategy:
+            type: Recreate
+          ingress:
+            enabled: false
+        trillian:
+          namespace:
+            name: rekor
+            create: false
+          forceNamespace: rekor
+        mysql:
+          auth:
+            # Can't use password generator as it would constantly regenerate
+            # causing infinite resyncs
+            password: "password"
+
+  destination:
+    namespace: rekor
+    server: https://kubernetes.default.svc
+
+  syncPolicy:
+    # Comment this out if you want to manually trigger deployments (using the
+    # Argo CD Web UI or Argo CD CLI), rather than automatically deploying on
+    # every new Git commit to your directory.
+    automated:
+      prune: true
+      selfHeal: true
+
+    retry:
+      limit: 50 # number of failed sync attempt retries; unlimited number of attempts if less than 0
+      backoff:
+        duration: 15s # the amount to back off. Default unit is seconds, but could also be a duration (e.g. "2m", "1h")

--- a/components/enterprise-contract/rekor-off/chains-config.yaml
+++ b/components/enterprise-contract/rekor-off/chains-config.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: chains-config
+  namespace: tekton-chains
+
+data:
+  transparency.enabled: "false"

--- a/components/enterprise-contract/rekor-off/kustomization.yaml
+++ b/components/enterprise-contract/rekor-off/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../base/
+
+patchesStrategicMerge:
+  - chains-config.yaml

--- a/components/enterprise-contract/rekor-sigstore/chains-config.yaml
+++ b/components/enterprise-contract/rekor-sigstore/chains-config.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: chains-config
+  namespace: tekton-chains
+
+data:
+  transparency.enabled: "true"
+  transparency.url: "https://rekor.sigstore.dev"

--- a/components/enterprise-contract/rekor-sigstore/kustomization.yaml
+++ b/components/enterprise-contract/rekor-sigstore/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../base/
+
+patchesStrategicMerge:
+  - chains-config.yaml

--- a/components/pipeline-service/tekton-chains/kustomization.yaml
+++ b/components/pipeline-service/tekton-chains/kustomization.yaml
@@ -12,9 +12,8 @@ resources:
 - tekton-chains-controller-shared-secrets-rolebinding.yaml
 
 patchesStrategicMerge:
-#
-# Add some chains configuration
-- chains-config.yaml
+# We need to manage chains-config from enterprise-contract
+- remove-chains-config.yaml
 #
 # Remove runAsUser and runAsGroup from security context
 - security-context-fix.yaml

--- a/components/pipeline-service/tekton-chains/remove-chains-config.yaml
+++ b/components/pipeline-service/tekton-chains/remove-chains-config.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: chains-config
+  namespace: tekton-chains
+$patch: delete

--- a/hack/chains/README.md
+++ b/hack/chains/README.md
@@ -78,7 +78,7 @@ Execute the following commands to update the chains configmap to allow chains to
 
     # patch the configmap
     $ kubectl patch configmap chains-config -n tekton-chains \
-    -p='{"data":{"transparency.url": "http://rekor.enterprise-contract-service.svc:3000"}}'
+    -p='{"data":{"transparency.url": "http://rekor-server.rekor.svc.cluster.local"}}'
 
 ### External access for local cluster rekor server
 

--- a/hack/chains/config.sh
+++ b/hack/chains/config.sh
@@ -84,8 +84,8 @@ case "$1" in
     ;;
 
   rekor-local )
-    REKOR_SERVER=$(kubectl get ingress -n enterprise-contract-service -o jsonpath='{.items[0].spec.rules[0].host}')
-    $0 "transparency.url: \"https://$REKOR_SERVER\"" $2
+    REKOR_SERVER=http://rekor-server.rekor.svc.cluster.local
+    $0 "transparency.url: \"$REKOR_SERVER\"" $2
 
     ;;
 


### PR DESCRIPTION
This allows for customizing Tekton Chains transparency configuration and
correspondingly the Rekor instance. Three modes are now available:
 * off      - transparency off
 * local    - transparency on, with an in-cluster Rekor instance
 * sigstore - transparency on, with Sigstore public Rekor instance

These are set via ApplicationSet list generator and the custom "rekor"
parameter set there, see argo-cd-apps/base/enterprise-contract.yaml.

It is possible to change this parameter in a gitops manner and the
resulting state should reflect the value of the parameter, e.g. changing
from "local" to "off" should remove the "rekor" ArgoCD Application and
configure the "chains-config" ConfigMap accordingly.

The in-cluster deployed instance of Rekor no longer has an Ingress to
it's service, so it is no longer available outside of the cluster.

The `runAsUser` by default is set to 65533, so the annotations on the
`rekor` namespace are set to allow that. Still when the `rekor-server`
Pod is starting the following is logged:

```
spec:2022/12/20 19:56:39 warning: could not resolve current working directory: stat .: permission denied
```

The creation of`treeID` is forced (`createtree.forced=true`), found no
other way for Rekor not to fail with:

```
api/error.go:72	error processing request	{"requestID": "rekor-server-7fc8f96d54-gkbp6/YAfKPyHOLp-000029", "handler": "tlog.GetLogInfo", "statusCode": 500, "clientMessage": "unexpected error communicating with transparency log", "error": "grpc error: rpc error: code = NotFound desc = tree 1234567890 not found"}
```

This will cause data loss if the `rekor-createtree` Job is re-run,
creating a new `treeID`, and the `rekor-server` Pod is restarted to
reconfigure the new `treeID` from the `rekor-config` ConfigMap.

We can't manage `tekton-chans/chains-config` ConfigMap from the
`pipeline-service` as we need to modify it based on the state of the
Rekor mode from `enterprise-contract` Application, so the
`chains-config` ConfigMap was removed from the `pipeline-service` and
was added to `enterprise-contract` where it can be managed/patched.