### PR TITLE
Fix logging operator setup for kflux-prd-es01 cluster

### DIFF
--- a/argo-cd-apps/base/all-clusters/infra-deployments/monitoring-workload-logging/monitoring-workload-logging.yaml
+++ b/argo-cd-apps/base/all-clusters/infra-deployments/monitoring-workload-logging/monitoring-workload-logging.yaml
@@ -17,6 +17,8 @@ spec:
               elements:
                 - nameNormalized: kflux-stg-es01
                   values.clusterDir: kflux-stg-es01
+                - nameNormalized: kflux-prd-es01
+                  values.clusterDir: kflux-prd-es01
                 - nameNormalized: stone-stage-p01
                   values.clusterDir: stone-stage-p01
                 - nameNormalized: stone-prod-p01

--- a/components/monitoring/logging/production/kflux-prd-es01/kustomization.yaml
+++ b/components/monitoring/logging/production/kflux-prd-es01/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../base
+- ../../base/logging-operator-prerequisite


### PR DESCRIPTION
This fixes the same issue from #3680 but for production.