### PR TITLE
feat(RHTAPREL-675): ignore differences in releaseplans (#2684)

### DIFF
--- a/argo-cd-apps/base/tenants-config/tenants-config.yaml
+++ b/argo-cd-apps/base/tenants-config/tenants-config.yaml
@@ -33,6 +33,7 @@ spec:
           kind: ReleasePlan
           jsonPointers:
             - /metadata/labels/release.appstudio.openshift.io~author
+            - /metadata/labels/release.appstudio.openshift.io~standing-attribution
       syncPolicy:
         automated:
           prune: true


### PR DESCRIPTION
- additional label required.
- tell ArgoCD to ignore differences in ReleasePlan for the label /metadata/labels/release.appstudio.openshift.io~standing-attribution