### PR TITLE
Update repo validator config to latest revision

### DIFF
--- a/components/repository-validator/production/kustomization.yaml
+++ b/components/repository-validator/production/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - https://github.com/konflux-ci/repository-validator/config/ocp?ref=1a1bd5856c7caf40ebf3d9a24fce209ba8a74bd9
-  - https://github.com/redhat-appstudio/internal-infra-deployments/components/repository-validator/production?ref=ccb5d30304c16ba421d4b0380f9e9cedeefe0d49
+  - https://github.com/redhat-appstudio/internal-infra-deployments/components/repository-validator/production?ref=c16a02deb08e4cb63de9b66558306cfff2aa6ddb
 images:
   - name: controller
     newName: quay.io/redhat-user-workloads/konflux-infra-tenant/repository-validator/repository-validator

--- a/components/repository-validator/staging/kustomization.yaml
+++ b/components/repository-validator/staging/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - https://github.com/konflux-ci/repository-validator/config/ocp?ref=1a1bd5856c7caf40ebf3d9a24fce209ba8a74bd9
-  - https://github.com/redhat-appstudio/internal-infra-deployments/components/repository-validator/staging?ref=ccb5d30304c16ba421d4b0380f9e9cedeefe0d49
+  - https://github.com/redhat-appstudio/internal-infra-deployments/components/repository-validator/staging?ref=c16a02deb08e4cb63de9b66558306cfff2aa6ddb
 images:
   - name: controller
     newName: quay.io/redhat-user-workloads/konflux-infra-tenant/repository-validator/repository-validator


### PR DESCRIPTION
* Allow repository  github.com/parodos-dev/serverless-workflows

[KFLUXINFRA-563](https://issues.redhat.com//browse/KFLUXINFRA-563)