### PR TITLE
OTel - Remove logging from list of exporters in the pipeline

### DIFF
--- a/components/tracing/otel-collector/production/otel-collector-helm-values.yaml
+++ b/components/tracing/otel-collector/production/otel-collector-helm-values.yaml
@@ -52,7 +52,6 @@ config:
       traces:
         exporters:
           - debug
-          - logging
           - sapm
           - signalfx
         processors:

--- a/components/tracing/otel-collector/staging/otel-collector-helm-values.yaml
+++ b/components/tracing/otel-collector/staging/otel-collector-helm-values.yaml
@@ -52,7 +52,6 @@ config:
       traces:
         exporters:
           - debug
-          - logging
           - sapm
           - signalfx
         processors:


### PR DESCRIPTION
This fixes a config issue preventing the start of the collector.