### PR TITLE
chore(KFLUXINFRA-743) Prod local platforms

### DIFF
--- a/components/multi-platform-controller/production-downstream/host-config.yaml
+++ b/components/multi-platform-controller/production-downstream/host-config.yaml
@@ -7,7 +7,29 @@ metadata:
   namespace: multi-platform-controller
 data:
 
-  dynamic-platforms: linux/arm64,linux/amd64,linux-mxlarge/amd64,linux-mxlarge/arm64,linux-m2xlarge/amd64,linux-m2xlarge/arm64,linux-m4xlarge/amd64,linux-m4xlarge/arm64,linux-m8xlarge/amd64,linux-m8xlarge/arm64,linux-cxlarge/amd64,linux-cxlarge/arm64,linux-c2xlarge/amd64,linux-c2xlarge/arm64,linux-c4xlarge/amd64,linux-c4xlarge/arm64,linux-c8xlarge/amd64,linux-c8xlarge/arm64,linux-root/arm64,linux-root/amd64,linux/s390x #,linux/ppc64le
+  dynamic-platforms: "\
+    linux/arm64,\
+    linux/amd64,\
+    linux-mxlarge/amd64,\
+    linux-mxlarge/arm64,\
+    linux-m2xlarge/amd64,\
+    linux-m2xlarge/arm64,\
+    linux-m4xlarge/amd64,\
+    linux-m4xlarge/arm64,\
+    linux-m8xlarge/amd64,\
+    linux-m8xlarge/arm64,\
+    linux-cxlarge/amd64,\
+    linux-cxlarge/arm64,\
+    linux-c2xlarge/amd64,\
+    linux-c2xlarge/arm64,\
+    linux-c4xlarge/amd64,\
+    linux-c4xlarge/arm64,\
+    linux-c8xlarge/amd64,\
+    linux-c8xlarge/arm64,\
+    linux-root/arm64,\
+    linux-root/amd64,\
+    linux/s390x\
+    "
   instance-tag: rhtap-prod
 
   # cpu:memory (1:4)

--- a/components/multi-platform-controller/production-downstream/host-config.yaml
+++ b/components/multi-platform-controller/production-downstream/host-config.yaml
@@ -6,10 +6,16 @@ metadata:
   name: host-config
   namespace: multi-platform-controller
 data:
-
+  local-platforms: "\
+    linux/x86_64,\
+    local,\
+    localhost,\
+    "
   dynamic-platforms: "\
     linux/arm64,\
     linux/amd64,\
+    linux-mlarge/amd64,\
+    linux-mlarge/arm64,\
     linux-mxlarge/amd64,\
     linux-mxlarge/arm64,\
     linux-m2xlarge/amd64,\
@@ -26,9 +32,9 @@ data:
     linux-c4xlarge/arm64,\
     linux-c8xlarge/amd64,\
     linux-c8xlarge/arm64,\
+    linux/s390x,\
     linux-root/arm64,\
-    linux-root/amd64,\
-    linux/s390x\
+    linux-root/amd64\
     "
   instance-tag: rhtap-prod
 
@@ -43,6 +49,17 @@ data:
   dynamic.linux-arm64.security-group-id: sg-0903aedd465be979e
   dynamic.linux-arm64.max-instances: "10"
   dynamic.linux-arm64.subnet-id: subnet-0aa719a6c5b602b16
+
+  dynamic.linux-mlarge-arm64.type: aws
+  dynamic.linux-mlarge-arm64.region: us-east-1
+  dynamic.linux-mlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-mlarge-arm64.instance-type: m6g.large
+  dynamic.linux-mlarge-arm64.key-name: konflux-prod-int-mab01
+  dynamic.linux-mlarge-arm64.aws-secret: aws-account
+  dynamic.linux-mlarge-arm64.ssh-secret: aws-ssh-key
+  dynamic.linux-mlarge-arm64.security-group-id: sg-0903aedd465be979e
+  dynamic.linux-mlarge-arm64.max-instances: "10"
+  dynamic.linux-mlarge-arm64.subnet-id: subnet-0aa719a6c5b602b16
 
   dynamic.linux-mxlarge-arm64.type: aws
   dynamic.linux-mxlarge-arm64.region: us-east-1
@@ -98,6 +115,17 @@ data:
   dynamic.linux-amd64.security-group-id: sg-0903aedd465be979e
   dynamic.linux-amd64.max-instances: "10"
   dynamic.linux-amd64.subnet-id: subnet-0aa719a6c5b602b16
+
+  dynamic.linux-mlarge-amd64.type: aws
+  dynamic.linux-mlarge-amd64.region: us-east-1
+  dynamic.linux-mlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-mlarge-amd64.instance-type: m6a.large
+  dynamic.linux-mlarge-amd64.key-name: konflux-prod-int-mab01
+  dynamic.linux-mlarge-amd64.aws-secret: aws-account
+  dynamic.linux-mlarge-amd64.ssh-secret: aws-ssh-key
+  dynamic.linux-mlarge-amd64.security-group-id: sg-0903aedd465be979e
+  dynamic.linux-mlarge-amd64.max-instances: "10"
+  dynamic.linux-mlarge-amd64.subnet-id: subnet-0aa719a6c5b602b16
 
   dynamic.linux-mxlarge-amd64.type: aws
   dynamic.linux-mxlarge-amd64.region: us-east-1

