### PR TITLE
Bump Vector (Results) batch max size

### DIFF
--- a/components/vector-tekton-logs-collector/development/vector-helm-values.yaml
+++ b/components/vector-tekton-logs-collector/development/vector-helm-values.yaml
@@ -18,7 +18,6 @@ customConfig:
       type: kubernetes_logs
       rotate_wait_secs: 5
       glob_minimum_cooldown_ms: 500
-      max_read_bytes: 3145728
       max_line_bytes: 3145728
       auto_partial_merge: true
       extra_label_selector: "app.kubernetes.io/managed-by in (tekton-pipelines,pipelinesascode.tekton.dev)"
@@ -65,7 +64,8 @@ customConfig:
         max_events: 10000
         when_full: "block"
       batch:
-        max_events: 100000
+        max_bytes: 524288000  # documentation is wrong about this (https://github.com/vectordotdev/vector/issues/10020), 524288000 is actually around 10MB
+        timeout_secs: 300  # default
       inputs: ["remap_app_logs"]
       compression: "none"
       endpoint: ${ENDPOINT}

--- a/components/vector-tekton-logs-collector/staging/vector-helm-values.yaml
+++ b/components/vector-tekton-logs-collector/staging/vector-helm-values.yaml
@@ -18,7 +18,6 @@ customConfig:
       type: kubernetes_logs
       rotate_wait_secs: 5
       glob_minimum_cooldown_ms: 500
-      max_read_bytes: 3145728
       max_line_bytes: 3145728
       auto_partial_merge: true
       extra_label_selector: "app.kubernetes.io/managed-by in (tekton-pipelines,pipelinesascode.tekton.dev)"
@@ -65,7 +64,8 @@ customConfig:
         max_events: 10000
         when_full: "block"
       batch:
-        max_events: 100000
+        max_bytes: 524288000  # documentation is wrong about this (https://github.com/vectordotdev/vector/issues/10020), 524288000 is actually around 10MB
+        timeout_secs: 300  # default
       inputs: ["remap_app_logs"]
       compression: "none"
       endpoint: ${ENDPOINT}


### PR DESCRIPTION
The batch max size is cutting logs short and the default value (which is also wrongly documented) cuts the logs at around 140KB size. With the value 524288000 I was able to store log files of size close to 10MB, which should be enough given the biggest step/container logs files I've encounted in Konflux are ~4.7MB.

Removed kubernetes_logs.max_read_bytes as it does not play a role in the logs storing and it was confusing.