### PR TITLE
enable mfrancisc to view spacebindingrequests 

### DIFF
--- a/components/sandbox/base/rbac/view-spacebindingrequests.yaml
+++ b/components/sandbox/base/rbac/view-spacebindingrequests.yaml
@@ -1,0 +1,24 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: view-spacebindingrequests
+rules:
+- apiGroups:
+  - "toolchain.dev.openshift.com"
+  resources:
+  - "spacebindingrequests"
+  verbs:
+  - "get"
+  - "list"
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: view-spacebindingrequests
+subjects:
+  - kind: User
+    name: mfrancisc
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: view-spacebindingrequests


### PR DESCRIPTION
I need to investigate SpaceBindingRequests CRs on PROD and STAGE clusters. 
Specifically right now for the spacebindingrequests migration controller task : https://issues.redhat.com/browse/ASC-432 , in order to double check any failed SpaceBindingRequest object. 