### PR TITLE
Set Image Controller quay token refresh interval to 15 minutes

### DIFF
--- a/components/image-controller/base/external-secrets/quaytoken.yaml
+++ b/components/image-controller/base/external-secrets/quaytoken.yaml
@@ -9,7 +9,7 @@ spec:
   dataFrom:
     - extract:
         key: staging/build/image-controller
-  refreshInterval: 1h
+  refreshInterval: 15m
   secretStoreRef:
     kind: ClusterSecretStore
     name: appsre-stonesoup-vault


### PR DESCRIPTION
Quay.io doesn't allow preserving old token when new one is created. To avoid long outages, setting ExternalSecret refresh time to 15 minutes.