### PR TITLE
monitoring: Add missing pointers to base

### DIFF
--- a/components/monitoring/logging/stagging/base/kustomization.yaml
+++ b/components/monitoring/logging/stagging/base/kustomization.yaml
@@ -3,3 +3,4 @@ kind: Kustomization
 
 resources:
 - ../../base/external-secrets
+- ../../base

--- a/components/monitoring/prometheus/production/base/kustomization.yaml
+++ b/components/monitoring/prometheus/production/base/kustomization.yaml
@@ -3,3 +3,4 @@ kind: Kustomization
 
 resources:
 - ../../base/external-secrets
+- ../../base

--- a/components/monitoring/prometheus/stagging/base/kustomization.yaml
+++ b/components/monitoring/prometheus/stagging/base/kustomization.yaml
@@ -3,3 +3,4 @@ kind: Kustomization
 
 resources:
 - ../../base/external-secrets
+- ../../base


### PR DESCRIPTION
Some of the resources were missing because the were no pointer from the overlay to the required base.