### PR TITLE
add konflux-rhel-read-events Role to p02

### DIFF
--- a/components/konflux-rbac/production/stone-prod-p02/kustomization.yaml
+++ b/components/konflux-rbac/production/stone-prod-p02/kustomization.yaml
@@ -2,3 +2,4 @@ kind: Kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 resources:
   - ../base
+  - ./rhel

--- a/components/konflux-rbac/production/stone-prod-p02/rhel/konflux-rhel-read-events-role.yaml
+++ b/components/konflux-rbac/production/stone-prod-p02/rhel/konflux-rhel-read-events-role.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: konflux-rhel-read-events
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - get
+  - list
+  - watch

--- a/components/konflux-rbac/production/stone-prod-p02/rhel/kustomization.yaml
+++ b/components/konflux-rbac/production/stone-prod-p02/rhel/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- konflux-rhel-read-events-role.yaml


### PR DESCRIPTION
rhel needs to give read permission on events to their automation. Adding a custom role for them to p02.

Signed-off-by: Francesco Ilario <filario@redhat.com>
