### PR TITLE
KONFLUX-5876 Correct the name of ClusterLogging

### DIFF
--- a/components/monitoring/logging/staging/base/configure-clusterlogging.yaml
+++ b/components/monitoring/logging/staging/base/configure-clusterlogging.yaml
@@ -1,7 +1,7 @@
 apiVersion: logging.openshift.io/v1
 kind: ClusterLogging
 metadata:
-  name:  cluster-logging
+  name: instance
 spec:
   managementState: "Managed"
   collection:


### PR DESCRIPTION
Changes do not seem to take effect on Pods. [Review of installation documentation](https://docs.redhat.com/en/documentation/openshift_container_platform/4.15/html/logging/cluster-logging-deploying#logging-es-deploy-cli_cluster-logging-deploying) shows that the name of the resource must be set to "instance".