### PR TITLE
Add a ServiceMonitor to collect OADP/velero metrics

### DIFF
--- a/components/backup/base/all-clusters/kustomization.yaml
+++ b/components/backup/base/all-clusters/kustomization.yaml
@@ -4,4 +4,5 @@ namespace: openshift-adp
 resources:
   - external-secret.yaml
   - namespace.yaml
+  - servicemonitor.yaml
   - oadp

--- a/components/backup/base/all-clusters/servicemonitor.yaml
+++ b/components/backup/base/all-clusters/servicemonitor.yaml
@@ -1,0 +1,18 @@
+---
+# Taken from https://github.com/openshift/oadp-operator/blob/498109cc0f4162b3ecab5b7329e0dec4556ffc21/docs/oadp_monitoring.md
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    app: oadp-service-monitor
+  name: oadp-service-monitor
+  namespace: openshift-adp
+spec:
+  endpoints:
+  - interval: 30s
+    path: /metrics
+    targetPort: 8085
+    scheme: http
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: "velero"


### PR DESCRIPTION
I tested this by applying the ServiceMonitor to a dev cluster with the OADP operator manually installed and configured to backup to a local minio instance.