### PR TITLE
Rollout new Component Service Account model to production

### DIFF
--- a/components/build-service/production/base/kustomization.yaml
+++ b/components/build-service/production/base/kustomization.yaml
@@ -3,14 +3,14 @@ kind: Kustomization
 resources:
 - ../../base
 - ../../base/external-secrets
-- https://github.com/konflux-ci/build-service/config/default?ref=79c8a5dd15a84294d1b16a705c2bffc1d4c16e1a
+- https://github.com/konflux-ci/build-service/config/default?ref=2cbb127f9c43c8e827053c217554ae46235f3f5b
 
 namespace: build-service
 
 images:
 - name: quay.io/konflux-ci/build-service
   newName: quay.io/konflux-ci/build-service
-  newTag: 79c8a5dd15a84294d1b16a705c2bffc1d4c16e1a
+  newTag: 2cbb127f9c43c8e827053c217554ae46235f3f5b
 
 commonAnnotations:
   argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true

--- a/components/image-controller/production/base/kustomization.yaml
+++ b/components/image-controller/production/base/kustomization.yaml
@@ -3,12 +3,12 @@ kind: Kustomization
 resources:
 - ../../base
 - ../../base/external-secrets
-- https://github.com/konflux-ci/image-controller/config/default?ref=1b554f3db76d4a443f991f608f594c0f8d6efac6
+- https://github.com/konflux-ci/image-controller/config/default?ref=5202f9a251a48769c129e588a45bedd0b9ea352b
 
 images:
 - name: quay.io/konflux-ci/image-controller
   newName: quay.io/konflux-ci/image-controller
-  newTag: 1b554f3db76d4a443f991f608f594c0f8d6efac6
+  newTag: 5202f9a251a48769c129e588a45bedd0b9ea352b
 
 namespace: image-controller
 


### PR DESCRIPTION
This PR promotes [Build Service](https://github.com/redhat-appstudio/infra-deployments/pull/6165) and[ Image Controller](https://github.com/redhat-appstudio/infra-deployments/pull/6164) changes together, to rollout dedicated build pipeline Service Account per Component model to production clusters.