### PR TITLE
Set pipeline signing-secrets to orphan

### DIFF
--- a/components/pipeline-service/base/external-secrets/openshift-pipelines/chains-signing-secrets.yaml
+++ b/components/pipeline-service/base/external-secrets/openshift-pipelines/chains-signing-secrets.yaml
@@ -15,6 +15,5 @@ spec:
     kind: ClusterSecretStore
     name: appsre-stonesoup-vault
   target:
-    creationPolicy: Owner
-    deletionPolicy: Delete
+    creationPolicy: Orphan
     name: signing-secrets

--- a/components/pipeline-service/production/stone-prd-m01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prd-m01/deploy.yaml
@@ -1745,8 +1745,7 @@ spec:
     kind: ClusterSecretStore
     name: appsre-stonesoup-vault
   target:
-    creationPolicy: Owner
-    deletionPolicy: Delete
+    creationPolicy: Orphan
     name: signing-secrets
 ---
 apiVersion: external-secrets.io/v1beta1

--- a/components/pipeline-service/production/stone-prd-rh01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prd-rh01/deploy.yaml
@@ -1745,8 +1745,7 @@ spec:
     kind: ClusterSecretStore
     name: appsre-stonesoup-vault
   target:
-    creationPolicy: Owner
-    deletionPolicy: Delete
+    creationPolicy: Orphan
     name: signing-secrets
 ---
 apiVersion: external-secrets.io/v1beta1

--- a/components/pipeline-service/production/stone-prod-p01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prod-p01/deploy.yaml
@@ -1745,8 +1745,7 @@ spec:
     kind: ClusterSecretStore
     name: appsre-stonesoup-vault
   target:
-    creationPolicy: Owner
-    deletionPolicy: Delete
+    creationPolicy: Orphan
     name: signing-secrets
 ---
 apiVersion: external-secrets.io/v1beta1

--- a/components/pipeline-service/staging/stone-stage-p01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stage-p01/deploy.yaml
@@ -1746,8 +1746,7 @@ spec:
     kind: ClusterSecretStore
     name: appsre-stonesoup-vault
   target:
-    creationPolicy: Owner
-    deletionPolicy: Delete
+    creationPolicy: Orphan
     name: signing-secrets
 ---
 apiVersion: external-secrets.io/v1beta1

--- a/components/pipeline-service/staging/stone-stg-m01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stg-m01/deploy.yaml
@@ -1746,8 +1746,7 @@ spec:
     kind: ClusterSecretStore
     name: appsre-stonesoup-vault
   target:
-    creationPolicy: Owner
-    deletionPolicy: Delete
+    creationPolicy: Orphan
     name: signing-secrets
 ---
 apiVersion: external-secrets.io/v1beta1

--- a/components/pipeline-service/staging/stone-stg-rh01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stg-rh01/deploy.yaml
@@ -1746,8 +1746,7 @@ spec:
     kind: ClusterSecretStore
     name: appsre-stonesoup-vault
   target:
-    creationPolicy: Owner
-    deletionPolicy: Delete
+    creationPolicy: Orphan
     name: signing-secrets
 ---
 apiVersion: external-secrets.io/v1beta1


### PR DESCRIPTION
Even thought the secret is created by the ExternalSecret, the
TektonInstallerSet was taking over the secret ownership preventing the
ExternalSecret from managing the secret.

Set secret as orphan as we want the value to be updated if if change in
vault but we do not want to take ownership of the secret as it is
created by TektonInstallerSet.
