### PR TITLE
Fix kflux-rhel-p01 MPC subnet and security group

### DIFF
--- a/components/multi-platform-controller/production-downstream/kflux-rhel-p01/host-config.yaml
+++ b/components/multi-platform-controller/production-downstream/kflux-rhel-p01/host-config.yaml
@@ -59,9 +59,9 @@ data:
   dynamic.linux-arm64.key-name: kflux-prd-multi-p01-key-pair
   dynamic.linux-arm64.aws-secret: aws-account
   dynamic.linux-arm64.ssh-secret: aws-ssh-key
-  dynamic.linux-arm64.security-group-id: sg-004ef1b7bc3ef1bca
+  dynamic.linux-arm64.security-group-id: sg-0c67a834068be63d6
   dynamic.linux-arm64.max-instances: "50"
-  dynamic.linux-arm64.subnet-id: subnet-07a8bbf633e2bb187
+  dynamic.linux-arm64.subnet-id: subnet-0f3208c0214c55e2e
 
   dynamic.linux-mlarge-arm64.type: aws
   dynamic.linux-mlarge-arm64.region: us-east-1
@@ -71,9 +71,9 @@ data:
   dynamic.linux-mlarge-arm64.key-name: kflux-prd-multi-p01-key-pair
   dynamic.linux-mlarge-arm64.aws-secret: aws-account
   dynamic.linux-mlarge-arm64.ssh-secret: aws-ssh-key
-  dynamic.linux-mlarge-arm64.security-group-id: sg-004ef1b7bc3ef1bca
+  dynamic.linux-mlarge-arm64.security-group-id: sg-0c67a834068be63d6
   dynamic.linux-mlarge-arm64.max-instances: "50"
-  dynamic.linux-mlarge-arm64.subnet-id: subnet-07a8bbf633e2bb187
+  dynamic.linux-mlarge-arm64.subnet-id: subnet-0f3208c0214c55e2e
 
   dynamic.linux-mxlarge-arm64.type: aws
   dynamic.linux-mxlarge-arm64.region: us-east-1
@@ -83,9 +83,9 @@ data:
   dynamic.linux-mxlarge-arm64.key-name: kflux-prd-multi-p01-key-pair
   dynamic.linux-mxlarge-arm64.aws-secret: aws-account
   dynamic.linux-mxlarge-arm64.ssh-secret: aws-ssh-key
-  dynamic.linux-mxlarge-arm64.security-group-id: sg-004ef1b7bc3ef1bca
+  dynamic.linux-mxlarge-arm64.security-group-id: sg-0c67a834068be63d6
   dynamic.linux-mxlarge-arm64.max-instances: "20"
-  dynamic.linux-mxlarge-arm64.subnet-id: subnet-07a8bbf633e2bb187
+  dynamic.linux-mxlarge-arm64.subnet-id: subnet-0f3208c0214c55e2e
 
   dynamic.linux-m2xlarge-arm64.type: aws
   dynamic.linux-m2xlarge-arm64.region: us-east-1
@@ -95,9 +95,9 @@ data:
   dynamic.linux-m2xlarge-arm64.key-name: kflux-prd-multi-p01-key-pair
   dynamic.linux-m2xlarge-arm64.aws-secret: aws-account
   dynamic.linux-m2xlarge-arm64.ssh-secret: aws-ssh-key
-  dynamic.linux-m2xlarge-arm64.security-group-id: sg-004ef1b7bc3ef1bca
+  dynamic.linux-m2xlarge-arm64.security-group-id: sg-0c67a834068be63d6
   dynamic.linux-m2xlarge-arm64.max-instances: "20"
-  dynamic.linux-m2xlarge-arm64.subnet-id: subnet-07a8bbf633e2bb187
+  dynamic.linux-m2xlarge-arm64.subnet-id: subnet-0f3208c0214c55e2e
 
   dynamic.linux-m4xlarge-arm64.type: aws
   dynamic.linux-m4xlarge-arm64.region: us-east-1
