### PR TITLE
Revert "Builder serviceaccounts should be able to inspect events"

### DIFF
--- a/components/konflux-rbac/production/base/konflux-builder-bot-actions.yaml
+++ b/components/konflux-rbac/production/base/konflux-builder-bot-actions.yaml
@@ -15,11 +15,4 @@ rules:
   - update
   - patch
   - delete
-- apiGroups:
-    - ""
-  resources:
-    - events
-  verbs:
-    - get
-    - list
-    - watch
+


### PR DESCRIPTION
Reverts redhat-appstudio/infra-deployments#6380