### PR TITLE
Ignore differences for build request annotation

### DIFF
--- a/argo-cd-apps/base/tenants-config/tenants-config.yaml
+++ b/argo-cd-apps/base/tenants-config/tenants-config.yaml
@@ -22,6 +22,11 @@ spec:
       destination:
         namespace: '{{path.basename}}'
         name: '{{path[2]}}'
+      ignoreDifferences:
+        - group: appstudio.redhat.com
+          kind: Component
+          jsonPointers:
+            - /metadata/annotations/build.appstudio.openshift.io~1request
       syncPolicy:
         automated:
           prune: true


### PR DESCRIPTION
In order for configuring components usings ArgoCD, we need to ignore changes to the
build.appstudio.openshift.io/request annotation (it's being removed by the build controller).