### PR TITLE
fix(KFLUXBUGS-1735): increase memory limits for integration service

### DIFF
--- a/components/integration/production/base/manager_resources_patch.yaml
+++ b/components/integration/production/base/manager_resources_patch.yaml
@@ -11,10 +11,10 @@ spec:
         resources:
           limits:
             cpu: 600m
-            memory: 2048Mi
+            memory: 4096Mi
           requests:
             cpu: 200m
-            memory: 1024Mi
+            memory: 2048Mi
         env:
         - name: CONSOLE_NAME
           valueFrom:


### PR DESCRIPTION
* The service manager pod is getting OOMKilled because of increased amout of resources on the production cluster(s)
* Increase the limit to 4096Mi as agreed on architecture calls
* Increase the requests to 2048Mi as that's the new expected consumption

Signed-off-by: dirgim <kpavic@redhat.com>