### PR TITLE
set port when forwarding requests to workspaces

### DIFF
--- a/components/ui/base/proxy/nginx.conf
+++ b/components/ui/base/proxy/nginx.conf
@@ -56,7 +56,7 @@ http {
             # workspaces expects requests under the traditional API paths for
             # kubernetes api servers, so we need to strip /api/k8s from them
             rewrite ^/api/k8s/(.*)$ /$1 break;
-            proxy_pass http://workspaces-rest-api-server.workspaces-system.svc.cluster.local/;
+            proxy_pass http://workspaces-rest-api-server.workspaces-system.svc.cluster.local:8000/;
         }
 
         location /api/k8s/ {


### PR DESCRIPTION
The workspaces service listens on port 8000, so we need to explicitly communicate on that port when passing requests to it.