### PR TITLE
feat(STONEINTG-839): hacbs-test migration

### DIFF
--- a/components/tekton-ci/base/repository.yaml
+++ b/components/tekton-ci/base/repository.yaml
@@ -30,9 +30,9 @@ spec:
 apiVersion: pipelinesascode.tekton.dev/v1alpha1
 kind: Repository
 metadata:
-  name: hacbs-test
+  name: konflux-test
 spec:
-  url: "https://github.com/redhat-appstudio/hacbs-test"
+  url: "https://github.com/konflux-ci/konflux-test"
 ---
 apiVersion: pipelinesascode.tekton.dev/v1alpha1
 kind: Repository


### PR DESCRIPTION
hacbs-test has been renamed to konflux-test and moved under konflux-ci org