### PR TITLE
KFLUXINFRA-1183: Public Konflux information

### DIFF
--- a/argo-cd-apps/base/member/infra-deployments/konflux-info/konflux-info.yaml
+++ b/argo-cd-apps/base/member/infra-deployments/konflux-info/konflux-info.yaml
@@ -1,0 +1,58 @@
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: konflux-info
+spec:
+  generators:
+    - merge:
+        mergeKeys:
+          - nameNormalized
+        generators:
+          - clusters:
+              values:
+                sourceRoot: components/konflux-info
+                environment: staging
+                # This app requires cluster specific overlays
+                clusterDir: does-not-exist
+          - list:
+              elements:
+                - nameNormalized: kflux-ocp-p01
+                  values.clusterDir: kflux-ocp-p01
+                - nameNormalized: stone-stg-rh01
+                  values.clusterDir: stone-stg-rh01
+                - nameNormalized: stone-prd-m01
+                  values.clusterDir: stone-prd-m01
+                - nameNormalized: stone-prd-rh01
+                  values.clusterDir: stone-prd-rh01
+                - nameNormalized: stone-stage-p01
+                  values.clusterDir: stone-stage-p01
+                - nameNormalized: stone-prod-p01
+                  values.clusterDir: stone-prod-p01
+                - nameNormalized: stone-prod-p02
+                  values.clusterDir: stone-prod-p02
+                - nameNormalized: kflux-prd-rh02
+                  values.clusterDir: kflux-prd-rh02
+  template:
+    metadata:
+      name: konflux-info-{{nameNormalized}}
+    spec:
+      project: default
+      source:
+        path: '{{values.sourceRoot}}/{{values.environment}}/{{values.clusterDir}}'
+        repoURL: https://github.com/redhat-appstudio/infra-deployments.git
+        targetRevision: main
+      destination:
+        namespace: konflux-info
+        server: '{{server}}'
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: false
+        syncOptions:
+          - CreateNamespace=true
+        retry:
+          limit: -1
+          backoff:
+            duration: 10s
+            factor: 2
+            maxDuration: 3m

--- a/argo-cd-apps/base/member/infra-deployments/konflux-info/kustomization.yaml
+++ b/argo-cd-apps/base/member/infra-deployments/konflux-info/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- konflux-info.yaml
+components:
+  - ../../../../k-components/deploy-to-member-cluster-merge-generator

--- a/argo-cd-apps/base/member/infra-deployments/kustomization.yaml
+++ b/argo-cd-apps/base/member/infra-deployments/kustomization.yaml
@@ -28,5 +28,6 @@ resources:
   - crossplane-control-plane
   - konflux-ui
   - konflux-rbac
+  - konflux-info
 components:
   - ../../../k-components/inject-infra-deployments-repo-details

--- a/argo-cd-apps/overlays/development/delete-applications.yaml
+++ b/argo-cd-apps/overlays/development/delete-applications.yaml
@@ -112,3 +112,9 @@ kind: ApplicationSet
 metadata:
   name: konflux-rbac
 $patch: delete
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: konflux-info
+$patch: delete

--- a/argo-cd-apps/overlays/konflux-public-production/kustomization.yaml
+++ b/argo-cd-apps/overlays/konflux-public-production/kustomization.yaml
@@ -196,3 +196,8 @@ patches:
       kind: ApplicationSet
       version: v1alpha1
       name: konflux-rbac
+  - path: production-overlay-patch.yaml
+    target:
+      kind: ApplicationSet
+      version: v1alpha1
+      name: konflux-info

--- a/argo-cd-apps/overlays/production-downstream/kustomization.yaml
+++ b/argo-cd-apps/overlays/production-downstream/kustomization.yaml
@@ -196,3 +196,8 @@ patches:
       kind: ApplicationSet
       version: v1alpha1
       name: crossplane-control-plane
+  - path: production-overlay-patch.yaml
+    target:
+      kind: ApplicationSet
+      version: v1alpha1
+      name: konflux-info

--- a/components/konflux-info/base/kustomization.yaml
+++ b/components/konflux-info/base/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - rbac.yaml
+
+namespace: konflux-info

