### PR TITLE
Enable Tekton StepActions in dev and staging

### DIFF
--- a/components/pipeline-service/development/enable-step-actions.yaml
+++ b/components/pipeline-service/development/enable-step-actions.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: operator.tekton.dev/v1alpha1
+kind: TektonConfig
+metadata:
+  name: config
+spec:
+  pipeline:
+    enable-step-actions: true

--- a/components/pipeline-service/development/kustomization.yaml
+++ b/components/pipeline-service/development/kustomization.yaml
@@ -52,3 +52,7 @@ patches:
       kind: Deployment
       namespace: tekton-results
       name: tekton-results-watcher
+  - path: enable-step-actions.yaml
+    target:
+      kind: TektonConfig
+      name: config

--- a/components/pipeline-service/staging/stone-stage-p01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stage-p01/deploy.yaml
@@ -1878,6 +1878,7 @@ spec:
     enable-git-resolver: true
     enable-hub-resolver: true
     enable-tekton-oci-bundles: true
+    enable-step-actions: true
     options:
       configMaps:
         config-logging:

--- a/components/pipeline-service/staging/stone-stg-m01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stg-m01/deploy.yaml
@@ -1878,6 +1878,7 @@ spec:
     enable-git-resolver: true
     enable-hub-resolver: true
     enable-tekton-oci-bundles: true
+    enable-step-actions: true
     options:
       configMaps:
         config-logging:

--- a/components/pipeline-service/staging/stone-stg-rh01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stg-rh01/deploy.yaml
@@ -1878,6 +1878,7 @@ spec:
     enable-git-resolver: true
     enable-hub-resolver: true
     enable-tekton-oci-bundles: true
+    enable-step-actions: true
     options:
       configMaps:
         config-logging:


### PR DESCRIPTION
This is a workaround for passing artifacts between tasks in an integration pipeline where workspaces backed by persistent volumes are not available. It was one of the suggestions proposed during last week's community architecture call on the topic of passing around ephemeral cluster credentials after they've been provisioned.