### PR TITLE
Fix source path for sprayproxy

### DIFF
--- a/argo-cd-apps/base/host/sprayproxy/sprayproxy.yaml
+++ b/argo-cd-apps/base/host/sprayproxy/sprayproxy.yaml
@@ -13,7 +13,7 @@ spec:
               values:
                 sourceRoot: components/sprayproxy
                 environment: staging
-                clusterDir: base
+                clusterDir: ""
           - list:
               elements: []
   template:


### PR DESCRIPTION
The sprayproxy overlay doesn't have any cluster specific overlay, so it can be omitted from the ApplicatioSet definition.