### PR TITLE
Update Tekton Results to v0.15.2-2 prod

### DIFF
--- a/components/pipeline-service/production/base/main-pipeline-service-configuration.yaml
+++ b/components/pipeline-service/production/base/main-pipeline-service-configuration.yaml
@@ -1099,7 +1099,7 @@ spec:
             secretKeyRef:
               key: db.name
               name: tekton-results-database
-        image: quay.io/konflux-ci/tekton-results-api:e2b02c42c263823137ebd1440f4a7a4b6238909d
+        image: quay.io/konflux-ci/tekton-results-api:99db802a56c3d62e823e162feee9811e55ed1f5b
         livenessProbe:
           httpGet:
             path: /healthz
@@ -1289,7 +1289,7 @@ spec:
             secretKeyRef:
               key: db.name
               name: tekton-results-database
-        image: quay.io/konflux-ci/tekton-results-api:e2b02c42c263823137ebd1440f4a7a4b6238909d
+        image: quay.io/konflux-ci/tekton-results-api:99db802a56c3d62e823e162feee9811e55ed1f5b
         livenessProbe:
           httpGet:
             path: /healthz
@@ -1391,7 +1391,7 @@ spec:
             secretKeyRef:
               key: POSTGRES_PASSWORD
               name: tekton-results-postgres
-        image: quay.io/konflux-ci/tekton-results-retention-policy-agent:e2b02c42c263823137ebd1440f4a7a4b6238909d
+        image: quay.io/konflux-ci/tekton-results-retention-policy-agent:99db802a56c3d62e823e162feee9811e55ed1f5b
         name: retention-policy-agent
         resources:
           limits:
@@ -1528,7 +1528,7 @@ spec:
           value: token
         - name: KUBERNETES_MIN_VERSION
           value: "v1.28.0"
-        image: quay.io/konflux-ci/tekton-results-watcher:e2b02c42c263823137ebd1440f4a7a4b6238909d
+        image: quay.io/konflux-ci/tekton-results-watcher:99db802a56c3d62e823e162feee9811e55ed1f5b
         name: watcher
         ports:
         - containerPort: 9090

--- a/components/pipeline-service/production/kflux-ocp-p01/deploy.yaml
+++ b/components/pipeline-service/production/kflux-ocp-p01/deploy.yaml
@@ -1529,7 +1529,7 @@ spec:
             secretKeyRef:
               key: db.name
               name: tekton-results-database
-        image: quay.io/konflux-ci/tekton-results-api:e2b02c42c263823137ebd1440f4a7a4b6238909d
+        image: quay.io/konflux-ci/tekton-results-api:99db802a56c3d62e823e162feee9811e55ed1f5b
         livenessProbe:
           httpGet:
             path: /healthz
@@ -1719,7 +1719,7 @@ spec:
             secretKeyRef:
               key: db.name
               name: tekton-results-database
-        image: quay.io/konflux-ci/tekton-results-api:e2b02c42c263823137ebd1440f4a7a4b6238909d
+        image: quay.io/konflux-ci/tekton-results-api:99db802a56c3d62e823e162feee9811e55ed1f5b
         livenessProbe:
           httpGet:
             path: /healthz
@@ -1824,7 +1824,7 @@ spec:
             secretKeyRef:
               key: POSTGRES_PASSWORD
               name: tekton-results-postgres
-        image: quay.io/konflux-ci/tekton-results-retention-policy-agent:e2b02c42c263823137ebd1440f4a7a4b6238909d
+        image: quay.io/konflux-ci/tekton-results-retention-policy-agent:99db802a56c3d62e823e162feee9811e55ed1f5b
         name: retention-policy-agent
         resources:
           limits:
@@ -1961,7 +1961,7 @@ spec:
           value: token
         - name: KUBERNETES_MIN_VERSION
           value: v1.28.0
-        image: quay.io/konflux-ci/tekton-results-watcher:e2b02c42c263823137ebd1440f4a7a4b6238909d
+        image: quay.io/konflux-ci/tekton-results-watcher:99db802a56c3d62e823e162feee9811e55ed1f5b
         name: watcher
         ports:
         - containerPort: 9090

--- a/components/pipeline-service/production/kflux-osp-p01/deploy.yaml
+++ b/components/pipeline-service/production/kflux-osp-p01/deploy.yaml
@@ -1560,7 +1560,7 @@ spec:
             secretKeyRef:
               key: db.name
               name: tekton-results-database
