### PR TITLE
[DEVHAS-259] Fix replicas patch for HAS in production

### DIFF
--- a/components/has/production/kustomization.yaml
+++ b/components/has/production/kustomization.yaml
@@ -17,4 +17,4 @@ patches:
       kind: ExternalSecret
       group: external-secrets.io
       version: v1beta1
-  - ./replicas_patch.yaml
+  - path: ./replicas_patch.yaml

--- a/components/has/staging/kustomization.yaml
+++ b/components/has/staging/kustomization.yaml
@@ -11,4 +11,4 @@ configMapGenerator:
   behavior: replace
 
 patches:
-- ./replicas_patch.yaml
+- path: ./replicas_patch.yaml


### PR DESCRIPTION
Kustomize didn't like mixing patches where `path` was specified, and also not specified. So explicitly specifying it for all patches