### PR TITLE
kyverno: increase leader election retry period in dev and stg

### DIFF
--- a/components/kyverno/development/kyverno-helm-values.yaml
+++ b/components/kyverno/development/kyverno-helm-values.yaml
@@ -6,6 +6,8 @@ config:
   preserve: false
 admissionController:
   replicas: 1
+  extraArgs:
+    leaderElectionRetryPeriod: 5s
   initContainer:
     securityContext:
       allowPrivilegeEscalation: false
@@ -24,6 +26,8 @@ admissionController:
         - "ALL"
 backgroundController:
   replicas: 1
+  extraArgs:
+    leaderElectionRetryPeriod: 5s
   securityContext:
     allowPrivilegeEscalation: false
     readOnlyRootFilesystem: true

--- a/components/kyverno/staging/stone-stg-rh01/kyverno-helm-values.yaml
+++ b/components/kyverno/staging/stone-stg-rh01/kyverno-helm-values.yaml
@@ -4,6 +4,8 @@ config:
   preserve: false
 admissionController:
   replicas: 3
+  extraArgs:
+    leaderElectionRetryPeriod: 5s
   initContainer:
     securityContext:
       allowPrivilegeEscalation: false
@@ -28,6 +30,8 @@ admissionController:
         - "ALL"
 backgroundController:
   replicas: 3
+  extraArgs:
+    leaderElectionRetryPeriod: 5s
   resources:
     requests:
       cpu: 500m
@@ -43,6 +47,8 @@ backgroundController:
       - "ALL"
 cleanupController:
   replicas: 3
+  extraArgs:
+    leaderElectionRetryPeriod: 5s
   securityContext:
     allowPrivilegeEscalation: false
     readOnlyRootFilesystem: true


### PR DESCRIPTION
In prod rh01 kyverno is restarting because it can not renovate the lease.
We want to have leases that lasts at least `25 seconds`.

Kyverno accepts the flag `leaderElectionRetryPeriod` defaulted to `2s` (cf. https://kyverno.io/docs/installation/customization/#container-flags) and it's multiplying this factor for `6` to calculate the `LeaseDuration` value.

Bumping the `leaderElectionRetryPeriod` to `5s` will make the lease last at least `30s`.

Signed-off-by: Francesco Ilario <filario@redhat.com>
