### PR TITLE
Pull Results API metrics from both Services

### DIFF
--- a/components/pipeline-service/production/base/main-pipeline-service-configuration.yaml
+++ b/components/pipeline-service/production/base/main-pipeline-service-configuration.yaml
@@ -847,8 +847,10 @@ metadata:
     argocd.argoproj.io/sync-wave: "0"
     service.beta.openshift.io/serving-cert-secret-name: tekton-results-for-watcher-tls
   labels:
+    app: tekton-results-api
     app.kubernetes.io/name: tekton-results-api-for-watcher
     app.kubernetes.io/part-of: tekton-results
+    app.kubernetes.io/component: api
     app.kubernetes.io/version: devel
   name: tekton-results-api-service-for-watcher
   namespace: tekton-results
@@ -877,8 +879,10 @@ metadata:
     argocd.argoproj.io/sync-wave: "0"
     service.beta.openshift.io/serving-cert-secret-name: tekton-results-tls
   labels:
+    app: tekton-results-api
     app.kubernetes.io/name: tekton-results-api
     app.kubernetes.io/part-of: tekton-results
+    app.kubernetes.io/component: api
     app.kubernetes.io/version: devel
   name: tekton-results-api-service
   namespace: tekton-results
@@ -906,8 +910,10 @@ metadata:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
     argocd.argoproj.io/sync-wave: "2"
   labels:
+    app: tekton-results-watcher
     app.kubernetes.io/name: tekton-results-watcher
     app.kubernetes.io/part-of: tekton-results
+    app.kubernetes.io/component: watcher
     app.kubernetes.io/version: devel
   name: tekton-results-watcher
   namespace: tekton-results
@@ -1618,10 +1624,11 @@ spec:
     scheme: https
     tlsConfig:
       insecureSkipVerify: true
-  jobLabel: app.kubernetes.io/name
+  jobLabel: app
   selector:
     matchLabels:
-      app.kubernetes.io/name: tekton-results-api
+      app.kubernetes.io/part-of: tekton-results
+      app.kubernetes.io/component: api
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor

--- a/components/pipeline-service/production/kflux-ocp-p01/deploy.yaml
+++ b/components/pipeline-service/production/kflux-ocp-p01/deploy.yaml
@@ -1277,6 +1277,8 @@ metadata:
     argocd.argoproj.io/sync-wave: "0"
     service.beta.openshift.io/serving-cert-secret-name: tekton-results-tls
   labels:
+    app: tekton-results-api
+    app.kubernetes.io/component: api
     app.kubernetes.io/name: tekton-results-api
     app.kubernetes.io/part-of: tekton-results
     app.kubernetes.io/version: devel
@@ -1307,6 +1309,8 @@ metadata:
     argocd.argoproj.io/sync-wave: "0"
     service.beta.openshift.io/serving-cert-secret-name: tekton-results-for-watcher-tls
   labels:
+    app: tekton-results-api
+    app.kubernetes.io/component: api
     app.kubernetes.io/name: tekton-results-api-for-watcher
     app.kubernetes.io/part-of: tekton-results
     app.kubernetes.io/version: devel
@@ -1336,6 +1340,8 @@ metadata:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
     argocd.argoproj.io/sync-wave: "2"
   labels:
+    app: tekton-results-watcher
+    app.kubernetes.io/component: watcher
     app.kubernetes.io/name: tekton-results-watcher
     app.kubernetes.io/part-of: tekton-results
     app.kubernetes.io/version: devel
@@ -2201,10 +2207,11 @@ spec:
     scheme: https
     tlsConfig:
       insecureSkipVerify: true
-  jobLabel: app.kubernetes.io/name
+  jobLabel: app
   selector:
     matchLabels:
-      app.kubernetes.io/name: tekton-results-api
+      app.kubernetes.io/component: api
+      app.kubernetes.io/part-of: tekton-results
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor

--- a/components/pipeline-service/production/kflux-prd-rh02/deploy.yaml
+++ b/components/pipeline-service/production/kflux-prd-rh02/deploy.yaml
@@ -1308,6 +1308,8 @@ metadata:
     argocd.argoproj.io/sync-wave: "0"
     service.beta.openshift.io/serving-cert-secret-name: tekton-results-tls
   labels:
