### PR TITLE
Change s390x cobfiguration to static for ocp-art-p01

### DIFF
--- a/components/multi-platform-controller/production-downstream/kflux-ocp-p01/host-config.yaml
+++ b/components/multi-platform-controller/production-downstream/kflux-ocp-p01/host-config.yaml
@@ -48,10 +48,6 @@ data:
     linux-g6xlarge/amd64,\
     linux-root/arm64,\
     linux-root/amd64,\
-    linux/s390x,\
-    linux-large/s390x,\
-    linux-largecpu/s390x,\
-    linux-d250-largecpu/s390x,\
     linux/ppc64le,\
     linux-largecpu/ppc64le,\
     linux-d250-largecpu/ppc64le,\
@@ -677,71 +673,157 @@ data:
     restorecon -r /home/ec2-user
     
     --//--
+    
 
-  ## IBM s390x with 2CPU 8GiB RAM ####
-  dynamic.linux-s390x.type: ibmz
-  dynamic.linux-s390x.ssh-secret: "internal-prod-ibm-ssh-key"
-  dynamic.linux-s390x.secret: "internal-prod-ibm-api-key"
-  dynamic.linux-s390x.vpc: "konflux-internal-ocp-art-vpc"
-  dynamic.linux-s390x.key: "internal-prod-key"
-  dynamic.linux-s390x.subnet: "konflux-internal-ocp-art-vpc-subnet"
-  dynamic.linux-s390x.image-id: "r006-7af05e6b-b1cd-4467-8a37-770ce2094e8d"
-  dynamic.linux-s390x.region: "us-south-2"
-  dynamic.linux-s390x.url: "https://us-south.iaas.cloud.ibm.com/v1"
-  dynamic.linux-s390x.profile: "bz2-2x8"
-  dynamic.linux-s390x.max-instances: "30"
-  dynamic.linux-s390x.private-ip: "true"
-  dynamic.linux-s390x.allocation-timeout: "1800"
-  dynamic.linux-s390x.instance-tag: prod-s390x
+  host.s390x-static-1.address: "10.130.85.132"
+  host.s390x-static-1.platform: "linux/s390x"
+  host.s390x-static-1.user: "root"
+  host.s390x-static-1.secret: "s390x-static-ssh-key"
+  host.s390x-static-1.concurrency: "4"
 
-  ## IBM s390x with 4CPU 16GiB RAM ####
-  dynamic.linux-large-s390x.type: ibmz
-  dynamic.linux-large-s390x.ssh-secret: "internal-prod-ibm-ssh-key"
-  dynamic.linux-large-s390x.secret: "internal-prod-ibm-api-key"
-  dynamic.linux-large-s390x.vpc: "konflux-internal-ocp-art-vpc"
-  dynamic.linux-large-s390x.key: "internal-prod-key"
-  dynamic.linux-large-s390x.subnet: "konflux-internal-ocp-art-vpc-subnet"
-  dynamic.linux-large-s390x.image-id: "r006-7af05e6b-b1cd-4467-8a37-770ce2094e8d"
-  dynamic.linux-large-s390x.region: "us-south-2"
-  dynamic.linux-large-s390x.url: "https://us-south.iaas.cloud.ibm.com/v1"
-  dynamic.linux-large-s390x.profile: "bz2-4x16"
-  dynamic.linux-large-s390x.max-instances: "30"
-  dynamic.linux-large-s390x.private-ip: "true"
-  dynamic.linux-large-s390x.allocation-timeout: "1800"
-  dynamic.linux-large-s390x.instance-tag: prod-s390x-large
+  host.s390x-static-2.address: "10.130.85.133"
+  host.s390x-static-2.platform: "linux/s390x"
+  host.s390x-static-2.user: "root"
+  host.s390x-static-2.secret: "s390x-static-ssh-key"
+  host.s390x-static-2.concurrency: "4"
 
