### PR TITLE
Remove status section from backup schedule

### DIFF
--- a/components/backup/base/oadp/backup-tenants-schedule.yaml
+++ b/components/backup/base/oadp/backup-tenants-schedule.yaml
@@ -52,5 +52,3 @@ spec:
       - namespaces
     storageLocation: velero-aws-1
     ttl: 720h0m0s
-status:
-  phase: Enabled


### PR DESCRIPTION
This section is updated by the application, we should not have it in the object definition.

[RHTAPSRE-259](https://issues.redhat.com//browse/RHTAPSRE-259)