### PR TITLE
Remove unsupported defaultTier from ToolchainConfig

### DIFF
--- a/components/sandbox/toolchain-host-operator/staging/stone-stage-p01/toolchainconfig.yaml
+++ b/components/sandbox/toolchain-host-operator/staging/stone-stage-p01/toolchainconfig.yaml
@@ -8,7 +8,6 @@ metadata:
 spec:
     host:
       tiers:
-        defaultTier: 'appstudio'
         defaultSpaceTier: 'appstudio'
       automaticApproval:
         enabled: true


### PR DESCRIPTION
This field is causing ArgoCD to be out of sync as it add the field but OCP is removing it as it is not part of CRD definition.