### PR TITLE
Build CM - fix docker build pipeline name

### DIFF
--- a/components/build-service/base/build-pipeline-config/build-pipeline-config.yaml
+++ b/components/build-service/base/build-pipeline-config/build-pipeline-config.yaml
@@ -5,9 +5,9 @@ metadata:
   namespace: build-service
 data:
   config.yaml: |
-    default-pipeline-name: docker-builder
+    default-pipeline-name: docker-build
     pipelines:
     - name: fbc-builder
       bundle: quay.io/redhat-appstudio-tekton-catalog/pipeline-fbc-builder:13ecd03ec9f7de811f837a5460c41105231c911a
-    - name: docker-builder
+    - name: docker-build
       bundle: quay.io/redhat-appstudio-tekton-catalog/pipeline-docker-build:13ecd03ec9f7de811f837a5460c41105231c911a


### PR DESCRIPTION
The name of the pipeline in the bundle is "docker-build" not "docker-builder".