### PR TITLE
KFLUXINFRA-1131: Allow tekton to use the appstudio-scc

### DIFF
--- a/components/pipeline-service/production/kflux-prd-rh02/deploy.yaml
+++ b/components/pipeline-service/production/kflux-prd-rh02/deploy.yaml
@@ -124,6 +124,22 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   annotations:
+    argocd.argoproj.io/sync-wave: "0"
+  name: appstudio-pipelines-runner
+rules:
+- apiGroups:
+  - security.openshift.io
+  resourceNames:
+  - appstudio-pipelines-scc
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - use
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
     argocd.argoproj.io/sync-wave: "0"
   name: openshift-gitops-apply-tekton-config-parameters
@@ -830,6 +846,21 @@ subjects:
 - kind: ServiceAccount
   name: metrics-reader
   namespace: tekton-results
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+  name: tekton-pipelines-controller-konflux-scc
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: appstudio-pipelines-runner
+subjects:
+- kind: ServiceAccount
+  name: tekton-pipelines-controller
+  namespace: openshift-pipelines
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/components/pipeline-service/production/kflux-prd-rh02/resources/kustomization.yaml
+++ b/components/pipeline-service/production/kflux-prd-rh02/resources/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../base
+  - scc-rbac.yaml
 patches:
   - path: tekton-chains-public-key-path.yaml
     target:

--- a/components/pipeline-service/production/kflux-prd-rh02/resources/scc-rbac.yaml
+++ b/components/pipeline-service/production/kflux-prd-rh02/resources/scc-rbac.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: appstudio-pipelines-runner
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+rules:
+- apiGroups:
+  - security.openshift.io
+  resourceNames:
+  - appstudio-pipelines-scc
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - use
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: tekton-pipelines-controller-konflux-scc
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+subjects:
+  - kind: ServiceAccount
+    name: tekton-pipelines-controller
+    namespace: openshift-pipelines
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: appstudio-pipelines-runner


### PR DESCRIPTION
In the kflux-prd-rh02 cluster we don't deploy kubesaw which configure the pipelines service account in each namespace to have permissions to access the appstudio scc. Instead, give this permission to tekton's pipeline controller.