### PR TITLE
fix commit ref for sprayproxy in its new repository

### DIFF
--- a/components/sprayproxy/staging/kustomization.yaml
+++ b/components/sprayproxy/staging/kustomization.yaml
@@ -2,13 +2,13 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../base
-  - https://github.com/konflux-ci/sprayproxy/config?ref=53ae76d32a32be7babf32df376b89d0623e78726
+  - https://github.com/konflux-ci/sprayproxy/config?ref=2f488f7082df063350cc5a774b61ee3207481a9b
   - pipelines-as-code-secret.yaml
 
 images:
   - name: ko://github.com/konflux-ci/sprayproxy
     newName: quay.io/redhat-appstudio/sprayproxy
-    newTag: 53ae76d32a32be7babf32df376b89d0623e78726
+    newTag: 2f488f7082df063350cc5a774b61ee3207481a9b
 
 patches:
   - path: change-backends.yaml


### PR DESCRIPTION
spraproxy has been migrated to https://github.com/konflux-ci/sprayproxy/
this PR bumps the commit ref, and the image sha built by the ci