### PR TITLE
Increase the frequency of PaC secret refresh

### DIFF
--- a/components/pipeline-service/production/base/pipelines-as-code-secret.yaml
+++ b/components/pipeline-service/production/base/pipelines-as-code-secret.yaml
@@ -10,7 +10,7 @@ spec:
   dataFrom:
     - extract:
         key: production/pipeline-service/github-app
-  refreshInterval: 1h
+  refreshInterval: 5m
   secretStoreRef:
     kind: ClusterSecretStore
     name: appsre-stonesoup-vault

--- a/components/pipeline-service/staging/base/pipelines-as-code-secret.yaml
+++ b/components/pipeline-service/staging/base/pipelines-as-code-secret.yaml
@@ -10,7 +10,7 @@ spec:
   dataFrom:
     - extract:
         key: staging/pipeline-service/github-app
-  refreshInterval: 1h
+  refreshInterval: 5m
   secretStoreRef:
     kind: ClusterSecretStore
     name: appsre-stonesoup-vault

--- a/components/sprayproxy/production/pipelines-as-code-secret.yaml
+++ b/components/sprayproxy/production/pipelines-as-code-secret.yaml
@@ -9,7 +9,7 @@ spec:
   dataFrom:
     - extract:
         key: production/pipeline-service/github-app
-  refreshInterval: 1h
+  refreshInterval: 5m
   secretStoreRef:
     kind: ClusterSecretStore
     name: appsre-stonesoup-vault

--- a/components/sprayproxy/staging/pipelines-as-code-secret.yaml
+++ b/components/sprayproxy/staging/pipelines-as-code-secret.yaml
@@ -9,7 +9,7 @@ spec:
   dataFrom:
     - extract:
         key: staging/pipeline-service/github-app
-  refreshInterval: 1h
+  refreshInterval: 5m
   secretStoreRef:
     kind: ClusterSecretStore
     name: appsre-stonesoup-vault


### PR DESCRIPTION
The current frequency generates a long outage of PaC when the credentials are rotated. In order to keep the disruption to a minimum, the frequency is increased to 5 minutes.