### PR TITLE
Refactor results api labels and service monitor

### DIFF
--- a/components/pipeline-service/development/main-pipeline-service-configuration.yaml
+++ b/components/pipeline-service/development/main-pipeline-service-configuration.yaml
@@ -895,8 +895,10 @@ metadata:
     argocd.argoproj.io/sync-wave: "0"
     service.beta.openshift.io/serving-cert-secret-name: tekton-results-for-watcher-tls
   labels:
+    app: tekton-results-api
     app.kubernetes.io/name: tekton-results-api-for-watcher
     app.kubernetes.io/part-of: tekton-results
+    app.kubernetes.io/component: api
     app.kubernetes.io/version: devel
   name: tekton-results-api-service-for-watcher
   namespace: tekton-results
@@ -925,8 +927,10 @@ metadata:
     argocd.argoproj.io/sync-wave: "0"
     service.beta.openshift.io/serving-cert-secret-name: tekton-results-tls
   labels:
+    app: tekton-results-api
     app.kubernetes.io/name: tekton-results-api
     app.kubernetes.io/part-of: tekton-results
+    app.kubernetes.io/component: api
     app.kubernetes.io/version: devel
   name: tekton-results-api-service
   namespace: tekton-results
@@ -954,8 +958,10 @@ metadata:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
     argocd.argoproj.io/sync-wave: "2"
   labels:
+    app: tekton-results-watcher
     app.kubernetes.io/name: tekton-results-watcher
     app.kubernetes.io/part-of: tekton-results
+    app.kubernetes.io/component: operator
     app.kubernetes.io/version: devel
   name: tekton-results-watcher
   namespace: tekton-results
@@ -1807,10 +1813,11 @@ spec:
     scheme: https
     tlsConfig:
       insecureSkipVerify: true
-  jobLabel: app.kubernetes.io/name
+  jobLabel: app
   selector:
     matchLabels:
-      app.kubernetes.io/name: tekton-results-api-for-watcher
+      app.kubernetes.io/part-of: tekton-results
+      app.kubernetes.io/component: api
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor

--- a/components/pipeline-service/development/main-pipeline-service-configuration.yaml
+++ b/components/pipeline-service/development/main-pipeline-service-configuration.yaml
@@ -961,7 +961,7 @@ metadata:
     app: tekton-results-watcher
     app.kubernetes.io/name: tekton-results-watcher
     app.kubernetes.io/part-of: tekton-results
-    app.kubernetes.io/component: operator
+    app.kubernetes.io/component: watcher
     app.kubernetes.io/version: devel
   name: tekton-results-watcher
   namespace: tekton-results

--- a/components/pipeline-service/staging/base/main-pipeline-service-configuration.yaml
+++ b/components/pipeline-service/staging/base/main-pipeline-service-configuration.yaml
@@ -911,10 +911,10 @@ metadata:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
     argocd.argoproj.io/sync-wave: "2"
   labels:
-    app: tekton-results-api
+    app: tekton-results-watcher
     app.kubernetes.io/name: tekton-results-watcher
     app.kubernetes.io/part-of: tekton-results
-    app.kubernetes.io/component: operator
+    app.kubernetes.io/component: watcher
     app.kubernetes.io/version: devel
   name: tekton-results-watcher
   namespace: tekton-results

--- a/components/pipeline-service/staging/base/main-pipeline-service-configuration.yaml
+++ b/components/pipeline-service/staging/base/main-pipeline-service-configuration.yaml
@@ -848,8 +848,10 @@ metadata:
     argocd.argoproj.io/sync-wave: "0"
     service.beta.openshift.io/serving-cert-secret-name: tekton-results-for-watcher-tls
   labels:
+    app: tekton-results-api
     app.kubernetes.io/name: tekton-results-api-for-watcher
     app.kubernetes.io/part-of: tekton-results
+    app.kubernetes.io/component: api
     app.kubernetes.io/version: devel
   name: tekton-results-api-service-for-watcher
   namespace: tekton-results
@@ -878,8 +880,10 @@ metadata:
     argocd.argoproj.io/sync-wave: "0"
     service.beta.openshift.io/serving-cert-secret-name: tekton-results-tls
   labels:
+    app: tekton-results-api
     app.kubernetes.io/name: tekton-results-api
     app.kubernetes.io/part-of: tekton-results
+    app.kubernetes.io/component: api
     app.kubernetes.io/version: devel
   name: tekton-results-api-service
   namespace: tekton-results
@@ -907,8 +911,10 @@ metadata:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
     argocd.argoproj.io/sync-wave: "2"
   labels:
+    app: tekton-results-api
     app.kubernetes.io/name: tekton-results-watcher
     app.kubernetes.io/part-of: tekton-results
+    app.kubernetes.io/component: operator
     app.kubernetes.io/version: devel
   name: tekton-results-watcher
   namespace: tekton-results
@@ -1620,10 +1626,11 @@ spec:
     scheme: https
     tlsConfig:
       insecureSkipVerify: true
-  jobLabel: app.kubernetes.io/name
+  jobLabel: app
   selector:
     matchLabels:
-      app.kubernetes.io/name: tekton-results-api-for-watcher
+      app.kubernetes.io/part-of: tekton-results
+      app.kubernetes.io/component: api
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor

--- a/components/pipeline-service/staging/stone-stage-p01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stage-p01/deploy.yaml
@@ -1343,10 +1343,10 @@ metadata:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
     argocd.argoproj.io/sync-wave: "2"
   labels:
