### PR TITLE
etcd-shield: remove cluster-monitoring label

### DIFF
--- a/components/etcd-shield/base/ns.yaml
+++ b/components/etcd-shield/base/ns.yaml
@@ -2,5 +2,3 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: etcd-shield
-  labels:
-    openshift.io/cluster-monitoring: "true"

--- a/components/etcd-shield/production/base/ns.yaml
+++ b/components/etcd-shield/production/base/ns.yaml
@@ -2,5 +2,3 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: etcd-shield
-  labels:
-    openshift.io/cluster-monitoring: "true"


### PR DESCRIPTION
It was used for debugging purposes, and has no business being set on the production nor staging clusters.