### PR TITLE
KFLUXBUGS-863: bump stg results watcher controller tuning

### DIFF
--- a/components/pipeline-service/staging/base/bump-results-watcher-mem.yaml
+++ b/components/pipeline-service/staging/base/bump-results-watcher-mem.yaml
@@ -1,0 +1,7 @@
+---
+- op: replace
+  path: /spec/template/spec/containers/1/resources/limits/memory
+  value: "4Gi"
+- op: replace
+  path: /spec/template/spec/containers/1/resources/requests/memory
+  value: "4Gi"

--- a/components/pipeline-service/staging/base/kustomization.yaml
+++ b/components/pipeline-service/staging/base/kustomization.yaml
@@ -20,6 +20,11 @@ patches:
       kind: Deployment
       name: pipeline-metrics-exporter
       namespace: openshift-pipelines
+  - path: bump-results-watcher-mem.yaml
+    target:
+      kind: Deployment
+      namespace: tekton-results
+      name: tekton-results-watcher
   - path: update-tekton-config-pac.yaml
     target:
       kind: TektonConfig
@@ -34,6 +39,11 @@ patches:
       kind: TektonConfig
       name: config
   - path: bump-results-watcher-replicas.yaml
+    target:
+      kind: Deployment
+      namespace: tekton-results
+      name: tekton-results-watcher
+  - path: update-results-watcher-performance.yaml
     target:
       kind: Deployment
       namespace: tekton-results

--- a/components/pipeline-service/staging/base/update-results-watcher-performance.yaml
+++ b/components/pipeline-service/staging/base/update-results-watcher-performance.yaml
@@ -1,0 +1,13 @@
+---
+- op: add
+  path: /spec/template/spec/containers/1/args/-
+  value: "-threadiness"
+- op: add
+  path: /spec/template/spec/containers/1/args/-
+  value: "32"
+- op: replace
+  path: /spec/template/spec/containers/1/resources/requests/cpu
+  value: "250m"
+- op: replace
+  path: /spec/template/spec/containers/1/resources/limits/cpu
+  value: "250m"

--- a/components/pipeline-service/staging/stone-stage-p01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stage-p01/deploy.yaml
@@ -1473,6 +1473,8 @@ spec:
         - -check_owner=false
         - -completed_run_grace_period
         - 10m
+        - -threadiness
+        - "32"
         env:
         - name: SYSTEM_NAMESPACE
           valueFrom:
@@ -1500,10 +1502,10 @@ spec:
         resources:
           limits:
             cpu: 250m
-            memory: 2Gi
+            memory: 4Gi
           requests:
-            cpu: 100m
-            memory: 64Mi
+            cpu: 250m
+            memory: 4Gi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/components/pipeline-service/staging/stone-stg-m01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stg-m01/deploy.yaml
@@ -1473,6 +1473,8 @@ spec:
         - -check_owner=false
         - -completed_run_grace_period
         - 10m
+        - -threadiness
+        - "32"
         env:
         - name: SYSTEM_NAMESPACE
           valueFrom:
@@ -1500,10 +1502,10 @@ spec:
         resources:
           limits:
             cpu: 250m
-            memory: 2Gi
+            memory: 4Gi
           requests:
-            cpu: 100m
-            memory: 64Mi
+            cpu: 250m
+            memory: 4Gi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/components/pipeline-service/staging/stone-stg-rh01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stg-rh01/deploy.yaml
@@ -1473,6 +1473,8 @@ spec:
         - -check_owner=false
         - -completed_run_grace_period
         - 10m
+        - -threadiness
+        - "32"
         env:
         - name: SYSTEM_NAMESPACE
           valueFrom:
@@ -1500,10 +1502,10 @@ spec:
         resources:
           limits:
             cpu: 250m
-            memory: 2Gi
+            memory: 4Gi
           requests:
-            cpu: 100m
-            memory: 64Mi
+            cpu: 250m
+            memory: 4Gi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:


### PR DESCRIPTION
Similar to what we did for the tekton pipelines controller, we are bumping the knative tuning parameters for controller worker thread count to the recommended, higher scale, non development, settings. Unfortunately, results/watcher bypasses the api clientqps/burst command line args that knative provides, and it is at an old enough knative level that it does provide the environment variable overrides for those settings. So we bypass that tuning at this time.  We are also bumping cpu request/limits and mem limit (again) based on recent obsevations.

We are finally moving forward with the worker thread bump since we have the goroutine/memory lead sorted out.

FYI the recently discovered pruning issue in stage https://issues.redhat.com/browse/PLNSRVCE-1679 is unrelated to the mem leak fix (though we may temporarily patch results downstream to bypass that bug while PaC gets sorted out).

I am not setting these values in the development overlay as I was worried about developer and e2e cluster size varying enough.

Based on what we see in staging, if need be I'll revert this and then start vetting through the developer overlay path.

rh-pre-commit.version: 2.2.0
rh-pre-commit.check-secrets: ENABLED