### PR TITLE
Increase the dev sso tokens to 2h.

### DIFF
--- a/components/dev-sso/keycloak-realm.yaml
+++ b/components/dev-sso/keycloak-realm.yaml
@@ -7,6 +7,7 @@ spec:
     matchLabels:
       app.kubernetes.io/instance: dev-sso
   realm:
+    accessTokenLifespan: 7200
     clients:
       - enabled: true
         redirectUris:


### PR DESCRIPTION
Sometimes testing locally with keycloak token is hard because we need to update the token every 5 minutes. This PR just update the token lifetime to 2hrs