### PR TITLE
add network policy for proxy-metrics

### DIFF
--- a/components/sandbox/base/kustomization.yaml
+++ b/components/sandbox/base/kustomization.yaml
@@ -4,3 +4,4 @@ resources:
 - ./rbac/edit-secrets.yaml
 - ./rbac/sandbox-sre-admins.yaml
 - ./monitoring/sandbox-registration-service-proxy.yaml
+- ./monitoring/prometheus-network-policy.yaml

--- a/components/sandbox/base/monitoring/prometheus-network-policy.yaml
+++ b/components/sandbox/base/monitoring/prometheus-network-policy.yaml
@@ -1,0 +1,14 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-from-appstudio-monitoring
+  namespace: toolchain-host-operator
+spec:
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: appstudio-monitoring
+  podSelector: {}
+  policyTypes:
+    - Ingress


### PR DESCRIPTION
add network policy to allow traffic from appstudio-monitoring to toolchain-host-operator