### PR TITLE
Configure OCP cluster to use static PPC64le VMs

### DIFF
--- a/components/multi-platform-controller/production-downstream/kflux-ocp-p01/host-config.yaml
+++ b/components/multi-platform-controller/production-downstream/kflux-ocp-p01/host-config.yaml
@@ -825,104 +825,153 @@ data:
 #  dynamic.linux-d250-largecpu-s390x.instance-tag: prod-s390x-d250-largecpu
 #  dynamic.linux-d250-largecpu-s390x.disk: "250"
 
-  #PPC64LE dynamic nodes
-  dynamic.linux-ppc64le.type: ibmp
-  dynamic.linux-ppc64le.ssh-secret: "internal-prod-ibm-ssh-key"
-  dynamic.linux-ppc64le.secret: "internal-prod-ibm-api-key"
-  dynamic.linux-ppc64le.key: "prod-konflux-infra"
-  dynamic.linux-ppc64le.image: "ppc64le-rhel-94-base-27nov2024"
-  dynamic.linux-ppc64le.crn: "crn:v1:bluemix:public:power-iaas:dal12:a/eebc7153d0c844f9915fb6f3b9850a3b:d6faf373-c0b6-4ba9-b0bc-4f7e0a74f9d5::"
-  dynamic.linux-ppc64le.url: "https://us-south.power-iaas.cloud.ibm.com"
-  dynamic.linux-ppc64le.network: "4d164943-b043-4c6e-bba5-d233abf66c6a"
-  dynamic.linux-ppc64le.system: "e1080"
-  dynamic.linux-ppc64le.cores: "2"
-  dynamic.linux-ppc64le.memory: "8"
-  dynamic.linux-ppc64le.max-instances: "30"
-  dynamic.linux-ppc64le.allocation-timeout: "1800"
-  dynamic.linux-ppc64le.instance-tag: prod-ppc64le
 
-  # Same as linux-ppc64le but with 200GB disk instead of default 100GB
-  dynamic.linux-d200-ppc64le.type: ibmp
-  dynamic.linux-d200-ppc64le.ssh-secret: "internal-prod-ibm-ssh-key"
-  dynamic.linux-d200-ppc64le.secret: "internal-prod-ibm-api-key"
-  dynamic.linux-d200-ppc64le.key: "prod-konflux-infra"
-  dynamic.linux-d200-ppc64le.image: "ppc64le-rhel-94-base-27nov2024"
-  dynamic.linux-d200-ppc64le.crn: "crn:v1:bluemix:public:power-iaas:dal12:a/eebc7153d0c844f9915fb6f3b9850a3b:d6faf373-c0b6-4ba9-b0bc-4f7e0a74f9d5::"
-  dynamic.linux-d200-ppc64le.url: "https://us-south.power-iaas.cloud.ibm.com"
-  dynamic.linux-d200-ppc64le.network: "4d164943-b043-4c6e-bba5-d233abf66c6a"
-  dynamic.linux-d200-ppc64le.system: "e1080"
-  dynamic.linux-d200-ppc64le.cores: "2"
-  dynamic.linux-d200-ppc64le.memory: "8"
-  dynamic.linux-d200-ppc64le.max-instances: "30"
-  dynamic.linux-d200-ppc64le.allocation-timeout: "1800"
-  dynamic.linux-d200-ppc64le.disk: "200"
-  dynamic.linux-d200-ppc64le.instance-tag: prod-ppc64le-d200
+  host.ppc64le-static-1.address: "10.130.84.91"
+  host.ppc64le-static-1.platform: "linux/ppc64le"
+  host.ppc64le-static-1.user: "root"
+  host.ppc64le-static-1.secret: "internal-prod-ibm-ssh-key"
+  host.ppc64le-static-1.concurrency: "8"
 
