### PR TITLE
bump pipeline metrics exporter mem in prod

### DIFF
--- a/components/pipeline-service/production/base/bump-exporter-mem.yaml
+++ b/components/pipeline-service/production/base/bump-exporter-mem.yaml
@@ -1,4 +1,7 @@
 ---
 - op: replace
   path: /spec/template/spec/containers/0/resources/limits/memory
-  value: "1Gi"
+  value: "2Gi"
+- op: replace
+  path: /spec/template/spec/containers/0/resources/requests/memory
+  value: "2Gi"

--- a/components/pipeline-service/production/stone-prd-m01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prd-m01/deploy.yaml
@@ -1221,10 +1221,10 @@ spec:
         resources:
           limits:
             cpu: 500m
-            memory: 1Gi
+            memory: 2Gi
           requests:
             cpu: 250m
-            memory: 128Mi
+            memory: 2Gi
         securityContext:
           readOnlyRootFilesystem: true
           runAsNonRoot: true

--- a/components/pipeline-service/production/stone-prd-rh01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prd-rh01/deploy.yaml
@@ -1221,10 +1221,10 @@ spec:
         resources:
           limits:
             cpu: 500m
-            memory: 1Gi
+            memory: 2Gi
           requests:
             cpu: 250m
-            memory: 128Mi
+            memory: 2Gi
         securityContext:
           readOnlyRootFilesystem: true
           runAsNonRoot: true

--- a/components/pipeline-service/production/stone-prod-p01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prod-p01/deploy.yaml
@@ -1221,10 +1221,10 @@ spec:
         resources:
           limits:
             cpu: 500m
-            memory: 1Gi
+            memory: 2Gi
           requests:
             cpu: 250m
-            memory: 128Mi
+            memory: 2Gi
         securityContext:
           readOnlyRootFilesystem: true
           runAsNonRoot: true


### PR DESCRIPTION
after monitoring exporter memory usage in prod-rh01 over a few weeks, it is my conclusion that increased load there has rendored the current 1Gi limit as tight

GC is occurring, but load on Konflux has simply increased a bunch.

rh-pre-commit.version: 2.2.0
rh-pre-commit.check-secrets: ENABLED