### PR TITLE
mintmaker: Revert mintmaker cronjobs security context change

### DIFF
--- a/components/mintmaker/base/cronjobs/create-dependency-update-check.yaml
+++ b/components/mintmaker/base/cronjobs/create-dependency-update-check.yaml
@@ -38,6 +38,5 @@ spec:
                   cpu: 100m
                   memory: 100Mi
               securityContext:
-                runAsUser: 1001120000
                 runAsNonRoot: true
                 readOnlyRootFilesystem: true

--- a/components/mintmaker/base/cronjobs/delete-dependency-update-checks.yaml
+++ b/components/mintmaker/base/cronjobs/delete-dependency-update-checks.yaml
@@ -58,7 +58,6 @@ spec:
                   cpu: 50m
                   memory: 200Mi
               securityContext:
-                runAsUser: 1001120000
                 allowPrivilegeEscalation: false
                 capabilities:
                   drop:


### PR DESCRIPTION
This reverts commit 1b94198aa9313c5579866a135783c90a4e2ba717.

Jobs are now not executable with user 1001120000 due to error:

    unable to validate against any security context constraint ...