### PR TITLE
Improve deployment

### DIFF
--- a/components/keycloak/base/namespace.yaml
+++ b/components/keycloak/base/namespace.yaml
@@ -3,3 +3,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: rhtap-auth
+  annotations:
+    argocd.argoproj.io/sync-wave: "-3"

--- a/components/keycloak/base/rhsso-operator.yaml
+++ b/components/keycloak/base/rhsso-operator.yaml
@@ -3,6 +3,8 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
   name: rhsso-operator
+  annotations:
+    argocd.argoproj.io/sync-wave: "-2"
 spec:
   channel: stable
   name: rhsso-operator
@@ -14,6 +16,8 @@ apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:
   name: keycloak-operatorgroup
+  annotations:
+    argocd.argoproj.io/sync-wave: "-3"
 spec:
   targetNamespaces:
     - rhtap-auth

--- a/components/sandbox/toolchain-host-operator/base/kustomization.yaml
+++ b/components/sandbox/toolchain-host-operator/base/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
 - ./monitoring
 - ./proxy
 - ./olm
+- ns.yaml

--- a/components/sandbox/toolchain-host-operator/base/ns.yaml
+++ b/components/sandbox/toolchain-host-operator/base/ns.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "-5"
+  name: to-be-added-by-kustomize

--- a/components/sandbox/toolchain-host-operator/base/olm/toolchain-host-operator.yaml
+++ b/components/sandbox/toolchain-host-operator/base/olm/toolchain-host-operator.yaml
@@ -3,6 +3,8 @@ kind: CatalogSource
 metadata:
   labels:
     opsrc-provider: codeready-toolchain
+  annotations:
+    argocd.argoproj.io/sync-wave: "-4"
   name: dev-sandbox-host
   namespace: toolchain-host-operator
 spec:
@@ -18,6 +20,8 @@ kind: OperatorGroup
 metadata:
   name: dev-sandbox-host
   namespace: toolchain-host-operator
+  annotations:
+    argocd.argoproj.io/sync-wave: "-3"
 spec:
   targetNamespaces:
   - toolchain-host-operator
@@ -27,6 +31,8 @@ kind: Subscription
 metadata:
   name: dev-sandbox-host
   namespace: toolchain-host-operator
+  annotations:
+    argocd.argoproj.io/sync-wave: "-2"
 spec:
   channel: staging
   installPlanApproval: Automatic

--- a/components/sandbox/toolchain-member-operator/base/kustomization.yaml
+++ b/components/sandbox/toolchain-member-operator/base/kustomization.yaml
@@ -4,3 +4,4 @@ namespace: toolchain-member-operator
 resources:
 - ./rbac
 - ./olm
+- ns.yaml

--- a/components/sandbox/toolchain-member-operator/base/ns.yaml
+++ b/components/sandbox/toolchain-member-operator/base/ns.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "-5"
+  name: to-be-added-by-kustomize

--- a/components/sandbox/toolchain-member-operator/base/olm/toolchain-member-operator.yaml
+++ b/components/sandbox/toolchain-member-operator/base/olm/toolchain-member-operator.yaml
@@ -3,6 +3,8 @@ kind: CatalogSource
 metadata:
   labels:
     opsrc-provider: codeready-toolchain
+  annotations:
+    argocd.argoproj.io/sync-wave: "-4"
   name: dev-sandbox-member
   namespace: toolchain-member-operator
 spec:
@@ -18,6 +20,8 @@ kind: OperatorGroup
 metadata:
   name: dev-sandbox-member
   namespace: toolchain-member-operator
+  annotations:
+    argocd.argoproj.io/sync-wave: "-3"
 spec:
   targetNamespaces:
   - toolchain-member-operator
@@ -27,6 +31,8 @@ kind: Subscription
 metadata:
   name: dev-sandbox-member
   namespace: toolchain-member-operator
+  annotations:
+    argocd.argoproj.io/sync-wave: "-2"
 spec:
   channel: staging
   installPlanApproval: Automatic


### PR DESCRIPTION
    Sync waves for Keycloak
    
    Deploy the namespace, operator group, subscription, and then
    all the rest. Otherwise CRs are failed to get deployed.


    Improve sandbox deployment
    
    1. Create the namespace for the host and member components.
    2. Use sync waves because there are dependency between the resources.
