### PR TITLE
Support local platforms in CQ generation and verify using GH action

### DIFF
--- a/.github/workflows/verify-kueue-queue-configs.yaml
+++ b/.github/workflows/verify-kueue-queue-configs.yaml
@@ -1,0 +1,37 @@
+name: Verify Kueue Queue Configurations
+
+on:
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'components/multi-platform-controller/**'
+      - 'components/kueue/**'
+      - 'hack/kueue-vm-quotas/**'
+      - '.github/workflows/verify-kueue-queue-configs.yaml'
+
+jobs:
+  verify-queue-configs:
+    name: Verify queue configurations are up to date
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install PyYAML
+
+      - name: Verify Kueue queue configurations are up to date
+        run: |
+          ./hack/kueue-vm-quotas/generate-queue-config.sh --verify-no-change
+
+      - name: Report success
+        if: success()
+        run: |
+          echo "✅ All Kueue queue configurations are up to date with their corresponding host-config files" 

--- a/components/kueue/staging/stone-stage-p01/queue-config/cluster-queue.yaml
+++ b/components/kueue/staging/stone-stage-p01/queue-config/cluster-queue.yaml
@@ -43,6 +43,7 @@ spec:
       - name: memory
         nominalQuota: 500Ti
   - coveredResources:
+    - linux-amd64
     - linux-arm64
     - linux-c2xlarge-amd64
     - linux-c2xlarge-arm64
@@ -58,10 +59,11 @@ spec:
     - linux-m2xlarge-arm64
     - linux-m4xlarge-amd64
     - linux-m4xlarge-arm64
-    - linux-m8xlarge-amd64
     flavors:
     - name: platform-group-1
       resources:
+      - name: linux-amd64
+        nominalQuota: '1000'
       - name: linux-arm64
         nominalQuota: '100'
       - name: linux-c2xlarge-amd64
@@ -92,9 +94,8 @@ spec:
         nominalQuota: '100'
       - name: linux-m4xlarge-arm64
         nominalQuota: '100'
-      - name: linux-m8xlarge-amd64
-        nominalQuota: '100'
   - coveredResources:
+    - linux-m8xlarge-amd64
     - linux-m8xlarge-arm64
     - linux-mlarge-amd64
     - linux-mlarge-arm64
@@ -104,13 +105,14 @@ spec:
     - linux-root-amd64
     - linux-root-arm64
     - linux-s390x
-    - linux-amd64
     - linux-x86-64
     - local
     - localhost
     flavors:
     - name: platform-group-2
       resources:
+      - name: linux-m8xlarge-amd64
+        nominalQuota: '100'
       - name: linux-m8xlarge-arm64
         nominalQuota: '100'
       - name: linux-mlarge-amd64
@@ -129,14 +131,12 @@ spec:
         nominalQuota: '100'
       - name: linux-s390x
         nominalQuota: '2'
-      - name: linux-amd64
-        nominalQuota: '500'
       - name: linux-x86-64
-        nominalQuota: '500'
+        nominalQuota: '1000'
       - name: local
-        nominalQuota: '500'
+        nominalQuota: '1000'
       - name: localhost
-        nominalQuota: '500'
+        nominalQuota: '1000'
 ---
 apiVersion: kueue.x-k8s.io/v1beta1
 kind: ResourceFlavor

--- a/components/kueue/staging/stone-stg-rh01/queue-config/cluster-queue.yaml
+++ b/components/kueue/staging/stone-stg-rh01/queue-config/cluster-queue.yaml
@@ -43,6 +43,7 @@ spec:
       - name: memory
         nominalQuota: 500Ti
   - coveredResources:
+    - linux-amd64
     - linux-arm64
     - linux-c2xlarge-amd64
     - linux-c2xlarge-arm64
@@ -58,10 +59,11 @@ spec:
     - linux-m2xlarge-amd64
     - linux-m2xlarge-arm64
     - linux-m4xlarge-amd64
-    - linux-m4xlarge-arm64
     flavors:
     - name: platform-group-1
       resources:
+      - name: linux-amd64
+        nominalQuota: '1000'
       - name: linux-arm64
         nominalQuota: '160'
       - name: linux-c2xlarge-amd64
@@ -92,9 +94,8 @@ spec:
         nominalQuota: '10'
       - name: linux-m4xlarge-amd64
         nominalQuota: '10'
-      - name: linux-m4xlarge-arm64
-        nominalQuota: '10'
   - coveredResources:
+    - linux-m4xlarge-arm64
     - linux-m8xlarge-amd64
     - linux-m8xlarge-arm64
     - linux-mlarge-amd64
@@ -105,13 +106,14 @@ spec:
     - linux-root-amd64
     - linux-root-arm64
     - linux-s390x
-    - linux-amd64
     - linux-x86-64
     - local
     - localhost
     flavors:
     - name: platform-group-2
       resources:
