### PR TITLE
grafana: move component code to subfolders

### DIFF
--- a/components/monitoring/grafana/base/build-service/kustomization.yaml
+++ b/components/monitoring/grafana/base/build-service/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- https://github.com/redhat-appstudio/build-service/config/monitoring/grafana-dashboards/?ref=63d2e88dbfcffe2702bf99cd7a9e2ceb7d6a1e94

--- a/components/monitoring/grafana/base/dora-metrics/kustomization.yaml
+++ b/components/monitoring/grafana/base/dora-metrics/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- https://github.com/redhat-appstudio/dora-metrics/deploy/grafana/?ref=326417b0ffc4205fa3acaa675bfc0286f12b7682

--- a/components/monitoring/grafana/base/kustomization.yaml
+++ b/components/monitoring/grafana/base/kustomization.yaml
@@ -2,11 +2,11 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - grafana-app.yaml
-- https://github.com/redhat-appstudio/service-provider-integration-operator/config/monitoring/base?ref=8456502ae3a4dca0688bc70abfac2db58ee8acb4
-- https://github.com/redhat-appstudio/release-service/config/monitoring/?ref=1f1725480b6d88ed90864aa7ab99e2b666c606ac
-- https://github.com/redhat-appstudio/build-service/config/monitoring/grafana-dashboards/?ref=63d2e88dbfcffe2702bf99cd7a9e2ceb7d6a1e94
-- https://github.com/redhat-appstudio/managed-gitops/manifests/base/monitoring/base?ref=283a1c391d64b251bf57c79403485ca47246be34
-- https://github.com/redhat-appstudio/dora-metrics/deploy/grafana/?ref=326417b0ffc4205fa3acaa675bfc0286f12b7682
+- spi/
+- release-service/
+- build-service/
+- managed-gitops/
+- dora-metrics/
 
 namespace: "appstudio-workload-monitoring"
 

--- a/components/monitoring/grafana/base/managed-gitops/kustomization.yaml
+++ b/components/monitoring/grafana/base/managed-gitops/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- https://github.com/redhat-appstudio/managed-gitops/manifests/base/monitoring/base?ref=283a1c391d64b251bf57c79403485ca47246be34

--- a/components/monitoring/grafana/base/release-service/kustomization.yaml
+++ b/components/monitoring/grafana/base/release-service/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- https://github.com/redhat-appstudio/release-service/config/monitoring/?ref=1f1725480b6d88ed90864aa7ab99e2b666c606ac

--- a/components/monitoring/grafana/base/spi/kustomization.yaml
+++ b/components/monitoring/grafana/base/spi/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- https://github.com/redhat-appstudio/service-provider-integration-operator/config/monitoring/base?ref=8456502ae3a4dca0688bc70abfac2db58ee8acb4


### PR DESCRIPTION
To avoid git conflicts moving grafana configurations of services to sub-folders.

Action required -> if you have update set in .tekton folder then update file path.