### PR TITLE
Fix for KFLUXINFRA-1473, which is the action item for KFLUXSPRT-2674

### DIFF
--- a/components/multi-platform-controller/production-downstream/kflux-ocp-p01/host-config.yaml
+++ b/components/multi-platform-controller/production-downstream/kflux-ocp-p01/host-config.yaml
@@ -143,7 +143,7 @@ data:
   dynamic.linux-d160-m2xlarge-arm64.region: us-east-1
   dynamic.linux-d160-m2xlarge-arm64.ami: ami-03d6a5256a46c9feb
   dynamic.linux-d160-m2xlarge-arm64.instance-type: m6g.2xlarge
-  dynamic.linux-d160-m2xlarge-arm64.instance-tag: prod-arm64-d160-m2xlarge
+  dynamic.linux-d160-m2xlarge-arm64.instance-tag: prod-arm64-m2xlarge-d160
   dynamic.linux-d160-m2xlarge-arm64.key-name: kflux-ocp-p01-key-pair
   dynamic.linux-d160-m2xlarge-arm64.aws-secret: aws-account
   dynamic.linux-d160-m2xlarge-arm64.ssh-secret: aws-ssh-key
@@ -170,7 +170,7 @@ data:
   dynamic.linux-d160-m4xlarge-arm64.region: us-east-1
   dynamic.linux-d160-m4xlarge-arm64.ami: ami-03d6a5256a46c9feb
   dynamic.linux-d160-m4xlarge-arm64.instance-type: m6g.4xlarge
-  dynamic.linux-d160-m4xlarge-arm64.instance-tag: prod-arm64-m4xlarge
+  dynamic.linux-d160-m4xlarge-arm64.instance-tag: prod-arm64-m4xlarge-d160
   dynamic.linux-d160-m4xlarge-arm64.key-name: kflux-ocp-p01-key-pair
   dynamic.linux-d160-m4xlarge-arm64.aws-secret: aws-account
   dynamic.linux-d160-m4xlarge-arm64.ssh-secret: aws-ssh-key
@@ -197,7 +197,7 @@ data:
   dynamic.linux-d160-m8xlarge-arm64.region: us-east-1
   dynamic.linux-d160-m8xlarge-arm64.ami: ami-03d6a5256a46c9feb
   dynamic.linux-d160-m8xlarge-arm64.instance-type: m6g.8xlarge
-  dynamic.linux-d160-m8xlarge-arm64.instance-tag: prod-arm64-m8xlarge
+  dynamic.linux-d160-m8xlarge-arm64.instance-tag: prod-arm64-m8xlarge-d160
   dynamic.linux-d160-m8xlarge-arm64.key-name: kflux-ocp-p01-key-pair
   dynamic.linux-d160-m8xlarge-arm64.aws-secret: aws-account
   dynamic.linux-d160-m8xlarge-arm64.ssh-secret: aws-ssh-key
@@ -341,7 +341,7 @@ data:
   dynamic.linux-d160-m2xlarge-amd64.region: us-east-1
   dynamic.linux-d160-m2xlarge-amd64.ami: ami-026ebd4cfe2c043b2
   dynamic.linux-d160-m2xlarge-amd64.instance-type: m6a.2xlarge
-  dynamic.linux-d160-m2xlarge-amd64.instance-tag: prod-amd64-d160-m2xlarge
+  dynamic.linux-d160-m2xlarge-amd64.instance-tag: prod-amd64-m2xlarge-d160
   dynamic.linux-d160-m2xlarge-amd64.key-name: kflux-ocp-p01-key-pair
   dynamic.linux-d160-m2xlarge-amd64.aws-secret: aws-account
   dynamic.linux-d160-m2xlarge-amd64.ssh-secret: aws-ssh-key
@@ -368,7 +368,7 @@ data:
   dynamic.linux-d160-m4xlarge-amd64.region: us-east-1
   dynamic.linux-d160-m4xlarge-amd64.ami: ami-026ebd4cfe2c043b2
   dynamic.linux-d160-m4xlarge-amd64.instance-type: m6a.4xlarge
-  dynamic.linux-d160-m4xlarge-amd64.instance-tag: prod-amd64-m4xlarge
+  dynamic.linux-d160-m4xlarge-amd64.instance-tag: prod-amd64-m4xlarge-d160
   dynamic.linux-d160-m4xlarge-amd64.key-name: kflux-ocp-p01-key-pair
   dynamic.linux-d160-m4xlarge-amd64.aws-secret: aws-account
   dynamic.linux-d160-m4xlarge-amd64.ssh-secret: aws-ssh-key
@@ -395,7 +395,7 @@ data:
   dynamic.linux-d160-m8xlarge-amd64.region: us-east-1
   dynamic.linux-d160-m8xlarge-amd64.ami: ami-026ebd4cfe2c043b2
   dynamic.linux-d160-m8xlarge-amd64.instance-type: m6a.8xlarge
-  dynamic.linux-d160-m8xlarge-amd64.instance-tag: prod-amd64-m8xlarge
+  dynamic.linux-d160-m8xlarge-amd64.instance-tag: prod-amd64-m8xlarge-d160
   dynamic.linux-d160-m8xlarge-amd64.key-name: kflux-ocp-p01-key-pair
   dynamic.linux-d160-m8xlarge-amd64.aws-secret: aws-account
   dynamic.linux-d160-m8xlarge-amd64.ssh-secret: aws-ssh-key

--- a/components/multi-platform-controller/production-downstream/kflux-ocp-p01/host-config.yaml
+++ b/components/multi-platform-controller/production-downstream/kflux-ocp-p01/host-config.yaml
@@ -20,14 +20,18 @@ data:
     linux-mxlarge/amd64,\
     linux-mxlarge/arm64,\
     linux-m2xlarge/amd64,\
-    linux-d160-m2xlarge/amd64,\
     linux-m2xlarge/arm64,\
+    linux-d160-m2xlarge/amd64,\
     linux-d160-m2xlarge/arm64,\
     linux-m4xlarge/amd64,\
     linux-m4xlarge/arm64,\
+    linux-d160-m4xlarge/amd64,\
+    linux-d160-m4xlarge/arm64,\
     linux-c6gd2xlarge/arm64,\
     linux-m8xlarge/amd64,\
     linux-m8xlarge/arm64,\
+    linux-d160-m8xlarge/amd64,\
+    linux-d160-m8xlarge/arm64,\
     linux-cxlarge/amd64,\
     linux-cxlarge/arm64,\
     linux-d160-cxlarge/arm64,\
@@ -162,6 +166,20 @@ data:
   dynamic.linux-m4xlarge-arm64.subnet-id: subnet-0864e71d16676bf7f
   dynamic.linux-m4xlarge-arm64.allocation-timeout: "1200"
 
+  dynamic.linux-d160-m4xlarge-arm64.type: aws
+  dynamic.linux-d160-m4xlarge-arm64.region: us-east-1
+  dynamic.linux-d160-m4xlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-d160-m4xlarge-arm64.instance-type: m6g.4xlarge
+  dynamic.linux-d160-m4xlarge-arm64.instance-tag: prod-arm64-m4xlarge
+  dynamic.linux-d160-m4xlarge-arm64.key-name: kflux-ocp-p01-key-pair
+  dynamic.linux-d160-m4xlarge-arm64.aws-secret: aws-account
+  dynamic.linux-d160-m4xlarge-arm64.ssh-secret: aws-ssh-key
+  dynamic.linux-d160-m4xlarge-arm64.security-group-id: sg-0a1f3fdbbf7198922
+  dynamic.linux-d160-m4xlarge-arm64.max-instances: "100"
+  dynamic.linux-d160-m4xlarge-arm64.subnet-id: subnet-0864e71d16676bf7f
+  dynamic.linux-d160-m4xlarge-arm64.allocation-timeout: "1200"
+  dynamic.linux-d160-m4xlarge-arm64.disk: "160"
+
   dynamic.linux-m8xlarge-arm64.type: aws
   dynamic.linux-m8xlarge-arm64.region: us-east-1
   dynamic.linux-m8xlarge-arm64.ami: ami-03d6a5256a46c9feb
@@ -174,6 +192,20 @@ data:
   dynamic.linux-m8xlarge-arm64.max-instances: "100"
   dynamic.linux-m8xlarge-arm64.subnet-id: subnet-0864e71d16676bf7f
   dynamic.linux-m8xlarge-arm64.allocation-timeout: "1200"
+
+  dynamic.linux-d160-m8xlarge-arm64.type: aws
+  dynamic.linux-d160-m8xlarge-arm64.region: us-east-1
+  dynamic.linux-d160-m8xlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-d160-m8xlarge-arm64.instance-type: m6g.8xlarge
+  dynamic.linux-d160-m8xlarge-arm64.instance-tag: prod-arm64-m8xlarge
+  dynamic.linux-d160-m8xlarge-arm64.key-name: kflux-ocp-p01-key-pair
+  dynamic.linux-d160-m8xlarge-arm64.aws-secret: aws-account
+  dynamic.linux-d160-m8xlarge-arm64.ssh-secret: aws-ssh-key
+  dynamic.linux-d160-m8xlarge-arm64.security-group-id: sg-0a1f3fdbbf7198922
+  dynamic.linux-d160-m8xlarge-arm64.max-instances: "100"
+  dynamic.linux-d160-m8xlarge-arm64.subnet-id: subnet-0864e71d16676bf7f
+  dynamic.linux-d160-m8xlarge-arm64.allocation-timeout: "1200"
+  dynamic.linux-d160-m8xlarge-arm64.disk: "160"
 
   dynamic.linux-c6gd2xlarge-arm64.type: aws
   dynamic.linux-c6gd2xlarge-arm64.region: us-east-1
