### PR TITLE
DO-NOT-MERGE test the revert-latest-external-secret branch in pipeline-service

### DIFF
--- a/components/pipeline-service/development/kustomization.yaml
+++ b/components/pipeline-service/development/kustomization.yaml
@@ -8,8 +8,8 @@ commonAnnotations:
   argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 
 resources:
-  - https://github.com/openshift-pipelines/pipeline-service.git/developer/openshift/gitops/argocd/pipeline-service?ref=73e3cce580020a9efed55dc2a4f740b26f65bbf7
-  - https://github.com/openshift-pipelines/pipeline-service.git/developer/openshift/gitops/argocd/pipeline-service-storage?ref=73e3cce580020a9efed55dc2a4f740b26f65bbf7
+  - https://github.com/gabemontero/pipeline-service.git/developer/openshift/gitops/argocd/pipeline-service?ref=revert-latest-external-secret
+  - https://github.com/gabemontero/pipeline-service.git/developer/openshift/gitops/argocd/pipeline-service-storage?ref=revert-latest-external-secret
   - ../base/rbac
 
 patches:


### PR DESCRIPTION
This should verify the revert of https://github.com/openshift-pipelines/pipeline-service/pull/935 that was performed in https://github.com/openshift-pipelines/pipeline-service/pull/952 fixes the removal of the tekton results watcher deployment here in infra-deployments.

@redhat-appstudio/konflux-pipeline-service FYI

rh-pre-commit.version: 2.2.0
rh-pre-commit.check-secrets: ENABLED