### PR TITLE
Deploy promotion application only on stg-rh01

### DIFF
--- a/argo-cd-apps/base/promotion/promotion.yaml
+++ b/argo-cd-apps/base/promotion/promotion.yaml
@@ -13,6 +13,9 @@ spec:
                 sourceRoot: components/promotion
                 environment: staging
                 clusterDir: ""
+              selector:
+                matchLabels:
+                  appstudio.redhat.com/rh-member-cluster: 'true'
           - list:
               elements:
                 - nameNormalized: stone-stg-rh01


### PR DESCRIPTION
The Promotion applicationset was creating one application per cluster, including the in-cluster which is control plane cluster.

Since we only want it on stone-stg-rh01, add a selector in the applicationset to select cluster with the
"appstudio.redhat.com/rh-member-cluster" label, which only stone-stg-rh01 has.