### PR TITLE
ClusterRole for integration pipeline service account runner

### DIFF
--- a/components/konflux-rbac/base/konflux-integration-runner.yaml
+++ b/components/konflux-rbac/base/konflux-integration-runner.yaml
@@ -1,0 +1,51 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: konflux-integration-runner
+rules:
+  - verbs:
+      - get
+      - list
+    apiGroups:
+      - ''
+    resources:
+      - secrets
+  - verbs:
+      - use
+    apiGroups:
+      - security.openshift.io
+    resources:
+      - securitycontextconstraints
+    resourceNames:
+      - appstudio-pipelines-scc
+  - verbs:
+      - get
+      - list
+    apiGroups:
+      - appstudio.redhat.com
+    resources:
+      - enterprisecontractpolicies
+  - verbs:
+      - get
+      - create
+      - delete
+      - list
+      - watch
+    apiGroups:
+      - eaas.konflux-ci.dev
+    resources:
+      - namespaces
+  - verbs:
+      - get
+      - list
+    apiGroups:
+      - tekton.dev
+    resources:
+      - pipelineruns
+      - taskruns
+  - verbs:
+      - "*"
+    apiGroups:
+      - ci.openshift.org
+    resources:
+      - testplatformclusters

--- a/components/konflux-rbac/base/kustomization.yaml
+++ b/components/konflux-rbac/base/kustomization.yaml
@@ -2,3 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - appstudio-pipelines-runner.yaml
+- konflux-integration-runner.yaml

--- a/components/konflux-rbac/production/base/konflux-integration-runner.yaml
+++ b/components/konflux-rbac/production/base/konflux-integration-runner.yaml
@@ -1,0 +1,51 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: konflux-integration-runner
+rules:
+  - verbs:
+      - get
+      - list
+    apiGroups:
+      - ''
+    resources:
+      - secrets
+  - verbs:
+      - use
+    apiGroups:
+      - security.openshift.io
+    resources:
+      - securitycontextconstraints
+    resourceNames:
+      - appstudio-pipelines-scc
+  - verbs:
+      - get
+      - list
+    apiGroups:
+      - appstudio.redhat.com
+    resources:
+      - enterprisecontractpolicies
+  - verbs:
+      - get
+      - create
+      - delete
+      - list
+      - watch
+    apiGroups:
+      - eaas.konflux-ci.dev
+    resources:
+      - namespaces
+  - verbs:
+      - get
+      - list
+    apiGroups:
+      - tekton.dev
+    resources:
+      - pipelineruns
+      - taskruns
+  - verbs:
+      - "*"
+    apiGroups:
+      - ci.openshift.org
+    resources:
+      - testplatformclusters

--- a/components/konflux-rbac/production/base/kustomization.yaml
+++ b/components/konflux-rbac/production/base/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
   - konflux-viewer-user-actions.yaml
   - konflux-builder-bot-actions.yaml
   - konflux-releaser-bot-actions.yaml
+  - konflux-integration-runner.yaml


### PR DESCRIPTION
Integration pipelines will eventually use new service accounts bound to this role.

Permissions for SpaceRequests are not included since toolchain is obsolete.

Assisted-by: cursor (claude-4-sonnet)