### PR TITLE
KFLUXBUGS-1451: Renewed power machines in the pool

### DIFF
--- a/components/multi-platform-controller/production-downstream/host-config.yaml
+++ b/components/multi-platform-controller/production-downstream/host-config.yaml
@@ -327,17 +327,17 @@ data:
   # dynamic.linux-ppc64le.memory: "2"
   # dynamic.linux-ppc64le.max-instances: "2"
 
-  host.power-rhtap-prod-1.address: "10.130.74.226"
+  host.power-rhtap-prod-1.address: "10.130.75.23"
   host.power-rhtap-prod-1.platform: "linux/ppc64le"
   host.power-rhtap-prod-1.user: "root"
   host.power-rhtap-prod-1.secret: "internal-prod-ibm-ssh-key"
-  host.power-rhtap-prod-1.concurrency: "4"
+  host.power-rhtap-prod-1.concurrency: "2"
 
-  host.power-rhtap-prod-2.address: "10.130.73.221"
+  host.power-rhtap-prod-2.address: "10.130.74.114"
   host.power-rhtap-prod-2.platform: "linux/ppc64le"
   host.power-rhtap-prod-2.user: "root"
   host.power-rhtap-prod-2.secret: "internal-prod-ibm-ssh-key"
-  host.power-rhtap-prod-2.concurrency: "4"
+  host.power-rhtap-prod-2.concurrency: "2"
 
   host.ibm-gpu-amd64.address: "10.130.81.14"
   host.ibm-gpu-amd64.platform: "linux-ibm-gpu/amd64"


### PR DESCRIPTION
This is to check existing Power Machines are causing this https://issues.redhat.com/browse/KFLUXBUGS-1451
* We updated and restarted the machine pool
* lowered the concurrent builds to 2