### PR TITLE
Fix SIGNALFX_API_KEY variable name mismatch

### DIFF
--- a/components/tracing/otel-collector/production/otel-collector-helm-values.yaml
+++ b/components/tracing/otel-collector/production/otel-collector-helm-values.yaml
@@ -2,12 +2,12 @@ config:
   exporters:
     sapm:
       endpoint: "https://ingest.us1.signalfx.com/v2/trace"
-      access_token: ${env:SIGNALFX_ACCESS_TOKEN}
+      access_token: ${env:SIGNALFX_API_TOKEN}
     signalfx:
       endpoint: "https://api.signalfx.com/v2/traces"
       realm: "us1"
       api_url: "https://api.us1.signalfx.com"
-      access_token: ${env:SIGNALFX_ACCESS_TOKEN} 
+      access_token: ${env:SIGNALFX_API_TOKEN} 
   extensions:
     # The health_check extension is mandatory for this chart.
     # Without the health_check extension the collector will fail the readiness and liveliness probes.

--- a/components/tracing/otel-collector/staging/otel-collector-helm-values.yaml
+++ b/components/tracing/otel-collector/staging/otel-collector-helm-values.yaml
@@ -2,12 +2,12 @@ config:
   exporters:
     sapm:
       endpoint: "https://ingest.us1.signalfx.com/v2/trace"
-      access_token: ${env:SIGNALFX_ACCESS_TOKEN}
+      access_token: ${env:SIGNALFX_API_TOKEN}
     signalfx:
       endpoint: "https://api.signalfx.com/v2/traces"
       realm: "us1"
       api_url: "https://api.us1.signalfx.com"
-      access_token: ${env:SIGNALFX_ACCESS_TOKEN} 
+      access_token: ${env:SIGNALFX_API_TOKEN} 
   extensions:
     # The health_check extension is mandatory for this chart.
     # Without the health_check extension the collector will fail the readiness and liveliness probes.


### PR DESCRIPTION
A mismatch in variable names is causing a deployment failure of the Otel collector; this fixes that issue.