### PR TITLE
Grant everyone can view role to konflux-contributors

### DIFF
--- a/components/authentication/base/everyone-can-view-patch.yaml
+++ b/components/authentication/base/everyone-can-view-patch.yaml
@@ -7,6 +7,9 @@
       name: 'konflux-build'
     - kind: Group
       apiGroup: rbac.authorization.k8s.io
+      name: 'konflux-contributors'
+    - kind: Group
+      apiGroup: rbac.authorization.k8s.io
       name: 'konflux-core'
     - kind: Group
       apiGroup: rbac.authorization.k8s.io
@@ -31,6 +34,9 @@
       name: 'konflux-hac'
     - kind: Group
       apiGroup: rbac.authorization.k8s.io
+      name: 'konflux-mintmaker-team'
+    - kind: Group
+      apiGroup: rbac.authorization.k8s.io
       name: 'konflux-o11y'
     - kind: Group
       apiGroup: rbac.authorization.k8s.io
@@ -44,6 +50,3 @@
     - kind: Group
       apiGroup: rbac.authorization.k8s.io
       name: 'konflux-release-team'
-    - kind: Group
-      apiGroup: rbac.authorization.k8s.io
-      name: 'konflux-mintmaker-team'


### PR DESCRIPTION
There are people contributing to Konflux that do not belong to any official Konflux team that we want to grant view access to our clusters. A new rover group was created to put those people in so grant view role to that new group.

Also re-order alphabetically the groups.