### PR TITLE
Fix add kubearchive-maintainer role

### DIFF
--- a/components/kubearchive/base/kustomization.yaml
+++ b/components/kubearchive/base/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
 - https://github.com/kubearchive/kubearchive/releases/download/v0.9.0/kubearchive.yaml?timeout=90
 - rbac.yaml
 - kubearchive-config.yaml
+- kubearchive-maintainer.yaml
 
 # ROSA does not support namespaces starting with `kube`
 namespace: product-kubearchive


### PR DESCRIPTION
KubeArchive maintainers need permissions to
read the kubearchive resources clusterwide.

Fix for https://github.com/redhat-appstudio/infra-deployments/pull/5500
