### PR TITLE
Deploy RPM enabled kanary exporter to prod

### DIFF
--- a/components/monitoring/kanary/production/stone-prod-p02/kustomization.yaml
+++ b/components/monitoring/kanary/production/stone-prod-p02/kustomization.yaml
@@ -2,12 +2,12 @@ resources:
   - ../base
   - rbac
   - external-secrets
-  - https://github.com/redhat-appstudio/o11y/config/exporters/monitoring/kanary/base?ref=4dfdc1adbb50d1adf1b697cc2b1c421c7f597edd
+  - https://github.com/redhat-appstudio/o11y/config/exporters/monitoring/kanary/base?ref=2298ef09366b02015c31f90050576bce26356552
 
 images:
   - name: quay.io/redhat-appstudio/o11y
     newName: quay.io/redhat-appstudio/o11y
-    newTag: 4dfdc1adbb50d1adf1b697cc2b1c421c7f597edd
+    newTag: 2298ef09366b02015c31f90050576bce26356552
 
 patches:
   - path: kanary-db-credentials-secret-path.yaml


### PR DESCRIPTION
This is done after the kanary exporter was deployed to stage and working successfully

Issue: [PVO11Y-4837](https://issues.redhat.com/browse/PVO11Y-4837)