### PR TITLE
KFLUXINFRA-1129: View Only Cluster Role for in-cluster Grafana

### DIFF
--- a/components/authentication/base/grafana-view-only.yaml
+++ b/components/authentication/base/grafana-view-only.yaml
@@ -1,0 +1,26 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: grafana-view-only
+rules:
+- apiGroups:
+  - grafana.integreatly.org/v1beta1
+  resources:
+  - grafanas
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: grafana-view-only
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: grafana-view-only
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: konflux-grafana-viewers

--- a/components/authentication/base/kustomization.yaml
+++ b/components/authentication/base/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
 - component-maintainer.yaml
 - everyone-can-view.yaml
 - konflux-admins.yaml
+- grafana-view-only.yaml
 
 patches:
   - path: everyone-can-view-patch.yaml


### PR DESCRIPTION
This Pull Request will do the following -
- Create a Cluster Role to provide view only access to in-cluster grafana
- Create a ClusterRoleBinding to allow users (part of konflux-grafana-viewers rover group) to use the Cluster Role