### PR TITLE
chore: Remove Pat from integration-service's OWNERS file

### DIFF
--- a/components/integration/OWNERS
+++ b/components/integration/OWNERS
@@ -9,7 +9,6 @@ approvers:
 - sonam1412
 - Josh-Everett
 - 14rcole
-- chipspeak
 - jencull
 
 reviewers:
@@ -21,5 +20,4 @@ reviewers:
 - sonam1412
 - Josh-Everett
 - 14rcole
-- chipspeak
 - jencull


### PR DESCRIPTION
This is because Pat has left the integration service team, and I would like to make his life a little bit better.

Signed-off-from: Dheeraj\<djodha@redhat.com>