### PR TITLE
disable kyverno reports in staging

### DIFF
--- a/components/kyverno/chainsaw/kyverno-helm-values.yaml
+++ b/components/kyverno/chainsaw/kyverno-helm-values.yaml
@@ -51,16 +51,6 @@ cleanupController:
       - "ALL"
 reportsController:
   enabled: false
-  resources:
-    limits:
-      cpu: 500m
-  securityContext:
-    allowPrivilegeEscalation: false
-    readOnlyRootFilesystem: true
-    runAsNonRoot: true
-    capabilities:
-      drop:
-      - "ALL"
 policyReportsCleanup:
   securityContext:
     allowPrivilegeEscalation: false

--- a/components/kyverno/development/kyverno-helm-values.yaml
+++ b/components/kyverno/development/kyverno-helm-values.yaml
@@ -50,16 +50,6 @@ cleanupController:
       - "ALL"
 reportsController:
   enabled: false
-  resources:
-    limits:
-      cpu: 500m
-  securityContext:
-    allowPrivilegeEscalation: false
-    readOnlyRootFilesystem: true
-    runAsNonRoot: true
-    capabilities:
-      drop:
-      - "ALL"
 policyReportsCleanup:
   securityContext:
     allowPrivilegeEscalation: false

--- a/components/kyverno/staging/stone-stage-p01/kyverno-helm-values.yaml
+++ b/components/kyverno/staging/stone-stage-p01/kyverno-helm-values.yaml
@@ -54,17 +54,7 @@ cleanupController:
       drop:
       - "ALL"
 reportsController:
-  replicas: 3
-  resources:
-    limits:
-      cpu: 500m
-  securityContext:
-    allowPrivilegeEscalation: false
-    readOnlyRootFilesystem: true
-    runAsNonRoot: true
-    capabilities:
-      drop:
-      - "ALL"
+  enabled: false
 policyReportsCleanup:
   image:
     registry: mirror.gcr.io

--- a/components/kyverno/staging/stone-stg-rh01/kyverno-helm-values.yaml
+++ b/components/kyverno/staging/stone-stg-rh01/kyverno-helm-values.yaml
@@ -54,17 +54,7 @@ cleanupController:
       drop:
       - "ALL"
 reportsController:
-  replicas: 3
-  resources:
-    limits:
-      cpu: 500m
-  securityContext:
-    allowPrivilegeEscalation: false
-    readOnlyRootFilesystem: true
-    runAsNonRoot: true
-    capabilities:
-      drop:
-      - "ALL"
+  enabled: false
 policyReportsCleanup:
   image:
     registry: mirror.gcr.io


### PR DESCRIPTION
At our scale Kyverno Reports is putting too much pressure on the APIServer.

Signed-off-by: Francesco Ilario <filario@redhat.com>
