### PR TITLE
make chainsaw tests more robust

### DIFF
--- a/.github/workflows/chainsaw-tests.yaml
+++ b/.github/workflows/chainsaw-tests.yaml
@@ -32,6 +32,14 @@ jobs:
     - name: Create k8s Kind Cluster
       uses: helm/kind-action@v1
 
+    - uses: actions/checkout@v4
+    
+    - name: Install Dependencies
+      shell: bash
+      run: |
+        kustomize build components/kyverno/chainsaw | \
+          kubectl apply -f - --server-side
+
     - name: Install Cosign
       uses: sigstore/cosign-installer@dc72c7d5c4d10cd6bcb8cf6e3fd625a9e5e537da  # v3.7.0
 
@@ -40,21 +48,12 @@ jobs:
       with:
         verify: true
 
-    - uses: actions/checkout@v4
-
-    - name: Install Dependencies
-      shell: bash
-      run: |
-        kustomize build components/kyverno/chainsaw | \
-          kubectl apply -f - --server-side
-
     - name: Wait for kyverno ready
       shell: bash
       run: |
         set -e
-        kubectl rollout status \
-          --namespace kyverno \
-          deployment \
+        kubectl rollout status deployment \
+          --namespace konflux-kyverno \
           --selector '!job-name' \
           --timeout=300s
 

--- a/.github/workflows/chainsaw-tests.yaml
+++ b/.github/workflows/chainsaw-tests.yaml
@@ -37,7 +37,7 @@ jobs:
     - name: Install Dependencies
       shell: bash
       run: |
-        kustomize build components/kyverno/chainsaw | \
+        kustomize build --enable-helm components/kyverno/chainsaw | \
           kubectl apply -f - --server-side
 
     - name: Install Cosign

--- a/components/kyverno/chainsaw/job_resources.yaml
+++ b/components/kyverno/chainsaw/job_resources.yaml
@@ -1,0 +1,10 @@
+---
+- op: add
+  path: /spec/template/spec/containers/0/resources
+  value:
+    requests:
+      cpu: 100m
+      memory: 64M
+    limits:
+      cpu: 400m
+      memory: 256M

--- a/components/kyverno/chainsaw/kustomization.yaml
+++ b/components/kyverno/chainsaw/kustomization.yaml
@@ -1,4 +1,17 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: konflux-kyverno
 resources:
 - https://github.com/kyverno/kyverno/raw/main/config/install-latest-testing.yaml
+
+patches:
+- target:
+    kind: Deployment
+    name: kyverno-admission-controller
+  patch: |-
+    - op: add
+      path: /spec/template/spec/containers/0/args/-
+      value: --reportsServiceAccountName=system:serviceaccount:konflux-kyverno:kyverno-reports-controller
+    - op: add
+      path: /spec/template/spec/containers/0/args/-
+      value: --backgroundServiceAccountName=system:serviceaccount:konflux-kyverno:kyverno-background-controller

--- a/components/kyverno/chainsaw/kustomization.yaml
+++ b/components/kyverno/chainsaw/kustomization.yaml
@@ -1,17 +1,78 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: konflux-kyverno
-resources:
-- https://github.com/kyverno/kyverno/raw/main/config/install-latest-testing.yaml
 
+namespace: konflux-kyverno
+
+resources:
+- namespace.yaml
+
+generators:
+- kyverno-helm-generator.yaml
+
+replacements:
+  # enforce serviceAccountName is used instead of serviceAccount in Jobs
+  # TODO: these replacements can be removed when bumping to kyverno:1.14
+  # https://github.com/kyverno/kyverno/pull/12158
+  - source:
+      group: batch
+      version: v1
+      kind: Job
+      name: konflux-kyverno-clean-reports
+      namespace: konflux-kyverno
+      fieldPath: spec.template.spec.serviceAccount
+    targets:
+      - select:
+          group: batch
+          version: v1
+          kind: Job
+          namespace: konflux-kyverno
+          name: konflux-kyverno-clean-reports
+        fieldPaths:
+          - spec.template.spec.serviceAccountName
+        options:
+          create: true
+  - source:
+      group: batch
+      version: v1
+      kind: Job
+      name: konflux-kyverno-migrate-resources
+      namespace: konflux-kyverno
+      fieldPath: spec.template.spec.serviceAccount
+    targets:
+      - select:
+          group: batch
+          version: v1
+          kind: Job
+          namespace: konflux-kyverno
+          name: konflux-kyverno-migrate-resources
+        fieldPaths:
+          - spec.template.spec.serviceAccountName
+        options:
+          create: true
+
+# set resources to jobs
 patches:
