### PR TITLE
Create logging namespace and operatorgroup on stone-stage-p01

### DIFF
--- a/argo-cd-apps/base/all-clusters/infra-deployments/monitoring-workload-logging/monitoring-workload-logging.yaml
+++ b/argo-cd-apps/base/all-clusters/infra-deployments/monitoring-workload-logging/monitoring-workload-logging.yaml
@@ -12,9 +12,11 @@ spec:
               values:
                 sourceRoot: components/monitoring/logging
                 environment: staging
-                clusterDir: ""
+                clusterDir: "base"
           - list:
-              elements: []
+              elements:
+                - nameNormalized: stone-stage-p01
+                  values.clusterDir: stone-stage-p01
   template:
     metadata:
       name: monitoring-workload-logging-{{nameNormalized}}

--- a/components/monitoring/logging/base/configure-logging/configure-log-collectors.yaml
+++ b/components/monitoring/logging/base/configure-logging/configure-log-collectors.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     logging.openshift.io/preview-vector-collector: enabled
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "2"
 spec:
   collection:
     logs:

--- a/components/monitoring/logging/base/configure-logging/configure-logforwarder.yaml
+++ b/components/monitoring/logging/base/configure-logging/configure-logforwarder.yaml
@@ -4,6 +4,7 @@ kind: ClusterLogForwarder
 metadata:
   annotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "1"
   name: instance
 spec:
   outputs:

--- a/components/monitoring/logging/base/install-logging-operator.yaml
+++ b/components/monitoring/logging/base/install-logging-operator.yaml
@@ -5,7 +5,9 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
   name: cluster-logging
-  namespace: openshift-logging 
+  namespace: openshift-logging
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
 spec:
   channel: "stable" 
   name: cluster-logging

--- a/components/monitoring/logging/base/logging-operator-prerequisite/kustomization.yaml
+++ b/components/monitoring/logging/base/logging-operator-prerequisite/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- namespace.yaml
+- operatorgroup.yaml

--- a/components/monitoring/logging/base/logging-operator-prerequisite/namespace.yaml
+++ b/components/monitoring/logging/base/logging-operator-prerequisite/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-logging
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"

--- a/components/monitoring/logging/base/logging-operator-prerequisite/operatorgroup.yaml
+++ b/components/monitoring/logging/base/logging-operator-prerequisite/operatorgroup.yaml
@@ -1,0 +1,10 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: cluster-logging
+  namespace: openshift-logging
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+spec:
+  targetNamespaces:
+  - openshift-logging

--- a/components/monitoring/logging/production/base/kustomization.yaml
+++ b/components/monitoring/logging/production/base/kustomization.yaml
@@ -1,8 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- ../base
-- ../base/external-secrets
+- ../../base
+- ../../base/external-secrets
 patches:
   - target:
       group: external-secrets.io

--- a/components/monitoring/logging/staging/base/kustomization.yaml
+++ b/components/monitoring/logging/staging/base/kustomization.yaml
@@ -1,8 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- ../base
-- ../base/external-secrets
+- ../../base
+- ../../base/external-secrets
 patches:
   - target:
       group: external-secrets.io

--- a/components/monitoring/logging/staging/stone-stage-p01/kustomization.yaml
+++ b/components/monitoring/logging/staging/stone-stage-p01/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../base
+- ../../base/logging-operator-prerequisite


### PR DESCRIPTION
All the clusters we had so far were ROSA classic, i.e. control plane nodes part of the cluster nodes. On those clusters, openshift-logging namespace and operatorgroup are already created and managed by hive.

The new stone-stage-p01 is a ROSA HCP(Hosted Control Plane) cluster and on those, the openshift-logging namespace and operatorgroup are not created/managed.

Move staging and production kustomize files into nested base folders and change logging argocd application to use base as default clusterDir. On stone-stage-p01, override the cluster dir to point to staging/stone-stage-p01 which include the base plus namespace and operatorgroup.

Also set argocd syn waves of a few resources to make sure the are created in the right order.

[RHTAPWATCH-695](https://issues.redhat.com//browse/RHTAPWATCH-695)