@@ -107,9 +107,9 @@ data:
   dynamic.linux-m4xlarge-arm64.key-name: kflux-prd-multi-p01-key-pair
   dynamic.linux-m4xlarge-arm64.aws-secret: aws-account
   dynamic.linux-m4xlarge-arm64.ssh-secret: aws-ssh-key
-  dynamic.linux-m4xlarge-arm64.security-group-id: sg-004ef1b7bc3ef1bca
+  dynamic.linux-m4xlarge-arm64.security-group-id: sg-0c67a834068be63d6
   dynamic.linux-m4xlarge-arm64.max-instances: "20"
-  dynamic.linux-m4xlarge-arm64.subnet-id: subnet-07a8bbf633e2bb187
+  dynamic.linux-m4xlarge-arm64.subnet-id: subnet-0f3208c0214c55e2e
 
   dynamic.linux-m8xlarge-arm64.type: aws
   dynamic.linux-m8xlarge-arm64.region: us-east-1
@@ -119,9 +119,9 @@ data:
   dynamic.linux-m8xlarge-arm64.key-name: kflux-prd-multi-p01-key-pair
   dynamic.linux-m8xlarge-arm64.aws-secret: aws-account
   dynamic.linux-m8xlarge-arm64.ssh-secret: aws-ssh-key
-  dynamic.linux-m8xlarge-arm64.security-group-id: sg-004ef1b7bc3ef1bca
+  dynamic.linux-m8xlarge-arm64.security-group-id: sg-0c67a834068be63d6
   dynamic.linux-m8xlarge-arm64.max-instances: "20"
-  dynamic.linux-m8xlarge-arm64.subnet-id: subnet-07a8bbf633e2bb187
+  dynamic.linux-m8xlarge-arm64.subnet-id: subnet-0f3208c0214c55e2e
 
   dynamic.linux-c6gd2xlarge-arm64.type: aws
   dynamic.linux-c6gd2xlarge-arm64.region: us-east-1
@@ -131,9 +131,9 @@ data:
   dynamic.linux-c6gd2xlarge-arm64.key-name: kflux-prd-multi-p01-key-pair
   dynamic.linux-c6gd2xlarge-arm64.aws-secret: aws-account
   dynamic.linux-c6gd2xlarge-arm64.ssh-secret: aws-ssh-key
-  dynamic.linux-c6gd2xlarge-arm64.security-group-id: sg-004ef1b7bc3ef1bca
+  dynamic.linux-c6gd2xlarge-arm64.security-group-id: sg-0c67a834068be63d6
   dynamic.linux-c6gd2xlarge-arm64.max-instances: "20"
-  dynamic.linux-c6gd2xlarge-arm64.subnet-id: subnet-07a8bbf633e2bb187
+  dynamic.linux-c6gd2xlarge-arm64.subnet-id: subnet-0f3208c0214c55e2e
   dynamic.linux-c6gd2xlarge-arm64.user-data: |-
     Content-Type: multipart/mixed; boundary="//"
     MIME-Version: 1.0
@@ -207,9 +207,9 @@ data:
   dynamic.linux-amd64.key-name: kflux-prd-multi-p01-key-pair
   dynamic.linux-amd64.aws-secret: aws-account
   dynamic.linux-amd64.ssh-secret: aws-ssh-key
-  dynamic.linux-amd64.security-group-id: sg-004ef1b7bc3ef1bca
+  dynamic.linux-amd64.security-group-id: sg-0c67a834068be63d6
   dynamic.linux-amd64.max-instances: "10"
-  dynamic.linux-amd64.subnet-id: subnet-07a8bbf633e2bb187
+  dynamic.linux-amd64.subnet-id: subnet-0f3208c0214c55e2e
 
   dynamic.linux-mlarge-amd64.type: aws
   dynamic.linux-mlarge-amd64.region: us-east-1
@@ -219,9 +219,9 @@ data:
   dynamic.linux-mlarge-amd64.key-name: kflux-prd-multi-p01-key-pair
   dynamic.linux-mlarge-amd64.aws-secret: aws-account
   dynamic.linux-mlarge-amd64.ssh-secret: aws-ssh-key
