### PR TITLE
Revert "Increase memory of production build controller"

### DIFF
--- a/components/build-service/production/base/increase-build-controller-memory.yaml
+++ b/components/build-service/production/base/increase-build-controller-memory.yaml
@@ -1,4 +1,0 @@
----
-- op: replace
-  path: /spec/template/spec/containers/0/resources/limits/memory
-  value: "512Mi"

--- a/components/build-service/production/base/kustomization.yaml
+++ b/components/build-service/production/base/kustomization.yaml
@@ -22,7 +22,3 @@ patches:
       kind: ExternalSecret
       group: external-secrets.io
       version: v1beta1
-  - path: increase-build-controller-memory.yaml
-    target:
-      kind: Deployment
-      name: build-service-controller-manager


### PR DESCRIPTION
Reverts redhat-appstudio/infra-deployments#3465 with increase memory workaround because newer version of Build Service with the memory limit changes has been released.