### PR TITLE
Grant builder and releaser SAs rights to create secrets

### DIFF
--- a/components/konflux-rbac/production/base/konflux-builder-bot-actions.yaml
+++ b/components/konflux-rbac/production/base/konflux-builder-bot-actions.yaml
@@ -15,4 +15,9 @@ rules:
   - update
   - patch
   - delete
-
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create

--- a/components/konflux-rbac/production/base/konflux-releaser-bot-actions.yaml
+++ b/components/konflux-rbac/production/base/konflux-releaser-bot-actions.yaml
@@ -10,3 +10,9 @@ rules:
   verbs:
   - watch
   - create
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create

--- a/components/konflux-rbac/staging/base/konflux-builder-bot-actions.yaml
+++ b/components/konflux-rbac/staging/base/konflux-builder-bot-actions.yaml
@@ -15,4 +15,9 @@ rules:
   - update
   - patch
   - delete
-
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create

--- a/components/konflux-rbac/staging/base/konflux-releaser-bot-actions.yaml
+++ b/components/konflux-rbac/staging/base/konflux-releaser-bot-actions.yaml
@@ -10,3 +10,9 @@ rules:
   verbs:
   - watch
   - create
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create


### PR DESCRIPTION
The need here is for an external CI provider that wants to initiate a build or release and needs to supply a short-term secret to that run. We want this SA to be able to create or update a previously created secret, but not get or read that secrets or any other secrets in the namespace.