### PR TITLE
Skip dry run on missing resources for sandbox host

### DIFF
--- a/components/sandbox/toolchain-host-operator/base/proxy/proxyplugin.yaml
+++ b/components/sandbox/toolchain-host-operator/base/proxy/proxyplugin.yaml
@@ -3,6 +3,8 @@ kind: ProxyPlugin
 metadata:
   name: tekton-results
   namespace: toolchain-host-operator
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   openShiftRouteTargetEndpoint:
     # see https://github.com/openshift-pipelines/pipeline-service/blob/main/operator/gitops/argocd/pipeline-service/tekton-results/api-route.yaml

--- a/components/sandbox/toolchain-host-operator/production/stone-prd-host1/space-provisioner-configs.yaml
+++ b/components/sandbox/toolchain-host-operator/production/stone-prd-host1/space-provisioner-configs.yaml
@@ -3,6 +3,8 @@ kind: SpaceProvisionerConfig
 metadata:
   name: member-stone-prd-m01.84db.p1.openshiftapps.com
   namespace: toolchain-host-operator
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   toolchainCluster: member-stone-prd-m01.84db.p1.openshiftapps.com
   enabled: true
@@ -17,6 +19,8 @@ kind: SpaceProvisionerConfig
 metadata:
   name: member-stone-prd-rh01.pg1f.p1.openshiftapps.com
   namespace: toolchain-host-operator
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   toolchainCluster: member-stone-prd-rh01.pg1f.p1.openshiftapps.com
   enabled: false

--- a/components/sandbox/toolchain-host-operator/production/stone-prod-p01/space-provisioner-configs.yaml
+++ b/components/sandbox/toolchain-host-operator/production/stone-prod-p01/space-provisioner-configs.yaml
@@ -3,6 +3,8 @@ kind: SpaceProvisionerConfig
 metadata:
   name: member-stone-prod-p01.wcfb.p1.openshiftapps.com
   namespace: toolchain-host-operator
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   toolchainCluster: member-stone-prod-p01.wcfb.p1.openshiftapps.com
   enabled: true

--- a/components/sandbox/toolchain-host-operator/production/stone-prod-p02/space-provisioner-configs.yaml
+++ b/components/sandbox/toolchain-host-operator/production/stone-prod-p02/space-provisioner-configs.yaml
@@ -3,6 +3,8 @@ kind: SpaceProvisionerConfig
 metadata:
   name: member-stone-prod-p02.hjvn.p1.openshiftapps.com
   namespace: toolchain-host-operator
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   toolchainCluster: member-stone-prod-p02.hjvn.p1.openshiftapps.com
   enabled: true

--- a/components/sandbox/toolchain-host-operator/staging/stone-stage-p01/space-provisioner-configs.yaml
+++ b/components/sandbox/toolchain-host-operator/staging/stone-stage-p01/space-provisioner-configs.yaml
@@ -3,6 +3,8 @@ kind: SpaceProvisionerConfig
 metadata:
   name: member-stone-stage-p01.hpmt.p1.openshiftapps.com
   namespace: toolchain-host-operator
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   toolchainCluster: member-stone-stage-p01.hpmt.p1.openshiftapps.com
   enabled: true

--- a/components/sandbox/toolchain-host-operator/staging/stone-stg-host/space-provisioner-configs.yaml
+++ b/components/sandbox/toolchain-host-operator/staging/stone-stg-host/space-provisioner-configs.yaml
@@ -3,6 +3,8 @@ kind: SpaceProvisionerConfig
 metadata:
   name: member-stone-stg-m01.7ayg.p1.openshiftapps.com
   namespace: toolchain-host-operator
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   toolchainCluster: member-stone-stg-m01.7ayg.p1.openshiftapps.com
   enabled: true
@@ -17,6 +19,8 @@ kind: SpaceProvisionerConfig
 metadata:
   name: member-stone-stg-rh01.l2vh.p1.openshiftapps.com
   namespace: toolchain-host-operator
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   toolchainCluster: member-stone-stg-rh01.l2vh.p1.openshiftapps.com
   enabled: false


### PR DESCRIPTION
Without it, the host crds are failed to be synced.