### PR TITLE
fix: remove failing checks

### DIFF
--- a/components/release/base/monitor/production/configmap.yaml
+++ b/components/release/base/monitor/production/configmap.yaml
@@ -7,20 +7,11 @@ data:
       pool_interval: 120
       metrics_prefix: release_service
     checks:
-      git:
-        - name: github
-          url: https://github.com/konflux-ci/release-service-catalog
-          revision: production
-          path: pipelines/fbc-release/fbc-release.yaml
       quay:
         - name: quayio
           tags:
             - latest
           pullspec: quay.io/konflux-ci/release-service-utils
-      http:
-        - name: pyxis
-          url: https://pyxis.api.redhat.com/v1/ping
-          insecure: true
 kind: ConfigMap
 metadata:
   name: release-service-monitor-config


### PR DESCRIPTION
this PR remove the failing checks github and pyxis. github is fails due to throttling (needs the secret) and pyxis, the release account don't have access to the new secrets, so the check from the release
namespace needs to be ajusted.