### PR TITLE
Grant access to secret store from rhtap-promotion-staging namespace

### DIFF
--- a/components/cluster-secret-store/staging/kustomization.yaml
+++ b/components/cluster-secret-store/staging/kustomization.yaml
@@ -2,3 +2,10 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../base
+patches:
+  - path: rhtap-promotion-staging-patch.yaml
+    target:
+      name: appsre-stonesoup-vault
+      kind: ClusterSecretStore
+      group: external-secrets.io
+      version: v1beta1

--- a/components/cluster-secret-store/staging/rhtap-promotion-staging-patch.yaml
+++ b/components/cluster-secret-store/staging/rhtap-promotion-staging-patch.yaml
@@ -1,0 +1,4 @@
+---
+- op: add
+  path: /spec/conditions/0/namespaces/-
+  value: rhtap-promotion-staging


### PR DESCRIPTION
In 37533f6aee79b78dea775ce2b4ed16813b93818e, promotion component was created and 2 external secrets added in the rhtap-promotion-staging namespace.

These external secrets were not able to get value from the secret store because secret store access is limited to a list of namespaces.

Add the rhtap-promotion-staging namespace in the list of allowed ones using a patch only applied in staging, as we do not want that in production overlay.