### PR TITLE
Extract kite database secret for stone-stg-rh01

### DIFF
--- a/components/cluster-secret-store/base/appsre-vault-secret-store.yml
+++ b/components/cluster-secret-store/base/appsre-vault-secret-store.yml
@@ -31,3 +31,4 @@ spec:
         - tekton-results
         - openshift-adp
         - product-kubearchive
+        - konflux-kite

--- a/components/konflux-kite/base/external-secrets/database-secret.yaml
+++ b/components/konflux-kite/base/external-secrets/database-secret.yaml
@@ -1,0 +1,20 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-1"
+  name: database-secret
+  namespace: konflux-kite
+spec:
+  dataFrom:
+  - extract:
+      key: "" # will be added by a patch specific to each cluster
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: appsre-vault
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    name: database-secret

--- a/components/konflux-kite/base/external-secrets/kustomization.yaml
+++ b/components/konflux-kite/base/external-secrets/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- database-secret.yaml

--- a/components/konflux-kite/staging/stone-stg-rh01/database-secret-path.yaml
+++ b/components/konflux-kite/staging/stone-stg-rh01/database-secret-path.yaml
@@ -1,0 +1,4 @@
+---
+- op: add
+  path: /spec/dataFrom/0/extract/key
+  value: integrations-output/external-resources/appsres11ue1/stonesoup-infra-stage/issues-dashboard-staging-rds

--- a/components/konflux-kite/staging/stone-stg-rh01/kustomization.yaml
+++ b/components/konflux-kite/staging/stone-stg-rh01/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  # only include secret for now, include base when ready to deploy kite to stone-stg-rh01
+  # - ../../base
+  - ../../base/external-secrets
+patches:
+  - path: database-secret-path.yaml
+    target:
+      name: database-secret
+      group: external-secrets.io
+      version: v1beta1
+      kind: ExternalSecret


### PR DESCRIPTION
Create ExternalSecret to extract database connection info. Create ES in base and patch the path in the cluster dir as each cluster will have a different secret path.

Also allow to get secret from appsre-vault in konflux-kite namespace.