### PR TITLE
preview: set only docker-hub secret in set-docker-hub-pull-secret.sh

### DIFF
--- a/hack/secret-creator/set-docker-hub-pull-secret.sh
+++ b/hack/secret-creator/set-docker-hub-pull-secret.sh
@@ -12,6 +12,8 @@ main() {
     oc registry login --registry=docker.io --auth-basic="$docker_io_auth" --to="$auth"
     oc set data secret/pull-secret -n openshift-config --from-file=.dockerconfigjson="$auth"
     # Set current namespace pipeline serviceaccount which is used by buildah
+    rm "$auth"
+    oc registry login --registry=docker.io --auth-basic="$docker_io_auth" --to="$auth"
     oc create secret docker-registry docker-io-pull --from-file=.dockerconfigjson="$auth" -o yaml --dry-run=client | oc apply -f-
     oc create serviceaccount pipeline -o yaml --dry-run=client | oc apply -f-
     oc secrets link pipeline docker-io-pull


### PR DESCRIPTION
Avoid setting global pull secrets for the namespace.