### PR TITLE
kubearchive's policy: add support for new tenant label

### DIFF
--- a/components/kubearchive/policies/.chainsaw-test/chainsaw-test.yaml
+++ b/components/kubearchive/policies/.chainsaw-test/chainsaw-test.yaml
@@ -2,6 +2,46 @@
 apiVersion: chainsaw.kyverno.io/v1alpha1
 kind: Test
 metadata:
+  name: mutate-new-namespace-konfluxcidev
+spec:
+  description: |
+    tests that the KubeArchiveConfig is created in a namespace
+    labelled with `konflux-ci.dev/type=tenant`
+  concurrent: false
+  namespace: 'generate-new-namespace'
+  bindings:
+  - name: suffix
+    value: konfluxcidev
+  steps:
+  - name: given-kubearchiveconfig-crd-exists
+    try:
+    - apply:
+        file: resources/kubearchive-crd.yaml
+  - name: given-kyverno-has-permission-on-resources
+    try:
+    - apply:
+        file: ../kyverno_rbac.yaml
+  - name: given-cluster-policy-is-ready
+    try:
+    - apply:
+        file: ../bootstrap-namespace.yaml
+    - assert:
+        file: chainsaw-assert-clusterpolicy.yaml
+  - name: when-konfluxcidev-labeled-namespace-is-created
+    try:
+    - apply:
+        file: resources/actual-namespace-konfluxcidev.yaml
+        template: true
+  - name: then-kubearchiveconfig-is-created
+    try:
+    - assert:
+        file: resources/expected-kubearchiveconfig.yaml
+        template: true
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
   name: mutate-new-namespace-konflux
 spec:
   description: |
@@ -184,6 +224,46 @@ spec:
     try:
     - apply:
         file: resources/actual-namespace-konflux.yaml
+        template: true
+  - name: when-cluster-policy-is-ready
+    try:
+    - apply:
+        file: ../bootstrap-namespace.yaml
+    - assert:
+        file: chainsaw-assert-clusterpolicy.yaml
+  - name: then-kubearchiveconfig-is-created
+    try:
+    - assert:
+        file: resources/expected-kubearchiveconfig.yaml
+        template: true
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: mutate-existing-namespace-konfluxcidev
+spec:
+  description: |
+    tests that the KubeArchiveConfig is created in an already existing
+    namespace labelled with `konflux-ci.dev/type=tenant`
+  concurrent: false
+  namespace: 'generate-existing-namespace'
+  bindings:
+  - name: suffix
+    value: konflux
+  steps:
+  - name: given-kubearchiveconfig-crd-exists
+    try:
+    - apply:
+        file: resources/kubearchive-crd.yaml
+  - name: given-kyverno-has-permission-on-resources
+    try:
+    - apply:
+        file: ../kyverno_rbac.yaml
+  - name: given-konfluxci-labeled-namespace-is-created
+    try:
+    - apply:
+        file: resources/actual-namespace-konfluxcidev.yaml
         template: true
   - name: when-cluster-policy-is-ready
     try:

--- a/components/kubearchive/policies/.chainsaw-test/resources/actual-namespace-konfluxcidev.yaml
+++ b/components/kubearchive/policies/.chainsaw-test/resources/actual-namespace-konfluxcidev.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: (join('-', [$namespace, $suffix]))
+  labels:
+    konflux-ci.dev/type: tenant

--- a/components/kubearchive/policies/bootstrap-namespace.yaml
+++ b/components/kubearchive/policies/bootstrap-namespace.yaml
@@ -19,6 +19,12 @@ spec:
           selector:
             matchLabels:
               konflux.ci/type: user
+      - resources:
+          kinds:
+          - Namespace
+          selector:
+            matchLabels:
+              konflux-ci.dev/type: tenant
     generate:
       generateExisting: true
       apiVersion: kubearchive.kubearchive.org/v1alpha1


### PR DESCRIPTION
Requires:
* #5645

This PR adds support for the new tenant label in the policy that generates the KubeArchiveConfig in each tenant namespace.

