### PR TITLE
fix(STONEINTG-861): add 'Konflux Dev version' to CONSOLE_NAME

### DIFF
--- a/components/integration/development/kustomization.yaml
+++ b/components/integration/development/kustomization.yaml
@@ -13,7 +13,7 @@ images:
 configMapGenerator:
 - name: console-url
   literals:
-    - CONSOLE_NAME=""
+    - CONSOLE_NAME="Konflux Dev version"
     - CONSOLE_URL=""
     - CONSOLE_URL_TASKLOG=""
 - name: pipelinerun-options


### PR DESCRIPTION
* add 'Konflux Dev version' to CONSOLE_NAME  development env configuration file

Signed-off-by: Hongwei Liu <hongliu@redhat.com>