### PR TITLE
Remove enable-tekton-oci-bundles from dev and staging TektonConfig

### DIFF
--- a/components/pipeline-service/development/main-pipeline-service-configuration.yaml
+++ b/components/pipeline-service/development/main-pipeline-service-configuration.yaml
@@ -1514,7 +1514,6 @@ spec:
     enable-git-resolver: true
     enable-hub-resolver: true
     enable-step-actions: true
-    enable-tekton-oci-bundles: true
     options:
       configMaps:
         config-logging:

--- a/components/pipeline-service/staging/base/main-pipeline-service-configuration.yaml
+++ b/components/pipeline-service/staging/base/main-pipeline-service-configuration.yaml
@@ -1330,7 +1330,6 @@ spec:
     enable-git-resolver: true
     enable-hub-resolver: true
     enable-step-actions: true
-    enable-tekton-oci-bundles: true
     options:
       configMaps:
         config-logging:

--- a/components/pipeline-service/staging/stone-stage-p01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stage-p01/deploy.yaml
@@ -1834,7 +1834,6 @@ spec:
     enable-git-resolver: true
     enable-hub-resolver: true
     enable-step-actions: true
-    enable-tekton-oci-bundles: true
     options:
       configMaps:
         config-defaults:

--- a/components/pipeline-service/staging/stone-stg-m01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stg-m01/deploy.yaml
@@ -1834,7 +1834,6 @@ spec:
     enable-git-resolver: true
     enable-hub-resolver: true
     enable-step-actions: true
-    enable-tekton-oci-bundles: true
     options:
       configMaps:
         config-defaults:

--- a/components/pipeline-service/staging/stone-stg-rh01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stg-rh01/deploy.yaml
@@ -1834,7 +1834,6 @@ spec:
     enable-git-resolver: true
     enable-hub-resolver: true
     enable-step-actions: true
-    enable-tekton-oci-bundles: true
     options:
       configMaps:
         config-defaults:


### PR DESCRIPTION
This configuration options was removed in Tekton v0.61.0 which we now use staging since ef952976970f7dd17094483cb57b9bfb0e0f74ae