### PR TITLE
Keep PipelineRuns for 24h in tekton-ci

### DIFF
--- a/components/tekton-ci/base/namespace.yaml
+++ b/components/tekton-ci/base/namespace.yaml
@@ -3,4 +3,5 @@ kind: Namespace
 metadata:
   name: tekton-ci
   annotations:
-    operator.tekton.dev/prune.skip: "true"
+    # Keeps PipelineRuns for 24h.
+    operator.tekton.dev/prune.keep-since: 1440


### PR DESCRIPTION
The existing configuration done for [PLNSRVCE-939](https://issues.redhat.com//browse/PLNSRVCE-939) keeps PipelineRuns forever. With the change PipelineRuns are kept for 24 hours to give time to developers to investigate before being pruned.