### PR TITLE
RHTAP-872: tekton-ci: fix SA update - ignore native secret

### DIFF
--- a/argo-cd-apps/base/tekton-ci/tekton-ci.yaml
+++ b/argo-cd-apps/base/tekton-ci/tekton-ci.yaml
@@ -35,7 +35,7 @@ spec:
         kind: "ServiceAccount"
         name: pipeline
         jqPathExpressions:
-        - .imagePullSecrets[] | select(.name | startswith("pipeline-dockercfg"))
+        - .imagePullSecrets[] | select(.name | startswith("appstudio-pipeline-dockercfg"))
       syncPolicy:
         automated:
           prune: true


### PR DESCRIPTION
Since the serviceaccount was changed to appstudio-pipeline we need to update argoCD definition to not update linked secret appstudio-pipeline-dockercfg-*