### PR TITLE
KFLUXINFRA-646: Removed host iops from extra fast amd64

### DIFF
--- a/components/multi-platform-controller/production/host-config.yaml
+++ b/components/multi-platform-controller/production/host-config.yaml
@@ -75,7 +75,7 @@ data:
   dynamic.linux-extra-fast-amd64.subnet-id: subnet-0c39ff75f819abfc5
   dynamic.linux-extra-fast-amd64.max-instances: "10"
   dynamic.linux-extra-fast-amd64.disk: "200"
-  dynamic.linux-extra-fast-amd64.iops: "16000"
+  # dynamic.linux-extra-fast-amd64.iops: "16000"
   dynamic.linux-extra-fast-amd64.throughput: "1000"
 
   dynamic.linux-root-amd64.type: aws


### PR DESCRIPTION
This PR is to understand the instance allocation issues with AWS c7a.12xlarge