### PR TITLE
Create a new konflux-ci workspace, sibling of tekton-ci

### DIFF
--- a/argo-cd-apps/base/konflux-ci/konflux-ci.yaml
+++ b/argo-cd-apps/base/konflux-ci/konflux-ci.yaml
@@ -1,0 +1,50 @@
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: konflux-ci
+spec:
+  generators:
+    - merge:
+        mergeKeys:
+          - nameNormalized
+        generators:
+          - clusters:
+              values:
+                sourceRoot: components/konflux-ci
+                environment: staging
+                clusterDir: ""
+              selector:
+                matchLabels:
+                  appstudio.redhat.com/konflux-ci: "true"
+          - list:
+              elements: []
+  template:
+    metadata:
+      name: konflux-ci-{{nameNormalized}}
+    spec:
+      project: default
+      source:
+        path: '{{values.sourceRoot}}/{{values.environment}}/{{values.clusterDir}}'
+        repoURL: https://github.com/redhat-appstudio/infra-deployments.git
+        targetRevision: main
+      destination:
+        namespace: konflux-ci
+        server: '{{server}}'
+      ignoreDifferences:
+      - group: ""
+        kind: "ServiceAccount"
+        name: appstudio-pipeline
+        jqPathExpressions:
+        - .imagePullSecrets[] | select(.name | startswith("appstudio-pipeline-dockercfg"))
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
+        syncOptions:
+          - CreateNamespace=true
+        retry:
+          limit: -1
+          backoff:
+            duration: 10s
+            factor: 2
+            maxDuration: 3m

--- a/argo-cd-apps/base/konflux-ci/kustomization.yaml
+++ b/argo-cd-apps/base/konflux-ci/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- konflux-ci.yaml

--- a/argo-cd-apps/overlays/konflux-public-production/kustomization.yaml
+++ b/argo-cd-apps/overlays/konflux-public-production/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
   - ../../base/member
   - ../../base/all-clusters
   - ../../base/tekton-ci
+  - ../../base/konflux-ci
   - ../../base/tenants-config
   - ../../base/cluster-secret-store-rh
   - ../../base/rh-managed-workspaces-config
@@ -72,6 +73,11 @@ patches:
       kind: ApplicationSet
       version: v1alpha1
       name: tekton-ci
+  - path: production-overlay-patch.yaml
+    target:
+      kind: ApplicationSet
+      version: v1alpha1
+      name: konflux-ci
   - path: production-overlay-patch.yaml
     target:
       kind: ApplicationSet

--- a/argo-cd-apps/overlays/production-downstream/kustomization.yaml
+++ b/argo-cd-apps/overlays/production-downstream/kustomization.yaml
@@ -73,6 +73,11 @@ patches:
     target:
       kind: ApplicationSet
       version: v1alpha1
+      name: konflux-ci
+  - path: production-overlay-patch.yaml
+    target:
+      kind: ApplicationSet
+      version: v1alpha1
       name: image-controller
   - path: production-overlay-patch.yaml
     target:

--- a/components/build-templates/base/e2e/rolebinding.yaml
+++ b/components/build-templates/base/e2e/rolebinding.yaml
@@ -11,6 +11,9 @@ subjects:
 - kind: ServiceAccount
   name: appstudio-pipeline
   namespace: tekton-ci
+- kind: ServiceAccount
+  name: appstudio-pipeline
+  namespace: konflux-ci
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -24,11 +27,14 @@ subjects:
 - kind: ServiceAccount
   name: appstudio-pipeline
   namespace: tekton-ci
+- kind: ServiceAccount
+  name: appstudio-pipeline
+  namespace: konflux-ci
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name:  admin-buildpipelineselectors-from-tekton-ci-namespace
+  name:  admin-buildpipelineselectors-from-ci-namespaces
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -37,6 +43,9 @@ subjects:
 - kind: ServiceAccount
   name: appstudio-pipeline
   namespace: tekton-ci
+- kind: ServiceAccount
+  name: appstudio-pipeline
+  namespace: konflux-ci
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/components/cluster-secret-store/base/appsre-stonesoup-vault-secret-store.yaml
+++ b/components/cluster-secret-store/base/appsre-stonesoup-vault-secret-store.yaml
@@ -36,6 +36,7 @@ spec:
         - build-templates-e2e
         - build-service
         - tekton-ci
