### PR TITLE
Add rhel-p01 entry to smee client

### DIFF
--- a/argo-cd-apps/base/smee-client/smee-client.yaml
+++ b/argo-cd-apps/base/smee-client/smee-client.yaml
@@ -24,6 +24,8 @@ spec:
                   values.clusterDir: stone-prod-p01
                 - nameNormalized: stone-prod-p02
                   values.clusterDir: stone-prod-p02
+                - nameNormalized: kflux-rhel-p01
+                  values.clusterDir: kflux-rhel-p01
   template:
     metadata:
       name: smee-client-{{nameNormalized}}


### PR DESCRIPTION
Adds the kflux-rhel-p01 cluster to the smee client so the Konflux app can be utilized.