### PR TITLE
Standardize s390x VM size in all common clusters

### DIFF
--- a/components/multi-platform-controller/production-downstream/stone-prod-p02/host-config.yaml
+++ b/components/multi-platform-controller/production-downstream/stone-prod-p02/host-config.yaml
@@ -39,8 +39,9 @@ data:
     linux-root/arm64,\
     linux-root/amd64,\
     linux/s390x,\
-    linux-d200-large/s390x,\
     linux-large/s390x,\
+    linux-d200/s390x,\
+    linux-d200-large/s390x,\
     linux/ppc64le,\
     linux-large/ppc64le,\
     linux-xlarge/ppc64le,\
@@ -521,7 +522,7 @@ data:
     
     --//--
 
-  ## IBM s390x with 2CPU 8GiB RAM ####
+  # S390X 2vCPU / 8GB RAM / 100GB disk
   dynamic.linux-s390x.type: ibmz
   dynamic.linux-s390x.ssh-secret: "internal-prod-ibm-ssh-key"
   dynamic.linux-s390x.secret: "internal-prod-ibm-api-key"
@@ -537,7 +538,7 @@ data:
   dynamic.linux-s390x.allocation-timeout: "1800"
   dynamic.linux-s390x.instance-tag: prod-s390x
 
-  ## IBM s390x with 4CPU 16GiB RAM ####
+  # S390X 4vCPU / 16GB RAM / 100GB disk
   dynamic.linux-large-s390x.type: ibmz
   dynamic.linux-large-s390x.ssh-secret: "internal-prod-ibm-ssh-key"
   dynamic.linux-large-s390x.secret: "internal-prod-ibm-api-key"
@@ -553,8 +554,24 @@ data:
   dynamic.linux-large-s390x.allocation-timeout: "1800"
   dynamic.linux-large-s390x.instance-tag: prod-s390x-large
 
+  # S390X 2vCPU / 8GB RAM / 200GB disk
+  dynamic.linux-d200-s390x.type: ibmz
+  dynamic.linux-d200-s390x.ssh-secret: "internal-prod-ibm-ssh-key"
+  dynamic.linux-d200-s390x.secret: "internal-prod-ibm-api-key"
+  dynamic.linux-d200-s390x.vpc: "konflux-internal-prod-us-east-1"
+  dynamic.linux-d200-s390x.key: "internal-prod-key"
+  dynamic.linux-d200-s390x.subnet: "internal-a"
+  dynamic.linux-d200-s390x.image-id: "r014-23be9e67-4ab2-4dc9-9a51-d56efb06943d"
+  dynamic.linux-d200-s390x.region: "us-east-1"
+  dynamic.linux-d200-s390x.url: "https://us-east.iaas.cloud.ibm.com/v1"
+  dynamic.linux-d200-s390x.profile: "bz2-2x8"
+  dynamic.linux-d200-s390x.max-instances: "30"
+  dynamic.linux-d200-s390x.private-ip: "true"
+  dynamic.linux-d200-s390x.allocation-timeout: "1800"
+  dynamic.linux-d200-s390x.disk: "200"
+  dynamic.linux-d200-s390x.instance-tag: prod-d200-s390x
 
-  # Same as linux-s390x-large but with 200GB disk instead of default 100GB
+  # S390X 4vCPU / 16GB RAM / 200GB disk
   dynamic.linux-d200-large-s390x.type: ibmz
   dynamic.linux-d200-large-s390x.ssh-secret: "internal-prod-ibm-ssh-key"
   dynamic.linux-d200-large-s390x.secret: "internal-prod-ibm-api-key"
@@ -569,6 +586,7 @@ data:
   dynamic.linux-d200-large-s390x.private-ip: "true"
   dynamic.linux-d200-large-s390x.allocation-timeout: "1800"
   dynamic.linux-d200-large-s390x.disk: "200"
+  dynamic.linux-d200-large-s390x.instance-tag: prod-d200-s390x-large
 
   # PPC64LE 2vCPU / 8GB RAM / 100GB disk
   dynamic.linux-ppc64le.type: ibmp

