### PR TITLE
tekton-ci: unlink quay-push-konflux-ci secret

### DIFF
--- a/components/tekton-ci/base/serviceaccount.yaml
+++ b/components/tekton-ci/base/serviceaccount.yaml
@@ -4,7 +4,5 @@ metadata:
   name: appstudio-pipeline
 secrets:
   - name: quay-push-secret
-  - name: quay-push-secret-konflux-ci
 imagePullSecrets:
   - name: quay-push-secret
-  - name: quay-push-secret-konflux-ci


### PR DESCRIPTION
After b1ce8f527d607725f3a9ae062873166354567bcf, the tekton-ci namespace contains two dockercfg secrets for quay.io authentication (both linked to the appstudio-pipeline SA). One of them has permissions for the redhat-appstudio org, the other one for the konflux-ci org. But since both of them contain auth for "quay.io", when the secrets get merged to produce the final auth file, only one of them wins. Given that our CI has lost permissions for pushing to the redhat-appstudio org, it seems that konflux-ci wins.