### PR TITLE
feat(SPRE-1697) New HTTP Metrics

### DIFF
--- a/components/monitoring/prometheus/base/monitoringstack/monitoringstack.yaml
+++ b/components/monitoring/prometheus/base/monitoringstack/monitoringstack.yaml
@@ -267,6 +267,10 @@ spec:
         - '{__name__="code:apiserver_request_total:rate5m"}'
         - '{__name__="instance:apiserver_request_total:rate5m"}'
         - '{__name__="prometheus_ready"}'
+        - '{__name__="code:http_request_duration_seconds_sum:rate5m"}'
+        - '{__name__="code:http_request_duration_seconds_bucket:rate5m"}'
+        - '{__name__="code:http_requests_total:rate5m"}'
+        - '{__name__="process_cpu_seconds_total", job="apiserver"}'
 
     relabelings:
     # override the target's address by the prometheus-k8s service name.


### PR DESCRIPTION

We are building a generic dashboard to monitor namespaces activity, for which we need to expose metrics to make this possible.
For now we are adding metrics for latency, traffic & errors: 

- code:http_request_duration_seconds_sum:rate5m
- code:http_request_duration_seconds_bucket:rate5m
- code:http_requests_total:rate5m

We will be monitoring cardinality in here, no ensure we are not hitting any limits and to ensure we are not creating lots of time series: [link](https://grafana.app-sre.devshift.net/explore?schemaVersion=1&panes=%7B%22msz%22:%7B%22datasource%22:%22P964F72B5985B1369%22,%22queries%22:%5B%7B%22expr%22:%22sum%20%28prometheus_tsdb_head_series%7Bnamespace%3D%5C%22observatorium-mst-production%5C%22%7D%29%20%2F%203%22,%22format%22:%22time_series%22,%22interval%22:%22%22,%22intervalFactor%22:1,%22legendFormat%22:%22%7B%7Bcode%7D%7D%22,%22refId%22:%22A%22,%22datasource%22:%7B%22type%22:%22prometheus%22,%22uid%22:%22P964F72B5985B1369%22%7D,%22adhocFilters%22:%5B%5D,%22editorMode%22:%22code%22,%22range%22:true,%22instant%22:true%7D,%7B%22refId%22:%22B%22,%22expr%22:%22%22,%22range%22:true,%22instant%22:true,%22datasource%22:%7B%22type%22:%22prometheus%22,%22uid%22:%22P964F72B5985B1369%22%7D%7D%5D,%22range%22:%7B%22from%22:%22now-7d%22,%22to%22:%22now%22%7D%7D%7D&orgId=1 )