### PR TITLE
Add per-platform instance tags

### DIFF
--- a/components/multi-platform-controller/staging-downstream/host-config.yaml
+++ b/components/multi-platform-controller/staging-downstream/host-config.yaml
@@ -55,6 +55,7 @@ data:
   dynamic.linux-arm64.region: us-east-1
   dynamic.linux-arm64.ami: ami-03d6a5256a46c9feb
   dynamic.linux-arm64.instance-type: m6g.large
+  dynamic.linux-arm64.instance-tag: stage-arm64
   dynamic.linux-arm64.key-name: konflux-stage-int-mab01
   dynamic.linux-arm64.aws-secret: aws-account
   dynamic.linux-arm64.ssh-secret: aws-ssh-key
@@ -67,6 +68,7 @@ data:
   dynamic.linux-mlarge-arm64.region: us-east-1
   dynamic.linux-mlarge-arm64.ami: ami-03d6a5256a46c9feb
   dynamic.linux-mlarge-arm64.instance-type: m6g.large
+  dynamic.linux-mlarge-arm64.instance-tag: stage-arm64-mlarge
   dynamic.linux-mlarge-arm64.key-name: konflux-stage-int-mab01
   dynamic.linux-mlarge-arm64.aws-secret: aws-account
   dynamic.linux-mlarge-arm64.ssh-secret: aws-ssh-key
@@ -79,6 +81,7 @@ data:
   dynamic.linux-mlarge-amd64.region: us-east-1
   dynamic.linux-mlarge-amd64.ami: ami-026ebd4cfe2c043b2
   dynamic.linux-mlarge-amd64.instance-type: m6a.large
+  dynamic.linux-mlarge-amd64.instance-tag: stage-amd64-mlarge
   dynamic.linux-mlarge-amd64.key-name: konflux-stage-int-mab01
   dynamic.linux-mlarge-amd64.aws-secret: aws-account
   dynamic.linux-mlarge-amd64.ssh-secret: aws-ssh-key
@@ -91,6 +94,7 @@ data:
   dynamic.linux-mxlarge-arm64.region: us-east-1
   dynamic.linux-mxlarge-arm64.ami: ami-03d6a5256a46c9feb
   dynamic.linux-mxlarge-arm64.instance-type: m6g.xlarge
+  dynamic.linux-mxlarge-arm64.instance-tag: stage-arm64-mxlarge
   dynamic.linux-mxlarge-arm64.key-name: konflux-stage-int-mab01
   dynamic.linux-mxlarge-arm64.aws-secret: aws-account
   dynamic.linux-mxlarge-arm64.ssh-secret: aws-ssh-key
@@ -103,6 +107,7 @@ data:
   dynamic.linux-m2xlarge-arm64.region: us-east-1
   dynamic.linux-m2xlarge-arm64.ami: ami-03d6a5256a46c9feb
   dynamic.linux-m2xlarge-arm64.instance-type: m6g.2xlarge
+  dynamic.linux-m2xlarge-arm64.instance-tag: stage-arm64-m2xlarge
   dynamic.linux-m2xlarge-arm64.key-name: konflux-stage-int-mab01
   dynamic.linux-m2xlarge-arm64.aws-secret: aws-account
   dynamic.linux-m2xlarge-arm64.ssh-secret: aws-ssh-key
@@ -115,6 +120,7 @@ data:
   dynamic.linux-m4xlarge-arm64.region: us-east-1
   dynamic.linux-m4xlarge-arm64.ami: ami-03d6a5256a46c9feb
   dynamic.linux-m4xlarge-arm64.instance-type: m6g.4xlarge
+  dynamic.linux-m4xlarge-arm64.instance-tag: stage-arm64-m4xlarge
   dynamic.linux-m4xlarge-arm64.key-name: konflux-stage-int-mab01
   dynamic.linux-m4xlarge-arm64.aws-secret: aws-account
   dynamic.linux-m4xlarge-arm64.ssh-secret: aws-ssh-key
@@ -127,6 +133,7 @@ data:
   dynamic.linux-m8xlarge-arm64.region: us-east-1
   dynamic.linux-m8xlarge-arm64.ami: ami-03d6a5256a46c9feb
   dynamic.linux-m8xlarge-arm64.instance-type: m6g.8xlarge
