### PR TITLE
Added alertmanager for prometheus to send email alerts

### DIFF
--- a/components/monitoring/prometheus/base/alermanager-config.yaml
+++ b/components/monitoring/prometheus/base/alermanager-config.yaml
@@ -1,0 +1,49 @@
+apiVersion: monitoring.coreos.com/v1
+kind: Alertmanager
+metadata:
+  name: alertmanager-appstudio
+  namespace: appstudio-workload-monitoring
+spec:
+  replicas: 3
+  alertmanagerConfigSelector:
+    matchLabels:
+      cluster: appstudio-stage
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: alertmanager-appstudio
+  namespace: appstudio-workload-monitoring
+  labels:
+    provider: appstudio-workload
+spec:
+  ports:
+  - name: web
+    port: 9093
+    protocol: TCP
+    targetPort: web
+  selector:
+    alertmanager: alertmanager-appstudio
+---
+apiVersion: monitoring.coreos.com/v1alpha1
+kind: AlertmanagerConfig
+metadata:
+  name: config-appstudio-stage
+  labels:
+    cluster: appstudio-stage
+spec:
+  route:
+    groupBy: ['job']
+    groupWait: 30s
+    groupInterval: 5m
+    repeatInterval: 12h
+    receiver: "stonesoup-stage"
+  receivers:
+  - name: "stonesoup-stage"
+    emailConfigs:
+    - to: 'appstudio-stage@redhat.com'
+      from: 'appstudio-stage@redhat.com'
+      #smarthost: <smtp-host>
+      #auth_username: <sender_email_id>
+      #auth_identity: <sender_email_id>
+      #auth_password: 'password'

--- a/components/monitoring/prometheus/base/configure-prometheus.yaml
+++ b/components/monitoring/prometheus/base/configure-prometheus.yaml
@@ -11,7 +11,7 @@ metadata:
 spec:
   alerting:
     alertmanagers:
-    - name: alertmanager-operated
+    - name: alertmanager-appstudio
       namespace: appstudio-workload-monitoring
       port: web
       scheme: http

--- a/components/monitoring/prometheus/base/kustomization.yaml
+++ b/components/monitoring/prometheus/base/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
 - prometheus-view.yaml
 - configure-prometheus.yaml
 - ./servicemonitors/
+- alertmanager-config.yaml
 
 namespace: "appstudio-workload-monitoring"
 


### PR DESCRIPTION
This PR is for configuring the alert managers. These alertmangers are for alerting the target audiances from prometheus.
It adds the following:
* Alertmanager: alertmanager-appstudio
* Service for exposing alertmanagers: alertmanager-appstudio
* AlertmanagerConfig: config-appstudio-stage

Signed-off-by: Bama Charan Kundu <bamachrn@gmail.com>