### PR TITLE
KubeArchive: fix broken staging deployment

### DIFF
--- a/argo-cd-apps/base/member/infra-deployments/kubearchive/kubearchive.yaml
+++ b/argo-cd-apps/base/member/infra-deployments/kubearchive/kubearchive.yaml
@@ -16,8 +16,10 @@ spec:
                 clusterDir: ""
           - list:
               elements:
-                - nameNormalized: stone-stage-p01
-                  values.clusterDir: stone-stage-p01
+                # - nameNormalized: stone-stage-p01
+                #   values.clusterDir: stone-stage-p01
+                - nameNormalized: stone-stage-rh01
+                  values.clusterDir: stone-stage-rh01
                 # Private
                 # - nameNormalized: kflux-ocp-p01
                 #   values.clusterDir: kflux-ocp-p01


### PR DESCRIPTION
When installing KubeArchive on production we changed the layout of the folders, it worked properly for production but not for staging. This PR aims to fix that.