### PR TITLE
KFLUXINFRA-1734: Add a dashboard for Kueue

### DIFF
--- a/components/monitoring/grafana/base/dashboards/kueue/dashboard.yaml
+++ b/components/monitoring/grafana/base/dashboards/kueue/dashboard.yaml
@@ -1,0 +1,13 @@
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: kueue-dashboard
+  labels: 
+    app: appstudio-grafana
+spec:
+  instanceSelector:
+    matchLabels:
+      dashboards: "appstudio-grafana"
+  configMapRef:
+    name: kueue-dashboard
+    key: kueue.json

--- a/components/monitoring/grafana/base/dashboards/kueue/kueue.json
+++ b/components/monitoring/grafana/base/dashboards/kueue/kueue.json
@@ -1,4 +1,59 @@
 {
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS-APPSTUDIO-DS",
+      "label": "prometheus-appstudio-ds",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__elements": {},
+  "__requires": [
+    {
+      "type": "panel",
+      "id": "bargauge",
+      "name": "Bar gauge",
+      "version": ""
+    },
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "11.3.0"
+    },
+    {
+      "type": "panel",
+      "id": "heatmap",
+      "name": "Heatmap",
+      "version": ""
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "stat",
+      "name": "Stat",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "table",
+      "name": "Table",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    }
+  ],
   "annotations": {
     "list": [
       {
@@ -20,7 +75,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 31,
+  "id": null,
   "links": [],
   "panels": [
     {
@@ -38,7 +93,8 @@
     },
     {
       "datasource": {
-        "type": "prometheus"
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS-APPSTUDIO-DS}"
       },
       "description": "The latency of an admission attempt.",
       "fieldConfig": {
@@ -117,7 +173,11 @@
           "format": "heatmap",
           "legendFormat": "{{le}}",
           "range": true,
-          "refId": "A"
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS-APPSTUDIO-DS}"
+          }
         }
       ],
       "title": "Admission Attempt Latency",
@@ -190,7 +250,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "dfc8894e-f8dc-4020-94d4-1645256804b7"
+        "uid": "${DS_PROMETHEUS-APPSTUDIO-DS}"
       },
       "fieldConfig": {
         "defaults": {
@@ -221,23 +281,7 @@
           },
           "unit": "percent"
         },
-        "overrides": [
-          {
-            "__systemRef": "hideSeriesFrom",
-            "matcher": {
-              "id": "byNames",
-              "options": {
-                "mode": "exclude",
-                "names": [
-                  "{__name__=\"container_memory_usage_bytes\", container=\"manager\", endpoint=\"https-metrics\", id=\"/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod78570a7a_3357_433f_916f_2381e6bcdd58.slice/crio-ebfe1ccf6bbbc0ffc6b0dfa316e5f831dabf9c1cf1d68b70a0b39e93950bdf8c.scope\", image=\"quay.io/konflux-ci/tekton-kueue:222e9e201f7c99e30a673c3b0d8ee072c2a06c93\", instance=\"10.0.40.139:10250\", job=\"kubelet\", metrics_path=\"/metrics/cadvisor\", name=\"k8s_manager_tekton-kueue-controller-manager-547bc84598-78h68_tekton-kueue_78570a7a-3357-433f-916f-2381e6bcdd58_0\", namespace=\"tekton-kueue\", node=\"ip-10-0-40-139.us-west-2.compute.internal\", pod=\"tekton-kueue-controller-manager-547bc84598-78h68\", prometheus=\"openshift-monitoring/k8s\", service=\"kubelet\"}"
-                ],
-                "prefix": "All except:",
-                "readOnly": true
-              }
-            },
-            "properties": []
-          }
-        ]
+        "overrides": []
       },
       "gridPos": {
         "h": 8,
@@ -277,7 +321,11 @@
           "expr": "container_memory_working_set_bytes{namespace=~\"tekton-kueue|kueue-external-admission|openshift-kueue-operator\", image!=\"\"} / on (pod) kube_pod_resource_limit{resource='memory',namespace=~\"tekton-kueue|kueue-external-admission|openshift-kueue-operator\"} * 100",
           "legendFormat": "__auto",
           "range": true,
-          "refId": "A"
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS-APPSTUDIO-DS}"
+          }
         }
       ],
       "title": "Pods Memory Utilization",
@@ -286,7 +334,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "dfc8894e-f8dc-4020-94d4-1645256804b7"
+        "uid": "${DS_PROMETHEUS-APPSTUDIO-DS}"
       },
       "fieldConfig": {
         "defaults": {
@@ -317,23 +365,7 @@
           },
           "unit": "percent"
         },
