### PR TITLE
KubeArchive: keep event_type

### DIFF
--- a/components/monitoring/prometheus/base/monitoringstack/monitoringstack.yaml
+++ b/components/monitoring/prometheus/base/monitoringstack/monitoringstack.yaml
@@ -56,7 +56,7 @@ spec:
           verb|request_kind|tested_cluster|resource_type|exported_job|http_method|\
           http_route|http_status_code|gin_errors|rule_result|rule_execution_cause|\
           policy_name|policy_background_mode|rule_type|policy_type|policy_validation_mode|\
-          resource_request_operation|resource_kind|policy_change_type"
+          resource_request_operation|resource_kind|policy_change_type|event_type"
           
 
 ---


### PR DESCRIPTION
We need to keep `event_type` for `kubearchive_cloudevents_total`. 