### PR TITLE
Update pipeline-service in production

### DIFF
--- a/components/pipeline-service/production/base/kustomization.yaml
+++ b/components/pipeline-service/production/base/kustomization.yaml
@@ -8,7 +8,7 @@ commonAnnotations:
   argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 
 resources:
-  - git::https://github.com/openshift-pipelines/pipeline-service.git/operator/gitops/argocd/pipeline-service?ref=9644d47a6cc62016af1b350aa8feb0e31cd7dd8b
+  - git::https://github.com/openshift-pipelines/pipeline-service.git/operator/gitops/argocd/pipeline-service?ref=303c19d55e2ae90f737ce3a245755eff34684099
   - ../../base/external-secrets
   - ../../base/testing
 
@@ -29,3 +29,7 @@ patches:
       kind: Deployment
       name: pipeline-metrics-exporter
       namespace: openshift-pipelines
+  - path: update-tekton-config-performance.yaml
+    target:
+      kind: TektonConfig
+      name: config

--- a/components/pipeline-service/production/base/update-tekton-config-performance.yaml
+++ b/components/pipeline-service/production/base/update-tekton-config-performance.yaml
@@ -1,0 +1,19 @@
+---
+- op: replace
+  path: /spec/pipeline/performance/threads-per-controller
+  # default upstream setting
+  value: 2
+  # upstream large scale env recommendation
+  # value: 32
+- op: replace
+  path: /spec/pipeline/performance/kube-api-qps
+  # default upstream setting
+  value: 5.0
+  # upstream large scale env recommendation
+  # value: 50
+- op: replace
+  path: /spec/pipeline/performance/kube-api-burst
+  # default upstream setting
+  value: 10
+  # upstream large scale env recommendation
+  # value: 50


### PR DESCRIPTION
* Added overlay for the performance settings so that default settings
  are used in production until we are ready to activate tuned settings
* Rename pipelines-scc to appstudio-pipelines-scc
* Update pipeline-service-exporter-reader ClusterRole to watch
  pipelineruns and task runs, and get customresourcedefinitions
* Align Pipelines Controller logs with [ADR-6](https://issues.redhat.com//browse/ADR-6)
* Use downstream image for tekton chains
* Add more ArgoCD sync-wave and phases
* Set 'enable-api-fields: beta' in OSP