### PR TITLE
ns-lister: apply prod overlay patch for prod deployments

### DIFF
--- a/argo-cd-apps/overlays/production-downstream/kustomization.yaml
+++ b/argo-cd-apps/overlays/production-downstream/kustomization.yaml
@@ -206,3 +206,8 @@ patches:
       kind: ApplicationSet
       version: v1alpha1
       name: cost-management
+  - path: production-overlay-patch.yaml
+    target:
+      kind: ApplicationSet
+      version: v1alpha1
+      name: namespace-lister


### PR DESCRIPTION
Without this patch, argocd tries to pull the production manifests from the staging environment, which is not correct.

Fixes #5634.