### PR TITLE
Fix Tekton Results grafana dashboard rates

### DIFF
--- a/components/monitoring/grafana/base/dashboards/pipeline-service/grafana-config.yaml
+++ b/components/monitoring/grafana/base/dashboards/pipeline-service/grafana-config.yaml
@@ -4033,7 +4033,7 @@ data:
               "targets": [
                 {
                   "exemplar": true,
-                  "expr": "sum(rate(watcher_workqueue_queue_latency_seconds_count{job=\"tekton-results-watcher\"}[10m]))",
+                  "expr": "sum(rate(watcher_workqueue_queue_latency_seconds_sum{job=\"tekton-results-watcher\"}[10m]))/sum(rate(watcher_workqueue_queue_latency_seconds_count{job=\"tekton-results-watcher\"}[10m]))",
                   "hide": false,
                   "interval": "",
                   "intervalFactor": 4,
@@ -4042,7 +4042,7 @@ data:
                 },
                 {
                   "exemplar": true,
-                  "expr": "sum(rate(watcher_reconcile_latency_count{job=\"tekton-results-watcher\"}[10m]))",
+                  "expr": "sum(rate(watcher_reconcile_latency_sum{job=\"tekton-results-watcher\"}[10m]))/sum(rate(watcher_reconcile_latency_count{job=\"tekton-results-watcher\"}[10m]))/1000",
                   "hide": false,
                   "interval": "",
                   "intervalFactor": 4,


### PR DESCRIPTION
The _count metrics previously used are the number of observations for the workqueue latency, wheras the _sum metrics are the sum of the latency reported by all items in the queue. In order to get the average latency per item, the formula is `sum(rate(metric_sum))/sum(rate(metric_count))`

The previous graph was actually showing the number of items being processed, not their latencies.

Also note that because `reconcile_latency` metrics are in milliseconds, we divide the final number by `1000` since the graph is in units of seconds

Before this change the workqueue depth remains quite high in spite of the workqueue latency being "low"
![image](https://github.com/user-attachments/assets/4d4499ec-2158-4024-9aca-2d03690bd9cf)


After this change the workqueue depth correlate more appropriately. We can also see a big difference in the reconcile latency at times
![image](https://github.com/user-attachments/assets/316d022c-adad-4196-a278-74e7a4c886d1)


