### PR TITLE
Revert "give unlimited cpu to Kyverno background on rh01 (#6537)"

### DIFF
--- a/components/kyverno/production/stone-prd-rh01/kyverno-helm-values.yaml
+++ b/components/kyverno/production/stone-prd-rh01/kyverno-helm-values.yaml
@@ -31,9 +31,10 @@ backgroundController:
   replicas: 3
   resources:
     requests:
-      cpu: 4000m
+      cpu: 2000m
       memory: 4Gi
     limits:
+      cpu: 2000m
       memory: 4Gi
   securityContext:
     allowPrivilegeEscalation: false


### PR DESCRIPTION
Kyverno no longer needs unlimited cpu resources, so add back the limits we had previously.

This reverts commit a5666c8d46d48b7dcbbbb6474ff87f29cac2b3c5.