### PR TITLE
updated the memory resource for tekton resources to prevent OOMKills

### DIFF
--- a/components/pipeline-service/production/base/main-pipeline-service-configuration.yaml
+++ b/components/pipeline-service/production/base/main-pipeline-service-configuration.yaml
@@ -961,10 +961,10 @@ spec:
         resources:
           limits:
             cpu: 500m
-            memory: 6Gi
+            memory: 8Gi
           requests:
             cpu: 250m
-            memory: 6Gi
+            memory: 8Gi
         securityContext:
           readOnlyRootFilesystem: true
           runAsNonRoot: true
@@ -1778,10 +1778,10 @@ spec:
                   - name: controller
                     resources:
                       limits:
-                        memory: 8Gi
+                        memory: 10Gi
                       requests:
                         cpu: "500m"
-                        memory: 8Gi
+                        memory: 10Gi
         tekton-pipelines-controller:
           spec:
             template:

--- a/components/pipeline-service/production/kflux-ocp-p01/deploy.yaml
+++ b/components/pipeline-service/production/kflux-ocp-p01/deploy.yaml
@@ -1391,10 +1391,10 @@ spec:
         resources:
           limits:
             cpu: 500m
-            memory: 6Gi
+            memory: 8Gi
           requests:
             cpu: 250m
-            memory: 6Gi
+            memory: 8Gi
         securityContext:
           readOnlyRootFilesystem: true
           runAsNonRoot: true
@@ -2416,10 +2416,10 @@ spec:
                 - name: controller
                   resources:
                     limits:
-                      memory: 8Gi
+                      memory: 10Gi
                     requests:
                       cpu: 500m
-                      memory: 8Gi
+                      memory: 10Gi
     performance:
       buckets: 8
       disable-ha: false

--- a/components/pipeline-service/production/kflux-prd-rh02/deploy.yaml
+++ b/components/pipeline-service/production/kflux-prd-rh02/deploy.yaml
@@ -1422,10 +1422,10 @@ spec:
         resources:
           limits:
             cpu: 500m
-            memory: 6Gi
+            memory: 8Gi
           requests:
             cpu: 250m
-            memory: 6Gi
+            memory: 8Gi
         securityContext:
           readOnlyRootFilesystem: true
           runAsNonRoot: true
@@ -2447,10 +2447,10 @@ spec:
                 - name: controller
                   resources:
                     limits:
-                      memory: 8Gi
+                      memory: 10Gi
                     requests:
                       cpu: 500m
-                      memory: 8Gi
+                      memory: 10Gi
     performance:
       buckets: 8
       disable-ha: false

--- a/components/pipeline-service/production/kflux-prd-rh03/deploy.yaml
+++ b/components/pipeline-service/production/kflux-prd-rh03/deploy.yaml
@@ -1422,10 +1422,10 @@ spec:
         resources:
           limits:
             cpu: 500m
-            memory: 6Gi
+            memory: 8Gi
           requests:
             cpu: 250m
-            memory: 6Gi
+            memory: 8Gi
         securityContext:
           readOnlyRootFilesystem: true
           runAsNonRoot: true
@@ -2447,10 +2447,10 @@ spec:
                 - name: controller
                   resources:
                     limits:
-                      memory: 8Gi
+                      memory: 10Gi
                     requests:
                       cpu: 500m
-                      memory: 8Gi
+                      memory: 10Gi
     performance:
       buckets: 8
       disable-ha: false

--- a/components/pipeline-service/production/stone-prd-m01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prd-m01/deploy.yaml
@@ -1391,10 +1391,10 @@ spec:
         resources:
           limits:
             cpu: 500m
-            memory: 6Gi
+            memory: 8Gi
           requests:
             cpu: 250m
-            memory: 6Gi
+            memory: 8Gi
         securityContext:
           readOnlyRootFilesystem: true
           runAsNonRoot: true
@@ -2416,10 +2416,10 @@ spec:
                 - name: controller
                   resources:
                     limits:
-                      memory: 8Gi
+                      memory: 10Gi
                     requests:
                       cpu: 500m
-                      memory: 8Gi
+                      memory: 10Gi
     performance:
       buckets: 8
       disable-ha: false

--- a/components/pipeline-service/production/stone-prd-rh01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prd-rh01/deploy.yaml
@@ -1391,10 +1391,10 @@ spec:
         resources:
           limits:
             cpu: 500m
-            memory: 6Gi
+            memory: 8Gi
           requests:
             cpu: 250m
-            memory: 6Gi
+            memory: 8Gi
         securityContext:
           readOnlyRootFilesystem: true
           runAsNonRoot: true
@@ -2416,10 +2416,10 @@ spec:
                 - name: controller
                   resources:
                     limits:
-                      memory: 8Gi
+                      memory: 10Gi
                     requests:
                       cpu: 500m
-                      memory: 8Gi
+                      memory: 10Gi
     performance:
       buckets: 8
       disable-ha: false

--- a/components/pipeline-service/production/stone-prod-p01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prod-p01/deploy.yaml
@@ -1391,10 +1391,10 @@ spec:
         resources:
           limits:
             cpu: 500m
-            memory: 6Gi
+            memory: 8Gi
           requests:
             cpu: 250m
-            memory: 6Gi
+            memory: 8Gi
         securityContext:
           readOnlyRootFilesystem: true
           runAsNonRoot: true
@@ -2416,10 +2416,10 @@ spec:
                 - name: controller
                   resources:
                     limits:
-                      memory: 8Gi
+                      memory: 10Gi
                     requests:
                       cpu: 500m
-                      memory: 8Gi
+                      memory: 10Gi
     performance:
       buckets: 8
       disable-ha: false

--- a/components/pipeline-service/production/stone-prod-p02/deploy.yaml
+++ b/components/pipeline-service/production/stone-prod-p02/deploy.yaml
@@ -1391,10 +1391,10 @@ spec:
         resources:
           limits:
             cpu: 500m
-            memory: 6Gi
+            memory: 8Gi
           requests:
             cpu: 250m
-            memory: 6Gi
+            memory: 8Gi
         securityContext:
           readOnlyRootFilesystem: true
           runAsNonRoot: true
@@ -2416,10 +2416,10 @@ spec:
                 - name: controller
                   resources:
                     limits:
-                      memory: 8Gi
+                      memory: 10Gi
                     requests:
                       cpu: 500m
-                      memory: 8Gi
+                      memory: 10Gi
     performance:
       buckets: 8
       disable-ha: false


### PR DESCRIPTION
This PR increases the memory resource limits for the following components to reduce OOM-related instability:

-     pipeline-metrics-exporter

       Was occasionally consuming its full 6 GiB allocation, leading to instability.

        Increased memory limits to improve reliability and prevent potential OOM issues.

-     tekton-pipeline-remote-resolver

        Also observed to use up its full 8 GiB memory allocation intermittently.

        Increased memory limits to improve reliability and prevent potential OOM issues.