### PR TITLE
Correct Mintmaker's configuration for rpm lockfile

### DIFF
--- a/components/mintmaker/base/renovate-config.yaml
+++ b/components/mintmaker/base/renovate-config.yaml
@@ -10,7 +10,7 @@ data:
       "requireConfig": "optional",
       "platformCommit": true,
       "autodiscover": false,
-      "enabledManagers": ["tekton", "dockerfile", "lockFileMaintenance"],
+      "enabledManagers": ["tekton", "dockerfile", "rpm"],
       "tekton": {
         "fileMatch": ["\\.yaml$","\\.yml$"],
         "includePaths": [".tekton/**"],


### PR DESCRIPTION
The correct manager for the rpm lockfile in Mintmaker is rpm.