### PR TITLE
rbac: disallow certain groups from rolebindings in prod

### DIFF
--- a/components/konflux-rbac/production/base/kustomization.yaml
+++ b/components/konflux-rbac/production/base/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - konflux-contributor-user-actions.yaml
   - konflux-viewer-user-actions.yaml
   - ../../policies/bootstrap-tenant-namespace/
+  - ../../policies/validate-rolebindings/


### PR DESCRIPTION
Disallow the following groups from being subjects in a rolebinding in a tenant namespace:

- `system:anonymous`
- `system:masters`
- `system:unauthenticated`

Staging appears to be stable, so it's likely safe to rollout to production.