### PR TITLE
Follow-up: Apply Resource Limits for Tekton Components in Production

### DIFF
--- a/components/pipeline-service/production/base/main-pipeline-service-configuration.yaml
+++ b/components/pipeline-service/production/base/main-pipeline-service-configuration.yaml
@@ -1771,6 +1771,136 @@ spec:
                     requests:
                       cpu: 400m
                       memory: 1Gi
+        pipelines-as-code-controller:
+          spec:
+            template:
+              spec:
+                containers:
+                  - name: pac-controller
+                    resources:
+                      limits:
+                        cpu: 400m
+                        memory: 250Mi
+                      requests:
+                        cpu: 400m
+                        memory: 250Mi
+        pipelines-as-code-watcher:
+          spec:
+            template:
+              spec:
+                containers:
+                  - name: pac-watcher
+                    resources:
+                      limits:
+                        cpu: 500m
+                        memory: 1Gi
+                      requests:
+                        cpu: 500m
+                        memory: 1Gi
+        pipelines-as-code-webhook:
+          spec:
+            template:
+              spec:
+                containers:
+                  - name: pac-webhook
+                    resources:
+                      limits:
+                        cpu: 400m
+                        memory: 250Mi
+                      requests:
+                        cpu: 400m
+                        memory: 250Mi
+        pipelines-console-plugin:
+          spec:
+            template:
+              spec:
+                containers:
+                  - name: pipelines-console-plugin
+                    resources:
+                      limits:
+                        cpu: 200m
+                        memory: 100Mi
+                      requests:
+                        cpu: 200m
+                        memory: 100Mi
+        tekton-chains-controller:
+          spec:
+            template:
+              spec:
+                containers:
+                  - name: tekton-chains-controller
+                    resources:
+                      limits:
+                        cpu: 500m
+                        memory: 1.5Gi
+                      requests:
+                        cpu: 500m
+                        memory: 1.5Gi
+        tekton-events-controller:
+          spec:
+            template:
+              spec:
+                containers:
+                  - name: tekton-events-controller
+                    resources:
+                      limits:
+                        cpu: 200m
+                        memory: 100Mi
+                      requests:
+                        cpu: 200m
+                        memory: 100Mi
+        tekton-triggers-controller:
+          spec:
+            template:
+              spec:
+                containers:
+                  - name: tekton-triggers-controller
+                    resources:
+                      limits:
+                        cpu: 400m
+                        memory: 250Mi
+                      requests:
+                        cpu: 400m
+                        memory: 250Mi
+        tekton-triggers-webhook:
+          spec:
+            template:
+              spec:
+                containers:
+                  - name: webhook
+                    resources:
+                      limits:
+                        cpu: 250m
+                        memory: 100Mi
+                      requests:
+                        cpu: 250m
+                        memory: 100Mi
+        tekton-triggers-core-interceptors:
+          spec:
+            template:
+              spec:
+                containers:
+                  - name: tekton-triggers-core-interceptors
+                    resources:
+                      limits:
+                        cpu: 500m
+                        memory: 1Gi
+                      requests:
+                        cpu: 500m
+                        memory: 1Gi
+        tkn-cli-serve:
+          spec:
+            template:
+              spec:
+                containers:
+                  - name: tkn-cli-serve
+                    resources:
+                      limits:
+                        cpu: 250m
+                        memory: 100Mi
+                      requests:
+                        cpu: 250m
+                        memory: 100Mi
       statefulSets:
         tekton-pipelines-remote-resolvers:
           spec:

--- a/components/pipeline-service/production/kflux-ocp-p01/deploy.yaml
+++ b/components/pipeline-service/production/kflux-ocp-p01/deploy.yaml
@@ -2327,6 +2327,84 @@ spec:
                 }
               }
       deployments:
