### PR TITLE
Permit releaser SAs to manage snapshots

### DIFF
--- a/components/konflux-rbac/production/base/konflux-releaser-bot-actions.yaml
+++ b/components/konflux-rbac/production/base/konflux-releaser-bot-actions.yaml
@@ -8,5 +8,16 @@ rules:
   resources:
   - releases
   verbs:
+  - list
+  - get
+  - watch
+  - create
+- apiGroups:
+  - appstudio.redhat.com
+  resources:
+  - snapshots
+  verbs:
+  - list
+  - get
   - watch
   - create

--- a/components/konflux-rbac/staging/base/konflux-releaser-bot-actions.yaml
+++ b/components/konflux-rbac/staging/base/konflux-releaser-bot-actions.yaml
@@ -8,5 +8,16 @@ rules:
   resources:
   - releases
   verbs:
+  - list
+  - get
+  - watch
+  - create
+- apiGroups:
+  - appstudio.redhat.com
+  resources:
+  - snapshots
+  verbs:
+  - list
+  - get
   - watch
   - create


### PR DESCRIPTION
If a user has a SA in place to manage releases, then it makes sense for them to also be able to manage snapshots with that SA so that they can achieve https://konflux.pages.redhat.com/docs/users/patterns/gitops-for-manual-releases.html

https://issues.redhat.com/browse/KONFLUX-9093