### PR TITLE
chore: upgrade gosmee image in production

### DIFF
--- a/components/smee-client/base/deployment.yaml
+++ b/components/smee-client/base/deployment.yaml
@@ -14,7 +14,7 @@ spec:
         app: gosmee-client
     spec:
       containers:
-        - image: "ghcr.io/chmouel/gosmee:v0.20.2"
+        - image: "ghcr.io/chmouel/gosmee:v0.26.1"
           imagePullPolicy: Always
           name: gosmee
           args:

--- a/components/smee/base/deployment.yaml
+++ b/components/smee/base/deployment.yaml
@@ -16,7 +16,7 @@ spec:
         app: gosmee
     spec:
       containers:
-        - image: "ghcr.io/chmouel/gosmee:v0.20.2"
+        - image: "ghcr.io/chmouel/gosmee:v0.26.1"
           imagePullPolicy: Always
           name: gosmee
           args: ["server", "--address", "0.0.0.0"]


### PR DESCRIPTION
Upgrade gosmee to latest version, as preparation for installing smee sidecar in production