### PR TITLE
bump versions of github actions dependencies

### DIFF
--- a/.github/workflows/kube-linter.yaml
+++ b/.github/workflows/kube-linter.yaml
@@ -10,7 +10,7 @@ jobs:
     permissions: write-all
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       # This prepares directory where github/codeql-action/upload-sarif@v1 looks up report files by default.
       - name: Create ../results directory for SARIF report files
@@ -49,7 +49,7 @@ jobs:
         continue-on-error: true
 
       - name: Upload SARIF report files to GitHub
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
 
       # Ensure the workflow eventually fails if files did not pass kube-linter checks.
       - name: Verify kube-linter-action succeeded


### PR DESCRIPTION
We've been receiving warnings whenever we run our github actions pipelines for a little while now, such as on [this PR][1].  For more information, read the following posts from github:

- https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/
- https://github.blog/changelog/2024-01-12-code-scanning-deprecation-of-codeql-action-v2/

To silence these warnings, we need to bump the following actions:

- `actions/checkout@v3` to `v4`
- `github/codeql-action/upload-sarif@v2` to `v3`

[1]: https://github.com/redhat-appstudio/infra-deployments/actions/runs/10563058594?pr=4393