### PR TITLE
SRVKP-4523: need both old and new tekton k8s throttle metrics available to app-sre

### DIFF
--- a/components/monitoring/prometheus/base/monitoringstack/monitoringstack.yaml
+++ b/components/monitoring/prometheus/base/monitoringstack/monitoringstack.yaml
@@ -99,6 +99,8 @@ spec:
         - '{__name__="taskrun_pod_create_not_attempted_or_pending_count"}'
         - '{__name__="tekton_pipelines_controller_running_taskruns_throttled_by_quota_count"}'
         - '{__name__="tekton_pipelines_controller_running_taskruns_throttled_by_node_count"}'
+        - '{__name__="tekton_pipelines_controller_running_taskruns_throttled_by_quota"}'
+        - '{__name__="tekton_pipelines_controller_running_taskruns_throttled_by_node"}'
         - '{__name__="tekton_pipelines_controller_pipelinerun_duration_seconds_sum"}'
         - '{__name__="tekton_pipelines_controller_pipelinerun_duration_seconds_count"}'
         - '{__name__="controller_runtime_reconcile_errors_total", namespace!~".*-tenant|openshift-.*|kube-.*"}'


### PR DESCRIPTION


Forgot a couple with https://github.com/redhat-appstudio/infra-deployments/pull/4159

rh-pre-commit.version: 2.3.0
rh-pre-commit.check-secrets: ENABLED