### PR TITLE
Increase memory limit for EaaS argocd controller

### DIFF
--- a/components/cluster-as-a-service/base/argocd.yaml
+++ b/components/cluster-as-a-service/base/argocd.yaml
@@ -14,3 +14,7 @@ spec:
       g, system:authenticated, role:readonly
       g, konflux-admins, role:admin
       g, konflux-sre, role:admin
+  controller:
+    resources:
+      limits:
+        memory: 8Gi


### PR DESCRIPTION
The default limit of 2Gi results in OOMKilled errors in production.