### PR TITLE
Remove s390x from dynamic platforms

### DIFF
--- a/components/multi-platform-controller/production/kflux-prd-rh03/host-config.yaml
+++ b/components/multi-platform-controller/production/kflux-prd-rh03/host-config.yaml
@@ -38,10 +38,6 @@ data:
     linux-root/amd64,\
     linux-fast/amd64,\
     linux-extra-fast/amd64,\
-    linux/s390x,\
-    linux-large/s390x,\
-    linux-d200/s390x,\
-    linux-d200-large/s390x,\
     linux/ppc64le,\
     linux-large/ppc64le,\
     linux-xlarge/ppc64le,\


### PR DESCRIPTION
It is a static platform.