### PR TITLE
feat: Add quay secret to push test artifacts

### DIFF
--- a/components/konflux-ci/base/external-secrets/kustomization.yaml
+++ b/components/konflux-ci/base/external-secrets/kustomization.yaml
@@ -9,4 +9,5 @@ resources:
 - github-secret.yaml
 - clair-in-ci-db-github-token.yaml
 - registry-redhat-io-pull-secret.yaml
+- test-artifacts-push-secret.yaml
 namespace: konflux-ci

--- a/components/konflux-ci/base/external-secrets/test-artifacts-push-secret.yaml
+++ b/components/konflux-ci/base/external-secrets/test-artifacts-push-secret.yaml
@@ -1,0 +1,24 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: konflux-test-infra
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  dataFrom:
+    - extract:
+        key: production/build/tekton-ci/test-artifacts-push-secret
+  refreshInterval: 15m
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: appsre-stonesoup-vault
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    name: quay-push-secret-konflux-ci
+    template:
+      engineVersion: v2
+      type: kubernetes.io/dockerconfigjson
+      data:
+        oci-storage-dockerconfigjson: "{{ .config }}"


### PR DESCRIPTION
This PR adding a quay secret needed to push the artifacts to `quay.io/konflux-test-storage/konflux-team/build-definitions` repo.
Part of the story: https://issues.redhat.com/browse/STONEBLD-3025