### PR TITLE
Configure ArgoCD to not prune signing-secrets secret

### DIFF
--- a/components/pipeline-service/base/external-secrets/openshift-pipelines/chains-signing-secrets.yaml
+++ b/components/pipeline-service/base/external-secrets/openshift-pipelines/chains-signing-secrets.yaml
@@ -17,3 +17,7 @@ spec:
   target:
     creationPolicy: Orphan
     name: signing-secrets
+    template:
+      metadata:
+        annotations:
+          argocd.argoproj.io/sync-options: Prune=false


### PR DESCRIPTION
We use Vault to store signing-secrets as a way to backup this secret and get it recreated on the cluster it its get deleted. To get it back in the cluster, ExternalSecret is used as usual to extract value from Vault and put in in signing-secrets secret.

Since this secret is created by created/managed by TektonInstallerSets, the ExternalSecret is configured to create the secret as orphan if it does not exists, meaning that it creates it without setting the owner reference so ES and TIS do not fight over the ownership.

Because ES is not setting ownership, the secret created was getting pruned by ArgoCD as soon as ES was creating it.

Fix this issue by adding the annotation
`argocd.argoproj.io/sync-options: Prune=false` to the secret being created by ES.