### PR TITLE
Remove imagestream from kustomization.

### DIFF
--- a/components/hac-pact-broker/kustomization.yaml
+++ b/components/hac-pact-broker/kustomization.yaml
@@ -1,5 +1,4 @@
 resources:
-  - imagestream.yaml
   - pactbroker.yaml
   - postgre.yaml
   - postgrepvc.yaml


### PR DESCRIPTION
Remove imagestream from kustomization to fix Pact broker deployment.