### PR TITLE
Replace `Release Team` group by `konflux-release-team`

### DIFF
--- a/components/internal-services/internal-services.yaml
+++ b/components/internal-services/internal-services.yaml
@@ -6,7 +6,7 @@ metadata:
 subjects:
   - kind: Group
     apiGroup: rbac.authorization.k8s.io
-    name: Release team
+    name: konflux-release-team
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -19,7 +19,7 @@ metadata:
 subjects:
   - kind: Group
     apiGroup: rbac.authorization.k8s.io
-    name: Release team
+    name: konflux-release-team
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/components/release/base/release-team.yaml
+++ b/components/release/base/release-team.yaml
@@ -6,7 +6,7 @@ metadata:
 subjects:
   - kind: Group
     apiGroup: rbac.authorization.k8s.io
-    name: Release team
+    name: konflux-release-team
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -20,7 +20,7 @@ metadata:
 subjects:
   - kind: Group
     apiGroup: rbac.authorization.k8s.io
-    name: Release team
+    name: konflux-release-team
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role


### PR DESCRIPTION
Use new group name which is aligned with new service name but also with the name of the Rover group. Having both GitHub and Rover group names aligned will allow to have clusters auth with either GitHub or Red Hat SSO without having any difference in the RBACs.

[RHTAPSRE-287](https://issues.redhat.com//browse/RHTAPSRE-287)