### PR TITLE
fix: apply konflux-ci component only to rh03

### DIFF
--- a/argo-cd-apps/base/konflux-ci/konflux-ci.yaml
+++ b/argo-cd-apps/base/konflux-ci/konflux-ci.yaml
@@ -17,7 +17,9 @@ spec:
                 matchLabels:
                   appstudio.redhat.com/konflux-ci: "true"
           - list:
-              elements: []
+              elements:
+                - nameNormalized: kflux-prd-rh03
+                  values.clusterDir: kflux-prd-rh03
   template:
     metadata:
       name: konflux-ci-{{nameNormalized}}


### PR DESCRIPTION
After the [last change](https://github.com/redhat-appstudio/infra-deployments/pull/7221), konflux-ci-kflux-prd-rh02 app is in [degraded state](https://argocd-server-konflux-public-production.apps.rosa.appsrep09ue1.03r5.p3.openshiftapps.com/applications/konflux-public-production/konflux-ci-kflux-prd-rh02?view=tree&resource=health%3ADegraded) in argo.  Making konflux-ci component is applicable to rh03 cluster only will fix this issue. 