### PR TITLE
Missed kustomization

### DIFF
--- a/ci/teams/kustomization.yaml
+++ b/ci/teams/kustomization.yaml
@@ -1,0 +1,7 @@
+resources:
+- rhtap-build
+- rhtap-gitops
+- rhtap-servicerelease
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization


### PR DESCRIPTION
* follow-up of https://github.com/redhat-appstudio/infra-deployments/pull/2061

* Referenced from 
https://github.com/redhat-appstudio/infra-deployments/blob/main/argo-cd-apps/base/ci-workspaces/ci-workspaces.yaml#L13


Without this, the resource list kinda looks empty :-)

<img width="1189" alt="image" src="https://github.com/redhat-appstudio/infra-deployments/assets/545280/cc5964d9-1de2-4d82-91ad-0549a95b645d">
