### PR TITLE
build-templates-e2e: set service account namespace

### DIFF
--- a/components/build-templates/production/e2e-serviceaccount.yaml
+++ b/components/build-templates/production/e2e-serviceaccount.yaml
@@ -7,3 +7,5 @@ secrets:
   - name: quay-push-secret
 imagePullSecrets:
   - name: quay-push-secret
+  # TODO: manage this secret properly via an ExternalSecret
+  - name: 6340056-stonesoup-build-definitions-e2e-pull-secret

--- a/components/build-templates/production/e2e-serviceaccount.yaml
+++ b/components/build-templates/production/e2e-serviceaccount.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: appstudio-pipeline
+  namespace: build-templates-e2e
 secrets:
   - name: quay-push-secret
 imagePullSecrets:

--- a/components/build-templates/production/kustomization.yaml
+++ b/components/build-templates/production/kustomization.yaml
@@ -3,4 +3,4 @@ kind: Kustomization
 resources:
   - ../base
   - e2e-quay-push-secret.yaml
-  - serviceaccount.yaml
+  - e2e-serviceaccount.yaml

--- a/components/build-templates/staging/e2e-serviceaccount.yaml
+++ b/components/build-templates/staging/e2e-serviceaccount.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: appstudio-pipeline
+  namespace: build-templates-e2e
 secrets:
   - name: quay-push-secret
 imagePullSecrets:

--- a/components/build-templates/staging/e2e-serviceaccount.yaml
+++ b/components/build-templates/staging/e2e-serviceaccount.yaml
@@ -7,3 +7,4 @@ secrets:
   - name: quay-push-secret
 imagePullSecrets:
   - name: quay-push-secret
+  # TODO: get a serviceaccount for registry.redhat.io pull access

--- a/components/build-templates/staging/kustomization.yaml
+++ b/components/build-templates/staging/kustomization.yaml
@@ -3,4 +3,4 @@ kind: Kustomization
 resources:
   - ../base
   - e2e-quay-push-secret.yaml
-  - serviceaccount.yaml
+  - e2e-serviceaccount.yaml


### PR DESCRIPTION
1. make sure the appstudio-pipeline service account in the build-templates component goes to the build-templates-e2e namespace
2. link the existing registry.redhat.io secret to ^ serviceaccount