+  dynamic.linux-m8xlarge-arm64.instance-tag: stage-arm64-m8xlarge
   dynamic.linux-m8xlarge-arm64.key-name: konflux-stage-int-mab01
   dynamic.linux-m8xlarge-arm64.aws-secret: aws-account
   dynamic.linux-m8xlarge-arm64.ssh-secret: aws-ssh-key
@@ -139,6 +146,7 @@ data:
   dynamic.linux-mxlarge-amd64.region: us-east-1
   dynamic.linux-mxlarge-amd64.ami: ami-026ebd4cfe2c043b2
   dynamic.linux-mxlarge-amd64.instance-type: m6a.xlarge
+  dynamic.linux-mxlarge-amd64.instance-tag: stage-amd64-mxlarge
   dynamic.linux-mxlarge-amd64.key-name: konflux-stage-int-mab01
   dynamic.linux-mxlarge-amd64.aws-secret: aws-account
   dynamic.linux-mxlarge-amd64.ssh-secret: aws-ssh-key
@@ -151,6 +159,7 @@ data:
   dynamic.linux-m2xlarge-amd64.region: us-east-1
   dynamic.linux-m2xlarge-amd64.ami: ami-026ebd4cfe2c043b2
   dynamic.linux-m2xlarge-amd64.instance-type: m6a.2xlarge
+  dynamic.linux-m2xlarge-amd64.instance-tag: stage-amd64-m2xlarge
   dynamic.linux-m2xlarge-amd64.key-name: konflux-stage-int-mab01
   dynamic.linux-m2xlarge-amd64.aws-secret: aws-account
   dynamic.linux-m2xlarge-amd64.ssh-secret: aws-ssh-key
@@ -163,6 +172,7 @@ data:
   dynamic.linux-m4xlarge-amd64.region: us-east-1
   dynamic.linux-m4xlarge-amd64.ami: ami-026ebd4cfe2c043b2
   dynamic.linux-m4xlarge-amd64.instance-type: m6a.4xlarge
+  dynamic.linux-m4xlarge-amd64.instance-tag: stage-amd64-m4xlarge-
   dynamic.linux-m4xlarge-amd64.key-name: konflux-stage-int-mab01
   dynamic.linux-m4xlarge-amd64.aws-secret: aws-account
   dynamic.linux-m4xlarge-amd64.ssh-secret: aws-ssh-key
@@ -175,6 +185,7 @@ data:
   dynamic.linux-m8xlarge-amd64.region: us-east-1
   dynamic.linux-m8xlarge-amd64.ami: ami-026ebd4cfe2c043b2
   dynamic.linux-m8xlarge-amd64.instance-type: m6a.8xlarge
+  dynamic.linux-m8xlarge-amd64.instance-tag: stage-amd64-m8xlarge
   dynamic.linux-m8xlarge-amd64.key-name: konflux-stage-int-mab01
   dynamic.linux-m8xlarge-amd64.aws-secret: aws-account
   dynamic.linux-m8xlarge-amd64.ssh-secret: aws-ssh-key
@@ -188,6 +199,7 @@ data:
   dynamic.linux-cxlarge-arm64.region: us-east-1
   dynamic.linux-cxlarge-arm64.ami: ami-03d6a5256a46c9feb
   dynamic.linux-cxlarge-arm64.instance-type: c6g.xlarge
+  dynamic.linux-cxlarge-arm64.instance-tag: stage-arm64-cxlarge
   dynamic.linux-cxlarge-arm64.key-name: konflux-stage-int-mab01
   dynamic.linux-cxlarge-arm64.aws-secret: aws-account
   dynamic.linux-cxlarge-arm64.ssh-secret: aws-ssh-key
@@ -200,6 +212,7 @@ data:
   dynamic.linux-c2xlarge-arm64.region: us-east-1
   dynamic.linux-c2xlarge-arm64.ami: ami-03d6a5256a46c9feb
   dynamic.linux-c2xlarge-arm64.instance-type: c6g.2xlarge
+  dynamic.linux-c2xlarge-arm64.instance-tag: stage-arm64-c2xlarge
   dynamic.linux-c2xlarge-arm64.key-name: konflux-stage-int-mab01
   dynamic.linux-c2xlarge-arm64.aws-secret: aws-account
   dynamic.linux-c2xlarge-arm64.ssh-secret: aws-ssh-key
@@ -212,6 +225,7 @@ data:
   dynamic.linux-c4xlarge-arm64.region: us-east-1
   dynamic.linux-c4xlarge-arm64.ami: ami-03d6a5256a46c9feb
   dynamic.linux-c4xlarge-arm64.instance-type: c6g.4xlarge
