### PR TITLE
Send traces via honeycomb refinery for sampling purposes

### DIFF
--- a/components/tracing/otel-collector/production/otel-collector-helm-values.yaml
+++ b/components/tracing/otel-collector/production/otel-collector-helm-values.yaml
@@ -1,7 +1,7 @@
 config:
   exporters:
     otlphttp:
-      endpoint: https://api.honeycomb.io:443
+      endpoint: https://honeycomb-refinery.apps.ext.spoke.prod.us-east-1.aws.paas.redhat.com:443
       headers:
         "x-honeycomb-team": ${HONEYCOMB_API_TOKEN}
   extensions:

--- a/components/tracing/otel-collector/staging/otel-collector-helm-values.yaml
+++ b/components/tracing/otel-collector/staging/otel-collector-helm-values.yaml
@@ -1,7 +1,7 @@
 config:
   exporters:
     otlphttp:
-      endpoint: https://api.honeycomb.io:443
+      endpoint: https://honeycomb-refinery.apps.ext.spoke.preprod.us-east-1.aws.paas.redhat.com:443
       headers:
         "x-honeycomb-team": ${HONEYCOMB_API_TOKEN}
   extensions:


### PR DESCRIPTION
Send traces via the RH Honeycomb Refinery instance to enable sampling of traces.