### PR TITLE
add list RoleBindings to maintainers and contributors in staging

### DIFF
--- a/components/konflux-rbac/staging/base/konflux-contributor-user-actions.yaml
+++ b/components/konflux-rbac/staging/base/konflux-contributor-user-actions.yaml
@@ -125,3 +125,9 @@ rules:
     resources:
       - cronjobs
       - jobs
+  - verbs:
+      - list
+    apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - rolebindings

--- a/components/konflux-rbac/staging/base/konflux-maintainer-user-actions.yaml
+++ b/components/konflux-rbac/staging/base/konflux-maintainer-user-actions.yaml
@@ -139,3 +139,9 @@ rules:
     resources:
       - cronjobs
       - jobs
+  - verbs:
+      - list
+    apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - rolebindings


### PR DESCRIPTION
This change fixes the visibility problem maintainers and contributors
are facing in the New UI's User Access page.

Signed-off-by: Francesco Ilario <filario@redhat.com>
