### PR TITLE
Increase tekton results memory

### DIFF
--- a/components/pipeline-service/production/base/main-pipeline-service-configuration.yaml
+++ b/components/pipeline-service/production/base/main-pipeline-service-configuration.yaml
@@ -1259,10 +1259,10 @@ spec:
         resources:
           limits:
             cpu: 250m
-            memory: 6Gi
+            memory: 8Gi
           requests:
             cpu: 250m
-            memory: 6Gi
+            memory: 8Gi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/components/pipeline-service/production/stone-prd-m01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prd-m01/deploy.yaml
@@ -1643,10 +1643,10 @@ spec:
         resources:
           limits:
             cpu: 250m
-            memory: 6Gi
+            memory: 8Gi
           requests:
             cpu: 250m
-            memory: 6Gi
+            memory: 8Gi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/components/pipeline-service/production/stone-prd-rh01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prd-rh01/deploy.yaml
@@ -1643,10 +1643,10 @@ spec:
         resources:
           limits:
             cpu: 250m
-            memory: 6Gi
+            memory: 8Gi
           requests:
             cpu: 250m
-            memory: 6Gi
+            memory: 8Gi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/components/pipeline-service/production/stone-prod-p01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prod-p01/deploy.yaml
@@ -1643,10 +1643,10 @@ spec:
         resources:
           limits:
             cpu: 250m
-            memory: 6Gi
+            memory: 8Gi
           requests:
             cpu: 250m
-            memory: 6Gi
+            memory: 8Gi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/components/pipeline-service/production/stone-prod-p02/deploy.yaml
+++ b/components/pipeline-service/production/stone-prod-p02/deploy.yaml
@@ -1643,10 +1643,10 @@ spec:
         resources:
           limits:
             cpu: 250m
-            memory: 6Gi
+            memory: 8Gi
           requests:
             cpu: 250m
-            memory: 6Gi
+            memory: 8Gi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/components/pipeline-service/staging/base/main-pipeline-service-configuration.yaml
+++ b/components/pipeline-service/staging/base/main-pipeline-service-configuration.yaml
@@ -1262,10 +1262,10 @@ spec:
           resources:
             limits:
               cpu: 250m
-              memory: 4Gi
+              memory: 8Gi
             requests:
               cpu: 250m
-              memory: 4Gi
+              memory: 8Gi
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/components/pipeline-service/staging/stone-stage-p01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stage-p01/deploy.yaml
@@ -1646,10 +1646,10 @@ spec:
         resources:
           limits:
             cpu: 250m
-            memory: 4Gi
+            memory: 8Gi
           requests:
             cpu: 250m
-            memory: 4Gi
+            memory: 8Gi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -2063,12 +2063,12 @@ spec:
                       cpu: 100m
                       memory: 1Gi
                 topologySpreadConstraints:
-                  - maxSkew: 1
-                    topologyKey: topology.kubernetes.io/zone
-                    whenUnsatisfiable: DoNotSchedule
-                    labelSelector:
-                      matchLabels:
-                        app: tekton-pipelines-controller
+                - labelSelector:
+                    matchLabels:
+                      app: tekton-pipelines-controller
+                  maxSkew: 1
+                  topologyKey: topology.kubernetes.io/zone
+                  whenUnsatisfiable: DoNotSchedule
         tekton-pipelines-remote-resolvers:
           spec:
             replicas: 2

--- a/components/pipeline-service/staging/stone-stg-rh01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stg-rh01/deploy.yaml
@@ -1646,10 +1646,10 @@ spec:
         resources:
           limits:
             cpu: 250m
-            memory: 4Gi
+            memory: 8Gi
           requests:
             cpu: 250m
-            memory: 4Gi
+            memory: 8Gi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -2063,12 +2063,12 @@ spec:
                       cpu: "1"
                       memory: 6Gi
                 topologySpreadConstraints:
-                  - maxSkew: 1
-                    topologyKey: topology.kubernetes.io/zone
-                    whenUnsatisfiable: DoNotSchedule
-                    labelSelector:
-                      matchLabels:
-                        app: tekton-pipelines-controller
+                - labelSelector:
+                    matchLabels:
+                      app: tekton-pipelines-controller
+                  maxSkew: 1
+                  topologyKey: topology.kubernetes.io/zone
+                  whenUnsatisfiable: DoNotSchedule
         tekton-pipelines-remote-resolvers:
           spec:
             replicas: 2


### PR DESCRIPTION
In production, on rh01, the container got OOMKilled. Increase from 6 to 8 and also set staging to same values. We want staging to be a mirror of prod.