### PR TITLE
chore: set GOMEMLIMIT for smee-sidecar in staging

### DIFF
--- a/components/smee-client/staging/deployment.yaml
+++ b/components/smee-client/staging/deployment.yaml
@@ -69,6 +69,8 @@ spec:
             value: "TBA"
           - name: HEALTH_CHECK_TIMEOUT_SECONDS
             value: "20"
+          - name: GOMEMLIMIT
+            value: "50MiB"
           livenessProbe:
             exec:
               command:


### PR DESCRIPTION
It doesn't seem as the sidecar is leaking memory, but at the same time, its container does ask for more memory over time.

Setting GOMEMLIMIT should hopefully make its memory request stabilize.