### PR TITLE
Remove unused imagestream

### DIFF
--- a/components/hac-pact-broker/imagestream.yaml
+++ b/components/hac-pact-broker/imagestream.yaml
@@ -1,6 +1,0 @@
-apiVersion: image.openshift.io/v1
-kind: ImageStream
-metadata:
-  labels:
-    app: pact-broker
-  name: pact-broker


### PR DESCRIPTION
Remove `imagestream` resource from pact-broker. It's not used for our deployments.