### PR TITLE
use correct label selector for metrics

### DIFF
--- a/components/namespace-lister/base/metrics/monitor.yaml
+++ b/components/namespace-lister/base/metrics/monitor.yaml
@@ -23,4 +23,4 @@ spec:
         serverName: namespace-lister.namespace-lister.svc
   selector:
     matchLabels:
-      apps: namespace-lister-metrics
+      apps: namespace-lister


### PR DESCRIPTION
We don't label any of our services with the `apps: namespace-lister-metrics` label, so we shouldn't be using it in our service monitor to watch for metrics.