### PR TITLE
kubearchive: add generate kyverno policy

### DIFF
--- a/.github/workflows/kyverno-policies-tests.yaml
+++ b/.github/workflows/kyverno-policies-tests.yaml
@@ -1,0 +1,21 @@
+name: Run Kyverno tests
+
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  kyverno-test:
+    name: Run Kyverno tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Kyverno CLI
+        uses: kyverno/action-install-cli@v0.2.0
+        with:
+          release: 'v1.13.4'
+
+      - name: Run Kyverno Tests
+        run: |
+          kyverno test ./

--- a/components/kubearchive/development/kustomization.yaml
+++ b/components/kubearchive/development/kustomization.yaml
@@ -3,6 +3,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../base
+  - ../policies
   - postgresql.yaml
 
 secretGenerator:

--- a/components/kubearchive/policies/.chainsaw-test/chainsaw-assert-clusterpolicy.yaml
+++ b/components/kubearchive/policies/.chainsaw-test/chainsaw-assert-clusterpolicy.yaml
@@ -1,0 +1,9 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: init-ns-kubearchiveconfig
+status:
+  conditions:
+  - reason: Succeeded
+    status: "True"
+    type: Ready

--- a/components/kubearchive/policies/.chainsaw-test/chainsaw-test.yaml
+++ b/components/kubearchive/policies/.chainsaw-test/chainsaw-test.yaml
@@ -316,3 +316,49 @@ spec:
     - error:
         file: resources/expected-kubearchiveconfig.yaml
         template: true
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: mutate-existing-namespace-konflux-toolchain-existing-kubearchiveconfig
+spec:
+  description: |
+    tests that the KubeArchiveConfig is not updated in an already existing
+    namespace labelled with `konflux.ci/type=user` or `toolchain.dev.openshift.com/type=tenant`
+    where the KubeArchiveConfig already exists
+  concurrent: false
+  namespace: 'generate-existing-namespace'
+  bindings:
+  - name: suffix
+    value: konflux-toolchain
+  steps:
+  - name: given-kubearchiveconfig-crd-exists
+    try:
+    - apply:
+        file: resources/kubearchive-crd.yaml
+  - name: given-kyverno-has-permission-on-resources
+    try:
+    - apply:
+        file: ../kyverno_rbac.yaml
+  - name: given-konfluxci-toolchain-labeled-namespace-is-created
+    try:
+    - apply:
+        file: resources/actual-namespace-konflux-toolchain.yaml
+        template: true
+  - name: given-kubearchiveconfig-is-created
+    try:
+    - apply:
+        file: resources/actual-kubeconfig-archive.yaml
+        template: true
+  - name: when-cluster-policy-is-ready
+    try:
+    - apply:
+        file: ../bootstrap-namespace.yaml
+    - assert:
+        file: chainsaw-assert-clusterpolicy.yaml
+  - name: then-kubearchiveconfig-is-not-changed
+    try:
+    - assert:
+        file: resources/actual-kubeconfig-archive.yaml
+        template: true

