### PR TITLE
Remove unneeded secret for perf-team-prometheus-reader

### DIFF
--- a/components/perf-team-prometheus-reader/base/serviceaccount.yaml
+++ b/components/perf-team-prometheus-reader/base/serviceaccount.yaml
@@ -25,12 +25,3 @@ roleRef:
   kind: ClusterRole
   name: perf-team-prometheus-reader-read-openshift-monitoring
   apiGroup: rbac.authorization.k8s.io
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: perf-team-prometheus-reader
-  namespace: perf-team-prometheus-reader
-  annotations:
-    kubernetes.io/service-account.name: perf-team-prometheus-reader
-type: kubernetes.io/service-account-token


### PR DESCRIPTION
Upon service account creation, both kubernetes.io/service-account-token and kubernetes.io/dockercfg secrets are created automatically, no need to create them explicitly.

In addition, this secret was causing the perf-team-prometheus-reader applications to be permanently out-of-sync.