### PR TITLE
workspaces: apply roles to translated service account name

### DIFF
--- a/components/workspaces/base/server/config/default/kustomization.yaml
+++ b/components/workspaces/base/server/config/default/kustomization.yaml
@@ -71,6 +71,27 @@ replacements:
       group: rbac.authorization.k8s.io
       kind: RoleBinding
       name: rest-api-server:usersignup-reader
+- source:
+    fieldPath: metadata.name
+    kind: ServiceAccount
+    name: rest-api-server
+  targets:
+  - fieldPaths:
+    - subjects.0.name
+    options:
+      create: true
+    select:
+      group: rbac.authorization.k8s.io
+      kind: RoleBinding
+      name: rest-api-server:spacebinding-reader
+  - fieldPaths:
+    - subjects.0.name
+    options:
+      create: true
+    select:
+      group: rbac.authorization.k8s.io
+      kind: RoleBinding
+      name: rest-api-server:usersignup-reader
 namespace: workspaces-system
 configMapGenerator:
 - behavior: replace


### PR DESCRIPTION
Currently, the role bindings we have for server apply to the service account `rest-api-server`, not `workspaces-rest-api-server`.  We need to overwrite the name in the bindings to reflect the processing the names of resources go through as a part of the kustomization process.