### PR TITLE
Remove IBM from stone-prod-p01

### DIFF
--- a/components/multi-platform-controller/production-downstream/stone-prod-p01/host-config.yaml
+++ b/components/multi-platform-controller/production-downstream/stone-prod-p01/host-config.yaml
@@ -41,11 +41,7 @@ data:
     linux-c8xlarge/arm64,\
     linux-g6xlarge/amd64,\
     linux-root/arm64,\
-    linux-root/amd64,\
-    linux/s390x,\
-    linux-large/s390x,\
-    linux/ppc64le,\
-    linux-large/ppc64le\
+    linux-root/amd64\
     "
   instance-tag: rhtap-prod
 
@@ -573,70 +569,6 @@ data:
     restorecon -r /home/ec2-user
     
     --//--
-
-  ## IBM s390x with 2CPU 8GiB RAM ####
-  dynamic.linux-s390x.type: ibmz
-  dynamic.linux-s390x.ssh-secret: "internal-prod-ibm-ssh-key"
-  dynamic.linux-s390x.secret: "internal-prod-ibm-api-key"
-  dynamic.linux-s390x.vpc: "konflux-internal-prod-us-east-1"
-  dynamic.linux-s390x.key: "internal-prod-key"
-  dynamic.linux-s390x.subnet: "internal-a"
-  dynamic.linux-s390x.image-id: "r014-23be9e67-4ab2-4dc9-9a51-d56efb06943d"
-  dynamic.linux-s390x.region: "us-east-1"
-  dynamic.linux-s390x.url: "https://us-east.iaas.cloud.ibm.com/v1"
-  dynamic.linux-s390x.profile: "bz2-2x8"
-  dynamic.linux-s390x.max-instances: "50"
-  dynamic.linux-s390x.private-ip: "true"
-  dynamic.linux-s390x.allocation-timeout: "1800"
-  dynamic.linux-s390x.instance-tag: prod-s390x
-
-  ## IBM s390x with 4CPU 16GiB RAM ####
-  dynamic.linux-large-s390x.type: ibmz
-  dynamic.linux-large-s390x.ssh-secret: "internal-prod-ibm-ssh-key"
-  dynamic.linux-large-s390x.secret: "internal-prod-ibm-api-key"
-  dynamic.linux-large-s390x.vpc: "konflux-internal-prod-us-east-1"
-  dynamic.linux-large-s390x.key: "internal-prod-key"
-  dynamic.linux-large-s390x.subnet: "internal-a"
-  dynamic.linux-large-s390x.image-id: "r014-23be9e67-4ab2-4dc9-9a51-d56efb06943d"
-  dynamic.linux-large-s390x.region: "us-east-1"
-  dynamic.linux-large-s390x.url: "https://us-east.iaas.cloud.ibm.com/v1"
-  dynamic.linux-large-s390x.profile: "bz2-4x16"
-  dynamic.linux-large-s390x.max-instances: "50"
-  dynamic.linux-large-s390x.private-ip: "true"
-  dynamic.linux-large-s390x.allocation-timeout: "1800"
-  dynamic.linux-large-s390x.instance-tag: prod-s390x-large
-
-  #PPC64LE dynamic nodes
-  dynamic.linux-ppc64le.type: ibmp
-  dynamic.linux-ppc64le.ssh-secret: "internal-prod-ibm-ssh-key"
-  dynamic.linux-ppc64le.secret: "internal-prod-ibm-api-key"
-  dynamic.linux-ppc64le.key: "prod-konflux-infra"
-  dynamic.linux-ppc64le.image: "konflux-internal-prod-ppc-base-oct-04-24"
-  dynamic.linux-ppc64le.crn: "crn:v1:bluemix:public:power-iaas:wdc06:a/5cb0704ee6304413bd0b171372c0fd77:4e9dc638-7a78-4e7c-b432-e83b7010c531::"
-  dynamic.linux-ppc64le.url: "https://us-east.power-iaas.cloud.ibm.com"
-  dynamic.linux-ppc64le.network: "a6d8d6da-c412-4106-9b57-4e25541b2e7f"
-  dynamic.linux-ppc64le.system: "e980"
-  dynamic.linux-ppc64le.cores: "2"
-  dynamic.linux-ppc64le.memory: "8"
-  dynamic.linux-ppc64le.max-instances: "50"
-  dynamic.linux-ppc64le.allocation-timeout: "1800"
-  dynamic.linux-ppc64le.instance-tag: prod-ppc64le
-
-  #PPC64LE Large dynamic nodes
-  dynamic.linux-large-ppc64le.type: ibmp
-  dynamic.linux-large-ppc64le.ssh-secret: "internal-prod-ibm-ssh-key"
-  dynamic.linux-large-ppc64le.secret: "internal-prod-ibm-api-key"
-  dynamic.linux-large-ppc64le.key: "prod-konflux-infra"
-  dynamic.linux-large-ppc64le.image: "konflux-internal-prod-ppc-base-oct-04-24"
-  dynamic.linux-large-ppc64le.crn: "crn:v1:bluemix:public:power-iaas:wdc06:a/5cb0704ee6304413bd0b171372c0fd77:4e9dc638-7a78-4e7c-b432-e83b7010c531::"
-  dynamic.linux-large-ppc64le.url: "https://us-east.power-iaas.cloud.ibm.com"
-  dynamic.linux-large-ppc64le.network: "a6d8d6da-c412-4106-9b57-4e25541b2e7f"
-  dynamic.linux-large-ppc64le.system: "e980"
-  dynamic.linux-large-ppc64le.cores: "4"
-  dynamic.linux-large-ppc64le.memory: "16"
-  dynamic.linux-large-ppc64le.max-instances: "50"
-  dynamic.linux-large-ppc64le.allocation-timeout: "1800"
-  dynamic.linux-large-ppc64le.instance-tag: prod-ppc64le-large
 
   # AWS GPU Nodes
   dynamic.linux-g6xlarge-amd64.type: aws


### PR DESCRIPTION
This cluster cannot support IBM arch due to a conflict between OCP pods CIDR and IBM one. This is why we create p02, it is the replacement of p01. Until we retire p01, remove IBM from MPC as it might confuse people into thinking that p01 support IBM arch.