### PR TITLE
feat(KONFLUX-4508): Expose metrics for Pipelines leases distribution alerts

### DIFF
--- a/components/monitoring/prometheus/base/monitoringstack/monitoringstack.yaml
+++ b/components/monitoring/prometheus/base/monitoringstack/monitoringstack.yaml
@@ -49,7 +49,8 @@ spec:
           storageclass|volumename|release_reason|instance|result|deployment_reason|\
           validation_reason|strategy|succeeded|target|name|method|code|sp|le|\
           unexpected_status|failure|hostname|label_app_kubernetes_io_managed_by|status|\
-          pipeline|pipelinename|pipelinerun|schedule|check|grpc_service|grpc_code"
+          pipeline|pipelinename|pipelinerun|schedule|check|grpc_service|grpc_code|\
+          lease|lease_holder"
 ---
 # Grant permission to Federate In-Cluster Prometheus
 apiVersion: rbac.authorization.k8s.io/v1
@@ -113,6 +114,7 @@ spec:
         - '{__name__="grpc_server_handling_seconds_bucket", namespace=~"tekton-results|openshift-pipelines"}'
         - '{__name__="controller_runtime_reconcile_errors_total", namespace!~".*-tenant|openshift-.*|kube-.*"}'
         - '{__name__="controller_runtime_reconcile_total", namespace!~".*-tenant|openshift-.*|kube-.*"}'
+        - '{__name__="kube_lease_owner", namespace="openshift-pipelines", lease=~"tekton-pipelines-controller.github.com.tektoncd.pipeline.pkg.reconciler..*"}'
         - '{__name__="kube_pod_status_unschedulable", namespace!~".*-tenant|openshift-.*|kube-.*"}'
         - '{__name__="kube_pod_container_status_restarts_total", namespace=~"openshift-pipelines|release-service"}'
         - '{__name__="kube_pod_container_status_waiting_reason", namespace!~".*-tenant|openshift-.*|kube-.*"}'


### PR DESCRIPTION
This is a dependency of https://github.com/redhat-appstudio/o11y/pull/388

Regarding how many labels combinations this mean, on `stone-stg-rh01` during last week I see 51. There are actually only 2 labels that change over time:

* `lease` - if we do not reconfigure Tekton Pipelines Controller to use different buckets count, there will be just 4 of these for every reconciler (so 12)
* `lease_holder` - this is a Pipelines Controller pod identification, so every time that pod restarts or so, new label value appears here (these pods are supposed to be stable, always running and restarts will be matter of upgrades or signs of cluster issues)