### PR TITLE
Update OSP dev and stage

### DIFF
--- a/components/pipeline-service/development/main-pipeline-service-configuration.yaml
+++ b/components/pipeline-service/development/main-pipeline-service-configuration.yaml
@@ -2050,6 +2050,8 @@ spec:
   profile: all
   pruner:
     disabled: true
+  result:
+    disabled: true
   targetNamespace: openshift-pipelines
   trigger:
     options:
@@ -2095,7 +2097,7 @@ metadata:
   namespace: openshift-marketplace
 spec:
   displayName: custom-operators
-  image: quay.io/openshift-pipeline/openshift-pipelines-pipelines-operator-bundle-container-index@sha256:63f934e04d88cc1fa2af49efc07b406eb88e04a622be25762a931168deeefb79
+  image: quay.io/openshift-pipeline/pipelines-index-4.15@sha256:64a745bfa289594f0eeb9c6af7646a0b9ab6072da0f2ec909441aa14ae82acf9
   sourceType: grpc
   updateStrategy:
     registryPoll:

--- a/components/pipeline-service/staging/base/main-pipeline-service-configuration.yaml
+++ b/components/pipeline-service/staging/base/main-pipeline-service-configuration.yaml
@@ -1872,6 +1872,8 @@ spec:
   profile: all
   pruner:
     disabled: true
+  result:
+    disabled: true
   targetNamespace: openshift-pipelines
   trigger:
     options:
@@ -1917,7 +1919,7 @@ metadata:
   namespace: openshift-marketplace
 spec:
   displayName: custom-operators
-  image: quay.io/openshift-pipeline/openshift-pipelines-pipelines-operator-bundle-container-index@sha256:63f934e04d88cc1fa2af49efc07b406eb88e04a622be25762a931168deeefb79
+  image: quay.io/openshift-pipeline/pipelines-index-4.15@sha256:64a745bfa289594f0eeb9c6af7646a0b9ab6072da0f2ec909441aa14ae82acf9
   sourceType: grpc
   updateStrategy:
     registryPoll:

--- a/components/pipeline-service/staging/stone-stage-p01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stage-p01/deploy.yaml
@@ -2458,6 +2458,8 @@ spec:
   profile: all
   pruner:
     disabled: true
+  result:
+    disabled: true
   targetNamespace: openshift-pipelines
   trigger:
     options:
@@ -2503,7 +2505,7 @@ metadata:
   namespace: openshift-marketplace
 spec:
   displayName: custom-operators
-  image: quay.io/openshift-pipeline/openshift-pipelines-pipelines-operator-bundle-container-index@sha256:63f934e04d88cc1fa2af49efc07b406eb88e04a622be25762a931168deeefb79
+  image: quay.io/openshift-pipeline/pipelines-index-4.15@sha256:64a745bfa289594f0eeb9c6af7646a0b9ab6072da0f2ec909441aa14ae82acf9
   sourceType: grpc
   updateStrategy:
     registryPoll:

--- a/components/pipeline-service/staging/stone-stg-rh01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stg-rh01/deploy.yaml
@@ -2469,6 +2469,8 @@ spec:
   profile: all
   pruner:
     disabled: true
+  result:
+    disabled: true
   targetNamespace: openshift-pipelines
   trigger:
     options:
@@ -2514,7 +2516,7 @@ metadata:
   namespace: openshift-marketplace
 spec:
   displayName: custom-operators
-  image: quay.io/openshift-pipeline/openshift-pipelines-pipelines-operator-bundle-container-index@sha256:63f934e04d88cc1fa2af49efc07b406eb88e04a622be25762a931168deeefb79
+  image: quay.io/openshift-pipeline/pipelines-index-4.15@sha256:64a745bfa289594f0eeb9c6af7646a0b9ab6072da0f2ec909441aa14ae82acf9
   sourceType: grpc
   updateStrategy:
     registryPoll:


### PR DESCRIPTION
- The update includes a new version produced by Konflux.
- Disable Tekton Results deployed automatically by the operator. Curently Results is deployed separately.