### PR TITLE
workspaces: add production configuration

### DIFF
--- a/argo-cd-apps/base/host/workspaces/workspaces.yaml
+++ b/argo-cd-apps/base/host/workspaces/workspaces.yaml
@@ -19,6 +19,12 @@ spec:
                   values.clusterDir: stone-stage-p01
                 - nameNormalized: stone-stg-host
                   values.clusterDir: stone-stg-host
+                - nameNormalized: stone-prod-p01
+                  values.clusterDir: stone-prod-p01
+                - nameNormalized: stone-prod-p02
+                  values.clusterDir: stone-prod-p02
+                - nameNormalized: stone-prd-host1
+                  values.clusterDir: stone-prd-host1
   template:
     metadata:
       name: workspaces-{{nameNormalized}}

--- a/components/workspaces/production/stone-prd-host1/kustomization.yaml
+++ b/components/workspaces/production/stone-prd-host1/kustomization.yaml
@@ -1,0 +1,16 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../base/
+- route.yaml
+images:
+- name: quay.io/konflux-workspaces/workspaces-server
+  newTag: v0.1.0-alpha5
+- name: quay.io/konflux-workspaces/workspaces-operator
+  newTag: v0.1.0-alpha5
+
+configMapGenerator:
+- behavior: merge
+  literals:
+  - log.level=0
+  name: rest-api-server-config

--- a/components/workspaces/production/stone-prd-host1/route.yaml
+++ b/components/workspaces/production/stone-prd-host1/route.yaml
@@ -1,0 +1,18 @@
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  labels:
+    provider: workspaces
+    app: rest-api-server
+  name: workspaces-rest-api-server
+  namespace: workspaces-system
+spec:
+  port:
+    targetPort: 8000
+  tls:
+    termination: edge
+  to:
+    kind: Service
+    name: workspaces-rest-api-server
+    weight: 100
+  wildcardPolicy: None

--- a/components/workspaces/production/stone-prod-p01/kustomization.yaml
+++ b/components/workspaces/production/stone-prod-p01/kustomization.yaml
@@ -1,0 +1,15 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../base/
+images:
+- name: quay.io/konflux-workspaces/workspaces-server
+  newTag: v0.1.0-alpha5
+- name: quay.io/konflux-workspaces/workspaces-operator
+  newTag: v0.1.0-alpha5
+
+configMapGenerator:
+- behavior: merge
+  literals:
+  - log.level=0
+  name: rest-api-server-config

--- a/components/workspaces/production/stone-prod-p02/kustomization.yaml
+++ b/components/workspaces/production/stone-prod-p02/kustomization.yaml
@@ -1,0 +1,15 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../base/
+images:
+- name: quay.io/konflux-workspaces/workspaces-server
+  newTag: v0.1.0-alpha5
+- name: quay.io/konflux-workspaces/workspaces-operator
+  newTag: v0.1.0-alpha5
+
+configMapGenerator:
+- behavior: merge
+  literals:
+  - log.level=0
+  name: rest-api-server-config


### PR DESCRIPTION
Let's try this again, only without the UI components.  Those will be added in a future PR once things settle.

The intention here is to make sure that workspaces gets its `ApplicationSet` rendered correctly and comes alive.