### PR TITLE
Allow qe admins to get secrets in quality-dashboard namespace

### DIFF
--- a/components/quality-dashboard/base/rbac/quality-dashboard.yaml
+++ b/components/quality-dashboard/base/rbac/quality-dashboard.yaml
@@ -8,6 +8,7 @@ rules:
       - create
       - delete
       - edit
+      - get
       - list
     apiGroups:
       - ''


### PR DESCRIPTION
The role was missing the `get` permission.