### PR TITLE
Add per-platform instance tags to production

### DIFF
--- a/components/multi-platform-controller/production-downstream/kflux-ocp-p01/host-config.yaml
+++ b/components/multi-platform-controller/production-downstream/kflux-ocp-p01/host-config.yaml
@@ -66,6 +66,7 @@ data:
   dynamic.linux-arm64.region: us-east-1
   dynamic.linux-arm64.ami: ami-03d6a5256a46c9feb
   dynamic.linux-arm64.instance-type: m6g.large
+  dynamic.linux-arm64.instance-tag: prod-arm64
   dynamic.linux-arm64.key-name: kflux-ocp-p01-key-pair
   dynamic.linux-arm64.aws-secret: aws-account
   dynamic.linux-arm64.ssh-secret: aws-ssh-key
@@ -79,6 +80,7 @@ data:
   dynamic.linux-d160-arm64.region: us-east-1
   dynamic.linux-d160-arm64.ami: ami-03d6a5256a46c9feb
   dynamic.linux-d160-arm64.instance-type: m6g.large
+  dynamic.linux-d160-arm64.instance-tag: prod-arm64-d160
   dynamic.linux-d160-arm64.key-name: kflux-ocp-p01-key-pair
   dynamic.linux-d160-arm64.aws-secret: aws-account
   dynamic.linux-d160-arm64.ssh-secret: aws-ssh-key
@@ -92,6 +94,7 @@ data:
   dynamic.linux-mlarge-arm64.region: us-east-1
   dynamic.linux-mlarge-arm64.ami: ami-03d6a5256a46c9feb
   dynamic.linux-mlarge-arm64.instance-type: m6g.large
+  dynamic.linux-mlarge-arm64.instance-tag: prod-arm64-mlarge
   dynamic.linux-mlarge-arm64.key-name: kflux-ocp-p01-key-pair
   dynamic.linux-mlarge-arm64.aws-secret: aws-account
   dynamic.linux-mlarge-arm64.ssh-secret: aws-ssh-key
@@ -104,6 +107,7 @@ data:
   dynamic.linux-mxlarge-arm64.region: us-east-1
   dynamic.linux-mxlarge-arm64.ami: ami-03d6a5256a46c9feb
   dynamic.linux-mxlarge-arm64.instance-type: m6g.xlarge
+  dynamic.linux-mxlarge-arm64.instance-tag: prod-arm64-mxlarge
   dynamic.linux-mxlarge-arm64.key-name: kflux-ocp-p01-key-pair
   dynamic.linux-mxlarge-arm64.aws-secret: aws-account
   dynamic.linux-mxlarge-arm64.ssh-secret: aws-ssh-key
@@ -116,6 +120,7 @@ data:
   dynamic.linux-m2xlarge-arm64.region: us-east-1
   dynamic.linux-m2xlarge-arm64.ami: ami-03d6a5256a46c9feb
   dynamic.linux-m2xlarge-arm64.instance-type: m6g.2xlarge
+  dynamic.linux-m2xlarge-arm64.instance-tag: prod-arm64-m2xlarge
   dynamic.linux-m2xlarge-arm64.key-name: kflux-ocp-p01-key-pair
   dynamic.linux-m2xlarge-arm64.aws-secret: aws-account
   dynamic.linux-m2xlarge-arm64.ssh-secret: aws-ssh-key
@@ -129,6 +134,7 @@ data:
   dynamic.linux-d160-m2xlarge-arm64.region: us-east-1
   dynamic.linux-d160-m2xlarge-arm64.ami: ami-03d6a5256a46c9feb
   dynamic.linux-d160-m2xlarge-arm64.instance-type: m6g.2xlarge
+  dynamic.linux-d160-m2xlarge-arm64.instance-tag: prod-arm64-d160-m2xlarge
   dynamic.linux-d160-m2xlarge-arm64.key-name: kflux-ocp-p01-key-pair
   dynamic.linux-d160-m2xlarge-arm64.aws-secret: aws-account
   dynamic.linux-d160-m2xlarge-arm64.ssh-secret: aws-ssh-key
@@ -142,6 +148,7 @@ data:
   dynamic.linux-m4xlarge-arm64.region: us-east-1
   dynamic.linux-m4xlarge-arm64.ami: ami-03d6a5256a46c9feb
   dynamic.linux-m4xlarge-arm64.instance-type: m6g.4xlarge
+  dynamic.linux-m4xlarge-arm64.instance-tag: prod-arm64-m4xlarge
   dynamic.linux-m4xlarge-arm64.key-name: kflux-ocp-p01-key-pair
   dynamic.linux-m4xlarge-arm64.aws-secret: aws-account
   dynamic.linux-m4xlarge-arm64.ssh-secret: aws-ssh-key
@@ -154,6 +161,7 @@ data:
   dynamic.linux-m8xlarge-arm64.region: us-east-1
   dynamic.linux-m8xlarge-arm64.ami: ami-03d6a5256a46c9feb
   dynamic.linux-m8xlarge-arm64.instance-type: m6g.8xlarge
+  dynamic.linux-m8xlarge-arm64.instance-tag: prod-arm64-m8xlarge
   dynamic.linux-m8xlarge-arm64.key-name: kflux-ocp-p01-key-pair
   dynamic.linux-m8xlarge-arm64.aws-secret: aws-account
   dynamic.linux-m8xlarge-arm64.ssh-secret: aws-ssh-key
@@ -166,6 +174,7 @@ data:
   dynamic.linux-amd64.region: us-east-1
   dynamic.linux-amd64.ami: ami-026ebd4cfe2c043b2
   dynamic.linux-amd64.instance-type: m6a.large
+  dynamic.linux-amd64.instance-tag: prod-amd64
   dynamic.linux-amd64.key-name: kflux-ocp-p01-key-pair
   dynamic.linux-amd64.aws-secret: aws-account
   dynamic.linux-amd64.ssh-secret: aws-ssh-key
@@ -178,6 +187,7 @@ data:
   dynamic.linux-mlarge-amd64.region: us-east-1
   dynamic.linux-mlarge-amd64.ami: ami-026ebd4cfe2c043b2
   dynamic.linux-mlarge-amd64.instance-type: m6a.large
+  dynamic.linux-mlarge-amd64.instance-tag: prod-amd64-mlarge
   dynamic.linux-mlarge-amd64.key-name: kflux-ocp-p01-key-pair
   dynamic.linux-mlarge-amd64.aws-secret: aws-account
   dynamic.linux-mlarge-amd64.ssh-secret: aws-ssh-key
@@ -190,6 +200,7 @@ data:
   dynamic.linux-mxlarge-amd64.region: us-east-1
   dynamic.linux-mxlarge-amd64.ami: ami-026ebd4cfe2c043b2
   dynamic.linux-mxlarge-amd64.instance-type: m6a.xlarge
+  dynamic.linux-mxlarge-amd64.instance-tag: prod-amd64-mxlarge
   dynamic.linux-mxlarge-amd64.key-name: kflux-ocp-p01-key-pair
   dynamic.linux-mxlarge-amd64.aws-secret: aws-account
   dynamic.linux-mxlarge-amd64.ssh-secret: aws-ssh-key
@@ -202,6 +213,7 @@ data:
   dynamic.linux-m2xlarge-amd64.region: us-east-1
   dynamic.linux-m2xlarge-amd64.ami: ami-026ebd4cfe2c043b2
   dynamic.linux-m2xlarge-amd64.instance-type: m6a.2xlarge
+  dynamic.linux-m2xlarge-amd64.instance-tag: prod-amd64-m2xlarge
   dynamic.linux-m2xlarge-amd64.key-name: kflux-ocp-p01-key-pair
   dynamic.linux-m2xlarge-amd64.aws-secret: aws-account
   dynamic.linux-m2xlarge-amd64.ssh-secret: aws-ssh-key
@@ -215,6 +227,7 @@ data:
   dynamic.linux-d160-m2xlarge-amd64.region: us-east-1
   dynamic.linux-d160-m2xlarge-amd64.ami: ami-026ebd4cfe2c043b2
   dynamic.linux-d160-m2xlarge-amd64.instance-type: m6a.2xlarge
+  dynamic.linux-d160-m2xlarge-amd64.instance-tag: prod-amd64-d160-m2xlarge
   dynamic.linux-d160-m2xlarge-amd64.key-name: kflux-ocp-p01-key-pair
   dynamic.linux-d160-m2xlarge-amd64.aws-secret: aws-account
   dynamic.linux-d160-m2xlarge-amd64.ssh-secret: aws-ssh-key
@@ -228,6 +241,7 @@ data:
   dynamic.linux-m4xlarge-amd64.region: us-east-1
   dynamic.linux-m4xlarge-amd64.ami: ami-026ebd4cfe2c043b2
   dynamic.linux-m4xlarge-amd64.instance-type: m6a.4xlarge
+  dynamic.linux-m4xlarge-amd64.instance-tag: prod-amd64-m4xlarge
   dynamic.linux-m4xlarge-amd64.key-name: kflux-ocp-p01-key-pair
   dynamic.linux-m4xlarge-amd64.aws-secret: aws-account
   dynamic.linux-m4xlarge-amd64.ssh-secret: aws-ssh-key
@@ -240,6 +254,7 @@ data:
   dynamic.linux-m8xlarge-amd64.region: us-east-1
   dynamic.linux-m8xlarge-amd64.ami: ami-026ebd4cfe2c043b2
   dynamic.linux-m8xlarge-amd64.instance-type: m6a.8xlarge
+  dynamic.linux-m8xlarge-amd64.instance-tag: prod-amd64-m8xlarge
   dynamic.linux-m8xlarge-amd64.key-name: kflux-ocp-p01-key-pair
   dynamic.linux-m8xlarge-amd64.aws-secret: aws-account
   dynamic.linux-m8xlarge-amd64.ssh-secret: aws-ssh-key
@@ -253,6 +268,7 @@ data:
   dynamic.linux-cxlarge-arm64.region: us-east-1
   dynamic.linux-cxlarge-arm64.ami: ami-03d6a5256a46c9feb
   dynamic.linux-cxlarge-arm64.instance-type: c6g.xlarge
+  dynamic.linux-cxlarge-arm64.instance-tag: prod-arm64-cxlarge
   dynamic.linux-cxlarge-arm64.key-name: kflux-ocp-p01-key-pair
   dynamic.linux-cxlarge-arm64.aws-secret: aws-account
   dynamic.linux-cxlarge-arm64.ssh-secret: aws-ssh-key
@@ -266,6 +282,7 @@ data:
   dynamic.linux-d160-cxlarge-arm64.region: us-east-1
   dynamic.linux-d160-cxlarge-arm64.ami: ami-03d6a5256a46c9feb
   dynamic.linux-d160-cxlarge-arm64.instance-type: c6g.xlarge
+  dynamic.linux-d160-cxlarge-arm64.instance-tag: prod-arm64-d160-cxlarge
   dynamic.linux-d160-cxlarge-arm64.key-name: kflux-ocp-p01-key-pair
   dynamic.linux-d160-cxlarge-arm64.aws-secret: aws-account
   dynamic.linux-d160-cxlarge-arm64.ssh-secret: aws-ssh-key
