### PR TITLE
Upgrade MCE to 2.7 in production

### DIFF
--- a/components/cluster-as-a-service/base/multicluster-engine.yaml
+++ b/components/cluster-as-a-service/base/multicluster-engine.yaml
@@ -27,7 +27,7 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "-1"
 spec:
-  channel: stable-2.6
+  channel: stable-2.7
   installPlanApproval: Automatic
   name: multicluster-engine
   source: redhat-operators

--- a/components/cluster-as-a-service/development/kustomization.yaml
+++ b/components/cluster-as-a-service/development/kustomization.yaml
@@ -14,11 +14,3 @@ patches:
     target:
       group: argoproj.io
       kind: ArgoCD
-  - patch: |
-      - op: replace
-        path: /spec/channel
-        value: stable-2.7
-    target:
-      group: operators.coreos.com
-      kind: Subscription
-      name: multicluster-engine

--- a/components/cluster-as-a-service/production/add-hypershift-params.yaml
+++ b/components/cluster-as-a-service/production/add-hypershift-params.yaml
@@ -9,7 +9,7 @@
   path: /spec/template/spec/source/helm/parameters/-
   value:
     name: hypershiftImage
-    value: registry.redhat.io/multicluster-engine/hypershift-rhel9-operator:v2.6
+    value: registry.redhat.io/multicluster-engine/hypershift-rhel9-operator:v2.7
 
 - op: add
   path: /spec/template/spec/source/helm/parameters/-

--- a/components/cluster-as-a-service/staging/kustomization.yaml
+++ b/components/cluster-as-a-service/staging/kustomization.yaml
@@ -11,11 +11,3 @@ patches:
       group: argoproj.io
       kind: ApplicationSet
       name: hypershift-aws-cluster
-  - patch: |
-      - op: replace
-        path: /spec/channel
-        value: stable-2.7
-    target:
-      group: operators.coreos.com
-      kind: Subscription
-      name: multicluster-engine


### PR DESCRIPTION
A 4.17.4 cluster was successfully provisioned in staging. Promoting the MCE upgrade to prod.