### PR TITLE
chore(KFLUXVNGD-93): Grant appstudio-pipelines-runner permissions to manage namespaces

### DIFF
--- a/components/sandbox/toolchain-member-operator/base/rbac/appstudio-pipelines-runner.yaml
+++ b/components/sandbox/toolchain-member-operator/base/rbac/appstudio-pipelines-runner.yaml
@@ -37,6 +37,16 @@ rules:
       - spacerequests
   - verbs:
       - get
+      - create
+      - delete
+      - list
+      - watch
+    apiGroups:
+      - eaas.konflux-ci.dev
+    resources:
+      - namespaces
+  - verbs:
+      - get
       - list
     apiGroups:
       - tekton.dev


### PR DESCRIPTION
Grant the appstudio-pipelines-runner serviceaccount permission to manage
namespaces.eaas.konflux-ci.dev resources.

Jira-Url: https://issues.redhat.com/browse/KFLUXVNGD-93