### PR TITLE
Run Vector pods only on nodes running pipelines

### DIFF
--- a/components/vector-tekton-logs-collector/development/vector-helm-values.yaml
+++ b/components/vector-tekton-logs-collector/development/vector-helm-values.yaml
@@ -102,10 +102,13 @@ env:
       secretKeyRef:
         name: tekton-results-s3
         key: endpoint
+nodeSelector:
+  konflux-ci.dev/workload: konflux-tenants
 tolerations:
   - effect: NoSchedule
     key: konflux-ci.dev/workload
-    operator: Exists
+    operator: Equal
+    value: konflux-tenants
 securityContext:
   allowPrivilegeEscalation: false
   capabilities:

--- a/components/vector-tekton-logs-collector/staging/vector-helm-values.yaml
+++ b/components/vector-tekton-logs-collector/staging/vector-helm-values.yaml
@@ -102,10 +102,13 @@ env:
       secretKeyRef:
         name: tekton-results-s3
         key: endpoint
+nodeSelector:
+  konflux-ci.dev/workload: konflux-tenants
 tolerations:
   - effect: NoSchedule
     key: konflux-ci.dev/workload
-    operator: Exists
+    operator: Equal
+    value: konflux-tenants
 securityContext:
   allowPrivilegeEscalation: false
   capabilities:


### PR DESCRIPTION
This limits the Vector pods only to nodes used to run user pipelines.