### PR TITLE
Add RBAC data to Konflux info for all clusters

### DIFF
--- a/components/konflux-info/production/kflux-ocp-p01/info.json
+++ b/components/konflux-info/production/kflux-ocp-p01/info.json
@@ -20,5 +20,34 @@
                 }
             ]
         }
-    }
+    },
+    "rbac": [
+        {
+            "displayName": "admin",
+            "description": "Full access to Konflux resources including secrets",
+            "roleRef": {
+                "apiGroup": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "konflux-admin-user-actions"
+            }
+        },
+        {
+            "displayName": "maintainer",
+            "description": "Partial access to Konflux resources without access to secrets",
+            "roleRef": {
+                "apiGroup": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "konflux-maintainer-user-actions"
+            }
+        },
+        {
+            "displayName": "contributor",
+            "description": "View access to Konflux resources without access to secrets",
+            "roleRef": {
+                "apiGroup": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "konflux-contributor-user-actions"
+            }
+        }
+    ]
 }

--- a/components/konflux-info/production/kflux-prd-rh02/info.json
+++ b/components/konflux-info/production/kflux-prd-rh02/info.json
@@ -20,5 +20,34 @@
                 }
             ]
         }
-    }
+    },
+    "rbac": [
+        {
+            "displayName": "admin",
+            "description": "Full access to Konflux resources including secrets",
+            "roleRef": {
+                "apiGroup": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "konflux-admin-user-actions"
+            }
+        },
+        {
+            "displayName": "maintainer",
+            "description": "Partial access to Konflux resources without access to secrets",
+            "roleRef": {
+                "apiGroup": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "konflux-maintainer-user-actions"
+            }
+        },
+        {
+            "displayName": "contributor",
+            "description": "View access to Konflux resources without access to secrets",
+            "roleRef": {
+                "apiGroup": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "konflux-contributor-user-actions"
+            }
+        }
+    ]
 }

--- a/components/konflux-info/production/stone-prd-rh01/info.json
+++ b/components/konflux-info/production/stone-prd-rh01/info.json
@@ -20,5 +20,34 @@
                 }
             ]
         }
-    }
+    },
+    "rbac": [
+        {
+            "displayName": "admin",
+            "description": "Full access to Konflux resources including secrets",
+            "roleRef": {
+                "apiGroup": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "konflux-admin-user-actions"
+            }
+        },
+        {
+            "displayName": "maintainer",
+            "description": "Partial access to Konflux resources without access to secrets",
+            "roleRef": {
+                "apiGroup": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "konflux-maintainer-user-actions"
+            }
+        },
+        {
+            "displayName": "contributor",
+            "description": "View access to Konflux resources without access to secrets",
+            "roleRef": {
+                "apiGroup": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "konflux-contributor-user-actions"
+            }
+        }
+    ]
 }

--- a/components/konflux-info/production/stone-prod-p01/info.json
+++ b/components/konflux-info/production/stone-prod-p01/info.json
@@ -20,5 +20,34 @@
                 }
             ]
         }
-    }
+    },
+    "rbac": [
+        {
+            "displayName": "admin",
+            "description": "Full access to Konflux resources including secrets",
+            "roleRef": {
+                "apiGroup": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "konflux-admin-user-actions"
+            }
+        },
+        {
+            "displayName": "maintainer",
+            "description": "Partial access to Konflux resources without access to secrets",
+            "roleRef": {
+                "apiGroup": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "konflux-maintainer-user-actions"
+            }
+        },
+        {
+            "displayName": "contributor",
+            "description": "View access to Konflux resources without access to secrets",
+            "roleRef": {
+                "apiGroup": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "konflux-contributor-user-actions"
+            }
+        }
+    ]
 }

--- a/components/konflux-info/production/stone-prod-p02/info.json
+++ b/components/konflux-info/production/stone-prod-p02/info.json
@@ -20,5 +20,34 @@
                 }
             ]
         }
-    }
+    },
+    "rbac": [
+        {
+            "displayName": "admin",
+            "description": "Full access to Konflux resources including secrets",
+            "roleRef": {
+                "apiGroup": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "konflux-admin-user-actions"
+            }
+        },
+        {
+            "displayName": "maintainer",
+            "description": "Partial access to Konflux resources without access to secrets",
+            "roleRef": {
+                "apiGroup": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "konflux-maintainer-user-actions"
+            }
+        },
+        {
+            "displayName": "contributor",
+            "description": "View access to Konflux resources without access to secrets",
+            "roleRef": {
+                "apiGroup": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "konflux-contributor-user-actions"
+            }
+        }
+    ]
 }

--- a/components/konflux-info/staging/stone-stage-p01/info.json
+++ b/components/konflux-info/staging/stone-stage-p01/info.json
@@ -20,5 +20,34 @@
                 }
             ]
         }
-    }
+    },
+    "rbac": [
+        {
+            "displayName": "admin",
+            "description": "Full access to Konflux resources including secrets",
+            "roleRef": {
+                "apiGroup": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "konflux-admin-user-actions"
+            }
+        },
+        {
+            "displayName": "maintainer",
+            "description": "Partial access to Konflux resources without access to secrets",
+            "roleRef": {
+                "apiGroup": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "konflux-maintainer-user-actions"
+            }
+        },
+        {
+            "displayName": "contributor",
+            "description": "View access to Konflux resources without access to secrets",
+            "roleRef": {
+                "apiGroup": "rbac.authorization.k8s.io",
+                "kind": "ClusterRole",
+                "name": "konflux-contributor-user-actions"
+            }
+        }
+    ]
 }


### PR DESCRIPTION
This data is used by the new UI to list the
available role users can use.