### PR TITLE
RHTAP-1495: AppSet for RH users configurations

### DIFF
--- a/argo-cd-apps/base/tenants-config/kustomization.yaml
+++ b/argo-cd-apps/base/tenants-config/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - tenants-config.yaml

--- a/argo-cd-apps/base/tenants-config/tenants-config.yaml
+++ b/argo-cd-apps/base/tenants-config/tenants-config.yaml
@@ -1,0 +1,36 @@
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: tenants-config
+spec:
+  generators:
+    - git:
+        repoUrl: https://github.com/redhat-appstudio/tenants-config
+        revision: main
+        directories:
+          - path: auto-generated/cluster/stone-prd-rh01/*
+  template:
+    metadata:
+      name: '{{path.basename}}-{{path[2]}}'
+    spec:
+      # The project is created using app-interface
+      project: tenants-config
+      source:
+        path: '{{path}}'
+        repoURL: https://github.com/redhat-appstudio/tenants-config
+        targetRevision: main
+      destination:
+        namespace: '{{path.basename}}'
+        name: '{{path[2]}}'
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
+        syncOptions:
+          - CreateNamespace=true
+        retry:
+          limit: 10
+          backoff:
+            duration: 10s
+            factor: 2
+            maxDuration: 3m

--- a/argo-cd-apps/overlays/production/kustomization.yaml
+++ b/argo-cd-apps/overlays/production/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - ../../base/all-clusters
   - ../../base/tekton-ci
   - ../../base/ci-workspaces
+  - ../../base/tenants-config
 namespace: argocd
 
 patchesStrategicMerge:


### PR DESCRIPTION
Add a new application set that will generate application for RH each tenant defined in https://github.com/redhat-appstudio/tenants-config Each tenant has a directory with the name if his/hers namespace. The generate application will be associated with the "tenants-config" project that restricts which resources can be deployed, to which namespaces and clusters. The project is defined using app-interface.