### PR TITLE
feat(KFLUXUI-504): Add banner content yaml and its kustomization files

### DIFF
--- a/.github/workflows/validate-banner.yaml
+++ b/.github/workflows/validate-banner.yaml
@@ -1,0 +1,38 @@
+name: Validate Banners
+
+on:
+  pull_request:
+    paths:
+      - 'components/konflux-info/**/**/banner-content.yaml'
+      - 'components/konflux-info/banner-schema.json'
+
+env:
+  BANNER_DIR: components/konflux-info
+  SCHEMA_FILE: components/konflux-info/banner-schema.json
+  TMP_DIR: .tmp/banners
+
+jobs:
+  validate-banner:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Install ajv-cli and yaml converter
+        run: |
+          npm install -g ajv-cli yamljs
+
+      - name: Convert YAML to JSON
+        run: |
+          mkdir -p ${{ env.TMP_DIR }}
+          for file in ${{ env.BANNER_DIR }}/**/**/banner-content.yaml; do
+            json_file="${{ env.TMP_DIR }}/${file#${{ env.BANNER_DIR }}/}"
+            json_file="${json_file%.yaml}.json"
+            mkdir -p "$(dirname "$json_file")"
+            yaml2json "$file" > "$json_file"
+          done
+
+      - name: Validate all banners against schema
+        run: |
+          ajv validate -s ${{ env.SCHEMA_FILE }} -d "${{ env.TMP_DIR }}/**/*.json" --errors=text

--- a/components/konflux-info/README.md
+++ b/components/konflux-info/README.md
@@ -2,19 +2,28 @@
 
 ## 📂 Directory Structure
 
+The `KONFLUX-INFO` directory contains:
+
 ```bash
 .
+├── auto-alert-schema.json  # JSON shema definition for auto-alert-content.yaml
 ├── base/                   # Common resources (e.g., RBAC)
 ├── production/             # Production cluster configurations
 ├── staging/                # Staging cluster configurations
 ├── banner-schema.json      # JSON schema definition for validating banner-content.yaml files
+
 ```
 
 Each cluster directory contains:
 
-- `banner-content.yaml` 👉 The banner content shown in the UI
-- `info.json` 👉 Metadata about the cluster
-- `kustomization.yaml` 👉 Kustomize configuration for this cluster
+```bash
+.
+├── auto-alerts # The directory manages auto-generated alerts content shown in the UI
+├── banner-content.yaml # The banner content shown in the UI
+├── info.json # Metadata about the cluster
+└── kustomization.yaml # Kustomize configuration for this cluster, including base, auto-alerts, and other configs
+
+```
 
 ---
 
@@ -26,13 +35,52 @@ The schema (`banner-schema.json`) specifies the required structure and fields fo
 
 ---
 
-## 📝 How to submit a PR
+## 📝 How to submit a PR for Banner
 
 1. Modify only the files relevant to your target cluster, e.g.: `staging/stone-stage-p01/banner-content.yaml` or `production/kflux-ocp-p01/banner-content.yaml`
 2. In your PR description, include:
-  - Target cluster (e.g. kflux-ocp-p01)
-  - Type of change (e.g. new banner / update info / typo fix)
-  - Purpose of change (e.g. downgrade notification / release announcement)
+
+- Target cluster (e.g. kflux-ocp-p01)
+- Type of change (e.g. new banner / update info / typo fix)
+- Purpose of change (e.g. downgrade notification / release announcement)
 
 ---
 
