### PR TITLE
PLNSRVCE-1326: switch tekton pipeline controller to larger scale settings in dev/stage

### DIFF
--- a/components/pipeline-service/development/update-tekton-config-performance.yaml
+++ b/components/pipeline-service/development/update-tekton-config-performance.yaml
@@ -2,18 +2,18 @@
 - op: replace
   path: /spec/pipeline/performance/threads-per-controller
   # default upstream setting
-  value: 2
+  # value: 2
   # upstream large scale env recommendation
-  # value: 32
+  value: 32
 - op: replace
   path: /spec/pipeline/performance/kube-api-qps
   # default upstream setting
-  value: 5.0
+  #value: 5.0
   # upstream large scale env recommendation
-  # value: 50
+  value: 50
 - op: replace
   path: /spec/pipeline/performance/kube-api-burst
   # default upstream setting
-  value: 10
+  # value: 10
   # upstream large scale env recommendation
-  # value: 50
+  value: 50

--- a/components/pipeline-service/staging/base/update-tekton-config-performance.yaml
+++ b/components/pipeline-service/staging/base/update-tekton-config-performance.yaml
@@ -2,18 +2,18 @@
 - op: replace
   path: /spec/pipeline/performance/threads-per-controller
   # default upstream setting
-  value: 2
+  # value: 2
   # upstream large scale env recommendation
-  # value: 32
+  value: 32
 - op: replace
   path: /spec/pipeline/performance/kube-api-qps
   # default upstream setting
-  value: 5.0
+  # value: 5.0
   # upstream large scale env recommendation
-  # value: 50
+  value: 50
 - op: replace
   path: /spec/pipeline/performance/kube-api-burst
   # default upstream setting
-  value: 10
+  #value: 10
   # upstream large scale env recommendation
-  # value: 50
+  value: 50


### PR DESCRIPTION
Based on findings in https://issues.redhat.com/browse/RHTAP-979 and confirmation in slack https://redhat-internal.slack.com/archives/C02CTEB3MMF/p1687355774619199 with @pmacik and @jhutar we are switching to the larger scale tekton pipeline controller settings

Following the standard bump dev/staging first, then when confirmed staging looks OK, bump to prod.

Note, as of this comment
- tekton-pipelines-controller in stg-rh01 is at around 50 MiB of memory, around 2m of cpu, and around 400 KiB of FS
- in stg-multi tenant, we are at around 400 MiB memory, anywhere from 10m to 45m cpu, and 12 MiB FS

@Roming22 @adambkaplan FYI