### PR TITLE
chore(ecp): update tag for ec-task-policy

### DIFF
--- a/components/enterprise-contract/ecp.yaml
+++ b/components/enterprise-contract/ecp.yaml
@@ -130,4 +130,4 @@ spec:
         - github.com/release-engineering/rhtap-ec-policy//data
       name: Default
       policy:
-        - oci::quay.io/enterprise-contract/ec-task-policy:git-2b9b061@sha256:9da69bec5b8c23df2b194c9a480f0965515d0f1f96f72fa0ebc138baf64ffd1a
+        - oci::quay.io/enterprise-contract/ec-task-policy:konflux


### PR DESCRIPTION
This commit updates the configuration of the redhat-trusted-tasks to use the floating tag `konflux`

Ref: EC-1161