### PR TITLE
fix: the target name of the test-artifacts-push-secret

### DIFF
--- a/components/konflux-ci/base/external-secrets/test-artifacts-push-secret.yaml
+++ b/components/konflux-ci/base/external-secrets/test-artifacts-push-secret.yaml
@@ -16,9 +16,10 @@ spec:
   target:
     creationPolicy: Owner
     deletionPolicy: Delete
-    name: quay-push-secret-konflux-ci
+    name: konflux-test-infra
     template:
       engineVersion: v2
       type: kubernetes.io/dockerconfigjson
       data:
         oci-storage-dockerconfigjson: "{{ .config }}"
+        github-bot-commenter-token: "{{ .github-bot-commenter-token }}"


### PR DESCRIPTION
- when created this secret in the [last PR](https://github.com/redhat-appstudio/infra-deployments/pull/5377), target name was wrong
- added github-bot-token key in the secret, needed for interacting with github