### PR TITLE
update resource configurations for Tekton components

### DIFF
--- a/components/pipeline-service/development/main-pipeline-service-configuration.yaml
+++ b/components/pipeline-service/development/main-pipeline-service-configuration.yaml
@@ -1960,6 +1960,136 @@ spec:
                       requests:
                         cpu: 200m
                         memory: 200Mi
+        pipelines-as-code-controller:
+          spec:
+            template:
+              spec:
+                containers:
+                  - name: pac-controller
+                    resources:
+                      limits:
+                        cpu: 400m
+                        memory: 250Mi
+                      requests:
+                        cpu: 200m
+                        memory: 200Mi
+        pipelines-as-code-watcher:
+          spec:
+            template:
+              spec:
+                containers:
+                  - name: pac-watcher
+                    resources:
+                      limits:
+                        cpu: 500m
+                        memory: 1Gi
+                      requests:
+                        cpu: 200m
+                        memory: 200Mi
+        pipelines-as-code-webhook:
+          spec:
+            template:
+              spec:
+                containers:
+                  - name: pac-webhook
+                    resources:
+                      limits:
+                        cpu: 400m
+                        memory: 250Mi
+                      requests:
+                        cpu: 200m
+                        memory: 200Mi
+        pipelines-console-plugin:
+          spec:
+            template:
+              spec:
+                containers:
+                  - name: pipelines-console-plugin
+                    resources:
+                      limits:
+                        cpu: 200m
+                        memory: 100Mi
+                      requests:
+                        cpu: 200m
+                        memory: 100Mi
+        tekton-chains-controller:
+          spec:
+            template:
+              spec:
+                containers:
+                  - name: tekton-chains-controller
+                    resources:
+                      limits:
+                        cpu: 500m
+                        memory: 1Gi
+                      requests:
+                        cpu: 200m
+                        memory: 200Mi
+        tekton-events-controller:
+          spec:
+            template:
+              spec:
+                containers:
+                  - name: tekton-events-controller
+                    resources:
+                      limits:
+                        cpu: 200m
+                        memory: 100Mi
+                      requests:
+                        cpu: 200m
+                        memory: 100Mi
+        tekton-triggers-controller:
+          spec:
+            template:
+              spec:
+                containers:
+                  - name: tekton-triggers-controller
+                    resources:
+                      limits:
+                        cpu: 400m
+                        memory: 250Mi
+                      requests:
+                        cpu: 200m
+                        memory: 200Mi
+        tekton-triggers-webhook:
+          spec:
+            template:
+              spec:
+                containers:
+                  - name: webhook
+                    resources:
+                      limits:
+                        cpu: 250m
+                        memory: 100Mi
+                      requests:
+                        cpu: 200m
+                        memory: 100Mi
+        tekton-triggers-core-interceptors:
+          spec:
+            template:
+              spec:
+                containers:
+                  - name: tekton-triggers-core-interceptors
+                    resources:
+                      limits:
+                        cpu: 500m
+                        memory: 1Gi
+                      requests:
+                        cpu: 200m
+                        memory: 200Mi
+        tkn-cli-serve:
+          spec:
+            template:
+              spec:
+                containers:
+                  - name: tkn-cli-serve
+                    resources:
+                      limits:
+                        cpu: 250m
+                        memory: 100Mi
+                      requests:
+                        cpu: 200m
+                        memory: 100Mi
       statefulSets:
         tekton-pipelines-controller:
           spec:

--- a/components/pipeline-service/staging/base/main-pipeline-service-configuration.yaml
+++ b/components/pipeline-service/staging/base/main-pipeline-service-configuration.yaml
@@ -1776,6 +1776,136 @@ spec:
                       requests:
                         cpu: 400m
                         memory: 1Gi
