### PR TITLE
chore: grant appstudio-pipelines-runner admin permissions on testplat…

### DIFF
--- a/components/sandbox/toolchain-member-operator/base/rbac/appstudio-pipelines-runner.yaml
+++ b/components/sandbox/toolchain-member-operator/base/rbac/appstudio-pipelines-runner.yaml
@@ -53,3 +53,9 @@ rules:
     resources:
       - pipelineruns
       - taskruns
+  - verbs:
+      - "*"
+    apiGroups:
+      - ci.openshift.org
+    resources:
+      - testplatformclusters


### PR DESCRIPTION
Grant admin capabilities to the `appstudio-pipelines-runner` role for `testplatformclusters` objects.
This will allow a pipeline running within a tenant NS to claim Test Platform ephemeral OCP clusters by creating a `testplatformcluster` claim.

Require https://github.com/redhat-appstudio/infra-deployments/pull/6503