### PR TITLE
Upgrade PAC to v0.15.0

### DIFF
--- a/components/pipeline-service/pipelines-as-code/kustomization.yaml
+++ b/components/pipeline-service/pipelines-as-code/kustomization.yaml
@@ -6,7 +6,7 @@ commonLabels:
 
 resources:
   - allow-argocd.yaml
-  - https://github.com/openshift-pipelines/pipelines-as-code/releases/download/v0.14.2/release.yaml
+  - https://github.com/openshift-pipelines/pipelines-as-code/releases/download/v0.15.0/release.yaml
 
 patchesStrategicMerge:
   - disable-pipelines-as-code-webhook.yaml


### PR DESCRIPTION
* Locally tested ✔️, `pipeline-service` argocd application is green in Argo CD Dashboard with PAC v0.15.0.

Signed-off-by: Satyam Bhardwaj <sabhardw@redhat.com>