### PR TITLE
bump pipeline service in prod

### DIFF
--- a/components/pipeline-service/production/base/kustomization.yaml
+++ b/components/pipeline-service/production/base/kustomization.yaml
@@ -8,7 +8,7 @@ commonAnnotations:
   argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 
 resources:
-  - git::https://github.com/openshift-pipelines/pipeline-service.git/operator/gitops/argocd/pipeline-service?ref=12862f674f40f65cf94d48691e3fe1a2d3bf95a6
+  - git::https://github.com/openshift-pipelines/pipeline-service.git/operator/gitops/argocd/pipeline-service?ref=0b50c94147059c992b78363ba050187f1f8ba06f
   - ../../base/external-secrets
   - ../../base/testing
   - ../../base/servicemonitors


### PR DESCRIPTION
Pull in the https://github.com/redhat-appstudio/infra-deployments/pull/2015 changes to dev/staging into production.  Note:  the https://github.com/redhat-appstudio/infra-deployments/pull/2015/files#diff-d99d1444c5e672b40e18d7e3637b32e4722598a1e086575e084da610d3455dc5 change from the prior PR should already be available in prod.

Examination of stage looks good after about 18 hours.

Reminder - any e2e results do not stem from this change, as we are only changing prod, and the e2e's work off dev (vs. stage or prod)