### PR TITLE
prod: allow authenticated metrics for namespace-lister

### DIFF
--- a/components/namespace-lister/production/base/kustomization.yaml
+++ b/components/namespace-lister/production/base/kustomization.yaml
@@ -13,7 +13,7 @@ namespace: namespace-lister
 images:
 - name: namespace-lister
   newName: quay.io/konflux-ci/namespace-lister
-  newTag: 7f96fde10f2612c324fdafe4b1d73b6949ccbcba
+  newTag: 7fdd5035064ffb27d1337ecffce42752f23f2548
 patches:
 - path: ./patches/with_cachenamespacelabelselector.yaml
   target:

--- a/components/namespace-lister/production/base/rbac.yaml
+++ b/components/namespace-lister/production/base/rbac.yaml
@@ -34,3 +34,11 @@ rules:
   - roles
   - rolebindings
   verbs: ["get", "list", "watch"]
+- apiGroups: ["authentication.k8s.io"]
+  resources:
+  - tokenreviews
+  verbs: ["create"]
+- apiGroups: ["authorization.k8s.io"]
+  resources:
+  - subjectaccessreviews
+  verbs: ["create"]


### PR DESCRIPTION
Rolls out #6169 to production clusters.