### PR TITLE
fix(KFLUXINFRA-1129): Fix in-cluster grafana permissions

### DIFF
--- a/components/monitoring/grafana/base/grafana-app.yaml
+++ b/components/monitoring/grafana/base/grafana-app.yaml
@@ -151,7 +151,6 @@ spec:
                 - '-http-address='
                 - '-email-domain=*'
                 - '-upstream=http://localhost:3000'
-                - '-openshift-sar={"resource": "namespaces", "resourceName": "appstudio-grafana", "namespace": "appstudio-grafana", "verb": "get"}'
                 - '-openshift-delegate-urls={"/": {"resource": "namespaces", "verb": "get"}}'
                 - '-tls-cert=/etc/tls/private/tls.crt'
                 - '-tls-key=/etc/tls/private/tls.key'


### PR DESCRIPTION
Fix in-cluster grafana permissions to allow users of rover group `konflux-grafana-viewers` to have view-only access to the in-cluster grafana.

Related Pull Request -
- https://github.com/redhat-appstudio/infra-deployments/pull/5188