### PR TITLE
Bump mintmaker-renovate-image

### DIFF
--- a/components/mintmaker/production/base/kustomization.yaml
+++ b/components/mintmaker/production/base/kustomization.yaml
@@ -14,7 +14,7 @@ images:
     newTag: 483319c06f597a3b2ed7f84d8a6f763e7db90a17
   - name: quay.io/konflux-ci/mintmaker-renovate-image
     newName: quay.io/konflux-ci/mintmaker-renovate-image
-    newTag: 083371d43e1eebd093592ac7d87762f8bae9197b
+    newTag: 289fc1f3a79aaf172bff9def716e2f864a7f25c4
 
 commonAnnotations:
   argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true

--- a/components/mintmaker/staging/base/kustomization.yaml
+++ b/components/mintmaker/staging/base/kustomization.yaml
@@ -14,7 +14,7 @@ images:
   newTag: 17adeaaddd3624cb7afc53976f3962f2cee61032
 - name: quay.io/konflux-ci/mintmaker-renovate-image
   newName: quay.io/konflux-ci/mintmaker-renovate-image
-  newTag: 083371d43e1eebd093592ac7d87762f8bae9197b
+  newTag: 289fc1f3a79aaf172bff9def716e2f864a7f25c4
 
 commonAnnotations:
   argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true


### PR DESCRIPTION
These PRs are in this update:

- https://github.com/konflux-ci/mintmaker-renovate-image/pull/88
- https://github.com/konflux-ci/mintmaker-renovate-image/pull/89

But most importantly we need a rebuild to fix [CWFHEALTH-3864](https://issues.redhat.com//browse/CWFHEALTH-3864)