### PR TITLE
Upgrade etcd-defrag image to latest revision

### DIFF
--- a/configs/etcd-defrag/base/cronjob.yaml
+++ b/configs/etcd-defrag/base/cronjob.yaml
@@ -22,4 +22,4 @@ spec:
                 - -c
                 - |
                   etcd_pod=$(oc get pod -l app=etcd -oname -n openshift-etcd | awk -F"/" 'NR==1{ print $2 }')
-                  oc -n openshift-etcd debug pod/${etcd_pod} fragmentationThreshold=15 --image=quay.io/konflux-ci/etcd-defrag:5cd77468927ab368aecfceaaf045b0e64fb10cfa --one-container=true -- /bin/sh -c "chmod +x /opt/defrag.sh && /opt/defrag.sh"
+                  oc -n openshift-etcd debug pod/${etcd_pod} fragmentationThreshold=15 --image=quay.io/konflux-ci/etcd-defrag:788c85baf311517c6534556fdf66f936a7239efb --one-container=true -- /bin/sh -c "chmod +x /opt/defrag.sh && /opt/defrag.sh"


### PR DESCRIPTION
* chore(deps): update konflux references
* Always compact ETCD before evaluating reclaimable space
* chore(deps): update registry.redhat.io/ubi9 docker tag to v9.6-1747219013
* Konflux build pipeline service account migration for defrag

[KFLUXINFRA-1644](https://issues.redhat.com//browse/KFLUXINFRA-1644)