### PR TITLE
Change s390x and ppc64le to static VMs on P02

### DIFF
--- a/components/multi-platform-controller/production-downstream/stone-prod-p02/host-config.yaml
+++ b/components/multi-platform-controller/production-downstream/stone-prod-p02/host-config.yaml
@@ -42,11 +42,9 @@ data:
     linux-g6xlarge/amd64,\
     linux-root/arm64,\
     linux-root/amd64,\
-    linux/s390x,\
     linux-large/s390x,\
     linux-d200/s390x,\
     linux-d200-large/s390x,\
-    linux/ppc64le,\
     linux-large/ppc64le,\
     linux-xlarge/ppc64le,\
     linux-2xlarge/ppc64le,\
@@ -583,21 +581,89 @@ data:
     
     --//--
 
-  # S390X 2vCPU / 8GB RAM / 100GB disk
-  dynamic.linux-s390x.type: ibmz
-  dynamic.linux-s390x.ssh-secret: "internal-prod-ibm-ssh-key"
-  dynamic.linux-s390x.secret: "internal-prod-ibm-api-key"
-  dynamic.linux-s390x.vpc: "konflux-internal-prod-us-east-1"
-  dynamic.linux-s390x.key: "internal-prod-key"
-  dynamic.linux-s390x.subnet: "internal-a"
-  dynamic.linux-s390x.image-id: "r014-23be9e67-4ab2-4dc9-9a51-d56efb06943d"
-  dynamic.linux-s390x.region: "us-east-1"
-  dynamic.linux-s390x.url: "https://us-east.iaas.cloud.ibm.com/v1"
-  dynamic.linux-s390x.profile: "bz2-2x8"
-  dynamic.linux-s390x.max-instances: "30"
-  dynamic.linux-s390x.private-ip: "true"
-  dynamic.linux-s390x.allocation-timeout: "1800"
-  dynamic.linux-s390x.instance-tag: prod-s390x
+  host.s390x-static-1.address: "10.130.79.4"
+  host.s390x-static-1.platform: "linux/s390x"
+  host.s390x-static-1.user: "root"
+  host.s390x-static-1.secret: "ibm-s390x-static-ssh-key"
+  host.s390x-static-1.concurrency: "4"
+
+  host.s390x-static-2.address: "10.130.79.5"
+  host.s390x-static-2.platform: "linux/s390x"
+  host.s390x-static-2.user: "root"
+  host.s390x-static-2.secret: "ibm-s390x-static-ssh-key"
+  host.s390x-static-2.concurrency: "4"
+
+  host.s390x-static-3.address: "10.130.79.6"
+  host.s390x-static-3.platform: "linux/s390x"
+  host.s390x-static-3.user: "root"
+  host.s390x-static-3.secret: "ibm-s390x-static-ssh-key"
+  host.s390x-static-3.concurrency: "4"
+
+  host.s390x-static-4.address: "10.130.79.37"
+  host.s390x-static-4.platform: "linux/s390x"
+  host.s390x-static-4.user: "root"
+  host.s390x-static-4.secret: "ibm-s390x-static-ssh-key"
+  host.s390x-static-4.concurrency: "4"
+
+  host.s390x-static-5.address: "10.130.79.36"
+  host.s390x-static-5.platform: "linux/s390x"
+  host.s390x-static-5.user: "root"
+  host.s390x-static-5.secret: "ibm-s390x-static-ssh-key"
+  host.s390x-static-5.concurrency: "4"
+
+  host.s390x-static-6.address: "10.130.79.68"
+  host.s390x-static-6.platform: "linux/s390x"
+  host.s390x-static-6.user: "root"
+  host.s390x-static-6.secret: "ibm-s390x-static-ssh-key"
+  host.s390x-static-6.concurrency: "4"
+
+  host.s390x-static-7.address: "10.130.79.69"
+  host.s390x-static-7.platform: "linux/s390x"
+  host.s390x-static-7.user: "root"
+  host.s390x-static-7.secret: "ibm-s390x-static-ssh-key"
+  host.s390x-static-7.concurrency: "4"
+
+  host.s390x-static-8.address: "10.130.79.70"
+  host.s390x-static-8.platform: "linux/s390x"
+  host.s390x-static-8.user: "root"
+  host.s390x-static-8.secret: "ibm-s390x-static-ssh-key"
+  host.s390x-static-8.concurrency: "4"
+
+  host.s390x-static-9.address: "10.130.79.71"
+  host.s390x-static-9.platform: "linux/s390x"
+  host.s390x-static-9.user: "root"
+  host.s390x-static-9.secret: "ibm-s390x-static-ssh-key"
+  host.s390x-static-9.concurrency: "4"
+
+  host.s390x-static-10.address: "10.130.79.72"
+  host.s390x-static-10.platform: "linux/s390x"
+  host.s390x-static-10.user: "root"
+  host.s390x-static-10.secret: "ibm-s390x-static-ssh-key"
+  host.s390x-static-10.concurrency: "4"
+
+  host.s390x-static-11.address: "10.130.79.73"
+  host.s390x-static-11.platform: "linux/s390x"
+  host.s390x-static-11.user: "root"
+  host.s390x-static-11.secret: "ibm-s390x-static-ssh-key"
+  host.s390x-static-11.concurrency: "4"
+
+  host.s390x-static-12.address: "10.130.79.74"
+  host.s390x-static-12.platform: "linux/s390x"
+  host.s390x-static-12.user: "root"
+  host.s390x-static-12.secret: "ibm-s390x-static-ssh-key"
+  host.s390x-static-12.concurrency: "4"
+
+  host.s390x-static-13.address: "10.130.79.75"
+  host.s390x-static-13.platform: "linux/s390x"
+  host.s390x-static-13.user: "root"
+  host.s390x-static-13.secret: "ibm-s390x-static-ssh-key"
+  host.s390x-static-13.concurrency: "4"
+
+  host.s390x-static-14.address: "10.130.79.76"
+  host.s390x-static-14.platform: "linux/s390x"
+  host.s390x-static-14.user: "root"
+  host.s390x-static-14.secret: "ibm-s390x-static-ssh-key"
+  host.s390x-static-14.concurrency: "4"
 
   # S390X 4vCPU / 16GB RAM / 100GB disk
   dynamic.linux-large-s390x.type: ibmz