+        - konflux-ci
         - image-controller
         - multi-platform-controller
         - jvm-build-service

--- a/components/konflux-ci/base/appstudio-pipelines-runner-rolebinding.yaml
+++ b/components/konflux-ci/base/appstudio-pipelines-runner-rolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: appstudio-pipelines-runner-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: appstudio-pipelines-runner
+subjects:
+- kind: ServiceAccount
+  name: appstudio-pipeline
+  namespace: konflux-ci

--- a/components/konflux-ci/base/external-secrets/clair-in-ci-db-github-token.yaml
+++ b/components/konflux-ci/base/external-secrets/clair-in-ci-db-github-token.yaml
@@ -1,0 +1,20 @@
+
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: clair-in-ci-db-github-token
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  dataFrom:
+    - extract:
+        key: "production/integration-service/tekton-ci/clair-in-ci-db-github-token"
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: appsre-stonesoup-vault
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    name: clair-in-ci-db-github-token

--- a/components/konflux-ci/base/external-secrets/github-secret.yaml
+++ b/components/konflux-ci/base/external-secrets/github-secret.yaml
@@ -1,0 +1,19 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: github
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  dataFrom:
+    - extract:
+        key: "production/build/tekton-ci/github-read-only"
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: appsre-stonesoup-vault
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    name: github

--- a/components/konflux-ci/base/external-secrets/infra-deployments-pr-creator.yaml
+++ b/components/konflux-ci/base/external-secrets/infra-deployments-pr-creator.yaml
@@ -1,0 +1,19 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: infra-deployments-pr-creator
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  dataFrom:
+    - extract:
+        key: staging/build/tekton-ci/infra-deployments-pr-creator
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: appsre-stonesoup-vault
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    name: infra-deployments-pr-creator

--- a/components/konflux-ci/base/external-secrets/kustomization.yaml
+++ b/components/konflux-ci/base/external-secrets/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- quay-push-secret.yaml
+- quay-push-secret-konflux-ci.yaml
+- infra-deployments-pr-creator.yaml
+- snyk-shared-token.yaml
+- slack-webhook-notification-secret.yaml
+- github-secret.yaml
+- clair-in-ci-db-github-token.yaml
+- registry-redhat-io-pull-secret.yaml
+namespace: konflux-ci

--- a/components/konflux-ci/base/external-secrets/quay-push-secret-konflux-ci.yaml
+++ b/components/konflux-ci/base/external-secrets/quay-push-secret-konflux-ci.yaml
@@ -1,0 +1,24 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: quay-push-secret-konflux-ci
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  dataFrom:
+    - extract:
+        key: staging/build/tekton-ci/quay-push-secret-konflux-ci
+  refreshInterval: 15m
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: appsre-stonesoup-vault
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    name: quay-push-secret-konflux-ci
+    template:
+      engineVersion: v2
+      type: kubernetes.io/dockerconfigjson
+      data:
+        .dockerconfigjson: "{{ .config }}"

--- a/components/konflux-ci/base/external-secrets/quay-push-secret.yaml
+++ b/components/konflux-ci/base/external-secrets/quay-push-secret.yaml
@@ -1,0 +1,24 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: quay-push-secret
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  dataFrom:
+    - extract:
+        key: staging/build/tekton-ci/quay-push-secret
+  refreshInterval: 15m
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: appsre-stonesoup-vault
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    name: quay-push-secret
+    template:
+      engineVersion: v2
+      type: kubernetes.io/dockerconfigjson
+      data:
+        .dockerconfigjson: "{{ .config }}"

--- a/components/konflux-ci/base/external-secrets/registry-redhat-io-pull-secret.yaml
+++ b/components/konflux-ci/base/external-secrets/registry-redhat-io-pull-secret.yaml
@@ -1,0 +1,24 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: registry-redhat-io-pull-secret
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  dataFrom:
+    - extract:
+        key: production/build/tekton-ci/registry-redhat-io-pull-secret
+  refreshInterval: 15m
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: appsre-stonesoup-vault
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    name: registry-redhat-io-pull-secret
+    template:
+      engineVersion: v2
+      type: kubernetes.io/dockerconfigjson
+      data:
+        .dockerconfigjson: "{{ .config }}"

