### PR TITLE
Correct c6gd2xlarge platform host configurations

### DIFF
--- a/components/multi-platform-controller/production-downstream/kflux-ocp-p01/host-config.yaml
+++ b/components/multi-platform-controller/production-downstream/kflux-ocp-p01/host-config.yaml
@@ -179,7 +179,7 @@ data:
   dynamic.linux-c6gd2xlarge-arm64.region: us-east-1
   dynamic.linux-c6gd2xlarge-arm64.ami: ami-03d6a5256a46c9feb
   dynamic.linux-c6gd2xlarge-arm64.instance-type: c6gd.2xlarge
-  dynamic.linux-c6gd2xlarge-arm64.instance-tag: prod-arm64-m8xlarge
+  dynamic.linux-c6gd2xlarge-arm64.instance-tag: prod-arm64-c6gd2xlarge
   dynamic.linux-c6gd2xlarge-arm64.key-name: kflux-ocp-p01-key-pair
   dynamic.linux-c6gd2xlarge-arm64.aws-secret: aws-account
   dynamic.linux-c6gd2xlarge-arm64.ssh-secret: aws-ssh-key

--- a/components/multi-platform-controller/production-downstream/stone-prod-p01/host-config.yaml
+++ b/components/multi-platform-controller/production-downstream/stone-prod-p01/host-config.yaml
@@ -136,7 +136,7 @@ data:
   dynamic.linux-c6gd2xlarge-arm64.region: us-east-1
   dynamic.linux-c6gd2xlarge-arm64.ami: ami-03d6a5256a46c9feb
   dynamic.linux-c6gd2xlarge-arm64.instance-type: c6gd.2xlarge
-  dynamic.linux-c6gd2xlarge-arm64.instance-tag: prod-arm64-m8xlarge
+  dynamic.linux-c6gd2xlarge-arm64.instance-tag: prod-arm64-c6gd2xlarge
   dynamic.linux-c6gd2xlarge-arm64.key-name: konflux-prod-int-mab01
   dynamic.linux-c6gd2xlarge-arm64.aws-secret: aws-account
   dynamic.linux-c6gd2xlarge-arm64.ssh-secret: aws-ssh-key

--- a/components/multi-platform-controller/production-downstream/stone-prod-p02/host-config.yaml
+++ b/components/multi-platform-controller/production-downstream/stone-prod-p02/host-config.yaml
@@ -127,7 +127,7 @@ data:
   dynamic.linux-c6gd2xlarge-arm64.region: us-east-1
   dynamic.linux-c6gd2xlarge-arm64.ami: ami-03d6a5256a46c9feb
   dynamic.linux-c6gd2xlarge-arm64.instance-type: c6gd.2xlarge
-  dynamic.linux-c6gd2xlarge-arm64.instance-tag: prod-arm64-m4xlarge
+  dynamic.linux-c6gd2xlarge-arm64.instance-tag: prod-arm64-c6gd2xlarge
   dynamic.linux-c6gd2xlarge-arm64.key-name: konflux-prod-int-mab01
   dynamic.linux-c6gd2xlarge-arm64.aws-secret: aws-account
   dynamic.linux-c6gd2xlarge-arm64.ssh-secret: aws-ssh-key

--- a/components/multi-platform-controller/production/kflux-prd-rh02/host-config.yaml
+++ b/components/multi-platform-controller/production/kflux-prd-rh02/host-config.yaml
@@ -131,7 +131,7 @@ data:
   dynamic.linux-c6gd2xlarge-arm64.region: us-east-1
   dynamic.linux-c6gd2xlarge-arm64.ami: ami-03d6a5256a46c9feb
   dynamic.linux-c6gd2xlarge-arm64.instance-type: c6gd.2xlarge
-  dynamic.linux-c6gd2xlarge-arm64.instance-tag: prod-arm64-m8xlarge
+  dynamic.linux-c6gd2xlarge-arm64.instance-tag: prod-arm64-c6gd2xlarge
   dynamic.linux-c6gd2xlarge-arm64.key-name: kflux-prd-multi-rh02-key-pair
   dynamic.linux-c6gd2xlarge-arm64.aws-secret: aws-account
   dynamic.linux-c6gd2xlarge-arm64.ssh-secret: aws-ssh-key

--- a/components/multi-platform-controller/staging-downstream/host-config.yaml
+++ b/components/multi-platform-controller/staging-downstream/host-config.yaml
@@ -197,9 +197,9 @@ data:
 
   dynamic.linux-c6gd2xlarge-arm64.type: aws
   dynamic.linux-c6gd2xlarge-arm64.region: us-east-1
-  dynamic.linux-c6gd2xlarge-arm64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-c6gd2xlarge-arm64.ami: ami-03d6a5256a46c9feb
   dynamic.linux-c6gd2xlarge-arm64.instance-type: c6gd.2xlarge
-  dynamic.linux-c6gd2xlarge-arm64.instance-tag: stage-amd64-m8xlarge
+  dynamic.linux-c6gd2xlarge-arm64.instance-tag: stage-arm64-m8xlarge
   dynamic.linux-c6gd2xlarge-arm64.key-name: konflux-stage-int-mab01
   dynamic.linux-c6gd2xlarge-arm64.aws-secret: aws-account
   dynamic.linux-c6gd2xlarge-arm64.ssh-secret: aws-ssh-key

--- a/components/multi-platform-controller/staging/host-config.yaml
+++ b/components/multi-platform-controller/staging/host-config.yaml
@@ -139,7 +139,7 @@ data:
   dynamic.linux-c6gd2xlarge-arm64.region: us-east-1
   dynamic.linux-c6gd2xlarge-arm64.ami: ami-03d6a5256a46c9feb
   dynamic.linux-c6gd2xlarge-arm64.instance-type: c6gd.2xlarge
-  dynamic.linux-c6gd2xlarge-arm64.instance-tag: stage-arm64-m8xlarge
+  dynamic.linux-c6gd2xlarge-arm64.instance-tag: stage-arm64-c6gd2xlarge
   dynamic.linux-c6gd2xlarge-arm64.key-name: konflux-stage-ext-mab01
   dynamic.linux-c6gd2xlarge-arm64.aws-secret: aws-account
   dynamic.linux-c6gd2xlarge-arm64.ssh-secret: aws-ssh-key


### PR DESCRIPTION
An issue provisioning a c6gd2xlarge VM instance for the private staging cluster prompted a look at the host configuration for this platform. The AMI field for the private staging cluster in addition to instance tags for this platform are fixed in this commit.