### PR TITLE
Install External secret operator version 0.11.0 on staging

### DIFF
--- a/components/external-secrets-operator/staging/starting-csv-patch.yaml
+++ b/components/external-secrets-operator/staging/starting-csv-patch.yaml
@@ -1,4 +1,4 @@
 ---
 - op: add
   path: /spec/startingCSV
-  value: external-secrets-operator.v0.9.1
+  value: external-secrets-operator.v0.11.0


### PR DESCRIPTION
We are starting at version 0.9.1 which is old, change to the latest version which support OLM.