### PR TITLE
Refactor pipelines as code config Kustomization to DRY common values

### DIFF
--- a/components/pipeline-service/production/base/main-pipeline-service-configuration.yaml
+++ b/components/pipeline-service/production/base/main-pipeline-service-configuration.yaml
@@ -1860,6 +1860,14 @@ spec:
             pipelines-as-code-webhook:
               spec:
                 replicas: 2
+        settings:
+          application-name: Red Hat Konflux
+          custom-console-name: Red Hat Konflux
+          custom-console-url: https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/
+          custom-console-url-pr-details: https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/{{ namespace }}/pipelinerun/{{ pr }}
+          custom-console-url-pr-tasklog: https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/{{ namespace }}/pipelinerun/{{ pr }}/logs/{{ task }}
+          remember-ok-to-test: "false"
+          secret-github-app-token-scoped: "false"
   profile: all
   pruner:
     disabled: false

--- a/components/pipeline-service/production/base/update-tekton-config-pac.yaml
+++ b/components/pipeline-service/production/base/update-tekton-config-pac.yaml
@@ -1,11 +1,16 @@
 ---
-- op: add
-  path: /spec/platforms/openshift/pipelinesAsCode/settings
-  value:
-    application-name: Red Hat Konflux
-    custom-console-name: Red Hat Konflux
-    custom-console-url: https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/
-    custom-console-url-pr-details: https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/{{ namespace }}/pipelinerun/{{ pr }}
-    custom-console-url-pr-tasklog: https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/{{ namespace }}/pipelinerun/{{ pr }}/logs/{{ task }}
-    remember-ok-to-test: "false"
-    secret-github-app-token-scoped: "false"
+- op: replace
+  path: /spec/platforms/openshift/pipelinesAsCode/settings/application-name
+  value: Red Hat Konflux
+- op: replace
+  path: /spec/platforms/openshift/pipelinesAsCode/settings/custom-console-name
+  value: Red Hat Konflux
+- op: replace
+  path: /spec/platforms/openshift/pipelinesAsCode/settings/custom-console-url
+  value: https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/
+- op: replace
+  path: /spec/platforms/openshift/pipelinesAsCode/settings/custom-console-url-pr-details
+  value: https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/{{ namespace }}/pipelinerun/{{ pr }}
+- op: replace
+  path: /spec/platforms/openshift/pipelinesAsCode/settings/custom-console-url-pr-tasklog
+  value: https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/{{ namespace }}/pipelinerun/{{ pr }}/logs/{{ task }}

--- a/components/pipeline-service/production/kflux-ocp-p01/deploy.yaml
+++ b/components/pipeline-service/production/kflux-ocp-p01/deploy.yaml
@@ -2451,6 +2451,7 @@ spec:
             namespace }}/pipelinerun/{{ pr }}
           custom-console-url-pr-tasklog: https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/{{
             namespace }}/pipelinerun/{{ pr }}/logs/{{ task }}
+          remember-ok-to-test: "false"
           secret-github-app-token-scoped: "false"
   profile: all
   pruner:

--- a/components/pipeline-service/production/kflux-ocp-p01/resources/update-tekton-config-pac.yaml
+++ b/components/pipeline-service/production/kflux-ocp-p01/resources/update-tekton-config-pac.yaml
@@ -1,10 +1,16 @@
 ---
-- op: add
-  path: /spec/platforms/openshift/pipelinesAsCode/settings
-  value:
-    application-name: Konflux OCP
-    custom-console-name: Konflux OCP
-    custom-console-url: https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com
-    custom-console-url-pr-details: https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/{{ namespace }}/pipelinerun/{{ pr }}
-    custom-console-url-pr-tasklog: https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/{{ namespace }}/pipelinerun/{{ pr }}/logs/{{ task }}
-    secret-github-app-token-scoped: "false"
+- op: replace
+  path: /spec/platforms/openshift/pipelinesAsCode/settings/application-name
+  value: Konflux OCP
+- op: replace
+  path: /spec/platforms/openshift/pipelinesAsCode/settings/custom-console-name
+  value: Konflux OCP
+- op: replace
+  path: /spec/platforms/openshift/pipelinesAsCode/settings/custom-console-url
+  value: https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com
+- op: replace
+  path: /spec/platforms/openshift/pipelinesAsCode/settings/custom-console-url-pr-details
+  value: https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/{{ namespace }}/pipelinerun/{{ pr }}
+- op: replace
+  path: /spec/platforms/openshift/pipelinesAsCode/settings/custom-console-url-pr-tasklog
+  value: https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/{{ namespace }}/pipelinerun/{{ pr }}/logs/{{ task }}

