### PR TITLE
scrape kyverno metrics in dev and stage

### DIFF
--- a/components/kyverno/development/kyverno-helm-values.yaml
+++ b/components/kyverno/development/kyverno-helm-values.yaml
@@ -24,6 +24,12 @@ admissionController:
       capabilities:
         drop:
         - "ALL"
+  metering:
+    disabled: false
+  serviceMonitor:
+    enabled: true
+    # kyverno doesn't seem to support HTTPS on metrics
+    secure: false
 backgroundController:
   replicas: 1
   extraArgs:
@@ -35,6 +41,12 @@ backgroundController:
     capabilities:
       drop:
       - "ALL"
+  metering:
+    disabled: false
+  serviceMonitor:
+    enabled: true
+    # kyverno doesn't seem to support HTTPS on metrics
+    secure: false
 cleanupController:
   enabled: false
 reportsController:

--- a/components/kyverno/staging/stone-stage-p01/kyverno-helm-values.yaml
+++ b/components/kyverno/staging/stone-stage-p01/kyverno-helm-values.yaml
@@ -26,6 +26,12 @@ admissionController:
       capabilities:
         drop:
         - "ALL"
+  metering:
+    disabled: false
+  serviceMonitor:
+    enabled: true
+    # kyverno doesn't seem to support HTTPS on metrics
+    secure: false
 backgroundController:
   replicas: 3
   resources:
@@ -41,6 +47,12 @@ backgroundController:
     capabilities:
       drop:
       - "ALL"
+  metering:
+    disabled: false
+  serviceMonitor:
+    enabled: true
+    # kyverno doesn't seem to support HTTPS on metrics
+    secure: false
 cleanupController:
   replicas: 3
   securityContext:
@@ -50,6 +62,12 @@ cleanupController:
     capabilities:
       drop:
       - "ALL"
+  metering:
+    disabled: false
+  serviceMonitor:
+    enabled: true
+    # kyverno doesn't seem to support HTTPS on metrics
+    secure: false
 reportsController:
   enabled: false
 policyReportsCleanup:

--- a/components/kyverno/staging/stone-stg-rh01/kyverno-helm-values.yaml
+++ b/components/kyverno/staging/stone-stg-rh01/kyverno-helm-values.yaml
@@ -29,6 +29,12 @@ admissionController:
       capabilities:
         drop:
         - "ALL"
+  metering:
+    disabled: false
+  serviceMonitor:
+    enabled: true
+    # kyverno doesn't seem to support HTTPS on metrics
+    secure: false
 backgroundController:
   replicas: 3
   extraArgs:
@@ -48,6 +54,12 @@ backgroundController:
     capabilities:
       drop:
       - "ALL"
+  metering:
+    disabled: false
+  serviceMonitor:
+    enabled: true
+    # kyverno doesn't seem to support HTTPS on metrics
+    secure: false
 cleanupController:
   replicas: 3
   extraArgs:
@@ -59,6 +71,12 @@ cleanupController:
     capabilities:
       drop:
       - "ALL"
+  metering:
+    disabled: false
+  serviceMonitor:
+    enabled: true
+    # kyverno doesn't seem to support HTTPS on metrics
+    secure: false
 reportsController:
   enabled: false
 policyReportsCleanup:


### PR DESCRIPTION
Kyverno doesn't seem to support HTTPS on the metrics server natively even though the Helm chart allows to configure the ServiceMonitor for that.
Further investigation is needed, deferring it to another PR.

Signed-off-by: Francesco Ilario <filario@redhat.com>
