### PR TITLE
Remove rights for rhtap-admin on internalrequests

### DIFF
--- a/components/authentication/base/rhtap-admins.yaml
+++ b/components/authentication/base/rhtap-admins.yaml
@@ -13,7 +13,8 @@ rules:
       - enterprisecontractpolicies
       - environments
       - integrationtestscenarios
-      - internalrequests
+      # RHTAP Admins should not be permitted to create or edit InternalRequest resources.
+      # - internalrequests
       - promotionruns
       - releaseplanadmissions
       - releaseplans


### PR DESCRIPTION
The InternalRequest resource permits elevated access outside of the RHTAP member cluster. Only the release pipeline service account should be managing these.