### PR TITLE
Added ServiceMonitor for pipeline-service

### DIFF
--- a/components/monitoring/prometheus/base/servicemonitors/kustomization.yaml
+++ b/components/monitoring/prometheus/base/servicemonitors/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
 - gitops-service.yaml
 - integration-service.yaml
 - jvm-build-service.yaml
+- pipeline-service.yaml
 - prometheus.yaml
 - release-service.yaml
 - sandbox-host-operator.yaml

--- a/components/monitoring/prometheus/base/servicemonitors/pipeline-service.yaml
+++ b/components/monitoring/prometheus/base/servicemonitors/pipeline-service.yaml
@@ -1,0 +1,33 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: pipeline-service
+  namespace: appstudio-workload-monitoring
+  labels:
+    app: pipeline-metrics-exporter
+    prometheus: appstudio-workload
+spec:
+  selector:
+    matchLabels:
+      app: pipeline-metrics-exporter
+  endpoints:
+    - path: /metrics
+      port: metrics
+      interval: 15s
+      scheme: http
+  namespaceSelector:
+    matchNames:
+      - openshift-pipelines
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: prometheus-pipeline-service-exporter-reader
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: pipeline-service-exporter-reader
+subjects:
+  - kind: ServiceAccount
+    name: prometheus-k8s
+    namespace: appstudio-workload-monitoring


### PR DESCRIPTION
- This PR goes along with https://github.com/openshift-pipelines/pipeline-service/pull/473 opened on Pipeline Service.
- Adds the required Service Monitor and cluster role binding in order to scrape metrics from the custom pipeline service metrics exporter.