### PR TITLE
Correctly set production overlay for remote-secret operator

### DIFF
--- a/argo-cd-apps/overlays/production/kustomization.yaml
+++ b/argo-cd-apps/overlays/production/kustomization.yaml
@@ -41,6 +41,11 @@ patches:
     target:
       kind: ApplicationSet
       version: v1alpha1
+      name: remote-secret-controller
+  - path: production-overlay-patch.yaml
+    target:
+      kind: ApplicationSet
+      version: v1alpha1
       name: dora-metrics
   - path: production-overlay-patch.yaml
     target:


### PR DESCRIPTION
- Correctly set production overlays for remote-secret.
- Without this override, it is fallback to `staging` overlay