### PR TITLE
Disable automatic approval on stone-prod-p01

### DIFF
--- a/components/sandbox/toolchain-host-operator/production/stone-prod-p01/toolchainconfig.yaml
+++ b/components/sandbox/toolchain-host-operator/production/stone-prod-p01/toolchainconfig.yaml
@@ -10,7 +10,7 @@ spec:
     tiers:
       defaultSpaceTier: 'appstudio'
     automaticApproval:
-      enabled: true
+      enabled: false
     spaceConfig:
       spaceRequestEnabled: true
       spaceBindingRequestEnabled: true


### PR DESCRIPTION
The plan is to decommission this cluster so disable automatic approval to prevent new users from coming in.

[KFLUXINFRA-648](https://issues.redhat.com//browse/KFLUXINFRA-648)