### PR TITLE
Align MPC VMs between p02 and rh01

### DIFF
--- a/components/multi-platform-controller/production-downstream/stone-prod-p02/host-config.yaml
+++ b/components/multi-platform-controller/production-downstream/stone-prod-p02/host-config.yaml
@@ -528,7 +528,7 @@ data:
   dynamic.linux-s390x.region: "us-east-1"
   dynamic.linux-s390x.url: "https://us-east.iaas.cloud.ibm.com/v1"
   dynamic.linux-s390x.profile: "bz2-2x8"
-  dynamic.linux-s390x.max-instances: "50"
+  dynamic.linux-s390x.max-instances: "30"
   dynamic.linux-s390x.private-ip: "true"
   dynamic.linux-s390x.allocation-timeout: "1800"
   dynamic.linux-s390x.instance-tag: prod-s390x
@@ -544,7 +544,7 @@ data:
   dynamic.linux-large-s390x.region: "us-east-1"
   dynamic.linux-large-s390x.url: "https://us-east.iaas.cloud.ibm.com/v1"
   dynamic.linux-large-s390x.profile: "bz2-4x16"
-  dynamic.linux-large-s390x.max-instances: "50"
+  dynamic.linux-large-s390x.max-instances: "10"
   dynamic.linux-large-s390x.private-ip: "true"
   dynamic.linux-large-s390x.allocation-timeout: "1800"
   dynamic.linux-large-s390x.instance-tag: prod-s390x-large
@@ -561,7 +561,7 @@ data:
   dynamic.linux-d200-large-s390x.region: "us-east-1"
   dynamic.linux-d200-large-s390x.url: "https://us-east.iaas.cloud.ibm.com/v1"
   dynamic.linux-d200-large-s390x.profile: "bz2-4x16"
-  dynamic.linux-d200-large-s390x.max-instances: "50"
+  dynamic.linux-d200-large-s390x.max-instances: "10"
   dynamic.linux-d200-large-s390x.private-ip: "true"
   dynamic.linux-d200-large-s390x.allocation-timeout: "1800"
   dynamic.linux-d200-large-s390x.disk: "200"
@@ -577,9 +577,9 @@ data:
   dynamic.linux-ppc64le.url: "https://us-east.power-iaas.cloud.ibm.com"
   dynamic.linux-ppc64le.network: "a6d8d6da-c412-4106-9b57-4e25541b2e7f"
   dynamic.linux-ppc64le.system: "e980"
-  dynamic.linux-ppc64le.cores: "1"
+  dynamic.linux-ppc64le.cores: "2"
   dynamic.linux-ppc64le.memory: "8"
-  dynamic.linux-ppc64le.max-instances: "50"
+  dynamic.linux-ppc64le.max-instances: "30"
   dynamic.linux-ppc64le.allocation-timeout: "1800"
   dynamic.linux-ppc64le.instance-tag: prod-ppc64le
 
@@ -593,9 +593,9 @@ data:
   dynamic.linux-large-ppc64le.url: "https://us-east.power-iaas.cloud.ibm.com"
   dynamic.linux-large-ppc64le.network: "a6d8d6da-c412-4106-9b57-4e25541b2e7f"
   dynamic.linux-large-ppc64le.system: "e980"
-  dynamic.linux-large-ppc64le.cores: "2"
-  dynamic.linux-large-ppc64le.memory: "32"
-  dynamic.linux-large-ppc64le.max-instances: "50"
+  dynamic.linux-large-ppc64le.cores: "4"
+  dynamic.linux-large-ppc64le.memory: "16"
+  dynamic.linux-large-ppc64le.max-instances: "10"
   dynamic.linux-large-ppc64le.allocation-timeout: "1800"
   dynamic.linux-large-ppc64le.instance-tag: prod-ppc64le-large
 
@@ -611,7 +611,7 @@ data:
   dynamic.linux-d200-large-ppc64le.system: "e980"
   dynamic.linux-d200-large-ppc64le.cores: "4"
   dynamic.linux-d200-large-ppc64le.memory: "16"
-  dynamic.linux-d200-large-ppc64le.max-instances: "50"
+  dynamic.linux-d200-large-ppc64le.max-instances: "10"
   dynamic.linux-d200-large-ppc64le.allocation-timeout: "1800"
   dynamic.linux-d200-large-ppc64le.disk: "200"
 


### PR DESCRIPTION
We should have the same spec between environments for documentation simplicity but also for user experience, large in one environment should be the same on another one.

[KONFLUX-6961](https://issues.redhat.com//browse/KONFLUX-6961)