### PR TITLE
PLNSRVCE-1470: minor fix to add the metrics/labels pipeline service wants scraped by app sre

### DIFF
--- a/components/monitoring/prometheus/base/monitoringstack/monitoringstack.yaml
+++ b/components/monitoring/prometheus/base/monitoringstack/monitoringstack.yaml
@@ -87,12 +87,12 @@ spec:
   endpoints:
   - params:
       'match[]': # scrape only required metrics from in-cluster prometheus
-        - '{__name__="pipelinerun_duration_scheduled_seconds_sum", namespace="openshift-pipelines"}'
-        - '{__name__="pipelinerun_duration_scheduled_seconds_count", namespace="openshift-pipelines"}'
-        - '{__name__="pipelinerun_gap_between_taskruns_milliseconds_sum", namespace="openshift-pipelines"}'
-        - '{__name__="pipelinerun_gap_between_taskruns_milliseconds_count", namespace="openshift-pipelines"}'
-        - '{__name__="tekton_pipelines_controller_pipelinerun_duration_seconds_sum", namespace="openshift-pipelines"}'
-        - '{__name__="tekton_pipelines_controller_pipelinerun_duration_seconds_count", namespace="openshift-pipelines"}'
+        - '{__name__="pipelinerun_duration_scheduled_seconds_sum", namespace~".*-tenant|tekton-ci"}'
+        - '{__name__="pipelinerun_duration_scheduled_seconds_count", namespace~".*-tenant|tekton-ci"}'
+        - '{__name__="pipelinerun_gap_between_taskruns_milliseconds_sum", namespace~".*-tenant|tekton-ci"}'
+        - '{__name__="pipelinerun_gap_between_taskruns_milliseconds_count", namespace~".*-tenant|tekton-ci"}'
+        - '{__name__="tekton_pipelines_controller_pipelinerun_duration_seconds_sum", namespace~".*-tenant|tekton-ci"}'
+        - '{__name__="tekton_pipelines_controller_pipelinerun_duration_seconds_count", namespace~".*-tenant|tekton-ci"}'
         - '{__name__="controller_runtime_reconcile_errors_total", namespace!~".*-tenant|openshift-.*|kube-.*"}'
         - '{__name__="controller_runtime_reconcile_total", namespace!~".*-tenant|openshift-.*|kube-.*"}'
         - '{__name__="kube_pod_status_unschedulable", namespace!~".*-tenant|openshift-.*|kube-.*"}'


### PR DESCRIPTION
Minor fix to https://github.com/redhat-appstudio/infra-deployments/pull/2633

the namespace in the regex refers to the namespace label of our metrics, which is where the pipelinerun is running, not where the metrics-exporter or tekton controller is running

so we are trying to include all tenants plus the `tekton-ci` namespace where all of appstudio's CI run on in the RHTAP prod cluster

@redhat-appstudio/pipeline-service FYI