-        image: quay.io/konflux-ci/tekton-results-api:e2b02c42c263823137ebd1440f4a7a4b6238909d
+        image: quay.io/konflux-ci/tekton-results-api:99db802a56c3d62e823e162feee9811e55ed1f5b
         livenessProbe:
           httpGet:
             path: /healthz
@@ -1750,7 +1750,7 @@ spec:
             secretKeyRef:
               key: db.name
               name: tekton-results-database
-        image: quay.io/konflux-ci/tekton-results-api:e2b02c42c263823137ebd1440f4a7a4b6238909d
+        image: quay.io/konflux-ci/tekton-results-api:99db802a56c3d62e823e162feee9811e55ed1f5b
         livenessProbe:
           httpGet:
             path: /healthz
@@ -1855,7 +1855,7 @@ spec:
             secretKeyRef:
               key: POSTGRES_PASSWORD
               name: tekton-results-postgres
-        image: quay.io/konflux-ci/tekton-results-retention-policy-agent:e2b02c42c263823137ebd1440f4a7a4b6238909d
+        image: quay.io/konflux-ci/tekton-results-retention-policy-agent:99db802a56c3d62e823e162feee9811e55ed1f5b
         name: retention-policy-agent
         resources:
           limits:
@@ -1992,7 +1992,7 @@ spec:
           value: token
         - name: KUBERNETES_MIN_VERSION
           value: v1.28.0
-        image: quay.io/konflux-ci/tekton-results-watcher:e2b02c42c263823137ebd1440f4a7a4b6238909d
+        image: quay.io/konflux-ci/tekton-results-watcher:99db802a56c3d62e823e162feee9811e55ed1f5b
         name: watcher
         ports:
         - containerPort: 9090

--- a/components/pipeline-service/production/kflux-prd-rh02/deploy.yaml
+++ b/components/pipeline-service/production/kflux-prd-rh02/deploy.yaml
@@ -1560,7 +1560,7 @@ spec:
             secretKeyRef:
               key: db.name
               name: tekton-results-database
-        image: quay.io/konflux-ci/tekton-results-api:e2b02c42c263823137ebd1440f4a7a4b6238909d
+        image: quay.io/konflux-ci/tekton-results-api:99db802a56c3d62e823e162feee9811e55ed1f5b
         livenessProbe:
           httpGet:
             path: /healthz
@@ -1750,7 +1750,7 @@ spec:
             secretKeyRef:
               key: db.name
               name: tekton-results-database
-        image: quay.io/konflux-ci/tekton-results-api:e2b02c42c263823137ebd1440f4a7a4b6238909d
+        image: quay.io/konflux-ci/tekton-results-api:99db802a56c3d62e823e162feee9811e55ed1f5b
         livenessProbe:
           httpGet:
             path: /healthz
@@ -1855,7 +1855,7 @@ spec:
             secretKeyRef:
               key: POSTGRES_PASSWORD
               name: tekton-results-postgres
-        image: quay.io/konflux-ci/tekton-results-retention-policy-agent:e2b02c42c263823137ebd1440f4a7a4b6238909d
+        image: quay.io/konflux-ci/tekton-results-retention-policy-agent:99db802a56c3d62e823e162feee9811e55ed1f5b
         name: retention-policy-agent
         resources:
           limits:
@@ -1992,7 +1992,7 @@ spec:
           value: token
         - name: KUBERNETES_MIN_VERSION
           value: v1.28.0
-        image: quay.io/konflux-ci/tekton-results-watcher:e2b02c42c263823137ebd1440f4a7a4b6238909d
+        image: quay.io/konflux-ci/tekton-results-watcher:99db802a56c3d62e823e162feee9811e55ed1f5b
         name: watcher
         ports:
         - containerPort: 9090

--- a/components/pipeline-service/production/kflux-prd-rh03/deploy.yaml
+++ b/components/pipeline-service/production/kflux-prd-rh03/deploy.yaml
@@ -1560,7 +1560,7 @@ spec:
             secretKeyRef:
               key: db.name
               name: tekton-results-database
-        image: quay.io/konflux-ci/tekton-results-api:e2b02c42c263823137ebd1440f4a7a4b6238909d
+        image: quay.io/konflux-ci/tekton-results-api:99db802a56c3d62e823e162feee9811e55ed1f5b
         livenessProbe:
           httpGet:
             path: /healthz
@@ -1750,7 +1750,7 @@ spec:
             secretKeyRef:
               key: db.name
               name: tekton-results-database
-        image: quay.io/konflux-ci/tekton-results-api:e2b02c42c263823137ebd1440f4a7a4b6238909d
+        image: quay.io/konflux-ci/tekton-results-api:99db802a56c3d62e823e162feee9811e55ed1f5b
         livenessProbe:
           httpGet:
             path: /healthz
