### PR TITLE
SRVKP-5832: maintain pinning of watcher image to mem leak version

### DIFF
--- a/components/pipeline-service/development/kustomization.yaml
+++ b/components/pipeline-service/development/kustomization.yaml
@@ -13,6 +13,9 @@ resources:
   - ../base/rbac
 
 images:
+  - name: quay.io/konflux-ci/tekton-results-watcher
+    newName: quay.io/redhat-appstudio/tekton-results-watcher
+    newTag: bae7851ff584423503af324200f52cd28ca99116
   - name: quay.io/redhat-appstudio/tekton-results-watcher
     newTag: bae7851ff584423503af324200f52cd28ca99116
 

--- a/components/pipeline-service/production/base/kustomization.yaml
+++ b/components/pipeline-service/production/base/kustomization.yaml
@@ -8,7 +8,7 @@ commonAnnotations:
   argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 
 resources:
-  - https://github.com/openshift-pipelines/pipeline-service.git/operator/gitops/argocd/pipeline-service?ref=c8432d3352db3ff70828caeb500e86e6bf0cbcdd
+  - https://github.com/openshift-pipelines/pipeline-service.git/operator/gitops/argocd/pipeline-service?ref=da64420f8df634736b1aff727155e626ec832dd1
   - pipelines-as-code-secret.yaml # create external secret in openshift-pipelines namespace
   - ../../base/external-secrets
   - ../../base/testing
@@ -16,6 +16,9 @@ resources:
   - ../../base/certificates
 
 images:
+  - name: quay.io/konflux-ci/tekton-results-watcher
+    newName: quay.io/redhat-appstudio/tekton-results-watcher
+    newTag: bae7851ff584423503af324200f52cd28ca99116
   - name: quay.io/redhat-appstudio/tekton-results-watcher
     newTag: bae7851ff584423503af324200f52cd28ca99116
 

--- a/components/pipeline-service/production/stone-prd-m01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prd-m01/deploy.yaml
@@ -1344,7 +1344,7 @@ spec:
       - args:
         - -pprof-address
         - "6060"
-        image: quay.io/redhat-appstudio/pipeline-service-exporter:c18a1079e58315454fb3ddf2ea9dc3c5cd4dc954
+        image: quay.io/konflux-ci/pipeline-service-exporter:95fe19bf616c628e6e8f30487113b61861569a6e
         name: pipeline-metrics-exporter
         ports:
         - containerPort: 9117
@@ -2022,8 +2022,8 @@ spec:
     enable-cluster-resolver: true
     enable-git-resolver: true
     enable-hub-resolver: true
-    enable-tekton-oci-bundles: true
     enable-step-actions: true
+    enable-tekton-oci-bundles: true
     options:
       configMaps:
         config-logging:

--- a/components/pipeline-service/production/stone-prd-rh01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prd-rh01/deploy.yaml
@@ -1344,7 +1344,7 @@ spec:
       - args:
         - -pprof-address
         - "6060"
-        image: quay.io/redhat-appstudio/pipeline-service-exporter:c18a1079e58315454fb3ddf2ea9dc3c5cd4dc954
+        image: quay.io/konflux-ci/pipeline-service-exporter:95fe19bf616c628e6e8f30487113b61861569a6e
         name: pipeline-metrics-exporter
         ports:
         - containerPort: 9117
@@ -2022,8 +2022,8 @@ spec:
     enable-cluster-resolver: true
     enable-git-resolver: true
     enable-hub-resolver: true
-    enable-tekton-oci-bundles: true
     enable-step-actions: true
+    enable-tekton-oci-bundles: true
     options:
       configMaps:
         config-logging:

--- a/components/pipeline-service/production/stone-prod-p01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prod-p01/deploy.yaml
@@ -1344,7 +1344,7 @@ spec:
       - args:
         - -pprof-address
         - "6060"
-        image: quay.io/redhat-appstudio/pipeline-service-exporter:c18a1079e58315454fb3ddf2ea9dc3c5cd4dc954
+        image: quay.io/konflux-ci/pipeline-service-exporter:95fe19bf616c628e6e8f30487113b61861569a6e
         name: pipeline-metrics-exporter
         ports:
         - containerPort: 9117
@@ -2022,8 +2022,8 @@ spec:
     enable-cluster-resolver: true
     enable-git-resolver: true
     enable-hub-resolver: true
-    enable-tekton-oci-bundles: true
     enable-step-actions: true
+    enable-tekton-oci-bundles: true
     options:
       configMaps:
         config-logging:

--- a/components/pipeline-service/production/stone-prod-p02/deploy.yaml
+++ b/components/pipeline-service/production/stone-prod-p02/deploy.yaml
@@ -1344,7 +1344,7 @@ spec:
       - args:
         - -pprof-address
         - "6060"
-        image: quay.io/redhat-appstudio/pipeline-service-exporter:c18a1079e58315454fb3ddf2ea9dc3c5cd4dc954
+        image: quay.io/konflux-ci/pipeline-service-exporter:95fe19bf616c628e6e8f30487113b61861569a6e
         name: pipeline-metrics-exporter
         ports:
         - containerPort: 9117
@@ -2022,8 +2022,8 @@ spec:
     enable-cluster-resolver: true
     enable-git-resolver: true
     enable-hub-resolver: true
-    enable-tekton-oci-bundles: true
     enable-step-actions: true
+    enable-tekton-oci-bundles: true
     options:
       configMaps:
         config-logging:

--- a/components/pipeline-service/staging/base/kustomization.yaml
+++ b/components/pipeline-service/staging/base/kustomization.yaml
@@ -16,6 +16,9 @@ resources:
   - ../../base/certificates
 
 images:
+  - name: quay.io/konflux-ci/tekton-results-watcher
+    newName: quay.io/redhat-appstudio/tekton-results-watcher
+    newTag: bae7851ff584423503af324200f52cd28ca99116
   - name: quay.io/redhat-appstudio/tekton-results-watcher
     newTag: bae7851ff584423503af324200f52cd28ca99116
 


### PR DESCRIPTION
Until @khrm can either productize his third party tool integration for results log storage, or unless the backup option of accessing S3 from the watcher is done at a tactical solution, the current mem leak version of the watcher still provides slightly better success / performance than the versions that fix the mem leak / cancelled context issues but are more negatively impacted by grpc/http2 scaling issues.

I did run `generate-deploy-config.sh ` @enarha in both the staging and production folders.

rh-pre-commit.version: 2.3.0
rh-pre-commit.check-secrets: ENABLED