### PR TITLE
Turn off self healing for konflux-ui

### DIFF
--- a/argo-cd-apps/base/member/infra-deployments/konflux-ui/konflux-ui.yaml
+++ b/argo-cd-apps/base/member/infra-deployments/konflux-ui/konflux-ui.yaml
@@ -33,7 +33,7 @@ spec:
       syncPolicy:
         automated:
           prune: true
-          selfHeal: true
+          selfHeal: false
         syncOptions:
           - CreateNamespace=true
         retry:


### PR DESCRIPTION
There is an issue where websockets connections
doesn't work with the new ui deployment. Turning off self healing will help debug the issue.