-  dynamic.linux-mlarge-amd64.security-group-id: sg-004ef1b7bc3ef1bca
+  dynamic.linux-mlarge-amd64.security-group-id: sg-0c67a834068be63d6
   dynamic.linux-mlarge-amd64.max-instances: "10"
-  dynamic.linux-mlarge-amd64.subnet-id: subnet-07a8bbf633e2bb187
+  dynamic.linux-mlarge-amd64.subnet-id: subnet-0f3208c0214c55e2e
 
   dynamic.linux-mxlarge-amd64.type: aws
   dynamic.linux-mxlarge-amd64.region: us-east-1
@@ -231,9 +231,9 @@ data:
   dynamic.linux-mxlarge-amd64.key-name: kflux-prd-multi-p01-key-pair
   dynamic.linux-mxlarge-amd64.aws-secret: aws-account
   dynamic.linux-mxlarge-amd64.ssh-secret: aws-ssh-key
-  dynamic.linux-mxlarge-amd64.security-group-id: sg-004ef1b7bc3ef1bca
+  dynamic.linux-mxlarge-amd64.security-group-id: sg-0c67a834068be63d6
   dynamic.linux-mxlarge-amd64.max-instances: "10"
-  dynamic.linux-mxlarge-amd64.subnet-id: subnet-07a8bbf633e2bb187
+  dynamic.linux-mxlarge-amd64.subnet-id: subnet-0f3208c0214c55e2e
 
   dynamic.linux-m2xlarge-amd64.type: aws
   dynamic.linux-m2xlarge-amd64.region: us-east-1
@@ -243,9 +243,9 @@ data:
   dynamic.linux-m2xlarge-amd64.key-name: kflux-prd-multi-p01-key-pair
   dynamic.linux-m2xlarge-amd64.aws-secret: aws-account
   dynamic.linux-m2xlarge-amd64.ssh-secret: aws-ssh-key
-  dynamic.linux-m2xlarge-amd64.security-group-id: sg-004ef1b7bc3ef1bca
+  dynamic.linux-m2xlarge-amd64.security-group-id: sg-0c67a834068be63d6
   dynamic.linux-m2xlarge-amd64.max-instances: "10"
-  dynamic.linux-m2xlarge-amd64.subnet-id: subnet-07a8bbf633e2bb187
+  dynamic.linux-m2xlarge-amd64.subnet-id: subnet-0f3208c0214c55e2e
 
   dynamic.linux-m4xlarge-amd64.type: aws
   dynamic.linux-m4xlarge-amd64.region: us-east-1
@@ -255,9 +255,9 @@ data:
   dynamic.linux-m4xlarge-amd64.key-name: kflux-prd-multi-p01-key-pair
   dynamic.linux-m4xlarge-amd64.aws-secret: aws-account
   dynamic.linux-m4xlarge-amd64.ssh-secret: aws-ssh-key
-  dynamic.linux-m4xlarge-amd64.security-group-id: sg-004ef1b7bc3ef1bca
+  dynamic.linux-m4xlarge-amd64.security-group-id: sg-0c67a834068be63d6
   dynamic.linux-m4xlarge-amd64.max-instances: "10"
-  dynamic.linux-m4xlarge-amd64.subnet-id: subnet-07a8bbf633e2bb187
+  dynamic.linux-m4xlarge-amd64.subnet-id: subnet-0f3208c0214c55e2e
 
   dynamic.linux-m8xlarge-amd64.type: aws
   dynamic.linux-m8xlarge-amd64.region: us-east-1
@@ -267,9 +267,9 @@ data:
   dynamic.linux-m8xlarge-amd64.key-name: kflux-prd-multi-p01-key-pair
   dynamic.linux-m8xlarge-amd64.aws-secret: aws-account
   dynamic.linux-m8xlarge-amd64.ssh-secret: aws-ssh-key
