### PR TITLE
kyverno: use server-side apply

### DIFF
--- a/argo-cd-apps/base/member/infra-deployments/kyverno/kyverno.yaml
+++ b/argo-cd-apps/base/member/infra-deployments/kyverno/kyverno.yaml
@@ -47,7 +47,7 @@ spec:
           selfHeal: true
         syncOptions:
           - CreateNamespace=true
-          - Replace=true # Recommended by upstream
+          - ServerSideApply=true
         retry:
           limit: 50
           backoff:


### PR DESCRIPTION
Occasionally, when reconciling some of Kyverno's CRDs, we get events that look like the following:

> CustomResourceDefinition.apiextensions.k8s.io "clusterpolicies.kyverno.io" is invalid: metadata.annotations: Too long: must have at most 262144 bytes

According to [upstream documentation][1], it's because argocd by default uses `kubectl apply`, which stuffs the resource into the annotations metadata.  If the resource is too large, it'll be rejected by kubernetes for being larger than the annotations space allocated (262144 bytes).

Upstream recommends we use `Replace=true` as a sync option within the ApplicationSet as a workaround, but it appears there are a few places within argocd that don't acknowledge that setting.  They also recommend that server-side apply would also work as a workaround.

Configure kyverno's Application to work with server-side apply.

[1]: https://kyverno.io/docs/installation/platform-notes/#notes-for-argocd-users