### PR TITLE
Link registry.redhat.io credential in SA secrets

### DIFF
--- a/components/tekton-ci/base/serviceaccount.yaml
+++ b/components/tekton-ci/base/serviceaccount.yaml
@@ -4,6 +4,7 @@ metadata:
   name: appstudio-pipeline
 secrets:
   - name: quay-push-secret
+  - name: registry-redhat-io-pull-secret
 imagePullSecrets:
   - name: quay-push-secret
   - name: registry-redhat-io-pull-secret


### PR DESCRIPTION
[STONEBLD-1832](https://issues.redhat.com//browse/STONEBLD-1832)

Tekton should handle the secret linked in the `secrets:' section, which will be merged into the ~/.docker/config.json.