### PR TITLE
Remove limit for one knative eventing component

### DIFF
--- a/components/knative-eventing/base/kustomization.yaml
+++ b/components/knative-eventing/base/kustomization.yaml
@@ -71,6 +71,10 @@ patches:
     metadata:
       name: mt-broker-controller
       namespace: knative-eventing
+      annotations:
+        ignore-check.kube-linter.io/unset-memory-requirements: >
+          "Startup traverses all the cluster. Its a known problem, being solved on upstream.
+          See https://github.com/knative/eventing/pull/8418"
     spec:
       template:
         spec:
@@ -82,7 +86,6 @@ patches:
                   memory: 400Mi
                 limits:
                   cpu: 150m
-                  memory: 400Mi
 
 # Requests are cpu 100m and memory 100Mi by default
 - patch: |-


### PR DESCRIPTION
I talked with the Eventing team and they have a fix, meanwhile the solution is to provide more memory. I don't want to keep trying values, so I opted to remove the limit for memory instead. What do you think? This will be removed and a limit will be established again when the fix is merged and then its released. I will keep an eye on this.