### PR TITLE
Add required sudo command into config

### DIFF
--- a/components/multi-platform-controller/production-downstream/kflux-rhel-p01/host-config.yaml
+++ b/components/multi-platform-controller/production-downstream/kflux-rhel-p01/host-config.yaml
@@ -379,7 +379,7 @@ data:
   dynamic.linux-root-arm64.security-group-id: sg-0c67a834068be63d6
   dynamic.linux-root-arm64.subnet-id: subnet-0f3208c0214c55e2e
   dynamic.linux-root-arm64.max-instances: "50"
-  dynamic.linux-root-arm64.sudo-commands: "/usr/bin/podman"
+  dynamic.linux-root-arm64.sudo-commands: "/usr/bin/podman, /usr/bin/rm /usr/share/containers/mounts.conf"
   dynamic.linux-root-arm64.disk: "200"
   dynamic.linux-root-arm64.iops: "16000"
   dynamic.linux-root-arm64.throughput: "1000"
@@ -426,7 +426,7 @@ data:
   dynamic.linux-root-amd64.security-group-id: sg-0c67a834068be63d6
   dynamic.linux-root-amd64.subnet-id: subnet-0f3208c0214c55e2e
   dynamic.linux-root-amd64.max-instances: "10"
-  dynamic.linux-root-amd64.sudo-commands: "/usr/bin/podman"
+  dynamic.linux-root-amd64.sudo-commands: "/usr/bin/podman, /usr/bin/rm /usr/share/containers/mounts.conf"
   dynamic.linux-root-amd64.user-data: |-
     Content-Type: multipart/mixed; boundary="//"
     MIME-Version: 1.0

--- a/components/multi-platform-controller/production/kflux-prd-rh02/host-config.yaml
+++ b/components/multi-platform-controller/production/kflux-prd-rh02/host-config.yaml
@@ -463,7 +463,7 @@ data:
   dynamic.linux-root-arm64.security-group-id: sg-004ef1b7bc3ef1bca
   dynamic.linux-root-arm64.subnet-id: subnet-07a8bbf633e2bb187
   dynamic.linux-root-arm64.max-instances: "50"
-  dynamic.linux-root-arm64.sudo-commands: "/usr/bin/podman"
+  dynamic.linux-root-arm64.sudo-commands: "/usr/bin/podman, /usr/bin/rm /usr/share/containers/mounts.conf"
   dynamic.linux-root-arm64.disk: "200"
   dynamic.linux-root-arm64.iops: "16000"
   dynamic.linux-root-arm64.throughput: "1000"
@@ -510,7 +510,7 @@ data:
   dynamic.linux-root-amd64.security-group-id: sg-004ef1b7bc3ef1bca
   dynamic.linux-root-amd64.subnet-id: subnet-07a8bbf633e2bb187
   dynamic.linux-root-amd64.max-instances: "10"
-  dynamic.linux-root-amd64.sudo-commands: "/usr/bin/podman"
+  dynamic.linux-root-amd64.sudo-commands: "/usr/bin/podman, /usr/bin/rm /usr/share/containers/mounts.conf"
   dynamic.linux-root-amd64.user-data: |-
     Content-Type: multipart/mixed; boundary="//"
     MIME-Version: 1.0

--- a/components/multi-platform-controller/production/kflux-prd-rh03/host-config.yaml
+++ b/components/multi-platform-controller/production/kflux-prd-rh03/host-config.yaml
@@ -379,7 +379,7 @@ data:
   dynamic.linux-root-arm64.security-group-id: sg-0759f4a43faada557
   dynamic.linux-root-arm64.subnet-id: subnet-0263af86f44821eac
   dynamic.linux-root-arm64.max-instances: "50"
-  dynamic.linux-root-arm64.sudo-commands: "/usr/bin/podman"
+  dynamic.linux-root-arm64.sudo-commands: "/usr/bin/podman, /usr/bin/rm /usr/share/containers/mounts.conf"
   dynamic.linux-root-arm64.disk: "200"
   dynamic.linux-root-arm64.iops: "16000"
   dynamic.linux-root-arm64.throughput: "1000"
@@ -426,7 +426,7 @@ data:
   dynamic.linux-root-amd64.security-group-id: sg-0759f4a43faada557
   dynamic.linux-root-amd64.subnet-id: subnet-0263af86f44821eac
   dynamic.linux-root-amd64.max-instances: "10"
-  dynamic.linux-root-amd64.sudo-commands: "/usr/bin/podman"
+  dynamic.linux-root-amd64.sudo-commands: "/usr/bin/podman, /usr/bin/rm /usr/share/containers/mounts.conf"
   dynamic.linux-root-amd64.user-data: |-
     Content-Type: multipart/mixed; boundary="//"
     MIME-Version: 1.0

--- a/components/multi-platform-controller/production/stone-prd-rh01/host-config.yaml
+++ b/components/multi-platform-controller/production/stone-prd-rh01/host-config.yaml
@@ -467,7 +467,7 @@ data:
   dynamic.linux-root-arm64.security-group-id: sg-0fbf35ced0d59fd4a
   dynamic.linux-root-arm64.subnet-id: subnet-0c39ff75f819abfc5
   dynamic.linux-root-arm64.max-instances: "50"
-  dynamic.linux-root-arm64.sudo-commands: "/usr/bin/podman"
+  dynamic.linux-root-arm64.sudo-commands: "/usr/bin/podman, /usr/bin/rm /usr/share/containers/mounts.conf"
   dynamic.linux-root-arm64.disk: "200"
   dynamic.linux-root-arm64.iops: "16000"
   dynamic.linux-root-arm64.throughput: "1000"
@@ -514,7 +514,7 @@ data:
   dynamic.linux-root-amd64.security-group-id: sg-0fbf35ced0d59fd4a
   dynamic.linux-root-amd64.subnet-id: subnet-0c39ff75f819abfc5
   dynamic.linux-root-amd64.max-instances: "10"
-  dynamic.linux-root-amd64.sudo-commands: "/usr/bin/podman"
+  dynamic.linux-root-amd64.sudo-commands: "/usr/bin/podman, /usr/bin/rm /usr/share/containers/mounts.conf"
   dynamic.linux-root-amd64.user-data: |-
     Content-Type: multipart/mixed; boundary="//"
     MIME-Version: 1.0


### PR DESCRIPTION
Not all our clusters configured equally,
some have a missing the  `sudo rm`  command admittance in order to run [build-vm-image](https://github.com/konflux-ci/build-definitions/blob/main/task/build-vm-image/0.1/build-vm-image.yaml#L205) task
