### PR TITLE
leverage etcd-shield to reject PipelineRuns in rh01

### DIFF
--- a/components/etcd-shield/production/stone-prd-rh01/base/config.yaml
+++ b/components/etcd-shield/production/stone-prd-rh01/base/config.yaml
@@ -1,0 +1,12 @@
+destName: etcd-shield-state
+destNamespace: etcd-shield
+prometheus:
+  address: https://prometheus-k8s.openshift-monitoring.svc:9091
+  alertName: EtcdShieldDenyAdmission
+  config:
+    authorization:
+      type: Bearer
+      credentials_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+    tls_config:
+      ca_file: /var/tls/tls.crt
+waitTime: 15s

--- a/components/etcd-shield/production/stone-prd-rh01/base/deployment.yaml
+++ b/components/etcd-shield/production/stone-prd-rh01/base/deployment.yaml
@@ -1,0 +1,88 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: etcd-shield
+  labels:
+    app: etcd-shield
+  annotations:
+    ignore-check.kube-linter.io/no-anti-affinity: "using topologySpreadConstraints"
+spec:
+  selector:
+    matchLabels:
+      app: etcd-shield
+  replicas: 3
+  template:
+    metadata:
+      labels:
+        app: etcd-shield
+    spec:
+      serviceAccountName: etcd-shield
+      topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: topology.kubernetes.io/zone
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app: etcd-shield
+      containers:
+      - args:
+        - -leader-elect=false
+        - -health-probe-bind-address=:8081
+        - -config=/etc/etcd-shield/config.yaml
+        - -port=8443
+        env:
+        - name: "NAMESPACE"
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        image: etcd-shield:latest
+        name: etcd-shield
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          initialDelaySeconds: 1
+          httpGet:
+            path: /healthz
+            port: 8081
+            scheme: HTTP
+        readinessProbe:
+          initialDelaySeconds: 1
+          httpGet:
+            path: /readyz
+            port: 8081
+            scheme: HTTP
+        resources:
+          limits:
+            cpu: 500m
+            memory: 128Mi
+          requests:
+            cpu: 500m
+            memory: 128Mi
+        ports:
+        - containerPort: 8443
+          name: http
+        - containerPort: 8081
+          name: healthz
+        - containerPort: 9100
+          name: metrics
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          capabilities:
+            drop:
+            - "ALL"
+        volumeMounts:
+        - name: tls
+          mountPath: /var/tls
+          readOnly: true
+        - name: config
+          mountPath: /etc/etcd-shield/
+          readOnly: true
+      terminationGracePeriodSeconds: 60
+      volumes:
+      - name: tls
+        secret:
+          secretName: etcd-shield-tls
+      - name: config
+        configMap:
+          name: etcd-shield-config

--- a/components/etcd-shield/production/stone-prd-rh01/base/etcd_shield_alerts.yaml
+++ b/components/etcd-shield/production/stone-prd-rh01/base/etcd_shield_alerts.yaml
@@ -1,0 +1,28 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: etcd-shield-triggers
+spec:
+  groups:
+  - name: etcd_shield_triggers
+    interval: 1m
+    rules:
+    - alert: EtcdShieldDenyAdmission
+      expr: etcd_shield_trigger != bool 0
+      for: 2m
+      keep_firing_for: 5m
+      labels:
+        severity: warning
+      annotations:
+        summary: etcd-shield is denying admission
+        description: Etcd is nearing capacity limits, so etcd-shield is denying admission
+    - record: etcd_shield_trigger
+      expr: |
+        (((etcd_mvcc_db_total_size_in_bytes >= bool (etcd_server_quota_backend_bytes * 0.30)) == 1) or
+            ((((etcd_mvcc_db_total_size_in_bytes) >= bool (etcd_server_quota_backend_bytes * 0.20)) == 1) and
+                (count without (alertname, alertstate, severity)
+                      (ALERTS{
+                        alertname="EtcdShieldDenyAdmission",
+                        alertstate="firing",
+                        severity="critical"
+                      }) == bool 1)))

