### PR TITLE
Fix links to RHTAP console from the PR

### DIFF
--- a/components/pipeline-service/staging/base/update-tekton-config-pac.yaml
+++ b/components/pipeline-service/staging/base/update-tekton-config-pac.yaml
@@ -5,3 +5,5 @@
     application-name: RHTAP Staging
     custom-console-name: RHTAP Staging
     custom-console-url: https://console.dev.redhat.com/preview/application-pipeline
+    custom-console-url-pr-details: https://console.dev.redhat.com/preview/application-pipeline
+    custom-console-url-pr-tasklog: https://console.dev.redhat.com/preview/application-pipeline


### PR DESCRIPTION
Initially set in a earlier PR, two configuration options were missing, now added.