### PR TITLE
Remove unused ec configmap keys

### DIFF
--- a/components/enterprise-contract/kustomization.yaml
+++ b/components/enterprise-contract/kustomization.yaml
@@ -12,8 +12,6 @@ configMapGenerator:
     namespace: enterprise-contract-service
     literals:
       - verify_ec_task_bundle=quay.io/hacbs-contract/ec-task-bundle:dcb40bd5c0bfacae659ff504f1249145f49d9633@sha256:6db94f2439398833126a2f8b384d66428075e4c53615e56ee969b464bd81f593
-      - ec_policy_source=oci::https://quay.io/hacbs-contract/ec-release-policy:git-8ca675b@sha256:caf2a8991ca3feb80edfc8ff7c1930ed09481a7c8d934bb719007bffc1153ecc
-      - ec_data_source=oci::https://quay.io/hacbs-contract/ec-policy-data:git-a3ca9be@sha256:d548e0808348c017782ae87920c94d45ad7117e0e630b5b991c8df557c22a844
 images:
   - name: quay.io/redhat-appstudio/enterprise-contract-controller
     newName: quay.io/redhat-appstudio/enterprise-contract-controller


### PR DESCRIPTION
The ec-defaults ConfigMap in the enterprise-contract-service namespace contains values for which policy and data refs to use when creating a new EnterpriseContractPolicy resource. However, we have moved away from using this ConfigMap for this purpose. Although the values still exist, they are no longer updated by automation.

The automation now keeps a few EnterpriseContractPolicy resources up to date. This commit removes the values from the ConfigMap in order to avoid confusion.

NOTE: The ConfigMap is still useful for determining the most up to date ref for the ec Tekton Task. There are no plans to change this.

https://issues.redhat.com/browse/HACBS-2315