### PR TITLE
improve tests for generate-tenant-resources-admission ClusterPolicy

### DIFF
--- a/components/konflux-rbac/policies/bootstrap-tenant-namespace/.chainsaw-test/resources/actual-appstudio-pipeline-clusterrole.yaml
+++ b/components/konflux-rbac/policies/bootstrap-tenant-namespace/.chainsaw-test/resources/actual-appstudio-pipeline-clusterrole.yaml
@@ -2,3 +2,16 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: appstudio-pipelines-runner
+rules:
+- apiGroups:
+  - autoscaling
+  resources:
+  - horizontalpodautoscalers
+  - horizontalpodautoscalers/status
+  verbs:
+  - get
+  - list
+  - watch
+  - patch
+  - update
+  - create


### PR DESCRIPTION
requires
* [x] #6113

This PR adds some content to the ClusterRole `appstudio-pipeline-runner` in chainsaw tests to make it more adherent to the real use case.

This is to make sure the policy's manifests are providing kyverno with the permission required to create the RoleBinding, i.e. the same permission the ClusterRole in the RoleBinding will provide to the assignee.

For this purpose permissions on `horizontalpodautoscaler` are a good fit as they aren't something shared globally and -if missed- an error would be raised.
