### PR TITLE
rollback integration development and stage to version from intg pr 1048

### DIFF
--- a/components/integration/development/kustomization.yaml
+++ b/components/integration/development/kustomization.yaml
@@ -2,13 +2,13 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - ../base
-- https://github.com/konflux-ci/integration-service/config/default?ref=cf24b223f4e92293134ec2626773d66b8b76af90
-- https://github.com/konflux-ci/integration-service/config/snapshotgc?ref=cf24b223f4e92293134ec2626773d66b8b76af90
+- https://github.com/konflux-ci/integration-service/config/default?ref=fcb8e9430917906e488066bdf42e07dff7cb1818
+- https://github.com/konflux-ci/integration-service/config/snapshotgc?ref=fcb8e9430917906e488066bdf42e07dff7cb1818
 
 images:
 - name: quay.io/konflux-ci/integration-service
   newName: quay.io/konflux-ci/integration-service
-  newTag: cf24b223f4e92293134ec2626773d66b8b76af90
+  newTag: fcb8e9430917906e488066bdf42e07dff7cb1818
 
 configMapGenerator:
 - name: integration-config

--- a/components/integration/staging/base/kustomization.yaml
+++ b/components/integration/staging/base/kustomization.yaml
@@ -3,13 +3,13 @@ kind: Kustomization
 resources:
 - ../../base
 - ../../base/external-secrets
-- https://github.com/konflux-ci/integration-service/config/default?ref=cf24b223f4e92293134ec2626773d66b8b76af90
-- https://github.com/konflux-ci/integration-service/config/snapshotgc?ref=cf24b223f4e92293134ec2626773d66b8b76af90
+- https://github.com/konflux-ci/integration-service/config/default?ref=fcb8e9430917906e488066bdf42e07dff7cb1818
+- https://github.com/konflux-ci/integration-service/config/snapshotgc?ref=fcb8e9430917906e488066bdf42e07dff7cb1818
 
 images:
 - name: quay.io/konflux-ci/integration-service
   newName: quay.io/konflux-ci/integration-service
-  newTag: cf24b223f4e92293134ec2626773d66b8b76af90
+  newTag: fcb8e9430917906e488066bdf42e07dff7cb1818
 
 configMapGenerator:
 - name: integration-config


### PR DESCRIPTION
rollback integration stage to version from intg pr 1048
    
    * rollback integration development and stage to release
      integration-service-lntnn-fcb8e94-plcl8 from
      https://github.com/konflux-ci/integration-service/pull/1048

Signed-off-by: Hongwei Liu <hongliu@redhat.com>