### PR TITLE
Allow maintainers to view ephemeral namespace resources

### DIFF
--- a/components/authentication/base/everyone-can-view.yaml
+++ b/components/authentication/base/everyone-can-view.yaml
@@ -79,6 +79,23 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - eaas.konflux-ci.dev
+  resources:
+  - namespaces
+  - xnamespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - kubernetes.crossplane.io
+  resources:
+  - objects
+  verbs:
+  - get
+  - list
+  - watch
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
This is useful when trying to debug issues with the ephemeral namespaces.