+  dynamic.linux-c4xlarge-arm64.instance-tag: stage-arm64-c4xlarge
   dynamic.linux-c4xlarge-arm64.key-name: konflux-stage-int-mab01
   dynamic.linux-c4xlarge-arm64.aws-secret: aws-account
   dynamic.linux-c4xlarge-arm64.ssh-secret: aws-ssh-key
@@ -224,6 +238,7 @@ data:
   dynamic.linux-c8xlarge-arm64.region: us-east-1
   dynamic.linux-c8xlarge-arm64.ami: ami-03d6a5256a46c9feb
   dynamic.linux-c8xlarge-arm64.instance-type: c6g.8xlarge
+  dynamic.linux-c8xlarge-arm64.instance-tag: stage-arm64-c8xlarge
   dynamic.linux-c8xlarge-arm64.key-name: konflux-stage-int-mab01
   dynamic.linux-c8xlarge-arm64.aws-secret: aws-account
   dynamic.linux-c8xlarge-arm64.ssh-secret: aws-ssh-key
@@ -236,6 +251,7 @@ data:
   dynamic.linux-cxlarge-amd64.region: us-east-1
   dynamic.linux-cxlarge-amd64.ami: ami-026ebd4cfe2c043b2
   dynamic.linux-cxlarge-amd64.instance-type: c6a.xlarge
+  dynamic.linux-cxlarge-amd64.instance-tag: stage-amd64-cxlarge
   dynamic.linux-cxlarge-amd64.key-name: konflux-stage-int-mab01
   dynamic.linux-cxlarge-amd64.aws-secret: aws-account
   dynamic.linux-cxlarge-amd64.ssh-secret: aws-ssh-key
@@ -248,6 +264,7 @@ data:
   dynamic.linux-c2xlarge-amd64.region: us-east-1
   dynamic.linux-c2xlarge-amd64.ami: ami-026ebd4cfe2c043b2
   dynamic.linux-c2xlarge-amd64.instance-type: c6a.2xlarge
+  dynamic.linux-c2xlarge-amd64.instance-tag: stage-amd64-c2xlarge
   dynamic.linux-c2xlarge-amd64.key-name: konflux-stage-int-mab01
   dynamic.linux-c2xlarge-amd64.aws-secret: aws-account
   dynamic.linux-c2xlarge-amd64.ssh-secret: aws-ssh-key
@@ -260,6 +277,7 @@ data:
   dynamic.linux-c4xlarge-amd64.region: us-east-1
   dynamic.linux-c4xlarge-amd64.ami: ami-026ebd4cfe2c043b2
   dynamic.linux-c4xlarge-amd64.instance-type: c6a.4xlarge
+  dynamic.linux-c4xlarge-amd64.instance-tag: stage-amd64-c4xlarge
   dynamic.linux-c4xlarge-amd64.key-name: konflux-stage-int-mab01
   dynamic.linux-c4xlarge-amd64.aws-secret: aws-account
   dynamic.linux-c4xlarge-amd64.ssh-secret: aws-ssh-key
@@ -271,6 +289,7 @@ data:
   dynamic.linux-c8xlarge-amd64.type: aws
   dynamic.linux-c8xlarge-amd64.region: us-east-1
   dynamic.linux-c8xlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-c8xlarge-amd64.instance-tag: stage-amd64-c8xlarge
   dynamic.linux-c8xlarge-amd64.instance-type: c6a.8xlarge
   dynamic.linux-c8xlarge-amd64.key-name: konflux-stage-int-mab01
   dynamic.linux-c8xlarge-amd64.aws-secret: aws-account
@@ -284,6 +303,7 @@ data:
   dynamic.linux-root-arm64.region: us-east-1
   dynamic.linux-root-arm64.ami: ami-03d6a5256a46c9feb
   dynamic.linux-root-arm64.instance-type: t4g.large
+  dynamic.linux-root-arm64.instance-tag: stage-arm64-root
   dynamic.linux-root-arm64.key-name: konflux-stage-int-mab01
   dynamic.linux-root-arm64.aws-secret: aws-account
   dynamic.linux-root-arm64.ssh-secret: aws-ssh-key
@@ -298,6 +318,7 @@ data:
   dynamic.linux-root-amd64.region: us-east-1
   dynamic.linux-root-amd64.ami: ami-026ebd4cfe2c043b2
   dynamic.linux-root-amd64.instance-type: m5.large