@@ -332,6 +364,20 @@ data:
   dynamic.linux-m4xlarge-amd64.subnet-id: subnet-0864e71d16676bf7f
   dynamic.linux-m4xlarge-amd64.allocation-timeout: "1200"
 
+  dynamic.linux-d160-m4xlarge-amd64.type: aws
+  dynamic.linux-d160-m4xlarge-amd64.region: us-east-1
+  dynamic.linux-d160-m4xlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-d160-m4xlarge-amd64.instance-type: m6a.4xlarge
+  dynamic.linux-d160-m4xlarge-amd64.instance-tag: prod-amd64-m4xlarge
+  dynamic.linux-d160-m4xlarge-amd64.key-name: kflux-ocp-p01-key-pair
+  dynamic.linux-d160-m4xlarge-amd64.aws-secret: aws-account
+  dynamic.linux-d160-m4xlarge-amd64.ssh-secret: aws-ssh-key
+  dynamic.linux-d160-m4xlarge-amd64.security-group-id: sg-0a1f3fdbbf7198922
+  dynamic.linux-d160-m4xlarge-amd64.max-instances: "100"
+  dynamic.linux-d160-m4xlarge-amd64.subnet-id: subnet-0864e71d16676bf7f
+  dynamic.linux-d160-m4xlarge-amd64.allocation-timeout: "1200"
+  dynamic.linux-d160-m4xlarge-amd64.disk: "160"
+
   dynamic.linux-m8xlarge-amd64.type: aws
   dynamic.linux-m8xlarge-amd64.region: us-east-1
   dynamic.linux-m8xlarge-amd64.ami: ami-026ebd4cfe2c043b2
@@ -344,6 +390,20 @@ data:
   dynamic.linux-m8xlarge-amd64.max-instances: "100"
   dynamic.linux-m8xlarge-amd64.subnet-id: subnet-0864e71d16676bf7f
   dynamic.linux-m8xlarge-amd64.allocation-timeout: "1200"
+
+  dynamic.linux-d160-m8xlarge-amd64.type: aws
+  dynamic.linux-d160-m8xlarge-amd64.region: us-east-1
+  dynamic.linux-d160-m8xlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-d160-m8xlarge-amd64.instance-type: m6a.8xlarge
+  dynamic.linux-d160-m8xlarge-amd64.instance-tag: prod-amd64-m8xlarge
+  dynamic.linux-d160-m8xlarge-amd64.key-name: kflux-ocp-p01-key-pair
+  dynamic.linux-d160-m8xlarge-amd64.aws-secret: aws-account
+  dynamic.linux-d160-m8xlarge-amd64.ssh-secret: aws-ssh-key
+  dynamic.linux-d160-m8xlarge-amd64.security-group-id: sg-0a1f3fdbbf7198922
+  dynamic.linux-d160-m8xlarge-amd64.max-instances: "100"
+  dynamic.linux-d160-m8xlarge-amd64.subnet-id: subnet-0864e71d16676bf7f
+  dynamic.linux-d160-m8xlarge-amd64.allocation-timeout: "1200"
+  dynamic.linux-d160-m8xlarge-amd64.disk: "160"
 
   # cpu:memory (1:2)
   dynamic.linux-cxlarge-arm64.type: aws

--- a/components/multi-platform-controller/production-downstream/stone-prod-p01/host-config.yaml
+++ b/components/multi-platform-controller/production-downstream/stone-prod-p01/host-config.yaml
@@ -20,10 +20,16 @@ data:
     linux-mxlarge/arm64,\
     linux-m2xlarge/amd64,\
     linux-m2xlarge/arm64,\
+    linux-d160-m2xlarge/amd64,\
+    linux-d160-m2xlarge/arm64,\
     linux-m4xlarge/amd64,\
     linux-m4xlarge/arm64,\
+    linux-d160-m4xlarge/amd64,\
+    linux-d160-m4xlarge/arm64,\
     linux-m8xlarge/amd64,\
     linux-m8xlarge/arm64,\
+    linux-d160-m8xlarge/amd64,\
+    linux-d160-m8xlarge/arm64,\
     linux-c6gd2xlarge/arm64,\
     linux-cxlarge/amd64,\
     linux-cxlarge/arm64,\
@@ -105,6 +111,20 @@ data:
   dynamic.linux-m2xlarge-arm64.subnet-id: subnet-0aa719a6c5b602b16
   dynamic.linux-m2xlarge-arm64.allocation-timeout: "1200"
 
+  dynamic.linux-d160-m2xlarge-arm64.type: aws
+  dynamic.linux-d160-m2xlarge-arm64.region: us-east-1
+  dynamic.linux-d160-m2xlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-d160-m2xlarge-arm64.instance-type: m6g.2xlarge
+  dynamic.linux-d160-m2xlarge-arm64.instance-tag: prod-arm64-m2xlarge
+  dynamic.linux-d160-m2xlarge-arm64.key-name: konflux-prod-int-mab01
+  dynamic.linux-d160-m2xlarge-arm64.aws-secret: aws-account
+  dynamic.linux-d160-m2xlarge-arm64.ssh-secret: aws-ssh-key
+  dynamic.linux-d160-m2xlarge-arm64.security-group-id: sg-0903aedd465be979e
+  dynamic.linux-d160-m2xlarge-arm64.max-instances: "100"
+  dynamic.linux-d160-m2xlarge-arm64.subnet-id: subnet-0aa719a6c5b602b16
+  dynamic.linux-d160-m2xlarge-arm64.allocation-timeout: "1200"
+  dynamic.linux-d160-m2xlarge-arm64.disk: "160"
+
   dynamic.linux-m4xlarge-arm64.type: aws
   dynamic.linux-m4xlarge-arm64.region: us-east-1
   dynamic.linux-m4xlarge-arm64.ami: ami-03d6a5256a46c9feb
@@ -117,6 +137,20 @@ data:
   dynamic.linux-m4xlarge-arm64.max-instances: "100"
   dynamic.linux-m4xlarge-arm64.subnet-id: subnet-0aa719a6c5b602b16
   dynamic.linux-m4xlarge-arm64.allocation-timeout: "1200"
+
+  dynamic.linux-d160-m4xlarge-arm64.type: aws
+  dynamic.linux-d160-m4xlarge-arm64.region: us-east-1
+  dynamic.linux-d160-m4xlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-d160-m4xlarge-arm64.instance-type: m6g.4xlarge
+  dynamic.linux-d160-m4xlarge-arm64.instance-tag: prod-arm64-m4xlarge
+  dynamic.linux-d160-m4xlarge-arm64.key-name: konflux-prod-int-mab01
+  dynamic.linux-d160-m4xlarge-arm64.aws-secret: aws-account
+  dynamic.linux-d160-m4xlarge-arm64.ssh-secret: aws-ssh-key
+  dynamic.linux-d160-m4xlarge-arm64.security-group-id: sg-0903aedd465be979e
+  dynamic.linux-d160-m4xlarge-arm64.max-instances: "100"
+  dynamic.linux-d160-m4xlarge-arm64.subnet-id: subnet-0aa719a6c5b602b16
+  dynamic.linux-d160-m4xlarge-arm64.allocation-timeout: "1200"
+  dynamic.linux-d160-m4xlarge-arm64.disk: "160"
 
   dynamic.linux-m8xlarge-arm64.type: aws
   dynamic.linux-m8xlarge-arm64.region: us-east-1
@@ -131,6 +165,19 @@ data:
   dynamic.linux-m8xlarge-arm64.subnet-id: subnet-0aa719a6c5b602b16
   dynamic.linux-m8xlarge-arm64.allocation-timeout: "1200"
 
+  dynamic.linux-d160-m8xlarge-arm64.type: aws
+  dynamic.linux-d160-m8xlarge-arm64.region: us-east-1
+  dynamic.linux-d160-m8xlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-d160-m8xlarge-arm64.instance-type: m6g.8xlarge
+  dynamic.linux-d160-m8xlarge-arm64.instance-tag: prod-arm64-m8xlarge
+  dynamic.linux-d160-m8xlarge-arm64.key-name: konflux-prod-int-mab01
+  dynamic.linux-d160-m8xlarge-arm64.aws-secret: aws-account
+  dynamic.linux-d160-m8xlarge-arm64.ssh-secret: aws-ssh-key
+  dynamic.linux-d160-m8xlarge-arm64.security-group-id: sg-0903aedd465be979e
+  dynamic.linux-d160-m8xlarge-arm64.max-instances: "100"
+  dynamic.linux-d160-m8xlarge-arm64.subnet-id: subnet-0aa719a6c5b602b16
+  dynamic.linux-d160-m8xlarge-arm64.allocation-timeout: "1200"
+  dynamic.linux-d160-m8xlarge-arm64.disk: "160"
   
   dynamic.linux-c6gd2xlarge-arm64.type: aws
   dynamic.linux-c6gd2xlarge-arm64.region: us-east-1
