### PR TITLE
fix: use devel tag instead of commit_id tag for the pipeline bundles

### DIFF
--- a/components/build-service/base/build-pipeline-config/build-pipeline-config.yaml
+++ b/components/build-service/base/build-pipeline-config/build-pipeline-config.yaml
@@ -8,18 +8,18 @@ data:
     default-pipeline-name: docker-build-oci-ta
     pipelines:
     - name: fbc-builder
-      bundle: quay.io/konflux-ci/tekton-catalog/pipeline-fbc-builder:47a7a8b185500aaebc35ada051ad4f75177bf4e6
+      bundle: quay.io/konflux-ci/tekton-catalog/pipeline-fbc-builder:devel
       additional-params:
       - build-platforms
     - name: docker-build
-      bundle: quay.io/konflux-ci/tekton-catalog/pipeline-docker-build:47a7a8b185500aaebc35ada051ad4f75177bf4e6
+      bundle: quay.io/konflux-ci/tekton-catalog/pipeline-docker-build:devel
     - name: docker-build-oci-ta
-      bundle: quay.io/konflux-ci/tekton-catalog/pipeline-docker-build-oci-ta:47a7a8b185500aaebc35ada051ad4f75177bf4e6
+      bundle: quay.io/konflux-ci/tekton-catalog/pipeline-docker-build-oci-ta:devel
     - name: docker-build-multi-platform-oci-ta
-      bundle: quay.io/konflux-ci/tekton-catalog/pipeline-docker-build-multi-platform-oci-ta:47a7a8b185500aaebc35ada051ad4f75177bf4e6
+      bundle: quay.io/konflux-ci/tekton-catalog/pipeline-docker-build-multi-platform-oci-ta:devel
       additional-params:
       - build-platforms
     - name: maven-zip-build-oci-ta
-      bundle: quay.io/konflux-ci/tekton-catalog/pipeline-maven-zip-build-oci-ta:47a7a8b185500aaebc35ada051ad4f75177bf4e6
+      bundle: quay.io/konflux-ci/tekton-catalog/pipeline-maven-zip-build-oci-ta:devel
     - name: tekton-bundle-builder-oci-ta
-      bundle: quay.io/konflux-ci/tekton-catalog/pipeline-tekton-bundle-builder-oci-ta:47a7a8b185500aaebc35ada051ad4f75177bf4e6
+      bundle: quay.io/konflux-ci/tekton-catalog/pipeline-tekton-bundle-builder-oci-ta:devel


### PR DESCRIPTION
This change is part of https://issues.redhat.com/browse/KONFLUX-7680
Associated [PR](https://github.com/konflux-ci/build-definitions/pull/2268) on the build-definitions side
