### PR TITLE
Configure kflux-rhel-p01 s390x and ppc VMs

### DIFF
--- a/components/multi-platform-controller/production-downstream/kflux-rhel-p01/host-config.yaml
+++ b/components/multi-platform-controller/production-downstream/kflux-rhel-p01/host-config.yaml
@@ -492,283 +492,70 @@ data:
 
     --//--
 
-  # S390X 2vCPU / 8GB RAM / 100GB disk
-#   dynamic.linux-s390x.type: ibmz
-#   dynamic.linux-s390x.ssh-secret: "ibm-s390x-ssh-key"
-#   dynamic.linux-s390x.secret: "ibm-api-key"
-#   dynamic.linux-s390x.vpc: "konflux-prod-multi-p01"
-#   dynamic.linux-s390x.key: "konflux-s390x-root"
-#   dynamic.linux-s390x.subnet: "sn-20241213-02"
-#   dynamic.linux-s390x.image-id: "r006-20e160c3-58d7-4b3b-827f-9d7994b68095"
-#   dynamic.linux-s390x.region: "us-south-2"
-#   dynamic.linux-s390x.url: "https://us-south.iaas.cloud.ibm.com/v1"
-#   dynamic.linux-s390x.profile: "bz2-2x8"
-#   dynamic.linux-s390x.max-instances: "30"
-#   dynamic.linux-s390x.private-ip: "true"
-#   dynamic.linux-s390x.allocation-timeout: "1800"
-#   dynamic.linux-s390x.instance-tag: prod-s390x
+  # S390X 16vCPU / 64GiB RAM / 1TB disk
+  host.s390x-static-1.address: "10.130.79.109"
+  host.s390x-static-1.platform: "linux/s390x"
+  host.s390x-static-1.user: "root"
+  host.s390x-static-1.secret: "ibm-s390x-ssh-key"
+  host.s390x-static-1.concurrency: "4"
 
-#   # S390X 4vCPU / 16GB RAM / 100GB disk
-#   dynamic.linux-large-s390x.type: ibmz
-#   dynamic.linux-large-s390x.ssh-secret: "ibm-s390x-ssh-key"
-#   dynamic.linux-large-s390x.secret: "ibm-api-key"
-#   dynamic.linux-large-s390x.vpc: "konflux-prod-multi-p01"
-#   dynamic.linux-large-s390x.key: "konflux-s390x-root"
-#   dynamic.linux-large-s390x.subnet: "sn-20241213-02"
-#   dynamic.linux-large-s390x.image-id: "r006-20e160c3-58d7-4b3b-827f-9d7994b68095"
-#   dynamic.linux-large-s390x.region: "us-south-2"
-#   dynamic.linux-large-s390x.url: "https://us-south.iaas.cloud.ibm.com/v1"
-#   dynamic.linux-large-s390x.profile: "bz2-4x16"
-#   dynamic.linux-large-s390x.max-instances: "10"
-#   dynamic.linux-large-s390x.private-ip: "true"
-#   dynamic.linux-large-s390x.allocation-timeout: "1800"
-#   dynamic.linux-large-s390x.instance-tag: prod-s390x-large
+  host.s390x-static-2.address: "10.130.79.106"
+  host.s390x-static-2.platform: "linux/s390x"
+  host.s390x-static-2.user: "root"
+  host.s390x-static-2.secret: "ibm-s390x-ssh-key"
+  host.s390x-static-2.concurrency: "4"
 
-#   # S390X 2vCPU / 8GB RAM / 200GB disk
-#   dynamic.linux-d200-s390x.type: ibmz
-#   dynamic.linux-d200-s390x.ssh-secret: "ibm-s390x-ssh-key"
-#   dynamic.linux-d200-s390x.secret: "ibm-api-key"
-#   dynamic.linux-d200-s390x.vpc: "konflux-prod-multi-p01"
-#   dynamic.linux-d200-s390x.key: "konflux-s390x-root"
-#   dynamic.linux-d200-s390x.subnet: "sn-20241213-02"
-#   dynamic.linux-d200-s390x.image-id: "r006-20e160c3-58d7-4b3b-827f-9d7994b68095"
-#   dynamic.linux-d200-s390x.region: "us-south-2"
-#   dynamic.linux-d200-s390x.url: "https://us-south.iaas.cloud.ibm.com/v1"
-#   dynamic.linux-d200-s390x.profile: "bz2-2x8"
-#   dynamic.linux-d200-s390x.max-instances: "30"
-#   dynamic.linux-d200-s390x.private-ip: "true"
-#   dynamic.linux-d200-s390x.allocation-timeout: "1800"
-#   dynamic.linux-d200-s390x.disk: "200"
-#   dynamic.linux-d200-s390x.instance-tag: prod-d200-s390x
+  host.s390x-static-3.address: "10.130.79.137"
+  host.s390x-static-3.platform: "linux/s390x"
+  host.s390x-static-3.user: "root"
+  host.s390x-static-3.secret: "ibm-s390x-ssh-key"
+  host.s390x-static-3.concurrency: "4"
 
