### PR TITLE
Use secrets from appsre[s/p]11ue1 cluster

### DIFF
--- a/components/pipeline-service/production/stone-prd-m01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prd-m01/deploy.yaml
@@ -1843,7 +1843,7 @@ metadata:
 spec:
   dataFrom:
   - extract:
-      key: integrations-output/terraform-resources/appsrep07ue1/stonesoup-infra-production/multi-tenant-prod-plnsvc-s3
+      key: integrations-output/terraform-resources/appsrep11ue1/stonesoup-infra-production/multi-tenant-prod-plnsvc-s3
   refreshInterval: 1h
   secretStoreRef:
     kind: ClusterSecretStore
@@ -1872,7 +1872,7 @@ metadata:
 spec:
   dataFrom:
   - extract:
-      key: integrations-output/terraform-resources/appsrep07ue1/stonesoup-infra-production/multi-tenant-prod-plnsvc-rds
+      key: integrations-output/terraform-resources/appsrep11ue1/stonesoup-infra-production/multi-tenant-prod-plnsvc-rds
   refreshInterval: 1h
   secretStoreRef:
     kind: ClusterSecretStore
@@ -1893,7 +1893,7 @@ metadata:
 spec:
   dataFrom:
   - extract:
-      key: integrations-output/terraform-resources/appsrep07ue1/stonesoup-infra-production/multi-tenant-prod-plnsvc-s3
+      key: integrations-output/terraform-resources/appsrep11ue1/stonesoup-infra-production/multi-tenant-prod-plnsvc-s3
   refreshInterval: 1h
   secretStoreRef:
     kind: ClusterSecretStore

--- a/components/pipeline-service/production/stone-prd-m01/resources/tekton-results-database-secret-path.yaml
+++ b/components/pipeline-service/production/stone-prd-m01/resources/tekton-results-database-secret-path.yaml
@@ -1,4 +1,4 @@
 ---
 - op: add
   path: /spec/dataFrom/0/extract/key
-  value: integrations-output/terraform-resources/appsrep07ue1/stonesoup-infra-production/multi-tenant-prod-plnsvc-rds
+  value: integrations-output/terraform-resources/appsrep11ue1/stonesoup-infra-production/multi-tenant-prod-plnsvc-rds

--- a/components/pipeline-service/production/stone-prd-m01/resources/tekton-results-s3-secret-path.yaml
+++ b/components/pipeline-service/production/stone-prd-m01/resources/tekton-results-s3-secret-path.yaml
@@ -1,4 +1,4 @@
 ---
 - op: add
   path: /spec/dataFrom/0/extract/key
-  value: integrations-output/terraform-resources/appsrep07ue1/stonesoup-infra-production/multi-tenant-prod-plnsvc-s3
+  value: integrations-output/terraform-resources/appsrep11ue1/stonesoup-infra-production/multi-tenant-prod-plnsvc-s3

--- a/components/pipeline-service/production/stone-prd-rh01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prd-rh01/deploy.yaml
@@ -1843,7 +1843,7 @@ metadata:
 spec:
   dataFrom:
   - extract:
-      key: integrations-output/terraform-resources/appsrep07ue1/stonesoup-infra-production/redhat-prod-plnsvc-s3
+      key: integrations-output/terraform-resources/appsrep11ue1/stonesoup-infra-production/redhat-prod-plnsvc-s3
   refreshInterval: 1h
   secretStoreRef:
     kind: ClusterSecretStore
@@ -1872,7 +1872,7 @@ metadata:
 spec:
   dataFrom:
   - extract:
-      key: integrations-output/terraform-resources/appsrep07ue1/stonesoup-infra-production/redhat-prod-plnsvc-rds
+      key: integrations-output/terraform-resources/appsrep11ue1/stonesoup-infra-production/redhat-prod-plnsvc-rds
   refreshInterval: 1h
   secretStoreRef:
     kind: ClusterSecretStore
@@ -1893,7 +1893,7 @@ metadata:
 spec:
   dataFrom:
   - extract:
-      key: integrations-output/terraform-resources/appsrep07ue1/stonesoup-infra-production/redhat-prod-plnsvc-s3
+      key: integrations-output/terraform-resources/appsrep11ue1/stonesoup-infra-production/redhat-prod-plnsvc-s3
   refreshInterval: 1h
   secretStoreRef:
     kind: ClusterSecretStore

