### PR TITLE
Allow rh-subs-watch-tenant access to insights-secret-store

### DIFF
--- a/components/cluster-secret-store-rh/production/stone-prd-rh01/insights-secret-store.yaml
+++ b/components/cluster-secret-store-rh/production/stone-prd-rh01/insights-secret-store.yaml
@@ -29,3 +29,6 @@ spec:
     - namespaces:
         - insights-management-tenant
         - hcm-eng-prod-tenant
+        - rh-subs-watch-tenant
+
+        

--- a/components/cluster-secret-store-rh/production/stone-prd-rh01/insights-secret-store.yaml
+++ b/components/cluster-secret-store-rh/production/stone-prd-rh01/insights-secret-store.yaml
@@ -30,5 +30,3 @@ spec:
         - insights-management-tenant
         - hcm-eng-prod-tenant
         - rh-subs-watch-tenant
-
-        


### PR DESCRIPTION
Trying to use the "consoledot-snyk" secret for [Subscription Watch](https://github.com/RedHatInsights/rhsm-subscriptions) (see https://gitlab.cee.redhat.com/releng/konflux-release-data/-/merge_requests/7660/diffs#88bfeccd05d09f58822ad7470f1e0a80599152a4_0_5).

ArgoCD is giving us this error.
```
error retrieving secret at .data[0], key: creds/konflux/app-sre-konflux, err: using cluster store "insights-appsre-vault" is not allowed from namespace "rh-subs-watch-tenant": denied by spec.condition
```

A very long slack rabbit hole led me here.