### PR TITLE
Fix KubeArchive metrics collection

### DIFF
--- a/components/kubearchive/base/monitoring-servicemonitor.yaml
+++ b/components/kubearchive/base/monitoring-servicemonitor.yaml
@@ -49,6 +49,7 @@ spec:
         key: token
       tlsConfig:
         insecureSkipVerify: true
+      honorLabels: true
   selector:
     matchLabels:
       app: otel-collector

--- a/components/kubearchive/base/otel-collector-config.yaml
+++ b/components/kubearchive/base/otel-collector-config.yaml
@@ -1,5 +1,3 @@
-# Copyright KubeArchive Authors
-# SPDX-License-Identifier: Apache-2.0
 ---
 receivers:
   otlp:
@@ -13,6 +11,9 @@ processors:
 exporters:
   prometheus:
     endpoint: '0.0.0.0:9090'
+    send_timestamps: true
+    add_metric_suffixes: false
+  debug:
 
 service:
   pipelines:
@@ -20,3 +21,7 @@ service:
       receivers: [otlp]
       processors: [batch]
       exporters: [prometheus]
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [debug]


### PR DESCRIPTION
This PR adds `honorLabels: true` which will make [Prometheus to respect labels when they collide](https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html/monitoring_apis/servicemonitor-monitoring-coreos-com-v1#spec-endpoints-2) and adds a couple more options on the OpenTelemetry side: don't add units to the metrics names and receive traces, even if they are just printed to debug.