### PR TITLE
PVO11Y-4717 Give observability admins permissions to manage appstudio-monitoring namespace

### DIFF
--- a/components/monitoring/prometheus/base/rbac/kustomization.yaml
+++ b/components/monitoring/prometheus/base/rbac/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- monitoring-admin.yaml

--- a/components/monitoring/prometheus/base/rbac/monitoring-admin.yaml
+++ b/components/monitoring/prometheus/base/rbac/monitoring-admin.yaml
@@ -1,0 +1,24 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: all-access-appstudio-monitoring
+  namespace: appstudio-monitoring
+rules:
+- apiGroups: [""]
+  resources: ["*"]
+  verbs: ["*"]
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: all-access-appstudio-monitoring
+  namespace: appstudio-monitoring
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: konflux-o11y-admins
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: all-access-appstudio-monitoring

--- a/components/monitoring/prometheus/production/base/kustomization.yaml
+++ b/components/monitoring/prometheus/production/base/kustomization.yaml
@@ -4,6 +4,7 @@ resources:
 - ../../base/uwm-config
 - ../../base/external-secrets
 - ../../base/observability-operator
+- ../../base/rbac
 - monitoringstack/
 patches:
   - path: rhobs-secret-path.yaml

--- a/components/monitoring/prometheus/staging/base/kustomization.yaml
+++ b/components/monitoring/prometheus/staging/base/kustomization.yaml
@@ -4,6 +4,7 @@ resources:
 - ../../base/uwm-config
 - ../../base/external-secrets
 - ../../base/observability-operator
+- ../../base/rbac
 - monitoringstack/
 patches:
   - path: rhobs-secret-path.yaml


### PR DESCRIPTION
This allows admin group members to debug and fix non-trivial issues.