### PR TITLE
GitOps: multi-cluster - Move to GitOps' Stonesoup member cluster kustomize overlay

### DIFF
--- a/components/authentication/gitops.yaml
+++ b/components/authentication/gitops.yaml
@@ -1,5 +1,5 @@
 ---
-kind: RoleBinding
+kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: gitops-service-gitops-component-maintainers

--- a/components/gitops/staging/kustomization.yaml
+++ b/components/gitops/staging/kustomization.yaml
@@ -2,13 +2,11 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-- https://github.com/redhat-appstudio/managed-gitops/manifests/overlays/appstudio-staging-cluster?ref=d2480e7abbe50e4207b4ef9368e481a9329a3a46
+- https://github.com/redhat-appstudio/managed-gitops/manifests/overlays/stonesoup-member-cluster?ref=6963dac78dbea949f9218e448c053fdde84759e5
 
 
 images:
   - name: \${COMMON_IMAGE}
     newName: quay.io/redhat-appstudio/gitops-service
-    newTag: d2480e7abbe50e4207b4ef9368e481a9329a3a46
+    newTag: 6963dac78dbea949f9218e448c053fdde84759e5
 
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization


### PR DESCRIPTION
- Move to the kustomize overlay in managed-gitops repo which is used to configure Stonesoup member cluster
- Update RB -> CRB, as it was incorrectly set previously
- Update to latest commit