### PR TITLE
KubeArchive: install to kflux-ocp-p01

### DIFF
--- a/argo-cd-apps/base/member/infra-deployments/kubearchive/kubearchive.yaml
+++ b/argo-cd-apps/base/member/infra-deployments/kubearchive/kubearchive.yaml
@@ -21,8 +21,8 @@ spec:
                 - nameNormalized: stone-stg-rh01
                   values.clusterDir: stone-stg-rh01
                 # Private
-                # - nameNormalized: kflux-ocp-p01
-                #   values.clusterDir: kflux-ocp-p01
+                - nameNormalized: kflux-ocp-p01
+                  values.clusterDir: kflux-ocp-p01
                 # - nameNormalized: stone-prod-p01
                 #   values.clusterDir: stone-prod-p01
                 - nameNormalized: stone-prod-p02

--- a/components/konflux-ui/production/kflux-ocp-p01/kustomization.yaml
+++ b/components/konflux-ui/production/kflux-ocp-p01/kustomization.yaml
@@ -13,6 +13,7 @@ configMapGenerator:
     literals:
       - IMPERSONATE=true
       - TEKTON_RESULTS_URL=https://tekton-results-api-service.tekton-results.svc.cluster.local:8080
+      - KUBEARCHIVE_URL=https://kubearchive-api-server.product-kubearchive.svc.cluster.local:8081
 
 patches:
   - path: add-service-certs-patch.yaml

--- a/components/kubearchive/production/kflux-ocp-p01/kustomization.yaml
+++ b/components/kubearchive/production/kflux-ocp-p01/kustomization.yaml
@@ -4,19 +4,11 @@ kind: Kustomization
 resources:
   - ../../base
   - ../base
-  - https://github.com/kubearchive/kubearchive/releases/download/v1.0.1/kubearchive.yaml?timeout=90
+  - https://github.com/kubearchive/kubearchive/releases/download/v1.2.0/kubearchive.yaml?timeout=90
 
 namespace: product-kubearchive
 
 patches:
-  # We don't need the Secret as it will be created by the ExternalSecrets Operator
-  - patch: |-
-      $patch: delete
-      apiVersion: v1
-      kind: Secret
-      metadata:
-        name: kubearchive-database-credentials
-        namespace: kubearchive
   - patch: |-
       apiVersion: batch/v1
       kind: Job
@@ -29,7 +21,15 @@ patches:
               - name: migration
                 env:
                   - name: KUBEARCHIVE_VERSION
-                    value: v1.0.1
+                    value: v1.2.0
+  # We don't need the Secret as it will be created by the ExternalSecrets Operator
+  - patch: |-
+      $patch: delete
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        name: kubearchive-database-credentials
+        namespace: kubearchive
   - patch: |-
       apiVersion: external-secrets.io/v1beta1
       kind: ExternalSecret
@@ -88,6 +88,8 @@ patches:
                   value: enabled
                 - name: OTEL_EXPORTER_OTLP_ENDPOINT
                   value: http://otel-collector:4318
+                - name: AUTH_IMPERSONATE
+                  value: "true"
                 securityContext:
                   readOnlyRootFilesystem: true
                   runAsNonRoot: true
@@ -114,11 +116,11 @@ patches:
                   - containerPort: 8081
                 resources:
                   limits:
-                    cpu: 500m
-                    memory: 256Mi
+                    cpu: 100m
+                    memory: 512Mi
                   requests:
-                    cpu: 10m
-                    memory: 256Mi
+                    cpu: 100m
+                    memory: 512Mi
 
   - patch: |-
       apiVersion: apps/v1


### PR DESCRIPTION
This PR installs KubeArchive into the cluster `kflux-ocp-p01`. I'm porting the changes from the `stone-prod-p02` cluster.