--- a/components/pipeline-service/production/stone-prd-rh01/resources/tekton-results-database-secret-path.yaml
+++ b/components/pipeline-service/production/stone-prd-rh01/resources/tekton-results-database-secret-path.yaml
@@ -1,4 +1,4 @@
 ---
 - op: add
   path: /spec/dataFrom/0/extract/key
-  value: integrations-output/terraform-resources/appsrep07ue1/stonesoup-infra-production/redhat-prod-plnsvc-rds
+  value: integrations-output/terraform-resources/appsrep11ue1/stonesoup-infra-production/redhat-prod-plnsvc-rds

--- a/components/pipeline-service/production/stone-prd-rh01/resources/tekton-results-s3-secret-path.yaml
+++ b/components/pipeline-service/production/stone-prd-rh01/resources/tekton-results-s3-secret-path.yaml
@@ -1,4 +1,4 @@
 ---
 - op: add
   path: /spec/dataFrom/0/extract/key
-  value: integrations-output/terraform-resources/appsrep07ue1/stonesoup-infra-production/redhat-prod-plnsvc-s3
+  value: integrations-output/terraform-resources/appsrep11ue1/stonesoup-infra-production/redhat-prod-plnsvc-s3

--- a/components/pipeline-service/staging/stone-stg-rh01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stg-rh01/deploy.yaml
@@ -1847,7 +1847,7 @@ metadata:
 spec:
   dataFrom:
   - extract:
-      key: integrations-output/terraform-resources/appsres07ue1/stonesoup-infra-stage/redhat-stg-plnsvc-s3
+      key: integrations-output/terraform-resources/appsres11ue1/stonesoup-infra-stage/redhat-stg-plnsvc-s3
   refreshInterval: 1h
   secretStoreRef:
     kind: ClusterSecretStore
@@ -1876,7 +1876,7 @@ metadata:
 spec:
   dataFrom:
   - extract:
-      key: integrations-output/terraform-resources/appsres07ue1/stonesoup-infra-stage/redhat-staging-plnsvc-rds
+      key: integrations-output/terraform-resources/appsres11ue1/stonesoup-infra-stage/redhat-staging-plnsvc-rds
   refreshInterval: 1h
   secretStoreRef:
     kind: ClusterSecretStore
@@ -1897,7 +1897,7 @@ metadata:
 spec:
   dataFrom:
   - extract:
-      key: integrations-output/terraform-resources/appsres07ue1/stonesoup-infra-stage/redhat-stg-plnsvc-s3
+      key: integrations-output/terraform-resources/appsres11ue1/stonesoup-infra-stage/redhat-stg-plnsvc-s3
   refreshInterval: 1h
   secretStoreRef:
     kind: ClusterSecretStore

--- a/components/pipeline-service/staging/stone-stg-rh01/resources/tekton-results-database-secret-path.yaml
+++ b/components/pipeline-service/staging/stone-stg-rh01/resources/tekton-results-database-secret-path.yaml
@@ -1,4 +1,4 @@
 ---
 - op: add
   path: /spec/dataFrom/0/extract/key
-  value: integrations-output/terraform-resources/appsres07ue1/stonesoup-infra-stage/redhat-staging-plnsvc-rds
+  value: integrations-output/terraform-resources/appsres11ue1/stonesoup-infra-stage/redhat-staging-plnsvc-rds

--- a/components/pipeline-service/staging/stone-stg-rh01/resources/tekton-results-s3-secret-path.yaml
+++ b/components/pipeline-service/staging/stone-stg-rh01/resources/tekton-results-s3-secret-path.yaml
@@ -1,4 +1,4 @@
 ---
 - op: add
   path: /spec/dataFrom/0/extract/key
-  value: integrations-output/terraform-resources/appsres07ue1/stonesoup-infra-stage/redhat-stg-plnsvc-s3
+  value: integrations-output/terraform-resources/appsres11ue1/stonesoup-infra-stage/redhat-stg-plnsvc-s3


### PR DESCRIPTION
APPSRE is decommissioning appsre[s/p]07ue1 clusters. The namespaces and secrets were created already on new clusters, this PR is making us of them so we can delete the ones from former clusters after.

[KFLUXINFRA-1265](https://issues.redhat.com//browse/KFLUXINFRA-1265)