### PR TITLE
disable mutate-namespace-enforce-label in rh01

### DIFF
--- a/components/namespace-lister/production/base/kustomization.yaml
+++ b/components/namespace-lister/production/base/kustomization.yaml
@@ -8,7 +8,6 @@ resources:
 - network_policy_allow_to_apiserver.yaml
 - network_policy_allow_from_konfluxui.yaml
 - metrics/
-- ../../policies/ns-label
 namespace: namespace-lister
 images:
 - name: namespace-lister

--- a/components/namespace-lister/production/kflux-ocp-p01/kustomization.yaml
+++ b/components/namespace-lister/production/kflux-ocp-p01/kustomization.yaml
@@ -2,3 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - ../base/
+- ../../policies/ns-label

--- a/components/namespace-lister/production/kflux-prd-rh02/kustomization.yaml
+++ b/components/namespace-lister/production/kflux-prd-rh02/kustomization.yaml
@@ -2,3 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - ../base/
+- ../../policies/ns-label

--- a/components/namespace-lister/production/kflux-prd-rh03/kustomization.yaml
+++ b/components/namespace-lister/production/kflux-prd-rh03/kustomization.yaml
@@ -2,3 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - ../base/
+- ../../policies/ns-label

--- a/components/namespace-lister/production/stone-prod-p01/kustomization.yaml
+++ b/components/namespace-lister/production/stone-prod-p01/kustomization.yaml
@@ -2,3 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - ../base/
+- ../../policies/ns-label

--- a/components/namespace-lister/production/stone-prod-p02/kustomization.yaml
+++ b/components/namespace-lister/production/stone-prod-p02/kustomization.yaml
@@ -2,3 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - ../base/
+- ../../policies/ns-label


### PR DESCRIPTION
This policy is adding a lot of pressure on rh01, we'll finish migration
manually. We are no more expecting any Namespace to be created with the
`toolchain.dev.openshift.com` or the `konflux.ci` labels.

Signed-off-by: Francesco Ilario <filario@redhat.com>
