### PR TITLE
install ksctl during kubesaw deployment

### DIFF
--- a/hack/sandbox-development-mode.sh
+++ b/hack/sandbox-development-mode.sh
@@ -10,4 +10,5 @@ echo
 echo "Installing the Toolchain (Sandbox) operators in dev environment:"
 rm -rf ${TOOLCHAIN_E2E_TEMP_DIR} 2>/dev/null || true
 git clone --depth=1 https://github.com/codeready-toolchain/toolchain-e2e.git ${TOOLCHAIN_E2E_TEMP_DIR}
-make -C ${TOOLCHAIN_E2E_TEMP_DIR} appstudio-dev-deploy-latest SHOW_CLEAN_COMMAND="make -C ${TOOLCHAIN_E2E_TEMP_DIR} appstudio-cleanup"
+make -C ${TOOLCHAIN_E2E_TEMP_DIR} install-ksctl
+make -C ${TOOLCHAIN_E2E_TEMP_DIR} appstudio-dev-deploy-latest SHOW_CLEAN_COMMAND="make -C ${TOOLCHAIN_E2E_TEMP_DIR} appstudio-cleanup" USE_INSTALLED_KSCTL=true

--- a/hack/sandbox-development-mode.sh
+++ b/hack/sandbox-development-mode.sh
@@ -10,5 +10,5 @@ echo
 echo "Installing the Toolchain (Sandbox) operators in dev environment:"
 rm -rf ${TOOLCHAIN_E2E_TEMP_DIR} 2>/dev/null || true
 git clone --depth=1 https://github.com/codeready-toolchain/toolchain-e2e.git ${TOOLCHAIN_E2E_TEMP_DIR}
-make -C ${TOOLCHAIN_E2E_TEMP_DIR} install-ksctl
+CGO_ENABLED=0 go install github.com/kubesaw/ksctl/cmd/ksctl@master
 make -C ${TOOLCHAIN_E2E_TEMP_DIR} appstudio-dev-deploy-latest SHOW_CLEAN_COMMAND="make -C ${TOOLCHAIN_E2E_TEMP_DIR} appstudio-cleanup" USE_INSTALLED_KSCTL=true


### PR DESCRIPTION
With [PR #1030] landing in toolchain-e2e, tests now will try to pair an open PR against toolchain-e2e with an open PR against [ksctl].  We're always going to run tests with the latest version of ksctl, so we should install it before deploying member-operator.

[PR #1030]: https://github.com/codeready-toolchain/toolchain-e2e/pull/1030
[ksctl]: https://github.com/kubesaw/ksctl/