### PR TITLE
RHTAPREL-435: remove release-service from tekton-ci

### DIFF
--- a/components/tekton-ci/base/repository.yaml
+++ b/components/tekton-ci/base/repository.yaml
@@ -72,13 +72,6 @@ spec:
 apiVersion: pipelinesascode.tekton.dev/v1alpha1
 kind: Repository
 metadata:
-  name: release-service
-spec:
-  url: "https://github.com/redhat-appstudio/release-service"
----
-apiVersion: pipelinesascode.tekton.dev/v1alpha1
-kind: Repository
-metadata:
   name: build-service
 spec:
   url: "https://github.com/redhat-appstudio/build-service"


### PR DESCRIPTION
- allow release-service to be built as native component in RHTAP
- PipelineAsCode fails if the repo is defined in tekton-ci
- See https://github.com/redhat-appstudio/tenants-config/pull/55