### PR TITLE
Revert "bump results to stage level to address memory leak, help performance; keep at OSP 1.13 for now; add timeout, goroutine dump in dynamic reconciler (#3441)"

### DIFF
--- a/components/pipeline-service/production/base/kustomization.yaml
+++ b/components/pipeline-service/production/base/kustomization.yaml
@@ -8,7 +8,7 @@ commonAnnotations:
   argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 
 resources:
-  - https://github.com/openshift-pipelines/pipeline-service.git/operator/gitops/argocd/pipeline-service?ref=7ca341c412a0654bb2ba16e079ff7507195e5e1f
+  - https://github.com/openshift-pipelines/pipeline-service.git/operator/gitops/argocd/pipeline-service?ref=43bb04294bf63ea4c80b3c389fe5553c2a4dd2a3
   - pipelines-as-code-secret.yaml # create external secret in openshift-pipelines namespace
   - ../../base/external-secrets
   - ../../base/testing
@@ -43,22 +43,3 @@ patches:
       kind: Deployment
       namespace: tekton-results
       name: tekton-results-watcher
-  - path: update-results-watcher-performance.yaml
-    target:
-      kind: Deployment
-      namespace: tekton-results
-      name: tekton-results-watcher
-  - path: stay-at-1-13-handle-bump-to-nightly-separately.yaml
-    target:
-      kind: Subscription
-      namespace: openshift-operators
-      name: openshift-pipelines-operator
-
-patchesStrategicMerge:
-  - |-
-    apiVersion: operators.coreos.com/v1alpha1
-    kind: CatalogSource
-    metadata:
-      name: custom-operators
-      namespace: openshift-marketplace
-    $patch: delete

--- a/components/pipeline-service/production/base/stay-at-1-13-handle-bump-to-nightly-separately.yaml
+++ b/components/pipeline-service/production/base/stay-at-1-13-handle-bump-to-nightly-separately.yaml
@@ -1,7 +1,0 @@
----
-- op: replace
-  path: /spec/channel
-  value: "pipelines-1.13"
-- op: replace
-  path: /spec/source
-  value: "redhat-operators"

--- a/components/pipeline-service/production/base/update-results-watcher-performance.yaml
+++ b/components/pipeline-service/production/base/update-results-watcher-performance.yaml
@@ -1,6 +1,0 @@
-- op: replace
-  path: /spec/template/spec/containers/1/resources/requests/cpu
-  value: "250m"
-- op: replace
-  path: /spec/template/spec/containers/1/resources/limits/cpu
-  value: "250m"

--- a/components/pipeline-service/production/stone-prd-m01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prd-m01/deploy.yaml
@@ -1370,7 +1370,7 @@ spec:
             secretKeyRef:
               key: db.name
               name: tekton-results-database
-        image: quay.io/redhat-appstudio/tekton-results-api:3429e667f92396aa273eb60c4212105ca2ffda9b
+        image: quay.io/redhat-appstudio/tekton-results-api:1c5b3054ffb52f172fda31587d7dfd88a9724c8f
         livenessProbe:
           httpGet:
             path: /healthz
@@ -1391,8 +1391,8 @@ spec:
             cpu: 100m
             memory: 512Mi
           requests:
-            cpu: 100m
-            memory: 512Mi
+            cpu: 5m
+            memory: 128Mi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -1416,6 +1416,52 @@ spec:
           readOnly: true
         - mountPath: /etc/tls
           name: tls
+          readOnly: true
+      initContainers:
+      - env:
+        - name: DB_USER
+          valueFrom:
+            secretKeyRef:
+              key: db.user
+              name: tekton-results-database
+        - name: DB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: db.password
+              name: tekton-results-database
+        - name: DB_HOST
+          valueFrom:
+            secretKeyRef:
+              key: db.host
+              name: tekton-results-database
+        - name: DB_NAME
+          valueFrom:
+            secretKeyRef:
+              key: db.name
+              name: tekton-results-database
+        image: quay.io/redhat-appstudio/tekton-results-migrator:1c5b3054ffb52f172fda31587d7dfd88a9724c8f
+        name: migrator
+        resources:
+          limits:
+            cpu: 100m
+            memory: 128Mi
+          requests:
+            cpu: 5m
+            memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            add:
+            - NET_BIND_SERVICE
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          seccompProfile:
+            type: RuntimeDefault
+        volumeMounts:
+        - mountPath: /etc/tekton/results
+          name: config
           readOnly: true
       serviceAccountName: tekton-results-api
       volumes:
@@ -1505,8 +1551,6 @@ spec:
         - -check_owner=false
         - -completed_run_grace_period
         - 10m
-        - -threadiness
-        - "32"
         env:
         - name: SYSTEM_NAMESPACE
           valueFrom:
