### PR TITLE
fix: update release references to match image tag

### DIFF
--- a/components/release/production/kustomization.yaml
+++ b/components/release/production/kustomization.yaml
@@ -3,7 +3,7 @@ kind: Kustomization
 resources:
   - ../base
   - ../base/monitor/production
-  - https://github.com/konflux-ci/release-service/config/default?ref=48d3044042ac90957d64850c85c355832a82173b
+  - https://github.com/konflux-ci/release-service/config/default?ref=054fd6de76eadc41ef28942d8fcc3eb37bb9438b
   - release_service_config.yaml
 
 components:


### PR DESCRIPTION
The resources reference to the release-service config was out of sync with the deployed image tag. As a result, production continued applying outdated CRDs.

This mismatch happened because the promotion script relies on the image tag and the ref being the same. Once they diverged, the script only updated the image tag since it performs a string replacement from old ref to the new.

This PR updates the pinned ref in kustomization.yaml to match the current image tag
054fd6de76eadc41ef28942d8fcc3eb37bb9438b