### PR TITLE
fix(RELEASE-1645): allow serviceaccounts to see cm

### DIFF
--- a/components/pipeline-service/base/rbac/openshift-pipelines/configmap-viewer.yaml
+++ b/components/pipeline-service/base/rbac/openshift-pipelines/configmap-viewer.yaml
@@ -1,0 +1,33 @@
+---
+# Grant access to authenticated users to be able to view
+# openshift-pipelines configMaps. The user case involves
+# service accounts running automated tests being able to
+# discover the custom URL for the Konflux UI
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: configmap-viewer
+  namespace: openshift-pipelines
+rules:
+  - verbs:
+      - get
+      - watch
+      - list
+    apiGroups:
+      - ''
+    resources:
+      - configmaps
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: configmap-viewer
+  namespace: openshift-pipelines
+subjects:
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: 'system:authenticated'
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: configmap-viewer

--- a/components/pipeline-service/base/rbac/openshift-pipelines/kustomization.yaml
+++ b/components/pipeline-service/base/rbac/openshift-pipelines/kustomization.yaml
@@ -2,5 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: openshift-pipelines
 resources:
+  - configmap-viewer.yaml
   - pipeline-service-sre.yaml
   - resolution-req-perms-exporter.yaml


### PR DESCRIPTION
- Grant access to authenticated users to be able to view openshift-pipelines configMaps. 
- The use case involves service accounts running automated tests being able to discover the custom URL for the Konflux UI