### PR TITLE
Optimize Vector Results

### DIFF
--- a/components/vector-tekton-logs-collector/development/vector-helm-values.yaml
+++ b/components/vector-tekton-logs-collector/development/vector-helm-values.yaml
@@ -22,35 +22,41 @@ customConfig:
       auto_partial_merge: true
       extra_label_selector: "app.kubernetes.io/managed-by in (tekton-pipelines,pipelinesascode.tekton.dev)"
   transforms:
+    reduce_events:
+      type: reduce
+      inputs:
+        - kubernetes_logs
+      group_by:
+        - file
+      flush_period_ms: 2000
+      end_every_period_ms: 2000
+      merge_strategies:
+        message: concat_newline
     remap_app_logs:
       type: remap
-      inputs: [kubernetes_logs]
+      inputs:
+        - reduce_events
       source: |-
-        .log_type = "application"
-        .kubernetes_namespace_name = .kubernetes.pod_namespace
-            if exists(.kubernetes.pod_labels."tekton.dev/taskRunUID") {
-              .taskRunUID = del(.kubernetes.pod_labels."tekton.dev/taskRunUID")
-            } else {
-              .taskRunUID = "none"
-              }
-            if exists(.kubernetes.pod_labels."tekton.dev/pipelineRunUID") {
-              .pipelineRunUID = del(.kubernetes.pod_labels."tekton.dev/pipelineRunUID")
-            .result = .pipelineRunUID
-            } else {
-               .result = .taskRunUID
-            }
-            if exists(.kubernetes.pod_labels."tekton.dev/task") {
-              .task = del(.kubernetes.pod_labels."tekton.dev/task")
-            } else {
-              .task = "none"
-            }
-            if exists(.kubernetes.pod_namespace) {
-              .namespace = del(.kubernetes.pod_namespace)
-            } else {
-              .namespace = "unlabeled"
-            }
-            .pod = .kubernetes.pod_name
-            .container = .kubernetes.container_name
+        .tmp = del(.)
+        if exists(.tmp.kubernetes.pod_labels."tekton.dev/taskRunUID") {
+          .taskRunUID = del(.tmp.kubernetes.pod_labels."tekton.dev/taskRunUID")
+        } else {
+          .taskRunUID = "none"
+        }
+        if exists(.tmp.kubernetes.pod_labels."tekton.dev/pipelineRunUID") {
+          .pipelineRunUID = del(.tmp.kubernetes.pod_labels."tekton.dev/pipelineRunUID")
+          .result = .pipelineRunUID
+        } else {
+          .result = .taskRunUID
+        }
+        if exists(.tmp.kubernetes.pod_namespace) {
+          .namespace = del(.tmp.kubernetes.pod_namespace)
+        } else {
+          .namespace = "unlabeled"
+        }
+        .container = del(.tmp.kubernetes.container_name)
+        .message = del(.tmp.message)
+        del(.tmp)
   sinks:
     aws_s3:
       type: "aws_s3"

--- a/components/vector-tekton-logs-collector/staging/vector-helm-values.yaml
+++ b/components/vector-tekton-logs-collector/staging/vector-helm-values.yaml
@@ -22,35 +22,41 @@ customConfig:
       auto_partial_merge: true
       extra_label_selector: "app.kubernetes.io/managed-by in (tekton-pipelines,pipelinesascode.tekton.dev)"
   transforms:
+    reduce_events:
+      type: reduce
+      inputs:
+        - kubernetes_logs
+      group_by:
+        - file
+      flush_period_ms: 2000
+      end_every_period_ms: 2000
+      merge_strategies:
+        message: concat_newline
     remap_app_logs:
       type: remap
-      inputs: [kubernetes_logs]
+      inputs:
+        - reduce_events
       source: |-
-        .log_type = "application"
-        .kubernetes_namespace_name = .kubernetes.pod_namespace
-            if exists(.kubernetes.pod_labels."tekton.dev/taskRunUID") {
-              .taskRunUID = del(.kubernetes.pod_labels."tekton.dev/taskRunUID")
-            } else {
-              .taskRunUID = "none"
-              }
-            if exists(.kubernetes.pod_labels."tekton.dev/pipelineRunUID") {
-              .pipelineRunUID = del(.kubernetes.pod_labels."tekton.dev/pipelineRunUID")
-            .result = .pipelineRunUID
-            } else {
-               .result = .taskRunUID
-            }
-            if exists(.kubernetes.pod_labels."tekton.dev/task") {
-              .task = del(.kubernetes.pod_labels."tekton.dev/task")
-            } else {
-              .task = "none"
-            }
-            if exists(.kubernetes.pod_namespace) {
-              .namespace = del(.kubernetes.pod_namespace)
-            } else {
-              .namespace = "unlabeled"
-            }
-            .pod = .kubernetes.pod_name
-            .container = .kubernetes.container_name
+        .tmp = del(.)
+        if exists(.tmp.kubernetes.pod_labels."tekton.dev/taskRunUID") {
+          .taskRunUID = del(.tmp.kubernetes.pod_labels."tekton.dev/taskRunUID")
+        } else {
+          .taskRunUID = "none"
+        }
+        if exists(.tmp.kubernetes.pod_labels."tekton.dev/pipelineRunUID") {
+          .pipelineRunUID = del(.tmp.kubernetes.pod_labels."tekton.dev/pipelineRunUID")
+          .result = .pipelineRunUID
+        } else {
+          .result = .taskRunUID
+        }
+        if exists(.tmp.kubernetes.pod_namespace) {
+          .namespace = del(.tmp.kubernetes.pod_namespace)
+        } else {
+          .namespace = "unlabeled"
+        }
+        .container = del(.tmp.kubernetes.container_name)
+        .message = del(.tmp.message)
+        del(.tmp)
   sinks:
     aws_s3:
       type: "aws_s3"


### PR DESCRIPTION
To reduce the memory consumption and avoid OOM pod removal:
- Reduce the number of events by combining the log lines for multiple events into single event, avoiding storing the same event metadata for each event.
- Reduce the metadata we store for each event to only what's actually needed. Previously for each log line (~70 bytes), we were storing 3.5Kb and more of metadata.