--- a/components/multi-platform-controller/production/host-config.yaml
+++ b/components/multi-platform-controller/production/host-config.yaml
@@ -6,10 +6,16 @@ metadata:
   name: host-config
   namespace: multi-platform-controller
 data:
-
+  local-platforms: "\
+    linux/x86_64,\
+    local,\
+    localhost,\
+    "
   dynamic-platforms: "\
     linux/arm64,\
     linux/amd64,\
+    linux-mlarge/arm64,\
+    linux-mlarge/amd64,\
     linux-mxlarge/amd64,\
     linux-mxlarge/arm64,\
     linux-m2xlarge/amd64,\
@@ -44,6 +50,17 @@ data:
   dynamic.linux-arm64.security-group-id: sg-0fbf35ced0d59fd4a
   dynamic.linux-arm64.max-instances: "10"
   dynamic.linux-arm64.subnet-id: subnet-0c39ff75f819abfc5
+
+  dynamic.linux-mlarge-arm64.type: aws
+  dynamic.linux-mlarge-arm64.region: us-east-1
+  dynamic.linux-mlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-mlarge-arm64.instance-type: m6g.large
+  dynamic.linux-mlarge-arm64.key-name: konflux-prod-ext-mab01
+  dynamic.linux-mlarge-arm64.aws-secret: aws-account
+  dynamic.linux-mlarge-arm64.ssh-secret: aws-ssh-key
+  dynamic.linux-mlarge-arm64.security-group-id: sg-0fbf35ced0d59fd4a
+  dynamic.linux-mlarge-arm64.max-instances: "10"
+  dynamic.linux-mlarge-arm64.subnet-id: subnet-0c39ff75f819abfc5
 
   dynamic.linux-mxlarge-arm64.type: aws
   dynamic.linux-mxlarge-arm64.region: us-east-1
@@ -99,6 +116,17 @@ data:
   dynamic.linux-amd64.security-group-id: sg-0fbf35ced0d59fd4a
   dynamic.linux-amd64.max-instances: "10"
   dynamic.linux-amd64.subnet-id: subnet-0c39ff75f819abfc5
+
+  dynamic.linux-mlarge-amd64.type: aws
+  dynamic.linux-mlarge-amd64.region: us-east-1
+  dynamic.linux-mlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-mlarge-amd64.instance-type: m6a.large
+  dynamic.linux-mlarge-amd64.key-name: konflux-prod-ext-mab01
+  dynamic.linux-mlarge-amd64.aws-secret: aws-account
+  dynamic.linux-mlarge-amd64.ssh-secret: aws-ssh-key
+  dynamic.linux-mlarge-amd64.security-group-id: sg-0fbf35ced0d59fd4a
+  dynamic.linux-mlarge-amd64.max-instances: "10"
+  dynamic.linux-mlarge-amd64.subnet-id: subnet-0c39ff75f819abfc5
 
   dynamic.linux-mxlarge-amd64.type: aws
   dynamic.linux-mxlarge-amd64.region: us-east-1

--- a/components/multi-platform-controller/production/host-config.yaml
+++ b/components/multi-platform-controller/production/host-config.yaml
@@ -7,7 +7,30 @@ metadata:
   namespace: multi-platform-controller
 data:
 
-  dynamic-platforms: linux/arm64,linux/amd64,linux-mxlarge/amd64,linux-mxlarge/arm64,linux-m2xlarge/amd64,linux-m2xlarge/arm64,linux-m4xlarge/amd64,linux-m4xlarge/arm64,linux-m8xlarge/amd64,linux-m8xlarge/arm64,linux-cxlarge/amd64,linux-cxlarge/arm64,linux-c2xlarge/amd64,linux-c2xlarge/arm64,linux-c4xlarge/amd64,linux-c4xlarge/arm64,linux-c8xlarge/amd64,linux-c8xlarge/arm64,linux-root/arm64,linux-root/amd64,linux-fast/amd64,linux-extra-fast/amd64
+  dynamic-platforms: "\
+    linux/arm64,\
+    linux/amd64,\
+    linux-mxlarge/amd64,\
+    linux-mxlarge/arm64,\
+    linux-m2xlarge/amd64,\
+    linux-m2xlarge/arm64,\
+    linux-m4xlarge/amd64,\
+    linux-m4xlarge/arm64,\
+    linux-m8xlarge/amd64,\
+    linux-m8xlarge/arm64,\
+    linux-cxlarge/amd64,\
+    linux-cxlarge/arm64,\
+    linux-c2xlarge/amd64,\
+    linux-c2xlarge/arm64,\
+    linux-c4xlarge/amd64,\
+    linux-c4xlarge/arm64,\
+    linux-c8xlarge/amd64,\
+    linux-c8xlarge/arm64,\
+    linux-root/arm64,\
+    linux-root/amd64,\
+    linux-fast/amd64,\
+    linux-extra-fast/amd64\
+    "
   instance-tag: rhtap-prod
 
   # cpu:memory (1:4)


### PR DESCRIPTION
Adding a set of MPC platforms that use the "local" definitions.
Also adding "mlarge" platforms as a migration path away from using MPC with generic platform names as a way to run on a VM.

This change would require #4328 to work.