### PR TITLE
managed-gitops: Upgrade OpenShift GitOps Subscription to v1.10

### DIFF
--- a/components/gitops/openshift-gitops/overlays/production-and-dev/subscription-openshift-gitops.yaml
+++ b/components/gitops/openshift-gitops/overlays/production-and-dev/subscription-openshift-gitops.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "-1"
 spec:
-  channel: gitops-1.9
+  channel: gitops-1.10
   installPlanApproval: Automatic
   name: openshift-gitops-operator
   source: redhat-operators

--- a/components/gitops/openshift-gitops/overlays/staging/subscription-openshift-gitops.yaml
+++ b/components/gitops/openshift-gitops/overlays/staging/subscription-openshift-gitops.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "-1"
 spec:
-  channel: gitops-1.9
+  channel: gitops-1.10
   installPlanApproval: Automatic
   name: openshift-gitops-operator
   source: redhat-operators

--- a/components/sandbox/toolchain-host-operator/development/kustomization.yaml
+++ b/components/sandbox/toolchain-host-operator/development/kustomization.yaml
@@ -1,2 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+
+resources: [] # Kustomize v5.1 and up will throw an error if the resources field is not defined.

--- a/components/sandbox/toolchain-member-operator/development/kustomization.yaml
+++ b/components/sandbox/toolchain-member-operator/development/kustomization.yaml
@@ -1,2 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+
+resources: [] # Kustomize v5.1 and up will throw an error if the resources field is not defined.


### PR DESCRIPTION
Upgrade OpenShift GitOps `Operator` Subscription to `gitops-1.10` channel.