--- a/components/kubearchive/policies/.chainsaw-test/chainsaw-test.yaml
+++ b/components/kubearchive/policies/.chainsaw-test/chainsaw-test.yaml
@@ -1,0 +1,318 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: mutate-new-namespace-konflux
+spec:
+  description: |
+    tests that the KubeArchiveConfig is created in a namespace
+    labelled with `konflux.ci/type=user`
+  concurrent: false
+  namespace: 'generate-new-namespace'
+  bindings:
+  - name: suffix
+    value: konflux
+  steps:
+  - name: given-kubearchiveconfig-crd-exists
+    try:
+    - apply:
+        file: resources/kubearchive-crd.yaml
+  - name: given-kyverno-has-permission-on-resources
+    try:
+    - apply:
+        file: ../kyverno_rbac.yaml
+  - name: given-cluster-policy-is-ready
+    try:
+    - apply:
+        file: ../bootstrap-namespace.yaml
+    - assert:
+        file: chainsaw-assert-clusterpolicy.yaml
+  - name: when-konfluxci-labeled-namespace-is-created
+    try:
+    - apply:
+        file: resources/actual-namespace-konflux.yaml
+        template: true
+  - name: then-kubearchiveconfig-is-created
+    try:
+    - assert:
+        file: resources/expected-kubearchiveconfig.yaml
+        template: true
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: mutate-new-namespace-toolchain
+spec:
+  description: |
+    tests that the KubeArchiveConfig is created in a namespace
+    labelled with `toolchain.dev.openshift.com/type=tenant`
+  concurrent: false
+  namespace: 'generate-new-namespace'
+  bindings:
+  - name: suffix
+    value: toolchain
+  steps:
+  - name: given-kubearchiveconfig-crd-exists
+    try:
+    - apply:
+        file: resources/kubearchive-crd.yaml
+  - name: given-kyverno-has-permission-on-resources
+    try:
+    - apply:
+        file: ../kyverno_rbac.yaml
+  - name: given-cluster-policy-is-ready
+    try:
+    - apply:
+        file: ../bootstrap-namespace.yaml
+    - assert:
+        file: chainsaw-assert-clusterpolicy.yaml
+  - name: when-toolchain-labeled-namespace-is-created
+    try:
+    - apply:
+        file: resources/actual-namespace-toolchain.yaml
+        template: true
+  - name: then-kubearchiveconfig-is-created
+    try:
+    - assert:
+        file: resources/expected-kubearchiveconfig.yaml
+        template: true
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: mutate-new-namespace-konflux-toolchain
+spec:
+  description: |
+    tests that the KubeArchiveConfig is created in a namespace labelled 
+    with `konflux.ci/type=user` or `toolchain.dev.openshift.com/type=tenant`
+  concurrent: false
+  namespace: 'generate-new-namespace'
+  bindings:
+  - name: suffix
+    value: konflux-toolchain
+  steps:
+  - name: given-kubearchiveconfig-crd-exists
+    try:
+    - apply:
+        file: resources/kubearchive-crd.yaml
+  - name: given-kyverno-has-permission-on-resources
+    try:
+    - apply:
+        file: ../kyverno_rbac.yaml
+  - name: given-cluster-policy-is-ready
+    try:
+    - apply:
+        file: ../bootstrap-namespace.yaml
+    - assert:
+        file: chainsaw-assert-clusterpolicy.yaml
+  - name: when-konfluxci-toolchain-labeled-namespace-is-created
+    try:
+    - apply:
+        file: resources/actual-namespace-konflux-toolchain.yaml
+        template: true
+  - name: then-kubearchiveconfig-is-created
+    try:
+    - assert:
+        file: resources/expected-kubearchiveconfig.yaml
+        template: true
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: mutate-new-namespace-unlabelled
+spec:
+  description: |
+    tests that the KubeArchiveConfig is NOT created in an unlabelled namespace
+  concurrent: false
+  namespace: 'generate-new-namespace'
+  bindings:
+  - name: suffix
+    value: unlabelled
+  steps:
+  - name: given-kubearchiveconfig-crd-exists
+    try:
+    - apply:
+        file: resources/kubearchive-crd.yaml
+  - name: given-kyverno-has-permission-on-resources
+    try:
+    - apply:
+        file: ../kyverno_rbac.yaml
+  - name: given-cluster-policy-is-ready
+    try:
+    - apply:
+        file: ../bootstrap-namespace.yaml
+    - assert:
+        file: chainsaw-assert-clusterpolicy.yaml
+  - name: when-unlabeled-namespace-is-created
+    try:
+    - apply:
+        file: resources/actual-namespace-konflux-toolchain.yaml
+        template: true
+  - name: then-kubearchiveconfig-is-created
+    try:
+    - error:
+        file: resources/expected-kubearchiveconfig.yaml
+        template: true
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: mutate-existing-namespace-konflux
+spec:
+  description: |
+    tests that the KubeArchiveConfig is created in an already existing
+    namespace labelled with `konflux.ci/type=user`
+  concurrent: false
+  namespace: 'generate-existing-namespace'
+  bindings:
+  - name: suffix
+    value: konflux
+  steps:
+  - name: given-kubearchiveconfig-crd-exists
+    try:
+    - apply:
+        file: resources/kubearchive-crd.yaml
+  - name: given-kyverno-has-permission-on-resources
+    try:
+    - apply:
+        file: ../kyverno_rbac.yaml
+  - name: given-konfluxci-labeled-namespace-is-created
+    try:
+    - apply:
+        file: resources/actual-namespace-konflux.yaml
+        template: true
+  - name: when-cluster-policy-is-ready
+    try:
+    - apply:
+        file: ../bootstrap-namespace.yaml
+    - assert:
+        file: chainsaw-assert-clusterpolicy.yaml
+  - name: then-kubearchiveconfig-is-created
+    try:
+    - assert:
+        file: resources/expected-kubearchiveconfig.yaml
+        template: true
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: mutate-existing-namespace-toolchain
+spec:
+  description: |
+    tests that the KubeArchiveConfig is created in an already existing
+    namespace labelled with `toolchain.dev.openshift.com/type=tenant`
+  concurrent: false
+  namespace: 'generate-existing-namespace'
+  bindings:
+  - name: suffix
+    value: toolchain
+  steps:
+  - name: given-kubearchiveconfig-crd-exists
+    try:
+    - apply:
+        file: resources/kubearchive-crd.yaml
+  - name: given-kyverno-has-permission-on-resources
+    try:
+    - apply:
+        file: ../kyverno_rbac.yaml
+  - name: given-toolchain-labeled-namespace-is-created
+    try:
+    - apply:
+        file: resources/actual-namespace-toolchain.yaml
+        template: true
+  - name: when-cluster-policy-is-ready
+    try:
+    - apply:
+        file: ../bootstrap-namespace.yaml
+    - assert:
+        file: chainsaw-assert-clusterpolicy.yaml
+  - name: then-kubearchiveconfig-is-created
+    try:
+    - assert:
+        file: resources/expected-kubearchiveconfig.yaml
+        template: true
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: mutate-existing-namespace-konflux-toolchain
+spec:
+  description: |
+    tests that the KubeArchiveConfig is created in an already existing
+    namespace labelled with `konflux.ci/type=user` or `toolchain.dev.openshift.com/type=tenant`
+  concurrent: false
+  namespace: 'generate-existing-namespace'
+  bindings:
+  - name: suffix
+    value: konflux-toolchain
+  steps:
+  - name: given-kubearchiveconfig-crd-exists
+    try:
+    - apply:
+        file: resources/kubearchive-crd.yaml
+  - name: given-kyverno-has-permission-on-resources
+    try:
+    - apply:
+        file: ../kyverno_rbac.yaml
+  - name: given-konfluxci-toolchain-labeled-namespace-is-created
+    try:
+    - apply:
+        file: resources/actual-namespace-konflux-toolchain.yaml
+        template: true
+  - name: when-cluster-policy-is-ready
+    try:
+    - apply:
+        file: ../bootstrap-namespace.yaml
+    - assert:
+        file: chainsaw-assert-clusterpolicy.yaml
+  - name: then-kubearchiveconfig-is-created
+    try:
+    - assert:
+        file: resources/expected-kubearchiveconfig.yaml
+        template: true
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: mutate-existing-namespace-unlabelled
+spec:
+  description: |
+    tests that the KubeArchiveConfig is NOT created in an 
+    existing unlabelled namespace
+  concurrent: false
+  namespace: 'generate-existing-namespace'
+  bindings:
+  - name: suffix
+    value: unlabelled
+  steps:
+  - name: given-kubearchiveconfig-crd-exists
+    try:
+    - apply:
+        file: resources/kubearchive-crd.yaml
+  - name: given-kyverno-has-permission-on-resources
+    try:
+    - apply:
+        file: ../kyverno_rbac.yaml
+  - name: given-unlabeled-namespace-is-created
+    try:
+    - apply:
+        file: resources/actual-namespace-konflux-toolchain.yaml
+        template: true
+  - name: when-cluster-policy-is-ready
+    try:
+    - apply:
+        file: ../bootstrap-namespace.yaml
+    - assert:
+        file: chainsaw-assert-clusterpolicy.yaml
+  - name: then-kubearchiveconfig-is-created
+    try:
+    - error:
+        file: resources/expected-kubearchiveconfig.yaml
+        template: true

