### PR TITLE
Update ksctl with sandbox replacements

### DIFF
--- a/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/sandbox-sre-host/serviceaccounts/alkazako.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/sandbox-sre-host/serviceaccounts/alkazako.yaml
@@ -8,7 +8,7 @@ metadata:
   annotations:
     argocd.argoproj.io/compare-options: IgnoreExtraneous
   labels:
-    provider: sandbox-sre
+    provider: ksctl
     username: alkazako
   name: alkazako
   namespace: sandbox-sre-host

--- a/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/sandbox-sre-host/serviceaccounts/bcook.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/sandbox-sre-host/serviceaccounts/bcook.yaml
@@ -8,7 +8,7 @@ metadata:
   annotations:
     argocd.argoproj.io/compare-options: IgnoreExtraneous
   labels:
-    provider: sandbox-sre
+    provider: ksctl
     username: bcook
   name: bcook
   namespace: sandbox-sre-host

--- a/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/sandbox-sre-host/serviceaccounts/bkundu.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/sandbox-sre-host/serviceaccounts/bkundu.yaml
@@ -8,7 +8,7 @@ metadata:
   annotations:
     argocd.argoproj.io/compare-options: IgnoreExtraneous
   labels:
-    provider: sandbox-sre
+    provider: ksctl
     username: bkundu
   name: bkundu
   namespace: sandbox-sre-host

--- a/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/sandbox-sre-host/serviceaccounts/bsutter.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/sandbox-sre-host/serviceaccounts/bsutter.yaml
@@ -8,7 +8,7 @@ metadata:
   annotations:
     argocd.argoproj.io/compare-options: IgnoreExtraneous
   labels:
-    provider: sandbox-sre
+    provider: ksctl
     username: bsutter
   name: bsutter
   namespace: sandbox-sre-host

--- a/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/sandbox-sre-host/serviceaccounts/dfodor.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/sandbox-sre-host/serviceaccounts/dfodor.yaml
@@ -8,7 +8,7 @@ metadata:
   annotations:
     argocd.argoproj.io/compare-options: IgnoreExtraneous
   labels:
-    provider: sandbox-sre
+    provider: ksctl
     username: dfodor
   name: dfodor
   namespace: sandbox-sre-host

--- a/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/sandbox-sre-host/serviceaccounts/dperaza4dustbit.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/sandbox-sre-host/serviceaccounts/dperaza4dustbit.yaml
@@ -8,7 +8,7 @@ metadata:
   annotations:
     argocd.argoproj.io/compare-options: IgnoreExtraneous
   labels:
-    provider: sandbox-sre
+    provider: ksctl
     username: dperaza4dustbit
   name: dperaza4dustbit
   namespace: sandbox-sre-host

--- a/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/sandbox-sre-host/serviceaccounts/eedri.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/sandbox-sre-host/serviceaccounts/eedri.yaml
@@ -8,7 +8,7 @@ metadata:
   annotations:
     argocd.argoproj.io/compare-options: IgnoreExtraneous
   labels:
-    provider: sandbox-sre
+    provider: ksctl
     username: eedri
   name: eedri
   namespace: sandbox-sre-host

--- a/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/sandbox-sre-host/serviceaccounts/ergonzal.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/sandbox-sre-host/serviceaccounts/ergonzal.yaml
@@ -8,7 +8,7 @@ metadata:
   annotations:
     argocd.argoproj.io/compare-options: IgnoreExtraneous
   labels:
-    provider: sandbox-sre
+    provider: ksctl
     username: ergonzal
   name: ergonzal
   namespace: sandbox-sre-host

--- a/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/sandbox-sre-host/serviceaccounts/filariow.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/sandbox-sre-host/serviceaccounts/filariow.yaml
@@ -8,7 +8,7 @@ metadata:
   annotations:
     argocd.argoproj.io/compare-options: IgnoreExtraneous
   labels:
-    provider: sandbox-sre
+    provider: ksctl
     username: filariow
   name: filariow
   namespace: sandbox-sre-host

--- a/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/sandbox-sre-host/serviceaccounts/fmuntean.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/sandbox-sre-host/serviceaccounts/fmuntean.yaml
@@ -8,7 +8,7 @@ metadata:
   annotations:
     argocd.argoproj.io/compare-options: IgnoreExtraneous
   labels:
-    provider: sandbox-sre
+    provider: ksctl
     username: fmuntean
   name: fmuntean
   namespace: sandbox-sre-host

--- a/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/sandbox-sre-host/serviceaccounts/gbenhaim.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/sandbox-sre-host/serviceaccounts/gbenhaim.yaml
@@ -8,7 +8,7 @@ metadata:
   annotations:
     argocd.argoproj.io/compare-options: IgnoreExtraneous
   labels:
-    provider: sandbox-sre
+    provider: ksctl
     username: gbenhaim
   name: gbenhaim
   namespace: sandbox-sre-host

--- a/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/sandbox-sre-host/serviceaccounts/hugares.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/sandbox-sre-host/serviceaccounts/hugares.yaml
@@ -8,7 +8,7 @@ metadata:
   annotations:
     argocd.argoproj.io/compare-options: IgnoreExtraneous
   labels:
-    provider: sandbox-sre
+    provider: ksctl
     username: hugares
   name: hugares
   namespace: sandbox-sre-host

--- a/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/sandbox-sre-host/serviceaccounts/mjobanek.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/sandbox-sre-host/serviceaccounts/mjobanek.yaml
@@ -8,7 +8,7 @@ metadata:
   annotations:
     argocd.argoproj.io/compare-options: IgnoreExtraneous
   labels:
-    provider: sandbox-sre
+    provider: ksctl
     username: mjobanek
   name: mjobanek
   namespace: sandbox-sre-host

--- a/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/sandbox-sre-host/serviceaccounts/pdave.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/sandbox-sre-host/serviceaccounts/pdave.yaml
@@ -8,7 +8,7 @@ metadata:
   annotations:
     argocd.argoproj.io/compare-options: IgnoreExtraneous
   labels:
-    provider: sandbox-sre
+    provider: ksctl
     username: pdave
   name: pdave
   namespace: sandbox-sre-host

--- a/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/sandbox-sre-host/serviceaccounts/ralphbean.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/sandbox-sre-host/serviceaccounts/ralphbean.yaml
@@ -8,7 +8,7 @@ metadata:
   annotations:
     argocd.argoproj.io/compare-options: IgnoreExtraneous
   labels:
-    provider: sandbox-sre
+    provider: ksctl
     username: ralphbean
   name: ralphbean
   namespace: sandbox-sre-host

--- a/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/sandbox-sre-host/serviceaccounts/rorai.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/sandbox-sre-host/serviceaccounts/rorai.yaml
@@ -8,7 +8,7 @@ metadata:
   annotations:
     argocd.argoproj.io/compare-options: IgnoreExtraneous
   labels:
-    provider: sandbox-sre
+    provider: ksctl
     username: rorai
   name: rorai
   namespace: sandbox-sre-host

--- a/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/sandbox-sre-host/serviceaccounts/sadlerap.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/sandbox-sre-host/serviceaccounts/sadlerap.yaml
@@ -8,7 +8,7 @@ metadata:
   annotations:
     argocd.argoproj.io/compare-options: IgnoreExtraneous
   labels:
