### PR TITLE
   Upgrade Pipeline-Service

### DIFF
--- a/components/pipeline-service/development/kustomization.yaml
+++ b/components/pipeline-service/development/kustomization.yaml
@@ -8,8 +8,8 @@ commonAnnotations:
   argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 
 resources:
-  - git::https://github.com/openshift-pipelines/pipeline-service.git/developer/openshift/gitops/argocd/pipeline-service?ref=709ba3afe1cb80b9a8181849b7eb174e0d50f458
-  - git::https://github.com/openshift-pipelines/pipeline-service.git/developer/openshift/gitops/argocd/pipeline-service-storage?ref=709ba3afe1cb80b9a8181849b7eb174e0d50f458
+  - git::https://github.com/openshift-pipelines/pipeline-service.git/developer/openshift/gitops/argocd/pipeline-service?ref=01d8e1eb09fbfe1665e73d654bdc806207a72bd4
+  - git::https://github.com/openshift-pipelines/pipeline-service.git/developer/openshift/gitops/argocd/pipeline-service-storage?ref=01d8e1eb09fbfe1665e73d654bdc806207a72bd4
 
 components:
   - ../components/tekton-chains

--- a/components/pipeline-service/staging/base/kustomization.yaml
+++ b/components/pipeline-service/staging/base/kustomization.yaml
@@ -8,7 +8,7 @@ commonAnnotations:
   argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 
 resources:
-  - git::https://github.com/openshift-pipelines/pipeline-service.git/operator/gitops/argocd/pipeline-service?ref=709ba3afe1cb80b9a8181849b7eb174e0d50f458
+  - git::https://github.com/openshift-pipelines/pipeline-service.git/operator/gitops/argocd/pipeline-service?ref=01d8e1eb09fbfe1665e73d654bdc806207a72bd4
   - ../../base/external-secrets
   - ../../base/testing
 


### PR DESCRIPTION
Upgrade Pipeline-Service
- change default SA for Pipelines to appstudio-pipeline    
- align tekton-results logs with [ADR-6](https://issues.redhat.com//browse/ADR-6)
#### Step 4 in the Rollout Plan for updating the default Service account in Pipelines.