### PR TITLE
[OCP] Bumping ppc disk from 200 to 400 GB

### DIFF
--- a/components/multi-platform-controller/production-downstream/kflux-ocp-p01/host-config.yaml
+++ b/components/multi-platform-controller/production-downstream/kflux-ocp-p01/host-config.yaml
@@ -46,7 +46,7 @@ data:
     linux-largecpu/ppc64le,\
     linux-d200/ppc64le,\
     linux-large/ppc64le,\
-    linux-d200-large/ppc64le\
+    linux-d400-large/ppc64le\
     "
   instance-tag: rhtap-prod
 
@@ -508,21 +508,21 @@ data:
   dynamic.linux-ppc64le.max-instances: "30"
   dynamic.linux-ppc64le.allocation-timeout: "1800"
 
-  # Same as linux-ppc64le but with 200GB disk instead of default 100GB
-  dynamic.linux-d200-ppc64le.type: ibmp
-  dynamic.linux-d200-ppc64le.ssh-secret: "internal-prod-ibm-ssh-key"
-  dynamic.linux-d200-ppc64le.secret: "internal-prod-ibm-api-key"
-  dynamic.linux-d200-ppc64le.key: "prod-konflux-infra"
-  dynamic.linux-d200-ppc64le.image: "ppc64le-rhel-94-base-27nov2024"
-  dynamic.linux-d200-ppc64le.crn: "crn:v1:bluemix:public:power-iaas:dal12:a/eebc7153d0c844f9915fb6f3b9850a3b:d6faf373-c0b6-4ba9-b0bc-4f7e0a74f9d5::"
-  dynamic.linux-d200-ppc64le.url: "https://us-south.power-iaas.cloud.ibm.com"
-  dynamic.linux-d200-ppc64le.network: "4d164943-b043-4c6e-bba5-d233abf66c6a"
-  dynamic.linux-d200-ppc64le.system: "e980"
-  dynamic.linux-d200-ppc64le.cores: "2"
-  dynamic.linux-d200-ppc64le.memory: "8"
-  dynamic.linux-d200-ppc64le.max-instances: "30"
-  dynamic.linux-d200-ppc64le.allocation-timeout: "1800"
-  dynamic.linux-d200-ppc64le.disk: "200"
+  # Same as linux-ppc64le but with 400GB disk instead of default 100GB
+  dynamic.linux-d400-ppc64le.type: ibmp
+  dynamic.linux-d400-ppc64le.ssh-secret: "internal-prod-ibm-ssh-key"
+  dynamic.linux-d400-ppc64le.secret: "internal-prod-ibm-api-key"
+  dynamic.linux-d400-ppc64le.key: "prod-konflux-infra"
+  dynamic.linux-d400-ppc64le.image: "ppc64le-rhel-94-base-27nov2024"
+  dynamic.linux-d400-ppc64le.crn: "crn:v1:bluemix:public:power-iaas:dal12:a/eebc7153d0c844f9915fb6f3b9850a3b:d6faf373-c0b6-4ba9-b0bc-4f7e0a74f9d5::"
+  dynamic.linux-d400-ppc64le.url: "https://us-south.power-iaas.cloud.ibm.com"
+  dynamic.linux-d400-ppc64le.network: "4d164943-b043-4c6e-bba5-d233abf66c6a"
+  dynamic.linux-d400-ppc64le.system: "e980"
+  dynamic.linux-d400-ppc64le.cores: "2"
+  dynamic.linux-d400-ppc64le.memory: "8"
+  dynamic.linux-d400-ppc64le.max-instances: "30"
+  dynamic.linux-d400-ppc64le.allocation-timeout: "1800"
+  dynamic.linux-d400-ppc64le.disk: "400"
 
   #PPC64LE Large dynamic nodes
   dynamic.linux-large-ppc64le.type: ibmp


### PR DESCRIPTION
Looks like 200 wasn't enough: https://konflux.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/application-pipeline/workspaces/ocp-art/applications/openshift-4-19/pipelineruns/ose-4-19-ose-installer-artifacts-hr9d2