### PR TITLE
Fix components kustomization files

### DIFF
--- a/components/image-controller/base/kustomization.yaml
+++ b/components/image-controller/base/kustomization.yaml
@@ -10,8 +10,8 @@ images:
 namespace: image-controller
 
 patches:
-  - ./manager_resources_patch.yaml
-  
+  - path: ./manager_resources_patch.yaml
+
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 

--- a/components/integration/kustomization.yaml
+++ b/components/integration/kustomization.yaml
@@ -14,4 +14,4 @@ images:
 namespace: integration-service
 
 patches:
-  - ./manager_resources_patch.yaml
+  - path: ./manager_resources_patch.yaml

--- a/components/release/kustomization.yaml
+++ b/components/release/kustomization.yaml
@@ -15,4 +15,4 @@ images:
 namespace: release-service
 
 patches:
-  - ./manager_resources_patch.yaml
+  - path: ./manager_resources_patch.yaml


### PR DESCRIPTION
The `preview.sh` script throws an error when it comes to executing `kustomize build` for the following projects:
- `components/image-controller`
- `components/integration`
- `components/release`

The error seems related to the Patches field in the `kustomization.yaml` files:
```
ERROR='[{"lastTransitionTime":"2023-07-03T09:22:48Z","message":"rpc error: code = Unknown desc = `kustomize build .components/image-controller/development` failed exit status 1: Error: accumulating resources: accumulation err='\''accumulating resources from '\''../base'\'': '\''.components/image-controller/base'\'' must resolve to a file'\'': couldn'\''t make target for path '\''.components/image-controller/base'\'': invalid Kustomization: json: cannot unmarshal string into Go struct field Kustomization.patches of type types.Patch","type":"ComparisonError"}]'
```
The ArgoCD actually used (v2.7.2+cbee7e6) should be leveraging on kustomize 5.0.1.

I replicated the problem locally with the following `kustomize` versions:
- 4.5.7
- 5.0.1
- 5.1.0

To replicate the bug just use `kustomize build components/image-controller` with of the aforementioned kustomize version.