-    provider: sandbox-sre
+    provider: ksctl
     username: sadlerap
   name: sadlerap
   namespace: sandbox-sre-host

--- a/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/sandbox-sre-host/serviceaccounts/saviv.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/sandbox-sre-host/serviceaccounts/saviv.yaml
@@ -8,7 +8,7 @@ metadata:
   annotations:
     argocd.argoproj.io/compare-options: IgnoreExtraneous
   labels:
-    provider: sandbox-sre
+    provider: ksctl
     username: saviv
   name: saviv
   namespace: sandbox-sre-host

--- a/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/approve-user-alkazako-host.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/approve-user-alkazako-host.yaml
@@ -6,7 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    provider: sandbox-sre
+    provider: ksctl
   name: approve-user-alkazako-host
   namespace: toolchain-host-operator
 roleRef:

--- a/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/approve-user-bcook-host.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/approve-user-bcook-host.yaml
@@ -6,7 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    provider: sandbox-sre
+    provider: ksctl
   name: approve-user-bcook-host
   namespace: toolchain-host-operator
 roleRef:

--- a/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/approve-user-bkundu-host.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/approve-user-bkundu-host.yaml
@@ -6,7 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    provider: sandbox-sre
+    provider: ksctl
   name: approve-user-bkundu-host
   namespace: toolchain-host-operator
 roleRef:

--- a/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/approve-user-bsutter-host.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/approve-user-bsutter-host.yaml
@@ -6,7 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    provider: sandbox-sre
+    provider: ksctl
   name: approve-user-bsutter-host
   namespace: toolchain-host-operator
 roleRef:

--- a/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/approve-user-dfodor-host.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/approve-user-dfodor-host.yaml
@@ -6,7 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    provider: sandbox-sre
+    provider: ksctl
   name: approve-user-dfodor-host
   namespace: toolchain-host-operator
 roleRef:

--- a/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/approve-user-dperaza4dustbit-host.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/approve-user-dperaza4dustbit-host.yaml
@@ -6,7 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    provider: sandbox-sre
+    provider: ksctl
   name: approve-user-dperaza4dustbit-host
   namespace: toolchain-host-operator
 roleRef:

--- a/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/approve-user-eedri-host.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/approve-user-eedri-host.yaml
@@ -6,7 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    provider: sandbox-sre
+    provider: ksctl
   name: approve-user-eedri-host
   namespace: toolchain-host-operator
 roleRef:

--- a/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/approve-user-ergonzal-host.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/approve-user-ergonzal-host.yaml
@@ -6,7 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    provider: sandbox-sre
+    provider: ksctl
   name: approve-user-ergonzal-host
   namespace: toolchain-host-operator
 roleRef:

--- a/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/approve-user-filariow-host.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/approve-user-filariow-host.yaml
@@ -6,7 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    provider: sandbox-sre
+    provider: ksctl
   name: approve-user-filariow-host
   namespace: toolchain-host-operator
 roleRef:

--- a/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/approve-user-fmuntean-host.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/approve-user-fmuntean-host.yaml
@@ -6,7 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    provider: sandbox-sre
+    provider: ksctl
   name: approve-user-fmuntean-host
   namespace: toolchain-host-operator
 roleRef:

--- a/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/approve-user-gbenhaim-host.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/approve-user-gbenhaim-host.yaml
@@ -6,7 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    provider: sandbox-sre
+    provider: ksctl
   name: approve-user-gbenhaim-host
   namespace: toolchain-host-operator
 roleRef:

--- a/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/approve-user-hugares-host.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/approve-user-hugares-host.yaml
@@ -6,7 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    provider: sandbox-sre
+    provider: ksctl
   name: approve-user-hugares-host
   namespace: toolchain-host-operator
 roleRef:

--- a/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/approve-user-mjobanek-host.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/approve-user-mjobanek-host.yaml
@@ -6,7 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    provider: sandbox-sre
+    provider: ksctl
   name: approve-user-mjobanek-host
   namespace: toolchain-host-operator
 roleRef:

--- a/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/approve-user-pdave-host.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/approve-user-pdave-host.yaml
@@ -6,7 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    provider: sandbox-sre
+    provider: ksctl
   name: approve-user-pdave-host
   namespace: toolchain-host-operator
 roleRef:

--- a/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/approve-user-ralphbean-host.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/approve-user-ralphbean-host.yaml
@@ -6,7 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    provider: sandbox-sre
+    provider: ksctl
   name: approve-user-ralphbean-host
   namespace: toolchain-host-operator
 roleRef:

--- a/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/approve-user-rorai-host.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/approve-user-rorai-host.yaml
@@ -6,7 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    provider: sandbox-sre
+    provider: ksctl
   name: approve-user-rorai-host
   namespace: toolchain-host-operator
 roleRef:

--- a/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/approve-user-sadlerap-host.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/approve-user-sadlerap-host.yaml
@@ -6,7 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    provider: sandbox-sre
+    provider: ksctl
   name: approve-user-sadlerap-host
   namespace: toolchain-host-operator
 roleRef:

--- a/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/approve-user-saviv-host.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/approve-user-saviv-host.yaml
@@ -6,7 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    provider: sandbox-sre
+    provider: ksctl
   name: approve-user-saviv-host
   namespace: toolchain-host-operator
 roleRef:

--- a/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/ban-user-alkazako-host.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/ban-user-alkazako-host.yaml
@@ -6,7 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    provider: sandbox-sre
+    provider: ksctl
   name: ban-user-alkazako-host
   namespace: toolchain-host-operator
 roleRef:

--- a/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/ban-user-dperaza4dustbit-host.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/ban-user-dperaza4dustbit-host.yaml
@@ -6,7 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    provider: sandbox-sre
+    provider: ksctl
   name: ban-user-dperaza4dustbit-host
   namespace: toolchain-host-operator
 roleRef:

--- a/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/ban-user-filariow-host.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/ban-user-filariow-host.yaml
@@ -6,7 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    provider: sandbox-sre
+    provider: ksctl
   name: ban-user-filariow-host
   namespace: toolchain-host-operator
 roleRef:

--- a/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/ban-user-fmuntean-host.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/ban-user-fmuntean-host.yaml
@@ -6,7 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    provider: sandbox-sre
+    provider: ksctl
   name: ban-user-fmuntean-host
   namespace: toolchain-host-operator
 roleRef:

--- a/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/ban-user-mjobanek-host.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/ban-user-mjobanek-host.yaml
@@ -6,7 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    provider: sandbox-sre
+    provider: ksctl
   name: ban-user-mjobanek-host
   namespace: toolchain-host-operator
 roleRef:

--- a/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/ban-user-sadlerap-host.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/ban-user-sadlerap-host.yaml
@@ -6,7 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    provider: sandbox-sre
+    provider: ksctl
   name: ban-user-sadlerap-host
   namespace: toolchain-host-operator
 roleRef:

--- a/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/clusterrole-view-alkazako-host.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/clusterrole-view-alkazako-host.yaml
@@ -6,7 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    provider: sandbox-sre
+    provider: ksctl
   name: clusterrole-view-alkazako-host
   namespace: toolchain-host-operator
 roleRef:

