### PR TITLE
Disable kyverno WebhookCleanup job in dev and stg

### DIFF
--- a/components/kyverno/development/kyverno-helm-values.yaml
+++ b/components/kyverno/development/kyverno-helm-values.yaml
@@ -69,6 +69,7 @@ policyReportsCleanup:
       drop:
       - "ALL"
 webhooksCleanup:
+  enable: false
   securityContext:
     allowPrivilegeEscalation: false
     readOnlyRootFilesystem: true

--- a/components/kyverno/staging/stone-stage-p01/kyverno-helm-values.yaml
+++ b/components/kyverno/staging/stone-stage-p01/kyverno-helm-values.yaml
@@ -78,6 +78,7 @@ policyReportsCleanup:
       drop:
       - "ALL"
 webhooksCleanup:
+  enable: false
   image:
     registry: mirror.gcr.io
   securityContext:

--- a/components/kyverno/staging/stone-stg-rh01/kyverno-helm-values.yaml
+++ b/components/kyverno/staging/stone-stg-rh01/kyverno-helm-values.yaml
@@ -78,6 +78,7 @@ policyReportsCleanup:
       drop:
       - "ALL"
 webhooksCleanup:
+  enable: false
   image:
     registry: mirror.gcr.io
   securityContext:


### PR DESCRIPTION
This will prevent the scale-to-zero job from being created.
This is not required in a GitOps environment, as the helm's `pre-delete` hook is not supported by ArgoCD and the effect of the scale-to-zero job will be reverted by ArgoCD itself.

cf:
* https://github.com/kyverno/kyverno/blob/77e2a860c8d0b66c65e2203d97348d19d2cb0136/charts/kyverno/templates/hooks/pre-delete-scale-to-zero.yaml#L11
* https://argo-cd.readthedocs.io/en/latest/user-guide/helm/#helm-hooks

Signed-off-by: Francesco Ilario <filario@redhat.com>
