### PR TITLE
Build services Prometheus monitor

### DIFF
--- a/components/monitoring/prometheus/base/prometheus-servicemonitors.yaml
+++ b/components/monitoring/prometheus/base/prometheus-servicemonitors.yaml
@@ -124,3 +124,50 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/instance: monitoring-workload-in-cluster
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    control-plane: controller-manager
+    prometheus: appstudio-workload
+  name: build-service
+  namespace: appstudio-workload-monitoring
+spec:
+  endpoints:
+  - path: /metrics
+    interval: 15s
+    port: https
+    scheme: https
+    bearerTokenSecret:
+      name: "prometheus-k8s-token-xhrjb"
+      key: token
+    tlsConfig:
+      insecureSkipVerify: true
+  namespaceSelector:
+    matchNames:
+    - build-service
+  selector:
+    matchLabels:
+      control-plane: controller-manager
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    control-plane: controller-manager
+    prometheus: appstudio-workload
+  name: jvm-build-service
+  namespace: appstudio-workload-monitoring
+spec:
+  endpoints:
+  - path: /metrics
+    interval: 15s
+    port: http-metrics
+    scheme: http
+  namespaceSelector:
+    matchNames:
+    - jvm-build-service
+  selector:
+    matchLabels:
+      app: hacbs-jvm-operator


### PR DESCRIPTION
Enable ServiceMonitor for build-service and jvm-build-service.

'jvm-build-service' provides metrics already. 

'build-service' will provide metrics after merge of #1119

[PLNSRVCE-984](https://issues.redhat.com/browse/PLNSRVCE-984)