+  dynamic.linux-root-amd64.instance-tag: stage-amd64-root
   dynamic.linux-root-amd64.key-name: konflux-stage-int-mab01
   dynamic.linux-root-amd64.aws-secret: aws-account
   dynamic.linux-root-amd64.ssh-secret: aws-ssh-key
@@ -322,6 +343,7 @@ data:
   dynamic.linux-s390x.private-ip: "true"
   dynamic.linux-s390x.disk: "200"
   dynamic.linux-s390x.allocation-timeout: "1800"
+  dynamic.linux-s390x.instance-tag: stage-s390x
 
   dynamic.linux-ppc64le.type: ibmp
   dynamic.linux-ppc64le.ssh-secret: "internal-stage-ibm-ssh-key"
@@ -337,6 +359,7 @@ data:
   dynamic.linux-ppc64le.disk: "200"
   dynamic.linux-ppc64le.max-instances: "50"
   dynamic.linux-ppc64le.allocation-timeout: "1800"
+  dynamic.linux-ppc64le.instance-tag: stage-ppc64le
 
 # GPU Instances
   dynamic.linux-g6xlarge-amd64.type: aws
@@ -349,6 +372,7 @@ data:
   dynamic.linux-g6xlarge-amd64.security-group-id: sg-0482e8ccae008b240
   dynamic.linux-g6xlarge-amd64.max-instances: "10"
   dynamic.linux-g6xlarge-amd64.allocation-timeout: "1200"
+  dynamic.linux-g6xlarge-amd64.instance-tag: stage-amd64-g6xlarge
   dynamic.linux-g6xlarge-amd64.subnet-id: subnet-07597d1edafa2b9d3
   dynamic.linux-g6xlarge-amd64.user-data: |-
     Content-Type: multipart/mixed; boundary="//"

--- a/components/multi-platform-controller/staging/host-config.yaml
+++ b/components/multi-platform-controller/staging/host-config.yaml
@@ -54,6 +54,7 @@ data:
   dynamic.linux-arm64.region: us-east-1
   dynamic.linux-arm64.ami: ami-03d6a5256a46c9feb
   dynamic.linux-arm64.instance-type: m6g.large
+  dynamic.linux-arm64.instance-tag: stage-arm64
   dynamic.linux-arm64.key-name: konflux-stage-ext-mab01
   dynamic.linux-arm64.aws-secret: aws-account
   dynamic.linux-arm64.ssh-secret: aws-ssh-key
@@ -65,6 +66,7 @@ data:
   dynamic.linux-mlarge-arm64.region: us-east-1
   dynamic.linux-mlarge-arm64.ami: ami-03d6a5256a46c9feb
   dynamic.linux-mlarge-arm64.instance-type: m6g.large
+  dynamic.linux-mlarge-arm64.instance-tag: stage-arm64-mlarge
   dynamic.linux-mlarge-arm64.key-name: konflux-stage-ext-mab01
   dynamic.linux-mlarge-arm64.aws-secret: aws-account
   dynamic.linux-mlarge-arm64.ssh-secret: aws-ssh-key
@@ -76,6 +78,7 @@ data:
   dynamic.linux-mlarge-amd64.region: us-east-1
   dynamic.linux-mlarge-amd64.ami: ami-026ebd4cfe2c043b2
   dynamic.linux-mlarge-amd64.instance-type: m6a.large
+  dynamic.linux-mlarge-amd64.instance-tag: stage-amd64-mlarge
   dynamic.linux-mlarge-amd64.key-name: konflux-stage-ext-mab01
   dynamic.linux-mlarge-amd64.aws-secret: aws-account
   dynamic.linux-mlarge-amd64.ssh-secret: aws-ssh-key
@@ -87,6 +90,7 @@ data:
   dynamic.linux-mxlarge-arm64.region: us-east-1
   dynamic.linux-mxlarge-arm64.ami: ami-03d6a5256a46c9feb
   dynamic.linux-mxlarge-arm64.instance-type: m6g.xlarge
+  dynamic.linux-mxlarge-arm64.instance-tag: stage-arm64-mxlarge
   dynamic.linux-mxlarge-arm64.key-name: konflux-stage-ext-mab01
   dynamic.linux-mxlarge-arm64.aws-secret: aws-account
   dynamic.linux-mxlarge-arm64.ssh-secret: aws-ssh-key