--- a/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/clusterrole-view-bcook-host.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/clusterrole-view-bcook-host.yaml
@@ -6,7 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    provider: sandbox-sre
+    provider: ksctl
   name: clusterrole-view-bcook-host
   namespace: toolchain-host-operator
 roleRef:

--- a/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/clusterrole-view-bkundu-host.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/clusterrole-view-bkundu-host.yaml
@@ -6,7 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    provider: sandbox-sre
+    provider: ksctl
   name: clusterrole-view-bkundu-host
   namespace: toolchain-host-operator
 roleRef:

--- a/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/clusterrole-view-bsutter-host.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/clusterrole-view-bsutter-host.yaml
@@ -6,7 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    provider: sandbox-sre
+    provider: ksctl
   name: clusterrole-view-bsutter-host
   namespace: toolchain-host-operator
 roleRef:

--- a/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/clusterrole-view-dfodor-host.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/clusterrole-view-dfodor-host.yaml
@@ -6,7 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    provider: sandbox-sre
+    provider: ksctl
   name: clusterrole-view-dfodor-host
   namespace: toolchain-host-operator
 roleRef:

--- a/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/clusterrole-view-dperaza4dustbit-host.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/clusterrole-view-dperaza4dustbit-host.yaml
@@ -6,7 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    provider: sandbox-sre
+    provider: ksctl
   name: clusterrole-view-dperaza4dustbit-host
   namespace: toolchain-host-operator
 roleRef:

--- a/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/clusterrole-view-eedri-host.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/clusterrole-view-eedri-host.yaml
@@ -6,7 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    provider: sandbox-sre
+    provider: ksctl
   name: clusterrole-view-eedri-host
   namespace: toolchain-host-operator
 roleRef:

--- a/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/clusterrole-view-ergonzal-host.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/clusterrole-view-ergonzal-host.yaml
@@ -6,7 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    provider: sandbox-sre
+    provider: ksctl
   name: clusterrole-view-ergonzal-host
   namespace: toolchain-host-operator
 roleRef:

--- a/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/clusterrole-view-filariow-host.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/clusterrole-view-filariow-host.yaml
@@ -6,7 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    provider: sandbox-sre
+    provider: ksctl
   name: clusterrole-view-filariow-host
   namespace: toolchain-host-operator
 roleRef:

--- a/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/clusterrole-view-fmuntean-host.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/clusterrole-view-fmuntean-host.yaml
@@ -6,7 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    provider: sandbox-sre
+    provider: ksctl
   name: clusterrole-view-fmuntean-host
   namespace: toolchain-host-operator
 roleRef:

--- a/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/clusterrole-view-gbenhaim-host.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/clusterrole-view-gbenhaim-host.yaml
@@ -6,7 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    provider: sandbox-sre
+    provider: ksctl
   name: clusterrole-view-gbenhaim-host
   namespace: toolchain-host-operator
 roleRef:

--- a/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/clusterrole-view-hugares-host.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/clusterrole-view-hugares-host.yaml
@@ -6,7 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    provider: sandbox-sre
+    provider: ksctl
   name: clusterrole-view-hugares-host
   namespace: toolchain-host-operator
 roleRef:

--- a/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/clusterrole-view-mjobanek-host.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/clusterrole-view-mjobanek-host.yaml
@@ -6,7 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    provider: sandbox-sre
+    provider: ksctl
   name: clusterrole-view-mjobanek-host
   namespace: toolchain-host-operator
 roleRef:

--- a/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/clusterrole-view-pdave-host.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/clusterrole-view-pdave-host.yaml
@@ -6,7 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    provider: sandbox-sre
+    provider: ksctl
   name: clusterrole-view-pdave-host
   namespace: toolchain-host-operator
 roleRef:

--- a/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/clusterrole-view-ralphbean-host.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/clusterrole-view-ralphbean-host.yaml
@@ -6,7 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    provider: sandbox-sre
+    provider: ksctl
   name: clusterrole-view-ralphbean-host
   namespace: toolchain-host-operator
 roleRef:

--- a/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/clusterrole-view-rorai-host.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/clusterrole-view-rorai-host.yaml
@@ -6,7 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    provider: sandbox-sre
+    provider: ksctl
   name: clusterrole-view-rorai-host
   namespace: toolchain-host-operator
 roleRef:

--- a/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/clusterrole-view-sadlerap-host.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/clusterrole-view-sadlerap-host.yaml
@@ -6,7 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    provider: sandbox-sre
+    provider: ksctl
   name: clusterrole-view-sadlerap-host
   namespace: toolchain-host-operator
 roleRef:

--- a/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/clusterrole-view-saviv-host.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/clusterrole-view-saviv-host.yaml
@@ -6,7 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    provider: sandbox-sre
+    provider: ksctl
   name: clusterrole-view-saviv-host
   namespace: toolchain-host-operator
 roleRef:

--- a/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/deactivate-user-alkazako-host.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/deactivate-user-alkazako-host.yaml
@@ -6,7 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    provider: sandbox-sre
+    provider: ksctl
   name: deactivate-user-alkazako-host
   namespace: toolchain-host-operator
 roleRef:

--- a/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/deactivate-user-bcook-host.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/deactivate-user-bcook-host.yaml
@@ -6,7 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    provider: sandbox-sre
+    provider: ksctl
   name: deactivate-user-bcook-host
   namespace: toolchain-host-operator
 roleRef:

--- a/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/deactivate-user-bsutter-host.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/deactivate-user-bsutter-host.yaml
@@ -6,7 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    provider: sandbox-sre
+    provider: ksctl
   name: deactivate-user-bsutter-host
   namespace: toolchain-host-operator
 roleRef:

--- a/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/deactivate-user-dperaza4dustbit-host.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/deactivate-user-dperaza4dustbit-host.yaml
@@ -6,7 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    provider: sandbox-sre
+    provider: ksctl
   name: deactivate-user-dperaza4dustbit-host
   namespace: toolchain-host-operator
 roleRef:

--- a/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/deactivate-user-filariow-host.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/deactivate-user-filariow-host.yaml
@@ -6,7 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    provider: sandbox-sre
+    provider: ksctl
   name: deactivate-user-filariow-host
   namespace: toolchain-host-operator
 roleRef:

--- a/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/deactivate-user-fmuntean-host.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/deactivate-user-fmuntean-host.yaml
@@ -6,7 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    provider: sandbox-sre
+    provider: ksctl
   name: deactivate-user-fmuntean-host
   namespace: toolchain-host-operator
 roleRef:

--- a/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/deactivate-user-hugares-host.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/deactivate-user-hugares-host.yaml
@@ -6,7 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    provider: sandbox-sre
+    provider: ksctl
   name: deactivate-user-hugares-host
   namespace: toolchain-host-operator
 roleRef:

--- a/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/deactivate-user-mjobanek-host.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/deactivate-user-mjobanek-host.yaml
@@ -6,7 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    provider: sandbox-sre
+    provider: ksctl
   name: deactivate-user-mjobanek-host
   namespace: toolchain-host-operator
 roleRef:

