### PR TITLE
prod: bump tekton-pipeline-webhook to 6 minimum replicas to avoid intermittent context deadline exceeded performance issues

### DIFF
--- a/components/pipeline-service/production/base/update-tekton-config-performance.yaml
+++ b/components/pipeline-service/production/base/update-tekton-config-performance.yaml
@@ -43,3 +43,6 @@
   path: /spec/platforms/openshift/pipelinesAsCode/options/deployments/pipelines-as-code-webhook/spec/replicas
   # default pipeline-service setting is 1
   value: 2
+- op: replace
+  path: /spec/pipeline/options/horizontalPodAutoscalers/tekton-pipelines-webhook/spec/minReplicas
+  value: 6

--- a/components/pipeline-service/production/stone-prd-m01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prd-m01/deploy.yaml
@@ -1973,7 +1973,7 @@ spec:
                   averageUtilization: 100
                   type: Utilization
               type: Resource
-            minReplicas: 2
+            minReplicas: 6
     performance:
       buckets: 4
       disable-ha: false

--- a/components/pipeline-service/production/stone-prd-rh01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prd-rh01/deploy.yaml
@@ -1973,7 +1973,7 @@ spec:
                   averageUtilization: 100
                   type: Utilization
               type: Resource
-            minReplicas: 2
+            minReplicas: 6
     performance:
       buckets: 4
       disable-ha: false

--- a/components/pipeline-service/production/stone-prod-p01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prod-p01/deploy.yaml
@@ -1973,7 +1973,7 @@ spec:
                   averageUtilization: 100
                   type: Utilization
               type: Resource
-            minReplicas: 2
+            minReplicas: 6
     performance:
       buckets: 4
       disable-ha: false


### PR DESCRIPTION
the prod version of https://github.com/redhat-appstudio/infra-deployments/pull/3574

to reiterate from there ^^ on sufficiently sized personal cluster I was able to update the development overlay to 6 and successfully bootstrap, etc.

rh-pre-commit.version: 2.2.0
rh-pre-commit.check-secrets: ENABLED