### PR TITLE
Limit memory usage Pipeline Service components

### DIFF
--- a/components/pipeline-service/staging/base/main-pipeline-service-configuration.yaml
+++ b/components/pipeline-service/staging/base/main-pipeline-service-configuration.yaml
@@ -1781,10 +1781,10 @@ spec:
                   - name: tekton-pipelines-controller
                     resources:
                       requests:
-                        memory: 6Gi
+                        memory: 1Gi
                         cpu: "1"
                       limits:
-                        memory: 6Gi
+                        memory: 2Gi
                 topologySpreadConstraints:
                   - maxSkew: 1
                     topologyKey: topology.kubernetes.io/zone
@@ -1801,10 +1801,10 @@ spec:
                   - name: controller
                     resources:
                       limits:
-                        memory: 4Gi
+                        memory: 2Gi
                       requests:
                         cpu: "500m"
-                        memory: 4Gi
+                        memory: 1Gi
       disabled: false
       horizontalPodAutoscalers:
         tekton-operator-proxy-webhook:

--- a/components/pipeline-service/staging/stone-stage-p01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stage-p01/deploy.yaml
@@ -2402,10 +2402,10 @@ spec:
                 - name: tekton-pipelines-controller
                   resources:
                     limits:
-                      memory: 6Gi
+                      memory: 2Gi
                     requests:
                       cpu: "1"
-                      memory: 6Gi
+                      memory: 1Gi
                 topologySpreadConstraints:
                 - labelSelector:
                     matchLabels:
@@ -2422,10 +2422,10 @@ spec:
                 - name: controller
                   resources:
                     limits:
-                      memory: 4Gi
+                      memory: 2Gi
                     requests:
                       cpu: 500m
-                      memory: 4Gi
+                      memory: 1Gi
     performance:
       buckets: 4
       disable-ha: false

--- a/components/pipeline-service/staging/stone-stg-rh01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stg-rh01/deploy.yaml
@@ -2414,10 +2414,10 @@ spec:
                 - name: tekton-pipelines-controller
                   resources:
                     limits:
-                      memory: 6Gi
+                      memory: 2Gi
                     requests:
                       cpu: "1"
-                      memory: 6Gi
+                      memory: 1Gi
                 topologySpreadConstraints:
                 - labelSelector:
                     matchLabels:
@@ -2434,10 +2434,10 @@ spec:
                 - name: controller
                   resources:
                     limits:
-                      memory: 4Gi
+                      memory: 2Gi
                     requests:
                       cpu: 500m
-                      memory: 4Gi
+                      memory: 1Gi
     performance:
       buckets: 4
       disable-ha: false

--- a/components/vector-tekton-logs-collector/development/vector-helm-values.yaml
+++ b/components/vector-tekton-logs-collector/development/vector-helm-values.yaml
@@ -3,10 +3,10 @@ role: Agent
 resources:
   requests:
     cpu: 512m
-    memory: 4096Mi
+    memory: 2048Mi
   limits:
     cpu: 2000m
-    memory: 4096Mi
+    memory: 2048Mi
 customConfig:
   data_dir: /vector-data-dir
   api:

--- a/components/vector-tekton-logs-collector/staging/vector-helm-values.yaml
+++ b/components/vector-tekton-logs-collector/staging/vector-helm-values.yaml
@@ -3,10 +3,10 @@ role: Agent
 resources:
   requests:
     cpu: 512m
-    memory: 4096Mi
+    memory: 2048Mi
   limits:
     cpu: 2000m
-    memory: 4096Mi
+    memory: 2048Mi
 customConfig:
   data_dir: /vector-data-dir
   api:


### PR DESCRIPTION
- Limit memory usage for controllers running multiple replicas staging.
- Limit Vector pods memory usage development and staging.