### PR TITLE
Add one more s390x VM to rh01

### DIFF
--- a/components/multi-platform-controller/production/stone-prd-rh01/host-config.yaml
+++ b/components/multi-platform-controller/production/stone-prd-rh01/host-config.yaml
@@ -625,6 +625,12 @@ data:
   host.s390x-static-6.secret: "ibm-s390x-static-ssh-key"
   host.s390x-static-6.concurrency: "4"
 
+  host.s390x-static-8.address: "10.249.66.21"
+  host.s390x-static-8.platform: "linux/s390x"
+  host.s390x-static-8.user: "root"
+  host.s390x-static-8.secret: "ibm-s390x-static-ssh-key"
+  host.s390x-static-8.concurrency: "4"
+
   host.s390x-static-9.address: "10.249.65.14"
   host.s390x-static-9.platform: "linux/s390x"
   host.s390x-static-9.user: "root"


### PR DESCRIPTION
With this one, we are only missing one to get to the 16 objective, which would allow to match the 64 concurrent builds we can do on PPC side.