### PR TITLE
cost-management validate policy as ValidatingAdmissionPolicy

### DIFF
--- a/components/cost-management/staging/policies/validate-cost-management-labels-vap/.chainsaw-test/chainsaw-test.yaml
+++ b/components/cost-management/staging/policies/validate-cost-management-labels-vap/.chainsaw-test/chainsaw-test.yaml
@@ -1,0 +1,166 @@
+---
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: allow-namespace-with-cost-center
+spec:
+  concurrent: false
+  description: |
+    Tests that a namespace labeled as `konflux-ci.dev/type: tenant`
+    is allowed only if it has the `cost-center` label.
+  steps:
+    - name: Apply ValidatingAdmissionPolicy and ValidatingAdmissionPolicyBinding
+      try:
+        - create:
+            file: ../validate-cost-management-labels-vap.yaml
+        - apply:
+            file: ../validate-cost-management-labels-vapb.yaml
+        - sleep:
+            duration: 2s
+        - assert:
+            file: ./resources/expected-policy.yaml
+    - name: Create a tenant namespace with cost-center label
+      try:
+        - create:
+            file: ./resources/namespace-cost-center.yaml
+            template: true
+            bindings:
+              - name: namespace
+                value: tenant
+              - name: cost_center
+                value: "670"
+            expect:
+              - match:
+                  kind: Namespace
+                check:
+                  ($error == null): true
+---
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: allow-namespace-without-tenant-label
+spec:
+  concurrent: false
+  description: |
+    Tests that a namespace without the `konflux-ci.dev/type: tenant` label
+    is allowed regardless of the `cost-center` label.
+  steps:
+    - name: Apply ValidatingAdmissionPolicy and ValidatingAdmissionPolicyBinding
+      try:
+        - create:
+            file: ../validate-cost-management-labels-vap.yaml
+        - apply:
+            file: ../validate-cost-management-labels-vapb.yaml
+        - sleep:
+            duration: 2s
+        - assert:
+            file: ./resources/expected-policy.yaml
+    - name: Create a namespace without tenant label
+      try:
+        - create:
+            file: ./resources/namespace-nonmatching.yaml
+            expect:
+              - match:
+                  kind: Namespace
+                check:
+                  ($error == null): true
+---
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: deny-namespace-with-empty-cost-center
+spec:
+  concurrent: false
+  description: |
+    Tests that a namespace labeled as `konflux-ci.dev/type: tenant`
+    is denied if the `cost-center` label is empty.
+  steps:
+    - name: Apply ValidatingAdmissionPolicy and ValidatingAdmissionPolicyBinding
+      try:
+        - create:
+            file: ../validate-cost-management-labels-vap.yaml
+        - apply:
+            file: ../validate-cost-management-labels-vapb.yaml
+        - sleep:
+            duration: 2s
+        - assert:
+            file: ./resources/expected-policy.yaml
+    - name: Attempt to create a tenant namespace with empty cost-center label
+      try:
+        - create:
+            file: ./resources/namespace-empty-cost-center.yaml
+            expect:
+            - match:
+                kind: Namespace
+              check:
+                ($error != null): true
+---
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: deny-namespace-without-cost-center
+spec:
+  concurrent: false
+  description: |
+    Tests that a namespace labeled as `konflux-ci.dev/type: tenant`
+    is denied if it does not have the `cost-center` label.
+  steps:
+    - name: Apply ValidatingAdmissionPolicy and ValidatingAdmissionPolicyBinding
+      try:
+        - create:
+            file: ../validate-cost-management-labels-vap.yaml
+        - apply:
+            file: ../validate-cost-management-labels-vapb.yaml
+        - sleep:
+            duration: 2s
+        - assert:
+            file: ./resources/expected-policy.yaml
+    - name: Attempt to create a tenant namespace without cost-center label
+      try:
+        - create:
+            file: ./resources/namespace-no-cost-center.yaml
+            template: true
+            bindings:
+              - name: namespace
+                value: tenant-no-cost-center
+            expect:
+            - match:
+                kind: Namespace
+              check:
+                ($error != null): true
+---
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: deny-namespace-with-invalid-cost-center
+spec:
+  concurrent: false
+  description: |
+    Tests that a namespace labeled as `konflux-ci.dev/type: tenant`
+    is denied if the `cost-center` label is invalid.
+  steps:
+    - name: Apply ValidatingAdmissionPolicy and ValidatingAdmissionPolicyBinding
+      try:
+        - create:
+            file: ../validate-cost-management-labels-vap.yaml
+        - apply:
+            file: ../validate-cost-management-labels-vapb.yaml
+        - sleep:
+            duration: 2s
+        - assert:
+            file: ./resources/expected-policy.yaml
+    - name: Attempt to create a tenant namespace with invalid cost-center label
+      try:
+        - create:
+            file: ./resources/namespace-cost-center.yaml
+            template: true
+            bindings:
+              - name: namespace
+                value: tenant
+              - name: cost_center
+                value: "invalid-should-be-all-numbers"
+            expect:
+            - match:
+                kind: Namespace
+              check:
+                ($error != null): true

