### PR TITLE
add OWNERS for components/konflux-rbac

### DIFF
--- a/components/konflux-rbac/OWNERS
+++ b/components/konflux-rbac/OWNERS
@@ -1,0 +1,11 @@
+# See the OWNERS docs: https://go.k8s.io/owners
+
+approvers:
+- gbenhaim
+- filariow
+- sadlerap
+
+reviewers:
+- gbenhaim
+- filariow
+- sadlerap


### PR DESCRIPTION
Signed-off-by: Francesco Ilario <filario@redhat.com>
