### PR TITLE
Disable Tekton Pruner

### DIFF
--- a/components/pipeline-service/production/base/main-pipeline-service-configuration.yaml
+++ b/components/pipeline-service/production/base/main-pipeline-service-configuration.yaml
@@ -1859,11 +1859,7 @@ spec:
                 replicas: 2
   profile: all
   pruner:
-    disabled: false
-    keep-since: 60
-    resources:
-      - pipelinerun
-    schedule: '*/10 * * * *'
+    disabled: true
   result:
     disabled: true
   targetNamespace: openshift-pipelines

--- a/components/pipeline-service/production/kflux-ocp-p01/deploy.yaml
+++ b/components/pipeline-service/production/kflux-ocp-p01/deploy.yaml
@@ -2450,11 +2450,7 @@ spec:
             namespace }}/pipelinerun/{{ pr }}/logs/{{ task }}
   profile: all
   pruner:
-    disabled: false
-    keep-since: 60
-    resources:
-    - pipelinerun
-    schedule: '*/10 * * * *'
+    disabled: true
   result:
     disabled: true
   targetNamespace: openshift-pipelines

--- a/components/pipeline-service/production/kflux-prd-rh02/deploy.yaml
+++ b/components/pipeline-service/production/kflux-prd-rh02/deploy.yaml
@@ -2481,11 +2481,7 @@ spec:
             namespace }}/pipelinerun/{{ pr }}/logs/{{ task }}
   profile: all
   pruner:
-    disabled: false
-    keep-since: 60
-    resources:
-    - pipelinerun
-    schedule: '*/10 * * * *'
+    disabled: true
   result:
     disabled: true
   targetNamespace: openshift-pipelines

--- a/components/pipeline-service/production/kflux-prd-rh03/deploy.yaml
+++ b/components/pipeline-service/production/kflux-prd-rh03/deploy.yaml
@@ -2481,11 +2481,7 @@ spec:
             namespace }}/pipelinerun/{{ pr }}/logs/{{ task }}
   profile: all
   pruner:
-    disabled: false
-    keep-since: 60
-    resources:
-    - pipelinerun
-    schedule: '*/10 * * * *'
+    disabled: true
   result:
     disabled: true
   targetNamespace: openshift-pipelines

--- a/components/pipeline-service/production/stone-prd-m01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prd-m01/deploy.yaml
@@ -2451,11 +2451,7 @@ spec:
           remember-ok-to-test: "false"
   profile: all
   pruner:
-    disabled: false
-    keep-since: 60
-    resources:
-    - pipelinerun
-    schedule: '*/10 * * * *'
+    disabled: true
   result:
     disabled: true
   targetNamespace: openshift-pipelines

--- a/components/pipeline-service/production/stone-prd-rh01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prd-rh01/deploy.yaml
@@ -2451,11 +2451,7 @@ spec:
           remember-ok-to-test: "false"
   profile: all
   pruner:
-    disabled: false
-    keep-since: 60
-    resources:
-    - pipelinerun
-    schedule: '*/10 * * * *'
+    disabled: true
   result:
     disabled: true
   targetNamespace: openshift-pipelines

--- a/components/pipeline-service/production/stone-prod-p01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prod-p01/deploy.yaml
@@ -2451,11 +2451,7 @@ spec:
           remember-ok-to-test: "false"
   profile: all
   pruner:
-    disabled: false
-    keep-since: 60
-    resources:
-    - pipelinerun
-    schedule: '*/10 * * * *'
+    disabled: true
   result:
     disabled: true
   targetNamespace: openshift-pipelines

--- a/components/pipeline-service/production/stone-prod-p02/deploy.yaml
+++ b/components/pipeline-service/production/stone-prod-p02/deploy.yaml
@@ -2451,11 +2451,7 @@ spec:
           remember-ok-to-test: "false"
   profile: all
   pruner:
-    disabled: false
-    keep-since: 60
-    resources:
-    - pipelinerun
-    schedule: '*/10 * * * *'
+    disabled: true
   result:
     disabled: true
   targetNamespace: openshift-pipelines


### PR DESCRIPTION
Tekton Pruner was initially enabled to help the Results Watcher workqueue from growing too big. With the recent optimizations that probably won't be required anymore. Furthermore, we suspect the pruner removing forcefully the pipelineruns could be the reason some taskruns are not properly stored by Results.