### PR TITLE
remove cpu limits for etcd-shield

### DIFF
--- a/components/etcd-shield/base/deployment.yaml
+++ b/components/etcd-shield/base/deployment.yaml
@@ -52,7 +52,6 @@ spec:
             scheme: HTTP
         resources:
           limits:
-            cpu: 500m
             memory: 128Mi
           requests:
             cpu: 500m

--- a/components/etcd-shield/production/base/deployment.yaml
+++ b/components/etcd-shield/production/base/deployment.yaml
@@ -52,7 +52,6 @@ spec:
             scheme: HTTP
         resources:
           limits:
-            cpu: 500m
             memory: 128Mi
           requests:
             cpu: 500m


### PR DESCRIPTION
we don't need to set limit for cpu, we just require accurate request.

Signed-off-by: Francesco Ilario <filario@redhat.com>
