### PR TITLE
Update the Tekton Results watcher timeouts

### DIFF
--- a/components/pipeline-service/production/kflux-rhel-p01/deploy.yaml
+++ b/components/pipeline-service/production/kflux-rhel-p01/deploy.yaml
@@ -2308,6 +2308,7 @@ spec:
     enable-cluster-resolver: true
     enable-git-resolver: true
     enable-hub-resolver: true
+    enable-param-enum: true
     enable-step-actions: true
     options:
       configMaps:

--- a/components/pipeline-service/production/stone-prod-p02/deploy.yaml
+++ b/components/pipeline-service/production/stone-prod-p02/deploy.yaml
@@ -1935,8 +1935,10 @@ spec:
         - -auth_mode
         - token
         - -check_owner=false
-        - -completed_run_grace_period
-        - 10m
+        - -completed_run_grace_period=5m
+        - -requeue_interval=2m
+        - -store_deadline=30m
+        - -forward_buffer=1m
         - -threadiness=32
         - -logs_api=true
         env:

--- a/components/pipeline-service/production/stone-prod-p02/resources/kustomization.yaml
+++ b/components/pipeline-service/production/stone-prod-p02/resources/kustomization.yaml
@@ -37,3 +37,7 @@ patches:
     target:
       kind: TektonConfig
       name: config
+  - path: update-results-timeouts.yaml
+    target:
+      kind: Deployment
+      name: tekton-results-watcher

--- a/components/pipeline-service/production/stone-prod-p02/resources/update-results-timeouts.yaml
+++ b/components/pipeline-service/production/stone-prod-p02/resources/update-results-timeouts.yaml
@@ -1,0 +1,15 @@
+---
+- op: replace
+  path: /spec/template/spec/containers/1/args
+  value:
+    - "-api_addr"
+    - "tekton-results-api-service-for-watcher.tekton-results.svc.cluster.local:8080"
+    - "-auth_mode"
+    - "token"
+    - "-check_owner=false"
+    - "-completed_run_grace_period=5m"
+    - "-requeue_interval=2m"
+    - "-store_deadline=30m"
+    - "-forward_buffer=1m"
+    - "-threadiness=32"
+    - "-logs_api=true"


### PR DESCRIPTION
More information about the change:
https://github.com/redhat-appstudio/infra-deployments/pull/6779 We start with single production cluster, before updating the rest.

The `enable-param-enum: true` change is unrelated, but since the kflux-rhel-p01 cluster was out of sync with the base, it was now added to the generated diff and all clusters brought to sync with base.