### PR TITLE
RHTAPSRE-376: Deploy operator group for the openshift-logging operator

### DIFF
--- a/argo-cd-apps/base/all-clusters/infra-deployments/monitoring-workload-logging/monitoring-workload-logging.yaml
+++ b/argo-cd-apps/base/all-clusters/infra-deployments/monitoring-workload-logging/monitoring-workload-logging.yaml
@@ -17,6 +17,8 @@ spec:
               elements:
                 - nameNormalized: stone-stage-p01
                   values.clusterDir: stone-stage-p01
+                - nameNormalized: stone-prod-p01
+                  values.clusterDir: stone-prod-p01
   template:
     metadata:
       name: monitoring-workload-logging-{{nameNormalized}}

--- a/components/monitoring/logging/production/stone-prod-p01/kustomization.yaml
+++ b/components/monitoring/logging/production/stone-prod-p01/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../base
+- ../../base/logging-operator-prerequisite


### PR DESCRIPTION
It seems that stone-prod-p01 (even though it's a classic ROSA) doesn't have the operator group pre installed.