### PR TITLE
Allow mintmaker team members to create delete dependencyupdatechecks

### DIFF
--- a/components/mintmaker/base/rbac/mintmaker-team.yaml
+++ b/components/mintmaker/base/rbac/mintmaker-team.yaml
@@ -10,6 +10,12 @@ rules:
       - jobs
     verbs:
       - '*'
+  - apiGroups:
+      - appstudio.redhat.com
+    resources:
+      - dependencyupdatechecks
+    verbs:
+      - '*'
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
DependencyUpdateCheck is a CR used by mintmaker to trigger Renovate jobs.