### PR TITLE
Add argocd_app_reconcile_bucket metric

### DIFF
--- a/components/monitoring/prometheus/base/monitoringstack/monitoringstack.yaml
+++ b/components/monitoring/prometheus/base/monitoringstack/monitoringstack.yaml
@@ -105,6 +105,7 @@ spec:
         - '{__name__="openshift_route_status", namespace="gitops-service-argocd"}'
         - '{__name__="kube_deployment_status_replicas_ready", namespace="gitops-service-argocd"}'
         - '{__name__="kube_deployment_spec_replicas", namespace="gitops-service-argocd"}'
+        - '{__name__="argocd_app_reconcile_bucket", namespace="gitops-service-argocd"}'
     relabelings:
     # override the target's address by the prometheus-k8s service name.
     - action: replace


### PR DESCRIPTION
Need to add a new metric, `argocd_app_reconcile_bucket`, for GitOps Service monitoring. This is related to https://github.com/redhat-appstudio/o11y/pull/127.