### PR TITLE
Add maruiz93 and mafh314 as owners of kubearchive and knative

### DIFF
--- a/components/knative-eventing/OWNERS
+++ b/components/knative-eventing/OWNERS
@@ -8,8 +8,12 @@ approvers:
 - rh-hemartin
 - skoved
 - ggallen
+- maruiz93
+- mafh314
 
 reviewers:
 - rh-hemartin
 - skoved
 - ggallen
+- maruiz93
+- mafh314

--- a/components/kubearchive/OWNERS
+++ b/components/kubearchive/OWNERS
@@ -4,8 +4,12 @@ approvers:
 - rh-hemartin
 - skoved
 - ggallen
+- maruiz93
+- mafh314
 
 reviewers:
 - rh-hemartin
 - skoved
 - ggallen
+- maruiz93
+- mafh314


### PR DESCRIPTION
Adding mafh413 and maruiz93, contributors of kubearchive as owners of kubearchive and knative components in konflux