### PR TITLE
Revert "Move cachi2 pipelines from tekton-ci to konflux-ci (#4618)"

### DIFF
--- a/components/konflux-ci/base/repository.yaml
+++ b/components/konflux-ci/base/repository.yaml
@@ -23,13 +23,6 @@ spec:
 apiVersion: pipelinesascode.tekton.dev/v1alpha1
 kind: Repository
 metadata:
-  name: cachi2
-spec:
-  url: "https://github.com/containerbuildsystem/cachi2"
----
-apiVersion: pipelinesascode.tekton.dev/v1alpha1
-kind: Repository
-metadata:
   name: quality-dashboard
 spec:
   url: "https://github.com/konflux-ci/quality-dashboard"

--- a/components/tekton-ci/base/repository.yaml
+++ b/components/tekton-ci/base/repository.yaml
@@ -37,6 +37,13 @@ spec:
 apiVersion: pipelinesascode.tekton.dev/v1alpha1
 kind: Repository
 metadata:
+  name: cachi2
+spec:
+  url: "https://github.com/containerbuildsystem/cachi2"
+---
+apiVersion: pipelinesascode.tekton.dev/v1alpha1
+kind: Repository
+metadata:
   name: infra-deployments
 spec:
   url: "https://github.com/redhat-appstudio/infra-deployments"


### PR DESCRIPTION
This reverts commit 3076d38f801845b322d9d14bc01584659c531014.

We don't have all the pieces needed in place yet and the change in question would break cachi2's release process. Revert the change until cachi2 is truly ready to make the change. This unblocks release of cachi2 which is pending.