### PR TITLE
DO-NOT-MERGE: PLNSRVCE-1302: temporary direct override pac images to validate fixes

### DIFF
--- a/components/pipeline-service/development/kustomization.yaml
+++ b/components/pipeline-service/development/kustomization.yaml
@@ -12,6 +12,17 @@ resources:
   - git::https://github.com/openshift-pipelines/pipeline-service.git/developer/openshift/gitops/argocd/pipeline-service-storage?ref=12862f674f40f65cf94d48691e3fe1a2d3bf95a6
   - ../base/servicemonitors
 
+images:
+  - name: ghcr.io/openshift-pipelines/pipelines-as-code-controller
+    newName: registry.redhat.io/openshift-pipelines/pipelines-pipelines-as-code-rhel8
+    newTag: v1.10.4-1
+  - name: ghcr.io/openshift-pipelines/pipelines-as-code-watcher
+    newName: registry.redhat.io/openshift-pipelines/pipelines-pipelines-as-code-rhel8
+    newTag: v1.10.4-1
+  - name: ghcr.io/openshift-pipelines/pipelines-as-code-webhook
+    newName: registry.redhat.io/openshift-pipelines/pipelines-pipelines-as-code-rhel8
+    newTag: v1.10.4-1
+
 patches:
 #  - path: scale-down-exporter.yaml
 #    target:


### PR DESCRIPTION
Pulls in PaC fixes reported in https://issues.redhat.com/browse/SRVKP-3134 from out last attempt to upgrade to 0.17.x

This at least comes up for me clean with a locally provisioned RHTAP cluster.  I'll see about running e2e's locally if they start failing here.

Once we can get a passing e2e with PaC -.17.x here (currently 0.17.4), we will officially upgrade via https://github.com/openshift-pipelines/pipeline-service/pull/670 followed by a pipeline-service bump back here in infra-deployments

After that, we'll switch to the downstream version of 0.17.4, and then declare [PLNSRVCE-1302](https://issues.redhat.com//browse/PLNSRVCE-1302) complete

If we do not get passing e2e's because of PaC issues, I'll work with @chmouel to triage and address with additional PaC fixes, and then we will return back here and try with the next PaC version

@Roming22 @chmouel @Michkov 