### PR TITLE
fix: move the production update pipelines to run under tekton-ci ns in prod

### DIFF
--- a/.tekton/build-service-prod-overlay-update.yaml
+++ b/.tekton/build-service-prod-overlay-update.yaml
@@ -2,7 +2,7 @@ apiVersion: tekton.dev/v1beta1
 kind: PipelineRun
 metadata:
   name: build-service-prod-overlay-update
-  namespace: rhtap-promotion-staging
+  namespace: tekton-ci
   annotations:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push" && target_branch == "main" && "components/build-service/staging/base/kustomization.yaml".pathChanged()

--- a/.tekton/image-controller-prod-overlay-update.yaml
+++ b/.tekton/image-controller-prod-overlay-update.yaml
@@ -2,7 +2,7 @@ apiVersion: tekton.dev/v1beta1
 kind: PipelineRun
 metadata:
   name: image-controller-prod-overlay-update
-  namespace: rhtap-promotion-staging
+  namespace: tekton-ci
   annotations:
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push" && target_branch == "main" && "components/image-controller/staging/kustomization.yaml".pathChanged()

--- a/components/tekton-ci/base/repository.yaml
+++ b/components/tekton-ci/base/repository.yaml
@@ -103,3 +103,10 @@ metadata:
   name: pipeline-service
 spec:
   url: "https://github.com/openshift-pipelines/pipeline-service"
+---
+apiVersion: pipelinesascode.tekton.dev/v1alpha1
+kind: Repository
+metadata:
+  name: infra-deployments
+spec:
+  url: "https://github.com/redhat-appstudio/infra-deployments"


### PR DESCRIPTION
We are observing below error in PaC logs when it tried to run the pipeline for this [commit](https://github.com/redhat-appstudio/infra-deployments/commit/70a19c3acc36b7d305dd290bc74a46658370b5f9)

```
{"level":"error","ts":"2024-02-06T14:35:45.424Z","logger":"pipelinesascode","caller":"events/emit.go:46","msg":"failed to match pipelineRuns: cannot find referenced task git-clone. if it's a remote task make sure to add it in the annotations","provider":"github","event-id":"014832e0-c4fd-11ee-99ea-355f6aba0e9b","event-sha":"70a19c3acc36b7d305dd290bc74a46658370b5f9","event-type":"push","namespace":"rhtap-promotion-staging","stacktrace":"github.com/openshift-pipelines/pipelines-as-code/pkg/events.(*EventEmitter).EmitMessage\n\t/go/src/github.com/openshift-pipelines/pipelines-as-code/pkg/events/emit.go:46\ngithub.com/openshift-pipelines/pipelines-as-code/pkg/pipelineascode.(*PacRun).getPipelineRunsFromRepo\n\t/go/src/github.com/openshift-pipelines/pipelines-as-code/pkg/pipelineascode/match.go:235\ngithub.com/openshift-pipelines/pipelines-as-code/pkg/pipelineascode.(*PacRun).matchRepoPR\n\t/go/src/github.com/openshift-pipelines/pipelines-as-code/pkg/pipelineascode/match.go:35\ngithub.com/openshift-pipelines/pipelines-as-code/pkg/pipelineascode.(*PacRun).Run\n\t/go/src/github.com/openshift-pipelines/pipelines-as-code/pkg/pipelineascode/pipelineascode.go:50\ngithub.com/openshift-pipelines/pipelines-as-code/pkg/adapter.(*sinker).processEvent\n\t/go/src/github.com/openshift-pipelines/pipelines-as-code/pkg/adapter/sinker.go:52\ngithub.com/openshift-pipelines/pipelines-as-code/pkg/adapter.listener.handleEvent.func1.2\n\t/go/src/github.com/openshift-pipelines/pipelines-as-code/pkg/adapter/adapter.go:190"}
```
