### PR TITLE
Mintmaker: create a cronjob for generating the OSV database

### DIFF
--- a/components/mintmaker/base/kustomization.yaml
+++ b/components/mintmaker/base/kustomization.yaml
@@ -1,6 +1,7 @@
 resources:
 - cronjobs/
 - rbac/
+- osv-database-builder/
 
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/components/mintmaker/base/osv-database-builder/create-database-generator-cronjob.yaml
+++ b/components/mintmaker/base/osv-database-builder/create-database-generator-cronjob.yaml
@@ -1,0 +1,38 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: create-database-generator
+  namespace: mintmaker
+spec:
+  schedule: "0 */4 * * *"
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: Never
+          containers:
+            - name: database-generator
+              image: quay.io/konflux-ci/mintmaker:next
+              imagePullPolicy: IfNotPresent
+              command:
+                - /bin/sh
+                - -c
+                - /osv-generator -destination-dir /mnt/database -docker-filename docker.nedb -rpm-filename rpm.nedb -days 1
+              resources:
+                requests:
+                  cpu: 100m
+                  memory: 500Mi
+                limits:
+                  cpu: 100m
+                  memory: 500Mi
+              volumeMounts:
+                - name: osv-db
+                  mountPath: /mnt/database
+              securityContext:
+                runAsNonRoot: true
+                readOnlyRootFilesystem: true
+          volumes:
+            - name: osv-db
+              persistentVolumeClaim:
+                claimName: osv-offline-db

--- a/components/mintmaker/base/osv-database-builder/create-database-generator-job.yaml
+++ b/components/mintmaker/base/osv-database-builder/create-database-generator-job.yaml
@@ -1,0 +1,37 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: database-generator
+  namespace: mintmaker
+  annotations:
+    argocd.argoproj.io/hook: Sync
+    argocd.argoproj.io/hook-delete-policy: HookSucceeded
+spec:
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: database-generator
+          image: quay.io/konflux-ci/mintmaker:next
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/sh
+            - -c
+            - /osv-generator -destination-dir /mnt/database -docker-filename docker.nedb -rpm-filename rpm.nedb -days 1
+          resources:
+            requests:
+              cpu: 100m
+              memory: 500Mi
+            limits:
+              cpu: 100m
+              memory: 500Mi
+          volumeMounts:
+            - name: osv-db
+              mountPath: /mnt/database
+          securityContext:
+            runAsNonRoot: true
+            readOnlyRootFilesystem: true
+      volumes:
+        - name: osv-db
+          persistentVolumeClaim:
+            claimName: osv-offline-db

--- a/components/mintmaker/base/osv-database-builder/create-database-pvc.yaml
+++ b/components/mintmaker/base/osv-database-builder/create-database-pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: osv-offline-db
+  namespace: mintmaker
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+  volumeMode: Filesystem

--- a/components/mintmaker/base/osv-database-builder/kustomization.yaml
+++ b/components/mintmaker/base/osv-database-builder/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- create-database-pvc.yaml
+- create-database-generator-cronjob.yaml
+- create-database-generator-job.yaml
+namespace: mintmaker


### PR DESCRIPTION
The database will be in a persistent volume which will be mounted by pods running renovate. The cronjob downloads the upstream OSV database and generates custom RPM and docker DB files on each run. The job uses the same image as MintMaker controller, so no modifications to the release process are necessary.

The reason why the cronjob was duplicated as a job is that the schedule "every X hours" does not create a job upon cronjob creation. This can cause issues when bootstrapping, since no DB will exist for several hours. The job is implemented as a hook, and the resource will self-delete after its run.