### PR TITLE
Update name of e2e push secret

### DIFF
--- a/components/build-templates/production/e2e-quay-push-secret.yaml
+++ b/components/build-templates/production/e2e-quay-push-secret.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   dataFrom:
     - extract:
-        key: production/build/tekton-ci/quay-push-secret
+        key: production/build/tekton-ci/quay-push-secret-konflux-ci
   refreshInterval: 15m
   secretStoreRef:
     kind: ClusterSecretStore


### PR DESCRIPTION
This change updates the push secret so tests can push to the konflux-ci quay org.