### PR TITLE
Allow access vault-secret store from openshift-pipelines

### DIFF
--- a/components/cluster-secret-store/base/appsre-stonesoup-vault-secret-store.yaml
+++ b/components/cluster-secret-store/base/appsre-stonesoup-vault-secret-store.yaml
@@ -43,3 +43,4 @@ spec:
         - openshift-logging
         - sprayproxy
         - appstudio-monitoring
+        - openshift-pipelines


### PR DESCRIPTION
Pipelines-as-code externalsecret is being deployed to openshift-pipelines namespace