--- a/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/deactivate-user-sadlerap-host.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/deactivate-user-sadlerap-host.yaml
@@ -6,7 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    provider: sandbox-sre
+    provider: ksctl
   name: deactivate-user-sadlerap-host
   namespace: toolchain-host-operator
 roleRef:

--- a/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/gdpr-delete-alkazako-host.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/gdpr-delete-alkazako-host.yaml
@@ -6,7 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    provider: sandbox-sre
+    provider: ksctl
   name: gdpr-delete-alkazako-host
   namespace: toolchain-host-operator
 roleRef:

--- a/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/gdpr-delete-bcook-host.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/gdpr-delete-bcook-host.yaml
@@ -6,7 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    provider: sandbox-sre
+    provider: ksctl
   name: gdpr-delete-bcook-host
   namespace: toolchain-host-operator
 roleRef:

--- a/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/gdpr-delete-bsutter-host.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/gdpr-delete-bsutter-host.yaml
@@ -6,7 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    provider: sandbox-sre
+    provider: ksctl
   name: gdpr-delete-bsutter-host
   namespace: toolchain-host-operator
 roleRef:

--- a/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/gdpr-delete-dperaza4dustbit-host.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/gdpr-delete-dperaza4dustbit-host.yaml
@@ -6,7 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    provider: sandbox-sre
+    provider: ksctl
   name: gdpr-delete-dperaza4dustbit-host
   namespace: toolchain-host-operator
 roleRef:

--- a/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/gdpr-delete-filariow-host.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/gdpr-delete-filariow-host.yaml
@@ -6,7 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    provider: sandbox-sre
+    provider: ksctl
   name: gdpr-delete-filariow-host
   namespace: toolchain-host-operator
 roleRef:

--- a/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/gdpr-delete-fmuntean-host.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/gdpr-delete-fmuntean-host.yaml
@@ -6,7 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    provider: sandbox-sre
+    provider: ksctl
   name: gdpr-delete-fmuntean-host
   namespace: toolchain-host-operator
 roleRef:

--- a/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/gdpr-delete-hugares-host.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/gdpr-delete-hugares-host.yaml
@@ -6,7 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    provider: sandbox-sre
+    provider: ksctl
   name: gdpr-delete-hugares-host
   namespace: toolchain-host-operator
 roleRef:

--- a/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/gdpr-delete-mjobanek-host.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/gdpr-delete-mjobanek-host.yaml
@@ -6,7 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    provider: sandbox-sre
+    provider: ksctl
   name: gdpr-delete-mjobanek-host
   namespace: toolchain-host-operator
 roleRef:

--- a/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/gdpr-delete-sadlerap-host.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/gdpr-delete-sadlerap-host.yaml
@@ -6,7 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    provider: sandbox-sre
+    provider: ksctl
   name: gdpr-delete-sadlerap-host
   namespace: toolchain-host-operator
 roleRef:

--- a/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/kustomization.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/kustomization.yaml
@@ -84,8 +84,8 @@ resources:
 - retarget-user-bcook-host.yaml
 - retarget-user-bsutter-host.yaml
 - retarget-user-dfodor-host.yaml
-- retarget-user-eedri-host.yaml
 - retarget-user-dperaza4dustbit-host.yaml
+- retarget-user-eedri-host.yaml
 - retarget-user-ergonzal-host.yaml
 - retarget-user-filariow-host.yaml
 - retarget-user-fmuntean-host.yaml

--- a/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/promote-user-alkazako-host.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/promote-user-alkazako-host.yaml
@@ -6,7 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    provider: sandbox-sre
+    provider: ksctl
   name: promote-user-alkazako-host
   namespace: toolchain-host-operator
 roleRef:

--- a/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/promote-user-bcook-host.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/promote-user-bcook-host.yaml
@@ -6,7 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    provider: sandbox-sre
+    provider: ksctl
   name: promote-user-bcook-host
   namespace: toolchain-host-operator
 roleRef:

--- a/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/promote-user-bsutter-host.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/promote-user-bsutter-host.yaml
@@ -6,7 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    provider: sandbox-sre
+    provider: ksctl
   name: promote-user-bsutter-host
   namespace: toolchain-host-operator
 roleRef:

--- a/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/promote-user-dperaza4dustbit-host.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/promote-user-dperaza4dustbit-host.yaml
@@ -6,7 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    provider: sandbox-sre
+    provider: ksctl
   name: promote-user-dperaza4dustbit-host
   namespace: toolchain-host-operator
 roleRef:

--- a/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/promote-user-filariow-host.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/promote-user-filariow-host.yaml
@@ -6,7 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    provider: sandbox-sre
+    provider: ksctl
   name: promote-user-filariow-host
   namespace: toolchain-host-operator
 roleRef:

--- a/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/promote-user-fmuntean-host.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/promote-user-fmuntean-host.yaml
@@ -6,7 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    provider: sandbox-sre
+    provider: ksctl
   name: promote-user-fmuntean-host
   namespace: toolchain-host-operator
 roleRef:

--- a/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/promote-user-hugares-host.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/promote-user-hugares-host.yaml
@@ -6,7 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    provider: sandbox-sre
+    provider: ksctl
   name: promote-user-hugares-host
   namespace: toolchain-host-operator
 roleRef:

--- a/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/promote-user-mjobanek-host.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/promote-user-mjobanek-host.yaml
@@ -6,7 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    provider: sandbox-sre
+    provider: ksctl
   name: promote-user-mjobanek-host
   namespace: toolchain-host-operator
 roleRef:

--- a/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/promote-user-sadlerap-host.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/promote-user-sadlerap-host.yaml
@@ -6,7 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    provider: sandbox-sre
+    provider: ksctl
   name: promote-user-sadlerap-host
   namespace: toolchain-host-operator
 roleRef:

--- a/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/restart-deployment-alkazako-host.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/restart-deployment-alkazako-host.yaml
@@ -6,7 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    provider: sandbox-sre
+    provider: ksctl
   name: restart-deployment-alkazako-host
   namespace: toolchain-host-operator
 roleRef:

--- a/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/restart-deployment-dperaza4dustbit-host.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/restart-deployment-dperaza4dustbit-host.yaml
@@ -6,7 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    provider: sandbox-sre
+    provider: ksctl
   name: restart-deployment-dperaza4dustbit-host
   namespace: toolchain-host-operator
 roleRef:

--- a/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/restart-deployment-filariow-host.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/restart-deployment-filariow-host.yaml
@@ -6,7 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    provider: sandbox-sre
+    provider: ksctl
   name: restart-deployment-filariow-host
   namespace: toolchain-host-operator
 roleRef:

--- a/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/restart-deployment-fmuntean-host.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/restart-deployment-fmuntean-host.yaml
@@ -6,7 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    provider: sandbox-sre
+    provider: ksctl
   name: restart-deployment-fmuntean-host
   namespace: toolchain-host-operator
 roleRef:

--- a/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/restart-deployment-mjobanek-host.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/restart-deployment-mjobanek-host.yaml
@@ -6,7 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    provider: sandbox-sre
+    provider: ksctl
   name: restart-deployment-mjobanek-host
   namespace: toolchain-host-operator
 roleRef:

