### PR TITLE
Add Role For Monitoring Release Pipelines

### DIFF
--- a/components/release/base/kustomization.yaml
+++ b/components/release/base/kustomization.yaml
@@ -1,7 +1,7 @@
 resources:
   - allow-argocd-to-manage.yaml
   - argocd-permissions.yaml
-  - release-pipeline-monitor-role.yaml
+  - monitor-pipeline-role.yaml
   - release-pipeline-resources-clusterrole.yaml
   - release-service-config-rbac.yaml
   - release-service-configurator-role.yaml

--- a/components/release/base/kustomization.yaml
+++ b/components/release/base/kustomization.yaml
@@ -1,11 +1,12 @@
 resources:
-- allow-argocd-to-manage.yaml
-- argocd-permissions.yaml
-- release-pipeline-resources-clusterrole.yaml
-- release-service-config-rbac.yaml
-- release-service-configurator-role.yaml
-- release-team.yaml
-- cronjobs/
+  - allow-argocd-to-manage.yaml
+  - argocd-permissions.yaml
+  - release-pipeline-monitor-role.yaml
+  - release-pipeline-resources-clusterrole.yaml
+  - release-service-config-rbac.yaml
+  - release-service-configurator-role.yaml
+  - release-team.yaml
+  - cronjobs/
 
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/components/release/base/monitor-pipeline-role.yaml
+++ b/components/release/base/monitor-pipeline-role.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: monitor-release-pipeline-role
+  name: monitor-pipeline-role
 rules:
   - apiGroups: [""]
     resources: ["pods", "pods/log"]

--- a/components/release/base/release-pipeline-monitor-role.yaml
+++ b/components/release/base/release-pipeline-monitor-role.yaml
@@ -8,5 +8,5 @@ rules:
     resources: ["pods", "pods/log"]
     verbs: ["get", "watch", "list"]
   - apiGroups: ["tekton.dev"]
-    resources: ["pods", "pods/log"]
+    resources: ["pipelineruns", "pipelines"]
     verbs: ["get", "watch", "list"]

--- a/components/release/base/release-pipeline-monitor-role.yaml
+++ b/components/release/base/release-pipeline-monitor-role.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: monitor-release-pipeline-role
+rules:
+  - apiGroups:
+      - tekton.dev
+      - ""
+    resources:
+      - pipelineruns
+      - pipelines
+      - pods
+      - pods/logs
+    verbs:
+      - get
+      - list
+      - watch

--- a/components/release/base/release-pipeline-monitor-role.yaml
+++ b/components/release/base/release-pipeline-monitor-role.yaml
@@ -4,15 +4,9 @@ kind: ClusterRole
 metadata:
   name: monitor-release-pipeline-role
 rules:
-  - apiGroups:
-      - tekton.dev
-      - ""
-    resources:
-      - pipelineruns
-      - pipelines
-      - pods
-      - pods/logs
-    verbs:
-      - get
-      - list
-      - watch
+  - apiGroups: [""]
+    resources: ["pods", "pods/log"]
+    verbs: ["get", "watch", "list"]
+  - apiGroups: ["tekton.dev"]
+    resources: ["pods", "pods/log"]
+    verbs: ["get", "watch", "list"]


### PR DESCRIPTION
We want to create a service account that can be used by users to automate monitoring the status of their managed release pipelines. The thought for now is it will only require:
* get
* list
* watch

permissions for:
* pipelineruns
* pipelines
* pods
* pods/logs