### PR TITLE
move to 4.12 version of sharead resources, including official images; add reminders for moves to OCP 4.13, 4.14

### DIFF
--- a/components/shared-resources/globally-shared-secrets-clusterrole.yaml
+++ b/components/shared-resources/globally-shared-secrets-clusterrole.yaml
@@ -13,6 +13,7 @@ rules:
       - redhat-appstudio-user-workload
     verbs:
       - use
+# the rule to use the csi-scc can be removed when we move to 4.13 OCP
   - verbs:
       - use
     apiGroups:

--- a/components/shared-resources/kustomization.yaml
+++ b/components/shared-resources/kustomization.yaml
@@ -1,19 +1,25 @@
 resources:
 # when stonesoup rebases on OCP 4.14, shared resources will be part of the GA install; as such, if we are still using shared resources,
 # all these raw.githubusercontent refs to install shared resources can go away
-- https://raw.githubusercontent.com/openshift/csi-driver-shared-resource-operator/c60295f4e59c0d3f17fd1c5b920296ec58231db1/assets/config_configmap.yaml
-- https://raw.githubusercontent.com/openshift/csi-driver-shared-resource-operator/c60295f4e59c0d3f17fd1c5b920296ec58231db1/assets/csidriver.yaml
-- https://raw.githubusercontent.com/openshift/csi-driver-shared-resource-operator/c60295f4e59c0d3f17fd1c5b920296ec58231db1/assets/metrics_service.yaml
-- https://raw.githubusercontent.com/openshift/csi-driver-shared-resource-operator/c60295f4e59c0d3f17fd1c5b920296ec58231db1/assets/node_sa.yaml
-- https://raw.githubusercontent.com/openshift/csi-driver-shared-resource-operator/c60295f4e59c0d3f17fd1c5b920296ec58231db1/assets/node.yaml
-- https://raw.githubusercontent.com/openshift/csi-driver-shared-resource-operator/c60295f4e59c0d3f17fd1c5b920296ec58231db1/assets/servicemonitor.yaml
-- https://raw.githubusercontent.com/openshift/csi-driver-shared-resource-operator/c60295f4e59c0d3f17fd1c5b920296ec58231db1/assets/service.yaml
-- https://raw.githubusercontent.com/openshift/csi-driver-shared-resource-operator/c60295f4e59c0d3f17fd1c5b920296ec58231db1/assets/rbac/node_binding.yaml
-- https://raw.githubusercontent.com/openshift/csi-driver-shared-resource-operator/c60295f4e59c0d3f17fd1c5b920296ec58231db1/assets/rbac/node_privileged_binding.yaml
-- https://raw.githubusercontent.com/openshift/csi-driver-shared-resource-operator/c60295f4e59c0d3f17fd1c5b920296ec58231db1/assets/rbac/node_role.yaml
-- https://raw.githubusercontent.com/openshift/csi-driver-shared-resource-operator/c60295f4e59c0d3f17fd1c5b920296ec58231db1/assets/rbac/privileged_role.yaml
-- https://raw.githubusercontent.com/openshift/csi-driver-shared-resource-operator/c60295f4e59c0d3f17fd1c5b920296ec58231db1/assets/rbac/prometheus_rolebinding.yaml
-- https://raw.githubusercontent.com/openshift/csi-driver-shared-resource-operator/c60295f4e59c0d3f17fd1c5b920296ec58231db1/assets/rbac/prometheus_role.yaml
+
+# Prior to 4.14 GA of OCP, which will include shared resources, we still installing shared resources manually here at the 4.12 level
+- https://raw.githubusercontent.com/openshift/csi-driver-shared-resource-operator/e2363205aacfcc2dad711b32e24e73e11471652d/assets/config_configmap.yaml
+- https://raw.githubusercontent.com/openshift/csi-driver-shared-resource-operator/e2363205aacfcc2dad711b32e24e73e11471652d/assets/csidriver.yaml
+- https://raw.githubusercontent.com/openshift/csi-driver-shared-resource-operator/e2363205aacfcc2dad711b32e24e73e11471652d/assets/metrics_service.yaml
+- https://raw.githubusercontent.com/openshift/csi-driver-shared-resource-operator/e2363205aacfcc2dad711b32e24e73e11471652d/assets/node_sa.yaml
+- https://raw.githubusercontent.com/openshift/csi-driver-shared-resource-operator/e2363205aacfcc2dad711b32e24e73e11471652d/assets/node.yaml
+- https://raw.githubusercontent.com/openshift/csi-driver-shared-resource-operator/e2363205aacfcc2dad711b32e24e73e11471652d/assets/servicemonitor.yaml
+- https://raw.githubusercontent.com/openshift/csi-driver-shared-resource-operator/e2363205aacfcc2dad711b32e24e73e11471652d/assets/service.yaml
+- https://raw.githubusercontent.com/openshift/csi-driver-shared-resource-operator/e2363205aacfcc2dad711b32e24e73e11471652d/assets/sharedconfigmaplist_configmap.yaml
+- https://raw.githubusercontent.com/openshift/csi-driver-shared-resource-operator/e2363205aacfcc2dad711b32e24e73e11471652d/assets/sharedsecretlist_configmap.yaml
+- https://raw.githubusercontent.com/openshift/csi-driver-shared-resource-operator/e2363205aacfcc2dad711b32e24e73e11471652d/assets/rbac/node_binding.yaml
+- https://raw.githubusercontent.com/openshift/csi-driver-shared-resource-operator/e2363205aacfcc2dad711b32e24e73e11471652d/assets/rbac/node_privileged_binding.yaml
+- https://raw.githubusercontent.com/openshift/csi-driver-shared-resource-operator/e2363205aacfcc2dad711b32e24e73e11471652d/assets/rbac/node_role.yaml
+- https://raw.githubusercontent.com/openshift/csi-driver-shared-resource-operator/e2363205aacfcc2dad711b32e24e73e11471652d/assets/rbac/privileged_role.yaml
+- https://raw.githubusercontent.com/openshift/csi-driver-shared-resource-operator/e2363205aacfcc2dad711b32e24e73e11471652d/assets/rbac/prometheus_rolebinding.yaml
+# NOTE, with stonesoup's move toward hypershift, the shared resource admission webhooks will not successfully launch via manual application for the same reasons we needed to
+# back out shared resources as GA for 4.13.  Shared-resources on hypershift, along with shared resources as GA level OCP, is on tap for 4.14 of OCP.
+# The same restrictions enforced by the webhooks are also enforced by the driver
 - https://raw.githubusercontent.com/openshift/api/9d91c1f6cfd40449bd2af8a6b697a3bf7baf933b/sharedresource/v1alpha1/0000_10_sharedconfigmap.crd.yaml
 - https://raw.githubusercontent.com/openshift/api/9d91c1f6cfd40449bd2af8a6b697a3bf7baf933b/sharedresource/v1alpha1/0000_10_sharedsecret.crd.yaml
 # the scc.yaml can be removed when we move to 4.13 OCP, as the storage team's CSI in-line security 
