### PR TITLE
Fix IBM a100 ssh key

### DIFF
--- a/components/multi-platform-controller/production-downstream/host-config.yaml
+++ b/components/multi-platform-controller/production-downstream/host-config.yaml
@@ -378,5 +378,5 @@ data:
   host.ibm-gpu-amd64.address: "10.130.81.14"
   host.ibm-gpu-amd64.platform: "linux-ibm-gpu/amd64"
   host.ibm-gpu-amd64.user: "root"
-  host.ibm-gpu-amd64.secret: "internal-stage-ibm-ssh-key"
+  host.ibm-gpu-amd64.secret: "internal-prod-ibm-ssh-key"
   host.ibm-gpu-amd64.concurrency: "4"


### PR DESCRIPTION
This VM has both stage and prod ssh key but the stage one is not available as a secret in the prod cluster.

This is causing the multi-platform-controller update task to fail for this node.