### PR TITLE
fix: set the integration staging memory requests equal to limits

### DIFF
--- a/components/integration/staging/base/manager_resources_patch.yaml
+++ b/components/integration/staging/base/manager_resources_patch.yaml
@@ -14,7 +14,7 @@ spec:
             memory: 4Gi
           requests:
             cpu: 100m
-            memory: 2Gi
+            memory: 4Gi
         env:
         - name: CONSOLE_NAME
           valueFrom:


### PR DESCRIPTION
* Set the integration service staging memory memory requests equal to limits
* This helps avoid a scenario where the pod runs on a node that is already experiencing high memory usage, which could lead to the pod being killed

Signed-off-by: dirgim <kpavic@redhat.com>