### PR TITLE
Fix kube-linter issues for cluster-registration component

### DIFF
--- a/components/cluster-registration/installer-patch.yaml
+++ b/components/cluster-registration/installer-patch.yaml
@@ -1,0 +1,13 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+      - name: installer
+        securityContext:
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true

--- a/components/cluster-registration/kustomization.yaml
+++ b/components/cluster-registration/kustomization.yaml
@@ -24,3 +24,6 @@ namespace: cluster-reg-config
 # Note that it should also match with the prefix (text before '-') of the namespace
 # field above.
 namePrefix: cluster-registration-installer-
+
+patches:
+  - path: ./installer-patch.yaml


### PR DESCRIPTION
Set readOnlyRootFilesystem and runAsNonRoot to true for cluster-registration container.