### PR TITLE
Increase OSP remote resolver replicas to 4

### DIFF
--- a/components/pipeline-service/production/base/main-pipeline-service-configuration.yaml
+++ b/components/pipeline-service/production/base/main-pipeline-service-configuration.yaml
@@ -1526,7 +1526,7 @@ spec:
             default-timeout-minutes: "120"    
         config-leader-election-resolvers:
           data:
-            buckets: "4"
+            buckets: "8"
       deployments:
         tekton-operator-proxy-webhook:
           spec:
@@ -1544,7 +1544,7 @@ spec:
                       memory: 100Mi
         tekton-pipelines-remote-resolvers:
           spec:
-            replicas: 2
+            replicas: 4
             template:
               spec:
                 containers:

--- a/components/pipeline-service/production/stone-prd-m01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prd-m01/deploy.yaml
@@ -2001,7 +2001,7 @@ spec:
             default-timeout-minutes: "120"
         config-leader-election-resolvers:
           data:
-            buckets: "4"
+            buckets: "8"
         config-logging:
           data:
             loglevel.controller: info
@@ -2067,7 +2067,7 @@ spec:
                   whenUnsatisfiable: DoNotSchedule
         tekton-pipelines-remote-resolvers:
           spec:
-            replicas: 2
+            replicas: 4
             template:
               spec:
                 containers:

--- a/components/pipeline-service/production/stone-prd-rh01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prd-rh01/deploy.yaml
@@ -2001,7 +2001,7 @@ spec:
             default-timeout-minutes: "120"
         config-leader-election-resolvers:
           data:
-            buckets: "4"
+            buckets: "8"
         config-logging:
           data:
             loglevel.controller: info
@@ -2067,7 +2067,7 @@ spec:
                   whenUnsatisfiable: DoNotSchedule
         tekton-pipelines-remote-resolvers:
           spec:
-            replicas: 2
+            replicas: 4
             template:
               spec:
                 containers:

--- a/components/pipeline-service/production/stone-prod-p01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prod-p01/deploy.yaml
@@ -2001,7 +2001,7 @@ spec:
             default-timeout-minutes: "120"
         config-leader-election-resolvers:
           data:
-            buckets: "4"
+            buckets: "8"
         config-logging:
           data:
             loglevel.controller: info
@@ -2067,7 +2067,7 @@ spec:
                   whenUnsatisfiable: DoNotSchedule
         tekton-pipelines-remote-resolvers:
           spec:
-            replicas: 2
+            replicas: 4
             template:
               spec:
                 containers:

--- a/components/pipeline-service/production/stone-prod-p02/deploy.yaml
+++ b/components/pipeline-service/production/stone-prod-p02/deploy.yaml
@@ -2001,7 +2001,7 @@ spec:
             default-timeout-minutes: "120"
         config-leader-election-resolvers:
           data:
-            buckets: "4"
+            buckets: "8"
         config-logging:
           data:
             loglevel.controller: info
@@ -2067,7 +2067,7 @@ spec:
                   whenUnsatisfiable: DoNotSchedule
         tekton-pipelines-remote-resolvers:
           spec:
-            replicas: 2
+            replicas: 4
             template:
               spec:
                 containers:


### PR DESCRIPTION
This change is an attempt to improve the resolutionRequest time, we see a lot of resolution timing out. We cannot configure the number of threads per controller yet so increase the number of controllers.

[KFLUXBUGS-1784](https://issues.redhat.com//browse/KFLUXBUGS-1784)