### PR TITLE
chore: udpate hac-dev to latest

### DIFF
--- a/components/ui/production/kflux-ocp-p01/kustomization.yaml
+++ b/components/ui/production/kflux-ocp-p01/kustomization.yaml
@@ -19,7 +19,7 @@ images:
   # hac-dev
   - name: quay.io/cloudservices/hac-dev-frontend
     newName: quay.io/cloudservices/hac-dev-frontend
-    newTag: de23e42
+    newTag: 198c611
 
 configMapGenerator:
   - name: fed-modules

--- a/components/ui/production/stone-prod-p01/kustomization.yaml
+++ b/components/ui/production/stone-prod-p01/kustomization.yaml
@@ -19,7 +19,7 @@ images:
   # hac-dev
   - name: quay.io/cloudservices/hac-dev-frontend
     newName: quay.io/cloudservices/hac-dev-frontend
-    newTag: de23e42
+    newTag: 198c611
 
 configMapGenerator:
   - name: fed-modules

--- a/components/ui/production/stone-prod-p02/kustomization.yaml
+++ b/components/ui/production/stone-prod-p02/kustomization.yaml
@@ -19,7 +19,7 @@ images:
   # hac-dev
   - name: quay.io/cloudservices/hac-dev-frontend
     newName: quay.io/cloudservices/hac-dev-frontend
-    newTag: de23e42
+    newTag: 198c611
 
 configMapGenerator:
   - name: fed-modules

--- a/components/ui/staging/kustomization.yaml
+++ b/components/ui/staging/kustomization.yaml
@@ -19,7 +19,7 @@ images:
   # hac-dev
   - name: quay.io/cloudservices/hac-dev-frontend
     newName: quay.io/cloudservices/hac-dev-frontend
-    newTag: de23e42
+    newTag: 198c611
 
 configMapGenerator:
   - name: fed-modules


### PR DESCRIPTION
# Pull Requests Changelog
Repository: openshift/hac-dev
Changes between de23e42 and 198c611

## 🚀 Features
- openshift/hac-dev#1033 feat([KFLUXUI-256](https://issues.redhat.com//browse/KFLUXUI-256)): support component.spec.containerImage as latestImage by @testcara [`lgtm,approved`] ([PR](https://github.com/openshift/hac-dev/pull/1033))

## 🐛 Bug Fixes
- openshift/hac-dev#1035 fix: unblock component list loading from pipeline runs by @sahil143 [`lgtm,approved`] ([PR](https://github.com/openshift/hac-dev/pull/1035))
- openshift/hac-dev#1034 fix: ec regex to extract voilation reports from tkn logs by @sahil143 [`lgtm,approved`] ([PR](https://github.com/openshift/hac-dev/pull/1034))

