### PR TITLE
Install dvo on rhtap clusters

### DIFF
--- a/argo-cd-apps/base/all-clusters/infra-deployments/enable-dvo-for-all-cluster/enable-dvo.yaml
+++ b/argo-cd-apps/base/all-clusters/infra-deployments/enable-dvo-for-all-cluster/enable-dvo.yaml
@@ -25,11 +25,14 @@ spec:
         repoURL: https://github.com/redhat-appstudio/infra-deployments.git
         targetRevision: main
       destination:
+        namespace: deployment-validation-operator
         server: '{{server}}'
       syncPolicy:
         automated:
           prune: true
           selfHeal: true
+        syncOptions:
+          - CreateNamespace=true
         retry:
           limit: -1
           backoff:

--- a/argo-cd-apps/base/all-clusters/infra-deployments/enable-dvo-for-all-cluster/enable-dvo.yaml
+++ b/argo-cd-apps/base/all-clusters/infra-deployments/enable-dvo-for-all-cluster/enable-dvo.yaml
@@ -1,0 +1,38 @@
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: enable-dvo
+spec:
+  generators:
+    - merge:
+        mergeKeys:
+          - nameNormalized
+        generators:
+          - clusters:
+              values:
+                sourceRoot: configs/enable-dvo-for-all-cluster
+                environment: staging
+                clusterDir: ""
+          - list:
+              elements: []
+  template:
+    metadata:
+      name: enable-dvo-{{nameNormalized}}
+    spec:
+      project: default
+      source:
+        path: configs/enable-dvo-for-all-cluster
+        repoURL: https://github.com/redhat-appstudio/infra-deployments.git
+        targetRevision: main
+      destination:
+        server: '{{server}}'
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
+        retry:
+          limit: -1
+          backoff:
+            duration: 10s
+            factor: 2
+            maxDuration: 3m

--- a/argo-cd-apps/base/all-clusters/infra-deployments/enable-dvo-for-all-cluster/kustomization.yaml
+++ b/argo-cd-apps/base/all-clusters/infra-deployments/enable-dvo-for-all-cluster/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - enable-dvo.yaml

--- a/argo-cd-apps/base/all-clusters/infra-deployments/kustomization.yaml
+++ b/argo-cd-apps/base/all-clusters/infra-deployments/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
   - monitoring-workload-logging
   - authentication
   - disable-csvcopy-for-all-cluster
+  - enable-dvo-for-all-cluster
 
 components:
   - ../../../k-components/inject-infra-deployments-repo-details

--- a/configs/enable-dvo-for-all-cluster/configure-dvo.yaml
+++ b/configs/enable-dvo-for-all-cluster/configure-dvo.yaml
@@ -1,0 +1,42 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: deployment-validation-operator-config
+  namespace: deployment-validation-operator
+  labels:
+    name: deployment-validation-operator
+data:
+  deployment-validation-operator-config.yaml: |-
+    checks:
+      doNotAutoAddDefaults: true
+      addAllBuiltIn: false
+      include:
+      - "host-ipc"
+      - "host-network"
+      - "host-pid"
+      - "non-isolated-pod"
+      - "pdb-max-unavailable"
+      - "pdb-min-available"
+      - "privilege-escalation-container"
+      - "privileged-container"
+      - "run-as-non-root"
+      - "unsafe-sysctls"
+      - "unset-cpu-requirements"
+      - "unset-memory-requirements"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: deployment-validation-operator
+  name: deployment-validation-operator-metrics
+  namespace: deployment-validation-operator
+spec:
+  ports:
+  - name: http-metrics
+    port: 8383
+    protocol: TCP
+    targetPort: 8383
+  selector:
+    name: deployment-validation-operator

--- a/configs/enable-dvo-for-all-cluster/install-dvo.yaml
+++ b/configs/enable-dvo-for-all-cluster/install-dvo.yaml
@@ -1,9 +1,26 @@
 ---
 apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: deployment-validation-operator-catalog
+  labels:
+    name: deployment-validation-operator
+spec:
+  displayName: Deployment Validation Operator
+  grpcPodConfig:
+    securityContextConfig: restricted
+  image: quay.io/app-sre/deployment-validation-operator-catalog:latest
+  publisher: OperatorHub.io
+  sourceType: grpc
+
+---
+apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
   name: deployment-validation-operator
-  namespace: openshift-operators
+  labels:
+    name: deployment-validation-operator
+  namespace: deployment-validation-operator
 spec:
   channel: alpha
   installPlanApproval: Automatic
@@ -11,3 +28,15 @@ spec:
   source: community-operators
   sourceNamespace: openshift-marketplace
   startingCSV: deployment-validation-operator.v0.6.0
+
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: deployment-validation-operator
+  labels:
+    name: deployment-validation-operator
+  namespace: deployment-validation-operator
+spec:
+  targetNamespaces:
+  - deployment-validation-operator

--- a/configs/enable-dvo-for-all-cluster/install-dvo.yaml
+++ b/configs/enable-dvo-for-all-cluster/install-dvo.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: deployment-validation-operator
+  namespace: openshift-operators
+spec:
+  channel: alpha
+  installPlanApproval: Automatic
+  name: deployment-validation-operator
+  source: community-operators
+  sourceNamespace: openshift-marketplace
+  startingCSV: deployment-validation-operator.v0.6.0

--- a/configs/enable-dvo-for-all-cluster/kustomization.yaml
+++ b/configs/enable-dvo-for-all-cluster/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - install-dvo.yaml

--- a/configs/enable-dvo-for-all-cluster/kustomization.yaml
+++ b/configs/enable-dvo-for-all-cluster/kustomization.yaml
@@ -1,4 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: deployment-validation-operator
 resources:
   - install-dvo.yaml
+  - configure-dvo.yaml


### PR DESCRIPTION
* This PR installs Deployment-Validation-Operator(DVO) in all RHTAP clusters.
* DVO works as a second level of checking on the installed CRs as kube-lint in the CI.
* This is part of the following best practices effort https://issues.redhat.com/browse/RHTAPSRE-93
