### PR TITLE
Fix PaC's custom console URL in prod

### DIFF
--- a/components/pipeline-service/production/kflux-ocp-p01/deploy.yaml
+++ b/components/pipeline-service/production/kflux-ocp-p01/deploy.yaml
@@ -2441,10 +2441,10 @@ spec:
         settings:
           application-name: Konflux OCP
           custom-console-name: Konflux OCP
-          custom-console-url: https://konflux.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com
-          custom-console-url-pr-details: https://konflux.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/application-pipeline/ns/{{
+          custom-console-url: https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com
+          custom-console-url-pr-details: https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/{{
             namespace }}/pipelinerun/{{ pr }}
-          custom-console-url-pr-tasklog: https://konflux.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/application-pipeline/ns/{{
+          custom-console-url-pr-tasklog: https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/{{
             namespace }}/pipelinerun/{{ pr }}/logs/{{ task }}
   profile: all
   pruner:

--- a/components/pipeline-service/production/stone-prd-m01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prd-m01/deploy.yaml
@@ -2441,10 +2441,10 @@ spec:
         settings:
           application-name: Red Hat Konflux
           custom-console-name: Red Hat Konflux
-          custom-console-url: https://console.redhat.com/application-pipeline
-          custom-console-url-pr-details: https://console.redhat.com/application-pipeline/ns/{{
+          custom-console-url: https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/
+          custom-console-url-pr-details: https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/{{
             namespace }}/pipelinerun/{{ pr }}
-          custom-console-url-pr-tasklog: https://console.redhat.com/application-pipeline/ns/{{
+          custom-console-url-pr-tasklog: https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/{{
             namespace }}/pipelinerun/{{ pr }}/logs/{{ task }}
           remember-ok-to-test: "false"
   profile: all

--- a/components/pipeline-service/production/stone-prd-rh01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prd-rh01/deploy.yaml
@@ -2441,10 +2441,10 @@ spec:
         settings:
           application-name: Red Hat Konflux
           custom-console-name: Red Hat Konflux
-          custom-console-url: https://console.redhat.com/application-pipeline
-          custom-console-url-pr-details: https://console.redhat.com/application-pipeline/ns/{{
+          custom-console-url: https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/
+          custom-console-url-pr-details: https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/{{
             namespace }}/pipelinerun/{{ pr }}
-          custom-console-url-pr-tasklog: https://console.redhat.com/application-pipeline/ns/{{
+          custom-console-url-pr-tasklog: https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/{{
             namespace }}/pipelinerun/{{ pr }}/logs/{{ task }}
           remember-ok-to-test: "false"
   profile: all

--- a/components/pipeline-service/production/stone-prod-p01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prod-p01/deploy.yaml
@@ -2441,10 +2441,10 @@ spec:
         settings:
           application-name: Konflux Production Internal
           custom-console-name: Konflux Production Internal
-          custom-console-url: https://konflux.apps.stone-prod-p01.wcfb.p1.openshiftapps.com
-          custom-console-url-pr-details: https://konflux.apps.stone-prod-p01.wcfb.p1.openshiftapps.com/application-pipeline/ns/{{
+          custom-console-url: https://konflux-ui.apps.stone-prod-p01.wcfb.p1.openshiftapps.com
+          custom-console-url-pr-details: https://konflux-ui.apps.stone-prod-p01.wcfb.p1.openshiftapps.com/ns/{{
             namespace }}/pipelinerun/{{ pr }}
-          custom-console-url-pr-tasklog: https://konflux.apps.stone-prod-p01.wcfb.p1.openshiftapps.com/application-pipeline/ns/{{
+          custom-console-url-pr-tasklog: https://konflux-ui.apps.stone-prod-p01.wcfb.p1.openshiftapps.com/ns/{{
             namespace }}/pipelinerun/{{ pr }}/logs/{{ task }}
           remember-ok-to-test: "false"
   profile: all

--- a/components/pipeline-service/production/stone-prod-p02/deploy.yaml
+++ b/components/pipeline-service/production/stone-prod-p02/deploy.yaml
@@ -2441,10 +2441,10 @@ spec:
         settings:
           application-name: Konflux Production Internal
           custom-console-name: Konflux Production Internal
-          custom-console-url: https://konflux.apps.stone-prod-p02.hjvn.p1.openshiftapps.com
-          custom-console-url-pr-details: https://konflux.apps.stone-prod-p02.hjvn.p1.openshiftapps.com/application-pipeline/ns/{{
+          custom-console-url: https://konflux-ui.apps.stone-prod-p02.hjvn.p1.openshiftapps.com
+          custom-console-url-pr-details: https://konflux-ui.apps.stone-prod-p02.hjvn.p1.openshiftapps.com/ns/{{
             namespace }}/pipelinerun/{{ pr }}
-          custom-console-url-pr-tasklog: https://konflux.apps.stone-prod-p02.hjvn.p1.openshiftapps.com/application-pipeline/ns/{{
+          custom-console-url-pr-tasklog: https://konflux-ui.apps.stone-prod-p02.hjvn.p1.openshiftapps.com/ns/{{
             namespace }}/pipelinerun/{{ pr }}/logs/{{ task }}
           remember-ok-to-test: "false"
   profile: all


### PR DESCRIPTION
In b1f11c0a2aa04c446dd4180ad9dd9f3f384e1f90, the PaC URLs were changed in the src files but deploy.yaml files were not regenerated.