### PR TITLE
fix appstudio-pipelines-runner CR in prod rh02

### DIFF
--- a/components/pipeline-service/production/kflux-prd-rh02/deploy.yaml
+++ b/components/pipeline-service/production/kflux-prd-rh02/deploy.yaml
@@ -144,7 +144,7 @@ kind: ClusterRole
 metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "0"
-  name: appstudio-pipelines-runner
+  name: tekton-pipelines-controller-konflux-scc
 rules:
 - apiGroups:
   - security.openshift.io
@@ -823,7 +823,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: appstudio-pipelines-runner
+  name: tekton-pipelines-controller-konflux-scc
 subjects:
 - kind: ServiceAccount
   name: tekton-pipelines-controller

--- a/components/pipeline-service/production/kflux-prd-rh02/resources/scc-rbac.yaml
+++ b/components/pipeline-service/production/kflux-prd-rh02/resources/scc-rbac.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: appstudio-pipelines-runner
+  name: tekton-pipelines-controller-konflux-scc
   annotations:
     argocd.argoproj.io/sync-wave: "0"
 rules:
@@ -28,4 +28,4 @@ subjects:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: appstudio-pipelines-runner
+  name: tekton-pipelines-controller-konflux-scc


### PR DESCRIPTION
Both `toolchain-member-operator` and `pipeline-service` components are deploying the appstudio-pipelines-runner. This is causing failures.

Signed-off-by: Francesco Ilario <filario@redhat.com>
