### PR TITLE
chore(RHTAPWATCH-1188): prevent cascade deletion

### DIFF
--- a/argo-cd-apps/base/rh-managed-workspaces-config/rh-managed-workspaces-config.yaml
+++ b/argo-cd-apps/base/rh-managed-workspaces-config/rh-managed-workspaces-config.yaml
@@ -3,6 +3,8 @@ kind: ApplicationSet
 metadata:
   name: rh-managed-workspaces-config
 spec:
+  syncPolicy:
+    preserveResourcesOnDeletion: true
   generators:
     - git:
         repoURL: https://github.com/redhat-appstudio/tenants-config

--- a/argo-cd-apps/base/tenants-config/tenants-config.yaml
+++ b/argo-cd-apps/base/tenants-config/tenants-config.yaml
@@ -3,6 +3,8 @@ kind: ApplicationSet
 metadata:
   name: tenants-config
 spec:
+  syncPolicy:
+    preserveResourcesOnDeletion: true
   generators:
     - git:
         repoURL: https://github.com/redhat-appstudio/tenants-config


### PR DESCRIPTION
- as part of the migration of tenants-config from GH to Gitlab, we need to eventually delete the ApplicationSets that point to GitHub while ensuring that resources are not deleted since they are being monitored by the ArgoCD instance that is looking at Gitlab.
- this is Part 1 of 2 in the process. Simply preventing cascading deletion.
- Part 2 will be the actual deletion of the ApplicationSet