### PR TITLE
konflux growth necessitates metric exporter bump

### DIFF
--- a/components/pipeline-service/production/base/bump-exporter-mem.yaml
+++ b/components/pipeline-service/production/base/bump-exporter-mem.yaml
@@ -1,7 +1,7 @@
 ---
 - op: replace
   path: /spec/template/spec/containers/0/resources/limits/memory
-  value: "3Gi"
+  value: "6Gi"
 - op: replace
   path: /spec/template/spec/containers/0/resources/requests/memory
-  value: "3Gi"
+  value: "6Gi"

--- a/components/pipeline-service/production/stone-prd-m01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prd-m01/deploy.yaml
@@ -1212,10 +1212,10 @@ spec:
         resources:
           limits:
             cpu: 500m
-            memory: 3Gi
+            memory: 6Gi
           requests:
             cpu: 250m
-            memory: 3Gi
+            memory: 6Gi
         securityContext:
           readOnlyRootFilesystem: true
           runAsNonRoot: true

--- a/components/pipeline-service/production/stone-prd-rh01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prd-rh01/deploy.yaml
@@ -1212,10 +1212,10 @@ spec:
         resources:
           limits:
             cpu: 500m
-            memory: 3Gi
+            memory: 6Gi
           requests:
             cpu: 250m
-            memory: 3Gi
+            memory: 6Gi
         securityContext:
           readOnlyRootFilesystem: true
           runAsNonRoot: true

--- a/components/pipeline-service/production/stone-prod-p01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prod-p01/deploy.yaml
@@ -1212,10 +1212,10 @@ spec:
         resources:
           limits:
             cpu: 500m
-            memory: 3Gi
+            memory: 6Gi
           requests:
             cpu: 250m
-            memory: 3Gi
+            memory: 6Gi
         securityContext:
           readOnlyRootFilesystem: true
           runAsNonRoot: true


### PR DESCRIPTION
core tekton controller are not running at over 10Gi now. there are too many pipelineruns for the exporter to look at in 3 Gi.

rh-pre-commit.version: 2.2.0
rh-pre-commit.check-secrets: ENABLED