### PR TITLE
Delete toolchain host and member application from dev overlay

### DIFF
--- a/argo-cd-apps/overlays/development/delete-applications.yaml
+++ b/argo-cd-apps/overlays/development/delete-applications.yaml
@@ -64,3 +64,15 @@ kind: ApplicationSet
 metadata:
   name: ca-bundle
 $patch: delete
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: toolchain-host-operator
+$patch: delete
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: toolchain-member-operator
+$patch: delete

--- a/components/sandbox/toolchain-host-operator/development/kustomization.yaml
+++ b/components/sandbox/toolchain-host-operator/development/kustomization.yaml
@@ -1,4 +1,0 @@
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-
-resources: []

--- a/components/sandbox/toolchain-member-operator/development/kustomization.yaml
+++ b/components/sandbox/toolchain-member-operator/development/kustomization.yaml
@@ -1,4 +1,0 @@
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-
-resources: []


### PR DESCRIPTION
Both applications point to an empty folder, kustomize resources wise. Remove both ArgoCD applications and they empty folders to remove the possible confusion. Toolchain is not deployed using ArgoCD in development overlay.