### PR TITLE
Fix staging get github token

### DIFF
--- a/.tekton/tasks/get-git-token.yaml
+++ b/.tekton/tasks/get-git-token.yaml
@@ -12,17 +12,17 @@ spec:
       description: secret in the namespace which contains private key for the GitHub App
     - name: GITHUB_APP_ID
       description: ID of Github app used for updating PR
-      default: "305606"
+      default: "172616"
     - name: GITHUB_APP_INSTALLATION_ID
       description: Installation ID of Github app in the organization
-      default: "35269675"
+      default: "23331085"
   workspaces:
    - name: shared-file-path
    - name: infra-deployment-git
   volumes:
     - name: infra-deployments-pr-creator
       secret:
-        # 'private-key' - private key for Github app
+        # 'appstudio-staging-ci' - private key for staging Github app
         secretName: $(params.shared-secret)
   steps:
     - name: get-token
@@ -33,7 +33,7 @@ spec:
           mountPath: /secrets/deploy-key
       env:
         - name: GITHUBAPP_KEY_PATH
-          value: /secrets/deploy-key/private-key
+          value: /secrets/deploy-key/appstudio-staging-ci
         - name: GITHUBAPP_APP_ID
           value: "$(params.GITHUB_APP_ID)"
         - name: GITHUBAPP_INSTALLATION_ID


### PR DESCRIPTION
Error:

```
RHTAP Staging / RHTAP Staging / rhtap-staging-e2e-
Failure snippet:
task check-merge-label has the status "Failed":
--git-owner GIT_OWNER --git-repo GIT_REPO --pr-number
                         PR_NUMBER
check-pr-label.py: error: argument --token/-t: expected one argument
```