### PR TITLE
add namespace-lister to ocp-kflux-p01

### DIFF
--- a/argo-cd-apps/base/member/infra-deployments/namespace-lister/namespace-lister.yaml
+++ b/argo-cd-apps/base/member/infra-deployments/namespace-lister/namespace-lister.yaml
@@ -31,6 +31,8 @@ spec:
                   values.clusterDir: stone-prod-p01
                 - nameNormalized: stone-prod-p02
                   values.clusterDir: stone-prod-p02
+                - nameNormalized: kflux-ocp-p01
+                  values.clusterDir: kflux-ocp-p01
   template:
     metadata:
       name: namespace-lister-{{nameNormalized}}

--- a/components/namespace-lister/production/kflux-ocp-p01/kustomization.yaml
+++ b/components/namespace-lister/production/kflux-ocp-p01/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../base/


### PR DESCRIPTION
Deploys namespace-lister to the internal production cluster `ocp-kflux-p01`.