### PR TITLE
Remove EC components from tekton-ci

### DIFF
--- a/components/tekton-ci/base/repository.yaml
+++ b/components/tekton-ci/base/repository.yaml
@@ -16,13 +16,6 @@ spec:
 apiVersion: pipelinesascode.tekton.dev/v1alpha1
 kind: Repository
 metadata:
-  name: enterprise-contract
-spec:
-  url: "https://github.com/enterprise-contract/enterprise-contract-controller"
----
-apiVersion: pipelinesascode.tekton.dev/v1alpha1
-kind: Repository
-metadata:
   name: application-service
 spec:
   url: "https://github.com/redhat-appstudio/application-service"
@@ -82,13 +75,6 @@ metadata:
   name: tekton-results
 spec:
   url: "https://github.com/openshift-pipelines/tektoncd-results"
----
-apiVersion: pipelinesascode.tekton.dev/v1alpha1
-kind: Repository
-metadata:
-  name: ec-golden-image
-spec:
-  url: "https://github.com/enterprise-contract/golden-container"
 ---
 apiVersion: pipelinesascode.tekton.dev/v1alpha1
 kind: Repository


### PR DESCRIPTION
In EC-331, the EC team is moving all of the EC builds to their own tenant, rhtap-contract.