### PR TITLE
Revert "Simplify backup ApplicationSet generators"

### DIFF
--- a/argo-cd-apps/base/member/infra-deployments/backup/backup.yaml
+++ b/argo-cd-apps/base/member/infra-deployments/backup/backup.yaml
@@ -4,10 +4,16 @@ metadata:
   name: backup
 spec:
   generators:
-    - clusters:
-        values:
-          sourceRoot: components/backup
-          environment: staging
+    - merge:
+        mergeKeys:
+          - nameNormalized
+        generators:
+          - clusters:
+              values:
+                sourceRoot: components/backup
+                environment: staging
+          - list:
+              elements: []
   template:
     metadata:
       name: backup-{{nameNormalized}}

--- a/argo-cd-apps/base/member/infra-deployments/backup/kustomization.yaml
+++ b/argo-cd-apps/base/member/infra-deployments/backup/kustomization.yaml
@@ -3,4 +3,4 @@ kind: Kustomization
 resources:
 - backup.yaml
 components:
-  - ../../../../k-components/deploy-to-member-cluster
+  - ../../../../k-components/deploy-to-member-cluster-merge-generator


### PR DESCRIPTION
Reverts redhat-appstudio/infra-deployments#2793

This changed worked on staging but does not in production, let's revert for now and I will reopen another PR with same change including fix for production.