### PR TITLE
KFLUXINFRA-1763: Add apiGroup permissions to konflux-admin

### DIFF
--- a/components/authentication/base/konflux-admins.yaml
+++ b/components/authentication/base/konflux-admins.yaml
@@ -223,6 +223,7 @@ rules:
       - get
       - list
       - watch
+      - delete
   - apiGroups:
       - rbac.authorization.k8s.io
     resources:


### PR DESCRIPTION
This is needed in order to clean a clusterrolebinding
as part of a cleanup ([KFLUXINFRA-1627](https://issues.redhat.com//browse/KFLUXINFRA-1627)).