### PR TITLE
Add build-service grafana dashboards

### DIFF
--- a/components/monitoring/grafana/base/grafana-app.yaml
+++ b/components/monitoring/grafana/base/grafana-app.yaml
@@ -102,6 +102,8 @@ spec:
           name: grafana-dashboard-spi-volume
         - mountPath: /var/lib/grafana/dashboards-release-service
           name: grafana-dashboard-release-service-volume
+        - mountPath: /var/lib/grafana/dashboards-build-service
+          name: grafana-dashboard-build-service-volume
         - mountPath: /var/lib/grafana/dashboards-dora-metrics
           name: grafana-dashboard-dora-metrics-volume
       - name: grafana-oauth2-proxy
@@ -215,6 +217,13 @@ spec:
           sources:
             - configMap:
                 name: grafana-dashboard-release-release-attempts
+      - name: grafana-dashboard-build-service-volume
+        projected:
+          sources:
+            - configMap:
+                name: grafana-dashboard-initial-build-pipeline
+            - configMap:
+                name: grafana-dashboard-pac-provision
       - name: grafana-dashboard-dora-metrics-volume
         projected:
           sources:
@@ -253,6 +262,12 @@ data:
         disableDeletion: true
         options:
           path: /var/lib/grafana/dashboards-release-service
+      - name: Build Service Operator
+        folder: "Build Service Operator"
+        type: file
+        disableDeletion: true
+        options:
+          path: /var/lib/grafana/dashboards-build-service
       - name: Dora Metrics
         folder: QE
         type: file

--- a/components/monitoring/grafana/base/kustomization.yaml
+++ b/components/monitoring/grafana/base/kustomization.yaml
@@ -4,6 +4,7 @@ resources:
 - grafana-app.yaml
 - https://github.com/redhat-appstudio/service-provider-integration-operator/config/monitoring/base?ref=d8ba81c868ec6b9c596e0848d7a3805507f5bd69
 - https://github.com/redhat-appstudio/release-service/config/monitoring/?ref=7889cd932fce8d9e655aaab0ff1bed48e528c224
+- https://github.com/redhat-appstudio/build-service/config/monitoring/grafana-dashboards/?ref=e9276f8c7541a65900118768c9e431513385d594
 - https://github.com/redhat-appstudio/managed-gitops/manifests/base/monitoring/base?ref=283a1c391d64b251bf57c79403485ca47246be34
 - https://github.com/redhat-appstudio/dora-metrics/deploy/grafana/?ref=326417b0ffc4205fa3acaa675bfc0286f12b7682
 


### PR DESCRIPTION
Adds Build Service dashboards introduced in [this PR](https://github.com/redhat-appstudio/build-service/pull/107).