+    app: tekton-results-api
+    app.kubernetes.io/component: api
     app.kubernetes.io/name: tekton-results-api
     app.kubernetes.io/part-of: tekton-results
     app.kubernetes.io/version: devel
@@ -1338,6 +1340,8 @@ metadata:
     argocd.argoproj.io/sync-wave: "0"
     service.beta.openshift.io/serving-cert-secret-name: tekton-results-for-watcher-tls
   labels:
+    app: tekton-results-api
+    app.kubernetes.io/component: api
     app.kubernetes.io/name: tekton-results-api-for-watcher
     app.kubernetes.io/part-of: tekton-results
     app.kubernetes.io/version: devel
@@ -1367,6 +1371,8 @@ metadata:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
     argocd.argoproj.io/sync-wave: "2"
   labels:
+    app: tekton-results-watcher
+    app.kubernetes.io/component: watcher
     app.kubernetes.io/name: tekton-results-watcher
     app.kubernetes.io/part-of: tekton-results
     app.kubernetes.io/version: devel
@@ -2232,10 +2238,11 @@ spec:
     scheme: https
     tlsConfig:
       insecureSkipVerify: true
-  jobLabel: app.kubernetes.io/name
+  jobLabel: app
   selector:
     matchLabels:
-      app.kubernetes.io/name: tekton-results-api
+      app.kubernetes.io/component: api
+      app.kubernetes.io/part-of: tekton-results
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor

--- a/components/pipeline-service/production/stone-prd-m01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prd-m01/deploy.yaml
@@ -1277,6 +1277,8 @@ metadata:
     argocd.argoproj.io/sync-wave: "0"
     service.beta.openshift.io/serving-cert-secret-name: tekton-results-tls
   labels:
+    app: tekton-results-api
+    app.kubernetes.io/component: api
     app.kubernetes.io/name: tekton-results-api
     app.kubernetes.io/part-of: tekton-results
     app.kubernetes.io/version: devel
@@ -1307,6 +1309,8 @@ metadata:
     argocd.argoproj.io/sync-wave: "0"
     service.beta.openshift.io/serving-cert-secret-name: tekton-results-for-watcher-tls
   labels:
+    app: tekton-results-api
+    app.kubernetes.io/component: api
     app.kubernetes.io/name: tekton-results-api-for-watcher
     app.kubernetes.io/part-of: tekton-results
     app.kubernetes.io/version: devel
@@ -1336,6 +1340,8 @@ metadata:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
     argocd.argoproj.io/sync-wave: "2"
   labels:
+    app: tekton-results-watcher
+    app.kubernetes.io/component: watcher
     app.kubernetes.io/name: tekton-results-watcher
     app.kubernetes.io/part-of: tekton-results
     app.kubernetes.io/version: devel
@@ -2201,10 +2207,11 @@ spec:
     scheme: https
     tlsConfig:
       insecureSkipVerify: true
-  jobLabel: app.kubernetes.io/name
+  jobLabel: app
   selector:
     matchLabels:
-      app.kubernetes.io/name: tekton-results-api
+      app.kubernetes.io/component: api
+      app.kubernetes.io/part-of: tekton-results
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor

--- a/components/pipeline-service/production/stone-prd-rh01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prd-rh01/deploy.yaml
@@ -1277,6 +1277,8 @@ metadata:
     argocd.argoproj.io/sync-wave: "0"
     service.beta.openshift.io/serving-cert-secret-name: tekton-results-tls
   labels:
+    app: tekton-results-api
+    app.kubernetes.io/component: api
     app.kubernetes.io/name: tekton-results-api
     app.kubernetes.io/part-of: tekton-results
     app.kubernetes.io/version: devel
@@ -1307,6 +1309,8 @@ metadata:
     argocd.argoproj.io/sync-wave: "0"
     service.beta.openshift.io/serving-cert-secret-name: tekton-results-for-watcher-tls
   labels:
+    app: tekton-results-api
+    app.kubernetes.io/component: api
     app.kubernetes.io/name: tekton-results-api-for-watcher
     app.kubernetes.io/part-of: tekton-results
     app.kubernetes.io/version: devel
@@ -1336,6 +1340,8 @@ metadata:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
     argocd.argoproj.io/sync-wave: "2"
   labels:
