### PR TITLE
Fix AWS Secret manager prefix

### DIFF
--- a/components/spi/overlays/production/stone-prd-m01/config-patch.json
+++ b/components/spi/overlays/production/stone-prd-m01/config-patch.json
@@ -12,6 +12,6 @@
   {
     "op": "add",
     "path": "/data/SPIINSTANCEID",
-    "value": "prd-m01"
+    "value": "spi-prod/m01"
   }
 ]

--- a/components/spi/overlays/production/stone-prd-rh01/config-patch.json
+++ b/components/spi/overlays/production/stone-prd-rh01/config-patch.json
@@ -12,6 +12,6 @@
   {
     "op": "add",
     "path": "/data/SPIINSTANCEID",
-    "value": "prd-rh01"
+    "value": "spi-prod/rh01"
   }
 ]


### PR DESCRIPTION
Sync AWS Secret prefix with stonesoup-infra-prod-s01ue1.yml