### PR TITLE
Increase application-service requests nearer to current usage

### DIFF
--- a/components/has/k-components/manager-resources/manager_resources_patch.yaml
+++ b/components/has/k-components/manager-resources/manager_resources_patch.yaml
@@ -14,7 +14,7 @@ spec:
             memory: 2Gi
           requests:
             cpu: 100m
-            memory: 20Mi
+            memory: 1Gi
         env:
           - name: IMAGE_REPOSITORY
             value: ""


### PR DESCRIPTION
Long term, application-service-controller-manager memory usage is above its requests which makes it very fragile when there is a memory pressure on the cluster.

Fixes [KONFLUX-5891](https://issues.redhat.com//browse/KONFLUX-5891)