### PR TITLE
Fix typo in kubearchive.conf for Konflux UI nginx

### DIFF
--- a/components/konflux-ui/staging/base/proxy/proxy.yaml
+++ b/components/konflux-ui/staging/base/proxy/proxy.yaml
@@ -84,7 +84,7 @@ spec:
             if [[ "$KUBEARCHIVE_URL" != "" ]]; then
               echo "location /api/k8s/plugins/kubearchive/ {" > /mnt/nginx-generated-config/kubearchive.conf
               echo "auth_request /oauth2/auth;" >> /mnt/nginx-generated-config/kubearchive.conf
-              echo "rewrite /api/k8s/plugins/kubearchive/(.+) /$1 break;" >> /mnt/nginx-generated-config/kubearchive.conf
+              echo "rewrite /api/k8s/plugins/kubearchive/(.+) /\$1 break;" >> /mnt/nginx-generated-config/kubearchive.conf
               echo "proxy_read_timeout 30m;" >> /mnt/nginx-generated-config/kubearchive.conf
               echo "proxy_pass ${KUBEARCHIVE_URL};" >> /mnt/nginx-generated-config/kubearchive.conf
               echo "include /mnt/nginx-generated-config/auth.conf;" >> /mnt/nginx-generated-config/kubearchive.conf


### PR DESCRIPTION
Currently the redirection made by the Konflux UI Nginx proxy to make KubeArchive API isn't working.

Even though the KubeArchive team does not have permissions to check the actual kubearchive.conf being used, we found this typo that is probably the culprit.

Before merging this PR it would be helpful though if someone with permissions can check the output of 

```
oc exec -n konflux-ui deploy/proxy -c nginx -- ls /mnt/nginx-generated-config/kubearchive.conf
```

in the public staging cluster so we can ensure that the content is what we expect and that we are not missing anything else