### PR TITLE
Patch RENOVATE_IMAGE env variable

### DIFF
--- a/components/mintmaker/production/base/kustomization.yaml
+++ b/components/mintmaker/production/base/kustomization.yaml
@@ -22,4 +22,4 @@ patches:
       kind: ExternalSecret
       group: external-secrets.io
       version: v1beta1
-  - path: manager_resources_patch.yaml
+  - path: manager_patches.yaml

--- a/components/mintmaker/production/base/manager_patches.yaml
+++ b/components/mintmaker/production/base/manager_patches.yaml
@@ -15,3 +15,6 @@ spec:
           requests:
             cpu: 100m
             memory: 256Mi
+        env:
+        - name: RENOVATE_IMAGE
+          value: "quay.io/konflux-ci/mintmaker-renovate-image:40af057"

--- a/components/mintmaker/staging/base/kustomization.yaml
+++ b/components/mintmaker/staging/base/kustomization.yaml
@@ -16,4 +16,4 @@ commonAnnotations:
   argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 
 patches:
-  - path: manager_resources_patch.yaml
+  - path: manager_patches.yaml

--- a/components/mintmaker/staging/base/manager_patches.yaml
+++ b/components/mintmaker/staging/base/manager_patches.yaml
@@ -15,3 +15,6 @@ spec:
           requests:
             cpu: 100m
             memory: 256Mi
+        env:
+        - name: RENOVATE_IMAGE
+          value: "quay.io/konflux-ci/mintmaker-renovate-image:latest"


### PR DESCRIPTION
For testing purposes, the staging environment should use the `latest` mintmaker-renovate-image, and production should use a specific digest instead, so we can make sure that the latest changes are well tested before going into production.

ref: [CWFHEALTH-3100](https://issues.redhat.com//browse/CWFHEALTH-3100)