### PR TITLE
add kyverno policy for standardizing namespace's tenant label

### DIFF
--- a/.chainsaw.yaml
+++ b/.chainsaw.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/configuration-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Configuration
+metadata:
+  name: configuration
+spec:
+  # parallel: 1
+  timeouts:
+    apply: 1m30s
+    assert: 1m30s
+    cleanup: 1m30s
+    delete: 1m30s
+    error: 1m30s
+    exec: 1m30s
+  fullName: true
+  forceTerminationGracePeriod: 5s
+  delayBeforeCleanup: 3s

--- a/.github/workflows/chainsaw-tests.yaml
+++ b/.github/workflows/chainsaw-tests.yaml
@@ -1,0 +1,50 @@
+name: Run Chainsaw tests
+
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  chainsaw-test:
+    name: Run Chainsaw tests
+    runs-on: ubuntu-latest
+    steps:
+    - name: Create k8s Kind Cluster
+      uses: helm/kind-action@v1
+    
+    - name: Install Cosign
+      uses: sigstore/cosign-installer@dc72c7d5c4d10cd6bcb8cf6e3fd625a9e5e537da # v3.7.0
+
+    - name: Install Chainsaw
+      uses: kyverno/action-install-chainsaw@f2b47b97dc889c12702113753d713f01ec268de5 # v0.2.12
+      with:
+        verify: true
+
+    - uses: actions/checkout@v4
+
+    - name: Install Dependencies
+      shell: bash
+      run: |
+        kustomize build components/kyverno/chainsaw | \
+          kubectl apply -f - --server-side
+
+    - name: Wait for kyverno ready
+      shell: bash
+      run: |
+        set -e
+        kubectl rollout status \
+          --namespace kyverno \
+          deployment \
+          --selector '!job-name' \
+          --timeout=300s
+
+    - name: Run chainsaw
+      shell: bash
+      run: |
+        # Run chainsaw tests for namespace-lister
+        # without parallelism, as they are sharing some
+        # cluster-scoped resources
+        chainsaw test components/namespace-lister/ \
+          --parallel 1 \
+          --config .chainsaw.yaml \
+          --no-color=false

--- a/.github/workflows/chainsaw-tests.yaml
+++ b/.github/workflows/chainsaw-tests.yaml
@@ -41,10 +41,7 @@ jobs:
     - name: Run chainsaw
       shell: bash
       run: |
-        # Run chainsaw tests for namespace-lister
-        # without parallelism, as they are sharing some
-        # cluster-scoped resources
-        chainsaw test components/namespace-lister/ \
-          --parallel 1 \
-          --config .chainsaw.yaml \
-          --no-color=false
+        find -name .chainsaw-test -type d -print0 | \
+          xargs -0 chainsaw test \
+            --config .chainsaw.yaml \
+            --no-color=false

--- a/.github/workflows/kube-linter.yaml
+++ b/.github/workflows/kube-linter.yaml
@@ -28,6 +28,7 @@ jobs:
             ! -path '*/k-components/*' \
             ! -path 'components/repository-validator/staging/*' \
             ! -path 'components/repository-validator/production/*' \
+            ! -path 'components/*/chainsaw/*' \
             | \
             xargs -I {} -n1 -P8  bash -c 'dir=$(dirname "{}"); output_file=$(echo $dir | tr / -)-kustomization.yaml; if ! log=$(kustomize build --enable-helm "$dir" -o "kustomizedfiles/$output_file" 2>&1); then echo "Error when running kustomize build for $dir: $log" && exit 1;fi'
 

--- a/components/kyverno/chainsaw/kustomization.yaml
+++ b/components/kyverno/chainsaw/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- https://github.com/kyverno/kyverno/raw/main/config/install-latest-testing.yaml

--- a/components/namespace-lister/base/kustomization.yaml
+++ b/components/namespace-lister/base/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
 - service.yaml
 - network_policy.yaml
 - metrics/
+- ../policies/ns-label/
 namespace: namespace-lister
 images:
 - name: namespace-lister

--- a/components/namespace-lister/policies/ns-label/.chainsaw-test/chainsaw-assert-clusterpolicy.yaml
+++ b/components/namespace-lister/policies/ns-label/.chainsaw-test/chainsaw-assert-clusterpolicy.yaml
@@ -1,0 +1,9 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: mutate-namespace-enforce-label
+status:
+  conditions:
+  - reason: Succeeded
+    status: "True"
+    type: Ready

