### PR TITLE
Deploy ci-helper-app only on clusters with matching label

### DIFF
--- a/argo-cd-apps/base/ci-helper-app/ci-helper-app.yaml
+++ b/argo-cd-apps/base/ci-helper-app/ci-helper-app.yaml
@@ -9,6 +9,9 @@ spec:
           - nameNormalized
         generators:
           - clusters:
+              selector:
+                matchLabels:
+                  appstudio.redhat.com/ci-helper-app: "true"
               values:
                 sourceRoot: components/ci-helper-app
                 environment: staging


### PR DESCRIPTION
Only deploy the application on clusters with label `appstudio.redhat.com/ci-helper-app: "true"`, i.e. stone-stg-rh01.