### PR TITLE
Update Results in Production, disable storing incomplete runs

### DIFF
--- a/components/pipeline-service/production/base/main-pipeline-service-configuration.yaml
+++ b/components/pipeline-service/production/base/main-pipeline-service-configuration.yaml
@@ -1099,7 +1099,7 @@ spec:
             secretKeyRef:
               key: db.name
               name: tekton-results-database
-        image: quay.io/konflux-ci/tekton-results-api:0a751a1ecaf7ab73f2a756a806d8a18c50c16547
+        image: quay.io/konflux-ci/tekton-results-api:e2b02c42c263823137ebd1440f4a7a4b6238909d
         livenessProbe:
           httpGet:
             path: /healthz
@@ -1289,7 +1289,7 @@ spec:
             secretKeyRef:
               key: db.name
               name: tekton-results-database
-        image: quay.io/konflux-ci/tekton-results-api:0a751a1ecaf7ab73f2a756a806d8a18c50c16547
+        image: quay.io/konflux-ci/tekton-results-api:e2b02c42c263823137ebd1440f4a7a4b6238909d
         livenessProbe:
           httpGet:
             path: /healthz
@@ -1391,7 +1391,7 @@ spec:
             secretKeyRef:
               key: POSTGRES_PASSWORD
               name: tekton-results-postgres
-        image: quay.io/konflux-ci/tekton-results-retention-policy-agent:0a751a1ecaf7ab73f2a756a806d8a18c50c16547
+        image: quay.io/konflux-ci/tekton-results-retention-policy-agent:e2b02c42c263823137ebd1440f4a7a4b6238909d
         name: retention-policy-agent
         resources:
           limits:
@@ -1508,6 +1508,7 @@ spec:
         - -forward_buffer=1m
         - -threadiness=32
         - -logs_api=true
+        - -disable_storing_incomplete_runs=true
         env:
         - name: SYSTEM_NAMESPACE
           valueFrom:
@@ -1527,7 +1528,7 @@ spec:
           value: token
         - name: KUBERNETES_MIN_VERSION
           value: "v1.28.0"
-        image: quay.io/konflux-ci/tekton-results-watcher:0a751a1ecaf7ab73f2a756a806d8a18c50c16547
+        image: quay.io/konflux-ci/tekton-results-watcher:e2b02c42c263823137ebd1440f4a7a4b6238909d
         name: watcher
         ports:
         - containerPort: 9090

--- a/components/pipeline-service/production/kflux-ocp-p01/deploy.yaml
+++ b/components/pipeline-service/production/kflux-ocp-p01/deploy.yaml
@@ -1529,7 +1529,7 @@ spec:
             secretKeyRef:
               key: db.name
               name: tekton-results-database
-        image: quay.io/konflux-ci/tekton-results-api:0a751a1ecaf7ab73f2a756a806d8a18c50c16547
+        image: quay.io/konflux-ci/tekton-results-api:e2b02c42c263823137ebd1440f4a7a4b6238909d
         livenessProbe:
           httpGet:
             path: /healthz
@@ -1719,7 +1719,7 @@ spec:
             secretKeyRef:
               key: db.name
               name: tekton-results-database
-        image: quay.io/konflux-ci/tekton-results-api:0a751a1ecaf7ab73f2a756a806d8a18c50c16547
+        image: quay.io/konflux-ci/tekton-results-api:e2b02c42c263823137ebd1440f4a7a4b6238909d
         livenessProbe:
           httpGet:
             path: /healthz
@@ -1824,7 +1824,7 @@ spec:
             secretKeyRef:
               key: POSTGRES_PASSWORD
               name: tekton-results-postgres
-        image: quay.io/konflux-ci/tekton-results-retention-policy-agent:0a751a1ecaf7ab73f2a756a806d8a18c50c16547
+        image: quay.io/konflux-ci/tekton-results-retention-policy-agent:e2b02c42c263823137ebd1440f4a7a4b6238909d
         name: retention-policy-agent
         resources:
           limits:
@@ -1941,6 +1941,7 @@ spec:
         - -forward_buffer=1m
         - -threadiness=32
         - -logs_api=true
+        - -disable_storing_incomplete_runs=true
         env:
         - name: SYSTEM_NAMESPACE
           valueFrom:
