### PR TITLE
bump kyverno UpdateRequest threshold in rh01

### DIFF
--- a/components/kyverno/production/stone-prd-rh01/kyverno-helm-values.yaml
+++ b/components/kyverno/production/stone-prd-rh01/kyverno-helm-values.yaml
@@ -1,7 +1,7 @@
 fullnameOverride: konflux-kyverno
 namespaceOverride: konflux-kyverno
 config:
-  updateRequestThreshold: 2000
+  updateRequestThreshold: 4000
 admissionController:
   replicas: 3
   initContainer:


### PR DESCRIPTION
Kyverno background controller is restarting as it reached the threshold for UpdateRequests.

Signed-off-by: Francesco Ilario <filario@redhat.com>
