### PR TITLE
Add SA to each namespace for running cron jobs

### DIFF
--- a/components/policies/staging/base/konflux-rbac/bootstrap-tenant-namespace/bootstrap-tenant-namespace-np-konflux-cron-sa.yaml
+++ b/components/policies/staging/base/konflux-rbac/bootstrap-tenant-namespace/bootstrap-tenant-namespace-np-konflux-cron-sa.yaml
@@ -1,0 +1,66 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: init-ns-cron-sa
+spec:
+  generateExisting: true
+  rules:
+    - name: generate-serviceaccount
+      match:
+        any:
+        - resources:
+            kinds:
+            - Namespace
+            selector:
+              matchLabels:
+                konflux-ci.dev/type: tenant
+      generate:
+        kind: ServiceAccount
+        apiVersion: v1
+        name: konflux-cron-sa
+        namespace: '{{request.object.metadata.name}}'
+        synchronize: true
+    - name: generate-snapshot-role
+      match:
+        any:
+        - resources:
+            kinds:
+            - Namespace
+            selector:
+              matchLabels:
+                konflux-ci.dev/type: tenant
+      generate:
+        kind: Role
+        apiVersion: rbac.authorization.k8s.io/v1
+        name: snapshot-access
+        namespace: '{{request.object.metadata.name}}'
+        synchronize: true
+        data:
+          rules:
+            - apiGroups: ["snapshot.mycompany.io"]  # Replace with actual CRD group
+              resources: ["snapshots"]
+              verbs: ["get", "list", "watch", "patch"]
+    - name: generate-snapshot-rolebinding
+      match:
+        any:
+        - resources:
+            kinds:
+            - Namespace
+            selector:
+              matchLabels:
+                konflux-ci.dev/type: tenant
+      generate:
+        kind: RoleBinding
+        apiVersion: rbac.authorization.k8s.io/v1
+        name: snapshot-access-binding
+        namespace: '{{request.object.metadata.name}}'
+        synchronize: true
+        data:
+          roleRef:
+            kind: Role
+            name: snapshot-access
+            apiGroup: rbac.authorization.k8s.io
+          subjects:
+            - kind: ServiceAccount
+              name: konflux-cron-sa
+              namespace: '{{request.object.metadata.name}}'


### PR DESCRIPTION
This PR supports adding a UI for https://konflux-ci.dev/docs/testing/integration/periodic-integration-tests/ In order for the UI to work an SA with correct permissions to mutate snapshots must exist in the namespace with a predictable name.