### PR TITLE
feat: Add ability to run the e2e-tests from rhtap-build-tenant ns

### DIFF
--- a/components/build-templates/base/e2e/rolebinding.yaml
+++ b/components/build-templates/base/e2e/rolebinding.yaml
@@ -14,6 +14,9 @@ subjects:
 - kind: ServiceAccount
   name: appstudio-pipeline
   namespace: konflux-ci
+- kind: ServiceAccount
+  name: appstudio-pipeline
+  namespace: rhtap-build-tenant
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -30,6 +33,9 @@ subjects:
 - kind: ServiceAccount
   name: appstudio-pipeline
   namespace: konflux-ci
+- kind: ServiceAccount
+  name: appstudio-pipeline
+  namespace: rhtap-build-tenant
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -46,6 +52,9 @@ subjects:
 - kind: ServiceAccount
   name: appstudio-pipeline
   namespace: konflux-ci
+- kind: ServiceAccount
+  name: appstudio-pipeline
+  namespace: rhtap-build-tenant
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
`rhtap-build-tenant:appstudio-pipeline` SA needs the same level of privileges that our `tekton-ci:appstudio-pipeline` sa has, to be able to run the e2e-tests in `build-templates-e2e` namespace of production cluster.
This PR adds required role-binding for `rhtap-build-tenant:appstudio-pipeline` SA to run e2e-tests in build-templates-e2e ns.
Part of the story: https://issues.redhat.com/browse/STONEBLD-2353
After the source-build image is built, we will run the e2e-tests through the integration-pipeline added in [this PR](https://github.com/redhat-appstudio/build-tasks-dockerfiles/pull/85) 