### PR TITLE
KFLUXBUGS-1305: Show the user's first and last name on the UI

### DIFF
--- a/components/keycloak/base/configure-keycloak.yaml
+++ b/components/keycloak/base/configure-keycloak.yaml
@@ -50,6 +50,33 @@ spec:
       app: sso
   realm:
     clientScopes:
+      - name: first-and-last-name
+        protocol: openid-connect
+        protocolMappers:
+          - name: first_name
+            protocol: openid-connect
+            protocolMapper: oidc-usermodel-property-mapper
+            config:
+              user.attribute: firstName
+              claim.name: first_name
+              jsonType.label: String
+              id.token.claim: 'true'
+              access.token.claim: 'true'
+              lightweight.claim: 'false'
+              userinfo.token.claim: 'true'
+              introspection.token.claim: 'true'
+          - name: last_name
+            protocol: openid-connect
+            protocolMapper: oidc-usermodel-property-mapper
+            config:
+              user.attribute: lastName
+              claim.name: last_name
+              jsonType.label: String
+              id.token.claim: 'true'
+              access.token.claim: 'true'
+              lightweight.claim: 'false'
+              userinfo.token.claim: 'true'
+              introspection.token.claim: 'true'
       - attributes:
           display.on.consent.screen: 'true'
           include.in.token.scope: 'true'
@@ -310,6 +337,7 @@ spec:
       - profile
       - roles
       - email
+      - first-and-last-name
     implicitFlowEnabled: false
     secret: client-secret
     publicClient: true


### PR DESCRIPTION
There was bug where the user's first and last name were not visible in the UI since they weren't included in the JWT token. Include the "first_name" and "last_name" claims in the JWT token.