### PR TITLE
fix: remove dead references in monitoring overlays

### DIFF
--- a/components/monitoring/prometheus/production/base/kustomization.yaml
+++ b/components/monitoring/prometheus/production/base/kustomization.yaml
@@ -2,5 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-- ../../base/external-secrets
 - ../../base

--- a/components/monitoring/prometheus/staging/base/kustomization.yaml
+++ b/components/monitoring/prometheus/staging/base/kustomization.yaml
@@ -2,5 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-- ../../base/external-secrets
 - ../../base


### PR DESCRIPTION
A number of monitoring-related yaml files were removed on a previous commit, but were still being referenced elsewhere. This commit removes those references.