### PR TITLE
KubeArchive: reopen 4318 for metrics

### DIFF
--- a/components/kubearchive/base/monitoring-otel-collector.yaml
+++ b/components/kubearchive/base/monitoring-otel-collector.yaml
@@ -78,6 +78,8 @@ spec:
           command:
             - '/otelcol'
             - '--config=/conf/otel-collector-config.yaml'
+          ports:
+            - containerPort: 4318
           resources:
             limits:
               cpu: 100m

--- a/components/kubearchive/base/otel-collector-config.yaml
+++ b/components/kubearchive/base/otel-collector-config.yaml
@@ -3,7 +3,7 @@ receivers:
   otlp:
     protocols:
       http:
-        endpoint: 127.0.0.1:4318
+        endpoint: 0.0.0.0:4318
 
 processors:
   batch:


### PR DESCRIPTION
I closed too much, this port is needed so our components push to the otel-collector.