### PR TITLE
KFLUXINFRA-1970: Change Max Instances for MPC Platforms

### DIFF
--- a/components/multi-platform-controller/production-downstream/kflux-ocp-p01/host-config.yaml
+++ b/components/multi-platform-controller/production-downstream/kflux-ocp-p01/host-config.yaml
@@ -70,7 +70,7 @@ data:
   dynamic.linux-arm64.aws-secret: aws-account
   dynamic.linux-arm64.ssh-secret: aws-ssh-key
   dynamic.linux-arm64.security-group-id: sg-0a1f3fdbbf7198922
-  dynamic.linux-arm64.max-instances: "100"
+  dynamic.linux-arm64.max-instances: "70"
   dynamic.linux-arm64.subnet-id: subnet-0864e71d16676bf7f
   dynamic.linux-arm64.allocation-timeout: "1200"
 
@@ -84,7 +84,7 @@ data:
   dynamic.linux-d160-arm64.aws-secret: aws-account
   dynamic.linux-d160-arm64.ssh-secret: aws-ssh-key
   dynamic.linux-d160-arm64.security-group-id: sg-0a1f3fdbbf7198922
-  dynamic.linux-d160-arm64.max-instances: "100"
+  dynamic.linux-d160-arm64.max-instances: "5"
   dynamic.linux-d160-arm64.subnet-id: subnet-0864e71d16676bf7f
   dynamic.linux-d160-arm64.allocation-timeout: "1200"
   dynamic.linux-d160-arm64.disk: "160"
@@ -98,7 +98,7 @@ data:
   dynamic.linux-mlarge-arm64.aws-secret: aws-account
   dynamic.linux-mlarge-arm64.ssh-secret: aws-ssh-key
   dynamic.linux-mlarge-arm64.security-group-id: sg-0a1f3fdbbf7198922
-  dynamic.linux-mlarge-arm64.max-instances: "100"
+  dynamic.linux-mlarge-arm64.max-instances: "5"
   dynamic.linux-mlarge-arm64.subnet-id: subnet-0864e71d16676bf7f
   dynamic.linux-mlarge-arm64.allocation-timeout: "1200"
 
@@ -111,7 +111,7 @@ data:
   dynamic.linux-mxlarge-arm64.aws-secret: aws-account
   dynamic.linux-mxlarge-arm64.ssh-secret: aws-ssh-key
   dynamic.linux-mxlarge-arm64.security-group-id: sg-0a1f3fdbbf7198922
-  dynamic.linux-mxlarge-arm64.max-instances: "100"
+  dynamic.linux-mxlarge-arm64.max-instances: "5"
   dynamic.linux-mxlarge-arm64.subnet-id: subnet-0864e71d16676bf7f
   dynamic.linux-mxlarge-arm64.allocation-timeout: "1200"
 
@@ -124,7 +124,7 @@ data:
   dynamic.linux-m2xlarge-arm64.aws-secret: aws-account
   dynamic.linux-m2xlarge-arm64.ssh-secret: aws-ssh-key
   dynamic.linux-m2xlarge-arm64.security-group-id: sg-0a1f3fdbbf7198922
-  dynamic.linux-m2xlarge-arm64.max-instances: "100"
+  dynamic.linux-m2xlarge-arm64.max-instances: "5"
   dynamic.linux-m2xlarge-arm64.subnet-id: subnet-0864e71d16676bf7f
   dynamic.linux-m2xlarge-arm64.allocation-timeout: "1200"
 
@@ -138,7 +138,7 @@ data:
   dynamic.linux-d160-m2xlarge-arm64.aws-secret: aws-account
   dynamic.linux-d160-m2xlarge-arm64.ssh-secret: aws-ssh-key
   dynamic.linux-d160-m2xlarge-arm64.security-group-id: sg-0a1f3fdbbf7198922
-  dynamic.linux-d160-m2xlarge-arm64.max-instances: "100"
+  dynamic.linux-d160-m2xlarge-arm64.max-instances: "5"
   dynamic.linux-d160-m2xlarge-arm64.subnet-id: subnet-0864e71d16676bf7f
   dynamic.linux-d160-m2xlarge-arm64.allocation-timeout: "1200"
   dynamic.linux-d160-m2xlarge-arm64.disk: "160"
@@ -152,7 +152,7 @@ data:
   dynamic.linux-m4xlarge-arm64.aws-secret: aws-account
   dynamic.linux-m4xlarge-arm64.ssh-secret: aws-ssh-key
   dynamic.linux-m4xlarge-arm64.security-group-id: sg-0a1f3fdbbf7198922
-  dynamic.linux-m4xlarge-arm64.max-instances: "100"
+  dynamic.linux-m4xlarge-arm64.max-instances: "5"
   dynamic.linux-m4xlarge-arm64.subnet-id: subnet-0864e71d16676bf7f
   dynamic.linux-m4xlarge-arm64.allocation-timeout: "1200"
 
@@ -165,7 +165,7 @@ data:
   dynamic.linux-d160-m4xlarge-arm64.aws-secret: aws-account
   dynamic.linux-d160-m4xlarge-arm64.ssh-secret: aws-ssh-key
   dynamic.linux-d160-m4xlarge-arm64.security-group-id: sg-0a1f3fdbbf7198922
-  dynamic.linux-d160-m4xlarge-arm64.max-instances: "100"
+  dynamic.linux-d160-m4xlarge-arm64.max-instances: "5"
   dynamic.linux-d160-m4xlarge-arm64.subnet-id: subnet-0864e71d16676bf7f
   dynamic.linux-d160-m4xlarge-arm64.allocation-timeout: "1200"
   dynamic.linux-d160-m4xlarge-arm64.disk: "160"
@@ -179,7 +179,7 @@ data:
   dynamic.linux-m8xlarge-arm64.aws-secret: aws-account
   dynamic.linux-m8xlarge-arm64.ssh-secret: aws-ssh-key
   dynamic.linux-m8xlarge-arm64.security-group-id: sg-0a1f3fdbbf7198922
-  dynamic.linux-m8xlarge-arm64.max-instances: "100"
+  dynamic.linux-m8xlarge-arm64.max-instances: "5"
   dynamic.linux-m8xlarge-arm64.subnet-id: subnet-0864e71d16676bf7f
   dynamic.linux-m8xlarge-arm64.allocation-timeout: "1200"
 
@@ -192,7 +192,7 @@ data:
   dynamic.linux-d160-m8xlarge-arm64.aws-secret: aws-account
   dynamic.linux-d160-m8xlarge-arm64.ssh-secret: aws-ssh-key
   dynamic.linux-d160-m8xlarge-arm64.security-group-id: sg-0a1f3fdbbf7198922
-  dynamic.linux-d160-m8xlarge-arm64.max-instances: "100"
+  dynamic.linux-d160-m8xlarge-arm64.max-instances: "5"
   dynamic.linux-d160-m8xlarge-arm64.subnet-id: subnet-0864e71d16676bf7f
   dynamic.linux-d160-m8xlarge-arm64.allocation-timeout: "1200"
   dynamic.linux-d160-m8xlarge-arm64.disk: "160"
@@ -206,7 +206,7 @@ data:
   dynamic.linux-c6gd2xlarge-arm64.aws-secret: aws-account
   dynamic.linux-c6gd2xlarge-arm64.ssh-secret: aws-ssh-key
   dynamic.linux-c6gd2xlarge-arm64.security-group-id: sg-0a1f3fdbbf7198922
-  dynamic.linux-c6gd2xlarge-arm64.max-instances: "100"
+  dynamic.linux-c6gd2xlarge-arm64.max-instances: "5"
   dynamic.linux-c6gd2xlarge-arm64.subnet-id: subnet-0864e71d16676bf7f
   dynamic.linux-c6gd2xlarge-arm64.allocation-timeout: "1200"
   dynamic.linux-c6gd2xlarge-arm64.user-data: |-
@@ -283,7 +283,7 @@ data:
   dynamic.linux-amd64.aws-secret: aws-account
   dynamic.linux-amd64.ssh-secret: aws-ssh-key
   dynamic.linux-amd64.security-group-id: sg-0a1f3fdbbf7198922
-  dynamic.linux-amd64.max-instances: "100"
+  dynamic.linux-amd64.max-instances: "30"
   dynamic.linux-amd64.subnet-id: subnet-0864e71d16676bf7f
   dynamic.linux-amd64.allocation-timeout: "1200"
 
@@ -296,7 +296,7 @@ data:
   dynamic.linux-mlarge-amd64.aws-secret: aws-account
   dynamic.linux-mlarge-amd64.ssh-secret: aws-ssh-key
   dynamic.linux-mlarge-amd64.security-group-id: sg-0a1f3fdbbf7198922
-  dynamic.linux-mlarge-amd64.max-instances: "100"
+  dynamic.linux-mlarge-amd64.max-instances: "5"
   dynamic.linux-mlarge-amd64.subnet-id: subnet-0864e71d16676bf7f
   dynamic.linux-mlarge-amd64.allocation-timeout: "1200"
 
@@ -309,7 +309,7 @@ data:
   dynamic.linux-mxlarge-amd64.aws-secret: aws-account
   dynamic.linux-mxlarge-amd64.ssh-secret: aws-ssh-key
   dynamic.linux-mxlarge-amd64.security-group-id: sg-0a1f3fdbbf7198922
-  dynamic.linux-mxlarge-amd64.max-instances: "100"
+  dynamic.linux-mxlarge-amd64.max-instances: "5"
   dynamic.linux-mxlarge-amd64.subnet-id: subnet-0864e71d16676bf7f
   dynamic.linux-mxlarge-amd64.allocation-timeout: "1200"
 
@@ -322,7 +322,7 @@ data:
   dynamic.linux-m2xlarge-amd64.aws-secret: aws-account
   dynamic.linux-m2xlarge-amd64.ssh-secret: aws-ssh-key
   dynamic.linux-m2xlarge-amd64.security-group-id: sg-0a1f3fdbbf7198922
-  dynamic.linux-m2xlarge-amd64.max-instances: "100"
+  dynamic.linux-m2xlarge-amd64.max-instances: "5"
   dynamic.linux-m2xlarge-amd64.subnet-id: subnet-0864e71d16676bf7f
   dynamic.linux-m2xlarge-amd64.allocation-timeout: "1200"
 
@@ -336,7 +336,7 @@ data:
   dynamic.linux-d160-m2xlarge-amd64.aws-secret: aws-account
   dynamic.linux-d160-m2xlarge-amd64.ssh-secret: aws-ssh-key
   dynamic.linux-d160-m2xlarge-amd64.security-group-id: sg-0a1f3fdbbf7198922
-  dynamic.linux-d160-m2xlarge-amd64.max-instances: "100"
+  dynamic.linux-d160-m2xlarge-amd64.max-instances: "5"
   dynamic.linux-d160-m2xlarge-amd64.subnet-id: subnet-0864e71d16676bf7f
   dynamic.linux-d160-m2xlarge-amd64.allocation-timeout: "1200"
   dynamic.linux-d160-m2xlarge-amd64.disk: "160"
@@ -350,7 +350,7 @@ data:
   dynamic.linux-m4xlarge-amd64.aws-secret: aws-account
   dynamic.linux-m4xlarge-amd64.ssh-secret: aws-ssh-key
   dynamic.linux-m4xlarge-amd64.security-group-id: sg-0a1f3fdbbf7198922
-  dynamic.linux-m4xlarge-amd64.max-instances: "100"
+  dynamic.linux-m4xlarge-amd64.max-instances: "5"
   dynamic.linux-m4xlarge-amd64.subnet-id: subnet-0864e71d16676bf7f
   dynamic.linux-m4xlarge-amd64.allocation-timeout: "1200"
 
@@ -363,7 +363,7 @@ data:
   dynamic.linux-d160-m4xlarge-amd64.aws-secret: aws-account
   dynamic.linux-d160-m4xlarge-amd64.ssh-secret: aws-ssh-key
   dynamic.linux-d160-m4xlarge-amd64.security-group-id: sg-0a1f3fdbbf7198922
-  dynamic.linux-d160-m4xlarge-amd64.max-instances: "100"
+  dynamic.linux-d160-m4xlarge-amd64.max-instances: "5"
   dynamic.linux-d160-m4xlarge-amd64.subnet-id: subnet-0864e71d16676bf7f
   dynamic.linux-d160-m4xlarge-amd64.allocation-timeout: "1200"
   dynamic.linux-d160-m4xlarge-amd64.disk: "160"
@@ -377,7 +377,7 @@ data:
   dynamic.linux-m8xlarge-amd64.aws-secret: aws-account
   dynamic.linux-m8xlarge-amd64.ssh-secret: aws-ssh-key
   dynamic.linux-m8xlarge-amd64.security-group-id: sg-0a1f3fdbbf7198922
-  dynamic.linux-m8xlarge-amd64.max-instances: "100"
+  dynamic.linux-m8xlarge-amd64.max-instances: "5"
   dynamic.linux-m8xlarge-amd64.subnet-id: subnet-0864e71d16676bf7f
   dynamic.linux-m8xlarge-amd64.allocation-timeout: "1200"
 
@@ -390,7 +390,7 @@ data:
   dynamic.linux-d160-m8xlarge-amd64.aws-secret: aws-account
   dynamic.linux-d160-m8xlarge-amd64.ssh-secret: aws-ssh-key
   dynamic.linux-d160-m8xlarge-amd64.security-group-id: sg-0a1f3fdbbf7198922
-  dynamic.linux-d160-m8xlarge-amd64.max-instances: "100"
+  dynamic.linux-d160-m8xlarge-amd64.max-instances: "5"
   dynamic.linux-d160-m8xlarge-amd64.subnet-id: subnet-0864e71d16676bf7f
   dynamic.linux-d160-m8xlarge-amd64.allocation-timeout: "1200"
   dynamic.linux-d160-m8xlarge-amd64.disk: "160"
@@ -405,7 +405,7 @@ data:
   dynamic.linux-cxlarge-arm64.aws-secret: aws-account
   dynamic.linux-cxlarge-arm64.ssh-secret: aws-ssh-key
   dynamic.linux-cxlarge-arm64.security-group-id: sg-0a1f3fdbbf7198922
-  dynamic.linux-cxlarge-arm64.max-instances: "100"
+  dynamic.linux-cxlarge-arm64.max-instances: "5"
   dynamic.linux-cxlarge-arm64.subnet-id: subnet-0864e71d16676bf7f
   dynamic.linux-cxlarge-arm64.allocation-timeout: "1200"
 
@@ -419,7 +419,7 @@ data:
   dynamic.linux-d160-cxlarge-arm64.aws-secret: aws-account
   dynamic.linux-d160-cxlarge-arm64.ssh-secret: aws-ssh-key
   dynamic.linux-d160-cxlarge-arm64.security-group-id: sg-0a1f3fdbbf7198922
-  dynamic.linux-d160-cxlarge-arm64.max-instances: "100"
+  dynamic.linux-d160-cxlarge-arm64.max-instances: "5"
   dynamic.linux-d160-cxlarge-arm64.subnet-id: subnet-0864e71d16676bf7f
   dynamic.linux-d160-cxlarge-arm64.allocation-timeout: "1200"
   dynamic.linux-d160-cxlarge-arm64.disk: "160"
@@ -433,7 +433,7 @@ data:
   dynamic.linux-c2xlarge-arm64.aws-secret: aws-account
   dynamic.linux-c2xlarge-arm64.ssh-secret: aws-ssh-key
   dynamic.linux-c2xlarge-arm64.security-group-id: sg-0a1f3fdbbf7198922
-  dynamic.linux-c2xlarge-arm64.max-instances: "100"
+  dynamic.linux-c2xlarge-arm64.max-instances: "5"
   dynamic.linux-c2xlarge-arm64.subnet-id: subnet-0864e71d16676bf7f
   dynamic.linux-c2xlarge-arm64.allocation-timeout: "1200"
 
@@ -446,7 +446,7 @@ data:
   dynamic.linux-c4xlarge-arm64.aws-secret: aws-account
   dynamic.linux-c4xlarge-arm64.ssh-secret: aws-ssh-key
   dynamic.linux-c4xlarge-arm64.security-group-id: sg-0a1f3fdbbf7198922
-  dynamic.linux-c4xlarge-arm64.max-instances: "100"
+  dynamic.linux-c4xlarge-arm64.max-instances: "5"
   dynamic.linux-c4xlarge-arm64.subnet-id: subnet-0864e71d16676bf7f
   dynamic.linux-c4xlarge-arm64.allocation-timeout: "1200"
 
@@ -460,7 +460,7 @@ data:
   dynamic.linux-d160-c4xlarge-arm64.aws-secret: aws-account
   dynamic.linux-d160-c4xlarge-arm64.ssh-secret: aws-ssh-key
   dynamic.linux-d160-c4xlarge-arm64.security-group-id: sg-0a1f3fdbbf7198922
-  dynamic.linux-d160-c4xlarge-arm64.max-instances: "100"
+  dynamic.linux-d160-c4xlarge-arm64.max-instances: "5"
   dynamic.linux-d160-c4xlarge-arm64.subnet-id: subnet-0864e71d16676bf7f
   dynamic.linux-d160-c4xlarge-arm64.allocation-timeout: "1200"
   dynamic.linux-d160-c4xlarge-arm64.disk: "160"
@@ -475,7 +475,7 @@ data:
   dynamic.linux-d320-c4xlarge-arm64.aws-secret: aws-account
   dynamic.linux-d320-c4xlarge-arm64.ssh-secret: aws-ssh-key
   dynamic.linux-d320-c4xlarge-arm64.security-group-id: sg-0a1f3fdbbf7198922
-  dynamic.linux-d320-c4xlarge-arm64.max-instances: "100"
+  dynamic.linux-d320-c4xlarge-arm64.max-instances: "5"
   dynamic.linux-d320-c4xlarge-arm64.subnet-id: subnet-0864e71d16676bf7f
   dynamic.linux-d320-c4xlarge-arm64.allocation-timeout: "1200"
   dynamic.linux-d320-c4xlarge-arm64.disk: "320"
@@ -489,7 +489,7 @@ data:
   dynamic.linux-c8xlarge-arm64.aws-secret: aws-account
   dynamic.linux-c8xlarge-arm64.ssh-secret: aws-ssh-key
   dynamic.linux-c8xlarge-arm64.security-group-id: sg-0a1f3fdbbf7198922
-  dynamic.linux-c8xlarge-arm64.max-instances: "100"
+  dynamic.linux-c8xlarge-arm64.max-instances: "5"
   dynamic.linux-c8xlarge-arm64.subnet-id: subnet-0864e71d16676bf7f
   dynamic.linux-c8xlarge-arm64.allocation-timeout: "1200"
 
