### PR TITLE
Add the role bindings for the Pipeline Service team

### DIFF
--- a/components/authentication/pipeline-service.yaml
+++ b/components/authentication/pipeline-service.yaml
@@ -1,0 +1,101 @@
+
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: pipeline-service
+  namespace: pipeline-as-code
+rules:
+  - verbs:
+      - get
+      - list
+    apiGroups:
+      - "*"
+    resources:
+      - "*"
+subjects:
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: Pipeline Service team
+  - kind: User
+    apiGroup: rbac.authorization.k8s.io
+    name: rarnaud
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: component-maintainer
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: pipeline-service
+  namespace: tekton-chains
+rules:
+  - verbs:
+      - get
+      - list
+    apiGroups:
+      - "*"
+    resources:
+      - "*"
+subjects:
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: Pipeline Service team
+  - kind: User
+    apiGroup: rbac.authorization.k8s.io
+    name: rarnaud
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: component-maintainer
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: pipeline-service
+  namespace: tekton-pipelines
+rules:
+  - verbs:
+      - get
+      - list
+    apiGroups:
+      - "*"
+    resources:
+      - "*"
+subjects:
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: Pipeline Service team
+  - kind: User
+    apiGroup: rbac.authorization.k8s.io
+    name: rarnaud
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: component-maintainer
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: pipeline-service
+  namespace: tekton-chains
+rules:
+  - verbs:
+      - get
+      - list
+    apiGroups:
+      - "*"
+    resources:
+      - "*"
+subjects:
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: Pipeline Service team
+  - kind: User
+    apiGroup: rbac.authorization.k8s.io
+    name: rarnaud
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: component-maintainer


### PR DESCRIPTION
Add full read access to namespaces under Pipeline Service team's control

Signed-off-by: Romain Arnaud <rarnaud@redhat.com>