### PR TITLE
fixup(PVO11Y-4652): Only export idle-mode metrics

### DIFF
--- a/components/monitoring/prometheus/base/monitoringstack/monitoringstack.yaml
+++ b/components/monitoring/prometheus/base/monitoringstack/monitoringstack.yaml
@@ -161,7 +161,7 @@ spec:
         - '{__name__="kube_job_spec_completions"}'
         - '{__name__="kube_job_status_succeeded"}'
         - '{__name__="kube_job_status_failed"}'
-        - '{__name__="node_cpu_seconds_total"}'
+        - '{__name__="node_cpu_seconds_total", mode="idle"}'
         - '{__name__="node_memory_MemTotal_bytes"}'
         - '{__name__="node_memory_MemAvailable_bytes"}'
         - '{__name__="platform:hypershift_hostedclusters:max"}'


### PR DESCRIPTION
This stops exporting non-idle-mode CPU usage for labels we don't observe in dashboards or alerts.