### PR TITLE
KFLUXINFRA-1131: RBAC manifests for rh02

### DIFF
--- a/argo-cd-apps/base/member/infra-deployments/konflux-rbac/konflux-rbac.yaml
+++ b/argo-cd-apps/base/member/infra-deployments/konflux-rbac/konflux-rbac.yaml
@@ -1,0 +1,45 @@
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: konflux-rbac
+spec:
+  generators:
+    - merge:
+        mergeKeys:
+          - nameNormalized
+        generators:
+          - clusters:
+              values:
+                sourceRoot: components/konflux-rbac
+                environment: staging
+                # empty-base is an overlay without resources.
+                # This allows to gradually deploy this app to all the clusters.
+                clusterDir: empty-base
+          - list:
+              elements:
+                - nameNormalized: kflux-prd-rh02
+                  values.clusterDir: kflux-prd-rh02
+  template:
+    metadata:
+      name: konflux-rbac-{{nameNormalized}}
+    spec:
+      project: default
+      source:
+        path: '{{values.sourceRoot}}/{{values.environment}}/{{values.clusterDir}}'
+        repoURL: https://github.com/redhat-appstudio/infra-deployments.git
+        targetRevision: main
+      destination:
+        namespace: konflux-rbac
+        server: '{{server}}'
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: false
+        syncOptions:
+          - CreateNamespace=true
+        retry:
+          limit: -1
+          backoff:
+            duration: 10s
+            factor: 2
+            maxDuration: 3m

--- a/argo-cd-apps/base/member/infra-deployments/konflux-rbac/kustomization.yaml
+++ b/argo-cd-apps/base/member/infra-deployments/konflux-rbac/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- konflux-rbac.yaml
+components:
+  - ../../../../k-components/deploy-to-member-cluster-merge-generator

--- a/argo-cd-apps/base/member/infra-deployments/kustomization.yaml
+++ b/argo-cd-apps/base/member/infra-deployments/kustomization.yaml
@@ -27,5 +27,6 @@ resources:
   - knative-eventing
   - crossplane-control-plane
   - konflux-ui
+  - konflux-rbac
 components:
   - ../../../k-components/inject-infra-deployments-repo-details

--- a/argo-cd-apps/overlays/development/delete-applications.yaml
+++ b/argo-cd-apps/overlays/development/delete-applications.yaml
@@ -106,3 +106,9 @@ kind: ApplicationSet
 metadata:
   name: konflux-ui
 $patch: delete
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: konflux-rbac
+$patch: delete

--- a/argo-cd-apps/overlays/konflux-public-production/kustomization.yaml
+++ b/argo-cd-apps/overlays/konflux-public-production/kustomization.yaml
@@ -191,3 +191,8 @@ patches:
       kind: ApplicationSet
       version: v1alpha1
       name: konflux-ui
+  - path: production-overlay-patch.yaml
+    target:
+      kind: ApplicationSet
+      version: v1alpha1
+      name: konflux-rbac

--- a/argo-cd-apps/overlays/konflux-public-staging/delete-applications.yaml
+++ b/argo-cd-apps/overlays/konflux-public-staging/delete-applications.yaml
@@ -5,3 +5,9 @@ kind: ApplicationSet
 metadata:
   name: tempo
 $patch: delete
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: konflux-rbac
+$patch: delete

--- a/components/konflux-rbac/production/base/konflux-admin-user-actions.yaml
+++ b/components/konflux-rbac/production/base/konflux-admin-user-actions.yaml
@@ -129,3 +129,16 @@ rules:
       - projects
       - projectdevelopmentstreams
       - projectdevelopmentstreamtemplates
+  - verbs:
+      - get
+    apiGroups:
+      - ''
+    resources:
+      - namespaces
+  - verbs:
+      - get
+    apiGroups:
+      - ''
+      - project.openshift.io
+    resources:
+      - projects

