### PR TITLE
chore: segment-bridge on authentication component

### DIFF
--- a/components/authentication/base/kustomization.yaml
+++ b/components/authentication/base/kustomization.yaml
@@ -14,6 +14,7 @@ resources:
 - sandbox-sre-admins.yaml
 - has-admin.yaml
 - inspect-pods.yaml
+- segment-bridge.yaml
 
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization


### PR DESCRIPTION
since segment-bridge needs to create resources on
the toolchain-host-operator, which doesn't have a component of its own, those resources are created through the authentication component.

While this will probably change later on, during the last change the connection between the resource yaml and the component was not made. this fix it.