### PR TITLE
Provision SPI's grafana dashboard

### DIFF
--- a/components/monitoring/grafana/base/grafana-app.yaml
+++ b/components/monitoring/grafana/base/grafana-app.yaml
@@ -98,6 +98,18 @@ spec:
           name: grafana-dashboards
         - mountPath: /var/lib/grafana/dashboards
           name: grafana-dashboard-definitions
+        - mountPath: /var/lib/grafana/dashboards/spi
+          subPath: grafana-dashboard-spi-health.json
+          name: grafana-dashboard-spi-health-volume
+          readOnly: true
+        - mountPath: /var/lib/grafana/dashboards/spi
+          subPath: grafana-dashboard-spi-outbound-traffic.json
+          name: grafana-dashboard-spi-outbound-traffic-volume
+          readOnly: true
+        - mountPath: /var/lib/grafana/dashboards/spi
+          subPath: grafana-dashboard-spi-slo.json
+          name: grafana-dashboard-spi-slo-volume
+          readOnly: true
       - name: grafana-oauth2-proxy
         args:
         - --provider=github
@@ -195,6 +207,15 @@ spec:
       - name: grafana-dashboard-definitions
         configMap:
           name: grafana-dashboard-definitions
+      - name: grafana-dashboard-spi-health-volume
+        configMap:
+          name: grafana-dashboard-spi-health
+      - name: grafana-dashboard-spi-outbound-traffic-volume
+        configMap:
+          name: grafana-dashboard-spi-outbound-traffic
+      - name: grafana-dashboard-spi-slo-volume
+        configMap:
+          name: grafana-dashboard-spi-slo
       - name: secret-grafana-tls
         secret:
           defaultMode: 420
@@ -216,6 +237,12 @@ data:
         type: file
         options:
           path: /var/lib/grafana/dashboards
+      - name: Spi
+        folder: spi
+        type: file
+        disableDeletion: true
+        options:
+          path: /var/lib/grafana/dashboards/spi
 ---
 # Route and service to provide a secured access to Grafana
 apiVersion: route.openshift.io/v1

--- a/components/monitoring/grafana/base/grafana.ini
+++ b/components/monitoring/grafana/base/grafana.ini
@@ -17,7 +17,7 @@ provisioning = /etc/grafana/provisioning
 http_addr = 0.0.0.0
 http_port = 3001
 [users]
-viewers_can_edit = true
+viewers_can_edit = false
 auto_assign_org_role = Admin
 default_theme = light
 [metrics]

--- a/components/monitoring/grafana/base/grafana.ini
+++ b/components/monitoring/grafana/base/grafana.ini
@@ -17,7 +17,7 @@ provisioning = /etc/grafana/provisioning
 http_addr = 0.0.0.0
 http_port = 3001
 [users]
-viewers_can_edit = false
+viewers_can_edit = true
 auto_assign_org_role = Admin
 default_theme = light
 [metrics]

--- a/components/monitoring/grafana/base/kustomization.yaml
+++ b/components/monitoring/grafana/base/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - grafana-app.yaml
+- https://github.com/redhat-appstudio/service-provider-integration-operator/config/monitoring/base?ref=8fb5a16870c86d2b97bb89559dc145a091a4d9ab
 
 namespace: "appstudio-workload-monitoring"
 


### PR DESCRIPTION
 - Service provider's dashboard 
 - SPI components state  dashboard
 - Dedicate to SPI's SLO dashboard

We decided to use individual configmaps per dashboard to make sure we are not hitting the limit 1Mb per configmap.