@@ -502,7 +502,7 @@ data:
   dynamic.linux-cxlarge-amd64.aws-secret: aws-account
   dynamic.linux-cxlarge-amd64.ssh-secret: aws-ssh-key
   dynamic.linux-cxlarge-amd64.security-group-id: sg-0a1f3fdbbf7198922
-  dynamic.linux-cxlarge-amd64.max-instances: "100"
+  dynamic.linux-cxlarge-amd64.max-instances: "5"
   dynamic.linux-cxlarge-amd64.subnet-id: subnet-0864e71d16676bf7f
   dynamic.linux-cxlarge-amd64.allocation-timeout: "1200"
 
@@ -515,7 +515,7 @@ data:
   dynamic.linux-c2xlarge-amd64.aws-secret: aws-account
   dynamic.linux-c2xlarge-amd64.ssh-secret: aws-ssh-key
   dynamic.linux-c2xlarge-amd64.security-group-id: sg-0a1f3fdbbf7198922
-  dynamic.linux-c2xlarge-amd64.max-instances: "100"
+  dynamic.linux-c2xlarge-amd64.max-instances: "5"
   dynamic.linux-c2xlarge-amd64.subnet-id: subnet-0864e71d16676bf7f
   dynamic.linux-c2xlarge-amd64.allocation-timeout: "1200"
 
@@ -528,7 +528,7 @@ data:
   dynamic.linux-c4xlarge-amd64.aws-secret: aws-account
   dynamic.linux-c4xlarge-amd64.ssh-secret: aws-ssh-key
   dynamic.linux-c4xlarge-amd64.security-group-id: sg-0a1f3fdbbf7198922
-  dynamic.linux-c4xlarge-amd64.max-instances: "100"
+  dynamic.linux-c4xlarge-amd64.max-instances: "5"
   dynamic.linux-c4xlarge-amd64.subnet-id: subnet-0864e71d16676bf7f
   dynamic.linux-c4xlarge-amd64.allocation-timeout: "1200"
 
@@ -542,7 +542,7 @@ data:
   dynamic.linux-d160-c4xlarge-amd64.aws-secret: aws-account
   dynamic.linux-d160-c4xlarge-amd64.ssh-secret: aws-ssh-key
   dynamic.linux-d160-c4xlarge-amd64.security-group-id: sg-0a1f3fdbbf7198922
-  dynamic.linux-d160-c4xlarge-amd64.max-instances: "100"
+  dynamic.linux-d160-c4xlarge-amd64.max-instances: "5"
   dynamic.linux-d160-c4xlarge-amd64.subnet-id: subnet-0864e71d16676bf7f
   dynamic.linux-d160-c4xlarge-amd64.allocation-timeout: "1200"
   dynamic.linux-d160-c4xlarge-amd64.disk: "160"
@@ -557,7 +557,7 @@ data:
   dynamic.linux-d320-c4xlarge-amd64.aws-secret: aws-account
   dynamic.linux-d320-c4xlarge-amd64.ssh-secret: aws-ssh-key
   dynamic.linux-d320-c4xlarge-amd64.security-group-id: sg-0a1f3fdbbf7198922
-  dynamic.linux-d320-c4xlarge-amd64.max-instances: "100"
+  dynamic.linux-d320-c4xlarge-amd64.max-instances: "5"
   dynamic.linux-d320-c4xlarge-amd64.subnet-id: subnet-0864e71d16676bf7f
   dynamic.linux-d320-c4xlarge-amd64.allocation-timeout: "1200"
   dynamic.linux-d320-c4xlarge-amd64.disk: "320"
@@ -571,7 +571,7 @@ data:
   dynamic.linux-c8xlarge-amd64.aws-secret: aws-account
   dynamic.linux-c8xlarge-amd64.ssh-secret: aws-ssh-key
   dynamic.linux-c8xlarge-amd64.security-group-id: sg-0a1f3fdbbf7198922
-  dynamic.linux-c8xlarge-amd64.max-instances: "100"
+  dynamic.linux-c8xlarge-amd64.max-instances: "5"
   dynamic.linux-c8xlarge-amd64.subnet-id: subnet-0864e71d16676bf7f
   dynamic.linux-c8xlarge-amd64.allocation-timeout: "1200"
 
@@ -585,7 +585,7 @@ data:
   dynamic.linux-root-arm64.ssh-secret: aws-ssh-key
   dynamic.linux-root-arm64.security-group-id: sg-0a1f3fdbbf7198922
   dynamic.linux-root-arm64.subnet-id: subnet-0864e71d16676bf7f
-  dynamic.linux-root-arm64.max-instances: "100"
+  dynamic.linux-root-arm64.max-instances: "5"
   dynamic.linux-root-arm64.sudo-commands: "/usr/bin/podman, /usr/bin/rm /usr/share/containers/mounts.conf"
   dynamic.linux-root-arm64.disk: "200"
   dynamic.linux-root-arm64.iops: "16000"
@@ -601,7 +601,7 @@ data:
   dynamic.linux-root-amd64.ssh-secret: aws-ssh-key
   dynamic.linux-root-amd64.security-group-id: sg-0a1f3fdbbf7198922
   dynamic.linux-root-amd64.subnet-id: subnet-0864e71d16676bf7f
-  dynamic.linux-root-amd64.max-instances: "100"
+  dynamic.linux-root-amd64.max-instances: "5"
   dynamic.linux-root-amd64.sudo-commands: "/usr/bin/podman, /usr/bin/rm /usr/share/containers/mounts.conf"
   dynamic.linux-root-amd64.user-data: |-
     Content-Type: multipart/mixed; boundary="//"
@@ -812,7 +812,7 @@ data:
   dynamic.linux-g6xlarge-amd64.ssh-secret: aws-ssh-key
   dynamic.linux-g6xlarge-amd64.security-group-id: sg-0a1f3fdbbf7198922
   dynamic.linux-g6xlarge-amd64.subnet-id: subnet-0864e71d16676bf7f
-  dynamic.linux-g6xlarge-amd64.max-instances: "100"
+  dynamic.linux-g6xlarge-amd64.max-instances: "5"
   dynamic.linux-g6xlarge-amd64.allocation-timeout: "1200"
   dynamic.linux-g6xlarge-amd64.instance-tag: prod-amd64-g6xlarge
   dynamic.linux-g6xlarge-amd64.user-data: |-

--- a/components/multi-platform-controller/production-downstream/kflux-osp-p01/host-config.yaml
+++ b/components/multi-platform-controller/production-downstream/kflux-osp-p01/host-config.yaml
@@ -60,7 +60,7 @@ data:
   dynamic.linux-arm64.aws-secret: aws-account
   dynamic.linux-arm64.ssh-secret: aws-ssh-key
   dynamic.linux-arm64.security-group-id: sg-0e1a9339d698a73e1
-  dynamic.linux-arm64.max-instances: "50"
+  dynamic.linux-arm64.max-instances: "70"
   dynamic.linux-arm64.subnet-id: subnet-0dffd53ed51b01e79
 
   dynamic.linux-mlarge-arm64.type: aws
@@ -72,7 +72,7 @@ data:
   dynamic.linux-mlarge-arm64.aws-secret: aws-account
   dynamic.linux-mlarge-arm64.ssh-secret: aws-ssh-key
   dynamic.linux-mlarge-arm64.security-group-id: sg-0e1a9339d698a73e1
-  dynamic.linux-mlarge-arm64.max-instances: "50"
+  dynamic.linux-mlarge-arm64.max-instances: "5"
   dynamic.linux-mlarge-arm64.subnet-id: subnet-0dffd53ed51b01e79
 
   dynamic.linux-mxlarge-arm64.type: aws
@@ -84,7 +84,7 @@ data:
   dynamic.linux-mxlarge-arm64.aws-secret: aws-account
   dynamic.linux-mxlarge-arm64.ssh-secret: aws-ssh-key
   dynamic.linux-mxlarge-arm64.security-group-id: sg-0e1a9339d698a73e1
-  dynamic.linux-mxlarge-arm64.max-instances: "20"
+  dynamic.linux-mxlarge-arm64.max-instances: "5"
   dynamic.linux-mxlarge-arm64.subnet-id: subnet-0dffd53ed51b01e79
 
   dynamic.linux-m2xlarge-arm64.type: aws
@@ -96,7 +96,7 @@ data:
   dynamic.linux-m2xlarge-arm64.aws-secret: aws-account
   dynamic.linux-m2xlarge-arm64.ssh-secret: aws-ssh-key
   dynamic.linux-m2xlarge-arm64.security-group-id: sg-0e1a9339d698a73e1
-  dynamic.linux-m2xlarge-arm64.max-instances: "20"
+  dynamic.linux-m2xlarge-arm64.max-instances: "5"
   dynamic.linux-m2xlarge-arm64.subnet-id: subnet-0dffd53ed51b01e79
 
   dynamic.linux-m4xlarge-arm64.type: aws
@@ -108,7 +108,7 @@ data:
   dynamic.linux-m4xlarge-arm64.aws-secret: aws-account
   dynamic.linux-m4xlarge-arm64.ssh-secret: aws-ssh-key
   dynamic.linux-m4xlarge-arm64.security-group-id: sg-0e1a9339d698a73e1
-  dynamic.linux-m4xlarge-arm64.max-instances: "20"
+  dynamic.linux-m4xlarge-arm64.max-instances: "5"
   dynamic.linux-m4xlarge-arm64.subnet-id: subnet-0dffd53ed51b01e79
 
   dynamic.linux-m8xlarge-arm64.type: aws
@@ -120,7 +120,7 @@ data:
   dynamic.linux-m8xlarge-arm64.aws-secret: aws-account
   dynamic.linux-m8xlarge-arm64.ssh-secret: aws-ssh-key
   dynamic.linux-m8xlarge-arm64.security-group-id: sg-0e1a9339d698a73e1
-  dynamic.linux-m8xlarge-arm64.max-instances: "20"
+  dynamic.linux-m8xlarge-arm64.max-instances: "5"
   dynamic.linux-m8xlarge-arm64.subnet-id: subnet-0dffd53ed51b01e79
 
   dynamic.linux-c6gd2xlarge-arm64.type: aws
@@ -132,7 +132,7 @@ data:
   dynamic.linux-c6gd2xlarge-arm64.aws-secret: aws-account
   dynamic.linux-c6gd2xlarge-arm64.ssh-secret: aws-ssh-key
   dynamic.linux-c6gd2xlarge-arm64.security-group-id: sg-0e1a9339d698a73e1
-  dynamic.linux-c6gd2xlarge-arm64.max-instances: "20"
+  dynamic.linux-c6gd2xlarge-arm64.max-instances: "5"
   dynamic.linux-c6gd2xlarge-arm64.subnet-id: subnet-0dffd53ed51b01e79
   dynamic.linux-c6gd2xlarge-arm64.user-data: |-
     Content-Type: multipart/mixed; boundary="//"
@@ -208,7 +208,7 @@ data:
   dynamic.linux-amd64.aws-secret: aws-account
   dynamic.linux-amd64.ssh-secret: aws-ssh-key
   dynamic.linux-amd64.security-group-id: sg-0e1a9339d698a73e1
-  dynamic.linux-amd64.max-instances: "10"
+  dynamic.linux-amd64.max-instances: "30"
   dynamic.linux-amd64.subnet-id: subnet-0dffd53ed51b01e79
 
   dynamic.linux-mlarge-amd64.type: aws
@@ -220,7 +220,7 @@ data:
   dynamic.linux-mlarge-amd64.aws-secret: aws-account
   dynamic.linux-mlarge-amd64.ssh-secret: aws-ssh-key
   dynamic.linux-mlarge-amd64.security-group-id: sg-0e1a9339d698a73e1
-  dynamic.linux-mlarge-amd64.max-instances: "10"
+  dynamic.linux-mlarge-amd64.max-instances: "5"
   dynamic.linux-mlarge-amd64.subnet-id: subnet-0dffd53ed51b01e79
 
   dynamic.linux-mxlarge-amd64.type: aws
@@ -232,7 +232,7 @@ data:
   dynamic.linux-mxlarge-amd64.aws-secret: aws-account
   dynamic.linux-mxlarge-amd64.ssh-secret: aws-ssh-key
   dynamic.linux-mxlarge-amd64.security-group-id: sg-0e1a9339d698a73e1
-  dynamic.linux-mxlarge-amd64.max-instances: "10"
+  dynamic.linux-mxlarge-amd64.max-instances: "5"
   dynamic.linux-mxlarge-amd64.subnet-id: subnet-0dffd53ed51b01e79
 
   dynamic.linux-m2xlarge-amd64.type: aws
@@ -244,7 +244,7 @@ data:
   dynamic.linux-m2xlarge-amd64.aws-secret: aws-account
   dynamic.linux-m2xlarge-amd64.ssh-secret: aws-ssh-key
   dynamic.linux-m2xlarge-amd64.security-group-id: sg-0e1a9339d698a73e1
-  dynamic.linux-m2xlarge-amd64.max-instances: "10"
+  dynamic.linux-m2xlarge-amd64.max-instances: "5"
   dynamic.linux-m2xlarge-amd64.subnet-id: subnet-0dffd53ed51b01e79
 
   dynamic.linux-m4xlarge-amd64.type: aws
@@ -256,7 +256,7 @@ data:
   dynamic.linux-m4xlarge-amd64.aws-secret: aws-account
   dynamic.linux-m4xlarge-amd64.ssh-secret: aws-ssh-key
   dynamic.linux-m4xlarge-amd64.security-group-id: sg-0e1a9339d698a73e1
-  dynamic.linux-m4xlarge-amd64.max-instances: "10"
+  dynamic.linux-m4xlarge-amd64.max-instances: "5"
   dynamic.linux-m4xlarge-amd64.subnet-id: subnet-0dffd53ed51b01e79
 
   dynamic.linux-m8xlarge-amd64.type: aws
@@ -268,7 +268,7 @@ data:
   dynamic.linux-m8xlarge-amd64.aws-secret: aws-account
   dynamic.linux-m8xlarge-amd64.ssh-secret: aws-ssh-key
   dynamic.linux-m8xlarge-amd64.security-group-id: sg-0e1a9339d698a73e1
-  dynamic.linux-m8xlarge-amd64.max-instances: "10"
+  dynamic.linux-m8xlarge-amd64.max-instances: "5"
   dynamic.linux-m8xlarge-amd64.subnet-id: subnet-0dffd53ed51b01e79
 
   # cpu:memory (1:2)
@@ -281,7 +281,7 @@ data:
   dynamic.linux-cxlarge-arm64.aws-secret: aws-account
   dynamic.linux-cxlarge-arm64.ssh-secret: aws-ssh-key
   dynamic.linux-cxlarge-arm64.security-group-id: sg-0e1a9339d698a73e1
-  dynamic.linux-cxlarge-arm64.max-instances: "50"
+  dynamic.linux-cxlarge-arm64.max-instances: "5"
   dynamic.linux-cxlarge-arm64.subnet-id: subnet-0dffd53ed51b01e79
 
   dynamic.linux-c2xlarge-arm64.type: aws
@@ -293,7 +293,7 @@ data:
   dynamic.linux-c2xlarge-arm64.aws-secret: aws-account
   dynamic.linux-c2xlarge-arm64.ssh-secret: aws-ssh-key
   dynamic.linux-c2xlarge-arm64.security-group-id: sg-0e1a9339d698a73e1
-  dynamic.linux-c2xlarge-arm64.max-instances: "20"
+  dynamic.linux-c2xlarge-arm64.max-instances: "5"
   dynamic.linux-c2xlarge-arm64.subnet-id: subnet-0dffd53ed51b01e79
 
   dynamic.linux-c4xlarge-arm64.type: aws
@@ -305,7 +305,7 @@ data:
   dynamic.linux-c4xlarge-arm64.aws-secret: aws-account
   dynamic.linux-c4xlarge-arm64.ssh-secret: aws-ssh-key
   dynamic.linux-c4xlarge-arm64.security-group-id: sg-0e1a9339d698a73e1
-  dynamic.linux-c4xlarge-arm64.max-instances: "20"
+  dynamic.linux-c4xlarge-arm64.max-instances: "5"
   dynamic.linux-c4xlarge-arm64.subnet-id: subnet-0dffd53ed51b01e79
 
   dynamic.linux-c8xlarge-arm64.type: aws
@@ -317,7 +317,7 @@ data:
   dynamic.linux-c8xlarge-arm64.aws-secret: aws-account
   dynamic.linux-c8xlarge-arm64.ssh-secret: aws-ssh-key
   dynamic.linux-c8xlarge-arm64.security-group-id: sg-0e1a9339d698a73e1
-  dynamic.linux-c8xlarge-arm64.max-instances: "20"
+  dynamic.linux-c8xlarge-arm64.max-instances: "5"
   dynamic.linux-c8xlarge-arm64.subnet-id: subnet-0dffd53ed51b01e79
 
   dynamic.linux-cxlarge-amd64.type: aws
@@ -329,7 +329,7 @@ data:
   dynamic.linux-cxlarge-amd64.aws-secret: aws-account
   dynamic.linux-cxlarge-amd64.ssh-secret: aws-ssh-key
   dynamic.linux-cxlarge-amd64.security-group-id: sg-0e1a9339d698a73e1
-  dynamic.linux-cxlarge-amd64.max-instances: "10"
+  dynamic.linux-cxlarge-amd64.max-instances: "5"
   dynamic.linux-cxlarge-amd64.subnet-id: subnet-0dffd53ed51b01e79
 
   dynamic.linux-c2xlarge-amd64.type: aws
@@ -341,7 +341,7 @@ data:
   dynamic.linux-c2xlarge-amd64.aws-secret: aws-account
   dynamic.linux-c2xlarge-amd64.ssh-secret: aws-ssh-key
   dynamic.linux-c2xlarge-amd64.security-group-id: sg-0e1a9339d698a73e1
-  dynamic.linux-c2xlarge-amd64.max-instances: "10"
+  dynamic.linux-c2xlarge-amd64.max-instances: "5"
   dynamic.linux-c2xlarge-amd64.subnet-id: subnet-0dffd53ed51b01e79
 
   dynamic.linux-c4xlarge-amd64.type: aws
@@ -353,7 +353,7 @@ data:
   dynamic.linux-c4xlarge-amd64.aws-secret: aws-account
   dynamic.linux-c4xlarge-amd64.ssh-secret: aws-ssh-key
   dynamic.linux-c4xlarge-amd64.security-group-id: sg-0e1a9339d698a73e1