@@ -279,6 +296,7 @@ data:
   dynamic.linux-c2xlarge-arm64.region: us-east-1
   dynamic.linux-c2xlarge-arm64.ami: ami-03d6a5256a46c9feb
   dynamic.linux-c2xlarge-arm64.instance-type: c6g.2xlarge
+  dynamic.linux-c2xlarge-arm64.instance-tag: prod-arm64-c2xlarge
   dynamic.linux-c2xlarge-arm64.key-name: kflux-ocp-p01-key-pair
   dynamic.linux-c2xlarge-arm64.aws-secret: aws-account
   dynamic.linux-c2xlarge-arm64.ssh-secret: aws-ssh-key
@@ -291,6 +309,7 @@ data:
   dynamic.linux-c4xlarge-arm64.region: us-east-1
   dynamic.linux-c4xlarge-arm64.ami: ami-03d6a5256a46c9feb
   dynamic.linux-c4xlarge-arm64.instance-type: c6g.4xlarge
+  dynamic.linux-c4xlarge-arm64.instance-tag: prod-arm64-c4xlarge
   dynamic.linux-c4xlarge-arm64.key-name: kflux-ocp-p01-key-pair
   dynamic.linux-c4xlarge-arm64.aws-secret: aws-account
   dynamic.linux-c4xlarge-arm64.ssh-secret: aws-ssh-key
@@ -317,6 +336,7 @@ data:
   dynamic.linux-c8xlarge-arm64.region: us-east-1
   dynamic.linux-c8xlarge-arm64.ami: ami-03d6a5256a46c9feb
   dynamic.linux-c8xlarge-arm64.instance-type: c6g.8xlarge
+  dynamic.linux-c8xlarge-arm64.instance-tag: prod-arm64-c8xlarge
   dynamic.linux-c8xlarge-arm64.key-name: kflux-ocp-p01-key-pair
   dynamic.linux-c8xlarge-arm64.aws-secret: aws-account
   dynamic.linux-c8xlarge-arm64.ssh-secret: aws-ssh-key
@@ -329,6 +349,7 @@ data:
   dynamic.linux-cxlarge-amd64.region: us-east-1
   dynamic.linux-cxlarge-amd64.ami: ami-026ebd4cfe2c043b2
   dynamic.linux-cxlarge-amd64.instance-type: c6a.xlarge
+  dynamic.linux-cxlarge-amd64.instance-tag: prod-amd64-cxlarge
   dynamic.linux-cxlarge-amd64.key-name: kflux-ocp-p01-key-pair
   dynamic.linux-cxlarge-amd64.aws-secret: aws-account
   dynamic.linux-cxlarge-amd64.ssh-secret: aws-ssh-key
@@ -341,6 +362,7 @@ data:
   dynamic.linux-c2xlarge-amd64.region: us-east-1
   dynamic.linux-c2xlarge-amd64.ami: ami-026ebd4cfe2c043b2
   dynamic.linux-c2xlarge-amd64.instance-type: c6a.2xlarge
+  dynamic.linux-c2xlarge-amd64.instance-tag: prod-amd64-c2xlarge
   dynamic.linux-c2xlarge-amd64.key-name: kflux-ocp-p01-key-pair
   dynamic.linux-c2xlarge-amd64.aws-secret: aws-account
   dynamic.linux-c2xlarge-amd64.ssh-secret: aws-ssh-key
@@ -353,6 +375,7 @@ data:
   dynamic.linux-c4xlarge-amd64.region: us-east-1
   dynamic.linux-c4xlarge-amd64.ami: ami-026ebd4cfe2c043b2
   dynamic.linux-c4xlarge-amd64.instance-type: c6a.4xlarge
+  dynamic.linux-c4xlarge-amd64.instance-tag: prod-amd64-c4xlarge
   dynamic.linux-c4xlarge-amd64.key-name: kflux-ocp-p01-key-pair
   dynamic.linux-c4xlarge-amd64.aws-secret: aws-account
   dynamic.linux-c4xlarge-amd64.ssh-secret: aws-ssh-key
@@ -379,6 +402,7 @@ data:
   dynamic.linux-c8xlarge-amd64.region: us-east-1
   dynamic.linux-c8xlarge-amd64.ami: ami-026ebd4cfe2c043b2
   dynamic.linux-c8xlarge-amd64.instance-type: c6a.8xlarge
+  dynamic.linux-c8xlarge-amd64.instance-tag: prod-amd64-c8xlarge
   dynamic.linux-c8xlarge-amd64.key-name: kflux-ocp-p01-key-pair
   dynamic.linux-c8xlarge-amd64.aws-secret: aws-account
   dynamic.linux-c8xlarge-amd64.ssh-secret: aws-ssh-key
@@ -391,6 +415,7 @@ data:
   dynamic.linux-root-arm64.region: us-east-1
   dynamic.linux-root-arm64.ami: ami-03d6a5256a46c9feb
   dynamic.linux-root-arm64.instance-type: m6g.large
+  dynamic.linux-root-arm64.instance-tag: prod-arm64-root
   dynamic.linux-root-arm64.key-name: kflux-ocp-p01-key-pair
   dynamic.linux-root-arm64.aws-secret: aws-account
   dynamic.linux-root-arm64.ssh-secret: aws-ssh-key
@@ -406,6 +431,7 @@ data:
   dynamic.linux-root-amd64.region: us-east-1
   dynamic.linux-root-amd64.ami: ami-026ebd4cfe2c043b2
   dynamic.linux-root-amd64.instance-type: m6idn.2xlarge
+  dynamic.linux-root-amd64.instance-tag: prod-amd64-root
   dynamic.linux-root-amd64.key-name: kflux-ocp-p01-key-pair
   dynamic.linux-root-amd64.aws-secret: aws-account
   dynamic.linux-root-amd64.ssh-secret: aws-ssh-key
@@ -492,6 +518,7 @@ data:
   dynamic.linux-s390x.max-instances: "30"
   dynamic.linux-s390x.private-ip: "true"
   dynamic.linux-s390x.allocation-timeout: "1800"
+  dynamic.linux-s390x.instance-tag: prod-s390x
 
   ## IBM s390x with 4CPU 16GiB RAM ####
   dynamic.linux-large-s390x.type: ibmz
@@ -507,6 +534,7 @@ data:
   dynamic.linux-large-s390x.max-instances: "10"
   dynamic.linux-large-s390x.private-ip: "true"
   dynamic.linux-large-s390x.allocation-timeout: "1800"
+  dynamic.linux-large-s390x.instance-tag: prod-s390x-large
 
   ## IBM s390x with 8CPU 16GiB RAM ####
   dynamic.linux-largecpu-s390x.type: ibmz
@@ -522,6 +550,7 @@ data:
   dynamic.linux-largecpu-s390x.max-instances: "5"
   dynamic.linux-largecpu-s390x.private-ip: "true"
   dynamic.linux-largecpu-s390x.allocation-timeout: "1800"
+  dynamic.linux-largecpu-s390x.instance-tag: prod-s390x-largecpu
 
   #PPC64LE dynamic nodes
   dynamic.linux-ppc64le.type: ibmp
@@ -537,6 +566,7 @@ data:
   dynamic.linux-ppc64le.memory: "8"
   dynamic.linux-ppc64le.max-instances: "30"
   dynamic.linux-ppc64le.allocation-timeout: "1800"
+  dynamic.linux-ppc64le.instance-tag: prod-ppc64le
 
   # Same as linux-ppc64le but with 200GB disk instead of default 100GB
   dynamic.linux-d200-ppc64le.type: ibmp
@@ -553,6 +583,7 @@ data:
   dynamic.linux-d200-ppc64le.max-instances: "30"
   dynamic.linux-d200-ppc64le.allocation-timeout: "1800"
   dynamic.linux-d200-ppc64le.disk: "200"
+  dynamic.linux-d200-ppc64le.instance-tag: prod-ppc64le-d200
 
   #PPC64LE Large dynamic nodes
   dynamic.linux-large-ppc64le.type: ibmp
@@ -568,6 +599,7 @@ data:
   dynamic.linux-large-ppc64le.memory: "16"
   dynamic.linux-large-ppc64le.max-instances: "10"
   dynamic.linux-large-ppc64le.allocation-timeout: "1800"
+  dynamic.linux-large-ppc64le.instance-tag: prod-ppc64le-large
 
   #PPC64LE CPU dynamic nodes
   dynamic.linux-largecpu-ppc64le.type: ibmp
@@ -583,6 +615,7 @@ data:
   dynamic.linux-largecpu-ppc64le.memory: "16"
   dynamic.linux-largecpu-ppc64le.max-instances: "5"
   dynamic.linux-largecpu-ppc64le.allocation-timeout: "1800"
+  dynamic.linux-largecpu-ppc64le.instance-tag: prod-ppc64le-largecpu
 
   # Same as linux-large-ppc64le but with 200GB disk instead of default 100GB
   dynamic.linux-d200-large-ppc64le.type: ibmp
@@ -599,6 +632,7 @@ data:
   dynamic.linux-d200-large-ppc64le.max-instances: "30"
   dynamic.linux-d200-large-ppc64le.allocation-timeout: "1800"
   dynamic.linux-d200-large-ppc64le.disk: "200"
+  dynamic.linux-d200-large-ppc64le.instance-tag: prod-ppc64le-d200-large
 
   # AWS GPU Nodes
   dynamic.linux-g6xlarge-amd64.type: aws
@@ -612,6 +646,7 @@ data:
   dynamic.linux-g6xlarge-amd64.subnet-id: subnet-0864e71d16676bf7f
   dynamic.linux-g6xlarge-amd64.max-instances: "100"
   dynamic.linux-g6xlarge-amd64.allocation-timeout: "1200"
+  dynamic.linux-g6xlarge-amd64.instance-tag: prod-amd64-g6xlarge
   dynamic.linux-g6xlarge-amd64.user-data: |-
     Content-Type: multipart/mixed; boundary="//"
     MIME-Version: 1.0

--- a/components/multi-platform-controller/production-downstream/stone-prod-p01/host-config.yaml
+++ b/components/multi-platform-controller/production-downstream/stone-prod-p01/host-config.yaml
@@ -56,6 +56,7 @@ data:
   dynamic.linux-arm64.region: us-east-1
   dynamic.linux-arm64.ami: ami-03d6a5256a46c9feb
   dynamic.linux-arm64.instance-type: m6g.large
+  dynamic.linux-arm64.instance-tag: prod-arm64
   dynamic.linux-arm64.key-name: konflux-prod-int-mab01
   dynamic.linux-arm64.aws-secret: aws-account
   dynamic.linux-arm64.ssh-secret: aws-ssh-key
@@ -68,6 +69,7 @@ data:
   dynamic.linux-mlarge-arm64.region: us-east-1
   dynamic.linux-mlarge-arm64.ami: ami-03d6a5256a46c9feb
   dynamic.linux-mlarge-arm64.instance-type: m6g.large
