### PR TITLE
KONFLUX-134: Cancel in-progress PipelineRuns for updated pull requests (staging)

### DIFF
--- a/components/pipeline-service/staging/base/main-pipeline-service-configuration.yaml
+++ b/components/pipeline-service/staging/base/main-pipeline-service-configuration.yaml
@@ -2006,6 +2006,9 @@ spec:
             namespace }}/pipelinerun/{{ pr }}
           custom-console-url-pr-tasklog: https://konflux-ui.apps.stone-stg-rh01.l2vh.p1.openshiftapps.com/ns/{{
             namespace }}/pipelinerun/{{ pr }}/logs/{{ task }}
+          remember-ok-to-test: "false"
+          secret-github-app-token-scoped: "false"
+          enable-cancel-in-progress-on-pull-requests: "true"
   profile: all
   pruner:
     disabled: true

--- a/components/pipeline-service/staging/stone-stage-p01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stage-p01/deploy.yaml
@@ -2593,6 +2593,7 @@ spec:
             namespace }}/pipelinerun/{{ pr }}/logs/{{ task }}
           remember-ok-to-test: "false"
           secret-github-app-token-scoped: "false"
+          enable-cancel-in-progress-on-pull-requests: "true"
   profile: all
   pruner:
     disabled: true

--- a/components/pipeline-service/staging/stone-stage-p01/resources/update-tekton-config-pac.yaml
+++ b/components/pipeline-service/staging/stone-stage-p01/resources/update-tekton-config-pac.yaml
@@ -9,3 +9,4 @@
     custom-console-url-pr-tasklog: https://konflux-ui.apps.stone-stage-p01.hpmt.p1.openshiftapps.com/ns/{{ namespace }}/pipelinerun/{{ pr }}/logs/{{ task }}
     remember-ok-to-test: "false"
     secret-github-app-token-scoped: "false"
+    enable-cancel-in-progress-on-pull-requests: "true"

--- a/components/pipeline-service/staging/stone-stg-rh01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stg-rh01/deploy.yaml
@@ -2603,6 +2603,9 @@ spec:
             namespace }}/pipelinerun/{{ pr }}
           custom-console-url-pr-tasklog: https://konflux-ui.apps.stone-stg-rh01.l2vh.p1.openshiftapps.com/ns/{{
             namespace }}/pipelinerun/{{ pr }}/logs/{{ task }}
+          remember-ok-to-test: "false"
+          secret-github-app-token-scoped: "false"
+          enable-cancel-in-progress-on-pull-requests: "true"
   profile: all
   pruner:
     disabled: true


### PR DESCRIPTION
This should reduce some load on the cluster when pull requests are updated over and over again. Earlier unnecessary PipelinesRuns will be cancelled and impose less load.