### PR TITLE
fix(KFLUXBUGS-1607): increase memory limits for integration service

### DIFF
--- a/components/integration/production/base/manager_resources_patch.yaml
+++ b/components/integration/production/base/manager_resources_patch.yaml
@@ -11,10 +11,10 @@ spec:
         resources:
           limits:
             cpu: 600m
-            memory: 1500Mi
+            memory: 2048Mi
           requests:
             cpu: 200m
-            memory: 600Mi
+            memory: 1024Mi
         env:
         - name: CONSOLE_NAME
           valueFrom:


### PR DESCRIPTION
* The service manager pod is getting OOMKilled because of increased amout of resources on the production cluster(s)
* Bring the memory limits in line with similar Konflux services

Signed-off-by: dirgim <kpavic@redhat.com>