+  dynamic.linux-mlarge-arm64.instance-tag: prod-arm64-mlarge
   dynamic.linux-mlarge-arm64.key-name: konflux-prod-int-mab01
   dynamic.linux-mlarge-arm64.aws-secret: aws-account
   dynamic.linux-mlarge-arm64.ssh-secret: aws-ssh-key
@@ -80,6 +82,7 @@ data:
   dynamic.linux-mxlarge-arm64.region: us-east-1
   dynamic.linux-mxlarge-arm64.ami: ami-03d6a5256a46c9feb
   dynamic.linux-mxlarge-arm64.instance-type: m6g.xlarge
+  dynamic.linux-mxlarge-arm64.instance-tag: prod-arm64-mxlarge
   dynamic.linux-mxlarge-arm64.key-name: konflux-prod-int-mab01
   dynamic.linux-mxlarge-arm64.aws-secret: aws-account
   dynamic.linux-mxlarge-arm64.ssh-secret: aws-ssh-key
@@ -92,6 +95,7 @@ data:
   dynamic.linux-m2xlarge-arm64.region: us-east-1
   dynamic.linux-m2xlarge-arm64.ami: ami-03d6a5256a46c9feb
   dynamic.linux-m2xlarge-arm64.instance-type: m6g.2xlarge
+  dynamic.linux-m2xlarge-arm64.instance-tag: prod-arm64-m2xlarge
   dynamic.linux-m2xlarge-arm64.key-name: konflux-prod-int-mab01
   dynamic.linux-m2xlarge-arm64.aws-secret: aws-account
   dynamic.linux-m2xlarge-arm64.ssh-secret: aws-ssh-key
@@ -104,6 +108,7 @@ data:
   dynamic.linux-m4xlarge-arm64.region: us-east-1
   dynamic.linux-m4xlarge-arm64.ami: ami-03d6a5256a46c9feb
   dynamic.linux-m4xlarge-arm64.instance-type: m6g.4xlarge
+  dynamic.linux-m4xlarge-arm64.instance-tag: prod-arm64-m4xlarge
   dynamic.linux-m4xlarge-arm64.key-name: konflux-prod-int-mab01
   dynamic.linux-m4xlarge-arm64.aws-secret: aws-account
   dynamic.linux-m4xlarge-arm64.ssh-secret: aws-ssh-key
@@ -116,6 +121,7 @@ data:
   dynamic.linux-m8xlarge-arm64.region: us-east-1
   dynamic.linux-m8xlarge-arm64.ami: ami-03d6a5256a46c9feb
   dynamic.linux-m8xlarge-arm64.instance-type: m6g.8xlarge
+  dynamic.linux-m8xlarge-arm64.instance-tag: prod-arm64-m8xlarge
   dynamic.linux-m8xlarge-arm64.key-name: konflux-prod-int-mab01
   dynamic.linux-m8xlarge-arm64.aws-secret: aws-account
   dynamic.linux-m8xlarge-arm64.ssh-secret: aws-ssh-key
@@ -128,6 +134,7 @@ data:
   dynamic.linux-amd64.region: us-east-1
   dynamic.linux-amd64.ami: ami-026ebd4cfe2c043b2
   dynamic.linux-amd64.instance-type: m6a.large
+  dynamic.linux-amd64.instance-tag: prod-amd64
   dynamic.linux-amd64.key-name: konflux-prod-int-mab01
   dynamic.linux-amd64.aws-secret: aws-account
   dynamic.linux-amd64.ssh-secret: aws-ssh-key
@@ -140,6 +147,7 @@ data:
   dynamic.linux-mlarge-amd64.region: us-east-1
   dynamic.linux-mlarge-amd64.ami: ami-026ebd4cfe2c043b2
   dynamic.linux-mlarge-amd64.instance-type: m6a.large
+  dynamic.linux-mlarge-amd64.instance-tag: prod-amd64-mlarge
   dynamic.linux-mlarge-amd64.key-name: konflux-prod-int-mab01
   dynamic.linux-mlarge-amd64.aws-secret: aws-account
   dynamic.linux-mlarge-amd64.ssh-secret: aws-ssh-key
@@ -152,6 +160,7 @@ data:
   dynamic.linux-mxlarge-amd64.region: us-east-1
   dynamic.linux-mxlarge-amd64.ami: ami-026ebd4cfe2c043b2
   dynamic.linux-mxlarge-amd64.instance-type: m6a.xlarge
+  dynamic.linux-mxlarge-amd64.instance-tag: prod-amd64-mxlarge
   dynamic.linux-mxlarge-amd64.key-name: konflux-prod-int-mab01
   dynamic.linux-mxlarge-amd64.aws-secret: aws-account
   dynamic.linux-mxlarge-amd64.ssh-secret: aws-ssh-key
@@ -164,6 +173,7 @@ data:
   dynamic.linux-m2xlarge-amd64.region: us-east-1
   dynamic.linux-m2xlarge-amd64.ami: ami-026ebd4cfe2c043b2
   dynamic.linux-m2xlarge-amd64.instance-type: m6a.2xlarge
+  dynamic.linux-m2xlarge-amd64.instance-tag: prod-amd64-m2xlarge
   dynamic.linux-m2xlarge-amd64.key-name: konflux-prod-int-mab01
   dynamic.linux-m2xlarge-amd64.aws-secret: aws-account
   dynamic.linux-m2xlarge-amd64.ssh-secret: aws-ssh-key
@@ -176,6 +186,7 @@ data:
   dynamic.linux-m4xlarge-amd64.region: us-east-1
   dynamic.linux-m4xlarge-amd64.ami: ami-026ebd4cfe2c043b2
   dynamic.linux-m4xlarge-amd64.instance-type: m6a.4xlarge
+  dynamic.linux-m4xlarge-amd64.instance-tag: prod-amd64-m4xlarge
   dynamic.linux-m4xlarge-amd64.key-name: konflux-prod-int-mab01
   dynamic.linux-m4xlarge-amd64.aws-secret: aws-account
   dynamic.linux-m4xlarge-amd64.ssh-secret: aws-ssh-key
@@ -188,6 +199,7 @@ data:
   dynamic.linux-m8xlarge-amd64.region: us-east-1
   dynamic.linux-m8xlarge-amd64.ami: ami-026ebd4cfe2c043b2
   dynamic.linux-m8xlarge-amd64.instance-type: m6a.8xlarge
+  dynamic.linux-m8xlarge-amd64.instance-tag: prod-amd64-m8xlarge
   dynamic.linux-m8xlarge-amd64.key-name: konflux-prod-int-mab01
   dynamic.linux-m8xlarge-amd64.aws-secret: aws-account
   dynamic.linux-m8xlarge-amd64.ssh-secret: aws-ssh-key
@@ -201,6 +213,7 @@ data:
   dynamic.linux-cxlarge-arm64.region: us-east-1
   dynamic.linux-cxlarge-arm64.ami: ami-03d6a5256a46c9feb
   dynamic.linux-cxlarge-arm64.instance-type: c6g.xlarge
+  dynamic.linux-cxlarge-arm64.instance-tag: prod-arm64-cxlarge
   dynamic.linux-cxlarge-arm64.key-name: konflux-prod-int-mab01
   dynamic.linux-cxlarge-arm64.aws-secret: aws-account
   dynamic.linux-cxlarge-arm64.ssh-secret: aws-ssh-key
@@ -213,6 +226,7 @@ data:
   dynamic.linux-c2xlarge-arm64.region: us-east-1
   dynamic.linux-c2xlarge-arm64.ami: ami-03d6a5256a46c9feb
   dynamic.linux-c2xlarge-arm64.instance-type: c6g.2xlarge
+  dynamic.linux-c2xlarge-arm64.instance-tag: prod-arm64-c2xlarge
   dynamic.linux-c2xlarge-arm64.key-name: konflux-prod-int-mab01
   dynamic.linux-c2xlarge-arm64.aws-secret: aws-account
   dynamic.linux-c2xlarge-arm64.ssh-secret: aws-ssh-key
@@ -225,6 +239,7 @@ data:
   dynamic.linux-c4xlarge-arm64.region: us-east-1
   dynamic.linux-c4xlarge-arm64.ami: ami-03d6a5256a46c9feb
   dynamic.linux-c4xlarge-arm64.instance-type: c6g.4xlarge
+  dynamic.linux-c4xlarge-arm64.instance-tag: prod-arm64-c4xlarge
   dynamic.linux-c4xlarge-arm64.key-name: konflux-prod-int-mab01
   dynamic.linux-c4xlarge-arm64.aws-secret: aws-account
   dynamic.linux-c4xlarge-arm64.ssh-secret: aws-ssh-key
@@ -237,6 +252,7 @@ data:
   dynamic.linux-c8xlarge-arm64.region: us-east-1
   dynamic.linux-c8xlarge-arm64.ami: ami-03d6a5256a46c9feb
   dynamic.linux-c8xlarge-arm64.instance-type: c6g.8xlarge
+  dynamic.linux-c8xlarge-arm64.instance-tag: prod-arm64-c8xlarge
   dynamic.linux-c8xlarge-arm64.key-name: konflux-prod-int-mab01
   dynamic.linux-c8xlarge-arm64.aws-secret: aws-account
   dynamic.linux-c8xlarge-arm64.ssh-secret: aws-ssh-key
@@ -249,6 +265,7 @@ data:
   dynamic.linux-cxlarge-amd64.region: us-east-1
   dynamic.linux-cxlarge-amd64.ami: ami-026ebd4cfe2c043b2
   dynamic.linux-cxlarge-amd64.instance-type: c6a.xlarge
+  dynamic.linux-cxlarge-amd64.instance-tag: prod-amd64-cxlarge
   dynamic.linux-cxlarge-amd64.key-name: konflux-prod-int-mab01
   dynamic.linux-cxlarge-amd64.aws-secret: aws-account
   dynamic.linux-cxlarge-amd64.ssh-secret: aws-ssh-key
@@ -261,6 +278,7 @@ data:
   dynamic.linux-c2xlarge-amd64.region: us-east-1
   dynamic.linux-c2xlarge-amd64.ami: ami-026ebd4cfe2c043b2
   dynamic.linux-c2xlarge-amd64.instance-type: c6a.2xlarge
+  dynamic.linux-c2xlarge-amd64.instance-tag: prod-amd64-c2xlarge
   dynamic.linux-c2xlarge-amd64.key-name: konflux-prod-int-mab01
   dynamic.linux-c2xlarge-amd64.aws-secret: aws-account
   dynamic.linux-c2xlarge-amd64.ssh-secret: aws-ssh-key
@@ -273,6 +291,7 @@ data:
   dynamic.linux-c4xlarge-amd64.region: us-east-1
   dynamic.linux-c4xlarge-amd64.ami: ami-026ebd4cfe2c043b2
   dynamic.linux-c4xlarge-amd64.instance-type: c6a.4xlarge