-  #PPC64LE Large dynamic nodes
-  dynamic.linux-large-ppc64le.type: ibmp
-  dynamic.linux-large-ppc64le.ssh-secret: "internal-prod-ibm-ssh-key"
-  dynamic.linux-large-ppc64le.secret: "internal-prod-ibm-api-key"
-  dynamic.linux-large-ppc64le.key: "prod-konflux-infra"
-  dynamic.linux-large-ppc64le.image: "ppc64le-rhel-94-base-27nov2024"
-  dynamic.linux-large-ppc64le.crn: "crn:v1:bluemix:public:power-iaas:dal12:a/eebc7153d0c844f9915fb6f3b9850a3b:d6faf373-c0b6-4ba9-b0bc-4f7e0a74f9d5::"
-  dynamic.linux-large-ppc64le.url: "https://us-south.power-iaas.cloud.ibm.com"
-  dynamic.linux-large-ppc64le.network: "4d164943-b043-4c6e-bba5-d233abf66c6a"
-  dynamic.linux-large-ppc64le.system: "e1080"
-  dynamic.linux-large-ppc64le.cores: "4"
-  dynamic.linux-large-ppc64le.memory: "16"
-  dynamic.linux-large-ppc64le.max-instances: "50"
-  dynamic.linux-large-ppc64le.allocation-timeout: "1800"
-  dynamic.linux-large-ppc64le.instance-tag: prod-ppc64le-large
+  host.ppc64le-static-2.address: "10.130.84.192"
+  host.ppc64le-static-2.platform: "linux/ppc64le"
+  host.ppc64le-static-2.user: "root"
+  host.ppc64le-static-2.secret: "internal-prod-ibm-ssh-key"
+  host.ppc64le-static-2.concurrency: "8"
 
-  #PPC64LE CPU dynamic nodes
-  dynamic.linux-largecpu-ppc64le.type: ibmp
-  dynamic.linux-largecpu-ppc64le.ssh-secret: "internal-prod-ibm-ssh-key"
-  dynamic.linux-largecpu-ppc64le.secret: "internal-prod-ibm-api-key"
-  dynamic.linux-largecpu-ppc64le.key: "prod-konflux-infra"
-  dynamic.linux-largecpu-ppc64le.image: "ppc64le-rhel-94-base-27nov2024"
-  dynamic.linux-largecpu-ppc64le.crn: "crn:v1:bluemix:public:power-iaas:dal12:a/eebc7153d0c844f9915fb6f3b9850a3b:d6faf373-c0b6-4ba9-b0bc-4f7e0a74f9d5::"
-  dynamic.linux-largecpu-ppc64le.url: "https://us-south.power-iaas.cloud.ibm.com"
-  dynamic.linux-largecpu-ppc64le.network: "4d164943-b043-4c6e-bba5-d233abf66c6a"
-  dynamic.linux-largecpu-ppc64le.system: "e1080"
-  dynamic.linux-largecpu-ppc64le.cores: "8"
-  dynamic.linux-largecpu-ppc64le.memory: "16"
-  dynamic.linux-largecpu-ppc64le.max-instances: "15"
-  dynamic.linux-largecpu-ppc64le.allocation-timeout: "1800"
-  dynamic.linux-largecpu-ppc64le.instance-tag: prod-ppc64le-largecpu
+  host.ppc64le-static-3.address: "10.130.84.230"
+  host.ppc64le-static-3.platform: "linux/ppc64le"
+  host.ppc64le-static-3.user: "root"
+  host.ppc64le-static-3.secret: "internal-prod-ibm-ssh-key"
+  host.ppc64le-static-3.concurrency: "8"
 
-  # Same as linux-largecpu-ppc64le but with 250 GB disk
-  dynamic.linux-d250-largecpu-ppc64le.type: ibmp
-  dynamic.linux-d250-largecpu-ppc64le.ssh-secret: "internal-prod-ibm-ssh-key"
-  dynamic.linux-d250-largecpu-ppc64le.secret: "internal-prod-ibm-api-key"
-  dynamic.linux-d250-largecpu-ppc64le.key: "prod-konflux-infra"
-  dynamic.linux-d250-largecpu-ppc64le.image: "ppc64le-rhel-94-base-27nov2024"
-  dynamic.linux-d250-largecpu-ppc64le.crn: "crn:v1:bluemix:public:power-iaas:dal12:a/eebc7153d0c844f9915fb6f3b9850a3b:d6faf373-c0b6-4ba9-b0bc-4f7e0a74f9d5::"
-  dynamic.linux-d250-largecpu-ppc64le.url: "https://us-south.power-iaas.cloud.ibm.com"
-  dynamic.linux-d250-largecpu-ppc64le.network: "4d164943-b043-4c6e-bba5-d233abf66c6a"
-  dynamic.linux-d250-largecpu-ppc64le.system: "e1080"
-  dynamic.linux-d250-largecpu-ppc64le.cores: "8"
-  dynamic.linux-d250-largecpu-ppc64le.memory: "16"
-  dynamic.linux-d250-largecpu-ppc64le.max-instances: "15"
-  dynamic.linux-d250-largecpu-ppc64le.allocation-timeout: "1800"
-  dynamic.linux-d250-largecpu-ppc64le.instance-tag: ppc64le-d250-largecpu
-  dynamic.linux-d250-largecpu-ppc64le.disk: "250"
+  host.ppc64le-static-4.address: "10.130.84.12"
+  host.ppc64le-static-4.platform: "linux/ppc64le"
+  host.ppc64le-static-4.user: "root"
+  host.ppc64le-static-4.secret: "internal-prod-ibm-ssh-key"
+  host.ppc64le-static-4.concurrency: "8"
 
