### PR TITLE
PVO11Y-4603 Deploy cluster observability operator

### DIFF
--- a/components/monitoring/prometheus/base/observability-operator/observability-operator.yaml
+++ b/components/monitoring/prometheus/base/observability-operator/observability-operator.yaml
@@ -1,16 +1,4 @@
 ---
-apiVersion: operators.coreos.com/v1alpha1
-kind: CatalogSource
-metadata:
-  name: observability-operator-catalog
-  namespace: openshift-marketplace
-spec:
-  displayName: Red Hat Observability Operator
-  image: >-
-    quay.io/rhobs/observability-operator-catalog@sha256:86f808d1fbd10af986628916902faf2b250ffad1dd63b662c0e10de968a97445
-  publisher: OSD Red Hat Addons
-  sourceType: grpc
----
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:
@@ -22,13 +10,11 @@ spec:
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
-  labels:
-    operators.coreos.com/observability-operator.appstudio-monitoring: ""
-  name: observability-operator
+  name: cluster-observability-operator
   namespace: appstudio-monitoring
 spec:
-  channel: stable
+  channel: development
   installPlanApproval: Automatic
-  name: observability-operator
-  source: observability-operator-catalog
+  name: cluster-observability-operator
+  source: redhat-operators
   sourceNamespace: openshift-marketplace


### PR DESCRIPTION
As detailed in this [KCS article](https://access.redhat.com/articles/7103797), the Observability Operator (OBO) will no longer be deployed automatically (by Hive) on ROSA clusters as of Jan 30th.

This means that the new Cluster Observability Operator (aka COO, the productized version of OBO), should be deployed on all Konflux clusters. 

Before rolling this out to production, we will test this only in the stone-stage-p01 cluster and validate. There will be a follow up PR where the production deployments will be added.