### PR TITLE
Removing Spot Instance Option for Multi-Platform Build

### DIFF
--- a/components/multi-platform-controller/staging/host-config.yaml
+++ b/components/multi-platform-controller/staging/host-config.yaml
@@ -20,7 +20,7 @@ data:
   # dynamic.linux-arm64.security-group: "multi-arch-build-sg"
   dynamic.linux-arm64.security-group-id: sg-05bc8dd0b52158567
   dynamic.linux-arm64.max-instances: "10"
-  dynamic.linux-arm64.spot-price: "0.010"
+  # dynamic.linux-arm64.spot-price: "0.010"
   dynamic.linux-arm64.subnet-id: subnet-030738beb81d3863a
 
   dynamic.linux-amd64.type: aws
@@ -33,7 +33,7 @@ data:
   # dynamic.linux-amd64.security-group: "multi-arch-build-sg"
   dynamic.linux-amd64.security-group-id: sg-05bc8dd0b52158567
   dynamic.linux-amd64.max-instances: "10"
-  dynamic.linux-amd64.spot-price: "0.050"
+  # dynamic.linux-amd64.spot-price: "0.050"
   dynamic.linux-amd64.subnet-id: subnet-030738beb81d3863a
 
   host.ppc1.address: "150.240.147.198"


### PR DESCRIPTION
Removing Spot Instance Option for Multi-Platform Build.

We must handle the scenario to run an on-demand instance when the capacity is full. 