### PR TITLE
feat(STONEINTG-844): add configuration template of task URL

### DIFF
--- a/components/integration/development/kustomization.yaml
+++ b/components/integration/development/kustomization.yaml
@@ -14,6 +14,7 @@ configMapGenerator:
 - name: console-url
   literals:
     - CONSOLE_URL=""
+    - CONSOLE_URL_TASKLOG=""
 
 namespace: integration-service
 

--- a/components/integration/development/manager_resources_patch.yaml
+++ b/components/integration/development/manager_resources_patch.yaml
@@ -22,3 +22,9 @@ spec:
                 name: console-url
                 key: CONSOLE_URL
                 optional: true
+        - name: CONSOLE_URL_TASKLOG
+          valueFrom:
+            configMapKeyRef:
+              name: console-url
+              key: CONSOLE_URL_TASKLOG
+              optional: true

--- a/components/integration/production/base/kustomization.yaml
+++ b/components/integration/production/base/kustomization.yaml
@@ -15,6 +15,7 @@ configMapGenerator:
 - name: console-url
   literals:
     - CONSOLE_URL="https://console.redhat.com/preview/application-pipeline/ns/{{ .Namespace }}/pipelinerun/{{ .PipelineRunName }}"
+    - CONSOLE_URL_TASKLOG=""="https://console.redhat.com/preview/application-pipeline/ns/{{ .Namespace }}/pipelinerun/{{ .PipelineRunName }}/logs/{{ .TaskName }}"
 
 namespace: integration-service
 

--- a/components/integration/production/base/manager_resources_patch.yaml
+++ b/components/integration/production/base/manager_resources_patch.yaml
@@ -22,3 +22,9 @@ spec:
                 name: console-url
                 key: CONSOLE_URL
                 optional: true
+        - name: CONSOLE_URL_TASKLOG
+          valueFrom:
+            configMapKeyRef:
+              name: console-url
+              key: CONSOLE_URL_TASKLOG
+              optional: true

--- a/components/integration/production/stone-prod-p01/console-url-config-patch.json
+++ b/components/integration/production/stone-prod-p01/console-url-config-patch.json
@@ -1,0 +1,12 @@
+[
+  {
+    "op": "replace",
+    "path": "/data/CONSOLE_URL",
+    "value": "https://konflux.apps.stone-prod-p01.wcfb.p1.openshiftapps.com/ns/{{ .Namespace }}/pipelinerun/{{ .PipelineRunName }}"
+  },
+  {
+    "op": "replace",
+    "path": "/data/CONSOLE_URL_TASKLOG",
+    "value": "https://konflux.apps.stone-prod-p01.wcfb.p1.openshiftapps.com/ns/{{ .Namespace }}/pipelinerun/{{ .PipelineRunName }}/logs/{{ .TaskName }}"
+  }
+]

--- a/components/integration/production/stone-prod-p01/kustomization.yaml
+++ b/components/integration/production/stone-prod-p01/kustomization.yaml
@@ -9,6 +9,10 @@ patches:
       group: external-secrets.io
       version: v1beta1
       kind: ExternalSecret
+  - path: console-url-config-patch.json
+    target:
+      kind: ConfigMap
+      name: console-url
 components:
   - ../../rh-certs
 

--- a/components/integration/staging/base/kustomization.yaml
+++ b/components/integration/staging/base/kustomization.yaml
@@ -15,6 +15,7 @@ configMapGenerator:
 - name: console-url
   literals:
     - CONSOLE_URL="https://console.dev.redhat.com/preview/application-pipeline/ns/{{ .Namespace }}/pipelinerun/{{ .PipelineRunName }}"
+    - CONSOLE_URL_TASKLOG="https://console.dev.redhat.com/preview/application-pipeline/ns/{{ .Namespace }}/pipelinerun/{{ .PipelineRunName }}/logs/{{ .TaskName }}"
 
 namespace: integration-service
 

--- a/components/integration/staging/base/manager_resources_patch.yaml
+++ b/components/integration/staging/base/manager_resources_patch.yaml
@@ -22,3 +22,9 @@ spec:
                 name: console-url
                 key: CONSOLE_URL
                 optional: true
+        - name: CONSOLE_URL_TASKLOG
+          valueFrom:
+            configMapKeyRef:
+              name: console-url
+              key: CONSOLE_URL_TASKLOG
+              optional: true

--- a/components/integration/staging/stone-stage-p01/console-url-config-patch.json
+++ b/components/integration/staging/stone-stage-p01/console-url-config-patch.json
@@ -1,0 +1,12 @@
+[
+  {
+    "op": "replace",
+    "path": "/data/CONSOLE_URL",
+    "value": "https://rhtap.apps.rosa.stone-stage-p01.apys.p3.openshiftapps.com/application-pipeline/ns/{{ .Namespace }}/pipelinerun/{{ .PipelineRunName }}"
+  },
+  {
+    "op": "replace",
+    "path": "/data/CONSOLE_URL_TASKLOG",
+    "value": "https://rhtap.apps.rosa.stone-stage-p01.apys.p3.openshiftapps.com/application-pipeline/ns/{{ .Namespace }}/pipelinerun/{{ .PipelineRunName }}/logs/{{ .TaskName }}"
+  }
+]

--- a/components/integration/staging/stone-stage-p01/kustomization.yaml
+++ b/components/integration/staging/stone-stage-p01/kustomization.yaml
@@ -9,6 +9,10 @@ patches:
       group: external-secrets.io
       version: v1beta1
       kind: ExternalSecret
+  - path: console-url-config-patch.json
+    target:
+      kind: ConfigMap
+      name: console-url
 components:
   - ../../rh-certs
 


### PR DESCRIPTION
* Adds a new configuration template of task URL to a new envvar so it can be used by integration service
* Override the default stage console URL configuration to account for the different console base URL