### PR TITLE
disable `mutate-namespace-enforce-label` policy in staging

### DIFF
--- a/components/namespace-lister/base/kustomization.yaml
+++ b/components/namespace-lister/base/kustomization.yaml
@@ -8,7 +8,6 @@ resources:
 - network_policy_allow_from_konfluxui.yaml
 - network_policy_allow_to_apiserver.yaml
 - metrics/
-- ../policies/ns-label/
 namespace: namespace-lister
 images:
 - name: namespace-lister


### PR DESCRIPTION
At this point we migrated all the namespace to the new label. We are no more expecting any Namespace to be created with the `toolchain.dev.openshift.com` or the `konflux.ci` labels.

Signed-off-by: Francesco Ilario <filario@redhat.com>
