### PR TITLE
Allow Konflux devs to see compute tab

### DIFF
--- a/components/authentication/base/everyone-can-view.yaml
+++ b/components/authentication/base/everyone-can-view.yaml
@@ -111,6 +111,37 @@ rules:
   - list
   - watch
 ---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: view-compute
+rules:
+- apiGroups:
+  - ''
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - 'machine.openshift.io'
+  resources:
+  - machines
+  - machinesets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - 'autoscaling.openshift.io'
+  resources:
+  - machineautoscalers
+  verbs:
+  - get
+  - list
+  - watch
+---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -150,3 +181,13 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: cluster-monitoring-view
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: everyone-view-compute
+subjects: [] # added by patch to avoid duplicating the groups
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: view-compute

--- a/components/authentication/base/kustomization.yaml
+++ b/components/authentication/base/kustomization.yaml
@@ -33,3 +33,9 @@ patches:
       kind: ClusterRoleBinding
       group: rbac.authorization.k8s.io
       version: v1
+  - path: everyone-can-view-patch.yaml
+    target:
+      name: everyone-view-compute
+      kind: ClusterRoleBinding
+      group: rbac.authorization.k8s.io
+      version: v1


### PR DESCRIPTION
Nodes, machines, machinesets and autoscallers resource are not aggregated in the view cluster role. Add these to our everyone can view roles.