### PR TITLE
update hac-dev ui to latest(9522a36)

### DIFF
--- a/components/ui/development/kustomization.yaml
+++ b/components/ui/development/kustomization.yaml
@@ -15,7 +15,7 @@ images:
   # hac-dev
   - name: quay.io/cloudservices/hac-dev-frontend
     newName: quay.io/cloudservices/hac-dev-frontend
-    newTag: 26babff
+    newTag: 9522a36
 
 configMapGenerator:
   - name: fed-modules

--- a/components/ui/production/kflux-ocp-p01/kustomization.yaml
+++ b/components/ui/production/kflux-ocp-p01/kustomization.yaml
@@ -19,7 +19,7 @@ images:
   # hac-dev
   - name: quay.io/cloudservices/hac-dev-frontend
     newName: quay.io/cloudservices/hac-dev-frontend
-    newTag: f97289a
+    newTag: 9522a36
 
 configMapGenerator:
   - name: fed-modules

--- a/components/ui/production/stone-prod-p01/kustomization.yaml
+++ b/components/ui/production/stone-prod-p01/kustomization.yaml
@@ -19,7 +19,7 @@ images:
   # hac-dev
   - name: quay.io/cloudservices/hac-dev-frontend
     newName: quay.io/cloudservices/hac-dev-frontend
-    newTag: f97289a
+    newTag: 9522a36
 
 configMapGenerator:
   - name: fed-modules

--- a/components/ui/production/stone-prod-p02/kustomization.yaml
+++ b/components/ui/production/stone-prod-p02/kustomization.yaml
@@ -19,7 +19,7 @@ images:
   # hac-dev
   - name: quay.io/cloudservices/hac-dev-frontend
     newName: quay.io/cloudservices/hac-dev-frontend
-    newTag: f97289a
+    newTag: 9522a36
 
 configMapGenerator:
   - name: fed-modules

--- a/components/ui/staging/kustomization.yaml
+++ b/components/ui/staging/kustomization.yaml
@@ -19,7 +19,7 @@ images:
   # hac-dev
   - name: quay.io/cloudservices/hac-dev-frontend
     newName: quay.io/cloudservices/hac-dev-frontend
-    newTag: 26babff
+    newTag: 9522a36
 
 configMapGenerator:
   - name: fed-modules


### PR DESCRIPTION
# Pull Requests change-log
Repository: openshift/hac-dev
Changes between f97289a and 9522a36

## 🚀 Features
- openshift/hac-dev#1013 feat([KFLUXBUGS-1372](https://issues.redhat.com//browse/KFLUXBUGS-1372)): improve the label of private image repo by @testcara [`lgtm,approved`] ([PR](https://github.com/openshift/hac-dev/pull/1013))
- openshift/hac-dev#997 feat(HAC-5814): allow users to set context in UI by @CryptoRodeo [`lgtm,approved`] ([PR](https://github.com/openshift/hac-dev/pull/997))
- openshift/hac-dev#994 feat([KFLUXBUGS-1540](https://issues.redhat.com//browse/KFLUXBUGS-1540)): filter on Applications by @caugello [`lgtm,approved`] ([PR](https://github.com/openshift/hac-dev/pull/994))
- openshift/hac-dev#969 feat(import): add gitlab annotation by @abhinandan13jan [`lgtm,approved`] ([PR](https://github.com/openshift/hac-dev/pull/969))

