### PR TITLE
Add Results ServiceMonitor to pipeline-service

### DIFF
--- a/components/pipeline-service/base/servicemonitors/kustomization.yaml
+++ b/components/pipeline-service/base/servicemonitors/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - tekton-results-service-monitor.yaml

--- a/components/pipeline-service/base/servicemonitors/tekton-results-service-monitor.yaml
+++ b/components/pipeline-service/base/servicemonitors/tekton-results-service-monitor.yaml
@@ -1,0 +1,75 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: metrics-reader
+  namespace: tekton-results
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: metrics-reader
+  namespace: tekton-results
+  annotations:
+    kubernetes.io/service-account.name: metrics-reader
+type: kubernetes.io/service-account-token
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: tekton-results-service-metrics-reader
+rules:
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: prometheus-tekton-results-service-metrics-reader
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: tekton-results-service-metrics-reader
+subjects:
+- kind: ServiceAccount
+  name: metrics-reader
+  namespace: tekton-results
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: tekton-results-api
+  namespace: tekton-results
+spec:
+  endpoints:
+  - path: /metrics
+    port: prometheus
+    scheme: https
+    bearerTokenSecret:
+      name: "metrics-reader"
+      key: token
+    tlsConfig:
+      insecureSkipVerify: true
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: tekton-results-api
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: tekton-results-watcher
+  namespace: tekton-results
+spec:
+  endpoints:
+  - path: /metrics
+    port: metrics
+    scheme: https
+    bearerTokenSecret:
+      name: "metrics-reader"
+      key: token
+    tlsConfig:
+      insecureSkipVerify: true
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: tekton-results-watcher

--- a/components/pipeline-service/development/kustomization.yaml
+++ b/components/pipeline-service/development/kustomization.yaml
@@ -10,6 +10,7 @@ commonAnnotations:
 resources:
   - git::https://github.com/openshift-pipelines/pipeline-service.git/developer/openshift/gitops/argocd/pipeline-service?ref=303c19d55e2ae90f737ce3a245755eff34684099
   - git::https://github.com/openshift-pipelines/pipeline-service.git/developer/openshift/gitops/argocd/pipeline-service-storage?ref=303c19d55e2ae90f737ce3a245755eff34684099
+  - ../base/servicemonitors
 
 patches:
   - path: scale-down-exporter.yaml

--- a/components/pipeline-service/staging/base/kustomization.yaml
+++ b/components/pipeline-service/staging/base/kustomization.yaml
@@ -11,6 +11,7 @@ resources:
   - git::https://github.com/openshift-pipelines/pipeline-service.git/operator/gitops/argocd/pipeline-service?ref=303c19d55e2ae90f737ce3a245755eff34684099
   - ../../base/external-secrets
   - ../../base/testing
+  - ../../base/servicemonitors
 
 patches:
   - path: pac-app-name.yaml


### PR DESCRIPTION
Adds two service monitors to pipeline-service for Tekton Results api and watcher.