### PR TITLE
workspaces: fix outdated namespace reference

### DIFF
--- a/argo-cd-apps/base/host/workspaces/workspaces.yaml
+++ b/argo-cd-apps/base/host/workspaces/workspaces.yaml
@@ -29,7 +29,7 @@ spec:
         repoURL: https://github.com/redhat-appstudio/infra-deployments.git
         targetRevision: main
       destination:
-        namespace: konflux-workspaces
+        namespace: workspaces-system
         server: '{{server}}'
       syncPolicy:
         automated:


### PR DESCRIPTION
Workspaces is deployed in the `workspaces-system` namespace, not the `konflux-workspaces` namespace.  Update argocd's reference so that it doesn't have to manage a namespace that will never be populated.