--- a/components/namespace-lister/policies/ns-label/.chainsaw-test/chainsaw-test.yaml
+++ b/components/namespace-lister/policies/ns-label/.chainsaw-test/chainsaw-test.yaml
@@ -1,0 +1,223 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: mutate-namespace-konflux
+spec:
+  steps:
+  - name: given-kyverno-has-permission-on-namespaces
+    try:
+    - apply:
+        file: ../kyverno-background-konflux-ns-label-clusterrole.yaml
+  - name: given-label-cluster-policy-is-ready
+    try:
+    - apply:
+        file: ../namespace-enforce-label-clusterpolicy.yaml
+    - assert:
+        file: chainsaw-assert-clusterpolicy.yaml
+  - name: when-konfluxci-labeled-namespace-is-created
+    try:
+    - apply:
+        file: resources/actual-namespace-konflux.yaml
+        template: true
+  - name: then-all-labels-are-injected
+    try:
+    - assert:
+        file: resources/expected-namespace-konflux.yaml
+        template: true
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: mutate-namespace-toolchain
+spec:
+  steps:
+  - name: given-kyverno-has-permission-on-namespaces
+    try:
+    - apply:
+        file: ../kyverno-background-konflux-ns-label-clusterrole.yaml
+  - name: given-label-cluster-policy-is-ready
+    try:
+    - apply:
+        file: ../namespace-enforce-label-clusterpolicy.yaml
+    - assert:
+        file: chainsaw-assert-clusterpolicy.yaml
+  - name: when-konfluxci-labeled-namespace-is-created
+    try:
+    - apply:
+        file: resources/actual-namespace-toolchain.yaml
+        template: true
+  - name: then-all-labels-are-injected
+    try:
+    - assert:
+        file: resources/expected-namespace-toolchain.yaml
+        template: true
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: mutate-namespace-konflux-toolchain
+spec:
+  steps:
+  - name: given-kyverno-has-permission-on-namespaces
+    try:
+    - apply:
+        file: ../kyverno-background-konflux-ns-label-clusterrole.yaml
+  - name: given-label-cluster-policy-is-ready
+    try:
+    - apply:
+        file: ../namespace-enforce-label-clusterpolicy.yaml
+    - assert:
+        file: chainsaw-assert-clusterpolicy.yaml
+  - name: when-konfluxci-labeled-namespace-is-created
+    try:
+    - apply:
+        file: resources/actual-namespace-konflux-toolchain.yaml
+        template: true
+  - name: then-all-labels-are-injected
+    try:
+    - assert:
+        file: resources/expected-namespace-konflux-toolchain.yaml
+        template: true
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: mutate-namespace-unlabeled
+spec:
+  steps:
+  - name: given-kyverno-has-permission-on-namespaces
+    try:
+    - apply:
+        file: ../kyverno-background-konflux-ns-label-clusterrole.yaml
+  - name: given-label-cluster-policy-is-ready
+    try:
+    - apply:
+        file: ../namespace-enforce-label-clusterpolicy.yaml
+    - assert:
+        file: chainsaw-assert-clusterpolicy.yaml
+  - name: when-konfluxci-unlabeled-namespace-is-created
+    try:
+    - apply:
+        file: resources/actual-namespace-unlabeled.yaml
+        template: true
+  - name: then-no-labels-are-injected
+    try:
+    - assert:
+        file: resources/expected-namespace-unlabeled.yaml
+        template: true
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: mutate-namespace-existing-konflux
+spec:
+  steps:
+  - name: given-kyverno-has-permission-on-namespaces
+    try:
+    - apply:
+        file: ../kyverno-background-konflux-ns-label-clusterrole.yaml
+  - name: given-konfluxci-labeled-namespace-is-created
+    try:
+    - apply:
+        file: resources/actual-namespace-konflux.yaml
+        template: true
+  - name: when-label-cluster-policy-is-ready
+    try:
+    - apply:
+        file: ../namespace-enforce-label-clusterpolicy.yaml
+    - assert:
+        file: chainsaw-assert-clusterpolicy.yaml
+  - name: then-all-labels-are-injected
+    try:
+    - assert:
+        file: resources/expected-namespace-konflux.yaml
+        template: true
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: mutate-namespace-existing-toolchain
+spec:
+  steps:
+  - name: given-kyverno-has-permission-on-namespaces
+    try:
+    - apply:
+        file: ../kyverno-background-konflux-ns-label-clusterrole.yaml
+  - name: given-toolchain-labeled-namespace-is-created
+    try:
+    - apply:
+        file: resources/actual-namespace-toolchain.yaml
+        template: true
+  - name: when-label-cluster-policy-is-ready
+    try:
+    - apply:
+        file: ../namespace-enforce-label-clusterpolicy.yaml
+    - assert:
+        file: chainsaw-assert-clusterpolicy.yaml
+  - name: then-all-labels-are-injected
+    try:
+    - assert:
+        file: resources/expected-namespace-toolchain.yaml
+        template: true
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: mutate-namespace-existing-konflux-toolchain
+spec:
+  steps:
+  - name: given-kyverno-has-permission-on-namespaces
+    try:
+    - apply:
+        file: ../kyverno-background-konflux-ns-label-clusterrole.yaml
+  - name: given-konfluxci-labeled-namespace-is-created
+    try:
+    - apply:
+        file: resources/actual-namespace-konflux-toolchain.yaml
+        template: true
+  - name: when-label-cluster-policy-is-ready
+    try:
+    - apply:
+        file: ../namespace-enforce-label-clusterpolicy.yaml
+    - assert:
+        file: chainsaw-assert-clusterpolicy.yaml
+  - name: then-all-labels-are-injected
+    try:
+    - assert:
+        file: resources/expected-namespace-konflux-toolchain.yaml
+        template: true
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: mutate-namespace-existing-unlabeled
+spec:
+  steps:
+  - name: given-kyverno-has-permission-on-namespaces
+    try:
+    - apply:
+        file: ../kyverno-background-konflux-ns-label-clusterrole.yaml
+  - name: given-konfluxci-unlabeled-namespace-is-created
+    try:
+    - apply:
+        file: resources/actual-namespace-unlabeled.yaml
+        template: true
+  - name: when-label-cluster-policy-is-ready
+    try:
+    - apply:
+        file: ../namespace-enforce-label-clusterpolicy.yaml
+    - assert:
+        file: chainsaw-assert-clusterpolicy.yaml
+  - name: then-no-labels-are-injected
+    try:
+    - assert:
+        file: resources/expected-namespace-unlabeled.yaml
+        template: true

