### PR TITLE
give more cpu to Kyverno background on rh01

### DIFF
--- a/components/kyverno/production/stone-prd-rh01/kyverno-helm-values.yaml
+++ b/components/kyverno/production/stone-prd-rh01/kyverno-helm-values.yaml
@@ -31,10 +31,10 @@ backgroundController:
   replicas: 3
   resources:
     requests:
-      cpu: 500m
+      cpu: 2000m
       memory: 4Gi
     limits:
-      cpu: 500m
+      cpu: 2000m
       memory: 4Gi
   securityContext:
     allowPrivilegeEscalation: false


### PR DESCRIPTION
Kyverno background is using all the CPU time we provided.
Let's give it more compute power

Signed-off-by: Francesco Ilario <filario@redhat.com>
