### PR TITLE
Include clair-in-ci-db repo

### DIFF
--- a/components/tekton-ci/base/repository.yaml
+++ b/components/tekton-ci/base/repository.yaml
@@ -58,6 +58,13 @@ spec:
 apiVersion: pipelinesascode.tekton.dev/v1alpha1
 kind: Repository
 metadata:
+  name: clair-in-ci-db
+spec:
+  url: "https://github.com/redhat-appstudio/clair-in-ci-db"
+---
+apiVersion: pipelinesascode.tekton.dev/v1alpha1
+kind: Repository
+metadata:
   name: hacbs-test
 spec:
   url: "https://github.com/redhat-appstudio/hacbs-test"


### PR DESCRIPTION
Enable clair-in-ci-db repo for tekton-ci.