### PR TITLE
KFLUXINFRA-808: Set default pipelines timeout to 2 hours - stage

### DIFF
--- a/components/pipeline-service/development/main-pipeline-service-configuration.yaml
+++ b/components/pipeline-service/development/main-pipeline-service-configuration.yaml
@@ -1707,6 +1707,7 @@ spec:
                 requests:
                   memory: "256Mi"
                   cpu: "100m"
+            default-timeout-minutes: "120"
       deployments:
         tekton-operator-proxy-webhook:
           spec:

--- a/components/pipeline-service/staging/base/main-pipeline-service-configuration.yaml
+++ b/components/pipeline-service/staging/base/main-pipeline-service-configuration.yaml
@@ -1641,6 +1641,7 @@ spec:
                 requests:
                   memory: "256Mi"
                   cpu: "100m"
+            default-timeout-minutes: "120"
       deployments:
         tekton-operator-proxy-webhook:
           spec:

--- a/components/pipeline-service/staging/stone-stage-p01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stage-p01/deploy.yaml
@@ -2075,6 +2075,14 @@ spec:
     enable-tekton-oci-bundles: true
     options:
       configMaps:
+        config-defaults:
+          data:
+            default-container-resource-requirements: |
+              default:
+                requests:
+                  memory: "256Mi"
+                  cpu: "100m"
+            default-timeout-minutes: "120"
         config-logging:
           data:
             loglevel.controller: info
@@ -2104,13 +2112,6 @@ spec:
                   "callerEncoder": ""
                 }
               }
-        config-defaults:
-          data:
-            default-container-resource-requirements: |
-              default:
-                requests:
-                  memory: "256Mi"
-                  cpu: "100m"
       deployments:
         tekton-operator-proxy-webhook:
           spec:

--- a/components/pipeline-service/staging/stone-stg-m01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stg-m01/deploy.yaml
@@ -2075,6 +2075,14 @@ spec:
     enable-tekton-oci-bundles: true
     options:
       configMaps:
+        config-defaults:
+          data:
+            default-container-resource-requirements: |
+              default:
+                requests:
+                  memory: "256Mi"
+                  cpu: "100m"
+            default-timeout-minutes: "120"
         config-logging:
           data:
             loglevel.controller: info
@@ -2104,13 +2112,6 @@ spec:
                   "callerEncoder": ""
                 }
               }
-        config-defaults:
-          data:
-            default-container-resource-requirements: |
-              default:
-                requests:
-                  memory: "256Mi"
-                  cpu: "100m"
       deployments:
         tekton-operator-proxy-webhook:
           spec:

--- a/components/pipeline-service/staging/stone-stg-rh01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stg-rh01/deploy.yaml
@@ -2075,6 +2075,14 @@ spec:
     enable-tekton-oci-bundles: true
     options:
       configMaps:
+        config-defaults:
+          data:
+            default-container-resource-requirements: |
+              default:
+                requests:
+                  memory: "256Mi"
+                  cpu: "100m"
+            default-timeout-minutes: "120"
         config-logging:
           data:
             loglevel.controller: info
@@ -2104,13 +2112,6 @@ spec:
                   "callerEncoder": ""
                 }
               }
-        config-defaults:
-          data:
-            default-container-resource-requirements: |
-              default:
-                requests:
-                  memory: "256Mi"
-                  cpu: "100m"
       deployments:
         tekton-operator-proxy-webhook:
           spec:


### PR DESCRIPTION
Increase the default timeout for pipelines from
1 hours (the default) to 2 hours.

The reason is that users complained about timeouts while their pipelines were waiting for resources.