### PR TITLE
Skip dry run on missing resources for backup

### DIFF
--- a/components/backup/base/all-clusters/oadp/dpa.yaml
+++ b/components/backup/base/all-clusters/oadp/dpa.yaml
@@ -4,6 +4,7 @@ metadata:
   name: velero-aws
   annotations:
     argocd.argoproj.io/sync-wave: "-1"
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   backupLocations:
     - velero:

--- a/components/backup/base/host/schedules/backup-toolchain-host-schedule.yaml
+++ b/components/backup/base/host/schedules/backup-toolchain-host-schedule.yaml
@@ -2,6 +2,8 @@ apiVersion: velero.io/v1
 kind: Schedule
 metadata:
   name: backup-toolchain-host
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   schedule: 30 1,13 * * * # every day 1:30, 13:30 UTC
   template:

--- a/components/backup/base/member/schedules/backup-tenants-schedule.yaml
+++ b/components/backup/base/member/schedules/backup-tenants-schedule.yaml
@@ -2,6 +2,8 @@ apiVersion: velero.io/v1
 kind: Schedule
 metadata:
   name: backup-tenants
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   schedule: 30 1,13 * * * # every day 1:30, 13:30 UTC
   template:

--- a/components/backup/base/member/schedules/backup-toolchain-member-schedule.yaml
+++ b/components/backup/base/member/schedules/backup-toolchain-member-schedule.yaml
@@ -2,6 +2,8 @@ apiVersion: velero.io/v1
 kind: Schedule
 metadata:
   name: backup-toolchain-member
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   schedule: 30 1,13 * * * # every day 1:30, 13:30 UTC
   template:


### PR DESCRIPTION
Without it, the backup crds are failed to be synced.