### PR TITLE
chore(RHTAPWATCH-242): rename Grafana datasource

### DIFF
--- a/components/monitoring/grafana/base/grafana-app.yaml
+++ b/components/monitoring/grafana/base/grafana-app.yaml
@@ -210,7 +210,7 @@ kind: GrafanaDataSource
 metadata:
   annotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
-  name: prometheus-grafanadatasource
+  name: prometheus-appstudio-ds
   namespace: appstudio-grafana
 spec:
   name: prometheus-thanos-grafanadatasource.yaml
@@ -222,7 +222,7 @@ spec:
         httpHeaderName1: Authorization
         timeInterval: 5s
         tlsSkipVerify: true
-      name: Prometheus
+      name: prometheus-appstudio-ds
       secureJsonData:
         httpHeaderValue1: 'Bearer ${thanostoken}'
       type: prometheus


### PR DESCRIPTION
Rename Grafana datasource to `prometheus-appstudio-ds` so it will be caught when using templating with `.*(appstudio)-.*` regex