### PR TITLE
KFLUXINFRA-554: Adding matchLabel Cluster Generator for Backup Component

### DIFF
--- a/argo-cd-apps/base/all-clusters/infra-deployments/backup/backup.yaml
+++ b/argo-cd-apps/base/all-clusters/infra-deployments/backup/backup.yaml
@@ -9,6 +9,9 @@ spec:
           - nameNormalized
         generators:
           - clusters:
+              selector:
+                matchLabels:
+                  appstudio.redhat.com/backup: 'true'
               values:
                 sourceRoot: components/backup
                 environment: staging


### PR DESCRIPTION
With adding EaaS Clusters, We needed to add `matchLabel` in the cluster generator to deploy the backup component on those clusters with `appstudio.redhat.com/backup: 'true'` label. 