### PR TITLE
Enable proactive scaler in staging

### DIFF
--- a/argo-cd-apps/overlays/konflux-public-staging/delete-applications.yaml
+++ b/argo-cd-apps/overlays/konflux-public-staging/delete-applications.yaml
@@ -5,9 +5,3 @@ kind: ApplicationSet
 metadata:
   name: tempo
 $patch: delete
----
-apiVersion: argoproj.io/v1alpha1
-kind: ApplicationSet
-metadata:
-  name: proactive-scaler
-$patch: delete

--- a/argo-cd-apps/overlays/production-downstream/kustomization.yaml
+++ b/argo-cd-apps/overlays/production-downstream/kustomization.yaml
@@ -8,7 +8,6 @@ resources:
   - ../../base/keycloak
   - ../../base/repository-validator
   - ../../base/cluster-secret-store-rh
-  - ../../base/member/infra-deployments/proactive-scaler
 patchesStrategicMerge:
   - delete-applications.yaml
 namespace: argocd


### PR DESCRIPTION
Since we use nodes with nvme in staging too, we need to enable proactive scaler otherwise it take too much time to add a node. In addition, we need staging to be configured the same way as prod so any test we run there are more representative of production environment.