### PR TITLE
Reset `ec-task-policy` to floating tag.

### DIFF
--- a/components/enterprise-contract/ecp.yaml
+++ b/components/enterprise-contract/ecp.yaml
@@ -130,4 +130,4 @@ spec:
         - github.com/release-engineering/rhtap-ec-policy//data
       name: Default
       policy:
-        - oci::quay.io/enterprise-contract/ec-task-policy:git-bad9611@sha256:d7ef030348e754bc9cf521ecd417d46776aa3760ebf957caa212827c84b53f4f
+        - oci::quay.io/enterprise-contract/ec-task-policy:konflux


### PR DESCRIPTION
This commit fixes an overwrite of the `ec-task-policy` floating tag in the EnterpriseContractPolicy.

Ref: [EC-1283](https://issues.redhat.com//browse/EC-1283)