### PR TITLE
restrict update event for integration's ClusterPolicy

### DIFF
--- a/components/policies/development/integration/bootstrap-namespace/.chainsaw-test/chainsaw-test.yaml
+++ b/components/policies/development/integration/bootstrap-namespace/.chainsaw-test/chainsaw-test.yaml
@@ -188,3 +188,141 @@ spec:
         expect:
         - check:
             ($error != null): true
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: mutate-existing-namespace-unlabeled-to-labeled
+spec:
+  description: |
+    tests that the ServiceAccount and RoleBinding are created in an
+    existing unlabeled namespace when it is labeled
+  concurrent: false
+  namespace: 'generate-existing-namespace'
+  bindings:
+  - name: suffix
+    value: to-labeled
+  steps:
+  - name: given-konflux-integration-runner-clusterrole-exists
+    try:
+    - apply:
+        file: resources/actual-konflux-integration-runner-clusterrole.yaml
+  - name: given-kyverno-has-permission-on-resources
+    try:
+    - apply:
+        file: ../kyverno-rbac.yaml
+  - name: given-unlabeled-namespace-is-created
+    try:
+    - apply:
+        file: resources/actual-namespace-unlabeled.yaml
+        template: true
+  - name: given-cluster-policy-is-ready
+    try:
+    - apply:
+        file: ../bootstrap-namespace.yaml
+    - assert:
+        file: chainsaw-assert-clusterpolicy.yaml
+  - name: given-serviceaccount-is-not-created
+    try:
+    - delete:
+        file: resources/expected-integration-serviceaccount.yaml
+        template: true
+        expect:
+        - check:
+            ($error != null): true
+  - name: given-rolebinding-is-not-created
+    try:
+    - delete:
+        file: resources/expected-integration-rolebinding.yaml
+        template: true
+        expect:
+        - check:
+            ($error != null): true
+  - name: when-konfluxci-namespace-is-labeled-namespace
+    try:
+    - apply:
+        file: resources/actual-namespace-konfluxcidev.yaml
+        template: true
+  - name: then-serviceaccount-is-created
+    try:
+    - assert:
+        file: resources/expected-integration-serviceaccount.yaml
+        template: true
+  - name: then-rolebinding-is-created
+    try:
+    - assert:
+        file: resources/expected-integration-rolebinding.yaml
+        template: true
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: mutate-existing-namespace-unlabeled-to-unlabeled
+spec:
+  description: |
+    tests that the ServiceAccount and RoleBinding are not created in an
+    existing unlabeled namespace when it is updated but still found unlabeled
+  concurrent: false
+  namespace: 'generate-existing-namespace'
+  bindings:
+  - name: suffix
+    value: to-unlabeled
+  steps:
+  - name: given-konflux-integration-runner-clusterrole-exists
+    try:
+    - apply:
+        file: resources/actual-konflux-integration-runner-clusterrole.yaml
+  - name: given-kyverno-has-permission-on-resources
+    try:
+    - apply:
+        file: ../kyverno-rbac.yaml
+  - name: given-unlabeled-namespace-is-created
+    try:
+    - apply:
+        file: resources/actual-namespace-unlabeled.yaml
+        template: true
+  - name: given-cluster-policy-is-ready
+    try:
+    - apply:
+        file: ../bootstrap-namespace.yaml
+    - assert:
+        file: chainsaw-assert-clusterpolicy.yaml
+  - name: given-serviceaccount-is-not-created
+    try:
+    - delete:
+        file: resources/expected-integration-serviceaccount.yaml
+        template: true
+        expect:
+        - check:
+            ($error != null): true
+  - name: given-rolebinding-is-not-created
+    try:
+    - delete:
+        file: resources/expected-integration-rolebinding.yaml
+        template: true
+        expect:
+        - check:
+            ($error != null): true
+  - name: when-konfluxci-namespace-is-updated-to-unlabeled-namespace
+    try:
+    - apply:
+        file: resources/actual-namespace-unlabeled-extra.yaml
+        template: true
+  - name: then-serviceaccount-is-not-created
+    try:
+    - delete:
+        file: resources/expected-integration-serviceaccount.yaml
+        template: true
+        expect:
+        - check:
+            ($error != null): true
+  - name: then-rolebinding-is-not-created
+    try:
+    - delete:
+        file: resources/expected-integration-rolebinding.yaml
+        template: true
+        expect:
+        - check:
+            ($error != null): true

--- a/components/policies/development/integration/bootstrap-namespace/.chainsaw-test/chainsaw-test.yaml
+++ b/components/policies/development/integration/bootstrap-namespace/.chainsaw-test/chainsaw-test.yaml
@@ -128,6 +128,7 @@ spec:
     - assert:
         file: chainsaw-assert-clusterpolicy.yaml
   - name: then-serviceaccount-is-created
