### PR TITLE
Make PaC webhook SSL check configurable

### DIFF
--- a/components/build-service/development/kustomization.yaml
+++ b/components/build-service/development/kustomization.yaml
@@ -16,3 +16,9 @@ patches:
       kind: Deployment
       name: build-service-controller-manager
     path: image-expiration-patch.yaml
+  - target:
+      group: apps
+      version: v1
+      kind: Deployment
+      name: build-service-controller-manager
+    path: pac-webhook-insecure-ssl-patch.yaml

--- a/components/build-service/development/pac-webhook-insecure-ssl-patch.yaml
+++ b/components/build-service/development/pac-webhook-insecure-ssl-patch.yaml
@@ -1,0 +1,12 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: build-service-controller-manager
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager
+        env:
+          - name: PAC_WEBHOOK_INSECURE_SSL
+            value: "1"


### PR DESCRIPTION
Disables PaC webhhok TLS verification for dev mode in order to avoid creation of commonly trusted TLS certificates for dev clusters.