--- a/components/kubearchive/policies/.chainsaw-test/resources/actual-kubeconfig-archive.yaml
+++ b/components/kubearchive/policies/.chainsaw-test/resources/actual-kubeconfig-archive.yaml
@@ -1,0 +1,11 @@
+apiVersion: kubearchive.kubearchive.org/v1alpha1
+kind: KubeArchiveConfig
+metadata:
+  name: kubearchive
+  namespace: (join('-', [$namespace, $suffix]))
+spec:
+  resources:
+    - selector:
+        apiVersion: v1
+        kind: Pod
+      archiveOnDelete: "true"

--- a/components/kubearchive/policies/.chainsaw-test/resources/actual-namespace-konflux-toolchain.yaml
+++ b/components/kubearchive/policies/.chainsaw-test/resources/actual-namespace-konflux-toolchain.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: (join('-', [$namespace, $suffix]))
+  labels:
+    konflux.ci/type: user
+    toolchain.dev.openshift.com/type: tenant

--- a/components/kubearchive/policies/.chainsaw-test/resources/actual-namespace-konflux.yaml
+++ b/components/kubearchive/policies/.chainsaw-test/resources/actual-namespace-konflux.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: (join('-', [$namespace, $suffix]))
+  labels:
+    konflux.ci/type: user

