### PR TITLE
Move secrets file to each internal MPC cluster folder

### DIFF
--- a/components/multi-platform-controller/production-downstream/base/kustomization.yaml
+++ b/components/multi-platform-controller/production-downstream/base/kustomization.yaml
@@ -7,7 +7,6 @@ resources:
 - ../../base/common
 - https://github.com/konflux-ci/multi-platform-controller/deploy/operator?ref=468136ac1005dbf83fb25d385016f2feb3cb7e18
 - https://github.com/konflux-ci/multi-platform-controller/deploy/otp?ref=468136ac1005dbf83fb25d385016f2feb3cb7e18
-- external-secrets.yaml
 
 components:
   - ../../k-components/manager-resources

--- a/components/multi-platform-controller/production-downstream/kflux-ocp-p01/aws-account.patch.yaml
+++ b/components/multi-platform-controller/production-downstream/kflux-ocp-p01/aws-account.patch.yaml
@@ -1,4 +1,0 @@
----
-- op: replace
-  path: /spec/dataFrom/0/extract/key
-  value: production/build/multi-platform-controller/kflux-ocp-p01-aws-account

--- a/components/multi-platform-controller/production-downstream/kflux-ocp-p01/aws-ssh-key.patch.yaml
+++ b/components/multi-platform-controller/production-downstream/kflux-ocp-p01/aws-ssh-key.patch.yaml
@@ -1,4 +1,0 @@
----
-- op: replace
-  path: /spec/dataFrom/0/extract/key
-  value: production/build/multi-platform-controller/kflux-ocp-p01-ssh-key

--- a/components/multi-platform-controller/production-downstream/kflux-ocp-p01/external-secrets.yaml
+++ b/components/multi-platform-controller/production-downstream/kflux-ocp-p01/external-secrets.yaml
@@ -11,7 +11,7 @@ metadata:
 spec:
   dataFrom:
     - extract:
-        key: production/build/multi-platform-controller/internal-prod-ssh-key
+        key: production/build/multi-platform-controller/kflux-ocp-p01-ssh-key
   refreshInterval: 1h
   secretStoreRef:
     kind: ClusterSecretStore
@@ -34,7 +34,7 @@ metadata:
 spec:
   dataFrom:
     - extract:
-        key: production/build/multi-platform-controller/internal-prod-aws-account
+        key: production/build/multi-platform-controller/kflux-ocp-p01-aws-account
   refreshInterval: 1h
   secretStoreRef:
     kind: ClusterSecretStore
@@ -57,7 +57,7 @@ metadata:
 spec:
   dataFrom:
     - extract:
-        key: production/build/multi-platform-controller/internal-prod-ibm-ssh-key
+        key: production/build/multi-platform-controller/kflux-ocp-p01-ibm-ssh-key
   refreshInterval: 1h
   secretStoreRef:
     kind: ClusterSecretStore
@@ -80,7 +80,7 @@ metadata:
 spec:
   dataFrom:
     - extract:
-        key: production/build/multi-platform-controller/internal-prod-ibm-api-key
+        key: production/build/multi-platform-controller/kflux-ocp-p01-ibm-api-key
   refreshInterval: 1h
   secretStoreRef:
     kind: ClusterSecretStore

--- a/components/multi-platform-controller/production-downstream/kflux-ocp-p01/ibm-account.patch.yaml
+++ b/components/multi-platform-controller/production-downstream/kflux-ocp-p01/ibm-account.patch.yaml
@@ -1,4 +1,0 @@
----
-- op: replace
-  path: /spec/dataFrom/0/extract/key
-  value: production/build/multi-platform-controller/kflux-ocp-p01-ibm-api-key

--- a/components/multi-platform-controller/production-downstream/kflux-ocp-p01/ibm-ssh-key.patch.yaml
+++ b/components/multi-platform-controller/production-downstream/kflux-ocp-p01/ibm-ssh-key.patch.yaml
@@ -1,4 +1,0 @@
----
-- op: replace
-  path: /spec/dataFrom/0/extract/key
-  value: production/build/multi-platform-controller/kflux-ocp-p01-ibm-ssh-key

