### PR TITLE
Revert "KONFLUX-5670: Enable NVMe Disk Configuration (#5244)"

### DIFF
--- a/argo-cd-apps/overlays/staging-downstream/delete-applications.yaml
+++ b/argo-cd-apps/overlays/staging-downstream/delete-applications.yaml
@@ -57,12 +57,6 @@ metadata:
   name: konflux-ui
 $patch: delete
 ---
-# apiVersion: argoproj.io/v1alpha1
-# kind: ApplicationSet
-# metadata:
-#   name: nvme-storage-configurator
-# $patch: delete
----
 apiVersion: argoproj.io/v1alpha1
 kind: ApplicationSet
 metadata:
@@ -73,4 +67,10 @@ apiVersion: argoproj.io/v1alpha1
 kind: ApplicationSet
 metadata:
   name: namespace-lister
+$patch: delete
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: nvme-storage-configurator
 $patch: delete


### PR DESCRIPTION
This reverts commit df73235785aa650efbd8afd975cf4141afa847b6.

Yesterday we discussed on "Konflux Performance WG weekly" that this NVMe permission problem is not up to Perf team to solve, so I'm going to stop looking into it, so we do not need it deployed on Stage.