### PR TITLE
[KFLUXSPRT-1933] d320 VM flavors

### DIFF
--- a/components/multi-platform-controller/production-downstream/kflux-ocp-p01/host-config.yaml
+++ b/components/multi-platform-controller/production-downstream/kflux-ocp-p01/host-config.yaml
@@ -35,8 +35,10 @@ data:
     linux-c2xlarge/arm64,\
     linux-c4xlarge/amd64,\
     linux-d160-c4xlarge/amd64,\
+    linux-d320-c4xlarge/amd64,\
     linux-c4xlarge/arm64,\
     linux-d160-c4xlarge/arm64,\
+    linux-d320-c4xlarge/arm64,\
     linux-c8xlarge/amd64,\
     linux-c8xlarge/arm64,\
     linux-g6xlarge/amd64,\
@@ -45,8 +47,10 @@ data:
     linux/s390x,\
     linux-large/s390x,\
     linux-largecpu/s390x,\
+    linux-d320-largecpu/s390x,\
     linux/ppc64le,\
     linux-largecpu/ppc64le,\
+    linux-d320-largecpu/ppc64le,\
     linux-d200/ppc64le,\
     linux-large/ppc64le,\
     linux-d200-large/ppc64le\
@@ -410,6 +414,20 @@ data:
   dynamic.linux-d160-c4xlarge-arm64.allocation-timeout: "1200"
   dynamic.linux-d160-c4xlarge-arm64.disk: "160"
 
+  # Same as linux-c4xlarge-arm64, but with 320GB disk space
+  dynamic.linux-d320-c4xlarge-arm64.type: aws
+  dynamic.linux-d320-c4xlarge-arm64.region: us-east-1
+  dynamic.linux-d320-c4xlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-d320-c4xlarge-arm64.instance-type: c6g.4xlarge
+  dynamic.linux-d320-c4xlarge-arm64.key-name: kflux-ocp-p01-key-pair
+  dynamic.linux-d320-c4xlarge-arm64.aws-secret: aws-account
+  dynamic.linux-d320-c4xlarge-arm64.ssh-secret: aws-ssh-key
+  dynamic.linux-d320-c4xlarge-arm64.security-group-id: sg-0a1f3fdbbf7198922
+  dynamic.linux-d320-c4xlarge-arm64.max-instances: "100"
+  dynamic.linux-d320-c4xlarge-arm64.subnet-id: subnet-0864e71d16676bf7f
+  dynamic.linux-d320-c4xlarge-arm64.allocation-timeout: "1200"
+  dynamic.linux-d320-c4xlarge-arm64.disk: "320"
+
   dynamic.linux-c8xlarge-arm64.type: aws
   dynamic.linux-c8xlarge-arm64.region: us-east-1
   dynamic.linux-c8xlarge-arm64.ami: ami-03d6a5256a46c9feb
@@ -475,6 +493,20 @@ data:
   dynamic.linux-d160-c4xlarge-amd64.subnet-id: subnet-0864e71d16676bf7f
   dynamic.linux-d160-c4xlarge-amd64.allocation-timeout: "1200"
   dynamic.linux-d160-c4xlarge-amd64-arm64.disk: "160"
+
+  # Same as linux-c4xlarge-amd64, but with 320 GB storage
+  dynamic.linux-d320-c4xlarge-amd64.type: aws
+  dynamic.linux-d320-c4xlarge-amd64.region: us-east-1
+  dynamic.linux-d320-c4xlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-d320-c4xlarge-amd64.instance-type: c6a.4xlarge
+  dynamic.linux-d320-c4xlarge-amd64.key-name: kflux-ocp-p01-key-pair
+  dynamic.linux-d320-c4xlarge-amd64.aws-secret: aws-account
+  dynamic.linux-d320-c4xlarge-amd64.ssh-secret: aws-ssh-key
+  dynamic.linux-d320-c4xlarge-amd64.security-group-id: sg-0a1f3fdbbf7198922
+  dynamic.linux-d320-c4xlarge-amd64.max-instances: "100"
+  dynamic.linux-d320-c4xlarge-amd64.subnet-id: subnet-0864e71d16676bf7f
+  dynamic.linux-d320-c4xlarge-amd64.allocation-timeout: "1200"
+  dynamic.linux-d320-c4xlarge-amd64-arm64.disk: "320"
 
   dynamic.linux-c8xlarge-amd64.type: aws
   dynamic.linux-c8xlarge-amd64.region: us-east-1
@@ -630,6 +662,23 @@ data:
   dynamic.linux-largecpu-s390x.allocation-timeout: "1800"
   dynamic.linux-largecpu-s390x.instance-tag: prod-s390x-largecpu
 
