### PR TITLE
monitoring: Add path to cluster overlays

### DIFF
--- a/argo-cd-apps/base/member/infra-deployments/monitoring-workload-logging/monitoring-workload-logging.yaml
+++ b/argo-cd-apps/base/member/infra-deployments/monitoring-workload-logging/monitoring-workload-logging.yaml
@@ -14,7 +14,15 @@ spec:
                 environment: staging
                 clusterDir: ""
           - list:
-              elements: []
+              elements:
+                - nameNormalized: stone-stg-m01
+                  values.clusterDir: stone-stg-m01
+                - nameNormalized: stone-stg-rh01
+                  values.clusterDir: stone-stg-rh01
+                - nameNormalized: stone-prd-m01
+                  values.clusterDir: stone-prd-m01
+                - nameNormalized: stone-prd-rh01
+                  values.clusterDir: stone-prd-rh01
   template:
     metadata:
       name: monitoring-workload-logging-{{nameNormalized}}

--- a/argo-cd-apps/base/member/infra-deployments/monitoring-workload-prometheus/monitoring-workload-prometheus.yaml
+++ b/argo-cd-apps/base/member/infra-deployments/monitoring-workload-prometheus/monitoring-workload-prometheus.yaml
@@ -14,7 +14,15 @@ spec:
                 environment: staging
                 clusterDir: ""
           - list:
-              elements: []
+              elements:
+                - nameNormalized: stone-stg-m01
+                  values.clusterDir: stone-stg-m01
+                - nameNormalized: stone-stg-rh01
+                  values.clusterDir: stone-stg-rh01
+                - nameNormalized: stone-prd-m01
+                  values.clusterDir: stone-prd-m01
+                - nameNormalized: stone-prd-rh01
+                  values.clusterDir: stone-prd-rh01
   template:
     metadata:
       name: monitoring-workload-prometheus-{{nameNormalized}}


### PR DESCRIPTION
Some of the monitoring applications requires cluster specific overlay, so it should be reflected in the ApplicationSet.