### PR TITLE
Etcd shield updates

### DIFF
--- a/components/etcd-shield/base/deployment.yaml
+++ b/components/etcd-shield/base/deployment.yaml
@@ -17,7 +17,7 @@ spec:
       serviceAccountName: etcd-shield
       containers:
       - args:
-        - -leader-elect
+        - -leader-elect=false
         - -health-probe-bind-address=:8081
         - -config=/etc/etcd-shield/config.yaml
         - -port=8443

--- a/components/etcd-shield/base/deployment.yaml
+++ b/components/etcd-shield/base/deployment.yaml
@@ -4,17 +4,26 @@ metadata:
   name: etcd-shield
   labels:
     app: etcd-shield
+  annotations:
+    ignore-check.kube-linter.io/no-anti-affinity: "using topologySpreadConstraints"
 spec:
   selector:
     matchLabels:
       app: etcd-shield
-  replicas: 1
+  replicas: 3
   template:
     metadata:
       labels:
         app: etcd-shield
     spec:
       serviceAccountName: etcd-shield
+      topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: topology.kubernetes.io/zone
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app: etcd-shield
       containers:
       - args:
         - -leader-elect=false

--- a/components/etcd-shield/production/base/deployment.yaml
+++ b/components/etcd-shield/production/base/deployment.yaml
@@ -17,7 +17,7 @@ spec:
       serviceAccountName: etcd-shield
       containers:
       - args:
-        - -leader-elect
+        - -leader-elect=false
         - -health-probe-bind-address=:8081
         - -config=/etc/etcd-shield/config.yaml
         - -port=8443

--- a/components/etcd-shield/production/base/deployment.yaml
+++ b/components/etcd-shield/production/base/deployment.yaml
@@ -4,17 +4,26 @@ metadata:
   name: etcd-shield
   labels:
     app: etcd-shield
+  annotations:
+    ignore-check.kube-linter.io/no-anti-affinity: "using topologySpreadConstraints"
 spec:
   selector:
     matchLabels:
       app: etcd-shield
-  replicas: 1
+  replicas: 3
   template:
     metadata:
       labels:
         app: etcd-shield
     spec:
       serviceAccountName: etcd-shield
+      topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: topology.kubernetes.io/zone
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app: etcd-shield
       containers:
       - args:
         - -leader-elect=false


### PR DESCRIPTION
The highlights:
- 3 replicas instead of 1, so etcd-shield is more resiliant to pods falling over
- disable leader election, since we don't need it for anything.