### PR TITLE
Promote latest MPC version from stg to prod

### DIFF
--- a/components/multi-platform-controller/production-downstream/base/kustomization.yaml
+++ b/components/multi-platform-controller/production-downstream/base/kustomization.yaml
@@ -5,8 +5,8 @@ namespace: multi-platform-controller
 
 resources:
 - ../../base/common
-- https://github.com/konflux-ci/multi-platform-controller/deploy/operator?ref=644f445cdc34b9d52a00f0e3e6d3f08820f22e07
-- https://github.com/konflux-ci/multi-platform-controller/deploy/otp?ref=644f445cdc34b9d52a00f0e3e6d3f08820f22e07
+- https://github.com/konflux-ci/multi-platform-controller/deploy/operator?ref=80d8f460fb3caa729942d62d23499656b3cee480
+- https://github.com/konflux-ci/multi-platform-controller/deploy/otp?ref=80d8f460fb3caa729942d62d23499656b3cee480
 - external-secrets.yaml
 
 components:
@@ -15,7 +15,7 @@ components:
 images:
 - name: multi-platform-controller
   newName: quay.io/konflux-ci/multi-platform-controller
-  newTag: 644f445cdc34b9d52a00f0e3e6d3f08820f22e07
+  newTag: 80d8f460fb3caa729942d62d23499656b3cee480
 - name: multi-platform-otp-server
   newName: quay.io/konflux-ci/multi-platform-controller-otp-service
-  newTag: 644f445cdc34b9d52a00f0e3e6d3f08820f22e07
+  newTag: 80d8f460fb3caa729942d62d23499656b3cee480

--- a/components/multi-platform-controller/production/kflux-prd-rh02/kustomization.yaml
+++ b/components/multi-platform-controller/production/kflux-prd-rh02/kustomization.yaml
@@ -7,8 +7,8 @@ resources:
 - ../../base/common
 - host-config.yaml
 - external-secrets.yaml
-- https://github.com/konflux-ci/multi-platform-controller/deploy/operator?ref=644f445cdc34b9d52a00f0e3e6d3f08820f22e07
-- https://github.com/konflux-ci/multi-platform-controller/deploy/otp?ref=644f445cdc34b9d52a00f0e3e6d3f08820f22e07
+- https://github.com/konflux-ci/multi-platform-controller/deploy/operator?ref=80d8f460fb3caa729942d62d23499656b3cee480
+- https://github.com/konflux-ci/multi-platform-controller/deploy/otp?ref=80d8f460fb3caa729942d62d23499656b3cee480
 
 components:
   - ../../k-components/manager-resources
@@ -16,7 +16,7 @@ components:
 images:
 - name: multi-platform-controller
   newName: quay.io/konflux-ci/multi-platform-controller
-  newTag: 644f445cdc34b9d52a00f0e3e6d3f08820f22e07
+  newTag: 80d8f460fb3caa729942d62d23499656b3cee480
 - name: multi-platform-otp-server
   newName: quay.io/konflux-ci/multi-platform-controller-otp-service
-  newTag: 644f445cdc34b9d52a00f0e3e6d3f08820f22e07
+  newTag: 80d8f460fb3caa729942d62d23499656b3cee480

--- a/components/multi-platform-controller/production/stone-prd-rh01/kustomization.yaml
+++ b/components/multi-platform-controller/production/stone-prd-rh01/kustomization.yaml
@@ -7,16 +7,16 @@ resources:
 - ../../base/common
 - host-config.yaml
 - external-secrets.yaml
-- https://github.com/konflux-ci/multi-platform-controller/deploy/operator?ref=644f445cdc34b9d52a00f0e3e6d3f08820f22e07
-- https://github.com/konflux-ci/multi-platform-controller/deploy/otp?ref=644f445cdc34b9d52a00f0e3e6d3f08820f22e07
+- https://github.com/konflux-ci/multi-platform-controller/deploy/operator?ref=80d8f460fb3caa729942d62d23499656b3cee480
+- https://github.com/konflux-ci/multi-platform-controller/deploy/otp?ref=80d8f460fb3caa729942d62d23499656b3cee480
 
 images:
 - name: multi-platform-controller
   newName: quay.io/konflux-ci/multi-platform-controller
-  newTag: 644f445cdc34b9d52a00f0e3e6d3f08820f22e07
+  newTag: 80d8f460fb3caa729942d62d23499656b3cee480
 - name: multi-platform-otp-server
   newName: quay.io/konflux-ci/multi-platform-controller-otp-service
-  newTag: 644f445cdc34b9d52a00f0e3e6d3f08820f22e07
+  newTag: 80d8f460fb3caa729942d62d23499656b3cee480
 
 patches:
  - path: manager_resources_patch.yaml


### PR DESCRIPTION
Update includes:
 - Configurable volumes sizes for IBM (s390/ppc64le)
 - Logging improvements/cleanup
 - Fix for routines context which may help with better VM cleanups