### PR TITLE
DO-NOT-MERGE-YET: direct patch bump (vs. pipeline service bump) of chains to latest downstream image

### DIFF
--- a/components/pipeline-service/components/tekton-chains/tekton-chains-controller-deployment.yaml
+++ b/components/pipeline-service/components/tekton-chains/tekton-chains-controller-deployment.yaml
@@ -11,6 +11,7 @@ spec:
     spec:
       containers:
         - name: tekton-chains-controller
+          image: registry.redhat.io/openshift-pipelines/pipelines-chains-controller-rhel8:v1.10.2-1
           securityContext:
             allowPrivilegeEscalation: false
             $patch: replace


### PR DESCRIPTION
Confirm the https://issues.redhat.com/browse/RHTAPBUGS-254 fixes work

If we get green e2e's, and based on the pipeline service activity around the SA switch, and proper approvals from PM / arch etc. we can decide if we move forward on this via this change, or the more typical bump pipeline service path.

@mmalina 
@Roming22 
@sbose78 

FYI