### PR TITLE
Replace dora-metrics RBAC users by `konflux-qe-admins` group

### DIFF
--- a/components/dora-metrics/base/rbac/dora-metrics.yaml
+++ b/components/dora-metrics/base/rbac/dora-metrics.yaml
@@ -20,21 +20,9 @@ metadata:
   name: dora-metrics-maintainers
   namespace: dora-metrics
 subjects:
-  - kind: User
+  - kind: Group
     apiGroup: rbac.authorization.k8s.io
-    name: rhopp
-  - kind: User
-    apiGroup: rbac.authorization.k8s.io
-    name: flacatus
-  - kind: User
-    apiGroup: rbac.authorization.k8s.io
-    name: jkopriva
-  - kind: User
-    apiGroup: rbac.authorization.k8s.io
-    name: sawood14012
-  - kind: User
-    apiGroup: rbac.authorization.k8s.io
-    name: albarbaro
+    name: konflux-qe-admins
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole


### PR DESCRIPTION
Use new group name which is aligned with new service name but also with the name of a new Rover group. Having both GitHub and Rover group names aligned will allow to have clusters auth with either GitHub or Red Hat SSO without having any difference in the RBACs.

[RHTAPSRE-287](https://issues.redhat.com//browse/RHTAPSRE-287)