### PR TITLE
Fix DB secret keys for KubeArchive

### DIFF
--- a/components/kubearchive/staging/database-secret.yaml
+++ b/components/kubearchive/staging/database-secret.yaml
@@ -23,4 +23,4 @@ spec:
         POSTGRES_URL: '{{ index . "db.host" }}'
         POSTGRES_PASSWORD: '{{ index . "db.password" }}'
         POSTGRES_USER: '{{ index . "db.user" }}'
-        POSTGRES_DATABASE: '{{ index . "db.name" }}'
+        POSTGRES_DB: '{{ index . "db.name" }}'


### PR DESCRIPTION
A key for the KubeArchive's DB secret was wrong, sorry about the multiple PRs.