### PR TITLE
Prune the deleted Rover groups

### DIFF
--- a/components/authentication/base/rh-idp/group-sync/konflux-rover-groups.yaml
+++ b/components/authentication/base/rh-idp/group-sync/konflux-rover-groups.yaml
@@ -13,6 +13,7 @@ spec:
           name: mtls-ca-validators
           namespace: group-sync-operator
         insecure: false
+        prune: true
         rfc2307:
           usersQuery:
             baseDN: 'dc=redhat,dc=com'


### PR DESCRIPTION
Change configuration of Rover groups sync to prune the ones deleted from Rover.

[RHTAPSRE-287](https://issues.redhat.com//browse/RHTAPSRE-287)