### PR TITLE
fix: running ir shold not be removed

### DIFF
--- a/components/release/base/cronjobs/remove-internal-requests.yaml
+++ b/components/release/base/cronjobs/remove-internal-requests.yaml
@@ -31,7 +31,8 @@ spec:
                   YD=$(date -d 'yesterday' +%s)
                   kubectl get internalrequests --all-namespaces \
                   --sort-by=.status.completionTime \
-                  --template '{{range .items}}{{.metadata.name}}{{"\t"}}{{.metadata.namespace}}{{"\t"}}{{.status.completionTime}}{{"\n"}}{{end}}' > $KUBECTL_OUTPUT
+                  --template '{{range .items}}{{.metadata.name}}{{"\t"}}{{.metadata.namespace}}{{"\t"}}{{.status.completionTime}}{{"\n"}}{{end}}' \
+                    | grep -E "[0-9]{4}((-?)[0-9]{2})+T.*Z$" > $KUBECTL_OUTPUT
                   awk -v yesterday=${YD} '{
                        # parsing the completionTime and converting it to epoch
                        # so we can compute the precise IRs that should be deleted


### PR DESCRIPTION
this PR fixes the case where a running IR is
wrongly removed by the cronjob due to the missing
completionTime field, that is only added after
finishing the IR run.