### PR TITLE
bump namespace-lister in staging

### DIFF
--- a/components/konflux-ui/staging/base/proxy/nginx.conf
+++ b/components/konflux-ui/staging/base/proxy/nginx.conf
@@ -49,7 +49,7 @@ http {
         }
 
         location = /oauth2/auth {
-            internal; 
+            internal;
             proxy_pass       http://127.0.0.1:6000;
             proxy_set_header Host             $host;
             proxy_set_header X-Real-IP        $remote_addr;
@@ -109,9 +109,10 @@ http {
         location @namespacelister {
             auth_request /oauth2/auth;
             proxy_read_timeout 30m;
-            auth_request_set $username  $upstream_http_x_auth_request_preferred_username; 
+            auth_request_set $username  $upstream_http_x_auth_request_preferred_username;
             proxy_set_header X-User $username;
             proxy_set_header X-Group system:authenticated;
+            proxy_hide_header X-Correlation-ID
 
             rewrite ^.*$ /api/v1/namespaces break;
 

--- a/components/konflux-ui/staging/base/proxy/nginx.conf
+++ b/components/konflux-ui/staging/base/proxy/nginx.conf
@@ -112,7 +112,7 @@ http {
             auth_request_set $username  $upstream_http_x_auth_request_preferred_username;
             proxy_set_header X-User $username;
             proxy_set_header X-Group system:authenticated;
-            proxy_hide_header X-Correlation-ID
+            proxy_hide_header X-Correlation-ID;
 
             rewrite ^.*$ /api/v1/namespaces break;
 

--- a/components/namespace-lister/base/kustomization.yaml
+++ b/components/namespace-lister/base/kustomization.yaml
@@ -13,7 +13,7 @@ namespace: namespace-lister
 images:
 - name: namespace-lister
   newName: quay.io/konflux-ci/namespace-lister
-  newTag: fb43db0f7db1024e58ed5306dd5cb37acc22543b
+  newTag: 7d82c8e86473c7001a963dba7e0d27c597bef4af
 patches:
 - path: ./patches/with_cachenamespacelabelselector.yaml
   target:


### PR DESCRIPTION
A list of changes:

    Francesco Ilario (4):
          avoid checking string equality twice in removeDuplicateSubjects (#117)
          trim policy rules stored in accesscache (#116)
          reduce log verbosity (#119)
          add support for X-Correlation-ID header (#120)

    red-hat-konflux[bot] (3):
          chore(deps): update registry.access.redhat.com/ubi9/go-toolset docker digest to 293b288 (#122)
          chore(deps): update konflux references (#123)
          chore(deps): update github.com/golang/groupcache digest to 2c02b82 (#124)