### PR TITLE
Upgrade OADP operator to channel 1.3

### DIFF
--- a/components/backup/base/oadp/install-oadp.yaml
+++ b/components/backup/base/oadp/install-oadp.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "-2"
 spec:
-  channel: stable-1.2
+  channel: stable-1.3
   installPlanApproval: Automatic
   name: redhat-oadp-operator
   source: redhat-operators


### PR DESCRIPTION
Version 1.3.0 was released so upgrade to that version since we did not start to take backups. Let's upgrade now and test backup with latest version.