--- a/components/multi-platform-controller/production/kflux-prd-rh02/host-config.yaml
+++ b/components/multi-platform-controller/production/kflux-prd-rh02/host-config.yaml
@@ -40,6 +40,8 @@ data:
     linux-extra-fast/amd64,\
     linux/s390x,\
     linux-large/s390x,\
+    linux-d200/s390x,\
+    linux-d200-large/s390x,\
     linux/ppc64le,\
     linux-large/ppc64le,\
     linux-xlarge/ppc64le,\
@@ -501,8 +503,7 @@ data:
 
     --//--
 
-# S390x nodes for multi rh02
-
+  # S390X 2vCPU / 8GB RAM / 100GB disk
   dynamic.linux-s390x.type: ibmz
   dynamic.linux-s390x.ssh-secret: "ibm-ssh-key"
   dynamic.linux-s390x.secret: "ibm-api-key"
@@ -515,8 +516,10 @@ data:
   dynamic.linux-s390x.profile: "bz2-2x8"
   dynamic.linux-s390x.max-instances: "30"
   dynamic.linux-s390x.private-ip: "true"
+  dynamic.linux-s390x.allocation-timeout: "1800"
   dynamic.linux-s390x.instance-tag: prod-s390x
 
+  # S390X 4vCPU / 16GB RAM / 100GB disk
   dynamic.linux-large-s390x.type: ibmz
   dynamic.linux-large-s390x.ssh-secret: "ibm-ssh-key"
   dynamic.linux-large-s390x.secret: "ibm-api-key"
@@ -529,7 +532,42 @@ data:
   dynamic.linux-large-s390x.profile: "bz2-4x16"
   dynamic.linux-large-s390x.max-instances: "10"
   dynamic.linux-large-s390x.private-ip: "true"
+  dynamic.linux-large-s390x.allocation-timeout: "1800"
   dynamic.linux-large-s390x.instance-tag: prod-s390x-large
+
+  # S390X 2vCPU / 8GB RAM / 200GB disk
+  dynamic.linux-d200-s390x.type: ibmz
+  dynamic.linux-d200-s390x.ssh-secret: "ibm-ssh-key"
+  dynamic.linux-d200-s390x.secret: "ibm-api-key"
+  dynamic.linux-d200-s390x.vpc: "konflux-prod-multi-rh02"
+  dynamic.linux-d200-s390x.key: "konflux-s390x-root"
+  dynamic.linux-d200-s390x.subnet: "sn-20241213-02"
+  dynamic.linux-d200-s390x.image-id: "r006-20e160c3-58d7-4b3b-827f-9d7994b68095"
+  dynamic.linux-d200-s390x.region: "us-south-2"
+  dynamic.linux-d200-s390x.url: "https://us-south.iaas.cloud.ibm.com/v1"
+  dynamic.linux-d200-s390x.profile: "bz2-2x8"
+  dynamic.linux-d200-s390x.max-instances: "30"
+  dynamic.linux-d200-s390x.private-ip: "true"
+  dynamic.linux-d200-s390x.allocation-timeout: "1800"
+  dynamic.linux-d200-s390x.disk: "200"
+  dynamic.linux-d200-s390x.instance-tag: prod-d200-s390x
+
+  # S390X 4vCPU / 16GB RAM / 200GB disk
+  dynamic.linux-d200-large-s390x.type: ibmz
+  dynamic.linux-d200-large-s390x.ssh-secret: "ibm-ssh-key"
+  dynamic.linux-d200-large-s390x.secret: "ibm-api-key"
+  dynamic.linux-d200-large-s390x.vpc: "konflux-prod-multi-rh02"
+  dynamic.linux-d200-large-s390x.key: "konflux-s390x-root"
+  dynamic.linux-d200-large-s390x.subnet: "sn-20241213-02"
+  dynamic.linux-d200-large-s390x.image-id: "r006-20e160c3-58d7-4b3b-827f-9d7994b68095"
+  dynamic.linux-d200-large-s390x.region: "us-south-2"
+  dynamic.linux-d200-large-s390x.url: "https://us-south.iaas.cloud.ibm.com/v1"
+  dynamic.linux-d200-large-s390x.profile: "bz2-4x16"
+  dynamic.linux-d200-large-s390x.max-instances: "10"
+  dynamic.linux-d200-large-s390x.private-ip: "true"
+  dynamic.linux-d200-large-s390x.allocation-timeout: "1800"
+  dynamic.linux-d200-large-s390x.disk: "200"
+  dynamic.linux-d200-large-s390x.instance-tag: prod-d200-s390x-large
 
   # PPC64LE 2vCPU / 8GB RAM / 100GB disk
   dynamic.linux-ppc64le.type: ibmp

