### PR TITLE
fix kubearchive policy's tests

### DIFF
--- a/components/kubearchive/policies/.chainsaw-test/chainsaw-test.yaml
+++ b/components/kubearchive/policies/.chainsaw-test/chainsaw-test.yaml
@@ -73,9 +73,12 @@ spec:
         template: true
   - name: then-kubearchiveconfig-is-created
     try:
-    - error:
+    - delete:
         file: resources/expected-kubearchiveconfig.yaml
         template: true
+        expect:
+        - check:
+            ($error != null): true
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
 apiVersion: chainsaw.kyverno.io/v1alpha1
@@ -153,9 +156,12 @@ spec:
         file: chainsaw-assert-clusterpolicy.yaml
   - name: then-kubearchiveconfig-is-created
     try:
-    - error:
+    - delete:
         file: resources/expected-kubearchiveconfig.yaml
         template: true
+        expect:
+        - check:
+            ($error != null): true
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
 apiVersion: chainsaw.kyverno.io/v1alpha1


### PR DESCRIPTION
[`error`](https://kyverno.github.io/chainsaw/0.2.3/operations/error/) is NOT checking that the resource doesn't exist. Let's [`delete`](https://kyverno.github.io/chainsaw/0.2.3/operations/delete/) the resource and check the operation failed.

Signed-off-by: Francesco Ilario <filario@redhat.com>
