### PR TITLE
Optimize timeouts for Tekton Results Watcher

### DIFF
--- a/components/pipeline-service/development/main-pipeline-service-configuration.yaml
+++ b/components/pipeline-service/development/main-pipeline-service-configuration.yaml
@@ -1593,6 +1593,7 @@ spec:
             - token
             - -check_owner=false
             - -completed_run_grace_period=2h
+            - -requeue_interval=2m
             - -store_deadline=1m
             - -forward_buffer=1m
             - -threadiness=32

--- a/components/pipeline-service/staging/base/main-pipeline-service-configuration.yaml
+++ b/components/pipeline-service/staging/base/main-pipeline-service-configuration.yaml
@@ -1504,8 +1504,10 @@ spec:
             - -auth_mode
             - token
             - -check_owner=false
-            - -completed_run_grace_period
-            - 10m
+            - -completed_run_grace_period=5m
+            - -requeue_interval=2m
+            - -store_deadline=30m
+            - -forward_buffer=1m
             - -threadiness=32
             - -logs_api=true
           env:

--- a/components/pipeline-service/staging/stone-stage-p01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stage-p01/deploy.yaml
@@ -1939,8 +1939,10 @@ spec:
         - -auth_mode
         - token
         - -check_owner=false
-        - -completed_run_grace_period
-        - 10m
+        - -completed_run_grace_period=5m
+        - -requeue_interval=2m
+        - -store_deadline=30m
+        - -forward_buffer=1m
         - -threadiness=32
         - -logs_api=true
         env:

--- a/components/pipeline-service/staging/stone-stg-rh01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stg-rh01/deploy.yaml
@@ -1939,8 +1939,10 @@ spec:
         - -auth_mode
         - token
         - -check_owner=false
-        - -completed_run_grace_period
-        - 10m
+        - -completed_run_grace_period=5m
+        - -requeue_interval=2m
+        - -store_deadline=30m
+        - -forward_buffer=1m
         - -threadiness=32
         - -logs_api=true
         env:


### PR DESCRIPTION
Decreasing the completed runs grace period will help with the etcd pressure.
The requeue interval (default 10m) was too long and it applies to finished pipelineruns, so we can retry faster.
The store deadline (default 10m) was matching the completed runs grace period which I think does not make much sense, especially given issues with taskruns not being stored. Increasing that value will  help, but could lead to pipelineruns kept on the cluster for longer. If that happens, we need to find the reason and fix that, as this is the final resort to remove stale pipelineruns.
With the current Vector configuration which is well optimized, logs are stored quite quickly (few secs delay), so there is no reason to wait that long. Once applied, we can check for logs not being stored and eventually decrease that value even further.
For the development overlay, the completed_run_grace_period was set to 2h. I'm not sure why such high value and the history is lost as we moved the configuration from the old pipeline-service repo as a single commit, but I'll try to find more and eventually set to match staging.