### PR TITLE
Update MintMaker to use rpm-lockfile script v0.9.0

### DIFF
--- a/components/mintmaker/production/base/manager_patches.yaml
+++ b/components/mintmaker/production/base/manager_patches.yaml
@@ -17,4 +17,4 @@ spec:
             memory: 256Mi
         env:
         - name: RENOVATE_IMAGE
-          value: "quay.io/konflux-ci/mintmaker-renovate-image:e8ede3a"
+          value: "quay.io/konflux-ci/mintmaker-renovate-image:2b2655d"


### PR DESCRIPTION
This commit updates MintMaker to use the latest image, which includes an update to the rpm-lockfile script.