--- a/components/kubearchive/policies/.chainsaw-test/resources/actual-namespace-toolchain.yaml
+++ b/components/kubearchive/policies/.chainsaw-test/resources/actual-namespace-toolchain.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: (join('-', [$namespace, $suffix]))
+  labels:
+    toolchain.dev.openshift.com/type: tenant

--- a/components/kubearchive/policies/.chainsaw-test/resources/actual-namespace-unlabeled.yaml
+++ b/components/kubearchive/policies/.chainsaw-test/resources/actual-namespace-unlabeled.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: (join('-', [$namespace, $suffix]))

--- a/components/kubearchive/policies/.chainsaw-test/resources/expected-kubearchiveconfig.yaml
+++ b/components/kubearchive/policies/.chainsaw-test/resources/expected-kubearchiveconfig.yaml
@@ -1,0 +1,7 @@
+apiVersion: kubearchive.kubearchive.org/v1alpha1
+kind: KubeArchiveConfig
+metadata:
+  name: kubearchive
+  namespace: (join('-', [$namespace, $suffix]))
+spec:
+  resources: []

--- a/components/kubearchive/policies/.chainsaw-test/resources/kubearchive-crd.yaml
+++ b/components/kubearchive/policies/.chainsaw-test/resources/kubearchive-crd.yaml
@@ -1,0 +1,138 @@
+# Source: kubearchive-helm/crds/kubearchive.kubearchive.org_kubearchiveconfigs.yaml
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+    cert-manager.io/inject-ca-from: kubearchive/kubearchive-operator-certificate
+  name: kubearchiveconfigs.kubearchive.kubearchive.org
+spec:
+  group: kubearchive.kubearchive.org
+  names:
+    kind: KubeArchiveConfig
+    listKind: KubeArchiveConfigList
+    plural: kubearchiveconfigs
+    shortNames:
+      - kac
+      - kacs
+    singular: kubearchiveconfig
+  scope: Namespaced
+  versions:
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: KubeArchiveConfig is the Schema for the kubearchiveconfigs API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: KubeArchiveConfigSpec defines the desired state of KubeArchiveConfig
+              properties:
+                resources:
+                  items:
+                    properties:
+                      archiveOnDelete:
+                        type: string
+                      archiveWhen:
+                        type: string
+                      deleteWhen:
+                        type: string
+                      selector:
+                        description: APIVersionKindSelector is an APIVersion Kind tuple with a LabelSelector.
+                        properties:
+                          apiVersion:
+                            description: APIVersion - the API version of the resource to watch.
+                            type: string
+                          kind:
+                            description: |-
+                              Kind of the resource to watch.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                            type: string
+                          selector:
+                            description: |-
+                              LabelSelector filters this source to objects to those resources pass the
+                              label selector.
+                              More info: http://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                items:
+                                  description: |-
+                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector applies to.
+                                      type: string
+                                    operator:
+                                      description: |-
+                                        operator represents a key's relationship to a set of values.
+                                        Valid operators are In, NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: |-
+                                        values is an array of string values. If the operator is In or NotIn,
+                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                        the values array must be empty. This array is replaced during a strategic
+                                        merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  required:
+                                    - key
+                                    - operator
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                type: object
+                            type: object
+                            x-kubernetes-map-type: atomic
+                        required:
+                          - apiVersion
+                          - kind
+                        type: object
+                    type: object
+                  type: array
+              type: object
+            status:
+              description: KubeArchiveConfigStatus defines the observed state of KubeArchiveConfig
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          namespace: kubearchive
+          name: webhook-service
+          path: /convert
+      conversionReviewVersions:
+        - v1