## 🐛 Bug Fixes
- openshift/hac-dev#1025 Fix mounted files permissions by @Katka92 [`lgtm,approved`] ([PR](https://github.com/openshift/hac-dev/pull/1025))
- openshift/hac-dev#1005 fix([KFLUXBUGS-1680](https://issues.redhat.com//browse/KFLUXBUGS-1680)): filter records on creationTimestamp by @caugello [`lgtm,approved`] ([PR](https://github.com/openshift/hac-dev/pull/1005))
- openshift/hac-dev#1018 fix([KFLUXBUGS-1751](https://issues.redhat.com//browse/KFLUXBUGS-1751)): release status replies on status and reason of the release type by @testcara [`lgtm,approved`] ([PR](https://github.com/openshift/hac-dev/pull/1018))
- openshift/hac-dev#1017 fix([KFLUXBUGS-1537](https://issues.redhat.com//browse/KFLUXBUGS-1537)): activity tab should use component.metadata.name by @testcara [`lgtm,approved`] ([PR](https://github.com/openshift/hac-dev/pull/1017))
- openshift/hac-dev#1023 fix(e2e): enable tests on eph env by @Katka92 [`lgtm,approved`] ([PR](https://github.com/openshift/hac-dev/pull/1023))
- openshift/hac-dev#1011 fix(e2e): fix and stabilize e2e tests by @Katka92 [`lgtm,approved`] ([PR](https://github.com/openshift/hac-dev/pull/1011))
- openshift/hac-dev#1016 fix([KFLUXBUGS-1485](https://issues.redhat.com//browse/KFLUXBUGS-1485)): cancelled state on stopped runs by @caugello [`lgtm,approved`] ([PR](https://github.com/openshift/hac-dev/pull/1016))
- openshift/hac-dev#1010 fix(e2e): enable sbom test, fix missing pageobjects by @Katka92 [`lgtm,approved`] ([PR](https://github.com/openshift/hac-dev/pull/1010))
- openshift/hac-dev#1002 fix(pipeline): null check on status of taskrun by @abhinandan13jan [`lgtm,approved`] ([PR](https://github.com/openshift/hac-dev/pull/1002))
- openshift/hac-dev#993 fix([KFLUXBUGS-603](https://issues.redhat.com//browse/KFLUXBUGS-603)): update usage of build trigger by @CryptoRodeo [`lgtm,ok-to-test,approved`] ([PR](https://github.com/openshift/hac-dev/pull/993))
- openshift/hac-dev#1007 fix([KFLUXBUGS-1648](https://issues.redhat.com//browse/KFLUXBUGS-1648)): display parameter name for IntegrationTests by @marcin-michal [`lgtm,approved`] ([PR](https://github.com/openshift/hac-dev/pull/1007))
- openshift/hac-dev#1001 fix([KFLUXBUGS-902](https://issues.redhat.com//browse/KFLUXBUGS-902)): disable pipeline actions for contributors by @caugello [`lgtm,approved`] ([PR](https://github.com/openshift/hac-dev/pull/1001))
- openshift/hac-dev#1003 fix([KFLUXBUGS-1719](https://issues.redhat.com//browse/KFLUXBUGS-1719)): support dot in the username format by @testcara [`lgtm,approved`] ([PR](https://github.com/openshift/hac-dev/pull/1003))
- openshift/hac-dev#1004 fix(HAC-5855): only suggest branches for component by @CryptoRodeo [`lgtm,approved`] ([PR](https://github.com/openshift/hac-dev/pull/1004))
- openshift/hac-dev#1000 fix([KFLUXBUGS-1144](https://issues.redhat.com//browse/KFLUXBUGS-1144)): readable RPAs for contributors by @caugello [`lgtm,approved`] ([PR](https://github.com/openshift/hac-dev/pull/1000))
- openshift/hac-dev#998 fix: use status.managedProcessing to get the pipelineRun for Release by @sahil143 [`lgtm,approved`] ([PR](https://github.com/openshift/hac-dev/pull/998))
- openshift/hac-dev#981 fix: use the correct workspace based on namespace for Github redirect by @sahil143 [`lgtm,approved`] ([PR](https://github.com/openshift/hac-dev/pull/981))
- openshift/hac-dev#990 fix([KFLUXBUGS-1494](https://issues.redhat.com//browse/KFLUXBUGS-1494)): get correct snapshots by @CryptoRodeo [`lgtm,ok-to-test,approved`] ([PR](https://github.com/openshift/hac-dev/pull/990))
- openshift/hac-dev#991 fix([KFLUXBUGS-96](https://issues.redhat.com//browse/KFLUXBUGS-96)): make the secret forms more clear by @JoaoPedroPP [`lgtm,ok-to-test,approved`] ([PR](https://github.com/openshift/hac-dev/pull/991))
- openshift/hac-dev#995 fix(test): fix integration test name by @Katka92 [`lgtm,approved`] ([PR](https://github.com/openshift/hac-dev/pull/995))
- openshift/hac-dev#988 fix([KFLUXBUGS-1197](https://issues.redhat.com//browse/KFLUXBUGS-1197)): component relationship remove button by @caugello [`lgtm,ok-to-test,approved`] ([PR](https://github.com/openshift/hac-dev/pull/988))
- openshift/hac-dev#987 Fix private and advanced tests by @Katka92 [`lgtm,approved`] ([PR](https://github.com/openshift/hac-dev/pull/987))
- openshift/hac-dev#983 fix: check permission for Component relationships by @sahil143 [`lgtm,approved`] ([PR](https://github.com/openshift/hac-dev/pull/983))
- openshift/hac-dev#982 fix: enable rerun action only forpush builds by @sahil143 [`lgtm,approved`] ([PR](https://github.com/openshift/hac-dev/pull/982))
- openshift/hac-dev#984 fix: format integration test param in the EditParamsModal by @sahil143 [`lgtm,approved`] ([PR](https://github.com/openshift/hac-dev/pull/984))
- openshift/hac-dev#986 fix(e2e): wait for eph deployment to roll out by @jrichter1 [`lgtm,approved`] ([PR](https://github.com/openshift/hac-dev/pull/986))
- openshift/hac-dev#970 fix(components): update imageURL by @abhinandan13jan [`lgtm,approved`] ([PR](https://github.com/openshift/hac-dev/pull/970))

## 📦 Other Changes
- openshift/hac-dev#1014 update owners file by @Katka92 [`lgtm,approved`] ([PR](https://github.com/openshift/hac-dev/pull/1014))
- openshift/hac-dev#996 enable SBOM check during advanced test flow by @Katka92 [`lgtm,approved`] ([PR](https://github.com/openshift/hac-dev/pull/996))
- openshift/hac-dev#999 chore: add reviewers by @sahil143 [`lgtm,approved`] ([PR](https://github.com/openshift/hac-dev/pull/999))
