### PR TITLE
add policy to create appstudio-pipeline rolebinding in staging

### DIFF
--- a/components/konflux-ci/policies/bootstrap-tenant-namespace/.chainsaw-test/chainsaw-assert-clusterpolicy.yaml
+++ b/components/konflux-ci/policies/bootstrap-tenant-namespace/.chainsaw-test/chainsaw-assert-clusterpolicy.yaml
@@ -1,0 +1,9 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: bootstrap-tenant-namespace
+status:
+  conditions:
+  - reason: Succeeded
+    status: "True"
+    type: Ready

--- a/components/konflux-ci/policies/bootstrap-tenant-namespace/.chainsaw-test/chainsaw-test.yaml
+++ b/components/konflux-ci/policies/bootstrap-tenant-namespace/.chainsaw-test/chainsaw-test.yaml
@@ -1,0 +1,204 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: konfluxci-bootstrap-ns-mutate-new-namespace-konfluxcidev
+spec:
+  description: |
+    tests that the RoleBinding is created in a namespace
+    labeled with `konflux-ci.dev/type=tenant`
+  concurrent: false
+  namespace: 'pipelinesa-generate-new-namespace'
+  bindings:
+  - name: suffix
+    value: labeled 
+  steps:
+  - name: pipelinesa-given-appstudio-pipeline-clusterrole-exists
+    try:
+    - apply:
+        file: ./resources/actual-appstudio-pipeline-clusterrole.yaml
+  - name: pipelinesa-given-kyverno-has-permission-on-resources
+    try:
+    - apply:
+        file: ../kyverno_rbac.yaml
+  - name: pipelinesa-given-cluster-policy-is-ready
+    try:
+    - apply:
+        file: ../bootstrap-tenant-namespace-clusterpolicy.yaml
+    - assert:
+        file: chainsaw-assert-clusterpolicy.yaml
+  - name: pipelinesa-when-konfluxcidev-labeled-namespace-is-created
+    try:
+    - apply:
+        file: resources/actual-namespace-konfluxcidev.yaml
+        template: true
+  - name: pipelinesa-then-rolebinding-is-created
+    try:
+    - assert:
+        file: resources/expected-rolebinding.yaml
+        template: true
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: konfluxci-bootstrap-ns-mutate-new-namespace-unlabeled
+spec:
+  description: |
+    tests that the RoleBinding is NOT created in an unlabeled namespace
+  concurrent: false
+  namespace: 'pipelinesa-generate-new-namespace'
+  bindings:
+  - name: suffix
+    value: unlabeled
+  steps:
+  - name: pipelinesa-given-appstudio-pipeline-clusterrole-exists
+    try:
+    - apply:
+        file: ./resources/actual-appstudio-pipeline-clusterrole.yaml
+  - name: pipelinesa-given-kyverno-has-permission-on-resources
+    try:
+    - apply:
+        file: ../kyverno_rbac.yaml
+  - name: pipelinesa-given-cluster-policy-is-ready
+    try:
+    - apply:
+        file: ../bootstrap-tenant-namespace-clusterpolicy.yaml
+    - assert:
+        file: chainsaw-assert-clusterpolicy.yaml
+  - name: pipelinesa-when-unlabeled-namespace-is-created
+    try:
+    - apply:
+        file: resources/actual-namespace-unlabeled.yaml
+        template: true
+  - name: pipelinesa-then-rolebinding-is-created
+    try:
+    - error:
+        file: resources/expected-rolebinding.yaml
+        template: true
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: konfluxci-bootstrap-ns-mutate-existing-namespace-konfluxcidev
+spec:
+  description: |
+    tests that the RoleBinding is created in an already existing
+    namespace labeled with `konflux-ci.dev/type=tenant`
+  concurrent: false
+  namespace: 'pipelinesa-generate-existing-namespace'
+  bindings:
+  - name: suffix
+    value: labeled
+  steps:
+  - name: pipelinesa-given-appstudio-pipeline-clusterrole-exists
+    try:
+    - apply:
+        file: ./resources/actual-appstudio-pipeline-clusterrole.yaml
+  - name: pipelinesa-given-kyverno-has-permission-on-resources
+    try:
+    - apply:
+        file: ../kyverno_rbac.yaml
+  - name: pipelinesa-given-konfluxci-labeled-namespace-is-created
+    try:
+    - apply:
+        file: resources/actual-namespace-konfluxcidev.yaml
+        template: true
+  - name: pipelinesa-when-cluster-policy-is-ready
+    try:
+    - apply:
+        file: ../bootstrap-tenant-namespace-clusterpolicy.yaml
+    - assert:
+        file: chainsaw-assert-clusterpolicy.yaml
+  - name: pipelinesa-then-rolebinding-is-created
+    try:
+    - assert:
+        file: resources/expected-rolebinding.yaml
+        template: true
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: konfluxci-bootstrap-ns-mutate-existing-namespace-unlabeled
+spec:
+  description: |
+    tests that the RoleBinding is NOT created in an 
+    existing unlabeled namespace
+  concurrent: false
+  namespace: 'pipelinesa-generate-existing-namespace'
+  bindings:
+  - name: suffix
+    value: unlabeled
+  steps:
+  - name: pipelinesa-given-appstudio-pipeline-clusterrole-exists
+    try:
+    - apply:
+        file: ./resources/actual-appstudio-pipeline-clusterrole.yaml
+  - name: pipelinesa-given-kyverno-has-permission-on-resources
+    try:
+    - apply:
+        file: ../kyverno_rbac.yaml
+  - name: pipelinesa-given-unlabeled-namespace-is-created
+    try:
+    - apply:
+        file: resources/actual-namespace-unlabeled.yaml
+        template: true
+  - name: pipelinesa-when-cluster-policy-is-ready
+    try:
+    - apply:
+        file: ../bootstrap-tenant-namespace-clusterpolicy.yaml
+    - assert:
+        file: chainsaw-assert-clusterpolicy.yaml
+  - name: pipelinesa-then-rolebinding-is-created
+    try:
+    - error:
+        file: resources/expected-rolebinding.yaml
+        template: true
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: konfluxci-bootstrap-ns-mutate-existing-namespace-konfluxcidev-existing-rolebinding
+spec:
+  description: |
+    tests that the RoleBinding is not updated in an already existing
+    namespace labeled with `konflux-ci.dev/type=tenant` where the 
+    RoleBinding already exists
+  concurrent: false
+  namespace: 'pipelinesa-generate-existing-namespace'
+  bindings:
+  - name: suffix
+    value: labeled
+  steps:
+  - name: pipelinesa-given-appstudio-pipeline-clusterrole-exists
+    try:
+    - apply:
+        file: ./resources/actual-appstudio-pipeline-clusterrole.yaml
+  - name: pipelinesa-given-kyverno-has-permission-on-resources
+    try:
+    - apply:
+        file: ../kyverno_rbac.yaml
+  - name: pipelinesa-given-konfluxcidev-labeled-namespace-is-created
+    try:
+    - apply:
+        file: resources/actual-namespace-konfluxcidev.yaml
+        template: true
+  - name: pipelinesa-given-rolebinding-is-created
+    try:
+    - apply:
+        file: resources/actual-existing-rolebinding.yaml
+        template: true
+  - name: pipelinesa-when-cluster-policy-is-ready
+    try:
+    - apply:
+        file: ../bootstrap-tenant-namespace-clusterpolicy.yaml
+    - assert:
+        file: chainsaw-assert-clusterpolicy.yaml
+  - name: pipelinesa-then-rolebinding-is-not-changed
+    try:
+    - assert:
+        file: resources/actual-existing-rolebinding.yaml
+        template: true

