### PR TITLE
Add a cron job to send notification about cluster/dedicated-admins

### DIFF
--- a/components/authentication/base/admin-checker/admin-checker-sa.yaml
+++ b/components/authentication/base/admin-checker/admin-checker-sa.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: admin-checker-sa
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: groups-reader
+rules:
+- apiGroups:
+    - "user.openshift.io"
+  resources:
+    - "groups"
+  verbs:
+    - "get"
+    - "list"
+    - "watch"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: admin-checker-group-reader
+subjects:
+- kind: ServiceAccount
+  name: admin-checker-sa
+  namespace: admin-checker
+roleRef:
+  kind: ClusterRole
+  name: groups-reader
+  apiGroup: rbac.authorization.k8s.io

--- a/components/authentication/base/admin-checker/cronjob.yaml
+++ b/components/authentication/base/admin-checker/cronjob.yaml
@@ -1,0 +1,51 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: check-cluster-admins
+spec:
+  schedule: "0 7 * * 1" # every Monday at 7:00
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+            - name: admin-checker
+              image: registry.redhat.io/openshift4/ose-cli:v4.12
+              env:
+                - name: ADMIN_CHECKER_WORKFLOW_URL
+                  valueFrom:
+                    secretKeyRef:
+                      name: rhtap-infra-secrets
+                      key: admin-checker-workflow-url
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  validate_and_notify_for_group(){
+                    local group="$1"
+                    local users
+                    users=$(oc get group "${group}" -o jsonpath='{.users}' | tr -d '"[]')
+                    if [[ -n "${users}" ]]; then
+                      echo "The list of ${group} is: ${users}"
+                      curl -s -X POST "${ADMIN_CHECKER_WORKFLOW_URL}" \
+                      -H 'Content-Type: application/json' \
+                      -d '{"clusterName": "'$(oc whoami --show-console)'", "userNames": "'${users}'", "groupName": "'${group}'" }'
+                    else
+                      echo "The is no one part of ${group}"
+                    fi
+                  }
+
+                  validate_and_notify_for_group "cluster-admins"
+                  validate_and_notify_for_group "dedicated-admins"
+              resources:
+                requests:
+                  cpu: 100m
+                  memory: 10Mi
+                limits:
+                  cpu: 100m
+                  memory: 100Mi
+              securityContext:
+                readOnlyRootFilesystem: true
+                runAsNonRoot: true
+          restartPolicy: OnFailure
+          serviceAccountName: admin-checker-sa

--- a/components/authentication/base/admin-checker/external-secrets/kustomization.yaml
+++ b/components/authentication/base/admin-checker/external-secrets/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - rhtap-infra-secrets.yaml

--- a/components/authentication/base/admin-checker/external-secrets/rhtap-infra-secrets.yaml
+++ b/components/authentication/base/admin-checker/external-secrets/rhtap-infra-secrets.yaml
@@ -1,0 +1,21 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: rhtap-infra-secrets
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  dataFrom:
+    - extract:
+        conversionStrategy: Default
+        decodingStrategy: None
+        key: staging/platform/rhtap-infra-secrets
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: appsre-stonesoup-vault
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    name: rhtap-infra-secrets

--- a/components/authentication/base/admin-checker/kustomization.yaml
+++ b/components/authentication/base/admin-checker/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: admin-checker
+resources:
+  - admin-checker-sa.yaml
+  - cronjob.yaml
+  - namespace.yaml
+  - external-secrets/

--- a/components/authentication/base/admin-checker/namespace.yaml
+++ b/components/authentication/base/admin-checker/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: admin-checker

--- a/components/authentication/base/kustomization.yaml
+++ b/components/authentication/base/kustomization.yaml
@@ -3,6 +3,7 @@ resources:
 - component-maintainer.yaml
 - group-sync/
 - rhtap-admins.yaml
+- admin-checker/
 
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/components/authentication/production/kustomization.yaml
+++ b/components/authentication/production/kustomization.yaml
@@ -15,3 +15,9 @@ patches:
       kind: ExternalSecret
       group: external-secrets.io
       version: v1beta1
+  - path: rhtap-infra-secrets-patch.yaml
+    target:
+      name: rhtap-infra-secrets
+      kind: ExternalSecret
+      group: external-secrets.io
+      version: v1beta1

--- a/components/authentication/production/rhtap-infra-secrets-patch.yaml
+++ b/components/authentication/production/rhtap-infra-secrets-patch.yaml
@@ -1,0 +1,4 @@
+---
+- op: add
+  path: /spec/dataFrom/0/extract/key
+  value: production/platform/rhtap-infra-secrets

--- a/components/cluster-secret-store/base/appsre-stonesoup-vault-secret-store.yaml
+++ b/components/cluster-secret-store/base/appsre-stonesoup-vault-secret-store.yaml
@@ -46,3 +46,4 @@ spec:
         - rhtap-servicerelease-tenant
         - rhtap-build-tenant
         - rhtap-o11y-tenant
+        - admin-checker


### PR DESCRIPTION
Both cluster-admins and dedicated-admins groups should have no permanent members. We add people to those groups as a temporary measure only. This cron checks if there are members in those groups and if there are, send a notification to team-rhtap-infra slack private channel.

To send the notification, the cron calls a slack workflow URL which accept clusterName, userNames aand groupName as parameters. The workflow then compose a message and send it to the team-rhtap-slack channel, e.g.:

```
Hi, this is a friendly reminder to not forget to remove the following
admin access:
cluster name: https://console-openshift-console.apps.somecluster.com
group: cluster-admins
user names: hares
```

[RHTAPSRE-29](https://issues.redhat.com//browse/RHTAPSRE-29)