### PR TITLE
Grant everyone can view role to konflux-support

### DIFF
--- a/components/authentication/base/everyone-can-view-patch.yaml
+++ b/components/authentication/base/everyone-can-view-patch.yaml
@@ -50,3 +50,6 @@
     - kind: Group
       apiGroup: rbac.authorization.k8s.io
       name: 'konflux-kubearchive'
+    - kind: Group
+      apiGroup: rbac.authorization.k8s.io
+      name: 'konflux-support'


### PR DESCRIPTION
There are people supporting Konflux that do not belong to any official Konflux team that we want to grant view access to our clusters. A new rover group was created to put those people in so grant view role to that new group.

[KFLUXINFRA-1173](https://issues.redhat.com//browse/KFLUXINFRA-1173)