### PR TITLE
Revert "Disable automated sync for toolchain-member-operator (#4126)"

### DIFF
--- a/argo-cd-apps/base/toolchain-member/toolchain-member-operator.yaml
+++ b/argo-cd-apps/base/toolchain-member/toolchain-member-operator.yaml
@@ -30,3 +30,15 @@ spec:
       destination:
         namespace: toolchain-member-operator
         server: '{{server}}'
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
+        syncOptions:
+          - CreateNamespace=false
+        retry:
+          limit: -1
+          backoff:
+            duration: 10s
+            factor: 2
+            maxDuration: 3m


### PR DESCRIPTION
This reverts commit bba8ee419954122078133b1a3a0cf97c8d3aaba6.