### PR TITLE
fix(test): add api.console scope to keycloak

### DIFF
--- a/components/dev-sso/keycloak-realm.yaml
+++ b/components/dev-sso/keycloak-realm.yaml
@@ -525,6 +525,7 @@ spec:
           - profile
           - roles
           - email
+          - api.console
         optionalClientScopes:
           - address
           - phone
@@ -992,6 +993,12 @@ spec:
         attributes:
           include.in.token.scope: "true"
           display.on.consent.screen: "true"
+      - id: 1d8a366c-3fae-4134-b58a-4ed5dc3b0022
+        name: api.console
+        protocol: openid-connect
+        attributes: 
+          include.in.token.scope: "true"
+          display.on.consent.screen: "true"
       - id: b4120472-4f73-4659-ae6b-d24bd45c4fa3
         name: address
         description: 'OpenID Connect built-in scope: address'
@@ -1023,6 +1030,7 @@ spec:
       - roles
       - web-origins
       - acr
+      - api.console
     smtpServer: {}
     loginTheme: rh-sso
     eventsEnabled: false


### PR DESCRIPTION
The user sign-up in HAC tests started to fail due to the new scope added [here](https://issues.redhat.com/browse/RHCLOUD-29135). Adding a new scope also to the keycloak.

https://issues.redhat.com/browse/HAC-5624