### PR TITLE
chore: add env var to snapshotgc cronjob

### DIFF
--- a/components/integration/development/kustomization.yaml
+++ b/components/integration/development/kustomization.yaml
@@ -14,3 +14,7 @@ namespace: integration-service
 
 patches:
   - path: manager_resources_patch.yaml
+  - path: snapshotgc_inputs_patch.yaml
+    target:
+      kind: CronJob
+      name: snapshot-garbage-collector

--- a/components/integration/development/snapshotgc_inputs_patch.yaml
+++ b/components/integration/development/snapshotgc_inputs_patch.yaml
@@ -1,0 +1,5 @@
+- op: add
+  path: /spec/jobTemplate/spec/template/spec/containers/0/env
+  value:
+    - name: PR_SNAPSHOTS_TO_KEEP
+      value: "10"


### PR DESCRIPTION
Add env var to cronjob that will take precedence over the value provided in the cronjob definition.