### PR TITLE
PLNSRVCE-1381: prototype adding cluster-wide results viewing to some pipeline-service team members

### DIFF
--- a/components/authentication/staging/kustomization.yaml
+++ b/components/authentication/staging/kustomization.yaml
@@ -3,3 +3,4 @@ kind: Kustomization
 resources:
   - ../base
   - ./has-exec.yaml
+  - ./results-cluster-viewer.yaml

--- a/components/authentication/staging/results-cluster-viewer.yaml
+++ b/components/authentication/staging/results-cluster-viewer.yaml
@@ -1,0 +1,29 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: results-cluster-viewer
+rules:
+  - apiGroups:
+      - results.tekton.dev
+    resources:
+      - results
+      - records
+    verbs:
+      - get
+      - list
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: results-cluster-viewer
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: results-cluster-viewer
+subjects:
+  - kind: User
+    name: gabemontero
+    apiGroup: rbac.authorization.k8s.io
+  - kind: User
+    name: sayan-biswas
+    apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
what I think an initial permission bump in staging only would look like so either @sayan-biswas or myself could start prototyping direct viewing of logs / records of results in staging only

Of course let me know @sayan-biswas if I misremembered the resources / verbs needed

@redhat-appstudio/pipeline-service FYI