### PR TITLE
Fix ExternalSecret labels

### DIFF
--- a/components/cluster-as-a-service/staging/external-secrets.yaml
+++ b/components/cluster-as-a-service/staging/external-secrets.yaml
@@ -3,6 +3,8 @@ kind: ExternalSecret
 metadata:
   name: cluster-as-a-service-hypershift-credentials
   namespace: clusters
+  labels:
+    hypershift.openshift.io/safe-to-delete-with-cluster: "false"
 spec:
   dataFrom:
   - extract:
@@ -18,8 +20,6 @@ spec:
     deletionPolicy: Delete
     name: hypershift
     template:
-      labels:
-        hypershift.openshift.io/safe-to-delete-with-cluster: "false"
       data:
         aws_access_key_id: "{{ .aws_access_key_id }}"
         aws_secret_access_key: "{{ .aws_secret_access_key }}"


### PR DESCRIPTION
Labels inside `spec.target.template` are ignored by the API causing the Application to stay out of sync. Labels inside `metadata` should be copied to the resulting Secret.