### PR TITLE
fix(KFLUXINFRA-836): STAGE: Align MPC image 2 src

### DIFF
--- a/components/multi-platform-controller/base/kustomization.yaml
+++ b/components/multi-platform-controller/base/kustomization.yaml
@@ -11,8 +11,8 @@ resources:
 
 images:
 - name: multi-platform-controller
-  newName: quay.io/mshaposhnik/multi-platform-controller
-  newTag: 8db827ce11627d63bd11d068712776825b703b7a
+  newName: quay.io/konflux-ci/multi-platform-controller
+  newTag: deed3c92266a5c09c7cba3e4d7a305134bce036b
 - name: multi-platform-otp-server
-  newName: quay.io/mshaposhnik/multi-platform-controller-otp-service
-  newTag: 8db827ce11627d63bd11d068712776825b703b7a
+  newName: quay.io/konflux-ci/multi-platform-controller-otp-service
+  newTag: deed3c92266a5c09c7cba3e4d7a305134bce036b


### PR DESCRIPTION
Align the version of the MPC image we're using in STAGE and DEV to the latest MPC source.