+    timeout: 180s
     try:
     - assert:
         file: resources/expected-integration-serviceaccount.yaml

--- a/components/policies/development/integration/bootstrap-namespace/.chainsaw-test/chainsaw-test.yaml
+++ b/components/policies/development/integration/bootstrap-namespace/.chainsaw-test/chainsaw-test.yaml
@@ -128,9 +128,9 @@ spec:
     - assert:
         file: chainsaw-assert-clusterpolicy.yaml
   - name: then-serviceaccount-is-created
-    timeout: 180s
     try:
     - assert:
+        timeout: 180s
         file: resources/expected-integration-serviceaccount.yaml
         template: true
   - name: then-rolebinding-is-created

--- a/components/policies/development/integration/bootstrap-namespace/.chainsaw-test/resources/actual-namespace-unlabeled-extra.yaml
+++ b/components/policies/development/integration/bootstrap-namespace/.chainsaw-test/resources/actual-namespace-unlabeled-extra.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: (join('-', [$namespace, $suffix]))
+  labels:
+    mylabel: extra

--- a/components/policies/development/integration/bootstrap-namespace/bootstrap-namespace.yaml
+++ b/components/policies/development/integration/bootstrap-namespace/bootstrap-namespace.yaml
@@ -19,6 +19,12 @@ spec:
           selector:
             matchLabels:
               konflux-ci.dev/type: tenant
+          operations:
+          - CREATE
+          - UPDATE
+    celPreconditions:
+    - name: "oldObject had no konflux-ci.dev/type=tenant label"
+      expression: "request.operation == CREATE || ! (has(oldObject.metadata.labels) && 'konflux-ci.dev/type' in oldObject.metadata.labels && oldObject.metadata.labels['konflux-ci.dev/type] == 'tenant')"
     generate:
       generateExisting: true
       synchronize: false
@@ -36,6 +42,12 @@ spec:
           selector:
             matchLabels:
               konflux-ci.dev/type: tenant
+          operations:
+          - CREATE
+          - UPDATE
+    celPreconditions:
+    - name: "oldObject had no konflux-ci.dev/type=tenant label"
+      expression: "request.operation == CREATE || ! (has(oldObject.metadata.labels) && 'konflux-ci.dev/type' in oldObject.metadata.labels && oldObject.metadata.labels['konflux-ci.dev/type] == 'tenant')"
     generate:
       generateExisting: true
       synchronize: false

--- a/components/policies/development/integration/bootstrap-namespace/bootstrap-namespace.yaml
+++ b/components/policies/development/integration/bootstrap-namespace/bootstrap-namespace.yaml
@@ -19,12 +19,9 @@ spec:
           selector:
             matchLabels:
               konflux-ci.dev/type: tenant
-          operations:
-          - CREATE
-          - UPDATE
     celPreconditions:
-    - name: "oldObject had no konflux-ci.dev/type=tenant label"
-      expression: "request.operation == CREATE || ! (has(oldObject.metadata.labels) && 'konflux-ci.dev/type' in oldObject.metadata.labels && oldObject.metadata.labels['konflux-ci.dev/type] == 'tenant')"
+    - name: "on update, oldObject had no konflux-ci.dev/type=tenant label"
+      expression: "request.operation != UPDATE || ! (has(oldObject.metadata.labels) && 'konflux-ci.dev/type' in oldObject.metadata.labels && oldObject.metadata.labels['konflux-ci.dev/type] == 'tenant')"
     generate:
       generateExisting: true
       synchronize: false
@@ -42,12 +39,9 @@ spec:
           selector:
             matchLabels:
               konflux-ci.dev/type: tenant
-          operations:
-          - CREATE
-          - UPDATE
     celPreconditions:
-    - name: "oldObject had no konflux-ci.dev/type=tenant label"
-      expression: "request.operation == CREATE || ! (has(oldObject.metadata.labels) && 'konflux-ci.dev/type' in oldObject.metadata.labels && oldObject.metadata.labels['konflux-ci.dev/type] == 'tenant')"
+    - name: "on update, oldObject had no konflux-ci.dev/type=tenant label"
+      expression: "request.operation != UPDATE || ! (has(oldObject.metadata.labels) && 'konflux-ci.dev/type' in oldObject.metadata.labels && oldObject.metadata.labels['konflux-ci.dev/type] == 'tenant')"
     generate:
       generateExisting: true
       synchronize: false


### PR DESCRIPTION
We need to create the resources only when the namespace is promoted to tenant namespace. We can skip the other updates to the namespaces.

Signed-off-by: Francesco Ilario <filario@redhat.com>
