### PR TITLE
Increase memory for Eventing mt-broker-controller

### DIFF
--- a/components/knative-eventing/base/kustomization.yaml
+++ b/components/knative-eventing/base/kustomization.yaml
@@ -79,10 +79,10 @@ patches:
               resources:
                 requests:
                   cpu: 150m
-                  memory: 200Mi
+                  memory: 400Mi
                 limits:
                   cpu: 150m
-                  memory: 200Mi
+                  memory: 400Mi
 
 # Requests are cpu 100m and memory 100Mi by default
 - patch: |-


### PR DESCRIPTION
Followup for #5291, the controller keeps failing. I keep not being able to reproduce it locally. Sorry about it.