### PR TITLE
Fix Results API cert after service split

### DIFF
--- a/components/pipeline-service/staging/base/main-pipeline-service-configuration.yaml
+++ b/components/pipeline-service/staging/base/main-pipeline-service-configuration.yaml
@@ -846,7 +846,7 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
     argocd.argoproj.io/sync-wave: "0"
-    service.beta.openshift.io/serving-cert-secret-name: tekton-results-tls
+    service.beta.openshift.io/serving-cert-secret-name: tekton-results-for-watcher-tls
   labels:
     app.kubernetes.io/name: tekton-results-api-for-watcher
     app.kubernetes.io/part-of: tekton-results
@@ -1153,7 +1153,7 @@ spec:
         name: config
       - name: tls
         secret:
-          secretName: tekton-results-tls
+          secretName: tekton-results-for-watcher-tls
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -1548,7 +1548,7 @@ spec:
       volumes:
         - name: tls
           secret:
-            secretName: tekton-results-tls
+            secretName: tekton-results-for-watcher-tls
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor

--- a/components/pipeline-service/staging/stone-stage-p01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stage-p01/deploy.yaml
@@ -1308,7 +1308,7 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
     argocd.argoproj.io/sync-wave: "0"
-    service.beta.openshift.io/serving-cert-secret-name: tekton-results-tls
+    service.beta.openshift.io/serving-cert-secret-name: tekton-results-for-watcher-tls
   labels:
     app.kubernetes.io/name: tekton-results-api-for-watcher
     app.kubernetes.io/part-of: tekton-results
@@ -1775,7 +1775,7 @@ spec:
         name: config
       - name: tls
         secret:
-          secretName: tekton-results-tls
+          secretName: tekton-results-for-watcher-tls
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -1983,7 +1983,7 @@ spec:
       volumes:
       - name: tls
         secret:
-          secretName: tekton-results-tls
+          secretName: tekton-results-for-watcher-tls
 ---
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret

--- a/components/pipeline-service/staging/stone-stg-rh01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stg-rh01/deploy.yaml
@@ -1308,7 +1308,7 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
     argocd.argoproj.io/sync-wave: "0"
-    service.beta.openshift.io/serving-cert-secret-name: tekton-results-tls
+    service.beta.openshift.io/serving-cert-secret-name: tekton-results-for-watcher-tls
   labels:
     app.kubernetes.io/name: tekton-results-api-for-watcher
     app.kubernetes.io/part-of: tekton-results
@@ -1775,7 +1775,7 @@ spec:
         name: config
       - name: tls
         secret:
-          secretName: tekton-results-tls
+          secretName: tekton-results-for-watcher-tls
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -1983,7 +1983,7 @@ spec:
       volumes:
       - name: tls
         secret:
-          secretName: tekton-results-tls
+          secretName: tekton-results-for-watcher-tls
 ---
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret


### PR DESCRIPTION
The Results API service was split into two services. This fixes the certificate of the new service.