### PR TITLE
add update verb for rolebinding resources

### DIFF
--- a/components/authentication/base/rhtap-admins.yaml
+++ b/components/authentication/base/rhtap-admins.yaml
@@ -242,6 +242,7 @@ rules:
       - rolebindings
     verbs:
       - create
+      - update
       - delete
       - get
       - list


### PR DESCRIPTION
As RHTAP admin I'm trying to update the rolebindings in toolchain-host-operator, but getting a permissions error:

```
....
rolebindings.rbac.authorization.k8s.io "install-operator-sandbox-sre-cd-host" is forbidden: User "mfrancisc" cannot update resource "rolebindings" in API group "rbac.authorization.k8s.io" in the namespace "toolchain-host-operator"
```