### PR TITLE
PLNSRVCE-1326: switch tekton pipeline controller to larger scale settings in prod

### DIFF
--- a/components/pipeline-service/production/base/update-tekton-config-performance.yaml
+++ b/components/pipeline-service/production/base/update-tekton-config-performance.yaml
@@ -2,18 +2,18 @@
 - op: replace
   path: /spec/pipeline/performance/threads-per-controller
   # default upstream setting
-  value: 2
+  # value: 2
   # upstream large scale env recommendation
-  # value: 32
+  value: 32
 - op: replace
   path: /spec/pipeline/performance/kube-api-qps
   # default upstream setting
-  value: 5.0
+  # value: 5.0
   # upstream large scale env recommendation
-  # value: 50
+  value: 50
 - op: replace
   path: /spec/pipeline/performance/kube-api-burst
   # default upstream setting
-  value: 10
+  # value: 10
   # upstream large scale env recommendation
-  # value: 50
+  value: 50


### PR DESCRIPTION
staging has looked good since https://github.com/redhat-appstudio/infra-deployments/pull/1991 merged yesterday

No restarts.

cpu/mem/fs either the same on slightly less impactful both rh and multi stagings

promoting the changes to prod

@jhutar @pmacik FYI