### PR TITLE
Run Mintmaker DependencyUpdateCheck cronjobs as non-root

### DIFF
--- a/components/mintmaker/base/cronjobs/create-dependency-update-check.yaml
+++ b/components/mintmaker/base/cronjobs/create-dependency-update-check.yaml
@@ -38,5 +38,6 @@ spec:
                   cpu: 100m
                   memory: 100Mi
               securityContext:
+                runAsUser: 1001120000
                 runAsNonRoot: true
                 readOnlyRootFilesystem: true

--- a/components/mintmaker/base/cronjobs/delete-dependency-update-checks.yaml
+++ b/components/mintmaker/base/cronjobs/delete-dependency-update-checks.yaml
@@ -58,6 +58,7 @@ spec:
                   cpu: 50m
                   memory: 200Mi
               securityContext:
+                runAsUser: 1001120000
                 allowPrivilegeEscalation: false
                 capabilities:
                   drop:


### PR DESCRIPTION
Mintmaker SA has been granted the anyuid SCC becuase it needs to run its subscription-manager pod as root[1]. A side effect is that now it tries to run all of its pods as root by default. This is not secure and also conflicts with the setting runAsNonRoot: true, resulting in failing jobs. Explicitly run these cronjobs as a non-root user.

[1] https://github.com/konflux-ci/mintmaker/pull/222