### PR TITLE
Create openshift-adp namespace in backup component

### DIFF
--- a/components/backup/base/kustomization.yaml
+++ b/components/backup/base/kustomization.yaml
@@ -3,3 +3,4 @@ kind: Kustomization
 namespace: openshift-adp
 resources:
   - external-secret.yaml
+  - namespace.yaml

--- a/components/backup/base/namespace.yaml
+++ b/components/backup/base/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-adp


### PR DESCRIPTION
The ExternalSecret is created in that namespace which was missing.

[RHTAPSRE-215](https://issues.redhat.com//browse/RHTAPSRE-215)