### PR TITLE
KFLUXINFRA-799: adjusted tenant name for insights

### DIFF
--- a/components/cluster-secret-store/base/insights-secret-store.yaml
+++ b/components/cluster-secret-store/base/insights-secret-store.yaml
@@ -27,4 +27,4 @@ spec:
             namespace: appsre-vault
   conditions:
     - namespaces:
-        - insights-management
+        - insights-management-tenant


### PR DESCRIPTION
Fixing the wrong tenant name for a cluster secret defined in https://github.com/redhat-appstudio/infra-deployments/pull/4677