### PR TITLE
Temporarily decrease max instances for testing

### DIFF
--- a/components/multi-platform-controller/staging/host-config.yaml
+++ b/components/multi-platform-controller/staging/host-config.yaml
@@ -59,7 +59,7 @@ data:
   dynamic.linux-arm64.aws-secret: aws-account
   dynamic.linux-arm64.ssh-secret: aws-ssh-key
   dynamic.linux-arm64.security-group-id: sg-05bc8dd0b52158567
-  dynamic.linux-arm64.max-instances: "160"
+  dynamic.linux-arm64.max-instances: "2"
   dynamic.linux-arm64.subnet-id: subnet-030738beb81d3863a
 
   dynamic.linux-mlarge-arm64.type: aws
@@ -342,7 +342,7 @@ data:
   dynamic.linux-s390x.region: "us-east-2"
   dynamic.linux-s390x.url: "https://us-east.iaas.cloud.ibm.com/v1"
   dynamic.linux-s390x.profile: "bz2-2x8"
-  dynamic.linux-s390x.max-instances: "4"
+  dynamic.linux-s390x.max-instances: "2"
   dynamic.linux-s390x.private-ip: "true"
   dynamic.linux-s390x.instance-tag: stage-s390x
 


### PR DESCRIPTION
In order to inexpensively test that the new per-platform instance tags added in a previous commit properly limit the number of instances running, the s390x and arm64 VM flavor maximum instances are temporarily decreased in staging. This will allow for verification that only the total number of instances of a specific "flavor" controls whether the maximum number of instances of that "flavor" has been reached.