### PR TITLE
RHTAPSRE-431: enable auto sync for production argocd instance

### DIFF
--- a/argo-cd-apps/overlays/konflux-public-production/kustomization.yaml
+++ b/argo-cd-apps/overlays/konflux-public-production/kustomization.yaml
@@ -147,7 +147,3 @@ patches:
       kind: ApplicationSet
       version: v1alpha1
       name: smee
-  - path: migration.patch.yaml
-    target:
-      kind: ApplicationSet
-      version: v1alpha1

--- a/argo-cd-apps/overlays/konflux-public-production/migration.patch.yaml
+++ b/argo-cd-apps/overlays/konflux-public-production/migration.patch.yaml
@@ -1,2 +1,0 @@
-- op: remove
-  path: /spec/template/spec/syncPolicy


### PR DESCRIPTION
This pull request enables auto-sync for the production argocd instance running on `appresp05ue1` cluster and this will also remove older overlays `staging` and `production`