### PR TITLE
Allow the pipeline runner SA to list secrets

### DIFF
--- a/components/sandbox/toolchain-member-operator/base/rbac/appstudio-pipelines-runner.yaml
+++ b/components/sandbox/toolchain-member-operator/base/rbac/appstudio-pipelines-runner.yaml
@@ -5,6 +5,7 @@ metadata:
 rules:
   - verbs:
       - get
+      - list
     apiGroups:
       - ''
     resources:


### PR DESCRIPTION
The SA can already get secrets but this [stepaction](https://github.com/konflux-ci/build-definitions/tree/main/stepactions/eaas-copy-secrets-to-ephemeral-cluster/0.1) requires list permissions.