### PR TITLE
Change KubeArchive namespace because of ROSA

### DIFF
--- a/argo-cd-apps/base/member/infra-deployments/kubearchive/kubearchive.yaml
+++ b/argo-cd-apps/base/member/infra-deployments/kubearchive/kubearchive.yaml
@@ -26,7 +26,9 @@ spec:
         repoURL: https://github.com/redhat-appstudio/infra-deployments.git
         targetRevision: main
       destination:
-        namespace: kubearchive
+        # This is the default namespace if resources or kustomziation.yaml do
+        # not specifcy namespace
+        namespace: product-kubearchive
         server: '{{server}}'
       syncPolicy:
         automated:

--- a/components/authentication/base/everyone-can-view-patch.yaml
+++ b/components/authentication/base/everyone-can-view-patch.yaml
@@ -50,3 +50,6 @@
     - kind: Group
       apiGroup: rbac.authorization.k8s.io
       name: 'konflux-release-team'
+    - kind: Group
+      apiGroup: rbac.authorization.k8s.io
+      name: 'konflux-kubearchive'

--- a/components/kubearchive/base/kustomization.yaml
+++ b/components/kubearchive/base/kustomization.yaml
@@ -4,11 +4,75 @@ kind: Kustomization
 resources:
 - https://github.com/kubearchive/kubearchive/releases/download/v0.1.0/kubearchive.yaml?timeout=90
 - rbac.yaml
-namespace: kubearchive
+
+# ROSA does not support namespaces starting with `kube`
+namespace: product-kubearchive
+
+
+patches:
+# These patches changes some resources that point directly to
+# the 'kubearchive' namespace in their function.
+- patch: |-
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      name: kubearchive-operator-leader-election
+    subjects:
+    - kind: ServiceAccount
+      name: kubearchive-operator
+      namespace: product-kubearchive
+- patch: |-
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      name: kubearchive-api-server
+    subjects:
+    - kind: ServiceAccount
+      name: kubearchive-api-server
+      namespace: product-kubearchive
+- patch: |-
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      name: kubearchive-operator
+    subjects:
+    - kind: ServiceAccount
+      name: kubearchive-operator
+      namespace: product-kubearchive
+- patch: |-
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      name: kubearchive-operator-proxy
+    subjects:
+    - kind: ServiceAccount
+      name: kubearchive-operator
+      namespace: product-kubearchive
+- patch: |-
+    apiVersion: admissionregistration.k8s.io/v1
+    kind: MutatingWebhookConfiguration
+    metadata:
+      name: kubearchive-mutating-webhook-configuration
+    webhooks:
+    - name: mkubearchiveconfig.kb.io
+      clientConfig:
+        service:
+          name: kubearchive-operator-webhooks
+          namespace: product-kubearchive
+- patch: |-
+    apiVersion: admissionregistration.k8s.io/v1
+    kind: ValidatingWebhookConfiguration
+    metadata:
+      name: kubearchive-validating-webhook-configuration
+    webhooks:
+    - name: vkubearchiveconfig.kb.io
+      clientConfig:
+        service:
+          name: kubearchive-operator-webhooks
+          namespace: product-kubearchive
 
 # These patches add an annotation so an OpenShift service
 # creates the TLS secrets instead of Cert Manager
-patches:
 - patch: |-
     apiVersion: v1
     kind: Service
@@ -16,7 +80,6 @@ patches:
       name: kubearchive-api-server
       annotations:
         service.beta.openshift.io/serving-cert-secret-name: kubearchive-api-server-tls
-
 - patch: |-
     apiVersion: v1
     kind: Service
@@ -25,6 +88,7 @@ patches:
       annotations:
         service.beta.openshift.io/serving-cert-secret-name: kubearchive-operator-tls
 
+# These patches solve Kube Linter problems
 - patch: |-
     apiVersion: apps/v1
     kind: Deployment
@@ -45,7 +109,6 @@ patches:
               securityContext:
                 readOnlyRootFilesystem: true
                 runAsNonRoot: true
-
 - patch: |-
     apiVersion: apps/v1
     kind: Deployment
@@ -65,7 +128,6 @@ patches:
               securityContext:
                 readOnlyRootFilesystem: true
                 runAsNonRoot: true
-
 - patch: |-
     apiVersion: apps/v1
     kind: Deployment
@@ -87,7 +149,7 @@ patches:
                 readOnlyRootFilesystem: true
                 runAsNonRoot: true
 
-# Remove Certificates and Issuer
+# These patches remove Certificates and Issuer from Cert-Manager
 - patch: |-
     $patch: delete
     apiVersion: cert-manager.io/v1

--- a/components/kubearchive/development/kustomization.yaml
+++ b/components/kubearchive/development/kustomization.yaml
@@ -4,8 +4,6 @@ resources:
 - ../base
 - postgresql.yaml
 
-namespace: kubearchive
-
 secretGenerator:
 - behavior: merge
   literals:

--- a/components/kubearchive/staging/kustomization.yaml
+++ b/components/kubearchive/staging/kustomization.yaml
@@ -4,7 +4,5 @@ resources:
   - ../base
   - database-secret.yaml
 
-namespace: kubearchive
-
 commonAnnotations:
   argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true


### PR DESCRIPTION
This PR aims to change the namespace of KubeArchive because ROSA does not support namespaces for applications that are `kube.*`, which matches `kubearchive`. I changed it to be `product-kubearchive` given that we don't have any other name and I didn't want to use our shorthand (`k9e`). I tested it on CRC with the `prepare-crc.sh` script and then the `bootstrap-cluster.sh preview`.