### PR TITLE
Temporarily adjust Renovate jobs to run every 4 hours from Friday to Sunday

### DIFF
--- a/components/mintmaker/base/cronjobs/create-dependency-update-check.yaml
+++ b/components/mintmaker/base/cronjobs/create-dependency-update-check.yaml
@@ -4,7 +4,7 @@ metadata:
   name: create-dependencyupdatecheck
   namespace: mintmaker
 spec:
-  schedule: "0 */4 * * *" # every 4 hours
+  schedule: "0 */4 * * 5-7" # every 4 hours from Friday to Sunday
   jobTemplate:
     spec:
       template:

--- a/components/mintmaker/production/stone-prod-p01/cronjob-patch.yaml
+++ b/components/mintmaker/production/stone-prod-p01/cronjob-patch.yaml
@@ -1,0 +1,3 @@
+- op: replace
+  path: /spec/schedule
+  value: "0 */4 * * *" # every 4 hours

--- a/components/mintmaker/production/stone-prod-p01/kustomization.yaml
+++ b/components/mintmaker/production/stone-prod-p01/kustomization.yaml
@@ -10,6 +10,10 @@ patches:
       group: external-secrets.io
       version: v1beta1
       kind: ExternalSecret
+  - path: cronjob-patch.yaml
+    target:
+      name: create-dependencyupdatecheck
+      kind: CronJob
 
 components:
   - ../../components/rh-certs

--- a/components/mintmaker/production/stone-prod-p02/cronjob-patch.yaml
+++ b/components/mintmaker/production/stone-prod-p02/cronjob-patch.yaml
@@ -1,0 +1,3 @@
+- op: replace
+  path: /spec/schedule
+  value: "0 */4 * * *" # every 4 hours

--- a/components/mintmaker/production/stone-prod-p02/kustomization.yaml
+++ b/components/mintmaker/production/stone-prod-p02/kustomization.yaml
@@ -10,6 +10,10 @@ patches:
       group: external-secrets.io
       version: v1beta1
       kind: ExternalSecret
+  - path: cronjob-patch.yaml
+    target:
+      name: create-dependencyupdatecheck
+      kind: CronJob
 
 components:
   - ../../components/rh-certs


### PR DESCRIPTION
This change will be reverted after the new release of the customized schedule for managers is deployed, planned for tomorrow.

The change is not applied to p01 and p02 clusters.