### PR TITLE
Deploy latest crossplane configs

### DIFF
--- a/components/crossplane-control-plane/base/kustomization.yaml
+++ b/components/crossplane-control-plane/base/kustomization.yaml
@@ -1,6 +1,6 @@
 resources:
-- https://github.com/konflux-ci/crossplane-control-plane/crossplane?ref=5d6c42730c1c9f66b5d3567bdf04d587832ceac1
-- https://github.com/konflux-ci/crossplane-control-plane/config?ref=5d6c42730c1c9f66b5d3567bdf04d587832ceac1
+- https://github.com/konflux-ci/crossplane-control-plane/crossplane?ref=67eadc539704e0915465bd6d45904931bdfdb910
+- https://github.com/konflux-ci/crossplane-control-plane/config?ref=67eadc539704e0915465bd6d45904931bdfdb910
 - rbac.yaml
 - cronjob.yaml
 - configmap.yaml


### PR DESCRIPTION
This change should fix an issue where ephemeral namespace names containing illegal dot characters couldn't be created.