### PR TITLE
Remove duplicate crb

### DIFF
--- a/components/monitoring/prometheus/base/servicemonitors/pipeline-service.yaml
+++ b/components/monitoring/prometheus/base/servicemonitors/pipeline-service.yaml
@@ -18,16 +18,3 @@ spec:
   namespaceSelector:
     matchNames:
       - openshift-pipelines
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: prometheus-pipeline-service-exporter-reader
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: pipeline-service-exporter-reader
-subjects:
-  - kind: ServiceAccount
-    name: prometheus-k8s
-    namespace: appstudio-workload-monitoring


### PR DESCRIPTION
ClusterRoleBinding/prometheus-pipeline-service-exporter-reader is part of applications argocd/monitoring-workload-prometheus-stone-prd-rh01 and pipeline-service-stone-prd-rh01.