### PR TITLE
feat: update kustomize binary

### DIFF
--- a/.github/workflows/kube-linter.yaml
+++ b/.github/workflows/kube-linter.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Kustomize
         uses: multani/action-setup-kustomize@v1
         with:
-          version: 5.1.1
+          version: 5.6.0
 
       - name: Run kustomize build
         run: |


### PR DESCRIPTION
this PR updates the kustomize binary to 5.6.0 as
the current one (5.1.1) does not support the new
patching format.

Signed-off-by: Leandro Mendes <lmendes@redhat.com>