### PR TITLE
Added grafana oauth2-proxy secret from vault

### DIFF
--- a/components/monitoring/grafana/base/external-secrets/kustomization.yaml
+++ b/components/monitoring/grafana/base/external-secrets/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- monitoring-grafana-oauth-config.yaml
+namespace: appstudio-workload-monitoring

--- a/components/monitoring/grafana/base/external-secrets/monitoring-grafana-oauth-config.yaml
+++ b/components/monitoring/grafana/base/external-secrets/monitoring-grafana-oauth-config.yaml
@@ -1,0 +1,20 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: monitoring-grafana-oauth-config
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  dataFrom:
+  - extract:
+      key: "" # will be added by the overlays
+      decodingStrategy: Base64
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: appsre-stonesoup-vault
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    name: grafana-oauth2-proxy

--- a/components/monitoring/grafana/production/kustomization.yaml
+++ b/components/monitoring/grafana/production/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../base/external-secrets
+- ../base
+patches:
+  - path: monitoring-grafana-oauth-config-path.yaml
+    target:
+      name: monitoring-grafana-oauth-config
+      group: external-secrets.io
+      version: v1beta1
+      kind: ExternalSecret

--- a/components/monitoring/grafana/production/monitoring-grafana-oauth-config-path.yaml
+++ b/components/monitoring/grafana/production/monitoring-grafana-oauth-config-path.yaml
@@ -1,0 +1,4 @@
+---
+- op: add
+  path: /spec/dataFrom/0/extract/key
+  value: production/monitoring/prd-m01/grafana/grafana-oauth2-proxy

--- a/components/monitoring/grafana/staging/kustomization.yaml
+++ b/components/monitoring/grafana/staging/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../base/external-secrets
+- ../base
+patches:
+  - path: monitoring-grafana-oauth-config-path.yaml
+    target:
+      name: monitoring-grafana-oauth-config
+      group: external-secrets.io
+      version: v1beta1
+      kind: ExternalSecret

--- a/components/monitoring/grafana/staging/monitoring-grafana-oauth-config-path.yaml
+++ b/components/monitoring/grafana/staging/monitoring-grafana-oauth-config-path.yaml
@@ -1,0 +1,4 @@
+---
+- op: add
+  path: /spec/dataFrom/0/extract/key
+  value: staging/monitoring/grafana/grafana-oauth2-proxy


### PR DESCRIPTION
We should have access to one grafana (connected to all the prometheus and logging) per env