### PR TITLE
nslister: promote egress NetworkPolicy to prod

### DIFF
--- a/components/namespace-lister/production/base/kustomization.yaml
+++ b/components/namespace-lister/production/base/kustomization.yaml
@@ -5,7 +5,8 @@ resources:
 - namespace.yaml
 - rbac.yaml
 - service.yaml
-- network_policy.yaml
+- network_policy_allow_to_apiserver.yaml
+- network_policy_allow_from_konfluxui.yaml
 - metrics/
 namespace: namespace-lister
 images:

--- a/components/namespace-lister/production/base/network_policy_allow_from_konfluxui.yaml
+++ b/components/namespace-lister/production/base/network_policy_allow_from_konfluxui.yaml
@@ -11,12 +11,12 @@ spec:
   - Ingress
   ingress:
   - from:
-    - namespaceSelector:
-        matchLabels:
-          kubernetes.io/metadata.name: konflux-ui
     - podSelector:
         matchLabels:
           app: proxy
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: konflux-ui
     ports:
-    - protocol: TCP
-      port: 8080
+    - port: 8080
+      protocol: TCP

--- a/components/namespace-lister/production/base/network_policy_allow_to_apiserver.yaml
+++ b/components/namespace-lister/production/base/network_policy_allow_to_apiserver.yaml
@@ -1,0 +1,22 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-to-apiserver
+  namespace: namespace-lister
+spec:
+  podSelector:
+    matchLabels:
+      apps: namespace-lister
+  policyTypes:
+  - Egress
+  egress:
+  - to:
+    - podSelector:
+        matchLabels:
+          app: openshift-kube-apiserver
+      namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: openshift-kube-apiserver
+    ports:
+    - port: 6443
+      protocol: TCP


### PR DESCRIPTION
This change allows the namespace-lister to only reach-out to the APIServer in production clusters

Signed-off-by: Francesco Ilario <filario@redhat.com>
