### PR TITLE
Additional sandbox configurations for int staging

### DIFF
--- a/components/sandbox/toolchain-host-operator/staging/stone-stage-p01/kustomization.yaml
+++ b/components/sandbox/toolchain-host-operator/staging/stone-stage-p01/kustomization.yaml
@@ -4,3 +4,4 @@ resources:
 - ../../base
 - toolchainconfig.yaml
 - space-provisioner-configs.yaml
+- network-policy.yaml

--- a/components/sandbox/toolchain-host-operator/staging/stone-stage-p01/network-policy.yaml
+++ b/components/sandbox/toolchain-host-operator/staging/stone-stage-p01/network-policy.yaml
@@ -1,0 +1,18 @@
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-traffic-from-ui-proxy-and-router
+  namespace: toolchain-host-operator
+spec:
+  podSelector: {}
+  ingress:
+    - from:
+      - namespaceSelector:
+          matchLabels:
+            policy-group.network.openshift.io/ingress: ""
+    - from:
+      - namespaceSelector:
+          matchLabels:
+            kubernetes.io/metadata.name: rhtap-ui
+  policyTypes:
+    - Ingress

--- a/components/sandbox/toolchain-host-operator/staging/stone-stage-p01/space-provisioner-configs.yaml
+++ b/components/sandbox/toolchain-host-operator/staging/stone-stage-p01/space-provisioner-configs.yaml
@@ -1,10 +1,10 @@
 apiVersion: toolchain.dev.openshift.com/v1alpha1
 kind: SpaceProvisionerConfig
 metadata:
-  name: member-stone-stage-p01.apys.p3.openshiftapps.com
+  name: member-stone-stage-p01.hpmt.p1.openshiftapps.com
   namespace: toolchain-host-operator
 spec:
-  toolchainCluster: member-stone-stage-p01.apys.p3.openshiftapps.com
+  toolchainCluster: member-stone-stage-p01.hpmt.p1.openshiftapps.com
   enabled: true
   capacityThresholds:
     maxNumberOfSpaces: 1500


### PR DESCRIPTION
    Router and UI proxy access for the registration service
    
    The OCP router needs access to the host operator namespace since
    it has routes in it.
    
    In addition, the proxy used by the UI needs to access the registration
    service.

    Update routes for int stage space provisioner
