### PR TITLE
workspaces: don't delete applicationset from prod

### DIFF
--- a/argo-cd-apps/overlays/konflux-public-production/delete-applications.yaml
+++ b/argo-cd-apps/overlays/konflux-public-production/delete-applications.yaml
@@ -5,12 +5,6 @@ metadata:
   name: gitops
 $patch: delete
 ---
-apiVersion: argoproj.io/v1alpha1
-kind: ApplicationSet
-metadata:
-  name: workspaces
-$patch: delete
----
 # Tempo is excluded from the production
 apiVersion: argoproj.io/v1alpha1
 kind: ApplicationSet

--- a/argo-cd-apps/overlays/konflux-public-production/kustomization.yaml
+++ b/argo-cd-apps/overlays/konflux-public-production/kustomization.yaml
@@ -177,3 +177,8 @@ patches:
       kind: ApplicationSet
       version: v1alpha1
       name: cluster-as-a-service
+  - path: production-overlay-patch.yaml
+    target:
+      kind: ApplicationSet
+      version: v1alpha1
+      name: workspaces

--- a/argo-cd-apps/overlays/production-downstream/delete-applications.yaml
+++ b/argo-cd-apps/overlays/production-downstream/delete-applications.yaml
@@ -29,9 +29,3 @@ kind: ApplicationSet
 metadata:
   name: quality-dashboard
 $patch: delete
----
-apiVersion: argoproj.io/v1alpha1
-kind: ApplicationSet
-metadata:
-  name: workspaces
-$patch: delete

--- a/argo-cd-apps/overlays/production-downstream/kustomization.yaml
+++ b/argo-cd-apps/overlays/production-downstream/kustomization.yaml
@@ -192,3 +192,8 @@ patches:
       kind: ApplicationSet
       version: v1alpha1
       name: tracing-workload-tracing
+  - path: production-overlay-patch.yaml
+    target:
+      kind: ApplicationSet
+      version: v1alpha1
+      name: workspaces


### PR DESCRIPTION
This enables workspaces in production environments.  Resources were added in PR #4393.