### PR TITLE
Backup additional resources

### DIFF
--- a/components/backup/base/member/schedules/backup-tenants-schedule.yaml
+++ b/components/backup/base/member/schedules/backup-tenants-schedule.yaml
@@ -46,7 +46,13 @@ spec:
       - secrets
       - snapshots.appstudio.redhat.com
       - serviceaccounts
+      - rolebindings
       - namespaces
+      - imagerepositories.appstudio.redhat.com
+      - repositories.pipelinesascode.tekton.dev
+      - releases.appstudio.redhat.com
+      - releaseplans.appstudio.redhat.com
+      - releaseplanadmissions.appstudio.redhat.com
     storageLocation: velero-aws-1
     ttl: 720h0m0s
   useOwnerReferencesInBackup: true


### PR DESCRIPTION
Add additional resources to the backup as follows:

1. rolebindings - users a allowed to create role binding for their service account. In addition, in clusters that doesn't use kubesaw, rolebindings are used for granting permissions to users.

2. imagerepositories - the ImageRepository resources is created by the UI when onboarding a new component, thus it should be backed up as well.

3. repositories - the Tekton repository resource is created by the build service if the component doesn't have the "build.appstudio.openshift.io/status" annotation. Since the components in the back have this annotation, the build service won't create the repository resources after restoring the components, thus the repository resource should be backed up as well.

4. release resources - those are core Konflux resources thus they should be backed up as well.