### PR TITLE
kubesaw: add network policy for in-namespace communication

### DIFF
--- a/components/sandbox/toolchain-host-operator/production/stone-prod-p02/network-policy.yaml
+++ b/components/sandbox/toolchain-host-operator/production/stone-prod-p02/network-policy.yaml
@@ -16,3 +16,16 @@ spec:
             kubernetes.io/metadata.name: rhtap-ui
   policyTypes:
     - Ingress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-from-same-namespace
+  namespace: toolchain-host-operator
+spec:
+  ingress:
+  - from:
+    - podSelector: {}
+  podSelector: {}
+  policyTypes:
+  - Ingress

--- a/components/sandbox/toolchain-host-operator/staging/stone-stage-p01/network-policy.yaml
+++ b/components/sandbox/toolchain-host-operator/staging/stone-stage-p01/network-policy.yaml
@@ -16,3 +16,16 @@ spec:
             kubernetes.io/metadata.name: rhtap-ui
   policyTypes:
     - Ingress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-from-same-namespace
+  namespace: toolchain-host-operator
+spec:
+  ingress:
+  - from:
+    - podSelector: {}
+  podSelector: {}
+  policyTypes:
+  - Ingress


### PR DESCRIPTION
Host operator needs to talk to registration-service to check health endpoints to set the status of the toolchainstatus resource.  However, since there are network policies defined on registration service, host-operator is disallowed from making network connections to registration-service, causing the toolchainstatus resource to report that registration service was unavailable.

To fix this, we need a network that allows pods within toolchain-host-operator to talk with each other.  This policy was already defined on the external clusters and the p01 internal cluster, but not on the others.
