### PR TITLE
Update keycloak user

### DIFF
--- a/components/dev-sso/keycloak-realm.yaml
+++ b/components/dev-sso/keycloak-realm.yaml
@@ -36,3 +36,6 @@ spec:
         firstName: user1
         id: user1
         username: user1
+        clientRoles:
+          realm-management:
+            - "manage-users"


### PR DESCRIPTION
Add a role to keycloak user `user1` to manage users. 
The `user1` will add a new user per test run. Having a unique user per test helps track user actions in logs in case something fails. 