@@ -1960,7 +1961,7 @@ spec:
           value: token
         - name: KUBERNETES_MIN_VERSION
           value: v1.28.0
-        image: quay.io/konflux-ci/tekton-results-watcher:0a751a1ecaf7ab73f2a756a806d8a18c50c16547
+        image: quay.io/konflux-ci/tekton-results-watcher:e2b02c42c263823137ebd1440f4a7a4b6238909d
         name: watcher
         ports:
         - containerPort: 9090

--- a/components/pipeline-service/production/kflux-osp-p01/deploy.yaml
+++ b/components/pipeline-service/production/kflux-osp-p01/deploy.yaml
@@ -1560,7 +1560,7 @@ spec:
             secretKeyRef:
               key: db.name
               name: tekton-results-database
-        image: quay.io/konflux-ci/tekton-results-api:0a751a1ecaf7ab73f2a756a806d8a18c50c16547
+        image: quay.io/konflux-ci/tekton-results-api:e2b02c42c263823137ebd1440f4a7a4b6238909d
         livenessProbe:
           httpGet:
             path: /healthz
@@ -1750,7 +1750,7 @@ spec:
             secretKeyRef:
               key: db.name
               name: tekton-results-database
-        image: quay.io/konflux-ci/tekton-results-api:0a751a1ecaf7ab73f2a756a806d8a18c50c16547
+        image: quay.io/konflux-ci/tekton-results-api:e2b02c42c263823137ebd1440f4a7a4b6238909d
         livenessProbe:
           httpGet:
             path: /healthz
@@ -1855,7 +1855,7 @@ spec:
             secretKeyRef:
               key: POSTGRES_PASSWORD
               name: tekton-results-postgres
-        image: quay.io/konflux-ci/tekton-results-retention-policy-agent:0a751a1ecaf7ab73f2a756a806d8a18c50c16547
+        image: quay.io/konflux-ci/tekton-results-retention-policy-agent:e2b02c42c263823137ebd1440f4a7a4b6238909d
         name: retention-policy-agent
         resources:
           limits:
@@ -1972,6 +1972,7 @@ spec:
         - -forward_buffer=1m
         - -threadiness=32
         - -logs_api=true
+        - -disable_storing_incomplete_runs=true
         env:
         - name: SYSTEM_NAMESPACE
           valueFrom:
@@ -1991,7 +1992,7 @@ spec:
           value: token
         - name: KUBERNETES_MIN_VERSION
           value: v1.28.0
-        image: quay.io/konflux-ci/tekton-results-watcher:0a751a1ecaf7ab73f2a756a806d8a18c50c16547
+        image: quay.io/konflux-ci/tekton-results-watcher:e2b02c42c263823137ebd1440f4a7a4b6238909d
         name: watcher
         ports:
         - containerPort: 9090

--- a/components/pipeline-service/production/kflux-prd-rh02/deploy.yaml
+++ b/components/pipeline-service/production/kflux-prd-rh02/deploy.yaml
@@ -1560,7 +1560,7 @@ spec:
             secretKeyRef:
               key: db.name
               name: tekton-results-database
-        image: quay.io/konflux-ci/tekton-results-api:0a751a1ecaf7ab73f2a756a806d8a18c50c16547
+        image: quay.io/konflux-ci/tekton-results-api:e2b02c42c263823137ebd1440f4a7a4b6238909d
         livenessProbe:
           httpGet:
             path: /healthz
@@ -1750,7 +1750,7 @@ spec:
             secretKeyRef:
               key: db.name
               name: tekton-results-database
-        image: quay.io/konflux-ci/tekton-results-api:0a751a1ecaf7ab73f2a756a806d8a18c50c16547
+        image: quay.io/konflux-ci/tekton-results-api:e2b02c42c263823137ebd1440f4a7a4b6238909d
         livenessProbe:
           httpGet:
             path: /healthz
@@ -1855,7 +1855,7 @@ spec:
             secretKeyRef:
               key: POSTGRES_PASSWORD
               name: tekton-results-postgres