-  ## IBM s390x with 8CPU 16GiB RAM ####
-  dynamic.linux-largecpu-s390x.type: ibmz
-  dynamic.linux-largecpu-s390x.ssh-secret: "internal-prod-ibm-ssh-key"
-  dynamic.linux-largecpu-s390x.secret: "internal-prod-ibm-api-key"
-  dynamic.linux-largecpu-s390x.vpc: "konflux-internal-ocp-art-vpc"
-  dynamic.linux-largecpu-s390x.key: "internal-prod-key"
-  dynamic.linux-largecpu-s390x.subnet: "konflux-internal-ocp-art-vpc-subnet"
-  dynamic.linux-largecpu-s390x.image-id: "r006-7af05e6b-b1cd-4467-8a37-770ce2094e8d"
-  dynamic.linux-largecpu-s390x.region: "us-south-2"
-  dynamic.linux-largecpu-s390x.url: "https://us-south.iaas.cloud.ibm.com/v1"
-  dynamic.linux-largecpu-s390x.profile: "cz2-8x16"
-  dynamic.linux-largecpu-s390x.max-instances: "5"
-  dynamic.linux-largecpu-s390x.private-ip: "true"
-  dynamic.linux-largecpu-s390x.allocation-timeout: "1800"
-  dynamic.linux-largecpu-s390x.instance-tag: prod-s390x-largecpu
+  host.s390x-static-3.address: "10.130.85.134"
+  host.s390x-static-3.platform: "linux/s390x"
+  host.s390x-static-3.user: "root"
+  host.s390x-static-3.secret: "s390x-static-ssh-key"
+  host.s390x-static-3.concurrency: "4"
 
