### PR TITLE
Fail kustomize build step on failure

### DIFF
--- a/.github/workflows/kube-linter.yaml
+++ b/.github/workflows/kube-linter.yaml
@@ -24,7 +24,8 @@ jobs:
 
       - name: Run kustomize build
         run: |
-          for p in $(find argo-cd-apps components -name "*kustomization.yaml*"); do kustomize build ${p%/*} -o kustomizedfiles/${p//\//-} || echo "^ ERROR when running kustomize build for ${p%/*} ^"; done
+          find argo-cd-apps components -name 'kustomization.yaml' ! -path '*/k-components/*' | \
+            xargs -I {} -n1 -P0  bash -c 'dir=$(dirname "{}"); output_file=$(echo $dir | tr / -)-kustomization.yaml; if ! log=$(kustomize build "$dir" -o "kustomizedfiles/$output_file" 2>&1); then echo "Error when running kustomize build for $dir: $log" && exit 1;fi'
 
       - name: Scan yaml files with kube-linter
         uses: stackrox/kube-linter-action@v1.0.4


### PR DESCRIPTION
The kustomize build step was considered a success even if kustomize build failed. Change implementation to fail the step if at least one of kustomize build commands fail.

Exclude the k-components from the search as some of them are used for sharing patches between overlays. Those components do not build on their own and they get built through the included overlays.

Instead of using a for loop as before, change implementation to use xargs so kustomize build command can run in parallel and print error message so we know which folder did not build. This brings down the execution time from 3 minutes to 1.

[RHTAPSRE-309](https://issues.redhat.com//browse/RHTAPSRE-309)