### PR TITLE
chore: revert webhook changes in integration-service

### DIFF
--- a/components/integration/development/kustomization.yaml
+++ b/components/integration/development/kustomization.yaml
@@ -2,13 +2,13 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - ../base
-- https://github.com/konflux-ci/integration-service/config/default?ref=160013f5a2653f4414019bf07e02006f6cf699cb
-- https://github.com/konflux-ci/integration-service/config/snapshotgc?ref=160013f5a2653f4414019bf07e02006f6cf699cb
+- https://github.com/konflux-ci/integration-service/config/default?ref=05c9fb070b2e69a6ce8d7a9df7df49d2b26fcf3a
+- https://github.com/konflux-ci/integration-service/config/snapshotgc?ref=05c9fb070b2e69a6ce8d7a9df7df49d2b26fcf3a
 
 images:
 - name: quay.io/konflux-ci/integration-service
   newName: quay.io/konflux-ci/integration-service
-  newTag: 160013f5a2653f4414019bf07e02006f6cf699cb
+  newTag: 05c9fb070b2e69a6ce8d7a9df7df49d2b26fcf3a
 
 configMapGenerator:
 - name: integration-config

--- a/components/integration/production/base/kustomization.yaml
+++ b/components/integration/production/base/kustomization.yaml
@@ -3,13 +3,13 @@ kind: Kustomization
 resources:
 - ../../base
 - ../../base/external-secrets
-- https://github.com/konflux-ci/integration-service/config/default?ref=160013f5a2653f4414019bf07e02006f6cf699cb
-- https://github.com/konflux-ci/integration-service/config/snapshotgc?ref=160013f5a2653f4414019bf07e02006f6cf699cb
+- https://github.com/konflux-ci/integration-service/config/default?ref=05c9fb070b2e69a6ce8d7a9df7df49d2b26fcf3a
+- https://github.com/konflux-ci/integration-service/config/snapshotgc?ref=05c9fb070b2e69a6ce8d7a9df7df49d2b26fcf3a
 
 images:
 - name: quay.io/konflux-ci/integration-service
   newName: quay.io/konflux-ci/integration-service
-  newTag: 160013f5a2653f4414019bf07e02006f6cf699cb
+  newTag: 05c9fb070b2e69a6ce8d7a9df7df49d2b26fcf3a
 
 configMapGenerator:
 - name: integration-config

--- a/components/integration/staging/base/kustomization.yaml
+++ b/components/integration/staging/base/kustomization.yaml
@@ -3,13 +3,13 @@ kind: Kustomization
 resources:
 - ../../base
 - ../../base/external-secrets
-- https://github.com/konflux-ci/integration-service/config/default?ref=160013f5a2653f4414019bf07e02006f6cf699cb
-- https://github.com/konflux-ci/integration-service/config/snapshotgc?ref=160013f5a2653f4414019bf07e02006f6cf699cb
+- https://github.com/konflux-ci/integration-service/config/default?ref=05c9fb070b2e69a6ce8d7a9df7df49d2b26fcf3a
+- https://github.com/konflux-ci/integration-service/config/snapshotgc?ref=05c9fb070b2e69a6ce8d7a9df7df49d2b26fcf3a
 
 images:
 - name: quay.io/konflux-ci/integration-service
   newName: quay.io/konflux-ci/integration-service
-  newTag: 160013f5a2653f4414019bf07e02006f6cf699cb
+  newTag: 05c9fb070b2e69a6ce8d7a9df7df49d2b26fcf3a
 
 configMapGenerator:
 - name: integration-config


### PR DESCRIPTION
Now that production has been fixed, revert changes to integrationtestscenario webhooks to no longer ignore errors