### PR TITLE
GitOps Service: Update to latest dashboard contents on managed-gitops repository

### DIFF
--- a/components/monitoring/grafana/base/managed-gitops/kustomization.yaml
+++ b/components/monitoring/grafana/base/managed-gitops/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- https://github.com/redhat-appstudio/managed-gitops/manifests/base/monitoring/grafana-dashboards/stonesoup?ref=c1db9861f43af233e2af42119a7d7b0025fb630c
+- https://github.com/redhat-appstudio/managed-gitops/manifests/base/monitoring/grafana-dashboards/stonesoup-new?ref=d2480e7abbe50e4207b4ef9368e481a9329a3a46


### PR DESCRIPTION
Another stab at attempting to pull in the GitOps Service Dashboard :smile: 

JIRA: https://issues.redhat.com/browse/GITOPSRVCE-341