--- a/components/konflux-ci/base/external-secrets/slack-webhook-notification-secret.yaml
+++ b/components/konflux-ci/base/external-secrets/slack-webhook-notification-secret.yaml
@@ -1,0 +1,19 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: slack-webhook-notification-secret
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  dataFrom:
+    - extract:
+        key: "production/build/tekton-ci/slack-webhook-notification-secret"
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: appsre-stonesoup-vault
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    name: slack-webhook-notification-secret

--- a/components/konflux-ci/base/external-secrets/snyk-shared-token.yaml
+++ b/components/konflux-ci/base/external-secrets/snyk-shared-token.yaml
@@ -1,0 +1,19 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: snyk-shared-token 
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  dataFrom:
+    - extract:
+        key: "staging/build/tekton-ci/snyk-shared-secret" # will be added by the overlays
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: appsre-stonesoup-vault
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    name: snyk-secret

--- a/components/konflux-ci/base/konflux-ci-maintainers-rb.yaml
+++ b/components/konflux-ci/base/konflux-ci-maintainers-rb.yaml
@@ -1,0 +1,13 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: konflux-ci-maintainers
+  namespace: konflux-ci
+subjects:
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: konflux-build
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: component-maintainer

--- a/components/konflux-ci/base/kustomization.yaml
+++ b/components/konflux-ci/base/kustomization.yaml
@@ -1,0 +1,15 @@
+resources:
+- namespace.yaml
+- serviceaccount.yaml
+- repository.yaml
+- konflux-ci-maintainers-rb.yaml
+- appstudio-pipelines-runner-rolebinding.yaml
+
+# Skip applying the Tekton/PaC operands while the Tekton/PaC operator is being installed.
+# See more information about this option, here: 
+# https://argo-cd.readthedocs.io/en/stable/user-guide/sync-options/#skip-dry-run-for-new-custom-resources-types 
+commonAnnotations:
+  argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization

--- a/components/konflux-ci/base/namespace.yaml
+++ b/components/konflux-ci/base/namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: konflux-ci
+  annotations:
+    # Keeps PipelineRuns for 24h.
+    operator.tekton.dev/prune.keep-since: 1440

--- a/components/konflux-ci/base/repository.yaml
+++ b/components/konflux-ci/base/repository.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: pipelinesascode.tekton.dev/v1alpha1
+kind: Repository
+metadata:
+  name: sprayproxy
+spec:
+  url: "https://github.com/konflux-ci/sprayproxy"

--- a/components/konflux-ci/base/serviceaccount.yaml
+++ b/components/konflux-ci/base/serviceaccount.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: appstudio-pipeline
+secrets:
+  - name: quay-push-secret
+  - name: registry-redhat-io-pull-secret
+imagePullSecrets:
+  - name: quay-push-secret
+  - name: registry-redhat-io-pull-secret

--- a/components/konflux-ci/production/infra-deployments-pr-creator.yaml
+++ b/components/konflux-ci/production/infra-deployments-pr-creator.yaml
@@ -1,0 +1,4 @@
+---
+- op: add
+  path: /spec/dataFrom/0/extract/key
+  value: production/build/tekton-ci/infra-deployments-pr-creator

--- a/components/konflux-ci/production/kustomization.yaml
+++ b/components/konflux-ci/production/kustomization.yaml
@@ -1,0 +1,33 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../base
+- ../base/external-secrets
+- plnsvc-ci-secret.yaml
+- plnsvc-codecov-secret.yaml
+
+patches:
+  - path: quay-push-secret.yaml
+    target:
+      name: quay-push-secret
+      kind: ExternalSecret
+      group: external-secrets.io
+      version: v1beta1
+  - path: quay-push-secret-konflux-ci.yaml
+    target:
+      name: quay-push-secret-konflux-ci
+      kind: ExternalSecret
+      group: external-secrets.io
+      version: v1beta1
+  - path: infra-deployments-pr-creator.yaml
+    target:
+      name: infra-deployments-pr-creator
+      kind: ExternalSecret
+      group: external-secrets.io
+      version: v1beta1
+  - path: snyk-shared-token.yaml
+    target:
+      name: snyk-shared-token
+      kind: ExternalSecret
+      group: external-secrets.io
+      version: v1beta1

