### PR TITLE
workspaces: specify host for route

### DIFF
--- a/components/workspaces/staging/stone-stg-host/route.yaml
+++ b/components/workspaces/staging/stone-stg-host/route.yaml
@@ -7,7 +7,7 @@ metadata:
   name: workspaces-rest-api-server
   namespace: workspaces-system
 spec:
-  host: ''
+  host: workspaces-rest-api-server-workspaces-system.apps.stone-stg-host.qc0p.p1.openshiftapps.com
   port:
     targetPort: 8000
   tls:


### PR DESCRIPTION
This fixes a out-of-sync loop between what ArgoCD wants (an empty host) and what the route controller wants (a populated .spec.host field).