### PR TITLE
ui: remove nginx proxy for konflux workspaces

### DIFF
--- a/components/ui/base/proxy/nginx.conf
+++ b/components/ui/base/proxy/nginx.conf
@@ -58,11 +58,6 @@ http {
             proxy_read_timeout 30m;
         }
 
-        location /apis/workspaces.konflux.io/ {
-            # Konflux Workspaces
-            proxy_pass http://workspaces-rest-api-server.workspaces-system.svc.cluster.local/;
-        }
-
         location /wss/k8s/ {
             # Kube-API websockets
             proxy_pass http://api.toolchain-host-operator.svc.cluster.local/;


### PR DESCRIPTION
This is causing issues in production, since konflux-workspaces isn't available there yet.  Until workspaces is deployed in production, remove this section of the configuration.

See [here][1] for more context.

[1]: https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1721129546697399