### PR TITLE
feat(KFLUXVNGD-330): deploying smee sidecar in staging

### DIFF
--- a/components/smee-client/OWNERS
+++ b/components/smee-client/OWNERS
@@ -4,3 +4,5 @@ approvers:
 - ifireball
 - gbenhaim
 - amisstea
+- yftacherzog
+- avi-biton

--- a/components/smee-client/staging/deployment.yaml
+++ b/components/smee-client/staging/deployment.yaml
@@ -1,0 +1,86 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gosmee-client
+  annotations:
+    ignore-check.kube-linter.io/liveness-port: "gosmee probes sidecar port"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: gosmee-client
+  template:
+    metadata:
+      labels:
+        app: gosmee-client
+    spec:
+      containers:
+        - image: "ghcr.io/chmouel/gosmee:v0.26.1"
+          imagePullPolicy: Always
+          name: gosmee
+          args:
+            - "client"
+            - TBA
+            - "http://localhost:8080"
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - "ALL"
+            seccompProfile:
+              type: RuntimeDefault
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+          resources:
+            limits:
+              cpu: 1
+              memory: 750Mi
+            requests:
+              cpu: 1
+              memory: 750Mi
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 9100
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 25 # Must be > the healthz handler's timeout
+            failureThreshold: 2
+        - name: health-check-sidecar
+          image: quay.io/konflux-ci/smee-sidecar:latest@sha256:c977ebe1fc430ddf5deb5d0433c79f24da22a7accfe45998538df32c4a6d05ed
+          imagePullPolicy: Always
+          ports:
+            - name: http
+              containerPort: 8080
+            - name: healthz
+              containerPort: 9100
+          env:
+          - name: DOWNSTREAM_SERVICE_URL
+            value: "http://pipelines-as-code-controller.openshift-pipelines:8080"
+          - name: SMEE_CHANNEL_URL
+            value: "TBA"
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 9100
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 25 # Must be > the healthz handler's timeout
+            failureThreshold: 2
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - "ALL"
+            seccompProfile:
+              type: RuntimeDefault
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+          resources:
+            limits:
+              cpu: 100m
+              memory: 32Mi
+            requests:
+              cpu: 100m
+              memory: 32Mi

--- a/components/smee-client/staging/kustomization.yaml
+++ b/components/smee-client/staging/kustomization.yaml
@@ -1,7 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ../base
+  # TODO: change to point to ../base when deploying sidecar to production
+  - deployment.yaml
 patches:
   - path: sever-url-patch.yaml
     target:

--- a/components/smee-client/staging/sever-url-patch.yaml
+++ b/components/smee-client/staging/sever-url-patch.yaml
@@ -2,3 +2,6 @@
 - op: replace
   path: /spec/template/spec/containers/0/args/1
   value: https://smee-smee.apps.stone-stg-host.qc0p.p1.openshiftapps.com/redhathook12
+- op: replace
+  path: /spec/template/spec/containers/1/env/1/value
+  value: https://smee-smee.apps.stone-stg-host.qc0p.p1.openshiftapps.com/redhathook12


### PR DESCRIPTION
The smee sidecar implements a health check loop that sends an event to the same server that the client listens on and verifies the client forwards it.

This addresses an issue in which the client freezes and stops forwarding events, while still looking alive.