### PR TITLE
RHTAPSRE-353: RBAC for creating workspaces in internal clusters

### DIFF
--- a/argo-cd-apps/base/keycloak/keycloak.yaml
+++ b/argo-cd-apps/base/keycloak/keycloak.yaml
@@ -1,0 +1,49 @@
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: keycloak
+spec:
+  generators:
+    - merge:
+        mergeKeys:
+          - nameNormalized
+        generators:
+          - clusters:
+              values:
+                sourceRoot: components/keycloak
+                environment: staging
+                clusterDir: base
+              selector:
+                matchLabels:
+                  appstudio.redhat.com/internal-member-cluster: "true"
+          - list:
+              elements: []
+  template:
+    metadata:
+      name: keycloak-{{nameNormalized}}
+    spec:
+      project: default
+      source:
+        path: '{{values.sourceRoot}}/{{values.environment}}/{{values.clusterDir}}'
+        repoURL: https://github.com/redhat-appstudio/infra-deployments.git
+        targetRevision: main
+      destination:
+        namespace: rhtap-auth
+        server: '{{server}}'
+      ignoreDifferences:
+        - group: keycloak.org
+          kind: KeycloakRealm
+          jsonPointers:
+            - /spec/realm/identityProviders/0/config/clientSecret
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
+        syncOptions:
+          - CreateNamespace=true
+        retry:
+          limit: -1
+          backoff:
+            duration: 10s
+            factor: 2
+            maxDuration: 3m

--- a/argo-cd-apps/base/keycloak/kustomization.yaml
+++ b/argo-cd-apps/base/keycloak/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- keycloak.yaml
+components:
+  - ../../k-components/inject-infra-deployments-repo-details

--- a/argo-cd-apps/overlays/production-downstream/kustomization.yaml
+++ b/argo-cd-apps/overlays/production-downstream/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
   - ../../base/smee-client
   - ../../base/ui
   - ../../base/ca-bundle
+  - ../../base/keycloak
 patchesStrategicMerge:
   - delete-applications.yaml
 namespace: argocd
@@ -159,3 +160,8 @@ patches:
       kind: ApplicationSet
       version: v1alpha1
       name: ca-bundle
+  - path: production-overlay-patch.yaml
+    target:
+      kind: ApplicationSet
+      version: v1alpha1
+      name: keycloak

--- a/argo-cd-apps/overlays/staging-downstream/kustomization.yaml
+++ b/argo-cd-apps/overlays/staging-downstream/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - ../../base/smee-client
   - ../../base/ui
   - ../../base/ca-bundle
+  - ../../base/keycloak
 patchesStrategicMerge:
   - delete-applications.yaml
 patches:

--- a/components/keycloak/base/konflux-workspace-admins/kustomization.yaml
+++ b/components/keycloak/base/konflux-workspace-admins/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - rbac.yaml
+namespace: rhtap-auth

--- a/components/keycloak/base/konflux-workspace-admins/rbac.yaml
+++ b/components/keycloak/base/konflux-workspace-admins/rbac.yaml
@@ -1,0 +1,30 @@
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: workspaces-manager
+rules:
+  - apiGroups:
+      - keycloak.org
+    resources:
+      - keycloakusers
+    verbs:
+      - get
+      - list
+      - update
+      - patch
+      - create
+      - delete
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: konflux-workspace-admins
+subjects:
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: konflux-workspace-admins
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: workspaces-manager

--- a/components/keycloak/base/kustomization.yaml
+++ b/components/keycloak/base/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - konflux-workspace-admins
+namespace: rhtap-auth

--- a/components/keycloak/production/base/kustomization.yaml
+++ b/components/keycloak/production/base/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base/konflux-workspace-admins

--- a/components/keycloak/staging/base/kustomization.yaml
+++ b/components/keycloak/staging/base/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base/konflux-workspace-admins


### PR DESCRIPTION
For creating new workspaces in the internal cluster a keycloak user should be created. Provide the permissions to manage keycloak users to the `konflux-workspace-admins` group.