### PR TITLE
Migrate ClusterRole appstudio-pipelines-runner

### DIFF
--- a/components/sandbox/toolchain-member-operator/base/rbac/appstudio-pipelines-runner.yaml
+++ b/components/sandbox/toolchain-member-operator/base/rbac/appstudio-pipelines-runner.yaml
@@ -1,0 +1,36 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: appstudio-pipelines-runner
+rules:
+  - verbs:
+      - get
+    apiGroups:
+      - ''
+    resources:
+      - secrets
+  - verbs:
+      - use
+    apiGroups:
+      - security.openshift.io
+    resources:
+      - securitycontextconstraints
+    resourceNames:
+      - appstudio-pipelines-scc
+  - verbs:
+      - get
+      - list
+    apiGroups:
+      - appstudio.redhat.com
+    resources:
+      - enterprisecontractpolicies
+  - verbs:
+      - get
+      - create
+      - delete
+      - list
+      - watch
+    apiGroups:
+      - toolchain.dev.openshift.com
+    resources:
+      - spacerequests

--- a/components/sandbox/toolchain-member-operator/base/rbac/kustomization.yaml
+++ b/components/sandbox/toolchain-member-operator/base/rbac/kustomization.yaml
@@ -2,5 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: toolchain-member-operator
 resources:
+- appstudio-pipelines-runner.yaml
 - register-cluster-extra-member-permissions.yaml
 - sandbox-sre-admins.yaml


### PR DESCRIPTION
- currently this ClusterRole is managed and deployed by the Sandbox host operator.
- Since it is a Konflux specific role, it should be migrated and maintained in this repo and deployed by Argo
- This role should be installed on member clusters


Needed for [KONFLUX-4171](https://issues.redhat.com//browse/KONFLUX-4171)