### PR TITLE
Remove generatorOptions from dashboard configmap gen

### DIFF
--- a/components/monitoring/grafana/base/managed-gitops/kustomization.yaml
+++ b/components/monitoring/grafana/base/managed-gitops/kustomization.yaml
@@ -1,5 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- https://github.com/redhat-appstudio/managed-gitops/manifests/base/monitoring/grafana-dashboards-new?ref=b432c75256a43e308eea3f74e6ff88e1809cbc50
+- https://github.com/redhat-appstudio/managed-gitops/manifests/base/monitoring/grafana-dashboards-new?ref=23253fe449172c7907da9675d6c42bcd670c907e
 - dashboard.yaml


### PR DESCRIPTION
Remove disableNameSuffixHash, as recommended as a solution to the lack of dashboard refresh that was mentioned on https://github.com/redhat-appstudio/application-service/pull/318/files

JIRA: https://issues.redhat.com/browse/GITOPSRVCE-563