### PR TITLE
chore: Remove crossplane-config secret file

### DIFF
--- a/components/crossplane-config/base/kustomization.yaml
+++ b/components/crossplane-config/base/kustomization.yaml
@@ -3,4 +3,3 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - rbac.yaml
-  - secret.yaml

--- a/components/crossplane-config/base/secret.yaml
+++ b/components/crossplane-config/base/secret.yaml
@@ -1,9 +1,0 @@
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: crossplane-secret
-  namespace: crossplane-config
-  annotations:
-    kubernetes.io/service-account.name: crossplane-sa
-type: kubernetes.io/service-account-token


### PR DESCRIPTION
Remove crossplane-config secret file since argocd
might override the token generated.

Jira-Url: https://issues.redhat.com/browse/KFLUXVNGD-89