### PR TITLE
Reduce number of IBM VMs in internal prod

### DIFF
--- a/components/multi-platform-controller/production-downstream/host-config.yaml
+++ b/components/multi-platform-controller/production-downstream/host-config.yaml
@@ -395,7 +395,7 @@ data:
   dynamic.linux-s390x.region: "us-east-1"
   dynamic.linux-s390x.url: "https://us-east.iaas.cloud.ibm.com/v1"
   dynamic.linux-s390x.profile: "bz2-2x8"
-  dynamic.linux-s390x.max-instances: "100"
+  dynamic.linux-s390x.max-instances: "30"
   dynamic.linux-s390x.private-ip: "true"
   dynamic.linux-s390x.allocation-timeout: "1800"
 
@@ -410,7 +410,7 @@ data:
   dynamic.linux-large-s390x.region: "us-east-1"
   dynamic.linux-large-s390x.url: "https://us-east.iaas.cloud.ibm.com/v1"
   dynamic.linux-large-s390x.profile: "bz2-4x16"
-  dynamic.linux-large-s390x.max-instances: "100"
+  dynamic.linux-large-s390x.max-instances: "30"
   dynamic.linux-large-s390x.private-ip: "true"
   dynamic.linux-large-s390x.allocation-timeout: "1800"
 
@@ -426,7 +426,7 @@ data:
   dynamic.linux-ppc64le.system: "e980"
   dynamic.linux-ppc64le.cores: "2"
   dynamic.linux-ppc64le.memory: "8"
-  dynamic.linux-ppc64le.max-instances: "200"
+  dynamic.linux-ppc64le.max-instances: "30"
   dynamic.linux-ppc64le.allocation-timeout: "1800"
   dynamic.linux-ppc64le.user-data: |-
     #cloud-config
@@ -446,7 +446,7 @@ data:
   dynamic.linux-large-ppc64le.system: "e980"
   dynamic.linux-large-ppc64le.cores: "4"
   dynamic.linux-large-ppc64le.memory: "16"
-  dynamic.linux-large-ppc64le.max-instances: "100"
+  dynamic.linux-large-ppc64le.max-instances: "30"
   dynamic.linux-large-ppc64le.allocation-timeout: "1800"
   dynamic.linux-large-ppc64le.user-data: |-
     #cloud-config


### PR DESCRIPTION
We have seen on p02 that MPC takes long to complete reconciliation due to IBM API calls being slow. We did increase the number of VMs but that made thing worse.