### PR TITLE
Run MintMaker every 4 hours instead of 2 hours

### DIFF
--- a/components/mintmaker/base/cronjobs/create-dependency-update-check.yaml
+++ b/components/mintmaker/base/cronjobs/create-dependency-update-check.yaml
@@ -4,7 +4,7 @@ metadata:
   name: create-dependencyupdatecheck
   namespace: mintmaker
 spec:
-  schedule: "0 */2 * * *" # every 2 hours
+  schedule: "0 */4 * * *" # every 4 hours
   jobTemplate:
     spec:
       template:


### PR DESCRIPTION
Due to the amount of components on-boarding to Konflux, the load of MintMaker runs is increasing quite a lot. Let's reduce the frequency, at least untile we figure out how to improve the performances.