### PR TITLE
Export cluster RAM metrics for MintMaker

### DIFF
--- a/components/monitoring/prometheus/base/monitoringstack/monitoringstack.yaml
+++ b/components/monitoring/prometheus/base/monitoringstack/monitoringstack.yaml
@@ -167,6 +167,8 @@ spec:
         - '{__name__="kube_deployment_status_replicas_ready", namespace="mintmaker"}'
         - '{__name__="kube_deployment_status_replicas_available", namespace="mintmaker"}'
         - '{__name__="kube_deployment_spec_replicas", namespace="mintmaker"}'
+        - '{__name__="cluster_ram_requested_perc"}'
+        - '{__name__="node_memory_pressured_perc"}'
 
         # Namespace (expression):  ~".*monitoring.*"
         - '{__name__="kube_deployment_status_replicas_ready", namespace=~".*monitoring.*"}'


### PR DESCRIPTION
This commit exports two metrics that will be important for monitoring MintMaker service quality.
    
The metrics are already contributed to 'o11y', now we need to export them in order to have them available in the monitoring stack. (https://github.com/redhat-appstudio/o11y/blob/main/rhobs/recording/mintmaker_service_quality_recording_rules.yaml)