### PR TITLE
KFLUXINFRA-471: Replacing stonesoupp01ue1 with appsrep05ue1 in Secret Paths

### DIFF
--- a/components/backup/production/stone-prd-host1/backup-s3-credentials-patch.yaml
+++ b/components/backup/production/stone-prd-host1/backup-s3-credentials-patch.yaml
@@ -1,3 +1,3 @@
 - op: replace
   path: /spec/dataFrom/0/extract/key
-  value: integrations-output/terraform-resources/stonesoupp01ue1/stonesoup-infra-prod-backup/backup-stone-prd-host1
+  value: integrations-output/terraform-resources/appsrep05ue1/stonesoup-infra-prod-backup/backup-stone-prd-host1

--- a/components/backup/production/stone-prd-m01/backup-s3-credentials-patch.yaml
+++ b/components/backup/production/stone-prd-m01/backup-s3-credentials-patch.yaml
@@ -1,3 +1,3 @@
 - op: replace
   path: /spec/dataFrom/0/extract/key
-  value: integrations-output/terraform-resources/stonesoupp01ue1/stonesoup-infra-prod-backup/backup-stone-prd-m01
+  value: integrations-output/terraform-resources/appsrep05ue1/stonesoup-infra-prod-backup/backup-stone-prd-m01

--- a/components/backup/production/stone-prd-rh01/backup-s3-credentials-patch.yaml
+++ b/components/backup/production/stone-prd-rh01/backup-s3-credentials-patch.yaml
@@ -1,3 +1,3 @@
 - op: replace
   path: /spec/dataFrom/0/extract/key
-  value: integrations-output/terraform-resources/stonesoupp01ue1/stonesoup-infra-prod-backup/backup-stone-prd-rh01
+  value: integrations-output/terraform-resources/appsrep05ue1/stonesoup-infra-prod-backup/backup-stone-prd-rh01

--- a/components/backup/production/stone-prod-p01/backup-s3-credentials-patch.yaml
+++ b/components/backup/production/stone-prod-p01/backup-s3-credentials-patch.yaml
@@ -1,3 +1,3 @@
 - op: replace
   path: /spec/dataFrom/0/extract/key
-  value: integrations-output/terraform-resources/stonesoupp01ue1/stonesoup-infra-prod-backup/backup-stone-prod-p01
+  value: integrations-output/terraform-resources/appsrep05ue1/stonesoup-infra-prod-backup/backup-stone-prod-p01

--- a/components/cluster-secret-store-rh/base/rh-artifacts-bucket-writer-secret-store.yml
+++ b/components/cluster-secret-store-rh/base/rh-artifacts-bucket-writer-secret-store.yml
@@ -9,7 +9,7 @@ spec:
   provider:
     vault:
       server: "https://vault.ci.ext.devshift.net"
-      path: app-sre/integrations-output/terraform-resources/stonesoupp01ue1/stonesoup-infra-production/rh-artifacts-bucket-writer
+      path: app-sre/integrations-output/terraform-resources/appsrep05ue1/stonesoup-infra-production/rh-artifacts-bucket-writer
       version: v1
       auth:
         # VaultAppRole authenticates with Vault using the

--- a/components/remote-secret-controller/overlays/production/stone-prd-m01/aws-credentials-path-patch.yaml
+++ b/components/remote-secret-controller/overlays/production/stone-prd-m01/aws-credentials-path-patch.yaml
@@ -1,7 +1,7 @@
 ---
 - op: replace
   path: /spec/data/0/remoteRef/key
-  value: integrations-output/terraform-resources/stonesoupp01ue1/stonesoup-infra-production/spi-secrets-manager
+  value: integrations-output/terraform-resources/appsrep05ue1/stonesoup-infra-production/spi-secrets-manager
 - op: replace
   path: /spec/data/1/remoteRef/key
-  value: integrations-output/terraform-resources/stonesoupp01ue1/stonesoup-infra-production/spi-secrets-manager
+  value: integrations-output/terraform-resources/appsrep05ue1/stonesoup-infra-production/spi-secrets-manager

--- a/components/remote-secret-controller/overlays/production/stone-prd-rh01/aws-credentials-path-patch.yaml
+++ b/components/remote-secret-controller/overlays/production/stone-prd-rh01/aws-credentials-path-patch.yaml
@@ -1,7 +1,7 @@
 ---
 - op: replace
   path: /spec/data/0/remoteRef/key
-  value: integrations-output/terraform-resources/stonesoupp01ue1/stonesoup-infra-production/spi-secrets-manager
+  value: integrations-output/terraform-resources/appsrep05ue1/stonesoup-infra-production/spi-secrets-manager
 - op: replace
   path: /spec/data/1/remoteRef/key
-  value: integrations-output/terraform-resources/stonesoupp01ue1/stonesoup-infra-production/spi-secrets-manager
+  value: integrations-output/terraform-resources/appsrep05ue1/stonesoup-infra-production/spi-secrets-manager

--- a/components/spi/overlays/production/stone-prd-m01/spi-aws-credentials-path-patch.yaml
+++ b/components/spi/overlays/production/stone-prd-m01/spi-aws-credentials-path-patch.yaml
@@ -1,7 +1,7 @@
 ---
 - op: replace
   path: /spec/data/0/remoteRef/key
-  value: integrations-output/terraform-resources/stonesoupp01ue1/stonesoup-infra-production/spi-secrets-manager
+  value: integrations-output/terraform-resources/appsrep05ue1/stonesoup-infra-production/spi-secrets-manager
 - op: replace
   path: /spec/data/1/remoteRef/key
-  value: integrations-output/terraform-resources/stonesoupp01ue1/stonesoup-infra-production/spi-secrets-manager
+  value: integrations-output/terraform-resources/appsrep05ue1/stonesoup-infra-production/spi-secrets-manager

--- a/components/spi/overlays/production/stone-prd-rh01/spi-aws-credentials-path-patch.yaml
+++ b/components/spi/overlays/production/stone-prd-rh01/spi-aws-credentials-path-patch.yaml
@@ -1,7 +1,7 @@
 ---
 - op: replace
   path: /spec/data/0/remoteRef/key
-  value: integrations-output/terraform-resources/stonesoupp01ue1/stonesoup-infra-production/spi-secrets-manager
+  value: integrations-output/terraform-resources/appsrep05ue1/stonesoup-infra-production/spi-secrets-manager
 - op: replace
   path: /spec/data/1/remoteRef/key
-  value: integrations-output/terraform-resources/stonesoupp01ue1/stonesoup-infra-production/spi-secrets-manager
+  value: integrations-output/terraform-resources/appsrep05ue1/stonesoup-infra-production/spi-secrets-manager


### PR DESCRIPTION
We're migrating all the Konflux resources from `stonesoupp01ue1` to `appsrep05ue1`. This requires to update the secret paths or configurations containing `stonesoupp01ue1` with `appsrep05ue1`.