### PR TITLE
Remove OSP pruner configuration

### DIFF
--- a/components/pipeline-service/staging/base/greedy-pruner.yaml
+++ b/components/pipeline-service/staging/base/greedy-pruner.yaml
@@ -1,4 +1,0 @@
----
-- op: replace
-  path: /spec/pruner/keep
-  value: 2

--- a/components/pipeline-service/staging/base/kustomization.yaml
+++ b/components/pipeline-service/staging/base/kustomization.yaml
@@ -15,10 +15,6 @@ resources:
   - ../../base/rbac
 
 patches:
-  - path: greedy-pruner.yaml
-    target:
-      kind: TektonConfig
-      name: config
   - path: metrics-exporter-trace.yaml
     target:
       kind: Deployment

--- a/components/pipeline-service/staging/stone-stage-p01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stage-p01/deploy.yaml
@@ -1892,7 +1892,6 @@ spec:
   profile: all
   pruner:
     disabled: true
-    keep: 2
   targetNamespace: openshift-pipelines
 ---
 apiVersion: operators.coreos.com/v1alpha1

--- a/components/pipeline-service/staging/stone-stg-m01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stg-m01/deploy.yaml
@@ -1892,7 +1892,6 @@ spec:
   profile: all
   pruner:
     disabled: true
-    keep: 2
   targetNamespace: openshift-pipelines
 ---
 apiVersion: operators.coreos.com/v1alpha1

--- a/components/pipeline-service/staging/stone-stg-rh01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stg-rh01/deploy.yaml
@@ -1892,7 +1892,6 @@ spec:
   profile: all
   pruner:
     disabled: true
-    keep: 2
   targetNamespace: openshift-pipelines
 ---
 apiVersion: operators.coreos.com/v1alpha1


### PR DESCRIPTION
OSP pruner has been disabled

rh-pre-commit.version: 2.0.3
rh-pre-commit.check-secrets: ENABLED