### PR TITLE
bump namespace-lister in production

### DIFF
--- a/components/konflux-ui/production/base/proxy/nginx.conf
+++ b/components/konflux-ui/production/base/proxy/nginx.conf
@@ -49,7 +49,7 @@ http {
         }
 
         location = /oauth2/auth {
-            internal; 
+            internal;
             proxy_pass       http://127.0.0.1:6000;
             proxy_set_header Host             $host;
             proxy_set_header X-Real-IP        $remote_addr;
@@ -72,10 +72,10 @@ http {
             proxy_set_header X-Email $email;
             auth_request_set $user  $upstream_http_x_auth_request_user;
             proxy_set_header X-User  $user;
-            auth_request_set $username  $upstream_http_x_auth_request_preferred_username; 
+            auth_request_set $username  $upstream_http_x_auth_request_preferred_username;
             proxy_set_header X-Auth-Request-Preferred-Username $username;
             auth_request_set $groups  $upstream_http_x_auth_request_groups;
-            proxy_set_header X-Auth-Request-Groups  $user;    
+            proxy_set_header X-Auth-Request-Groups  $user;
 
             auth_request /oauth2/auth;
             proxy_pass http://127.0.0.1:5000/;
@@ -87,7 +87,7 @@ http {
             proxy_set_header X-Email $email;
             auth_request_set $user  $upstream_http_x_auth_request_user;
             proxy_set_header X-User  $user;
-            auth_request_set $username  $upstream_http_x_auth_request_preferred_username; 
+            auth_request_set $username  $upstream_http_x_auth_request_preferred_username;
             proxy_set_header X-Auth-Request-Preferred-Username $username;
             auth_request_set $groups  $upstream_http_x_auth_request_groups;
             proxy_set_header X-Auth-Request-Groups  $user;
@@ -148,7 +148,7 @@ http {
             include /mnt/nginx-generated-config/tekton-results.conf;
             include /mnt/nginx-generated-config/auth.conf;
         }
-        
+
         location /api/k8s/plugins/tekton-results/ {
             auth_request /oauth2/auth;
 
@@ -174,6 +174,7 @@ http {
             proxy_read_timeout 30m;
             proxy_set_header X-User $email;
             proxy_set_header X-Group system:authenticated;
+            proxy_hide_header X-Correlation-ID;
 
             rewrite ^.*$ /api/v1/namespaces break;
 

--- a/components/namespace-lister/production/base/kustomization.yaml
+++ b/components/namespace-lister/production/base/kustomization.yaml
@@ -13,7 +13,7 @@ namespace: namespace-lister
 images:
 - name: namespace-lister
   newName: quay.io/konflux-ci/namespace-lister
-  newTag: fb43db0f7db1024e58ed5306dd5cb37acc22543b
+  newTag: 7f96fde10f2612c324fdafe4b1d73b6949ccbcba
 patches:
 - path: ./patches/with_cachenamespacelabelselector.yaml
   target:


### PR DESCRIPTION
Changelog:

    Francesco Ilario (5):
          avoid checking string equality twice in removeDuplicateSubjects (#117)
          trim policy rules stored in accesscache (#116)
          reduce log verbosity (#119)
          add support for X-Correlation-ID header (#120)
          add sast-shell-check and sast-unicode-check tasks (#127)

    red-hat-konflux[bot] (4):
          chore(deps): update registry.access.redhat.com/ubi9/go-toolset docker digest to 293b288 (#122)
          chore(deps): update konflux references (#123)
          chore(deps): update github.com/golang/groupcache digest to 2c02b82 (#124)
          chore(deps): update registry.access.redhat.com/ubi9/go-toolset docker digest to 0fb743b (#126)