### PR TITLE
Only deploy quality-dashboard ApplicationSet on public staging

### DIFF
--- a/argo-cd-apps/base/local-cluster-secret/all-in-one/kustomization.yaml
+++ b/argo-cd-apps/base/local-cluster-secret/all-in-one/kustomization.yaml
@@ -7,5 +7,3 @@ components:
   - ../../../k-components/assign-host-role-to-local-cluster
   - ../../../k-components/assign-member-role-to-local-cluster
   - ../../../k-components/assign-internal-cluster-role-to-local-cluster
-commonLabels:
-  appstudio.redhat.com/quality-dashboard: "true"

--- a/argo-cd-apps/overlays/development/delete-applications.yaml
+++ b/argo-cd-apps/overlays/development/delete-applications.yaml
@@ -74,12 +74,6 @@ $patch: delete
 apiVersion: argoproj.io/v1alpha1
 kind: ApplicationSet
 metadata:
-  name: quality-dashboard
-$patch: delete
----
-apiVersion: argoproj.io/v1alpha1
-kind: ApplicationSet
-metadata:
   name: kubesaw-common
 $patch: delete
 ---

--- a/argo-cd-apps/overlays/development/kustomization.yaml
+++ b/argo-cd-apps/overlays/development/kustomization.yaml
@@ -9,7 +9,6 @@ resources:
   - ../../base/all-clusters
   - ../../base/ca-bundle
   - ../../base/repository-validator
-  - ../../base/quality-dashboard
   - ../../base/keycloak
   - ../../base/ui
 
@@ -152,8 +151,3 @@ patches:
       kind: ApplicationSet
       version: v1alpha1
       name: spacerequest-cleaner
-  - path: development-overlay-patch.yaml
-    target:
-      kind: ApplicationSet
-      version: v1alpha1
-      name: quality-dashboard

--- a/argo-cd-apps/overlays/production-downstream/delete-applications.yaml
+++ b/argo-cd-apps/overlays/production-downstream/delete-applications.yaml
@@ -23,3 +23,9 @@ kind: ApplicationSet
 metadata:
   name: ci-helper-app
 $patch: delete
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: quality-dashboard
+$patch: delete

--- a/argo-cd-apps/overlays/staging-downstream/delete-applications.yaml
+++ b/argo-cd-apps/overlays/staging-downstream/delete-applications.yaml
@@ -23,3 +23,9 @@ kind: ApplicationSet
 metadata:
   name: ci-helper-app
 $patch: delete
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: quality-dashboard
+$patch: delete


### PR DESCRIPTION
ApplicationSet was added to development overlay to then be deleted. Simplify this by not adding in the first place.

Since both staging and production downstream are based on public staging overlay, they inherit the quality-dashboard  ApplicationSet but we do not have a cluster labeled with
`appstudio.redhat.com/quality-dashboard: "true"` so not application are created. Delete the ApplicationSet from those overlays.