### PR TITLE
Bump vm size for ephemeral arm multi-platform builds

### DIFF
--- a/components/multi-platform-controller/production/host-config.yaml
+++ b/components/multi-platform-controller/production/host-config.yaml
@@ -13,7 +13,7 @@ data:
   dynamic.linux-arm64.type: aws
   dynamic.linux-arm64.region: us-east-1
   dynamic.linux-arm64.ami: ami-03d6a5256a46c9feb
-  dynamic.linux-arm64.instance-type: t4g.small
+  dynamic.linux-arm64.instance-type: m6g.large
   dynamic.linux-arm64.key-name: multi-platform-aws-prod
   dynamic.linux-arm64.aws-secret: aws-account
   dynamic.linux-arm64.ssh-secret: aws-ssh-key


### PR DESCRIPTION
OOM kills were happening with t4g.small, changing to a larger VM for more memory.

Addresses: https://issues.redhat.com/browse/RHTAPBUGS-953