### PR TITLE
Set up RBAC to kubearchive group

### DIFF
--- a/components/kubearchive/base/rbac.yaml
+++ b/components/kubearchive/base/rbac.yaml
@@ -1,4 +1,32 @@
 ---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: kubearchive-api-proxy
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - services/proxy
+    verbs:
+      - get
+    resourceNames:
+      - https:kubearchive-api-server:server
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: api-proxy-default-test
+  namespace: kubearchive
+subjects:
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: konflux-kubearchive  # rover group
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kubearchive-api-proxy
+---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:


### PR DESCRIPTION
Allow access to kubearchive API through proxy

This configuration allows to access the KubeArchive API the following way:

```bash
curl -k -H "Authorization: Bearer $(oc whoami --show-token)" "https://api.stone-stg-rh01.l2vh.p1.openshiftapps.com:6443/api/v1/namespaces/kubearchive/services/https:kubearchive-api-server:server/proxy/livez"
```

This is needed for the cli, and any other KubeArchive API client (like Konflux UI)

We will need to extend this to every authenticated user within the cluster through a ClusterRoleBinding to allow Konflux users to use this API.
I will create a ticket for this.
