### PR TITLE
PVO11Y-4624 Increase COO resource limits

### DIFF
--- a/components/monitoring/prometheus/base/observability-operator/observability-operator.yaml
+++ b/components/monitoring/prometheus/base/observability-operator/observability-operator.yaml
@@ -18,3 +18,7 @@ spec:
   name: cluster-observability-operator
   source: redhat-operators
   sourceNamespace: openshift-marketplace
+  config:
+    resources:
+      limits:
+        memory: "400Mi"


### PR DESCRIPTION
This should prevent out-of-memory Pod killing of the Obervability Operator deployed by the Cluster observability operator.

This has a side effect of increasing limits of all pods managed by this operator.