### PR TITLE
fix: correct ns for pipeline svc grafana dashbord/configmap objs

### DIFF
--- a/components/monitoring/grafana/base/dashboards/pipeline-service/grafana-config.yaml
+++ b/components/monitoring/grafana/base/dashboards/pipeline-service/grafana-config.yaml
@@ -4593,7 +4593,7 @@ data:
 kind: ConfigMap
 metadata:
   name: grafana-dashboard-pipeline-service-49k4mt28kg
-  namespace: o11y
+  namespace: appstudio-grafana
 ---
 apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDashboard
@@ -4603,7 +4603,7 @@ metadata:
   labels:
     app: appstudio-grafana
   name: grafana-dashboard-pipeline-service
-  namespace: o11y
+  namespace: appstudio-grafana
 spec:
   configMapRef:
     key: pipeline-service-dashboard.json


### PR DESCRIPTION
when I moved infra-deployments away from pipeline-service repo refs the `kustomize build` I ran did not pick up the `appstudio-grafana` namespace correctly (as it did not employ the configmap generator in the parent dir)

discovered while doing local testing of https://github.com/redhat-appstudio/infra-deployments/pull/4338

rh-pre-commit.version: 2.3.1
rh-pre-commit.check-secrets: ENABLED