### PR TITLE
Revert "multi-platform-controller update"

### DIFF
--- a/components/multi-platform-controller/base/kustomization.yaml
+++ b/components/multi-platform-controller/base/kustomization.yaml
@@ -3,17 +3,17 @@ kind: Kustomization
 
 resources:
 - allow-argocd-to-manage.yaml
-- https://github.com/redhat-appstudio/multi-platform-controller/deploy/operator?ref=857aab5f1a0fe256fa28e351de06d2fa64c33947
-- https://github.com/redhat-appstudio/multi-platform-controller/deploy/otp?ref=857aab5f1a0fe256fa28e351de06d2fa64c33947
+- https://github.com/redhat-appstudio/multi-platform-controller/deploy/operator?ref=6491fb49fdeb1c371011d89e551874bc8b53f0e3
+- https://github.com/redhat-appstudio/multi-platform-controller/deploy/otp?ref=6491fb49fdeb1c371011d89e551874bc8b53f0e3
 
 
 images:
 - name: multi-platform-controller
   newName: quay.io/redhat-user-workloads/rhtap-build-tenant/multi-arch-controller/multi-arch-controller
-  newTag: 857aab5f1a0fe256fa28e351de06d2fa64c33947
+  newTag: 6491fb49fdeb1c371011d89e551874bc8b53f0e3
 - name: multi-platform-otp-server
   newName: quay.io/redhat-user-workloads/rhtap-build-tenant/multi-arch-controller/multi-platform-controller-otp-service
-  newTag: 857aab5f1a0fe256fa28e351de06d2fa64c33947
+  newTag: 6491fb49fdeb1c371011d89e551874bc8b53f0e3
 
 namespace: multi-platform-controller
 


### PR DESCRIPTION
All architectures are failing now. Proposing to revert this change to at least have some architectures working. 

Reverts redhat-appstudio/infra-deployments#3604