### PR TITLE
mintmaker: increase memory limit to prevent OOMKilled

### DIFF
--- a/components/mintmaker/production/base/manager_patch.yaml
+++ b/components/mintmaker/production/base/manager_patch.yaml
@@ -11,7 +11,7 @@ spec:
         resources:
           limits:
             cpu: 500m
-            memory: 5Gi
+            memory: 8Gi
           requests:
             cpu: 100m
-            memory: 5Gi
+            memory: 8Gi


### PR DESCRIPTION
Temporarily increase controller pod memory allocation to address recurring OOMKilled errors when memory usage reaches the current limit.