### PR TITLE
RHTAPSRE-281: nginx mount /run

### DIFF
--- a/components/ui/base/proxy/proxy.yaml
+++ b/components/ui/base/proxy/proxy.yaml
@@ -88,6 +88,8 @@ spec:
             mountPath: /var/log/nginx
           - name: nginx-tmp
             mountPath: /var/lib/nginx/tmp
+          - name: run
+            mountPath: /run
         securityContext:
           readOnlyRootFilesystem: true
           runAsNonRoot: true
@@ -104,6 +106,8 @@ spec:
         - name: logs
           emptyDir: {}
         - name: nginx-tmp
+          emptyDir: {}
+        - name: run
           emptyDir: {}
 ---
 apiVersion: v1


### PR DESCRIPTION
nginx tries to write its PID to /run so it needs to have a writeable volume.