### PR TITLE
Revert "Pass QPS, Burst and Thread Flag to Results Watcher (#5055)"

### DIFF
--- a/components/pipeline-service/development/main-pipeline-service-configuration.yaml
+++ b/components/pipeline-service/development/main-pipeline-service-configuration.yaml
@@ -1278,9 +1278,6 @@ spec:
             - -completed_run_grace_period=2h
             - -store_deadline=1m
             - -forward_buffer=1m
-            - -kube-api-qps=50
-            - -kube-api-burst=50
-            - -threadiness=32
             - -logs_api=true
           env:
             - name: SYSTEM_NAMESPACE

--- a/components/pipeline-service/production/base/main-pipeline-service-configuration.yaml
+++ b/components/pipeline-service/production/base/main-pipeline-service-configuration.yaml
@@ -1232,9 +1232,6 @@ spec:
         - -check_owner=false
         - -completed_run_grace_period
         - 10m
-        - -kube-api-qps=50
-        - -kube-api-burst=50
-        - -threadiness=32
         env:
         - name: SYSTEM_NAMESPACE
           valueFrom:

--- a/components/pipeline-service/production/kflux-ocp-p01/deploy.yaml
+++ b/components/pipeline-service/production/kflux-ocp-p01/deploy.yaml
@@ -1616,9 +1616,6 @@ spec:
         - -check_owner=false
         - -completed_run_grace_period
         - 10m
-        - -kube-api-qps=50
-        - -kube-api-burst=50
-        - -threadiness=32
         env:
         - name: SYSTEM_NAMESPACE
           valueFrom:

--- a/components/pipeline-service/production/kflux-prd-rh02/deploy.yaml
+++ b/components/pipeline-service/production/kflux-prd-rh02/deploy.yaml
@@ -1616,9 +1616,6 @@ spec:
         - -check_owner=false
         - -completed_run_grace_period
         - 10m
-        - -kube-api-qps=50
-        - -kube-api-burst=50
-        - -threadiness=32
         env:
         - name: SYSTEM_NAMESPACE
           valueFrom:

--- a/components/pipeline-service/production/stone-prd-m01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prd-m01/deploy.yaml
@@ -1616,9 +1616,6 @@ spec:
         - -check_owner=false
         - -completed_run_grace_period
         - 10m
-        - -kube-api-qps=50
-        - -kube-api-burst=50
-        - -threadiness=32
         env:
         - name: SYSTEM_NAMESPACE
           valueFrom:

--- a/components/pipeline-service/production/stone-prd-rh01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prd-rh01/deploy.yaml
@@ -1616,9 +1616,6 @@ spec:
         - -check_owner=false
         - -completed_run_grace_period
         - 10m
-        - -kube-api-qps=50
-        - -kube-api-burst=50
-        - -threadiness=32
         env:
         - name: SYSTEM_NAMESPACE
           valueFrom:

--- a/components/pipeline-service/production/stone-prod-p01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prod-p01/deploy.yaml
@@ -1616,9 +1616,6 @@ spec:
         - -check_owner=false
         - -completed_run_grace_period
         - 10m
-        - -kube-api-qps=50
-        - -kube-api-burst=50
-        - -threadiness=32
         env:
         - name: SYSTEM_NAMESPACE
           valueFrom:

--- a/components/pipeline-service/production/stone-prod-p02/deploy.yaml
+++ b/components/pipeline-service/production/stone-prod-p02/deploy.yaml
@@ -1616,9 +1616,6 @@ spec:
         - -check_owner=false
         - -completed_run_grace_period
         - 10m
-        - -kube-api-qps=50
-        - -kube-api-burst=50
-        - -threadiness=32
         env:
         - name: SYSTEM_NAMESPACE
           valueFrom:

--- a/components/pipeline-service/staging/base/main-pipeline-service-configuration.yaml
+++ b/components/pipeline-service/staging/base/main-pipeline-service-configuration.yaml
@@ -1271,9 +1271,6 @@ spec:
             - -completed_run_grace_period
             - 10m
             - -logs_api=true
-            - -kube-api-qps=50
-            - -kube-api-burst=50
-            - -threadiness=32
           env:
             - name: SYSTEM_NAMESPACE
               valueFrom:

--- a/components/pipeline-service/staging/stone-stage-p01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stage-p01/deploy.yaml
@@ -1660,9 +1660,6 @@ spec:
         - -completed_run_grace_period
         - 10m
         - -logs_api=true
-        - -kube-api-qps=50
-        - -kube-api-burst=50
-        - -threadiness=32
         env:
         - name: SYSTEM_NAMESPACE
           valueFrom:

--- a/components/pipeline-service/staging/stone-stg-rh01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stg-rh01/deploy.yaml
@@ -1660,9 +1660,6 @@ spec:
         - -completed_run_grace_period
         - 10m
         - -logs_api=true
-        - -kube-api-qps=50
-        - -kube-api-burst=50
-        - -threadiness=32
         env:
         - name: SYSTEM_NAMESPACE
           valueFrom:


### PR DESCRIPTION
This reverts commit 247d757c412a067eed746e753de94c202d59879a. Watcher is not starting due to invalid -kube-api-qps.