+        pipelines-as-code-controller:
+          spec:
+            template:
+              spec:
+                containers:
+                - name: pac-controller
+                  resources:
+                    limits:
+                      cpu: 400m
+                      memory: 250Mi
+                    requests:
+                      cpu: 400m
+                      memory: 250Mi
+        pipelines-as-code-watcher:
+          spec:
+            template:
+              spec:
+                containers:
+                - name: pac-watcher
+                  resources:
+                    limits:
+                      cpu: 500m
+                      memory: 1Gi
+                    requests:
+                      cpu: 500m
+                      memory: 1Gi
+        pipelines-as-code-webhook:
+          spec:
+            template:
+              spec:
+                containers:
+                - name: pac-webhook
+                  resources:
+                    limits:
+                      cpu: 400m
+                      memory: 250Mi
+                    requests:
+                      cpu: 400m
+                      memory: 250Mi
+        pipelines-console-plugin:
+          spec:
+            template:
+              spec:
+                containers:
+                - name: pipelines-console-plugin
+                  resources:
+                    limits:
+                      cpu: 200m
+                      memory: 100Mi
+                    requests:
+                      cpu: 200m
+                      memory: 100Mi
+        tekton-chains-controller:
+          spec:
+            template:
+              spec:
+                containers:
+                - name: tekton-chains-controller
+                  resources:
+                    limits:
+                      cpu: 500m
+                      memory: 1.5Gi
+                    requests:
+                      cpu: 500m
+                      memory: 1.5Gi
+        tekton-events-controller:
+          spec:
+            template:
+              spec:
+                containers:
+                - name: tekton-events-controller
+                  resources:
+                    limits:
+                      cpu: 200m
+                      memory: 100Mi
+                    requests:
+                      cpu: 200m
+                      memory: 100Mi
         tekton-operator-proxy-webhook:
           spec:
             replicas: 2
@@ -2354,6 +2432,58 @@ spec:
                     requests:
                       cpu: 400m
                       memory: 1Gi
+        tekton-triggers-controller:
+          spec:
+            template:
+              spec:
+                containers:
+                - name: tekton-triggers-controller
+                  resources:
+                    limits:
+                      cpu: 400m
+                      memory: 250Mi
+                    requests:
+                      cpu: 400m
+                      memory: 250Mi
+        tekton-triggers-core-interceptors:
+          spec:
+            template:
+              spec:
+                containers:
+                - name: tekton-triggers-core-interceptors
+                  resources:
+                    limits:
+                      cpu: 500m
+                      memory: 1Gi
+                    requests:
+                      cpu: 500m
+                      memory: 1Gi
+        tekton-triggers-webhook:
+          spec:
+            template:
+              spec:
+                containers:
+                - name: webhook
+                  resources:
+                    limits:
+                      cpu: 250m
+                      memory: 100Mi
+                    requests:
+                      cpu: 250m
+                      memory: 100Mi
+        tkn-cli-serve:
+          spec:
+            template:
+              spec:
+                containers:
+                - name: tkn-cli-serve
+                  resources:
+                    limits:
+                      cpu: 250m
+                      memory: 100Mi
+                    requests:
+                      cpu: 250m
+                      memory: 100Mi
       disabled: false
       horizontalPodAutoscalers:
         tekton-operator-proxy-webhook:

--- a/components/pipeline-service/production/kflux-prd-rh02/deploy.yaml
+++ b/components/pipeline-service/production/kflux-prd-rh02/deploy.yaml
@@ -2358,6 +2358,84 @@ spec:
                 }
               }
       deployments:
