### PR TITLE
Revert "feat: Pass QPS, Burst and Thread Flag to Results Watcher, att…

### DIFF
--- a/components/pipeline-service/development/main-pipeline-service-configuration.yaml
+++ b/components/pipeline-service/development/main-pipeline-service-configuration.yaml
@@ -1278,9 +1278,6 @@ spec:
             - -completed_run_grace_period=2h
             - -store_deadline=1m
             - -forward_buffer=1m
-            - -qps=50
-            - -burst=50
-            - -threadiness=32
             - -logs_api=true
           env:
             - name: SYSTEM_NAMESPACE

--- a/components/pipeline-service/production/base/main-pipeline-service-configuration.yaml
+++ b/components/pipeline-service/production/base/main-pipeline-service-configuration.yaml
@@ -1141,9 +1141,6 @@ spec:
         - -check_owner=false
         - -completed_run_grace_period
         - 10m
-        - -qps=50
-        - -burst=50
-        - -threadiness=32
         env:
         - name: SYSTEM_NAMESPACE
           valueFrom:

--- a/components/pipeline-service/production/kflux-ocp-p01/deploy.yaml
+++ b/components/pipeline-service/production/kflux-ocp-p01/deploy.yaml
@@ -1525,9 +1525,6 @@ spec:
         - -check_owner=false
         - -completed_run_grace_period
         - 10m
-        - -qps=50
-        - -burst=50
-        - -threadiness=32
         env:
         - name: SYSTEM_NAMESPACE
           valueFrom:

--- a/components/pipeline-service/production/kflux-prd-rh02/deploy.yaml
+++ b/components/pipeline-service/production/kflux-prd-rh02/deploy.yaml
@@ -1556,9 +1556,6 @@ spec:
         - -check_owner=false
         - -completed_run_grace_period
         - 10m
-        - -qps=50
-        - -burst=50
-        - -threadiness=32
         env:
         - name: SYSTEM_NAMESPACE
           valueFrom:

--- a/components/pipeline-service/production/stone-prd-m01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prd-m01/deploy.yaml
@@ -1525,9 +1525,6 @@ spec:
         - -check_owner=false
         - -completed_run_grace_period
         - 10m
-        - -qps=50
-        - -burst=50
-        - -threadiness=32
         env:
         - name: SYSTEM_NAMESPACE
           valueFrom:

--- a/components/pipeline-service/production/stone-prd-rh01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prd-rh01/deploy.yaml
@@ -1525,9 +1525,6 @@ spec:
         - -check_owner=false
         - -completed_run_grace_period
         - 10m
-        - -qps=50
-        - -burst=50
-        - -threadiness=32
         env:
         - name: SYSTEM_NAMESPACE
           valueFrom:

--- a/components/pipeline-service/production/stone-prod-p01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prod-p01/deploy.yaml
@@ -1525,9 +1525,6 @@ spec:
         - -check_owner=false
         - -completed_run_grace_period
         - 10m
-        - -qps=50
-        - -burst=50
-        - -threadiness=32
         env:
         - name: SYSTEM_NAMESPACE
           valueFrom:

--- a/components/pipeline-service/production/stone-prod-p02/deploy.yaml
+++ b/components/pipeline-service/production/stone-prod-p02/deploy.yaml
@@ -1525,9 +1525,6 @@ spec:
         - -check_owner=false
         - -completed_run_grace_period
         - 10m
-        - -qps=50
-        - -burst=50
-        - -threadiness=32
         env:
         - name: SYSTEM_NAMESPACE
           valueFrom:

--- a/components/pipeline-service/staging/base/main-pipeline-service-configuration.yaml
+++ b/components/pipeline-service/staging/base/main-pipeline-service-configuration.yaml
@@ -1270,9 +1270,6 @@ spec:
             - -check_owner=false
             - -completed_run_grace_period
             - 10m
-            - -qps=50
-            - -burst=50
-            - -threadiness=32
             - -logs_api=true
           env:
             - name: SYSTEM_NAMESPACE

--- a/components/pipeline-service/staging/stone-stage-p01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stage-p01/deploy.yaml
@@ -1659,9 +1659,6 @@ spec:
         - -check_owner=false
         - -completed_run_grace_period
         - 10m
-        - -qps=50
-        - -burst=50
-        - -threadiness=32
         - -logs_api=true
         env:
         - name: SYSTEM_NAMESPACE

--- a/components/pipeline-service/staging/stone-stg-rh01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stg-rh01/deploy.yaml
@@ -1659,9 +1659,6 @@ spec:
         - -check_owner=false
         - -completed_run_grace_period
         - 10m
-        - -qps=50
-        - -burst=50
-        - -threadiness=32
         - -logs_api=true
         env:
         - name: SYSTEM_NAMESPACE


### PR DESCRIPTION
…empt 2"

The tuning options are not available in production yet because we run an old tekton-results version. We will re-apply this change once production is upgraded to the results version running on staging.

This reverts commit 9c0fdcd07005f533c44735a7b8fff140c21a0a5c.