### PR TITLE
namespace-lister: label service

### DIFF
--- a/components/namespace-lister/base/service.yaml
+++ b/components/namespace-lister/base/service.yaml
@@ -1,6 +1,8 @@
 apiVersion: v1
 kind: Service
 metadata:
+  labels:
+    apps: namespace-lister
   name: namespace-lister
   namespace: namespace-lister
 spec:


### PR DESCRIPTION
The servicemonitor will search for endpoints by label, and we're not setting any label on services, which will create endpoints.  This means that the servicemonitor isn't finding any metrics to use.

To fix this, apply the label that the servicemonitor is listening for.