--- a/components/namespace-lister/policies/ns-label/.chainsaw-test/chainsaw-test.yaml
+++ b/components/namespace-lister/policies/ns-label/.chainsaw-test/chainsaw-test.yaml
@@ -2,12 +2,13 @@
 apiVersion: chainsaw.kyverno.io/v1alpha1
 kind: Test
 metadata:
-  name: mutate-namespace-konflux
+  name: mutate-new-namespace-konflux
 spec:
   description: |
     tests that the label is added to a new namespace
     that has the `konflux.ci/type=user` label
   concurrent: false
+  namespace: 'mutate-new-namespace'
   steps:
   - name: given-kyverno-has-permission-on-namespaces
     try:
@@ -34,12 +35,13 @@ spec:
 apiVersion: chainsaw.kyverno.io/v1alpha1
 kind: Test
 metadata:
-  name: mutate-namespace-toolchain
+  name: mutate-new-namespace-toolchain
 spec:
   description: |
     tests that the label is added to a new namespace
     that has the `toolchain.dev.openshift.com/type=tenant` label
   concurrent: false
+  namespace: "mutate-new-namespace"
   steps:
   - name: given-kyverno-has-permission-on-namespaces
     try:
@@ -66,13 +68,14 @@ spec:
 apiVersion: chainsaw.kyverno.io/v1alpha1
 kind: Test
 metadata:
-  name: mutate-namespace-konflux-toolchain
+  name: mutate-new-namespace-konflux-toolchain
 spec:
   description: |
     tests that the label is added to a new namespace
     that has bot the `konflux.ci/type=user` and 
     the `toolchain.dev.openshift.com/type=tenant` label
   concurrent: false
+  namespace: "mutate-new-namespace"
   steps:
   - name: given-kyverno-has-permission-on-namespaces
     try:
@@ -99,13 +102,14 @@ spec:
 apiVersion: chainsaw.kyverno.io/v1alpha1
 kind: Test
 metadata:
-  name: mutate-namespace-unlabeled
+  name: mutate-new-namespace-unlabeled
 spec:
   description: |
     tests that the label is NOT added to a new namespace
     that has neither the `konflux.ci/type=user` nor 
     the `toolchain.dev.openshift.com/type=tenant` label
   concurrent: false
