### PR TITLE
plnsvc: update path of vault credentials for s3 in staging

### DIFF
--- a/components/pipeline-service/staging/stone-stg-m01/tekton-results-s3-secret-path.yaml
+++ b/components/pipeline-service/staging/stone-stg-m01/tekton-results-s3-secret-path.yaml
@@ -1,4 +1,4 @@
 ---
 - op: add
   path: /spec/dataFrom/0/extract/key
-  value: integrations-output/terraform-resources/app-sre-stage-01/stonesoup-infra-stage/multi-tenant-staging-plnsvc-s3
+  value: integrations-output/terraform-resources/app-sre-stage-01/stonesoup-infra-stage/multi-tenant-stg-plnsvc-s3

--- a/components/pipeline-service/staging/stone-stg-rh01/tekton-results-s3-secret-path.yaml
+++ b/components/pipeline-service/staging/stone-stg-rh01/tekton-results-s3-secret-path.yaml
@@ -1,4 +1,4 @@
 ---
 - op: add
   path: /spec/dataFrom/0/extract/key
-  value: integrations-output/terraform-resources/app-sre-stage-01/stonesoup-infra-stage/redhat-staging-plnsvc-s3
+  value: integrations-output/terraform-resources/app-sre-stage-01/stonesoup-infra-stage/redhat-stg-plnsvc-s3


### PR DESCRIPTION
s3 buckets for staging  were created with `stg` in the bucket's name instead of `stage` because the latter conflicts with s3 buckets of old staging still not deleted from AWS.
Vault path for corresponding secrets was updated accordingly 