### PR TITLE
fix(STONEINTG-1190): update ref for intg grafana dashboard

### DIFF
--- a/components/monitoring/grafana/base/dashboards/integration/kustomization.yaml
+++ b/components/monitoring/grafana/base/dashboards/integration/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - https://github.com/konflux-ci/integration-service/config/grafana/?ref=74306597b3335d6f57c3375a35315ae0b5c0b7e8
+  - https://github.com/konflux-ci/integration-service/config/grafana/?ref=b278f4a75a02026ebb3e3cae470b549348d698b3


### PR DESCRIPTION
[Integration Service Health dashboard ](https://grafana-access-appstudio-grafana.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/d/b18e4904-b2c7-4942-8df6-60ffeeb04dde/integration-service-health?orgId=1) is still using the ref before https://github.com/konflux-ci/integration-service/pull/927/files
This PR is to update ref to the latest production version for https://github.com/konflux-ci/integration-service/pull/927


Signed-off-by: Hongwei Liu <hongliu@redhat.com>