### PR TITLE
workspaces: use correct subdir of staging/ to deploy

### DIFF
--- a/argo-cd-apps/base/host/workspaces/workspaces.yaml
+++ b/argo-cd-apps/base/host/workspaces/workspaces.yaml
@@ -14,7 +14,11 @@ spec:
                 environment: staging
                 clusterDir: ""
           - list:
-              elements: []
+              elements:
+                - nameNormalized: stone-stage-p01
+                  values.clusterDir: stone-stage-p01
+                - nameNormalized: stone-stg-host
+                  values.clusterDir: stone-stg-host
   template:
     metadata:
       name: workspaces-{{nameNormalized}}


### PR DESCRIPTION
Argo was looking at the top-level staging/ directory of components/workspaces/, when it should be using the subdirectories based off of the deployment environment.