### PR TITLE
Add sprayproxy to tekton-ci

### DIFF
--- a/components/tekton-ci/repository.yaml
+++ b/components/tekton-ci/repository.yaml
@@ -118,3 +118,10 @@ metadata:
 spec:
   url: "https://github.com/redhat-appstudio/gitops-repo-pruner"
 ---
+apiVersion: pipelinesascode.tekton.dev/v1alpha1
+kind: Repository
+metadata:
+  name: sprayproxy
+spec:
+  url: "https://github.com/redhat-appstudio/sprayproxy"
+---


### PR DESCRIPTION
Add the "spray" proxy for Pipelines as Code to our CI infrastructure. This will enable tests driven by Pipelines as Code.

Note that this component will be deployed on StoneSoup host clusters. A respective ArgoCD app will be created in the future once infra deployments supports host cluster ArgoCD applications.