### PR TITLE
fix: reinstate the o11y repo in tekton-ci

### DIFF
--- a/components/tekton-ci/base/repository.yaml
+++ b/components/tekton-ci/base/repository.yaml
@@ -156,6 +156,13 @@ spec:
 apiVersion: pipelinesascode.tekton.dev/v1alpha1
 kind: Repository
 metadata:
+  name: o11y
+spec:
+  url: "https://github.com/redhat-appstudio/o11y"
+---
+apiVersion: pipelinesascode.tekton.dev/v1alpha1
+kind: Repository
+metadata:
   name: cachi2
 spec:
   url: "https://github.com/containerbuildsystem/cachi2"


### PR DESCRIPTION
The o11y repo was accidentally removed from the tekton-ci component which prevents CI from running for the o11y repo.

This change reintroduces the repo