### PR TITLE
KubeArchive: increase operator memory limit

### DIFF
--- a/components/kubearchive/base/kustomization.yaml
+++ b/components/kubearchive/base/kustomization.yaml
@@ -132,6 +132,12 @@ patches:
                 runAsNonRoot: true
               ports:
                 - containerPort: 8081
+              resources:
+                requests:
+                  memory: 256Mi
+                limits:
+                  memory: 256Mi
+                
 - patch: |-
     apiVersion: apps/v1
     kind: Deployment


### PR DESCRIPTION
KubeArchive's operator is being OOMKilled, it needs more memory. We don't know why this is the case, in theory nothing points to increased memory usage with increased cluster size, but looks like that is the problem.