### PR TITLE
turn on metrics exporter trace in dev/stage

### DIFF
--- a/components/pipeline-service/development/kustomization.yaml
+++ b/components/pipeline-service/development/kustomization.yaml
@@ -11,8 +11,13 @@ resources:
   - https://github.com/openshift-pipelines/pipeline-service.git/developer/openshift/gitops/argocd/pipeline-service?ref=589d6e4688334ed09eb4e10ddd5bdd7a01a5122b
   - https://github.com/openshift-pipelines/pipeline-service.git/developer/openshift/gitops/argocd/pipeline-service-storage?ref=589d6e4688334ed09eb4e10ddd5bdd7a01a5122b
   - ../base/rbac
-  
+
 patches:
+  - path: metrics-exporter-trace.yaml
+    target:
+      kind: Deployment
+      name: pipeline-metrics-exporter
+      namespace: openshift-pipelines
 #  - path: scale-down-exporter.yaml
 #    target:
 #      kind: Deployment

--- a/components/pipeline-service/development/metrics-exporter-trace.yaml
+++ b/components/pipeline-service/development/metrics-exporter-trace.yaml
@@ -1,0 +1,4 @@
+---
+- op: add
+  path: /spec/template/spec/containers/0/args/-
+  value: '-zap-log-level=6'

--- a/components/pipeline-service/staging/base/kustomization.yaml
+++ b/components/pipeline-service/staging/base/kustomization.yaml
@@ -19,6 +19,11 @@ patches:
     target:
       kind: TektonConfig
       name: config
+  - path: metrics-exporter-trace.yaml
+    target:
+      kind: Deployment
+      name: pipeline-metrics-exporter
+      namespace: openshift-pipelines
   - path: update-tekton-config-pac.yaml
     target:
       kind: TektonConfig

--- a/components/pipeline-service/staging/base/metrics-exporter-trace.yaml
+++ b/components/pipeline-service/staging/base/metrics-exporter-trace.yaml
@@ -1,0 +1,4 @@
+---
+- op: add
+  path: /spec/template/spec/containers/0/args/-
+  value: '-zap-log-level=6'


### PR DESCRIPTION
I want some detail on our new consolidated alert metric as I compare it with the existing multi metric alert query

Sorted out the gitops / kustomize approach here after https://github.com/openshift-pipelines/pipeline-service/pull/860 with @Roming22 

Also tested against a personally provisioned cluster with boostrap-cluster.sh preview -t