### PR TITLE
PVO11Y-4852 Fix: add new rolebinding to kustomization file

### DIFF
--- a/components/monitoring/prometheus/base/rbac/kustomization.yaml
+++ b/components/monitoring/prometheus/base/rbac/kustomization.yaml
@@ -2,3 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - monitoring-admin.yaml
+- monitoring-all-admin.yaml


### PR DESCRIPTION
The new rolebinding was not deployed because it was not added to the kustomization file resources.