### PR TITLE
Improve nginx deployment

### DIFF
--- a/components/ui/base/proxy/proxy.yaml
+++ b/components/ui/base/proxy/proxy.yaml
@@ -12,10 +12,11 @@ spec:
   selector:
     matchLabels:
       app: proxy
+  minReadySeconds: 60
   strategy:
     rollingUpdate:
-      maxSurge: 25%
-      maxUnavailable: 25%
+      maxSurge: 1
+      maxUnavailable: 0
   template:
     metadata:
       labels:
@@ -62,9 +63,19 @@ spec:
             path: /health
             port: 8080
             scheme: HTTP
-          initialDelaySeconds: 10
+          initialDelaySeconds: 60
           periodSeconds: 60
           successThreshold: 1
+          timeoutSeconds: 1
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /health
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 60
+          periodSeconds: 30
+          successThreshold: 3
           timeoutSeconds: 1
         ports:
         - containerPort: 8080


### PR DESCRIPTION
1. For 60 seconds, check if no containers in the pod crash loop and only then declare that the pod ready.

2. Add readiness probe. Traffic will be forwarded only to pods that pass the readiness check.

3. Adjust probes to start only after 60 seconds to match the change mention in 1.

4. During upgrade, allow an additional pod to be scheduled for the new replicaset.

5. Don't allow the deployment to have less that 3 pod ready, even during upgrade.