### PR TITLE
restrict update event integration policy

### DIFF
--- a/components/policies/development/integration/bootstrap-namespace/.chainsaw-test/chainsaw-test.yaml
+++ b/components/policies/development/integration/bootstrap-namespace/.chainsaw-test/chainsaw-test.yaml
@@ -130,6 +130,7 @@ spec:
   - name: then-serviceaccount-is-created
     try:
     - assert:
+        timeout: 180s
         file: resources/expected-integration-serviceaccount.yaml
         template: true
   - name: then-rolebinding-is-created
@@ -172,6 +173,144 @@ spec:
         file: ../bootstrap-namespace.yaml
     - assert:
         file: chainsaw-assert-clusterpolicy.yaml
+  - name: then-serviceaccount-is-not-created
+    try:
+    - delete:
+        file: resources/expected-integration-serviceaccount.yaml
+        template: true
+        expect:
+        - check:
+            ($error != null): true
+  - name: then-rolebinding-is-not-created
+    try:
+    - delete:
+        file: resources/expected-integration-rolebinding.yaml
+        template: true
+        expect:
+        - check:
+            ($error != null): true
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: mutate-existing-namespace-unlabeled-to-labeled
+spec:
+  description: |
+    tests that the ServiceAccount and RoleBinding are created in an
+    existing unlabeled namespace when it is labeled
+  concurrent: false
+  namespace: 'generate-existing-namespace'
+  bindings:
+  - name: suffix
+    value: to-labeled
+  steps:
+  - name: given-konflux-integration-runner-clusterrole-exists
+    try:
+    - apply:
+        file: resources/actual-konflux-integration-runner-clusterrole.yaml
+  - name: given-kyverno-has-permission-on-resources
+    try:
+    - apply:
+        file: ../kyverno-rbac.yaml
+  - name: given-unlabeled-namespace-is-created
+    try:
+    - apply:
+        file: resources/actual-namespace-unlabeled.yaml
+        template: true
+  - name: given-cluster-policy-is-ready
+    try:
+    - apply:
+        file: ../bootstrap-namespace.yaml
+    - assert:
+        file: chainsaw-assert-clusterpolicy.yaml
+  - name: given-serviceaccount-is-not-created
+    try:
+    - delete:
+        file: resources/expected-integration-serviceaccount.yaml
+        template: true
+        expect:
+        - check:
+            ($error != null): true
+  - name: given-rolebinding-is-not-created
+    try:
+    - delete:
+        file: resources/expected-integration-rolebinding.yaml
+        template: true
+        expect:
+        - check:
+            ($error != null): true
+  - name: when-konfluxci-namespace-is-labeled-namespace
+    try:
+    - apply:
+        file: resources/actual-namespace-konfluxcidev.yaml
+        template: true
+  - name: then-serviceaccount-is-created
+    try:
+    - assert:
+        file: resources/expected-integration-serviceaccount.yaml
+        template: true
+  - name: then-rolebinding-is-created
+    try:
+    - assert:
+        file: resources/expected-integration-rolebinding.yaml
+        template: true
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: mutate-existing-namespace-unlabeled-to-unlabeled
+spec:
+  description: |
+    tests that the ServiceAccount and RoleBinding are not created in an
+    existing unlabeled namespace when it is updated but still found unlabeled
+  concurrent: false
+  namespace: 'generate-existing-namespace'
+  bindings:
+  - name: suffix
+    value: to-unlabeled
+  steps:
+  - name: given-konflux-integration-runner-clusterrole-exists
+    try:
+    - apply:
+        file: resources/actual-konflux-integration-runner-clusterrole.yaml
+  - name: given-kyverno-has-permission-on-resources
+    try:
+    - apply:
+        file: ../kyverno-rbac.yaml
+  - name: given-unlabeled-namespace-is-created
+    try:
+    - apply:
+        file: resources/actual-namespace-unlabeled.yaml
+        template: true
+  - name: given-cluster-policy-is-ready
+    try:
+    - apply:
+        file: ../bootstrap-namespace.yaml
+    - assert:
+        file: chainsaw-assert-clusterpolicy.yaml
+  - name: given-serviceaccount-is-not-created
+    try:
+    - delete:
+        file: resources/expected-integration-serviceaccount.yaml
+        template: true
+        expect:
+        - check:
+            ($error != null): true
+  - name: given-rolebinding-is-not-created
+    try:
+    - delete:
+        file: resources/expected-integration-rolebinding.yaml
+        template: true
+        expect:
+        - check:
+            ($error != null): true
+  - name: when-konfluxci-namespace-is-updated-to-unlabeled-namespace
+    try:
+    - apply:
+        file: resources/actual-namespace-unlabeled-extra.yaml
+        template: true
   - name: then-serviceaccount-is-not-created
     try:
     - delete:

--- a/components/policies/development/integration/bootstrap-namespace/.chainsaw-test/resources/actual-namespace-unlabeled-extra.yaml
+++ b/components/policies/development/integration/bootstrap-namespace/.chainsaw-test/resources/actual-namespace-unlabeled-extra.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: (join('-', [$namespace, $suffix]))
+  labels:
+    mylabel: extra

--- a/components/policies/development/integration/bootstrap-namespace/bootstrap-namespace.yaml
+++ b/components/policies/development/integration/bootstrap-namespace/bootstrap-namespace.yaml
@@ -19,6 +19,9 @@ spec:
           selector:
             matchLabels:
               konflux-ci.dev/type: tenant
+    celPreconditions:
+    - name: "on update, oldObject had no konflux-ci.dev/type=tenant label"
+      expression: "request.operation != UPDATE || ! (has(oldObject.metadata.labels) && 'konflux-ci.dev/type' in oldObject.metadata.labels && oldObject.metadata.labels['konflux-ci.dev/type] == 'tenant')"
     generate:
       generateExisting: true
       synchronize: false
@@ -36,6 +39,9 @@ spec:
           selector:
             matchLabels:
               konflux-ci.dev/type: tenant
+    celPreconditions:
+    - name: "on update, oldObject had no konflux-ci.dev/type=tenant label"
+      expression: "request.operation != UPDATE || ! (has(oldObject.metadata.labels) && 'konflux-ci.dev/type' in oldObject.metadata.labels && oldObject.metadata.labels['konflux-ci.dev/type] == 'tenant')"
     generate:
       generateExisting: true
       synchronize: false

--- a/components/policies/development/integration/kustomization.yaml
+++ b/components/policies/development/integration/kustomization.yaml
@@ -2,3 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - bootstrap-namespace
+namePrefix: integration-


### PR DESCRIPTION
this PR will deploy the updated version of the  integration ClusterPolicy by recreating it with a different name and at the same time add a name prefix to the component's owned resources.

Requires

* [x] #7349
