### PR TITLE
Fix prd sprayproxy duplicated GH_APP_WEBHOOK_SECRET

### DIFF
--- a/components/sprayproxy/production/add-backends.yml
+++ b/components/sprayproxy/production/add-backends.yml
@@ -1,6 +1,0 @@
----
-- op: add
-  path: /spec/template/spec/containers/0/env/0/value
-  value: >
-      https://pipelines-as-code-controller-openshift-pipelines.apps.stone-prd-m01.84db.p1.openshiftapps.com
-      https://pipelines-as-code-controller-openshift-pipelines.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com

--- a/components/sprayproxy/production/add-webhook-secret.yaml
+++ b/components/sprayproxy/production/add-webhook-secret.yaml
@@ -1,9 +1,0 @@
----
-- op: add
-  path: /spec/template/spec/containers/0/env/-
-  value:
-    name: GH_APP_WEBHOOK_SECRET
-    valueFrom:
-      secretKeyRef:
-        name: pipelines-as-code-secret
-        key: webhook.secret

--- a/components/sprayproxy/production/change-backends.yaml
+++ b/components/sprayproxy/production/change-backends.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sprayproxy
+  namespace: sprayproxy
+spec:
+  template:
+    spec:
+      containers:
+        - name: sprayproxy
+          env:
+            - name: SPRAYPROXY_SERVER_BACKEND
+              value: >
+                https://pipelines-as-code-controller-openshift-pipelines.apps.stone-prd-m01.84db.p1.openshiftapps.com
+                https://pipelines-as-code-controller-openshift-pipelines.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com

--- a/components/sprayproxy/production/change-webhook-secret.yaml
+++ b/components/sprayproxy/production/change-webhook-secret.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sprayproxy
+  namespace: sprayproxy
+spec:
+  template:
+    spec:
+      containers:
+        - name: sprayproxy
+          env:
+            - name: GH_APP_WEBHOOK_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: pipelines-as-code-secret
+                  key: webhook.secret

--- a/components/sprayproxy/production/kustomization.yaml
+++ b/components/sprayproxy/production/kustomization.yaml
@@ -11,14 +11,5 @@ images:
     newTag: 8a03dffd427c35646ba6aca73ee17ec68fd356c2
 
 patches:
-  - path: add-backends.yml
-    target:
-      name: sprayproxy
-      group: apps
-      version: v1
-  - path: add-webhook-secret.yaml
-    target:
-      name: sprayproxy
-      group: apps
-      version: v1
-      kind: Deployment
+  - path: change-backends.yaml
+  - path: change-webhook-secret.yaml


### PR DESCRIPTION
GH_APP_WEBHOOK_SECRET is defined in the config at the repo level so using a "patch add" was resulting in duplicated variable:

```
spec:
  template:
    spec:
      containers:
      - args:
        env:
        - name: GH_APP_WEBHOOK_SECRET
        - name: GH_APP_WEBHOOK_SECRET
          valueFrom:
            secretKeyRef:
              key: webhook.secret
              name: pipelines-as-code-secret
```

Instead, patch the variable using a strategic merge. In addition to fix the duplicate, this methodology do not rely on container or variable indices so also change the SPRAYPROXY_SERVER_BACKEND to use same mechanism for robustness and consistency reasons.

[PLNSRVCE-1477](https://issues.redhat.com//browse/PLNSRVCE-1477)