### PR TITLE
Replace rhel-p01 AMD VMs by m7a

### DIFF
--- a/components/multi-platform-controller/production-downstream/kflux-rhel-p01/host-config.yaml
+++ b/components/multi-platform-controller/production-downstream/kflux-rhel-p01/host-config.yaml
@@ -202,7 +202,7 @@ data:
   dynamic.linux-amd64.type: aws
   dynamic.linux-amd64.region: us-east-1
   dynamic.linux-amd64.ami: ami-026ebd4cfe2c043b2
-  dynamic.linux-amd64.instance-type: m6a.large
+  dynamic.linux-amd64.instance-type: m7a.large
   dynamic.linux-amd64.instance-tag: prod-amd64
   dynamic.linux-amd64.key-name: kflux-rhel-p01-key-pair
   dynamic.linux-amd64.aws-secret: aws-account
@@ -214,7 +214,7 @@ data:
   dynamic.linux-mlarge-amd64.type: aws
   dynamic.linux-mlarge-amd64.region: us-east-1
   dynamic.linux-mlarge-amd64.ami: ami-026ebd4cfe2c043b2
-  dynamic.linux-mlarge-amd64.instance-type: m6a.large
+  dynamic.linux-mlarge-amd64.instance-type: m7a.large
   dynamic.linux-mlarge-amd64.instance-tag: prod-amd64-mlarge
   dynamic.linux-mlarge-amd64.key-name: kflux-rhel-p01-key-pair
   dynamic.linux-mlarge-amd64.aws-secret: aws-account
@@ -226,7 +226,7 @@ data:
   dynamic.linux-mxlarge-amd64.type: aws
   dynamic.linux-mxlarge-amd64.region: us-east-1
   dynamic.linux-mxlarge-amd64.ami: ami-026ebd4cfe2c043b2
-  dynamic.linux-mxlarge-amd64.instance-type: m6a.xlarge
+  dynamic.linux-mxlarge-amd64.instance-type: m7a.xlarge
   dynamic.linux-mxlarge-amd64.instance-tag: prod-amd64-mxlarge
   dynamic.linux-mxlarge-amd64.key-name: kflux-rhel-p01-key-pair
   dynamic.linux-mxlarge-amd64.aws-secret: aws-account
@@ -238,7 +238,7 @@ data:
   dynamic.linux-m2xlarge-amd64.type: aws
   dynamic.linux-m2xlarge-amd64.region: us-east-1
   dynamic.linux-m2xlarge-amd64.ami: ami-026ebd4cfe2c043b2
-  dynamic.linux-m2xlarge-amd64.instance-type: m6a.2xlarge
+  dynamic.linux-m2xlarge-amd64.instance-type: m7a.2xlarge
   dynamic.linux-m2xlarge-amd64.instance-tag: prod-amd64-m2xlarge
   dynamic.linux-m2xlarge-amd64.key-name: kflux-rhel-p01-key-pair
   dynamic.linux-m2xlarge-amd64.aws-secret: aws-account
@@ -250,7 +250,7 @@ data:
   dynamic.linux-m4xlarge-amd64.type: aws
   dynamic.linux-m4xlarge-amd64.region: us-east-1
   dynamic.linux-m4xlarge-amd64.ami: ami-026ebd4cfe2c043b2
-  dynamic.linux-m4xlarge-amd64.instance-type: m6a.4xlarge
+  dynamic.linux-m4xlarge-amd64.instance-type: m7a.4xlarge
   dynamic.linux-m4xlarge-amd64.instance-tag: prod-amd64-m4xlarge
   dynamic.linux-m4xlarge-amd64.key-name: kflux-rhel-p01-key-pair
   dynamic.linux-m4xlarge-amd64.aws-secret: aws-account
@@ -262,7 +262,7 @@ data:
   dynamic.linux-m8xlarge-amd64.type: aws
   dynamic.linux-m8xlarge-amd64.region: us-east-1
   dynamic.linux-m8xlarge-amd64.ami: ami-026ebd4cfe2c043b2
-  dynamic.linux-m8xlarge-amd64.instance-type: m6a.8xlarge
+  dynamic.linux-m8xlarge-amd64.instance-type: m7a.8xlarge
   dynamic.linux-m8xlarge-amd64.instance-tag: prod-amd64-m8xlarge
   dynamic.linux-m8xlarge-amd64.key-name: kflux-rhel-p01-key-pair
   dynamic.linux-m8xlarge-amd64.aws-secret: aws-account


### PR DESCRIPTION
The RHEL rpm builds are building x86_64 using MPC VMs, not in cluster so change the MPC EC2 instances from m6a to m7a.

[KONFLUX-8247](https://issues.redhat.com//browse/KONFLUX-8247)