+        pipelines-as-code-controller:
+          spec:
+            template:
+              spec:
+                containers:
+                - name: pac-controller
+                  resources:
+                    limits:
+                      cpu: 400m
+                      memory: 250Mi
+                    requests:
+                      cpu: 400m
+                      memory: 250Mi
+        pipelines-as-code-watcher:
+          spec:
+            template:
+              spec:
+                containers:
+                - name: pac-watcher
+                  resources:
+                    limits:
+                      cpu: 500m
+                      memory: 1Gi
+                    requests:
+                      cpu: 500m
+                      memory: 1Gi
+        pipelines-as-code-webhook:
+          spec:
+            template:
+              spec:
+                containers:
+                - name: pac-webhook
+                  resources:
+                    limits:
+                      cpu: 400m
+                      memory: 250Mi
+                    requests:
+                      cpu: 400m
+                      memory: 250Mi
+        pipelines-console-plugin:
+          spec:
+            template:
+              spec:
+                containers:
+                - name: pipelines-console-plugin
+                  resources:
+                    limits:
+                      cpu: 200m
+                      memory: 100Mi
+                    requests:
+                      cpu: 200m
+                      memory: 100Mi
+        tekton-chains-controller:
+          spec:
+            template:
+              spec:
+                containers:
+                - name: tekton-chains-controller
+                  resources:
+                    limits:
+                      cpu: 500m
+                      memory: 1.5Gi
+                    requests:
+                      cpu: 500m
+                      memory: 1.5Gi
+        tekton-events-controller:
+          spec:
+            template:
+              spec:
+                containers:
+                - name: tekton-events-controller
+                  resources:
+                    limits:
+                      cpu: 200m
+                      memory: 100Mi
+                    requests:
+                      cpu: 200m
+                      memory: 100Mi
         tekton-operator-proxy-webhook:
           spec:
             replicas: 2
@@ -2385,6 +2463,58 @@ spec:
                     requests:
                       cpu: 400m
                       memory: 1Gi
+        tekton-triggers-controller:
+          spec:
+            template:
+              spec:
+                containers:
+                - name: tekton-triggers-controller
+                  resources:
+                    limits:
+                      cpu: 400m
+                      memory: 250Mi
+                    requests:
+                      cpu: 400m
+                      memory: 250Mi
+        tekton-triggers-core-interceptors:
+          spec:
+            template:
+              spec:
+                containers:
+                - name: tekton-triggers-core-interceptors
+                  resources:
+                    limits:
+                      cpu: 500m
+                      memory: 1Gi
+                    requests:
+                      cpu: 500m
+                      memory: 1Gi
+        tekton-triggers-webhook:
+          spec:
+            template:
+              spec:
+                containers:
+                - name: webhook
+                  resources:
+                    limits:
+                      cpu: 250m
+                      memory: 100Mi
+                    requests:
+                      cpu: 250m
+                      memory: 100Mi
+        tkn-cli-serve:
+          spec:
+            template:
+              spec:
+                containers:
+                - name: tkn-cli-serve
+                  resources:
+                    limits:
+                      cpu: 250m
+                      memory: 100Mi
+                    requests:
+                      cpu: 250m
+                      memory: 100Mi
       disabled: false
       horizontalPodAutoscalers:
         tekton-operator-proxy-webhook:

--- a/components/pipeline-service/production/kflux-prd-rh03/deploy.yaml
+++ b/components/pipeline-service/production/kflux-prd-rh03/deploy.yaml
@@ -2358,6 +2358,84 @@ spec:
                 }
               }
       deployments:
+        pipelines-as-code-controller:
+          spec:
+            template:
+              spec:
+                containers:
+                - name: pac-controller
+                  resources:
+                    limits:
+                      cpu: 400m
+                      memory: 250Mi
+                    requests:
+                      cpu: 400m
+                      memory: 250Mi
+        pipelines-as-code-watcher:
+          spec:
+            template:
+              spec:
+                containers:
+                - name: pac-watcher
+                  resources:
+                    limits:
+                      cpu: 500m
+                      memory: 1Gi
+                    requests:
+                      cpu: 500m
+                      memory: 1Gi
+        pipelines-as-code-webhook:
+          spec:
+            template:
+              spec:
+                containers:
+                - name: pac-webhook
+                  resources:
+                    limits:
+                      cpu: 400m
+                      memory: 250Mi
+                    requests:
+                      cpu: 400m
+                      memory: 250Mi
+        pipelines-console-plugin:
+          spec:
+            template:
+              spec:
+                containers:
+                - name: pipelines-console-plugin
+                  resources:
+                    limits:
+                      cpu: 200m
+                      memory: 100Mi
+                    requests:
+                      cpu: 200m
+                      memory: 100Mi
+        tekton-chains-controller:
+          spec:
+            template:
+              spec:
+                containers:
+                - name: tekton-chains-controller
+                  resources:
+                    limits:
+                      cpu: 500m
+                      memory: 1.5Gi
+                    requests:
+                      cpu: 500m
+                      memory: 1.5Gi
+        tekton-events-controller:
+          spec:
+            template:
+              spec:
+                containers:
+                - name: tekton-events-controller
+                  resources:
+                    limits:
+                      cpu: 200m
+                      memory: 100Mi
+                    requests:
+                      cpu: 200m
+                      memory: 100Mi
         tekton-operator-proxy-webhook:
           spec:
             replicas: 2
