### PR TITLE
tell ArgoCD to respect the ignoreDifferences

### DIFF
--- a/argo-cd-apps/base/tenants-config/tenants-config.yaml
+++ b/argo-cd-apps/base/tenants-config/tenants-config.yaml
@@ -40,6 +40,7 @@ spec:
           selfHeal: true
         syncOptions:
           - CreateNamespace=true
+          - RespectIgnoreDifferences=true
         retry:
           limit: 10
           backoff:


### PR DESCRIPTION
By default, Argo CD uses the ignoreDifferences config just for computing the diff between the live and desired state which defines if the application is synced or not. However during the sync stage, the desired state is applied as-is.

The patch is calculated using a 3-way-merge between the live state the desired state and the last-applied-configuration annotation. This sometimes leads to an undesired results. This behavior can be changed by setting the RespectIgnoreDifferences=true sync option.

Taken from https://argo-cd.readthedocs.io/en/stable/user-guide/sync-options/