### PR TITLE
Update Results v0.14.0-4 prod

### DIFF
--- a/components/pipeline-service/production/base/main-pipeline-service-configuration.yaml
+++ b/components/pipeline-service/production/base/main-pipeline-service-configuration.yaml
@@ -1099,7 +1099,7 @@ spec:
             secretKeyRef:
               key: db.name
               name: tekton-results-database
-        image: quay.io/konflux-ci/tekton-results-api:425fcd0988b50965139238038e0d3bd3cb4f8bbc
+        image: quay.io/konflux-ci/tekton-results-api:0a751a1ecaf7ab73f2a756a806d8a18c50c16547
         livenessProbe:
           httpGet:
             path: /healthz
@@ -1289,7 +1289,7 @@ spec:
             secretKeyRef:
               key: db.name
               name: tekton-results-database
-        image: quay.io/konflux-ci/tekton-results-api:425fcd0988b50965139238038e0d3bd3cb4f8bbc
+        image: quay.io/konflux-ci/tekton-results-api:0a751a1ecaf7ab73f2a756a806d8a18c50c16547
         livenessProbe:
           httpGet:
             path: /healthz
@@ -1391,7 +1391,7 @@ spec:
             secretKeyRef:
               key: POSTGRES_PASSWORD
               name: tekton-results-postgres
-        image: quay.io/konflux-ci/tekton-results-retention-policy-agent:425fcd0988b50965139238038e0d3bd3cb4f8bbc
+        image: quay.io/konflux-ci/tekton-results-retention-policy-agent:0a751a1ecaf7ab73f2a756a806d8a18c50c16547
         name: retention-policy-agent
         resources:
           limits:
@@ -1523,7 +1523,9 @@ spec:
           value: tekton-results-api-service-for-watcher.tekton-results.svc.cluster.local:8080
         - name: AUTH_MODE
           value: token
-        image: quay.io/konflux-ci/tekton-results-watcher:425fcd0988b50965139238038e0d3bd3cb4f8bbc
+        - name: KUBERNETES_MIN_VERSION
+          value: "v1.28.0"
+        image: quay.io/konflux-ci/tekton-results-watcher:0a751a1ecaf7ab73f2a756a806d8a18c50c16547
         name: watcher
         ports:
         - containerPort: 9090

--- a/components/pipeline-service/production/kflux-ocp-p01/deploy.yaml
+++ b/components/pipeline-service/production/kflux-ocp-p01/deploy.yaml
@@ -1529,7 +1529,7 @@ spec:
             secretKeyRef:
               key: db.name
               name: tekton-results-database
-        image: quay.io/konflux-ci/tekton-results-api:425fcd0988b50965139238038e0d3bd3cb4f8bbc
+        image: quay.io/konflux-ci/tekton-results-api:0a751a1ecaf7ab73f2a756a806d8a18c50c16547
         livenessProbe:
           httpGet:
             path: /healthz
@@ -1719,7 +1719,7 @@ spec:
             secretKeyRef:
               key: db.name
               name: tekton-results-database
-        image: quay.io/konflux-ci/tekton-results-api:425fcd0988b50965139238038e0d3bd3cb4f8bbc
+        image: quay.io/konflux-ci/tekton-results-api:0a751a1ecaf7ab73f2a756a806d8a18c50c16547
         livenessProbe:
           httpGet:
             path: /healthz
@@ -1824,7 +1824,7 @@ spec:
             secretKeyRef:
               key: POSTGRES_PASSWORD
               name: tekton-results-postgres
-        image: quay.io/konflux-ci/tekton-results-retention-policy-agent:425fcd0988b50965139238038e0d3bd3cb4f8bbc
+        image: quay.io/konflux-ci/tekton-results-retention-policy-agent:0a751a1ecaf7ab73f2a756a806d8a18c50c16547
         name: retention-policy-agent
         resources:
           limits:
@@ -1956,7 +1956,9 @@ spec:
           value: tekton-results-api-service-for-watcher.tekton-results.svc.cluster.local:8080
         - name: AUTH_MODE
           value: token
-        image: quay.io/konflux-ci/tekton-results-watcher:425fcd0988b50965139238038e0d3bd3cb4f8bbc
+        - name: KUBERNETES_MIN_VERSION
+          value: v1.28.0
+        image: quay.io/konflux-ci/tekton-results-watcher:0a751a1ecaf7ab73f2a756a806d8a18c50c16547
         name: watcher
         ports:
         - containerPort: 9090

