### PR TITLE
fix(STONEINTG-861): update intg configMap name for CONSOLE_NAME

### DIFF
--- a/components/integration/development/manager_resources_patch.yaml
+++ b/components/integration/development/manager_resources_patch.yaml
@@ -19,7 +19,7 @@ spec:
         - name: CONSOLE_NAME
           valueFrom:
             configMapKeyRef:
-              name: console-name
+              name: console-url
               key: CONSOLE_NAME
               optional: true
         - name: CONSOLE_URL

--- a/components/integration/production/base/manager_resources_patch.yaml
+++ b/components/integration/production/base/manager_resources_patch.yaml
@@ -19,7 +19,7 @@ spec:
         - name: CONSOLE_NAME
           valueFrom:
               configMapKeyRef:
-                name: console-name
+                name: console-url
                 key: CONSOLE_NAME
                 optional: true
         - name: CONSOLE_URL

--- a/components/integration/staging/base/manager_resources_patch.yaml
+++ b/components/integration/staging/base/manager_resources_patch.yaml
@@ -19,7 +19,7 @@ spec:
         - name: CONSOLE_NAME
           valueFrom:
               configMapKeyRef:
-                name: console-name
+                name: console-url
                 key: CONSOLE_NAME
                 optional: true
         - name: CONSOLE_URL


### PR DESCRIPTION
A fix for https://github.com/redhat-appstudio/infra-deployments/pull/3763, we should use `console-url` as configMap name.

Signed-off-by: Hongwei Liu <hongliu@redhat.com>