### PR TITLE
Remove the operations key from generate rule

### DIFF
--- a/components/kueue/staging/base/queue-config/cluster-policy.yaml
+++ b/components/kueue/staging/base/queue-config/cluster-policy.yaml
@@ -14,9 +14,6 @@ spec:
           selector:
             matchLabels:
               konflux-ci.dev/type: tenant
-          operations:
-            - CREATE
-            - UPDATE
     generate:
       generateExisting: true
       synchronize: true


### PR DESCRIPTION
The operations key isn't required for generating rules.