### PR TITLE
Builder serviceaccounts should be able to inspect events

### DIFF
--- a/components/konflux-rbac/production/base/konflux-builder-bot-actions.yaml
+++ b/components/konflux-rbac/production/base/konflux-builder-bot-actions.yaml
@@ -15,4 +15,11 @@ rules:
   - update
   - patch
   - delete
-
+- apiGroups:
+    - ""
+  resources:
+    - events
+  verbs:
+    - get
+    - list
+    - watch


### PR DESCRIPTION
This is useful for summarizing why a pipelinerun failed.