### PR TITLE
SVPI-518: split vault-init into vault-init, spi-init, and remote-secret-init scripts

### DIFF
--- a/hack/preview.sh
+++ b/hack/preview.sh
@@ -167,7 +167,7 @@ rm $TMP_FILE
 
 $ROOT/hack/util-set-github-org $MY_GITHUB_ORG
 
-domain=$(kubectl get ingresses.config.openshift.io cluster --template={{.spec.domain}})
+domain=$(oc get ingresses.config.openshift.io cluster --template={{.spec.domain}})
 
 rekor_server="rekor.$domain"
 sed -i.bak "s/rekor-server.enterprise-contract-service.svc/$rekor_server/" $ROOT/argo-cd-apps/base/member/optional/helm/rekor/rekor.yaml && rm $ROOT/argo-cd-apps/base/member/optional/helm/rekor/rekor.yaml.bak
@@ -216,51 +216,22 @@ while [ "$(oc get applications.argoproj.io all-application-sets -n openshift-git
   sleep 5
 done
 
-if ! timeout 100s bash -c "while ! kubectl get applications.argoproj.io -n openshift-gitops -o name | grep -q spi-in-cluster-local; do printf '.'; sleep 5; done"; then
-  printf "Application spi-in-cluster-local not found (timeout)\n" 
-  kubectl get apps -n openshift-gitops -o name
-  exit 1
-else
-  if [ "$(oc get applications.argoproj.io spi-in-cluster-local -n openshift-gitops -o jsonpath='{.status.health.status} {.status.sync.status}')" != "Healthy Synced" ]; then
-    echo Initializing SPI
-    curl https://raw.githubusercontent.com/redhat-appstudio/service-provider-integration-operator/main/hack/vault-init.sh | VAULT_PODNAME='vault-0' VAULT_NAMESPACE='spi-vault' bash -s
-    SPI_APP_ROLE_FILE=$ROOT/.tmp/approle_secret.yaml
-    if [ -f "$SPI_APP_ROLE_FILE" ]; then
-        echo "$SPI_APP_ROLE_FILE exists."
-        kubectl apply -f $SPI_APP_ROLE_FILE  -n spi-system
-    fi
-    echo "Vault init complete"
-  else
-     echo "Vault initialization skipped"
-  fi
-fi
+# Init Vault
+$ROOT/hack/spi/vault-init.sh
 
-if ! timeout 300s bash -c "while ! kubectl get applications.argoproj.io -n openshift-gitops -o name | grep -q remote-secret-controller-in-cluster-local; do printf '.'; sleep 5; done"; then
-  printf "Application remote-secret-controller-in-cluster-local not found (timeout)\n"
-  kubectl get apps -n openshift-gitops -o name
-  exit 1
-else
-  if [ "$(oc get applications.argoproj.io  remote-secret-controller-in-cluster-local -n openshift-gitops -o jsonpath='{.status.health.status} {.status.sync.status}')" != "Healthy Synced" ]; then
-    echo Initializing remote secret controller
-    REMOTE_SECRET_APP_ROLE_FILE=$ROOT/.tmp/approle_remote_secret.yaml
-    if [ ! -f "$REMOTE_SECRET_APP_ROLE_FILE" ]; then
-      curl https://raw.githubusercontent.com/redhat-appstudio/service-provider-integration-operator/main/hack/vault-init.sh | VAULT_PODNAME='vault-0' VAULT_NAMESPACE='spi-vault' bash -s
-    fi
-    kubectl apply -f $REMOTE_SECRET_APP_ROLE_FILE  -n remotesecret
-    echo "Vault init complete for remote secret controller"
-  else
-     echo "Vault initialization skipped for remote secret controller"
-  fi
-fi
+# Init SPI
+$ROOT/hack/spi/spi-init.sh
 
+# Init Remote Secret
+$ROOT/hack/spi/remote-secret-init.sh
 
 # Configure Pipelines as Code and required credentials
 $ROOT/hack/build/setup-pac-integration.sh
 
-APPS=$(kubectl get apps -n openshift-gitops -o name)
+APPS=$(oc get apps -n openshift-gitops -o name)
 # trigger refresh of apps
 for APP in $APPS; do
-  kubectl patch $APP -n openshift-gitops --type merge -p='{"metadata": {"annotations":{"argocd.argoproj.io/refresh": "hard"}}}' &
+  oc patch $APP -n openshift-gitops --type merge -p='{"metadata": {"annotations":{"argocd.argoproj.io/refresh": "hard"}}}' &
 done
 wait
 
@@ -271,7 +242,7 @@ done
 
 INTERVAL=10
 while :; do
-  STATE=$(kubectl get apps -n openshift-gitops --no-headers)
+  STATE=$(oc get apps -n openshift-gitops --no-headers)
   NOT_DONE=$(echo "$STATE" | grep -v "Synced[[:blank:]]*Healthy" || true)
   echo "$NOT_DONE"
   if [ -z "$NOT_DONE" ]; then
@@ -284,7 +255,7 @@ while :; do
          ERROR=$(oc get -n openshift-gitops applications.argoproj.io $app -o jsonpath='{.status.conditions}')
          if echo "$ERROR" | grep -q 'context deadline exceeded'; then
            echo Refreshing $app
-           kubectl patch applications.argoproj.io $app -n openshift-gitops --type merge -p='{"metadata": {"annotations":{"argocd.argoproj.io/refresh": "soft"}}}'
+           oc patch applications.argoproj.io $app -n openshift-gitops --type merge -p='{"metadata": {"annotations":{"argocd.argoproj.io/refresh": "soft"}}}'
            while [ -n "$(oc get applications.argoproj.io -n openshift-gitops $app -o jsonpath='{.metadata.annotations.argocd\.argoproj\.io/refresh}')" ]; do
              sleep 5
            done

--- a/hack/spi/remote-secret-init.sh
+++ b/hack/spi/remote-secret-init.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+# !!! Note that this script should not be used for production purposes !!!
+
+source $(dirname "$0")/utils.sh
+
+REMOTE_SECRET_APP_ROLE_FILE="$(realpath .tmp)/approle_remote_secret.yaml"
+
+function auth() {
+	if ! vaultExec "vault auth list | grep -q approle"; then
+		echo "setup approle authentication ..."
+		vaultExec "vault auth enable approle"
+	fi
+
+	mkdir -p .tmp
+
+	echo '' > ${REMOTE_SECRET_APP_ROLE_FILE}
+	approleSet remote-secret-operator ${REMOTE_SECRET_APP_ROLE_FILE}
+
+	echo "secret yaml with Vault credentials prepared"
+}
+
+function approleAuthRemoteSecret() {
+	login
+	audit
+	auth
+}
+
+if ! timeout 300s bash -c "while ! oc get applications.argoproj.io -n openshift-gitops -o name | grep -q remote-secret-controller-in-cluster-local; do printf '.'; sleep 5; done"; then
+	printf "Application remote-secret-controller-in-cluster-local not found (timeout)\n"
+	oc get apps -n openshift-gitops -o name
+	exit 1
+else
+	if [ "$(oc get applications.argoproj.io remote-secret-controller-in-cluster-local -n openshift-gitops -o jsonpath='{.status.health.status} {.status.sync.status}')" != "Healthy Synced" ]; then
+		echo "Initializing remote secret controller"
+		approleAuthRemoteSecret
+		restart
+		oc apply -f $REMOTE_SECRET_APP_ROLE_FILE -n remotesecret
+		echo "Remote secret controller initialization was completed"
+	else
+		echo "Remote secret controller initialization was skipped"
+	fi
+fi

--- a/hack/spi/spi-init.sh
+++ b/hack/spi/spi-init.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+
+# !!! Note that this script should not be used for production purposes !!!
+
+source $(dirname "$0")/utils.sh
+
+SPI_DATA_PATH_PREFIX=${SPI_DATA_PATH_PREFIX:-spi}
+SPI_POLICY_NAME=${SPI_DATA_PATH_PREFIX//\//-}
+SPI_APP_ROLE_FILE="$(realpath .tmp)/approle_secret.yaml"
+
+function k8sAuth() {
+	if ! vaultExec "vault auth list | grep -q kubernetes"; then
+		echo "setup kubernetes authentication ..."
+		vaultExec "vault auth enable kubernetes"
+	fi
+	vaultExec "vault write auth/kubernetes/role/spi-controller-manager \
+        bound_service_account_names=spi-controller-manager \
+        bound_service_account_namespaces=spi-system \
+        policies=${SPI_POLICY_NAME}"
+	vaultExec "vault write auth/kubernetes/role/spi-oauth \
+          bound_service_account_names=spi-oauth-sa \
+          bound_service_account_namespaces=spi-system \
+          policies=${SPI_POLICY_NAME}"
+	# shellcheck disable=SC2016
+	vaultExec 'vault write auth/kubernetes/config \
+        kubernetes_host=https://$KUBERNETES_SERVICE_HOST:$KUBERNETES_SERVICE_PORT'
+}
+
+function approleAuth() {
+	if ! vaultExec "vault auth list | grep -q approle"; then
+		echo "setup approle authentication ..."
+		vaultExec "vault auth enable approle"
+	fi
+
+	mkdir -p .tmp
+
+	echo '' > ${SPI_APP_ROLE_FILE}
+	approleSet spi-operator ${SPI_APP_ROLE_FILE}
+	approleSet spi-oauth ${SPI_APP_ROLE_FILE}
+
+	echo "secret yaml with Vault credentials prepared"
+}
+
+function auth() {
+	k8sAuth
+	approleAuth
+}
+
+function approleAuthSPI() {
+	login
+	audit
+	auth
+}
+
+if ! timeout 100s bash -c "while ! oc get applications.argoproj.io -n openshift-gitops -o name | grep -q spi-in-cluster-local; do printf '.'; sleep 5; done"; then
+	printf "Application spi-in-cluster-local not found (timeout)\n"
+	oc get apps -n openshift-gitops -o name
+	exit 1
+else
+	if [ "$(oc get applications.argoproj.io spi-in-cluster-local -n openshift-gitops -o jsonpath='{.status.health.status} {.status.sync.status}')" != "Healthy Synced" ]; then
+		echo "Initializing SPI"
+		approleAuthSPI
+		oc apply -f $SPI_APP_ROLE_FILE -n spi-system
+		echo "SPI initialization was completed"
+	else
+		echo "SPI initialization was skipped"
+	fi
+fi

--- a/hack/spi/utils.sh
+++ b/hack/spi/utils.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+SPI_DATA_PATH_PREFIX=${SPI_DATA_PATH_PREFIX:-spi}
+SPI_POLICY_NAME=${SPI_DATA_PATH_PREFIX//\//-}
+VAULT_KUBE_CONFIG=${VAULT_KUBE_CONFIG:-${KUBECONFIG:-$HOME/.kube/config}}
+VAULT_NAMESPACE=${VAULT_NAMESPACE:-spi-vault}
+VAULT_PODNAME=${VAULT_PODNAME:-vault-0}
+ROOT_TOKEN_NAME=vault-root-token
+
+function login() {
+	ROOT_TOKEN=$(oc --kubeconfig=${VAULT_KUBE_CONFIG} get secret ${ROOT_TOKEN_NAME} -n ${VAULT_NAMESPACE} -o jsonpath="{.data.root_token}" | base64 --decode)
+	vaultExec "vault login ${ROOT_TOKEN} > /dev/null"
+}
+
+function audit() {
+	if ! vaultExec "vault audit list | grep -q file"; then
+		echo "enabling audit log ..."
+		vaultExec "vault audit enable file file_path=stdout"
+	fi
+}
+
+function vaultExec() {
+	COMMAND=${1}
+	oc --kubeconfig=${VAULT_KUBE_CONFIG} exec ${VAULT_PODNAME} -n ${VAULT_NAMESPACE} -- sh -c "${COMMAND}" 2>/dev/null
+}
+
+function approleSet() {
+	vaultExec "vault write auth/approle/role/${1} token_policies=${SPI_POLICY_NAME}"
+	ROLE_ID=$(vaultExec "vault read auth/approle/role/${1}/role-id --format=json" | jq -r '.data.role_id')
+	SECRET_ID=$(vaultExec "vault write -force auth/approle/role/${1}/secret-id --format=json" | jq -r '.data.secret_id')
+	APP_ROLE_FILE=${2}
+	echo "---" >>${APP_ROLE_FILE}
+	oc --kubeconfig=${VAULT_KUBE_CONFIG} create secret generic vault-approle-${1} \
+		--from-literal=role_id=${ROLE_ID} --from-literal=secret_id=${SECRET_ID} \
+		--dry-run=client -o yaml >>${APP_ROLE_FILE}
+}
+
+function restart() {
+	echo "restarting vault pod '${VAULT_PODNAME}' ..."
+	oc --kubeconfig=${VAULT_KUBE_CONFIG} delete pod ${VAULT_PODNAME} -n ${VAULT_NAMESPACE} >/dev/null
+}

--- a/hack/spi/vault-init.sh
+++ b/hack/spi/vault-init.sh
@@ -1,0 +1,169 @@
+#!/bin/bash
+
+# !!! Note that this script should not be used for production purposes !!!
+
+source $(dirname "$0")/utils.sh
+
+set -e
+
+VAULT_KUBE_CONFIG=${VAULT_KUBE_CONFIG:-${KUBECONFIG:-$HOME/.kube/config}}
+VAULT_NAMESPACE=${VAULT_NAMESPACE:-spi-vault}
+SECRET_NAME=spi-vault-keys
+VAULT_PODNAME=${VAULT_PODNAME:-vault-0}
+KEYS_FILE=${KEYS_FILE:-$(mktemp)}
+ROOT_TOKEN=""
+ROOT_TOKEN_NAME=vault-root-token
+
+SPI_DATA_PATH_PREFIX=${SPI_DATA_PATH_PREFIX:-spi}
+SPI_POLICY_NAME=${SPI_DATA_PATH_PREFIX//\//-}
+
+function init() {
+	INIT_STATE=$(isInitialized)
+	if [ "$INIT_STATE" == "false" ]; then
+		vaultExec "vault operator init" >"${KEYS_FILE}"
+		echo "Keys written at ${KEYS_FILE}"
+	elif [ "$INIT_STATE" == "true" ]; then
+		echo "Vault already initialized"
+	else
+		echo "$INIT_STATE"
+		exit 1
+	fi
+}
+
+function isInitialized() {
+	STATUS=$(vaultExec "vault status -format=yaml 2>&1")
+	INITIALIZED=$(echo "$STATUS" | grep "initialized")
+	if [ -z "${INITIALIZED}" ]; then
+		echo "failed to obtain initialization status; vault may be in an irrecoverable error state"
+		echo "vault status output: ${STATUS}"
+	fi
+	echo "${INITIALIZED}" | awk '{split($0,a,": "); print a[2]}'
+}
+
+function isSealed() {
+	SEALED=$(vaultExec "vault status -format=yaml | grep sealed")
+	echo "${SEALED}" | awk '{split($0,a,": "); print a[2]}'
+}
+
+function secret() {
+	if [ ! -s "${KEYS_FILE}" ]; then
+		return
+	fi
+
+	if oc --kubeconfig=${VAULT_KUBE_CONFIG} get secret ${SECRET_NAME} -n ${VAULT_NAMESPACE} 2>/dev/null; then
+		echo "Secret ${SECRET_NAME} already exists. Deleting ..."
+		oc --kubeconfig=${VAULT_KUBE_CONFIG} delete secret ${SECRET_NAME} -n ${VAULT_NAMESPACE}
+	fi
+
+	COMMAND="oc --kubeconfig=${VAULT_KUBE_CONFIG} create secret generic ${SECRET_NAME} -n ${VAULT_NAMESPACE}"
+	KEYI=1
+	# shellcheck disable=SC2013
+	for KEY in $(grep "Unseal Key" "${KEYS_FILE}" | awk '{split($0,a,": "); print a[2]}'); do
+		COMMAND="${COMMAND} --from-literal=key${KEYI}=${KEY}"
+		((KEYI++))
+	done
+
+	${COMMAND}
+}
+
+function unseal() {
+	KEYI=1
+	until [ "$(isSealed)" == "false" ]; do
+		echo "unsealing ..."
+		KEY=$(oc --kubeconfig=${VAULT_KUBE_CONFIG} get secret ${SECRET_NAME} -n ${VAULT_NAMESPACE} --template="{{.data.key${KEYI}}}" | base64 --decode)
+		if [ -z "${KEY}" ]; then
+			echo "failed to unseal"
+			exit 1
+		fi
+		vaultExec "vault operator unseal ${KEY}"
+		((KEYI++))
+	done
+	echo "unsealed"
+}
+
+function ensureRootToken() {
+	if [ -s "${KEYS_FILE}" ]; then
+		ROOT_TOKEN=$(grep "Root Token" "${KEYS_FILE}" | awk '{split($0,a,": "); print a[2]}')
+	else
+		generateRootToken
+	fi
+
+	# save ROOT_TOKEN to be used in the `spi-init` and `remote-secret-init` scripts
+	oc --kubeconfig=${VAULT_KUBE_CONFIG} create secret generic ${ROOT_TOKEN_NAME} \
+		--from-literal=root_token=${ROOT_TOKEN} -n ${VAULT_NAMESPACE}
+}
+
+function generateRootToken() {
+	echo "generating root token ..."
+
+	vaultExec "vault operator generate-root -cancel" >/dev/null
+	INIT=$(vaultExec "vault operator generate-root -init -format=yaml")
+	NONCE=$(echo "${INIT}" | grep "nonce:" | awk '{split($0,a,": "); print a[2]}')
+	OTP=$(echo "${INIT}" | grep "otp:" | awk '{split($0,a,": "); print a[2]}')
+
+	KEYI=1
+	COMPLETE="false"
+	until [ "${COMPLETE}" == "true" ]; do
+		KEY=$(oc --kubeconfig=${VAULT_KUBE_CONFIG} get secret ${SECRET_NAME} -n ${VAULT_NAMESPACE} --template="{{.data.key${KEYI}}}" | base64 --decode)
+		if [ -z "${KEY}" ]; then
+			echo "failed to generate token"
+			exit 1
+		fi
+		GENERATE_OUTPUT=$(vaultExec "echo ${KEY} | vault operator generate-root -nonce=${NONCE} -format=yaml -")
+		COMPLETE=$(echo "${GENERATE_OUTPUT}" | grep "complete:" | awk '{split($0,a,": "); print a[2]}')
+		if [ "${COMPLETE}" == "true" ]; then
+			ENCODED_TOKEN=$(echo "${GENERATE_OUTPUT}" | grep "encoded_token" | awk '{split($0,a,": "); print a[2]}')
+			ROOT_TOKEN=$(vaultExec "vault operator generate-root \
+        -decode=${ENCODED_TOKEN} \
+        -otp=${OTP} -format=yaml" |
+				awk '{split($0,a,": "); print a[2]}')
+		fi
+		((KEYI++))
+	done
+}
+
+function applyPolicy() {
+	POLICY_FILE=/tmp/spi_policy.hcl
+	vaultExec "echo 'path \"${SPI_DATA_PATH_PREFIX}/*\" { capabilities = [\"read\", \"create\", \"list\", \"delete\", \"update\"] }' > ${POLICY_FILE}"
+	vaultExec "vault policy write ${SPI_POLICY_NAME} ${POLICY_FILE}"
+	vaultExec "rm ${POLICY_FILE}"
+}
+
+function spiSecretEngine() {
+	if ! vaultExec "vault secrets list | grep -q ${SPI_DATA_PATH_PREFIX}"; then
+		echo "creating SPI secret engine ..."
+		vaultExec "vault secrets enable -path=${SPI_DATA_PATH_PREFIX} kv-v2"
+	fi
+}
+
+function initVault() {
+	until [ "$(oc --kubeconfig=${VAULT_KUBE_CONFIG} get pod ${VAULT_PODNAME} -n ${VAULT_NAMESPACE} -o jsonpath='{.status.phase}')" == "Running" ]; do
+		sleep 5
+		echo "Waiting for Vault pod to be running."
+	done
+
+	sleep 5
+
+	init
+	secret
+	unseal
+	ensureRootToken
+	login
+	audit
+	spiSecretEngine
+	applyPolicy
+}
+
+if ! timeout 100s bash -c "while ! oc get applications.argoproj.io -n openshift-gitops -o name | grep -q spi-vault-in-cluster-local; do printf '.'; sleep 5; done"; then
+	printf "Application spi-vault-in-cluster-local not found (timeout)\n"
+	oc get apps -n openshift-gitops -o name
+	exit 1
+else
+	if [ "$(oc get applications.argoproj.io spi-vault-in-cluster-local -n openshift-gitops -o jsonpath='{.status.health.status} {.status.sync.status}')" != "Healthy Synced" ]; then
+		echo "Initializing vault"
+		initVault
+		echo "Vault initialization was completed"
+	else
+		echo "Vault initialization was skipped"
+	fi
+fi


### PR DESCRIPTION
### What does this PR do?
The present PR splits `vault-init` of `service-provider-integration-operator` repo into `vault-init`, `spi-init`, and `remote-secret-init` in order to create a new set of scripts designed for specific infra-deployments use cases for `develop` environment.
With this change, the `infra-deployments` repo will have the spi scripts and it will not call the script in `service-provider-integration-operator` repo.

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/SVPI-518


### How to test this PR?

#### Install RHTAP through `bootstrap-cluster` script

- Set the required environment variables, such as: `MY_GIT_FORK_REMOTE`, `MY_GITHUB_ORG`, and `MY_GITHUB_TOKEN`
- Run `./hack/bootstrap-cluster.sh preview --keycloak --toolchain` script on infra-deployments dir

#### Install RHTAP through `e2e-tests` repo
Before following the steps on https://github.com/redhat-appstudio/e2e-tests#install-appstudio-in-e2e-mode, please set the following environment variables:

```
export INFRA_DEPLOYMENTS_ORG=rsoaresd
export INFRA_DEPLOYMENTS_BRANCH=SVPI-518
```