@@ -632,90 +698,6 @@ data:
   dynamic.linux-d200-s390x.disk: "200"
   dynamic.linux-d200-s390x.instance-tag: prod-d200-s390x
 
-  host.tests390x-static-1.address: "10.130.79.4"
-  host.tests390x-static-1.platform: "linux/tests390x"
-  host.tests390x-static-1.user: "root"
-  host.tests390x-static-1.secret: "ibm-s390x-static-ssh-key"
-  host.tests390x-static-1.concurrency: "4"
-
-  host.tests390x-static-2.address: "10.130.79.5"
-  host.tests390x-static-2.platform: "linux/tests390x"
-  host.tests390x-static-2.user: "root"
-  host.tests390x-static-2.secret: "ibm-s390x-static-ssh-key"
-  host.tests390x-static-2.concurrency: "4"
-
-  host.tests390x-static-3.address: "10.130.79.6"
-  host.tests390x-static-3.platform: "linux/tests390x"
-  host.tests390x-static-3.user: "root"
-  host.tests390x-static-3.secret: "ibm-s390x-static-ssh-key"
-  host.tests390x-static-3.concurrency: "4"
-
-  host.tests390x-static-4.address: "10.130.79.37"
-  host.tests390x-static-4.platform: "linux/tests390x"
-  host.tests390x-static-4.user: "root"
-  host.tests390x-static-4.secret: "ibm-s390x-static-ssh-key"
-  host.tests390x-static-4.concurrency: "4"
-
-  host.tests390x-static-5.address: "10.130.79.36"
-  host.tests390x-static-5.platform: "linux/tests390x"
-  host.tests390x-static-5.user: "root"
-  host.tests390x-static-5.secret: "ibm-s390x-static-ssh-key"
-  host.tests390x-static-5.concurrency: "4"
-
-  host.tests390x-static-6.address: "10.130.79.68"
-  host.tests390x-static-6.platform: "linux/tests390x"
-  host.tests390x-static-6.user: "root"
-  host.tests390x-static-6.secret: "ibm-s390x-static-ssh-key"
-  host.tests390x-static-6.concurrency: "4"
-
-  host.tests390x-static-7.address: "10.130.79.69"
-  host.tests390x-static-7.platform: "linux/tests390x"
-  host.tests390x-static-7.user: "root"
-  host.tests390x-static-7.secret: "ibm-s390x-static-ssh-key"
-  host.tests390x-static-7.concurrency: "4"
-
-  host.tests390x-static-8.address: "10.130.79.70"
-  host.tests390x-static-8.platform: "linux/tests390x"
-  host.tests390x-static-8.user: "root"
-  host.tests390x-static-8.secret: "ibm-s390x-static-ssh-key"
-  host.tests390x-static-8.concurrency: "4"
-
-  host.tests390x-static-9.address: "10.130.79.71"
-  host.tests390x-static-9.platform: "linux/tests390x"
-  host.tests390x-static-9.user: "root"
-  host.tests390x-static-9.secret: "ibm-s390x-static-ssh-key"
-  host.tests390x-static-9.concurrency: "4"
-
-  host.tests390x-static-10.address: "10.130.79.72"
-  host.tests390x-static-10.platform: "linux/tests390x"
-  host.tests390x-static-10.user: "root"
-  host.tests390x-static-10.secret: "ibm-s390x-static-ssh-key"
-  host.tests390x-static-10.concurrency: "4"
-
-  host.tests390x-static-11.address: "10.130.79.73"
-  host.tests390x-static-11.platform: "linux/tests390x"
-  host.tests390x-static-11.user: "root"
-  host.tests390x-static-11.secret: "ibm-s390x-static-ssh-key"
-  host.tests390x-static-11.concurrency: "4"
-
-  host.tests390x-static-12.address: "10.130.79.74"
-  host.tests390x-static-12.platform: "linux/tests390x"
-  host.tests390x-static-12.user: "root"
-  host.tests390x-static-12.secret: "ibm-s390x-static-ssh-key"
-  host.tests390x-static-12.concurrency: "4"
-
-  host.tests390x-static-13.address: "10.130.79.75"
-  host.tests390x-static-13.platform: "linux/tests390x"
-  host.tests390x-static-13.user: "root"
-  host.tests390x-static-13.secret: "ibm-s390x-static-ssh-key"
-  host.tests390x-static-13.concurrency: "4"
-
-  host.tests390x-static-14.address: "10.130.79.76"
-  host.tests390x-static-14.platform: "linux/tests390x"
-  host.tests390x-static-14.user: "root"
-  host.tests390x-static-14.secret: "ibm-s390x-static-ssh-key"
-  host.tests390x-static-14.concurrency: "4"
-
   # S390X 4vCPU / 16GB RAM / 200GB disk
   dynamic.linux-d200-large-s390x.type: ibmz
   dynamic.linux-d200-large-s390x.ssh-secret: "internal-prod-ibm-ssh-key"
