### PR TITLE
chore(RHTAP-687): Don't prune local cluster secret

### DIFF
--- a/argo-cd-apps/base/local-cluster-secret/host-on-local-cluster/kustomization.yaml
+++ b/argo-cd-apps/base/local-cluster-secret/host-on-local-cluster/kustomization.yaml
@@ -5,3 +5,5 @@ resources:
   - ../base
 components:
   - ../../../k-components/assign-host-role-to-local-cluster
+commonAnnotations:
+  argocd.argoproj.io/sync-options: Prune=false


### PR DESCRIPTION
As part of [RHTAP-687](https://issues.redhat.com//browse/RHTAP-687), ArgoCD is migrated to a dedicated cluster that isn't going to run any host applications. For allowing the migration we need to delete the local-cluster secret, but while the migration is on going, we need to keep the current ArgoCD instance working.