### PR TITLE
Further reduce maximum application age

### DIFF
--- a/components/tekton-ci/production/cleanup-cronjob.yaml
+++ b/components/tekton-ci/production/cleanup-cronjob.yaml
@@ -17,7 +17,7 @@ spec:
             - -c
             - |
               date; echo Cleaning up the stale applications
-              oc get application -n build-templates-e2e -o go-template --template '{{range .items}}{{.metadata.name}} {{.metadata.creationTimestamp}}{{"\n"}}{{end}}' | awk '$2 <= "'$(date -d '1 day ago' --iso-8601=seconds --utc | sed 's/+00:00/Z/')'" { print $1 }' | xargs --no-run-if-empty oc delete application -n build-templates-e2e
+              oc get application -n build-templates-e2e -o go-template --template '{{range .items}}{{.metadata.name}} {{.metadata.creationTimestamp}}{{"\n"}}{{end}}' | awk '$2 <= "'$(date -d '2.5 hours ago' --iso-8601=seconds --utc | sed 's/+00:00/Z/')'" { print $1 }' | xargs --no-run-if-empty oc delete application -n build-templates-e2e
             resources:
               limits:
                 cpu: 100m

--- a/components/tekton-ci/production/cleanup-cronjob.yaml
+++ b/components/tekton-ci/production/cleanup-cronjob.yaml
@@ -17,7 +17,7 @@ spec:
             - -c
             - |
               date; echo Cleaning up the stale applications
-              oc get application -n build-templates-e2e -o go-template --template '{{range .items}}{{.metadata.name}} {{.metadata.creationTimestamp}}{{"\n"}}{{end}}' | awk '$2 <= "'$(date -d '2.5 hours ago' --iso-8601=seconds --utc | sed 's/+00:00/Z/')'" { print $1 }' | xargs --no-run-if-empty oc delete application -n build-templates-e2e
+              oc get application -n build-templates-e2e -o go-template --template '{{range .items}}{{.metadata.name}} {{.metadata.creationTimestamp}}{{"\n"}}{{end}}' | awk '$2 <= "'$(date -d '150 minutes ago' --iso-8601=seconds --utc | sed 's/+00:00/Z/')'" { print $1 }' | xargs --no-run-if-empty oc delete application -n build-templates-e2e
             resources:
               limits:
                 cpu: 100m


### PR DESCRIPTION
Even removing applications that are older than a day wasn't sufficient. Since deleting applications will trigger the deletion of a component and any imagerepositories, we need to ensure that deletion happens after the PLR timeout.

While the e2e tests have a 2 hour timeout for the pipelineruns, deleting the imagerespositories will also result in deleting the quay repos. Increasing timeout to the [e2e pipeline timeout](https://github.com/konflux-ci/build-definitions/blob/050297455791697a52c97fa50a1e2f5e4d914bcc/.tekton/pull-request.yaml#L270) + 30 minutes.