### PR TITLE
Remove application-service from tekton-ci

### DIFF
--- a/components/tekton-ci/base/repository.yaml
+++ b/components/tekton-ci/base/repository.yaml
@@ -16,13 +16,6 @@ spec:
 apiVersion: pipelinesascode.tekton.dev/v1alpha1
 kind: Repository
 metadata:
-  name: application-service
-spec:
-  url: "https://github.com/redhat-appstudio/application-service"
----
-apiVersion: pipelinesascode.tekton.dev/v1alpha1
-kind: Repository
-metadata:
   name: application-api
 spec:
   url: "https://github.com/redhat-appstudio/application-api"


### PR DESCRIPTION
As part of https://issues.redhat.com/browse/DEVHAS-588, the HAS team is migrating its builds to the rhtap-has tenant