### PR TITLE
Fix priority class of the proactive scaler pods

### DIFF
--- a/configs/proactive-scaler/base/deployments.yaml
+++ b/configs/proactive-scaler/base/deployments.yaml
@@ -22,7 +22,7 @@ spec:
           operator: "Equal"
           value: "konflux-tenants"
           effect: "NoSchedule"
-      priorityClassName: pause-pods
+      priorityClassName: proactive-scaler-pods
       containers:
         - name: reserve-resources
           image: registry.k8s.io/pause

--- a/configs/proactive-scaler/base/priority-class.yaml
+++ b/configs/proactive-scaler/base/priority-class.yaml
@@ -2,7 +2,7 @@
 apiVersion: scheduling.k8s.io/v1
 kind: PriorityClass
 metadata:
-  name: konflux-priority-class
+  name: konflux-default
 value: 0
 globalDefault: true
 description: "Default Priority class."
@@ -10,7 +10,7 @@ description: "Default Priority class."
 apiVersion: scheduling.k8s.io/v1
 kind: PriorityClass
 metadata:
-  name: pause-pods
-value: -1
+  name: proactive-scaler-pods
+value: -10
 globalDefault: false
-description: "Priority class used by pause-pods for overprovisioning."
+description: "Priority class used by proactive scaler pods to over provision nodes."


### PR DESCRIPTION
This priority class is meant to be lower that priority class used by the tenant pods. The original change created a default class with priority value of 0 and scaler pods used a class with priority of -1.

The problem is all the tenants pods get assigned to sandbox-users-pods priority class which has a value of -3, causing the scaler pods to not be evicted from the node when resource are needed.

We are planning to remove sandbox so this sandbox-users-pods priority class will be deleted eventually but in the meantime, set scaler pods to -10.

Also rename the 2 priority classes so their name are more meaningful.

[KFLUXINFRA-889](https://issues.redhat.com//browse/KFLUXINFRA-889)