### PR TITLE
GitOps: Upgrade OpenShift GitOps up to gitops-1.8 channel

### DIFF
--- a/components/gitops/openshift-gitops/overlays/production-and-dev/subscription-openshift-gitops.yaml
+++ b/components/gitops/openshift-gitops/overlays/production-and-dev/subscription-openshift-gitops.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "-1"
 spec:
-  channel: gitops-1.7
+  channel: gitops-1.8
   installPlanApproval: Automatic
   name: openshift-gitops-operator
   source: redhat-operators


### PR DESCRIPTION
This PR:
- Moves OpenShift GitOps up to 1.8 on production member clusters, and updates the dev mode `Subscription` version, as well.
- Staging was previously moved up to 1.8 earlier in the week, and no issues were found.