### PR TITLE
Set application name for PaC

### DIFF
--- a/components/pipeline-service/production/base/kustomization.yaml
+++ b/components/pipeline-service/production/base/kustomization.yaml
@@ -22,3 +22,8 @@ patches:
       group: external-secrets.io
       version: v1beta1
       kind: ExternalSecret
+  - path: pac-app-name.yaml
+    target:
+      kind: ConfigMap
+      name: pipelines-as-code
+      namespace: pipelines-as-code

--- a/components/pipeline-service/production/base/pac-app-name.yaml
+++ b/components/pipeline-service/production/base/pac-app-name.yaml
@@ -1,0 +1,4 @@
+---
+- op: replace
+  path: /data/application-name
+  value: Red Hat Trusted App Pipeline

--- a/components/pipeline-service/staging/base/kustomization.yaml
+++ b/components/pipeline-service/staging/base/kustomization.yaml
@@ -14,3 +14,10 @@ resources:
 
 components:
   - ../../components/tekton-chains
+
+patches:
+  - path: pac-app-name.yaml
+    target:
+      kind: ConfigMap
+      name: pipelines-as-code
+      namespace: pipelines-as-code

--- a/components/pipeline-service/staging/base/pac-app-name.yaml
+++ b/components/pipeline-service/staging/base/pac-app-name.yaml
@@ -1,0 +1,4 @@
+---
+- op: replace
+  path: /data/application-name
+  value: RHTAP Staging


### PR DESCRIPTION
Update the name developers see when Pipelines as Code sends Checks API results back.

Production: "Red Hat Trusted App Pipeline"
Staging: "RHTAP Staging"