### PR TITLE
Expose KubeArchive API 

### DIFF
--- a/components/konflux-ui/staging/base/proxy/nginx.conf
+++ b/components/konflux-ui/staging/base/proxy/nginx.conf
@@ -96,6 +96,16 @@ http {
             include /mnt/nginx-generated-config/auth.conf;
         }
 
+
+        location /api/k8s/plugins/kubearchive/ {
+            auth_request /oauth2/auth;
+
+            rewrite /api/k8s/plugins/kubearchive/(.+) /$1 break;
+            proxy_read_timeout 30m;
+            include /mnt/nginx-generated-config/kubearchive.conf;
+            include /mnt/nginx-generated-config/auth.conf;
+        }
+
         # GET requests to /api/k8s/api/v1/namespaces and /api/k8s/api/v1/namespaces/
         # are handled from the namespace-lister.
         # Requests with other methods are handled by the Kube-API

--- a/components/konflux-ui/staging/base/proxy/proxy.yaml
+++ b/components/konflux-ui/staging/base/proxy/proxy.yaml
@@ -80,6 +80,10 @@ spec:
             echo \
               "proxy_pass ${TEKTON_RESULTS_URL:?tekton results url must be provided};" \
               > /mnt/nginx-generated-config/tekton-results.conf
+            
+            echo \
+              "proxy_pass ${KUBEARCHIVE_URL:?kubearchive url must be provided};" \
+              > /mnt/nginx-generated-config/kubearchive.conf
 
         volumeMounts:
         - name: nginx-generated-config

--- a/components/konflux-ui/staging/stone-stage-p01/kustomization.yaml
+++ b/components/konflux-ui/staging/stone-stage-p01/kustomization.yaml
@@ -13,6 +13,7 @@ configMapGenerator:
   literals:
     - IMPERSONATE=true
     - TEKTON_RESULTS_URL=https://tekton-results-api-service.tekton-results.svc.cluster.local:8080
+    - KUBEARCHIVE_URL=https://kubearchive-api-server.product-kubearchive.svc.cluster.local:8081
 
 patches:
 - path: add-service-certs-patch.yaml

--- a/components/konflux-ui/staging/stone-stg-rh01/kustomization.yaml
+++ b/components/konflux-ui/staging/stone-stg-rh01/kustomization.yaml
@@ -13,6 +13,7 @@ configMapGenerator:
   literals:
     - IMPERSONATE=true
     - TEKTON_RESULTS_URL=https://tekton-results-api-service.tekton-results.svc.cluster.local:8080
+    - KUBEARCHIVE_URL=https://kubearchive-api-server.product-kubearchive.svc.cluster.local:8081
 
 patches:
 - path: add-service-certs-patch.yaml

--- a/components/kubearchive/base/kubearchive-routes.yaml
+++ b/components/kubearchive/base/kubearchive-routes.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "0"
+    haproxy.router.openshift.io/hsts_header: max-age=63072000
+    haproxy.router.openshift.io/timeout: 86410s
+    openshift.io/host.generated: "true"
+    router.openshift.io/haproxy.health.check.interval: 86400s
+  labels:
+    app.kubernetes.io/name: "kubearchive-api-server"
+    app.kubernetes.io/component: api-server
+    app.kubernetes.io/part-of: kubearchive
+  name: kubearchive-api-server
+  namespace: product-kubearchive
+spec:
+  port:
+    targetPort: server
+  tls:
+    insecureEdgeTerminationPolicy: Redirect
+    termination: reencrypt
+  to:
+    kind: Service
+    name: kubearchive-api-server
+    weight: 100
+  wildcardPolicy: None


### PR DESCRIPTION
Configure nginx proxy in Konflux UI so it can access it from staging.

The KubeArchive API is exposed with an Openshift Route, the same way it's done for Tekton Results.

I've replicated the NGINX configuration for Tekton Results in Konflux UI, but I haven't tested it. Please, let me know if it needs any changes.

