### PR TITLE
chore(KFLUXVNGD-136): export label deployment

### DIFF
--- a/components/monitoring/prometheus/base/monitoringstack/monitoringstack.yaml
+++ b/components/monitoring/prometheus/base/monitoringstack/monitoringstack.yaml
@@ -50,7 +50,7 @@ spec:
           validation_reason|strategy|succeeded|target|name|method|code|sp|le|\
           unexpected_status|failure|hostname|label_app_kubernetes_io_managed_by|status|\
           pipeline|pipelinename|pipelinerun|schedule|check|grpc_service|grpc_code|\
-          lease|lease_holder"
+          lease|lease_holder|deployment"
 ---
 # Grant permission to Federate In-Cluster Prometheus
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
The deployment Prometheus label is needed for monitoring project-controller's availability in RHOBS.