### PR TITLE
hotfix: Return shared snyk secret used by infra-update

### DIFF
--- a/components/shared-resources/globally-shared-secrets-clusterrole.yaml
+++ b/components/shared-resources/globally-shared-secrets-clusterrole.yaml
@@ -13,6 +13,7 @@ rules:
       - redhat-appstudio-user-workload
       - snyk-shared-secret
       - redhat-appstudio-staginguser
+      - test-team-snyk # needed by old pipelines with infra-update task
     verbs:
       - use
   - verbs:

--- a/components/shared-resources/snyk-shared-secret.yaml
+++ b/components/shared-resources/snyk-shared-secret.yaml
@@ -8,6 +8,16 @@ spec:
     name: snyk-shared-secret
     namespace: test-team
 ---
+# needed by old pipelines with infra-update task
+apiVersion: sharedresource.openshift.io/v1alpha1
+kind: SharedSecret
+metadata:
+  name:  test-team-snyk
+spec:
+  secretRef:
+    name: snyk-shared-secret
+    namespace: test-team
+---
 apiVersion: v1
 kind: Namespace
 metadata:


### PR DESCRIPTION
Infra-update pipelines for components CI are using old pipelineruns which are still pointing to old snyk-secret. Returning it.