### PR TITLE
Bump hac-dev, chrome service, chrome frontend tags

### DIFF
--- a/components/ui/production/kustomization.yaml
+++ b/components/ui/production/kustomization.yaml
@@ -11,7 +11,7 @@ images:
   # chrome service
   - name: quay.io/cloudservices/chrome-service
     newName: quay.io/cloudservices/chrome-service
-    newTag: 0574186
+    newTag: 1f6a4c1
   # hac
   - name: quay.io/cloudservices/hac-core-frontend
     newName: quay.io/cloudservices/hac-core-frontend

--- a/components/ui/production/kustomization.yaml
+++ b/components/ui/production/kustomization.yaml
@@ -7,11 +7,11 @@ images:
   # chrome frontend
   - name: quay.io/cloudservices/insights-chrome-frontend
     newName: quay.io/cloudservices/insights-chrome-frontend
-    newTag: 3194dee
+    newTag: d76ce23
   # chrome service
   - name: quay.io/cloudservices/chrome-service
     newName: quay.io/cloudservices/chrome-service
-    newTag: 1f6a4c1
+    newTag: 6f08f67
   # hac
   - name: quay.io/cloudservices/hac-core-frontend
     newName: quay.io/cloudservices/hac-core-frontend
@@ -19,7 +19,7 @@ images:
   # hac-dev
   - name: quay.io/cloudservices/hac-dev-frontend
     newName: quay.io/cloudservices/hac-dev-frontend
-    newTag: 91fe4fe
+    newTag: a8ca051
 
 configMapGenerator:
   - name: fed-modules

--- a/components/ui/production/kustomization.yaml
+++ b/components/ui/production/kustomization.yaml
@@ -7,11 +7,11 @@ images:
   # chrome frontend
   - name: quay.io/cloudservices/insights-chrome-frontend
     newName: quay.io/cloudservices/insights-chrome-frontend
-    newTag: 03a0a14
+    newTag: 3194dee
   # chrome service
   - name: quay.io/cloudservices/chrome-service
     newName: quay.io/cloudservices/chrome-service
-    newTag: acd4a91
+    newTag: 0574186
   # hac
   - name: quay.io/cloudservices/hac-core-frontend
     newName: quay.io/cloudservices/hac-core-frontend
@@ -19,7 +19,7 @@ images:
   # hac-dev
   - name: quay.io/cloudservices/hac-dev-frontend
     newName: quay.io/cloudservices/hac-dev-frontend
-    newTag: d5e862c
+    newTag: 91fe4fe
 
 configMapGenerator:
   - name: fed-modules


### PR DESCRIPTION
Mainly to get https://github.com/openshift/hac-dev/pull/926 in, but bumping the others as well.