### PR TITLE
feat: Add a cluster role to manage periodic jobs resources

### DIFF
--- a/components/integration/base/manage-periodic-jobs.yaml
+++ b/components/integration/base/manage-periodic-jobs.yaml
@@ -1,0 +1,14 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: manage-periodic-jobs
+rules:
+  - apiGroups:
+      - "appstudio.redhat.com"
+    resources:
+      - "snapshots"
+      - "components"
+    verbs:
+      - "get"
+      - "list"
+      - "watch"


### PR DESCRIPTION
In order to run a job periodically we need to have permission:

* A service Account that will have roles to snapshot and components
* Access to cronjobs. Already done