### PR TITLE
Backup all resources in workspaces host namespace

### DIFF
--- a/components/backup/base/host/schedules/backup-toolchain-host-schedule.yaml
+++ b/components/backup/base/host/schedules/backup-toolchain-host-schedule.yaml
@@ -7,12 +7,6 @@ spec:
   template:
     includedNamespaces:
       - toolchain-host-operator
-    includedResources:
-      - bannedusers.toolchain.dev.openshift.com
-      - masteruserrecords.toolchain.dev.openshift.com
-      - spacebindings.toolchain.dev.openshift.com
-      - spaces.toolchain.dev.openshift.com
-      - usersignups.toolchain.dev.openshift.com
     storageLocation: velero-aws-1
     ttl: 720h0m0s
   useOwnerReferencesInBackup: true


### PR DESCRIPTION
Backing up a list of resources can lead to incomplete backup, e.g. if a CRD is added without updating the back up list.

To be on the safe side, change the backup to include all resources in toolchain-host-operator and restore procedure will explicitly mention which resources to restore. Doing it that way will cost a bit more on the AWS storage but has the huge advantage of covering the case of CRD being added later. Backup will include it and restore procedure might not but can be adjusted when restore is performed.