### PR TITLE
Fix for nvme disk configuration service

### DIFF
--- a/configs/nvme-storage-configurator/base/nvme-storage.service
+++ b/configs/nvme-storage-configurator/base/nvme-storage.service
@@ -9,7 +9,7 @@ Type=oneshot
 RemainAfterExit=yes
 StandardOutput=tty
 StandardError=tty
-ExecStart=/usr/local/bin/configuration.sh
+ExecStart=/usr/local/bin/mount.sh
 
 [Install]
 RequiredBy=local-fs.target


### PR DESCRIPTION
NVME Disk Configuration Service was pointing to incorrect script. We have fixed that by poiting it to `mount.sh`. We have also hard coded the nvme device name `/dev/nvme1n1`