--- a/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/restart-deployment-sadlerap-host.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/restart-deployment-sadlerap-host.yaml
@@ -6,7 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    provider: sandbox-sre
+    provider: ksctl
   name: restart-deployment-sadlerap-host
   namespace: toolchain-host-operator
 roleRef:

--- a/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/retarget-user-alkazako-host.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/retarget-user-alkazako-host.yaml
@@ -6,7 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    provider: sandbox-sre
+    provider: ksctl
   name: retarget-user-alkazako-host
   namespace: toolchain-host-operator
 roleRef:

--- a/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/retarget-user-bcook-host.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/retarget-user-bcook-host.yaml
@@ -6,7 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    provider: sandbox-sre
+    provider: ksctl
   name: retarget-user-bcook-host
   namespace: toolchain-host-operator
 roleRef:

--- a/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/retarget-user-bsutter-host.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/retarget-user-bsutter-host.yaml
@@ -6,7 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    provider: sandbox-sre
+    provider: ksctl
   name: retarget-user-bsutter-host
   namespace: toolchain-host-operator
 roleRef:

--- a/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/retarget-user-dfodor-host.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/retarget-user-dfodor-host.yaml
@@ -6,7 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    provider: sandbox-sre
+    provider: ksctl
   name: retarget-user-dfodor-host
   namespace: toolchain-host-operator
 roleRef:

--- a/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/retarget-user-dperaza4dustbit-host.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/retarget-user-dperaza4dustbit-host.yaml
@@ -6,7 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    provider: sandbox-sre
+    provider: ksctl
   name: retarget-user-dperaza4dustbit-host
   namespace: toolchain-host-operator
 roleRef:

--- a/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/retarget-user-eedri-host.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/retarget-user-eedri-host.yaml
@@ -6,7 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    provider: sandbox-sre
+    provider: ksctl
   name: retarget-user-eedri-host
   namespace: toolchain-host-operator
 roleRef:

--- a/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/retarget-user-ergonzal-host.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/retarget-user-ergonzal-host.yaml
@@ -6,7 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    provider: sandbox-sre
+    provider: ksctl
   name: retarget-user-ergonzal-host
   namespace: toolchain-host-operator
 roleRef:

--- a/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/retarget-user-filariow-host.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/retarget-user-filariow-host.yaml
@@ -6,7 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    provider: sandbox-sre
+    provider: ksctl
   name: retarget-user-filariow-host
   namespace: toolchain-host-operator
 roleRef:

--- a/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/retarget-user-fmuntean-host.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/retarget-user-fmuntean-host.yaml
@@ -6,7 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    provider: sandbox-sre
+    provider: ksctl
   name: retarget-user-fmuntean-host
   namespace: toolchain-host-operator
 roleRef:

--- a/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/retarget-user-gbenhaim-host.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/retarget-user-gbenhaim-host.yaml
@@ -6,7 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    provider: sandbox-sre
+    provider: ksctl
   name: retarget-user-gbenhaim-host
   namespace: toolchain-host-operator
 roleRef:

--- a/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/retarget-user-hugares-host.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/retarget-user-hugares-host.yaml
@@ -6,7 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    provider: sandbox-sre
+    provider: ksctl
   name: retarget-user-hugares-host
   namespace: toolchain-host-operator
 roleRef:

--- a/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/retarget-user-mjobanek-host.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/retarget-user-mjobanek-host.yaml
@@ -6,7 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    provider: sandbox-sre
+    provider: ksctl
   name: retarget-user-mjobanek-host
   namespace: toolchain-host-operator
 roleRef:

--- a/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/retarget-user-ralphbean-host.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/retarget-user-ralphbean-host.yaml
@@ -6,7 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    provider: sandbox-sre
+    provider: ksctl
   name: retarget-user-ralphbean-host
   namespace: toolchain-host-operator
 roleRef:

--- a/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/retarget-user-sadlerap-host.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/retarget-user-sadlerap-host.yaml
@@ -6,7 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    provider: sandbox-sre
+    provider: ksctl
   name: retarget-user-sadlerap-host
   namespace: toolchain-host-operator
 roleRef:

--- a/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/retarget-user-saviv-host.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/rolebindings/retarget-user-saviv-host.yaml
@@ -6,7 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    provider: sandbox-sre
+    provider: ksctl
   name: retarget-user-saviv-host
   namespace: toolchain-host-operator
 roleRef:

--- a/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/roles/approve-user-host.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/roles/approve-user-host.yaml
@@ -6,7 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    provider: sandbox-sre
+    provider: ksctl
   name: approve-user-host
   namespace: toolchain-host-operator
 rules:

--- a/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/roles/ban-user-host.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/roles/ban-user-host.yaml
@@ -6,7 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    provider: sandbox-sre
+    provider: ksctl
   name: ban-user-host
   namespace: toolchain-host-operator
 rules:

--- a/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/roles/deactivate-user-host.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/roles/deactivate-user-host.yaml
@@ -6,7 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    provider: sandbox-sre
+    provider: ksctl
   name: deactivate-user-host
   namespace: toolchain-host-operator
 rules:

--- a/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/roles/gdpr-delete-host.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/roles/gdpr-delete-host.yaml
@@ -6,7 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    provider: sandbox-sre
+    provider: ksctl
   name: gdpr-delete-host
   namespace: toolchain-host-operator
 rules:

--- a/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/roles/promote-user-host.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/roles/promote-user-host.yaml
@@ -6,7 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    provider: sandbox-sre
+    provider: ksctl
   name: promote-user-host
   namespace: toolchain-host-operator
 rules:

--- a/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/roles/restart-deployment-host.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/roles/restart-deployment-host.yaml
@@ -6,7 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    provider: sandbox-sre
+    provider: ksctl
   name: restart-deployment-host
   namespace: toolchain-host-operator
 rules:

--- a/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/roles/retarget-user-host.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/host/namespace-scoped/toolchain-host-operator/roles/retarget-user-host.yaml
@@ -6,7 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    provider: sandbox-sre
+    provider: ksctl
   name: retarget-user-host
   namespace: toolchain-host-operator
 rules:

--- a/components/sandbox/user-management/production/generated-manifests/member/namespace-scoped/sandbox-sre-member/serviceaccounts/alkazako.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/member/namespace-scoped/sandbox-sre-member/serviceaccounts/alkazako.yaml
@@ -8,7 +8,7 @@ metadata:
   annotations:
     argocd.argoproj.io/compare-options: IgnoreExtraneous
   labels:
-    provider: sandbox-sre
+    provider: ksctl
     username: alkazako
   name: alkazako
   namespace: sandbox-sre-member

--- a/components/sandbox/user-management/production/generated-manifests/member/namespace-scoped/sandbox-sre-member/serviceaccounts/bcook.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/member/namespace-scoped/sandbox-sre-member/serviceaccounts/bcook.yaml
@@ -8,7 +8,7 @@ metadata:
   annotations:
     argocd.argoproj.io/compare-options: IgnoreExtraneous
   labels:
-    provider: sandbox-sre
+    provider: ksctl
     username: bcook
   name: bcook
   namespace: sandbox-sre-member

--- a/components/sandbox/user-management/production/generated-manifests/member/namespace-scoped/sandbox-sre-member/serviceaccounts/bkundu.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/member/namespace-scoped/sandbox-sre-member/serviceaccounts/bkundu.yaml
@@ -8,7 +8,7 @@ metadata:
   annotations:
     argocd.argoproj.io/compare-options: IgnoreExtraneous
   labels:
