### PR TITLE
Update ServiceMonitors and reference to the grafana dashboard

### DIFF
--- a/components/monitoring/grafana/base/managed-gitops/kustomization.yaml
+++ b/components/monitoring/grafana/base/managed-gitops/kustomization.yaml
@@ -1,5 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- https://github.com/redhat-appstudio/managed-gitops/manifests/base/monitoring/grafana-dashboards/stonesoup?ref=d2480e7abbe50e4207b4ef9368e481a9329a3a46
+- https://github.com/redhat-appstudio/managed-gitops/manifests/base/monitoring/grafana-dashboards/stonesoup?ref=e972d39dfc6ddcfcf9c23ced787625589195b954
 - dashboard.yaml

--- a/components/monitoring/grafana/base/managed-gitops/kustomization.yaml
+++ b/components/monitoring/grafana/base/managed-gitops/kustomization.yaml
@@ -1,5 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- https://github.com/redhat-appstudio/managed-gitops/manifests/base/monitoring/grafana-dashboards/stonesoup?ref=e972d39dfc6ddcfcf9c23ced787625589195b954
+- https://github.com/redhat-appstudio/managed-gitops/manifests/base/monitoring/grafana-dashboards-new?ref=b432c75256a43e308eea3f74e6ff88e1809cbc50
 - dashboard.yaml


### PR DESCRIPTION
Updated ServiceMonitors based on managed-gitops and references to grafana dashboard

Jira link - https://issues.redhat.com/browse/GITOPSRVCE-563 