### PR TITLE
stage: Give the Vanguard team admin permission on the smee-client ns

### DIFF
--- a/components/smee-client/staging/kustomization.yaml
+++ b/components/smee-client/staging/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
   # TODO: change to point to ../base when deploying sidecar to production
   - deployment.yaml
+  - rbac.yaml
 
 images:
 - name: quay.io/konflux-ci/smee-sidecar

--- a/components/smee-client/staging/rbac.yaml
+++ b/components/smee-client/staging/rbac.yaml
@@ -1,0 +1,13 @@
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: konflux-vanguard-admins
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: konflux-vanguard
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: admin


### PR DESCRIPTION
The team needs it in order to maintain the smee client.