### PR TITLE
SRVKP-5832: move to downstream tekton-results PAC CI to konflux-ci namespace

### DIFF
--- a/components/konflux-ci/base/repository.yaml
+++ b/components/konflux-ci/base/repository.yaml
@@ -40,3 +40,10 @@ metadata:
   name: pipeline-service
 spec:
   url: "https://github.com/openshift-pipelines/pipeline-service"
+---
+apiVersion: pipelinesascode.tekton.dev/v1alpha1
+kind: Repository
+metadata:
+  name: tekton-results
+spec:
+  url: "https://github.com/openshift-pipelines/tektoncd-results"

--- a/components/tekton-ci/base/repository.yaml
+++ b/components/tekton-ci/base/repository.yaml
@@ -37,13 +37,6 @@ spec:
 apiVersion: pipelinesascode.tekton.dev/v1alpha1
 kind: Repository
 metadata:
-  name: tekton-results
-spec:
-  url: "https://github.com/openshift-pipelines/tektoncd-results"
----
-apiVersion: pipelinesascode.tekton.dev/v1alpha1
-kind: Repository
-metadata:
   name: gitops-repo-pruner
 spec:
   url: "https://github.com/redhat-appstudio/gitops-repo-pruner"


### PR DESCRIPTION
similar to pipeline-service-exporter and pipeline-service changes https://github.com/redhat-appstudio/infra-deployments/pull/4055 and https://github.com/redhat-appstudio/infra-deployments/pull/4053

rh-pre-commit.version: 2.3.0
rh-pre-commit.check-secrets: ENABLED