### PR TITLE
Bump UI in the internal cluster

### DIFF
--- a/components/ui/staging/kustomization.yaml
+++ b/components/ui/staging/kustomization.yaml
@@ -19,7 +19,7 @@ images:
   # hac-dev
   - name: quay.io/cloudservices/hac-dev-frontend
     newName: quay.io/cloudservices/hac-dev-frontend
-    newTag: 7932b2a   
+    newTag: 55f5671   
 
 configMapGenerator:
   - name: fed-modules


### PR DESCRIPTION
Internal cluster needs https://github.com/openshift/hac-dev/pull/902 commit or later for the GH app flow to work correctly, which includes fix for https://issues.redhat.com/browse/RHTAPBUGS-1128