### PR TITLE
chore(STONEO11Y-84): Remove openshift-operators-redhat namespace

### DIFF
--- a/components/monitoring/logging/base/install-logging-operator.yaml
+++ b/components/monitoring/logging/base/install-logging-operator.yaml
@@ -2,15 +2,6 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: openshift-operators-redhat 
-  annotations:
-    openshift.io/node-selector: ""
-  labels:
-    openshift.io/cluster-monitoring: "true"
----
-apiVersion: v1
-kind: Namespace
-metadata:
   name: openshift-logging
   annotations:
     openshift.io/node-selector: ""


### PR DESCRIPTION
It's unused and we get errors on ArgoCD that we shouldn't created it on a managed cluster.