### PR TITLE
kvyerno: move helm values to file

### DIFF
--- a/argo-cd-apps/base/member/infra-deployments/kyverno/kyverno.yaml
+++ b/argo-cd-apps/base/member/infra-deployments/kyverno/kyverno.yaml
@@ -27,17 +27,11 @@ spec:
           repoURL: https://kyverno.github.io/kyverno/
           targetRevision: 3.3.4
           helm:
-            values: |
-              admissionController:
-                replicas: 3
-              backgroundController:
-                replicas: 3
-              cleanupController:
-                replicas: 3
-              reportsController:
-                replicas: 3
-              policyReportsCleanup:
-                securityContext: null
+            valueFiles:
+            - $values/{{values.sourceRoot}}/{{values.environment}}/kyverno-values.yaml
+        - repoURL: https://github.com/redhat-appstudio/infra-deployments.git
+          targetRevision: main
+          ref: values
       destination:
         namespace: konflux-kyverno
         server: '{{server}}'

--- a/components/kyverno/OWNERS
+++ b/components/kyverno/OWNERS
@@ -1,0 +1,11 @@
+# See the OWNERS docs: https://go.k8s.io/owners
+
+approvers:
+- dperaza4dustbit
+- filariow
+- sadlerap
+
+reviewers:
+- dperaza4dustbit
+- filariow
+- sadlerap

--- a/components/kyverno/staging/kyverno-values.yaml
+++ b/components/kyverno/staging/kyverno-values.yaml
@@ -1,0 +1,10 @@
+admissionController:
+  replicas: 3
+backgroundController:
+  replicas: 3
+cleanupController:
+  replicas: 3
+reportsController:
+  replicas: 3
+policyReportsCleanup:
+  securityContext: null


### PR DESCRIPTION
Keeping the helm values inline to the applicationset is getting in our way, so we should move away from this if we can.

This copies the approach that the `tracing-workload-otel-collector` applicationset uses.