### PR TITLE
Increase MPC controller to 16Gi

### DIFF
--- a/components/multi-platform-controller/production/manager_resources_patch.yaml
+++ b/components/multi-platform-controller/production/manager_resources_patch.yaml
@@ -11,8 +11,8 @@ spec:
         resources:
           limits:
             cpu: 500m
-            memory: 8Gi
+            memory: 16Gi
           requests:
             cpu: 500m
-            memory: 8Gi
+            memory: 16Gi
 


### PR DESCRIPTION
Something is happening on prd-rh01 and controller is getting OOMKilled even with 8Gi Increase this further just to try to get things working before we investigate.