-    provider: sandbox-sre
+    provider: ksctl
     username: bkundu
   name: bkundu
   namespace: sandbox-sre-member

--- a/components/sandbox/user-management/production/generated-manifests/member/namespace-scoped/sandbox-sre-member/serviceaccounts/bsutter.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/member/namespace-scoped/sandbox-sre-member/serviceaccounts/bsutter.yaml
@@ -8,7 +8,7 @@ metadata:
   annotations:
     argocd.argoproj.io/compare-options: IgnoreExtraneous
   labels:
-    provider: sandbox-sre
+    provider: ksctl
     username: bsutter
   name: bsutter
   namespace: sandbox-sre-member

--- a/components/sandbox/user-management/production/generated-manifests/member/namespace-scoped/sandbox-sre-member/serviceaccounts/dfodor.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/member/namespace-scoped/sandbox-sre-member/serviceaccounts/dfodor.yaml
@@ -8,7 +8,7 @@ metadata:
   annotations:
     argocd.argoproj.io/compare-options: IgnoreExtraneous
   labels:
-    provider: sandbox-sre
+    provider: ksctl
     username: dfodor
   name: dfodor
   namespace: sandbox-sre-member

--- a/components/sandbox/user-management/production/generated-manifests/member/namespace-scoped/sandbox-sre-member/serviceaccounts/dperaza4dustbit.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/member/namespace-scoped/sandbox-sre-member/serviceaccounts/dperaza4dustbit.yaml
@@ -8,7 +8,7 @@ metadata:
   annotations:
     argocd.argoproj.io/compare-options: IgnoreExtraneous
   labels:
-    provider: sandbox-sre
+    provider: ksctl
     username: dperaza4dustbit
   name: dperaza4dustbit
   namespace: sandbox-sre-member

--- a/components/sandbox/user-management/production/generated-manifests/member/namespace-scoped/sandbox-sre-member/serviceaccounts/eedri.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/member/namespace-scoped/sandbox-sre-member/serviceaccounts/eedri.yaml
@@ -8,7 +8,7 @@ metadata:
   annotations:
     argocd.argoproj.io/compare-options: IgnoreExtraneous
   labels:
-    provider: sandbox-sre
+    provider: ksctl
     username: eedri
   name: eedri
   namespace: sandbox-sre-member

--- a/components/sandbox/user-management/production/generated-manifests/member/namespace-scoped/sandbox-sre-member/serviceaccounts/ergonzal.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/member/namespace-scoped/sandbox-sre-member/serviceaccounts/ergonzal.yaml
@@ -8,7 +8,7 @@ metadata:
   annotations:
     argocd.argoproj.io/compare-options: IgnoreExtraneous
   labels:
-    provider: sandbox-sre
+    provider: ksctl
     username: ergonzal
   name: ergonzal
   namespace: sandbox-sre-member

--- a/components/sandbox/user-management/production/generated-manifests/member/namespace-scoped/sandbox-sre-member/serviceaccounts/filariow.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/member/namespace-scoped/sandbox-sre-member/serviceaccounts/filariow.yaml
@@ -8,7 +8,7 @@ metadata:
   annotations:
     argocd.argoproj.io/compare-options: IgnoreExtraneous
   labels:
-    provider: sandbox-sre
+    provider: ksctl
     username: filariow
   name: filariow
   namespace: sandbox-sre-member

--- a/components/sandbox/user-management/production/generated-manifests/member/namespace-scoped/sandbox-sre-member/serviceaccounts/fmuntean.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/member/namespace-scoped/sandbox-sre-member/serviceaccounts/fmuntean.yaml
@@ -8,7 +8,7 @@ metadata:
   annotations:
     argocd.argoproj.io/compare-options: IgnoreExtraneous
   labels:
-    provider: sandbox-sre
+    provider: ksctl
     username: fmuntean
   name: fmuntean
   namespace: sandbox-sre-member

--- a/components/sandbox/user-management/production/generated-manifests/member/namespace-scoped/sandbox-sre-member/serviceaccounts/gbenhaim.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/member/namespace-scoped/sandbox-sre-member/serviceaccounts/gbenhaim.yaml
@@ -8,7 +8,7 @@ metadata:
   annotations:
     argocd.argoproj.io/compare-options: IgnoreExtraneous
   labels:
-    provider: sandbox-sre
+    provider: ksctl
     username: gbenhaim
   name: gbenhaim
   namespace: sandbox-sre-member

--- a/components/sandbox/user-management/production/generated-manifests/member/namespace-scoped/sandbox-sre-member/serviceaccounts/hugares.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/member/namespace-scoped/sandbox-sre-member/serviceaccounts/hugares.yaml
@@ -8,7 +8,7 @@ metadata:
   annotations:
     argocd.argoproj.io/compare-options: IgnoreExtraneous
   labels:
-    provider: sandbox-sre
+    provider: ksctl
     username: hugares
   name: hugares
   namespace: sandbox-sre-member

--- a/components/sandbox/user-management/production/generated-manifests/member/namespace-scoped/sandbox-sre-member/serviceaccounts/mjobanek.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/member/namespace-scoped/sandbox-sre-member/serviceaccounts/mjobanek.yaml
@@ -8,7 +8,7 @@ metadata:
   annotations:
     argocd.argoproj.io/compare-options: IgnoreExtraneous
   labels:
-    provider: sandbox-sre
+    provider: ksctl
     username: mjobanek
   name: mjobanek
   namespace: sandbox-sre-member

--- a/components/sandbox/user-management/production/generated-manifests/member/namespace-scoped/sandbox-sre-member/serviceaccounts/pdave.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/member/namespace-scoped/sandbox-sre-member/serviceaccounts/pdave.yaml
@@ -8,7 +8,7 @@ metadata:
   annotations:
     argocd.argoproj.io/compare-options: IgnoreExtraneous
   labels:
-    provider: sandbox-sre
+    provider: ksctl
     username: pdave
   name: pdave
   namespace: sandbox-sre-member

--- a/components/sandbox/user-management/production/generated-manifests/member/namespace-scoped/sandbox-sre-member/serviceaccounts/ralphbean.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/member/namespace-scoped/sandbox-sre-member/serviceaccounts/ralphbean.yaml
@@ -8,7 +8,7 @@ metadata:
   annotations:
     argocd.argoproj.io/compare-options: IgnoreExtraneous
   labels:
-    provider: sandbox-sre
+    provider: ksctl
     username: ralphbean
   name: ralphbean
   namespace: sandbox-sre-member

--- a/components/sandbox/user-management/production/generated-manifests/member/namespace-scoped/sandbox-sre-member/serviceaccounts/rorai.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/member/namespace-scoped/sandbox-sre-member/serviceaccounts/rorai.yaml
@@ -8,7 +8,7 @@ metadata:
   annotations:
     argocd.argoproj.io/compare-options: IgnoreExtraneous
   labels:
-    provider: sandbox-sre
+    provider: ksctl
     username: rorai
   name: rorai
   namespace: sandbox-sre-member