+  # Same as linux-largecpu-s390x, but with 320 GB storage
+  dynamic.linux-d320-largecpu-s390x.type: ibmz
+  dynamic.linux-d320-largecpu-s390x.ssh-secret: "internal-prod-ibm-ssh-key"
+  dynamic.linux-d320-largecpu-s390x.secret: "internal-prod-ibm-api-key"
+  dynamic.linux-d320-largecpu-s390x.vpc: "konflux-internal-ocp-art-vpc"
+  dynamic.linux-d320-largecpu-s390x.key: "internal-prod-key"
+  dynamic.linux-d320-largecpu-s390x.subnet: "konflux-internal-ocp-art-vpc-subnet"
+  dynamic.linux-d320-largecpu-s390x.image-id: "r006-7af05e6b-b1cd-4467-8a37-770ce2094e8d"
+  dynamic.linux-d320-largecpu-s390x.region: "us-south-2"
+  dynamic.linux-d320-largecpu-s390x.url: "https://us-south.iaas.cloud.ibm.com/v1"
+  dynamic.linux-d320-largecpu-s390x.profile: "cz2-8x16"
+  dynamic.linux-d320-largecpu-s390x.max-instances: "5"
+  dynamic.linux-d320-largecpu-s390x.private-ip: "true"
+  dynamic.linux-d320-largecpu-s390x.allocation-timeout: "1800"
+  dynamic.linux-d320-largecpu-s390x.instance-tag: prod-s390x-largecpu
+  dynamic.linux-d320-largecpu-s390x.disk: "320"
+
   #PPC64LE dynamic nodes
   dynamic.linux-ppc64le.type: ibmp
   dynamic.linux-ppc64le.ssh-secret: "internal-prod-ibm-ssh-key"
@@ -694,6 +743,23 @@ data:
   dynamic.linux-largecpu-ppc64le.max-instances: "5"
   dynamic.linux-largecpu-ppc64le.allocation-timeout: "1800"
   dynamic.linux-largecpu-ppc64le.instance-tag: prod-ppc64le-largecpu
+
+  #PPC64LE CPU dynamic nodes
+  dynamic.linux-d320-largecpu-ppc64le.type: ibmp
+  dynamic.linux-d320-largecpu-ppc64le.ssh-secret: "internal-prod-ibm-ssh-key"
+  dynamic.linux-d320-largecpu-ppc64le.secret: "internal-prod-ibm-api-key"
+  dynamic.linux-d320-largecpu-ppc64le.key: "prod-konflux-infra"
+  dynamic.linux-d320-largecpu-ppc64le.image: "ppc64le-rhel-94-base-27nov2024"
+  dynamic.linux-d320-largecpu-ppc64le.crn: "crn:v1:bluemix:public:power-iaas:dal12:a/eebc7153d0c844f9915fb6f3b9850a3b:d6faf373-c0b6-4ba9-b0bc-4f7e0a74f9d5::"
+  dynamic.linux-d320-largecpu-ppc64le.url: "https://us-south.power-iaas.cloud.ibm.com"
+  dynamic.linux-d320-largecpu-ppc64le.network: "4d164943-b043-4c6e-bba5-d233abf66c6a"
+  dynamic.linux-d320-largecpu-ppc64le.system: "e980"
+  dynamic.linux-d320-largecpu-ppc64le.cores: "8"
+  dynamic.linux-d320-largecpu-ppc64le.memory: "16"
+  dynamic.linux-d320-largecpu-ppc64le.max-instances: "5"
+  dynamic.linux-d320-largecpu-ppc64le.allocation-timeout: "1800"
+  dynamic.linux-d320-largecpu-ppc64le.instance-tag: prod-ppc64le-largecpu
+  dynamic.linux-d320-largecpu-ppc64le.disk: "320"
 
   # Same as linux-large-ppc64le but with 200GB disk instead of default 100GB
   dynamic.linux-d200-large-ppc64le.type: ibmp

--- a/components/multi-platform-controller/production-downstream/kflux-ocp-p01/host-config.yaml
+++ b/components/multi-platform-controller/production-downstream/kflux-ocp-p01/host-config.yaml
@@ -676,7 +676,7 @@ data:
   dynamic.linux-d320-largecpu-s390x.max-instances: "5"
   dynamic.linux-d320-largecpu-s390x.private-ip: "true"
   dynamic.linux-d320-largecpu-s390x.allocation-timeout: "1800"
-  dynamic.linux-d320-largecpu-s390x.instance-tag: prod-s390x-largecpu
+  dynamic.linux-d320-largecpu-s390x.instance-tag: prod-s390x-d320-largecpu
   dynamic.linux-d320-largecpu-s390x.disk: "320"
 
   #PPC64LE dynamic nodes
@@ -758,7 +758,7 @@ data:
   dynamic.linux-d320-largecpu-ppc64le.memory: "16"
   dynamic.linux-d320-largecpu-ppc64le.max-instances: "5"
   dynamic.linux-d320-largecpu-ppc64le.allocation-timeout: "1800"
-  dynamic.linux-d320-largecpu-ppc64le.instance-tag: prod-ppc64le-largecpu
+  dynamic.linux-d320-largecpu-ppc64le.instance-tag: prod-ppc64le-d320-largecpu
   dynamic.linux-d320-largecpu-ppc64le.disk: "320"
 
   # Same as linux-large-ppc64le but with 200GB disk instead of default 100GB


### PR DESCRIPTION
New VM flavors for all arches, with 320 GB disk space