### PR TITLE
Apply prd overlay patch to both segment-bridge applications

### DIFF
--- a/argo-cd-apps/overlays/production/kustomization.yaml
+++ b/argo-cd-apps/overlays/production/kustomization.yaml
@@ -101,7 +101,12 @@ patches:
     target:
       kind: ApplicationSet
       version: v1alpha1
-      name: segment-bridge
+      name: segment-bridge-host
+  - path: production-overlay-patch.yaml
+    target:
+      kind: ApplicationSet
+      version: v1alpha1
+      name: segment-bridge-member
   - path: production-overlay-patch.yaml
     target:
       kind: ApplicationSet


### PR DESCRIPTION
Without this, the productions applications were deployed from the staging folder.