--- a/components/konflux-rbac/production/base/konflux-admin-user-actions.yaml
+++ b/components/konflux-rbac/production/base/konflux-admin-user-actions.yaml
@@ -1,0 +1,131 @@
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: konflux-admin-user-actions
+  labels:
+    konflux-cluster-role: "true"
+rules:
+  - verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+      - deletecollection
+    apiGroups:
+      - appstudio.redhat.com
+    resources:
+      - applications
+      - components
+      - imagerepositories
+  - verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+    apiGroups:
+      - appstudio.redhat.com
+    resources:
+      - snapshots
+  - verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+    apiGroups:
+      - tekton.dev
+    resources:
+      - pipelineruns
+      - taskruns      
+  - verbs:
+      - get
+      - list
+    apiGroups:
+      - results.tekton.dev
+    resources:
+      - results
+      - records
+      - logs
+  - verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+    apiGroups:
+      - appstudio.redhat.com
+    resources:
+      - enterprisecontractpolicies
+      - integrationtestscenarios
+      - releases
+      - releaseplans
+      - releaseplanadmissions
+  - verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+    apiGroups:
+      - jvmbuildservice.io
+    resources:
+      - jbsconfigs
+      - artifactbuilds
+  - verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+    apiGroups:
+      - ''
+    resources:
+      - secrets
+  - verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+    apiGroups:
+      - ''
+    resources:
+      - configmaps
+  - verbs:
+      - get
+    apiGroups:
+      - ''
+    resources:
+      - pods
+      - pods/log
+  - verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+    apiGroups:
+      - projctl.konflux.dev
+    resources:
+      - projects
+      - projectdevelopmentstreams
+      - projectdevelopmentstreamtemplates

--- a/components/konflux-rbac/production/base/konflux-contributor-user-actions.yaml
+++ b/components/konflux-rbac/production/base/konflux-contributor-user-actions.yaml
@@ -1,0 +1,103 @@
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: konflux-contributor-user-actions
+  labels:
+    konflux-cluster-role: "true"
+rules:
+  - verbs:
+      - get
+      - list
+      - watch
+    apiGroups:
+      - appstudio.redhat.com
+    resources:
+      - applications
+      - components
+      - imagerepositories
+  - verbs:
+      - get
+      - list
+      - watch
+    apiGroups:
+      - appstudio.redhat.com
+    resources:
+      - snapshots
+  - verbs:
+      - get
+      - list
+      - watch
+    apiGroups:
+      - tekton.dev
+    resources:
+      - pipelineruns
+  - verbs:
+      - get
+      - list
+    apiGroups:
+      - results.tekton.dev
+    resources:
+      - results
+      - records
+      - logs
+  - verbs:
+      - get
+      - list
+      - watch
+    apiGroups:
+      - appstudio.redhat.com
+    resources:
+      - integrationtestscenarios
+  - verbs:
+      - get
+      - list
+      - watch
+    apiGroups:
+      - appstudio.redhat.com
+    resources:
+      - enterprisecontractpolicies
+  - verbs:
+      - get
+      - list
+      - watch
+    apiGroups:
+      - appstudio.redhat.com
+    resources:
+      - releases
+      - releaseplans
+  - verbs:
+      - get
+      - list
+      - watch
+    apiGroups:
+      - appstudio.redhat.com
+    resources:
+      - releaseplanadmissions
+  - verbs:
+      - get
+      - list
+      - watch
+    apiGroups:
+      - jvmbuildservice.io
+    resources:
+      - jbsconfigs
+      - artifactbuilds
+  - verbs:
+      - get
+      - list
+      - watch
+    apiGroups:
+      - ''
+    resources:
+      - configmaps
+  - verbs:
+      - get
+      - list
+      - watch
+    apiGroups:
+      - projctl.konflux.dev
+    resources:
+      - projects
+      - projectdevelopmentstreams
+      - projectdevelopmentstreamtemplates

