### PR TITLE
Renaming kubesaw-common namespace to bypass validation rules

### DIFF
--- a/argo-cd-apps/base/all-clusters/infra-deployments/kubesaw-common/kubesaw-common.yaml
+++ b/argo-cd-apps/base/all-clusters/infra-deployments/kubesaw-common/kubesaw-common.yaml
@@ -25,14 +25,14 @@ spec:
         repoURL: https://github.com/redhat-appstudio/infra-deployments.git
         targetRevision: main
       destination:
-        namespace: kubesaw-common
+        namespace: ksaw-common
         server: '{{server}}'
       syncPolicy:
         automated:
           prune: true
           selfHeal: true
         syncOptions:
-          - CreateNamespace=false
+          - CreateNamespace=true
         retry:
           limit: -1
           backoff:

--- a/components/sandbox/common/kustomization.yaml
+++ b/components/sandbox/common/kustomization.yaml
@@ -3,4 +3,3 @@ kind: Kustomization
 resources:
 - ./rbac
 - ./olm-restart
-- namespace.yaml

--- a/components/sandbox/common/namespace.yaml
+++ b/components/sandbox/common/namespace.yaml
@@ -1,4 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: kubesaw-common

--- a/components/sandbox/common/olm-restart/kustomization.yaml
+++ b/components/sandbox/common/olm-restart/kustomization.yaml
@@ -1,6 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: kubesaw-common
+namespace: ksaw-common
 resources:
 - cronjob.yaml
 - sandbox-sre-olm-restart.yaml


### PR DESCRIPTION
There is a velidation webhook that blocks namespaces that contains string kube.