### PR TITLE
KONFLUX-2040: Add robot push token for quay.io/konflux-ci

### DIFF
--- a/components/tekton-ci/base/external-secrets/kustomization.yaml
+++ b/components/tekton-ci/base/external-secrets/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - quay-push-secret.yaml
+- quay-push-secret-konflux-ci.yaml
 - infra-deployments-pr-creator.yaml
 - snyk-shared-token.yaml
 - slack-webhook-notification-secret.yaml

--- a/components/tekton-ci/base/external-secrets/quay-push-secret-konflux-ci.yaml
+++ b/components/tekton-ci/base/external-secrets/quay-push-secret-konflux-ci.yaml
@@ -1,0 +1,24 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: quay-push-secret-konflux-ci
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  dataFrom:
+    - extract:
+        key: staging/build/tekton-ci/quay-push-secret-konflux-ci
+  refreshInterval: 15m
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: appsre-stonesoup-vault
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    name: quay-push-secret-konflux-ci
+    template:
+      engineVersion: v2
+      type: kubernetes.io/dockerconfigjson
+      data:
+        .dockerconfigjson: "{{ .config }}"

--- a/components/tekton-ci/base/serviceaccount.yaml
+++ b/components/tekton-ci/base/serviceaccount.yaml
@@ -4,5 +4,7 @@ metadata:
   name: appstudio-pipeline
 secrets:
   - name: quay-push-secret
+  - name: quay-push-secret-konflux-ci
 imagePullSecrets:
   - name: quay-push-secret
+  - name: quay-push-secret-konflux-ci

--- a/components/tekton-ci/production/kustomization.yaml
+++ b/components/tekton-ci/production/kustomization.yaml
@@ -13,6 +13,12 @@ patches:
       kind: ExternalSecret
       group: external-secrets.io
       version: v1beta1
+  - path: quay-push-secret-konflux-ci.yaml
+    target:
+      name: quay-push-secret-konflux-ci
+      kind: ExternalSecret
+      group: external-secrets.io
+      version: v1beta1
   - path: infra-deployments-pr-creator.yaml
     target:
       name: infra-deployments-pr-creator

--- a/components/tekton-ci/production/quay-push-secret-konflux-ci.yaml
+++ b/components/tekton-ci/production/quay-push-secret-konflux-ci.yaml
@@ -1,0 +1,4 @@
+---
+- op: add
+  path: /spec/dataFrom/0/extract/key
+  value: production/build/tekton-ci/quay-push-secret-konflux-ci


### PR DESCRIPTION
The purpose is to support a migration of container images from quay.io/redhat-appstudio to quay.io/konflux-ci.