### PR TITLE
Fail kube-linter check if issues are found

### DIFF
--- a/.github/workflows/kube-linter.yaml
+++ b/.github/workflows/kube-linter.yaml
@@ -48,5 +48,4 @@ jobs:
         shell: bash
         run: |
           echo "If this step fails, kube-linter found issues. Check the output of the scan step above."
-          echo "TODO: (RHTAPSRE-109) Failing the kube-linter is temporarily disabled. Uncomment the line below once all detected issues are resolved"
-          # [[ "${{ steps.kube-linter-action-scan.outcome }}" == "success" ]]
+          [[ "${{ steps.kube-linter-action-scan.outcome }}" == "success" ]]


### PR DESCRIPTION
Now that all issues have been fixed, fail the check if new kube-linter issues are found.

[RHTAPSRE-139](https://issues.redhat.com//browse/RHTAPSRE-139)