### PR TITLE
Do not swallow errors on ec downloads

### DIFF
--- a/components/enterprise-contract/download-service.yaml
+++ b/components/enterprise-contract/download-service.yaml
@@ -114,7 +114,8 @@ spec:
               set -o pipefail
 
               function handle_error {
-                sleep infinity
+                printf 'Error on line #%s\nCommand: %s\n' "$(caller)" "${BASH_COMMAND}"
+                exit 1
               }
               trap handle_error ERR
 


### PR DESCRIPTION
There's a script which is responsible for setting up the download service for Enterprise Contract. This script runs as part of the initContainer for the Deployment.

Prior to this commit, if there were any errors while executing the script, the script would wait forever.

This commit changes the behavior to allow the script to exit on errors and report some information about the failure. The idea is that if there is some sort of timing issue, OpenShift will retry executing the container again. This leverages that instead of entering a pseudo-deadlock state.

This is an attempt to fix RHTAPBUGS-1106, or to at least provide more information if the error does happen again.