### PR TITLE
Add cost-management prod external secret

### DIFF
--- a/components/cost-management/base/kustomization.yaml
+++ b/components/cost-management/base/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
   - costmanagement-metrics-operator.yaml
   - costmanagement-metrics-config.yaml
+  - external-service-account-secret.yaml
 
 commonAnnotations:
   argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true

--- a/components/cost-management/production/cost-mangement-external-secret-patch.yaml
+++ b/components/cost-management/production/cost-mangement-external-secret-patch.yaml
@@ -1,0 +1,4 @@
+---
+- op: add
+  path: /spec/dataFrom/0/extract/key
+  value: production/cost-management/konflux-service-account

--- a/components/cost-management/production/kflux-ocp-p01/cost-management-config-source-patch.yaml
+++ b/components/cost-management/production/kflux-ocp-p01/cost-management-config-source-patch.yaml
@@ -1,4 +1,10 @@
 ---
 - op: add
   path: /spec/source/name
-  value: konflux-ocp-p01
+  value: kflux-ocp-p01
+- op: replace
+  path: /spec/authentication/type
+  value: service-account
+- op: add
+  path: /spec/authentication/secret_name
+  value: konflux-service-account

--- a/components/cost-management/production/kflux-prd-es01/cost-management-config-source-patch.yaml
+++ b/components/cost-management/production/kflux-prd-es01/cost-management-config-source-patch.yaml
@@ -1,4 +1,10 @@
 ---
 - op: add
   path: /spec/source/name
-  value: konflux-prd-es01
+  value: kflux-prd-es01
+- op: replace
+  path: /spec/authentication/type
+  value: service-account
+- op: add
+  path: /spec/authentication/secret_name
+  value: konflux-service-account

--- a/components/cost-management/production/kustomization.yaml
+++ b/components/cost-management/production/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../base
+
+patches:
+  - path: cost-mangement-external-secret-patch.yaml
+    target:
+      name: konflux-service-account
+      kind: ExternalSecret
+      group: external-secrets.io
+      version: v1beta1

--- a/components/cost-management/production/stone-prd-host1/cost-management-config-source-patch.yaml
+++ b/components/cost-management/production/stone-prd-host1/cost-management-config-source-patch.yaml
@@ -1,4 +1,10 @@
 ---
 - op: add
   path: /spec/source/name
-  value: konflux-prd-host1
+  value: stone-prd-host1
+- op: replace
+  path: /spec/authentication/type
+  value: service-account
+- op: add
+  path: /spec/authentication/secret_name
+  value: konflux-service-account

--- a/components/cost-management/production/stone-prd-rh01/cost-management-config-source-patch.yaml
+++ b/components/cost-management/production/stone-prd-rh01/cost-management-config-source-patch.yaml
@@ -1,4 +1,10 @@
 ---
 - op: add
   path: /spec/source/name
-  value: konflux-prd-rh01
+  value: stone-prd-rh01
+- op: replace
+  path: /spec/authentication/type
+  value: service-account
+- op: add
+  path: /spec/authentication/secret_name
+  value: konflux-service-account

--- a/components/cost-management/production/stone-prd-rh02/cost-management-config-source-patch.yaml
+++ b/components/cost-management/production/stone-prd-rh02/cost-management-config-source-patch.yaml
@@ -1,4 +1,10 @@
 ---
 - op: add
   path: /spec/source/name
-  value: konflux-prd-rh02
+  value: stone-prd-rh02
+- op: replace
+  path: /spec/authentication/type
+  value: service-account
+- op: add
+  path: /spec/authentication/secret_name
+  value: konflux-service-account

--- a/components/cost-management/production/stone-prod-p01/cost-management-config-source-patch.yaml
+++ b/components/cost-management/production/stone-prod-p01/cost-management-config-source-patch.yaml
@@ -1,4 +1,10 @@
 ---
 - op: add
   path: /spec/source/name
-  value: konflux-prod-p01
+  value: stone-prod-p01
+- op: replace
+  path: /spec/authentication/type
+  value: service-account
+- op: add
+  path: /spec/authentication/secret_name
+  value: konflux-service-account

--- a/components/cost-management/production/stone-prod-p02/cost-management-config-source-patch.yaml
+++ b/components/cost-management/production/stone-prod-p02/cost-management-config-source-patch.yaml
@@ -1,4 +1,10 @@
 ---
 - op: add
   path: /spec/source/name
-  value: konflux-prod-p02
+  value: stone-prod-p02
+- op: replace
+  path: /spec/authentication/type
+  value: service-account
+- op: add
+  path: /spec/authentication/secret_name
+  value: konflux-service-account


### PR DESCRIPTION
PVO11Y-4650 - This is required to enable access to the production Konflux clusters data via the service account to avoid needing OCM permissions.

This should be merged after - https://issues.redhat.com/browse/KFLUXINFRA-1309

