### PR TITLE
Remove s390x and ppc VMs from p02

### DIFF
--- a/components/multi-platform-controller/production-downstream/stone-prod-p02/host-config.yaml
+++ b/components/multi-platform-controller/production-downstream/stone-prod-p02/host-config.yaml
@@ -633,42 +633,6 @@ data:
   host.s390x-static-10.secret: "ibm-s390x-static-ssh-key"
   host.s390x-static-10.concurrency: "4"
 
-  host.s390x-static-11.address: "10.130.79.73"
-  host.s390x-static-11.platform: "linux/s390x"
-  host.s390x-static-11.user: "root"
-  host.s390x-static-11.secret: "ibm-s390x-static-ssh-key"
-  host.s390x-static-11.concurrency: "4"
-
-  host.s390x-static-12.address: "10.130.79.74"
-  host.s390x-static-12.platform: "linux/s390x"
-  host.s390x-static-12.user: "root"
-  host.s390x-static-12.secret: "ibm-s390x-static-ssh-key"
-  host.s390x-static-12.concurrency: "4"
-
-  host.s390x-static-13.address: "10.130.79.75"
-  host.s390x-static-13.platform: "linux/s390x"
-  host.s390x-static-13.user: "root"
-  host.s390x-static-13.secret: "ibm-s390x-static-ssh-key"
-  host.s390x-static-13.concurrency: "4"
-
-  host.s390x-static-14.address: "10.130.79.76"
-  host.s390x-static-14.platform: "linux/s390x"
-  host.s390x-static-14.user: "root"
-  host.s390x-static-14.secret: "ibm-s390x-static-ssh-key"
-  host.s390x-static-14.concurrency: "4"
-
-  host.s390x-static-15.address: "10.130.79.40"
-  host.s390x-static-15.platform: "linux/s390x"
-  host.s390x-static-15.user: "root"
-  host.s390x-static-15.secret: "ibm-s390x-static-ssh-key"
-  host.s390x-static-15.concurrency: "4"
-
-  host.s390x-static-16.address: "10.130.79.79"
-  host.s390x-static-16.platform: "linux/s390x"
-  host.s390x-static-16.user: "root"
-  host.s390x-static-16.secret: "ibm-s390x-static-ssh-key"
-  host.s390x-static-16.concurrency: "4"
-
   # PPC64LE 4cores(32vCPU) / 128GiB RAM / 2TB disk
   host.ppc64le-static-1.address: "10.130.73.170"
   host.ppc64le-static-1.platform: "linux/ppc64le"
@@ -699,24 +663,6 @@ data:
   host.ppc64le-static-5.user: "root"
   host.ppc64le-static-5.secret: "internal-prod-ibm-ssh-key"
   host.ppc64le-static-5.concurrency: "8"
-
-  host.ppc64le-static-6.address: "10.130.73.73"
-  host.ppc64le-static-6.platform: "linux/ppc64le"
-  host.ppc64le-static-6.user: "root"
-  host.ppc64le-static-6.secret: "internal-prod-ibm-ssh-key"
-  host.ppc64le-static-6.concurrency: "8"
-
-  host.ppc64le-static-7.address: "10.130.72.127"
-  host.ppc64le-static-7.platform: "linux/ppc64le"
-  host.ppc64le-static-7.user: "root"
-  host.ppc64le-static-7.secret: "internal-prod-ibm-ssh-key"
-  host.ppc64le-static-7.concurrency: "8"
-
-  host.ppc64le-static-8.address: "10.130.73.0"
-  host.ppc64le-static-8.platform: "linux/ppc64le"
-  host.ppc64le-static-8.user: "root"
-  host.ppc64le-static-8.secret: "internal-prod-ibm-ssh-key"
-  host.ppc64le-static-8.concurrency: "8"
 
   # AWS GPU Nodes
   dynamic.linux-g6xlarge-amd64.type: aws


### PR DESCRIPTION
The us-south datacenter is full for s390x. Remove 6 VMs from p02 to move them to the rhel cluster. Since 6 VMs can do 24 concurrent builds, reduce the power accordingly since there is no point of being able to do more ppc than s390x

[KFLUXINFRA-1639](https://issues.redhat.com//browse/KFLUXINFRA-1639)