### PR TITLE
add konflux-ci-repo-creator secret to konflux-ci

### DIFF
--- a/components/konflux-ci/base/external-secrets/konflux-ci-repo-creator.yaml
+++ b/components/konflux-ci/base/external-secrets/konflux-ci-repo-creator.yaml
@@ -1,0 +1,19 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: konflux-ci-repo-creator
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  dataFrom:
+    - extract:
+        key: production/build/tekton-ci/konflux-ci-repo-creator
+  refreshInterval: 15m
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: appsre-stonesoup-vault
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    name: konflux-ci-repo-creator

--- a/components/konflux-ci/base/external-secrets/kustomization.yaml
+++ b/components/konflux-ci/base/external-secrets/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
 - quay-push-secret-konflux-ci.yaml
 - infra-deployments-pr-creator.yaml
+- konflux-ci-repo-creator.yaml
 - snyk-shared-token.yaml
 - slack-webhook-notification-secret.yaml
 - github-secret.yaml


### PR DESCRIPTION
[STONEBLD-2875](https://issues.redhat.com/browse/STONEBLD-2875)
- konflux-ci-repo-creator secret is a Quay token used for creating new repos in
https://quay.io/organization/konflux-ci
- Create the ExternalSecret in konflux-ci because it's going to be used in tasks
in build-definitions repository