### PR TITLE
Ignore Aggregated Roles in Knative Eventing

### DIFF
--- a/argo-cd-apps/base/member/infra-deployments/knative-eventing/knative-eventing.yaml
+++ b/argo-cd-apps/base/member/infra-deployments/knative-eventing/knative-eventing.yaml
@@ -28,12 +28,40 @@ spec:
       destination:
         namespace: knative-eventing
         server: '{{server}}'
+      ignoreDifferences:
+        # ignore aggregated roles changes
+        - kind: ClusterRole
+          group: rbac.authorization.k8s.io
+          name: addressable-resolver
+          jsonPointers:
+            - /rules
+        - kind: ClusterRole
+          group: rbac.authorization.k8s.io
+          name: channelable-manipulator
+          jsonPointers:
+            - /rules
+        - kind: ClusterRole
+          group: rbac.authorization.k8s.io
+          name: crossnamespace-subscriber
+          jsonPointers:
+            - /rules
+        - kind: ClusterRole
+          group: rbac.authorization.k8s.io
+          name: podspecable-binding
+          jsonPointers:
+            - /rules
+        - kind: ClusterRole
+          group: rbac.authorization.k8s.io
+          name: source-observer
+          jsonPointers:
+            - /rules
       syncPolicy:
         automated:
           prune: true
           selfHeal: true
         syncOptions:
           - CreateNamespace=true
+          - RespectIgnoreDifferences=true
         retry:
           limit: 50
           backoff:


### PR DESCRIPTION
#4764 Knative Eventing was introduced, but the deployment was in and out of sync constantly. This is because Knative Eventing uses aggregated roles. The following PR makes the Knative Eventing ArgoCD application ignore the roles that were being aggregated.

PD: I found no way to tell the `ignoreDifferences` option to ignore "all clusterroles that have `aggregateRules`". So I had to exclude them one by one.

cc @hugares 