--- a/components/pipeline-service/production/kflux-prd-rh02/deploy.yaml
+++ b/components/pipeline-service/production/kflux-prd-rh02/deploy.yaml
@@ -2482,6 +2482,7 @@ spec:
             namespace }}/pipelinerun/{{ pr }}
           custom-console-url-pr-tasklog: https://konflux-ui.apps.kflux-prd-rh02.0fk9.p1.openshiftapps.com/ns/{{
             namespace }}/pipelinerun/{{ pr }}/logs/{{ task }}
+          remember-ok-to-test: "false"
           secret-github-app-token-scoped: "false"
   profile: all
   pruner:

--- a/components/pipeline-service/production/kflux-prd-rh02/resources/update-tekton-config-pac.yaml
+++ b/components/pipeline-service/production/kflux-prd-rh02/resources/update-tekton-config-pac.yaml
@@ -1,10 +1,16 @@
 ---
-- op: add
-  path: /spec/platforms/openshift/pipelinesAsCode/settings
-  value:
-    application-name: Konflux kflux-prd-rh02 
-    custom-console-name: Konflux kflux-prd-rh02
-    custom-console-url: https://konflux-ui.apps.kflux-prd-rh02.0fk9.p1.openshiftapps.com
-    custom-console-url-pr-details: https://konflux-ui.apps.kflux-prd-rh02.0fk9.p1.openshiftapps.com/ns/{{ namespace }}/pipelinerun/{{ pr }}
-    custom-console-url-pr-tasklog: https://konflux-ui.apps.kflux-prd-rh02.0fk9.p1.openshiftapps.com/ns/{{ namespace }}/pipelinerun/{{ pr }}/logs/{{ task }}
-    secret-github-app-token-scoped: "false"
+- op: replace
+  path: /spec/platforms/openshift/pipelinesAsCode/settings/application-name
+  value: Konflux kflux-prd-rh02 
+- op: replace
+  path: /spec/platforms/openshift/pipelinesAsCode/settings/custom-console-name
+  value: Konflux kflux-prd-rh02
+- op: replace
+  path: /spec/platforms/openshift/pipelinesAsCode/settings/custom-console-url
+  value: https://konflux-ui.apps.kflux-prd-rh02.0fk9.p1.openshiftapps.com
+- op: replace
+  path: /spec/platforms/openshift/pipelinesAsCode/settings/custom-console-url-pr-details
+  value: https://konflux-ui.apps.kflux-prd-rh02.0fk9.p1.openshiftapps.com/ns/{{ namespace }}/pipelinerun/{{ pr }}
+- op: replace
+  path: /spec/platforms/openshift/pipelinesAsCode/settings/custom-console-url-pr-tasklog
+  value: https://konflux-ui.apps.kflux-prd-rh02.0fk9.p1.openshiftapps.com/ns/{{ namespace }}/pipelinerun/{{ pr }}/logs/{{ task }}

--- a/components/pipeline-service/production/kflux-prd-rh03/deploy.yaml
+++ b/components/pipeline-service/production/kflux-prd-rh03/deploy.yaml
@@ -2482,6 +2482,7 @@ spec:
             namespace }}/pipelinerun/{{ pr }}
           custom-console-url-pr-tasklog: https://konflux-ui.apps.kflux-prd-rh03.nnv1.p1.openshiftapps.com/ns/{{
             namespace }}/pipelinerun/{{ pr }}/logs/{{ task }}
+          remember-ok-to-test: "false"
           secret-github-app-token-scoped: "false"
   profile: all
   pruner:

--- a/components/pipeline-service/production/kflux-prd-rh03/resources/update-tekton-config-pac.yaml
+++ b/components/pipeline-service/production/kflux-prd-rh03/resources/update-tekton-config-pac.yaml
@@ -1,10 +1,16 @@
 ---
