### PR TITLE
RHTAP-1495: correct typo in tenants-config

### DIFF
--- a/argo-cd-apps/base/tenants-config/tenants-config.yaml
+++ b/argo-cd-apps/base/tenants-config/tenants-config.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   generators:
     - git:
-        repoUrl: https://github.com/redhat-appstudio/tenants-config
+        repoURL: https://github.com/redhat-appstudio/tenants-config
         revision: main
         directories:
           - path: auto-generated/cluster/stone-prd-rh01/*


### PR DESCRIPTION
- ApplicationSet.argoproj.io "tenants-config" is invalid: spec.generators[0].git.repoURL: Required value