### PR TITLE
Automate adding NAT Gateway IPs to smee allow list

### DIFF
--- a/hack/new-cluster/playbook.yaml
+++ b/hack/new-cluster/playbook.yaml
@@ -38,6 +38,7 @@
     smee_webhook_server_slug: "{{ (env == 'staging') | ternary('stone-stg-host.qc0p.p1', 'stone-prd-host1.wdlc.p1') }}"
     smee_webhook_server: "https://smee-smee.apps.{{ smee_webhook_server_slug }}.openshiftapps.com"
     smee_webhook_url: "{{ smee_webhook_server }}/redhathook{{cutename}}"
+    smee_ip_allow_list_file: "{{ dst }}/components/smee/{{ env }}/ip-allow-list.yaml"
 
     required_vars:
       - shortname
@@ -139,6 +140,36 @@
       loop: "{{ argo_cd_app_files }}"
       loop_control:
         loop_var: filename
+        
+    - name: Get NAT Gateway Public IPs for smee
+      tags: [smee-ips]
+      include_tasks: tasks/aws/smee-ips.yaml
+    
+    - name: Get current content of {{ env }} smee IP allow list
+      # If the path does not exist, yq will return an empty string to stdout.
+      command: yq '.[0].value' {{ smee_ip_allow_list_file }}
+      register: current_ip_allow_list
+      changed_when: false # This task only reads data, it doesn't change anything.
+
+    - name: Add the NAT Gateway Public IPs to the {{ env }} IP allow list
+      # This task executes only if the current content in the file
+      # does not contain ALL of the desired 'ips' list content.
+      # It will modify the file in place and pass the multi-line IP list via
+      # an environment variable.
+      vars:
+        ips_to_add: "{{ hostvars['localhost']['nat_gateway_ips'] }}"
+        current_ips: " {{ current_ip_allow_list.stdout.strip().split('\n')}} "
+
+      command: |
+          yq -i eval '.[0].value = strenv(IP_LIST_VAR)' {{ smee_ip_allow_list_file }}
+      environment:
+        # Pass the collected IPs (now a host fact) as a joined multi-line string
+        IP_LIST_VAR: "{{ ips_to_add | join('\n') }}"
+      when: >- 
+        ({{ ips_to_add }} | unique | difference( current_ips | unique)) | length > 0
+      # This task is considered changed when its 'when' condition is met,
+      # indicating that 'yq' has modified the file.
+      changed_when: true
 
     - name: Copy cluster-specific component manifests
       tags: [components]

--- a/hack/new-cluster/tasks/aws/smee-ips.yaml
+++ b/hack/new-cluster/tasks/aws/smee-ips.yaml
@@ -1,0 +1,70 @@
+---
+- name: Get NAT Gateway Public IPs for ROSA VPC
+  hosts: localhost # This task runs on the Ansible control machine
+  connection: local # Use local connection as we are interacting with AWS API directly
+  gather_facts: false
+
+  # Ensure the community.aws collection is installed:
+  # ansible-galaxy collection install community.aws
+
+  vars:
+    aws_region: us-east-1
+    nat_gateway_ips: []
+
+  tasks:
+    - name: Get all VPCs in the specified region
+      community.aws.ec2_vpc_info:
+        region: "{{ aws_region }}"
+      register: vpcs_info
+      tags: [ 'smee-ips' ]
+
+    - name: Find the VPC named '{{ shortname }}-rosa'
+      set_fact:
+        target_vpc_id: "{{ item.id }}"
+      loop: "{{ vpcs_info.vpcs }}"
+      when:
+        - item.tags is defined
+        - item.tags.Name is defined
+        - item.tags.Name | lower == (shortname | lower) + '-rosa'
+      # This task will set target_vpc_id to the ID of the first matching VPC found.
+      # If multiple VPCs match the exact name, only the first one will be used.
+      tags: [ 'smee-ips' ]
+
+    - name: Fail if no VPC named '{{ shortname }}-rosa' was found
+      ansible.builtin.fail:
+        msg: "No VPC found with the name '{{ shortname }}-rosa' in region {{ aws_region }}."
+      when: target_vpc_id is not defined
+      tags: [ 'smee-ips' ]
+
+    - name: Debug - Found VPC ID
+      ansible.builtin.debug:
+        msg: "Found target VPC ID: {{ target_vpc_id }} (matching name '{{ shortname }}-rosa')"
+      when: target_vpc_id is defined
+      tags: [ 'smee-ips' ]
+
+    - name: Get all NAT Gateways for the target VPC
+      community.aws.ec2_vpc_nat_gateway_info:
+        region: "{{ aws_region }}"
+        filters:
+          vpc-id: "{{ target_vpc_id }}"
+      register: nat_gateways_info
+      tags: [ 'smee-ips' ]
+
+    - name: Extract public IPs for each NAT Gateway
+      set_fact:
+        nat_gateway_ips: "{{ nat_gateway_ips + [item.nat_gateway_addresses[0].public_ip] }}"
+      loop: "{{ nat_gateways_info.nat_gateways }}"
+      when:
+        - item.state == 'available' # Only consider available NAT Gateways
+        - item.nat_gateway_addresses is defined
+        - item.nat_gateway_addresses | length > 0
+        - item.nat_gateway_addresses[0].public_ip is defined
+      tags: [ 'smee-ips' ]
+
+    - name: Debug - Collected NAT Gateway IPs and check count
+      ansible.builtin.debug:
+        msg:
+          - "Collected NAT Gateway Public IPs: {{ nat_gateway_ips }}"
+          - "{{ 'WARNING: Expected 3 NAT Gateways, but found ' + (nat_gateway_ips | length | string) + '.' if nat_gateway_ips | length != 3 else '' }}"
+      when: nat_gateway_ips is defined # Ensure the variable is defined before attempting to access its length
+      tags: [ 'smee-ips' ]


### PR DESCRIPTION
This adds a task to communicate with AWS and get the cluster VPC's NAT Gateway IPs and adds some tasks to the main playbook to add the retrieved IPs if they do not already exist in the the cluster's smee IP allow list.

Assisted-by: Gemini