### PR TITLE
RHTAPSRE-281: Mount nginx logs volume

### DIFF
--- a/components/ui/base/proxy/proxy.yaml
+++ b/components/ui/base/proxy/proxy.yaml
@@ -85,7 +85,7 @@ spec:
           - name: chrome-static
             mountPath: /opt/app-root/src/chrome
           - name: logs
-            mountPath: /var/log
+            mountPath: /var/log/nginx
           - name: nginx-tmp
             mountPath: /var/lib/nginx/tmp
         securityContext:


### PR DESCRIPTION
Apparently, the nginx process doesn't create the "nginx" directory under /var/log, so mount the volume to /var/log/nginx for solving it.