@@ -2385,6 +2463,58 @@ spec:
                     requests:
                       cpu: 400m
                       memory: 1Gi
+        tekton-triggers-controller:
+          spec:
+            template:
+              spec:
+                containers:
+                - name: tekton-triggers-controller
+                  resources:
+                    limits:
+                      cpu: 400m
+                      memory: 250Mi
+                    requests:
+                      cpu: 400m
+                      memory: 250Mi
+        tekton-triggers-core-interceptors:
+          spec:
+            template:
+              spec:
+                containers:
+                - name: tekton-triggers-core-interceptors
+                  resources:
+                    limits:
+                      cpu: 500m
+                      memory: 1Gi
+                    requests:
+                      cpu: 500m
+                      memory: 1Gi
+        tekton-triggers-webhook:
+          spec:
+            template:
+              spec:
+                containers:
+                - name: webhook
+                  resources:
+                    limits:
+                      cpu: 250m
+                      memory: 100Mi
+                    requests:
+                      cpu: 250m
+                      memory: 100Mi
+        tkn-cli-serve:
+          spec:
+            template:
+              spec:
+                containers:
+                - name: tkn-cli-serve
+                  resources:
+                    limits:
+                      cpu: 250m
+                      memory: 100Mi
+                    requests:
+                      cpu: 250m
+                      memory: 100Mi
       disabled: false
       horizontalPodAutoscalers:
         tekton-operator-proxy-webhook:

--- a/components/pipeline-service/production/kflux-rhel-p01/deploy.yaml
+++ b/components/pipeline-service/production/kflux-rhel-p01/deploy.yaml
@@ -2358,6 +2358,84 @@ spec:
                 }
               }
       deployments:
+        pipelines-as-code-controller:
+          spec:
+            template:
+              spec:
+                containers:
+                - name: pac-controller
+                  resources:
+                    limits:
+                      cpu: 400m
+                      memory: 250Mi
+                    requests:
+                      cpu: 400m
+                      memory: 250Mi
+        pipelines-as-code-watcher:
+          spec:
+            template:
+              spec:
+                containers:
+                - name: pac-watcher
+                  resources:
+                    limits:
+                      cpu: 500m
+                      memory: 1Gi
+                    requests:
+                      cpu: 500m
+                      memory: 1Gi
+        pipelines-as-code-webhook:
+          spec:
+            template:
+              spec:
+                containers:
+                - name: pac-webhook
+                  resources:
+                    limits:
+                      cpu: 400m
+                      memory: 250Mi
+                    requests:
+                      cpu: 400m
+                      memory: 250Mi
+        pipelines-console-plugin:
+          spec:
+            template:
+              spec:
+                containers:
+                - name: pipelines-console-plugin
+                  resources:
+                    limits:
+                      cpu: 200m
+                      memory: 100Mi
+                    requests:
+                      cpu: 200m
+                      memory: 100Mi
+        tekton-chains-controller:
+          spec:
+            template:
+              spec:
+                containers:
+                - name: tekton-chains-controller
+                  resources:
+                    limits:
+                      cpu: 500m
+                      memory: 1.5Gi
+                    requests:
+                      cpu: 500m
+                      memory: 1.5Gi
+        tekton-events-controller:
+          spec:
+            template:
+              spec:
+                containers:
+                - name: tekton-events-controller
+                  resources:
+                    limits:
+                      cpu: 200m
+                      memory: 100Mi
+                    requests:
+                      cpu: 200m
+                      memory: 100Mi
         tekton-operator-proxy-webhook:
           spec:
             replicas: 2
