### PR TITLE
go back to 1 watcher replica, asses impact on prod-rh01 results RDS hang

### DIFF
--- a/components/pipeline-service/production/base/bump-results-watcher-replicas.yaml
+++ b/components/pipeline-service/production/base/bump-results-watcher-replicas.yaml
@@ -1,4 +1,4 @@
 - op: replace
   path: /spec/replicas
   # default pipeline-service setting is 1
-  value: 2
+  value: 1

--- a/components/pipeline-service/production/stone-prd-m01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prd-m01/deploy.yaml
@@ -1485,7 +1485,7 @@ metadata:
   name: tekton-results-watcher
   namespace: tekton-results
 spec:
-  replicas: 2
+  replicas: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: tekton-results-watcher

--- a/components/pipeline-service/production/stone-prd-rh01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prd-rh01/deploy.yaml
@@ -1485,7 +1485,7 @@ metadata:
   name: tekton-results-watcher
   namespace: tekton-results
 spec:
-  replicas: 2
+  replicas: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: tekton-results-watcher

--- a/components/pipeline-service/production/stone-prod-p01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prod-p01/deploy.yaml
@@ -1485,7 +1485,7 @@ metadata:
   name: tekton-results-watcher
   namespace: tekton-results
 spec:
-  replicas: 2
+  replicas: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: tekton-results-watcher


### PR DESCRIPTION
During triage of the prod-rh01 results RDS lock contention query hand issue, noticed for the first time since we enabled multiple watcher replicas that both replicas were processing objects, vs. one acting and the primary and processing object, and the other replica acting as a standby.

We could not find an instance of a pipeline run or task run being processed by both replicas, but there are too many to effectively search for.

Removing this variable of 2 replicas manipulating the same DB entries leading to the lock contention.

@hugares @sayan-biswas FYI

rh-pre-commit.version: 2.2.0
rh-pre-commit.check-secrets: ENABLED