### PR TITLE
Disable pause pods in production for ephemeral cluster provisioning

### DIFF
--- a/components/cluster-as-a-service/base/clustertemplates.yaml
+++ b/components/cluster-as-a-service/base/clustertemplates.yaml
@@ -42,7 +42,5 @@ spec:
               value: cluster-provisioner
             - name: nodePoolReplicas
               value: "3"
-            - name: pausePod.priorityClass
-              value: pause-pod-priority
       syncPolicy:
         automated: {}

--- a/components/cluster-as-a-service/base/kustomization.yaml
+++ b/components/cluster-as-a-service/base/kustomization.yaml
@@ -9,4 +9,3 @@ resources:
   - rbac.yaml
   - clustertemplatequotas.yaml
   - clustertemplates.yaml
-  - priorityclass.yaml

--- a/components/cluster-as-a-service/base/priorityclass.yaml
+++ b/components/cluster-as-a-service/base/priorityclass.yaml
@@ -1,8 +1,0 @@
----
-apiVersion: scheduling.k8s.io/v1
-kind: PriorityClass
-metadata:
-  name: pause-pod-priority
-value: -10
-globalDefault: false
-description: Priority class used by pause pods to over provision

--- a/components/cluster-as-a-service/production/add-hypershift-params.yaml
+++ b/components/cluster-as-a-service/production/add-hypershift-params.yaml
@@ -16,14 +16,3 @@
   value:
     name: hypershiftRoleArn
     value: arn:aws:iam::590184136207:role/eaas-hypershift-cli-role
-
-- op: add
-  path: /spec/template/spec/source/helm/parameters/-
-  value:
-    # Over provision the workload with a pause container so there are always resources
-    # available when the hub cluster needs to scale up. The autoscaler will evict this low
-    # priority pod and schedule it on newly provisioned nodes. This will allow higher
-    # priority control plane pods to immediately consume the freed up resources on
-    # existing nodes.
-    name: pausePod.enabled
-    value: "true"


### PR DESCRIPTION
Testing in staging demonstrated that these pause pods didn't make much difference in overall performance and stability.