### PR TITLE
Link docker-io-pull secret to the correct service account

### DIFF
--- a/hack/secret-creator/set-docker-hub-pull-secret.sh
+++ b/hack/secret-creator/set-docker-hub-pull-secret.sh
@@ -15,8 +15,8 @@ main() {
     rm "$auth"
     oc registry login --registry=docker.io --auth-basic="$docker_io_auth" --to="$auth"
     oc create secret docker-registry docker-io-pull --from-file=.dockerconfigjson="$auth" -o yaml --dry-run=client | oc apply -f-
-    oc create serviceaccount pipeline -o yaml --dry-run=client | oc apply -f-
-    oc secrets link pipeline docker-io-pull
+    oc create serviceaccount appstudio-pipeline -o yaml --dry-run=client | oc apply -f-
+    oc secrets link appstudio-pipeline docker-io-pull
     rm "$auth"
 }
 


### PR DESCRIPTION
This should be appstudio-pipeline as used by the build-service.