+  namespace: "mutate-new-namespace"
   steps:
   - name: given-kyverno-has-permission-on-namespaces
     try:
@@ -132,12 +136,13 @@ spec:
 apiVersion: chainsaw.kyverno.io/v1alpha1
 kind: Test
 metadata:
-  name: mutate-namespace-existing-konflux
+  name: mutate-existing-namespace-konflux
 spec:
   description: |
     tests that the label is added to an existing namespace
     that has the `konflux.ci/type=user` label
   concurrent: false
+  namespace: mutate-existing-namespace
   steps:
   - name: given-kyverno-has-permission-on-namespaces
     try:
@@ -164,12 +169,13 @@ spec:
 apiVersion: chainsaw.kyverno.io/v1alpha1
 kind: Test
 metadata:
-  name: mutate-namespace-existing-toolchain
+  name: mutate-existing-namespace-toolchain
 spec:
   description: |
     tests that the label is added to an existing namespace
     that has the `toolchain.dev.openshift.com/type=tenant` label
   concurrent: false
+  namespace: mutate-existing-namespace
   steps:
   - name: given-kyverno-has-permission-on-namespaces
     try:
@@ -196,13 +202,14 @@ spec:
 apiVersion: chainsaw.kyverno.io/v1alpha1
 kind: Test
 metadata:
-  name: mutate-namespace-existing-konflux-toolchain
+  name: mutate-existing-namespace-konflux-toolchain
 spec:
   description: |
     tests that the label is added to an existing namespace
     that has bot the `konflux.ci/type=user` and 
     the `toolchain.dev.openshift.com/type=tenant` label
   concurrent: false
+  namespace: mutate-existing-namespace
   steps:
   - name: given-kyverno-has-permission-on-namespaces
     try:
@@ -229,13 +236,14 @@ spec:
 apiVersion: chainsaw.kyverno.io/v1alpha1
 kind: Test
 metadata:
-  name: mutate-namespace-existing-unlabeled
+  name: mutate-existing-namespace-unlabeled
 spec:
   description: |
     tests that the label is NOT added to an existing namespace
     that has neither the `konflux.ci/type=user` nor 
     the `toolchain.dev.openshift.com/type=tenant` label
   concurrent: false
+  namespace: mutate-existing-namespace
   steps:
   - name: given-kyverno-has-permission-on-namespaces
     try:

--- a/components/namespace-lister/policies/ns-label/.chainsaw-test/chainsaw-test.yaml
+++ b/components/namespace-lister/policies/ns-label/.chainsaw-test/chainsaw-test.yaml
@@ -4,6 +4,9 @@ kind: Test
 metadata:
   name: mutate-namespace-konflux
 spec:
+  description: |
+    tests that the label is added to a new namespace
+    that has the `konflux.ci/type=user` label
   concurrent: false
   steps:
   - name: given-kyverno-has-permission-on-namespaces
@@ -33,6 +36,9 @@ kind: Test
 metadata:
   name: mutate-namespace-toolchain
 spec:
+  description: |
+    tests that the label is added to a new namespace
+    that has the `toolchain.dev.openshift.com/type=tenant` label
   concurrent: false
   steps:
   - name: given-kyverno-has-permission-on-namespaces
@@ -62,6 +68,10 @@ kind: Test
 metadata:
   name: mutate-namespace-konflux-toolchain
 spec:
+  description: |
+    tests that the label is added to a new namespace
+    that has bot the `konflux.ci/type=user` and 
+    the `toolchain.dev.openshift.com/type=tenant` label
   concurrent: false
   steps:
   - name: given-kyverno-has-permission-on-namespaces
@@ -91,6 +101,10 @@ kind: Test
 metadata:
   name: mutate-namespace-unlabeled
 spec:
+  description: |
+    tests that the label is NOT added to a new namespace
+    that has neither the `konflux.ci/type=user` nor 
+    the `toolchain.dev.openshift.com/type=tenant` label
   concurrent: false
   steps:
   - name: given-kyverno-has-permission-on-namespaces
@@ -120,6 +134,9 @@ kind: Test
 metadata:
   name: mutate-namespace-existing-konflux
 spec:
+  description: |
+    tests that the label is added to an existing namespace
+    that has the `konflux.ci/type=user` label
   concurrent: false
   steps:
   - name: given-kyverno-has-permission-on-namespaces
@@ -149,6 +166,9 @@ kind: Test
 metadata:
   name: mutate-namespace-existing-toolchain
 spec:
