### PR TITLE
test correct default pipelines security group in kflux-rh02

### DIFF
--- a/components/pipeline-service/production/kflux-prd-rh02/deploy.yaml
+++ b/components/pipeline-service/production/kflux-prd-rh02/deploy.yaml
@@ -2479,6 +2479,8 @@ spec:
             namespace }}/pipelinerun/{{ pr }}
           custom-console-url-pr-tasklog: https://konflux-ui.apps.kflux-prd-rh02.0fk9.p1.openshiftapps.com/ns/{{
             namespace }}/pipelinerun/{{ pr }}/logs/{{ task }}
+      scc:
+        default: appstudio-pipelines-scc
   profile: all
   pruner:
     disabled: false

--- a/components/pipeline-service/production/kflux-prd-rh02/resources/kustomization.yaml
+++ b/components/pipeline-service/production/kflux-prd-rh02/resources/kustomization.yaml
@@ -38,3 +38,8 @@ patches:
     target:
       kind: TektonConfig
       name: config
+  # TODO: either remove this or move it to the base config
+  - path: temp-set-pipelines-default-scc.yaml
+    target:
+      kind: TektonConfig
+      name: config

--- a/components/pipeline-service/production/kflux-prd-rh02/resources/temp-set-pipelines-default-scc.yaml
+++ b/components/pipeline-service/production/kflux-prd-rh02/resources/temp-set-pipelines-default-scc.yaml
@@ -1,0 +1,5 @@
+---
+- op: add
+  path: /spec/platforms/openshift/scc
+  value:
+    default: appstudio-pipelines-scc


### PR DESCRIPTION
The current default appears to be set as `pipelines-scc`, which does not exist....

More context in [this slack thread](https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1746731894794529?thread_ts=1746425126.665539&cid=C04PZ7H0VA8)
