### PR TITLE
Do not create openshift-logging namespace

### DIFF
--- a/components/monitoring/logging/base/logging-operator-prerequisite/kustomization.yaml
+++ b/components/monitoring/logging/base/logging-operator-prerequisite/kustomization.yaml
@@ -1,5 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- namespace.yaml
 - operatorgroup.yaml

--- a/components/monitoring/logging/base/logging-operator-prerequisite/namespace.yaml
+++ b/components/monitoring/logging/base/logging-operator-prerequisite/namespace.yaml
@@ -1,6 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: openshift-logging
-  annotations:
-    argocd.argoproj.io/sync-wave: "-1"


### PR DESCRIPTION
This was added to the prerequisite folder for stone-stage-p01 when it was HCP cluster but on ROSA clusters, the namespace already exists and cannot be tampered with as it is protected by admission web hook.

This is the reason why logging application is always out of sync on stone-prod-p01 and now the same is happening on kflux-stg-es01 as it will happen on stone-stage-p01 once ongoing re-installation is completed.