### PR TITLE
RHTAPSRE-281: Mount empty dirs to the ui proxy

### DIFF
--- a/components/ui/base/proxy/proxy.yaml
+++ b/components/ui/base/proxy/proxy.yaml
@@ -84,6 +84,10 @@ spec:
             readOnly: true
           - name: chrome-static
             mountPath: /opt/app-root/src/chrome
+          - name: logs
+            mountPath: /var/log
+          - name: nginx-tmp
+            mountPath: /var/lib/nginx/tmp
         securityContext:
           readOnlyRootFilesystem: true
           runAsNonRoot: true
@@ -96,6 +100,10 @@ spec:
                 path: nginx.conf 
           name: proxy
         - name: chrome-static
+          emptyDir: {}
+        - name: logs
+          emptyDir: {}
+        - name: nginx-tmp
           emptyDir: {}
 ---
 apiVersion: v1


### PR DESCRIPTION
nginx requires some directories to be writeable, and because the container's file system is readonly, we need to mount a writeable volume.