### PR TITLE
revert production patch for notification-service

### DIFF
--- a/components/notification-controller/production/topic_region_add.yaml
+++ b/components/notification-controller/production/topic_region_add.yaml
@@ -1,6 +1,6 @@
 ---
 - op: add
-  path: /spec/template/spec/containers/0/env
+  path: /spec/template/spec/containers/1/env
   value: 
     - name: NOTIFICATION_TOPIC_ARN
       value: "arn:aws:sns:us-east-1:520050076864:scan_topic"


### PR DESCRIPTION
The new definitions only apply for dev and stage, the production environment remains the same for now and therefor should not been updated.