--- a/components/kubearchive/policies/.kyverno-test/kyverno-test.yaml
+++ b/components/kubearchive/policies/.kyverno-test/kyverno-test.yaml
@@ -1,0 +1,24 @@
+apiVersion: cli.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: bootstrap-existing-namespaces
+policies:
+- ../bootstrap-namespace.yaml
+resources:
+- ../resources/labeled-namespace-konflux.yaml
+- ../resources/labeled-namespace-toolchain.yaml
+results:
+- policy: init-ns-kubearchiveconfig
+  generatedResource: ../resources/expected-kubearchiveconfig-konflux.yaml
+  kind: Namespace
+  resources:
+  - labeled-namespace-konflux
+  result: pass
+  rule: init-ns-kubearchiveconfig
+- policy: init-ns-kubearchiveconfig
+  generatedresource: ../resources/expected-kubearchiveconfig-toolchain.yaml
+  kind: Namespace
+  resources:
+  - labeled-namespace-toolchain
+  result: pass
+  rule: init-ns-kubearchiveconfig

--- a/components/kubearchive/policies/bootstrap-namespace.yaml
+++ b/components/kubearchive/policies/bootstrap-namespace.yaml
@@ -1,0 +1,37 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: init-ns-kubearchiveconfig
+spec:
+  rules:
+  - name: init-ns-kubearchiveconfig
+    match:
+      any:
+      - resources:
+          kinds:
+          - Namespace
+          selector:
+            matchExpressions:
+            - key: toolchain.dev.openshift.com/type
+              operator: In
+              values:
+              - tenant
+      - resources:
+          kinds:
+          - Namespace
+          selector:
+            matchExpressions:
+            - key: konflux.ci/type
+              operator: In
+              values:
+              - user
+    generate:
+      generateExisting: true
+      apiVersion: kubearchive.kubearchive.org/v1alpha1
+      kind: KubeArchiveConfig
+      name: kubearchive
+      namespace: '{{request.object.metadata.name}}'
+      synchronize: false
+      data:
+        spec:
+          resources: []

--- a/components/kubearchive/policies/bootstrap-namespace.yaml
+++ b/components/kubearchive/policies/bootstrap-namespace.yaml
@@ -11,20 +11,14 @@ spec:
           kinds:
           - Namespace
           selector:
-            matchExpressions:
-            - key: toolchain.dev.openshift.com/type
-              operator: In
-              values:
-              - tenant
+            matchLabels:
+              toolchain.dev.openshift.com/type: tenant
       - resources:
           kinds:
           - Namespace
           selector:
-            matchExpressions:
-            - key: konflux.ci/type
-              operator: In
-              values:
-              - user
+            matchLabels:
+              konflux.ci/type: user
     generate:
       generateExisting: true
       apiVersion: kubearchive.kubearchive.org/v1alpha1

--- a/components/kubearchive/policies/kustomization.yaml
+++ b/components/kubearchive/policies/kustomization.yaml
@@ -2,3 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - bootstrap-namespace.yaml
+- kyverno_rbac.yaml

--- a/components/kubearchive/policies/kustomization.yaml
+++ b/components/kubearchive/policies/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- bootstrap-namespace.yaml

