### PR TITLE
KubeArchive: ignoreDifferences in ClusterRoleBinding

### DIFF
--- a/argo-cd-apps/base/member/infra-deployments/kubearchive/kubearchive.yaml
+++ b/argo-cd-apps/base/member/infra-deployments/kubearchive/kubearchive.yaml
@@ -39,6 +39,13 @@ spec:
     metadata:
       name: kubearchive-{{nameNormalized}}
     spec:
+      ignoreDifferences:
+        # ignore CRB that gets modified by KubeArchive
+        - kind: ClusterRoleBinding
+          group: rbac.authorization.k8s.io
+          name: clusterkubearchiveconfig-read
+          jsonPointers:
+            - /subjects
       project: default
       source:
         path: "{{values.sourceRoot}}/{{values.environment}}/{{values.clusterDir}}"


### PR DESCRIPTION
This PR aims to ignoreDifferences of a CRB that KubeArchive modifies in its activity. ArgoCD is trying to turn it back to the original state, which will make KubeArchive malfunction. This will be applied to all installations, which makes sense.