### PR TITLE
Skip on missing

### DIFF
--- a/components/authentication/base/group-sync/github-redhat-appstudio-sre.yaml
+++ b/components/authentication/base/group-sync/github-redhat-appstudio-sre.yaml
@@ -2,6 +2,8 @@ apiVersion: redhatcop.redhat.io/v1alpha1
 kind: GroupSync
 metadata:
   name: github-redhat-appstudio-sre
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   schedule: "*/15 * * * *"
   providers:

--- a/components/authentication/base/group-sync/github-redhat-appstudio.yaml
+++ b/components/authentication/base/group-sync/github-redhat-appstudio.yaml
@@ -2,6 +2,8 @@ apiVersion: redhatcop.redhat.io/v1alpha1
 kind: GroupSync
 metadata:
   name: github-redhat-appstudio
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   schedule: "*/15 * * * *"
   providers:

--- a/components/gitops/production/base/kustomization.yaml
+++ b/components/gitops/production/base/kustomization.yaml
@@ -10,3 +10,6 @@ images:
   - name: \${COMMON_IMAGE}
     newName: quay.io/redhat-appstudio/gitops-service
     newTag: 6963dac78dbea949f9218e448c053fdde84759e5
+
+commonAnnotations:
+  argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true

--- a/components/gitops/staging/base/kustomization.yaml
+++ b/components/gitops/staging/base/kustomization.yaml
@@ -10,3 +10,6 @@ images:
   - name: \${COMMON_IMAGE}
     newName: quay.io/redhat-appstudio/gitops-service
     newTag: 6963dac78dbea949f9218e448c053fdde84759e5
+
+commonAnnotations:
+  argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true


### PR DESCRIPTION
    authentication: Skip on missing resources
    
    Since the authentication app installs the GroupSync CR and Subscription
    , it should skip the dry run for checking if there are missing
    resources.


    gitops: Skip on missing resources
    
    Since Gitops installs the ArgoCD CR and Subscription for
    openshift-gitops, it should skip the dry run for checking if there are
    missing resources.
