### PR TITLE
Increase memory requests/limits of smee-client

### DIFF
--- a/components/smee-client/base/deployment.yaml
+++ b/components/smee-client/base/deployment.yaml
@@ -27,7 +27,7 @@ spec:
           resources:
             limits:
               cpu: 1
-              memory: 32Mi
+              memory: 750Mi
             requests:
               cpu: 1
-              memory: 32Mi
+              memory: 750Mi


### PR DESCRIPTION
The usage can peak to a bit more that 500Mi, set requests=limits=750Mi to guarantee that amount of memory and avoid container being OOMKilled.

[KONFLUX-5728](https://issues.redhat.com//browse/KONFLUX-5728)