### PR TITLE
KFLUXINFRA-567: Replacing appsrep05ue1 to appsrep09ue1

### DIFF
--- a/components/backup/production/stone-prd-host1/backup-s3-credentials-patch.yaml
+++ b/components/backup/production/stone-prd-host1/backup-s3-credentials-patch.yaml
@@ -1,3 +1,3 @@
 - op: replace
   path: /spec/dataFrom/0/extract/key
-  value: integrations-output/terraform-resources/appsrep05ue1/stonesoup-infra-prod-backup/backup-stone-prd-host1
+  value: integrations-output/terraform-resources/appsrep09ue1/stonesoup-infra-prod-backup/backup-stone-prd-host1

--- a/components/backup/production/stone-prd-m01/backup-s3-credentials-patch.yaml
+++ b/components/backup/production/stone-prd-m01/backup-s3-credentials-patch.yaml
@@ -1,3 +1,3 @@
 - op: replace
   path: /spec/dataFrom/0/extract/key
-  value: integrations-output/terraform-resources/appsrep05ue1/stonesoup-infra-prod-backup/backup-stone-prd-m01
+  value: integrations-output/terraform-resources/appsrep09ue1/stonesoup-infra-prod-backup/backup-stone-prd-m01

--- a/components/backup/production/stone-prd-rh01/backup-s3-credentials-patch.yaml
+++ b/components/backup/production/stone-prd-rh01/backup-s3-credentials-patch.yaml
@@ -1,3 +1,3 @@
 - op: replace
   path: /spec/dataFrom/0/extract/key
-  value: integrations-output/terraform-resources/appsrep05ue1/stonesoup-infra-prod-backup/backup-stone-prd-rh01
+  value: integrations-output/terraform-resources/appsrep09ue1/stonesoup-infra-prod-backup/backup-stone-prd-rh01

--- a/components/backup/production/stone-prod-p01/backup-s3-credentials-patch.yaml
+++ b/components/backup/production/stone-prod-p01/backup-s3-credentials-patch.yaml
@@ -1,3 +1,3 @@
 - op: replace
   path: /spec/dataFrom/0/extract/key
-  value: integrations-output/terraform-resources/appsrep05ue1/stonesoup-infra-prod-backup/backup-stone-prod-p01
+  value: integrations-output/terraform-resources/appsrep09ue1/stonesoup-infra-prod-backup/backup-stone-prod-p01

--- a/components/cluster-secret-store-rh/base/rh-artifacts-bucket-writer-secret-store.yml
+++ b/components/cluster-secret-store-rh/base/rh-artifacts-bucket-writer-secret-store.yml
@@ -9,7 +9,7 @@ spec:
   provider:
     vault:
       server: "https://vault.ci.ext.devshift.net"
-      path: app-sre/integrations-output/terraform-resources/appsrep05ue1/stonesoup-infra-production/rh-artifacts-bucket-writer
+      path: app-sre/integrations-output/terraform-resources/appsrep09ue1/stonesoup-infra-production/rh-artifacts-bucket-writer
       version: v1
       auth:
         # VaultAppRole authenticates with Vault using the

--- a/components/gitops/production/stone-prod-p01/gitops-service-postgres-rds-config-path.yaml
+++ b/components/gitops/production/stone-prod-p01/gitops-service-postgres-rds-config-path.yaml
@@ -1,4 +1,4 @@
 ---
 - op: add
   path: /spec/dataFrom/0/extract/key
-  value: integrations-output/terraform-resources/appsrep05ue1/stone-prod-p01/stone-prod-p01-gitopsvc-rds
+  value: integrations-output/terraform-resources/appsrep09ue1/stone-prod-p01/stone-prod-p01-gitopsvc-rds

--- a/components/pipeline-service/production/stone-prod-p01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prod-p01/deploy.yaml
@@ -1703,7 +1703,7 @@ metadata:
 spec:
   dataFrom:
   - extract:
-      key: integrations-output/terraform-resources/appsrep05ue1/stone-prod-p01/stone-prod-p01-plnsvc-rds
+      key: integrations-output/terraform-resources/appsrep09ue1/stone-prod-p01/stone-prod-p01-plnsvc-rds
   refreshInterval: 1h
   secretStoreRef:
     kind: ClusterSecretStore
@@ -1724,7 +1724,7 @@ metadata:
 spec:
   dataFrom:
   - extract:
