### PR TITLE
Rhtap 953/create rhtap perf tests grafana dashboards

### DIFF
--- a/components/monitoring/grafana/base/performance/dashboard.yaml
+++ b/components/monitoring/grafana/base/performance/dashboard.yaml
@@ -1,12 +1,12 @@
 apiVersion: integreatly.org/v1alpha1
 kind: GrafanaDashboard
 metadata:
-  name: performance-team-dashboard-cluster-monitoring
+  name: kubernetes-cluster-monitoring
   labels: 
     app: appstudio-grafana
 spec:
   configMapRef:
-    name: performance-team-dashboard-cluster-monitoring
+    name: kubernetes-cluster-monitoring
     key: kubernetes-cluster-monitoring.json
 ---
 apiVersion: integreatly.org/v1alpha1

--- a/components/monitoring/grafana/base/performance/dashboards/kubernetes-cluster-monitoring.json
+++ b/components/monitoring/grafana/base/performance/dashboards/kubernetes-cluster-monitoring.json
@@ -81,7 +81,6 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.17",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -1037,7 +1036,6 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.17",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -1487,7 +1485,6 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.17",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -1609,7 +1606,6 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.17",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -1731,7 +1727,6 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.17",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -1871,7 +1866,6 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.17",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -1993,7 +1987,6 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.17",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",

--- a/components/monitoring/grafana/base/performance/kustomization.yaml
+++ b/components/monitoring/grafana/base/performance/kustomization.yaml
@@ -3,7 +3,7 @@ kind: Kustomization
 resources:
   - dashboard.yaml
 configMapGenerator:
-  - name: performance-team-cluster-monitoring
+  - name: kubernetes-cluster-monitoring
     files:
       - dashboards/kubernetes-cluster-monitoring.json
   - name: kubernetes-persistent-volumes


### PR DESCRIPTION
I have fixed a problem concerning in the performance kustomization.yaml and dashboard.yaml
That caused a problem not allowing the kubernetes-cluster-monitoring config file being discovered by Grafana

Now both dashboards are active in discoverable by Grafana
kubernetes-cluster-monitoring and kubernetes-persistent-volumes