### PR TITLE
perfscale/grafana: Extending the Grafana dashboard(controllers-overview) to include data from more controllers

### DIFF
--- a/components/monitoring/grafana/base/dashboards/performance/kustomization.yaml
+++ b/components/monitoring/grafana/base/dashboards/performance/kustomization.yaml
@@ -2,4 +2,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - https://github.com/redhat-appstudio/perfscale/grafana/?ref=1823f62b3c677a8dfbdcc8e3824181e291b99f13
+  - https://github.com/redhat-appstudio/perfscale/grafana/?ref=01a32ab0c89ff1d44c500fa0ed8e26d9d590cd5d

--- a/components/monitoring/grafana/base/dashboards/performance/kustomization.yaml
+++ b/components/monitoring/grafana/base/dashboards/performance/kustomization.yaml
@@ -2,4 +2,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - https://github.com/redhat-appstudio/perfscale/grafana/?ref=01a32ab0c89ff1d44c500fa0ed8e26d9d590cd5d
+  - https://github.com/redhat-appstudio/perfscale/grafana/?ref=66a1c0209636bf815b0945cf45215c5d03ae4413


### PR DESCRIPTION
Updating the dashboards present in the performance directory to point to a new commit that extends them to include metrics from the additional controllers. This will improve visibility into Konflux's performance

```
external-secrets-operator-controller-manager
repository-validator-controller-manager
mintmaker-controller-manager
```

Note: Please do not merge this until the related changes are merged - https://github.com/redhat-appstudio/perfscale/pull/12