### PR TITLE
chore: re-add quality dashboard

### DIFF
--- a/argo-cd-apps/base/quality-dashboard/kustomization.yaml
+++ b/argo-cd-apps/base/quality-dashboard/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- quality-dashboard.yaml
+components:
+  - ../../k-components/inject-infra-deployments-repo-details

--- a/argo-cd-apps/base/quality-dashboard/quality-dashboard.yaml
+++ b/argo-cd-apps/base/quality-dashboard/quality-dashboard.yaml
@@ -1,0 +1,44 @@
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: quality-dashboard
+spec:
+  generators:
+    - merge:
+        mergeKeys:
+          - nameNormalized
+        generators:
+          - clusters:
+              selector:
+                matchLabels:
+                  appstudio.redhat.com/quality-dashboard: "true"
+              values:
+                sourceRoot: components/quality-dashboard
+                environment: staging
+                clusterDir: ""
+          - list:
+              elements: []
+  template:
+    metadata:
+      name: quality-dashboard-{{nameNormalized}}
+    spec:
+      project: default
+      source:
+        path: '{{values.sourceRoot}}/{{values.environment}}/{{values.clusterDir}}'
+        repoURL: https://github.com/redhat-appstudio/infra-deployments.git
+        targetRevision: main
+      destination:
+        namespace: quality-dashboard
+        server: '{{server}}'
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
+        syncOptions:
+          - CreateNamespace=true
+        retry:
+          limit: -1
+          backoff:
+            duration: 10s
+            factor: 2
+            maxDuration: 3m

--- a/argo-cd-apps/overlays/development/delete-applications.yaml
+++ b/argo-cd-apps/overlays/development/delete-applications.yaml
@@ -76,3 +76,9 @@ kind: ApplicationSet
 metadata:
   name: toolchain-member-operator
 $patch: delete
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: quality-dashboard
+$patch: delete

--- a/argo-cd-apps/overlays/development/kustomization.yaml
+++ b/argo-cd-apps/overlays/development/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
   - ../../base/all-clusters
   - ../../base/ca-bundle
   - ../../base/repository-validator
+  - ../../base/quality-dashboard
 
 patchesStrategicMerge:
   - delete-applications.yaml
@@ -129,3 +130,8 @@ patches:
       kind: ApplicationSet
       version: v1alpha1
       name: spacerequest-cleaner
+  - path: development-overlay-patch.yaml
+    target:
+      kind: ApplicationSet
+      version: v1alpha1
+      name: quality-dashboard

--- a/argo-cd-apps/overlays/konflux-public-staging/kustomization.yaml
+++ b/argo-cd-apps/overlays/konflux-public-staging/kustomization.yaml
@@ -4,4 +4,5 @@ resources:
   - ../../base/host
   - ../../base/member
   - ../../base/all-clusters
+  - ../../base/quality-dashboard
 namespace: konflux-public-staging

--- a/components/cluster-secret-store/base/appsre-stonesoup-vault-secret-store.yaml
+++ b/components/cluster-secret-store/base/appsre-stonesoup-vault-secret-store.yaml
@@ -41,6 +41,7 @@ spec:
         - multi-platform-controller
         - jvm-build-service
         - openshift-logging
+        - quality-dashboard
         - sprayproxy
         - appstudio-monitoring
         - openshift-pipelines

--- a/components/quality-dashboard/OWNERS
+++ b/components/quality-dashboard/OWNERS
@@ -1,0 +1,8 @@
+# See the OWNERS docs: https://go.k8s.io/owners
+
+approvers:
+- sawood14012
+- rhopp
+- jkopriva
+- flacatus
+- psturc

--- a/components/quality-dashboard/base/backend/kustomization.yaml
+++ b/components/quality-dashboard/base/backend/kustomization.yaml
@@ -1,0 +1,11 @@
+resources:
+- https://github.com/redhat-appstudio/quality-dashboard/backend/deploy/base?ref=e82bf3ad53b9a75af8acad6f3dd17f9dd5d860a9
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+
+images:
+  - name: quay.io/redhat-appstudio/quality-dashboard-backend
+    newName: quay.io/redhat-appstudio/quality-dashboard-backend
+    newTag: e82bf3ad53b9a75af8acad6f3dd17f9dd5d860a9

