### PR TITLE
Update build-service dashboard owners

### DIFF
--- a/components/build-service/OWNERS
+++ b/components/build-service/OWNERS
@@ -1,13 +1,16 @@
 # See the OWNERS docs: https://go.k8s.io/owners
+# Should be kept in sync with components/monitoring/grafana/base/dashboards/build-service/OWNERS
 
 approvers:
 - mmorhun
 - tkdchen
 - rcerven
 - mkosiarc
+- stuartwdouglas
 
 reviewers:
 - mmorhun
 - tkdchen
 - rcerven
 - mkosiarc
+- stuartwdouglas

--- a/components/monitoring/grafana/base/dashboards/build-service/OWNERS
+++ b/components/monitoring/grafana/base/dashboards/build-service/OWNERS
@@ -1,7 +1,16 @@
 # See the OWNERS docs: https://go.k8s.io/owners
+# Should be kept in sync with components/monitoring/grafana/base/dashboards/build-service/OWNERS
 
 approvers:
 - mmorhun
+- tkdchen
+- rcerven
+- mkosiarc
+- stuartwdouglas
 
 reviewers:
 - mmorhun
+- tkdchen
+- rcerven
+- mkosiarc
+- stuartwdouglas


### PR DESCRIPTION
Update the build service dashboards to match the build-service owners. At the moment only mmorhun can merge build service update PRs because the dashboard is also updated.