### PR TITLE
chore(integration-service): update controller resources

### DIFF
--- a/components/integration/production/manager_resources_patch.yaml
+++ b/components/integration/production/manager_resources_patch.yaml
@@ -10,8 +10,8 @@ spec:
       - name: manager
         resources:
           limits:
-            cpu: 500m
-            memory: 1Gi
+            cpu: 600m
+            memory: 1200Mi
           requests:
-            cpu: 100m
-            memory: 20Mi
+            cpu: 200m
+            memory: 600Mi


### PR DESCRIPTION
Currently in production integration-service is using ~600Mi of memory and ~200mi of CPU.

Updating requests accordingly.