### PR TITLE
chore: increase smee-sidecar failure threshold

### DIFF
--- a/components/smee-client/staging/deployment.yaml
+++ b/components/smee-client/staging/deployment.yaml
@@ -46,7 +46,7 @@ spec:
             initialDelaySeconds: 30
             periodSeconds: 30
             timeoutSeconds: 25 # Must be > the healthz handler's timeout
-            failureThreshold: 2
+            failureThreshold: 12 # High-enough not to fail if other container crashlooping
         - name: health-check-sidecar
           image: quay.io/konflux-ci/smee-sidecar:latest@sha256:55f4715ba7e91c7908be0c6319638399c4de8e1bfdf082d6cd7287affb3b398f
           imagePullPolicy: Always
@@ -67,7 +67,7 @@ spec:
             initialDelaySeconds: 30
             periodSeconds: 30
             timeoutSeconds: 25 # Must be > the healthz handler's timeout
-            failureThreshold: 2
+            failureThreshold: 12 # High-enough not to fail if other container crashlooping
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/components/smee/staging/deployment.yaml
+++ b/components/smee/staging/deployment.yaml
@@ -33,7 +33,7 @@ spec:
             initialDelaySeconds: 30
             periodSeconds: 30
             timeoutSeconds: 25 # Must be > the healthz handler's timeout
-            failureThreshold: 2
+            failureThreshold: 12 # High-enough not to fail if other container crashlooping
           securityContext:
             readOnlyRootFilesystem: true
             runAsNonRoot: true
@@ -74,7 +74,7 @@ spec:
             initialDelaySeconds: 30
             periodSeconds: 30
             timeoutSeconds: 25 # Must be > the healthz handler's timeout
-            failureThreshold: 2
+            failureThreshold: 12 # High-enough not to fail if other container crashlooping
         - name: health-check-sidecar
           image: quay.io/konflux-ci/smee-sidecar:latest@sha256:55f4715ba7e91c7908be0c6319638399c4de8e1bfdf082d6cd7287affb3b398f
           imagePullPolicy: Always
@@ -95,7 +95,7 @@ spec:
             initialDelaySeconds: 30
             periodSeconds: 30
             timeoutSeconds: 25 # Must be > the healthz handler's timeout
-            failureThreshold: 2
+            failureThreshold: 12 # High-enough not to fail if other container crashlooping
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:


### PR DESCRIPTION
If the sidecar or one of the other containers are crashlooping, we might get to a state in which a container restarts but the liveness probe will always fail as the other container is in crashloopbackoff.

Making the threshold higher than the max backoff time (should be 5 minutes), will ensure that the probe will have a chance to succeed.