### PR TITLE
konfluxui: add replace and force argocd annotation to job

### DIFF
--- a/components/konflux-ui/staging/stone-stage-p01/configure-oauth-proxy-secret.yaml
+++ b/components/konflux-ui/staging/stone-stage-p01/configure-oauth-proxy-secret.yaml
@@ -45,6 +45,8 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: konflux-generate-oauth-proxy-secrets
+  annotations:
+    argocd.argoproj.io/sync-options: Force=true,Replace=true
 spec:
   template:
     spec:

--- a/components/konflux-ui/staging/stone-stg-rh01/configure-oauth-proxy-secret.yaml
+++ b/components/konflux-ui/staging/stone-stg-rh01/configure-oauth-proxy-secret.yaml
@@ -45,6 +45,8 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: konflux-generate-oauth-proxy-secrets
+  annotations:
+    argocd.argoproj.io/sync-options: Force=true,Replace=true
 spec:
   template:
     spec:


### PR DESCRIPTION
ArgoCD errors synching the Job because the PodSpec is an immutable field.
This annotation will force the deletion of the job before creating the new version

Signed-off-by: Francesco Ilario <filario@redhat.com>
