### PR TITLE
Refactor nginx configs structure

### DIFF
--- a/components/konflux-ui/staging/base/proxy/auth.conf
+++ b/components/konflux-ui/staging/base/proxy/auth.conf
@@ -1,0 +1,5 @@
+# Auth configuration with impersonation enabled
+auth_request_set $user  $upstream_http_x_auth_request_email;
+proxy_set_header Impersonate-User $user;
+proxy_set_header Impersonate-Group system:authenticated;
+proxy_set_header Authorization "Bearer __BEARER_TOKEN__";

--- a/components/konflux-ui/staging/base/proxy/kubearchive.conf
+++ b/components/konflux-ui/staging/base/proxy/kubearchive.conf
@@ -1,0 +1,7 @@
+location /api/k8s/plugins/kubearchive/ {
+    auth_request /oauth2/auth;
+    rewrite /api/k8s/plugins/kubearchive/(.+) /$1 break;
+    proxy_read_timeout 30m;
+    proxy_pass https://kubearchive-api-server.product-kubearchive.svc.cluster.local:8081;
+    include /mnt/nginx-generated-config/auth.conf;
+}

--- a/components/konflux-ui/staging/base/proxy/kustomization.yaml
+++ b/components/konflux-ui/staging/base/proxy/kustomization.yaml
@@ -7,3 +7,10 @@ configMapGenerator:
   - name: proxy
     files:
       - nginx.conf
+  - name: proxy-nginx-templates
+    files:
+      - auth.conf
+  - name: proxy-nginx-static
+    files:
+      - tekton-results.conf
+      - kubearchive.conf

--- a/components/konflux-ui/staging/base/proxy/nginx.conf
+++ b/components/konflux-ui/staging/base/proxy/nginx.conf
@@ -87,14 +87,7 @@ http {
             include /mnt/nginx-generated-config/auth.conf;
         }
 
-        location /api/k8s/plugins/tekton-results/ {
-            auth_request /oauth2/auth;
 
-            rewrite /api/k8s/plugins/tekton-results/(.+) /$1 break;
-            proxy_read_timeout 30m;
-            include /mnt/nginx-generated-config/tekton-results.conf;
-            include /mnt/nginx-generated-config/auth.conf;
-        }
 
         # GET requests to /api/k8s/api/v1/namespaces and /api/k8s/api/v1/namespaces/
         # are handled from the namespace-lister.
