### PR TITLE
Allow namespace admins to list and watch pods

### DIFF
--- a/components/konflux-rbac/production/base/konflux-admin-user-actions.yaml
+++ b/components/konflux-rbac/production/base/konflux-admin-user-actions.yaml
@@ -110,6 +110,8 @@ rules:
       - configmaps
   - verbs:
       - get
+      - list
+      - watch
     apiGroups:
       - ''
     resources:

--- a/components/konflux-rbac/staging/base/konflux-admin-user-actions.yaml
+++ b/components/konflux-rbac/staging/base/konflux-admin-user-actions.yaml
@@ -110,6 +110,8 @@ rules:
       - configmaps
   - verbs:
       - get
+      - list
+      - watch
     apiGroups:
       - ''
     resources:


### PR DESCRIPTION
This permissions is required in order tail logs
using opc.