### PR TITLE
PLNSRVCE-1281: Update sprayproxy component for staging kustomize overlay

### DIFF
--- a/components/sprayproxy/base/kustomization.yaml
+++ b/components/sprayproxy/base/kustomization.yaml
@@ -1,12 +1,4 @@
-resources:
-  - https://github.com/redhat-appstudio/sprayproxy/config?ref=b488cf7dada7cdf4767fd32f041c6ea3507f0043
-
-namespace: sprayproxy
-
-images:
-  - name: ko://github.com/redhat-appstudio/sprayproxy
-    newName: quay.io/redhat-appstudio/sprayproxy
-    newTag: b488cf7dada7cdf4767fd32f041c6ea3507f0043
-
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+
+namespace: sprayproxy

--- a/components/sprayproxy/production/kustomization.yaml
+++ b/components/sprayproxy/production/kustomization.yaml
@@ -1,7 +1,13 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ../base
+  - https://github.com/redhat-appstudio/sprayproxy/config?ref=b488cf7dada7cdf4767fd32f041c6ea3507f0043
+
+images:
+  - name: ko://github.com/redhat-appstudio/sprayproxy
+    newName: quay.io/redhat-appstudio/sprayproxy
+    newTag: b488cf7dada7cdf4767fd32f041c6ea3507f0043
+
 patches:
   - path: add-backends.yml
     target:

--- a/components/sprayproxy/staging/kustomization.yaml
+++ b/components/sprayproxy/staging/kustomization.yaml
@@ -1,7 +1,13 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ../base
+  - https://github.com/redhat-appstudio/sprayproxy/config?ref=e7703f63751ee924dcbfcd081e3bc90d4d284961
+
+images:
+  - name: ko://github.com/redhat-appstudio/sprayproxy
+    newName: quay.io/redhat-appstudio/sprayproxy
+    newTag: e7703f63751ee924dcbfcd081e3bc90d4d284961
+
 patches:
   - path: add-backends.yml
     target:


### PR DESCRIPTION
### Update staging sprayproxy component.

- Update sprayproxy deployment link and image, but only for staging kustomize overlay.
-- Deployment should be updated to include harden sprayproxy api route fix.
-- Image should be updated to include improvement: log forwarding requests.
- Moved base spraypoxy url to the overlay kustomization.yaml to provide opportunity apply deployment changes only for staging vs. production.