### PR TITLE
Set GIT_SSL_CAINFO env on Pipeline resolvers prod

### DIFF
--- a/components/pipeline-service/production/base/main-pipeline-service-configuration.yaml
+++ b/components/pipeline-service/production/base/main-pipeline-service-configuration.yaml
@@ -1915,6 +1915,9 @@ spec:
               spec:
                 containers:
                   - name: controller
+                    env:
+                      - name: GIT_SSL_CAINFO
+                        value: /tekton-custom-certs/ca-bundle.crt
                     resources:
                       limits:
                         memory: 10Gi
@@ -2052,7 +2055,7 @@ metadata:
   namespace: openshift-marketplace
 spec:
   displayName: custom-operators
-  image: quay.io/openshift-pipeline/pipelines-index-4.15@sha256:1ad7bfa236b620db80afbc07261cb25d7024e41333bf9716e2b9d943b04c12a2
+  image: quay.io/openshift-pipeline/pipelines-index-4.15@sha256:6788ffeab369f7a773d7022358f67cd93d094003c3b6c82e3278f620e9065135
   sourceType: grpc
   updateStrategy:
     registryPoll:
@@ -2075,6 +2078,8 @@ spec:
     env:
       - name: AUTOINSTALL_COMPONENTS
         value: "false"
+      - name: IMAGE_ADDONS_TKN_CLI_SERVE
+        value: registry.redhat.io/openshift-pipelines/pipelines-serve-tkn-cli-rhel9@sha256:d055d2b35a663aef3e1aafdbed0b12957867c0670c946ebae66e9c44a768bda2
 ---
 apiVersion: route.openshift.io/v1
 kind: Route

--- a/components/pipeline-service/production/kflux-ocp-p01/deploy.yaml
+++ b/components/pipeline-service/production/kflux-ocp-p01/deploy.yaml
@@ -2421,7 +2421,10 @@ spec:
             template:
               spec:
                 containers:
-                - name: controller
+                - env:
+                  - name: GIT_SSL_CAINFO
+                    value: /tekton-custom-certs/ca-bundle.crt
+                  name: controller
                   resources:
                     limits:
                       memory: 10Gi
@@ -2513,7 +2516,7 @@ metadata:
   namespace: openshift-marketplace
 spec:
   displayName: custom-operators
-  image: quay.io/openshift-pipeline/pipelines-index-4.15@sha256:1ad7bfa236b620db80afbc07261cb25d7024e41333bf9716e2b9d943b04c12a2
+  image: quay.io/openshift-pipeline/pipelines-index-4.15@sha256:6788ffeab369f7a773d7022358f67cd93d094003c3b6c82e3278f620e9065135
   sourceType: grpc
   updateStrategy:
     registryPoll:
@@ -2533,6 +2536,8 @@ spec:
     env:
     - name: AUTOINSTALL_COMPONENTS
       value: "false"
+    - name: IMAGE_ADDONS_TKN_CLI_SERVE
+      value: registry.redhat.io/openshift-pipelines/pipelines-serve-tkn-cli-rhel9@sha256:d055d2b35a663aef3e1aafdbed0b12957867c0670c946ebae66e9c44a768bda2
   name: openshift-pipelines-operator-rh
   source: custom-operators
   sourceNamespace: openshift-marketplace

--- a/components/pipeline-service/production/kflux-osp-p01/deploy.yaml
+++ b/components/pipeline-service/production/kflux-osp-p01/deploy.yaml
@@ -2452,7 +2452,10 @@ spec:
             template:
               spec:
                 containers:
-                - name: controller
+                - env:
+                  - name: GIT_SSL_CAINFO
+                    value: /tekton-custom-certs/ca-bundle.crt
+                  name: controller
                   resources:
                     limits:
                       memory: 10Gi
@@ -2544,7 +2547,7 @@ metadata:
   namespace: openshift-marketplace
 spec:
   displayName: custom-operators
-  image: quay.io/openshift-pipeline/pipelines-index-4.15@sha256:1ad7bfa236b620db80afbc07261cb25d7024e41333bf9716e2b9d943b04c12a2
+  image: quay.io/openshift-pipeline/pipelines-index-4.15@sha256:6788ffeab369f7a773d7022358f67cd93d094003c3b6c82e3278f620e9065135
   sourceType: grpc
   updateStrategy:
     registryPoll:
@@ -2564,6 +2567,8 @@ spec:
     env:
     - name: AUTOINSTALL_COMPONENTS
       value: "false"
+    - name: IMAGE_ADDONS_TKN_CLI_SERVE
+      value: registry.redhat.io/openshift-pipelines/pipelines-serve-tkn-cli-rhel9@sha256:d055d2b35a663aef3e1aafdbed0b12957867c0670c946ebae66e9c44a768bda2
   name: openshift-pipelines-operator-rh
   source: custom-operators
   sourceNamespace: openshift-marketplace

