### PR TITLE
namespace-lister: disable configmap name suffix hashing

### DIFF
--- a/components/namespace-lister/base/kustomization.yaml
+++ b/components/namespace-lister/base/kustomization.yaml
@@ -12,6 +12,8 @@ configMapGenerator:
 - files:
   - nginx.conf=nginx.conf
   name: nginx
+  options:
+    disableNameSuffixHash: true
 images:
 - name: namespace-lister
   newName: quay.io/konflux-ci/namespace-lister


### PR DESCRIPTION
Currently, when we generate the configmap for the proxy, kustomize will automatically append a hash to its name.  This breaks the proxy deployment, since it looks for a configmap with a specific name.

We can fix this either by disabling name suffix hashing or by injecting the name via a replacement.  The former is easier to implement, so opt to implement that method.