### PR TITLE
Disable MintMaker runs on Saturday

### DIFF
--- a/components/mintmaker/base/cronjobs/create-dependency-update-check.yaml
+++ b/components/mintmaker/base/cronjobs/create-dependency-update-check.yaml
@@ -4,7 +4,7 @@ metadata:
   name: create-dependencyupdatecheck
   namespace: mintmaker
 spec:
-  schedule: "0 */4 * * *" # every 4 hours
+  schedule: "0 */4 * * 0-5" # every 4 hours, except on Saturdays
   jobTemplate:
     spec:
       template:


### PR DESCRIPTION
Tekton manager, which runs on Saturdays is currently broken, so we should skip its run on the upcoming Saturday. This change disables MintMaker from running during the entire day.

This solution was chosen because it's safer than doing a hasty prod deployment.