+  dynamic.linux-c4xlarge-amd64.instance-tag: prod-amd64-c4xlarge
   dynamic.linux-c4xlarge-amd64.key-name: konflux-prod-int-mab01
   dynamic.linux-c4xlarge-amd64.aws-secret: aws-account
   dynamic.linux-c4xlarge-amd64.ssh-secret: aws-ssh-key
@@ -285,6 +304,7 @@ data:
   dynamic.linux-c8xlarge-amd64.region: us-east-1
   dynamic.linux-c8xlarge-amd64.ami: ami-026ebd4cfe2c043b2
   dynamic.linux-c8xlarge-amd64.instance-type: c6a.8xlarge
+  dynamic.linux-c8xlarge-amd64.instance-tag: prod-amd64-c8xlarge
   dynamic.linux-c8xlarge-amd64.key-name: konflux-prod-int-mab01
   dynamic.linux-c8xlarge-amd64.aws-secret: aws-account
   dynamic.linux-c8xlarge-amd64.ssh-secret: aws-ssh-key
@@ -297,6 +317,7 @@ data:
   dynamic.linux-root-arm64.region: us-east-1
   dynamic.linux-root-arm64.ami: ami-03d6a5256a46c9feb
   dynamic.linux-root-arm64.instance-type: m6g.large
+  dynamic.linux-root-arm64.instance-tag: prod-arm64-root
   dynamic.linux-root-arm64.key-name: konflux-prod-int-mab01
   dynamic.linux-root-arm64.aws-secret: aws-account
   dynamic.linux-root-arm64.ssh-secret: aws-ssh-key
@@ -312,6 +333,7 @@ data:
   dynamic.linux-root-amd64.region: us-east-1
   dynamic.linux-root-amd64.ami: ami-026ebd4cfe2c043b2
   dynamic.linux-root-amd64.instance-type: m6idn.2xlarge
+  dynamic.linux-root-amd64.instance-tag: prod-amd64-root
   dynamic.linux-root-amd64.key-name: konflux-prod-int-mab01
   dynamic.linux-root-amd64.aws-secret: aws-account
   dynamic.linux-root-amd64.ssh-secret: aws-ssh-key
@@ -398,6 +420,7 @@ data:
   dynamic.linux-s390x.max-instances: "50"
   dynamic.linux-s390x.private-ip: "true"
   dynamic.linux-s390x.allocation-timeout: "1800"
+  dynamic.linux-s390x.instance-tag: prod-s390x
 
   ## IBM s390x with 4CPU 16GiB RAM ####
   dynamic.linux-large-s390x.type: ibmz
@@ -413,6 +436,7 @@ data:
   dynamic.linux-large-s390x.max-instances: "50"
   dynamic.linux-large-s390x.private-ip: "true"
   dynamic.linux-large-s390x.allocation-timeout: "1800"
+  dynamic.linux-large-s390x.instance-tag: prod-s390x-large
 
   #PPC64LE dynamic nodes
   dynamic.linux-ppc64le.type: ibmp
@@ -428,6 +452,7 @@ data:
   dynamic.linux-ppc64le.memory: "8"
   dynamic.linux-ppc64le.max-instances: "50"
   dynamic.linux-ppc64le.allocation-timeout: "1800"
+  dynamic.linux-ppc64le.instance-tag: prod-ppc64le
 
   #PPC64LE Large dynamic nodes
   dynamic.linux-large-ppc64le.type: ibmp
@@ -443,6 +468,7 @@ data:
   dynamic.linux-large-ppc64le.memory: "16"
   dynamic.linux-large-ppc64le.max-instances: "50"
   dynamic.linux-large-ppc64le.allocation-timeout: "1800"
+  dynamic.linux-large-ppc64le.instance-tag: prod-ppc64le-large
 
   # AWS GPU Nodes
   dynamic.linux-g6xlarge-amd64.type: aws
@@ -456,6 +482,7 @@ data:
   dynamic.linux-g6xlarge-amd64.subnet-id: subnet-0aa719a6c5b602b16
   dynamic.linux-g6xlarge-amd64.max-instances: "100"
   dynamic.linux-g6xlarge-amd64.allocation-timeout: "1200"
+  dynamic.linux-g6xlarge-amd64.instance-tag: prod-amd64-g6xlarge
   dynamic.linux-g6xlarge-amd64.user-data: |-
     Content-Type: multipart/mixed; boundary="//"
     MIME-Version: 1.0

--- a/components/multi-platform-controller/production-downstream/stone-prod-p02/host-config.yaml
+++ b/components/multi-platform-controller/production-downstream/stone-prod-p02/host-config.yaml
@@ -60,6 +60,7 @@ data:
   dynamic.linux-arm64.region: us-east-1
   dynamic.linux-arm64.ami: ami-03d6a5256a46c9feb
   dynamic.linux-arm64.instance-type: m6g.large
+  dynamic.linux-arm64.instance-tag: prod-arm64
   dynamic.linux-arm64.key-name: konflux-prod-int-mab01
   dynamic.linux-arm64.aws-secret: aws-account
   dynamic.linux-arm64.ssh-secret: aws-ssh-key
@@ -72,6 +73,7 @@ data:
   dynamic.linux-mlarge-arm64.region: us-east-1
   dynamic.linux-mlarge-arm64.ami: ami-03d6a5256a46c9feb
   dynamic.linux-mlarge-arm64.instance-type: m6g.large
+  dynamic.linux-mlarge-arm64.instance-tag: prod-arm64-mlarge
   dynamic.linux-mlarge-arm64.key-name: konflux-prod-int-mab01
   dynamic.linux-mlarge-arm64.aws-secret: aws-account
   dynamic.linux-mlarge-arm64.ssh-secret: aws-ssh-key
@@ -84,6 +86,7 @@ data:
   dynamic.linux-mxlarge-arm64.region: us-east-1
   dynamic.linux-mxlarge-arm64.ami: ami-03d6a5256a46c9feb
   dynamic.linux-mxlarge-arm64.instance-type: m6g.xlarge
+  dynamic.linux-mxlarge-arm64.instance-tag: prod-arm64-mxlarge
   dynamic.linux-mxlarge-arm64.key-name: konflux-prod-int-mab01
   dynamic.linux-mxlarge-arm64.aws-secret: aws-account
   dynamic.linux-mxlarge-arm64.ssh-secret: aws-ssh-key
@@ -96,6 +99,7 @@ data:
   dynamic.linux-m2xlarge-arm64.region: us-east-1
   dynamic.linux-m2xlarge-arm64.ami: ami-03d6a5256a46c9feb
   dynamic.linux-m2xlarge-arm64.instance-type: m6g.2xlarge
+  dynamic.linux-m2xlarge-arm64.instance-tag: prod-arm64-m2xlarge
   dynamic.linux-m2xlarge-arm64.key-name: konflux-prod-int-mab01
   dynamic.linux-m2xlarge-arm64.aws-secret: aws-account
   dynamic.linux-m2xlarge-arm64.ssh-secret: aws-ssh-key
@@ -108,6 +112,7 @@ data:
   dynamic.linux-m4xlarge-arm64.region: us-east-1
   dynamic.linux-m4xlarge-arm64.ami: ami-03d6a5256a46c9feb
   dynamic.linux-m4xlarge-arm64.instance-type: m6g.4xlarge
+  dynamic.linux-m4xlarge-arm64.instance-tag: prod-arm64-m4xlarge
   dynamic.linux-m4xlarge-arm64.key-name: konflux-prod-int-mab01
   dynamic.linux-m4xlarge-arm64.aws-secret: aws-account
   dynamic.linux-m4xlarge-arm64.ssh-secret: aws-ssh-key
@@ -134,6 +139,7 @@ data:
   dynamic.linux-m8xlarge-arm64.region: us-east-1
   dynamic.linux-m8xlarge-arm64.ami: ami-03d6a5256a46c9feb
   dynamic.linux-m8xlarge-arm64.instance-type: m6g.8xlarge
+  dynamic.linux-m8xlarge-arm64.instance-tag: prod-arm64-m8xlarge
   dynamic.linux-m8xlarge-arm64.key-name: konflux-prod-int-mab01
   dynamic.linux-m8xlarge-arm64.aws-secret: aws-account
   dynamic.linux-m8xlarge-arm64.ssh-secret: aws-ssh-key
@@ -146,6 +152,7 @@ data:
   dynamic.linux-amd64.region: us-east-1
   dynamic.linux-amd64.ami: ami-026ebd4cfe2c043b2
   dynamic.linux-amd64.instance-type: m6a.large
+  dynamic.linux-amd64.instance-tag: prod-amd64
   dynamic.linux-amd64.key-name: konflux-prod-int-mab01
   dynamic.linux-amd64.aws-secret: aws-account
   dynamic.linux-amd64.ssh-secret: aws-ssh-key
@@ -158,6 +165,7 @@ data:
   dynamic.linux-mlarge-amd64.region: us-east-1
   dynamic.linux-mlarge-amd64.ami: ami-026ebd4cfe2c043b2
   dynamic.linux-mlarge-amd64.instance-type: m6a.large
+  dynamic.linux-mlarge-amd64.instance-tag: prod-amd64-mlarge
   dynamic.linux-mlarge-amd64.key-name: konflux-prod-int-mab01
   dynamic.linux-mlarge-amd64.aws-secret: aws-account
   dynamic.linux-mlarge-amd64.ssh-secret: aws-ssh-key
@@ -170,6 +178,7 @@ data:
   dynamic.linux-mxlarge-amd64.region: us-east-1
   dynamic.linux-mxlarge-amd64.ami: ami-026ebd4cfe2c043b2
   dynamic.linux-mxlarge-amd64.instance-type: m6a.xlarge
+  dynamic.linux-mxlarge-amd64.instance-tag: prod-amd64-mxlarge
   dynamic.linux-mxlarge-amd64.key-name: konflux-prod-int-mab01
   dynamic.linux-mxlarge-amd64.aws-secret: aws-account
   dynamic.linux-mxlarge-amd64.ssh-secret: aws-ssh-key
@@ -182,6 +191,7 @@ data:
   dynamic.linux-m2xlarge-amd64.region: us-east-1
   dynamic.linux-m2xlarge-amd64.ami: ami-026ebd4cfe2c043b2
   dynamic.linux-m2xlarge-amd64.instance-type: m6a.2xlarge
+  dynamic.linux-m2xlarge-amd64.instance-tag: prod-amd64-m2xlarge
   dynamic.linux-m2xlarge-amd64.key-name: konflux-prod-int-mab01
   dynamic.linux-m2xlarge-amd64.aws-secret: aws-account
   dynamic.linux-m2xlarge-amd64.ssh-secret: aws-ssh-key
@@ -194,6 +204,7 @@ data:
   dynamic.linux-m4xlarge-amd64.region: us-east-1
   dynamic.linux-m4xlarge-amd64.ami: ami-026ebd4cfe2c043b2
   dynamic.linux-m4xlarge-amd64.instance-type: m6a.4xlarge
+  dynamic.linux-m4xlarge-amd64.instance-tag: prod-amd64-m4xlarge
   dynamic.linux-m4xlarge-amd64.key-name: konflux-prod-int-mab01
   dynamic.linux-m4xlarge-amd64.aws-secret: aws-account
   dynamic.linux-m4xlarge-amd64.ssh-secret: aws-ssh-key
