### PR TITLE
Grant test-platform-ci admins permission to troubleshoot testplatformclusters Claim and XR

### DIFF
--- a/components/authentication/base/group-sync/kustomization.yaml
+++ b/components/authentication/base/group-sync/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
 - konflux-rover-groups.yaml
 - namespaces.yaml
 - subscription.yaml
+- test-platform-ci-admins-rover-group.yaml

--- a/components/authentication/base/group-sync/test-platform-ci-admins-rover-group.yaml
+++ b/components/authentication/base/group-sync/test-platform-ci-admins-rover-group.yaml
@@ -1,0 +1,42 @@
+apiVersion: redhatcop.redhat.io/v1alpha1
+kind: GroupSync
+metadata:
+  name: test-platform-ci-rover-groups
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  providers:
+    - ldap:
+        ca:
+          key: ca.crt
+          kind: Secret
+          name: mtls-ca-validators
+          namespace: group-sync-operator
+        credentialsSecret:
+          name: konflux-ldap-sa
+          namespace: group-sync-operator
+        insecure: false
+        prune: true
+        rfc2307:
+          usersQuery:
+            baseDN: 'dc=redhat,dc=com'
+            derefAliases: never
+            scope: sub
+          groupNameAttributes:
+            - cn
+          tolerateMemberNotFoundErrors: true
+          tolerateMemberOutOfScopeErrors: true
+          groupUIDAttribute: dn
+          groupMembershipAttributes:
+            - uniqueMember
+          userNameAttributes:
+            - uid
+          groupsQuery:
+            baseDN: 'ou=adhoc,ou=managedGroups,dc=redhat,dc=com'
+            derefAliases: never
+            filter: (&(objectClass=rhatRoverGroup)(cn=test-platform-ci-admins))
+            scope: sub
+          userUIDAttribute: dn
+        url: 'ldaps://ldapfrac.corp.redhat.com'
+      name: ldap-corp
+  schedule: '*/15 * * * *'

--- a/components/authentication/base/kustomization.yaml
+++ b/components/authentication/base/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
 - everyone-can-view.yaml
 - konflux-admins.yaml
 - grafana-view-only.yaml
+- test-platform-ci-admins-can-view.yaml
 
 patches:
   - path: everyone-can-view-patch.yaml

--- a/components/authentication/base/test-platform-ci-admins-can-view.yaml
+++ b/components/authentication/base/test-platform-ci-admins-can-view.yaml
@@ -1,0 +1,27 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: view-testplatformclusters
+rules:
+- apiGroups:
+  - ci.openshift.org
+  resources:
+  - testplatformclusters
+  - xtestplatformclusters
+  verbs:
+  - get
+  - list
+  - watch
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: test-platform-ci-admins-view
+subjects:
+- kind: Group
+  apiGroup: rbac.authorization.k8s.io
+  name: test-platform-ci-admins
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: view-testplatformclusters

--- a/components/authentication/k-components/ldap-url-patch/kustomization.yaml
+++ b/components/authentication/k-components/ldap-url-patch/kustomization.yaml
@@ -8,3 +8,9 @@ patches:
       kind: GroupSync
       group: redhatcop.redhat.io
       version: v1alpha1
+  - path: ldap-url-patch.yaml
+    target:
+      name: test-platform-ci-rover-groups
+      kind: GroupSync
+      group: redhatcop.redhat.io
+      version: v1alpha1


### PR DESCRIPTION
Test Platform is in the middle of implementing a new feature (provision Test Platform ephemeral clusters from Konflux) and this would ease troubleshooting when things go sideways.

[Here](https://rover.redhat.com/groups/group/test-platform-ci-admins) the members who belong to the `test-platform-ci-admins` group.

Check https://github.com/konflux-ci/crossplane-control-plane/pull/33 to get more context about `testplatformclusters` and `xtestplatformclusters` objects.