### PR TITLE
Add cluster-as-a-service resources

### DIFF
--- a/argo-cd-apps/base/eaas/cluster-as-a-service/cluster-as-a-service.yaml
+++ b/argo-cd-apps/base/eaas/cluster-as-a-service/cluster-as-a-service.yaml
@@ -27,6 +27,12 @@ spec:
       destination:
         namespace: cluster-as-a-service
         server: "{{server}}"
+      ignoreDifferences:
+        # Ignore generators applied by the CaaS operator to cluster template AppSets
+        - group: argoproj.io
+          kind: ApplicationSet
+          jqPathExpressions:
+            - .spec.generators
       syncPolicy:
         automated:
           prune: true

--- a/argo-cd-apps/k-components/deploy-to-all-clusters/all-clusters-label-selector.yaml
+++ b/argo-cd-apps/k-components/deploy-to-all-clusters/all-clusters-label-selector.yaml
@@ -8,3 +8,7 @@
       - key: app.kubernetes.io/name
         operator: NotIn
         values: [argocd-default-cluster-config]
+      # Prevent clusters provisioned by the cluster-as-a-service component from being used in
+      # an AppSet cluster generator.
+      - key: clustertemplateinstance.openshift.io/name
+        operator: DoesNotExist

--- a/components/cluster-as-a-service/base/argocd.yaml
+++ b/components/cluster-as-a-service/base/argocd.yaml
@@ -2,7 +2,9 @@
 apiVersion: argoproj.io/v1beta1
 kind: ArgoCD
 metadata:
- name: openshift-gitops
- namespace: openshift-gitops
+  name: openshift-gitops
+  namespace: openshift-gitops
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
- resourceTrackingMethod: annotation
+  resourceTrackingMethod: annotation

--- a/components/cluster-as-a-service/base/cluster-aas-operator.yaml
+++ b/components/cluster-as-a-service/base/cluster-aas-operator.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: caas-operator
+  # OLM dependency resolution forces us to install the CaaS operator in the same namespace as the
+  # openshift-gitops operator. Otherwise, OLM will resolve and install the ArgoCD operator from the
+  # community catalog.
+  namespace: openshift-operators
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  channel: alpha
+  installPlanApproval: Automatic
+  name: cluster-aas-operator
+  source: community-operators
+  sourceNamespace: openshift-marketplace
+
+---
+apiVersion: clustertemplate.openshift.io/v1alpha1
+kind: Config
+metadata:
+  name: config
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  argoCDNamespace: openshift-gitops
+  uiEnabled: false

--- a/components/cluster-as-a-service/base/clustertemplatequotas.yaml
+++ b/components/cluster-as-a-service/base/clustertemplatequotas.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: clustertemplate.openshift.io/v1alpha1
+kind: ClusterTemplateQuota
+metadata:
+  name: quota
+  namespace: clusters
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  budget: 100
+  allowedTemplates:
+    - name: hypershift-aws-cluster
+      deleteAfter: 2h

--- a/components/cluster-as-a-service/base/clustertemplates.yaml
+++ b/components/cluster-as-a-service/base/clustertemplates.yaml
@@ -1,0 +1,53 @@
+---
+apiVersion: clustertemplate.openshift.io/v1alpha1
+kind: ClusterTemplate
+metadata:
+  name: hypershift-aws-cluster
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  clusterDefinition: hypershift-aws-cluster
+  skipClusterRegistration: true
+  cost: 1
+
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: hypershift-aws-cluster
+  namespace: openshift-gitops
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  generators:
+    - {}
+  template:
+    metadata:
+      # Workaround for https://github.com/argoproj/argo-cd/issues/17181
+      finalizers:
+        - resources-finalizer.argocd.argoproj.io
+        - post-delete-finalizer.argocd.argoproj.io
+        - post-delete-finalizer.argocd.argoproj.io/cleanup
+    spec:
+      destination:
+        namespace: clusters
+        server: '{{ url }}'
+      project: default
+      source:
+        chart: hypershift-aws-template
+        repoURL: https://konflux-ci.dev/cluster-template-charts/
+        targetRevision: 0.0.2
+        helm:
+          parameters:
+            - name: region
+              value: us-east-1
+            - name: secret
+              value: hypershift
+            - name: serviceAccount
+              value: cluster-provisioner
+            - name: hypershiftImageTag
+              value: "4.14"
+            - name: nodePoolReplicas
+              value: "3"
+      syncPolicy:
+        automated: {}

