### PR TITLE
Read Results API service metrics from api-for-watcher

### DIFF
--- a/components/pipeline-service/development/main-pipeline-service-configuration.yaml
+++ b/components/pipeline-service/development/main-pipeline-service-configuration.yaml
@@ -1810,7 +1810,7 @@ spec:
   jobLabel: app.kubernetes.io/name
   selector:
     matchLabels:
-      app.kubernetes.io/name: tekton-results-api
+      app.kubernetes.io/name: tekton-results-api-for-watcher
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor

--- a/components/pipeline-service/staging/base/main-pipeline-service-configuration.yaml
+++ b/components/pipeline-service/staging/base/main-pipeline-service-configuration.yaml
@@ -1623,7 +1623,7 @@ spec:
   jobLabel: app.kubernetes.io/name
   selector:
     matchLabels:
-      app.kubernetes.io/name: tekton-results-api
+      app.kubernetes.io/name: tekton-results-api-for-watcher
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor

--- a/components/pipeline-service/staging/stone-stage-p01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stage-p01/deploy.yaml
@@ -2208,7 +2208,7 @@ spec:
   jobLabel: app.kubernetes.io/name
   selector:
     matchLabels:
-      app.kubernetes.io/name: tekton-results-api
+      app.kubernetes.io/name: tekton-results-api-for-watcher
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor

--- a/components/pipeline-service/staging/stone-stg-rh01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stg-rh01/deploy.yaml
@@ -2208,7 +2208,7 @@ spec:
   jobLabel: app.kubernetes.io/name
   selector:
     matchLabels:
-      app.kubernetes.io/name: tekton-results-api
+      app.kubernetes.io/name: tekton-results-api-for-watcher
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor


### PR DESCRIPTION
Splitting the load of the Results API service, switched the watcher/controller related request  to a new pod which handles most of the load. With the original service now used only by users, it gets much less load (that was the purpose), but it triggers some false positives from the monitoring service. Here we switch the ServiceMonitor to the new pods running most of the load.