### PR TITLE
Increase s390x capacity for supporting more production load

### DIFF
--- a/components/multi-platform-controller/production-downstream/host-config.yaml
+++ b/components/multi-platform-controller/production-downstream/host-config.yaml
@@ -310,8 +310,8 @@ data:
   dynamic.linux-s390x.image-id: "r014-23be9e67-4ab2-4dc9-9a51-d56efb06943d"
   dynamic.linux-s390x.region: "us-east-1"
   dynamic.linux-s390x.url: "https://us-east.iaas.cloud.ibm.com/v1"
-  dynamic.linux-s390x.profile: "bz2-1x4"
-  dynamic.linux-s390x.max-instances: "2"
+  dynamic.linux-s390x.profile: "bz2-2x8"
+  dynamic.linux-s390x.max-instances: "20"
   dynamic.linux-s390x.private-ip: "true"
 
   # dynamic.linux-ppc64le.type: ibmp


### PR DESCRIPTION
* This PR is for managing loads in the production system where we have multiple buildpipeline running and requesting nodes.
* Also increasing the node capacity from 1CPU, 4GiB RAM ro 2CPU 8GiB ram