### PR TITLE
Increase memory allocation for mintmaker controller

### DIFF
--- a/components/mintmaker/k-components/manager-resources-patch/kustomization.yaml
+++ b/components/mintmaker/k-components/manager-resources-patch/kustomization.yaml
@@ -1,5 +1,0 @@
-apiVersion: kustomize.config.k8s.io/v1alpha1
-kind: Component
-
-patches:
-  - path: manager_resources_patch.yaml

--- a/components/mintmaker/production/kustomization.yaml
+++ b/components/mintmaker/production/kustomization.yaml
@@ -4,9 +4,6 @@ resources:
   - ../base
   - https://github.com/konflux-ci/mintmaker/config/default?ref=f6a6a9c25b02d3ca6cd808d5d440529de006d994
 
-components:
-  - ../k-components/manager-resources-patch
-
 images:
   - name: quay.io/konflux-ci/mintmaker
     newName: quay.io/konflux-ci/mintmaker

--- a/components/mintmaker/staging/base/kustomization.yaml
+++ b/components/mintmaker/staging/base/kustomization.yaml
@@ -14,3 +14,6 @@ images:
 
 commonAnnotations:
   argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+
+patches:
+  - path: manager_resources_patch.yaml

--- a/components/mintmaker/staging/base/manager_resources_patch.yaml
+++ b/components/mintmaker/staging/base/manager_resources_patch.yaml
@@ -11,7 +11,7 @@ spec:
         resources:
           limits:
             cpu: 500m
-            memory: 1024Mi
+            memory: 2048Mi
           requests:
             cpu: 100m
-            memory: 20Mi
+            memory: 256Mi


### PR DESCRIPTION
The mintmaker controller ran out of memory in the staging environment, which currently handles approximately 500 components.