-        "overrides": [
-          {
-            "__systemRef": "hideSeriesFrom",
-            "matcher": {
-              "id": "byNames",
-              "options": {
-                "mode": "exclude",
-                "names": [
-                  "{__name__=\"container_memory_usage_bytes\", container=\"manager\", endpoint=\"https-metrics\", id=\"/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod78570a7a_3357_433f_916f_2381e6bcdd58.slice/crio-ebfe1ccf6bbbc0ffc6b0dfa316e5f831dabf9c1cf1d68b70a0b39e93950bdf8c.scope\", image=\"quay.io/konflux-ci/tekton-kueue:222e9e201f7c99e30a673c3b0d8ee072c2a06c93\", instance=\"10.0.40.139:10250\", job=\"kubelet\", metrics_path=\"/metrics/cadvisor\", name=\"k8s_manager_tekton-kueue-controller-manager-547bc84598-78h68_tekton-kueue_78570a7a-3357-433f-916f-2381e6bcdd58_0\", namespace=\"tekton-kueue\", node=\"ip-10-0-40-139.us-west-2.compute.internal\", pod=\"tekton-kueue-controller-manager-547bc84598-78h68\", prometheus=\"openshift-monitoring/k8s\", service=\"kubelet\"}"
-                ],
-                "prefix": "All except:",
-                "readOnly": true
-              }
-            },
-            "properties": []
-          }
-        ]
+        "overrides": []
       },
       "gridPos": {
         "h": 8,
@@ -373,7 +405,11 @@
           "expr": "pod:container_cpu_usage:sum{namespace=~\"tekton-kueue|kueue-external-admission|openshift-kueue-operator\"} / on (pod) kube_pod_resource_limit{resource='cpu',namespace=~\"tekton-kueue|kueue-external-admission|openshift-kueue-operator\"} * 100",
           "legendFormat": "__auto",
           "range": true,
-          "refId": "A"
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS-APPSTUDIO-DS}"
+          }
         }
       ],
       "title": "Pods CPU Utilization",
@@ -592,6 +628,10 @@
       "type": "stat"
     },
     {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS-APPSTUDIO-DS}"
+      },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -599,6 +639,8 @@
           },
           "decimals": 1,
           "mappings": [],
+          "max": 100,
+          "min": 0,
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -657,7 +699,11 @@
           "instant": false,
           "legendFormat": "{{resource}}",
           "range": true,
-          "refId": "A"
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS-APPSTUDIO-DS}"
+          }
         }
       ],
       "title": "Resource Reservation / Nominal Quota",
@@ -674,7 +720,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "yellow"
+                "color": "yellow",
+                "value": null
               },
               {
                 "color": "semi-dark-green",
@@ -726,7 +773,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "dfc8894e-f8dc-4020-94d4-1645256804b7"
+        "uid": "${DS_PROMETHEUS-APPSTUDIO-DS}"
       },
       "description": "kueue_admission_wait_time_seconds",
       "fieldConfig": {
@@ -795,7 +842,11 @@
           "format": "heatmap",
           "legendFormat": "{{le}}",
           "range": true,
-          "refId": "A"
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS-APPSTUDIO-DS}"
+          }
         }
       ],
       "title": "Admission Wait Time",
@@ -804,7 +855,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "dfc8894e-f8dc-4020-94d4-1645256804b7"
+        "uid": "${DS_PROMETHEUS-APPSTUDIO-DS}"
       },
       "description": "The time between a workload was created or requeued until it got quota reservation",
       "fieldConfig": {
@@ -872,7 +923,11 @@
           "format": "heatmap",
           "legendFormat": "{{le}}",
           "range": true,
-          "refId": "A"
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS-APPSTUDIO-DS}"
+          }
         }
       ],
       "title": "Quota Reserved Wait Time",
@@ -881,7 +936,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "dfc8894e-f8dc-4020-94d4-1645256804b7"
+        "uid": "${DS_PROMETHEUS-APPSTUDIO-DS}"
       },
       "description": "The time from when a workload got the quota reservation until admission",
       "fieldConfig": {
@@ -949,14 +1004,18 @@
           "format": "heatmap",
           "legendFormat": "{{le}}",
           "range": true,
-          "refId": "A"
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS-APPSTUDIO-DS}"
+          }
         }
       ],
       "title": "Admission Check Wait Time",
       "type": "heatmap"
     },
     {
-      "collapsed": true,
+      "collapsed": false,
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -964,182 +1023,182 @@
         "y": 90
       },
       "id": 4,
