### PR TITLE
fix: update release role

### DIFF
--- a/components/release/base/release-pipeline-resources-clusterrole.yaml
+++ b/components/release/base/release-pipeline-resources-clusterrole.yaml
@@ -10,7 +10,6 @@ rules:
   - releases
   - releaseplans
   - releaseplanadmissions
-  - releasestrategies
   - snapshots
   verbs:
   - get
@@ -22,6 +21,7 @@ rules:
   - internalrequests
   verbs:
   - create
+  - delete
   - get
   - list
   - watch


### PR DESCRIPTION
ReleaseStrategies are deprecated so it needs to be removed from the Role. In addition, we need to delete InternalRequests. The Role contains now that verb for this resource.