-- op: add
-  path: /spec/platforms/openshift/pipelinesAsCode/settings
-  value:
-    application-name: Konflux kflux-prd-rh03
-    custom-console-name: Konflux kflux-prd-rh03
-    custom-console-url: https://konflux-ui.apps.kflux-prd-rh03.nnv1.p1.openshiftapps.com
-    custom-console-url-pr-details: https://konflux-ui.apps.kflux-prd-rh03.nnv1.p1.openshiftapps.com/ns/{{ namespace }}/pipelinerun/{{ pr }}
-    custom-console-url-pr-tasklog: https://konflux-ui.apps.kflux-prd-rh03.nnv1.p1.openshiftapps.com/ns/{{ namespace }}/pipelinerun/{{ pr }}/logs/{{ task }}
-    secret-github-app-token-scoped: "false"
+- op: replace
+  path: /spec/platforms/openshift/pipelinesAsCode/settings/application-name
+  value: Konflux kflux-prd-rh03
+- op: replace
+  path: /spec/platforms/openshift/pipelinesAsCode/settings/custom-console-name
+  value: Konflux kflux-prd-rh03
+- op: replace
+  path: /spec/platforms/openshift/pipelinesAsCode/settings/custom-console-url
+  value: https://konflux-ui.apps.kflux-prd-rh03.nnv1.p1.openshiftapps.com
+- op: replace
+  path: /spec/platforms/openshift/pipelinesAsCode/settings/custom-console-url-pr-details
+  value: https://konflux-ui.apps.kflux-prd-rh03.nnv1.p1.openshiftapps.com/ns/{{ namespace }}/pipelinerun/{{ pr }}
+- op: replace
+  path: /spec/platforms/openshift/pipelinesAsCode/settings/custom-console-url-pr-tasklog
+  value: https://konflux-ui.apps.kflux-prd-rh03.nnv1.p1.openshiftapps.com/ns/{{ namespace }}/pipelinerun/{{ pr }}/logs/{{ task }}

--- a/components/pipeline-service/production/kflux-rhel-p01/resources/update-tekton-config-pac.yaml
+++ b/components/pipeline-service/production/kflux-rhel-p01/resources/update-tekton-config-pac.yaml
@@ -1,11 +1,16 @@
 ---
-- op: add
-  path: /spec/platforms/openshift/pipelinesAsCode/settings
-  value:
-    application-name: Konflux kflux-rhel-p01
-    custom-console-name: Konflux kflux-rhel-p01
-    custom-console-url: https://konflux-ui.apps.kflux-rhel-p01.fc38.p1.openshiftapps.com
-    custom-console-url-pr-details: https://konflux-ui.apps.kflux-rhel-p01.fc38.p1.openshiftapps.com/ns/{{ namespace }}/pipelinerun/{{ pr }}
-    custom-console-url-pr-tasklog: https://konflux-ui.apps.kflux-rhel-p01.fc38.p1.openshiftapps.com/ns/{{ namespace }}/pipelinerun/{{ pr }}/logs/{{ task }}
-    remember-ok-to-test: "false"
-    secret-github-app-token-scoped: "false"
+- op: replace
+  path: /spec/platforms/openshift/pipelinesAsCode/settings/application-name
+  value: Konflux kflux-rhel-p01
+- op: replace
+  path: /spec/platforms/openshift/pipelinesAsCode/settings/custom-console-name
+  value: Konflux kflux-rhel-p01
+- op: replace
+  path: /spec/platforms/openshift/pipelinesAsCode/settings/custom-console-url
+  value: https://konflux-ui.apps.kflux-rhel-p01.fc38.p1.openshiftapps.com
+- op: replace
+  path: /spec/platforms/openshift/pipelinesAsCode/settings/custom-console-url-pr-details
+  value: https://konflux-ui.apps.kflux-rhel-p01.fc38.p1.openshiftapps.com/ns/{{ namespace }}/pipelinerun/{{ pr }}
+- op: replace
+  path: /spec/platforms/openshift/pipelinesAsCode/settings/custom-console-url-pr-tasklog
+  value: https://konflux-ui.apps.kflux-rhel-p01.fc38.p1.openshiftapps.com/ns/{{ namespace }}/pipelinerun/{{ pr }}/logs/{{ task }}

