### PR TITLE
Grant rhtap-admins access to user.openshift.io resources

### DIFF
--- a/components/authentication/base/rhtap-admins.yaml
+++ b/components/authentication/base/rhtap-admins.yaml
@@ -226,6 +226,15 @@ rules:
       - thanosrulers
     verbs:
       - '*'
+  - apiGroups:
+    - user.openshift.io
+    resources:
+      - groups
+      - identities
+      - useridentitymappings
+      - users
+    verbs:
+      - '*'
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
This is part of dedicated admin and was missing in original change[1] to replace dedicated-admins by rhtap-admins.

[RHTAPSRE-168](https://issues.redhat.com//browse/RHTAPSRE-168)

[1]616fc37f64b20c31677f91a2c7175948cadc6923