### PR TITLE
Remove unused controller image reference

### DIFF
--- a/components/enterprise-contract/kustomization.yaml
+++ b/components/enterprise-contract/kustomization.yaml
@@ -16,7 +16,3 @@ configMapGenerator:
       - verify_ec_task_git_url=https://github.com/enterprise-contract/ec-cli.git
       - verify_ec_task_git_revision=2f65d22d006597d65f16318c821ad7d9ad7f9d96
       - verify_ec_task_git_pathInRepo=tasks/verify-enterprise-contract/0.1/verify-enterprise-contract.yaml
-images:
-  - name: quay.io/redhat-appstudio/enterprise-contract-controller
-    newName: quay.io/redhat-appstudio/enterprise-contract-controller
-    newTag: 4ed0cb3ca999a444536d7fffd0825c9bb3eca993


### PR DESCRIPTION
The enterprise-contract-controller repository produces a container image. This is meant to run a Kubernetes controller. However, the controller is never deployed in konflux. (It is actually not deployed anywhere!). The repo is solely used to host the EC CRDs.

This commit removes references to the unused controller.