### PR TITLE
kyverno set skipBackgroundRequests to default value

### DIFF
--- a/components/policies/staging/base/konflux-rbac/bootstrap-tenant-namespace/bootstrap-tenant-namespace-np-ocpconsole-clusterpolicy.yaml
+++ b/components/policies/staging/base/konflux-rbac/bootstrap-tenant-namespace/bootstrap-tenant-namespace-np-ocpconsole-clusterpolicy.yaml
@@ -6,6 +6,7 @@ metadata:
 spec:
   rules:
   - name: create-allow-from-console-namespaces-networkpolicy
+    skipBackgroundRequests: true
     match:
       any:
       - resources:

--- a/components/policies/staging/base/konflux-rbac/bootstrap-tenant-namespace/bootstrap-tenant-namespace-np-ocpingress-clusterpolicy.yaml
+++ b/components/policies/staging/base/konflux-rbac/bootstrap-tenant-namespace/bootstrap-tenant-namespace-np-ocpingress-clusterpolicy.yaml
@@ -6,6 +6,7 @@ metadata:
 spec:
   rules:
   - name: create-allow-from-openshift-ingress-networkpolicy
+    skipBackgroundRequests: true
     match:
       any:
       - resources:

--- a/components/policies/staging/base/konflux-rbac/bootstrap-tenant-namespace/bootstrap-tenant-namespace-np-ocpmonitoring-clusterpolicy.yaml
+++ b/components/policies/staging/base/konflux-rbac/bootstrap-tenant-namespace/bootstrap-tenant-namespace-np-ocpmonitoring-clusterpolicy.yaml
@@ -6,6 +6,7 @@ metadata:
 spec:
   rules:
   - name: create-allow-from-openshift-monitoring-networkpolicy
+    skipBackgroundRequests: true
     match:
       any:
       - resources:

--- a/components/policies/staging/base/konflux-rbac/bootstrap-tenant-namespace/bootstrap-tenant-namespace-np-olm-clusterpolicy.yaml
+++ b/components/policies/staging/base/konflux-rbac/bootstrap-tenant-namespace/bootstrap-tenant-namespace-np-olm-clusterpolicy.yaml
@@ -6,6 +6,7 @@ metadata:
 spec:
   rules:
   - name: create-allow-from-olm-namespaces-networkpolicy
+    skipBackgroundRequests: true
     match:
       any:
       - resources:

--- a/components/policies/staging/base/konflux-rbac/bootstrap-tenant-namespace/bootstrap-tenant-namespace-np-samenamespace-clusterpolicy.yaml
+++ b/components/policies/staging/base/konflux-rbac/bootstrap-tenant-namespace/bootstrap-tenant-namespace-np-samenamespace-clusterpolicy.yaml
@@ -6,6 +6,7 @@ metadata:
 spec:
   rules:
   - name: create-allow-same-namespace-networkpolicy
+    skipBackgroundRequests: true
     match:
       any:
       - resources:

--- a/components/policies/staging/base/konflux-rbac/bootstrap-tenant-namespace/bootstrap-tenant-namespace-rbcm-clusterpolicy.yaml
+++ b/components/policies/staging/base/konflux-rbac/bootstrap-tenant-namespace/bootstrap-tenant-namespace-rbcm-clusterpolicy.yaml
@@ -6,6 +6,7 @@ metadata:
 spec:
   rules:
   - name: create-appstudio-runner-rolebinding
+    skipBackgroundRequests: true
     match:
       any:
       - resources:


### PR DESCRIPTION
ArgoCD is complaining about OutOfSync resources for this field.
Explicitly setting it to the default value (`true`).
https://release-1-12-0.kyverno.io/docs/writing-policies/policy-settings/

Signed-off-by: Francesco Ilario <filario@redhat.com>
