### PR TITLE
SVPI-567: refactor vault-init to keep keys in a specific file

### DIFF
--- a/hack/spi/vault-init.sh
+++ b/hack/spi/vault-init.sh
@@ -23,7 +23,7 @@ SPI_POLICY_NAME=${SPI_DATA_PATH_PREFIX//\//-}
 function init() {
 	INIT_STATE=$(isInitialized)
 	if [ "$INIT_STATE" == "false" ]; then
-	    echo '' > ${KEYS_FILE}
+		echo '' >${KEYS_FILE}
 		vaultExec "vault operator init" >"${KEYS_FILE}"
 		echo "Keys written at ${KEYS_FILE}"
 	elif [ "$INIT_STATE" == "true" ]; then

--- a/hack/spi/vault-init.sh
+++ b/hack/spi/vault-init.sh
@@ -6,11 +6,14 @@ source $(dirname "$0")/utils.sh
 
 set -e
 
+mkdir -p $HOME/.tmp
+touch $HOME/.tmp/keys-file
+
 VAULT_KUBE_CONFIG=${VAULT_KUBE_CONFIG:-${KUBECONFIG:-$HOME/.kube/config}}
 VAULT_NAMESPACE=${VAULT_NAMESPACE:-spi-vault}
 SECRET_NAME=spi-vault-keys
 VAULT_PODNAME=${VAULT_PODNAME:-vault-0}
-KEYS_FILE=${KEYS_FILE:-$(mktemp)}
+KEYS_FILE=${KEYS_FILE:-"$(echo $HOME/.tmp)/keys-file"}
 ROOT_TOKEN=""
 ROOT_TOKEN_NAME=vault-root-token
 
@@ -20,6 +23,7 @@ SPI_POLICY_NAME=${SPI_DATA_PATH_PREFIX//\//-}
 function init() {
 	INIT_STATE=$(isInitialized)
 	if [ "$INIT_STATE" == "false" ]; then
+	    echo '' > ${KEYS_FILE}
 		vaultExec "vault operator init" >"${KEYS_FILE}"
 		echo "Keys written at ${KEYS_FILE}"
 	elif [ "$INIT_STATE" == "true" ]; then


### PR DESCRIPTION
### What does this PR do?
Refactor vault-init to keep keys in a specific file in order to make them reachable in a second attempt, for example, in case the secret is not created in the first attempt.

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/SVPI-567


### How to test this PR?

#### Install RHTAP through `bootstrap-cluster` script

- Set the required environment variables, such as: `MY_GIT_FORK_REMOTE`, `MY_GITHUB_ORG`, and `MY_GITHUB_TOKEN`
- Run `./hack/bootstrap-cluster.sh preview --keycloak --toolchain` script on infra-deployments dir

#### Install RHTAP through `e2e-tests` repo
Before following the steps on https://github.com/redhat-appstudio/e2e-tests#install-appstudio-in-e2e-mode, please set the following environment variables:

```
export INFRA_DEPLOYMENTS_ORG=rsoaresd
export INFRA_DEPLOYMENTS_BRANCH=SVPI-567
```