### PR TITLE
Remove PaC ConfigMap Prod

### DIFF
--- a/components/pipeline-service/production/base/kustomization.yaml
+++ b/components/pipeline-service/production/base/kustomization.yaml
@@ -8,7 +8,7 @@ commonAnnotations:
   argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 
 resources:
-  - git::https://github.com/openshift-pipelines/pipeline-service.git/operator/gitops/argocd/pipeline-service?ref=153ce437712b2da250c5d9b168ac0fed5e0ffd85
+  - git::https://github.com/openshift-pipelines/pipeline-service.git/operator/gitops/argocd/pipeline-service?ref=a806b150697f03f47395a8c998d4fc82dbc25f95
   - pipelines-as-code-secret.yaml # create external secret in openshift-pipelines namespace
   - ../../base/external-secrets
   - ../../base/testing
@@ -16,16 +16,15 @@ resources:
   - team-support-rbac.yaml
 
 patches:
-  - path: pac-config.yaml
-    target:
-      kind: ConfigMap
-      name: pipelines-as-code
-      namespace: openshift-pipelines
 #  - path: scale-down-exporter.yaml
 #    target:
 #      kind: Deployment
 #      name: pipeline-metrics-exporter
 #      namespace: openshift-pipelines
+  - path: update-tekton-config-pac.yaml
+    target:
+      kind: TektonConfig
+      name: config
   - path: update-tekton-config-performance.yaml
     target:
       kind: TektonConfig

--- a/components/pipeline-service/production/base/pipelines-as-code-secret-path.yaml
+++ b/components/pipeline-service/production/base/pipelines-as-code-secret-path.yaml
@@ -1,4 +1,0 @@
----
-- op: add
-  path: /spec/dataFrom/0/extract/key
-  value: production/pipeline-service/github-app

--- a/components/pipeline-service/production/base/update-tekton-config-pac.yaml
+++ b/components/pipeline-service/production/base/update-tekton-config-pac.yaml
@@ -1,0 +1,9 @@
+---
+- op: add
+  path: /spec/platforms/openshift/pipelinesAsCode/settings
+  value:
+    application-name: Red Hat Trusted App Pipeline
+    custom-console-name: Red Hat Trusted App Pipeline
+    custom-console-url: https://console.redhat.com/preview/application-pipeline
+    custom-console-url-pr-details: https://console.redhat.com/preview/application-pipeline
+    custom-console-url-pr-tasklog: https://console.redhat.com/preview/application-pipeline


### PR DESCRIPTION
We now deploy PaC through the OSP operator, so the configuration is read from the TektonConfig CR. The change has been validated in Staging. CLEANUP: pipelines-as-code-secret-path.yaml was a leftover from a previous change and it was not used.