@@ -1855,7 +1855,7 @@ spec:
             secretKeyRef:
               key: POSTGRES_PASSWORD
               name: tekton-results-postgres
-        image: quay.io/konflux-ci/tekton-results-retention-policy-agent:e2b02c42c263823137ebd1440f4a7a4b6238909d
+        image: quay.io/konflux-ci/tekton-results-retention-policy-agent:99db802a56c3d62e823e162feee9811e55ed1f5b
         name: retention-policy-agent
         resources:
           limits:
@@ -1992,7 +1992,7 @@ spec:
           value: token
         - name: KUBERNETES_MIN_VERSION
           value: v1.28.0
-        image: quay.io/konflux-ci/tekton-results-watcher:e2b02c42c263823137ebd1440f4a7a4b6238909d
+        image: quay.io/konflux-ci/tekton-results-watcher:99db802a56c3d62e823e162feee9811e55ed1f5b
         name: watcher
         ports:
         - containerPort: 9090

--- a/components/pipeline-service/production/kflux-rhel-p01/deploy.yaml
+++ b/components/pipeline-service/production/kflux-rhel-p01/deploy.yaml
@@ -1560,7 +1560,7 @@ spec:
             secretKeyRef:
               key: db.name
               name: tekton-results-database
-        image: quay.io/konflux-ci/tekton-results-api:e2b02c42c263823137ebd1440f4a7a4b6238909d
+        image: quay.io/konflux-ci/tekton-results-api:99db802a56c3d62e823e162feee9811e55ed1f5b
         livenessProbe:
           httpGet:
             path: /healthz
@@ -1750,7 +1750,7 @@ spec:
             secretKeyRef:
               key: db.name
               name: tekton-results-database
-        image: quay.io/konflux-ci/tekton-results-api:e2b02c42c263823137ebd1440f4a7a4b6238909d
+        image: quay.io/konflux-ci/tekton-results-api:99db802a56c3d62e823e162feee9811e55ed1f5b
         livenessProbe:
           httpGet:
             path: /healthz
@@ -1855,7 +1855,7 @@ spec:
             secretKeyRef:
               key: POSTGRES_PASSWORD
               name: tekton-results-postgres
-        image: quay.io/konflux-ci/tekton-results-retention-policy-agent:e2b02c42c263823137ebd1440f4a7a4b6238909d
+        image: quay.io/konflux-ci/tekton-results-retention-policy-agent:99db802a56c3d62e823e162feee9811e55ed1f5b
         name: retention-policy-agent
         resources:
           limits:
@@ -1992,7 +1992,7 @@ spec:
           value: token
         - name: KUBERNETES_MIN_VERSION
           value: v1.28.0
-        image: quay.io/konflux-ci/tekton-results-watcher:e2b02c42c263823137ebd1440f4a7a4b6238909d
+        image: quay.io/konflux-ci/tekton-results-watcher:99db802a56c3d62e823e162feee9811e55ed1f5b
         name: watcher
         ports:
         - containerPort: 9090

--- a/components/pipeline-service/production/stone-prd-rh01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prd-rh01/deploy.yaml
@@ -1529,7 +1529,7 @@ spec:
             secretKeyRef:
               key: db.name
               name: tekton-results-database
-        image: quay.io/konflux-ci/tekton-results-api:e2b02c42c263823137ebd1440f4a7a4b6238909d
+        image: quay.io/konflux-ci/tekton-results-api:99db802a56c3d62e823e162feee9811e55ed1f5b
         livenessProbe:
           httpGet:
             path: /healthz
@@ -1719,7 +1719,7 @@ spec:
             secretKeyRef:
               key: db.name
               name: tekton-results-database
-        image: quay.io/konflux-ci/tekton-results-api:e2b02c42c263823137ebd1440f4a7a4b6238909d
+        image: quay.io/konflux-ci/tekton-results-api:99db802a56c3d62e823e162feee9811e55ed1f5b
         livenessProbe:
           httpGet:
             path: /healthz
@@ -1824,7 +1824,7 @@ spec:
             secretKeyRef:
               key: POSTGRES_PASSWORD
               name: tekton-results-postgres
-        image: quay.io/konflux-ci/tekton-results-retention-policy-agent:e2b02c42c263823137ebd1440f4a7a4b6238909d
+        image: quay.io/konflux-ci/tekton-results-retention-policy-agent:99db802a56c3d62e823e162feee9811e55ed1f5b
         name: retention-policy-agent
         resources:
           limits:
