### PR TITLE
add restrict-binding-system-authenticated Policy

### DIFF
--- a/components/konflux-rbac/policies/restrict-binding-system-authenticated/.chainsaw-test/chainsaw-assert-clusterpolicy.yaml
+++ b/components/konflux-rbac/policies/restrict-binding-system-authenticated/.chainsaw-test/chainsaw-assert-clusterpolicy.yaml
@@ -1,0 +1,9 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: validate-restrict-binding-system-authenticated
+status:
+  conditions:
+  - reason: Succeeded
+    status: "True"
+    type: Ready

--- a/components/konflux-rbac/policies/restrict-binding-system-authenticated/.chainsaw-test/chainsaw-test.yaml
+++ b/components/konflux-rbac/policies/restrict-binding-system-authenticated/.chainsaw-test/chainsaw-test.yaml
@@ -63,6 +63,9 @@ spec:
     try:
     - apply:
         file: ./resources/valid-systemauthenticated-rolebinding.yaml
+        expect:
+        - check:
+            ($error != null): false
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
 apiVersion: chainsaw.kyverno.io/v1alpha1
@@ -90,3 +93,6 @@ spec:
     try:
     - apply:
         file: ./resources/valid-systemauthenticated-rolebinding.yaml
+        expect:
+        - check:
+            ($error != null): false

--- a/components/konflux-rbac/policies/restrict-binding-system-authenticated/.chainsaw-test/chainsaw-test.yaml
+++ b/components/konflux-rbac/policies/restrict-binding-system-authenticated/.chainsaw-test/chainsaw-test.yaml
@@ -1,0 +1,92 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: in-tenant-invalid-rolebinding
+spec:
+  description: |
+    tests that the a invalid RoleBinding can NOT be created
+    in a tenant namespace
+  concurrent: true
+  namespace: 'invalid-systemauthenticated-rb-tenant-namespace'
+  steps:
+  - name: given-kyverno-has-permission-on-resources
+    try:
+    - apply:
+        file: ../kyverno_rbac.yaml
+  - name: given-cluster-policy-is-ready
+    try:
+    - apply:
+        file: ../validate-restrict-binding-system-authenticated-clusterpolicy.yaml
+    - assert:
+        file: chainsaw-assert-clusterpolicy.yaml
+  - name: given-tenant-namespace-exists
+    try:
+    - apply:
+        file: ./resources/tenant-namespace.yaml
+  - name: then-invalid-rolebinding-can-not-be-created
+    try:
+    - apply:
+        file: ./resources/invalid-systemauthenticated-rolebinding.yaml
+        expect:
+        - check:
+            ($error != null): true
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: in-tenant-valid-rolebinding
+spec:
+  description: |
+    tests that the a valid RoleBinding can be created in a 
+    tenant namespace
+  concurrent: true
+  namespace: 'valid-systemauthenticated-rb-tenant-namespace'
+  steps:
+  - name: given-kyverno-has-permission-on-resources
+    try:
+    - apply:
+        file: ../kyverno_rbac.yaml
+  - name: given-cluster-policy-is-ready
+    try:
+    - apply:
+        file: ../validate-restrict-binding-system-authenticated-clusterpolicy.yaml
+    - assert:
+        file: chainsaw-assert-clusterpolicy.yaml
+  - name: given-tenant-namespace-exists
+    try:
+    - apply:
+        file: ./resources/tenant-namespace.yaml
+  - name: then-valid-rolebinding-can-be-created
+    try:
+    - apply:
+        file: ./resources/valid-systemauthenticated-rolebinding.yaml
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: out-of-tenant-rolebinding
+spec:
+  description: |
+    tests that the whatever RoleBinding can be created in a 
+    non-tenant namespace
+  concurrent: true
+  namespace: 'valid-systemauthenticated-rb-namespace'
+  steps:
+  - name: given-kyverno-has-permission-on-resources
+    try:
+    - apply:
+        file: ../kyverno_rbac.yaml
+  - name: given-cluster-policy-is-ready
+    try:
+    - apply:
+        file: ../validate-restrict-binding-system-authenticated-clusterpolicy.yaml
+    - assert:
+        file: chainsaw-assert-clusterpolicy.yaml
+  - name: then-rolebinding-can-be-created-in-a-nontenant-namespace
+    try:
+    - apply:
+        file: ./resources/valid-systemauthenticated-rolebinding.yaml

--- a/components/konflux-rbac/policies/restrict-binding-system-authenticated/.chainsaw-test/resources/invalid-systemauthenticated-rolebinding.yaml
+++ b/components/konflux-rbac/policies/restrict-binding-system-authenticated/.chainsaw-test/resources/invalid-systemauthenticated-rolebinding.yaml
@@ -1,0 +1,18 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: invalid-systemauthenticated-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: not-konflux-viewer-user-actions
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:authenticated
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: my-user
+- apiGroup: ""
+  kind: ServiceAccount
+  name: my-serviceaccount

--- a/components/konflux-rbac/policies/restrict-binding-system-authenticated/.chainsaw-test/resources/tenant-namespace.yaml
+++ b/components/konflux-rbac/policies/restrict-binding-system-authenticated/.chainsaw-test/resources/tenant-namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ($namespace)
+  labels:
+    konflux-ci.dev/type: tenant

