### PR TITLE
feat: allow rootful MPC builds to disable entitlement mounts

### DIFF
--- a/components/multi-platform-controller/production-downstream/host-config.yaml
+++ b/components/multi-platform-controller/production-downstream/host-config.yaml
@@ -44,7 +44,7 @@ data:
   dynamic.linux-root-arm64.security-group-id: sg-0903aedd465be979e
   dynamic.linux-root-arm64.subnet-id: subnet-0aa719a6c5b602b16
   dynamic.linux-root-arm64.max-instances: "10"
-  dynamic.linux-root-arm64.sudo-commands: "/usr/bin/podman"
+  dynamic.linux-root-arm64.sudo-commands: "/usr/bin/podman, /usr/bin/rm /usr/share/containers/mounts.conf"
   dynamic.linux-root-arm64.disk: "200"
   dynamic.linux-root-arm64.iops: "16000"
   dynamic.linux-root-arm64.throughput: "1000"
@@ -59,7 +59,7 @@ data:
   dynamic.linux-root-amd64.security-group-id: sg-0903aedd465be979e
   dynamic.linux-root-amd64.subnet-id: subnet-0aa719a6c5b602b16
   dynamic.linux-root-amd64.max-instances: "10"
-  dynamic.linux-root-amd64.sudo-commands: "/usr/bin/podman"
+  dynamic.linux-root-amd64.sudo-commands: "/usr/bin/podman, /usr/bin/rm /usr/share/containers/mounts.conf"
   dynamic.linux-root-amd64.user-data: |-
     Content-Type: multipart/mixed; boundary="//"
     MIME-Version: 1.0


### PR DESCRIPTION
By default, podman will mount secrets declared in
/usr/share/containers/mounts.conf, even if those secrets do not exist on the host system.  This means that it is impossible to mount in entitlements provided by the user, because the subscription management tools will choose the empty entitlement mounted in over the creds mounted in by the user.