### PR TITLE
Revert Pipeline Service Update #1592

### DIFF
--- a/components/enterprise-contract/ecp.yaml
+++ b/components/enterprise-contract/ecp.yaml
@@ -18,9 +18,9 @@ spec:
   sources:
     - name: Release Policies
       data:
-        - oci::quay.io/hacbs-contract/ec-policy-data:git-d995f67@sha256:eb713f2c0d9c944cbbb298a2c8a0ca1e5a741d149f033b145296d6f550ebd10b
+        - oci::quay.io/hacbs-contract/ec-policy-data:git-bca7d72@sha256:be3aa728acc3d8ae602e8c57e9cb3fece050bd120f17bde9de3225294a7f7c99
       policy:
-        - oci::quay.io/hacbs-contract/ec-release-policy:git-d995f67@sha256:9d2cffae5ed8a541b4bff1acbaa9bb0b42290214de969e515e78f97b8cf8ff51
+        - oci::quay.io/hacbs-contract/ec-release-policy:git-76b0b9d@sha256:4c49ed849a3d979fe4f4c7cf8d2b3fc64a476836a05b2ee91441861a8eca3c5f
 ---
 apiVersion: appstudio.redhat.com/v1alpha1
 kind: EnterpriseContractPolicy
@@ -37,6 +37,6 @@ spec:
   sources:
     - name: Release Policies
       data:
-        - oci::quay.io/hacbs-contract/ec-policy-data:git-d995f67@sha256:eb713f2c0d9c944cbbb298a2c8a0ca1e5a741d149f033b145296d6f550ebd10b
+        - oci::quay.io/hacbs-contract/ec-policy-data:git-bca7d72@sha256:be3aa728acc3d8ae602e8c57e9cb3fece050bd120f17bde9de3225294a7f7c99
       policy:
-        - oci::quay.io/hacbs-contract/ec-release-policy:git-d995f67@sha256:9d2cffae5ed8a541b4bff1acbaa9bb0b42290214de969e515e78f97b8cf8ff51
+        - oci::quay.io/hacbs-contract/ec-release-policy:git-76b0b9d@sha256:4c49ed849a3d979fe4f4c7cf8d2b3fc64a476836a05b2ee91441861a8eca3c5f

--- a/components/enterprise-contract/kustomization.yaml
+++ b/components/enterprise-contract/kustomization.yaml
@@ -1,13 +1,13 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - https://github.com/enterprise-contract/enterprise-contract-controller/config/crd?ref=2844b6da6e72a6b25f6b2ed3702c6fda8a88adc9
+  - https://github.com/enterprise-contract/enterprise-contract-controller/config/crd?ref=a44c4f60da41e15f8a78a58205eae6dda1c109c8
   # Kustomize does not allow github.com urls that reference a single-file. They must always reference
   # a directory that contains a kustomization.yaml file. The directory /config/rbac does include a
   # kustomization.yaml file but it includes many other RBAC changes that are not desirable here. Use
   # a URL to the "raw" version of the file instead.
-  - https://raw.githubusercontent.com/enterprise-contract/enterprise-contract-controller/2844b6da6e72a6b25f6b2ed3702c6fda8a88adc9/config/rbac/enterprisecontractpolicy_viewer_role.yaml
-  - https://raw.githubusercontent.com/enterprise-contract/enterprise-contract-controller/2844b6da6e72a6b25f6b2ed3702c6fda8a88adc9/config/rbac/enterprisecontractpolicy_editor_role.yaml
+  - https://raw.githubusercontent.com/enterprise-contract/enterprise-contract-controller/a44c4f60da41e15f8a78a58205eae6dda1c109c8/config/rbac/enterprisecontractpolicy_viewer_role.yaml
+  - https://raw.githubusercontent.com/enterprise-contract/enterprise-contract-controller/a44c4f60da41e15f8a78a58205eae6dda1c109c8/config/rbac/enterprisecontractpolicy_editor_role.yaml
   - ecp.yaml
   - role.yaml
   - rolebinding.yaml
@@ -17,10 +17,10 @@ configMapGenerator:
   - name: ec-defaults
     namespace: enterprise-contract-service
     literals:
