### PR TITLE
Update pipeline service to have the custom exporter changes

### DIFF
--- a/components/pipeline-service/kustomization.yaml
+++ b/components/pipeline-service/kustomization.yaml
@@ -8,7 +8,7 @@ commonAnnotations:
   argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 
 resources:
-  - git::https://github.com/openshift-pipelines/pipeline-service.git/operator/gitops/argocd/pipeline-service?ref=3cce2e2dc3a468dfc1cde5a04c2a55583d9d1c66
+  - git::https://github.com/openshift-pipelines/pipeline-service.git/operator/gitops/argocd/pipeline-service?ref=cc7b0c5a3a73d6966f3d6ce2ce2664ebd32a2f02
   - tekton-chains-controller-shared-secrets-rolebinding.yaml
 
 patchesStrategicMerge:


### PR DESCRIPTION
This will also include changes to expose the public-key secret in the tekton-chains namespace to all users of the clusters to allow users to decode tekton-chains signed payloads.