### PR TITLE
bump namespace-lister to latest version in production

### DIFF
--- a/components/namespace-lister/production/base/kustomization.yaml
+++ b/components/namespace-lister/production/base/kustomization.yaml
@@ -11,7 +11,7 @@ namespace: namespace-lister
 images:
 - name: namespace-lister
   newName: quay.io/konflux-ci/namespace-lister
-  newTag: 1181ecb4ba10d6fbe5ea7bb94393b04cb2a932f8
+  newTag: 35d579c298bf593105d217606da6db0e56d757ba
 patches:
 - path: ./patches/with_cachenamespacelabelselector.yaml
   target:


### PR DESCRIPTION
Main changes released by this bump are releated to cache instrumentation and to dependencies.

Requires:
* [x] #5651

Signed-off-by: Francesco Ilario <filario@redhat.com>
