### PR TITLE
bump prod to staging level

### DIFF
--- a/components/pipeline-service/production/base/kustomization.yaml
+++ b/components/pipeline-service/production/base/kustomization.yaml
@@ -8,7 +8,7 @@ commonAnnotations:
   argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 
 resources:
-  - https://github.com/openshift-pipelines/pipeline-service.git/operator/gitops/argocd/pipeline-service?ref=542db3fcc168c426d39dbed231a4230b101f8a2a
+  - https://github.com/openshift-pipelines/pipeline-service.git/operator/gitops/argocd/pipeline-service?ref=e605798a3007da71f9d812273b97249a77b5635a
   - pipelines-as-code-secret.yaml # create external secret in openshift-pipelines namespace
   - ../../base/external-secrets
   - ../../base/testing

--- a/components/pipeline-service/production/stone-prd-m01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prd-m01/deploy.yaml
@@ -1204,7 +1204,7 @@ spec:
     spec:
       containers:
       - args: []
-        image: quay.io/redhat-appstudio/pipeline-service-exporter:c42b1b9defaa61937765610ab188b9e0552cae23
+        image: quay.io/redhat-appstudio/pipeline-service-exporter:2a5d2420d60643d685d860e3aa36824de715b9b8
         name: pipeline-metrics-exporter
         ports:
         - containerPort: 9117

--- a/components/pipeline-service/production/stone-prd-rh01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prd-rh01/deploy.yaml
@@ -1204,7 +1204,7 @@ spec:
     spec:
       containers:
       - args: []
-        image: quay.io/redhat-appstudio/pipeline-service-exporter:c42b1b9defaa61937765610ab188b9e0552cae23
+        image: quay.io/redhat-appstudio/pipeline-service-exporter:2a5d2420d60643d685d860e3aa36824de715b9b8
         name: pipeline-metrics-exporter
         ports:
         - containerPort: 9117

--- a/components/pipeline-service/production/stone-prod-p01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prod-p01/deploy.yaml
@@ -1204,7 +1204,7 @@ spec:
     spec:
       containers:
       - args: []
-        image: quay.io/redhat-appstudio/pipeline-service-exporter:c42b1b9defaa61937765610ab188b9e0552cae23
+        image: quay.io/redhat-appstudio/pipeline-service-exporter:2a5d2420d60643d685d860e3aa36824de715b9b8
         name: pipeline-metrics-exporter
         ports:
         - containerPort: 9117


### PR DESCRIPTION
These commits are technically included:

[fix wait_for_pipelines debug](https://github.com/openshift-pipelines/pipeline-service/commit/e605798a3007da71f9d812273b97249a77b5635a)
[Revert "add config for enabling tekton results dbssl"](https://github.com/openshift-pipelines/pipeline-service/commit/91776680abc5935af19695150f709421429bda85)
[update operator/gitops/argocd/pipeline-service/metrics-exporter/kustomization.yaml](https://github.com/openshift-pipelines/pipeline-service/commit/41ee6fe4915125880e1c8bb09f5892396da4cd2b)
[add config for enabling tekton results dbssl](https://github.com/openshift-pipelines/pipeline-service/commit/5e38cd44d8455e77def659ea116a684c5cfa4320)

But in reality all that is being changed is the version of the metrics exporter, as we had to revert Avinal's SSL change for the exchanges between th results api server and db since it was still non-functional in Konflux dev/stage/prod overlays vs. running in dev mode in pipeline service.

The other changes is a pipeline service CI only change

rh-pre-commit.version: 2.2.0
rh-pre-commit.check-secrets: ENABLED