### PR TITLE
give kyverno permission to create appstudio-pipeline rolebinding

### DIFF
--- a/components/konflux-rbac/policies/bootstrap-tenant-namespace/kyverno_rbac.yaml
+++ b/components/konflux-rbac/policies/bootstrap-tenant-namespace/kyverno_rbac.yaml
@@ -31,3 +31,21 @@ rules:
   - list
   - delete
   - update
+---
+# To allow kyverno to create the RoleBinding,
+# the kyverno-background-controller's ServiceAccount
+# needs to have the same permissions it wants to assign
+# to someone else
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kyverno-background:appstudio-pipeline-runner
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: appstudio-pipelines-runner
+subjects:
+- kind: ServiceAccount
+  namespace: konflux-kyverno
+  name: kyverno-background-controller
+


### PR DESCRIPTION
To allow kyverno to create the RoleBinding, the kyverno-background-controller's ServiceAccount needs to have the same permissions it wants to assign to someone else.

Signed-off-by: Francesco Ilario <filario@redhat.com>
