### PR TITLE
KFLUXINFRA-2015: Enable newer arm64 instance types (m7g+)

### DIFF
--- a/components/multi-platform-controller/production/kflux-prd-rh03/host-config.yaml
+++ b/components/multi-platform-controller/production/kflux-prd-rh03/host-config.yaml
@@ -26,6 +26,8 @@ data:
     linux-m4xlarge/arm64,\
     linux-m8xlarge/amd64,\
     linux-m8xlarge/arm64,\
+    linux-d160-m8-8xlarge/arm64,\
+    linux-d160-m7-8xlarge/amd64,\
     linux-c6gd2xlarge/arm64,\
     linux-cxlarge/amd64,\
     linux-cxlarge/arm64,\
@@ -139,6 +141,19 @@ data:
   dynamic.linux-m8xlarge-arm64.security-group-id: sg-0759f4a43faada557
   dynamic.linux-m8xlarge-arm64.max-instances: "5"
   dynamic.linux-m8xlarge-arm64.subnet-id: subnet-0263af86f44821eac
+
+  dynamic.linux-d160-m8-8xlarge-arm64.type: aws
+  dynamic.linux-d160-m8-8xlarge-arm64.region: us-east-1
+  dynamic.linux-d160-m8-8xlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-d160-m8-8xlarge-arm64.instance-type: m8g.8xlarge
+  dynamic.linux-d160-m8-8xlarge-arm64.instance-tag: prod-arm64-m8-8xlarge-d160
+  dynamic.linux-d160-m8-8xlarge-arm64.key-name: kflux-prd-rh03-key-pair
+  dynamic.linux-d160-m8-8xlarge-arm64.aws-secret: aws-account
+  dynamic.linux-d160-m8-8xlarge-arm64.ssh-secret: aws-ssh-key
+  dynamic.linux-d160-m8-8xlarge-arm64.security-group-id: sg-0759f4a43faada557
+  dynamic.linux-d160-m8-8xlarge-arm64.max-instances: "5"
+  dynamic.linux-d160-m8-8xlarge-arm64.subnet-id: subnet-0263af86f44821eac
+  dynamic.linux-d160-m8-8xlarge-arm64.disk: "160"
 
   dynamic.linux-c6gd2xlarge-arm64.type: aws
   dynamic.linux-c6gd2xlarge-arm64.region: us-east-1
@@ -300,6 +315,19 @@ data:
   dynamic.linux-m8xlarge-amd64.security-group-id: sg-0759f4a43faada557
   dynamic.linux-m8xlarge-amd64.max-instances: "5"
   dynamic.linux-m8xlarge-amd64.subnet-id: subnet-0263af86f44821eac
+
+  dynamic.linux-d160-m7-8xlarge-amd64.type: aws
+  dynamic.linux-d160-m7-8xlarge-amd64.region: us-east-1
+  dynamic.linux-d160-m7-8xlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-d160-m7-8xlarge-amd64.instance-type: m7a.8xlarge
+  dynamic.linux-d160-m7-8xlarge-amd64.instance-tag: prod-amd64-m7-8xlarge-d160
+  dynamic.linux-d160-m7-8xlarge-amd64.key-name: kflux-prd-rh03-key-pair
+  dynamic.linux-d160-m7-8xlarge-amd64.aws-secret: aws-account
+  dynamic.linux-d160-m7-8xlarge-amd64.ssh-secret: aws-ssh-key
+  dynamic.linux-d160-m7-8xlarge-amd64.security-group-id: sg-0759f4a43faada557
+  dynamic.linux-d160-m7-8xlarge-amd64.max-instances: "5"
+  dynamic.linux-d160-m7-8xlarge-amd64.subnet-id: subnet-0263af86f44821eac
+  dynamic.linux-d160-m7-8xlarge-amd64.disk: "160"
 
   # cpu:memory (1:2)
   dynamic.linux-cxlarge-arm64.type: aws


### PR DESCRIPTION
Add large disk instances of the latest `arm64` and `amd64` instance types available in AWS. These instance types support newer cpu features required to build and test `vllm`. And the higher network and disk performance will accelerate the very resource-intensive `vllm` builds.