### PR TITLE
enable compression in SPLUNK log forwarder for the staging cluster

### DIFF
--- a/components/monitoring/logging/staging/stone-stage-p01/configure-logforwarder-compression-patch.yaml
+++ b/components/monitoring/logging/staging/stone-stage-p01/configure-logforwarder-compression-patch.yaml
@@ -1,0 +1,5 @@
+---
+- op: add
+  path: /spec/tuning
+  value: 
+    compression: gzip

--- a/components/monitoring/logging/staging/stone-stage-p01/kustomization.yaml
+++ b/components/monitoring/logging/staging/stone-stage-p01/kustomization.yaml
@@ -3,3 +3,11 @@ kind: Kustomization
 resources:
 - ../base
 - ../../base/logging-operator-prerequisite
+
+patches:
+  - path: configure-logforwarder-compression-patch.yaml
+    target:
+      group: logging.openshift.io
+      version: v1
+      kind: ClusterLogForwarder
+      name: instance


### PR DESCRIPTION
This PR enables `gzip` compression on logs forwarded to SPLUNK from the stage p01 cluster. We expect this to just work and to see a reduction in generated traffic towards SPLUNK.

Official doc for [Configuring log forwarding in OpenShift](https://docs.openshift.com/container-platform/4.15/observability/logging/log_collection_forwarding/configuring-log-forwarding.html\#logging-delivery-tuning_configuring-log-forwarding)

Signed-off-by: Francesco Ilario <filario@redhat.com>
