### PR TITLE
stage: bump tekton-pipeline-webhook to 6 minimum replicas to avoid intermittent context deadline exceeded performance issues

### DIFF
--- a/components/pipeline-service/staging/base/update-tekton-config-performance.yaml
+++ b/components/pipeline-service/staging/base/update-tekton-config-performance.yaml
@@ -43,3 +43,6 @@
   path: /spec/platforms/openshift/pipelinesAsCode/options/deployments/pipelines-as-code-webhook/spec/replicas
   # default pipeline-service setting is 1
   value: 2
+- op: replace
+  path: /spec/pipeline/options/horizontalPodAutoscalers/tekton-pipelines-webhook/spec/minReplicas
+  value: 6

--- a/components/pipeline-service/staging/stone-stage-p01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stage-p01/deploy.yaml
@@ -1974,7 +1974,7 @@ spec:
                   averageUtilization: 100
                   type: Utilization
               type: Resource
-            minReplicas: 2
+            minReplicas: 6
     performance:
       buckets: 4
       disable-ha: false

--- a/components/pipeline-service/staging/stone-stg-m01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stg-m01/deploy.yaml
@@ -1974,7 +1974,7 @@ spec:
                   averageUtilization: 100
                   type: Utilization
               type: Resource
-            minReplicas: 2
+            minReplicas: 6
     performance:
       buckets: 4
       disable-ha: false

--- a/components/pipeline-service/staging/stone-stg-rh01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stg-rh01/deploy.yaml
@@ -1974,7 +1974,7 @@ spec:
                   averageUtilization: 100
                   type: Utilization
               type: Resource
-            minReplicas: 2
+            minReplicas: 6
     performance:
       buckets: 4
       disable-ha: false


### PR DESCRIPTION
quick workaround to maximize computing capacity for the `tekton-pipelines-webhook` webhook getting periodic context deadline exceeded errors reported in 

https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1713275865233269
https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1713252235282299
https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1713180672587489

@hugares @gbenhaim @savitaashture @khrm @enarha 


rh-pre-commit.version: 2.2.0
rh-pre-commit.check-secrets: ENABLED