-        image: quay.io/konflux-ci/tekton-results-retention-policy-agent:0a751a1ecaf7ab73f2a756a806d8a18c50c16547
+        image: quay.io/konflux-ci/tekton-results-retention-policy-agent:e2b02c42c263823137ebd1440f4a7a4b6238909d
         name: retention-policy-agent
         resources:
           limits:
@@ -1972,6 +1972,7 @@ spec:
         - -forward_buffer=1m
         - -threadiness=32
         - -logs_api=true
+        - -disable_storing_incomplete_runs=true
         env:
         - name: SYSTEM_NAMESPACE
           valueFrom:
@@ -1991,7 +1992,7 @@ spec:
           value: token
         - name: KUBERNETES_MIN_VERSION
           value: v1.28.0
-        image: quay.io/konflux-ci/tekton-results-watcher:0a751a1ecaf7ab73f2a756a806d8a18c50c16547
+        image: quay.io/konflux-ci/tekton-results-watcher:e2b02c42c263823137ebd1440f4a7a4b6238909d
         name: watcher
         ports:
         - containerPort: 9090

--- a/components/pipeline-service/production/kflux-prd-rh03/deploy.yaml
+++ b/components/pipeline-service/production/kflux-prd-rh03/deploy.yaml
@@ -1560,7 +1560,7 @@ spec:
             secretKeyRef:
               key: db.name
               name: tekton-results-database
-        image: quay.io/konflux-ci/tekton-results-api:0a751a1ecaf7ab73f2a756a806d8a18c50c16547
+        image: quay.io/konflux-ci/tekton-results-api:e2b02c42c263823137ebd1440f4a7a4b6238909d
         livenessProbe:
           httpGet:
             path: /healthz
@@ -1750,7 +1750,7 @@ spec:
             secretKeyRef:
               key: db.name
               name: tekton-results-database
-        image: quay.io/konflux-ci/tekton-results-api:0a751a1ecaf7ab73f2a756a806d8a18c50c16547
+        image: quay.io/konflux-ci/tekton-results-api:e2b02c42c263823137ebd1440f4a7a4b6238909d
         livenessProbe:
           httpGet:
             path: /healthz
@@ -1855,7 +1855,7 @@ spec:
             secretKeyRef:
               key: POSTGRES_PASSWORD
               name: tekton-results-postgres
-        image: quay.io/konflux-ci/tekton-results-retention-policy-agent:0a751a1ecaf7ab73f2a756a806d8a18c50c16547
+        image: quay.io/konflux-ci/tekton-results-retention-policy-agent:e2b02c42c263823137ebd1440f4a7a4b6238909d
         name: retention-policy-agent
         resources:
           limits:
@@ -1972,6 +1972,7 @@ spec:
         - -forward_buffer=1m
         - -threadiness=32
         - -logs_api=true
+        - -disable_storing_incomplete_runs=true
         env:
         - name: SYSTEM_NAMESPACE
           valueFrom:
@@ -1991,7 +1992,7 @@ spec:
           value: token
         - name: KUBERNETES_MIN_VERSION
           value: v1.28.0
-        image: quay.io/konflux-ci/tekton-results-watcher:0a751a1ecaf7ab73f2a756a806d8a18c50c16547
+        image: quay.io/konflux-ci/tekton-results-watcher:e2b02c42c263823137ebd1440f4a7a4b6238909d
         name: watcher
         ports:
         - containerPort: 9090

--- a/components/pipeline-service/production/kflux-rhel-p01/deploy.yaml
+++ b/components/pipeline-service/production/kflux-rhel-p01/deploy.yaml
@@ -1560,7 +1560,7 @@ spec:
             secretKeyRef:
               key: db.name
               name: tekton-results-database
-        image: quay.io/konflux-ci/tekton-results-api:0a751a1ecaf7ab73f2a756a806d8a18c50c16547
+        image: quay.io/konflux-ci/tekton-results-api:e2b02c42c263823137ebd1440f4a7a4b6238909d
         livenessProbe:
           httpGet:
             path: /healthz
@@ -1750,7 +1750,7 @@ spec:
             secretKeyRef:
               key: db.name
               name: tekton-results-database
-        image: quay.io/konflux-ci/tekton-results-api:0a751a1ecaf7ab73f2a756a806d8a18c50c16547
+        image: quay.io/konflux-ci/tekton-results-api:e2b02c42c263823137ebd1440f4a7a4b6238909d
         livenessProbe:
           httpGet:
             path: /healthz
