### PR TITLE
give pipeline-service team view access to the sprayproxy namespace for support

### DIFF
--- a/components/sprayproxy/base/kustomization.yaml
+++ b/components/sprayproxy/base/kustomization.yaml
@@ -2,3 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 namespace: sprayproxy
+
+resources:
+  - team-support-rbac.yaml

--- a/components/sprayproxy/base/team-support-rbac.yaml
+++ b/components/sprayproxy/base/team-support-rbac.yaml
@@ -1,0 +1,31 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: sprayproxy-rbac-for-support
+  namespace: sprayproxy
+subjects:
+  - kind: User
+    name: adambkaplan
+    apiGroup: rbac.authorization.k8s.io
+  - kind: User
+    name: Roming22
+    apiGroup: rbac.authorization.k8s.io
+  - kind: User
+    name: gabemontero
+    apiGroup: rbac.authorization.k8s.io
+  - kind: User
+    name: avinal
+    apiGroup: rbac.authorization.k8s.io
+  - kind: User
+    name: sayan-biswas
+    apiGroup: rbac.authorization.k8s.io
+  - kind: User
+    name: enarha
+    apiGroup: rbac.authorization.k8s.io
+  - kind: User
+    name: AndrienkoAleksandr
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: view
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
So the pipeline service team has a situation where as part of our current access to the various staging/prod environments, we do not have access to the sprayproxy namespace, since it is deployed as part of the sandbox/codeready toolchain host (vs. member) side of things.

That hampers our support of course

Per discussion with @amfred in https://redhat-internal.slack.com/archives/C04F4NE15U1/p1683316863120999 she had a straight forward solution.  Create RBAC specific for our team to only view that namespace.

Here is my offering to handle that for both staging / production by including in the base dir.

Unfortunately, the `hack/bootstrap-host-cluster.sh` command does not seem to go through the sprayproxy path, so some guidance on local testing, or validating via review, is appreciated.

@gbenhaim given as I recall your initial work on sprayproxy's addition to infra-deployments, I am hoping you can provide guidance here.  Perhaps I need move this from base to copies in staging/prod?

@Roming22 @adambkaplan @avinal @sayan-biswas @enarha @AndrienkoAleksandr I have added you all initially.  Please chime in for any additions (or if you want to be removed) from this.