### PR TITLE
KubeArchive: fix always out of sync

### DIFF
--- a/argo-cd-apps/base/member/infra-deployments/kubearchive/kubearchive.yaml
+++ b/argo-cd-apps/base/member/infra-deployments/kubearchive/kubearchive.yaml
@@ -49,6 +49,11 @@ spec:
         # not specifcy namespace
         namespace: product-kubearchive
         server: "{{server}}"
+      ignoreDifferences:
+        # Secret get modified by ExternalSecrets operator
+        - group: ""
+          kind: Secret
+          name: kubearchive-database-credentials
       syncPolicy:
         automated:
           prune: true


### PR DESCRIPTION
ArgoCD shows that KubeArchive is always out of sync because the DB secrets keeps being changed by the ExternalSecrets operator and needs to be reestablished to its original content. This is not the case, so we will ignore the differences from now on.