### PR TITLE
Allow RHTAP admins to patch PipelineRun

### DIFF
--- a/components/authentication/base/rhtap-admins.yaml
+++ b/components/authentication/base/rhtap-admins.yaml
@@ -281,6 +281,15 @@ rules:
     verbs:
       - '*'
   - apiGroups:
+      - tekton.dev
+    resources:
+      - pipelineruns
+    verbs:
+      - get
+      - list
+      - patch
+      - watch
+  - apiGroups:
     - user.openshift.io
     resources:
       - groups


### PR DESCRIPTION
This is needed sometimes e.g. when a finalizer is stuck and preventing deletion of the PipelineRun.

```
oc patch <pipeline-run> --type merge -p '{"metadata":{"finalizers":null}}'
```