### PR TITLE
Add temporary permissions to the nginx proxy sa

### DIFF
--- a/components/konflux-ui/staging/base/proxy/proxy.yaml
+++ b/components/konflux-ui/staging/base/proxy/proxy.yaml
@@ -272,6 +272,14 @@ rules:
 - apiGroups: ["authorization.k8s.io"]
   resources: ["localsubjectaccessreviews"]
   verbs: ["create"]
+- apiGroups:  # TEMPORARY SOLUTION TO UNBLOCK KONFLUX-166 WHILE KAR-510 IS NOT SOLVED
+    - "appstudio.redhat.com"
+  resources:
+    - "snapshots"
+    - "releases"
+  verbs:
+    - "list"
+    - "get"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
While KubeArchive does not support impersonation
the Konflux UI team need to have unblocked the
access to the Snapshots and Releases in staging
for KubeArchive.