### PR TITLE
Fix namespace-lister NetworkPolicy ingress rule

### DIFF
--- a/components/namespace-lister/base/network_policy_allow_from_konfluxui.yaml
+++ b/components/namespace-lister/base/network_policy_allow_from_konfluxui.yaml
@@ -14,7 +14,7 @@ spec:
     - namespaceSelector:
         matchLabels:
           kubernetes.io/metadata.name: konflux-ui
-    - podSelector:
+      podSelector:
         matchLabels:
           app: proxy
     ports:


### PR DESCRIPTION
I'm pretty sure this is a typo.

If two entries appear in a list like this, they are "OR"'d together, like "any pod matching the namespace selectors" or "any pods matching the podselector [in this namespace]", which is not what we want.

Things are currently working, because the namespaceselector permits *any* pod in the matched namespaces, which includes the single target pod we wanted to permit.

By making this into a list of one rule, we'll permit only the matched pod in only the matched namespace to speak to this target pod.