### PR TITLE
add image-controller to main CI

### DIFF
--- a/components/tekton-ci/repository.yaml
+++ b/components/tekton-ci/repository.yaml
@@ -131,3 +131,10 @@ metadata:
   name: ec-cli
 spec:
   url: "https://github.com/hacbs-contract/ec-cli"
+---
+apiVersion: pipelinesascode.tekton.dev/v1alpha1
+kind: Repository
+metadata:
+  name: image-controller
+spec:
+  url: "https://github.com/redhat-appstudio/image-controller"


### PR DESCRIPTION
So far, I was running this on my own tenant namespace. I'm going to be moving this off to the tekton-ci Component as part of this PR.

