### PR TITLE
Promote MintMaker prod

### DIFF
--- a/components/mintmaker/development/kustomization.yaml
+++ b/components/mintmaker/development/kustomization.yaml
@@ -2,13 +2,13 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../base
-  - https://github.com/konflux-ci/mintmaker/config/default?ref=7f0cd9e10e0ede8e2dcce8e5cbaa3647b4548cc4
-  - https://github.com/konflux-ci/mintmaker/config/renovate?ref=7f0cd9e10e0ede8e2dcce8e5cbaa3647b4548cc4
+  - https://github.com/konflux-ci/mintmaker/config/default?ref=483319c06f597a3b2ed7f84d8a6f763e7db90a17
+  - https://github.com/konflux-ci/mintmaker/config/renovate?ref=483319c06f597a3b2ed7f84d8a6f763e7db90a17
 
 images:
   - name: quay.io/konflux-ci/mintmaker
     newName: quay.io/konflux-ci/mintmaker
-    newTag: 7f0cd9e10e0ede8e2dcce8e5cbaa3647b4548cc4
+    newTag: 483319c06f597a3b2ed7f84d8a6f763e7db90a17
 
 namespace: mintmaker
 

--- a/components/mintmaker/production/base/kustomization.yaml
+++ b/components/mintmaker/production/base/kustomization.yaml
@@ -3,15 +3,15 @@ kind: Kustomization
 resources:
   - ../../base
   - ../../base/external-secrets
-  - https://github.com/konflux-ci/mintmaker/config/default?ref=7f0cd9e10e0ede8e2dcce8e5cbaa3647b4548cc4
-  - https://github.com/konflux-ci/mintmaker/config/renovate?ref=7f0cd9e10e0ede8e2dcce8e5cbaa3647b4548cc4
+  - https://github.com/konflux-ci/mintmaker/config/default?ref=483319c06f597a3b2ed7f84d8a6f763e7db90a17
+  - https://github.com/konflux-ci/mintmaker/config/renovate?ref=483319c06f597a3b2ed7f84d8a6f763e7db90a17
 
 namespace: mintmaker
 
 images:
   - name: quay.io/konflux-ci/mintmaker
     newName: quay.io/konflux-ci/mintmaker
-    newTag: 7f0cd9e10e0ede8e2dcce8e5cbaa3647b4548cc4
+    newTag: 483319c06f597a3b2ed7f84d8a6f763e7db90a17
   - name: quay.io/konflux-ci/mintmaker-renovate-image
     newName: quay.io/konflux-ci/mintmaker-renovate-image
     newTag: 083371d43e1eebd093592ac7d87762f8bae9197b

--- a/components/mintmaker/staging/base/kustomization.yaml
+++ b/components/mintmaker/staging/base/kustomization.yaml
@@ -3,15 +3,15 @@ kind: Kustomization
 resources:
 - ../../base
 - ../../base/external-secrets
-- https://github.com/konflux-ci/mintmaker/config/default?ref=062080578747badc43ab7b74db501f9e429901f8
-- https://github.com/konflux-ci/mintmaker/config/renovate?ref=062080578747badc43ab7b74db501f9e429901f8
+- https://github.com/konflux-ci/mintmaker/config/default?ref=483319c06f597a3b2ed7f84d8a6f763e7db90a17
+- https://github.com/konflux-ci/mintmaker/config/renovate?ref=483319c06f597a3b2ed7f84d8a6f763e7db90a17
 
 namespace: mintmaker
 
 images:
 - name: quay.io/konflux-ci/mintmaker
-  newName: quay.io/redhat-user-workloads/konflux-mintmaker-tenant/mintmaker-refactoring-pipelinerun
-  newTag: 31f4b5da85d8231c764bdc42f8603a631265f255
+  newName: quay.io/konflux-ci/mintmaker
+  newTag: 483319c06f597a3b2ed7f84d8a6f763e7db90a17
 - name: quay.io/konflux-ci/mintmaker-renovate-image
   newName: quay.io/konflux-ci/mintmaker-renovate-image
   newTag: 083371d43e1eebd093592ac7d87762f8bae9197b


### PR DESCRIPTION
This change includes the refactoring. MintMaker now uses PipelineRuns instead of jobs.
This commit also brings back stage to its usual state (it was recentely changed to point to another branch). It updates development too.