### PR TITLE
Make stg-rh01 the default member cluster

### DIFF
--- a/components/sandbox/toolchain-host-operator/staging/stone-stg-host/space-provisioner-configs.yaml
+++ b/components/sandbox/toolchain-host-operator/staging/stone-stg-host/space-provisioner-configs.yaml
@@ -7,7 +7,7 @@ metadata:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   toolchainCluster: member-stone-stg-m01.7ayg.p1.openshiftapps.com
-  enabled: true
+  enabled: false
   capacityThresholds:
     maxNumberOfSpaces: 1500
     maxMemoryUtilizationPercent: 90
@@ -23,7 +23,7 @@ metadata:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   toolchainCluster: member-stone-stg-rh01.l2vh.p1.openshiftapps.com
-  enabled: false
+  enabled: true
   capacityThresholds:
     maxMemoryUtilizationPercent: 90
   placementRoles:


### PR DESCRIPTION
This is first step to be able to decommission m01.

[KFLUXINFRA-796](https://issues.redhat.com//browse/KFLUXINFRA-796)