@@ -2385,6 +2463,58 @@ spec:
                     requests:
                       cpu: 400m
                       memory: 1Gi
+        tekton-triggers-controller:
+          spec:
+            template:
+              spec:
+                containers:
+                - name: tekton-triggers-controller
+                  resources:
+                    limits:
+                      cpu: 400m
+                      memory: 250Mi
+                    requests:
+                      cpu: 400m
+                      memory: 250Mi
+        tekton-triggers-core-interceptors:
+          spec:
+            template:
+              spec:
+                containers:
+                - name: tekton-triggers-core-interceptors
+                  resources:
+                    limits:
+                      cpu: 500m
+                      memory: 1Gi
+                    requests:
+                      cpu: 500m
+                      memory: 1Gi
+        tekton-triggers-webhook:
+          spec:
+            template:
+              spec:
+                containers:
+                - name: webhook
+                  resources:
+                    limits:
+                      cpu: 250m
+                      memory: 100Mi
+                    requests:
+                      cpu: 250m
+                      memory: 100Mi
+        tkn-cli-serve:
+          spec:
+            template:
+              spec:
+                containers:
+                - name: tkn-cli-serve
+                  resources:
+                    limits:
+                      cpu: 250m
+                      memory: 100Mi
+                    requests:
+                      cpu: 250m
+                      memory: 100Mi
       disabled: false
       horizontalPodAutoscalers:
         tekton-operator-proxy-webhook:

--- a/components/pipeline-service/production/stone-prd-rh01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prd-rh01/deploy.yaml
@@ -2327,6 +2327,84 @@ spec:
                 }
               }
       deployments:
+        pipelines-as-code-controller:
+          spec:
+            template:
+              spec:
+                containers:
+                - name: pac-controller
+                  resources:
+                    limits:
+                      cpu: 400m
+                      memory: 250Mi
+                    requests:
+                      cpu: 400m
+                      memory: 250Mi
+        pipelines-as-code-watcher:
+          spec:
+            template:
+              spec:
+                containers:
+                - name: pac-watcher
+                  resources:
+                    limits:
+                      cpu: 500m
+                      memory: 1Gi
+                    requests:
+                      cpu: 500m
+                      memory: 1Gi
+        pipelines-as-code-webhook:
+          spec:
+            template:
+              spec:
+                containers:
+                - name: pac-webhook
+                  resources:
+                    limits:
+                      cpu: 400m
+                      memory: 250Mi
+                    requests:
+                      cpu: 400m
+                      memory: 250Mi
+        pipelines-console-plugin:
+          spec:
+            template:
+              spec:
+                containers:
+                - name: pipelines-console-plugin
+                  resources:
+                    limits:
+                      cpu: 200m
+                      memory: 100Mi
+                    requests:
+                      cpu: 200m
+                      memory: 100Mi
+        tekton-chains-controller:
+          spec:
+            template:
+              spec:
+                containers:
+                - name: tekton-chains-controller
+                  resources:
+                    limits:
+                      cpu: 500m
+                      memory: 1.5Gi
+                    requests:
+                      cpu: 500m
+                      memory: 1.5Gi
+        tekton-events-controller:
+          spec:
+            template:
+              spec:
+                containers:
+                - name: tekton-events-controller
+                  resources:
+                    limits:
+                      cpu: 200m
+                      memory: 100Mi
+                    requests:
+                      cpu: 200m
+                      memory: 100Mi
         tekton-operator-proxy-webhook:
           spec:
             replicas: 2
@@ -2354,6 +2432,58 @@ spec:
                     requests:
                       cpu: 400m
                       memory: 1Gi
