### PR TITLE
Add missing group/version in auth app

### DIFF
--- a/components/authentication/base/inspect-pods.yaml
+++ b/components/authentication/base/inspect-pods.yaml
@@ -1,3 +1,5 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: inspect-pods


### PR DESCRIPTION
One of the clusters rules had a missing group/version field.