### PR TITLE
deploy namespace-lister to remaining staging clusters

### DIFF
--- a/argo-cd-apps/overlays/staging-downstream/delete-applications.yaml
+++ b/argo-cd-apps/overlays/staging-downstream/delete-applications.yaml
@@ -68,9 +68,3 @@ kind: ApplicationSet
 metadata:
   name: kyverno
 $patch: delete
----
-apiVersion: argoproj.io/v1alpha1
-kind: ApplicationSet
-metadata:
-  name: namespace-lister
-$patch: delete

--- a/components/namespace-lister/staging/stone-stage-p01/kustomization.yaml
+++ b/components/namespace-lister/staging/stone-stage-p01/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../base/


### PR DESCRIPTION
It's stabilized on stone-stg-rh01, so let's move it on to the other staging clusters.  Production clusters will follow soon.