### PR TITLE
mintmaker: add brew.registry.redhat.io pull secret to kustomization

### DIFF
--- a/components/mintmaker/base/external-secrets/kustomization.yaml
+++ b/components/mintmaker/base/external-secrets/kustomization.yaml
@@ -4,4 +4,5 @@ resources:
 - pipelines-as-code-secret.yaml
 - registry-redhat-io-pull-secret.yaml
 - registry-stage-redhat-io-pull-secret.yaml
+- brew-registry-redhat-io-pull-secret.yaml
 namespace: mintmaker


### PR DESCRIPTION
The external secret was previously created in 53e323c4 but not included in the kustomization configuration.