### PR TITLE
add log retention for new log groups

### DIFF
--- a/components/monitoring/logging/base/configure-logging/configure-logforwarder.yaml
+++ b/components/monitoring/logging/base/configure-logging/configure-logforwarder.yaml
@@ -10,6 +10,7 @@ spec:
     - cloudwatch:
         groupBy: namespaceName
         region: us-east-1
+        retention_in_days: 180
       name: remote-cloudwatch
       secret:
         name: cloudwatch-forwarder


### PR DESCRIPTION
We need to get fluentd to set the log retention period for us.  Otherwise, every time we get a new tenant, its logs have a retention period of "forever".
Docs: https://banzaicloud.com/docs/one-eye/logging-operator/plugins/outputs/cloudwatch/ 
How it's done manually: https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/Working-with-log-groups-and-streams.html#SettingLogRetention
Terraform example: https://docs.bridgecrew.io/docs/logging_13 
I couldn't find a Kustomize example other than the one from Banzai.
