### PR TITLE
Update MintMaker image in prod

### DIFF
--- a/components/mintmaker/production/base/manager_patches.yaml
+++ b/components/mintmaker/production/base/manager_patches.yaml
@@ -17,4 +17,4 @@ spec:
             memory: 256Mi
         env:
         - name: RENOVATE_IMAGE
-          value: "quay.io/konflux-ci/mintmaker-renovate-image:8c1cbf7"
+          value: "quay.io/konflux-ci/mintmaker-renovate-image:333b7ba"


### PR DESCRIPTION
This commit updates MintMaker's prod image to a newer version.
This version is still pinned.