### PR TITLE
Adding temp access to workspace team to assist with migration

### DIFF
--- a/argo-cd-apps/base/member/infra-deployments/workspaces/workspaces.yaml
+++ b/argo-cd-apps/base/member/infra-deployments/workspaces/workspaces.yaml
@@ -23,6 +23,10 @@ spec:
                   values.clusterDir: stone-stage-p01
                 - nameNormalized: stone-prod-p02
                   values.clusterDir: stone-prod-p02
+                - nameNormalized: kflux-ocp-p01
+                  values.clusterDir: kflux-ocp-p01
+                - nameNormalized: stone-prod-p01
+                  values.clusterDir: stone-prod-p01
   template:
     metadata:
       name: workspaces-{{nameNormalized}}

--- a/components/workspaces/production/kflux-ocp-p01/kustomization.yaml
+++ b/components/workspaces/production/kflux-ocp-p01/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../team/migration

--- a/components/workspaces/production/stone-prod-p01/kustomization.yaml
+++ b/components/workspaces/production/stone-prod-p01/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../team/migration


### PR DESCRIPTION
Missing prod-p01 and ocp-p01 from the list that needs to be migrated off KubeSaw