### PR TITLE
enable OSP pruner again

### DIFF
--- a/components/pipeline-service/production/base/update-tekton-config-performance.yaml
+++ b/components/pipeline-service/production/base/update-tekton-config-performance.yaml
@@ -31,6 +31,14 @@
   path: /spec/pipeline/options/deployments/tekton-operator-proxy-webhook/spec/replicas
   # default pipeline-service setting is 1
   value: 2
+- op: replace
+  path: /spec/pruner
+  value:
+    disabled: false
+    keep-since: 60
+    resources:
+      - pipelinerun
+    schedule: "*/10 * * * *"
 - op: add
   path: /spec/pipeline/options/deployments/tekton-pipelines-remote-resolvers/spec
   # replicas - default pipeline-service setting is 1

--- a/components/pipeline-service/production/stone-prd-m01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prd-m01/deploy.yaml
@@ -2162,7 +2162,11 @@ spec:
             namespace }}/pipelinerun/{{ pr }}/logs/{{ task }}
   profile: all
   pruner:
-    disabled: true
+    disabled: false
+    keep-since: 60
+    resources:
+    - pipelinerun
+    schedule: '*/10 * * * *'
   targetNamespace: openshift-pipelines
   trigger:
     options:

--- a/components/pipeline-service/production/stone-prd-rh01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prd-rh01/deploy.yaml
@@ -2162,7 +2162,11 @@ spec:
             namespace }}/pipelinerun/{{ pr }}/logs/{{ task }}
   profile: all
   pruner:
-    disabled: true
+    disabled: false
+    keep-since: 60
+    resources:
+    - pipelinerun
+    schedule: '*/10 * * * *'
   targetNamespace: openshift-pipelines
   trigger:
     options:

--- a/components/pipeline-service/production/stone-prod-p01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prod-p01/deploy.yaml
@@ -2162,7 +2162,11 @@ spec:
             namespace }}/pipelinerun/{{ pr }}/logs/{{ task }}
   profile: all
   pruner:
-    disabled: true
+    disabled: false
+    keep-since: 60
+    resources:
+    - pipelinerun
+    schedule: '*/10 * * * *'
   targetNamespace: openshift-pipelines
   trigger:
     options:

--- a/components/pipeline-service/production/stone-prod-p02/deploy.yaml
+++ b/components/pipeline-service/production/stone-prod-p02/deploy.yaml
@@ -2162,7 +2162,11 @@ spec:
             namespace }}/pipelinerun/{{ pr }}/logs/{{ task }}
   profile: all
   pruner:
-    disabled: true
+    disabled: false
+    keep-since: 60
+    resources:
+    - pipelinerun
+    schedule: '*/10 * * * *'
   targetNamespace: openshift-pipelines
   trigger:
     options:


### PR DESCRIPTION
enable OSP pruner again for resolver memory issues and results prune performance issues seen on prod-rh01 (#4171). The pruner is set to run every 10 minutes, pruning pipelineruns older than 60 minutes. It serves as a backup pruner for the Tekton Results pruner which ideally will be pruning the pipelineruns earlier up to 10 mins after completion.

This is a temporary measure until the Results pruner performance is improved.