### PR TITLE
patch to staging cluster-provisioner pod read

### DIFF
--- a/components/cluster-as-a-service/staging/kustomization.yaml
+++ b/components/cluster-as-a-service/staging/kustomization.yaml
@@ -5,6 +5,8 @@ resources:
   - ../base
   - ../../openshift-gitops
   - external-secrets.yaml
+  - namespace-manager-pod-reader-role.yaml
+  - namespace-manager-pod-reader-binding.yaml
 patches:
   - path: add-hypershift-params.yaml
     target:

--- a/components/cluster-as-a-service/staging/namespace-manager-pod-reader-binding.yaml
+++ b/components/cluster-as-a-service/staging/namespace-manager-pod-reader-binding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: namespace-manager-pod-reader-binding
+  namespace: clusters # Binding is scoped to the 'clusters' namespace
+subjects:
+  - kind: ServiceAccount
+    name: namespace-manager
+    namespace: ${SPACE_NAME}-eaas # TODO: need to find a non var solution here
+roleRef:
+  kind: Role
+  name: namespace-manager-pod-reader # Refers to the Role in the 'clusters' namespace
+  apiGroup: rbac.authorization.k8s.io

--- a/components/cluster-as-a-service/staging/namespace-manager-pod-reader-role.yaml
+++ b/components/cluster-as-a-service/staging/namespace-manager-pod-reader-role.yaml
@@ -1,0 +1,9 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: namespace-manager-pod-reader
+  namespace: clusters # Restricts the permissions to the 'clusters' namespace
+rules:
+  - apiGroups: [""]
+    resources: ["pods/log"]
+    verbs: ["get"]


### PR DESCRIPTION
This PR should patch the clusterRole cluster-provisioner to also allow for getting pod logs.