### PR TITLE
KONFLUX-134: Cancel in-progress PipelineRuns for updated pull requests (prod)

### DIFF
--- a/components/pipeline-service/production/base/update-tekton-config-pac.yaml
+++ b/components/pipeline-service/production/base/update-tekton-config-pac.yaml
@@ -9,3 +9,4 @@
     custom-console-url-pr-tasklog: https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/{{ namespace }}/pipelinerun/{{ pr }}/logs/{{ task }}
     remember-ok-to-test: "false"
     secret-github-app-token-scoped: "false"
+    enable-cancel-in-progress-on-pull-requests: "true"

--- a/components/pipeline-service/production/kflux-ocp-p01/deploy.yaml
+++ b/components/pipeline-service/production/kflux-ocp-p01/deploy.yaml
@@ -2459,7 +2459,9 @@ spec:
             namespace }}/pipelinerun/{{ pr }}
           custom-console-url-pr-tasklog: https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/{{
             namespace }}/pipelinerun/{{ pr }}/logs/{{ task }}
+          remember-ok-to-test: "false"
           secret-github-app-token-scoped: "false"
+          enable-cancel-in-progress-on-pull-requests: "true"
   profile: all
   pruner:
     disabled: false

--- a/components/pipeline-service/production/kflux-ocp-p01/resources/update-tekton-config-pac.yaml
+++ b/components/pipeline-service/production/kflux-ocp-p01/resources/update-tekton-config-pac.yaml
@@ -7,4 +7,6 @@
     custom-console-url: https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com
     custom-console-url-pr-details: https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/{{ namespace }}/pipelinerun/{{ pr }}
     custom-console-url-pr-tasklog: https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/{{ namespace }}/pipelinerun/{{ pr }}/logs/{{ task }}
+    remember-ok-to-test: "false"
     secret-github-app-token-scoped: "false"
+    enable-cancel-in-progress-on-pull-requests: "true"

--- a/components/pipeline-service/production/kflux-osp-p01/deploy.yaml
+++ b/components/pipeline-service/production/kflux-osp-p01/deploy.yaml
@@ -2491,6 +2491,8 @@ spec:
           custom-console-url-pr-tasklog: https://konflux-ui.apps.kflux-osp-p01.yt45.p1.openshiftapps.com/ns/{{
             namespace }}/pipelinerun/{{ pr }}/logs/{{ task }}
           remember-ok-to-test: "false"
+          secret-github-app-token-scoped: "false"
+          enable-cancel-in-progress-on-pull-requests: "true"
   profile: all
   pruner:
     disabled: false

--- a/components/pipeline-service/production/kflux-osp-p01/resources/update-tekton-config-pac.yaml
+++ b/components/pipeline-service/production/kflux-osp-p01/resources/update-tekton-config-pac.yaml
@@ -8,3 +8,5 @@
     custom-console-url-pr-details: https://konflux-ui.apps.kflux-osp-p01.yt45.p1.openshiftapps.com/ns/{{ namespace }}/pipelinerun/{{ pr }}
     custom-console-url-pr-tasklog: https://konflux-ui.apps.kflux-osp-p01.yt45.p1.openshiftapps.com/ns/{{ namespace }}/pipelinerun/{{ pr }}/logs/{{ task }}
     remember-ok-to-test: "false"
+    secret-github-app-token-scoped: "false"
+    enable-cancel-in-progress-on-pull-requests: "true"

--- a/components/pipeline-service/production/kflux-prd-rh02/deploy.yaml
+++ b/components/pipeline-service/production/kflux-prd-rh02/deploy.yaml
@@ -2490,7 +2490,9 @@ spec:
             namespace }}/pipelinerun/{{ pr }}
           custom-console-url-pr-tasklog: https://konflux-ui.apps.kflux-prd-rh02.0fk9.p1.openshiftapps.com/ns/{{
             namespace }}/pipelinerun/{{ pr }}/logs/{{ task }}
+          remember-ok-to-test: "false"
           secret-github-app-token-scoped: "false"
+          enable-cancel-in-progress-on-pull-requests: "true"
   profile: all
   pruner:
     disabled: false

--- a/components/pipeline-service/production/kflux-prd-rh02/resources/update-tekton-config-pac.yaml
+++ b/components/pipeline-service/production/kflux-prd-rh02/resources/update-tekton-config-pac.yaml
@@ -7,4 +7,6 @@
     custom-console-url: https://konflux-ui.apps.kflux-prd-rh02.0fk9.p1.openshiftapps.com
     custom-console-url-pr-details: https://konflux-ui.apps.kflux-prd-rh02.0fk9.p1.openshiftapps.com/ns/{{ namespace }}/pipelinerun/{{ pr }}
     custom-console-url-pr-tasklog: https://konflux-ui.apps.kflux-prd-rh02.0fk9.p1.openshiftapps.com/ns/{{ namespace }}/pipelinerun/{{ pr }}/logs/{{ task }}
