### PR TITLE
APPSRE-11137 add app-sre SecretStore

### DIFF
--- a/components/cluster-secret-store-rh/base/app-sre-secret-store.yaml
+++ b/components/cluster-secret-store-rh/base/app-sre-secret-store.yaml
@@ -27,7 +27,7 @@ spec:
           roleId: "" # will be added by the overlay
           # Reference to a key in a K8 Secret that contains the App Role SecretId
           secretRef:
-            name: app-sre-vault
+            name: secret-store-credentials
             key: secret-id
-            namespace: appsre-vault
+            namespace: app-sre-tenant
 

--- a/components/cluster-secret-store-rh/base/app-sre-secret-store.yaml
+++ b/components/cluster-secret-store-rh/base/app-sre-secret-store.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: external-secrets.io/v1beta1
+kind: SecretStore
+metadata:
+  name: app-sre-vault
+  namespace: app-sre-tenant
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  provider:
+    vault:
+      server: "https://vault.ci.ext.devshift.net"
+      # Path is the mount path of the Vault KV backend endpoint
+      # Used as a path prefix for the external secret key
+      path: app-sre-v2
+      # Version is the Vault KV secret engine version.
+      # This can be either "v1" or "v2", defaults to "v2"
+      version: v2
+      auth:
+        # VaultAppRole authenticates with Vault using the
+        # App Role auth mechanism
+        # https://www.vaultproject.io/docs/auth/approle
+        appRole:
+          # Path where the App Role authentication backend is mounted
+          path: approle
+          # RoleID configured in the App Role authentication backend
+          roleId: "" # will be added by the overlay
+          # Reference to a key in a K8 Secret that contains the App Role SecretId
+          secretRef:
+            name: app-sre-vault
+            key: secret-id
+            namespace: appsre-vault
+

--- a/components/cluster-secret-store-rh/base/kustomization.yaml
+++ b/components/cluster-secret-store-rh/base/kustomization.yaml
@@ -4,3 +4,5 @@ resources:
   - appsre-stonesoup-vault-rh-secret-store.yaml
   - insights-secret-store.yaml
   - rh-artifacts-bucket-writer-secret-store.yml
+  - app-sre-secret-store.yaml
+

--- a/components/cluster-secret-store-rh/production/app-sre-approle-id-patch.yaml
+++ b/components/cluster-secret-store-rh/production/app-sre-approle-id-patch.yaml
@@ -1,0 +1,4 @@
+---
+- op: add
+  path: /spec/provider/vault/auth/appRole/roleId
+  value: 3c48c2ff-2638-8df7-ab13-b50560f6104e

--- a/components/cluster-secret-store-rh/production/kustomization.yaml
+++ b/components/cluster-secret-store-rh/production/kustomization.yaml
@@ -14,3 +14,9 @@ patches:
       kind: ClusterSecretStore
       group: external-secrets.io
       version: v1beta1
+  - path: app-sre-approle-id-patch.yaml
+    target:
+      name: app-sre-vault
+      kind: SecretStore
+      group: external-secrets.io
+      version: v1beta1


### PR DESCRIPTION
**Intent**

Adding a `SecretStore` for the `app-sre-tenant` namespace in **public** Konflux instance.
secretID is already provisioned manually in our own workspace `app-sre-tenant`.

Open questions:

- how can I make sure this is only provisioned in the public konflux instance?
~~- how do I provision the secretID in `appsre-vault`?~~ 