### PR TITLE
Skip step_image_registries in the minimal ECP

### DIFF
--- a/components/enterprise-contract/ecp.yaml
+++ b/components/enterprise-contract/ecp.yaml
@@ -11,6 +11,9 @@ spec:
   configuration:
     collections:
       - minimal
+    exclude:
+      # This can be removed once https://issues.redhat.com/browse/OCPBUGS-8428 is addressed
+      - step_image_registries
   publicKey: k8s://tekton-chains/public-key
   sources:
     - name: Release Policies


### PR DESCRIPTION
Due to https://issues.redhat.com/browse/OCPBUGS-8428, this rule may cause unnecessary violations.