### PR TITLE
chore(RHTAPREL-435): remove internal-services PaC repo

### DIFF
--- a/components/tekton-ci/base/repository.yaml
+++ b/components/tekton-ci/base/repository.yaml
@@ -100,13 +100,6 @@ spec:
 apiVersion: pipelinesascode.tekton.dev/v1alpha1
 kind: Repository
 metadata:
-  name: internal-services
-spec:
-  url: "https://github.com/redhat-appstudio/internal-services"
----
-apiVersion: pipelinesascode.tekton.dev/v1alpha1
-kind: Repository
-metadata:
   name: ec-golden-image
 spec:
   url: "https://github.com/enterprise-contract/golden-container"


### PR DESCRIPTION
- removed PaC repo for internal-services so the GH repo can be onboarded to RHTAP