### PR TITLE
Update production repository validator

### DIFF
--- a/components/repository-validator/production/kustomization.yaml
+++ b/components/repository-validator/production/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - https://github.com/konflux-ci/repository-validator/config/ocp?ref=1a1bd5856c7caf40ebf3d9a24fce209ba8a74bd9
-  - https://github.com/redhat-appstudio/internal-infra-deployments/components/repository-validator/production?ref=0cadffd95878818bd759b38e78ae1dcabaf5dc53
+  - https://github.com/redhat-appstudio/internal-infra-deployments/components/repository-validator/production?ref=29ecb9773ff0054f5622ddaed0f3c3dd38e5d2b3
 images:
   - name: controller
     newName: quay.io/redhat-user-workloads/konflux-infra-tenant/repository-validator/repository-validator


### PR DESCRIPTION
This commit allows the ibmstorage GitHub repository to be added to the production repository allow list.