### PR TITLE
add konflux-viewer-user-actions role to stg and prod

### DIFF
--- a/components/konflux-rbac/production/base/konflux-viewer-user-actions.yaml
+++ b/components/konflux-rbac/production/base/konflux-viewer-user-actions.yaml
@@ -1,0 +1,127 @@
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: konflux-viewer-user-actions
+  labels:
+    konflux-cluster-role: "true"
+rules:
+  - verbs:
+      - get
+      - list
+      - watch
+    apiGroups:
+      - appstudio.redhat.com
+    resources:
+      - applications
+      - components
+      - imagerepositories
+  - verbs:
+      - get
+      - list
+      - watch
+    apiGroups:
+      - appstudio.redhat.com
+    resources:
+      - snapshots
+  - verbs:
+      - get
+      - list
+      - watch
+    apiGroups:
+      - tekton.dev
+    resources:
+      - pipelineruns
+      - taskruns
+  - verbs:
+      - get
+      - list
+    apiGroups:
+      - results.tekton.dev
+    resources:
+      - results
+      - records
+      - logs
+  - verbs:
+      - get
+      - list
+      - watch
+    apiGroups:
+      - appstudio.redhat.com
+    resources:
+      - integrationtestscenarios
+  - verbs:
+      - get
+      - list
+      - watch
+    apiGroups:
+      - appstudio.redhat.com
+    resources:
+      - enterprisecontractpolicies
+  - verbs:
+      - get
+      - list
+      - watch
+    apiGroups:
+      - appstudio.redhat.com
+    resources:
+      - releases
+      - releaseplans
+  - verbs:
+      - get
+      - list
+      - watch
+    apiGroups:
+      - appstudio.redhat.com
+    resources:
+      - releaseplanadmissions
+  - verbs:
+      - get
+      - list
+      - watch
+    apiGroups:
+      - jvmbuildservice.io
+    resources:
+      - jbsconfigs
+      - artifactbuilds
+  - verbs:
+      - get
+      - list
+      - watch
+    apiGroups:
+      - ''
+    resources:
+      - configmaps
+      - pods
+      - pods/log
+  - verbs:
+      - get
+      - list
+      - watch
+    apiGroups:
+      - projctl.konflux.dev
+    resources:
+      - projects
+      - projectdevelopmentstreams
+      - projectdevelopmentstreamtemplates
+  - verbs:
+      - get
+    apiGroups:
+      - ''
+    resources:
+      - namespaces
+  - verbs:
+      - get
+    apiGroups:
+      - project.openshift.io
+    resources:
+      - projects
+  - verbs:
+      - get
+      - list
+      - watch
+    apiGroups:
+      - batch
+    resources:
+      - cronjobs
+      - jobs

--- a/components/konflux-rbac/production/base/kustomization.yaml
+++ b/components/konflux-rbac/production/base/kustomization.yaml
@@ -4,4 +4,5 @@ resources:
   - konflux-admin-user-actions.yaml
   - konflux-maintainer-user-actions.yaml
   - konflux-contributor-user-actions.yaml
+  - konflux-viewer-user-actions.yaml
   - ../../policies/bootstrap-tenant-namespace/

--- a/components/konflux-rbac/staging/base/konflux-viewer-user-actions.yaml
+++ b/components/konflux-rbac/staging/base/konflux-viewer-user-actions.yaml
@@ -1,0 +1,127 @@
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: konflux-viewer-user-actions
+  labels:
+    konflux-cluster-role: "true"
+rules:
+  - verbs:
+      - get
+      - list
+      - watch
+    apiGroups:
+      - appstudio.redhat.com
+    resources:
+      - applications
+      - components
+      - imagerepositories
+  - verbs:
+      - get
+      - list
+      - watch
+    apiGroups:
+      - appstudio.redhat.com
+    resources:
+      - snapshots
+  - verbs:
+      - get
+      - list
+      - watch
+    apiGroups:
+      - tekton.dev
+    resources:
+      - pipelineruns
+      - taskruns
+  - verbs:
+      - get
+      - list
+    apiGroups:
+      - results.tekton.dev
+    resources:
+      - results
+      - records
+      - logs
+  - verbs:
+      - get
+      - list
+      - watch
+    apiGroups:
+      - appstudio.redhat.com
+    resources:
+      - integrationtestscenarios
+  - verbs:
+      - get
+      - list
+      - watch
+    apiGroups:
+      - appstudio.redhat.com
+    resources:
+      - enterprisecontractpolicies
+  - verbs:
+      - get
+      - list
+      - watch
+    apiGroups:
+      - appstudio.redhat.com
+    resources:
+      - releases
+      - releaseplans
+  - verbs:
+      - get
+      - list
+      - watch
+    apiGroups:
+      - appstudio.redhat.com
+    resources:
+      - releaseplanadmissions
+  - verbs:
+      - get
+      - list
+      - watch
+    apiGroups:
+      - jvmbuildservice.io
+    resources:
+      - jbsconfigs
+      - artifactbuilds
+  - verbs:
+      - get
+      - list
+      - watch
+    apiGroups:
+      - ''
+    resources:
+      - configmaps
+      - pods
+      - pods/log
+  - verbs:
+      - get
+      - list
+      - watch
+    apiGroups:
+      - projctl.konflux.dev
+    resources:
+      - projects
+      - projectdevelopmentstreams
+      - projectdevelopmentstreamtemplates
+  - verbs:
+      - get
+    apiGroups:
+      - ''
+    resources:
+      - namespaces
+  - verbs:
+      - get
+    apiGroups:
+      - project.openshift.io
+    resources:
+      - projects
+  - verbs:
+      - get
+      - list
+      - watch
+    apiGroups:
+      - batch
+    resources:
+      - cronjobs
+      - jobs

--- a/components/konflux-rbac/staging/base/kustomization.yaml
+++ b/components/konflux-rbac/staging/base/kustomization.yaml
@@ -4,4 +4,5 @@ resources:
   - konflux-admin-user-actions.yaml
   - konflux-maintainer-user-actions.yaml
   - konflux-contributor-user-actions.yaml
+  - konflux-viewer-user-actions.yaml
   - ../../policies/bootstrap-tenant-namespace/


### PR DESCRIPTION
Add the `konflux-viewer-user-actions` role. It provides the same rights the `konflux-contributor-user-actions `role provides.
It is required for the implementation of Public view feature.

Signed-off-by: Francesco Ilario <filario@redhat.com>
