### PR TITLE
Move ocp-art cluster PPC nodes to e1080 arch

### DIFF
--- a/components/multi-platform-controller/production-downstream/kflux-ocp-p01/host-config.yaml
+++ b/components/multi-platform-controller/production-downstream/kflux-ocp-p01/host-config.yaml
@@ -788,7 +788,7 @@ data:
   dynamic.linux-large-ppc64le.system: "e1080"
   dynamic.linux-large-ppc64le.cores: "4"
   dynamic.linux-large-ppc64le.memory: "16"
-  dynamic.linux-large-ppc64le.max-instances: "50"  # those are used most
+  dynamic.linux-large-ppc64le.max-instances: "50"
   dynamic.linux-large-ppc64le.allocation-timeout: "1800"
   dynamic.linux-large-ppc64le.instance-tag: prod-ppc64le-large
 


### PR DESCRIPTION
Experimentally move ocp-art cluster PPC nodes to `e1080` arch as their instances are usually large or xlarge and drain alot of `e980` capacity. 
Also, set new vm count limits = 30 for regular size (unchanged), 50 for large as most used, and 15 for xlarge.