### PR TITLE
chore(RHTAPWATCH-579): Remove o11y repository from infra-deployments

### DIFF
--- a/components/tekton-ci/base/repository.yaml
+++ b/components/tekton-ci/base/repository.yaml
@@ -114,13 +114,6 @@ spec:
 apiVersion: pipelinesascode.tekton.dev/v1alpha1
 kind: Repository
 metadata:
-  name: o11y
-spec:
-  url: "https://github.com/redhat-appstudio/o11y"
----
-apiVersion: pipelinesascode.tekton.dev/v1alpha1
-kind: Repository
-metadata:
   name: cachi2
 spec:
   url: "https://github.com/containerbuildsystem/cachi2"


### PR DESCRIPTION
Removed o11y component which is using the tekton-ci facility from RHTAP to enable custom build pipeline.