@@ -1855,7 +1855,7 @@ spec:
             secretKeyRef:
               key: POSTGRES_PASSWORD
               name: tekton-results-postgres
-        image: quay.io/konflux-ci/tekton-results-retention-policy-agent:0a751a1ecaf7ab73f2a756a806d8a18c50c16547
+        image: quay.io/konflux-ci/tekton-results-retention-policy-agent:e2b02c42c263823137ebd1440f4a7a4b6238909d
         name: retention-policy-agent
         resources:
           limits:
@@ -1972,6 +1972,7 @@ spec:
         - -forward_buffer=1m
         - -threadiness=32
         - -logs_api=true
+        - -disable_storing_incomplete_runs=true
         env:
         - name: SYSTEM_NAMESPACE
           valueFrom:
@@ -1991,7 +1992,7 @@ spec:
           value: token
         - name: KUBERNETES_MIN_VERSION
           value: v1.28.0
-        image: quay.io/konflux-ci/tekton-results-watcher:0a751a1ecaf7ab73f2a756a806d8a18c50c16547
+        image: quay.io/konflux-ci/tekton-results-watcher:e2b02c42c263823137ebd1440f4a7a4b6238909d
         name: watcher
         ports:
         - containerPort: 9090

--- a/components/pipeline-service/production/stone-prd-rh01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prd-rh01/deploy.yaml
@@ -1529,7 +1529,7 @@ spec:
             secretKeyRef:
               key: db.name
               name: tekton-results-database
-        image: quay.io/konflux-ci/tekton-results-api:0a751a1ecaf7ab73f2a756a806d8a18c50c16547
+        image: quay.io/konflux-ci/tekton-results-api:e2b02c42c263823137ebd1440f4a7a4b6238909d
         livenessProbe:
           httpGet:
             path: /healthz
@@ -1719,7 +1719,7 @@ spec:
             secretKeyRef:
               key: db.name
               name: tekton-results-database
-        image: quay.io/konflux-ci/tekton-results-api:0a751a1ecaf7ab73f2a756a806d8a18c50c16547
+        image: quay.io/konflux-ci/tekton-results-api:e2b02c42c263823137ebd1440f4a7a4b6238909d
         livenessProbe:
           httpGet:
             path: /healthz
@@ -1824,7 +1824,7 @@ spec:
             secretKeyRef:
               key: POSTGRES_PASSWORD
               name: tekton-results-postgres
-        image: quay.io/konflux-ci/tekton-results-retention-policy-agent:0a751a1ecaf7ab73f2a756a806d8a18c50c16547
+        image: quay.io/konflux-ci/tekton-results-retention-policy-agent:e2b02c42c263823137ebd1440f4a7a4b6238909d
         name: retention-policy-agent
         resources:
           limits:
@@ -1941,6 +1941,7 @@ spec:
         - -forward_buffer=1m
         - -threadiness=32
         - -logs_api=true
+        - -disable_storing_incomplete_runs=true
         env:
         - name: SYSTEM_NAMESPACE
           valueFrom:
@@ -1960,7 +1961,7 @@ spec:
           value: token
         - name: KUBERNETES_MIN_VERSION
           value: v1.28.0
-        image: quay.io/konflux-ci/tekton-results-watcher:0a751a1ecaf7ab73f2a756a806d8a18c50c16547
+        image: quay.io/konflux-ci/tekton-results-watcher:e2b02c42c263823137ebd1440f4a7a4b6238909d
         name: watcher
         ports:
         - containerPort: 9090

--- a/components/pipeline-service/production/stone-prod-p01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prod-p01/deploy.yaml
@@ -1529,7 +1529,7 @@ spec:
             secretKeyRef:
               key: db.name
               name: tekton-results-database
-        image: quay.io/konflux-ci/tekton-results-api:0a751a1ecaf7ab73f2a756a806d8a18c50c16547
+        image: quay.io/konflux-ci/tekton-results-api:e2b02c42c263823137ebd1440f4a7a4b6238909d
         livenessProbe:
           httpGet:
             path: /healthz