-- target:
-    kind: Deployment
-    name: kyverno-admission-controller
-  patch: |-
-    - op: add
-      path: /spec/template/spec/containers/0/args/-
-      value: --reportsServiceAccountName=system:serviceaccount:konflux-kyverno:kyverno-reports-controller
-    - op: add
-      path: /spec/template/spec/containers/0/args/-
-      value: --backgroundServiceAccountName=system:serviceaccount:konflux-kyverno:kyverno-background-controller
+  - path: job_resources.yaml
+    target:
+      group: batch
+      version: v1
+      kind: Job
+      name: konflux-kyverno-scale-to-zero
+  - path: job_resources.yaml
+    target:
+      group: batch
+      version: v1
+      kind: Job
+      name: konflux-kyverno-clean-reports
+  - path: job_resources.yaml
+    target:
+      group: batch
+      version: v1
+      kind: Job
+      name: konflux-kyverno-migrate-resources
+  - path: job_resources.yaml
+    target:
+      group: batch
+      version: v1
+      kind: Job
+      name: konflux-kyverno-remove-configmap

--- a/components/kyverno/chainsaw/kyverno-helm-generator.yaml
+++ b/components/kyverno/chainsaw/kyverno-helm-generator.yaml
@@ -1,0 +1,13 @@
+apiVersion: builtin
+kind: HelmChartInflationGenerator
+metadata:
+  name: kyverno
+name: kyverno
+repo: https://kyverno.github.io/kyverno/
+# TODO: when bumping to kyverno:1.14 we can remove ServiceAccountName 
+# replacements from the kustomization.yaml file
+# https://github.com/kyverno/kyverno/pull/12158
+version: 3.3.7
+namespace: konflux-kyverno
+valuesFile: kyverno-helm-values.yaml
+releaseName: kyverno

--- a/components/kyverno/chainsaw/kyverno-helm-values.yaml
+++ b/components/kyverno/chainsaw/kyverno-helm-values.yaml
@@ -1,0 +1,105 @@
+---
+fullnameOverride: konflux-kyverno
+namespaceOverride: konflux-kyverno
+config:
+  updateRequestThreshold: 1000
+  preserve: false
+admissionController:
+  replicas: 1
+  initContainer:
+    securityContext:
+      allowPrivilegeEscalation: false
+      readOnlyRootFilesystem: true
+      runAsNonRoot: true
+      capabilities:
+        drop:
+        - "ALL"
+  container:
+    resources:
+      limits:
+        cpu: 500m
+    securityContext:
+      allowPrivilegeEscalation: false
+      readOnlyRootFilesystem: true
+      runAsNonRoot: true
+      capabilities:
+        drop:
+        - "ALL"
+backgroundController:
+  replicas: 1
+  resources:
+    limits:
+      cpu: 500m
+  securityContext:
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: true
+    runAsNonRoot: true
+    capabilities:
+      drop:
+      - "ALL"
+cleanupController:
+  enabled: false
+  resources:
+    limits:
+      cpu: 500m
+  securityContext:
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: true
+    runAsNonRoot: true
+    capabilities:
+      drop:
+      - "ALL"
+reportsController:
+  enabled: false
+  resources:
+    limits:
+      cpu: 500m
+  securityContext:
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: true
+    runAsNonRoot: true
+    capabilities:
+      drop:
+      - "ALL"
+policyReportsCleanup:
+  securityContext:
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: true
+    runAsNonRoot: true
+    runAsGroup: null
+    runAsUser: null
+    capabilities:
+      drop:
+      - "ALL"
+webhooksCleanup:
+  enabled: false
+  securityContext:
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: true
+    runAsNonRoot: true
+    runAsGroup: null
+    runAsUser: null
+    capabilities:
+      drop:
+      - "ALL"
+test:
+  securityContext:
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: true
+    runAsNonRoot: true
+    runAsGroup: null
+    runAsUser: null
+    capabilities:
+      drop:
+      - "ALL"
+crds:
+  migration:
+    securityContext:
+      allowPrivilegeEscalation: false
+      readOnlyRootFilesystem: true
+      runAsNonRoot: true
+      runAsGroup: null
+      runAsUser: null
+      capabilities:
+        drop:
+        - "ALL"

--- a/components/kyverno/chainsaw/namespace.yaml
+++ b/components/kyverno/chainsaw/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: konflux-kyverno

--- a/hack/chainsaw/chainsaw-prepare.sh
+++ b/hack/chainsaw/chainsaw-prepare.sh
@@ -10,4 +10,7 @@ kustomize build components/kyverno/chainsaw | \
   kubectl apply -f - --server-side
 
 ## wait for kyverno to rollout
-kubectl rollout status --namespace kyverno deployment --selector '!job-name' --timeout=300s
+kubectl rollout status deployment \
+  --namespace konflux-kyverno \
+  --selector '!job-name' \
+  --timeout=300s

--- a/hack/chainsaw/chainsaw-prepare.sh
+++ b/hack/chainsaw/chainsaw-prepare.sh
@@ -6,7 +6,7 @@ set -e
 kind create cluster --name infra-deployments-chainsaw
 
 ## Install kyverno
-kustomize build components/kyverno/chainsaw | \
+kustomize build --enable-helm components/kyverno/chainsaw | \
   kubectl apply -f - --server-side
 
 ## wait for kyverno to rollout


### PR DESCRIPTION
This PR
* changes the order of steps for the chainsaw tests pipeline to make it faster
* changes default namespace of chainsaw tests to `konflux-kyverno` to match the other environments
* enforce Helm manifests are used also in the `chainsaw` overlay