### PR TITLE
upgrade crossplane environments

### DIFF
--- a/components/crossplane-control-plane/base/kustomization.yaml
+++ b/components/crossplane-control-plane/base/kustomization.yaml
@@ -1,6 +1,6 @@
 resources:
-- https://github.com/konflux-ci/crossplane-control-plane/crossplane?ref=67eadc539704e0915465bd6d45904931bdfdb910
-- https://github.com/konflux-ci/crossplane-control-plane/config?ref=67eadc539704e0915465bd6d45904931bdfdb910
+- https://github.com/konflux-ci/crossplane-control-plane/crossplane?ref=3df90763aa750cf27b45df24e6dc67ccd139a056
+- https://github.com/konflux-ci/crossplane-control-plane/config?ref=3df90763aa750cf27b45df24e6dc67ccd139a056
 - rbac.yaml
 - cronjob.yaml
 - configmap.yaml

--- a/components/crossplane-control-plane/development/kustomization.yaml
+++ b/components/crossplane-control-plane/development/kustomization.yaml
@@ -1,6 +1,6 @@
 resources:
 - ../base
-- https://github.com/konflux-ci/crossplane-control-plane/examples/provider-kubernetes-in-cluster?ref=5d6c42730c1c9f66b5d3567bdf04d587832ceac1
+- https://github.com/konflux-ci/crossplane-control-plane/examples/provider-kubernetes-in-cluster?ref=3df90763aa750cf27b45df24e6dc67ccd139a056
 
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization


### PR DESCRIPTION
Same as https://github.com/redhat-appstudio/infra-deployments/pull/6503.
I had to rename my fork from `danilo-gemoli/redhat-appstudio-infra-deployments` to `danilo-gemoli/infra-deployments` because there are some e2e tests that make assumptions on the fork name: the name should match this pattern `<your-org>/infra-deployments`.