### PR TITLE
STONEBLD-29: add slack notification secret for tekton-ci

### DIFF
--- a/components/tekton-ci/base/external-secrets/kustomization.yaml
+++ b/components/tekton-ci/base/external-secrets/kustomization.yaml
@@ -4,4 +4,5 @@ resources:
 - tekton-ci-push-secret.yaml
 - infra-deployments-pr-creator.yaml
 - snyk-shared-token.yaml
+- slack-webhook-notification-secret.yaml
 namespace: tekton-ci

--- a/components/tekton-ci/base/external-secrets/slack-webhook-notification-secret.yaml
+++ b/components/tekton-ci/base/external-secrets/slack-webhook-notification-secret.yaml
@@ -1,0 +1,19 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: slack-webhook-notification-secret
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  dataFrom:
+    - extract:
+        key: "production/build/slack-webhook-notification-secret"
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: appsre-stonesoup-vault
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    name: slack-webhook-notification-secret


### PR DESCRIPTION
Sync secret from vault with webhooks urls for slack so that pipeline will be able to notify failures via slack.