### PR TITLE
Separate renovate config for each environment and fix errors

### DIFF
--- a/components/mintmaker/development/kustomization.yaml
+++ b/components/mintmaker/development/kustomization.yaml
@@ -16,3 +16,6 @@ commonAnnotations:
 
 components:
   - ../components/rh-certs
+
+patches:
+  - path: renovate-config.yaml

--- a/components/mintmaker/development/renovate-config.yaml
+++ b/components/mintmaker/development/renovate-config.yaml
@@ -1,0 +1,58 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: renovate-config
+  namespace: mintmaker
+data:
+  renovate.json: |
+    {
+      "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+      "extends": [
+        "config:recommended",
+        ":gitSignOff",
+        ":disableDependencyDashboard"
+      ],
+      "ignorePresets": [":dependencyDashboard"],
+      "onboarding": false,
+      "requireConfig": "optional",
+      "platformCommit": true,
+      "autodiscover": false,
+      "enabledManagers": ["tekton", "dockerfile", "rpm"],
+      "tekton": {
+        "fileMatch": ["\\.yaml$","\\.yml$"],
+        "includePaths": [".tekton/**"],
+        "packageRules": [
+          {
+            "matchPackagePatterns": [
+              "^quay.io/redhat-appstudio-tekton-catalog/",
+              "^quay.io/konflux-ci/tekton-catalog/"
+            ],
+            "enabled": true,
+            "groupName": "Konflux references",
+            "branchPrefix": "konflux/references/",
+            "branchTopic": "{{baseBranch}}",
+            "commitMessageTopic": "Konflux references",
+            "semanticCommits": "enabled",
+            "prFooter": "To execute skipped test pipelines write comment `/ok-to-test`",
+            "prBodyColumns": [
+              "Package",
+              "Change",
+              "Notes"
+            ],
+            "prBodyDefinitions": { "Notes": "{{#if (or (containsString updateType 'minor') (containsString updateType 'major'))}}:warning:[migration](https://github.com/redhat-appstudio/build-definitions/blob/main/task/{{{replace '^quay.io/redhat-appstudio-tekton-catalog/task-' '' packageName}}}/{{{newVersion}}}/MIGRATION.md):warning:{{/if}}" },
+            "prBodyTemplate": "{{{header}}}{{{table}}}{{{notes}}}{{{changelogs}}}{{{footer}}}",
+            "recreateWhen": "always",
+            "rebaseWhen": "behind-base-branch"
+          }
+        ]
+      },
+      "lockFileMaintenance": {
+        "enabled": true,
+        "recreateWhen": "always",
+        "rebaseWhen": "behind-base-branch",
+        "branchTopic": "lock-file-maintenance",
+        "schedule": ["at any time"]
+      },
+      "forkProcessing": "enabled",
+      "dependencyDashboard": false
+    }

--- a/components/mintmaker/production/base/kustomization.yaml
+++ b/components/mintmaker/production/base/kustomization.yaml
@@ -23,3 +23,4 @@ patches:
       group: external-secrets.io
       version: v1beta1
   - path: manager_patches.yaml
+  - path: renovate-config.yaml

--- a/components/mintmaker/production/base/renovate-config.yaml
+++ b/components/mintmaker/production/base/renovate-config.yaml
@@ -1,0 +1,57 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: renovate-config
+  namespace: mintmaker
+data:
+  renovate.json: |
+    {
+      "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+      "extends": [
+        "config:recommended",
+        ":gitSignOff",
+        ":disableDependencyDashboard"
+      ],
+      "ignorePresets": [":dependencyDashboard"],
+      "onboarding": false,
+      "requireConfig": "optional",
+      "platformCommit": true,
+      "autodiscover": false,
+      "enabledManagers": ["tekton", "dockerfile", "rpm"],
+      "tekton": {
+        "fileMatch": ["\\.yaml$","\\.yml$"],
+        "includePaths": [".tekton/**"],
+        "packageRules": [
+          {
+            "matchPackagePatterns": [
+              "^quay.io/redhat-appstudio-tekton-catalog/",
+              "^quay.io/konflux-ci/tekton-catalog/"
+            ],
+            "enabled": true,
+            "groupName": "Konflux references",
+            "branchName": "konflux/references/{{baseBranch}}",
+            "commitMessageTopic": "Konflux references",
+            "semanticCommits": "enabled",
+            "prFooter": "To execute skipped test pipelines write comment `/ok-to-test`",
+            "prBodyColumns": [
+              "Package",
+              "Change",
+              "Notes"
+            ],
+            "prBodyDefinitions": "{ \"Notes\": \"{{#if (or (containsString updateType 'minor') (containsString updateType 'major'))}}:warning:[migration](https://github.com/redhat-appstudio/build-definitions/blob/main/task/{{{replace '^quay.io/redhat-appstudio-tekton-catalog/task-' '' packageName}}}/{{{newVersion}}}/MIGRATION.md):warning:{{/if}}\" }",
+            "prBodyTemplate": "{{{header}}}{{{table}}}{{{notes}}}{{{changelogs}}}{{{footer}}}",
+            "recreateWhen": "always",
+            "rebaseWhen": "behind-base-branch"
+          }
+        ]
+      },
+      "lockFileMaintenance": {
+        "enabled": true,
+        "recreateWhen": "always",
+        "rebaseStalePrs": true,
+        "branchTopic": "lock-file-maintenance",
+        "schedule": ["at any time"]
+      },
+      "forkProcessing": "enabled",
+      "dependencyDashboard": false
+    }

