### PR TITLE
kyverno: bump memory limits in stone-stg-rh01 to 1Gi

### DIFF
--- a/components/kyverno/staging/stone-stg-rh01/kyverno-helm-values.yaml
+++ b/components/kyverno/staging/stone-stg-rh01/kyverno-helm-values.yaml
@@ -26,10 +26,10 @@ backgroundController:
   resources:
     requests:
       cpu: 500m
-      memory: 512Mi
+      memory: 1Gi
     limits:
       cpu: 500m
-      memory: 512Mi
+      memory: 1Gi
   securityContext:
     allowPrivilegeEscalation: false
     readOnlyRootFilesystem: true


### PR DESCRIPTION
Like what we were seeing in stone-prd-rh01, the equivalent staging cluster doesn't have enough memory, so increase it.