### PR TITLE
etcd-shield: add metrics to staging

### DIFF
--- a/components/etcd-shield/base/deployment.yaml
+++ b/components/etcd-shield/base/deployment.yaml
@@ -30,6 +30,7 @@ spec:
         - -health-probe-bind-address=:8081
         - -config=/etc/etcd-shield/config.yaml
         - -port=8443
+        - -metrics-addr=:9100
         env:
         - name: "NAMESPACE"
           valueFrom:

--- a/components/etcd-shield/base/kustomization.yaml
+++ b/components/etcd-shield/base/kustomization.yaml
@@ -10,7 +10,7 @@ configMapGenerator:
 images:
 - name: etcd-shield
   newName: quay.io/konflux-ci/etcd-shield
-  newTag: 3de52a71e086e152b3d2b33bfc897ce7bf8ea0dd
+  newTag: 9e7f8f586294e0866a719e98e093e6b55873bf26
 namespace: etcd-shield
 resources:
 - deployment.yaml
@@ -19,3 +19,4 @@ resources:
 - service.yaml
 - webhook.yaml
 - etcd_shield_alerts.yaml
+- ./metrics

--- a/components/etcd-shield/base/metrics/kustomization.yaml
+++ b/components/etcd-shield/base/metrics/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- monitor.yaml
+- service-account.yaml
+- rbac.yaml
+- network-policy.yaml
+- metrics-service.yaml

--- a/components/etcd-shield/base/metrics/metrics-service.yaml
+++ b/components/etcd-shield/base/metrics/metrics-service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: etcd-shield-metrics
+  namespace: etcd-shield
+spec:
+  selector:
+    app: etcd-shield
+  type: ClusterIP
+  ports:
+  - name: metrics
+    targetPort: 9100
+    port: 9100

--- a/components/etcd-shield/base/metrics/monitor.yaml
+++ b/components/etcd-shield/base/metrics/monitor.yaml
@@ -1,0 +1,26 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: etcd-shield-metrics
+  labels:
+    apps: etcd-shield
+spec:
+  endpoints:
+    - interval: 15s
+      scheme: https
+      path: /metrics
+      port: metrics
+      authorization:
+        credentials:
+          key: token
+          name: metrics-reader
+      tlsConfig:
+        ca:
+          secret:
+            key: service-ca.crt
+            name: metrics-reader
+            optional: false
+        serverName: etcd-shield.etcd-shield.svc
+  selector:
+    matchLabels:
+      apps: etcd-shield

--- a/components/etcd-shield/base/metrics/network-policy.yaml
+++ b/components/etcd-shield/base/metrics/network-policy.yaml
@@ -1,0 +1,19 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-from-openshift-user-workload-monitoring
+  namespace: etcd-shield
+spec:
+  podSelector:
+    matchLabels:
+      apps: etcd-shield
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: openshift-user-workload-monitoring
+    ports:
+    - protocol: TCP
+      port: metrics

--- a/components/etcd-shield/base/metrics/rbac.yaml
+++ b/components/etcd-shield/base/metrics/rbac.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: etcd-shield-metrics
+rules:
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: prometheus-etcd-shield-metrics-reader
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: etcd-shield-metrics
+subjects:
+- kind: ServiceAccount
+  name: metrics-reader
+  namespace: etcd-shield

--- a/components/etcd-shield/base/metrics/service-account.yaml
+++ b/components/etcd-shield/base/metrics/service-account.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  annotations:
+    kubernetes.io/service-account.name: metrics-reader
+  name: metrics-reader
+type: kubernetes.io/service-account-token
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: metrics-reader
+  namespace: etcd-shield

--- a/components/etcd-shield/base/rbac.yaml
+++ b/components/etcd-shield/base/rbac.yaml
@@ -19,6 +19,18 @@ roleRef:
   name: etcd-shield-authorizer
 ---
 apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: etcd-shield-authorizer
+rules:
+- apiGroups: ["authentication.k8s.io"]
+  resources: ["tokenreviews"]
+  verbs: ["create"]
+- apiGroups: ["authorization.k8s.io"]
+  resources: ["subjectaccessreviews"]
+  verbs: ["create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: etcd-shield


### PR DESCRIPTION
This enables etcd-shield's metrics in staging clusters.  `etcd-shield` will now report the following metrics:

- metrics from go's runtime
- metrics from controller-runtime
- `etcd_shield_query_enabled`: What does etcd-shield think the current admission state is?