### PR TITLE
kyverno: defaults for skipBackgroundRequests and allowExistingViolations

### DIFF
--- a/components/policies/staging/base/konflux-rbac/bootstrap-tenant-namespace/bootstrap-tenant-namespace-rbcm-clusterpolicy.yaml
+++ b/components/policies/staging/base/konflux-rbac/bootstrap-tenant-namespace/bootstrap-tenant-namespace-rbcm-clusterpolicy.yaml
@@ -36,6 +36,7 @@ spec:
           namespace: '{{request.object.metadata.name}}'
           name: appstudio-pipeline
   - name: create-trusted-ca-configmap
+    skipBackgroundRequests: true
     match:
       any:
       - resources:

--- a/components/policies/staging/base/konflux-rbac/restrict-binding-system-authenticated/validate-restrict-binding-system-authenticated-clusterpolicy.yaml
+++ b/components/policies/staging/base/konflux-rbac/restrict-binding-system-authenticated/validate-restrict-binding-system-authenticated-clusterpolicy.yaml
@@ -14,6 +14,7 @@ metadata:
 spec:
   rules:
   - name: restrict-authenticated
+    skipBackgroundRequests: true
     match:
       any:
       - resources:
@@ -34,6 +35,7 @@ spec:
         operator: NotEquals
         value: "konflux-viewer-user-actions"
     validate:
+      allowExistingViolations: true
       failureAction: Enforce
       message: "Only ClusterRole konflux-viewer-user-actions can be bound to system:authenticated."
       deny: {}

--- a/components/policies/staging/base/konflux-rbac/validate-rolebindings/invalid-subjects.yaml
+++ b/components/policies/staging/base/konflux-rbac/validate-rolebindings/invalid-subjects.yaml
@@ -6,6 +6,7 @@ spec:
   background: false
   rules:
   - name: deny-restricted-groups
+    skipBackgroundRequests: true
     match:
       any:
       - resources:
@@ -20,6 +21,7 @@ spec:
         operator: AnyIn
         value: '["system:anonymous", "system:unauthenticated", "system:masters"]'
     validate:
+      allowExistingViolations: true
       failureAction: Enforce
       message: "RoleBindings to restricted system groups is not allowed in tenant namespaces."
       deny: {}


### PR DESCRIPTION
ArgoCD is complaining because some policies are OutOfSync.

Explicitly setting the skipBackgroundRequests and allowExistingViolations fields to their default values will fix.

Signed-off-by: Francesco Ilario <filario@redhat.com>
