### PR TITLE
Over-provision ephemeral cluster control planes

### DIFF
--- a/components/cluster-as-a-service/base/clustertemplates.yaml
+++ b/components/cluster-as-a-service/base/clustertemplates.yaml
@@ -36,7 +36,7 @@ spec:
       source:
         chart: hypershift-aws-template
         repoURL: https://konflux-ci.dev/cluster-template-charts/
-        targetRevision: 0.1.5
+        targetRevision: 0.1.6
         helm:
           parameters:
             - name: region
@@ -47,5 +47,14 @@ spec:
               value: cluster-provisioner
             - name: nodePoolReplicas
               value: "3"
+            # Over provision the workload with a pause container so there are always resources
+            # available when the hub cluster needs to scale up. The autoscaler will evict this low
+            # priority pod and schedule it on newly provisioned nodes. This will allow higher
+            # priority control plane pods to immediately consume the freed up resources on
+            # existing nodes.
+            - name: pausePod.enabled
+              value: "true"
+            - name: pausePod.priorityClass
+              value: pause-pod-priority
       syncPolicy:
         automated: {}

--- a/components/cluster-as-a-service/base/kustomization.yaml
+++ b/components/cluster-as-a-service/base/kustomization.yaml
@@ -9,3 +9,4 @@ resources:
   - rbac.yaml
   - clustertemplatequotas.yaml
   - clustertemplates.yaml
+  - priorityclass.yaml

--- a/components/cluster-as-a-service/base/priorityclass.yaml
+++ b/components/cluster-as-a-service/base/priorityclass.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: pause-pod-priority
+value: -10
+globalDefault: false
+description: Priority class used by pause pods to over provision


### PR DESCRIPTION
Must only be merged after https://github.com/konflux-ci/cluster-template-charts/pull/18.