### PR TITLE
Upgrade MCE operator to 2.8 in prod

### DIFF
--- a/components/cluster-as-a-service/base/multicluster-engine.yaml
+++ b/components/cluster-as-a-service/base/multicluster-engine.yaml
@@ -27,7 +27,7 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "-1"
 spec:
-  channel: stable-2.7
+  channel: stable-2.8
   installPlanApproval: Automatic
   name: multicluster-engine
   source: redhat-operators

--- a/components/cluster-as-a-service/production/add-hypershift-params.yaml
+++ b/components/cluster-as-a-service/production/add-hypershift-params.yaml
@@ -9,7 +9,7 @@
   path: /spec/template/spec/source/helm/parameters/-
   value:
     name: hypershiftImage
-    value: registry.redhat.io/multicluster-engine/hypershift-rhel9-operator:v2.7
+    value: registry.redhat.io/multicluster-engine/hypershift-rhel9-operator:v2.8
 
 - op: add
   path: /spec/template/spec/source/helm/parameters/-


### PR DESCRIPTION
This adds support for provisioning OCP 4.18 with EaaS.