### PR TITLE
Replace `Build [Admins] team` groups by `konflux-build[-admins]`

### DIFF
--- a/components/build-service/base/rbac/build-admin.yaml
+++ b/components/build-service/base/rbac/build-admin.yaml
@@ -35,7 +35,7 @@ metadata:
 subjects:
   - apiGroup: rbac.authorization.k8s.io
     kind: Group
-    name: Build Admins team
+    name: konflux-build-admins
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/components/build-service/base/rbac/build-maintainer.yaml
+++ b/components/build-service/base/rbac/build-maintainer.yaml
@@ -28,7 +28,7 @@ metadata:
 subjects:
   - apiGroup: rbac.authorization.k8s.io
     kind: Group
-    name: Build team
+    name: konflux-build
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/components/build-templates/base/e2e/rolebinding.yaml
+++ b/components/build-templates/base/e2e/rolebinding.yaml
@@ -59,7 +59,7 @@ metadata:
 subjects:
   - apiGroup: rbac.authorization.k8s.io
     kind: Group
-    name: Build Admins team
+    name: konflux-build-admins
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/components/image-controller/base/rbac/image-controller-admin.yaml
+++ b/components/image-controller/base/rbac/image-controller-admin.yaml
@@ -35,7 +35,7 @@ metadata:
 subjects:
   - apiGroup: rbac.authorization.k8s.io
     kind: Group
-    name: Build Admins team
+    name: konflux-build-admins
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/components/image-controller/base/rbac/image-controller-maintainer.yaml
+++ b/components/image-controller/base/rbac/image-controller-maintainer.yaml
@@ -43,7 +43,7 @@ metadata:
 subjects:
   - apiGroup: rbac.authorization.k8s.io
     kind: Group
-    name: Build team
+    name: konflux-build
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/components/tekton-ci/base/tekton-ci-maintainers-rb.yaml
+++ b/components/tekton-ci/base/tekton-ci-maintainers-rb.yaml
@@ -6,7 +6,7 @@ metadata:
 subjects:
   - kind: Group
     apiGroup: rbac.authorization.k8s.io
-    name: Build team
+    name: konflux-build
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole


### PR DESCRIPTION
Use new group names which are aligned with new service name but also with the names of new Rover groups. Having both GitHub and Rover group names aligned will allow to have clusters auth with either GitHub or Red Hat SSO without having any difference in the RBACs.

[RHTAPSRE-287](https://issues.redhat.com//browse/RHTAPSRE-287)