### PR TITLE
Update integration service for STONEINTG-419

### DIFF
--- a/components/integration/kustomization.yaml
+++ b/components/integration/kustomization.yaml
@@ -1,7 +1,7 @@
 resources:
 - allow-argocd-to-manage.yaml
 - argocd-permissions.yaml
-- https://github.com/redhat-appstudio/integration-service/config/default?ref=a886623c035d25c48dd700aa317c035c177caac3
+- https://github.com/redhat-appstudio/integration-service/config/default?ref=9ae5f506922ba9a1a9f47b0edb135b3bbc6b8b53
 
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
@@ -9,7 +9,7 @@ kind: Kustomization
 images:
 - name: quay.io/redhat-appstudio/integration-service
   newName: quay.io/redhat-appstudio/integration-service
-  newTag: a886623c035d25c48dd700aa317c035c177caac3
+  newTag: 9ae5f506922ba9a1a9f47b0edb135b3bbc6b8b53
 
 namespace: integration-service
 


### PR DESCRIPTION
Manual update since the workflow on push was broken.
This PR updates the integration service to the latest commit which has only changes for [STONEINTG-419](https://issues.redhat.com//browse/STONEINTG-419) and has no dependabot-related updates in it in order to comply with the code-freeze exception.