### PR TITLE
Increase memory limit for crossplane controller in prod and staging

### DIFF
--- a/components/crossplane-control-plane/production/kustomization.yaml
+++ b/components/crossplane-control-plane/production/kustomization.yaml
@@ -1,6 +1,22 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
 resources:
 - ../base
 - provider-config.yaml
 
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
+patches:
+  - patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: crossplane
+        namespace: crossplane-system
+      spec:
+        template:
+          spec:
+            containers:
+              - name: crossplane
+                resources:
+                  limits:
+                    memory: 4Gi

--- a/components/crossplane-control-plane/staging/kustomization.yaml
+++ b/components/crossplane-control-plane/staging/kustomization.yaml
@@ -1,6 +1,22 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
 resources:
 - ../base
 - provider-config.yaml
 
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
+patches:
+  - patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: crossplane
+        namespace: crossplane-system
+      spec:
+        template:
+          spec:
+            containers:
+              - name: crossplane
+                resources:
+                  limits:
+                    memory: 4Gi


### PR DESCRIPTION
OOMKilled errors are occurring with the default 1Gi limit.