### PR TITLE
fix: replace authorization.openshift.io in integration base

### DIFF
--- a/components/integration/base/delete-snapshots.yaml
+++ b/components/integration/base/delete-snapshots.yaml
@@ -1,0 +1,25 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: delete-snapshots
+rules:
+  - apiGroups:
+    - "appstudio.redhat.com"
+    resources:
+      - "snapshots"
+    verbs:
+      - "delete"
+      - "deletecollection"
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: delete-snapshots
+subjects:
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: Integration Team
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: delete-snapshots

--- a/components/integration/base/kustomization.yaml
+++ b/components/integration/base/kustomization.yaml
@@ -1,6 +1,7 @@
 resources:
 - allow-argocd-to-manage.yaml
 - argocd-permissions.yaml
+- delete-snapshots.yaml
 - integration.yaml
 
 apiVersion: kustomize.config.k8s.io/v1beta1


### PR DESCRIPTION
Kustomization YAML file that allows the integration team to delete snapshots is not working because the `authorization.openshift.io` labe needs to be replaced with `rbac.authorization.k8s.io`.