### PR TITLE
increase QPS and Burst for Kyverno in stg rh01

### DIFF
--- a/components/kyverno/staging/stone-stg-rh01/kustomization.yaml
+++ b/components/kyverno/staging/stone-stg-rh01/kustomization.yaml
@@ -37,3 +37,9 @@ patches:
       version: v1
       kind: Job
       name: konflux-kyverno-migrate-resources
+  - path: patch-background-controller-qps-burst.yaml
+    target:
+      group: apps
+      version: v1
+      kind: Deployment
+      name: kyverno-background-controller

--- a/components/kyverno/staging/stone-stg-rh01/patch-background-controller-qps-burst.yaml
+++ b/components/kyverno/staging/stone-stg-rh01/patch-background-controller-qps-burst.yaml
@@ -1,0 +1,9 @@
+---
+- op: add
+  path: /spec/template/spec/containers/0/args/-
+  value:
+    --clientRateLimitQPS=1000
+- op: add
+  path: /spec/template/spec/containers/0/args/-
+  value:
+    --clientRateLimitBurst=1000


### PR DESCRIPTION
Bumping Kyverno background controller's QPS and Burst to test impact on APIServer performances. Default values were 300 each.

```
      containers:
        - args:
            - --enablePolicyException=false
            - --enableReporting=validate,mutate,mutateExisting,imageVerify,generate
            - --clientRateLimitQPS=1000
            - --clientRateLimitBurst=1000
          env:
            - name: KYVERNO_SERVICEACCOUNT_NAME
```

Signed-off-by: Francesco Ilario <filario@redhat.com>
