### PR TITLE
Use GH group for RBACs in integration component

### DIFF
--- a/components/integration/base/integration.yaml
+++ b/components/integration/base/integration.yaml
@@ -4,9 +4,9 @@ metadata:
   name: integration-service-maintainers
   namespace: integration-service
 subjects:
-  - kind: User
+  - kind: Group
     apiGroup: rbac.authorization.k8s.io
-    name: dirgim
+    name: konflux-integration
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole


### PR DESCRIPTION
In order to support both GH and RH SSO authentication, we cannot use usernames as they wont be the same on both sides.

Having both a GitHub and Rover group will allow to have the RBACs the same on both type of clusters and group sync will take care of populating the group with right users.

RHTAPSRE-287