### PR TITLE
chore(RHTAPWATCH-1267): Update quay repository for project-controller

### DIFF
--- a/components/project-controller/development/kustomization.yaml
+++ b/components/project-controller/development/kustomization.yaml
@@ -2,11 +2,11 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - ../base
-- https://github.com/konflux-ci/project-controller/config/default?ref=6773b77f353cc019166754ecd4d563035968019c
+- https://github.com/konflux-ci/project-controller/config/default?ref=de7482473d739d0037f42ef0c81504920fa1f286
 
 images:
 - name: konflux-project-controller
-  newName: quay.io/redhat-appstudio/project-controller
-  newTag: 6773b77f353cc019166754ecd4d563035968019c
+  newName: quay.io/konflux-ci/project-controller
+  newTag: de7482473d739d0037f42ef0c81504920fa1f286
 
 namespace: project-controller

--- a/components/project-controller/staging/kustomization.yaml
+++ b/components/project-controller/staging/kustomization.yaml
@@ -2,11 +2,11 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../base
-  - https://github.com/konflux-ci/project-controller/config/default?ref=6773b77f353cc019166754ecd4d563035968019c
+  - https://github.com/konflux-ci/project-controller/config/default?ref=de7482473d739d0037f42ef0c81504920fa1f286
 
 images:
 - name: konflux-project-controller
-  newName: quay.io/redhat-appstudio/project-controller
-  newTag: 6773b77f353cc019166754ecd4d563035968019c
+  newName: quay.io/konflux-ci/project-controller
+  newTag: de7482473d739d0037f42ef0c81504920fa1f286
 
 namespace: project-controller


### PR DESCRIPTION
Update project-controller quay repository to change to konflux-ci organization from redhat-appstudio.

Jira-Url: https://issues.redhat.com/browse/RHTAPWATCH-1267