### PR TITLE
Fix delete-snapshots ClusterRole

### DIFF
--- a/components/integration/base/delete-snapshots.yaml
+++ b/components/integration/base/delete-snapshots.yaml
@@ -1,5 +1,5 @@
 kind: ClusterRole
-apiVersion: authorization.openshift.io/v1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: delete-snapshots
 rules:


### PR DESCRIPTION
In 07dfa001f6f573ab9025496e0fa9bd83c1bb499b, this ClusterRole was added but the apiVersion should have been `rbac.authorization.k8s.io/v1`, not `authorization.openshift.io/v1`.

This is causing issues as ArcoCD cannot create the resource and status is forever stuck as syncing.