### PR TITLE
Adding Namespace to access insights appsre vault

### DIFF
--- a/components/cluster-secret-store-rh/base/insights-secret-store.yaml
+++ b/components/cluster-secret-store-rh/base/insights-secret-store.yaml
@@ -28,3 +28,4 @@ spec:
   conditions:
     - namespaces:
         - insights-management-tenant
+        - hcm-eng-prod-tenant


### PR DESCRIPTION
Adding the following namespace to allow access to Insights AppSre Vault 

`hcm-eng-prod-tenant`