### PR TITLE
fix-up(PVO11Y-4652): Keep node cpu label

### DIFF
--- a/components/monitoring/prometheus/base/monitoringstack/monitoringstack.yaml
+++ b/components/monitoring/prometheus/base/monitoringstack/monitoringstack.yaml
@@ -52,7 +52,7 @@ spec:
           validation_reason|strategy|succeeded|target|name|method|code|sp|le|\
           unexpected_status|failure|hostname|label_app_kubernetes_io_managed_by|status|\
           pipeline|pipelinename|pipelinerun|schedule|check|grpc_service|grpc_code|\
-          grpc_method|lease|lease_holder|deployment|platform"
+          grpc_method|lease|lease_holder|deployment|platform|mode"
 ---
 # Grant permission to Federate In-Cluster Prometheus
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
Label mode required to export node cpu seconds metric