-  # Same as linux-large-ppc64le but with 200GB disk instead of default 100GB
-  dynamic.linux-d200-large-ppc64le.type: ibmp
-  dynamic.linux-d200-large-ppc64le.ssh-secret: "internal-prod-ibm-ssh-key"
-  dynamic.linux-d200-large-ppc64le.secret: "internal-prod-ibm-api-key"
-  dynamic.linux-d200-large-ppc64le.key: "prod-konflux-infra"
-  dynamic.linux-d200-large-ppc64le.image: "ppc64le-rhel-94-base-27nov2024"
-  dynamic.linux-d200-large-ppc64le.crn: "crn:v1:bluemix:public:power-iaas:dal12:a/eebc7153d0c844f9915fb6f3b9850a3b:d6faf373-c0b6-4ba9-b0bc-4f7e0a74f9d5::"
-  dynamic.linux-d200-large-ppc64le.url: "https://us-south.power-iaas.cloud.ibm.com"
-  dynamic.linux-d200-large-ppc64le.network: "4d164943-b043-4c6e-bba5-d233abf66c6a"
-  dynamic.linux-d200-large-ppc64le.system: "e1080"
-  dynamic.linux-d200-large-ppc64le.cores: "4"
-  dynamic.linux-d200-large-ppc64le.memory: "16"
-  dynamic.linux-d200-large-ppc64le.max-instances: "50"
-  dynamic.linux-d200-large-ppc64le.allocation-timeout: "1800"
-  dynamic.linux-d200-large-ppc64le.disk: "200"
-  dynamic.linux-d200-large-ppc64le.instance-tag: prod-ppc64le-d200-large
+  host.ppc64le-static-5.address: "10.130.84.30"
+  host.ppc64le-static-5.platform: "linux/ppc64le"
+  host.ppc64le-static-5.user: "root"
+  host.ppc64le-static-5.secret: "internal-prod-ibm-ssh-key"
+  host.ppc64le-static-5.concurrency: "8"
+
+  host.ppc64le-static-6.address: "10.130.84.97"
+  host.ppc64le-static-6.platform: "linux/ppc64le"
+  host.ppc64le-static-6.user: "root"
+  host.ppc64le-static-6.secret: "internal-prod-ibm-ssh-key"
+  host.ppc64le-static-6.concurrency: "8"
+
+  host.ppc64le-static-7.address: "10.130.84.165"
+  host.ppc64le-static-7.platform: "linux/ppc64le"
+  host.ppc64le-static-7.user: "root"
+  host.ppc64le-static-7.secret: "internal-prod-ibm-ssh-key"
+  host.ppc64le-static-7.concurrency: "8"
+
+  host.ppc64le-static-8.address: "10.130.84.210"
+  host.ppc64le-static-8.platform: "linux/ppc64le"
+  host.ppc64le-static-8.user: "root"
+  host.ppc64le-static-8.secret: "internal-prod-ibm-ssh-key"
+  host.ppc64le-static-8.concurrency: "8"
+
+  # #PPC64LE dynamic nodes
+  # dynamic.linux-ppc64le.type: ibmp
+  # dynamic.linux-ppc64le.ssh-secret: "internal-prod-ibm-ssh-key"
+  # dynamic.linux-ppc64le.secret: "internal-prod-ibm-api-key"
+  # dynamic.linux-ppc64le.key: "prod-konflux-infra"
+  # dynamic.linux-ppc64le.image: "ppc64le-rhel-94-base-27nov2024"
+  # dynamic.linux-ppc64le.crn: "crn:v1:bluemix:public:power-iaas:dal12:a/eebc7153d0c844f9915fb6f3b9850a3b:d6faf373-c0b6-4ba9-b0bc-4f7e0a74f9d5::"
+  # dynamic.linux-ppc64le.url: "https://us-south.power-iaas.cloud.ibm.com"
+  # dynamic.linux-ppc64le.network: "4d164943-b043-4c6e-bba5-d233abf66c6a"
+  # dynamic.linux-ppc64le.system: "e1080"
+  # dynamic.linux-ppc64le.cores: "2"
+  # dynamic.linux-ppc64le.memory: "8"
+  # dynamic.linux-ppc64le.max-instances: "30"
+  # dynamic.linux-ppc64le.allocation-timeout: "1800"
+  # dynamic.linux-ppc64le.instance-tag: prod-ppc64le
+
+  # # Same as linux-ppc64le but with 200GB disk instead of default 100GB
+  # dynamic.linux-d200-ppc64le.type: ibmp
+  # dynamic.linux-d200-ppc64le.ssh-secret: "internal-prod-ibm-ssh-key"
+  # dynamic.linux-d200-ppc64le.secret: "internal-prod-ibm-api-key"
+  # dynamic.linux-d200-ppc64le.key: "prod-konflux-infra"
+  # dynamic.linux-d200-ppc64le.image: "ppc64le-rhel-94-base-27nov2024"
+  # dynamic.linux-d200-ppc64le.crn: "crn:v1:bluemix:public:power-iaas:dal12:a/eebc7153d0c844f9915fb6f3b9850a3b:d6faf373-c0b6-4ba9-b0bc-4f7e0a74f9d5::"
+  # dynamic.linux-d200-ppc64le.url: "https://us-south.power-iaas.cloud.ibm.com"
+  # dynamic.linux-d200-ppc64le.network: "4d164943-b043-4c6e-bba5-d233abf66c6a"
+  # dynamic.linux-d200-ppc64le.system: "e1080"
+  # dynamic.linux-d200-ppc64le.cores: "2"
+  # dynamic.linux-d200-ppc64le.memory: "8"
+  # dynamic.linux-d200-ppc64le.max-instances: "30"
+  # dynamic.linux-d200-ppc64le.allocation-timeout: "1800"
+  # dynamic.linux-d200-ppc64le.disk: "200"
+  # dynamic.linux-d200-ppc64le.instance-tag: prod-ppc64le-d200
+
+  # #PPC64LE Large dynamic nodes
+  # dynamic.linux-large-ppc64le.type: ibmp
+  # dynamic.linux-large-ppc64le.ssh-secret: "internal-prod-ibm-ssh-key"
+  # dynamic.linux-large-ppc64le.secret: "internal-prod-ibm-api-key"
+  # dynamic.linux-large-ppc64le.key: "prod-konflux-infra"
+  # dynamic.linux-large-ppc64le.image: "ppc64le-rhel-94-base-27nov2024"
+  # dynamic.linux-large-ppc64le.crn: "crn:v1:bluemix:public:power-iaas:dal12:a/eebc7153d0c844f9915fb6f3b9850a3b:d6faf373-c0b6-4ba9-b0bc-4f7e0a74f9d5::"
+  # dynamic.linux-large-ppc64le.url: "https://us-south.power-iaas.cloud.ibm.com"
+  # dynamic.linux-large-ppc64le.network: "4d164943-b043-4c6e-bba5-d233abf66c6a"
+  # dynamic.linux-large-ppc64le.system: "e1080"
+  # dynamic.linux-large-ppc64le.cores: "4"
+  # dynamic.linux-large-ppc64le.memory: "16"
+  # dynamic.linux-large-ppc64le.max-instances: "50"
+  # dynamic.linux-large-ppc64le.allocation-timeout: "1800"
+  # dynamic.linux-large-ppc64le.instance-tag: prod-ppc64le-large
+
+  # #PPC64LE CPU dynamic nodes
+  # dynamic.linux-largecpu-ppc64le.type: ibmp
+  # dynamic.linux-largecpu-ppc64le.ssh-secret: "internal-prod-ibm-ssh-key"
+  # dynamic.linux-largecpu-ppc64le.secret: "internal-prod-ibm-api-key"
+  # dynamic.linux-largecpu-ppc64le.key: "prod-konflux-infra"
+  # dynamic.linux-largecpu-ppc64le.image: "ppc64le-rhel-94-base-27nov2024"
+  # dynamic.linux-largecpu-ppc64le.crn: "crn:v1:bluemix:public:power-iaas:dal12:a/eebc7153d0c844f9915fb6f3b9850a3b:d6faf373-c0b6-4ba9-b0bc-4f7e0a74f9d5::"
+  # dynamic.linux-largecpu-ppc64le.url: "https://us-south.power-iaas.cloud.ibm.com"
+  # dynamic.linux-largecpu-ppc64le.network: "4d164943-b043-4c6e-bba5-d233abf66c6a"
+  # dynamic.linux-largecpu-ppc64le.system: "e1080"
+  # dynamic.linux-largecpu-ppc64le.cores: "8"
+  # dynamic.linux-largecpu-ppc64le.memory: "16"
+  # dynamic.linux-largecpu-ppc64le.max-instances: "15"
+  # dynamic.linux-largecpu-ppc64le.allocation-timeout: "1800"
+  # dynamic.linux-largecpu-ppc64le.instance-tag: prod-ppc64le-largecpu
+
+  # # Same as linux-largecpu-ppc64le but with 250 GB disk
+  # dynamic.linux-d250-largecpu-ppc64le.type: ibmp
+  # dynamic.linux-d250-largecpu-ppc64le.ssh-secret: "internal-prod-ibm-ssh-key"
+  # dynamic.linux-d250-largecpu-ppc64le.secret: "internal-prod-ibm-api-key"
+  # dynamic.linux-d250-largecpu-ppc64le.key: "prod-konflux-infra"
+  # dynamic.linux-d250-largecpu-ppc64le.image: "ppc64le-rhel-94-base-27nov2024"
+  # dynamic.linux-d250-largecpu-ppc64le.crn: "crn:v1:bluemix:public:power-iaas:dal12:a/eebc7153d0c844f9915fb6f3b9850a3b:d6faf373-c0b6-4ba9-b0bc-4f7e0a74f9d5::"
+  # dynamic.linux-d250-largecpu-ppc64le.url: "https://us-south.power-iaas.cloud.ibm.com"
+  # dynamic.linux-d250-largecpu-ppc64le.network: "4d164943-b043-4c6e-bba5-d233abf66c6a"
+  # dynamic.linux-d250-largecpu-ppc64le.system: "e1080"
+  # dynamic.linux-d250-largecpu-ppc64le.cores: "8"
+  # dynamic.linux-d250-largecpu-ppc64le.memory: "16"
+  # dynamic.linux-d250-largecpu-ppc64le.max-instances: "15"
+  # dynamic.linux-d250-largecpu-ppc64le.allocation-timeout: "1800"
+  # dynamic.linux-d250-largecpu-ppc64le.instance-tag: ppc64le-d250-largecpu
+  # dynamic.linux-d250-largecpu-ppc64le.disk: "250"
+
+  # # Same as linux-large-ppc64le but with 200GB disk instead of default 100GB
+  # dynamic.linux-d200-large-ppc64le.type: ibmp
+  # dynamic.linux-d200-large-ppc64le.ssh-secret: "internal-prod-ibm-ssh-key"
+  # dynamic.linux-d200-large-ppc64le.secret: "internal-prod-ibm-api-key"
+  # dynamic.linux-d200-large-ppc64le.key: "prod-konflux-infra"
+  # dynamic.linux-d200-large-ppc64le.image: "ppc64le-rhel-94-base-27nov2024"
+  # dynamic.linux-d200-large-ppc64le.crn: "crn:v1:bluemix:public:power-iaas:dal12:a/eebc7153d0c844f9915fb6f3b9850a3b:d6faf373-c0b6-4ba9-b0bc-4f7e0a74f9d5::"
+  # dynamic.linux-d200-large-ppc64le.url: "https://us-south.power-iaas.cloud.ibm.com"
+  # dynamic.linux-d200-large-ppc64le.network: "4d164943-b043-4c6e-bba5-d233abf66c6a"
+  # dynamic.linux-d200-large-ppc64le.system: "e1080"
+  # dynamic.linux-d200-large-ppc64le.cores: "4"
+  # dynamic.linux-d200-large-ppc64le.memory: "16"
+  # dynamic.linux-d200-large-ppc64le.max-instances: "50"
+  # dynamic.linux-d200-large-ppc64le.allocation-timeout: "1800"
+  # dynamic.linux-d200-large-ppc64le.disk: "200"
+  # dynamic.linux-d200-large-ppc64le.instance-tag: prod-ppc64le-d200-large
 
   # AWS GPU Nodes
   dynamic.linux-g6xlarge-amd64.type: aws


### PR DESCRIPTION
Multi-architectural builds in the OCP cluster are timing out due to waiting for PPC VMs to be provisioned. To decrease the time needed to complete the build, a set of static VMs is provisioned so that the only wait time is for if a VM is at its current concurrency limit.