### PR TITLE
Add the multi-arch pipeline to the pipeline config

### DIFF
--- a/components/build-service/base/build-pipeline-config/build-pipeline-config.yaml
+++ b/components/build-service/base/build-pipeline-config/build-pipeline-config.yaml
@@ -13,3 +13,5 @@ data:
       bundle: quay.io/konflux-ci/tekton-catalog/pipeline-docker-build:4bb57bb518b2a5473574cfdc292a32eb2c18c1b7
     - name: docker-build-oci-ta
       bundle: quay.io/konflux-ci/tekton-catalog/pipeline-docker-build-oci-ta:4bb57bb518b2a5473574cfdc292a32eb2c18c1b7
+    - name: docker-build-multi-platform-oci-ta
+      bundle: quay.io/konflux-ci/tekton-catalog/pipeline-docker-build-multi-platform-oci-ta:37d628c611de158165fd13c0f8b98e2361003759


### PR DESCRIPTION
With https://github.com/konflux-ci/build-definitions/pull/1236, we started building a multi-arch pipeline. This change adds it to the config map so that it can be used for configuring components.