### PR TITLE
STONEINTG-840: migrate clair-in-ci-db to konflux-ci org

### DIFF
--- a/components/tekton-ci/base/repository.yaml
+++ b/components/tekton-ci/base/repository.yaml
@@ -25,7 +25,7 @@ kind: Repository
 metadata:
   name: clair-in-ci-db
 spec:
-  url: "https://github.com/redhat-appstudio/clair-in-ci-db"
+  url: "https://github.com/konflux-ci/clair-in-ci-db"
 ---
 apiVersion: pipelinesascode.tekton.dev/v1alpha1
 kind: Repository


### PR DESCRIPTION
Tekton-ci repo config has to be updated.