### PR TITLE
fix: build-via-appstudio.sh - link secret

### DIFF
--- a/hack/build/build-via-appstudio.sh
+++ b/hack/build/build-via-appstudio.sh
@@ -21,6 +21,7 @@ SECRET=$(mktemp)
 echo '{"auths": {' $(yq eval '.auths | with_entries(select(.key == "quay.io"))' $AUTH_FILE) '}}' > $SECRET
 oc create secret docker-registry redhat-appstudio-registry-pull-secret --from-file=.dockerconfigjson=$SECRET --dry-run=client -o yaml | oc apply -f-
 rm $SECRET
+oc secret link pipeline redhat-appstudio-registry-pull-secret
 
 # Label namespace to be managed by gitops-service-argocd
 oc label namespace $(oc config view --minify -o 'jsonpath={..namespace}') --overwrite argocd.argoproj.io/managed-by=gitops-service-argocd


### PR DESCRIPTION
Registry-auth support was removed in [PLNSRVCE-910](https://issues.redhat.com//browse/PLNSRVCE-910) and it's replaced by secrets linked to the serviceaccount.