@@ -733,69 +715,53 @@ data:
   dynamic.linux-d200-large-s390x.disk: "200"
   dynamic.linux-d200-large-s390x.instance-tag: prod-d200-s390x-large
 
-  host.testppc64le-static-1.address: "10.130.74.90"
-  host.testppc64le-static-1.platform: "linux/testppc64le"
-  host.testppc64le-static-1.user: "root"
-  host.testppc64le-static-1.secret: "internal-prod-ibm-ssh-key"
-  host.testppc64le-static-1.concurrency: "8"
+  host.ppc64le-static-1.address: "10.130.74.90"
+  host.ppc64le-static-1.platform: "linux/ppc64le"
+  host.ppc64le-static-1.user: "root"
+  host.ppc64le-static-1.secret: "internal-prod-ibm-ssh-key"
+  host.ppc64le-static-1.concurrency: "8"
 
-  host.testppc64le-static-2.address: "10.130.75.60"
-  host.testppc64le-static-2.platform: "linux/testppc64le"
-  host.testppc64le-static-2.user: "root"
-  host.testppc64le-static-2.secret: "internal-prod-ibm-ssh-key"
-  host.testppc64le-static-2.concurrency: "8"
+  host.ppc64le-static-2.address: "10.130.75.60"
+  host.ppc64le-static-2.platform: "linux/ppc64le"
+  host.ppc64le-static-2.user: "root"
+  host.ppc64le-static-2.secret: "internal-prod-ibm-ssh-key"
+  host.ppc64le-static-2.concurrency: "8"
 
-  host.testppc64le-static-3.address: "10.130.73.71"
-  host.testppc64le-static-3.platform: "linux/testppc64le"
-  host.testppc64le-static-3.user: "root"
-  host.testppc64le-static-3.secret: "internal-prod-ibm-ssh-key"
-  host.testppc64le-static-3.concurrency: "8"
+  host.ppc64le-static-3.address: "10.130.73.71"
+  host.ppc64le-static-3.platform: "linux/ppc64le"
+  host.ppc64le-static-3.user: "root"
+  host.ppc64le-static-3.secret: "internal-prod-ibm-ssh-key"
+  host.ppc64le-static-3.concurrency: "8"
 
-  host.testppc64le-static-4.address: "10.130.73.187"
-  host.testppc64le-static-4.platform: "linux/testppc64le"
-  host.testppc64le-static-4.user: "root"
-  host.testppc64le-static-4.secret: "internal-prod-ibm-ssh-key"
-  host.testppc64le-static-4.concurrency: "8"
+  host.ppc64le-static-4.address: "10.130.73.187"
+  host.ppc64le-static-4.platform: "linux/ppc64le"
+  host.ppc64le-static-4.user: "root"
+  host.ppc64le-static-4.secret: "internal-prod-ibm-ssh-key"
+  host.ppc64le-static-4.concurrency: "8"
 
