### PR TITLE
Create namespace visibility Kyverno policy

### DIFF
--- a/components/policies/staging/base/konflux-rbac/set-tenant-namespace-visibility/.chainsaw-test/chainsaw-assert-clusterpolicy.yaml
+++ b/components/policies/staging/base/konflux-rbac/set-tenant-namespace-visibility/.chainsaw-test/chainsaw-assert-clusterpolicy.yaml
@@ -1,0 +1,9 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: set-tenant-namespace-visibility
+status:
+  conditions:
+  - reason: Succeeded
+    status: "True"
+    type: Ready

--- a/components/policies/staging/base/konflux-rbac/set-tenant-namespace-visibility/.chainsaw-test/chainsaw-test.yaml
+++ b/components/policies/staging/base/konflux-rbac/set-tenant-namespace-visibility/.chainsaw-test/chainsaw-test.yaml
@@ -1,0 +1,324 @@
+# These tests assume that a tenant namespace already has the `konflux-ci.dev/visibility=private`
+# label and that the cluster policy does not apply to the following scenarios:
+# 1. A non-tenant namespace is changed into a private tenant namespace (no konflux-ci.dev/visibility
+#    label will be added).
+# 2. A private tenant namespace is changed into a non-tenant namespace (the
+#    konflux-ci.dev/visibility label will not be removed).
+
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: set-tenant-namespace-visibility-to-public
+spec:
+  description: |
+    tests that a Namespace labeled with `konflux-ci.dev/type=tenant`
+    will also get labeled with `konflux-ci.dev/visibility=public` if
+    there is a RoleBinding for the `system:authenticated group` in the
+    same Namespace
+  bindings:
+  - name: type
+    value: tenant
+  steps:
+  - name: given-kyverno-has-permission-on-resources
+    try:
+    - apply:
+        file: ../kyverno_rbac.yaml
+  - name: given-set-tenant-namespace-visibility-clusterpolicy-exists
+    try:
+    - apply:
+        file: ../set-tenant-namespace-visibility-clusterpolicy.yaml
+    - assert:
+        file: chainsaw-assert-clusterpolicy.yaml
+  - name: given-tenant-namespace-exists
+    try:
+    - apply:
+        file: ./resources/tenant-namespace.yaml
+  - name: when-authenticated-rolebinding-exists
+    try:
+    - apply:
+        file: ./resources/authenticated-rolebinding.yaml
+    - assert:
+        file: ./resources/authenticated-rolebinding.yaml
+  - name: then-visibility-is-public
+    try:
+    - assert:
+        file: ./resources/expected-public-tenant-namespace.yaml
+
+---
+
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+   name: do-not-modify-non-tenant-namespace
+spec:
+  description: |
+    tests that a non-tenant Namespace (one without a 
+    `konflux-ci.dev/type=tenant` label) will not get get labeled 
+    with a `konflux-ci.dev/visibility` label if a RoleBinding
+    for the `system:authenticated group` is created
+  bindings:
+  - name: type
+    value: non-tenant
+  steps:
+  - name: given-kyverno-has-permission-on-resources
+    try:
+    - apply:
+        file: ../kyverno_rbac.yaml
+  - name: given-set-tenant-namespace-visibility-clusterpolicy-exists
+    try:
+    - apply:
+        file: ../set-tenant-namespace-visibility-clusterpolicy.yaml    
+    - assert:
+        file: chainsaw-assert-clusterpolicy.yaml
+  - name: given-non-tenant-namespace-exists
+    try:
+    - apply:
+        file: ./resources/non-tenant-namespace.yaml
+  - name: when-authenticated-rolebinding-exists
+    try:
+    - apply:
+        file: ./resources/authenticated-rolebinding.yaml  
+    - assert:
+        file: ./resources/authenticated-rolebinding.yaml
+  - name: then-there-is-no-visibility
+    try:
+    - assert:
+        file: ./resources/non-tenant-namespace.yaml
+
+---
+
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+   name: change-namespace-from-private-to-public
+spec:
+  description: |
+    tests that a Namespace with a `konflux-ci.dev/type=tenant` label
+    and no RoleBinding for the `system:authenticated group` will
+    get labeled with `konflux-ci.dev/visibility=private`. Once that
+    Rolebinding is created, the label should change to 
+    `konflux-ci.dev/visibility=public`.
+  bindings:
+  - name: type
+    value: tenant
+  steps:
+  - name: given-kyverno-has-permission-on-resources
+    try:
+    - apply:
+        file: ../kyverno_rbac.yaml
+  - name: given-set-tenant-namespace-visibility-clusterpolicy-exists
+    try:
+    - apply:
+        file: ../set-tenant-namespace-visibility-clusterpolicy.yaml
+    - assert:
+        file: chainsaw-assert-clusterpolicy.yaml
+  - name: given-tenant-namespace-exists
+    try:
+    - apply:
+        file: ./resources/tenant-namespace.yaml
+  - name: then-visibility-is-private
+    try:
+    - assert:
+        file: ./resources/expected-private-tenant-namespace.yaml
+  - name: when-authenticated-rolebinding-exists
+    try:
+    - apply:
+        file: ./resources/authenticated-rolebinding.yaml
+    - assert:
+        file: ./resources/authenticated-rolebinding.yaml
+  - name: then-visibility-is-public
+    try:
+    - assert:
+        file: ./resources/expected-public-tenant-namespace.yaml
+
+---
+
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+   name: change-namespace-from-public-to-private
+spec:
+  description: |
+    tests that a Namespace with a `konflux-ci.dev/type=tenant` label
+    and a RoleBinding for the `system:authenticated group` will
+    get labeled with `konflux-ci.dev/visibility=public`. Once that
+    RoleBinding is removed, the label should change to 
+    `konflux-ci.dev/visibility=private`.
+  bindings:
+  - name: type
+    value: tenant
+  steps:
+  - name: given-kyverno-has-permission-on-resources
+    try:
+    - apply:
+        file: ../kyverno_rbac.yaml
+  - name: given-set-tenant-namespace-visibility-clusterpolicy-exists
+    try:
+    - apply:
+        file: ../set-tenant-namespace-visibility-clusterpolicy.yaml
+    - assert:
+        file: chainsaw-assert-clusterpolicy.yaml
+  - name: given-tenant-namespace-exists
+    try:
+    - apply:
+        file: ./resources/tenant-namespace.yaml  
+  - name: when-authenticated-rolebinding-exists
+    try:
+    - apply:
+        file: ./resources/authenticated-rolebinding.yaml
+    - assert:
+        file: ./resources/authenticated-rolebinding.yaml
+  - name: then-visibility-is-public
+    try:
+    - assert:
+        file: ./resources/expected-public-tenant-namespace.yaml
+  - name: when-authenticated-rolebinding-is-deleted
+    try:
+    - delete:
+        file: ./resources/authenticated-rolebinding.yaml
+  - name: then-visibility-is-private
+    try:
+    - assert:
+        timeout: 2m
+        file: ./resources/expected-private-tenant-namespace.yaml
+
+---
+
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+   name: change-namespace-type-to-public-tenant
+spec:
+  description: |
+    tests that a non-tenant Namespace (one without a 
+    `konflux-ci.dev/type=tenant` label) will not get a 
+    `konflux-ci.dev/visibility` label. Once a 
+    `konflux-ci.dev/type=tenant` label is added to the Namespace
+    and a RoleBinding for the `system:authenticated group` is 
+    created, the `konflux-ci.dev/visibility=public` label will be 
+    added.
+  bindings:
+  - name: type
+    value: tenant-to-be
+  steps:
+  - name: given-kyverno-has-permission-on-resources
+    try:
+    - apply:
+        file: ../kyverno_rbac.yaml
+  - name: given-set-tenant-namespace-visibility-clusterpolicy-exists
+    try:
+    - apply:
+        file: ../set-tenant-namespace-visibility-clusterpolicy.yaml
+    - assert:
+        file: chainsaw-assert-clusterpolicy.yaml
+  - name: given-non-tenant-namespace-exists
+    try:
+    - apply:
+        file: ./resources/non-tenant-namespace.yaml
+  - name: then-namespace-has-no-visibility
+    try:
+    - assert:
+        file: ./resources/non-tenant-namespace.yaml
+  - name: given-type-label-exists-on-current-namespace
+    try:
+    - patch:
+        file: ./resources/tenant-namespace.yaml  
+  - name: when-authenticated-rolebinding-exists
+    try:
+    - apply:
+        file: ./resources/authenticated-rolebinding.yaml
+    - assert:
+        file: ./resources/authenticated-rolebinding.yaml
+  - name: then-visibility-is-public
+    try:
+    - assert:
+        file: ./resources/expected-public-tenant-namespace.yaml
+
+---
+
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: do-not-modify-tenant-namespace-with-non-clusterrole-rolebinding
+spec:
+  description: |
+    tests that a Namespace labeled with `konflux-ci.dev/type=tenant`
+    will keep its `konflux-ci.dev/visibility=private` label if
+    there is a RoleBinding for the `system:authenticated group` (with a
+    non-ClusterRole role reference) in the same Namespace
+  bindings:
+  - name: type
+    value: tenant
+  steps:
+  - name: given-kyverno-has-permission-on-resources
+    try:
+    - apply:
+        file: ../kyverno_rbac.yaml
+  - name: given-set-tenant-namespace-visibility-clusterpolicy-exists
+    try:
+    - apply:
+        file: ../set-tenant-namespace-visibility-clusterpolicy.yaml
+    - assert:
+        file: chainsaw-assert-clusterpolicy.yaml
+  - name: given-tenant-namespace-exists
+    try:
+    - apply:
+        file: ./resources/tenant-namespace.yaml
+  - name: when-non-clusterrole-rolebinding-exists
+    try:
+    - apply:
+        file: ./resources/non-clusterrole-rolebinding.yaml
+    - assert:
+        file: ./resources/non-clusterrole-rolebinding.yaml
+  - name: then-visibility-is-private
+    try:
+    - assert:
+        file: ./resources/expected-private-tenant-namespace.yaml
+
+---
+
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: do-not-modify-tenant-namespace-with-wrong-clusterrole-rolebinding
+spec:
+  description: |
+    tests that a Namespace labeled with `konflux-ci.dev/type=tenant`
+    will keep its `konflux-ci.dev/visibility=private` label if
+    there is a RoleBinding for the `system:authenticated group` (without
+    the 'konflux-viewer-user-actions' role reference) in the same Namespace
+  bindings:
+  - name: type
+    value: tenant
+  steps:
+  - name: given-kyverno-has-permission-on-resources
+    try:
+    - apply:
+        file: ../kyverno_rbac.yaml
+  - name: given-set-tenant-namespace-visibility-clusterpolicy-exists
+    try:
+    - apply:
+        file: ../set-tenant-namespace-visibility-clusterpolicy.yaml
+    - assert:
+        file: chainsaw-assert-clusterpolicy.yaml
+  - name: given-tenant-namespace-exists
+    try:
+    - apply:
+        file: ./resources/tenant-namespace.yaml
+  - name: when-wrong-clusterrole-rolebinding-exists
+    try:
+    - apply:
+        file: ./resources/wrong-clusterrole-rolebinding.yaml
+    - assert:
+        file: ./resources/wrong-clusterrole-rolebinding.yaml
+  - name: then-visibility-is-private
+    try:
+    - assert:
+        file: ./resources/expected-private-tenant-namespace.yaml

