### PR TITLE
KubeArchive: changing commonAnnotations

### DIFF
--- a/argo-cd-apps/base/member/infra-deployments/kubearchive/kubearchive.yaml
+++ b/argo-cd-apps/base/member/infra-deployments/kubearchive/kubearchive.yaml
@@ -55,6 +55,7 @@ spec:
           selfHeal: true
         syncOptions:
           - CreateNamespace=true
+          - SkipDryRunOnMissingResource=true
         retry:
           limit: 50
           backoff:

--- a/components/kubearchive/development/kustomization.yaml
+++ b/components/kubearchive/development/kustomization.yaml
@@ -20,9 +20,6 @@ secretGenerator:
     namespace: kubearchive
     type: Opaque
 
-commonAnnotations:
-  argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
-
 patches:
   - patch: |-
       apiVersion: batch/v1

--- a/components/kubearchive/staging/stone-stg-rh01/kustomization.yaml
+++ b/components/kubearchive/staging/stone-stg-rh01/kustomization.yaml
@@ -7,9 +7,6 @@ resources:
 
 namespace: product-kubearchive
 
-commonAnnotations:
-  argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
-
 patches:
   - patch: |-
       $patch: delete


### PR DESCRIPTION
This PR moves the SkipDryRunOnMissingResources to the application set so we can remove commonAnnotations and then use specific annotations for certain resources. The Job we use to update the database schema needs specific annotations.