--- a/components/cost-management/staging/policies/validate-cost-management-labels-vap/.chainsaw-test/resources/expected-policy.yaml
+++ b/components/cost-management/staging/policies/validate-cost-management-labels-vap/.chainsaw-test/resources/expected-policy.yaml
@@ -1,0 +1,6 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: validate-cost-management-labels
+status:
+  observedGeneration: 1

--- a/components/cost-management/staging/policies/validate-cost-management-labels-vap/.chainsaw-test/resources/namespace-cost-center.yaml
+++ b/components/cost-management/staging/policies/validate-cost-management-labels-vap/.chainsaw-test/resources/namespace-cost-center.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ($namespace)
+  labels:
+    konflux-ci.dev/type: tenant
+    cost-center: ($cost_center)
+    insights_cost_management_optimizations: "true"

--- a/components/cost-management/staging/policies/validate-cost-management-labels-vap/.chainsaw-test/resources/namespace-empty-cost-center.yaml
+++ b/components/cost-management/staging/policies/validate-cost-management-labels-vap/.chainsaw-test/resources/namespace-empty-cost-center.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: tenant-empty-cost-center
+  labels:
+    konflux-ci.dev/type: tenant
+    cost-center: ""
+    insights_cost_management_optimizations: "true"

--- a/components/cost-management/staging/policies/validate-cost-management-labels-vap/.chainsaw-test/resources/namespace-no-cost-center.yaml
+++ b/components/cost-management/staging/policies/validate-cost-management-labels-vap/.chainsaw-test/resources/namespace-no-cost-center.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ($namespace)
+  labels:
+    konflux-ci.dev/type: tenant

--- a/components/cost-management/staging/policies/validate-cost-management-labels-vap/.chainsaw-test/resources/namespace-nonmatching.yaml
+++ b/components/cost-management/staging/policies/validate-cost-management-labels-vap/.chainsaw-test/resources/namespace-nonmatching.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: random-ns

--- a/components/cost-management/staging/policies/validate-cost-management-labels-vap/kustomization.yaml
+++ b/components/cost-management/staging/policies/validate-cost-management-labels-vap/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- validate-cost-management-labels-vap.yaml
+- validate-cost-management-labels-vapb.yaml

--- a/components/cost-management/staging/policies/validate-cost-management-labels-vap/validate-cost-management-labels-vap.yaml
+++ b/components/cost-management/staging/policies/validate-cost-management-labels-vap/validate-cost-management-labels-vap.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: validate-cost-management-labels
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+      - apiGroups: [""]
+        apiVersions: ["v1"]
+        operations: ["CREATE", "UPDATE"]
+        resources: ["namespaces"]
+  variables:
+    - name: costCenterLabel
+      expression: "'cost-center' in object.metadata.labels ? object.metadata.labels['cost-center'] : ''"
+  validations:
+    - expression: "variables.costCenterLabel != ''"
+      message: 'all tenant namespaces must have the cost-center label'
+    - expression: "variables.costCenterLabel.matches('^[0-9]+$')"
+      message: 'cost-center label can only contain numbers.'

--- a/components/cost-management/staging/policies/validate-cost-management-labels-vap/validate-cost-management-labels-vapb.yaml
+++ b/components/cost-management/staging/policies/validate-cost-management-labels-vap/validate-cost-management-labels-vapb.yaml
@@ -1,0 +1,11 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: validate-cost-management-labels
+spec:
+  policyName: validate-cost-management-labels
+  validationActions: [Deny]
+  matchResources:
+    objectSelector:
+      matchLabels:
+        konflux-ci.dev/type: tenant


### PR DESCRIPTION
Starting from Kubernetes 1.30 / OCP 4.17 we can use the kubernetes native ValidatingAdmissionPolicy for some validating policy.

> Validating admission policies offer a declarative, in-process alternative to validating admission webhooks.

This commit rewrites the cost-management validate namespace policy.

* https://docs.okd.io/4.17/rest_api/extension_apis/validatingadmissionpolicy-admissionregistration-k8s-io-v1.html
* https://kubernetes.io/docs/reference/access-authn-authz/validating-admission-policy/

Signed-off-by: Francesco Ilario <filario@redhat.com>
