### PR TITLE
Extract Gitops and plnsvc app-sre secrets from new cluster

### DIFF
--- a/components/gitops/production/stone-prd-m01/gitops-service-postgres-rds-config-path.yaml
+++ b/components/gitops/production/stone-prd-m01/gitops-service-postgres-rds-config-path.yaml
@@ -1,4 +1,4 @@
 ---
 - op: add
   path: /spec/dataFrom/0/extract/key
-  value: integrations-output/terraform-resources/app-sre-prod-01/stonesoup-infra-production/multi-tenant-prod-gitopsvc-rds
+  value: integrations-output/terraform-resources/appsrep07ue1/stonesoup-infra-production/multi-tenant-prod-gitopsvc-rds

--- a/components/gitops/production/stone-prd-rh01/gitops-service-postgres-rds-config-path.yaml
+++ b/components/gitops/production/stone-prd-rh01/gitops-service-postgres-rds-config-path.yaml
@@ -1,4 +1,4 @@
 ---
 - op: add
   path: /spec/dataFrom/0/extract/key
-  value: integrations-output/terraform-resources/app-sre-prod-01/stonesoup-infra-production/redhat-prod-gitopsvc-rds
+  value: integrations-output/terraform-resources/appsrep07ue1/stonesoup-infra-production/redhat-prod-gitopsvc-rds

--- a/components/pipeline-service/production/stone-prd-m01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prd-m01/deploy.yaml
@@ -1710,7 +1710,7 @@ metadata:
 spec:
   dataFrom:
   - extract:
-      key: integrations-output/terraform-resources/app-sre-prod-01/stonesoup-infra-production/multi-tenant-prod-plnsvc-rds
+      key: integrations-output/terraform-resources/appsrep07ue1/stonesoup-infra-production/multi-tenant-prod-plnsvc-rds
   refreshInterval: 1h
   secretStoreRef:
     kind: ClusterSecretStore
@@ -1731,7 +1731,7 @@ metadata:
 spec:
   dataFrom:
   - extract:
-      key: integrations-output/terraform-resources/app-sre-prod-01/stonesoup-infra-production/multi-tenant-prod-plnsvc-s3
+      key: integrations-output/terraform-resources/appsrep07ue1/stonesoup-infra-production/multi-tenant-prod-plnsvc-s3
   refreshInterval: 1h
   secretStoreRef:
     kind: ClusterSecretStore

--- a/components/pipeline-service/production/stone-prd-m01/resources/tekton-results-database-secret-path.yaml
+++ b/components/pipeline-service/production/stone-prd-m01/resources/tekton-results-database-secret-path.yaml
@@ -1,4 +1,4 @@
 ---
 - op: add
   path: /spec/dataFrom/0/extract/key
-  value: integrations-output/terraform-resources/app-sre-prod-01/stonesoup-infra-production/multi-tenant-prod-plnsvc-rds
+  value: integrations-output/terraform-resources/appsrep07ue1/stonesoup-infra-production/multi-tenant-prod-plnsvc-rds

--- a/components/pipeline-service/production/stone-prd-m01/resources/tekton-results-s3-secret-path.yaml
+++ b/components/pipeline-service/production/stone-prd-m01/resources/tekton-results-s3-secret-path.yaml
@@ -1,4 +1,4 @@
 ---
 - op: add
   path: /spec/dataFrom/0/extract/key
-  value: integrations-output/terraform-resources/app-sre-prod-01/stonesoup-infra-production/multi-tenant-prod-plnsvc-s3
+  value: integrations-output/terraform-resources/appsrep07ue1/stonesoup-infra-production/multi-tenant-prod-plnsvc-s3

--- a/components/pipeline-service/production/stone-prd-rh01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prd-rh01/deploy.yaml
@@ -1710,7 +1710,7 @@ metadata:
 spec:
   dataFrom:
   - extract:
-      key: integrations-output/terraform-resources/app-sre-prod-01/stonesoup-infra-production/redhat-prod-plnsvc-rds
+      key: integrations-output/terraform-resources/appsrep07ue1/stonesoup-infra-production/redhat-prod-plnsvc-rds
   refreshInterval: 1h
   secretStoreRef:
     kind: ClusterSecretStore
@@ -1731,7 +1731,7 @@ metadata:
 spec:
   dataFrom:
   - extract:
-      key: integrations-output/terraform-resources/app-sre-prod-01/stonesoup-infra-production/redhat-prod-plnsvc-s3
+      key: integrations-output/terraform-resources/appsrep07ue1/stonesoup-infra-production/redhat-prod-plnsvc-s3
   refreshInterval: 1h
   secretStoreRef:
     kind: ClusterSecretStore

--- a/components/pipeline-service/production/stone-prd-rh01/resources/tekton-results-database-secret-path.yaml
+++ b/components/pipeline-service/production/stone-prd-rh01/resources/tekton-results-database-secret-path.yaml
@@ -1,4 +1,4 @@
 ---
 - op: add
   path: /spec/dataFrom/0/extract/key
-  value: integrations-output/terraform-resources/app-sre-prod-01/stonesoup-infra-production/redhat-prod-plnsvc-rds
+  value: integrations-output/terraform-resources/appsrep07ue1/stonesoup-infra-production/redhat-prod-plnsvc-rds

--- a/components/pipeline-service/production/stone-prd-rh01/resources/tekton-results-s3-secret-path.yaml
+++ b/components/pipeline-service/production/stone-prd-rh01/resources/tekton-results-s3-secret-path.yaml
@@ -1,4 +1,4 @@
 ---
 - op: add
   path: /spec/dataFrom/0/extract/key
-  value: integrations-output/terraform-resources/app-sre-prod-01/stonesoup-infra-production/redhat-prod-plnsvc-s3
+  value: integrations-output/terraform-resources/appsrep07ue1/stonesoup-infra-production/redhat-prod-plnsvc-s3


### PR DESCRIPTION
The RDS and S3 resources moved from cluster app-sre-prod-01 to appsrep07ue1. The databases and bucket were not re-created, they are the same on AWS side. The only thing that change is the location of the secrets we extract as the secrets names include the name of the cluster it is created on.

RHTAPSRE-310