### PR TITLE
chore: add ci-helper-app Repository CR

### DIFF
--- a/components/tekton-ci/base/repository.yaml
+++ b/components/tekton-ci/base/repository.yaml
@@ -103,3 +103,10 @@ metadata:
   name: quality-dashboard
 spec:
   url: "https://github.com/redhat-appstudio/quality-dashboard"
+---
+apiVersion: pipelinesascode.tekton.dev/v1alpha1
+kind: Repository
+metadata:
+  name: ci-helper-app
+spec:
+  url: "https://github.com/redhat-appstudio/ci-helper-app"


### PR DESCRIPTION
https://issues.redhat.com/browse/KONFLUX-2245

First part of moving manifests for ci-helper-app to infra-deployments