--- a/components/policies/staging/base/konflux-rbac/set-tenant-namespace-visibility/.chainsaw-test/resources/authenticated-rolebinding.yaml
+++ b/components/policies/staging/base/konflux-rbac/set-tenant-namespace-visibility/.chainsaw-test/resources/authenticated-rolebinding.yaml
@@ -1,0 +1,16 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: authenticated-rolebinding
+  namespace:  (join('-', [$type, $namespace]))
+subjects:
+- kind: Group
+  name: system:authenticated
+  apiGroup: rbac.authorization.k8s.io
+- kind: Group
+  name: test-group
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole 
+  name: konflux-viewer-user-actions
+  apiGroup: rbac.authorization.k8s.io

--- a/components/policies/staging/base/konflux-rbac/set-tenant-namespace-visibility/.chainsaw-test/resources/expected-private-tenant-namespace.yaml
+++ b/components/policies/staging/base/konflux-rbac/set-tenant-namespace-visibility/.chainsaw-test/resources/expected-private-tenant-namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: (join('-', [$type, $namespace]))
+  labels:
+    konflux-ci.dev/type: tenant
+    konflux-ci.dev/visibility: private

--- a/components/policies/staging/base/konflux-rbac/set-tenant-namespace-visibility/.chainsaw-test/resources/expected-public-tenant-namespace.yaml
+++ b/components/policies/staging/base/konflux-rbac/set-tenant-namespace-visibility/.chainsaw-test/resources/expected-public-tenant-namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: (join('-', [$type, $namespace]))
+  labels:
+    konflux-ci.dev/type: tenant
+    konflux-ci.dev/visibility: public

