### PR TITLE
Replace `Performance` group by `konflux-performance`

### DIFF
--- a/components/authentication/base/rh-idp/everyone-can-view-patch.yaml
+++ b/components/authentication/base/rh-idp/everyone-can-view-patch.yaml
@@ -34,6 +34,9 @@
       name: 'konflux-o11y'
     - kind: Group
       apiGroup: rbac.authorization.k8s.io
+      name: 'konflux-performance'
+    - kind: Group
+      apiGroup: rbac.authorization.k8s.io
       name: 'konflux-pipeline-service'
     - kind: Group
       apiGroup: rbac.authorization.k8s.io

--- a/components/perf-team-prometheus-reader/base/perf-team.yaml
+++ b/components/perf-team-prometheus-reader/base/perf-team.yaml
@@ -6,7 +6,7 @@ metadata:
 subjects:
   - kind: Group
     apiGroup: rbac.authorization.k8s.io
-    name: Performance
+    name: konflux-performance
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole


### PR DESCRIPTION
Use new group name which is aligned with new service name but also with the name of a new Rover group. Having both GitHub and Rover group names aligned will allow to have clusters auth with either GitHub or Red Hat SSO without having any difference in the RBACs.

Also add the new group to the everyone can view role for RH IdP.

[RHTAPSRE-287](https://issues.redhat.com//browse/RHTAPSRE-287)