### PR TITLE
Fix the crossplane RBAC and staging ProviderConfig

### DIFF
--- a/components/crossplane-config/base/rbac.yaml
+++ b/components/crossplane-config/base/rbac.yaml
@@ -16,29 +16,13 @@ rules:
   resources:
   - limitranges
   - namespaces
-  - secrets
-  - serviceaccounts
+  - resourcequotas
   verbs:
   - "*"
 - apiGroups:
-  - authorization.openshift.io
   - rbac.authorization.k8s.io
   resources:
-  - roles
   - rolebindings
-  verbs:
-  - "*"
-- apiGroups:
-  - networking.k8s.io
-  resources:
-  - networkpolicies
-  verbs:
-  - "*"
-- apiGroups:
-  - quota.openshift.io
-  resources:
-  - resourcequotas
-  - clusterresourcequotas
   verbs:
   - "*"
 
@@ -54,4 +38,18 @@ subjects:
 roleRef:
   kind: ClusterRole
   name: crossplane-clusterrole
+  apiGroup: rbac.authorization.k8s.io
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: crossplane-edit-crb
+subjects:
+- kind: ServiceAccount
+  name: crossplane-sa
+  namespace: crossplane-config
+roleRef:
+  kind: ClusterRole
+  name: edit
   apiGroup: rbac.authorization.k8s.io

--- a/components/crossplane-control-plane/staging/provider-config.yaml
+++ b/components/crossplane-control-plane/staging/provider-config.yaml
@@ -2,7 +2,7 @@
 apiVersion: kubernetes.crossplane.io/v1alpha1
 kind: ProviderConfig
 metadata:
-  name: eaas-stage-kubernetes-provider-config
+  name: eaas-kubernetes-provider-config
   annotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
@@ -12,6 +12,7 @@ spec:
       namespace: crossplane-system
       name: eaas-cluster
       key: kubeconfig
+
 ---
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret


### PR DESCRIPTION
Our XNamespace composition references the ProviderConfig by a different name. It also assigns the `edit` ClusterRole so `crossplane-sa` must also be granted these permissions.