### PR TITLE
fix: authentication is not having sandbox-sre-admins.yaml

### DIFF
--- a/components/authentication/base/kustomization.yaml
+++ b/components/authentication/base/kustomization.yaml
@@ -4,7 +4,6 @@ resources:
 - build.yaml
 - group-sync/
 - pipeline-service-sre.yaml
-- sandbox-sre-admins.yaml
 - inspect-pods.yaml
 
 apiVersion: kustomize.config.k8s.io/v1beta1


### PR DESCRIPTION
sandbox-sre-admins.yaml has been moved to
./components/sandbox/base/rbac/, this is causing fail of sync of authentication component.