### PR TITLE
deploy namespace-lister to production rh02

### DIFF
--- a/argo-cd-apps/base/member/infra-deployments/namespace-lister/namespace-lister.yaml
+++ b/argo-cd-apps/base/member/infra-deployments/namespace-lister/namespace-lister.yaml
@@ -10,15 +10,21 @@ spec:
         generators:
           - clusters:
               values:
+                # This app must have cluster specific configurations, so we
+                # need to provide a config for clusters we do not wish to deploy
+                # to.  The `empty-base` clusterDir is an overlay that deploys no
+                # resources to non-matching clusters.
+                clusterDir: empty-base
                 sourceRoot: components/namespace-lister
                 environment: staging
-                clusterDir: ""
           - list:
               elements:
                 - nameNormalized: stone-stg-rh01
                   values.clusterDir: stone-stg-rh01
                 - nameNormalized: stone-stg-p01
                   values.clusterDir: stone-stg-p01
+                - nameNormalized: kflux-prd-rh02
+                  values.clusterDir: kflux-prd-rh02
   template:
     metadata:
       name: namespace-lister-{{nameNormalized}}

--- a/argo-cd-apps/overlays/konflux-public-production/delete-applications.yaml
+++ b/argo-cd-apps/overlays/konflux-public-production/delete-applications.yaml
@@ -45,9 +45,3 @@ kind: ApplicationSet
 metadata:
   name: kyverno
 $patch: delete
----
-apiVersion: argoproj.io/v1alpha1
-kind: ApplicationSet
-metadata:
-  name: namespace-lister
-$patch: delete

--- a/components/namespace-lister/empty-base/kustomization.yaml
+++ b/components/namespace-lister/empty-base/kustomization.yaml
@@ -1,0 +1,3 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: namespace-lister

--- a/components/namespace-lister/production/base/deployment.yaml
+++ b/components/namespace-lister/production/base/deployment.yaml
@@ -1,0 +1,69 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: namespace-lister
+  namespace: namespace-lister
+  labels:
+    apps: namespace-lister
+  annotations:
+    ignore-check.kube-linter.io/no-anti-affinity: "Using topologySpreadConstraints"
+spec:
+  selector:
+    matchLabels:
+      apps: namespace-lister
+  replicas: 3
+  template:
+    metadata:
+      labels:
+        apps: namespace-lister
+    spec:
+      serviceAccountName: namespace-lister
+      topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: topology.kubernetes.io/zone
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            apps: namespace-lister
+      containers:
+      - args:
+        - -enable-tls
+        - -cert-path=/var/tls/tls.crt
+        - -key-path=/var/tls/tls.key
+        - -enable-metrics
+        - -metrics-address=:9100
+        image: namespace-lister:foo
+        name: namespace-lister
+        env:
+        - name: LOG_LEVEL
+          value: "0"
+        - name: CACHE_RESYNC_PERIOD
+          value: 10m
+        resources:
+          limits:
+            cpu: 500m
+            memory: 1Gi
+          requests:
+            cpu: 500m
+            memory: 256Mi
+        ports:
+        - containerPort: 8080
+          name: http
+        - containerPort: 9100
+          name: metrics
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          capabilities:
+            drop:
+            - "ALL"
+        volumeMounts:
+        - name: tls
+          mountPath: /var/tls
+          readOnly: true
+      volumes:
+      - name: tls
+        secret:
+          secretName: namespace-lister-tls
+      terminationGracePeriodSeconds: 60

--- a/components/namespace-lister/production/base/kustomization.yaml
+++ b/components/namespace-lister/production/base/kustomization.yaml
@@ -1,0 +1,27 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- deployment.yaml
+- namespace.yaml
+- rbac.yaml
+- service.yaml
+- network_policy.yaml
+- metrics/
+namespace: namespace-lister
+images:
+- name: namespace-lister
+  newName: quay.io/konflux-ci/namespace-lister
+  newTag: 1181ecb4ba10d6fbe5ea7bb94393b04cb2a932f8
+patches:
+- path: ./patches/with_cachenamespacelabelselector.yaml
+  target:
+    group: apps
+    kind: Deployment
+    name: namespace-lister
+    namespace: namespace-lister
+- path: ./patches/with_header_auth_user.yaml
+  target:
+    group: apps
+    kind: Deployment
+    name: namespace-lister
+    namespace: namespace-lister

--- a/components/namespace-lister/production/base/metrics/kustomization.yaml
+++ b/components/namespace-lister/production/base/metrics/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- monitor.yaml
+- service-account.yaml
+- rbac.yaml
+- network_policy.yaml

--- a/components/namespace-lister/production/base/metrics/monitor.yaml
+++ b/components/namespace-lister/production/base/metrics/monitor.yaml
@@ -1,0 +1,26 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: namespace-lister-metrics
+  labels:
+    apps: namespace-lister
+spec:
+  endpoints:
+    - interval: 15s
+      scheme: https
+      path: /metrics
+      port: metrics
+      authorization:
+        credentials:
+          key: token
+          name: metrics-reader
+      tlsConfig:
+        ca:
+          secret:
+            key: service-ca.crt
+            name: metrics-reader
+            optional: false
+        serverName: namespace-lister.namespace-lister.svc
+  selector:
+    matchLabels:
+      apps: namespace-lister

