### PR TITLE
chore(RHTAP-687): Disable autosync on staging

### DIFF
--- a/argo-cd-apps/k-components/disable-auto-sync/disable-auto-sync.yaml
+++ b/argo-cd-apps/k-components/disable-auto-sync/disable-auto-sync.yaml
@@ -1,0 +1,3 @@
+---
+- op: remove
+  path: /spec/template/spec/syncPolicy/automated

--- a/argo-cd-apps/k-components/disable-auto-sync/kustomization.yaml
+++ b/argo-cd-apps/k-components/disable-auto-sync/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+patches:
+  - path: disable-auto-sync.yaml
+    target:
+      group: argoproj.io
+      version: v1alpha1
+      kind: ApplicationSet

--- a/argo-cd-apps/overlays/staging/kustomization.yaml
+++ b/argo-cd-apps/overlays/staging/kustomization.yaml
@@ -5,3 +5,5 @@ resources:
   - ../../base/member
   - ../../base/all-clusters
   - ../../base/quality-dashboard
+components:
+  - ../../k-components/disable-auto-sync


### PR DESCRIPTION
As part of the migration of ArgoCD to a new cluster, disable autosync.