### PR TITLE
Allow repos from quipucords organization

### DIFF
--- a/components/repository-validator/production/kustomization.yaml
+++ b/components/repository-validator/production/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - https://github.com/konflux-ci/repository-validator/config/ocp?ref=1a1bd5856c7caf40ebf3d9a24fce209ba8a74bd9
-  - https://github.com/redhat-appstudio/internal-infra-deployments/components/repository-validator/production?ref=4f9859137cd4fc8a21abc0e85eaccf27d40b91f8
+  - https://github.com/redhat-appstudio/internal-infra-deployments/components/repository-validator/production?ref=f2474320620c4198806295906fbff0e08255e96b
 images:
   - name: controller
     newName: quay.io/redhat-user-workloads/konflux-infra-tenant/repository-validator/repository-validator


### PR DESCRIPTION
This org is enforcing RH sso so it can be added to the allowed list.

[KFLUXINFRA-1169](https://issues.redhat.com//browse/KFLUXINFRA-1169)