### PR TITLE
Add controls to prBodyTemplate for Tekton updates

### DIFF
--- a/components/mintmaker/base/renovate-config.yaml
+++ b/components/mintmaker/base/renovate-config.yaml
@@ -39,7 +39,7 @@ data:
               "Notes"
             ],
             "prBodyDefinitions": "{ \"Notes\": \"{{#if (or (containsString updateType 'minor') (containsString updateType 'major'))}}:warning:[migration](https://github.com/redhat-appstudio/build-definitions/blob/main/task/{{{replace '^quay.io/redhat-appstudio-tekton-catalog/task-' '' packageName}}}/{{{newVersion}}}/MIGRATION.md):warning:{{/if}}\" }",
-            "prBodyTemplate": "{{{header}}}{{{table}}}{{{notes}}}{{{changelogs}}}{{{footer}}}",
+            "prBodyTemplate": "{{{header}}}{{{table}}}{{{notes}}}{{{changelogs}}}{{{controls}}}{{{footer}}}",
             "recreateWhen": "always",
             "rebaseWhen": "behind-base-branch"
           }


### PR DESCRIPTION
This should fix the issue with missing rebase checkbox on updates from [CWFHEALTH-3224](https://issues.redhat.com//browse/CWFHEALTH-3224).

Essentially the issue that we were missing `{{{controls}}}` in `prBodyTemplate` which - from the Renovate source code - is just the checkbox: https://github.com/renovatebot/renovate/blob/main/lib/workers/repository/update/pr/body/controls.ts