### PR TITLE
etcd-shield: fixes

### DIFF
--- a/argo-cd-apps/base/member/infra-deployments/kustomization.yaml
+++ b/argo-cd-apps/base/member/infra-deployments/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
   - pipeline-service
   - build-templates
   - etcd-defrag
+  - etcd-shield
   - internal-services
   - image-controller
   - multi-platform-controller

--- a/argo-cd-apps/overlays/development/delete-applications.yaml
+++ b/argo-cd-apps/overlays/development/delete-applications.yaml
@@ -130,3 +130,9 @@ kind: ApplicationSet
 metadata:
   name: etcd-defrag
 $patch: delete
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: etcd-shield
+$patch: delete

--- a/argo-cd-apps/overlays/konflux-public-production/delete-applications.yaml
+++ b/argo-cd-apps/overlays/konflux-public-production/delete-applications.yaml
@@ -24,3 +24,9 @@ kind: ApplicationSet
 metadata:
   name: power-monitoring
 $patch: delete
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: etcd-shield
+$patch: delete

--- a/argo-cd-apps/overlays/production-downstream/delete-applications.yaml
+++ b/argo-cd-apps/overlays/production-downstream/delete-applications.yaml
@@ -42,3 +42,9 @@ kind: ApplicationSet
 metadata:
   name: nvme-storage-configurator
 $patch: delete
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: etcd-shield
+$patch: delete

--- a/components/etcd-shield/base/etcd_shield_alerts.yaml
+++ b/components/etcd-shield/base/etcd_shield_alerts.yaml
@@ -18,17 +18,11 @@ spec:
         description: Etcd is nearing capacity limits, so etcd-shield is denying admission
     - record: etcd_shield_trigger
       expr: |
-        (((max(etcd_mvcc_db_total_size_in_bytes) >= bool (etcd_shield_db_size * etcd_shield_upper_threshold)) == 1) or
-            (((max(etcd_mvcc_db_total_size_in_bytes) >= bool (etcd_shield_db_size * etcd_shield_lower_threshold)) == 1) and
-            ((count without (alertname, alertstate, severity)
-                (ALERTS{
-                  alertname="EtcdShieldDenyAdmission",
-                  alertstate="firing",
-                  severity="critical"
-                }) == bool 1) != 0)))
-    - record: etcd_shield_db_size
-      expr: vector(8589934592)  # 2 ** 33 bytes, or 8GiB
-    - record: etcd_shield_upper_threshold
-      expr: vector(0.95)
-    - record: etcd_shield_lower_threshold
-      expr: vector(0.80)
+        (((etcd_mvcc_db_total_size_in_bytes >= bool (etcd_server_quota_backend_bytes * 0.95)) == 1) or
+            ((((etcd_mvcc_db_total_size_in_bytes) >= bool (etcd_server_quota_backend_bytes * 0.8)) == 1) and
+                (count without (alertname, alertstate, severity)
+                      (ALERTS{
+                        alertname="EtcdShieldDenyAdmission",
+                        alertstate="firing",
+                        severity="critical"
+                      }) == bool 1)))


### PR DESCRIPTION
Two important changes:
- Pull etcd's maximum size from its own metrics, rather than hard-code it ourselves.  This is information it exposes, so use it.
- Actually deploy the applicationset as a part of the staging overlays.