### PR TITLE
PLNSRVCE-1307: pipeline service update dev/staging: reenable exporter with caching client

### DIFF
--- a/components/pipeline-service/development/kustomization.yaml
+++ b/components/pipeline-service/development/kustomization.yaml
@@ -8,8 +8,8 @@ commonAnnotations:
   argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 
 resources:
-  - git::https://github.com/openshift-pipelines/pipeline-service.git/developer/openshift/gitops/argocd/pipeline-service?ref=303c19d55e2ae90f737ce3a245755eff34684099
-  - git::https://github.com/openshift-pipelines/pipeline-service.git/developer/openshift/gitops/argocd/pipeline-service-storage?ref=303c19d55e2ae90f737ce3a245755eff34684099
+  - git::https://github.com/openshift-pipelines/pipeline-service.git/developer/openshift/gitops/argocd/pipeline-service?ref=aacffd568cf9f320362cc98a60b38673f5892b03
+  - git::https://github.com/openshift-pipelines/pipeline-service.git/developer/openshift/gitops/argocd/pipeline-service-storage?ref=aacffd568cf9f320362cc98a60b38673f5892b03
 
 patches:
   - path: scale-down-exporter.yaml

--- a/components/pipeline-service/development/kustomization.yaml
+++ b/components/pipeline-service/development/kustomization.yaml
@@ -10,10 +10,3 @@ commonAnnotations:
 resources:
   - git::https://github.com/openshift-pipelines/pipeline-service.git/developer/openshift/gitops/argocd/pipeline-service?ref=aacffd568cf9f320362cc98a60b38673f5892b03
   - git::https://github.com/openshift-pipelines/pipeline-service.git/developer/openshift/gitops/argocd/pipeline-service-storage?ref=aacffd568cf9f320362cc98a60b38673f5892b03
-
-patches:
-  - path: scale-down-exporter.yaml
-    target:
-      kind: Deployment
-      name: pipeline-metrics-exporter
-      namespace: openshift-pipelines

--- a/components/pipeline-service/development/scale-down-exporter.yaml
+++ b/components/pipeline-service/development/scale-down-exporter.yaml
@@ -1,4 +1,0 @@
----
-- op: replace
-  path: /spec/replicas
-  value: 0

--- a/components/pipeline-service/staging/base/kustomization.yaml
+++ b/components/pipeline-service/staging/base/kustomization.yaml
@@ -18,8 +18,3 @@ patches:
       kind: ConfigMap
       name: pipelines-as-code
       namespace: pipelines-as-code
-  - path: scale-down-exporter.yaml
-    target:
-      kind: Deployment
-      name: pipeline-metrics-exporter
-      namespace: openshift-pipelines

--- a/components/pipeline-service/staging/base/kustomization.yaml
+++ b/components/pipeline-service/staging/base/kustomization.yaml
@@ -8,7 +8,7 @@ commonAnnotations:
   argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 
 resources:
-  - git::https://github.com/openshift-pipelines/pipeline-service.git/operator/gitops/argocd/pipeline-service?ref=303c19d55e2ae90f737ce3a245755eff34684099
+  - git::https://github.com/openshift-pipelines/pipeline-service.git/operator/gitops/argocd/pipeline-service?ref=aacffd568cf9f320362cc98a60b38673f5892b03
   - ../../base/external-secrets
   - ../../base/testing
 

--- a/components/pipeline-service/staging/base/scale-down-exporter.yaml
+++ b/components/pipeline-service/staging/base/scale-down-exporter.yaml
@@ -1,4 +1,0 @@
----
-- op: replace
-  path: /spec/replicas
-  value: 0


### PR DESCRIPTION
So @adambkaplan @Roming22 let's decided if we want to 

- see the benefit alone of the non-caching client wrt metrics exporter stability, first in dev/staging, then prod, as this PR currently is the next step in that path
- or not bother on seeing the impact of a caching client on its own, and do not re-enable the metrics exporter until we rework the granularity/structure of the current completion and scheduled metrics

I'll mention in planning tomorrow as well if you all do not comment here beforehand.