### PR TITLE
add ability to view pac repositories

### DIFF
--- a/components/release/base/e2e-release-pipeline-resources-role.yaml
+++ b/components/release/base/e2e-release-pipeline-resources-role.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: e2e-release-pipeline-resources-role
+rules:
+- apiGroups:
+  - pipelinesascode.tekton.dev
+  resources:
+  - repositories
+  verbs:
+  - get
+  - list
+  - watch

--- a/components/release/base/kustomization.yaml
+++ b/components/release/base/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - release-service-config-rbac.yaml
   - release-service-configurator-role.yaml
   - release-team.yaml
+  - e2e-release-pipeline-resources-role.yaml
   - cronjobs/
 
 apiVersion: kustomize.config.k8s.io/v1beta1


### PR DESCRIPTION
- The legacy components/authentication/base/everyone-can-view.yaml seemed to include this RBAC.
- it helps users determine if a Repository might point to be deleted secret for example.