### PR TITLE
RHTAPWATCH-322: Fluentd collectors are incompatible with Splunk ClusterLogForwarder configuration

### DIFF
--- a/components/monitoring/logging/base/configure-logging/configure-log-collectors.yaml
+++ b/components/monitoring/logging/base/configure-logging/configure-log-collectors.yaml
@@ -2,11 +2,12 @@
 apiVersion: "logging.openshift.io/v1"
 kind: "ClusterLogging"
 metadata:
-  annotations:
-    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
   name: "instance"
+  annotations:
+    logging.openshift.io/preview-vector-collector: enabled
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   collection:
     logs:
-      fluentd: {}
-      type: fluentd
+      type: vector
+      vector: {}


### PR DESCRIPTION
Fluentd collectors are incompatible with Splunk ClusterLogForwarder configuration.
    
As detailed in
https://docs.openshift.com/container-platform/4.13/logging/cluster-logging-external.html#logging-forward-splunk_cluster-logging-external
fluentd is not supported with the Splunk Log Forwarder configuration.
    
Therefore, this commit swaps fluentd with vector.
