### PR TITLE
Create rhtap-admins cluster role and binding

### DIFF
--- a/components/authentication/base/kustomization.yaml
+++ b/components/authentication/base/kustomization.yaml
@@ -2,6 +2,7 @@ resources:
 - everyone-can-view.yaml
 - component-maintainer.yaml
 - group-sync/
+- rhtap-admins.yaml
 
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/components/authentication/base/rhtap-admins.yaml
+++ b/components/authentication/base/rhtap-admins.yaml
@@ -1,0 +1,254 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: rhtap-admins
+rules:
+  - apiGroups:
+      - appstudio.redhat.com
+    resources:
+      - applications
+      - buildpipelineselectors
+      - componentdetectionqueries
+      - components
+      - enterprisecontractpolicies
+      - environments
+      - integrationtestscenarios
+      - promotionruns
+      - releaseplanadmissions
+      - releaseplans
+      - releases
+      - releasestrategies
+      - snapshotenvironmentbindings
+      - snapshots
+      - spiaccesschecks
+      - spiaccesstokenbindings
+      - spifilecontentrequests
+      - remotesecrets
+    verbs:
+      - '*'
+  - apiGroups:
+      - managed-gitops.redhat.com
+    resources:
+      - gitopsdeploymentmanagedenvironments
+      - gitopsdeployments
+      - gitopsdeploymentsyncruns
+      - operations
+    verbs:
+      - '*'
+  - apiGroups:
+      - jvmbuildservice.io
+    resources:
+      - artifactbuilds
+      - dependencybuilds
+      - rebuiltartifacts
+      - systemconfigs
+      - tektonwrappers
+      - jbsconfigs
+    verbs:
+      - '*'
+  - apiGroups:
+      - pipelinesascode.tekton.dev
+    resources:
+      - repositories
+    verbs:
+      - '*'
+  - apiGroups:
+      - ''
+    resources:
+      - clusterpolicybindings
+      - clusterresourcequotas
+      - images
+      - netnamespaces
+      - nodes
+      - persistentvolumes
+      - securitycontextconstraints
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - apiserver.openshift.io
+    resources:
+      - apirequestcounts
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - machineconfiguration.openshift.io
+    resources:
+      - machineconfigs
+      - machineconfigpools
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - machine.openshift.io
+    resources:
+      - machinesets
+      - machines
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - network.openshift.io
+    resources:
+      - clusternetworks
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ''
+    resources:
+      - buildconfigs/webhooks
+      - buildlogs
+      - configmaps
+      - deploymentconfigs
+      - deploymentconfigs/scale
+      - egressnetworkpolicies
+      - endpoints
+      - imagestreamimages
+      - imagestreammappings
+      - imagestreams
+      - imagetags
+      - limitranges
+      - persistentvolumeclaims
+      - pods
+      - pods/attach
+      - pods/exec
+      - pods/port-forward
+      - processedtemplates
+      - replicationcontrollers
+      - replicationcontrollers/scale
+      - resourcequotas
+      - roles
+      - routes
+      - serviceaccounts
+      - services
+      - templateconfigs
+      - templateinstances
+      - templates
+    verbs:
+      - '*'
+  - apiGroups:
+      - 'apps'
+    resources:
+      - daemonsets
+      - deployments
+      - deployments/scale
+      - replicasets
+      - replicasets/scale
+      - statefulsets
+      - statefulsets/scale
+    verbs:
+      - '*'
+  - apiGroups:
+      - 'batch'
+    resources:
+      - cronjobs
+      - jobs
+    verbs:
+      - '*'
+  - apiGroups:
+      - extensions
+    resources:
+      - daemonsets
+      - deployments
+      - deployements/rollback
+      - deployments/scale
+      - ingresses
+      - networkpolicies
+      - replicasets
+      - replicasets/scale
+      - replicationcontrollers/scale
+    verbs:
+      - '*'
+  - apiGroups:
+      - apps.openshift.io
+    resources:
+      - deploymentconfigs
+      - deploymentconfigs/scale
+    verbs:
+      - '*'
+  - apiGroups:
+      - authorization.openshift.io
+    resources:
+      - roles
+    verbs:
+      - '*'
+  - apiGroups:
+      - build.openshift.io
+    resources:
+      - builds
+      - buildconfigs
+      - buildconfigs/webhooks
+      - buildlogs
+    verbs:
+      - '*'
+  - apiGroups:
+      - image.openshift.io
+    resources:
+      - imagestreams
+      - imagestreamimages
+      - imagestreammappings
+      - imagetags
+    verbs:
+      - '*'
+  - apiGroups:
+      - route.openshift.io
+    resources:
+      - routes
+    verbs:
+      - '*'
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - roles
+    verbs:
+      - '*'
+  - apiGroups:
+      - autoscaling
+    resources:
+      - horizontalpodautoscalers
+    verbs:
+      - '*'
+  - apiGroups:
+      - monitoring.coreos.com
+    resources:
+      - alertmanagers
+      - prometheuses
+      - prometheusrules
+      - servicemonitors
+      - podmonitors
+      - thanosrulers
+    verbs:
+      - '*'
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: rhtap-admins
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: rhtap-admins
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: RHTAP Admins
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: rhtap-admins-view
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: view
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: RHTAP Admins


### PR DESCRIPTION
The managed built-in role dedicated-admins grants access to secrets in all namespaces and we do not want that. Create a new cluster role which will used instead of dedicated-admins and that role does not have the right to list secrets.

The initial set or rules proposed in this change was put together by inspecting the dedicated-admins role, which is an aggregated cluster role. Some permissions might be missing as this is an initial proposal only and we can add missing ones as we find them.

[RHTAPSRE-168](https://issues.redhat.com//browse/RHTAPSRE-168)