### PR TITLE
use external-secrets for pyxis

### DIFF
--- a/ci/teams/rhtap-servicerelease/external-secrets/kustomization.yaml
+++ b/ci/teams/rhtap-servicerelease/external-secrets/kustomization.yaml
@@ -3,4 +3,5 @@ kind: Kustomization
 resources:
 - infra-deployments-pr-creator.yaml
 - slack-webhook-notification-secret.yaml
+- pyxis-secret.yaml
 namespace: rhtap-servicerelease-tenant

--- a/ci/teams/rhtap-servicerelease/external-secrets/pyxis-secret.yaml
+++ b/ci/teams/rhtap-servicerelease/external-secrets/pyxis-secret.yaml
@@ -1,0 +1,19 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: pyxis-staging-secret
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  dataFrom:
+    - extract:
+        key: "staging/release/pyxis/certificate"
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: appsre-stonesoup-vault
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    name: pyxis-staging-secret

--- a/ci/teams/rhtap-servicerelease/release-strategy.yaml
+++ b/ci/teams/rhtap-servicerelease/release-strategy.yaml
@@ -42,7 +42,7 @@ spec:
     - name: pyxisServerType
       value: stage
     - name: pyxisSecret
-      value: pyxis
+      value: pyxis-staging-secret
     - name: tag
       value: latest
     - name: addGitShaTag


### PR DESCRIPTION
- pull in pyxis secret from vault using external-secrets
- refer to new secret in release-strategy