### PR TITLE
Use new konflux-gitops[-admins] groups

### DIFF
--- a/components/gitops/base/authentication/gitops-clusterrolebindings.yaml
+++ b/components/gitops/base/authentication/gitops-clusterrolebindings.yaml
@@ -7,7 +7,7 @@ metadata:
 subjects:
   - kind: Group
     apiGroup: rbac.authorization.k8s.io
-    name: GitOps Service Team Admins
+    name: konflux-gitops-admins
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/components/gitops/production/base/authentication/gitops-rolebindings.yaml
+++ b/components/gitops/production/base/authentication/gitops-rolebindings.yaml
@@ -7,7 +7,7 @@ metadata:
 subjects:
   - kind: Group
     apiGroup: rbac.authorization.k8s.io
-    name: GitOps Service Team
+    name: konflux-gitops
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -21,7 +21,7 @@ metadata:
 subjects:
   - kind: Group
     apiGroup: rbac.authorization.k8s.io
-    name: GitOps Service Team
+    name: konflux-gitops
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -35,7 +35,7 @@ metadata:
 subjects:
   - kind: Group
     apiGroup: rbac.authorization.k8s.io
-    name: GitOps Service Team Admins
+    name: konflux-gitops-admins
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -49,7 +49,7 @@ metadata:
 subjects:
   - kind: Group
     apiGroup: rbac.authorization.k8s.io
-    name: GitOps Service Team Admins
+    name: konflux-gitops-admins
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/components/gitops/production/stone-prd-m01/gitops-team-member-namespaces.yaml
+++ b/components/gitops/production/stone-prd-m01/gitops-team-member-namespaces.yaml
@@ -7,7 +7,7 @@ metadata:
 subjects:
   - kind: Group
     apiGroup: rbac.authorization.k8s.io
-    name: GitOps Service Team Admins
+    name: konflux-gitops-admins
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/components/gitops/staging/base/authentication/gitops-rolebindings.yaml
+++ b/components/gitops/staging/base/authentication/gitops-rolebindings.yaml
@@ -7,7 +7,7 @@ metadata:
 subjects:
   - kind: Group
     apiGroup: rbac.authorization.k8s.io
-    name: GitOps Service Team
+    name: konflux-gitops
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -21,7 +21,7 @@ metadata:
 subjects:
   - kind: Group
     apiGroup: rbac.authorization.k8s.io
-    name: GitOps Service Team
+    name: konflux-gitops
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -35,7 +35,7 @@ metadata:
 subjects:
   - kind: Group
     apiGroup: rbac.authorization.k8s.io
-    name: GitOps Service Team
+    name: konflux-gitops
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -49,7 +49,7 @@ metadata:
 subjects:
   - kind: Group
     apiGroup: rbac.authorization.k8s.io
-    name: GitOps Service Team
+    name: konflux-gitops
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/components/gitops/staging/stone-stg-m01/gitops-team-member-namespaces.yaml
+++ b/components/gitops/staging/stone-stg-m01/gitops-team-member-namespaces.yaml
@@ -11,7 +11,7 @@ metadata:
 subjects:
   - kind: Group
     apiGroup: rbac.authorization.k8s.io
-    name: GitOps Service Team
+    name: konflux-gitops
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role


### PR DESCRIPTION
In order to support both GH and RH SSO authentication, having both a GitHub and Rover group will allow to have the RBACs the same on both type of clusters and group sync will take care of populating the group with right users.

Use new groups which are aligned with new service name but also with the name of new Rover groups.

The members of the 2 new konflux groups are the same as old ones. Create the groups even though gitops service is deprecated as we need to support internal cluster using RH SSO before gitops is removed.

[RHTAPSRE-287](https://issues.redhat.com//browse/RHTAPSRE-287)