### PR TITLE
bump exporter mem limit in prod

### DIFF
--- a/components/pipeline-service/production/base/bump-exporter-mem.yaml
+++ b/components/pipeline-service/production/base/bump-exporter-mem.yaml
@@ -1,0 +1,4 @@
+---
+- op: replace
+  path: /spec/template/spec/containers/0/resources/limits/memory
+  value: "1Gi"

--- a/components/pipeline-service/production/base/kustomization.yaml
+++ b/components/pipeline-service/production/base/kustomization.yaml
@@ -20,6 +20,11 @@ patches:
   #     kind: Deployment
   #     name: pipeline-metrics-exporter
   #     namespace: openshift-pipelines
+  - path: bump-exporter-mem.yaml
+    target:
+      kind: Deployment
+      name: pipeline-metrics-exporter
+      namespace: openshift-pipelines
   - path: update-tekton-config-pac.yaml
     target:
       kind: TektonConfig

--- a/components/pipeline-service/production/stone-prd-m01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prd-m01/deploy.yaml
@@ -1207,7 +1207,7 @@ spec:
         resources:
           limits:
             cpu: 500m
-            memory: 512Mi
+            memory: 1Gi
           requests:
             cpu: 250m
             memory: 128Mi

--- a/components/pipeline-service/production/stone-prd-rh01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prd-rh01/deploy.yaml
@@ -1207,7 +1207,7 @@ spec:
         resources:
           limits:
             cpu: 500m
-            memory: 512Mi
+            memory: 1Gi
           requests:
             cpu: 250m
             memory: 128Mi


### PR DESCRIPTION
With the increase of activity in rhtap prod and where the controller-runtime based metrics exporter starts at with its need to watch all pipelineruns and taskruns, 512Mi is no longer sufficient.  I do see regularly GC occurring, but sufficient spikes lead to OOM restarts of some frequency.  This is also in line with other controllers which have to listen for all pipelinerun/taskruns in every namespace.