### PR TITLE
Add 2 MPC VM profiles to p02

### DIFF
--- a/components/multi-platform-controller/production-downstream/stone-prod-p02/host-config.yaml
+++ b/components/multi-platform-controller/production-downstream/stone-prod-p02/host-config.yaml
@@ -41,7 +41,9 @@ data:
     linux-c8xlarge/arm64,\
     linux-g6xlarge/amd64,\
     linux-root/arm64,\
-    linux-root/amd64\
+    linux-root/amd64,\
+    linux-fast/amd64,\
+    linux-extra-fast/amd64\
     "
   instance-tag: rhtap-prod
 
@@ -373,6 +375,32 @@ data:
   dynamic.linux-d160-m8xlarge-amd64.subnet-id: subnet-0aa719a6c5b602b16
   dynamic.linux-d160-m8xlarge-amd64.allocation-timeout: "1200"
   dynamic.linux-d160-m8xlarge-amd64.disk: "160"
+
+  dynamic.linux-fast-amd64.type: aws
+  dynamic.linux-fast-amd64.region: us-east-1
+  dynamic.linux-fast-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-fast-amd64.instance-type: c7a.8xlarge
+  dynamic.linux-fast-amd64.instance-tag: prod-amd64-fast
+  dynamic.linux-fast-amd64.key-name: konflux-prod-int-mab01
+  dynamic.linux-fast-amd64.aws-secret: aws-account
+  dynamic.linux-fast-amd64.ssh-secret: aws-ssh-key
+  dynamic.linux-fast-amd64.security-group-id: sg-0903aedd465be979e
+  dynamic.linux-fast-amd64.subnet-id: subnet-0aa719a6c5b602b16
+  dynamic.linux-fast-amd64.max-instances: "10"
+  dynamic.linux-fast-amd64.disk: "200"
+
+  dynamic.linux-extra-fast-amd64.type: aws
+  dynamic.linux-extra-fast-amd64.region: us-east-1
+  dynamic.linux-extra-fast-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-extra-fast-amd64.instance-type: c7a.12xlarge
+  dynamic.linux-extra-fast-amd64.instance-tag: prod-amd64-extra-fast
+  dynamic.linux-extra-fast-amd64.key-name: konflux-prod-int-mab01
+  dynamic.linux-extra-fast-amd64.aws-secret: aws-account
+  dynamic.linux-extra-fast-amd64.ssh-secret: aws-ssh-key
+  dynamic.linux-extra-fast-amd64.security-group-id: sg-0903aedd465be979e
+  dynamic.linux-extra-fast-amd64.subnet-id: subnet-0aa719a6c5b602b16
+  dynamic.linux-extra-fast-amd64.max-instances: "10"
+  dynamic.linux-extra-fast-amd64.disk: "200"
 
   # cpu:memory (1:2)
   dynamic.linux-cxlarge-arm64.type: aws


### PR DESCRIPTION
Those 2 profiles were on all the non dedicated clusters except p02. Users are requesting them on p02 to migrate some builds from rh01 to p02.