### PR TITLE
make request watcher mem req/limit equal to better ensure we get the amount of mem desired

### DIFF
--- a/components/pipeline-service/production/base/bump-results-watcher-mem.yaml
+++ b/components/pipeline-service/production/base/bump-results-watcher-mem.yaml
@@ -2,3 +2,6 @@
 - op: replace
   path: /spec/template/spec/containers/1/resources/limits/memory
   value: "3Gi"
+- op: replace
+  path: /spec/template/spec/containers/1/resources/requests/memory
+  value: "3Gi"

--- a/components/pipeline-service/production/stone-prd-m01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prd-m01/deploy.yaml
@@ -1548,7 +1548,7 @@ spec:
             memory: 3Gi
           requests:
             cpu: 100m
-            memory: 64Mi
+            memory: 3Gi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/components/pipeline-service/production/stone-prd-rh01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prd-rh01/deploy.yaml
@@ -1548,7 +1548,7 @@ spec:
             memory: 3Gi
           requests:
             cpu: 100m
-            memory: 64Mi
+            memory: 3Gi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/components/pipeline-service/production/stone-prod-p01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prod-p01/deploy.yaml
@@ -1548,7 +1548,7 @@ spec:
             memory: 3Gi
           requests:
             cpu: 100m
-            memory: 64Mi
+            memory: 3Gi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:


### PR DESCRIPTION
per @hugares recent feedback in a metrics exporter related PR, I just today saw results watcher restarted when it was denied moving past 2.01 G, where I was only setting limit to 3Gi.

This PR addresses that, employing the well know best practice of having requests=limit.

@redhat-appstudio/konflux-pipeline-service FYI

rh-pre-commit.version: 2.2.0
rh-pre-commit.check-secrets: ENABLED