### PR TITLE
mintmaker: update redis deployment to reduce CPU and memory footprint

### DIFF
--- a/components/mintmaker/base/redis-cache/redis-deployment.yaml
+++ b/components/mintmaker/base/redis-cache/redis-deployment.yaml
@@ -27,11 +27,11 @@ spec:
           args: ["run-redis"]
           resources:
             requests:
-              memory: "800Mi"
-              cpu: "0.75"
+              memory: 250Mi
+              cpu: 50m
             limits:
-              memory: "1Gi"
-              cpu: "1"
+              memory: 800Mi
+              cpu: 300m
           securityContext:
             runAsNonRoot: true
             runAsUser: 1001


### PR DESCRIPTION
Seems we don't need so much cpu/memory resource for redis-deployment.

To prevent the Redis deployment from consuming excessive resources while deploying Konflux, I reduced the resource requests.