### PR TITLE
update kubearchive to v0.11.0 with the memory patch

### DIFF
--- a/argo-cd-apps/overlays/konflux-public-staging/delete-sync-policy.yaml
+++ b/argo-cd-apps/overlays/konflux-public-staging/delete-sync-policy.yaml
@@ -1,2 +1,0 @@
-- op: remove
-  path: /spec/template/spec/syncPolicy

--- a/argo-cd-apps/overlays/konflux-public-staging/kustomization.yaml
+++ b/argo-cd-apps/overlays/konflux-public-staging/kustomization.yaml
@@ -12,9 +12,3 @@ resources:
 namespace: konflux-public-staging
 patchesStrategicMerge:
   - delete-applications.yaml
-patches:
- - path: delete-sync-policy.yaml
-   target:
-     kind: ApplicationSet
-     version: v1alpha1
-     name: kubearchive

--- a/components/kubearchive/base/kustomization.yaml
+++ b/components/kubearchive/base/kustomization.yaml
@@ -2,7 +2,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- https://gist.githubusercontent.com/ggallen/0aa25baf754578550425e5c17122f776/raw/d33b5051478d4755e0c6712e23acb2916032cf83/kubearchive.yaml?timeout=90
+- https://github.com/kubearchive/kubearchive/releases/download/v0.11.0/kubearchive.yaml?timeout=90
 - rbac.yaml
 - kubearchive-config.yaml
 - kubearchive-maintainer.yaml
@@ -137,7 +137,11 @@ patches:
               ports:
                 - containerPort: 8081
               resources:
+                $patch: replace
+                limits:
+                  cpu: 500m
                 requests:
+                  cpu: 10m
                   memory: 256Mi
                 
 - patch: |-


### PR DESCRIPTION
we released a new version of kubearchive and I updated the patches that we apply so that I didn't need to updated the previous gist. Also I re-enabled argocd sync for kubearchive