### PR TITLE
bump tekton results api pod resources

### DIFF
--- a/components/pipeline-service/production/base/bump-results-api-resources.yaml
+++ b/components/pipeline-service/production/base/bump-results-api-resources.yaml
@@ -1,0 +1,13 @@
+---
+- op: replace
+  path: /spec/template/spec/containers/1/resources/limits/memory
+  value: "1Gi"
+- op: replace
+  path: /spec/template/spec/containers/1/resources/requests/memory
+  value: "500Mi"
+- op: replace
+  path: /spec/template/spec/containers/1/resources/limits/cpu
+  value: "3000m"
+- op: replace
+  path: /spec/template/spec/containers/1/resources/requests/cpu
+  value: "1000m"

--- a/components/pipeline-service/production/base/kustomization.yaml
+++ b/components/pipeline-service/production/base/kustomization.yaml
@@ -43,3 +43,8 @@ patches:
       kind: Deployment
       namespace: tekton-results
       name: tekton-results-watcher
+  - path: bump-results-api-resources.yaml
+    target:
+      kind: Deployment
+      namespace: tekton-results
+      name: tekton-results-api

--- a/components/pipeline-service/production/stone-prd-m01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prd-m01/deploy.yaml
@@ -1388,11 +1388,11 @@ spec:
           periodSeconds: 10
         resources:
           limits:
-            cpu: 100m
-            memory: 512Mi
+            cpu: 3000m
+            memory: 1Gi
           requests:
-            cpu: 5m
-            memory: 128Mi
+            cpu: 1000m
+            memory: 500Mi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/components/pipeline-service/production/stone-prd-rh01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prd-rh01/deploy.yaml
@@ -1388,11 +1388,11 @@ spec:
           periodSeconds: 10
         resources:
           limits:
-            cpu: 100m
-            memory: 512Mi
+            cpu: 3000m
+            memory: 1Gi
           requests:
-            cpu: 5m
-            memory: 128Mi
+            cpu: 1000m
+            memory: 500Mi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/components/pipeline-service/production/stone-prod-p01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prod-p01/deploy.yaml
@@ -1388,11 +1388,11 @@ spec:
           periodSeconds: 10
         resources:
           limits:
-            cpu: 100m
-            memory: 512Mi
+            cpu: 3000m
+            memory: 1Gi
           requests:
-            cpu: 5m
-            memory: 128Mi
+            cpu: 1000m
+            memory: 500Mi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:


### PR DESCRIPTION
- set limits CPU to 3000m and memory 1Gi
- set request CPU to 1000m and memory 500Mi

Signed-off-by: Avinal Kumar <avinal@redhat.com>

rh-pre-commit.version: 2.2.0
rh-pre-commit.check-secrets: ENABLED
