### PR TITLE
Enable remote secret on prod for SPI controller

### DIFF
--- a/components/spi/overlays/production/base/config-patch.json
+++ b/components/spi/overlays/production/base/config-patch.json
@@ -1,0 +1,7 @@
+[
+  {
+    "op": "add",
+    "path": "/data/ENABLEREMOTESECRETS",
+    "value": "true"
+  }
+]

--- a/components/spi/overlays/production/base/kustomization.yaml
+++ b/components/spi/overlays/production/base/kustomization.yaml
@@ -21,4 +21,8 @@ patches:
       kind: Deployment
       name: spi-controller-manager
     path: operator-limits-patch.json
+  - target:
+      kind: ConfigMap
+      name: shared-environment-config
+    path: config-patch.json
   - path: delete-shared-configuration-file.yaml


### PR DESCRIPTION
- ENABLEREMOTESECRETS - default false
- Enable RemoteSecret on RHTAP production | https://issues.redhat.com/browse/SVPI-519
- Announced https://redhat-internal.slack.com/archives/C02CTEB3MMF/p1687861065175639