### PR TITLE
Update public production with latest MPC version from staging

### DIFF
--- a/components/multi-platform-controller/production/kflux-prd-rh02/kustomization.yaml
+++ b/components/multi-platform-controller/production/kflux-prd-rh02/kustomization.yaml
@@ -7,8 +7,8 @@ resources:
 - ../../base/common
 - host-config.yaml
 - external-secrets.yaml
-- https://github.com/konflux-ci/multi-platform-controller/deploy/operator?ref=e637dc899b2f1afba9e66406deabbc0d067df859
-- https://github.com/konflux-ci/multi-platform-controller/deploy/otp?ref=e637dc899b2f1afba9e66406deabbc0d067df859
+- https://github.com/konflux-ci/multi-platform-controller/deploy/operator?ref=ccd22bfb87cde8de268f4a40e0217ebacf54e51e
+- https://github.com/konflux-ci/multi-platform-controller/deploy/otp?ref=ccd22bfb87cde8de268f4a40e0217ebacf54e51e
 
 components:
   - ../../k-components/manager-resources
@@ -16,10 +16,10 @@ components:
 images:
 - name: multi-platform-controller
   newName: quay.io/konflux-ci/multi-platform-controller
-  newTag: e637dc899b2f1afba9e66406deabbc0d067df859
+  newTag: ccd22bfb87cde8de268f4a40e0217ebacf54e51e
 - name: multi-platform-otp-server
   newName: quay.io/konflux-ci/multi-platform-controller-otp-service
-  newTag: e637dc899b2f1afba9e66406deabbc0d067df859
+  newTag: ccd22bfb87cde8de268f4a40e0217ebacf54e51e
 
 patches:
   - path: manager_resources_patch.yaml

--- a/components/multi-platform-controller/production/kflux-prd-rh03/kustomization.yaml
+++ b/components/multi-platform-controller/production/kflux-prd-rh03/kustomization.yaml
@@ -7,8 +7,8 @@ resources:
 - ../../base/common
 - host-config.yaml
 - external-secrets.yaml
-- https://github.com/konflux-ci/multi-platform-controller/deploy/operator?ref=e637dc899b2f1afba9e66406deabbc0d067df859
-- https://github.com/konflux-ci/multi-platform-controller/deploy/otp?ref=e637dc899b2f1afba9e66406deabbc0d067df859
+- https://github.com/konflux-ci/multi-platform-controller/deploy/operator?ref=ccd22bfb87cde8de268f4a40e0217ebacf54e51e
+- https://github.com/konflux-ci/multi-platform-controller/deploy/otp?ref=ccd22bfb87cde8de268f4a40e0217ebacf54e51e
 
 components:
   - ../../k-components/manager-resources
@@ -16,10 +16,10 @@ components:
 images:
 - name: multi-platform-controller
   newName: quay.io/konflux-ci/multi-platform-controller
-  newTag: e637dc899b2f1afba9e66406deabbc0d067df859
+  newTag: ccd22bfb87cde8de268f4a40e0217ebacf54e51e
 - name: multi-platform-otp-server
   newName: quay.io/konflux-ci/multi-platform-controller-otp-service
-  newTag: e637dc899b2f1afba9e66406deabbc0d067df859
+  newTag: ccd22bfb87cde8de268f4a40e0217ebacf54e51e
 
 patches:
   - path: manager_resources_patch.yaml

--- a/components/multi-platform-controller/production/stone-prd-rh01/kustomization.yaml
+++ b/components/multi-platform-controller/production/stone-prd-rh01/kustomization.yaml
@@ -7,8 +7,8 @@ resources:
 - ../../base/common
 - host-config.yaml
 - external-secrets.yaml
-- https://github.com/konflux-ci/multi-platform-controller/deploy/operator?ref=e637dc899b2f1afba9e66406deabbc0d067df859
-- https://github.com/konflux-ci/multi-platform-controller/deploy/otp?ref=e637dc899b2f1afba9e66406deabbc0d067df859
+- https://github.com/konflux-ci/multi-platform-controller/deploy/operator?ref=ccd22bfb87cde8de268f4a40e0217ebacf54e51e
+- https://github.com/konflux-ci/multi-platform-controller/deploy/otp?ref=ccd22bfb87cde8de268f4a40e0217ebacf54e51e
 
 components:
   - ../../k-components/manager-resources
@@ -16,10 +16,10 @@ components:
 images:
 - name: multi-platform-controller
   newName: quay.io/konflux-ci/multi-platform-controller
-  newTag: e637dc899b2f1afba9e66406deabbc0d067df859
+  newTag: ccd22bfb87cde8de268f4a40e0217ebacf54e51e
 - name: multi-platform-otp-server
   newName: quay.io/konflux-ci/multi-platform-controller-otp-service
-  newTag: e637dc899b2f1afba9e66406deabbc0d067df859
+  newTag: ccd22bfb87cde8de268f4a40e0217ebacf54e51e
 
 
 patches:


### PR DESCRIPTION
This including the important fix:
[Comment out resizing block as it is not needed for static VMs](https://github.com/konflux-ci/multi-platform-controller/commit/ccd22bfb87cde8de268f4a40e0217ebacf54e51e)