### PR TITLE
Fix Tekton Results servicemonitors scheme

### DIFF
--- a/components/pipeline-service/base/servicemonitors/tekton-results-service-monitor.yaml
+++ b/components/pipeline-service/base/servicemonitors/tekton-results-service-monitor.yaml
@@ -45,7 +45,7 @@ spec:
   endpoints:
   - path: /metrics
     port: prometheus
-    scheme: https
+    scheme: http
     bearerTokenSecret:
       name: "metrics-reader"
       key: token
@@ -64,7 +64,7 @@ spec:
   endpoints:
   - path: /metrics
     port: metrics
-    scheme: https
+    scheme: http
     bearerTokenSecret:
       name: "metrics-reader"
       key: token


### PR DESCRIPTION
Tekton results exports metrics over HTTP and not HTTPS. Changing that requires upstream update of code, which is not given will be accepted. As a fix here we change the scheme to HTTP.