### PR TITLE
RHTAP-872: rename service account for build-definitions e2e

### DIFF
--- a/components/build-templates/base/e2e/rolebinding.yaml
+++ b/components/build-templates/base/e2e/rolebinding.yaml
@@ -9,7 +9,7 @@ roleRef:
   name:  edit
 subjects:
 - kind: ServiceAccount
-  name: pipeline
+  name: appstudio-pipeline
   namespace: tekton-ci
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -22,7 +22,7 @@ roleRef:
   name:  edit-namespace
 subjects:
 - kind: ServiceAccount
-  name: pipeline
+  name: appstudio-pipeline
   namespace: tekton-ci
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -35,5 +35,5 @@ roleRef:
   name:  admin-buildpipelineselectors
 subjects:
 - kind: ServiceAccount
-  name: pipeline
+  name: appstudio-pipeline
   namespace: tekton-ci


### PR DESCRIPTION
Build-definitions e2e tests are run on existing cluster to test the modifications directly. With the rename of service account the validation stopped working.