### PR TITLE
chore: konflux-admin can patch release status

### DIFF
--- a/components/authentication/base/konflux-admins.yaml
+++ b/components/authentication/base/konflux-admins.yaml
@@ -19,6 +19,7 @@ rules:
       - releaseplanadmissions
       - releaseplans
       - releases
+      - releases/status
       - releaseserviceconfigs
       - releasestrategies
       - snapshots


### PR DESCRIPTION
- the konflux-admin group should be able to patch releases.status