### PR TITLE
Set cpu/memory request and memory limit for tkn controllers in prod

### DIFF
--- a/components/pipeline-service/production/base/main-pipeline-service-configuration.yaml
+++ b/components/pipeline-service/production/base/main-pipeline-service-configuration.yaml
@@ -1566,6 +1566,18 @@ spec:
                     requests:
                       cpu: 200m
                       memory: 200Mi
+        tekton-pipelines-controller:
+          spec:
+            template:
+              spec:
+                containers:
+                  - name: tekton-pipelines-controller
+                    resources:
+                      requests:
+                        memory: 6Gi
+                        cpu: "1"
+                      limits:
+                        memory: 8Gi
       disabled: false
       horizontalPodAutoscalers:
         tekton-operator-proxy-webhook:

--- a/components/pipeline-service/production/stone-prd-m01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prd-m01/deploy.yaml
@@ -2043,6 +2043,18 @@ spec:
                     requests:
                       cpu: 100m
                       memory: 100Mi
+        tekton-pipelines-controller:
+          spec:
+            template:
+              spec:
+                containers:
+                - name: tekton-pipelines-controller
+                  resources:
+                    limits:
+                      memory: 8Gi
+                    requests:
+                      cpu: "1"
+                      memory: 6Gi
         tekton-pipelines-remote-resolvers:
           spec:
             replicas: 1

--- a/components/pipeline-service/production/stone-prd-rh01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prd-rh01/deploy.yaml
@@ -2043,6 +2043,18 @@ spec:
                     requests:
                       cpu: 100m
                       memory: 100Mi
+        tekton-pipelines-controller:
+          spec:
+            template:
+              spec:
+                containers:
+                - name: tekton-pipelines-controller
+                  resources:
+                    limits:
+                      memory: 8Gi
+                    requests:
+                      cpu: "1"
+                      memory: 6Gi
         tekton-pipelines-remote-resolvers:
           spec:
             replicas: 1

--- a/components/pipeline-service/production/stone-prod-p01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prod-p01/deploy.yaml
@@ -2043,6 +2043,18 @@ spec:
                     requests:
                       cpu: 100m
                       memory: 100Mi
+        tekton-pipelines-controller:
+          spec:
+            template:
+              spec:
+                containers:
+                - name: tekton-pipelines-controller
+                  resources:
+                    limits:
+                      memory: 8Gi
+                    requests:
+                      cpu: "1"
+                      memory: 6Gi
         tekton-pipelines-remote-resolvers:
           spec:
             replicas: 1

--- a/components/pipeline-service/production/stone-prod-p02/deploy.yaml
+++ b/components/pipeline-service/production/stone-prod-p02/deploy.yaml
@@ -2043,6 +2043,18 @@ spec:
                     requests:
                       cpu: 100m
                       memory: 100Mi
+        tekton-pipelines-controller:
+          spec:
+            template:
+              spec:
+                containers:
+                - name: tekton-pipelines-controller
+                  resources:
+                    limits:
+                      memory: 8Gi
+                    requests:
+                      cpu: "1"
+                      memory: 6Gi
         tekton-pipelines-remote-resolvers:
           spec:
             replicas: 1

--- a/components/pipeline-service/staging/stone-stg-rh01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stg-rh01/deploy.yaml
@@ -2060,7 +2060,7 @@ spec:
                     limits:
                       memory: 8Gi
                     requests:
-                      cpu: 500m
+                      cpu: "1"
                       memory: 6Gi
         tekton-pipelines-remote-resolvers:
           spec:

--- a/components/pipeline-service/staging/stone-stg-rh01/resources/update-tekton-controller-resources.yaml
+++ b/components/pipeline-service/staging/stone-stg-rh01/resources/update-tekton-controller-resources.yaml
@@ -15,6 +15,6 @@ spec:
                     resources:
                       requests:
                         memory: 6Gi
-                        cpu: 500m
+                        cpu: "1"
                       limits:
                         memory: 8Gi


### PR DESCRIPTION
The tekton-pipelines-controller pod did not have request and limit set and this is causing the pods to be evicted from the nodes where they run in production. Not having request make those pods ideal candidates for eviction and when this happens, it cause a slight outage during restart of the controllers as they need to process the queue of pipeline runs.

The cpu limit was not set intentionally as setting CPU limit in k8s is not a good idea and even an anti-pattern. Many articles are available out there explaining why but here is one of them[1].

This commit is a follow up of this commit[2] where the same was changed but for staging.

[1] https://home.robusta.dev/blog/stop-using-cpu-limits
[2] 90ee9cb7a3ce13e58e53a695f48c53597649c350

[SRVKP-6410](https://issues.redhat.com//browse/SRVKP-6410)