--- a/components/konflux-ci/production/plnsvc-ci-secret.yaml
+++ b/components/konflux-ci/production/plnsvc-ci-secret.yaml
@@ -1,0 +1,19 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: plnsvc-ci-secret
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  dataFrom:
+    - extract:
+        key: production/pipeline-service/plnsvc-ci
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: appsre-stonesoup-vault
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    name: plnsvc-ci-secret

--- a/components/konflux-ci/production/plnsvc-codecov-secret.yaml
+++ b/components/konflux-ci/production/plnsvc-codecov-secret.yaml
@@ -1,0 +1,19 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: plnsvc-codecov-secret
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  dataFrom:
+    - extract:
+        key: production/pipeline-service/codecov
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: appsre-stonesoup-vault
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    name: plnsvc-codecov-secret

--- a/components/konflux-ci/production/quay-push-secret-konflux-ci.yaml
+++ b/components/konflux-ci/production/quay-push-secret-konflux-ci.yaml
@@ -1,0 +1,4 @@
+---
+- op: add
+  path: /spec/dataFrom/0/extract/key
+  value: production/build/tekton-ci/quay-push-secret-konflux-ci

--- a/components/konflux-ci/production/quay-push-secret.yaml
+++ b/components/konflux-ci/production/quay-push-secret.yaml
@@ -1,0 +1,4 @@
+---
+- op: add
+  path: /spec/dataFrom/0/extract/key
+  value: production/build/tekton-ci/quay-push-secret

--- a/components/konflux-ci/production/snyk-shared-token.yaml
+++ b/components/konflux-ci/production/snyk-shared-token.yaml
@@ -1,0 +1,4 @@
+---
+- op: add
+  path: /spec/dataFrom/0/extract/key
+  value: production/build/tekton-ci/snyk-shared-secret 

--- a/components/konflux-ci/staging/kustomization.yaml
+++ b/components/konflux-ci/staging/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../base
+- ../base/external-secrets

--- a/components/pipeline-service/production/stone-prd-m01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prd-m01/deploy.yaml
@@ -1629,7 +1629,7 @@ spec:
               set -o errexit
               set -o nounset
               set -o pipefail
-              for namespace in $(kubectl get namespaces -o name | cut -d/ -f2 | grep -E "\\-tenant$|^tekton-ci$"); do
+              for namespace in $(kubectl get namespaces -o name | cut -d/ -f2 | grep -E "\\-tenant$|^tekton-ci$|^konflux-ci$"); do
                 echo "$namespace: Cleaning pac-gitauth secrets"
                 kubectl get secrets --namespace $namespace -o json | \
                   jq -r '.items[] |

--- a/components/pipeline-service/production/stone-prd-rh01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prd-rh01/deploy.yaml
@@ -1629,7 +1629,7 @@ spec:
               set -o errexit
               set -o nounset
               set -o pipefail
-              for namespace in $(kubectl get namespaces -o name | cut -d/ -f2 | grep -E "\\-tenant$|^tekton-ci$"); do
+              for namespace in $(kubectl get namespaces -o name | cut -d/ -f2 | grep -E "\\-tenant$|^tekton-ci$|^konflux-ci$"); do
                 echo "$namespace: Cleaning pac-gitauth secrets"
                 kubectl get secrets --namespace $namespace -o json | \
                   jq -r '.items[] |

--- a/components/pipeline-service/production/stone-prod-p01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prod-p01/deploy.yaml
@@ -1629,7 +1629,7 @@ spec:
               set -o errexit
               set -o nounset
               set -o pipefail
-              for namespace in $(kubectl get namespaces -o name | cut -d/ -f2 | grep -E "\\-tenant$|^tekton-ci$"); do
+              for namespace in $(kubectl get namespaces -o name | cut -d/ -f2 | grep -E "\\-tenant$|^tekton-ci$|^konflux-ci$"); do
                 echo "$namespace: Cleaning pac-gitauth secrets"
                 kubectl get secrets --namespace $namespace -o json | \
                   jq -r '.items[] |

--- a/components/pipeline-service/staging/stone-stage-p01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stage-p01/deploy.yaml
@@ -1588,7 +1588,7 @@ spec:
               set -o errexit
               set -o nounset
               set -o pipefail
