### PR TITLE
[dev+stage] Add SCC for nested containerization

### DIFF
--- a/components/pipeline-service/development/main-pipeline-service-configuration.yaml
+++ b/components/pipeline-service/development/main-pipeline-service-configuration.yaml
@@ -2187,3 +2187,45 @@ volumes:
 - persistentVolumeClaim
 - projected
 - secret
+---
+allowHostDirVolumePlugin: false
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: false
+allowHostPorts: false
+allowPrivilegeEscalation: false
+allowPrivilegedContainer: false
+allowedCapabilities:
+- SETFCAP
+apiVersion: security.openshift.io/v1
+defaultAddCapabilities: null
+fsGroup:
+  type: MustRunAs
+groups:
+- system:cluster-admins
+kind: SecurityContextConstraints
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "0"
+  name: appstudio-pipelines-nested-containerization-scc
+priority: 10
+readOnlyRootFilesystem: false
+requiredDropCapabilities:
+- MKNOD
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: MustRunAs
+  seLinuxOptions:
+    type: container_runtime_t
+supplementalGroups:
+  type: RunAsAny
+users: []
+volumes:
+- configMap
+- downwardAPI
+- emptyDir
+- persistentVolumeClaim
+- projected
+- secret

--- a/components/pipeline-service/staging/base/main-pipeline-service-configuration.yaml
+++ b/components/pipeline-service/staging/base/main-pipeline-service-configuration.yaml
@@ -2009,3 +2009,45 @@ volumes:
 - persistentVolumeClaim
 - projected
 - secret
+---
+allowHostDirVolumePlugin: false
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: false
+allowHostPorts: false
+allowPrivilegeEscalation: false
+allowPrivilegedContainer: false
+allowedCapabilities:
+- SETFCAP
+apiVersion: security.openshift.io/v1
+defaultAddCapabilities: null
+fsGroup:
+  type: MustRunAs
+groups:
+- system:cluster-admins
+kind: SecurityContextConstraints
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "0"
+  name: appstudio-pipelines-nested-containerization-scc
+priority: 10
+readOnlyRootFilesystem: false
+requiredDropCapabilities:
+- MKNOD
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: MustRunAs
+  seLinuxOptions:
+    type: container_runtime_t
+supplementalGroups:
+  type: RunAsAny
+users: []
+volumes:
+- configMap
+- downwardAPI
+- emptyDir
+- persistentVolumeClaim
+- projected
+- secret

--- a/components/pipeline-service/staging/stone-stage-p01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stage-p01/deploy.yaml
@@ -2595,3 +2595,45 @@ volumes:
 - persistentVolumeClaim
 - projected
 - secret
+---
+allowHostDirVolumePlugin: false
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: false
+allowHostPorts: false
+allowPrivilegeEscalation: false
+allowPrivilegedContainer: false
+allowedCapabilities:
+- SETFCAP
+apiVersion: security.openshift.io/v1
+defaultAddCapabilities: null
+fsGroup:
+  type: MustRunAs
+groups:
+- system:cluster-admins
+kind: SecurityContextConstraints
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "0"
+  name: appstudio-pipelines-nested-containerization-scc
+priority: 10
+readOnlyRootFilesystem: false
+requiredDropCapabilities:
+- MKNOD
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: MustRunAs
+  seLinuxOptions:
+    type: container_runtime_t
+supplementalGroups:
+  type: RunAsAny
+users: []
+volumes:
+- configMap
+- downwardAPI
+- emptyDir
+- persistentVolumeClaim
+- projected
+- secret

--- a/components/pipeline-service/staging/stone-stg-rh01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stg-rh01/deploy.yaml
@@ -2606,3 +2606,45 @@ volumes:
 - persistentVolumeClaim
 - projected
 - secret
+---
+allowHostDirVolumePlugin: false
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: false
+allowHostPorts: false
+allowPrivilegeEscalation: false
+allowPrivilegedContainer: false
+allowedCapabilities:
+- SETFCAP
+apiVersion: security.openshift.io/v1
+defaultAddCapabilities: null
+fsGroup:
+  type: MustRunAs
+groups:
+- system:cluster-admins
+kind: SecurityContextConstraints
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "0"
+  name: appstudio-pipelines-nested-containerization-scc
+priority: 10
+readOnlyRootFilesystem: false
+requiredDropCapabilities:
+- MKNOD
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: MustRunAs
+  seLinuxOptions:
+    type: container_runtime_t
+supplementalGroups:
+  type: RunAsAny
+users: []
+volumes:
+- configMap
+- downwardAPI
+- emptyDir
+- persistentVolumeClaim
+- projected
+- secret

--- a/components/sandbox/toolchain-member-operator/staging/kustomization.yaml
+++ b/components/sandbox/toolchain-member-operator/staging/kustomization.yaml
@@ -6,3 +6,7 @@ resources:
 - ../../user-management/staging/generated-manifests/member
 patches:
   - path: patch_resources.yaml
+  - path: patch-appstudio-pipelines-runner.yaml
+    target:
+      kind: ClusterRole
+      name: appstudio-pipelines-runner

--- a/components/sandbox/toolchain-member-operator/staging/patch-appstudio-pipelines-runner.yaml
+++ b/components/sandbox/toolchain-member-operator/staging/patch-appstudio-pipelines-runner.yaml
@@ -1,0 +1,8 @@
+# check that we're patching the correct resource
+- op: test
+  path: /rules/1/resources/0
+  value: securitycontextconstraints
+
+- op: add
+  path: /rules/1/resourceNames/-
+  value: appstudio-pipelines-nested-containerization-scc


### PR DESCRIPTION
Add the appstudio-pipelines-nested-containerization-scc. It is a copy of the regular appstudio-pipelines-scc, the only difference being the seLinuxContext.seLinuxOptions setting that allows (forces, in fact) the usage of the container_runtime_t label.

The container_runtime_t label is needed to enable buildah-in-kubernetes workflows with a more robust isolation mechanism (rather than chroot). See https://github.com/containers/buildah/issues/5818 for details.

Allow the appstudio-pipelines-runner ClusterRole - and by extension, the appstudio-pipeline ServiceAccount - to use the new SCC.

All in all, this should allow the appstudio-pipeline SA to set the container_runtime_t label on Pods (but not force, because the SA can still use the regular appstudio-pipelines-scc), making it possible to use more robust mechanisms for buildah isolation.