+        pipelines-as-code-controller:
+          spec:
+            template:
+              spec:
+                containers:
+                  - name: pac-controller
+                    resources:
+                      limits:
+                        cpu: 400m
+                        memory: 250Mi
+                      requests:
+                        cpu: 400m
+                        memory: 250Mi
+        pipelines-as-code-watcher:
+          spec:
+            template:
+              spec:
+                containers:
+                  - name: pac-watcher
+                    resources:
+                      limits:
+                        cpu: 500m
+                        memory: 1Gi
+                      requests:
+                        cpu: 500m
+                        memory: 1Gi
+        pipelines-as-code-webhook:
+          spec:
+            template:
+              spec:
+                containers:
+                  - name: pac-webhook
+                    resources:
+                      limits:
+                        cpu: 400m
+                        memory: 250Mi
+                      requests:
+                        cpu: 400m
+                        memory: 250Mi
+        pipelines-console-plugin:
+          spec:
+            template:
+              spec:
+                containers:
+                  - name: pipelines-console-plugin
+                    resources:
+                      limits:
+                        cpu: 200m
+                        memory: 100Mi
+                      requests:
+                        cpu: 200m
+                        memory: 100Mi
+        tekton-chains-controller:
+          spec:
+            template:
+              spec:
+                containers:
+                  - name: tekton-chains-controller
+                    resources:
+                      limits:
+                        cpu: 500m
+                        memory: 1.5Gi
+                      requests:
+                        cpu: 500m
+                        memory: 1.5Gi
+        tekton-events-controller:
+          spec:
+            template:
+              spec:
+                containers:
+                  - name: tekton-events-controller
+                    resources:
+                      limits:
+                        cpu: 200m
+                        memory: 100Mi
+                      requests:
+                        cpu: 200m
+                        memory: 100Mi
+        tekton-triggers-controller:
+          spec:
+            template:
+              spec:
+                containers:
+                  - name: tekton-triggers-controller
+                    resources:
+                      limits:
+                        cpu: 400m
+                        memory: 250Mi
+                      requests:
+                        cpu: 400m
+                        memory: 250Mi
+        tekton-triggers-webhook:
+          spec:
+            template:
+              spec:
+                containers:
+                  - name: webhook
+                    resources:
+                      limits:
+                        cpu: 250m
+                        memory: 100Mi
+                      requests:
+                        cpu: 250m
+                        memory: 100Mi
+        tekton-triggers-core-interceptors:
+          spec:
+            template:
+              spec:
+                containers:
+                  - name: tekton-triggers-core-interceptors
+                    resources:
+                      limits:
+                        cpu: 500m
+                        memory: 1Gi
+                      requests:
+                        cpu: 500m
+                        memory: 1Gi
+        tkn-cli-serve:
+          spec:
+            template:
+              spec:
+                containers:
+                  - name: tkn-cli-serve
+                    resources:
+                      limits:
+                        cpu: 250m
+                        memory: 100Mi
+                      requests:
+                        cpu: 250m
+                        memory: 100Mi
       statefulSets:
         tekton-pipelines-controller:
           spec:

--- a/components/pipeline-service/staging/stone-stage-p01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stage-p01/deploy.yaml
@@ -2334,6 +2334,84 @@ spec:
                 }
               }
       deployments:
+        pipelines-as-code-controller:
+          spec:
+            template:
+              spec:
+                containers:
+                - name: pac-controller
+                  resources:
+                    limits:
+                      cpu: 400m
+                      memory: 250Mi
+                    requests:
+                      cpu: 400m
+                      memory: 250Mi
+        pipelines-as-code-watcher:
+          spec:
+            template:
+              spec:
+                containers:
+                - name: pac-watcher
+                  resources:
+                    limits:
+                      cpu: 500m
+                      memory: 1Gi
+                    requests:
+                      cpu: 500m
+                      memory: 1Gi
+        pipelines-as-code-webhook:
+          spec:
+            template:
+              spec:
+                containers:
+                - name: pac-webhook
+                  resources:
+                    limits:
+                      cpu: 400m
+                      memory: 250Mi
+                    requests:
+                      cpu: 400m
+                      memory: 250Mi
+        pipelines-console-plugin:
+          spec:
+            template:
+              spec:
+                containers:
+                - name: pipelines-console-plugin
+                  resources:
+                    limits:
+                      cpu: 200m
+                      memory: 100Mi
+                    requests:
+                      cpu: 200m
+                      memory: 100Mi
+        tekton-chains-controller:
+          spec:
+            template:
+              spec:
+                containers:
+                - name: tekton-chains-controller
+                  resources:
+                    limits:
+                      cpu: 500m
+                      memory: 1.5Gi
+                    requests:
+                      cpu: 500m
+                      memory: 1.5Gi
+        tekton-events-controller:
+          spec:
+            template:
+              spec:
+                containers:
+                - name: tekton-events-controller
+                  resources:
+                    limits:
+                      cpu: 200m
+                      memory: 100Mi
+                    requests:
+                      cpu: 200m
+                      memory: 100Mi
         tekton-operator-proxy-webhook:
           spec:
             replicas: 2
@@ -2361,6 +2439,58 @@ spec:
                     requests:
                       cpu: 400m
                       memory: 1Gi
