### PR TITLE
Add RBAC to fix orphaned SpaceRequests on staging

### DIFF
--- a/components/gitops/base/authentication/gitops-clusterroles.yaml
+++ b/components/gitops/base/authentication/gitops-clusterroles.yaml
@@ -20,6 +20,18 @@ rules:
       - delete
 
   - apiGroups:
+    - toolchain.dev.openshift.com
+    resources:
+    - spacerequests
+    verbs:
+    - list
+    - watch
+    - create
+    - update
+    - patch
+    - delete
+
+  - apiGroups:
       - operators.coreos.com
     resources:
       - installplans


### PR DESCRIPTION
As requested [on RHTAP Slack](https://redhat-internal.slack.com/archives/C02C3SE8QS2/p1692913633009639), there are a number of SpaceRequests that are orphaned in a couple of namespaces on RHTAP staging. This grants access to us to allow us to delete them.