### PR TITLE
docs(RHTAPWATCH-1261): prepare o11y docs for handoff

### DIFF
--- a/components/monitoring/README.md
+++ b/components/monitoring/README.md
@@ -1,214 +1,233 @@
-## Onboarding Services to Monitoring
+# Onboarding Services to Monitoring
 
+This document contains guidelines and references for configuring services in the
+Konflux clusters to be monitored and graphed.
 
-### 1. Metrics-exporting services
+## 1. Metrics-exporting Services
 
-- The intended service should export the metrics from the application so that prometheus is able to understand it.
+For a service to be monitored, it needs to instrument Prometheus metrics, or have an
+external service that will poll it and generate metrics on its behalf.
 
-- For reference, see
-  [Writing Exporters](https://prometheus.io/docs/instrumenting/writing_exporters)
+For reference, see
+[Writing Exporters](https://prometheus.io/docs/instrumenting/writing_exporters)
 
-- The exported port, service and route should be accessible to the prometheus service.
+Prometheus needs to be able to reach the service in order to scrape the metrics it
+generates. Check out [this example](./prometheus/development/dummy-service.yaml) of a
+metrics-exporting service.
 
-- Check out [this example](./prometheus/development/dummy-service.yaml) of a
-  metrics-exporting service.
+## 2. Service Monitors
 
-
-### 2. Service monitors
-
-Creating a service monitor instructs Prometheus to create a new target to collect
-metrics from.
+Service Monitors (ServiceMonitors) are Kubernetes custom resources that the Prometheus
+operator uses for creating scraping configurations for Prometheus pods. Consequently,
+Creating a Service Monitor creates a new target for Prometheus to collect metrics from.
 
 Copy and modify
 [this example](./prometheus/development/dummy-service-service-monitor.yaml)
-for adding the service monitor declaration:
+for adding the Service Monitor declaration.
 
-- The service monitor should be defined under the component which it monitors. Copy the
-  example under your [component](../../components/) and reference it in your
-  kustomization.yaml file.
+Ideally, the Service Monitor should be defined inside the component repository and then
+referenced by the infra-deployment [component's](../../components/) configurations.
 
-- Namespace: the service monitor should be defined under the same namespace as the
-  service it monitors. Same goes for the namespaces for the rest of the resources
-  defined for the service monitor. Namely, service, servicemonitor and the
-  servicemonitor's serviceaccount and secret.
+**Namespace**: the Service Monitor should be defined under the **same namespace** as the
+service it monitors. Same goes for the namespaces for the rest of the resources
+defined for the Service Monitor. Namely, `service`, `servicemonitor` and the
+servicemonitor's `serviceaccount` and `secret`.
 
-- ClusterRole and ClusterRoleBinding: make sure you edit the cluster role and cluster
-  role binding definitions so their names are unique.
+**ClusterRole and ClusterRoleBinding**: make sure you edit the cluster role and cluster
+role binding definitions so their names are **unique**.
 
-- ServiceMonitor: Verify the validity of the service monitor's selector. For example,
-  it can be matching a label - make sure you specify your app's label appropriately
-  (e.g. `app: my-app`, `control-plane: controller-manager`).
+**ServiceMonitor**: Verify the validity of the Service Monitor's selector. For example,
+if it's matching a label, make sure you specify your app's label appropriately (e.g.
+`app: my-app`, `control-plane: controller-manager`).
 
 > **_IMPORTANT:_** make sure your service's namespace does NOT contain label
                    `openshift.io/cluster-monitoring: 'true'`. Otherwise, it will not be
                    monitored by the user workload Prometheus instance.
-                  
 
-### 3. Grafana Datasource
+## 3. Grafana Datasource
 
 Grafana datasources contain the connection settings to the Prometheus instances.
 
-A single [datasource (Thanos querier)](https://github.com/redhat-appstudio/infra-deployments/blob/main/components/monitoring/grafana/base/grafana-app.yaml#L206), `appstudio-datasource` is defined and it lets us query metrics from the Platform and User Workload Monitoring Prometheus.
+A single
+[datasource (Thanos querier)](https://github.com/redhat-appstudio/infra-deployments/blob/16e48656370dc65dba6471a9f50d745832535723/components/monitoring/grafana/base/grafana-app.yaml#L216),
+`appstudio-datasource` is defined and it lets us query metrics from the Platform and
+User Workload Monitoring Prometheus.
 
-To use this default datasource any definition of a datasource in the dashboard json file should be removed or a `templating` should be used.
+To use this default datasource any definition of a datasource in the dashboard json file
+should be removed or a `templating` should be used.
 
-
-### 4. Grafana dashboards
+## 4. Grafana Dashboards
 
 A dashboard is a set of one or more panels organized and arranged into one or more rows. 
 It visualizes results from multiple data sources simultaneously.
-New dashboards can be added through the user interface, preconfigured in the infra-deployments repository, 
-or imported from other projects.
+New dashboards can be added through the user interface, preconfigured in the
+infra-deployments repository, or imported from other projects.
 
+### Create a Dashboard
 
-#### Create a dashboard
+1. [Create a dashboard](https://grafana.com/docs/grafana/v10.4/dashboards/)
+   for your team's view of your service's Service Level Indicators
+   (After navigating to your folder + Create Dashboard).
 
-  1. [Create a dashboard](https://grafana.com/docs/grafana/v9.0/dashboards/)
-  for your team's view of your service's Service Level Indicators.
-  (After navigating to your folder, + Create Dashboard)  
-  ***Note:***  
-  Creating a new dashboard manually is available only for development environment.  
-  You may copy and edit the `example` dashboard json instead, and test the new dashboard on the staging and production environments. 
+   > **_Note:_**  Creating a new dashboard manually is available only for development
+                   environment. You may copy and edit the `example` dashboard json
+                   instead, and test the new dashboard on the staging and production
+                   environments. The `example` dashboard json definition can be found
+                   [here](https://github.com/redhat-appstudio/infra-deployments/blob/main/components/monitoring/grafana/base/dashboards/generic-dashboards/example.json)
 
-      The `example` dashboard json definition can be found 
-      [here](https://github.com/redhat-appstudio/infra-deployments/blob/main/components/monitoring/grafana/base/dashboards/generic-dashboards/example.json)
+2. Add tiles to the dashboard to track your initial set of service level indicators.
+   If the servicemonitor was added correctly to the stage Prometheus datasource,
+   it will show up in the query list when you edit a tile.
 
+3. Export the dashboard definition in JSON format: At the top of the screen, select the
+   icon with 3 dots and click `Share dashboard or panel` --> `Export` -->
+   `Save to file`.
 
-  2. Add tiles to the dashboard to track your initial set of service level indicators.  
-  If the servicemonitor was added correctly to the stage Prometheus datasource, 
-  it will show up in the query list when you edit a tile.
+### Team's Repository
 
-  3. Export the dashboard definition in JSON format. 
-  (At the top of the screen, the icon with 3 dots lets you "Share dashboard or panel". Select Export... Save to file.)
-   
+Follow the next steps to define a dashboard in your team's repository:
 
-#### Team's repository
+1. The dashboard should be located in the team’s repository, so no change in
+   `infra-deployments` is required.
 
-Follow the next steps to define a dashboard in your team's repository
+   The recommended structure is:
 
-  1. The dashboard should be located in the team’s repository, no change in `infra-deployments` is required,
-  the recommended structure is:
-      ```
-      ├── grafana
-      │   ├── dashboards
-      │   │   └── <teams_dashboard>.json
-      │   ├── <GrafanaDashboard resource file>
-      │   └── kustomization.yaml
-      ```
-      For example:
-      ```
-      ├── grafana
-      │   ├── dashboards
-      │   │   └── example-dashboard.json
-      │   ├── dashboard.yaml
-      │   └── kustomization.yaml
-      ```
+   ```
+   ├── grafana
+   │   ├── dashboards
+   │   │   └── <teams_dashboard>.json
+   │   ├── <GrafanaDashboard resource file>
+   │   └── kustomization.yaml
+   ```
 
-  2. Create a folder in your team's repository to maintain the dashboard configuration (e.g. grafana)
+   For example:
+   ```
+   ├── grafana
+   │   ├── dashboards
+   │   │   └── example-dashboard.json
+   │   ├── dashboard.yaml
+   │   └── kustomization.yaml
+   ```
+
+2. Create a folder in your team's repository to maintain the dashboard configuration
+   (e.g. grafana)
   
-  3. Edit the dashboard json file:  
-      - to pick the default predefined datasource Edit the dashboard json file and **remove** `datasource` from it, for example:
-          ```yaml 
-            "datasource": {
-              "type": "prometheus",
-              "uid": "PF224BEF3374A25F8"
-            }
-          ```
+3. Edit the dashboard json file:
+
+   To pick the default predefined datasource, edit the dashboard json file and
+   **remove** `datasource` from it. For example:
+
+   ```yaml
+     "datasource": {
+       "type": "prometheus",
+       "uid": "PF224BEF3374A25F8"
+     }
+   ```
         
-      - Alternatively it is possible to use templating to select a datasource, for example: 
-          ```json
-          "templating": {
-            "list": [
-              {
-                "current": {
-                  "selected": true,
-                  "text": "Prometheus",
-                  "value": "Prometheus"
-                },
-                "hide": 0,
-                "includeAll": false,
-                "multi": false,
-                "name": "datasource",
-                "options": [],
-                "query": "prometheus",
-                "queryValue": "",
-                "refresh": 1,
-                "regex": ".*-(appstudio)-.*",
-                "skipUrlSync": false,
-                "type": "datasource"
-              }
-            ]
-          },
-          ```
-        
-        In this example, the dashboard will use `Prometheus` datasource, with ability to use other datasource that contains `appstudio` in the name.
-      
-  4. Add the dashboard json file to the folder you created.
+   Alternatively it is possible to use templating to select a datasource. For example:
 
-  5. Create a `kustomization.yaml` to generate a config map from the dashboard json, 
-  and to add the `GrafanaDashboard` resource file (`dashboard.yaml`), for example: 
-      ```yaml
-      kind: Kustomization
-      apiVersion: kustomize.config.k8s.io/v1beta1
-
-      namespace: example
-
-      configMapGenerator:
-        - name: grafana-dashboard-example
-          files:
-            - dashboards/example-dashboard.json
-
-      resources:
-        - dashboard.yaml
-      ```
+   ```json
+   "templating": {
+     "list": [
+       {
+         "current": {
+           "selected": true,
+           "text": "Prometheus",
+           "value": "Prometheus"
+         },
+         "hide": 0,
+         "includeAll": false,
+         "multi": false,
+         "name": "datasource",
+         "options": [],
+         "query": "prometheus",
+         "queryValue": "",
+         "refresh": 1,
+         "regex": ".*-(appstudio)-.*",
+         "skipUrlSync": false,
+         "type": "datasource"
+       }
+     ]
+   },
+   ```
   
-  6. Create the `GrafanaDashboard` resource file that uses the config map to create the dashboard
-      ```yaml
-      apiVersion: grafana.integreatly.org/v1beta1
-      kind: GrafanaDashboard
-      metadata:
-        name: grafana-dashboard-example
-        labels:
-          app: appstudio-grafana
-      spec:
-        instanceSelector:
-          matchLabels:
-            dashboards: "appstudio-grafana"
-        configMapRef:
-          name: grafana-dashboard-example
-          key: example-dashboard.json
-      ```
- 7. Push the code to the team's repository
+   In this example, the dashboard will use `Prometheus` datasource, with ability to use
+   other datasource that contains `appstudio` in the name.
 
- - Check out [this example o11y PR](https://github.com/redhat-appstudio/o11y/pull/39) 
- for creating a dashboard in the team's repository
+4. Add the dashboard json file to the folder you created.
+
+5. Create a `kustomization.yaml` file to generate a config map from the dashboard json,
+   and to add the `GrafanaDashboard` resource file (`dashboard.yaml`). For example:
+
+   ```yaml
+   kind: Kustomization
+   apiVersion: kustomize.config.k8s.io/v1beta1
+
+   namespace: example
+
+   configMapGenerator:
+     - name: grafana-dashboard-example
+       files:
+         - dashboards/example-dashboard.json
+
+   resources:
+     - dashboard.yaml
+   ```
+
+6. Create the `GrafanaDashboard` resource file that uses the config map to create the
+   dashboard:
+
+   ```yaml
+   apiVersion: grafana.integreatly.org/v1beta1
+   kind: GrafanaDashboard
+   metadata:
+     name: grafana-dashboard-example
+     labels:
+       app: appstudio-grafana
+   spec:
+     instanceSelector:
+       matchLabels:
+         dashboards: "appstudio-grafana"
+     configMapRef:
+       name: grafana-dashboard-example
+       key: example-dashboard.json
+   ```
+
+7. Push the code to the team's repository.
+
+Check out [this example o11y PR](https://github.com/redhat-appstudio/o11y/pull/39)
+for creating a dashboard in the team's repository.
+
+### infra-deployments Repository
+
+Follow these steps to add a dashboard to the `infra-deployments` repository:
+
+1. Create a team folder under `components/monitoring/grafana/base/<team_name>`.
+
+2. Create a `kustomization.yaml` file and add the dashboard you created as a resource by
+   using the commit sha as ref. For example:
+
+   ```yaml
+   apiVersion: kustomize.config.k8s.io/v1beta1
+   kind: Kustomization
+   resources:
+     - https://github.com/redhat-appstudio/o11y/grafana/?ref=82bec1c488250ae32d458c77755e432329be1b45
+   ```
+
+3. Add your team's folder to the base
+   [kustomization file](https://github.com/redhat-appstudio/infra-deployments/blob/main/components/monitoring/grafana/base/kustomization.yaml#L14)
+   to automatically add it to future deployments.
   
-
-#### infra-deployments repository
-Follow these steps to add a dashboard to the `infra-deployments` repository
-
-  1. Create a team folder under `components/monitoring/grafana/base/<team_name>`
-  
-  2. Create a `kustomization.yaml` file and add the dashboard you created as a resource by using the commit sha as ref, 
-  for example:
-      ```yaml
-      apiVersion: kustomize.config.k8s.io/v1beta1
-      kind: Kustomization
-      resources:
-        - https://github.com/redhat-appstudio/o11y/grafana/?ref=82bec1c488250ae32d458c77755e432329be1b45
-      ```
-    
-  3. Add your team's folder to the base [kustomization file](https://github.com/redhat-appstudio/infra-deployments/blob/main/components/monitoring/grafana/base/kustomization.yaml#L14) to automatically add it to future deployments.
-   
-  4. Push the code to the `infra-deployments` repository
+4. Push the code to the `infra-deployments` repository.
 
 
-#### Verification
+### Verification
 
-Follow the next steps to to verify and check your dashboard after merging the configurations
+Follow the next steps to verify and check your dashboard after merging the
+configurations:
 
-1. Open the Grafana UI
+1. Open the Grafana UI.
 
-2. Click the `Manage` option in the `Dashboards` menu
+2. Click the `Manage` option in the `Dashboards` menu.
 
-3. Verify that your team’s dashboard is located under `appstudio-grafana` folder 
+3. Verify that your team’s dashboard is located under `appstudio-grafana` folder.

--- a/components/monitoring/prometheus/README.md
+++ b/components/monitoring/prometheus/README.md
@@ -1,23 +1,23 @@
-## RHTAP Central Monitoring
-The RHTAP monitoring solution is based on three Prometheus instances deployed to each
-Production and Staging host and member clusters. Each cluster writes a subset of the
+# Konflux Central Monitoring
+The Konflux monitoring solution is based on three Prometheus instances deployed to each
+Production and Staging host and member cluster. Each cluster writes a subset of the
 metrics it generates into Observatorium (RHOBS), marking each metric with a label
 indicating its cluster of origin.
 
-Observatorium holds metrics for RHTAP's tenant in two RHOBS environments – Production
-and one Staging. The metrics collected for each of those environments are available
-for presentation via the AppSRE Grafana instance.
+Observatorium holds metrics for Konflux's tenant in two RHOBS environments – Production
+and Staging. The metrics collected for each of those environments are available for
+presentation via the AppSRE Grafana instance.
 
 ```mermaid
 %%{init: {'theme':'forest'}}%%
 flowchart BT
-  services(RHTAP Services) --> |scrape|UWM
+  services(Konflux Services) --> |scrape|UWM
   pods(kubelet, pods, etc.) --> |scrape|Platform
   UWM(User Workload Monitoring) --> |federate| MS(Monitoring Stack)
   Platform --> |federate|MS(Monitoring Stack)
   MS --> |remote-write|rhobs(Observatorium)
 
-  services2(RHTAP Services) --> |scrape|UWM2
+  services2(Konflux Services) --> |scrape|UWM2
   pods2(kubelet, pods, etc.) --> |scrape|Platform2
   UWM2(User Workload Monitoring) --> |federate| MS2(Monitoring Stack)
   Platform2(Platform) --> |federate|MS2(Monitoring Stack)
@@ -25,7 +25,7 @@ flowchart BT
 
   rhobs --> |scrape|grafana(AppSRE Grafana)
 
-  subgraph member[RHTAP Member Clusters]
+  subgraph member[Konflux Member Clusters]
     services
     pods
     subgraph "cmo member"[Cluster Monitoring Operator]
@@ -35,7 +35,7 @@ flowchart BT
     MS
   end
 
-  subgraph host["RHTAP Host Cluster"]
+  subgraph host["Konflux Host Cluster"]
     services2
     pods2
     subgraph "cmo host"[Cluster Monitoring Operator]
@@ -48,34 +48,30 @@ flowchart BT
   style member color:blue
   style host color:red
 ```
-### Data Plane Clusters Prometheus Instances
+## Data Plane Clusters Prometheus Instances
 We use the
 [Openshift-provided](https://docs.openshift.com/container-platform/4.12/monitoring/monitoring-overview.html)
 Prometheus deployments, Platform and user-workload-monitoring (UWM), alongside a
 Prometheus instance deployed by the RHOBS
 [Observability Operator](https://github.com/rhobs/observability-operator).
 
-#### Platform Prometheus
-Mainly scrapes generic metrics produced by built-in exports such as cAdvisor,
-kube-state-metrics, etc.
+### Platform Prometheus
+Mainly scrapes generic metrics produced by built-in exporters such as cAdvisor and
+kube-state-metrics.
 
-#### User Workload Monitoring (UWM) Prometheus
-Scrapes custom metrics provided by services deployed by the different RHTAP teams, and
+### User Workload Monitoring (UWM) Prometheus
+Scrapes custom metrics provided by services deployed by the different Konflux teams, and
 collected by Service Monitors, also provided by the teams.
 
 In Production and Staging, UWM Prometheus is enabled using OCM (since it maintains the
-Prometheus configurations).  
-The retention is set to 3 days and the retention size is set to 10GiB.  
-It is defined in `components/monitoring/prometheus/base/uwm-config/uwm-config.yaml`
-and it is controlled by ArgoCD.
+Prometheus configurations).
+The retention period and size is maintained using an ArgoCD-controlled
+[ConfigMap](./base/uwm-config/uwm-config.yaml).
 
+In Development this ConfigMap is created implicitly when UWM is enabled. Consequently,
+the retention period and size assume their default values. To configure those for a development environment, edit the  `user-workload-monitoring-config` ConfigMap in
+`openshift-user-workload-monitoring` namespace.
 
-In Development it's enabled without deploying a ConfigMap using ArgoCD 
-(The ConfigMap is created automatically when UWM is enabled)  
-
-The retention is set to default (24h).  
-To configure the retention for development environment, edit the 
-`user-workload-monitoring-config` ConfigMap in `openshift-user-workload-monitoring` namespace.  
 For example:
 ```yaml
 apiVersion: v1
@@ -90,16 +86,16 @@ data:
       retentionSize: 1GiB
 ```
 
-#### Observability Operator (OBO) Prometheus
-Federates the Platform and UWM Prometheus instances.
+### Observability Operator (OBO) Prometheus
+This instance federates the Platform and UWM Prometheus instances.
 
 There are limitations for both built-in Prometheus instances that do not allow us to
-use them to write metrics to RHOBS:
+use them directly to write metrics to RHOBS:
 
 - The configurations of the Platform Prometheus instance are owned by SRE Platform, thus
 we cannot configure this instance to remote-write.
 - Service Monitors for The UWM Prometheus instance are limited for scraping metrics
-from the same namespace in which the Service Monitor is defined. it means that this
+from the same namespace in which the Service Monitor is defined. It means that this
 instance cannot federate the Platform Prometheus instance, thus cannot hold all data
 needed to be exported (it also cannot remote-write metrics coming from different
 namespaces).
@@ -112,15 +108,15 @@ remote-writes selected labels for those metrics to RHOBS, which in turn, makes t
 metrics accessible to AppSRE Grafana.
 
 This Prometheus instance is deployed using a MonitoringStack custom resource provided
-by the Observability Operator. This operator is installed by default in Production and Staging clusters.  
+by the Observability Operator. This operator is installed by default in Production and Staging clusters.
 In Development clusters, it's not installed by default to prevent conflicts with other deployments. 
-It can be installed and configured in development by using the `--obo/-o` flags.  
+It can be installed and configured in development by using the `--obo/-o` flags.
 For example:
 
 `./hack/bootstrap-cluster.sh preview --obo`  
 `./hack/bootstrap-cluster.sh preview -o`
 
-#### Federation and Remote-write
+### Federation and Remote-write
 
 Through Federation and remote-write configurations, only a subset of the metrics and
 the labels collected within the data plane clusters reach RHOBS. For that reason, it
@@ -128,10 +124,10 @@ might be that metrics that are visible via the OCP web console (under Observe --
 Metrics) do not reach RHOBS and are not visible in AppSRE Grafana.
 
 The Platform Prometheus instance monitors a wide variety of resources which are, in
-nature, of an unbound cardinality (e.g. containers, pods, jobs). Consequently, it
-generates a substantial amount of metrics time series that cannot all be forwarded to
-RHOBS. For that reason, we only allow a very small subset of the metrics it scrapes
-to be federated by the OBO Prometheus instance (and later remote-written to RHOBS).
+nature, of an unbound cardinality (e.g. containers, pods, jobs, pipelineruns, taskruns).
+Consequently, it generates a substantial amount of metrics time series that cannot all
+be forwarded to RHOBS. For that reason, we only allow a very small subset of the metrics
+it scrapes to be federated by the OBO Prometheus instance (and later remote-written to RHOBS).
 
 The UWM Prometheus instance, on the other hand, generates a very few time series by
 default, and the metrics it is configured to scrape for services are generally of
@@ -145,45 +141,3 @@ will not include some of the labels the same time series have on the data plane
 clusters. The OBO instance is configured to remote-write only specific labels, and if
 the presence of a new label is required in alerting rules or AppSRE Grafana dashboards,
 then this label should be added to the configurations.
-
-##### Troubleshooting Missing Metrics and Labels
-
-There are a few steps to follow when specific metrics or labels are required for new
-alerting rules or Grafana dashboards, but are not present in AppSRE Grafana.
-
-> **_NOTE:_**  While we remote-write the metrics to RHOBS rather than to AppSRE Grafana,
-we don't have an easy way to directly confirm whether metrics are reaching RHOBS or not.
-Instead, we check AppSRE Grafana, assuming no metrics/labels are dropped between RHOBS
-and AppSRE Grafana. Nevertheless, such drops are possible, although far less probable
-comparing to MonitoringStack misconfigurations.
-
-If the metric is missing altogether:
-
-1. Verify that the metric does exist inside its expected cluster of origin by querying
-   for it on the Observe --> Metrics screen on the OCP web console.
-    * If it doesn't, further troubleshoot the service monitor expected to collect the
-      metric and the Kubernetes resource expected to generate it.
-2. While querying for the metric, check the value of its `prometheus` label.
-    * if the value is `openshift-monitoring/k8s`, it means it's being collected by the
-      Platform Prometheus instance. As we only federate specific metrics from this
-      instance, the metric needs to be added to the `match` list under the
-      `appstudio-federate-smon` ServiceMonitor resource within the
-      [MonitoringStack configurations].
-    * if the label value is different, reach out to the o11y team on [Slack][o11y-slack]
-3. Once added, the metric should be federated by the OBO instance and remote-written to
-   RHOBS.
-
-If the metric is present, but labels are missing:
-
-1. Verify that the labels do exist when querying for the metric through the OCP web
-   console.
-    * If not, further troubleshoot the resource that should export or instrument
-      the metric.
-2. Add the missing labels to the `LabelKeep` action's `regex` field within the
-   `MonitoringStack` resource definition in the [MonitoringStack configurations].
-3. Once added, the label should be remote-written by the OBO instance to RHOBS.
-
-For further assistance, reach out to the o11y team on [Slack][o11y-slack].
-
-[MonitoringStack configurations]: base/monitoringstack/monitoringstack.yaml
-[o11y-slack]: https://redhat-internal.slack.com/archives/C04FDFTF8EB


### PR DESCRIPTION
This changes mainly includes minor updates for things changed since the documentation was written. Additionally, some of the content was removed as it's being moved to the SOP repository.