-  # Same as linux-largecpu-s390x, but with 250 GB disk
-  dynamic.linux-d250-largecpu-s390x.type: ibmz
-  dynamic.linux-d250-largecpu-s390x.ssh-secret: "internal-prod-ibm-ssh-key"
-  dynamic.linux-d250-largecpu-s390x.secret: "internal-prod-ibm-api-key"
-  dynamic.linux-d250-largecpu-s390x.vpc: "konflux-internal-ocp-art-vpc"
-  dynamic.linux-d250-largecpu-s390x.key: "internal-prod-key"
-  dynamic.linux-d250-largecpu-s390x.subnet: "konflux-internal-ocp-art-vpc-subnet"
-  dynamic.linux-d250-largecpu-s390x.image-id: "r006-7af05e6b-b1cd-4467-8a37-770ce2094e8d"
-  dynamic.linux-d250-largecpu-s390x.region: "us-south-2"
-  dynamic.linux-d250-largecpu-s390x.url: "https://us-south.iaas.cloud.ibm.com/v1"
-  dynamic.linux-d250-largecpu-s390x.profile: "cz2-8x16"
-  dynamic.linux-d250-largecpu-s390x.max-instances: "5"
-  dynamic.linux-d250-largecpu-s390x.private-ip: "true"
-  dynamic.linux-d250-largecpu-s390x.allocation-timeout: "1800"
-  dynamic.linux-d250-largecpu-s390x.instance-tag: prod-s390x-d250-largecpu
-  dynamic.linux-d250-largecpu-s390x.disk: "250"
+  host.s390x-static-4.address: "10.130.85.135"
+  host.s390x-static-4.platform: "linux/s390x"
+  host.s390x-static-4.user: "root"
+  host.s390x-static-4.secret: "s390x-static-ssh-key"
+  host.s390x-static-4.concurrency: "4"
+
+  host.s390x-static-5.address: "10.130.85.164"
+  host.s390x-static-5.platform: "linux/s390x"
+  host.s390x-static-5.user: "root"
+  host.s390x-static-5.secret: "s390x-static-ssh-key"
+  host.s390x-static-5.concurrency: "4"
+
+  host.s390x-static-6.address: "10.130.85.196"
+  host.s390x-static-6.platform: "linux/s390x"
+  host.s390x-static-6.user: "root"
+  host.s390x-static-6.secret: "s390x-static-ssh-key"
+  host.s390x-static-6.concurrency: "4"
+
+  host.s390x-static-7.address: "10.130.85.197"
+  host.s390x-static-7.platform: "linux/s390x"
+  host.s390x-static-7.user: "root"
+  host.s390x-static-7.secret: "s390x-static-ssh-key"
+  host.s390x-static-7.concurrency: "4"
+
+  host.s390x-static-8.address: "10.130.85.198"
+  host.s390x-static-8.platform: "linux/s390x"
+  host.s390x-static-8.user: "root"
+  host.s390x-static-8.secret: "s390x-static-ssh-key"
+  host.s390x-static-8.concurrency: "4"
+
+  host.s390x-static-9.address: "10.130.85.199"
+  host.s390x-static-9.platform: "linux/s390x"
+  host.s390x-static-9.user: "root"
+  host.s390x-static-9.secret: "s390x-static-ssh-key"
+  host.s390x-static-9.concurrency: "4"
+
+  host.s390x-static-10.address: "10.130.85.200"
+  host.s390x-static-10.platform: "linux/s390x"
+  host.s390x-static-10.user: "root"
+  host.s390x-static-10.secret: "s390x-static-ssh-key"
+  host.s390x-static-10.concurrency: "4"
+
+  host.s390x-static-11.address: "10.130.85.201"
+  host.s390x-static-11.platform: "linux/s390x"
+  host.s390x-static-11.user: "root"
+  host.s390x-static-11.secret: "s390x-static-ssh-key"
+  host.s390x-static-11.concurrency: "4"
+
+  host.s390x-static-12.address: "10.130.85.202"
+  host.s390x-static-12.platform: "linux/s390x"
+  host.s390x-static-12.user: "root"
+  host.s390x-static-12.secret: "s390x-static-ssh-key"
+  host.s390x-static-12.concurrency: "4"
+
+  host.s390x-static-13.address: "10.130.85.203"
+  host.s390x-static-13.platform: "linux/s390x"
+  host.s390x-static-13.user: "root"
+  host.s390x-static-13.secret: "s390x-static-ssh-key"
+  host.s390x-static-13.concurrency: "4"
+
+  host.s390x-static-14.address: "10.130.85.137"
+  host.s390x-static-14.platform: "linux/s390x"
+  host.s390x-static-14.user: "root"
+  host.s390x-static-14.secret: "s390x-static-ssh-key"
+  host.s390x-static-14.concurrency: "4"
+
+
+#  ## IBM s390x with 2CPU 8GiB RAM ####
+#  dynamic.linux-s390x.type: ibmz
+#  dynamic.linux-s390x.ssh-secret: "internal-prod-ibm-ssh-key"
+#  dynamic.linux-s390x.secret: "internal-prod-ibm-api-key"
+#  dynamic.linux-s390x.vpc: "konflux-internal-ocp-art-vpc"
+#  dynamic.linux-s390x.key: "internal-prod-key"
+#  dynamic.linux-s390x.subnet: "konflux-internal-ocp-art-vpc-subnet"
+#  dynamic.linux-s390x.image-id: "r006-7af05e6b-b1cd-4467-8a37-770ce2094e8d"
+#  dynamic.linux-s390x.region: "us-south-2"
+#  dynamic.linux-s390x.url: "https://us-south.iaas.cloud.ibm.com/v1"
+#  dynamic.linux-s390x.profile: "bz2-2x8"
+#  dynamic.linux-s390x.max-instances: "30"
+#  dynamic.linux-s390x.private-ip: "true"
+#  dynamic.linux-s390x.allocation-timeout: "1800"
+#  dynamic.linux-s390x.instance-tag: prod-s390x
+#
+#  ## IBM s390x with 4CPU 16GiB RAM ####
+#  dynamic.linux-large-s390x.type: ibmz
+#  dynamic.linux-large-s390x.ssh-secret: "internal-prod-ibm-ssh-key"
+#  dynamic.linux-large-s390x.secret: "internal-prod-ibm-api-key"
+#  dynamic.linux-large-s390x.vpc: "konflux-internal-ocp-art-vpc"
+#  dynamic.linux-large-s390x.key: "internal-prod-key"
+#  dynamic.linux-large-s390x.subnet: "konflux-internal-ocp-art-vpc-subnet"
+#  dynamic.linux-large-s390x.image-id: "r006-7af05e6b-b1cd-4467-8a37-770ce2094e8d"
+#  dynamic.linux-large-s390x.region: "us-south-2"
+#  dynamic.linux-large-s390x.url: "https://us-south.iaas.cloud.ibm.com/v1"
+#  dynamic.linux-large-s390x.profile: "bz2-4x16"
+#  dynamic.linux-large-s390x.max-instances: "30"
+#  dynamic.linux-large-s390x.private-ip: "true"
+#  dynamic.linux-large-s390x.allocation-timeout: "1800"
+#  dynamic.linux-large-s390x.instance-tag: prod-s390x-large
+#
+#  ## IBM s390x with 8CPU 16GiB RAM ####
+#  dynamic.linux-largecpu-s390x.type: ibmz
+#  dynamic.linux-largecpu-s390x.ssh-secret: "internal-prod-ibm-ssh-key"
+#  dynamic.linux-largecpu-s390x.secret: "internal-prod-ibm-api-key"
+#  dynamic.linux-largecpu-s390x.vpc: "konflux-internal-ocp-art-vpc"
+#  dynamic.linux-largecpu-s390x.key: "internal-prod-key"
+#  dynamic.linux-largecpu-s390x.subnet: "konflux-internal-ocp-art-vpc-subnet"
+#  dynamic.linux-largecpu-s390x.image-id: "r006-7af05e6b-b1cd-4467-8a37-770ce2094e8d"
+#  dynamic.linux-largecpu-s390x.region: "us-south-2"
+#  dynamic.linux-largecpu-s390x.url: "https://us-south.iaas.cloud.ibm.com/v1"
+#  dynamic.linux-largecpu-s390x.profile: "cz2-8x16"
+#  dynamic.linux-largecpu-s390x.max-instances: "5"
+#  dynamic.linux-largecpu-s390x.private-ip: "true"
+#  dynamic.linux-largecpu-s390x.allocation-timeout: "1800"
+#  dynamic.linux-largecpu-s390x.instance-tag: prod-s390x-largecpu
+#
+#  # Same as linux-largecpu-s390x, but with 250 GB disk
+#  dynamic.linux-d250-largecpu-s390x.type: ibmz
+#  dynamic.linux-d250-largecpu-s390x.ssh-secret: "internal-prod-ibm-ssh-key"
+#  dynamic.linux-d250-largecpu-s390x.secret: "internal-prod-ibm-api-key"
+#  dynamic.linux-d250-largecpu-s390x.vpc: "konflux-internal-ocp-art-vpc"
+#  dynamic.linux-d250-largecpu-s390x.key: "internal-prod-key"
+#  dynamic.linux-d250-largecpu-s390x.subnet: "konflux-internal-ocp-art-vpc-subnet"
+#  dynamic.linux-d250-largecpu-s390x.image-id: "r006-7af05e6b-b1cd-4467-8a37-770ce2094e8d"
+#  dynamic.linux-d250-largecpu-s390x.region: "us-south-2"
+#  dynamic.linux-d250-largecpu-s390x.url: "https://us-south.iaas.cloud.ibm.com/v1"
+#  dynamic.linux-d250-largecpu-s390x.profile: "cz2-8x16"
+#  dynamic.linux-d250-largecpu-s390x.max-instances: "5"
+#  dynamic.linux-d250-largecpu-s390x.private-ip: "true"
+#  dynamic.linux-d250-largecpu-s390x.allocation-timeout: "1800"
+#  dynamic.linux-d250-largecpu-s390x.instance-tag: prod-s390x-d250-largecpu
+#  dynamic.linux-d250-largecpu-s390x.disk: "250"
 
   #PPC64LE dynamic nodes
   dynamic.linux-ppc64le.type: ibmp


### PR DESCRIPTION
For the upcoming release, we change the provisioning way for s390x from dynamic to static.
All machines are `bz2-16x64 ` with a 1TB volume mount as `/home`