### PR TITLE
Configure MPC memory for staging and production

### DIFF
--- a/components/multi-platform-controller/k-components/manager-resources/kustomization.yaml
+++ b/components/multi-platform-controller/k-components/manager-resources/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+patches:
+  - path: ./manager_resources_patch.yaml

--- a/components/multi-platform-controller/k-components/manager-resources/manager_resources_patch.yaml
+++ b/components/multi-platform-controller/k-components/manager-resources/manager_resources_patch.yaml
@@ -11,8 +11,7 @@ spec:
         resources:
           limits:
             cpu: 500m
-            memory: 16Gi
+            memory: 10Gi
           requests:
             cpu: 500m
-            memory: 16Gi
-
+            memory: 10Gi

--- a/components/multi-platform-controller/production-downstream/kustomization.yaml
+++ b/components/multi-platform-controller/production-downstream/kustomization.yaml
@@ -10,6 +10,9 @@ resources:
 - host-config.yaml
 - external-secrets.yaml
 
+components:
+  - ../k-components/manager-resources
+
 images:
 - name: multi-platform-controller
   newName: quay.io/konflux-ci/multi-platform-controller

--- a/components/multi-platform-controller/production/kustomization.yaml
+++ b/components/multi-platform-controller/production/kustomization.yaml
@@ -10,6 +10,9 @@ resources:
 - https://github.com/konflux-ci/multi-platform-controller/deploy/operator?ref=53a13363d5e6cffb1bb4b4c260cb151f1fea672f
 - https://github.com/konflux-ci/multi-platform-controller/deploy/otp?ref=53a13363d5e6cffb1bb4b4c260cb151f1fea672f
 
+components:
+  - ../k-components/manager-resources
+
 images:
 - name: multi-platform-controller
   newName: quay.io/konflux-ci/multi-platform-controller
@@ -17,6 +20,3 @@ images:
 - name: multi-platform-otp-server
   newName: quay.io/konflux-ci/multi-platform-controller-otp-service
   newTag: 53a13363d5e6cffb1bb4b4c260cb151f1fea672f
-
-patches:
-  - path: ./manager_resources_patch.yaml

--- a/components/multi-platform-controller/staging-downstream/kustomization.yaml
+++ b/components/multi-platform-controller/staging-downstream/kustomization.yaml
@@ -5,4 +5,7 @@ resources:
 - host-config.yaml
 - external-secrets.yaml
 
+components:
+  - ../k-components/manager-resources
+
 namespace: multi-platform-controller

--- a/components/multi-platform-controller/staging/kustomization.yaml
+++ b/components/multi-platform-controller/staging/kustomization.yaml
@@ -5,4 +5,7 @@ resources:
 - host-config.yaml
 - external-secrets.yaml
 
+components:
+  - ../k-components/manager-resources
+
 namespace: multi-platform-controller


### PR DESCRIPTION
Align MPC controller memory to be the same on all staging and production environments. Also reduce memory from 16Gi to 10Gi, rh01 is the most used cluster and memory is never going past 6Gi.