--- a/components/sandbox/user-management/production/generated-manifests/member/namespace-scoped/sandbox-sre-member/serviceaccounts/sadlerap.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/member/namespace-scoped/sandbox-sre-member/serviceaccounts/sadlerap.yaml
@@ -8,7 +8,7 @@ metadata:
   annotations:
     argocd.argoproj.io/compare-options: IgnoreExtraneous
   labels:
-    provider: sandbox-sre
+    provider: ksctl
     username: sadlerap
   name: sadlerap
   namespace: sandbox-sre-member

--- a/components/sandbox/user-management/production/generated-manifests/member/namespace-scoped/sandbox-sre-member/serviceaccounts/saviv.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/member/namespace-scoped/sandbox-sre-member/serviceaccounts/saviv.yaml
@@ -8,7 +8,7 @@ metadata:
   annotations:
     argocd.argoproj.io/compare-options: IgnoreExtraneous
   labels:
-    provider: sandbox-sre
+    provider: ksctl
     username: saviv
   name: saviv
   namespace: sandbox-sre-member

--- a/components/sandbox/user-management/production/generated-manifests/member/namespace-scoped/toolchain-member-operator/rolebindings/clusterrole-view-alkazako-member.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/member/namespace-scoped/toolchain-member-operator/rolebindings/clusterrole-view-alkazako-member.yaml
@@ -6,7 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    provider: sandbox-sre
+    provider: ksctl
   name: clusterrole-view-alkazako-member
   namespace: toolchain-member-operator
 roleRef:

--- a/components/sandbox/user-management/production/generated-manifests/member/namespace-scoped/toolchain-member-operator/rolebindings/clusterrole-view-bcook-member.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/member/namespace-scoped/toolchain-member-operator/rolebindings/clusterrole-view-bcook-member.yaml
@@ -6,7 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    provider: sandbox-sre
+    provider: ksctl
   name: clusterrole-view-bcook-member
   namespace: toolchain-member-operator
 roleRef:

--- a/components/sandbox/user-management/production/generated-manifests/member/namespace-scoped/toolchain-member-operator/rolebindings/clusterrole-view-bkundu-member.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/member/namespace-scoped/toolchain-member-operator/rolebindings/clusterrole-view-bkundu-member.yaml
@@ -6,7 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    provider: sandbox-sre
+    provider: ksctl
   name: clusterrole-view-bkundu-member
   namespace: toolchain-member-operator
 roleRef:

--- a/components/sandbox/user-management/production/generated-manifests/member/namespace-scoped/toolchain-member-operator/rolebindings/clusterrole-view-bsutter-member.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/member/namespace-scoped/toolchain-member-operator/rolebindings/clusterrole-view-bsutter-member.yaml
@@ -6,7 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    provider: sandbox-sre
+    provider: ksctl
   name: clusterrole-view-bsutter-member
   namespace: toolchain-member-operator
 roleRef:

--- a/components/sandbox/user-management/production/generated-manifests/member/namespace-scoped/toolchain-member-operator/rolebindings/clusterrole-view-dfodor-member.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/member/namespace-scoped/toolchain-member-operator/rolebindings/clusterrole-view-dfodor-member.yaml
@@ -6,7 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    provider: sandbox-sre
+    provider: ksctl
   name: clusterrole-view-dfodor-member
   namespace: toolchain-member-operator
 roleRef:

--- a/components/sandbox/user-management/production/generated-manifests/member/namespace-scoped/toolchain-member-operator/rolebindings/clusterrole-view-dperaza4dustbit-member.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/member/namespace-scoped/toolchain-member-operator/rolebindings/clusterrole-view-dperaza4dustbit-member.yaml
@@ -6,7 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    provider: sandbox-sre
+    provider: ksctl
   name: clusterrole-view-dperaza4dustbit-member
   namespace: toolchain-member-operator
 roleRef:

--- a/components/sandbox/user-management/production/generated-manifests/member/namespace-scoped/toolchain-member-operator/rolebindings/clusterrole-view-eedri-member.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/member/namespace-scoped/toolchain-member-operator/rolebindings/clusterrole-view-eedri-member.yaml
@@ -6,7 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    provider: sandbox-sre
+    provider: ksctl
   name: clusterrole-view-eedri-member
   namespace: toolchain-member-operator
 roleRef:

--- a/components/sandbox/user-management/production/generated-manifests/member/namespace-scoped/toolchain-member-operator/rolebindings/clusterrole-view-ergonzal-member.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/member/namespace-scoped/toolchain-member-operator/rolebindings/clusterrole-view-ergonzal-member.yaml
@@ -6,7 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    provider: sandbox-sre
+    provider: ksctl
   name: clusterrole-view-ergonzal-member
   namespace: toolchain-member-operator
 roleRef:

--- a/components/sandbox/user-management/production/generated-manifests/member/namespace-scoped/toolchain-member-operator/rolebindings/clusterrole-view-filariow-member.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/member/namespace-scoped/toolchain-member-operator/rolebindings/clusterrole-view-filariow-member.yaml
@@ -6,7 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    provider: sandbox-sre
+    provider: ksctl
   name: clusterrole-view-filariow-member
   namespace: toolchain-member-operator
 roleRef:

--- a/components/sandbox/user-management/production/generated-manifests/member/namespace-scoped/toolchain-member-operator/rolebindings/clusterrole-view-fmuntean-member.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/member/namespace-scoped/toolchain-member-operator/rolebindings/clusterrole-view-fmuntean-member.yaml
@@ -6,7 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    provider: sandbox-sre
+    provider: ksctl
   name: clusterrole-view-fmuntean-member
   namespace: toolchain-member-operator
 roleRef:

--- a/components/sandbox/user-management/production/generated-manifests/member/namespace-scoped/toolchain-member-operator/rolebindings/clusterrole-view-gbenhaim-member.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/member/namespace-scoped/toolchain-member-operator/rolebindings/clusterrole-view-gbenhaim-member.yaml
@@ -6,7 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    provider: sandbox-sre
+    provider: ksctl
   name: clusterrole-view-gbenhaim-member
   namespace: toolchain-member-operator
 roleRef:

--- a/components/sandbox/user-management/production/generated-manifests/member/namespace-scoped/toolchain-member-operator/rolebindings/clusterrole-view-hugares-member.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/member/namespace-scoped/toolchain-member-operator/rolebindings/clusterrole-view-hugares-member.yaml
@@ -6,7 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    provider: sandbox-sre
+    provider: ksctl
   name: clusterrole-view-hugares-member
   namespace: toolchain-member-operator
 roleRef:

--- a/components/sandbox/user-management/production/generated-manifests/member/namespace-scoped/toolchain-member-operator/rolebindings/clusterrole-view-mjobanek-member.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/member/namespace-scoped/toolchain-member-operator/rolebindings/clusterrole-view-mjobanek-member.yaml
@@ -6,7 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    provider: sandbox-sre
+    provider: ksctl
   name: clusterrole-view-mjobanek-member
   namespace: toolchain-member-operator
 roleRef:

