### PR TITLE
Disable automated sync for toolchain-member-operator

### DIFF
--- a/argo-cd-apps/base/toolchain-member/toolchain-member-operator.yaml
+++ b/argo-cd-apps/base/toolchain-member/toolchain-member-operator.yaml
@@ -30,15 +30,3 @@ spec:
       destination:
         namespace: toolchain-member-operator
         server: '{{server}}'
-      syncPolicy:
-        automated:
-          prune: true
-          selfHeal: true
-        syncOptions:
-          - CreateNamespace=false
-        retry:
-          limit: -1
-          backoff:
-            duration: 10s
-            factor: 2
-            maxDuration: 3m


### PR DESCRIPTION
There is an issue in prod were NS was deleted and we do not want ArgoCD to automatically sync to allow us to restore things.