### PR TITLE
update PaC's custom console URL in prod

### DIFF
--- a/components/pipeline-service/production/base/update-tekton-config-pac.yaml
+++ b/components/pipeline-service/production/base/update-tekton-config-pac.yaml
@@ -4,7 +4,7 @@
   value:
     application-name: Red Hat Konflux
     custom-console-name: Red Hat Konflux
-    custom-console-url: https://console.redhat.com/application-pipeline
-    custom-console-url-pr-details: https://console.redhat.com/application-pipeline/ns/{{ namespace }}/pipelinerun/{{ pr }}
-    custom-console-url-pr-tasklog: https://console.redhat.com/application-pipeline/ns/{{ namespace }}/pipelinerun/{{ pr }}/logs/{{ task }}
+    custom-console-url: https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/
+    custom-console-url-pr-details: https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/{{ namespace }}/pipelinerun/{{ pr }}
+    custom-console-url-pr-tasklog: https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/{{ namespace }}/pipelinerun/{{ pr }}/logs/{{ task }}
     remember-ok-to-test: "false"

--- a/components/pipeline-service/production/kflux-ocp-p01/resources/update-tekton-config-pac.yaml
+++ b/components/pipeline-service/production/kflux-ocp-p01/resources/update-tekton-config-pac.yaml
@@ -4,6 +4,6 @@
   value:
     application-name: Konflux OCP
     custom-console-name: Konflux OCP
-    custom-console-url: https://konflux.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com
-    custom-console-url-pr-details: https://konflux.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/application-pipeline/ns/{{ namespace }}/pipelinerun/{{ pr }}
-    custom-console-url-pr-tasklog: https://konflux.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/application-pipeline/ns/{{ namespace }}/pipelinerun/{{ pr }}/logs/{{ task }}
+    custom-console-url: https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com
+    custom-console-url-pr-details: https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/{{ namespace }}/pipelinerun/{{ pr }}
+    custom-console-url-pr-tasklog: https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/{{ namespace }}/pipelinerun/{{ pr }}/logs/{{ task }}

--- a/components/pipeline-service/production/stone-prod-p01/resources/update-tekton-config-pac.yaml
+++ b/components/pipeline-service/production/stone-prod-p01/resources/update-tekton-config-pac.yaml
@@ -4,7 +4,7 @@
   value:
     application-name: Konflux Production Internal
     custom-console-name: Konflux Production Internal
-    custom-console-url: https://konflux.apps.stone-prod-p01.wcfb.p1.openshiftapps.com
-    custom-console-url-pr-details: https://konflux.apps.stone-prod-p01.wcfb.p1.openshiftapps.com/application-pipeline/ns/{{ namespace }}/pipelinerun/{{ pr }}
-    custom-console-url-pr-tasklog: https://konflux.apps.stone-prod-p01.wcfb.p1.openshiftapps.com/application-pipeline/ns/{{ namespace }}/pipelinerun/{{ pr }}/logs/{{ task }}
+    custom-console-url: https://konflux-ui.apps.stone-prod-p01.wcfb.p1.openshiftapps.com
+    custom-console-url-pr-details: https://konflux-ui.apps.stone-prod-p01.wcfb.p1.openshiftapps.com/ns/{{ namespace }}/pipelinerun/{{ pr }}
+    custom-console-url-pr-tasklog: https://konflux-ui.apps.stone-prod-p01.wcfb.p1.openshiftapps.com/ns/{{ namespace }}/pipelinerun/{{ pr }}/logs/{{ task }}
     remember-ok-to-test: "false"

--- a/components/pipeline-service/production/stone-prod-p02/resources/update-tekton-config-pac.yaml
+++ b/components/pipeline-service/production/stone-prod-p02/resources/update-tekton-config-pac.yaml
@@ -4,7 +4,7 @@
   value:
     application-name: Konflux Production Internal
     custom-console-name: Konflux Production Internal
-    custom-console-url: https://konflux.apps.stone-prod-p02.hjvn.p1.openshiftapps.com
-    custom-console-url-pr-details: https://konflux.apps.stone-prod-p02.hjvn.p1.openshiftapps.com/application-pipeline/ns/{{ namespace }}/pipelinerun/{{ pr }}
-    custom-console-url-pr-tasklog: https://konflux.apps.stone-prod-p02.hjvn.p1.openshiftapps.com/application-pipeline/ns/{{ namespace }}/pipelinerun/{{ pr }}/logs/{{ task }}
+    custom-console-url: https://konflux-ui.apps.stone-prod-p02.hjvn.p1.openshiftapps.com
+    custom-console-url-pr-details: https://konflux-ui.apps.stone-prod-p02.hjvn.p1.openshiftapps.com/ns/{{ namespace }}/pipelinerun/{{ pr }}
+    custom-console-url-pr-tasklog: https://konflux-ui.apps.stone-prod-p02.hjvn.p1.openshiftapps.com/ns/{{ namespace }}/pipelinerun/{{ pr }}/logs/{{ task }}
     remember-ok-to-test: "false"


### PR DESCRIPTION
Updates PaC's custom console URL for production clusters:
* ocp-p01
* rh01
* p01
* p02

Signed-off-by: Francesco Ilario <filario@redhat.com>
