### PR TITLE
Remove ArgoCD finalizer from app-of-appsets

### DIFF
--- a/argo-cd-apps/app-of-app-sets/base/all-application-sets.yaml
+++ b/argo-cd-apps/app-of-app-sets/base/all-application-sets.yaml
@@ -2,8 +2,6 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: all-application-sets
-  finalizers:
-    - resources-finalizer.argocd.argoproj.io
 spec:
   project: default
   source:


### PR DESCRIPTION
To be on the safe side, avoid accidental deletion of all the application sets when the root app is removed.