### PR TITLE
Simplify backup ApplicationSet generators

### DIFF
--- a/argo-cd-apps/base/member/infra-deployments/backup/backup.yaml
+++ b/argo-cd-apps/base/member/infra-deployments/backup/backup.yaml
@@ -4,16 +4,10 @@ metadata:
   name: backup
 spec:
   generators:
-    - merge:
-        mergeKeys:
-          - nameNormalized
-        generators:
-          - clusters:
-              values:
-                sourceRoot: components/backup
-                environment: staging
-          - list:
-              elements: []
+    - clusters:
+        values:
+          sourceRoot: components/backup
+          environment: staging
   template:
     metadata:
       name: backup-{{nameNormalized}}

--- a/argo-cd-apps/base/member/infra-deployments/backup/kustomization.yaml
+++ b/argo-cd-apps/base/member/infra-deployments/backup/kustomization.yaml
@@ -3,4 +3,4 @@ kind: Kustomization
 resources:
 - backup.yaml
 components:
-  - ../../../../k-components/deploy-to-member-cluster-merge-generator
+  - ../../../../k-components/deploy-to-member-cluster


### PR DESCRIPTION
The is no point using a merge generator to merge cluster with an empty list generators. Remove the list generator as it is empty anyway.