-#   # S390X 4vCPU / 16GB RAM / 200GB disk
-#   dynamic.linux-d200-large-s390x.type: ibmz
-#   dynamic.linux-d200-large-s390x.ssh-secret: "ibm-s390x-ssh-key"
-#   dynamic.linux-d200-large-s390x.secret: "ibm-api-key"
-#   dynamic.linux-d200-large-s390x.vpc: "konflux-prod-multi-p01"
-#   dynamic.linux-d200-large-s390x.key: "konflux-s390x-root"
-#   dynamic.linux-d200-large-s390x.subnet: "sn-20241213-02"
-#   dynamic.linux-d200-large-s390x.image-id: "r006-20e160c3-58d7-4b3b-827f-9d7994b68095"
-#   dynamic.linux-d200-large-s390x.region: "us-south-2"
-#   dynamic.linux-d200-large-s390x.url: "https://us-south.iaas.cloud.ibm.com/v1"
-#   dynamic.linux-d200-large-s390x.profile: "bz2-4x16"
-#   dynamic.linux-d200-large-s390x.max-instances: "10"
-#   dynamic.linux-d200-large-s390x.private-ip: "true"
-#   dynamic.linux-d200-large-s390x.allocation-timeout: "1800"
-#   dynamic.linux-d200-large-s390x.disk: "200"
-#   dynamic.linux-d200-large-s390x.instance-tag: prod-d200-s390x-large
+  # PPC64LE 4cores(32vCPU) / 128GiB RAM / 2TB disk
+  host.ppc64le-static-0.address: "10.130.81.12"
+  host.ppc64le-static-0.platform: "linux/ppc64le"
+  host.ppc64le-static-0.user: "root"
+  host.ppc64le-static-0.secret: "ibm-ppc64le-ssh-key"
+  host.ppc64le-static-0.concurrency: "8"
 
-#   # PPC64LE 2vCPU / 8GB RAM / 100GB disk
-#   dynamic.linux-ppc64le.type: ibmp
-#   dynamic.linux-ppc64le.ssh-secret: "ibm-ppc64le-ssh-key"
-#   dynamic.linux-ppc64le.secret: "ibm-api-key"
-#   dynamic.linux-ppc64le.key: "prod-konflux-infra-external"
-#   dynamic.linux-ppc64le.image: "kflux-ppc-base-04-feb-2025"
-#   dynamic.linux-ppc64le.crn: "crn:v1:bluemix:public:power-iaas:dal12:a/8cfd5baa22024ab9822f1e9d4659a5e5:e08f6cb5-9d8c-4931-87c2-16580c2ffe0a::"
-#   dynamic.linux-ppc64le.url: "https://us-south.power-iaas.cloud.ibm.com"
-#   dynamic.linux-ppc64le.network: "54fc8e49-fcb0-4842-9802-405865f0597d"
-#   dynamic.linux-ppc64le.system: "e980"
-#   dynamic.linux-ppc64le.cores: "0.25"
-#   dynamic.linux-ppc64le.memory: "8"
-#   dynamic.linux-ppc64le.max-instances: "30"
-#   dynamic.linux-ppc64le.allocation-timeout: "1800"
-#   dynamic.linux-ppc64le.instance-tag: prod-ppc64le
+  host.ppc64le-static-1.address: "10.130.81.6"
+  host.ppc64le-static-1.platform: "linux/ppc64le"
+  host.ppc64le-static-1.user: "root"
+  host.ppc64le-static-1.secret: "ibm-ppc64le-ssh-key"
+  host.ppc64le-static-1.concurrency: "8"
 