--- a/components/konflux-rbac/policies/restrict-binding-system-authenticated/.chainsaw-test/resources/valid-systemauthenticated-rolebinding.yaml
+++ b/components/konflux-rbac/policies/restrict-binding-system-authenticated/.chainsaw-test/resources/valid-systemauthenticated-rolebinding.yaml
@@ -1,0 +1,18 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: valid-systemauthenticated-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: konflux-viewer-user-actions
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:authenticated
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: my-user
+- apiGroup: ""
+  kind: ServiceAccount
+  name: my-serviceaccount

--- a/components/konflux-rbac/policies/restrict-binding-system-authenticated/kustomization.yaml
+++ b/components/konflux-rbac/policies/restrict-binding-system-authenticated/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namePrefix: konflux-rbac-
+resources:
+- validate-restrict-binding-system-authenticated-clusterpolicy.yaml
+- kyverno_rbac.yaml

--- a/components/konflux-rbac/policies/restrict-binding-system-authenticated/kyverno_rbac.yaml
+++ b/components/konflux-rbac/policies/restrict-binding-system-authenticated/kyverno_rbac.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kyverno-admission:restrict-binding-system-authenticated
+  labels:
+    rbac.kyverno.io/aggregate-to-admission-controller: "true"
+rules:
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - rolebindings
+  verbs:
+  - list
+  - get
+  - watch
+---

--- a/components/konflux-rbac/policies/restrict-binding-system-authenticated/validate-restrict-binding-system-authenticated-clusterpolicy.yaml
+++ b/components/konflux-rbac/policies/restrict-binding-system-authenticated/validate-restrict-binding-system-authenticated-clusterpolicy.yaml
@@ -18,14 +18,18 @@ spec:
       any:
       - resources:
           kinds:
-            - RoleBinding
+          - RoleBinding
     context:
     - name: konfluxtype
       apiCall:
         urlPath: "/api/v1/namespaces/{{ request.object.metadata.namespace }}"
-        jmesPath: 'metadata.labels."konflux-ci.dev/type"'
+        jmesPath: 'metadata.labels."konflux-ci.dev/type" || ""'
     preconditions:
-      - key: "{{ request.object.subjects.name }}"
+      all:
+      - key: "{{ konfluxtype }}"
+        operator: Equals
+        value: tenant
+      - key: "{{ request.object.subjects[].name }}"
         operator: AnyIn
         value: "system:authenticated"
       - key: "{{ request.object.roleRef.kind }}"
@@ -37,9 +41,4 @@ spec:
     validate:
       failureAction: Enforce
       message: "Only ClusterRole konflux-viewer-user-actions can be bound to system:authenticated."
-      deny:
-        conditions:
-          all:
-          - key: "{{ konfluxtype || '' }}"
-            operator: Equals
-            value: "tenant"
+      deny: {}

--- a/components/konflux-rbac/policies/restrict-binding-system-authenticated/validate-restrict-binding-system-authenticated-clusterpolicy.yaml
+++ b/components/konflux-rbac/policies/restrict-binding-system-authenticated/validate-restrict-binding-system-authenticated-clusterpolicy.yaml
@@ -1,0 +1,45 @@
+---
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: validate-restrict-binding-system-authenticated
+  annotations:
+    policies.kyverno.io/title: Restrict Binding System Groups
+    policies.kyverno.io/category: Security
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: RoleBinding, RBAC
+    policies.kyverno.io/description: >-
+      We don't want users to bind system:authenticated group with any role
+      except for the konflux-viewer-user-actions ClusterRole.
+spec:
+  rules:
+  - name: restrict-authenticated
+    match:
+      any:
+      - resources:
+          kinds:
+            - RoleBinding
+    context:
+    - name: konfluxtype
+      apiCall:
+        urlPath: "/api/v1/namespaces/{{ request.object.metadata.namespace }}"
+        jmesPath: 'metadata.labels."konflux-ci.dev/type"'
+    preconditions:
+      - key: "{{ request.object.subjects.name }}"
+        operator: AnyIn
+        value: "system:authenticated"
+      - key: "{{ request.object.roleRef.kind }}"
+        operator: Equals
+        value: "ClusterRole"
+      - key: "{{ request.object.roleRef.name }}"
+        operator: NotEquals
+        value: "konflux-viewer-user-actions"
+    validate:
+      failureAction: Enforce
+      message: "Only ClusterRole konflux-viewer-user-actions can be bound to system:authenticated."
+      deny:
+        conditions:
+          all:
+          - key: "{{ konfluxtype || '' }}"
+            operator: Equals
+            value: "tenant"

--- a/components/konflux-rbac/staging/base/kustomization.yaml
+++ b/components/konflux-rbac/staging/base/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - konflux-contributor-user-actions.yaml
   - konflux-viewer-user-actions.yaml
   - ../../policies/bootstrap-tenant-namespace/
+  - ../../policies/restrict-binding-system-authenticated/


### PR DESCRIPTION
This PR adds a Policy to restrict the Roles an user can share in a tenant namespace to `konflux-viewer-user-actions`.

It requires:
* [x] #6271
