### PR TITLE
KFLUXINFRA-1131: Remove cluster path from authentication app

### DIFF
--- a/argo-cd-apps/base/all-clusters/infra-deployments/authentication/authentication.yaml
+++ b/argo-cd-apps/base/all-clusters/infra-deployments/authentication/authentication.yaml
@@ -23,8 +23,6 @@ spec:
                   values.clusterDir: stone-prod-p01
                 - nameNormalized: stone-prod-p02
                   values.clusterDir: stone-prod-p02
-                - nameNormalized: kflux-prd-rh02
-                  values.clusterDir: kflux-prd-rh02
   template:
     metadata:
       name: authentication-{{nameNormalized}}


### PR DESCRIPTION
Public clusters doesn't need to have a dedicated overlay in the authentication app.