### PR TITLE
Use KubeArchive's PostgreSQL image on Quay

### DIFF
--- a/components/kubearchive/development/postgresql.yaml
+++ b/components/kubearchive/development/postgresql.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
         - name: postgresql
-          image: bitnami/postgresql:16.4.0
+          image: quay.io/kubearchive/postgresql:16.4.0
           ports:
             - containerPort: 5432
           resources:


### PR DESCRIPTION
Tests were reaching DockerHub's rate limit for images given that the KubeArchive's PostgreSQL image was on Docker. We mirrored the image into KubeArchive's Quay organization.

@flacatus @hugares @maruiz93 