### PR TITLE
KFLUXINFRA-808: Set default pipelines timeout to 2 hours - prod

### DIFF
--- a/components/pipeline-service/production/base/main-pipeline-service-configuration.yaml
+++ b/components/pipeline-service/production/base/main-pipeline-service-configuration.yaml
@@ -1513,6 +1513,9 @@ spec:
                   "callerEncoder": ""
                 }
               }
+        config-defaults:
+          data:
+            default-timeout-minutes: "120"    
       deployments:
         tekton-operator-proxy-webhook:
           spec:

--- a/components/pipeline-service/production/stone-prd-m01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prd-m01/deploy.yaml
@@ -1980,6 +1980,9 @@ spec:
     enable-tekton-oci-bundles: true
     options:
       configMaps:
+        config-defaults:
+          data:
+            default-timeout-minutes: "120"
         config-logging:
           data:
             loglevel.controller: info

--- a/components/pipeline-service/production/stone-prd-rh01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prd-rh01/deploy.yaml
@@ -1980,6 +1980,9 @@ spec:
     enable-tekton-oci-bundles: true
     options:
       configMaps:
+        config-defaults:
+          data:
+            default-timeout-minutes: "120"
         config-logging:
           data:
             loglevel.controller: info

--- a/components/pipeline-service/production/stone-prod-p01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prod-p01/deploy.yaml
@@ -1980,6 +1980,9 @@ spec:
     enable-tekton-oci-bundles: true
     options:
       configMaps:
+        config-defaults:
+          data:
+            default-timeout-minutes: "120"
         config-logging:
           data:
             loglevel.controller: info

--- a/components/pipeline-service/production/stone-prod-p02/deploy.yaml
+++ b/components/pipeline-service/production/stone-prod-p02/deploy.yaml
@@ -1980,6 +1980,9 @@ spec:
     enable-tekton-oci-bundles: true
     options:
       configMaps:
+        config-defaults:
+          data:
+            default-timeout-minutes: "120"
         config-logging:
           data:
             loglevel.controller: info


### PR DESCRIPTION
Increase the default timeout for pipelines from
1 hours (the default) to 2 hours.

The reason is that users complained about timeouts while their pipelines were waiting for resources.