### PR TITLE
Install knative-eventing instead knative-eventing-core

### DIFF
--- a/components/knative-eventing/base/kustomization.yaml
+++ b/components/knative-eventing/base/kustomization.yaml
@@ -2,7 +2,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - https://github.com/knative/eventing/releases/download/knative-v1.15.3/eventing-core.yaml?timeout=90s
+  - https://github.com/knative/eventing/releases/download/knative-v1.15.3/eventing.yaml?timeout=90s
 
 patches:
 # kube-lint fixes


### PR DESCRIPTION
* KubeArchive needs knative-eventing instead knative-eventing-core now that brokers are introduced
* KubeArchive is using in-memory brokers by default which we think is enough. If you think Konflux need more performant brokers like Kafka those should be included.