### PR TITLE
KFLUXBUGS-1150: reduce watcher cpu/mem reqs for smaller e2e clusters; finish enabling widening of prune interval for e2e

### DIFF
--- a/components/pipeline-service/development/increase-results-pruner-gracePeriod.yaml
+++ b/components/pipeline-service/development/increase-results-pruner-gracePeriod.yaml
@@ -15,7 +15,5 @@ spec:
               "-auth_mode",
               "token",
               "-check_owner=false",
-              "-completed_run_grace_period",
-              # default pipeline-service configuration has a greacePeriod of "10m" and will be moving towards immediate pruning in future
-              "2h",
+              "-completed_run_grace_period=2h",
             ]

--- a/components/pipeline-service/development/kustomization.yaml
+++ b/components/pipeline-service/development/kustomization.yaml
@@ -33,3 +33,12 @@ patches:
       namespace: tekton-results
       name: tekton-results-watcher
   - path: increase-results-pruner-gracePeriod.yaml
+    target:
+      kind: Deployment
+      namespace: tekton-results
+      name: tekton-results-watcher
+  - path: reduce-watcher-cpu-mem-reqs.yaml
+    target:
+      kind: Deployment
+      namespace: tekton-results
+      name: tekton-results-watcher

--- a/components/pipeline-service/development/reduce-watcher-cpu-mem-reqs.yaml
+++ b/components/pipeline-service/development/reduce-watcher-cpu-mem-reqs.yaml
@@ -1,0 +1,7 @@
+---
+- op: replace
+  path: /spec/template/spec/containers/0/resources/requests/cpu
+  value: "100m"
+- op: replace
+  path: /spec/template/spec/containers/0/resources/requests/memory
+  value: "64Mi"


### PR DESCRIPTION
see https://redhat-internal.slack.com/archives/C02FTKEMBU1/p1710173062721049

also, when editing the development kustomization.yaml file I found an yaml formatting problem with the 
`increase-restuls-pruner-gracePeriod.yaml` file being listed as a path, but not deployment target listed

This stems https://github.com/redhat-appstudio/infra-deployments/pull/3340 that was authored by @ramessesii2 and approved by @Roming22 

I've taken a stab and fully enabling it, thinking the bump to 2 hours makes sense for e2e's in order to allow for must gather to obtain pipelineruns without fear of them getting pruned

however, if instead @ramessesii2 @Roming22 you all think that file and override should be removed altogether, please let me know

rh-pre-commit.version: 2.2.0
rh-pre-commit.check-secrets: ENABLED