### PR TITLE
Add testing NS for pipeline-service

### DIFF
--- a/components/pipeline-service/base/testing/kustomization.yaml
+++ b/components/pipeline-service/base/testing/kustomization.yaml
@@ -2,3 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ns.yaml
+  - rbac.yaml

--- a/components/pipeline-service/base/testing/rbac.yaml
+++ b/components/pipeline-service/base/testing/rbac.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: tekton-results-tests
+  namespace: plnsvc-tests
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: tekton-results-tests
+  namespace: plnsvc-tests
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: tekton-results-readonly
+subjects:
+  - kind: ServiceAccount
+    name: tekton-results-tests
+    namespace: plnsvc-tests
+


### PR DESCRIPTION
The testing NS and its related resources are used to run pipeline-service smoke tests.