### PR TITLE
chore: remove konflux-test repository from tekton-ci namespace

### DIFF
--- a/components/tekton-ci/base/repository.yaml
+++ b/components/tekton-ci/base/repository.yaml
@@ -16,13 +16,6 @@ spec:
 apiVersion: pipelinesascode.tekton.dev/v1alpha1
 kind: Repository
 metadata:
-  name: konflux-test
-spec:
-  url: "https://github.com/konflux-ci/konflux-test"
----
-apiVersion: pipelinesascode.tekton.dev/v1alpha1
-kind: Repository
-metadata:
   name: gitops-repo-pruner
 spec:
   url: "https://github.com/redhat-appstudio/gitops-repo-pruner"


### PR DESCRIPTION
The konflux-test repository was left over from the migration to konflux-ci.  The repository is no longer needed and is preventing the integration team from onboarding the konflux-test repo to konflux.