-  dynamic.linux-c4xlarge-amd64.max-instances: "10"
+  dynamic.linux-c4xlarge-amd64.max-instances: "5"
   dynamic.linux-c4xlarge-amd64.subnet-id: subnet-0dffd53ed51b01e79
 
   dynamic.linux-c8xlarge-amd64.type: aws
@@ -365,7 +365,7 @@ data:
   dynamic.linux-c8xlarge-amd64.aws-secret: aws-account
   dynamic.linux-c8xlarge-amd64.ssh-secret: aws-ssh-key
   dynamic.linux-c8xlarge-amd64.security-group-id: sg-0e1a9339d698a73e1
-  dynamic.linux-c8xlarge-amd64.max-instances: "10"
+  dynamic.linux-c8xlarge-amd64.max-instances: "5"
   dynamic.linux-c8xlarge-amd64.subnet-id: subnet-0dffd53ed51b01e79
 
   dynamic.linux-root-arm64.type: aws
@@ -378,7 +378,7 @@ data:
   dynamic.linux-root-arm64.ssh-secret: aws-ssh-key
   dynamic.linux-root-arm64.security-group-id: sg-0e1a9339d698a73e1
   dynamic.linux-root-arm64.subnet-id: subnet-0dffd53ed51b01e79
-  dynamic.linux-root-arm64.max-instances: "50"
+  dynamic.linux-root-arm64.max-instances: "5"
   dynamic.linux-root-arm64.sudo-commands: "/usr/bin/podman"
   dynamic.linux-root-arm64.disk: "200"
   dynamic.linux-root-arm64.iops: "16000"
@@ -395,7 +395,7 @@ data:
   dynamic.linux-fast-amd64.ssh-secret: aws-ssh-key
   dynamic.linux-fast-amd64.security-group-id: sg-0e1a9339d698a73e1
   dynamic.linux-fast-amd64.subnet-id: subnet-0dffd53ed51b01e79
-  dynamic.linux-fast-amd64.max-instances: "10"
+  dynamic.linux-fast-amd64.max-instances: "5"
   dynamic.linux-fast-amd64.disk: "200"
   #  dynamic.linux-fast-amd64.iops: "16000"
   #  dynamic.linux-fast-amd64.throughput: "1000"
@@ -410,7 +410,7 @@ data:
   dynamic.linux-extra-fast-amd64.ssh-secret: aws-ssh-key
   dynamic.linux-extra-fast-amd64.security-group-id: sg-0e1a9339d698a73e1
   dynamic.linux-extra-fast-amd64.subnet-id: subnet-0dffd53ed51b01e79
-  dynamic.linux-extra-fast-amd64.max-instances: "10"
+  dynamic.linux-extra-fast-amd64.max-instances: "5"
   dynamic.linux-extra-fast-amd64.disk: "200"
   # dynamic.linux-extra-fast-amd64.iops: "16000"
   # dynamic.linux-extra-fast-amd64.throughput: "1000"
@@ -425,7 +425,7 @@ data:
   dynamic.linux-root-amd64.ssh-secret: aws-ssh-key
   dynamic.linux-root-amd64.security-group-id: sg-0e1a9339d698a73e1
   dynamic.linux-root-amd64.subnet-id: subnet-0dffd53ed51b01e79
-  dynamic.linux-root-amd64.max-instances: "10"
+  dynamic.linux-root-amd64.max-instances: "5"
   dynamic.linux-root-amd64.sudo-commands: "/usr/bin/podman"
   dynamic.linux-root-amd64.user-data: |-
     Content-Type: multipart/mixed; boundary="//"
@@ -550,7 +550,7 @@ data:
   dynamic.linux-g6xlarge-amd64.aws-secret: aws-account
   dynamic.linux-g6xlarge-amd64.ssh-secret: aws-ssh-key
   dynamic.linux-g6xlarge-amd64.security-group-id: sg-0e1a9339d698a73e1
-  dynamic.linux-g6xlarge-amd64.max-instances: "10"
+  dynamic.linux-g6xlarge-amd64.max-instances: "5"
   dynamic.linux-g6xlarge-amd64.subnet-id: subnet-0dffd53ed51b01e79
   dynamic.linux-g6xlarge-amd64.instance-tag: prod-amd64-g6xlarge
   dynamic.linux-g6xlarge-amd64.user-data: |-

--- a/components/multi-platform-controller/production-downstream/kflux-rhel-p01/host-config.yaml
+++ b/components/multi-platform-controller/production-downstream/kflux-rhel-p01/host-config.yaml
@@ -60,7 +60,7 @@ data:
   dynamic.linux-arm64.aws-secret: aws-account
   dynamic.linux-arm64.ssh-secret: aws-ssh-key
   dynamic.linux-arm64.security-group-id: sg-0c67a834068be63d6
-  dynamic.linux-arm64.max-instances: "50"
+  dynamic.linux-arm64.max-instances: "70"
   dynamic.linux-arm64.subnet-id: subnet-0f3208c0214c55e2e
 
   dynamic.linux-mlarge-arm64.type: aws
@@ -72,7 +72,7 @@ data:
   dynamic.linux-mlarge-arm64.aws-secret: aws-account
   dynamic.linux-mlarge-arm64.ssh-secret: aws-ssh-key
   dynamic.linux-mlarge-arm64.security-group-id: sg-0c67a834068be63d6
-  dynamic.linux-mlarge-arm64.max-instances: "50"
+  dynamic.linux-mlarge-arm64.max-instances: "5"
   dynamic.linux-mlarge-arm64.subnet-id: subnet-0f3208c0214c55e2e
 
   dynamic.linux-mxlarge-arm64.type: aws
@@ -84,7 +84,7 @@ data:
   dynamic.linux-mxlarge-arm64.aws-secret: aws-account
   dynamic.linux-mxlarge-arm64.ssh-secret: aws-ssh-key
   dynamic.linux-mxlarge-arm64.security-group-id: sg-0c67a834068be63d6
-  dynamic.linux-mxlarge-arm64.max-instances: "20"
+  dynamic.linux-mxlarge-arm64.max-instances: "5"
   dynamic.linux-mxlarge-arm64.subnet-id: subnet-0f3208c0214c55e2e
 
   dynamic.linux-m2xlarge-arm64.type: aws
@@ -96,7 +96,7 @@ data:
   dynamic.linux-m2xlarge-arm64.aws-secret: aws-account
   dynamic.linux-m2xlarge-arm64.ssh-secret: aws-ssh-key
   dynamic.linux-m2xlarge-arm64.security-group-id: sg-0c67a834068be63d6
-  dynamic.linux-m2xlarge-arm64.max-instances: "20"
+  dynamic.linux-m2xlarge-arm64.max-instances: "5"
   dynamic.linux-m2xlarge-arm64.subnet-id: subnet-0f3208c0214c55e2e
 
   dynamic.linux-m4xlarge-arm64.type: aws
@@ -108,7 +108,7 @@ data:
   dynamic.linux-m4xlarge-arm64.aws-secret: aws-account
   dynamic.linux-m4xlarge-arm64.ssh-secret: aws-ssh-key
   dynamic.linux-m4xlarge-arm64.security-group-id: sg-0c67a834068be63d6
-  dynamic.linux-m4xlarge-arm64.max-instances: "20"
+  dynamic.linux-m4xlarge-arm64.max-instances: "5"
   dynamic.linux-m4xlarge-arm64.subnet-id: subnet-0f3208c0214c55e2e
 
   dynamic.linux-m8xlarge-arm64.type: aws
@@ -120,7 +120,7 @@ data:
   dynamic.linux-m8xlarge-arm64.aws-secret: aws-account
   dynamic.linux-m8xlarge-arm64.ssh-secret: aws-ssh-key
   dynamic.linux-m8xlarge-arm64.security-group-id: sg-0c67a834068be63d6
-  dynamic.linux-m8xlarge-arm64.max-instances: "20"
+  dynamic.linux-m8xlarge-arm64.max-instances: "5"
   dynamic.linux-m8xlarge-arm64.subnet-id: subnet-0f3208c0214c55e2e
 
   dynamic.linux-c6gd2xlarge-arm64.type: aws
@@ -132,7 +132,7 @@ data:
   dynamic.linux-c6gd2xlarge-arm64.aws-secret: aws-account
   dynamic.linux-c6gd2xlarge-arm64.ssh-secret: aws-ssh-key
   dynamic.linux-c6gd2xlarge-arm64.security-group-id: sg-0c67a834068be63d6
-  dynamic.linux-c6gd2xlarge-arm64.max-instances: "20"
+  dynamic.linux-c6gd2xlarge-arm64.max-instances: "5"
   dynamic.linux-c6gd2xlarge-arm64.subnet-id: subnet-0f3208c0214c55e2e
   dynamic.linux-c6gd2xlarge-arm64.user-data: |-
     Content-Type: multipart/mixed; boundary="//"
@@ -208,7 +208,7 @@ data:
   dynamic.linux-amd64.aws-secret: aws-account
   dynamic.linux-amd64.ssh-secret: aws-ssh-key
   dynamic.linux-amd64.security-group-id: sg-0c67a834068be63d6
-  dynamic.linux-amd64.max-instances: "10"
+  dynamic.linux-amd64.max-instances: "30"
   dynamic.linux-amd64.subnet-id: subnet-0f3208c0214c55e2e
 
   dynamic.linux-mlarge-amd64.type: aws
@@ -220,7 +220,7 @@ data:
   dynamic.linux-mlarge-amd64.aws-secret: aws-account
   dynamic.linux-mlarge-amd64.ssh-secret: aws-ssh-key
   dynamic.linux-mlarge-amd64.security-group-id: sg-0c67a834068be63d6
-  dynamic.linux-mlarge-amd64.max-instances: "10"
+  dynamic.linux-mlarge-amd64.max-instances: "5"
   dynamic.linux-mlarge-amd64.subnet-id: subnet-0f3208c0214c55e2e
 
   dynamic.linux-mxlarge-amd64.type: aws
@@ -232,7 +232,7 @@ data:
   dynamic.linux-mxlarge-amd64.aws-secret: aws-account
   dynamic.linux-mxlarge-amd64.ssh-secret: aws-ssh-key
   dynamic.linux-mxlarge-amd64.security-group-id: sg-0c67a834068be63d6
-  dynamic.linux-mxlarge-amd64.max-instances: "10"
+  dynamic.linux-mxlarge-amd64.max-instances: "5"
   dynamic.linux-mxlarge-amd64.subnet-id: subnet-0f3208c0214c55e2e
 
   dynamic.linux-m2xlarge-amd64.type: aws
@@ -244,7 +244,7 @@ data:
   dynamic.linux-m2xlarge-amd64.aws-secret: aws-account
   dynamic.linux-m2xlarge-amd64.ssh-secret: aws-ssh-key
   dynamic.linux-m2xlarge-amd64.security-group-id: sg-0c67a834068be63d6
-  dynamic.linux-m2xlarge-amd64.max-instances: "10"
+  dynamic.linux-m2xlarge-amd64.max-instances: "5"
   dynamic.linux-m2xlarge-amd64.subnet-id: subnet-0f3208c0214c55e2e
 
   dynamic.linux-m4xlarge-amd64.type: aws
@@ -256,7 +256,7 @@ data:
   dynamic.linux-m4xlarge-amd64.aws-secret: aws-account
   dynamic.linux-m4xlarge-amd64.ssh-secret: aws-ssh-key
   dynamic.linux-m4xlarge-amd64.security-group-id: sg-0c67a834068be63d6
-  dynamic.linux-m4xlarge-amd64.max-instances: "10"
+  dynamic.linux-m4xlarge-amd64.max-instances: "5"
   dynamic.linux-m4xlarge-amd64.subnet-id: subnet-0f3208c0214c55e2e
 
   dynamic.linux-m8xlarge-amd64.type: aws
@@ -268,7 +268,7 @@ data:
   dynamic.linux-m8xlarge-amd64.aws-secret: aws-account
   dynamic.linux-m8xlarge-amd64.ssh-secret: aws-ssh-key
   dynamic.linux-m8xlarge-amd64.security-group-id: sg-0c67a834068be63d6
-  dynamic.linux-m8xlarge-amd64.max-instances: "10"
+  dynamic.linux-m8xlarge-amd64.max-instances: "5"
   dynamic.linux-m8xlarge-amd64.subnet-id: subnet-0f3208c0214c55e2e
 
   # cpu:memory (1:2)
@@ -281,7 +281,7 @@ data:
   dynamic.linux-cxlarge-arm64.aws-secret: aws-account
   dynamic.linux-cxlarge-arm64.ssh-secret: aws-ssh-key
   dynamic.linux-cxlarge-arm64.security-group-id: sg-0c67a834068be63d6
-  dynamic.linux-cxlarge-arm64.max-instances: "50"
+  dynamic.linux-cxlarge-arm64.max-instances: "5"
   dynamic.linux-cxlarge-arm64.subnet-id: subnet-0f3208c0214c55e2e
 
   dynamic.linux-c2xlarge-arm64.type: aws
@@ -293,7 +293,7 @@ data:
   dynamic.linux-c2xlarge-arm64.aws-secret: aws-account
   dynamic.linux-c2xlarge-arm64.ssh-secret: aws-ssh-key
   dynamic.linux-c2xlarge-arm64.security-group-id: sg-0c67a834068be63d6
-  dynamic.linux-c2xlarge-arm64.max-instances: "20"
+  dynamic.linux-c2xlarge-arm64.max-instances: "5"
   dynamic.linux-c2xlarge-arm64.subnet-id: subnet-0f3208c0214c55e2e
 
   dynamic.linux-c4xlarge-arm64.type: aws
@@ -305,7 +305,7 @@ data:
   dynamic.linux-c4xlarge-arm64.aws-secret: aws-account
   dynamic.linux-c4xlarge-arm64.ssh-secret: aws-ssh-key
   dynamic.linux-c4xlarge-arm64.security-group-id: sg-0c67a834068be63d6
-  dynamic.linux-c4xlarge-arm64.max-instances: "20"
+  dynamic.linux-c4xlarge-arm64.max-instances: "5"
   dynamic.linux-c4xlarge-arm64.subnet-id: subnet-0f3208c0214c55e2e
 
   dynamic.linux-c8xlarge-arm64.type: aws
@@ -317,7 +317,7 @@ data:
   dynamic.linux-c8xlarge-arm64.aws-secret: aws-account
   dynamic.linux-c8xlarge-arm64.ssh-secret: aws-ssh-key
   dynamic.linux-c8xlarge-arm64.security-group-id: sg-0c67a834068be63d6
-  dynamic.linux-c8xlarge-arm64.max-instances: "20"
+  dynamic.linux-c8xlarge-arm64.max-instances: "5"
   dynamic.linux-c8xlarge-arm64.subnet-id: subnet-0f3208c0214c55e2e
 
   dynamic.linux-cxlarge-amd64.type: aws
@@ -329,7 +329,7 @@ data:
   dynamic.linux-cxlarge-amd64.aws-secret: aws-account
   dynamic.linux-cxlarge-amd64.ssh-secret: aws-ssh-key
   dynamic.linux-cxlarge-amd64.security-group-id: sg-0c67a834068be63d6
-  dynamic.linux-cxlarge-amd64.max-instances: "10"
+  dynamic.linux-cxlarge-amd64.max-instances: "5"
   dynamic.linux-cxlarge-amd64.subnet-id: subnet-0f3208c0214c55e2e
 
   dynamic.linux-c2xlarge-amd64.type: aws
@@ -341,7 +341,7 @@ data:
   dynamic.linux-c2xlarge-amd64.aws-secret: aws-account
   dynamic.linux-c2xlarge-amd64.ssh-secret: aws-ssh-key
   dynamic.linux-c2xlarge-amd64.security-group-id: sg-0c67a834068be63d6
-  dynamic.linux-c2xlarge-amd64.max-instances: "10"
+  dynamic.linux-c2xlarge-amd64.max-instances: "5"
   dynamic.linux-c2xlarge-amd64.subnet-id: subnet-0f3208c0214c55e2e
 
   dynamic.linux-c4xlarge-amd64.type: aws
@@ -353,7 +353,7 @@ data:
   dynamic.linux-c4xlarge-amd64.aws-secret: aws-account
   dynamic.linux-c4xlarge-amd64.ssh-secret: aws-ssh-key
   dynamic.linux-c4xlarge-amd64.security-group-id: sg-0c67a834068be63d6
-  dynamic.linux-c4xlarge-amd64.max-instances: "10"
+  dynamic.linux-c4xlarge-amd64.max-instances: "5"
   dynamic.linux-c4xlarge-amd64.subnet-id: subnet-0f3208c0214c55e2e
 
   dynamic.linux-c8xlarge-amd64.type: aws
@@ -365,7 +365,7 @@ data:
   dynamic.linux-c8xlarge-amd64.aws-secret: aws-account
   dynamic.linux-c8xlarge-amd64.ssh-secret: aws-ssh-key
   dynamic.linux-c8xlarge-amd64.security-group-id: sg-0c67a834068be63d6
-  dynamic.linux-c8xlarge-amd64.max-instances: "10"
+  dynamic.linux-c8xlarge-amd64.max-instances: "5"
   dynamic.linux-c8xlarge-amd64.subnet-id: subnet-0f3208c0214c55e2e
 
   dynamic.linux-root-arm64.type: aws
@@ -378,7 +378,7 @@ data:
   dynamic.linux-root-arm64.ssh-secret: aws-ssh-key
   dynamic.linux-root-arm64.security-group-id: sg-0c67a834068be63d6
   dynamic.linux-root-arm64.subnet-id: subnet-0f3208c0214c55e2e
-  dynamic.linux-root-arm64.max-instances: "50"
+  dynamic.linux-root-arm64.max-instances: "5"
   dynamic.linux-root-arm64.sudo-commands: "/usr/bin/podman, /usr/bin/rm /usr/share/containers/mounts.conf"
   dynamic.linux-root-arm64.disk: "200"
   dynamic.linux-root-arm64.iops: "16000"
@@ -395,7 +395,7 @@ data:
   dynamic.linux-fast-amd64.ssh-secret: aws-ssh-key
   dynamic.linux-fast-amd64.security-group-id: sg-0c67a834068be63d6
   dynamic.linux-fast-amd64.subnet-id: subnet-0f3208c0214c55e2e
-  dynamic.linux-fast-amd64.max-instances: "10"
+  dynamic.linux-fast-amd64.max-instances: "5"
   dynamic.linux-fast-amd64.disk: "200"
   #  dynamic.linux-fast-amd64.iops: "16000"
   #  dynamic.linux-fast-amd64.throughput: "1000"