--- a/components/pipeline-service/production/kflux-prd-rh02/deploy.yaml
+++ b/components/pipeline-service/production/kflux-prd-rh02/deploy.yaml
@@ -1560,7 +1560,7 @@ spec:
             secretKeyRef:
               key: db.name
               name: tekton-results-database
-        image: quay.io/konflux-ci/tekton-results-api:425fcd0988b50965139238038e0d3bd3cb4f8bbc
+        image: quay.io/konflux-ci/tekton-results-api:0a751a1ecaf7ab73f2a756a806d8a18c50c16547
         livenessProbe:
           httpGet:
             path: /healthz
@@ -1750,7 +1750,7 @@ spec:
             secretKeyRef:
               key: db.name
               name: tekton-results-database
-        image: quay.io/konflux-ci/tekton-results-api:425fcd0988b50965139238038e0d3bd3cb4f8bbc
+        image: quay.io/konflux-ci/tekton-results-api:0a751a1ecaf7ab73f2a756a806d8a18c50c16547
         livenessProbe:
           httpGet:
             path: /healthz
@@ -1855,7 +1855,7 @@ spec:
             secretKeyRef:
               key: POSTGRES_PASSWORD
               name: tekton-results-postgres
-        image: quay.io/konflux-ci/tekton-results-retention-policy-agent:425fcd0988b50965139238038e0d3bd3cb4f8bbc
+        image: quay.io/konflux-ci/tekton-results-retention-policy-agent:0a751a1ecaf7ab73f2a756a806d8a18c50c16547
         name: retention-policy-agent
         resources:
           limits:
@@ -1987,7 +1987,9 @@ spec:
           value: tekton-results-api-service-for-watcher.tekton-results.svc.cluster.local:8080
         - name: AUTH_MODE
           value: token
-        image: quay.io/konflux-ci/tekton-results-watcher:425fcd0988b50965139238038e0d3bd3cb4f8bbc
+        - name: KUBERNETES_MIN_VERSION
+          value: v1.28.0
+        image: quay.io/konflux-ci/tekton-results-watcher:0a751a1ecaf7ab73f2a756a806d8a18c50c16547
         name: watcher
         ports:
         - containerPort: 9090

--- a/components/pipeline-service/production/kflux-prd-rh03/deploy.yaml
+++ b/components/pipeline-service/production/kflux-prd-rh03/deploy.yaml
@@ -1560,7 +1560,7 @@ spec:
             secretKeyRef:
               key: db.name
               name: tekton-results-database
-        image: quay.io/konflux-ci/tekton-results-api:425fcd0988b50965139238038e0d3bd3cb4f8bbc
+        image: quay.io/konflux-ci/tekton-results-api:0a751a1ecaf7ab73f2a756a806d8a18c50c16547
         livenessProbe:
           httpGet:
             path: /healthz
@@ -1750,7 +1750,7 @@ spec:
             secretKeyRef:
               key: db.name
               name: tekton-results-database
-        image: quay.io/konflux-ci/tekton-results-api:425fcd0988b50965139238038e0d3bd3cb4f8bbc
+        image: quay.io/konflux-ci/tekton-results-api:0a751a1ecaf7ab73f2a756a806d8a18c50c16547
         livenessProbe:
           httpGet:
             path: /healthz
@@ -1855,7 +1855,7 @@ spec:
             secretKeyRef:
               key: POSTGRES_PASSWORD
               name: tekton-results-postgres
-        image: quay.io/konflux-ci/tekton-results-retention-policy-agent:425fcd0988b50965139238038e0d3bd3cb4f8bbc
+        image: quay.io/konflux-ci/tekton-results-retention-policy-agent:0a751a1ecaf7ab73f2a756a806d8a18c50c16547
         name: retention-policy-agent
         resources:
           limits:
@@ -1987,7 +1987,9 @@ spec:
           value: tekton-results-api-service-for-watcher.tekton-results.svc.cluster.local:8080
         - name: AUTH_MODE
           value: token
-        image: quay.io/konflux-ci/tekton-results-watcher:425fcd0988b50965139238038e0d3bd3cb4f8bbc
+        - name: KUBERNETES_MIN_VERSION
+          value: v1.28.0
+        image: quay.io/konflux-ci/tekton-results-watcher:0a751a1ecaf7ab73f2a756a806d8a18c50c16547
         name: watcher
         ports:
         - containerPort: 9090