-      "panels": [
-        {
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "thresholds"
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green"
-                  }
-                ]
-              }
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 7,
-            "w": 7,
-            "x": 0,
-            "y": 93
-          },
-          "id": 2,
-          "options": {
-            "colorMode": "value",
-            "graphMode": "area",
-            "justifyMode": "auto",
-            "orientation": "auto",
-            "percentChangeColorMode": "standard",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "showPercentChange": false,
-            "textMode": "auto",
-            "wideLayout": true
-          },
-          "pluginVersion": "11.3.0",
-          "targets": [
-            {
-              "editorMode": "code",
-              "expr": "sum(kube_namespace_labels{label_konflux_ci_dev_type=\"tenant\"})",
-              "legendFormat": "__auto",
-              "range": true,
-              "refId": "A"
-            }
-          ],
-          "title": "Number of Tenants",
-          "type": "stat"
-        },
-        {
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisBorderShow": false,
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "barWidthFactor": 0.6,
-                "drawStyle": "line",
-                "fillOpacity": 0,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "insertNulls": false,
-                "lineInterpolation": "linear",
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "auto",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "none"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green"
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              }
-            },
-            "overrides": [
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "max(etcd_mvcc_db_total_size_in_use_in_bytes)"
-                },
-                "properties": [
-                  {
-                    "id": "custom.axisPlacement",
-                    "value": "right"
-                  },
-                  {
-                    "id": "unit",
-                    "value": "decbytes"
-                  }
-                ]
-              }
-            ]
-          },
-          "gridPos": {
-            "h": 14,
-            "w": 13,
-            "x": 0,
-            "y": 100
-          },
-          "id": 15,
-          "options": {
-            "legend": {
-              "calcs": [],
-              "displayMode": "list",
-              "placement": "bottom",
-              "showLegend": true
-            },
-            "tooltip": {
-              "mode": "single",
-              "sort": "none"
-            }
-          },
-          "pluginVersion": "11.3.0",
-          "targets": [
-            {
-              "editorMode": "code",
-              "expr": "max(kueue_admitted_active_workloads{cluster_queue=\"cluster-pipeline-queue\"})",
-              "legendFormat": "__auto",
-              "range": true,
-              "refId": "A"
-            },
-            {
-              "editorMode": "code",
-              "exemplar": false,
-              "expr": "max(etcd_mvcc_db_total_size_in_use_in_bytes)",
-              "hide": false,
-              "instant": false,
-              "legendFormat": "__auto",
-              "range": true,
-              "refId": "B"
-            }
-          ],
-          "title": "Active Workloads vs Etcd Usage",
-          "type": "timeseries"
-        }
-      ],
+      "panels": [],
       "title": "Cluster Metrics",
       "type": "row"
+    },
+    {
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 7,
+        "x": 0,
+        "y": 91
+      },
+      "id": 2,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.3.0",
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "sum(kube_namespace_labels{label_konflux_ci_dev_type=\"tenant\"})",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Number of Tenants",
+      "type": "stat"
+    },
+    {
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "max(etcd_mvcc_db_total_size_in_use_in_bytes)"
+            },
+            "properties": [
+              {
+                "id": "custom.axisPlacement",
+                "value": "right"
+              },
+              {
+                "id": "unit",
+                "value": "decbytes"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 14,
+        "w": 13,
+        "x": 0,
+        "y": 98
+      },
+      "id": 15,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.3.0",
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "max(kueue_admitted_active_workloads{cluster_queue=\"cluster-pipeline-queue\"})",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "max(etcd_mvcc_db_total_size_in_use_in_bytes)",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Active Workloads vs Etcd Usage",
+      "type": "timeseries"
     }
   ],
-  "preload": false,
   "refresh": "auto",
   "schemaVersion": 40,
   "tags": [],
@@ -1153,7 +1212,7 @@
   "timepicker": {},
   "timezone": "",
   "title": "Kueue",
-  "uid": "feq3mrtohyepsf",
+  "uid": "ceq3r2cpy01z4a",
   "version": 1,
   "weekStart": ""
 }

