### PR TITLE
Update CatalogSource mem target to avoid eviction

### DIFF
--- a/components/sandbox/toolchain-member-operator/base/olm/toolchain-member-operator.yaml
+++ b/components/sandbox/toolchain-member-operator/base/olm/toolchain-member-operator.yaml
@@ -14,6 +14,8 @@ spec:
   updateStrategy:
     registryPoll:
       interval: 5m0s
+  grpcPodConfig:
+    memoryTarget: 250Mi
 ---
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup


### PR DESCRIPTION
When nodes are overcommited pods that are over their requested memory can be evicted. Increasing the target memory will reduce this risk.