### PR TITLE
fix(STONEINTG-694): tekton-ci - clair-in-ci-db token

### DIFF
--- a/components/tekton-ci/base/external-secrets/clair-in-ci-db-github-token.yaml
+++ b/components/tekton-ci/base/external-secrets/clair-in-ci-db-github-token.yaml
@@ -2,14 +2,14 @@
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
-  name: integration-github-token 
+  name: clair-in-ci-db-github-token
   annotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
     argocd.argoproj.io/sync-wave: "-1"
 spec:
   dataFrom:
     - extract:
-        key: "production/build/tekton-ci/integration-github-token"
+        key: "production/integration-service/tekton-ci/clair-in-ci-db-github-token"
   refreshInterval: 1h
   secretStoreRef:
     kind: ClusterSecretStore
@@ -17,4 +17,4 @@ spec:
   target:
     creationPolicy: Owner
     deletionPolicy: Delete
-    name: integration-github-token
+    name: clair-in-ci-db-github-token


### PR DESCRIPTION
Migrating clair-in-ci-db github token into separate key withint integration-service away from build-service namespace.