--- a/components/mintmaker/staging/base/kustomization.yaml
+++ b/components/mintmaker/staging/base/kustomization.yaml
@@ -17,3 +17,4 @@ commonAnnotations:
 
 patches:
   - path: manager_patches.yaml
+  - path: renovate-config.yaml

--- a/components/mintmaker/staging/base/renovate-config.yaml
+++ b/components/mintmaker/staging/base/renovate-config.yaml
@@ -1,0 +1,57 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: renovate-config
+  namespace: mintmaker
+data:
+  renovate.json: |
+    {
+      "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+      "extends": [
+        "config:recommended",
+        ":gitSignOff",
+        ":disableDependencyDashboard"
+      ],
+      "ignorePresets": [":dependencyDashboard"],
+      "onboarding": false,
+      "requireConfig": "optional",
+      "platformCommit": true,
+      "autodiscover": false,
+      "enabledManagers": ["tekton", "dockerfile", "rpm"],
+      "tekton": {
+        "fileMatch": ["\\.yaml$","\\.yml$"],
+        "includePaths": [".tekton/**"],
+        "packageRules": [
+          {
+            "matchPackagePatterns": [
+              "^quay.io/redhat-appstudio-tekton-catalog/",
+              "^quay.io/konflux-ci/tekton-catalog/"
+            ],
+            "enabled": true,
+            "groupName": "Konflux references",
+            "branchName": "konflux/references/{{baseBranch}}",
+            "commitMessageTopic": "Konflux references",
+            "semanticCommits": "enabled",
+            "prFooter": "To execute skipped test pipelines write comment `/ok-to-test`",
+            "prBodyColumns": [
+              "Package",
+              "Change",
+              "Notes"
+            ],
+            "prBodyDefinitions": "{ \"Notes\": \"{{#if (or (containsString updateType 'minor') (containsString updateType 'major'))}}:warning:[migration](https://github.com/redhat-appstudio/build-definitions/blob/main/task/{{{replace '^quay.io/redhat-appstudio-tekton-catalog/task-' '' packageName}}}/{{{newVersion}}}/MIGRATION.md):warning:{{/if}}\" }",
+            "prBodyTemplate": "{{{header}}}{{{table}}}{{{notes}}}{{{changelogs}}}{{{footer}}}",
+            "recreateWhen": "always",
+            "rebaseWhen": "behind-base-branch"
+          }
+        ]
+      },
+      "lockFileMaintenance": {
+        "enabled": true,
+        "recreateWhen": "always",
+        "rebaseStalePrs": true,
+        "branchTopic": "lock-file-maintenance",
+        "schedule": ["at any time"]
+      },
+      "forkProcessing": "enabled",
+      "dependencyDashboard": false
+    }


### PR DESCRIPTION
Fix renovate config's errors and warnings as detected by renovate-config-validator. List of changes:
- Remove outer quotes from prBodyDefinitions, as this field expects a JSON object. This is the only error in the config
- Change the branchName field to branchPrefix and branchTopic. The branchName field is deprecated.
- Change '"rebaseStalePrs": true' to '"rebaseWhen": "behind-base-branch"'. This change was suggested as a renovate migration.

Change configuration so that each env has its own renovate config file definition. This is so that we can effectively test config changes. Apply the aforementioned changes only to dev env so far.

Refers to CWFHEALTH-3210, [CWFHEALTH-3206](https://issues.redhat.com//browse/CWFHEALTH-3206)