### PR TITLE
KONFLUX-2256: multi-platform controller can spawn GPU accelerated nodes

### DIFF
--- a/components/multi-platform-controller/staging/host-config.yaml
+++ b/components/multi-platform-controller/staging/host-config.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: multi-platform-controller
 data:
 
-  dynamic-platforms: linux/arm64,linux/amd64,linux-mxlarge/amd64,linux-mxlarge/arm64,linux-m2xlarge/amd64,linux-m2xlarge/arm64,linux-m4xlarge/amd64,linux-m4xlarge/arm64,linux-m8xlarge/amd64,linux-m8xlarge/arm64,linux-cxlarge/amd64,linux-cxlarge/arm64,linux-c2xlarge/amd64,linux-c2xlarge/arm64,linux-c4xlarge/amd64,linux-c4xlarge/arm64,linux-c8xlarge/amd64,linux-c8xlarge/arm64,linux-root/arm64,linux-root/amd64
+  dynamic-platforms: linux/arm64,linux/amd64,linux-mxlarge/amd64,linux-mxlarge/arm64,linux-m2xlarge/amd64,linux-m2xlarge/arm64,linux-m4xlarge/amd64,linux-m4xlarge/arm64,linux-m8xlarge/amd64,linux-m8xlarge/arm64,linux-cxlarge/amd64,linux-cxlarge/arm64,linux-c2xlarge/amd64,linux-c2xlarge/arm64,linux-c4xlarge/amd64,linux-c4xlarge/arm64,linux-c8xlarge/amd64,linux-c8xlarge/arm64,linux-g4xlarge/amd64,linux-root/arm64,linux-root/amd64
   instance-tag: rhtap-staging
 
   # cpu:memory (1:4)
@@ -209,6 +209,17 @@ data:
   dynamic.linux-c8xlarge-amd64.security-group-id: sg-05bc8dd0b52158567
   dynamic.linux-c8xlarge-amd64.max-instances: "10"
   dynamic.linux-c8xlarge-amd64.subnet-id: subnet-030738beb81d3863a
+
+  dynamic.linux-g4xlarge-amd64.type: aws
+  dynamic.linux-g4xlarge-amd64.region: us-east-1
+  dynamic.linux-g4xlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-g4xlarge-amd64.instance-type: g6.4xlarge
+  dynamic.linux-g4xlarge-amd64.key-name: konflux-stage-ext-mab01
+  dynamic.linux-g4xlarge-amd64.aws-secret: aws-account
+  dynamic.linux-g4xlarge-amd64.ssh-secret: aws-ssh-key
+  dynamic.linux-g4xlarge-amd64.security-group-id: sg-05bc8dd0b52158567
+  dynamic.linux-g4xlarge-amd64.max-instances: "10"
+  dynamic.linux-g4xlarge-amd64.subnet-id: subnet-030738beb81d3863a
 
   #root
   dynamic.linux-root-arm64.type: aws


### PR DESCRIPTION
Added linux-g4xlarge/amd64 dynamic platform, backed by g6.4xlarge AWS instance type.