### PR TITLE
updated  performance/dashboard.yaml to rename kubernetes-cluster-moni…

### DIFF
--- a/components/monitoring/grafana/base/performance/dashboard.yaml
+++ b/components/monitoring/grafana/base/performance/dashboard.yaml
@@ -1,12 +1,12 @@
 apiVersion: integreatly.org/v1alpha1
 kind: GrafanaDashboard
 metadata:
-  name: performance-team-dashboard-cluster-monitoring
+  name: kubernetes-cluster-monitoring
   labels: 
     app: appstudio-grafana
 spec:
   configMapRef:
-    name: performance-team-dashboard-cluster-monitoring
+    name: kubernetes-cluster-monitoring
     key: kubernetes-cluster-monitoring.json
 ---
 apiVersion: integreatly.org/v1alpha1


### PR DESCRIPTION
Updated performance-team-dashboard-cluster-monitoring dashboard name into kubernetes-cluster-monitoring
To resolve an issue that prevented the dashboard's configmap being recognized by grafana