### PR TITLE
Add scheme to endpoint value of s3 secret

### DIFF
--- a/components/pipeline-service/base/external-secrets/tekton-results/tekton-results-s3.yaml
+++ b/components/pipeline-service/base/external-secrets/tekton-results/tekton-results-s3.yaml
@@ -17,3 +17,10 @@ spec:
     creationPolicy: Owner
     deletionPolicy: Delete
     name: tekton-results-s3
+    template:
+      data:
+        aws_access_key_id: "{{ .aws_access_key_id }}"
+        aws_secret_access_key: "{{ .aws_secret_access_key }}"
+        aws_region: "{{ .aws_region }}"
+        bucket: "{{ .bucket }}"
+        endpoint: "https://{{ .endpoint }}"


### PR DESCRIPTION
The value of the s3 endpoint in tekton-results-s3 secret is missing the
URL scheme (host copied as it is from Vault) this makes connections from
tekton-results fail. This patch adds the "https://" scheme