### PR TITLE
PVO11Y-4717 Increase the limit to 4Gi

### DIFF
--- a/components/monitoring/prometheus/base/observability-operator/observability-operator.yaml
+++ b/components/monitoring/prometheus/base/observability-operator/observability-operator.yaml
@@ -18,3 +18,7 @@ spec:
   name: cluster-observability-operator
   source: redhat-operators
   sourceNamespace: openshift-marketplace
+  config:
+    resources:
+      limits:
+        memory: "4Gi"


### PR DESCRIPTION
This should allow observability-operator pod to survive the initial memory spike before the usage stabilises. The largest memory spike was noted on the stone-prod-p02 cluster as 1.5Gi.

Sideffect of this is that this applies limits to ALL Operator pods, including prometheus-operator, perses-operator and webhook-admission.
This should not impact scheduling as limits are not considered during scheduling.

Existing proposal for configuring operator resource usage: https://github.com/operator-framework/operator-controller/issues/1507