### PR TITLE
add deployment visibility to konflux-info

### DIFF
--- a/components/konflux-info/production/kflux-ocp-p01/info.json
+++ b/components/konflux-info/production/kflux-ocp-p01/info.json
@@ -49,5 +49,6 @@
                 "name": "konflux-contributor-user-actions"
             }
         }
-    ]
+    ],
+    "visibility": "private"
 }

--- a/components/konflux-info/production/kflux-prd-rh02/info.json
+++ b/components/konflux-info/production/kflux-prd-rh02/info.json
@@ -49,5 +49,6 @@
                 "name": "konflux-contributor-user-actions"
             }
         }
-    ]
+    ],
+    "visibility": "public"
 }

--- a/components/konflux-info/production/kflux-prd-rh03/info.json
+++ b/components/konflux-info/production/kflux-prd-rh03/info.json
@@ -49,5 +49,6 @@
                 "name": "konflux-contributor-user-actions"
             }
         }
-    ]
+    ],
+    "visibility": "public"
 }

--- a/components/konflux-info/production/kflux-rhel-p01/info.json
+++ b/components/konflux-info/production/kflux-rhel-p01/info.json
@@ -49,5 +49,6 @@
                 "name": "konflux-contributor-user-actions"
             }
         }
-    ]
+    ],
+    "visibility": "private"
 }

--- a/components/konflux-info/production/stone-prd-rh01/info.json
+++ b/components/konflux-info/production/stone-prd-rh01/info.json
@@ -49,5 +49,6 @@
                 "name": "konflux-contributor-user-actions"
             }
         }
-    ]
+    ],
+    "visibility": "public"
 }

--- a/components/konflux-info/production/stone-prod-p01/info.json
+++ b/components/konflux-info/production/stone-prod-p01/info.json
@@ -49,5 +49,6 @@
                 "name": "konflux-contributor-user-actions"
             }
         }
-    ]
+    ],
+    "visibility": "private"
 }

--- a/components/konflux-info/production/stone-prod-p02/info.json
+++ b/components/konflux-info/production/stone-prod-p02/info.json
@@ -49,5 +49,6 @@
                 "name": "konflux-contributor-user-actions"
             }
         }
-    ]
+    ],
+    "visibility": "private"
 }

--- a/components/konflux-info/staging/stone-stage-p01/info.json
+++ b/components/konflux-info/staging/stone-stage-p01/info.json
@@ -49,5 +49,6 @@
                 "name": "konflux-contributor-user-actions"
             }
         }
-    ]
+    ],
+    "visibility": "private"
 }

--- a/components/konflux-info/staging/stone-stg-rh01/info.json
+++ b/components/konflux-info/staging/stone-stg-rh01/info.json
@@ -49,5 +49,6 @@
                 "name": "konflux-contributor-user-actions"
             }
         }
-    ]
+    ],
+    "visibility": "public"
 }

--- a/hack/new-cluster/templates/konflux-info/info.json
+++ b/hack/new-cluster/templates/konflux-info/info.json
@@ -49,5 +49,6 @@
                 "name": "konflux-contributor-user-actions"
             }
         }
-    ]
+    ],
+    "visibility": "public"
 }


### PR DESCRIPTION
related to [KONFLUX-8558](https://issues.redhat.com/browse/KONFLUX-8558), it is beneficial for the UI to be able to differentiate, if the current deployment is public or private