### PR TITLE
Remove dvo from rhtap dev and CI

### DIFF
--- a/argo-cd-apps/overlays/development/delete-applications.yaml
+++ b/argo-cd-apps/overlays/development/delete-applications.yaml
@@ -52,3 +52,9 @@ kind: ApplicationSet
 metadata:
   name: cluster-registration
 $patch: delete
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: enable-dvo
+$patch: delete

--- a/configs/enable-dvo-for-all-cluster/install-dvo.yaml
+++ b/configs/enable-dvo-for-all-cluster/install-dvo.yaml
@@ -20,14 +20,12 @@ metadata:
   name: deployment-validation-operator
   labels:
     name: deployment-validation-operator
-  namespace: deployment-validation-operator
 spec:
   channel: alpha
   installPlanApproval: Automatic
   name: deployment-validation-operator
   source: community-operators
-  sourceNamespace: openshift-marketplace
-  startingCSV: deployment-validation-operator.v0.6.0
+  sourceNamespace: deployment-validation-operator
 
 ---
 apiVersion: operators.coreos.com/v1


### PR DESCRIPTION
* DVO is used for doing a second level of installed CRs in the cluster.
* We need this in stage and prod, so excluding the CI and dev
*  the issues are handled with prometheus metrics.