### PR TITLE
smee base - livenesProbe creation

### DIFF
--- a/components/smee/base/deployment.yaml
+++ b/components/smee/base/deployment.yaml
@@ -24,6 +24,14 @@ spec:
             - name: "gosmee-http"
               containerPort: 3333
               protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 3333
+          initialDelaySeconds: 10
+          periodSeconds: 5
+          timeoutSeconds: 2
+          failureThreshold: 3
           securityContext:
             readOnlyRootFilesystem: true
             runAsNonRoot: true


### PR DESCRIPTION
Based on https://issues.redhat.com/browse/SPRE-1255 and issue originated on https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1743183353400319?thread_ts=1743149867.743659&cid=C04PZ7H0VA8 we need to setup a livenesProbe to automate the process of restarting the Pod if failing for some reason 

