### PR TITLE
Add static s390x hosts for kflux-prd-rh02

### DIFF
--- a/components/multi-platform-controller/production/kflux-prd-rh02/external-secrets.yaml
+++ b/components/multi-platform-controller/production/kflux-prd-rh02/external-secrets.yaml
@@ -70,6 +70,29 @@ spec:
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
+  name: ibm-s390x-static-ssh-key
+  namespace: multi-platform-controller
+  labels:
+    build.appstudio.redhat.com/multi-platform-secret: "true"
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  dataFrom:
+    - extract:
+        key: production/build/multi-platform-controller/kflux-prd-rh02-ibm-s390x-static-ssh-key
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: appsre-stonesoup-vault
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    name: ibm-s390x-static-ssh-key
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
   name: ibm-api-key
   namespace: multi-platform-controller
   labels:

--- a/components/multi-platform-controller/production/kflux-prd-rh02/host-config.yaml
+++ b/components/multi-platform-controller/production/kflux-prd-rh02/host-config.yaml
@@ -587,6 +587,102 @@ data:
 
     --//--
 
+  host.tests390x-static-1.address: "10.250.66.15"
+  host.tests390x-static-1.platform: "linux/tests390x"
+  host.tests390x-static-1.user: "root"
+  host.tests390x-static-1.secret: "ibm-s390x-static-ssh-key"
+  host.tests390x-static-1.concurrency: "4"
+
+  host.tests390x-static-2.address: "10.250.66.16"
+  host.tests390x-static-2.platform: "linux/tests390x"
+  host.tests390x-static-2.user: "root"
+  host.tests390x-static-2.secret: "ibm-s390x-static-ssh-key"
+  host.tests390x-static-2.concurrency: "4"
+
+  host.tests390x-static-3.address: "10.250.66.17"
+  host.tests390x-static-3.platform: "linux/tests390x"
+  host.tests390x-static-3.user: "root"
+  host.tests390x-static-3.secret: "ibm-s390x-static-ssh-key"
+  host.tests390x-static-3.concurrency: "4"
+
+  host.tests390x-static-4.address: "10.250.66.18"
+  host.tests390x-static-4.platform: "linux/tests390x"
+  host.tests390x-static-4.user: "root"
+  host.tests390x-static-4.secret: "ibm-s390x-static-ssh-key"
+  host.tests390x-static-4.concurrency: "4"
+
+  host.tests390x-static-5.address: "10.250.66.19"
+  host.tests390x-static-5.platform: "linux/tests390x"
+  host.tests390x-static-5.user: "root"
+  host.tests390x-static-5.secret: "ibm-s390x-static-ssh-key"
+  host.tests390x-static-5.concurrency: "4"
+
+  host.tests390x-static-6.address: "10.250.66.20"
+  host.tests390x-static-6.platform: "linux/tests390x"
+  host.tests390x-static-6.user: "root"
+  host.tests390x-static-6.secret: "ibm-s390x-static-ssh-key"
+  host.tests390x-static-6.concurrency: "4"
+
+  host.tests390x-static-7.address: "10.250.66.21"
+  host.tests390x-static-7.platform: "linux/tests390x"
+  host.tests390x-static-7.user: "root"
+  host.tests390x-static-7.secret: "ibm-s390x-static-ssh-key"
+  host.tests390x-static-7.concurrency: "4"
+
+  host.tests390x-static-8.address: "10.250.66.22"
+  host.tests390x-static-8.platform: "linux/tests390x"
+  host.tests390x-static-8.user: "root"
+  host.tests390x-static-8.secret: "ibm-s390x-static-ssh-key"
+  host.tests390x-static-8.concurrency: "4"
+
+  host.tests390x-static-9.address: "10.250.66.23"
+  host.tests390x-static-9.platform: "linux/tests390x"
+  host.tests390x-static-9.user: "root"
+  host.tests390x-static-9.secret: "ibm-s390x-static-ssh-key"
+  host.tests390x-static-9.concurrency: "4"
+
+  host.tests390x-static-10.address: "10.250.66.24"
+  host.tests390x-static-10.platform: "linux/tests390x"
+  host.tests390x-static-10.user: "root"
+  host.tests390x-static-10.secret: "ibm-s390x-static-ssh-key"
+  host.tests390x-static-10.concurrency: "4"
+
+  host.tests390x-static-11.address: "10.250.67.4"
+  host.tests390x-static-11.platform: "linux/tests390x"
+  host.tests390x-static-11.user: "root"
+  host.tests390x-static-11.secret: "ibm-s390x-static-ssh-key"
+  host.tests390x-static-11.concurrency: "4"
+
+  host.tests390x-static-12.address: "10.250.67.5"
+  host.tests390x-static-12.platform: "linux/tests390x"
+  host.tests390x-static-12.user: "root"
+  host.tests390x-static-12.secret: "ibm-s390x-static-ssh-key"
+  host.tests390x-static-12.concurrency: "4"
+
+  host.tests390x-static-13.address: "10.250.67.6"
+  host.tests390x-static-13.platform: "linux/tests390x"
+  host.tests390x-static-13.user: "root"
+  host.tests390x-static-13.secret: "ibm-s390x-static-ssh-key"
+  host.tests390x-static-13.concurrency: "4"
+
+  host.tests390x-static-14.address: "10.250.67.7"
+  host.tests390x-static-14.platform: "linux/tests390x"
+  host.tests390x-static-14.user: "root"
+  host.tests390x-static-14.secret: "ibm-s390x-static-ssh-key"
+  host.tests390x-static-14.concurrency: "4"
+
+  host.tests390x-static-15.address: "10.250.67.8"
+  host.tests390x-static-15.platform: "linux/tests390x"
+  host.tests390x-static-15.user: "root"
+  host.tests390x-static-15.secret: "ibm-s390x-static-ssh-key"
+  host.tests390x-static-15.concurrency: "4"
+
+  host.tests390x-static-16.address: "10.250.67.9"
+  host.tests390x-static-16.platform: "linux/tests390x"
+  host.tests390x-static-16.user: "root"
+  host.tests390x-static-16.secret: "ibm-s390x-static-ssh-key"
+  host.tests390x-static-16.concurrency: "4"
+
   # S390X 2vCPU / 8GB RAM / 100GB disk
   dynamic.linux-s390x.type: ibmz
   dynamic.linux-s390x.ssh-secret: "ibm-ssh-key"


### PR DESCRIPTION
Add all the static host using a temporary platform name to be able to test them out without affecting prod. A follow up change will replace dynamic by static ones.

[KFLUXINFRA-1530](https://issues.redhat.com//browse/KFLUXINFRA-1530)