### PR TITLE
ui: pass relevant requests to workspaces

### DIFF
--- a/components/ui/base/proxy/nginx.conf
+++ b/components/ui/base/proxy/nginx.conf
@@ -52,6 +52,13 @@ http {
             proxy_pass http://registration-service.toolchain-host-operator.svc.cluster.local/;
         }
 
+        location /api/k8s/apis/workspaces.konflux-ci.dev/ {
+            # workspaces expects requests under the traditional API paths for
+            # kubernetes api servers, so we need to strip /api/k8s from them
+            rewrite ^/api/k8s/(.*)$ /$1 break;
+            proxy_pass http://workspaces-rest-api-server.workspaces-system.svc.cluster.local/;
+        }
+
         location /api/k8s/ {
             # Kube-API
             proxy_pass http://api.toolchain-host-operator.svc.cluster.local/;


### PR DESCRIPTION
Workspaces is now live in production environments, but is currently inaccessible as it's not exposed.  In external environments, workspaces is configured to use a route, but on internal environments, it can piggy-back off of the nginx configuration already in place for UI components.