-  dynamic.linux-m8xlarge-amd64.security-group-id: sg-004ef1b7bc3ef1bca
+  dynamic.linux-m8xlarge-amd64.security-group-id: sg-0c67a834068be63d6
   dynamic.linux-m8xlarge-amd64.max-instances: "10"
-  dynamic.linux-m8xlarge-amd64.subnet-id: subnet-07a8bbf633e2bb187
+  dynamic.linux-m8xlarge-amd64.subnet-id: subnet-0f3208c0214c55e2e
 
   # cpu:memory (1:2)
   dynamic.linux-cxlarge-arm64.type: aws
@@ -280,9 +280,9 @@ data:
   dynamic.linux-cxlarge-arm64.key-name: kflux-prd-multi-p01-key-pair
   dynamic.linux-cxlarge-arm64.aws-secret: aws-account
   dynamic.linux-cxlarge-arm64.ssh-secret: aws-ssh-key
-  dynamic.linux-cxlarge-arm64.security-group-id: sg-004ef1b7bc3ef1bca
+  dynamic.linux-cxlarge-arm64.security-group-id: sg-0c67a834068be63d6
   dynamic.linux-cxlarge-arm64.max-instances: "50"
-  dynamic.linux-cxlarge-arm64.subnet-id: subnet-07a8bbf633e2bb187
+  dynamic.linux-cxlarge-arm64.subnet-id: subnet-0f3208c0214c55e2e
 
   dynamic.linux-c2xlarge-arm64.type: aws
   dynamic.linux-c2xlarge-arm64.region: us-east-1
@@ -292,9 +292,9 @@ data:
   dynamic.linux-c2xlarge-arm64.key-name: kflux-prd-multi-p01-key-pair
   dynamic.linux-c2xlarge-arm64.aws-secret: aws-account
   dynamic.linux-c2xlarge-arm64.ssh-secret: aws-ssh-key
-  dynamic.linux-c2xlarge-arm64.security-group-id: sg-004ef1b7bc3ef1bca
+  dynamic.linux-c2xlarge-arm64.security-group-id: sg-0c67a834068be63d6
   dynamic.linux-c2xlarge-arm64.max-instances: "20"
-  dynamic.linux-c2xlarge-arm64.subnet-id: subnet-07a8bbf633e2bb187
+  dynamic.linux-c2xlarge-arm64.subnet-id: subnet-0f3208c0214c55e2e
 
   dynamic.linux-c4xlarge-arm64.type: aws
   dynamic.linux-c4xlarge-arm64.region: us-east-1
@@ -304,9 +304,9 @@ data:
   dynamic.linux-c4xlarge-arm64.key-name: kflux-prd-multi-p01-key-pair
   dynamic.linux-c4xlarge-arm64.aws-secret: aws-account
   dynamic.linux-c4xlarge-arm64.ssh-secret: aws-ssh-key
-  dynamic.linux-c4xlarge-arm64.security-group-id: sg-004ef1b7bc3ef1bca
+  dynamic.linux-c4xlarge-arm64.security-group-id: sg-0c67a834068be63d6
   dynamic.linux-c4xlarge-arm64.max-instances: "20"
-  dynamic.linux-c4xlarge-arm64.subnet-id: subnet-07a8bbf633e2bb187
+  dynamic.linux-c4xlarge-arm64.subnet-id: subnet-0f3208c0214c55e2e
 
   dynamic.linux-c8xlarge-arm64.type: aws
   dynamic.linux-c8xlarge-arm64.region: us-east-1
@@ -316,9 +316,9 @@ data:
   dynamic.linux-c8xlarge-arm64.key-name: kflux-prd-multi-p01-key-pair
   dynamic.linux-c8xlarge-arm64.aws-secret: aws-account
   dynamic.linux-c8xlarge-arm64.ssh-secret: aws-ssh-key
-  dynamic.linux-c8xlarge-arm64.security-group-id: sg-004ef1b7bc3ef1bca
+  dynamic.linux-c8xlarge-arm64.security-group-id: sg-0c67a834068be63d6
   dynamic.linux-c8xlarge-arm64.max-instances: "20"
