### PR TITLE
Grant cluster-monitoring-view role to all Konflux teams

### DIFF
--- a/components/authentication/base/everyone-can-view.yaml
+++ b/components/authentication/base/everyone-can-view.yaml
@@ -126,3 +126,13 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: view-cluster-version
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: everyone-view-cluster-monitoring
+subjects: [] # added by patch to avoid duplicating the groups
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-monitoring-view

--- a/components/authentication/base/kustomization.yaml
+++ b/components/authentication/base/kustomization.yaml
@@ -26,3 +26,9 @@ patches:
       kind: ClusterRoleBinding
       group: rbac.authorization.k8s.io
       version: v1
+  - path: everyone-can-view-patch.yaml
+    target:
+      name: everyone-view-cluster-monitoring
+      kind: ClusterRoleBinding
+      group: rbac.authorization.k8s.io
+      version: v1


### PR DESCRIPTION
Until version 4.14 of OCP, all Konflux teams could access cluster monitoring, grant view cluster role was enough. Starting with 4.15, something changed and view clusterrole no longer allow to access monitoring and execute queries.

Granting cluster-monitoring-view cluster role to all teams resolve the issue.