### PR TITLE
etcd-shield: use in-memory IPC in production

### DIFF
--- a/components/etcd-shield/production/base/deployment.yaml
+++ b/components/etcd-shield/production/base/deployment.yaml
@@ -35,6 +35,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: "STATE_MANAGER"
+          value: "in-memory"
         image: etcd-shield:latest
         name: etcd-shield
         imagePullPolicy: IfNotPresent

--- a/components/etcd-shield/production/base/kustomization.yaml
+++ b/components/etcd-shield/production/base/kustomization.yaml
@@ -10,7 +10,7 @@ configMapGenerator:
 images:
 - name: etcd-shield
   newName: quay.io/konflux-ci/etcd-shield
-  newTag: 3de52a71e086e152b3d2b33bfc897ce7bf8ea0dd
+  newTag: 422de3326c0890fabfb1d3b7eb9d4d1a25881030
 namespace: etcd-shield
 resources:
 - deployment.yaml


### PR DESCRIPTION
Etcd-shield has two sets of threads:
- One set queries alertmanager for etcd's state.
- One set handles admission requests.

These threads communicated by reading/writing serialized state to a configmap.  However, etcd-shield now supports communicating this state over memory shared between threads.  Configure etcd-shield to use this new IPC mechanism.

Production version of #6875.