-  dynamic.linux-c8xlarge-arm64.subnet-id: subnet-07a8bbf633e2bb187
+  dynamic.linux-c8xlarge-arm64.subnet-id: subnet-0f3208c0214c55e2e
 
   dynamic.linux-cxlarge-amd64.type: aws
   dynamic.linux-cxlarge-amd64.region: us-east-1
@@ -328,9 +328,9 @@ data:
   dynamic.linux-cxlarge-amd64.key-name: kflux-prd-multi-p01-key-pair
   dynamic.linux-cxlarge-amd64.aws-secret: aws-account
   dynamic.linux-cxlarge-amd64.ssh-secret: aws-ssh-key
-  dynamic.linux-cxlarge-amd64.security-group-id: sg-004ef1b7bc3ef1bca
+  dynamic.linux-cxlarge-amd64.security-group-id: sg-0c67a834068be63d6
   dynamic.linux-cxlarge-amd64.max-instances: "10"
-  dynamic.linux-cxlarge-amd64.subnet-id: subnet-07a8bbf633e2bb187
+  dynamic.linux-cxlarge-amd64.subnet-id: subnet-0f3208c0214c55e2e
 
   dynamic.linux-c2xlarge-amd64.type: aws
   dynamic.linux-c2xlarge-amd64.region: us-east-1
@@ -340,9 +340,9 @@ data:
   dynamic.linux-c2xlarge-amd64.key-name: kflux-prd-multi-p01-key-pair
   dynamic.linux-c2xlarge-amd64.aws-secret: aws-account
   dynamic.linux-c2xlarge-amd64.ssh-secret: aws-ssh-key
-  dynamic.linux-c2xlarge-amd64.security-group-id: sg-004ef1b7bc3ef1bca
+  dynamic.linux-c2xlarge-amd64.security-group-id: sg-0c67a834068be63d6
   dynamic.linux-c2xlarge-amd64.max-instances: "10"
-  dynamic.linux-c2xlarge-amd64.subnet-id: subnet-07a8bbf633e2bb187
+  dynamic.linux-c2xlarge-amd64.subnet-id: subnet-0f3208c0214c55e2e
 
   dynamic.linux-c4xlarge-amd64.type: aws
   dynamic.linux-c4xlarge-amd64.region: us-east-1
@@ -352,9 +352,9 @@ data:
   dynamic.linux-c4xlarge-amd64.key-name: kflux-prd-multi-p01-key-pair
   dynamic.linux-c4xlarge-amd64.aws-secret: aws-account
   dynamic.linux-c4xlarge-amd64.ssh-secret: aws-ssh-key
-  dynamic.linux-c4xlarge-amd64.security-group-id: sg-004ef1b7bc3ef1bca
+  dynamic.linux-c4xlarge-amd64.security-group-id: sg-0c67a834068be63d6
   dynamic.linux-c4xlarge-amd64.max-instances: "10"
-  dynamic.linux-c4xlarge-amd64.subnet-id: subnet-07a8bbf633e2bb187
+  dynamic.linux-c4xlarge-amd64.subnet-id: subnet-0f3208c0214c55e2e
 
   dynamic.linux-c8xlarge-amd64.type: aws
   dynamic.linux-c8xlarge-amd64.region: us-east-1
@@ -364,9 +364,9 @@ data:
   dynamic.linux-c8xlarge-amd64.key-name: kflux-prd-multi-p01-key-pair
   dynamic.linux-c8xlarge-amd64.aws-secret: aws-account
   dynamic.linux-c8xlarge-amd64.ssh-secret: aws-ssh-key
-  dynamic.linux-c8xlarge-amd64.security-group-id: sg-004ef1b7bc3ef1bca
+  dynamic.linux-c8xlarge-amd64.security-group-id: sg-0c67a834068be63d6
   dynamic.linux-c8xlarge-amd64.max-instances: "10"
