### PR TITLE
feat: set pipeline priority and multi-platform build quotas for development

### DIFF
--- a/components/kueue/development/queue-config/cluster-queue.yaml
+++ b/components/kueue/development/queue-config/cluster-queue.yaml
@@ -34,11 +34,23 @@ spec:
       - tekton.dev/pipelineruns
       - cpu
       - memory
+      - linux-arm64
+      - linux-amd64
+      - linux-s390x
+      - linux-ppc64le
       flavors:
       - name: default-flavor
         resources:
         - name: tekton.dev/pipelineruns
           nominalQuota: "500"
+        - name: linux-arm64
+          nominalQuota: "10"
+        - name: linux-amd64
+          nominalQuota: "10"
+        - name: linux-s390x
+          nominalQuota: "10"
+        - name: linux-ppc64le
+          nominalQuota: "10"
         # When a Workload doesn't have cpu or memory requests, if there is a limit range
         # in the namespace, Kueue will assign the requests from it to the Workload.
         # We don't care about the cpu/memory for PipelineRuns, thus setting a high value for both.

--- a/components/kueue/development/queue-config/kustomization.yaml
+++ b/components/kueue/development/queue-config/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - cluster-queue.yaml
+- workload-priority-class.yaml
 
 # ensure that installation starts after the installation of kueue complete
 commonAnnotations:

--- a/components/kueue/development/queue-config/workload-priority-class.yaml
+++ b/components/kueue/development/queue-config/workload-priority-class.yaml
@@ -1,0 +1,57 @@
+---
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: WorkloadPriorityClass
+metadata:
+  name: konflux-release
+value: 1000
+description: "Highest priority for release pipelines"
+---
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: WorkloadPriorityClass
+metadata:
+  name: konflux-tenant-release
+value: 900
+description: "High priority for tenant release pipelines"
+---
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: WorkloadPriorityClass
+metadata:
+  name: konflux-post-merge-test
+value: 800
+description: "Priority for post-merge tests"
+---
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: WorkloadPriorityClass
+metadata:
+  name: konflux-post-merge-build
+value: 700
+description: "Priority for post-merge builds"
+---
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: WorkloadPriorityClass
+metadata:
+  name: konflux-pre-merge-test
+value: 600
+description: "Priority for pre-merge tests"
+---
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: WorkloadPriorityClass
+metadata:
+  name: konflux-pre-merge-build
+value: 500
+description: "Priority for pre-merge builds"
+---
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: WorkloadPriorityClass
+metadata:
+  name: konflux-default
+value: 400
+description: "Default priority for konflux pipelines"
+---
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: WorkloadPriorityClass
+metadata:
+  name: konflux-dependency-update
+value: 300
+description: "Lower priority for dependency updates"
+

--- a/components/kueue/development/tekton-kueue/config.yaml
+++ b/components/kueue/development/tekton-kueue/config.yaml
@@ -1,0 +1,52 @@
+queueName: pipelines-queue
+cel:
+  expressions:
+    # Set resource requests for multi platform pipelines
+    - |
+        has(pipelineRun.spec.params) &&
+        pipelineRun.spec.params.exists(p, p.name == 'build-platforms') ?
+        pipelineRun.spec.params.filter(
+          p, 
+          p.name == 'build-platforms')[0]
+        .value.map(
+          p,
+          annotation("kueue.konflux-ci.dev/requests-" + replace(p, "/", "-"), "1") 
+        ) : []
+
+    # Set resource requests for multi platform pipelines which doesn't use the build-platforms parameter (old style)
+    - |
+      has(pipelineRun.spec.pipelineSpec) &&
+      pipelineRun.spec.pipelineSpec.tasks.size() > 0 ?
+      pipelineRun.spec.pipelineSpec.tasks.map(
+        task,
+        has(task.params) ? task.params.filter(p, p.name == 'PLATFORM') : []
+      )
+      .filter(p, p.size() > 0)
+      .map(
+        p,
+        annotation("kueue.konflux-ci.dev/requests-" + replace(p[0].value, "/", "-"), "1")
+      ) : []
+
+    # Set the pipeline priority
+    - |
+        pacEventType == 'push' ? priority('konflux-post-merge-build') :
+        pacEventType == 'pull_request' ? priority('konflux-pre-merge-build') :
+        pacTestEventType == 'push' ? priority('konflux-post-merge-test') :
+        pacTestEventType == 'pull_request' ? priority('konflux-pre-merge-test') :
+
+        has(pipelineRun.metadata.labels) &&
+        'appstudio.openshift.io/service' in pipelineRun.metadata.labels &&
+        pipelineRun.metadata.labels['appstudio.openshift.io/service'] == 'release' &&
+        'pipelines.appstudio.openshift.io/type' in pipelineRun.metadata.labels &&
+        pipelineRun.metadata.labels['pipelines.appstudio.openshift.io/type'] == 'managed' ?
+        priority('konflux-release') :
+
+        has(pipelineRun.metadata.labels) &&
+        'appstudio.openshift.io/service' in pipelineRun.metadata.labels &&
+        pipelineRun.metadata.labels['appstudio.openshift.io/service'] == 'release' &&
+        'pipelines.appstudio.openshift.io/type' in pipelineRun.metadata.labels &&
+        pipelineRun.metadata.labels['pipelines.appstudio.openshift.io/type'] == 'tenant' ?
+        priority('konflux-tenant-release') :
+
+        plrNamespace == 'mintmaker' ? priority('konflux-dependency-update') :
+        priority('konflux-default')

--- a/components/kueue/development/tekton-kueue/kustomization.yaml
+++ b/components/kueue/development/tekton-kueue/kustomization.yaml
@@ -12,3 +12,10 @@ namespace: tekton-kueue
 # ensure that installation starts after the installation of kueue complete
 commonAnnotations:
   argocd.argoproj.io/sync-wave: "10"
+
+configMapGenerator:
+  - name: tekton-kueue-config
+    namespace: tekton-kueue
+    behavior: replace
+    files:
+      - config.yaml


### PR DESCRIPTION
- Add WorkloadPriorityClass resources (see workload-priority-class.yaml)

- Add tekton-kueue configuration with CEL expressions for:
  - Multi-platform pipeline resource requests (linux-arm64, linux-amd64, linux-s390x, linux-ppc64le)
  - Dynamic priority assignment based on PAC event types, service labels, and namespaces
  - Support for both new and legacy multi-platform pipeline formats

- Update cluster queue with nominalQuota for multi-platform VMs:
  - Add quotas for linux-arm64, linux-amd64, linux-s390x, linux-ppc64le (10 each)

- Configure tekton-kueue-config ConfigMap generation from config.yaml

Assisted-By: Cursor