### PR TITLE
PLNSRVCE-1537: add new combined/filtered pipeline service alert metrics to app sre in-cluster prometheus list

### DIFF
--- a/components/monitoring/prometheus/base/monitoringstack/monitoringstack.yaml
+++ b/components/monitoring/prometheus/base/monitoringstack/monitoringstack.yaml
@@ -87,6 +87,10 @@ spec:
   endpoints:
   - params:
       'match[]': # scrape only required metrics from in-cluster prometheus
+        - '{__name__="pipeline_service_schedule_overhead_percentage_sum"}'
+        - '{__name__="pipeline_service_schedule_overhead_percentage_count"}'
+        - '{__name__="pipeline_service_execution_overhead_percentage_sum"}'
+        - '{__name__="pipeline_service_execution_overhead_percentage_count"}'
         - '{__name__="pipelinerun_duration_scheduled_seconds_sum"}'
         - '{__name__="pipelinerun_duration_scheduled_seconds_count"}'
         - '{__name__="pipelinerun_gap_between_taskruns_milliseconds_sum"}'


### PR DESCRIPTION
We have combined the 2 seperate histograms used each for our execution and overhead alert queries into one metric.  This reduces the number metric queries required for our alerts by half, and also allows us to filter pipelieruns that incorrectly corrupt our overall averages (because they only take a few seconds to complete)

Note - I will remove the original metrics we added for the pipeline-service after the app sre grafana panels have been updated in both app sre stage and prod.

@redhat-appstudio/pipeline-service FYI