@@ -261,6 +308,20 @@ data:
   dynamic.linux-m2xlarge-amd64.subnet-id: subnet-0aa719a6c5b602b16
   dynamic.linux-m2xlarge-amd64.allocation-timeout: "1200"
 
+  dynamic.linux-d160-m2xlarge-amd64.type: aws
+  dynamic.linux-d160-m2xlarge-amd64.region: us-east-1
+  dynamic.linux-d160-m2xlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-d160-m2xlarge-amd64.instance-type: m6a.2xlarge
+  dynamic.linux-d160-m2xlarge-amd64.instance-tag: prod-amd64-m2xlarge
+  dynamic.linux-d160-m2xlarge-amd64.key-name: konflux-prod-int-mab01
+  dynamic.linux-d160-m2xlarge-amd64.aws-secret: aws-account
+  dynamic.linux-d160-m2xlarge-amd64.ssh-secret: aws-ssh-key
+  dynamic.linux-d160-m2xlarge-amd64.security-group-id: sg-0903aedd465be979e
+  dynamic.linux-d160-m2xlarge-amd64.max-instances: "100"
+  dynamic.linux-d160-m2xlarge-amd64.subnet-id: subnet-0aa719a6c5b602b16
+  dynamic.linux-d160-m2xlarge-amd64.allocation-timeout: "1200"
+  dynamic.linux-d160-m2xlarge-amd64.disk: "160"
+
   dynamic.linux-m4xlarge-amd64.type: aws
   dynamic.linux-m4xlarge-amd64.region: us-east-1
   dynamic.linux-m4xlarge-amd64.ami: ami-026ebd4cfe2c043b2
@@ -274,6 +335,20 @@ data:
   dynamic.linux-m4xlarge-amd64.subnet-id: subnet-0aa719a6c5b602b16
   dynamic.linux-m4xlarge-amd64.allocation-timeout: "1200"
 
+  dynamic.linux-d160-m4xlarge-amd64.type: aws
+  dynamic.linux-d160-m4xlarge-amd64.region: us-east-1
+  dynamic.linux-d160-m4xlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-d160-m4xlarge-amd64.instance-type: m6a.4xlarge
+  dynamic.linux-d160-m4xlarge-amd64.instance-tag: prod-amd64-m4xlarge
+  dynamic.linux-d160-m4xlarge-amd64.key-name: konflux-prod-int-mab01
+  dynamic.linux-d160-m4xlarge-amd64.aws-secret: aws-account
+  dynamic.linux-d160-m4xlarge-amd64.ssh-secret: aws-ssh-key
+  dynamic.linux-d160-m4xlarge-amd64.security-group-id: sg-0903aedd465be979e
+  dynamic.linux-d160-m4xlarge-amd64.max-instances: "100"
+  dynamic.linux-d160-m4xlarge-amd64.subnet-id: subnet-0aa719a6c5b602b16
+  dynamic.linux-d160-m4xlarge-amd64.allocation-timeout: "1200"
+  dynamic.linux-d160-m4xlarge-amd64.disk: "160"
+
   dynamic.linux-m8xlarge-amd64.type: aws
   dynamic.linux-m8xlarge-amd64.region: us-east-1
   dynamic.linux-m8xlarge-amd64.ami: ami-026ebd4cfe2c043b2
@@ -286,6 +361,20 @@ data:
   dynamic.linux-m8xlarge-amd64.max-instances: "100"
   dynamic.linux-m8xlarge-amd64.subnet-id: subnet-0aa719a6c5b602b16
   dynamic.linux-m8xlarge-amd64.allocation-timeout: "1200"
+
+  dynamic.linux-d160-m8xlarge-amd64.type: aws
+  dynamic.linux-d160-m8xlarge-amd64.region: us-east-1
+  dynamic.linux-d160-m8xlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-d160-m8xlarge-amd64.instance-type: m6a.8xlarge
+  dynamic.linux-d160-m8xlarge-amd64.instance-tag: prod-amd64-m8xlarge
+  dynamic.linux-d160-m8xlarge-amd64.key-name: konflux-prod-int-mab01
+  dynamic.linux-d160-m8xlarge-amd64.aws-secret: aws-account
+  dynamic.linux-d160-m8xlarge-amd64.ssh-secret: aws-ssh-key
+  dynamic.linux-d160-m8xlarge-amd64.security-group-id: sg-0903aedd465be979e
+  dynamic.linux-d160-m8xlarge-amd64.max-instances: "100"
+  dynamic.linux-d160-m8xlarge-amd64.subnet-id: subnet-0aa719a6c5b602b16
+  dynamic.linux-d160-m8xlarge-amd64.allocation-timeout: "1200"
+  dynamic.linux-d160-m8xlarge-amd64.disk: "160"
 
   # cpu:memory (1:2)
   dynamic.linux-cxlarge-arm64.type: aws

--- a/components/multi-platform-controller/production-downstream/stone-prod-p01/host-config.yaml
+++ b/components/multi-platform-controller/production-downstream/stone-prod-p01/host-config.yaml
@@ -115,7 +115,7 @@ data:
   dynamic.linux-d160-m2xlarge-arm64.region: us-east-1
   dynamic.linux-d160-m2xlarge-arm64.ami: ami-03d6a5256a46c9feb
   dynamic.linux-d160-m2xlarge-arm64.instance-type: m6g.2xlarge
-  dynamic.linux-d160-m2xlarge-arm64.instance-tag: prod-arm64-m2xlarge
+  dynamic.linux-d160-m2xlarge-arm64.instance-tag: prod-arm64-m2xlarge-d160
   dynamic.linux-d160-m2xlarge-arm64.key-name: konflux-prod-int-mab01
   dynamic.linux-d160-m2xlarge-arm64.aws-secret: aws-account
   dynamic.linux-d160-m2xlarge-arm64.ssh-secret: aws-ssh-key
@@ -142,7 +142,7 @@ data:
   dynamic.linux-d160-m4xlarge-arm64.region: us-east-1
   dynamic.linux-d160-m4xlarge-arm64.ami: ami-03d6a5256a46c9feb
   dynamic.linux-d160-m4xlarge-arm64.instance-type: m6g.4xlarge
-  dynamic.linux-d160-m4xlarge-arm64.instance-tag: prod-arm64-m4xlarge
+  dynamic.linux-d160-m4xlarge-arm64.instance-tag: prod-arm64-m4xlarge-d160
   dynamic.linux-d160-m4xlarge-arm64.key-name: konflux-prod-int-mab01
   dynamic.linux-d160-m4xlarge-arm64.aws-secret: aws-account
   dynamic.linux-d160-m4xlarge-arm64.ssh-secret: aws-ssh-key
@@ -169,7 +169,7 @@ data:
   dynamic.linux-d160-m8xlarge-arm64.region: us-east-1
   dynamic.linux-d160-m8xlarge-arm64.ami: ami-03d6a5256a46c9feb
   dynamic.linux-d160-m8xlarge-arm64.instance-type: m6g.8xlarge
-  dynamic.linux-d160-m8xlarge-arm64.instance-tag: prod-arm64-m8xlarge
+  dynamic.linux-d160-m8xlarge-arm64.instance-tag: prod-arm64-m8xlarge-d160
   dynamic.linux-d160-m8xlarge-arm64.key-name: konflux-prod-int-mab01
   dynamic.linux-d160-m8xlarge-arm64.aws-secret: aws-account
   dynamic.linux-d160-m8xlarge-arm64.ssh-secret: aws-ssh-key
@@ -312,7 +312,7 @@ data:
   dynamic.linux-d160-m2xlarge-amd64.region: us-east-1
   dynamic.linux-d160-m2xlarge-amd64.ami: ami-026ebd4cfe2c043b2
   dynamic.linux-d160-m2xlarge-amd64.instance-type: m6a.2xlarge
-  dynamic.linux-d160-m2xlarge-amd64.instance-tag: prod-amd64-m2xlarge
+  dynamic.linux-d160-m2xlarge-amd64.instance-tag: prod-amd64-m2xlarge-d160
   dynamic.linux-d160-m2xlarge-amd64.key-name: konflux-prod-int-mab01
   dynamic.linux-d160-m2xlarge-amd64.aws-secret: aws-account
   dynamic.linux-d160-m2xlarge-amd64.ssh-secret: aws-ssh-key
@@ -339,7 +339,7 @@ data:
   dynamic.linux-d160-m4xlarge-amd64.region: us-east-1
   dynamic.linux-d160-m4xlarge-amd64.ami: ami-026ebd4cfe2c043b2
   dynamic.linux-d160-m4xlarge-amd64.instance-type: m6a.4xlarge
