### PR TITLE
Remove the deletion of nvme-storage app from downstream overlays

### DIFF
--- a/argo-cd-apps/overlays/production-downstream/delete-applications.yaml
+++ b/argo-cd-apps/overlays/production-downstream/delete-applications.yaml
@@ -36,9 +36,3 @@ kind: ApplicationSet
 metadata:
   name: kubearchive
 $patch: delete
----
-apiVersion: argoproj.io/v1alpha1
-kind: ApplicationSet
-metadata:
-  name: nvme-storage-configurator
-$patch: delete

--- a/argo-cd-apps/overlays/staging-downstream/delete-applications.yaml
+++ b/argo-cd-apps/overlays/staging-downstream/delete-applications.yaml
@@ -36,9 +36,3 @@ kind: ApplicationSet
 metadata:
   name: kubearchive
 $patch: delete
----
-apiVersion: argoproj.io/v1alpha1
-kind: ApplicationSet
-metadata:
-  name: nvme-storage-configurator
-$patch: delete


### PR DESCRIPTION
    It's already getting deleted in the parent overlay so if we
    try to delete it again kustomize build fails.
