### PR TITLE
Remove cluster dir from o11y overlay path

### DIFF
--- a/argo-cd-apps/base/member/infra-deployments/o11y/o11y.yaml
+++ b/argo-cd-apps/base/member/infra-deployments/o11y/o11y.yaml
@@ -12,7 +12,7 @@ spec:
               values:
                 sourceRoot: components/o11y
                 environment: staging
-                clusterDir: base
+                clusterDir: ""
           - list:
               elements: []
   template:


### PR DESCRIPTION
The o11y component doesn't have any cluster specific overlay.