### PR TITLE
fix: release controller oomkill on start up

### DIFF
--- a/components/release/k-components/manager-resources-patch/manager_resources_patch.yaml
+++ b/components/release/k-components/manager-resources-patch/manager_resources_patch.yaml
@@ -11,7 +11,7 @@ spec:
         resources:
           limits:
             cpu: 500m
-            memory: 1024Mi
+            memory: 2048Mi
           requests:
             cpu: 100m
-            memory: 20Mi
+            memory: 1024Mi


### PR DESCRIPTION
this commit fixes the OOMKill happening during controller start up by increase the memory resources for the pod.

Signed-off-by: Leandro Mendes <lmendes@redhat.com>