### PR TITLE
add neccessary SpaceRequst permissions to sandbox-sre admins

### DIFF
--- a/components/authentication/base/sandbox-sre-admins.yaml
+++ b/components/authentication/base/sandbox-sre-admins.yaml
@@ -11,6 +11,20 @@ rules:
   - "users"
   verbs:
   - "impersonate"
+- apiGroups:
+  - "toolchain.dev.openshift.com"
+  resources:
+  - "spacerequests/finalizers"
+  verbs:
+  - "update"
+- apiGroups:
+  - "toolchain.dev.openshift.com"
+  resources:
+  - "spacerequests/status"
+  verbs:
+  - "get"
+  - "patch"
+  - "update"
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
add necessary SpaceRequst permissions to sandbox-sre admins to be able to configure SA that updates SpaceRequest sub-resources
cc @mfrancisc 