### PR TITLE
SRVKP-5825: move pipeline-service repository obj from tekton-ci to konflux-ci

### DIFF
--- a/components/konflux-ci/base/repository.yaml
+++ b/components/konflux-ci/base/repository.yaml
@@ -33,3 +33,10 @@ metadata:
   name: pipeline-service-exporter
 spec:
   url: "https://github.com/openshift-pipelines/pipeline-service-exporter"
+---
+apiVersion: pipelinesascode.tekton.dev/v1alpha1
+kind: Repository
+metadata:
+  name: pipeline-service
+spec:
+  url: "https://github.com/openshift-pipelines/pipeline-service"

--- a/components/tekton-ci/base/repository.yaml
+++ b/components/tekton-ci/base/repository.yaml
@@ -58,13 +58,6 @@ spec:
 apiVersion: pipelinesascode.tekton.dev/v1alpha1
 kind: Repository
 metadata:
-  name: pipeline-service
-spec:
-  url: "https://github.com/openshift-pipelines/pipeline-service"
----
-apiVersion: pipelinesascode.tekton.dev/v1alpha1
-kind: Repository
-metadata:
   name: infra-deployments
 spec:
   url: "https://github.com/redhat-appstudio/infra-deployments"


### PR DESCRIPTION
https://issues.redhat.com/browse/PLNSRVCE-1673 related

rh-pre-commit.version: 2.3.0
rh-pre-commit.check-secrets: ENABLED