### PR TITLE
KFLUXBUGS-863: repin watcher image to mem leak version

### DIFF
--- a/components/pipeline-service/development/kustomization.yaml
+++ b/components/pipeline-service/development/kustomization.yaml
@@ -12,6 +12,10 @@ resources:
   - https://github.com/openshift-pipelines/pipeline-service.git/developer/openshift/gitops/argocd/pipeline-service-storage?ref=ad974044255725077080ace5e4be8840ee85b2da
   - ../base/rbac
 
+images:
+  - name: quay.io/redhat-appstudio/tekton-results-watcher
+    newTag: bae7851ff584423503af324200f52cd28ca99116
+
 # generate a new configmap with updated values (logs api, db ssl mode) and replace the default one
 configMapGenerator:
   - behavior: replace
@@ -63,8 +67,3 @@ patches:
     target:
       kind: TektonConfig
       name: config
-  - path: update-results-watcher-performance.yaml
-    target:
-        kind: Deployment
-        namespace: tekton-results
-        name: tekton-results-watcher

--- a/components/pipeline-service/staging/base/kustomization.yaml
+++ b/components/pipeline-service/staging/base/kustomization.yaml
@@ -15,6 +15,11 @@ resources:
   - ../../base/rbac
   - ../../base/certificates
 
+images:
+  - name: quay.io/redhat-appstudio/tekton-results-watcher
+    newTag: bae7851ff584423503af324200f52cd28ca99116
+
+
 # generate a new configmap with updated values (logs api, db ssl mode) and replace the default one
 configMapGenerator:
   - behavior: replace
@@ -57,11 +62,6 @@ patches:
       kind: TektonConfig
       name: config
   - path: bump-results-watcher-replicas.yaml
-    target:
-      kind: Deployment
-      namespace: tekton-results
-      name: tekton-results-watcher
-  - path: update-results-watcher-performance.yaml
     target:
       kind: Deployment
       namespace: tekton-results

--- a/components/pipeline-service/staging/stone-stage-p01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stage-p01/deploy.yaml
@@ -1615,16 +1615,6 @@ spec:
         - -check_owner=false
         - -completed_run_grace_period
         - 10m
-        - -threadiness
-        - "50"
-        - -qps
-        - "50"
-        - -burst
-        - "100"
-        - -update_log_timeout
-        - 9m
-        - -dynamic_reconcile_timeout
-        - 9m
         env:
         - name: SYSTEM_NAMESPACE
           valueFrom:
@@ -1642,7 +1632,7 @@ spec:
           value: tekton-results-api-service.tekton-pipelines.svc.cluster.local:8080
         - name: AUTH_MODE
           value: token
-        image: quay.io/redhat-appstudio/tekton-results-watcher:ed360eccc021ad5eedf8ea9c0732912ef602b15a
+        image: quay.io/redhat-appstudio/tekton-results-watcher:bae7851ff584423503af324200f52cd28ca99116
         name: watcher
         ports:
         - containerPort: 9090

--- a/components/pipeline-service/staging/stone-stg-m01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stg-m01/deploy.yaml
@@ -1615,16 +1615,6 @@ spec:
         - -check_owner=false
         - -completed_run_grace_period
         - 10m
-        - -threadiness
-        - "50"
-        - -qps
-        - "50"
-        - -burst
-        - "100"
-        - -update_log_timeout
-        - 9m
-        - -dynamic_reconcile_timeout
-        - 9m
         env:
         - name: SYSTEM_NAMESPACE
           valueFrom:
@@ -1642,7 +1632,7 @@ spec:
           value: tekton-results-api-service.tekton-pipelines.svc.cluster.local:8080
         - name: AUTH_MODE
           value: token
-        image: quay.io/redhat-appstudio/tekton-results-watcher:ed360eccc021ad5eedf8ea9c0732912ef602b15a
+        image: quay.io/redhat-appstudio/tekton-results-watcher:bae7851ff584423503af324200f52cd28ca99116
         name: watcher
         ports:
         - containerPort: 9090

--- a/components/pipeline-service/staging/stone-stg-rh01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stg-rh01/deploy.yaml
@@ -1615,16 +1615,6 @@ spec:
         - -check_owner=false
         - -completed_run_grace_period
         - 10m
-        - -threadiness
-        - "50"
-        - -qps
-        - "50"
-        - -burst
-        - "100"
-        - -update_log_timeout
-        - 9m
-        - -dynamic_reconcile_timeout
-        - 9m
         env:
         - name: SYSTEM_NAMESPACE
           valueFrom:
@@ -1642,7 +1632,7 @@ spec:
           value: tekton-results-api-service.tekton-pipelines.svc.cluster.local:8080
         - name: AUTH_MODE
           value: token
-        image: quay.io/redhat-appstudio/tekton-results-watcher:ed360eccc021ad5eedf8ea9c0732912ef602b15a
+        image: quay.io/redhat-appstudio/tekton-results-watcher:bae7851ff584423503af324200f52cd28ca99116
         name: watcher
         ports:
         - containerPort: 9090


### PR DESCRIPTION
While the now third version of the mem leak and cancelled context  fixes held up better in stage by moving log storage off the reconciler thread, the ongoing grpc/http2 performance issues showed enough performance regression from the mem leak fix, coupled with no improvement with cancelled context (log storage still got interrupted) that I am resetting the watcher version to what is currently in prod.

We are actively working the prototypes to either do log retrieval in the api server, or preferrably, move S3 interaction to the watcher.

I was able to successfully test the older version of the watcher with the latest version of the api server, so I am leaving the api server at the more recent version to get its performance tuning improvements.

long term we need https://github.com/openshift-pipelines/pipeline-service/pull/1010 in place so that future pipeline service updates to not accidentally bump the version of the watcher image

I also left the enablement of pprof for the watcher, so that we can get thread dumps if necessary; per go doc enablement of pprof is safe in prod as long as you don't cpu profile

@enarha PTAL ... once this is in place, then along with https://github.com/redhat-appstudio/infra-deployments/blob/main/components/pipeline-service/production/base/kustomization.yaml#L17-L21 (though we can undo the api server pin if things look OK in stage) you should be able to move forward with TLS related changes for results without disrupting how the watcher is currently working in prod.

rh-pre-commit.version: 2.3.0
rh-pre-commit.check-secrets: ENABLED