### PR TITLE
chore: adds konflux secret store

### DIFF
--- a/components/cluster-secret-store/base/appsre-konflux-vault-secret-store.yaml
+++ b/components/cluster-secret-store/base/appsre-konflux-vault-secret-store.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ClusterSecretStore
+metadata:
+  name: appsre-konflux-vault
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  provider:
+    vault:
+      server: "https://vault.ci.ext.devshift.net"
+      path: konflux
+      version: v2
+      auth:
+        # VaultAppRole authenticates with Vault using the
+        # App Role auth mechanism
+        # https://www.vaultproject.io/docs/auth/approle
+        appRole:
+          # Path where the App Role authentication backend is mounted
+          path: approle
+          # RoleID configured in the App Role authentication backend
+          roleId: d2d9c931-5fce-7b40-bf69-f4ee411ee891
+          # Reference to a key in a K8 Secret that contains the App Role SecretId
+          secretRef:
+            name: appsre-vault
+            key: secret-id
+            namespace: appsre-vault
+  conditions:
+    - namespaces:
+        - rhtap-release-2-tenant
+        - release-service

--- a/components/cluster-secret-store/base/kustomization.yaml
+++ b/components/cluster-secret-store/base/kustomization.yaml
@@ -2,4 +2,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - appsre-stonesoup-vault-secret-store.yaml
+  - appsre-konflux-vault-secret-store.yaml
   - appsre-vault-secret-store.yml


### PR DESCRIPTION
this PR adds the vault path */konflux* to the
Cluster secret store so the release-service-monitor can use the pyxis stage secret.