### PR TITLE
fix appstudio pipelines runner cr conflict prod

### DIFF
--- a/components/pipeline-service/production/kflux-prd-rh03/deploy.yaml
+++ b/components/pipeline-service/production/kflux-prd-rh03/deploy.yaml
@@ -143,22 +143,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   annotations:
-    argocd.argoproj.io/sync-wave: "0"
-  name: appstudio-pipelines-runner
-rules:
-- apiGroups:
-  - security.openshift.io
-  resourceNames:
-  - appstudio-pipelines-scc
-  resources:
-  - securitycontextconstraints
-  verbs:
-  - use
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  annotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
     argocd.argoproj.io/sync-wave: "0"
   name: openshift-gitops-apply-tekton-config-parameters
@@ -369,6 +353,22 @@ rules:
   - get
   - list
   - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+  name: tekton-pipelines-controller-konflux-scc
+rules:
+- apiGroups:
+  - security.openshift.io
+  resourceNames:
+  - appstudio-pipelines-scc
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - use
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -823,7 +823,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: appstudio-pipelines-runner
+  name: tekton-pipelines-controller-konflux-scc
 subjects:
 - kind: ServiceAccount
   name: tekton-pipelines-controller

--- a/components/pipeline-service/production/kflux-prd-rh03/resources/scc-rbac.yaml
+++ b/components/pipeline-service/production/kflux-prd-rh03/resources/scc-rbac.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: appstudio-pipelines-runner
+  name: tekton-pipelines-controller-konflux-scc
   annotations:
     argocd.argoproj.io/sync-wave: "0"
 rules:
@@ -28,4 +28,4 @@ subjects:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: appstudio-pipelines-runner
+  name: tekton-pipelines-controller-konflux-scc

--- a/components/pipeline-service/production/kflux-rhel-p01/deploy.yaml
+++ b/components/pipeline-service/production/kflux-rhel-p01/deploy.yaml
@@ -143,22 +143,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   annotations:
-    argocd.argoproj.io/sync-wave: "0"
-  name: appstudio-pipelines-runner
-rules:
-- apiGroups:
-  - security.openshift.io
-  resourceNames:
-  - appstudio-pipelines-scc
-  resources:
-  - securitycontextconstraints
-  verbs:
-  - use
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  annotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
     argocd.argoproj.io/sync-wave: "0"
   name: openshift-gitops-apply-tekton-config-parameters
@@ -369,6 +353,22 @@ rules:
   - get
   - list
   - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+  name: tekton-pipelines-controller-konflux-scc
+rules:
+- apiGroups:
+  - security.openshift.io
+  resourceNames:
+  - appstudio-pipelines-scc
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - use
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -823,7 +823,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: appstudio-pipelines-runner
+  name: tekton-pipelines-controller-konflux-scc
 subjects:
 - kind: ServiceAccount
   name: tekton-pipelines-controller

--- a/components/pipeline-service/production/kflux-rhel-p01/resources/scc-rbac.yaml
+++ b/components/pipeline-service/production/kflux-rhel-p01/resources/scc-rbac.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: appstudio-pipelines-runner
+  name: tekton-pipelines-controller-konflux-scc
   annotations:
     argocd.argoproj.io/sync-wave: "0"
 rules:
@@ -28,4 +28,4 @@ subjects:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: appstudio-pipelines-runner
+  name: tekton-pipelines-controller-konflux-scc


### PR DESCRIPTION
Both `toolchain-member-operator` and `pipeline-service` components are deploying the appstudio-pipelines-runner. This is causing failures.

Requires:
* [x] #6861
* [x] #6865

Signed-off-by: Francesco Ilario <filario@redhat.com>

