### PR TITLE
chore(RHTAP-687): Remove local cluster secret from prod

### DIFF
--- a/argo-cd-apps/overlays/production/kustomization.yaml
+++ b/argo-cd-apps/overlays/production/kustomization.yaml
@@ -1,7 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ../../base/local-cluster-secret/host-on-local-cluster
   - ../../base/host
   - ../../base/member
   - ../../base/all-clusters


### PR DESCRIPTION
Since ArgoCD isn't going to deploy any application on the control plane cluster, there is no need for the local secret.