### PR TITLE
Update GitOps Component Maintainer Role YAML: fix quotes

### DIFF
--- a/components/authentication/gitops-component-maintainer.yaml
+++ b/components/authentication/gitops-component-maintainer.yaml
@@ -19,8 +19,8 @@ metadata:
   namespace: gitops
 rules:
   - apiGroups:
-      - "*"
+      - '*'
     resources:
-      - "*"
+      - '*'
     verbs:
-      - "*"
+      - '*'


### PR DESCRIPTION
- As described in the title, switch to single-quotes from quotation marks