### PR TITLE
PVCORE-4213 - Initial tracing commit

### DIFF
--- a/argo-cd-apps/base/all-clusters/infra-deployments/enable-tekton-tracing/enable-tekton-tracing.yaml
+++ b/argo-cd-apps/base/all-clusters/infra-deployments/enable-tekton-tracing/enable-tekton-tracing.yaml
@@ -1,0 +1,38 @@
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: enable-tekton-tracing
+spec:
+  generators:
+    - merge:
+        mergeKeys:
+          - nameNormalized
+        generators:
+          - clusters:
+              values:
+                sourceRoot: configs/enable-tekton-tracing
+                environment: staging
+                clusterDir: ""
+          - list:
+              elements: []
+  template:
+    metadata:
+      name: enable-tekton-tracing-{{nameNormalized}}
+    spec:
+      project: default
+      source:
+        path: configs/enable-tekton-tracing
+        repoURL: https://github.com/redhat-appstudio/infra-deployments.git
+        targetRevision: main
+      destination:
+        server: '{{server}}'
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
+        retry:
+          limit: -1
+          backoff:
+            duration: 10s
+            factor: 2
+            maxDuration: 3m

--- a/argo-cd-apps/base/all-clusters/infra-deployments/enable-tekton-tracing/kustomization.yaml
+++ b/argo-cd-apps/base/all-clusters/infra-deployments/enable-tekton-tracing/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - enable-tekton-tracing.yaml

--- a/argo-cd-apps/base/all-clusters/infra-deployments/kustomization.yaml
+++ b/argo-cd-apps/base/all-clusters/infra-deployments/kustomization.yaml
@@ -11,5 +11,7 @@ resources:
   - disable-csvcopy-for-all-cluster
   - enable-dvo-for-all-cluster
   - kubesaw-common
+  - tracing-workload-otel-collector
+  - enable-tekton-tracing
 components:
   - ../../../k-components/inject-infra-deployments-repo-details

--- a/argo-cd-apps/base/all-clusters/infra-deployments/tracing-workload-otel-collector/kustomization.yaml
+++ b/argo-cd-apps/base/all-clusters/infra-deployments/tracing-workload-otel-collector/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- tracing-workload-otel-collector.yaml

--- a/argo-cd-apps/base/all-clusters/infra-deployments/tracing-workload-otel-collector/tracing-workload-otel-collector.yaml
+++ b/argo-cd-apps/base/all-clusters/infra-deployments/tracing-workload-otel-collector/tracing-workload-otel-collector.yaml
@@ -1,0 +1,132 @@
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: tracing-workload-otel-collector
+  labels:
+    ### Prevent the repoURL from being transformed to a local fork name.
+    noSourceTransform: "true"
+spec:
+  generators:
+    - merge:
+        mergeKeys:
+          - nameNormalized
+        generators:
+          - clusters:
+              values:
+                sourceRoot: components/tracing/otel-collector
+                environment: staging
+                clusterDir: ""
+          - list:
+              elements: []
+  template:
+    metadata:
+      name: tracing-workload-otel-collector-{{nameNormalized}}
+    spec:
+      project: default
+      source:
+        chart: opentelemetry-collector
+        path: '{{values.sourceRoot}}/{{values.environment}}/{{values.clusterDir}}'
+        repoURL: https://open-telemetry.github.io/opentelemetry-helm-charts
+        targetRevision: 0.90.1
+        helm:
+          parameters:
+            - name: "image.repository"
+              value: otel/opentelemetry-collector-k8s
+            - name: "mode"
+              value: deployment
+          releaseName: open-telemetry
+          values: |
+            config:
+              exporters:
+                debug:
+                  verbosity: basic
+              #             ### To be configured in later work for stage and prod clusters..
+              #                otlphttp:
+              #                  endpoint: https://api.honeycomb.io:443
+              #                  headers:
+              #                    "x-honeycomb-team": ${HONEYCOMB_API_TOKEN}
+              extensions:
+                # The health_check extension is mandatory for this chart.
+                # Without the health_check extension the collector will fail the readiness and liveliness probes.
+                # The health_check extension can be modified, but should never be removed.
+                health_check: {}
+                memory_ballast: {}
+              processors:
+                batch: {}
+                # If set to null, will be overridden with values based on k8s resource limits
+                memory_limiter:
+                  check_interval: 2s
+                  limit_mib: 512
+                  spike_limit_percentage: 100
+                attributes/collector-info:
+                  actions:
+                    - key: collector.hostname
+                      action: insert
+                      value: ${env:HOSTNAME}
+                    - key: collector.clustername
+                      action: insert
+                      value: dev
+              receivers:
+                jaeger: null
+                prometheus: null
+                zipkin: null
+                otlp:
+                  protocols:
+                    grpc:
+                      endpoint: 0.0.0.0:4317
+                      max_recv_msg_size_mib: 999999999
+                    http:
+                      endpoint: 0.0.0.0:4318
+              service:
+                extensions:
+                  - health_check
+                  - memory_ballast
+                pipelines:
+                  traces:
+                    exporters:
+                      - debug
+                    processors:
+                      - memory_limiter
+                      - attributes/collector-info
+                      - batch
+                    receivers:
+                      - otlp
+                  metrics: null
+            # Configuration for ports
+            ports:
+              otlp:
+                enabled: true
+                containerPort: 4317
+                servicePort: 4317
+                hostPort: 4317
+                protocol: TCP
+              otlp-http:
+                enabled: true
+                containerPort: 4318
+                servicePort: 4318
+                hostPort: 4318
+                protocol: TCP
+              jaeger-compact:
+                enabled: false
+              jaeger-thrift:
+                enabled: false
+              jaeger-grpc:
+                enabled: false
+              zipkin:
+                enabled: false
+
+      destination:
+        namespace: konflux-otel
+        server: '{{server}}'
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
+        syncOptions:
+          - CreateNamespace=true
+        retry:
+          limit: 50
+          backoff:
+            duration: 10s
+            factor: 2
+            maxDuration: 3m

