### PR TITLE
KFLUXINFRA-745: ConfigMap Settings for the Default Resource Requests and Limits

### DIFF
--- a/components/pipeline-service/staging/base/kustomization.yaml
+++ b/components/pipeline-service/staging/base/kustomization.yaml
@@ -32,9 +32,12 @@ configMapGenerator:
     options:
       disableNameSuffixHash: true
   - behavior: merge
-    name: config-observability
+    name: config-defaults
     literals:
-      - profiling.enable="true"
+      - default-container-resource-requirements.default.requests.memory="256Mi"
+      - default-container-resource-requirements.default.requests.cpu="250m"
+      - default-container-resource-requirements.default.limits.memory="512Mi"
+      - default-container-resource-requirements.default.limits.cpu="500m"
 
 patches:
   - path: chains-tekton-config-patches.yaml


### PR DESCRIPTION
Pipeline ConfigMap Settings for the Default Resource Requests and Limits.

These values are not tested and are for testing purposes to see if it enforces resource requests and limits for the PipelineRin containers with no resource requests and limits set.