### PR TITLE
Fix logging operator installation on kflux-stg-es01

### DIFF
--- a/argo-cd-apps/base/all-clusters/infra-deployments/monitoring-workload-logging/monitoring-workload-logging.yaml
+++ b/argo-cd-apps/base/all-clusters/infra-deployments/monitoring-workload-logging/monitoring-workload-logging.yaml
@@ -15,6 +15,8 @@ spec:
                 clusterDir: "base"
           - list:
               elements:
+                - nameNormalized: kflux-stg-es01
+                  values.clusterDir: kflux-stg-es01
                 - nameNormalized: stone-stage-p01
                   values.clusterDir: stone-stage-p01
                 - nameNormalized: stone-prod-p01

--- a/components/monitoring/logging/staging/kflux-stg-es01/kustomization.yaml
+++ b/components/monitoring/logging/staging/kflux-stg-es01/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../base
+- ../../base/logging-operator-prerequisite


### PR DESCRIPTION
This cluster does not have the operatorgroup so deploy the logging operator prerequisites.

[KFLUXINFRA-554](https://issues.redhat.com//browse/KFLUXINFRA-554)