### PR TITLE
chore: add ci-helper-app

### DIFF
--- a/argo-cd-apps/base/ci-helper-app/ci-helper-app.yaml
+++ b/argo-cd-apps/base/ci-helper-app/ci-helper-app.yaml
@@ -1,0 +1,41 @@
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: ci-helper-app
+spec:
+  generators:
+    - merge:
+        mergeKeys:
+          - nameNormalized
+        generators:
+          - clusters:
+              values:
+                sourceRoot: components/ci-helper-app
+                environment: staging
+                clusterDir: ""
+          - list:
+              elements: []
+  template:
+    metadata:
+      name: ci-helper-app-{{nameNormalized}}
+    spec:
+      project: default
+      source:
+        path: '{{values.sourceRoot}}/{{values.environment}}/{{values.clusterDir}}'
+        repoURL: https://github.com/redhat-appstudio/infra-deployments.git
+        targetRevision: main
+      destination:
+        namespace: ci-helper-app
+        server: '{{server}}'
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
+        syncOptions:
+          - CreateNamespace=true
+        retry:
+          limit: -1
+          backoff:
+            duration: 10s
+            factor: 2
+            maxDuration: 3m

--- a/argo-cd-apps/base/ci-helper-app/kustomization.yaml
+++ b/argo-cd-apps/base/ci-helper-app/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ci-helper-app.yaml
+components:
+  - ../../k-components/inject-infra-deployments-repo-details

--- a/argo-cd-apps/overlays/development/delete-applications.yaml
+++ b/argo-cd-apps/overlays/development/delete-applications.yaml
@@ -94,3 +94,9 @@ kind: ApplicationSet
 metadata:
   name: ui
 $patch: delete
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: ci-helper-app
+$patch: delete

--- a/argo-cd-apps/overlays/development/kustomization.yaml
+++ b/argo-cd-apps/overlays/development/kustomization.yaml
@@ -12,6 +12,7 @@ resources:
   - ../../base/quality-dashboard
   - ../../base/keycloak
   - ../../base/ui
+  - ../../base/ci-helper-app
 
 patchesStrategicMerge:
   - delete-applications.yaml
@@ -157,3 +158,8 @@ patches:
       kind: ApplicationSet
       version: v1alpha1
       name: quality-dashboard
+  - path: development-overlay-patch.yaml
+    target:
+      kind: ApplicationSet
+      version: v1alpha1
+      name: ci-helper-app

--- a/argo-cd-apps/overlays/konflux-public-staging/kustomization.yaml
+++ b/argo-cd-apps/overlays/konflux-public-staging/kustomization.yaml
@@ -6,4 +6,5 @@ resources:
   - ../../base/all-clusters
   - ../../base/backup
   - ../../base/quality-dashboard
+  - ../../base/ci-helper-app
 namespace: konflux-public-staging

--- a/components/backup/base/member/schedules/backup-tenants-schedule.yaml
+++ b/components/backup/base/member/schedules/backup-tenants-schedule.yaml
@@ -16,6 +16,7 @@ spec:
       - build-service
       - build-templates
       - build-templates-e2e
+      - ci-helper-app
       - dedicated-admin
       - deployment-validation-operator
       - dora-metrics

--- a/components/ci-helper-app/OWNERS
+++ b/components/ci-helper-app/OWNERS
@@ -1,0 +1,5 @@
+# See the OWNERS docs: https://go.k8s.io/owners
+
+approvers:
+- dheerajodha
+- psturc

--- a/components/ci-helper-app/base/kustomization.yaml
+++ b/components/ci-helper-app/base/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- rbac
+- https://github.com/konflux-ci/ci-helper-app/deploy/base?ref=bda888fd5b7a72f27b486429bde3ae7b361d6bd1
+
+
+images:
+- name: quay.io/konflux-ci/ci-helper-app
+  newName: quay.io/konflux-ci/ci-helper-app
+  newTag: bda888fd5b7a72f27b486429bde3ae7b361d6bd1
+
+namespace: ci-helper-app

--- a/components/ci-helper-app/base/rbac/ci-helper-app.yaml
+++ b/components/ci-helper-app/base/rbac/ci-helper-app.yaml
@@ -1,0 +1,30 @@
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: ci-helper-app-maintainer
+  namespace: ci-helper-app
+rules:
+  - verbs:
+      - create
+      - delete
+      - edit
+      - get
+      - list
+    apiGroups:
+      - ''
+    resources:
+      - secrets
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: ci-helper-app-maintainers
+  namespace: ci-helper-app
+subjects:
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: konflux-qe-admins
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: ci-helper-app-maintainer

--- a/components/ci-helper-app/base/rbac/kustomization.yaml
+++ b/components/ci-helper-app/base/rbac/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ci-helper-app.yaml

--- a/components/ci-helper-app/development/kustomization.yaml
+++ b/components/ci-helper-app/development/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../base

--- a/components/ci-helper-app/staging/external-secrets/ci-helper-app-secrets.yaml
+++ b/components/ci-helper-app/staging/external-secrets/ci-helper-app-secrets.yaml
@@ -1,0 +1,19 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: ci-helper-app-secrets
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  dataFrom:
+    - extract:
+        key: staging/qe/ci-helper-app-secrets
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: appsre-stonesoup-vault
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    name: ci-helper-app-secrets

