### PR TITLE
Fix typo on kubearchive-maintainer cr

### DIFF
--- a/components/kubearchive/base/kubearchive-maintainer.yaml
+++ b/components/kubearchive/base/kubearchive-maintainer.yaml
@@ -6,7 +6,7 @@ rules:
   - apiGroups:
       - kubearchive.kubearchive.org
     resources:
-      - kubearchiveconfig
+      - kubearchiveconfigs
     verbs:
       - get
       - list


### PR DESCRIPTION
The resource name needs to be in plural, the same way it appears in `kubectl api-resources`.

This should fix the current issue of not being able to see this resources.