### PR TITLE
bump namespace-lister in staging

### DIFF
--- a/components/namespace-lister/base/kustomization.yaml
+++ b/components/namespace-lister/base/kustomization.yaml
@@ -12,7 +12,7 @@ namespace: namespace-lister
 images:
 - name: namespace-lister
   newName: quay.io/konflux-ci/namespace-lister
-  newTag: 7fdd5035064ffb27d1337ecffce42752f23f2548
+  newTag: 9536d62f29543226cae51217973e93c867e4cd58
 patches:
 - path: ./patches/with_cachenamespacelabelselector.yaml
   target:


### PR DESCRIPTION
The recent updates focus on introducing a new feature for managing access control using virtual labels and annotations. This allows for more flexible namespace access configurations.
Additionally, there have been several improvements to the continuous integration (CI) system, such as updating the linting tools and streamlining the build process. The project's dependencies, including the base container images, have also been updated.

# Changelog

* https://github.com/konflux-ci/namespace-lister/pull/148
* https://github.com/konflux-ci/namespace-lister/pull/147
* https://github.com/konflux-ci/namespace-lister/pull/146
* https://github.com/konflux-ci/namespace-lister/pull/144
* https://github.com/konflux-ci/namespace-lister/pull/142
* https://github.com/konflux-ci/namespace-lister/pull/141
* https://github.com/konflux-ci/namespace-lister/pull/139
* https://github.com/konflux-ci/namespace-lister/pull/140
* https://github.com/konflux-ci/namespace-lister/pull/137

Signed-off-by: Francesco Ilario <filario@redhat.com>
Assisted-by: Cursor-AI