### PR TITLE
Create missing namespace when bootstrapping an upstream test cluster

### DIFF
--- a/hack/bootstrap-cluster.sh
+++ b/hack/bootstrap-cluster.sh
@@ -37,6 +37,7 @@ main() {
     echo "Setting Cluster Mode: ${MODE:-Upstream}"
     case $mode in
     "" | "upstream")
+        kubectl create namespace argocd-staging
         kubectl create -k $ROOT/argo-cd-apps/app-of-app-sets/staging
         # Check if we have a tekton-chains namespace, and if so, remove any explicit transparency.url setting
         # which might be left from running this script with the 'preview' flag to enable the cluster local


### PR DESCRIPTION
Current version fails to install an upstream version of the cluster because the namespace in which the application is created does not exists.