### PR TITLE
fix: release-expiration cronjob incorrect directory

### DIFF
--- a/components/release/base/cronjobs/remove-expired-releases.yaml
+++ b/components/release/base/cronjobs/remove-expired-releases.yaml
@@ -30,7 +30,7 @@ spec:
                   NOW=$(date +%s)
                   kubectl get release --all-namespaces \
                   --sort-by=.status.expirationTime \
-                  --template '{{range .items}}{{.metadata.name}}{{"\t"}}{{.metadata.namespace}}{{"\t"}}{{.status.expirationTime}}{{"\n"}}{{end}}' > /tmp/kubectl-out
+                  --template '{{range .items}}{{.metadata.name}}{{"\t"}}{{.metadata.namespace}}{{"\t"}}{{.status.expirationTime}}{{"\n"}}{{end}}' > /var/tmp/kubectl-out
                   awk -v now=${NOW} '{
                        # parsing the expirationTime and converting it to epoch
                        # so we can calculate easier the expired Releases

--- a/components/release/base/cronjobs/remove-expired-releases.yaml
+++ b/components/release/base/cronjobs/remove-expired-releases.yaml
@@ -27,10 +27,11 @@ spec:
                   PATH="/bin:/usr/bin:/usr/local/bin"
                   MAX_PROCS=5
                   EXPIRED_RELEASES_FILE="/var/tmp/releases-to-be-deleted"
+                  KUBECTL_OUTPUT=$(mktemp -p /var/tmp)
                   NOW=$(date +%s)
                   kubectl get release --all-namespaces \
                   --sort-by=.status.expirationTime \
-                  --template '{{range .items}}{{.metadata.name}}{{"\t"}}{{.metadata.namespace}}{{"\t"}}{{.status.expirationTime}}{{"\n"}}{{end}}' > /var/tmp/kubectl-out
+                  --template '{{range .items}}{{.metadata.name}}{{"\t"}}{{.metadata.namespace}}{{"\t"}}{{.status.expirationTime}}{{"\n"}}{{end}}' > $KUBECTL_OUTPUT
                   awk -v now=${NOW} '{
                        # parsing the expirationTime and converting it to epoch
                        # so we can calculate easier the expired Releases
@@ -43,7 +44,7 @@ spec:
                          args="%s:%s"
                          printf(args, $1, $2)
                        } 
-                    }' /var/tmp/kubectl-out > $EXPIRED_RELEASES_FILE
+                    }' $KUBECTL_OUTPUT > $EXPIRED_RELEASES_FILE
                   # The deleteAndLog will run the Release deletion and save the operation in a structured way that        
                   # can be read easily by kubectl or journalctl                                                           
                   function deleteAndLog() {


### PR DESCRIPTION
This PR changes the output temp directory used by the cronjob `remove-expired-releases`