### PR TITLE
nslister-monitoring: add panel for subject types

### DIFF
--- a/components/monitoring/grafana/base/dashboards/namespace-lister/namespace-lister-metrics.json
+++ b/components/monitoring/grafana/base/dashboards/namespace-lister/namespace-lister-metrics.json
@@ -286,6 +286,64 @@
       "type": "stat"
     },
     {
+      "description": "The subjects grouped by type for which the cache is storing access data",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "fixedColor": "green",
+            "mode": "fixed"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 11,
+        "w": 15,
+        "x": 9,
+        "y": 14
+      },
+      "id": 19,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": true,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "10.4.3",
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "sum by (subject_gk) (namespace_lister_accesscache_subject_namespace_pairs) ",
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Subject types",
+      "type": "stat"
+    },
+    {
       "fieldConfig": {
         "defaults": {
           "color": {


### PR DESCRIPTION
This PR adds a panel in the namespace-lister Grafana Dashboard that shows the number of subjects stored in cache grouped by type

Signed-off-by: Francesco Ilario <filario@redhat.com>
