### PR TITLE
changes to bootstrap to accomodate the pulpaccessrequets

### DIFF
--- a/components/konflux-rbac/policies/bootstrap-tenant-namespace/bootstrap-tenant-namespace-clusterpolicy.yaml
+++ b/components/konflux-rbac/policies/bootstrap-tenant-namespace/bootstrap-tenant-namespace-clusterpolicy.yaml
@@ -1,0 +1,43 @@
+---
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: bootstrap-tenant-namespace-pulp-access
+  annotations:
+    policies.kyverno.io/title: Bootstrap Tenant Namespace Pulp Access
+    policies.kyverno.io/category: Bootstrap
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: RoleBinding, RBAC
+    policies.kyverno.io/description: >-
+      Creates a RoleBinding for pulp access in tenant namespaces
+spec:
+  rules:
+  - name: create-pulp-access-rolebinding
+    match:
+      any:
+      - resources:
+          kinds:
+          - Namespace
+          selector:
+            matchLabels:
+              konflux-ci.dev/type: tenant
+          operations:
+            - CREATE
+            - UPDATE
+    generate:
+      generateExisting: false
+      synchronize: false
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      name: appstudio-pulp-access-rolebinding
+      namespace: '{{request.object.metadata.name}}'
+      data:
+        roleRef:
+          apiGroup: rbac.authorization.k8s.io
+          kind: ClusterRole
+          name: konflux-pulp-access-actions
+        subjects:
+        - apiGroup: ""
+          kind: ServiceAccount
+          namespace: '{{request.object.metadata.name}}'
+          name: appstudio-pipeline

--- a/components/konflux-rbac/policies/bootstrap-tenant-namespace/kustomization.yaml
+++ b/components/konflux-rbac/policies/bootstrap-tenant-namespace/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
 - bootstrap-tenant-namespace-rbcm-clusterpolicy.yaml
 - bootstrap-tenant-namespace-networkpolicies-clusterpolicy.yaml
 - kyverno_rbac.yaml
+- bootstrap-tenant-namespace-clusterpolicy.yaml

--- a/components/konflux-rbac/policies/bootstrap-tenant-namespace/kyverno_rbac.yaml
+++ b/components/konflux-rbac/policies/bootstrap-tenant-namespace/kyverno_rbac.yaml
@@ -65,4 +65,16 @@ subjects:
 - kind: ServiceAccount
   namespace: konflux-kyverno
   name: kyverno-background-controller
-
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kyverno-background:konflux-pulp-access
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: konflux-pulp-access-actions
+subjects:
+- kind: ServiceAccount
+  namespace: konflux-kyverno
+  name: kyverno-background-controller

--- a/components/konflux-rbac/production/base/konflux-pulp-access-actions.yaml
+++ b/components/konflux-rbac/production/base/konflux-pulp-access-actions.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: konflux-pulp-access-actions
+rules:
+- apiGroups:
+  - pulp.konflux-ci.dev
+  resources:
+  - pulpaccessrequests
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+  - patch
+  - delete

--- a/components/konflux-rbac/production/base/kustomization.yaml
+++ b/components/konflux-rbac/production/base/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
   - konflux-viewer-user-actions.yaml
   - konflux-builder-bot-actions.yaml
   - konflux-releaser-bot-actions.yaml
+  - konflux-pulp-access-actions.yaml
   - ../policies/bootstrap-tenant-namespace/
   - ../policies/restrict-binding-system-authenticated/
   - ../policies/validate-rolebindings/

--- a/components/konflux-rbac/staging/base/konflux-pulp-access-actions.yaml
+++ b/components/konflux-rbac/staging/base/konflux-pulp-access-actions.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: konflux-pulp-access-actions
+rules:
+- apiGroups:
+  - pulp.konflux-ci.dev
+  resources:
+  - pulpaccessrequests
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+  - patch
+  - delete

--- a/components/konflux-rbac/staging/base/kustomization.yaml
+++ b/components/konflux-rbac/staging/base/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
   - konflux-viewer-user-actions.yaml
   - konflux-builder-bot-actions.yaml
   - konflux-releaser-bot-actions.yaml
+  - konflux-pulp-access-actions.yaml
   - ../../policies/bootstrap-tenant-namespace/
   - ../../policies/restrict-binding-system-authenticated/
   - ../../policies/validate-rolebindings/


### PR DESCRIPTION
The current problem with pulpaccessrequets is that when you try to use the new controller from insdie a pipeline, the automatically generated user which is namespace based, doesn't have access to the crd
And looking at the rbac, I believe that a change to the namespace bootstrap will help with this