### PR TITLE
Add missing env patch to konflux-rbac

### DIFF
--- a/argo-cd-apps/overlays/production-downstream/kustomization.yaml
+++ b/argo-cd-apps/overlays/production-downstream/kustomization.yaml
@@ -226,3 +226,8 @@ patches:
       kind: ApplicationSet
       version: v1alpha1
       name: kyverno
+  - path: production-overlay-patch.yaml
+    target:
+      kind: ApplicationSet
+      version: v1alpha1
+      name: konflux-rbac


### PR DESCRIPTION
The patch which sets the env for konflux-rbac
was missing in production-downstream.