### PR TITLE
chore(RHTAPWATCH-580): deploy prometheus exporter from o11y

### DIFF
--- a/components/monitoring/grafana/base/kustomization.yaml
+++ b/components/monitoring/grafana/base/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
 - grafana-app.yaml
 - dashboards
 - https://github.com/redhat-appstudio/o11y/config/probes/monitoring/grafana/base?ref=a59a05e52c0fa06092b851d2cfff1faaf9cdd392
+- https://github.com/redhat-appstudio/o11y/config/exporters/monitoring/grafana/base?ref=fefbef58a77f412eae89a1293b94683931bb3b8b


### PR DESCRIPTION
Deploy the grafana availability exporter from o11y to infra-deployments.

Signed-off-by: Homaja Marisetty <hmariset@redhat.com>
