### PR TITLE
Fix admin-checker cron on empty list of users

### DIFF
--- a/components/authentication/base/admin-checker/cronjob.yaml
+++ b/components/authentication/base/admin-checker/cronjob.yaml
@@ -24,7 +24,7 @@ spec:
                   validate_and_notify_for_group(){
                     local group="$1"
                     local users
-                    users=$(oc get group "${group}" -o jsonpath='{.users}' | tr -d '"[]')
+                    users=$(oc get group "${group}" -o jsonpath='{.users}' | sed "s/<nil>//g" | tr -d '"[]')
                     if [[ -n "${users}" ]]; then
                       echo "The list of ${group} is: ${users}"
                       curl -s -X POST "${ADMIN_CHECKER_WORKFLOW_URL}" \


### PR DESCRIPTION
Before last OCP upgrade, the command
`oc get group "${group}" -o jsonpath='{.users}'` was returing `[]` when no users were in the group, now it returns `<nil>`. Adjust script to support both use cases.