### PR TITLE
Upgrade to KubeArchive v1.2.0

### DIFF
--- a/components/konflux-ui/staging/base/proxy/proxy.yaml
+++ b/components/konflux-ui/staging/base/proxy/proxy.yaml
@@ -280,14 +280,6 @@ rules:
 - apiGroups: ["authorization.k8s.io"]
   resources: ["localsubjectaccessreviews"]
   verbs: ["create"]
-- apiGroups:  # TEMPORARY SOLUTION TO UNBLOCK KONFLUX-166 WHILE KAR-510 IS NOT SOLVED
-    - "appstudio.redhat.com"
-  resources:
-    - "snapshots"
-    - "releases"
-  verbs:
-    - "list"
-    - "get"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/components/kubearchive/development/kustomization.yaml
+++ b/components/kubearchive/development/kustomization.yaml
@@ -4,7 +4,7 @@ kind: Kustomization
 resources:
   - ../base
   - postgresql.yaml
-  - https://github.com/kubearchive/kubearchive/releases/download/v1.1.0/kubearchive.yaml?timeout=90
+  - https://github.com/kubearchive/kubearchive/releases/download/v1.2.0/kubearchive.yaml?timeout=90
 
 namespace: product-kubearchive
 secretGenerator:
@@ -33,7 +33,7 @@ patches:
               - name: migration
                 env:
                   - name: KUBEARCHIVE_VERSION
-                    value: v1.1.0
+                    value: v1.2.0
   # These patches add an annotation so an OpenShift service
   # creates the TLS secrets instead of Cert Manager
   - patch: |-
@@ -83,6 +83,8 @@ patches:
                   value: enabled
                 - name: OTEL_EXPORTER_OTLP_ENDPOINT
                   value: http://otel-collector:4318
+                - name: AUTH_IMPERSONATE
+                  value: "true"
                 securityContext:
                   readOnlyRootFilesystem: true
                   runAsNonRoot: true


### PR DESCRIPTION
Include impersonation and remove old workaround
to enable the UI to access the KubeArchive API
with proper permissions.