### PR TITLE
PVO11Y-4845 Allow o11y admins to debug UWM Prometheus

### DIFF
--- a/components/monitoring/prometheus/base/uwm-config/kustomization.yaml
+++ b/components/monitoring/prometheus/base/uwm-config/kustomization.yaml
@@ -3,3 +3,4 @@ kind: Kustomization
 
 resources:
 - uwm-config.yaml
+- uwm-rbac.yaml

--- a/components/monitoring/prometheus/base/uwm-config/uwm-rbac.yaml
+++ b/components/monitoring/prometheus/base/uwm-config/uwm-rbac.yaml
@@ -1,0 +1,28 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: o11y-debug-access-user-workload-monitoring
+  namespace: openshift-user-workload-monitoring
+rules:
+# Grant access to some base API resources useful for debugging of UWM Prometheus server
+- apiGroups: [""]
+  resources:
+    - pods
+    - pods/attach
+    - pods/exec
+  verbs: ["*"]
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: o11y-debug-access-user-workload-monitoring
+  namespace: openshift-user-workload-monitoring
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: konflux-o11y-admins
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: o11y-debug-access-user-workload-monitoring


### PR DESCRIPTION
During investigation of PVO11Y-4845, we needed to check the configuration of the UWM Prometheus server. Granting o11y admins access to the Prometheus pods will allow them to view this configuration as well as debug any future issues.