### PR TITLE
Revert sprayproxy migration

### DIFF
--- a/components/sprayproxy/production/kustomization.yaml
+++ b/components/sprayproxy/production/kustomization.yaml
@@ -2,13 +2,13 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../base
-  - https://github.com/konflux-ci/sprayproxy/config?ref=f1afe07688592565986ded70ca912d80629c04a0
+  - https://github.com/konflux-ci/sprayproxy/config?ref=2f488f7082df063350cc5a774b61ee3207481a9b
   - pipelines-as-code-secret.yaml
 
 images:
   - name: ko://github.com/konflux-ci/sprayproxy
-    newName: quay.io/konflux-ci/sprayproxy
-    newTag: f1afe07688592565986ded70ca912d80629c04a0
+    newName: quay.io/redhat-appstudio/sprayproxy
+    newTag: 2f488f7082df063350cc5a774b61ee3207481a9b
 
 patches:
   - path: change-backends.yaml

--- a/components/sprayproxy/staging/kustomization.yaml
+++ b/components/sprayproxy/staging/kustomization.yaml
@@ -2,13 +2,13 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../base
-  - https://github.com/konflux-ci/sprayproxy/config?ref=f1afe07688592565986ded70ca912d80629c04a0
+  - https://github.com/konflux-ci/sprayproxy/config?ref=2f488f7082df063350cc5a774b61ee3207481a9b
   - pipelines-as-code-secret.yaml
 
 images:
   - name: ko://github.com/konflux-ci/sprayproxy
-    newName: quay.io/konflux-ci/sprayproxy
-    newTag: f1afe07688592565986ded70ca912d80629c04a0
+    newName: quay.io/redhat-appstudio/sprayproxy
+    newTag: 2f488f7082df063350cc5a774b61ee3207481a9b
 
 patches:
   - path: change-backends.yaml


### PR DESCRIPTION
There is an issue pushing images to quay actually

``` 
Error: POST https://quay.io/v2/redhat-appstudio/pull-request-builds/blobs/uploads/: UNAUTHORIZED: access to the requested resource is not authorized; map[]
main.go:74: error during command execution: POST https://quay.io/v2/redhat-appstudio/pull-request-builds/blobs/uploads/: UNAUTHORIZED: access to the requested resource is not authorized; map[]
```

We suspect the issue coming from https://github.com/redhat-appstudio/infra-deployments/pull/3435
We trying to revert https://github.com/redhat-appstudio/infra-deployments/pull/3435 here https://github.com/redhat-appstudio/infra-deployments/pull/3469

If the revert is merged we should also revert this