### PR TITLE
Create ClusterRoles appropriate for service accounts

### DIFF
--- a/components/konflux-rbac/production/base/konflux-builder-bot-actions.yaml
+++ b/components/konflux-rbac/production/base/konflux-builder-bot-actions.yaml
@@ -1,0 +1,18 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: konflux-builder-bot-actions
+rules:
+- apiGroups:
+  - tekton.dev
+  resources:
+  - pipelineruns
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+

--- a/components/konflux-rbac/production/base/konflux-releaser-bot-actions.yaml
+++ b/components/konflux-rbac/production/base/konflux-releaser-bot-actions.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: konflux-builder-bot-actions
+rules:
+- apiGroups:
+  - appstudio.redhat.com
+  resources:
+  - releases
+  verbs:
+  - watch
+  - create

--- a/components/konflux-rbac/production/base/kustomization.yaml
+++ b/components/konflux-rbac/production/base/kustomization.yaml
@@ -5,6 +5,8 @@ resources:
   - konflux-maintainer-user-actions.yaml
   - konflux-contributor-user-actions.yaml
   - konflux-viewer-user-actions.yaml
+  - konflux-builder-bot-actions.yaml
+  - konflux-releaser-bot-actions.yaml
   - ../../policies/bootstrap-tenant-namespace/
   - ../../policies/restrict-binding-system-authenticated/
   - ../../policies/validate-rolebindings/

--- a/components/konflux-rbac/staging/base/konflux-builder-bot-actions.yaml
+++ b/components/konflux-rbac/staging/base/konflux-builder-bot-actions.yaml
@@ -1,0 +1,18 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: konflux-builder-bot-actions
+rules:
+- apiGroups:
+  - tekton.dev
+  resources:
+  - pipelineruns
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+

--- a/components/konflux-rbac/staging/base/konflux-releaser-bot-actions.yaml
+++ b/components/konflux-rbac/staging/base/konflux-releaser-bot-actions.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: konflux-builder-bot-actions
+rules:
+- apiGroups:
+  - appstudio.redhat.com
+  resources:
+  - releases
+  verbs:
+  - watch
+  - create

--- a/components/konflux-rbac/staging/base/kustomization.yaml
+++ b/components/konflux-rbac/staging/base/kustomization.yaml
@@ -5,6 +5,8 @@ resources:
   - konflux-maintainer-user-actions.yaml
   - konflux-contributor-user-actions.yaml
   - konflux-viewer-user-actions.yaml
+  - konflux-builder-bot-actions.yaml
+  - konflux-releaser-bot-actions.yaml
   - ../../policies/bootstrap-tenant-namespace/
   - ../../policies/restrict-binding-system-authenticated/
   - ../../policies/validate-rolebindings/


### PR DESCRIPTION
Here, I'm thinking to add something similar like what is used by the art tenant. There, there's an in-namespace Role. But, general, consistent clusterroles across clusters will be helpful to other users who want to do similar things.