### PR TITLE
Add read perms of kac resources

### DIFF
--- a/components/kubearchive/base/kubearchive-maintainer.yaml
+++ b/components/kubearchive/base/kubearchive-maintainer.yaml
@@ -1,0 +1,13 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: kubearchive-maintainer
+rules:
+  - apiGroups:
+      - kubearchive.kubearchive.org
+    resources:
+      - kubearchiveconfig
+    verbs:
+      - get
+      - list
+      - watch

--- a/components/kubearchive/base/rbac.yaml
+++ b/components/kubearchive/base/rbac.yaml
@@ -2,7 +2,7 @@
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: kubearchive-maintainers
+  name: kubearchive-component-maintainers
   namespace: kubearchive
 subjects:
   - kind: Group
@@ -12,3 +12,16 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: component-maintainer
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: kubearchive-maintainers
+subjects:
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: konflux-kubearchive  # rover group
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kubearchive-maintainer


### PR DESCRIPTION
KubeArchive maintainers need permissions to
read the kubearchive resources clusterwide.