### PR TITLE
MintMaker weekly release: promote stage to prod

### DIFF
--- a/components/mintmaker/production/base/kustomization.yaml
+++ b/components/mintmaker/production/base/kustomization.yaml
@@ -3,18 +3,18 @@ kind: Kustomization
 resources:
   - ../../base
   - ../../base/external-secrets
-  - https://github.com/konflux-ci/mintmaker/config/default?ref=537b432d89aa25a3b9ebbccff601d8058454fada
-  - https://github.com/konflux-ci/mintmaker/config/renovate?ref=537b432d89aa25a3b9ebbccff601d8058454fada
+  - https://github.com/konflux-ci/mintmaker/config/default?ref=32f8d02efd57f78ad3fed5c4173cd14ebf8780b1
+  - https://github.com/konflux-ci/mintmaker/config/renovate?ref=32f8d02efd57f78ad3fed5c4173cd14ebf8780b1
 
 namespace: mintmaker
 
 images:
   - name: quay.io/konflux-ci/mintmaker
     newName: quay.io/konflux-ci/mintmaker
-    newTag: 537b432d89aa25a3b9ebbccff601d8058454fada
+    newTag: 32f8d02efd57f78ad3fed5c4173cd14ebf8780b1
   - name: quay.io/konflux-ci/mintmaker-renovate-image
     newName: quay.io/konflux-ci/mintmaker-renovate-image
-    newTag: 9c7b69cbaf869c6204cd1420c9bb790b3cf38e08
+    newTag: d86322c957440bc5169521667c1eb631451cef20
 
 commonAnnotations:
   argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true


### PR DESCRIPTION
This commit promotes the latest images tested in stage to prod, as part of the weekly release for
MintMaker.

### Testing remarks
I monitored the deployment in stage and there were no errors. I also double-checked quay and the images were built without problem there.

I believe it is safe to promote this to prod.