### PR TITLE
Refer to pulp-access-controller by commit

### DIFF
--- a/components/pulp-access-controller/base/kustomization.yaml
+++ b/components/pulp-access-controller/base/kustomization.yaml
@@ -1,6 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- https://github.com/pulp/pulp-access-controller/config/manifests?ref=main
+- https://github.com/pulp/pulp-access-controller/config/manifests?ref=27bf4a085dbae558f2149fe292e01fae24af8890
 
 namespace: pulp-access-controller


### PR DESCRIPTION
This way, if they break something on their end, we won't automatically absorb that changes into infra-deployments.