### PR TITLE
authentication: give admins rights over kyverno resources

### DIFF
--- a/components/authentication/base/konflux-admins.yaml
+++ b/components/authentication/base/konflux-admins.yaml
@@ -325,6 +325,25 @@ rules:
     verbs:
       - list
       - get
+  - apiGroups:
+      - kyverno.io
+    resources:
+      - cleanuppolicies
+      - clustercleanuppolicies
+      - clusterpolicies
+      - globalcontextentries
+      - policies
+      - policyexceptions
+      - updaterequests
+    verbs:
+      - '*'
+  - apiGroups:
+      - reports.kyverno.io
+    resources:
+      - ephemeralreports
+      - clusterephemeralreports
+    verbs:
+      - '*'
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
Kyverno is becoming more and more important to the administration of the konflux clusters, so give administrators rights to administrate kyverno's resources.