### PR TITLE
bump namespace-lister to latest version in staging

### DIFF
--- a/components/namespace-lister/base/kustomization.yaml
+++ b/components/namespace-lister/base/kustomization.yaml
@@ -11,7 +11,7 @@ namespace: namespace-lister
 images:
 - name: namespace-lister
   newName: quay.io/konflux-ci/namespace-lister
-  newTag: 1181ecb4ba10d6fbe5ea7bb94393b04cb2a932f8
+  newTag: 496127e2571f72a56ccb8c01e358129e7a42d510
 patches:
 - path: ./patches/with_cachenamespacelabelselector.yaml
   target:


### PR DESCRIPTION
Main changes released by this bump are releated to cache instrumentation and to dependencies.

## Feature
* https://github.com/konflux-ci/namespace-lister/pull/79

## Tests
* https://github.com/konflux-ci/namespace-lister/pull/69
* https://github.com/konflux-ci/namespace-lister/pull/59
* https://github.com/konflux-ci/namespace-lister/pull/65

## Maintenance
* https://github.com/konflux-ci/namespace-lister/pull/60

## Dependencies
* https://github.com/konflux-ci/namespace-lister/pull/80
* https://github.com/konflux-ci/namespace-lister/pull/73
* https://github.com/konflux-ci/namespace-lister/pull/70
* https://github.com/konflux-ci/namespace-lister/pull/77
* https://github.com/konflux-ci/namespace-lister/pull/75
* https://github.com/konflux-ci/namespace-lister/pull/78
* https://github.com/konflux-ci/namespace-lister/pull/76
* https://github.com/konflux-ci/namespace-lister/pull/72
* https://github.com/konflux-ci/namespace-lister/pull/67
* https://github.com/konflux-ci/namespace-lister/pull/68
* https://github.com/konflux-ci/namespace-lister/pull/63
* https://github.com/konflux-ci/namespace-lister/pull/66

Signed-off-by: Francesco Ilario <filario@redhat.com>
