### PR TITLE
chore: qd: konflux-qe-admins perms for pods

### DIFF
--- a/components/ci-helper-app/base/rbac/ci-helper-app.yaml
+++ b/components/ci-helper-app/base/rbac/ci-helper-app.yaml
@@ -14,6 +14,7 @@ rules:
       - ''
     resources:
       - secrets
+      - pods
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/components/quality-dashboard/base/rbac/quality-dashboard.yaml
+++ b/components/quality-dashboard/base/rbac/quality-dashboard.yaml
@@ -14,6 +14,7 @@ rules:
       - ''
     resources:
       - secrets
+      - pods
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
we want to be able to restart pods for QD and ci-helper-app on staging cluster in cases when for example secrets get updated in vault