### PR TITLE
increase integration stage memory limit

### DIFF
--- a/components/integration/staging/base/manager_resources_patch.yaml
+++ b/components/integration/staging/base/manager_resources_patch.yaml
@@ -11,10 +11,10 @@ spec:
         resources:
           limits:
             cpu: 500m
-            memory: 2Gi
+            memory: 4Gi
           requests:
             cpu: 100m
-            memory: 20Mi
+            memory: 2Gi
         env:
         - name: CONSOLE_NAME
           valueFrom:


### PR DESCRIPTION
* increase integration stage memory limit since it met OOMKilled it seems that https://github.com/redhat-appstudio/infra-deployments/pull/5864 is not enough

https://console-openshift-console.apps.stone-stg-rh01.l2vh.p1.openshiftapps.com/k8s/ns/integration-service/pods/integration-service-controller-manager-7978bb8687-h89w7/yaml
```
  containerStatuses:
    - restartCount: 11
      started: false
      ready: false
      name: manager
      state:
        waiting:
          reason: CrashLoopBackOff
          message: back-off 5m0s restarting failed container=manager pod=integration-service-controller-manager-7978bb8687-h89w7_integration-service(4e439931-2415-4164-8d35-1ffd44d0f656)
      imageID: 'quay.io/konflux-ci/integration-service@sha256:ccd6960b2a54691d05d91f5d8c2ef80801256992b7fd15ad1f750a150b09adef'
      image: 'quay.io/konflux-ci/integration-service:cf24b223f4e92293134ec2626773d66b8b76af90'
      lastState:
        terminated:
          exitCode: 137
          reason: OOMKilled
          startedAt: '2025-03-19T07:05:12Z'
          finishedAt: '2025-03-19T07:05:40Z'
          containerID: 'cri-o://aa76f6d522dd99f662296bff22f7f6b30f970ce367c3af9fd2f9600c7e9dc320'
      containerID: 'cri-o://aa76f6d522dd99f662296bff22f7f6b30f970ce367c3af9fd2f9600c7e9dc320'
```

Signed-off-by: Hongwei Liu <hongliu@redhat.com>