### PR TITLE
Add konflux-rhel-read-events to rhel cluster

### DIFF
--- a/components/konflux-rbac/production/kflux-rhel-p01/kustomization.yaml
+++ b/components/konflux-rbac/production/kflux-rhel-p01/kustomization.yaml
@@ -2,3 +2,4 @@ kind: Kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 resources:
   - ../base
+  - ./rhel

--- a/components/konflux-rbac/production/kflux-rhel-p01/rhel/konflux-rhel-read-events-role.yaml
+++ b/components/konflux-rbac/production/kflux-rhel-p01/rhel/konflux-rhel-read-events-role.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: konflux-rhel-read-events
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - get
+  - list
+  - watch

--- a/components/konflux-rbac/production/kflux-rhel-p01/rhel/kustomization.yaml
+++ b/components/konflux-rbac/production/kflux-rhel-p01/rhel/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- konflux-rhel-read-events-role.yaml


### PR DESCRIPTION
RHEL team needs to give permission on events to their automation so add this role to their dedicated cluster.

KFLUXINFR-1642