### PR TITLE
Enable kflux-stg-es01 SpaceProvisionerConfig

### DIFF
--- a/components/sandbox/toolchain-host-operator/staging/stone-stg-host/space-provisioner-configs.yaml
+++ b/components/sandbox/toolchain-host-operator/staging/stone-stg-host/space-provisioner-configs.yaml
@@ -38,7 +38,7 @@ metadata:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   toolchainCluster: member-kflux-stg-es01.21tc.p1.openshiftapps.com
-  enabled: false
+  enabled: true
   capacityThresholds:
     maxNumberOfSpaces: 1500
     maxMemoryUtilizationPercent: 90


### PR DESCRIPTION
SpaceRequests cannot be provisioned unless this is enabled. The default targetClusterRole for user signup is tenant so the placementRoles on the SpaceProvisionerConfig should prevent it from being undesireably used for that flow.