### PR TITLE
KONFLUX-5876 Fix incorrect apiVersion

### DIFF
--- a/components/monitoring/logging/staging/base/configure-clusterlogging.yaml
+++ b/components/monitoring/logging/staging/base/configure-clusterlogging.yaml
@@ -1,4 +1,4 @@
-apiVersion: observability.openshift.io/v1
+apiVersion: logging.openshift.io/v1
 kind: ClusterLogging
 metadata:
   name:  cluster-logging


### PR DESCRIPTION
ArgoCD deployment fails with: Resource not found in cluster: observability.openshift.io/v1/ClusterLogging:cluster-logging

This fixes the incorrect apiVersion.