### PR TITLE
mintmaker: add configmaps and secrets permissions for mintmaker team

### DIFF
--- a/components/mintmaker/base/rbac/mintmaker-team.yaml
+++ b/components/mintmaker/base/rbac/mintmaker-team.yaml
@@ -2,7 +2,15 @@ kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: mintmaker-admin
+  namespace: mintmaker
 rules:
+  - apiGroups:
+      - ''
+    resources:
+      - secrets
+      - configmaps
+    verbs:
+      - '*'
   - apiGroups:
       - 'batch'
     resources:


### PR DESCRIPTION
The controller sometimes leaves undeleted temporary configmaps/secrets
from renovate pipelineruns when bug happens. Grant team full access
to configmaps and secrets in mintmaker namespace for better self-service
capability, as other secrets and configmaps are safely managed by ArgoCD.