### PR TITLE
bump pipeline service in dev/stage

### DIFF
--- a/components/monitoring/grafana/base/pipeline-service/kustomization.yaml
+++ b/components/monitoring/grafana/base/pipeline-service/kustomization.yaml
@@ -2,4 +2,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - https://github.com/openshift-pipelines/pipeline-service/operator/gitops/argocd/grafana/?ref=0b50c94147059c992b78363ba050187f1f8ba06f
+  - https://github.com/openshift-pipelines/pipeline-service/operator/gitops/argocd/grafana/?ref=11ccced9edec7c657d8f191e93606f0ab83279e6

--- a/components/pipeline-service/development/kustomization.yaml
+++ b/components/pipeline-service/development/kustomization.yaml
@@ -8,8 +8,8 @@ commonAnnotations:
   argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 
 resources:
-  - git::https://github.com/openshift-pipelines/pipeline-service.git/developer/openshift/gitops/argocd/pipeline-service?ref=0b50c94147059c992b78363ba050187f1f8ba06f
-  - git::https://github.com/openshift-pipelines/pipeline-service.git/developer/openshift/gitops/argocd/pipeline-service-storage?ref=0b50c94147059c992b78363ba050187f1f8ba06f
+  - git::https://github.com/openshift-pipelines/pipeline-service.git/developer/openshift/gitops/argocd/pipeline-service?ref=11ccced9edec7c657d8f191e93606f0ab83279e6
+  - git::https://github.com/openshift-pipelines/pipeline-service.git/developer/openshift/gitops/argocd/pipeline-service-storage?ref=11ccced9edec7c657d8f191e93606f0ab83279e6
   - ../base/servicemonitors
 
 patches:

--- a/components/pipeline-service/staging/base/kustomization.yaml
+++ b/components/pipeline-service/staging/base/kustomization.yaml
@@ -8,7 +8,7 @@ commonAnnotations:
   argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 
 resources:
-  - git::https://github.com/openshift-pipelines/pipeline-service.git/operator/gitops/argocd/pipeline-service?ref=0b50c94147059c992b78363ba050187f1f8ba06f
+  - git::https://github.com/openshift-pipelines/pipeline-service.git/operator/gitops/argocd/pipeline-service?ref=11ccced9edec7c657d8f191e93606f0ab83279e6
   - ../../base/external-secrets
   - ../../base/testing
   - ../../base/servicemonitors


### PR DESCRIPTION
Pull in the exporter pivot to controller based collection, and removal of the duplicate (with upstream) completion duration historgram.