### PR TITLE
Group konflux tekton updates

### DIFF
--- a/components/mintmaker/base/renovate-config.yaml
+++ b/components/mintmaker/base/renovate-config.yaml
@@ -17,11 +17,13 @@ data:
         "packageRules": [
           {
             "matchPackagePatterns": [
-              "^quay.io/redhat-appstudio-tekton-catalog/"
+              "^quay.io/redhat-appstudio-tekton-catalog/",
+              "^quay.io/konflux-ci/tekton-catalog/"
             ],
             "enabled": true,
             "matchDepPatterns": [
-              "^quay.io/redhat-appstudio-tekton-catalog/"
+              "^quay.io/redhat-appstudio-tekton-catalog/",
+              "^quay.io/konflux-ci/tekton-catalog/"
             ],
             "groupName": "Konflux references",
             "branchName": "konflux/references/{{baseBranch}}",

--- a/components/mintmaker/base/renovate-config.yaml
+++ b/components/mintmaker/base/renovate-config.yaml
@@ -21,10 +21,6 @@ data:
               "^quay.io/konflux-ci/tekton-catalog/"
             ],
             "enabled": true,
-            "matchDepPatterns": [
-              "^quay.io/redhat-appstudio-tekton-catalog/",
-              "^quay.io/konflux-ci/tekton-catalog/"
-            ],
             "groupName": "Konflux references",
             "branchName": "konflux/references/{{baseBranch}}",
             "commitBody": "Signed-off-by: {{{gitAuthor}}}",


### PR DESCRIPTION
This update will allow noise reduction by grouping quay.io/konflux-ci/tekton-catalog/* tekton updates into a single PR.

This is a clone of https://github.com/redhat-appstudio/infra-deployments/pull/3951 due to failed CI.