--- a/components/pipeline-service/production/stone-prd-m01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prd-m01/deploy.yaml
@@ -1529,7 +1529,7 @@ spec:
             secretKeyRef:
               key: db.name
               name: tekton-results-database
-        image: quay.io/konflux-ci/tekton-results-api:425fcd0988b50965139238038e0d3bd3cb4f8bbc
+        image: quay.io/konflux-ci/tekton-results-api:0a751a1ecaf7ab73f2a756a806d8a18c50c16547
         livenessProbe:
           httpGet:
             path: /healthz
@@ -1719,7 +1719,7 @@ spec:
             secretKeyRef:
               key: db.name
               name: tekton-results-database
-        image: quay.io/konflux-ci/tekton-results-api:425fcd0988b50965139238038e0d3bd3cb4f8bbc
+        image: quay.io/konflux-ci/tekton-results-api:0a751a1ecaf7ab73f2a756a806d8a18c50c16547
         livenessProbe:
           httpGet:
             path: /healthz
@@ -1824,7 +1824,7 @@ spec:
             secretKeyRef:
               key: POSTGRES_PASSWORD
               name: tekton-results-postgres
-        image: quay.io/konflux-ci/tekton-results-retention-policy-agent:425fcd0988b50965139238038e0d3bd3cb4f8bbc
+        image: quay.io/konflux-ci/tekton-results-retention-policy-agent:0a751a1ecaf7ab73f2a756a806d8a18c50c16547
         name: retention-policy-agent
         resources:
           limits:
@@ -1956,7 +1956,9 @@ spec:
           value: tekton-results-api-service-for-watcher.tekton-results.svc.cluster.local:8080
         - name: AUTH_MODE
           value: token
-        image: quay.io/konflux-ci/tekton-results-watcher:425fcd0988b50965139238038e0d3bd3cb4f8bbc
+        - name: KUBERNETES_MIN_VERSION
+          value: v1.28.0
+        image: quay.io/konflux-ci/tekton-results-watcher:0a751a1ecaf7ab73f2a756a806d8a18c50c16547
         name: watcher
         ports:
         - containerPort: 9090

--- a/components/pipeline-service/production/stone-prd-rh01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prd-rh01/deploy.yaml
@@ -1529,7 +1529,7 @@ spec:
             secretKeyRef:
               key: db.name
               name: tekton-results-database
-        image: quay.io/konflux-ci/tekton-results-api:425fcd0988b50965139238038e0d3bd3cb4f8bbc
+        image: quay.io/konflux-ci/tekton-results-api:0a751a1ecaf7ab73f2a756a806d8a18c50c16547
         livenessProbe:
           httpGet:
             path: /healthz
@@ -1719,7 +1719,7 @@ spec:
             secretKeyRef:
               key: db.name
               name: tekton-results-database
-        image: quay.io/konflux-ci/tekton-results-api:425fcd0988b50965139238038e0d3bd3cb4f8bbc
+        image: quay.io/konflux-ci/tekton-results-api:0a751a1ecaf7ab73f2a756a806d8a18c50c16547
         livenessProbe:
           httpGet:
             path: /healthz
@@ -1824,7 +1824,7 @@ spec:
             secretKeyRef:
               key: POSTGRES_PASSWORD
               name: tekton-results-postgres
-        image: quay.io/konflux-ci/tekton-results-retention-policy-agent:425fcd0988b50965139238038e0d3bd3cb4f8bbc
+        image: quay.io/konflux-ci/tekton-results-retention-policy-agent:0a751a1ecaf7ab73f2a756a806d8a18c50c16547
         name: retention-policy-agent
         resources:
           limits:
@@ -1956,7 +1956,9 @@ spec:
           value: tekton-results-api-service-for-watcher.tekton-results.svc.cluster.local:8080
         - name: AUTH_MODE
           value: token
-        image: quay.io/konflux-ci/tekton-results-watcher:425fcd0988b50965139238038e0d3bd3cb4f8bbc
+        - name: KUBERNETES_MIN_VERSION
+          value: v1.28.0
+        image: quay.io/konflux-ci/tekton-results-watcher:0a751a1ecaf7ab73f2a756a806d8a18c50c16547
         name: watcher
         ports:
         - containerPort: 9090

