### PR TITLE
Fix staging kubearchive external secret

### DIFF
--- a/components/kubearchive/staging/database-secret.yaml
+++ b/components/kubearchive/staging/database-secret.yaml
@@ -9,8 +9,7 @@ metadata:
 spec:
   dataFrom:
     - extract:
-        key: >
-          integrations-output/terraform-resources/appsres09ue1/stonesoup-infra-stage/kube-archive-staging-rds
+        key: integrations-output/terraform-resources/appsres09ue1/stonesoup-infra-stage/kube-archive-staging-rds
   refreshInterval: 1h
   secretStoreRef:
     kind: ClusterSecretStore


### PR DESCRIPTION
In 3586dfc28a8d4a90a782dcdf9fb1fce2cf4172e4, the key to extract the secret from was updated from:
```
- key: integrations-output/terraform-resources/appsres09ue1/stonesoup-infra-stage/kube-archive-staging-rds
```
to:
```
- key: |
        integrations-output/terraform-resources/appsres09ue1/stonesoup-infra-stage/kube-archive-staging-rds
```

This was the cause of External Secret failing to extract value from vault, revert to what it was before.