### PR TITLE
remove CI config for external-secrets

### DIFF
--- a/components/tekton-ci/base/repository.yaml
+++ b/components/tekton-ci/base/repository.yaml
@@ -170,13 +170,6 @@ spec:
 apiVersion: pipelinesascode.tekton.dev/v1alpha1
 kind: Repository
 metadata:
-  name: external-secrets
-spec:
-  url: "https://github.com/redhat-appstudio/external-secrets"
----
-apiVersion: pipelinesascode.tekton.dev/v1alpha1
-kind: Repository
-metadata:
   name: remote-secrets
 spec:
   url: "https://github.com/redhat-appstudio/remote-secret"


### PR DESCRIPTION
This isn't in use yet. This will be replaced by https://docs.google.com/document/d/1oTtgDr7caQzTY7qzXH1UUYdk9EV4MqCT22gxwUaM_1Y/edit#heading=h.orkzaa7nxhu0