### PR TITLE
Add gitSignOff preset

### DIFF
--- a/components/mintmaker/base/renovate-config.yaml
+++ b/components/mintmaker/base/renovate-config.yaml
@@ -8,7 +8,8 @@ data:
     {
       "$schema": "https://docs.renovatebot.com/renovate-schema.json",
       "extends": [
-        "config:recommended"
+        "config:recommended",
+        ":gitSignOff"
       ],
       "onboarding": false,
       "requireConfig": "optional",
@@ -29,7 +30,6 @@ data:
             ],
             "groupName": "Konflux references",
             "branchName": "konflux/references/{{baseBranch}}",
-            "commitBody": "Signed-off-by: {{{gitAuthor}}}",
             "commitMessageTopic": "Konflux references",
             "semanticCommits": "enabled",
             "prFooter": "To execute skipped test pipelines write comment `/ok-to-test`",


### PR DESCRIPTION
This just appends
```json
{
  "commitBody": "Signed-off-by: {{{gitAuthor}}}"
}
```
to the config, which should IMO be enabled for all managers regardless.