### PR TITLE
Only enable pause pods in production

### DIFF
--- a/components/cluster-as-a-service/base/clustertemplates.yaml
+++ b/components/cluster-as-a-service/base/clustertemplates.yaml
@@ -42,13 +42,6 @@ spec:
               value: cluster-provisioner
             - name: nodePoolReplicas
               value: "3"
-            # Over provision the workload with a pause container so there are always resources
-            # available when the hub cluster needs to scale up. The autoscaler will evict this low
-            # priority pod and schedule it on newly provisioned nodes. This will allow higher
-            # priority control plane pods to immediately consume the freed up resources on
-            # existing nodes.
-            - name: pausePod.enabled
-              value: "true"
             - name: pausePod.priorityClass
               value: pause-pod-priority
       syncPolicy:

--- a/components/cluster-as-a-service/production/add-hypershift-params.yaml
+++ b/components/cluster-as-a-service/production/add-hypershift-params.yaml
@@ -16,3 +16,14 @@
   value:
     name: hypershiftRoleArn
     value: arn:aws:iam::590184136207:role/eaas-hypershift-cli-role
+
+- op: add
+  path: /spec/template/spec/source/helm/parameters/-
+  value:
+    # Over provision the workload with a pause container so there are always resources
+    # available when the hub cluster needs to scale up. The autoscaler will evict this low
+    # priority pod and schedule it on newly provisioned nodes. This will allow higher
+    # priority control plane pods to immediately consume the freed up resources on
+    # existing nodes.
+    name: pausePod.enabled
+    value: "true"


### PR DESCRIPTION
This is to experiment without them in staging.

They should be avoided in development due to typical resource constraints.