### PR TITLE
KONFLUX-3382 Add fast VM's for openshift AI

### DIFF
--- a/components/multi-platform-controller/production/host-config.yaml
+++ b/components/multi-platform-controller/production/host-config.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: multi-platform-controller
 data:
 
-  dynamic-platforms: linux/arm64,linux/amd64,linux-root/arm64,linux-root/amd64
+  dynamic-platforms: linux/arm64,linux/amd64,linux-root/arm64,linux-root/amd64,linux-fast/amd64,linux-extra-fast/amd64
   instance-tag: rhtap-prod
 
   dynamic.linux-arm64.type: aws
@@ -48,6 +48,35 @@ data:
   dynamic.linux-root-arm64.disk: "200"
   dynamic.linux-root-arm64.iops: "16000"
   dynamic.linux-root-arm64.throughput: "1000"
+
+
+  dynamic.linux-fast-amd64.type: aws
+  dynamic.linux-fast-amd64.region: us-east-1
+  dynamic.linux-fast-amd64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-fast-amd64.instance-type: c7a.8xlarge
+  dynamic.linux-fast-amd64.key-name: konflux-prod-ext-mab01
+  dynamic.linux-fast-amd64.aws-secret: aws-account
+  dynamic.linux-fast-amd64.ssh-secret: aws-ssh-key
+  dynamic.linux-fast-amd64.security-group-id: sg-0fbf35ced0d59fd4a
+  dynamic.linux-fast-amd64.subnet-id: subnet-0c39ff75f819abfc5
+  dynamic.linux-fast-amd64.max-instances: "10"
+  dynamic.linux-fast-amd64.disk: "200"
+  dynamic.linux-fast-amd64.iops: "16000"
+  dynamic.linux-fast-amd64.throughput: "1000"
+
+  dynamic.linux-extra-fast-amd64.type: aws
+  dynamic.linux-extra-fast-amd64.region: us-east-1
+  dynamic.linux-extra-fast-amd64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-extra-fast-amd64.instance-type: c7a.12xlarge
+  dynamic.linux-extra-fast-amd64.key-name: konflux-prod-ext-mab01
+  dynamic.linux-extra-fast-amd64.aws-secret: aws-account
+  dynamic.linux-extra-fast-amd64.ssh-secret: aws-ssh-key
+  dynamic.linux-extra-fast-amd64.security-group-id: sg-0fbf35ced0d59fd4a
+  dynamic.linux-extra-fast-amd64.subnet-id: subnet-0c39ff75f819abfc5
+  dynamic.linux-extra-fast-amd64.max-instances: "10"
+  dynamic.linux-extra-fast-amd64.disk: "200"
+  dynamic.linux-extra-fast-amd64.iops: "16000"
+  dynamic.linux-extra-fast-amd64.throughput: "1000"
 
   dynamic.linux-root-amd64.type: aws
   dynamic.linux-root-amd64.region: us-east-1


### PR DESCRIPTION
These are not for general use but at the moment we have no way of limiting this to specific namespaces.