### PR TITLE
fix(PVO11Y-4653): Add es01 clusterDir for monitoring-workload-prometheus

### DIFF
--- a/argo-cd-apps/base/all-clusters/infra-deployments/monitoring-workload-prometheus/monitoring-workload-prometheus.yaml
+++ b/argo-cd-apps/base/all-clusters/infra-deployments/monitoring-workload-prometheus/monitoring-workload-prometheus.yaml
@@ -37,6 +37,10 @@ spec:
                   values.clusterDir: kflux-prd-rh02
                 - nameNormalized: kflux-prd-rh03
                   values.clusterDir: kflux-prd-rh03
+                - nameNormalized: kflux-stg-es01
+                  values.clusterDir: kflux-stg-es01
+                - nameNormalized: kflux-prd-es01
+                  values.clusterDir: kflux-prd-es01
   template:
     metadata:
       name: monitoring-workload-prometheus-{{nameNormalized}}


### PR DESCRIPTION
#6332 adds some external labeling for es01 that is not being applied due to es01 clusters defaulting to the base kustomize configuration for monitoring-workload-prometheus.
Added es01 clusterDir so those clusters can use their own kustomize configuration instead.