### PR TITLE
Update ClusterLogging CR collection spec

### DIFF
--- a/components/monitoring/logging/base/configure-logging/configure-log-collectors.yaml
+++ b/components/monitoring/logging/base/configure-logging/configure-log-collectors.yaml
@@ -9,5 +9,4 @@ metadata:
     argocd.argoproj.io/sync-wave: "2"
 spec:
   collection:
-    logs:
-      type: vector
+    type: vector


### PR DESCRIPTION
Update the 'ClusterLogging' CR collection spec
according to the updated spec as documented here:
https://docs.openshift.com/container-platform/4.16/observability/logging/log_collection_forwarding/cluster-logging-collector.html#configuring-logging-collector_cluster-logging-collector