### PR TITLE
feat(RELEASE-1192): allow rhtap-releng to use es

### DIFF
--- a/components/cluster-secret-store/base/appsre-stonesoup-vault-secret-store.yaml
+++ b/components/cluster-secret-store/base/appsre-stonesoup-vault-secret-store.yaml
@@ -59,5 +59,6 @@ spec:
         - notification-controller
         - rhtap-integration-tenant
         - rhtap-release-2-tenant
-          
+        - rhtap-releng-tenant
+
 


### PR DESCRIPTION
- this allows ExternalSecrets to work in the rhtap-releng-tenant