### PR TITLE
feat(RELEASE-1541): use trusted artifacts (#6147)

### DIFF
--- a/components/release/production/release_service_config.yaml
+++ b/components/release/production/release_service_config.yaml
@@ -7,7 +7,7 @@ spec:
   EmptyDirOverrides:
     - url: ".*"
       revision: ".*"
-      pathInRepo: "pipelines/managed/rh-advisories/rh-advisories-oci-ta.yaml"
+      pathInRepo: "pipelines/managed/rh-advisories/rh-advisories.yaml"
     - url: ".*"
       revision: ".*"
-      pathInRepo: "pipelines/managed/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io-oci-ta.yaml"
+      pathInRepo: "pipelines/managed/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io.yaml"


### PR DESCRIPTION
- enable emptyDirs for rh-advisory and rh-push-to-registry-redhat-io in production