### PR TITLE
PLNSRVCE-1526: bump prod to staging level, including the operator proxy webhook replica bump

### DIFF
--- a/components/pipeline-service/production/base/kustomization.yaml
+++ b/components/pipeline-service/production/base/kustomization.yaml
@@ -8,7 +8,7 @@ commonAnnotations:
   argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 
 resources:
-  - https://github.com/openshift-pipelines/pipeline-service.git/operator/gitops/argocd/pipeline-service?ref=3b297d99c01d1beeb9eda2b93dd69e34ab3b0933
+  - https://github.com/openshift-pipelines/pipeline-service.git/operator/gitops/argocd/pipeline-service?ref=37dd9bab130381ec03995c34f76514b86c810315
   - pipelines-as-code-secret.yaml # create external secret in openshift-pipelines namespace
   - ../../base/external-secrets
   - ../../base/testing

--- a/components/pipeline-service/production/base/update-tekton-config-performance.yaml
+++ b/components/pipeline-service/production/base/update-tekton-config-performance.yaml
@@ -27,3 +27,7 @@
   path: /spec/pipeline/performance/replicas
   # default pipeline-service setting is 1
   value: 2
+- op: replace
+  path: /spec/pipeline/options/deployments/tekton-operator-proxy-webhook/spec/replicas
+  # default pipeline-service setting is 1
+  value: 2

--- a/components/pipeline-service/production/stone-prd-m01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prd-m01/deploy.yaml
@@ -1882,6 +1882,15 @@ spec:
     enable-git-resolver: true
     enable-hub-resolver: true
     enable-tekton-oci-bundles: true
+    options:
+      deployments:
+        tekton-operator-proxy-webhook:
+          spec:
+            replicas: 2
+        tekton-pipelines-webhook:
+          spec:
+            replicas: 1
+      disabled: false
     performance:
       buckets: 4
       disable-ha: false

--- a/components/pipeline-service/production/stone-prd-rh01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prd-rh01/deploy.yaml
@@ -1882,6 +1882,15 @@ spec:
     enable-git-resolver: true
     enable-hub-resolver: true
     enable-tekton-oci-bundles: true
+    options:
+      deployments:
+        tekton-operator-proxy-webhook:
+          spec:
+            replicas: 2
+        tekton-pipelines-webhook:
+          spec:
+            replicas: 1
+      disabled: false
     performance:
       buckets: 4
       disable-ha: false

--- a/components/pipeline-service/production/stone-prod-p01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prod-p01/deploy.yaml
@@ -1882,6 +1882,15 @@ spec:
     enable-git-resolver: true
     enable-hub-resolver: true
     enable-tekton-oci-bundles: true
+    options:
+      deployments:
+        tekton-operator-proxy-webhook:
+          spec:
+            replicas: 2
+        tekton-pipelines-webhook:
+          spec:
+            replicas: 1
+      disabled: false
     performance:
       buckets: 4
       disable-ha: false


### PR DESCRIPTION
https://github.com/redhat-appstudio/infra-deployments/pull/3244 checks out in staging

matches with https://github.com/redhat-appstudio/infra-deployments/blob/0792841eb605315900c3cef42028a5af0a26810b/components/pipeline-service/staging/base/kustomization.yaml#L11
which matches https://github.com/redhat-appstudio/infra-deployments/blob/main/components/pipeline-service/staging/base/kustomization.yaml#L11 as I type

@redhat-appstudio/konflux-pipeline-service FYI

rh-pre-commit.version: 2.1.0
rh-pre-commit.check-secrets: ENABLED