### PR TITLE
[konflux-ui] add user to OWNERS file

### DIFF
--- a/components/konflux-ui/OWNERS
+++ b/components/konflux-ui/OWNERS
@@ -11,6 +11,7 @@ approvers:
 - dperaza4dustbit
 - filariow
 - sadlerap
+- rrosatti
 
 reviewers:
 - abhinandan13jan
@@ -23,3 +24,4 @@ reviewers:
 - dperaza4dustbit
 - filariow
 - sadlerap
+- rrosatti


### PR DESCRIPTION
## Description

In this PR we're adding my GH user (`rrosatti`) to konflux-ui `OWNERS` file, so I'd be able to approve the PRs related to our project.