### PR TITLE
Reverting to Old AMIs

### DIFF
--- a/components/multi-platform-controller/staging/host-config.yaml
+++ b/components/multi-platform-controller/staging/host-config.yaml
@@ -12,7 +12,7 @@ data:
 
   dynamic.linux-arm64.type: aws
   dynamic.linux-arm64.region: us-east-1
-  dynamic.linux-arm64.ami: ami-078a9bdcc8d8f2c9c
+  dynamic.linux-arm64.ami: ami-03d6a5256a46c9feb
   dynamic.linux-arm64.instance-type: t4g.small
   dynamic.linux-arm64.key-name: konflux-stage-ext-mab01
   dynamic.linux-arm64.aws-secret: aws-account
@@ -25,7 +25,7 @@ data:
 
   dynamic.linux-amd64.type: aws
   dynamic.linux-amd64.region: us-east-1
-  dynamic.linux-amd64.ami: ami-06461039ebf1a764d
+  dynamic.linux-amd64.ami: ami-026ebd4cfe2c043b2
   dynamic.linux-amd64.instance-type: m5.large
   dynamic.linux-amd64.key-name: konflux-stage-ext-mab01
   dynamic.linux-amd64.aws-secret: aws-account


### PR DESCRIPTION
Blessed AMI(s) are encrypted with KMS Keys from Another AWS Account.

That would require some spike story to use them for the Multi-Platform Controller. 