### PR TITLE
remove old ui labels from kubearchive's policy

### DIFF
--- a/components/kubearchive/policies/.chainsaw-test/chainsaw-test.yaml
+++ b/components/kubearchive/policies/.chainsaw-test/chainsaw-test.yaml
@@ -42,135 +42,15 @@ spec:
 apiVersion: chainsaw.kyverno.io/v1alpha1
 kind: Test
 metadata:
-  name: mutate-new-namespace-konflux
+  name: mutate-new-namespace-unlabeled
 spec:
   description: |
-    tests that the KubeArchiveConfig is created in a namespace
-    labelled with `konflux.ci/type=user`
+    tests that the KubeArchiveConfig is NOT created in an unlabeled namespace
   concurrent: false
   namespace: 'generate-new-namespace'
   bindings:
   - name: suffix
-    value: konflux
-  steps:
-  - name: given-kubearchiveconfig-crd-exists
-    try:
-    - apply:
-        file: resources/kubearchive-crd.yaml
-  - name: given-kyverno-has-permission-on-resources
-    try:
-    - apply:
-        file: ../kyverno_rbac.yaml
-  - name: given-cluster-policy-is-ready
-    try:
-    - apply:
-        file: ../bootstrap-namespace.yaml
-    - assert:
-        file: chainsaw-assert-clusterpolicy.yaml
-  - name: when-konfluxci-labeled-namespace-is-created
-    try:
-    - apply:
-        file: resources/actual-namespace-konflux.yaml
-        template: true
-  - name: then-kubearchiveconfig-is-created
-    try:
-    - assert:
-        file: resources/expected-kubearchiveconfig.yaml
-        template: true
----
-# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
-apiVersion: chainsaw.kyverno.io/v1alpha1
-kind: Test
-metadata:
-  name: mutate-new-namespace-toolchain
-spec:
-  description: |
-    tests that the KubeArchiveConfig is created in a namespace
-    labelled with `toolchain.dev.openshift.com/type=tenant`
-  concurrent: false
-  namespace: 'generate-new-namespace'
-  bindings:
-  - name: suffix
-    value: toolchain
-  steps:
-  - name: given-kubearchiveconfig-crd-exists
-    try:
-    - apply:
-        file: resources/kubearchive-crd.yaml
-  - name: given-kyverno-has-permission-on-resources
-    try:
-    - apply:
-        file: ../kyverno_rbac.yaml
-  - name: given-cluster-policy-is-ready
-    try:
-    - apply:
-        file: ../bootstrap-namespace.yaml
-    - assert:
-        file: chainsaw-assert-clusterpolicy.yaml
-  - name: when-toolchain-labeled-namespace-is-created
-    try:
-    - apply:
-        file: resources/actual-namespace-toolchain.yaml
-        template: true
-  - name: then-kubearchiveconfig-is-created
-    try:
-    - assert:
-        file: resources/expected-kubearchiveconfig.yaml
-        template: true
----
-# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
-apiVersion: chainsaw.kyverno.io/v1alpha1
-kind: Test
-metadata:
-  name: mutate-new-namespace-konflux-toolchain
-spec:
-  description: |
-    tests that the KubeArchiveConfig is created in a namespace labelled 
-    with `konflux.ci/type=user` or `toolchain.dev.openshift.com/type=tenant`
-  concurrent: false
-  namespace: 'generate-new-namespace'
-  bindings:
-  - name: suffix
-    value: konflux-toolchain
-  steps:
-  - name: given-kubearchiveconfig-crd-exists
-    try:
-    - apply:
-        file: resources/kubearchive-crd.yaml
-  - name: given-kyverno-has-permission-on-resources
-    try:
-    - apply:
-        file: ../kyverno_rbac.yaml
-  - name: given-cluster-policy-is-ready
-    try:
-    - apply:
-        file: ../bootstrap-namespace.yaml
-    - assert:
-        file: chainsaw-assert-clusterpolicy.yaml
-  - name: when-konfluxci-toolchain-labeled-namespace-is-created
-    try:
-    - apply:
-        file: resources/actual-namespace-konflux-toolchain.yaml
-        template: true
-  - name: then-kubearchiveconfig-is-created
-    try:
-    - assert:
-        file: resources/expected-kubearchiveconfig.yaml
-        template: true
----
-# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
-apiVersion: chainsaw.kyverno.io/v1alpha1
-kind: Test
-metadata:
-  name: mutate-new-namespace-unlabelled
-spec:
-  description: |
-    tests that the KubeArchiveConfig is NOT created in an unlabelled namespace
-  concurrent: false
-  namespace: 'generate-new-namespace'
-  bindings:
-  - name: suffix
-    value: unlabelled
+    value: unlabeled
   steps:
   - name: given-kubearchiveconfig-crd-exists
     try:
