### PR TITLE
Update GitOps Maintainers and maintainer role: fix duplicate role names in kustomize.yaml

### DIFF
--- a/components/authentication/gitops.yaml
+++ b/components/authentication/gitops.yaml
@@ -2,7 +2,7 @@
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: gitops-service-maintainers
+  name: gitops-service-gitops-component-maintainers
   namespace: gitops
 subjects:
   - kind: User

--- a/components/authentication/kustomization.yaml
+++ b/components/authentication/kustomization.yaml
@@ -4,6 +4,7 @@ resources:
 - spi.yaml
 - spi-vault-admin.yaml
 - gitops.yaml
+- gitops-component-maintainer.yaml
 - release-team.yaml
 - has.yaml
 - build.yaml


### PR DESCRIPTION
- Fix an issue with duplicate role names
- Add `gitops-component-maintainer.yaml` new file to `kustomization.yaml`