### PR TITLE
rename tenant namespace boostrap policy

### DIFF
--- a/components/konflux-rbac/policies/bootstrap-tenant-namespace/.chainsaw-test/chainsaw-assert-clusterpolicy.yaml
+++ b/components/konflux-rbac/policies/bootstrap-tenant-namespace/.chainsaw-test/chainsaw-assert-clusterpolicy.yaml
@@ -1,7 +1,7 @@
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
-  name: bootstrap-tenant-namespace
+  name: generate-tenant-resources-admission
 status:
   conditions:
   - reason: Succeeded

--- a/components/konflux-rbac/policies/bootstrap-tenant-namespace/.kyverno-test/kyverno-test.yaml
+++ b/components/konflux-rbac/policies/bootstrap-tenant-namespace/.kyverno-test/kyverno-test.yaml
@@ -7,7 +7,7 @@ policies:
 resources:
 - ./resources/labeled-namespace-konflux.yaml
 results:
-- policy: bootstrap-tenant-namespace
+- policy: generate-tenant-resources-admission
   generatedResource: ./resources/expected-rolebinding-appstudio-runner.yaml
   kind: Namespace
   resources:

--- a/components/konflux-rbac/policies/bootstrap-tenant-namespace/bootstrap-tenant-namespace-clusterpolicy.yaml
+++ b/components/konflux-rbac/policies/bootstrap-tenant-namespace/bootstrap-tenant-namespace-clusterpolicy.yaml
@@ -2,7 +2,7 @@
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
-  name: bootstrap-tenant-namespace
+  name: generate-tenant-resources-admission
 spec:
   rules:
   - name: create-appstudio-runner-rolebinding


### PR DESCRIPTION
Some changes recently made to this policy are causing issues with kyverno, since the fields that were changed are immutable.  Renaming the policy should provide us with two benefits:
- Works around this issue by making a new resource entirely
- Make the policy's purpose clearer from its name.