### PR TITLE
fix the rollout of 'pipelines-as-code-secret' in staging

### DIFF
--- a/components/pipeline-service/staging/base/kustomization.yaml
+++ b/components/pipeline-service/staging/base/kustomization.yaml
@@ -22,7 +22,7 @@ patches:
     target:
       kind: ConfigMap
       name: pipelines-as-code
-      namespace: pipelines-as-code
+      namespace: openshift-pipelines
 #  - path: scale-down-exporter.yaml
 #    target:
 #      kind: Deployment

--- a/components/pipeline-service/staging/base/kustomization.yaml
+++ b/components/pipeline-service/staging/base/kustomization.yaml
@@ -10,6 +10,7 @@ commonAnnotations:
 resources:
   - git::https://github.com/openshift-pipelines/pipeline-service.git/operator/gitops/argocd/pipeline-service?ref=5bfee7ea5b973bcd504ff4fe03b6bf444f6dffcb
   - pipelines-as-code-namespace.yaml
+  - pipelines-as-code-secret.yaml
   - ../../base/external-secrets
   - ../../base/testing
   - ../../base/servicemonitors

--- a/components/pipeline-service/staging/base/kustomization.yaml
+++ b/components/pipeline-service/staging/base/kustomization.yaml
@@ -9,6 +9,7 @@ commonAnnotations:
 
 resources:
   - git::https://github.com/openshift-pipelines/pipeline-service.git/operator/gitops/argocd/pipeline-service?ref=5bfee7ea5b973bcd504ff4fe03b6bf444f6dffcb
+  - pipelines-as-code-namespace.yaml
   - ../../base/external-secrets
   - ../../base/testing
   - ../../base/servicemonitors

--- a/components/pipeline-service/staging/base/pipelines-as-code-namespace.yaml
+++ b/components/pipeline-service/staging/base/pipelines-as-code-namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: pipelines-as-code

--- a/components/pipeline-service/staging/base/pipelines-as-code-secret.yaml
+++ b/components/pipeline-service/staging/base/pipelines-as-code-secret.yaml
@@ -1,0 +1,20 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: pipelines-as-code-secret
+  namespace: openshift-pipelines
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  dataFrom:
+    - extract:
+        key: staging/pipeline-service/github-app
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: appsre-stonesoup-vault
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    name: pipelines-as-code-secret


### PR DESCRIPTION
The 1.11 bump https://github.com/redhat-appstudio/infra-deployments/pull/1985 and its moving of PaC from `pipelines-as-code` namespace to `openshift-pipeilnes` namespace did not account for refs to the old namespace.

Currently the gitops rollout in staging per https://argocd-server-argocd-staging.apps.stonesoups01ue1.2d3m.p1.openshiftapps.com/applications/argocd-staging/pipeline-service-stone-stg-m01?view=tree&resource= is incomplete and currently stuck on

```
one or more objects failed to apply, reason: namespaces "pipelines-as-code" not found. Retrying attempt #115 at 7:04PM.
```

when processing the `pipelines-as-code-secret` defined in infra-deployments

