### PR TITLE
Mintmaker: explicitly disable Dependency Dashboard

### DIFF
--- a/components/mintmaker/base/renovate-config.yaml
+++ b/components/mintmaker/base/renovate-config.yaml
@@ -9,8 +9,10 @@ data:
       "$schema": "https://docs.renovatebot.com/renovate-schema.json",
       "extends": [
         "config:recommended",
-        ":gitSignOff"
+        ":gitSignOff",
+        ":disableDependencyDashboard"
       ],
+      "ignorePresets": [":dependencyDashboard"],
       "onboarding": false,
       "requireConfig": "optional",
       "platformCommit": true,


### PR DESCRIPTION
Seems like we have to manually disable that because some preset might be taking effect:
https://github.com/renovatebot/renovate/discussions/11330

Let's force this, so that we can disable the dashboard.