--- a/components/cluster-as-a-service/base/kustomization.yaml
+++ b/components/cluster-as-a-service/base/kustomization.yaml
@@ -3,3 +3,9 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - argocd.yaml
+  - multicluster-engine.yaml
+  - cluster-aas-operator.yaml
+  - namespaces.yaml
+  - rbac.yaml
+  - clustertemplatequotas.yaml
+  - clustertemplates.yaml

--- a/components/cluster-as-a-service/base/multicluster-engine.yaml
+++ b/components/cluster-as-a-service/base/multicluster-engine.yaml
@@ -1,0 +1,40 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: multicluster-engine
+
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: multicluster-engine
+  namespace: multicluster-engine
+  annotations:
+    argocd.argoproj.io/sync-wave: "-2"
+spec:
+  targetNamespaces:
+    - multicluster-engine
+
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: multicluster-engine
+  namespace: multicluster-engine
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  channel: stable-2.5
+  installPlanApproval: Automatic
+  name: multicluster-engine
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+
+---
+apiVersion: multicluster.openshift.io/v1
+kind: MultiClusterEngine
+metadata:
+  name: engine
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true

--- a/components/cluster-as-a-service/base/namespaces.yaml
+++ b/components/cluster-as-a-service/base/namespaces.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: clusters
+  labels:
+    argocd.argoproj.io/managed-by: openshift-gitops

--- a/components/cluster-as-a-service/base/rbac.yaml
+++ b/components/cluster-as-a-service/base/rbac.yaml
@@ -1,0 +1,125 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cluster-provisioner
+  namespace: clusters
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cluster-provisioner
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - "*"
+- apiGroups:
+  - hypershift.openshift.io
+  resources:
+  - hostedclusters
+  - nodepools
+  verbs:
+  - "*"
+- apiGroups:
+  - clustertemplate.openshift.io
+  resources:
+  - clustertemplateinstances
+  verbs:
+  - "*"
+- apiGroups:
+  - clustertemplate.openshift.io
+  resources:
+  - clustertemplates
+  verbs:
+  - get
+  - list
+
+---
+# Allow the cluster-provisioner SA in the clusters namespace to manage clusters
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cluster-provisioner-rb
+  namespace: clusters
+subjects:
+- kind: ServiceAccount
+  name: cluster-provisioner
+  namespace: clusters
+roleRef:
+  kind: ClusterRole
+  name: cluster-provisioner
+  apiGroup: rbac.authorization.k8s.io
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: oidc-configmap-reader
+  namespace: kube-public
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  resourceNames:
+  - oidc-storage-provider-s3-config
+  verbs:
+  - get
+
+---
+# Allow all service accounts to read the OIDC bucket configuration
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: oidc-configmap-reader-rb
+  namespace: kube-public
+subjects:
+- kind: Group
+  name: system:serviceaccounts
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: Role
+  name: oidc-configmap-reader
+  apiGroup: rbac.authorization.k8s.io
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: supported-versions-reader
+  namespace: hypershift
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  resourceNames:
+  - supported-versions
+  verbs:
+  - get
+
+---
+# Allow all authenticated users to read the supported hypershift versions
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: supported-versions-reader-rb
+  namespace: hypershift
+subjects:
+- kind: Group
+  name: system:authenticated
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: Role
+  name: supported-versions-reader
+  apiGroup: rbac.authorization.k8s.io

--- a/components/cluster-as-a-service/development/add-base-domain-param.yaml
+++ b/components/cluster-as-a-service/development/add-base-domain-param.yaml
@@ -1,0 +1,6 @@
+---
+- op: add
+  path: /spec/template/spec/source/helm/parameters/-
+  value:
+    name: baseDomain
+    value: eaasdemo.com

--- a/components/cluster-as-a-service/development/kustomization.yaml
+++ b/components/cluster-as-a-service/development/kustomization.yaml
@@ -3,3 +3,9 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../base
+patches:
+  - path: add-base-domain-param.yaml
+    target:
+      group: argoproj.io
+      kind: ApplicationSet
+      version: v1alpha1


### PR DESCRIPTION
Also included is a fix for some Konflux Apps being undesirably deployed to the ephemeral clusters provided by the cluster-as-a-service component.