### PR TITLE
[Managed-Gitops] Add metrics.

### DIFF
--- a/components/monitoring/prometheus/base/monitoringstack/monitoringstack.yaml
+++ b/components/monitoring/prometheus/base/monitoringstack/monitoringstack.yaml
@@ -100,6 +100,11 @@ spec:
         - '{__name__="kube_pod_status_phase", namespace!~".*-tenant|openshift-.*|kube-.*"}'
         - '{__name__="kube_persistentvolume_status_phase", namespace!~".*-tenant|openshift-.*|kube-.*"}'
         - '{__name__="kube_resourcequota", namespace!~".*-tenant|openshift-.*|kube-.*"}'
+        - '{__name__="kube_statefulset_status_replicas_ready", namespace="gitops-service-argocd"}'
+        - '{__name__="kube_statefulset_replicas", namespace="gitops-service-argocd"}'
+        - '{__name__="openshift_route_status", namespace="gitops-service-argocd"}'
+        - '{__name__="kube_deployment_status_replicas_ready", namespace="gitops-service-argocd"}'
+        - '{__name__="kube_deployment_spec_replicas", namespace="gitops-service-argocd"}'
     relabelings:
     # override the target's address by the prometheus-k8s service name.
     - action: replace


### PR DESCRIPTION
This PR is to add few new metrics for Gitops-Service monitoring. Few metrics we need for adding new panels in [RHTAP SLO dashboards](https://grafana.stage.devshift.net/d/rhtap-slos/rhtap-slos?orgId=1&var-datasource=rhtap-observatorium-production&from=now-28d&to=now&refresh=1h) are missing, hence updating [MonitoringStack configurations](https://github.com/redhat-appstudio/infra-deployments/blob/main/components/monitoring/prometheus/base/monitoringstack/monitoringstack.yaml) as mentioned in this [doc](https://github.com/redhat-appstudio/infra-deployments/tree/main/components/monitoring/prometheus#troubleshooting-missing-metrics-and-labels). 

## Jira Ticket
https://issues.redhat.com/browse/GITOPSRVCE-751
