### PR TITLE
Remove SPI repositories from tekton-ci

### DIFF
--- a/components/tekton-ci/base/repository.yaml
+++ b/components/tekton-ci/base/repository.yaml
@@ -9,13 +9,6 @@ spec:
 apiVersion: pipelinesascode.tekton.dev/v1alpha1
 kind: Repository
 metadata:
-  name: service-provider-integration
-spec:
-  url: "https://github.com/redhat-appstudio/service-provider-integration-operator"
----
-apiVersion: pipelinesascode.tekton.dev/v1alpha1
-kind: Repository
-metadata:
   name: e2e-tests
 spec:
   url: "https://github.com/redhat-appstudio/e2e-tests"
@@ -145,13 +138,6 @@ metadata:
   name: cachi2
 spec:
   url: "https://github.com/containerbuildsystem/cachi2"
----
-apiVersion: pipelinesascode.tekton.dev/v1alpha1
-kind: Repository
-metadata:
-  name: remote-secrets
-spec:
-  url: "https://github.com/redhat-appstudio/remote-secret"
 ---
 apiVersion: pipelinesascode.tekton.dev/v1alpha1
 kind: Repository


### PR DESCRIPTION
{SUBJ} 
The goal is to use RHTAP for SPI components
Context https://issues.redhat.com/browse/SVPI-666