### PR TITLE
KFLUXINFRA-1211: Upgrade OpenShift GitOps to 1.15

### DIFF
--- a/components/openshift-gitops/subscription.yaml
+++ b/components/openshift-gitops/subscription.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "-1"
 spec:
-  channel: gitops-1.12
+  channel: gitops-1.15
   installPlanApproval: Automatic
   name: openshift-gitops-operator
   source: redhat-operators


### PR DESCRIPTION
Upgrading OpenShift GitOps to 1.15 for Development Overlay.