--- a/components/pipeline-service/production/stone-prod-p01/resources/update-tekton-config-pac.yaml
+++ b/components/pipeline-service/production/stone-prod-p01/resources/update-tekton-config-pac.yaml
@@ -1,11 +1,16 @@
 ---
-- op: add
-  path: /spec/platforms/openshift/pipelinesAsCode/settings
-  value:
-    application-name: Konflux Production Internal
-    custom-console-name: Konflux Production Internal
-    custom-console-url: https://konflux-ui.apps.stone-prod-p01.wcfb.p1.openshiftapps.com
-    custom-console-url-pr-details: https://konflux-ui.apps.stone-prod-p01.wcfb.p1.openshiftapps.com/ns/{{ namespace }}/pipelinerun/{{ pr }}
-    custom-console-url-pr-tasklog: https://konflux-ui.apps.stone-prod-p01.wcfb.p1.openshiftapps.com/ns/{{ namespace }}/pipelinerun/{{ pr }}/logs/{{ task }}
-    remember-ok-to-test: "false"
-    secret-github-app-token-scoped: "false"
+- op: replace
+  path: /spec/platforms/openshift/pipelinesAsCode/settings/application-name
+  value: Konflux Production Internal
+- op: replace
+  path: /spec/platforms/openshift/pipelinesAsCode/settings/custom-console-name
+  value: Konflux Production Internal
+- op: replace
+  path: /spec/platforms/openshift/pipelinesAsCode/settings/custom-console-url
+  value: https://konflux-ui.apps.stone-prod-p01.wcfb.p1.openshiftapps.com
+- op: replace
+  path: /spec/platforms/openshift/pipelinesAsCode/settings/custom-console-url-pr-details
+  value: https://konflux-ui.apps.stone-prod-p01.wcfb.p1.openshiftapps.com/ns/{{ namespace }}/pipelinerun/{{ pr }}
+- op: replace
+  path: /spec/platforms/openshift/pipelinesAsCode/settings/custom-console-url-pr-tasklog
+  value: https://konflux-ui.apps.stone-prod-p01.wcfb.p1.openshiftapps.com/ns/{{ namespace }}/pipelinerun/{{ pr }}/logs/{{ task }}

--- a/components/pipeline-service/production/stone-prod-p02/resources/update-tekton-config-pac.yaml
+++ b/components/pipeline-service/production/stone-prod-p02/resources/update-tekton-config-pac.yaml
@@ -1,11 +1,16 @@
 ---
-- op: add
-  path: /spec/platforms/openshift/pipelinesAsCode/settings
-  value:
-    application-name: Konflux Production Internal
-    custom-console-name: Konflux Production Internal
-    custom-console-url: https://konflux-ui.apps.stone-prod-p02.hjvn.p1.openshiftapps.com
-    custom-console-url-pr-details: https://konflux-ui.apps.stone-prod-p02.hjvn.p1.openshiftapps.com/ns/{{ namespace }}/pipelinerun/{{ pr }}
-    custom-console-url-pr-tasklog: https://konflux-ui.apps.stone-prod-p02.hjvn.p1.openshiftapps.com/ns/{{ namespace }}/pipelinerun/{{ pr }}/logs/{{ task }}
-    remember-ok-to-test: "false"
-    secret-github-app-token-scoped: "false"
+- op: replace
+  path: /spec/platforms/openshift/pipelinesAsCode/settings/application-name
+  value: Konflux Production Internal
+- op: replace
+  path: /spec/platforms/openshift/pipelinesAsCode/settings/custom-console-name
+  value: Konflux Production Internal
+- op: replace
+  path: /spec/platforms/openshift/pipelinesAsCode/settings/custom-console-url
+  value: https://konflux-ui.apps.stone-prod-p02.hjvn.p1.openshiftapps.com
+- op: replace
+  path: /spec/platforms/openshift/pipelinesAsCode/settings/custom-console-url-pr-details
+  value: https://konflux-ui.apps.stone-prod-p02.hjvn.p1.openshiftapps.com/ns/{{ namespace }}/pipelinerun/{{ pr }}
+- op: replace
+  path: /spec/platforms/openshift/pipelinesAsCode/settings/custom-console-url-pr-tasklog
+  value: https://konflux-ui.apps.stone-prod-p02.hjvn.p1.openshiftapps.com/ns/{{ namespace }}/pipelinerun/{{ pr }}/logs/{{ task }}

