### PR TITLE
pin results image until watcher mem leak fix is deemed ok

### DIFF
--- a/components/pipeline-service/development/kustomization.yaml
+++ b/components/pipeline-service/development/kustomization.yaml
@@ -12,6 +12,12 @@ resources:
   - https://github.com/openshift-pipelines/pipeline-service.git/developer/openshift/gitops/argocd/pipeline-service-storage?ref=e52f83e174efb8f308f6e32d1e0fc9f8eb9ed893
   - ../base/rbac
 
+images:
+  - name: quay.io/redhat-appstudio/tekton-results-api
+    newTag: bae7851ff584423503af324200f52cd28ca99116
+  - name: quay.io/redhat-appstudio/tekton-results-watcher
+    newTag: bae7851ff584423503af324200f52cd28ca99116
+
 patches:
   - path: chains-tekton-config-patches.yaml
     target:

--- a/components/pipeline-service/production/base/kustomization.yaml
+++ b/components/pipeline-service/production/base/kustomization.yaml
@@ -14,6 +14,12 @@ resources:
   - ../../base/testing
   - ../../base/rbac
 
+images:
+  - name: quay.io/redhat-appstudio/tekton-results-api
+    newTag: bae7851ff584423503af324200f52cd28ca99116
+  - name: quay.io/redhat-appstudio/tekton-results-watcher
+    newTag: bae7851ff584423503af324200f52cd28ca99116
+
 patches:
   # - path: scale-down-exporter.yaml
   #   target:

--- a/components/pipeline-service/staging/base/kustomization.yaml
+++ b/components/pipeline-service/staging/base/kustomization.yaml
@@ -14,6 +14,12 @@ resources:
   - ../../base/testing
   - ../../base/rbac
 
+images:
+  - name: quay.io/redhat-appstudio/tekton-results-api
+    newTag: bae7851ff584423503af324200f52cd28ca99116
+  - name: quay.io/redhat-appstudio/tekton-results-watcher
+    newTag: bae7851ff584423503af324200f52cd28ca99116
+
 patches:
   - path: chains-tekton-config-patches.yaml
     target:


### PR DESCRIPTION
An idea I had @enarha to bypass the results bump I'm getting performance QE to help me test with https://github.com/redhat-appstudio/infra-deployments/pull/3616

Rather than pick up the results image bumps like you see in https://github.com/redhat-appstudio/infra-deployments/pull/3616/files#diff-e961bdc3a405dfda1b39ed17ee82576bb68e2a35e9288e7de208e695e4ee5944R1497

We could force dev/stage/prod to specific sha's of the results image from here in infra deployments, and effectively pin the version here.

That way, if your operator bump is ready to merge before the testing completes with https://github.com/redhat-appstudio/infra-deployments/pull/3616 we could include something like this in the PR that does your operator bump without having to revert the results bump in openshift-pipelines/pipeline-service.

What do you think?

rh-pre-commit.version: 2.2.0
rh-pre-commit.check-secrets: ENABLED