### PR TITLE
fix: reduce-tekton-pr kyverno policy for e2e tests

### DIFF
--- a/components/policies/development/taskruns-cluster-policy.yaml
+++ b/components/policies/development/taskruns-cluster-policy.yaml
@@ -16,8 +16,7 @@ spec:
           kinds:
           - Pod
           names:
-          - '*-on-pull-request-*'
-          - '*-on-push-*'
+          - '*-pod'
           operations:
           - CREATE
           selector:
@@ -27,8 +26,7 @@ spec:
           kinds:
           - Pod
           names:
-          - '*ec-*'
-          - '*enterprise-contract-*'
+          - '*-pod'
           operations:
           - CREATE
           selector:


### PR DESCRIPTION
previous kyverno policy did not apply to all pods created by e2e test pipelines, because when the component name is long, the TaskRun's pod name no longer contains - `-on-pull-request-` or `-on-push-` in its name, but the suffix `-pod` always remains