### PR TITLE
Bump hypershift-aws-template chart to 0.1.8

### DIFF
--- a/components/cluster-as-a-service/base/clustertemplates.yaml
+++ b/components/cluster-as-a-service/base/clustertemplates.yaml
@@ -31,7 +31,7 @@ spec:
       source:
         chart: hypershift-aws-template
         repoURL: https://konflux-ci.dev/cluster-template-charts/
-        targetRevision: 0.1.7
+        targetRevision: 0.1.8
         helm:
           parameters:
             - name: region


### PR DESCRIPTION
This should fix an issue where fips is always enabled on EaaS ephemeral clusters when it should be disabled.