### PR TITLE
KFLUXINFRA-799: Fixing Role ID for Insights Vault App Role

### DIFF
--- a/components/cluster-secret-store/production/insights-approle-id-patch.yaml
+++ b/components/cluster-secret-store/production/insights-approle-id-patch.yaml
@@ -1,4 +1,4 @@
 ---
 - op: add
   path: /spec/provider/vault/auth/appRole/roleId
-  value: 573e6024-0c58-7e95-365b-d2ad6127e838
+  value: dbbc1114-ba0e-38c4-fbf7-ce0cad753509

--- a/components/cluster-secret-store/staging/insights-approle-id-patch.yaml
+++ b/components/cluster-secret-store/staging/insights-approle-id-patch.yaml
@@ -1,4 +1,4 @@
 ---
 - op: add
   path: /spec/provider/vault/auth/appRole/roleId
-  value: 573e6024-0c58-7e95-365b-d2ad6127e838
+  value: dbbc1114-ba0e-38c4-fbf7-ce0cad753509


### PR DESCRIPTION
Changing Role ID for Insights Vault App Role to authenticate to external vault instance. 