### PR TITLE
Disable autogeneration of TektonConfig

### DIFF
--- a/components/pipeline-service/development/main-pipeline-service-configuration.yaml
+++ b/components/pipeline-service/development/main-pipeline-service-configuration.yaml
@@ -1853,6 +1853,10 @@ spec:
   name: openshift-pipelines-operator-rh
   source: custom-operators
   sourceNamespace: openshift-marketplace
+  config:
+    env:
+      - name: AUTOINSTALL_COMPONENTS
+        value: "false"
 ---
 apiVersion: route.openshift.io/v1
 kind: Route

--- a/components/pipeline-service/staging/base/main-pipeline-service-configuration.yaml
+++ b/components/pipeline-service/staging/base/main-pipeline-service-configuration.yaml
@@ -1795,6 +1795,10 @@ spec:
   name: openshift-pipelines-operator-rh
   source: custom-operators
   sourceNamespace: openshift-marketplace
+  config:
+    env:
+      - name: AUTOINSTALL_COMPONENTS
+        value: "false"
 ---
 apiVersion: route.openshift.io/v1
 kind: Route

--- a/components/pipeline-service/staging/stone-stage-p01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stage-p01/deploy.yaml
@@ -2262,6 +2262,10 @@ metadata:
   namespace: openshift-operators
 spec:
   channel: latest
+  config:
+    env:
+    - name: AUTOINSTALL_COMPONENTS
+      value: "false"
   name: openshift-pipelines-operator-rh
   source: custom-operators
   sourceNamespace: openshift-marketplace

--- a/components/pipeline-service/staging/stone-stg-m01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stg-m01/deploy.yaml
@@ -2262,6 +2262,10 @@ metadata:
   namespace: openshift-operators
 spec:
   channel: latest
+  config:
+    env:
+    - name: AUTOINSTALL_COMPONENTS
+      value: "false"
   name: openshift-pipelines-operator-rh
   source: custom-operators
   sourceNamespace: openshift-marketplace

--- a/components/pipeline-service/staging/stone-stg-rh01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stg-rh01/deploy.yaml
@@ -2262,6 +2262,10 @@ metadata:
   namespace: openshift-operators
 spec:
   channel: latest
+  config:
+    env:
+    - name: AUTOINSTALL_COMPONENTS
+      value: "false"
   name: openshift-pipelines-operator-rh
   source: custom-operators
   sourceNamespace: openshift-marketplace


### PR DESCRIPTION
When deploying OSP, the operator generates a default TektonConfig is one does not already exist. This creates a race condition with the TektonConfig managed in this repo and deployed on the cluster by ArgoCD. Setting the AUTOINSTALL_COMPONENTS=false variable in the OSP Subscription, prevents the generation of the TektonConfig, so always the one from this repo is used.