### PR TITLE
tekton-ci: github-read-only-token from ExternalSecrets

### DIFF
--- a/components/tekton-ci/base/external-secrets/github-secret.yaml
+++ b/components/tekton-ci/base/external-secrets/github-secret.yaml
@@ -1,0 +1,19 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: github
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  dataFrom:
+    - extract:
+        key: "production/build/github-read-only"
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: appsre-stonesoup-vault
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    name: github

--- a/components/tekton-ci/base/external-secrets/kustomization.yaml
+++ b/components/tekton-ci/base/external-secrets/kustomization.yaml
@@ -5,4 +5,5 @@ resources:
 - infra-deployments-pr-creator.yaml
 - snyk-shared-token.yaml
 - slack-webhook-notification-secret.yaml
+- github-secret.yaml
 namespace: tekton-ci


### PR DESCRIPTION
Add github-read-only-token to ExternalSecrets so that the secret is not created manually but by operator.