### PR TITLE
fix(KONFLUX-4955): Update cluster monitoring permission for Perf-Monitoring Service Account

### DIFF
--- a/components/perf-team-prometheus-reader/base/serviceaccount.yaml
+++ b/components/perf-team-prometheus-reader/base/serviceaccount.yaml
@@ -1,27 +1,20 @@
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: perf-team-prometheus-reader-read-openshift-monitoring
-rules:
-  - apiGroups: [""]
-    resources: ["namespaces"]
-    verbs: ["get", "list", "watch"]
----
+
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: perf-team-prometheus-reader-cluster-sa
   namespace: perf-team-prometheus-reader
 ---
+# Grant permission to Federate In-Cluster Prometheus
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: sa-read-permissions-openshift-monitoring
 subjects:
-  - kind: ServiceAccount
-    name: perf-team-prometheus-reader-cluster-sa
-    namespace: perf-team-prometheus-reader
+- kind: ServiceAccount
+  name: perf-team-prometheus-reader-cluster-sa
+  namespace: perf-team-prometheus-reader
 roleRef:
-  kind: ClusterRole
-  name: perf-team-prometheus-reader-read-openshift-monitoring
   apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-monitoring-view


### PR DESCRIPTION
### Description

This PR updates cluster permission of service account `perf-team-prometheus-reader-cluster-sa` in order to access Thanos Querier API.

Fix is based on the solution: https://access.redhat.com/solutions/5151831




 