### PR TITLE
chore(RELEASE-1047): bump internal-services crd commit

### DIFF
--- a/components/internal-services/kustomization.yaml
+++ b/components/internal-services/kustomization.yaml
@@ -4,7 +4,7 @@ resources:
 - internal_service_request_service_account.yaml
 - internal_service_service_account_token.yaml
 - internal-services.yaml
-- https://github.com/konflux-ci/internal-services/config/crd?ref=01434f5d914d940ba5b43e4d1a0ffb7db45e52ff
+- https://github.com/konflux-ci/internal-services/config/crd?ref=d52084b5f693a2cc4be5408136ea89f87ab321b2
 
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization


### PR DESCRIPTION
The new commit includes the serviceAccount field in the InternalRequest.Spec.