### PR TITLE
SRVKP-4361: enable results from sidecar logs for pipelines in prod - p01 only

### DIFF
--- a/components/pipeline-service/production/base/kustomization.yaml
+++ b/components/pipeline-service/production/base/kustomization.yaml
@@ -13,6 +13,7 @@ resources:
   - ../../base/external-secrets
   - ../../base/testing
   - ../../base/rbac
+  - tekton-pipelines-controller-pods-log-access-rbac.yaml
 
 images:
   - name: quay.io/redhat-appstudio/tekton-results-api
@@ -41,6 +42,10 @@ patches:
       namespace: tekton-results
       name: tekton-results-watcher
   - path: update-tekton-config-pac.yaml
+    target:
+      kind: TektonConfig
+      name: config
+  - path: update-tekton-config-features.yaml
     target:
       kind: TektonConfig
       name: config

--- a/components/pipeline-service/production/base/tekton-pipelines-controller-pods-log-access-rbac.yaml
+++ b/components/pipeline-service/production/base/tekton-pipelines-controller-pods-log-access-rbac.yaml
@@ -1,0 +1,30 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: tekton-pipelines-controller-pods-log-access
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
+  - list
+  - watch
+--- 
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: tekton-pipelines-controller-pods-log-access
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: tekton-pipelines-controller-pods-log-access
+subjects:
+  - kind: ServiceAccount
+    name: tekton-pipelines-controller
+    namespace: openshift-pipelines

--- a/components/pipeline-service/production/base/update-tekton-config-features.yaml
+++ b/components/pipeline-service/production/base/update-tekton-config-features.yaml
@@ -1,0 +1,12 @@
+---
+- op: add
+  path: /spec/pipeline/results-from
+  # default upstream setting
+  # value: termination-message
+  value: sidecar-logs
+
+- op: add
+  path: /spec/pipeline/max-result-size
+  # default upstream setting
+  # value: 4096
+  value: 12288

--- a/components/pipeline-service/production/stone-prod-p01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prod-p01/deploy.yaml
@@ -396,6 +396,23 @@ kind: ClusterRole
 metadata:
   annotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "0"
+  name: tekton-pipelines-controller-pods-log-access
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
   labels:
     app.kubernetes.io/part-of: tekton-results
     app.kubernetes.io/version: devel
@@ -826,6 +843,22 @@ subjects:
 - kind: ServiceAccount
   name: metrics-reader
   namespace: tekton-results
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "0"
+  name: tekton-pipelines-controller-pods-log-access
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: tekton-pipelines-controller-pods-log-access
+subjects:
+- kind: ServiceAccount
+  name: tekton-pipelines-controller
+  namespace: openshift-pipelines
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -1883,6 +1916,7 @@ spec:
     enable-git-resolver: true
     enable-hub-resolver: true
     enable-tekton-oci-bundles: true
+    max-result-size: 12288
     options:
       configMaps:
         config-logging:
@@ -1988,6 +2022,7 @@ spec:
       kube-api-qps: 50
       replicas: 2
       threads-per-controller: 32
+    results-from: sidecar-logs
   platforms:
     openshift:
       pipelinesAsCode:


### PR DESCRIPTION
see https://redhat-internal.slack.com/archives/C02CTEB3MMF/p1717120576571899 

@scoheb @lcarva @stuartwdouglas 

rh-pre-commit.version: 2.2.0
rh-pre-commit.check-secrets: ENABLED