--- a/components/monitoring/grafana/base/dashboards/kueue/kueue.json
+++ b/components/monitoring/grafana/base/dashboards/kueue/kueue.json
@@ -20,7 +20,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 8,
+  "id": 31,
   "links": [],
   "panels": [
     {
@@ -37,6 +37,9 @@
       "type": "row"
     },
     {
+      "datasource": {
+        "type": "prometheus"
+      },
       "description": "The latency of an admission attempt.",
       "fieldConfig": {
         "defaults": {
@@ -61,7 +64,7 @@
       },
       "id": 1,
       "options": {
-        "calculate": true,
+        "calculate": false,
         "calculation": {
           "xBuckets": {
             "mode": "size"
@@ -78,7 +81,7 @@
           "exponent": 0.5,
           "fill": "dark-orange",
           "mode": "scheme",
-          "reverse": true,
+          "reverse": false,
           "scale": "exponential",
           "scheme": "Oranges",
           "steps": 15
@@ -110,8 +113,9 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "sum by (le) (rate(kueue_admission_attempt_duration_seconds_bucket[$__range]))",
-          "legendFormat": "__auto",
+          "expr": "sum by (le) (increase(kueue_admission_attempt_duration_seconds_bucket[$__range]))",
+          "format": "heatmap",
+          "legendFormat": "{{le}}",
           "range": true,
           "refId": "A"
         }
@@ -145,7 +149,7 @@
       },
       "gridPos": {
         "h": 10,
-        "w": 11,
+        "w": 12,
         "x": 12,
         "y": 1
       },
@@ -184,12 +188,204 @@
       "type": "stat"
     },
     {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "dfc8894e-f8dc-4020-94d4-1645256804b7"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 0,
+          "fieldMinMax": false,
+          "mappings": [],
+          "max": 100,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 60
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": [
+          {
+            "__systemRef": "hideSeriesFrom",
+            "matcher": {
+              "id": "byNames",
+              "options": {
+                "mode": "exclude",
+                "names": [
+                  "{__name__=\"container_memory_usage_bytes\", container=\"manager\", endpoint=\"https-metrics\", id=\"/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod78570a7a_3357_433f_916f_2381e6bcdd58.slice/crio-ebfe1ccf6bbbc0ffc6b0dfa316e5f831dabf9c1cf1d68b70a0b39e93950bdf8c.scope\", image=\"quay.io/konflux-ci/tekton-kueue:222e9e201f7c99e30a673c3b0d8ee072c2a06c93\", instance=\"10.0.40.139:10250\", job=\"kubelet\", metrics_path=\"/metrics/cadvisor\", name=\"k8s_manager_tekton-kueue-controller-manager-547bc84598-78h68_tekton-kueue_78570a7a-3357-433f-916f-2381e6bcdd58_0\", namespace=\"tekton-kueue\", node=\"ip-10-0-40-139.us-west-2.compute.internal\", pod=\"tekton-kueue-controller-manager-547bc84598-78h68\", prometheus=\"openshift-monitoring/k8s\", service=\"kubelet\"}"
+                ],
+                "prefix": "All except:",
+                "readOnly": true
+              }
+            },
+            "properties": []
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 11
+      },
+      "id": 16,
+      "options": {
+        "displayMode": "lcd",
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "maxVizHeight": 300,
+        "minVizHeight": 16,
+        "minVizWidth": 8,
+        "namePlacement": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true,
+        "sizing": "auto",
+        "valueMode": "color"
+      },
+      "pluginVersion": "11.3.0",
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "container_memory_working_set_bytes{namespace=~\"tekton-kueue|kueue-external-admission|openshift-kueue-operator\", image!=\"\"} / on (pod) kube_pod_resource_limit{resource='memory',namespace=~\"tekton-kueue|kueue-external-admission|openshift-kueue-operator\"} * 100",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Pods Memory Utilization",
+      "type": "bargauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "dfc8894e-f8dc-4020-94d4-1645256804b7"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 1,
+          "fieldMinMax": false,
+          "mappings": [],
+          "max": 100,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 60
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": [
+          {
+            "__systemRef": "hideSeriesFrom",
+            "matcher": {
+              "id": "byNames",
+              "options": {
+                "mode": "exclude",
+                "names": [
+                  "{__name__=\"container_memory_usage_bytes\", container=\"manager\", endpoint=\"https-metrics\", id=\"/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod78570a7a_3357_433f_916f_2381e6bcdd58.slice/crio-ebfe1ccf6bbbc0ffc6b0dfa316e5f831dabf9c1cf1d68b70a0b39e93950bdf8c.scope\", image=\"quay.io/konflux-ci/tekton-kueue:222e9e201f7c99e30a673c3b0d8ee072c2a06c93\", instance=\"10.0.40.139:10250\", job=\"kubelet\", metrics_path=\"/metrics/cadvisor\", name=\"k8s_manager_tekton-kueue-controller-manager-547bc84598-78h68_tekton-kueue_78570a7a-3357-433f-916f-2381e6bcdd58_0\", namespace=\"tekton-kueue\", node=\"ip-10-0-40-139.us-west-2.compute.internal\", pod=\"tekton-kueue-controller-manager-547bc84598-78h68\", prometheus=\"openshift-monitoring/k8s\", service=\"kubelet\"}"
+                ],
+                "prefix": "All except:",
+                "readOnly": true
+              }
+            },
+            "properties": []
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 19
+      },
+      "id": 17,
+      "options": {
+        "displayMode": "lcd",
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "maxVizHeight": 300,
+        "minVizHeight": 16,
+        "minVizWidth": 8,
+        "namePlacement": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true,
+        "sizing": "auto",
+        "valueMode": "color"
+      },
+      "pluginVersion": "11.3.0",
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "pod:container_cpu_usage:sum{namespace=~\"tekton-kueue|kueue-external-admission|openshift-kueue-operator\"} / on (pod) kube_pod_resource_limit{resource='cpu',namespace=~\"tekton-kueue|kueue-external-admission|openshift-kueue-operator\"} * 100",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Pods CPU Utilization",
+      "type": "bargauge"
+    },
+    {
       "collapsed": false,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 15
+        "y": 27
       },
       "id": 6,
       "panels": [],
@@ -244,7 +440,7 @@
         "h": 6,
         "w": 3,
         "x": 0,
-        "y": 16
+        "y": 28
       },
       "id": 11,
       "options": {
@@ -305,7 +501,7 @@
         "h": 6,
         "w": 6,
         "x": 3,
-        "y": 16
+        "y": 28
       },
       "id": 9,
       "options": {
@@ -362,7 +558,7 @@
         "h": 6,
         "w": 15,
         "x": 9,
-        "y": 16
+        "y": 28
       },
       "id": 10,
       "options": {
@@ -424,7 +620,7 @@
         "h": 11,
         "w": 9,
         "x": 0,
-        "y": 22
+        "y": 34
       },
       "id": 7,
       "options": {
@@ -478,8 +674,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "yellow",
-                "value": null
+                "color": "yellow"
               },
               {
                 "color": "semi-dark-green",
@@ -495,7 +690,7 @@
         "h": 4,
         "w": 9,
         "x": 0,
-        "y": 33
+        "y": 45
       },
       "id": 8,
       "options": {
@@ -529,6 +724,10 @@
       "type": "stat"
     },
     {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "dfc8894e-f8dc-4020-94d4-1645256804b7"
+      },
       "description": "kueue_admission_wait_time_seconds",
       "fieldConfig": {
         "defaults": {
@@ -549,18 +748,18 @@
         "h": 15,
         "w": 14,
         "x": 0,
-        "y": 37
+        "y": 49
       },
       "id": 12,
       "options": {
-        "calculate": true,
+        "calculate": false,
         "cellGap": 1,
         "cellValues": {},
         "color": {
           "exponent": 0.5,
           "fill": "dark-orange",
           "mode": "scheme",
-          "reverse": true,
+          "reverse": false,
           "scale": "exponential",
           "scheme": "Oranges",
           "steps": 64
@@ -592,8 +791,9 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "sum by (le) (rate(kueue_admission_wait_time_seconds_bucket{cluster_queue=\"cluster-pipeline-queue\"}[$__range]))",
-          "legendFormat": "__auto",
+          "expr": "sum by (le) (increase(kueue_admission_wait_time_seconds_bucket{cluster_queue=\"cluster-pipeline-queue\"}[$__range]))",
+          "format": "heatmap",
+          "legendFormat": "{{le}}",
           "range": true,
           "refId": "A"
         }
@@ -602,6 +802,10 @@
       "type": "heatmap"
     },
     {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "dfc8894e-f8dc-4020-94d4-1645256804b7"
+      },
       "description": "The time between a workload was created or requeued until it got quota reservation",
       "fieldConfig": {
         "defaults": {
@@ -622,17 +826,17 @@
         "h": 13,
         "w": 14,
         "x": 0,
-        "y": 52
+        "y": 64
       },
       "id": 14,
       "options": {
-        "calculate": true,
+        "calculate": false,
         "cellGap": 1,
         "color": {
           "exponent": 0.5,
           "fill": "dark-orange",
           "mode": "scheme",
-          "reverse": true,
+          "reverse": false,
           "scale": "exponential",
           "scheme": "Oranges",
           "steps": 64
@@ -664,8 +868,9 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "sum by (le) (rate(kueue_quota_reserved_wait_time_seconds_bucket{cluster_queue=\"cluster-pipeline-queue\"}[$__range]))",
-          "legendFormat": "__auto",
+          "expr": "sum by (le) (increase(kueue_quota_reserved_wait_time_seconds_bucket{cluster_queue=\"cluster-pipeline-queue\"}[$__range]))",
+          "format": "heatmap",
+          "legendFormat": "{{le}}",
           "range": true,
           "refId": "A"
         }
@@ -674,6 +879,10 @@
       "type": "heatmap"
     },
     {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "dfc8894e-f8dc-4020-94d4-1645256804b7"
+      },
       "description": "The time from when a workload got the quota reservation until admission",
       "fieldConfig": {
         "defaults": {
@@ -694,17 +903,17 @@
         "h": 13,
         "w": 14,
         "x": 0,
-        "y": 65
+        "y": 77
       },
       "id": 13,
       "options": {
-        "calculate": true,
+        "calculate": false,
         "cellGap": 1,
         "color": {
           "exponent": 0.5,
           "fill": "dark-orange",
           "mode": "scheme",
-          "reverse": true,
+          "reverse": false,
           "scale": "exponential",
           "scheme": "Oranges",
           "steps": 64
@@ -736,8 +945,9 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "sum by (le) (rate(kueue_admission_checks_wait_time_seconds_bucket{cluster_queue=\"cluster-pipeline-queue\"}[$__range]))",
-          "legendFormat": "__auto",
+          "expr": "sum by (le) (increase(kueue_admission_checks_wait_time_seconds_bucket{cluster_queue=\"cluster-pipeline-queue\"}[$__range]))",
+          "format": "heatmap",
+          "legendFormat": "{{le}}",
           "range": true,
           "refId": "A"
         }
@@ -751,7 +961,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 78
+        "y": 90
       },
       "id": 4,
       "panels": [
@@ -766,8 +976,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   }
                 ]
               }
@@ -855,8 +1064,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -945,7 +1153,7 @@
   "timepicker": {},
   "timezone": "",
   "title": "Kueue",
-  "uid": "DVlSKyOVzzzz",
-  "version": 1143,
+  "uid": "feq3mrtohyepsf",
+  "version": 1,
   "weekStart": ""
 }

--- a/components/monitoring/grafana/base/dashboards/kueue/kueue.json
+++ b/components/monitoring/grafana/base/dashboards/kueue/kueue.json
@@ -1,0 +1,1010 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": 8,
+  "links": [],
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 3,
+      "panels": [],
+      "title": "Kueue Health",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "d56348f1-77d7-4896-a34f-495c93f4d0be"
+      },
+      "description": "The latency of an admission attempt.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "scaleDistribution": {
+              "type": "linear"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 14,
+        "w": 11,
+        "x": 0,
+        "y": 1
+      },
+      "id": 1,
+      "options": {
+        "calculate": true,
+        "calculation": {
+          "xBuckets": {
+            "mode": "size"
+          },
+          "yBuckets": {
+            "mode": "size",
+            "scale": {
+              "type": "linear"
+            }
+          }
+        },
+        "cellGap": 1,
+        "color": {
+          "exponent": 0.5,
+          "fill": "dark-orange",
+          "mode": "scheme",
+          "reverse": true,
+          "scale": "exponential",
+          "scheme": "Oranges",
+          "steps": 15
+        },
+        "exemplars": {
+          "color": "rgba(255,0,255,0.7)"
+        },
+        "filterValues": {
+          "le": 1e-9
+        },
+        "legend": {
+          "show": true
+        },
+        "rowsFrame": {
+          "layout": "auto"
+        },
+        "tooltip": {
+          "mode": "single",
+          "showColorScale": true,
+          "yHistogram": false
+        },
+        "yAxis": {
+          "axisPlacement": "left",
+          "reverse": false,
+          "unit": "s"
+        }
+      },
+      "pluginVersion": "11.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "d56348f1-77d7-4896-a34f-495c93f4d0be"
+          },
+          "editorMode": "code",
+          "expr": "sum by (le) (rate(kueue_admission_attempt_duration_seconds_bucket[$__range]))",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Admission Attempt Latency",
+      "type": "heatmap"
+    },
+    {
+      "datasource": {
+        "uid": "d56348f1-77d7-4896-a34f-495c93f4d0be"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "dark-red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 100
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 11,
+        "x": 12,
+        "y": 1
+      },
+      "id": 5,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.3.0",
+      "targets": [
+        {
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "(\n  kube_deployment_status_replicas_available{namespace=~\"openshift-kueue-operator|tekton-kueue|kueue-external-admission\"}\n)\n/\nclamp_min(\n  kube_deployment_spec_replicas{namespace=~\"openshift-kueue-operator|tekton-kueue|kueue-external-admission\"},\n  1\n) * 100",
+          "format": "time_series",
+          "instant": false,
+          "legendFormat": "{{deployment}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Replicas",
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 15
+      },
+      "id": 6,
+      "panels": [],
+      "title": "Cluster Queue",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "d56348f1-77d7-4896-a34f-495c93f4d0be"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "mappings": [
+            {
+              "options": {
+                "active": {
+                  "index": 0,
+                  "text": "🟢 Active"
+                },
+                "pending": {
+                  "index": 1,
+                  "text": "🟡 Pending"
+                },
+                "terminated": {
+                  "index": 2,
+                  "text": "🔴 Terminated"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 3,
+        "x": 0,
+        "y": 16
+      },
+      "id": 11,
+      "options": {
+        "cellHeight": "lg",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "frameIndex": 0,
+        "showHeader": true
+      },
+      "pluginVersion": "11.3.0",
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "max by (status) (kueue_cluster_queue_status{cluster_queue=\"cluster-pipeline-queue\"}) == 1",
+          "legendFormat": "{{status}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Queue Status",
+      "transformations": [
+        {
+          "id": "labelsToFields",
+          "options": {
+            "mode": "rows"
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "d56348f1-77d7-4896-a34f-495c93f4d0be"
+      },
+      "description": "The number of pending workloads",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 3,
+        "y": 16
+      },
+      "id": 9,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.3.0",
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "max by (status) (kueue_pending_workloads{cluster_queue=\"cluster-pipeline-queue\"})",
+          "legendFormat": "{{status}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Pending Workloads",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "d56348f1-77d7-4896-a34f-495c93f4d0be"
+      },
+      "description": "The number of admitted Workloads that are active (unsuspended and not finished)",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 15,
+        "x": 9,
+        "y": 16
+      },
+      "id": 10,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.3.0",
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "max(kueue_admitted_active_workloads{cluster_queue=\"cluster-pipeline-queue\"})",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Admitted Active Workloads",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "d56348f1-77d7-4896-a34f-495c93f4d0be"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 1,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 11,
+        "w": 9,
+        "x": 0,
+        "y": 22
+      },
+      "id": 7,
+      "options": {
+        "displayMode": "lcd",
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "maxVizHeight": 300,
+        "minVizHeight": 16,
+        "minVizWidth": 8,
+        "namePlacement": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true,
+        "sizing": "auto",
+        "valueMode": "color"
+      },
+      "pluginVersion": "11.3.0",
+      "targets": [
+        {
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "max by (resource) (kueue_cluster_queue_resource_reservation{cluster_queue=\"cluster-pipeline-queue\"} /kueue_cluster_queue_nominal_quota{cluster_queue=\"cluster-pipeline-queue\"} * 100)",
+          "format": "time_series",
+          "instant": false,
+          "legendFormat": "{{resource}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Resource Reservation / Nominal Quota",
+      "type": "bargauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "d56348f1-77d7-4896-a34f-495c93f4d0be"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "yellow",
+                "value": null
+              },
+              {
+                "color": "semi-dark-green",
+                "value": 100
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 9,
+        "x": 0,
+        "y": 33
+      },
+      "id": 8,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.3.0",
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "max by (resource) (kueue_cluster_queue_resource_usage{cluster_queue=\"cluster-pipeline-queue\"} / kueue_cluster_queue_resource_reservation{cluster_queue=\"cluster-pipeline-queue\"} * 100)",
+          "legendFormat": "{{resource}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Resource Usage / Reservation",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "d56348f1-77d7-4896-a34f-495c93f4d0be"
+      },
+      "description": "kueue_admission_wait_time_seconds",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "scaleDistribution": {
+              "type": "linear"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 15,
+        "w": 14,
+        "x": 0,
+        "y": 37
+      },
+      "id": 12,
+      "options": {
+        "calculate": true,
+        "cellGap": 1,
+        "cellValues": {},
+        "color": {
+          "exponent": 0.5,
+          "fill": "dark-orange",
+          "mode": "scheme",
+          "reverse": true,
+          "scale": "exponential",
+          "scheme": "Oranges",
+          "steps": 64
+        },
+        "exemplars": {
+          "color": "rgba(255,0,255,0.7)"
+        },
+        "filterValues": {
+          "le": 1e-9
+        },
+        "legend": {
+          "show": true
+        },
+        "rowsFrame": {
+          "layout": "auto"
+        },
+        "tooltip": {
+          "mode": "single",
+          "showColorScale": false,
+          "yHistogram": false
+        },
+        "yAxis": {
+          "axisPlacement": "left",
+          "reverse": false,
+          "unit": "s"
+        }
+      },
+      "pluginVersion": "11.3.0",
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "sum by (le) (rate(kueue_admission_wait_time_seconds_bucket{cluster_queue=\"cluster-pipeline-queue\"}[$__range]))",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Admission Wait Time",
+      "type": "heatmap"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "d56348f1-77d7-4896-a34f-495c93f4d0be"
+      },
+      "description": "The time between a workload was created or requeued until it got quota reservation",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "scaleDistribution": {
+              "type": "linear"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 13,
+        "w": 14,
+        "x": 0,
+        "y": 52
+      },
+      "id": 14,
+      "options": {
+        "calculate": true,
+        "cellGap": 1,
+        "color": {
+          "exponent": 0.5,
+          "fill": "dark-orange",
+          "mode": "scheme",
+          "reverse": true,
+          "scale": "exponential",
+          "scheme": "Oranges",
+          "steps": 64
+        },
+        "exemplars": {
+          "color": "rgba(255,0,255,0.7)"
+        },
+        "filterValues": {
+          "le": 1e-9
+        },
+        "legend": {
+          "show": true
+        },
+        "rowsFrame": {
+          "layout": "auto"
+        },
+        "tooltip": {
+          "mode": "single",
+          "showColorScale": false,
+          "yHistogram": false
+        },
+        "yAxis": {
+          "axisPlacement": "left",
+          "reverse": false,
+          "unit": "s"
+        }
+      },
+      "pluginVersion": "11.3.0",
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "sum by (le) (rate(kueue_quota_reserved_wait_time_seconds_bucket{cluster_queue=\"cluster-pipeline-queue\"}[$__range]))",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Quota Reserved Wait Time",
+      "type": "heatmap"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "d56348f1-77d7-4896-a34f-495c93f4d0be"
+      },
+      "description": "The time from when a workload got the quota reservation until admission",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "scaleDistribution": {
+              "type": "linear"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 13,
+        "w": 14,
+        "x": 0,
+        "y": 65
+      },
+      "id": 13,
+      "options": {
+        "calculate": true,
+        "cellGap": 1,
+        "color": {
+          "exponent": 0.5,
+          "fill": "dark-orange",
+          "mode": "scheme",
+          "reverse": true,
+          "scale": "exponential",
+          "scheme": "Oranges",
+          "steps": 64
+        },
+        "exemplars": {
+          "color": "rgba(255,0,255,0.7)"
+        },
+        "filterValues": {
+          "le": 1e-9
+        },
+        "legend": {
+          "show": true
+        },
+        "rowsFrame": {
+          "layout": "auto"
+        },
+        "tooltip": {
+          "mode": "single",
+          "showColorScale": false,
+          "yHistogram": false
+        },
+        "yAxis": {
+          "axisPlacement": "left",
+          "reverse": false,
+          "unit": "s"
+        }
+      },
+      "pluginVersion": "11.3.0",
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "sum by (le) (rate(kueue_admission_checks_wait_time_seconds_bucket{cluster_queue=\"cluster-pipeline-queue\"}[$__range]))",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Admission Check Wait Time",
+      "type": "heatmap"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 78
+      },
+      "id": 4,
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "d56348f1-77d7-4896-a34f-495c93f4d0be"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 7,
+            "x": 0,
+            "y": 93
+          },
+          "id": 2,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "percentChangeColorMode": "standard",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showPercentChange": false,
+            "textMode": "auto",
+            "wideLayout": true
+          },
+          "pluginVersion": "11.3.0",
+          "targets": [
+            {
+              "editorMode": "code",
+              "expr": "sum(kube_namespace_labels{label_konflux_ci_dev_type=\"tenant\"})",
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Number of Tenants",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "d56348f1-77d7-4896-a34f-495c93f4d0be"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "max(etcd_mvcc_db_total_size_in_use_in_bytes)"
+                },
+                "properties": [
+                  {
+                    "id": "custom.axisPlacement",
+                    "value": "right"
+                  },
+                  {
+                    "id": "unit",
+                    "value": "decbytes"
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 14,
+            "w": 13,
+            "x": 0,
+            "y": 100
+          },
+          "id": 15,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "11.3.0",
+          "targets": [
+            {
+              "editorMode": "code",
+              "expr": "max(kueue_admitted_active_workloads{cluster_queue=\"cluster-pipeline-queue\"})",
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "d56348f1-77d7-4896-a34f-495c93f4d0be"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "max(etcd_mvcc_db_total_size_in_use_in_bytes)",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "B"
+            }
+          ],
+          "title": "Active Workloads vs Etcd Usage",
+          "type": "timeseries"
+        }
+      ],
+      "title": "Cluster Metrics",
+      "type": "row"
+    }
+  ],
+  "preload": false,
+  "refresh": "auto",
+  "schemaVersion": 40,
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-5m",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Queue",
+  "uid": "DVlSKyOVzzzz",
+  "version": 1143,
+  "weekStart": ""
+}

