### PR TITLE
increase integration stage memory limit

### DIFF
--- a/components/integration/staging/base/manager_resources_patch.yaml
+++ b/components/integration/staging/base/manager_resources_patch.yaml
@@ -11,7 +11,7 @@ spec:
         resources:
           limits:
             cpu: 500m
-            memory: 1Gi
+            memory: 2Gi
           requests:
             cpu: 100m
             memory: 20Mi


### PR DESCRIPTION
* increase integration stage memory limit since it met `OOMKilled` in [https://console-openshift-console.apps.stone-stg-rh01.l2vh.p1.openshiftapps.com/k8s/ns/integration-service/pods/[…]ler-manager-688576694b-shvsr/yaml](https://console-openshift-console.apps.stone-stg-rh01.l2vh.p1.openshiftapps.com/k8s/ns/integration-service/pods/integration-service-controller-manager-688576694b-shvsr/yaml)
```
  containerStatuses:
    - restartCount: 89
      started: false
      ready: false
      name: manager
      state:
        waiting:
          reason: CrashLoopBackOff
          message: back-off 5m0s restarting failed container=manager pod=integration-service-controller-manager-688576694b-shvsr_integration-service(f3a99704-508c-4602-9136-cb09bb250374)
      imageID: 'quay.io/konflux-ci/integration-service@sha256:ccd6960b2a54691d05d91f5d8c2ef80801256992b7fd15ad1f750a150b09adef'
      image: 'quay.io/konflux-ci/integration-service:cf24b223f4e92293134ec2626773d66b8b76af90'
      lastState:
        terminated:
          exitCode: 137
          reason: OOMKilled
          startedAt: '2025-03-19T05:27:58Z'
          finishedAt: '2025-03-19T05:28:30Z'
          containerID: 'cri-o://95af4bab02ee3d6375dd6dd8473117e7722d278131695a78fe91773737ce077c'
      containerID: 'cri-o://95af4bab02ee3d6375dd6dd8473117e7722d278131695a78fe91773737ce077c'
```

Signed-off-by: Hongwei Liu <hongliu@redhat.com>