### PR TITLE
Use v0.1.7 of the hypershift-aws-cluster chart with EaaS

### DIFF
--- a/components/cluster-as-a-service/base/clustertemplates.yaml
+++ b/components/cluster-as-a-service/base/clustertemplates.yaml
@@ -31,7 +31,7 @@ spec:
       source:
         chart: hypershift-aws-template
         repoURL: https://konflux-ci.dev/cluster-template-charts/
-        targetRevision: 0.1.6
+        targetRevision: 0.1.7
         helm:
           parameters:
             - name: region


### PR DESCRIPTION
This version includes a new `fips` value and updated dependencies.