### PR TITLE
KFLUXINFRA-1131: Add missing prod patch for the ui

### DIFF
--- a/argo-cd-apps/overlays/konflux-public-production/kustomization.yaml
+++ b/argo-cd-apps/overlays/konflux-public-production/kustomization.yaml
@@ -186,3 +186,8 @@ patches:
       kind: ApplicationSet
       version: v1alpha1
       name: ingresscontroller
+  - path: production-overlay-patch.yaml
+    target:
+      kind: ApplicationSet
+      version: v1alpha1
+      name: konflux-ui


### PR DESCRIPTION
The public production overlay was missing the patch for the konflux-ui app.