-    app: tekton-results-api
+    app: tekton-results-watcher
     app.kubernetes.io/name: tekton-results-watcher
     app.kubernetes.io/part-of: tekton-results
-    app.kubernetes.io/component: operator
+    app.kubernetes.io/component: watcher
     app.kubernetes.io/version: devel
   name: tekton-results-watcher
   namespace: tekton-results

--- a/components/pipeline-service/staging/stone-stage-p01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stage-p01/deploy.yaml
@@ -1280,8 +1280,10 @@ metadata:
     argocd.argoproj.io/sync-wave: "0"
     service.beta.openshift.io/serving-cert-secret-name: tekton-results-tls
   labels:
+    app: tekton-results-api
     app.kubernetes.io/name: tekton-results-api
     app.kubernetes.io/part-of: tekton-results
+    app.kubernetes.io/component: api
     app.kubernetes.io/version: devel
   name: tekton-results-api-service
   namespace: tekton-results
@@ -1310,8 +1312,10 @@ metadata:
     argocd.argoproj.io/sync-wave: "0"
     service.beta.openshift.io/serving-cert-secret-name: tekton-results-for-watcher-tls
   labels:
+    app: tekton-results-api
     app.kubernetes.io/name: tekton-results-api-for-watcher
     app.kubernetes.io/part-of: tekton-results
+    app.kubernetes.io/component: api
     app.kubernetes.io/version: devel
   name: tekton-results-api-service-for-watcher
   namespace: tekton-results
@@ -1339,8 +1343,10 @@ metadata:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
     argocd.argoproj.io/sync-wave: "2"
   labels:
+    app: tekton-results-api
     app.kubernetes.io/name: tekton-results-watcher
     app.kubernetes.io/part-of: tekton-results
+    app.kubernetes.io/component: operator
     app.kubernetes.io/version: devel
   name: tekton-results-watcher
   namespace: tekton-results
@@ -2205,10 +2211,11 @@ spec:
     scheme: https
     tlsConfig:
       insecureSkipVerify: true
-  jobLabel: app.kubernetes.io/name
+  jobLabel: app
   selector:
     matchLabels:
-      app.kubernetes.io/name: tekton-results-api-for-watcher
+      app.kubernetes.io/part-of: tekton-results
+      app.kubernetes.io/component: api
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor

--- a/components/pipeline-service/staging/stone-stg-rh01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stg-rh01/deploy.yaml
@@ -1343,10 +1343,10 @@ metadata:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
     argocd.argoproj.io/sync-wave: "2"
   labels:
-    app: tekton-results-api
+    app: tekton-results-watcher
     app.kubernetes.io/name: tekton-results-watcher
     app.kubernetes.io/part-of: tekton-results
-    app.kubernetes.io/component: operator
+    app.kubernetes.io/component: watcher
     app.kubernetes.io/version: devel
   name: tekton-results-watcher
   namespace: tekton-results

--- a/components/pipeline-service/staging/stone-stg-rh01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stg-rh01/deploy.yaml
@@ -1280,8 +1280,10 @@ metadata:
     argocd.argoproj.io/sync-wave: "0"
     service.beta.openshift.io/serving-cert-secret-name: tekton-results-tls
   labels:
+    app: tekton-results-api
     app.kubernetes.io/name: tekton-results-api
     app.kubernetes.io/part-of: tekton-results
+    app.kubernetes.io/component: api
     app.kubernetes.io/version: devel
   name: tekton-results-api-service
   namespace: tekton-results
@@ -1310,8 +1312,10 @@ metadata:
     argocd.argoproj.io/sync-wave: "0"
     service.beta.openshift.io/serving-cert-secret-name: tekton-results-for-watcher-tls
   labels:
+    app: tekton-results-api
     app.kubernetes.io/name: tekton-results-api-for-watcher
     app.kubernetes.io/part-of: tekton-results
+    app.kubernetes.io/component: api
     app.kubernetes.io/version: devel
   name: tekton-results-api-service-for-watcher
   namespace: tekton-results
@@ -1339,8 +1343,10 @@ metadata:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
     argocd.argoproj.io/sync-wave: "2"
   labels:
+    app: tekton-results-api
     app.kubernetes.io/name: tekton-results-watcher
     app.kubernetes.io/part-of: tekton-results
+    app.kubernetes.io/component: operator
     app.kubernetes.io/version: devel
   name: tekton-results-watcher
   namespace: tekton-results
@@ -2205,10 +2211,11 @@ spec:
     scheme: https
     tlsConfig:
       insecureSkipVerify: true
-  jobLabel: app.kubernetes.io/name
+  jobLabel: app
   selector:
     matchLabels:
-      app.kubernetes.io/name: tekton-results-api-for-watcher
+      app.kubernetes.io/part-of: tekton-results-api
+      app.kubernetes.io/component: api
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor


### PR DESCRIPTION
The Service Monitor for Tekton Results needs to label with `job: tekton-results-api` since pagerduty alerts and grafana dashboards both depend on the `job` label. However the monitor needs to match both the normal `tekton-results-api` service as well as the new "writer" service `tekton-results-api-for-watcher`.

This PR adds the `app` and `app.kubernetes.io/component` labels to all `tekton-results` services, similar to what is done for tekton chains, in order for the ServiceMonitor to correctly match both API services and not the Watcher service. 