### PR TITLE
feat: Pass QPS, Burst and Thread Flag to Results Watcher, attempt 2

### DIFF
--- a/components/pipeline-service/development/main-pipeline-service-configuration.yaml
+++ b/components/pipeline-service/development/main-pipeline-service-configuration.yaml
@@ -1278,6 +1278,9 @@ spec:
             - -completed_run_grace_period=2h
             - -store_deadline=1m
             - -forward_buffer=1m
+            - -qps=50
+            - -burst=50
+            - -threadiness=32
             - -logs_api=true
           env:
             - name: SYSTEM_NAMESPACE

--- a/components/pipeline-service/production/base/main-pipeline-service-configuration.yaml
+++ b/components/pipeline-service/production/base/main-pipeline-service-configuration.yaml
@@ -1232,6 +1232,9 @@ spec:
         - -check_owner=false
         - -completed_run_grace_period
         - 10m
+        - -qps=50
+        - -burst=50
+        - -threadiness=32
         env:
         - name: SYSTEM_NAMESPACE
           valueFrom:

--- a/components/pipeline-service/production/kflux-ocp-p01/deploy.yaml
+++ b/components/pipeline-service/production/kflux-ocp-p01/deploy.yaml
@@ -1616,6 +1616,9 @@ spec:
         - -check_owner=false
         - -completed_run_grace_period
         - 10m
+        - -qps=50
+        - -burst=50
+        - -threadiness=32
         env:
         - name: SYSTEM_NAMESPACE
           valueFrom:

--- a/components/pipeline-service/production/kflux-prd-rh02/deploy.yaml
+++ b/components/pipeline-service/production/kflux-prd-rh02/deploy.yaml
@@ -1616,6 +1616,9 @@ spec:
         - -check_owner=false
         - -completed_run_grace_period
         - 10m
+        - -qps=50
+        - -burst=50
+        - -threadiness=32
         env:
         - name: SYSTEM_NAMESPACE
           valueFrom:

--- a/components/pipeline-service/production/stone-prd-m01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prd-m01/deploy.yaml
@@ -1616,6 +1616,9 @@ spec:
         - -check_owner=false
         - -completed_run_grace_period
         - 10m
+        - -qps=50
+        - -burst=50
+        - -threadiness=32
         env:
         - name: SYSTEM_NAMESPACE
           valueFrom:

--- a/components/pipeline-service/production/stone-prd-rh01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prd-rh01/deploy.yaml
@@ -1616,6 +1616,9 @@ spec:
         - -check_owner=false
         - -completed_run_grace_period
         - 10m
+        - -qps=50
+        - -burst=50
+        - -threadiness=32
         env:
         - name: SYSTEM_NAMESPACE
           valueFrom:

--- a/components/pipeline-service/production/stone-prod-p01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prod-p01/deploy.yaml
@@ -1616,6 +1616,9 @@ spec:
         - -check_owner=false
         - -completed_run_grace_period
         - 10m
+        - -qps=50
+        - -burst=50
+        - -threadiness=32
         env:
         - name: SYSTEM_NAMESPACE
           valueFrom:

--- a/components/pipeline-service/production/stone-prod-p02/deploy.yaml
+++ b/components/pipeline-service/production/stone-prod-p02/deploy.yaml
@@ -1616,6 +1616,9 @@ spec:
         - -check_owner=false
         - -completed_run_grace_period
         - 10m
+        - -qps=50
+        - -burst=50
+        - -threadiness=32
         env:
         - name: SYSTEM_NAMESPACE
           valueFrom:

--- a/components/pipeline-service/staging/base/main-pipeline-service-configuration.yaml
+++ b/components/pipeline-service/staging/base/main-pipeline-service-configuration.yaml
@@ -1270,6 +1270,9 @@ spec:
             - -check_owner=false
             - -completed_run_grace_period
             - 10m
+            - -qps=50
+            - -burst=50
+            - -threadiness=32
             - -logs_api=true
           env:
             - name: SYSTEM_NAMESPACE

--- a/components/pipeline-service/staging/stone-stage-p01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stage-p01/deploy.yaml
@@ -1659,6 +1659,9 @@ spec:
         - -check_owner=false
         - -completed_run_grace_period
         - 10m
+        - -qps=50
+        - -burst=50
+        - -threadiness=32
         - -logs_api=true
         env:
         - name: SYSTEM_NAMESPACE

--- a/components/pipeline-service/staging/stone-stg-rh01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stg-rh01/deploy.yaml
@@ -1659,6 +1659,9 @@ spec:
         - -check_owner=false
         - -completed_run_grace_period
         - 10m
+        - -qps=50
+        - -burst=50
+        - -threadiness=32
         - -logs_api=true
         env:
         - name: SYSTEM_NAMESPACE


### PR DESCRIPTION
This was initially attempted here: https://github.com/redhat-appstudio/infra-deployments/pull/5055

And reverted here: https://github.com/redhat-appstudio/infra-deployments/pull/5066

Looking at this https://github.com/tektoncd/results/blob/main/cmd/watcher/main.go#L60-L80, looks like right options should not be `-kube-api-qps=50 -kube-api-burst=50 -threadiness=32`, but maybe `-qps=50 -burst=50 -threadiness=32`.

I have not tested this at all though :-/