### PR TITLE
fix: enlarge memery resouce limsit for integration service

### DIFF
--- a/components/integration/production/base/manager_resources_patch.yaml
+++ b/components/integration/production/base/manager_resources_patch.yaml
@@ -11,7 +11,7 @@ spec:
         resources:
           limits:
             cpu: 600m
-            memory: 1200Mi
+            memory: 1500Mi
           requests:
             cpu: 200m
             memory: 600Mi


### PR DESCRIPTION
Enlarge integration service memery resource limit due to OOM in rh01 prod integration service pod

<img width="1542" alt="image" src="https://github.com/redhat-appstudio/infra-deployments/assets/34546888/5ef4fe8a-5301-4d3c-afb3-5cc11d44fdf0">

