### PR TITLE
Bump hypershift-aws-template to 0.1.5

### DIFF
--- a/components/cluster-as-a-service/base/clustertemplates.yaml
+++ b/components/cluster-as-a-service/base/clustertemplates.yaml
@@ -36,7 +36,7 @@ spec:
       source:
         chart: hypershift-aws-template
         repoURL: https://konflux-ci.dev/cluster-template-charts/
-        targetRevision: 0.1.4
+        targetRevision: 0.1.5
         helm:
           parameters:
             - name: region


### PR DESCRIPTION
This removes the limit on retries when trying to destroy clusters.