### PR TITLE
Deploy konflux-rbac to public staging

### DIFF
--- a/argo-cd-apps/base/member/infra-deployments/konflux-rbac/konflux-rbac.yaml
+++ b/argo-cd-apps/base/member/infra-deployments/konflux-rbac/konflux-rbac.yaml
@@ -19,6 +19,8 @@ spec:
               elements:
                 - nameNormalized: kflux-prd-rh02
                   values.clusterDir: kflux-prd-rh02
+                - nameNormalized: stone-stg-rh01
+                  values.clusterDir: stone-stg-rh01
   template:
     metadata:
       name: konflux-rbac-{{nameNormalized}}

--- a/argo-cd-apps/overlays/konflux-public-staging/delete-applications.yaml
+++ b/argo-cd-apps/overlays/konflux-public-staging/delete-applications.yaml
@@ -5,9 +5,3 @@ kind: ApplicationSet
 metadata:
   name: tempo
 $patch: delete
----
-apiVersion: argoproj.io/v1alpha1
-kind: ApplicationSet
-metadata:
-  name: konflux-rbac
-$patch: delete

--- a/components/konflux-rbac/staging/base/konflux-admin-user-actions.yaml
+++ b/components/konflux-rbac/staging/base/konflux-admin-user-actions.yaml
@@ -1,0 +1,143 @@
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: konflux-admin-user-actions
+  labels:
+    konflux-cluster-role: "true"
+rules:
+  - verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+      - deletecollection
+    apiGroups:
+      - appstudio.redhat.com
+    resources:
+      - applications
+      - components
+      - imagerepositories
+  - verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+    apiGroups:
+      - appstudio.redhat.com
+    resources:
+      - snapshots
+  - verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+    apiGroups:
+      - tekton.dev
+    resources:
+      - pipelineruns
+      - taskruns      
+  - verbs:
+      - get
+      - list
+    apiGroups:
+      - results.tekton.dev
+    resources:
+      - results
+      - records
+      - logs
+  - verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+    apiGroups:
+      - appstudio.redhat.com
+    resources:
+      - enterprisecontractpolicies
+      - integrationtestscenarios
+      - releases
+      - releaseplans
+      - releaseplanadmissions
+  - verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+    apiGroups:
+      - jvmbuildservice.io
+    resources:
+      - jbsconfigs
+      - artifactbuilds
+  - verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+    apiGroups:
+      - ''
+    resources:
+      - secrets
+  - verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+    apiGroups:
+      - ''
+    resources:
+      - configmaps
+  - verbs:
+      - get
+    apiGroups:
+      - ''
+    resources:
+      - pods
+      - pods/log
+  - verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+    apiGroups:
+      - projctl.konflux.dev
+    resources:
+      - projects
+      - projectdevelopmentstreams
+      - projectdevelopmentstreamtemplates
+  - verbs:
+      - get
+    apiGroups:
+      - ''
+    resources:
+      - namespaces
+  - verbs:
+      - get
+    apiGroups:
+      - project.openshift.io
+    resources:
+      - projects

