### PR TITLE
chore: add secret information to release-monitor

### DIFF
--- a/components/release/base/monitor/staging/configmap.yaml
+++ b/components/release/base/monitor/staging/configmap.yaml
@@ -20,7 +20,7 @@ data:
           pullspec: quay.io/konflux-ci/release-service-utils
       http:
         - name: pyxis
-          url: https://pyxis.nonprod.redhat.com/v1/ping
+          url: https://pyxis.preprod.api.redhat.com/v1/ping
           insecure: true
 kind: ConfigMap
 metadata:

--- a/components/release/base/monitor/staging/kustomization.yaml
+++ b/components/release/base/monitor/staging/kustomization.yaml
@@ -9,4 +9,7 @@ images:
     newName: quay.io/konflux-ci/release-service-monitor
     newTag: 73e63a3db71ab5084150b31277710aabff613b03
 
+patches:
+  - path: patches/env-secrets-patch.yaml
+
 namespace: release-service

--- a/components/release/base/monitor/staging/patches/env-secrets-patch.yaml
+++ b/components/release/base/monitor/staging/patches/env-secrets-patch.yaml
@@ -1,0 +1,17 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: release-service-monitor-deployment
+  namespace: release-service
+spec:
+  template:
+    spec:
+      containers:
+        - name: release-service-monitor
+          env:
+            - name: GITHUB_GIT_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: release-monitor-secret
+                  key: github_token
+


### PR DESCRIPTION
this PR adds the secret reference so the release-monitor can use it to check the release required endpoints

Signed-off-by: Leandro Mendes <lmendes@redhat.com>