### PR TITLE
Set memory limit as Mi

### DIFF
--- a/components/pipeline-service/staging/base/main-pipeline-service-configuration.yaml
+++ b/components/pipeline-service/staging/base/main-pipeline-service-configuration.yaml
@@ -1840,10 +1840,10 @@ spec:
                     resources:
                       limits:
                         cpu: 500m
-                        memory: 1.5Gi
+                        memory: 1536Mi
                       requests:
                         cpu: 500m
-                        memory: 1.5Gi
+                        memory: 1536Mi
         tekton-events-controller:
           spec:
             template:

--- a/components/pipeline-service/staging/stone-stage-p01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stage-p01/deploy.yaml
@@ -2398,10 +2398,10 @@ spec:
                   resources:
                     limits:
                       cpu: 500m
-                      memory: 1.5Gi
+                      memory: 1536Mi
                     requests:
                       cpu: 500m
-                      memory: 1.5Gi
+                      memory: 1536Mi
         tekton-events-controller:
           spec:
             template:

--- a/components/pipeline-service/staging/stone-stg-rh01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stg-rh01/deploy.yaml
@@ -2398,10 +2398,10 @@ spec:
                   resources:
                     limits:
                       cpu: 500m
-                      memory: 1.5Gi
+                      memory: 1536Mi
                     requests:
                       cpu: 500m
-                      memory: 1.5Gi
+                      memory: 1536Mi
         tekton-events-controller:
           spec:
             template:


### PR DESCRIPTION
Initial value (1.5Gi) was set as Gi, but the controller is transforming it to Mi (1536Mi) and it's "fighting" with ArgoCD over that value, blocking the TektonConfig update. So no real change here, the actual value will remain the same, only the representation is changed.