+        tekton-triggers-controller:
+          spec:
+            template:
+              spec:
+                containers:
+                - name: tekton-triggers-controller
+                  resources:
+                    limits:
+                      cpu: 400m
+                      memory: 250Mi
+                    requests:
+                      cpu: 400m
+                      memory: 250Mi
+        tekton-triggers-core-interceptors:
+          spec:
+            template:
+              spec:
+                containers:
+                - name: tekton-triggers-core-interceptors
+                  resources:
+                    limits:
+                      cpu: 500m
+                      memory: 1Gi
+                    requests:
+                      cpu: 500m
+                      memory: 1Gi
+        tekton-triggers-webhook:
+          spec:
+            template:
+              spec:
+                containers:
+                - name: webhook
+                  resources:
+                    limits:
+                      cpu: 250m
+                      memory: 100Mi
+                    requests:
+                      cpu: 250m
+                      memory: 100Mi
+        tkn-cli-serve:
+          spec:
+            template:
+              spec:
+                containers:
+                - name: tkn-cli-serve
+                  resources:
+                    limits:
+                      cpu: 250m
+                      memory: 100Mi
+                    requests:
+                      cpu: 250m
+                      memory: 100Mi
       disabled: false
       horizontalPodAutoscalers:
         tekton-operator-proxy-webhook:

--- a/components/pipeline-service/production/stone-prod-p01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prod-p01/deploy.yaml
@@ -2327,6 +2327,84 @@ spec:
                 }
               }
       deployments:
+        pipelines-as-code-controller:
+          spec:
+            template:
+              spec:
+                containers:
+                - name: pac-controller
+                  resources:
+                    limits:
+                      cpu: 400m
+                      memory: 250Mi
+                    requests:
+                      cpu: 400m
+                      memory: 250Mi
+        pipelines-as-code-watcher:
+          spec:
+            template:
+              spec:
+                containers:
+                - name: pac-watcher
+                  resources:
+                    limits:
+                      cpu: 500m
+                      memory: 1Gi
+                    requests:
+                      cpu: 500m
+                      memory: 1Gi
+        pipelines-as-code-webhook:
+          spec:
+            template:
+              spec:
+                containers:
+                - name: pac-webhook
+                  resources:
+                    limits:
+                      cpu: 400m
+                      memory: 250Mi
+                    requests:
+                      cpu: 400m
+                      memory: 250Mi
+        pipelines-console-plugin:
+          spec:
+            template:
+              spec:
+                containers:
+                - name: pipelines-console-plugin
+                  resources:
+                    limits:
+                      cpu: 200m
+                      memory: 100Mi
+                    requests:
+                      cpu: 200m
+                      memory: 100Mi
+        tekton-chains-controller:
+          spec:
+            template:
+              spec:
+                containers:
+                - name: tekton-chains-controller
+                  resources:
+                    limits:
+                      cpu: 500m
+                      memory: 1.5Gi
+                    requests:
+                      cpu: 500m
+                      memory: 1.5Gi
+        tekton-events-controller:
+          spec:
+            template:
+              spec:
+                containers:
+                - name: tekton-events-controller
+                  resources:
+                    limits:
+                      cpu: 200m
+                      memory: 100Mi
+                    requests:
+                      cpu: 200m
+                      memory: 100Mi
         tekton-operator-proxy-webhook:
           spec:
             replicas: 2
@@ -2354,6 +2432,58 @@ spec:
                     requests:
                       cpu: 400m
                       memory: 1Gi
+        tekton-triggers-controller:
+          spec:
+            template:
+              spec:
+                containers:
+                - name: tekton-triggers-controller
+                  resources:
+                    limits:
+                      cpu: 400m
+                      memory: 250Mi
+                    requests:
+                      cpu: 400m
+                      memory: 250Mi
+        tekton-triggers-core-interceptors:
+          spec:
+            template:
+              spec:
+                containers:
+                - name: tekton-triggers-core-interceptors
+                  resources:
+                    limits:
+                      cpu: 500m
+                      memory: 1Gi
+                    requests:
+                      cpu: 500m
+                      memory: 1Gi
+        tekton-triggers-webhook:
+          spec:
+            template:
+              spec:
+                containers:
+                - name: webhook
+                  resources:
+                    limits:
+                      cpu: 250m
+                      memory: 100Mi
+                    requests:
+                      cpu: 250m
+                      memory: 100Mi
+        tkn-cli-serve:
+          spec:
+            template:
+              spec:
+                containers:
+                - name: tkn-cli-serve
+                  resources:
+                    limits:
+                      cpu: 250m
+                      memory: 100Mi
+                    requests:
+                      cpu: 250m
+                      memory: 100Mi
       disabled: false
       horizontalPodAutoscalers:
         tekton-operator-proxy-webhook:

