### PR TITLE
etcd-shield: deploy to staging

### DIFF
--- a/argo-cd-apps/base/member/infra-deployments/etcd-shield/etcd-shield.yaml
+++ b/argo-cd-apps/base/member/infra-deployments/etcd-shield/etcd-shield.yaml
@@ -1,0 +1,44 @@
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: namespace-lister
+spec:
+  generators:
+    - merge:
+        mergeKeys:
+          - nameNormalized
+        generators:
+          - clusters:
+              values:
+                sourceRoot: components/etcd-shield
+                environment: staging
+          - list:
+              elements:
+                - nameNormalized: stone-stg-rh01
+                  values.clusterDir: stone-stg-rh01
+                - nameNormalized: stone-stage-p01
+                  values.clusterDir: stone-stage-p01
+  template:
+    metadata:
+      name: etcd-shield-{{nameNormalized}}
+    spec:
+      project: default
+      source:
+        path: '{{values.sourceRoot}}/{{values.environment}}/{{values.clusterDir}}'
+        repoURL: https://github.com/redhat-appstudio/infra-deployments.git
+        targetRevision: main
+      destination:
+        namespace: etcd-shield
+        server: '{{server}}'
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
+        syncOptions:
+          - CreateNamespace=true
+        retry:
+          limit: -1
+          backoff:
+            duration: 10s
+            factor: 2
+            maxDuration: 3m

--- a/argo-cd-apps/base/member/infra-deployments/etcd-shield/kustomization.yaml
+++ b/argo-cd-apps/base/member/infra-deployments/etcd-shield/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- etcd-shield.yaml
+components:
+  - ../../../../k-components/inject-infra-deployments-repo-details
+  - ../../../../k-components/deploy-to-member-cluster-merge-generator

--- a/components/etcd-shield/OWNERS
+++ b/components/etcd-shield/OWNERS
@@ -1,0 +1,13 @@
+# See the OWNERS docs: https://go.k8s.io/owners
+
+approvers:
+- hugares
+- filariow
+- gbenhaim
+- sadlerap
+
+reviewers:
+- hugares
+- filariow
+- gbenhaim
+- sadlerap

--- a/components/etcd-shield/base/config.yaml
+++ b/components/etcd-shield/base/config.yaml
@@ -1,0 +1,12 @@
+destName: etcd-shield-state
+destNamespace: etcd-shield
+prometheus:
+  address: https://prometheus-k8s.openshift-monitoring.svc:9091
+  alertName: EtcdShieldDenyAdmission
+  config:
+    authorization:
+      type: Bearer
+      credentials_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+    tls_config:
+      ca_file: /var/tls/tls.crt
+waitTime: 15s

--- a/components/etcd-shield/base/deployment.yaml
+++ b/components/etcd-shield/base/deployment.yaml
@@ -1,0 +1,79 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: etcd-shield
+  labels:
+    app: etcd-shield
+spec:
+  selector:
+    matchLabels:
+      app: etcd-shield
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: etcd-shield
+    spec:
+      serviceAccountName: etcd-shield
+      containers:
+      - args:
+        - -leader-elect
+        - -health-probe-bind-address=:8081
+        - -config=/etc/etcd-shield/config.yaml
+        - -port=8443
+        env:
+        - name: "NAMESPACE"
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        image: etcd-shield:latest
+        name: etcd-shield
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          initialDelaySeconds: 1
+          httpGet:
+            path: /healthz
+            port: 8081
+            scheme: HTTP
+        readinessProbe:
+          initialDelaySeconds: 1
+          httpGet:
+            path: /readyz
+            port: 8081
+            scheme: HTTP
+        resources:
+          limits:
+            cpu: 500m
+            memory: 128Mi
+          requests:
+            cpu: 500m
+            memory: 128Mi
+        ports:
+        - containerPort: 8443
+          name: http
+        - containerPort: 8081
+          name: healthz
+        - containerPort: 9100
+          name: metrics
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          capabilities:
+            drop:
+            - "ALL"
+        volumeMounts:
+        - name: tls
+          mountPath: /var/tls
+          readOnly: true
+        - name: config
+          mountPath: /etc/etcd-shield/
+          readOnly: true
+      terminationGracePeriodSeconds: 60
+      volumes:
+      - name: tls
+        secret:
+          secretName: etcd-shield-tls
+      - name: config
+        configMap:
+          name: etcd-shield-config