--- a/components/policies/staging/base/konflux-rbac/set-tenant-namespace-visibility/.chainsaw-test/resources/non-clusterrole-rolebinding.yaml
+++ b/components/policies/staging/base/konflux-rbac/set-tenant-namespace-visibility/.chainsaw-test/resources/non-clusterrole-rolebinding.yaml
@@ -1,0 +1,16 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: non-clusterrole-rolebinding
+  namespace:  (join('-', [$type, $namespace]))
+subjects:
+- kind: Group
+  name: system:authenticated
+  apiGroup: rbac.authorization.k8s.io
+- kind: Group
+  name: test-group
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: Role 
+  name: test-role
+  apiGroup: rbac.authorization.k8s.io

--- a/components/policies/staging/base/konflux-rbac/set-tenant-namespace-visibility/.chainsaw-test/resources/non-tenant-namespace.yaml
+++ b/components/policies/staging/base/konflux-rbac/set-tenant-namespace-visibility/.chainsaw-test/resources/non-tenant-namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: (join('-', [$type, $namespace]))

--- a/components/policies/staging/base/konflux-rbac/set-tenant-namespace-visibility/.chainsaw-test/resources/tenant-namespace.yaml
+++ b/components/policies/staging/base/konflux-rbac/set-tenant-namespace-visibility/.chainsaw-test/resources/tenant-namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: (join('-', [$type, $namespace]))
+  labels:
+    konflux-ci.dev/type: tenant
+    konflux-ci.dev/visibility: private

