### PR TITLE
chore: don't remote write taskrun duration metric

### DIFF
--- a/components/monitoring/prometheus/base/monitoringstack/monitoringstack.yaml
+++ b/components/monitoring/prometheus/base/monitoringstack/monitoringstack.yaml
@@ -105,7 +105,6 @@ spec:
         - '{__name__="tekton_pipelines_controller_running_taskruns_throttled_by_node"}'
         - '{__name__="tekton_pipelines_controller_pipelinerun_duration_seconds_sum"}'
         - '{__name__="tekton_pipelines_controller_pipelinerun_duration_seconds_count"}'
-        - '{__name__="tekton_pipelines_controller_pipelinerun_taskrun_duration_seconds_bucket"}'
         - '{__name__="watcher_workqueue_depth"}'
         - '{__name__="watcher_client_latency_bucket"}'
         - '{__name__="pac_watcher_work_queue_depth"}'


### PR DESCRIPTION
Temporarily drop this metric from being remote-written to see if it affects the ability to remote-write other metrics.