@@ -1524,7 +1568,7 @@ spec:
           value: tekton-results-api-service.tekton-pipelines.svc.cluster.local:8080
         - name: AUTH_MODE
           value: token
-        image: quay.io/redhat-appstudio/tekton-results-watcher:3429e667f92396aa273eb60c4212105ca2ffda9b
+        image: quay.io/redhat-appstudio/tekton-results-watcher:1c5b3054ffb52f172fda31587d7dfd88a9724c8f
         name: watcher
         ports:
         - containerPort: 9090
@@ -1536,7 +1580,7 @@ spec:
             cpu: 250m
             memory: 3Gi
           requests:
-            cpu: 250m
+            cpu: 100m
             memory: 3Gi
         securityContext:
           allowPrivilegeEscalation: false
@@ -1662,6 +1706,14 @@ spec:
             # The secret should be created as immutable.
             echo "Generating k8s secret/$secret in $namespace with key-pair"
             env COSIGN_PASSWORD=$RANDOM_PASS cosign generate-key-pair "k8s://$namespace/$secret"
+          fi
+
+          # If the secret is not marked as immutable, make it so.
+          if [ "$(kubectl get secret "$secret" -n "$namespace" -o jsonpath='{.immutable}')" != "true" ]; then
+            echo "Making secret immutable"
+            kubectl patch secret "$secret" -n "$namespace" --dry-run=client -o yaml \
+              --patch='{"immutable": true}' \
+            | kubectl apply -f -
           fi
 
           echo "Generating/updating the secret with the public key"
@@ -1909,69 +1961,10 @@ spec:
         tekton-operator-proxy-webhook:
           spec:
             replicas: 2
-            template:
-              spec:
-                containers:
-                - name: proxy
-                  resources:
-                    limits:
-                      cpu: 500m
-                      memory: 500Mi
-                    requests:
-                      cpu: 100m
-                      memory: 100Mi
         tekton-pipelines-remote-resolvers:
           spec:
             replicas: 2
-        tekton-pipelines-webhook:
-          spec:
-            template:
-              spec:
-                containers:
-                - name: webhook
-                  resources:
-                    limits:
-                      cpu: "1"
-                      memory: 1Gi
-                    requests:
-                      cpu: 200m
-                      memory: 200Mi
       disabled: false
-      horizontalPodAutoscalers:
-        tekton-operator-proxy-webhook:
-          spec:
-            maxReplicas: 6
-            metrics:
-            - resource:
-                name: cpu
-                target:
-                  averageUtilization: 100
-                  type: Utilization
-              type: Resource
-            - resource:
-                name: memory
-                target:
-                  averageUtilization: 100
-                  type: Utilization
-              type: Resource
-            minReplicas: 2
-        tekton-pipelines-webhook:
-          spec:
-            maxReplicas: 6
-            metrics:
-            - resource:
-                name: cpu
-                target:
-                  averageUtilization: 100
-                  type: Utilization
-              type: Resource
-            - resource:
-                name: memory
-                target:
-                  averageUtilization: 100
-                  type: Utilization
-              type: Resource
-            minReplicas: 2
     performance:
       buckets: 4
       disable-ha: false

--- a/components/pipeline-service/production/stone-prd-rh01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prd-rh01/deploy.yaml
@@ -1370,7 +1370,7 @@ spec:
             secretKeyRef:
               key: db.name
               name: tekton-results-database
-        image: quay.io/redhat-appstudio/tekton-results-api:3429e667f92396aa273eb60c4212105ca2ffda9b
+        image: quay.io/redhat-appstudio/tekton-results-api:1c5b3054ffb52f172fda31587d7dfd88a9724c8f
         livenessProbe:
           httpGet:
             path: /healthz
@@ -1391,8 +1391,8 @@ spec:
             cpu: 100m
             memory: 512Mi
           requests:
-            cpu: 100m
-            memory: 512Mi
+            cpu: 5m
+            memory: 128Mi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -1416,6 +1416,52 @@ spec:
           readOnly: true
         - mountPath: /etc/tls
           name: tls
+          readOnly: true
+      initContainers:
+      - env:
+        - name: DB_USER
+          valueFrom:
+            secretKeyRef:
+              key: db.user
+              name: tekton-results-database
+        - name: DB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: db.password
+              name: tekton-results-database
+        - name: DB_HOST
+          valueFrom:
+            secretKeyRef:
+              key: db.host
+              name: tekton-results-database
+        - name: DB_NAME
+          valueFrom:
+            secretKeyRef:
+              key: db.name
+              name: tekton-results-database
+        image: quay.io/redhat-appstudio/tekton-results-migrator:1c5b3054ffb52f172fda31587d7dfd88a9724c8f
+        name: migrator
+        resources:
+          limits:
+            cpu: 100m
+            memory: 128Mi
+          requests:
+            cpu: 5m
+            memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            add:
+            - NET_BIND_SERVICE
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          seccompProfile:
+            type: RuntimeDefault
+        volumeMounts:
+        - mountPath: /etc/tekton/results
+          name: config
           readOnly: true
       serviceAccountName: tekton-results-api
       volumes:
