### PR TITLE
Add cert-manager operator

### DIFF
--- a/components/cert-manager/base/cert-manager.yaml
+++ b/components/cert-manager/base/cert-manager.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: cert-manager
+  namespace: openshift-operators
+spec:
+  channel: stable
+  name: cert-manager
+  source: community-operators
+  sourceNamespace: openshift-marketplace
+  installPlanApproval: Automatic

--- a/components/cert-manager/base/kustomization.yaml
+++ b/components/cert-manager/base/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - cert-manager.yaml
+

--- a/components/cert-manager/development/kustomization.yaml
+++ b/components/cert-manager/development/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../base

--- a/components/cert-manager/staging/kustomization.yaml
+++ b/components/cert-manager/staging/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../base


### PR DESCRIPTION
This component is mainly used by mutating webhook that is going to be used on staging env.
Reference to planned webhook:
https://github.com/redhat-appstudio/integration-service/pull/152

Let me please know if the component placement is correct and if it needs to be mentioned somepleace else to get automatically deployed.

This change could be applied once the Summit is over.