--- a/components/pipeline-service/production/kflux-prd-rh02/deploy.yaml
+++ b/components/pipeline-service/production/kflux-prd-rh02/deploy.yaml
@@ -2452,7 +2452,10 @@ spec:
             template:
               spec:
                 containers:
-                - name: controller
+                - env:
+                  - name: GIT_SSL_CAINFO
+                    value: /tekton-custom-certs/ca-bundle.crt
+                  name: controller
                   resources:
                     limits:
                       memory: 10Gi
@@ -2544,7 +2547,7 @@ metadata:
   namespace: openshift-marketplace
 spec:
   displayName: custom-operators
-  image: quay.io/openshift-pipeline/pipelines-index-4.15@sha256:1ad7bfa236b620db80afbc07261cb25d7024e41333bf9716e2b9d943b04c12a2
+  image: quay.io/openshift-pipeline/pipelines-index-4.15@sha256:6788ffeab369f7a773d7022358f67cd93d094003c3b6c82e3278f620e9065135
   sourceType: grpc
   updateStrategy:
     registryPoll:
@@ -2564,6 +2567,8 @@ spec:
     env:
     - name: AUTOINSTALL_COMPONENTS
       value: "false"
+    - name: IMAGE_ADDONS_TKN_CLI_SERVE
+      value: registry.redhat.io/openshift-pipelines/pipelines-serve-tkn-cli-rhel9@sha256:d055d2b35a663aef3e1aafdbed0b12957867c0670c946ebae66e9c44a768bda2
     - name: IMAGE_PIPELINES_PROXY
       value: quay.io/openshift-pipeline/pipelines-operator-proxy-rhel9@sha256:e37a2b061eff6984f8d341825e5989e459de4125322e33480ac01dce5a57c801
   name: openshift-pipelines-operator-rh

--- a/components/pipeline-service/production/kflux-prd-rh03/deploy.yaml
+++ b/components/pipeline-service/production/kflux-prd-rh03/deploy.yaml
@@ -2452,7 +2452,10 @@ spec:
             template:
               spec:
                 containers:
-                - name: controller
+                - env:
+                  - name: GIT_SSL_CAINFO
+                    value: /tekton-custom-certs/ca-bundle.crt
+                  name: controller
                   resources:
                     limits:
                       memory: 10Gi
@@ -2544,7 +2547,7 @@ metadata:
   namespace: openshift-marketplace
 spec:
   displayName: custom-operators
-  image: quay.io/openshift-pipeline/pipelines-index-4.15@sha256:1ad7bfa236b620db80afbc07261cb25d7024e41333bf9716e2b9d943b04c12a2
+  image: quay.io/openshift-pipeline/pipelines-index-4.15@sha256:6788ffeab369f7a773d7022358f67cd93d094003c3b6c82e3278f620e9065135
   sourceType: grpc
   updateStrategy:
     registryPoll:
@@ -2564,6 +2567,8 @@ spec:
     env:
     - name: AUTOINSTALL_COMPONENTS
       value: "false"
+    - name: IMAGE_ADDONS_TKN_CLI_SERVE
+      value: registry.redhat.io/openshift-pipelines/pipelines-serve-tkn-cli-rhel9@sha256:d055d2b35a663aef3e1aafdbed0b12957867c0670c946ebae66e9c44a768bda2
   name: openshift-pipelines-operator-rh
   source: custom-operators
   sourceNamespace: openshift-marketplace

--- a/components/pipeline-service/production/kflux-rhel-p01/deploy.yaml
+++ b/components/pipeline-service/production/kflux-rhel-p01/deploy.yaml
@@ -2452,7 +2452,10 @@ spec:
             template:
               spec:
                 containers:
-                - name: controller
+                - env:
+                  - name: GIT_SSL_CAINFO
+                    value: /tekton-custom-certs/ca-bundle.crt
+                  name: controller
                   resources:
                     limits:
                       memory: 10Gi
@@ -2545,7 +2548,7 @@ metadata:
   namespace: openshift-marketplace
 spec:
   displayName: custom-operators
-  image: quay.io/openshift-pipeline/pipelines-index-4.15@sha256:1ad7bfa236b620db80afbc07261cb25d7024e41333bf9716e2b9d943b04c12a2
+  image: quay.io/openshift-pipeline/pipelines-index-4.15@sha256:6788ffeab369f7a773d7022358f67cd93d094003c3b6c82e3278f620e9065135
   sourceType: grpc
   updateStrategy:
     registryPoll:
@@ -2565,6 +2568,8 @@ spec:
     env:
     - name: AUTOINSTALL_COMPONENTS
       value: "false"
+    - name: IMAGE_ADDONS_TKN_CLI_SERVE
+      value: registry.redhat.io/openshift-pipelines/pipelines-serve-tkn-cli-rhel9@sha256:d055d2b35a663aef3e1aafdbed0b12957867c0670c946ebae66e9c44a768bda2
   name: openshift-pipelines-operator-rh
   source: custom-operators
   sourceNamespace: openshift-marketplace

