### PR TITLE
Run Mintmaker DependencyUpdateCheck cronjobs as non-root (attempt #2)

### DIFF
--- a/components/mintmaker/staging/base/kustomization.yaml
+++ b/components/mintmaker/staging/base/kustomization.yaml
@@ -21,6 +21,22 @@ commonAnnotations:
 
 patches:
   - path: manager_patch.yaml
+  - target:
+      version: v1
+      kind: CronJob
+      name: create-dependencyupdatecheck
+    patch: |-
+      - op: add
+        path: /spec/jobTemplate/spec/template/spec/containers/0/securityContext/runAsUser
+        value: 1001120000
+  - target:
+      version: v1
+      kind: CronJob
+      name: delete-dependencyupdatechecks
+    patch: |-
+      - op: add
+        path: /spec/jobTemplate/spec/template/spec/containers/0/securityContext/runAsUser
+        value: 1001120000
 
 configurations:
 - kustomizeconfig.yaml


### PR DESCRIPTION
Mintmaker SA has been granted the anyuid SCC becuase it needs to run its subscription-manager pod as root[1]. A side effect is that now it tries to run all of its pods as root by default. This is not secure and also conflicts with the setting runAsNonRoot: true, resulting in failing jobs. Explicitly run these cronjobs as a non-root user.

This commit should be merged at the same time as [1], otherwise the created jobs will fail with an error. Without the anyuid SCC, pods cannot have arbitrary UIDs - they must be selected from the allowed range. Each namespace has its own range and it is chosen arbitrarily. This means that mintmaker namespace in each cluster has a different allowed UID range. Explicitly setting the UID will cause an error - at least in some clusters. Having anyuid SCC solves this as any UID that doesn't have to adhere to the predefined UID range can be chosen.

Merging this commit after [1] will cause these cronjob pods to be created as a root user, which is not allowed as per the defined security context.

[1] https://github.com/konflux-ci/mintmaker/pull/222

Refers to [CLOUDDST-26090](https://issues.redhat.com//browse/CLOUDDST-26090)