### PR TITLE
Use Vector mirrored image

### DIFF
--- a/components/vector-tekton-logs-collector/development/vector-helm-generator.yaml
+++ b/components/vector-tekton-logs-collector/development/vector-helm-generator.yaml
@@ -4,6 +4,10 @@ metadata:
   name: vector
 name: vector
 repo: https://helm.vector.dev
+# We mirror the image from Docker to Quay. To update the version, mirror the respective
+# image. You can use skopeo e.g
+# `skopeo copy docker://timberio/vector:0.45.0-distroless-libc docker://quay.io/openshift-pipeline/vector:0.45.0-distroless-libc`
+# The tag obviously will differ.
 version: 0.41.0
 releaseName: vector-tekton-logs-collector
 namespace: tekton-logging

--- a/components/vector-tekton-logs-collector/development/vector-helm-values.yaml
+++ b/components/vector-tekton-logs-collector/development/vector-helm-values.yaml
@@ -109,6 +109,9 @@ tolerations:
     key: konflux-ci.dev/workload
     operator: Equal
     value: konflux-tenants
+image:
+  repository: quay.io/openshift-pipeline/vector
+  tag: 0.45.0-distroless-libc
 securityContext:
   allowPrivilegeEscalation: false
   capabilities:

--- a/components/vector-tekton-logs-collector/staging/vector-helm-generator.yaml
+++ b/components/vector-tekton-logs-collector/staging/vector-helm-generator.yaml
@@ -4,6 +4,10 @@ metadata:
   name: vector
 name: vector
 repo: https://helm.vector.dev
+# We mirror the image from Docker to Quay. To update the version, mirror the respective
+# image. You can use skopeo e.g
+# `skopeo copy docker://timberio/vector:0.45.0-distroless-libc docker://quay.io/openshift-pipeline/vector:0.45.0-distroless-libc`
+# The tag obviously will differ.
 version: 0.41.0
 releaseName: vector-tekton-logs-collector
 namespace: tekton-logging

--- a/components/vector-tekton-logs-collector/staging/vector-helm-values.yaml
+++ b/components/vector-tekton-logs-collector/staging/vector-helm-values.yaml
@@ -109,6 +109,9 @@ tolerations:
     key: konflux-ci.dev/workload
     operator: Equal
     value: konflux-tenants
+image:
+  repository: quay.io/openshift-pipeline/vector
+  tag: 0.45.0-distroless-libc
 securityContext:
   allowPrivilegeEscalation: false
   capabilities:


### PR DESCRIPTION
The Helm chart used to deploy Vector reference the image stored in the Docker registry. With the image being pulled for each node running users' pipelines and CI jobs also pulling that image, we hit the rate limit on the Docker repo, fail to deploy Vector in a timely manner and miss logs from the users' pipelines. Here we switch to using image mirrored to Quay.