+  description: |
+    tests that the label is added to an existing namespace
+    that has the `toolchain.dev.openshift.com/type=tenant` label
   concurrent: false
   steps:
   - name: given-kyverno-has-permission-on-namespaces
@@ -178,6 +198,10 @@ kind: Test
 metadata:
   name: mutate-namespace-existing-konflux-toolchain
 spec:
+  description: |
+    tests that the label is added to an existing namespace
+    that has bot the `konflux.ci/type=user` and 
+    the `toolchain.dev.openshift.com/type=tenant` label
   concurrent: false
   steps:
   - name: given-kyverno-has-permission-on-namespaces
@@ -207,6 +231,10 @@ kind: Test
 metadata:
   name: mutate-namespace-existing-unlabeled
 spec:
+  description: |
+    tests that the label is NOT added to an existing namespace
+    that has neither the `konflux.ci/type=user` nor 
+    the `toolchain.dev.openshift.com/type=tenant` label
   concurrent: false
   steps:
   - name: given-kyverno-has-permission-on-namespaces

--- a/components/namespace-lister/policies/ns-label/.chainsaw-test/chainsaw-test.yaml
+++ b/components/namespace-lister/policies/ns-label/.chainsaw-test/chainsaw-test.yaml
@@ -4,6 +4,7 @@ kind: Test
 metadata:
   name: mutate-namespace-konflux
 spec:
+  concurrent: false
   steps:
   - name: given-kyverno-has-permission-on-namespaces
     try:
@@ -32,6 +33,7 @@ kind: Test
 metadata:
   name: mutate-namespace-toolchain
 spec:
+  concurrent: false
   steps:
   - name: given-kyverno-has-permission-on-namespaces
     try:
@@ -60,6 +62,7 @@ kind: Test
 metadata:
   name: mutate-namespace-konflux-toolchain
 spec:
+  concurrent: false
   steps:
   - name: given-kyverno-has-permission-on-namespaces
     try:
@@ -88,6 +91,7 @@ kind: Test
 metadata:
   name: mutate-namespace-unlabeled
 spec:
+  concurrent: false
   steps:
   - name: given-kyverno-has-permission-on-namespaces
     try:
@@ -116,6 +120,7 @@ kind: Test
 metadata:
   name: mutate-namespace-existing-konflux
 spec:
+  concurrent: false
   steps:
   - name: given-kyverno-has-permission-on-namespaces
     try:
@@ -144,6 +149,7 @@ kind: Test
 metadata:
   name: mutate-namespace-existing-toolchain
 spec:
+  concurrent: false
   steps:
   - name: given-kyverno-has-permission-on-namespaces
     try:
@@ -172,6 +178,7 @@ kind: Test
 metadata:
   name: mutate-namespace-existing-konflux-toolchain
 spec:
+  concurrent: false
   steps:
   - name: given-kyverno-has-permission-on-namespaces
     try:
@@ -200,6 +207,7 @@ kind: Test
 metadata:
   name: mutate-namespace-existing-unlabeled
 spec:
+  concurrent: false
   steps:
   - name: given-kyverno-has-permission-on-namespaces
     try:

--- a/components/namespace-lister/policies/ns-label/.chainsaw-test/resources/actual-namespace-konflux-toolchain.yaml
+++ b/components/namespace-lister/policies/ns-label/.chainsaw-test/resources/actual-namespace-konflux-toolchain.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: (join('-', [$namespace, 'konflux']))
+  labels:
+    konflux.ci/type: user
+    toolchain.dev.openshift.com/type: tenant

--- a/components/namespace-lister/policies/ns-label/.chainsaw-test/resources/actual-namespace-konflux.yaml
+++ b/components/namespace-lister/policies/ns-label/.chainsaw-test/resources/actual-namespace-konflux.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: (join('-', [$namespace, 'konflux']))
+  labels:
+    konflux.ci/type: user

--- a/components/namespace-lister/policies/ns-label/.chainsaw-test/resources/actual-namespace-toolchain.yaml
+++ b/components/namespace-lister/policies/ns-label/.chainsaw-test/resources/actual-namespace-toolchain.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: (join('-', [$namespace, 'toolchain']))
+  labels:
+    toolchain.dev.openshift.com/type: tenant

--- a/components/namespace-lister/policies/ns-label/.chainsaw-test/resources/actual-namespace-unlabeled.yaml
+++ b/components/namespace-lister/policies/ns-label/.chainsaw-test/resources/actual-namespace-unlabeled.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: (join('-', [$namespace, 'konflux']))

