### PR TITLE
Revert max instances decrease on internal

### DIFF
--- a/components/multi-platform-controller/staging-downstream/host-config.yaml
+++ b/components/multi-platform-controller/staging-downstream/host-config.yaml
@@ -60,7 +60,7 @@ data:
   dynamic.linux-arm64.aws-secret: aws-account
   dynamic.linux-arm64.ssh-secret: aws-ssh-key
   dynamic.linux-arm64.security-group-id: sg-0482e8ccae008b240
-  dynamic.linux-arm64.max-instances: "2"
+  dynamic.linux-arm64.max-instances: "100"
   dynamic.linux-arm64.subnet-id: subnet-07597d1edafa2b9d3
   dynamic.linux-arm64.allocation-timeout: "1200"
 
@@ -339,7 +339,7 @@ data:
   dynamic.linux-s390x.region: "us-east-1"
   dynamic.linux-s390x.url: "https://us-east.iaas.cloud.ibm.com/v1"
   dynamic.linux-s390x.profile: "bz2-1x4"
-  dynamic.linux-s390x.max-instances: "2"
+  dynamic.linux-s390x.max-instances: "50"
   dynamic.linux-s390x.private-ip: "true"
   dynamic.linux-s390x.disk: "200"
   dynamic.linux-s390x.allocation-timeout: "1800"


### PR DESCRIPTION
Testing has been completed regarding the maximum number of instances for a particular VM flavor, so this reverts the maximum number of instances back to their original values on the internal cluster.