### PR TITLE
KubeArchive: port 9090 should not be exposed

### DIFF
--- a/components/kubearchive/base/monitoring-otel-collector.yaml
+++ b/components/kubearchive/base/monitoring-otel-collector.yaml
@@ -78,10 +78,6 @@ spec:
           command:
             - '/otelcol'
             - '--config=/conf/otel-collector-config.yaml'
-          ports:
-            - containerPort: 4318
-            - containerPort: 8888
-            - containerPort: 9090
           resources:
             limits:
               cpu: 100m

--- a/components/kubearchive/base/otel-collector-config.yaml
+++ b/components/kubearchive/base/otel-collector-config.yaml
@@ -3,14 +3,14 @@ receivers:
   otlp:
     protocols:
       http:
-        endpoint: 0.0.0.0:4318
+        endpoint: 127.0.0.1:4318
 
 processors:
   batch:
 
 exporters:
   prometheus:
-    endpoint: '0.0.0.0:9090'
+    endpoint: 127.0.0.1:9090
     send_timestamps: true
     add_metric_suffixes: false
   debug:


### PR DESCRIPTION
The port was open for anyone to reach, but there is no need as the one who is exposing something is the kube-rbac-proxy. This could led to an error in which a ServiceMonitor was monitoring this container even if it intended to monitoring another one. This being available could be part of the problem.