### PR TITLE
etcd-shield: deploy to production

### DIFF
--- a/argo-cd-apps/base/member/infra-deployments/etcd-shield/etcd-shield.yaml
+++ b/argo-cd-apps/base/member/infra-deployments/etcd-shield/etcd-shield.yaml
@@ -18,6 +18,18 @@ spec:
                   values.clusterDir: stone-stg-rh01
                 - nameNormalized: stone-stage-p01
                   values.clusterDir: stone-stage-p01
+                - nameNormalized: kflux-ocp-p01
+                  values.clusterDir: kflux-ocp-p01
+                - nameNormalized: kflux-prd-rh02
+                  values.clusterDir: kflux-prd-rh02
+                - nameNormalized: kflux-prd-rh03
+                  values.clusterDir: kflux-prd-rh03
+                - nameNormalized: stone-prd-rh01
+                  values.clusterDir: stone-prd-rh01
+                - nameNormalized: stone-prod-p01
+                  values.clusterDir: stone-prod-p01
+                - nameNormalized: stone-prod-p02
+                  values.clusterDir: stone-prod-p02
   template:
     metadata:
       name: etcd-shield-{{nameNormalized}}

--- a/argo-cd-apps/overlays/konflux-public-production/kustomization.yaml
+++ b/argo-cd-apps/overlays/konflux-public-production/kustomization.yaml
@@ -226,3 +226,8 @@ patches:
       kind: ApplicationSet
       version: v1alpha1
       name: knative-eventing
+  - path: production-overlay-patch.yaml
+    target:
+      kind: ApplicationSet
+      version: v1alpha1
+      name: etcd-shield

--- a/argo-cd-apps/overlays/production-downstream/kustomization.yaml
+++ b/argo-cd-apps/overlays/production-downstream/kustomization.yaml
@@ -236,3 +236,8 @@ patches:
       kind: ApplicationSet
       version: v1alpha1
       name: knative-eventing
+  - path: production-overlay-patch.yaml
+    target:
+      kind: ApplicationSet
+      version: v1alpha1
+      name: etcd-shield

--- a/components/etcd-shield/production/base/config.yaml
+++ b/components/etcd-shield/production/base/config.yaml
@@ -1,0 +1,12 @@
+destName: etcd-shield-state
+destNamespace: etcd-shield
+prometheus:
+  address: https://prometheus-k8s.openshift-monitoring.svc:9091
+  alertName: EtcdShieldDenyAdmission
+  config:
+    authorization:
+      type: Bearer
+      credentials_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+    tls_config:
+      ca_file: /var/tls/tls.crt
+waitTime: 15s

--- a/components/etcd-shield/production/base/deployment.yaml
+++ b/components/etcd-shield/production/base/deployment.yaml
@@ -1,0 +1,79 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: etcd-shield
+  labels:
+    app: etcd-shield
+spec:
+  selector:
+    matchLabels:
+      app: etcd-shield
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: etcd-shield
+    spec:
+      serviceAccountName: etcd-shield
+      containers:
+      - args:
+        - -leader-elect
+        - -health-probe-bind-address=:8081
+        - -config=/etc/etcd-shield/config.yaml
+        - -port=8443
+        env:
+        - name: "NAMESPACE"
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        image: etcd-shield:latest
+        name: etcd-shield
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          initialDelaySeconds: 1
+          httpGet:
+            path: /healthz
+            port: 8081
+            scheme: HTTP
+        readinessProbe:
+          initialDelaySeconds: 1
+          httpGet:
+            path: /readyz
+            port: 8081
+            scheme: HTTP
+        resources:
+          limits:
+            cpu: 500m
+            memory: 128Mi
+          requests:
+            cpu: 500m
+            memory: 128Mi
+        ports:
+        - containerPort: 8443
+          name: http
+        - containerPort: 8081
+          name: healthz
+        - containerPort: 9100
+          name: metrics
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          capabilities:
+            drop:
+            - "ALL"
+        volumeMounts:
+        - name: tls
+          mountPath: /var/tls
+          readOnly: true
+        - name: config
+          mountPath: /etc/etcd-shield/
+          readOnly: true
+      terminationGracePeriodSeconds: 60
+      volumes:
+      - name: tls
+        secret:
+          secretName: etcd-shield-tls
+      - name: config
+        configMap:
+          name: etcd-shield-config