-#   # PPC64LE 4vCPU / 16GB RAM / 100GB disk
-#   dynamic.linux-large-ppc64le.type: ibmp
-#   dynamic.linux-large-ppc64le.ssh-secret: "ibm-ppc64le-ssh-key"
-#   dynamic.linux-large-ppc64le.secret: "ibm-api-key"
-#   dynamic.linux-large-ppc64le.key: "prod-konflux-infra-external"
-#   dynamic.linux-large-ppc64le.image: "kflux-ppc-base-04-feb-2025"
-#   dynamic.linux-large-ppc64le.crn: "crn:v1:bluemix:public:power-iaas:dal12:a/8cfd5baa22024ab9822f1e9d4659a5e5:e08f6cb5-9d8c-4931-87c2-16580c2ffe0a::"
-#   dynamic.linux-large-ppc64le.url: "https://us-south.power-iaas.cloud.ibm.com"
-#   dynamic.linux-large-ppc64le.network: "54fc8e49-fcb0-4842-9802-405865f0597d"
-#   dynamic.linux-large-ppc64le.system: "e980"
-#   dynamic.linux-large-ppc64le.cores: "0.5"
-#   dynamic.linux-large-ppc64le.memory: "16"
-#   dynamic.linux-large-ppc64le.max-instances: "10"
-#   dynamic.linux-large-ppc64le.allocation-timeout: "1800"
-#   dynamic.linux-large-ppc64le.instance-tag: prod-ppc64le-large
+  host.ppc64le-static-2.address: "10.130.81.13"
+  host.ppc64le-static-2.platform: "linux/ppc64le"
+  host.ppc64le-static-2.user: "root"
+  host.ppc64le-static-2.secret: "ibm-ppc64le-ssh-key"
+  host.ppc64le-static-2.concurrency: "8"
 
-#   # PPC64LE 8vCPU / 32GB RAM / 100GB disk
-#   dynamic.linux-xlarge-ppc64le.type: ibmp
-#   dynamic.linux-xlarge-ppc64le.ssh-secret: "ibm-ppc64le-ssh-key"
-#   dynamic.linux-xlarge-ppc64le.secret: "ibm-api-key"
-#   dynamic.linux-xlarge-ppc64le.key: "prod-konflux-infra-external"
-#   dynamic.linux-xlarge-ppc64le.image: "kflux-ppc-base-04-feb-2025"
-#   dynamic.linux-xlarge-ppc64le.crn: "crn:v1:bluemix:public:power-iaas:dal12:a/8cfd5baa22024ab9822f1e9d4659a5e5:e08f6cb5-9d8c-4931-87c2-16580c2ffe0a::"
-#   dynamic.linux-xlarge-ppc64le.url: "https://us-south.power-iaas.cloud.ibm.com"
-#   dynamic.linux-xlarge-ppc64le.network: "54fc8e49-fcb0-4842-9802-405865f0597d"
-#   dynamic.linux-xlarge-ppc64le.system: "e980"
-#   dynamic.linux-xlarge-ppc64le.cores: "1"
-#   dynamic.linux-xlarge-ppc64le.memory: "32"
-#   dynamic.linux-xlarge-ppc64le.max-instances: "10"
-#   dynamic.linux-xlarge-ppc64le.allocation-timeout: "1800"
-#   dynamic.linux-xlarge-ppc64le.instance-tag: prod-ppc64le-xlarge
+  host.ppc64le-static-3.address: "10.130.81.11"
+  host.ppc64le-static-3.platform: "linux/ppc64le"
+  host.ppc64le-static-3.user: "root"
+  host.ppc64le-static-3.secret: "ibm-ppc64le-ssh-key"
+  host.ppc64le-static-3.concurrency: "8"
 
