### PR TITLE
bump pipeline-service prod to the same level that has been vetted in stage

### DIFF
--- a/components/pipeline-service/production/base/kustomization.yaml
+++ b/components/pipeline-service/production/base/kustomization.yaml
@@ -8,7 +8,7 @@ commonAnnotations:
   argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 
 resources:
-  - https://github.com/openshift-pipelines/pipeline-service.git/operator/gitops/argocd/pipeline-service?ref=a806b150697f03f47395a8c998d4fc82dbc25f95
+  - https://github.com/openshift-pipelines/pipeline-service.git/operator/gitops/argocd/pipeline-service?ref=0ec317814d86b591df6d40fd0b11567ff5a477ea
   - pipelines-as-code-secret.yaml # create external secret in openshift-pipelines namespace
   - ../../base/external-secrets
   - ../../base/testing


### PR DESCRIPTION
Includes these commits:
[allow ingress annotation overwrite](https://github.com/openshift-pipelines/pipeline-service/commit/528d66ca0ac052daddb9db844daf94535430401c)
[update operator/gitops/argocd/pipeline-service/metrics-exporter/kusto…](https://github.com/openshift-pipelines/pipeline-service/commit/532acec5d86ffe83992565bc4d4cd6913b8a29c7)
[add tekton chains grafana dashboard](https://github.com/openshift-pipelines/pipeline-service/commit/34211efea5a7e7012e5f0c283048746930517e77)
[update operator/gitops/argocd/pipeline-service/tekton-results/kustomi…](https://github.com/openshift-pipelines/pipeline-service/commit/ea3ef24d9d65ab1ea3ee7c103078472b4a2c1002)
[Remove TLS_HOSTNAME_OVERRIDE](https://github.com/openshift-pipelines/pipeline-service/commit/7d6a86c687bc0f3bc32d43d81d237f08673c2334)
[Refactor update-dependencies 2/2](https://github.com/openshift-pipelines/pipeline-service/commit/b62bc2571e7e763d6cab0c6f0a5dc661b3a23e7e)
[Update binaries](https://github.com/openshift-pipelines/pipeline-service/commit/1b61d28ae8d25a38af19f6d0f84bcbe1ae366d0a)
[update operator/gitops/argocd/pipeline-service/metrics-exporter/kusto…](https://github.com/openshift-pipelines/pipeline-service/commit/6ca17bf939b8480c3cf1ca240a2b05a98be381c9)
[update operator/gitops/argocd/pipeline-service/metrics-exporter/kusto…](https://github.com/openshift-pipelines/pipeline-service/commit/bd054a18533ac64975a28210f3175d6a327b572e)
[preserve cluster sprayproxy-qe](https://github.com/openshift-pipelines/pipeline-service/commit/d09e915cb22559ec31c5f762c2f456f48b66c953)
[Update binaries](https://github.com/openshift-pipelines/pipeline-service/commit/a5382231904b42d3a46975a007cb559e2222928a)
[Fix http2 errors in tekton-results API server](https://github.com/openshift-pipelines/pipeline-service/commit/0ec317814d86b591df6d40fd0b11567ff5a477ea)