### PR TITLE
stage: Add RBAC details to konflux-public-info cm

### DIFF
--- a/components/konflux-info/staging/stone-stg-rh01/info.json
+++ b/components/konflux-info/staging/stone-stg-rh01/info.json
@@ -20,5 +20,34 @@
                 }
             ]
         }
-    }
+    },
+    "rbac": [
+        {
+            "displayName": "admin",
+            "description": "Full access to Konflux resources including secrets",
+            "roleRef": {
+                "apiGroup": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "konflux-admin-user-actions"
+            }
+        },
+        {
+            "displayName": "maintainer",
+            "description": "Partial access to Konflux resources without access to secrets",
+            "roleRef": {
+                "apiGroup": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "konflux-maintainer-user-actions"
+            }
+        },
+        {
+            "displayName": "contributor",
+            "description": "View access to Konflux resources without access to secrets",
+            "roleRef": {
+                "apiGroup": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "konflux-contributor-user-actions"
+            }
+        }
+    ]
 }


### PR DESCRIPTION
The information will be used by the UI when
rendering the user access page and when creating
role bindings for users.