### PR TITLE
fix group propagation for nslister in stg

### DIFF
--- a/components/namespace-lister/base/patches/with_header_auth_groups.yaml
+++ b/components/namespace-lister/base/patches/with_header_auth_groups.yaml
@@ -2,4 +2,4 @@
   path: /spec/template/spec/containers/0/env/-
   value:
     name: AUTH_GROUPS_HEADER
-    value: Impersonate-Group
+    value: X-Group


### PR DESCRIPTION
namespace-lister is not showing the correct results for group `system:authenticated`.

Signed-off-by: Francesco Ilario <filario@redhat.com>
