### PR TITLE
kyverno: specify values inline

### DIFF
--- a/argo-cd-apps/base/member/infra-deployments/kyverno/kyverno.yaml
+++ b/argo-cd-apps/base/member/infra-deployments/kyverno/kyverno.yaml
@@ -27,8 +27,15 @@ spec:
           repoURL: https://kyverno.github.io/kyverno/
           targetRevision: 3.3.4
           helm:
-            valueFiles:
-              - "{{values.sourceRoot}}/{{values.environment}}/values.yaml"
+            values: |
+              admissionController:
+                replicas: 3
+              backgroundController:
+                replicas: 3
+              cleanupController:
+                replicas: 3
+              reportsController:
+                replicas: 3
       destination:
         namespace: konflux-kyverno
         server: '{{server}}'

--- a/components/kyverno/staging/values.yaml
+++ b/components/kyverno/staging/values.yaml
@@ -1,8 +1,0 @@
-admissionController:
-  replicas: 3
-backgroundController:
-  replicas: 3
-cleanupController:
-  replicas: 3
-reportsController:
-  replicas: 3


### PR DESCRIPTION
Argocd doesn't do template substitution when determining the location of helm's values files, which we were relying on to pick up the values file for the helm chart.  To fix this, specify the values in the ApplicationSet itself.