### PR TITLE
Use GH group for RBACs in segment-bridge component

### DIFF
--- a/components/segment-bridge/base/serviceaccount.yaml
+++ b/components/segment-bridge/base/serviceaccount.yaml
@@ -52,10 +52,9 @@ metadata:
   name: segment-bridge-read-member-sa-secret-binding
   namespace: segment-bridge
 subjects:
-  - kind: User
-    name: Omeramsc
-  - kind: User
-    name: ifireball
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: konflux-o11y
 roleRef:
   kind: Role
   name: segment-bridge-read-member-sa-secret


### PR DESCRIPTION
In order to support both GH and RH SSO authentication, we cannot use usernames as they wont be the same on both sides.

Having both a GitHub and Rover group will allow to have the RBACs the same on both type of clusters and group sync will take care of populating the group with right users.

[RHTAPSRE-287](https://issues.redhat.com//browse/RHTAPSRE-287)