### PR TITLE
Bump version for hypershift-aws-cluster template

### DIFF
--- a/components/cluster-as-a-service/base/clustertemplates.yaml
+++ b/components/cluster-as-a-service/base/clustertemplates.yaml
@@ -36,7 +36,7 @@ spec:
       source:
         chart: hypershift-aws-template
         repoURL: https://konflux-ci.dev/cluster-template-charts/
-        targetRevision: 0.0.2
+        targetRevision: 0.0.3
         helm:
           parameters:
             - name: region


### PR DESCRIPTION
The updated chart includes a configurable timeout value.