--- a/components/policies/staging/base/konflux-rbac/set-tenant-namespace-visibility/.chainsaw-test/resources/wrong-clusterrole-rolebinding.yaml
+++ b/components/policies/staging/base/konflux-rbac/set-tenant-namespace-visibility/.chainsaw-test/resources/wrong-clusterrole-rolebinding.yaml
@@ -1,0 +1,16 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: wrong-clusterrole-rolebinding
+  namespace:  (join('-', [$type, $namespace]))
+subjects:
+- kind: Group
+  name: system:authenticated
+  apiGroup: rbac.authorization.k8s.io
+- kind: Group
+  name: test-group
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole 
+  name: test-role
+  apiGroup: rbac.authorization.k8s.io

--- a/components/policies/staging/base/konflux-rbac/set-tenant-namespace-visibility/kustomization.yaml
+++ b/components/policies/staging/base/konflux-rbac/set-tenant-namespace-visibility/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- set-tenant-namespace-visibility-clusterpolicy.yaml
+- kyverno_rbac.yaml

--- a/components/policies/staging/base/konflux-rbac/set-tenant-namespace-visibility/kyverno_rbac.yaml
+++ b/components/policies/staging/base/konflux-rbac/set-tenant-namespace-visibility/kyverno_rbac.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kyverno-background-controller:set-tenant-namespace-visibility
+  labels:
+    rbac.kyverno.io/aggregate-to-background-controller: "true"
+rules:
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - rolebindings
+  verbs:
+  - list
+  - get
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - list
+  - get
+  - watch
+  - update
+  - patch
+  - create
+  - delete

