### PR TITLE
Only suggest TA pipelines for newer functionality

### DIFF
--- a/components/build-service/base/build-pipeline-config/build-pipeline-config.yaml
+++ b/components/build-service/base/build-pipeline-config/build-pipeline-config.yaml
@@ -19,11 +19,7 @@ data:
       bundle: quay.io/konflux-ci/tekton-catalog/pipeline-docker-build-multi-platform-oci-ta:89a3c55ccd2ae3923cd1a0d1c190989dc6013596
       additional-params:
       - build-platforms
-    - name: maven-zip-build
-      bundle: quay.io/konflux-ci/tekton-catalog/pipeline-maven-zip-build:89a3c55ccd2ae3923cd1a0d1c190989dc6013596
     - name: maven-zip-build-oci-ta
       bundle: quay.io/konflux-ci/tekton-catalog/pipeline-maven-zip-build-oci-ta:89a3c55ccd2ae3923cd1a0d1c190989dc6013596
-    - name: tekton-bundle-builder
-      bundle: quay.io/konflux-ci/tekton-catalog/pipeline-tekton-bundle-builder:89a3c55ccd2ae3923cd1a0d1c190989dc6013596
     - name: tekton-bundle-builder-oci-ta
       bundle: quay.io/konflux-ci/tekton-catalog/pipeline-tekton-bundle-builder-oci-ta:89a3c55ccd2ae3923cd1a0d1c190989dc6013596


### PR DESCRIPTION
Non-trusted artifact pipelines were added for newer functionality because we have both variants for the `docker-build` pipeline. While we can build these pipeline bundles, we don't need to offer them as an option to users unless there is a specific need for them.