### PR TITLE
Fix logging deployment to the clusters

### DIFF
--- a/argo-cd-apps/base/member/infra-deployments/monitoring-workload-logging/monitoring-workload-logging.yaml
+++ b/argo-cd-apps/base/member/infra-deployments/monitoring-workload-logging/monitoring-workload-logging.yaml
@@ -10,19 +10,11 @@ spec:
         generators:
           - clusters:
               values:
-                sourceRoot: components/monitoring/prometheus
+                sourceRoot: components/monitoring/logging
                 environment: staging
                 clusterDir: ""
           - list:
-              elements:
-                - nameNormalized: stone-stg-m01
-                  values.clusterDir: stone-stg-m01
-                - nameNormalized: stone-stg-rh01
-                  values.clusterDir: stone-stg-rh01
-                - nameNormalized: stone-prd-m01
-                  values.clusterDir: stone-prd-m01
-                - nameNormalized: stone-prd-rh01
-                  values.clusterDir: stone-prd-rh01
+              elements: []
   template:
     metadata:
       name: monitoring-workload-logging-{{nameNormalized}}

--- a/argo-cd-apps/overlays/production/kustomization.yaml
+++ b/argo-cd-apps/overlays/production/kustomization.yaml
@@ -73,3 +73,8 @@ patches:
       kind: ApplicationSet
       version: v1alpha1
       name: image-controller
+  - path: production-overlay-patch.yaml
+    target:
+      kind: ApplicationSet
+      version: v1alpha1
+      name: monitoring-workload-logging


### PR DESCRIPTION
This PR updates the logging deployment menifests from prometheus to logging for fluentd