+## 📢 Auto Alerts
+
+We enables the infrastructure team to automatically surface specific operational issues or warnings in the Konflux UI.
+
+These alerts would be auto-generated from monitoring systems or automation scripts, written as Kubernetes ConfigMaps, and automatically picked up by the Konflux UI to inform users of system-wide conditions.
+
+### ✅ Alert YAML Format
+
+Each file under auto-alerts/ must be a valid Kubernetes ConfigMap, including at minimum:
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: konflux-auto-alert-xyz
+  namespace: konflux-info
+  labels:
+    konflux-auto-alert: "true" # Required. UI filter alerts out by this label.
+data:
+  auto-alert-content.yaml: |
+    enable: true
+    summary: "Builds are delayed due to maintenance"
+    type: "warning"
+```
+
+🔐 The data.banner-content.yaml should follow the schema defined in `auto-alert-schema.json`
+
+### Folder Structure
+
+```bash
+
+auto-alerts/   # Alert ConfigMaps (one file = one alert)
+.
+├── alert-1.yaml           # Fully valid ConfigMap YAML
+├── alert-2.yaml
+└── kustomization.yaml     # Auto-generated, includes all alert YAMLs
+
+```

--- a/components/konflux-info/README.md
+++ b/components/konflux-info/README.md
@@ -1,0 +1,38 @@
+# 🚀 konflux-info Repository Guide
+
+## 📂 Directory Structure
+
+```bash
+.
+├── base/                   # Common resources (e.g., RBAC)
+├── production/             # Production cluster configurations
+├── staging/                # Staging cluster configurations
+├── banner-schema.json      # JSON schema definition for validating banner-content.yaml files
+```
+
+Each cluster directory contains:
+
+- `banner-content.yaml` 👉 The banner content shown in the UI
+- `info.json` 👉 Metadata about the cluster
+- `kustomization.yaml` 👉 Kustomize configuration for this cluster
+
+---
+
+## ✅ Banner Content Validation
+
+A GitHub workflow named `banner-validate` automatically checks that each `banner-content.yaml` file conforms to the schema defined in `banner-schema.json`.  
+This workflow runs whenever either the schema or any `banner-content.yaml` file is changed.  
+The schema (`banner-schema.json`) specifies the required structure and fields for banner content, ensuring consistency and correctness across environments.
+
+---
+
+## 📝 How to submit a PR
+
+1. Modify only the files relevant to your target cluster, e.g.: `staging/stone-stage-p01/banner-content.yaml` or `production/kflux-ocp-p01/banner-content.yaml`
+2. In your PR description, include:
+  - Target cluster (e.g. kflux-ocp-p01)
+  - Type of change (e.g. new banner / update info / typo fix)
+  - Purpose of change (e.g. downgrade notification / release announcement)
+
+---
+

--- a/components/konflux-info/auto-alert-schema.json
+++ b/components/konflux-info/auto-alert-schema.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "enable": {
+      "type": "boolean",
+      "description": "Whether the banner is enabled or not."
+    },
+    "type": {
+      "type": "string",
+      "enum": ["info", "warning", "danger"],
+      "description": "The type of banner to display. Can be 'info', 'warning', or 'danger'."
+    },
+    "summary": {
+      "description": "The summary text to display in the banner. Allows only alphanumeric characters, spaces, and specific punctuation marks.",
+      "type": "string",
+      "minLength": 5,
+      "maxLength": 200,
+      "pattern": "^[a-zA-Z0-9 ,.!?:;\"'()\\[\\]{}@#&*+=\\-_/]*$"
+    }
+  },
+  "required": ["summary", "type"],
+  "additionalProperties": false
+}

--- a/components/konflux-info/banner-schema.json
+++ b/components/konflux-info/banner-schema.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "enable": {
+      "type": "boolean",
+      "description": "Whether the banner is enabled or not."
+    },
+    "type": {
+      "type": "string",
+      "enum": ["info", "warning", "danger"],
+      "description": "The type of banner to display. Can be 'info', 'warning', or 'danger'."
+    },
+    "summary": {
+      "description": "The summary text to display in the banner. Allows only alphanumeric characters, spaces, and specific punctuation marks.",
+      "type": "string",
+      "minLength": 5,
+      "maxLength": 200,
+      "pattern": "^[a-zA-Z0-9 ,.!?:;\"'()\\[\\]{}@#&*+=\\-_/]*$"
+    },
+    "startTime": {
+      "type": "string",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?(?:Z|[+-]\\d{2}:\\d{2})$",
+      "description": "The start time when the banner should be displayed, in ISO 8601 date-time format (e.g., 2023-01-01T12:00:00Z)."
+    },
+    "endTime": {
+      "type": "string",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?(?:Z|[+-]\\d{2}:\\d{2})$",
+      "description": "The end time when the banner should stop being displayed, in ISO 8601 date-time format (e.g., 2023-01-01T12:00:00Z)."
+    }
+  },
+  "required": ["enable", "summary", "type"],
+  "additionalProperties": false
+}

--- a/components/konflux-info/production/kflux-ocp-p01/auto-alerts/auto-alert-1.yaml
+++ b/components/konflux-info/production/kflux-ocp-p01/auto-alerts/auto-alert-1.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+data:
+  auto-alert-content.yaml: |-
+    enable: false
+    type: warning
+    summary: pipeline run cannot run
+kind: ConfigMap
+metadata:
+  labels:
+    konflux-auto-alert: "true"
+  name: konflux-autoalert-configmap-1
+  namespace: konflux-info

--- a/components/konflux-info/production/kflux-ocp-p01/auto-alerts/kustomization.yaml
+++ b/components/konflux-info/production/kflux-ocp-p01/auto-alerts/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+ - auto-alert-1.yaml

--- a/components/konflux-info/production/kflux-ocp-p01/banner-content.yaml
+++ b/components/konflux-info/production/kflux-ocp-p01/banner-content.yaml
@@ -1,0 +1,5 @@
+enable: false
+type: warning # options: info, warning, danger
+summary: The Konflux platform will undergo scheduled maintenance tonight. Temporary service interruptions may occur.
+startTime: "2025-05-15T21:00:00Z"
+endTime: "2025-05-15T23:00:00Z"

--- a/components/konflux-info/production/kflux-ocp-p01/kustomization.yaml
+++ b/components/konflux-info/production/kflux-ocp-p01/kustomization.yaml
@@ -11,4 +11,9 @@ configMapGenerator:
     files:
       - info.json
 
+configMapGenerator:
+  - name: konflux-banner-configmap
+    files:
+      - banner-content.yaml
+
 namespace: konflux-info

--- a/components/konflux-info/production/kflux-ocp-p01/kustomization.yaml
+++ b/components/konflux-info/production/kflux-ocp-p01/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../base
+  - auto-alerts
 
 generatorOptions:
  disableNameSuffixHash: true
@@ -10,8 +11,6 @@ configMapGenerator:
   - name: konflux-public-info
     files:
       - info.json
-
-configMapGenerator:
   - name: konflux-banner-configmap
     files:
       - banner-content.yaml

--- a/components/konflux-info/production/kflux-prd-rh02/auto-alerts/auto-alert-1.yaml
+++ b/components/konflux-info/production/kflux-prd-rh02/auto-alerts/auto-alert-1.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+data:
+  auto-alert-content.yaml: |-
+    enable: false
+    type: warning
+    summary: pipeline run cannot run
+kind: ConfigMap
+metadata:
+  labels:
+    konflux-auto-alert: "true"
+  name: konflux-autoalert-configmap-1
+  namespace: konflux-info

--- a/components/konflux-info/production/kflux-prd-rh02/auto-alerts/kustomization.yaml
+++ b/components/konflux-info/production/kflux-prd-rh02/auto-alerts/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+ - auto-alert-1.yaml

--- a/components/konflux-info/production/kflux-prd-rh02/banner-content.yaml
+++ b/components/konflux-info/production/kflux-prd-rh02/banner-content.yaml
@@ -1,0 +1,5 @@
+enable: false
+type: warning # options: info, warning, danger
+summary: The Konflux platform will undergo scheduled maintenance tonight. Temporary service interruptions may occur.
+startTime: "2025-05-15T21:00:00Z"
+endTime: "2025-05-15T23:00:00Z"

--- a/components/konflux-info/production/kflux-prd-rh02/kustomization.yaml
+++ b/components/konflux-info/production/kflux-prd-rh02/kustomization.yaml
@@ -11,4 +11,9 @@ configMapGenerator:
     files:
       - info.json
 
+configMapGenerator:
+  - name: konflux-banner-configmap
+    files:
+      - banner-content.yaml
+
 namespace: konflux-info

--- a/components/konflux-info/production/kflux-prd-rh02/kustomization.yaml
+++ b/components/konflux-info/production/kflux-prd-rh02/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../base
+  - auto-alerts
 
 generatorOptions:
  disableNameSuffixHash: true
@@ -10,8 +11,6 @@ configMapGenerator:
   - name: konflux-public-info
     files:
       - info.json
-
-configMapGenerator:
   - name: konflux-banner-configmap
     files:
       - banner-content.yaml

--- a/components/konflux-info/production/kflux-prd-rh03/auto-alerts/auto-alert-1.yaml
+++ b/components/konflux-info/production/kflux-prd-rh03/auto-alerts/auto-alert-1.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+data:
+  auto-alert-content.yaml: |-
+    enable: false
+    type: warning
+    summary: pipeline run cannot run
+kind: ConfigMap
+metadata:
+  labels:
+    konflux-auto-alert: "true"
+  name: konflux-autoalert-configmap-1
+  namespace: konflux-info

--- a/components/konflux-info/production/kflux-prd-rh03/auto-alerts/kustomization.yaml
+++ b/components/konflux-info/production/kflux-prd-rh03/auto-alerts/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+ - auto-alert-1.yaml

--- a/components/konflux-info/production/kflux-prd-rh03/banner-content.yaml
+++ b/components/konflux-info/production/kflux-prd-rh03/banner-content.yaml
@@ -1,0 +1,5 @@
+enable: false
+type: warning # options: info, warning, danger
+summary: The Konflux platform will undergo scheduled maintenance tonight. Temporary service interruptions may occur.
+startTime: "2025-05-15T21:00:00Z"
+endTime: "2025-05-15T23:00:00Z"

--- a/components/konflux-info/production/kflux-prd-rh03/kustomization.yaml
+++ b/components/konflux-info/production/kflux-prd-rh03/kustomization.yaml
@@ -11,4 +11,9 @@ configMapGenerator:
     files:
       - info.json
 
+configMapGenerator:
+  - name: konflux-banner-configmap
+    files:
+      - banner-content.yaml
+
 namespace: konflux-info

--- a/components/konflux-info/production/kflux-prd-rh03/kustomization.yaml
+++ b/components/konflux-info/production/kflux-prd-rh03/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../base
+  - auto-alerts
 
 generatorOptions:
  disableNameSuffixHash: true
@@ -10,8 +11,6 @@ configMapGenerator:
   - name: konflux-public-info
     files:
       - info.json
-
-configMapGenerator:
   - name: konflux-banner-configmap
     files:
       - banner-content.yaml

--- a/components/konflux-info/production/kflux-rhel-p01/auto-alerts/auto-alert-1.yaml
+++ b/components/konflux-info/production/kflux-rhel-p01/auto-alerts/auto-alert-1.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+data:
+  auto-alert-content.yaml: |-
+    enable: false
+    type: warning
+    summary: pipeline run cannot run
+kind: ConfigMap
+metadata:
+  labels:
+    konflux-auto-alert: "true"
+  name: konflux-autoalert-configmap-1
+  namespace: konflux-info

--- a/components/konflux-info/production/kflux-rhel-p01/auto-alerts/kustomization.yaml
+++ b/components/konflux-info/production/kflux-rhel-p01/auto-alerts/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+ - auto-alert-1.yaml

--- a/components/konflux-info/production/kflux-rhel-p01/banner-content.yaml
+++ b/components/konflux-info/production/kflux-rhel-p01/banner-content.yaml
@@ -1,0 +1,5 @@
+enable: false
+type: warning # options: info, warning, danger
+summary: The Konflux platform will undergo scheduled maintenance tonight. Temporary service interruptions may occur.
+startTime: "2025-05-15T21:00:00Z"
+endTime: "2025-05-15T23:00:00Z"

--- a/components/konflux-info/production/kflux-rhel-p01/kustomization.yaml
+++ b/components/konflux-info/production/kflux-rhel-p01/kustomization.yaml
@@ -11,4 +11,9 @@ configMapGenerator:
     files:
       - info.json
 
+configMapGenerator:
+  - name: konflux-banner-configmap
+    files:
+      - banner-content.yaml
+
 namespace: konflux-info

--- a/components/konflux-info/production/stone-prd-rh01/auto-alerts/auto-alert-1.yaml
+++ b/components/konflux-info/production/stone-prd-rh01/auto-alerts/auto-alert-1.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+data:
+  auto-alert-content.yaml: |-
+    enable: false
+    type: warning
+    summary: pipeline run cannot run
+kind: ConfigMap
+metadata:
+  labels:
+    konflux-auto-alert: "true"
+  name: konflux-autoalert-configmap-1
+  namespace: konflux-info

--- a/components/konflux-info/production/stone-prd-rh01/auto-alerts/kustomization.yaml
+++ b/components/konflux-info/production/stone-prd-rh01/auto-alerts/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+ - auto-alert-1.yaml

--- a/components/konflux-info/production/stone-prd-rh01/banner-content.yaml
+++ b/components/konflux-info/production/stone-prd-rh01/banner-content.yaml
@@ -1,0 +1,5 @@
+enable: false
+type: warning # options: info, warning, danger
+summary: The Konflux platform will undergo scheduled maintenance tonight. Temporary service interruptions may occur.
+startTime: "2025-05-15T21:00:00Z"
+endTime: "2025-05-15T23:00:00Z"

--- a/components/konflux-info/production/stone-prd-rh01/kustomization.yaml
+++ b/components/konflux-info/production/stone-prd-rh01/kustomization.yaml
@@ -11,4 +11,9 @@ configMapGenerator:
     files:
       - info.json
 
+configMapGenerator:
+  - name: konflux-banner-configmap
+    files:
+      - banner-content.yaml
+
 namespace: konflux-info

--- a/components/konflux-info/production/stone-prd-rh01/kustomization.yaml
+++ b/components/konflux-info/production/stone-prd-rh01/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../base
+  - auto-alerts
 
 generatorOptions:
  disableNameSuffixHash: true
@@ -10,8 +11,6 @@ configMapGenerator:
   - name: konflux-public-info
     files:
       - info.json
-
-configMapGenerator:
   - name: konflux-banner-configmap
     files:
       - banner-content.yaml

--- a/components/konflux-info/production/stone-prod-p01/auto-alerts/auto-alert-1.yaml
+++ b/components/konflux-info/production/stone-prod-p01/auto-alerts/auto-alert-1.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+data:
+  auto-alert-content.yaml: |-
+    enable: false
+    type: warning
+    summary: pipeline run cannot run
+kind: ConfigMap
+metadata:
+  labels:
+    konflux-auto-alert: "true"
+  name: konflux-autoalert-configmap-1
+  namespace: konflux-info

--- a/components/konflux-info/production/stone-prod-p01/auto-alerts/kustomization.yaml
+++ b/components/konflux-info/production/stone-prod-p01/auto-alerts/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+ - auto-alert-1.yaml

--- a/components/konflux-info/production/stone-prod-p01/banner-content.yaml
+++ b/components/konflux-info/production/stone-prod-p01/banner-content.yaml
@@ -1,0 +1,5 @@
+enable: false
+type: warning # options: info, warning, danger
+summary: The Konflux platform will undergo scheduled maintenance tonight. Temporary service interruptions may occur.
+startTime: "2025-05-15T21:00:00Z"
+endTime: "2025-05-15T23:00:00Z"

--- a/components/konflux-info/production/stone-prod-p01/kustomization.yaml
+++ b/components/konflux-info/production/stone-prod-p01/kustomization.yaml
@@ -11,4 +11,9 @@ configMapGenerator:
     files:
       - info.json
 
+configMapGenerator:
+  - name: konflux-banner-configmap
+    files:
+      - banner-content.yaml
+
 namespace: konflux-info

--- a/components/konflux-info/production/stone-prod-p01/kustomization.yaml
+++ b/components/konflux-info/production/stone-prod-p01/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../base
+  - auto-alerts
 
 generatorOptions:
  disableNameSuffixHash: true
@@ -10,8 +11,6 @@ configMapGenerator:
   - name: konflux-public-info
     files:
       - info.json
-
-configMapGenerator:
   - name: konflux-banner-configmap
     files:
       - banner-content.yaml

--- a/components/konflux-info/production/stone-prod-p02/auto-alerts/auto-alert-1.yaml
+++ b/components/konflux-info/production/stone-prod-p02/auto-alerts/auto-alert-1.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+data:
+  auto-alert-content.yaml: |-
+    enable: false
+    type: warning
+    summary: pipeline run cannot run
+kind: ConfigMap
+metadata:
+  labels:
+    konflux-auto-alert: "true"
+  name: konflux-autoalert-configmap-1
+  namespace: konflux-info

--- a/components/konflux-info/production/stone-prod-p02/auto-alerts/kustomization.yaml
+++ b/components/konflux-info/production/stone-prod-p02/auto-alerts/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+ - auto-alert-1.yaml

--- a/components/konflux-info/production/stone-prod-p02/banner-content.yaml
+++ b/components/konflux-info/production/stone-prod-p02/banner-content.yaml
@@ -1,0 +1,5 @@
+enable: false
+type: warning # options: info, warning, danger
+summary: The Konflux platform will undergo scheduled maintenance tonight. Temporary service interruptions may occur.
+startTime: "2025-05-15T21:00:00Z"
+endTime: "2025-05-15T23:00:00Z"

--- a/components/konflux-info/production/stone-prod-p02/kustomization.yaml
+++ b/components/konflux-info/production/stone-prod-p02/kustomization.yaml
@@ -11,4 +11,9 @@ configMapGenerator:
     files:
       - info.json
 
+configMapGenerator:
+  - name: konflux-banner-configmap
+    files:
+      - banner-content.yaml
+
 namespace: konflux-info

--- a/components/konflux-info/production/stone-prod-p02/kustomization.yaml
+++ b/components/konflux-info/production/stone-prod-p02/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../base
+  - auto-alerts
 
 generatorOptions:
  disableNameSuffixHash: true
@@ -10,8 +11,6 @@ configMapGenerator:
   - name: konflux-public-info
     files:
       - info.json
-
-configMapGenerator:
   - name: konflux-banner-configmap
     files:
       - banner-content.yaml

--- a/components/konflux-info/staging/stone-stage-p01/auto-alerts/auto-alert-1.yaml
+++ b/components/konflux-info/staging/stone-stage-p01/auto-alerts/auto-alert-1.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+data:
+  auto-alert-content.yaml: |-
+    enable: false
+    type: warning
+    summary: pipeline run cannot run
+kind: ConfigMap
+metadata:
+  labels:
+    konflux-auto-alert: "true"
+  name: konflux-autoalert-configmap-1
+  namespace: konflux-info

--- a/components/konflux-info/staging/stone-stage-p01/auto-alerts/kustomization.yaml
+++ b/components/konflux-info/staging/stone-stage-p01/auto-alerts/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+ - auto-alert-1.yaml

--- a/components/konflux-info/staging/stone-stage-p01/banner-content.yaml
+++ b/components/konflux-info/staging/stone-stage-p01/banner-content.yaml
@@ -1,0 +1,5 @@
+enable: false
+type: warning # options: info, warning, danger
+summary: The Konflux platform will undergo scheduled maintenance tonight. Temporary service interruptions may occur.
+startTime: "2025-05-15T21:00:00Z"
+endTime: "2025-05-15T23:00:00Z"

--- a/components/konflux-info/staging/stone-stage-p01/kustomization.yaml
+++ b/components/konflux-info/staging/stone-stage-p01/kustomization.yaml
@@ -11,4 +11,9 @@ configMapGenerator:
     files:
       - info.json
 
+configMapGenerator:
+  - name: konflux-banner-configmap
+    files:
+      - banner-content.yaml
+
 namespace: konflux-info

--- a/components/konflux-info/staging/stone-stage-p01/kustomization.yaml
+++ b/components/konflux-info/staging/stone-stage-p01/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../base
+  - auto-alerts
 
 generatorOptions:
  disableNameSuffixHash: true
@@ -10,8 +11,6 @@ configMapGenerator:
   - name: konflux-public-info
     files:
       - info.json
-
-configMapGenerator:
   - name: konflux-banner-configmap
     files:
       - banner-content.yaml

--- a/components/konflux-info/staging/stone-stg-rh01/auto-alerts/auto-alert-1.yaml
+++ b/components/konflux-info/staging/stone-stg-rh01/auto-alerts/auto-alert-1.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+data:
+  auto-alert-content.yaml: |-
+    enable: false
+    type: warning
+    summary: pipeline run cannot run
+kind: ConfigMap
+metadata:
+  labels:
+    konflux-auto-alert: "true"
+  name: konflux-autoalert-configmap-1
+  namespace: konflux-info

--- a/components/konflux-info/staging/stone-stg-rh01/auto-alerts/kustomization.yaml
+++ b/components/konflux-info/staging/stone-stg-rh01/auto-alerts/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+ - auto-alert-1.yaml

--- a/components/konflux-info/staging/stone-stg-rh01/banner-content.yaml
+++ b/components/konflux-info/staging/stone-stg-rh01/banner-content.yaml
@@ -1,0 +1,5 @@
+enable: false
+type: warning # options: info, warning, danger
+summary: The Konflux platform will undergo scheduled maintenance tonight. Temporary service interruptions may occur.
+startTime: "2025-05-15T21:00:00Z"
+endTime: "2025-05-15T23:00:00Z"

--- a/components/konflux-info/staging/stone-stg-rh01/kustomization.yaml
+++ b/components/konflux-info/staging/stone-stg-rh01/kustomization.yaml
@@ -11,4 +11,9 @@ configMapGenerator:
     files:
       - info.json
 
+configMapGenerator:
+  - name: konflux-banner-configmap
+    files:
+      - banner-content.yaml
+
 namespace: konflux-info

--- a/components/konflux-info/staging/stone-stg-rh01/kustomization.yaml
+++ b/components/konflux-info/staging/stone-stg-rh01/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../base
+  - auto-alerts
 
 generatorOptions:
  disableNameSuffixHash: true
@@ -10,8 +11,6 @@ configMapGenerator:
   - name: konflux-public-info
     files:
       - info.json
-
-configMapGenerator:
   - name: konflux-banner-configmap
     files:
       - banner-content.yaml


### PR DESCRIPTION
[KFLUXUI-500](https://issues.redhat.com/browse/KFLUXUI-500) aims to provide konflux banner to users.

The PR does:
supporting the single manual banner:
- add the banner-content.yaml for each cluster under konflux-info
- update its kustomize to ensure the its confimap could be generated
- add README.md and github workflow validation support for banner content including schema & safe content
supporting the multiple auto generated alerts:
- add the auto-alerts directory and its fake kustomize 
- update genearl kustomize for auto-alerts
- update README.md to explain how we can enjoy the auto-alerts.

Here is one video about how UI integrate with them:
https://drive.google.com/file/d/17X3qkgLD7aXWq_wnuteAWUu3WE7_J2M5/view