--- a/argo-cd-apps/k-components/inject-infra-deployments-repo-details/kustomization.yaml
+++ b/argo-cd-apps/k-components/inject-infra-deployments-repo-details/kustomization.yaml
@@ -7,8 +7,10 @@ patches:
       group: argoproj.io
       version: v1alpha1
       kind: ApplicationSet
+      labelSelector: noSourceTransform != true
   - path: application-patch.yaml
     target:
       group: argoproj.io
       version: v1alpha1
       kind: Application
+      labelSelector: noSourceTransform != true

--- a/argo-cd-apps/overlays/development/kustomization.yaml
+++ b/argo-cd-apps/overlays/development/kustomization.yaml
@@ -159,3 +159,8 @@ patches:
       kind: ApplicationSet
       version: v1alpha1
       name: cluster-as-a-service
+  - path: development-overlay-patch.yaml
+    target:
+      kind: ApplicationSet
+      version: v1alpha1
+      name: tracing-workload-otel-collector

--- a/argo-cd-apps/overlays/konflux-public-production/delete-applications.yaml
+++ b/argo-cd-apps/overlays/konflux-public-production/delete-applications.yaml
@@ -4,3 +4,9 @@ kind: ApplicationSet
 metadata:
   name: gitops
 $patch: delete
+# otel-collector is dev only.
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: tracing-workload-otel-collector
+$patch: delete

--- a/argo-cd-apps/overlays/production-downstream/delete-applications.yaml
+++ b/argo-cd-apps/overlays/production-downstream/delete-applications.yaml
@@ -29,3 +29,9 @@ kind: ApplicationSet
 metadata:
   name: quality-dashboard
 $patch: delete
+# otel-collector is dev only.
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: tracing-workload-otel-collector
+$patch: delete

--- a/argo-cd-apps/overlays/staging-downstream/delete-applications.yaml
+++ b/argo-cd-apps/overlays/staging-downstream/delete-applications.yaml
@@ -29,3 +29,9 @@ kind: ApplicationSet
 metadata:
   name: quality-dashboard
 $patch: delete
+# otel-collector is dev only.
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: tracing-workload-otel-collector
+$patch: delete

--- a/argo-cd-apps/overlays/staging-downstream/kustomization.yaml
+++ b/argo-cd-apps/overlays/staging-downstream/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
   - ../../base/repository-validator
 patchesStrategicMerge:
   - delete-applications.yaml
+
 patches:
   - path: staging-downstream-overlay-patch.yaml
     target:

--- a/components/tracing/OWNERS
+++ b/components/tracing/OWNERS
@@ -1,0 +1,8 @@
+# See the OWNERS docs: https://go.k8s.io/owners
+
+approvers:
+- mike-kingsbury
+- mftb
+- pacho-rh
+- raks-tt
+

--- a/configs/enable-tekton-tracing/enable-tekton-tracing.yaml
+++ b/configs/enable-tekton-tracing/enable-tekton-tracing.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-tracing
+  namespace: openshift-pipelines
+data:
+  enabled: "true"
+  endpoint: "http://open-telemetry-opentelemetry-collector.konflux-otel.svc.cluster.local:4318/v1/traces"

--- a/configs/enable-tekton-tracing/kustomization.yaml
+++ b/configs/enable-tekton-tracing/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - enable-tekton-tracing.yaml


### PR DESCRIPTION
Initial Tracing support in Konflux.  Supports Tekton pipeline tracing forwarded to a local OpenTelemetry collector.  Future work includes a local instance of Jaeger for visualization and forwarding to SaaS provider(s).