### PR TITLE
Replace `RHTAP Admins` group by `konflux-admins`

### DIFF
--- a/components/authentication/base/konflux-admins.yaml
+++ b/components/authentication/base/konflux-admins.yaml
@@ -1,7 +1,7 @@
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: rhtap-admins
+  name: konflux-admins
 rules:
   - apiGroups:
       - appstudio.redhat.com
@@ -13,7 +13,7 @@ rules:
       - enterprisecontractpolicies
       - environments
       - integrationtestscenarios
-      # RHTAP Admins should not be permitted to create or edit InternalRequest resources.
+      # konflux-admins should not be permitted to create or edit InternalRequest resources.
       # - internalrequests
       - promotionruns
       - releaseplanadmissions
@@ -314,20 +314,20 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: rhtap-admins
+  name: konflux-admins
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: rhtap-admins
+  name: konflux-admins
 subjects:
   - apiGroup: rbac.authorization.k8s.io
     kind: Group
-    name: RHTAP Admins
+    name: konflux-admins
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: rhtap-admins-view
+  name: konflux-admins-view
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -335,4 +335,4 @@ roleRef:
 subjects:
   - apiGroup: rbac.authorization.k8s.io
     kind: Group
-    name: RHTAP Admins
+    name: konflux-admins

--- a/components/authentication/base/kustomization.yaml
+++ b/components/authentication/base/kustomization.yaml
@@ -2,7 +2,7 @@ resources:
 - everyone-can-view.yaml
 - component-maintainer.yaml
 - group-sync/
-- rhtap-admins.yaml
+- konflux-admins.yaml
 - admin-checker/
 
 apiVersion: kustomize.config.k8s.io/v1beta1


### PR DESCRIPTION
Use new group name which is aligned with new service name but also with the name of a new Rover group. Having both GitHub and Rover group names aligned will allow to have clusters auth with either GitHub or Red Hat SSO without having any difference in the RBACs.

[RHTAPSRE-287](https://issues.redhat.com//browse/RHTAPSRE-287)