@@ -410,7 +410,7 @@ data:
   dynamic.linux-extra-fast-amd64.ssh-secret: aws-ssh-key
   dynamic.linux-extra-fast-amd64.security-group-id: sg-0c67a834068be63d6
   dynamic.linux-extra-fast-amd64.subnet-id: subnet-0f3208c0214c55e2e
-  dynamic.linux-extra-fast-amd64.max-instances: "10"
+  dynamic.linux-extra-fast-amd64.max-instances: "5"
   dynamic.linux-extra-fast-amd64.disk: "200"
   # dynamic.linux-extra-fast-amd64.iops: "16000"
   # dynamic.linux-extra-fast-amd64.throughput: "1000"
@@ -425,7 +425,7 @@ data:
   dynamic.linux-root-amd64.ssh-secret: aws-ssh-key
   dynamic.linux-root-amd64.security-group-id: sg-0c67a834068be63d6
   dynamic.linux-root-amd64.subnet-id: subnet-0f3208c0214c55e2e
-  dynamic.linux-root-amd64.max-instances: "10"
+  dynamic.linux-root-amd64.max-instances: "5"
   dynamic.linux-root-amd64.sudo-commands: "/usr/bin/podman, /usr/bin/rm /usr/share/containers/mounts.conf"
   dynamic.linux-root-amd64.user-data: |-
     Content-Type: multipart/mixed; boundary="//"

--- a/components/multi-platform-controller/production-downstream/stone-prod-p02/host-config.yaml
+++ b/components/multi-platform-controller/production-downstream/stone-prod-p02/host-config.yaml
@@ -66,8 +66,8 @@ data:
   dynamic.linux-arm64.aws-secret: aws-account
   dynamic.linux-arm64.ssh-secret: aws-ssh-key
   dynamic.linux-arm64.security-group-id: sg-0903aedd465be979e
-  dynamic.linux-arm64.max-instances: "100"
-  dynamic.linux-arm64.subnet-id: subnet-0aa719a6c5b602b16
+  dynamic.linux-arm64.max-instances: "70"
+  dynamic.linux-arm64.subnet-id: subnet-02c476f8d2a4ae05e
   dynamic.linux-arm64.allocation-timeout: "1200"
 
   dynamic.linux-mlarge-arm64.type: aws
@@ -79,8 +79,8 @@ data:
   dynamic.linux-mlarge-arm64.aws-secret: aws-account
   dynamic.linux-mlarge-arm64.ssh-secret: aws-ssh-key
   dynamic.linux-mlarge-arm64.security-group-id: sg-0903aedd465be979e
-  dynamic.linux-mlarge-arm64.max-instances: "100"
-  dynamic.linux-mlarge-arm64.subnet-id: subnet-0aa719a6c5b602b16
+  dynamic.linux-mlarge-arm64.max-instances: "5"
+  dynamic.linux-mlarge-arm64.subnet-id: subnet-02c476f8d2a4ae05e
   dynamic.linux-mlarge-arm64.allocation-timeout: "1200"
 
   dynamic.linux-mxlarge-arm64.type: aws
@@ -92,8 +92,8 @@ data:
   dynamic.linux-mxlarge-arm64.aws-secret: aws-account
   dynamic.linux-mxlarge-arm64.ssh-secret: aws-ssh-key
   dynamic.linux-mxlarge-arm64.security-group-id: sg-0903aedd465be979e
-  dynamic.linux-mxlarge-arm64.max-instances: "100"
-  dynamic.linux-mxlarge-arm64.subnet-id: subnet-0aa719a6c5b602b16
+  dynamic.linux-mxlarge-arm64.max-instances: "5"
+  dynamic.linux-mxlarge-arm64.subnet-id: subnet-02c476f8d2a4ae05e
   dynamic.linux-mxlarge-arm64.allocation-timeout: "1200"
 
   dynamic.linux-m2xlarge-arm64.type: aws
@@ -105,8 +105,8 @@ data:
   dynamic.linux-m2xlarge-arm64.aws-secret: aws-account
   dynamic.linux-m2xlarge-arm64.ssh-secret: aws-ssh-key
   dynamic.linux-m2xlarge-arm64.security-group-id: sg-0903aedd465be979e
-  dynamic.linux-m2xlarge-arm64.max-instances: "100"
-  dynamic.linux-m2xlarge-arm64.subnet-id: subnet-0aa719a6c5b602b16
+  dynamic.linux-m2xlarge-arm64.max-instances: "5"
+  dynamic.linux-m2xlarge-arm64.subnet-id: subnet-02c476f8d2a4ae05e
   dynamic.linux-m2xlarge-arm64.allocation-timeout: "1200"
 
   dynamic.linux-d160-m2xlarge-arm64.type: aws
@@ -118,8 +118,8 @@ data:
   dynamic.linux-d160-m2xlarge-arm64.aws-secret: aws-account
   dynamic.linux-d160-m2xlarge-arm64.ssh-secret: aws-ssh-key
   dynamic.linux-d160-m2xlarge-arm64.security-group-id: sg-0903aedd465be979e
-  dynamic.linux-d160-m2xlarge-arm64.max-instances: "100"
-  dynamic.linux-d160-m2xlarge-arm64.subnet-id: subnet-0aa719a6c5b602b16
+  dynamic.linux-d160-m2xlarge-arm64.max-instances: "5"
+  dynamic.linux-d160-m2xlarge-arm64.subnet-id: subnet-02c476f8d2a4ae05e
   dynamic.linux-d160-m2xlarge-arm64.allocation-timeout: "1200"
   dynamic.linux-d160-m2xlarge-arm64.disk: "160"
 
@@ -132,8 +132,8 @@ data:
   dynamic.linux-m4xlarge-arm64.aws-secret: aws-account
   dynamic.linux-m4xlarge-arm64.ssh-secret: aws-ssh-key
   dynamic.linux-m4xlarge-arm64.security-group-id: sg-0903aedd465be979e
-  dynamic.linux-m4xlarge-arm64.max-instances: "100"
-  dynamic.linux-m4xlarge-arm64.subnet-id: subnet-0aa719a6c5b602b16
+  dynamic.linux-m4xlarge-arm64.max-instances: "5"
+  dynamic.linux-m4xlarge-arm64.subnet-id: subnet-02c476f8d2a4ae05e
   dynamic.linux-m4xlarge-arm64.allocation-timeout: "1200"
 
   dynamic.linux-c6gd2xlarge-arm64.type: aws
@@ -145,8 +145,8 @@ data:
   dynamic.linux-c6gd2xlarge-arm64.aws-secret: aws-account
   dynamic.linux-c6gd2xlarge-arm64.ssh-secret: aws-ssh-key
   dynamic.linux-c6gd2xlarge-arm64.security-group-id: sg-0903aedd465be979e
-  dynamic.linux-c6gd2xlarge-arm64.max-instances: "100"
-  dynamic.linux-c6gd2xlarge-arm64.subnet-id: subnet-0aa719a6c5b602b16
+  dynamic.linux-c6gd2xlarge-arm64.max-instances: "5"
+  dynamic.linux-c6gd2xlarge-arm64.subnet-id: subnet-02c476f8d2a4ae05e
   dynamic.linux-c6gd2xlarge-arm64.allocation-timeout: "1200"
   dynamic.linux-c6gd2xlarge-arm64.user-data: |-
     Content-Type: multipart/mixed; boundary="//"
@@ -223,8 +223,8 @@ data:
   dynamic.linux-d160-m4xlarge-arm64.aws-secret: aws-account
   dynamic.linux-d160-m4xlarge-arm64.ssh-secret: aws-ssh-key
   dynamic.linux-d160-m4xlarge-arm64.security-group-id: sg-0903aedd465be979e
-  dynamic.linux-d160-m4xlarge-arm64.max-instances: "100"
-  dynamic.linux-d160-m4xlarge-arm64.subnet-id: subnet-0aa719a6c5b602b16
+  dynamic.linux-d160-m4xlarge-arm64.max-instances: "5"
+  dynamic.linux-d160-m4xlarge-arm64.subnet-id: subnet-02c476f8d2a4ae05e
   dynamic.linux-d160-m4xlarge-arm64.allocation-timeout: "1200"
   dynamic.linux-d160-m4xlarge-arm64.disk: "160"
 
@@ -237,8 +237,8 @@ data:
   dynamic.linux-m8xlarge-arm64.aws-secret: aws-account
   dynamic.linux-m8xlarge-arm64.ssh-secret: aws-ssh-key
   dynamic.linux-m8xlarge-arm64.security-group-id: sg-0903aedd465be979e
-  dynamic.linux-m8xlarge-arm64.max-instances: "100"
-  dynamic.linux-m8xlarge-arm64.subnet-id: subnet-0aa719a6c5b602b16
+  dynamic.linux-m8xlarge-arm64.max-instances: "5"
+  dynamic.linux-m8xlarge-arm64.subnet-id: subnet-02c476f8d2a4ae05e
   dynamic.linux-m8xlarge-arm64.allocation-timeout: "1200"
 
   dynamic.linux-d160-m8xlarge-arm64.type: aws
@@ -250,8 +250,8 @@ data:
   dynamic.linux-d160-m8xlarge-arm64.aws-secret: aws-account
   dynamic.linux-d160-m8xlarge-arm64.ssh-secret: aws-ssh-key
   dynamic.linux-d160-m8xlarge-arm64.security-group-id: sg-0903aedd465be979e
-  dynamic.linux-d160-m8xlarge-arm64.max-instances: "100"
-  dynamic.linux-d160-m8xlarge-arm64.subnet-id: subnet-0aa719a6c5b602b16
+  dynamic.linux-d160-m8xlarge-arm64.max-instances: "5"
+  dynamic.linux-d160-m8xlarge-arm64.subnet-id: subnet-02c476f8d2a4ae05e
   dynamic.linux-d160-m8xlarge-arm64.allocation-timeout: "1200"
   dynamic.linux-d160-m8xlarge-arm64.disk: "160"
 
@@ -264,8 +264,8 @@ data:
   dynamic.linux-amd64.aws-secret: aws-account
   dynamic.linux-amd64.ssh-secret: aws-ssh-key
   dynamic.linux-amd64.security-group-id: sg-0903aedd465be979e
-  dynamic.linux-amd64.max-instances: "100"
-  dynamic.linux-amd64.subnet-id: subnet-0aa719a6c5b602b16
+  dynamic.linux-amd64.max-instances: "30"
+  dynamic.linux-amd64.subnet-id: subnet-02c476f8d2a4ae05e
   dynamic.linux-amd64.allocation-timeout: "1200"
 
   dynamic.linux-mlarge-amd64.type: aws
@@ -277,8 +277,8 @@ data:
   dynamic.linux-mlarge-amd64.aws-secret: aws-account
   dynamic.linux-mlarge-amd64.ssh-secret: aws-ssh-key
   dynamic.linux-mlarge-amd64.security-group-id: sg-0903aedd465be979e
-  dynamic.linux-mlarge-amd64.max-instances: "100"
-  dynamic.linux-mlarge-amd64.subnet-id: subnet-0aa719a6c5b602b16
+  dynamic.linux-mlarge-amd64.max-instances: "5"
+  dynamic.linux-mlarge-amd64.subnet-id: subnet-02c476f8d2a4ae05e
   dynamic.linux-mlarge-amd64.allocation-timeout: "1200"
 
   dynamic.linux-mxlarge-amd64.type: aws
@@ -290,8 +290,8 @@ data:
   dynamic.linux-mxlarge-amd64.aws-secret: aws-account
   dynamic.linux-mxlarge-amd64.ssh-secret: aws-ssh-key
   dynamic.linux-mxlarge-amd64.security-group-id: sg-0903aedd465be979e
-  dynamic.linux-mxlarge-amd64.max-instances: "100"
-  dynamic.linux-mxlarge-amd64.subnet-id: subnet-0aa719a6c5b602b16
+  dynamic.linux-mxlarge-amd64.max-instances: "5"
+  dynamic.linux-mxlarge-amd64.subnet-id: subnet-02c476f8d2a4ae05e
   dynamic.linux-mxlarge-amd64.allocation-timeout: "1200"
 
   dynamic.linux-m2xlarge-amd64.type: aws
@@ -303,8 +303,8 @@ data:
   dynamic.linux-m2xlarge-amd64.aws-secret: aws-account
   dynamic.linux-m2xlarge-amd64.ssh-secret: aws-ssh-key
   dynamic.linux-m2xlarge-amd64.security-group-id: sg-0903aedd465be979e
-  dynamic.linux-m2xlarge-amd64.max-instances: "100"
-  dynamic.linux-m2xlarge-amd64.subnet-id: subnet-0aa719a6c5b602b16
+  dynamic.linux-m2xlarge-amd64.max-instances: "5"
+  dynamic.linux-m2xlarge-amd64.subnet-id: subnet-02c476f8d2a4ae05e
   dynamic.linux-m2xlarge-amd64.allocation-timeout: "1200"
 
   dynamic.linux-d160-m2xlarge-amd64.type: aws
@@ -316,8 +316,8 @@ data:
   dynamic.linux-d160-m2xlarge-amd64.aws-secret: aws-account
   dynamic.linux-d160-m2xlarge-amd64.ssh-secret: aws-ssh-key
   dynamic.linux-d160-m2xlarge-amd64.security-group-id: sg-0903aedd465be979e
-  dynamic.linux-d160-m2xlarge-amd64.max-instances: "100"
-  dynamic.linux-d160-m2xlarge-amd64.subnet-id: subnet-0aa719a6c5b602b16
+  dynamic.linux-d160-m2xlarge-amd64.max-instances: "5"
+  dynamic.linux-d160-m2xlarge-amd64.subnet-id: subnet-02c476f8d2a4ae05e
   dynamic.linux-d160-m2xlarge-amd64.allocation-timeout: "1200"
   dynamic.linux-d160-m2xlarge-amd64.disk: "160"
 
@@ -330,8 +330,8 @@ data:
   dynamic.linux-m4xlarge-amd64.aws-secret: aws-account
   dynamic.linux-m4xlarge-amd64.ssh-secret: aws-ssh-key
   dynamic.linux-m4xlarge-amd64.security-group-id: sg-0903aedd465be979e
-  dynamic.linux-m4xlarge-amd64.max-instances: "100"
-  dynamic.linux-m4xlarge-amd64.subnet-id: subnet-0aa719a6c5b602b16
+  dynamic.linux-m4xlarge-amd64.max-instances: "5"
+  dynamic.linux-m4xlarge-amd64.subnet-id: subnet-02c476f8d2a4ae05e
   dynamic.linux-m4xlarge-amd64.allocation-timeout: "1200"
 
   # same as m4xlarge-amd64 bug 160G disk
@@ -344,8 +344,8 @@ data:
   dynamic.linux-d160-m4xlarge-amd64.aws-secret: aws-account
   dynamic.linux-d160-m4xlarge-amd64.ssh-secret: aws-ssh-key
   dynamic.linux-d160-m4xlarge-amd64.security-group-id: sg-0903aedd465be979e
-  dynamic.linux-d160-m4xlarge-amd64.max-instances: "100"
-  dynamic.linux-d160-m4xlarge-amd64.subnet-id: subnet-0aa719a6c5b602b16
+  dynamic.linux-d160-m4xlarge-amd64.max-instances: "5"
+  dynamic.linux-d160-m4xlarge-amd64.subnet-id: subnet-02c476f8d2a4ae05e
   dynamic.linux-d160-m4xlarge-amd64.allocation-timeout: "1200"
   dynamic.linux-d160-m4xlarge-amd64.disk: "160"
 
@@ -358,8 +358,8 @@ data:
   dynamic.linux-m8xlarge-amd64.aws-secret: aws-account
   dynamic.linux-m8xlarge-amd64.ssh-secret: aws-ssh-key
   dynamic.linux-m8xlarge-amd64.security-group-id: sg-0903aedd465be979e
-  dynamic.linux-m8xlarge-amd64.max-instances: "100"
-  dynamic.linux-m8xlarge-amd64.subnet-id: subnet-0aa719a6c5b602b16
+  dynamic.linux-m8xlarge-amd64.max-instances: "5"
+  dynamic.linux-m8xlarge-amd64.subnet-id: subnet-02c476f8d2a4ae05e
   dynamic.linux-m8xlarge-amd64.allocation-timeout: "1200"
 
   dynamic.linux-d160-m8xlarge-amd64.type: aws
@@ -371,8 +371,8 @@ data:
   dynamic.linux-d160-m8xlarge-amd64.aws-secret: aws-account
   dynamic.linux-d160-m8xlarge-amd64.ssh-secret: aws-ssh-key
   dynamic.linux-d160-m8xlarge-amd64.security-group-id: sg-0903aedd465be979e
-  dynamic.linux-d160-m8xlarge-amd64.max-instances: "100"
-  dynamic.linux-d160-m8xlarge-amd64.subnet-id: subnet-0aa719a6c5b602b16
+  dynamic.linux-d160-m8xlarge-amd64.max-instances: "5"
+  dynamic.linux-d160-m8xlarge-amd64.subnet-id: subnet-02c476f8d2a4ae05e
   dynamic.linux-d160-m8xlarge-amd64.allocation-timeout: "1200"
   dynamic.linux-d160-m8xlarge-amd64.disk: "160"
 
@@ -385,8 +385,8 @@ data:
   dynamic.linux-fast-amd64.aws-secret: aws-account
   dynamic.linux-fast-amd64.ssh-secret: aws-ssh-key
   dynamic.linux-fast-amd64.security-group-id: sg-0903aedd465be979e
-  dynamic.linux-fast-amd64.subnet-id: subnet-0aa719a6c5b602b16
-  dynamic.linux-fast-amd64.max-instances: "10"
+  dynamic.linux-fast-amd64.subnet-id: subnet-02c476f8d2a4ae05e
+  dynamic.linux-fast-amd64.max-instances: "5"
   dynamic.linux-fast-amd64.disk: "200"
 
   dynamic.linux-extra-fast-amd64.type: aws
@@ -398,8 +398,8 @@ data:
   dynamic.linux-extra-fast-amd64.aws-secret: aws-account
   dynamic.linux-extra-fast-amd64.ssh-secret: aws-ssh-key
   dynamic.linux-extra-fast-amd64.security-group-id: sg-0903aedd465be979e
-  dynamic.linux-extra-fast-amd64.subnet-id: subnet-0aa719a6c5b602b16
-  dynamic.linux-extra-fast-amd64.max-instances: "10"
+  dynamic.linux-extra-fast-amd64.subnet-id: subnet-02c476f8d2a4ae05e
+  dynamic.linux-extra-fast-amd64.max-instances: "5"
   dynamic.linux-extra-fast-amd64.disk: "200"
 
   # cpu:memory (1:2)
