### PR TITLE
build-definitions-e2e: fix appstudio-pipeline SA

### DIFF
--- a/components/build-templates/base/e2e/rolebinding.yaml
+++ b/components/build-templates/base/e2e/rolebinding.yaml
@@ -37,3 +37,16 @@ subjects:
 - kind: ServiceAccount
   name: appstudio-pipeline
   namespace: tekton-ci
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: appstudio-pipelines-runner-rolebinding
+subjects:
+  - kind: ServiceAccount
+    name: appstudio-pipeline
+    namespace: build-templates-e2e
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: appstudio-pipelines-runner


### PR DESCRIPTION
appstudio-pipeline needs access to pipelines-scc to be able to execute pipelines.