### PR TITLE
[OCP] update IBM tags

### DIFF
--- a/components/multi-platform-controller/production-downstream/kflux-ocp-p01/host-config.yaml
+++ b/components/multi-platform-controller/production-downstream/kflux-ocp-p01/host-config.yaml
@@ -680,7 +680,7 @@ data:
   dynamic.linux-d320-largecpu-s390x.max-instances: "5"
   dynamic.linux-d320-largecpu-s390x.private-ip: "true"
   dynamic.linux-d320-largecpu-s390x.allocation-timeout: "1800"
-  dynamic.linux-d320-largecpu-s390x.instance-tag: prod-s390x-d320-largecpu
+  dynamic.linux-d320-largecpu-s390x.instance-tag: s390x-d320
   dynamic.linux-d320-largecpu-s390x.disk: "320"
 
   #PPC64LE dynamic nodes
@@ -762,7 +762,7 @@ data:
   dynamic.linux-d320-largecpu-ppc64le.memory: "16"
   dynamic.linux-d320-largecpu-ppc64le.max-instances: "5"
   dynamic.linux-d320-largecpu-ppc64le.allocation-timeout: "1800"
-  dynamic.linux-d320-largecpu-ppc64le.instance-tag: prod-ppc64le-d320-largecpu
+  dynamic.linux-d320-largecpu-ppc64le.instance-tag: ppc64le-d320
   dynamic.linux-d320-largecpu-ppc64le.disk: "320"
 
   # Same as linux-large-ppc64le but with 200GB disk instead of default 100GB


### PR DESCRIPTION
Testing to see if a shorter tag name will prevent this error from popping up
```
step-build

mkdir -p ~/.ssh
if [ -e "/ssh/error" ]; then
  #no server could be provisioned
  cat /ssh/error
  exit 1
fi
Error allocating host: bad request

Context info:
  Platform: linux-d320-largecpu/ppc64le
  File:     /opt/app-root/src/pkg/reconciler/taskrun/taskrun.go
  Line:     457
```

ref [thread](https://redhat-internal.slack.com/archives/C06Q309QUDV/p1740584497902059?thread_ts=1740531053.708299&cid=C06Q309QUDV) for details