### PR TITLE
Remove pulp-access-controller from development

### DIFF
--- a/argo-cd-apps/overlays/development/delete-applications.yaml
+++ b/argo-cd-apps/overlays/development/delete-applications.yaml
@@ -130,3 +130,9 @@ kind: ApplicationSet
 metadata:
   name: etcd-defrag
 $patch: delete
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: pulp-access-controller
+$patch: delete


### PR DESCRIPTION
This application deploys an external secret and we don't install ESO in development, because of that the deployment of development got broken.