### PR TITLE
fix(STONEINTG-1259): disable integration leader election in prod

### DIFF
--- a/components/integration/production/base/manager_resources_patch.yaml
+++ b/components/integration/production/base/manager_resources_patch.yaml
@@ -8,6 +8,8 @@ spec:
     spec:
       containers:
       - name: manager
+        args:
+          - "--leader-elect=false"
         resources:
           limits:
             cpu: 600m


### PR DESCRIPTION
* Disable the leader election for the integration service controller manager in prod environment

Signed-off-by: dirgim <kpavic@redhat.com>