### PR TITLE
Add script for setup namespace for appstudio execution

### DIFF
--- a/hack/build/build-via-appstudio.sh
+++ b/hack/build/build-via-appstudio.sh
@@ -25,8 +25,8 @@ if [ -z "$GENERATE_IMAGE" ]; then
   oc secret link pipeline redhat-appstudio-registry-pull-secret
 fi
 
-# Label namespace to be managed by gitops-service-argocd
-oc label namespace $(oc config view --minify -o 'jsonpath={..namespace}') --overwrite argocd.argoproj.io/managed-by=gitops-service-argocd
+# Configure namespace
+$SCRIPTDIR/setup-namespace.sh
 
 oc delete --ignore-not-found -f $SCRIPTDIR/templates/application.yaml
 oc create -f $SCRIPTDIR/templates/application.yaml

--- a/hack/build/setup-namespace.sh
+++ b/hack/build/setup-namespace.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# Script for setting namespace which is not managed by toolchain host operator
+
+CURRENT_NAMESPACE=$(oc config view --minify -o 'jsonpath={..namespace}')
+oc label namespace $CURRENT_NAMESPACE --overwrite argocd.argoproj.io/managed-by=gitops-service-argocd
+oc apply -f https://raw.githubusercontent.com/codeready-toolchain/member-operator/master/config/appstudio-pipelines-runner/base/appstudio_pipelines_runner_role.yaml
+oc create --dry-run=client -o yaml serviceaccount appstudio-pipeline | oc apply -f-
+oc create --dry-run=client -o yaml rolebinding appstudio-pipelines-runner-rolebinding --clusterrole=appstudio-pipelines-runner --serviceaccount=$CURRENT_NAMESPACE:appstudio-pipeline | oc apply -f-


### PR DESCRIPTION
This is script for setting namespace which is not managed by toolchain operator. For testing purposes only.