### PR TITLE
feat(KFLUXINFRA-739): freeze MPC version in PROD

### DIFF
--- a/components/multi-platform-controller/base/kustomization.yaml
+++ b/components/multi-platform-controller/base/kustomization.yaml
@@ -1,6 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
+namespace: multi-platform-controller
+
 resources:
 - monitoring.yaml
 - allow-argocd-to-manage.yaml
@@ -14,7 +16,3 @@ images:
 - name: multi-platform-otp-server
   newName: quay.io/konflux-ci/multi-platform-controller-otp-service
   newTag: f54047c5bc77752ce64eb78774535eb35eb406f2
-
-namespace: multi-platform-controller
-
-

--- a/components/multi-platform-controller/production-downstream/kustomization.yaml
+++ b/components/multi-platform-controller/production-downstream/kustomization.yaml
@@ -1,8 +1,17 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+
+namespace: multi-platform-controller
+
 resources:
 - ../base
 - host-config.yaml
 - external-secrets.yaml
 
-namespace: multi-platform-controller
+images:
+- name: multi-platform-controller
+  newName: quay.io/konflux-ci/multi-platform-controller
+  newTag: f54047c5bc77752ce64eb78774535eb35eb406f2
+- name: multi-platform-otp-server
+  newName: quay.io/konflux-ci/multi-platform-controller-otp-service
+  newTag: f54047c5bc77752ce64eb78774535eb35eb406f2

--- a/components/multi-platform-controller/production/kustomization.yaml
+++ b/components/multi-platform-controller/production/kustomization.yaml
@@ -1,9 +1,17 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+
+namespace: multi-platform-controller
+
 resources:
 - ../base
 - host-config.yaml
 - external-secrets.yaml
 
-
-namespace: multi-platform-controller
+images:
+- name: multi-platform-controller
+  newName: quay.io/konflux-ci/multi-platform-controller
+  newTag: f54047c5bc77752ce64eb78774535eb35eb406f2
+- name: multi-platform-otp-server
+  newName: quay.io/konflux-ci/multi-platform-controller-otp-service
+  newTag: f54047c5bc77752ce64eb78774535eb35eb406f2


### PR DESCRIPTION
Change production overlays for multi-platform-controller to specify
a fixed version so that a maunal update would be needed in ordr to push
changes to the production clusters.