### PR TITLE
chore: promote project-controller to production

### DIFF
--- a/components/project-controller/production/kustomization.yaml
+++ b/components/project-controller/production/kustomization.yaml
@@ -2,11 +2,11 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - ../base
-- https://github.com/konflux-ci/project-controller/config/default?ref=1a27894d93961d737d2a9e911d3a9fd8020841c2
+- https://github.com/konflux-ci/project-controller/config/default?ref=25132f7b2c836c3eebadc87b6c0bd0320ba3d080
 
 images:
 - name: konflux-project-controller
   newName: quay.io/konflux-ci/project-controller
-  newTag: 1a27894d93961d737d2a9e911d3a9fd8020841c2
+  newTag: 25132f7b2c836c3eebadc87b6c0bd0320ba3d080
 
 namespace: project-controller


### PR DESCRIPTION
This introduces into production a change in which the controller watches also over the project and template resources.
https://github.com/konflux-ci/project-controller/pull/124