### PR TITLE
etcd-shield: enable in production

### DIFF
--- a/argo-cd-apps/overlays/konflux-public-production/delete-applications.yaml
+++ b/argo-cd-apps/overlays/konflux-public-production/delete-applications.yaml
@@ -24,9 +24,3 @@ kind: ApplicationSet
 metadata:
   name: power-monitoring
 $patch: delete
----
-apiVersion: argoproj.io/v1alpha1
-kind: ApplicationSet
-metadata:
-  name: etcd-shield
-$patch: delete

--- a/argo-cd-apps/overlays/production-downstream/delete-applications.yaml
+++ b/argo-cd-apps/overlays/production-downstream/delete-applications.yaml
@@ -42,9 +42,3 @@ kind: ApplicationSet
 metadata:
   name: nvme-storage-configurator
 $patch: delete
----
-apiVersion: argoproj.io/v1alpha1
-kind: ApplicationSet
-metadata:
-  name: etcd-shield
-$patch: delete


### PR DESCRIPTION
Remove the patch deleting etcd-shield from production overlays.