@@ -412,8 +412,8 @@ data:
   dynamic.linux-cxlarge-arm64.aws-secret: aws-account
   dynamic.linux-cxlarge-arm64.ssh-secret: aws-ssh-key
   dynamic.linux-cxlarge-arm64.security-group-id: sg-0903aedd465be979e
-  dynamic.linux-cxlarge-arm64.max-instances: "100"
-  dynamic.linux-cxlarge-arm64.subnet-id: subnet-0aa719a6c5b602b16
+  dynamic.linux-cxlarge-arm64.max-instances: "5"
+  dynamic.linux-cxlarge-arm64.subnet-id: subnet-02c476f8d2a4ae05e
   dynamic.linux-cxlarge-arm64.allocation-timeout: "1200"
 
   dynamic.linux-c2xlarge-arm64.type: aws
@@ -425,8 +425,8 @@ data:
   dynamic.linux-c2xlarge-arm64.aws-secret: aws-account
   dynamic.linux-c2xlarge-arm64.ssh-secret: aws-ssh-key
   dynamic.linux-c2xlarge-arm64.security-group-id: sg-0903aedd465be979e
-  dynamic.linux-c2xlarge-arm64.max-instances: "100"
-  dynamic.linux-c2xlarge-arm64.subnet-id: subnet-0aa719a6c5b602b16
+  dynamic.linux-c2xlarge-arm64.max-instances: "5"
+  dynamic.linux-c2xlarge-arm64.subnet-id: subnet-02c476f8d2a4ae05e
   dynamic.linux-c2xlarge-arm64.allocation-timeout: "1200"
 
   dynamic.linux-c4xlarge-arm64.type: aws
@@ -438,8 +438,8 @@ data:
   dynamic.linux-c4xlarge-arm64.aws-secret: aws-account
   dynamic.linux-c4xlarge-arm64.ssh-secret: aws-ssh-key
   dynamic.linux-c4xlarge-arm64.security-group-id: sg-0903aedd465be979e
-  dynamic.linux-c4xlarge-arm64.max-instances: "100"
-  dynamic.linux-c4xlarge-arm64.subnet-id: subnet-0aa719a6c5b602b16
+  dynamic.linux-c4xlarge-arm64.max-instances: "5"
+  dynamic.linux-c4xlarge-arm64.subnet-id: subnet-02c476f8d2a4ae05e
   dynamic.linux-c4xlarge-arm64.allocation-timeout: "1200"
 
   dynamic.linux-c8xlarge-arm64.type: aws
@@ -451,8 +451,8 @@ data:
   dynamic.linux-c8xlarge-arm64.aws-secret: aws-account
   dynamic.linux-c8xlarge-arm64.ssh-secret: aws-ssh-key
   dynamic.linux-c8xlarge-arm64.security-group-id: sg-0903aedd465be979e
-  dynamic.linux-c8xlarge-arm64.max-instances: "100"
-  dynamic.linux-c8xlarge-arm64.subnet-id: subnet-0aa719a6c5b602b16
+  dynamic.linux-c8xlarge-arm64.max-instances: "5"
+  dynamic.linux-c8xlarge-arm64.subnet-id: subnet-02c476f8d2a4ae05e
   dynamic.linux-c8xlarge-arm64.allocation-timeout: "1200"
 
   dynamic.linux-cxlarge-amd64.type: aws
@@ -464,8 +464,8 @@ data:
   dynamic.linux-cxlarge-amd64.aws-secret: aws-account
   dynamic.linux-cxlarge-amd64.ssh-secret: aws-ssh-key
   dynamic.linux-cxlarge-amd64.security-group-id: sg-0903aedd465be979e
-  dynamic.linux-cxlarge-amd64.max-instances: "100"
-  dynamic.linux-cxlarge-amd64.subnet-id: subnet-0aa719a6c5b602b16
+  dynamic.linux-cxlarge-amd64.max-instances: "5"
+  dynamic.linux-cxlarge-amd64.subnet-id: subnet-02c476f8d2a4ae05e
   dynamic.linux-cxlarge-amd64.allocation-timeout: "1200"
 
   dynamic.linux-c2xlarge-amd64.type: aws
@@ -477,8 +477,8 @@ data:
   dynamic.linux-c2xlarge-amd64.aws-secret: aws-account
   dynamic.linux-c2xlarge-amd64.ssh-secret: aws-ssh-key
   dynamic.linux-c2xlarge-amd64.security-group-id: sg-0903aedd465be979e
-  dynamic.linux-c2xlarge-amd64.max-instances: "100"
-  dynamic.linux-c2xlarge-amd64.subnet-id: subnet-0aa719a6c5b602b16
+  dynamic.linux-c2xlarge-amd64.max-instances: "5"
+  dynamic.linux-c2xlarge-amd64.subnet-id: subnet-02c476f8d2a4ae05e
   dynamic.linux-c2xlarge-amd64.allocation-timeout: "1200"
 
   dynamic.linux-c4xlarge-amd64.type: aws
@@ -490,8 +490,8 @@ data:
   dynamic.linux-c4xlarge-amd64.aws-secret: aws-account
   dynamic.linux-c4xlarge-amd64.ssh-secret: aws-ssh-key
   dynamic.linux-c4xlarge-amd64.security-group-id: sg-0903aedd465be979e
-  dynamic.linux-c4xlarge-amd64.max-instances: "100"
-  dynamic.linux-c4xlarge-amd64.subnet-id: subnet-0aa719a6c5b602b16
+  dynamic.linux-c4xlarge-amd64.max-instances: "5"
+  dynamic.linux-c4xlarge-amd64.subnet-id: subnet-02c476f8d2a4ae05e
   dynamic.linux-c4xlarge-amd64.allocation-timeout: "1200"
 
   dynamic.linux-c8xlarge-amd64.type: aws
@@ -503,8 +503,8 @@ data:
   dynamic.linux-c8xlarge-amd64.aws-secret: aws-account
   dynamic.linux-c8xlarge-amd64.ssh-secret: aws-ssh-key
   dynamic.linux-c8xlarge-amd64.security-group-id: sg-0903aedd465be979e
-  dynamic.linux-c8xlarge-amd64.max-instances: "100"
-  dynamic.linux-c8xlarge-amd64.subnet-id: subnet-0aa719a6c5b602b16
+  dynamic.linux-c8xlarge-amd64.max-instances: "5"
+  dynamic.linux-c8xlarge-amd64.subnet-id: subnet-02c476f8d2a4ae05e
   dynamic.linux-c8xlarge-amd64.allocation-timeout: "1200"
 
   dynamic.linux-root-arm64.type: aws
@@ -516,8 +516,8 @@ data:
   dynamic.linux-root-arm64.aws-secret: aws-account
   dynamic.linux-root-arm64.ssh-secret: aws-ssh-key
   dynamic.linux-root-arm64.security-group-id: sg-0903aedd465be979e
-  dynamic.linux-root-arm64.subnet-id: subnet-0aa719a6c5b602b16
-  dynamic.linux-root-arm64.max-instances: "100"
+  dynamic.linux-root-arm64.subnet-id: subnet-02c476f8d2a4ae05e
+  dynamic.linux-root-arm64.max-instances: "5"
   dynamic.linux-root-arm64.sudo-commands: "/usr/bin/podman, /usr/bin/rm /usr/share/containers/mounts.conf"
   dynamic.linux-root-arm64.disk: "200"
   dynamic.linux-root-arm64.iops: "16000"
@@ -532,8 +532,8 @@ data:
   dynamic.linux-root-amd64.aws-secret: aws-account
   dynamic.linux-root-amd64.ssh-secret: aws-ssh-key
   dynamic.linux-root-amd64.security-group-id: sg-0903aedd465be979e
-  dynamic.linux-root-amd64.subnet-id: subnet-0aa719a6c5b602b16
-  dynamic.linux-root-amd64.max-instances: "100"
+  dynamic.linux-root-amd64.subnet-id: subnet-02c476f8d2a4ae05e
+  dynamic.linux-root-amd64.max-instances: "5"
   dynamic.linux-root-amd64.sudo-commands: "/usr/bin/podman, /usr/bin/rm /usr/share/containers/mounts.conf"
   dynamic.linux-root-amd64.user-data: |-
     Content-Type: multipart/mixed; boundary="//"
@@ -701,8 +701,8 @@ data:
   dynamic.linux-g6xlarge-amd64.aws-secret: aws-account
   dynamic.linux-g6xlarge-amd64.ssh-secret: aws-ssh-key
   dynamic.linux-g6xlarge-amd64.security-group-id: sg-0903aedd465be979e
-  dynamic.linux-g6xlarge-amd64.subnet-id: subnet-0aa719a6c5b602b16
-  dynamic.linux-g6xlarge-amd64.max-instances: "100"
+  dynamic.linux-g6xlarge-amd64.subnet-id: subnet-02c476f8d2a4ae05e
+  dynamic.linux-g6xlarge-amd64.max-instances: "5"
   dynamic.linux-g6xlarge-amd64.allocation-timeout: "1200"
   dynamic.linux-g6xlarge-amd64.instance-tag: prod-amd64-g6xlarge
   dynamic.linux-g6xlarge-amd64.user-data: |-

--- a/components/multi-platform-controller/production/kflux-prd-rh02/host-config.yaml
+++ b/components/multi-platform-controller/production/kflux-prd-rh02/host-config.yaml
@@ -66,8 +66,8 @@ data:
   dynamic.linux-arm64.aws-secret: aws-account
   dynamic.linux-arm64.ssh-secret: aws-ssh-key
   dynamic.linux-arm64.security-group-id: sg-004ef1b7bc3ef1bca
-  dynamic.linux-arm64.max-instances: "50"
-  dynamic.linux-arm64.subnet-id: subnet-07a8bbf633e2bb187
+  dynamic.linux-arm64.max-instances: "70"
+  dynamic.linux-arm64.subnet-id: subnet-02ca0b0e3e0a76caf
 
   dynamic.linux-mlarge-arm64.type: aws
   dynamic.linux-mlarge-arm64.region: us-east-1
@@ -78,8 +78,8 @@ data:
   dynamic.linux-mlarge-arm64.aws-secret: aws-account
   dynamic.linux-mlarge-arm64.ssh-secret: aws-ssh-key
   dynamic.linux-mlarge-arm64.security-group-id: sg-004ef1b7bc3ef1bca
-  dynamic.linux-mlarge-arm64.max-instances: "50"
-  dynamic.linux-mlarge-arm64.subnet-id: subnet-07a8bbf633e2bb187
+  dynamic.linux-mlarge-arm64.max-instances: "5"
+  dynamic.linux-mlarge-arm64.subnet-id: subnet-02ca0b0e3e0a76caf
 
   dynamic.linux-mxlarge-arm64.type: aws
   dynamic.linux-mxlarge-arm64.region: us-east-1
@@ -90,8 +90,8 @@ data:
   dynamic.linux-mxlarge-arm64.aws-secret: aws-account
   dynamic.linux-mxlarge-arm64.ssh-secret: aws-ssh-key
   dynamic.linux-mxlarge-arm64.security-group-id: sg-004ef1b7bc3ef1bca
-  dynamic.linux-mxlarge-arm64.max-instances: "20"
-  dynamic.linux-mxlarge-arm64.subnet-id: subnet-07a8bbf633e2bb187
+  dynamic.linux-mxlarge-arm64.max-instances: "5"
+  dynamic.linux-mxlarge-arm64.subnet-id: subnet-02ca0b0e3e0a76caf
 
   dynamic.linux-m2xlarge-arm64.type: aws
   dynamic.linux-m2xlarge-arm64.region: us-east-1
@@ -102,8 +102,8 @@ data:
   dynamic.linux-m2xlarge-arm64.aws-secret: aws-account
   dynamic.linux-m2xlarge-arm64.ssh-secret: aws-ssh-key
   dynamic.linux-m2xlarge-arm64.security-group-id: sg-004ef1b7bc3ef1bca
-  dynamic.linux-m2xlarge-arm64.max-instances: "20"
-  dynamic.linux-m2xlarge-arm64.subnet-id: subnet-07a8bbf633e2bb187
+  dynamic.linux-m2xlarge-arm64.max-instances: "5"
+  dynamic.linux-m2xlarge-arm64.subnet-id: subnet-02ca0b0e3e0a76caf
 
   dynamic.linux-d160-m2xlarge-arm64.type: aws
   dynamic.linux-d160-m2xlarge-arm64.region: us-east-1
@@ -114,8 +114,8 @@ data:
   dynamic.linux-d160-m2xlarge-arm64.aws-secret: aws-account
   dynamic.linux-d160-m2xlarge-arm64.ssh-secret: aws-ssh-key
   dynamic.linux-d160-m2xlarge-arm64.security-group-id: sg-004ef1b7bc3ef1bca
-  dynamic.linux-d160-m2xlarge-arm64.max-instances: "20"
-  dynamic.linux-d160-m2xlarge-arm64.subnet-id: subnet-07a8bbf633e2bb187
+  dynamic.linux-d160-m2xlarge-arm64.max-instances: "5"
+  dynamic.linux-d160-m2xlarge-arm64.subnet-id: subnet-02ca0b0e3e0a76caf
   dynamic.linux-d160-m2xlarge-arm64.disk: "160"
 
   dynamic.linux-m4xlarge-arm64.type: aws
@@ -127,8 +127,8 @@ data:
   dynamic.linux-m4xlarge-arm64.aws-secret: aws-account
   dynamic.linux-m4xlarge-arm64.ssh-secret: aws-ssh-key
   dynamic.linux-m4xlarge-arm64.security-group-id: sg-004ef1b7bc3ef1bca
-  dynamic.linux-m4xlarge-arm64.max-instances: "20"
-  dynamic.linux-m4xlarge-arm64.subnet-id: subnet-07a8bbf633e2bb187
+  dynamic.linux-m4xlarge-arm64.max-instances: "5"
+  dynamic.linux-m4xlarge-arm64.subnet-id: subnet-02ca0b0e3e0a76caf
 
   dynamic.linux-d160-m4xlarge-arm64.type: aws
   dynamic.linux-d160-m4xlarge-arm64.region: us-east-1
@@ -139,8 +139,8 @@ data:
   dynamic.linux-d160-m4xlarge-arm64.aws-secret: aws-account
   dynamic.linux-d160-m4xlarge-arm64.ssh-secret: aws-ssh-key
   dynamic.linux-d160-m4xlarge-arm64.security-group-id: sg-004ef1b7bc3ef1bca
-  dynamic.linux-d160-m4xlarge-arm64.max-instances: "20"
-  dynamic.linux-d160-m4xlarge-arm64.subnet-id: subnet-07a8bbf633e2bb187
+  dynamic.linux-d160-m4xlarge-arm64.max-instances: "5"
+  dynamic.linux-d160-m4xlarge-arm64.subnet-id: subnet-02ca0b0e3e0a76caf
   dynamic.linux-d160-m4xlarge-arm64.disk: "160"
 
   dynamic.linux-m8xlarge-arm64.type: aws
@@ -152,8 +152,8 @@ data:
   dynamic.linux-m8xlarge-arm64.aws-secret: aws-account
   dynamic.linux-m8xlarge-arm64.ssh-secret: aws-ssh-key
   dynamic.linux-m8xlarge-arm64.security-group-id: sg-004ef1b7bc3ef1bca
-  dynamic.linux-m8xlarge-arm64.max-instances: "20"
-  dynamic.linux-m8xlarge-arm64.subnet-id: subnet-07a8bbf633e2bb187
+  dynamic.linux-m8xlarge-arm64.max-instances: "5"
+  dynamic.linux-m8xlarge-arm64.subnet-id: subnet-02ca0b0e3e0a76caf
 
   dynamic.linux-d160-m8xlarge-arm64.type: aws
   dynamic.linux-d160-m8xlarge-arm64.region: us-east-1
@@ -164,8 +164,8 @@ data:
   dynamic.linux-d160-m8xlarge-arm64.aws-secret: aws-account
   dynamic.linux-d160-m8xlarge-arm64.ssh-secret: aws-ssh-key
   dynamic.linux-d160-m8xlarge-arm64.security-group-id: sg-004ef1b7bc3ef1bca
-  dynamic.linux-d160-m8xlarge-arm64.max-instances: "20"
-  dynamic.linux-d160-m8xlarge-arm64.subnet-id: subnet-07a8bbf633e2bb187
+  dynamic.linux-d160-m8xlarge-arm64.max-instances: "5"
+  dynamic.linux-d160-m8xlarge-arm64.subnet-id: subnet-02ca0b0e3e0a76caf
   dynamic.linux-d160-m8xlarge-arm64.disk: "160"
 
   dynamic.linux-c6gd2xlarge-arm64.type: aws
@@ -177,8 +177,8 @@ data:
   dynamic.linux-c6gd2xlarge-arm64.aws-secret: aws-account
   dynamic.linux-c6gd2xlarge-arm64.ssh-secret: aws-ssh-key
   dynamic.linux-c6gd2xlarge-arm64.security-group-id: sg-004ef1b7bc3ef1bca
-  dynamic.linux-c6gd2xlarge-arm64.max-instances: "20"
-  dynamic.linux-c6gd2xlarge-arm64.subnet-id: subnet-07a8bbf633e2bb187
+  dynamic.linux-c6gd2xlarge-arm64.max-instances: "5"
+  dynamic.linux-c6gd2xlarge-arm64.subnet-id: subnet-02ca0b0e3e0a76caf
   dynamic.linux-c6gd2xlarge-arm64.user-data: |-
     Content-Type: multipart/mixed; boundary="//"
     MIME-Version: 1.0
@@ -253,8 +253,8 @@ data:
   dynamic.linux-amd64.aws-secret: aws-account
   dynamic.linux-amd64.ssh-secret: aws-ssh-key
   dynamic.linux-amd64.security-group-id: sg-004ef1b7bc3ef1bca
-  dynamic.linux-amd64.max-instances: "10"
-  dynamic.linux-amd64.subnet-id: subnet-07a8bbf633e2bb187
+  dynamic.linux-amd64.max-instances: "30"
+  dynamic.linux-amd64.subnet-id: subnet-02ca0b0e3e0a76caf
 
   dynamic.linux-mlarge-amd64.type: aws
   dynamic.linux-mlarge-amd64.region: us-east-1
@@ -265,8 +265,8 @@ data:
   dynamic.linux-mlarge-amd64.aws-secret: aws-account
   dynamic.linux-mlarge-amd64.ssh-secret: aws-ssh-key
   dynamic.linux-mlarge-amd64.security-group-id: sg-004ef1b7bc3ef1bca
