### PR TITLE
deploy knative-eventing to stone-stg-rh01

### DIFF
--- a/argo-cd-apps/base/member/infra-deployments/knative-eventing/knative-eventing.yaml
+++ b/argo-cd-apps/base/member/infra-deployments/knative-eventing/knative-eventing.yaml
@@ -20,6 +20,8 @@ spec:
                   values.clusterDir: kflux-ocp-p01
                 - nameNormalized: stone-stage-p01
                   values.clusterDir: stone-stage-p01
+                - nameNormalized: stone-stg-rh01
+                  values.clusterDir: stone-stg-rh01
                 - nameNormalized: stone-prod-p01
                   values.clusterDir: stone-prod-p01
                 - nameNormalized: stone-prod-p02

--- a/components/knative-eventing/staging/stone-stg-rh01/kustomization.yaml
+++ b/components/knative-eventing/staging/stone-stg-rh01/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base


### PR DESCRIPTION
It's on the production clusters and internal staging, no reason not to have it on external staging as well.