--- a/components/konflux-rbac/staging/base/konflux-contributor-user-actions.yaml
+++ b/components/konflux-rbac/staging/base/konflux-contributor-user-actions.yaml
@@ -1,0 +1,115 @@
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: konflux-contributor-user-actions
+  labels:
+    konflux-cluster-role: "true"
+rules:
+  - verbs:
+      - get
+      - list
+      - watch
+    apiGroups:
+      - appstudio.redhat.com
+    resources:
+      - applications
+      - components
+      - imagerepositories
+  - verbs:
+      - get
+      - list
+      - watch
+    apiGroups:
+      - appstudio.redhat.com
+    resources:
+      - snapshots
+  - verbs:
+      - get
+      - list
+      - watch
+    apiGroups:
+      - tekton.dev
+    resources:
+      - pipelineruns
+  - verbs:
+      - get
+      - list
+    apiGroups:
+      - results.tekton.dev
+    resources:
+      - results
+      - records
+      - logs
+  - verbs:
+      - get
+      - list
+      - watch
+    apiGroups:
+      - appstudio.redhat.com
+    resources:
+      - integrationtestscenarios
+  - verbs:
+      - get
+      - list
+      - watch
+    apiGroups:
+      - appstudio.redhat.com
+    resources:
+      - enterprisecontractpolicies
+  - verbs:
+      - get
+      - list
+      - watch
+    apiGroups:
+      - appstudio.redhat.com
+    resources:
+      - releases
+      - releaseplans
+  - verbs:
+      - get
+      - list
+      - watch
+    apiGroups:
+      - appstudio.redhat.com
+    resources:
+      - releaseplanadmissions
+  - verbs:
+      - get
+      - list
+      - watch
+    apiGroups:
+      - jvmbuildservice.io
+    resources:
+      - jbsconfigs
+      - artifactbuilds
+  - verbs:
+      - get
+      - list
+      - watch
+    apiGroups:
+      - ''
+    resources:
+      - configmaps
+  - verbs:
+      - get
+      - list
+      - watch
+    apiGroups:
+      - projctl.konflux.dev
+    resources:
+      - projects
+      - projectdevelopmentstreams
+      - projectdevelopmentstreamtemplates
+  - verbs:
+      - get
+    apiGroups:
+      - ''
+    resources:
+      - namespaces
+  - verbs:
+      - get
+    apiGroups:
+      - project.openshift.io
+    resources:
+      - projects

--- a/components/konflux-rbac/staging/base/konflux-maintainer-user-actions.yaml
+++ b/components/konflux-rbac/staging/base/konflux-maintainer-user-actions.yaml
@@ -1,0 +1,129 @@
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: konflux-maintainer-user-actions
+  labels:
+    konflux-cluster-role: "true"
+rules:
+  - verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+    apiGroups:
+      - appstudio.redhat.com
+    resources:
+      - applications
+      - components
+      - imagerepositories
+      - snapshots
+  - verbs:
+      - get
+      - list
+      - watch
+    apiGroups:
+      - tekton.dev
+    resources:
+      - pipelineruns
+  - verbs:
+      - get
+      - list
+    apiGroups:
+      - results.tekton.dev
+    resources:
+      - results
+      - records
+      - logs
+  - verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+    apiGroups:
+      - appstudio.redhat.com
+    resources:
+      - integrationtestscenarios
+  - verbs:
+      - get
+      - list
+      - watch
+    apiGroups:
+      - appstudio.redhat.com
+    resources:
+      - enterprisecontractpolicies
+  - verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+    apiGroups:
+      - appstudio.redhat.com
+    resources:
+      - releases
+      - releaseplans
+  - verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+    apiGroups:
+      - appstudio.redhat.com
+    resources:
+      - releaseplanadmissions
+  - verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+    apiGroups:
+      - jvmbuildservice.io
+    resources:
+      - jbsconfigs
+      - artifactbuilds
+  - verbs:
+      - get
+      - list
+      - watch
+    apiGroups:
+      - ''
+    resources:
+      - configmaps
+  - verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+    apiGroups:
+      - projctl.konflux.dev
+    resources:
+      - projects
+      - projectdevelopmentstreams
+      - projectdevelopmentstreamtemplates
+  - verbs:
+      - get
+    apiGroups:
+      - ''
+    resources:
+      - namespaces
+  - verbs:
+      - get
+    apiGroups:
+      - project.openshift.io
+    resources:
+      - projects

--- a/components/konflux-rbac/staging/base/kustomization.yaml
+++ b/components/konflux-rbac/staging/base/kustomization.yaml
@@ -1,0 +1,6 @@
+kind: Kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+resources:
+  - konflux-admin-user-actions.yaml
+  - konflux-maintainer-user-actions.yaml
+  - konflux-contributor-user-actions.yaml

--- a/components/konflux-rbac/staging/empty-base/kustomization.yaml
+++ b/components/konflux-rbac/staging/empty-base/kustomization.yaml
@@ -1,0 +1,3 @@
+kind: Kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+resources: []

--- a/components/konflux-rbac/staging/stone-stg-rh01/kustomization.yaml
+++ b/components/konflux-rbac/staging/stone-stg-rh01/kustomization.yaml
@@ -1,0 +1,4 @@
+kind: Kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+resources:
+  - ../base


### PR DESCRIPTION
The cluster roles will be used for granting
permissions to users after we stop using kubesaw.

Right now those roles are needed by the UI team
for testing changes they make to the UI.