### PR TITLE
managed-gitops: update cluster role to allow cluster maintenance of SnapshotEnvironmentBindings

### DIFF
--- a/components/gitops/base/authentication/gitops-clusterroles.yaml
+++ b/components/gitops/base/authentication/gitops-clusterroles.yaml
@@ -11,6 +11,14 @@ rules:
       - get
       - list
       - watch
+
+  - apiGroups:
+      - appstudio.redhat.com
+    resources:
+      - snapshotenvironmentbindings
+    verbs:
+      - delete
+
   - apiGroups:
       - operators.coreos.com
     resources:


### PR DESCRIPTION
Allow a single team member (myself) to delete SnapshotEnvironmentBindings: this will be used to clean up old SnapshotEnvironmentBindings that are orphaned due to https://issues.redhat.com/browse/RHTAPBUGS-498