### PR TITLE
Grant admin access to kubearchive team

### DIFF
--- a/components/kubearchive/base/rbac.yaml
+++ b/components/kubearchive/base/rbac.yaml
@@ -25,3 +25,17 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: kubearchive-maintainer
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: kubearchive-admin
+  namespace: kubearchive
+subjects:
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: konflux-kubearchive  # rover group
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: admin


### PR DESCRIPTION
Grant them admin access in the namespace where they deploy their application. This is needed to troubleshoot an issue on staging.