@@ -220,6 +231,7 @@ data:
   dynamic.linux-m8xlarge-amd64.region: us-east-1
   dynamic.linux-m8xlarge-amd64.ami: ami-026ebd4cfe2c043b2
   dynamic.linux-m8xlarge-amd64.instance-type: m6a.8xlarge
+  dynamic.linux-m8xlarge-amd64.instance-tag: prod-amd64-m8xlarge
   dynamic.linux-m8xlarge-amd64.key-name: konflux-prod-int-mab01
   dynamic.linux-m8xlarge-amd64.aws-secret: aws-account
   dynamic.linux-m8xlarge-amd64.ssh-secret: aws-ssh-key
@@ -233,6 +245,7 @@ data:
   dynamic.linux-cxlarge-arm64.region: us-east-1
   dynamic.linux-cxlarge-arm64.ami: ami-03d6a5256a46c9feb
   dynamic.linux-cxlarge-arm64.instance-type: c6g.xlarge
+  dynamic.linux-cxlarge-arm64.instance-tag: prod-arm64-cxlarge
   dynamic.linux-cxlarge-arm64.key-name: konflux-prod-int-mab01
   dynamic.linux-cxlarge-arm64.aws-secret: aws-account
   dynamic.linux-cxlarge-arm64.ssh-secret: aws-ssh-key
@@ -245,6 +258,7 @@ data:
   dynamic.linux-c2xlarge-arm64.region: us-east-1
   dynamic.linux-c2xlarge-arm64.ami: ami-03d6a5256a46c9feb
   dynamic.linux-c2xlarge-arm64.instance-type: c6g.2xlarge
+  dynamic.linux-c2xlarge-arm64.instance-tag: prod-arm64-c2xlarge
   dynamic.linux-c2xlarge-arm64.key-name: konflux-prod-int-mab01
   dynamic.linux-c2xlarge-arm64.aws-secret: aws-account
   dynamic.linux-c2xlarge-arm64.ssh-secret: aws-ssh-key
@@ -257,6 +271,7 @@ data:
   dynamic.linux-c4xlarge-arm64.region: us-east-1
   dynamic.linux-c4xlarge-arm64.ami: ami-03d6a5256a46c9feb
   dynamic.linux-c4xlarge-arm64.instance-type: c6g.4xlarge
+  dynamic.linux-c4xlarge-arm64.instance-tag: prod-arm64-c4xlarge
   dynamic.linux-c4xlarge-arm64.key-name: konflux-prod-int-mab01
   dynamic.linux-c4xlarge-arm64.aws-secret: aws-account
   dynamic.linux-c4xlarge-arm64.ssh-secret: aws-ssh-key
@@ -269,6 +284,7 @@ data:
   dynamic.linux-c8xlarge-arm64.region: us-east-1
   dynamic.linux-c8xlarge-arm64.ami: ami-03d6a5256a46c9feb
   dynamic.linux-c8xlarge-arm64.instance-type: c6g.8xlarge
+  dynamic.linux-c8xlarge-arm64.instance-tag: prod-arm64-c8xlarge
   dynamic.linux-c8xlarge-arm64.key-name: konflux-prod-int-mab01
   dynamic.linux-c8xlarge-arm64.aws-secret: aws-account
   dynamic.linux-c8xlarge-arm64.ssh-secret: aws-ssh-key
@@ -281,6 +297,7 @@ data:
   dynamic.linux-cxlarge-amd64.region: us-east-1
   dynamic.linux-cxlarge-amd64.ami: ami-026ebd4cfe2c043b2
   dynamic.linux-cxlarge-amd64.instance-type: c6a.xlarge
+  dynamic.linux-cxlarge-amd64.instance-tag: prod-amd64-cxlarge
   dynamic.linux-cxlarge-amd64.key-name: konflux-prod-int-mab01
   dynamic.linux-cxlarge-amd64.aws-secret: aws-account
   dynamic.linux-cxlarge-amd64.ssh-secret: aws-ssh-key
@@ -293,6 +310,7 @@ data:
   dynamic.linux-c2xlarge-amd64.region: us-east-1
   dynamic.linux-c2xlarge-amd64.ami: ami-026ebd4cfe2c043b2
   dynamic.linux-c2xlarge-amd64.instance-type: c6a.2xlarge
+  dynamic.linux-c2xlarge-amd64.instance-tag: prod-amd64-c2xlarge
   dynamic.linux-c2xlarge-amd64.key-name: konflux-prod-int-mab01
   dynamic.linux-c2xlarge-amd64.aws-secret: aws-account
   dynamic.linux-c2xlarge-amd64.ssh-secret: aws-ssh-key
@@ -305,6 +323,7 @@ data:
   dynamic.linux-c4xlarge-amd64.region: us-east-1
   dynamic.linux-c4xlarge-amd64.ami: ami-026ebd4cfe2c043b2
   dynamic.linux-c4xlarge-amd64.instance-type: c6a.4xlarge
+  dynamic.linux-c4xlarge-amd64.instance-tag: prod-amd64-c4xlarge
   dynamic.linux-c4xlarge-amd64.key-name: konflux-prod-int-mab01
   dynamic.linux-c4xlarge-amd64.aws-secret: aws-account
   dynamic.linux-c4xlarge-amd64.ssh-secret: aws-ssh-key
@@ -317,6 +336,7 @@ data:
   dynamic.linux-c8xlarge-amd64.region: us-east-1
   dynamic.linux-c8xlarge-amd64.ami: ami-026ebd4cfe2c043b2
   dynamic.linux-c8xlarge-amd64.instance-type: c6a.8xlarge
+  dynamic.linux-c8xlarge-amd64.instance-tag: prod-amd64-c8xlarge
   dynamic.linux-c8xlarge-amd64.key-name: konflux-prod-int-mab01
   dynamic.linux-c8xlarge-amd64.aws-secret: aws-account
   dynamic.linux-c8xlarge-amd64.ssh-secret: aws-ssh-key
@@ -329,6 +349,7 @@ data:
   dynamic.linux-root-arm64.region: us-east-1
   dynamic.linux-root-arm64.ami: ami-03d6a5256a46c9feb
   dynamic.linux-root-arm64.instance-type: m6g.large
+  dynamic.linux-root-arm64.instance-tag: prod-arm64-root
   dynamic.linux-root-arm64.key-name: konflux-prod-int-mab01
   dynamic.linux-root-arm64.aws-secret: aws-account
   dynamic.linux-root-arm64.ssh-secret: aws-ssh-key
@@ -344,6 +365,7 @@ data:
   dynamic.linux-root-amd64.region: us-east-1
   dynamic.linux-root-amd64.ami: ami-026ebd4cfe2c043b2
   dynamic.linux-root-amd64.instance-type: m6idn.2xlarge
+  dynamic.linux-root-amd64.instance-tag: prod-amd64-root
   dynamic.linux-root-amd64.key-name: konflux-prod-int-mab01
   dynamic.linux-root-amd64.aws-secret: aws-account
   dynamic.linux-root-amd64.ssh-secret: aws-ssh-key
@@ -430,6 +452,7 @@ data:
   dynamic.linux-s390x.max-instances: "50"
   dynamic.linux-s390x.private-ip: "true"
   dynamic.linux-s390x.allocation-timeout: "1800"
+  dynamic.linux-s390x.instance-tag: prod-s390x
 
   ## IBM s390x with 4CPU 16GiB RAM ####
   dynamic.linux-large-s390x.type: ibmz
@@ -445,6 +468,7 @@ data:
   dynamic.linux-large-s390x.max-instances: "50"
   dynamic.linux-large-s390x.private-ip: "true"
   dynamic.linux-large-s390x.allocation-timeout: "1800"
+  dynamic.linux-large-s390x.instance-tag: prod-s390x-large
 
 
   # Same as linux-s390x-large but with 200GB disk instead of default 100GB
@@ -478,6 +502,7 @@ data:
   dynamic.linux-ppc64le.memory: "8"
   dynamic.linux-ppc64le.max-instances: "50"
   dynamic.linux-ppc64le.allocation-timeout: "1800"
+  dynamic.linux-ppc64le.instance-tag: prod-ppc64le
 
   #PPC64LE Large dynamic nodes
   dynamic.linux-large-ppc64le.type: ibmp
@@ -493,6 +518,7 @@ data:
   dynamic.linux-large-ppc64le.memory: "16"
   dynamic.linux-large-ppc64le.max-instances: "50"
   dynamic.linux-large-ppc64le.allocation-timeout: "1800"
+  dynamic.linux-large-ppc64le.instance-tag: prod-ppc64le-large
 
   # Same as linux-ppc64le-large but with 200GB disk instead of default 100GB
   dynamic.linux-d200-large-ppc64le.type: ibmp
@@ -522,6 +548,7 @@ data:
   dynamic.linux-g6xlarge-amd64.subnet-id: subnet-0aa719a6c5b602b16
   dynamic.linux-g6xlarge-amd64.max-instances: "100"
   dynamic.linux-g6xlarge-amd64.allocation-timeout: "1200"
+  dynamic.linux-g6xlarge-amd64.instance-tag: prod-amd64-g6xlarge
   dynamic.linux-g6xlarge-amd64.user-data: |-
     Content-Type: multipart/mixed; boundary="//"
     MIME-Version: 1.0

--- a/components/multi-platform-controller/production/kflux-prd-rh02/host-config.yaml
+++ b/components/multi-platform-controller/production/kflux-prd-rh02/host-config.yaml
@@ -58,6 +58,7 @@ data:
   dynamic.linux-arm64.region: us-east-1
   dynamic.linux-arm64.ami: ami-03d6a5256a46c9feb
   dynamic.linux-arm64.instance-type: m6g.large
+  dynamic.linux-arm64.instance-tag: prod-arm64
   dynamic.linux-arm64.key-name: kflux-prd-multi-rh02-key-pair
   dynamic.linux-arm64.aws-secret: aws-account
   dynamic.linux-arm64.ssh-secret: aws-ssh-key
@@ -69,6 +70,7 @@ data:
   dynamic.linux-mlarge-arm64.region: us-east-1
   dynamic.linux-mlarge-arm64.ami: ami-03d6a5256a46c9feb
   dynamic.linux-mlarge-arm64.instance-type: m6g.large
+  dynamic.linux-mlarge-arm64.instance-tag: prod-arm64-mlarge
   dynamic.linux-mlarge-arm64.key-name: kflux-prd-multi-rh02-key-pair
   dynamic.linux-mlarge-arm64.aws-secret: aws-account
   dynamic.linux-mlarge-arm64.ssh-secret: aws-ssh-key
@@ -80,6 +82,7 @@ data:
   dynamic.linux-mxlarge-arm64.region: us-east-1
   dynamic.linux-mxlarge-arm64.ami: ami-03d6a5256a46c9feb
   dynamic.linux-mxlarge-arm64.instance-type: m6g.xlarge
