### PR TITLE
disable kyverno's helm tests manifests in dev, chainsaw and stg

### DIFF
--- a/components/kyverno/chainsaw/kyverno-helm-generator.yaml
+++ b/components/kyverno/chainsaw/kyverno-helm-generator.yaml
@@ -11,3 +11,4 @@ version: 3.3.7
 namespace: konflux-kyverno
 valuesFile: kyverno-helm-values.yaml
 releaseName: kyverno
+skipTests: true

--- a/components/kyverno/chainsaw/kyverno-helm-values.yaml
+++ b/components/kyverno/chainsaw/kyverno-helm-values.yaml
@@ -39,16 +39,6 @@ policyReportsCleanup:
   enabled: false
 webhooksCleanup:
   enabled: false
-test:
-  securityContext:
-    allowPrivilegeEscalation: false
-    readOnlyRootFilesystem: true
-    runAsNonRoot: true
-    runAsGroup: null
-    runAsUser: null
-    capabilities:
-      drop:
-      - "ALL"
 crds:
   migration:
     securityContext:

--- a/components/kyverno/development/kyverno-helm-generator.yaml
+++ b/components/kyverno/development/kyverno-helm-generator.yaml
@@ -11,3 +11,4 @@ version: 3.3.7
 namespace: konflux-kyverno
 valuesFile: kyverno-helm-values.yaml
 releaseName: kyverno
+skipTests: true

--- a/components/kyverno/development/kyverno-helm-values.yaml
+++ b/components/kyverno/development/kyverno-helm-values.yaml
@@ -43,16 +43,6 @@ policyReportsCleanup:
   enabled: false
 webhooksCleanup:
   enabled: false
-test:
-  securityContext:
-    allowPrivilegeEscalation: false
-    readOnlyRootFilesystem: true
-    runAsNonRoot: true
-    runAsGroup: null
-    runAsUser: null
-    capabilities:
-      drop:
-      - "ALL"
 crds:
   migration:
     securityContext:

--- a/components/kyverno/staging/stone-stage-p01/kyverno-helm-generator.yaml
+++ b/components/kyverno/staging/stone-stage-p01/kyverno-helm-generator.yaml
@@ -11,3 +11,4 @@ version: 3.3.7
 namespace: konflux-kyverno
 valuesFile: kyverno-helm-values.yaml
 releaseName: kyverno
+skipTests: true

--- a/components/kyverno/staging/stone-stage-p01/kyverno-helm-values.yaml
+++ b/components/kyverno/staging/stone-stage-p01/kyverno-helm-values.yaml
@@ -56,16 +56,6 @@ policyReportsCleanup:
   enabled: false
 webhooksCleanup:
   enabled: false
-test:
-  securityContext:
-    allowPrivilegeEscalation: false
-    readOnlyRootFilesystem: true
-    runAsNonRoot: true
-    runAsGroup: null
-    runAsUser: null
-    capabilities:
-      drop:
-      - "ALL"
 crds:
   migration:
     securityContext:

--- a/components/kyverno/staging/stone-stg-rh01/kyverno-helm-generator.yaml
+++ b/components/kyverno/staging/stone-stg-rh01/kyverno-helm-generator.yaml
@@ -11,3 +11,4 @@ version: 3.3.7
 namespace: konflux-kyverno
 valuesFile: kyverno-helm-values.yaml
 releaseName: kyverno
+skipTests: true

--- a/components/kyverno/staging/stone-stg-rh01/kyverno-helm-values.yaml
+++ b/components/kyverno/staging/stone-stg-rh01/kyverno-helm-values.yaml
@@ -64,16 +64,6 @@ policyReportsCleanup:
   enabled: false
 webhooksCleanup:
   enabled: false
-test:
-  securityContext:
-    allowPrivilegeEscalation: false
-    readOnlyRootFilesystem: true
-    runAsNonRoot: true
-    runAsGroup: null
-    runAsUser: null
-    capabilities:
-      drop:
-      - "ALL"
 crds:
   migration:
     securityContext:


### PR DESCRIPTION
From https://argo-cd.readthedocs.io/en/latest/user-guide/helm/#helm-skip-tests
> By default, Helm includes test manifests when rendering templates. Argo CD currently skips manifests that include hooks not supported by Argo CD, including Helm test hooks.

Signed-off-by: Francesco Ilario <filario@redhat.com>