-#   # PPC64LE 16vCPU / 64GB RAM / 100GB disk
-#   dynamic.linux-2xlarge-ppc64le.type: ibmp
-#   dynamic.linux-2xlarge-ppc64le.ssh-secret: "ibm-ppc64le-ssh-key"
-#   dynamic.linux-2xlarge-ppc64le.secret: "ibm-api-key"
-#   dynamic.linux-2xlarge-ppc64le.key: "prod-konflux-infra-external"
-#   dynamic.linux-2xlarge-ppc64le.image: "kflux-ppc-base-04-feb-2025"
-#   dynamic.linux-2xlarge-ppc64le.crn: "crn:v1:bluemix:public:power-iaas:dal12:a/8cfd5baa22024ab9822f1e9d4659a5e5:e08f6cb5-9d8c-4931-87c2-16580c2ffe0a::"
-#   dynamic.linux-2xlarge-ppc64le.url: "https://us-south.power-iaas.cloud.ibm.com"
-#   dynamic.linux-2xlarge-ppc64le.network: "54fc8e49-fcb0-4842-9802-405865f0597d"
-#   dynamic.linux-2xlarge-ppc64le.system: "e980"
-#   dynamic.linux-2xlarge-ppc64le.cores: "2"
-#   dynamic.linux-2xlarge-ppc64le.memory: "64"
-#   dynamic.linux-2xlarge-ppc64le.max-instances: "10"
-#   dynamic.linux-2xlarge-ppc64le.allocation-timeout: "1800"
-#   dynamic.linux-2xlarge-ppc64le.instance-tag: prod-ppc64le-2xlarge
+  host.ppc64le-static-4.address: "10.130.81.5"
+  host.ppc64le-static-4.platform: "linux/ppc64le"
+  host.ppc64le-static-4.user: "root"
+  host.ppc64le-static-4.secret: "ibm-ppc64le-ssh-key"
+  host.ppc64le-static-4.concurrency: "8"
 
-#   # PPC64LE 2vCPU / 8GB RAM / 200GB disk
-#   dynamic.linux-d200-ppc64le.type: ibmp
-#   dynamic.linux-d200-ppc64le.ssh-secret: "ibm-ppc64le-ssh-key"
-#   dynamic.linux-d200-ppc64le.secret: "ibm-api-key"
-#   dynamic.linux-d200-ppc64le.key: "prod-konflux-infra-external"
-#   dynamic.linux-d200-ppc64le.image: "kflux-ppc-base-04-feb-2025"
-#   dynamic.linux-d200-ppc64le.crn: "crn:v1:bluemix:public:power-iaas:dal12:a/8cfd5baa22024ab9822f1e9d4659a5e5:e08f6cb5-9d8c-4931-87c2-16580c2ffe0a::"
-#   dynamic.linux-d200-ppc64le.url: "https://us-south.power-iaas.cloud.ibm.com"
-#   dynamic.linux-d200-ppc64le.network: "54fc8e49-fcb0-4842-9802-405865f0597d"
-#   dynamic.linux-d200-ppc64le.system: "e980"
-#   dynamic.linux-d200-ppc64le.cores: "0.25"
-#   dynamic.linux-d200-ppc64le.memory: "8"
-#   dynamic.linux-d200-ppc64le.max-instances: "10"
-#   dynamic.linux-d200-ppc64le.allocation-timeout: "1800"
-#   dynamic.linux-d200-ppc64le.disk: "200"
-#   dynamic.linux-d200-ppc64le.instance-tag: prod-d200-ppc64le
+  host.ppc64le-static-5.address: "10.130.81.3"
+  host.ppc64le-static-5.platform: "linux/ppc64le"
+  host.ppc64le-static-5.user: "root"
+  host.ppc64le-static-5.secret: "ibm-ppc64le-ssh-key"
+  host.ppc64le-static-5.concurrency: "8"
 
-#   # PPC64LE 4vCPU / 16GB RAM / 200GB disk
-#   dynamic.linux-d200-large-ppc64le.type: ibmp
-#   dynamic.linux-d200-large-ppc64le.ssh-secret: "ibm-ppc64le-ssh-key"
-#   dynamic.linux-d200-large-ppc64le.secret: "ibm-api-key"
-#   dynamic.linux-d200-large-ppc64le.key: "prod-konflux-infra-external"
-#   dynamic.linux-d200-large-ppc64le.image: "kflux-ppc-base-04-feb-2025"
-#   dynamic.linux-d200-large-ppc64le.crn: "crn:v1:bluemix:public:power-iaas:dal12:a/8cfd5baa22024ab9822f1e9d4659a5e5:e08f6cb5-9d8c-4931-87c2-16580c2ffe0a::"
-#   dynamic.linux-d200-large-ppc64le.url: "https://us-south.power-iaas.cloud.ibm.com"
-#   dynamic.linux-d200-large-ppc64le.network: "54fc8e49-fcb0-4842-9802-405865f0597d"
-#   dynamic.linux-d200-large-ppc64le.system: "e980"
-#   dynamic.linux-d200-large-ppc64le.cores: "0.5"
-#   dynamic.linux-d200-large-ppc64le.memory: "16"
-#   dynamic.linux-d200-large-ppc64le.max-instances: "10"
-#   dynamic.linux-d200-large-ppc64le.allocation-timeout: "1800"
-#   dynamic.linux-d200-large-ppc64le.disk: "200"
-#   dynamic.linux-d200-large-ppc64le.instance-tag: prod-d200-ppc64le-large
+  host.ppc64le-static-6.address: "10.130.81.7"
+  host.ppc64le-static-6.platform: "linux/ppc64le"
+  host.ppc64le-static-6.user: "root"
+  host.ppc64le-static-6.secret: "ibm-ppc64le-ssh-key"
+  host.ppc64le-static-6.concurrency: "8"
 