-  dynamic.linux-d160-m4xlarge-amd64.instance-tag: prod-amd64-m4xlarge
+  dynamic.linux-d160-m4xlarge-amd64.instance-tag: prod-amd64-m4xlarge-d160
   dynamic.linux-d160-m4xlarge-amd64.key-name: konflux-prod-int-mab01
   dynamic.linux-d160-m4xlarge-amd64.aws-secret: aws-account
   dynamic.linux-d160-m4xlarge-amd64.ssh-secret: aws-ssh-key
@@ -366,7 +366,7 @@ data:
   dynamic.linux-d160-m8xlarge-amd64.region: us-east-1
   dynamic.linux-d160-m8xlarge-amd64.ami: ami-026ebd4cfe2c043b2
   dynamic.linux-d160-m8xlarge-amd64.instance-type: m6a.8xlarge
-  dynamic.linux-d160-m8xlarge-amd64.instance-tag: prod-amd64-m8xlarge
+  dynamic.linux-d160-m8xlarge-amd64.instance-tag: prod-amd64-m8xlarge-d160
   dynamic.linux-d160-m8xlarge-amd64.key-name: konflux-prod-int-mab01
   dynamic.linux-d160-m8xlarge-amd64.aws-secret: aws-account
   dynamic.linux-d160-m8xlarge-amd64.ssh-secret: aws-ssh-key

--- a/components/multi-platform-controller/production-downstream/stone-prod-p02/host-config.yaml
+++ b/components/multi-platform-controller/production-downstream/stone-prod-p02/host-config.yaml
@@ -20,12 +20,16 @@ data:
     linux-mxlarge/arm64,\
     linux-m2xlarge/amd64,\
     linux-m2xlarge/arm64,\
+    linux-d160-m2xlarge/amd64,\
+    linux-d160-m2xlarge/arm64,\
     linux-m4xlarge/amd64,\
-    linux-d160-m4xlarge/amd64,\
     linux-m4xlarge/arm64,\
+    linux-d160-m4xlarge/amd64,\
     linux-d160-m4xlarge/arm64,\
     linux-m8xlarge/amd64,\
     linux-m8xlarge/arm64,\
+    linux-d160-m8xlarge/amd64,\
+    linux-d160-m8xlarge/arm64,\
     linux-c6gd2xlarge/arm64,\
     linux-cxlarge/amd64,\
     linux-cxlarge/arm64,\
@@ -114,6 +118,20 @@ data:
   dynamic.linux-m2xlarge-arm64.subnet-id: subnet-0aa719a6c5b602b16
   dynamic.linux-m2xlarge-arm64.allocation-timeout: "1200"
 
+  dynamic.linux-d160-m2xlarge-arm64.type: aws
+  dynamic.linux-d160-m2xlarge-arm64.region: us-east-1
+  dynamic.linux-d160-m2xlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-d160-m2xlarge-arm64.instance-type: m6g.2xlarge
+  dynamic.linux-d160-m2xlarge-arm64.instance-tag: prod-arm64-m2xlarge
+  dynamic.linux-d160-m2xlarge-arm64.key-name: konflux-prod-int-mab01
+  dynamic.linux-d160-m2xlarge-arm64.aws-secret: aws-account
+  dynamic.linux-d160-m2xlarge-arm64.ssh-secret: aws-ssh-key
+  dynamic.linux-d160-m2xlarge-arm64.security-group-id: sg-0903aedd465be979e
+  dynamic.linux-d160-m2xlarge-arm64.max-instances: "100"
+  dynamic.linux-d160-m2xlarge-arm64.subnet-id: subnet-0aa719a6c5b602b16
+  dynamic.linux-d160-m2xlarge-arm64.allocation-timeout: "1200"
+  dynamic.linux-d160-m2xlarge-arm64.disk: "160"
+
   dynamic.linux-m4xlarge-arm64.type: aws
   dynamic.linux-m4xlarge-arm64.region: us-east-1
   dynamic.linux-m4xlarge-arm64.ami: ami-03d6a5256a46c9feb
@@ -127,7 +145,6 @@ data:
   dynamic.linux-m4xlarge-arm64.subnet-id: subnet-0aa719a6c5b602b16
   dynamic.linux-m4xlarge-arm64.allocation-timeout: "1200"
 
-  
   dynamic.linux-c6gd2xlarge-arm64.type: aws
   dynamic.linux-c6gd2xlarge-arm64.region: us-east-1
   dynamic.linux-c6gd2xlarge-arm64.ami: ami-03d6a5256a46c9feb
@@ -232,6 +249,20 @@ data:
   dynamic.linux-m8xlarge-arm64.subnet-id: subnet-0aa719a6c5b602b16
   dynamic.linux-m8xlarge-arm64.allocation-timeout: "1200"
 
+  dynamic.linux-d160-m8xlarge-arm64.type: aws
+  dynamic.linux-d160-m8xlarge-arm64.region: us-east-1
+  dynamic.linux-d160-m8xlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-d160-m8xlarge-arm64.instance-type: m6g.8xlarge
+  dynamic.linux-d160-m8xlarge-arm64.instance-tag: prod-arm64-m8xlarge
+  dynamic.linux-d160-m8xlarge-arm64.key-name: konflux-prod-int-mab01
+  dynamic.linux-d160-m8xlarge-arm64.aws-secret: aws-account
+  dynamic.linux-d160-m8xlarge-arm64.ssh-secret: aws-ssh-key
+  dynamic.linux-d160-m8xlarge-arm64.security-group-id: sg-0903aedd465be979e
+  dynamic.linux-d160-m8xlarge-arm64.max-instances: "100"
+  dynamic.linux-d160-m8xlarge-arm64.subnet-id: subnet-0aa719a6c5b602b16
+  dynamic.linux-d160-m8xlarge-arm64.allocation-timeout: "1200"
+  dynamic.linux-d160-m8xlarge-arm64.disk: "160"
+
   dynamic.linux-amd64.type: aws
   dynamic.linux-amd64.region: us-east-1
   dynamic.linux-amd64.ami: ami-026ebd4cfe2c043b2
@@ -284,6 +315,20 @@ data:
   dynamic.linux-m2xlarge-amd64.subnet-id: subnet-0aa719a6c5b602b16
   dynamic.linux-m2xlarge-amd64.allocation-timeout: "1200"
 
+  dynamic.linux-d160-m2xlarge-amd64.type: aws
+  dynamic.linux-d160-m2xlarge-amd64.region: us-east-1
+  dynamic.linux-d160-m2xlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-d160-m2xlarge-amd64.instance-type: m6a.2xlarge
+  dynamic.linux-d160-m2xlarge-amd64.instance-tag: prod-amd64-m2xlarge
+  dynamic.linux-d160-m2xlarge-amd64.key-name: konflux-prod-int-mab01
+  dynamic.linux-d160-m2xlarge-amd64.aws-secret: aws-account
+  dynamic.linux-d160-m2xlarge-amd64.ssh-secret: aws-ssh-key
+  dynamic.linux-d160-m2xlarge-amd64.security-group-id: sg-0903aedd465be979e
+  dynamic.linux-d160-m2xlarge-amd64.max-instances: "100"
+  dynamic.linux-d160-m2xlarge-amd64.subnet-id: subnet-0aa719a6c5b602b16
+  dynamic.linux-d160-m2xlarge-amd64.allocation-timeout: "1200"
+  dynamic.linux-d160-m2xlarge-amd64.disk: "160"
+
   dynamic.linux-m4xlarge-amd64.type: aws
   dynamic.linux-m4xlarge-amd64.region: us-east-1
   dynamic.linux-m4xlarge-amd64.ami: ami-026ebd4cfe2c043b2
@@ -323,6 +368,20 @@ data:
   dynamic.linux-m8xlarge-amd64.max-instances: "100"
   dynamic.linux-m8xlarge-amd64.subnet-id: subnet-0aa719a6c5b602b16
   dynamic.linux-m8xlarge-amd64.allocation-timeout: "1200"
+
+  dynamic.linux-d160-m8xlarge-amd64.type: aws
+  dynamic.linux-d160-m8xlarge-amd64.region: us-east-1
+  dynamic.linux-d160-m8xlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-d160-m8xlarge-amd64.instance-type: m6a.8xlarge
+  dynamic.linux-d160-m8xlarge-amd64.instance-tag: prod-amd64-m8xlarge
+  dynamic.linux-d160-m8xlarge-amd64.key-name: konflux-prod-int-mab01
+  dynamic.linux-d160-m8xlarge-amd64.aws-secret: aws-account
+  dynamic.linux-d160-m8xlarge-amd64.ssh-secret: aws-ssh-key
+  dynamic.linux-d160-m8xlarge-amd64.security-group-id: sg-0903aedd465be979e
+  dynamic.linux-d160-m8xlarge-amd64.max-instances: "100"
+  dynamic.linux-d160-m8xlarge-amd64.subnet-id: subnet-0aa719a6c5b602b16
+  dynamic.linux-d160-m8xlarge-amd64.allocation-timeout: "1200"
+  dynamic.linux-d160-m8xlarge-amd64.disk: "160"
 
   # cpu:memory (1:2)
   dynamic.linux-cxlarge-arm64.type: aws

