### PR TITLE
Add quay-push-secret to build-templates-e2e namespace in stage and prod

### DIFF
--- a/components/build-templates/production/e2e-quay-push-secret.yaml
+++ b/components/build-templates/production/e2e-quay-push-secret.yaml
@@ -1,0 +1,25 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: quay-push-secret
+  namespace: build-templates-e2e
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  dataFrom:
+    - extract:
+        key: production/build/tekton-ci/quay-push-secret
+  refreshInterval: 15m
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: appsre-stonesoup-vault
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    name: quay-push-secret
+    template:
+      engineVersion: v2
+      type: kubernetes.io/dockerconfigjson
+      data:
+        .dockerconfigjson: "{{ .config }}"

--- a/components/build-templates/production/kustomization.yaml
+++ b/components/build-templates/production/kustomization.yaml
@@ -2,3 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../base
+  - e2e-quay-push-secret.yaml

--- a/components/build-templates/staging/e2e-quay-push-secret.yaml
+++ b/components/build-templates/staging/e2e-quay-push-secret.yaml
@@ -1,0 +1,25 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: quay-push-secret
+  namespace: build-templates-e2e
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  dataFrom:
+    - extract:
+        key: staging/build/tekton-ci/quay-push-secret
+  refreshInterval: 15m
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: appsre-stonesoup-vault
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    name: quay-push-secret
+    template:
+      engineVersion: v2
+      type: kubernetes.io/dockerconfigjson
+      data:
+        .dockerconfigjson: "{{ .config }}"

--- a/components/build-templates/staging/kustomization.yaml
+++ b/components/build-templates/staging/kustomization.yaml
@@ -2,3 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../base
+  - e2e-quay-push-secret.yaml


### PR DESCRIPTION
There is a quay-push-secret in the build-templates-e2e namespace, but
nobody knows how it got there. The other quay-push-secret (the one in
tekton-ci) got rotated and now the one in build-templates-e2e is
invalid.

Attempt to fix the issue by copy-pasting the quay-push-secret external
secret from tekton-ci to build-templates-e2e.