### PR TITLE
[OCP] increase linux-ppc64le max-instances

### DIFF
--- a/components/multi-platform-controller/production-downstream/kflux-ocp-p01/host-config.yaml
+++ b/components/multi-platform-controller/production-downstream/kflux-ocp-p01/host-config.yaml
@@ -695,7 +695,7 @@ data:
   dynamic.linux-ppc64le.system: "e980"
   dynamic.linux-ppc64le.cores: "2"
   dynamic.linux-ppc64le.memory: "8"
-  dynamic.linux-ppc64le.max-instances: "30"
+  dynamic.linux-ppc64le.max-instances: "100"
   dynamic.linux-ppc64le.allocation-timeout: "1800"
   dynamic.linux-ppc64le.instance-tag: prod-ppc64le
 
@@ -728,7 +728,7 @@ data:
   dynamic.linux-large-ppc64le.system: "e980"
   dynamic.linux-large-ppc64le.cores: "4"
   dynamic.linux-large-ppc64le.memory: "16"
-  dynamic.linux-large-ppc64le.max-instances: "10"
+  dynamic.linux-large-ppc64le.max-instances: "30"
   dynamic.linux-large-ppc64le.allocation-timeout: "1800"
   dynamic.linux-large-ppc64le.instance-tag: prod-ppc64le-large
 


### PR DESCRIPTION
Since we are usually waiting for VMs to start. `linux-ppc64le` is the most common one that we are using, hence increasing it to 100 to match non-IBM arches. While `linux-large-ppc64le` should work with `30`