-      - verify_ec_task_bundle=quay.io/hacbs-contract/ec-task-bundle:f1d0eb8927f50ed285f6d517e48935dd9bb3e093@sha256:4116bec9c813d9d3b59c6488d5b0dc2a3d3cd57c8c329283c4313911e6d122ec
+      - verify_ec_task_bundle=quay.io/hacbs-contract/ec-task-bundle:e18a97905c6a9e9f96ce39575062084e2c57ea45@sha256:64cf61db656fc8b49e9d5ef966a672a943db47f27c9531deacc9ffe2b5e581b7
       - ec_policy_source=oci::https://quay.io/hacbs-contract/ec-release-policy:git-8ca675b@sha256:caf2a8991ca3feb80edfc8ff7c1930ed09481a7c8d934bb719007bffc1153ecc
       - ec_data_source=oci::https://quay.io/hacbs-contract/ec-policy-data:git-a3ca9be@sha256:d548e0808348c017782ae87920c94d45ad7117e0e630b5b991c8df557c22a844
 images:
   - name: quay.io/redhat-appstudio/enterprise-contract-controller
     newName: quay.io/redhat-appstudio/enterprise-contract-controller
-    newTag: 5befd172d5589ca2799ba60683e0879f972dd831
+    newTag: a44c4f60da41e15f8a78a58205eae6dda1c109c8

--- a/components/pipeline-service/development/kustomization.yaml
+++ b/components/pipeline-service/development/kustomization.yaml
@@ -8,8 +8,8 @@ commonAnnotations:
   argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 
 resources:
-  - git::https://github.com/openshift-pipelines/pipeline-service.git/developer/openshift/gitops/argocd/pipeline-service?ref=c145a6af3eac31e267846450edc97c8553a04b83
-  - git::https://github.com/openshift-pipelines/pipeline-service.git/developer/openshift/gitops/argocd/pipeline-service-storage?ref=c145a6af3eac31e267846450edc97c8553a04b83
+  - git::https://github.com/openshift-pipelines/pipeline-service.git/developer/openshift/gitops/argocd/pipeline-service?ref=8f3ebf86101a4cf21fe7e86335e85a3fb6e3671f
+  - git::https://github.com/openshift-pipelines/pipeline-service.git/developer/openshift/gitops/argocd/pipeline-service-storage?ref=8f3ebf86101a4cf21fe7e86335e85a3fb6e3671f
 
 components:
   - ../components/tekton-chains

--- a/components/pipeline-service/production/base/kustomization.yaml
+++ b/components/pipeline-service/production/base/kustomization.yaml
@@ -8,7 +8,7 @@ commonAnnotations:
   argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 
 resources:
-  - git::https://github.com/openshift-pipelines/pipeline-service.git/operator/gitops/argocd/pipeline-service?ref=c145a6af3eac31e267846450edc97c8553a04b83
+  - git::https://github.com/openshift-pipelines/pipeline-service.git/operator/gitops/argocd/pipeline-service?ref=8f3ebf86101a4cf21fe7e86335e85a3fb6e3671f
   - ../../base/external-secrets
   - ../../base/testing
 

--- a/components/pipeline-service/staging/base/kustomization.yaml
+++ b/components/pipeline-service/staging/base/kustomization.yaml
@@ -8,7 +8,7 @@ commonAnnotations:
   argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 
 resources:
-  - git::https://github.com/openshift-pipelines/pipeline-service.git/operator/gitops/argocd/pipeline-service?ref=c145a6af3eac31e267846450edc97c8553a04b83
+  - git::https://github.com/openshift-pipelines/pipeline-service.git/operator/gitops/argocd/pipeline-service?ref=8f3ebf86101a4cf21fe7e86335e85a3fb6e3671f
   - ../../base/external-secrets
   - ../../base/testing
 


### PR DESCRIPTION
This reverts commit 8de070405118b3b984fa00aa06b2ff689923b075. This change has caused the Results apiserver to crashloop due to failed database automigrations.

Incident: https://issues.redhat.com/browse/PLNSRVCE-1262