### PR TITLE
mintmaker: update brew.registry.redhat.io secret labels

### DIFF
--- a/components/mintmaker/base/external-secrets/brew-registry-redhat-io-pull-secret.yaml
+++ b/components/mintmaker/base/external-secrets/brew-registry-redhat-io-pull-secret.yaml
@@ -20,5 +20,8 @@ spec:
     template:
       engineVersion: v2
       type: kubernetes.io/dockerconfigjson
+      metadata:
+        labels:
+          mintmaker.appstudio.redhat.com/secret-type: registry
       data:
         .dockerconfigjson: "{{ .config }}"


### PR DESCRIPTION
Add the following lable to brew.registry.redhat.io secret:

   mintmaker.appstudio.redhat.com/secret-type: registry

mintmaker will combine secrets with this label, and mount it to Renovate container, then podman/skopeo can use the combined secret for image pulling.