### PR TITLE
chore: Update crossplane-control-plane commit sha

### DIFF
--- a/components/crossplane-control-plane/base/kustomization.yaml
+++ b/components/crossplane-control-plane/base/kustomization.yaml
@@ -1,6 +1,6 @@
 resources:
-- https://github.com/konflux-ci/crossplane-control-plane/crossplane/ocp?ref=0ffb42297262d413169dbf4b5d11967efbb7c7ed
-- https://github.com/konflux-ci/crossplane-control-plane/config/ocp?ref=0ffb42297262d413169dbf4b5d11967efbb7c7ed
+- https://github.com/konflux-ci/crossplane-control-plane/crossplane/ocp?ref=429b2638313b298febcc24fb44b27a132f266722
+- https://github.com/konflux-ci/crossplane-control-plane/config/ocp?ref=429b2638313b298febcc24fb44b27a132f266722
 
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization


### PR DESCRIPTION
crossplane-control-plane commit sha is updated to include the kubernetes provider config.