+  dynamic.linux-mxlarge-arm64.instance-tag: prod-arm64-mxlarge
   dynamic.linux-mxlarge-arm64.key-name: kflux-prd-multi-rh02-key-pair
   dynamic.linux-mxlarge-arm64.aws-secret: aws-account
   dynamic.linux-mxlarge-arm64.ssh-secret: aws-ssh-key
@@ -91,6 +94,7 @@ data:
   dynamic.linux-m2xlarge-arm64.region: us-east-1
   dynamic.linux-m2xlarge-arm64.ami: ami-03d6a5256a46c9feb
   dynamic.linux-m2xlarge-arm64.instance-type: m6g.2xlarge
+  dynamic.linux-m2xlarge-arm64.instance-tag: prod-arm64-m2xlarge
   dynamic.linux-m2xlarge-arm64.key-name: kflux-prd-multi-rh02-key-pair
   dynamic.linux-m2xlarge-arm64.aws-secret: aws-account
   dynamic.linux-m2xlarge-arm64.ssh-secret: aws-ssh-key
@@ -102,6 +106,7 @@ data:
   dynamic.linux-m4xlarge-arm64.region: us-east-1
   dynamic.linux-m4xlarge-arm64.ami: ami-03d6a5256a46c9feb
   dynamic.linux-m4xlarge-arm64.instance-type: m6g.4xlarge
+  dynamic.linux-m4xlarge-arm64.instance-tag: prod-arm64-m4xlarge
   dynamic.linux-m4xlarge-arm64.key-name: kflux-prd-multi-rh02-key-pair
   dynamic.linux-m4xlarge-arm64.aws-secret: aws-account
   dynamic.linux-m4xlarge-arm64.ssh-secret: aws-ssh-key
@@ -113,6 +118,7 @@ data:
   dynamic.linux-m8xlarge-arm64.region: us-east-1
   dynamic.linux-m8xlarge-arm64.ami: ami-03d6a5256a46c9feb
   dynamic.linux-m8xlarge-arm64.instance-type: m6g.8xlarge
+  dynamic.linux-m8xlarge-arm64.instance-tag: prod-arm64-m8xlarge
   dynamic.linux-m8xlarge-arm64.key-name: kflux-prd-multi-rh02-key-pair
   dynamic.linux-m8xlarge-arm64.aws-secret: aws-account
   dynamic.linux-m8xlarge-arm64.ssh-secret: aws-ssh-key
@@ -124,6 +130,7 @@ data:
   dynamic.linux-amd64.region: us-east-1
   dynamic.linux-amd64.ami: ami-026ebd4cfe2c043b2
   dynamic.linux-amd64.instance-type: m6a.large
+  dynamic.linux-amd64.instance-tag: prod-amd64
   dynamic.linux-amd64.key-name: kflux-prd-multi-rh02-key-pair
   dynamic.linux-amd64.aws-secret: aws-account
   dynamic.linux-amd64.ssh-secret: aws-ssh-key
@@ -135,6 +142,7 @@ data:
   dynamic.linux-mlarge-amd64.region: us-east-1
   dynamic.linux-mlarge-amd64.ami: ami-026ebd4cfe2c043b2
   dynamic.linux-mlarge-amd64.instance-type: m6a.large
+  dynamic.linux-mlarge-amd64.instance-tag: prod-amd64-mlarge
   dynamic.linux-mlarge-amd64.key-name: kflux-prd-multi-rh02-key-pair
   dynamic.linux-mlarge-amd64.aws-secret: aws-account
   dynamic.linux-mlarge-amd64.ssh-secret: aws-ssh-key
@@ -146,6 +154,7 @@ data:
   dynamic.linux-mxlarge-amd64.region: us-east-1
   dynamic.linux-mxlarge-amd64.ami: ami-026ebd4cfe2c043b2
   dynamic.linux-mxlarge-amd64.instance-type: m6a.xlarge
+  dynamic.linux-mxlarge-amd64.instance-tag: prod-amd64-mxlarge
   dynamic.linux-mxlarge-amd64.key-name: kflux-prd-multi-rh02-key-pair
   dynamic.linux-mxlarge-amd64.aws-secret: aws-account
   dynamic.linux-mxlarge-amd64.ssh-secret: aws-ssh-key
@@ -157,6 +166,7 @@ data:
   dynamic.linux-m2xlarge-amd64.region: us-east-1
   dynamic.linux-m2xlarge-amd64.ami: ami-026ebd4cfe2c043b2
   dynamic.linux-m2xlarge-amd64.instance-type: m6a.2xlarge
+  dynamic.linux-m2xlarge-amd64.instance-tag: prod-amd64-m2xlarge
   dynamic.linux-m2xlarge-amd64.key-name: kflux-prd-multi-rh02-key-pair
   dynamic.linux-m2xlarge-amd64.aws-secret: aws-account
   dynamic.linux-m2xlarge-amd64.ssh-secret: aws-ssh-key
@@ -168,6 +178,7 @@ data:
   dynamic.linux-m4xlarge-amd64.region: us-east-1
   dynamic.linux-m4xlarge-amd64.ami: ami-026ebd4cfe2c043b2
   dynamic.linux-m4xlarge-amd64.instance-type: m6a.4xlarge
+  dynamic.linux-m4xlarge-amd64.instance-tag: prod-amd64-m4xlarge
   dynamic.linux-m4xlarge-amd64.key-name: kflux-prd-multi-rh02-key-pair
   dynamic.linux-m4xlarge-amd64.aws-secret: aws-account
   dynamic.linux-m4xlarge-amd64.ssh-secret: aws-ssh-key
@@ -179,6 +190,7 @@ data:
   dynamic.linux-m8xlarge-amd64.region: us-east-1
   dynamic.linux-m8xlarge-amd64.ami: ami-026ebd4cfe2c043b2
   dynamic.linux-m8xlarge-amd64.instance-type: m6a.8xlarge
+  dynamic.linux-m8xlarge-amd64.instance-tag: prod-amd64-m8xlarge
   dynamic.linux-m8xlarge-amd64.key-name: kflux-prd-multi-rh02-key-pair
   dynamic.linux-m8xlarge-amd64.aws-secret: aws-account
   dynamic.linux-m8xlarge-amd64.ssh-secret: aws-ssh-key
@@ -191,6 +203,7 @@ data:
   dynamic.linux-cxlarge-arm64.region: us-east-1
   dynamic.linux-cxlarge-arm64.ami: ami-03d6a5256a46c9feb
   dynamic.linux-cxlarge-arm64.instance-type: c6g.xlarge
+  dynamic.linux-cxlarge-arm64.instance-tag: prod-arm64-cxlarge
   dynamic.linux-cxlarge-arm64.key-name: kflux-prd-multi-rh02-key-pair
   dynamic.linux-cxlarge-arm64.aws-secret: aws-account
   dynamic.linux-cxlarge-arm64.ssh-secret: aws-ssh-key
@@ -202,6 +215,7 @@ data:
   dynamic.linux-c2xlarge-arm64.region: us-east-1
   dynamic.linux-c2xlarge-arm64.ami: ami-03d6a5256a46c9feb
   dynamic.linux-c2xlarge-arm64.instance-type: c6g.2xlarge
+  dynamic.linux-c2xlarge-arm64.instance-tag: prod-arm64-c2xlarge
   dynamic.linux-c2xlarge-arm64.key-name: kflux-prd-multi-rh02-key-pair
   dynamic.linux-c2xlarge-arm64.aws-secret: aws-account
   dynamic.linux-c2xlarge-arm64.ssh-secret: aws-ssh-key
@@ -213,6 +227,7 @@ data:
   dynamic.linux-c4xlarge-arm64.region: us-east-1
   dynamic.linux-c4xlarge-arm64.ami: ami-03d6a5256a46c9feb
   dynamic.linux-c4xlarge-arm64.instance-type: c6g.4xlarge
+  dynamic.linux-c4xlarge-arm64.instance-tag: prod-arm64-c4xlarge
   dynamic.linux-c4xlarge-arm64.key-name: kflux-prd-multi-rh02-key-pair
   dynamic.linux-c4xlarge-arm64.aws-secret: aws-account
   dynamic.linux-c4xlarge-arm64.ssh-secret: aws-ssh-key
@@ -224,6 +239,7 @@ data:
   dynamic.linux-c8xlarge-arm64.region: us-east-1
   dynamic.linux-c8xlarge-arm64.ami: ami-03d6a5256a46c9feb
   dynamic.linux-c8xlarge-arm64.instance-type: c6g.8xlarge
+  dynamic.linux-c8xlarge-arm64.instance-tag: prod-arm64-c8xlarge
   dynamic.linux-c8xlarge-arm64.key-name: kflux-prd-multi-rh02-key-pair
   dynamic.linux-c8xlarge-arm64.aws-secret: aws-account
   dynamic.linux-c8xlarge-arm64.ssh-secret: aws-ssh-key
@@ -235,6 +251,7 @@ data:
   dynamic.linux-cxlarge-amd64.region: us-east-1
   dynamic.linux-cxlarge-amd64.ami: ami-026ebd4cfe2c043b2
   dynamic.linux-cxlarge-amd64.instance-type: c6a.xlarge
+  dynamic.linux-cxlarge-amd64.instance-tag: prod-amd64-cxlarge
   dynamic.linux-cxlarge-amd64.key-name: kflux-prd-multi-rh02-key-pair
   dynamic.linux-cxlarge-amd64.aws-secret: aws-account
   dynamic.linux-cxlarge-amd64.ssh-secret: aws-ssh-key
@@ -246,6 +263,7 @@ data:
   dynamic.linux-c2xlarge-amd64.region: us-east-1
   dynamic.linux-c2xlarge-amd64.ami: ami-026ebd4cfe2c043b2
   dynamic.linux-c2xlarge-amd64.instance-type: c6a.2xlarge
+  dynamic.linux-c2xlarge-amd64.instance-tag: prod-amd64-c2xlarge
   dynamic.linux-c2xlarge-amd64.key-name: kflux-prd-multi-rh02-key-pair
   dynamic.linux-c2xlarge-amd64.aws-secret: aws-account
   dynamic.linux-c2xlarge-amd64.ssh-secret: aws-ssh-key
@@ -257,6 +275,7 @@ data:
   dynamic.linux-c4xlarge-amd64.region: us-east-1
   dynamic.linux-c4xlarge-amd64.ami: ami-026ebd4cfe2c043b2
   dynamic.linux-c4xlarge-amd64.instance-type: c6a.4xlarge
+  dynamic.linux-c4xlarge-amd64.instance-tag: prod-amd64-c4xlarge
   dynamic.linux-c4xlarge-amd64.key-name: kflux-prd-multi-rh02-key-pair
   dynamic.linux-c4xlarge-amd64.aws-secret: aws-account
   dynamic.linux-c4xlarge-amd64.ssh-secret: aws-ssh-key
@@ -268,6 +287,7 @@ data:
   dynamic.linux-c8xlarge-amd64.region: us-east-1
   dynamic.linux-c8xlarge-amd64.ami: ami-026ebd4cfe2c043b2
   dynamic.linux-c8xlarge-amd64.instance-type: c6a.8xlarge
