### PR TITLE
pipeline-service update (manual)

### DIFF
--- a/components/monitoring/grafana/base/dashboards/pipeline-service/kustomization.yaml
+++ b/components/monitoring/grafana/base/dashboards/pipeline-service/kustomization.yaml
@@ -2,4 +2,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - https://github.com/openshift-pipelines/pipeline-service/operator/gitops/argocd/grafana/?ref=3b297d99c01d1beeb9eda2b93dd69e34ab3b0933
+  - https://github.com/openshift-pipelines/pipeline-service/operator/gitops/argocd/grafana/?ref=05217bcc5f07f0a99c400f18010d98684196519d

--- a/components/pipeline-service/development/kustomization.yaml
+++ b/components/pipeline-service/development/kustomization.yaml
@@ -8,8 +8,8 @@ commonAnnotations:
   argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 
 resources:
-  - https://github.com/openshift-pipelines/pipeline-service.git/developer/openshift/gitops/argocd/pipeline-service?ref=3b297d99c01d1beeb9eda2b93dd69e34ab3b0933
-  - https://github.com/openshift-pipelines/pipeline-service.git/developer/openshift/gitops/argocd/pipeline-service-storage?ref=3b297d99c01d1beeb9eda2b93dd69e34ab3b0933
+  - https://github.com/openshift-pipelines/pipeline-service.git/developer/openshift/gitops/argocd/pipeline-service?ref=05217bcc5f07f0a99c400f18010d98684196519d
+  - https://github.com/openshift-pipelines/pipeline-service.git/developer/openshift/gitops/argocd/pipeline-service-storage?ref=05217bcc5f07f0a99c400f18010d98684196519d
   - ../base/rbac
 
 patches:

--- a/components/pipeline-service/staging/base/kustomization.yaml
+++ b/components/pipeline-service/staging/base/kustomization.yaml
@@ -8,7 +8,7 @@ commonAnnotations:
   argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 
 resources:
-  - https://github.com/openshift-pipelines/pipeline-service.git/operator/gitops/argocd/pipeline-service?ref=3b297d99c01d1beeb9eda2b93dd69e34ab3b0933
+  - https://github.com/openshift-pipelines/pipeline-service.git/operator/gitops/argocd/pipeline-service?ref=05217bcc5f07f0a99c400f18010d98684196519d
   - pipelines-as-code-secret.yaml
   - ../../base/external-secrets
   - ../../base/testing

--- a/components/pipeline-service/staging/stone-stage-p01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stage-p01/deploy.yaml
@@ -1883,6 +1883,15 @@ spec:
     enable-git-resolver: true
     enable-hub-resolver: true
     enable-tekton-oci-bundles: true
+    options:
+      deployments:
+        tekton-operator-proxy-webhook:
+          spec:
+            replicas: 1
+        tekton-pipelines-webhook:
+          spec:
+            replicas: 1
+      disabled: false
     performance:
       buckets: 4
       disable-ha: false

--- a/components/pipeline-service/staging/stone-stg-m01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stg-m01/deploy.yaml
@@ -1883,6 +1883,15 @@ spec:
     enable-git-resolver: true
     enable-hub-resolver: true
     enable-tekton-oci-bundles: true
+    options:
+      deployments:
+        tekton-operator-proxy-webhook:
+          spec:
+            replicas: 1
+        tekton-pipelines-webhook:
+          spec:
+            replicas: 1
+      disabled: false
     performance:
       buckets: 4
       disable-ha: false

--- a/components/pipeline-service/staging/stone-stg-rh01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stg-rh01/deploy.yaml
@@ -1883,6 +1883,15 @@ spec:
     enable-git-resolver: true
     enable-hub-resolver: true
     enable-tekton-oci-bundles: true
+    options:
+      deployments:
+        tekton-operator-proxy-webhook:
+          spec:
+            replicas: 1
+        tekton-pipelines-webhook:
+          spec:
+            replicas: 1
+      disabled: false
     performance:
       buckets: 4
       disable-ha: false


### PR DESCRIPTION
this pulls in the updates from https://github.com/redhat-appstudio/infra-deployments/pull/3213

And then pull the 2 updates since then:
https://github.com/openshift-pipelines/pipeline-service/pull/916
https://github.com/openshift-pipelines/pipeline-service/pull/931

Something has happened to our update infra deployments PAC job.  We have some clues, but want to get this bump going first.

@enarha @Roming22 FYI


rh-pre-commit.version: 2.1.0
rh-pre-commit.check-secrets: ENABLED