### PR TITLE
don't filter namespace-lister from internal prod overlay

### DIFF
--- a/argo-cd-apps/overlays/production-downstream/delete-applications.yaml
+++ b/argo-cd-apps/overlays/production-downstream/delete-applications.yaml
@@ -59,11 +59,5 @@ $patch: delete
 apiVersion: argoproj.io/v1alpha1
 kind: ApplicationSet
 metadata:
-  name: namespace-lister
-$patch: delete
----
-apiVersion: argoproj.io/v1alpha1
-kind: ApplicationSet
-metadata:
   name: kyverno
 $patch: delete


### PR DESCRIPTION
The application set for namespace-lister is ready to go - don't filter it from the overlay.