### PR TITLE
Update rhel-p01 smee-client server path

### DIFF
--- a/components/smee-client/production/kflux-rhel-p01/sever-url-patch.yaml
+++ b/components/smee-client/production/kflux-rhel-p01/sever-url-patch.yaml
@@ -1,4 +1,4 @@
 ---
 - op: replace
   path: /spec/template/spec/containers/0/args/1
-  value: "https://smee-smee.apps.stone-prd-host1.wdlc.p1.openshiftapps.com/redhathookp01"
+  value: "https://smee-smee.apps.stone-prd-host1.wdlc.p1.openshiftapps.com/redhathook15"


### PR DESCRIPTION
The rhel-p01 cluster's smee server URL path was not consistent with what was in use on the cluster, so the GitHub app was not functioning properly. This commit fixes that.