### PR TITLE
Fix Results API cert after service split - development

### DIFF
--- a/components/pipeline-service/development/main-pipeline-service-configuration.yaml
+++ b/components/pipeline-service/development/main-pipeline-service-configuration.yaml
@@ -893,7 +893,7 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
     argocd.argoproj.io/sync-wave: "0"
-    service.beta.openshift.io/serving-cert-secret-name: tekton-results-tls
+    service.beta.openshift.io/serving-cert-secret-name: tekton-results-for-watcher-tls
   labels:
     app.kubernetes.io/name: tekton-results-api-for-watcher
     app.kubernetes.io/part-of: tekton-results
@@ -1206,7 +1206,7 @@ spec:
         name: config
       - name: tls
         secret:
-          secretName: tekton-results-tls
+          secretName: tekton-results-for-watcher-tls
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -1664,7 +1664,7 @@ spec:
       volumes:
         - name: tls
           secret:
-            secretName: tekton-results-tls
+            secretName: tekton-results-for-watcher-tls
 ---
 apiVersion: batch/v1
 kind: Job


### PR DESCRIPTION
The issue did not actually affect development, but we've seen it in staging. This brings the development overlay in sync with staging.