### PR TITLE
fix: correct ReleasePlan ignoreDifferences

### DIFF
--- a/argo-cd-apps/base/tenants-config/tenants-config.yaml
+++ b/argo-cd-apps/base/tenants-config/tenants-config.yaml
@@ -32,8 +32,8 @@ spec:
         - group: appstudio.redhat.com
           kind: ReleasePlan
           jsonPointers:
-            - /metadata/labels/release.appstudio.openshift.io~author
-            - /metadata/labels/release.appstudio.openshift.io~standing-attribution
+            - /metadata/labels/release.appstudio.openshift.io~1author
+            - /metadata/labels/release.appstudio.openshift.io~1standing-attribution
       syncPolicy:
         automated:
           prune: true


### PR DESCRIPTION
- This will prevent Argo from constantly trying to Sync since the Release Service wants to update that value