### PR TITLE
[WIP] Fixed prometheus secrets for servicemonitors

### DIFF
--- a/components/monitoring/prometheus/base/servicemonitors/build-service.yaml
+++ b/components/monitoring/prometheus/base/servicemonitors/build-service.yaml
@@ -13,7 +13,7 @@ spec:
     port: https
     scheme: https
     bearerTokenSecret:
-      name: "prometheus-k8s-token-xhrjb"
+      name: "dummy-token"
       key: token
     tlsConfig:
       insecureSkipVerify: true

--- a/components/monitoring/prometheus/base/servicemonitors/dora-service.yaml
+++ b/components/monitoring/prometheus/base/servicemonitors/dora-service.yaml
@@ -12,6 +12,9 @@ spec:
   - interval: 120s
     path: /metrics
     port: metrics-port
+    bearerTokenSecret:
+      name: "dummy-token"
+      key: token
     tlsConfig:
       insecureSkipVerify: true
     scrapeTimeout: 30s

--- a/components/monitoring/prometheus/base/servicemonitors/gitops-service.yaml
+++ b/components/monitoring/prometheus/base/servicemonitors/gitops-service.yaml
@@ -9,7 +9,7 @@ spec:
   endpoints:
   - bearerTokenSecret:
       key: token
-      name: prometheus-k8s-token-xhrjb
+      name: "dummy-token"
     interval: 15s
     path: /metrics
     port: metrics

--- a/components/monitoring/prometheus/base/servicemonitors/integration-service.yaml
+++ b/components/monitoring/prometheus/base/servicemonitors/integration-service.yaml
@@ -12,7 +12,7 @@ spec:
     port: https
     scheme: https
     bearerTokenSecret:
-      name: "prometheus-k8s-token-xhrjb"
+      name: "dummy-token"
       key: token
     tlsConfig:
       insecureSkipVerify: true

--- a/components/monitoring/prometheus/base/servicemonitors/jvm-build-service.yaml
+++ b/components/monitoring/prometheus/base/servicemonitors/jvm-build-service.yaml
@@ -12,6 +12,9 @@ spec:
     interval: 15s
     port: http-metrics
     scheme: http
+    bearerTokenSecret:
+      name: "dummy-token"
+      key: token
   namespaceSelector:
     matchNames:
     - jvm-build-service

--- a/components/monitoring/prometheus/base/servicemonitors/pipeline-service.yaml
+++ b/components/monitoring/prometheus/base/servicemonitors/pipeline-service.yaml
@@ -15,6 +15,9 @@ spec:
       port: metrics
       interval: 15s
       scheme: http
+      bearerTokenSecret:
+        name: "dummy-token"
+        key: token
   namespaceSelector:
     matchNames:
       - openshift-pipelines

--- a/components/monitoring/prometheus/base/servicemonitors/prometheus.yaml
+++ b/components/monitoring/prometheus/base/servicemonitors/prometheus.yaml
@@ -8,7 +8,8 @@ metadata:
 spec:
   endpoints:
   - bearerTokenSecret:
-      key: ""
+      name: "dummy-token"
+      key: ""  
     interval: 15s
     path: /metrics
     port: oauth2-proxy

--- a/components/monitoring/prometheus/base/servicemonitors/release-service.yaml
+++ b/components/monitoring/prometheus/base/servicemonitors/release-service.yaml
@@ -12,7 +12,7 @@ spec:
     port: https
     scheme: https
     bearerTokenSecret:
-      name: "prometheus-k8s-token-xhrjb"
+      name: "dummy-token"
       key: token
     tlsConfig:
       insecureSkipVerify: true

--- a/components/monitoring/prometheus/base/servicemonitors/sandbox-host-operator.yaml
+++ b/components/monitoring/prometheus/base/servicemonitors/sandbox-host-operator.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   endpoints:
   - bearerTokenSecret:
-      name: "prometheus-k8s-token-xhrjb"
+      name: "dummy-token"
       key: token
     interval: 15s
     scheme: https

--- a/components/monitoring/prometheus/base/servicemonitors/sandbox-member-operator.yaml
+++ b/components/monitoring/prometheus/base/servicemonitors/sandbox-member-operator.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   endpoints:
   - bearerTokenSecret:
-      name: "prometheus-k8s-token-xhrjb"
+      name: "dummy-token"
       key: token
     interval: 15s
     scheme: https

--- a/components/monitoring/prometheus/base/servicemonitors/spi-operator.yaml
+++ b/components/monitoring/prometheus/base/servicemonitors/spi-operator.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   endpoints:
   - bearerTokenSecret:
-      name: "prometheus-k8s-token-xhrjb"
+      name: "dummy-token"
       key: token
     scheme: https
     tlsConfig:

--- a/components/monitoring/prometheus/production/stone-prd-m01/kustomization.yaml
+++ b/components/monitoring/prometheus/production/stone-prd-m01/kustomization.yaml
@@ -9,3 +9,10 @@ patches:
       group: external-secrets.io
       version: v1beta1
       kind: ExternalSecret
+  - path: monitoring-prometheus-sm-secret-path.yaml
+    target:
+      group: monitoring.coreos.com
+      version: v1
+      kind: ServiceMonitor
+      labelSelector: prometheus=appstudio-workload
+

--- a/components/monitoring/prometheus/production/stone-prd-m01/monitoring-prometheus-sm-secret-path.yaml
+++ b/components/monitoring/prometheus/production/stone-prd-m01/monitoring-prometheus-sm-secret-path.yaml
@@ -1,0 +1,4 @@
+---
+- op: replace
+  path: /spec/endpoints/0/bearerTokenSecret/name
+  value: "prometheus-k8s-token-rwrnv"

--- a/components/monitoring/prometheus/production/stone-prd-rh01/kustomization.yaml
+++ b/components/monitoring/prometheus/production/stone-prd-rh01/kustomization.yaml
@@ -9,3 +9,9 @@ patches:
       group: external-secrets.io
       version: v1beta1
       kind: ExternalSecret
+  - path: monitoring-prometheus-sm-secret-path.yaml
+    target:
+      group: monitoring.coreos.com
+      version: v1
+      kind: ServiceMonitor
+      labelSelector: prometheus=appstudio-workload

--- a/components/monitoring/prometheus/production/stone-prd-rh01/monitoring-prometheus-sm-secret-path.yaml
+++ b/components/monitoring/prometheus/production/stone-prd-rh01/monitoring-prometheus-sm-secret-path.yaml
@@ -1,0 +1,4 @@
+---
+- op: replace
+  path: /spec/endpoints/0/bearerTokenSecret/name
+  value: "prometheus-k8s-token-pqhwk"


### PR DESCRIPTION
This PR
* stream lines all the servicemonitors to use the similar authentication for scraping
* adds the token secret as patch