--- a/components/quality-dashboard/base/dex/kustomization.yaml
+++ b/components/quality-dashboard/base/dex/kustomization.yaml
@@ -1,0 +1,5 @@
+resources:
+- https://github.com/redhat-appstudio/quality-dashboard/dex/deploy/base?ref=0b072313be6e68ea933f0189242f966f0a42a807
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization

--- a/components/quality-dashboard/base/frontend/kustomization.yaml
+++ b/components/quality-dashboard/base/frontend/kustomization.yaml
@@ -1,0 +1,10 @@
+resources:
+- https://github.com/redhat-appstudio/quality-dashboard/frontend/deploy/base?ref=e82bf3ad53b9a75af8acad6f3dd17f9dd5d860a9
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+images:
+  - name: quay.io/redhat-appstudio/quality-dashboard-frontend
+    newName: quay.io/redhat-appstudio/quality-dashboard-frontend
+    newTag: e82bf3ad53b9a75af8acad6f3dd17f9dd5d860a9

--- a/components/quality-dashboard/base/kustomization.yaml
+++ b/components/quality-dashboard/base/kustomization.yaml
@@ -1,0 +1,7 @@
+resources:
+  - backend/
+  - dex/
+  - frontend/
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization

--- a/components/quality-dashboard/base/rbac/kustomization.yaml
+++ b/components/quality-dashboard/base/rbac/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - quality-dashboard.yaml

--- a/components/quality-dashboard/base/rbac/quality-dashboard.yaml
+++ b/components/quality-dashboard/base/rbac/quality-dashboard.yaml
@@ -1,4 +1,4 @@
-kind: ClusterRole
+kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: quality-dashboard-maintainer
@@ -25,5 +25,5 @@ subjects:
     name: konflux-qe-admins
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
+  kind: Role
   name: quality-dashboard-maintainer

--- a/components/quality-dashboard/base/rbac/quality-dashboard.yaml
+++ b/components/quality-dashboard/base/rbac/quality-dashboard.yaml
@@ -1,0 +1,29 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: quality-dashboard-maintainer
+  namespace: quality-dashboard
+rules:
+  - verbs:
+      - create
+      - delete
+      - edit
+      - list
+    apiGroups:
+      - ''
+    resources:
+      - secrets
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: quality-dashboard-maintainers
+  namespace: quality-dashboard
+subjects:
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: konflux-qe-admins
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: quality-dashboard-maintainer

--- a/components/quality-dashboard/development/kustomization.yaml
+++ b/components/quality-dashboard/development/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../base

--- a/components/quality-dashboard/staging/external-secrets/kustomization.yaml
+++ b/components/quality-dashboard/staging/external-secrets/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- quality-dashboard-secrets.yaml
+namespace: quality-dashboard

--- a/components/quality-dashboard/staging/external-secrets/quality-dashboard-secrets.yaml
+++ b/components/quality-dashboard/staging/external-secrets/quality-dashboard-secrets.yaml
@@ -1,0 +1,19 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: quality-dashboard-secrets
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  dataFrom:
+    - extract:
+        key: staging/qe/quality-dashboard-secrets
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: appsre-stonesoup-vault
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    name: quality-dashboard-secrets

--- a/components/quality-dashboard/staging/kustomization.yaml
+++ b/components/quality-dashboard/staging/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../base
+- external-secrets
+- ../base/rbac

--- a/docs/_data/navigation.yml
+++ b/docs/_data/navigation.yml
@@ -55,5 +55,7 @@ docs-en:
         url: /components/ui/README.html
   - title: Misc
     children:
+      - title: Quality Dashboard
+        url: /docs/misc/quality-dashboard.html
       - title: FAQs/Troubleshooting
         url: /docs/misc/faq.html

--- a/docs/misc/quality-dashboard.md
+++ b/docs/misc/quality-dashboard.md
@@ -1,0 +1,10 @@
+---
+title: Quality Dashboard
+---
+
+The purpose of the Quality Dashboard is to provide information that indicates the quality
+of the different Konflux services. More details can be found here https://github.com/redhat-appstudio/quality-dashboard
+
+The manifests can be found [here](../../components/quality-dashboard/)
+
+For validating changes to Quality Dashboard on a dev cluster, configure related environment variables specified in [preview-template.env](../../hack/preview-template.env)

