### PR TITLE
KubeArchive: remove it from UI config

### DIFF
--- a/components/konflux-ui/production/base/proxy/nginx.conf
+++ b/components/konflux-ui/production/base/proxy/nginx.conf
@@ -158,15 +158,6 @@ http {
             include /mnt/nginx-generated-config/auth.conf;
         }
 
-        location /api/k8s/plugins/kubearchive/ {
-            auth_request /oauth2/auth;
-
-            rewrite /api/k8s/plugins/kubearchive/(.+) /$1 break;
-            proxy_read_timeout 30m;
-            include /mnt/nginx-generated-config/kubearchive.conf;
-            include /mnt/nginx-generated-config/auth.conf;
-        }
-
         # GET requests to /api/k8s/api/v1/namespaces and /api/k8s/api/v1/namespaces/
         # are handled from the namespace-lister.
         # Requests with other methods are handled by the Kube-API

--- a/components/konflux-ui/production/base/proxy/proxy.yaml
+++ b/components/konflux-ui/production/base/proxy/proxy.yaml
@@ -80,10 +80,6 @@ spec:
             echo \
               "proxy_pass ${TEKTON_RESULTS_URL:?tekton results url must be provided};" \
               > /mnt/nginx-generated-config/tekton-results.conf
-            
-            echo \
-              "proxy_pass ${KUBEARCHIVE_URL:?kubearchive url must be provided};" \
-              > /mnt/nginx-generated-config/kubearchive.conf
 
         volumeMounts:
         - name: nginx-generated-config

--- a/components/konflux-ui/production/kflux-ocp-p01/kustomization.yaml
+++ b/components/konflux-ui/production/kflux-ocp-p01/kustomization.yaml
@@ -13,7 +13,6 @@ configMapGenerator:
     literals:
       - IMPERSONATE=true
       - TEKTON_RESULTS_URL=https://tekton-results-api-service.tekton-results.svc.cluster.local:8080
-      - KUBEARCHIVE_URL=https://kubearchive-api-server.product-kubearchive.svc.cluster.local:8081
 
 patches:
   - path: add-service-certs-patch.yaml

--- a/components/konflux-ui/production/kflux-prd-rh02/kustomization.yaml
+++ b/components/konflux-ui/production/kflux-prd-rh02/kustomization.yaml
@@ -13,7 +13,6 @@ configMapGenerator:
     literals:
       - IMPERSONATE=true
       - TEKTON_RESULTS_URL=https://tekton-results-api-service.tekton-results.svc.cluster.local:8080
-      - KUBEARCHIVE_URL=https://kubearchive-api-server.product-kubearchive.svc.cluster.local:8081
 
 patches:
   - path: add-service-certs-patch.yaml

--- a/components/konflux-ui/production/kflux-prd-rh03/kustomization.yaml
+++ b/components/konflux-ui/production/kflux-prd-rh03/kustomization.yaml
@@ -12,7 +12,6 @@ configMapGenerator:
     literals:
       - IMPERSONATE=true
       - TEKTON_RESULTS_URL=https://tekton-results-api-service.tekton-results.svc.cluster.local:8080
-      - KUBEARCHIVE_URL=https://kubearchive-api-server.product-kubearchive.svc.cluster.local:8081
 
 patches:
   - path: add-service-certs-patch.yaml

--- a/components/konflux-ui/production/stone-prd-rh01/kustomization.yaml
+++ b/components/konflux-ui/production/stone-prd-rh01/kustomization.yaml
@@ -13,7 +13,6 @@ configMapGenerator:
     literals:
       - IMPERSONATE=true
       - TEKTON_RESULTS_URL=https://tekton-results-api-service.tekton-results.svc.cluster.local:8080
-      - KUBEARCHIVE_URL=https://kubearchive-api-server.product-kubearchive.svc.cluster.local:8081
 
 patches:
   - path: add-service-certs-patch.yaml

--- a/components/konflux-ui/production/stone-prod-p01/kustomization.yaml
+++ b/components/konflux-ui/production/stone-prod-p01/kustomization.yaml
@@ -13,7 +13,6 @@ configMapGenerator:
     literals:
       - IMPERSONATE=true
       - TEKTON_RESULTS_URL=https://tekton-results-api-service.tekton-results.svc.cluster.local:8080
-      - KUBEARCHIVE_URL=https://kubearchive-api-server.product-kubearchive.svc.cluster.local:8081
 
 patches:
   - path: add-service-certs-patch.yaml


### PR DESCRIPTION
Removing KubeArchive from UI configuration on production clusters, as KubeArchive is not installed on all production clusters, just p02. So this causes the proxy to CrashLoopBackOff because there is no host for nginx to communicate to.