### PR TITLE
use ubuntu-latest instead of ubuntu-20.04

### DIFF
--- a/.github/workflows/chainsaw-tests.yaml
+++ b/.github/workflows/chainsaw-tests.yaml
@@ -7,7 +7,7 @@ on:
 jobs:
   find-chainsaw-tests:
     name: Find chainsaw tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     outputs:
       directories: ${{ steps.list-tests.outputs.directories }}
     steps:


### PR DESCRIPTION
> This is a scheduled Ubuntu 20.04 brownout. Ubuntu 20.04 LTS runner will be removed on 2025-04-15. For more details, see https://github.com/actions/runner-images/issues/11101

Signed-off-by: Francesco Ilario <filario@redhat.com>
