### PR TITLE
chore: segment-bridge has the right usersignup access

### DIFF
--- a/components/authentication/base/segment-bridge.yaml
+++ b/components/authentication/base/segment-bridge.yaml
@@ -4,8 +4,8 @@ metadata:
   name: segment-bridge-read-access
   namespace: toolchain-host-operator
 rules:
-- apiGroups: [""]
-  resources: ["UserSignup"]
+- apiGroups: ["toolchain.dev.openshift.com"]
+  resources: ["usersignups"]
   verbs: ["get", "list", "watch"]
 ---
 apiVersion: v1


### PR DESCRIPTION
The apiGroups set in the segment-bridge configuration to access toolchain-host-operator were wrong.
This PR fix it by changing it to toolchain.dev.openshift.com.