### PR TITLE
Increase tekton remote resolver resources

### DIFF
--- a/components/pipeline-service/production/base/main-pipeline-service-configuration.yaml
+++ b/components/pipeline-service/production/base/main-pipeline-service-configuration.yaml
@@ -1548,11 +1548,10 @@ spec:
                   - name: controller
                     resources:
                       limits:
-                        cpu: "1"
                         memory: 16Gi
                       requests:
-                        cpu: 100m
-                        memory: 100Mi
+                        cpu: "1"
+                        memory: 16Gi
         tekton-pipelines-webhook:
           spec:
             template:

--- a/components/pipeline-service/production/stone-prd-m01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prd-m01/deploy.yaml
@@ -2071,11 +2071,10 @@ spec:
                 - name: controller
                   resources:
                     limits:
-                      cpu: "1"
                       memory: 16Gi
                     requests:
-                      cpu: 100m
-                      memory: 100Mi
+                      cpu: "1"
+                      memory: 16Gi
         tekton-pipelines-webhook:
           spec:
             template:

--- a/components/pipeline-service/production/stone-prd-rh01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prd-rh01/deploy.yaml
@@ -2071,11 +2071,10 @@ spec:
                 - name: controller
                   resources:
                     limits:
-                      cpu: "1"
                       memory: 16Gi
                     requests:
-                      cpu: 100m
-                      memory: 100Mi
+                      cpu: "1"
+                      memory: 16Gi
         tekton-pipelines-webhook:
           spec:
             template:

--- a/components/pipeline-service/production/stone-prod-p01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prod-p01/deploy.yaml
@@ -2071,11 +2071,10 @@ spec:
                 - name: controller
                   resources:
                     limits:
-                      cpu: "1"
                       memory: 16Gi
                     requests:
-                      cpu: 100m
-                      memory: 100Mi
+                      cpu: "1"
+                      memory: 16Gi
         tekton-pipelines-webhook:
           spec:
             template:

--- a/components/pipeline-service/production/stone-prod-p02/deploy.yaml
+++ b/components/pipeline-service/production/stone-prod-p02/deploy.yaml
@@ -2071,11 +2071,10 @@ spec:
                 - name: controller
                   resources:
                     limits:
-                      cpu: "1"
                       memory: 16Gi
                     requests:
-                      cpu: 100m
-                      memory: 100Mi
+                      cpu: "1"
+                      memory: 16Gi
         tekton-pipelines-webhook:
           spec:
             template:


### PR DESCRIPTION
Request is what is guaranteed so having such low requests vs limit is not good. There is a problem in production where resolving remote bundle is timing out. To rule out lack of resources, set the memory request same as limit to guarantee access to that amount of memory. Also increase CPU request for same reason and remove CPU limit.

If we see over time that we do not need such high memory request, a follow up change will be done to reduce it.