### PR TITLE
MintMaker: Deploy Redis for Renovate cache in stage

### DIFF
--- a/components/mintmaker/base/redis-cache/kustomization.yaml
+++ b/components/mintmaker/base/redis-cache/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- redis-configmap.yaml
+- redis-deployment.yaml
+- redis-networkpolicy.yaml
+- redis-pvc.yaml
+- redis-service.yaml
+namespace: mintmaker

--- a/components/mintmaker/base/redis-cache/redis-configmap.yaml
+++ b/components/mintmaker/base/redis-cache/redis-configmap.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redis-config
+  namespace: mintmaker
+data:
+  redis.conf: |
+    bind 0.0.0.0
+    protected-mode no
+    port 6379
+    maxmemory 800mb
+    maxmemory-policy allkeys-lru
+    dir /var/lib/redis/data
+
+    appendonly yes
+    aof-use-rdb-preamble yes
+    appendfsync everysec
+
+    save 900 1
+    save 300 10
+    save 60 10000
+
+    logfile ""
+    loglevel notice
+

--- a/components/mintmaker/base/redis-cache/redis-deployment.yaml
+++ b/components/mintmaker/base/redis-cache/redis-deployment.yaml
@@ -1,0 +1,51 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis
+  namespace: mintmaker
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: redis
+  template:
+    metadata:
+      labels:
+        app: redis
+    spec:
+      serviceAccountName: mintmaker-controller-manager
+      securityContext:
+        fsGroup: 1001
+      containers:
+        - name: redis
+          image: registry.redhat.io/rhel9/redis-7:9.5
+          ports:
+            - containerPort: 6379
+          command: ["container-entrypoint"]
+          args: ["run-redis"]
+          resources:
+            requests:
+              memory: "800Mi"
+              cpu: "0.75"
+            limits:
+              memory: "1Gi"
+              cpu: "1"
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1001
+            readOnlyRootFilesystem: true
+          volumeMounts:
+            - name: redis-data
+              mountPath: /var/lib/redis/data
+            - name: redis-config
+              mountPath: /etc/redis/redis.conf
+              subPath: redis.conf
+      volumes:
+        - name: redis-data
+          persistentVolumeClaim:
+            claimName: redis-pvc
+        - name: redis-config
+          configMap:
+            name: redis-config

--- a/components/mintmaker/base/redis-cache/redis-networkpolicy.yaml
+++ b/components/mintmaker/base/redis-cache/redis-networkpolicy.yaml
@@ -1,0 +1,12 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: restrict-redis-access
+  namespace: mintmaker
+spec:
+  podSelector:
+    matchLabels:
+      app: redis
+  ingress:
+  - from:
+    - podSelector: {}

--- a/components/mintmaker/base/redis-cache/redis-pvc.yaml
+++ b/components/mintmaker/base/redis-cache/redis-pvc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: redis-pvc
+  namespace: mintmaker
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi

--- a/components/mintmaker/base/redis-cache/redis-service.yaml
+++ b/components/mintmaker/base/redis-cache/redis-service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis
+  namespace: mintmaker
+spec:
+  selector:
+    app: redis
+  ports:
+    - port: 6379
+      targetPort: 6379
+  type: ClusterIP

--- a/components/mintmaker/development/kustomization.yaml
+++ b/components/mintmaker/development/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../base
+  - ../base/redis-cache
   - https://github.com/konflux-ci/mintmaker/config/default?ref=74f0afef5157cdb7bce03e63efb793fece700af6
   - https://github.com/konflux-ci/mintmaker/config/renovate?ref=74f0afef5157cdb7bce03e63efb793fece700af6
 

--- a/components/mintmaker/staging/base/kustomization.yaml
+++ b/components/mintmaker/staging/base/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
 - ../../base
 - ../../base/external-secrets
+- ../../base/redis-cache
 - https://github.com/konflux-ci/mintmaker/config/default?ref=74f0afef5157cdb7bce03e63efb793fece700af6
 - https://github.com/konflux-ci/mintmaker/config/renovate?ref=74f0afef5157cdb7bce03e63efb793fece700af6
 


### PR DESCRIPTION
Redis will be used by renovate PLRs to store and retrieve cache in order to improve performance and decrease the number of API calls. Connection is not password protected, but a network policy exists to restrict access only to pods in the "mintmaker" namespace. I think that a password is unnecessary since it would complicate the deployment and no sensitive or important data will be stored in the database. The persistent volume exists to back up the data so that Redis can reload it after restart.

The memory limit was chosen somewhat arbitrarily, but we can increase it if high use is observed over time. OOM errors should not happen since Redis limit is configured lower than Openshift limit.