### PR TITLE
Deploy RPM enabled kanary exporter in stage

### DIFF
--- a/components/monitoring/kanary/staging/stone-stage-p01/kustomization.yaml
+++ b/components/monitoring/kanary/staging/stone-stage-p01/kustomization.yaml
@@ -2,12 +2,12 @@ resources:
   - ../base
   - rbac
   - external-secrets
-  - https://github.com/redhat-appstudio/o11y/config/exporters/monitoring/kanary/base?ref=4dfdc1adbb50d1adf1b697cc2b1c421c7f597edd
+  - https://github.com/redhat-appstudio/o11y/config/exporters/monitoring/kanary/base?ref=2298ef09366b02015c31f90050576bce26356552
 
 images:
   - name: quay.io/redhat-appstudio/o11y
     newName: quay.io/redhat-appstudio/o11y
-    newTag: 4dfdc1adbb50d1adf1b697cc2b1c421c7f597edd
+    newTag: 2298ef09366b02015c31f90050576bce26356552
 
 patches:
   - path: kanary-db-credentials-secret-path.yaml


### PR DESCRIPTION
This is to test out the new kanary exporter with the RPM e2e tests enabled.

This would also unblock any work that needs to be done on the [Kanary Dashboard ](https://grafana.app-sre.devshift.net/d/eeoimpx3yutq9f/kanary-signal-dashboard?orgId=1&from=now-24h&to=now&timezone=browser&var-kanary_datasource=P22466E8E7855F1E0&var-kanary_clusters=stone-prd-rh01&var-kanary_clusters=stone-prod-p01&var-kanary_clusters=stone-prod-p02&var-kanary_clusters=stone-stage-p01&var-kanary_clusters=stone-stg-rh01)to extend it for RPM too.


Issue: [PVO11Y-4837](https://issues.redhat.com/browse/PVO11Y-4837)