### PR TITLE
Add ec CLI downloads to OpenShift Console

### DIFF
--- a/components/enterprise-contract/download-service.yaml
+++ b/components/enterprise-contract/download-service.yaml
@@ -1,0 +1,275 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: ec-cli-download-role
+  namespace: enterprise-contract-service
+rules:
+  - apiGroups:
+      - route.openshift.io
+    resourceNames:
+      - ec-cli-download-route
+    resources:
+      - routes
+    verbs:
+      - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: ec-cli-download-role-binding
+  namespace: enterprise-contract-service
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: ec-cli-download-role
+subjects:
+  - kind: ServiceAccount
+    name: default
+    namespace: enterprise-contract-service
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: ec-cli-download-cluster-role
+  namespace: enterprise-contract-service
+rules:
+  - apiGroups:
+      - console.openshift.io
+    resources:
+      - consoleclidownloads
+    verbs:
+      - create
+      - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: ec-cli-download-cluster-role-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: ec-cli-download-cluster-role
+subjects:
+  - kind: ServiceAccount
+    name: default
+    namespace: enterprise-contract-service
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: 2
+    ignore-check.kube-linter.io/latest-tag: The openshift/tools:latest ImageStream only has the latest tag, and that is the version we want here
+    ignore-check.kube-linter.io/no-read-only-root-fs: The httpd init scripts modify its configuration
+  labels:
+    app.kubernetes.io/name: ec-cli-download
+    app.kubernetes.io/part-of: enterprise-contract
+  name: ec-cli-download-deployment
+  namespace: enterprise-contract-service
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: ec-cli-download
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: ec-cli-download
+    spec:
+      containers:
+        - image: image-registry.openshift-image-registry.svc:5000/openshift/httpd:2.4-ubi9
+          name: http
+          ports:
+            - containerPort: 8443
+              name: https
+              protocol: TCP
+          resources:
+            limits:
+              cpu: 100m
+              memory: 100Mi
+            requests:
+              cpu: 100m
+              memory: 10Mi
+          securityContext:
+            #readOnlyRootFilesystem: true
+            runAsNonRoot: true
+          volumeMounts:
+            - mountPath: /var/www/html
+              name: wwwdata
+              readOnly: true
+            - mountPath: /opt/app-root/httpd-ssl/private
+              name: tls-key
+              readOnly: true
+            - mountPath: /opt/app-root/httpd-ssl/certs
+              name: tls-certificate
+              readOnly: true
+      initContainers:
+        - args:
+            - |
+              #!/usr/bin/bash
+
+              set -o errexit
+              set -o nounset
+              set -o pipefail
+
+              function handle_error {
+                sleep infinity
+              }
+              trap handle_error ERR
+
+              imgref=$({
+                dir="$(mktemp --directory --tmpdir=.)"
+                cd "${dir}"
+                oc image extract "$EC_TASK_BUNDLE_REF"
+                jq -r '.spec.steps[0].image' verify-enterprise-contract
+                cd ..
+                rm -rf "${dir}"
+              })
+              echo "Determined ec CLI image to be ${imgref}"
+
+              base="${imgref%:*}"
+              base="${imgref%@*}"
+
+              manifests="$(oc image info --output=json --show-multiarch=true "${imgref}")"
+
+              download_ec() {
+                os="$1"
+                architecture="$2"
+                digest="$3"
+
+                echo "Downloading ${base}@${digest} for ${os}/${architecture}"
+
+                mkdir -p "${os}_${architecture}"
+                oc image extract "${base}@${digest}" --path /usr/bin/ec:"${os}_${architecture}" --confirm
+                chmod +x "${os}_${architecture}/ec"
+                tar czf "${os}_${architecture}/ec_${os}_${architecture}.tar.gz" -C "${os}_${architecture}" ec
+                echo "Downloaded ${base}@${digest}"
+              }
+
+              while read -r line; do
+                read -r -a args <<< "${line}"
+                download_ec "${args[@]}" &
+              done < <(echo "${manifests}" | jq -r ".[] | \"\(.config.os) \(.config.architecture) \(.digest)\"")
+
+              pids=$(jobs -p)
+              (
+                trap 'exit 0' TERM
+                while true
+                do
+                  echo Downloading...
+                  sleep 3
+                done
+              ) &
+              ticker_pid=$!
+
+              # shellcheck disable=SC2046
+              wait $pids
+              kill $ticker_pid
+
+              ingress="$(oc get route ec-cli-download-route --output=jsonpath='{.spec.host}')"
+
+              {
+                echo "apiVersion: console.openshift.io/v1
+              kind: ConsoleCLIDownload
+              metadata:
+                name: ec-cli
+              spec:
+                description: |
+                  The \`ec\` CLI is used to evaluate Enterprise Contract policies for Software Supply Chain.
+                displayName: ec - Enterprise Contract CLI
+                links:"
+                echo "${manifests}" | jq -r ".[] | \"    - href: https://${ingress}/\(.config.os)_\(.config.architecture)/ec_\(.config.os)_\(.config.architecture).tar.gz
+                    text: Download ec CLI for \(.config.os)/\(.config.architecture)\""
+              } | oc apply -f -
+
+              {
+                echo '<!doctype html>
+              <html>
+              <style>
+              html { font-family: "RedHatText", "Overpass", overpass, helvetica, arial, sans-serif; line-height: 1.5rem; }
+              ul { list-style: none; padding-left: 0; }
+              </style>
+              <body>
+              <ul>'
+                echo "${manifests}" | jq -r ".[] | \"<li><a href=\\\"\(.config.os)_\(.config.architecture)/ec_\(.config.os)_\(.config.architecture).tar.gz\\\">Download ec CLI for \(.config.os)/\(.config.architecture)</a></li>\""
+                echo '</ul>
+              </body>
+              </html>'
+              } > index.html
+          command:
+            - /bin/bash
+            - -c
+          env:
+            - name: EC_TASK_BUNDLE_REF
+              valueFrom:
+                configMapKeyRef:
+                  key: verify_ec_task_bundle
+                  name: ec-defaults
+          image: image-registry.openshift-image-registry.svc:5000/openshift/tools:latest
+          name: download
+          resources:
+            limits:
+              cpu: 1000m
+              memory: 512Mi
+            requests:
+              cpu: 500m
+              memory: 128Mi
+          securityContext:
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+          volumeMounts:
+            - mountPath: /var/www/html
+              name: wwwdata
+          workingDir: /var/www/html
+      volumes:
+        - emptyDir: {}
+          name: wwwdata
+        - name: tls-key
+          secret:
+            items:
+              - key: tls.key
+                path: server.pem
+            secretName: ec-cli-download-tls
+        - name: tls-certificate
+          secret:
+            items:
+              - key: tls.crt
+                path: server.pem
+            secretName: ec-cli-download-tls
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: 2
+    service.beta.openshift.io/serving-cert-secret-name: ec-cli-download-tls
+  labels:
+    app.kubernetes.io/name: ec-cli-download
+    app.kubernetes.io/part-of: enterprise-contract
+  name: ec-cli-download-service
+  namespace: enterprise-contract-service
+spec:
+  ports:
+    - name: https
+      port: 8443
+      targetPort: https
+  selector:
+    app.kubernetes.io/name: ec-cli-download
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  labels:
+    app.kubernetes.io/name: ec-cli-download
+    app.kubernetes.io/part-of: enterprise-contract
+  name: ec-cli-download-route
+  namespace: enterprise-contract-service
+spec:
+  port:
+    targetPort: https
+  tls:
+    termination: reencrypt
+  to:
+    kind: Service
+    name: ec-cli-download-service

--- a/components/enterprise-contract/kustomization.yaml
+++ b/components/enterprise-contract/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
   - ecp.yaml
   - role.yaml
   - rolebinding.yaml
+  - download-service.yaml
 generatorOptions:
   disableNameSuffixHash: true
 configMapGenerator:


### PR DESCRIPTION
With this the ec CLI referenced from the EC Tekton Task bundle, i.e. the `verify_ec_task_bundle` key of the `ec-defaults` ConfigMap, will be used to download all `ec` binaries from all images in the multi-arch ec CLI image, feed to a emptyDir volume and served via Apache HTTPD running on the cluster. The URL those will be propagated to the `ConsoleCLIDownload` resource, which in turn will make those downloads available on the OpenShift Console.

Ref: https://issues.redhat.com/browse/EC-278