--- a/components/kubearchive/policies/kyverno_rbac.yaml
+++ b/components/kubearchive/policies/kyverno_rbac.yaml
@@ -1,0 +1,55 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: read-kubearchiveconfig
+rules:
+- apiGroups:
+  - kubearchive.kubearchive.org
+  resources:
+  - kubearchiveconfigs
+  verbs:
+  - list
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kyverno-admission-controller:read-kubearchiveconfig
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: read-kubearchiveconfig
+subjects:
+- kind: ServiceAccount
+  name: kyverno-admission-controller
+  namespace: konflux-kyverno
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: manage-kubearchiveconfig
+rules:
+- apiGroups:
+  - kubearchive.kubearchive.org
+  resources:
+  - kubearchiveconfigs
+  verbs:
+  - create
+  - get
+  - list
+  - delete
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kyverno-background-controller:manage-kubearchiveconfig
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: manage-kubearchiveconfig
+subjects:
+- kind: ServiceAccount
+  name: kyverno-background-controller
+  namespace: konflux-kyverno

--- a/components/kubearchive/policies/kyverno_rbac.yaml
+++ b/components/kubearchive/policies/kyverno_rbac.yaml
@@ -2,7 +2,9 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: read-kubearchiveconfig
+  name: kyverno-read-kubearchiveconfig
+  labels:
+    rbac.kyverno.io/aggregate-to-admission-controller: "true"
 rules:
 - apiGroups:
   - kubearchive.kubearchive.org
@@ -13,22 +15,11 @@ rules:
   - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: kyverno-admission-controller:read-kubearchiveconfig
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: read-kubearchiveconfig
-subjects:
-- kind: ServiceAccount
-  name: kyverno-admission-controller
-  namespace: konflux-kyverno
----
-apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: manage-kubearchiveconfig
+  name: kyverno-manage-kubearchiveconfig
+  labels:
+    rbac.kyverno.io/aggregate-to-background-controller: "true"
 rules:
 - apiGroups:
   - kubearchive.kubearchive.org
@@ -40,16 +31,3 @@ rules:
   - list
   - delete
   - update
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: kyverno-background-controller:manage-kubearchiveconfig
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: manage-kubearchiveconfig
-subjects:
-- kind: ServiceAccount
-  name: kyverno-background-controller
-  namespace: konflux-kyverno

--- a/components/kubearchive/policies/resources/expected-kubearchiveconfig-konflux.yaml
+++ b/components/kubearchive/policies/resources/expected-kubearchiveconfig-konflux.yaml
@@ -1,0 +1,7 @@
+apiVersion: kubearchive.kubearchive.org/v1alpha1
+kind: KubeArchiveConfig
+metadata:
+  name: kubearchive
+  namespace: labeled-namespace-konflux
+spec:
+  resources: []

--- a/components/kubearchive/policies/resources/expected-kubearchiveconfig-toolchain.yaml
+++ b/components/kubearchive/policies/resources/expected-kubearchiveconfig-toolchain.yaml
@@ -1,0 +1,7 @@
+apiVersion: kubearchive.kubearchive.org/v1alpha1
+kind: KubeArchiveConfig
+metadata:
+  name: kubearchive
+  namespace: labeled-namespace-toolchain
+spec:
+  resources: []

--- a/components/kubearchive/policies/resources/labeled-namespace-konflux.yaml
+++ b/components/kubearchive/policies/resources/labeled-namespace-konflux.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: labeled-namespace-konflux
+  labels:
+    konflux.ci/type: user

--- a/components/kubearchive/policies/resources/labeled-namespace-toolchain.yaml
+++ b/components/kubearchive/policies/resources/labeled-namespace-toolchain.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: labeled-namespace-toolchain
+  labels:
+    toolchain.dev.openshift.com/type: tenant

--- a/components/kubearchive/staging/kustomization.yaml
+++ b/components/kubearchive/staging/kustomization.yaml
@@ -3,6 +3,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../base
+  - ../policies
   - database-secret.yaml
 
 commonAnnotations:


### PR DESCRIPTION
This PR introduces a Kyverno policy in the development overlay to generate a KubeArchiveConfig in each tenant namespace.

As of now, tenant namespaces are labeled with either `toolchain.dev.openshift.com/type=tenant` or `konflux.ci/type=user`.

The PR also introduces a GitHub Action executing tests to validate the behavior of the proposed Generate Policy and provides to Kyverno the permissions required to generate the KubeArchiveConfigs.
