### PR TITLE
chore(STONEINTG-1220): update ref for intg grafana dashboard

### DIFF
--- a/components/monitoring/grafana/base/dashboards/integration/kustomization.yaml
+++ b/components/monitoring/grafana/base/dashboards/integration/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - https://github.com/konflux-ci/integration-service/config/grafana/?ref=b278f4a75a02026ebb3e3cae470b549348d698b3
+  - https://github.com/konflux-ci/integration-service/config/grafana/?ref=3c79ca66d4bcb4caeec56f7b00e759d80d6948b8


### PR DESCRIPTION
* Change integration service availability panels names to GithubApp Availability

Signed-off-by: dirgim <kpavic@redhat.com>

rh-pre-commit.version: 2.2.0
rh-pre-commit.check-secrets: ENABLED