### PR TITLE
wait for Tekton CRDs to be ready

### DIFF
--- a/hack/preview.sh
+++ b/hack/preview.sh
@@ -337,3 +337,20 @@ if $KEYCLOAK && $TOOLCHAIN ; then
 	  exit 1
   fi
 fi
+
+# Sometimes Tekton CRDs need a few mins to be ready
+retry=0
+while true; do
+  if [ "$retry" -eq 5 ]; then
+    printf "Error: Tekton CRDs cannot be ready on the cluster.\n" >&2
+    exit 1
+  fi
+  tekton_crds=$(oc api-resources --api-group="tekton.dev" --no-headers)
+  if [[ $tekton_crds =~ pipelines && $tekton_crds =~ tasks && $tekton_crds =~ pipelineruns && $tekton_crds =~ taskruns ]]; then
+    echo "Tekton CRDs are ready"
+    break
+  fi
+  sleep $INTERVAL
+  retry=$((retry + 1))
+done
+

--- a/hack/preview.sh
+++ b/hack/preview.sh
@@ -342,7 +342,7 @@ fi
 retry=0
 while true; do
   if [ "$retry" -eq 5 ]; then
-    printf "Error: Tekton CRDs cannot be ready on the cluster.\n" >&2
+    printf "Error: Tekton CRDs are not yet available on the cluster.\n" >&2
     exit 1
   fi
   tekton_crds=$(oc api-resources --api-group="tekton.dev" --no-headers)


### PR DESCRIPTION
This PR is to fix bug [RHTAPBUGS-903](https://issues.redhat.com/browse/RHTAPBUGS-903). Sometimes Tekton CRDs need a few mins to be ready, this PR is to make sure all of Tekton CRDs to be ready before running tests.   