### PR TITLE
fix: increase smee sidecar memory

### DIFF
--- a/components/smee-client/staging/deployment.yaml
+++ b/components/smee-client/staging/deployment.yaml
@@ -89,7 +89,7 @@ spec:
           resources:
             limits:
               cpu: 100m
-              memory: 32Mi
+              memory: 128Mi
             requests:
               cpu: 100m
-              memory: 32Mi
+              memory: 128Mi

--- a/components/smee/staging/deployment.yaml
+++ b/components/smee/staging/deployment.yaml
@@ -72,10 +72,10 @@ spec:
           resources:
             limits:
               cpu: 100m
-              memory: 32Mi
+              memory: 64Mi
             requests:
               cpu: 100m
-              memory: 32Mi
+              memory: 64Mi
           livenessProbe:
             exec:
               command:
@@ -122,7 +122,7 @@ spec:
           resources:
             limits:
               cpu: 100m
-              memory: 32Mi
+              memory: 128Mi
             requests:
               cpu: 100m
-              memory: 32Mi
+              memory: 128Mi


### PR DESCRIPTION
Sidecar crashed as it went out of memory.