### PR TITLE
increase QPS and Burst for Kyverno in prod rh01

### DIFF
--- a/components/kyverno/production/stone-prd-rh01/kustomization.yaml
+++ b/components/kyverno/production/stone-prd-rh01/kustomization.yaml
@@ -85,3 +85,9 @@ patches:
       version: v1
       kind: Job
       name: konflux-kyverno-remove-configmap
+  - path: patch_background_controller_qps_burst.yaml
+    target:
+      group: apps
+      version: v1
+      kind: Deployment
+      name: kyverno-background-controller

--- a/components/kyverno/production/stone-prd-rh01/patch_background_controller_qps_burst.yaml
+++ b/components/kyverno/production/stone-prd-rh01/patch_background_controller_qps_burst.yaml
@@ -1,0 +1,10 @@
+---
+- op: add
+  path: /spec/template/spec/containers/0/args/-
+  value:
+    --clientRateLimitQPS=1000
+- op: add
+  path: /spec/template/spec/containers/0/args/-
+  value:
+    --clientRateLimitBurst=1000
+


### PR DESCRIPTION
Kyverno is failing as it's throttled while renovating the lease. Bumping QPS and Burst could help. Default values were 300 each.

```yaml
      containers:
        - args:
            [ ... REDACTED ... ]
            - --enablePolicyException=false
            - --enableReporting=validate,mutate,mutateExisting,imageVerify,generate
            - --clientRateLimitQPS=1000
            - --clientRateLimitBurst=1000
          env:
            - name: KYVERNO_SERVICEACCOUNT_NAME
```

Useful links:
* https://kyverno.io/docs/installation/customization/#container-flags

Signed-off-by: Francesco Ilario <filario@redhat.com>
