### PR TITLE
Reverting updates to managed-gitops service components to last known good version

### DIFF
--- a/components/gitops/development/kustomization.yaml
+++ b/components/gitops/development/kustomization.yaml
@@ -2,10 +2,10 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-- https://github.com/redhat-appstudio/managed-gitops/manifests/overlays/appstudio-staging-cluster?ref=491d83f7a0e67f20a872269572f9e8392452f00d
+- https://github.com/redhat-appstudio/managed-gitops/manifests/overlays/appstudio-staging-cluster?ref=bdfabd4fc106b7f25535ef3a7a800f99a8bc0233
 - ../openshift-gitops
 
 images:
   - name: \${COMMON_IMAGE}
     newName: quay.io/redhat-appstudio/gitops-service
-    newTag: 491d83f7a0e67f20a872269572f9e8392452f00d
+    newTag: bdfabd4fc106b7f25535ef3a7a800f99a8bc0233

--- a/components/gitops/production/base/kustomization.yaml
+++ b/components/gitops/production/base/kustomization.yaml
@@ -2,14 +2,14 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-- https://github.com/redhat-appstudio/managed-gitops/manifests/overlays/stonesoup-member-cluster?ref=6963dac78dbea949f9218e448c053fdde84759e5
+- https://github.com/redhat-appstudio/managed-gitops/manifests/overlays/stonesoup-member-cluster?ref=bdfabd4fc106b7f25535ef3a7a800f99a8bc0233
 - ../../openshift-gitops
 - ../../base/external-secrets
 
 images:
   - name: \${COMMON_IMAGE}
     newName: quay.io/redhat-appstudio/gitops-service
-    newTag: 6963dac78dbea949f9218e448c053fdde84759e5
+    newTag: bdfabd4fc106b7f25535ef3a7a800f99a8bc0233
 
 commonAnnotations:
   argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true

--- a/components/gitops/production/base/kustomization.yaml
+++ b/components/gitops/production/base/kustomization.yaml
@@ -9,7 +9,7 @@ resources:
 images:
   - name: \${COMMON_IMAGE}
     newName: quay.io/redhat-appstudio/gitops-service
-    newTag: bdfabd4fc106b7f25535ef3a7a800f99a8bc0233
+    newTag: 6963dac78dbea949f9218e448c053fdde84759e5
 
 commonAnnotations:
   argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true

--- a/components/gitops/staging/base/kustomization.yaml
+++ b/components/gitops/staging/base/kustomization.yaml
@@ -2,14 +2,14 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-- https://github.com/redhat-appstudio/managed-gitops/manifests/overlays/stonesoup-member-cluster?ref=6963dac78dbea949f9218e448c053fdde84759e5
+- https://github.com/redhat-appstudio/managed-gitops/manifests/overlays/stonesoup-member-cluster?ref=bdfabd4fc106b7f25535ef3a7a800f99a8bc0233
 - ../../openshift-gitops
 - ../../base/external-secrets
 
 images:
   - name: \${COMMON_IMAGE}
     newName: quay.io/redhat-appstudio/gitops-service
-    newTag: 6963dac78dbea949f9218e448c053fdde84759e5
+    newTag: bdfabd4fc106b7f25535ef3a7a800f99a8bc0233
 
 commonAnnotations:
   argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true


### PR DESCRIPTION
Reverting PR https://github.com/redhat-appstudio/infra-deployments/pull/1349 to revert managed-gitops service components in Production environment to last known good version.
**Note**: The changes are being reverted only in the Production environment so that the development and staging environment can be used for debugging the issue and finding the root cause.