--- a/components/pipeline-service/staging/base/main-pipeline-service-configuration.yaml
+++ b/components/pipeline-service/staging/base/main-pipeline-service-configuration.yaml
@@ -2001,10 +2001,10 @@ spec:
           application-name: Konflux Staging
           custom-console-name: Konflux Staging
           custom-console-url: https://konflux-ui.apps.stone-stg-rh01.l2vh.p1.openshiftapps.com/
-          custom-console-url-pr-details: https://konflux-ui.apps.stone-stg-rh01.l2vh.p1.openshiftapps.com/ns/{{
-            namespace }}/pipelinerun/{{ pr }}
-          custom-console-url-pr-tasklog: https://konflux-ui.apps.stone-stg-rh01.l2vh.p1.openshiftapps.com/ns/{{
-            namespace }}/pipelinerun/{{ pr }}/logs/{{ task }}
+          custom-console-url-pr-details: https://konflux-ui.apps.stone-stg-rh01.l2vh.p1.openshiftapps.com/ns/{{namespace }}/pipelinerun/{{ pr }}
+          custom-console-url-pr-tasklog: https://konflux-ui.apps.stone-stg-rh01.l2vh.p1.openshiftapps.com/ns/{{namespace }}/pipelinerun/{{ pr }}/logs/{{ task }}
+          remember-ok-to-test: "false"
+          secret-github-app-token-scoped: "false"
   profile: all
   pruner:
     disabled: true

--- a/components/pipeline-service/staging/stone-stage-p01/resources/update-tekton-config-pac.yaml
+++ b/components/pipeline-service/staging/stone-stage-p01/resources/update-tekton-config-pac.yaml
@@ -1,11 +1,16 @@
 ---
-- op: add
-  path: /spec/platforms/openshift/pipelinesAsCode/settings
-  value:
-    application-name: Konflux Staging Internal
-    custom-console-name: Konflux Staging Internal
-    custom-console-url: https://konflux-ui.apps.stone-stage-p01.hpmt.p1.openshiftapps.com
-    custom-console-url-pr-details: https://konflux-ui.apps.stone-stage-p01.hpmt.p1.openshiftapps.com/ns/{{ namespace }}/pipelinerun/{{ pr }}
-    custom-console-url-pr-tasklog: https://konflux-ui.apps.stone-stage-p01.hpmt.p1.openshiftapps.com/ns/{{ namespace }}/pipelinerun/{{ pr }}/logs/{{ task }}
-    remember-ok-to-test: "false"
-    secret-github-app-token-scoped: "false"
+- op: replace
+  path: /spec/platforms/openshift/pipelinesAsCode/settings/application-name
+  value: Konflux Staging Internal
+- op: replace
+  path: /spec/platforms/openshift/pipelinesAsCode/settings/custom-console-name
+  value: Konflux Staging Internal
+- op: replace
+  path: /spec/platforms/openshift/pipelinesAsCode/settings/custom-console-url
+  value: https://konflux-ui.apps.stone-stage-p01.hpmt.p1.openshiftapps.com
+- op: replace
+  path: /spec/platforms/openshift/pipelinesAsCode/settings/custom-console-url-pr-details
+  value: https://konflux-ui.apps.stone-stage-p01.hpmt.p1.openshiftapps.com/ns/{{ namespace }}/pipelinerun/{{ pr }}
+- op: replace
+  path: /spec/platforms/openshift/pipelinesAsCode/settings/custom-console-url-pr-tasklog
+  value: https://konflux-ui.apps.stone-stage-p01.hpmt.p1.openshiftapps.com/ns/{{ namespace }}/pipelinerun/{{ pr }}/logs/{{ task }}

--- a/components/pipeline-service/staging/stone-stg-rh01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stg-rh01/deploy.yaml
@@ -2598,10 +2598,12 @@ spec:
           application-name: Konflux Staging
           custom-console-name: Konflux Staging
           custom-console-url: https://konflux-ui.apps.stone-stg-rh01.l2vh.p1.openshiftapps.com/
