### PR TITLE
public-stage: Increase pipelines controller memory

### DIFF
--- a/components/pipeline-service/staging/stone-stg-rh01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stg-rh01/deploy.yaml
@@ -2437,10 +2437,10 @@ spec:
                 - name: tekton-pipelines-controller
                   resources:
                     limits:
-                      memory: 8Gi
+                      memory: 12Gi
                     requests:
                       cpu: "1"
-                      memory: 6Gi
+                      memory: 12Gi
         tekton-pipelines-webhook:
           spec:
             template:

--- a/components/pipeline-service/staging/stone-stg-rh01/resources/update-tekton-controller-resources.yaml
+++ b/components/pipeline-service/staging/stone-stg-rh01/resources/update-tekton-controller-resources.yaml
@@ -14,7 +14,7 @@ spec:
                   - name: tekton-pipelines-controller
                     resources:
                       requests:
-                        memory: 6Gi
+                        memory: 12Gi
                         cpu: "1"
                       limits:
-                        memory: 8Gi
+                        memory: 12Gi


### PR DESCRIPTION
As part of testing Kueue, a large amount of pipelines will be run on the cluster. Increase the memory of the pipelines controller in order to allow it.