### PR TITLE
Revert "test correct default pipelines security group in kflux-rh02"

### DIFF
--- a/components/pipeline-service/production/kflux-prd-rh02/deploy.yaml
+++ b/components/pipeline-service/production/kflux-prd-rh02/deploy.yaml
@@ -2479,8 +2479,6 @@ spec:
             namespace }}/pipelinerun/{{ pr }}
           custom-console-url-pr-tasklog: https://konflux-ui.apps.kflux-prd-rh02.0fk9.p1.openshiftapps.com/ns/{{
             namespace }}/pipelinerun/{{ pr }}/logs/{{ task }}
-      scc:
-        default: appstudio-pipelines-scc
   profile: all
   pruner:
     disabled: false

--- a/components/pipeline-service/production/kflux-prd-rh02/resources/kustomization.yaml
+++ b/components/pipeline-service/production/kflux-prd-rh02/resources/kustomization.yaml
@@ -38,8 +38,3 @@ patches:
     target:
       kind: TektonConfig
       name: config
-  # TODO: either remove this or move it to the base config
-  - path: temp-set-pipelines-default-scc.yaml
-    target:
-      kind: TektonConfig
-      name: config

--- a/components/pipeline-service/production/kflux-prd-rh02/resources/temp-set-pipelines-default-scc.yaml
+++ b/components/pipeline-service/production/kflux-prd-rh02/resources/temp-set-pipelines-default-scc.yaml
@@ -1,5 +1,0 @@
----
-- op: add
-  path: /spec/platforms/openshift/scc
-  value:
-    default: appstudio-pipelines-scc


### PR DESCRIPTION
Reverts redhat-appstudio/infra-deployments#6353

This change did not resolve the issue, so the change is being reverted 