### PR TITLE
Allow pipeline-service to delete logging pods

### DIFF
--- a/components/pipeline-service/base/rbac/kustomization.yaml
+++ b/components/pipeline-service/base/rbac/kustomization.yaml
@@ -4,3 +4,4 @@ resources:
   - cluster-role
   - openshift-pipelines
   - tekton-results
+  - tekton-logging

--- a/components/pipeline-service/base/rbac/tekton-logging/kustomization.yaml
+++ b/components/pipeline-service/base/rbac/tekton-logging/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: tekton-logging
+resources:
+  - pipeline-service-sre.yaml

--- a/components/pipeline-service/base/rbac/tekton-logging/pipeline-service-sre.yaml
+++ b/components/pipeline-service/base/rbac/tekton-logging/pipeline-service-sre.yaml
@@ -1,0 +1,45 @@
+---
+# Grant access to the tekton-logging namespace
+# This binding is needed to allow the pipelines team to manage the pods
+# which happen to stuck during an upgrade.
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: pipeline-service-sre-manage-vector-pods
+  namespace: tekton-logging
+rules:
+  - apiGroups:
+      - ""
+    verbs:
+      - get
+      - list
+      - watch
+      - delete
+    resources:
+      - pods
+  - apiGroups:
+      - "apps"
+    verbs:
+      - get
+      - list
+      - watch
+      - delete
+    resources:
+      - daemonsets
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: pipeline-service-sre-manage-vector-pods
+  namespace: tekton-logging
+subjects:
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: konflux-pipeline-service
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: konflux-sre
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: pipeline-service-sre-manage-vector-pods

--- a/components/pipeline-service/staging/stone-stage-p01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stage-p01/deploy.yaml
@@ -78,6 +78,33 @@ kind: Role
 metadata:
   annotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+  name: pipeline-service-sre-manage-vector-pods
+  namespace: tekton-logging
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+  - delete
+- apiGroups:
+  - apps
+  resources:
+  - daemonsets
+  verbs:
+  - get
+  - list
+  - watch
+  - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
   name: pipeline-service-sre-exec-pprof-data
   namespace: tekton-results
 rules:
@@ -582,6 +609,25 @@ subjects:
 - apiGroup: rbac.authorization.k8s.io
   kind: Group
   name: konflux-pipeline-service
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+  name: pipeline-service-sre-manage-vector-pods
+  namespace: tekton-logging
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: pipeline-service-sre-manage-vector-pods
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: konflux-pipeline-service
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: konflux-sre
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/components/pipeline-service/staging/stone-stg-rh01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stg-rh01/deploy.yaml
@@ -78,6 +78,33 @@ kind: Role
 metadata:
   annotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+  name: pipeline-service-sre-manage-vector-pods
+  namespace: tekton-logging
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+  - delete
+- apiGroups:
+  - apps
+  resources:
+  - daemonsets
+  verbs:
+  - get
+  - list
+  - watch
+  - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
   name: pipeline-service-sre-exec-pprof-data
   namespace: tekton-results
 rules:
@@ -582,6 +609,25 @@ subjects:
 - apiGroup: rbac.authorization.k8s.io
   kind: Group
   name: konflux-pipeline-service
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+  name: pipeline-service-sre-manage-vector-pods
+  namespace: tekton-logging
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: pipeline-service-sre-manage-vector-pods
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: konflux-pipeline-service
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: konflux-sre
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding


### PR DESCRIPTION
The way the Vector pods are deployed today it happened that when a new version was deployed, we ended up with 2 DaemonSets, with the pods of the old DaemonSets running and blocking the pods of the new DaemonSet. Deleting the DaemonSet/pods allowed the new DaemonSet to spawn its own pods. We need that flexibility as managers of the service.