### PR TITLE
managed-gitops: Revert #2560 from staging, "update components/gitops/staging/base/kustomization.yaml (#2560)"

### DIFF
--- a/components/gitops/staging/base/kustomization.yaml
+++ b/components/gitops/staging/base/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-- https://github.com/redhat-appstudio/managed-gitops/manifests/overlays/stonesoup-member-cluster?ref=eb5a1c032c54bb1912d5fc01c7f5d4c4fac11855
+- https://github.com/redhat-appstudio/managed-gitops/manifests/overlays/stonesoup-member-cluster?ref=875753ce0341cd58b26707185bfc5ed657c69df6
 - ../../openshift-gitops/overlays/staging
 - ../../base/external-secrets
 - ../../base/monitoring
@@ -11,7 +11,7 @@ resources:
 images:
   - name: \${COMMON_IMAGE}
     newName: quay.io/redhat-appstudio/gitops-service
-    newTag: eb5a1c032c54bb1912d5fc01c7f5d4c4fac11855
+    newTag: 875753ce0341cd58b26707185bfc5ed657c69df6
 
 commonAnnotations:
   argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true


### PR DESCRIPTION
#2560 was delivered to staging to verify the functionality, however, there are additional errors that are occuring, so reverting to fix.

This reverts commit 89971ca4b6fa1f8ab872c8b7e5fa02d797d4c89d.