### PR TITLE
Reduce priority for nested containerization SCC

### DIFF
--- a/components/pipeline-service/development/main-pipeline-service-configuration.yaml
+++ b/components/pipeline-service/development/main-pipeline-service-configuration.yaml
@@ -2209,7 +2209,7 @@ metadata:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
     argocd.argoproj.io/sync-wave: "0"
   name: appstudio-pipelines-nested-containerization-scc
-priority: 10
+priority: 0
 readOnlyRootFilesystem: false
 requiredDropCapabilities:
 - MKNOD

--- a/components/pipeline-service/staging/base/main-pipeline-service-configuration.yaml
+++ b/components/pipeline-service/staging/base/main-pipeline-service-configuration.yaml
@@ -2031,7 +2031,7 @@ metadata:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
     argocd.argoproj.io/sync-wave: "0"
   name: appstudio-pipelines-nested-containerization-scc
-priority: 10
+priority: 0
 readOnlyRootFilesystem: false
 requiredDropCapabilities:
 - MKNOD

--- a/components/pipeline-service/staging/stone-stage-p01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stage-p01/deploy.yaml
@@ -2617,7 +2617,7 @@ metadata:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
     argocd.argoproj.io/sync-wave: "0"
   name: appstudio-pipelines-nested-containerization-scc
-priority: 10
+priority: 0
 readOnlyRootFilesystem: false
 requiredDropCapabilities:
 - MKNOD

--- a/components/pipeline-service/staging/stone-stg-rh01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stg-rh01/deploy.yaml
@@ -2628,7 +2628,7 @@ metadata:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
     argocd.argoproj.io/sync-wave: "0"
   name: appstudio-pipelines-nested-containerization-scc
-priority: 10
+priority: 0
 readOnlyRootFilesystem: false
 requiredDropCapabilities:
 - MKNOD


### PR DESCRIPTION
Previously, appstudio-pipelines-scc and
appstudio-pipelines-nested-containerization-scc had the same priority. The nested-containerization SCC is considered more restrictive (it forces a specific label while the normal SCC does not). Because of that, OpenShift prioritized it over the normal SCC and all Tekton Task Pods were defaulting to the container_runtime_t label.

Reduce the appstudio-pipelines-nested-containerization-scc priority to make sure Pods default to appstudio-pipelines-scc.

Ref: https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html/authentication_and_authorization/managing-pod-security-policies#scc-prioritization_configuring-internal-oauth