### PR TITLE
KubeArchive: enable Kyverno policies

### DIFF
--- a/components/policies/production/kflux-ocp-p01/kustomization.yaml
+++ b/components/policies/production/kflux-ocp-p01/kustomization.yaml
@@ -2,3 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - ../base
+- ../policies/kubearchive/

--- a/components/policies/production/kflux-prd-rh03/kustomization.yaml
+++ b/components/policies/production/kflux-prd-rh03/kustomization.yaml
@@ -2,3 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - ../base
+- ../policies/kubearchive/


### PR DESCRIPTION
I forgot this existed, adding policies to clusters we were installed recently.