### PR TITLE
bump prod pipeline service level to what we have in staging

### DIFF
--- a/components/pipeline-service/production/base/kustomization.yaml
+++ b/components/pipeline-service/production/base/kustomization.yaml
@@ -8,7 +8,7 @@ commonAnnotations:
   argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 
 resources:
-  - https://github.com/openshift-pipelines/pipeline-service.git/operator/gitops/argocd/pipeline-service?ref=15f755cf4f4aaa575107f05ec3b44c92218802f1
+  - https://github.com/openshift-pipelines/pipeline-service.git/operator/gitops/argocd/pipeline-service?ref=8313c38b61d684562cb93bd7d4757b08401d2c44
   - pipelines-as-code-secret.yaml # create external secret in openshift-pipelines namespace
   - ../../base/external-secrets
   - ../../base/testing


### PR DESCRIPTION
Brings into prod these commits which are in staging as of this PR's creation:
[update scheduled alert panel to only use successful pipelineruns with…](https://github.com/openshift-pipelines/pipeline-service/commit/cad76877d5abd32d1c9f7943a928ad2e07bcf9f1)
[fix threshold color for 2 alert panels](https://github.com/openshift-pipelines/pipeline-service/commit/f18c544fcc483663acdb8928a343934be8252022)
[fix the issue of rosa cli by upgrading to 1.2.29](https://github.com/openshift-pipelines/pipeline-service/commit/4fc1aa6e9fa0bae3b0f77e307d313cab9577430a)
[Fix images definitions](https://github.com/openshift-pipelines/pipeline-service/commit/5b5a32f929af2e709027c1546d847303b97e7a46)
[Update base images SHA in Dockerfiles](https://github.com/openshift-pipelines/pipeline-service/commit/45a81b8c1270c48a68dd497e1dbcae9d1f48237f)
[update operator/gitops/argocd/pipeline-service/metrics-exporter/kusto…](https://github.com/openshift-pipelines/pipeline-service/commit/f604f8bc30afc0ce7b6495dcc787634b804050b7)
[update operator/gitops/argocd/pipeline-service/metrics-exporter/kusto…](https://github.com/openshift-pipelines/pipeline-service/commit/56fa72395df2b7d1e8f20da2a233acfb5aab6240)
[Bump github action/checkout version](https://github.com/openshift-pipelines/pipeline-service/commit/8d6e23180addf07b919d4639b3678a35c3e50044)
[add empty args for safer patching in infra-deployments](https://github.com/openshift-pipelines/pipeline-service/commit/589d6e4688334ed09eb4e10ddd5bdd7a01a5122b)
[update operator/gitops/argocd/pipeline-service/metrics-exporter/kusto…](https://github.com/openshift-pipelines/pipeline-service/commit/8313c38b61d684562cb93bd7d4757b08401d2c44)


