### PR TITLE
Added permissions for the following apiGroups

### DIFF
--- a/components/authentication/base/rhtap-admins.yaml
+++ b/components/authentication/base/rhtap-admins.yaml
@@ -265,6 +265,16 @@ rules:
     verbs:
       - '*'
   - apiGroups:
+      - oadp.openshift.io
+    resources:
+      - dataprotectionapplications
+      - cloudstorages
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+  - apiGroups:
     - user.openshift.io
     resources:
       - groups
@@ -273,6 +283,17 @@ rules:
       - users
     verbs:
       - '*'
+  - apiGroups:
+      - velero.io
+    resources:
+      - backups
+      - restores
+      - schedules
+    verbs:
+      - create
+      - delete
+      - get
+      - list
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
1. oadp.openshift.io (dataprotectionapplications, cloudstorages)
2. velero.io (backups, restores, schedules)