--- a/hack/bootstrap-host-cluster.sh
+++ b/hack/bootstrap-host-cluster.sh
@@ -4,6 +4,7 @@ declare -r ROOT="${BASH_SOURCE[0]%/*}"
 
 main() {
     load_global_vars
+    "${ROOT}/secret-creator/quality-dashboard/create-quality-dashboard-secrets.sh"
 }
 
 load_global_vars() {

--- a/hack/destroy-cluster.sh
+++ b/hack/destroy-cluster.sh
@@ -41,7 +41,7 @@ oc delete clusterserviceversions.operators.coreos.com --all -n openshift-operato
 
 echo
 echo "Removing custom projects"
-oc delete project enterprise-contract-service gitops internal-services application-api
+oc delete project enterprise-contract-service gitops quality-dashboard internal-services application-api
 
 echo
 echo "Removing dev-sso"

--- a/hack/preview-template.env
+++ b/hack/preview-template.env
@@ -120,3 +120,21 @@ export IMAGE_CONTROLLER_IMAGE_REPO=
 export IMAGE_CONTROLLER_IMAGE_TAG=
 export IMAGE_CONTROLLER_PR_OWNER=
 export IMAGE_CONTROLLER_PR_SHA=
+
+# Quality Dashboard
+export QD_APP_ID=
+## QD_IN_CLUSTER_DB=true - deploy postgresql DB on an OpenShift cluster
+## QD_IN_CLUSTER_DB=false - test with DB deployed remotely, e.g. AWS RDS
+export QD_IN_CLUSTER_DB=
+export QD_DB_NAME=
+export QD_DB_USER=
+export QD_DB_PASSWORD=
+export QD_DB_HOST=
+export QD_GITHUB_TOKEN=
+export QD_JIRA_TOKEN=
+export QD_SLACK_TOKEN=
+## Dex issuer specific secrets
+export QD_GITHUB_ORG=
+### Client ID/Secret for OAuth app - see https://github.com/redhat-appstudio/quality-dashboard?tab=readme-ov-file#dex-for-oauth for more details
+export QD_OAUTH_CLIENT_ID=
+export QD_OAUTH_CLIENT_SECRET=

--- a/hack/secret-creator/quality-dashboard/.gitignore
+++ b/hack/secret-creator/quality-dashboard/.gitignore
@@ -1,0 +1,1 @@
+dex-config.yaml

--- a/hack/secret-creator/quality-dashboard/create-quality-dashboard-secrets.sh
+++ b/hack/secret-creator/quality-dashboard/create-quality-dashboard-secrets.sh
@@ -1,0 +1,66 @@
+#!/bin/bash -e
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+main() {
+    echo "Setting secrets for Quality Dashboard"
+    DOMAIN=$(oc get ingresses.config.openshift.io cluster --template={{.spec.domain}})
+
+    NS=quality-dashboard
+
+    BACKEND_URL="https://backend-$NS.${DOMAIN}"
+    DEX_URL="https://dex-$NS.${DOMAIN}"
+    FRONTEND_URL="https://frontend-$NS.${DOMAIN}"
+    
+    SECRET_NAME=$NS-secrets
+
+    APP_ID=${QD_APP_ID:-redhat-quality-studio-app}
+
+    IN_CLUSTER_DB=${QD_IN_CLUSTER_DB:-false}
+    DB_NAME=${QD_DB_NAME:-quality}
+    DB_USER=${QD_DB_USER:-qd}
+    DB_PASSWORD=${QD_DB_PASSWORD:-qd}
+    DB_HOST=${QD_DB_HOST:-postgresql}
+
+    JIRA_TOKEN=${QD_JIRA_TOKEN:-}
+    GITHUB_TOKEN=${QD_GITHUB_TOKEN:-$MY_GITHUB_TOKEN}
+    SLACK_TOKEN=${QD_SLACK_TOKEN:-}
+
+    DEX_CONFIG_TEMPLATE_PATH=$SCRIPT_DIR/dex-config-template.yaml
+    DEX_CONFIG_PATH=$SCRIPT_DIR/dex-config.yaml
+
+    GITHUB_ORG=${QD_GITHUB_ORG:-$MY_GITHUB_ORG}
+    OAUTH_CLIENT_ID=${QD_OAUTH_CLIENT_ID:-}
+    OAUTH_CLIENT_SECRET=${QD_OAUTH_CLIENT_SECRET:-}
+
+    kubectl create namespace $NS -o yaml --dry-run=client | oc apply -f-
+
+    if [ "${IN_CLUSTER_DB}" = "true" ]; then
+        oc process postgresql-ephemeral -n openshift -p POSTGRESQL_USER="$DB_USER" -p POSTGRESQL_PASSWORD="$DB_PASSWORD" -p POSTGRESQL_DATABASE="$DB_NAME" | oc apply -n $NS -f -
+    fi
+
+    cp "$DEX_CONFIG_TEMPLATE_PATH" "$DEX_CONFIG_PATH"
+    yq -i ".issuer=\"https://dex-$NS.$DOMAIN/dex\"" $DEX_CONFIG_PATH
+    yq -i "(.staticClients.[] | select(.name==\"Red Hat Quality Studio\")) |=(.id=\"$APP_ID\",.redirectURIs=[\"$FRONTEND_URL/home/overview\", \"$FRONTEND_URL/login\", \"$FRONTEND_URL/\"])" $DEX_CONFIG_PATH
+    yq -i "(.connectors.[] | select(.name==\"GitHub\").config) |=(.clientID=\"$OAUTH_CLIENT_ID\",.clientSecret=\"$OAUTH_CLIENT_SECRET\",.redirectURI=\"$DEX_URL/dex/callback\",.orgs=[{\"name\":\"$GITHUB_ORG\"}])" $DEX_CONFIG_PATH
+
+    if ! kubectl get secret $SECRET_NAME -n $NS  &>/dev/null; then
+        kubectl create secret generic $SECRET_NAME \
+            --namespace=$NS \
+            --from-literal=backend-route=$BACKEND_URL \
+            --from-literal=dex-application-id=$APP_ID \
+            --from-literal=dex-issuer="$DEX_URL/dex" \
+            --from-literal=frontend-route=$FRONTEND_URL/login \
+            --from-literal=github-token=$GITHUB_TOKEN \
+            --from-literal=jira-token=$JIRA_TOKEN \
+            --from-literal=rds-endpoint=$DB_HOST \
+            --from-literal=slack_token=$SLACK_TOKEN \
+            --from-literal=storage-database=$DB_NAME \
+            --from-literal=storage-password=$DB_PASSWORD \
+            --from-literal=storage-user=$DB_USER \
+            --from-file=$DEX_CONFIG_PATH
+    fi
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+    main "$@"
+fi

--- a/hack/secret-creator/quality-dashboard/dex-config-template.yaml
+++ b/hack/secret-creator/quality-dashboard/dex-config-template.yaml
@@ -1,0 +1,39 @@
+---
+issuer: https://dex-quality-dashboard.<cluster-domain>/dex
+storage:
+  type: sqlite3
+web:
+  http: 0.0.0.0:5556
+  allowedOrigins: ["*"]
+oauth2:
+  skipApprovalScreen: true
+telemetry:
+  http: 0.0.0.0:5558
+  enableProfiling: true
+expiry:
+  deviceRequests: "5m"
+  signingKeys: "6h"
+  idTokens: "1h"
+  refreshTokens:
+    reuseInterval: "3s"
+    validIfNotUsedFor: "2160h"
+    absoluteLifetime: "3960h"
+staticClients:
+- id: "<APP_ID>"
+  redirectURIs:
+  - "https://frontend-quality-dashboard.<cluster-domain>/home/overview"
+  - "https://frontend-quality-dashboard.<cluster-domain>/login"
+  - "https://frontend-quality-dashboard.<cluster-domain>/"
+  name: "Red Hat Quality Studio"
+  public: true
+connectors:
+- type: github
+  id: github
+  name: GitHub
+  config:
+    orgs:
+    - name: <GITHUB_ORG>
+    clientID: <OAUTH_CLIENT_ID>
+    clientSecret: <OAUTH_CLIENT_SECRET>
+    # Dex's issuer URL + "/callback"
+    redirectURI: https://dex-quality-dashboard.<cluster-domain>/dex/callback


### PR DESCRIPTION
https://issues.redhat.com/browse/KONFLUX-2244

Based on this PR: https://github.com/redhat-appstudio/infra-deployments/pull/2676

Deployment of QD can be validated on a dev cluster by following instructions in `docs/misc/quality-dashboard.md`