### PR TITLE
[ocp] increase linux-large max instances for IBM arches

### DIFF
--- a/components/multi-platform-controller/production-downstream/kflux-ocp-p01/host-config.yaml
+++ b/components/multi-platform-controller/production-downstream/kflux-ocp-p01/host-config.yaml
@@ -705,7 +705,7 @@ data:
   dynamic.linux-large-s390x.region: "us-south-2"
   dynamic.linux-large-s390x.url: "https://us-south.iaas.cloud.ibm.com/v1"
   dynamic.linux-large-s390x.profile: "bz2-4x16"
-  dynamic.linux-large-s390x.max-instances: "30"
+  dynamic.linux-large-s390x.max-instances: "100"
   dynamic.linux-large-s390x.private-ip: "true"
   dynamic.linux-large-s390x.allocation-timeout: "1800"
   dynamic.linux-large-s390x.instance-tag: prod-s390x-large
@@ -788,7 +788,7 @@ data:
   dynamic.linux-large-ppc64le.system: "e980"
   dynamic.linux-large-ppc64le.cores: "4"
   dynamic.linux-large-ppc64le.memory: "16"
-  dynamic.linux-large-ppc64le.max-instances: "30"
+  dynamic.linux-large-ppc64le.max-instances: "100"
   dynamic.linux-large-ppc64le.allocation-timeout: "1800"
   dynamic.linux-large-ppc64le.instance-tag: prod-ppc64le-large
 


### PR DESCRIPTION
OCP uses the `linux-large-*` variants by default since it has the same specs as the lowest x86/arm specs. The current max-instances of 30 builds is a bottleneck. Setting the value same as x86/arm