### PR TITLE
Revert "integration-service update"

### DIFF
--- a/components/integration/development/kustomization.yaml
+++ b/components/integration/development/kustomization.yaml
@@ -2,13 +2,13 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - ../base
-- https://github.com/redhat-appstudio/integration-service/config/default?ref=e7ef5a145df9c58364d1337a67ea9454176e1e5c
-- https://github.com/redhat-appstudio/integration-service/config/snapshotgc?ref=e7ef5a145df9c58364d1337a67ea9454176e1e5c
+- https://github.com/redhat-appstudio/integration-service/config/default?ref=c6ceab5e54a3b57e1a699d534ad1179ac60029f2
+- https://github.com/redhat-appstudio/integration-service/config/snapshotgc?ref=c6ceab5e54a3b57e1a699d534ad1179ac60029f2
 
 images:
 - name: quay.io/redhat-appstudio/integration-service
   newName: quay.io/redhat-appstudio/integration-service
-  newTag: e7ef5a145df9c58364d1337a67ea9454176e1e5c
+  newTag: c6ceab5e54a3b57e1a699d534ad1179ac60029f2
 
 namespace: integration-service
 

--- a/components/integration/staging/base/kustomization.yaml
+++ b/components/integration/staging/base/kustomization.yaml
@@ -3,13 +3,13 @@ kind: Kustomization
 resources:
 - ../../base
 - ../../base/external-secrets
-- https://github.com/redhat-appstudio/integration-service/config/default?ref=e7ef5a145df9c58364d1337a67ea9454176e1e5c
-- https://github.com/redhat-appstudio/integration-service/config/snapshotgc?ref=e7ef5a145df9c58364d1337a67ea9454176e1e5c
+- https://github.com/redhat-appstudio/integration-service/config/default?ref=c6ceab5e54a3b57e1a699d534ad1179ac60029f2
+- https://github.com/redhat-appstudio/integration-service/config/snapshotgc?ref=c6ceab5e54a3b57e1a699d534ad1179ac60029f2
 
 images:
 - name: quay.io/redhat-appstudio/integration-service
   newName: quay.io/redhat-appstudio/integration-service
-  newTag: e7ef5a145df9c58364d1337a67ea9454176e1e5c
+  newTag: c6ceab5e54a3b57e1a699d534ad1179ac60029f2
 
 namespace: integration-service
 


### PR DESCRIPTION
This accidentally overwrote newer version with old image

Reverts redhat-appstudio/infra-deployments#3357