### PR TITLE
konflux-ci: add dockerhub pull secret

### DIFF
--- a/components/konflux-ci/base/external-secrets/dockerhub-pull-secret.yaml
+++ b/components/konflux-ci/base/external-secrets/dockerhub-pull-secret.yaml
@@ -1,0 +1,24 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: dockerhub-pull-secret
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  dataFrom:
+    - extract:
+        key: production/build/tekton-ci/dockerhub-pull-secret
+  refreshInterval: 15m
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: appsre-stonesoup-vault
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    name: dockerhub-pull-secret
+    template:
+      engineVersion: v2
+      type: kubernetes.io/dockerconfigjson
+      data:
+        .dockerconfigjson: "{{ .config }}"

--- a/components/konflux-ci/base/external-secrets/kustomization.yaml
+++ b/components/konflux-ci/base/external-secrets/kustomization.yaml
@@ -10,4 +10,5 @@ resources:
 - clair-in-ci-db-github-token.yaml
 - registry-redhat-io-pull-secret.yaml
 - test-artifacts-push-secret.yaml
+- dockerhub-pull-secret.yaml
 namespace: konflux-ci

--- a/components/konflux-ci/base/serviceaccount.yaml
+++ b/components/konflux-ci/base/serviceaccount.yaml
@@ -5,6 +5,8 @@ metadata:
 secrets:
   - name: quay-push-secret-konflux-ci
   - name: registry-redhat-io-pull-secret
+  - name:  dockerhub-pull-secret
 imagePullSecrets:
   - name: quay-push-secret-konflux-ci
   - name: registry-redhat-io-pull-secret
+  - name: dockerhub-pull-secret


### PR DESCRIPTION
Cachi2 needs images from dockerhub and we are hitting rate limits from annonymous access