### PR TITLE
scaffold kyverno across all relevant clusters

### DIFF
--- a/argo-cd-apps/base/member/infra-deployments/kyverno/kyverno.yaml
+++ b/argo-cd-apps/base/member/infra-deployments/kyverno/kyverno.yaml
@@ -19,8 +19,16 @@ spec:
                   values.clusterDir: stone-stg-rh01
                 - nameNormalized: stone-stage-p01
                   values.clusterDir: stone-stage-p01
+                - nameNormalized: stone-prd-rh01
+                  values.clusterDir: stone-prd-rh01
                 - nameNormalized: kflux-prd-rh02
                   values.clusterDir: kflux-prd-rh02
+                - nameNormalized: stone-prod-p01
+                  values.clusterDir: stone-prod-p01
+                - nameNormalized: stone-prod-p02
+                  values.clusterDir: stone-prod-p02
+                - nameNormalized: kflux-ocp-p01
+                  values.clusterDir: kflux-ocp-p01
   template:
     metadata:
       name: kyverno-{{nameNormalized}}

--- a/argo-cd-apps/overlays/production-downstream/delete-applications.yaml
+++ b/argo-cd-apps/overlays/production-downstream/delete-applications.yaml
@@ -53,11 +53,5 @@ $patch: delete
 apiVersion: argoproj.io/v1alpha1
 kind: ApplicationSet
 metadata:
-  name: kyverno
-$patch: delete
----
-apiVersion: argoproj.io/v1alpha1
-kind: ApplicationSet
-metadata:
   name: etcd-defrag
 $patch: delete

--- a/argo-cd-apps/overlays/production-downstream/kustomization.yaml
+++ b/argo-cd-apps/overlays/production-downstream/kustomization.yaml
@@ -221,3 +221,8 @@ patches:
       kind: ApplicationSet
       version: v1alpha1
       name: konflux-ui
+  - path: production-overlay-patch.yaml
+    target:
+      kind: ApplicationSet
+      version: v1alpha1
+      name: kyverno

--- a/components/kyverno/production/kflux-ocp-p01/kustomization.yaml
+++ b/components/kyverno/production/kflux-ocp-p01/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../empty-base

--- a/components/kyverno/production/stone-prd-rh01/kustomization.yaml
+++ b/components/kyverno/production/stone-prd-rh01/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../empty-base

--- a/components/kyverno/production/stone-prod-p01/kustomization.yaml
+++ b/components/kyverno/production/stone-prod-p01/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../empty-base

--- a/components/kyverno/production/stone-prod-p02/kustomization.yaml
+++ b/components/kyverno/production/stone-prod-p02/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../empty-base


### PR DESCRIPTION
This enables the kyverno application on all clusters currently relevant to its deployment.  Enablement on each cluster will come in separate PRs.

This will save some time on review from the infra team, since enabling kyverno on each of the clusters won't require a review from them after this merges.