### PR TITLE
fix: make build-service smee webhook url match smee-client for p02

### DIFF
--- a/components/build-service/production/stone-prod-p02/webhook-config.json
+++ b/components/build-service/production/stone-prod-p02/webhook-config.json
@@ -1,4 +1,4 @@
 {
-    "https://github.com": "https://smee-smee.apps.stone-prd-host1.wdlc.p1.openshiftapps.com/redhathook12",
-    "https://gitlab.com": "https://smee-smee.apps.stone-prd-host1.wdlc.p1.openshiftapps.com/redhathook12"
+    "https://github.com": "https://smee-smee.apps.stone-prd-host1.wdlc.p1.openshiftapps.com/redhathook13",
+    "https://gitlab.com": "https://smee-smee.apps.stone-prd-host1.wdlc.p1.openshiftapps.com/redhathook13"
 }


### PR DESCRIPTION
The smee-client on p02 is listening to "redhathook13" not redhathook12.