@@ -1719,7 +1719,7 @@ spec:
             secretKeyRef:
               key: db.name
               name: tekton-results-database
-        image: quay.io/konflux-ci/tekton-results-api:0a751a1ecaf7ab73f2a756a806d8a18c50c16547
+        image: quay.io/konflux-ci/tekton-results-api:e2b02c42c263823137ebd1440f4a7a4b6238909d
         livenessProbe:
           httpGet:
             path: /healthz
@@ -1824,7 +1824,7 @@ spec:
             secretKeyRef:
               key: POSTGRES_PASSWORD
               name: tekton-results-postgres
-        image: quay.io/konflux-ci/tekton-results-retention-policy-agent:0a751a1ecaf7ab73f2a756a806d8a18c50c16547
+        image: quay.io/konflux-ci/tekton-results-retention-policy-agent:e2b02c42c263823137ebd1440f4a7a4b6238909d
         name: retention-policy-agent
         resources:
           limits:
@@ -1941,6 +1941,7 @@ spec:
         - -forward_buffer=1m
         - -threadiness=32
         - -logs_api=true
+        - -disable_storing_incomplete_runs=true
         env:
         - name: SYSTEM_NAMESPACE
           valueFrom:
@@ -1960,7 +1961,7 @@ spec:
           value: token
         - name: KUBERNETES_MIN_VERSION
           value: v1.28.0
-        image: quay.io/konflux-ci/tekton-results-watcher:0a751a1ecaf7ab73f2a756a806d8a18c50c16547
+        image: quay.io/konflux-ci/tekton-results-watcher:e2b02c42c263823137ebd1440f4a7a4b6238909d
         name: watcher
         ports:
         - containerPort: 9090

--- a/components/pipeline-service/production/stone-prod-p02/deploy.yaml
+++ b/components/pipeline-service/production/stone-prod-p02/deploy.yaml
@@ -1529,7 +1529,7 @@ spec:
             secretKeyRef:
               key: db.name
               name: tekton-results-database
-        image: quay.io/konflux-ci/tekton-results-api:0a751a1ecaf7ab73f2a756a806d8a18c50c16547
+        image: quay.io/konflux-ci/tekton-results-api:e2b02c42c263823137ebd1440f4a7a4b6238909d
         livenessProbe:
           httpGet:
             path: /healthz
@@ -1719,7 +1719,7 @@ spec:
             secretKeyRef:
               key: db.name
               name: tekton-results-database
-        image: quay.io/konflux-ci/tekton-results-api:0a751a1ecaf7ab73f2a756a806d8a18c50c16547
+        image: quay.io/konflux-ci/tekton-results-api:e2b02c42c263823137ebd1440f4a7a4b6238909d
         livenessProbe:
           httpGet:
             path: /healthz
@@ -1824,7 +1824,7 @@ spec:
             secretKeyRef:
               key: POSTGRES_PASSWORD
               name: tekton-results-postgres
-        image: quay.io/konflux-ci/tekton-results-retention-policy-agent:0a751a1ecaf7ab73f2a756a806d8a18c50c16547
+        image: quay.io/konflux-ci/tekton-results-retention-policy-agent:e2b02c42c263823137ebd1440f4a7a4b6238909d
         name: retention-policy-agent
         resources:
           limits:
@@ -1941,6 +1941,7 @@ spec:
         - -forward_buffer=1m
         - -threadiness=32
         - -logs_api=true
+        - -disable_storing_incomplete_runs=true
         env:
         - name: SYSTEM_NAMESPACE
           valueFrom:
@@ -1960,7 +1961,7 @@ spec:
           value: token
         - name: KUBERNETES_MIN_VERSION
           value: v1.28.0
-        image: quay.io/konflux-ci/tekton-results-watcher:0a751a1ecaf7ab73f2a756a806d8a18c50c16547
+        image: quay.io/konflux-ci/tekton-results-watcher:e2b02c42c263823137ebd1440f4a7a4b6238909d
         name: watcher
         ports:
         - containerPort: 9090


### PR DESCRIPTION
Promoting the change from  #7013  to production

This update includes a feature to disable storing of incomplete PipelineRuns and TaskRuns aiming to reduce the calls on the k8s API server, decrease the workqueue size and improve the overal performance.
