### PR TITLE
[OCP] New c4xlarge VM flavor with higher disk space

### DIFF
--- a/components/multi-platform-controller/production-downstream/kflux-ocp-p01/host-config.yaml
+++ b/components/multi-platform-controller/production-downstream/kflux-ocp-p01/host-config.yaml
@@ -48,7 +48,7 @@ data:
     linux-largecpu/ppc64le,\
     linux-d200/ppc64le,\
     linux-large/ppc64le,\
-    linux-d400-large/ppc64le\
+    linux-d200-large/ppc64le\
     "
   instance-tag: rhtap-prod
 
@@ -585,20 +585,20 @@ data:
   dynamic.linux-largecpu-ppc64le.allocation-timeout: "1800"
 
   # Same as linux-large-ppc64le but with 200GB disk instead of default 100GB
-  dynamic.linux-d400-large-ppc64le.type: ibmp
-  dynamic.linux-d400-large-ppc64le.ssh-secret: "internal-prod-ibm-ssh-key"
-  dynamic.linux-d400-large-ppc64le.secret: "internal-prod-ibm-api-key"
-  dynamic.linux-d400-large-ppc64le.key: "prod-konflux-infra"
-  dynamic.linux-d400-large-ppc64le.image: "ppc64le-rhel-94-base-27nov2024"
-  dynamic.linux-d400-large-ppc64le.crn: "crn:v1:bluemix:public:power-iaas:dal12:a/eebc7153d0c844f9915fb6f3b9850a3b:d6faf373-c0b6-4ba9-b0bc-4f7e0a74f9d5::"
-  dynamic.linux-d400-large-ppc64le.url: "https://us-south.power-iaas.cloud.ibm.com"
-  dynamic.linux-d400-large-ppc64le.network: "4d164943-b043-4c6e-bba5-d233abf66c6a"
-  dynamic.linux-d400-large-ppc64le.system: "e980"
-  dynamic.linux-d400-large-ppc64le.cores: "4"
-  dynamic.linux-d400-large-ppc64le.memory: "16"
-  dynamic.linux-d400-large-ppc64le.max-instances: "30"
-  dynamic.linux-d400-large-ppc64le.allocation-timeout: "1800"
-  dynamic.linux-d400-large-ppc64le.disk: "200"
+  dynamic.linux-d200-large-ppc64le.type: ibmp
+  dynamic.linux-d200-large-ppc64le.ssh-secret: "internal-prod-ibm-ssh-key"
+  dynamic.linux-d200-large-ppc64le.secret: "internal-prod-ibm-api-key"
+  dynamic.linux-d200-large-ppc64le.key: "prod-konflux-infra"
+  dynamic.linux-d200-large-ppc64le.image: "ppc64le-rhel-94-base-27nov2024"
+  dynamic.linux-d200-large-ppc64le.crn: "crn:v1:bluemix:public:power-iaas:dal12:a/eebc7153d0c844f9915fb6f3b9850a3b:d6faf373-c0b6-4ba9-b0bc-4f7e0a74f9d5::"
+  dynamic.linux-d200-large-ppc64le.url: "https://us-south.power-iaas.cloud.ibm.com"
+  dynamic.linux-d200-large-ppc64le.network: "4d164943-b043-4c6e-bba5-d233abf66c6a"
+  dynamic.linux-d200-large-ppc64le.system: "e980"
+  dynamic.linux-d200-large-ppc64le.cores: "4"
+  dynamic.linux-d200-large-ppc64le.memory: "16"
+  dynamic.linux-d200-large-ppc64le.max-instances: "30"
+  dynamic.linux-d200-large-ppc64le.allocation-timeout: "1800"
+  dynamic.linux-d200-large-ppc64le.disk: "200"
 
   # AWS GPU Nodes
   dynamic.linux-g6xlarge-amd64.type: aws

