### PR TITLE
etcd-shield: remove leader election permissions in staging

### DIFF
--- a/components/etcd-shield/base/rbac.yaml
+++ b/components/etcd-shield/base/rbac.yaml
@@ -53,12 +53,6 @@ rules:
 - apiGroups: [""]
   resources: ["configmaps"]
   verbs: ["get", "list", "watch", "create", "update", "patch"]
-- apiGroups: ["coordination.k8s.io"]
-  resources: ["leases"]
-  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
-- apiGroups: [""]
-  resources: ["events"]
-  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
Under no circumstances should etcd-shield use leader election.  When a cluster is having etcd capacity issues, the leader won't be able to update its lease, causing etcd-shield's pods to lose leadership.

The current build and configuration of etcd-shield is configured to never use leader election, so it's safe to remove etcd-shield's permissions to use it.