### PR TITLE
Revert "Disable Tekton Pruner"

### DIFF
--- a/components/pipeline-service/production/base/main-pipeline-service-configuration.yaml
+++ b/components/pipeline-service/production/base/main-pipeline-service-configuration.yaml
@@ -1859,7 +1859,11 @@ spec:
                 replicas: 2
   profile: all
   pruner:
-    disabled: true
+    disabled: false
+    keep-since: 60
+    resources:
+      - pipelinerun
+    schedule: '*/10 * * * *'
   result:
     disabled: true
   targetNamespace: openshift-pipelines

--- a/components/pipeline-service/production/kflux-ocp-p01/deploy.yaml
+++ b/components/pipeline-service/production/kflux-ocp-p01/deploy.yaml
@@ -2450,7 +2450,11 @@ spec:
             namespace }}/pipelinerun/{{ pr }}/logs/{{ task }}
   profile: all
   pruner:
-    disabled: true
+    disabled: false
+    keep-since: 60
+    resources:
+    - pipelinerun
+    schedule: '*/10 * * * *'
   result:
     disabled: true
   targetNamespace: openshift-pipelines

--- a/components/pipeline-service/production/kflux-prd-rh02/deploy.yaml
+++ b/components/pipeline-service/production/kflux-prd-rh02/deploy.yaml
@@ -2481,7 +2481,11 @@ spec:
             namespace }}/pipelinerun/{{ pr }}/logs/{{ task }}
   profile: all
   pruner:
-    disabled: true
+    disabled: false
+    keep-since: 60
+    resources:
+    - pipelinerun
+    schedule: '*/10 * * * *'
   result:
     disabled: true
   targetNamespace: openshift-pipelines

--- a/components/pipeline-service/production/kflux-prd-rh03/deploy.yaml
+++ b/components/pipeline-service/production/kflux-prd-rh03/deploy.yaml
@@ -2481,7 +2481,11 @@ spec:
             namespace }}/pipelinerun/{{ pr }}/logs/{{ task }}
   profile: all
   pruner:
-    disabled: true
+    disabled: false
+    keep-since: 60
+    resources:
+    - pipelinerun
+    schedule: '*/10 * * * *'
   result:
     disabled: true
   targetNamespace: openshift-pipelines

--- a/components/pipeline-service/production/stone-prd-m01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prd-m01/deploy.yaml
@@ -2451,7 +2451,11 @@ spec:
           remember-ok-to-test: "false"
   profile: all
   pruner:
-    disabled: true
+    disabled: false
+    keep-since: 60
+    resources:
+    - pipelinerun
+    schedule: '*/10 * * * *'
   result:
     disabled: true
   targetNamespace: openshift-pipelines

--- a/components/pipeline-service/production/stone-prd-rh01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prd-rh01/deploy.yaml
@@ -2451,7 +2451,11 @@ spec:
           remember-ok-to-test: "false"
   profile: all
   pruner:
-    disabled: true
+    disabled: false
+    keep-since: 60
+    resources:
+    - pipelinerun
+    schedule: '*/10 * * * *'
   result:
     disabled: true
   targetNamespace: openshift-pipelines

--- a/components/pipeline-service/production/stone-prod-p01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prod-p01/deploy.yaml
@@ -2451,7 +2451,11 @@ spec:
           remember-ok-to-test: "false"
   profile: all
   pruner:
-    disabled: true
+    disabled: false
+    keep-since: 60
+    resources:
+    - pipelinerun
+    schedule: '*/10 * * * *'
   result:
     disabled: true
   targetNamespace: openshift-pipelines

--- a/components/pipeline-service/production/stone-prod-p02/deploy.yaml
+++ b/components/pipeline-service/production/stone-prod-p02/deploy.yaml
@@ -2451,7 +2451,11 @@ spec:
           remember-ok-to-test: "false"
   profile: all
   pruner:
-    disabled: true
+    disabled: false
+    keep-since: 60
+    resources:
+    - pipelinerun
+    schedule: '*/10 * * * *'
   result:
     disabled: true
   targetNamespace: openshift-pipelines


### PR DESCRIPTION
Reverts redhat-appstudio/infra-deployments#6405

Reverting the change as it looks it exposes some performance issues on the prod clusters. We can remove that again after the performance issues are resolved.