### PR TITLE
KFLUXINFRA-1000: Remove routing setup to support TGW route prod internal

### DIFF
--- a/components/multi-platform-controller/production-downstream/host-config.yaml
+++ b/components/multi-platform-controller/production-downstream/host-config.yaml
@@ -428,11 +428,6 @@ data:
   dynamic.linux-ppc64le.memory: "8"
   dynamic.linux-ppc64le.max-instances: "50"
   dynamic.linux-ppc64le.allocation-timeout: "1800"
-  dynamic.linux-ppc64le.user-data: |-
-    #cloud-config
-    runcmd:
-    - ip route add 10.0.0.0/8 via 10.130.72.1
-    - ip route add 0.0.0.0/0 via 10.130.73.115
 
   #PPC64LE Large dynamic nodes
   dynamic.linux-large-ppc64le.type: ibmp


### PR DESCRIPTION
Allow TGW routetable to manage the routing for the internet traffic