+    remember-ok-to-test: "false"
     secret-github-app-token-scoped: "false"
+    enable-cancel-in-progress-on-pull-requests: "true"

--- a/components/pipeline-service/production/kflux-prd-rh03/deploy.yaml
+++ b/components/pipeline-service/production/kflux-prd-rh03/deploy.yaml
@@ -2490,7 +2490,9 @@ spec:
             namespace }}/pipelinerun/{{ pr }}
           custom-console-url-pr-tasklog: https://konflux-ui.apps.kflux-prd-rh03.nnv1.p1.openshiftapps.com/ns/{{
             namespace }}/pipelinerun/{{ pr }}/logs/{{ task }}
+          remember-ok-to-test: "false"
           secret-github-app-token-scoped: "false"
+          enable-cancel-in-progress-on-pull-requests: "true"
   profile: all
   pruner:
     disabled: false

--- a/components/pipeline-service/production/kflux-prd-rh03/resources/update-tekton-config-pac.yaml
+++ b/components/pipeline-service/production/kflux-prd-rh03/resources/update-tekton-config-pac.yaml
@@ -7,4 +7,6 @@
     custom-console-url: https://konflux-ui.apps.kflux-prd-rh03.nnv1.p1.openshiftapps.com
     custom-console-url-pr-details: https://konflux-ui.apps.kflux-prd-rh03.nnv1.p1.openshiftapps.com/ns/{{ namespace }}/pipelinerun/{{ pr }}
     custom-console-url-pr-tasklog: https://konflux-ui.apps.kflux-prd-rh03.nnv1.p1.openshiftapps.com/ns/{{ namespace }}/pipelinerun/{{ pr }}/logs/{{ task }}
+    remember-ok-to-test: "false"
     secret-github-app-token-scoped: "false"
+    enable-cancel-in-progress-on-pull-requests: "true"

--- a/components/pipeline-service/production/kflux-rhel-p01/deploy.yaml
+++ b/components/pipeline-service/production/kflux-rhel-p01/deploy.yaml
@@ -2492,6 +2492,7 @@ spec:
             namespace }}/pipelinerun/{{ pr }}/logs/{{ task }}
           remember-ok-to-test: "false"
           secret-github-app-token-scoped: "false"
+          enable-cancel-in-progress-on-pull-requests: "true"
   profile: all
   pruner:
     disabled: false

--- a/components/pipeline-service/production/kflux-rhel-p01/resources/update-tekton-config-pac.yaml
+++ b/components/pipeline-service/production/kflux-rhel-p01/resources/update-tekton-config-pac.yaml
@@ -9,3 +9,4 @@
     custom-console-url-pr-tasklog: https://konflux-ui.apps.kflux-rhel-p01.fc38.p1.openshiftapps.com/ns/{{ namespace }}/pipelinerun/{{ pr }}/logs/{{ task }}
     remember-ok-to-test: "false"
     secret-github-app-token-scoped: "false"
+    enable-cancel-in-progress-on-pull-requests: "true"

--- a/components/pipeline-service/production/stone-prd-rh01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prd-rh01/deploy.yaml
@@ -2461,6 +2461,7 @@ spec:
             namespace }}/pipelinerun/{{ pr }}/logs/{{ task }}
           remember-ok-to-test: "false"
           secret-github-app-token-scoped: "false"
+          enable-cancel-in-progress-on-pull-requests: "true"
   profile: all
   pruner:
     disabled: false

--- a/components/pipeline-service/production/stone-prod-p01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prod-p01/deploy.yaml
@@ -2461,6 +2461,7 @@ spec:
             namespace }}/pipelinerun/{{ pr }}/logs/{{ task }}
           remember-ok-to-test: "false"
           secret-github-app-token-scoped: "false"
+          enable-cancel-in-progress-on-pull-requests: "true"
   profile: all
   pruner:
     disabled: false

--- a/components/pipeline-service/production/stone-prod-p01/resources/update-tekton-config-pac.yaml
+++ b/components/pipeline-service/production/stone-prod-p01/resources/update-tekton-config-pac.yaml
@@ -9,3 +9,4 @@
     custom-console-url-pr-tasklog: https://konflux-ui.apps.stone-prod-p01.wcfb.p1.openshiftapps.com/ns/{{ namespace }}/pipelinerun/{{ pr }}/logs/{{ task }}
     remember-ok-to-test: "false"
     secret-github-app-token-scoped: "false"