@@ -135,6 +128,5 @@ http {
         }
 
         include /mnt/nginx-additional-location-configs/*.conf;
-        include /mnt/nginx-generated-config/kubearchive.conf;
     }
 }

--- a/components/konflux-ui/staging/base/proxy/proxy.yaml
+++ b/components/konflux-ui/staging/base/proxy/proxy.yaml
@@ -54,48 +54,23 @@ spec:
             memory: 64Mi
       - name: generate-nginx-configs
         image: registry.access.redhat.com/ubi9/ubi@sha256:66233eebd72bb5baa25190d4f55e1dc3fff3a9b77186c1f91a0abdb274452072
-        envFrom:
-          - configMapRef:
-              name: proxy-init-config
         command:
           - sh
           - -c
           - |
             set -e
 
-            auth_conf=/mnt/nginx-generated-config/auth.conf
-            
-            if [[ "$IMPERSONATE" == "true" ]]; then
-              token=$(cat /mnt/api-token/token)
-              echo 'auth_request_set $user  $upstream_http_x_auth_request_email;' > "$auth_conf"
-              echo 'proxy_set_header Impersonate-User $user;' >> "$auth_conf"
-              echo 'proxy_set_header Impersonate-Group system:authenticated;' >> "$auth_conf"
-              echo "proxy_set_header Authorization \"Bearer $token\";" >> "$auth_conf"
-            else
-              echo "# impersonation was disabled by config" > "$auth_conf"
-            fi
+            # Generate auth.conf with bearer token replacement
+            token=$(cat /mnt/api-token/token)
+            sed "s/__BEARER_TOKEN__/$token/g" /mnt/nginx-templates/auth-impersonate.conf > /mnt/nginx-generated-config/auth.conf
 
-            chmod 640 "$auth_conf"
-
-            echo \
-              "proxy_pass ${TEKTON_RESULTS_URL:?tekton results url must be provided};" \
-              > /mnt/nginx-generated-config/tekton-results.conf
-            
-            if [[ "$KUBEARCHIVE_URL" != "" ]]; then
-              echo "location /api/k8s/plugins/kubearchive/ {" > /mnt/nginx-generated-config/kubearchive.conf
-              echo "auth_request /oauth2/auth;" >> /mnt/nginx-generated-config/kubearchive.conf
-              echo "rewrite /api/k8s/plugins/kubearchive/(.+) /\$1 break;" >> /mnt/nginx-generated-config/kubearchive.conf
-              echo "proxy_read_timeout 30m;" >> /mnt/nginx-generated-config/kubearchive.conf
-              echo "proxy_pass ${KUBEARCHIVE_URL};" >> /mnt/nginx-generated-config/kubearchive.conf
-              echo "include /mnt/nginx-generated-config/auth.conf;" >> /mnt/nginx-generated-config/kubearchive.conf
-              echo "}" >> /mnt/nginx-generated-config/kubearchive.conf
-            else
-              echo "# KubeArchive disabled by config" > /mnt/nginx-generated-config/kubearchive.conf
-            fi
+            chmod 640 /mnt/nginx-generated-config/auth.conf
 
         volumeMounts:
         - name: nginx-generated-config
           mountPath: /mnt/nginx-generated-config
+        - name: nginx-templates
+          mountPath: /mnt/nginx-templates
         - name: api-token
           mountPath: /mnt/api-token
         securityContext:
@@ -167,6 +142,8 @@ spec:
             mountPath: /mnt
           - name: nginx-generated-config
             mountPath: /mnt/nginx-generated-config
+          - name: nginx-static
+            mountPath: /mnt/nginx-additional-location-configs
           - name: static-content
             mountPath: /opt/app-root/src/static-content
         securityContext:
@@ -211,6 +188,14 @@ spec:
               - key: nginx.conf
                 path: nginx.conf 
           name: proxy
+        - configMap:
+            defaultMode: 420
+            name: proxy-nginx-templates
+          name: nginx-templates
+        - configMap:
+            defaultMode: 420
+            name: proxy-nginx-static
+          name: nginx-static
         - name: logs
           emptyDir: {}
         - name: nginx-tmp

--- a/components/konflux-ui/staging/base/proxy/tekton-results.conf
+++ b/components/konflux-ui/staging/base/proxy/tekton-results.conf
@@ -1,0 +1,8 @@
+location /api/k8s/plugins/tekton-results/ {
+    auth_request /oauth2/auth;
+
+    rewrite /api/k8s/plugins/tekton-results/(.+) /$1 break;
+    proxy_read_timeout 30m;
+    proxy_pass https://tekton-results-api-service.tekton-results.svc.cluster.local:8080;
+    include /mnt/nginx-generated-config/auth.conf;
+}

--- a/components/konflux-ui/staging/stone-stage-p01/kubearchive.conf
+++ b/components/konflux-ui/staging/stone-stage-p01/kubearchive.conf
@@ -1,0 +1,1 @@
+# KubeArchive disabled by config

--- a/components/konflux-ui/staging/stone-stage-p01/kustomization.yaml
+++ b/components/konflux-ui/staging/stone-stage-p01/kustomization.yaml
@@ -6,13 +6,13 @@ resources:
 # - ./configure-oauth-proxy-secret.yaml
 
 configMapGenerator:
-- files:
-  - dex-config.yaml
-  name: dex
-- name: proxy-init-config
-  literals:
-    - IMPERSONATE=true
-    - TEKTON_RESULTS_URL=https://tekton-results-api-service.tekton-results.svc.cluster.local:8080
+  - name: dex
+    files:
+    - dex-config.yaml
+  - name: proxy-nginx-static
+    files:
+      - kubearchive.conf
+    behavior: merge
 
 patches:
 - path: add-service-certs-patch.yaml

--- a/components/konflux-ui/staging/stone-stg-rh01/kustomization.yaml
+++ b/components/konflux-ui/staging/stone-stg-rh01/kustomization.yaml
@@ -9,11 +9,7 @@ configMapGenerator:
 - files:
   - dex-config.yaml
   name: dex
-- name: proxy-init-config
-  literals:
-    - IMPERSONATE=true
-    - TEKTON_RESULTS_URL=https://tekton-results-api-service.tekton-results.svc.cluster.local:8080
-    - KUBEARCHIVE_URL=https://kubearchive-api-server.product-kubearchive.svc.cluster.local:8081
+
 
 patches:
 - path: add-service-certs-patch.yaml


### PR DESCRIPTION
As owners of the KubeArchive component within Konflux we are going to be asked if the UI doesn't have access to the KubeArchive API and that could happen due to issues on the nginx configuration.

Due to this, I want to propose a refactor on how the different imported configurations within the `nginx.conf` file are exposed, not only doing changes on the `kubearchive.conf` part but also on the `tekton-results.conf` and `auth.conf` configuration files.

With these changes I am covering the following:
* Reduce what's done in the `generate-nginx-config` initContainer of the `nginx` pod. Now it only fills the `API_TOKEN` for the impersonation
* Exposing `tekton-results.conf` and `kubearchive.conf`as ConfigMaps that are directly mounted on the `nginx` container of the `nginx` Pod
* To disable either Tekton Results or KubeArchive we should override those files properly on the `proxy-nginx-static` ConfigMap
* There are two different ConfigMaps now, one for the files that need to be modified (used as a template) `proxy-nginx-templates`, and one that holds the static config files that might be overriden inthe different clusters `proxy-nginx-static`.