### PR TITLE
Manually promote mintmaker to prod

### DIFF
--- a/components/mintmaker/production/base/kustomization.yaml
+++ b/components/mintmaker/production/base/kustomization.yaml
@@ -3,18 +3,18 @@ kind: Kustomization
 resources:
   - ../../base
   - ../../base/external-secrets
-  - https://github.com/konflux-ci/mintmaker/config/default?ref=435c3914c47fe68d6fee7ce4eb15dfc56413a448
-  - https://github.com/konflux-ci/mintmaker/config/renovate?ref=435c3914c47fe68d6fee7ce4eb15dfc56413a448
+  - https://github.com/konflux-ci/mintmaker/config/default?ref=68052519f16c5045eec5f9316db2a43e5065d52b
+  - https://github.com/konflux-ci/mintmaker/config/renovate?ref=68052519f16c5045eec5f9316db2a43e5065d52b
 
 namespace: mintmaker
 
 images:
   - name: quay.io/konflux-ci/mintmaker
     newName: quay.io/konflux-ci/mintmaker
-    newTag: 435c3914c47fe68d6fee7ce4eb15dfc56413a448
+    newTag: 68052519f16c5045eec5f9316db2a43e5065d52b
   - name: quay.io/konflux-ci/mintmaker-renovate-image
     newName: quay.io/konflux-ci/mintmaker-renovate-image
-    newTag: 7205136be48686f4a8aa7cba4fe98d7062570e67
+    newTag: 6df984fceaa78e1a018e0328ee888f63c01cd7d3
 
 commonAnnotations:
   argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true


### PR DESCRIPTION
Automatic promote PR is missing an update to the Mintmaker image, likely due to a custom image being deployed in stage.