### PR TITLE
give konflux-core team ownership over konflux-ui

### DIFF
--- a/components/konflux-ui/OWNERS
+++ b/components/konflux-ui/OWNERS
@@ -8,6 +8,9 @@ approvers:
 - Katka92
 - sahil143
 - testcara
+- dperaza4dustbit
+- filariow
+- sadlerap
 
 reviewers:
 - abhinandan13jan
@@ -17,3 +20,6 @@ reviewers:
 - Katka92
 - sahil143
 - testcara
+- dperaza4dustbit
+- filariow
+- sadlerap


### PR DESCRIPTION
These permissions are temporary.
The konflux-core team will take care of deploying the new UI to all the clusters and then revert them

Signed-off-by: Francesco Ilario <filario@redhat.com>
