### PR TITLE
bump pipeline-service prod to current stage level

### DIFF
--- a/components/pipeline-service/production/base/kustomization.yaml
+++ b/components/pipeline-service/production/base/kustomization.yaml
@@ -8,7 +8,7 @@ commonAnnotations:
   argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 
 resources:
-  - https://github.com/openshift-pipelines/pipeline-service.git/operator/gitops/argocd/pipeline-service?ref=81454e7a3c38fc1b1f145b5cb1d537417e195192
+  - https://github.com/openshift-pipelines/pipeline-service.git/operator/gitops/argocd/pipeline-service?ref=1f13ca5c4851190effa9660d55fbc20d459d7762
   - pipelines-as-code-secret.yaml # create external secret in openshift-pipelines namespace
   - ../../base/external-secrets
   - ../../base/testing


### PR DESCRIPTION
Includes 
[Enable completed_run_grace_period for tekton-results](https://github.com/openshift-pipelines/pipeline-service/commit/b2626be4fc649b5184b8bf3e661bbc46319c884b)
[Fix TektonConfig](https://github.com/openshift-pipelines/pipeline-service/commit/db423b0030f4a0e886fdf7ce7f81e3c95e08d20e)
[Optimizing the process of ROSA provisioning in CI](https://github.com/openshift-pipelines/pipeline-service/commit/f74b260c32715977dcc7acc20a3b28e8cbac1454)
[Set Set cpu/memory requests/limits for tekton-results-api init contai…](https://github.com/openshift-pipelines/pipeline-service/commit/47c14a4acc7b99647ac7fabfef201af337725579)
[Set cpu/memory requests/limits for chains-secret-generation container](https://github.com/openshift-pipelines/pipeline-service/commit/7daba2740a9be1b2d8fc673a5dc7d35f57ba5b2c)
[Enable OSP pruner](https://github.com/openshift-pipelines/pipeline-service/commit/962f485476bb1c75a8f9f6a743a0cb953e587fbc)
[Update base images SHA in Dockerfiles](https://github.com/openshift-pipelines/pipeline-service/commit/ee4e0fea1244e47a6eaa92236d1b60957a33f1c6)
[update operator/gitops/argocd/pipeline-service/metrics-exporter/kusto…](https://github.com/openshift-pipelines/pipeline-service/commit/1f13ca5c4851190effa9660d55fbc20d459d7762)


/hold

a question if we need to clean up the terminated cron job affected by [Set cpu/memory requests/limits for chains-secret-generation container](https://github.com/openshift-pipelines/pipeline-service/commit/7daba2740a9be1b2d8fc673a5dc7d35f57ba5b2c) 