### PR TITLE
Add GitOps Service' Prometheus ServiceMonitors/ClusteRoleBindings

### DIFF
--- a/components/monitoring/prometheus/base/servicemonitors/gitops-service.yaml
+++ b/components/monitoring/prometheus/base/servicemonitors/gitops-service.yaml
@@ -1,0 +1,113 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: gitops-appstudio-service-controller
+  namespace: appstudio-workload-monitoring
+  labels:
+    prometheus: appstudio-workload
+spec:
+  endpoints:
+  - bearerTokenSecret:
+      key: token
+      name: prometheus-k8s-token-xhrjb
+    interval: 15s
+    path: /metrics
+    port: metrics
+    scheme: https
+    tlsConfig:
+      insecureSkipVerify: true
+  namespaceSelector:
+    matchNames:
+    - gitops
+  selector:
+    matchLabels:
+      control-plane: appstudio-controller-manager
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: prometheus-gitops-appstudio-service-reader
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: gitops-appstudio-service-metrics-reader
+subjects:
+- kind: ServiceAccount
+  name: prometheus-k8s
+  namespace: appstudio-workload-monitoring
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: gitops-backend-controller
+  namespace: appstudio-workload-monitoring
+  labels:
+    prometheus: appstudio-workload
+spec:
+  endpoints:
+  - bearerTokenSecret:
+      key: token
+      name: prometheus-k8s-token-xhrjb
+    interval: 15s
+    path: /metrics
+    port: metrics
+    scheme: https
+    tlsConfig:
+      insecureSkipVerify: true
+  namespaceSelector:
+    matchNames:
+    - gitops
+  selector:
+    matchLabels:
+      control-plane: backend-controller-manager
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: prometheus-gitops-core-service-metrics-reader
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: gitops-core-service-metrics-reader
+subjects:
+- kind: ServiceAccount
+  name: prometheus-k8s
+  namespace: appstudio-workload-monitoring
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: gitops-cluster-agent-controller
+  namespace: appstudio-workload-monitoring
+  labels:
+    prometheus: appstudio-workload
+spec:
+  endpoints:
+  - bearerTokenSecret:
+      key: token
+      name: prometheus-k8s-token-xhrjb
+    interval: 15s
+    path: /metrics
+    port: metrics
+    scheme: https
+    tlsConfig:
+      insecureSkipVerify: true
+  namespaceSelector:
+    matchNames:
+    - gitops
+  selector:
+    matchLabels:
+      control-plane: cluster-agent-controller-manager
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: prometheus-gitops-service-agent-metrics-reader
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: gitops-service-agent-metrics-reader
+subjects:
+- kind: ServiceAccount
+  name: prometheus-k8s
+  namespace: appstudio-workload-monitoring

--- a/components/monitoring/prometheus/base/servicemonitors/kustomization.yaml
+++ b/components/monitoring/prometheus/base/servicemonitors/kustomization.yaml
@@ -4,6 +4,7 @@ kind: Kustomization
 resources:
 - build-service.yaml
 - dora-service.yaml
+- gitops-service.yaml
 - integration-service.yaml
 - jvm-build-service.yaml
 - prometheus.yaml


### PR DESCRIPTION
Add GitOps Service' Prometheus ServiceMonitors/ClusteRoleBindings. Up-to-date with recent refactoring of Prometheus YAMLs.