### PR TITLE
Fix PAC secret in production build service

### DIFF
--- a/components/build-service/production/base/kustomization.yaml
+++ b/components/build-service/production/base/kustomization.yaml
@@ -22,9 +22,7 @@ patches:
       kind: ExternalSecret
       group: external-secrets.io
       version: v1beta1
+  - path: manager_resources_patch.yaml
 
 components:
   - ../../components/rh-certs
-
-patches:
-  - path: manager_resources_patch.yaml


### PR DESCRIPTION
In 8475b04da, a patch was added to change build services manager resources but by mistake, as second "patches" section was added causing the patch in the original section to be ignored.

Fold both "patches" section into one so both resources and secret patches get applied.

[KFLUXBUGS-1880](https://issues.redhat.com//browse/KFLUXBUGS-1880)