### PR TITLE
fix(STONEINTG-654): remove SnapshotinvalidTotal metric

### DIFF
--- a/components/monitoring/grafana/base/dashboards/integration/kustomization.yaml
+++ b/components/monitoring/grafana/base/dashboards/integration/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - https://github.com/redhat-appstudio/integration-service/config/grafana/?ref=dd5a5e7abc4e575de00d5b568b95a8f74a13a50d
+  - https://github.com/redhat-appstudio/integration-service/config/grafana/?ref=52cd9c927aa8858c4136147389ab620283bbdacb


### PR DESCRIPTION
SnapshotInvalidTotal metric removed from integration-service
grafana panel "Snapshot Attempts Invalid Total" removed 