### PR TITLE
Promote Kueue to stage

### DIFF
--- a/components/kueue/staging/base/kueue-external-admission/controller-patch.yaml
+++ b/components/kueue/staging/base/kueue-external-admission/controller-patch.yaml
@@ -35,3 +35,15 @@
   value:
     cpu: 500m
     memory: 1Gi
+
+- op: add
+  path: /spec/template/spec/containers/0/args/-
+  value: "--leader-elect-lease-duration=137s"
+
+- op: add
+  path: /spec/template/spec/containers/0/args/-
+  value: "--leader-elect-renew-deadline=107s"
+
+- op: add
+  path: /spec/template/spec/containers/0/args/-
+  value: "--leader-elect-retry-period=26s"

--- a/components/kueue/staging/base/kueue-external-admission/kustomization.yaml
+++ b/components/kueue/staging/base/kueue-external-admission/kustomization.yaml
@@ -1,13 +1,13 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- https://github.com/konflux-ci/kueue-external-admission/config/default?ref=b88442ea3598ef84d24728ddbb5e39ae159ba781
+- https://github.com/konflux-ci/kueue-external-admission/config/default?ref=aa92aa7f658e34577a23b072204de2af5768b3cc
 - monitoring.yaml
 
 images:
 - name: example.com/alert-manager-kueue-admission
   newName: quay.io/konflux-ci/kueue-external-admission
-  newTag: b88442ea3598ef84d24728ddbb5e39ae159ba781
+  newTag: aa92aa7f658e34577a23b072204de2af5768b3cc
 
 namespace: kueue-external-admission
 

--- a/components/kueue/staging/base/kueue/kueue.yaml
+++ b/components/kueue/staging/base/kueue/kueue.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: operator.openshift.io/v1alpha1
+apiVersion: kueue.openshift.io/v1
 kind: Kueue
 metadata:
   labels:

--- a/components/kueue/staging/base/kueue/operator.yaml
+++ b/components/kueue/staging/base/kueue/operator.yaml
@@ -40,7 +40,7 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "-1"
 spec:
-  channel: stable-v0.1
+  channel: stable-v0.2
   installPlanApproval: Automatic
   name: kueue-operator
   source: redhat-operators-1-18

--- a/components/kueue/staging/base/tekton-kueue/controller-patch.yaml
+++ b/components/kueue/staging/base/tekton-kueue/controller-patch.yaml
@@ -35,3 +35,15 @@
   value:
     cpu: 500m
     memory: 1Gi
+
+- op: add
+  path: /spec/template/spec/containers/0/args/-
+  value: "--leader-elect-lease-duration=137s"
+
+- op: add
+  path: /spec/template/spec/containers/0/args/-
+  value: "--leader-elect-renew-deadline=107s"
+
+- op: add
+  path: /spec/template/spec/containers/0/args/-
+  value: "--leader-elect-retry-period=26s"

--- a/components/kueue/staging/base/tekton-kueue/kustomization.yaml
+++ b/components/kueue/staging/base/tekton-kueue/kustomization.yaml
@@ -1,12 +1,12 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- https://github.com/konflux-ci/tekton-kueue/config/default?ref=222e9e201f7c99e30a673c3b0d8ee072c2a06c93
+- https://github.com/konflux-ci/tekton-kueue/config/default?ref=011960b9bcd96f59b8a7db66e61ca9f195c800f7
 
 images:
 - name: konflux-ci/tekton-kueue
   newName: quay.io/konflux-ci/tekton-kueue
-  newTag: 222e9e201f7c99e30a673c3b0d8ee072c2a06c93
+  newTag: 011960b9bcd96f59b8a7db66e61ca9f195c800f7
 
 namespace: tekton-kueue
 # ensure that installation starts after the installation of kueue complete


### PR DESCRIPTION
- Upgrade the kueue operator channel
- Lease configuration for tekton-kueue and kueue-external-admission. The durations were taken from OCP's guidelines - http://github.com/openshift/enhancements/blob/0f916a52af1a6fbdab0c5b80ae0e66c7a27efb6a/CONVENTIONS.md#handling-kube-apiserver-disruption