-          custom-console-url-pr-details: https://konflux-ui.apps.stone-stg-rh01.l2vh.p1.openshiftapps.com/ns/{{
-            namespace }}/pipelinerun/{{ pr }}
-          custom-console-url-pr-tasklog: https://konflux-ui.apps.stone-stg-rh01.l2vh.p1.openshiftapps.com/ns/{{
-            namespace }}/pipelinerun/{{ pr }}/logs/{{ task }}
+          custom-console-url-pr-details: https://konflux-ui.apps.stone-stg-rh01.l2vh.p1.openshiftapps.com/ns/{{namespace
+            }}/pipelinerun/{{ pr }}
+          custom-console-url-pr-tasklog: https://konflux-ui.apps.stone-stg-rh01.l2vh.p1.openshiftapps.com/ns/{{namespace
+            }}/pipelinerun/{{ pr }}/logs/{{ task }}
+          remember-ok-to-test: "false"
+          secret-github-app-token-scoped: "false"
   profile: all
   pruner:
     disabled: true

--- a/hack/new-cluster/templates/pipeline-service/deploy.yaml
+++ b/hack/new-cluster/templates/pipeline-service/deploy.yaml
@@ -2481,6 +2481,8 @@ spec:
 {% endraw %}
           custom-console-url-pr-tasklog: https://konflux-ui.apps.{{ longname }}.openshiftapps.com/ns/{% raw %}{{ namespace }}/pipelinerun/{{ pr }}/logs/{{ task }}
 {% endraw %}
+          remember-ok-to-test: "false"
+          secret-github-app-token-scoped: "false"
   profile: all
   pruner:
     disabled: false

--- a/hack/new-cluster/templates/pipeline-service/resources/update-tekton-config-pac.yaml
+++ b/hack/new-cluster/templates/pipeline-service/resources/update-tekton-config-pac.yaml
@@ -1,12 +1,18 @@
 ---
-- op: add
-  path: /spec/platforms/openshift/pipelinesAsCode/settings
-  value:
-    application-name: Konflux {{ shortname }}
-    custom-console-name: Konflux {{ shortname }}
-    custom-console-url: https://konflux-ui.apps.{{ longname }}.openshiftapps.com
-    custom-console-url-pr-details: https://konflux-ui.apps.{{ longname }}.openshiftapps.com/ns/{% raw %}{{ namespace }}/pipelinerun/{{ pr }}
+- op: replace
+  path: /spec/platforms/openshift/pipelinesAsCode/settings/application-name
+  value: Konflux {{ shortname }}
+- op: replace
+  path: /spec/platforms/openshift/pipelinesAsCode/settings/custom-console-name
+  value: Konflux {{ shortname }}
+- op: replace
+  path: /spec/platforms/openshift/pipelinesAsCode/settings/custom-console-url
+  value: https://konflux-ui.apps.{{ longname }}.openshiftapps.com
+- op: replace
+  path: /spec/platforms/openshift/pipelinesAsCode/settings/custom-console-url-pr-details
+  value: https://konflux-ui.apps.{{ longname }}.openshiftapps.com/ns/{% raw %}{{ namespace }}/pipelinerun/{{ pr }}
 {% endraw %}
-    custom-console-url-pr-tasklog: https://konflux-ui.apps.{{ longname }}.openshiftapps.com/ns/{% raw %}{{ namespace }}/pipelinerun/{{ pr }}/logs/{{ task }}
+- op: replace
+  path: /spec/platforms/openshift/pipelinesAsCode/settings/custom-console-url-pr-tasklog
+  value: https://konflux-ui.apps.{{ longname }}.openshiftapps.com/ns/{% raw %}{{ namespace }}/pipelinerun/{{ pr }}/logs/{{ task }}
 {% endraw %}
-    remember-ok-to-test: "false"


### PR DESCRIPTION
Previously every cluster used a kustomize patch to add the PaC settings object to the TektonConfig. Since most of the values were unique per cluster this was fine. However as global settings like `remember-ok-to-test` and `secret-github-app-token-scope` have been set, there is no need to duplicate the entire settings block per cluster. Instead, we can use Kustomize to override just the settings which are cluster-specific

Please note that the after refactoring the settings there are no substantive changes to the PaC config in each deployment, except for several clusters in which `remember-ok-to-test` was not propogated (`kflux-ocp-p01`, kflux-prd-rh02`, `kflux-prd-rh03`, and all but one staging cluster). 