--- a/components/etcd-shield/production/stone-prd-rh01/base/kustomization.yaml
+++ b/components/etcd-shield/production/stone-prd-rh01/base/kustomization.yaml
@@ -1,0 +1,21 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+configMapGenerator:
+- files:
+  - ./config.yaml
+  name: etcd-shield-config
+# generatorOptions:
+#   # until https://github.com/kubernetes-sigs/kustomize/issues/4475 is fixed
+#   disableNameSuffixHash: true
+images:
+- name: etcd-shield
+  newName: quay.io/konflux-ci/etcd-shield
+  newTag: 3de52a71e086e152b3d2b33bfc897ce7bf8ea0dd
+namespace: etcd-shield
+resources:
+- deployment.yaml
+- ns.yaml
+- rbac.yaml
+- service.yaml
+- webhook.yaml
+- etcd_shield_alerts.yaml

--- a/components/etcd-shield/production/stone-prd-rh01/base/ns.yaml
+++ b/components/etcd-shield/production/stone-prd-rh01/base/ns.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: etcd-shield
+  labels:
+    openshift.io/cluster-monitoring: "true"

--- a/components/etcd-shield/production/stone-prd-rh01/base/rbac.yaml
+++ b/components/etcd-shield/production/stone-prd-rh01/base/rbac.yaml
@@ -1,0 +1,63 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: etcd-shield
+  namespace: etcd-shield
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: etcd-shield-authorizer
+subjects:
+- apiGroup: ""
+  kind: ServiceAccount
+  name: etcd-shield
+  namespace: etcd-shield
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: etcd-shield-authorizer
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: etcd-shield
+subjects:
+- apiGroup: ""
+  kind: ServiceAccount
+  name: etcd-shield
+  namespace: etcd-shield
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: etcd-shield
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: etcd-shield
+  namespace: etcd-shield
+rules:
+- apiGroups: [""]
+  resources: ["configmaps"]
+  verbs: ["get", "list", "watch", "create", "update", "patch"]
+- apiGroups: ["coordination.k8s.io"]
+  resources: ["leases"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+- apiGroups: [""]
+  resources: ["events"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: etcd-shield:cluster-monitoring-view
+subjects:
+- apiGroup: ""
+  kind: ServiceAccount
+  name: etcd-shield
+  namespace: etcd-shield
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-monitoring-view

--- a/components/etcd-shield/production/stone-prd-rh01/base/service.yaml
+++ b/components/etcd-shield/production/stone-prd-rh01/base/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: etcd-shield-tls
+  name: etcd-shield
+spec:
+  ports:
+  - port: 443
+    protocol: TCP
+    targetPort: 8443
+  selector:
+    app: etcd-shield

--- a/components/etcd-shield/production/stone-prd-rh01/base/webhook.yaml
+++ b/components/etcd-shield/production/stone-prd-rh01/base/webhook.yaml
@@ -1,0 +1,26 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  annotations:
+    service.beta.openshift.io/inject-cabundle: 'true'
+  name: etcd-shield-validating-webhook-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: etcd-shield
+      namespace: etcd-shield
+      path: /validate-tekton-dev-v1-pipelinerun
+  failurePolicy: Fail
+  name: vpipelineruns.konflux-ci.dev
+  rules:
+  - apiGroups:
+    - tekton.dev
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    resources:
+    - pipelineruns
+  sideEffects: None

--- a/components/etcd-shield/production/stone-prd-rh01/kustomization.yaml
+++ b/components/etcd-shield/production/stone-prd-rh01/kustomization.yaml
@@ -1,4 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- ../base
+- ./base
+


### PR DESCRIPTION
We want to temporarily prevent new PipelineRuns to be created in rh01.

This PR just copies the base folder to rh01 instead of patching the rule for the sake of time.

Signed-off-by: Francesco Ilario <filario@redhat.com>
