### PR TITLE
Replace `Infra Team` group by `konflux-infra`

### DIFF
--- a/components/authentication/base/group-sync/group-sync.yaml
+++ b/components/authentication/base/group-sync/group-sync.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: group-sync-operator
 subjects:
   - kind: Group
-    name: Infra Team
+    name: konflux-infra
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole


### PR DESCRIPTION
Use new group name which is aligned with new service name but also with the name of a new Rover group. Having both GitHub and Rover group names aligned will allow to have clusters auth with either GitHub or Red Hat SSO without having any difference in the RBACs.

[RHTAPSRE-287](https://issues.redhat.com//browse/RHTAPSRE-287)