--- a/components/multi-platform-controller/production-downstream/stone-prod-p02/host-config.yaml
+++ b/components/multi-platform-controller/production-downstream/stone-prod-p02/host-config.yaml
@@ -122,7 +122,7 @@ data:
   dynamic.linux-d160-m2xlarge-arm64.region: us-east-1
   dynamic.linux-d160-m2xlarge-arm64.ami: ami-03d6a5256a46c9feb
   dynamic.linux-d160-m2xlarge-arm64.instance-type: m6g.2xlarge
-  dynamic.linux-d160-m2xlarge-arm64.instance-tag: prod-arm64-m2xlarge
+  dynamic.linux-d160-m2xlarge-arm64.instance-tag: prod-arm64-m2xlarge-d160
   dynamic.linux-d160-m2xlarge-arm64.key-name: konflux-prod-int-mab01
   dynamic.linux-d160-m2xlarge-arm64.aws-secret: aws-account
   dynamic.linux-d160-m2xlarge-arm64.ssh-secret: aws-ssh-key
@@ -227,6 +227,7 @@ data:
   dynamic.linux-d160-m4xlarge-arm64.region: us-east-1
   dynamic.linux-d160-m4xlarge-arm64.ami: ami-03d6a5256a46c9feb
   dynamic.linux-d160-m4xlarge-arm64.instance-type: m6g.4xlarge
+  dynamic.linux-d160-m4xlarge-arm64.instance-tag: prod-arm64-4xlarge-d160
   dynamic.linux-d160-m4xlarge-arm64.key-name: konflux-prod-int-mab01
   dynamic.linux-d160-m4xlarge-arm64.aws-secret: aws-account
   dynamic.linux-d160-m4xlarge-arm64.ssh-secret: aws-ssh-key
@@ -253,7 +254,7 @@ data:
   dynamic.linux-d160-m8xlarge-arm64.region: us-east-1
   dynamic.linux-d160-m8xlarge-arm64.ami: ami-03d6a5256a46c9feb
   dynamic.linux-d160-m8xlarge-arm64.instance-type: m6g.8xlarge
-  dynamic.linux-d160-m8xlarge-arm64.instance-tag: prod-arm64-m8xlarge
+  dynamic.linux-d160-m8xlarge-arm64.instance-tag: prod-arm64-m8xlarge-d160
   dynamic.linux-d160-m8xlarge-arm64.key-name: konflux-prod-int-mab01
   dynamic.linux-d160-m8xlarge-arm64.aws-secret: aws-account
   dynamic.linux-d160-m8xlarge-arm64.ssh-secret: aws-ssh-key
@@ -319,7 +320,7 @@ data:
   dynamic.linux-d160-m2xlarge-amd64.region: us-east-1
   dynamic.linux-d160-m2xlarge-amd64.ami: ami-026ebd4cfe2c043b2
   dynamic.linux-d160-m2xlarge-amd64.instance-type: m6a.2xlarge
-  dynamic.linux-d160-m2xlarge-amd64.instance-tag: prod-amd64-m2xlarge
+  dynamic.linux-d160-m2xlarge-amd64.instance-tag: prod-amd64-m2xlarge-d160
   dynamic.linux-d160-m2xlarge-amd64.key-name: konflux-prod-int-mab01
   dynamic.linux-d160-m2xlarge-amd64.aws-secret: aws-account
   dynamic.linux-d160-m2xlarge-amd64.ssh-secret: aws-ssh-key
@@ -347,6 +348,7 @@ data:
   dynamic.linux-d160-m4xlarge-amd64.region: us-east-1
   dynamic.linux-d160-m4xlarge-amd64.ami: ami-026ebd4cfe2c043b2
   dynamic.linux-d160-m4xlarge-amd64.instance-type: m6a.4xlarge
+  dynamic.linux-d160-m4xlarge-amd64.instance-tag: prod-amd64-m4xlarge-d160
   dynamic.linux-d160-m4xlarge-amd64.key-name: konflux-prod-int-mab01
   dynamic.linux-d160-m4xlarge-amd64.aws-secret: aws-account
   dynamic.linux-d160-m4xlarge-amd64.ssh-secret: aws-ssh-key
@@ -373,7 +375,7 @@ data:
   dynamic.linux-d160-m8xlarge-amd64.region: us-east-1
   dynamic.linux-d160-m8xlarge-amd64.ami: ami-026ebd4cfe2c043b2
   dynamic.linux-d160-m8xlarge-amd64.instance-type: m6a.8xlarge
-  dynamic.linux-d160-m8xlarge-amd64.instance-tag: prod-amd64-m8xlarge
+  dynamic.linux-d160-m8xlarge-amd64.instance-tag: prod-amd64-m8xlarge-d160
   dynamic.linux-d160-m8xlarge-amd64.key-name: konflux-prod-int-mab01
   dynamic.linux-d160-m8xlarge-amd64.aws-secret: aws-account
   dynamic.linux-d160-m8xlarge-amd64.ssh-secret: aws-ssh-key

--- a/components/multi-platform-controller/production/kflux-prd-rh02/host-config.yaml
+++ b/components/multi-platform-controller/production/kflux-prd-rh02/host-config.yaml
@@ -120,7 +120,7 @@ data:
   dynamic.linux-d160-m2xlarge-arm64.region: us-east-1
   dynamic.linux-d160-m2xlarge-arm64.ami: ami-03d6a5256a46c9feb
   dynamic.linux-d160-m2xlarge-arm64.instance-type: m6g.2xlarge
-  dynamic.linux-d160-m2xlarge-arm64.instance-tag: prod-arm64-m2xlarge
+  dynamic.linux-d160-m2xlarge-arm64.instance-tag: prod-arm64-m2xlarge-d160
   dynamic.linux-d160-m2xlarge-arm64.key-name: kflux-prd-multi-rh02-key-pair
   dynamic.linux-d160-m2xlarge-arm64.aws-secret: aws-account
   dynamic.linux-d160-m2xlarge-arm64.ssh-secret: aws-ssh-key
@@ -145,7 +145,7 @@ data:
   dynamic.linux-d160-m4xlarge-arm64.region: us-east-1
   dynamic.linux-d160-m4xlarge-arm64.ami: ami-03d6a5256a46c9feb
   dynamic.linux-d160-m4xlarge-arm64.instance-type: m6g.4xlarge
-  dynamic.linux-d160-m4xlarge-arm64.instance-tag: prod-arm64-m4xlarge
+  dynamic.linux-d160-m4xlarge-arm64.instance-tag: prod-arm64-m4xlarge-d160
   dynamic.linux-d160-m4xlarge-arm64.key-name: kflux-prd-multi-rh02-key-pair
   dynamic.linux-d160-m4xlarge-arm64.aws-secret: aws-account
   dynamic.linux-d160-m4xlarge-arm64.ssh-secret: aws-ssh-key
@@ -170,7 +170,7 @@ data:
   dynamic.linux-d160-m8xlarge-arm64.region: us-east-1
   dynamic.linux-d160-m8xlarge-arm64.ami: ami-03d6a5256a46c9feb
   dynamic.linux-d160-m8xlarge-arm64.instance-type: m6g.8xlarge
-  dynamic.linux-d160-m8xlarge-arm64.instance-tag: prod-arm64-m8xlarge
+  dynamic.linux-d160-m8xlarge-arm64.instance-tag: prod-arm64-m8xlarge-d160
   dynamic.linux-d160-m8xlarge-arm64.key-name: kflux-prd-multi-rh02-key-pair
   dynamic.linux-d160-m8xlarge-arm64.aws-secret: aws-account
   dynamic.linux-d160-m8xlarge-arm64.ssh-secret: aws-ssh-key
@@ -307,7 +307,7 @@ data:
   dynamic.linux-d160-m2xlarge-amd64.region: us-east-1
   dynamic.linux-d160-m2xlarge-amd64.ami: ami-026ebd4cfe2c043b2
   dynamic.linux-d160-m2xlarge-amd64.instance-type: m6a.2xlarge
-  dynamic.linux-d160-m2xlarge-amd64.instance-tag: prod-amd64-m2xlarge
+  dynamic.linux-d160-m2xlarge-amd64.instance-tag: prod-amd64-m2xlarge-d160
   dynamic.linux-d160-m2xlarge-amd64.key-name: kflux-prd-multi-rh02-key-pair
   dynamic.linux-d160-m2xlarge-amd64.aws-secret: aws-account
   dynamic.linux-d160-m2xlarge-amd64.ssh-secret: aws-ssh-key
@@ -332,7 +332,7 @@ data:
   dynamic.linux-d160-m4xlarge-amd64.region: us-east-1
   dynamic.linux-d160-m4xlarge-amd64.ami: ami-026ebd4cfe2c043b2
   dynamic.linux-d160-m4xlarge-amd64.instance-type: m6a.4xlarge
