### PR TITLE
Add static s390x hosts for stone-prod-p02

### DIFF
--- a/components/multi-platform-controller/production-downstream/stone-prod-p02/external-secrets.yaml
+++ b/components/multi-platform-controller/production-downstream/stone-prod-p02/external-secrets.yaml
@@ -1,0 +1,23 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: ibm-s390x-static-ssh-key
+  namespace: multi-platform-controller
+  labels:
+    build.appstudio.redhat.com/multi-platform-secret: "true"
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  dataFrom:
+    - extract:
+        key: production/build/multi-platform-controller/stone-prod-p02-ibm-s390x-static-ssh-key
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: appsre-stonesoup-vault
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    name: ibm-s390x-static-ssh-key
+

--- a/components/multi-platform-controller/production-downstream/stone-prod-p02/host-config.yaml
+++ b/components/multi-platform-controller/production-downstream/stone-prod-p02/host-config.yaml
@@ -632,6 +632,90 @@ data:
   dynamic.linux-d200-s390x.disk: "200"
   dynamic.linux-d200-s390x.instance-tag: prod-d200-s390x
 
+  host.tests390x-static-1.address: "10.130.79.4"
+  host.tests390x-static-1.platform: "linux/s390x"
+  host.tests390x-static-1.user: "root"
+  host.tests390x-static-1.secret: "ibm-s390x-static-ssh-key"
+  host.tests390x-static-1.concurrency: "4"
+
+  host.tests390x-static-2.address: "10.130.79.5"
+  host.tests390x-static-2.platform: "linux/s390x"
+  host.tests390x-static-2.user: "root"
+  host.tests390x-static-2.secret: "ibm-s390x-static-ssh-key"
+  host.tests390x-static-2.concurrency: "4"
+
+  host.tests390x-static-3.address: "10.130.79.6"
+  host.tests390x-static-3.platform: "linux/s390x"
+  host.tests390x-static-3.user: "root"
+  host.tests390x-static-3.secret: "ibm-s390x-static-ssh-key"
+  host.tests390x-static-3.concurrency: "4"
+
+  host.tests390x-static-4.address: "10.130.79.37"
+  host.tests390x-static-4.platform: "linux/s390x"
+  host.tests390x-static-4.user: "root"
+  host.tests390x-static-4.secret: "ibm-s390x-static-ssh-key"
+  host.tests390x-static-4.concurrency: "4"
+
+  host.tests390x-static-5.address: "10.130.79.36"
+  host.tests390x-static-5.platform: "linux/s390x"
+  host.tests390x-static-5.user: "root"
+  host.tests390x-static-5.secret: "ibm-s390x-static-ssh-key"
+  host.tests390x-static-5.concurrency: "4"
+
+  host.tests390x-static-6.address: "10.130.79.68"
+  host.tests390x-static-6.platform: "linux/s390x"
+  host.tests390x-static-6.user: "root"
+  host.tests390x-static-6.secret: "ibm-s390x-static-ssh-key"
+  host.tests390x-static-6.concurrency: "4"
+
+  host.tests390x-static-7.address: "10.130.79.69"
+  host.tests390x-static-7.platform: "linux/s390x"
+  host.tests390x-static-7.user: "root"
+  host.tests390x-static-7.secret: "ibm-s390x-static-ssh-key"
+  host.tests390x-static-7.concurrency: "4"
+
+  host.tests390x-static-8.address: "10.130.79.70"
+  host.tests390x-static-8.platform: "linux/s390x"
+  host.tests390x-static-8.user: "root"
+  host.tests390x-static-8.secret: "ibm-s390x-static-ssh-key"
+  host.tests390x-static-8.concurrency: "4"
+
+  host.tests390x-static-9.address: "10.130.79.71"
+  host.tests390x-static-9.platform: "linux/s390x"
+  host.tests390x-static-9.user: "root"
+  host.tests390x-static-9.secret: "ibm-s390x-static-ssh-key"
+  host.tests390x-static-9.concurrency: "4"
+
+  host.tests390x-static-10.address: "10.130.79.72"
+  host.tests390x-static-10.platform: "linux/s390x"
+  host.tests390x-static-10.user: "root"
+  host.tests390x-static-10.secret: "ibm-s390x-static-ssh-key"
+  host.tests390x-static-10.concurrency: "4"
+
+  host.tests390x-static-11.address: "10.130.79.73"
+  host.tests390x-static-11.platform: "linux/s390x"
+  host.tests390x-static-11.user: "root"
+  host.tests390x-static-11.secret: "ibm-s390x-static-ssh-key"
+  host.tests390x-static-11.concurrency: "4"
+
+  host.tests390x-static-12.address: "10.130.79.74"
+  host.tests390x-static-12.platform: "linux/s390x"
+  host.tests390x-static-12.user: "root"
+  host.tests390x-static-12.secret: "ibm-s390x-static-ssh-key"
+  host.tests390x-static-12.concurrency: "4"
+
+  host.tests390x-static-13.address: "10.130.79.75"
+  host.tests390x-static-13.platform: "linux/s390x"
+  host.tests390x-static-13.user: "root"
+  host.tests390x-static-13.secret: "ibm-s390x-static-ssh-key"
+  host.tests390x-static-13.concurrency: "4"
+
+  host.tests390x-static-14.address: "10.130.79.76"
+  host.tests390x-static-14.platform: "linux/s390x"
+  host.tests390x-static-14.user: "root"
+  host.tests390x-static-14.secret: "ibm-s390x-static-ssh-key"
+  host.tests390x-static-14.concurrency: "4"
+
   # S390X 4vCPU / 16GB RAM / 200GB disk
   dynamic.linux-d200-large-s390x.type: ibmz
   dynamic.linux-d200-large-s390x.ssh-secret: "internal-prod-ibm-ssh-key"

--- a/components/multi-platform-controller/production-downstream/stone-prod-p02/kustomization.yaml
+++ b/components/multi-platform-controller/production-downstream/stone-prod-p02/kustomization.yaml
@@ -6,3 +6,4 @@ namespace: multi-platform-controller
 resources:
 - ../base
 - host-config.yaml
+- external-secrets.yaml


### PR DESCRIPTION
Add all the static host using a temporary platform name to be able to test them out without affecting prod. A follow up change will replace dynamic by static ones.

KFLUXINFRA-1538