### PR TITLE
fix(KONFLUX-7357): increase integration service memory to 8gb

### DIFF
--- a/components/integration/production/base/manager_resources_patch.yaml
+++ b/components/integration/production/base/manager_resources_patch.yaml
@@ -11,10 +11,10 @@ spec:
         resources:
           limits:
             cpu: 600m
-            memory: 4096Mi
+            memory: 8192Mi
           requests:
             cpu: 200m
-            memory: 2048Mi
+            memory: 8192Mi
         env:
         - name: CONSOLE_NAME
           valueFrom:

--- a/components/integration/staging/base/manager_resources_patch.yaml
+++ b/components/integration/staging/base/manager_resources_patch.yaml
@@ -11,10 +11,10 @@ spec:
         resources:
           limits:
             cpu: 500m
-            memory: 4Gi
+            memory: 8192Mi
           requests:
             cpu: 100m
-            memory: 4Gi
+            memory: 8192Mi
         env:
         - name: CONSOLE_NAME
           valueFrom:


### PR DESCRIPTION
* Since the increased load and added functionalities are causing frequent restarts on staging and production clusters, increase the memory requirements and limits to 8192Mi

Signed-off-by: dirgim <kpavic@redhat.com>