### PR TITLE
Update sprayproxy version prod

### DIFF
--- a/components/sprayproxy/production/kustomization.yaml
+++ b/components/sprayproxy/production/kustomization.yaml
@@ -1,14 +1,14 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - https://github.com/redhat-appstudio/sprayproxy/config?ref=00571eee2e5ca7c143406820a41a181ed5d1dfc6
+  - https://github.com/redhat-appstudio/sprayproxy/config?ref=94d5165db684a31a347162363ec9ab1c801d946f
   - pipelines-as-code-secret.yaml
   - team-support-rbac.yaml
 
 images:
   - name: ko://github.com/redhat-appstudio/sprayproxy
     newName: quay.io/redhat-appstudio/sprayproxy
-    newTag: 00571eee2e5ca7c143406820a41a181ed5d1dfc6
+    newTag: 94d5165db684a31a347162363ec9ab1c801d946f
 
 patches:
   - path: add-backends.yml


### PR DESCRIPTION
New features added:

- Add GitHub webhook validation - https://github.com/redhat-appstudio/sprayproxy/pull/37
- Add forwarding request timeout - https://github.com/redhat-appstudio/sprayproxy/pull/40
- Limit proxy request size - https://github.com/redhat-appstudio/sprayproxy/pull/43