### PR TITLE
fix(STONEINTG-694): fix broken kustomize for tekton-ci

### DIFF
--- a/components/tekton-ci/base/external-secrets/kustomization.yaml
+++ b/components/tekton-ci/base/external-secrets/kustomization.yaml
@@ -6,5 +6,5 @@ resources:
 - snyk-shared-token.yaml
 - slack-webhook-notification-secret.yaml
 - github-secret.yaml
-- integration-github-token.yaml
+- clair-in-ci-db-github-token.yaml
 namespace: tekton-ci


### PR DESCRIPTION
Clair-in-ci-db secrets is not creeated due the error in kustomize