### PR TITLE
namespace-lister: filter by konflux-ci.dev label

### DIFF
--- a/components/namespace-lister/base/patches/with_cachenamespacelabelselector.yaml
+++ b/components/namespace-lister/base/patches/with_cachenamespacelabelselector.yaml
@@ -2,4 +2,4 @@
   path: /spec/template/spec/containers/0/env/-
   value:
     name: CACHE_NAMESPACE_LABELSELECTOR
-    value: 'toolchain.dev.openshift.com/type=tenant'
+    value: 'konflux-ci.dev/type=tenant'


### PR DESCRIPTION
As  #5759 got merged, we can now rely on the new label in staging.

Signed-off-by: Francesco Ilario <filario@redhat.com>
