### PR TITLE
Namespace-lister: use https instead of http

### DIFF
--- a/components/konflux-ui/staging/base/proxy/nginx.conf
+++ b/components/konflux-ui/staging/base/proxy/nginx.conf
@@ -184,7 +184,7 @@ http {
 
             rewrite ^.*$ /api/v1/namespaces break;
 
-            proxy_pass http://namespace-lister.namespace-lister.svc.cluster.local:8080;
+            proxy_pass https://namespace-lister.namespace-lister.svc.cluster.local:8080;
         }
 
         location @kubeapi {

--- a/components/namespace-lister/base/deployment.yaml
+++ b/components/namespace-lister/base/deployment.yaml
@@ -26,10 +26,12 @@ spec:
           matchLabels:
             apps: namespace-lister
       containers:
-      - image: namespace-lister:foo
+      - args:
+        - -enable-tls
+        - -cert-path=/var/tls/tls.crt
+        - -key-path=/var/tls/tls.key
+        image: namespace-lister:foo
         name: namespace-lister
-        args:
-        - "-enable-tls=false"
         env:
         - name: LOG_LEVEL
           value: "0"
@@ -50,4 +52,12 @@ spec:
           capabilities:
             drop:
             - "ALL"
+        volumeMounts:
+        - name: tls
+          mountPath: /var/tls
+          readOnly: true
+      volumes:
+      - name: tls
+        secret:
+          secretName: namespace-lister-tls
       terminationGracePeriodSeconds: 60

--- a/components/namespace-lister/base/service.yaml
+++ b/components/namespace-lister/base/service.yaml
@@ -1,6 +1,8 @@
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: namespace-lister-tls
   labels:
     apps: namespace-lister
   name: namespace-lister


### PR DESCRIPTION
Namespace-lister now supports https connections, so use it instead of http.