--- a/components/pipeline-service/production/stone-prd-rh01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prd-rh01/deploy.yaml
@@ -2421,7 +2421,10 @@ spec:
             template:
               spec:
                 containers:
-                - name: controller
+                - env:
+                  - name: GIT_SSL_CAINFO
+                    value: /tekton-custom-certs/ca-bundle.crt
+                  name: controller
                   resources:
                     limits:
                       memory: 10Gi
@@ -2514,7 +2517,7 @@ metadata:
   namespace: openshift-marketplace
 spec:
   displayName: custom-operators
-  image: quay.io/openshift-pipeline/pipelines-index-4.15@sha256:1ad7bfa236b620db80afbc07261cb25d7024e41333bf9716e2b9d943b04c12a2
+  image: quay.io/openshift-pipeline/pipelines-index-4.15@sha256:6788ffeab369f7a773d7022358f67cd93d094003c3b6c82e3278f620e9065135
   sourceType: grpc
   updateStrategy:
     registryPoll:
@@ -2534,6 +2537,8 @@ spec:
     env:
     - name: AUTOINSTALL_COMPONENTS
       value: "false"
+    - name: IMAGE_ADDONS_TKN_CLI_SERVE
+      value: registry.redhat.io/openshift-pipelines/pipelines-serve-tkn-cli-rhel9@sha256:d055d2b35a663aef3e1aafdbed0b12957867c0670c946ebae66e9c44a768bda2
   name: openshift-pipelines-operator-rh
   source: custom-operators
   sourceNamespace: openshift-marketplace

--- a/components/pipeline-service/production/stone-prod-p01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prod-p01/deploy.yaml
@@ -2421,7 +2421,10 @@ spec:
             template:
               spec:
                 containers:
-                - name: controller
+                - env:
+                  - name: GIT_SSL_CAINFO
+                    value: /tekton-custom-certs/ca-bundle.crt
+                  name: controller
                   resources:
                     limits:
                       memory: 10Gi
@@ -2514,7 +2517,7 @@ metadata:
   namespace: openshift-marketplace
 spec:
   displayName: custom-operators
-  image: quay.io/openshift-pipeline/pipelines-index-4.15@sha256:1ad7bfa236b620db80afbc07261cb25d7024e41333bf9716e2b9d943b04c12a2
+  image: quay.io/openshift-pipeline/pipelines-index-4.15@sha256:6788ffeab369f7a773d7022358f67cd93d094003c3b6c82e3278f620e9065135
   sourceType: grpc
   updateStrategy:
     registryPoll:
@@ -2534,6 +2537,8 @@ spec:
     env:
     - name: AUTOINSTALL_COMPONENTS
       value: "false"
+    - name: IMAGE_ADDONS_TKN_CLI_SERVE
+      value: registry.redhat.io/openshift-pipelines/pipelines-serve-tkn-cli-rhel9@sha256:d055d2b35a663aef3e1aafdbed0b12957867c0670c946ebae66e9c44a768bda2
   name: openshift-pipelines-operator-rh
   source: custom-operators
   sourceNamespace: openshift-marketplace

--- a/components/pipeline-service/production/stone-prod-p02/deploy.yaml
+++ b/components/pipeline-service/production/stone-prod-p02/deploy.yaml
@@ -2421,7 +2421,10 @@ spec:
             template:
               spec:
                 containers:
-                - name: controller
+                - env:
+                  - name: GIT_SSL_CAINFO
+                    value: /tekton-custom-certs/ca-bundle.crt
+                  name: controller
                   resources:
                     limits:
                       memory: 10Gi
@@ -2514,7 +2517,7 @@ metadata:
   namespace: openshift-marketplace
 spec:
   displayName: custom-operators
-  image: quay.io/openshift-pipeline/pipelines-index-4.15@sha256:1ad7bfa236b620db80afbc07261cb25d7024e41333bf9716e2b9d943b04c12a2
+  image: quay.io/openshift-pipeline/pipelines-index-4.15@sha256:6788ffeab369f7a773d7022358f67cd93d094003c3b6c82e3278f620e9065135
   sourceType: grpc
   updateStrategy:
     registryPoll:
@@ -2534,6 +2537,8 @@ spec:
     env:
     - name: AUTOINSTALL_COMPONENTS
       value: "false"
+    - name: IMAGE_ADDONS_TKN_CLI_SERVE
+      value: registry.redhat.io/openshift-pipelines/pipelines-serve-tkn-cli-rhel9@sha256:d055d2b35a663aef3e1aafdbed0b12957867c0670c946ebae66e9c44a768bda2
   name: openshift-pipelines-operator-rh
   source: custom-operators
   sourceNamespace: openshift-marketplace


### PR DESCRIPTION
Also override the tkn-cli-serve image, as the image ref is broken in that latest release. tkn-cli-serveis not used anyway, so this should have no impact.