### PR TITLE
Backup all resources in toolchain member namespace

### DIFF
--- a/components/backup/base/member/schedules/backup-toolchain-member-schedule.yaml
+++ b/components/backup/base/member/schedules/backup-toolchain-member-schedule.yaml
@@ -7,9 +7,8 @@ metadata:
 spec:
   schedule: 30 1,13 * * * # every day 1:30, 13:30 UTC
   template:
-    includedResources:
-      - spacebindingrequests.toolchain.dev.openshift.com
-      - spacerequests.toolchain.dev.openshift.com
+    includedNamespaces:
+      - toolchain-member-operator
     storageLocation: velero-aws-1
     ttl: 720h0m0s
   useOwnerReferencesInBackup: true


### PR DESCRIPTION
Backing up a list of resources can lead to incomplete backup, e.g. if a CRD is added without updating the back up list.

To be on the safe side, change the backup to include all resources in toolchain-member-operator and restore procedure will explicitly mention which resources to restore. Doing it that way will cost a bit more on the AWS storage but has the huge advantage of covering the case of CRD being added later. Backup will include it and restore procedure might not but can be adjusted when restore is performed.

[KFLUXINFRA-730](https://issues.redhat.com//browse/KFLUXINFRA-730)