### PR TITLE
feat(HACBS-2310): add clusterrole for release pipelines

### DIFF
--- a/components/release/kustomization.yaml
+++ b/components/release/kustomization.yaml
@@ -2,6 +2,7 @@ resources:
 - allow-argocd-to-manage.yaml
 - argocd-permissions.yaml
 - https://github.com/redhat-appstudio/release-service/config/default?ref=bc67ba2f68c4719d059b3b295f1dfd7ba1571e36
+- release-pipeline-resources-clusterrole.yaml
 
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/components/release/release-pipeline-resources-clusterrole.yaml
+++ b/components/release/release-pipeline-resources-clusterrole.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: release-pipeline-resource-role
+rules:
+- apiGroups:
+  - appstudio.redhat.com
+  resources:
+  - releases
+  - releaseplans
+  - releaseplanadmissions
+  - releasestrategies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - appstudio.redhat.com
+  resources:
+  - internalrequests
+  verbs:
+  - create
+  - get
+  - list
+  - watch


### PR DESCRIPTION
Release PipelineRuns need access to Custom Resources in dev and managed namespaces. This commit adds a ClusterRole to provide those permissions. We can then create RoleBindings in the namespaces we need to pull from so that the pipelineruns can access the resources.