### PR TITLE
adjust exporter mem to account for increased prod load

### DIFF
--- a/components/pipeline-service/production/base/bump-exporter-mem.yaml
+++ b/components/pipeline-service/production/base/bump-exporter-mem.yaml
@@ -1,7 +1,7 @@
 ---
 - op: replace
   path: /spec/template/spec/containers/0/resources/limits/memory
-  value: "2Gi"
+  value: "3Gi"
 - op: replace
   path: /spec/template/spec/containers/0/resources/requests/memory
-  value: "2Gi"
+  value: "3Gi"

--- a/components/pipeline-service/production/stone-prd-m01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prd-m01/deploy.yaml
@@ -1254,10 +1254,10 @@ spec:
         resources:
           limits:
             cpu: 500m
-            memory: 2Gi
+            memory: 3Gi
           requests:
             cpu: 250m
-            memory: 2Gi
+            memory: 3Gi
         securityContext:
           readOnlyRootFilesystem: true
           runAsNonRoot: true

--- a/components/pipeline-service/production/stone-prd-rh01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prd-rh01/deploy.yaml
@@ -1254,10 +1254,10 @@ spec:
         resources:
           limits:
             cpu: 500m
-            memory: 2Gi
+            memory: 3Gi
           requests:
             cpu: 250m
-            memory: 2Gi
+            memory: 3Gi
         securityContext:
           readOnlyRootFilesystem: true
           runAsNonRoot: true

--- a/components/pipeline-service/production/stone-prod-p01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prod-p01/deploy.yaml
@@ -1254,10 +1254,10 @@ spec:
         resources:
           limits:
             cpu: 500m
-            memory: 2Gi
+            memory: 3Gi
           requests:
             cpu: 250m
-            memory: 2Gi
+            memory: 3Gi
         securityContext:
           readOnlyRootFilesystem: true
           runAsNonRoot: true


### PR DESCRIPTION
monitoring exporter for the last few days, I still see GC occurring and memory reductions, but it simply day to day is closer to the current 2Gi memory limit than it used to be

rh-pre-commit.version: 2.2.0
rh-pre-commit.check-secrets: ENABLED