### PR TITLE
Upgrade OADP operator on all clusters

### DIFF
--- a/components/backup/base/all-clusters/oadp/install-oadp.yaml
+++ b/components/backup/base/all-clusters/oadp/install-oadp.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "-2"
 spec:
-  channel: stable-1.3
+  channel: stable-1.4
   installPlanApproval: Automatic
   name: redhat-oadp-operator
   source: redhat-operators

--- a/components/backup/staging/stone-stage-p01/dpa-channel-patch.yaml
+++ b/components/backup/staging/stone-stage-p01/dpa-channel-patch.yaml
@@ -1,3 +1,0 @@
-- op: replace
-  path: /spec/channel
-  value: stable-1.4

--- a/components/backup/staging/stone-stage-p01/kustomization.yaml
+++ b/components/backup/staging/stone-stage-p01/kustomization.yaml
@@ -23,9 +23,3 @@ patches:
       kind: DataProtectionApplication
       name: velero-aws
     path: dpa-kmskeyid-patch.yaml
-  - target:
-      group: operators.coreos.com
-      version: v1alpha1
-      kind: Subscription
-      name: redhat-oadp-operator
-    path: dpa-channel-patch.yaml

--- a/components/backup/staging/stone-stg-rh01/dpa-channel-patch.yaml
+++ b/components/backup/staging/stone-stg-rh01/dpa-channel-patch.yaml
@@ -1,3 +1,0 @@
-- op: replace
-  path: /spec/channel
-  value: stable-1.4

--- a/components/backup/staging/stone-stg-rh01/kustomization.yaml
+++ b/components/backup/staging/stone-stg-rh01/kustomization.yaml
@@ -21,9 +21,3 @@ patches:
       kind: DataProtectionApplication
       name: velero-aws
     path: dpa-kmskeyid-patch.yaml
-  - target:
-      group: operators.coreos.com
-      version: v1alpha1
-      kind: Subscription
-      name: redhat-oadp-operator
-    path: dpa-channel-patch.yaml


### PR DESCRIPTION
The update is required for upgrading the cluster to 4.16.

```
openshift-adp/oadp-operator.v1.3.6 is incompatible with OpenShift minor versions greater than 4.15
```

[KFLUXINFRA-1760](https://issues.redhat.com//browse/KFLUXINFRA-1760)