### PR TITLE
fix: rename one of the smee servers containers

### DIFF
--- a/components/smee/staging/deployment.yaml
+++ b/components/smee/staging/deployment.yaml
@@ -50,7 +50,7 @@ spec:
               memory: 256Mi
         - image: "ghcr.io/chmouel/gosmee:v0.20.2"
           imagePullPolicy: Always
-          name: gosmee
+          name: gosmee-liveness-probe-client
           args:
             - "client"
             - "http://localhost:3333/smeesvrmonit"


### PR DESCRIPTION
Two containers had the same name