### PR TITLE
Install oadp operator in stg-rh01 cluster

### DIFF
--- a/components/backup/base/oadp/dpa.yaml
+++ b/components/backup/base/oadp/dpa.yaml
@@ -1,0 +1,26 @@
+apiVersion: oadp.openshift.io/v1alpha1
+kind: DataProtectionApplication
+metadata:
+  name: velero-aws
+spec:
+  backupLocations:
+    - velero:
+        config:
+          kmsKeyId: CHANGE_ME
+          profile: default
+          region: us-east-1
+        credential:
+          key: cloud
+          name: backup-s3-credentials
+        default: true
+        objectStorage:
+          bucket: CHANGE_ME
+          prefix: velero
+        provider: aws
+  configuration:
+    restic:
+      enable: false
+    velero:
+      defaultPlugins:
+        - openshift
+        - aws

--- a/components/backup/base/oadp/install-oadp.yaml
+++ b/components/backup/base/oadp/install-oadp.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: redhat-oadp-operator
+spec:
+  channel: stable-1.2
+  installPlanApproval: Automatic
+  name: redhat-oadp-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: openshift-adp
+spec:
+  targetNamespaces:
+  - openshift-adp

--- a/components/backup/base/oadp/kustomization.yaml
+++ b/components/backup/base/oadp/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: openshift-adp
+resources:
+  - dpa.yaml
+  - install-oadp.yaml

--- a/components/backup/staging/stone-stg-rh01/dpa-bucket-patch.yaml
+++ b/components/backup/staging/stone-stg-rh01/dpa-bucket-patch.yaml
@@ -1,0 +1,3 @@
+- op: replace
+  path: /spec/backupLocations/0/velero/objectStorage/bucket
+  value: backup-stone-stg-rh01

--- a/components/backup/staging/stone-stg-rh01/dpa-kmskeyid-patch.yaml
+++ b/components/backup/staging/stone-stg-rh01/dpa-kmskeyid-patch.yaml
@@ -1,0 +1,3 @@
+- op: replace
+  path: /spec/backupLocations/0/velero/config/kmsKeyId
+  value: f1db03bc-ea5b-48f8-a40b-1afbbe666178

--- a/components/backup/staging/stone-stg-rh01/kustomization.yaml
+++ b/components/backup/staging/stone-stg-rh01/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../base/
+  - ../../base/oadp
 patches:
   - target:
       group: external-secrets.io
@@ -9,3 +10,15 @@ patches:
       kind: ExternalSecret
       name: backup-s3-credentials
     path: backup-s3-credentials-patch.yaml
+  - target:
+      group: oadp.openshift.io
+      version: v1alpha1
+      kind: DataProtectionApplication
+      name: velero-aws
+    path: dpa-bucket-patch.yaml
+  - target:
+      group: oadp.openshift.io
+      version: v1alpha1
+      kind: DataProtectionApplication
+      name: velero-aws
+    path: dpa-kmskeyid-patch.yaml


### PR DESCRIPTION
This change is installing oadp operator, configuring the DataProtectionApplication to use the proper credentials and aws bucket in stg-rh01 cluster.

 A backup schedule will be created in a follow up change. Once this  change is in, we will test backup once manually before creating a schedule.

[RHTAPSRE-259](https://issues.redhat.com//browse/RHTAPSRE-259)