### PR TITLE
monitoring: Add GitOps Service's Argo CD Dashboard

### DIFF
--- a/components/monitoring/grafana/base/managed-gitops/gitops-service-argocd-dashboard.yaml
+++ b/components/monitoring/grafana/base/managed-gitops/gitops-service-argocd-dashboard.yaml
@@ -1,0 +1,10 @@
+apiVersion: integreatly.org/v1alpha1
+kind: GrafanaDashboard
+metadata:
+  name: grafana-dashboard-gitops-service-argocd
+  labels: 
+    app: appstudio-grafana
+spec:
+  configMapRef:
+    name: grafana-dashboard-gitops-service
+    key: gitops-argocd-dashboard.json

--- a/components/monitoring/grafana/base/managed-gitops/kustomization.yaml
+++ b/components/monitoring/grafana/base/managed-gitops/kustomization.yaml
@@ -3,3 +3,4 @@ kind: Kustomization
 resources:
 - https://github.com/redhat-appstudio/managed-gitops/manifests/base/monitoring/grafana-dashboards-new?ref=23253fe449172c7907da9675d6c42bcd670c907e
 - dashboard.yaml
+- gitops-service-argocd-dashboard.yaml


### PR DESCRIPTION
The contents of the dashboard that monitors the Argo CD instance in `gitops-service-argocd` is already part of the ConfigMap, we just need to create the corresponding `GrafanaDashboard` CR.