### PR TITLE
[DEVHAS-259] Increase number of replicas for HAS

### DIFF
--- a/components/has/production/kustomization.yaml
+++ b/components/has/production/kustomization.yaml
@@ -4,6 +4,10 @@ resources:
   - ../base
   - ../base/external-secrets
 
+replicas:
+- name: controller-system
+  count: 3
+
 configMapGenerator:
 - literals:
   - GITHUB_ORG="redhat-appstudio-appdata"

--- a/components/has/staging/kustomization.yaml
+++ b/components/has/staging/kustomization.yaml
@@ -4,6 +4,10 @@ resources:
   - ../base
   - ../base/external-secrets
 
+replicas:
+- name: controller-system
+  count: 3
+
 configMapGenerator:
 - literals:
   - GITHUB_ORG="redhat-appstudio-appdata-staging"


### PR DESCRIPTION
https://issues.redhat.com/browse/DEVHAS-259

We've noticed in the past when HAS has either crashed / been evicted / gone down for some reason, that there can be a significant delay (e.g. https://redhat-internal.slack.com/archives/C02CTEB3MMF/p1681233397095549), until HAS becomes available again.

While only one instance of HAS will ever be reconciling at a time, having multiple instances available to assume the lease and become leader (and resume reconciliation) upon HAS crashing, should significantly reduce downtime.