### PR TITLE
fix: increase cpu and mem for release cleanup cronjob

### DIFF
--- a/components/release/base/cronjobs/remove-expired-releases.yaml
+++ b/components/release/base/cronjobs/remove-expired-releases.yaml
@@ -64,10 +64,10 @@ spec:
               resources:
                 limits:
                   cpu: 200m
-                  memory: 200Mi
+                  memory: 300Mi
                 requests:
-                  cpu: 10m
-                  memory: 10Mi
+                  cpu: 100m
+                  memory: 200Mi
               securityContext:
                 allowPrivilegeEscalation: false
                 capabilities:


### PR DESCRIPTION
This commit increases the memory and cpu set for remove-expired-releases cronjob.

Signed-off-by: Leandro Mendes <lmendes@redhat.com>