### PR TITLE
RHTAP: Add inputRefs to CloudWatch log forwarder

### DIFF
--- a/components/monitoring/logging/base/configure-logging/configure-logforwarder.yaml
+++ b/components/monitoring/logging/base/configure-logging/configure-logforwarder.yaml
@@ -18,6 +18,8 @@ spec:
   pipelines:
     - inputRefs:
         - application
+        - infrastructure
+        - audit
       name: fluentd-cloudwatch-logforward
       outputRefs:
         - remote-cloudwatch


### PR DESCRIPTION
Add inputRefs to CloudWatch log forwarder as they were prematurely, as we still don't have those audit logs in Splunk.

The intension here is to have also `infrastructure` and `audit` logs in CloudWatch for the time being.