### PR TITLE
KFLUXBUGS-1610 - Logging Operator update -  Update Splunk secret object to secretName & key

### DIFF
--- a/components/monitoring/logging/base/configure-logging/configure-logforwarder.yaml
+++ b/components/monitoring/logging/base/configure-logging/configure-logforwarder.yaml
@@ -19,13 +19,17 @@ spec:
       splunk:
         url: https://http-inputs-rhcorporate.splunkcloud.com
         authentication:
-          token: log-forwarder-splunk-rhtap-application-secret
+          token:
+              secretName: log-forwarder-splunk-rhtap-application-secret
+              key: hecToken
     - name: splunk-receiver-audit
       type: splunk
       splunk:
         url: https://http-inputs-rhcorporate.splunkcloud.com
         authentication:
-          token: log-forwarder-splunk-rhtap-audit-secret
+          token:
+              secretName: log-forwarder-splunk-rhtap-audit-secret
+              key: hecToken
   filters:
     - name: parse-json
       type: parse


### PR DESCRIPTION
As part of the migration to the Logging Operator v6.0, the spec to define the Splunk key was changed; this reconciles our definition with the new spec.