--- a/components/pipeline-service/production/stone-prod-p01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prod-p01/deploy.yaml
@@ -1529,7 +1529,7 @@ spec:
             secretKeyRef:
               key: db.name
               name: tekton-results-database
-        image: quay.io/konflux-ci/tekton-results-api:425fcd0988b50965139238038e0d3bd3cb4f8bbc
+        image: quay.io/konflux-ci/tekton-results-api:0a751a1ecaf7ab73f2a756a806d8a18c50c16547
         livenessProbe:
           httpGet:
             path: /healthz
@@ -1719,7 +1719,7 @@ spec:
             secretKeyRef:
               key: db.name
               name: tekton-results-database
-        image: quay.io/konflux-ci/tekton-results-api:425fcd0988b50965139238038e0d3bd3cb4f8bbc
+        image: quay.io/konflux-ci/tekton-results-api:0a751a1ecaf7ab73f2a756a806d8a18c50c16547
         livenessProbe:
           httpGet:
             path: /healthz
@@ -1824,7 +1824,7 @@ spec:
             secretKeyRef:
               key: POSTGRES_PASSWORD
               name: tekton-results-postgres
-        image: quay.io/konflux-ci/tekton-results-retention-policy-agent:425fcd0988b50965139238038e0d3bd3cb4f8bbc
+        image: quay.io/konflux-ci/tekton-results-retention-policy-agent:0a751a1ecaf7ab73f2a756a806d8a18c50c16547
         name: retention-policy-agent
         resources:
           limits:
@@ -1956,7 +1956,9 @@ spec:
           value: tekton-results-api-service-for-watcher.tekton-results.svc.cluster.local:8080
         - name: AUTH_MODE
           value: token
-        image: quay.io/konflux-ci/tekton-results-watcher:425fcd0988b50965139238038e0d3bd3cb4f8bbc
+        - name: KUBERNETES_MIN_VERSION
+          value: v1.28.0
+        image: quay.io/konflux-ci/tekton-results-watcher:0a751a1ecaf7ab73f2a756a806d8a18c50c16547
         name: watcher
         ports:
         - containerPort: 9090

--- a/components/pipeline-service/production/stone-prod-p02/deploy.yaml
+++ b/components/pipeline-service/production/stone-prod-p02/deploy.yaml
@@ -1529,7 +1529,7 @@ spec:
             secretKeyRef:
               key: db.name
               name: tekton-results-database
-        image: quay.io/konflux-ci/tekton-results-api:425fcd0988b50965139238038e0d3bd3cb4f8bbc
+        image: quay.io/konflux-ci/tekton-results-api:0a751a1ecaf7ab73f2a756a806d8a18c50c16547
         livenessProbe:
           httpGet:
             path: /healthz
@@ -1719,7 +1719,7 @@ spec:
             secretKeyRef:
               key: db.name
               name: tekton-results-database
-        image: quay.io/konflux-ci/tekton-results-api:425fcd0988b50965139238038e0d3bd3cb4f8bbc
+        image: quay.io/konflux-ci/tekton-results-api:0a751a1ecaf7ab73f2a756a806d8a18c50c16547
         livenessProbe:
           httpGet:
             path: /healthz
@@ -1824,7 +1824,7 @@ spec:
             secretKeyRef:
               key: POSTGRES_PASSWORD
               name: tekton-results-postgres
-        image: quay.io/konflux-ci/tekton-results-retention-policy-agent:425fcd0988b50965139238038e0d3bd3cb4f8bbc
+        image: quay.io/konflux-ci/tekton-results-retention-policy-agent:0a751a1ecaf7ab73f2a756a806d8a18c50c16547
         name: retention-policy-agent
         resources:
           limits:
@@ -1956,7 +1956,9 @@ spec:
           value: tekton-results-api-service-for-watcher.tekton-results.svc.cluster.local:8080
         - name: AUTH_MODE
           value: token
-        image: quay.io/konflux-ci/tekton-results-watcher:425fcd0988b50965139238038e0d3bd3cb4f8bbc
+        - name: KUBERNETES_MIN_VERSION
+          value: v1.28.0
+        image: quay.io/konflux-ci/tekton-results-watcher:0a751a1ecaf7ab73f2a756a806d8a18c50c16547
         name: watcher
         ports:
         - containerPort: 9090


### PR DESCRIPTION
Update Tekton Results to the v0.14.0-4 downstream version. Allow earlier Kubernetes version (v1.28.0) as the Knative package dependency requires v1.30.0.