### PR TITLE
STONEBLD-1999: use new registry.redhat.io secret for e2e-tests

### DIFF
--- a/components/build-templates/production/e2e-registry-redhat-io-pull-secret.yaml
+++ b/components/build-templates/production/e2e-registry-redhat-io-pull-secret.yaml
@@ -1,0 +1,25 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: registry-redhat-io-pull-secret
+  namespace: build-templates-e2e
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  dataFrom:
+    - extract:
+        key: production/build/build-templates-e2e/registry-redhat-io-pull-secret
+  refreshInterval: 15m
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: appsre-stonesoup-vault
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    name: registry-redhat-io-pull-secret
+    template:
+      engineVersion: v2
+      type: kubernetes.io/dockerconfigjson
+      data:
+        .dockerconfigjson: "{{ .config }}"

--- a/components/build-templates/production/e2e-serviceaccount.yaml
+++ b/components/build-templates/production/e2e-serviceaccount.yaml
@@ -5,8 +5,7 @@ metadata:
   namespace: build-templates-e2e
 secrets:
   - name: quay-push-secret
-  - name: 6340056-stonesoup-build-definitions-e2e-pull-secret
+  - name: registry-redhat-io-pull-secret
 imagePullSecrets:
   - name: quay-push-secret
-  # TODO: manage this secret properly via an ExternalSecret
-  - name: 6340056-stonesoup-build-definitions-e2e-pull-secret
+  - name: registry-redhat-io-pull-secret

--- a/components/build-templates/production/kustomization.yaml
+++ b/components/build-templates/production/kustomization.yaml
@@ -3,4 +3,5 @@ kind: Kustomization
 resources:
   - ../base
   - e2e-quay-push-secret.yaml
+  - e2e-registry-redhat-io-pull-secret.yaml
   - e2e-serviceaccount.yaml

--- a/components/build-templates/staging/e2e-serviceaccount.yaml
+++ b/components/build-templates/staging/e2e-serviceaccount.yaml
@@ -7,4 +7,3 @@ secrets:
   - name: quay-push-secret
 imagePullSecrets:
   - name: quay-push-secret
-  # TODO: get a serviceaccount for registry.redhat.io pull access


### PR DESCRIPTION
[STONEBLD-1999](https://issues.redhat.com//browse/STONEBLD-1999)

- New service account rhtap-e2e-tests-pull-secret is created in customer
  portal Registry Service Accounts management page. This service account
  contains the token required for authentication by registry.redhat.io.
- Secret registry-redhat-io-pull-secret is created under vault path
  production/build/build-templates-e2e. Its content is copied from the
  service account manually.
- The token is syned to production cluster via an ExternalSecret
  resource.
- ServiceAccount is updated to link the token.
- Since e2e-tests runs on production cluster only, all these changes
  apply to production only. The ServiceAccount for staging is updated to
  not link the secret.
