### PR TITLE
feat(STONEO11Y-163): Grafana dashboards

### DIFF
--- a/argo-cd-apps/overlays/development/kustomization.yaml
+++ b/argo-cd-apps/overlays/development/kustomization.yaml
@@ -70,4 +70,4 @@ patches:
     target:
       kind: ApplicationSet
       version: v1alpha1
-      name: grafana
+      name: monitoring-workload-grafana

--- a/components/monitoring/grafana/base/build-service/dashboard.yaml
+++ b/components/monitoring/grafana/base/build-service/dashboard.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: integreatly.org/v1alpha1
+kind: GrafanaDashboard
+metadata:
+  name: grafana-dashboard-initial-build-pipeline
+  labels: 
+    app: appstudio-grafana
+spec:
+  configMapRef:
+    name: grafana-dashboard-initial-build-pipeline
+    key: grafana-dashboard-initial-build-pipeline.json
+---
+apiVersion: integreatly.org/v1alpha1
+kind: GrafanaDashboard
+metadata:
+  name: grafana-dashboard-pac-provision
+  labels: 
+    app: appstudio-grafana
+spec:
+  configMapRef:
+    name: grafana-dashboard-pac-provision
+    key: grafana-dashboard-pac-provision.json
+

--- a/components/monitoring/grafana/base/build-service/kustomization.yaml
+++ b/components/monitoring/grafana/base/build-service/kustomization.yaml
@@ -2,3 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - https://github.com/redhat-appstudio/build-service/config/monitoring/grafana-dashboards/?ref=36027b1048f2ee9913f4728e396c082dd3b5605e
+- dashboard.yaml

--- a/components/monitoring/grafana/base/dora-metrics/dashboard.yaml
+++ b/components/monitoring/grafana/base/dora-metrics/dashboard.yaml
@@ -1,0 +1,10 @@
+apiVersion: integreatly.org/v1alpha1
+kind: GrafanaDashboard
+metadata:
+  name: grafana-dashboard-dora-metrics
+  labels: 
+    app: appstudio-grafana
+spec:
+  configMapRef:
+    name: grafana-dashboard-dora-metrics
+    key: dora-dashboard.json

--- a/components/monitoring/grafana/base/dora-metrics/kustomization.yaml
+++ b/components/monitoring/grafana/base/dora-metrics/kustomization.yaml
@@ -2,3 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - https://github.com/redhat-appstudio/dora-metrics/deploy/grafana/?ref=326417b0ffc4205fa3acaa675bfc0286f12b7682
+- dashboard.yaml

--- a/components/monitoring/grafana/base/has/dashboard.yaml
+++ b/components/monitoring/grafana/base/has/dashboard.yaml
@@ -1,0 +1,10 @@
+apiVersion: integreatly.org/v1alpha1
+kind: GrafanaDashboard
+metadata:
+  name: grafana-dashboard-has-gitops-repo-metrics
+  labels: 
+    app: appstudio-grafana
+spec:
+  configMapRef:
+    name: grafana-dashboard-has-gitops-repo-metrics
+    key: has-gitops-repo-metrics.json

--- a/components/monitoring/grafana/base/has/kustomization.yaml
+++ b/components/monitoring/grafana/base/has/kustomization.yaml
@@ -2,3 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - https://github.com/redhat-appstudio/application-service/config/monitoring/?ref=28a8f33e67cfcda61c82cf7d06c8820bc9d12305
+  - dashboard.yaml

--- a/components/monitoring/grafana/base/jvm-build-service/dashboard.yaml
+++ b/components/monitoring/grafana/base/jvm-build-service/dashboard.yaml
@@ -1,0 +1,10 @@
+apiVersion: integreatly.org/v1alpha1
+kind: GrafanaDashboard
+metadata:
+  name: grafana-dashboard-jvm-dependency-builds
+  labels: 
+    app: appstudio-grafana
+spec:
+  configMapRef:
+    name: grafana-dashboard-jvm-dependency-builds
+    key: grafana-dashboard-jvm-dependency-builds.json

