### PR TITLE
chore: Update grapahan dashboard reference

### DIFF
--- a/components/monitoring/grafana/base/dashboards/build-service/kustomization.yaml
+++ b/components/monitoring/grafana/base/dashboards/build-service/kustomization.yaml
@@ -1,5 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- https://github.com/redhat-appstudio/build-service/config/monitoring/grafana-dashboards/?ref=76523a64ea661814bfc6eb2b5628a2ed3cedae77
+- https://github.com/redhat-appstudio/build-service/config/monitoring/grafana-dashboards/?ref=a037b0de83021d2f9a1bd3a40311ddc1b05cca53
 - dashboard.yaml


### PR DESCRIPTION
During prod update of build-service both [build-service kustomization](https://github.com/redhat-appstudio/infra-deployments/blob/main/components/build-service/production/base/kustomization.yaml) and [build-service graphana dashboard reference](https://github.com/redhat-appstudio/infra-deployments/blob/main/components/monitoring/grafana/base/dashboards/build-service/kustomization.yaml) should be updated as per the [update script](https://github.com/redhat-appstudio/infra-deployments/blob/main/.tekton/build-service-prod-overlay-update.yaml#L22-L26). But since one of them got updated manually, so it broke and now only updating build-service production kustomization file during [stage to prod update PR](https://github.com/redhat-appstudio/infra-deployments/pull/3592/files).