### PR TITLE
 chore(STONEO11Y-84): Don't create openshift-operators

### DIFF
--- a/components/monitoring/logging/base/install-logging-operator.yaml
+++ b/components/monitoring/logging/base/install-logging-operator.yaml
@@ -1,12 +1,5 @@
----
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: openshift-logging
-  annotations:
-    openshift.io/node-selector: ""
-  labels:
-    openshift.io/cluster-monitoring: "true"
+# On managed clusters, there is no need to create the openshift-logging
+# namespace because it's created automatically by hive.
 ---
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription


### PR DESCRIPTION
 Because we are using managed clsuters, the openshift-operators ns
 is created automatically by hive. When trying to created it using
 ArgoCD we are getting the following error:

one or more objects failed to apply, reason: admission webhook "namespace-validation.managed.openshift.io" denied the request: Prevented from accessing Red Hat managed namespaces