### PR TITLE
fix: buildpipelineselectors roles, rolebindings

### DIFF
--- a/components/authentication/everyone-can-view.yaml
+++ b/components/authentication/everyone-can-view.yaml
@@ -7,6 +7,7 @@ rules:
   - appstudio.redhat.com
   resources:
   - applications
+  - buildpipelineselectors
   - componentdetectionqueries
   - components
   - enterprisecontractpolicies

--- a/components/build-templates/e2e/role.yaml
+++ b/components/build-templates/e2e/role.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -10,3 +11,21 @@ rules:
   verbs:
   - update
   - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: admin-buildpipelineselectors
+rules:
+- apiGroups:
+  - "appstudio.redhat.com"
+  resources:
+  - buildpipelineselectors
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/components/build-templates/e2e/rolebinding.yaml
+++ b/components/build-templates/e2e/rolebinding.yaml
@@ -24,3 +24,16 @@ subjects:
 - kind: ServiceAccount
   name: pipeline
   namespace: tekton-ci
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name:  admin-buildpipelineselectors-from-tekton-ci-namespace
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name:  admin-buildpipelineselectors
+subjects:
+- kind: ServiceAccount
+  name: pipeline
+  namespace: tekton-ci


### PR DESCRIPTION
add roles and rolebindings around buildpipelineselectors

* add permissions to read buildpipelineselectors for authenticated users
* add permissions to pipeline SA in tekton-ci namespace to administer buildpipelineselectors in build-templates-e2e namespace