### PR TITLE
disable cost-management policy in staging

### DIFF
--- a/components/policies/staging/base/kustomization.yaml
+++ b/components/policies/staging/base/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- cost-management
+# - cost-management
 - integration
 - konflux-rbac
 - ../empty-base


### PR DESCRIPTION
We see errors while fetching data for the APICall.
Temporarily disabling this ClusterPolicy.

Signed-off-by: Francesco Ilario <filario@redhat.com>
