### PR TITLE
Update image registry link

### DIFF
--- a/hack/quicklab/templates/deployment.yaml
+++ b/hack/quicklab/templates/deployment.yaml
@@ -21,7 +21,7 @@ spec:
       serviceAccountName: nfs-client-provisioner
       containers:
         - name: nfs-client-provisioner
-          image: k8s.gcr.io/sig-storage/nfs-subdir-external-provisioner:v4.0.2
+          image: registry.k8s.io/sig-storage/nfs-subdir-external-provisioner:v4.0.2
           volumeMounts:
             - name: nfs-client-root
               mountPath: /persistentvolumes


### PR DESCRIPTION
registry.k8s.io replaces k8s.gcr.io. Announcement: https://kubernetes.io/blog/2023/03/10/image-registry-redirect/