### PR TITLE
Fix kubearchive database secret extraction

### DIFF
--- a/components/kubearchive/staging/database-secret.yaml
+++ b/components/kubearchive/staging/database-secret.yaml
@@ -20,7 +20,7 @@ spec:
     template:
       data:
         POSTGRES_PORT: "5432"
-        POSTGRES_URL: "{{ .db.host }}"
-        POSTGRES_PASSWORD: "{{ .db.password }}"
-        POSTGRES_USER: "{{ .db.user }}"
-        POSTGRES_DATABASE: "{{ .db.name }}"
+        POSTGRES_URL: '{{ index . "db.host" }}'
+        POSTGRES_PASSWORD: '{{ index . "db.password" }}'
+        POSTGRES_USER: '{{ index . "db.user" }}'
+        POSTGRES_DATABASE: '{{ index . "db.name" }}'


### PR DESCRIPTION
ExternalSecret are using go templates when using template to create the target secret. If the key to access contains a dot (e.g. db.user), we must use an index function to access it otherwise is is looking for an object(db) containing another object (user).