-  host.testppc64le-static-5.address: "10.130.73.142"
-  host.testppc64le-static-5.platform: "linux/testppc64le"
-  host.testppc64le-static-5.user: "root"
-  host.testppc64le-static-5.secret: "internal-prod-ibm-ssh-key"
-  host.testppc64le-static-5.concurrency: "8"
+  host.ppc64le-static-5.address: "10.130.73.142"
+  host.ppc64le-static-5.platform: "linux/ppc64le"
+  host.ppc64le-static-5.user: "root"
+  host.ppc64le-static-5.secret: "internal-prod-ibm-ssh-key"
+  host.ppc64le-static-5.concurrency: "8"
 
-  host.testppc64le-static-6.address: "10.130.74.34"
-  host.testppc64le-static-6.platform: "linux/testppc64le"
-  host.testppc64le-static-6.user: "root"
-  host.testppc64le-static-6.secret: "internal-prod-ibm-ssh-key"
-  host.testppc64le-static-6.concurrency: "8"
+  host.ppc64le-static-6.address: "10.130.74.34"
+  host.ppc64le-static-6.platform: "linux/ppc64le"
+  host.ppc64le-static-6.user: "root"
+  host.ppc64le-static-6.secret: "internal-prod-ibm-ssh-key"
+  host.ppc64le-static-6.concurrency: "8"
 
-  host.testppc64le-static-7.address: "10.130.73.237"
-  host.testppc64le-static-7.platform: "linux/testppc64le"
-  host.testppc64le-static-7.user: "root"
-  host.testppc64le-static-7.secret: "internal-prod-ibm-ssh-key"
-  host.testppc64le-static-7.concurrency: "8"
+  host.ppc64le-static-7.address: "10.130.73.237"
+  host.ppc64le-static-7.platform: "linux/ppc64le"
+  host.ppc64le-static-7.user: "root"
+  host.ppc64le-static-7.secret: "internal-prod-ibm-ssh-key"
+  host.ppc64le-static-7.concurrency: "8"
 
-  host.testppc64le-static-8.address: "10.130.72.108"
-  host.testppc64le-static-8.platform: "linux/testppc64le"
-  host.testppc64le-static-8.user: "root"
-  host.testppc64le-static-8.secret: "internal-prod-ibm-ssh-key"
-  host.testppc64le-static-8.concurrency: "8"
-
-  # PPC64LE 2vCPU / 8GB RAM / 100GB disk
-  dynamic.linux-ppc64le.type: ibmp
-  dynamic.linux-ppc64le.ssh-secret: "internal-prod-ibm-ssh-key"
-  dynamic.linux-ppc64le.secret: "internal-prod-ibm-api-key"
-  dynamic.linux-ppc64le.key: "prod-konflux-infra"
-  dynamic.linux-ppc64le.image: "konflux-internal-prod-ppc-base-oct-04-24"
-  dynamic.linux-ppc64le.crn: "crn:v1:bluemix:public:power-iaas:wdc06:a/5cb0704ee6304413bd0b171372c0fd77:4e9dc638-7a78-4e7c-b432-e83b7010c531::"
-  dynamic.linux-ppc64le.url: "https://us-east.power-iaas.cloud.ibm.com"
-  dynamic.linux-ppc64le.network: "a6d8d6da-c412-4106-9b57-4e25541b2e7f"
-  dynamic.linux-ppc64le.system: "e980"
-  dynamic.linux-ppc64le.cores: "0.25"
-  dynamic.linux-ppc64le.memory: "8"
-  dynamic.linux-ppc64le.max-instances: "50"
-  dynamic.linux-ppc64le.allocation-timeout: "1800"
-  dynamic.linux-ppc64le.instance-tag: prod-ppc64le
+  host.ppc64le-static-8.address: "10.130.72.108"
+  host.ppc64le-static-8.platform: "linux/ppc64le"
+  host.ppc64le-static-8.user: "root"
+  host.ppc64le-static-8.secret: "internal-prod-ibm-ssh-key"
+  host.ppc64le-static-8.concurrency: "8"
 
   # PPC64LE 4vCPU / 16GB RAM / 100GB disk
   dynamic.linux-large-ppc64le.type: ibmp


### PR DESCRIPTION
Only change the default platforms to not do a breaking change, then an announcement will be sent to ask users to stop using larger platform flavors in favor of default ones. The default platforms are running on static VMs that are large enough to accommodate larger build needs.

A follow up change will remove the larger flavors once users had time to migrate.

[KFLUXINFRA-1538](https://issues.redhat.com//browse/KFLUXINFRA-1538)
[KFLUXINFRA-1540](https://issues.redhat.com//browse/KFLUXINFRA-1540)