@@ -1961,7 +1961,7 @@ spec:
           value: token
         - name: KUBERNETES_MIN_VERSION
           value: v1.28.0
-        image: quay.io/konflux-ci/tekton-results-watcher:e2b02c42c263823137ebd1440f4a7a4b6238909d
+        image: quay.io/konflux-ci/tekton-results-watcher:99db802a56c3d62e823e162feee9811e55ed1f5b
         name: watcher
         ports:
         - containerPort: 9090

--- a/components/pipeline-service/production/stone-prod-p01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prod-p01/deploy.yaml
@@ -1529,7 +1529,7 @@ spec:
             secretKeyRef:
               key: db.name
               name: tekton-results-database
-        image: quay.io/konflux-ci/tekton-results-api:e2b02c42c263823137ebd1440f4a7a4b6238909d
+        image: quay.io/konflux-ci/tekton-results-api:99db802a56c3d62e823e162feee9811e55ed1f5b
         livenessProbe:
           httpGet:
             path: /healthz
@@ -1719,7 +1719,7 @@ spec:
             secretKeyRef:
               key: db.name
               name: tekton-results-database
-        image: quay.io/konflux-ci/tekton-results-api:e2b02c42c263823137ebd1440f4a7a4b6238909d
+        image: quay.io/konflux-ci/tekton-results-api:99db802a56c3d62e823e162feee9811e55ed1f5b
         livenessProbe:
           httpGet:
             path: /healthz
@@ -1824,7 +1824,7 @@ spec:
             secretKeyRef:
               key: POSTGRES_PASSWORD
               name: tekton-results-postgres
-        image: quay.io/konflux-ci/tekton-results-retention-policy-agent:e2b02c42c263823137ebd1440f4a7a4b6238909d
+        image: quay.io/konflux-ci/tekton-results-retention-policy-agent:99db802a56c3d62e823e162feee9811e55ed1f5b
         name: retention-policy-agent
         resources:
           limits:
@@ -1961,7 +1961,7 @@ spec:
           value: token
         - name: KUBERNETES_MIN_VERSION
           value: v1.28.0
-        image: quay.io/konflux-ci/tekton-results-watcher:e2b02c42c263823137ebd1440f4a7a4b6238909d
+        image: quay.io/konflux-ci/tekton-results-watcher:99db802a56c3d62e823e162feee9811e55ed1f5b
         name: watcher
         ports:
         - containerPort: 9090

--- a/components/pipeline-service/production/stone-prod-p02/deploy.yaml
+++ b/components/pipeline-service/production/stone-prod-p02/deploy.yaml
@@ -1529,7 +1529,7 @@ spec:
             secretKeyRef:
               key: db.name
               name: tekton-results-database
-        image: quay.io/konflux-ci/tekton-results-api:e2b02c42c263823137ebd1440f4a7a4b6238909d
+        image: quay.io/konflux-ci/tekton-results-api:99db802a56c3d62e823e162feee9811e55ed1f5b
         livenessProbe:
           httpGet:
             path: /healthz
@@ -1719,7 +1719,7 @@ spec:
             secretKeyRef:
               key: db.name
               name: tekton-results-database
-        image: quay.io/konflux-ci/tekton-results-api:e2b02c42c263823137ebd1440f4a7a4b6238909d
+        image: quay.io/konflux-ci/tekton-results-api:99db802a56c3d62e823e162feee9811e55ed1f5b
         livenessProbe:
           httpGet:
             path: /healthz
@@ -1824,7 +1824,7 @@ spec:
             secretKeyRef:
               key: POSTGRES_PASSWORD
               name: tekton-results-postgres
-        image: quay.io/konflux-ci/tekton-results-retention-policy-agent:e2b02c42c263823137ebd1440f4a7a4b6238909d
+        image: quay.io/konflux-ci/tekton-results-retention-policy-agent:99db802a56c3d62e823e162feee9811e55ed1f5b
         name: retention-policy-agent
         resources:
           limits:
@@ -1961,7 +1961,7 @@ spec:
           value: token
         - name: KUBERNETES_MIN_VERSION
           value: v1.28.0
-        image: quay.io/konflux-ci/tekton-results-watcher:e2b02c42c263823137ebd1440f4a7a4b6238909d
+        image: quay.io/konflux-ci/tekton-results-watcher:99db802a56c3d62e823e162feee9811e55ed1f5b
         name: watcher
         ports:
         - containerPort: 9090


### PR DESCRIPTION
This update includes a fix, to skip reconciliation of stored PieplineRuns and TaskRuns.
Previous PR #7062 updated stage.