--- a/components/namespace-lister/production/base/metrics/network_policy.yaml
+++ b/components/namespace-lister/production/base/metrics/network_policy.yaml
@@ -1,0 +1,19 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-from-openshift-user-workload-monitoring
+  namespace: namespace-lister
+spec:
+  podSelector:
+    matchLabels:
+      apps: namespace-lister
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: openshift-user-workload-monitoring
+    ports:
+    - protocol: TCP
+      port: metrics

--- a/components/namespace-lister/production/base/metrics/rbac.yaml
+++ b/components/namespace-lister/production/base/metrics/rbac.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: namespace-lister-metrics
+rules:
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: prometheus-namespace-lister-metrics-reader
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: namespace-lister-metrics
+subjects:
+- kind: ServiceAccount
+  name: metrics-reader
+  namespace: namespace-lister

--- a/components/namespace-lister/production/base/metrics/service-account.yaml
+++ b/components/namespace-lister/production/base/metrics/service-account.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  annotations:
+    kubernetes.io/service-account.name: metrics-reader
+  name: metrics-reader
+type: kubernetes.io/service-account-token
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: metrics-reader
+  namespace: namespace-lister

--- a/components/namespace-lister/production/base/namespace.yaml
+++ b/components/namespace-lister/production/base/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: namespace-lister

--- a/components/namespace-lister/production/base/network_policy.yaml
+++ b/components/namespace-lister/production/base/network_policy.yaml
@@ -1,0 +1,22 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-from-konflux-ui
+  namespace: namespace-lister
+spec:
+  podSelector:
+    matchLabels:
+      apps: namespace-lister
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: konflux-ui
+    - podSelector:
+        matchLabels:
+          app: proxy
+    ports:
+    - protocol: TCP
+      port: 8080

--- a/components/namespace-lister/production/base/patches/with-header-auth-email.yaml
+++ b/components/namespace-lister/production/base/patches/with-header-auth-email.yaml
@@ -1,0 +1,5 @@
+- op: add
+  path: /spec/template/spec/containers/0/env/-
+  value:
+    name: AUTH_USERNAME_HEADER
+    value: X-Email

--- a/components/namespace-lister/production/base/patches/with_cachenamespacelabelselector.yaml
+++ b/components/namespace-lister/production/base/patches/with_cachenamespacelabelselector.yaml
@@ -1,0 +1,5 @@
+- op: add
+  path: /spec/template/spec/containers/0/env/-
+  value:
+    name: CACHE_NAMESPACE_LABELSELECTOR
+    value: 'konflux.ci/type=user'

--- a/components/namespace-lister/production/base/patches/with_header_auth_user.yaml
+++ b/components/namespace-lister/production/base/patches/with_header_auth_user.yaml
@@ -1,0 +1,5 @@
+- op: add
+  path: /spec/template/spec/containers/0/env/-
+  value:
+    name: AUTH_USERNAME_HEADER
+    value: X-User

--- a/components/namespace-lister/production/base/rbac.yaml
+++ b/components/namespace-lister/production/base/rbac.yaml
@@ -1,0 +1,36 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: namespace-lister
+  namespace: namespace-lister
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: namespace-lister-authorizer
+subjects:
+- apiGroup: ""
+  kind: ServiceAccount
+  name: namespace-lister
+  namespace: namespace-lister
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: namespace-lister-authorizer
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: namespace-lister-authorizer
+rules:
+- apiGroups: [""]
+  resources: ["namespaces"]
+  verbs: ["get", "list", "watch"]
+- apiGroups:
+  - "rbac.authorization.k8s.io"
+  resources:
+  - clusterroles
+  - clusterrolebindings
+  - roles
+  - rolebindings
+  verbs: ["get", "list", "watch"]

--- a/components/namespace-lister/production/base/service.yaml
+++ b/components/namespace-lister/production/base/service.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: namespace-lister-tls
+  labels:
+    apps: namespace-lister
+  name: namespace-lister
+  namespace: namespace-lister
+spec:
+  selector:
+    apps: namespace-lister
+  type: ClusterIP
+  ports:
+  - name: http
+    targetPort: 8080
+    port: 8080
+  - name: metrics
+    targetPort: metrics
+    port: 9100

--- a/components/namespace-lister/production/kflux-prd-rh02/kustomization.yaml
+++ b/components/namespace-lister/production/kflux-prd-rh02/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../base/


### PR DESCRIPTION
The deployments for namespace-lister appear to be stable on the relevant staging cluster (`stone-stg-rh01`), so we can begin to roll this out to the relevant production clusters.

For now, the only cluster we wish to deploy to is `kflux-prd-rh02`, since the component `konflux-ui` has not been deployed to any other production clusters yet.  All other clusters affected by the `konflux-public-production` overlay will see no new resources added to the cluster.

Adding namespace-lister to konflux-ui's production proxy config will come in a separate PR.