### PR TITLE
RHTAPSRE-292: Add Github app for the internal cluster

### DIFF
--- a/argo-cd-apps/base/member/infra-deployments/build-service/build-service.yaml
+++ b/argo-cd-apps/base/member/infra-deployments/build-service/build-service.yaml
@@ -12,9 +12,11 @@ spec:
               values:
                 sourceRoot: components/build-service
                 environment: staging
-                clusterDir: ""
+                clusterDir: base
           - list:
-              elements: []
+              elements:
+                - nameNormalized: stone-stage-p01
+                  values.clusterDir: stone-stage-p01
   template:
     metadata:
       name: build-service-{{nameNormalized}}

--- a/components/build-service/staging/base/kustomization.yaml
+++ b/components/build-service/staging/base/kustomization.yaml
@@ -1,5 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- ../base
-- ../base/external-secrets
+- ../../base
+- ../../base/external-secrets

--- a/components/build-service/staging/stone-stage-p01/kustomization.yaml
+++ b/components/build-service/staging/stone-stage-p01/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../base
+patches:
+  - path: pipelines-as-code-secret-path.yaml
+    target:
+      name: pipelines-as-code-secret
+      group: external-secrets.io
+      version: v1beta1
+      kind: ExternalSecret

--- a/components/build-service/staging/stone-stage-p01/pipelines-as-code-secret-path.yaml
+++ b/components/build-service/staging/stone-stage-p01/pipelines-as-code-secret-path.yaml
@@ -1,0 +1,4 @@
+---
+- op: add
+  path: /spec/dataFrom/0/extract/key
+  value: staging/build/stone-stage-p01/github-app

--- a/components/pipeline-service/staging/stone-stage-p01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stage-p01/deploy.yaml
@@ -1689,7 +1689,7 @@ metadata:
 spec:
   dataFrom:
   - extract:
-      key: staging/pipeline-service/github-app
+      key: staging/pipeline-service/stone-stage-p01/github-app
   refreshInterval: 5m
   secretStoreRef:
     kind: ClusterSecretStore

--- a/components/pipeline-service/staging/stone-stage-p01/resources/kustomization.yaml
+++ b/components/pipeline-service/staging/stone-stage-p01/resources/kustomization.yaml
@@ -15,3 +15,9 @@ patches:
       group: external-secrets.io
       version: v1beta1
       kind: ExternalSecret
+  - path: pipelines-as-code-secret-path.yaml
+    target:
+      name: pipelines-as-code-secret
+      group: external-secrets.io
+      version: v1beta1
+      kind: ExternalSecret

--- a/components/pipeline-service/staging/stone-stage-p01/resources/pipelines-as-code-secret-path.yaml
+++ b/components/pipeline-service/staging/stone-stage-p01/resources/pipelines-as-code-secret-path.yaml
@@ -1,0 +1,4 @@
+---
+- op: add
+  path: /spec/dataFrom/0/extract/key
+  value: staging/pipeline-service/stone-stage-p01/github-app


### PR DESCRIPTION
The internal cluster uses a different webhook url, so it needs its own Github app.