### PR TITLE
namespace-lister: add healthz and readyz checks to prod

### DIFF
--- a/components/namespace-lister/production/base/deployment.yaml
+++ b/components/namespace-lister/production/base/deployment.yaml
@@ -39,6 +39,18 @@ spec:
           value: "0"
         - name: CACHE_RESYNC_PERIOD
           value: 10m
+        livenessProbe:
+          initialDelaySeconds: 1
+          httpGet:
+            path: /healthz
+            port: 8080
+            scheme: HTTPS
+        readinessProbe:
+          initialDelaySeconds: 1
+          httpGet:
+            path: /readyz
+            port: 8080
+            scheme: HTTPS
         resources:
           limits:
             cpu: 500m

--- a/components/namespace-lister/production/base/kustomization.yaml
+++ b/components/namespace-lister/production/base/kustomization.yaml
@@ -12,7 +12,7 @@ namespace: namespace-lister
 images:
 - name: namespace-lister
   newName: quay.io/konflux-ci/namespace-lister
-  newTag: 35d579c298bf593105d217606da6db0e56d757ba
+  newTag: d7e98fa32be5796726c7b87b0759e693fd413b8e
 patches:
 - path: ./patches/with_cachenamespacelabelselector.yaml
   target:


### PR DESCRIPTION
Add healthz and readyz checks, so that we have hooks to inform the pod controller if we're alive and if we're ready to serve requests.