### PR TITLE
KubeArchive: pull release file to remove the dependency

### DIFF
--- a/components/kubearchive/base/kubearchive.yaml
+++ b/components/kubearchive/base/kubearchive.yaml
@@ -1,0 +1,1093 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    app.kubernetes.io/component: namespace
+    app.kubernetes.io/name: kubearchive
+    app.kubernetes.io/part-of: kubearchive
+    app.kubernetes.io/version: v0.12.1
+  name: kubearchive
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: kubearchive/kubearchive-operator-certificate
+    controller-gen.kubebuilder.io/version: v0.14.0
+  name: kubearchiveconfigs.kubearchive.kubearchive.org
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: webhook-service
+          namespace: kubearchive
+          path: /convert
+      conversionReviewVersions:
+        - v1
+  group: kubearchive.kubearchive.org
+  names:
+    kind: KubeArchiveConfig
+    listKind: KubeArchiveConfigList
+    plural: kubearchiveconfigs
+    shortNames:
+      - kac
+      - kacs
+    singular: kubearchiveconfig
+  scope: Namespaced
+  versions:
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: KubeArchiveConfig is the Schema for the kubearchiveconfigs API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: KubeArchiveConfigSpec defines the desired state of KubeArchiveConfig
+              properties:
+                resources:
+                  items:
+                    properties:
+                      archiveOnDelete:
+                        type: string
+                      archiveWhen:
+                        type: string
+                      deleteWhen:
+                        type: string
+                      selector:
+                        description: APIVersionKindSelector is an APIVersion Kind tuple with a LabelSelector.
+                        properties:
+                          apiVersion:
+                            description: APIVersion - the API version of the resource to watch.
+                            type: string
+                          kind:
+                            description: |-
+                              Kind of the resource to watch.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                            type: string
+                          selector:
+                            description: |-
+                              LabelSelector filters this source to objects to those resources pass the
+                              label selector.
+                              More info: http://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                items:
+                                  description: |-
+                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector applies to.
+                                      type: string
+                                    operator:
+                                      description: |-
+                                        operator represents a key's relationship to a set of values.
+                                        Valid operators are In, NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: |-
+                                        values is an array of string values. If the operator is In or NotIn,
+                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                        the values array must be empty. This array is replaced during a strategic
+                                        merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  required:
+                                    - key
+                                    - operator
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                type: object
+                            type: object
+                            x-kubernetes-map-type: atomic
+                        required:
+                          - apiVersion
+                          - kind
+                        type: object
+                    type: object
+                  type: array
+              type: object
+            status:
+              description: KubeArchiveConfigStatus defines the observed state of KubeArchiveConfig
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/component: api-server
+    app.kubernetes.io/name: kubearchive-api-server
+    app.kubernetes.io/part-of: kubearchive
+    app.kubernetes.io/version: v0.12.1
+  name: kubearchive-api-server
+  namespace: kubearchive
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/component: operator
+    app.kubernetes.io/name: kubearchive-operator
+    app.kubernetes.io/part-of: kubearchive
+    app.kubernetes.io/version: v0.12.1
+  name: kubearchive-operator
+  namespace: kubearchive
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/component: sink
+    app.kubernetes.io/name: kubearchive-sink
+    app.kubernetes.io/part-of: kubearchive
+    app.kubernetes.io/version: v0.12.1
+  name: kubearchive-sink
+  namespace: kubearchive
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/component: operator
+    app.kubernetes.io/name: kubearchive-operator-leader-election
+    app.kubernetes.io/part-of: kubearchive
+    app.kubernetes.io/version: v0.12.1
+  name: kubearchive-operator-leader-election
+  namespace: kubearchive
+rules:
+  - apiGroups:
+      - ''
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - ''
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/component: sink
+    app.kubernetes.io/name: kubearchive-sink-watch
+    app.kubernetes.io/part-of: kubearchive
+    app.kubernetes.io/version: v0.12.1
+  name: kubearchive-sink-watch
+  namespace: kubearchive
+rules:
+  - apiGroups:
+      - ''
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: api-server
+    app.kubernetes.io/name: kubearchive-api-server
+    app.kubernetes.io/part-of: kubearchive
+    app.kubernetes.io/version: v0.12.1
+  name: kubearchive-api-server
+rules:
+  - apiGroups:
+      - authorization.k8s.io
+      - authentication.k8s.io
+    resources:
+      - subjectaccessreviews
+      - tokenreviews
+    verbs:
+      - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kubearchive-operator
+rules:
+  - apiGroups:
+      - ''
+    resources:
+      - configmaps
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - update
+      - watch
+  - apiGroups:
+      - ''
+    resources:
+      - namespaces
+    verbs:
+      - get
+      - list
+      - update
+      - watch
+  - apiGroups:
+      - ''
+    resources:
+      - serviceaccounts
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - update
+      - watch
+  - apiGroups:
+      - kubearchive.kubearchive.org
+    resources:
+      - kubearchiveconfigs
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - kubearchive.kubearchive.org
+    resources:
+      - kubearchiveconfigs/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - kubearchive.kubearchive.org
+    resources:
+      - kubearchiveconfigs/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - clusterroles
+      - rolebindings
+      - roles
+    verbs:
+      - bind
+      - create
+      - delete
+      - escalate
+      - get
+      - list
+      - update
+      - watch
+  - apiGroups:
+      - sources.knative.dev
+    resources:
+      - apiserversources
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - update
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: operator
+    app.kubernetes.io/name: kubearchive-operator-config-editor
+    app.kubernetes.io/part-of: kubearchive
+    app.kubernetes.io/version: v0.12.1
+  name: kubearchive-operator-config-editor
+rules:
+  - apiGroups:
+      - kubearchive.kubearchive.org
+    resources:
+      - kubearchiveconfigs
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - kubearchive.kubearchive.org
+    resources:
+      - kubearchiveconfigs/status
+    verbs:
+      - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: operator
+    app.kubernetes.io/name: kubearchive-operator-config-viewer
+    app.kubernetes.io/part-of: kubearchive
+    app.kubernetes.io/version: v0.12.1
+  name: kubearchive-operator-config-viewer
+rules:
+  - apiGroups:
+      - kubearchive.kubearchive.org
+    resources:
+      - kubearchiveconfigs
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - kubearchive.kubearchive.org
+    resources:
+      - kubearchiveconfigs/status
+    verbs:
+      - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/component: operator
+    app.kubernetes.io/name: kubearchive-operator-leader-election
+    app.kubernetes.io/part-of: kubearchive
+    app.kubernetes.io/version: v0.12.1
+  name: kubearchive-operator-leader-election
+  namespace: kubearchive
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: kubearchive-operator-leader-election
+subjects:
+  - kind: ServiceAccount
+    name: kubearchive-operator
+    namespace: kubearchive
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/component: sink
+    app.kubernetes.io/name: kubearchive-sink-watch
+    app.kubernetes.io/part-of: kubearchive
+    app.kubernetes.io/version: v0.12.1
+  name: kubearchive-sink-watch
+  namespace: kubearchive
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: kubearchive-sink-watch
+subjects:
+  - kind: ServiceAccount
+    name: kubearchive-sink
+    namespace: kubearchive
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/component: api-server
+    app.kubernetes.io/name: kubearchive-api-server
+    app.kubernetes.io/part-of: kubearchive
+    app.kubernetes.io/version: v0.12.1
+  name: kubearchive-api-server
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kubearchive-api-server
+subjects:
+  - kind: ServiceAccount
+    name: kubearchive-api-server
+    namespace: kubearchive
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/component: operator
+    app.kubernetes.io/name: kubearchive-operator
+    app.kubernetes.io/part-of: kubearchive
+    app.kubernetes.io/version: v0.12.1
+  name: kubearchive-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kubearchive-operator
+subjects:
+  - kind: ServiceAccount
+    name: kubearchive-operator
+    namespace: kubearchive
+---
+apiVersion: v1
+data: null
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/component: logging
+    app.kubernetes.io/name: kubearchive-logging
+    app.kubernetes.io/part-of: kubearchive
+    app.kubernetes.io/version: v0.12.1
+  name: kubearchive-logging
+  namespace: kubearchive
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/component: operator
+    app.kubernetes.io/name: sink-filters
+    app.kubernetes.io/part-of: kubearchive
+    app.kubernetes.io/version: v0.12.1
+  name: sink-filters
+  namespace: kubearchive
+---
+apiVersion: v1
+data:
+  DATABASE_DB: a3ViZWFyY2hpdmU=
+  DATABASE_KIND: cG9zdGdyZXNxbA==
+  DATABASE_PASSWORD: RGF0YWJhczNQYXNzdzByZA== # notsecret
+  DATABASE_PORT: NTQzMg==
+  DATABASE_URL: a3ViZWFyY2hpdmUtcncucG9zdGdyZXNxbC5zdmMuY2x1c3Rlci5sb2NhbA==
+  DATABASE_USER: a3ViZWFyY2hpdmU=
+kind: Secret
+metadata:
+  labels:
+    app.kubernetes.io/component: database
+    app.kubernetes.io/name: kubearchive-database-credentials
+    app.kubernetes.io/part-of: kubearchive
+    app.kubernetes.io/version: v0.12.1
+  name: kubearchive-database-credentials
+  namespace: kubearchive
+type: Opaque
+---
+apiVersion: v1
+data:
+  PASSWORD: Y2hhbmdlbWU= # notsecret
+  USER: YWRtaW4=
+kind: Secret
+metadata:
+  labels:
+    app.kubernetes.io/component: logging
+    app.kubernetes.io/name: kubearchive-logging
+    app.kubernetes.io/part-of: kubearchive
+    app.kubernetes.io/version: v0.12.1
+  name: kubearchive-logging
+  namespace: kubearchive
+type: Opaque
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: api-server
+    app.kubernetes.io/name: kubearchive-api-server
+    app.kubernetes.io/part-of: kubearchive
+    app.kubernetes.io/version: v0.12.1
+  name: kubearchive-api-server
+  namespace: kubearchive
+spec:
+  ports:
+    - name: server
+      port: 8081
+      protocol: TCP
+      targetPort: 8081
+  selector:
+    app: kubearchive-api-server
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: operator
+    app.kubernetes.io/name: kubearchive-operator-webhooks
+    app.kubernetes.io/part-of: kubearchive
+    app.kubernetes.io/version: v0.12.1
+  name: kubearchive-operator-webhooks
+  namespace: kubearchive
+spec:
+  ports:
+    - name: webhook-server
+      port: 443
+      protocol: TCP
+      targetPort: 9443
+    - name: pprof-server
+      port: 8082
+      protocol: TCP
+      targetPort: 8082
+  selector:
+    control-plane: controller-manager
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: sink
+    app.kubernetes.io/name: kubearchive-sink
+    app.kubernetes.io/part-of: kubearchive
+    app.kubernetes.io/version: v0.12.1
+  name: kubearchive-sink
+  namespace: kubearchive
+spec:
+  ports:
+    - port: 80
+      protocol: TCP
+      targetPort: 8080
+  selector:
+    app: kubearchive-sink
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/component: api-server
+    app.kubernetes.io/name: kubearchive-api-server
+    app.kubernetes.io/part-of: kubearchive
+    app.kubernetes.io/version: v0.12.1
+  name: kubearchive-api-server
+  namespace: kubearchive
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kubearchive-api-server
+  template:
+    metadata:
+      labels:
+        app: kubearchive-api-server
+    spec:
+      containers:
+        - env:
+            - name: KUBEARCHIVE_ENABLE_PPROF
+              value: 'true'
+            - name: LOG_LEVEL
+              value: INFO
+            - name: GIN_MODE
+              value: release
+            - name: KUBEARCHIVE_OTEL_MODE
+              value: disabled
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: ''
+            - name: KUBEARCHIVE_OTLP_SEND_LOGS
+              value: 'false'
+            - name: OTEL_GO_X_DEPRECATED_RUNTIME_METRICS
+              value: 'false'
+            - name: GOMEMLIMIT
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.memory
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.cpu
+            - name: CACHE_EXPIRATION_AUTHORIZED
+              value: 10m
+            - name: CACHE_EXPIRATION_UNAUTHORIZED
+              value: 1m
+            - name: KUBEARCHIVE_LOGGING_DIR
+              value: /data/logging
+          envFrom:
+            - secretRef:
+                name: kubearchive-database-credentials
+          image: quay.io/kubearchive/api:v0.12.1@sha256:3dcc37943830e436d24824500e2ae1e460a84f35939655106bebe958513b6d29
+          livenessProbe:
+            httpGet:
+              path: /livez
+              port: 8081
+              scheme: HTTPS
+          name: kubearchive-api-server
+          ports:
+            - containerPort: 8081
+              name: server
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 8081
+              scheme: HTTPS
+          resources:
+            limits:
+              cpu: 700m
+              memory: 256Mi
+            requests:
+              cpu: 200m
+              memory: 230Mi
+          volumeMounts:
+            - mountPath: /etc/kubearchive/ssl/
+              name: tls-secret
+              readOnly: true
+            - mountPath: /data/logging
+              name: logging-secret
+      serviceAccountName: kubearchive-api-server
+      volumes:
+        - name: tls-secret
+          secret:
+            secretName: kubearchive-api-server-tls
+        - name: logging-secret
+          secret:
+            secretName: kubearchive-logging
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/component: operator
+    app.kubernetes.io/name: kubearchive-operator
+    app.kubernetes.io/part-of: kubearchive
+    app.kubernetes.io/version: v0.12.1
+  name: kubearchive-operator
+  namespace: kubearchive
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      control-plane: controller-manager
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: manager
+      labels:
+        control-plane: controller-manager
+    spec:
+      containers:
+        - args:
+            - --health-probe-bind-address=:8081
+            - --leader-elect
+          env:
+            - name: KUBEARCHIVE_ENABLE_PPROF
+              value: 'true'
+            - name: LOG_LEVEL
+              value: INFO
+            - name: KUBEARCHIVE_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: KUBEARCHIVE_OTEL_MODE
+              value: disabled
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: ''
+            - name: KUBEARCHIVE_OTLP_SEND_LOGS
+              value: 'false'
+            - name: OTEL_GO_X_DEPRECATED_RUNTIME_METRICS
+              value: 'false'
+            - name: GOMEMLIMIT
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.memory
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.cpu
+          image: quay.io/kubearchive/operator:v0.12.1@sha256:b494529db55a3c8faa7fdd5f2e8c9609958d1d4717464c3e1532d88c5881e586
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8081
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          name: manager
+          ports:
+            - containerPort: 9443
+              name: webhook-server
+              protocol: TCP
+            - containerPort: 8082
+              name: pprof-server
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 8081
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            limits:
+              cpu: 500m
+              memory: 128Mi
+            requests:
+              cpu: 10m
+              memory: 64Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - mountPath: /tmp/k8s-webhook-server/serving-certs
+              name: cert
+              readOnly: true
+      securityContext:
+        runAsNonRoot: true
+      serviceAccountName: kubearchive-operator
+      terminationGracePeriodSeconds: 10
+      volumes:
+        - name: cert
+          secret:
+            defaultMode: 420
+            secretName: kubearchive-operator-tls
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/component: sink
+    app.kubernetes.io/name: kubearchive-sink
+    app.kubernetes.io/part-of: kubearchive
+    app.kubernetes.io/version: v0.12.1
+  name: kubearchive-sink
+  namespace: kubearchive
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kubearchive-sink
+  template:
+    metadata:
+      labels:
+        app: kubearchive-sink
+    spec:
+      containers:
+        - env:
+            - name: KUBEARCHIVE_ENABLE_PPROF
+              value: 'true'
+            - name: GIN_MODE
+              value: release
+            - name: LOG_LEVEL
+              value: INFO
+            - name: KUBEARCHIVE_OTEL_MODE
+              value: disabled
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: ''
+            - name: KUBEARCHIVE_OTLP_SEND_LOGS
+              value: 'false'
+            - name: OTEL_GO_X_DEPRECATED_RUNTIME_METRICS
+              value: 'false'
+            - name: GOMEMLIMIT
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.memory
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.cpu
+            - name: KUBEARCHIVE_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: KUBEARCHIVE_LOGGING_DIR
+              value: /data/logging
+          envFrom:
+            - secretRef:
+                name: kubearchive-database-credentials
+          image: quay.io/kubearchive/sink:v0.12.1@sha256:ae0bd5e633a67ba87bb6595dd97a13d7d2036c038d37ea693b849109e538d37e
+          livenessProbe:
+            httpGet:
+              path: /livez
+              port: 8080
+          name: kubearchive-sink
+          ports:
+            - containerPort: 8080
+              name: sink
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 8080
+          resources:
+            limits:
+              cpu: 200m
+              memory: 256Mi
+            requests:
+              cpu: 200m
+              memory: 230Mi
+          volumeMounts:
+            - mountPath: /data/logging
+              name: logging-config
+      serviceAccountName: kubearchive-sink
+      volumes:
+        - configMap:
+            name: kubearchive-logging
+          name: logging-config
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  labels:
+    app.kubernetes.io/component: api-server
+    app.kubernetes.io/name: kubearchive-api-server-certificate
+    app.kubernetes.io/part-of: kubearchive
+    app.kubernetes.io/version: v0.12.1
+  name: kubearchive-api-server-certificate
+  namespace: kubearchive
+spec:
+  commonName: kubearchive-api-server
+  dnsNames:
+    - localhost
+    - kubearchive-api-server
+    - kubearchive-api-server.kubearchive.svc
+  duration: 720h
+  isCA: false
+  issuerRef:
+    group: cert-manager.io
+    kind: Issuer
+    name: kubearchive
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  renewBefore: 360h
+  secretName: kubearchive-api-server-tls
+  subject:
+    organizations:
+      - kubearchive
+  usages:
+    - digital signature
+    - key encipherment
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  labels:
+    app.kubernetes.io/component: certs
+    app.kubernetes.io/name: kubearchive-ca
+    app.kubernetes.io/part-of: kubearchive
+    app.kubernetes.io/version: v0.12.1
+  name: kubearchive-ca
+  namespace: kubearchive
+spec:
+  commonName: kubearchive-ca-certificate
+  isCA: true
+  issuerRef:
+    group: cert-manager.io
+    kind: Issuer
+    name: kubearchive-ca
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  secretName: kubearchive-ca
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  labels:
+    app.kubernetes.io/component: operator
+    app.kubernetes.io/name: kubearchive-operator-certificate
+    app.kubernetes.io/part-of: kubearchive
+    app.kubernetes.io/version: v0.12.1
+  name: kubearchive-operator-certificate
+  namespace: kubearchive
+spec:
+  dnsNames:
+    - kubearchive-operator-webhooks.kubearchive.svc
+    - kubearchive-operator-webhooks.kubearchive.svc.cluster.local
+  issuerRef:
+    kind: Issuer
+    name: kubearchive
+  secretName: kubearchive-operator-tls
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  labels:
+    app.kubernetes.io/component: certs
+    app.kubernetes.io/name: kubearchive
+    app.kubernetes.io/part-of: kubearchive
+    app.kubernetes.io/version: v0.12.1
+  name: kubearchive
+  namespace: kubearchive
+spec:
+  ca:
+    secretName: kubearchive-ca
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  labels:
+    app.kubernetes.io/component: certs
+    app.kubernetes.io/name: kubearchive-ca
+    app.kubernetes.io/part-of: kubearchive
+    app.kubernetes.io/version: v0.12.1
+  name: kubearchive-ca
+  namespace: kubearchive
+spec:
+  selfSigned: {}
+---
+apiVersion: eventing.knative.dev/v1
+kind: Broker
+metadata:
+  labels:
+    app.kubernetes.io/component: sink
+    app.kubernetes.io/name: kubearchive-broker
+    app.kubernetes.io/part-of: kubearchive
+    app.kubernetes.io/version: v0.12.1
+  name: kubearchive-broker
+  namespace: kubearchive
+spec:
+  delivery:
+    backoffDelay: PT0.5S
+    backoffPolicy: linear
+    deadLetterSink:
+      ref:
+        apiVersion: eventing.knative.dev/v1
+        kind: Broker
+        name: kubearchive-dls
+    retry: 4
+---
+apiVersion: eventing.knative.dev/v1
+kind: Broker
+metadata:
+  labels:
+    app.kubernetes.io/component: sink
+    app.kubernetes.io/name: kubearchive-dls
+    app.kubernetes.io/part-of: kubearchive
+    app.kubernetes.io/version: v0.12.1
+  name: kubearchive-dls
+  namespace: kubearchive
+spec:
+  delivery:
+    backoffDelay: PT0.5S
+    backoffPolicy: linear
+    retry: 4
+---
+apiVersion: eventing.knative.dev/v1
+kind: Trigger
+metadata:
+  labels:
+    app.kubernetes.io/component: sink
+    app.kubernetes.io/name: kubearchive-sink
+    app.kubernetes.io/part-of: kubearchive
+    app.kubernetes.io/version: v0.12.1
+  name: kubearchive-sink
+  namespace: kubearchive
+spec:
+  broker: kubearchive-broker
+  subscriber:
+    ref:
+      apiVersion: v1
+      kind: Service
+      name: kubearchive-sink
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: kubearchive/kubearchive-operator-certificate
+  labels:
+    app.kubernetes.io/component: operator
+    app.kubernetes.io/name: kubearchive-mutating-webhook-configuration
+    app.kubernetes.io/part-of: kubearchive
+    app.kubernetes.io/version: v0.12.1
+  name: kubearchive-mutating-webhook-configuration
+webhooks:
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      service:
+        name: kubearchive-operator-webhooks
+        namespace: kubearchive
+        path: /mutate-kubearchive-kubearchive-org-v1alpha1-kubearchiveconfig
+    failurePolicy: Fail
+    name: mkubearchiveconfig.kb.io
+    rules:
+      - apiGroups:
+          - kubearchive.kubearchive.org
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - kubearchiveconfigs
+    sideEffects: None
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: kubearchive/kubearchive-operator-certificate
+  labels:
+    app.kubernetes.io/component: operator
+    app.kubernetes.io/name: kubearchive-validating-webhook-configuration
+    app.kubernetes.io/part-of: kubearchive
+    app.kubernetes.io/version: v0.12.1
+  name: kubearchive-validating-webhook-configuration
+webhooks:
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      service:
+        name: kubearchive-operator-webhooks
+        namespace: kubearchive
+        path: /validate-kubearchive-kubearchive-org-v1alpha1-kubearchiveconfig
+    failurePolicy: Fail
+    name: vkubearchiveconfig.kb.io
+    rules:
+      - apiGroups:
+          - kubearchive.kubearchive.org
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - kubearchiveconfigs
+    sideEffects: None
+
+---
+

--- a/components/kubearchive/base/kustomization.yaml
+++ b/components/kubearchive/base/kustomization.yaml
@@ -2,7 +2,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- https://github.com/kubearchive/kubearchive/releases/download/v0.12.1/kubearchive.yaml?timeout=90
+- kubearchive.yaml
 - rbac.yaml
 - kubearchive-config.yaml
 - kubearchive-maintainer.yaml


### PR DESCRIPTION
This PR pulls the manifests being used by KubeArchive (a patched version due to some problems with memory consumption) so the process is independent from GitHub. Soon KubeArchive will be renamed due to restrictions of the CNCF, so when the KubeArchive organization gets renamed the KubeArchive deployment here will fail. To avoid that scenario we copy the manifest in this PR.