### PR TITLE
Move stone-stg-m01 and stone-stg-rh01 authentication to rh-idp

### DIFF
--- a/argo-cd-apps/base/all-clusters/infra-deployments/authentication/authentication.yaml
+++ b/argo-cd-apps/base/all-clusters/infra-deployments/authentication/authentication.yaml
@@ -19,8 +19,6 @@ spec:
                   values.clusterDir: stone-stage-p01
                 - nameNormalized: stone-prod-p01
                   values.clusterDir: stone-prod-p01
-                - nameNormalized: stone-stg-host
-                  values.clusterDir: stone-stg-host
   template:
     metadata:
       name: authentication-{{nameNormalized}}

--- a/components/authentication/staging/base/kustomization.yaml
+++ b/components/authentication/staging/base/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ../../base/github
+  - ../../base/rh-idp

--- a/components/authentication/staging/stone-stg-host/kustomization.yaml
+++ b/components/authentication/staging/stone-stg-host/kustomization.yaml
@@ -1,4 +1,0 @@
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-resources:
-  - ../../base/rh-idp


### PR DESCRIPTION
RH sso is configured as an identity provider already on those clusters. Change the authentication component to use rh-idp folder instead of github which will sync the groups from rover instead of github.

Since all the clusters staging clusters now use rh-idp, change staging/base and get rid of special case for stone-stg-host.

[KFLUXINFRA-132](https://issues.redhat.com//browse/KFLUXINFRA-132)