### PR TITLE
Update store deadline and pruner time values - 2

### DIFF
--- a/components/pipeline-service/production/base/main-pipeline-service-configuration.yaml
+++ b/components/pipeline-service/production/base/main-pipeline-service-configuration.yaml
@@ -1504,7 +1504,7 @@ spec:
         - -check_owner=false
         - -completed_run_grace_period=5m
         - -requeue_interval=2m
-        - -store_deadline=90m
+        - -store_deadline=240m
         - -forward_buffer=1m
         - -threadiness=32
         - -logs_api=true
@@ -1863,10 +1863,10 @@ spec:
   profile: all
   pruner:
     disabled: false
-    keep-since: 120
+    keep-since: 240
     resources:
       - pipelinerun
-    schedule: '*/10 * * * *'
+    schedule: '*/30 * * * *'
   result:
     disabled: true
   targetNamespace: openshift-pipelines

--- a/components/pipeline-service/production/kflux-ocp-p01/deploy.yaml
+++ b/components/pipeline-service/production/kflux-ocp-p01/deploy.yaml
@@ -1937,7 +1937,7 @@ spec:
         - -check_owner=false
         - -completed_run_grace_period=5m
         - -requeue_interval=2m
-        - -store_deadline=90m
+        - -store_deadline=240m
         - -forward_buffer=1m
         - -threadiness=32
         - -logs_api=true
@@ -2455,10 +2455,10 @@ spec:
   profile: all
   pruner:
     disabled: false
-    keep-since: 120
+    keep-since: 240
     resources:
     - pipelinerun
-    schedule: '*/10 * * * *'
+    schedule: '*/30 * * * *'
   result:
     disabled: true
   targetNamespace: openshift-pipelines

--- a/components/pipeline-service/production/kflux-osp-p01/deploy.yaml
+++ b/components/pipeline-service/production/kflux-osp-p01/deploy.yaml
@@ -1968,7 +1968,7 @@ spec:
         - -check_owner=false
         - -completed_run_grace_period=5m
         - -requeue_interval=2m
-        - -store_deadline=90m
+        - -store_deadline=240m
         - -forward_buffer=1m
         - -threadiness=32
         - -logs_api=true
@@ -2486,10 +2486,10 @@ spec:
   profile: all
   pruner:
     disabled: false
-    keep-since: 120
+    keep-since: 240
     resources:
     - pipelinerun
-    schedule: '*/10 * * * *'
+    schedule: '*/30 * * * *'
   result:
     disabled: true
   targetNamespace: openshift-pipelines

--- a/components/pipeline-service/production/kflux-prd-rh02/deploy.yaml
+++ b/components/pipeline-service/production/kflux-prd-rh02/deploy.yaml
@@ -1968,7 +1968,7 @@ spec:
         - -check_owner=false
         - -completed_run_grace_period=5m
         - -requeue_interval=2m
-        - -store_deadline=90m
+        - -store_deadline=240m
         - -forward_buffer=1m
         - -threadiness=32
         - -logs_api=true
@@ -2486,10 +2486,10 @@ spec:
   profile: all
   pruner:
     disabled: false
-    keep-since: 120
+    keep-since: 240
     resources:
     - pipelinerun
-    schedule: '*/10 * * * *'
+    schedule: '*/30 * * * *'
   result:
     disabled: true
   targetNamespace: openshift-pipelines

--- a/components/pipeline-service/production/kflux-prd-rh03/deploy.yaml
+++ b/components/pipeline-service/production/kflux-prd-rh03/deploy.yaml
@@ -1968,7 +1968,7 @@ spec:
         - -check_owner=false
         - -completed_run_grace_period=5m
         - -requeue_interval=2m
-        - -store_deadline=90m
+        - -store_deadline=240m
         - -forward_buffer=1m
         - -threadiness=32
         - -logs_api=true
@@ -2486,10 +2486,10 @@ spec:
   profile: all
   pruner:
     disabled: false
-    keep-since: 120
+    keep-since: 240
     resources:
     - pipelinerun
-    schedule: '*/10 * * * *'
+    schedule: '*/30 * * * *'
   result:
     disabled: true
   targetNamespace: openshift-pipelines

--- a/components/pipeline-service/production/kflux-rhel-p01/deploy.yaml
+++ b/components/pipeline-service/production/kflux-rhel-p01/deploy.yaml
@@ -1968,7 +1968,7 @@ spec:
         - -check_owner=false
         - -completed_run_grace_period=5m
         - -requeue_interval=2m
-        - -store_deadline=90m
+        - -store_deadline=240m
         - -forward_buffer=1m
         - -threadiness=32
         - -logs_api=true
@@ -2487,10 +2487,10 @@ spec:
   profile: all
   pruner:
     disabled: false
-    keep-since: 120
+    keep-since: 240
     resources:
     - pipelinerun
-    schedule: '*/10 * * * *'
+    schedule: '*/30 * * * *'
   result:
     disabled: true
   targetNamespace: openshift-pipelines

--- a/components/pipeline-service/production/stone-prd-rh01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prd-rh01/deploy.yaml
@@ -1937,7 +1937,7 @@ spec:
         - -check_owner=false
         - -completed_run_grace_period=5m
         - -requeue_interval=2m
-        - -store_deadline=90m
+        - -store_deadline=240m
         - -forward_buffer=1m
         - -threadiness=32
         - -logs_api=true
@@ -2456,10 +2456,10 @@ spec:
   profile: all
   pruner:
     disabled: false
-    keep-since: 120
+    keep-since: 240
     resources:
     - pipelinerun
-    schedule: '*/10 * * * *'
+    schedule: '*/30 * * * *'
   result:
     disabled: true
   targetNamespace: openshift-pipelines

--- a/components/pipeline-service/production/stone-prod-p01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prod-p01/deploy.yaml
@@ -1937,7 +1937,7 @@ spec:
         - -check_owner=false
         - -completed_run_grace_period=5m
         - -requeue_interval=2m
-        - -store_deadline=90m
+        - -store_deadline=240m
         - -forward_buffer=1m
         - -threadiness=32
         - -logs_api=true
@@ -2456,10 +2456,10 @@ spec:
   profile: all
   pruner:
     disabled: false
-    keep-since: 120
+    keep-since: 240
     resources:
     - pipelinerun
-    schedule: '*/10 * * * *'
+    schedule: '*/30 * * * *'
   result:
     disabled: true
   targetNamespace: openshift-pipelines

--- a/components/pipeline-service/production/stone-prod-p02/deploy.yaml
+++ b/components/pipeline-service/production/stone-prod-p02/deploy.yaml
@@ -1937,7 +1937,7 @@ spec:
         - -check_owner=false
         - -completed_run_grace_period=5m
         - -requeue_interval=2m
-        - -store_deadline=90m
+        - -store_deadline=240m
         - -forward_buffer=1m
         - -threadiness=32
         - -logs_api=true
@@ -2456,10 +2456,10 @@ spec:
   profile: all
   pruner:
     disabled: false
-    keep-since: 120
+    keep-since: 240
     resources:
     - pipelinerun
-    schedule: '*/10 * * * *'
+    schedule: '*/30 * * * *'
   result:
     disabled: true
   targetNamespace: openshift-pipelines


### PR DESCRIPTION
While we are working on multiple optimization to increase the throughput of Tekton Results, to avoid missing PipelineRuns/TaskRuns we need to allow enough time for those objects to be stored before they are pruned from the cluster. At peak times we see reconciliation time taking 3+ hours.