### PR TITLE
Remove of chain deep-inspection config option

### DIFF
--- a/components/pipeline-service/development/main-pipeline-service-configuration.yaml
+++ b/components/pipeline-service/development/main-pipeline-service-configuration.yaml
@@ -1485,7 +1485,6 @@ metadata:
 spec:
   chain:
     artifacts.oci.storage: oci
-    artifacts.pipelinerun.enable-deep-inspection: "true"
     artifacts.pipelinerun.format: in-toto
     artifacts.pipelinerun.storage: oci
     artifacts.taskrun.format: in-toto

--- a/components/pipeline-service/staging/base/main-pipeline-service-configuration.yaml
+++ b/components/pipeline-service/staging/base/main-pipeline-service-configuration.yaml
@@ -1301,7 +1301,6 @@ metadata:
 spec:
   chain:
     artifacts.oci.storage: oci
-    artifacts.pipelinerun.enable-deep-inspection: "true"
     artifacts.pipelinerun.format: in-toto
     artifacts.pipelinerun.storage: oci
     artifacts.taskrun.format: in-toto

--- a/components/pipeline-service/staging/stone-stage-p01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stage-p01/deploy.yaml
@@ -1805,7 +1805,6 @@ metadata:
 spec:
   chain:
     artifacts.oci.storage: oci
-    artifacts.pipelinerun.enable-deep-inspection: "true"
     artifacts.pipelinerun.format: in-toto
     artifacts.pipelinerun.storage: oci
     artifacts.taskrun.format: in-toto

--- a/components/pipeline-service/staging/stone-stg-m01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stg-m01/deploy.yaml
@@ -1805,7 +1805,6 @@ metadata:
 spec:
   chain:
     artifacts.oci.storage: oci
-    artifacts.pipelinerun.enable-deep-inspection: "true"
     artifacts.pipelinerun.format: in-toto
     artifacts.pipelinerun.storage: oci
     artifacts.taskrun.format: in-toto

--- a/components/pipeline-service/staging/stone-stg-rh01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stg-rh01/deploy.yaml
@@ -1805,7 +1805,6 @@ metadata:
 spec:
   chain:
     artifacts.oci.storage: oci
-    artifacts.pipelinerun.enable-deep-inspection: "true"
     artifacts.pipelinerun.format: in-toto
     artifacts.pipelinerun.storage: oci
     artifacts.taskrun.format: in-toto


### PR DESCRIPTION
There is a change in the Tekton operator switching the supported value of Chains' enable-deep-inspection from bool to string ("true"/"false replace true/false). The update of OSP got blocked on some of the clusters because the TektonCOnfig value happened faster than the Catalog update and the actual upgrade. The upgrade was blocked because the old version of the operator does not support the new value in the tektonconfig. As a workaround, we remove that value, let the upgrade finish and in a following PR we switch to the new value.