### PR TITLE
Grant test-platform-ci admins permission to view crossplane objects

### DIFF
--- a/components/authentication/base/test-platform-ci-admins-can-view.yaml
+++ b/components/authentication/base/test-platform-ci-admins-can-view.yaml
@@ -12,6 +12,14 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - kubernetes.crossplane.io
+  resources:
+  - objects
+  verbs:
+  - get
+  - list
+  - watch
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
Follow up of https://github.com/redhat-appstudio/infra-deployments/pull/6925 but for viewing crossplance objects.