### PR TITLE
Add backup schedule for tenants namespaces

### DIFF
--- a/components/backup/base/external-secret.yaml
+++ b/components/backup/base/external-secret.yaml
@@ -3,7 +3,7 @@ kind: ExternalSecret
 metadata:
   name: backup-s3-credentials
   annotations:
-    argocd.argoproj.io/sync-wave: "-1"
+    argocd.argoproj.io/sync-wave: "-2"
 spec:
   dataFrom:
   - extract:

--- a/components/backup/base/oadp/backup-tenants-schedule.yaml
+++ b/components/backup/base/oadp/backup-tenants-schedule.yaml
@@ -1,0 +1,56 @@
+apiVersion: velero.io/v1
+kind: Schedule
+metadata:
+  name: backup-tenants
+spec:
+  schedule: 30 1,13 * * * # every day 1:30, 13:30 UTC
+  template:
+    excludedNamespaces:
+      - kube-*
+      - openshift*
+      - appstudio*
+      - admin-checker
+      - application-api
+      - application-service
+      - appsre-vault
+      - build-service
+      - build-templates
+      - build-templates-e2e
+      - dedicated-admin
+      - deployment-validation-operator
+      - dora-metrics
+      - enterprise-contract-service
+      - external-secrets-operator
+      - gitops
+      - gitops-service-argocd
+      - group-sync-operator
+      - hac-pact-broker
+      - image-controller
+      - integration-service
+      - internal-services
+      - jvm-build-service
+      - multi-platform-controller
+      - perf-team-prometheus-reader
+      - plnsvc-tests
+      - quality-dashboard
+      - release-service
+      - remotesecret
+      - sandbox-sre-member
+      - segment-bridge
+      - spi-system
+      - tekton-results
+      - toolchain-member-operator
+    includedResources:
+      - applications.appstudio.redhat.com
+      - components.appstudio.redhat.com
+      - environments.appstudio.redhat.com
+      - integrationtestscenarios.appstudio.redhat.com
+      - secrets
+      - snapshots.appstudio.redhat.com
+      - snapshotenvironmentbindings.appstudio.redhat.com
+      - serviceaccounts
+      - namespaces
+    storageLocation: velero-aws-1
+    ttl: 720h0m0s
+status:
+  phase: Enabled

--- a/components/backup/base/oadp/dpa.yaml
+++ b/components/backup/base/oadp/dpa.yaml
@@ -2,6 +2,8 @@ apiVersion: oadp.openshift.io/v1alpha1
 kind: DataProtectionApplication
 metadata:
   name: velero-aws
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
 spec:
   backupLocations:
     - velero:

--- a/components/backup/base/oadp/kustomization.yaml
+++ b/components/backup/base/oadp/kustomization.yaml
@@ -2,5 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: openshift-adp
 resources:
+  - backup-tenants-schedule.yaml
   - dpa.yaml
   - install-oadp.yaml


### PR DESCRIPTION
Is it not supported to use wildcards in the includedNamespaces so exclude the namespaces we do not want instead. That way, we might backup more than needed but that is better than less.

Schedule the backup twicee a day, at 1:30 UTC which is outside of working hours from GMT-8(5:30PM) to 
 GMT+5:30(7:00AM) and at 13:30 UTC which is 12 hours after first backup to minimise work loss in case on an
incident.


Move the ExternalSecret to the -2 sync wave, since it can be done at same time operator is being installed. Move DPA to -1 sync wave as we need this to be created before backup schedule.

[RHTAPSRE-259](https://issues.redhat.com//browse/RHTAPSRE-259)