### PR TITLE
fix: the secret key name and use `_` instead

### DIFF
--- a/components/konflux-ci/base/external-secrets/test-artifacts-push-secret.yaml
+++ b/components/konflux-ci/base/external-secrets/test-artifacts-push-secret.yaml
@@ -22,4 +22,4 @@ spec:
       type: kubernetes.io/dockerconfigjson
       data:
         oci-storage-dockerconfigjson: "{{ .config }}"
-        github-bot-commenter-token: "{{ .github-bot-commenter-token }}"
+        github-bot-commenter-token: "{{ .github_bot_commenter_token }}"


### PR DESCRIPTION
during argo sync of this ExternalSecret..  resource is degraded with this error 
```
could not apply template: could not execute template: could not execute template: unable to execute template at key github-bot-commenter-token: unable to parse template at key github-bot-commenter-token: template: github-bot-commenter-token:1: bad character U+002D '-'
```
`-` character in the key name is causing the issue, so changed key name to use `_` instead.