### PR TITLE
Update OSP to 5.0.5-555 on prod m01

### DIFF
--- a/components/pipeline-service/production/stone-prd-m01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prd-m01/deploy.yaml
@@ -2057,7 +2057,7 @@ metadata:
   namespace: openshift-marketplace
 spec:
   displayName: custom-operators
-  image: quay.io/openshift-pipeline/openshift-pipelines-pipelines-operator-bundle-container-index@sha256:d34f2de74b26b384643b04e5b391dc3216289f7e351ca36e8b46e4d8b03e47ce
+  image: quay.io/openshift-pipeline/openshift-pipelines-pipelines-operator-bundle-container-index@sha256:41e3a30346050886e0cf7a17d65140415f028f8c8d511915387ec68a1dab7f75
   sourceType: grpc
   updateStrategy:
     registryPoll:

--- a/components/pipeline-service/production/stone-prd-m01/resources/osp-nightly-version.yaml
+++ b/components/pipeline-service/production/stone-prd-m01/resources/osp-nightly-version.yaml
@@ -1,0 +1,4 @@
+---
+- op: replace
+  path: /spec/image
+  value: quay.io/openshift-pipeline/openshift-pipelines-pipelines-operator-bundle-container-index@sha256:41e3a30346050886e0cf7a17d65140415f028f8c8d511915387ec68a1dab7f75


### PR DESCRIPTION
- this has a fix for the bundle size limit hit
- this comes with pipeline 0.66.0 (https://github.com/tektoncd/pipeline/releases/tag/v0.66.0)
- this comes with pac 0.30.0 (https://github.com/openshift-pipelines/pipelines-as-code/releases/tag/v0.30.0)