### PR TITLE
Use GH group for RBACs in sandbox component

### DIFF
--- a/components/sandbox/base/rbac/sandbox-sre-admins.yaml
+++ b/components/sandbox/base/rbac/sandbox-sre-admins.yaml
@@ -80,18 +80,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: sandbox-sre-admins-can-register-clusters
 subjects:
-  - kind: User
+  - kind: Group
     apiGroup: rbac.authorization.k8s.io
-    name: MatousJobanek
-  - kind: User
-    apiGroup: rbac.authorization.k8s.io
-    name: alexeykazakov
-  - kind: User
-    apiGroup: rbac.authorization.k8s.io
-    name: xcoulon
-  - kind: User
-    apiGroup: rbac.authorization.k8s.io
-    name: mfrancisc
+    name: konflux-core
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/components/sandbox/toolchain-host-operator/base/rbac/sandbox-sre-admins.yaml
+++ b/components/sandbox/toolchain-host-operator/base/rbac/sandbox-sre-admins.yaml
@@ -5,18 +5,9 @@ metadata:
   name: sandbox-sre-host-admins
   namespace: sandbox-sre-host
 subjects:
-  - kind: User
+  - kind: Group
     apiGroup: rbac.authorization.k8s.io
-    name: MatousJobanek
-  - kind: User
-    apiGroup: rbac.authorization.k8s.io
-    name: alexeykazakov
-  - kind: User
-    apiGroup: rbac.authorization.k8s.io
-    name: xcoulon
-  - kind: User
-    apiGroup: rbac.authorization.k8s.io
-    name: mfrancisc
+    name: konflux-core
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -28,18 +19,9 @@ roleRef:
    name: sandbox-sre-host-operator-admins
    namespace: toolchain-host-operator
  subjects:
-   - kind: User
+   - kind: Group
      apiGroup: rbac.authorization.k8s.io
-     name: MatousJobanek
-   - kind: User
-     apiGroup: rbac.authorization.k8s.io
-     name: alexeykazakov
-   - kind: User
-     apiGroup: rbac.authorization.k8s.io
-     name: xcoulon
-   - kind: User
-     apiGroup: rbac.authorization.k8s.io
-     name: mfrancisc
+     name: konflux-core
  roleRef:
    apiGroup: rbac.authorization.k8s.io
    kind: ClusterRole

--- a/components/sandbox/toolchain-member-operator/base/rbac/register-cluster-extra-member-permissions.yaml
+++ b/components/sandbox/toolchain-member-operator/base/rbac/register-cluster-extra-member-permissions.yaml
@@ -86,15 +86,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: sandbox-sre-admins-can-register-member-clusters
 subjects:
-- kind: User
+- kind: Group
   apiGroup: rbac.authorization.k8s.io
-  name: MatousJobanek
-- kind: User
-  apiGroup: rbac.authorization.k8s.io
-  name: alexeykazakov
-- kind: User
-  apiGroup: rbac.authorization.k8s.io
-  name: xcoulon
+  name: konflux-core
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/components/sandbox/toolchain-member-operator/base/rbac/sandbox-sre-admins.yaml
+++ b/components/sandbox/toolchain-member-operator/base/rbac/sandbox-sre-admins.yaml
@@ -5,18 +5,9 @@ metadata:
   name: sandbox-sre-member-admins
   namespace: sandbox-sre-member
 subjects:
-  - kind: User
+  - kind: Group
     apiGroup: rbac.authorization.k8s.io
-    name: MatousJobanek
-  - kind: User
-    apiGroup: rbac.authorization.k8s.io
-    name: alexeykazakov
-  - kind: User
-    apiGroup: rbac.authorization.k8s.io
-    name: xcoulon
-  - kind: User
-    apiGroup: rbac.authorization.k8s.io
-    name: mfrancisc
+    name: konflux-core
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -28,18 +19,9 @@ roleRef:
    name: sandbox-sre-member-operator-admins
    namespace: toolchain-member-operator
  subjects:
-   - kind: User
+   - kind: Group
      apiGroup: rbac.authorization.k8s.io
-     name: MatousJobanek
-   - kind: User
-     apiGroup: rbac.authorization.k8s.io
-     name: alexeykazakov
-   - kind: User
-     apiGroup: rbac.authorization.k8s.io
-     name: xcoulon
-   - kind: User
-     apiGroup: rbac.authorization.k8s.io
-     name: mfrancisc
+     name: konflux-core
  roleRef:
    apiGroup: rbac.authorization.k8s.io
    kind: ClusterRole


### PR DESCRIPTION
In order to support both GH and RH SSO authentication, we cannot use usernames as they wont be the same on both sides.

Having both a GitHub and Rover group will allow to have the RBACs the same on both type of clusters and group sync will take care of populating the group with right users.

Replace users by new group named konflux-core, defined here[1] for GH and there[2] for Rover.

[1]https://github.com/orgs/redhat-appstudio/teams/konflux-core
[2]https://rover.redhat.com/groups/group/konflux-core

[RHTAPSRE-287](https://issues.redhat.com//browse/RHTAPSRE-287)