### PR TITLE
chore(RHTAPWATCH-1188): part 2: rm tenants-config

### DIFF
--- a/argo-cd-apps/overlays/konflux-public-production/delete-applications.yaml
+++ b/argo-cd-apps/overlays/konflux-public-production/delete-applications.yaml
@@ -17,3 +17,17 @@ kind: ApplicationSet
 metadata:
   name: tempo
 $patch: delete
+---
+# See RHTAPWATCH-1188
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: tenants-config
+$patch: delete
+---
+# See RHTAPWATCH-1188
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: rh-managed-workspaces-config
+$patch: delete


### PR DESCRIPTION
- remove old tenants-config and rh-managed-workspaces-config ApplicationSets from production overlays.
- Thanks to #4243 (part 1), a cascade deletion of resources will be prevented.
- Part 3 will be the deletion of the tenants-config and rh-managed-workspaces-config resources from this repo.