### PR TITLE
Enable konflux-ui on internal-production clusters

### DIFF
--- a/argo-cd-apps/overlays/production-downstream/kustomization.yaml
+++ b/argo-cd-apps/overlays/production-downstream/kustomization.yaml
@@ -216,3 +216,8 @@ patches:
       kind: ApplicationSet
       version: v1alpha1
       name: workspaces-member
+  - path: production-overlay-patch.yaml
+    target:
+      kind: ApplicationSet
+      version: v1alpha1
+      name: konflux-ui


### PR DESCRIPTION
We need to enable konflux-ui in the production clusters by applying the production overlay patch.