### PR TITLE
Remove capacityThresholds from the ToolchainConfig on staging

### DIFF
--- a/components/sandbox/toolchain-host-operator/staging/stone-stage-p01/toolchainconfig.yaml
+++ b/components/sandbox/toolchain-host-operator/staging/stone-stage-p01/toolchainconfig.yaml
@@ -12,9 +12,6 @@ spec:
         defaultSpaceTier: 'appstudio'
       automaticApproval:
         enabled: true
-      capacityThresholds:
-        resourceCapacityThreshold:
-          defaultThreshold: 90
       spaceConfig:
         spaceRequestEnabled: true
         spaceBindingRequestEnabled: true

--- a/components/sandbox/toolchain-host-operator/staging/stone-stg-host/toolchainconfig.yaml
+++ b/components/sandbox/toolchain-host-operator/staging/stone-stg-host/toolchainconfig.yaml
@@ -11,12 +11,6 @@ spec:
         defaultSpaceTier: 'appstudio'
       automaticApproval:
         enabled: true
-      capacityThresholds:
-        maxNumberOfSpacesPerMemberCluster:
-          member-stone-stg-m01.7ayg.p1.openshiftapps.com: 1500
-          member-stone-stg-rh01.l2vh.p1.openshiftapps.com: -1 # Only manual re-targeting to this cluster is allowed
-        resourceCapacityThreshold:
-          defaultThreshold: 90
       spaceConfig:
         spaceRequestEnabled: true
         spaceBindingRequestEnabled: true


### PR DESCRIPTION
This has been replaced by the dedicated SpaceProvisionerConfig CRs and is being removed from the ToolchainConfig CRD altogether.


Note that the deployed version of the sandbox host operator no longer uses this configuration and only looks at the configuration provided by the SpaceProvisionerConfig so this should be safe to do. Nevertheless, this PR only updates the staging cluster configuration and if all goes well, the same can be applied to prod.

There is a separate PR doing the same thing on prod: https://github.com/redhat-appstudio/infra-deployments/pull/3517