### PR TITLE
Fix DB secret name for KubeArchive

### DIFF
--- a/components/kubearchive/staging/database-secret.yaml
+++ b/components/kubearchive/staging/database-secret.yaml
@@ -16,7 +16,7 @@ spec:
   target:
     creationPolicy: Owner
     deletionPolicy: Delete
-    name: kubearchive-database-secret
+    name: kubearchive-database-credentials
     template:
       data:
         POSTGRES_PORT: "5432"


### PR DESCRIPTION
This PR changes the name of the Secret created by ExternalSecret to the correct one. It needs to be called `kubearchive-database-credentials` not `kubearchive-database-secret`.