### PR TITLE
[DEVHAS-272] Add HAS Service Monitor

### DIFF
--- a/components/has/base/kustomization.yaml
+++ b/components/has/base/kustomization.yaml
@@ -2,6 +2,7 @@ resources:
 - allow-argocd-to-manage.yaml
 - argocd-permissions.yaml
 - https://github.com/redhat-appstudio/application-service/config/default?ref=df4cd6732afa5f13d8d354b493ed11958288ac31
+- https://github.com/redhat-appstudio/application-service/config/prometheus/?ref=df4cd6732afa5f13d8d354b493ed11958288ac31
 
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization


### PR DESCRIPTION
Adds the Service Monitor defined in the HAS repo. Part of work done in https://issues.redhat.com/browse/DEVHAS-272

Updated version of https://github.com/redhat-appstudio/infra-deployments/pull/1733 which was accidentally closed