--- a/components/monitoring/grafana/base/dashboards/kueue/kueue.json
+++ b/components/monitoring/grafana/base/dashboards/kueue/kueue.json
@@ -3,10 +3,6 @@
     "list": [
       {
         "builtIn": 1,
-        "datasource": {
-          "type": "grafana",
-          "uid": "-- Grafana --"
-        },
         "enable": true,
         "hide": true,
         "iconColor": "rgba(0, 211, 255, 1)",
@@ -41,10 +37,6 @@
       "type": "row"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "d56348f1-77d7-4896-a34f-495c93f4d0be"
-      },
       "description": "The latency of an admission attempt.",
       "fieldConfig": {
         "defaults": {
@@ -117,10 +109,6 @@
       "pluginVersion": "11.3.0",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "d56348f1-77d7-4896-a34f-495c93f4d0be"
-          },
           "editorMode": "code",
           "expr": "sum by (le) (rate(kueue_admission_attempt_duration_seconds_bucket[$__range]))",
           "legendFormat": "__auto",
@@ -132,9 +120,6 @@
       "type": "heatmap"
     },
     {
-      "datasource": {
-        "uid": "d56348f1-77d7-4896-a34f-495c93f4d0be"
-      },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -212,10 +197,6 @@
       "type": "row"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "d56348f1-77d7-4896-a34f-495c93f4d0be"
-      },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -301,10 +282,6 @@
       "type": "table"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "d56348f1-77d7-4896-a34f-495c93f4d0be"
-      },
       "description": "The number of pending workloads",
       "fieldConfig": {
         "defaults": {
@@ -362,10 +339,6 @@
       "type": "stat"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "d56348f1-77d7-4896-a34f-495c93f4d0be"
-      },
       "description": "The number of admitted Workloads that are active (unsuspended and not finished)",
       "fieldConfig": {
         "defaults": {
@@ -423,10 +396,6 @@
       "type": "stat"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "d56348f1-77d7-4896-a34f-495c93f4d0be"
-      },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -499,10 +468,6 @@
       "type": "bargauge"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "d56348f1-77d7-4896-a34f-495c93f4d0be"
-      },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -564,10 +529,6 @@
       "type": "stat"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "d56348f1-77d7-4896-a34f-495c93f4d0be"
-      },
       "description": "kueue_admission_wait_time_seconds",
       "fieldConfig": {
         "defaults": {
@@ -641,10 +602,6 @@
       "type": "heatmap"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "d56348f1-77d7-4896-a34f-495c93f4d0be"
-      },
       "description": "The time between a workload was created or requeued until it got quota reservation",
       "fieldConfig": {
         "defaults": {
@@ -717,10 +674,6 @@
       "type": "heatmap"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "d56348f1-77d7-4896-a34f-495c93f4d0be"
-      },
       "description": "The time from when a workload got the quota reservation until admission",
       "fieldConfig": {
         "defaults": {
@@ -803,10 +756,6 @@
       "id": 4,
       "panels": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "d56348f1-77d7-4896-a34f-495c93f4d0be"
-          },
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -863,10 +812,6 @@
           "type": "stat"
         },
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "d56348f1-77d7-4896-a34f-495c93f4d0be"
-          },
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -968,10 +913,6 @@
               "refId": "A"
             },
             {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "d56348f1-77d7-4896-a34f-495c93f4d0be"
-              },
               "editorMode": "code",
               "exemplar": false,
               "expr": "max(etcd_mvcc_db_total_size_in_use_in_bytes)",
@@ -1003,7 +944,7 @@
   },
   "timepicker": {},
   "timezone": "",
-  "title": "Queue",
+  "title": "Kueue",
   "uid": "DVlSKyOVzzzz",
   "version": 1143,
   "weekStart": ""

--- a/components/monitoring/grafana/base/dashboards/kueue/kustomization.yaml
+++ b/components/monitoring/grafana/base/dashboards/kueue/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - dashboard.yaml
+configMapGenerator:
+  - name: kueue-dashboard
+    files:
+      - kueue.json

--- a/components/monitoring/grafana/base/dashboards/kustomization.yaml
+++ b/components/monitoring/grafana/base/dashboards/kustomization.yaml
@@ -13,6 +13,7 @@ resources:
 - pipeline-service/
 - generic-dashboards/
 - namespace-lister/
+- kueue
 
 # Removing the installation of power-monitoring dashboard for now
 # - power-monitoring/


### PR DESCRIPTION
The dashboard will show:

- Kueue (and plugins) health status
- Cluster queue resource utilization
- Cluster queue Workloads status
- Cluster queue duration metrics for Workloads admission.