### PR TITLE
Grant grafana component maintainer to o11y team

### DIFF
--- a/components/authentication/base/all/component-maintainer.yaml
+++ b/components/authentication/base/all/component-maintainer.yaml
@@ -59,3 +59,4 @@ rules:
     verbs:
       - get
       - patch
+      - delete

--- a/components/monitoring/grafana/base/kustomization.yaml
+++ b/components/monitoring/grafana/base/kustomization.yaml
@@ -4,4 +4,5 @@ resources:
 - grafana-operator.yaml
 - grafana-app.yaml
 - dashboards
+- rbac
 - https://github.com/redhat-appstudio/o11y/config/probes/monitoring/grafana/base?ref=ff478366bb92b0a9d7e4eb1625194e0cce138185

--- a/components/monitoring/grafana/base/rbac/grafana-maintainers.yaml
+++ b/components/monitoring/grafana/base/rbac/grafana-maintainers.yaml
@@ -1,0 +1,12 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: appstudio-grafana-maintainers
+  namespace: appstudio-grafana
+subjects:
+  - kind: Group
+    name: konflux-o11y
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: component-maintainer

--- a/components/monitoring/grafana/base/rbac/kustomization.yaml
+++ b/components/monitoring/grafana/base/rbac/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - grafana-maintainers.yaml


### PR DESCRIPTION
Component maintainer is an existing ClusterRole giving permissions extra permissions on installplans, serviceaccounts, secrets, pods and deployments, see exact definition here[1].

Grant components-maintainer role to konflux-o11y for the grafana components, i.e. appstudio-grafana namespace.

Also add the delete deployments permission in component-maintainer as this is needed for grafana but it make sense to add for all components maintainers.

[1]https://github.com/redhat-appstudio/infra-deployments/blob/main/components/authentication/base/all/component-maintainer.yaml