--- a/components/multi-platform-controller/production-downstream/kflux-ocp-p01/kustomization.yaml
+++ b/components/multi-platform-controller/production-downstream/kflux-ocp-p01/kustomization.yaml
@@ -4,22 +4,7 @@ namespace: multi-platform-controller
 resources:
 - ../base
 - host-config.yaml
+- external-secrets.yaml
 
 patches:
-- path: aws-account.patch.yaml
-  target:
-    kind: ExternalSecret
-    name: aws-account
-- path: aws-ssh-key.patch.yaml
-  target:
-    kind: ExternalSecret
-    name: aws-ssh-key
-- path: ibm-account.patch.yaml
-  target:
-    kind: ExternalSecret
-    name: internal-prod-ibm-api-key
-- path: ibm-ssh-key.patch.yaml
-  target:
-    kind: ExternalSecret
-    name: internal-prod-ibm-ssh-key
 - path: manager_resources_patch.yaml

--- a/components/multi-platform-controller/production-downstream/stone-prod-p01/external-secrets.yaml
+++ b/components/multi-platform-controller/production-downstream/stone-prod-p01/external-secrets.yaml
@@ -1,0 +1,45 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: aws-ssh-key
+  namespace: multi-platform-controller
+  labels:
+    build.appstudio.redhat.com/multi-platform-secret: "true"
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  dataFrom:
+    - extract:
+        key: production/build/multi-platform-controller/internal-prod-ssh-key
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: appsre-stonesoup-vault
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    name: aws-ssh-key
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: aws-account
+  namespace: multi-platform-controller
+  labels:
+    build.appstudio.redhat.com/multi-platform-secret: "true"
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  dataFrom:
+    - extract:
+        key: production/build/multi-platform-controller/internal-prod-aws-account
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: appsre-stonesoup-vault
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    name: aws-account

--- a/components/multi-platform-controller/production-downstream/stone-prod-p01/kustomization.yaml
+++ b/components/multi-platform-controller/production-downstream/stone-prod-p01/kustomization.yaml
@@ -6,3 +6,4 @@ namespace: multi-platform-controller
 resources:
 - ../base
 - host-config.yaml
+- external-secrets.yaml

--- a/components/multi-platform-controller/production-downstream/stone-prod-p02/external-secrets.yaml
+++ b/components/multi-platform-controller/production-downstream/stone-prod-p02/external-secrets.yaml
@@ -1,6 +1,98 @@
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
+  name: aws-ssh-key
+  namespace: multi-platform-controller
+  labels:
+    build.appstudio.redhat.com/multi-platform-secret: "true"
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  dataFrom:
+    - extract:
+        key: production/build/multi-platform-controller/internal-prod-ssh-key
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: appsre-stonesoup-vault
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    name: aws-ssh-key
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: aws-account
+  namespace: multi-platform-controller
+  labels:
+    build.appstudio.redhat.com/multi-platform-secret: "true"
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  dataFrom:
+    - extract:
+        key: production/build/multi-platform-controller/internal-prod-aws-account
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: appsre-stonesoup-vault
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    name: aws-account
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: internal-prod-ibm-ssh-key
+  namespace: multi-platform-controller
+  labels:
+    build.appstudio.redhat.com/multi-platform-secret: "true"
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  dataFrom:
+    - extract:
+        key: production/build/multi-platform-controller/internal-prod-ibm-ssh-key
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: appsre-stonesoup-vault
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    name: internal-prod-ibm-ssh-key
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: internal-prod-ibm-api-key
+  namespace: multi-platform-controller
+  labels:
+    build.appstudio.redhat.com/multi-platform-secret: "true"
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  dataFrom:
+    - extract:
+        key: production/build/multi-platform-controller/internal-prod-ibm-api-key
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: appsre-stonesoup-vault
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    name: internal-prod-ibm-api-key
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
   name: ibm-s390x-static-ssh-key
   namespace: multi-platform-controller
   labels:


### PR DESCRIPTION
Having the secrets in the base is making things more complicated as some clusters do not need all the secrets and some others, secrets must be patched to have right path in vault.

As first step, duplicate the secrets in each cluster and adjust accordingly. We have a task to standardize the MPC secrets name, one this is done we will be able to remove duplication and created them in the base overlay.