### PR TITLE
Reduce Tekton resolver resources

### DIFF
--- a/components/pipeline-service/production/base/main-pipeline-service-configuration.yaml
+++ b/components/pipeline-service/production/base/main-pipeline-service-configuration.yaml
@@ -1548,10 +1548,10 @@ spec:
                   - name: controller
                     resources:
                       limits:
-                        memory: 16Gi
+                        memory: 4Gi
                       requests:
-                        cpu: "1"
-                        memory: 16Gi
+                        cpu: "500m"
+                        memory: 4Gi
         tekton-pipelines-webhook:
           spec:
             template:

--- a/components/pipeline-service/production/stone-prd-m01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prd-m01/deploy.yaml
@@ -2071,10 +2071,10 @@ spec:
                 - name: controller
                   resources:
                     limits:
-                      memory: 16Gi
+                      memory: 4Gi
                     requests:
-                      cpu: "1"
-                      memory: 16Gi
+                      cpu: 500m
+                      memory: 4Gi
         tekton-pipelines-webhook:
           spec:
             template:

--- a/components/pipeline-service/production/stone-prd-rh01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prd-rh01/deploy.yaml
@@ -2071,10 +2071,10 @@ spec:
                 - name: controller
                   resources:
                     limits:
-                      memory: 16Gi
+                      memory: 4Gi
                     requests:
-                      cpu: "1"
-                      memory: 16Gi
+                      cpu: 500m
+                      memory: 4Gi
         tekton-pipelines-webhook:
           spec:
             template:

--- a/components/pipeline-service/production/stone-prod-p01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prod-p01/deploy.yaml
@@ -2071,10 +2071,10 @@ spec:
                 - name: controller
                   resources:
                     limits:
-                      memory: 16Gi
+                      memory: 4Gi
                     requests:
-                      cpu: "1"
-                      memory: 16Gi
+                      cpu: 500m
+                      memory: 4Gi
         tekton-pipelines-webhook:
           spec:
             template:

--- a/components/pipeline-service/production/stone-prod-p02/deploy.yaml
+++ b/components/pipeline-service/production/stone-prod-p02/deploy.yaml
@@ -2071,10 +2071,10 @@ spec:
                 - name: controller
                   resources:
                     limits:
-                      memory: 16Gi
+                      memory: 4Gi
                     requests:
-                      cpu: "1"
-                      memory: 16Gi
+                      cpu: 500m
+                      memory: 4Gi
         tekton-pipelines-webhook:
           spec:
             template:


### PR DESCRIPTION
In 5e0efd89e2a35795ed277dc5c3005595ab6ce7fd, the resources requests/limits were changed to rule out potential lack of resources issue.

After the change was done, we could see the actual usage of the remote resolver controller. Reduce the resource requirements to number closer to actual usage. These numbers do include a buffer.