### PR TITLE
Fix UID and dashboard name for Remote Secret dashboard

### DIFF
--- a/components/monitoring/grafana/base/dashboards/spi/kustomization.yaml
+++ b/components/monitoring/grafana/base/dashboards/spi/kustomization.yaml
@@ -2,5 +2,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - https://github.com/redhat-appstudio/service-provider-integration-operator/config/monitoring/grafana/base?ref=1b33efa4b02986cde3c00da0718ae487a8c2cd12
-- https://github.com/redhat-appstudio/remote-secret/config/monitoring/grafana/base?ref=377ef39196d17a9d78424ea07f43f10e4d4f0614
+- https://github.com/redhat-appstudio/remote-secret/config/monitoring/grafana/base?ref=8f7ff94e0e6a1f1cc920dcc0830d0ce3172e0dcb
 - dashboard.yaml


### PR DESCRIPTION
Fix UID and dashboard name for Remote Secret dashboard, because duplicate UID causes Grafana to error state.