### PR TITLE
Add 2 more s390x machines for p02

### DIFF
--- a/components/multi-platform-controller/production-downstream/stone-prod-p02/host-config.yaml
+++ b/components/multi-platform-controller/production-downstream/stone-prod-p02/host-config.yaml
@@ -665,6 +665,18 @@ data:
   host.s390x-static-14.secret: "ibm-s390x-static-ssh-key"
   host.s390x-static-14.concurrency: "4"
 
+  host.s390x-static-15.address: "10.130.79.40"
+  host.s390x-static-15.platform: "linux/s390x"
+  host.s390x-static-15.user: "root"
+  host.s390x-static-15.secret: "ibm-s390x-static-ssh-key"
+  host.s390x-static-15.concurrency: "4"
+
+  host.s390x-static-16.address: "10.130.79.79"
+  host.s390x-static-16.platform: "linux/s390x"
+  host.s390x-static-16.user: "root"
+  host.s390x-static-16.secret: "ibm-s390x-static-ssh-key"
+  host.s390x-static-16.concurrency: "4"
+
   # S390X 4vCPU / 16GB RAM / 100GB disk
   dynamic.linux-large-s390x.type: ibmz
   dynamic.linux-large-s390x.ssh-secret: "internal-prod-ibm-ssh-key"


### PR DESCRIPTION
This 2 machines brings the count to 16 with 4 builds each for a total of 64 concurrent builds, par with ppc64le.

[KFLUXINFRA-1527](https://issues.redhat.com//browse/KFLUXINFRA-1527)