### PR TITLE
fix: promote latest hac-dev to staging

### DIFF
--- a/components/ui/development/kustomization.yaml
+++ b/components/ui/development/kustomization.yaml
@@ -15,7 +15,7 @@ images:
   # hac-dev
   - name: quay.io/cloudservices/hac-dev-frontend
     newName: quay.io/cloudservices/hac-dev-frontend
-    newTag: f97289a
+    newTag: 26babff
 
 configMapGenerator:
   - name: fed-modules

--- a/components/ui/staging/kustomization.yaml
+++ b/components/ui/staging/kustomization.yaml
@@ -19,7 +19,7 @@ images:
   # hac-dev
   - name: quay.io/cloudservices/hac-dev-frontend
     newName: quay.io/cloudservices/hac-dev-frontend
-    newTag: f97289a
+    newTag: 26babff
 
 configMapGenerator:
   - name: fed-modules


### PR DESCRIPTION
- openshift/hac-dev#970 from abhinandan13jan/fix-component-url (#f97289a9 972d55e4)
- openshift/hac-dev#986 from jrichter1/wait-for-mbop (#6b5f00eb 9bc1cd6e)
- openshift/hac-dev#984 from sahil143/it-params (#3a05ee41 f73e9847)
- openshift/hac-dev#982 from sahil143/rerun-pipeline-run (#aa03f816 b21fc0e8)
- openshift/hac-dev#1 from Katka92/fix_dropdown_locator (#50ff3af6 5d42a263)
- openshift/hac-dev#983 from sahil143/nudge-permission (#3ff2d0d2 07770925)
- openshift/hac-dev#987 from Katka92/fix_tests (#6f80bb7a a7ea8728)
- openshift/hac-dev#988 from caugello/KFLUXBUGS-1197 (#55270666 79065eec)
- openshift/hac-dev#995 from Katka92/fix_advanced_test (#8cddfe10 135923f2)
- openshift/hac-dev#991 from JoaoPedroPP/KFLUXBUGS-96 (#caa7cb1e a14a004e)
- openshift/hac-dev#990 from CryptoRodeo/kfluxbugs-1494 (#16f1279d 99fb9fad)
- openshift/hac-dev#999 from sahil143/add-reviewers (#dade8fd4 83d29585)
- openshift/hac-dev#981 from sahil143/github-redirect-fix (#c36d7205 0004fc95)
- openshift/hac-dev#998 from sahil143/releases-fix (#d3872831 d7be6d38)
- openshift/hac-dev#1000 from caugello/KFLUXBUGS-1144 (#75aaf8d9 654f6153)
- openshift/hac-dev#969 from abhinandan13jan/add-gitlab-annotation (#12ad1441 f77d7f98)
- openshift/hac-dev#996 from Katka92/enable_sbom_test (#ec397ae5 cc6db15e)
- openshift/hac-dev#1004 from CryptoRodeo/hac-5855 (#217ca339 e9107481)
- openshift/hac-dev#1003 from testcara/KFLUXBUGS-1719 (#1078eb46 153a4b24)
- openshift/hac-dev#1001 from caugello/KFLUXBUGS-902 (#a1f8d4ae 630df68f)
- openshift/hac-dev#994 from caugello/KFLUXBUGS-1540 (#343292c5 23f3c2bf)