### PR TITLE
chore(RHTAPWATCH-110): Add "label_app_kubernetes_io_managed_by" label to the monitoringstack

### DIFF
--- a/components/monitoring/prometheus/base/monitoringstack/monitoringstack.yaml
+++ b/components/monitoring/prometheus/base/monitoringstack/monitoringstack.yaml
@@ -48,7 +48,7 @@ spec:
           commit_hash|job|operation|tokenName|rateLimited|state|persistentvolumeclaim|\
           storageclass|volumename|release_reason|instance|result|deployment_reason|\
           validation_reason|strategy|succeeded|target|name|method|code|sp|\
-          unexpected_status|failure|hostname"
+          unexpected_status|failure|hostname|label_app_kubernetes_io_managed_by"
 ---
 # Grant permission to Federate In-Cluster Prometheus
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
* This is a part of chore([RHTAPWATCH-110](https://issues.redhat.com//browse/RHTAPWATCH-110)): Differ between uncategorized pipelines and deployments, adding "label_app_kubernetes_io_managed_by" label to the monitoringstack.