### PR TITLE
Remove invalid fields from monitoring kustomize transformation

### DIFF
--- a/components/monitoring/grafana/base/dashboards/cm-dashboard.yaml
+++ b/components/monitoring/grafana/base/dashboards/cm-dashboard.yaml
@@ -1,10 +1,5 @@
-apiVersion: builtin
-kind: ConfigMapGenerator
-metadata:
-  name: cm-dashboard
 nameReference:
   - kind: ConfigMap
     fieldSpecs:
       - kind: GrafanaDashboard
         path: spec/configMapRef/name
-


### PR DESCRIPTION
This transformation does have invalid fields which are ignored by kustomize version < 5.4.0. Starting with 5.4.0, kustomize uses strict unmarsheling so kustomize build command is failing. This change is needed to upgrade from gitops 1.12 to 1.15 which include ArgoCD version which uses kustomize version 5.4.3

[KFLUXINFRA-1211](https://issues.redhat.com//browse/KFLUXINFRA-1211)