### PR TITLE
KubeArchive: bump to v1, breaking changes

### DIFF
--- a/components/authentication/base/everyone-can-view.yaml
+++ b/components/authentication/base/everyone-can-view.yaml
@@ -4,7 +4,7 @@ metadata:
   name: view-appstudio
 rules:
 - apiGroups:
-  - kubearchive.kubearchive.org
+  - kubearchive.org
   resources:
   - kubearchiveconfigs
   verbs:

--- a/components/kubearchive/base/kubearchive-config.yaml
+++ b/components/kubearchive/base/kubearchive-config.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: kubearchive.kubearchive.org/v1alpha1
+apiVersion: kubearchive.org/v1
 kind: KubeArchiveConfig
 metadata:
   name: kubearchive

--- a/components/kubearchive/base/kubearchive-maintainer.yaml
+++ b/components/kubearchive/base/kubearchive-maintainer.yaml
@@ -4,7 +4,7 @@ metadata:
   name: kubearchive-maintainer
 rules:
   - apiGroups:
-      - kubearchive.kubearchive.org
+      - kubearchive.org
     resources:
       - kubearchiveconfigs
     verbs:

--- a/components/kubearchive/base/kustomization.yaml
+++ b/components/kubearchive/base/kustomization.yaml
@@ -2,7 +2,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- https://github.com/kubearchive/kubearchive/releases/download/v0.12.1/kubearchive.yaml?timeout=90
+- https://github.com/kubearchive/kubearchive/releases/download/v1.0.0/kubearchive.yaml?timeout=90
 - rbac.yaml
 - kubearchive-config.yaml
 - kubearchive-maintainer.yaml
@@ -104,7 +104,17 @@ patches:
       name: kubearchive-validating-webhook-configuration
       annotations:
         service.beta.openshift.io/inject-cabundle: "true"
+
 # These patches solve Kube Linter problems
+# We don't need this CronJob as it is suspended, we can enable it later
+- patch: |-
+    $patch: delete
+    apiVersion: batch/v1
+    kind: CronJob
+    metadata:
+      name: cluster-vacuum
+      namespace: kubearchive
+
 - patch: |-
     apiVersion: apps/v1
     kind: Deployment

--- a/components/kubearchive/policies/.chainsaw-test/resources/actual-kubeconfig-archive.yaml
+++ b/components/kubearchive/policies/.chainsaw-test/resources/actual-kubeconfig-archive.yaml
@@ -1,4 +1,4 @@
-apiVersion: kubearchive.kubearchive.org/v1alpha1
+apiVersion: kubearchive.org/v1
 kind: KubeArchiveConfig
 metadata:
   name: kubearchive

--- a/components/kubearchive/policies/.chainsaw-test/resources/expected-kubearchiveconfig.yaml
+++ b/components/kubearchive/policies/.chainsaw-test/resources/expected-kubearchiveconfig.yaml
@@ -1,4 +1,4 @@
-apiVersion: kubearchive.kubearchive.org/v1alpha1
+apiVersion: kubearchive.org/v1
 kind: KubeArchiveConfig
 metadata:
   name: kubearchive

--- a/components/kubearchive/policies/.chainsaw-test/resources/kubearchive-crd.yaml
+++ b/components/kubearchive/policies/.chainsaw-test/resources/kubearchive-crd.yaml
@@ -6,9 +6,9 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.14.0
     cert-manager.io/inject-ca-from: kubearchive/kubearchive-operator-certificate
-  name: kubearchiveconfigs.kubearchive.kubearchive.org
+  name: kubearchiveconfigs.kubearchive.org
 spec:
-  group: kubearchive.kubearchive.org
+  group: kubearchive.org
   names:
     kind: KubeArchiveConfig
     listKind: KubeArchiveConfigList
@@ -19,7 +19,7 @@ spec:
     singular: kubearchiveconfig
   scope: Namespaced
   versions:
-    - name: v1alpha1
+    - name: v1
       schema:
         openAPIV3Schema:
           description: KubeArchiveConfig is the Schema for the kubearchiveconfigs API

--- a/components/kubearchive/policies/bootstrap-namespace.yaml
+++ b/components/kubearchive/policies/bootstrap-namespace.yaml
@@ -15,7 +15,7 @@ spec:
               konflux-ci.dev/type: tenant
     generate:
       generateExisting: true
-      apiVersion: kubearchive.kubearchive.org/v1alpha1
+      apiVersion: kubearchive.org/v1
       kind: KubeArchiveConfig
       name: kubearchive
       namespace: '{{request.object.metadata.name}}'

--- a/components/kubearchive/policies/kyverno_rbac.yaml
+++ b/components/kubearchive/policies/kyverno_rbac.yaml
@@ -7,7 +7,7 @@ metadata:
     rbac.kyverno.io/aggregate-to-admission-controller: "true"
 rules:
 - apiGroups:
-  - kubearchive.kubearchive.org
+  - kubearchive.org
   resources:
   - kubearchiveconfigs
   verbs:
@@ -22,7 +22,7 @@ metadata:
     rbac.kyverno.io/aggregate-to-background-controller: "true"
 rules:
 - apiGroups:
-  - kubearchive.kubearchive.org
+  - kubearchive.org
   resources:
   - kubearchiveconfigs
   verbs:

--- a/components/kubearchive/policies/resources/expected-kubearchiveconfig-konflux.yaml
+++ b/components/kubearchive/policies/resources/expected-kubearchiveconfig-konflux.yaml
@@ -1,4 +1,4 @@
-apiVersion: kubearchive.kubearchive.org/v1alpha1
+apiVersion: kubearchive.org/v1
 kind: KubeArchiveConfig
 metadata:
   name: kubearchive

--- a/components/release/staging/kustomization.yaml
+++ b/components/release/staging/kustomization.yaml
@@ -11,8 +11,8 @@ patches:
   - path: kubearchive-config-patch.yaml
     target:
       name: kubearchive
-      group: kubearchive.kubearchive.org
-      version: v1alpha1
+      group: kubearchive.org
+      version: v1
       kind: KubeArchiveConfig
 
 components:


### PR DESCRIPTION
This PR bumps KubeArchive to v1.0.0. This release includes breaking changes in the `apiVersion` of the KubeArchive CRDs: the group changes from `kubearchive.kubearchive.org` to `kubearchive.org` and the version changes from `v1alpha` to `v1`.

I tested it locally and Kyverno should create the new objects without any problems and I tried the deletion too. All existing `KubeArchiveConfig`s that are `kubearchive.kubearchive.org/v1alpha` need to have their `finalizer` removed and then deleted. I'm using:

```
kubectl patch -n <namespace> kubearchiveconfigs.kubearchive.kubearchive.org kubearchive -p '{"metadata": {"finalizers": []}}' --type=merge
kubectl delete -n <namespace> kubearchiveconfigs.kubearchive.kubearchive.org kubearchive
```

The CRD also needs to be deleted as far as I know, even if ArgoCD will try to remove it:

```
kubectl delete crd kubearchiveconfigs.kubearchive.kubearchive.org
```

There are no changes no the database, so it can merged mostly unattended.

**Questions**

* I don't know if I have wide-cluster permissions, I guess I should not, so I'm not sure if I will be able to delete the old resources and the CRD. Someone could  jump in for that?