### PR TITLE
Fix konflux-admins and konflux-sre view permissions

### DIFF
--- a/components/authentication/base/everyone-can-view-patch.yaml
+++ b/components/authentication/base/everyone-can-view-patch.yaml
@@ -4,6 +4,9 @@
   value:
     - kind: Group
       apiGroup: rbac.authorization.k8s.io
+      name: 'konflux-admins'
+    - kind: Group
+      apiGroup: rbac.authorization.k8s.io
       name: 'konflux-build'
     - kind: Group
       apiGroup: rbac.authorization.k8s.io
@@ -31,6 +34,9 @@
       name: 'konflux-hac'
     - kind: Group
       apiGroup: rbac.authorization.k8s.io
+      name: 'konflux-kubearchive'
+    - kind: Group
+      apiGroup: rbac.authorization.k8s.io
       name: 'konflux-mintmaker-team'
     - kind: Group
       apiGroup: rbac.authorization.k8s.io
@@ -49,7 +55,7 @@
       name: 'konflux-release-team'
     - kind: Group
       apiGroup: rbac.authorization.k8s.io
-      name: 'konflux-kubearchive'
+      name: 'konflux-sre'
     - kind: Group
       apiGroup: rbac.authorization.k8s.io
       name: 'konflux-support'

--- a/components/authentication/base/konflux-admins.yaml
+++ b/components/authentication/base/konflux-admins.yaml
@@ -338,22 +338,3 @@ subjects:
   - apiGroup: rbac.authorization.k8s.io
     kind: Group
     name: konflux-admins
-  - apiGroup: rbac.authorization.k8s.io
-    kind: Group
-    name: konflux-sre
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: konflux-admins-view
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: view
-subjects:
-  - apiGroup: rbac.authorization.k8s.io
-    kind: Group
-    name: konflux-admins
-  - apiGroup: rbac.authorization.k8s.io
-    kind: Group
-    name: konflux-sre


### PR DESCRIPTION
The everyone-can-view.yaml manifest have the latest needed view permissions that we grant all konflux-* groups. At one point we added a view permission to see cluster metrics but this was fixed only for the groups patched in everyone-can-view.yaml.

Both Konflux-admins and konflux-sre view permissions were duplicated/into another file and did not get the fix for cluster metrics. Move them both to the list of groups patched in everyone-can-view.yaml to fix permission to see cluster metrics. Also re-order the groups alphabetically.