### PR TITLE
workspaces: enable public-viewer support in public staging

### DIFF
--- a/components/sandbox/toolchain-host-operator/staging/stone-stg-host/toolchainconfig.yaml
+++ b/components/sandbox/toolchain-host-operator/staging/stone-stg-host/toolchainconfig.yaml
@@ -25,6 +25,8 @@ spec:
           mailgunSenderEmail: mailgun.sender.email
           ref: host-operator-secret
         templateSetName: 'appstudio'
+      publicViewerConfig:
+        enabled: true
       registrationService:
         auth:
           authClientConfigRaw: '{


### PR DESCRIPTION
These changes enable support for public-viewer in public staging even if the feature is not completely merged in KubeSaw. This will avoid the loop in which KubeSaw host-operator deletes the SpaceBinding for the Public-Viewer user and the Konflux-Workspaces operator is creating it back.

RegistrationService is not going to be impacted by this change until https://github.com/codeready-toolchain/registration-service/pull/453 merges.