### PR TITLE
chore(STONEO11Y-169): limit login to grafana

### DIFF
--- a/components/monitoring/grafana/base/grafana-app.yaml
+++ b/components/monitoring/grafana/base/grafana-app.yaml
@@ -135,7 +135,7 @@ spec:
         - '-http-address='
         - '-email-domain=*'
         - '-upstream=http://localhost:3000'
-        - '-openshift-sar={"resource": "namespaces", "verb": "get"}'
+        - '-openshift-sar={"resource": "namespaces", "resourceName": "appstudio-grafana", "namespace": "appstudio-grafana", "verb": "get"}'
         - '-openshift-delegate-urls={"/": {"resource": "namespaces", "verb": "get"}}'
         - '-tls-cert=/etc/tls/private/tls.crt'
         - '-tls-key=/etc/tls/private/tls.key'


### PR DESCRIPTION
Limit login to Grafana UI.
Only users with access to 'appstudio-grafana' namespace will get access to Grafana UI.