### PR TITLE
Align SPI's scrape interval with other ServiceMonitors

### DIFF
--- a/components/monitoring/prometheus/base/prometheus-servicemonitors.yaml
+++ b/components/monitoring/prometheus/base/prometheus-servicemonitors.yaml
@@ -65,6 +65,7 @@ spec:
     scheme: https
     tlsConfig:
       insecureSkipVerify: true
+    interval: 15s
     path: /metrics
     port: metrics
   namespaceSelector:


### PR DESCRIPTION
 - Override default value 30sec and set it 15sec as it is set in other ServiceMonitors