### PR TITLE
RHTAPSRE-431: Migrating Konflux Public Production (ArgoCD) to appsrep05ue1

### DIFF
--- a/argo-cd-apps/app-of-app-sets/konflux-public-production/change-source-path.yaml
+++ b/argo-cd-apps/app-of-app-sets/konflux-public-production/change-source-path.yaml
@@ -1,0 +1,4 @@
+---
+- op: replace
+  path: /spec/source/path
+  value: argo-cd-apps/overlays/konflux-public-production

--- a/argo-cd-apps/app-of-app-sets/konflux-public-production/change-target-namespace.yaml
+++ b/argo-cd-apps/app-of-app-sets/konflux-public-production/change-target-namespace.yaml
@@ -1,0 +1,4 @@
+---
+- op: replace
+  path: /spec/destination/namespace
+  value: konflux-public-production

--- a/argo-cd-apps/app-of-app-sets/konflux-public-production/kustomization.yaml
+++ b/argo-cd-apps/app-of-app-sets/konflux-public-production/kustomization.yaml
@@ -1,0 +1,16 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../base
+patches:
+  - path: change-source-path.yaml
+    target:
+      group: argoproj.io
+      version: v1alpha1
+      kind: Application
+  - path: change-target-namespace.yaml
+    target:
+      group: argoproj.io
+      version: v1alpha1
+      kind: Application
+namespace: konflux-public-production

--- a/argo-cd-apps/overlays/konflux-public-production/kustomization.yaml
+++ b/argo-cd-apps/overlays/konflux-public-production/kustomization.yaml
@@ -9,7 +9,7 @@ resources:
   - ../../base/cluster-secret-store-rh
   - ../../base/rh-managed-workspaces-config
 
-namespace: argocd
+namespace: konflux-public-production
 
 patches:
   - path: production-overlay-patch.yaml

--- a/argo-cd-apps/overlays/konflux-public-production/migration.patch.yaml
+++ b/argo-cd-apps/overlays/konflux-public-production/migration.patch.yaml
@@ -1,0 +1,2 @@
+- op: remove
+  path: /spec/template/spec/syncPolicy

--- a/argo-cd-apps/overlays/konflux-public-production/production-overlay-patch.yaml
+++ b/argo-cd-apps/overlays/konflux-public-production/production-overlay-patch.yaml
@@ -1,0 +1,4 @@
+---
+- op: add
+  path: /spec/generators/0/merge/generators/0/clusters/values/environment
+  value: production

--- a/argo-cd-apps/overlays/production/migration.patch.yaml
+++ b/argo-cd-apps/overlays/production/migration.patch.yaml
@@ -1,0 +1,2 @@
+- op: remove
+  path: /spec/template/spec/syncPolicy


### PR DESCRIPTION
This PR will make the following changes:
- [x] This creates another overlay  for migrating public production argocd instances to appsre managed cluster
- [x] This will disable the auto sync option for production argocd