### PR TITLE
ClusterLogging instance is constantly on OutOfSync status in Argo

### DIFF
--- a/components/monitoring/logging/base/configure-logging/configure-log-collectors.yaml
+++ b/components/monitoring/logging/base/configure-logging/configure-log-collectors.yaml
@@ -10,4 +10,3 @@ spec:
   collection:
     logs:
       type: vector
-      vector: {}


### PR DESCRIPTION
This fixes the issue on both staging and production.