### PR TITLE
Fix: rename tekton-ci secret

### DIFF
--- a/components/tekton-ci/base/serviceaccount.yaml
+++ b/components/tekton-ci/base/serviceaccount.yaml
@@ -3,6 +3,6 @@ kind: ServiceAccount
 metadata:
   name: appstudio-pipeline
 secrets:
-  - name: tekton-ci-push-secret
+  - name: quay-push-secret
 imagePullSecrets:
-  - name: tekton-ci-push-secret
+  - name: quay-push-secret


### PR DESCRIPTION
Tekton-ci secret has been renamed in #2181, fixing to proper value