### PR TITLE
enable multi-repo Github App token scoping

### DIFF
--- a/components/pipeline-service/staging/stone-stage-p01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stage-p01/deploy.yaml
@@ -2591,6 +2591,7 @@ spec:
           custom-console-url-pr-tasklog: https://konflux-ui.apps.stone-stage-p01.hpmt.p1.openshiftapps.com/ns/{{
             namespace }}/pipelinerun/{{ pr }}/logs/{{ task }}
           remember-ok-to-test: "false"
+          secret-github-app-token-scoped: "false"
   profile: all
   pruner:
     disabled: true

--- a/components/pipeline-service/staging/stone-stage-p01/resources/update-tekton-config-pac.yaml
+++ b/components/pipeline-service/staging/stone-stage-p01/resources/update-tekton-config-pac.yaml
@@ -8,3 +8,4 @@
     custom-console-url-pr-details: https://konflux-ui.apps.stone-stage-p01.hpmt.p1.openshiftapps.com/ns/{{ namespace }}/pipelinerun/{{ pr }}
     custom-console-url-pr-tasklog: https://konflux-ui.apps.stone-stage-p01.hpmt.p1.openshiftapps.com/ns/{{ namespace }}/pipelinerun/{{ pr }}/logs/{{ task }}
     remember-ok-to-test: "false"
+    secret-github-app-token-scoped: "false"


### PR DESCRIPTION
Disabling this setting allows users to enumerate additional private repositories for which their Github Token will be scoped. Importantly, the additional private repositories can only be included in the token's scope if both repositories have the same Github App installed and the their respective Repository CRs exist in the same namespace, which is in line with Konflux's security model. 

Part of https://issues.redhat.com/browse/KONFLUX-8780