### PR TITLE
Fixup MPC container patch

### DIFF
--- a/components/multi-platform-controller/development/logs-in-console-format-cmd-arg-patch.yaml
+++ b/components/multi-platform-controller/development/logs-in-console-format-cmd-arg-patch.yaml
@@ -1,4 +1,4 @@
 ---
 - op: add
-  path: /spec/template/spec/containers/0/args/-
+  path: /spec/template/spec/containers/1/args/-
   value: '--zap-encoder=console'


### PR DESCRIPTION
With adding the `rbac-proxy` container, the order is changed and patched one is now index `1`