### PR TITLE
KFLUXINFRA-801: Segregate Konflux and Tenants Workload using Tekton Config

### DIFF
--- a/components/pipeline-service/staging/stone-stg-m01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stg-m01/deploy.yaml
@@ -1949,6 +1949,14 @@ metadata:
     argocd.argoproj.io/sync-wave: "0"
   name: config
 spec:
+  config:
+    nodeSelector:
+      appstudio.redhat.com/workload: tenants
+    tolerations:
+      - key: appstudio.redhat.com/workload
+        operator: "Equal"
+        value: "tenants"
+        effect: "NoSchedule"
   chain:
     artifacts.oci.storage: oci
     artifacts.pipelinerun.enable-deep-inspection: true


### PR DESCRIPTION
This PR will help us schedule Konflux and Tenants Workload on dedicated Node Pools. This will make use of TektonConfig.

`NodeSelector` and `Tolerations` values are sample values only, we can change them if we want. We will need to create a new Node Pool in OCM (Manually or using Terraform) with the values of (`NodeSelector` and `Tolerations` ) we specifiy in the TektonConfig. 

[Tekton Config Documentation](https://tekton.dev/docs/operator/tektonconfig/)