### PR TITLE
Fix dynamic-platforms on stg-p01

### DIFF
--- a/components/multi-platform-controller/staging-downstream/host-config.yaml
+++ b/components/multi-platform-controller/staging-downstream/host-config.yaml
@@ -38,11 +38,11 @@ data:
     linux-root/arm64,\
     linux-root/amd64,\
     linux/ppc64le,\
-    linux-large/ppc64le, \
-    linux-xlarge/ppc64le, \
-    linux-2xlarge/ppc64le, \
+    linux-large/ppc64le,\
+    linux-xlarge/ppc64le,\
+    linux-2xlarge/ppc64le,\
     linux-d200-large/ppc64le,\
-    linux-d200-xlarge/ppc64le, \
+    linux-d200-xlarge/ppc64le,\
     linux-d200-2xlarge/ppc64le\
     "
   #dynamic-pool-platforms: linux/ppc64le


### PR DESCRIPTION
There must be no space between the platform names.