--- a/components/pipeline-service/production/stone-prod-p02/deploy.yaml
+++ b/components/pipeline-service/production/stone-prod-p02/deploy.yaml
@@ -2327,6 +2327,84 @@ spec:
                 }
               }
       deployments:
+        pipelines-as-code-controller:
+          spec:
+            template:
+              spec:
+                containers:
+                - name: pac-controller
+                  resources:
+                    limits:
+                      cpu: 400m
+                      memory: 250Mi
+                    requests:
+                      cpu: 400m
+                      memory: 250Mi
+        pipelines-as-code-watcher:
+          spec:
+            template:
+              spec:
+                containers:
+                - name: pac-watcher
+                  resources:
+                    limits:
+                      cpu: 500m
+                      memory: 1Gi
+                    requests:
+                      cpu: 500m
+                      memory: 1Gi
+        pipelines-as-code-webhook:
+          spec:
+            template:
+              spec:
+                containers:
+                - name: pac-webhook
+                  resources:
+                    limits:
+                      cpu: 400m
+                      memory: 250Mi
+                    requests:
+                      cpu: 400m
+                      memory: 250Mi
+        pipelines-console-plugin:
+          spec:
+            template:
+              spec:
+                containers:
+                - name: pipelines-console-plugin
+                  resources:
+                    limits:
+                      cpu: 200m
+                      memory: 100Mi
+                    requests:
+                      cpu: 200m
+                      memory: 100Mi
+        tekton-chains-controller:
+          spec:
+            template:
+              spec:
+                containers:
+                - name: tekton-chains-controller
+                  resources:
+                    limits:
+                      cpu: 500m
+                      memory: 1.5Gi
+                    requests:
+                      cpu: 500m
+                      memory: 1.5Gi
+        tekton-events-controller:
+          spec:
+            template:
+              spec:
+                containers:
+                - name: tekton-events-controller
+                  resources:
+                    limits:
+                      cpu: 200m
+                      memory: 100Mi
+                    requests:
+                      cpu: 200m
+                      memory: 100Mi
         tekton-operator-proxy-webhook:
           spec:
             replicas: 2
@@ -2354,6 +2432,58 @@ spec:
                     requests:
                       cpu: 400m
                       memory: 1Gi
+        tekton-triggers-controller:
+          spec:
+            template:
+              spec:
+                containers:
+                - name: tekton-triggers-controller
+                  resources:
+                    limits:
+                      cpu: 400m
+                      memory: 250Mi
+                    requests:
+                      cpu: 400m
+                      memory: 250Mi
+        tekton-triggers-core-interceptors:
+          spec:
+            template:
+              spec:
+                containers:
+                - name: tekton-triggers-core-interceptors
+                  resources:
+                    limits:
+                      cpu: 500m
+                      memory: 1Gi
+                    requests:
+                      cpu: 500m
+                      memory: 1Gi
+        tekton-triggers-webhook:
+          spec:
+            template:
+              spec:
+                containers:
+                - name: webhook
+                  resources:
+                    limits:
+                      cpu: 250m
+                      memory: 100Mi
+                    requests:
+                      cpu: 250m
+                      memory: 100Mi
+        tkn-cli-serve:
+          spec:
+            template:
+              spec:
+                containers:
+                - name: tkn-cli-serve
+                  resources:
+                    limits:
+                      cpu: 250m
+                      memory: 100Mi
+                    requests:
+                      cpu: 250m
+                      memory: 100Mi
       disabled: false
       horizontalPodAutoscalers:
         tekton-operator-proxy-webhook:


### PR DESCRIPTION
This PR mirrors the changes introduced in [#6435](https://github.com/redhat-appstudio/infra-deployments/pull/6435) by applying CPU and memory limits for Tekton components in the production environments.