### PR TITLE
feat(STONE-812): IS mapping to console URL

### DIFF
--- a/components/integration/development/kustomization.yaml
+++ b/components/integration/development/kustomization.yaml
@@ -10,6 +10,11 @@ images:
   newName: quay.io/redhat-appstudio/integration-service
   newTag: 55b2bae85419df8cd8b9e633d212826a7b9567ee
 
+configMapGenerator:
+- name: console-url
+  literals:
+    - CONSOLE_URL=""
+
 namespace: integration-service
 
 patches:

--- a/components/integration/development/manager_resources_patch.yaml
+++ b/components/integration/development/manager_resources_patch.yaml
@@ -15,3 +15,10 @@ spec:
           requests:
             cpu: 100m
             memory: 20Mi
+        env:
+        - name: CONSOLE_URL
+          valueFrom:
+              configMapKeyRef:
+                name: console-url
+                key: CONSOLE_URL
+                optional: true

--- a/components/integration/production/base/kustomization.yaml
+++ b/components/integration/production/base/kustomization.yaml
@@ -11,6 +11,11 @@ images:
   newName: quay.io/redhat-appstudio/integration-service
   newTag: c6ceab5e54a3b57e1a699d534ad1179ac60029f2
 
+configMapGenerator:
+- name: console-url
+  literals:
+    - CONSOLE_URL="https://console.redhat.com/preview/application-pipeline/ns/{{ .Namespace }}/pipelinerun/{{ .PipelineRunName }}"
+
 namespace: integration-service
 
 patches:

--- a/components/integration/production/base/manager_resources_patch.yaml
+++ b/components/integration/production/base/manager_resources_patch.yaml
@@ -15,3 +15,10 @@ spec:
           requests:
             cpu: 200m
             memory: 600Mi
+        env:
+        - name: CONSOLE_URL
+          valueFrom:
+              configMapKeyRef:
+                name: console-url
+                key: CONSOLE_URL
+                optional: true

--- a/components/integration/staging/base/kustomization.yaml
+++ b/components/integration/staging/base/kustomization.yaml
@@ -11,6 +11,11 @@ images:
   newName: quay.io/redhat-appstudio/integration-service
   newTag: 55b2bae85419df8cd8b9e633d212826a7b9567ee
 
+configMapGenerator:
+- name: console-url
+  literals:
+    - CONSOLE_URL="https://console.dev.redhat.com/preview/application-pipeline/ns/{{ .Namespace }}/pipelinerun/{{ .PipelineRunName }}"
+
 namespace: integration-service
 
 patches:

--- a/components/integration/staging/base/manager_resources_patch.yaml
+++ b/components/integration/staging/base/manager_resources_patch.yaml
@@ -15,3 +15,10 @@ spec:
           requests:
             cpu: 100m
             memory: 20Mi
+        env:
+        - name: CONSOLE_URL
+          valueFrom:
+              configMapKeyRef:
+                name: console-url
+                key: CONSOLE_URL
+                optional: true


### PR DESCRIPTION
Integration Service needs to establish a way to configure a console url to be used for reporting links in gitHub.
This is the way how we would create ConfigMap containing link to specific environment which will be then fetched by pipeline adapter in integration service.