### PR TITLE
feat(STONEINTG-362): adding PAC to hacbs-test repo

### DIFF
--- a/components/tekton-ci/base/repository.yaml
+++ b/components/tekton-ci/base/repository.yaml
@@ -58,6 +58,13 @@ spec:
 apiVersion: pipelinesascode.tekton.dev/v1alpha1
 kind: Repository
 metadata:
+  name: hacbs-test
+spec:
+  url: "https://github.com/redhat-appstudio/hacbs-test"
+---
+apiVersion: pipelinesascode.tekton.dev/v1alpha1
+kind: Repository
+metadata:
   name: release-service
 spec:
   url: "https://github.com/redhat-appstudio/release-service"


### PR DESCRIPTION
Adding hacbs-test repo because of regular building of an image.