--- a/components/sandbox/user-management/production/generated-manifests/member/namespace-scoped/toolchain-member-operator/rolebindings/clusterrole-view-pdave-member.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/member/namespace-scoped/toolchain-member-operator/rolebindings/clusterrole-view-pdave-member.yaml
@@ -6,7 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    provider: sandbox-sre
+    provider: ksctl
   name: clusterrole-view-pdave-member
   namespace: toolchain-member-operator
 roleRef:

--- a/components/sandbox/user-management/production/generated-manifests/member/namespace-scoped/toolchain-member-operator/rolebindings/clusterrole-view-ralphbean-member.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/member/namespace-scoped/toolchain-member-operator/rolebindings/clusterrole-view-ralphbean-member.yaml
@@ -6,7 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    provider: sandbox-sre
+    provider: ksctl
   name: clusterrole-view-ralphbean-member
   namespace: toolchain-member-operator
 roleRef:

--- a/components/sandbox/user-management/production/generated-manifests/member/namespace-scoped/toolchain-member-operator/rolebindings/clusterrole-view-rorai-member.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/member/namespace-scoped/toolchain-member-operator/rolebindings/clusterrole-view-rorai-member.yaml
@@ -6,7 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    provider: sandbox-sre
+    provider: ksctl
   name: clusterrole-view-rorai-member
   namespace: toolchain-member-operator
 roleRef:

--- a/components/sandbox/user-management/production/generated-manifests/member/namespace-scoped/toolchain-member-operator/rolebindings/clusterrole-view-sadlerap-member.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/member/namespace-scoped/toolchain-member-operator/rolebindings/clusterrole-view-sadlerap-member.yaml
@@ -6,7 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    provider: sandbox-sre
+    provider: ksctl
   name: clusterrole-view-sadlerap-member
   namespace: toolchain-member-operator
 roleRef:

--- a/components/sandbox/user-management/production/generated-manifests/member/namespace-scoped/toolchain-member-operator/rolebindings/clusterrole-view-saviv-member.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/member/namespace-scoped/toolchain-member-operator/rolebindings/clusterrole-view-saviv-member.yaml
@@ -6,7 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    provider: sandbox-sre
+    provider: ksctl
   name: clusterrole-view-saviv-member
   namespace: toolchain-member-operator
 roleRef:

--- a/components/sandbox/user-management/production/generated-manifests/member/namespace-scoped/toolchain-member-operator/rolebindings/restart-deployment-alkazako-member.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/member/namespace-scoped/toolchain-member-operator/rolebindings/restart-deployment-alkazako-member.yaml
@@ -6,7 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    provider: sandbox-sre
+    provider: ksctl
   name: restart-deployment-alkazako-member
   namespace: toolchain-member-operator
 roleRef:

--- a/components/sandbox/user-management/production/generated-manifests/member/namespace-scoped/toolchain-member-operator/rolebindings/restart-deployment-bkundu-member.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/member/namespace-scoped/toolchain-member-operator/rolebindings/restart-deployment-bkundu-member.yaml
@@ -6,7 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    provider: sandbox-sre
+    provider: ksctl
   name: restart-deployment-bkundu-member
   namespace: toolchain-member-operator
 roleRef:

--- a/components/sandbox/user-management/production/generated-manifests/member/namespace-scoped/toolchain-member-operator/rolebindings/restart-deployment-dperaza4dustbit-member.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/member/namespace-scoped/toolchain-member-operator/rolebindings/restart-deployment-dperaza4dustbit-member.yaml
@@ -6,7 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    provider: sandbox-sre
+    provider: ksctl
   name: restart-deployment-dperaza4dustbit-member
   namespace: toolchain-member-operator
 roleRef:

--- a/components/sandbox/user-management/production/generated-manifests/member/namespace-scoped/toolchain-member-operator/rolebindings/restart-deployment-filariow-member.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/member/namespace-scoped/toolchain-member-operator/rolebindings/restart-deployment-filariow-member.yaml
@@ -6,7 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    provider: sandbox-sre
+    provider: ksctl
   name: restart-deployment-filariow-member
   namespace: toolchain-member-operator
 roleRef:

--- a/components/sandbox/user-management/production/generated-manifests/member/namespace-scoped/toolchain-member-operator/rolebindings/restart-deployment-fmuntean-member.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/member/namespace-scoped/toolchain-member-operator/rolebindings/restart-deployment-fmuntean-member.yaml
@@ -6,7 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    provider: sandbox-sre
+    provider: ksctl
   name: restart-deployment-fmuntean-member
   namespace: toolchain-member-operator
 roleRef:

--- a/components/sandbox/user-management/production/generated-manifests/member/namespace-scoped/toolchain-member-operator/rolebindings/restart-deployment-mjobanek-member.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/member/namespace-scoped/toolchain-member-operator/rolebindings/restart-deployment-mjobanek-member.yaml
@@ -6,7 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    provider: sandbox-sre
+    provider: ksctl
   name: restart-deployment-mjobanek-member
   namespace: toolchain-member-operator
 roleRef:

--- a/components/sandbox/user-management/production/generated-manifests/member/namespace-scoped/toolchain-member-operator/rolebindings/restart-deployment-sadlerap-member.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/member/namespace-scoped/toolchain-member-operator/rolebindings/restart-deployment-sadlerap-member.yaml
@@ -6,7 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    provider: sandbox-sre
+    provider: ksctl
   name: restart-deployment-sadlerap-member
   namespace: toolchain-member-operator
 roleRef:

--- a/components/sandbox/user-management/production/generated-manifests/member/namespace-scoped/toolchain-member-operator/roles/restart-deployment-member.yaml
+++ b/components/sandbox/user-management/production/generated-manifests/member/namespace-scoped/toolchain-member-operator/roles/restart-deployment-member.yaml
@@ -6,7 +6,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    provider: sandbox-sre
+    provider: ksctl
   name: restart-deployment-member
   namespace: toolchain-member-operator
 rules:

--- a/components/sandbox/user-management/production/kubesaw-admins.yaml
+++ b/components/sandbox/user-management/production/kubesaw-admins.yaml
@@ -7,6 +7,10 @@ clusters:
   - api: https://api.stone-prd-rh01.pg1f.p1.openshiftapps.com:6443
     name: member-rh-1
 
+defaultServiceAccountsNamespace:
+  host: sandbox-sre-host
+  member: sandbox-sre-member
+
 serviceAccounts:
 ## service accounts to be used by humans via `ksctl`
 - name: alkazako

--- a/components/sandbox/user-management/staging/kubesaw-admins.yaml
+++ b/components/sandbox/user-management/staging/kubesaw-admins.yaml
@@ -7,6 +7,10 @@ clusters:
   - api: https://api.stone-stg-rh01.l2vh.p1.openshiftapps.com:6443
     name: member-rh-1
 
+defaultServiceAccountsNamespace:
+  host: sandbox-sre-host
+  member: sandbox-sre-member
+
 serviceAccounts:
 ## service accounts to be used by humans via `ksctl`
 - name: filariow


### PR DESCRIPTION
update ksctl version with the latest version & regenerate the admin manifests
* this updates the label in the generated CRs
* plus it uses different default SA namespace names, so I define the existing ones in the kubesaw-admins.yaml file

related PRs:
* https://github.com/kubesaw/ksctl/pull/69
* https://github.com/kubesaw/ksctl/pull/72