### PR TITLE
Create local queue in the mintmaker namespace

### DIFF
--- a/components/policies/development/kueue/queue-config/cluster-policy.yaml
+++ b/components/policies/development/kueue/queue-config/cluster-policy.yaml
@@ -15,6 +15,11 @@ spec:
           selector:
             matchLabels:
               konflux-ci.dev/type: tenant
+      - resources:
+          kinds:
+          - Namespace
+          names:
+          - mintmaker
     generate:
       generateExisting: true
       synchronize: true


### PR DESCRIPTION
Adjust the cluster policy which create local queues to select the mintmaker namespace as well since it contains pipelineruns that should be managed by Kueue.