### PR TITLE
managed-gitops: temporarily all component maintainer to modify WebhookConfiguration

### DIFF
--- a/components/gitops/base/authentication/gitops-clusterroles.yaml
+++ b/components/gitops/base/authentication/gitops-clusterroles.yaml
@@ -20,9 +20,10 @@ rules:
       - delete
 
   - apiGroups:
-    - toolchain.dev.openshift.com
+    - admissionregistration.k8s.io
     resources:
-    - spacerequests
+    - validatingwebhookconfigurations
+    - mutatingwebhookconfigurations
     verbs:
     - list
     - watch


### PR DESCRIPTION
Temporarily enable write RBAC on `ValidatingWebhookConfiguration`, to allow us to debug the root cause of https://issues.redhat.com/browse/RHTAPBUGS-862.