### PR TITLE
mintmaker: fix invalid k8s cronjob schedule

### DIFF
--- a/components/mintmaker/base/cronjobs/create-dependency-update-check.yaml
+++ b/components/mintmaker/base/cronjobs/create-dependency-update-check.yaml
@@ -4,7 +4,7 @@ metadata:
   name: create-dependencyupdatecheck
   namespace: mintmaker
 spec:
-  schedule: "0 */4 * * 5-7" # every 4 hours from Friday to Sunday
+  schedule: "0 */4 * * 5-6" # every 4 hours from Friday to Saturday
   jobTemplate:
     spec:
       template:


### PR DESCRIPTION
The k8s CronJob schedule uses a syntax similar to Linux crontab, but it has a key difference: the day of the week field only accepts values from 0 to 6.