### PR TITLE
PLNSRVCE-1325:  patch tektonconfig so performance setting are reverted to upstream defaults

### DIFF
--- a/components/pipeline-service/development/kustomization.yaml
+++ b/components/pipeline-service/development/kustomization.yaml
@@ -17,3 +17,7 @@ patches:
       kind: Deployment
       name: pipeline-metrics-exporter
       namespace: openshift-pipelines
+  - path: update-tekton-config-performance.yaml
+    target:
+      kind: TektonConfig
+      name: config

--- a/components/pipeline-service/development/update-tekton-config-performance.yaml
+++ b/components/pipeline-service/development/update-tekton-config-performance.yaml
@@ -1,0 +1,19 @@
+---
+- op: replace
+  path: /spec/pipeline/performance/threads-per-controller
+  # default upstream setting
+  value: 2
+  # upstream large scale env recommendation
+  # value: 32
+- op: replace
+  path: /spec/pipeline/performance/kube-api-qps
+  # default upstream setting
+  value: 5.0
+  # upstream large scale env recommendation
+  # value: 50
+- op: replace
+  path: /spec/pipeline/performance/kube-api-burst
+  # default upstream setting
+  value: 10
+  # upstream large scale env recommendation
+  # value: 50

--- a/components/pipeline-service/staging/base/kustomization.yaml
+++ b/components/pipeline-service/staging/base/kustomization.yaml
@@ -23,3 +23,7 @@ patches:
       kind: Deployment
       name: pipeline-metrics-exporter
       namespace: openshift-pipelines
+  - path: update-tekton-config-performance.yaml
+    target:
+      kind: TektonConfig
+      name: config

--- a/components/pipeline-service/staging/base/update-tekton-config-performance.yaml
+++ b/components/pipeline-service/staging/base/update-tekton-config-performance.yaml
@@ -1,0 +1,19 @@
+---
+- op: replace
+  path: /spec/pipeline/performance/threads-per-controller
+  # default upstream setting
+  value: 2
+  # upstream large scale env recommendation
+  # value: 32
+- op: replace
+  path: /spec/pipeline/performance/kube-api-qps
+  # default upstream setting
+  value: 5.0
+  # upstream large scale env recommendation
+  # value: 50
+- op: replace
+  path: /spec/pipeline/performance/kube-api-burst
+  # default upstream setting
+  value: 10
+  # upstream large scale env recommendation
+  # value: 50


### PR DESCRIPTION
As part of trying to isolate the performance impact of the TektonConfig performance tuning options, this PR controls the setting directly from infra-deployments, vs. changing the tektonconfig in pipeline-service and then update to the new version of pipeline-service here

I have verified the behavior via an infra-deployments bootstrap preview using this branch and an OCP cluster I personally provisioned.