### PR TITLE
build-service: fix prod image reference

### DIFF
--- a/components/build-service/production/base/kustomization.yaml
+++ b/components/build-service/production/base/kustomization.yaml
@@ -8,8 +8,8 @@ resources:
 namespace: build-service
 
 images:
-- name: quay.io/redhat-appstudio/build-service
-  newName: quay.io/redhat-appstudio/build-service
+- name: quay.io/konflux-ci/build-service
+  newName: quay.io/konflux-ci/build-service
   newTag: 0e591f628aab9cbe9fac2b9bdc8883e955a560e7
 
 commonAnnotations:


### PR DESCRIPTION
[STONEBLD-2336](https://issues.redhat.com//browse/STONEBLD-2336)

The build-service commit ref got automatically promoted in
5056de658b40f80a3e8a80f409ed36a0fed6ab0a without the corresponding image
ref update.

Signed-off-by: Adam Cmiel <acmiel@redhat.com>
