### PR TITLE
Replace ec-release-policy tag with floating tag

### DIFF
--- a/components/enterprise-contract/ecp.yaml
+++ b/components/enterprise-contract/ecp.yaml
@@ -23,7 +23,7 @@ spec:
         - github.com/release-engineering/rhtap-ec-policy//data
       name: Default
       policy:
-        - oci::quay.io/enterprise-contract/ec-release-policy:git-ea77b8f@sha256:562c441a7555e635736157622c889b6e8590e9ba880ff9327b7fb2917be10fdd
+        - oci::quay.io/enterprise-contract/ec-release-policy:konflux
 ---
 apiVersion: appstudio.redhat.com/v1alpha1
 kind: EnterpriseContractPolicy
@@ -46,7 +46,7 @@ spec:
         - github.com/release-engineering/rhtap-ec-policy//data
       name: Default
       policy:
-        - oci::quay.io/enterprise-contract/ec-release-policy:git-ea77b8f@sha256:562c441a7555e635736157622c889b6e8590e9ba880ff9327b7fb2917be10fdd
+        - oci::quay.io/enterprise-contract/ec-release-policy:konflux
 ---
 apiVersion: appstudio.redhat.com/v1alpha1
 kind: EnterpriseContractPolicy
@@ -67,7 +67,7 @@ spec:
         - github.com/release-engineering/rhtap-ec-policy//data
       name: Default
       policy:
-        - oci::quay.io/enterprise-contract/ec-release-policy:git-ea77b8f@sha256:562c441a7555e635736157622c889b6e8590e9ba880ff9327b7fb2917be10fdd
+        - oci::quay.io/enterprise-contract/ec-release-policy:konflux
 ---
 apiVersion: appstudio.redhat.com/v1alpha1
 kind: EnterpriseContractPolicy
@@ -89,7 +89,7 @@ spec:
         - github.com/release-engineering/rhtap-ec-policy//data
       name: Default
       policy:
-        - oci::quay.io/enterprise-contract/ec-release-policy:git-ea77b8f@sha256:562c441a7555e635736157622c889b6e8590e9ba880ff9327b7fb2917be10fdd
+        - oci::quay.io/enterprise-contract/ec-release-policy:konflux
 ---
 apiVersion: appstudio.redhat.com/v1alpha1
 kind: EnterpriseContractPolicy


### PR DESCRIPTION
This removes the need to keep bumping the version
with automation. Instead the floating tag will
be updated after each update to ec-policies and
once that update has passed the EC CI in the
ec-policies repo.

For background:
https://issues.redhat.com/browse/EC-884
https://issues.redhat.com/browse/EC-952

Ref: [EC-951](https://issues.redhat.com//browse/EC-951)