### PR TITLE
tekton-ci: re-link quay-push-konflux-ci secret

### DIFF
--- a/components/tekton-ci/base/serviceaccount.yaml
+++ b/components/tekton-ci/base/serviceaccount.yaml
@@ -4,5 +4,7 @@ metadata:
   name: appstudio-pipeline
 secrets:
   - name: quay-push-secret
+  - name: quay-push-secret-konflux-ci
 imagePullSecrets:
   - name: quay-push-secret
+  - name: quay-push-secret-konflux-ci


### PR DESCRIPTION
This reverts commit 668f83cf37a1981abd302d00d21fb021d48c2122.

Adam made manual changes to the secret values to namespace them for the two quay.io orgs. We think it is safe to reintroduce this change now.