### PR TITLE
Fix Vector connection to Minio S3 storage in development environments

### DIFF
--- a/components/vector-tekton-logs-collector/development/vector-helm-values.yaml
+++ b/components/vector-tekton-logs-collector/development/vector-helm-values.yaml
@@ -71,6 +71,8 @@ customConfig:
       inputs: ["remap_app_logs"]
       compression: "none"
       endpoint: ${ENDPOINT}
+      tls:
+        verify_certificate:false
       encoding:
         codec: "text"
       key_prefix: "/logs/{{ `{{ .namespace }}` }}/{{`{{ .result }}`}}/{{`{{ .taskRunUID }}`}}/{{`{{ .container }}`}}"


### PR DESCRIPTION
In development environments, Vector logs were showing "Healthcheck failed" errors 
when trying to connect to Minio (S3 storage).

We're using HTTPS for the MinIO endpoint. Based on [Vector's](https://vector.dev/docs/reference/configuration/sinks/aws_s3/#tls.verify_certificate) docs, this error could be due to TLS certificate issues.