### PR TITLE
fix: release operator config update

### DIFF
--- a/components/release/production/kustomization.yaml
+++ b/components/release/production/kustomization.yaml
@@ -3,7 +3,7 @@ kind: Kustomization
 resources:
   - ../base
   - ../base/monitor/production
-  - https://github.com/konflux-ci/release-service/config/default?ref=9d08c98247425ff72c1ebbb3ee2e3ca439ae798b
+  - https://github.com/konflux-ci/release-service/config/default?ref=48d3044042ac90957d64850c85c355832a82173b
   - release_service_config.yaml
 
 components:


### PR DESCRIPTION
this PR updates the config of the release
service operator, to fix the configuration
for its metrics reachability.