### PR TITLE
Update mintmaker-renovate-image digest

### DIFF
--- a/components/mintmaker/production/base/manager_patches.yaml
+++ b/components/mintmaker/production/base/manager_patches.yaml
@@ -17,4 +17,4 @@ spec:
             memory: 256Mi
         env:
         - name: RENOVATE_IMAGE
-          value: "quay.io/konflux-ci/mintmaker-renovate-image:717feeb"
+          value: "quay.io/konflux-ci/mintmaker-renovate-image:c56e548"


### PR DESCRIPTION
Included PRs:

- https://github.com/konflux-ci/mintmaker-renovate-image/pull/33
- https://github.com/konflux-ci/mintmaker-renovate-image/pull/36
- https://github.com/konflux-ci/mintmaker-renovate-image/pull/37

This fixes CWFHEALTH-3280. Tested this image locally, `pip3` shows correctly `rpm-lockfile-prototype    0.5.1`. [Changelog](https://github.com/konflux-ci/rpm-lockfile-prototype/blob/main/CHANGELOG.md).