### PR TITLE
KFLUXINFRA-837: Changing AWS GPU Instance Type

### DIFF
--- a/components/multi-platform-controller/production-downstream/host-config.yaml
+++ b/components/multi-platform-controller/production-downstream/host-config.yaml
@@ -32,7 +32,7 @@ data:
     linux-c4xlarge/arm64,\
     linux-c8xlarge/amd64,\
     linux-c8xlarge/arm64,\
-    linux-gadxlarge/amd64,\
+    linux-gdnxlarge/amd64,\
     linux-root/arm64,\
     linux-root/amd64,\
     linux/s390x,\
@@ -465,17 +465,17 @@ data:
   host.ibm-gpu-amd64.concurrency: "4"
 
   # AWS GPU Nodes
-  dynamic.linux-gadxlarge-amd64.type: aws
-  dynamic.linux-gadxlarge-amd64.region: us-east-1
-  dynamic.linux-gadxlarge-amd64.ami: ami-026ebd4cfe2c043b2
-  dynamic.linux-gadxlarge-amd64.instance-type: g4ad.xlarge
-  dynamic.linux-gadxlarge-amd64.key-name: konflux-prod-int-mab01
-  dynamic.linux-gadxlarge-amd64.aws-secret: aws-account
-  dynamic.linux-gadxlarge-amd64.ssh-secret: aws-ssh-key
-  dynamic.linux-gadxlarge-amd64.security-group-id: sg-0903aedd465be979e
-  dynamic.linux-gadxlarge-amd64.subnet-id: subnet-0aa719a6c5b602b16
-  dynamic.linux-gadxlarge-amd64.max-instances: "10"
-  dynamic.linux-gadxlarge-amd64.user-data: |-
+  dynamic.linux-gdnxlarge-amd64.type: aws
+  dynamic.linux-gdnxlarge-amd64.region: us-east-1
+  dynamic.linux-gdnxlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-gdnxlarge-amd64.instance-type: g4dn.xlarge
+  dynamic.linux-gdnxlarge-amd64.key-name: konflux-prod-int-mab01
+  dynamic.linux-gdnxlarge-amd64.aws-secret: aws-account
+  dynamic.linux-gdnxlarge-amd64.ssh-secret: aws-ssh-key
+  dynamic.linux-gdnxlarge-amd64.security-group-id: sg-0903aedd465be979e
+  dynamic.linux-gdnxlarge-amd64.subnet-id: subnet-0aa719a6c5b602b16
+  dynamic.linux-gdnxlarge-amd64.max-instances: "10"
+  dynamic.linux-gdnxlarge-amd64.user-data: |-
     Content-Type: multipart/mixed; boundary="//"
     MIME-Version: 1.0
     

--- a/components/multi-platform-controller/production/host-config.yaml
+++ b/components/multi-platform-controller/production/host-config.yaml
@@ -32,7 +32,7 @@ data:
     linux-c4xlarge/arm64,\
     linux-c8xlarge/amd64,\
     linux-c8xlarge/arm64,\
-    linux-gadxlarge/amd64,\
+    linux-gdnxlarge/amd64,\
     linux-root/arm64,\
     linux-root/amd64,\
     linux-fast/amd64,\
@@ -469,17 +469,17 @@ data:
   # dynamic.linux-s390x.private-ip: "false"
 
 # GPU Instances
-  dynamic.linux-gadxlarge-amd64.type: aws
-  dynamic.linux-gadxlarge-amd64.region: us-east-1
-  dynamic.linux-gadxlarge-amd64.ami: ami-026ebd4cfe2c043b2
-  dynamic.linux-gadxlarge-amd64.instance-type: g4ad.xlarge
-  dynamic.linux-gadxlarge-amd64.key-name: konflux-prod-ext-mab01
-  dynamic.linux-gadxlarge-amd64.aws-secret: aws-account
-  dynamic.linux-gadxlarge-amd64.ssh-secret: aws-ssh-key
-  dynamic.linux-gadxlarge-amd64.security-group-id: sg-0fbf35ced0d59fd4a
-  dynamic.linux-gadxlarge-amd64.max-instances: "10"
-  dynamic.linux-gadxlarge-amd64.subnet-id: subnet-0c39ff75f819abfc5
-  dynamic.linux-gadxlarge.user-data: |-
+  dynamic.linux-gdnxlarge-amd64.type: aws
+  dynamic.linux-gdnxlarge-amd64.region: us-east-1
+  dynamic.linux-gdnxlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-gdnxlarge-amd64.instance-type: g4dn.xlarge
+  dynamic.linux-gdnxlarge-amd64.key-name: konflux-prod-ext-mab01
+  dynamic.linux-gdnxlarge-amd64.aws-secret: aws-account
+  dynamic.linux-gdnxlarge-amd64.ssh-secret: aws-ssh-key
+  dynamic.linux-gdnxlarge-amd64.security-group-id: sg-0fbf35ced0d59fd4a
+  dynamic.linux-gdnxlarge-amd64.max-instances: "10"
+  dynamic.linux-gdnxlarge-amd64.subnet-id: subnet-0c39ff75f819abfc5
+  dynamic.linux-gdnxlarge.user-data: |-
     Content-Type: multipart/mixed; boundary="//"
     MIME-Version: 1.0
 

