### PR TITLE
Rename plnscv ExternalSecret target

### DIFF
--- a/components/pipeline-service/staging/base/kustomization.yaml
+++ b/components/pipeline-service/staging/base/kustomization.yaml
@@ -15,6 +15,12 @@ resources:
   - ../../base/rbac
 
 patches:
+  - path: tekton-chains-signing-secret-name.yaml
+    target:
+      name: tekton-chains-signing-secret
+      group: external-secrets.io
+      version: v1beta1
+      kind: ExternalSecret
   - path: metrics-exporter-trace.yaml
     target:
       kind: Deployment

--- a/components/pipeline-service/staging/base/tekton-chains-signing-secret-name.yaml
+++ b/components/pipeline-service/staging/base/tekton-chains-signing-secret-name.yaml
@@ -1,0 +1,4 @@
+---
+- op: add
+  path: /spec/target/name
+  value: signing-secrets

--- a/components/pipeline-service/staging/stone-stage-p01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stage-p01/deploy.yaml
@@ -1731,7 +1731,7 @@ spec:
   target:
     creationPolicy: Owner
     deletionPolicy: Delete
-    name: signing-secrets-vault
+    name: signing-secrets
 ---
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret

--- a/components/pipeline-service/staging/stone-stg-m01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stg-m01/deploy.yaml
@@ -1731,7 +1731,7 @@ spec:
   target:
     creationPolicy: Owner
     deletionPolicy: Delete
-    name: signing-secrets-vault
+    name: signing-secrets
 ---
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret

--- a/components/pipeline-service/staging/stone-stg-rh01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stg-rh01/deploy.yaml
@@ -1731,7 +1731,7 @@ spec:
   target:
     creationPolicy: Owner
     deletionPolicy: Delete
-    name: signing-secrets-vault
+    name: signing-secrets
 ---
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret


### PR DESCRIPTION
This change completes the migration of the Chains signing secret to Vault in staging.
Once validated a similar change will be promoted to production.

rh-pre-commit.version: 2.1.0
rh-pre-commit.check-secrets: ENABLED