### PR TITLE
Update store deadline and pruner time values

### DIFF
--- a/components/pipeline-service/production/base/main-pipeline-service-configuration.yaml
+++ b/components/pipeline-service/production/base/main-pipeline-service-configuration.yaml
@@ -1504,7 +1504,7 @@ spec:
         - -check_owner=false
         - -completed_run_grace_period=5m
         - -requeue_interval=2m
-        - -store_deadline=30m
+        - -store_deadline=90m
         - -forward_buffer=1m
         - -threadiness=32
         - -logs_api=true
@@ -1863,7 +1863,7 @@ spec:
   profile: all
   pruner:
     disabled: false
-    keep-since: 60
+    keep-since: 120
     resources:
       - pipelinerun
     schedule: '*/10 * * * *'

--- a/components/pipeline-service/production/kflux-ocp-p01/deploy.yaml
+++ b/components/pipeline-service/production/kflux-ocp-p01/deploy.yaml
@@ -1937,7 +1937,7 @@ spec:
         - -check_owner=false
         - -completed_run_grace_period=5m
         - -requeue_interval=2m
-        - -store_deadline=30m
+        - -store_deadline=90m
         - -forward_buffer=1m
         - -threadiness=32
         - -logs_api=true
@@ -2455,7 +2455,7 @@ spec:
   profile: all
   pruner:
     disabled: false
-    keep-since: 60
+    keep-since: 120
     resources:
     - pipelinerun
     schedule: '*/10 * * * *'

--- a/components/pipeline-service/production/kflux-prd-rh02/deploy.yaml
+++ b/components/pipeline-service/production/kflux-prd-rh02/deploy.yaml
@@ -1968,7 +1968,7 @@ spec:
         - -check_owner=false
         - -completed_run_grace_period=5m
         - -requeue_interval=2m
-        - -store_deadline=30m
+        - -store_deadline=90m
         - -forward_buffer=1m
         - -threadiness=32
         - -logs_api=true
@@ -2486,7 +2486,7 @@ spec:
   profile: all
   pruner:
     disabled: false
-    keep-since: 60
+    keep-since: 120
     resources:
     - pipelinerun
     schedule: '*/10 * * * *'

--- a/components/pipeline-service/production/kflux-prd-rh03/deploy.yaml
+++ b/components/pipeline-service/production/kflux-prd-rh03/deploy.yaml
@@ -1968,7 +1968,7 @@ spec:
         - -check_owner=false
         - -completed_run_grace_period=5m
         - -requeue_interval=2m
-        - -store_deadline=30m
+        - -store_deadline=90m
         - -forward_buffer=1m
         - -threadiness=32
         - -logs_api=true
@@ -2486,7 +2486,7 @@ spec:
   profile: all
   pruner:
     disabled: false
-    keep-since: 60
+    keep-since: 120
     resources:
     - pipelinerun
     schedule: '*/10 * * * *'

--- a/components/pipeline-service/production/kflux-rhel-p01/deploy.yaml
+++ b/components/pipeline-service/production/kflux-rhel-p01/deploy.yaml
@@ -1968,7 +1968,7 @@ spec:
         - -check_owner=false
         - -completed_run_grace_period=5m
         - -requeue_interval=2m
-        - -store_deadline=30m
+        - -store_deadline=90m
         - -forward_buffer=1m
         - -threadiness=32
         - -logs_api=true
@@ -2487,7 +2487,7 @@ spec:
   profile: all
   pruner:
     disabled: false
-    keep-since: 60
+    keep-since: 120
     resources:
     - pipelinerun
     schedule: '*/10 * * * *'

--- a/components/pipeline-service/production/stone-prd-rh01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prd-rh01/deploy.yaml
@@ -1937,7 +1937,7 @@ spec:
         - -check_owner=false
         - -completed_run_grace_period=5m
         - -requeue_interval=2m
-        - -store_deadline=30m
+        - -store_deadline=90m
         - -forward_buffer=1m
         - -threadiness=32
         - -logs_api=true
@@ -2456,7 +2456,7 @@ spec:
   profile: all
   pruner:
     disabled: false
-    keep-since: 60
+    keep-since: 120
     resources:
     - pipelinerun
     schedule: '*/10 * * * *'

--- a/components/pipeline-service/production/stone-prod-p01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prod-p01/deploy.yaml
@@ -1937,7 +1937,7 @@ spec:
         - -check_owner=false
         - -completed_run_grace_period=5m
         - -requeue_interval=2m
-        - -store_deadline=30m
+        - -store_deadline=90m
         - -forward_buffer=1m
         - -threadiness=32
         - -logs_api=true
@@ -2456,7 +2456,7 @@ spec:
   profile: all
   pruner:
     disabled: false
-    keep-since: 60
+    keep-since: 120
     resources:
     - pipelinerun
     schedule: '*/10 * * * *'

--- a/components/pipeline-service/production/stone-prod-p02/deploy.yaml
+++ b/components/pipeline-service/production/stone-prod-p02/deploy.yaml
@@ -1937,7 +1937,7 @@ spec:
         - -check_owner=false
         - -completed_run_grace_period=5m
         - -requeue_interval=2m
-        - -store_deadline=30m
+        - -store_deadline=90m
         - -forward_buffer=1m
         - -threadiness=32
         - -logs_api=true
@@ -2456,7 +2456,7 @@ spec:
   profile: all
   pruner:
     disabled: false
-    keep-since: 60
+    keep-since: 120
     resources:
     - pipelinerun
     schedule: '*/10 * * * *'


### PR DESCRIPTION
On the busiest production cluster, we see pipelineruns and more rarely taskruns are not reconciled timely resulting objects removed from the cluster before they are actually stored in the DB. With the updated values we wait longer before giving up and force remove the objects.
In addition we also scale up the number of replicas of the watcher controller. Once we see the effect of it, we can lower back the time values.