--- a/components/monitoring/grafana/base/jvm-build-service/kustomization.yaml
+++ b/components/monitoring/grafana/base/jvm-build-service/kustomization.yaml
@@ -2,3 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - https://github.com/redhat-appstudio/jvm-build-service/deploy/monitoring/grafana-dashboards/?ref=e45fdb3f4634c592ba8c8ca554773345d9103600
+- dashboard.yaml

--- a/components/monitoring/grafana/base/managed-gitops/dashboard.yaml
+++ b/components/monitoring/grafana/base/managed-gitops/dashboard.yaml
@@ -1,0 +1,10 @@
+apiVersion: integreatly.org/v1alpha1
+kind: GrafanaDashboard
+metadata:
+  name: grafana-dashboard-gitops-service
+  labels: 
+    app: appstudio-grafana
+spec:
+  configMapRef:
+    name: grafana-dashboard-gitops-service
+    key: gitops-dashboard.json

--- a/components/monitoring/grafana/base/managed-gitops/kustomization.yaml
+++ b/components/monitoring/grafana/base/managed-gitops/kustomization.yaml
@@ -2,3 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - https://github.com/redhat-appstudio/managed-gitops/manifests/base/monitoring/grafana-dashboards/stonesoup?ref=d2480e7abbe50e4207b4ef9368e481a9329a3a46
+- dashboard.yaml

--- a/components/monitoring/grafana/base/release-service/dashboard.yaml
+++ b/components/monitoring/grafana/base/release-service/dashboard.yaml
@@ -1,0 +1,10 @@
+apiVersion: integreatly.org/v1alpha1
+kind: GrafanaDashboard
+metadata:
+  name: grafana-dashboard-release-release-attempts
+  labels: 
+    app: appstudio-grafana
+spec:
+  configMapRef:
+    name: grafana-dashboard-release-release-attempts
+    key: release-attempts.json

--- a/components/monitoring/grafana/base/release-service/kustomization.yaml
+++ b/components/monitoring/grafana/base/release-service/kustomization.yaml
@@ -2,3 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - https://github.com/redhat-appstudio/release-service/config/monitoring/?ref=21edb2dadc4e6031568689ab46ff78ad3a55de8c
+- dashboard.yaml

--- a/components/monitoring/grafana/base/spi/dashboard.yaml
+++ b/components/monitoring/grafana/base/spi/dashboard.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: integreatly.org/v1alpha1
+kind: GrafanaDashboard
+metadata:
+  name: grafana-dashboard-spi-health
+  labels: 
+    app: appstudio-grafana
+spec:
+  configMapRef:
+    name: grafana-dashboard-spi-health
+    key: spi-health.json
+---
+apiVersion: integreatly.org/v1alpha1
+kind: GrafanaDashboard
+metadata:
+  name: grafana-dashboard-spi-outbound-traffic
+  labels: 
+    app: appstudio-grafana
+spec:
+  configMapRef:
+    name: grafana-dashboard-spi-outbound-traffic
+    key: spi-outbound-traffic.json
+---
+apiVersion: integreatly.org/v1alpha1
+kind: GrafanaDashboard
+metadata:
+  name: grafana-dashboard-spi-slo
+  labels: 
+    app: appstudio-grafana
+spec:
+  configMapRef:
+    name: grafana-dashboard-spi-slo
+    key: spi-slo.json

--- a/components/monitoring/grafana/base/spi/kustomization.yaml
+++ b/components/monitoring/grafana/base/spi/kustomization.yaml
@@ -2,3 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - https://github.com/redhat-appstudio/service-provider-integration-operator/config/monitoring/base?ref=645b321aaa1e444b9b9adde5aa8bffb4315879ff
+- dashboard.yaml


### PR DESCRIPTION
    feat(STONEO11Y-163): Grafana dashboards
    
    Since we use the operator for deploying Grafana, a CR for each dashboard
    should be created.

    Fix development patch for Grafana
    
    The patch referenced the wrong ApplicationSet.


