### PR TITLE
mintmaker: grant pod management permissions to mintmaker-team

### DIFF
--- a/components/mintmaker/base/rbac/mintmaker-team.yaml
+++ b/components/mintmaker/base/rbac/mintmaker-team.yaml
@@ -7,6 +7,7 @@ rules:
   - apiGroups:
       - ''
     resources:
+      - pods
       - secrets
       - configmaps
     verbs:


### PR DESCRIPTION
Grant full pod control permissions to mintmaker-team within the mintmaker namespace.