### PR TITLE
fix(RHTAPWATCH-542): Add status label to the spi metric on app-sre

### DIFF
--- a/components/monitoring/prometheus/base/monitoringstack/monitoringstack.yaml
+++ b/components/monitoring/prometheus/base/monitoringstack/monitoringstack.yaml
@@ -48,7 +48,7 @@ spec:
           commit_hash|job|operation|tokenName|rateLimited|state|persistentvolumeclaim|\
           storageclass|volumename|release_reason|instance|result|deployment_reason|\
           validation_reason|strategy|succeeded|target|name|method|code|sp|\
-          unexpected_status|failure|hostname|label_app_kubernetes_io_managed_by"
+          unexpected_status|failure|hostname|label_app_kubernetes_io_managed_by|status"
 ---
 # Grant permission to Federate In-Cluster Prometheus
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
status label was missing in the LabelKeep list so it couldn't be accessed for the spi metric on the app-sre grafana. This change enables the status label.