### PR TITLE
Update sprayproxy backends after OSP 1.11 upgrade

### DIFF
--- a/components/sprayproxy/staging/add-backends.yml
+++ b/components/sprayproxy/staging/add-backends.yml
@@ -2,5 +2,5 @@
 - op: add
   path: /spec/template/spec/containers/0/env/0/value
   value: >
-    https://pipelines-as-code-controller-pipelines-as-code.apps.stone-stg-m01.7ayg.p1.openshiftapps.com
-    https://pipelines-as-code-controller-pipelines-as-code.apps.stone-stg-rh01.l2vh.p1.openshiftapps.com
+    https://pipelines-as-code-controller-openshift-pipelines.apps.stone-stg-m01.7ayg.p1.openshiftapps.com
+    https://pipelines-as-code-controller-openshift-pipelines.apps.stone-stg-rh01.l2vh.p1.openshiftapps.com


### PR DESCRIPTION
In OSP 1.11 the PaC resources are deployed under the openshift-pipelines namespace which also changes the endpoints where requests are forwarded.