### PR TITLE
Remove pods/exec from component maintainer role

### DIFF
--- a/components/authentication/base/component-maintainer.yaml
+++ b/components/authentication/base/component-maintainer.yaml
@@ -39,7 +39,6 @@ rules:
   - apiGroups:
     - ''
     resources:
-    - pods/exec
     - pods/portforward
     verbs:
     - create


### PR DESCRIPTION
Removes roles for the `pods/exec` subresource from the component maintainer role, as it should not be needed