### PR TITLE
exclude kubesaw managed namespace from tenant bootstrapping in stg

### DIFF
--- a/components/konflux-rbac/policies/bootstrap-tenant-namespace/.chainsaw-test/chainsaw-test.yaml
+++ b/components/konflux-rbac/policies/bootstrap-tenant-namespace/.chainsaw-test/chainsaw-test.yaml
@@ -185,6 +185,66 @@ spec:
 apiVersion: chainsaw.kyverno.io/v1alpha1
 kind: Test
 metadata:
+  name: konfluxci-bootstrap-ns-mutate-new-namespace-toolchain
+spec:
+  description: |
+    tests that the resources are NOT created in an namespace managed by KubeSaw
+  concurrent: false
+  namespace: 'generate-new-namespace'
+  bindings:
+  - name: suffix
+    value: unlabeled
+  steps:
+  - name: given-appstudio-pipeline-clusterrole-exists
+    try:
+    - apply:
+        file: ./resources/actual-appstudio-pipeline-clusterrole.yaml
+  - name: given-kyverno-has-permission-on-resources
+    try:
+    - apply:
+        file: ../kyverno_rbac.yaml
+  - name: given-cluster-policies-are-ready
+    try:
+    - apply:
+        file: ../bootstrap-tenant-namespace-np-ocpconsole-clusterpolicy.yaml
+    - apply:
+        file: ../bootstrap-tenant-namespace-np-ocpingress-clusterpolicy.yaml
+    - apply:
+        file: ../bootstrap-tenant-namespace-np-ocpmonitoring-clusterpolicy.yaml
+    - apply:
+        file: ../bootstrap-tenant-namespace-np-olm-clusterpolicy.yaml
+    - apply:
+        file: ../bootstrap-tenant-namespace-np-samenamespace-clusterpolicy.yaml
+    - apply:
+        file: ../bootstrap-tenant-namespace-rbcm-clusterpolicy.yaml
+    - assert:
+        file: chainsaw-assert-clusterpolicy.yaml
+  - name: when-unlabeled-namespace-is-created
+    try:
+    - apply:
+        file: resources/actual-namespace-kubesaw.yaml
+        template: true
+  - name: then-rolebinding-is-not-created
+    try:
+    - delete:
+        file: resources/expected-rolebinding.yaml
+        template: true
+        expect:
+        - check:
+            ($error != null): true
+  - name: then-resources-are-not-created
+    try:
+    - delete:
+        file: resources/expected-resources.yaml
+        template: true
+        expect:
+        - check:
+            ($error != null): true
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
   name: konfluxci-bootstrap-ns-mutate-existing-namespace
 spec:
   description: |
@@ -239,6 +299,68 @@ spec:
         expect:
         - check:
             ($error != null): true
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: konfluxci-bootstrap-ns-mutate-existing-namespace-unlabeled
+spec:
+  description: |
+    tests that the resources are NOT created in an 
+    existing namespace managed by KubeSaw
+  concurrent: false
+  namespace: 'generate-existing-namespace'
+  bindings:
+  - name: suffix
+    value: unlabeled
+  steps:
+  - name: given-appstudio-pipeline-clusterrole-exists
+    try:
+    - apply:
+        file: ./resources/actual-appstudio-pipeline-clusterrole.yaml
+  - name: given-kyverno-has-permission-on-resources
+    try:
+    - apply:
+        file: ../kyverno_rbac.yaml
+  - name: given-unlabeled-namespace-is-created
+    try:
+    - apply:
+        file: resources/actual-namespace-kubesaw.yaml
+        template: true
+  - name: when-cluster-policies-are-ready
+    try:
+    - apply:
+        file: ../bootstrap-tenant-namespace-np-ocpconsole-clusterpolicy.yaml
+    - apply:
+        file: ../bootstrap-tenant-namespace-np-ocpingress-clusterpolicy.yaml
+    - apply:
+        file: ../bootstrap-tenant-namespace-np-ocpmonitoring-clusterpolicy.yaml
+    - apply:
+        file: ../bootstrap-tenant-namespace-np-olm-clusterpolicy.yaml
+    - apply:
+        file: ../bootstrap-tenant-namespace-np-samenamespace-clusterpolicy.yaml
+    - apply:
+        file: ../bootstrap-tenant-namespace-rbcm-clusterpolicy.yaml
+    - assert:
+        file: chainsaw-assert-clusterpolicy.yaml
+  - name: then-rolebinding-is-not-created
+    try:
+    - delete:
+        file: resources/expected-rolebinding.yaml
+        template: true
+        expect:
+        - check:
+            ($error != null): true
+  - name: then-resources-are-not-created
+    try:
+    - delete:
+        file: resources/expected-resources.yaml
+        template: true
+        expect:
+        - check:
+            ($error != null): true
+---
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
 apiVersion: chainsaw.kyverno.io/v1alpha1

