### PR TITLE
Fixing mismatched file names in kustomize reference

### DIFF
--- a/components/tekton-ci/production/kustomization.yaml
+++ b/components/tekton-ci/production/kustomization.yaml
@@ -17,9 +17,9 @@ patches:
       kind: ExternalSecret
       group: external-secrets.io
       version: v1beta1
-  - path: snyk-shared-secret.yaml
+  - path: snyk-shared-token.yaml
     target:
-      name: snyk-shared-secret
+      name: snyk-shared-token
       kind: ExternalSecret
       group: external-secrets.io
       version: v1beta1


### PR DESCRIPTION
Tested with
```
cd components/tekton-ci
kustomize build production
```

