### PR TITLE
[STONEO11Y-221] Auto-assign the Editor role to users in the grafana main org

### DIFF
--- a/components/monitoring/grafana/base/grafana-app.yaml
+++ b/components/monitoring/grafana/base/grafana-app.yaml
@@ -101,6 +101,7 @@ spec:
   config:
     users:
       viewers_can_edit: true
+      auto_assign_org_role: Editor
     log:
       mode: "console"
       level: "warn"


### PR DESCRIPTION
This allows logged in users to manage dashboards via the Grafana UI.