### PR TITLE
PVCORE-4435 - Move otel image to Quay.  Pin versions of image and chart

### DIFF
--- a/argo-cd-apps/base/member/infra-deployments/tracing-workload-otel-collector/tracing-workload-otel-collector.yaml
+++ b/argo-cd-apps/base/member/infra-deployments/tracing-workload-otel-collector/tracing-workload-otel-collector.yaml
@@ -26,7 +26,7 @@ spec:
           # Chart from OTel Project
         - chart: opentelemetry-collector
           repoURL: https://open-telemetry.github.io/opentelemetry-helm-charts
-          targetRevision: 0.90.1
+          targetRevision: 0.101.2
           helm:
             parameters:
               - name: "image.repository"

--- a/components/tracing/otel-collector/development/otel-collector-helm-values.yaml
+++ b/components/tracing/otel-collector/development/otel-collector-helm-values.yaml
@@ -7,14 +7,14 @@ config:
     # Without the health_check extension the collector will fail the readiness and liveliness probes.
     # The health_check extension can be modified, but should never be removed.
     health_check: {}
-    memory_ballast: {}
   processors:
     batch: {}
     # If set to null, will be overridden with values based on k8s resource limits
     memory_limiter:
       check_interval: 2s
       limit_mib: 512
-      spike_limit_percentage: 100
+      limit_percentage: 95
+      spike_limit_percentage: 90
     attributes/collector-info:
       actions:
         - key: collector.hostname
@@ -37,7 +37,6 @@ config:
   service:
     extensions:
       - health_check
-      - memory_ballast
     pipelines:
       traces:
         exporters:
@@ -71,4 +70,9 @@ ports:
     enabled: false
   zipkin:
     enabled: false
+image:
+  repository: quay.io/konflux-ci/opentelemetry-collector-k8s
+  pullPolicy: Always
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: "0.106.0"
 

--- a/components/tracing/otel-collector/production/otel-collector-helm-values.yaml
+++ b/components/tracing/otel-collector/production/otel-collector-helm-values.yaml
@@ -9,14 +9,14 @@ config:
     # Without the health_check extension the collector will fail the readiness and liveliness probes.
     # The health_check extension can be modified, but should never be removed.
     health_check: {}
-    memory_ballast: {}
   processors:
     batch: {}
     # If set to null, will be overridden with values based on k8s resource limits
     memory_limiter:
       check_interval: 2s
       limit_mib: 512
-      spike_limit_percentage: 100
+      limit_percentage: 95
+      spike_limit_percentage: 90
     attributes/collector-info:
       actions:
         - key: collector.hostname
@@ -39,7 +39,6 @@ config:
   service:
     extensions:
       - health_check
-      - memory_ballast
     pipelines:
       traces:
         exporters:
@@ -80,4 +79,8 @@ extraEnvs:
       secretKeyRef:
         name: "honeycomb-api-key"
         key: konflux-tracing-prod
-
+image:
+  repository: quay.io/konflux-ci/opentelemetry-collector-k8s
+  pullPolicy: Always
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: "0.106.0"

--- a/components/tracing/otel-collector/staging/otel-collector-helm-values.yaml
+++ b/components/tracing/otel-collector/staging/otel-collector-helm-values.yaml
@@ -9,14 +9,14 @@ config:
     # Without the health_check extension the collector will fail the readiness and liveliness probes.
     # The health_check extension can be modified, but should never be removed.
     health_check: {}
-    memory_ballast: {}
   processors:
     batch: {}
     # If set to null, will be overridden with values based on k8s resource limits
     memory_limiter:
       check_interval: 2s
       limit_mib: 512
-      spike_limit_percentage: 100
+      limit_percentage: 95
+      spike_limit_percentage: 90
     attributes/collector-info:
       actions:
         - key: collector.hostname
@@ -39,7 +39,6 @@ config:
   service:
     extensions:
       - health_check
-      - memory_ballast
     pipelines:
       traces:
         exporters:
@@ -80,3 +79,8 @@ extraEnvs:
       secretKeyRef:
         name: "honeycomb-api-key"
         key: konflux-tracing-stage
+image:
+  repository: quay.io/konflux-ci/opentelemetry-collector-k8s
+  pullPolicy: Always
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: "0.106.0"


### PR DESCRIPTION
- Moves the image to quay.io and pins it to a specific tag.
- Pins the chart to a specific version to avoid mismatches in the future.