--- a/components/multi-platform-controller/production/stone-prd-rh01/host-config.yaml
+++ b/components/multi-platform-controller/production/stone-prd-rh01/host-config.yaml
@@ -41,8 +41,9 @@ data:
     linux-fast/amd64,\
     linux-extra-fast/amd64,\
     linux/s390x,\
-    linux-d200-large/s390x,\
     linux-large/s390x,\
+    linux-d200/s390x,\
+    linux-d200-large/s390x,\
     linux/ppc64le,\
     linux-large/ppc64le,\
     linux-xlarge/ppc64le,\
@@ -534,7 +535,7 @@ data:
 
     --//--
 
-  ## IBM s390x with 2CPU 8GiB RAM ####
+  # S390X 2vCPU / 8GB RAM / 100GB disk
   dynamic.linux-s390x.type: ibmz
   dynamic.linux-s390x.ssh-secret: "ibm-production-s390x-ssh-key"
   dynamic.linux-s390x.secret: "public-prod-ibm-api-key"
@@ -550,7 +551,7 @@ data:
   dynamic.linux-s390x.allocation-timeout: "1800"
   dynamic.linux-s390x.instance-tag: prod-s390x
 
-  ## IBM s390x with 4CPU 16GiB RAM ####
+  # S390X 4vCPU / 16GB RAM / 100GB disk
   dynamic.linux-large-s390x.type: ibmz
   dynamic.linux-large-s390x.ssh-secret: "ibm-production-s390x-ssh-key"
   dynamic.linux-large-s390x.secret: "public-prod-ibm-api-key"
@@ -566,7 +567,24 @@ data:
   dynamic.linux-large-s390x.allocation-timeout: "1800"
   dynamic.linux-large-s390x.instance-tag: prod-s390x-large
 
-  # Same as linux-s390x-large but with 200GB disk instead of default 100GB
+  # S390X 2vCPU / 8GB RAM / 200GB disk
+  dynamic.linux-d200-s390x.type: ibmz
+  dynamic.linux-d200-s390x.ssh-secret: "ibm-production-s390x-ssh-key"
+  dynamic.linux-d200-s390x.secret: "public-prod-ibm-api-key"
+  dynamic.linux-d200-s390x.vpc: "us-east-default-vpc"
+  dynamic.linux-d200-s390x.key: "konflux-s390x-root"
+  dynamic.linux-d200-s390x.subnet: "konflux-ext-prod-1"
+  dynamic.linux-d200-s390x.image-id: "r014-96daa951-6026-4112-95b1-87e86e82fcf3"
+  dynamic.linux-d200-s390x.region: "us-east-2"
+  dynamic.linux-d200-s390x.url: "https://us-east.iaas.cloud.ibm.com/v1"
+  dynamic.linux-d200-s390x.profile: "bz2-2x8"
+  dynamic.linux-d200-s390x.max-instances: "30"
+  dynamic.linux-d200-s390x.private-ip: "true"
+  dynamic.linux-d200-s390x.allocation-timeout: "1800"
+  dynamic.linux-d200-s390x.disk: "200"
+  dynamic.linux-d200-s390x.instance-tag: prod-d200-s390x
+
+  # S390X 4vCPU / 16GB RAM / 200GB disk
   dynamic.linux-d200-large-s390x.type: ibmz
   dynamic.linux-d200-large-s390x.ssh-secret: "ibm-production-s390x-ssh-key"
   dynamic.linux-d200-large-s390x.secret: "public-prod-ibm-api-key"


### PR DESCRIPTION
Make sure we have same VMs everywhere in all clusters except dedicated ones. This will allow to have one common user documentation for VM size.

KONFLUX-6961