### PR TITLE
feat: Adding perf team that maintains perf-team-prometheus-reader NS

### DIFF
--- a/components/perf-team-prometheus-reader/base/kustomization.yaml
+++ b/components/perf-team-prometheus-reader/base/kustomization.yaml
@@ -1,4 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: perf-team-prometheus-reader
 resources:
   - serviceaccount.yaml
+  - perf-team.yaml

--- a/components/perf-team-prometheus-reader/base/perf-team.yaml
+++ b/components/perf-team-prometheus-reader/base/perf-team.yaml
@@ -1,0 +1,13 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: perf-team-prometheus-reader-maintainers
+  namespace: perf-team-prometheus-reader
+subjects:
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: Performance
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: component-maintainer


### PR DESCRIPTION
This is for Perf&Scale team to be able to read secret created for the service account.