### PR TITLE
bump pipeilne-service prod to same level as stage

### DIFF
--- a/components/pipeline-service/production/base/kustomization.yaml
+++ b/components/pipeline-service/production/base/kustomization.yaml
@@ -8,7 +8,7 @@ commonAnnotations:
   argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 
 resources:
-  - https://github.com/openshift-pipelines/pipeline-service.git/operator/gitops/argocd/pipeline-service?ref=2f469a4598925608dd83063f316fde616828ed3a
+  - https://github.com/openshift-pipelines/pipeline-service.git/operator/gitops/argocd/pipeline-service?ref=81454e7a3c38fc1b1f145b5cb1d537417e195192
   - pipelines-as-code-secret.yaml # create external secret in openshift-pipelines namespace
   - ../../base/external-secrets
   - ../../base/testing


### PR DESCRIPTION
Includes:
[fix issues of pipeline-service test](https://github.com/openshift-pipelines/pipeline-service/commit/81454e7a3c38fc1b1f145b5cb1d537417e195192)
[update operator/gitops/argocd/pipeline-service/metrics-exporter/kusto…](https://github.com/openshift-pipelines/pipeline-service/commit/0dec9dbdbef0ac6cc33ce2803b7ee87d43178826)
[fixed error that unable to find a match 'python3-devel-3.11.5'](https://github.com/openshift-pipelines/pipeline-service/commit/8757ada7c033b21dc59720267d2643a9c8c08b86)
[Fix kube-linter issues](https://github.com/openshift-pipelines/pipeline-service/commit/b707aab8929f8a0a766f69132907a56823a6c7fb)
[Optimizing the process of ROSA destroying](https://github.com/openshift-pipelines/pipeline-service/commit/e6c4eb75235c23243961c047fac83c0993b7eb3a)

other that the metrics exporter bump the rest of these are specific to pipeline-service CI

@redhat-appstudio/pipeline-service  FYI