### PR TITLE
disable kyverno's report controller on rh01

### DIFF
--- a/components/kyverno/production/stone-prd-rh01/kyverno-helm-values.yaml
+++ b/components/kyverno/production/stone-prd-rh01/kyverno-helm-values.yaml
@@ -56,6 +56,7 @@ cleanupController:
       drop:
       - "ALL"
 reportsController:
+  enabled: false
   replicas: 3
   resources:
     requests:


### PR DESCRIPTION
This change disables Kyverno's Reports controller to reduce load on rh01

Signed-off-by: Francesco Ilario <filario@redhat.com>
