### PR TITLE
workspaces: fix server's configmap

### DIFF
--- a/components/workspaces/base/server/config/default/kustomization.yaml
+++ b/components/workspaces/base/server/config/default/kustomization.yaml
@@ -7,11 +7,6 @@ resources:
 namePrefix: workspaces-
 
 configMapGenerator:
-- literals:
-  - toolchain_namespace=toolchain-host-operator
-  name: rest-api-server-cm
-  options:
-    disableNameSuffixHash: true
 - behavior: replace
   literals:
   - log.level=0
@@ -24,9 +19,9 @@ configMapGenerator:
       # RoleBinding to read UserSignups should target the ServiceAccount in workspaces-system
 replacements:
 - source:
-    fieldPath: data.toolchain_namespace
+    fieldPath: data.[kubesaw.namespace]
     kind: ConfigMap
-    name: rest-api-server-cm
+    name: rest-api-server-config
     options:
       create: true
   targets:

--- a/components/workspaces/base/server/config/server/deployment.yaml
+++ b/components/workspaces/base/server/config/server/deployment.yaml
@@ -101,7 +101,7 @@ kind: ConfigMap
 metadata:
   name: rest-api-server-config
 data:
-  kubesaw.namespace=system
+  kubesaw.namespace: system
 ---
 apiVersion: v1
 data: {}


### PR DESCRIPTION
This fixes the konflux-workspaces REST API Server's configuration. The ConfigMap that stores the configuration for the REST API Server is not populated correctly.

linked to: #4040 and https://github.com/konflux-workspaces/workspaces/pull/235