### PR TITLE
Fix kustomize build of toolchain development overlay

### DIFF
--- a/components/sandbox/toolchain-host-operator/development/kustomization.yaml
+++ b/components/sandbox/toolchain-host-operator/development/kustomization.yaml
@@ -1,2 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+
+resources: []

--- a/components/sandbox/toolchain-member-operator/development/kustomization.yaml
+++ b/components/sandbox/toolchain-member-operator/development/kustomization.yaml
@@ -1,2 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+
+resources: []


### PR DESCRIPTION
This overlay is empty for the moment so add empty resources otherwise kustomize build was failing and preventing us to setup a kustomize build as a pre-merge check.

[RHTAPSRE-309](https://issues.redhat.com//browse/RHTAPSRE-309)