### PR TITLE
Improve development documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 For the full documentation click [here](https://redhat-appstudio.github.io/infra-deployments/docs/introduction/about.html)
 
+When working on documentation updates, you may want to enable GitHub pages for your forked repository,
+see the [GitHub docs: Publishing from a branch](https://docs.github.com/en/pages/getting-started-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site#publishing-from-a-branch).
+The site will be available at `https://<username>.github.io/<repository>` (`https://<username>.github.io/infra-deployments` if you didn't rename yor fork).
+
 This repository is an initial set of Argo-CD-based deployments of StoneSoup components to a cluster, plus a script to bootstrap Argo CD onto that cluster (to drive these Argo-CD-based deployments, via OpenShift GitOps).
 
 This repository is structured as a GitOps monorepo (e.g. the repository contains the K8s resources for *multiple* applications), using [Kustomize](https://kustomize.io/).

--- a/docs/development/deployment.md
+++ b/docs/development/deployment.md
@@ -179,6 +179,48 @@ Finally, install the application for your organization. See the [GitHub docs: In
 GitHub App][github-install-app]. Select `All repositories` when installing to make sure it will have
 access to all the repos you're going to create/fork into your org in the future.
 
+### Verifying your setup
+
+**Simple build:**
+
+* Fork <https://github.com/devfile-samples/devfile-sample-python-basic> into your GitHub organization.
+* Run `hack/build/build-via-appstudio.sh https://github.com/MY_STONESOUP_ORG/devfile-sample-python-basic`
+
+The script will create a test application and a component for you:
+
+```shell
+$ oc get application
+NAME               AGE   STATUS   REASON
+test-application   74s   True     OK
+
+$ oc get component
+NAME                          AGE   STATUS   REASON   TYPE
+devfile-sample-python-basic   86s   True     OK       Created
+```
+
+Build-service should start a pipeline for your new component almost immediately:
+
+```shell
+$ tkn pipelinerun list
+NAME                                STARTED         DURATION   STATUS
+devfile-sample-python-basic-jpg29   2 minutes ago   ---        Running
+```
+
+You can also see the PipelineRun in the OpenShift console in your cluster.
+
+**Pipelines as Code onboarding:**
+
+```shell
+$ oc annotate component devfile-sample-python-basic build.appstudio.openshift.io/request=configure-pac
+component.appstudio.redhat.com/devfile-sample-python-basic annotated
+```
+
+Build-service should create a new pull request in your forked devfile-sample-python-basic repository.
+
+If your cluster is accessible on the public internet, commenting `/ok-to-test` on the pull request
+will trigger the on-pull-request PipelineRun. Merging the pull request will trigger the on-push PipelineRun.
+If your cluster is hidden behind a VPN, this won't work.
+
 ## Optional: OpenShift Local Post-Bootstrap Configuration
 
 Even with 6 CPU cores, you will need to reduce the CPU resource requests for each StoneSoup application. Either run `./hack/reduce-gitops-cpu-requests.sh` which will set resources.requests.cpu values to 50m or use `kubectl edit argocd/openshift-gitops -n openshift-gitops` to reduce the values to some other value. More details are in the FAQ below.

--- a/docs/development/deployment.md
+++ b/docs/development/deployment.md
@@ -39,7 +39,8 @@ Preview mode works in a feature branch, apply script which creates new preview b
 
 Steps:
 
-1. Copy `hack/preview-template.env` to `hack/preview.env` and update new file based on instructions. File `hack/preview.env` should never be included in commit.
+1. Copy `hack/preview-template.env` to `hack/preview.env` and update new file based on [instructions](#previewenv-instructions).
+   File `hack/preview.env` should never be included in commit.
 
 2. Work on your changes in a feature branch
 
@@ -60,6 +61,130 @@ If you want to reset your environment you can run the `hack/util-update-app-of-a
 
 Note running these scripts in a clone repo will have no effect as the repo will remain `https://github.com/redhat-appstudio/infra-deployments.git`
 
+### preview.env instructions
+
+I want a development deployment of StoneSoup where I can:
+
+* Run simple builds
+* Onboard a repository to Pipelines as Code
+
+What environment variables do I need to set in `preview.env` before I run the preview script?
+How to set up all the prerequisites?
+
+| Variable                      | How to set up                     |
+| ----------------------------- | --------------------------------- |
+| `MY_GIT_FORK_REMOTE`          | [Fork the repo](#fork-the-repo)   |
+| `MY_GITHUB_ORG`               | [GitHub setup](#github-setup)     |
+| `MY_GITHUB_TOKEN`             | [GitHub setup](#github-setup)     |
+| `IMAGE_CONTROLLER_QUAY_ORG`   | [Quay setup](#quay-setup)         |
+| `IMAGE_CONTROLLER_QUAY_TOKEN` | [Quay setup](#quay-setup)         |
+| `PAC_GITHUB_APP_PRIVATE_KEY`  | [PaC setup](#pac-setup)           |
+| `PAC_GITHUB_APP_ID`           | [PaC setup](#pac-setup)           |
+
+#### Fork the repo
+
+If you haven't done so yet, fork <https://github.com/redhat-appstudio/infra-deployments> and clone
+it locally. Copy [`hack/preview-template.env`][preview-template.env] to `hack/preview.env` - that's
+where you want to set all the environment variables.
+
+The first one is `MY_GIT_FORK_REMOTE` - the name of the git remote which points to your fork.
+
+```shell
+$ git remote -v
+origin  git@github.com:<gh_username>/infra-deployments.git (fetch)
+origin  git@github.com:<gh_username>/infra-deployments.git (push)
+upstream    https://github.com/redhat-appstudio/infra-deployments.git (fetch)
+upstream    https://github.com/redhat-appstudio/infra-deployments.git (push)
+```
+
+Set the name of the git remote in `preview.env`:
+
+```shell
+export MY_GIT_FORK_REMOTE=origin
+```
+
+#### GitHub setup
+
+Create a new organization, see the [GitHub docs: Creating a new organization from scratch][github-create-org].
+This is the organization where you will later install the Pipelines as Code application. When testing
+the PaC integration features of StoneSoup, you will need to use repositories from this organization
+(or fork existing repositories into this org).
+
+Copy the organization name to `preview.env`. For example:
+
+```shell
+export MY_GITHUB_ORG=<gh_username>-stonesoup
+```
+
+Next, you will need an access token. See the [GitHub docs: Creating a personal access token][github-get-access-token].
+The token needs all the `repo` permissions and the `delete_repo` permission.
+
+Copy the token value to `preview.env`:
+
+```shell
+export MY_GITHUB_TOKEN=ghp_***
+```
+
+#### Quay setup
+
+Create a new [Quay.io](https://quay.io) organization. If you need a new email address for the organization,
+you can use the `+` trick - e.g. `<gmail_username>+quayorg@gmail.com`.
+
+Copy the organization name to `preview.env`. For example:
+
+```shell
+export IMAGE_CONTROLLER_QUAY_ORG=<quay_username>-stonesoup
+```
+
+Next, you need to generate an access token for your Quay.io organization. See the instructions for
+`IMAGE_CONTROLLER_QUAY_TOKEN` in [preview.env][preview-template.env]. Once you have created the token,
+copy its value to `preview.env`:
+
+```shell
+export IMAGE_CONTROLLER_QUAY_TOKEN=***
+```
+
+#### PaC setup
+
+Follow the [Pipelines as Code: Setup Manually][pac-setup-manual] instructions to create the GitHub application.
+You can create the application in your organization settings (<https://github.com/organizations/MY_STONESOUP_ORG/settings/apps>)
+or your personal settings (<https://github.com/settings/apps>). If you create the app under your organization,
+you can allow it `Only on this account`, otherwise you will have to allow `Any account`.
+
+Compared to the Pipelines as Code documentation, you will want to set these fields differently:
+
+* **GitHub Application Name**: use a unique name, e.g. `<gh_username>-stonesoup PaC`
+* **Webhook URL**: use a dummy url, e.g. <https://example.org>. The `preview.sh` script will fix the
+  webhook url automatically.
+* **Webhook secret**: leave it empty, the `preview.sh` script will set the secret automatically.
+
+Once you have created the GitHub app, copy its App ID to `preview.env`:
+
+```shell
+export PAC_GITHUB_APP_ID=<number>
+```
+
+Generate a private key for the application (in the GitHub UI; refer to the Pipelines as Code docs linked
+above). Encode the private key as base64 and copy it to `preview.env`:
+
+```shell
+base64 --wrap=0 <path to downloaded key>
+```
+
+```shell
+export PAC_GITHUB_APP_PRIVATE_KEY=<output of the command above>
+```
+
+Finally, install the application for your organization. See the [GitHub docs: Installing your own
+GitHub App][github-install-app]. Select `All repositories` when installing to make sure it will have
+access to all the repos you're going to create/fork into your org in the future.
+
 ## Optional: OpenShift Local Post-Bootstrap Configuration
 
 Even with 6 CPU cores, you will need to reduce the CPU resource requests for each StoneSoup application. Either run `./hack/reduce-gitops-cpu-requests.sh` which will set resources.requests.cpu values to 50m or use `kubectl edit argocd/openshift-gitops -n openshift-gitops` to reduce the values to some other value. More details are in the FAQ below.
+
+[preview-template.env]: https://github.com/redhat-appstudio/infra-deployments/blob/main/hack/preview-template.env
+[github-create-org]: https://docs.github.com/en/organizations/collaborating-with-groups-in-organizations/creating-a-new-organization-from-scratch
+[github-get-access-token]: https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-personal-access-token-classic
+[github-install-app]: https://docs.github.com/en/apps/using-github-apps/installing-your-own-github-app
+[pac-setup-manual]: https://pipelinesascode.com/docs/install/github_apps/#setup-manually

--- a/hack/preview-template.env
+++ b/hack/preview-template.env
@@ -1,4 +1,7 @@
+# See https://redhat-appstudio.github.io/infra-deployments/docs/development/deployment.html#setting-preview-mode
+
 # Required
+
 ## Git remote repo name where is your fork where to push the changes.
 ## List of remotes -> git remote -v
 ## Example value: origin

--- a/hack/preview-template.env
+++ b/hack/preview-template.env
@@ -103,7 +103,7 @@ export DOCKER_IO_AUTH=""
 ### pipelines-as-code-secret is created by preview.sh
 export PAC_GITHUB_APP_PRIVATE_KEY= # Base64 encoded private key of the GitHub APP
 export PAC_GITHUB_APP_ID= # Application ID
-export PAC_GITHUB_APP_WEBHOOK_SECRET= # Webhook secret of the GitHub APP
+export PAC_GITHUB_APP_WEBHOOK_SECRET= # Webhook secret of the GitHub APP, leave this empty to let preview.sh set it automatically
 
 # GitHub webhook integration (alternative to the GitHub PaC application)
 # See https://pipelinesascode.com/docs/install/github_webhook/#setup-git-repository for the required token permissions


### PR DESCRIPTION
The instructions present as comments in the preview.env file are not
sufficient for a new member trying to set up their development
environment for the first time.

Add a section in the documentation that explains what needs to be set in
preview.env and how to set up the prerequisites.

\+ instructions for how to verify that your deployment works
\+ instructions for testing your code changes