### PR TITLE
Deploy external-secrets operator in a dedicated ns

### DIFF
--- a/components/external-secrets-operator/kustomization.yaml
+++ b/components/external-secrets-operator/kustomization.yaml
@@ -3,3 +3,4 @@ kind: Kustomization
 resources:
   - subscription.yaml
   - operator-config.yaml
+namespace: external-secrets-operator

--- a/components/external-secrets-operator/operator-config.yaml
+++ b/components/external-secrets-operator/operator-config.yaml
@@ -2,10 +2,9 @@ apiVersion: operator.external-secrets.io/v1alpha1
 kind: OperatorConfig
 metadata:
   name: cluster
-  namespace: external-secrets-operator
   annotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
-    argocd.argoproj.io/sync-wave: "0"
+    argocd.argoproj.io/sync-wave: "-1"
 spec:
   prometheus:
     enabled: true

--- a/components/external-secrets-operator/subscription.yaml
+++ b/components/external-secrets-operator/subscription.yaml
@@ -1,15 +1,24 @@
 ---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: external-secrets-operator
+  annotations:
+    argocd.argoproj.io/sync-wave: "-3"
+spec:
+  targetNamespaces:
+  - external-secrets-operator
+---
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
   name: external-secrets-operator
-  namespace: openshift-operators
   annotations:
-    argocd.argoproj.io/sync-wave: "-1"
+    argocd.argoproj.io/sync-wave: "-2"
 spec:
   channel: stable
   installPlanApproval: Manual
   name: external-secrets-operator
   source: community-operators
   sourceNamespace: openshift-marketplace
-  startingCSV: external-secrets-operator.v0.7.2
+  startingCSV: external-secrets-operator.v0.8.1


### PR DESCRIPTION
By deploying the eso in its own namespace, it can be upgraded independently from other operators.