### PR TITLE
Use GH group for RBACs in has component

### DIFF
--- a/components/has/base/rbac/has-admin.yaml
+++ b/components/has/base/rbac/has-admin.yaml
@@ -24,18 +24,9 @@ metadata:
   name: has-admin
   namespace: application-service
 subjects:
-  - kind: User
-    name: johnmcollier
-  - kind: User
-    name: kim-tsao
-  - kind: User
-    name: maysunfaisal
-  - kind: User
-    name: yangcao77
-  - kind: User
-    name: thepetk
-  - kind: User
-    name: michael-valdron
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: konflux-has
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/components/has/base/rbac/has.yaml
+++ b/components/has/base/rbac/has.yaml
@@ -4,27 +4,9 @@ metadata:
   name: application-service-maintainers
   namespace: application-service
 subjects:
-  - kind: User
-    apiGroup: rbac.authorization.k8s.io
-    name: johnmcollier
-  - kind: User
-    apiGroup: rbac.authorization.k8s.io
-    name: jduimovich
-  - kind: User
-    apiGroup: rbac.authorization.k8s.io
-    name: kim-tsao
-  - kind: User
-    apiGroup: rbac.authorization.k8s.io
-    name: yangcao77
-  - kind: User
-    apiGroup: rbac.authorization.k8s.io
-    name: maysunfaisal
-  - kind: User
-    apiGroup: rbac.authorization.k8s.io
-    name: thepetk
-  - kind: User
-    apiGroup: rbac.authorization.k8s.io
-    name: michael-valdron
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: konflux-has
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/components/has/staging/rbac/has-exec.yaml
+++ b/components/has/staging/rbac/has-exec.yaml
@@ -17,8 +17,9 @@ metadata:
   name: has-exec
   namespace: application-service
 subjects:
-  - kind: User
-    name: johnmcollier
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: konflux-has
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role


### PR DESCRIPTION
In order to support both GH and RH SSO authentication, we cannot use usernames as they wont be the same on both sides.

Having both a GitHub and Rover group will allow to have the RBACs the same on both type of clusters and group sync will take care of populating the group with right users.

[RHTAPSRE-287](https://issues.redhat.com//browse/RHTAPSRE-287)