### PR TITLE
[OCP] rename linux 250d variant

### DIFF
--- a/components/multi-platform-controller/production-downstream/kflux-ocp-p01/host-config.yaml
+++ b/components/multi-platform-controller/production-downstream/kflux-ocp-p01/host-config.yaml
@@ -762,7 +762,7 @@ data:
   dynamic.linux-d250-largecpu-ppc64le.memory: "16"
   dynamic.linux-d250-largecpu-ppc64le.max-instances: "5"
   dynamic.linux-d250-largecpu-ppc64le.allocation-timeout: "1800"
-  dynamic.linux-d250-largecpu-ppc64le.instance-tag: prod-ppc64le-d250-largecpu
+  dynamic.linux-d250-largecpu-ppc64le.instance-tag: ppc64le-d250-largecpu
   dynamic.linux-d250-largecpu-ppc64le.disk: "250"
 
   # Same as linux-large-ppc64le but with 200GB disk instead of default 100GB


### PR DESCRIPTION
Since `linux-d200-large-ppc64le` is working, we should be good with this new name `linux-d250-8x16-ppc64le`