### PR TITLE
Create first application/component on eaas cluster

### DIFF
--- a/argo-cd-apps/base/eaas/kustomization.yaml
+++ b/argo-cd-apps/base/eaas/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - some-component
+components:
+  - ../../k-components/deploy-to-eaas-cluster-merge-generator
+  - ../../k-components/inject-argocd-namespace

--- a/argo-cd-apps/base/eaas/some-component/kustomization.yaml
+++ b/argo-cd-apps/base/eaas/some-component/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - some-component.yaml
+components:
+  - ../../../k-components/inject-infra-deployments-repo-details

--- a/argo-cd-apps/base/eaas/some-component/some-component.yaml
+++ b/argo-cd-apps/base/eaas/some-component/some-component.yaml
@@ -1,0 +1,41 @@
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: some-component
+spec:
+  generators:
+    - merge:
+        mergeKeys:
+          - nameNormalized
+        generators:
+          - clusters:
+              values:
+                sourceRoot: components/some-component
+                environment: staging
+                clusterDir: base
+          - list:
+              elements: []
+  template:
+    metadata:
+      name: some-component-{{nameNormalized}}
+    spec:
+      project: default
+      source:
+        path: "{{values.sourceRoot}}/{{values.environment}}/{{values.clusterDir}}"
+        repoURL: https://github.com/redhat-appstudio/infra-deployments.git
+        targetRevision: main
+      destination:
+        namespace: some-component
+        server: "{{server}}"
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
+        syncOptions:
+          - CreateNamespace=true
+        retry:
+          limit: -1
+          backoff:
+            duration: 10s
+            factor: 2
+            maxDuration: 3m

--- a/argo-cd-apps/k-components/deploy-to-eaas-cluster-merge-generator/eaas-cluster-label-selector.yaml
+++ b/argo-cd-apps/k-components/deploy-to-eaas-cluster-merge-generator/eaas-cluster-label-selector.yaml
@@ -1,0 +1,6 @@
+---
+- op: add
+  path: /spec/generators/0/merge/generators/0/clusters/selector
+  value:
+      matchLabels:
+        appstudio.redhat.com/eaas-cluster: "true"

--- a/argo-cd-apps/k-components/deploy-to-eaas-cluster-merge-generator/kustomization.yaml
+++ b/argo-cd-apps/k-components/deploy-to-eaas-cluster-merge-generator/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+patches:
+  - path: eaas-cluster-label-selector.yaml
+    target:
+      group: argoproj.io
+      version: v1alpha1
+      kind: ApplicationSet

--- a/argo-cd-apps/overlays/production-downstream/kustomization.yaml
+++ b/argo-cd-apps/overlays/production-downstream/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../konflux-public-staging
+  - ../../base/eaas
   - ../../base/smee-client
   - ../../base/ui
   - ../../base/ca-bundle

--- a/argo-cd-apps/overlays/staging-downstream/kustomization.yaml
+++ b/argo-cd-apps/overlays/staging-downstream/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 namespace: argocd-staging
 resources:
   - ../konflux-public-staging
+  - ../../base/eaas
   - ../../base/smee-client
   - ../../base/ui
   - ../../base/ca-bundle

--- a/components/some-component/base/kustomization.yaml
+++ b/components/some-component/base/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- namespace.yaml

--- a/components/some-component/base/namespace.yaml
+++ b/components/some-component/base/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: some-component

--- a/components/some-component/production/kustomization.yaml
+++ b/components/some-component/production/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../base

--- a/components/some-component/staging/kustomization.yaml
+++ b/components/some-component/staging/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../base


### PR DESCRIPTION
This change add a new eaas folder where we can put all ArgoCD applications specific to that cluster type.

To have a complete skeleton, add a dummy application/component named `some-component`, to be replaced with real one.