### PR TITLE
Remove stg-m01 spaceProvisionerConfig

### DIFF
--- a/components/sandbox/toolchain-host-operator/staging/stone-stg-host/space-provisioner-configs.yaml
+++ b/components/sandbox/toolchain-host-operator/staging/stone-stg-host/space-provisioner-configs.yaml
@@ -1,22 +1,6 @@
 apiVersion: toolchain.dev.openshift.com/v1alpha1
 kind: SpaceProvisionerConfig
 metadata:
-  name: member-stone-stg-m01.7ayg.p1.openshiftapps.com
-  namespace: toolchain-host-operator
-  annotations:
-    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
-spec:
-  toolchainCluster: member-stone-stg-m01.7ayg.p1.openshiftapps.com
-  enabled: false
-  capacityThresholds:
-    maxNumberOfSpaces: 1500
-    maxMemoryUtilizationPercent: 90
-  placementRoles:
-  - cluster-role.toolchain.dev.openshift.com/tenant
----
-apiVersion: toolchain.dev.openshift.com/v1alpha1
-kind: SpaceProvisionerConfig
-metadata:
   name: member-stone-stg-rh01.l2vh.p1.openshiftapps.com
   namespace: toolchain-host-operator
   annotations:


### PR DESCRIPTION
All spaces were move from m01 to rh01, remove the possibility to provision new spaces on that cluster.

[KFLUXINFRA-796](https://issues.redhat.com//browse/KFLUXINFRA-796)