### PR TITLE
Revert "Promote integration-service from staging to production"

### DIFF
--- a/components/integration/production/kustomization.yaml
+++ b/components/integration/production/kustomization.yaml
@@ -3,12 +3,12 @@ kind: Kustomization
 resources:
 - ../base
 - ../base/external-secrets
-- https://github.com/redhat-appstudio/integration-service/config/default?ref=4b89853a9724bc241412714c3a1cd2e443848f49
+- https://github.com/redhat-appstudio/integration-service/config/default?ref=cad02429e3133890bcf92b2d7cc1f94233b8037e
 
 images:
 - name: quay.io/redhat-appstudio/integration-service
   newName: quay.io/redhat-appstudio/integration-service
-  newTag: 4b89853a9724bc241412714c3a1cd2e443848f49
+  newTag: cad02429e3133890bcf92b2d7cc1f94233b8037e
 
 namespace: integration-service
 


### PR DESCRIPTION
Reverts redhat-appstudio/infra-deployments#3256, reverting removal of v1alpha1 version together with webhook.