### PR TITLE
smee-client - livenessProbe creation

### DIFF
--- a/components/smee-client/base/deployment.yaml
+++ b/components/smee-client/base/deployment.yaml
@@ -24,7 +24,7 @@ spec:
           livenessProbe:
             httpGet:
               path: /
-              port: 3333
+              port: 8080
           initialDelaySeconds: 10
           periodSeconds: 5
           timeoutSeconds: 2

--- a/components/smee-client/base/deployment.yaml
+++ b/components/smee-client/base/deployment.yaml
@@ -21,6 +21,14 @@ spec:
             - "client"
             - TBA
             - "http://pipelines-as-code-controller.openshift-pipelines:8080"
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 3333
+          initialDelaySeconds: 10
+          periodSeconds: 5
+          timeoutSeconds: 2
+          failureThreshold: 3
           securityContext:
             readOnlyRootFilesystem: true
             runAsNonRoot: true

--- a/components/smee/base/deployment.yaml
+++ b/components/smee/base/deployment.yaml
@@ -24,6 +24,14 @@ spec:
             - name: "gosmee-http"
               containerPort: 3333
               protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 3333
+          initialDelaySeconds: 10
+          periodSeconds: 5
+          timeoutSeconds: 2
+          failureThreshold: 3
           securityContext:
             readOnlyRootFilesystem: true
             runAsNonRoot: true


### PR DESCRIPTION
Based on https://issues.redhat.com/browse/SPRE-1255, as well as for smee server, we need to set up a livenessProbe for the client.