### PR TITLE
Add cost-management staging external secret

### DIFF
--- a/components/cost-management/base/external-service-account-secret.yaml
+++ b/components/cost-management/base/external-service-account-secret.yaml
@@ -1,0 +1,19 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: konflux-service-account
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  dataFrom:
+    - extract:
+        key: # will be added by the overlays
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: appsre-stonesoup-vault
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    name: konflux-service-account

--- a/components/cost-management/staging/cost-mangement-external-secret-patch.yaml
+++ b/components/cost-management/staging/cost-mangement-external-secret-patch.yaml
@@ -1,0 +1,4 @@
+---
+- op: add
+  path: /spec/dataFrom/0/extract/key
+  value: staging/cost-management/konflux-service-account

--- a/components/cost-management/staging/kflux-stg-es01/cost-management-config-source-patch.yaml
+++ b/components/cost-management/staging/kflux-stg-es01/cost-management-config-source-patch.yaml
@@ -1,4 +1,10 @@
 ---
 - op: add
   path: /spec/source/name
-  value: konflux-stg-es01
+  value: kflux-stg-es01
+- op: replace
+  path: /spec/authentication/type
+  value: service-account
+- op: add
+  path: /spec/authentication/secret_name
+  value: konflux-service-account

--- a/components/cost-management/staging/kustomization.yaml
+++ b/components/cost-management/staging/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../base
+
+patches:
+  - path: cost-mangement-external-secret-patch.yaml
+    target:
+      name: konflux-service-account
+      kind: ExternalSecret
+      group: external-secrets.io
+      version: v1beta1

--- a/components/cost-management/staging/stone-stage-p01/cost-management-config-source-patch.yaml
+++ b/components/cost-management/staging/stone-stage-p01/cost-management-config-source-patch.yaml
@@ -1,4 +1,10 @@
 ---
 - op: add
   path: /spec/source/name
-  value: konflux-stage-p01
+  value: stone-stage-p01
+- op: replace
+  path: /spec/authentication/type
+  value: service-account
+- op: add
+  path: /spec/authentication/secret_name
+  value: konflux-service-account

--- a/components/cost-management/staging/stone-stg-host/cost-management-config-source-patch.yaml
+++ b/components/cost-management/staging/stone-stg-host/cost-management-config-source-patch.yaml
@@ -1,4 +1,10 @@
 ---
 - op: add
   path: /spec/source/name
-  value: konflux-stg-host
+  value: stone-stg-host
+- op: replace
+  path: /spec/authentication/type
+  value: service-account
+- op: add
+  path: /spec/authentication/secret_name
+  value: konflux-service-account

--- a/components/cost-management/staging/stone-stg-rh01/cost-management-config-source-patch.yaml
+++ b/components/cost-management/staging/stone-stg-rh01/cost-management-config-source-patch.yaml
@@ -1,4 +1,10 @@
 ---
 - op: add
   path: /spec/source/name
-  value: konflux-stg-rh01
+  value: stone-stg-rh01
+- op: replace
+  path: /spec/authentication/type
+  value: service-account
+- op: add
+  path: /spec/authentication/secret_name
+  value: konflux-service-account


### PR DESCRIPTION
PVO11Y-4650 - This is required to enable access the Konflux clusters data via service account to avoid needing OCM permissions. 

This should be merged after - https://issues.redhat.com/browse/KFLUXINFRA-1307