### PR TITLE
fix(RHTAPWATCH-356): obo conflicts when using OSD on AWS

### DIFF
--- a/components/monitoring/prometheus/README.md
+++ b/components/monitoring/prometheus/README.md
@@ -112,5 +112,9 @@ remote-writes selected labels for those metrics to RHOBS, which in turn, makes t
 metrics accessible to AppSRE Grafana.
 
 This Prometheus instance is deployed using a MonitoringStack custom resource provided
-by the Observability Operator. This operator is installed by default in Production and
-Staging clusters. In Development clusters, it's installed and configured using ArgoCD.
+by the Observability Operator. This operator is installed by default in Production and Staging clusters.  
+In Development clusters, it's not installed by default to prevent conflicts with other deployments. 
+It can be installed and configured in development by using the `--obo/-o` flags.  
+For example:  
+`./hack/bootstrap-cluster.sh preview --obo`  
+`./hack/bootstrap-cluster.sh preview -o`

--- a/components/monitoring/prometheus/development/kustomization.yaml
+++ b/components/monitoring/prometheus/development/kustomization.yaml
@@ -5,7 +5,6 @@ resources:
 - dummy-service-namespace.yaml
 - dummy-service-service-monitor.yaml
 - dummy-service.yaml
-- monitoringstack/
 
 commonAnnotations:
   argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true

--- a/hack/bootstrap-cluster.sh
+++ b/hack/bootstrap-cluster.sh
@@ -3,7 +3,7 @@
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"/..
 
 main() {
-    local mode keycloak toolchain
+    local mode keycloak toolchain obo
     while [[ $# -gt 0 ]]; do
         key=$1
         case $key in
@@ -13,6 +13,10 @@ main() {
             ;;
         --keycloak | -kc)
             keycloak="--keycloak"
+            shift
+            ;;
+        --obo | -o)
+            obo="--obo"
             shift
             ;;
         preview | upstream)
@@ -52,19 +56,20 @@ main() {
         fi
         ;;
     "preview")
-        $ROOT/hack/preview.sh $toolchain $keycloak
+        $ROOT/hack/preview.sh $toolchain $keycloak $obo
         ;;
     esac
 }
 
 print_help() {
-    echo "Usae: $0 MODE [-t|--toolchain] [-kc|--keycloak] [-h|--help]"
+    echo "Usae: $0 MODE [-t|--toolchain] [-kc|--keycloak] [-o|--obo] [-h|--help]"
     echo "  MODE             upstream/preview (default: upstream)"
     echo "  -t, --toolchain  (only in preview mode) Install toolchain operators"
     echo "  -kc, --keycloak  (only in preview mode) Configure the toolchain operator to use keycloak deployed on the cluster"
+    echo "  -o, --obo        (only in preview mode) Install Observability operator and Prometheus instance for federation"
     echo "  -h, --help       Show this help message and exit"
     echo
-    echo "Example usage: \`$0 preview --toolchain --keycloak"
+    echo "Example usage: \`$0 preview --toolchain --keycloak --obo"
 }
 
 if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then


### PR DESCRIPTION
- OBO (Observability operator) is not deployed by default
- Adding --obo/-o to enable obo deployment in development environment

Examples:   
`./hack/bootstrap-cluster.sh preview --obo`
`./hack/bootstrap-cluster.sh preview -o`