### PR TITLE
chore(RHTAP-687): Enable autosync on production

### DIFF
--- a/argo-cd-apps/overlays/production/kustomization.yaml
+++ b/argo-cd-apps/overlays/production/kustomization.yaml
@@ -82,5 +82,3 @@ patches:
       kind: ApplicationSet
       version: v1alpha1
       name: monitoring-workload-prometheus
-components:
-  - ../../k-components/disable-auto-sync


### PR DESCRIPTION
The migration of ArgoCD to a new cluster was completed.