### PR TITLE
feat(PVO11Y-4787): Setup Kanary signal deployment

### DIFF
--- a/argo-cd-apps/base/monitoring-workload-kanary/kustomization.yaml
+++ b/argo-cd-apps/base/monitoring-workload-kanary/kustomization.yaml
@@ -1,0 +1,4 @@
+resources:
+- monitoring-workload-kanary.yaml
+components:
+  - ../../k-components/deploy-to-member-cluster-merge-generator

--- a/argo-cd-apps/base/monitoring-workload-kanary/monitoring-workload-kanary.yaml
+++ b/argo-cd-apps/base/monitoring-workload-kanary/monitoring-workload-kanary.yaml
@@ -1,0 +1,41 @@
+kind: ApplicationSet
+apiVersion: argoproj.io/v1alpha1
+metadata:
+  name: monitoring-workload-kanary
+spec:
+  generators:
+    - merge:
+        mergeKeys:
+          - nameNormalized
+        generators:
+          - clusters:
+              values:
+                sourceRoot: components/monitoring/kanary
+                environment: staging
+                clusterDir: base
+          - list:
+              elements:
+                - nameNormalized: stone-stage-p01
+                  values.clusterDir: stone-stage-p01
+  template:
+    metadata:
+      name: monitoring-workload-kanary-{{nameNormalized}}
+    spec:
+      project: default
+      source:
+        path: '{{values.sourceRoot}}/{{values.environment}}/{{values.clusterDir}}'
+        repoURL: https://github.com/redhat-appstudio/infra-deployments.git
+        targetRevision: main
+      destination:
+        namespace: appstudio-kanary-exporter
+        server: '{{server}}'
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
+        syncOptions:
+        - CreateNamespace=true
+        retry:
+          limit: 50
+          backoff:
+            duration: 15s

--- a/argo-cd-apps/overlays/production-downstream/delete-applications.yaml
+++ b/argo-cd-apps/overlays/production-downstream/delete-applications.yaml
@@ -48,4 +48,3 @@ kind: ApplicationSet
 metadata:
   name: pulp-access-controller
 $patch: delete
-

--- a/argo-cd-apps/overlays/staging-downstream/kustomization.yaml
+++ b/argo-cd-apps/overlays/staging-downstream/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
   - ../../base/ca-bundle
   - ../../base/keycloak
   - ../../base/repository-validator
+  - ../../base/monitoring-workload-kanary
 patchesStrategicMerge:
   - delete-applications.yaml
 

--- a/components/cluster-secret-store/base/appsre-stonesoup-vault-secret-store.yaml
+++ b/components/cluster-secret-store/base/appsre-stonesoup-vault-secret-store.yaml
@@ -42,6 +42,7 @@ spec:
         - quality-dashboard
         - sprayproxy
         - appstudio-monitoring
+        - appstudio-kanary-exporter
         - openshift-pipelines
         - rhtap-servicerelease-tenant
         - rhtap-build-tenant

--- a/components/monitoring/kanary/README.md
+++ b/components/monitoring/kanary/README.md
@@ -1,0 +1,16 @@
+
+## Installing and configuring Kanary on a data-plane cluster
+
+Note: The steps below should be handled by Argo CD
+
+- Create the `appstudio-kanary-exporter` namespace on the clusters, if it does not exist yet:
+
+    ```
+    $ oc create namespace appstudio-kanary-exporter
+    ```
+
+- Create the `base` resources by running the following command:
+
+    ```
+    $ kustomize build components/monitoring/grafana/base | oc apply -f -   
+    ```

--- a/components/monitoring/kanary/base/external-secrets/kanary-db-credentials.yaml
+++ b/components/monitoring/kanary/base/external-secrets/kanary-db-credentials.yaml
@@ -1,0 +1,19 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: kanary-db-credentials
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  dataFrom:
+    - extract:
+        key: # will be added by the overlays
+  refreshInterval: 15m
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: appsre-stonesoup-vault
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    name: kanary-db-credentials

--- a/components/monitoring/kanary/base/external-secrets/kustomization.yaml
+++ b/components/monitoring/kanary/base/external-secrets/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - kanary-db-credentials.yaml

--- a/components/monitoring/kanary/base/kustomization.yaml
+++ b/components/monitoring/kanary/base/kustomization.yaml
@@ -1,0 +1,4 @@
+resources:
+- rbac
+- external-secrets
+namespace: appstudio-kanary-exporter

--- a/components/monitoring/kanary/base/rbac/kanary-maintainers.yaml
+++ b/components/monitoring/kanary/base/rbac/kanary-maintainers.yaml
@@ -1,0 +1,11 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: appstudio-kanary-maintainers
+subjects:
+  - kind: Group
+    name: konflux-o11y
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: component-maintainer

--- a/components/monitoring/kanary/base/rbac/kustomization.yaml
+++ b/components/monitoring/kanary/base/rbac/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - kanary-maintainers.yaml

--- a/components/monitoring/kanary/staging/base/kanary-db-credentials-secret-path.yaml
+++ b/components/monitoring/kanary/staging/base/kanary-db-credentials-secret-path.yaml
@@ -1,0 +1,4 @@
+---
+- op: add
+  path: /spec/dataFrom/0/extract/key
+  value: staging/monitoring/kanary-db-credentials

--- a/components/monitoring/kanary/staging/base/kustomization.yaml
+++ b/components/monitoring/kanary/staging/base/kustomization.yaml
@@ -1,0 +1,9 @@
+resources:
+  - ../../base
+patches:
+  - path: kanary-db-credentials-secret-path.yaml
+    target:
+      name: kanary-db-credentials
+      kind: ExternalSecret
+      group: external-secrets.io
+      version: v1beta1

--- a/components/monitoring/kanary/staging/stone-stage-p01/kustomization.yaml
+++ b/components/monitoring/kanary/staging/stone-stage-p01/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+  - https://github.com/redhat-appstudio/o11y/config/exporters/monitoring/kanary/base?ref=1525c2bbb966c5db4f7ac6fe3b5cbc399493fb61
+
+images:
+- name: quay.io/redhat-appstudio/o11y
+  newName: quay.io/redhat-appstudio/o11y
+  newTag: 1525c2bbb966c5db4f7ac6fe3b5cbc399493fb61


### PR DESCRIPTION
This commit establishes the new 'appstudio-kanary-exporter'
namespace and configures the associated GitOps deployment
for the Kanary signal exporter.

Key changes include:
- Creation of the 'monitoring-workload-kanary' ArgoCD ApplicationSet.
- Definition of the Kanary exporter component under 'components/monitoring/kanary/'.
- Updates to cluster secret store and RBAC to support the new namespace and component.

NOTES:
- This is deployed just for the stone-stage-p01 cluster by using the staging-downstream overlay.
- The base resources will still be deployed to any member cluster that may be added under the 'staging-downstream' cluster fleet. This is not ideal behavior, but it is not a breaking problem, since the exporter itself will only be deployed to that one cluster.

Related issue: [PVO11Y-4787](https://issues.redhat.com/browse/PVO11Y-4787)