### PR TITLE
chore(RHTAPWATCH-552): sync production cluster's for segment-bridge

### DIFF
--- a/argo-cd-apps/base/host/segment-bridge/segment-bridge-host.yaml
+++ b/argo-cd-apps/base/host/segment-bridge/segment-bridge-host.yaml
@@ -17,18 +17,20 @@ spec:
               elements:
                 - nameNormalized: stone-stg-host
                   values.clusterDir: stone-stg-host
+                - nameNormalized: stone-prd-host
+                  values.clusterDir: stone-stg-host
   template:
     metadata:
       name: segment-bridge-host-{{nameNormalized}}
     spec:
       project: default
       source:
-        path: '{{values.sourceRoot}}/{{values.environment}}/{{values.clusterDir}}'
+        path: "{{values.sourceRoot}}/{{values.environment}}/{{values.clusterDir}}"
         repoURL: https://github.com/redhat-appstudio/infra-deployments.git
         targetRevision: main
       destination:
         namespace: segment-bridge
-        server: '{{server}}'
+        server: "{{server}}"
       syncPolicy:
         automated:
           prune: true

--- a/argo-cd-apps/base/member/infra-deployments/segment-bridge/segment-bridge-member.yaml
+++ b/argo-cd-apps/base/member/infra-deployments/segment-bridge/segment-bridge-member.yaml
@@ -19,18 +19,22 @@ spec:
                   values.clusterDir: stone-stg-m01
                 - nameNormalized: stone-stg-rh01
                   values.clusterDir: stone-stg-rh01
+                - nameNormalized: stone-prd-m01
+                  values.clusterDir: stone-stg-m01
+                - nameNormalized: stone-prd-rh01
+                  values.clusterDir: stone-stg-rh01
   template:
     metadata:
       name: segment-bridge-member-{{nameNormalized}}
     spec:
       project: default
       source:
-        path: '{{values.sourceRoot}}/{{values.environment}}/{{values.clusterDir}}'
+        path: "{{values.sourceRoot}}/{{values.environment}}/{{values.clusterDir}}"
         repoURL: https://github.com/redhat-appstudio/infra-deployments.git
         targetRevision: main
       destination:
         namespace: segment-bridge
-        server: '{{server}}'
+        server: "{{server}}"
       syncPolicy:
         automated:
           prune: true

--- a/components/segment-bridge/production/rbac/kustomization.yaml
+++ b/components/segment-bridge/production/rbac/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../rbac

--- a/components/segment-bridge/production/stone-prd-host/kustomization.yaml
+++ b/components/segment-bridge/production/stone-prd-host/kustomization.yaml
@@ -1,5 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- ../base
-
+  - ../rbac

--- a/components/segment-bridge/production/stone-prd-m01/kustomization.yaml
+++ b/components/segment-bridge/production/stone-prd-m01/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../base

--- a/components/segment-bridge/production/stone-prd-rh01/kustomization.yaml
+++ b/components/segment-bridge/production/stone-prd-rh01/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../base


### PR DESCRIPTION
The segment-bridge component had sync issues on some of its objects. The cause seem to be the toolchain-host-operator setting, which moved into the segment-bridge directory and so got applied to all of its cluster's settings.

Applying the settings to the RH clusters in which
the toolchain-host-operator component does not exist is the cause for the unsync issue.

This was previously fixed for the staging environment; this patch apply the same logic to the production environment.