### PR TITLE
Fix fast pool AMI

### DIFF
--- a/components/multi-platform-controller/production/host-config.yaml
+++ b/components/multi-platform-controller/production/host-config.yaml
@@ -52,7 +52,7 @@ data:
 
   dynamic.linux-fast-amd64.type: aws
   dynamic.linux-fast-amd64.region: us-east-1
-  dynamic.linux-fast-amd64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-fast-amd64.ami: ami-026ebd4cfe2c043b2
   dynamic.linux-fast-amd64.instance-type: c7a.8xlarge
   dynamic.linux-fast-amd64.key-name: konflux-prod-ext-mab01
   dynamic.linux-fast-amd64.aws-secret: aws-account
@@ -66,7 +66,7 @@ data:
 
   dynamic.linux-extra-fast-amd64.type: aws
   dynamic.linux-extra-fast-amd64.region: us-east-1
-  dynamic.linux-extra-fast-amd64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-extra-fast-amd64.ami: ami-026ebd4cfe2c043b2
   dynamic.linux-extra-fast-amd64.instance-type: c7a.12xlarge
   dynamic.linux-extra-fast-amd64.key-name: konflux-prod-ext-mab01
   dynamic.linux-extra-fast-amd64.aws-secret: aws-account


### PR DESCRIPTION
There was a copy/paste error that used an AMI with the wrong arch.