### PR TITLE
chore(RHTAPWATCH-327): offboard o11y prometheus rules

### DIFF
--- a/components/o11y/base/kustomization.yaml
+++ b/components/o11y/base/kustomization.yaml
@@ -3,5 +3,4 @@ kind: Kustomization
 commonLabels:
   openshift.io/workload-monitoring: "true"
 
-resources:
-- https://github.com/redhat-appstudio/o11y/prometheus/base?ref=1eaa7b2080cdb39db231dad30cf8d7135ac22207
+resources: []


### PR DESCRIPTION
The Prometheus rules coming from the o11y repo should not be deployed to RHTAP using argoCD. Instead, they are to be deployed using app-interface.

Later on we might want to offboard the o11y component altogether