### PR TITLE
chore: give integration team permission to manage resolutionrequests

### DIFF
--- a/components/integration/base/kustomization.yaml
+++ b/components/integration/base/kustomization.yaml
@@ -3,6 +3,7 @@ resources:
 - argocd-permissions.yaml
 - delete-snapshots.yaml
 - manage-integrationtestscenarios.yaml
+- manage-resolutionrequests.yaml
 - integration.yaml
 - modify-pipelineruns-taskruns.yaml
 

--- a/components/integration/base/manage-resolutionrequests.yaml
+++ b/components/integration/base/manage-resolutionrequests.yaml
@@ -1,0 +1,28 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: manage-resolutionrequests
+rules:
+  - apiGroups:
+    - "resolution.tekton.dev"
+    resources:
+      - "resolutionrequests"
+    verbs:
+      - "create"
+      - "get"
+      - "list"
+      - "watch"
+      - "delete"
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: manage-resolutionrequests
+subjects:
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: konflux-integration
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: manage-resolutionrequests


### PR DESCRIPTION
Now that the integration service is creating resolutionrequests the integration team needs to be able to manage  resolutionrequests in order to debug issues that arise on the cluster