### PR TITLE
delete vault approle secrets on staging

### DIFF
--- a/components/spi/overlays/staging/base/delete-vault-approle-secrets.yaml
+++ b/components/spi/overlays/staging/base/delete-vault-approle-secrets.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+kind: ExternalSecret
+metadata:
+  name: spi-vault-approle-spi-oauth
+$patch: delete
+---
+apiVersion: v1
+kind: ExternalSecret
+metadata:
+  name: spi-vault-approle-spi-operator
+$patch: delete

--- a/components/spi/overlays/staging/base/kustomization.yaml
+++ b/components/spi/overlays/staging/base/kustomization.yaml
@@ -22,3 +22,4 @@ patches:
       name: spi-controller-manager
     path: operator-limits-patch.json
   - path: delete-shared-configuration-file.yaml
+  - path: delete-vault-approle-secrets.yaml


### PR DESCRIPTION
https://issues.redhat.com/browse/SVPI-439

we no longer use vault on staging. we need to delete the external secrets (leftover from https://github.com/redhat-appstudio/infra-deployments/pull/1632)