--- a/components/ci-helper-app/staging/external-secrets/kustomization.yaml
+++ b/components/ci-helper-app/staging/external-secrets/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ci-helper-app-secrets.yaml
+namespace: ci-helper-app

--- a/components/ci-helper-app/staging/kustomization.yaml
+++ b/components/ci-helper-app/staging/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../base
+- external-secrets

--- a/components/cluster-secret-store/base/appsre-stonesoup-vault-secret-store.yaml
+++ b/components/cluster-secret-store/base/appsre-stonesoup-vault-secret-store.yaml
@@ -50,3 +50,4 @@ spec:
         - rhtap-o11y-tenant
         - admin-checker
         - integration-service
+        - ci-helper-app

--- a/docs/_data/navigation.yml
+++ b/docs/_data/navigation.yml
@@ -57,5 +57,7 @@ docs-en:
     children:
       - title: Quality Dashboard
         url: /docs/misc/quality-dashboard.html
+      - title: CI Helper App
+        url: /docs/misc/ci-helper-app.html
       - title: FAQs/Troubleshooting
         url: /docs/misc/faq.html

--- a/docs/misc/ci-helper-app.md
+++ b/docs/misc/ci-helper-app.md
@@ -1,0 +1,10 @@
+---
+title: CI Helper App
+---
+
+The purpose of the CI Helper App is to analyze CI failures linked in pull requests by openshift-ci bot and provide more details about the failure in a PR comment.
+More details can be found here https://github.com/konflux-ci/ci-helper-app
+
+The manifests can be found [here](../../components/ci-helper-app/)
+
+For validating changes to CI Helper App on a dev cluster, configure related environment variables specified in [preview-template.env](../../hack/preview-template.env)

--- a/hack/bootstrap-host-cluster.sh
+++ b/hack/bootstrap-host-cluster.sh
@@ -5,6 +5,7 @@ declare -r ROOT="${BASH_SOURCE[0]%/*}"
 main() {
     load_global_vars
     "${ROOT}/secret-creator/quality-dashboard/create-quality-dashboard-secrets.sh"
+    "${ROOT}/secret-creator/create-ci-helper-app-secret.sh"
 }
 
 load_global_vars() {

--- a/hack/destroy-cluster.sh
+++ b/hack/destroy-cluster.sh
@@ -41,7 +41,7 @@ oc delete clusterserviceversions.operators.coreos.com --all -n openshift-operato
 
 echo
 echo "Removing custom projects"
-oc delete project enterprise-contract-service gitops quality-dashboard internal-services application-api
+oc delete project enterprise-contract-service gitops quality-dashboard ci-helper-app internal-services application-api
 
 echo
 echo "Removing dev-sso"

--- a/hack/preview-template.env
+++ b/hack/preview-template.env
@@ -138,3 +138,8 @@ export QD_GITHUB_ORG=
 ### Client ID/Secret for OAuth app - see https://github.com/redhat-appstudio/quality-dashboard?tab=readme-ov-file#dex-for-oauth for more details
 export QD_OAUTH_CLIENT_ID=
 export QD_OAUTH_CLIENT_SECRET=
+
+# CI Helper App
+export CI_HELPER_GITHUB_APP_INTEGRATION_ID=
+export CI_HELPER_GITHUB_APP_PRIVATE_KEY=
+export CI_HELPER_GITHUB_APP_WEBHOOK_SECRET=

--- a/hack/secret-creator/create-ci-helper-app-secret.sh
+++ b/hack/secret-creator/create-ci-helper-app-secret.sh
@@ -1,0 +1,26 @@
+#!/bin/bash -e
+
+main() {
+    echo "Creating secret for CI Helper App"
+
+    NS=ci-helper-app
+    SECRET_NAME=$NS-secrets
+
+    APP_ID=${CI_HELPER_GITHUB_APP_INTEGRATION_ID:-}
+    PRIVATE_KEY=${CI_HELPER_GITHUB_APP_PRIVATE_KEY:-}
+    WEBHOOK_SECRET=${CI_HELPER_GITHUB_APP_WEBHOOK_SECRET:-}
+
+    kubectl create namespace $NS -o yaml --dry-run=client | oc apply -f-
+
+    if ! kubectl get secret $SECRET_NAME -n $NS  &>/dev/null; then
+        kubectl create secret generic $SECRET_NAME \
+            --namespace=$NS \
+            --from-literal=app-id="$APP_ID" \
+            --from-literal=app-private-key="$PRIVATE_KEY" \
+            --from-literal=webhook-secret="$WEBHOOK_SECRET"
+    fi
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+    main "$@"
+fi


### PR DESCRIPTION
### JIRA
[KONFLUX-2245](https://issues.redhat.com//browse/KONFLUX-2245)

### Comments
* [ci-helper-app](https://github.com/konflux-ci/ci-helper-app) won't be deployed to dev/test env by default, the plan is to deploy it only in staging
* the validation was done locally by deleting [this part](https://github.com/redhat-appstudio/infra-deployments/pull/3643/files#diff-5d86190d9437c923d52539a453aff2af6eabfbdbc5cb2a5b466082002d16d427R91-R96) and setting up [required env vars](https://github.com/redhat-appstudio/infra-deployments/pull/3643/files#diff-d06ff763d99c81add8827eb9d1f3d99d1ce2ae43eaf235926a0bccfad78c5d2aR142-R145), followed by running `preview` script
* the required secrets are already present in vault