### PR TITLE
Remove enable-tekton-oci-bundles TektonConfig

### DIFF
--- a/components/pipeline-service/production/base/main-pipeline-service-configuration.yaml
+++ b/components/pipeline-service/production/base/main-pipeline-service-configuration.yaml
@@ -1447,7 +1447,6 @@ spec:
     enable-git-resolver: true
     enable-hub-resolver: true
     enable-step-actions: true
-    enable-tekton-oci-bundles: true
     options:
       configMaps:
         config-logging:

--- a/components/pipeline-service/production/kflux-ocp-p01/deploy.yaml
+++ b/components/pipeline-service/production/kflux-ocp-p01/deploy.yaml
@@ -1833,7 +1833,6 @@ spec:
     enable-git-resolver: true
     enable-hub-resolver: true
     enable-step-actions: true
-    enable-tekton-oci-bundles: true
     options:
       configMaps:
         config-defaults:

--- a/components/pipeline-service/production/kflux-prd-rh02/deploy.yaml
+++ b/components/pipeline-service/production/kflux-prd-rh02/deploy.yaml
@@ -1864,7 +1864,6 @@ spec:
     enable-git-resolver: true
     enable-hub-resolver: true
     enable-step-actions: true
-    enable-tekton-oci-bundles: true
     options:
       configMaps:
         config-defaults:

--- a/components/pipeline-service/production/stone-prd-m01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prd-m01/deploy.yaml
@@ -1833,7 +1833,6 @@ spec:
     enable-git-resolver: true
     enable-hub-resolver: true
     enable-step-actions: true
-    enable-tekton-oci-bundles: true
     options:
       configMaps:
         config-defaults:

--- a/components/pipeline-service/production/stone-prd-rh01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prd-rh01/deploy.yaml
@@ -1833,7 +1833,6 @@ spec:
     enable-git-resolver: true
     enable-hub-resolver: true
     enable-step-actions: true
-    enable-tekton-oci-bundles: true
     options:
       configMaps:
         config-defaults:

--- a/components/pipeline-service/production/stone-prod-p01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prod-p01/deploy.yaml
@@ -1984,7 +1984,6 @@ spec:
     enable-git-resolver: true
     enable-hub-resolver: true
     enable-step-actions: true
-    enable-tekton-oci-bundles: true
     options:
       configMaps:
         config-defaults:

--- a/components/pipeline-service/production/stone-prod-p02/deploy.yaml
+++ b/components/pipeline-service/production/stone-prod-p02/deploy.yaml
@@ -1833,7 +1833,6 @@ spec:
     enable-git-resolver: true
     enable-hub-resolver: true
     enable-step-actions: true
-    enable-tekton-oci-bundles: true
     options:
       configMaps:
         config-defaults:


### PR DESCRIPTION
Remove enable-tekton-oci-bundles from production clusters. This configuration options was removed in Tekton v0.61.0.