### PR TITLE
Increase defrag threshold to 30%

### DIFF
--- a/configs/etcd-defrag/base/cronjob.yaml
+++ b/configs/etcd-defrag/base/cronjob.yaml
@@ -22,4 +22,4 @@ spec:
                 - -c
                 - |
                   etcd_pod=$(oc get pod -l app=etcd -oname -n openshift-etcd | awk -F"/" 'NR==1{ print $2 }')
-                  oc -n openshift-etcd debug pod/${etcd_pod} fragmentationThreshold=15 --image=quay.io/konflux-ci/etcd-defrag:788c85baf311517c6534556fdf66f936a7239efb --one-container=true -- /bin/sh -c "chmod +x /opt/defrag.sh && /opt/defrag.sh"
+                  oc -n openshift-etcd debug pod/${etcd_pod} fragmentationThreshold=30 --image=quay.io/konflux-ci/etcd-defrag:788c85baf311517c6534556fdf66f936a7239efb --one-container=true -- /bin/sh -c "chmod +x /opt/defrag.sh && /opt/defrag.sh"


### PR DESCRIPTION
Having a threshold of 15% is too aggressive causing unnecessary defragmentation when DB size is < 4GB. At 4 GB, 15% means defrag will happen as soon as 607MB is reclaimable. There is not point defragmenting for 607MB when DB size is at 50% capacity.

Increase the threshold to 30% to reduce defrag when DB size in not even 50%. When DB is larger 60-70%, this is where we need to more aggressively defrag and this is happening due to other condition where we do it if 1GB is reclaimable.

[KFLUXINFRA-1644](https://issues.redhat.com//browse/KFLUXINFRA-1644)