### PR TITLE
feat: add the konflux-banner-configmap as parts of  konflux-public-info

### DIFF
--- a/components/konflux-info/base/rbac.yaml
+++ b/components/konflux-info/base/rbac.yaml
@@ -10,6 +10,7 @@ rules:
       - ''
     resourceNames:
       - konflux-public-info
+      - konflux-banner-configmap
     resources:
       - configmaps
 ---


### PR DESCRIPTION
It is for: 
https://issues.redhat.com/browse/KFLUXUI-587

PR details:
It is just one-line-change PR to ensure the konflux-banner-configmap is public as part of konflux-public-info