### PR TITLE
PLNSRVCE-1526: bump eligible tekton controllers and webhooks in openshift-pipelines to 2 replicas

### DIFF
--- a/components/pipeline-service/development/update-tekton-config-performance.yaml
+++ b/components/pipeline-service/development/update-tekton-config-performance.yaml
@@ -31,3 +31,19 @@
   path: /spec/pipeline/options/deployments/tekton-operator-proxy-webhook/spec/replicas
   # default pipeline-service setting is 1
   value: 2
+- op: replace
+  path: /spec/pipeline/options/deployments/tekton-pipelines-remote-resolvers/spec/replicas
+  # default pipeline-service setting is 1
+  value: 2
+- op: replace
+  path: /spec/platforms/openshift/pipelinesAsCode/options/deployments/pipelines-as-code-watcher/spec/replicas
+  # default pipeline-service setting is 1
+  value: 2
+- op: replace
+  path: /spec/platforms/openshift/pipelinesAsCode/options/deployments/pipelines-as-code-webhook/spec/replicas
+  # default pipeline-service setting is 1
+  value: 2
+- op: replace
+  path: /spec/chain/options/deployments/tekton-chains-controller/spec/replicas
+  # default pipeline-service setting is 1
+  value: 2

--- a/components/pipeline-service/staging/base/update-tekton-config-performance.yaml
+++ b/components/pipeline-service/staging/base/update-tekton-config-performance.yaml
@@ -31,3 +31,19 @@
   path: /spec/pipeline/options/deployments/tekton-operator-proxy-webhook/spec/replicas
   # default pipeline-service setting is 1
   value: 2
+- op: replace
+  path: /spec/pipeline/options/deployments/tekton-pipelines-remote-resolvers/spec/replicas
+  # default pipeline-service setting is 1
+  value: 2
+- op: replace
+  path: /spec/platforms/openshift/pipelinesAsCode/options/deployments/pipelines-as-code-watcher/spec/replicas
+  # default pipeline-service setting is 1
+  value: 2
+- op: replace
+  path: /spec/platforms/openshift/pipelinesAsCode/options/deployments/pipelines-as-code-webhook/spec/replicas
+  # default pipeline-service setting is 1
+  value: 2
+- op: replace
+  path: /spec/chain/options/deployments/tekton-chains-controller/spec/replicas
+  # default pipeline-service setting is 1
+  value: 2

--- a/components/pipeline-service/staging/stone-stage-p01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stage-p01/deploy.yaml
@@ -1897,7 +1897,7 @@ spec:
       deployments:
         tekton-chains-controller:
           spec:
-            replicas: 1
+            replicas: 2
     transparency.enabled: "false"
   params:
   - name: createRbacResource
@@ -1917,7 +1917,7 @@ spec:
             replicas: 2
         tekton-pipelines-remote-resolvers:
           spec:
-            replicas: 1
+            replicas: 2
       disabled: false
     performance:
       buckets: 4
@@ -1934,10 +1934,10 @@ spec:
           deployments:
             pipelines-as-code-watcher:
               spec:
-                replicas: 1
+                replicas: 2
             pipelines-as-code-webhook:
               spec:
-                replicas: 1
+                replicas: 2
         settings:
           application-name: Konflux Staging Internal
           custom-console-name: Konflux Staging Internal

--- a/components/pipeline-service/staging/stone-stg-m01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stg-m01/deploy.yaml
@@ -1897,7 +1897,7 @@ spec:
       deployments:
         tekton-chains-controller:
           spec:
-            replicas: 1
+            replicas: 2
     transparency.enabled: "false"
   params:
   - name: createRbacResource
@@ -1917,7 +1917,7 @@ spec:
             replicas: 2
         tekton-pipelines-remote-resolvers:
           spec:
-            replicas: 1
+            replicas: 2
       disabled: false
     performance:
       buckets: 4
@@ -1934,10 +1934,10 @@ spec:
           deployments:
             pipelines-as-code-watcher:
               spec:
-                replicas: 1
+                replicas: 2
             pipelines-as-code-webhook:
               spec:
-                replicas: 1
+                replicas: 2
         settings:
           application-name: Konflux Staging
           custom-console-name: Konflux Staging

--- a/components/pipeline-service/staging/stone-stg-rh01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stg-rh01/deploy.yaml
@@ -1897,7 +1897,7 @@ spec:
       deployments:
         tekton-chains-controller:
           spec:
-            replicas: 1
+            replicas: 2
     transparency.enabled: "false"
   params:
   - name: createRbacResource
@@ -1917,7 +1917,7 @@ spec:
             replicas: 2
         tekton-pipelines-remote-resolvers:
           spec:
-            replicas: 1
+            replicas: 2
       disabled: false
     performance:
       buckets: 4
@@ -1934,10 +1934,10 @@ spec:
           deployments:
             pipelines-as-code-watcher:
               spec:
-                replicas: 1
+                replicas: 2
             pipelines-as-code-webhook:
               spec:
-                replicas: 1
+                replicas: 2
         settings:
           application-name: Konflux Staging
           custom-console-name: Konflux Staging


### PR DESCRIPTION
for dev / stage overlays

rh-pre-commit.version: 2.1.0
rh-pre-commit.check-secrets: ENABLED