### PR TITLE
Configure prod-p02 cluster to test static PVMs

### DIFF
--- a/components/multi-platform-controller/production-downstream/stone-prod-p02/host-config.yaml
+++ b/components/multi-platform-controller/production-downstream/stone-prod-p02/host-config.yaml
@@ -649,6 +649,54 @@ data:
   dynamic.linux-d200-large-s390x.disk: "200"
   dynamic.linux-d200-large-s390x.instance-tag: prod-d200-s390x-large
 
+  host.testppc64le-static-1.address: "10.130.74.90"
+  host.testppc64le-static-1.platform: "linux/testppc64le"
+  host.testppc64le-static-1.user: "root"
+  host.testppc64le-static-1.secret: "internal-prod-ibm-ssh-key"
+  host.testppc64le-static-1.concurrency: "8"
+
+  host.testppc64le-static-2.address: "10.130.75.60"
+  host.testppc64le-static-2.platform: "linux/testppc64le"
+  host.testppc64le-static-2.user: "root"
+  host.testppc64le-static-2.secret: "internal-prod-ibm-ssh-key"
+  host.testppc64le-static-2.concurrency: "8"
+
+  host.testppc64le-static-3.address: "10.130.73.71"
+  host.testppc64le-static-3.platform: "linux/testppc64le"
+  host.testppc64le-static-3.user: "root"
+  host.testppc64le-static-3.secret: "internal-prod-ibm-ssh-key"
+  host.testppc64le-static-3.concurrency: "8"
+
+  host.testppc64le-static-4.address: "10.130.73.187"
+  host.testppc64le-static-4.platform: "linux/testppc64le"
+  host.testppc64le-static-4.user: "root"
+  host.testppc64le-static-4.secret: "internal-prod-ibm-ssh-key"
+  host.testppc64le-static-4.concurrency: "8"
+
+  host.testppc64le-static-5.address: "10.130.73.142"
+  host.testppc64le-static-5.platform: "linux/testppc64le"
+  host.testppc64le-static-5.user: "root"
+  host.testppc64le-static-5.secret: "internal-prod-ibm-ssh-key"
+  host.testppc64le-static-5.concurrency: "8"
+
+  host.testppc64le-static-6.address: "10.130.74.34"
+  host.testppc64le-static-6.platform: "linux/testppc64le"
+  host.testppc64le-static-6.user: "root"
+  host.testppc64le-static-6.secret: "internal-prod-ibm-ssh-key"
+  host.testppc64le-static-6.concurrency: "8"
+
+  host.testppc64le-static-7.address: "10.130.73.237"
+  host.testppc64le-static-7.platform: "linux/testppc64le"
+  host.testppc64le-static-7.user: "root"
+  host.testppc64le-static-7.secret: "internal-prod-ibm-ssh-key"
+  host.testppc64le-static-7.concurrency: "8"
+
+  host.testppc64le-static-8.address: "10.130.72.108"
+  host.testppc64le-static-8.platform: "linux/testppc64le"
+  host.testppc64le-static-8.user: "root"
+  host.testppc64le-static-8.secret: "internal-prod-ibm-ssh-key"
+  host.testppc64le-static-8.concurrency: "8"
+
   # PPC64LE 2vCPU / 8GB RAM / 100GB disk
   dynamic.linux-ppc64le.type: ibmp
   dynamic.linux-ppc64le.ssh-secret: "internal-prod-ibm-ssh-key"


### PR DESCRIPTION
Multi-architectural builds in the prod-p02 cluster are timing out due to waiting for PPC VMs to be provisioned. To decrease the time needed to complete the build, a set of static VMs is provisioned so that the only wait time is for if a VM is at its current concurrency limit. These static VMs are currently prefaced with "test" so testing them will not interfere with current builds.