### PR TITLE
Bump hypershift-aws-template chart version

### DIFF
--- a/components/cluster-as-a-service/base/clustertemplates.yaml
+++ b/components/cluster-as-a-service/base/clustertemplates.yaml
@@ -36,7 +36,7 @@ spec:
       source:
         chart: hypershift-aws-template
         repoURL: https://konflux-ci.dev/cluster-template-charts/
-        targetRevision: 0.1.1
+        targetRevision: 0.1.2
         helm:
           parameters:
             - name: region


### PR DESCRIPTION
The imageContentSources chart value is made available as a result of this change.