@@ -98,6 +102,7 @@ data:
   dynamic.linux-m2xlarge-arm64.region: us-east-1
   dynamic.linux-m2xlarge-arm64.ami: ami-03d6a5256a46c9feb
   dynamic.linux-m2xlarge-arm64.instance-type: m6g.2xlarge
+  dynamic.linux-m2xlarge-arm64.instance-tag: stage-arm64-m2xlarge
   dynamic.linux-m2xlarge-arm64.key-name: konflux-stage-ext-mab01
   dynamic.linux-m2xlarge-arm64.aws-secret: aws-account
   dynamic.linux-m2xlarge-arm64.ssh-secret: aws-ssh-key
@@ -109,6 +114,7 @@ data:
   dynamic.linux-m4xlarge-arm64.region: us-east-1
   dynamic.linux-m4xlarge-arm64.ami: ami-03d6a5256a46c9feb
   dynamic.linux-m4xlarge-arm64.instance-type: m6g.4xlarge
+  dynamic.linux-m4xlarge-arm64.instance-tag: stage-arm64-m4xlarge
   dynamic.linux-m4xlarge-arm64.key-name: konflux-stage-ext-mab01
   dynamic.linux-m4xlarge-arm64.aws-secret: aws-account
   dynamic.linux-m4xlarge-arm64.ssh-secret: aws-ssh-key
@@ -120,6 +126,7 @@ data:
   dynamic.linux-m8xlarge-arm64.region: us-east-1
   dynamic.linux-m8xlarge-arm64.ami: ami-03d6a5256a46c9feb
   dynamic.linux-m8xlarge-arm64.instance-type: m6g.8xlarge
+  dynamic.linux-m8xlarge-arm64.instance-tag: stage-arm64-m8xlarge
   dynamic.linux-m8xlarge-arm64.key-name: konflux-stage-ext-mab01
   dynamic.linux-m8xlarge-arm64.aws-secret: aws-account
   dynamic.linux-m8xlarge-arm64.ssh-secret: aws-ssh-key
@@ -131,6 +138,7 @@ data:
   dynamic.linux-mxlarge-amd64.region: us-east-1
   dynamic.linux-mxlarge-amd64.ami: ami-026ebd4cfe2c043b2
   dynamic.linux-mxlarge-amd64.instance-type: m6a.xlarge
+  dynamic.linux-mxlarge-amd64.instance-tag: stage-amd64-mxlarge
   dynamic.linux-mxlarge-amd64.key-name: konflux-stage-ext-mab01
   dynamic.linux-mxlarge-amd64.aws-secret: aws-account
   dynamic.linux-mxlarge-amd64.ssh-secret: aws-ssh-key
@@ -142,6 +150,7 @@ data:
   dynamic.linux-m2xlarge-amd64.region: us-east-1
   dynamic.linux-m2xlarge-amd64.ami: ami-026ebd4cfe2c043b2
   dynamic.linux-m2xlarge-amd64.instance-type: m6a.2xlarge
+  dynamic.linux-m2xlarge-amd64.instance-tag: stage-amd64-m2xlarge
   dynamic.linux-m2xlarge-amd64.key-name: konflux-stage-ext-mab01
   dynamic.linux-m2xlarge-amd64.aws-secret: aws-account
   dynamic.linux-m2xlarge-amd64.ssh-secret: aws-ssh-key
@@ -153,6 +162,7 @@ data:
   dynamic.linux-m4xlarge-amd64.region: us-east-1
   dynamic.linux-m4xlarge-amd64.ami: ami-026ebd4cfe2c043b2
   dynamic.linux-m4xlarge-amd64.instance-type: m6a.4xlarge
+  dynamic.linux-m4xlarge-amd64.instance-tag: stage-amd64-m4xlarge
   dynamic.linux-m4xlarge-amd64.key-name: konflux-stage-ext-mab01
   dynamic.linux-m4xlarge-amd64.aws-secret: aws-account
   dynamic.linux-m4xlarge-amd64.ssh-secret: aws-ssh-key
@@ -164,6 +174,7 @@ data:
   dynamic.linux-m8xlarge-amd64.region: us-east-1
   dynamic.linux-m8xlarge-amd64.ami: ami-026ebd4cfe2c043b2
   dynamic.linux-m8xlarge-amd64.instance-type: m6a.8xlarge