+    app: tekton-results-watcher
+    app.kubernetes.io/component: watcher
     app.kubernetes.io/name: tekton-results-watcher
     app.kubernetes.io/part-of: tekton-results
     app.kubernetes.io/version: devel
@@ -2201,10 +2207,11 @@ spec:
     scheme: https
     tlsConfig:
       insecureSkipVerify: true
-  jobLabel: app.kubernetes.io/name
+  jobLabel: app
   selector:
     matchLabels:
-      app.kubernetes.io/name: tekton-results-api
+      app.kubernetes.io/component: api
+      app.kubernetes.io/part-of: tekton-results
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor

--- a/components/pipeline-service/production/stone-prod-p01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prod-p01/deploy.yaml
@@ -1277,6 +1277,8 @@ metadata:
     argocd.argoproj.io/sync-wave: "0"
     service.beta.openshift.io/serving-cert-secret-name: tekton-results-tls
   labels:
+    app: tekton-results-api
+    app.kubernetes.io/component: api
     app.kubernetes.io/name: tekton-results-api
     app.kubernetes.io/part-of: tekton-results
     app.kubernetes.io/version: devel
@@ -1307,6 +1309,8 @@ metadata:
     argocd.argoproj.io/sync-wave: "0"
     service.beta.openshift.io/serving-cert-secret-name: tekton-results-for-watcher-tls
   labels:
+    app: tekton-results-api
+    app.kubernetes.io/component: api
     app.kubernetes.io/name: tekton-results-api-for-watcher
     app.kubernetes.io/part-of: tekton-results
     app.kubernetes.io/version: devel
@@ -1336,6 +1340,8 @@ metadata:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
     argocd.argoproj.io/sync-wave: "2"
   labels:
+    app: tekton-results-watcher
+    app.kubernetes.io/component: watcher
     app.kubernetes.io/name: tekton-results-watcher
     app.kubernetes.io/part-of: tekton-results
     app.kubernetes.io/version: devel
@@ -2201,10 +2207,11 @@ spec:
     scheme: https
     tlsConfig:
       insecureSkipVerify: true
-  jobLabel: app.kubernetes.io/name
+  jobLabel: app
   selector:
     matchLabels:
-      app.kubernetes.io/name: tekton-results-api
+      app.kubernetes.io/component: api
+      app.kubernetes.io/part-of: tekton-results
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor

--- a/components/pipeline-service/production/stone-prod-p02/deploy.yaml
+++ b/components/pipeline-service/production/stone-prod-p02/deploy.yaml
@@ -1277,6 +1277,8 @@ metadata:
     argocd.argoproj.io/sync-wave: "0"
     service.beta.openshift.io/serving-cert-secret-name: tekton-results-tls
   labels:
+    app: tekton-results-api
+    app.kubernetes.io/component: api
     app.kubernetes.io/name: tekton-results-api
     app.kubernetes.io/part-of: tekton-results
     app.kubernetes.io/version: devel
@@ -1307,6 +1309,8 @@ metadata:
     argocd.argoproj.io/sync-wave: "0"
     service.beta.openshift.io/serving-cert-secret-name: tekton-results-for-watcher-tls
   labels:
+    app: tekton-results-api
+    app.kubernetes.io/component: api
     app.kubernetes.io/name: tekton-results-api-for-watcher
     app.kubernetes.io/part-of: tekton-results
     app.kubernetes.io/version: devel
@@ -1336,6 +1340,8 @@ metadata:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
     argocd.argoproj.io/sync-wave: "2"
   labels:
+    app: tekton-results-watcher
+    app.kubernetes.io/component: watcher
     app.kubernetes.io/name: tekton-results-watcher
     app.kubernetes.io/part-of: tekton-results
     app.kubernetes.io/version: devel
@@ -2201,10 +2207,11 @@ spec:
     scheme: https
     tlsConfig:
       insecureSkipVerify: true
-  jobLabel: app.kubernetes.io/name
+  jobLabel: app
   selector:
     matchLabels:
-      app.kubernetes.io/name: tekton-results-api
+      app.kubernetes.io/component: api
+      app.kubernetes.io/part-of: tekton-results
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor


### PR DESCRIPTION
After splitting the workload betwen two services, this updates the ServiceMonitor to monitor both.