### PR TITLE
Remove PaC config for ec-cli repo

### DIFF
--- a/components/tekton-ci/base/repository.yaml
+++ b/components/tekton-ci/base/repository.yaml
@@ -121,13 +121,6 @@ spec:
 apiVersion: pipelinesascode.tekton.dev/v1alpha1
 kind: Repository
 metadata:
-  name: ec-cli
-spec:
-  url: "https://github.com/enterprise-contract/ec-cli"
----
-apiVersion: pipelinesascode.tekton.dev/v1alpha1
-kind: Repository
-metadata:
   name: o11y
 spec:
   url: "https://github.com/redhat-appstudio/o11y"


### PR DESCRIPTION
This is causing problems as we onboard EC to RHTAP. RHTAP is saying "Git repository is already handled by Pipelines as Code" and refusing to create the custom build pipeline PR.

IIUC the existing PaC pipelines in this repo were experimental and should not be mission critical. The tekton bundles being created by those are also pushed by the GitHub actions workflow.

Ref: [EC-289](https://issues.redhat.com/browse/EC-289)