--- a/components/multi-platform-controller/production-downstream/kflux-ocp-p01/host-config.yaml
+++ b/components/multi-platform-controller/production-downstream/kflux-ocp-p01/host-config.yaml
@@ -33,7 +33,9 @@ data:
     linux-c2xlarge/amd64,\
     linux-c2xlarge/arm64,\
     linux-c4xlarge/amd64,\
+    linux-d160-c4xlarge/amd64,\
     linux-c4xlarge/arm64,\
+    linux-d160-c4xlarge/arm64,\
     linux-c8xlarge/amd64,\
     linux-c8xlarge/arm64,\
     linux-g6xlarge/amd64,\
@@ -297,6 +299,20 @@ data:
   dynamic.linux-c4xlarge-arm64.subnet-id: subnet-0864e71d16676bf7f
   dynamic.linux-c4xlarge-arm64.allocation-timeout: "1200"
 
+  # Same as linux-c4xlarge-arm64, but with 160GB disk space
+  dynamic.linux-d160-c4xlarge-arm64.type: aws
+  dynamic.linux-d160-c4xlarge-arm64.region: us-east-1
+  dynamic.linux-d160-c4xlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-d160-c4xlarge-arm64.instance-type: c6g.4xlarge
+  dynamic.linux-d160-c4xlarge-arm64.key-name: kflux-ocp-p01-key-pair
+  dynamic.linux-d160-c4xlarge-arm64.aws-secret: aws-account
+  dynamic.linux-d160-c4xlarge-arm64.ssh-secret: aws-ssh-key
+  dynamic.linux-d160-c4xlarge-arm64.security-group-id: sg-0a1f3fdbbf7198922
+  dynamic.linux-d160-c4xlarge-arm64.max-instances: "100"
+  dynamic.linux-d160-c4xlarge-arm64.subnet-id: subnet-0864e71d16676bf7f
+  dynamic.linux-d160-c4xlarge-arm64.allocation-timeout: "1200"
+  dynamic.linux-d160-c4xlarge-arm64.disk: "160"
+
   dynamic.linux-c8xlarge-arm64.type: aws
   dynamic.linux-c8xlarge-arm64.region: us-east-1
   dynamic.linux-c8xlarge-arm64.ami: ami-03d6a5256a46c9feb
@@ -344,6 +360,20 @@ data:
   dynamic.linux-c4xlarge-amd64.max-instances: "100"
   dynamic.linux-c4xlarge-amd64.subnet-id: subnet-0864e71d16676bf7f
   dynamic.linux-c4xlarge-amd64.allocation-timeout: "1200"
+
+  # Same as linux-c4xlarge-amd64, but with 160 GB storage
+  dynamic.linux-d160-c4xlarge-amd64.type: aws
+  dynamic.linux-d160-c4xlarge-amd64.region: us-east-1
+  dynamic.linux-d160-c4xlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-d160-c4xlarge-amd64.instance-type: c6a.4xlarge
+  dynamic.linux-d160-c4xlarge-amd64.key-name: kflux-ocp-p01-key-pair
+  dynamic.linux-d160-c4xlarge-amd64.aws-secret: aws-account
+  dynamic.linux-d160-c4xlarge-amd64.ssh-secret: aws-ssh-key
+  dynamic.linux-d160-c4xlarge-amd64.security-group-id: sg-0a1f3fdbbf7198922
+  dynamic.linux-d160-c4xlarge-amd64.max-instances: "100"
+  dynamic.linux-d160-c4xlarge-amd64.subnet-id: subnet-0864e71d16676bf7f
+  dynamic.linux-d160-c4xlarge-amd64.allocation-timeout: "1200"
+  dynamic.linux-d160-c4xlarge-amd64-arm64.disk: "160"
 
   dynamic.linux-c8xlarge-amd64.type: aws
   dynamic.linux-c8xlarge-amd64.region: us-east-1


### PR DESCRIPTION
For https://github.com/openshift-eng/ocp-build-data/pull/6096

Also includes a naming fix, where a PPC VM was named as `d400` when it configured for `d200`