### PR TITLE
fix: added openssl to prerequisites

### DIFF
--- a/docs/development/pre.md
+++ b/docs/development/pre.md
@@ -11,6 +11,7 @@ The prerequisites are:
   - `oc` - that matches your cluster version.
   - `jq` >= `1.6`
   - [`yq`](https://github.com/mikefarah/yq) >= `v4.23.1`
+  - `openssl` >= v3.0.2
 - The script `./hack/setup/install-pre-req.sh` will install these prerequisites for you, if they're not already installed.
 - You must have `kubectl` and `oc` pointing to an existing OpenShift cluster, that you wish to deploy to.
 

--- a/hack/setup/debian-based.sh
+++ b/hack/setup/debian-based.sh
@@ -10,4 +10,4 @@ wget https://github.com/mikefarah/yq/releases/download/${VERSION}/${BINARY}.tar.
 curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl
 chmod +x ./kubectl
 sudo mv ./kubectl /usr/local/bin
-sudo apt-get install jq
+sudo apt-get install jq openssl

--- a/hack/setup/redhat-based.sh
+++ b/hack/setup/redhat-based.sh
@@ -9,4 +9,4 @@ wget https://github.com/mikefarah/yq/releases/download/${VERSION}/${BINARY}.tar.
 curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl
 chmod +x ./kubectl
 sudo mv ./kubectl /usr/local/bin
-sudo dnf install jq
+sudo dnf install jq openssl


### PR DESCRIPTION
https://issues.redhat.com/browse/STONEBLD-728

I have noticed that openssl is required, but was not listed in the prerequisites for debian-based distros and redhat-based distros.

I added openssl to debian-based.sh and redhat-based.sh and to doc pre.md.

I have tested the commands on Fedora baremetal and in a Ubuntu podman container.