### PR TITLE
KubeArchive: disable leader election

### DIFF
--- a/components/kubearchive/development/kustomization.yaml
+++ b/components/kubearchive/development/kustomization.yaml
@@ -99,6 +99,7 @@ patches:
           spec:
             containers:
               - name: manager
+                args: [--health-probe-bind-address=:8081]
                 env:
                 - name: KUBEARCHIVE_OTEL_MODE
                   value: enabled


### PR DESCRIPTION
Our operator is getting restarted due to etcd defrag that makes the leases unavailable for more than 15s, the default timeout for leases. I'm disabling the leader election since patching the timeout will take some days.