-  dynamic.linux-d160-m4xlarge-amd64.instance-tag: prod-amd64-m4xlarge
+  dynamic.linux-d160-m4xlarge-amd64.instance-tag: prod-amd64-m4xlarge-d160
   dynamic.linux-d160-m4xlarge-amd64.key-name: kflux-prd-multi-rh02-key-pair
   dynamic.linux-d160-m4xlarge-amd64.aws-secret: aws-account
   dynamic.linux-d160-m4xlarge-amd64.ssh-secret: aws-ssh-key
@@ -357,7 +357,7 @@ data:
   dynamic.linux-d160-m8xlarge-amd64.region: us-east-1
   dynamic.linux-d160-m8xlarge-amd64.ami: ami-026ebd4cfe2c043b2
   dynamic.linux-d160-m8xlarge-amd64.instance-type: m6a.8xlarge
-  dynamic.linux-d160-m8xlarge-amd64.instance-tag: prod-amd64-m8xlarge
+  dynamic.linux-d160-m8xlarge-amd64.instance-tag: prod-amd64-m8xlarge-d160
   dynamic.linux-d160-m8xlarge-amd64.key-name: kflux-prd-multi-rh02-key-pair
   dynamic.linux-d160-m8xlarge-amd64.aws-secret: aws-account
   dynamic.linux-d160-m8xlarge-amd64.ssh-secret: aws-ssh-key

--- a/components/multi-platform-controller/production/kflux-prd-rh02/host-config.yaml
+++ b/components/multi-platform-controller/production/kflux-prd-rh02/host-config.yaml
@@ -20,10 +20,16 @@ data:
     linux-mxlarge/arm64,\
     linux-m2xlarge/amd64,\
     linux-m2xlarge/arm64,\
+    linux-d160-m2xlarge/amd64,\
+    linux-d160-m2xlarge/arm64,\
     linux-m4xlarge/amd64,\
     linux-m4xlarge/arm64,\
+    linux-d160-m4xlarge/amd64,\
+    linux-d160-m4xlarge/arm64,\
     linux-m8xlarge/amd64,\
     linux-m8xlarge/arm64,\
+    linux-d160-m8xlarge/amd64,\
+    linux-d160-m8xlarge/arm64,\
     linux-c6gd2xlarge/arm64,\
     linux-cxlarge/amd64,\
     linux-cxlarge/arm64,\
@@ -110,6 +116,19 @@ data:
   dynamic.linux-m2xlarge-arm64.max-instances: "20"
   dynamic.linux-m2xlarge-arm64.subnet-id: subnet-07a8bbf633e2bb187
 
+  dynamic.linux-d160-m2xlarge-arm64.type: aws
+  dynamic.linux-d160-m2xlarge-arm64.region: us-east-1
+  dynamic.linux-d160-m2xlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-d160-m2xlarge-arm64.instance-type: m6g.2xlarge
+  dynamic.linux-d160-m2xlarge-arm64.instance-tag: prod-arm64-m2xlarge
+  dynamic.linux-d160-m2xlarge-arm64.key-name: kflux-prd-multi-rh02-key-pair
+  dynamic.linux-d160-m2xlarge-arm64.aws-secret: aws-account
+  dynamic.linux-d160-m2xlarge-arm64.ssh-secret: aws-ssh-key
+  dynamic.linux-d160-m2xlarge-arm64.security-group-id: sg-004ef1b7bc3ef1bca
+  dynamic.linux-d160-m2xlarge-arm64.max-instances: "20"
+  dynamic.linux-d160-m2xlarge-arm64.subnet-id: subnet-07a8bbf633e2bb187
+  dynamic.linux-d160-m2xlarge-arm64.disk: "160"
+
   dynamic.linux-m4xlarge-arm64.type: aws
   dynamic.linux-m4xlarge-arm64.region: us-east-1
   dynamic.linux-m4xlarge-arm64.ami: ami-03d6a5256a46c9feb
@@ -122,6 +141,19 @@ data:
   dynamic.linux-m4xlarge-arm64.max-instances: "20"
   dynamic.linux-m4xlarge-arm64.subnet-id: subnet-07a8bbf633e2bb187
 
+  dynamic.linux-d160-m4xlarge-arm64.type: aws
+  dynamic.linux-d160-m4xlarge-arm64.region: us-east-1
+  dynamic.linux-d160-m4xlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-d160-m4xlarge-arm64.instance-type: m6g.4xlarge
+  dynamic.linux-d160-m4xlarge-arm64.instance-tag: prod-arm64-m4xlarge
+  dynamic.linux-d160-m4xlarge-arm64.key-name: kflux-prd-multi-rh02-key-pair
+  dynamic.linux-d160-m4xlarge-arm64.aws-secret: aws-account
+  dynamic.linux-d160-m4xlarge-arm64.ssh-secret: aws-ssh-key
+  dynamic.linux-d160-m4xlarge-arm64.security-group-id: sg-004ef1b7bc3ef1bca
+  dynamic.linux-d160-m4xlarge-arm64.max-instances: "20"
+  dynamic.linux-d160-m4xlarge-arm64.subnet-id: subnet-07a8bbf633e2bb187
+  dynamic.linux-d160-m4xlarge-arm64.disk: "160"
+
   dynamic.linux-m8xlarge-arm64.type: aws
   dynamic.linux-m8xlarge-arm64.region: us-east-1
   dynamic.linux-m8xlarge-arm64.ami: ami-03d6a5256a46c9feb
@@ -133,6 +165,19 @@ data:
   dynamic.linux-m8xlarge-arm64.security-group-id: sg-004ef1b7bc3ef1bca
   dynamic.linux-m8xlarge-arm64.max-instances: "20"
   dynamic.linux-m8xlarge-arm64.subnet-id: subnet-07a8bbf633e2bb187
+
+  dynamic.linux-d160-m8xlarge-arm64.type: aws
+  dynamic.linux-d160-m8xlarge-arm64.region: us-east-1
+  dynamic.linux-d160-m8xlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-d160-m8xlarge-arm64.instance-type: m6g.8xlarge
+  dynamic.linux-d160-m8xlarge-arm64.instance-tag: prod-arm64-m8xlarge
+  dynamic.linux-d160-m8xlarge-arm64.key-name: kflux-prd-multi-rh02-key-pair
+  dynamic.linux-d160-m8xlarge-arm64.aws-secret: aws-account
+  dynamic.linux-d160-m8xlarge-arm64.ssh-secret: aws-ssh-key
+  dynamic.linux-d160-m8xlarge-arm64.security-group-id: sg-004ef1b7bc3ef1bca
+  dynamic.linux-d160-m8xlarge-arm64.max-instances: "20"
+  dynamic.linux-d160-m8xlarge-arm64.subnet-id: subnet-07a8bbf633e2bb187
+  dynamic.linux-d160-m8xlarge-arm64.disk: "160"
 
   dynamic.linux-c6gd2xlarge-arm64.type: aws
   dynamic.linux-c6gd2xlarge-arm64.region: us-east-1
@@ -258,6 +303,19 @@ data:
   dynamic.linux-m2xlarge-amd64.max-instances: "10"
   dynamic.linux-m2xlarge-amd64.subnet-id: subnet-07a8bbf633e2bb187
 
+  dynamic.linux-d160-m2xlarge-amd64.type: aws
+  dynamic.linux-d160-m2xlarge-amd64.region: us-east-1
+  dynamic.linux-d160-m2xlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-d160-m2xlarge-amd64.instance-type: m6a.2xlarge
+  dynamic.linux-d160-m2xlarge-amd64.instance-tag: prod-amd64-m2xlarge
+  dynamic.linux-d160-m2xlarge-amd64.key-name: kflux-prd-multi-rh02-key-pair
+  dynamic.linux-d160-m2xlarge-amd64.aws-secret: aws-account
+  dynamic.linux-d160-m2xlarge-amd64.ssh-secret: aws-ssh-key
+  dynamic.linux-d160-m2xlarge-amd64.security-group-id: sg-004ef1b7bc3ef1bca
+  dynamic.linux-d160-m2xlarge-amd64.max-instances: "10"
+  dynamic.linux-d160-m2xlarge-amd64.subnet-id: subnet-07a8bbf633e2bb187
+  dynamic.linux-d160-m2xlarge-amd64.disk: "160"
+
   dynamic.linux-m4xlarge-amd64.type: aws
   dynamic.linux-m4xlarge-amd64.region: us-east-1
   dynamic.linux-m4xlarge-amd64.ami: ami-026ebd4cfe2c043b2
@@ -270,6 +328,19 @@ data:
   dynamic.linux-m4xlarge-amd64.max-instances: "10"
   dynamic.linux-m4xlarge-amd64.subnet-id: subnet-07a8bbf633e2bb187
 
