### PR TITLE
fix(RHTAPWATCH-456): Resolve kubelinter warnings for monitoring component

### DIFF
--- a/components/monitoring/prometheus/development/dummy-service.yaml
+++ b/components/monitoring/prometheus/development/dummy-service.yaml
@@ -75,9 +75,28 @@ spec:
         ports:
         - containerPort: 8443
           name: https
+        resources:
+          limits:
+            cpu: 100m
+            memory: 200Mi
+          requests:
+            cpu: 100m
+            memory: 200Mi
         securityContext:
           allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
       - name: prometheus-example-app
         image: quay.io/brancz/prometheus-example-app:v0.1.0
         args:
         - "--bind=127.0.0.1:8081"
+        resources:
+          limits:
+            cpu: 100m
+            memory: 200Mi
+          requests:
+            cpu: 100m
+            memory: 200Mi
+        securityContext:
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true


### PR DESCRIPTION
KubeLinter output:
```
> kube-linter lint components/monitoring                                 
KubeLinter development

No lint errors found!
```

Also verified the dummy-service pod runs in a dev env and its metrics are still being collected successfully.