### PR TITLE
feat(RELEASE-935): update release-pipeline clusterrole

### DIFF
--- a/components/release/base/release-pipeline-resources-clusterrole.yaml
+++ b/components/release/base/release-pipeline-resources-clusterrole.yaml
@@ -25,3 +25,10 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - appstudio.redhat.com
+  resources:
+  - releases/status
+  verbs:
+  - get
+  - patch


### PR DESCRIPTION
This commit updates the release-pipeline-resources-clusterrole to be able to patch Releases. The get verb is also required in order to patch successfully. The reasoning behind this is we want a future task in release-service managed pipelines to update the Release.Status with the created artifacts.