### PR TITLE
Kubearchive (stone-prod-p02): double operator memory

### DIFF
--- a/components/kubearchive/production/stone-prod-p02/kustomization.yaml
+++ b/components/kubearchive/production/stone-prod-p02/kustomization.yaml
@@ -116,11 +116,11 @@ patches:
                   - containerPort: 8081
                 resources:
                   limits:
-                    cpu: 500m
-                    memory: 256Mi
+                    cpu: 100m
+                    memory: 512Mi
                   requests:
-                    cpu: 10m
-                    memory: 256Mi
+                    cpu: 100m
+                    memory: 512Mi
 
   - patch: |-
       apiVersion: apps/v1


### PR DESCRIPTION
* Looks like we crossed the line for the operator, before was working OK, now its restarting endlessly. Increasing its memory to prevent that. We will work to see if we can reproduce this and then lower its consumption on upstream.