### PR TITLE
add pulp-access-controller component to public prod

### DIFF
--- a/argo-cd-apps/overlays/konflux-public-production/delete-applications.yaml
+++ b/argo-cd-apps/overlays/konflux-public-production/delete-applications.yaml
@@ -22,12 +22,6 @@ $patch: delete
 apiVersion: argoproj.io/v1alpha1
 kind: ApplicationSet
 metadata:
-  name: pulp-access-controller
-$patch: delete
----
-apiVersion: argoproj.io/v1alpha1
-kind: ApplicationSet
-metadata:
   name: cert-manager
 $patch: delete
 ---


### PR DESCRIPTION
It appears that pulp should be in all clusters, not just the internal clusters.  It's already in the staging clusters and internal production, but we didn't remove the deletion patch from the public production overlays in #6561.

Remove the deletion patch so that pulp is deployed to the public production clusters.

Fixes: fbef70802 ("pulp to production (#6561)")