### PR TITLE
Increase Kyverno UpdateRequests threshold

### DIFF
--- a/components/kyverno/development/kyverno-helm-values.yaml
+++ b/components/kyverno/development/kyverno-helm-values.yaml
@@ -1,6 +1,8 @@
 ---
 fullnameOverride: konflux-kyverno
 namespaceOverride: konflux-kyverno
+config:
+  updateRequestThreshold: 2000
 admissionController:
   replicas: 1
   initContainer:

--- a/components/kyverno/production/stone-prd-rh01/kyverno-helm-values.yaml
+++ b/components/kyverno/production/stone-prd-rh01/kyverno-helm-values.yaml
@@ -1,5 +1,7 @@
 fullnameOverride: konflux-kyverno
 namespaceOverride: konflux-kyverno
+config:
+  updateRequestThreshold: 2000
 admissionController:
   replicas: 3
   initContainer:


### PR DESCRIPTION
This PR increases the UpdateRequests Threshold for clusters where we are hitting the limit.
The old (default) value was 1000, so this PR doubles it.

Signed-off-by: Francesco Ilario <filario@redhat.com>