+  dynamic.linux-m8xlarge-amd64.instance-tag: stage-amd64-m8xlarge
   dynamic.linux-m8xlarge-amd64.key-name: konflux-stage-ext-mab01
   dynamic.linux-m8xlarge-amd64.aws-secret: aws-account
   dynamic.linux-m8xlarge-amd64.ssh-secret: aws-ssh-key
@@ -176,6 +187,7 @@ data:
   dynamic.linux-cxlarge-arm64.region: us-east-1
   dynamic.linux-cxlarge-arm64.ami: ami-03d6a5256a46c9feb
   dynamic.linux-cxlarge-arm64.instance-type: c6g.xlarge
+  dynamic.linux-cxlarge-arm64.instance-tag: stage-arm64-cxlarge
   dynamic.linux-cxlarge-arm64.key-name: konflux-stage-ext-mab01
   dynamic.linux-cxlarge-arm64.aws-secret: aws-account
   dynamic.linux-cxlarge-arm64.ssh-secret: aws-ssh-key
@@ -187,6 +199,7 @@ data:
   dynamic.linux-c2xlarge-arm64.region: us-east-1
   dynamic.linux-c2xlarge-arm64.ami: ami-03d6a5256a46c9feb
   dynamic.linux-c2xlarge-arm64.instance-type: c6g.2xlarge
+  dynamic.linux-c2xlarge-arm64.instance-tag: stage-arm64-c2xlarge
   dynamic.linux-c2xlarge-arm64.key-name: konflux-stage-ext-mab01
   dynamic.linux-c2xlarge-arm64.aws-secret: aws-account
   dynamic.linux-c2xlarge-arm64.ssh-secret: aws-ssh-key
@@ -198,6 +211,7 @@ data:
   dynamic.linux-c4xlarge-arm64.region: us-east-1
   dynamic.linux-c4xlarge-arm64.ami: ami-03d6a5256a46c9feb
   dynamic.linux-c4xlarge-arm64.instance-type: c6g.4xlarge
+  dynamic.linux-c4xlarge-arm64.instance-tag: stage-arm64-c4xlarge
   dynamic.linux-c4xlarge-arm64.key-name: konflux-stage-ext-mab01
   dynamic.linux-c4xlarge-arm64.aws-secret: aws-account
   dynamic.linux-c4xlarge-arm64.ssh-secret: aws-ssh-key
@@ -209,6 +223,7 @@ data:
   dynamic.linux-c8xlarge-arm64.region: us-east-1
   dynamic.linux-c8xlarge-arm64.ami: ami-03d6a5256a46c9feb
   dynamic.linux-c8xlarge-arm64.instance-type: c6g.8xlarge
+  dynamic.linux-c8xlarge-arm64.instance-tag: stage-arm64-c8xlarge
   dynamic.linux-c8xlarge-arm64.key-name: konflux-stage-ext-mab01
   dynamic.linux-c8xlarge-arm64.aws-secret: aws-account
   dynamic.linux-c8xlarge-arm64.ssh-secret: aws-ssh-key
@@ -220,6 +235,7 @@ data:
   dynamic.linux-cxlarge-amd64.region: us-east-1
   dynamic.linux-cxlarge-amd64.ami: ami-026ebd4cfe2c043b2
   dynamic.linux-cxlarge-amd64.instance-type: c6a.xlarge
+  dynamic.linux-cxlarge-amd64.instance-tag: stage-amd64-cxlarge
   dynamic.linux-cxlarge-amd64.key-name: konflux-stage-ext-mab01
   dynamic.linux-cxlarge-amd64.aws-secret: aws-account
   dynamic.linux-cxlarge-amd64.ssh-secret: aws-ssh-key
@@ -231,6 +247,7 @@ data:
   dynamic.linux-c2xlarge-amd64.region: us-east-1
   dynamic.linux-c2xlarge-amd64.ami: ami-026ebd4cfe2c043b2
   dynamic.linux-c2xlarge-amd64.instance-type: c6a.2xlarge
+  dynamic.linux-c2xlarge-amd64.instance-tag: stage-amd64-c2xlarge
   dynamic.linux-c2xlarge-amd64.key-name: konflux-stage-ext-mab01
   dynamic.linux-c2xlarge-amd64.aws-secret: aws-account
   dynamic.linux-c2xlarge-amd64.ssh-secret: aws-ssh-key
