### PR TITLE
Grant Build Service rights to run build pipelines

### DIFF
--- a/components/build-service/base/build-pipeline-runner-rolebinding.yaml
+++ b/components/build-service/base/build-pipeline-runner-rolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: build-pipeline-runner-rolebinding
+subjects:
+  - kind: ServiceAccount
+    name: build-service-controller-manager
+    namespace: build-service
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: appstudio-pipelines-runner

--- a/components/build-service/base/kustomization.yaml
+++ b/components/build-service/base/kustomization.yaml
@@ -3,6 +3,7 @@ resources:
 - build-pipeline-config/build-pipeline-config.yaml
 - monitoring.yaml
 - rbac
+- build-pipeline-runner-rolebinding.yaml
 
 # Skip applying the build-service operands while the build-service operator is being installed.
 # See more information about this option, here:


### PR DESCRIPTION
Since Build Service starts to manage Component build pipeline Service Account, it has to have the rights to run build pipelines to grant them to Components.