### PR TITLE
Add PipelineAsCode labels selector to the forwarder log

### DIFF
--- a/components/pipeline-service/development/main-pipeline-service-configuration.yaml
+++ b/components/pipeline-service/development/main-pipeline-service-configuration.yaml
@@ -1799,7 +1799,7 @@ spec:
               rotate_wait_secs: 5
               glob_minimum_cooldown_ms: 15000
               auto_partial_merge: true
-              extra_label_selector: "app.kubernetes.io/managed-by=tekton-pipelines"
+              extra_label_selector: "app.kubernetes.io/managed-by in (tekton-pipelines,pipelinesascode.tekton.dev)"
             internal_metrics:
               type: internal_metrics
           transforms:

--- a/components/pipeline-service/staging/base/main-pipeline-service-configuration.yaml
+++ b/components/pipeline-service/staging/base/main-pipeline-service-configuration.yaml
@@ -1751,7 +1751,7 @@ spec:
               rotate_wait_secs: 5
               glob_minimum_cooldown_ms: 15000
               auto_partial_merge: true
-              extra_label_selector: "app.kubernetes.io/managed-by=tekton-pipelines"
+              extra_label_selector: "app.kubernetes.io/managed-by in (tekton-pipelines,pipelinesascode.tekton.dev)"
             internal_metrics:
               type: internal_metrics
           transforms:

--- a/components/pipeline-service/staging/stone-stage-p01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stage-p01/deploy.yaml
@@ -1740,7 +1740,7 @@ spec:
               rotate_wait_secs: 5
               glob_minimum_cooldown_ms: 15000
               auto_partial_merge: true
-              extra_label_selector: "app.kubernetes.io/managed-by=tekton-pipelines"
+              extra_label_selector: "app.kubernetes.io/managed-by in (tekton-pipelines,pipelinesascode.tekton.dev)"
             internal_metrics:
               type: internal_metrics
           transforms:

--- a/components/pipeline-service/staging/stone-stg-rh01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stg-rh01/deploy.yaml
@@ -1740,7 +1740,7 @@ spec:
               rotate_wait_secs: 5
               glob_minimum_cooldown_ms: 15000
               auto_partial_merge: true
-              extra_label_selector: "app.kubernetes.io/managed-by=tekton-pipelines"
+              extra_label_selector: "app.kubernetes.io/managed-by in (tekton-pipelines,pipelinesascode.tekton.dev)"
             internal_metrics:
               type: internal_metrics
           transforms:


### PR DESCRIPTION
We had only Tekton Labels in vector, this adds PAC labels also.