### PR TITLE
feat(STONEINTG-948): Migrate redhat-appstudio/clair-in-ci

### DIFF
--- a/components/konflux-ci/base/repository.yaml
+++ b/components/konflux-ci/base/repository.yaml
@@ -54,3 +54,10 @@ metadata:
   name: tekton-results
 spec:
   url: "https://github.com/openshift-pipelines/tektoncd-results"
+---
+apiVersion: pipelinesascode.tekton.dev/v1alpha1
+kind: Repository
+metadata:
+  name: clair-in-ci-db
+spec:
+  url: "https://github.com/konflux-ci/clair-in-ci-db"

--- a/components/tekton-ci/base/repository.yaml
+++ b/components/tekton-ci/base/repository.yaml
@@ -16,13 +16,6 @@ spec:
 apiVersion: pipelinesascode.tekton.dev/v1alpha1
 kind: Repository
 metadata:
-  name: clair-in-ci-db
-spec:
-  url: "https://github.com/konflux-ci/clair-in-ci-db"
----
-apiVersion: pipelinesascode.tekton.dev/v1alpha1
-kind: Repository
-metadata:
   name: konflux-test
 spec:
   url: "https://github.com/konflux-ci/konflux-test"


### PR DESCRIPTION
Update references to redhat-appstudio quay org to reflect move to konflux-ci.