### PR TITLE
Added external secrets for stone-prod-prometheus

### DIFF
--- a/components/monitoring/prometheus/production/base/kustomization.yaml
+++ b/components/monitoring/prometheus/production/base/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- ../../base/external-secrets

--- a/components/monitoring/prometheus/production/stone-prd-m01/kustomization.yaml
+++ b/components/monitoring/prometheus/production/stone-prd-m01/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../base
+patches:
+  - path: monitoring-prometheus-oauth-config-path.yaml
+    target:
+      name: monitoring-prometheus-oauth-config
+      group: external-secrets.io
+      version: v1beta1
+      kind: ExternalSecret

--- a/components/monitoring/prometheus/production/stone-prd-m01/monitoring-prometheus-oauth-config-path.yaml
+++ b/components/monitoring/prometheus/production/stone-prd-m01/monitoring-prometheus-oauth-config-path.yaml
@@ -1,0 +1,4 @@
+---
+- op: add
+  path: /spec/dataFrom/0/extract/key
+  value: production/monitoring/prd-m01/promtheus/monitoring-workload-prometheus/prometheus-oauth2-proxy

--- a/components/monitoring/prometheus/production/stone-prd-m01/monitoring-prometheus-oauth-config-path.yaml
+++ b/components/monitoring/prometheus/production/stone-prd-m01/monitoring-prometheus-oauth-config-path.yaml
@@ -1,4 +1,4 @@
 ---
 - op: add
   path: /spec/dataFrom/0/extract/key
-  value: production/monitoring/prd-m01/promtheus/monitoring-workload-prometheus/prometheus-oauth2-proxy
+  value: production/monitoring/prd-m01/prometheus/monitoring-workload-prometheus/prometheus-oauth2-proxy

--- a/components/monitoring/prometheus/production/stone-prd-rh01/kustomization.yaml
+++ b/components/monitoring/prometheus/production/stone-prd-rh01/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../base
+patches:
+  - path: monitoring-prometheus-oauth-config-path.yaml
+    target:
+      name: monitoring-prometheus-oauth-config
+      group: external-secrets.io
+      version: v1beta1
+      kind: ExternalSecret

--- a/components/monitoring/prometheus/production/stone-prd-rh01/monitoring-prometheus-oauth-config-path.yaml
+++ b/components/monitoring/prometheus/production/stone-prd-rh01/monitoring-prometheus-oauth-config-path.yaml
@@ -1,0 +1,4 @@
+---
+- op: add
+  path: /spec/dataFrom/0/extract/key
+  value: production/monitoring/prd-rh01/promtheus/monitoring-workload-prometheus/prometheus-oauth2-proxy

--- a/components/monitoring/prometheus/production/stone-prd-rh01/monitoring-prometheus-oauth-config-path.yaml
+++ b/components/monitoring/prometheus/production/stone-prd-rh01/monitoring-prometheus-oauth-config-path.yaml
@@ -1,4 +1,4 @@
 ---
 - op: add
   path: /spec/dataFrom/0/extract/key
-  value: production/monitoring/prd-rh01/promtheus/monitoring-workload-prometheus/prometheus-oauth2-proxy
+  value: production/monitoring/prd-rh01/prometheus/monitoring-workload-prometheus/prometheus-oauth2-proxy


### PR DESCRIPTION
This PR adds `prometheus-oauth2-proxy` secrets to the prod environment using external secrets 


Signed-off-by: Bama Charan Kundu <bamachrn@gmail.com>