### PR TITLE
fix: increase release controller memory

### DIFF
--- a/components/release/k-components/manager-resources-patch/manager_resources_patch.yaml
+++ b/components/release/k-components/manager-resources-patch/manager_resources_patch.yaml
@@ -11,7 +11,7 @@ spec:
         resources:
           limits:
             cpu: 500m
-            memory: 2048Mi
+            memory: 4096Mi
           requests:
             cpu: 100m
-            memory: 1024Mi
+            memory: 3072Mi


### PR DESCRIPTION
Increasing memory limits for the release-service controller.

![image](https://github.com/user-attachments/assets/a138aa54-a32a-42fc-9dbb-4acca65ffcc2)


Signed-off-by: Leandro Mendes <lmendes@redhat.com>