### PR TITLE
Remove the SpaceProvisionerConfig for EaaS in public staging

### DIFF
--- a/components/sandbox/toolchain-host-operator/staging/stone-stg-host/space-provisioner-configs.yaml
+++ b/components/sandbox/toolchain-host-operator/staging/stone-stg-host/space-provisioner-configs.yaml
@@ -28,19 +28,3 @@ spec:
     maxMemoryUtilizationPercent: 90
   placementRoles:
   - cluster-role.toolchain.dev.openshift.com/tenant
----
-apiVersion: toolchain.dev.openshift.com/v1alpha1
-kind: SpaceProvisionerConfig
-metadata:
-  name: member-kflux-stg-es01.21tc.p1.openshiftapps.com
-  namespace: toolchain-host-operator
-  annotations:
-    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
-spec:
-  toolchainCluster: member-kflux-stg-es01.21tc.p1.openshiftapps.com
-  enabled: true
-  capacityThresholds:
-    maxNumberOfSpaces: 1500
-    maxMemoryUtilizationPercent: 90
-  placementRoles:
-  - cluster-role.toolchain.dev.openshift.com/eaas


### PR DESCRIPTION
This was included by mistake in a prior commit.