-      key: integrations-output/terraform-resources/appsrep05ue1/stone-prod-p01/stone-prod-p01-plnsvc-s3
+      key: integrations-output/terraform-resources/appsrep09ue1/stone-prod-p01/stone-prod-p01-plnsvc-s3
   refreshInterval: 1h
   secretStoreRef:
     kind: ClusterSecretStore

--- a/components/pipeline-service/production/stone-prod-p01/resources/tekton-results-database-secret-path.yaml
+++ b/components/pipeline-service/production/stone-prod-p01/resources/tekton-results-database-secret-path.yaml
@@ -1,4 +1,4 @@
 ---
 - op: add
   path: /spec/dataFrom/0/extract/key
-  value: integrations-output/terraform-resources/appsrep05ue1/stone-prod-p01/stone-prod-p01-plnsvc-rds
+  value: integrations-output/terraform-resources/appsrep09ue1/stone-prod-p01/stone-prod-p01-plnsvc-rds

--- a/components/pipeline-service/production/stone-prod-p01/resources/tekton-results-s3-secret-path.yaml
+++ b/components/pipeline-service/production/stone-prod-p01/resources/tekton-results-s3-secret-path.yaml
@@ -1,4 +1,4 @@
 ---
 - op: add
   path: /spec/dataFrom/0/extract/key
-  value: integrations-output/terraform-resources/appsrep05ue1/stone-prod-p01/stone-prod-p01-plnsvc-s3
+  value: integrations-output/terraform-resources/appsrep09ue1/stone-prod-p01/stone-prod-p01-plnsvc-s3

--- a/components/remote-secret-controller/overlays/production/stone-prd-m01/aws-credentials-path-patch.yaml
+++ b/components/remote-secret-controller/overlays/production/stone-prd-m01/aws-credentials-path-patch.yaml
@@ -1,7 +1,7 @@
 ---
 - op: replace
   path: /spec/data/0/remoteRef/key
-  value: integrations-output/terraform-resources/appsrep05ue1/stonesoup-infra-production/spi-secrets-manager
+  value: integrations-output/terraform-resources/appsrep09ue1/stonesoup-infra-production/spi-secrets-manager
 - op: replace
   path: /spec/data/1/remoteRef/key
-  value: integrations-output/terraform-resources/appsrep05ue1/stonesoup-infra-production/spi-secrets-manager
+  value: integrations-output/terraform-resources/appsrep09ue1/stonesoup-infra-production/spi-secrets-manager

--- a/components/remote-secret-controller/overlays/production/stone-prd-rh01/aws-credentials-path-patch.yaml
+++ b/components/remote-secret-controller/overlays/production/stone-prd-rh01/aws-credentials-path-patch.yaml
@@ -1,7 +1,7 @@
 ---
 - op: replace
   path: /spec/data/0/remoteRef/key
-  value: integrations-output/terraform-resources/appsrep05ue1/stonesoup-infra-production/spi-secrets-manager
+  value: integrations-output/terraform-resources/appsrep09ue1/stonesoup-infra-production/spi-secrets-manager
 - op: replace
   path: /spec/data/1/remoteRef/key
-  value: integrations-output/terraform-resources/appsrep05ue1/stonesoup-infra-production/spi-secrets-manager
+  value: integrations-output/terraform-resources/appsrep09ue1/stonesoup-infra-production/spi-secrets-manager

--- a/components/remote-secret-controller/overlays/production/stone-prod-p01/aws-credentials-path-patch.yaml
+++ b/components/remote-secret-controller/overlays/production/stone-prod-p01/aws-credentials-path-patch.yaml
@@ -1,7 +1,7 @@
 ---
 - op: replace
   path: /spec/data/0/remoteRef/key
-  value: integrations-output/terraform-resources/appsrep05ue1/stone-prod-p01/spi-secrets-manager
+  value: integrations-output/terraform-resources/appsrep09ue1/stone-prod-p01/spi-secrets-manager
 - op: replace
   path: /spec/data/1/remoteRef/key
-  value: integrations-output/terraform-resources/appsrep05ue1/stone-prod-p01/spi-secrets-manager
+  value: integrations-output/terraform-resources/appsrep09ue1/stone-prod-p01/spi-secrets-manager

--- a/components/spi/overlays/production/stone-prd-m01/spi-aws-credentials-path-patch.yaml
+++ b/components/spi/overlays/production/stone-prd-m01/spi-aws-credentials-path-patch.yaml
@@ -1,7 +1,7 @@
 ---
 - op: replace
   path: /spec/data/0/remoteRef/key