-#   # PPC64LE 8vCPU / 32GB RAM / 200GB disk
-#   dynamic.linux-d200-xlarge-ppc64le.type: ibmp
-#   dynamic.linux-d200-xlarge-ppc64le.ssh-secret: "ibm-ppc64le-ssh-key"
-#   dynamic.linux-d200-xlarge-ppc64le.secret: "ibm-api-key"
-#   dynamic.linux-d200-xlarge-ppc64le.key: "prod-konflux-infra-external"
-#   dynamic.linux-d200-xlarge-ppc64le.image: "kflux-ppc-base-04-feb-2025"
-#   dynamic.linux-d200-xlarge-ppc64le.crn: "crn:v1:bluemix:public:power-iaas:dal12:a/8cfd5baa22024ab9822f1e9d4659a5e5:e08f6cb5-9d8c-4931-87c2-16580c2ffe0a::"
-#   dynamic.linux-d200-xlarge-ppc64le.url: "https://us-south.power-iaas.cloud.ibm.com"
-#   dynamic.linux-d200-xlarge-ppc64le.network: "54fc8e49-fcb0-4842-9802-405865f0597d"
-#   dynamic.linux-d200-xlarge-ppc64le.system: "e980"
-#   dynamic.linux-d200-xlarge-ppc64le.cores: "1"
-#   dynamic.linux-d200-xlarge-ppc64le.memory: "32"
-#   dynamic.linux-d200-xlarge-ppc64le.max-instances: "10"
-#   dynamic.linux-d200-xlarge-ppc64le.allocation-timeout: "1800"
-#   dynamic.linux-d200-xlarge-ppc64le.disk: "200"
-#   dynamic.linux-d200-xlarge-ppc64le.instance-tag: prod-d200-ppc64le-xlarge
-
-#   # PPC64LE 16vCPU / 64GB RAM / 200GB disk
-#   dynamic.linux-d200-2xlarge-ppc64le.type: ibmp
-#   dynamic.linux-d200-2xlarge-ppc64le.ssh-secret: "ibm-ppc64le-ssh-key"
-#   dynamic.linux-d200-2xlarge-ppc64le.secret: "ibm-api-key"
-#   dynamic.linux-d200-2xlarge-ppc64le.key: "prod-konflux-infra-external"
-#   dynamic.linux-d200-2xlarge-ppc64le.image: "kflux-ppc-base-04-feb-2025"
-#   dynamic.linux-d200-2xlarge-ppc64le.crn: "crn:v1:bluemix:public:power-iaas:dal12:a/8cfd5baa22024ab9822f1e9d4659a5e5:e08f6cb5-9d8c-4931-87c2-16580c2ffe0a::"
-#   dynamic.linux-d200-2xlarge-ppc64le.url: "https://us-south.power-iaas.cloud.ibm.com"
-#   dynamic.linux-d200-2xlarge-ppc64le.network: "54fc8e49-fcb0-4842-9802-405865f0597d"
-#   dynamic.linux-d200-2xlarge-ppc64le.system: "e980"
-#   dynamic.linux-d200-2xlarge-ppc64le.cores: "2"
-#   dynamic.linux-d200-2xlarge-ppc64le.memory: "64"
-#   dynamic.linux-d200-2xlarge-ppc64le.max-instances: "10"
-#   dynamic.linux-d200-2xlarge-ppc64le.allocation-timeout: "1800"
-#   dynamic.linux-d200-2xlarge-ppc64le.disk: "200"
-#   dynamic.linux-d200-2xlarge-ppc64le.instance-tag: prod-d200-ppc64le-2xlarge
-
-
-# # GPU Instances
-#   dynamic.linux-g6xlarge-amd64.type: aws
-#   dynamic.linux-g6xlarge-amd64.region: us-east-1
-#   dynamic.linux-g6xlarge-amd64.ami: ami-0ad6c6b0ac6c36199
-#   dynamic.linux-g6xlarge-amd64.instance-type: g6.xlarge
-#   dynamic.linux-g6xlarge-amd64.key-name: kflux-prd-multi-p01-key-pair
-#   dynamic.linux-g6xlarge-amd64.aws-secret: aws-account
-#   dynamic.linux-g6xlarge-amd64.ssh-secret: aws-ssh-key
-#   dynamic.linux-g6xlarge-amd64.security-group-id: sg-004ef1b7bc3ef1bca
-#   dynamic.linux-g6xlarge-amd64.max-instances: "10"
-#   dynamic.linux-g6xlarge-amd64.subnet-id: subnet-07a8bbf633e2bb187
-#   dynamic.linux-g6xlarge-amd64.instance-tag: prod-amd64-g6xlarge
-#   dynamic.linux-g6xlarge-amd64.user-data: |-
-#     Content-Type: multipart/mixed; boundary="//"
-#     MIME-Version: 1.0
-
-#     --//
-#     Content-Type: text/cloud-config; charset="us-ascii"
-#     MIME-Version: 1.0
-#     Content-Transfer-Encoding: 7bit
-#     Content-Disposition: attachment; filename="cloud-config.txt"
-
-#     #cloud-config
-#     cloud_final_modules:
-#       - [scripts-user, always]
-
-#     --//
-#     Content-Type: text/x-shellscript; charset="us-ascii"
-#     MIME-Version: 1.0
-#     Content-Transfer-Encoding: 7bit
-#     Content-Disposition: attachment; filename="userdata.txt"
-
-#     #!/bin/bash -ex
-
-#     if lsblk -no FSTYPE /dev/nvme1n1 | grep -qE '\S'; then
-#       echo "File system exists on the disk."
-#     else
-#       echo "No file system found on the disk /dev/nvme1n1"
-#       mkfs -t xfs /dev/nvme1n1
-#     fi
-
-#     mount /dev/nvme1n1 /home
-
-#     if [ -d "/home/var-lib-containers" ]; then
-#       echo "Directory '/home/var-lib-containers' exist"
-#     else
-#       echo "Directory '/home/var-lib-containers' doesn't exist"
-#       mkdir -p /home/var-lib-containers /var/lib/containers
-#     fi
-
-#     mount --bind /home/var-lib-containers /var/lib/containers
-
-#     if [ -d "/home/var-tmp" ]; then
-#       echo "Directory '/home/var-tmp' exist"
-#     else
-#       echo "Directory '/home/var-tmp' doesn't exist"
-#       mkdir -p /home/var-tmp /var/tmp
-#     fi
-
-#     mount --bind /home/var-tmp /var/tmp
-#     chmod a+rw /var/tmp
-
-#     if [ -d "/home/ec2-user" ]; then
-#       echo "ec2-user home exists"
-#     else
-#       echo "ec2-user home doesn't exist"
-#       mkdir -p /home/ec2-user/.ssh
-#       chown -R ec2-user /home/ec2-user
-#     fi
-
-#     sed -n 's,.*\(ssh-.*\s\),\1,p' /root/.ssh/authorized_keys > /home/ec2-user/.ssh/authorized_keys
-#     chown ec2-user /home/ec2-user/.ssh/authorized_keys
-#     chmod 600 /home/ec2-user/.ssh/authorized_keys
-#     chmod 700 /home/ec2-user/.ssh
-#     restorecon -r /home/ec2-user
-
-#     mkdir -p /etc/cdi
-#     chmod a+rwx /etc/cdi
-#     su - ec2-user
-#     nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml
-#     --//--
+  host.ppc64le-static-7.address: "10.130.81.10"
+  host.ppc64le-static-7.platform: "linux/ppc64le"
+  host.ppc64le-static-7.user: "root"
+  host.ppc64le-static-7.secret: "ibm-ppc64le-ssh-key"
+  host.ppc64le-static-7.concurrency: "8"


### PR DESCRIPTION
Add all 8 ppc machines and only 3 s390x machines. We are missing 13 s390x machines that will be added once we sort it out with IBM/IT, we might need to move to another datacenter.

A follow up PR will be done with remaining machines.

[KFLUXINFRA-1638](https://issues.redhat.com//browse/KFLUXINFRA-1638)
[KFLUXINFRA-1639](https://issues.redhat.com//browse/KFLUXINFRA-1639)