--- a/components/konflux-rbac/policies/bootstrap-tenant-namespace/.chainsaw-test/resources/actual-namespace-kubesaw.yaml
+++ b/components/konflux-rbac/policies/bootstrap-tenant-namespace/.chainsaw-test/resources/actual-namespace-kubesaw.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: (join('-', [$namespace, $suffix]))
+  labels:
+    toolchain.dev.openshift.com/type: tenant
+    konflux-ci.dev/type: tenant

--- a/components/konflux-rbac/policies/bootstrap-tenant-namespace/bootstrap-tenant-namespace-np-ocpconsole-clusterpolicy.yaml
+++ b/components/konflux-rbac/policies/bootstrap-tenant-namespace/bootstrap-tenant-namespace-np-ocpconsole-clusterpolicy.yaml
@@ -14,6 +14,14 @@ spec:
           selector:
             matchLabels:
               konflux-ci.dev/type: tenant
+    exclude:
+      any:
+      - resources:
+          kinds:
+            - Namespace
+          selector:
+            matchLabels:
+              toolchain.dev.openshift.com/type: tenant
     generate:
       generateExisting: true
       synchronize: false

--- a/components/konflux-rbac/policies/bootstrap-tenant-namespace/bootstrap-tenant-namespace-np-ocpingress-clusterpolicy.yaml
+++ b/components/konflux-rbac/policies/bootstrap-tenant-namespace/bootstrap-tenant-namespace-np-ocpingress-clusterpolicy.yaml
@@ -14,6 +14,14 @@ spec:
           selector:
             matchLabels:
               konflux-ci.dev/type: tenant
+    exclude:
+      any:
+      - resources:
+          kinds:
+            - Namespace
+          selector:
+            matchLabels:
+              toolchain.dev.openshift.com/type: tenant
     generate:
       generateExisting: true
       synchronize: false

--- a/components/konflux-rbac/policies/bootstrap-tenant-namespace/bootstrap-tenant-namespace-np-ocpmonitoring-clusterpolicy.yaml
+++ b/components/konflux-rbac/policies/bootstrap-tenant-namespace/bootstrap-tenant-namespace-np-ocpmonitoring-clusterpolicy.yaml
@@ -14,6 +14,14 @@ spec:
           selector:
             matchLabels:
               konflux-ci.dev/type: tenant
+    exclude:
+      any:
+      - resources:
+          kinds:
+            - Namespace
+          selector:
+            matchLabels:
+              toolchain.dev.openshift.com/type: tenant
     generate:
       generateExisting: true
       synchronize: false

--- a/components/konflux-rbac/policies/bootstrap-tenant-namespace/bootstrap-tenant-namespace-np-olm-clusterpolicy.yaml
+++ b/components/konflux-rbac/policies/bootstrap-tenant-namespace/bootstrap-tenant-namespace-np-olm-clusterpolicy.yaml
@@ -14,6 +14,14 @@ spec:
           selector:
             matchLabels:
               konflux-ci.dev/type: tenant
+    exclude:
+      any:
+      - resources:
+          kinds:
+            - Namespace
+          selector:
+            matchLabels:
+              toolchain.dev.openshift.com/type: tenant
     generate:
       generateExisting: true
       synchronize: false

--- a/components/konflux-rbac/policies/bootstrap-tenant-namespace/bootstrap-tenant-namespace-np-samenamespace-clusterpolicy.yaml
+++ b/components/konflux-rbac/policies/bootstrap-tenant-namespace/bootstrap-tenant-namespace-np-samenamespace-clusterpolicy.yaml
@@ -14,6 +14,14 @@ spec:
           selector:
             matchLabels:
               konflux-ci.dev/type: tenant
+    exclude:
+      any:
+      - resources:
+          kinds:
+            - Namespace
+          selector:
+            matchLabels:
+              toolchain.dev.openshift.com/type: tenant
     generate:
       generateExisting: true
       synchronize: false

--- a/components/konflux-rbac/policies/bootstrap-tenant-namespace/bootstrap-tenant-namespace-rbcm-clusterpolicy.yaml
+++ b/components/konflux-rbac/policies/bootstrap-tenant-namespace/bootstrap-tenant-namespace-rbcm-clusterpolicy.yaml
@@ -17,6 +17,14 @@ spec:
           operations:
             - CREATE
             - UPDATE
+    exclude:
+      any:
+      - resources:
+          kinds:
+            - Namespace
+          selector:
+            matchLabels:
+              toolchain.dev.openshift.com/type: tenant
     generate:
       generateExisting: false
       synchronize: false
@@ -43,6 +51,14 @@ spec:
           selector:
             matchLabels:
               konflux-ci.dev/type: tenant
+    exclude:
+      any:
+      - resources:
+          kinds:
+            - Namespace
+          selector:
+            matchLabels:
+              toolchain.dev.openshift.com/type: tenant
     generate:
       generateExisting: true
       synchronize: false


### PR DESCRIPTION
we want to make sure kubesaw and kyverno are not competing on the same resources created during tenant bootstrapping.

Signed-off-by: Francesco Ilario <filario@redhat.com>
