### PR TITLE
PVO11Y-4772 - Export prometheus_ready metric for monitoring the internal prom instances.

### DIFF
--- a/components/monitoring/prometheus/base/monitoringstack/monitoringstack.yaml
+++ b/components/monitoring/prometheus/base/monitoringstack/monitoringstack.yaml
@@ -232,7 +232,7 @@ spec:
         - '{__name__="apiserver_storage_objects"}'
         - '{__name__="apiserver_request_total"}'
         - '{__name__="apiserver_current_inflight_requests"}'
-
+        - '{__name__="prometheus_ready"}'
     relabelings:
     # override the target's address by the prometheus-k8s service name.
     - action: replace


### PR DESCRIPTION
In order to detect issues with Prometheus internal to each cluster, export the `prometheus_ready` metric. 