### PR TITLE
Set number of OSP buckets to 4

### DIFF
--- a/components/pipeline-service/production/base/main-pipeline-service-configuration.yaml
+++ b/components/pipeline-service/production/base/main-pipeline-service-configuration.yaml
@@ -1838,7 +1838,7 @@ spec:
               type: Resource
             minReplicas: 6
     performance:
-      buckets: 8
+      buckets: 4
       disable-ha: false
       kube-api-burst: 50
       kube-api-qps: 50

--- a/components/pipeline-service/production/kflux-ocp-p01/deploy.yaml
+++ b/components/pipeline-service/production/kflux-ocp-p01/deploy.yaml
@@ -2421,7 +2421,7 @@ spec:
                       cpu: 500m
                       memory: 8Gi
     performance:
-      buckets: 8
+      buckets: 4
       disable-ha: false
       kube-api-burst: 50
       kube-api-qps: 50

--- a/components/pipeline-service/production/kflux-prd-rh02/deploy.yaml
+++ b/components/pipeline-service/production/kflux-prd-rh02/deploy.yaml
@@ -2452,7 +2452,7 @@ spec:
                       cpu: 500m
                       memory: 8Gi
     performance:
-      buckets: 8
+      buckets: 4
       disable-ha: false
       kube-api-burst: 50
       kube-api-qps: 50

--- a/components/pipeline-service/production/kflux-prd-rh03/deploy.yaml
+++ b/components/pipeline-service/production/kflux-prd-rh03/deploy.yaml
@@ -2452,7 +2452,7 @@ spec:
                       cpu: 500m
                       memory: 8Gi
     performance:
-      buckets: 8
+      buckets: 4
       disable-ha: false
       kube-api-burst: 50
       kube-api-qps: 50

--- a/components/pipeline-service/production/kflux-rhel-p01/deploy.yaml
+++ b/components/pipeline-service/production/kflux-rhel-p01/deploy.yaml
@@ -2452,7 +2452,7 @@ spec:
                       cpu: 500m
                       memory: 8Gi
     performance:
-      buckets: 8
+      buckets: 4
       disable-ha: false
       kube-api-burst: 50
       kube-api-qps: 50

--- a/components/pipeline-service/production/stone-prd-m01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prd-m01/deploy.yaml
@@ -2421,7 +2421,7 @@ spec:
                       cpu: 500m
                       memory: 8Gi
     performance:
-      buckets: 8
+      buckets: 4
       disable-ha: false
       kube-api-burst: 50
       kube-api-qps: 50

--- a/components/pipeline-service/production/stone-prd-rh01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prd-rh01/deploy.yaml
@@ -2421,7 +2421,7 @@ spec:
                       cpu: 500m
                       memory: 8Gi
     performance:
-      buckets: 8
+      buckets: 4
       disable-ha: false
       kube-api-burst: 50
       kube-api-qps: 50

--- a/components/pipeline-service/production/stone-prod-p01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prod-p01/deploy.yaml
@@ -2421,7 +2421,7 @@ spec:
                       cpu: 500m
                       memory: 8Gi
     performance:
-      buckets: 8
+      buckets: 4
       disable-ha: false
       kube-api-burst: 50
       kube-api-qps: 50

--- a/components/pipeline-service/production/stone-prod-p02/deploy.yaml
+++ b/components/pipeline-service/production/stone-prod-p02/deploy.yaml
@@ -2421,7 +2421,7 @@ spec:
                       cpu: 500m
                       memory: 8Gi
     performance:
-      buckets: 8
+      buckets: 4
       disable-ha: false
       kube-api-burst: 50
       kube-api-qps: 50


### PR DESCRIPTION
Config is set to 8 but ArgoCD is showing TektonConfig out of sync in all the production cluster, the live TektonConfig only has 4 buckets