### PR TITLE
bump version of namespace-lister

### DIFF
--- a/components/namespace-lister/base/kustomization.yaml
+++ b/components/namespace-lister/base/kustomization.yaml
@@ -11,7 +11,7 @@ namespace: namespace-lister
 images:
 - name: namespace-lister
   newName: quay.io/konflux-ci/namespace-lister
-  newTag: 10d01ce65358762c0b35eeba896dfa2887bbfc63
+  newTag: 4cf1954d33ac12be74c54755748c515427db443f
 patches:
 - path: ./patches/with_cachenamespacelabelselector.yaml
   target:


### PR DESCRIPTION
This aligns with upstream commit [4cf1954] (enhance metrics unit tests ([#84](https://github.com/konflux-ci/namespace-lister/pull/84))).

[4cf1954]: https://github.com/konflux-ci/namespace-lister/commit/4cf1954d33ac12be74c54755748c515427db443f