### PR TITLE
KONFLUX-3273: Add build pipeline for MRRC release process

### DIFF
--- a/components/build-service/base/build-pipeline-config/build-pipeline-config.yaml
+++ b/components/build-service/base/build-pipeline-config/build-pipeline-config.yaml
@@ -19,3 +19,7 @@ data:
       bundle: quay.io/konflux-ci/tekton-catalog/pipeline-docker-build-multi-platform-oci-ta:d550bc5f4610fe09081d2c177bf4aef64775a66a
       additional-params:
       - build-platforms
+    - name: maven-zip-build
+      bundle: quay.io/konflux-ci/tekton-catalog/pipeline-maven-zip-build:84b3cd21b9cc194838dd310fedcc316ea8a4aab4
+    - name: maven-zip-build-oci-ta
+      bundle: quay.io/konflux-ci/tekton-catalog/pipeline-maven-zip-build-oci-ta:84b3cd21b9cc194838dd310fedcc316ea8a4aab4


### PR DESCRIPTION
The MRRC maven build pipeline for the whole MRRC release process is developed done in following PRs:
   * https://github.com/konflux-ci/build-definitions/pull/1643
   * https://github.com/konflux-ci/build-definitions/pull/1691 
 
We want to deploy these two pipelines to the kflux-prd-rh02 for user to do early use. This PR addressing the deployment.