### PR TITLE
Temporarily increase MPC memory on rh01

### DIFF
--- a/components/multi-platform-controller/production/stone-prd-rh01/kustomization.yaml
+++ b/components/multi-platform-controller/production/stone-prd-rh01/kustomization.yaml
@@ -10,9 +10,6 @@ resources:
 - https://github.com/konflux-ci/multi-platform-controller/deploy/operator?ref=644f445cdc34b9d52a00f0e3e6d3f08820f22e07
 - https://github.com/konflux-ci/multi-platform-controller/deploy/otp?ref=644f445cdc34b9d52a00f0e3e6d3f08820f22e07
 
-components:
-  - ../../k-components/manager-resources
-
 images:
 - name: multi-platform-controller
   newName: quay.io/konflux-ci/multi-platform-controller
@@ -20,3 +17,6 @@ images:
 - name: multi-platform-otp-server
   newName: quay.io/konflux-ci/multi-platform-controller-otp-service
   newTag: 644f445cdc34b9d52a00f0e3e6d3f08820f22e07
+
+patches:
+ - path: manager_resources_patch.yaml

--- a/components/multi-platform-controller/production/stone-prd-rh01/manager_resources_patch.yaml
+++ b/components/multi-platform-controller/production/stone-prd-rh01/manager_resources_patch.yaml
@@ -1,0 +1,17 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: multi-platform-controller
+  namespace: multi-platform-controller
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager
+        resources:
+          limits:
+            cpu: 500m
+            memory: 16Gi
+          requests:
+            cpu: 500m
+            memory: 16Gi


### PR DESCRIPTION
We have an issues where too many TaskRuns are causing the pod to use too much memory and be OOMKilled.