@@ -189,51 +69,11 @@ spec:
   - name: when-unlabeled-namespace-is-created
     try:
     - apply:
-        file: resources/actual-namespace-konflux-toolchain.yaml
+        file: resources/actual-namespace-unlabeled.yaml
         template: true
   - name: then-kubearchiveconfig-is-created
     try:
     - error:
-        file: resources/expected-kubearchiveconfig.yaml
-        template: true
----
-# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
-apiVersion: chainsaw.kyverno.io/v1alpha1
-kind: Test
-metadata:
-  name: mutate-existing-namespace-konflux
-spec:
-  description: |
-    tests that the KubeArchiveConfig is created in an already existing
-    namespace labelled with `konflux.ci/type=user`
-  concurrent: false
-  namespace: 'generate-existing-namespace'
-  bindings:
-  - name: suffix
-    value: konflux
-  steps:
-  - name: given-kubearchiveconfig-crd-exists
-    try:
-    - apply:
-        file: resources/kubearchive-crd.yaml
-  - name: given-kyverno-has-permission-on-resources
-    try:
-    - apply:
-        file: ../kyverno_rbac.yaml
-  - name: given-konfluxci-labeled-namespace-is-created
-    try:
-    - apply:
-        file: resources/actual-namespace-konflux.yaml
-        template: true
-  - name: when-cluster-policy-is-ready
-    try:
-    - apply:
-        file: ../bootstrap-namespace.yaml
-    - assert:
-        file: chainsaw-assert-clusterpolicy.yaml
-  - name: then-kubearchiveconfig-is-created
-    try:
-    - assert:
         file: resources/expected-kubearchiveconfig.yaml
         template: true
 ---
@@ -281,96 +121,16 @@ spec:
 apiVersion: chainsaw.kyverno.io/v1alpha1
 kind: Test
 metadata:
