### PR TITLE
fix(KFLUXSPRT-4158): revert integration production to 5a79cbc

### DIFF
--- a/components/integration/production/base/kustomization.yaml
+++ b/components/integration/production/base/kustomization.yaml
@@ -3,13 +3,13 @@ kind: Kustomization
 resources:
 - ../../base
 - ../../base/external-secrets
-- https://github.com/konflux-ci/integration-service/config/default?ref=ff0d0fa3d588761b5730b937da59657347f26974
-- https://github.com/konflux-ci/integration-service/config/snapshotgc?ref=ff0d0fa3d588761b5730b937da59657347f26974
+- https://github.com/konflux-ci/integration-service/config/default?ref=5a79cbca6e8769fc9077dd11edca888d8058c74a
+- https://github.com/konflux-ci/integration-service/config/snapshotgc?ref=5a79cbca6e8769fc9077dd11edca888d8058c74a
 
 images:
 - name: quay.io/konflux-ci/integration-service
   newName: quay.io/konflux-ci/integration-service
-  newTag: ff0d0fa3d588761b5730b937da59657347f26974
+  newTag: 5a79cbca6e8769fc9077dd11edca888d8058c74a
 
 configMapGenerator:
 - name: integration-config


### PR DESCRIPTION
* Revert production version for integration service to the [5a79cbca6e8769fc9077dd11edca888d8058c74a](https://github.com/konflux-ci/integration-service/commit/5a79cbca6e8769fc9077dd11edca888d8058c74a) commit that's before the one that introduces the bug with webhooks preventing creation of an application through the UI

Signed-off-by: dirgim <kpavic@redhat.com>