### PR TITLE
PLNSRVCE-1124-Move CI to StoneSoup Prod MVP

### DIFF
--- a/components/tekton-ci/base/repository.yaml
+++ b/components/tekton-ci/base/repository.yaml
@@ -180,3 +180,10 @@ metadata:
   name: remote-secrets
 spec:
   url: "https://github.com/redhat-appstudio/remote-secret"
+---
+apiVersion: pipelinesascode.tekton.dev/v1alpha1
+kind: Repository
+metadata:
+  name: pipeline-service
+spec:
+  url: "https://github.com/openshift-pipelines/pipeline-service"

--- a/components/tekton-ci/production/kustomization.yaml
+++ b/components/tekton-ci/production/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
 - ../base
 - ../base/external-secrets
+- plnsvc-ci-secret.yaml
 
 patches:
   - path: tekton-ci-push-secret.yaml

--- a/components/tekton-ci/production/plnsvc-ci-secret.yaml
+++ b/components/tekton-ci/production/plnsvc-ci-secret.yaml
@@ -1,0 +1,19 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: plnsvc-ci-secret
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  dataFrom:
+    - extract:
+        key: production/pipeline-service/plnsvc-ci
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: appsre-stonesoup-vault
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    name: plnsvc-ci-secret


### PR DESCRIPTION
This PR is to move Pipeline Service CI to RHTAP production
1. Added Pipeline Service Repository CR
2. Created an ExternalSecret for use of Pipeline Service CI