### PR TITLE
Increase memory of production build controller

### DIFF
--- a/components/build-service/production/base/increase-build-controller-memory.yaml
+++ b/components/build-service/production/base/increase-build-controller-memory.yaml
@@ -1,0 +1,4 @@
+---
+- op: replace
+  path: /spec/template/spec/containers/0/resources/limits/memory
+  value: "512Mi"

--- a/components/build-service/production/base/kustomization.yaml
+++ b/components/build-service/production/base/kustomization.yaml
@@ -22,3 +22,7 @@ patches:
       kind: ExternalSecret
       group: external-secrets.io
       version: v1beta1
+  - path: increase-build-controller-memory.yaml
+    target:
+      kind: Deployment
+      name: build-service-controller-manager


### PR DESCRIPTION
On rh01, the pod is getting OOMKilled. This change is temporary to increase the memory limit. Once we have the working number, the change will be done in build-service repository.