+        tekton-triggers-controller:
+          spec:
+            template:
+              spec:
+                containers:
+                - name: tekton-triggers-controller
+                  resources:
+                    limits:
+                      cpu: 400m
+                      memory: 250Mi
+                    requests:
+                      cpu: 400m
+                      memory: 250Mi
+        tekton-triggers-core-interceptors:
+          spec:
+            template:
+              spec:
+                containers:
+                - name: tekton-triggers-core-interceptors
+                  resources:
+                    limits:
+                      cpu: 500m
+                      memory: 1Gi
+                    requests:
+                      cpu: 500m
+                      memory: 1Gi
+        tekton-triggers-webhook:
+          spec:
+            template:
+              spec:
+                containers:
+                - name: webhook
+                  resources:
+                    limits:
+                      cpu: 250m
+                      memory: 100Mi
+                    requests:
+                      cpu: 250m
+                      memory: 100Mi
+        tkn-cli-serve:
+          spec:
+            template:
+              spec:
+                containers:
+                - name: tkn-cli-serve
+                  resources:
+                    limits:
+                      cpu: 250m
+                      memory: 100Mi
+                    requests:
+                      cpu: 250m
+                      memory: 100Mi
       disabled: false
       horizontalPodAutoscalers:
         tekton-operator-proxy-webhook:

--- a/components/pipeline-service/staging/stone-stg-rh01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stg-rh01/deploy.yaml
@@ -2334,6 +2334,84 @@ spec:
                 }
               }
       deployments:
+        pipelines-as-code-controller:
+          spec:
+            template:
+              spec:
+                containers:
+                - name: pac-controller
+                  resources:
+                    limits:
+                      cpu: 400m
+                      memory: 250Mi
+                    requests:
+                      cpu: 400m
+                      memory: 250Mi
+        pipelines-as-code-watcher:
+          spec:
+            template:
+              spec:
+                containers:
+                - name: pac-watcher
+                  resources:
+                    limits:
+                      cpu: 500m
+                      memory: 1Gi
+                    requests:
+                      cpu: 500m
+                      memory: 1Gi
+        pipelines-as-code-webhook:
+          spec:
+            template:
+              spec:
+                containers:
+                - name: pac-webhook
+                  resources:
+                    limits:
+                      cpu: 400m
+                      memory: 250Mi
+                    requests:
+                      cpu: 400m
+                      memory: 250Mi
+        pipelines-console-plugin:
+          spec:
+            template:
+              spec:
+                containers:
+                - name: pipelines-console-plugin
+                  resources:
+                    limits:
+                      cpu: 200m
+                      memory: 100Mi
+                    requests:
+                      cpu: 200m
+                      memory: 100Mi
+        tekton-chains-controller:
+          spec:
+            template:
+              spec:
+                containers:
+                - name: tekton-chains-controller
+                  resources:
+                    limits:
+                      cpu: 500m
+                      memory: 1.5Gi
+                    requests:
+                      cpu: 500m
+                      memory: 1.5Gi
+        tekton-events-controller:
+          spec:
+            template:
+              spec:
+                containers:
+                - name: tekton-events-controller
+                  resources:
+                    limits:
+                      cpu: 200m
+                      memory: 100Mi
+                    requests:
+                      cpu: 200m
+                      memory: 100Mi
         tekton-operator-proxy-webhook:
           spec:
             replicas: 2
@@ -2373,6 +2451,58 @@ spec:
                     requests:
                       cpu: 400m
                       memory: 1Gi
+        tekton-triggers-controller:
+          spec:
+            template:
+              spec:
+                containers:
+                - name: tekton-triggers-controller
+                  resources:
+                    limits:
+                      cpu: 400m
+                      memory: 250Mi
+                    requests:
+                      cpu: 400m
+                      memory: 250Mi
+        tekton-triggers-core-interceptors:
+          spec:
+            template:
+              spec:
+                containers:
+                - name: tekton-triggers-core-interceptors
+                  resources:
+                    limits:
+                      cpu: 500m
+                      memory: 1Gi
+                    requests:
+                      cpu: 500m
+                      memory: 1Gi
+        tekton-triggers-webhook:
+          spec:
+            template:
+              spec:
+                containers:
+                - name: webhook
+                  resources:
+                    limits:
+                      cpu: 250m
+                      memory: 100Mi
+                    requests:
+                      cpu: 250m
+                      memory: 100Mi
+        tkn-cli-serve:
+          spec:
+            template:
+              spec:
+                containers:
+                - name: tkn-cli-serve
+                  resources:
+                    limits:
+                      cpu: 250m
+                      memory: 100Mi
+                    requests:
+                      cpu: 250m
+                      memory: 100Mi
       disabled: false
       horizontalPodAutoscalers:
         tekton-operator-proxy-webhook:


### PR DESCRIPTION
Added CPU and memory limits for following Tekton resources:
* pipelines-as-code-controller
* pipelines-as-code-watcher
* pipelines-as-code-webhook
* pipelines-console-plugin
* tekton-chains-controller
* tekton-events-controller
* tekton-triggers-controller
* tekton-triggers-core-interceptors
* tekton-triggers-webhook
* tkn-cli-serve
