### PR TITLE
Allow 70ppc VMs with default profile

### DIFF
--- a/components/multi-platform-controller/production-downstream/stone-prod-p02/host-config.yaml
+++ b/components/multi-platform-controller/production-downstream/stone-prod-p02/host-config.yaml
@@ -600,7 +600,7 @@ data:
   dynamic.linux-ppc64le.system: "e980"
   dynamic.linux-ppc64le.cores: "0.25"
   dynamic.linux-ppc64le.memory: "8"
-  dynamic.linux-ppc64le.max-instances: "50"
+  dynamic.linux-ppc64le.max-instances: "70"
   dynamic.linux-ppc64le.allocation-timeout: "1800"
   dynamic.linux-ppc64le.instance-tag: prod-ppc64le
 

--- a/components/multi-platform-controller/production/stone-prd-rh01/host-config.yaml
+++ b/components/multi-platform-controller/production/stone-prd-rh01/host-config.yaml
@@ -74,7 +74,7 @@ data:
   dynamic.linux-arm64.aws-secret: aws-account
   dynamic.linux-arm64.ssh-secret: aws-ssh-key
   dynamic.linux-arm64.security-group-id: sg-0fbf35ced0d59fd4a
-  dynamic.linux-arm64.max-instances: "50"
+  dynamic.linux-arm64.max-instances: "70"
   dynamic.linux-arm64.subnet-id: subnet-0c39ff75f819abfc5
 
   dynamic.linux-mlarge-arm64.type: aws


### PR DESCRIPTION
Since we reduced number of core, there should be room for more, let's try.