--- a/components/policies/staging/base/konflux-rbac/set-tenant-namespace-visibility/set-tenant-namespace-visibility-clusterpolicy.yaml
+++ b/components/policies/staging/base/konflux-rbac/set-tenant-namespace-visibility/set-tenant-namespace-visibility-clusterpolicy.yaml
@@ -7,11 +7,12 @@ metadata:
     policies.kyverno.io/description: |
       Sets the 'konflux-ci.dev/visibility' label on tenant namespaces to 'public'
       if a RoleBinding for 'system:authenticated' with a role reference to the 
-      'konflux-viewer-user-actions' CLusterRole exists, and 'private' if it does not.
+      'konflux-viewer-user-actions' ClusterRole exists, and 'private' if it does not.
 spec:
   background: false
   rules:
   - name: set-visibility
+    skipBackgroundRequests: true
     match:
       all:
       - resources:

--- a/components/policies/staging/base/konflux-rbac/set-tenant-namespace-visibility/set-tenant-namespace-visibility-clusterpolicy.yaml
+++ b/components/policies/staging/base/konflux-rbac/set-tenant-namespace-visibility/set-tenant-namespace-visibility-clusterpolicy.yaml
@@ -1,0 +1,46 @@
+---
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: set-tenant-namespace-visibility
+  annotations:
+    policies.kyverno.io/description: |
+      Sets the 'konflux-ci.dev/visibility' label on tenant namespaces to 'public'
+      if a RoleBinding for 'system:authenticated' with a role reference to the 
+      'konflux-viewer-user-actions' CLusterRole exists, and 'private' if it does not.
+spec:
+  background: false
+  rules:
+  - name: set-visibility
+    match:
+      all:
+      - resources:
+          kinds:
+          - RoleBinding
+          operations:
+            - CREATE
+            - UPDATE
+            - DELETE
+          namespaceSelector:
+            matchLabels:
+              konflux-ci.dev/type: tenant
+    preconditions:
+      all:
+        - key: "{{ request.object.subjects[?kind=='Group' && name=='system:authenticated'] | length(@) }}"
+          operator: GreaterThanOrEquals
+          value: 1
+        - key: "{{ request.object.roleRef.name }}"
+          operator: Equals
+          value: 'konflux-viewer-user-actions'
+        - key: "{{ request.object.roleRef.kind }}"
+          operator: Equals
+          value: ClusterRole
+    mutate:
+      targets:
+      - apiVersion: v1
+        kind: Namespace
+        name: "{{ request.object.metadata.namespace }}"
+      patchStrategicMerge:
+        metadata:
+          labels:
+            konflux-ci.dev/visibility: "{{ request.operation == 'DELETE' | @ && 'private' || 'public' }}"


### PR DESCRIPTION
[KFLUXINFRA-1522](https://issues.redhat.com/browse/KFLUXINFRA-1522)

This commit adds a Kyverno policy that adds the
`konflux-ci.dev/visibility`` label to any tenant namespace ands sets it to 'public' if the RoleBinding for the `system:authenticated group exists or to private otherwise. The policy is currently only added to the staging clusters for testing.

Assisted-by: Gemini