### PR TITLE
Rename plnscv ExternalSecret target in prd

### DIFF
--- a/components/pipeline-service/base/external-secrets/openshift-pipelines/chains-signing-secrets.yaml
+++ b/components/pipeline-service/base/external-secrets/openshift-pipelines/chains-signing-secrets.yaml
@@ -17,4 +17,4 @@ spec:
   target:
     creationPolicy: Owner
     deletionPolicy: Delete
-    name: signing-secrets-vault # Will need to be renamed to signing-secrets to complete the migration
+    name: signing-secrets

--- a/components/pipeline-service/production/stone-prd-m01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prd-m01/deploy.yaml
@@ -1730,7 +1730,7 @@ spec:
   target:
     creationPolicy: Owner
     deletionPolicy: Delete
-    name: signing-secrets-vault
+    name: signing-secrets
 ---
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret

--- a/components/pipeline-service/production/stone-prd-rh01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prd-rh01/deploy.yaml
@@ -1730,7 +1730,7 @@ spec:
   target:
     creationPolicy: Owner
     deletionPolicy: Delete
-    name: signing-secrets-vault
+    name: signing-secrets
 ---
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret

--- a/components/pipeline-service/production/stone-prod-p01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prod-p01/deploy.yaml
@@ -1730,7 +1730,7 @@ spec:
   target:
     creationPolicy: Owner
     deletionPolicy: Delete
-    name: signing-secrets-vault
+    name: signing-secrets
 ---
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret

--- a/components/pipeline-service/staging/base/kustomization.yaml
+++ b/components/pipeline-service/staging/base/kustomization.yaml
@@ -15,12 +15,6 @@ resources:
   - ../../base/rbac
 
 patches:
-  - path: tekton-chains-signing-secret-name.yaml
-    target:
-      name: tekton-chains-signing-secret
-      group: external-secrets.io
-      version: v1beta1
-      kind: ExternalSecret
   - path: metrics-exporter-trace.yaml
     target:
       kind: Deployment

--- a/components/pipeline-service/staging/base/tekton-chains-signing-secret-name.yaml
+++ b/components/pipeline-service/staging/base/tekton-chains-signing-secret-name.yaml
@@ -1,4 +1,0 @@
----
-- op: add
-  path: /spec/target/name
-  value: signing-secrets


### PR DESCRIPTION
This change completes the migration of the Chains signing secret to Vault in production.

Additional info:
* Staging specific config is removed as part of the prod activation.
* `signing-secrets` needs to be manually deleted for the gitops sync to be successful.
* `signing-secrets-vault` needs to be manually cleaned up.

rh-pre-commit.version: 2.1.0
rh-pre-commit.check-secrets: ENABLED