### PR TITLE
Bump kubelinter

### DIFF
--- a/.github/workflows/kube-linter.yaml
+++ b/.github/workflows/kube-linter.yaml
@@ -5,6 +5,8 @@ on:
   # SARIF reports.
   pull_request:
     branches: [ main ]
+  push:
+    branches: [ main ]
 jobs:
   scan:
     permissions: write-all

--- a/.github/workflows/kube-linter.yaml
+++ b/.github/workflows/kube-linter.yaml
@@ -36,9 +36,7 @@ jobs:
         uses: stackrox/kube-linter-action@v1.0.4
         id: kube-linter-action-scan
         with:
-          # version 0.6.6 contains a new liveness check. We do have a few liveness issue already so use previous version for now
-          # Once we fix all issues, we will revert to use latest again.
-          version: v0.6.5
+          version: v0.7.2
           # Adjust this directory to the location where your kubernetes resources and helm charts are located.
           directory: kustomizedfiles
           # The following two settings make kube-linter produce scan analysis in SARIF format which would then be

--- a/.kube-linter.yaml
+++ b/.kube-linter.yaml
@@ -1,0 +1,5 @@
+checks:
+  exclude:
+  - liveness-port
+  - readiness-port
+  - startup-port


### PR DESCRIPTION
We're running a fairly outdated version of kube-linter; let's update it to the latest version.

Unfortunately, kube-linter has introduced some new lints, and some of the components in our repository aren't in compliance with them.  We'll need to disable them for now until these components are fixed.

As long as we're at it, let's also run kube-linter checks on push to `main`.  It should get sarif reports working on PRs, and we should check that commits that wind up in `main` are linted appropriately.