### PR TITLE
fix: correct memory request format in Smee deployment configuration

### DIFF
--- a/components/smee/staging/deployment.yaml
+++ b/components/smee/staging/deployment.yaml
@@ -70,7 +70,7 @@ spec:
               memory: 32Mi
             requests:
               cpu: 100m
-              memory: 32MiMi
+              memory: 32Mi
           livenessProbe:
             httpGet:
               path: /healthz


### PR DESCRIPTION
Updated the memory request in the Smee server deployment from an incorrect value to the correct format, ensuring proper resource allocation.

Signed-off-by: Barak Korren <bkorren@redhat.com>