### PR TITLE
fix: add pod reader role to appstudio-pipeline SA

### DIFF
--- a/components/konflux-ci/base/kustomization.yaml
+++ b/components/konflux-ci/base/kustomization.yaml
@@ -4,6 +4,8 @@ resources:
 - repository.yaml
 - konflux-ci-maintainers-rb.yaml
 - appstudio-pipelines-runner-rolebinding.yaml
+- pod-logs-reader-role.yaml
+- pod-logs-reader-rolebinding.yaml
 
 # Skip applying the Tekton/PaC operands while the Tekton/PaC operator is being installed.
 # See more information about this option, here: 

--- a/components/konflux-ci/base/pod-logs-reader-role.yaml
+++ b/components/konflux-ci/base/pod-logs-reader-role.yaml
@@ -1,0 +1,9 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: pod-logs-reader
+  namespace: konflux-ci
+rules:
+- apiGroups: [""]
+  resources: ["pods", "pods/log"]
+  verbs: ["get", "list"]

--- a/components/konflux-ci/base/pod-logs-reader-rolebinding.yaml
+++ b/components/konflux-ci/base/pod-logs-reader-rolebinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: pod-logs-reader-rolebinding
+  namespace: konflux-ci
+subjects:
+- kind: ServiceAccount
+  name: appstudio-pipeline
+  namespace: konflux-ci
+roleRef:
+  kind: Role
+  name: pod-logs-reader
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
In konflux-ci namespace, appstudio-pipeline SA needs pod reader role to archive e2e-tests logs.