### PR TITLE
Change pipeline pruner behavior in Staging

### DIFF
--- a/components/pipeline-service/staging/base/greedy-pruner.yaml
+++ b/components/pipeline-service/staging/base/greedy-pruner.yaml
@@ -1,4 +1,4 @@
 ---
 - op: replace
   path: /spec/pruner/keep
-  value: 1
+  value: 2


### PR DESCRIPTION
Change the pruner settings to aggressively delete finished PipelineRuns. The latest 2 PLRs are kept, as each change on the repository will now trigger 2 PLRs.