### PR TITLE
 add list RoleBindings to maintainers and contributors in prod

### DIFF
--- a/components/konflux-rbac/production/base/konflux-contributor-user-actions.yaml
+++ b/components/konflux-rbac/production/base/konflux-contributor-user-actions.yaml
@@ -133,3 +133,9 @@ rules:
       - pulp.konflux-ci.dev
     resources:
       - pulpaccessrequests
+  - verbs:
+      - list
+    apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - rolebindings

--- a/components/konflux-rbac/production/base/konflux-maintainer-user-actions.yaml
+++ b/components/konflux-rbac/production/base/konflux-maintainer-user-actions.yaml
@@ -150,3 +150,9 @@ rules:
       - pulp.konflux-ci.dev
     resources:
       - pulpaccessrequests
+  - verbs:
+      - list
+    apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - rolebindings


### PR DESCRIPTION
This change fixes the visibility problem maintainers and contributors are facing in the New UI's User Access page.

Follows up to #6373

Signed-off-by: Francesco Ilario <filario@redhat.com>
