### PR TITLE
bump namespace-lister image ref

### DIFF
--- a/components/namespace-lister/base/kustomization.yaml
+++ b/components/namespace-lister/base/kustomization.yaml
@@ -12,7 +12,7 @@ namespace: namespace-lister
 images:
 - name: namespace-lister
   newName: quay.io/konflux-ci/namespace-lister
-  newTag: 9536d62f29543226cae51217973e93c867e4cd58
+  newTag: 5b89509cb7b60f7594b76f364fc2caa3fd5a389f
 patches:
 - path: ./patches/with_cachenamespacelabelselector.yaml
   target:


### PR DESCRIPTION
The image tagged 9536d62f29543226cae51217973e93c867e4cd58 doesn't exist, and is causing issues on the staging clusters.  Update the image reference to 5b89509cb7b60f7594b76f364fc2caa3fd5a389f.