### PR TITLE
increase memory for knative-eventing imc-controller

### DIFF
--- a/components/knative-eventing/base/kustomization.yaml
+++ b/components/knative-eventing/base/kustomization.yaml
@@ -43,10 +43,10 @@ patches:
               resources:
                 requests:
                   cpu: 100m
-                  memory: 100Mi
+                  memory: 1Gi
                 limits:
                   cpu: 150m
-                  memory: 320Mi
+                  memory: 1Gi
 
 - patch: |-
     apiVersion: apps/v1


### PR DESCRIPTION
since July 4 it has restarted 44 times. Reason: OOM Killed