### PR TITLE
Temporarily disable sync of kubearchive application

### DIFF
--- a/argo-cd-apps/overlays/konflux-public-staging/delete-sync-policy.yaml
+++ b/argo-cd-apps/overlays/konflux-public-staging/delete-sync-policy.yaml
@@ -1,0 +1,2 @@
+- op: remove
+  path: /spec/template/spec/syncPolicy

--- a/argo-cd-apps/overlays/konflux-public-staging/kustomization.yaml
+++ b/argo-cd-apps/overlays/konflux-public-staging/kustomization.yaml
@@ -12,3 +12,9 @@ resources:
 namespace: konflux-public-staging
 patchesStrategicMerge:
   - delete-applications.yaml
+patches:
+ - path: delete-sync-policy.yaml
+   target:
+     kind: ApplicationSet
+     version: v1alpha1
+     name: kubearchive


### PR DESCRIPTION
Kuebearchive is only deployed on staging clusters and there is an issue so disable the auto sync to allow modifying the deployment in staging to troubleshoot the issue. This change will be reverted once troubleshooting is done.