### PR TITLE
Increase results-watcher number of threads

### DIFF
--- a/components/pipeline-service/development/main-pipeline-service-configuration.yaml
+++ b/components/pipeline-service/development/main-pipeline-service-configuration.yaml
@@ -1278,6 +1278,7 @@ spec:
             - -completed_run_grace_period=2h
             - -store_deadline=1m
             - -forward_buffer=1m
+            - -threadiness=32
             - -logs_api=true
           env:
             - name: SYSTEM_NAMESPACE

--- a/components/pipeline-service/production/base/main-pipeline-service-configuration.yaml
+++ b/components/pipeline-service/production/base/main-pipeline-service-configuration.yaml
@@ -1141,6 +1141,7 @@ spec:
         - -check_owner=false
         - -completed_run_grace_period
         - 10m
+        - -threadiness=32
         env:
         - name: SYSTEM_NAMESPACE
           valueFrom:

--- a/components/pipeline-service/production/kflux-ocp-p01/deploy.yaml
+++ b/components/pipeline-service/production/kflux-ocp-p01/deploy.yaml
@@ -1525,6 +1525,7 @@ spec:
         - -check_owner=false
         - -completed_run_grace_period
         - 10m
+        - -threadiness=32
         env:
         - name: SYSTEM_NAMESPACE
           valueFrom:

--- a/components/pipeline-service/production/kflux-prd-rh02/deploy.yaml
+++ b/components/pipeline-service/production/kflux-prd-rh02/deploy.yaml
@@ -1556,6 +1556,7 @@ spec:
         - -check_owner=false
         - -completed_run_grace_period
         - 10m
+        - -threadiness=32
         env:
         - name: SYSTEM_NAMESPACE
           valueFrom:

--- a/components/pipeline-service/production/stone-prd-m01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prd-m01/deploy.yaml
@@ -1525,6 +1525,7 @@ spec:
         - -check_owner=false
         - -completed_run_grace_period
         - 10m
+        - -threadiness=32
         env:
         - name: SYSTEM_NAMESPACE
           valueFrom:

--- a/components/pipeline-service/production/stone-prd-rh01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prd-rh01/deploy.yaml
@@ -1525,6 +1525,7 @@ spec:
         - -check_owner=false
         - -completed_run_grace_period
         - 10m
+        - -threadiness=32
         env:
         - name: SYSTEM_NAMESPACE
           valueFrom:

--- a/components/pipeline-service/production/stone-prod-p01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prod-p01/deploy.yaml
@@ -1525,6 +1525,7 @@ spec:
         - -check_owner=false
         - -completed_run_grace_period
         - 10m
+        - -threadiness=32
         env:
         - name: SYSTEM_NAMESPACE
           valueFrom:

--- a/components/pipeline-service/production/stone-prod-p02/deploy.yaml
+++ b/components/pipeline-service/production/stone-prod-p02/deploy.yaml
@@ -1525,6 +1525,7 @@ spec:
         - -check_owner=false
         - -completed_run_grace_period
         - 10m
+        - -threadiness=32
         env:
         - name: SYSTEM_NAMESPACE
           valueFrom:

--- a/components/pipeline-service/staging/base/main-pipeline-service-configuration.yaml
+++ b/components/pipeline-service/staging/base/main-pipeline-service-configuration.yaml
@@ -1270,6 +1270,7 @@ spec:
             - -check_owner=false
             - -completed_run_grace_period
             - 10m
+            - -threadiness=32
             - -logs_api=true
           env:
             - name: SYSTEM_NAMESPACE

--- a/components/pipeline-service/staging/stone-stage-p01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stage-p01/deploy.yaml
@@ -1659,6 +1659,7 @@ spec:
         - -check_owner=false
         - -completed_run_grace_period
         - 10m
+        - -threadiness=32
         - -logs_api=true
         env:
         - name: SYSTEM_NAMESPACE

--- a/components/pipeline-service/staging/stone-stg-rh01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stg-rh01/deploy.yaml
@@ -1659,6 +1659,7 @@ spec:
         - -check_owner=false
         - -completed_run_grace_period
         - 10m
+        - -threadiness=32
         - -logs_api=true
         env:
         - name: SYSTEM_NAMESPACE


### PR DESCRIPTION
The other tekton controllers processing pipelineRun have 4 replicas with 32 threads each. Results watcher only has one replica with 2 thread. Try to increase the processing capacity of watcher by configuring number of threads. The other options we use normally (qps and burst) cannot be configured yet as the version of results in production does not support them.

[KFLUXINFRA-1115](https://issues.redhat.com//browse/KFLUXINFRA-1115)