### PR TITLE
feat: Add environment configmaps to integration service

### DIFF
--- a/components/integration/development/kustomization.yaml
+++ b/components/integration/development/kustomization.yaml
@@ -13,3 +13,9 @@ namespace: integration-service
 
 components:
   - ../k-components/manager-resources-patch
+
+configMapGenerator:
+  - literals:
+      - ENVIRONMENT="development"
+    name: feature-flag-config
+    behavior: replace

--- a/components/integration/production/kustomization.yaml
+++ b/components/integration/production/kustomization.yaml
@@ -22,3 +22,9 @@ patches:
       kind: ExternalSecret
       group: external-secrets.io
       version: v1beta1
+
+configMapGenerator:
+  - literals:
+      - ENVIRONMENT="production"
+    name: feature-flag-config
+    behavior: replace

--- a/components/integration/staging/kustomization.yaml
+++ b/components/integration/staging/kustomization.yaml
@@ -14,3 +14,9 @@ namespace: integration-service
 
 components:
   - ../k-components/manager-resources-patch
+
+configMapGenerator:
+  - literals:
+      - ENVIRONMENT="staging"
+    name: feature-flag-config
+    behavior: replace


### PR DESCRIPTION
Add configmaps to the integration service so that the service can tell what environment it's running in.  This will be used to selectively enable pprof profiling.