### PR TITLE
enable UWM to scrape toolchain-host-operator namespace

### DIFF
--- a/components/sandbox/toolchain-host-operator/base/monitoring/kustomization.yaml
+++ b/components/sandbox/toolchain-host-operator/base/monitoring/kustomization.yaml
@@ -3,3 +3,4 @@ kind: Kustomization
 namespace: toolchain-host-operator
 resources:
 - sandbox-registration-service-proxy.yaml
+- prometheus-network-policy.yaml

--- a/components/sandbox/toolchain-host-operator/base/monitoring/prometheus-network-policy.yaml
+++ b/components/sandbox/toolchain-host-operator/base/monitoring/prometheus-network-policy.yaml
@@ -1,0 +1,14 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-from-openshift-user-workload-monitoring
+  namespace: toolchain-host-operator
+spec:
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-user-workload-monitoring
+  podSelector: {}
+  policyTypes:
+    - Ingress


### PR DESCRIPTION
Try to fix issue with ServiceMonitor not being available
