### PR TITLE
Make sure we have 2 worker nodes in advance

### DIFF
--- a/configs/proactive-scaler/base/deployments.yaml
+++ b/configs/proactive-scaler/base/deployments.yaml
@@ -5,7 +5,7 @@ metadata:
   name: m6a-4xlarge
   namespace: proactive-scaler
 spec:
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels:
       run: m6a-4xlarge


### PR DESCRIPTION
Looking at the tekton task throttled by node, we can see that one node in advance is helping but not enough to get rid of task pending due to lack of nodes.