-  dynamic.linux-c8xlarge-amd64.subnet-id: subnet-07a8bbf633e2bb187
+  dynamic.linux-c8xlarge-amd64.subnet-id: subnet-0f3208c0214c55e2e
 
   dynamic.linux-root-arm64.type: aws
   dynamic.linux-root-arm64.region: us-east-1
@@ -376,8 +376,8 @@ data:
   dynamic.linux-root-arm64.key-name: kflux-prd-multi-p01-key-pair
   dynamic.linux-root-arm64.aws-secret: aws-account
   dynamic.linux-root-arm64.ssh-secret: aws-ssh-key
-  dynamic.linux-root-arm64.security-group-id: sg-004ef1b7bc3ef1bca
-  dynamic.linux-root-arm64.subnet-id: subnet-07a8bbf633e2bb187
+  dynamic.linux-root-arm64.security-group-id: sg-0c67a834068be63d6
+  dynamic.linux-root-arm64.subnet-id: subnet-0f3208c0214c55e2e
   dynamic.linux-root-arm64.max-instances: "50"
   dynamic.linux-root-arm64.sudo-commands: "/usr/bin/podman"
   dynamic.linux-root-arm64.disk: "200"
@@ -393,8 +393,8 @@ data:
   dynamic.linux-fast-amd64.key-name: kflux-prd-multi-p01-key-pair
   dynamic.linux-fast-amd64.aws-secret: aws-account
   dynamic.linux-fast-amd64.ssh-secret: aws-ssh-key
-  dynamic.linux-fast-amd64.security-group-id: sg-004ef1b7bc3ef1bca
-  dynamic.linux-fast-amd64.subnet-id: subnet-07a8bbf633e2bb187
+  dynamic.linux-fast-amd64.security-group-id: sg-0c67a834068be63d6
+  dynamic.linux-fast-amd64.subnet-id: subnet-0f3208c0214c55e2e
   dynamic.linux-fast-amd64.max-instances: "10"
   dynamic.linux-fast-amd64.disk: "200"
   #  dynamic.linux-fast-amd64.iops: "16000"
@@ -408,8 +408,8 @@ data:
   dynamic.linux-extra-fast-amd64.key-name: kflux-prd-multi-p01-key-pair
   dynamic.linux-extra-fast-amd64.aws-secret: aws-account
   dynamic.linux-extra-fast-amd64.ssh-secret: aws-ssh-key
-  dynamic.linux-extra-fast-amd64.security-group-id: sg-004ef1b7bc3ef1bca
-  dynamic.linux-extra-fast-amd64.subnet-id: subnet-07a8bbf633e2bb187
+  dynamic.linux-extra-fast-amd64.security-group-id: sg-0c67a834068be63d6
+  dynamic.linux-extra-fast-amd64.subnet-id: subnet-0f3208c0214c55e2e
   dynamic.linux-extra-fast-amd64.max-instances: "10"
   dynamic.linux-extra-fast-amd64.disk: "200"
   # dynamic.linux-extra-fast-amd64.iops: "16000"
@@ -423,8 +423,8 @@ data:
   dynamic.linux-root-amd64.key-name: kflux-prd-multi-p01-key-pair
   dynamic.linux-root-amd64.aws-secret: aws-account
   dynamic.linux-root-amd64.ssh-secret: aws-ssh-key
-  dynamic.linux-root-amd64.security-group-id: sg-004ef1b7bc3ef1bca
-  dynamic.linux-root-amd64.subnet-id: subnet-07a8bbf633e2bb187
+  dynamic.linux-root-amd64.security-group-id: sg-0c67a834068be63d6
+  dynamic.linux-root-amd64.subnet-id: subnet-0f3208c0214c55e2e
   dynamic.linux-root-amd64.max-instances: "10"
   dynamic.linux-root-amd64.sudo-commands: "/usr/bin/podman"
   dynamic.linux-root-amd64.user-data: |-


### PR DESCRIPTION
I do not know where the ones we had configured came from but they are not the right ones, use the ones I found in MPC AWS account.