### PR TITLE
Grant BKorren permissions for MCP

### DIFF
--- a/components/multi-platform-controller/OWNERS
+++ b/components/multi-platform-controller/OWNERS
@@ -3,7 +3,9 @@
 approvers:
 - stuartwdouglas
 - arewm
+- ifireball
 
 reviewers:
 - stuartwdouglas
 - arewm
+- ifireball


### PR DESCRIPTION
Add Bkorren to the multi-platform-controller OWNERS file.