### PR TITLE
 fix: add ServerSideApply to sync release-service

### DIFF
--- a/argo-cd-apps/base/member/infra-deployments/release/release.yaml
+++ b/argo-cd-apps/base/member/infra-deployments/release/release.yaml
@@ -33,6 +33,7 @@ spec:
           selfHeal: true
         syncOptions:
         - CreateNamespace=true
+        - ServerSideApply=true
         retry:
           limit: 50
           backoff:


### PR DESCRIPTION
this PR sets the ServerSideApply flag to argocd
syncOptions, to avoid errors syncing big chuncks
of text present in Release CRDs, that are added
to the object annotations.

Signed-off-by: Leandro Mendes <lmendes@redhat.com>