### PR TITLE
PLNSRVCE-1525:  bump prod tekton pipeline controller to 2 replicas and 4 buckets

### DIFF
--- a/components/pipeline-service/production/base/update-tekton-config-performance.yaml
+++ b/components/pipeline-service/production/base/update-tekton-config-performance.yaml
@@ -17,3 +17,13 @@
   # value: 10
   # upstream large scale env recommendation
   value: 50
+- op: replace
+  path: /spec/pipeline/performance/buckets
+  # default pipeline-service setting is 1
+  # we make buckets twice the replica number per the
+  # convention adopted in https://github.com/openshift-pipelines/performance/blob/main/ci-scripts/setup-cluster.sh
+  value: 4
+- op: replace
+  path: /spec/pipeline/performance/replicas
+  # default pipeline-service setting is 1
+  value: 2

--- a/components/pipeline-service/production/stone-prd-m01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prd-m01/deploy.yaml
@@ -1872,11 +1872,11 @@ spec:
     enable-hub-resolver: true
     enable-tekton-oci-bundles: true
     performance:
-      buckets: 1
+      buckets: 4
       disable-ha: false
       kube-api-burst: 50
       kube-api-qps: 50
-      replicas: 1
+      replicas: 2
       threads-per-controller: 32
   platforms:
     openshift:

--- a/components/pipeline-service/production/stone-prd-rh01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prd-rh01/deploy.yaml
@@ -1872,11 +1872,11 @@ spec:
     enable-hub-resolver: true
     enable-tekton-oci-bundles: true
     performance:
-      buckets: 1
+      buckets: 4
       disable-ha: false
       kube-api-burst: 50
       kube-api-qps: 50
-      replicas: 1
+      replicas: 2
       threads-per-controller: 32
   platforms:
     openshift:


### PR DESCRIPTION
This copies the updates that have been running in staging since https://github.com/redhat-appstudio/infra-deployments/pull/3051 merged. The ratio between replicas and buckets is based on the findings from the joint openshift-pipelines and RHTAP performance team endeavor around HA and continual openshift-pipelines performance analysis.  This also involves running 'for dir in stone-*; do cd $dir/resources && kustomize build . > ../deploy.yaml; cd -; done' from the 'components/pipeline-service/production' subdirectory

@redhat-appstudio/pipeline-service FYI