--- a/components/konflux-info/base/rbac.yaml
+++ b/components/konflux-info/base/rbac.yaml
@@ -1,0 +1,27 @@
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: konflux-public-info-view-role
+rules:
+  - verbs:
+      - get
+    apiGroups:
+      - ''
+    resourceNames:
+      - konflux-public-info
+    resources:
+      - configmaps
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: konflux-public-info-view-rb
+subjects:
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: 'system:authenticated'
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: konflux-public-info-view-role

--- a/components/konflux-info/production/kflux-ocp-p01/info.json
+++ b/components/konflux-info/production/kflux-ocp-p01/info.json
@@ -1,0 +1,24 @@
+{
+    "environment": "production",
+    "integrations": {
+        "github": {
+            "application_url": "https://github.com/apps/konflux-kflux-ocp-p01"
+        },
+        "sbom_server": {
+            "url": "https://atlas.devshift.net/sbom/content/<PLACEHOLDER>"
+        },
+        "image_controller": {
+            "enabled": true,
+            "notifications": [
+                {
+                    "title": "SBOM-event-to-Bombino",
+                    "event": "repo_push",
+                    "method": "webhook",
+                    "config": {
+                        "url": "https://bombino.api.redhat.com/v1/sbom/quay/push"
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/components/konflux-info/production/kflux-ocp-p01/kustomization.yaml
+++ b/components/konflux-info/production/kflux-ocp-p01/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+
+generatorOptions:
+ disableNameSuffixHash: true
+
+configMapGenerator:
+  - name: konflux-public-info
+    files:
+      - info.json
+
+namespace: konflux-info

--- a/components/konflux-info/production/kflux-prd-rh02/info.json
+++ b/components/konflux-info/production/kflux-prd-rh02/info.json
@@ -1,0 +1,24 @@
+{
+    "environment": "production",
+    "integrations": {
+        "github": {
+            "application_url": "https://github.com/apps/red-hat-konflux-kflux-prd-rh02"
+        },
+        "sbom_server": {
+            "url": "https://atlas.devshift.net/sbom/content/<PLACEHOLDER>"
+        },
+        "image_controller": {
+            "enabled": true,
+            "notifications": [
+                {
+                    "title": "SBOM-event-to-Bombino",
+                    "event": "repo_push",
+                    "method": "webhook",
+                    "config": {
+                        "url": "https://bombino.api.redhat.com/v1/sbom/quay/push"
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/components/konflux-info/production/kflux-prd-rh02/kustomization.yaml
+++ b/components/konflux-info/production/kflux-prd-rh02/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+
+generatorOptions:
+ disableNameSuffixHash: true
+
+configMapGenerator:
+  - name: konflux-public-info
+    files:
+      - info.json
+
+namespace: konflux-info

--- a/components/konflux-info/production/stone-prd-rh01/info.json
+++ b/components/konflux-info/production/stone-prd-rh01/info.json
@@ -1,0 +1,24 @@
+{
+    "environment": "production",
+    "integrations": {
+        "github": {
+            "application_url": "https://github.com/apps/red-hat-konflux"
+        },
+        "sbom_server": {
+            "url": "https://atlas.devshift.net/sbom/content/<PLACEHOLDER>"
+        },
+        "image_controller": {
+            "enabled": true,
+            "notifications": [
+                {
+                    "title": "SBOM-event-to-Bombino",
+                    "event": "repo_push",
+                    "method": "webhook",
+                    "config": {
+                        "url": "https://bombino.api.redhat.com/v1/sbom/quay/push"
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/components/konflux-info/production/stone-prd-rh01/kustomization.yaml
+++ b/components/konflux-info/production/stone-prd-rh01/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+
+generatorOptions:
+ disableNameSuffixHash: true
+
+configMapGenerator:
+  - name: konflux-public-info
+    files:
+      - info.json
+
+namespace: konflux-info

--- a/components/konflux-info/production/stone-prod-p01/info.json
+++ b/components/konflux-info/production/stone-prod-p01/info.json
@@ -1,0 +1,24 @@
+{
+    "environment": "production",
+    "integrations": {
+        "github": {
+            "application_url": "https://github.com/apps/konflux-internal"
+        },
+        "sbom_server": {
+            "url": "https://atlas.devshift.net/sbom/content/<PLACEHOLDER>"
+        },
+        "image_controller": {
+            "enabled": true,
+            "notifications": [
+                {
+                    "title": "SBOM-event-to-Bombino",
+                    "event": "repo_push",
+                    "method": "webhook",
+                    "config": {
+                        "url": "https://bombino.api.redhat.com/v1/sbom/quay/push"
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/components/konflux-info/production/stone-prod-p01/kustomization.yaml
+++ b/components/konflux-info/production/stone-prod-p01/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+
+generatorOptions:
+ disableNameSuffixHash: true
+
+configMapGenerator:
+  - name: konflux-public-info
+    files:
+      - info.json
+
+namespace: konflux-info

--- a/components/konflux-info/production/stone-prod-p02/info.json
+++ b/components/konflux-info/production/stone-prod-p02/info.json
@@ -1,0 +1,24 @@
+{
+    "environment": "production",
+    "integrations": {
+        "github": {
+            "application_url": "https://github.com/apps/konflux-internal-p02"
+        },
+        "sbom_server": {
+            "url": "https://atlas.devshift.net/sbom/content/<PLACEHOLDER>"
+        },
+        "image_controller": {
+            "enabled": true,
+            "notifications": [
+                {
+                    "title": "SBOM-event-to-Bombino",
+                    "event": "repo_push",
+                    "method": "webhook",
+                    "config": {
+                        "url": "https://bombino.api.redhat.com/v1/sbom/quay/push"
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/components/konflux-info/production/stone-prod-p02/kustomization.yaml
+++ b/components/konflux-info/production/stone-prod-p02/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+
+generatorOptions:
+ disableNameSuffixHash: true
+
+configMapGenerator:
+  - name: konflux-public-info
+    files:
+      - info.json
+
+namespace: konflux-info

--- a/components/konflux-info/staging/stone-stage-p01/info.json
+++ b/components/konflux-info/staging/stone-stage-p01/info.json
@@ -1,0 +1,24 @@
+{
+    "environment": "staging",
+    "integrations": {
+        "github": {
+            "application_url": "https://github.com/apps/konflux-staging-internal"
+        },
+        "sbom_server": {
+            "url": "https://atlas.stage.devshift.net/sbom/content/<PLACEHOLDER>"
+        },
+        "image_controller": {
+            "enabled": true,
+            "notifications": [
+                {
+                    "title": "SBOM-event-to-Bombino",
+                    "event": "repo_push",
+                    "method": "webhook",
+                    "config": {
+                        "url": "https://bombino.preprod.api.redhat.com/v1/sbom/quay/push"
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/components/konflux-info/staging/stone-stage-p01/kustomization.yaml
+++ b/components/konflux-info/staging/stone-stage-p01/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+
+generatorOptions:
+ disableNameSuffixHash: true
+
+configMapGenerator:
+  - name: konflux-public-info
+    files:
+      - info.json
+
+namespace: konflux-info

--- a/components/konflux-info/staging/stone-stg-rh01/info.json
+++ b/components/konflux-info/staging/stone-stg-rh01/info.json
@@ -1,0 +1,24 @@
+{
+    "environment": "staging",
+    "integrations": {
+        "github": {
+            "application_url": "https://github.com/apps/konflux-staging"
+        },
+        "sbom_server": {
+            "url": "https://atlas.stage.devshift.net/sbom/content/<PLACEHOLDER>"
+        },
+        "image_controller": {
+            "enabled": true,
+            "notifications": [
+                {
+                    "title": "SBOM-event-to-Bombino",
+                    "event": "repo_push",
+                    "method": "webhook",
+                    "config": {
+                        "url": "https://bombino.preprod.api.redhat.com/v1/sbom/quay/push"
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/components/konflux-info/staging/stone-stg-rh01/kustomization.yaml
+++ b/components/konflux-info/staging/stone-stg-rh01/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+
+generatorOptions:
+ disableNameSuffixHash: true
+
+configMapGenerator:
+  - name: konflux-public-info
+    files:
+      - info.json
+
+namespace: konflux-info


### PR DESCRIPTION
Expose a configmap which is readable by all authenticated users that contains public information about the Konflux instance.

This information, for example, can be used by the UI, instead of hardcoding it in the UI codebase.