### PR TITLE
Skip dry run on missing resources for keycloak

### DIFF
--- a/components/keycloak/base/configure-keycloak.yaml
+++ b/components/keycloak/base/configure-keycloak.yaml
@@ -20,6 +20,8 @@ metadata:
   labels:
     app: sso
   name: keycloak
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   external:
     enabled: false
@@ -40,6 +42,8 @@ metadata:
   labels:
     realm: redhat-external
     app: sso
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   instanceSelector:
     matchLabels:
@@ -284,6 +288,8 @@ metadata:
   name: cloud-services
   labels:
     app: sso
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   client:
     enabled: true


### PR DESCRIPTION
Without it, the keycloak crds are failed to be synced.