--- a/components/etcd-shield/production/base/etcd_shield_alerts.yaml
+++ b/components/etcd-shield/production/base/etcd_shield_alerts.yaml
@@ -1,0 +1,28 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: etcd-shield-triggers
+spec:
+  groups:
+  - name: etcd_shield_triggers
+    interval: 1m
+    rules:
+    - alert: EtcdShieldDenyAdmission
+      expr: etcd_shield_trigger != bool 0
+      for: 2m
+      keep_firing_for: 5m
+      labels:
+        severity: critical
+      annotations:
+        summary: etcd-shield is denying admission
+        description: Etcd is nearing capacity limits, so etcd-shield is denying admission
+    - record: etcd_shield_trigger
+      expr: |
+        (((etcd_mvcc_db_total_size_in_bytes >= bool (etcd_server_quota_backend_bytes * 0.95)) == 1) or
+            ((((etcd_mvcc_db_total_size_in_bytes) >= bool (etcd_server_quota_backend_bytes * 0.8)) == 1) and
+                (count without (alertname, alertstate, severity)
+                      (ALERTS{
+                        alertname="EtcdShieldDenyAdmission",
+                        alertstate="firing",
+                        severity="critical"
+                      }) == bool 1)))

--- a/components/etcd-shield/production/base/kustomization.yaml
+++ b/components/etcd-shield/production/base/kustomization.yaml
@@ -1,0 +1,21 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+configMapGenerator:
+- files:
+  - ./config.yaml
+  name: etcd-shield-config
+# generatorOptions:
+#   # until https://github.com/kubernetes-sigs/kustomize/issues/4475 is fixed
+#   disableNameSuffixHash: true
+images:
+- name: etcd-shield
+  newName: quay.io/konflux-ci/etcd-shield
+  newTag: 3de52a71e086e152b3d2b33bfc897ce7bf8ea0dd
+namespace: etcd-shield
+resources:
+- deployment.yaml
+- ns.yaml
+- rbac.yaml
+- service.yaml
+- webhook.yaml
+- etcd_shield_alerts.yaml

--- a/components/etcd-shield/production/base/ns.yaml
+++ b/components/etcd-shield/production/base/ns.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: etcd-shield
+  labels:
+    openshift.io/cluster-monitoring: "true"

--- a/components/etcd-shield/production/base/rbac.yaml
+++ b/components/etcd-shield/production/base/rbac.yaml
@@ -1,0 +1,63 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: etcd-shield
+  namespace: etcd-shield
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: etcd-shield-authorizer
+subjects:
+- apiGroup: ""
+  kind: ServiceAccount
+  name: etcd-shield
+  namespace: etcd-shield
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: etcd-shield-authorizer
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: etcd-shield
+subjects:
+- apiGroup: ""
+  kind: ServiceAccount
+  name: etcd-shield
+  namespace: etcd-shield
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: etcd-shield
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: etcd-shield
+  namespace: etcd-shield
+rules:
+- apiGroups: [""]
+  resources: ["configmaps"]
+  verbs: ["get", "list", "watch", "create", "update", "patch"]
+- apiGroups: ["coordination.k8s.io"]
+  resources: ["leases"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+- apiGroups: [""]
+  resources: ["events"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: etcd-shield:cluster-monitoring-view
+subjects:
+- apiGroup: ""
+  kind: ServiceAccount
+  name: etcd-shield
+  namespace: etcd-shield
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-monitoring-view

--- a/components/etcd-shield/production/base/service.yaml
+++ b/components/etcd-shield/production/base/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: etcd-shield-tls
+  name: etcd-shield
+spec:
+  ports:
+  - port: 443
+    protocol: TCP
+    targetPort: 8443
+  selector:
+    app: etcd-shield

--- a/components/etcd-shield/production/base/webhook.yaml
+++ b/components/etcd-shield/production/base/webhook.yaml
@@ -1,0 +1,26 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  annotations:
+    service.beta.openshift.io/inject-cabundle: 'true'
+  name: etcd-shield-validating-webhook-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: etcd-shield
+      namespace: etcd-shield
+      path: /validate-tekton-dev-v1-pipelinerun
+  failurePolicy: Fail
+  name: vpipelineruns.konflux-ci.dev
+  rules:
+  - apiGroups:
+    - tekton.dev
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    resources:
+    - pipelineruns
+  sideEffects: None

--- a/components/etcd-shield/production/kflux-ocp-p01/kustomization.yaml
+++ b/components/etcd-shield/production/kflux-ocp-p01/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../base

--- a/components/etcd-shield/production/kflux-prd-rh02/kustomization.yaml
+++ b/components/etcd-shield/production/kflux-prd-rh02/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../base

--- a/components/etcd-shield/production/kflux-prd-rh03/kustomization.yaml
+++ b/components/etcd-shield/production/kflux-prd-rh03/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../base

--- a/components/etcd-shield/production/stone-prd-rh01/kustomization.yaml
+++ b/components/etcd-shield/production/stone-prd-rh01/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../base

--- a/components/etcd-shield/production/stone-prod-p01/kustomization.yaml
+++ b/components/etcd-shield/production/stone-prod-p01/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../base

--- a/components/etcd-shield/production/stone-prod-p02/kustomization.yaml
+++ b/components/etcd-shield/production/stone-prod-p02/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../base


### PR DESCRIPTION
Deploys to all production clusters.  Production manifests are kept distinct from staging manifests.