+  dynamic.linux-d160-m4xlarge-amd64.type: aws
+  dynamic.linux-d160-m4xlarge-amd64.region: us-east-1
+  dynamic.linux-d160-m4xlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-d160-m4xlarge-amd64.instance-type: m6a.4xlarge
+  dynamic.linux-d160-m4xlarge-amd64.instance-tag: prod-amd64-m4xlarge
+  dynamic.linux-d160-m4xlarge-amd64.key-name: kflux-prd-multi-rh02-key-pair
+  dynamic.linux-d160-m4xlarge-amd64.aws-secret: aws-account
+  dynamic.linux-d160-m4xlarge-amd64.ssh-secret: aws-ssh-key
+  dynamic.linux-d160-m4xlarge-amd64.security-group-id: sg-004ef1b7bc3ef1bca
+  dynamic.linux-d160-m4xlarge-amd64.max-instances: "10"
+  dynamic.linux-d160-m4xlarge-amd64.subnet-id: subnet-07a8bbf633e2bb187
+  dynamic.linux-d160-m4xlarge-amd64.disk: "160"
+
   dynamic.linux-m8xlarge-amd64.type: aws
   dynamic.linux-m8xlarge-amd64.region: us-east-1
   dynamic.linux-m8xlarge-amd64.ami: ami-026ebd4cfe2c043b2
@@ -281,6 +352,19 @@ data:
   dynamic.linux-m8xlarge-amd64.security-group-id: sg-004ef1b7bc3ef1bca
   dynamic.linux-m8xlarge-amd64.max-instances: "10"
   dynamic.linux-m8xlarge-amd64.subnet-id: subnet-07a8bbf633e2bb187
+
+  dynamic.linux-d160-m8xlarge-amd64.type: aws
+  dynamic.linux-d160-m8xlarge-amd64.region: us-east-1
+  dynamic.linux-d160-m8xlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-d160-m8xlarge-amd64.instance-type: m6a.8xlarge
+  dynamic.linux-d160-m8xlarge-amd64.instance-tag: prod-amd64-m8xlarge
+  dynamic.linux-d160-m8xlarge-amd64.key-name: kflux-prd-multi-rh02-key-pair
+  dynamic.linux-d160-m8xlarge-amd64.aws-secret: aws-account
+  dynamic.linux-d160-m8xlarge-amd64.ssh-secret: aws-ssh-key
+  dynamic.linux-d160-m8xlarge-amd64.security-group-id: sg-004ef1b7bc3ef1bca
+  dynamic.linux-d160-m8xlarge-amd64.max-instances: "10"
+  dynamic.linux-d160-m8xlarge-amd64.subnet-id: subnet-07a8bbf633e2bb187
+  dynamic.linux-d160-m8xlarge-amd64.disk: "160"
 
   # cpu:memory (1:2)
   dynamic.linux-cxlarge-arm64.type: aws

--- a/components/multi-platform-controller/production/stone-prd-rh01/host-config.yaml
+++ b/components/multi-platform-controller/production/stone-prd-rh01/host-config.yaml
@@ -142,19 +142,6 @@ data:
   dynamic.linux-m4xlarge-arm64.max-instances: "20"
   dynamic.linux-m4xlarge-arm64.subnet-id: subnet-0c39ff75f819abfc5
 
-  dynamic.linux-d160-m4xlarge-arm64.type: aws
-  dynamic.linux-d160-m4xlarge-arm64.region: us-east-1
-  dynamic.linux-d160-m4xlarge-arm64.ami: ami-03d6a5256a46c9feb
-  dynamic.linux-d160-m4xlarge-arm64.instance-type: m6g.4xlarge
-  dynamic.linux-d160-m4xlarge-arm64.instance-tag: prod-arm64-m4xlarge
-  dynamic.linux-d160-m4xlarge-arm64.key-name: konflux-prod-ext-mab01
-  dynamic.linux-d160-m4xlarge-arm64.aws-secret: aws-account
-  dynamic.linux-d160-m4xlarge-arm64.ssh-secret: aws-ssh-key
-  dynamic.linux-d160-m4xlarge-arm64.security-group-id: sg-0fbf35ced0d59fd4a
-  dynamic.linux-d160-m4xlarge-arm64.max-instances: "20"
-  dynamic.linux-d160-m4xlarge-arm64.subnet-id: subnet-0c39ff75f819abfc5
-  dynamic.linux-d160-m4xlarge-arm64.disk: "160"
-
   dynamic.linux-m8xlarge-arm64.type: aws
   dynamic.linux-m8xlarge-arm64.region: us-east-1
   dynamic.linux-m8xlarge-arm64.ami: ami-03d6a5256a46c9feb

--- a/components/multi-platform-controller/production/stone-prd-rh01/host-config.yaml
+++ b/components/multi-platform-controller/production/stone-prd-rh01/host-config.yaml
@@ -20,12 +20,16 @@ data:
     linux-mxlarge/arm64,\
     linux-m2xlarge/amd64,\
     linux-m2xlarge/arm64,\
+    linux-d160-m2xlarge/amd64,\
+    linux-d160-m2xlarge/arm64,\
     linux-m4xlarge/amd64,\
-    linux-d160-m4xlarge/amd64,\
     linux-m4xlarge/arm64,\
+    linux-d160-m4xlarge/amd64,\
     linux-d160-m4xlarge/arm64,\
     linux-m8xlarge/amd64,\
     linux-m8xlarge/arm64,\
+    linux-d160-m8xlarge/amd64,\
+    linux-d160-m8xlarge/arm64,\
     linux-c6gd2xlarge/arm64,\
     linux-cxlarge/amd64,\
     linux-cxlarge/arm64,\
@@ -113,6 +117,19 @@ data:
   dynamic.linux-m2xlarge-arm64.max-instances: "20"
   dynamic.linux-m2xlarge-arm64.subnet-id: subnet-0c39ff75f819abfc5
 
+  dynamic.linux-d160-m2xlarge-arm64.type: aws
+  dynamic.linux-d160-m2xlarge-arm64.region: us-east-1
+  dynamic.linux-d160-m2xlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-d160-m2xlarge-arm64.instance-type: m6g.2xlarge
+  dynamic.linux-d160-m2xlarge-arm64.instance-tag: prod-arm64-m2xlarge
+  dynamic.linux-d160-m2xlarge-arm64.key-name: konflux-prod-ext-mab01
+  dynamic.linux-d160-m2xlarge-arm64.aws-secret: aws-account
+  dynamic.linux-d160-m2xlarge-arm64.ssh-secret: aws-ssh-key
+  dynamic.linux-d160-m2xlarge-arm64.security-group-id: sg-0fbf35ced0d59fd4a
+  dynamic.linux-d160-m2xlarge-arm64.max-instances: "20"
+  dynamic.linux-d160-m2xlarge-arm64.subnet-id: subnet-0c39ff75f819abfc5
+  dynamic.linux-d160-m2xlarge-arm64.disk: "160"
+
   dynamic.linux-m4xlarge-arm64.type: aws
   dynamic.linux-m4xlarge-arm64.region: us-east-1
   dynamic.linux-m4xlarge-arm64.ami: ami-03d6a5256a46c9feb
@@ -125,6 +142,19 @@ data:
   dynamic.linux-m4xlarge-arm64.max-instances: "20"
   dynamic.linux-m4xlarge-arm64.subnet-id: subnet-0c39ff75f819abfc5
 
+  dynamic.linux-d160-m4xlarge-arm64.type: aws
+  dynamic.linux-d160-m4xlarge-arm64.region: us-east-1
+  dynamic.linux-d160-m4xlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-d160-m4xlarge-arm64.instance-type: m6g.4xlarge
+  dynamic.linux-d160-m4xlarge-arm64.instance-tag: prod-arm64-m4xlarge
+  dynamic.linux-d160-m4xlarge-arm64.key-name: konflux-prod-ext-mab01
+  dynamic.linux-d160-m4xlarge-arm64.aws-secret: aws-account
+  dynamic.linux-d160-m4xlarge-arm64.ssh-secret: aws-ssh-key
+  dynamic.linux-d160-m4xlarge-arm64.security-group-id: sg-0fbf35ced0d59fd4a
+  dynamic.linux-d160-m4xlarge-arm64.max-instances: "20"
+  dynamic.linux-d160-m4xlarge-arm64.subnet-id: subnet-0c39ff75f819abfc5
+  dynamic.linux-d160-m4xlarge-arm64.disk: "160"
+
   dynamic.linux-m8xlarge-arm64.type: aws
   dynamic.linux-m8xlarge-arm64.region: us-east-1
   dynamic.linux-m8xlarge-arm64.ami: ami-03d6a5256a46c9feb
@@ -136,6 +166,19 @@ data:
   dynamic.linux-m8xlarge-arm64.security-group-id: sg-0fbf35ced0d59fd4a
   dynamic.linux-m8xlarge-arm64.max-instances: "20"
   dynamic.linux-m8xlarge-arm64.subnet-id: subnet-0c39ff75f819abfc5
