### PR TITLE
WIP - Update tekton-results database secret name

### DIFF
--- a/components/pipeline-service/staging/base/external-secrets/tekton-results/tekton-results-database.yaml
+++ b/components/pipeline-service/staging/base/external-secrets/tekton-results/tekton-results-database.yaml
@@ -1,7 +1,7 @@
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
-  name: tekton-results-database
+  name: tekton-results-postgres
   annotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
     argocd.argoproj.io/sync-wave: "1"
@@ -16,4 +16,4 @@ spec:
   target:
     creationPolicy: Owner
     deletionPolicy: Delete
-    name: tekton-results-database
+    name: tekton-results-postgres


### PR DESCRIPTION
## Changes

**NOTE: this is a breaking change. Needs openshift-pipelines/pipeline-service#504**

The latest changes to the tekton-results manifests in pipeline-service will use `tekton-results-postgres` as the secret name. 

## Action Items

The data fields provided to this secret must follow the naming convention as provided here: https://github.com/bitnami/containers/blob/main/bitnami/postgresql/15/debian-11/rootfs/opt/bitnami/scripts/postgresql-env.sh.

### Required Changes to `tekton-results-postgres` secret's data fields

Refer: https://github.com/openshift-pipelines/tektoncd-results/blob/downstream/config/api.yaml#L38-L53

```
db.name -> DB_NAME
db.host -> DB_HOST
db.password -> POSTGRES_PASSWORD
db.user -> POSTGRES_USER
```