### PR TITLE
etcd-shield: fix ApplicationSet name

### DIFF
--- a/argo-cd-apps/base/member/infra-deployments/etcd-shield/etcd-shield.yaml
+++ b/argo-cd-apps/base/member/infra-deployments/etcd-shield/etcd-shield.yaml
@@ -1,7 +1,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: ApplicationSet
 metadata:
-  name: namespace-lister
+  name: etcd-shield
 spec:
   generators:
     - merge:


### PR DESCRIPTION
Overwriting existing applicationsets is a bad idea, don't do it.