### PR TITLE
RHTAPSRE-429: Disabling Sync Policy for Staging Public ArgoCD

### DIFF
--- a/argo-cd-apps/overlays/staging/kustomization.yaml
+++ b/argo-cd-apps/overlays/staging/kustomization.yaml
@@ -4,3 +4,8 @@ resources:
   - ../../base/host
   - ../../base/member
   - ../../base/all-clusters
+patches:
+  - path: migration.patch.yaml
+    target:
+      kind: ApplicationSet
+      version: v1alpha1

--- a/argo-cd-apps/overlays/staging/migration.patch.yaml
+++ b/argo-cd-apps/overlays/staging/migration.patch.yaml
@@ -1,0 +1,2 @@
+- op: remove
+  path: /spec/template/spec/syncPolicy


### PR DESCRIPTION
This pull request will disable `sync_policy` for the Staging Public ArgoCD instance. We are migrating this ArgoCD instance to appsre managed OSD Cluster. 