### PR TITLE
Replace rhtap-infra by konflux-infra email

### DIFF
--- a/components/sandbox/toolchain-host-operator/production/stone-prd-host1/toolchainconfig.yaml
+++ b/components/sandbox/toolchain-host-operator/production/stone-prd-host1/toolchainconfig.yaml
@@ -23,7 +23,7 @@ spec:
     deactivation:
       deactivationDomainsExcluded: '@redhat.com'
     notifications:
-      adminEmail: rhtap-infra@redhat.com
+      adminEmail: konflux-infra@redhat.com
       secret:
         mailgunAPIKey: mailgun.api.key
         mailgunDomain: mailgun.domain

--- a/components/sandbox/toolchain-host-operator/production/stone-prod-p01/toolchainconfig.yaml
+++ b/components/sandbox/toolchain-host-operator/production/stone-prod-p01/toolchainconfig.yaml
@@ -20,7 +20,7 @@ spec:
     deactivation:
       deactivationDomainsExcluded: '@redhat.com'
     notifications:
-      adminEmail: rhtap-infra@redhat.com
+      adminEmail: konflux-infra@redhat.com
       secret:
         mailgunAPIKey: mailgun.api.key
         mailgunDomain: mailgun.domain

--- a/components/sandbox/toolchain-host-operator/staging/stone-stage-p01/toolchainconfig.yaml
+++ b/components/sandbox/toolchain-host-operator/staging/stone-stage-p01/toolchainconfig.yaml
@@ -21,7 +21,7 @@ spec:
       deactivation:
         deactivationDomainsExcluded: '@redhat.com'
       notifications:
-        adminEmail: rhtap-infra@redhat.com
+        adminEmail: konflux-infra@redhat.com
         secret:
           mailgunAPIKey: mailgun.api.key
           mailgunDomain: mailgun.domain

--- a/components/sandbox/toolchain-host-operator/staging/stone-stg-host/toolchainconfig.yaml
+++ b/components/sandbox/toolchain-host-operator/staging/stone-stg-host/toolchainconfig.yaml
@@ -23,7 +23,7 @@ spec:
       deactivation:
         deactivationDomainsExcluded: '@redhat.com'
       notifications:
-        adminEmail: rhtap-infra@redhat.com
+        adminEmail: konflux-infra@redhat.com
         secret:
           mailgunAPIKey: mailgun.api.key
           mailgunDomain: mailgun.domain


### PR DESCRIPTION
Use new email in toolchain config, former one will be decommissioned.

[KFLUXINFRA-423](https://issues.redhat.com//browse/KFLUXINFRA-423)