### PR TITLE
managed-gitops: disable temporary Environment webhook on staging

### DIFF
--- a/components/gitops/staging/base/kustomization.yaml
+++ b/components/gitops/staging/base/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-- https://github.com/redhat-appstudio/managed-gitops/manifests/overlays/tmp-stonesoup-member-cluster-env-webhook?ref=f717e18d97963c224d1ffc934f0fedbb10d4dfe1
+- https://github.com/redhat-appstudio/managed-gitops/manifests/overlays/stonesoup-member-cluster?ref=696f2eb74ccb96d80d2536d3d605594db8c12d13
 - ../../openshift-gitops/overlays/staging
 - ../../base/external-secrets
 - ../../base/monitoring


### PR DESCRIPTION
Disable the temporary webhook that was enabled by https://github.com/redhat-appstudio/infra-deployments/pull/2546