### PR TITLE
chore(KFLUXINFRA-930): Bump MPC in production

### DIFF
--- a/components/multi-platform-controller/production-downstream/base/kustomization.yaml
+++ b/components/multi-platform-controller/production-downstream/base/kustomization.yaml
@@ -5,8 +5,8 @@ namespace: multi-platform-controller
 
 resources:
 - ../../base/common
-- https://github.com/konflux-ci/multi-platform-controller/deploy/operator?ref=6f8abf513a9da030c16286ef9fffa4084db33cca
-- https://github.com/konflux-ci/multi-platform-controller/deploy/otp?ref=6f8abf513a9da030c16286ef9fffa4084db33cca
+- https://github.com/konflux-ci/multi-platform-controller/deploy/operator?ref=143b83fa5a2b2fe6a8abe02cc669c05b5c3f4f15
+- https://github.com/konflux-ci/multi-platform-controller/deploy/otp?ref=143b83fa5a2b2fe6a8abe02cc669c05b5c3f4f15
 - external-secrets.yaml
 
 components:
@@ -15,7 +15,7 @@ components:
 images:
 - name: multi-platform-controller
   newName: quay.io/konflux-ci/multi-platform-controller
-  newTag: 6f8abf513a9da030c16286ef9fffa4084db33cca
+  newTag: 143b83fa5a2b2fe6a8abe02cc669c05b5c3f4f15
 - name: multi-platform-otp-server
   newName: quay.io/konflux-ci/multi-platform-controller-otp-service
-  newTag: 6f8abf513a9da030c16286ef9fffa4084db33cca
+  newTag: 143b83fa5a2b2fe6a8abe02cc669c05b5c3f4f15

--- a/components/multi-platform-controller/production/kustomization.yaml
+++ b/components/multi-platform-controller/production/kustomization.yaml
@@ -7,8 +7,8 @@ resources:
 - ../base/common
 - host-config.yaml
 - external-secrets.yaml
-- https://github.com/konflux-ci/multi-platform-controller/deploy/operator?ref=6f8abf513a9da030c16286ef9fffa4084db33cca
-- https://github.com/konflux-ci/multi-platform-controller/deploy/otp?ref=6f8abf513a9da030c16286ef9fffa4084db33cca
+- https://github.com/konflux-ci/multi-platform-controller/deploy/operator?ref=143b83fa5a2b2fe6a8abe02cc669c05b5c3f4f15
+- https://github.com/konflux-ci/multi-platform-controller/deploy/otp?ref=143b83fa5a2b2fe6a8abe02cc669c05b5c3f4f15
 
 components:
   - ../k-components/manager-resources
@@ -16,7 +16,7 @@ components:
 images:
 - name: multi-platform-controller
   newName: quay.io/konflux-ci/multi-platform-controller
-  newTag: 6f8abf513a9da030c16286ef9fffa4084db33cca
+  newTag: 143b83fa5a2b2fe6a8abe02cc669c05b5c3f4f15
 - name: multi-platform-otp-server
   newName: quay.io/konflux-ci/multi-platform-controller-otp-service
-  newTag: 6f8abf513a9da030c16286ef9fffa4084db33cca
+  newTag: 143b83fa5a2b2fe6a8abe02cc669c05b5c3f4f15


### PR DESCRIPTION
This is in order to  include the more detailed logging in SSH secret we
now have.