### PR TITLE
Adding temp access to workspace team to read RoleBindings

### DIFF
--- a/argo-cd-apps/base/member/infra-deployments/workspaces/workspaces.yaml
+++ b/argo-cd-apps/base/member/infra-deployments/workspaces/workspaces.yaml
@@ -17,6 +17,12 @@ spec:
               elements:
                 - nameNormalized: stone-stg-rh01
                   values.clusterDir: stone-stg-rh01
+                - nameNormalized: stone-prd-rh01
+                  values.clusterDir: stone-prd-rh01
+                - nameNormalized: stone-stage-p01
+                  values.clusterDir: stone-stage-p01
+                - nameNormalized: stone-prod-p02
+                  values.clusterDir: stone-prod-p02
   template:
     metadata:
       name: workspaces-{{nameNormalized}}

--- a/argo-cd-apps/overlays/konflux-public-production/delete-applications.yaml
+++ b/argo-cd-apps/overlays/konflux-public-production/delete-applications.yaml
@@ -13,13 +13,6 @@ metadata:
   name: kubearchive
 $patch: delete
 ---
-# Workspaces CRD on member not yet ready to go to production
-apiVersion: argoproj.io/v1alpha1
-kind: ApplicationSet
-metadata:
-  name: workspaces-member
-$patch: delete
----
 # KubeArchive not yet ready to go to production
 apiVersion: argoproj.io/v1alpha1
 kind: ApplicationSet

--- a/argo-cd-apps/overlays/production-downstream/delete-applications.yaml
+++ b/argo-cd-apps/overlays/production-downstream/delete-applications.yaml
@@ -37,13 +37,6 @@ metadata:
   name: kubearchive
 $patch: delete
 ---
-# Workspaces CRD on member not yet ready to go to production
-apiVersion: argoproj.io/v1alpha1
-kind: ApplicationSet
-metadata:
-  name: workspaces-member
-$patch: delete
----
 # KubeArchive not yet ready to go to production
 apiVersion: argoproj.io/v1alpha1
 kind: ApplicationSet

--- a/argo-cd-apps/overlays/staging-downstream/delete-applications.yaml
+++ b/argo-cd-apps/overlays/staging-downstream/delete-applications.yaml
@@ -37,13 +37,6 @@ metadata:
   name: kubearchive
 $patch: delete
 ---
-# Workspaces CRD is already installed in single cluster setup
-apiVersion: argoproj.io/v1alpha1
-kind: ApplicationSet
-metadata:
-  name: workspaces-member
-$patch: delete
----
 # KubeArchive is not yet installed here
 apiVersion: argoproj.io/v1alpha1
 kind: ApplicationSet

--- a/components/workspaces/production/stone-prd-rh01/kustomization.yaml
+++ b/components/workspaces/production/stone-prd-rh01/kustomization.yaml
@@ -1,5 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- ../../team/kyverno
 - ../../team/migration

--- a/components/workspaces/production/stone-prod-p02/kustomization.yaml
+++ b/components/workspaces/production/stone-prod-p02/kustomization.yaml
@@ -1,5 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- ../../team/kyverno
 - ../../team/migration

--- a/components/workspaces/staging/stone-stage-p01/kustomization.yaml
+++ b/components/workspaces/staging/stone-stage-p01/kustomization.yaml
@@ -1,5 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- ../../team/kyverno
 - ../../team/migration

--- a/components/workspaces/team/migration/kustomization.yaml
+++ b/components/workspaces/team/migration/kustomization.yaml
@@ -1,5 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- ../../team/kyverno
-- ../../team/migration
+- temp-workspace-team-rbac.yaml

--- a/components/workspaces/team/migration/temp-workspace-team-rbac.yaml
+++ b/components/workspaces/team/migration/temp-workspace-team-rbac.yaml
@@ -1,13 +1,11 @@
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: dperaza-role-temp
+  name: workspace-role-temp
 rules:
   - verbs:
       - get
       - list
-      - create
-      - delete
     apiGroups:
       - 'rbac.authorization.k8s.io'
     resources:
@@ -16,12 +14,12 @@ rules:
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: dperaza-role-binding-temp
+  name: workspace-role-binding-temp
 subjects:
   - apiGroup: rbac.authorization.k8s.io
-    kind: User
-    name: dperaza
+    kind: Group
+    name: konflux-tenant-ops
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: dperaza-role-temp
+  name: workspace-role-temp


### PR DESCRIPTION
Need this acces to be able to run and debug the migration tool before infra team applies the migrate role bindings.

Partially implements [ASC-726](https://issues.redhat.com//browse/ASC-726)