### PR TITLE
Use MCE provided images for the hypershift CLI

### DIFF
--- a/components/cluster-as-a-service/base/clustertemplates.yaml
+++ b/components/cluster-as-a-service/base/clustertemplates.yaml
@@ -36,7 +36,7 @@ spec:
       source:
         chart: hypershift-aws-template
         repoURL: https://konflux-ci.dev/cluster-template-charts/
-        targetRevision: 0.1.0
+        targetRevision: 0.1.1
         helm:
           parameters:
             - name: region

--- a/components/cluster-as-a-service/development/add-hypershift-params.yaml
+++ b/components/cluster-as-a-service/development/add-hypershift-params.yaml
@@ -8,8 +8,8 @@
 - op: add
   path: /spec/template/spec/source/helm/parameters/-
   value:
-    name: hypershiftImageTag
-    value: "4.16"
+    name: hypershiftImage
+    value: registry.redhat.io/multicluster-engine/hypershift-rhel9-operator:v2.6
 
 - op: add
   path: /spec/template/spec/source/helm/parameters/-

--- a/components/cluster-as-a-service/production/add-hypershift-params.yaml
+++ b/components/cluster-as-a-service/production/add-hypershift-params.yaml
@@ -8,8 +8,8 @@
 - op: add
   path: /spec/template/spec/source/helm/parameters/-
   value:
-    name: hypershiftImageTag
-    value: "4.16"
+    name: hypershiftImage
+    value: registry.redhat.io/multicluster-engine/hypershift-rhel9-operator:v2.6
 
 - op: add
   path: /spec/template/spec/source/helm/parameters/-

--- a/components/cluster-as-a-service/staging/add-hypershift-params.yaml
+++ b/components/cluster-as-a-service/staging/add-hypershift-params.yaml
@@ -8,8 +8,8 @@
 - op: add
   path: /spec/template/spec/source/helm/parameters/-
   value:
-    name: hypershiftImageTag
-    value: "4.16"
+    name: hypershiftImage
+    value: registry.redhat.io/multicluster-engine/hypershift-rhel9-operator:v2.6
 
 - op: add
   path: /spec/template/spec/source/helm/parameters/-


### PR DESCRIPTION
The previously used image repo unexpectedly removed tags for OCP versions. The MCE operator provides its own HO image which should provide better guarantees of compatibility since the image tag corresponds to the version of MCE deployed.