-              for namespace in $(kubectl get namespaces -o name | cut -d/ -f2 | grep -E "\\-tenant$|^tekton-ci$"); do
+              for namespace in $(kubectl get namespaces -o name | cut -d/ -f2 | grep -E "\\-tenant$|^tekton-ci$|^konflux-ci$"); do
                 echo "$namespace: Cleaning pac-gitauth secrets"
                 kubectl get secrets --namespace $namespace -o json | \
                   jq -r '.items[] |

--- a/components/pipeline-service/staging/stone-stg-m01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stg-m01/deploy.yaml
@@ -1588,7 +1588,7 @@ spec:
               set -o errexit
               set -o nounset
               set -o pipefail
-              for namespace in $(kubectl get namespaces -o name | cut -d/ -f2 | grep -E "\\-tenant$|^tekton-ci$"); do
+              for namespace in $(kubectl get namespaces -o name | cut -d/ -f2 | grep -E "\\-tenant$|^tekton-ci$|^konflux-ci$"); do
                 echo "$namespace: Cleaning pac-gitauth secrets"
                 kubectl get secrets --namespace $namespace -o json | \
                   jq -r '.items[] |

--- a/components/pipeline-service/staging/stone-stg-rh01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stg-rh01/deploy.yaml
@@ -1588,7 +1588,7 @@ spec:
               set -o errexit
               set -o nounset
               set -o pipefail
-              for namespace in $(kubectl get namespaces -o name | cut -d/ -f2 | grep -E "\\-tenant$|^tekton-ci$"); do
+              for namespace in $(kubectl get namespaces -o name | cut -d/ -f2 | grep -E "\\-tenant$|^tekton-ci$|^konflux-ci$"); do
                 echo "$namespace: Cleaning pac-gitauth secrets"
                 kubectl get secrets --namespace $namespace -o json | \
                   jq -r '.items[] |

--- a/components/tekton-ci/base/repository.yaml
+++ b/components/tekton-ci/base/repository.yaml
@@ -79,13 +79,6 @@ spec:
 apiVersion: pipelinesascode.tekton.dev/v1alpha1
 kind: Repository
 metadata:
-  name: sprayproxy
-spec:
-  url: "https://github.com/konflux-ci/sprayproxy"
----
-apiVersion: pipelinesascode.tekton.dev/v1alpha1
-kind: Repository
-metadata:
   name: pipeline-service-exporter
 spec:
   url: "https://github.com/openshift-pipelines/pipeline-service-exporter"

--- a/docs/deployment/extending-the-service.md
+++ b/docs/deployment/extending-the-service.md
@@ -117,7 +117,7 @@ More examples of using Kustomize to drive deployments using GitOps can be [found
 ## Component testing and building of images
 
 [Pipelines as Code](https://pipelinesascode.com/) is deployed and available for testing and building of images.
-To test and run builds for a component, add your github repository to `components/tekton-ci/repository.yaml`.
+To test and run builds for a component, add your github repository to `components/tekton-ci/repository.yaml` if you want to publish to quay.io/redhat-appstudio or `components/konflux-ci/repository.yaml` if you want to publish to quay.io/konflux-ci.
 
 Target repository has to have installed GitHub app - [Red Hat Trusted App Pipeline](https://github.com/apps/red-hat-trusted-app-pipeline) and pipelineRuns created in `.tekton` folder, example [Build Service](https://github.com/redhat-appstudio/build-service/tree/main/.tekton). Target image repository in quay.io must exist and robot account `redhat-appstudio+production_tektonci` has to have `write` permission on the repository.
 


### PR DESCRIPTION
The goal is to be able to publish our own images to quay.io/konflux-ci as we migrate from quay.io/redhat-appstudio.

In previous changes, we attempted to load a konflux-ci push secret into the tekton-ci namespace. This worked for pushes of images (both secrets were available and the push task knew to select the right secret), but it appears that the "cosign attach" task does not know how to select the right secret.

In order to create a path for teams to start publishing to quay.io/konflux-ci, here we're creating a new namespace that will only contain the secret necessary to push to quay.io/konflux-ci. As teams migrate, they should disable their repository entry in the tekton-ci namespace and enable their repository in the konflux-ci namespace by editing the repository entries for each here in infra-deployments.