### PR TITLE
bump memory for image-controller

### DIFF
--- a/components/image-controller/production/base/manager_resources_patch.yaml
+++ b/components/image-controller/production/base/manager_resources_patch.yaml
@@ -11,8 +11,8 @@ spec:
         resources:
           limits:
             cpu: 500m
-            memory: 2Gi
+            memory: 6Gi
           requests:
             cpu: 250m
-            memory: 1Gi
+            memory: 3Gi
 

--- a/components/image-controller/staging/base/manager_resources_patch.yaml
+++ b/components/image-controller/staging/base/manager_resources_patch.yaml
@@ -11,8 +11,8 @@ spec:
         resources:
           limits:
             cpu: 500m
-            memory: 2Gi
+            memory: 6Gi
           requests:
             cpu: 250m
-            memory: 1Gi
+            memory: 3Gi
 


### PR DESCRIPTION
[STONEBLD-3526](https://issues.redhat.com//browse/STONEBLD-3526)