### PR TITLE
Fix staging sprayproxy duplicated GH_APP_WEBHOOK_SECRET

### DIFF
--- a/components/sprayproxy/staging/add-backends.yml
+++ b/components/sprayproxy/staging/add-backends.yml
@@ -1,6 +1,0 @@
----
-- op: add
-  path: /spec/template/spec/containers/0/env/0/value
-  value: >
-    https://pipelines-as-code-controller-openshift-pipelines.apps.stone-stg-m01.7ayg.p1.openshiftapps.com
-    https://pipelines-as-code-controller-openshift-pipelines.apps.stone-stg-rh01.l2vh.p1.openshiftapps.com

--- a/components/sprayproxy/staging/add-webhook-secret.yaml
+++ b/components/sprayproxy/staging/add-webhook-secret.yaml
@@ -1,9 +1,0 @@
----
-- op: add
-  path: /spec/template/spec/containers/0/env/-
-  value:
-    name: GH_APP_WEBHOOK_SECRET
-    valueFrom:
-      secretKeyRef:
-        name: pipelines-as-code-secret
-        key: webhook.secret

--- a/components/sprayproxy/staging/change-backends.yaml
+++ b/components/sprayproxy/staging/change-backends.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sprayproxy
+  namespace: sprayproxy
+spec:
+  template:
+    spec:
+      containers:
+        - name: sprayproxy
+          env:
+            - name: SPRAYPROXY_SERVER_BACKEND
+              value: >
+                https://pipelines-as-code-controller-openshift-pipelines.apps.stone-stg-m01.7ayg.p1.openshiftapps.com
+                https://pipelines-as-code-controller-openshift-pipelines.apps.stone-stg-rh01.l2vh.p1.openshiftapps.com

--- a/components/sprayproxy/staging/change-webhook-secret.yaml
+++ b/components/sprayproxy/staging/change-webhook-secret.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sprayproxy
+  namespace: sprayproxy
+spec:
+  template:
+    spec:
+      containers:
+        - name: sprayproxy
+          env:
+            - name: GH_APP_WEBHOOK_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: pipelines-as-code-secret
+                  key: webhook.secret

--- a/components/sprayproxy/staging/kustomization.yaml
+++ b/components/sprayproxy/staging/kustomization.yaml
@@ -11,14 +11,5 @@ images:
     newTag: 5ba6ee480187adae0ded1321fd19f46cd884884b
 
 patches:
-  - path: add-backends.yml
-    target:
-      name: sprayproxy
-      group: apps
-      version: v1
-  - path: add-webhook-secret.yaml
-    target:
-      name: sprayproxy
-      group: apps
-      version: v1
-      kind: Deployment
+  - path: change-backends.yaml
+  - path: change-webhook-secret.yaml


### PR DESCRIPTION
GH_APP_WEBHOOK_SECRET is defined in the config at the repo level so using a "patch add" was resulting in duplicated variable:

```
spec:
  template:
    spec:
      containers:
      - args:
        env:
        - name: GH_APP_WEBHOOK_SECRET
        - name: GH_APP_WEBHOOK_SECRET
          valueFrom:
            secretKeyRef:
              key: webhook.secret
              name: pipelines-as-code-secret
```

Instead, patch the varialble using a strategic merge. In addition to fix the duplicate, this methodology do not rely on container or variable indices so also change the SPRAYPROXY_SERVER_BACKEND to use same mechanism for robusness and consistency reasons.