--- a/components/namespace-lister/policies/ns-label/.chainsaw-test/resources/expected-namespace-konflux-toolchain.yaml
+++ b/components/namespace-lister/policies/ns-label/.chainsaw-test/resources/expected-namespace-konflux-toolchain.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: (join('-', [$namespace, 'konflux']))
+  labels:
+    konflux.ci/type: user
+    konflux-ci.dev/type: tenant
+    toolchain.dev.openshift.com/type: tenant

--- a/components/namespace-lister/policies/ns-label/.chainsaw-test/resources/expected-namespace-konflux.yaml
+++ b/components/namespace-lister/policies/ns-label/.chainsaw-test/resources/expected-namespace-konflux.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: (join('-', [$namespace, 'konflux']))
+  labels:
+    konflux.ci/type: user
+    konflux-ci.dev/type: tenant

--- a/components/namespace-lister/policies/ns-label/.chainsaw-test/resources/expected-namespace-toolchain.yaml
+++ b/components/namespace-lister/policies/ns-label/.chainsaw-test/resources/expected-namespace-toolchain.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: (join('-', [$namespace, 'toolchain']))
+  labels:
+    konflux.ci/type: user
+    konflux-ci.dev/type: tenant
+    toolchain.dev.openshift.com/type: tenant

--- a/components/namespace-lister/policies/ns-label/.chainsaw-test/resources/expected-namespace-unlabeled.yaml
+++ b/components/namespace-lister/policies/ns-label/.chainsaw-test/resources/expected-namespace-unlabeled.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: (join('-', [$namespace, 'konflux']))

--- a/components/namespace-lister/policies/ns-label/kustomization.yaml
+++ b/components/namespace-lister/policies/ns-label/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- namespace-enforce-label-clusterpolicy.yaml
+- kyverno-background-konflux-ns-label-clusterrole.yaml

--- a/components/namespace-lister/policies/ns-label/kyverno-background-konflux-ns-label-clusterrole.yaml
+++ b/components/namespace-lister/policies/ns-label/kyverno-background-konflux-ns-label-clusterrole.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kyverno-background-konflux-ns-label
+  labels:
+    rbac.kyverno.io/aggregate-to-background-controller: "true"
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - update
+  - patch

--- a/components/namespace-lister/policies/ns-label/namespace-enforce-label-clusterpolicy.yaml
+++ b/components/namespace-lister/policies/ns-label/namespace-enforce-label-clusterpolicy.yaml
@@ -1,0 +1,32 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: mutate-namespace-enforce-label
+spec:
+  rules:
+    - name: mutate-namespace-enforce-label
+      match:
+        any:
+        - resources:
+            kinds:
+            - v1/Namespace
+            selector:
+              matchLabels:
+                toolchain.dev.openshift.com/type: tenant
+        - resources:
+            kinds:
+            - v1/Namespace
+            selector:
+              matchLabels:
+                konflux.ci/type: user
+      mutate:
+        mutateExistingOnPolicyUpdate: true
+        targets:
+        - apiVersion: v1
+          kind: Namespace
+          name: "{{ request.object.metadata.name }}"
+        patchStrategicMerge:
+          metadata:
+            labels:
+              konflux.ci/type: user
+              konflux-ci.dev/type: tenant

--- a/hack/chainsaw/chainsaw-prepare.sh
+++ b/hack/chainsaw/chainsaw-prepare.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -e
+
+## Create the kind cluster
+kind create cluster --name infra-deployments-chainsaw
+
+## Install kyverno
+kustomize build components/kyverno/chainsaw | \
+  kubectl apply -f - --server-side
+
+## wait for kyverno to rollout
+kubectl rollout status --namespace kyverno deployment --selector '!job-name' --timeout=300s


### PR DESCRIPTION
This PR adds a kyverno ClusterPolicy to ensure that the new label used to identify tenant namespaces is present in already existing and new tenant namespaces.

The new label is `konflux-ci.dev/type: tenant` and will be added to every namespace with `toolchain.dev.openshift.com/type: tenant` (KubeSaw tenant namespaces) or `konflux.ci/type: user` (Workspace Manager tenant namespaces).

To test the ClusterPolicy, this PR introduces support for [kyverno chainsaw](https://github.com/kyverno/chainsaw).
A GitHub Action is added to run chainsaw as part of our CI. 

Signed-off-by: Francesco Ilario <filario@redhat.com>
