### PR TITLE
Remove finalizer workaround for cluster templates

### DIFF
--- a/components/cluster-as-a-service/base/clustertemplates.yaml
+++ b/components/cluster-as-a-service/base/clustertemplates.yaml
@@ -22,12 +22,7 @@ spec:
   generators:
     - {}
   template:
-    metadata:
-      # Workaround for https://github.com/argoproj/argo-cd/issues/17181
-      finalizers:
-        - resources-finalizer.argocd.argoproj.io
-        - post-delete-finalizer.argocd.argoproj.io
-        - post-delete-finalizer.argocd.argoproj.io/cleanup
+    metadata: {}
     spec:
       destination:
         namespace: clusters


### PR DESCRIPTION
This is currently causing issues with cleanup in production.

The recently upgraded ArgoCD no longer requires the workaround. The apps are getting stuck in the deleting state while the argocd controllers endlessly append duplicate entries to the finalizers list.