+    enable-cancel-in-progress-on-pull-requests: "true"

--- a/components/pipeline-service/production/stone-prod-p02/deploy.yaml
+++ b/components/pipeline-service/production/stone-prod-p02/deploy.yaml
@@ -2461,6 +2461,7 @@ spec:
             namespace }}/pipelinerun/{{ pr }}/logs/{{ task }}
           remember-ok-to-test: "false"
           secret-github-app-token-scoped: "false"
+          enable-cancel-in-progress-on-pull-requests: "true"
   profile: all
   pruner:
     disabled: false

--- a/components/pipeline-service/production/stone-prod-p02/resources/update-tekton-config-pac.yaml
+++ b/components/pipeline-service/production/stone-prod-p02/resources/update-tekton-config-pac.yaml
@@ -9,3 +9,4 @@
     custom-console-url-pr-tasklog: https://konflux-ui.apps.stone-prod-p02.hjvn.p1.openshiftapps.com/ns/{{ namespace }}/pipelinerun/{{ pr }}/logs/{{ task }}
     remember-ok-to-test: "false"
     secret-github-app-token-scoped: "false"
+    enable-cancel-in-progress-on-pull-requests: "true"

--- a/components/pipeline-service/staging/stone-stage-p01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stage-p01/deploy.yaml
@@ -2599,9 +2599,9 @@ spec:
             namespace }}/pipelinerun/{{ pr }}
           custom-console-url-pr-tasklog: https://konflux-ui.apps.stone-stage-p01.hpmt.p1.openshiftapps.com/ns/{{
             namespace }}/pipelinerun/{{ pr }}/logs/{{ task }}
-          enable-cancel-in-progress-on-pull-requests: "true"
           remember-ok-to-test: "false"
           secret-github-app-token-scoped: "false"
+          enable-cancel-in-progress-on-pull-requests: "true"
   profile: all
   pruner:
     disabled: true

--- a/components/pipeline-service/staging/stone-stg-rh01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stg-rh01/deploy.yaml
@@ -2611,9 +2611,9 @@ spec:
             namespace }}/pipelinerun/{{ pr }}
           custom-console-url-pr-tasklog: https://konflux-ui.apps.stone-stg-rh01.l2vh.p1.openshiftapps.com/ns/{{
             namespace }}/pipelinerun/{{ pr }}/logs/{{ task }}
-          enable-cancel-in-progress-on-pull-requests: "true"
           remember-ok-to-test: "false"
           secret-github-app-token-scoped: "false"
+          enable-cancel-in-progress-on-pull-requests: "true"
   profile: all
   pruner:
     disabled: true

--- a/hack/new-cluster/templates/pipeline-service/deploy.yaml
+++ b/hack/new-cluster/templates/pipeline-service/deploy.yaml
@@ -2481,6 +2481,9 @@ spec:
 {% endraw %}
           custom-console-url-pr-tasklog: https://konflux-ui.apps.{{ longname }}.openshiftapps.com/ns/{% raw %}{{ namespace }}/pipelinerun/{{ pr }}/logs/{{ task }}
 {% endraw %}
+          remember-ok-to-test: "false"
+          secret-github-app-token-scoped: "false"
+          enable-cancel-in-progress-on-pull-requests: "true"
   profile: all
   pruner:
     disabled: false

--- a/hack/new-cluster/templates/pipeline-service/resources/update-tekton-config-pac.yaml
+++ b/hack/new-cluster/templates/pipeline-service/resources/update-tekton-config-pac.yaml
@@ -10,3 +10,5 @@
     custom-console-url-pr-tasklog: https://konflux-ui.apps.{{ longname }}.openshiftapps.com/ns/{% raw %}{{ namespace }}/pipelinerun/{{ pr }}/logs/{{ task }}
 {% endraw %}
     remember-ok-to-test: "false"
+    secret-github-app-token-scoped: "false"
+    enable-cancel-in-progress-on-pull-requests: "true"


### PR DESCRIPTION
This should reduce some load on the cluster when pull requests are updated over and over again. Earlier unnecessary PipelinesRuns will be cancelled and impose less load.

This was deployed to staging a few weeks ago in https://github.com/redhat-appstudio/infra-deployments/pull/7079. This catches things up in prod.

Additionally, I re-ordered a few settings on different clusters to make them consistent, and updated the hack/new-cluster/templates/ to reflect this change.