@@ -24,11 +30,11 @@ resources:
 # the images section can be removed when we move to 4.14 OCP
 images:
 - name: \${NODE_DRIVER_REGISTRAR_IMAGE}
-  newName: quay.io/openshift/origin-csi-node-driver-registrar
-  newTag: 4.11.0
+  newName: registry.redhat.io/openshift4/ose-csi-node-driver-registrar
+  newTag: v4.12.0-202302061702.p0.g805d5ac.assembly.stream
 - name: \${DRIVER_IMAGE}
-  newName: quay.io/openshift/origin-csi-driver-shared-resource
-  newTag: 4.11.0
+  newName: registry.redhat.io/openshift4/ose-csi-driver-shared-resource-rhel8
+  newTag: v4.12.0-202302061702.p0.g20cffc0.assembly.stream
 
 # Skip applying the Tekton operands while the Tekton operator is being installed.
 # See more information about this option, here:

--- a/components/shared-resources/kustomization.yaml
+++ b/components/shared-resources/kustomization.yaml
@@ -1,4 +1,6 @@
 resources:
+# when stonesoup rebases on OCP 4.14, shared resources will be part of the GA install; as such, if we are still using shared resources,
+# all these raw.githubusercontent refs to install shared resources can go away
 - https://raw.githubusercontent.com/openshift/csi-driver-shared-resource-operator/c60295f4e59c0d3f17fd1c5b920296ec58231db1/assets/config_configmap.yaml
 - https://raw.githubusercontent.com/openshift/csi-driver-shared-resource-operator/c60295f4e59c0d3f17fd1c5b920296ec58231db1/assets/csidriver.yaml
 - https://raw.githubusercontent.com/openshift/csi-driver-shared-resource-operator/c60295f4e59c0d3f17fd1c5b920296ec58231db1/assets/metrics_service.yaml
@@ -14,10 +16,12 @@ resources:
 - https://raw.githubusercontent.com/openshift/csi-driver-shared-resource-operator/c60295f4e59c0d3f17fd1c5b920296ec58231db1/assets/rbac/prometheus_role.yaml
 - https://raw.githubusercontent.com/openshift/api/9d91c1f6cfd40449bd2af8a6b697a3bf7baf933b/sharedresource/v1alpha1/0000_10_sharedconfigmap.crd.yaml
 - https://raw.githubusercontent.com/openshift/api/9d91c1f6cfd40449bd2af8a6b697a3bf7baf933b/sharedresource/v1alpha1/0000_10_sharedsecret.crd.yaml
+# the scc.yaml can be removed when we move to 4.13 OCP, as the storage team's CSI in-line security 
 - scc.yaml
 - redhat-appstudio-user-workload-sharedsecret.yaml
 - globally-shared-secrets-clusterrole.yaml
 
+# the images section can be removed when we move to 4.14 OCP
 images:
 - name: \${NODE_DRIVER_REGISTRAR_IMAGE}
   newName: quay.io/openshift/origin-csi-node-driver-registrar

--- a/components/shared-resources/scc.yaml
+++ b/components/shared-resources/scc.yaml
@@ -1,3 +1,4 @@
+# this file can be deleted when we rebase on top of OCP 4.13
 allowHostDirVolumePlugin: false
 allowHostIPC: false
 allowHostNetwork: false


### PR DESCRIPTION
I could not find any jira trackers for this yet (not surprising, 4.13 does not GA until April) but I wanted to register some placeholders somewhere to possibly help remind us when the time comes 