### PR TITLE
Set cpu/memory request and memory limit for tkn controllers in staging

### DIFF
--- a/components/pipeline-service/staging/base/main-pipeline-service-configuration.yaml
+++ b/components/pipeline-service/staging/base/main-pipeline-service-configuration.yaml
@@ -1562,6 +1562,18 @@ spec:
                       requests:
                         cpu: 200m
                         memory: 200Mi
+        tekton-pipelines-controller:
+          spec:
+            template:
+              spec:
+                containers:
+                  - name: tekton-pipelines-controller
+                    resources:
+                      requests:
+                        memory: 1Gi
+                        cpu: 100m
+                      limits:
+                        memory: 2Gi
       disabled: false
       horizontalPodAutoscalers:
         tekton-operator-proxy-webhook:

--- a/components/pipeline-service/staging/stone-stage-p01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stage-p01/deploy.yaml
@@ -2050,6 +2050,18 @@ spec:
                     requests:
                       cpu: 100m
                       memory: 100Mi
+        tekton-pipelines-controller:
+          spec:
+            template:
+              spec:
+                containers:
+                - name: tekton-pipelines-controller
+                  resources:
+                    limits:
+                      memory: 2Gi
+                    requests:
+                      cpu: 100m
+                      memory: 1Gi
         tekton-pipelines-remote-resolvers:
           spec:
             replicas: 2

--- a/components/pipeline-service/staging/stone-stg-rh01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stg-rh01/deploy.yaml
@@ -2050,6 +2050,18 @@ spec:
                     requests:
                       cpu: 100m
                       memory: 100Mi
+        tekton-pipelines-controller:
+          spec:
+            template:
+              spec:
+                containers:
+                - name: tekton-pipelines-controller
+                  resources:
+                    limits:
+                      memory: 8Gi
+                    requests:
+                      cpu: 500m
+                      memory: 6Gi
         tekton-pipelines-remote-resolvers:
           spec:
             replicas: 2

--- a/components/pipeline-service/staging/stone-stg-rh01/resources/kustomization.yaml
+++ b/components/pipeline-service/staging/stone-stg-rh01/resources/kustomization.yaml
@@ -27,3 +27,4 @@ patches:
       group: external-secrets.io
       version: v1beta1
       kind: ExternalSecret
+  - path: update-tekton-controller-resources.yaml

--- a/components/pipeline-service/staging/stone-stg-rh01/resources/update-tekton-controller-resources.yaml
+++ b/components/pipeline-service/staging/stone-stg-rh01/resources/update-tekton-controller-resources.yaml
@@ -1,0 +1,20 @@
+apiVersion: operator.tekton.dev/v1alpha1
+kind: TektonConfig
+metadata:
+  name: config
+spec:
+  pipeline:
+    options:
+      deployments:
+        tekton-pipelines-controller:
+          spec:
+            template:
+              spec:
+                containers:
+                  - name: tekton-pipelines-controller
+                    resources:
+                      requests:
+                        memory: 6Gi
+                        cpu: 500m
+                      limits:
+                        memory: 8Gi


### PR DESCRIPTION
The tekton-pipelines-controller pod did not have request and limit set and this is causing the pods to be evicted from the nodes where they run in production. Not having request make those pods ideal candidates for eviction and when this happens, it cause a slight outage during restart of the controllers as they need to process the queue of pipeline runs.

Set cpu/memory request and memory limit in staging first, a follow up change will be done for production.

The cpu limit was not set intentionally as setting CPU limit in k8s is not a good idea and even an anti-pattern. Many articles are available out there explaining why but here is one of them[1].

The resources are different for stg-rh01 as we want them to be the same as production to be able to do load testing on that staging cluster.

[1]https://home.robusta.dev/blog/stop-using-cpu-limits

[SRVKP-6410](https://issues.redhat.com//browse/SRVKP-6410)