### PR TITLE
Fixed spi's grafana dashboard deployment

### DIFF
--- a/components/monitoring/grafana/base/grafana-app.yaml
+++ b/components/monitoring/grafana/base/grafana-app.yaml
@@ -98,18 +98,8 @@ spec:
           name: grafana-dashboards
         - mountPath: /var/lib/grafana/dashboards
           name: grafana-dashboard-definitions
-        - mountPath: /var/lib/grafana/dashboards/spi/grafana-dashboard-spi-health.json
-          subPath: grafana-dashboard-spi-health.json
-          name: grafana-dashboard-spi-health-volume
-          readOnly: true
-        - mountPath: /var/lib/grafana/dashboards/spi/grafana-dashboard-spi-outbound-traffic.json
-          subPath: grafana-dashboard-spi-outbound-traffic.json
-          name: grafana-dashboard-spi-outbound-traffic-volume
-          readOnly: true
-        - mountPath: /var/lib/grafana/dashboards/spi/grafana-dashboard-spi-slo.json
-          subPath: grafana-dashboard-spi-slo.json
-          name: grafana-dashboard-spi-slo-volume
-          readOnly: true
+        - mountPath: /var/lib/grafana/dashboards-spi
+          name: grafana-dashboard-spi-volume
       - name: grafana-oauth2-proxy
         args:
         - --provider=github
@@ -207,15 +197,15 @@ spec:
       - name: grafana-dashboard-definitions
         configMap:
           name: grafana-dashboard-definitions
-      - name: grafana-dashboard-spi-health-volume
-        configMap:
-          name: grafana-dashboard-spi-health
-      - name: grafana-dashboard-spi-outbound-traffic-volume
-        configMap:
-          name: grafana-dashboard-spi-outbound-traffic
-      - name: grafana-dashboard-spi-slo-volume
-        configMap:
-          name: grafana-dashboard-spi-slo
+      - name: grafana-dashboard-spi-volume
+        projected:
+          sources:
+          - configMap:
+              name: grafana-dashboard-spi-health
+          - configMap:
+              name: grafana-dashboard-spi-outbound-traffic
+          - configMap:
+              name: grafana-dashboard-spi-slo
       - name: secret-grafana-tls
         secret:
           defaultMode: 420
@@ -242,7 +232,7 @@ data:
         type: file
         disableDeletion: true
         options:
-          path: /var/lib/grafana/dashboards/spi
+          path: /var/lib/grafana/dashboards-spi
 ---
 # Route and service to provide a secured access to Grafana
 apiVersion: route.openshift.io/v1

--- a/components/monitoring/grafana/base/kustomization.yaml
+++ b/components/monitoring/grafana/base/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - grafana-app.yaml
-- https://github.com/redhat-appstudio/service-provider-integration-operator/config/monitoring/base?ref=8fb5a16870c86d2b97bb89559dc145a091a4d9ab
+- https://github.com/redhat-appstudio/service-provider-integration-operator/config/monitoring/base?ref=45fa68db56318d2e729010f561680008fe2f64b9
 
 namespace: "appstudio-workload-monitoring"
 


### PR DESCRIPTION
 - Tested on rhpds
 - Used projected volume
 - Moved mount path to a separate folder (not a subfolder)
 - Fixed SLO dashboard UID https://github.com/redhat-appstudio/service-provider-integration-operator/pull/399

<img width="1696" alt="Знімок екрана 2023-01-13 о 13 15 13" src="https://user-images.githubusercontent.com/1614429/212308362-b13bc38d-9242-46ed-b709-8f12b21abb95.png">
