### PR TITLE
Increase line size for vector log collection prod

### DIFF
--- a/components/vector-tekton-logs-collector/production/vector-helm-values.yaml
+++ b/components/vector-tekton-logs-collector/production/vector-helm-values.yaml
@@ -19,6 +19,7 @@ customConfig:
       rotate_wait_secs: 5
       glob_minimum_cooldown_ms: 500
       max_read_bytes: 3145728
+      max_line_bytes: 3145728
       auto_partial_merge: true
       extra_label_selector: "app.kubernetes.io/managed-by in (tekton-pipelines,pipelinesascode.tekton.dev)"
     internal_metrics:


### PR DESCRIPTION
We are seeing some very long lines (~280k char) being truncated. That should fix it.