### PR TITLE
Fix namespace-claim-cleaner cronjob

### DIFF
--- a/components/crossplane-control-plane/base/configmap.yaml
+++ b/components/crossplane-control-plane/base/configmap.yaml
@@ -8,8 +8,8 @@ data:
     #!/bin/bash
     set -eo pipefail
 
-    namespaces=$(kubectl get namespaces.eaas.konflux-ci.dev --all-namespaces -o json | jq -c '.items[] | "\(.metadata.name) \(.metadata.namespace) \(.metadata.creationTimestamp)"' | sed 's/"//g' | xargs)
-    
+    namespaces=$(kubectl get namespaces.eaas.konflux-ci.dev --all-namespaces -o jsonpath='{range .items[*]}{.metadata.name} {.metadata.namespace} {.metadata.creationTimestamp}{"\n"}{end}')
+
     if [[ -z "$namespaces" ]]; then
       echo "No namespaces found"
       exit 0

--- a/components/crossplane-control-plane/base/cronjob.yaml
+++ b/components/crossplane-control-plane/base/cronjob.yaml
@@ -4,7 +4,7 @@ metadata:
   name: namespace-claim-cleaner
   namespace: crossplane-system
 spec:
-  schedule: "0 4 * * *" # every day at 4AM UTC
+  schedule: "0 * * * *" # every hour
   jobTemplate:
     spec:
       template:


### PR DESCRIPTION
The jobs would fail when multiple claims were found. The frequency of the cronjob has also been increased to once per hour. Otherwise users could have access to ephemeral namespaces for up to 24h.