### PR TITLE
workspaces: correctly override image references

### DIFF
--- a/components/workspaces/base/server/config/server/kustomization.yaml
+++ b/components/workspaces/base/server/config/server/kustomization.yaml
@@ -19,4 +19,4 @@ configMapGenerator:
 images:
 - name: workspaces/rest-api
   newName: quay.io/konflux-workspaces/workspaces-server
-  newTag: v0.1.0-alpha3
+  newTag: v0.1.0-alpha4

--- a/components/workspaces/staging/stone-stage-p01/kustomization.yaml
+++ b/components/workspaces/staging/stone-stage-p01/kustomization.yaml
@@ -3,11 +3,9 @@ kind: Kustomization
 resources:
 - ../../base/
 images:
-- name: workspaces/rest-api
-  newName: quay.io/konflux-workspaces/workspaces-server
+- name: quay.io/konflux-workspaces/workspaces-server
   newTag: v0.1.0-alpha4
-- name: controller
-  newName: quay.io/konflux-workspaces/workspaces-operator
+- name: quay.io/konflux-workspaces/workspaces-operator
   newTag: v0.1.0-alpha4
 
 configMapGenerator:

--- a/components/workspaces/staging/stone-stg-host/kustomization.yaml
+++ b/components/workspaces/staging/stone-stg-host/kustomization.yaml
@@ -4,11 +4,9 @@ resources:
 - ../../base/
 - route.yaml
 images:
-- name: workspaces/rest-api
-  newName: quay.io/konflux-workspaces/workspaces-server
+- name: quay.io/konflux-workspaces/workspaces-server
   newTag: v0.1.0-alpha4
-- name: controller
-  newName: quay.io/konflux-workspaces/workspaces-operator
+- name: quay.io/konflux-workspaces/workspaces-operator
   newTag: v0.1.0-alpha4
 
 configMapGenerator:


### PR DESCRIPTION
In our top-level kustomize manifest for each staging environment, we were referring to the image name embedded in the deployment manifests directly, not the name that would be replacing it after processing by lower-level kustomize manifests.