### PR TITLE
Give the Vanguard team admin permission on the smee-client ns

### DIFF
--- a/components/smee-client/base/kustomization.yaml
+++ b/components/smee-client/base/kustomization.yaml
@@ -2,3 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - deployment.yaml
+  - rbac.yaml

--- a/components/smee-client/base/rbac.yaml
+++ b/components/smee-client/base/rbac.yaml
@@ -1,0 +1,13 @@
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: konflux-vanguard-admins
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: konflux-vanguard
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: admin


### PR DESCRIPTION
The team needs it in order to maintain the smee client.