### PR TITLE
chore: Give access to integration service to access vault secrets for e2e tests

### DIFF
--- a/components/cluster-secret-store/base/appsre-stonesoup-vault-secret-store.yaml
+++ b/components/cluster-secret-store/base/appsre-stonesoup-vault-secret-store.yaml
@@ -58,4 +58,5 @@ spec:
         - konflux-qe-team-tenant
         - rhtap-shared-team-tenant
         - notification-controller
+        - rhtap-integration-tenant
 


### PR DESCRIPTION
Integration service need access to QE secrets in order to run e2e tests in Konflux CI