### PR TITLE
KubeArchive: add 'resource_type' label to the monitoring stack

### DIFF
--- a/components/monitoring/prometheus/base/monitoringstack/monitoringstack.yaml
+++ b/components/monitoring/prometheus/base/monitoringstack/monitoringstack.yaml
@@ -52,7 +52,8 @@ spec:
           validation_reason|strategy|succeeded|target|name|method|code|sp|le|\
           unexpected_status|failure|hostname|label_app_kubernetes_io_managed_by|status|\
           pipeline|pipelinename|pipelinerun|schedule|check|grpc_service|grpc_code|\
-          grpc_method|lease|lease_holder|deployment|platform|mode|cpu|role|node|kind|verb|request_kind|tested_cluster"
+          grpc_method|lease|lease_holder|deployment|platform|mode|cpu|role|node|kind|\
+          verb|request_kind|tested_cluster|resource_type"
 ---
 # Grant permission to Federate In-Cluster Prometheus
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
This PR introduces the label `resource_type`, which is part of the metric `kubearchive_cloudevents_total`, so it gets propagated to the grafana instance and can be viewed there. The change shortens the previous line to keep it of similar length to the previous ones.