### PR TITLE
KFLUXBUGS-24: bump dev/stage overlay chains deployment to use performance arguments

### DIFF
--- a/components/pipeline-service/development/chains-deployment-perf-bump.yaml
+++ b/components/pipeline-service/development/chains-deployment-perf-bump.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: operator.tekton.dev/v1alpha1
+kind: TektonConfig
+metadata:
+  name: config
+spec:
+  chain:
+    options:
+      deployments:
+        tekton-chains-controller:
+          spec:
+            template:
+              spec:
+                containers:
+                  - name: tekton-chains-controller
+                    args:
+                      [
+                        '--threads-per-controller=32',
+                        '--kube-api-qps=50',
+                        '--kube-api-burst=50',
+                      ]

--- a/components/pipeline-service/development/kustomization.yaml
+++ b/components/pipeline-service/development/kustomization.yaml
@@ -13,6 +13,10 @@ resources:
   - ../base/rbac
 
 patches:
+  - path: chains-deployment-perf-bump.yaml
+    target:
+      kind: TektonConfig
+      name: config
   - path: metrics-exporter-trace.yaml
     target:
       kind: Deployment

--- a/components/pipeline-service/staging/base/chains-deployment-perf-bump.yaml
+++ b/components/pipeline-service/staging/base/chains-deployment-perf-bump.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: operator.tekton.dev/v1alpha1
+kind: TektonConfig
+metadata:
+  name: config
+spec:
+  chain:
+    options:
+      deployments:
+        tekton-chains-controller:
+          spec:
+            template:
+              spec:
+                containers:
+                  - name: tekton-chains-controller
+                    args:
+                      [
+                        '--threads-per-controller=32',
+                        '--kube-api-qps=50',
+                        '--kube-api-burst=50',
+                      ]

--- a/components/pipeline-service/staging/base/kustomization.yaml
+++ b/components/pipeline-service/staging/base/kustomization.yaml
@@ -15,6 +15,10 @@ resources:
   - ../../base/rbac
 
 patches:
+  - path: chains-deployment-perf-bump.yaml
+    target:
+      kind: TektonConfig
+      name: config
   - path: metrics-exporter-trace.yaml
     target:
       kind: Deployment

--- a/components/pipeline-service/staging/stone-stage-p01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stage-p01/deploy.yaml
@@ -1853,6 +1853,18 @@ spec:
     artifacts.pipelinerun.storage: oci
     artifacts.taskrun.format: in-toto
     artifacts.taskrun.storage: ""
+    options:
+      deployments:
+        tekton-chains-controller:
+          spec:
+            template:
+              spec:
+                containers:
+                - args:
+                  - --threads-per-controller=32
+                  - --kube-api-qps=50
+                  - --kube-api-burst=50
+                  name: tekton-chains-controller
     transparency.enabled: "false"
   params:
   - name: createRbacResource

--- a/components/pipeline-service/staging/stone-stg-m01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stg-m01/deploy.yaml
@@ -1853,6 +1853,18 @@ spec:
     artifacts.pipelinerun.storage: oci
     artifacts.taskrun.format: in-toto
     artifacts.taskrun.storage: ""
+    options:
+      deployments:
+        tekton-chains-controller:
+          spec:
+            template:
+              spec:
+                containers:
+                - args:
+                  - --threads-per-controller=32
+                  - --kube-api-qps=50
+                  - --kube-api-burst=50
+                  name: tekton-chains-controller
     transparency.enabled: "false"
   params:
   - name: createRbacResource

--- a/components/pipeline-service/staging/stone-stg-rh01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stg-rh01/deploy.yaml
@@ -1853,6 +1853,18 @@ spec:
     artifacts.pipelinerun.storage: oci
     artifacts.taskrun.format: in-toto
     artifacts.taskrun.storage: ""
+    options:
+      deployments:
+        tekton-chains-controller:
+          spec:
+            template:
+              spec:
+                containers:
+                - args:
+                  - --threads-per-controller=32
+                  - --kube-api-qps=50
+                  - --kube-api-burst=50
+                  name: tekton-chains-controller
     transparency.enabled: "false"
   params:
   - name: createRbacResource


### PR DESCRIPTION
I'm not sure if these new args are just ignored, or rejected as invalid, if we don't have a version of chains installed that actually processes them.  We should find out with the e2e's, as I've updated the developer overlay with this change

But if it does cause a failure, then getting the correct openshift pipelines version will serve as the verification that everything is correct

FYI I duplicated the policy we use for core tekton controller, which comes from https://github.com/tektoncd/pipeline/blob/main/docs/tekton-controller-performance-configuration.md 

@lcarva @enarha @rupalibehera  FYI / PTAL

rh-pre-commit.version: 2.2.0
rh-pre-commit.check-secrets: ENABLED