### PR TITLE
KubeArchive: don't configure UI for p01

### DIFF
--- a/components/konflux-ui/staging/base/proxy/nginx.conf
+++ b/components/konflux-ui/staging/base/proxy/nginx.conf
@@ -96,16 +96,6 @@ http {
             include /mnt/nginx-generated-config/auth.conf;
         }
 
-
-        location /api/k8s/plugins/kubearchive/ {
-            auth_request /oauth2/auth;
-
-            rewrite /api/k8s/plugins/kubearchive/(.+) /$1 break;
-            proxy_read_timeout 30m;
-            include /mnt/nginx-generated-config/kubearchive.conf;
-            include /mnt/nginx-generated-config/auth.conf;
-        }
-
         # GET requests to /api/k8s/api/v1/namespaces and /api/k8s/api/v1/namespaces/
         # are handled from the namespace-lister.
         # Requests with other methods are handled by the Kube-API
@@ -145,5 +135,6 @@ http {
         }
 
         include /mnt/nginx-additional-location-configs/*.conf;
+        include /mnt/nginx-generated-config/kubearchive.conf;
     }
 }

--- a/components/konflux-ui/staging/base/proxy/proxy.yaml
+++ b/components/konflux-ui/staging/base/proxy/proxy.yaml
@@ -81,9 +81,17 @@ spec:
               "proxy_pass ${TEKTON_RESULTS_URL:?tekton results url must be provided};" \
               > /mnt/nginx-generated-config/tekton-results.conf
             
-            echo \
-              "proxy_pass ${KUBEARCHIVE_URL:?kubearchive url must be provided};" \
-              > /mnt/nginx-generated-config/kubearchive.conf
+            if [[ "$KUBEARCHIVE_URL" != "" ]]; then
+              echo "location /api/k8s/plugins/kubearchive/ {" >> /mnt/nginx-generated-config/kubearchive.conf
+              echo "auth_request /oauth2/auth;" >> /mnt/nginx-generated-config/kubearchive.conf
+              echo "rewrite /api/k8s/plugins/kubearchive/(.+) /$1 break;" >> /mnt/nginx-generated-config/kubearchive.conf
+              echo "proxy_read_timeout 30m;" >> /mnt/nginx-generated-config/kubearchive.conf
+              echo "proxy_pass ${KUBEARCHIVE_URL};" >> /mnt/nginx-generated-config/kubearchive.conf
+              echo "include /mnt/nginx-generated-config/auth.conf;" >> /mnt/nginx-generated-config/kubearchive.conf
+              echo "}" > /mnt/nginx-generated-config/kubearchive.conf
+            else
+              echo "# KubeArchive disabled by config" > /mnt/nginx-generated-config/kubearchive.conf
+            fi
 
         volumeMounts:
         - name: nginx-generated-config

--- a/components/konflux-ui/staging/stone-stage-p01/kustomization.yaml
+++ b/components/konflux-ui/staging/stone-stage-p01/kustomization.yaml
@@ -13,7 +13,6 @@ configMapGenerator:
   literals:
     - IMPERSONATE=true
     - TEKTON_RESULTS_URL=https://tekton-results-api-service.tekton-results.svc.cluster.local:8080
-    - KUBEARCHIVE_URL=https://kubearchive-api-server.product-kubearchive.svc.cluster.local:8081
 
 patches:
 - path: add-service-certs-patch.yaml


### PR DESCRIPTION
This PR introduces a condition that if the KUBEARCHIVE_URL is not set, the `proxy_pass` is not set for NGINX.