### PR TITLE
Allow contributors and maintainers to list and watch pods

### DIFF
--- a/components/konflux-rbac/production/base/konflux-contributor-user-actions.yaml
+++ b/components/konflux-rbac/production/base/konflux-contributor-user-actions.yaml
@@ -91,6 +91,8 @@ rules:
       - ''
     resources:
       - configmaps
+      - pods
+      - pods/log
   - verbs:
       - get
       - list

--- a/components/konflux-rbac/production/base/konflux-maintainer-user-actions.yaml
+++ b/components/konflux-rbac/production/base/konflux-maintainer-user-actions.yaml
@@ -102,6 +102,8 @@ rules:
       - ''
     resources:
       - configmaps
+      - pods
+      - pods/log
   - verbs:
       - get
       - list

--- a/components/konflux-rbac/staging/base/konflux-contributor-user-actions.yaml
+++ b/components/konflux-rbac/staging/base/konflux-contributor-user-actions.yaml
@@ -91,6 +91,8 @@ rules:
       - ''
     resources:
       - configmaps
+      - pods
+      - pods/log
   - verbs:
       - get
       - list

--- a/components/konflux-rbac/staging/base/konflux-maintainer-user-actions.yaml
+++ b/components/konflux-rbac/staging/base/konflux-maintainer-user-actions.yaml
@@ -102,6 +102,8 @@ rules:
       - ''
     resources:
       - configmaps
+      - pods
+      - pods/log
   - verbs:
       - get
       - list


### PR DESCRIPTION
Similar as #5525 but giving maintainers and contributors these permissions to to tail logs (e.g. via `opc`).
As discussed in https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1739344743638089?thread_ts=1739289575.061129&cid=C04PZ7H0VA8

/assign @gbenhaim @ralphbean @scoheb 