### PR TITLE
KFLUXINFRA-802: Segregate Konflux and Tenants Workload using TektonConfig

### DIFF
--- a/components/pipeline-service/staging/stone-stg-m01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stg-m01/deploy.yaml
@@ -1990,6 +1990,14 @@ spec:
                 requests:
                   memory: "256Mi"
                   cpu: "100m"
+            default-pod-template: |
+              nodeSelector:
+                konflux-ci.dev/workload: konflux-tenants
+              tolerations:
+                - key: konflux-ci.dev/workload
+                  operator: "Equal"
+                  value: "konflux-tenants"
+                  effect: "NoSchedule"
             default-timeout-minutes: "120"
         config-logging:
           data:

--- a/components/pipeline-service/staging/stone-stg-m01/resources/kustomization.yaml
+++ b/components/pipeline-service/staging/stone-stg-m01/resources/kustomization.yaml
@@ -27,3 +27,9 @@ patches:
       group: external-secrets.io
       version: v1beta1
       kind: ExternalSecret
+  - path: tekton-config-patch.yaml
+    target:
+      name: config
+      group: operator.tekton.dev
+      version: v1alpha1
+      kind: TektonConfig

--- a/components/pipeline-service/staging/stone-stg-m01/resources/tekton-config-patch.yaml
+++ b/components/pipeline-service/staging/stone-stg-m01/resources/tekton-config-patch.yaml
@@ -1,0 +1,18 @@
+apiVersion: operator.tekton.dev/v1alpha1
+kind: TektonConfig
+metadata:
+  name: config
+spec:
+  pipeline:
+    options:
+      configMaps:
+        config-defaults:
+          data:
+            default-pod-template: |
+              nodeSelector:
+                konflux-ci.dev/workload: konflux-tenants
+              tolerations:
+                - key: konflux-ci.dev/workload
+                  operator: "Equal"
+                  value: "konflux-tenants"
+                  effect: "NoSchedule"


### PR DESCRIPTION
This PR will help us schedule Konflux and Tenants Workload on dedicated Node Pools. This will make use of TektonConfig.

NodeSelector and Tolerations values are sample values only, we can change them if we want. We will need to create a new Node Pool in OCM (Manually or using Terraform) with the values of (NodeSelector and Tolerations ) we specifiy in the TektonConfig.