### PR TITLE
chore: Update the External Secret version in crossplane

### DIFF
--- a/components/crossplane-control-plane/staging/provider-config.yaml
+++ b/components/crossplane-control-plane/staging/provider-config.yaml
@@ -13,7 +13,7 @@ spec:
       name: eaas-cluster
       key: kubeconfig
 ---
-apiVersion: external-secrets.io/v1alpha1
+apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
   name: eaas-cluster


### PR DESCRIPTION
v1aplha1 doesn't have Extract option so updating it to v1beta1 in crossplane-control-plane ExternalSecret.