@@ -242,6 +259,7 @@ data:
   dynamic.linux-c4xlarge-amd64.region: us-east-1
   dynamic.linux-c4xlarge-amd64.ami: ami-026ebd4cfe2c043b2
   dynamic.linux-c4xlarge-amd64.instance-type: c6a.4xlarge
+  dynamic.linux-c4xlarge-amd64.instance-tag: stage-amd64-c4xlarge
   dynamic.linux-c4xlarge-amd64.key-name: konflux-stage-ext-mab01
   dynamic.linux-c4xlarge-amd64.aws-secret: aws-account
   dynamic.linux-c4xlarge-amd64.ssh-secret: aws-ssh-key
@@ -253,6 +271,7 @@ data:
   dynamic.linux-c8xlarge-amd64.region: us-east-1
   dynamic.linux-c8xlarge-amd64.ami: ami-026ebd4cfe2c043b2
   dynamic.linux-c8xlarge-amd64.instance-type: c6a.8xlarge
+  dynamic.linux-c8xlarge-amd64.instance-tag: stage-amd64-c8xlarge
   dynamic.linux-c8xlarge-amd64.key-name: konflux-stage-ext-mab01
   dynamic.linux-c8xlarge-amd64.aws-secret: aws-account
   dynamic.linux-c8xlarge-amd64.ssh-secret: aws-ssh-key
@@ -264,6 +283,7 @@ data:
   dynamic.linux-g4xlarge-amd64.region: us-east-1
   dynamic.linux-g4xlarge-amd64.ami: ami-026ebd4cfe2c043b2
   dynamic.linux-g4xlarge-amd64.instance-type: g6.4xlarge
+  dynamic.linux-g4xlarge-amd64.instance-tag: stage-amd64-g4xlarge
   dynamic.linux-g4xlarge-amd64.key-name: konflux-stage-ext-mab01
   dynamic.linux-g4xlarge-amd64.aws-secret: aws-account
   dynamic.linux-g4xlarge-amd64.ssh-secret: aws-ssh-key
@@ -276,6 +296,7 @@ data:
   dynamic.linux-root-arm64.region: us-east-1
   dynamic.linux-root-arm64.ami: ami-03d6a5256a46c9feb
   dynamic.linux-root-arm64.instance-type: t4g.large
+  dynamic.linux-root-arm64.instance-tag: stage-arm64-root
   dynamic.linux-root-arm64.key-name: konflux-stage-ext-mab01
   dynamic.linux-root-arm64.aws-secret: aws-account
   dynamic.linux-root-arm64.ssh-secret: aws-ssh-key
@@ -289,6 +310,7 @@ data:
   dynamic.linux-root-amd64.region: us-east-1
   dynamic.linux-root-amd64.ami: ami-026ebd4cfe2c043b2
   dynamic.linux-root-amd64.instance-type: m5.2xlarge
+  dynamic.linux-root-amd64.instance-tag: stage-amd64-root
   dynamic.linux-root-amd64.key-name: konflux-stage-ext-mab01
   dynamic.linux-root-amd64.aws-secret: aws-account
   dynamic.linux-root-amd64.ssh-secret: aws-ssh-key
@@ -322,6 +344,7 @@ data:
   dynamic.linux-s390x.profile: "bz2-2x8"
   dynamic.linux-s390x.max-instances: "4"
   dynamic.linux-s390x.private-ip: "true"
+  dynamic.linux-s390x.instance-tag: stage-s390x
 
 # GPU Instances
   dynamic.linux-g6xlarge-amd64.type: aws
@@ -334,6 +357,7 @@ data:
   dynamic.linux-g6xlarge-amd64.security-group-id: sg-05bc8dd0b52158567
   dynamic.linux-g6xlarge-amd64.max-instances: "10"
   dynamic.linux-g6xlarge-amd64.subnet-id: subnet-030738beb81d3863a
+  dynamic.linux-g6xlarge-amd64.instance-tag: stage-amd64-g6xlarge
   dynamic.linux-g6xlarge-amd64.user-data: |-
     Content-Type: multipart/mixed; boundary="//"
     MIME-Version: 1.0


### PR DESCRIPTION
When determining if a particular VM instance can be created, the VM flavor's maximum number of instances is compared to the current number of instances with the same `instance-tag` to ensure no more than the maximum number of VMs are created. Since the current configurations have all flavors using the same instance tag, the count of unique instances (flavors, in this case) is wrong. Adding per-platform/flavor instance tags should fix this.