-  name: mutate-existing-namespace-toolchain
-spec:
-  description: |
-    tests that the KubeArchiveConfig is created in an already existing
-    namespace labelled with `toolchain.dev.openshift.com/type=tenant`
-  concurrent: false
-  namespace: 'generate-existing-namespace'
-  bindings:
-  - name: suffix
-    value: toolchain
-  steps:
-  - name: given-kubearchiveconfig-crd-exists
-    try:
-    - apply:
-        file: resources/kubearchive-crd.yaml
-  - name: given-kyverno-has-permission-on-resources
-    try:
-    - apply:
-        file: ../kyverno_rbac.yaml
-  - name: given-toolchain-labeled-namespace-is-created
-    try:
-    - apply:
-        file: resources/actual-namespace-toolchain.yaml
-        template: true
-  - name: when-cluster-policy-is-ready
-    try:
-    - apply:
-        file: ../bootstrap-namespace.yaml
-    - assert:
-        file: chainsaw-assert-clusterpolicy.yaml
-  - name: then-kubearchiveconfig-is-created
-    try:
-    - assert:
-        file: resources/expected-kubearchiveconfig.yaml
-        template: true
----
-# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
-apiVersion: chainsaw.kyverno.io/v1alpha1
-kind: Test
-metadata:
-  name: mutate-existing-namespace-konflux-toolchain
-spec:
-  description: |
-    tests that the KubeArchiveConfig is created in an already existing
-    namespace labelled with `konflux.ci/type=user` or `toolchain.dev.openshift.com/type=tenant`
-  concurrent: false
-  namespace: 'generate-existing-namespace'
-  bindings:
-  - name: suffix
-    value: konflux-toolchain
-  steps:
-  - name: given-kubearchiveconfig-crd-exists
-    try:
-    - apply:
-        file: resources/kubearchive-crd.yaml
-  - name: given-kyverno-has-permission-on-resources
-    try:
-    - apply:
-        file: ../kyverno_rbac.yaml
-  - name: given-konfluxci-toolchain-labeled-namespace-is-created
-    try:
-    - apply:
-        file: resources/actual-namespace-konflux-toolchain.yaml
-        template: true
-  - name: when-cluster-policy-is-ready
-    try:
-    - apply:
-        file: ../bootstrap-namespace.yaml
-    - assert:
-        file: chainsaw-assert-clusterpolicy.yaml
-  - name: then-kubearchiveconfig-is-created
-    try:
-    - assert:
-        file: resources/expected-kubearchiveconfig.yaml
-        template: true
----
-# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
-apiVersion: chainsaw.kyverno.io/v1alpha1
-kind: Test
-metadata:
-  name: mutate-existing-namespace-unlabelled
+  name: mutate-existing-namespace-unlabeled
 spec:
   description: |
     tests that the KubeArchiveConfig is NOT created in an 
-    existing unlabelled namespace
+    existing unlabeled namespace
   concurrent: false
   namespace: 'generate-existing-namespace'
   bindings:
   - name: suffix
-    value: unlabelled
+    value: unlabeled
   steps:
   - name: given-kubearchiveconfig-crd-exists
     try:
@@ -383,7 +143,7 @@ spec:
   - name: given-unlabeled-namespace-is-created
     try:
     - apply:
-        file: resources/actual-namespace-konflux-toolchain.yaml
+        file: resources/actual-namespace-unlabeled.yaml
         template: true
   - name: when-cluster-policy-is-ready
     try:
@@ -401,17 +161,17 @@ spec:
 apiVersion: chainsaw.kyverno.io/v1alpha1
 kind: Test
 metadata:
-  name: mutate-existing-namespace-konflux-toolchain-existing-kubearchiveconfig
+  name: mutate-existing-namespace-konfluxcidev-existing-kubearchiveconfig
 spec:
   description: |
     tests that the KubeArchiveConfig is not updated in an already existing
-    namespace labelled with `konflux.ci/type=user` or `toolchain.dev.openshift.com/type=tenant`
-    where the KubeArchiveConfig already exists
+    namespace labelled with `konflux-ci.dev/type=tenant` where the 
+    KubeArchiveConfig already exists
   concurrent: false
   namespace: 'generate-existing-namespace'
   bindings:
   - name: suffix
-    value: konflux-toolchain
+    value: konfluxcidev-existing-kubearchive
   steps:
   - name: given-kubearchiveconfig-crd-exists
     try:
@@ -421,10 +181,10 @@ spec:
     try:
     - apply:
         file: ../kyverno_rbac.yaml
-  - name: given-konfluxci-toolchain-labeled-namespace-is-created
+  - name: given-konfluxcidev-labeled-namespace-is-created
     try:
     - apply:
-        file: resources/actual-namespace-konflux-toolchain.yaml
+        file: resources/actual-namespace-konfluxcidev.yaml
         template: true
   - name: given-kubearchiveconfig-is-created
     try:

--- a/components/kubearchive/policies/.chainsaw-test/resources/actual-namespace-konflux-toolchain.yaml
+++ b/components/kubearchive/policies/.chainsaw-test/resources/actual-namespace-konflux-toolchain.yaml
@@ -1,7 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: (join('-', [$namespace, $suffix]))
-  labels:
-    konflux.ci/type: user
-    toolchain.dev.openshift.com/type: tenant

