### PR TITLE
Add Knative Event, KubeArchive dependency, as infra component

### DIFF
--- a/argo-cd-apps/base/member/infra-deployments/knative-eventing/knative-eventing.yaml
+++ b/argo-cd-apps/base/member/infra-deployments/knative-eventing/knative-eventing.yaml
@@ -1,0 +1,40 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: knative-eventing
+spec:
+  generators:
+    - merge:
+        mergeKeys:
+          - nameNormalized
+        generators:
+          - clusters:
+              values:
+                sourceRoot: components/knative-eventing
+                environment: staging
+                clusterDir: ""
+          - list:
+              elements: []
+  template:
+    metadata:
+      name: knative-eventing-{{nameNormalized}}
+    spec:
+      project: default
+      source:
+        path: '{{values.sourceRoot}}/{{values.environment}}/{{values.clusterDir}}'
+        repoURL: https://github.com/redhat-appstudio/infra-deployments.git
+        targetRevision: main
+      destination:
+        namespace: knative-eventing
+        server: '{{server}}'
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
+        syncOptions:
+          - CreateNamespace=true
+        retry:
+          limit: 50
+          backoff:
+            duration: 15s

--- a/argo-cd-apps/base/member/infra-deployments/knative-eventing/kustomization.yaml
+++ b/argo-cd-apps/base/member/infra-deployments/knative-eventing/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- knative-eventing.yaml
+components:
+  - ../../../../k-components/deploy-to-member-cluster-merge-generator

--- a/argo-cd-apps/base/member/infra-deployments/kustomization.yaml
+++ b/argo-cd-apps/base/member/infra-deployments/kustomization.yaml
@@ -25,5 +25,6 @@ resources:
   - kubearchive
   - workspaces
   - proactive-scaler
+  - knative-eventing
 components:
   - ../../../k-components/inject-infra-deployments-repo-details

--- a/argo-cd-apps/overlays/development/kustomization.yaml
+++ b/argo-cd-apps/overlays/development/kustomization.yaml
@@ -179,3 +179,8 @@ patches:
       kind: ApplicationSet
       version: v1alpha1
       name: kubearchive
+  - path: development-overlay-patch.yaml
+    target:
+      kind: ApplicationSet
+      version: v1alpha1
+      name: knative-eventing

--- a/argo-cd-apps/overlays/konflux-public-production/delete-applications.yaml
+++ b/argo-cd-apps/overlays/konflux-public-production/delete-applications.yaml
@@ -31,3 +31,10 @@ kind: ApplicationSet
 metadata:
   name: proactive-scaler
 $patch: delete
+---
+# KubeArchive not yet ready to go to production
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: knative-eventing
+$patch: delete

--- a/argo-cd-apps/overlays/production-downstream/delete-applications.yaml
+++ b/argo-cd-apps/overlays/production-downstream/delete-applications.yaml
@@ -49,3 +49,10 @@ kind: ApplicationSet
 metadata:
   name: proactive-scaler
 $patch: delete
+---
+# KubeArchive not yet ready to go to production
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: knative-eventing
+$patch: delete

--- a/argo-cd-apps/overlays/staging-downstream/delete-applications.yaml
+++ b/argo-cd-apps/overlays/staging-downstream/delete-applications.yaml
@@ -43,3 +43,10 @@ kind: ApplicationSet
 metadata:
   name: workspaces-member
 $patch: delete
+---
+# KubeArchive is not yet installed here
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: knative-eventing
+$patch: delete

--- a/components/knative-eventing/OWNERS
+++ b/components/knative-eventing/OWNERS
@@ -1,0 +1,15 @@
+# See the OWNERS docs: https://go.k8s.io/owners
+# These owners are the same as the ones on KubeArchive
+# because Knative Eventing is a dependency for KubeArchive
+# if you also use Knative Eventing as a dependency, please
+# add yourself here too.
+
+approvers:
+- rh-hemartin
+- skoved
+- ggallen
+
+reviewers:
+- rh-hemartin
+- skoved
+- ggallen

--- a/components/knative-eventing/base/kustomization.yaml
+++ b/components/knative-eventing/base/kustomization.yaml
@@ -1,0 +1,35 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - https://github.com/knative/eventing/releases/download/knative-v1.15.3/eventing-core.yaml?timeout=90s
+
+patches:
+# kube-lint fixes
+- patch: |-
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: eventing-controller
+      namespace: knative-eventing
+    spec:
+      template:
+        spec:
+          containers:
+            - name: eventing-controller
+              resources:
+                requests:
+                  cpu: 35m
+                  memory: 100Mi
+                limits:
+                  cpu: 100m
+                  memory: 200Mi
+# This was causing issues with kube-linter and I didn't want
+# to increase its replicas to 2, so I deleted it instead
+- patch: |-
+    $patch: delete
+    apiVersion: policy/v1
+    kind: PodDisruptionBudget
+    metadata:
+      name: eventing-webhook
+      namespace: knative-eventing

--- a/components/knative-eventing/development/kustomization.yaml
+++ b/components/knative-eventing/development/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../base

--- a/components/knative-eventing/staging/kustomization.yaml
+++ b/components/knative-eventing/staging/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../base


### PR DESCRIPTION
I'm adding Knative Eventing because its a dependency for KubeArchive. There was an [ADR](https://github.com/konflux-ci/architecture/pull/202) to install it for everyone use, but my intention here is that is used by KubeArchive.

cc @ralphbean @hugares 