### PR TITLE
add resolution.tekton.dev to pipeline service sre permissions

### DIFF
--- a/components/pipeline-service/base/rbac/cluster-role/pipeline-service-sre.yaml
+++ b/components/pipeline-service/base/rbac/cluster-role/pipeline-service-sre.yaml
@@ -48,6 +48,7 @@ rules:
       - results.tekton.dev
       - tekton.dev
       - triggers.tekton.dev
+      - resolution.tekton.dev
     resources:
       - "*"
     verbs:


### PR DESCRIPTION
In order to invesitate issues around bundle processing, we need to be able to inspect the API from the resolution.tekton.dev API group like ResolutionRequests

@redhat-appstudio/pipeline-service FYI

Otherwise you get

```
gmontero ~ $ oc get resolutionrequests
Error from server (Forbidden): resolutionrequests.resolution.tekton.dev is forbidden: User "gabemontero" cannot list resource "resolutionrequests" in API group "resolution.tekton.dev" in the namespace "tekton-ci"
gmontero ~ $ 
```