### PR TITLE
actions: run chainsaw tests concurrently

### DIFF
--- a/.github/workflows/chainsaw-tests.yaml
+++ b/.github/workflows/chainsaw-tests.yaml
@@ -5,18 +5,38 @@ on:
     branches: [ main ]
 
 jobs:
+  find-chainsaw-tests:
+    name: Find chainsaw tests
+    runs-on: ubuntu-20.04
+    outputs:
+      directories: ${{ steps.list-tests.outputs.directories }}
+    steps:
+      - name: Checkout Git Repository
+        uses: actions/checkout@v4
+
+      - id: list-tests
+        run: |
+          DIRS=$(find -name .chainsaw-test -type d | jq -R -s -c 'split("\n")[:-1]')
+          echo "directories=${DIRS}" >> $GITHUB_OUTPUT
+
   chainsaw-test:
     name: Run Chainsaw tests
     runs-on: ubuntu-latest
+    needs: ["find-chainsaw-tests"]
+    strategy:
+      fail-fast: false
+      matrix:
+        directory: ${{ fromJSON(needs.find-chainsaw-tests.outputs.directories) }}
+
     steps:
     - name: Create k8s Kind Cluster
       uses: helm/kind-action@v1
-    
+
     - name: Install Cosign
-      uses: sigstore/cosign-installer@dc72c7d5c4d10cd6bcb8cf6e3fd625a9e5e537da # v3.7.0
+      uses: sigstore/cosign-installer@dc72c7d5c4d10cd6bcb8cf6e3fd625a9e5e537da  # v3.7.0
 
     - name: Install Chainsaw
-      uses: kyverno/action-install-chainsaw@f2b47b97dc889c12702113753d713f01ec268de5 # v0.2.12
+      uses: kyverno/action-install-chainsaw@f2b47b97dc889c12702113753d713f01ec268de5  # v0.2.12
       with:
         verify: true
 
@@ -41,7 +61,7 @@ jobs:
     - name: Run chainsaw
       shell: bash
       run: |
-        find -name .chainsaw-test -type d -print0 | \
-          xargs -0 chainsaw test \
-            --config .chainsaw.yaml \
-            --no-color=false
+        chainsaw test \
+          --config .chainsaw.yaml \
+          --no-color=false \
+          "${{ matrix.directory }}"


### PR DESCRIPTION
Chainsaw tests may leave artifacts on the cluster after executing tests, which might cause issues with later tests.  To address this, run each test suite independently and concurrently.

Fixes issues uncovered in #6062.