### PR TITLE
fix: adding rbac needed to run tests

### DIFF
--- a/components/konflux-ci/base/kustomization.yaml
+++ b/components/konflux-ci/base/kustomization.yaml
@@ -6,6 +6,8 @@ resources:
 - appstudio-pipelines-runner-rolebinding.yaml
 - pod-logs-reader-role.yaml
 - pod-logs-reader-rolebinding.yaml
+- test-runner-cluster-role.yaml
+- test-runner-rolebinding.yaml
 
 # Skip applying the Tekton/PaC operands while the Tekton/PaC operator is being installed.
 # See more information about this option, here: 

--- a/components/konflux-ci/base/test-runner-cluster-role.yaml
+++ b/components/konflux-ci/base/test-runner-cluster-role.yaml
@@ -1,0 +1,8 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: test-runner
+rules:
+- apiGroups: ["appstudio.redhat.com"]
+  resources: ["imagerepositories"]
+  verbs: ["get", "list", "watch"]

--- a/components/konflux-ci/base/test-runner-rolebinding.yaml
+++ b/components/konflux-ci/base/test-runner-rolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: test-runner-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: test-runner
+subjects:
+- kind: ServiceAccount
+  name: appstudio-pipeline
+  namespace: konflux-ci


### PR DESCRIPTION
After moving test execution to rh03 cluster, appstudio-pipeline sa missing permission to get image-repositories causing the tests to fail, adding the needed ClusterRole and RoleBiding. 