### PR TITLE
feat: allow integration team to manage integrationtestscenarios

### DIFF
--- a/components/integration/base/kustomization.yaml
+++ b/components/integration/base/kustomization.yaml
@@ -2,6 +2,7 @@ resources:
 - allow-argocd-to-manage.yaml
 - argocd-permissions.yaml
 - delete-snapshots.yaml
+- manage-integrationtestscenarios.yaml
 - integration.yaml
 
 apiVersion: kustomize.config.k8s.io/v1beta1

--- a/components/integration/base/manage-integrationtestscenarios.yaml
+++ b/components/integration/base/manage-integrationtestscenarios.yaml
@@ -1,0 +1,31 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: manage-integrationtestscenarios
+rules:
+  - apiGroups:
+    - "appstudio.redhat.com"
+    resources:
+      - "integrationtestscenarios"
+    verbs:
+      - "create"
+      - "get"
+      - "list"
+      - "patch"
+      - "update"
+      - "watch"
+      - "delete"
+      - "deletecollection"
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: manage-integrationtestscenarios
+subjects:
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: konflux-integration
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: manage-integrationtestscenarios


### PR DESCRIPTION
* The integration team is currently best suited to deal with issues with IntegrationTestScenario resources
* Giving the integration team permission to manage IntegrationTestScenarios across all namespaces will decrease customer complaints and prevent them from having to recognize and resolve the issue themselves