### PR TITLE
PLNSRVCE-1310: bump pipeline service prod to vetted staging version

### DIFF
--- a/components/pipeline-service/production/base/kustomization.yaml
+++ b/components/pipeline-service/production/base/kustomization.yaml
@@ -8,7 +8,7 @@ commonAnnotations:
   argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 
 resources:
-  - git::https://github.com/openshift-pipelines/pipeline-service.git/operator/gitops/argocd/pipeline-service?ref=e9c5d3d54095f2c63990788e2f2e21f37a7540f7
+  - git::https://github.com/openshift-pipelines/pipeline-service.git/operator/gitops/argocd/pipeline-service?ref=12862f674f40f65cf94d48691e3fe1a2d3bf95a6
   - ../../base/external-secrets
   - ../../base/testing
 


### PR DESCRIPTION
- move prod to the version in staging we just vetted with https://github.com/redhat-appstudio/infra-deployments/pull/1948
- note as we just saw with staging, this bump in pipeline-service does not change the version of the core pipeline/task controllers; it will roll out metrics exporter because of the limit change, and the chains controller because the internal image registry CA were removed