### PR TITLE
GITOPSRVCE-780: remove overly broad GitOps RBAC rules

### DIFF
--- a/components/gitops/base/authentication/gitops-clusterrolebindings.yaml
+++ b/components/gitops/base/authentication/gitops-clusterrolebindings.yaml
@@ -5,9 +5,9 @@ metadata:
   name: gitops-service-gitops-component-maintainers
   namespace: gitops
 subjects:
-  - kind: User
+  - kind: Group
     apiGroup: rbac.authorization.k8s.io
-    name: jgwest
+    name: GitOps Service Team Admins
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/components/gitops/base/authentication/gitops-clusterroles.yaml
+++ b/components/gitops/base/authentication/gitops-clusterroles.yaml
@@ -3,14 +3,62 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: gitops-component-maintainer
 rules:
+
   - apiGroups:
-      - '*'
-    resources:
-      - '*'
+      - apiextensions.k8s.io
     verbs:
       - get
       - list
       - watch
+    resources:
+      - customresourcedefinitions
+
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - clusterrolebindings
+      - clusterroles
+    verbs:
+      - get
+      - list
+      - watch
+
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - rolebindings
+      - roles
+    verbs:
+      - get
+      - list
+      - watch
+
+
+  - apiGroups:
+      - ''
+      - 'apps'
+    resources:
+      - 'bindings'
+      - 'configmaps'
+      - 'daemonsets'
+      - 'deployments'
+      - 'events'
+      - 'namespaces'
+      - 'nodes'
+      - 'pods'
+      - 'pods/log'
+      - 'replicas'
+      - 'replicasets'
+      - 'routes'
+      - 'secrets'
+      - 'serviceaccounts'
+      - 'services'
+      - 'statefulsets'
+    verbs:
+      - 'get'
+      - 'list'
+      - 'watch'
+
 
   - apiGroups:
       - appstudio.redhat.com
@@ -20,17 +68,49 @@ rules:
       - delete
 
   - apiGroups:
-    - admissionregistration.k8s.io
+      - admissionregistration.k8s.io
     resources:
-    - validatingwebhookconfigurations
-    - mutatingwebhookconfigurations
+      - validatingwebhookconfigurations
+      - mutatingwebhookconfigurations
     verbs:
-    - list
-    - watch
-    - create
-    - update
-    - patch
-    - delete
+      - get
+      - list
+      - watch
+      - delete
+
+  - apiGroups: 
+      - operators.coreos.com
+    resources:
+      - catalogsources
+      - clusterserviceversions
+      - installplans
+      - operatorgroups
+      - subscriptions
+    verbs:
+      - 'get'
+      - 'list'
+      - 'watch'
+
+  - apiGroups:
+      - "toolchain.dev.openshift.com"
+    resources:
+      - "spacerequests"
+    verbs:
+      - 'get'
+      - 'list'
+      - 'watch'
+
+  - apiGroups:
+      - monitoring.coreos.com
+    resources:
+      - alertmanagers
+      - prometheuses
+      - prometheusrules
+      - servicemonitors
+    verbs:
+      - 'get'
+      - 'list'
+      - 'watch'
 
   - apiGroups:
       - operators.coreos.com
@@ -41,64 +121,3 @@ rules:
       - list
       - update
       - patch
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: gitops-namespaces-all-access
-rules:
-  - apiGroups:
-      - '*'
-    resources:
-      - '*'
-    verbs:
-      - '*'
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: gitops-namespaces-read-all-access
-rules:
-  - apiGroups:
-      - '*'
-    resources:
-      - '*'
-    verbs:
-      - 'get'
-      - 'list'
-      - 'watch'
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: gitops-namespaces-read-access
-rules:
-  - apiGroups:
-      - ''
-      - 'apps'
-    resources:
-      - 'pods'
-      - 'pods/log'
-      - 'deployments'
-      - 'events'
-      - 'bindings'
-      - 'replicas'
-      - 'configmaps'
-      - 'namespaces'
-    verbs:
-      - 'get'
-      - 'list'
-      - 'watch'
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: gitops-namespaces-delete-pods-access
-rules:
-  - apiGroups:
-      - ''
-      - 'apps'
-    resources:
-      - 'pods'
-    verbs:
-      - 'delete'

--- a/components/gitops/base/authentication/gitops-namespace-roles/gitops-namespace/kustomization.yaml
+++ b/components/gitops/base/authentication/gitops-namespace-roles/gitops-namespace/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../roles
+
+namespace: gitops

--- a/components/gitops/base/authentication/gitops-namespace-roles/gitops-service-argocd-namespace/kustomization.yaml
+++ b/components/gitops/base/authentication/gitops-namespace-roles/gitops-service-argocd-namespace/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../roles
+
+namespace: gitops-service-argocd

--- a/components/gitops/base/authentication/gitops-namespace-roles/jgwest-tenant/kustomization.yaml
+++ b/components/gitops/base/authentication/gitops-namespace-roles/jgwest-tenant/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../roles
+
+namespace: jgwest-tenant

--- a/components/gitops/base/authentication/gitops-namespace-roles/kustomization.yaml
+++ b/components/gitops/base/authentication/gitops-namespace-roles/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- gitops-namespace
+- gitops-service-argocd-namespace
+- jgwest-tenant

