### PR TITLE
KFLUXINFRA-1759: Update OCP DPA on stage

### DIFF
--- a/components/backup/staging/stone-stage-p01/dpa-channel-patch.yaml
+++ b/components/backup/staging/stone-stage-p01/dpa-channel-patch.yaml
@@ -1,0 +1,3 @@
+- op: replace
+  path: /spec/channel
+  value: stable-1.4

--- a/components/backup/staging/stone-stage-p01/kustomization.yaml
+++ b/components/backup/staging/stone-stage-p01/kustomization.yaml
@@ -23,3 +23,9 @@ patches:
       kind: DataProtectionApplication
       name: velero-aws
     path: dpa-kmskeyid-patch.yaml
+  - target:
+      group: operators.coreos.com
+      version: v1alpha1
+      kind: Subscription
+      name: redhat-oadp-operator
+    path: dpa-channel-patch.yaml

--- a/components/backup/staging/stone-stg-rh01/dpa-channel-patch.yaml
+++ b/components/backup/staging/stone-stg-rh01/dpa-channel-patch.yaml
@@ -1,0 +1,3 @@
+- op: replace
+  path: /spec/channel
+  value: stable-1.4

--- a/components/backup/staging/stone-stg-rh01/kustomization.yaml
+++ b/components/backup/staging/stone-stg-rh01/kustomization.yaml
@@ -21,3 +21,9 @@ patches:
       kind: DataProtectionApplication
       name: velero-aws
     path: dpa-kmskeyid-patch.yaml
+  - target:
+      group: operators.coreos.com
+      version: v1alpha1
+      kind: Subscription
+      name: redhat-oadp-operator
+    path: dpa-channel-patch.yaml


### PR DESCRIPTION
The update is required for upgrading the cluster to 4.16.

```
openshift-adp/oadp-operator.v1.3.6 is incompatible with OpenShift minor versions greater than 4.15
```