--- a/components/etcd-shield/base/etcd_shield_alerts.yaml
+++ b/components/etcd-shield/base/etcd_shield_alerts.yaml
@@ -1,0 +1,34 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: etcd-shield-triggers
+spec:
+  groups:
+  - name: etcd_shield_triggers
+    interval: 1m
+    rules:
+    - alert: EtcdShieldDenyAdmission
+      expr: etcd_shield_trigger != bool 0
+      for: 2m
+      keep_firing_for: 5m
+      labels:
+        severity: critical
+      annotations:
+        summary: etcd-shield is denying admission
+        description: Etcd is nearing capacity limits, so etcd-shield is denying admission
+    - record: etcd_shield_trigger
+      expr: |
+        (((max(etcd_mvcc_db_total_size_in_bytes) >= bool (etcd_shield_db_size * etcd_shield_upper_threshold)) == 1) or
+            (((max(etcd_mvcc_db_total_size_in_bytes) >= bool (etcd_shield_db_size * etcd_shield_lower_threshold)) == 1) and
+            ((count without (alertname, alertstate, severity)
+                (ALERTS{
+                  alertname="EtcdShieldDenyAdmission",
+                  alertstate="firing",
+                  severity="critical"
+                }) == bool 1) != 0)))
+    - record: etcd_shield_db_size
+      expr: vector(8589934592)  # 2 ** 33 bytes, or 8GiB
+    - record: etcd_shield_upper_threshold
+      expr: vector(0.95)
+    - record: etcd_shield_lower_threshold
+      expr: vector(0.80)

--- a/components/etcd-shield/base/kustomization.yaml
+++ b/components/etcd-shield/base/kustomization.yaml
@@ -1,0 +1,21 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+configMapGenerator:
+- files:
+  - ./config.yaml
+  name: etcd-shield-config
+# generatorOptions:
+#   # until https://github.com/kubernetes-sigs/kustomize/issues/4475 is fixed
+#   disableNameSuffixHash: true
+images:
+- name: etcd-shield
+  newName: quay.io/konflux-ci/etcd-shield
+  newTag: 3de52a71e086e152b3d2b33bfc897ce7bf8ea0dd
+namespace: etcd-shield
+resources:
+- deployment.yaml
+- ns.yaml
+- rbac.yaml
+- service.yaml
+- webhook.yaml
+- etcd_shield_alerts.yaml

--- a/components/etcd-shield/base/ns.yaml
+++ b/components/etcd-shield/base/ns.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: etcd-shield
+  labels:
+    openshift.io/cluster-monitoring: "true"

--- a/components/etcd-shield/base/rbac.yaml
+++ b/components/etcd-shield/base/rbac.yaml
@@ -1,0 +1,63 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: etcd-shield
+  namespace: etcd-shield
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: etcd-shield-authorizer
+subjects:
+- apiGroup: ""
+  kind: ServiceAccount
+  name: etcd-shield
+  namespace: etcd-shield
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: etcd-shield-authorizer
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: etcd-shield
+subjects:
+- apiGroup: ""
+  kind: ServiceAccount
+  name: etcd-shield
+  namespace: etcd-shield
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: etcd-shield
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: etcd-shield
+  namespace: etcd-shield
+rules:
+- apiGroups: [""]
+  resources: ["configmaps"]
+  verbs: ["get", "list", "watch", "create", "update", "patch"]
+- apiGroups: ["coordination.k8s.io"]
+  resources: ["leases"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+- apiGroups: [""]
+  resources: ["events"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: etcd-shield:cluster-monitoring-view
+subjects:
+- apiGroup: ""
+  kind: ServiceAccount
+  name: etcd-shield
+  namespace: etcd-shield
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-monitoring-view

--- a/components/etcd-shield/base/service.yaml
+++ b/components/etcd-shield/base/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: etcd-shield-tls
+  name: etcd-shield
+spec:
+  ports:
+  - port: 443
+    protocol: TCP
+    targetPort: 8443
+  selector:
+    app: etcd-shield

--- a/components/etcd-shield/base/webhook.yaml
+++ b/components/etcd-shield/base/webhook.yaml
@@ -1,0 +1,26 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  annotations:
+    service.beta.openshift.io/inject-cabundle: 'true'
+  name: etcd-shield-validating-webhook-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: etcd-shield
+      namespace: etcd-shield
+      path: /validate-tekton-dev-v1-pipelinerun
+  failurePolicy: Fail
+  name: vpipelineruns.konflux-ci.dev
+  rules:
+  - apiGroups:
+    - tekton.dev
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    resources:
+    - pipelineruns
+  sideEffects: None

--- a/components/etcd-shield/staging/stone-stage-p01/kustomization.yaml
+++ b/components/etcd-shield/staging/stone-stage-p01/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../base

--- a/components/etcd-shield/staging/stone-stg-rh01/kustomization.yaml
+++ b/components/etcd-shield/staging/stone-stg-rh01/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../base


### PR DESCRIPTION
Overview
========

etcd-shield is a load-shedding tool designed to provide a more consistent experience to users when an outage is occurring.  When a configured alert is firing, it denies the admission of pipelineruns into the cluster.

Currently, it's configured to watch for etcd's on-disk capacity (hence the name).  The database capacity limits are not stored as prometheus time-series entries, so we're forced to hard-code the current 8GiB limit in the PrometheusRule resource.

In the future, we could add more alerts to match on and more resources types for this service to deny.

Alert configuration
===================

The alert is configured to trigger at 95% capacity, and hold that trigger until capacity drops below 80%.  This is done to provide a buffer between when we stop allowing new resources and when we start providing them again.  We'd like to ensure that when we allow resource admission again, it isn't going to immediately begin denying them; having a gap of 15% will buy the cluster some breathing room.

Of course, these capacity percentages can be changed if we need to.