### PR TITLE
fix: remove unneeded metrics from federation

### DIFF
--- a/components/monitoring/prometheus/base/monitoringstack/monitoringstack.yaml
+++ b/components/monitoring/prometheus/base/monitoringstack/monitoringstack.yaml
@@ -86,10 +86,6 @@ spec:
   endpoints:
   - params:
       'match[]': # scrape only required metrics from in-cluster prometheus
-        - '{__name__="container_network_transmit_bytes_total", namespace!~".*-tenant|openshift-.*|kube-.*"}'
-        - '{__name__=~"kube_pod_.*container_resource_limits", namespace!~".*-tenant|openshift-.*|kube-.*"}'
-        - '{__name__="kube_pod_labels", namespace!~".*-tenant|openshift-.*|kube-.*"}'
-        - '{__name__="container_last_seen", namespace!~".*-tenant|openshift-.*|kube-.*"}'
         - '{__name__="argocd_app_info", namespace!~".*-tenant|openshift-.*|kube-.*"}'
         - '{__name__="controller_runtime_reconcile_errors_total", namespace!~".*-tenant|openshift-.*|kube-.*"}'
         - '{__name__="controller_runtime_reconcile_total", namespace!~".*-tenant|openshift-.*|kube-.*"}'


### PR DESCRIPTION
Several metrics were included inside the service monitor for federating the platform Prometheus instance, which are meant to be used for billing-related recording rules.

It's uncertain at the moment whether those metrics are going to be used in this context (i.e. processed to rules in RHOBS), but in any case, the way that they are currently being scraped is excluding tenants namespaces, which means we're needlessly sending metrics from unrelated namespaces to RHOBS.

This change remove those metrics from the list of metrics to be federated.