### PR TITLE
Gran konflux-infra member permissions to debug MPC

### DIFF
--- a/components/multi-platform-controller/base/rbac/pod-debug-restart.yaml
+++ b/components/multi-platform-controller/base/rbac/pod-debug-restart.yaml
@@ -33,6 +33,13 @@ rules:
       - pods/status 
     verbs:
       - get
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - get
+      - list
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -40,9 +47,6 @@ metadata:
   name: debug-pod
   namespace: multi-platform-controller
 subjects:
-  - kind: Group
-    apiGroup: rbac.authorization.k8s.io
-    name: konflux-sre
   - apiGroup: rbac.authorization.k8s.io
     kind: Group
     name: konflux-infra


### PR DESCRIPTION
Once debug pod is created, they need access to secret in MPC namespace to be able to connect to the MPC VMs.

Remove konflux-sre, we do not want to give secrets access to people outside of the infra team.