--- a/components/konflux-ci/policies/bootstrap-tenant-namespace/.chainsaw-test/resources/actual-appstudio-pipeline-clusterrole.yaml
+++ b/components/konflux-ci/policies/bootstrap-tenant-namespace/.chainsaw-test/resources/actual-appstudio-pipeline-clusterrole.yaml
@@ -1,0 +1,4 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: appstudio-pipeline

--- a/components/konflux-ci/policies/bootstrap-tenant-namespace/.chainsaw-test/resources/actual-existing-rolebinding.yaml
+++ b/components/konflux-ci/policies/bootstrap-tenant-namespace/.chainsaw-test/resources/actual-existing-rolebinding.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: appstudio-pipelines-runner-rolebinding
+  namespace: (join('-', [$namespace, $suffix]))
+  labels:
+    already-existing: expected-not-to-be-removed
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: appstudio-pipeline
+subjects:
+- kind: ServiceAccount
+  namespace: (join('-', [$namespace, $suffix]))
+  name: appstudio-pipeline

--- a/components/konflux-ci/policies/bootstrap-tenant-namespace/.chainsaw-test/resources/actual-namespace-konfluxcidev.yaml
+++ b/components/konflux-ci/policies/bootstrap-tenant-namespace/.chainsaw-test/resources/actual-namespace-konfluxcidev.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: (join('-', [$namespace, $suffix]))
+  labels:
+    konflux-ci.dev/type: tenant

--- a/components/konflux-ci/policies/bootstrap-tenant-namespace/.chainsaw-test/resources/actual-namespace-unlabeled.yaml
+++ b/components/konflux-ci/policies/bootstrap-tenant-namespace/.chainsaw-test/resources/actual-namespace-unlabeled.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: (join('-', [$namespace, $suffix]))

