### PR TITLE
Fix backup application path

### DIFF
--- a/argo-cd-apps/base/member/infra-deployments/backup/backup.yaml
+++ b/argo-cd-apps/base/member/infra-deployments/backup/backup.yaml
@@ -12,7 +12,6 @@ spec:
               values:
                 sourceRoot: components/backup
                 environment: staging
-                clusterDir: ""
           - list:
               elements: []
   template:
@@ -21,7 +20,7 @@ spec:
     spec:
       project: default
       source:
-        path: '{{values.sourceRoot}}/{{values.environment}}/{{values.clusterDir}}'
+        path: '{{values.sourceRoot}}/{{values.environment}}/{{nameNormalized}}'
         repoURL: https://github.com/redhat-appstudio/infra-deployments.git
         targetRevision: main
       destination:


### PR DESCRIPTION
The original change introducing backup component was using clusterDir which is not set. Instead of defining the clusterDir for each possible cluster as it is done in other places:
```
- list:
    elements:
      - nameNormalized: stone-stg-m01
        values.clusterDir: stone-stg-m01
      - nameNormalized: stone-stg-rh01
        values.clusterDir: stone-stg-rh01
      - nameNormalized: stone-prd-m01
        values.clusterDir: stone-prd-m01
      - nameNormalized: stone-prd-rh01
        values.clusterDir: stone-prd-rh01
```
Simply use the normalized name of the cluster which correspond to the folder structure within the backup component. This is a better solution as we do not need to hardcode the cluster names in the backup component.

[RHTAPSRE-215](https://issues.redhat.com//browse/RHTAPSRE-215)