### PR TITLE
fix(RHTAPWATCH-8): Update gitops-service-argocd-dashboard CRD

### DIFF
--- a/components/monitoring/grafana/base/dashboards/managed-gitops/gitops-service-argocd-dashboard.yaml
+++ b/components/monitoring/grafana/base/dashboards/managed-gitops/gitops-service-argocd-dashboard.yaml
@@ -1,10 +1,13 @@
-apiVersion: integreatly.org/v1alpha1
+apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDashboard
 metadata:
   name: grafana-dashboard-gitops-service-argocd
   labels: 
     app: appstudio-grafana
 spec:
+  instanceSelector:
+    matchLabels:
+      dashboards: "appstudio-grafana"
   configMapRef:
     name: grafana-dashboard-gitops-service
     key: gitops-argocd-dashboard.json


### PR DESCRIPTION
Update gitops-service-argocd-dashboard CRD with Grafana Operator v5 api and `instanceSelector`