--- a/components/multi-platform-controller/staging-downstream/host-config.yaml
+++ b/components/multi-platform-controller/staging-downstream/host-config.yaml
@@ -32,7 +32,7 @@ data:
     linux-c4xlarge/arm64,\
     linux-c8xlarge/amd64,\
     linux-c8xlarge/arm64,\
-    linux-gadxlarge/amd64,\
+    linux-gdnxlarge/amd64,\
     linux/s390x,\
     linux-root/arm64,\
     linux-root/amd64\
@@ -343,17 +343,17 @@ data:
   host.ibm-gpu-amd64.concurrency: "4"
 
 # GPU Instances
-  dynamic.linux-gadxlarge-amd64.type: aws
-  dynamic.linux-gadxlarge-amd64.region: us-east-1
-  dynamic.linux-gadxlarge-amd64.ami: ami-026ebd4cfe2c043b2
-  dynamic.linux-gadxlarge-amd64.instance-type: g4ad.xlarge
-  dynamic.linux-gadxlarge-amd64.key-name: konflux-stage-int-mab01
-  dynamic.linux-gadxlarge-amd64.aws-secret: aws-account
-  dynamic.linux-gadxlarge-amd64.ssh-secret: aws-ssh-key
-  dynamic.linux-gadxlarge-amd64.security-group-id: sg-0482e8ccae008b240
-  dynamic.linux-gadxlarge-amd64.max-instances: "10"
-  dynamic.linux-gadxlarge-amd64.subnet-id: subnet-07597d1edafa2b9d3
-  dynamic.linux-gadxlarge.user-data: |-
+  dynamic.linux-gdnxlarge-amd64.type: aws
+  dynamic.linux-gdnxlarge-amd64.region: us-east-1
+  dynamic.linux-gdnxlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-gdnxlarge-amd64.instance-type: g4dn.xlarge
+  dynamic.linux-gdnxlarge-amd64.key-name: konflux-stage-int-mab01
+  dynamic.linux-gdnxlarge-amd64.aws-secret: aws-account
+  dynamic.linux-gdnxlarge-amd64.ssh-secret: aws-ssh-key
+  dynamic.linux-gdnxlarge-amd64.security-group-id: sg-0482e8ccae008b240
+  dynamic.linux-gdnxlarge-amd64.max-instances: "10"
+  dynamic.linux-gdnxlarge-amd64.subnet-id: subnet-07597d1edafa2b9d3
+  dynamic.linux-gdnxlarge.user-data: |-
     Content-Type: multipart/mixed; boundary="//"
     MIME-Version: 1.0
 

--- a/components/multi-platform-controller/staging/host-config.yaml
+++ b/components/multi-platform-controller/staging/host-config.yaml
@@ -32,7 +32,7 @@ data:
     linux-c4xlarge/arm64,\
     linux-c8xlarge/amd64,\
     linux-c8xlarge/arm64,\
-    linux-gadxlarge/amd64,\
+    linux-gdnxlarge/amd64,\
     linux-g4xlarge/amd64,\
     linux-root/arm64,\
     linux-root/amd64,\
@@ -315,17 +315,17 @@ data:
   dynamic.linux-s390x.private-ip: "false"
 
 # GPU Instances
-  dynamic.linux-gadxlarge-amd64.type: aws
-  dynamic.linux-gadxlarge-amd64.region: us-east-1
-  dynamic.linux-gadxlarge-amd64.ami: ami-026ebd4cfe2c043b2
-  dynamic.linux-gadxlarge-amd64.instance-type: g4ad.xlarge
-  dynamic.linux-gadxlarge-amd64.key-name: konflux-stage-ext-mab01
-  dynamic.linux-gadxlarge-amd64.aws-secret: aws-account
-  dynamic.linux-gadxlarge-amd64.ssh-secret: aws-ssh-key
-  dynamic.linux-gadxlarge-amd64.security-group-id: sg-05bc8dd0b52158567
-  dynamic.linux-gadxlarge-amd64.max-instances: "10"
-  dynamic.linux-gadxlarge-amd64.subnet-id: subnet-030738beb81d3863a
-  dynamic.linux-gadxlarge.user-data: |-
+  dynamic.linux-gdnxlarge-amd64.type: aws
+  dynamic.linux-gdnxlarge-amd64.region: us-east-1
+  dynamic.linux-gdnxlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-gdnxlarge-amd64.instance-type: g4dn.xlarge
+  dynamic.linux-gdnxlarge-amd64.key-name: konflux-stage-ext-mab01
+  dynamic.linux-gdnxlarge-amd64.aws-secret: aws-account
+  dynamic.linux-gdnxlarge-amd64.ssh-secret: aws-ssh-key
+  dynamic.linux-gdnxlarge-amd64.security-group-id: sg-05bc8dd0b52158567
+  dynamic.linux-gdnxlarge-amd64.max-instances: "10"
+  dynamic.linux-gdnxlarge-amd64.subnet-id: subnet-030738beb81d3863a
+  dynamic.linux-gdnxlarge.user-data: |-
     Content-Type: multipart/mixed; boundary="//"
     MIME-Version: 1.0
 


### PR DESCRIPTION
Changing AWS GPU Instance Type to `g4dn.xlarge`