### PR TITLE
Set MPC deployment replicas to 3 for internal cluster

### DIFF
--- a/components/multi-platform-controller/staging-downstream/kustomization.yaml
+++ b/components/multi-platform-controller/staging-downstream/kustomization.yaml
@@ -6,3 +6,7 @@ resources:
 - external-secrets.yaml
 
 namespace: multi-platform-controller
+
+
+patchesStrategicMerge:
+  - replicas_patch.yaml

--- a/components/multi-platform-controller/staging-downstream/replicas_patch.yaml
+++ b/components/multi-platform-controller/staging-downstream/replicas_patch.yaml
@@ -1,0 +1,21 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: multi-platform-controller
+  namespace: multi-platform-controller
+spec:
+  replicas: 3
+  template:
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                    - key: app
+                      operator: In
+                      values:
+                        - multi-platform-controller
+                topologyKey: kubernetes.io/hostname


### PR DESCRIPTION
Issue with timed out TaskRuns still persist on `p02`, let's try to scale the MPC to 3 instances to see if that have any effect.
Discussion: https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1728630785195409 (at the bottom)