### PR TITLE
chore(RHTAP-687): Disable autosync on production

### DIFF
--- a/argo-cd-apps/overlays/production/kustomization.yaml
+++ b/argo-cd-apps/overlays/production/kustomization.yaml
@@ -83,3 +83,5 @@ patches:
       kind: ApplicationSet
       version: v1alpha1
       name: monitoring-workload-prometheus
+components:
+  - ../../k-components/disable-auto-sync


### PR DESCRIPTION
Need to migrate the ArgoCD instance to a new cluster.