### PR TITLE
chore(RHTAPWATCH-518): deploy grafana probe from o11y repo

### DIFF
--- a/components/monitoring/grafana/base/dashboards/kustomization.yaml
+++ b/components/monitoring/grafana/base/dashboards/kustomization.yaml
@@ -22,3 +22,5 @@ commonAnnotations:
 
 configurations:
   - cm-dashboard.yaml
+
+namespace: "appstudio-grafana"

--- a/components/monitoring/grafana/base/kustomization.yaml
+++ b/components/monitoring/grafana/base/kustomization.yaml
@@ -4,5 +4,4 @@ resources:
 - grafana-operator.yaml
 - grafana-app.yaml
 - dashboards
-
-namespace: "appstudio-grafana"
+- https://github.com/redhat-appstudio/o11y/config/probes/monitoring/grafana/base?ref=e8f31ce7ab37729d4c2d2f1b676995de8bb27e37


### PR DESCRIPTION
Deploy the Grafana availability probe from o11y to infra-deployments.

To allow deploying resources to multiple namespaces from monitoring/grafana kustomization file, I had to move the namespace field from the top-level file to the dashboards directory. Other than resources inside the dashboards dir, all existing resources here already had the namespace explicitly provided, so no change was needed there elsewhere.