### PR TITLE
[ocp] increase default linux-large max-instances to 30

### DIFF
--- a/components/multi-platform-controller/production-downstream/kflux-ocp-p01/host-config.yaml
+++ b/components/multi-platform-controller/production-downstream/kflux-ocp-p01/host-config.yaml
@@ -645,7 +645,7 @@ data:
   dynamic.linux-large-s390x.region: "us-south-2"
   dynamic.linux-large-s390x.url: "https://us-south.iaas.cloud.ibm.com/v1"
   dynamic.linux-large-s390x.profile: "bz2-4x16"
-  dynamic.linux-large-s390x.max-instances: "10"
+  dynamic.linux-large-s390x.max-instances: "30"
   dynamic.linux-large-s390x.private-ip: "true"
   dynamic.linux-large-s390x.allocation-timeout: "1800"
   dynamic.linux-large-s390x.instance-tag: prod-s390x-large
@@ -728,7 +728,7 @@ data:
   dynamic.linux-large-ppc64le.system: "e980"
   dynamic.linux-large-ppc64le.cores: "4"
   dynamic.linux-large-ppc64le.memory: "16"
-  dynamic.linux-large-ppc64le.max-instances: "10"
+  dynamic.linux-large-ppc64le.max-instances: "30"
   dynamic.linux-large-ppc64le.allocation-timeout: "1800"
   dynamic.linux-large-ppc64le.instance-tag: prod-ppc64le-large
 


### PR DESCRIPTION
10 instances might be too low. Requesting the number to be at least the same as the default VM flavor