### PR TITLE
Promote new MPC to the public prod clusters

### DIFF
--- a/components/multi-platform-controller/production/kflux-prd-rh02/kustomization.yaml
+++ b/components/multi-platform-controller/production/kflux-prd-rh02/kustomization.yaml
@@ -7,8 +7,8 @@ resources:
 - ../../base/common
 - host-config.yaml
 - external-secrets.yaml
-- https://github.com/konflux-ci/multi-platform-controller/deploy/operator?ref=468136ac1005dbf83fb25d385016f2feb3cb7e18
-- https://github.com/konflux-ci/multi-platform-controller/deploy/otp?ref=468136ac1005dbf83fb25d385016f2feb3cb7e18
+- https://github.com/konflux-ci/multi-platform-controller/deploy/operator?ref=e637dc899b2f1afba9e66406deabbc0d067df859
+- https://github.com/konflux-ci/multi-platform-controller/deploy/otp?ref=e637dc899b2f1afba9e66406deabbc0d067df859
 
 components:
   - ../../k-components/manager-resources
@@ -16,10 +16,10 @@ components:
 images:
 - name: multi-platform-controller
   newName: quay.io/konflux-ci/multi-platform-controller
-  newTag: 468136ac1005dbf83fb25d385016f2feb3cb7e18
+  newTag: e637dc899b2f1afba9e66406deabbc0d067df859
 - name: multi-platform-otp-server
   newName: quay.io/konflux-ci/multi-platform-controller-otp-service
-  newTag: 468136ac1005dbf83fb25d385016f2feb3cb7e18
+  newTag: e637dc899b2f1afba9e66406deabbc0d067df859
 
 patches:
   - path: manager_resources_patch.yaml

--- a/components/multi-platform-controller/production/kflux-prd-rh03/kustomization.yaml
+++ b/components/multi-platform-controller/production/kflux-prd-rh03/kustomization.yaml
@@ -7,8 +7,8 @@ resources:
 - ../../base/common
 - host-config.yaml
 - external-secrets.yaml
-- https://github.com/konflux-ci/multi-platform-controller/deploy/operator?ref=468136ac1005dbf83fb25d385016f2feb3cb7e18
-- https://github.com/konflux-ci/multi-platform-controller/deploy/otp?ref=468136ac1005dbf83fb25d385016f2feb3cb7e18
+- https://github.com/konflux-ci/multi-platform-controller/deploy/operator?ref=e637dc899b2f1afba9e66406deabbc0d067df859
+- https://github.com/konflux-ci/multi-platform-controller/deploy/otp?ref=e637dc899b2f1afba9e66406deabbc0d067df859
 
 components:
   - ../../k-components/manager-resources
@@ -16,10 +16,10 @@ components:
 images:
 - name: multi-platform-controller
   newName: quay.io/konflux-ci/multi-platform-controller
-  newTag: 468136ac1005dbf83fb25d385016f2feb3cb7e18
+  newTag: e637dc899b2f1afba9e66406deabbc0d067df859
 - name: multi-platform-otp-server
   newName: quay.io/konflux-ci/multi-platform-controller-otp-service
-  newTag: 468136ac1005dbf83fb25d385016f2feb3cb7e18
+  newTag: e637dc899b2f1afba9e66406deabbc0d067df859
 
 patches:
   - path: manager_resources_patch.yaml

--- a/components/multi-platform-controller/production/stone-prd-rh01/kustomization.yaml
+++ b/components/multi-platform-controller/production/stone-prd-rh01/kustomization.yaml
@@ -7,8 +7,8 @@ resources:
 - ../../base/common
 - host-config.yaml
 - external-secrets.yaml
-- https://github.com/konflux-ci/multi-platform-controller/deploy/operator?ref=468136ac1005dbf83fb25d385016f2feb3cb7e18
-- https://github.com/konflux-ci/multi-platform-controller/deploy/otp?ref=468136ac1005dbf83fb25d385016f2feb3cb7e18
+- https://github.com/konflux-ci/multi-platform-controller/deploy/operator?ref=e637dc899b2f1afba9e66406deabbc0d067df859
+- https://github.com/konflux-ci/multi-platform-controller/deploy/otp?ref=e637dc899b2f1afba9e66406deabbc0d067df859
 
 components:
   - ../../k-components/manager-resources
@@ -16,10 +16,10 @@ components:
 images:
 - name: multi-platform-controller
   newName: quay.io/konflux-ci/multi-platform-controller
-  newTag: 468136ac1005dbf83fb25d385016f2feb3cb7e18
+  newTag: e637dc899b2f1afba9e66406deabbc0d067df859
 - name: multi-platform-otp-server
   newName: quay.io/konflux-ci/multi-platform-controller-otp-service
-  newTag: 468136ac1005dbf83fb25d385016f2feb3cb7e18
+  newTag: e637dc899b2f1afba9e66406deabbc0d067df859
 
 
 patches:


### PR DESCRIPTION
Private ones were updates [last week](https://github.com/redhat-appstudio/infra-deployments/pull/6585), showing no major problems.

Updates:

Provision/cleanup task names generation refactor to avoid duplicates
Searchable Platform labels for MPC tasks
