### PR TITLE
Upgrade KubeArchive to v0.9.0: TLS fix

### DIFF
--- a/components/kubearchive/base/kustomization.yaml
+++ b/components/kubearchive/base/kustomization.yaml
@@ -2,7 +2,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- https://github.com/kubearchive/kubearchive/releases/download/v0.6.0/kubearchive.yaml?timeout=90
+- https://github.com/kubearchive/kubearchive/releases/download/v0.9.0/kubearchive.yaml?timeout=90
 - rbac.yaml
 
 # ROSA does not support namespaces starting with `kube`
@@ -35,15 +35,6 @@ patches:
     kind: ClusterRoleBinding
     metadata:
       name: kubearchive-operator
-    subjects:
-    - kind: ServiceAccount
-      name: kubearchive-operator
-      namespace: product-kubearchive
-- patch: |-
-    apiVersion: rbac.authorization.k8s.io/v1
-    kind: ClusterRoleBinding
-    metadata:
-      name: kubearchive-operator-proxy
     subjects:
     - kind: ServiceAccount
       name: kubearchive-operator
@@ -110,6 +101,11 @@ patches:
     metadata:
       name: kubearchive-api-server
       namespace: kubearchive
+      annotations:
+        ignore-check.kube-linter.io/readiness-port: >
+          "The port is working properly, just not exposed. Will be fixed in newer versions"
+        ignore-check.kube-linter.io/liveness-port: >
+          "The port is working properly, just not exposed. Will be fixed in newer versions"
     spec:
       template:
         spec:
@@ -134,10 +130,6 @@ patches:
                 runAsNonRoot: true
               ports:
                 - containerPort: 8081
-            - name: kube-rbac-proxy
-              securityContext:
-                readOnlyRootFilesystem: true
-                runAsNonRoot: true
 - patch: |-
     apiVersion: apps/v1
     kind: Deployment

--- a/components/kubearchive/development/postgresql.yaml
+++ b/components/kubearchive/development/postgresql.yaml
@@ -18,9 +18,17 @@ spec:
       labels:
         app: postgresql
     spec:
+      volumes:
+        - name: ssl
+          secret:
+            secretName: postgresql-tls
+            defaultMode: 384
       containers:
         - name: postgresql
           image: quay.io/kubearchive/postgresql:16.4.0
+          volumeMounts:
+            - name: ssl
+              mountPath: /mount/ssl-postgres/
           ports:
             - containerPort: 5432
           resources:
@@ -39,6 +47,12 @@ spec:
               value: password  # notsecret
             - name: POSTGRESQL_REPLICATION_USE_PASSFILE # https://github.com/bitnami/containers/issues/74788
               value: no
+            - name: POSTGRESQL_ENABLE_TLS
+              value: yes
+            - name: POSTGRESQL_TLS_CERT_FILE
+              value: /mount/ssl-postgres/tls.crt
+            - name: POSTGRESQL_TLS_KEY_FILE
+              value: /mount/ssl-postgres/tls.key
           securityContext:
             readOnlyRootFilesystem: false
             runAsNonRoot: true
@@ -49,6 +63,8 @@ metadata:
   name: postgresql
   labels:
     app: postgresql
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: postgresql-tls
 spec:
   type: ClusterIP
   ports:


### PR DESCRIPTION
This PR upgrades KubeArchive to version v0.9.0 which among other things contains a change to accomodate for RDS requirements of encryption. This should unblock KubeArchive from its current state (which is infinite restarts due to not being able to connect to RDS).