### PR TITLE
Update PostgreSQL image to 17.5.0 in development overlay

### DIFF
--- a/components/pipeline-service/development/dev-only-pipeline-service-storage-configuration.yaml
+++ b/components/pipeline-service/development/dev-only-pipeline-service-storage-configuration.yaml
@@ -61,7 +61,7 @@ spec:
     helm:
       parameters:
       - name: image.tag
-        value: 13.14.0
+        value: 17.5.0
       - name: tls.enabled
         value: "true"
       - name: tls.certificatesSecret


### PR DESCRIPTION
This PR updates the PostgreSQL image version used in the development overlay for the pipeline-service to 17.5.0. The update ensures alignment with the latest supported version in the Bitnami Helm chart (16.7.15)..