### PR TITLE
namespace-lister: provide a tls config to ServiceMonitor

### DIFF
--- a/components/namespace-lister/base/metrics/monitor.yaml
+++ b/components/namespace-lister/base/metrics/monitor.yaml
@@ -14,6 +14,13 @@ spec:
         credentials:
           key: token
           name: metrics-reader
+      tlsConfig:
+        ca:
+          secret:
+            key: tls.crt
+            name: namespace-lister-tls
+            optional: false
+        serverName: namespace-lister.namespace-lister.svc
   selector:
     matchLabels:
       apps: namespace-lister


### PR DESCRIPTION
The service monitor doesn't know anything about the service it's talking to in terms of TLS, so we need to provide the following information:

- A Certificate Authority for requests to authenticate against.
- A server name to verify that we're talking to the correct service.