+      - name: linux-m4xlarge-arm64
+        nominalQuota: '10'
       - name: linux-m8xlarge-amd64
         nominalQuota: '10'
       - name: linux-m8xlarge-arm64
@@ -132,14 +134,12 @@ spec:
         nominalQuota: '10'
       - name: linux-s390x
         nominalQuota: '2'
-      - name: linux-amd64
-        nominalQuota: '500'
       - name: linux-x86-64
-        nominalQuota: '500'
+        nominalQuota: '1000'
       - name: local
-        nominalQuota: '500'
+        nominalQuota: '1000'
       - name: localhost
-        nominalQuota: '500'
+        nominalQuota: '1000'
 ---
 apiVersion: kueue.x-k8s.io/v1beta1
 kind: ResourceFlavor

--- a/hack/kueue-vm-quotas/generate-queue-config.sh
+++ b/hack/kueue-vm-quotas/generate-queue-config.sh
@@ -2,22 +2,76 @@
 # This script generates Kueue cluster queue configuration files for VM quotas
 # by processing host configuration files and invoking the update-kueue-vm-quotas.py
 # script with the appropriate input and output paths.
+#
+# Usage: generate-queue-config.sh [--verify-no-change]
+#   --verify-no-change: Verify that no changes were made to the output files
 
 declare -r ROOT="${BASH_SOURCE[0]%/*}"
 
-main() {
-    local cli="hack/kueue-vm-quotas/update-kueue-vm-quotas.py"
-    # public staging
-    python3 \
-        "$cli" \
-        components/multi-platform-controller/staging/host-config.yaml \
-        components/kueue/staging/stone-stg-rh01/queue-config/cluster-queue.yaml
+usage() {
+    echo "Usage: $0 [--verify-no-change]"
+    echo "  --verify-no-change: Verify that no changes were made to the output files"
+    exit 1
+}
 
-    # private staging
-    python3 \
-        "$cli" \
-        components/multi-platform-controller/staging-downstream/host-config.yaml \
-        components/kueue/staging/stone-stage-p01/queue-config/cluster-queue.yaml
+main() {
+    local verify_no_change=false
+    
+    # Parse arguments
+    while [[ $# -gt 0 ]]; do
+        case $1 in
+            --verify-no-change)
+                verify_no_change=true
+                shift
+                ;;
+            -h|--help)
+                usage
+                ;;
+            *)
+                echo "Unknown argument: $1"
+                usage
+                ;;
+        esac
+    done
+
+    local cli="hack/kueue-vm-quotas/update-kueue-vm-quotas.py"
+    
+    # Define input-output file pairs
+    local -A queue_configs=(
+        ["components/multi-platform-controller/staging/host-config.yaml"]="components/kueue/staging/stone-stg-rh01/queue-config/cluster-queue.yaml"
+        ["components/multi-platform-controller/staging-downstream/host-config.yaml"]="components/kueue/staging/stone-stage-p01/queue-config/cluster-queue.yaml"
+    )
+    
+    # Generate queue configurations
+    for input_file in "${!queue_configs[@]}"; do
+        local output_file="${queue_configs[$input_file]}"
+        echo "Generating queue config: $input_file -> $output_file"
+        python3 "$cli" "$input_file" "$output_file"
+    done
+
+    # Verify no changes if flag is set
+    if [[ "$verify_no_change" != "true" ]]; then
+        return 0
+    fi
+
+    echo "Verifying no changes were made to cluster-queue.yaml files..."
+    
+    local changes_detected=false
+    for input_file in "${!queue_configs[@]}"; do
+        local output_file="${queue_configs[$input_file]}"
+        if ! git diff --exit-code --quiet "$output_file" 2>/dev/null; then
+            echo "ERROR: Changes detected in $output_file"
+            git diff "$output_file"
+            changes_detected=true
+        fi
+    done
+    
+    if [[ "$changes_detected" == "true" ]]; then
+        echo "ERROR: Verification failed - changes were detected in output files"
+        exit 1
+    else
+        echo "SUCCESS: No changes detected in cluster-queue.yaml files"
+    fi
 }
 
 if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then


### PR DESCRIPTION
    KFLUXINFRA-1982: Consider local platform when generating CQ
    
    - When generating the cluster queue take include the local platform.
    
    - Local platforms has a fixed quota of 1000 (for simplicity). It's
      possible to configure it in that way because the workload will be
      queued based on the quota for pipelineruns (which will likely be lower).
    
    - Update the CQ's in staging.
  
    KFLUXINFRA-1985: Validate queue definition is up to date
    
    - Add --verify-no-change flag to the generate-queue-config.sh script.
      With this flag the script will fail if there were any modifications
      to the files containing the queue definition.
    
    - Add a Github action for running the verification on PRs.
    