### PR TITLE
Fix deployment of kubesaw-common application

### DIFF
--- a/argo-cd-apps/base/all-clusters/infra-deployments/kubesaw-common/kubesaw-common.yaml
+++ b/argo-cd-apps/base/all-clusters/infra-deployments/kubesaw-common/kubesaw-common.yaml
@@ -32,7 +32,7 @@ spec:
           prune: true
           selfHeal: true
         syncOptions:
-          - CreateNamespace=true
+          - CreateNamespace=false
         retry:
           limit: -1
           backoff:

--- a/components/sandbox/common/kustomization.yaml
+++ b/components/sandbox/common/kustomization.yaml
@@ -3,3 +3,4 @@ kind: Kustomization
 resources:
 - ./rbac
 - ./olm-restart
+- namespace.yaml

--- a/components/sandbox/common/namespace.yaml
+++ b/components/sandbox/common/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kubesaw-common

--- a/components/sandbox/common/olm-restart/kustomization.yaml
+++ b/components/sandbox/common/olm-restart/kustomization.yaml
@@ -1,5 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: kubesaw-common
 resources:
 - cronjob.yaml
 - sandbox-sre-olm-restart.yaml


### PR DESCRIPTION
The deployment was failing due to the missing namespace. Create the namespace resource and also add the namespace directive in the kustomization file to create all resources in the namespace.

[ASC-503](https://issues.redhat.com//browse/ASC-503)