### PR TITLE
Make Knative Eventing MT Broker Controller Guaranteed

### DIFF
--- a/components/knative-eventing/base/kustomization.yaml
+++ b/components/knative-eventing/base/kustomization.yaml
@@ -64,6 +64,7 @@ patches:
                   memory: 200Mi
 
 # Requests are cpu 100m and memory 100Mi by default
+# This is QoS Guaranteed (150m, 200Mi) because it was OOMKilled on Burstable (100m, 100Mi)
 - patch: |-
     apiVersion: apps/v1
     kind: Deployment
@@ -76,6 +77,9 @@ patches:
           containers:
             - name: mt-broker-controller
               resources:
+                requests:
+                  cpu: 150m
+                  memory: 200Mi
                 limits:
                   cpu: 150m
                   memory: 200Mi


### PR DESCRIPTION
The pod for the `mt-broker-controller` deployment of `knative-eventing` was failing with OOMKilled. This was not happening locally. This PR increases the limit memory and requests from 150 and 100, to 200. It also assigns the QoS Guaranteed by having the same requests and limits for every resource.