### PR TITLE
Update production RDS vault secret paths

### DIFF
--- a/components/pipeline-service/production/kflux-ocp-p01/deploy.yaml
+++ b/components/pipeline-service/production/kflux-ocp-p01/deploy.yaml
@@ -2099,7 +2099,7 @@ metadata:
 spec:
   dataFrom:
   - extract:
-      key: integrations-output/terraform-resources/appsrep09ue1/kflux-ocp-p01/kflux-ocp-p01-plnsvc-rds
+      key: integrations-output/external-resources/appsrep09ue1/kflux-ocp-p01/kflux-ocp-p01-plnsvc-rds
   refreshInterval: 1h
   secretStoreRef:
     kind: ClusterSecretStore

--- a/components/pipeline-service/production/kflux-ocp-p01/resources/tekton-results-database-secret-path.yaml
+++ b/components/pipeline-service/production/kflux-ocp-p01/resources/tekton-results-database-secret-path.yaml
@@ -1,4 +1,4 @@
 ---
 - op: add
   path: /spec/dataFrom/0/extract/key
-  value: integrations-output/terraform-resources/appsrep09ue1/kflux-ocp-p01/kflux-ocp-p01-plnsvc-rds
+  value: integrations-output/external-resources/appsrep09ue1/kflux-ocp-p01/kflux-ocp-p01-plnsvc-rds

--- a/components/pipeline-service/production/kflux-prd-rh02/deploy.yaml
+++ b/components/pipeline-service/production/kflux-prd-rh02/deploy.yaml
@@ -2130,7 +2130,7 @@ metadata:
 spec:
   dataFrom:
   - extract:
-      key: integrations-output/terraform-resources/appsrep09ue1/kflux-prd-rh02/kflux-prd-rh02-plnsvc-rds
+      key: integrations-output/external-resources/appsrep09ue1/kflux-prd-rh02/kflux-prd-rh02-plnsvc-rds
   refreshInterval: 1h
   secretStoreRef:
     kind: ClusterSecretStore

--- a/components/pipeline-service/production/kflux-prd-rh02/resources/tekton-results-database-secret-path.yaml
+++ b/components/pipeline-service/production/kflux-prd-rh02/resources/tekton-results-database-secret-path.yaml
@@ -1,4 +1,4 @@
 ---
 - op: add
   path: /spec/dataFrom/0/extract/key
-  value: integrations-output/terraform-resources/appsrep09ue1/kflux-prd-rh02/kflux-prd-rh02-plnsvc-rds
+  value: integrations-output/external-resources/appsrep09ue1/kflux-prd-rh02/kflux-prd-rh02-plnsvc-rds

--- a/components/pipeline-service/production/stone-prd-m01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prd-m01/deploy.yaml
@@ -2099,7 +2099,7 @@ metadata:
 spec:
   dataFrom:
   - extract:
-      key: integrations-output/terraform-resources/appsrep11ue1/stonesoup-infra-production/multi-tenant-prod-plnsvc-rds
+      key: integrations-output/external-resources/appsrep11ue1/stonesoup-infra-production/multi-tenant-prod-plnsvc-rds
   refreshInterval: 1h
   secretStoreRef:
     kind: ClusterSecretStore

--- a/components/pipeline-service/production/stone-prd-m01/resources/tekton-results-database-secret-path.yaml
+++ b/components/pipeline-service/production/stone-prd-m01/resources/tekton-results-database-secret-path.yaml
@@ -1,4 +1,4 @@
 ---
 - op: add
   path: /spec/dataFrom/0/extract/key
-  value: integrations-output/terraform-resources/appsrep11ue1/stonesoup-infra-production/multi-tenant-prod-plnsvc-rds
+  value: integrations-output/external-resources/appsrep11ue1/stonesoup-infra-production/multi-tenant-prod-plnsvc-rds

--- a/components/pipeline-service/production/stone-prd-rh01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prd-rh01/deploy.yaml
@@ -2099,7 +2099,7 @@ metadata:
 spec:
   dataFrom:
   - extract:
-      key: integrations-output/terraform-resources/appsrep11ue1/stonesoup-infra-production/redhat-prod-plnsvc-rds
+      key: integrations-output/external-resources/appsrep11ue1/stonesoup-infra-production/redhat-prod-plnsvc-rds
   refreshInterval: 1h
   secretStoreRef:
     kind: ClusterSecretStore