+
+  dynamic.linux-d160-m8xlarge-arm64.type: aws
+  dynamic.linux-d160-m8xlarge-arm64.region: us-east-1
+  dynamic.linux-d160-m8xlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-d160-m8xlarge-arm64.instance-type: m6g.8xlarge
+  dynamic.linux-d160-m8xlarge-arm64.instance-tag: prod-arm64-m8xlarge
+  dynamic.linux-d160-m8xlarge-arm64.key-name: konflux-prod-ext-mab01
+  dynamic.linux-d160-m8xlarge-arm64.aws-secret: aws-account
+  dynamic.linux-d160-m8xlarge-arm64.ssh-secret: aws-ssh-key
+  dynamic.linux-d160-m8xlarge-arm64.security-group-id: sg-0fbf35ced0d59fd4a
+  dynamic.linux-d160-m8xlarge-arm64.max-instances: "20"
+  dynamic.linux-d160-m8xlarge-arm64.subnet-id: subnet-0c39ff75f819abfc5
+  dynamic.linux-d160-m8xlarge-arm64.disk: "160"
 
   dynamic.linux-c6gd2xlarge-arm64.type: aws
   dynamic.linux-c6gd2xlarge-arm64.region: us-east-1
@@ -276,6 +319,19 @@ data:
   dynamic.linux-m2xlarge-amd64.max-instances: "10"
   dynamic.linux-m2xlarge-amd64.subnet-id: subnet-0c39ff75f819abfc5
 
+  dynamic.linux-d160-m2xlarge-amd64.type: aws
+  dynamic.linux-d160-m2xlarge-amd64.region: us-east-1
+  dynamic.linux-d160-m2xlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-d160-m2xlarge-amd64.instance-type: m6a.2xlarge
+  dynamic.linux-d160-m2xlarge-amd64.instance-tag: prod-amd64-m2xlarge
+  dynamic.linux-d160-m2xlarge-amd64.key-name: konflux-prod-ext-mab01
+  dynamic.linux-d160-m2xlarge-amd64.aws-secret: aws-account
+  dynamic.linux-d160-m2xlarge-amd64.ssh-secret: aws-ssh-key
+  dynamic.linux-d160-m2xlarge-amd64.security-group-id: sg-0fbf35ced0d59fd4a
+  dynamic.linux-d160-m2xlarge-amd64.max-instances: "10"
+  dynamic.linux-d160-m2xlarge-amd64.subnet-id: subnet-0c39ff75f819abfc5
+  dynamic.linux-d160-m2xlarge-amd64.disk: "160"
+
   dynamic.linux-m4xlarge-amd64.type: aws
   dynamic.linux-m4xlarge-amd64.region: us-east-1
   dynamic.linux-m4xlarge-amd64.ami: ami-026ebd4cfe2c043b2
@@ -314,6 +370,19 @@ data:
   dynamic.linux-m8xlarge-amd64.security-group-id: sg-0fbf35ced0d59fd4a
   dynamic.linux-m8xlarge-amd64.max-instances: "10"
   dynamic.linux-m8xlarge-amd64.subnet-id: subnet-0c39ff75f819abfc5
+
+  dynamic.linux-d160-m8xlarge-amd64.type: aws
+  dynamic.linux-d160-m8xlarge-amd64.region: us-east-1
+  dynamic.linux-d160-m8xlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-d160-m8xlarge-amd64.instance-type: m6a.8xlarge
+  dynamic.linux-d160-m8xlarge-amd64.instance-tag: prod-amd64-m8xlarge
+  dynamic.linux-d160-m8xlarge-amd64.key-name: konflux-prod-ext-mab01
+  dynamic.linux-d160-m8xlarge-amd64.aws-secret: aws-account
+  dynamic.linux-d160-m8xlarge-amd64.ssh-secret: aws-ssh-key
+  dynamic.linux-d160-m8xlarge-amd64.security-group-id: sg-0fbf35ced0d59fd4a
+  dynamic.linux-d160-m8xlarge-amd64.max-instances: "10"
+  dynamic.linux-d160-m8xlarge-amd64.subnet-id: subnet-0c39ff75f819abfc5
+  dynamic.linux-d160-m8xlarge-amd64.disk: "160"
 
   # cpu:memory (1:2)
   dynamic.linux-cxlarge-arm64.type: aws

--- a/components/multi-platform-controller/production/stone-prd-rh01/host-config.yaml
+++ b/components/multi-platform-controller/production/stone-prd-rh01/host-config.yaml
@@ -121,7 +121,7 @@ data:
   dynamic.linux-d160-m2xlarge-arm64.region: us-east-1
   dynamic.linux-d160-m2xlarge-arm64.ami: ami-03d6a5256a46c9feb
   dynamic.linux-d160-m2xlarge-arm64.instance-type: m6g.2xlarge
-  dynamic.linux-d160-m2xlarge-arm64.instance-tag: prod-arm64-m2xlarge
+  dynamic.linux-d160-m2xlarge-arm64.instance-tag: prod-arm64-m2xlarge-d160
   dynamic.linux-d160-m2xlarge-arm64.key-name: konflux-prod-ext-mab01
   dynamic.linux-d160-m2xlarge-arm64.aws-secret: aws-account
   dynamic.linux-d160-m2xlarge-arm64.ssh-secret: aws-ssh-key
@@ -158,7 +158,7 @@ data:
   dynamic.linux-d160-m8xlarge-arm64.region: us-east-1
   dynamic.linux-d160-m8xlarge-arm64.ami: ami-03d6a5256a46c9feb
   dynamic.linux-d160-m8xlarge-arm64.instance-type: m6g.8xlarge
-  dynamic.linux-d160-m8xlarge-arm64.instance-tag: prod-arm64-m8xlarge
+  dynamic.linux-d160-m8xlarge-arm64.instance-tag: prod-arm64-m8xlarge-d160
   dynamic.linux-d160-m8xlarge-arm64.key-name: konflux-prod-ext-mab01
   dynamic.linux-d160-m8xlarge-arm64.aws-secret: aws-account
   dynamic.linux-d160-m8xlarge-arm64.ssh-secret: aws-ssh-key
@@ -248,7 +248,7 @@ data:
   dynamic.linux-d160-m4xlarge-arm64.region: us-east-1
   dynamic.linux-d160-m4xlarge-arm64.ami: ami-03d6a5256a46c9feb
   dynamic.linux-d160-m4xlarge-arm64.instance-type: m6g.4xlarge
-  dynamic.linux-d160-m4xlarge-arm64.instance-tag: prod-arm64-d160-m4xlarge
+  dynamic.linux-d160-m4xlarge-arm64.instance-tag: prod-arm64-m4xlarge-d160
   dynamic.linux-d160-m4xlarge-arm64.key-name: konflux-prod-ext-mab01
   dynamic.linux-d160-m4xlarge-arm64.aws-secret: aws-account
   dynamic.linux-d160-m4xlarge-arm64.ssh-secret: aws-ssh-key
@@ -310,7 +310,7 @@ data:
   dynamic.linux-d160-m2xlarge-amd64.region: us-east-1
   dynamic.linux-d160-m2xlarge-amd64.ami: ami-026ebd4cfe2c043b2
   dynamic.linux-d160-m2xlarge-amd64.instance-type: m6a.2xlarge
-  dynamic.linux-d160-m2xlarge-amd64.instance-tag: prod-amd64-m2xlarge
+  dynamic.linux-d160-m2xlarge-amd64.instance-tag: prod-amd64-m2xlarge-d160
   dynamic.linux-d160-m2xlarge-amd64.key-name: konflux-prod-ext-mab01
   dynamic.linux-d160-m2xlarge-amd64.aws-secret: aws-account
   dynamic.linux-d160-m2xlarge-amd64.ssh-secret: aws-ssh-key
@@ -336,7 +336,7 @@ data:
   dynamic.linux-d160-m4xlarge-amd64.region: us-east-1
   dynamic.linux-d160-m4xlarge-amd64.ami: ami-026ebd4cfe2c043b2
   dynamic.linux-d160-m4xlarge-amd64.instance-type: m6a.4xlarge
-  dynamic.linux-d160-m4xlarge-amd64.instance-tag: prod-amd64-d160-m4xlarge
+  dynamic.linux-d160-m4xlarge-amd64.instance-tag: prod-amd64-m4xlarge-d160
   dynamic.linux-d160-m4xlarge-amd64.key-name: konflux-prod-ext-mab01
   dynamic.linux-d160-m4xlarge-amd64.aws-secret: aws-account
   dynamic.linux-d160-m4xlarge-amd64.ssh-secret: aws-ssh-key
@@ -362,7 +362,7 @@ data:
   dynamic.linux-d160-m8xlarge-amd64.region: us-east-1
   dynamic.linux-d160-m8xlarge-amd64.ami: ami-026ebd4cfe2c043b2
   dynamic.linux-d160-m8xlarge-amd64.instance-type: m6a.8xlarge
-  dynamic.linux-d160-m8xlarge-amd64.instance-tag: prod-amd64-m8xlarge
+  dynamic.linux-d160-m8xlarge-amd64.instance-tag: prod-amd64-m8xlarge-d160
   dynamic.linux-d160-m8xlarge-amd64.key-name: konflux-prod-ext-mab01
   dynamic.linux-d160-m8xlarge-amd64.aws-secret: aws-account
   dynamic.linux-d160-m8xlarge-amd64.ssh-secret: aws-ssh-key


### PR DESCRIPTION
Add a `d160-` flavore to all mNxlarge instances to host-config.yaml files of all production clusters. [Link](https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1744243945937309) to the original konflux-users thread.