### PR TITLE
Link the registry secret as a mountable secret

### DIFF
--- a/components/build-templates/production/e2e-serviceaccount.yaml
+++ b/components/build-templates/production/e2e-serviceaccount.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: build-templates-e2e
 secrets:
   - name: quay-push-secret
+  - name: 6340056-stonesoup-build-definitions-e2e-pull-secret
 imagePullSecrets:
   - name: quay-push-secret
   # TODO: manage this secret properly via an ExternalSecret


### PR DESCRIPTION
Having it in imagePullSecrets is not enough, it was not discovered in the build-task.