### PR TITLE
GitOps Service: Add Grafana dashboard JSON

### DIFF
--- a/components/monitoring/grafana/base/kustomization.yaml
+++ b/components/monitoring/grafana/base/kustomization.yaml
@@ -4,6 +4,7 @@ resources:
 - grafana-app.yaml
 - https://github.com/redhat-appstudio/service-provider-integration-operator/config/monitoring/base?ref=cc6210e3d43da993062b6452c8a6c9aa41b3da6d
 - https://github.com/redhat-appstudio/release-service/config/monitoring/?ref=bf8962318388cea9892319f2760707c7cb1d6ba2
+- https://github.com/redhat-appstudio/managed-gitops/manifests/base/monitoring/base?ref=283a1c391d64b251bf57c79403485ca47246be34
 
 namespace: "appstudio-workload-monitoring"
 


### PR DESCRIPTION
Add link to GitOps Service Grafana dashboard JSON, in GitOps Service repository.