### PR TITLE
fix kubearchive PostrgreSQL deployment

### DIFF
--- a/components/kubearchive/development/postgresql.yaml
+++ b/components/kubearchive/development/postgresql.yaml
@@ -35,6 +35,8 @@ spec:
               value: kubearchive
             - name: POSTGRESQL_PASSWORD
               value: password  # notsecret
+            - name: POSTGRESQL_REPLICATION_USE_PASSFILE # https://github.com/bitnami/containers/issues/74788
+              value: no
           securityContext:
             readOnlyRootFilesystem: false
             runAsNonRoot: true


### PR DESCRIPTION
This is necessary due to what seems to be a bug in the bitnami/postgresql:16.4 container. See
https://github.com/bitnami/containers/issues/74788