### PR TITLE
[HAS] Move prometheus to staging and production overlays

### DIFF
--- a/components/has/base/kustomization.yaml
+++ b/components/has/base/kustomization.yaml
@@ -1,7 +1,6 @@
 resources:
 - allow-argocd-to-manage.yaml
 - argocd-permissions.yaml
-- https://github.com/redhat-appstudio/application-service/config/prometheus/?ref=df4cd6732afa5f13d8d354b493ed11958288ac31
 - https://github.com/redhat-appstudio/application-service/config/default?ref=df4cd6732afa5f13d8d354b493ed11958288ac31
 
 apiVersion: kustomize.config.k8s.io/v1beta1

--- a/components/has/base/kustomization.yaml
+++ b/components/has/base/kustomization.yaml
@@ -1,8 +1,8 @@
 resources:
 - allow-argocd-to-manage.yaml
 - argocd-permissions.yaml
-- https://github.com/redhat-appstudio/application-service/config/default?ref=df4cd6732afa5f13d8d354b493ed11958288ac31
 - https://github.com/redhat-appstudio/application-service/config/prometheus/?ref=df4cd6732afa5f13d8d354b493ed11958288ac31
+- https://github.com/redhat-appstudio/application-service/config/default?ref=df4cd6732afa5f13d8d354b493ed11958288ac31
 
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/components/has/development/kustomization.yaml
+++ b/components/has/development/kustomization.yaml
@@ -2,4 +2,3 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../base
-  - https://github.com/redhat-appstudio/application-service/config/prometheus/?ref=df4cd6732afa5f13d8d354b493ed11958288ac31

--- a/components/has/development/kustomization.yaml
+++ b/components/has/development/kustomization.yaml
@@ -2,3 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../base
+  - https://github.com/redhat-appstudio/application-service/config/prometheus/?ref=df4cd6732afa5f13d8d354b493ed11958288ac31

--- a/components/has/production/kustomization.yaml
+++ b/components/has/production/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
   - ../base
   - ../base/external-secrets
+  - https://github.com/redhat-appstudio/application-service/config/prometheus/?ref=df4cd6732afa5f13d8d354b493ed11958288ac31
 
 configMapGenerator:
 - literals:

--- a/components/has/staging/kustomization.yaml
+++ b/components/has/staging/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
   - ../base
   - ../base/external-secrets
+  - https://github.com/redhat-appstudio/application-service/config/prometheus/?ref=df4cd6732afa5f13d8d354b493ed11958288ac31
 
 configMapGenerator:
 - literals:


### PR DESCRIPTION
Based on errors in https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/redhat-appstudio_application-service/307/pull-ci-redhat-appstudio-application-service-main-application-service-e2e/1652114871954706432, I'm wondering if having two links to kustomize overlays in https://github.com/redhat-appstudio/application-service is tripping up the tests. Moving the prometheus overlays (which are only needed in staging and production) to confirm.