### PR TITLE
KubeArchive: reduce verbosity of RBAC container

### DIFF
--- a/components/kubearchive/base/monitoring-otel-collector.yaml
+++ b/components/kubearchive/base/monitoring-otel-collector.yaml
@@ -58,7 +58,7 @@ spec:
             - '--secure-listen-address=0.0.0.0:8443'
             - '--upstream=http://127.0.0.1:9090/'
             - '--logtostderr=true'
-            - '--v=10'
+            - '--v=6'
           ports:
             - containerPort: 8443
               name: https


### PR DESCRIPTION
Looks like we are leaking our service account metrics-reader token in the logs, this is to try to reduce it. I need to check it on a cluster for sure. So this is a draft.