### PR TITLE
Reduce from 8 to 4 threads to run kustomize build

### DIFF
--- a/.github/workflows/kube-linter.yaml
+++ b/.github/workflows/kube-linter.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: Run kustomize build
         run: |
           find argo-cd-apps components -name 'kustomization.yaml' ! -path '*/k-components/*' | \
-            xargs -I {} -n1 -P0  bash -c 'dir=$(dirname "{}"); output_file=$(echo $dir | tr / -)-kustomization.yaml; if ! log=$(kustomize build "$dir" -o "kustomizedfiles/$output_file" 2>&1); then echo "Error when running kustomize build for $dir: $log" && exit 1;fi'
+            xargs -I {} -n1 -P8  bash -c 'dir=$(dirname "{}"); output_file=$(echo $dir | tr / -)-kustomization.yaml; if ! log=$(kustomize build "$dir" -o "kustomizedfiles/$output_file" 2>&1); then echo "Error when running kustomize build for $dir: $log" && exit 1;fi'
 
       - name: Scan yaml files with kube-linter
         uses: stackrox/kube-linter-action@v1.0.4


### PR DESCRIPTION
Recently, we started to see timeout errors while running kustomize
build:
```
URL is a git repository': hit 27s timeout running
'/usr/bin/git fetch --depth=1
https://github.com/redhat-appstudio/jvm-build-service 1f980ef8f4540dc09fcfc8454972418a7c114404'
```

I am not sure what changed on GitHub side as the kube linter check has
been using 8 threads to run kustomize build of the various components
folder for a few months without any issue.

Reducing the number of threads from 8 to 4 seems to fix the issue. I say
`fix` because the pattern to reproduce the issue is not well defined. We
will try with that and see if it solves the issue.