### PR TITLE
Promote MPC fixes to internal production

### DIFF
--- a/components/multi-platform-controller/production-downstream/kustomization.yaml
+++ b/components/multi-platform-controller/production-downstream/kustomization.yaml
@@ -5,15 +5,15 @@ namespace: multi-platform-controller
 
 resources:
 - ../base/common
-- https://github.com/konflux-ci/multi-platform-controller/deploy/operator?ref=ba9953e0eb90e3ff2f58b8e6d5f28182f3bd2ddd
-- https://github.com/konflux-ci/multi-platform-controller/deploy/otp?ref=ba9953e0eb90e3ff2f58b8e6d5f28182f3bd2ddd
+- https://github.com/konflux-ci/multi-platform-controller/deploy/operator?ref=09ca43a7a0415feb6ff29fa2278f2d2f34374bac
+- https://github.com/konflux-ci/multi-platform-controller/deploy/otp?ref=09ca43a7a0415feb6ff29fa2278f2d2f34374bac
 - host-config.yaml
 - external-secrets.yaml
 
 images:
 - name: multi-platform-controller
   newName: quay.io/konflux-ci/multi-platform-controller
-  newTag: ba9953e0eb90e3ff2f58b8e6d5f28182f3bd2ddd
+  newTag: 09ca43a7a0415feb6ff29fa2278f2d2f34374bac
 - name: multi-platform-otp-server
   newName: quay.io/konflux-ci/multi-platform-controller-otp-service
-  newTag: ba9953e0eb90e3ff2f58b8e6d5f28182f3bd2ddd
+  newTag: 09ca43a7a0415feb6ff29fa2278f2d2f34374bac


### PR DESCRIPTION
It's a follow-up of https://github.com/redhat-appstudio/infra-deployments/pull/4711

Promotes the following fixes to production:  

 - https://github.com/konflux-ci/multi-platform-controller/pull/306

 - https://github.com/konflux-ci/multi-platform-controller/pull/311