### PR TITLE
Add cluster-secret-store-rh to internal clusters

### DIFF
--- a/argo-cd-apps/overlays/production-downstream/kustomization.yaml
+++ b/argo-cd-apps/overlays/production-downstream/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
   - ../../base/ca-bundle
   - ../../base/keycloak
   - ../../base/repository-validator
+  - ../../base/cluster-secret-store-rh
 patchesStrategicMerge:
   - delete-applications.yaml
 namespace: argocd


### PR DESCRIPTION
This is required for tenants to be able to extract secrets from those clusterstore on internal clusters.