### PR TITLE
Enable pipeline SA to read and list plrs

### DIFF
--- a/components/sandbox/toolchain-member-operator/base/rbac/appstudio-pipelines-runner.yaml
+++ b/components/sandbox/toolchain-member-operator/base/rbac/appstudio-pipelines-runner.yaml
@@ -34,3 +34,11 @@ rules:
       - toolchain.dev.openshift.com
     resources:
       - spacerequests
+  - verbs:
+      - get
+      - list
+    apiGroups:
+      - tekton.dev
+    resources:
+      - pipelineruns
+      - taskruns


### PR DESCRIPTION
- This PR enables the appstudio-pipeline service account to get and list PipelineRuns
- The motivation for this is to allow Integration Test Scenarios PipelineRuns to query itself to inspect label and annotations added by the Integration Service such as:

```
appstudio.openshift.io/component: acb-service
test.appstudio.openshift.io/type: component
```

which tells you that the underlying Snapshot for this Test was created by a component that was recently built called `abc-service`

Addresses [KONFLUX-4171](https://issues.redhat.com//browse/KONFLUX-4171)