### PR TITLE
nslister: use the new tenant label in prod

### DIFF
--- a/components/namespace-lister/production/base/patches/with_cachenamespacelabelselector.yaml
+++ b/components/namespace-lister/production/base/patches/with_cachenamespacelabelselector.yaml
@@ -2,4 +2,4 @@
   path: /spec/template/spec/containers/0/env/-
   value:
     name: CACHE_NAMESPACE_LABELSELECTOR
-    value: 'konflux.ci/type=user'
+    value: 'konflux-ci.dev/type=tenant'


### PR DESCRIPTION
The new tenant label  has been rolled out in prod.
This PR configures the namespace-lister to use this one to filter namespaces

Signed-off-by: Francesco Ilario <filario@redhat.com>
