### PR TITLE
Add taskruns permissions to contributor and maintainer

### DIFF
--- a/components/konflux-rbac/production/base/konflux-contributor-user-actions.yaml
+++ b/components/konflux-rbac/production/base/konflux-contributor-user-actions.yaml
@@ -32,6 +32,7 @@ rules:
       - tekton.dev
     resources:
       - pipelineruns
+      - taskruns
   - verbs:
       - get
       - list

--- a/components/konflux-rbac/production/base/konflux-maintainer-user-actions.yaml
+++ b/components/konflux-rbac/production/base/konflux-maintainer-user-actions.yaml
@@ -28,6 +28,7 @@ rules:
       - tekton.dev
     resources:
       - pipelineruns
+      - taskruns
   - verbs:
       - get
       - list

--- a/components/konflux-rbac/staging/base/konflux-contributor-user-actions.yaml
+++ b/components/konflux-rbac/staging/base/konflux-contributor-user-actions.yaml
@@ -32,6 +32,7 @@ rules:
       - tekton.dev
     resources:
       - pipelineruns
+      - taskruns
   - verbs:
       - get
       - list

--- a/components/konflux-rbac/staging/base/konflux-maintainer-user-actions.yaml
+++ b/components/konflux-rbac/staging/base/konflux-maintainer-user-actions.yaml
@@ -28,6 +28,7 @@ rules:
       - tekton.dev
     resources:
       - pipelineruns
+      - taskruns
   - verbs:
       - get
       - list


### PR DESCRIPTION
Allow contributor and maintainer roles to get/list/watch taskruns. This is required in order for getting pipelinerun logs using opc.