### PR TITLE
etcd-shield: use in-memory IPC in staging

### DIFF
--- a/components/etcd-shield/base/deployment.yaml
+++ b/components/etcd-shield/base/deployment.yaml
@@ -36,6 +36,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: "STATE_MANAGER"
+          value: "in-memory"
         image: etcd-shield:latest
         name: etcd-shield
         imagePullPolicy: IfNotPresent

--- a/components/etcd-shield/base/kustomization.yaml
+++ b/components/etcd-shield/base/kustomization.yaml
@@ -10,7 +10,7 @@ configMapGenerator:
 images:
 - name: etcd-shield
   newName: quay.io/konflux-ci/etcd-shield
-  newTag: 9e7f8f586294e0866a719e98e093e6b55873bf26
+  newTag: 422de3326c0890fabfb1d3b7eb9d4d1a25881030
 namespace: etcd-shield
 resources:
 - deployment.yaml


### PR DESCRIPTION
Etcd-shield has two sets of threads:
- One set queries alertmanager for etcd's state.
- One set handles admission requests.

These threads communicated by reading/writing serialized state to a configmap.  However, etcd-shield now supports communicating this state over memory shared between threads.  Configure etcd-shield to use this new IPC mechanism.