### PR TITLE
chore: move smee server sidecar to file based probe

### DIFF
--- a/components/smee/staging/deployment.yaml
+++ b/components/smee/staging/deployment.yaml
@@ -17,6 +17,9 @@ spec:
       labels:
         app: gosmee
     spec:
+      volumes:
+        - name: shared-health
+          emptyDir: {}
       containers:
         - image: "ghcr.io/chmouel/gosmee:v0.26.1"
           imagePullPolicy: Always
@@ -26,13 +29,16 @@ spec:
             - name: "gosmee-http"
               containerPort: 3333
               protocol: TCP
+          volumeMounts:
+            - name: shared-health
+              mountPath: /shared
           livenessProbe:
-            httpGet:
-              path: /healthz
-              port: 9100
+            exec:
+              command:
+                - /shared/check-smee-health.sh
             initialDelaySeconds: 30
             periodSeconds: 30
-            timeoutSeconds: 25 # Must be > the healthz handler's timeout
+            timeoutSeconds: 25
             failureThreshold: 12 # High-enough not to fail if other container crashlooping
           securityContext:
             readOnlyRootFilesystem: true
@@ -51,6 +57,9 @@ spec:
             - "client"
             - "http://localhost:3333/smeesvrmonit"
             - "http://localhost:8080"
+          volumeMounts:
+            - name: shared-health
+              mountPath: /shared
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
@@ -68,33 +77,38 @@ spec:
               cpu: 100m
               memory: 32Mi
           livenessProbe:
-            httpGet:
-              path: /healthz
-              port: 9100
+            exec:
+              command:
+                - /shared/check-smee-health.sh
             initialDelaySeconds: 30
             periodSeconds: 30
-            timeoutSeconds: 25 # Must be > the healthz handler's timeout
+            timeoutSeconds: 25
             failureThreshold: 12 # High-enough not to fail if other container crashlooping
         - name: health-check-sidecar
-          image: quay.io/konflux-ci/smee-sidecar:latest@sha256:3b1c6e66ed95ce43aa2ef0671f2f8b92c4f5753d7a0087e360704a52350d71b7
+          image: quay.io/konflux-ci/smee-sidecar@sha256:8d23f6b2a80503d9c88442046ce2cd1cd8952387ad67909a1bdadba4ab84dcc5
           imagePullPolicy: Always
           ports:
             - name: http
               containerPort: 8080
-            - name: healthz
+            - name: metrics
               containerPort: 9100
+          volumeMounts:
+            - name: shared-health
+              mountPath: /shared
           env:
             - name: DOWNSTREAM_SERVICE_URL
               value: "http://no.smee.svc.cluster.local:8080"
             - name: SMEE_CHANNEL_URL
               value: "http://localhost:3333/smeesvrmonit"
+            - name: HEALTH_CHECK_TIMEOUT_SECONDS
+              value: "20"
           livenessProbe:
-            httpGet:
-              path: /livez
-              port: 9100
+            exec:
+              command:
+                - /shared/check-sidecar-health.sh
             initialDelaySeconds: 30
             periodSeconds: 30
-            timeoutSeconds: 25 # Must be > the healthz handler's timeout
+            timeoutSeconds: 25
             failureThreshold: 3
           securityContext:
             allowPrivilegeEscalation: false


### PR DESCRIPTION
This eliminates the use of GET calls with side effects.