### PR TITLE
chore: update references to ec config repo

### DIFF
--- a/components/enterprise-contract/ecp.yaml
+++ b/components/enterprise-contract/ecp.yaml
@@ -1,6 +1,6 @@
 #
 # The contents of this file are automatically generated based on the Konflux configs defined in the
-# github.com/enterprise-contract/config repo. Any manual modifications will be overridden.
+# github.com/conforma/config repo. Any manual modifications will be overridden.
 #
 
 ---
@@ -10,7 +10,7 @@ metadata:
   name: default
   namespace: enterprise-contract-service
 spec:
-  description: 'Includes rules for levels 1, 2 & 3 of SLSA v0.1. This is the default config used for new Konflux applications. Source: https://github.com/enterprise-contract/config/blob/main/default/policy.yaml'
+  description: 'Includes rules for levels 1, 2 & 3 of SLSA v0.1. This is the default config used for new Konflux applications. Source: https://github.com/conforma/config/blob/main/default/policy.yaml'
   name: Default
   publicKey: k8s://openshift-pipelines/public-key
   sources:
@@ -32,7 +32,7 @@ metadata:
   name: redhat-no-hermetic
   namespace: enterprise-contract-service
 spec:
-  description: 'Includes most of the rules and policies required internally by Red Hat when building Red Hat products. It excludes the requirement of hermetic builds. Source: https://github.com/enterprise-contract/config/blob/main/redhat-no-hermetic/policy.yaml'
+  description: 'Includes most of the rules and policies required internally by Red Hat when building Red Hat products. It excludes the requirement of hermetic builds. Source: https://github.com/conforma/config/blob/main/redhat-no-hermetic/policy.yaml'
   name: Red Hat (non hermetic)
   publicKey: k8s://openshift-pipelines/public-key
   sources:
@@ -56,7 +56,7 @@ metadata:
   name: redhat-rpms
   namespace: enterprise-contract-service
 spec:
-  description: 'For Red Hat RPM builds in Red Hat Konflux. Source: https://github.com/enterprise-contract/config/blob/main/redhat-rpms/policy.yaml'
+  description: 'For Red Hat RPM builds in Red Hat Konflux. Source: https://github.com/conforma/config/blob/main/redhat-rpms/policy.yaml'
   name: Red Hat RPMs
   publicKey: k8s://openshift-pipelines/public-key
   sources:
@@ -79,7 +79,7 @@ metadata:
   name: redhat
   namespace: enterprise-contract-service
 spec:
-  description: 'Includes the full set of rules and policies required internally by Red Hat when building Red Hat products. Source: https://github.com/enterprise-contract/config/blob/main/redhat/policy.yaml'
+  description: 'Includes the full set of rules and policies required internally by Red Hat when building Red Hat products. Source: https://github.com/conforma/config/blob/main/redhat/policy.yaml'
   name: Red Hat
   publicKey: k8s://openshift-pipelines/public-key
   sources:
@@ -101,7 +101,7 @@ metadata:
   name: slsa3
   namespace: enterprise-contract-service
 spec:
-  description: 'Rules specifically related to levels 1, 2 & 3 of SLSA v0.1, plus a set of basic checks that are expected to pass for all Konflux builds. Source: https://github.com/enterprise-contract/config/blob/main/slsa3/policy.yaml'
+  description: 'Rules specifically related to levels 1, 2 & 3 of SLSA v0.1, plus a set of basic checks that are expected to pass for all Konflux builds. Source: https://github.com/conforma/config/blob/main/slsa3/policy.yaml'
   name: SLSA3
   publicKey: k8s://openshift-pipelines/public-key
   sources:


### PR DESCRIPTION
This commit updates references to the Enterprise Contract config repo from `enterprise-contract/config` to `conforma/config`.

Ref: [EC-1115](https://issues.redhat.com//browse/EC-1115)