### PR TITLE
mintmaker: increase production memory resources

### DIFF
--- a/components/mintmaker/production/base/manager_patch.yaml
+++ b/components/mintmaker/production/base/manager_patch.yaml
@@ -11,7 +11,7 @@ spec:
         resources:
           limits:
             cpu: 500m
-            memory: 4Gi
+            memory: 5Gi
           requests:
             cpu: 100m
-            memory: 3Gi
+            memory: 5Gi


### PR DESCRIPTION
This change is to accommodate increased memory usage and prevent potential OOMKilled errors.