### PR TITLE
SRVKP-5825: move pipeline-metric-exporter PAC repository obj from tekton-ci to konflux-ci

### DIFF
--- a/components/konflux-ci/base/repository.yaml
+++ b/components/konflux-ci/base/repository.yaml
@@ -26,3 +26,10 @@ metadata:
   name: quality-dashboard
 spec:
   url: "https://github.com/konflux-ci/quality-dashboard"
+---
+apiVersion: pipelinesascode.tekton.dev/v1alpha1
+kind: Repository
+metadata:
+  name: pipeline-service-exporter
+spec:
+  url: "https://github.com/openshift-pipelines/pipeline-service-exporter"

--- a/components/tekton-ci/base/repository.yaml
+++ b/components/tekton-ci/base/repository.yaml
@@ -51,13 +51,6 @@ spec:
 apiVersion: pipelinesascode.tekton.dev/v1alpha1
 kind: Repository
 metadata:
-  name: pipeline-service-exporter
-spec:
-  url: "https://github.com/openshift-pipelines/pipeline-service-exporter"
----
-apiVersion: pipelinesascode.tekton.dev/v1alpha1
-kind: Repository
-metadata:
   name: cachi2
 spec:
   url: "https://github.com/containerbuildsystem/cachi2"


### PR DESCRIPTION
per explanation from @ralphbean in https://redhat-internal.slack.com/archives/C02CTEB3MMF/p1720725153164939 this facilitates https://github.com/openshift-pipelines/pipeline-service-exporter/pull/70

rh-pre-commit.version: 2.3.0
rh-pre-commit.check-secrets: ENABLED