### PR TITLE
Knative Eventing: Upgrade to improve memory usage

### DIFF
--- a/components/knative-eventing/base/kustomization.yaml
+++ b/components/knative-eventing/base/kustomization.yaml
@@ -2,7 +2,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - https://github.com/knative/eventing/releases/download/knative-v1.15.3/eventing.yaml?timeout=90s
+  - https://github.com/knative/eventing/releases/download/knative-v1.16.7/eventing.yaml?timeout=90s
 
 patches:
 # kube-lint fixes
@@ -42,7 +42,7 @@ patches:
                   memory: 100Mi
                 limits:
                   cpu: 150m
-                  memory: 200Mi
+                  memory: 320Mi
 
 - patch: |-
     apiVersion: apps/v1


### PR DESCRIPTION
* Increased memory limit as well because the pod keeps being restarted on production, testing first on staging.