### PR TITLE
Set MPC deployment replicas to 5 for internal clusters

### DIFF
--- a/components/multi-platform-controller/production-downstream/kustomization.yaml
+++ b/components/multi-platform-controller/production-downstream/kustomization.yaml
@@ -10,14 +10,8 @@ resources:
 - host-config.yaml
 - external-secrets.yaml
 
-patches:
-  - target:
-      kind: Deployment
-      name: multi-platform-controller
-    patch: |-
-      - op: replace
-        path: "/spec/replicas"
-        value: 3
+patchesStrategicMerge:
+  - replicas_patch.yaml
 
 images:
 - name: multi-platform-controller

--- a/components/multi-platform-controller/production-downstream/kustomization.yaml
+++ b/components/multi-platform-controller/production-downstream/kustomization.yaml
@@ -10,6 +10,15 @@ resources:
 - host-config.yaml
 - external-secrets.yaml
 
+patches:
+  - target:
+      kind: Deployment
+      name: multi-platform-controller
+    patch: |-
+      - op: replace
+        path: "/spec/replicas"
+        value: 3
+
 images:
 - name: multi-platform-controller
   newName: quay.io/konflux-ci/multi-platform-controller

--- a/components/multi-platform-controller/production-downstream/replicas_patch.yaml
+++ b/components/multi-platform-controller/production-downstream/replicas_patch.yaml
@@ -1,0 +1,21 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: multi-platform-controller
+  namespace: multi-platform-controller
+spec:
+  replicas: 3
+  template:
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                    - key: app
+                      operator: In
+                      values:
+                        - multi-platform-controller
+                topologyKey: kubernetes.io/hostname

--- a/components/multi-platform-controller/production-downstream/replicas_patch.yaml
+++ b/components/multi-platform-controller/production-downstream/replicas_patch.yaml
@@ -4,7 +4,7 @@ metadata:
   name: multi-platform-controller
   namespace: multi-platform-controller
 spec:
-  replicas: 3
+  replicas: 5
   template:
     spec:
       affinity:


### PR DESCRIPTION
Issue with timed out TaskRuns still persist on `p02`, let's try to scale the MPC to 3 instances to see if that have any effect.
Discussion: https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1728630785195409 (at the bottom)