### PR TITLE
PLNSRVCE-1328: allow access to clusterresourcequota for SOP for per namespace secrets quota

### DIFF
--- a/components/pipeline-service/base/rbac/cluster-role/pipeline-service-sre.yaml
+++ b/components/pipeline-service/base/rbac/cluster-role/pipeline-service-sre.yaml
@@ -12,6 +12,26 @@ rules:
       - delete
     resources:
       - secrets
+  # This rule is needed to deal with situations like RHTAPBUGS-256, where we followed up via PLNSRVCE-1328
+  - apiGroups:
+      - quota.openshift.io
+    verbs:
+      - list
+      - get
+      - watch
+    resources:
+      - clusterresourcequotas
+  # This rule is needed to deal with situations like RHTAPBUGS-256, where we followed up via PLNSRVCE-1328.
+  # It also serves as the replacement for the list/delete rule above, which will be removed when we upgrade
+  # to OSP 1.12.
+  - apiGroups:
+      - ""
+    verbs:
+      - get
+      - list
+      - watch
+    resources:
+      - secrets
   # Grant access to the default account used to run pipelines
   - apiGroups:
       - ""


### PR DESCRIPTION
To build upon the scripts constructed for RHTAPBUGS-256, being able to access the `ClusterResourceQuota` defined for secrets quota defined in https://github.com/codeready-toolchain/host-operator/blob/e0e1f34678c7da11dcb426975d887c4540e1283c/deploy/templates/nstemplatetiers/appstudio/cluster.yaml#L91-L103 is required

Then we can compare secret accounts per namespace with the quotas defined.  

Looks like existing RBAC should let is examine events around secret creation being prevented because of quota.