### PR TITLE
fix kyverno dev overlay configuration

### DIFF
--- a/components/kyverno/development/kustomization.yaml
+++ b/components/kyverno/development/kustomization.yaml
@@ -14,24 +14,6 @@ replacements:
       group: batch
       version: v1
       kind: Job
-      name: konflux-kyverno-scale-to-zero
-      namespace: konflux-kyverno
-      fieldPath: spec.template.spec.serviceAccount
-    targets:
-      - select:
-          group: batch
-          version: v1
-          kind: Job
-          namespace: konflux-kyverno
-          name: konflux-kyverno-scale-to-zero
-        fieldPaths:
-          - spec.template.spec.serviceAccountName
-        options:
-          create: true
-  - source:
-      group: batch
-      version: v1
-      kind: Job
       name: konflux-kyverno-clean-reports
       namespace: konflux-kyverno
       fieldPath: spec.template.spec.serviceAccount
@@ -85,12 +67,6 @@ replacements:
 
 # set resources to jobs
 patches:
-  - path: job_resources.yaml
-    target:
-      group: batch
-      version: v1
-      kind: Job
-      name: konflux-kyverno-scale-to-zero
   - path: job_resources.yaml
     target:
       group: batch

--- a/components/kyverno/development/kyverno-helm-values.yaml
+++ b/components/kyverno/development/kyverno-helm-values.yaml
@@ -71,7 +71,7 @@ policyReportsCleanup:
       drop:
       - "ALL"
 webhooksCleanup:
-  enable: false
+  enabled: false
   securityContext:
     allowPrivilegeEscalation: false
     readOnlyRootFilesystem: true


### PR DESCRIPTION
Due to a typo we were not disabling the scale-to-zero job as intended in the development overlay

Signed-off-by: Francesco Ilario <filario@redhat.com>
