### PR TITLE
deploy knative-eventing to stone-prod-p02

### DIFF
--- a/components/knative-eventing/production/stone-prod-p02/kustomization.yaml
+++ b/components/knative-eventing/production/stone-prod-p02/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../base


### PR DESCRIPTION
The ApplicationSet manifest for knative-eventing references deploying to stone-prod-p02, but no resources are actually deployed there.  Deploy knative-eventing's resources there just like the other clusters.