### PR TITLE
Fix(RHTAPWATCH-8): Upgrade to Grafana Operator v5

### DIFF
--- a/components/monitoring/README.md
+++ b/components/monitoring/README.md
@@ -164,13 +164,16 @@ Follow the next steps to define a dashboard in your team's repository
   
   6. Create the `GrafanaDashboard` resource file that uses the config map to create the dashboard
       ```yaml
-      apiVersion: integreatly.org/v1alpha1
+      apiVersion: grafana.integreatly.org/v1beta1
       kind: GrafanaDashboard
       metadata:
         name: grafana-dashboard-o11y
         labels:
           app: appstudio-grafana
       spec:
+        instanceSelector:
+          matchLabels:
+            dashboards: "appstudio-grafana"
         configMapRef:
           name: grafana-dashboard-o11y
           key: o11y-dashboard.json

--- a/components/monitoring/grafana/base/build-service/dashboard.yaml
+++ b/components/monitoring/grafana/base/build-service/dashboard.yaml
@@ -1,22 +1,28 @@
 ---
-apiVersion: integreatly.org/v1alpha1
+apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDashboard
 metadata:
   name: grafana-dashboard-initial-build-pipeline
   labels: 
     app: appstudio-grafana
 spec:
+  instanceSelector:
+    matchLabels:
+      dashboards: "appstudio-grafana"
   configMapRef:
     name: grafana-dashboard-initial-build-pipeline
-    key: grafana-dashboard-initial-build-pipeline.json
+    key: grafana-dashboard-initial-build-pipeline.json    
 ---
-apiVersion: integreatly.org/v1alpha1
+apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDashboard
 metadata:
   name: grafana-dashboard-pac-provision
   labels: 
     app: appstudio-grafana
 spec:
+  instanceSelector:
+    matchLabels:
+      dashboards: "appstudio-grafana"
   configMapRef:
     name: grafana-dashboard-pac-provision
     key: grafana-dashboard-pac-provision.json

--- a/components/monitoring/grafana/base/dora-metrics/dashboard.yaml
+++ b/components/monitoring/grafana/base/dora-metrics/dashboard.yaml
@@ -1,10 +1,13 @@
-apiVersion: integreatly.org/v1alpha1
+apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDashboard
 metadata:
   name: grafana-dashboard-dora-metrics
   labels: 
     app: appstudio-grafana
 spec:
+  instanceSelector:
+    matchLabels:
+      dashboards: "appstudio-grafana"
   configMapRef:
     name: grafana-dashboard-dora-metrics
     key: dora-dashboard.json

--- a/components/monitoring/grafana/base/generic-dashboards/controller-runtime-controllers-detail_rev1.json
+++ b/components/monitoring/grafana/base/generic-dashboards/controller-runtime-controllers-detail_rev1.json
@@ -45,10 +45,6 @@
       "id": 6,
       "panels": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PF224BEF3374A25F8"
-          },
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -119,10 +115,6 @@
           },
           "targets": [
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "PF224BEF3374A25F8"
-              },
               "exemplar": true,
               "expr": "controller_runtime_active_workers{namespace=\"$Namespace\", service=\"$Service\", pod=\"$Pod\"}",
               "interval": "",
@@ -134,10 +126,6 @@
           "type": "timeseries"
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PF224BEF3374A25F8"
-          },
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -208,10 +196,6 @@
           },
           "targets": [
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "PF224BEF3374A25F8"
-              },
               "exemplar": true,
               "expr": "sum by (result) (rate(controller_runtime_reconcile_total{namespace=\"$Namespace\", service=\"$Service\", pod=\"$Pod\"}[$__rate_interval]))",
               "interval": "",
@@ -225,10 +209,6 @@
       ],
       "targets": [
         {
-          "datasource": {
-            "type": "datasource",
-            "uid": "grafana"
-          },
           "refId": "A"
         }
       ],
@@ -263,10 +243,6 @@
       "type": "row"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "PF224BEF3374A25F8"
-      },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -340,10 +316,6 @@
       },
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PF224BEF3374A25F8"
-          },
           "exemplar": true,
           "expr": "rate(controller_runtime_reconcile_total{namespace=\"$Namespace\", service=\"$Service\", pod=\"$Pod\", controller=\"$Controller\"}[$__rate_interval])",
           "interval": "",
@@ -364,10 +336,6 @@
         "mode": "spectrum"
       },
       "dataFormat": "tsbuckets",
-      "datasource": {
-        "type": "prometheus",
-        "uid": "PF224BEF3374A25F8"
-      },
       "fieldConfig": {
         "defaults": {
           "custom": {
@@ -437,10 +405,6 @@
       "reverseYBuckets": false,
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PF224BEF3374A25F8"
-          },
           "exemplar": true,
           "expr": "rate(controller_runtime_reconcile_time_seconds_bucket{namespace='$Namespace', service='$Service', pod='$Pod', controller='$Controller'}[$__rate_interval])",
           "format": "heatmap",
@@ -478,10 +442,6 @@
           "text": "toolchain-member-operator",
           "value": "toolchain-member-operator"
         },
-        "datasource": {
-          "type": "prometheus",
-          "uid": "PF224BEF3374A25F8"
-        },
         "definition": "label_values(controller_runtime_active_workers, namespace)",
         "hide": 0,
         "includeAll": false,
@@ -503,10 +463,6 @@
           "selected": false,
           "text": "member-operator-metrics-service",
           "value": "member-operator-metrics-service"
-        },
-        "datasource": {
-          "type": "prometheus",
-          "uid": "PF224BEF3374A25F8"
         },
         "definition": "label_values(controller_runtime_active_workers{namespace=\"$Namespace\"}, service)",
         "hide": 0,
@@ -530,10 +486,6 @@
           "text": "member-operator-controller-manager-987bbbb6c-4j69n",
           "value": "member-operator-controller-manager-987bbbb6c-4j69n"
         },
-        "datasource": {
-          "type": "prometheus",
-          "uid": "PF224BEF3374A25F8"
-        },
         "definition": "label_values(controller_runtime_active_workers{namespace=\"$Namespace\", service=\"$Service\"},  pod)",
         "hide": 0,
         "includeAll": false,
@@ -555,10 +507,6 @@
           "selected": false,
           "text": "idler",
           "value": "idler"
-        },
-        "datasource": {
-          "type": "prometheus",
-          "uid": "PF224BEF3374A25F8"
         },
         "definition": "label_values(controller_runtime_active_workers{namespace=\"$Namespace\", service=\"$Service\", pod=\"$Pod\"},  controller)",
         "hide": 0,

--- a/components/monitoring/grafana/base/generic-dashboards/dashboard.yaml
+++ b/components/monitoring/grafana/base/generic-dashboards/dashboard.yaml
@@ -1,21 +1,27 @@
-apiVersion: integreatly.org/v1alpha1
+apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDashboard
 metadata:
   name: grafana-dashboard-go-processes
   labels: 
     app: appstudio-grafana
 spec:
+  instanceSelector:
+    matchLabels:
+      dashboards: "appstudio-grafana"
   configMapRef:
     name: grafana-dashboard-go-processes
     key: go-processes_rev1.json
 ---
-apiVersion: integreatly.org/v1alpha1
+apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDashboard
 metadata:
   name: grafana-dashboard-controller-runtime-controllers-detail
   labels: 
     app: appstudio-grafana
 spec:
+  instanceSelector:
+    matchLabels:
+      dashboards: "appstudio-grafana"
   configMapRef:
     name: grafana-dashboard-controller-runtime-controllers-detail
     key: controller-runtime-controllers-detail_rev1.json

--- a/components/monitoring/grafana/base/generic-dashboards/go-processes_rev1.json
+++ b/components/monitoring/grafana/base/generic-dashboards/go-processes_rev1.json
@@ -35,10 +35,6 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "PF224BEF3374A25F8"
-      },
       "editable": true,
       "error": false,
       "fill": 1,
@@ -87,10 +83,6 @@
       "steppedLine": false,
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PF224BEF3374A25F8"
-          },
           "expr": "process_resident_memory_bytes{namespace=~\"^($namespace)$\",pod=~\"^($pod)$\"}",
           "format": "time_series",
           "intervalFactor": 2,
@@ -100,10 +92,6 @@
           "step": 4
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PF224BEF3374A25F8"
-          },
           "expr": "process_virtual_memory_bytes{namespace=~\"^($namespace)$\",pod=~\"^($pod)$\"}",
           "format": "time_series",
           "intervalFactor": 2,
@@ -149,10 +137,6 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "PF224BEF3374A25F8"
-      },
       "editable": true,
       "error": false,
       "fill": 1,
@@ -200,10 +184,6 @@
       "steppedLine": false,
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PF224BEF3374A25F8"
-          },
           "expr": "rate(process_resident_memory_bytes{namespace=~\"^($namespace)$\",pod=~\"^($pod)$\"}[$interval])",
           "format": "time_series",
           "intervalFactor": 2,
@@ -213,10 +193,6 @@
           "step": 4
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PF224BEF3374A25F8"
-          },
           "expr": "deriv(process_virtual_memory_bytes{namespace=~\"^($namespace)$\",pod=~\"^($pod)$\"}[$interval])",
           "format": "time_series",
           "intervalFactor": 2,
@@ -262,10 +238,6 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "PF224BEF3374A25F8"
-      },
       "editable": true,
       "error": false,
       "fill": 1,
@@ -313,10 +285,6 @@
       "steppedLine": false,
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PF224BEF3374A25F8"
-          },
           "expr": "go_memstats_alloc_bytes{namespace=~\"^($namespace)$\",pod=~\"^($pod)$\"}",
           "format": "time_series",
           "intervalFactor": 2,
@@ -326,10 +294,6 @@
           "step": 4
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PF224BEF3374A25F8"
-          },
           "expr": "rate(go_memstats_alloc_bytes_total{namespace=~\"^($namespace)$\",pod=~\"^($pod)$\"}[30s])",
           "format": "time_series",
           "intervalFactor": 2,
@@ -339,10 +303,6 @@
           "step": 4
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PF224BEF3374A25F8"
-          },
           "expr": "go_memstats_stack_inuse_bytes{namespace=~\"^($namespace)$\",pod=~\"^($pod)$\"}",
           "format": "time_series",
           "intervalFactor": 2,
@@ -352,10 +312,6 @@
           "step": 4
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PF224BEF3374A25F8"
-          },
           "expr": "go_memstats_heap_inuse_bytes{namespace=~\"^($namespace)$\",pod=~\"^($pod)$\"}",
           "format": "time_series",
           "hide": false,
@@ -402,10 +358,6 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "PF224BEF3374A25F8"
-      },
       "editable": true,
       "error": false,
       "fill": 1,
@@ -453,10 +405,6 @@
       "steppedLine": false,
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PF224BEF3374A25F8"
-          },
           "expr": "deriv(go_memstats_alloc_bytes{namespace=~\"^($namespace)$\",pod=~\"^($pod)$\"}[$interval])",
           "format": "time_series",
           "intervalFactor": 2,
@@ -466,10 +414,6 @@
           "step": 4
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PF224BEF3374A25F8"
-          },
           "expr": "rate(go_memstats_alloc_bytes_total{namespace=~\"^($namespace)$\",pod=~\"^($pod)$\"}[$interval])",
           "format": "time_series",
           "intervalFactor": 2,
@@ -479,10 +423,6 @@
           "step": 4
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PF224BEF3374A25F8"
-          },
           "expr": "deriv(go_memstats_stack_inuse_bytes{namespace=~\"^($namespace)$\",pod=~\"^($pod)$\"}[$interval])",
           "format": "time_series",
           "intervalFactor": 2,
@@ -492,10 +432,6 @@
           "step": 4
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PF224BEF3374A25F8"
-          },
           "expr": "deriv(go_memstats_heap_inuse_bytes{namespace=~\"^($namespace)$\",pod=~\"^($pod)$\"}[$interval])",
           "format": "time_series",
           "hide": false,
@@ -542,10 +478,6 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "PF224BEF3374A25F8"
-      },
       "editable": true,
       "error": false,
       "fill": 1,
@@ -588,10 +520,6 @@
       "steppedLine": false,
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PF224BEF3374A25F8"
-          },
           "expr": "process_open_fds{namespace=~\"^($namespace)$\",pod=~\"^($pod)$\"}",
           "format": "time_series",
           "intervalFactor": 2,
@@ -637,10 +565,6 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "PF224BEF3374A25F8"
-      },
       "editable": true,
       "error": false,
       "fill": 1,
@@ -683,10 +607,6 @@
       "steppedLine": false,
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PF224BEF3374A25F8"
-          },
           "expr": "deriv(process_open_fds{namespace=~\"^($namespace)$\",pod=~\"^($pod)$\"}[$interval])",
           "format": "time_series",
           "intervalFactor": 2,
@@ -732,10 +652,6 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "PF224BEF3374A25F8"
-      },
       "editable": true,
       "error": false,
       "fill": 1,
@@ -778,10 +694,6 @@
       "steppedLine": false,
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PF224BEF3374A25F8"
-          },
           "expr": "go_goroutines{namespace=~\"^($namespace)$\",pod=~\"^($pod)$\"}",
           "format": "time_series",
           "intervalFactor": 2,
@@ -827,10 +739,6 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "PF224BEF3374A25F8"
-      },
       "editable": true,
       "error": false,
       "fill": 1,
@@ -873,10 +781,6 @@
       "steppedLine": false,
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PF224BEF3374A25F8"
-          },
           "expr": "go_gc_duration_seconds{namespace=~\"^($namespace)$\",pod=~\"^($pod)$\"}",
           "format": "time_series",
           "intervalFactor": 2,
@@ -931,10 +835,6 @@
           "text": "All",
           "value": "$__all"
         },
-        "datasource": {
-          "type": "prometheus",
-          "uid": "PF224BEF3374A25F8"
-        },
         "definition": "",
         "hide": 0,
         "includeAll": true,
@@ -960,10 +860,6 @@
           "selected": false,
           "text": "All",
           "value": "$__all"
-        },
-        "datasource": {
-          "type": "prometheus",
-          "uid": "PF224BEF3374A25F8"
         },
         "definition": "",
         "hide": 0,

--- a/components/monitoring/grafana/base/grafana-app.yaml
+++ b/components/monitoring/grafana/base/grafana-app.yaml
@@ -30,22 +30,24 @@ metadata:
 type: kubernetes.io/service-account-token
 ---
 # Create service account to connect to Grafana
+# Although the service account is created by the Grafana operator (named <Grafana_name>-sa)
+# We create it in advanced and assign a secret to it
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: grafana-serviceaccount
+  name: grafana-oauth-sa
   namespace: appstudio-grafana
   annotations:
     argocd.argoproj.io/compare-options: IgnoreExtraneous
 ---
-# Create secret for the Grafana service account
+# Create and assign a secret for the Grafana service account
 apiVersion: v1
 kind: Secret
 metadata:
   name: grafana-proxy
   namespace: appstudio-grafana
   annotations:
-    kubernetes.io/service-account.name: grafana-serviceaccount
+    kubernetes.io/service-account.name: grafana-oauth-sa
 type: kubernetes.io/service-account-token
 ---
 # Create Cluster Role for the Grafana service account
@@ -75,7 +77,7 @@ metadata:
   name: grafana-proxy
 subjects:
   - kind: ServiceAccount
-    name: grafana-serviceaccount
+    name: grafana-oauth-sa
     namespace: appstudio-grafana
 roleRef:
   kind: ClusterRole
@@ -92,99 +94,102 @@ metadata:
   name: ocp-injected-certs
 ---
 # Create the Grafana instance
-apiVersion: integreatly.org/v1alpha1
+# A service account is created automatically by the operator, the name is 
+# derived from the grafana name: <Grafana_name>-sa
+apiVersion: grafana.integreatly.org/v1beta1
 kind: Grafana
 metadata:
   namespace: appstudio-grafana
   name: grafana-oauth
+  labels: 
+    dashboards: "appstudio-grafana"
 spec:
   config:
     users:
-      viewers_can_edit: true
+      viewers_can_edit: "True"
     log:
       mode: "console"
       level: "warn"
     auth.anonymous:
-      enabled: false
+      enabled: "False"
     auth:
-      disable_login_form: False
-      disable_signout_menu: True
+      disable_login_form: "False"
+      disable_signout_menu: "True"
     auth.basic:
-      enabled: True
+      enabled: "True"
     auth.proxy:
-      enabled: True
-      enable_login_token: True
+      enabled: "True"
+      enable_login_token: "True"
       header_property: username
-      header_name: X-Forwarded-User
-  dashboardLabelSelector:
-    - matchExpressions:
-        - key: app
-          operator: In
-          values:
-            - appstudio-grafana
-  deployment:
-    envFrom:
-      - prefix: thanos
-        secretRef:
-          name: metrics-reader
-  containers:
-    - args:
-        - '-provider=openshift'
-        - '-pass-basic-auth=false'
-        - '-https-address=:9091'
-        - '-http-address='
-        - '-email-domain=*'
-        - '-upstream=http://localhost:3000'
-        - '-openshift-sar={"resource": "namespaces", "resourceName": "appstudio-grafana", "namespace": "appstudio-grafana", "verb": "get"}'
-        - '-openshift-delegate-urls={"/": {"resource": "namespaces", "verb": "get"}}'
-        - '-tls-cert=/etc/tls/private/tls.crt'
-        - '-tls-key=/etc/tls/private/tls.key'
-        - '-client-secret-file=/var/run/secrets/kubernetes.io/serviceaccount/token'
-        - '-cookie-secret-file=/etc/proxy/secrets/token'
-        - '-openshift-service-account=grafana-serviceaccount'
-        - '-openshift-ca=/etc/pki/tls/cert.pem'
-        - '-openshift-ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt'
-        - '-openshift-ca=/etc/grafana-configmaps/ocp-injected-certs/ca-bundle.crt'
-        - '-skip-auth-regex=^/metrics'
-      image: quay.io/openshift/origin-oauth-proxy@sha256:b6536bfcfaf30a6425d589facd672bae3245f933b2a7399bda3f12e393bd671b
-      name: grafana-proxy
-      ports:
-        - containerPort: 9091
-          name: https
-      resources: {}
-      volumeMounts:
-        - mountPath: /etc/tls/private
-          name: secret-grafana-tls
-          readOnly: false
-        - mountPath: /etc/proxy/secrets
-          name: secret-grafana-proxy
-          readOnly: false
-  secrets:
-    - grafana-tls
-    - grafana-proxy
-  configMaps:
-    - ocp-injected-certs
-  service:
-    ports:
-      - name: https
-        port: 9091
-        protocol: TCP
-        targetPort: https
-    annotations:
-      service.beta.openshift.io/serving-cert-secret-name: grafana-tls
-  ingress:
-    enabled: false
-    targetPort: https
-    termination: reencrypt
-    annotations:
-      service.beta.openshift.io/serving-cert-secret-name: grafana-tls
-  client:
-    preferService: True
+      header_name: "X-Forwarded-User"
   serviceAccount:
-    annotations:
-      serviceaccounts.openshift.io/oauth-redirectreference.primary: '{"kind":"OAuthRedirectReference","apiVersion":"v1","reference":{"kind":"Route","name":"grafana-access"}}'
+    metadata:
+      annotations:
+        serviceaccounts.openshift.io/oauth-redirectreference.primary: '{"kind":"OAuthRedirectReference","apiVersion":"v1","reference":{"kind":"Route","name":"grafana-access"}}'
+  deployment:
+    spec:
+      template:
+        spec:
+          volumes:
+          - name: grafana-tls
+            secret:
+              secretName: grafana-tls
+          - name: grafana-proxy
+            secret:
+              secretName: grafana-proxy
+          - name: ocp-injected-certs
+            configMap:
+              name: ocp-injected-certs
+          containers:
+            - name: grafana-proxy
+              args:
+                - '-provider=openshift'
+                - '-pass-basic-auth=false'
+                - '-https-address=:9091'
+                - '-http-address='
+                - '-email-domain=*'
+                - '-upstream=http://localhost:3000'
+                - '-openshift-sar={"resource": "namespaces", "resourceName": "appstudio-grafana", "namespace": "appstudio-grafana", "verb": "get"}'
+                - '-openshift-delegate-urls={"/": {"resource": "namespaces", "verb": "get"}}'
+                - '-tls-cert=/etc/tls/private/tls.crt'
+                - '-tls-key=/etc/tls/private/tls.key'
+                - '-client-secret-file=/var/run/secrets/kubernetes.io/serviceaccount/token'
+                - '-cookie-secret-file=/etc/proxy/secrets/token'
+                - '-openshift-service-account=grafana-oauth-sa'
+                - '-openshift-ca=/etc/pki/tls/cert.pem'
+                - '-openshift-ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt'
+                - '-openshift-ca=/etc/proxy/certs/ca-bundle.crt'
+                - '-skip-auth-regex=^/metrics'            
+              image: quay.io/openshift/origin-oauth-proxy@sha256:b6536bfcfaf30a6425d589facd672bae3245f933b2a7399bda3f12e393bd671b
+              ports:
+                - containerPort: 9091
+                  name: https
+              resources: { }
+              volumeMounts:
+                - mountPath: /etc/tls/private
+                  name: grafana-tls
+                  readOnly: false
+                - mountPath: /etc/proxy/secrets
+                  name: grafana-proxy
+                  readOnly: false
+                - mountPath: /etc/proxy/certs
+                  name: ocp-injected-certs
+                  readOnly: false
+             
+  service:
+    metadata:
+      annotations:
+        service.beta.openshift.io/serving-cert-secret-name: grafana-tls
+    spec:
+      ports:
+        - name: https
+          port: 9091
+          protocol: TCP
+          targetPort: https
+    
 ---
 # Adding route to Grafana
+# The service is created by the operator and named <Grafana_name>-service
 apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
@@ -199,37 +204,45 @@ spec:
     termination: reencrypt
   to:
     kind: Service
-    name: grafana-service
+    name: grafana-oauth-service
     weight: 100
   wildcardPolicy: None
 ---  
 # Add prometheus Datasource to Grafana
 # Using the thanos-querier url for the datasource
-apiVersion: integreatly.org/v1alpha1
-kind: GrafanaDataSource
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDatasource
 metadata:
   annotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
   name: prometheus-appstudio-ds
   namespace: appstudio-grafana
 spec:
-  name: prometheus-thanos-grafanadatasource.yaml
-  datasources:
-    - access: proxy
+  valuesFrom:
+    - targetPath: "secureJsonData.httpHeaderValue1"
+      valueFrom:
+        secretKeyRef:
+          name: "metrics-reader"
+          key: "token"
+  instanceSelector:
+    matchLabels:
+      dashboards: "appstudio-grafana"
+  datasource:
+      access: proxy
       editable: true
       isDefault: true
       jsonData:
-        httpHeaderName1: Authorization
+        httpHeaderName1: "Authorization"
         timeInterval: 5s
         tlsSkipVerify: true
       name: prometheus-appstudio-ds
       secureJsonData:
-        httpHeaderValue1: 'Bearer ${thanostoken}'
+        httpHeaderValue1: "Bearer ${token}"
       type: prometheus
       url: 'https://thanos-querier.openshift-monitoring.svc.cluster.local:9091'
 ---
 # Add example dashboard
-apiVersion: integreatly.org/v1alpha1
+apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDashboard
 metadata:
   name: example-dashboard
@@ -237,3 +250,6 @@ metadata:
     app: appstudio-grafana
 spec:
   url: https://raw.githubusercontent.com/redhat-appstudio/infra-deployments/main/components/monitoring/grafana/base/generic-dashboards/example.json
+  instanceSelector:
+    matchLabels:
+      dashboards: "appstudio-grafana"

--- a/components/monitoring/grafana/base/grafana-operator.yaml
+++ b/components/monitoring/grafana/base/grafana-operator.yaml
@@ -7,12 +7,11 @@ metadata:
   name: grafana-operator
   namespace: appstudio-grafana
 spec:
-  channel: v4
+  channel: v5
   installPlanApproval: Automatic
   name: grafana-operator
   source: community-operators
   sourceNamespace: openshift-marketplace
-  startingCSV: grafana-operator.v4.10.0
 ---
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup

--- a/components/monitoring/grafana/base/has/dashboard.yaml
+++ b/components/monitoring/grafana/base/has/dashboard.yaml
@@ -1,22 +1,28 @@
 ---
-apiVersion: integreatly.org/v1alpha1
+apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDashboard
 metadata:
   name: grafana-dashboard-has-gitops-repo-metrics
   labels: 
     app: appstudio-grafana
 spec:
+  instanceSelector:
+    matchLabels:
+      dashboards: "appstudio-grafana"
   configMapRef:
     name: grafana-dashboard-has-gitops-repo-metrics
     key: has-gitops-repo-metrics.json
 ---
-apiVersion: integreatly.org/v1alpha1
+apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDashboard
 metadata:
   name: grafana-dashboard-has-rate-limiting-metrics
   labels:
     app: appstudio-grafana
 spec:
+  instanceSelector:
+    matchLabels:
+      dashboards: "appstudio-grafana"
   configMapRef:
     name: grafana-dashboard-has-rate-limiting-metrics
     key: has-rate-limiting-metrics.json

--- a/components/monitoring/grafana/base/jvm-build-service/dashboard.yaml
+++ b/components/monitoring/grafana/base/jvm-build-service/dashboard.yaml
@@ -1,10 +1,13 @@
-apiVersion: integreatly.org/v1alpha1
+apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDashboard
 metadata:
   name: grafana-dashboard-jvm-dependency-builds
   labels: 
     app: appstudio-grafana
 spec:
+  instanceSelector:
+    matchLabels:
+      dashboards: "appstudio-grafana"
   configMapRef:
     name: grafana-dashboard-jvm-dependency-builds
     key: grafana-dashboard-jvm-dependency-builds.json

--- a/components/monitoring/grafana/base/kustomization.yaml
+++ b/components/monitoring/grafana/base/kustomization.yaml
@@ -26,3 +26,20 @@ namespace: "appstudio-grafana"
 
 configurations:
   - cm-dashboard.yaml
+
+# Migration patch from Grafana v4 to v5, should be removed when all projects are migrated
+patchesJson6902:
+  - target:
+      group: integreatly.org
+      version: v1alpha1
+      kind: GrafanaDashboard
+      name: '.*'
+    patch: |-
+      - op: replace
+        path: "/apiVersion"
+        value: grafana.integreatly.org/v1beta1
+      - op: add
+        path: /spec/instanceSelector
+        value:
+          matchLabels:
+            dashboards: "appstudio-grafana"

--- a/components/monitoring/grafana/base/managed-gitops/dashboard.yaml
+++ b/components/monitoring/grafana/base/managed-gitops/dashboard.yaml
@@ -1,10 +1,13 @@
-apiVersion: integreatly.org/v1alpha1
+apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDashboard
 metadata:
   name: grafana-dashboard-gitops-service
   labels: 
     app: appstudio-grafana
 spec:
+  instanceSelector:
+    matchLabels:
+      dashboards: "appstudio-grafana"
   configMapRef:
     name: grafana-dashboard-gitops-service
     key: gitops-dashboard.json

--- a/components/monitoring/grafana/base/migration/dashboard.yaml
+++ b/components/monitoring/grafana/base/migration/dashboard.yaml
@@ -1,10 +1,13 @@
-apiVersion: integreatly.org/v1alpha1
+apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDashboard
 metadata:
   name: migration-team-dashboard
   labels: 
     app: appstudio-grafana
 spec:
+  instanceSelector:
+    matchLabels:
+      dashboards: "appstudio-grafana"
   configMapRef:
     name: migration-team-dashboard
     key: migration-team-dashboard.json

--- a/components/monitoring/grafana/base/spi/dashboard.yaml
+++ b/components/monitoring/grafana/base/spi/dashboard.yaml
@@ -1,33 +1,42 @@
 ---
-apiVersion: integreatly.org/v1alpha1
+apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDashboard
 metadata:
   name: grafana-dashboard-spi-health
   labels: 
     app: appstudio-grafana
 spec:
+  instanceSelector:
+    matchLabels:
+      dashboards: "appstudio-grafana"
   configMapRef:
     name: grafana-dashboard-spi-health
     key: spi-health.json
 ---
-apiVersion: integreatly.org/v1alpha1
+apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDashboard
 metadata:
   name: grafana-dashboard-spi-outbound-traffic
   labels: 
     app: appstudio-grafana
 spec:
+  instanceSelector:
+    matchLabels:
+      dashboards: "appstudio-grafana"
   configMapRef:
     name: grafana-dashboard-spi-outbound-traffic
     key: spi-outbound-traffic.json
 ---
-apiVersion: integreatly.org/v1alpha1
+apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDashboard
 metadata:
   name: grafana-dashboard-spi-slo
   labels: 
     app: appstudio-grafana
 spec:
+  instanceSelector:
+    matchLabels:
+      dashboards: "appstudio-grafana"
   configMapRef:
     name: grafana-dashboard-spi-slo
     key: spi-slo.json


### PR DESCRIPTION
We are upgrading the Grafana Operator from v4 to v5 as part of a fix to [RHTAPWATCH-8](https://issues.redhat.com//browse/RHTAPWATCH-8) (Somtimes the Grafana insnace is not reachable)

Upgrade to Grafana Operator v5:

- Update Grafana Operator to v5.3.0
- Update Grafana deployment yaml
- Update the APIs in all CRs (Datasources, Dashboards)
- Remove datasource definition from `generic-dashboards`
- Update README file

Notes
Dashboards that their source is in the team's repository were not updated to fit the new API.  
After this PR will get merge these dashboards would not be presented in Grafana.  
We will update the teams' dashboards in their repositories.  
These are the dashboards and repositories:

- Integration - https://github.com/redhat-appstudio/integration-service/blob/main/config/grafana/dashboard.yaml
- Performance - https://github.com/redhat-appstudio/perfscale/blob/main/grafana/dashboard.yaml
- Pipeline-service - https://github.com/openshift-pipelines/pipeline-service/blob/main/operator/gitops/argocd/grafana/dashboard.yaml
- Release - https://github.com/redhat-appstudio/release-service/blob/main/config/grafana/dashboard.yaml

