### PR TITLE
increase QPS and Burst for Kyverno in prod rh01

### DIFF
--- a/components/kyverno/production/stone-prd-rh01/patch_background_controller_qps_burst.yaml
+++ b/components/kyverno/production/stone-prd-rh01/patch_background_controller_qps_burst.yaml
@@ -2,9 +2,9 @@
 - op: add
   path: /spec/template/spec/containers/0/args/-
   value:
-    --clientRateLimitQPS=1000
+    --clientRateLimitQPS=2000
 - op: add
   path: /spec/template/spec/containers/0/args/-
   value:
-    --clientRateLimitBurst=1000
+    --clientRateLimitBurst=2000
 


### PR DESCRIPTION
Bumping Kyverno background controller's QPS and Burst to test impact on
APIServer performances. Default values were 300 each.

```
      containers:
        - args:
            - --enablePolicyException=false
            - --enableReporting=validate,mutate,mutateExisting,imageVerify,generate
            - --clientRateLimitQPS=2000
            - --clientRateLimitBurst=2000
          env:
            - name: KYVERNO_SERVICEACCOUNT_NAME
```

Signed-off-by: Francesco Ilario <filario@redhat.com>
