### PR TITLE
sandbox-host: Allow traffic from olm namespace

### DIFF
--- a/components/sandbox/toolchain-host-operator/base/olm/toolchain-host-operator.yaml
+++ b/components/sandbox/toolchain-host-operator/base/olm/toolchain-host-operator.yaml
@@ -39,3 +39,26 @@ spec:
   name: toolchain-host-operator
   source: dev-sandbox-host
   sourceNamespace: toolchain-host-operator
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-from-olm
+  namespace: toolchain-host-operator
+  annotations:
+    argocd.argoproj.io/sync-wave: "-5"
+spec:
+  podSelector:
+    matchLabels:
+      olm.catalogSource: dev-sandbox-host
+  ingress:
+    - ports:
+        - protocol: TCP
+          port: 50051
+      from:
+        - podSelector: {}
+          namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-operator-lifecycle-manager
+  policyTypes:
+    - Ingress


### PR DESCRIPTION
The pods in the olm namespace need to access the catalog source pod which run on the toolchain-host-operator namespace.