### PR TITLE
konfluxui: fix job to create proxy's secrets

### DIFF
--- a/components/konflux-ui/production/kflux-ocp-p01/configure-oauth-proxy-secret.yaml
+++ b/components/konflux-ui/production/kflux-ocp-p01/configure-oauth-proxy-secret.yaml
@@ -88,7 +88,7 @@ spec:
               | kubectl apply -f -
 
           echo "Restarting the proxy deployment"
-          if kubectl get deployment/proxy; then
+          if kubectl -n "$namespace" get deployment/proxy; then
             kubectl -n "$namespace" rollout restart deployment/proxy
           else
             echo "skipping restart"

--- a/components/konflux-ui/production/kflux-prd-rh02/configure-oauth-proxy-secret.yaml
+++ b/components/konflux-ui/production/kflux-prd-rh02/configure-oauth-proxy-secret.yaml
@@ -88,7 +88,7 @@ spec:
               | kubectl apply -f -
 
           echo "Restarting the proxy deployment"
-          if kubectl get deployment/proxy; then
+          if kubectl -n "$namespace" get deployment/proxy; then
             kubectl -n "$namespace" rollout restart deployment/proxy
           else
             echo "skipping restart"

--- a/components/konflux-ui/production/stone-prd-rh01/configure-oauth-proxy-secret.yaml
+++ b/components/konflux-ui/production/stone-prd-rh01/configure-oauth-proxy-secret.yaml
@@ -88,7 +88,7 @@ spec:
               | kubectl apply -f -
 
           echo "Restarting the proxy deployment"
-          if kubectl get deployment/proxy; then
+          if kubectl -n "$namespace" get deployment/proxy; then
             kubectl -n "$namespace" rollout restart deployment/proxy
           else
             echo "skipping restart"

--- a/components/konflux-ui/production/stone-prod-p01/configure-oauth-proxy-secret.yaml
+++ b/components/konflux-ui/production/stone-prod-p01/configure-oauth-proxy-secret.yaml
@@ -88,7 +88,7 @@ spec:
               | kubectl apply -f -
 
           echo "Restarting the proxy deployment"
-          if kubectl get deployment/proxy; then
+          if kubectl -n "$namespace" get deployment/proxy; then
             kubectl -n "$namespace" rollout restart deployment/proxy
           else
             echo "skipping restart"

--- a/components/konflux-ui/production/stone-prod-p02/configure-oauth-proxy-secret.yaml
+++ b/components/konflux-ui/production/stone-prod-p02/configure-oauth-proxy-secret.yaml
@@ -88,7 +88,7 @@ spec:
               | kubectl apply -f -
 
           echo "Restarting the proxy deployment"
-          if kubectl get deployment/proxy; then
+          if kubectl -n "$namespace" get deployment/proxy; then
             kubectl -n "$namespace" rollout restart deployment/proxy
           else
             echo "skipping restart"

--- a/components/konflux-ui/staging/stone-stage-p01/configure-oauth-proxy-secret.yaml
+++ b/components/konflux-ui/staging/stone-stage-p01/configure-oauth-proxy-secret.yaml
@@ -88,7 +88,7 @@ spec:
               | kubectl apply -f -
 
           echo "Restarting the proxy deployment"
-          if kubectl get deployment/proxy; then
+          if kubectl -n "$namespace" get deployment/proxy; then
             kubectl -n "$namespace" rollout restart deployment/proxy
           else
             echo "skipping restart"

--- a/components/konflux-ui/staging/stone-stg-rh01/configure-oauth-proxy-secret.yaml
+++ b/components/konflux-ui/staging/stone-stg-rh01/configure-oauth-proxy-secret.yaml
@@ -88,7 +88,7 @@ spec:
               | kubectl apply -f -
 
           echo "Restarting the proxy deployment"
-          if kubectl get deployment/proxy; then
+          if kubectl -n "$namespace" get deployment/proxy; then
             kubectl -n "$namespace" rollout restart deployment/proxy
           else
             echo "skipping restart"


### PR DESCRIPTION
The job in charge of regenerating the secrets used for authentication was not restarting the proxy

Signed-off-by: Francesco Ilario <filario@redhat.com>
