### PR TITLE
feat(RELEASE-996): add release-service-monitor to production

### DIFF
--- a/components/release/production/kustomization.yaml
+++ b/components/release/production/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../base
+  - ../base/monitor/production
   - https://github.com/konflux-ci/release-service/config/default?ref=1072e7ad23bca36680a60504a2a2a3c0ae6d82e1
 
 components:


### PR DESCRIPTION
this commit adds the release-service-monitor to production cluster.

Signed-off-by: Leandro Mendes <lmendes@redhat.com>