### PR TITLE
Fix kustomize build of logging development overlay

### DIFF
--- a/components/monitoring/logging/development/kustomization.yaml
+++ b/components/monitoring/logging/development/kustomization.yaml
@@ -1,2 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+
+resources: []


### PR DESCRIPTION
This overlay is empty for the moment so add empty resources otherwise kustomize build was failing and preventing us to setup a kustomize build as a pre-merge check.

[RHTAPSRE-309](https://issues.redhat.com//browse/RHTAPSRE-309)