### PR TITLE
Increase OSP remote resolver replicas to 2

### DIFF
--- a/components/pipeline-service/production/base/main-pipeline-service-configuration.yaml
+++ b/components/pipeline-service/production/base/main-pipeline-service-configuration.yaml
@@ -1524,6 +1524,9 @@ spec:
                   value: "konflux-tenants"
                   effect: "NoSchedule"
             default-timeout-minutes: "120"    
+        config-leader-election-resolvers:
+          data:
+            buckets: "4"
       deployments:
         tekton-operator-proxy-webhook:
           spec:
@@ -1541,7 +1544,7 @@ spec:
                       memory: 100Mi
         tekton-pipelines-remote-resolvers:
           spec:
-            replicas: 1
+            replicas: 2
             template:
               spec:
                 containers:

--- a/components/pipeline-service/production/stone-prd-m01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prd-m01/deploy.yaml
@@ -1999,6 +1999,9 @@ spec:
                   value: "konflux-tenants"
                   effect: "NoSchedule"
             default-timeout-minutes: "120"
+        config-leader-election-resolvers:
+          data:
+            buckets: "4"
         config-logging:
           data:
             loglevel.controller: info
@@ -2064,7 +2067,7 @@ spec:
                   whenUnsatisfiable: DoNotSchedule
         tekton-pipelines-remote-resolvers:
           spec:
-            replicas: 1
+            replicas: 2
             template:
               spec:
                 containers:

--- a/components/pipeline-service/production/stone-prd-rh01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prd-rh01/deploy.yaml
@@ -1999,6 +1999,9 @@ spec:
                   value: "konflux-tenants"
                   effect: "NoSchedule"
             default-timeout-minutes: "120"
+        config-leader-election-resolvers:
+          data:
+            buckets: "4"
         config-logging:
           data:
             loglevel.controller: info
@@ -2064,7 +2067,7 @@ spec:
                   whenUnsatisfiable: DoNotSchedule
         tekton-pipelines-remote-resolvers:
           spec:
-            replicas: 1
+            replicas: 2
             template:
               spec:
                 containers:

--- a/components/pipeline-service/production/stone-prod-p01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prod-p01/deploy.yaml
@@ -1999,6 +1999,9 @@ spec:
                   value: "konflux-tenants"
                   effect: "NoSchedule"
             default-timeout-minutes: "120"
+        config-leader-election-resolvers:
+          data:
+            buckets: "4"
         config-logging:
           data:
             loglevel.controller: info
@@ -2064,7 +2067,7 @@ spec:
                   whenUnsatisfiable: DoNotSchedule
         tekton-pipelines-remote-resolvers:
           spec:
-            replicas: 1
+            replicas: 2
             template:
               spec:
                 containers:

--- a/components/pipeline-service/production/stone-prod-p02/deploy.yaml
+++ b/components/pipeline-service/production/stone-prod-p02/deploy.yaml
@@ -1999,6 +1999,9 @@ spec:
                   value: "konflux-tenants"
                   effect: "NoSchedule"
             default-timeout-minutes: "120"
+        config-leader-election-resolvers:
+          data:
+            buckets: "4"
         config-logging:
           data:
             loglevel.controller: info
@@ -2064,7 +2067,7 @@ spec:
                   whenUnsatisfiable: DoNotSchedule
         tekton-pipelines-remote-resolvers:
           spec:
-            replicas: 1
+            replicas: 2
             template:
               spec:
                 containers:


### PR DESCRIPTION
This change is an attempt to improve the resolutionRequest time, we see a lot of resolution timing out. We cannot configure the number of threads per controller yet so increase the number of controllers.

[KFLUXBUGS-1784](https://issues.redhat.com//browse/KFLUXBUGS-1784)