### PR TITLE
DO-NOT-MERGE: performance testing around tekton perf settings

### DIFF
--- a/components/pipeline-service/development/update-tekton-config-performance.yaml
+++ b/components/pipeline-service/development/update-tekton-config-performance.yaml
@@ -10,10 +10,10 @@
   # default upstream setting
   #value: 5.0
   # upstream large scale env recommendation
-  value: 50
+  value: 300
 - op: replace
   path: /spec/pipeline/performance/kube-api-burst
   # default upstream setting
   # value: 10
   # upstream large scale env recommendation
-  value: 50
+  value: 300

--- a/components/pipeline-service/development/update-tekton-config-performance.yaml
+++ b/components/pipeline-service/development/update-tekton-config-performance.yaml
@@ -4,7 +4,7 @@
   # default upstream setting
   # value: 2
   # upstream large scale env recommendation
-  value: 32
+  value: 128
 - op: replace
   path: /spec/pipeline/performance/kube-api-qps
   # default upstream setting


### PR DESCRIPTION
increase workqueue but leave k8s client settings alone