### PR TITLE
etcd-shield: decrease thresholds by 10%

### DIFF
--- a/components/etcd-shield/base/etcd_shield_alerts.yaml
+++ b/components/etcd-shield/base/etcd_shield_alerts.yaml
@@ -18,8 +18,8 @@ spec:
         description: Etcd is nearing capacity limits, so etcd-shield is denying admission
     - record: etcd_shield_trigger
       expr: |
-        (((etcd_mvcc_db_total_size_in_bytes >= bool (etcd_server_quota_backend_bytes * 0.90)) == 1) or
-            ((((etcd_mvcc_db_total_size_in_bytes) >= bool (etcd_server_quota_backend_bytes * 0.80)) == 1) and
+        (((etcd_mvcc_db_total_size_in_bytes >= bool (etcd_server_quota_backend_bytes * 0.80)) == 1) or
+            ((((etcd_mvcc_db_total_size_in_bytes) >= bool (etcd_server_quota_backend_bytes * 0.70)) == 1) and
                 (count without (alertname, alertstate, severity)
                       (ALERTS{
                         alertname="EtcdShieldDenyAdmission",

--- a/components/etcd-shield/production/base/etcd_shield_alerts.yaml
+++ b/components/etcd-shield/production/base/etcd_shield_alerts.yaml
@@ -18,8 +18,8 @@ spec:
         description: Etcd is nearing capacity limits, so etcd-shield is denying admission
     - record: etcd_shield_trigger
       expr: |
-        (((etcd_mvcc_db_total_size_in_bytes >= bool (etcd_server_quota_backend_bytes * 0.90)) == 1) or
-            ((((etcd_mvcc_db_total_size_in_bytes) >= bool (etcd_server_quota_backend_bytes * 0.80)) == 1) and
+        (((etcd_mvcc_db_total_size_in_bytes >= bool (etcd_server_quota_backend_bytes * 0.80)) == 1) or
+            ((((etcd_mvcc_db_total_size_in_bytes) >= bool (etcd_server_quota_backend_bytes * 0.70)) == 1) and
                 (count without (alertname, alertstate, severity)
                       (ALERTS{
                         alertname="EtcdShieldDenyAdmission",


### PR DESCRIPTION
Expansion of pipelineruns causes etcd to fill up, even when we cut off at 80%.  Lower thresholds by 10% to give us more breathing room.