### PR TITLE
Update SPI to the next OAuth-less version on production

### DIFF
--- a/components/spi/overlays/production/base/kustomization.yaml
+++ b/components/spi/overlays/production/base/kustomization.yaml
@@ -3,8 +3,8 @@ kind: Kustomization
 resources:
   - ../../../base
   - ../../../base/external-secrets
-  - https://github.com/konflux-ci/service-provider-integration-operator/config/overlays/openshift_aws?ref=34ae088dc064be78744886fff32e956cfd475591
-  - https://github.com/konflux-ci/service-provider-integration-operator/config/monitoring/prometheus/base?ref=34ae088dc064be78744886fff32e956cfd475591
+  - https://github.com/konflux-ci/service-provider-integration-operator/config/overlays/openshift_aws?ref=81e453a190e3d0a2c496e5cf3aeff380c4eccc45
+  - https://github.com/konflux-ci/service-provider-integration-operator/config/monitoring/prometheus/base?ref=81e453a190e3d0a2c496e5cf3aeff380c4eccc45
   - spi-aws-credentials-external-secret.yaml
 
 namespace: spi-system
@@ -12,10 +12,7 @@ namespace: spi-system
 images:
   - name:  quay.io/redhat-appstudio/service-provider-integration-operator
     newName: quay.io/redhat-appstudio/service-provider-integration-operator
-    newTag: 34ae088dc064be78744886fff32e956cfd475591
-  - name: quay.io/redhat-appstudio/service-provider-integration-oauth
-    newName: quay.io/redhat-appstudio/service-provider-integration-oauth
-    newTag: 34ae088dc064be78744886fff32e956cfd475591
+    newTag: 81e453a190e3d0a2c496e5cf3aeff380c4eccc45
 
 patches:
   - target:

--- a/components/spi/overlays/production/stone-prd-m01/kustomization.yaml
+++ b/components/spi/overlays/production/stone-prd-m01/kustomization.yaml
@@ -7,10 +7,6 @@ resources:
 patches:
   - target:
       kind: ConfigMap
-      name: oauth-service-environment-config
-    path: oauth-service-config-patch.json
-  - target:
-      kind: ConfigMap
       name: shared-environment-config
     path: config-patch.json
   - path: spi-shared-configuration-file-config-path.yaml

--- a/components/spi/overlays/production/stone-prd-m01/oauth-service-config-patch.json
+++ b/components/spi/overlays/production/stone-prd-m01/oauth-service-config-patch.json
@@ -1,7 +1,0 @@
-[
-  {
-    "op": "add",
-    "path": "/data/API_SERVER",
-    "value": "https://api-toolchain-host-operator.apps.stone-prd-host1.wdlc.p1.openshiftapps.com"
-  }
-]

--- a/components/spi/overlays/production/stone-prd-rh01/kustomization.yaml
+++ b/components/spi/overlays/production/stone-prd-rh01/kustomization.yaml
@@ -7,10 +7,6 @@ resources:
 patches:
   - target:
       kind: ConfigMap
-      name: oauth-service-environment-config
-    path: oauth-service-config-patch.json
-  - target:
-      kind: ConfigMap
       name: shared-environment-config
     path: config-patch.json
   - path: spi-shared-configuration-file-config-path.yaml

--- a/components/spi/overlays/production/stone-prd-rh01/oauth-service-config-patch.json
+++ b/components/spi/overlays/production/stone-prd-rh01/oauth-service-config-patch.json
@@ -1,7 +1,0 @@
-[
-  {
-    "op": "add",
-    "path": "/data/API_SERVER",
-    "value": "https://api-toolchain-host-operator.apps.stone-prd-host1.wdlc.p1.openshiftapps.com"
-  }
-]

--- a/components/spi/overlays/production/stone-prod-p01/kustomization.yaml
+++ b/components/spi/overlays/production/stone-prod-p01/kustomization.yaml
@@ -7,10 +7,6 @@ resources:
 patches:
   - target:
       kind: ConfigMap
-      name: oauth-service-environment-config
-    path: oauth-service-config-patch.json
-  - target:
-      kind: ConfigMap
       name: shared-environment-config
     path: config-patch.json
   - path: spi-shared-configuration-file-config-path.yaml

--- a/components/spi/overlays/production/stone-prod-p01/oauth-service-config-patch.json
+++ b/components/spi/overlays/production/stone-prod-p01/oauth-service-config-patch.json
@@ -1,7 +1,0 @@
-[
-  {
-    "op": "add",
-    "path": "/data/API_SERVER",
-    "value": "https://api-toolchain-host-operator.apps.stone-prod-p01.wcfb.p1.openshiftapps.com"
-  }
-]

--- a/components/spi/overlays/production/stone-prod-p02/kustomization.yaml
+++ b/components/spi/overlays/production/stone-prod-p02/kustomization.yaml
@@ -7,10 +7,6 @@ resources:
 patches:
   - target:
       kind: ConfigMap
-      name: oauth-service-environment-config
-    path: oauth-service-config-patch.json
-  - target:
-      kind: ConfigMap
       name: shared-environment-config
     path: config-patch.json
   - path: spi-shared-configuration-file-config-path.yaml

--- a/components/spi/overlays/production/stone-prod-p02/oauth-service-config-patch.json
+++ b/components/spi/overlays/production/stone-prod-p02/oauth-service-config-patch.json
@@ -1,7 +1,0 @@
-[
-  {
-    "op": "add",
-    "path": "/data/API_SERVER",
-    "value": "https://api-toolchain-host-operator.apps.stone-prod-p02.hjvn.p1.openshiftapps.com"
-  }
-]


### PR DESCRIPTION
Update SPI to the version without OAuth being deployed