### PR TITLE
mintmaker: create pull secret for brew.registry.redhat.io

### DIFF
--- a/components/mintmaker/base/external-secrets/brew-registry-redhat-io-pull-secret.yaml
+++ b/components/mintmaker/base/external-secrets/brew-registry-redhat-io-pull-secret.yaml
@@ -1,0 +1,24 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: brew-registry-redhat-io-pull-secret
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  dataFrom:
+    - extract:
+        key: production/mintmaker/brew-registry-redhat-io-pull-secret
+  refreshInterval: 15m
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: appsre-stonesoup-vault
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    name: brew-registry-redhat-io-pull-secret
+    template:
+      engineVersion: v2
+      type: kubernetes.io/dockerconfigjson
+      data:
+        .dockerconfigjson: "{{ .config }}"


### PR DESCRIPTION
The secret for registry.redhat.io can be used for
brew.registry.redhat.io, but we need to explicitly create this secret for skopeo to properly access brew.registry.redhat.io.