### PR TITLE
Allow app-sre vault access from kubearchive namespace

### DIFF
--- a/components/cluster-secret-store/base/appsre-vault-secret-store.yml
+++ b/components/cluster-secret-store/base/appsre-vault-secret-store.yml
@@ -30,3 +30,4 @@ spec:
         - tekton-results
         - gitops
         - openshift-adp
+        - product-kubearchive


### PR DESCRIPTION
Kubearchive need this access to retrieve RDS instances secret.