### PR TITLE
etcd-shield: decrease severity level to warning

### DIFF
--- a/components/etcd-shield/base/etcd_shield_alerts.yaml
+++ b/components/etcd-shield/base/etcd_shield_alerts.yaml
@@ -12,7 +12,7 @@ spec:
       for: 2m
       keep_firing_for: 5m
       labels:
-        severity: critical
+        severity: warning
       annotations:
         summary: etcd-shield is denying admission
         description: Etcd is nearing capacity limits, so etcd-shield is denying admission

--- a/components/etcd-shield/production/base/etcd_shield_alerts.yaml
+++ b/components/etcd-shield/production/base/etcd_shield_alerts.yaml
@@ -12,7 +12,7 @@ spec:
       for: 2m
       keep_firing_for: 5m
       labels:
-        severity: critical
+        severity: warning
       annotations:
         summary: etcd-shield is denying admission
         description: Etcd is nearing capacity limits, so etcd-shield is denying admission


### PR DESCRIPTION
A severity level of `critical` is unsuitable, as it triggers a PagerDuty alert.  Decrease the severity level to warning as other alerts will trigger the appropriate response.