### PR TITLE
Add admins for build-templates-e2e namespace

### DIFF
--- a/components/build-templates/base/e2e/role.yaml
+++ b/components/build-templates/base/e2e/role.yaml
@@ -29,3 +29,31 @@ rules:
   - patch
   - update
   - watch
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: build-admin
+  namespace: build-templates-e2e
+rules:
+  - apiGroups:
+      - ''
+    resources:
+      - secrets
+    verbs:
+      - get
+      - list
+      - watch
+      - update
+      - patch
+      - delete
+
+  - apiGroups:
+      - ''
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+      - delete

--- a/components/build-templates/base/e2e/rolebinding.yaml
+++ b/components/build-templates/base/e2e/rolebinding.yaml
@@ -50,3 +50,22 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: appstudio-pipelines-runner
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: build-admins
+  namespace: build-templates-e2e
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: Build Admins team
+  # TODO: remove mkosiarc, temporary for setup/debugging
+  - apiGroup: rbac.authorization.k8s.io
+    kind: User
+    name: mkosiarc
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: build-admin
+  


### PR DESCRIPTION
Currently the namespace does not have any admins. Previously it was managed manually with the role of cluster wide admin. We need people with admin access in the cluster to setup the secrets there - they weren't managed by infra-deployments configuration before but only manually, so we don't the names of the secrets currently in place.