### PR TITLE
Removed ArgoCD pointers for appstudio custom prometheus

### DIFF
--- a/argo-cd-apps/base/member/infra-deployments/kustomization.yaml
+++ b/argo-cd-apps/base/member/infra-deployments/kustomization.yaml
@@ -18,7 +18,7 @@ resources:
   - build-templates
   - shared-resources
   - internal-services
-  - monitoring-workload-prometheus
+  #- monitoring-workload-prometheus
   - monitoring-workload-grafana
   - monitoring-workload-logging
   - external-secrets-operator

--- a/argo-cd-apps/base/member/infra-deployments/kustomization.yaml
+++ b/argo-cd-apps/base/member/infra-deployments/kustomization.yaml
@@ -18,7 +18,6 @@ resources:
   - build-templates
   - shared-resources
   - internal-services
-  #- monitoring-workload-prometheus
   - monitoring-workload-grafana
   - monitoring-workload-logging
   - external-secrets-operator

--- a/argo-cd-apps/overlays/development/delete-applications.yaml
+++ b/argo-cd-apps/overlays/development/delete-applications.yaml
@@ -16,12 +16,12 @@ kind: ApplicationSet
 metadata:
   name: hac-pact-broker
 $patch: delete
----
-apiVersion: argoproj.io/v1alpha1
-kind: ApplicationSet
-metadata:
-  name: monitoring-workload-prometheus
-$patch: delete
+#---
+#apiVersion: argoproj.io/v1alpha1
+#kind: ApplicationSet
+#metadata:
+#  name: monitoring-workload-prometheus
+#$patch: delete
 ---
 apiVersion: argoproj.io/v1alpha1
 kind: ApplicationSet

--- a/argo-cd-apps/overlays/development/delete-applications.yaml
+++ b/argo-cd-apps/overlays/development/delete-applications.yaml
@@ -16,12 +16,6 @@ kind: ApplicationSet
 metadata:
   name: hac-pact-broker
 $patch: delete
-#---
-#apiVersion: argoproj.io/v1alpha1
-#kind: ApplicationSet
-#metadata:
-#  name: monitoring-workload-prometheus
-#$patch: delete
 ---
 apiVersion: argoproj.io/v1alpha1
 kind: ApplicationSet

--- a/argo-cd-apps/overlays/production/kustomization.yaml
+++ b/argo-cd-apps/overlays/production/kustomization.yaml
@@ -58,11 +58,11 @@ patches:
       kind: ApplicationSet
       version: v1alpha1
       name: sprayproxy
-  - path: production-overlay-patch.yaml
-    target:
-      kind: ApplicationSet
-      version: v1alpha1
-      name: monitoring-workload-prometheus
+#  - path: production-overlay-patch.yaml
+#    target:
+#      kind: ApplicationSet
+#      version: v1alpha1
+#      name: monitoring-workload-prometheus
   - path: production-overlay-patch.yaml
     target:
       kind: ApplicationSet

--- a/argo-cd-apps/overlays/production/kustomization.yaml
+++ b/argo-cd-apps/overlays/production/kustomization.yaml
@@ -58,11 +58,6 @@ patches:
       kind: ApplicationSet
       version: v1alpha1
       name: sprayproxy
-#  - path: production-overlay-patch.yaml
-#    target:
-#      kind: ApplicationSet
-#      version: v1alpha1
-#      name: monitoring-workload-prometheus
   - path: production-overlay-patch.yaml
     target:
       kind: ApplicationSet


### PR DESCRIPTION
This PR disables stonesoup custom promethues in favour of enabling UWM through OCM