### PR TITLE
chore: promote integration-service

### DIFF
--- a/components/integration/development/kustomization.yaml
+++ b/components/integration/development/kustomization.yaml
@@ -2,13 +2,13 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - ../base
-- https://github.com/konflux-ci/integration-service/config/default?ref=37f48c617d44598f5ba63d13104f72448ce1f1d1
-- https://github.com/konflux-ci/integration-service/config/snapshotgc?ref=37f48c617d44598f5ba63d13104f72448ce1f1d1
+- https://github.com/konflux-ci/integration-service/config/default?ref=160013f5a2653f4414019bf07e02006f6cf699cb
+- https://github.com/konflux-ci/integration-service/config/snapshotgc?ref=160013f5a2653f4414019bf07e02006f6cf699cb
 
 images:
 - name: quay.io/konflux-ci/integration-service
   newName: quay.io/konflux-ci/integration-service
-  newTag: 37f48c617d44598f5ba63d13104f72448ce1f1d1
+  newTag: 160013f5a2653f4414019bf07e02006f6cf699cb
 
 configMapGenerator:
 - name: integration-config

--- a/components/integration/production/base/kustomization.yaml
+++ b/components/integration/production/base/kustomization.yaml
@@ -3,13 +3,13 @@ kind: Kustomization
 resources:
 - ../../base
 - ../../base/external-secrets
-- https://github.com/konflux-ci/integration-service/config/default?ref=37f48c617d44598f5ba63d13104f72448ce1f1d1
-- https://github.com/konflux-ci/integration-service/config/snapshotgc?ref=37f48c617d44598f5ba63d13104f72448ce1f1d1
+- https://github.com/konflux-ci/integration-service/config/default?ref=160013f5a2653f4414019bf07e02006f6cf699cb
+- https://github.com/konflux-ci/integration-service/config/snapshotgc?ref=160013f5a2653f4414019bf07e02006f6cf699cb
 
 images:
 - name: quay.io/konflux-ci/integration-service
   newName: quay.io/konflux-ci/integration-service
-  newTag: 37f48c617d44598f5ba63d13104f72448ce1f1d1
+  newTag: 160013f5a2653f4414019bf07e02006f6cf699cb
 
 configMapGenerator:
 - name: integration-config

--- a/components/integration/staging/base/kustomization.yaml
+++ b/components/integration/staging/base/kustomization.yaml
@@ -3,13 +3,13 @@ kind: Kustomization
 resources:
 - ../../base
 - ../../base/external-secrets
-- https://github.com/konflux-ci/integration-service/config/default?ref=37f48c617d44598f5ba63d13104f72448ce1f1d1
-- https://github.com/konflux-ci/integration-service/config/snapshotgc?ref=37f48c617d44598f5ba63d13104f72448ce1f1d1
+- https://github.com/konflux-ci/integration-service/config/default?ref=160013f5a2653f4414019bf07e02006f6cf699cb
+- https://github.com/konflux-ci/integration-service/config/snapshotgc?ref=160013f5a2653f4414019bf07e02006f6cf699cb
 
 images:
 - name: quay.io/konflux-ci/integration-service
   newName: quay.io/konflux-ci/integration-service
-  newTag: 37f48c617d44598f5ba63d13104f72448ce1f1d1
+  newTag: 160013f5a2653f4414019bf07e02006f6cf699cb
 
 configMapGenerator:
 - name: integration-config


### PR DESCRIPTION
promotes integration-service in order to grant greater permissions for integrationtestscenario/status resources for integration admins