### PR TITLE
livenessprobe for smee-client and refine of smee-base

### DIFF
--- a/components/smee-client/base/deployment.yaml
+++ b/components/smee-client/base/deployment.yaml
@@ -21,6 +21,14 @@ spec:
             - "client"
             - TBA
             - "http://pipelines-as-code-controller.openshift-pipelines:8080"
+          livenessProbe:
+            exec:
+              command:
+                - echo "Service up"
+            initialDelaySeconds: 30
+            periodSeconds: 5
+            timeoutSeconds: 2
+            failureThreshold: 3
           securityContext:
             readOnlyRootFilesystem: true
             runAsNonRoot: true

--- a/components/smee/base/deployment.yaml
+++ b/components/smee/base/deployment.yaml
@@ -25,8 +25,7 @@ spec:
               containerPort: 3333
               protocol: TCP
           livenessProbe:
-            httpGet:
-              path: /
+            tcpSocket:
               port: 3333
           initialDelaySeconds: 30
           periodSeconds: 5


### PR DESCRIPTION
We have created a new livenessProbe for smee-client, based on a simple echo "Service up" instead of choosing http check due to port forwarding issue.
Also, we have refined the livenessProbe for smee-base due to a warning error on Openshif.
Tracking ticket: https://issues.redhat.com/browse/SPRE-1255
