### PR TITLE
Grant konflux-admins to konflux-sre team

### DIFF
--- a/components/authentication/base/all/konflux-admins.yaml
+++ b/components/authentication/base/all/konflux-admins.yaml
@@ -323,6 +323,9 @@ subjects:
   - apiGroup: rbac.authorization.k8s.io
     kind: Group
     name: konflux-admins
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: konflux-sre
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -336,3 +339,6 @@ subjects:
   - apiGroup: rbac.authorization.k8s.io
     kind: Group
     name: konflux-admins
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: konflux-sre


### PR DESCRIPTION
Create a new GH/rover group named konflux-sre to include SRE people and grant them konflux-admins.

Another option would have been to add them to konflux-admins group but I prefer to not do that. In fact, I would like to delete that group and grant konflux-admins role to teams who should have it, like konflux-sre.

[RHTAPSRE-425](https://issues.redhat.com//browse/RHTAPSRE-425)