### PR TITLE
KFLUXINFRA-786: Add resource pool for ppc64le in public prod

### DIFF
--- a/components/multi-platform-controller/production/host-config.yaml
+++ b/components/multi-platform-controller/production/host-config.yaml
@@ -331,17 +331,65 @@ data:
     --//--
 
 
-  host.power-rhtap-prod-1.address: "52.117.38.109"
+  host.power-rhtap-prod-1.address: "169.62.182.26"
   host.power-rhtap-prod-1.platform: "linux/ppc64le"
   host.power-rhtap-prod-1.user: "root"
   host.power-rhtap-prod-1.secret: "ibm-production-ppc64le-ssh-key"
-  host.power-rhtap-prod-1.concurrency: "4"
+  host.power-rhtap-prod-1.concurrency: "1"
 
-  host.power-rhtap-prod-2.address: "52.117.38.122"
+  host.power-rhtap-prod-2.address: "169.62.182.27"
   host.power-rhtap-prod-2.platform: "linux/ppc64le"
   host.power-rhtap-prod-2.user: "root"
   host.power-rhtap-prod-2.secret: "ibm-production-ppc64le-ssh-key"
-  host.power-rhtap-prod-2.concurrency: "4"
+  host.power-rhtap-prod-2.concurrency: "1"
+
+  host.power-rhtap-prod-3.address: "169.62.182.28"
+  host.power-rhtap-prod-3.platform: "linux/ppc64le"
+  host.power-rhtap-prod-3.user: "root"
+  host.power-rhtap-prod-3.secret: "ibm-production-ppc64le-ssh-key"
+  host.power-rhtap-prod-3.concurrency: "1"
+
+  host.power-rhtap-prod-4.address: "169.62.182.29"
+  host.power-rhtap-prod-4.platform: "linux/ppc64le"
+  host.power-rhtap-prod-4.user: "root"
+  host.power-rhtap-prod-4.secret: "ibm-production-ppc64le-ssh-key"
+  host.power-rhtap-prod-4.concurrency: "1"
+
+  host.power-rhtap-prod-5.address: "169.62.182.30"
+  host.power-rhtap-prod-5.platform: "linux/ppc64le"
+  host.power-rhtap-prod-5.user: "root"
+  host.power-rhtap-prod-5.secret: "ibm-production-ppc64le-ssh-key"
+  host.power-rhtap-prod-5.concurrency: "1"
+
+  host.power-rhtap-prod-6.address: "52.117.38.98"
+  host.power-rhtap-prod-6.platform: "linux/ppc64le"
+  host.power-rhtap-prod-6.user: "root"
+  host.power-rhtap-prod-6.secret: "ibm-production-ppc64le-ssh-key"
+  host.power-rhtap-prod-6.concurrency: "1"
+
+  host.power-rhtap-prod-7.address: "52.117.38.99"
+  host.power-rhtap-prod-7.platform: "linux/ppc64le"
+  host.power-rhtap-prod-7.user: "root"
+  host.power-rhtap-prod-7.secret: "ibm-production-ppc64le-ssh-key"
+  host.power-rhtap-prod-7.concurrency: "1"
+
+  host.power-rhtap-prod-8.address: "52.117.38.100"
+  host.power-rhtap-prod-8.platform: "linux/ppc64le"
+  host.power-rhtap-prod-8.user: "root"
+  host.power-rhtap-prod-8.secret: "ibm-production-ppc64le-ssh-key"
+  host.power-rhtap-prod-8.concurrency: "1"
+
+  host.power-rhtap-prod-9.address: "52.117.38.101"
+  host.power-rhtap-prod-9.platform: "linux/ppc64le"
+  host.power-rhtap-prod-9.user: "root"
+  host.power-rhtap-prod-9.secret: "ibm-production-ppc64le-ssh-key"
+  host.power-rhtap-prod-9.concurrency: "1"
+
+  host.power-rhtap-prod-10.address: "52.117.38.102"
+  host.power-rhtap-prod-10.platform: "linux/ppc64le"
+  host.power-rhtap-prod-10.user: "root"
+  host.power-rhtap-prod-10.secret: "ibm-production-ppc64le-ssh-key"
+  host.power-rhtap-prod-10.concurrency: "1"
 
   host.sysz-rhtap-prod-1.address: "169.63.184.30"
   host.sysz-rhtap-prod-1.platform: "linux/s390x"


### PR DESCRIPTION
This PR adds PPC64LE nodes reducing their concurrecy. This is to handle the issue of pods not getting assigned to the nodes.