### PR TITLE
WIP-DNM: example of how to update config-defaults in openshift-pipelines

### DIFF
--- a/components/pipeline-service/development/update-tekton-config-performance.yaml
+++ b/components/pipeline-service/development/update-tekton-config-performance.yaml
@@ -43,3 +43,16 @@
   path: /spec/platforms/openshift/pipelinesAsCode/options/deployments/pipelines-as-code-webhook/spec/replicas
   # default pipeline-service setting is 1
   value: 2
+- op: add
+  path: /spec/pipeline/options/configmaps
+  value:
+    config-defaults:
+      data:
+        default-container-resource-requirements: |
+          default:
+            requests:
+              memory: "256Mi"
+              cpu: "250m"
+            limits:
+              memory: "512Mi"
+              cpu: "500m""

--- a/components/pipeline-service/staging/base/update-tekton-config-performance.yaml
+++ b/components/pipeline-service/staging/base/update-tekton-config-performance.yaml
@@ -46,3 +46,16 @@
 - op: replace
   path: /spec/pipeline/options/horizontalPodAutoscalers/tekton-pipelines-webhook/spec/minReplicas
   value: 6
+- op: add
+  path: /spec/pipeline/options/configmaps
+  value:
+    config-defaults:
+      data:
+        default-container-resource-requirements: |
+          default:
+            requests:
+              memory: "256Mi"
+              cpu: "250m"
+            limits:
+              memory: "512Mi"
+              cpu: "500m""

--- a/components/pipeline-service/staging/stone-stage-p01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stage-p01/deploy.yaml
@@ -2104,6 +2104,17 @@ spec:
                   "callerEncoder": ""
                 }
               }
+      configmaps:
+        config-defaults:
+          data:
+            default-container-resource-requirements: |
+              default:
+                requests:
+                  memory: "256Mi"
+                  cpu: "250m"
+                limits:
+                  memory: "512Mi"
+                  cpu: "500m""
       deployments:
         tekton-operator-proxy-webhook:
           spec:

--- a/components/pipeline-service/staging/stone-stg-m01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stg-m01/deploy.yaml
@@ -2104,6 +2104,17 @@ spec:
                   "callerEncoder": ""
                 }
               }
+      configmaps:
+        config-defaults:
+          data:
+            default-container-resource-requirements: |
+              default:
+                requests:
+                  memory: "256Mi"
+                  cpu: "250m"
+                limits:
+                  memory: "512Mi"
+                  cpu: "500m""
       deployments:
         tekton-operator-proxy-webhook:
           spec:

--- a/components/pipeline-service/staging/stone-stg-rh01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stg-rh01/deploy.yaml
@@ -2104,6 +2104,17 @@ spec:
                   "callerEncoder": ""
                 }
               }
+      configmaps:
+        config-defaults:
+          data:
+            default-container-resource-requirements: |
+              default:
+                requests:
+                  memory: "256Mi"
+                  cpu: "250m"
+                limits:
+                  memory: "512Mi"
+                  cpu: "500m""
       deployments:
         tekton-operator-proxy-webhook:
           spec:


### PR DESCRIPTION
@manish-jangra @arewm this rather than what I described yesterday is the path for updating `config-defaults` in the `openshift-pipelines` namespace.

I forgot since the openshift pipelines operator owns and creates this configmap, we must use the TektonConfig to manipulate the config map.

I generated those deploy.yaml files below via this process:

```
gmontero ~/go/src/github.com/redhat-appstudio/infra-deployments  (test-create-defaults-cm)$ git status 
On branch test-create-defaults-cm
Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
	modified:   components/pipeline-service/staging/base/update-tekton-config-performance.yaml

no changes added to commit (use "git add" and/or "git commit -a")
gmontero ~/go/src/github.com/redhat-appstudio/infra-deployments  (test-create-defaults-cm)$ cd components/pipeline-service/staging/
gmontero ~/go/src/github.com/redhat-appstudio/infra-deployments/components/pipeline-service/staging  (test-create-defaults-cm)$ ../../../hack/generate-deploy-config.sh 
./stone-stg-m01/resources: ./stone-stg-m01/deploy.yaml
./stone-stg-rh01/resources: ./stone-stg-rh01/deploy.yaml
./stone-stage-p01/resources: ./stone-stage-p01/deploy.yaml
gmontero ~/go/src/github.com/redhat-appstudio/infra-deployments/components/pipeline-service/staging  (test-create-defaults-cm) $ 
```

this PR just sets the default vs. any `prefix-*` filtering.  I will leave it to you two to update  https://github.com/redhat-appstudio/infra-deployments/pull/4249 and decide if you want to filter with a prefix or keep the default.

rh-pre-commit.version: 2.3.0
rh-pre-commit.check-secrets: ENABLED