### PR TITLE
Add `ec-automation[bot]` as approver

### DIFF
--- a/components/enterprise-contract/OWNERS
+++ b/components/enterprise-contract/OWNERS
@@ -4,6 +4,7 @@ approvers:
 - simonbaird
 - zregvart
 - lcarva
+- ec-automation[bot]
 
 
 reviewers:


### PR DESCRIPTION
We can't seem to get pass the `Konflux Staging / Konflux Staging` check for the EC automatic updates for PRs like #3176. The issue seems to be related to this message found in the check status and the Pipelines as code controller logs:

```
User ec-automation[bot] is not allowed to run CI on this repo.
```

The `/ok-to-test` doesn't seem to make much difference and `Konflux Staging / Konflux Staging` check is a required check for whatever reason.

This severely blocks our ability to deliver changes, and the only alternative to get passed this check seems to be to add the `ec-automation[bot]` as an owner, in this case as an approver.