### PR TITLE
KFLUXINFRA-801: reverting tekton config changes

### DIFF
--- a/components/pipeline-service/staging/stone-stg-m01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stg-m01/deploy.yaml
@@ -1949,14 +1949,6 @@ metadata:
     argocd.argoproj.io/sync-wave: "0"
   name: config
 spec:
-  config:
-    nodeSelector:
-      appstudio.redhat.com/workload: tenants
-    tolerations:
-      - key: appstudio.redhat.com/workload
-        operator: "Equal"
-        value: "tenants"
-        effect: "NoSchedule"
   chain:
     artifacts.oci.storage: oci
     artifacts.pipelinerun.enable-deep-inspection: true


### PR DESCRIPTION
NodeSelector and Tolerations in TektonConfig schedules OpenShift Pipeline workload coming from the Pipeline Operator not the PipelineRuns and their associated TaskRuns. 

Hence, reverting the changes made to TektonConfig in `stone-sig-m01 `cluster.