### PR TITLE
Add role for bouncing HAS pods after token rotation

### DIFF
--- a/components/authentication/base/has-admin.yaml
+++ b/components/authentication/base/has-admin.yaml
@@ -1,0 +1,36 @@
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: has-admin
+  namespace: application-service
+rules:
+  - verbs:
+      - get
+      - delete
+    apiGroups:
+      - ''
+    resources:
+      - pods
+  - verbs:
+      - "patch"
+    apiGroups:
+      - "apps"
+    resources:
+      - "deployments/scale"
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: has-admin
+  namespace: application-service
+subjects:
+  - kind: User
+    name: johnmcollier
+  - kind: User
+    name: kim-tsao
+  - kind: User
+    name: maysunfaisal
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: has-admin

--- a/components/authentication/base/kustomization.yaml
+++ b/components/authentication/base/kustomization.yaml
@@ -15,6 +15,7 @@ resources:
 - internal-services.yaml
 - pipeline-service-sre.yaml
 - sandbox-sre-admins.yaml
+- has-admin.yaml
 
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization


### PR DESCRIPTION
After updating the tokens for HAS on Vault, bouncing the HAS pod(s) may be necessary. Adding a simple admin role for myself, @kim-tsao, and @maysunfaisal to do so.