### PR TITLE
Router and UI proxy access for the registration service

### DIFF
--- a/components/sandbox/toolchain-host-operator/production/stone-prod-p02/kustomization.yaml
+++ b/components/sandbox/toolchain-host-operator/production/stone-prod-p02/kustomization.yaml
@@ -4,3 +4,4 @@ resources:
 - ../../base
 - toolchainconfig.yaml
 - space-provisioner-configs.yaml
+- network-policy.yaml

--- a/components/sandbox/toolchain-host-operator/production/stone-prod-p02/network-policy.yaml
+++ b/components/sandbox/toolchain-host-operator/production/stone-prod-p02/network-policy.yaml
@@ -1,0 +1,18 @@
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-traffic-from-ui-proxy-and-router
+  namespace: toolchain-host-operator
+spec:
+  podSelector: {}
+  ingress:
+    - from:
+      - namespaceSelector:
+          matchLabels:
+            policy-group.network.openshift.io/ingress: ""
+    - from:
+      - namespaceSelector:
+          matchLabels:
+            kubernetes.io/metadata.name: rhtap-ui
+  policyTypes:
+    - Ingress


### PR DESCRIPTION
The OCP router needs access to the host operator namespace since it has routes in it.

In addition, the proxy used by the UI needs to access the registration service.