### PR TITLE
Increase Build Service memory request to be bigger than actual average usage

### DIFF
--- a/components/build-service/production/base/manager_resources_patch.yaml
+++ b/components/build-service/production/base/manager_resources_patch.yaml
@@ -11,7 +11,7 @@ spec:
         resources:
           limits:
             cpu: 500m
-            memory: 2Gi
+            memory: 4Gi
           requests:
             cpu: 250m
-            memory: 768Mi
+            memory: 2Gi

--- a/components/build-service/staging/base/manager_resources_patch.yaml
+++ b/components/build-service/staging/base/manager_resources_patch.yaml
@@ -11,7 +11,7 @@ spec:
         resources:
           limits:
             cpu: 500m
-            memory: 2Gi
+            memory: 4Gi
           requests:
             cpu: 250m
-            memory: 768Mi
+            memory: 2Gi


### PR DESCRIPTION
The investigation was done by perf team and the result is [this issue](https://issues.redhat.com/browse/KONFLUX-5911) which this PR fixes.