### PR TITLE
kyverno: defaults for skipBackgroundRequests and allowExistingViolations in prod

### DIFF
--- a/components/policies/production/base/konflux-rbac/bootstrap-tenant-namespace/bootstrap-tenant-namespace-np-ocpconsole-clusterpolicy.yaml
+++ b/components/policies/production/base/konflux-rbac/bootstrap-tenant-namespace/bootstrap-tenant-namespace-np-ocpconsole-clusterpolicy.yaml
@@ -6,6 +6,7 @@ metadata:
 spec:
   rules:
   - name: create-allow-from-console-namespaces-networkpolicy
+    skipBackgroundRequests: true
     match:
       any:
       - resources:

--- a/components/policies/production/base/konflux-rbac/bootstrap-tenant-namespace/bootstrap-tenant-namespace-np-ocpingress-clusterpolicy.yaml
+++ b/components/policies/production/base/konflux-rbac/bootstrap-tenant-namespace/bootstrap-tenant-namespace-np-ocpingress-clusterpolicy.yaml
@@ -6,6 +6,7 @@ metadata:
 spec:
   rules:
   - name: create-allow-from-openshift-ingress-networkpolicy
+    skipBackgroundRequests: true
     match:
       any:
       - resources:

--- a/components/policies/production/base/konflux-rbac/bootstrap-tenant-namespace/bootstrap-tenant-namespace-np-ocpmonitoring-clusterpolicy.yaml
+++ b/components/policies/production/base/konflux-rbac/bootstrap-tenant-namespace/bootstrap-tenant-namespace-np-ocpmonitoring-clusterpolicy.yaml
@@ -6,6 +6,7 @@ metadata:
 spec:
   rules:
   - name: create-allow-from-openshift-monitoring-networkpolicy
+    skipBackgroundRequests: true
     match:
       any:
       - resources:

--- a/components/policies/production/base/konflux-rbac/bootstrap-tenant-namespace/bootstrap-tenant-namespace-np-olm-clusterpolicy.yaml
+++ b/components/policies/production/base/konflux-rbac/bootstrap-tenant-namespace/bootstrap-tenant-namespace-np-olm-clusterpolicy.yaml
@@ -6,6 +6,7 @@ metadata:
 spec:
   rules:
   - name: create-allow-from-olm-namespaces-networkpolicy
+    skipBackgroundRequests: true
     match:
       any:
       - resources:

--- a/components/policies/production/base/konflux-rbac/bootstrap-tenant-namespace/bootstrap-tenant-namespace-np-samenamespace-clusterpolicy.yaml
+++ b/components/policies/production/base/konflux-rbac/bootstrap-tenant-namespace/bootstrap-tenant-namespace-np-samenamespace-clusterpolicy.yaml
@@ -6,6 +6,7 @@ metadata:
 spec:
   rules:
   - name: create-allow-same-namespace-networkpolicy
+    skipBackgroundRequests: true
     match:
       any:
       - resources:

--- a/components/policies/production/base/konflux-rbac/bootstrap-tenant-namespace/bootstrap-tenant-namespace-rbcm-clusterpolicy.yaml
+++ b/components/policies/production/base/konflux-rbac/bootstrap-tenant-namespace/bootstrap-tenant-namespace-rbcm-clusterpolicy.yaml
@@ -6,6 +6,7 @@ metadata:
 spec:
   rules:
   - name: create-appstudio-runner-rolebinding
+    skipBackgroundRequests: true
     match:
       any:
       - resources:
@@ -35,6 +36,7 @@ spec:
           namespace: '{{request.object.metadata.name}}'
           name: appstudio-pipeline
   - name: create-trusted-ca-configmap
+    skipBackgroundRequests: true
     match:
       any:
       - resources:

--- a/components/policies/production/base/konflux-rbac/restrict-binding-system-authenticated/validate-restrict-binding-system-authenticated-clusterpolicy.yaml
+++ b/components/policies/production/base/konflux-rbac/restrict-binding-system-authenticated/validate-restrict-binding-system-authenticated-clusterpolicy.yaml
@@ -14,6 +14,7 @@ metadata:
 spec:
   rules:
   - name: restrict-authenticated
+    skipBackgroundRequests: true
     match:
       any:
       - resources:
@@ -34,6 +35,7 @@ spec:
         operator: NotEquals
         value: "konflux-viewer-user-actions"
     validate:
+      allowExistingViolations: true
       failureAction: Enforce
       message: "Only ClusterRole konflux-viewer-user-actions can be bound to system:authenticated."
       deny: {}

--- a/components/policies/production/base/konflux-rbac/validate-rolebindings/invalid-subjects.yaml
+++ b/components/policies/production/base/konflux-rbac/validate-rolebindings/invalid-subjects.yaml
@@ -6,6 +6,7 @@ spec:
   background: false
   rules:
   - name: deny-restricted-groups
+    skipBackgroundRequests: true
     match:
       any:
       - resources:
@@ -20,6 +21,7 @@ spec:
         operator: AnyIn
         value: '["system:anonymous", "system:unauthenticated", "system:masters"]'
     validate:
+      allowExistingViolations: true
       failureAction: Enforce
       message: "RoleBindings to restricted system groups is not allowed in tenant namespaces."
       deny: {}


### PR DESCRIPTION
ArgoCD is complaining because some policies are OutOfSync.

Explicitly setting these skipBackgroundRequests and allowExistingViolations fields to their default values will fix.

Promoting changes from https://github.com/redhat-appstudio/infra-deployments/pull/6796 and https://github.com/redhat-appstudio/infra-deployments/pull/6790 to prod.

Signed-off-by: Francesco Ilario <filario@redhat.com>
