### PR TITLE
Fix MintMaker tag digest

### DIFF
--- a/components/mintmaker/production/base/manager_patches.yaml
+++ b/components/mintmaker/production/base/manager_patches.yaml
@@ -17,4 +17,4 @@ spec:
             memory: 256Mi
         env:
         - name: RENOVATE_IMAGE
-          value: "quay.io/konflux-ci/mintmaker-renovate-image:c56e548"
+          value: "quay.io/konflux-ci/mintmaker-renovate-image:fe84827"


### PR DESCRIPTION
For some reason the `c56e548` tag disappeared from quay?