--- a/components/konflux-rbac/production/base/konflux-contributor-user-actions.yaml
+++ b/components/konflux-rbac/production/base/konflux-contributor-user-actions.yaml
@@ -101,3 +101,16 @@ rules:
       - projects
       - projectdevelopmentstreams
       - projectdevelopmentstreamtemplates
+  - verbs:
+      - get
+    apiGroups:
+      - ''
+    resources:
+      - namespaces
+  - verbs:
+      - get
+    apiGroups:
+      - ''
+      - project.openshift.io
+    resources:
+      - projects

--- a/components/konflux-rbac/production/base/konflux-maintainer-user-actions.yaml
+++ b/components/konflux-rbac/production/base/konflux-maintainer-user-actions.yaml
@@ -122,3 +122,16 @@ rules:
       - projects
       - projectdevelopmentstreams
       - projectdevelopmentstreamtemplates
+  - verbs:
+      - get
+    apiGroups:
+      - ''
+    resources:
+      - namespaces
+  - verbs:
+      - get
+    apiGroups:
+      - ''
+      - project.openshift.io
+    resources:
+      - projects

--- a/components/konflux-rbac/production/base/konflux-maintainer-user-actions.yaml
+++ b/components/konflux-rbac/production/base/konflux-maintainer-user-actions.yaml
@@ -1,0 +1,124 @@
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: konflux-maintainer-user-actions
+  labels:
+    konflux-cluster-role: "true"
+rules:
+  - verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+    apiGroups:
+      - appstudio.redhat.com
+    resources:
+      - applications
+      - components
+      - imagerepositories
+  - verbs:
+      - get
+      - list
+      - watch
+    apiGroups:
+      - appstudio.redhat.com
+    resources:
+      - snapshots
+  - verbs:
+      - get
+      - list
+      - watch
+    apiGroups:
+      - tekton.dev
+    resources:
+      - pipelineruns
+  - verbs:
+      - get
+      - list
+    apiGroups:
+      - results.tekton.dev
+    resources:
+      - results
+      - records
+      - logs
+  - verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+    apiGroups:
+      - appstudio.redhat.com
+    resources:
+      - integrationtestscenarios
+  - verbs:
+      - get
+      - list
+      - watch
+    apiGroups:
+      - appstudio.redhat.com
+    resources:
+      - enterprisecontractpolicies
+  - verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+    apiGroups:
+      - appstudio.redhat.com
+    resources:
+      - releases
+      - releaseplans
+  - verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+    apiGroups:
+      - appstudio.redhat.com
+    resources:
+      - releaseplanadmissions
+  - verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+    apiGroups:
+      - jvmbuildservice.io
+    resources:
+      - jbsconfigs
+      - artifactbuilds
+  - verbs:
+      - get
+      - list
+      - watch
+    apiGroups:
+      - ''
+    resources:
+      - configmaps
+  - verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+    apiGroups:
+      - projctl.konflux.dev
+    resources:
+      - projects
+      - projectdevelopmentstreams
+      - projectdevelopmentstreamtemplates

--- a/components/konflux-rbac/production/base/kustomization.yaml
+++ b/components/konflux-rbac/production/base/kustomization.yaml
@@ -1,0 +1,6 @@
+kind: Kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+resources:
+  - konflux-admin-user-actions.yaml
+  - konflux-maintainer-user-actions.yaml
+  - konflux-contributor-user-actions.yaml

--- a/components/konflux-rbac/production/empty-base/kustomization.yaml
+++ b/components/konflux-rbac/production/empty-base/kustomization.yaml
@@ -1,0 +1,3 @@
+kind: Kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+resources: []

--- a/components/konflux-rbac/production/kflux-prd-rh02/kustomization.yaml
+++ b/components/konflux-rbac/production/kflux-prd-rh02/kustomization.yaml
@@ -1,0 +1,4 @@
+kind: Kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+resources:
+  - ../base


### PR DESCRIPTION
rh02 use our new architecture which doesn't include kubesaw. This requires creating ClusterRole that we be later assigned to Konflux users so they can use the system.