### PR TITLE
Fix installation order of backup components

### DIFF
--- a/components/backup/base/external-secret.yaml
+++ b/components/backup/base/external-secret.yaml
@@ -2,6 +2,8 @@ apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
   name: backup-s3-credentials
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
 spec:
   dataFrom:
   - extract:

--- a/components/backup/base/oadp/install-oadp.yaml
+++ b/components/backup/base/oadp/install-oadp.yaml
@@ -3,6 +3,8 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
   name: redhat-oadp-operator
+  annotations:
+    argocd.argoproj.io/sync-wave: "-2"
 spec:
   channel: stable-1.2
   installPlanApproval: Automatic
@@ -15,6 +17,8 @@ apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:
   name: openshift-adp
+  annotations:
+    argocd.argoproj.io/sync-wave: "-3"
 spec:
   targetNamespaces:
   - openshift-adp


### PR DESCRIPTION
Make sure backup components can install without having to intervene. ArgoCD tried to create dpa before the oadp was installed causing the whole backup application to be stuck as syncing.

Set sync-wave of the install in the following order: OperatorGroup, Subscription, ExternalSecret and then DataProtectionApplication.