### PR TITLE
restrict paths for kyverno tests CI

### DIFF
--- a/.github/workflows/chainsaw-tests.yaml
+++ b/.github/workflows/chainsaw-tests.yaml
@@ -5,7 +5,7 @@ on:
     branches: [ main ]
     paths:
       - '.github/workflows/chainsaw-tests.yaml'
-      - 'components/kyverno'
+      - 'components/kyverno/**'
       - 'components/policies/**'
 
 jobs:

--- a/.github/workflows/kyverno-policies-tests.yaml
+++ b/.github/workflows/kyverno-policies-tests.yaml
@@ -5,7 +5,7 @@ on:
     branches: [ main ]
     paths:
       - '.github/workflows/kyverno-policies-tests.yaml'
-      - 'components/kyverno'
+      - 'components/kyverno/**'
       - 'components/policies/**'
 
 jobs:


### PR DESCRIPTION
as we migrated all the `policies` under the policies component, we want only changes to some specific paths to trigger the CI jobs.

Requires:
* [x] https://github.com/redhat-appstudio/infra-deployments/pull/6804
* [x] https://github.com/redhat-appstudio/infra-deployments/pull/6761
* [x] https://github.com/redhat-appstudio/infra-deployments/pull/6831

Signed-off-by: Francesco Ilario <filario@redhat.com>