--- a/components/konflux-ci/policies/bootstrap-tenant-namespace/.chainsaw-test/resources/expected-rolebinding.yaml
+++ b/components/konflux-ci/policies/bootstrap-tenant-namespace/.chainsaw-test/resources/expected-rolebinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: appstudio-pipelines-runner-rolebinding
+  namespace: (join('-', [$namespace, $suffix]))
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: appstudio-pipeline
+subjects:
+- kind: ServiceAccount
+  namespace: (join('-', [$namespace, $suffix]))
+  name: appstudio-pipeline

--- a/components/konflux-ci/policies/bootstrap-tenant-namespace/.kyverno-test/kyverno-test.yaml
+++ b/components/konflux-ci/policies/bootstrap-tenant-namespace/.kyverno-test/kyverno-test.yaml
@@ -1,0 +1,16 @@
+apiVersion: cli.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: bootstrap-existing-namespaces
+policies:
+- ../bootstrap-tenant-namespace-clusterpolicy.yaml
+resources:
+- ./resources/labeled-namespace-konflux.yaml
+results:
+- policy: bootstrap-tenant-namespace
+  generatedResource: ./resources/expected-rolebinding-appstudio-runner.yaml
+  kind: Namespace
+  resources:
+  - labeled-namespace-konflux
+  result: pass
+  rule: create-appstudio-runner-rolebinding

--- a/components/konflux-ci/policies/bootstrap-tenant-namespace/.kyverno-test/resources/expected-rolebinding-appstudio-runner.yaml
+++ b/components/konflux-ci/policies/bootstrap-tenant-namespace/.kyverno-test/resources/expected-rolebinding-appstudio-runner.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: appstudio-pipelines-runner-rolebinding
+  namespace: labeled-namespace-konflux
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: appstudio-pipeline
+subjects:
+- apiGroup: ""
+  kind: ServiceAccount
+  namespace: labeled-namespace-konflux
+  name: appstudio-pipeline

--- a/components/konflux-ci/policies/bootstrap-tenant-namespace/.kyverno-test/resources/labeled-namespace-konflux.yaml
+++ b/components/konflux-ci/policies/bootstrap-tenant-namespace/.kyverno-test/resources/labeled-namespace-konflux.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: labeled-namespace-konflux
+  labels:
+    konflux-ci.dev/type: tenant

--- a/components/konflux-ci/policies/bootstrap-tenant-namespace/bootstrap-tenant-namespace-clusterpolicy.yaml
+++ b/components/konflux-ci/policies/bootstrap-tenant-namespace/bootstrap-tenant-namespace-clusterpolicy.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: bootstrap-tenant-namespace
+spec:
+  rules:
+  - name: create-appstudio-runner-rolebinding
+    match:
+      any:
+      - resources:
+          kinds:
+          - Namespace
+          selector:
+            matchLabels:
+              konflux-ci.dev/type: tenant
+    generate:
+      generateExisting: true
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      name: appstudio-pipelines-runner-rolebinding
+      namespace: '{{request.object.metadata.name}}'
+      synchronize: false
+      data:
+        roleRef:
+          apiGroup: rbac.authorization.k8s.io
+          kind: ClusterRole
+          name: appstudio-pipeline
+        subjects:
+        - apiGroup: ""
+          kind: ServiceAccount
+          namespace: '{{request.object.metadata.name}}'
+          name: appstudio-pipeline

--- a/components/konflux-ci/policies/bootstrap-tenant-namespace/kustomization.yaml
+++ b/components/konflux-ci/policies/bootstrap-tenant-namespace/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- bootstrap-tenant-namespace-clusterpolicy.yaml
+- kyverno_rbac.yaml

--- a/components/konflux-ci/policies/bootstrap-tenant-namespace/kyverno_rbac.yaml
+++ b/components/konflux-ci/policies/bootstrap-tenant-namespace/kyverno_rbac.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kyverno-admission:read-rolebindings
+  labels:
+    rbac.kyverno.io/aggregate-to-admission-controller: "true"
+rules:
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - rolebindings
+  verbs:
+  - list
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kyverno-background:manage-rolebindings
+  labels:
+    rbac.kyverno.io/aggregate-to-background-controller: "true"
+rules:
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - rolebindings
+  verbs:
+  - create
+  - get
+  - list
+  - delete
+  - update

--- a/components/konflux-ci/staging/kustomization.yaml
+++ b/components/konflux-ci/staging/kustomization.yaml
@@ -3,3 +3,4 @@ kind: Kustomization
 resources:
 - ../base
 - ../base/external-secrets
+- ../policies/bootstrap-tenant-namespace/


### PR DESCRIPTION
this policy ensures that a rolebinding for the appstudio-pipeline-runner exists in every tenant namespace

Requires:
* [x] https://github.com/redhat-appstudio/infra-deployments/pull/6067

Signed-off-by: Francesco Ilario <filario@redhat.com>
