### PR TITLE
fix(RELEASE-1441): allow rsc in development

### DIFF
--- a/components/monitoring/grafana/base/dashboards/release/kustomization.yaml
+++ b/components/monitoring/grafana/base/dashboards/release/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- https://github.com/konflux-ci/release-service/config/grafana/?ref=a590eb4249adfb592f7c68525bd1462f1064709d
+- https://github.com/konflux-ci/release-service/config/grafana/?ref=c3989c7a79c4d0b2a76930526cab370daef43aee

--- a/components/release/development/kustomization.yaml
+++ b/components/release/development/kustomization.yaml
@@ -3,12 +3,12 @@ kind: Kustomization
 resources:
   - ../base
   - ../base/monitor/development
-  - https://github.com/konflux-ci/release-service/config/default?ref=a590eb4249adfb592f7c68525bd1462f1064709d
+  - https://github.com/konflux-ci/release-service/config/default?ref=c3989c7a79c4d0b2a76930526cab370daef43aee
 
 images:
   - name: quay.io/konflux-ci/release-service
     newName: quay.io/konflux-ci/release-service
-    newTag: a590eb4249adfb592f7c68525bd1462f1064709d
+    newTag: c3989c7a79c4d0b2a76930526cab370daef43aee
 
 namespace: release-service
 

--- a/components/release/development/kustomization.yaml
+++ b/components/release/development/kustomization.yaml
@@ -4,6 +4,7 @@ resources:
   - ../base
   - ../base/monitor/development
   - https://github.com/konflux-ci/release-service/config/default?ref=c3989c7a79c4d0b2a76930526cab370daef43aee
+  - release_service_config.yaml
 
 images:
   - name: quay.io/konflux-ci/release-service

--- a/components/release/development/release_service_config.yaml
+++ b/components/release/development/release_service_config.yaml
@@ -1,0 +1,6 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: ReleaseServiceConfig
+metadata:
+  name: release-service-config
+spec:
+  debug: true

--- a/components/release/production/release_service_config.yaml
+++ b/components/release/production/release_service_config.yaml
@@ -1,0 +1,6 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: ReleaseServiceConfig
+metadata:
+  name: release-service-config
+spec:
+  debug: false

--- a/components/release/staging/kustomization.yaml
+++ b/components/release/staging/kustomization.yaml
@@ -23,4 +23,3 @@ images:
     newTag: 5954f10a8c86134fca5f70fc1d9898254ee1f082
 
 namespace: release-service
-

--- a/components/release/staging/release_service_config.yaml
+++ b/components/release/staging/release_service_config.yaml
@@ -1,0 +1,10 @@
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: ReleaseServiceConfig
+metadata:
+  name: release-service-config
+spec:
+  debug: false
+  EmptyDirOverrides:
+    - url: ".*"
+      revision: ".*"
+      pathInRepo: "pipelines/managed/rh-advisories/rh-advisories-oci-ta.yaml"


### PR DESCRIPTION
- the rsc needs to managed outside of the release
      service so that clusters can have a specific version
      for testing.
- A version can be deployed and managed by ArgoCD
      via infra-deployments for a specific environment
- This PR only affects the development overlay
- includes contents of PR https://github.com/redhat-appstudio/infra-deployments/pull/5541