### PR TITLE
bump pipeline service in dev/staging

### DIFF
--- a/components/monitoring/grafana/base/pipeline-service/kustomization.yaml
+++ b/components/monitoring/grafana/base/pipeline-service/kustomization.yaml
@@ -2,4 +2,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - https://github.com/openshift-pipelines/pipeline-service/operator/gitops/argocd/grafana/?ref=44618872ef2b481e3c5e7d1e373f1d4b5eebe811
+  - https://github.com/openshift-pipelines/pipeline-service/operator/gitops/argocd/grafana/?ref=0b50c94147059c992b78363ba050187f1f8ba06f

--- a/components/pipeline-service/development/kustomization.yaml
+++ b/components/pipeline-service/development/kustomization.yaml
@@ -8,8 +8,8 @@ commonAnnotations:
   argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 
 resources:
-  - git::https://github.com/openshift-pipelines/pipeline-service.git/developer/openshift/gitops/argocd/pipeline-service?ref=12862f674f40f65cf94d48691e3fe1a2d3bf95a6
-  - git::https://github.com/openshift-pipelines/pipeline-service.git/developer/openshift/gitops/argocd/pipeline-service-storage?ref=12862f674f40f65cf94d48691e3fe1a2d3bf95a6
+  - git::https://github.com/openshift-pipelines/pipeline-service.git/developer/openshift/gitops/argocd/pipeline-service?ref=0b50c94147059c992b78363ba050187f1f8ba06f
+  - git::https://github.com/openshift-pipelines/pipeline-service.git/developer/openshift/gitops/argocd/pipeline-service-storage?ref=0b50c94147059c992b78363ba050187f1f8ba06f
   - ../base/servicemonitors
 
 patches:

--- a/components/pipeline-service/staging/base/kustomization.yaml
+++ b/components/pipeline-service/staging/base/kustomization.yaml
@@ -8,7 +8,7 @@ commonAnnotations:
   argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 
 resources:
-  - git::https://github.com/openshift-pipelines/pipeline-service.git/operator/gitops/argocd/pipeline-service?ref=12862f674f40f65cf94d48691e3fe1a2d3bf95a6
+  - git::https://github.com/openshift-pipelines/pipeline-service.git/operator/gitops/argocd/pipeline-service?ref=0b50c94147059c992b78363ba050187f1f8ba06f
   - ../../base/external-secrets
   - ../../base/testing
   - ../../base/servicemonitors


### PR DESCRIPTION
Since 12862f674f40f65cf94d48691e3fe1a2d3bf95a6 we have
- added Grafana charts for pipeline controller resources
- define the exporter servicemonitor in pipeline-service repo
- various CI related changes which do no impact dev/stage/prod
- we are also bumping the charting ref in addition to the main pipeline-service refs