--- a/components/gitops/base/authentication/gitops-namespace-roles/roles/kustomization.yaml
+++ b/components/gitops/base/authentication/gitops-namespace-roles/roles/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- roles.yaml

--- a/components/gitops/base/authentication/gitops-namespace-roles/roles/roles.yaml
+++ b/components/gitops/base/authentication/gitops-namespace-roles/roles/roles.yaml
@@ -1,0 +1,61 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: gitops-namespaces-all-access
+rules:
+  - apiGroups:
+      - '*'
+    resources:
+      - '*'
+    verbs:
+      - '*'
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: gitops-namespaces-read-all-access
+rules:
+  - apiGroups:
+      - '*'
+    resources:
+      - '*'
+    verbs:
+      - 'get'
+      - 'list'
+      - 'watch'
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: gitops-namespaces-read-access
+rules:
+  - apiGroups:
+      - ''
+      - 'apps'
+    resources:
+      - 'pods'
+      - 'pods/log'
+      - 'deployments'
+      - 'events'
+      - 'bindings'
+      - 'replicas'
+      - 'configmaps'
+      - 'namespaces'
+    verbs:
+      - 'get'
+      - 'list'
+      - 'watch'
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: gitops-namespaces-delete-pods-access
+rules:
+  - apiGroups:
+      - ''
+      - 'apps'
+    resources:
+      - 'pods'
+    verbs:
+      - 'delete'

--- a/components/gitops/base/authentication/kustomization.yaml
+++ b/components/gitops/base/authentication/kustomization.yaml
@@ -2,5 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
+- gitops-namespace-roles
 - gitops-clusterroles.yaml
 - gitops-clusterrolebindings.yaml

--- a/components/gitops/production/base/authentication/gitops-rolebindings.yaml
+++ b/components/gitops/production/base/authentication/gitops-rolebindings.yaml
@@ -10,7 +10,7 @@ subjects:
     name: GitOps Service Team
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
+  kind: Role
   name: gitops-namespaces-read-access
 ---
 kind: RoleBinding
@@ -24,7 +24,7 @@ subjects:
     name: GitOps Service Team
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
+  kind: Role
   name: gitops-namespaces-read-access
 ---
 kind: RoleBinding
@@ -33,12 +33,9 @@ metadata:
   name: gitops-namespace-all-access
   namespace: gitops
 subjects:
-  - kind: User
+  - kind: Group
     apiGroup: rbac.authorization.k8s.io
-    name: jgwest
-  - kind: User
-    apiGroup: rbac.authorization.k8s.io
-    name: jannfis
+    name: GitOps Service Team Admins
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -50,12 +47,9 @@ metadata:
   name: gitops-service-argocd-namespace-all-access
   namespace: gitops-service-argocd
 subjects:
-  - kind: User
+  - kind: Group
     apiGroup: rbac.authorization.k8s.io
-    name: jgwest
-  - kind: User
-    apiGroup: rbac.authorization.k8s.io
-    name: jannfis
+    name: GitOps Service Team Admins
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/components/gitops/production/stone-prd-m01/gitops-team-member-namespaces.yaml
+++ b/components/gitops/production/stone-prd-m01/gitops-team-member-namespaces.yaml
@@ -5,11 +5,11 @@ metadata:
   name: gitops-allow-team-access-to-jgwest-tenant
   namespace: jgwest-tenant
 subjects:
-  - kind: User
+  - kind: Group
     apiGroup: rbac.authorization.k8s.io
-    name: jgwest
+    name: GitOps Service Team Admins
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
+  kind: Role
   name: gitops-namespaces-all-access
 ---

--- a/components/gitops/staging/base/authentication/gitops-rolebindings.yaml
+++ b/components/gitops/staging/base/authentication/gitops-rolebindings.yaml
@@ -10,7 +10,7 @@ subjects:
     name: GitOps Service Team
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
+  kind: Role
   name: gitops-namespaces-read-all-access
 ---
 kind: RoleBinding
@@ -24,7 +24,7 @@ subjects:
     name: GitOps Service Team
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
+  kind: Role
   name: gitops-namespaces-read-all-access
 ---
 kind: RoleBinding
@@ -38,7 +38,7 @@ subjects:
     name: GitOps Service Team
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
+  kind: Role
   name: gitops-namespaces-delete-pods-access
 ---
 kind: RoleBinding
@@ -52,5 +52,5 @@ subjects:
     name: GitOps Service Team
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
+  kind: Role
   name: gitops-namespaces-delete-pods-access

--- a/components/gitops/staging/stone-stg-m01/gitops-team-member-namespaces.yaml
+++ b/components/gitops/staging/stone-stg-m01/gitops-team-member-namespaces.yaml
@@ -14,6 +14,6 @@ subjects:
     name: GitOps Service Team
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
+  kind: Role
   name: gitops-namespaces-all-access
 ---


### PR DESCRIPTION
As requested on [RHTAP-1784](https://issues.redhat.com/browse/RHTAP-1784), our ClusterRoles/ClusterRoleBindings/Roles/RoleBindings can be improved to be much less broad.

Resolves:
- https://issues.redhat.com/browse/GITOPSRVCE-768
- https://issues.redhat.com/browse/GITOPSRVCE-780