@@ -1505,8 +1551,6 @@ spec:
         - -check_owner=false
         - -completed_run_grace_period
         - 10m
-        - -threadiness
-        - "32"
         env:
         - name: SYSTEM_NAMESPACE
           valueFrom:
@@ -1524,7 +1568,7 @@ spec:
           value: tekton-results-api-service.tekton-pipelines.svc.cluster.local:8080
         - name: AUTH_MODE
           value: token
-        image: quay.io/redhat-appstudio/tekton-results-watcher:3429e667f92396aa273eb60c4212105ca2ffda9b
+        image: quay.io/redhat-appstudio/tekton-results-watcher:1c5b3054ffb52f172fda31587d7dfd88a9724c8f
         name: watcher
         ports:
         - containerPort: 9090
@@ -1536,7 +1580,7 @@ spec:
             cpu: 250m
             memory: 3Gi
           requests:
-            cpu: 250m
+            cpu: 100m
             memory: 3Gi
         securityContext:
           allowPrivilegeEscalation: false
@@ -1662,6 +1706,14 @@ spec:
             # The secret should be created as immutable.
             echo "Generating k8s secret/$secret in $namespace with key-pair"
             env COSIGN_PASSWORD=$RANDOM_PASS cosign generate-key-pair "k8s://$namespace/$secret"
+          fi
+
+          # If the secret is not marked as immutable, make it so.
+          if [ "$(kubectl get secret "$secret" -n "$namespace" -o jsonpath='{.immutable}')" != "true" ]; then
+            echo "Making secret immutable"
+            kubectl patch secret "$secret" -n "$namespace" --dry-run=client -o yaml \
+              --patch='{"immutable": true}' \
+            | kubectl apply -f -
           fi
 
           echo "Generating/updating the secret with the public key"
@@ -1909,69 +1961,10 @@ spec:
         tekton-operator-proxy-webhook:
           spec:
             replicas: 2
-            template:
-              spec:
-                containers:
-                - name: proxy
-                  resources:
-                    limits:
-                      cpu: 500m
-                      memory: 500Mi
-                    requests:
-                      cpu: 100m
-                      memory: 100Mi
         tekton-pipelines-remote-resolvers:
           spec:
             replicas: 2
-        tekton-pipelines-webhook:
-          spec:
-            template:
-              spec:
-                containers:
-                - name: webhook
-                  resources:
-                    limits:
-                      cpu: "1"
-                      memory: 1Gi
-                    requests:
-                      cpu: 200m
-                      memory: 200Mi
       disabled: false
-      horizontalPodAutoscalers:
-        tekton-operator-proxy-webhook:
-          spec:
-            maxReplicas: 6
-            metrics:
-            - resource:
-                name: cpu
-                target:
-                  averageUtilization: 100
-                  type: Utilization
-              type: Resource
-            - resource:
-                name: memory
-                target:
-                  averageUtilization: 100
-                  type: Utilization
-              type: Resource
-            minReplicas: 2
-        tekton-pipelines-webhook:
-          spec:
-            maxReplicas: 6
-            metrics:
-            - resource:
-                name: cpu
-                target:
-                  averageUtilization: 100
-                  type: Utilization
-              type: Resource
-            - resource:
-                name: memory
-                target:
-                  averageUtilization: 100
-                  type: Utilization
-              type: Resource
-            minReplicas: 2
     performance:
       buckets: 4
       disable-ha: false

--- a/components/pipeline-service/production/stone-prod-p01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prod-p01/deploy.yaml
@@ -1370,7 +1370,7 @@ spec:
             secretKeyRef:
               key: db.name
               name: tekton-results-database
-        image: quay.io/redhat-appstudio/tekton-results-api:3429e667f92396aa273eb60c4212105ca2ffda9b
+        image: quay.io/redhat-appstudio/tekton-results-api:1c5b3054ffb52f172fda31587d7dfd88a9724c8f
         livenessProbe:
           httpGet:
             path: /healthz
@@ -1391,8 +1391,8 @@ spec:
             cpu: 100m
             memory: 512Mi
           requests:
-            cpu: 100m
-            memory: 512Mi
+            cpu: 5m
+            memory: 128Mi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -1416,6 +1416,52 @@ spec:
           readOnly: true
         - mountPath: /etc/tls
           name: tls
