### PR TITLE
fix(stoneinteg-761): update tag for integration grafana dashboard

### DIFF
--- a/components/monitoring/grafana/base/dashboards/integration/kustomization.yaml
+++ b/components/monitoring/grafana/base/dashboards/integration/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - https://github.com/redhat-appstudio/integration-service/config/grafana/?ref=93f0ff0a0ef11d491d249180f8380eba1d9abcce
+  - https://github.com/redhat-appstudio/integration-service/config/grafana/?ref=c25c29fb82da14a96095e3aeba6f0d17ee062f6c


### PR DESCRIPTION
Following to [STONEINTG-761](https://issues.redhat.com/browse/STONEINTG-761) , this is to update integration grafana pointing to the  latest integration-service 