### PR TITLE
chore: quality-dashboard -> konflux-ci part 1

### DIFF
--- a/components/konflux-ci/base/repository.yaml
+++ b/components/konflux-ci/base/repository.yaml
@@ -26,3 +26,10 @@ metadata:
   name: e2e-tests
 spec:
   url: "https://github.com/konflux-ci/e2e-tests"
+---
+apiVersion: pipelinesascode.tekton.dev/v1alpha1
+kind: Repository
+metadata:
+  name: quality-dashboard
+spec:
+  url: "https://github.com/konflux-ci/quality-dashboard"

--- a/components/tekton-ci/base/repository.yaml
+++ b/components/tekton-ci/base/repository.yaml
@@ -75,10 +75,3 @@ metadata:
   name: infra-deployments
 spec:
   url: "https://github.com/redhat-appstudio/infra-deployments"
----
-apiVersion: pipelinesascode.tekton.dev/v1alpha1
-kind: Repository
-metadata:
-  name: quality-dashboard
-spec:
-  url: "https://github.com/redhat-appstudio/quality-dashboard"

--- a/docs/misc/quality-dashboard.md
+++ b/docs/misc/quality-dashboard.md
@@ -3,7 +3,7 @@ title: Quality Dashboard
 ---
 
 The purpose of the Quality Dashboard is to provide information that indicates the quality
-of the different Konflux services. More details can be found here https://github.com/redhat-appstudio/quality-dashboard
+of the different Konflux services. More details can be found here https://github.com/konflux-ci/quality-dashboard
 
 The manifests can be found [here](../../components/quality-dashboard/)
 

--- a/hack/preview-template.env
+++ b/hack/preview-template.env
@@ -135,7 +135,7 @@ export QD_JIRA_TOKEN=
 export QD_SLACK_TOKEN=
 ## Dex issuer specific secrets
 export QD_GITHUB_ORG=
-### Client ID/Secret for OAuth app - see https://github.com/redhat-appstudio/quality-dashboard?tab=readme-ov-file#dex-for-oauth for more details
+### Client ID/Secret for OAuth app - see https://github.com/konflux-ci/quality-dashboard?tab=readme-ov-file#dex-for-oauth for more details
 export QD_OAUTH_CLIENT_ID=
 export QD_OAUTH_CLIENT_SECRET=
 


### PR DESCRIPTION
https://issues.redhat.com/browse/KONFLUX-3398

new repositories are created:
* https://quay.io/repository/konflux-ci/quality-dashboard-backend?tab=tags
* https://quay.io/repository/konflux-ci/quality-dashboard-frontend?tab=tags
* https://github.com/konflux-ci/quality-dashboard/pull/322

so we're good to go regarding the migration to konflux-ci org

[image refs and links to github resources](https://github.com/redhat-appstudio/infra-deployments/tree/main/components/quality-dashboard/base) will be updated once https://github.com/konflux-ci/quality-dashboard/pull/322 is merged




