### PR TITLE
Deploy Grafana's operator group first

### DIFF
--- a/components/monitoring/grafana/base/grafana-operator.yaml
+++ b/components/monitoring/grafana/base/grafana-operator.yaml
@@ -21,6 +21,8 @@ kind: OperatorGroup
 metadata:
   name: appstudio-grafana
   namespace: appstudio-grafana
+  annotations:
+    argocd.argoproj.io/sync-wave: "-2"
 spec:
   targetNamespaces:
   - appstudio-grafana


### PR DESCRIPTION
The operator group should get deployed before the subscription, otherwise we are getting:

```
failed to populate resolver cache from source
operatorgroup-unavailable/appstudio-grafana:
found 0 operatorgroups in namespace appstudio-grafana: expected 1
```