### PR TITLE
Allow GitOps maintainers to upgrade OpenShift GitOps operator via InstallPlans

### DIFF
--- a/components/authentication/base/gitops-component-maintainer.yaml
+++ b/components/authentication/base/gitops-component-maintainer.yaml
@@ -11,6 +11,15 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - operators.coreos.com
+    resources:
+      - installplans
+    verbs:
+      - get
+      - list
+      - update
+      - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role


### PR DESCRIPTION
This allows team members with the `gitops-component-maintainer` to upgrade the OpenShift GitOps operators on member clusters, via OpenShift Web Console OLM install plan.

(Based on investigation and discussion on https://github.com/redhat-appstudio/infra-deployments/pull/1556)