### PR TITLE
remove cpu limits for nslister

### DIFF
--- a/components/namespace-lister/base/deployment.yaml
+++ b/components/namespace-lister/base/deployment.yaml
@@ -53,7 +53,6 @@ spec:
             scheme: HTTPS
         resources:
           limits:
-            cpu: 500m
             memory: 1Gi
           requests:
             cpu: 500m

--- a/components/namespace-lister/production/base/deployment.yaml
+++ b/components/namespace-lister/production/base/deployment.yaml
@@ -53,7 +53,6 @@ spec:
             scheme: HTTPS
         resources:
           limits:
-            cpu: 500m
             memory: 1Gi
           requests:
             cpu: 500m


### PR DESCRIPTION
we don't need to set limit for cpu, we just require accurate request.

Signed-off-by: Francesco Ilario <filario@redhat.com>
