### PR TITLE
Add build-templates-e2e namespace for syncing with vault

### DIFF
--- a/components/cluster-secret-store/base/appsre-stonesoup-vault-secret-store.yaml
+++ b/components/cluster-secret-store/base/appsre-stonesoup-vault-secret-store.yaml
@@ -33,6 +33,7 @@ spec:
         - spi-system
         - group-sync-operator
         - build-templates
+        - build-templates-e2e
         - build-service
         - tekton-ci
         - image-controller


### PR DESCRIPTION
We updated components/tekton-ci/base/external-secrets/quay-push-secret.yaml in vault and it was synced with the tekton-ci namespace and it works there. But the same task fails in the build-templates-e2e namespace where the e2e tests with wrong credentials error.
I have a feeling that since it was missing from here, it did not sync the new secret.