--- a/components/kubearchive/policies/.chainsaw-test/resources/actual-namespace-konflux.yaml
+++ b/components/kubearchive/policies/.chainsaw-test/resources/actual-namespace-konflux.yaml
@@ -1,6 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: (join('-', [$namespace, $suffix]))
-  labels:
-    konflux.ci/type: user

--- a/components/kubearchive/policies/.chainsaw-test/resources/actual-namespace-toolchain.yaml
+++ b/components/kubearchive/policies/.chainsaw-test/resources/actual-namespace-toolchain.yaml
@@ -1,6 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: (join('-', [$namespace, $suffix]))
-  labels:
-    toolchain.dev.openshift.com/type: tenant

--- a/components/kubearchive/policies/.kyverno-test/kyverno-test.yaml
+++ b/components/kubearchive/policies/.kyverno-test/kyverno-test.yaml
@@ -6,19 +6,11 @@ policies:
 - ../bootstrap-namespace.yaml
 resources:
 - ../resources/labeled-namespace-konflux.yaml
-- ../resources/labeled-namespace-toolchain.yaml
 results:
 - policy: init-ns-kubearchiveconfig
   generatedResource: ../resources/expected-kubearchiveconfig-konflux.yaml
   kind: Namespace
   resources:
   - labeled-namespace-konflux
-  result: pass
-  rule: init-ns-kubearchiveconfig
-- policy: init-ns-kubearchiveconfig
-  generatedresource: ../resources/expected-kubearchiveconfig-toolchain.yaml
-  kind: Namespace
-  resources:
-  - labeled-namespace-toolchain
   result: pass
   rule: init-ns-kubearchiveconfig

--- a/components/kubearchive/policies/bootstrap-namespace.yaml
+++ b/components/kubearchive/policies/bootstrap-namespace.yaml
@@ -12,18 +12,6 @@ spec:
           - Namespace
           selector:
             matchLabels:
-              toolchain.dev.openshift.com/type: tenant
-      - resources:
-          kinds:
-          - Namespace
-          selector:
-            matchLabels:
-              konflux.ci/type: user
-      - resources:
-          kinds:
-          - Namespace
-          selector:
-            matchLabels:
               konflux-ci.dev/type: tenant
     generate:
       generateExisting: true

--- a/components/kubearchive/policies/resources/expected-kubearchiveconfig-toolchain.yaml
+++ b/components/kubearchive/policies/resources/expected-kubearchiveconfig-toolchain.yaml
@@ -1,7 +1,0 @@
-apiVersion: kubearchive.kubearchive.org/v1alpha1
-kind: KubeArchiveConfig
-metadata:
-  name: kubearchive
-  namespace: labeled-namespace-toolchain
-spec:
-  resources: []

--- a/components/kubearchive/policies/resources/labeled-namespace-konflux.yaml
+++ b/components/kubearchive/policies/resources/labeled-namespace-konflux.yaml
@@ -3,4 +3,4 @@ kind: Namespace
 metadata:
   name: labeled-namespace-konflux
   labels:
-    konflux.ci/type: user
+    konflux-ci.dev/type: tenant

--- a/components/kubearchive/policies/resources/labeled-namespace-toolchain.yaml
+++ b/components/kubearchive/policies/resources/labeled-namespace-toolchain.yaml
@@ -1,6 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: labeled-namespace-toolchain
-  labels:
-    toolchain.dev.openshift.com/type: tenant


### PR DESCRIPTION
as https://github.com/redhat-appstudio/infra-deployments/pull/5759 and
https://github.com/redhat-appstudio/infra-deployments/pull/5812 got merged, we can
remove old labels from kubearchive's policy.

Signed-off-by: Francesco Ilario <filario@redhat.com>