+  dynamic.linux-c8xlarge-amd64.instance-tag: prod-amd64-c8xlarge
   dynamic.linux-c8xlarge-amd64.key-name: kflux-prd-multi-rh02-key-pair
   dynamic.linux-c8xlarge-amd64.aws-secret: aws-account
   dynamic.linux-c8xlarge-amd64.ssh-secret: aws-ssh-key
@@ -279,6 +299,7 @@ data:
   dynamic.linux-root-arm64.region: us-east-1
   dynamic.linux-root-arm64.ami: ami-03d6a5256a46c9feb
   dynamic.linux-root-arm64.instance-type: m6g.large
+  dynamic.linux-root-arm64.instance-tag: prod-arm64-root
   dynamic.linux-root-arm64.key-name: kflux-prd-multi-rh02-key-pair
   dynamic.linux-root-arm64.aws-secret: aws-account
   dynamic.linux-root-arm64.ssh-secret: aws-ssh-key
@@ -295,6 +316,7 @@ data:
   dynamic.linux-fast-amd64.region: us-east-1
   dynamic.linux-fast-amd64.ami: ami-026ebd4cfe2c043b2
   dynamic.linux-fast-amd64.instance-type: c7a.8xlarge
+  dynamic.linux-fast-amd64.instance-tag: prod-amd64-fast
   dynamic.linux-fast-amd64.key-name: kflux-prd-multi-rh02-key-pair
   dynamic.linux-fast-amd64.aws-secret: aws-account
   dynamic.linux-fast-amd64.ssh-secret: aws-ssh-key
@@ -309,6 +331,7 @@ data:
   dynamic.linux-extra-fast-amd64.region: us-east-1
   dynamic.linux-extra-fast-amd64.ami: ami-026ebd4cfe2c043b2
   dynamic.linux-extra-fast-amd64.instance-type: c7a.12xlarge
+  dynamic.linux-extra-fast-amd64.instance-tag: prod-amd64-extra-fast
   dynamic.linux-extra-fast-amd64.key-name: kflux-prd-multi-rh02-key-pair
   dynamic.linux-extra-fast-amd64.aws-secret: aws-account
   dynamic.linux-extra-fast-amd64.ssh-secret: aws-ssh-key
@@ -323,6 +346,7 @@ data:
   dynamic.linux-root-amd64.region: us-east-1
   dynamic.linux-root-amd64.ami: ami-026ebd4cfe2c043b2
   dynamic.linux-root-amd64.instance-type: m6idn.2xlarge
+  dynamic.linux-root-amd64.instance-tag: prod-amd64-root
   dynamic.linux-root-amd64.key-name: kflux-prd-multi-rh02-key-pair
   dynamic.linux-root-amd64.aws-secret: aws-account
   dynamic.linux-root-amd64.ssh-secret: aws-ssh-key
@@ -409,6 +433,7 @@ data:
   dynamic.linux-s390x.profile: "bz2-2x8"
   dynamic.linux-s390x.max-instances: "30"
   dynamic.linux-s390x.private-ip: "true"
+  dynamic.linux-s390x.instance-tag: prod-s390x
 
   dynamic.linux-large-s390x.type: ibmz
   dynamic.linux-large-s390x.ssh-secret: "ibm-ssh-key"
@@ -422,6 +447,7 @@ data:
   dynamic.linux-large-s390x.profile: "bz2-4x16"
   dynamic.linux-large-s390x.max-instances: "10"
   dynamic.linux-large-s390x.private-ip: "true"
+  dynamic.linux-large-s390x.instance-tag: prod-s390x-large
 
 # PPC64LE nodes for multi rh02
   dynamic.linux-ppc64le.type: ibmp
@@ -437,6 +463,7 @@ data:
   dynamic.linux-ppc64le.memory: "8"
   dynamic.linux-ppc64le.max-instances: "30"
   dynamic.linux-ppc64le.allocation-timeout: "1800"
+  dynamic.linux-ppc64le.instance-tag: prod-ppc64le
 
 # PPC64LE large nodes
   dynamic.linux-large-ppc64le.type: ibmp
@@ -452,6 +479,7 @@ data:
   dynamic.linux-large-ppc64le.memory: "16"
   dynamic.linux-large-ppc64le.max-instances: "10"
   dynamic.linux-large-ppc64le.allocation-timeout: "1800"
+  dynamic.linux-large-ppc64le.instance-tag: prod-ppc64le-large
 
 # GPU Instances
   dynamic.linux-g6xlarge-amd64.type: aws
@@ -464,6 +492,7 @@ data:
   dynamic.linux-g6xlarge-amd64.security-group-id: sg-004ef1b7bc3ef1bca
   dynamic.linux-g6xlarge-amd64.max-instances: "10"
   dynamic.linux-g6xlarge-amd64.subnet-id: subnet-07a8bbf633e2bb187
+  dynamic.linux-g6xlarge-amd64.instance-tag: prod-amd64-g6xlarge
   dynamic.linux-g6xlarge-amd64.user-data: |-
     Content-Type: multipart/mixed; boundary="//"
     MIME-Version: 1.0

--- a/components/multi-platform-controller/production/stone-prd-rh01/host-config.yaml
+++ b/components/multi-platform-controller/production/stone-prd-rh01/host-config.yaml
@@ -56,6 +56,7 @@ data:
   dynamic.linux-arm64.region: us-east-1
   dynamic.linux-arm64.ami: ami-03d6a5256a46c9feb
   dynamic.linux-arm64.instance-type: m6g.large
+  dynamic.linux-arm64.instance-tag: prod-arm64
   dynamic.linux-arm64.key-name: konflux-prod-ext-mab01
   dynamic.linux-arm64.aws-secret: aws-account
   dynamic.linux-arm64.ssh-secret: aws-ssh-key
@@ -67,6 +68,7 @@ data:
   dynamic.linux-mlarge-arm64.region: us-east-1
   dynamic.linux-mlarge-arm64.ami: ami-03d6a5256a46c9feb
   dynamic.linux-mlarge-arm64.instance-type: m6g.large
+  dynamic.linux-mlarge-arm64.instance-tag: prod-arm64-mlarge
   dynamic.linux-mlarge-arm64.key-name: konflux-prod-ext-mab01
   dynamic.linux-mlarge-arm64.aws-secret: aws-account
   dynamic.linux-mlarge-arm64.ssh-secret: aws-ssh-key
@@ -78,6 +80,7 @@ data:
   dynamic.linux-mxlarge-arm64.region: us-east-1
   dynamic.linux-mxlarge-arm64.ami: ami-03d6a5256a46c9feb
   dynamic.linux-mxlarge-arm64.instance-type: m6g.xlarge
+  dynamic.linux-mxlarge-arm64.instance-tag: prod-arm64-mxlarge
   dynamic.linux-mxlarge-arm64.key-name: konflux-prod-ext-mab01
   dynamic.linux-mxlarge-arm64.aws-secret: aws-account
   dynamic.linux-mxlarge-arm64.ssh-secret: aws-ssh-key
@@ -89,6 +92,7 @@ data:
   dynamic.linux-m2xlarge-arm64.region: us-east-1
   dynamic.linux-m2xlarge-arm64.ami: ami-03d6a5256a46c9feb
   dynamic.linux-m2xlarge-arm64.instance-type: m6g.2xlarge
+  dynamic.linux-m2xlarge-arm64.instance-tag: prod-arm64-m2xlarge
   dynamic.linux-m2xlarge-arm64.key-name: konflux-prod-ext-mab01
   dynamic.linux-m2xlarge-arm64.aws-secret: aws-account
   dynamic.linux-m2xlarge-arm64.ssh-secret: aws-ssh-key
@@ -100,6 +104,7 @@ data:
   dynamic.linux-m4xlarge-arm64.region: us-east-1
   dynamic.linux-m4xlarge-arm64.ami: ami-03d6a5256a46c9feb
   dynamic.linux-m4xlarge-arm64.instance-type: m6g.4xlarge
+  dynamic.linux-m4xlarge-arm64.instance-tag: prod-arm64-m4xlarge
   dynamic.linux-m4xlarge-arm64.key-name: konflux-prod-ext-mab01
   dynamic.linux-m4xlarge-arm64.aws-secret: aws-account
   dynamic.linux-m4xlarge-arm64.ssh-secret: aws-ssh-key
@@ -111,6 +116,7 @@ data:
   dynamic.linux-m8xlarge-arm64.region: us-east-1
   dynamic.linux-m8xlarge-arm64.ami: ami-03d6a5256a46c9feb
   dynamic.linux-m8xlarge-arm64.instance-type: m6g.8xlarge
+  dynamic.linux-m8xlarge-arm64.instance-tag: prod-arm64-m8xlarge
   dynamic.linux-m8xlarge-arm64.key-name: konflux-prod-ext-mab01
   dynamic.linux-m8xlarge-arm64.aws-secret: aws-account
   dynamic.linux-m8xlarge-arm64.ssh-secret: aws-ssh-key
@@ -122,6 +128,7 @@ data:
   dynamic.linux-amd64.region: us-east-1
   dynamic.linux-amd64.ami: ami-026ebd4cfe2c043b2
   dynamic.linux-amd64.instance-type: m6a.large
+  dynamic.linux-amd64.instance-tag: prod-amd64
   dynamic.linux-amd64.key-name: konflux-prod-ext-mab01
   dynamic.linux-amd64.aws-secret: aws-account
   dynamic.linux-amd64.ssh-secret: aws-ssh-key
@@ -133,6 +140,7 @@ data:
   dynamic.linux-mlarge-amd64.region: us-east-1
   dynamic.linux-mlarge-amd64.ami: ami-026ebd4cfe2c043b2
   dynamic.linux-mlarge-amd64.instance-type: m6a.large
+  dynamic.linux-mlarge-amd64.instance-tag: prod-amd64-mlarge
   dynamic.linux-mlarge-amd64.key-name: konflux-prod-ext-mab01
   dynamic.linux-mlarge-amd64.aws-secret: aws-account
   dynamic.linux-mlarge-amd64.ssh-secret: aws-ssh-key
@@ -144,6 +152,7 @@ data:
   dynamic.linux-mxlarge-amd64.region: us-east-1
   dynamic.linux-mxlarge-amd64.ami: ami-026ebd4cfe2c043b2
   dynamic.linux-mxlarge-amd64.instance-type: m6a.xlarge
+  dynamic.linux-mxlarge-amd64.instance-tag: prod-amd64-mxlarge
   dynamic.linux-mxlarge-amd64.key-name: konflux-prod-ext-mab01
   dynamic.linux-mxlarge-amd64.aws-secret: aws-account
   dynamic.linux-mxlarge-amd64.ssh-secret: aws-ssh-key
@@ -155,6 +164,7 @@ data:
   dynamic.linux-m2xlarge-amd64.region: us-east-1
   dynamic.linux-m2xlarge-amd64.ami: ami-026ebd4cfe2c043b2
   dynamic.linux-m2xlarge-amd64.instance-type: m6a.2xlarge
