### PR TITLE
KubeArchive: fix UI proxy config for positive case

### DIFF
--- a/components/konflux-ui/staging/base/proxy/proxy.yaml
+++ b/components/konflux-ui/staging/base/proxy/proxy.yaml
@@ -82,13 +82,13 @@ spec:
               > /mnt/nginx-generated-config/tekton-results.conf
             
             if [[ "$KUBEARCHIVE_URL" != "" ]]; then
-              echo "location /api/k8s/plugins/kubearchive/ {" >> /mnt/nginx-generated-config/kubearchive.conf
+              echo "location /api/k8s/plugins/kubearchive/ {" > /mnt/nginx-generated-config/kubearchive.conf
               echo "auth_request /oauth2/auth;" >> /mnt/nginx-generated-config/kubearchive.conf
               echo "rewrite /api/k8s/plugins/kubearchive/(.+) /$1 break;" >> /mnt/nginx-generated-config/kubearchive.conf
               echo "proxy_read_timeout 30m;" >> /mnt/nginx-generated-config/kubearchive.conf
               echo "proxy_pass ${KUBEARCHIVE_URL};" >> /mnt/nginx-generated-config/kubearchive.conf
               echo "include /mnt/nginx-generated-config/auth.conf;" >> /mnt/nginx-generated-config/kubearchive.conf
-              echo "}" > /mnt/nginx-generated-config/kubearchive.conf
+              echo "}" >> /mnt/nginx-generated-config/kubearchive.conf
             else
               echo "# KubeArchive disabled by config" > /mnt/nginx-generated-config/kubearchive.conf
             fi


### PR DESCRIPTION
I introduced a typo, instead of `>>` I wrote `>` leading to the NGINX configuration file for kubearchive just contain `}`, causing the proxy to fail at startup.