### PR TITLE
Enable CI for pipeline-service-exporter component

### DIFF
--- a/components/tekton-ci/base/repository.yaml
+++ b/components/tekton-ci/base/repository.yaml
@@ -128,6 +128,13 @@ spec:
 apiVersion: pipelinesascode.tekton.dev/v1alpha1
 kind: Repository
 metadata:
+  name: pipeline-service-exporter
+spec:
+  url: "https://github.com/openshift-pipelines/pipeline-service-exporter"
+---
+apiVersion: pipelinesascode.tekton.dev/v1alpha1
+kind: Repository
+metadata:
   name: ec-cli
 spec:
   url: "https://github.com/enterprise-contract/ec-cli"


### PR DESCRIPTION
pipeline-service-exporter is already part of the pipeline-service component. Initially onboarded as a RHTAP user component we are switching to RHTAP component mode and enabling the CI for the repo.