### PR TITLE
Remove power monitoring from staging

### DIFF
--- a/argo-cd-apps/overlays/konflux-public-staging/delete-applications.yaml
+++ b/argo-cd-apps/overlays/konflux-public-staging/delete-applications.yaml
@@ -5,3 +5,9 @@ kind: ApplicationSet
 metadata:
   name: tempo
 $patch: delete
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: power-monitoring
+$patch: delete

--- a/argo-cd-apps/overlays/staging-downstream/delete-applications.yaml
+++ b/argo-cd-apps/overlays/staging-downstream/delete-applications.yaml
@@ -49,4 +49,3 @@ kind: ApplicationSet
 metadata:
   name: nvme-storage-configurator
 $patch: delete
-


### PR DESCRIPTION
We got a request from ROSA SRE team to remove that from the master nodes to help with an ongoing issue on stg-rh01. Kepler must run on all the nodes so instead of trying to fix the issue, remove the whole component.

This power-monitoring was deployed even though could VMs are not well supported, and this is what we use. In addition, we do not want to run workloads that are not necessary which is the case for power monitoring, it is deployed but we do not absolutely need this, at least not for now.