+          readOnly: true
+      initContainers:
+      - env:
+        - name: DB_USER
+          valueFrom:
+            secretKeyRef:
+              key: db.user
+              name: tekton-results-database
+        - name: DB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: db.password
+              name: tekton-results-database
+        - name: DB_HOST
+          valueFrom:
+            secretKeyRef:
+              key: db.host
+              name: tekton-results-database
+        - name: DB_NAME
+          valueFrom:
+            secretKeyRef:
+              key: db.name
+              name: tekton-results-database
+        image: quay.io/redhat-appstudio/tekton-results-migrator:1c5b3054ffb52f172fda31587d7dfd88a9724c8f
+        name: migrator
+        resources:
+          limits:
+            cpu: 100m
+            memory: 128Mi
+          requests:
+            cpu: 5m
+            memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            add:
+            - NET_BIND_SERVICE
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          seccompProfile:
+            type: RuntimeDefault
+        volumeMounts:
+        - mountPath: /etc/tekton/results
+          name: config
           readOnly: true
       serviceAccountName: tekton-results-api
       volumes:
@@ -1505,8 +1551,6 @@ spec:
         - -check_owner=false
         - -completed_run_grace_period
         - 10m
-        - -threadiness
-        - "32"
         env:
         - name: SYSTEM_NAMESPACE
           valueFrom:
@@ -1524,7 +1568,7 @@ spec:
           value: tekton-results-api-service.tekton-pipelines.svc.cluster.local:8080
         - name: AUTH_MODE
           value: token
-        image: quay.io/redhat-appstudio/tekton-results-watcher:3429e667f92396aa273eb60c4212105ca2ffda9b
+        image: quay.io/redhat-appstudio/tekton-results-watcher:1c5b3054ffb52f172fda31587d7dfd88a9724c8f
         name: watcher
         ports:
         - containerPort: 9090
@@ -1536,7 +1580,7 @@ spec:
             cpu: 250m
             memory: 3Gi
           requests:
-            cpu: 250m
+            cpu: 100m
             memory: 3Gi
         securityContext:
           allowPrivilegeEscalation: false
@@ -1662,6 +1706,14 @@ spec:
             # The secret should be created as immutable.
             echo "Generating k8s secret/$secret in $namespace with key-pair"
             env COSIGN_PASSWORD=$RANDOM_PASS cosign generate-key-pair "k8s://$namespace/$secret"
+          fi
+
+          # If the secret is not marked as immutable, make it so.
+          if [ "$(kubectl get secret "$secret" -n "$namespace" -o jsonpath='{.immutable}')" != "true" ]; then
+            echo "Making secret immutable"
+            kubectl patch secret "$secret" -n "$namespace" --dry-run=client -o yaml \
+              --patch='{"immutable": true}' \
+            | kubectl apply -f -
           fi
 
           echo "Generating/updating the secret with the public key"
@@ -1909,69 +1961,10 @@ spec:
         tekton-operator-proxy-webhook:
           spec:
             replicas: 2
-            template:
-              spec:
-                containers:
-                - name: proxy
-                  resources:
-                    limits:
-                      cpu: 500m
-                      memory: 500Mi
-                    requests:
-                      cpu: 100m
-                      memory: 100Mi
         tekton-pipelines-remote-resolvers:
           spec:
             replicas: 2
-        tekton-pipelines-webhook:
-          spec:
-            template:
-              spec:
-                containers:
-                - name: webhook
-                  resources:
-                    limits:
-                      cpu: "1"
-                      memory: 1Gi
-                    requests:
-                      cpu: 200m
-                      memory: 200Mi
       disabled: false
-      horizontalPodAutoscalers:
-        tekton-operator-proxy-webhook:
-          spec:
-            maxReplicas: 6
-            metrics:
-            - resource:
-                name: cpu
-                target:
-                  averageUtilization: 100
-                  type: Utilization
-              type: Resource
-            - resource:
-                name: memory
-                target:
-                  averageUtilization: 100
-                  type: Utilization
-              type: Resource
-            minReplicas: 2
-        tekton-pipelines-webhook:
-          spec:
-            maxReplicas: 6
-            metrics:
-            - resource:
-                name: cpu
-                target:
-                  averageUtilization: 100
-                  type: Utilization
-              type: Resource
-            - resource:
-                name: memory
-                target:
-                  averageUtilization: 100
-                  type: Utilization
-              type: Resource
-            minReplicas: 2
     performance:
       buckets: 4
       disable-ha: false


### PR DESCRIPTION
the autoscalers are not supported until 1.14 of the operator

This reverts commit 1819edc51b5fa7d6da26d2b747a5e9300b931a7d.