-  dynamic.linux-mlarge-amd64.max-instances: "10"
-  dynamic.linux-mlarge-amd64.subnet-id: subnet-07a8bbf633e2bb187
+  dynamic.linux-mlarge-amd64.max-instances: "5"
+  dynamic.linux-mlarge-amd64.subnet-id: subnet-02ca0b0e3e0a76caf
 
   dynamic.linux-mxlarge-amd64.type: aws
   dynamic.linux-mxlarge-amd64.region: us-east-1
@@ -277,8 +277,8 @@ data:
   dynamic.linux-mxlarge-amd64.aws-secret: aws-account
   dynamic.linux-mxlarge-amd64.ssh-secret: aws-ssh-key
   dynamic.linux-mxlarge-amd64.security-group-id: sg-004ef1b7bc3ef1bca
-  dynamic.linux-mxlarge-amd64.max-instances: "10"
-  dynamic.linux-mxlarge-amd64.subnet-id: subnet-07a8bbf633e2bb187
+  dynamic.linux-mxlarge-amd64.max-instances: "5"
+  dynamic.linux-mxlarge-amd64.subnet-id: subnet-02ca0b0e3e0a76caf
 
   dynamic.linux-m2xlarge-amd64.type: aws
   dynamic.linux-m2xlarge-amd64.region: us-east-1
@@ -289,8 +289,8 @@ data:
   dynamic.linux-m2xlarge-amd64.aws-secret: aws-account
   dynamic.linux-m2xlarge-amd64.ssh-secret: aws-ssh-key
   dynamic.linux-m2xlarge-amd64.security-group-id: sg-004ef1b7bc3ef1bca
-  dynamic.linux-m2xlarge-amd64.max-instances: "10"
-  dynamic.linux-m2xlarge-amd64.subnet-id: subnet-07a8bbf633e2bb187
+  dynamic.linux-m2xlarge-amd64.max-instances: "5"
+  dynamic.linux-m2xlarge-amd64.subnet-id: subnet-02ca0b0e3e0a76caf
 
   dynamic.linux-d160-m2xlarge-amd64.type: aws
   dynamic.linux-d160-m2xlarge-amd64.region: us-east-1
@@ -301,8 +301,8 @@ data:
   dynamic.linux-d160-m2xlarge-amd64.aws-secret: aws-account
   dynamic.linux-d160-m2xlarge-amd64.ssh-secret: aws-ssh-key
   dynamic.linux-d160-m2xlarge-amd64.security-group-id: sg-004ef1b7bc3ef1bca
-  dynamic.linux-d160-m2xlarge-amd64.max-instances: "10"
-  dynamic.linux-d160-m2xlarge-amd64.subnet-id: subnet-07a8bbf633e2bb187
+  dynamic.linux-d160-m2xlarge-amd64.max-instances: "5"
+  dynamic.linux-d160-m2xlarge-amd64.subnet-id: subnet-02ca0b0e3e0a76caf
   dynamic.linux-d160-m2xlarge-amd64.disk: "160"
 
   dynamic.linux-m4xlarge-amd64.type: aws
@@ -314,8 +314,8 @@ data:
   dynamic.linux-m4xlarge-amd64.aws-secret: aws-account
   dynamic.linux-m4xlarge-amd64.ssh-secret: aws-ssh-key
   dynamic.linux-m4xlarge-amd64.security-group-id: sg-004ef1b7bc3ef1bca
-  dynamic.linux-m4xlarge-amd64.max-instances: "10"
-  dynamic.linux-m4xlarge-amd64.subnet-id: subnet-07a8bbf633e2bb187
+  dynamic.linux-m4xlarge-amd64.max-instances: "5"
+  dynamic.linux-m4xlarge-amd64.subnet-id: subnet-02ca0b0e3e0a76caf
 
   dynamic.linux-d160-m4xlarge-amd64.type: aws
   dynamic.linux-d160-m4xlarge-amd64.region: us-east-1
@@ -326,8 +326,8 @@ data:
   dynamic.linux-d160-m4xlarge-amd64.aws-secret: aws-account
   dynamic.linux-d160-m4xlarge-amd64.ssh-secret: aws-ssh-key
   dynamic.linux-d160-m4xlarge-amd64.security-group-id: sg-004ef1b7bc3ef1bca
-  dynamic.linux-d160-m4xlarge-amd64.max-instances: "10"
-  dynamic.linux-d160-m4xlarge-amd64.subnet-id: subnet-07a8bbf633e2bb187
+  dynamic.linux-d160-m4xlarge-amd64.max-instances: "5"
+  dynamic.linux-d160-m4xlarge-amd64.subnet-id: subnet-02ca0b0e3e0a76caf
   dynamic.linux-d160-m4xlarge-amd64.disk: "160"
 
   dynamic.linux-m8xlarge-amd64.type: aws
@@ -339,8 +339,8 @@ data:
   dynamic.linux-m8xlarge-amd64.aws-secret: aws-account
   dynamic.linux-m8xlarge-amd64.ssh-secret: aws-ssh-key
   dynamic.linux-m8xlarge-amd64.security-group-id: sg-004ef1b7bc3ef1bca
-  dynamic.linux-m8xlarge-amd64.max-instances: "10"
-  dynamic.linux-m8xlarge-amd64.subnet-id: subnet-07a8bbf633e2bb187
+  dynamic.linux-m8xlarge-amd64.max-instances: "5"
+  dynamic.linux-m8xlarge-amd64.subnet-id: subnet-02ca0b0e3e0a76caf
 
   dynamic.linux-d160-m8xlarge-amd64.type: aws
   dynamic.linux-d160-m8xlarge-amd64.region: us-east-1
@@ -351,8 +351,8 @@ data:
   dynamic.linux-d160-m8xlarge-amd64.aws-secret: aws-account
   dynamic.linux-d160-m8xlarge-amd64.ssh-secret: aws-ssh-key
   dynamic.linux-d160-m8xlarge-amd64.security-group-id: sg-004ef1b7bc3ef1bca
-  dynamic.linux-d160-m8xlarge-amd64.max-instances: "10"
-  dynamic.linux-d160-m8xlarge-amd64.subnet-id: subnet-07a8bbf633e2bb187
+  dynamic.linux-d160-m8xlarge-amd64.max-instances: "5"
+  dynamic.linux-d160-m8xlarge-amd64.subnet-id: subnet-02ca0b0e3e0a76caf
   dynamic.linux-d160-m8xlarge-amd64.disk: "160"
 
   # cpu:memory (1:2)
@@ -365,8 +365,8 @@ data:
   dynamic.linux-cxlarge-arm64.aws-secret: aws-account
   dynamic.linux-cxlarge-arm64.ssh-secret: aws-ssh-key
   dynamic.linux-cxlarge-arm64.security-group-id: sg-004ef1b7bc3ef1bca
-  dynamic.linux-cxlarge-arm64.max-instances: "50"
-  dynamic.linux-cxlarge-arm64.subnet-id: subnet-07a8bbf633e2bb187
+  dynamic.linux-cxlarge-arm64.max-instances: "5"
+  dynamic.linux-cxlarge-arm64.subnet-id: subnet-02ca0b0e3e0a76caf
 
   dynamic.linux-c2xlarge-arm64.type: aws
   dynamic.linux-c2xlarge-arm64.region: us-east-1
@@ -377,8 +377,8 @@ data:
   dynamic.linux-c2xlarge-arm64.aws-secret: aws-account
   dynamic.linux-c2xlarge-arm64.ssh-secret: aws-ssh-key
   dynamic.linux-c2xlarge-arm64.security-group-id: sg-004ef1b7bc3ef1bca
-  dynamic.linux-c2xlarge-arm64.max-instances: "20"
-  dynamic.linux-c2xlarge-arm64.subnet-id: subnet-07a8bbf633e2bb187
+  dynamic.linux-c2xlarge-arm64.max-instances: "5"
+  dynamic.linux-c2xlarge-arm64.subnet-id: subnet-02ca0b0e3e0a76caf
 
   dynamic.linux-c4xlarge-arm64.type: aws
   dynamic.linux-c4xlarge-arm64.region: us-east-1
@@ -389,8 +389,8 @@ data:
   dynamic.linux-c4xlarge-arm64.aws-secret: aws-account
   dynamic.linux-c4xlarge-arm64.ssh-secret: aws-ssh-key
   dynamic.linux-c4xlarge-arm64.security-group-id: sg-004ef1b7bc3ef1bca
-  dynamic.linux-c4xlarge-arm64.max-instances: "20"
-  dynamic.linux-c4xlarge-arm64.subnet-id: subnet-07a8bbf633e2bb187
+  dynamic.linux-c4xlarge-arm64.max-instances: "5"
+  dynamic.linux-c4xlarge-arm64.subnet-id: subnet-02ca0b0e3e0a76caf
 
   dynamic.linux-c8xlarge-arm64.type: aws
   dynamic.linux-c8xlarge-arm64.region: us-east-1
@@ -401,8 +401,8 @@ data:
   dynamic.linux-c8xlarge-arm64.aws-secret: aws-account
   dynamic.linux-c8xlarge-arm64.ssh-secret: aws-ssh-key
   dynamic.linux-c8xlarge-arm64.security-group-id: sg-004ef1b7bc3ef1bca
-  dynamic.linux-c8xlarge-arm64.max-instances: "20"
-  dynamic.linux-c8xlarge-arm64.subnet-id: subnet-07a8bbf633e2bb187
+  dynamic.linux-c8xlarge-arm64.max-instances: "5"
+  dynamic.linux-c8xlarge-arm64.subnet-id: subnet-02ca0b0e3e0a76caf
 
   dynamic.linux-cxlarge-amd64.type: aws
   dynamic.linux-cxlarge-amd64.region: us-east-1
@@ -413,8 +413,8 @@ data:
   dynamic.linux-cxlarge-amd64.aws-secret: aws-account
   dynamic.linux-cxlarge-amd64.ssh-secret: aws-ssh-key
   dynamic.linux-cxlarge-amd64.security-group-id: sg-004ef1b7bc3ef1bca
-  dynamic.linux-cxlarge-amd64.max-instances: "10"
-  dynamic.linux-cxlarge-amd64.subnet-id: subnet-07a8bbf633e2bb187
+  dynamic.linux-cxlarge-amd64.max-instances: "5"
+  dynamic.linux-cxlarge-amd64.subnet-id: subnet-02ca0b0e3e0a76caf
 
   dynamic.linux-c2xlarge-amd64.type: aws
   dynamic.linux-c2xlarge-amd64.region: us-east-1
@@ -425,8 +425,8 @@ data:
   dynamic.linux-c2xlarge-amd64.aws-secret: aws-account
   dynamic.linux-c2xlarge-amd64.ssh-secret: aws-ssh-key
   dynamic.linux-c2xlarge-amd64.security-group-id: sg-004ef1b7bc3ef1bca
-  dynamic.linux-c2xlarge-amd64.max-instances: "10"
-  dynamic.linux-c2xlarge-amd64.subnet-id: subnet-07a8bbf633e2bb187
+  dynamic.linux-c2xlarge-amd64.max-instances: "5"
+  dynamic.linux-c2xlarge-amd64.subnet-id: subnet-02ca0b0e3e0a76caf
 
   dynamic.linux-c4xlarge-amd64.type: aws
   dynamic.linux-c4xlarge-amd64.region: us-east-1
@@ -437,8 +437,8 @@ data:
   dynamic.linux-c4xlarge-amd64.aws-secret: aws-account
   dynamic.linux-c4xlarge-amd64.ssh-secret: aws-ssh-key
   dynamic.linux-c4xlarge-amd64.security-group-id: sg-004ef1b7bc3ef1bca
-  dynamic.linux-c4xlarge-amd64.max-instances: "10"
-  dynamic.linux-c4xlarge-amd64.subnet-id: subnet-07a8bbf633e2bb187
+  dynamic.linux-c4xlarge-amd64.max-instances: "5"
+  dynamic.linux-c4xlarge-amd64.subnet-id: subnet-02ca0b0e3e0a76caf
 
   dynamic.linux-c8xlarge-amd64.type: aws
   dynamic.linux-c8xlarge-amd64.region: us-east-1
@@ -449,8 +449,8 @@ data:
   dynamic.linux-c8xlarge-amd64.aws-secret: aws-account
   dynamic.linux-c8xlarge-amd64.ssh-secret: aws-ssh-key
   dynamic.linux-c8xlarge-amd64.security-group-id: sg-004ef1b7bc3ef1bca
-  dynamic.linux-c8xlarge-amd64.max-instances: "10"
-  dynamic.linux-c8xlarge-amd64.subnet-id: subnet-07a8bbf633e2bb187
+  dynamic.linux-c8xlarge-amd64.max-instances: "5"
+  dynamic.linux-c8xlarge-amd64.subnet-id: subnet-02ca0b0e3e0a76caf
 
   dynamic.linux-root-arm64.type: aws
   dynamic.linux-root-arm64.region: us-east-1
@@ -461,8 +461,8 @@ data:
   dynamic.linux-root-arm64.aws-secret: aws-account
   dynamic.linux-root-arm64.ssh-secret: aws-ssh-key
   dynamic.linux-root-arm64.security-group-id: sg-004ef1b7bc3ef1bca
-  dynamic.linux-root-arm64.subnet-id: subnet-07a8bbf633e2bb187
-  dynamic.linux-root-arm64.max-instances: "50"
+  dynamic.linux-root-arm64.subnet-id: subnet-02ca0b0e3e0a76caf
+  dynamic.linux-root-arm64.max-instances: "5"
   dynamic.linux-root-arm64.sudo-commands: "/usr/bin/podman, /usr/bin/rm /usr/share/containers/mounts.conf"
   dynamic.linux-root-arm64.disk: "200"
   dynamic.linux-root-arm64.iops: "16000"
@@ -478,8 +478,8 @@ data:
   dynamic.linux-fast-amd64.aws-secret: aws-account
   dynamic.linux-fast-amd64.ssh-secret: aws-ssh-key
   dynamic.linux-fast-amd64.security-group-id: sg-004ef1b7bc3ef1bca
-  dynamic.linux-fast-amd64.subnet-id: subnet-07a8bbf633e2bb187
-  dynamic.linux-fast-amd64.max-instances: "10"
+  dynamic.linux-fast-amd64.subnet-id: subnet-02ca0b0e3e0a76caf
+  dynamic.linux-fast-amd64.max-instances: "5"
   dynamic.linux-fast-amd64.disk: "200"
   #  dynamic.linux-fast-amd64.iops: "16000"
   #  dynamic.linux-fast-amd64.throughput: "1000"
@@ -493,8 +493,8 @@ data:
   dynamic.linux-extra-fast-amd64.aws-secret: aws-account
   dynamic.linux-extra-fast-amd64.ssh-secret: aws-ssh-key
   dynamic.linux-extra-fast-amd64.security-group-id: sg-004ef1b7bc3ef1bca
-  dynamic.linux-extra-fast-amd64.subnet-id: subnet-07a8bbf633e2bb187
-  dynamic.linux-extra-fast-amd64.max-instances: "10"
+  dynamic.linux-extra-fast-amd64.subnet-id: subnet-02ca0b0e3e0a76caf
+  dynamic.linux-extra-fast-amd64.max-instances: "5"
   dynamic.linux-extra-fast-amd64.disk: "200"
   # dynamic.linux-extra-fast-amd64.iops: "16000"
   # dynamic.linux-extra-fast-amd64.throughput: "1000"
@@ -508,8 +508,8 @@ data:
   dynamic.linux-root-amd64.aws-secret: aws-account
   dynamic.linux-root-amd64.ssh-secret: aws-ssh-key
   dynamic.linux-root-amd64.security-group-id: sg-004ef1b7bc3ef1bca
-  dynamic.linux-root-amd64.subnet-id: subnet-07a8bbf633e2bb187
-  dynamic.linux-root-amd64.max-instances: "10"
+  dynamic.linux-root-amd64.subnet-id: subnet-02ca0b0e3e0a76caf
+  dynamic.linux-root-amd64.max-instances: "5"
   dynamic.linux-root-amd64.sudo-commands: "/usr/bin/podman, /usr/bin/rm /usr/share/containers/mounts.conf"
   dynamic.linux-root-amd64.user-data: |-
     Content-Type: multipart/mixed; boundary="//"
@@ -731,8 +731,8 @@ data:
   dynamic.linux-g6xlarge-amd64.aws-secret: aws-account
   dynamic.linux-g6xlarge-amd64.ssh-secret: aws-ssh-key
   dynamic.linux-g6xlarge-amd64.security-group-id: sg-004ef1b7bc3ef1bca
-  dynamic.linux-g6xlarge-amd64.max-instances: "10"
-  dynamic.linux-g6xlarge-amd64.subnet-id: subnet-07a8bbf633e2bb187
+  dynamic.linux-g6xlarge-amd64.max-instances: "5"
+  dynamic.linux-g6xlarge-amd64.subnet-id: subnet-02ca0b0e3e0a76caf
   dynamic.linux-g6xlarge-amd64.instance-tag: prod-amd64-g6xlarge
   dynamic.linux-g6xlarge-amd64.user-data: |-
     Content-Type: multipart/mixed; boundary="//"

--- a/components/multi-platform-controller/production/kflux-prd-rh03/host-config.yaml
+++ b/components/multi-platform-controller/production/kflux-prd-rh03/host-config.yaml
@@ -62,7 +62,7 @@ data:
   dynamic.linux-arm64.aws-secret: aws-account
   dynamic.linux-arm64.ssh-secret: aws-ssh-key
   dynamic.linux-arm64.security-group-id: sg-0759f4a43faada557
-  dynamic.linux-arm64.max-instances: "50"
+  dynamic.linux-arm64.max-instances: "70"
   dynamic.linux-arm64.subnet-id: subnet-0263af86f44821eac
 
   dynamic.linux-mlarge-arm64.type: aws
@@ -74,7 +74,7 @@ data:
   dynamic.linux-mlarge-arm64.aws-secret: aws-account
   dynamic.linux-mlarge-arm64.ssh-secret: aws-ssh-key
   dynamic.linux-mlarge-arm64.security-group-id: sg-0759f4a43faada557
-  dynamic.linux-mlarge-arm64.max-instances: "50"
+  dynamic.linux-mlarge-arm64.max-instances: "5"
   dynamic.linux-mlarge-arm64.subnet-id: subnet-0263af86f44821eac
 
   dynamic.linux-mxlarge-arm64.type: aws
@@ -86,7 +86,7 @@ data:
   dynamic.linux-mxlarge-arm64.aws-secret: aws-account
   dynamic.linux-mxlarge-arm64.ssh-secret: aws-ssh-key
   dynamic.linux-mxlarge-arm64.security-group-id: sg-0759f4a43faada557
