### PR TITLE
increase Tekton Results pruner gracePeriod for Dev env

### DIFF
--- a/components/pipeline-service/development/increase-results-pruner-gracePeriod.yaml
+++ b/components/pipeline-service/development/increase-results-pruner-gracePeriod.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tekton-results-watcher
+spec:
+  template:
+    spec:
+      containers:
+        - name: watcher
+          args:
+            [
+              "-api_addr",
+              "tekton-results-api-service.tekton-results.svc.cluster.local:8080",
+              "-auth_mode",
+              "token",
+              "-check_owner=false",
+              "-completed_run_grace_period",
+              # default pipeline-service configuration has a greacePeriod of "10m" and will be moving towards immediate pruning in future
+              "2h",
+            ]

--- a/components/pipeline-service/development/kustomization.yaml
+++ b/components/pipeline-service/development/kustomization.yaml
@@ -2,8 +2,8 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 # Skip applying the Tekton/PaC operands while the Tekton/PaC operator is being installed.
-# See more information about this option, here: 
-# https://argo-cd.readthedocs.io/en/stable/user-guide/sync-options/#skip-dry-run-for-new-custom-resources-types 
+# See more information about this option, here:
+# https://argo-cd.readthedocs.io/en/stable/user-guide/sync-options/#skip-dry-run-for-new-custom-resources-types
 commonAnnotations:
   argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 
@@ -32,3 +32,4 @@ patches:
       kind: Deployment
       namespace: tekton-results
       name: tekton-results-watcher
+  - path: increase-results-pruner-gracePeriod.yaml


### PR DESCRIPTION
Following Konflux-bug 348, increasing the time period before Results Pruner kicks in to prune executed PipelineRuns from 10m to 2h.

There have been few instances where the PipelineRuns fail but we can't find the exact cause of failure because PipelineRun is already pruned. Konflux e2e demands to have PipelineRuns stored in the cluster for a longer period in order to proceed with tests, and further debugging by devs if needed.

Signed-off-by: Satyam Bhardwaj <sabhardw@redhat.com>

rh-pre-commit.version: 2.2.0
rh-pre-commit.check-secrets: ENABLED