### PR TITLE
move dora metrics service monitor to its repository

### DIFF
--- a/components/dora-metrics/base/kustomization.yaml
+++ b/components/dora-metrics/base/kustomization.yaml
@@ -1,5 +1,5 @@
 resources:
-- https://github.com/redhat-appstudio/dora-metrics/deploy/base?ref=d1527e9ad74c96bb7333f02a4b55695f4c88d92c
+- https://github.com/redhat-appstudio/dora-metrics/deploy/base?ref=0781bca02657aa785740ed6e374ec5def7c9a0a5
 
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
@@ -7,4 +7,4 @@ kind: Kustomization
 images:
   - name: quay.io/redhat-appstudio/dora-metrics
     newName: quay.io/redhat-appstudio/dora-metrics
-    newTag: d1527e9ad74c96bb7333f02a4b55695f4c88d92c
+    newTag: 0781bca02657aa785740ed6e374ec5def7c9a0a5

--- a/components/monitoring/grafana/base/dora-metrics/kustomization.yaml
+++ b/components/monitoring/grafana/base/dora-metrics/kustomization.yaml
@@ -1,5 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- https://github.com/redhat-appstudio/dora-metrics/deploy/grafana/?ref=326417b0ffc4205fa3acaa675bfc0286f12b7682
+- https://github.com/redhat-appstudio/dora-metrics/deploy/grafana/?ref=0781bca02657aa785740ed6e374ec5def7c9a0a5
 - dashboard.yaml


### PR DESCRIPTION
Move dora metrics service monitor to its repository, as per new instructions. 