### PR TITLE
RHTAPSRE-351: Fix smee-client component path

### DIFF
--- a/argo-cd-apps/base/smee-client/smee-client.yaml
+++ b/argo-cd-apps/base/smee-client/smee-client.yaml
@@ -24,7 +24,7 @@ spec:
     spec:
       project: default
       source:
-        path: '{{values.sourceRoot}}'
+        path: '{{values.sourceRoot}}/{{values.environment}}/{{values.clusterDir}}'
         repoURL: https://github.com/redhat-appstudio/infra-deployments.git
         targetRevision: main
       destination:

--- a/argo-cd-apps/overlays/production-downstream/kustomization.yaml
+++ b/argo-cd-apps/overlays/production-downstream/kustomization.yaml
@@ -143,3 +143,8 @@ patches:
       kind: ApplicationSet
       version: v1alpha1
       name: ui
+  - path: production-overlay-patch.yaml
+    target:
+      kind: ApplicationSet
+      version: v1alpha1
+      name: smee-client


### PR DESCRIPTION
- There was a missing patch for production
- The path to the component in the ApplicationSet was wrong.