### PR TITLE
PLNSRVCE-1069: remove servicemonitor definition that is not currently being processed

### DIFF
--- a/components/monitoring/prometheus/base/servicemonitors/pipeline-service.yaml
+++ b/components/monitoring/prometheus/base/servicemonitors/pipeline-service.yaml
@@ -27,18 +27,3 @@ subjects:
   - kind: ServiceAccount
     name: pipeline-service-metrics-reader-sa
     namespace: openshift-pipelines
----
-apiVersion: monitoring.coreos.com/v1
-kind: ServiceMonitor
-metadata:
-  name: pipeline-service
-  namespace: openshift-pipelines
-spec:
-  endpoints:
-    - path: /metrics
-      port: metrics
-      interval: 15s
-      scheme: http
-  selector:
-    matchLabels:
-      app: pipeline-metrics-exporter


### PR DESCRIPTION
Per conversation with @amisstea , as this folder is not being processed (he indicated there were some errors in sibling folders), removing the exporter service monitor from infra-deployments, and we'll define in pipeline-service repo, as other components are doing.

https://github.com/openshift-pipelines/pipeline-service/pull/685 is adding to pipeline-service

I am leaving the SA and RBAC definitions for now, in case this subfolder gets reactivated, and those artifacts become useful again.

@adambkaplan @ramessesii2 