### PR TITLE
PLNSRVCE-1022: add kube-rbac-proxy related rback for sprayproxy; add sprayproxy servicemonitor; bump sprayproxy git/image sha

### DIFF
--- a/components/sprayproxy/kustomization.yaml
+++ b/components/sprayproxy/kustomization.yaml
@@ -1,12 +1,12 @@
 resources:
-  - https://github.com/redhat-appstudio/sprayproxy/config?ref=076942559b739729c156b3d64f87efda1731ab90
+  - https://github.com/redhat-appstudio/sprayproxy/config?ref=0eece5fdaf5c84ed79c852b7c9c7118ced5d4390
 
 namespace: sprayproxy
 
 images:
   - name: ko://github.com/redhat-appstudio/sprayproxy
     newName: quay.io/redhat-appstudio/sprayproxy
-    newTag: 076942559b739729c156b3d64f87efda1731ab90
+    newTag: 0eece5fdaf5c84ed79c852b7c9c7118ced5d4390
 
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/components/sprayproxy/servicemonitor-rbacproxy/auth-proxy-clusterrolebinding.yaml
+++ b/components/sprayproxy/servicemonitor-rbacproxy/auth-proxy-clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: prometheus-sprayproxy-metrics-reader
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: sprayproxy-metrics-reader
+subjects:
+  - kind: ServiceAccount
+    name: prometheus-k8s
+    namespace: appstudio-workload-monitoring

--- a/components/sprayproxy/servicemonitor-rbacproxy/kustomization.yaml
+++ b/components/sprayproxy/servicemonitor-rbacproxy/kustomization.yaml
@@ -1,0 +1,3 @@
+resources:
+  - servicemonitor.yaml
+  - auth-proxy-clusterrolebinding.yaml

--- a/components/sprayproxy/servicemonitor-rbacproxy/servicemonitor.yaml
+++ b/components/sprayproxy/servicemonitor-rbacproxy/servicemonitor.yaml
@@ -1,0 +1,26 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    app.kubernetes.io/name: sprayproxy
+    prometheus: appstudio-workload
+  name: sprayproxy
+  namespace: appstudio-workload-monitoring
+spec:
+  endpoints:
+    - path: /metrics
+      interval: 15s
+      port: https
+      scheme: https
+      bearerTokenSecret:
+        name: "prometheus-k8s-token-xhrjb"
+        key: token
+      tlsConfig:
+        insecureSkipVerify: true
+  namespaceSelector:
+    matchNames:
+      # fyi the yaml in the sprayproxy repo has 'redhat-sprayproxy' as the namespace, but the kustomization.yaml in the parent director is forcing the namespace to 'sprayproxy', so citing that here
+      - sprayproxy
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: sprayproxy


### PR DESCRIPTION
@adambkaplan @bamachrn @gbenhaim - changes stemming from the call between Gal, Bama, and I last week, plus the merge of https://github.com/redhat-appstudio/sprayproxy/pull/19

PR is based off of the latest multi-cluster branch