### PR TITLE
RHTAPREL-435: fix missing overlay

### DIFF
--- a/argo-cd-apps/overlays/production/kustomization.yaml
+++ b/argo-cd-apps/overlays/production/kustomization.yaml
@@ -5,7 +5,6 @@ resources:
   - ../../base/member
   - ../../base/all-clusters
   - ../../base/tekton-ci
-  - ../../base/ci-workspaces
   - ../../base/tenants-config
   - ../../base/cluster-secret-store-rh
   - ../../base/rh-managed-workspaces-config


### PR DESCRIPTION
- forgot to remove reference to ci-workspace