### PR TITLE
Add testplatform ProviderConfig

### DIFF
--- a/components/crossplane-control-plane/production/kustomization.yaml
+++ b/components/crossplane-control-plane/production/kustomization.yaml
@@ -4,6 +4,7 @@ kind: Kustomization
 resources:
 - ../base
 - provider-config.yaml
+- testplatform-provider-config.yaml
 
 patches:
   - patch: |-

--- a/components/crossplane-control-plane/production/testplatform-provider-config.yaml
+++ b/components/crossplane-control-plane/production/testplatform-provider-config.yaml
@@ -1,0 +1,35 @@
+---
+apiVersion: kubernetes.crossplane.io/v1alpha1
+kind: ProviderConfig
+metadata:
+  name: testplatform-kubernetes-provider-config
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  credentials:
+    source: Secret
+    secretRef:
+      namespace: crossplane-system
+      name: testplatform-cluster
+      key: kubeconfig
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: testplatform-cluster
+  namespace: crossplane-system
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  dataFrom:
+    - extract:
+        key: production/openshift-ci/ephemeral-cluster
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: appsre-stonesoup-vault
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    name: testplatform-cluster


### PR DESCRIPTION
Add a new `ProviderConfig` for crossplane. This is going to be needed in order to access the TestPlatform `appci` cluster via a `kubeconfig` stored into the Vault.