### PR TITLE
etcd-shield: add ClusterRole for metrics auth

### DIFF
--- a/components/etcd-shield/production/base/rbac.yaml
+++ b/components/etcd-shield/production/base/rbac.yaml
@@ -19,6 +19,18 @@ roleRef:
   name: etcd-shield-authorizer
 ---
 apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: etcd-shield-authorizer
+rules:
+- apiGroups: ["authentication.k8s.io"]
+  resources: ["tokenreviews"]
+  verbs: ["create"]
+- apiGroups: ["authorization.k8s.io"]
+  resources: ["subjectaccessreviews"]
+  verbs: ["create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: etcd-shield


### PR DESCRIPTION
The metrics service for etcd-shield needs to be able to create TokenReviews and SubjectAccessReviews to ensure metrics clients have appropriate permissions to view metrics.  Since a RoleBinding is already configured to accept this, add the appropriate ClusterRole to give etcd-shield's service account permissions to create these resources.