### PR TITLE
Add Pipeline Service team permissions

### DIFF
--- a/components/authentication/build.yaml
+++ b/components/authentication/build.yaml
@@ -4,6 +4,9 @@ metadata:
   name: pipelines-as-code-maintainers
   namespace: pipelines-as-code
 subjects:
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: Pipeline Service
   - kind: User
     apiGroup: rbac.authorization.k8s.io
     name: sbose78
@@ -64,6 +67,9 @@ metadata:
   name: component-maintainers
   namespace: tekton-pipelines
 subjects:
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: Pipeline Service
   - kind: User
     apiGroup: rbac.authorization.k8s.io
     name: sbose78
@@ -90,6 +96,9 @@ metadata:
   name: component-maintainers
   namespace: tekton-chains
 subjects:
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: Pipeline Service
   - kind: User
     apiGroup: rbac.authorization.k8s.io
     name: sbose78

--- a/components/authentication/pipeline-service-sre.yaml
+++ b/components/authentication/pipeline-service-sre.yaml
@@ -61,3 +61,31 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: pipeline-service-sre
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: tekton-results-maintainers
+  namespace: tekton-results
+subjects:
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: Pipeline Service
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: component-maintainer
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: openshift-pipelines-maintainers
+  namespace: openshift-pipelines
+subjects:
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: Pipeline Service
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: component-maintainer


### PR DESCRIPTION
Pipeline Service team should be able to maintain the following components:
- openshift-piplines/tekton-pipelines
- tekton-results
- tekton-chains
- pipelines-as-code