### PR TITLE
kyverno: pull kubectl from mirror.gcr.io in prod

### DIFF
--- a/components/kyverno/production/kflux-ocp-p01/kyverno-helm-values.yaml
+++ b/components/kyverno/production/kflux-ocp-p01/kyverno-helm-values.yaml
@@ -62,6 +62,8 @@ reportsController:
       drop:
       - "ALL"
 policyReportsCleanup:
+  image:
+    registry: mirror.gcr.io
   securityContext:
     allowPrivilegeEscalation: false
     readOnlyRootFilesystem: true
@@ -72,6 +74,8 @@ policyReportsCleanup:
       drop:
       - "ALL"
 webhooksCleanup:
+  image:
+    registry: mirror.gcr.io
   securityContext:
     allowPrivilegeEscalation: false
     readOnlyRootFilesystem: true

--- a/components/kyverno/production/kflux-prd-rh02/kyverno-helm-values.yaml
+++ b/components/kyverno/production/kflux-prd-rh02/kyverno-helm-values.yaml
@@ -62,6 +62,8 @@ reportsController:
       drop:
       - "ALL"
 policyReportsCleanup:
+  image:
+    registry: mirror.gcr.io
   securityContext:
     allowPrivilegeEscalation: false
     readOnlyRootFilesystem: true
@@ -72,6 +74,8 @@ policyReportsCleanup:
       drop:
       - "ALL"
 webhooksCleanup:
+  image:
+    registry: mirror.gcr.io
   securityContext:
     allowPrivilegeEscalation: false
     readOnlyRootFilesystem: true

--- a/components/kyverno/production/stone-prd-rh01/kyverno-helm-values.yaml
+++ b/components/kyverno/production/stone-prd-rh01/kyverno-helm-values.yaml
@@ -62,6 +62,8 @@ reportsController:
       drop:
       - "ALL"
 policyReportsCleanup:
+  image:
+    registry: mirror.gcr.io
   securityContext:
     allowPrivilegeEscalation: false
     readOnlyRootFilesystem: true
@@ -72,6 +74,8 @@ policyReportsCleanup:
       drop:
       - "ALL"
 webhooksCleanup:
+  image:
+    registry: mirror.gcr.io
   securityContext:
     allowPrivilegeEscalation: false
     readOnlyRootFilesystem: true

--- a/components/kyverno/production/stone-prod-p01/kyverno-helm-values.yaml
+++ b/components/kyverno/production/stone-prod-p01/kyverno-helm-values.yaml
@@ -62,6 +62,8 @@ reportsController:
       drop:
       - "ALL"
 policyReportsCleanup:
+  image:
+    registry: mirror.gcr.io
   securityContext:
     allowPrivilegeEscalation: false
     readOnlyRootFilesystem: true
@@ -72,6 +74,8 @@ policyReportsCleanup:
       drop:
       - "ALL"
 webhooksCleanup:
+  image:
+    registry: mirror.gcr.io
   securityContext:
     allowPrivilegeEscalation: false
     readOnlyRootFilesystem: true

--- a/components/kyverno/production/stone-prod-p02/kyverno-helm-values.yaml
+++ b/components/kyverno/production/stone-prod-p02/kyverno-helm-values.yaml
@@ -62,6 +62,8 @@ reportsController:
       drop:
       - "ALL"
 policyReportsCleanup:
+  image:
+    registry: mirror.gcr.io
   securityContext:
     allowPrivilegeEscalation: false
     readOnlyRootFilesystem: true
@@ -72,6 +74,8 @@ policyReportsCleanup:
       drop:
       - "ALL"
 webhooksCleanup:
+  image:
+    registry: mirror.gcr.io
   securityContext:
     allowPrivilegeEscalation: false
     readOnlyRootFilesystem: true


### PR DESCRIPTION
Pulling bitnami/kubectl from dockerhub directly may result in rate-limiting, since it appears docker wants users to have a subscription for pulling images.  To work around this for now, pull images via google's artifact registry mirror of dockerhub.

This registry will not be affected by the upcoming gcr.io outage.  See https://cloud.google.com/artifact-registry/docs/pull-cached-dockerhub-images for details on this mirror.