-  dynamic.linux-mxlarge-arm64.max-instances: "20"
+  dynamic.linux-mxlarge-arm64.max-instances: "5"
   dynamic.linux-mxlarge-arm64.subnet-id: subnet-0263af86f44821eac
 
   dynamic.linux-m2xlarge-arm64.type: aws
@@ -98,7 +98,7 @@ data:
   dynamic.linux-m2xlarge-arm64.aws-secret: aws-account
   dynamic.linux-m2xlarge-arm64.ssh-secret: aws-ssh-key
   dynamic.linux-m2xlarge-arm64.security-group-id: sg-0759f4a43faada557
-  dynamic.linux-m2xlarge-arm64.max-instances: "20"
+  dynamic.linux-m2xlarge-arm64.max-instances: "5"
   dynamic.linux-m2xlarge-arm64.subnet-id: subnet-0263af86f44821eac
 
   dynamic.linux-d160-m2xlarge-arm64.type: aws
@@ -110,7 +110,7 @@ data:
   dynamic.linux-d160-m2xlarge-arm64.aws-secret: aws-account
   dynamic.linux-d160-m2xlarge-arm64.ssh-secret: aws-ssh-key
   dynamic.linux-d160-m2xlarge-arm64.security-group-id: sg-0759f4a43faada557
-  dynamic.linux-d160-m2xlarge-arm64.max-instances: "20"
+  dynamic.linux-d160-m2xlarge-arm64.max-instances: "5"
   dynamic.linux-d160-m2xlarge-arm64.subnet-id: subnet-0263af86f44821eac
   dynamic.linux-d160-m2xlarge-arm64.disk: "160"
 
@@ -123,7 +123,7 @@ data:
   dynamic.linux-m4xlarge-arm64.aws-secret: aws-account
   dynamic.linux-m4xlarge-arm64.ssh-secret: aws-ssh-key
   dynamic.linux-m4xlarge-arm64.security-group-id: sg-0759f4a43faada557
-  dynamic.linux-m4xlarge-arm64.max-instances: "20"
+  dynamic.linux-m4xlarge-arm64.max-instances: "5"
   dynamic.linux-m4xlarge-arm64.subnet-id: subnet-0263af86f44821eac
 
   dynamic.linux-m8xlarge-arm64.type: aws
@@ -135,7 +135,7 @@ data:
   dynamic.linux-m8xlarge-arm64.aws-secret: aws-account
   dynamic.linux-m8xlarge-arm64.ssh-secret: aws-ssh-key
   dynamic.linux-m8xlarge-arm64.security-group-id: sg-0759f4a43faada557
-  dynamic.linux-m8xlarge-arm64.max-instances: "20"
+  dynamic.linux-m8xlarge-arm64.max-instances: "5"
   dynamic.linux-m8xlarge-arm64.subnet-id: subnet-0263af86f44821eac
 
   dynamic.linux-c6gd2xlarge-arm64.type: aws
@@ -147,7 +147,7 @@ data:
   dynamic.linux-c6gd2xlarge-arm64.aws-secret: aws-account
   dynamic.linux-c6gd2xlarge-arm64.ssh-secret: aws-ssh-key
   dynamic.linux-c6gd2xlarge-arm64.security-group-id: sg-0759f4a43faada557
-  dynamic.linux-c6gd2xlarge-arm64.max-instances: "20"
+  dynamic.linux-c6gd2xlarge-arm64.max-instances: "5"
   dynamic.linux-c6gd2xlarge-arm64.subnet-id: subnet-0263af86f44821eac
   dynamic.linux-c6gd2xlarge-arm64.user-data: |-
     Content-Type: multipart/mixed; boundary="//"
@@ -223,7 +223,7 @@ data:
   dynamic.linux-amd64.aws-secret: aws-account
   dynamic.linux-amd64.ssh-secret: aws-ssh-key
   dynamic.linux-amd64.security-group-id: sg-0759f4a43faada557
-  dynamic.linux-amd64.max-instances: "50"
+  dynamic.linux-amd64.max-instances: "30"
   dynamic.linux-amd64.subnet-id: subnet-0263af86f44821eac
 
   dynamic.linux-mlarge-amd64.type: aws
@@ -235,7 +235,7 @@ data:
   dynamic.linux-mlarge-amd64.aws-secret: aws-account
   dynamic.linux-mlarge-amd64.ssh-secret: aws-ssh-key
   dynamic.linux-mlarge-amd64.security-group-id: sg-0759f4a43faada557
-  dynamic.linux-mlarge-amd64.max-instances: "50"
+  dynamic.linux-mlarge-amd64.max-instances: "5"
   dynamic.linux-mlarge-amd64.subnet-id: subnet-0263af86f44821eac
 
   dynamic.linux-mxlarge-amd64.type: aws
@@ -247,7 +247,7 @@ data:
   dynamic.linux-mxlarge-amd64.aws-secret: aws-account
   dynamic.linux-mxlarge-amd64.ssh-secret: aws-ssh-key
   dynamic.linux-mxlarge-amd64.security-group-id: sg-0759f4a43faada557
-  dynamic.linux-mxlarge-amd64.max-instances: "20"
+  dynamic.linux-mxlarge-amd64.max-instances: "5"
   dynamic.linux-mxlarge-amd64.subnet-id: subnet-0263af86f44821eac
 
   dynamic.linux-m2xlarge-amd64.type: aws
@@ -259,7 +259,7 @@ data:
   dynamic.linux-m2xlarge-amd64.aws-secret: aws-account
   dynamic.linux-m2xlarge-amd64.ssh-secret: aws-ssh-key
   dynamic.linux-m2xlarge-amd64.security-group-id: sg-0759f4a43faada557
-  dynamic.linux-m2xlarge-amd64.max-instances: "20"
+  dynamic.linux-m2xlarge-amd64.max-instances: "5"
   dynamic.linux-m2xlarge-amd64.subnet-id: subnet-0263af86f44821eac
 
   dynamic.linux-d160-m2xlarge-amd64.type: aws
@@ -271,7 +271,7 @@ data:
   dynamic.linux-d160-m2xlarge-amd64.aws-secret: aws-account
   dynamic.linux-d160-m2xlarge-amd64.ssh-secret: aws-ssh-key
   dynamic.linux-d160-m2xlarge-amd64.security-group-id: sg-0759f4a43faada557
-  dynamic.linux-d160-m2xlarge-amd64.max-instances: "20"
+  dynamic.linux-d160-m2xlarge-amd64.max-instances: "5"
   dynamic.linux-d160-m2xlarge-amd64.subnet-id: subnet-0263af86f44821eac
   dynamic.linux-d160-m2xlarge-amd64.disk: "160"
 
@@ -284,7 +284,7 @@ data:
   dynamic.linux-m4xlarge-amd64.aws-secret: aws-account
   dynamic.linux-m4xlarge-amd64.ssh-secret: aws-ssh-key
   dynamic.linux-m4xlarge-amd64.security-group-id: sg-0759f4a43faada557
-  dynamic.linux-m4xlarge-amd64.max-instances: "20"
+  dynamic.linux-m4xlarge-amd64.max-instances: "5"
   dynamic.linux-m4xlarge-amd64.subnet-id: subnet-0263af86f44821eac
 
   dynamic.linux-m8xlarge-amd64.type: aws
@@ -296,7 +296,7 @@ data:
   dynamic.linux-m8xlarge-amd64.aws-secret: aws-account
   dynamic.linux-m8xlarge-amd64.ssh-secret: aws-ssh-key
   dynamic.linux-m8xlarge-amd64.security-group-id: sg-0759f4a43faada557
-  dynamic.linux-m8xlarge-amd64.max-instances: "20"
+  dynamic.linux-m8xlarge-amd64.max-instances: "5"
   dynamic.linux-m8xlarge-amd64.subnet-id: subnet-0263af86f44821eac
 
   # cpu:memory (1:2)
@@ -309,7 +309,7 @@ data:
   dynamic.linux-cxlarge-arm64.aws-secret: aws-account
   dynamic.linux-cxlarge-arm64.ssh-secret: aws-ssh-key
   dynamic.linux-cxlarge-arm64.security-group-id: sg-0759f4a43faada557
-  dynamic.linux-cxlarge-arm64.max-instances: "50"
+  dynamic.linux-cxlarge-arm64.max-instances: "5"
   dynamic.linux-cxlarge-arm64.subnet-id: subnet-0263af86f44821eac
 
   dynamic.linux-c2xlarge-arm64.type: aws
@@ -321,7 +321,7 @@ data:
   dynamic.linux-c2xlarge-arm64.aws-secret: aws-account
   dynamic.linux-c2xlarge-arm64.ssh-secret: aws-ssh-key
   dynamic.linux-c2xlarge-arm64.security-group-id: sg-0759f4a43faada557
-  dynamic.linux-c2xlarge-arm64.max-instances: "20"
+  dynamic.linux-c2xlarge-arm64.max-instances: "5"
   dynamic.linux-c2xlarge-arm64.subnet-id: subnet-0263af86f44821eac
 
   dynamic.linux-c4xlarge-arm64.type: aws
@@ -333,7 +333,7 @@ data:
   dynamic.linux-c4xlarge-arm64.aws-secret: aws-account
   dynamic.linux-c4xlarge-arm64.ssh-secret: aws-ssh-key
   dynamic.linux-c4xlarge-arm64.security-group-id: sg-0759f4a43faada557
-  dynamic.linux-c4xlarge-arm64.max-instances: "20"
+  dynamic.linux-c4xlarge-arm64.max-instances: "5"
   dynamic.linux-c4xlarge-arm64.subnet-id: subnet-0263af86f44821eac
 
   dynamic.linux-c8xlarge-arm64.type: aws
@@ -345,7 +345,7 @@ data:
   dynamic.linux-c8xlarge-arm64.aws-secret: aws-account
   dynamic.linux-c8xlarge-arm64.ssh-secret: aws-ssh-key
   dynamic.linux-c8xlarge-arm64.security-group-id: sg-0759f4a43faada557
-  dynamic.linux-c8xlarge-arm64.max-instances: "20"
+  dynamic.linux-c8xlarge-arm64.max-instances: "5"
   dynamic.linux-c8xlarge-arm64.subnet-id: subnet-0263af86f44821eac
 
   dynamic.linux-cxlarge-amd64.type: aws
@@ -357,7 +357,7 @@ data:
   dynamic.linux-cxlarge-amd64.aws-secret: aws-account
   dynamic.linux-cxlarge-amd64.ssh-secret: aws-ssh-key
   dynamic.linux-cxlarge-amd64.security-group-id: sg-0759f4a43faada557
-  dynamic.linux-cxlarge-amd64.max-instances: "10"
+  dynamic.linux-cxlarge-amd64.max-instances: "5"
   dynamic.linux-cxlarge-amd64.subnet-id: subnet-0263af86f44821eac
 
   dynamic.linux-c2xlarge-amd64.type: aws
@@ -369,7 +369,7 @@ data:
   dynamic.linux-c2xlarge-amd64.aws-secret: aws-account
   dynamic.linux-c2xlarge-amd64.ssh-secret: aws-ssh-key
   dynamic.linux-c2xlarge-amd64.security-group-id: sg-0759f4a43faada557
-  dynamic.linux-c2xlarge-amd64.max-instances: "10"
+  dynamic.linux-c2xlarge-amd64.max-instances: "5"
   dynamic.linux-c2xlarge-amd64.subnet-id: subnet-0263af86f44821eac
 
   dynamic.linux-c4xlarge-amd64.type: aws
@@ -381,7 +381,7 @@ data:
   dynamic.linux-c4xlarge-amd64.aws-secret: aws-account
   dynamic.linux-c4xlarge-amd64.ssh-secret: aws-ssh-key
   dynamic.linux-c4xlarge-amd64.security-group-id: sg-0759f4a43faada557
-  dynamic.linux-c4xlarge-amd64.max-instances: "10"
+  dynamic.linux-c4xlarge-amd64.max-instances: "5"
   dynamic.linux-c4xlarge-amd64.subnet-id: subnet-0263af86f44821eac
 
   dynamic.linux-c8xlarge-amd64.type: aws
@@ -393,7 +393,7 @@ data:
   dynamic.linux-c8xlarge-amd64.aws-secret: aws-account
   dynamic.linux-c8xlarge-amd64.ssh-secret: aws-ssh-key
   dynamic.linux-c8xlarge-amd64.security-group-id: sg-0759f4a43faada557
-  dynamic.linux-c8xlarge-amd64.max-instances: "10"
+  dynamic.linux-c8xlarge-amd64.max-instances: "5"
   dynamic.linux-c8xlarge-amd64.subnet-id: subnet-0263af86f44821eac
 
   dynamic.linux-root-arm64.type: aws
@@ -406,7 +406,7 @@ data:
   dynamic.linux-root-arm64.ssh-secret: aws-ssh-key
   dynamic.linux-root-arm64.security-group-id: sg-0759f4a43faada557
   dynamic.linux-root-arm64.subnet-id: subnet-0263af86f44821eac
-  dynamic.linux-root-arm64.max-instances: "50"
+  dynamic.linux-root-arm64.max-instances: "5"
   dynamic.linux-root-arm64.sudo-commands: "/usr/bin/podman, /usr/bin/rm /usr/share/containers/mounts.conf"
   dynamic.linux-root-arm64.disk: "200"
   dynamic.linux-root-arm64.iops: "16000"
@@ -423,7 +423,7 @@ data:
   dynamic.linux-fast-amd64.ssh-secret: aws-ssh-key
   dynamic.linux-fast-amd64.security-group-id: sg-0759f4a43faada557
   dynamic.linux-fast-amd64.subnet-id: subnet-0263af86f44821eac
-  dynamic.linux-fast-amd64.max-instances: "10"
+  dynamic.linux-fast-amd64.max-instances: "5"
   dynamic.linux-fast-amd64.disk: "200"
   #  dynamic.linux-fast-amd64.iops: "16000"
   #  dynamic.linux-fast-amd64.throughput: "1000"
@@ -438,7 +438,7 @@ data:
   dynamic.linux-extra-fast-amd64.ssh-secret: aws-ssh-key
   dynamic.linux-extra-fast-amd64.security-group-id: sg-0759f4a43faada557
   dynamic.linux-extra-fast-amd64.subnet-id: subnet-0263af86f44821eac
-  dynamic.linux-extra-fast-amd64.max-instances: "10"
+  dynamic.linux-extra-fast-amd64.max-instances: "5"
   dynamic.linux-extra-fast-amd64.disk: "200"
   # dynamic.linux-extra-fast-amd64.iops: "16000"
   # dynamic.linux-extra-fast-amd64.throughput: "1000"
@@ -453,7 +453,7 @@ data:
   dynamic.linux-root-amd64.ssh-secret: aws-ssh-key
   dynamic.linux-root-amd64.security-group-id: sg-0759f4a43faada557
   dynamic.linux-root-amd64.subnet-id: subnet-0263af86f44821eac
-  dynamic.linux-root-amd64.max-instances: "10"
+  dynamic.linux-root-amd64.max-instances: "5"
   dynamic.linux-root-amd64.sudo-commands: "/usr/bin/podman, /usr/bin/rm /usr/share/containers/mounts.conf"
   dynamic.linux-root-amd64.user-data: |-
     Content-Type: multipart/mixed; boundary="//"
@@ -663,7 +663,7 @@ data:
   dynamic.linux-g6xlarge-amd64.aws-secret: aws-account
   dynamic.linux-g6xlarge-amd64.ssh-secret: aws-ssh-key
   dynamic.linux-g6xlarge-amd64.security-group-id: sg-0759f4a43faada557
-  dynamic.linux-g6xlarge-amd64.max-instances: "10"
+  dynamic.linux-g6xlarge-amd64.max-instances: "5"
   dynamic.linux-g6xlarge-amd64.subnet-id: subnet-0263af86f44821eac
   dynamic.linux-g6xlarge-amd64.instance-tag: prod-amd64-g6xlarge
   dynamic.linux-g6xlarge-amd64.user-data: |-

--- a/components/multi-platform-controller/production/stone-prd-rh01/host-config.yaml
+++ b/components/multi-platform-controller/production/stone-prd-rh01/host-config.yaml
@@ -66,7 +66,7 @@ data:
   dynamic.linux-arm64.aws-secret: aws-account
   dynamic.linux-arm64.ssh-secret: aws-ssh-key
   dynamic.linux-arm64.security-group-id: sg-0fbf35ced0d59fd4a
-  dynamic.linux-arm64.max-instances: "50"
+  dynamic.linux-arm64.max-instances: "70"
   dynamic.linux-arm64.subnet-id: subnet-0c39ff75f819abfc5
 
   dynamic.linux-mlarge-arm64.type: aws
@@ -78,7 +78,7 @@ data:
   dynamic.linux-mlarge-arm64.aws-secret: aws-account
   dynamic.linux-mlarge-arm64.ssh-secret: aws-ssh-key
   dynamic.linux-mlarge-arm64.security-group-id: sg-0fbf35ced0d59fd4a
-  dynamic.linux-mlarge-arm64.max-instances: "50"
+  dynamic.linux-mlarge-arm64.max-instances: "5"
   dynamic.linux-mlarge-arm64.subnet-id: subnet-0c39ff75f819abfc5
 
   dynamic.linux-mxlarge-arm64.type: aws
@@ -90,7 +90,7 @@ data:
   dynamic.linux-mxlarge-arm64.aws-secret: aws-account
   dynamic.linux-mxlarge-arm64.ssh-secret: aws-ssh-key
   dynamic.linux-mxlarge-arm64.security-group-id: sg-0fbf35ced0d59fd4a
-  dynamic.linux-mxlarge-arm64.max-instances: "20"
+  dynamic.linux-mxlarge-arm64.max-instances: "5"
   dynamic.linux-mxlarge-arm64.subnet-id: subnet-0c39ff75f819abfc5
 
   dynamic.linux-m2xlarge-arm64.type: aws
@@ -102,7 +102,7 @@ data:
   dynamic.linux-m2xlarge-arm64.aws-secret: aws-account
   dynamic.linux-m2xlarge-arm64.ssh-secret: aws-ssh-key
   dynamic.linux-m2xlarge-arm64.security-group-id: sg-0fbf35ced0d59fd4a
-  dynamic.linux-m2xlarge-arm64.max-instances: "20"
+  dynamic.linux-m2xlarge-arm64.max-instances: "5"
   dynamic.linux-m2xlarge-arm64.subnet-id: subnet-0c39ff75f819abfc5
 
   dynamic.linux-d160-m2xlarge-arm64.type: aws
