### PR TITLE
fix: kube_pod_container_status_restarts_total federate match

### DIFF
--- a/components/monitoring/prometheus/base/monitoringstack/monitoringstack.yaml
+++ b/components/monitoring/prometheus/base/monitoringstack/monitoringstack.yaml
@@ -115,7 +115,7 @@ spec:
         - '{__name__="controller_runtime_reconcile_errors_total", namespace!~".*-tenant|openshift-.*|kube-.*"}'
         - '{__name__="controller_runtime_reconcile_total", namespace!~".*-tenant|openshift-.*|kube-.*"}'
         - '{__name__="kube_pod_status_unschedulable", namespace!~".*-tenant|openshift-.*|kube-.*"}'
-        - '{__name__="kube_pod_container_status_restarts_total", namespace="openshift-pipelines|release-service"}'
+        - '{__name__="kube_pod_container_status_restarts_total", namespace=~"openshift-pipelines|release-service"}'
         - '{__name__="kube_pod_container_status_waiting_reason", namespace!~".*-tenant|openshift-.*|kube-.*|release-service"}'
         - '{__name__="kube_pod_status_phase", namespace!~".*-tenant|openshift-.*|kube-.*|release-service"}'
         - '{__name__="kube_pod_container_status_terminated_reason", namespace="release-service"}'


### PR DESCRIPTION
Fix a typo in the match string for the service monitor used for federating  metric kube_pod_container_status_restarts_total