### PR TITLE
KubeArchive: allow exported_job to reach Prometheus

### DIFF
--- a/components/kubearchive/base/monitoring-servicemonitor.yaml
+++ b/components/kubearchive/base/monitoring-servicemonitor.yaml
@@ -49,7 +49,7 @@ spec:
         key: token
       tlsConfig:
         insecureSkipVerify: true
-      honorLabels: true
+      honorLabels: false # this is enforced as false at a higher level
   selector:
     matchLabels:
       app: otel-collector

--- a/components/monitoring/prometheus/base/monitoringstack/monitoringstack.yaml
+++ b/components/monitoring/prometheus/base/monitoringstack/monitoringstack.yaml
@@ -53,7 +53,7 @@ spec:
           unexpected_status|failure|hostname|label_app_kubernetes_io_managed_by|status|\
           pipeline|pipelinename|pipelinerun|schedule|check|grpc_service|grpc_code|\
           grpc_method|lease|lease_holder|deployment|platform|mode|cpu|role|node|kind|\
-          verb|request_kind|tested_cluster|resource_type"
+          verb|request_kind|tested_cluster|resource_type|exported_job"
 ---
 # Grant permission to Federate In-Cluster Prometheus
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
Due to how KubeArchive exposes metrics the `job` gets overwritten by a higher layer and it can't be changed, so we need to let `exported_job` to be passed to Prometheus. The reasoning behind that `honorLabels` is not honored is because users could potentially override labels as `namespace` leading to confusion and problems in metrics analysis. https://issues.redhat.com/browse/MON-793 and  PVO11Y-4845 for details.
