### PR TITLE
PLNSRVCE-1537: pipeline-service grafana only update

### DIFF
--- a/components/monitoring/grafana/base/dashboards/pipeline-service/kustomization.yaml
+++ b/components/monitoring/grafana/base/dashboards/pipeline-service/kustomization.yaml
@@ -2,4 +2,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - https://github.com/openshift-pipelines/pipeline-service/operator/gitops/argocd/grafana/?ref=c36e75cea7e9e15d20bcde54d8e16048d0ffdb19
+  - https://github.com/openshift-pipelines/pipeline-service/operator/gitops/argocd/grafana/?ref=8604ea7b7a9605a66daa68ebbe08643d44e94a8f


### PR DESCRIPTION
since https://github.com/redhat-appstudio/infra-deployments/pull/2803 is blocked by a tekton-results regression, @redhat-appstudio/pipeline-service agreed to bump just the grafana dashboard to unblock https://issues.redhat.com/browse/PLNSRVCE-1537 