-  value: integrations-output/terraform-resources/appsrep05ue1/stonesoup-infra-production/spi-secrets-manager
+  value: integrations-output/terraform-resources/appsrep09ue1/stonesoup-infra-production/spi-secrets-manager
 - op: replace
   path: /spec/data/1/remoteRef/key
-  value: integrations-output/terraform-resources/appsrep05ue1/stonesoup-infra-production/spi-secrets-manager
+  value: integrations-output/terraform-resources/appsrep09ue1/stonesoup-infra-production/spi-secrets-manager

--- a/components/spi/overlays/production/stone-prd-rh01/spi-aws-credentials-path-patch.yaml
+++ b/components/spi/overlays/production/stone-prd-rh01/spi-aws-credentials-path-patch.yaml
@@ -1,7 +1,7 @@
 ---
 - op: replace
   path: /spec/data/0/remoteRef/key
-  value: integrations-output/terraform-resources/appsrep05ue1/stonesoup-infra-production/spi-secrets-manager
+  value: integrations-output/terraform-resources/appsrep09ue1/stonesoup-infra-production/spi-secrets-manager
 - op: replace
   path: /spec/data/1/remoteRef/key
-  value: integrations-output/terraform-resources/appsrep05ue1/stonesoup-infra-production/spi-secrets-manager
+  value: integrations-output/terraform-resources/appsrep09ue1/stonesoup-infra-production/spi-secrets-manager

--- a/components/spi/overlays/production/stone-prod-p01/spi-aws-credentials-path-patch.yaml
+++ b/components/spi/overlays/production/stone-prod-p01/spi-aws-credentials-path-patch.yaml
@@ -1,7 +1,7 @@
 ---
 - op: replace
   path: /spec/data/0/remoteRef/key
-  value: integrations-output/terraform-resources/appsrep05ue1/stone-prod-p01/spi-secrets-manager
+  value: integrations-output/terraform-resources/appsrep09ue1/stone-prod-p01/spi-secrets-manager
 - op: replace
   path: /spec/data/1/remoteRef/key
-  value: integrations-output/terraform-resources/appsrep05ue1/stone-prod-p01/spi-secrets-manager
+  value: integrations-output/terraform-resources/appsrep09ue1/stone-prod-p01/spi-secrets-manager

--- a/hack/hac/installHac.sh
+++ b/hack/hac/installHac.sh
@@ -10,7 +10,7 @@ function helpUsage() {
     echo -e "   -ehk, --eph-hac-kubeconfig    A valid kubeconfig pointing to HAC Ephemeral cluster"
     echo -e "   -sk, --stonesoup-kubeconfig   A valid kubeconfig pointing to a cluster where Stonesoup controllers are installed."
     echo
-    echo -e "This command uses internal app-interface endpoint https://app-interface.apps.appsrep05ue1.zqxk.p1.openshiftapps.com/graphql (VPN required)"
+    echo -e "This command uses internal app-interface endpoint https://app-interface.apps.appsrep09ue1.03r5.p3.openshiftapps.com/graphql (VPN required)"
     echo -e "In order to use this without VPN, env vars QONTRACT_BASE_URL, QONTRACT_USERNAME and QONTRACT_PASSWORD need to be set."
 }
 
@@ -35,7 +35,7 @@ done
 
 if [[ -z "$QONTRACT_BASE_URL" ]]; then
     echo "[INFO] QONTRACT_BASE_URL env variable was not provided. Using default endpoint (RH VPN required)"
-    if ! curl --connect-timeout 3 https://app-interface.apps.appsrep05ue1.zqxk.p1.openshiftapps.com/graphql; then
+    if ! curl --connect-timeout 3 https://app-interface.apps.appsrep09ue1.03r5.p3.openshiftapps.com/graphql; then
         echo "[ERROR] QONTRACT_BASE_URL was not provided and default app-interface endpint cannot be reached (Are you on VPN?)."
         helpUsage & exit 1
     fi


### PR DESCRIPTION
AppSRE is migrating resources running on `appsrep05ue1` to `appsrep09ue1`. Infra Deployments for Konflux consume those resources in the form of the vault secrets, meaning those paths will be changed with this migration.

This PR will update the vault secret paths containing `appsrep05ue1` with `appsrep09ue1`.