### PR TITLE
Update staging RDS vault secret paths

### DIFF
--- a/components/kubearchive/staging/database-secret.yaml
+++ b/components/kubearchive/staging/database-secret.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   dataFrom:
     - extract:
-        key: integrations-output/terraform-resources/appsres09ue1/stonesoup-infra-stage/kube-archive-staging-rds
+        key: integrations-output/external-resources/appsres09ue1/stonesoup-infra-stage/kube-archive-staging-rds
   refreshInterval: 1h
   secretStoreRef:
     kind: ClusterSecretStore

--- a/components/pipeline-service/staging/stone-stage-p01/resources/tekton-results-database-secret-path.yaml
+++ b/components/pipeline-service/staging/stone-stage-p01/resources/tekton-results-database-secret-path.yaml
@@ -1,4 +1,4 @@
 ---
 - op: add
   path: /spec/dataFrom/0/extract/key
-  value: integrations-output/terraform-resources/appsres09ue1/stone-stage-p01/stone-stage-p01-plnsvc-rds
+  value: integrations-output/external-resources/appsres09ue1/stone-stage-p01/stone-stage-p01-plnsvc-rds

--- a/components/pipeline-service/staging/stone-stg-rh01/resources/tekton-results-database-secret-path.yaml
+++ b/components/pipeline-service/staging/stone-stg-rh01/resources/tekton-results-database-secret-path.yaml
@@ -1,4 +1,4 @@
 ---
 - op: add
   path: /spec/dataFrom/0/extract/key
-  value: integrations-output/terraform-resources/appsres11ue1/stonesoup-infra-stage/redhat-staging-plnsvc-rds
+  value: integrations-output/external-resources/appsres11ue1/stonesoup-infra-stage/redhat-staging-plnsvc-rds


### PR DESCRIPTION
[KFLUXINFRA-1412](https://issues.redhat.com/browse/KFLUXINFRA-1442): AppSRE has changed the integration that manages the Konflux RDS instances from `terraform-resources` to `external-resources`. This, in turn, requires a change to the vault secret paths for RDS instances in order to ensure the instances have the most up-to-date passwords.