### PR TITLE
fix(stoneinteg-761): update the kustomization to latest integration-service

### DIFF
--- a/components/monitoring/grafana/base/dashboards/integration/kustomization.yaml
+++ b/components/monitoring/grafana/base/dashboards/integration/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - https://github.com/redhat-appstudio/integration-service/config/grafana/?ref=52cd9c927aa8858c4136147389ab620283bbdacb
+  - https://github.com/redhat-appstudio/integration-service/config/grafana/?ref=741cb3cc24c649732d1bfb9ccc69f5f839a9a2ab


### PR DESCRIPTION
On [STONEINTG-761](https://issues.redhat.com/browse/STONEINTG-761) we made changes in metrics of integration-service , this PR as follow up to update in infra-deployments to point monitoring grafana to latest integration-service.