### PR TITLE
fix(STONEINTG-1259): disable integration leader election

### DIFF
--- a/components/integration/development/manager_resources_patch.yaml
+++ b/components/integration/development/manager_resources_patch.yaml
@@ -8,6 +8,8 @@ spec:
     spec:
       containers:
       - name: manager
+        args:
+          - "--leader-elect=false"
         imagePullPolicy: Always
         resources:
           limits:

--- a/components/integration/staging/base/manager_resources_patch.yaml
+++ b/components/integration/staging/base/manager_resources_patch.yaml
@@ -8,6 +8,8 @@ spec:
     spec:
       containers:
       - name: manager
+        args:
+          - "--leader-elect=false"
         resources:
           limits:
             cpu: 500m


### PR DESCRIPTION
* Disable the leader election for the integration service controller manager in staging/development
* The leader election is not needed for the integration service at this point
* The etcd defragmentation is causing pods to restart when failing to renew the lease

Signed-off-by: dirgim <kpavic@redhat.com>