### PR TITLE
fix: increase memory limit

### DIFF
--- a/components/release/k-components/manager-resources-patch/manager_resources_patch.yaml
+++ b/components/release/k-components/manager-resources-patch/manager_resources_patch.yaml
@@ -11,7 +11,7 @@ spec:
         resources:
           limits:
             cpu: 500m
-            memory: 4096Mi
+            memory: 8192Mi
           requests:
             cpu: 100m
-            memory: 3072Mi
+            memory: 8192Mi


### PR DESCRIPTION
This PR increases the memory limit to 8Gb to decrease the Pod restarts over the week.