### PR TITLE
feat(RHTAPWATCH-629): Add a gosmee server

### DIFF
--- a/argo-cd-apps/base/host/kustomization.yaml
+++ b/argo-cd-apps/base/host/kustomization.yaml
@@ -5,7 +5,7 @@ resources:
   - toolchain-host-operator
   - segment-bridge
   - ingresscontroller
+  - smee
 components:
   - ../../k-components/deploy-to-host-cluster-merge-generator
   - ../../k-components/inject-argocd-namespace
-

--- a/argo-cd-apps/base/host/smee/kustomization.yaml
+++ b/argo-cd-apps/base/host/smee/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - smee.yaml
+components:
+  - ../../../k-components/inject-infra-deployments-repo-details

--- a/argo-cd-apps/base/host/smee/smee.yaml
+++ b/argo-cd-apps/base/host/smee/smee.yaml
@@ -1,0 +1,41 @@
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: smee
+spec:
+  generators:
+    - merge:
+        mergeKeys:
+          - nameNormalized
+        generators:
+          - clusters:
+              values:
+                sourceRoot: components/smee
+                environment: staging
+                clusterDir: ""
+          - list:
+              elements: []
+  template:
+    metadata:
+      name: smee-{{nameNormalized}}
+    spec:
+      project: default
+      source:
+        path: '{{values.sourceRoot}}/{{values.environment}}/{{values.clusterDir}}'
+        repoURL: https://github.com/redhat-appstudio/infra-deployments.git
+        targetRevision: main
+      destination:
+        namespace: smee
+        server: '{{server}}'
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
+        syncOptions:
+          - CreateNamespace=true
+        retry:
+          limit: -1
+          backoff:
+            duration: 10s
+            factor: 2
+            maxDuration: 3m

--- a/argo-cd-apps/overlays/development/delete-applications.yaml
+++ b/argo-cd-apps/overlays/development/delete-applications.yaml
@@ -52,3 +52,9 @@ kind: ApplicationSet
 metadata:
   name: backup
 $patch: delete
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: smee
+$patch: delete

--- a/argo-cd-apps/overlays/development/kustomization.yaml
+++ b/argo-cd-apps/overlays/development/kustomization.yaml
@@ -102,3 +102,8 @@ patches:
       kind: ApplicationSet
       version: v1alpha1
       name: integration
+  - path: development-overlay-patch.yaml
+    target:
+      kind: ApplicationSet
+      version: v1alpha1
+      name: smee

--- a/argo-cd-apps/overlays/production/kustomization.yaml
+++ b/argo-cd-apps/overlays/production/kustomization.yaml
@@ -137,3 +137,8 @@ patches:
       kind: ApplicationSet
       version: v1alpha1
       name: integration
+  - path: production-overlay-patch.yaml
+    target:
+      kind: ApplicationSet
+      version: v1alpha1
+      name: smee

--- a/components/smee/OWNERS
+++ b/components/smee/OWNERS
@@ -1,0 +1,6 @@
+# See the OWNERS docs: https://go.k8s.io/owners
+
+approvers:
+- ifireball
+- gbenhaim
+- amisstea

--- a/components/smee/README.md
+++ b/components/smee/README.md
@@ -1,0 +1,9 @@
+# Smee component
+
+The Smee component deploys [gosmee][gs] in server mode to the host cluster.
+
+This allows our clusters to provide a webhook forwarding service similar to
+[smee.io][sm].
+
+[gs]: https://github.com/chmouel/gosmee
+[sm]: https://smee.io/

--- a/components/smee/base/kustomization.yaml
+++ b/components/smee/base/kustomization.yaml
@@ -1,0 +1,4 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources: []

--- a/components/smee/production/kustomization.yaml
+++ b/components/smee/production/kustomization.yaml
@@ -1,0 +1,4 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources: []

--- a/components/smee/staging/deployment.yaml
+++ b/components/smee/staging/deployment.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gosmee
+  labels:
+    app: gosmee
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: gosmee
+  template:
+    metadata:
+      labels:
+        app: gosmee
+    spec:
+      containers:
+        - image: "ghcr.io/chmouel/gosmee:v0.20.2"
+          imagePullPolicy: Always
+          name: gosmee
+          args: ["server", "--address", "0.0.0.0"]
+          ports:
+            - name: "gosmee-http"
+              containerPort: 3333
+              protocol: TCP
+          securityContext:
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+          resources:
+            limits:
+              cpu: 1
+              memory: 32Mi
+            requests:
+              cpu: 1
+              memory: 32Mi

--- a/components/smee/staging/kustomization.yaml
+++ b/components/smee/staging/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- deployment.yaml
+- route.yaml
+- service.yaml

--- a/components/smee/staging/route.yaml
+++ b/components/smee/staging/route.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: smee
+  annotations:
+    haproxy.router.openshift.io/timeout: 86410s
+    router.openshift.io/haproxy.health.check.interval: 86400s
+spec:
+  port:
+    targetPort: "http"
+  to:
+    kind: Service
+    name: smee
+  tls:
+    insecureEdgeTerminationPolicy: Redirect
+    termination: edge

--- a/components/smee/staging/service.yaml
+++ b/components/smee/staging/service.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: gosmee
+  name: smee
+spec:
+  ports:
+  - name: "http"
+    port: 3333
+    protocol: TCP
+    targetPort: "gosmee-http"
+  selector:
+    app: gosmee


### PR DESCRIPTION
Run a gosmee server on the host cluster to allow it to forward webhooks to internal clusters.

This is only deploying on staging clusters ATM.