### PR TITLE
Fix testplatform-kubernetes-provider-config secret reference

### DIFF
--- a/components/crossplane-control-plane/staging/testplatform-provider-config.yaml
+++ b/components/crossplane-control-plane/staging/testplatform-provider-config.yaml
@@ -32,4 +32,4 @@ spec:
   target:
     creationPolicy: Owner
     deletionPolicy: Delete
-    name: testplatform-cluster
+    name: testplatform-appci-cluster


### PR DESCRIPTION
Fix a wrong secret name introduced in https://github.com/redhat-appstudio/infra-deployments/pull/6449