### PR TITLE
Improve MintMaker memory resources

### DIFF
--- a/components/mintmaker/production/base/manager_patch.yaml
+++ b/components/mintmaker/production/base/manager_patch.yaml
@@ -11,7 +11,7 @@ spec:
         resources:
           limits:
             cpu: 500m
-            memory: 2048Mi
+            memory: 3Gi
           requests:
             cpu: 100m
             memory: 256Mi


### PR DESCRIPTION
We are experiences memory peaks, it might happen to reach the limit in high cluster loads period. Let's increase the memory a bit to prevent the pod from crashing.