### PR TITLE
[OCP] Increasing linux-d400-large-ppc64le.max-instances to 30

### DIFF
--- a/components/multi-platform-controller/production-downstream/kflux-ocp-p01/host-config.yaml
+++ b/components/multi-platform-controller/production-downstream/kflux-ocp-p01/host-config.yaml
@@ -566,7 +566,7 @@ data:
   dynamic.linux-d400-large-ppc64le.system: "e980"
   dynamic.linux-d400-large-ppc64le.cores: "4"
   dynamic.linux-d400-large-ppc64le.memory: "16"
-  dynamic.linux-d400-large-ppc64le.max-instances: "10"
+  dynamic.linux-d400-large-ppc64le.max-instances: "30"
   dynamic.linux-d400-large-ppc64le.allocation-timeout: "1800"
   dynamic.linux-d400-large-ppc64le.disk: "400"
 


### PR DESCRIPTION
Since builds doesn't seem to be starting