### PR TITLE
Use GH group for RBACs in SPI and remote-secrets components

### DIFF
--- a/components/remote-secret-controller/base/rbac/remote-secret.yaml
+++ b/components/remote-secret-controller/base/rbac/remote-secret.yaml
@@ -4,8 +4,8 @@ metadata:
   name: remotesecret-service-maintainers
   namespace: remotesecret
 subjects:
-  - kind: User
-    name: skabashnyuk
+  - kind: Group
+    name: konflux-spi-admins
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/components/spi/base/rbac/spi.yaml
+++ b/components/spi/base/rbac/spi.yaml
@@ -4,8 +4,8 @@ metadata:
   name: spi-service-maintainers
   namespace: spi-system
 subjects:
-  - kind: User
-    name: skabashnyuk
+  - kind: Group
+    name: konflux-spi-admins
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole


### PR DESCRIPTION
In order to support both GH and RH SSO authentication, we cannot use usernames as they wont be the same on both sides.

Having both a GitHub and Rover group will allow to have the RBACs the same on both type of clusters and group sync will take care of populating the group with right users.

For SPI, I created 2 GH groups, konflux-spi with all SPI team members and konflux-spi-admins with subset of SPI team members, i.e. only Sergii Kabashniuk. The same 2 groups were also create on Rover side for clusters using RH SSO.

RHTAPSRE-287