### PR TITLE
Override missing operator-proxy image

### DIFF
--- a/components/pipeline-service/production/kflux-prd-rh02/deploy.yaml
+++ b/components/pipeline-service/production/kflux-prd-rh02/deploy.yaml
@@ -2553,6 +2553,8 @@ spec:
     env:
     - name: AUTOINSTALL_COMPONENTS
       value: "false"
+    - name: IMAGE_PIPELINES_PROXY
+      value: quay.io/openshift-pipeline/pipelines-operator-proxy-rhel9@sha256:e37a2b061eff6984f8d341825e5989e459de4125322e33480ac01dce5a57c801
   name: openshift-pipelines-operator-rh
   source: custom-operators
   sourceNamespace: openshift-marketplace

--- a/components/pipeline-service/production/kflux-prd-rh02/resources/kustomization.yaml
+++ b/components/pipeline-service/production/kflux-prd-rh02/resources/kustomization.yaml
@@ -38,3 +38,7 @@ patches:
     target:
       kind: TektonConfig
       name: config
+  - path: override-missing-operator-proxy-image.yaml
+    target:
+      kind: Subscription
+      name: openshift-pipelines-operator

--- a/components/pipeline-service/production/kflux-prd-rh02/resources/override-missing-operator-proxy-image.yaml
+++ b/components/pipeline-service/production/kflux-prd-rh02/resources/override-missing-operator-proxy-image.yaml
@@ -1,0 +1,6 @@
+---
+- op: add
+  path: /spec/config/env/-
+  value:
+    name: IMAGE_PIPELINES_PROXY
+    value: quay.io/openshift-pipeline/pipelines-operator-proxy-rhel9@sha256:e37a2b061eff6984f8d341825e5989e459de4125322e33480ac01dce5a57c801

--- a/components/pipeline-service/production/kflux-rhel-p01/deploy.yaml
+++ b/components/pipeline-service/production/kflux-rhel-p01/deploy.yaml
@@ -1422,10 +1422,10 @@ spec:
         resources:
           limits:
             cpu: 500m
-            memory: 6Gi
+            memory: 8Gi
           requests:
             cpu: 250m
-            memory: 6Gi
+            memory: 8Gi
         securityContext:
           readOnlyRootFilesystem: true
           runAsNonRoot: true
@@ -2447,10 +2447,10 @@ spec:
                 - name: controller
                   resources:
                     limits:
-                      memory: 8Gi
+                      memory: 10Gi
                     requests:
                       cpu: 500m
-                      memory: 8Gi
+                      memory: 10Gi
     performance:
       buckets: 4
       disable-ha: false


### PR DESCRIPTION
The image was removed from the image repository and the deployment/pod/image pull is failing. Until we get a new build referencing an existing image, we override the image through the subscription.

The p01 cluster update is not related, but it is a leftover from #6436 which now the generate script picked up.