### PR TITLE
feat: Allow integration team to delete snapshots

### DIFF
--- a/components/integration/base/delete-snapshots.yaml
+++ b/components/integration/base/delete-snapshots.yaml
@@ -1,0 +1,25 @@
+kind: ClusterRole
+apiVersion: authorization.openshift.io/v1
+metadata:
+  name: delete-snapshots
+rules:
+  - apiGroups:
+    - "appstudio.redhat.com"
+    resources:
+      - "snapshots"
+    verbs:
+      - "delete"
+      - "deletecollection"
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: delete-snapshots
+subjects:
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: Integration Team
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: delete-snapshots

--- a/components/integration/base/kustomization.yaml
+++ b/components/integration/base/kustomization.yaml
@@ -1,6 +1,7 @@
 resources:
 - allow-argocd-to-manage.yaml
 - argocd-permissions.yaml
+- delete-snapshots.yaml
 - integration.yaml
 
 apiVersion: kustomize.config.k8s.io/v1beta1


### PR DESCRIPTION
Users are increasingly running into issues with their snapshot quota and the integration team is currently best suited too recognize these issues as they occur.  Giving the integration team permission to delete snapshots across all namespaces will decrease customer complaints and prevent them from having to recognize and resolve the issue themselves. Once Snapshot GC has been implemented this permmission can be revoked.