--- a/components/pipeline-service/production/stone-prd-rh01/resources/tekton-results-database-secret-path.yaml
+++ b/components/pipeline-service/production/stone-prd-rh01/resources/tekton-results-database-secret-path.yaml
@@ -1,4 +1,4 @@
 ---
 - op: add
   path: /spec/dataFrom/0/extract/key
-  value: integrations-output/terraform-resources/appsrep11ue1/stonesoup-infra-production/redhat-prod-plnsvc-rds
+  value: integrations-output/external-resources/appsrep11ue1/stonesoup-infra-production/redhat-prod-plnsvc-rds

--- a/components/pipeline-service/production/stone-prod-p01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prod-p01/deploy.yaml
@@ -2099,7 +2099,7 @@ metadata:
 spec:
   dataFrom:
   - extract:
-      key: integrations-output/terraform-resources/appsrep09ue1/stone-prod-p01/stone-prod-p01-plnsvc-rds
+      key: integrations-output/external-resources/appsrep09ue1/stone-prod-p01/stone-prod-p01-plnsvc-rds
   refreshInterval: 1h
   secretStoreRef:
     kind: ClusterSecretStore

--- a/components/pipeline-service/production/stone-prod-p01/resources/tekton-results-database-secret-path.yaml
+++ b/components/pipeline-service/production/stone-prod-p01/resources/tekton-results-database-secret-path.yaml
@@ -1,4 +1,4 @@
 ---
 - op: add
   path: /spec/dataFrom/0/extract/key
-  value: integrations-output/terraform-resources/appsrep09ue1/stone-prod-p01/stone-prod-p01-plnsvc-rds
+  value: integrations-output/external-resources/appsrep09ue1/stone-prod-p01/stone-prod-p01-plnsvc-rds

--- a/components/pipeline-service/production/stone-prod-p02/deploy.yaml
+++ b/components/pipeline-service/production/stone-prod-p02/deploy.yaml
@@ -2099,7 +2099,7 @@ metadata:
 spec:
   dataFrom:
   - extract:
-      key: integrations-output/terraform-resources/appsrep09ue1/konflux-internal-prod/stone-prod-p02-plnsvc-rds
+      key: integrations-output/external-resources/appsrep09ue1/konflux-internal-prod/stone-prod-p02-plnsvc-rds
   refreshInterval: 1h
   secretStoreRef:
     kind: ClusterSecretStore

--- a/components/pipeline-service/production/stone-prod-p02/resources/tekton-results-database-secret-path.yaml
+++ b/components/pipeline-service/production/stone-prod-p02/resources/tekton-results-database-secret-path.yaml
@@ -1,4 +1,4 @@
 ---
 - op: add
   path: /spec/dataFrom/0/extract/key
-  value: integrations-output/terraform-resources/appsrep09ue1/konflux-internal-prod/stone-prod-p02-plnsvc-rds
+  value: integrations-output/external-resources/appsrep09ue1/konflux-internal-prod/stone-prod-p02-plnsvc-rds

--- a/components/pipeline-service/staging/stone-stage-p01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stage-p01/deploy.yaml
@@ -2103,7 +2103,7 @@ metadata:
 spec:
   dataFrom:
   - extract:
-      key: integrations-output/terraform-resources/appsres09ue1/stone-stage-p01/stone-stage-p01-plnsvc-rds
+      key: integrations-output/external-resources/appsres09ue1/stone-stage-p01/stone-stage-p01-plnsvc-rds
   refreshInterval: 1h
   secretStoreRef:
     kind: ClusterSecretStore

--- a/components/pipeline-service/staging/stone-stg-rh01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stg-rh01/deploy.yaml
@@ -2103,7 +2103,7 @@ metadata:
 spec:
   dataFrom:
   - extract:
-      key: integrations-output/terraform-resources/appsres11ue1/stonesoup-infra-stage/redhat-staging-plnsvc-rds
+      key: integrations-output/external-resources/appsres11ue1/stonesoup-infra-stage/redhat-staging-plnsvc-rds
   refreshInterval: 1h
   secretStoreRef:
     kind: ClusterSecretStore


### PR DESCRIPTION
AppSRE has changed the integration that manages the Konflux RDS instances from terraform-resources to external-resources. This, in turn, requires a change to the vault secret paths for RDS instances in order to ensure the instances have the most up-to-date passwords.