### PR TITLE
PVO11Y-4650 - Add costmanagement-metrics-operator ns to cluster-secret-store

### DIFF
--- a/components/cluster-secret-store/base/appsre-stonesoup-vault-secret-store.yaml
+++ b/components/cluster-secret-store/base/appsre-stonesoup-vault-secret-store.yaml
@@ -61,5 +61,6 @@ spec:
         - rhtap-integration-tenant
         - rhtap-release-2-tenant
         - rhtap-releng-tenant
+        - costmanagement-metrics-operator
 
 


### PR DESCRIPTION
This change is required for cost-management metrics operator to access the secret stored in vault.