### PR TITLE
Remove konflux e2e repository cr

### DIFF
--- a/components/konflux-ci/base/repository.yaml
+++ b/components/konflux-ci/base/repository.yaml
@@ -23,13 +23,6 @@ spec:
 apiVersion: pipelinesascode.tekton.dev/v1alpha1
 kind: Repository
 metadata:
-  name: e2e-tests
-spec:
-  url: "https://github.com/konflux-ci/e2e-tests"
----
-apiVersion: pipelinesascode.tekton.dev/v1alpha1
-kind: Repository
-metadata:
   name: quality-dashboard
 spec:
   url: "https://github.com/konflux-ci/quality-dashboard"


### PR DESCRIPTION
E2e tests are already in Konflux. This pull request just remove e2e CR