### PR TITLE
fix(KFLUXSPRT-4158): revert integration dev and stage to 5a79cbc

### DIFF
--- a/components/integration/development/kustomization.yaml
+++ b/components/integration/development/kustomization.yaml
@@ -2,13 +2,13 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - ../base
-- https://github.com/konflux-ci/integration-service/config/default?ref=ff0d0fa3d588761b5730b937da59657347f26974
-- https://github.com/konflux-ci/integration-service/config/snapshotgc?ref=ff0d0fa3d588761b5730b937da59657347f26974
+- https://github.com/konflux-ci/integration-service/config/default?ref=5a79cbca6e8769fc9077dd11edca888d8058c74a
+- https://github.com/konflux-ci/integration-service/config/snapshotgc?ref=5a79cbca6e8769fc9077dd11edca888d8058c74a
 
 images:
 - name: quay.io/konflux-ci/integration-service
   newName: quay.io/konflux-ci/integration-service
-  newTag: ff0d0fa3d588761b5730b937da59657347f26974
+  newTag: 5a79cbca6e8769fc9077dd11edca888d8058c74a
 
 configMapGenerator:
 - name: integration-config

--- a/components/integration/staging/base/kustomization.yaml
+++ b/components/integration/staging/base/kustomization.yaml
@@ -3,13 +3,13 @@ kind: Kustomization
 resources:
 - ../../base
 - ../../base/external-secrets
-- https://github.com/konflux-ci/integration-service/config/default?ref=ff0d0fa3d588761b5730b937da59657347f26974
-- https://github.com/konflux-ci/integration-service/config/snapshotgc?ref=ff0d0fa3d588761b5730b937da59657347f26974
+- https://github.com/konflux-ci/integration-service/config/default?ref=5a79cbca6e8769fc9077dd11edca888d8058c74a
+- https://github.com/konflux-ci/integration-service/config/snapshotgc?ref=5a79cbca6e8769fc9077dd11edca888d8058c74a
 
 images:
 - name: quay.io/konflux-ci/integration-service
   newName: quay.io/konflux-ci/integration-service
-  newTag: ff0d0fa3d588761b5730b937da59657347f26974
+  newTag: 5a79cbca6e8769fc9077dd11edca888d8058c74a
 
 configMapGenerator:
 - name: integration-config


### PR DESCRIPTION
* Revert dev and stage versions of integration service to the 5a79cbca6e8769fc9077dd11edca888d8058c74a commit that's before the one that introduces the bug with webhooks preventing creation of an application through the UI

Signed-off-by: dirgim <kpavic@redhat.com>