### PR TITLE
Reduce mumber of IBM VM's for Ocp-Art cluster account

### DIFF
--- a/components/multi-platform-controller/production-downstream/kflux-ocp-p01/host-config.yaml
+++ b/components/multi-platform-controller/production-downstream/kflux-ocp-p01/host-config.yaml
@@ -410,7 +410,7 @@ data:
   dynamic.linux-s390x.region: "us-south-2"
   dynamic.linux-s390x.url: "https://us-south.iaas.cloud.ibm.com/v1"
   dynamic.linux-s390x.profile: "bz2-2x8"
-  dynamic.linux-s390x.max-instances: "50"
+  dynamic.linux-s390x.max-instances: "30"
   dynamic.linux-s390x.private-ip: "true"
   dynamic.linux-s390x.allocation-timeout: "1800"
 
@@ -425,7 +425,7 @@ data:
   dynamic.linux-large-s390x.region: "us-south-2"
   dynamic.linux-large-s390x.url: "https://us-south.iaas.cloud.ibm.com/v1"
   dynamic.linux-large-s390x.profile: "bz2-4x16"
-  dynamic.linux-large-s390x.max-instances: "50"
+  dynamic.linux-large-s390x.max-instances: "10"
   dynamic.linux-large-s390x.private-ip: "true"
   dynamic.linux-large-s390x.allocation-timeout: "1800"
 
@@ -441,7 +441,7 @@ data:
   dynamic.linux-ppc64le.system: "e980"
   dynamic.linux-ppc64le.cores: "2"
   dynamic.linux-ppc64le.memory: "8"
-  dynamic.linux-ppc64le.max-instances: "50"
+  dynamic.linux-ppc64le.max-instances: "30"
   dynamic.linux-ppc64le.allocation-timeout: "1800"
 
   #PPC64LE Large dynamic nodes
@@ -456,7 +456,7 @@ data:
   dynamic.linux-large-ppc64le.system: "e980"
   dynamic.linux-large-ppc64le.cores: "4"
   dynamic.linux-large-ppc64le.memory: "16"
-  dynamic.linux-large-ppc64le.max-instances: "50"
+  dynamic.linux-large-ppc64le.max-instances: "10"
   dynamic.linux-large-ppc64le.allocation-timeout: "1800"
 
   # AWS GPU Nodes


### PR DESCRIPTION
Looks like IBM cannot handle 50 (and even more so 100)  VM's in the single DC. The empiric value which work is about 30 VMs, if continue to start more VM they're dropping into `failed` state.
