### PR TITLE
kueue: replace "_" with "-" in build platforms

### DIFF
--- a/components/kueue/staging/base/tekton-kueue/config.yaml
+++ b/components/kueue/staging/base/tekton-kueue/config.yaml
@@ -10,7 +10,7 @@ cel:
           p.name == 'build-platforms')[0]
         .value.map(
           p,
-          annotation("kueue.konflux-ci.dev/requests-" + replace(p, "/", "-"), "1") 
+          annotation("kueue.konflux-ci.dev/requests-" + replace(replace(p, "/", "-"), "_", "-"), "1") 
         ) : []
 
     # Set resource requests for multi platform pipelines which doesn't use the build-platforms parameter (old style)
@@ -24,7 +24,7 @@ cel:
       .filter(p, p.size() > 0)
       .map(
         p,
-        annotation("kueue.konflux-ci.dev/requests-" + replace(p[0].value, "/", "-"), "1")
+        annotation("kueue.konflux-ci.dev/requests-" + replace(replace(p[0].value, "/", "-"), "_", "-"), "1")
       ) : []
 
     # Set the pipeline priority


### PR DESCRIPTION
MPC tracks some platforms as `linux/x86_64`, but kueue expects them to be `linux-x86-64`.  The CEL expressions we have for making platform requests produces `linux-x86_64`, which is not recognized as a platform and causes all pipelineruns with this platform to always be held in a pending state.

To fix this, have the CEL expressions replace the underscores in `x86_64` with `-`.  `x86_64` is the only platform with underscores, so no other platform will be affected by this change.