### PR TITLE
Allow GitOps team members to access jgwest-tenant namespace where it is available

### DIFF
--- a/components/gitops/production/stone-prd-m01/gitops-team-member-namespaces.yaml
+++ b/components/gitops/production/stone-prd-m01/gitops-team-member-namespaces.yaml
@@ -1,0 +1,15 @@
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: gitops-allow-team-access-to-jgwest-tenant
+  namespace: jgwest-tenant
+subjects:
+  - kind: User
+    apiGroup: rbac.authorization.k8s.io
+    name: jgwest
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: gitops-namespaces-all-access
+---

--- a/components/gitops/production/stone-prd-m01/kustomization.yaml
+++ b/components/gitops/production/stone-prd-m01/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 
 resources:
 - ../base
+- gitops-team-member-namespaces.yaml
 
 patches:
   - path: gitops-service-postgres-rds-config-path.yaml

--- a/components/gitops/staging/stone-stg-m01/gitops-team-member-namespaces.yaml
+++ b/components/gitops/staging/stone-stg-m01/gitops-team-member-namespaces.yaml
@@ -1,0 +1,19 @@
+#
+# This file grants access to some specific tenant namespaces, to GitOps Service team members, to allow debugging/testing in those Namespaces.
+# - Note: this grants access to the team members's GitHub ID, not to their Red Hat ID.
+#
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: gitops-allow-team-access-to-jgwest-tenant
+  namespace: jgwest-tenant
+subjects:
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: GitOps Service Team
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: gitops-namespaces-all-access
+---

--- a/components/gitops/staging/stone-stg-m01/kustomization.yaml
+++ b/components/gitops/staging/stone-stg-m01/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 
 resources:
 - ../base
+- gitops-team-member-namespaces.yaml
 
 patches:
   - path: gitops-service-postgres-rds-config-path.yaml


### PR DESCRIPTION
- On staging MT, allow GitOps Service Team members group to access `jgwest-tenant`
- On prod MT, allow only  `jgwest` github user id to access `jgwest-tenant`