### PR TITLE
PVO11Y-4655 - Update COO channel to stable

### DIFF
--- a/components/monitoring/prometheus/base/observability-operator/observability-operator.yaml
+++ b/components/monitoring/prometheus/base/observability-operator/observability-operator.yaml
@@ -13,7 +13,7 @@ metadata:
   name: cluster-observability-operator
   namespace: appstudio-monitoring
 spec:
-  channel: development
+  channel: stable
   installPlanApproval: Automatic
   name: cluster-observability-operator
   source: redhat-operators


### PR DESCRIPTION
Red Hat catalog provides the COO operator now has a stable channel only.