### PR TITLE
konflux-rbac: disallow certain groups in rolebindings

### DIFF
--- a/components/konflux-rbac/policies/validate-rolebindings/.chainsaw-test/chainsaw-assert-clusterpolicy.yaml
+++ b/components/konflux-rbac/policies/validate-rolebindings/.chainsaw-test/chainsaw-assert-clusterpolicy.yaml
@@ -1,0 +1,9 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: restrict-binding-system-groups
+status:
+  conditions:
+  - reason: Succeeded
+    status: "True"
+    type: Ready

--- a/components/konflux-rbac/policies/validate-rolebindings/.chainsaw-test/chainsaw-test.yaml
+++ b/components/konflux-rbac/policies/validate-rolebindings/.chainsaw-test/chainsaw-test.yaml
@@ -1,0 +1,107 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: disallow-tenant-groups
+spec:
+  description: |
+    Asserts that rolebindings to restricted groups are denied in tenant namespaces
+  concurrent: false
+  namespace: 'deny-tenant-groups'
+  steps:
+  - name: "Given namespace has tenant label"
+    try:
+    - apply:
+        file: ./resources/tenant-namespace.yaml
+  - name: "Given cluster policy is ready"
+    try:
+    - apply:
+        file: ../invalid-subjects.yaml
+    - assert:
+        file: ./chainsaw-assert-clusterpolicy.yaml
+  - name: "When invalid rolebinding is applied, assert an error"
+    try:
+    - apply:
+        bindings:
+        - name: group
+          value: "system:anonymous"
+        file: ./resources/rolebinding.yaml
+        template: true
+        expect:
+        - match:
+            kind: RoleBinding
+          check:
+            ($error != null): true
+    - apply:
+        bindings:
+        - name: group
+          value: "system:masters"
+        file: ./resources/rolebinding.yaml
+        template: true
+        expect:
+        - match:
+            kind: RoleBinding
+          check:
+            ($error != null): true
+    - apply:
+        bindings:
+        - name: group
+          value: "system:unauthenticated"
+        file: ./resources/rolebinding.yaml
+        template: true
+        expect:
+        - match:
+            kind: RoleBinding
+          check:
+            ($error != null): true
+---
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: allow-system-groups-in-non-tenant-namespaces
+spec:
+  description: |
+    Asserts that rolebindings restricted groups are allowed in non-tenant namespaces
+  concurrent: false
+  namespace: 'allow-system-groups'
+  steps:
+  - name: "Given cluster policy is ready"
+    try:
+    - apply:
+        file: ../invalid-subjects.yaml
+    - assert:
+        file: ./chainsaw-assert-clusterpolicy.yaml
+  - name: "When valid rolebinding is applied, assert no error"
+    try:
+    - apply:
+        bindings:
+        - name: group
+          value: "system:anonymous"
+        file: ./resources/rolebinding.yaml
+        template: true
+        expect:
+        - match:
+            kind: RoleBinding
+          check:
+            ($error != null): false
+    - apply:
+        bindings:
+        - name: group
+          value: "system:masters"
+        file: ./resources/rolebinding.yaml
+        template: true
+        expect:
+        - match:
+            kind: RoleBinding
+          check:
+            ($error != null): false
+    - apply:
+        bindings:
+        - name: group
+          value: "system:unauthenticated"
+        file: ./resources/rolebinding.yaml
+        template: true
+        expect:
+        - match:
+            kind: RoleBinding
+          check:
+            ($error != null): false

--- a/components/konflux-rbac/policies/validate-rolebindings/.chainsaw-test/resources/masters-rolebinding.yaml
+++ b/components/konflux-rbac/policies/validate-rolebindings/.chainsaw-test/resources/masters-rolebinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: system:masters-admin
+  namespace: ($namespace)
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: admin
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:masters

--- a/components/konflux-rbac/policies/validate-rolebindings/.chainsaw-test/resources/rolebinding.yaml
+++ b/components/konflux-rbac/policies/validate-rolebindings/.chainsaw-test/resources/rolebinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: ($group)-admin
+  namespace: ($namespace)
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: admin
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: ($group)

--- a/components/konflux-rbac/policies/validate-rolebindings/.chainsaw-test/resources/tenant-namespace.yaml
+++ b/components/konflux-rbac/policies/validate-rolebindings/.chainsaw-test/resources/tenant-namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ($namespace)
+  labels:
+    konflux-ci.dev/type: tenant

--- a/components/konflux-rbac/policies/validate-rolebindings/invalid-subjects.yaml
+++ b/components/konflux-rbac/policies/validate-rolebindings/invalid-subjects.yaml
@@ -1,0 +1,30 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: restrict-binding-system-groups
+spec:
+  background: false
+  rules:
+  - name: deny-restricted-groups
+    match:
+      any:
+      - resources:
+          kinds:
+          - RoleBinding
+    context:
+    - name: konfluxtype
+      apiCall:
+        urlPath: "/api/v1/namespaces/{{ request.object.metadata.namespace }}"
+        jmesPath: 'metadata.labels."konflux-ci.dev/type" || ""'
+    preconditions:
+      all:
+      - key: "{{ konfluxtype }}"
+        operator: Equal
+        value: "tenant"
+      - key: "{{ request.object.subjects[].name }}"
+        operator: AnyIn
+        value: '["system:anonymous", "system:unauthenticated", "system:masters"]'
+    validate:
+      failureAction: Enforce
+      message: "RoleBindings to restricted system groups is not allowed in tenant namespaces."
+      deny: {}

--- a/components/konflux-rbac/policies/validate-rolebindings/kustomization.yaml
+++ b/components/konflux-rbac/policies/validate-rolebindings/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- invalid-subjects.yaml
+- kyverno_rbac.yaml

--- a/components/konflux-rbac/policies/validate-rolebindings/kyverno_rbac.yaml
+++ b/components/konflux-rbac/policies/validate-rolebindings/kyverno_rbac.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kyverno-admission:validate-rolebindings
+  labels:
+    rbac.kyverno.io/aggregate-to-admission-controller: "true"
+rules:
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - rolebindings
+  verbs:
+  - list
+  - get
+  - watch

--- a/components/konflux-rbac/staging/base/kustomization.yaml
+++ b/components/konflux-rbac/staging/base/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
   - konflux-viewer-user-actions.yaml
   - ../../policies/bootstrap-tenant-namespace/
   - ../../policies/restrict-binding-system-authenticated/
+  - ../../policies/validate-rolebindings/


### PR DESCRIPTION
Some groups should not be allowed access across the cluster for any reason.  Add a cluster policy to enforce this in the staging clusters.