### PR TITLE
chore: adding pyxis secret reference

### DIFF
--- a/components/release/base/monitor/staging/patches/env-secrets-patch.yaml
+++ b/components/release/base/monitor/staging/patches/env-secrets-patch.yaml
@@ -9,6 +9,16 @@ spec:
       containers:
         - name: release-service-monitor
           env:
+            - name: PYXIS_HTTP_CERT
+              valueFrom:
+                secretKeyRef:
+                  name: release-monitor-secret
+                  key: pyxis_http_cert
+            - name: PYXIS_HTTP_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: release-monitor-secret
+                  key: pyxis_http_key
             - name: GITHUB_GIT_TOKEN
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
this PR adds the reference of the pyxis cert/key to the release-monitor-service