### PR TITLE
Bump Postgres TLS cert lifetime

### DIFF
--- a/hack/secret-creator/create-plnsvc-secrets.sh
+++ b/hack/secret-creator/create-plnsvc-secrets.sh
@@ -78,7 +78,7 @@ create_db_cert_secret_and_configmap() {
         -subj "/CN=cluster.local" \
         > /dev/null
     chmod og-rwx ".tmp/tekton-results/ca.key"
-    openssl x509 -req -days 7 -text -extensions v3_ca \
+    openssl x509 -req -days 9999 -text -extensions v3_ca \
         -signkey ".tmp/tekton-results/ca.key" \
         -in ".tmp/tekton-results/ca.csr" \
         -extfile "/etc/ssl/openssl.cnf" \
@@ -91,7 +91,7 @@ create_db_cert_secret_and_configmap() {
         -keyout ".tmp/tekton-results/tls.key" \
         > /dev/null
     chmod og-rwx ".tmp/tekton-results/tls.key"
-    openssl x509 -req -text -days 7 -CAcreateserial \
+    openssl x509 -req -text -days 9999 -CAcreateserial \
         -extfile <(printf "subjectAltName=DNS:postgres-postgresql.tekton-results.svc.cluster.local") \
         -in ".tmp/tekton-results/tls.csr" \
         -CA ".tmp/tekton-results/ca.crt" \


### PR DESCRIPTION
QE teams are using long living deployments (2+ years) and having short lived certificates breaking their deployments. Re-issuing of those certificates requires redeployment of some components to make use of the new configmaps and secrets. In the common case the use of these secrets is for short lived CI deployments where the lifetime of the certs does not have effect.