### PR TITLE
Use new konflux-o11y[-admins] groups

### DIFF
--- a/components/monitoring/logging/base/rbac/logging-admin.yaml
+++ b/components/monitoring/logging/base/rbac/logging-admin.yaml
@@ -17,7 +17,7 @@ metadata:
 subjects:
 - apiGroup: rbac.authorization.k8s.io
   kind: Group
-  name: Logging Admins
+  name: konflux-o11y-admins
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/components/segment-bridge/rbac/segment-bridge.yaml
+++ b/components/segment-bridge/rbac/segment-bridge.yaml
@@ -54,10 +54,9 @@ metadata:
   name: segment-bridge-read-host-sa-secret-binding
   namespace: toolchain-host-operator
 subjects:
-  - kind: User
-    name: Omeramsc
-  - kind: User
-    name: ifireball
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: konflux-o11y
 roleRef:
   kind: Role
   name: segment-bridge-read-host-sa-secret


### PR DESCRIPTION
In order to support both GH and RH SSO authentication, we cannot use usernames as they wont be the same on both sides.

Having both a GitHub and Rover group will allow to have the RBACs the same on both type of clusters and group sync will take care of populating the group with right users.

Use new groups which are aligned with new service name but also with the name of new Rover groups.

Once this change is done, the former groups `o11y` and `Logging Admins` will be deleted.

[RHTAPSRE-287](https://issues.redhat.com//browse/RHTAPSRE-287)