### PR TITLE
KFLUXINFRA-1154: Configure Backup for kflux-prd-rh02

### DIFF
--- a/components/backup/production/kflux-prd-rh02/backup-s3-credentials-patch.yaml
+++ b/components/backup/production/kflux-prd-rh02/backup-s3-credentials-patch.yaml
@@ -1,0 +1,3 @@
+- op: replace
+  path: /spec/dataFrom/0/extract/key
+  value: integrations-output/terraform-resources/appsrep09ue1/stonesoup-infra-prod-backup/backup-kflux-prd-rh02

--- a/components/backup/production/kflux-prd-rh02/backup-tenants-schedule.yaml
+++ b/components/backup/production/kflux-prd-rh02/backup-tenants-schedule.yaml
@@ -1,0 +1,52 @@
+apiVersion: velero.io/v1
+kind: Schedule
+metadata:
+  name: backup-tenants
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  schedule: 30 1,13 * * * # every day 1:30, 13:30 UTC
+  template:
+    excludedNamespaces:
+      - kube-*
+      - openshift*
+      - appstudio*
+      - admin-checker
+      - application-api
+      - application-service
+      - appsre-vault
+      - build-service
+      - build-templates
+      - build-templates-e2e
+      - ci-helper-app
+      - dedicated-admin
+      - deployment-validation-operator
+      - dora-metrics
+      - enterprise-contract-service
+      - external-secrets-operator
+      - group-sync-operator
+      - hac-pact-broker
+      - image-controller
+      - integration-service
+      - internal-services
+      - jvm-build-service
+      - multi-platform-controller
+      - perf-team-prometheus-reader
+      - plnsvc-tests
+      - quality-dashboard
+      - release-service
+      - sandbox-sre-member
+      - tekton-results
+      - toolchain-member-operator
+    includedResources:
+      - applications.appstudio.redhat.com
+      - components.appstudio.redhat.com
+      - environments.appstudio.redhat.com
+      - integrationtestscenarios.appstudio.redhat.com
+      - secrets
+      - snapshots.appstudio.redhat.com
+      - serviceaccounts
+      - namespaces
+    storageLocation: velero-aws-1
+    ttl: 720h0m0s
+  useOwnerReferencesInBackup: true

--- a/components/backup/production/kflux-prd-rh02/dpa-bucket-patch.yaml
+++ b/components/backup/production/kflux-prd-rh02/dpa-bucket-patch.yaml
@@ -1,0 +1,3 @@
+- op: replace
+  path: /spec/backupLocations/0/velero/objectStorage/bucket
+  value: backup-kflux-prd-rh02

--- a/components/backup/production/kflux-prd-rh02/dpa-kmskeyid-patch.yaml
+++ b/components/backup/production/kflux-prd-rh02/dpa-kmskeyid-patch.yaml
@@ -1,0 +1,3 @@
+- op: replace
+  path: /spec/backupLocations/0/velero/config/kmsKeyId
+  value: 4d05fc08-4fc7-452b-80e7-75cc1caef564

--- a/components/backup/production/kflux-prd-rh02/kustomization.yaml
+++ b/components/backup/production/kflux-prd-rh02/kustomization.yaml
@@ -1,0 +1,24 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base/all-clusters
+  - backup-tenants-schedule.yaml
+patches:
+  - target:
+      group: external-secrets.io
+      version: v1beta1
+      kind: ExternalSecret
+      name: backup-s3-credentials
+    path: backup-s3-credentials-patch.yaml
+  - target:
+      group: oadp.openshift.io
+      version: v1alpha1
+      kind: DataProtectionApplication
+      name: velero-aws
+    path: dpa-bucket-patch.yaml
+  - target:
+      group: oadp.openshift.io
+      version: v1alpha1
+      kind: DataProtectionApplication
+      name: velero-aws
+    path: dpa-kmskeyid-patch.yaml


### PR DESCRIPTION
This Pull Request will configure the backup for newly provisioned cluster `kflux-prd-rh02`.

This Cluster is hosting `toolchain-member-operator` as well as `toolchain-host-operator`, this backup targets both of them.