### PR TITLE
Eventing: promote SubjectAccessReview fix to production

### DIFF
--- a/components/knative-eventing/production/base/kustomization.yaml
+++ b/components/knative-eventing/production/base/kustomization.yaml
@@ -17,6 +17,10 @@ patches:
         spec:
           containers:
             - name: eventing-controller
+              image: quay.io/kubearchive/eventing-controller:fix
+              env:
+              - name: APISERVER_RA_IMAGE
+                value: quay.io/kubearchive/eventing-adapter:fix
               resources:
                 requests:
                   cpu: 100m


### PR DESCRIPTION
Promoting change to Knative Eventing so it does not send so many SubjectAccessReview requests to the Kubernetes API.