### PR TITLE
PLNSRVCE-1526: bump prod to staging level, including the remote-resolver,pac replica bumps

### DIFF
--- a/components/pipeline-service/production/base/kustomization.yaml
+++ b/components/pipeline-service/production/base/kustomization.yaml
@@ -8,7 +8,7 @@ commonAnnotations:
   argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 
 resources:
-  - https://github.com/openshift-pipelines/pipeline-service.git/operator/gitops/argocd/pipeline-service?ref=37dd9bab130381ec03995c34f76514b86c810315
+  - https://github.com/openshift-pipelines/pipeline-service.git/operator/gitops/argocd/pipeline-service?ref=2be0e3a49809ba66bf64625d01833de90c457094
   - pipelines-as-code-secret.yaml # create external secret in openshift-pipelines namespace
   - ../../base/external-secrets
   - ../../base/testing

--- a/components/pipeline-service/production/base/update-tekton-config-performance.yaml
+++ b/components/pipeline-service/production/base/update-tekton-config-performance.yaml
@@ -31,3 +31,15 @@
   path: /spec/pipeline/options/deployments/tekton-operator-proxy-webhook/spec/replicas
   # default pipeline-service setting is 1
   value: 2
+- op: replace
+  path: /spec/pipeline/options/deployments/tekton-pipelines-remote-resolvers/spec/replicas
+  # default pipeline-service setting is 1
+  value: 2
+- op: replace
+  path: /spec/platforms/openshift/pipelinesAsCode/options/deployments/pipelines-as-code-watcher/spec/replicas
+  # default pipeline-service setting is 1
+  value: 2
+- op: replace
+  path: /spec/platforms/openshift/pipelinesAsCode/options/deployments/pipelines-as-code-webhook/spec/replicas
+  # default pipeline-service setting is 1
+  value: 2

--- a/components/pipeline-service/production/stone-prd-m01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prd-m01/deploy.yaml
@@ -1615,6 +1615,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   annotations:
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
     argocd.argoproj.io/sync-wave: "1"
   name: tekton-chains-signing-secret
@@ -1887,9 +1888,9 @@ spec:
         tekton-operator-proxy-webhook:
           spec:
             replicas: 2
-        tekton-pipelines-webhook:
+        tekton-pipelines-remote-resolvers:
           spec:
-            replicas: 1
+            replicas: 2
       disabled: false
     performance:
       buckets: 4
@@ -1902,6 +1903,14 @@ spec:
     openshift:
       pipelinesAsCode:
         enable: true
+        options:
+          deployments:
+            pipelines-as-code-watcher:
+              spec:
+                replicas: 2
+            pipelines-as-code-webhook:
+              spec:
+                replicas: 2
         settings:
           application-name: Red Hat Konflux
           custom-console-name: Red Hat Konflux

--- a/components/pipeline-service/production/stone-prd-rh01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prd-rh01/deploy.yaml
@@ -1615,6 +1615,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   annotations:
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
     argocd.argoproj.io/sync-wave: "1"
   name: tekton-chains-signing-secret
@@ -1887,9 +1888,9 @@ spec:
         tekton-operator-proxy-webhook:
           spec:
             replicas: 2
-        tekton-pipelines-webhook:
+        tekton-pipelines-remote-resolvers:
           spec:
-            replicas: 1
+            replicas: 2
       disabled: false
     performance:
       buckets: 4
@@ -1902,6 +1903,14 @@ spec:
     openshift:
       pipelinesAsCode:
         enable: true
+        options:
+          deployments:
+            pipelines-as-code-watcher:
+              spec:
+                replicas: 2
+            pipelines-as-code-webhook:
+              spec:
+                replicas: 2
         settings:
           application-name: Red Hat Konflux
           custom-console-name: Red Hat Konflux

--- a/components/pipeline-service/production/stone-prod-p01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prod-p01/deploy.yaml
@@ -1615,6 +1615,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   annotations:
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
     argocd.argoproj.io/sync-wave: "1"
   name: tekton-chains-signing-secret
@@ -1887,9 +1888,9 @@ spec:
         tekton-operator-proxy-webhook:
           spec:
             replicas: 2
-        tekton-pipelines-webhook:
+        tekton-pipelines-remote-resolvers:
           spec:
-            replicas: 1
+            replicas: 2
       disabled: false
     performance:
       buckets: 4
@@ -1902,6 +1903,14 @@ spec:
     openshift:
       pipelinesAsCode:
         enable: true
+        options:
+          deployments:
+            pipelines-as-code-watcher:
+              spec:
+                replicas: 2
+            pipelines-as-code-webhook:
+              spec:
+                replicas: 2
         settings:
           application-name: Konflux Production Internal
           custom-console-name: Konflux Production Internal


### PR DESCRIPTION
@redhat-appstudio/konflux-pipeline-service FYI

I'm curious if the same timing issue we saw in staging with gitops and tekton operator trying to update the tektonconfig concurrently takes hold now that the chains bump has been removed

it got resolved when the next, unrelated infra-deployments PR merged which sorted out the update ordering from those 2 items

rh-pre-commit.version: 2.1.0
rh-pre-commit.check-secrets: ENABLED