### PR TITLE
namespace-lister: remove datasource from grafana dashboard

### DIFF
--- a/components/monitoring/grafana/base/dashboards/namespace-lister/namespace-lister-metrics.json
+++ b/components/monitoring/grafana/base/dashboards/namespace-lister/namespace-lister-metrics.json
@@ -32,10 +32,6 @@
       "type": "row"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "d56348f1-77d7-4896-a34f-495c93f4d0be"
-      },
       "description": "p95 latency of requests to list workspaces",
       "fieldConfig": {
         "defaults": {


### PR DESCRIPTION
All dashboard's panels but one are now working in every environment. This PR removes the missed datasource in #5739. 

Signed-off-by: Francesco Ilario <filario@redhat.com>