+  dynamic.linux-m2xlarge-amd64.instance-tag: prod-amd64-m2xlarge
   dynamic.linux-m2xlarge-amd64.key-name: konflux-prod-ext-mab01
   dynamic.linux-m2xlarge-amd64.aws-secret: aws-account
   dynamic.linux-m2xlarge-amd64.ssh-secret: aws-ssh-key
@@ -166,6 +176,7 @@ data:
   dynamic.linux-m4xlarge-amd64.region: us-east-1
   dynamic.linux-m4xlarge-amd64.ami: ami-026ebd4cfe2c043b2
   dynamic.linux-m4xlarge-amd64.instance-type: m6a.4xlarge
+  dynamic.linux-m4xlarge-amd64.instance-tag: prod-amd64-m4xlarge
   dynamic.linux-m4xlarge-amd64.key-name: konflux-prod-ext-mab01
   dynamic.linux-m4xlarge-amd64.aws-secret: aws-account
   dynamic.linux-m4xlarge-amd64.ssh-secret: aws-ssh-key
@@ -177,6 +188,7 @@ data:
   dynamic.linux-m8xlarge-amd64.region: us-east-1
   dynamic.linux-m8xlarge-amd64.ami: ami-026ebd4cfe2c043b2
   dynamic.linux-m8xlarge-amd64.instance-type: m6a.8xlarge
+  dynamic.linux-m8xlarge-amd64.instance-tag: prod-amd64-m8xlarge
   dynamic.linux-m8xlarge-amd64.key-name: konflux-prod-ext-mab01
   dynamic.linux-m8xlarge-amd64.aws-secret: aws-account
   dynamic.linux-m8xlarge-amd64.ssh-secret: aws-ssh-key
@@ -189,6 +201,7 @@ data:
   dynamic.linux-cxlarge-arm64.region: us-east-1
   dynamic.linux-cxlarge-arm64.ami: ami-03d6a5256a46c9feb
   dynamic.linux-cxlarge-arm64.instance-type: c6g.xlarge
+  dynamic.linux-cxlarge-arm64.instance-tag: prod-arm64-cxlarge
   dynamic.linux-cxlarge-arm64.key-name: konflux-prod-ext-mab01
   dynamic.linux-cxlarge-arm64.aws-secret: aws-account
   dynamic.linux-cxlarge-arm64.ssh-secret: aws-ssh-key
@@ -200,6 +213,7 @@ data:
   dynamic.linux-c2xlarge-arm64.region: us-east-1
   dynamic.linux-c2xlarge-arm64.ami: ami-03d6a5256a46c9feb
   dynamic.linux-c2xlarge-arm64.instance-type: c6g.2xlarge
+  dynamic.linux-c2xlarge-arm64.instance-tag: prod-arm64-c2xlarge
   dynamic.linux-c2xlarge-arm64.key-name: konflux-prod-ext-mab01
   dynamic.linux-c2xlarge-arm64.aws-secret: aws-account
   dynamic.linux-c2xlarge-arm64.ssh-secret: aws-ssh-key
@@ -211,6 +225,7 @@ data:
   dynamic.linux-c4xlarge-arm64.region: us-east-1
   dynamic.linux-c4xlarge-arm64.ami: ami-03d6a5256a46c9feb
   dynamic.linux-c4xlarge-arm64.instance-type: c6g.4xlarge
+  dynamic.linux-c4xlarge-arm64.instance-tag: prod-arm64-c4xlarge
   dynamic.linux-c4xlarge-arm64.key-name: konflux-prod-ext-mab01
   dynamic.linux-c4xlarge-arm64.aws-secret: aws-account
   dynamic.linux-c4xlarge-arm64.ssh-secret: aws-ssh-key
@@ -222,6 +237,7 @@ data:
   dynamic.linux-c8xlarge-arm64.region: us-east-1
   dynamic.linux-c8xlarge-arm64.ami: ami-03d6a5256a46c9feb
   dynamic.linux-c8xlarge-arm64.instance-type: c6g.8xlarge
+  dynamic.linux-c8xlarge-arm64.instance-tag: prod-arm64-c8xlarge
   dynamic.linux-c8xlarge-arm64.key-name: konflux-prod-ext-mab01
   dynamic.linux-c8xlarge-arm64.aws-secret: aws-account
   dynamic.linux-c8xlarge-arm64.ssh-secret: aws-ssh-key
@@ -233,6 +249,7 @@ data:
   dynamic.linux-cxlarge-amd64.region: us-east-1
   dynamic.linux-cxlarge-amd64.ami: ami-026ebd4cfe2c043b2
   dynamic.linux-cxlarge-amd64.instance-type: c6a.xlarge
+  dynamic.linux-cxlarge-amd64.instance-tag: prod-amd64-cxlarge
   dynamic.linux-cxlarge-amd64.key-name: konflux-prod-ext-mab01
   dynamic.linux-cxlarge-amd64.aws-secret: aws-account
   dynamic.linux-cxlarge-amd64.ssh-secret: aws-ssh-key
@@ -244,6 +261,7 @@ data:
   dynamic.linux-c2xlarge-amd64.region: us-east-1
   dynamic.linux-c2xlarge-amd64.ami: ami-026ebd4cfe2c043b2
   dynamic.linux-c2xlarge-amd64.instance-type: c6a.2xlarge
+  dynamic.linux-c2xlarge-amd64.instance-tag: prod-amd64-c2xlarge
   dynamic.linux-c2xlarge-amd64.key-name: konflux-prod-ext-mab01
   dynamic.linux-c2xlarge-amd64.aws-secret: aws-account
   dynamic.linux-c2xlarge-amd64.ssh-secret: aws-ssh-key
@@ -255,6 +273,7 @@ data:
   dynamic.linux-c4xlarge-amd64.region: us-east-1
   dynamic.linux-c4xlarge-amd64.ami: ami-026ebd4cfe2c043b2
   dynamic.linux-c4xlarge-amd64.instance-type: c6a.4xlarge
+  dynamic.linux-c4xlarge-amd64.instance-tag: prod-amd64-c4xlarge
   dynamic.linux-c4xlarge-amd64.key-name: konflux-prod-ext-mab01
   dynamic.linux-c4xlarge-amd64.aws-secret: aws-account
   dynamic.linux-c4xlarge-amd64.ssh-secret: aws-ssh-key
@@ -266,6 +285,7 @@ data:
   dynamic.linux-c8xlarge-amd64.region: us-east-1
   dynamic.linux-c8xlarge-amd64.ami: ami-026ebd4cfe2c043b2
   dynamic.linux-c8xlarge-amd64.instance-type: c6a.8xlarge
+  dynamic.linux-c8xlarge-amd64.instance-tag: prod-amd64-c8xlarge
   dynamic.linux-c8xlarge-amd64.key-name: konflux-prod-ext-mab01
   dynamic.linux-c8xlarge-amd64.aws-secret: aws-account
   dynamic.linux-c8xlarge-amd64.ssh-secret: aws-ssh-key
@@ -277,6 +297,7 @@ data:
   dynamic.linux-root-arm64.region: us-east-1
   dynamic.linux-root-arm64.ami: ami-03d6a5256a46c9feb
   dynamic.linux-root-arm64.instance-type: m6g.large
+  dynamic.linux-root-arm64.instance-tag: prod-arm64-root
   dynamic.linux-root-arm64.key-name: konflux-prod-ext-mab01
   dynamic.linux-root-arm64.aws-secret: aws-account
   dynamic.linux-root-arm64.ssh-secret: aws-ssh-key
@@ -293,6 +314,7 @@ data:
   dynamic.linux-fast-amd64.region: us-east-1
   dynamic.linux-fast-amd64.ami: ami-026ebd4cfe2c043b2
   dynamic.linux-fast-amd64.instance-type: c7a.8xlarge
+  dynamic.linux-fast-amd64.instance-tag: prod-amd64-fast
   dynamic.linux-fast-amd64.key-name: konflux-prod-ext-mab01
   dynamic.linux-fast-amd64.aws-secret: aws-account
   dynamic.linux-fast-amd64.ssh-secret: aws-ssh-key
@@ -307,6 +329,7 @@ data:
   dynamic.linux-extra-fast-amd64.region: us-east-1
   dynamic.linux-extra-fast-amd64.ami: ami-026ebd4cfe2c043b2
   dynamic.linux-extra-fast-amd64.instance-type: c7a.12xlarge
+  dynamic.linux-extra-fast-amd64.instance-tag: prod-amd64-extra-fast
   dynamic.linux-extra-fast-amd64.key-name: konflux-prod-ext-mab01
   dynamic.linux-extra-fast-amd64.aws-secret: aws-account
   dynamic.linux-extra-fast-amd64.ssh-secret: aws-ssh-key
@@ -321,6 +344,7 @@ data:
   dynamic.linux-root-amd64.region: us-east-1
   dynamic.linux-root-amd64.ami: ami-026ebd4cfe2c043b2
   dynamic.linux-root-amd64.instance-type: m6idn.2xlarge
+  dynamic.linux-root-amd64.instance-tag: prod-amd64-root
   dynamic.linux-root-amd64.key-name: konflux-prod-ext-mab01
   dynamic.linux-root-amd64.aws-secret: aws-account
   dynamic.linux-root-amd64.ssh-secret: aws-ssh-key
@@ -528,6 +552,7 @@ data:
   dynamic.linux-s390x.max-instances: "30"
   dynamic.linux-s390x.private-ip: "true"
   dynamic.linux-s390x.allocation-timeout: "1800"
+  dynamic.linux-s390x.instance-tag: prod-s390x
 
   ## IBM s390x with 4CPU 16GiB RAM ####
   dynamic.linux-large-s390x.type: ibmz
@@ -543,6 +568,7 @@ data:
   dynamic.linux-large-s390x.max-instances: "10"
   dynamic.linux-large-s390x.private-ip: "true"
   dynamic.linux-large-s390x.allocation-timeout: "1800"
+  dynamic.linux-large-s390x.instance-tag: prod-s390x-large
 
 # GPU Instances
   dynamic.linux-g6xlarge-amd64.type: aws
@@ -555,6 +581,7 @@ data:
   dynamic.linux-g6xlarge-amd64.security-group-id: sg-0fbf35ced0d59fd4a
   dynamic.linux-g6xlarge-amd64.max-instances: "10"
   dynamic.linux-g6xlarge-amd64.subnet-id: subnet-0c39ff75f819abfc5
+  dynamic.linux-g6xlarge-amd64.instance-tag: prod-amd64-g6xlarge
   dynamic.linux-g6xlarge-amd64.user-data: |-
     Content-Type: multipart/mixed; boundary="//"
     MIME-Version: 1.0


### PR DESCRIPTION
When determining if a particular VM instance can be created, the VM flavor's maximum number of instances is compared to the current number of instances with the same instance-tag to ensure no more than the maximum number of VMs are created. Since the current configurations have all flavors using the same instance tag, the count of unique instances (flavors, in this case) is wrong. Adding per-platform/flavor instance tags has been shown to fix this in the staging environment.