### PR TITLE
Update KubeArchive to v0.3.0

### DIFF
--- a/argo-cd-apps/base/member/infra-deployments/kubearchive/kubearchive.yaml
+++ b/argo-cd-apps/base/member/infra-deployments/kubearchive/kubearchive.yaml
@@ -35,7 +35,7 @@ spec:
           prune: true
           selfHeal: true
         syncOptions:
-        - CreateNamespace=true
+          - CreateNamespace=true
         retry:
           limit: 50
           backoff:

--- a/components/kubearchive/base/alternative-service.yaml
+++ b/components/kubearchive/base/alternative-service.yaml
@@ -1,0 +1,13 @@
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: product-kubearchive-sink
+  namespace: kubearchive
+spec:
+  selector:
+    app: kubearchive-sink
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8080

--- a/components/kubearchive/base/kustomization.yaml
+++ b/components/kubearchive/base/kustomization.yaml
@@ -2,12 +2,20 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- https://github.com/kubearchive/kubearchive/releases/download/v0.1.0/kubearchive.yaml?timeout=90
+- https://github.com/kubearchive/kubearchive/releases/download/v0.3.0/kubearchive.yaml?timeout=90
 - rbac.yaml
+# This alternative service is needed because the operator creates the
+# ApiServerSource pointing to <namespace>-sink, and here namespace is
+# product-kubearchive, so product-kubearchive-sink. However the service
+# is created as kubearchive-sink and the ApiServerSource does not find it.
+# The symptom is the following event:
+# Failed to update status for "product-kubearchive-a13e": ApiServerSource.sources.knative.dev
+#   "product-kubearchive-a13e" is invalid: namespaces: Invalid value: "null": namespaces in body
+#    must be of type array: "null"
+- alternative-service.yaml
 
 # ROSA does not support namespaces starting with `kube`
 namespace: product-kubearchive
-
 
 patches:
 # These patches changes some resources that point directly to
@@ -17,6 +25,7 @@ patches:
     kind: RoleBinding
     metadata:
       name: kubearchive-operator-leader-election
+      namespace: kubearchive
     subjects:
     - kind: ServiceAccount
       name: kubearchive-operator
@@ -78,6 +87,7 @@ patches:
     kind: Service
     metadata:
       name: kubearchive-api-server
+      namespace: kubearchive
       annotations:
         service.beta.openshift.io/serving-cert-secret-name: kubearchive-api-server-tls
 - patch: |-
@@ -85,15 +95,30 @@ patches:
     kind: Service
     metadata:
       name: kubearchive-operator-webhooks
+      namespace: kubearchive
       annotations:
         service.beta.openshift.io/serving-cert-secret-name: kubearchive-operator-tls
-
+- patch: |-
+    apiVersion: admissionregistration.k8s.io/v1
+    kind: MutatingWebhookConfiguration
+    metadata:
+      name: kubearchive-mutating-webhook-configuration
+      annotations:
+        service.beta.openshift.io/inject-cabundle: "true"
+- patch: |-
+    apiVersion: admissionregistration.k8s.io/v1
+    kind: ValidatingWebhookConfiguration
+    metadata:
+      name: kubearchive-validating-webhook-configuration
+      annotations:
+        service.beta.openshift.io/inject-cabundle: "true"
 # These patches solve Kube Linter problems
 - patch: |-
     apiVersion: apps/v1
     kind: Deployment
     metadata:
       name: kubearchive-api-server
+      namespace: kubearchive
     spec:
       template:
         spec:
@@ -114,6 +139,7 @@ patches:
     kind: Deployment
     metadata:
       name: kubearchive-operator
+      namespace: kubearchive
     spec:
       template:
         spec:
@@ -133,6 +159,7 @@ patches:
     kind: Deployment
     metadata:
       name: kubearchive-sink
+      namespace: kubearchive
     spec:
       template:
         spec:
@@ -156,27 +183,32 @@ patches:
     kind: Certificate
     metadata:
       name: "kubearchive-api-server-certificate"
+      namespace: kubearchive
 - patch: |-
     $patch: delete
     apiVersion: cert-manager.io/v1
     kind: Certificate
     metadata:
       name: "kubearchive-ca"
+      namespace: kubearchive
 - patch: |-
     $patch: delete
     apiVersion: cert-manager.io/v1
     kind: Issuer
     metadata:
       name: "kubearchive-ca"
+      namespace: kubearchive
 - patch: |-
     $patch: delete
     apiVersion: cert-manager.io/v1
     kind: Issuer
     metadata:
       name: "kubearchive"
+      namespace: kubearchive
 - patch: |-
     $patch: delete
     apiVersion: cert-manager.io/v1
     kind: Certificate
     metadata:
       name: "kubearchive-operator-certificate"
+      namespace: kubearchive

--- a/components/kubearchive/development/kustomization.yaml
+++ b/components/kubearchive/development/kustomization.yaml
@@ -7,11 +7,14 @@ resources:
 secretGenerator:
 - behavior: merge
   literals:
-  - POSTGRES_DB=kubearchive
-  - POSTGRES_USER=kubearchive
-  - POSTGRES_URL=postgresql.kubearchive.svc.cluster.local
-  - POSTGRES_PASSWORD=password  # notsecret
+  - DATABASE_KIND=postgresql
+  - DATABASE_PORT=5432
+  - DATABASE_DB=kubearchive
+  - DATABASE_USER=kubearchive
+  - DATABASE_URL=postgresql.product-kubearchive.svc.cluster.local
+  - DATABASE_PASSWORD=password  # notsecret
   name: kubearchive-database-credentials
+  namespace: kubearchive
   type: Opaque
 
 commonAnnotations:

--- a/components/kubearchive/staging/database-secret.yaml
+++ b/components/kubearchive/staging/database-secret.yaml
@@ -19,8 +19,9 @@ spec:
     name: kubearchive-database-credentials
     template:
       data:
-        POSTGRES_PORT: "5432"
-        POSTGRES_URL: '{{ index . "db.host" }}'
-        POSTGRES_PASSWORD: '{{ index . "db.password" }}'
-        POSTGRES_USER: '{{ index . "db.user" }}'
-        POSTGRES_DB: '{{ index . "db.name" }}'
+        DATABASE_KIND: postgresql
+        DATABASE_PORT: "5432"
+        DATABASE_URL: '{{ index . "db.host" }}'
+        DATABASE_PASSWORD: '{{ index . "db.password" }}'
+        DATABASE_USER: '{{ index . "db.user" }}'
+        DATABASE_DB: '{{ index . "db.name" }}'


### PR DESCRIPTION
Updating KubeArchive from 0.1.0 to 0.3.0. Some stuff related to the database changed, and now namespace is present on all resources, so patching takes that into account. Also I detected some problems regarding certificates in webhooks, so this is correcting it.

I want to wait for #4764 to be merged, so I can make sure KubeArchive archives stuff (I didn't properly test this before, just that it installed).