### PR TITLE
feat: enable emptyDir for fbc-release

### DIFF
--- a/components/release/development/release_service_config.yaml
+++ b/components/release/development/release_service_config.yaml
@@ -17,3 +17,6 @@ spec:
     - url: ".*"
       revision: ".*"
       pathInRepo: "pipelines/managed/push-to-external-registry/push-to-external-registry.yaml"
+    - url: ".*"
+      revision: ".*"
+      pathInRepo: "pipelines/managed/fbc-release/fbc-release.yaml"


### PR DESCRIPTION
- enable emtpyDir for fbc-release pipeline

Signed-off-by: Scott Hebert <scoheb@gmail.com>

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED