### PR TITLE
Patch etcd-shield applicatinset when generating new cluster manifests

### DIFF
--- a/argo-cd-apps/base/member/infra-deployments/etcd-shield/etcd-shield.yaml
+++ b/argo-cd-apps/base/member/infra-deployments/etcd-shield/etcd-shield.yaml
@@ -30,6 +30,8 @@ spec:
                   values.clusterDir: stone-prod-p01
                 - nameNormalized: stone-prod-p02
                   values.clusterDir: stone-prod-p02
+                - nameNormalized: kflux-rhel-p01
+                  values.clusterDir: kflux-rhel-p01
   template:
     metadata:
       name: etcd-shield-{{nameNormalized}}

--- a/hack/new-cluster/playbook.yaml
+++ b/hack/new-cluster/playbook.yaml
@@ -75,6 +75,7 @@
       - "{{ dst }}/argo-cd-apps/base/all-clusters/infra-deployments/monitoring-workload-logging/monitoring-workload-logging.yaml"
       - "{{ dst }}/argo-cd-apps/base/all-clusters/infra-deployments/monitoring-workload-prometheus/monitoring-workload-prometheus.yaml"
       - "{{ dst }}/argo-cd-apps/base/member/infra-deployments/build-service/build-service.yaml"
+      - "{{ dst }}/argo-cd-apps/base/member/infra-deployments/etcd-shield/etcd-shield.yaml"
       - "{{ dst }}/argo-cd-apps/base/member/infra-deployments/integration/integration.yaml"
       - "{{ dst }}/argo-cd-apps/base/member/infra-deployments/konflux-info/konflux-info.yaml"
       - "{{ dst }}/argo-cd-apps/base/member/infra-deployments/konflux-rbac/konflux-rbac.yaml"


### PR DESCRIPTION
The automation is creating the folder in the component but it was missing the path to the applicationset.