### PR TITLE
use emptyDir workspace for all oci-ta pipelines

### DIFF
--- a/components/release/development/release_service_config.yaml
+++ b/components/release/development/release_service_config.yaml
@@ -8,3 +8,6 @@ spec:
     - url: ".*"
       revision: ".*"
       pathInRepo: "pipelines/managed/rh-advisories/rh-advisories-oci-ta.yaml"
+    - url: ".*"
+      revision: ".*"
+      pathInRepo: "pipelines/managed/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io-oci-ta.yaml"

--- a/components/release/production/release_service_config.yaml
+++ b/components/release/production/release_service_config.yaml
@@ -8,3 +8,6 @@ spec:
     - url: ".*"
       revision: ".*"
       pathInRepo: "pipelines/managed/rh-advisories/rh-advisories-oci-ta.yaml"
+    - url: ".*"
+      revision: ".*"
+      pathInRepo: "pipelines/managed/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io-oci-ta.yaml"

--- a/components/release/staging/release_service_config.yaml
+++ b/components/release/staging/release_service_config.yaml
@@ -8,3 +8,6 @@ spec:
     - url: ".*"
       revision: ".*"
       pathInRepo: "pipelines/managed/rh-advisories/rh-advisories-oci-ta.yaml"
+    - url: ".*"
+      revision: ".*"
+      pathInRepo: "pipelines/managed/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io-oci-ta.yaml"


### PR DESCRIPTION
- use emptyDir for rh-push-to-registry-redhat-io-oci-ta.yaml