### PR TITLE
Allow o11y admins to view all monitoring resources in cluster

### DIFF
--- a/components/monitoring/prometheus/base/rbac/monitoring-all-admin.yaml
+++ b/components/monitoring/prometheus/base/rbac/monitoring-all-admin.yaml
@@ -1,0 +1,32 @@
+# allow access to all monitoring resources on the whole cluster
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: o11y-admins-cluster-view
+rules:
+  - apiGroups:
+      - monitoring.coreos.com
+    resources:
+      - alertmanagers
+      - prometheuses
+      - prometheusrules
+      - servicemonitors
+      - podmonitors
+      - thanosrulers
+    verbs:
+      - get
+      - list
+      - watch
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: o11y-admins-cluster-view
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: konflux-o11y-admins
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: o11y-admins-cluster-view


### PR DESCRIPTION
This is necessary for debugging of said resources.