### PR TITLE
Set prd-m01 as default cluster

### DIFF
--- a/components/sandbox/toolchain-host-operator/production/stone-prd-host1/space-provisioner-configs.yaml
+++ b/components/sandbox/toolchain-host-operator/production/stone-prd-host1/space-provisioner-configs.yaml
@@ -7,7 +7,7 @@ metadata:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   toolchainCluster: member-stone-prd-m01.84db.p1.openshiftapps.com
-  enabled: false
+  enabled: true
   capacityThresholds:
     maxNumberOfSpaces: 1000
     maxMemoryUtilizationPercent: 90
@@ -23,7 +23,7 @@ metadata:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   toolchainCluster: member-stone-prd-rh01.pg1f.p1.openshiftapps.com
-  enabled: true
+  enabled: false
   capacityThresholds:
     maxMemoryUtilizationPercent: 90
   placementRoles:


### PR DESCRIPTION
We are recovering from an outage and want to test m01 before recovering rh01. This change will be reverted after.