### PR TITLE
tekton-ci: prune build-templates-e2e harder

### DIFF
--- a/components/tekton-ci/production/cleanup-cronjob.yaml
+++ b/components/tekton-ci/production/cleanup-cronjob.yaml
@@ -3,7 +3,7 @@ kind: CronJob
 metadata:
   name: cleanup-stale-resources
 spec:
-  schedule: "0 1 * * *" #Daily at 01:00
+  schedule: "0 * * * *"  # hourly
   jobTemplate:
     spec:
       template:

--- a/components/tekton-ci/production/cleanup-cronjob.yaml
+++ b/components/tekton-ci/production/cleanup-cronjob.yaml
@@ -17,7 +17,7 @@ spec:
             - -c
             - |
               date; echo Cleaning up the stale applications
-              oc get application -n build-templates-e2e -o go-template --template '{{range .items}}{{.metadata.name}} {{.metadata.creationTimestamp}}{{"\n"}}{{end}}' | awk '$2 <= "'$(date -d'now-3 days' --iso-8601=seconds --utc | sed 's/+00:00/Z/')'" { print $1 }' | xargs --no-run-if-empty oc delete application -n build-templates-e2e
+              oc get application -n build-templates-e2e -o go-template --template '{{range .items}}{{.metadata.name}} {{.metadata.creationTimestamp}}{{"\n"}}{{end}}' | awk '$2 <= "'$(date -d '1 day ago' --iso-8601=seconds --utc | sed 's/+00:00/Z/')'" { print $1 }' | xargs --no-run-if-empty oc delete application -n build-templates-e2e
             resources:
               limits:
                 cpu: 100m


### PR DESCRIPTION
The cleanup-cronjob running in the tekton-ci namespace deletes
Applications used for e2e-tests. Currently, it deletes applications
at least 3 days old.

This doesn't seem to be enough to keep up with the rate of e2e-testing
in build-definitions anymore.

Remove applications after 1 day instead.

Also run the pruner every hour