### PR TITLE
workspaces: split internal & external staging

### DIFF
--- a/components/workspaces/staging/stone-stage-p01/kustomization.yaml
+++ b/components/workspaces/staging/stone-stage-p01/kustomization.yaml
@@ -1,0 +1,17 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../base/
+images:
+- name: workspaces/rest-api
+  newName: quay.io/konflux-workspaces/workspaces-server
+  newTag: v0.1.0-alpha3
+- name: controller
+  newName: quay.io/konflux-workspaces/workspaces-operator
+  newTag: v0.1.0-alpha3
+
+configMapGenerator:
+- behavior: merge
+  literals:
+  - log.level=-4
+  name: rest-api-server-config

--- a/components/workspaces/staging/stone-stg-host/kustomization.yaml
+++ b/components/workspaces/staging/stone-stg-host/kustomization.yaml
@@ -1,7 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- ../base/
+- ../../base/
+- route.yaml
 images:
 - name: workspaces/rest-api
   newName: quay.io/konflux-workspaces/workspaces-server

--- a/components/workspaces/staging/stone-stg-host/route.yaml
+++ b/components/workspaces/staging/stone-stg-host/route.yaml
@@ -1,0 +1,19 @@
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  labels:
+    provider: workspaces
+    app: rest-api-server
+  name: workspaces-rest-api-server
+  namespace: workspaces-system
+spec:
+  host: ''
+  port:
+    targetPort: 8000
+  tls:
+    termination: edge
+  to:
+    kind: Service
+    name: workspaces-rest-api-server
+    weight: 100
+  wildcardPolicy: None


### PR DESCRIPTION
We need to have a route in the external staging environment, which we won't need in the internal.  To rectify this, have our staging config split so that we can deal with each deployment environment separately.