### PR TITLE
PLNSRVCE-1526: back off all pipelines-as-code deployments to 1 replica

### DIFF
--- a/components/pipeline-service/development/update-tekton-config-performance.yaml
+++ b/components/pipeline-service/development/update-tekton-config-performance.yaml
@@ -35,11 +35,3 @@
   path: /spec/pipeline/options/deployments/tekton-pipelines-remote-resolvers/spec/replicas
   # default pipeline-service setting is 1
   value: 2
-- op: replace
-  path: /spec/platforms/openshift/pipelinesAsCode/options/deployments/pipelines-as-code-watcher/spec/replicas
-  # default pipeline-service setting is 1
-  value: 2
-- op: replace
-  path: /spec/platforms/openshift/pipelinesAsCode/options/deployments/pipelines-as-code-webhook/spec/replicas
-  # default pipeline-service setting is 1
-  value: 2

--- a/components/pipeline-service/production/base/update-tekton-config-performance.yaml
+++ b/components/pipeline-service/production/base/update-tekton-config-performance.yaml
@@ -35,11 +35,3 @@
   path: /spec/pipeline/options/deployments/tekton-pipelines-remote-resolvers/spec/replicas
   # default pipeline-service setting is 1
   value: 2
-- op: replace
-  path: /spec/platforms/openshift/pipelinesAsCode/options/deployments/pipelines-as-code-watcher/spec/replicas
-  # default pipeline-service setting is 1
-  value: 2
-- op: replace
-  path: /spec/platforms/openshift/pipelinesAsCode/options/deployments/pipelines-as-code-webhook/spec/replicas
-  # default pipeline-service setting is 1
-  value: 2

--- a/components/pipeline-service/production/stone-prd-m01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prd-m01/deploy.yaml
@@ -1928,10 +1928,10 @@ spec:
           deployments:
             pipelines-as-code-watcher:
               spec:
-                replicas: 2
+                replicas: 1
             pipelines-as-code-webhook:
               spec:
-                replicas: 2
+                replicas: 1
         settings:
           application-name: Red Hat Konflux
           custom-console-name: Red Hat Konflux

--- a/components/pipeline-service/production/stone-prd-rh01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prd-rh01/deploy.yaml
@@ -1928,10 +1928,10 @@ spec:
           deployments:
             pipelines-as-code-watcher:
               spec:
-                replicas: 2
+                replicas: 1
             pipelines-as-code-webhook:
               spec:
-                replicas: 2
+                replicas: 1
         settings:
           application-name: Red Hat Konflux
           custom-console-name: Red Hat Konflux

--- a/components/pipeline-service/production/stone-prod-p01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prod-p01/deploy.yaml
@@ -1928,10 +1928,10 @@ spec:
           deployments:
             pipelines-as-code-watcher:
               spec:
-                replicas: 2
+                replicas: 1
             pipelines-as-code-webhook:
               spec:
-                replicas: 2
+                replicas: 1
         settings:
           application-name: Konflux Production Internal
           custom-console-name: Konflux Production Internal

--- a/components/pipeline-service/staging/base/update-tekton-config-performance.yaml
+++ b/components/pipeline-service/staging/base/update-tekton-config-performance.yaml
@@ -35,11 +35,3 @@
   path: /spec/pipeline/options/deployments/tekton-pipelines-remote-resolvers/spec/replicas
   # default pipeline-service setting is 1
   value: 2
-- op: replace
-  path: /spec/platforms/openshift/pipelinesAsCode/options/deployments/pipelines-as-code-watcher/spec/replicas
-  # default pipeline-service setting is 1
-  value: 2
-- op: replace
-  path: /spec/platforms/openshift/pipelinesAsCode/options/deployments/pipelines-as-code-webhook/spec/replicas
-  # default pipeline-service setting is 1
-  value: 2

--- a/components/pipeline-service/staging/stone-stage-p01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stage-p01/deploy.yaml
@@ -1929,10 +1929,10 @@ spec:
           deployments:
             pipelines-as-code-watcher:
               spec:
-                replicas: 2
+                replicas: 1
             pipelines-as-code-webhook:
               spec:
-                replicas: 2
+                replicas: 1
         settings:
           application-name: Konflux Staging Internal
           custom-console-name: Konflux Staging Internal

--- a/components/pipeline-service/staging/stone-stg-m01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stg-m01/deploy.yaml
@@ -1929,10 +1929,10 @@ spec:
           deployments:
             pipelines-as-code-watcher:
               spec:
-                replicas: 2
+                replicas: 1
             pipelines-as-code-webhook:
               spec:
-                replicas: 2
+                replicas: 1
         settings:
           application-name: Konflux Staging
           custom-console-name: Konflux Staging

--- a/components/pipeline-service/staging/stone-stg-rh01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stg-rh01/deploy.yaml
@@ -1929,10 +1929,10 @@ spec:
           deployments:
             pipelines-as-code-watcher:
               spec:
-                replicas: 2
+                replicas: 1
             pipelines-as-code-webhook:
               spec:
-                replicas: 2
+                replicas: 1
         settings:
           application-name: Konflux Staging
           custom-console-name: Konflux Staging


### PR DESCRIPTION
while our local and e2e testing was OK, per https://redhat-internal.slack.com/archives/C032EJ007C0/p1707843119631329 from @enarha 's investigation we appear to have hit a weird timing issue with the backup PAC replica in a weird state.

until we can sort out with OSP team we are backing off multi replica for PAC

@redhat-appstudio/konflux-pipeline-service FYI

rh-pre-commit.version: 2.2.0
rh-pre-commit.check-secrets: ENABLED