### PR TITLE
Create new flavors of ppc in internal staging

### DIFF
--- a/components/multi-platform-controller/staging-downstream/host-config.yaml
+++ b/components/multi-platform-controller/staging-downstream/host-config.yaml
@@ -432,12 +432,73 @@ data:
   dynamic.linux-ppc64le.url: "https://us-east.power-iaas.cloud.ibm.com"
   dynamic.linux-ppc64le.network: "a6d8d6da-c412-4106-9b57-4e25541b2e7f"
   dynamic.linux-ppc64le.system: "e980"
-  dynamic.linux-ppc64le.cores: "2"
+  dynamic.linux-ppc64le.cores: "0.25"
   dynamic.linux-ppc64le.memory: "8"
-  dynamic.linux-ppc64le.disk: "200"
   dynamic.linux-ppc64le.max-instances: "50"
   dynamic.linux-ppc64le.allocation-timeout: "1800"
   dynamic.linux-ppc64le.instance-tag: stage-ppc64le
+
+  dynamic.linux-large-ppc64le.type: ibmp
+  dynamic.linux-large-ppc64le.ssh-secret: "internal-stage-ibm-ssh-key"
+  dynamic.linux-large-ppc64le.secret: "internal-stage-ibm-api-key"
+  dynamic.linux-large-ppc64le.key: "konflux-infra"
+  dynamic.linux-large-ppc64le.image: "konflux-stage-ppc-base-os-08-16-2024"
+  dynamic.linux-large-ppc64le.crn: "crn:v1:bluemix:public:power-iaas:wdc06:a/5cb0704ee6304413bd0b171372c0fd77:4e9dc638-7a78-4e7c-b432-e83b7010c531::"
+  dynamic.linux-large-ppc64le.url: "https://us-east.power-iaas.cloud.ibm.com"
+  dynamic.linux-large-ppc64le.network: "a6d8d6da-c412-4106-9b57-4e25541b2e7f"
+  dynamic.linux-large-ppc64le.system: "e980"
+  dynamic.linux-large-ppc64le.cores: "0.5"
+  dynamic.linux-large-ppc64le.memory: "16"
+  dynamic.linux-large-ppc64le.max-instances: "10"
+  dynamic.linux-large-ppc64le.allocation-timeout: "1800"
+  dynamic.linux-large-ppc64le.instance-tag: stage-ppc64le-large
+
+  dynamic.linux-xlarge-ppc64le.type: ibmp
+  dynamic.linux-xlarge-ppc64le.ssh-secret: "internal-stage-ibm-ssh-key"
+  dynamic.linux-xlarge-ppc64le.secret: "internal-stage-ibm-api-key"
+  dynamic.linux-xlarge-ppc64le.key: "konflux-infra"
+  dynamic.linux-xlarge-ppc64le.image: "konflux-stage-ppc-base-os-08-16-2024"
+  dynamic.linux-xlarge-ppc64le.crn: "crn:v1:bluemix:public:power-iaas:wdc06:a/5cb0704ee6304413bd0b171372c0fd77:4e9dc638-7a78-4e7c-b432-e83b7010c531::"
+  dynamic.linux-xlarge-ppc64le.url: "https://us-east.power-iaas.cloud.ibm.com"
+  dynamic.linux-xlarge-ppc64le.network: "a6d8d6da-c412-4106-9b57-4e25541b2e7f"
+  dynamic.linux-xlarge-ppc64le.system: "e980"
+  dynamic.linux-xlarge-ppc64le.cores: "1"
+  dynamic.linux-xlarge-ppc64le.memory: "32"
+  dynamic.linux-xlarge-ppc64le.max-instances: "10"
+  dynamic.linux-xlarge-ppc64le.allocation-timeout: "1800"
+  dynamic.linux-xlarge-ppc64le.instance-tag: stage-ppc64le-xlarge
+
+  dynamic.linux-2xlarge-ppc64le.type: ibmp
+  dynamic.linux-2xlarge-ppc64le.ssh-secret: "internal-stage-ibm-ssh-key"
+  dynamic.linux-2xlarge-ppc64le.secret: "internal-stage-ibm-api-key"
+  dynamic.linux-2xlarge-ppc64le.key: "konflux-infra"
+  dynamic.linux-2xlarge-ppc64le.image: "konflux-stage-ppc-base-os-08-16-2024"
+  dynamic.linux-2xlarge-ppc64le.crn: "crn:v1:bluemix:public:power-iaas:wdc06:a/5cb0704ee6304413bd0b171372c0fd77:4e9dc638-7a78-4e7c-b432-e83b7010c531::"
+  dynamic.linux-2xlarge-ppc64le.url: "https://us-east.power-iaas.cloud.ibm.com"
+  dynamic.linux-2xlarge-ppc64le.network: "a6d8d6da-c412-4106-9b57-4e25541b2e7f"
+  dynamic.linux-2xlarge-ppc64le.system: "e980"
+  dynamic.linux-2xlarge-ppc64le.cores: "2"
+  dynamic.linux-2xlarge-ppc64le.memory: "64"
+  dynamic.linux-2xlarge-ppc64le.max-instances: "10"
+  dynamic.linux-2xlarge-ppc64le.allocation-timeout: "1800"
+  dynamic.linux-2xlarge-ppc64le.instance-tag: stage-ppc64le-2xlarge
+
+
+  dynamic.linux-d200-large-ppc64le.type: ibmp
+  dynamic.linux-d200-large-ppc64le.ssh-secret: "internal-stage-ibm-ssh-key"
+  dynamic.linux-d200-large-ppc64le.secret: "internal-stage-ibm-api-key"
+  dynamic.linux-d200-large-ppc64le.key: "konflux-infra"
+  dynamic.linux-d200-large-ppc64le.image: "konflux-stage-ppc-base-os-08-16-2024"
+  dynamic.linux-d200-large-ppc64le.crn: "crn:v1:bluemix:public:power-iaas:wdc06:a/5cb0704ee6304413bd0b171372c0fd77:4e9dc638-7a78-4e7c-b432-e83b7010c531::"
+  dynamic.linux-d200-large-ppc64le.url: "https://us-east.power-iaas.cloud.ibm.com"
+  dynamic.linux-d200-large-ppc64le.network: "a6d8d6da-c412-4106-9b57-4e25541b2e7f"
+  dynamic.linux-d200-large-ppc64le.system: "e980"
+  dynamic.linux-d200-large-ppc64le.cores: "0.5"
+  dynamic.linux-d200-large-ppc64le.memory: "16"
+  dynamic.linux-d200-large-ppc64le.max-instances: "10"
+  dynamic.linux-d200-large-ppc64le.allocation-timeout: "1800"
+  dynamic.linux-d200-large-ppc64le.disk: "200"
+  dynamic.linux-d200-large-ppc64le.instance-tag: stage-d200-ppc64le-large
 
 # GPU Instances
   dynamic.linux-g6xlarge-amd64.type: aws


### PR DESCRIPTION
Create a various flavors of PPC machine, similar to what we have for amd and arm.

The main difference is ppc, we set the number or cores, which maps to virtual cores which maps to vCPU. So 0.25 core corresponds to the equivalent of 2 vCPU.