### PR TITLE
Fix patching of backup ExternalSecret

### DIFF
--- a/components/backup/production/stone-prd-m01/backup-s3-credentials-patch.yaml
+++ b/components/backup/production/stone-prd-m01/backup-s3-credentials-patch.yaml
@@ -1,0 +1,3 @@
+- op: replace
+  path: /spec/dataFrom/0/extract/key
+  value: integrations-output/terraform-resources/stonesoupp01ue1/stonesoup-infra-prod-backup/backup-stone-prd-m01

--- a/components/backup/production/stone-prd-m01/backup-stone-prd-m01.yaml
+++ b/components/backup/production/stone-prd-m01/backup-stone-prd-m01.yaml
@@ -1,8 +1,0 @@
-apiVersion: external-secrets.io/v1beta1
-kind: ExternalSecret
-metadata:
-  name: backup-s3-credentials
-spec:
-  dataFrom:
-  - extract:
-      key: integrations-output/terraform-resources/stonesoupp01ue1/stonesoup-infra-prod-backup/backup-stone-prd-m01

--- a/components/backup/production/stone-prd-m01/kustomization.yaml
+++ b/components/backup/production/stone-prd-m01/kustomization.yaml
@@ -3,4 +3,9 @@ kind: Kustomization
 resources:
   - ../../base/
 patches:
-  - path: backup-stone-prd-m01.yaml
+  - target:
+      group: external-secrets.io
+      version: v1beta1
+      kind: ExternalSecret
+      name: backup-s3-credentials
+    path: backup-s3-credentials-patch.yaml

--- a/components/backup/production/stone-prd-rh01/backup-s3-credentials-patch.yaml
+++ b/components/backup/production/stone-prd-rh01/backup-s3-credentials-patch.yaml
@@ -1,0 +1,3 @@
+- op: replace
+  path: /spec/dataFrom/0/extract/key
+  value: integrations-output/terraform-resources/stonesoupp01ue1/stonesoup-infra-prod-backup/backup-stone-prd-rh01

--- a/components/backup/production/stone-prd-rh01/backup-stone-prd-rh01.yaml
+++ b/components/backup/production/stone-prd-rh01/backup-stone-prd-rh01.yaml
@@ -1,8 +1,0 @@
-apiVersion: external-secrets.io/v1beta1
-kind: ExternalSecret
-metadata:
-  name: backup-s3-credentials
-spec:
-  dataFrom:
-  - extract:
-      key: integrations-output/terraform-resources/stonesoupp01ue1/stonesoup-infra-prod-backup/backup-stone-prd-rh01

--- a/components/backup/production/stone-prd-rh01/kustomization.yaml
+++ b/components/backup/production/stone-prd-rh01/kustomization.yaml
@@ -3,4 +3,9 @@ kind: Kustomization
 resources:
   - ../../base/
 patches:
-  - path: backup-stone-prd-rh01.yaml
+  - target:
+      group: external-secrets.io
+      version: v1beta1
+      kind: ExternalSecret
+      name: backup-s3-credentials
+    path: backup-s3-credentials-patch.yaml

--- a/components/backup/staging/stone-stg-m01/backup-s3-credentials-patch.yaml
+++ b/components/backup/staging/stone-stg-m01/backup-s3-credentials-patch.yaml
@@ -1,0 +1,3 @@
+- op: replace
+  path: /spec/dataFrom/0/extract/key
+  value: integrations-output/terraform-resources/stonesoups01ue1/stonesoup-infra-stage-backup/backup-stone-stg-m01

--- a/components/backup/staging/stone-stg-m01/backup-stone-stg-m01.yaml
+++ b/components/backup/staging/stone-stg-m01/backup-stone-stg-m01.yaml
@@ -1,8 +1,0 @@
-apiVersion: external-secrets.io/v1beta1
-kind: ExternalSecret
-metadata:
-  name: backup-s3-credentials
-spec:
-  dataFrom:
-  - extract:
-      key: integrations-output/terraform-resources/stonesoups01ue1/stonesoup-infra-stage-backup/backup-stone-stg-m01

--- a/components/backup/staging/stone-stg-m01/kustomization.yaml
+++ b/components/backup/staging/stone-stg-m01/kustomization.yaml
@@ -3,4 +3,9 @@ kind: Kustomization
 resources:
   - ../../base/
 patches:
-  - path: backup-stone-stg-m01.yaml
+  - target:
+      group: external-secrets.io
+      version: v1beta1
+      kind: ExternalSecret
+      name: backup-s3-credentials
+    path: backup-s3-credentials-patch.yaml

--- a/components/backup/staging/stone-stg-rh01/backup-s3-credentials-patch.yaml
+++ b/components/backup/staging/stone-stg-rh01/backup-s3-credentials-patch.yaml
@@ -1,0 +1,3 @@
+- op: replace
+  path: /spec/dataFrom/0/extract/key
+  value: integrations-output/terraform-resources/stonesoups01ue1/stonesoup-infra-stage-backup/backup-stone-stg-rh01

--- a/components/backup/staging/stone-stg-rh01/backup-stone-stg-rh01.yaml
+++ b/components/backup/staging/stone-stg-rh01/backup-stone-stg-rh01.yaml
@@ -1,8 +1,0 @@
-apiVersion: external-secrets.io/v1beta1
-kind: ExternalSecret
-metadata:
-  name: backup-s3-credentials
-spec:
-  dataFrom:
-  - extract:
-      key: integrations-output/terraform-resources/stonesoups01ue1/stonesoup-infra-stage-backup/backup-stone-stg-rh01

--- a/components/backup/staging/stone-stg-rh01/kustomization.yaml
+++ b/components/backup/staging/stone-stg-rh01/kustomization.yaml
@@ -3,4 +3,9 @@ kind: Kustomization
 resources:
   - ../../base/
 patches:
-  - path: backup-stone-stg-rh01.yaml
+  - target:
+      group: external-secrets.io
+      version: v1beta1
+      kind: ExternalSecret
+      name: backup-s3-credentials
+    path: backup-s3-credentials-patch.yaml


### PR DESCRIPTION
PatchStrategicMerge does not support merge for all type of resources. This is the case for ExternalSecret. Instead of replacing the key in the extract object, it replaces the entire extract object with the one from the patch resulting in removing onversionStrategy and decodingStrategy.

Fix this by using a PatchesJson6902 instead of a PatchStrategicMerge.

Original ExternalSecret resource:
```
spec:
  dataFrom:
  - extract:
      conversionStrategy: Default
      decodingStrategy: None
      key: CHANGE_ME
```

Patched with PatchStrategicMerge:
```
spec:
  dataFrom:
  - extract:
      key: integrations-output/terraform-resources/stonesoups01ue1/stonesoup-infra-stage-backup/backup-stone-stg-m01
```

Patched with PatchesJson6902
```
spec:
  dataFrom:
  - extract:
      conversionStrategy: Default
      decodingStrategy: None
      key: integrations-output/terraform-resources/stonesoups01ue1/stonesoup-infra-stage-backup/backup-stone-stg-m01
```