### PR TITLE
Enable auto-approval for external prod

### DIFF
--- a/components/sandbox/toolchain-host-operator/production/stone-prd-host1/space-provisioner-configs.yaml
+++ b/components/sandbox/toolchain-host-operator/production/stone-prd-host1/space-provisioner-configs.yaml
@@ -7,7 +7,7 @@ metadata:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   toolchainCluster: member-stone-prd-m01.84db.p1.openshiftapps.com
-  enabled: true
+  enabled: false
   capacityThresholds:
     maxNumberOfSpaces: 1000
     maxMemoryUtilizationPercent: 90
@@ -23,7 +23,7 @@ metadata:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   toolchainCluster: member-stone-prd-rh01.pg1f.p1.openshiftapps.com
-  enabled: false
+  enabled: true
   capacityThresholds:
     maxMemoryUtilizationPercent: 90
   placementRoles:

--- a/components/sandbox/toolchain-host-operator/production/stone-prd-host1/toolchainconfig.yaml
+++ b/components/sandbox/toolchain-host-operator/production/stone-prd-host1/toolchainconfig.yaml
@@ -10,7 +10,8 @@ spec:
     tiers:
       defaultSpaceTier: 'appstudio'
     automaticApproval:
-      enabled: false
+      enabled: true
+      domains: 'redhat.com'
     spaceConfig:
       spaceRequestEnabled: true
       spaceBindingRequestEnabled: true


### PR DESCRIPTION
Implements: [ASC-541](https://issues.redhat.com//browse/ASC-541)

Also changing the default target from m01 to rh01. There is no need to manually move workspaces after this change is merged