### PR TITLE
fix(stoneinteg-761): update integration grafana dashboards 

### DIFF
--- a/components/monitoring/grafana/base/dashboards/integration/kustomization.yaml
+++ b/components/monitoring/grafana/base/dashboards/integration/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - https://github.com/redhat-appstudio/integration-service/config/grafana/?ref=741cb3cc24c649732d1bfb9ccc69f5f839a9a2ab
+  - https://github.com/redhat-appstudio/integration-service/config/grafana/?ref=93f0ff0a0ef11d491d249180f8380eba1d9abcce


### PR DESCRIPTION
A follow up to work done in [STONEINTG-761](https://issues.redhat.com/browse/STONEINTG-761) , 
metrics were removed from instagration-service grafana dashboard , 
this PR is about update the kustomization to point to latest integration-service 
