### PR TITLE
fix: remove template part from the external secret

### DIFF
--- a/components/konflux-ci/base/external-secrets/test-artifacts-push-secret.yaml
+++ b/components/konflux-ci/base/external-secrets/test-artifacts-push-secret.yaml
@@ -8,6 +8,8 @@ metadata:
 spec:
   dataFrom:
     - extract:
+        conversionStrategy: Default
+        decodingStrategy: None
         key: production/build/tekton-ci/test-artifacts-push-secret
   refreshInterval: 15m
   secretStoreRef:
@@ -17,9 +19,3 @@ spec:
     creationPolicy: Owner
     deletionPolicy: Delete
     name: konflux-test-infra
-    template:
-      engineVersion: v2
-      type: kubernetes.io/dockerconfigjson
-      data:
-        oci-storage-dockerconfigjson: "{{ .config }}"
-        github-bot-commenter-token: "{{ .github_bot_commenter_token }}"


### PR DESCRIPTION
Still we are getting this error
```
could not apply template: could not execute template: could not execute template: unable to execute template at key github-bot-commenter-token: unable to parse template at key github-bot-commenter-token: template: github-bot-commenter-token:1: bad character U+002D '-'
```
Removing the template part and use the secret as it is.