### PR TITLE
Update kflux-osp-p01 MPC host config for IBM VMS

### DIFF
--- a/components/multi-platform-controller/production-downstream/kflux-osp-p01/host-config.yaml
+++ b/components/multi-platform-controller/production-downstream/kflux-osp-p01/host-config.yaml
@@ -37,18 +37,7 @@ data:
     linux-root/arm64,\
     linux-root/amd64,\
     linux-fast/amd64,\
-    linux-extra-fast/amd64,\
-    linux/s390x,\
-    linux-large/s390x,\
-    linux-d200/s390x,\
-    linux-d200-large/s390x,\
-    linux/ppc64le,\
-    linux-large/ppc64le,\
-    linux-xlarge/ppc64le,\
-    linux-2xlarge/ppc64le,\
-    linux-d200-large/ppc64le,\
-    linux-d200-xlarge/ppc64le,\
-    linux-d200-2xlarge/ppc64le\
+    linux-extra-fast/amd64\
     "
   instance-tag: rhtap-prod
 
@@ -502,6 +491,55 @@ data:
     restorecon -r /home/ec2-user
 
     --//--
+
+  # PPC64LE 4cores(32vCPU) / 128GiB RAM / 2TB disk
+  host.pi-static-x0.address: "10.130.81.249"
+  host.pi-static-x0.platform: "linux/ppc64le"
+  host.pi-static-x0.user: "root"
+  host.pi-static-x0.secret: "ibm-ppc64le-ssh-key"
+  host.pi-static-x0.concurrency: "8"
+
+  host.pi-static-x1.address: "10.130.81.208"
+  host.pi-static-x1.platform: "linux/ppc64le"
+  host.pi-static-x1.user: "root"
+  host.pi-static-x1.secret: "ibm-ppc64le-ssh-key"
+  host.pi-static-x1.concurrency: "8"
+
+  host.pi-static-x2.address: "10.130.81.235"
+  host.pi-static-x2.platform: "linux/ppc64le"
+  host.pi-static-x2.user: "root"
+  host.pi-static-x2.secret: "ibm-ppc64le-ssh-key"
+  host.pi-static-x2.concurrency: "8"
+
+  host.pi-static-x3.address: "10.130.81.207"
+  host.pi-static-x3.platform: "linux/ppc64le"
+  host.pi-static-x3.user: "root"
+  host.pi-static-x3.secret: "ibm-ppc64le-ssh-key"
+  host.pi-static-x3.concurrency: "8"
+
+  host.pi-static-x4.address: "10.130.81.203"
+  host.pi-static-x4.platform: "linux/ppc64le"
+  host.pi-static-x4.user: "root"
+  host.pi-static-x4.secret: "ibm-ppc64le-ssh-key"
+  host.pi-static-x4.concurrency: "8"
+
+  host.pi-static-x5.address: "10.130.81.226"
+  host.pi-static-x5.platform: "linux/ppc64le"
+  host.pi-static-x5.user: "root"
+  host.pi-static-x5.secret: "ibm-ppc64le-ssh-key"
+  host.pi-static-x5.concurrency: "8"
+
+  host.pi-static-x6.address: "10.130.81.233"
+  host.pi-static-x6.platform: "linux/ppc64le"
+  host.pi-static-x6.user: "root"
+  host.pi-static-x6.secret: "ibm-ppc64le-ssh-key"
+  host.pi-static-x6.concurrency: "8"
+
+  host.pi-static-x7.address: "10.130.81.252"
+  host.pi-static-x7.platform: "linux/ppc64le"
+  host.pi-static-x7.user: "root"
+  host.pi-static-x7.secret: "ibm-ppc64le-ssh-key"
+  host.pi-static-x7.concurrency: "8"
 
 # GPU Instances
   dynamic.linux-g6xlarge-amd64.type: aws


### PR DESCRIPTION
Remove the s390x & ppc64le platforms from dynamic provisioning and add the 8 static PPC VMs to the host config.