### PR TITLE
Fix service name for Opentelemetry Collector

### DIFF
--- a/argo-cd-apps/base/member/infra-deployments/tracing-workload-otel-collector/tracing-workload-otel-collector.yaml
+++ b/argo-cd-apps/base/member/infra-deployments/tracing-workload-otel-collector/tracing-workload-otel-collector.yaml
@@ -33,6 +33,8 @@ spec:
                 value: otel/opentelemetry-collector-k8s
               - name: "mode"
                 value: deployment
+              - name: "fullnameOverride"
+                value: "open-telemetry-opentelemetry-collector"
             valueFiles:
             - $values/{{values.sourceRoot}}/{{values.environment}}/otel-collector-helm-values.yaml
           # Values for chart from git


### PR DESCRIPTION
The ApplicationSet name with the cluster name normalized creates a service URL with the cluster name embedded in it.  By overriding the fullName in the Helm chart, the same name will be used across all deployments.  