@@ -114,7 +114,7 @@ data:
   dynamic.linux-d160-m2xlarge-arm64.aws-secret: aws-account
   dynamic.linux-d160-m2xlarge-arm64.ssh-secret: aws-ssh-key
   dynamic.linux-d160-m2xlarge-arm64.security-group-id: sg-0fbf35ced0d59fd4a
-  dynamic.linux-d160-m2xlarge-arm64.max-instances: "20"
+  dynamic.linux-d160-m2xlarge-arm64.max-instances: "5"
   dynamic.linux-d160-m2xlarge-arm64.subnet-id: subnet-0c39ff75f819abfc5
   dynamic.linux-d160-m2xlarge-arm64.disk: "160"
 
@@ -127,7 +127,7 @@ data:
   dynamic.linux-m4xlarge-arm64.aws-secret: aws-account
   dynamic.linux-m4xlarge-arm64.ssh-secret: aws-ssh-key
   dynamic.linux-m4xlarge-arm64.security-group-id: sg-0fbf35ced0d59fd4a
-  dynamic.linux-m4xlarge-arm64.max-instances: "20"
+  dynamic.linux-m4xlarge-arm64.max-instances: "5"
   dynamic.linux-m4xlarge-arm64.subnet-id: subnet-0c39ff75f819abfc5
 
   dynamic.linux-m8xlarge-arm64.type: aws
@@ -139,7 +139,7 @@ data:
   dynamic.linux-m8xlarge-arm64.aws-secret: aws-account
   dynamic.linux-m8xlarge-arm64.ssh-secret: aws-ssh-key
   dynamic.linux-m8xlarge-arm64.security-group-id: sg-0fbf35ced0d59fd4a
-  dynamic.linux-m8xlarge-arm64.max-instances: "20"
+  dynamic.linux-m8xlarge-arm64.max-instances: "5"
   dynamic.linux-m8xlarge-arm64.subnet-id: subnet-0c39ff75f819abfc5
 
   dynamic.linux-d160-m8xlarge-arm64.type: aws
@@ -151,7 +151,7 @@ data:
   dynamic.linux-d160-m8xlarge-arm64.aws-secret: aws-account
   dynamic.linux-d160-m8xlarge-arm64.ssh-secret: aws-ssh-key
   dynamic.linux-d160-m8xlarge-arm64.security-group-id: sg-0fbf35ced0d59fd4a
-  dynamic.linux-d160-m8xlarge-arm64.max-instances: "20"
+  dynamic.linux-d160-m8xlarge-arm64.max-instances: "5"
   dynamic.linux-d160-m8xlarge-arm64.subnet-id: subnet-0c39ff75f819abfc5
   dynamic.linux-d160-m8xlarge-arm64.disk: "160"
 
@@ -164,7 +164,7 @@ data:
   dynamic.linux-c6gd2xlarge-arm64.aws-secret: aws-account
   dynamic.linux-c6gd2xlarge-arm64.ssh-secret: aws-ssh-key
   dynamic.linux-c6gd2xlarge-arm64.security-group-id: sg-0fbf35ced0d59fd4a
-  dynamic.linux-c6gd2xlarge-arm64.max-instances: "20"
+  dynamic.linux-c6gd2xlarge-arm64.max-instances: "5"
   dynamic.linux-c6gd2xlarge-arm64.subnet-id: subnet-0c39ff75f819abfc5
   dynamic.linux-c6gd2xlarge-arm64.user-data: |-
     Content-Type: multipart/mixed; boundary="//"
@@ -241,7 +241,7 @@ data:
   dynamic.linux-d160-m4xlarge-arm64.aws-secret: aws-account
   dynamic.linux-d160-m4xlarge-arm64.ssh-secret: aws-ssh-key
   dynamic.linux-d160-m4xlarge-arm64.security-group-id: sg-0fbf35ced0d59fd4a
-  dynamic.linux-d160-m4xlarge-arm64.max-instances: "20"
+  dynamic.linux-d160-m4xlarge-arm64.max-instances: "5"
   dynamic.linux-d160-m4xlarge-arm64.subnet-id: subnet-0c39ff75f819abfc5
   dynamic.linux-d160-m4xlarge-arm64.allocation-timeout: "1200"
   dynamic.linux-d160-m4xlarge-arm64.disk: "160"
@@ -255,7 +255,7 @@ data:
   dynamic.linux-amd64.aws-secret: aws-account
   dynamic.linux-amd64.ssh-secret: aws-ssh-key
   dynamic.linux-amd64.security-group-id: sg-0fbf35ced0d59fd4a
-  dynamic.linux-amd64.max-instances: "50"
+  dynamic.linux-amd64.max-instances: "30"
   dynamic.linux-amd64.subnet-id: subnet-0c39ff75f819abfc5
 
   dynamic.linux-mlarge-amd64.type: aws
@@ -267,7 +267,7 @@ data:
   dynamic.linux-mlarge-amd64.aws-secret: aws-account
   dynamic.linux-mlarge-amd64.ssh-secret: aws-ssh-key
   dynamic.linux-mlarge-amd64.security-group-id: sg-0fbf35ced0d59fd4a
-  dynamic.linux-mlarge-amd64.max-instances: "10"
+  dynamic.linux-mlarge-amd64.max-instances: "5"
   dynamic.linux-mlarge-amd64.subnet-id: subnet-0c39ff75f819abfc5
 
   dynamic.linux-mxlarge-amd64.type: aws
@@ -279,7 +279,7 @@ data:
   dynamic.linux-mxlarge-amd64.aws-secret: aws-account
   dynamic.linux-mxlarge-amd64.ssh-secret: aws-ssh-key
   dynamic.linux-mxlarge-amd64.security-group-id: sg-0fbf35ced0d59fd4a
-  dynamic.linux-mxlarge-amd64.max-instances: "10"
+  dynamic.linux-mxlarge-amd64.max-instances: "5"
   dynamic.linux-mxlarge-amd64.subnet-id: subnet-0c39ff75f819abfc5
 
   dynamic.linux-m2xlarge-amd64.type: aws
@@ -291,7 +291,7 @@ data:
   dynamic.linux-m2xlarge-amd64.aws-secret: aws-account
   dynamic.linux-m2xlarge-amd64.ssh-secret: aws-ssh-key
   dynamic.linux-m2xlarge-amd64.security-group-id: sg-0fbf35ced0d59fd4a
-  dynamic.linux-m2xlarge-amd64.max-instances: "10"
+  dynamic.linux-m2xlarge-amd64.max-instances: "5"
   dynamic.linux-m2xlarge-amd64.subnet-id: subnet-0c39ff75f819abfc5
 
   dynamic.linux-d160-m2xlarge-amd64.type: aws
@@ -303,7 +303,7 @@ data:
   dynamic.linux-d160-m2xlarge-amd64.aws-secret: aws-account
   dynamic.linux-d160-m2xlarge-amd64.ssh-secret: aws-ssh-key
   dynamic.linux-d160-m2xlarge-amd64.security-group-id: sg-0fbf35ced0d59fd4a
-  dynamic.linux-d160-m2xlarge-amd64.max-instances: "10"
+  dynamic.linux-d160-m2xlarge-amd64.max-instances: "5"
   dynamic.linux-d160-m2xlarge-amd64.subnet-id: subnet-0c39ff75f819abfc5
   dynamic.linux-d160-m2xlarge-amd64.disk: "160"
 
@@ -316,7 +316,7 @@ data:
   dynamic.linux-m4xlarge-amd64.aws-secret: aws-account
   dynamic.linux-m4xlarge-amd64.ssh-secret: aws-ssh-key
   dynamic.linux-m4xlarge-amd64.security-group-id: sg-0fbf35ced0d59fd4a
-  dynamic.linux-m4xlarge-amd64.max-instances: "10"
+  dynamic.linux-m4xlarge-amd64.max-instances: "5"
   dynamic.linux-m4xlarge-amd64.subnet-id: subnet-0c39ff75f819abfc5
 
   # same as m4xlarge-amd64 bug 160G disk
@@ -329,7 +329,7 @@ data:
   dynamic.linux-d160-m4xlarge-amd64.aws-secret: aws-account
   dynamic.linux-d160-m4xlarge-amd64.ssh-secret: aws-ssh-key
   dynamic.linux-d160-m4xlarge-amd64.security-group-id: sg-0fbf35ced0d59fd4a
-  dynamic.linux-d160-m4xlarge-amd64.max-instances: "10"
+  dynamic.linux-d160-m4xlarge-amd64.max-instances: "5"
   dynamic.linux-d160-m4xlarge-amd64.subnet-id: subnet-0c39ff75f819abfc5
   dynamic.linux-d160-m4xlarge-amd64.allocation-timeout: "1200"
   dynamic.linux-d160-m4xlarge-amd64.disk: "160"
@@ -343,7 +343,7 @@ data:
   dynamic.linux-m8xlarge-amd64.aws-secret: aws-account
   dynamic.linux-m8xlarge-amd64.ssh-secret: aws-ssh-key
   dynamic.linux-m8xlarge-amd64.security-group-id: sg-0fbf35ced0d59fd4a
-  dynamic.linux-m8xlarge-amd64.max-instances: "10"
+  dynamic.linux-m8xlarge-amd64.max-instances: "5"
   dynamic.linux-m8xlarge-amd64.subnet-id: subnet-0c39ff75f819abfc5
 
   dynamic.linux-d160-m8xlarge-amd64.type: aws
@@ -355,7 +355,7 @@ data:
   dynamic.linux-d160-m8xlarge-amd64.aws-secret: aws-account
   dynamic.linux-d160-m8xlarge-amd64.ssh-secret: aws-ssh-key
   dynamic.linux-d160-m8xlarge-amd64.security-group-id: sg-0fbf35ced0d59fd4a
-  dynamic.linux-d160-m8xlarge-amd64.max-instances: "10"
+  dynamic.linux-d160-m8xlarge-amd64.max-instances: "5"
   dynamic.linux-d160-m8xlarge-amd64.subnet-id: subnet-0c39ff75f819abfc5
   dynamic.linux-d160-m8xlarge-amd64.disk: "160"
 
@@ -369,7 +369,7 @@ data:
   dynamic.linux-cxlarge-arm64.aws-secret: aws-account
   dynamic.linux-cxlarge-arm64.ssh-secret: aws-ssh-key
   dynamic.linux-cxlarge-arm64.security-group-id: sg-0fbf35ced0d59fd4a
-  dynamic.linux-cxlarge-arm64.max-instances: "50"
+  dynamic.linux-cxlarge-arm64.max-instances: "5"
   dynamic.linux-cxlarge-arm64.subnet-id: subnet-0c39ff75f819abfc5
 
   dynamic.linux-c2xlarge-arm64.type: aws
@@ -381,7 +381,7 @@ data:
   dynamic.linux-c2xlarge-arm64.aws-secret: aws-account
   dynamic.linux-c2xlarge-arm64.ssh-secret: aws-ssh-key
   dynamic.linux-c2xlarge-arm64.security-group-id: sg-0fbf35ced0d59fd4a
-  dynamic.linux-c2xlarge-arm64.max-instances: "20"
+  dynamic.linux-c2xlarge-arm64.max-instances: "5"
   dynamic.linux-c2xlarge-arm64.subnet-id: subnet-0c39ff75f819abfc5
 
   dynamic.linux-c4xlarge-arm64.type: aws
@@ -393,7 +393,7 @@ data:
   dynamic.linux-c4xlarge-arm64.aws-secret: aws-account
   dynamic.linux-c4xlarge-arm64.ssh-secret: aws-ssh-key
   dynamic.linux-c4xlarge-arm64.security-group-id: sg-0fbf35ced0d59fd4a
-  dynamic.linux-c4xlarge-arm64.max-instances: "20"
+  dynamic.linux-c4xlarge-arm64.max-instances: "5"
   dynamic.linux-c4xlarge-arm64.subnet-id: subnet-0c39ff75f819abfc5
 
   dynamic.linux-c8xlarge-arm64.type: aws
@@ -405,7 +405,7 @@ data:
   dynamic.linux-c8xlarge-arm64.aws-secret: aws-account
   dynamic.linux-c8xlarge-arm64.ssh-secret: aws-ssh-key
   dynamic.linux-c8xlarge-arm64.security-group-id: sg-0fbf35ced0d59fd4a
-  dynamic.linux-c8xlarge-arm64.max-instances: "20"
+  dynamic.linux-c8xlarge-arm64.max-instances: "5"
   dynamic.linux-c8xlarge-arm64.subnet-id: subnet-0c39ff75f819abfc5
 
   dynamic.linux-cxlarge-amd64.type: aws
@@ -417,7 +417,7 @@ data:
   dynamic.linux-cxlarge-amd64.aws-secret: aws-account
   dynamic.linux-cxlarge-amd64.ssh-secret: aws-ssh-key
   dynamic.linux-cxlarge-amd64.security-group-id: sg-0fbf35ced0d59fd4a
-  dynamic.linux-cxlarge-amd64.max-instances: "10"
+  dynamic.linux-cxlarge-amd64.max-instances: "5"
   dynamic.linux-cxlarge-amd64.subnet-id: subnet-0c39ff75f819abfc5
 
   dynamic.linux-c2xlarge-amd64.type: aws
@@ -429,7 +429,7 @@ data:
   dynamic.linux-c2xlarge-amd64.aws-secret: aws-account
   dynamic.linux-c2xlarge-amd64.ssh-secret: aws-ssh-key
   dynamic.linux-c2xlarge-amd64.security-group-id: sg-0fbf35ced0d59fd4a
-  dynamic.linux-c2xlarge-amd64.max-instances: "10"
+  dynamic.linux-c2xlarge-amd64.max-instances: "5"
   dynamic.linux-c2xlarge-amd64.subnet-id: subnet-0c39ff75f819abfc5
 
   dynamic.linux-c4xlarge-amd64.type: aws
@@ -441,7 +441,7 @@ data:
   dynamic.linux-c4xlarge-amd64.aws-secret: aws-account
   dynamic.linux-c4xlarge-amd64.ssh-secret: aws-ssh-key
   dynamic.linux-c4xlarge-amd64.security-group-id: sg-0fbf35ced0d59fd4a
-  dynamic.linux-c4xlarge-amd64.max-instances: "10"
+  dynamic.linux-c4xlarge-amd64.max-instances: "5"
   dynamic.linux-c4xlarge-amd64.subnet-id: subnet-0c39ff75f819abfc5
 
   dynamic.linux-c8xlarge-amd64.type: aws
@@ -453,7 +453,7 @@ data:
   dynamic.linux-c8xlarge-amd64.aws-secret: aws-account
   dynamic.linux-c8xlarge-amd64.ssh-secret: aws-ssh-key
   dynamic.linux-c8xlarge-amd64.security-group-id: sg-0fbf35ced0d59fd4a
-  dynamic.linux-c8xlarge-amd64.max-instances: "10"
+  dynamic.linux-c8xlarge-amd64.max-instances: "5"
   dynamic.linux-c8xlarge-amd64.subnet-id: subnet-0c39ff75f819abfc5
 
   dynamic.linux-root-arm64.type: aws
@@ -466,7 +466,7 @@ data:
   dynamic.linux-root-arm64.ssh-secret: aws-ssh-key
   dynamic.linux-root-arm64.security-group-id: sg-0fbf35ced0d59fd4a
   dynamic.linux-root-arm64.subnet-id: subnet-0c39ff75f819abfc5
-  dynamic.linux-root-arm64.max-instances: "50"
+  dynamic.linux-root-arm64.max-instances: "5"
   dynamic.linux-root-arm64.sudo-commands: "/usr/bin/podman, /usr/bin/rm /usr/share/containers/mounts.conf"
   dynamic.linux-root-arm64.disk: "200"
   dynamic.linux-root-arm64.iops: "16000"
@@ -483,7 +483,7 @@ data:
   dynamic.linux-fast-amd64.ssh-secret: aws-ssh-key
   dynamic.linux-fast-amd64.security-group-id: sg-0fbf35ced0d59fd4a
   dynamic.linux-fast-amd64.subnet-id: subnet-0c39ff75f819abfc5
-  dynamic.linux-fast-amd64.max-instances: "10"
+  dynamic.linux-fast-amd64.max-instances: "5"
   dynamic.linux-fast-amd64.disk: "200"
   #  dynamic.linux-fast-amd64.iops: "16000"
   #  dynamic.linux-fast-amd64.throughput: "1000"
@@ -498,7 +498,7 @@ data:
   dynamic.linux-extra-fast-amd64.ssh-secret: aws-ssh-key
   dynamic.linux-extra-fast-amd64.security-group-id: sg-0fbf35ced0d59fd4a
   dynamic.linux-extra-fast-amd64.subnet-id: subnet-0c39ff75f819abfc5
-  dynamic.linux-extra-fast-amd64.max-instances: "10"
+  dynamic.linux-extra-fast-amd64.max-instances: "5"
   dynamic.linux-extra-fast-amd64.disk: "200"
   # dynamic.linux-extra-fast-amd64.iops: "16000"
   # dynamic.linux-extra-fast-amd64.throughput: "1000"
@@ -513,7 +513,7 @@ data:
   dynamic.linux-root-amd64.ssh-secret: aws-ssh-key
   dynamic.linux-root-amd64.security-group-id: sg-0fbf35ced0d59fd4a
   dynamic.linux-root-amd64.subnet-id: subnet-0c39ff75f819abfc5
-  dynamic.linux-root-amd64.max-instances: "10"
+  dynamic.linux-root-amd64.max-instances: "5"
   dynamic.linux-root-amd64.sudo-commands: "/usr/bin/podman, /usr/bin/rm /usr/share/containers/mounts.conf"
   dynamic.linux-root-amd64.user-data: |-
     Content-Type: multipart/mixed; boundary="//"
@@ -729,7 +729,7 @@ data:
   dynamic.linux-g6xlarge-amd64.aws-secret: aws-account
   dynamic.linux-g6xlarge-amd64.ssh-secret: aws-ssh-key
   dynamic.linux-g6xlarge-amd64.security-group-id: sg-0fbf35ced0d59fd4a
-  dynamic.linux-g6xlarge-amd64.max-instances: "10"
+  dynamic.linux-g6xlarge-amd64.max-instances: "5"
   dynamic.linux-g6xlarge-amd64.subnet-id: subnet-0c39ff75f819abfc5
   dynamic.linux-g6xlarge-amd64.instance-tag: prod-amd64-g6xlarge
   dynamic.linux-g6xlarge-amd64.user-data: |-


### PR DESCRIPTION
This commit will change the max-instance for all the platforms specified in host-config making sure allowed number of instances do not exceed 250 instances.