### PR TITLE
fix: post-setup verification script update

### DIFF
--- a/components/build-service/README.md
+++ b/components/build-service/README.md
@@ -21,16 +21,16 @@ To try out a pre-configured, follow these steps.
 | Steps    |    |
 | ----------- | ----------- |
 | 1.  Create project for your pipelines execution. This can be run as any non-admin user (or admin)  and is needed to hold your execution pipelines.  |  oc new-project demo     |
-| 2.  Run build-deploy example with a quarkus app. | ./hack/build/build-via-appstudio.sh https://github.com/devfile-samples/devfile-sample-code-with-quarkus
+| 2.  Run build-deploy example with a quarkus app. | ./hack/build/build-via-appstudio.sh https://github.com/devfile-samples/devfile-sample-code-with-quarkus src/main/docker/Dockerfile.jvm.staged
 | 3.  View your build on the OpenShift Console under the pipelines page or view the logs via CLI. | `tkn pipelinerun logs`      |
 
 ## Tests via RHTAP
 
 To validate execution via RHTAP you can run `./hack/build/build-via-appstudio.sh` script which sets credentials and RHTAP application and components. Without parameters it creates example components.
-To build specific repository, pass its URL as argument as shown below:
+To build specific repository, pass its URL and path to repository's Dockerfile as arguments as shown below:
 
 ```
-./hack/build/build-via-appstudio.sh https://github.com/devfile-samples/devfile-sample-java-springboot-basic
+./hack/build/build-via-appstudio.sh https://github.com/devfile-samples/devfile-sample-java-springboot-basic docker/Dockerfile
 ```
 
 To enable PipelineAsCode integration you need to set `PIPELINESASCODE` env variable to `1` and also have to have set GitHub credentials in your `./hack/preview.env`.
@@ -40,7 +40,7 @@ Alternatively, to use GitHub webhook set `PAC_GITHUB_TOKEN` with [required permi
 Then run:
 
 ```
-PIPELINESASCODE=1 ./hack/build/build-via-appstudio.sh https://github.com/Michkov/devfile-sample-go-basic
+PIPELINESASCODE=1 ./hack/build/build-via-appstudio.sh https://github.com/Michkov/devfile-sample-go-basic docker/Dockerfile
 ```
 
 ### Change of default pipeline bundle

--- a/docs/development/deployment.md
+++ b/docs/development/deployment.md
@@ -184,7 +184,7 @@ access to all the repos you're going to create/fork into your org in the future.
 **Simple build:**
 
 * Fork <https://github.com/devfile-samples/devfile-sample-python-basic> into your GitHub organization.
-* Run `hack/build/build-via-appstudio.sh https://github.com/MY_STONESOUP_ORG/devfile-sample-python-basic`
+* Run `hack/build/build-via-appstudio.sh https://github.com/MY_STONESOUP_ORG/devfile-sample-python-basic <path-to-repository-dockerfile>`
 
 The script will create a test application and a component for you:
 

--- a/hack/build/build-via-appstudio.sh
+++ b/hack/build/build-via-appstudio.sh
@@ -2,36 +2,37 @@
 SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 COMPONENT=$1
+PATH_TO_DOCKERFILE=$2
+[ -z "$MY_GITHUB_TOKEN" ] && echo "error: MY_GITHUB_TOKEN env var is not exported" && exit 1
 
 # Configure namespace
 $SCRIPTDIR/setup-namespace.sh
 
 oc delete --ignore-not-found -f $SCRIPTDIR/templates/application.yaml
 oc create -f $SCRIPTDIR/templates/application.yaml
-if ! oc wait --for=condition=Created application/test-application; then
-  echo "Application was not created sucessfully, check:"
-  echo "oc get applications test-application -o yaml"
-  exit 1
-fi
+
+function create-secret {
+  yq e "(.stringData.password=\"$MY_GITHUB_TOKEN\")" $SCRIPTDIR/templates/secret.yaml | oc apply -f-
+}
 
 function create-component {
   GIT_URL=$1
+  PATH_TO_DOCKERFILE=$2
   REPO=$(echo $GIT_URL | grep -o '[^/]*$')
   NAME=${REPO%%.git}
   oc delete --ignore-not-found component $NAME
   [ -n "$SKIP_INITIAL_CHECKS" ] && ANNOTATE_SKIP_INITIAL_CHECKS='| (.metadata.annotations.skip-initial-checks="true")'
   [ -n "$ENABLE_PAC" ] && ANNOTATE_PAC_PROVISION='| (.metadata.annotations."build.appstudio.openshift.io/request"="configure-pac")'
-  yq e "(.metadata.name=\"$NAME\") | (.spec.componentName=\"$NAME\") | (.spec.source.git.url=\"$GIT_URL\") | (.spec.containerImage=\"$IMAGE\") $ANNOTATE_PAC_PROVISION $ANNOTATE_SKIP_INITIAL_CHECKS" $SCRIPTDIR/templates/component.yaml | oc apply -f-
+  yq e "(.metadata.name=\"$NAME\") | (.spec.componentName=\"$NAME\") | (.spec.source.git.url=\"$GIT_URL\") | (.spec.source.git.dockerfileUrl=\"$PATH_TO_DOCKERFILE\") $ANNOTATE_PAC_PROVISION $ANNOTATE_SKIP_INITIAL_CHECKS" $SCRIPTDIR/templates/component.yaml | oc apply -f-
 }
 
-echo Git Repo created:
-oc get application/test-application -o jsonpath='{.status.devfile}' | grep appModelRepository.url | cut -f2- -d':'
+create-secret
 
 if [ -z "$COMPONENT" ]; then
-  create-component https://github.com/devfile-samples/devfile-sample-java-springboot-basic
-  create-component https://github.com/devfile-samples/devfile-sample-code-with-quarkus
-  create-component https://github.com/devfile-samples/devfile-sample-python-basic
+  create-component https://github.com/devfile-samples/devfile-sample-java-springboot-basic docker/Dockerfile
+  create-component https://github.com/devfile-samples/devfile-sample-code-with-quarkus src/main/docker/Dockerfile.jvm.staged
+  create-component https://github.com/devfile-samples/devfile-sample-python-basic docker/Dockerfile
 else
-  create-component $COMPONENT
+  create-component $COMPONENT $PATH_TO_DOCKERFILE
 fi
 echo "Run this to show running builds: tkn pr list"

--- a/hack/build/templates/component.yaml
+++ b/hack/build/templates/component.yaml
@@ -9,5 +9,5 @@ spec:
   application: test-application
   source:
     git:
+      dockerfileUrl:
       url:
-  containerImage:

--- a/hack/build/templates/secret.yaml
+++ b/hack/build/templates/secret.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: test-scm-secret
+  labels:
+    appstudio.redhat.com/credentials: scm
+    appstudio.redhat.com/scm.host: github.com
+type: kubernetes.io/basic-auth
+stringData:
+  password: 


### PR DESCRIPTION
### Description
Application CR status is no longer being reconciled by application-service (see https://issues.redhat.com/browse/DEVHAS-651), hence this script needs to be updated accordingly

### Verification steps
1. bootstrap cluster
```
./hack/bootstrap-cluster.sh preview
```
2a. (run the script with arguments - git repository URL, repo Dockerfile path):
```
./hack/build/build-via-appstudio.sh https://github.com/<YOUR_GITHUB_ORG>/devfile-sample-python-basic docker/Dockerfile
``` 
2b. (run the script without any arguments - by default 3 components are created on a cluster):
```
./hack/build/build-via-appstudio.sh
```