### PR TITLE
GitOps: Update references to prod RDS vault secrets

### DIFF
--- a/components/gitops/production/stone-prd-m01/gitops-service-postgres-rds-config-path.yaml
+++ b/components/gitops/production/stone-prd-m01/gitops-service-postgres-rds-config-path.yaml
@@ -1,4 +1,4 @@
 ---
 - op: add
   path: /spec/dataFrom/0/extract/key
-  value: TBA
+  value: integrations-output/terraform-resources/app-sre-prod-01/stonesoup-infra-production/multi-tenant-prod-gitopsvc-rds

--- a/components/gitops/production/stone-prd-rh01/gitops-service-postgres-rds-config-path.yaml
+++ b/components/gitops/production/stone-prd-rh01/gitops-service-postgres-rds-config-path.yaml
@@ -1,4 +1,4 @@
 ---
 - op: add
   path: /spec/dataFrom/0/extract/key
-  value: TBA
+  value: integrations-output/terraform-resources/app-sre-prod-01/stonesoup-infra-production/redhat-prod-gitopsvc-rds


### PR DESCRIPTION
Update GitOps external secrets references, to new RDS secrets within app-interface

JIRA: [GITOPSRVCE-418](https://issues.redhat.com/browse/GITOPSRVCE-418)