### PR TITLE
Reduce minio replicas to 1 for development

### DIFF
--- a/components/pipeline-service/development/kustomization.yaml
+++ b/components/pipeline-service/development/kustomization.yaml
@@ -42,6 +42,9 @@ patches:
       - op: replace
         path: /spec/template/spec/containers/0/image
         value: "quay.io/minio/operator:v5.0.15"
+      - op: replace
+        path: /spec/replicas
+        value: 1
   - target:
       kind: Deployment
       name: console


### PR DESCRIPTION
This PR aims to reduce the number of replicas specified for development related to the minio operator. Currently the replicas is set to 2, but the pods have a antiaffinity constraint in which they can't be in the same node as another pod called minio-operator. This results in the second replica not being deployed, leaving the deployment in a degraded state, so the `preview.sh` script can't progress.