### PR TITLE
chore(RHTAPWATCH-765): pipeline-service can manage SpaceRequests

### DIFF
--- a/components/build-templates/base/e2e/rolebinding.yaml
+++ b/components/build-templates/base/e2e/rolebinding.yaml
@@ -54,6 +54,19 @@ roleRef:
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
+  name: appstudio-pipelines-namespace-creator-rolebinding
+subjects:
+  - kind: ServiceAccount
+    name: appstudio-pipeline
+    namespace: build-templates-e2e
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: appstudio-pipelines-namespace-creator
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
   name: build-admins
   namespace: build-templates-e2e
 subjects:

--- a/components/promotion/base/appstudio-pipelines-runner-rolebinding.yaml
+++ b/components/promotion/base/appstudio-pipelines-runner-rolebinding.yaml
@@ -10,3 +10,16 @@ subjects:
 - kind: ServiceAccount
   name: appstudio-pipeline
   namespace: rhtap-promotion-staging
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: appstudio-pipelines-namespace-creator-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: appstudio-pipeline-namespace-creator
+subjects:
+- kind: ServiceAccount
+  name: appstudio-pipeline
+  namespace: rhtap-promotion-staging

--- a/components/tekton-ci/base/appstudio-pipelines-runner-rolebinding.yaml
+++ b/components/tekton-ci/base/appstudio-pipelines-runner-rolebinding.yaml
@@ -10,3 +10,16 @@ subjects:
 - kind: ServiceAccount
   name: appstudio-pipeline
   namespace: tekton-ci
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: appstudio-pipelines-namespace-creator-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: appstudio-pipelines-namespace-creator
+subjects:
+- kind: ServiceAccount
+  name: appstudio-pipeline
+  namespace: tekton-ci

--- a/hack/build/appstudio_pipelines_namespace_request_role.yaml
+++ b/hack/build/appstudio_pipelines_namespace_request_role.yaml
@@ -1,0 +1,15 @@
+# permissions to be able to create a SpaceRequest
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: appstudio-pipelines-namespace-creator
+rules:
+- apiGroups:
+  - toolchain.dev.openshift.com
+  resources:
+  - spacerequests
+  verbs:
+  - get
+  - create
+  - delete
+

--- a/hack/build/setup-namespace.sh
+++ b/hack/build/setup-namespace.sh
@@ -1,9 +1,11 @@
 #!/bin/bash
 
 # Script for setting namespace which is not managed by toolchain host operator
-
+SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 CURRENT_NAMESPACE=$(oc config view --minify -o 'jsonpath={..namespace}')
 oc label namespace $CURRENT_NAMESPACE --overwrite argocd.argoproj.io/managed-by=gitops-service-argocd
 oc apply -f https://raw.githubusercontent.com/codeready-toolchain/member-operator/master/config/appstudio-pipelines-runner/base/appstudio_pipelines_runner_role.yaml
+oc apply -f $SCRIPTDIR/appstudio-namespace-creator_role.yaml
 oc create --dry-run=client -o yaml serviceaccount appstudio-pipeline | oc apply -f-
 oc create --dry-run=client -o yaml rolebinding appstudio-pipelines-runner-rolebinding --clusterrole=appstudio-pipelines-runner --serviceaccount=$CURRENT_NAMESPACE:appstudio-pipeline | oc apply -f-
+oc create --dry-run=client -o yaml rolebinding appstudio-pipelines-namespace-creator-rolebinding --clusterrole=appstudio-pipelines-namespace-creator --serviceaccount=$CURRENT_NAMESPACE:appstudio-pipeline | oc apply -f-


### PR DESCRIPTION
In order to create ephemeral namespaces for
testing konflux components, the pipeline-service
service account needs to be able to manage (create, delete, get) the SpaceRequest custom resource.

~Related PR:  https://github.com/codeready-toolchain/member-operator/pull/529~
Blocking: https://issues.redhat.com/browse/RHTAPWATCH-764