### PR TITLE
adust watcher mem for increased prod-rh01 load

### DIFF
--- a/components/pipeline-service/production/base/bump-results-watcher-mem.yaml
+++ b/components/pipeline-service/production/base/bump-results-watcher-mem.yaml
@@ -1,7 +1,7 @@
 ---
 - op: replace
   path: /spec/template/spec/containers/1/resources/limits/memory
-  value: "3Gi"
+  value: "6Gi"
 - op: replace
   path: /spec/template/spec/containers/1/resources/requests/memory
-  value: "3Gi"
+  value: "6Gi"

--- a/components/pipeline-service/production/stone-prd-m01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prd-m01/deploy.yaml
@@ -1636,10 +1636,10 @@ spec:
         resources:
           limits:
             cpu: 250m
-            memory: 3Gi
+            memory: 6Gi
           requests:
             cpu: 250m
-            memory: 3Gi
+            memory: 6Gi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/components/pipeline-service/production/stone-prd-rh01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prd-rh01/deploy.yaml
@@ -1636,10 +1636,10 @@ spec:
         resources:
           limits:
             cpu: 250m
-            memory: 3Gi
+            memory: 6Gi
           requests:
             cpu: 250m
-            memory: 3Gi
+            memory: 6Gi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/components/pipeline-service/production/stone-prod-p01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prod-p01/deploy.yaml
@@ -1636,10 +1636,10 @@ spec:
         resources:
           limits:
             cpu: 250m
-            memory: 3Gi
+            memory: 6Gi
           requests:
             cpu: 250m
-            memory: 3Gi
+            memory: 6Gi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/components/pipeline-service/production/stone-prod-p02/deploy.yaml
+++ b/components/pipeline-service/production/stone-prod-p02/deploy.yaml
@@ -1636,10 +1636,10 @@ spec:
         resources:
           limits:
             cpu: 250m
-            memory: 3Gi
+            memory: 6Gi
           requests:
             cpu: 250m
-            memory: 3Gi
+            memory: 6Gi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:


### PR DESCRIPTION
related to the recent remote-resolver and re-enablement of OSP pruning

rh-pre-commit.version: 2.3.0
rh-pre-commit.check-secrets: ENABLED