### PR TITLE
chore: update integration service in all environments

### DIFF
--- a/components/integration/development/kustomization.yaml
+++ b/components/integration/development/kustomization.yaml
@@ -2,8 +2,8 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - ../base
-- https://github.com/konflux-ci/integration-service/config/default?ref=05c9fb070b2e69a6ce8d7a9df7df49d2b26fcf3a
-- https://github.com/konflux-ci/integration-service/config/snapshotgc?ref=05c9fb070b2e69a6ce8d7a9df7df49d2b26fcf3a
+- https://github.com/konflux-ci/integration-service/config/default?ref=b278f4a75a02026ebb3e3cae470b549348d698b3
+- https://github.com/konflux-ci/integration-service/config/snapshotgc?ref=b278f4a75a02026ebb3e3cae470b549348d698b3
 
 images:
 - name: quay.io/konflux-ci/integration-service

--- a/components/integration/production/base/kustomization.yaml
+++ b/components/integration/production/base/kustomization.yaml
@@ -3,13 +3,13 @@ kind: Kustomization
 resources:
 - ../../base
 - ../../base/external-secrets
-- https://github.com/konflux-ci/integration-service/config/default?ref=05c9fb070b2e69a6ce8d7a9df7df49d2b26fcf3a
-- https://github.com/konflux-ci/integration-service/config/snapshotgc?ref=05c9fb070b2e69a6ce8d7a9df7df49d2b26fcf3a
+- https://github.com/konflux-ci/integration-service/config/default?ref=b278f4a75a02026ebb3e3cae470b549348d698b3
+- https://github.com/konflux-ci/integration-service/config/snapshotgc?ref=b278f4a75a02026ebb3e3cae470b549348d698b3
 
 images:
 - name: quay.io/konflux-ci/integration-service
   newName: quay.io/konflux-ci/integration-service
-  newTag: 05c9fb070b2e69a6ce8d7a9df7df49d2b26fcf3a
+  newTag: b278f4a75a02026ebb3e3cae470b549348d698b3
 
 configMapGenerator:
 - name: integration-config

--- a/components/integration/staging/base/kustomization.yaml
+++ b/components/integration/staging/base/kustomization.yaml
@@ -3,13 +3,13 @@ kind: Kustomization
 resources:
 - ../../base
 - ../../base/external-secrets
-- https://github.com/konflux-ci/integration-service/config/default?ref=05c9fb070b2e69a6ce8d7a9df7df49d2b26fcf3a
-- https://github.com/konflux-ci/integration-service/config/snapshotgc?ref=05c9fb070b2e69a6ce8d7a9df7df49d2b26fcf3a
+- https://github.com/konflux-ci/integration-service/config/default?ref=b278f4a75a02026ebb3e3cae470b549348d698b3
+- https://github.com/konflux-ci/integration-service/config/snapshotgc?ref=b278f4a75a02026ebb3e3cae470b549348d698b3
 
 images:
 - name: quay.io/konflux-ci/integration-service
   newName: quay.io/konflux-ci/integration-service
-  newTag: 05c9fb070b2e69a6ce8d7a9df7df49d2b26fcf3a
+  newTag: b278f4a75a02026ebb3e3cae470b549348d698b3
 
 configMapGenerator:
 - name: integration-config


### PR DESCRIPTION
Pushes a patch fixing a race condition in snapshot creation that is causing a CrashLoopBackoff