### PR TITLE
add workspaces.konflux-ci.dev to view-appstudio ClusterRole

### DIFF
--- a/components/authentication/base/everyone-can-view.yaml
+++ b/components/authentication/base/everyone-can-view.yaml
@@ -4,6 +4,14 @@ metadata:
   name: view-appstudio
 rules:
 - apiGroups:
+  - workspaces.konflux-ci.dev
+  resources:
+  - internalworkspaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - appstudio.redhat.com
   resources:
   - applications


### PR DESCRIPTION
This PR adds `get`, `list`, and `watch` permissions for InternalWorkspaces to anyone having the `view-appstudio` role