### PR TITLE
tekton-ci: remove build-service PaC Repository

### DIFF
--- a/components/tekton-ci/base/repository.yaml
+++ b/components/tekton-ci/base/repository.yaml
@@ -37,13 +37,6 @@ spec:
 apiVersion: pipelinesascode.tekton.dev/v1alpha1
 kind: Repository
 metadata:
-  name: build-service
-spec:
-  url: "https://github.com/konflux-ci/build-service"
----
-apiVersion: pipelinesascode.tekton.dev/v1alpha1
-kind: Repository
-metadata:
   name: build-definitions
 spec:
   url: "https://github.com/redhat-appstudio/build-definitions"


### PR DESCRIPTION
[STONEBLD-1987](https://issues.redhat.com//browse/STONEBLD-1987)

When trying to onboard build-service to Konflux, we get

    53: Git repository is already handled by Pipelines as Code

In order to be able to onboard to Konflux, the Repository has to be removed from the tekton-ci namespace.