### PR TITLE
Make ArgoCD ignore annotation on ImageRepository when sycning

### DIFF
--- a/argo-cd-apps/base/tenants-config/tenants-config.yaml
+++ b/argo-cd-apps/base/tenants-config/tenants-config.yaml
@@ -30,6 +30,10 @@ spec:
             - /metadata/annotations/image.redhat.com~1image
             - /metadata/annotations/image.redhat.com~1generate
         - group: appstudio.redhat.com
+          kind: ImageRepository
+          jsonPointers:
+            - /metadata/annotations/image-controller.appstudio.redhat.com~1update-component-image
+        - group: appstudio.redhat.com
           kind: ReleasePlan
           jsonPointers:
             - /metadata/labels/release.appstudio.openshift.io~author


### PR DESCRIPTION
Ignore image-controller.appstudio.redhat.com/update-component-image because controller is removing annotation after it is done with it. Without ignoring it, it would be constant loop fight between argoCD syncing and controller removing it