### PR TITLE
Disable automated pruning for toolchain operators

### DIFF
--- a/argo-cd-apps/base/host/toolchain-host-operator/toolchain-host-operator.yaml
+++ b/argo-cd-apps/base/host/toolchain-host-operator/toolchain-host-operator.yaml
@@ -39,7 +39,7 @@ spec:
         server: '{{server}}'
       syncPolicy:
         automated:
-          prune: true
+          prune: false
           selfHeal: true
         syncOptions:
           - CreateNamespace=false

--- a/argo-cd-apps/base/toolchain-member/toolchain-member-operator.yaml
+++ b/argo-cd-apps/base/toolchain-member/toolchain-member-operator.yaml
@@ -32,7 +32,7 @@ spec:
         server: '{{server}}'
       syncPolicy:
         automated:
-          prune: true
+          prune: false
           selfHeal: true
         syncOptions:
           - CreateNamespace=false


### PR DESCRIPTION
We had an outage due to a back overlay change. The overlay change resulted in deleting the toolchain member applications thus all resources in toolchain-member-operator namespace. We were lucky that we recovered without data loss.

Since toolchain host and member namespaces contains user registration CRs that are not deployed by ArgoCD, disable the automated pruning to prevent accidental deletion. From now on, if a resource is deleted from those application, someone will need to manually start the sync with prune option after reviewing the resources to delete.