### PR TITLE
mintmaker (prod): increase memory allocation for controller

### DIFF
--- a/components/mintmaker/production/base/manager_patch.yaml
+++ b/components/mintmaker/production/base/manager_patch.yaml
@@ -11,7 +11,7 @@ spec:
         resources:
           limits:
             cpu: 500m
-            memory: 3Gi
+            memory: 4Gi
           requests:
             cpu: 100m
-            memory: 256Mi
+            memory: 3Gi


### PR DESCRIPTION
The mintmaker controller requires substantial memory resources when analyzing components and creating renovate pipelineruns. When the cluster lacks sufficient free resources to allocate to the mintmaker controller, it may crash due to OOM errors.

This change increases requests.memory to 3Gi to ensure the cluster allocates this amount when creating the controller pod. Since I'm not certain 3Gi will always be sufficient, I've set limits.memory to 4Gi, allowing the controller to obtain up to 4Gi if needed and if the cluster has available memory.

Note that resource growth from 3Gi to 4Gi is not guaranteed, if the cluster has no free resources, the controller may be unable to acquire additional memory beyond its request.