### PR TITLE
fix: increases memory request/limit for release deletion pod

### DIFF
--- a/components/release/base/cronjobs/remove-expired-releases.yaml
+++ b/components/release/base/cronjobs/remove-expired-releases.yaml
@@ -64,10 +64,10 @@ spec:
               resources:
                 limits:
                   cpu: 200m
-                  memory: 300Mi
+                  memory: 1024Mi
                 requests:
                   cpu: 100m
-                  memory: 200Mi
+                  memory: 1024Mi
               securityContext:
                 allowPrivilegeEscalation: false
                 capabilities:


### PR DESCRIPTION
this PR increase the request and limit for the release prune cronjob pod to avoid it being oomkilled.