### PR TITLE
make sprayproxy namespace name consistent across relevant repositories

### DIFF
--- a/argo-cd-apps/base/host/sprayproxy/sprayproxy.yaml
+++ b/argo-cd-apps/base/host/sprayproxy/sprayproxy.yaml
@@ -16,7 +16,7 @@ spec:
         repoURL: https://github.com/redhat-appstudio/infra-deployments.git
         targetRevision: multi-cluster
       destination:
-        namespace: sprayproxy
+        namespace: redhat-sprayproxy
         server: '{{server}}'
       syncPolicy:
         automated:

--- a/components/sprayproxy/kustomization.yaml
+++ b/components/sprayproxy/kustomization.yaml
@@ -1,7 +1,7 @@
 resources:
   - https://github.com/redhat-appstudio/sprayproxy/config?ref=0eece5fdaf5c84ed79c852b7c9c7118ced5d4390
 
-namespace: sprayproxy
+namespace: redhat-sprayproxy
 
 images:
   - name: ko://github.com/redhat-appstudio/sprayproxy


### PR DESCRIPTION
See tail end of https://redhat-internal.slack.com/archives/C02CTEB3MMF/p1675779040727089

/assign @gbenhaim 
/assign @adambkaplan 

@ramessesii2 @avinal FYI