### PR TITLE
Update Cluster-logging operator to stable-6.1

### DIFF
--- a/components/monitoring/logging/base/install-logging-operator.yaml
+++ b/components/monitoring/logging/base/install-logging-operator.yaml
@@ -9,7 +9,7 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "0"
 spec:
-  channel: "stable-6.0"
+  channel: "stable-6.1"
   name: cluster-logging
   source: redhat-operators 
   sourceNamespace: openshift-marketplace


### PR DESCRIPTION
[PVO11Y-4730](https://issues.redhat.com/browse/PVO11Y-4730)

Update needed due to error messages from pods: cluster-logging-operator reports an issue updating status: ‘Operation cannot be fulfilled on clusterlogforwarders; the object has been modified. Please apply changes to the latest version and try again