### PR TITLE
Change pipeline pruner behavior in Staging

### DIFF
--- a/components/pipeline-service/staging/base/greedy-pruner.yaml
+++ b/components/pipeline-service/staging/base/greedy-pruner.yaml
@@ -1,0 +1,4 @@
+---
+- op: replace
+  path: /spec/pruner/keep
+  value: 1

--- a/components/pipeline-service/staging/base/kustomization.yaml
+++ b/components/pipeline-service/staging/base/kustomization.yaml
@@ -14,6 +14,10 @@ resources:
   - ../../base/servicemonitors
 
 patches:
+  - path: greedy-pruner.yaml
+    target:
+      kind: TektonConfig
+      name: config
   - path: pac-app-name.yaml
     target:
       kind: ConfigMap


### PR DESCRIPTION
Change the pruner settings to aggressively delete finshed PipelineRuns. This change has been requested as part of the investigation around performance testing.