### PR TITLE
KFLUXINFRA-570: Config Change for Multi-Arch Builds Public Staging

### DIFF
--- a/components/multi-platform-controller/staging/external-secrets.yaml
+++ b/components/multi-platform-controller/staging/external-secrets.yaml
@@ -11,7 +11,7 @@ metadata:
 spec:
   dataFrom:
     - extract:
-        key: staging/build/multi-platform-controller/aws-ssh-key
+        key: staging/build/multi-platform-controller/public-stage-ssh-key
   refreshInterval: 1h
   secretStoreRef:
     kind: ClusterSecretStore
@@ -57,7 +57,7 @@ metadata:
 spec:
   dataFrom:
     - extract:
-        key: staging/build/multi-platform-controller/aws-account
+        key: staging/build/multi-platform-controller/public-stage-aws-account
   refreshInterval: 1h
   secretStoreRef:
     kind: ClusterSecretStore

--- a/components/multi-platform-controller/staging/host-config.yaml
+++ b/components/multi-platform-controller/staging/host-config.yaml
@@ -12,23 +12,27 @@ data:
 
   dynamic.linux-arm64.type: aws
   dynamic.linux-arm64.region: us-east-1
-  dynamic.linux-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-arm64.ami: ami-078a9bdcc8d8f2c9c
   dynamic.linux-arm64.instance-type: t4g.small
-  dynamic.linux-arm64.key-name: multi-platform-aws-stage
+  dynamic.linux-arm64.key-name: konflux-stage-ext-mab01
   dynamic.linux-arm64.aws-secret: aws-account
   dynamic.linux-arm64.ssh-secret: aws-ssh-key
-  dynamic.linux-arm64.security-group: "launch-wizard-1"
+  dynamic.linux-arm64.security-group: "multi-arch-build-sg"
   dynamic.linux-arm64.max-instances: "10"
+  dynamic.linux-arm64.spot-price: "0.010"
+  dynamic.linux-arm64.subnet-id: subnet-030738beb81d3863a
 
   dynamic.linux-amd64.type: aws
   dynamic.linux-amd64.region: us-east-1
-  dynamic.linux-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-amd64.ami: ami-06461039ebf1a764d
   dynamic.linux-amd64.instance-type: m5.large
-  dynamic.linux-amd64.key-name: multi-platform-aws-stage
+  dynamic.linux-amd64.key-name: konflux-stage-ext-mab01
   dynamic.linux-amd64.aws-secret: aws-account
   dynamic.linux-amd64.ssh-secret: aws-ssh-key
-  dynamic.linux-amd64.security-group: "launch-wizard-1"
+  dynamic.linux-amd64.security-group: "multi-arch-build-sg"
   dynamic.linux-amd64.max-instances: "10"
+  dynamic.linux-amd64.spot-price: "0.050"
+  dynamic.linux-amd64.subnet-id: subnet-030738beb81d3863a
 
   host.ppc1.address: "150.240.147.198"
   host.ppc1.platform: "linux/ppc64le"


### PR DESCRIPTION
This PR will make the following changes --

- Replace RHEL Base images with Blessed Images
- Make use of spot instances
- New AWS Account for provisioning multi-arch VM(s)