### PR TITLE
Use pull secret as imagePullSecret in tekton-ci

### DIFF
--- a/components/tekton-ci/serviceaccount.yaml
+++ b/components/tekton-ci/serviceaccount.yaml
@@ -4,3 +4,5 @@ metadata:
   name: pipeline
 secrets:
   - name: redhat-appstudio-staginguser-pull-secret
+imagePullSecrets:
+  - name: redhat-appstudio-staginguser-pull-secret


### PR DESCRIPTION
The secret is used during the build Pipeline to push the image to the registry. This is done by mounting the secret, thus the secret is defined under `secrets` in the `pipeline` `ServiceAccount`. However, in order for Chains to re-use the secret to push image signatures and attestations, the secret must be a "pull secret" defined under `imagePullSecrets`

Signed-off-by: Luiz Carvalho <lucarval@redhat.com>