### PR TITLE
KFLUXINFRA-1956: Deploy Kueue on rh02 and rh03

### DIFF
--- a/argo-cd-apps/base/member/infra-deployments/kueue/kueue.yaml
+++ b/argo-cd-apps/base/member/infra-deployments/kueue/kueue.yaml
@@ -22,16 +22,16 @@ spec:
                   values.clusterDir: stone-stg-rh01
                 - nameNormalized: stone-stage-p01
                   values.clusterDir: stone-stage-p01
-                - nameNormalized: stone-prd-rh01
-                  values.clusterDir: stone-prd-rh01
+                # - nameNormalized: stone-prd-rh01
+                #   values.clusterDir: stone-prd-rh01
                 - nameNormalized: kflux-prd-rh02
                   values.clusterDir: kflux-prd-rh02
-                - nameNormalized: stone-prod-p01
-                  values.clusterDir: stone-prod-p01
-                - nameNormalized: stone-prod-p02
-                  values.clusterDir: stone-prod-p02
-                - nameNormalized: kflux-ocp-p01
-                  values.clusterDir: kflux-ocp-p01
+                # - nameNormalized: stone-prod-p01
+                #   values.clusterDir: stone-prod-p01
+                # - nameNormalized: stone-prod-p02
+                #   values.clusterDir: stone-prod-p02
+                # - nameNormalized: kflux-ocp-p01
+                #   values.clusterDir: kflux-ocp-p01
                 - nameNormalized: kflux-prd-rh03
                   values.clusterDir: kflux-prd-rh03
   template:

--- a/argo-cd-apps/overlays/konflux-public-production/delete-applications.yaml
+++ b/argo-cd-apps/overlays/konflux-public-production/delete-applications.yaml
@@ -12,12 +12,6 @@ metadata:
   name: nvme-storage-configurator
 $patch: delete
 ---
-apiVersion: argoproj.io/v1alpha1
-kind: ApplicationSet
-metadata:
-  name: kueue
-$patch: delete
----
 # Kite is still in proof-of-concept phase
 apiVersion: argoproj.io/v1alpha1
 kind: ApplicationSet

--- a/argo-cd-apps/overlays/konflux-public-production/kustomization.yaml
+++ b/argo-cd-apps/overlays/konflux-public-production/kustomization.yaml
@@ -246,3 +246,8 @@ patches:
       kind: ApplicationSet
       version: v1alpha1
       name: cert-manager
+  - path: production-overlay-patch.yaml
+    target:
+      kind: ApplicationSet
+      version: v1alpha1
+      name: kueue

--- a/argo-cd-apps/overlays/production-downstream/delete-applications.yaml
+++ b/argo-cd-apps/overlays/production-downstream/delete-applications.yaml
@@ -33,11 +33,5 @@ $patch: delete
 apiVersion: argoproj.io/v1alpha1
 kind: ApplicationSet
 metadata:
-  name: kueue
-$patch: delete
----
-apiVersion: argoproj.io/v1alpha1
-kind: ApplicationSet
-metadata:
   name: konflux-kite
 $patch: delete

--- a/argo-cd-apps/overlays/production-downstream/kustomization.yaml
+++ b/argo-cd-apps/overlays/production-downstream/kustomization.yaml
@@ -262,3 +262,8 @@ patches:
       kind: ApplicationSet
       version: v1alpha1
       name: cert-manager
+  - path: production-overlay-patch.yaml
+    target:
+      kind: ApplicationSet
+      version: v1alpha1
+      name: kueue

--- a/components/kueue/production/base/kueue/kueue.yaml
+++ b/components/kueue/production/base/kueue/kueue.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: kueue.openshift.io/v1
+kind: Kueue
+metadata:
+  labels:
+    app.kubernetes.io/name: kueue-operator
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+  name: cluster
+  namespace: openshift-kueue-operator
+spec:
+  managementState: Managed
+  config:
+    integrations:
+      frameworks: # The operator requires at lest one framework to be enabled
+       - BatchJob
+      externalFrameworks:
+       -  group: tekton.dev
+          version: v1
+          resource: pipelineruns

--- a/components/kueue/production/base/kueue/kustomization.yaml
+++ b/components/kueue/production/base/kueue/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- operator.yaml
+- kueue.yaml
+namespace: openshift-kueue-operator

--- a/components/kueue/production/base/kueue/operator.yaml
+++ b/components/kueue/production/base/kueue/operator.yaml
@@ -1,0 +1,47 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-kueue-operator
+  labels:
+    openshift.io/cluster-monitoring: "true"
+  annotations:
+    argocd.argoproj.io/sync-wave: "-4"
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-3"
+  name: redhat-operators-1-18
+  namespace: openshift-kueue-operator
+spec:
+  displayName: redhat-operators-1-18
+  image: registry.redhat.io/redhat/redhat-operator-index:v4.18
+  sourceType: grpc
+  updateStrategy:
+    registryPoll:
+      interval: 30m
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: openshift-kueue-operatorgroup
+  annotations:
+    argocd.argoproj.io/sync-wave: "-2"
+spec: {}
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: openshift-kueue-operator
+  namespace: openshift-kueue-operator
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  channel: stable-v1.0
+  installPlanApproval: Automatic
+  name: kueue-operator
+  source: redhat-operators-1-18
+  sourceNamespace: openshift-kueue-operator

--- a/components/kueue/production/base/kustomization.yaml
+++ b/components/kueue/production/base/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- kueue
+- tekton-kueue
+- tekton-kueue-monitoring
+
+commonAnnotations:
+  argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true

--- a/components/kueue/production/base/queue-config/kustomization.yaml
+++ b/components/kueue/production/base/queue-config/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - workload-priority-class.yaml
+- mintmaker-local-queue.yaml
 
 # ensure that installation starts after the installation of kueue complete
 commonAnnotations:

--- a/components/kueue/production/base/queue-config/kustomization.yaml
+++ b/components/kueue/production/base/queue-config/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- workload-priority-class.yaml
+
+# ensure that installation starts after the installation of kueue complete
+commonAnnotations:
+  argocd.argoproj.io/sync-wave: "10"

--- a/components/kueue/production/base/queue-config/mintmaker-local-queue.yaml
+++ b/components/kueue/production/base/queue-config/mintmaker-local-queue.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: LocalQueue
+metadata:
+  name: pipelines-queue
+  namespace: mintmaker
+spec:
+  clusterQueue: cluster-pipeline-queue

--- a/components/kueue/production/base/queue-config/workload-priority-class.yaml
+++ b/components/kueue/production/base/queue-config/workload-priority-class.yaml
@@ -1,0 +1,57 @@
+---
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: WorkloadPriorityClass
+metadata:
+  name: konflux-release
+value: 1000
+description: "Highest priority for release pipelines"
+---
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: WorkloadPriorityClass
+metadata:
+  name: konflux-tenant-release
+value: 900
+description: "High priority for tenant release pipelines"
+---
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: WorkloadPriorityClass
+metadata:
+  name: konflux-post-merge-test
+value: 800
+description: "Priority for post-merge tests"
+---
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: WorkloadPriorityClass
+metadata:
+  name: konflux-post-merge-build
+value: 700
+description: "Priority for post-merge builds"
+---
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: WorkloadPriorityClass
+metadata:
+  name: konflux-pre-merge-test
+value: 600
+description: "Priority for pre-merge tests"
+---
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: WorkloadPriorityClass
+metadata:
+  name: konflux-pre-merge-build
+value: 500
+description: "Priority for pre-merge builds"
+---
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: WorkloadPriorityClass
+metadata:
+  name: konflux-default
+value: 400
+description: "Default priority for konflux pipelines"
+---
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: WorkloadPriorityClass
+metadata:
+  name: konflux-dependency-update
+value: 300
+description: "Lower priority for dependency updates"
+

--- a/components/kueue/production/base/tekton-kueue-monitoring/kueue-prometheus-alerts.yaml
+++ b/components/kueue/production/base/tekton-kueue-monitoring/kueue-prometheus-alerts.yaml
@@ -1,0 +1,240 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: kueue-alerts
+spec:
+  groups:
+  - name: kueue.health
+    interval: 30s
+    rules:
+    - alert: KueueHighAdmissionLatency
+      expr: histogram_quantile(0.99, sum(increase(kueue_admission_attempt_duration_seconds_bucket[5m])) by (le)) > 30
+      for: 2m
+      labels:
+        severity: warning
+        component: kueue
+      annotations:
+        summary: "Kueue admission latency is high"
+        description: "99th percentile of Kueue admission attempt duration is {{ $value }}s, which is above the threshold of 30s"
+        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue.md?ref_type=heads
+        alert_team_handle: <!subteam^S05Q1P4Q2TG>
+        team: konflux-infra
+
+    - alert: KueueReplicasNotAvailable
+      expr: |
+        (
+          kube_deployment_status_replicas_available{namespace=~"openshift-kueue-operator|tekton-kueue|kueue-external-admission"}
+        )
+        /
+        clamp_min(
+          kube_deployment_spec_replicas{namespace=~"openshift-kueue-operator|tekton-kueue|kueue-external-admission"},
+          1
+        ) * 100 < 100
+      for: 5m
+      labels:
+        severity: warning
+        component: kueue
+      annotations:
+        summary: "Kueue deployment {{ $labels.deployment }} has unavailable replicas"
+        description: "Deployment {{ $labels.deployment }} has {{ $value }}% available replicas, which is less than 100%"
+        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue.md?ref_type=heads
+        alert_team_handle: <!subteam^S05Q1P4Q2TG>
+        team: konflux-infra
+
+    - alert: KueueHighMemoryUtilization
+      expr: |
+        (
+            container_memory_working_set_bytes{namespace=~"tekton-kueue|kueue-external-admission|openshift-kueue-operator", image!=""} 
+            * on(container, pod)
+            group_left
+            kube_pod_container_status_ready{namespace=~"tekton-kueue|kueue-external-admission|openshift-kueue-operator"}
+        )
+            / on (pod) kube_pod_resource_limit{resource='memory',namespace=~"tekton-kueue|kueue-external-admission|openshift-kueue-operator"} * 100 > 70
+      for: 5m
+      labels:
+        severity: warning
+        component: kueue
+      annotations:
+        summary: "Kueue pod {{ $labels.pod }} has high memory utilization"
+        description: "Pod {{ $labels.pod }} memory utilization is {{ $value }}%, which is above 70%"
+        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue.md?ref_type=heads
+        alert_team_handle: <!subteam^S05Q1P4Q2TG>
+        team: konflux-infra
+  
+    - alert: KueueHighCPUUtilization
+      expr: |
+        (
+            pod:container_cpu_usage:sum{namespace=~"tekton-kueue|kueue-external-admission|openshift-kueue-operator"}
+            * on(pod)
+            kube_pod_container_status_ready{namespace=~"tekton-kueue|kueue-external-admission|openshift-kueue-operator"}
+        ) / on (pod) group_right max by (pod) (kube_pod_resource_limit{resource='cpu',namespace=~"tekton-kueue|kueue-external-admission|openshift-kueue-operator"}) * 100 > 85
+      for: 5m
+      labels:
+        severity: warning
+        component: kueue
+      annotations:
+        summary: "Kueue pod {{ $labels.pod }} has high CPU utilization"
+        description: "Pod {{ $labels.pod }} CPU utilization is {{ $value }}%, which is above 85%"
+        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue.md?ref_type=heads
+        alert_team_handle: <!subteam^S05Q1P4Q2TG>
+        team: konflux-infra
+
+    - alert: KueueCELEvaluationFailures
+      expr: increase(tekton_kueue_cel_evaluations_total{result="failure"}[5m]) > 0
+      for: 1m
+      labels:
+        severity: warning
+        component: tekton-kueue
+      annotations:
+        summary: "Tekton Kueue CEL evaluation failures detected"
+        description: "{{ $value }} CEL evaluation failures occurred in the last 5 minutes"
+        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue.md?ref_type=heads
+        alert_team_handle: <!subteam^S05Q1P4Q2TG>
+        team: konflux-infra
+
+    - alert: KueueHighContainerRestarts
+      expr: |
+        increase(kube_pod_container_status_restarts_total{namespace=~"tekton-kueue|kueue-external-admission|openshift-kueue-operator"}[1h])
+        * on(container, pod)
+        kube_pod_container_status_ready{namespace=~"tekton-kueue|kueue-external-admission|openshift-kueue-operator"} >= 3
+      for: 0m
+      labels:
+        severity: warning
+        component: kueue
+      annotations:
+        summary: "Kueue pod {{ $labels.pod }} has high restart count"
+        description: "Pod {{ $labels.pod }} has restarted {{ $value }} times in the last hour"
+        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue.md?ref_type=heads
+        alert_team_handle: <!subteam^S05Q1P4Q2TG>
+        team: konflux-infra
+
+  - name: kueue.queue
+    interval: 30s
+    rules:
+    - alert: KueueClusterQueueNotActive
+      expr: max by (status) (kueue_cluster_queue_status{cluster_queue="cluster-pipeline-queue", status="active"}) != 1
+      for: 2m
+      labels:
+        severity: warning
+        component: kueue
+      annotations:
+        summary: "Kueue cluster queue is not active"
+        description: "Cluster queue 'cluster-pipeline-queue' is not in active state"
+        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue.md?ref_type=heads
+        alert_team_handle: <!subteam^S05Q1P4Q2TG>
+        team: konflux-infra
+
+    - alert: KueueHighPendingWorkloads
+      expr: max by (status) (kueue_pending_workloads{cluster_queue="cluster-pipeline-queue"}) > 300
+      for: 5m
+      labels:
+        severity: warning
+        component: kueue
+      annotations:
+        summary: "High number of pending workloads in Kueue"
+        description: "{{ $value }} workloads are pending in cluster queue 'cluster-pipeline-queue'"
+        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue.md?ref_type=heads
+        alert_team_handle: <!subteam^S05Q1P4Q2TG>
+        team: konflux-infra
+
+    - alert: KueueHighAdmissionWaitTime
+      expr: histogram_quantile(0.99, sum(increase(kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue"}[10m])) by (le)) > 900
+      for: 5m
+      labels:
+        severity: warning
+        component: kueue
+      annotations:
+        summary: "High admission wait time in Kueue"
+        description: "99th percentile admission wait time is {{ $value }}s, which is above 15 minutes"
+        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue.md?ref_type=heads
+        alert_team_handle: <!subteam^S05Q1P4Q2TG>
+        team: konflux-infra
+
+    - alert: KueueHighResourceReservation
+      expr: max by (resource) (kueue_cluster_queue_resource_reservation{cluster_queue="cluster-pipeline-queue"} / kueue_cluster_queue_nominal_quota{cluster_queue="cluster-pipeline-queue"} * 100) > 90
+      for: 5m
+      labels:
+        severity: warning
+        component: kueue
+      annotations:
+        summary: "High resource reservation in Kueue cluster queue"
+        description: "Resource {{ $labels.resource }} reservation is {{ $value }}% of nominal quota, which is above 90%"  
+        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue.md?ref_type=heads
+        alert_team_handle: <!subteam^S05Q1P4Q2TG>
+        team: konflux-infra
+
+    - alert: KueueLowResourceUsage
+      expr: max by (resource) (kueue_cluster_queue_resource_usage{cluster_queue="cluster-pipeline-queue"} / kueue_cluster_queue_resource_reservation{cluster_queue="cluster-pipeline-queue"} * 100) < 50
+      for: 10m
+      labels:
+        severity: info
+        component: kueue
+      annotations:
+        summary: "Low resource usage efficiency in Kueue"
+        description: "Resource {{ $labels.resource }} usage is only {{ $value }}% of reservation, indicating potential overprovisioning"
+        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue.md?ref_type=heads
+        alert_team_handle: <!subteam^S05Q1P4Q2TG>
+        team: konflux-infra
+
+    - alert: KueueHighPipelineDeletionDuration
+      expr: histogram_quantile(0.99, sum by (le) (increase(watcher_pipelinerun_delete_duration_seconds_bucket[10m]))) > 300
+      for: 5m
+      labels:
+        severity: warning
+        component: pipeline-watcher
+      annotations:
+        summary: "High PipelineRun deletion duration"
+        description: "99th percentile PipelineRun deletion duration is {{ $value }}s, which is above 5 minutes"
+        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue.md?ref_type=heads
+        alert_team_handle: <!subteam^S05Q1P4Q2TG>
+        team: konflux-infra
+
+  - name: kueue.deadman
+    interval: 60s
+    rules:
+    - alert: KueueMetricsDown
+      expr: up{job=~".*kueue.*"} == 0
+      for: 5m
+      labels:
+        severity: warning
+        component: kueue
+      annotations:
+        summary: "Kueue metrics endpoint is down"
+        description: "Kueue metrics endpoint {{ $labels.instance }} for job {{ $labels.job }} has been down for more than 5 minutes"
+        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue.md?ref_type=heads
+        alert_team_handle: <!subteam^S05Q1P4Q2TG>
+        team: konflux-infra
+
+    - alert: KueueNoRecentAdmissions
+      expr: increase(kueue_admitted_workloads_total[60m]) == 0
+      for: 60m
+      labels:
+        severity: warning
+        component: kueue
+      annotations:
+        summary: "No recent workload admissions in Kueue"
+        description: "No workloads have been admitted in the last hour, which might indicate a problem with the admission process"
+        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue.md?ref_type=heads
+        alert_team_handle: <!subteam^S05Q1P4Q2TG>
+        team: konflux-infra
+
+    - alert: KueueMutatingWebhookLowSuccessRate
+      expr: |
+        100 * sum(increase(apiserver_admission_webhook_request_total{
+          name="pipelinerun-kueue-defaulter.tekton-kueue.io", code=~"2.."
+        }[10m]))
+        /
+        sum(increase(apiserver_admission_webhook_request_total{
+          name="pipelinerun-kueue-defaulter.tekton-kueue.io"
+        }[10m]))
+        < 99
+      for: 10m
+      labels:
+        severity: warning
+        component: kueue
+      annotations:
+        summary: "Kueue mutating webhook success rate is below 99%"
+        description: "The mutating webhook 'pipelinerun-kueue-defaulter.tekton-kueue.io' has had a success rate below 99% over the past 10 minutes. Possible causes include webhook errors, rejections, or unreachability (e.g., code=600)."
+        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue.md?ref_type=heads
+        alert_team_handle: <!subteam^S05Q1P4Q2TG>
+        team: konflux-infra

--- a/components/kueue/production/base/tekton-kueue-monitoring/kustomization.yaml
+++ b/components/kueue/production/base/tekton-kueue-monitoring/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- monitoring.yaml
+- kueue-prometheus-alerts.yaml
+
+namespace: tekton-kueue

--- a/components/kueue/production/base/tekton-kueue-monitoring/monitoring.yaml
+++ b/components/kueue/production/base/tekton-kueue-monitoring/monitoring.yaml
@@ -1,0 +1,78 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: metrics-reader
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: metrics-reader
+  annotations:
+    kubernetes.io/service-account.name: metrics-reader
+type: kubernetes.io/service-account-token
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: prometheus-tekton-kueue-metrics-reader
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: tekton-kueue-metrics-reader
+subjects:
+- kind: ServiceAccount
+  name: metrics-reader
+  namespace: tekton-kueue
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: tekton-kueue-controller
+  annotations:
+    argocd.argoproj.io/sync-wave: "11"
+spec:
+  endpoints:
+  - path: /metrics
+    interval: 15s
+    port: https
+    scheme: https
+    bearerTokenSecret:
+      name: "metrics-reader"
+      key: token
+    tlsConfig:
+      serverName: tekton-kueue-controller-manager-metrics-service.tekton-kueue.svc.cluster.local
+      insecureSkipVerify: false
+      ca:
+        secret:
+          name: controller-manager-metrics-server-cert
+          key: ca.crt
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: tekton-kueue
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: tekton-kueue-webhook
+  annotations:
+    argocd.argoproj.io/sync-wave: "11"
+spec:
+  endpoints:
+  - path: /metrics
+    interval: 15s
+    port: metrics-server
+    scheme: https
+    bearerTokenSecret:
+      name: "metrics-reader"
+      key: token
+    tlsConfig:
+      serverName: tekton-kueue-webhook-service.tekton-kueue.svc.cluster.local
+      insecureSkipVerify: false
+      ca:
+        secret:
+          name: webhook-metrics-server-cert
+          key: ca.crt
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: tekton-kueue-webhook

--- a/components/kueue/production/base/tekton-kueue/config.yaml
+++ b/components/kueue/production/base/tekton-kueue/config.yaml
@@ -1,0 +1,52 @@
+queueName: pipelines-queue
+cel:
+  expressions:
+    # Set resource requests for multi platform pipelines
+    - |
+        has(pipelineRun.spec.params) &&
+        pipelineRun.spec.params.exists(p, p.name == 'build-platforms') ?
+        pipelineRun.spec.params.filter(
+          p, 
+          p.name == 'build-platforms')[0]
+        .value.map(
+          p,
+          annotation("kueue.konflux-ci.dev/requests-" + replace(replace(p, "/", "-"), "_", "-"), "1") 
+        ) : []
+
+    # Set resource requests for multi platform pipelines which doesn't use the build-platforms parameter (old style)
+    - |
+      has(pipelineRun.spec.pipelineSpec) &&
+      pipelineRun.spec.pipelineSpec.tasks.size() > 0 ?
+      pipelineRun.spec.pipelineSpec.tasks.map(
+        task,
+        has(task.params) ? task.params.filter(p, p.name == 'PLATFORM') : []
+      )
+      .filter(p, p.size() > 0)
+      .map(
+        p,
+        annotation("kueue.konflux-ci.dev/requests-" + replace(replace(p[0].value, "/", "-"), "_", "-"), "1")
+      ) : []
+
+    # Set the pipeline priority
+    - |
+        pacEventType == 'push' ? priority('konflux-post-merge-build') :
+        pacEventType == 'pull_request' ? priority('konflux-pre-merge-build') :
+        pacTestEventType == 'push' ? priority('konflux-post-merge-test') :
+        pacTestEventType == 'pull_request' ? priority('konflux-pre-merge-test') :
+
+        has(pipelineRun.metadata.labels) &&
+        'appstudio.openshift.io/service' in pipelineRun.metadata.labels &&
+        pipelineRun.metadata.labels['appstudio.openshift.io/service'] == 'release' &&
+        'pipelines.appstudio.openshift.io/type' in pipelineRun.metadata.labels &&
+        pipelineRun.metadata.labels['pipelines.appstudio.openshift.io/type'] == 'managed' ?
+        priority('konflux-release') :
+
+        has(pipelineRun.metadata.labels) &&
+        'appstudio.openshift.io/service' in pipelineRun.metadata.labels &&
+        pipelineRun.metadata.labels['appstudio.openshift.io/service'] == 'release' &&
+        'pipelines.appstudio.openshift.io/type' in pipelineRun.metadata.labels &&
+        pipelineRun.metadata.labels['pipelines.appstudio.openshift.io/type'] == 'tenant' ?
+        priority('konflux-tenant-release') :
+
+        plrNamespace == 'mintmaker' ? priority('konflux-dependency-update') :
+        priority('konflux-default')

--- a/components/kueue/production/base/tekton-kueue/controller-patch.yaml
+++ b/components/kueue/production/base/tekton-kueue/controller-patch.yaml
@@ -1,0 +1,49 @@
+---
+- op: replace
+  path: /spec/replicas
+  value: 2
+
+- op: add
+  path: /metadata/annotations/ignore-check.kube-linter.io~1no-anti-affinity
+  value: "Using topologySpreadConstraints"
+
+- op: add
+  path: /spec/strategy
+  value:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 0
+
+- op: add
+  path: /spec/template/spec/topologySpreadConstraints
+  value:
+    - maxSkew: 1
+      topologyKey: topology.kubernetes.io/zone
+      whenUnsatisfiable: ScheduleAnyway
+      labelSelector:
+        matchLabels:
+          app.kubernetes.io/name: tekton-kueue
+
+- op: add
+  path: /spec/template/spec/containers/0/resources/requests
+  value:
+    cpu: 500m
+    memory: 1Gi
+
+- op: add
+  path: /spec/template/spec/containers/0/resources/limits
+  value:
+    cpu: 500m
+    memory: 1Gi
+
+- op: add
+  path: /spec/template/spec/containers/0/args/-
+  value: "--leader-elect-lease-duration=137s"
+
+- op: add
+  path: /spec/template/spec/containers/0/args/-
+  value: "--leader-elect-renew-deadline=107s"
+
+- op: add
+  path: /spec/template/spec/containers/0/args/-
+  value: "--leader-elect-retry-period=26s"

--- a/components/kueue/production/base/tekton-kueue/kustomization.yaml
+++ b/components/kueue/production/base/tekton-kueue/kustomization.yaml
@@ -1,0 +1,42 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- https://github.com/konflux-ci/tekton-kueue/config/default?ref=a056ebc7e0e7829844c9b6294fe67654396cb53b
+
+images:
+- name: konflux-ci/tekton-kueue
+  newName: quay.io/konflux-ci/tekton-kueue
+  newTag: a056ebc7e0e7829844c9b6294fe67654396cb53b
+
+namespace: tekton-kueue
+# ensure that installation starts after the installation of kueue complete
+commonAnnotations:
+  argocd.argoproj.io/sync-wave: "10"
+
+configMapGenerator:
+  - name: tekton-kueue-config
+    namespace: tekton-kueue
+    behavior: replace
+    files:
+      - config.yaml
+
+patches:
+- path: webhook-patch.yaml
+  target:
+    group: apps
+    kind: Deployment
+    name: tekton-kueue-webhook
+    version: v1
+- path: controller-patch.yaml
+  target:
+    group: apps
+    kind: Deployment
+    name: tekton-kueue-controller-manager
+    version: v1
+- target:
+    kind: Namespace
+    name: tekton-kueue
+  patch: |-
+    - op: add
+      path: /metadata/labels/openshift.io~1cluster-monitoring
+      value: "true"

--- a/components/kueue/production/base/tekton-kueue/webhook-patch.yaml
+++ b/components/kueue/production/base/tekton-kueue/webhook-patch.yaml
@@ -1,0 +1,37 @@
+---
+- op: replace
+  path: /spec/replicas
+  value: 3
+
+- op: add
+  path: /metadata/annotations/ignore-check.kube-linter.io~1no-anti-affinity
+  value: "Using topologySpreadConstraints"
+
+- op: add
+  path: /spec/strategy
+  value:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 0
+
+- op: add
+  path: /spec/template/spec/topologySpreadConstraints
+  value:
+    - maxSkew: 1
+      topologyKey: topology.kubernetes.io/zone
+      whenUnsatisfiable: ScheduleAnyway
+      labelSelector:
+        matchLabels:
+          app.kubernetes.io/name: tekton-kueue-webhook
+
+- op: add
+  path: /spec/template/spec/containers/0/resources/requests
+  value:
+    cpu: 200m
+    memory: 256Mi
+
+- op: add
+  path: /spec/template/spec/containers/0/resources/limits
+  value:
+    cpu: 200m
+    memory: 256Mi

--- a/components/kueue/production/kflux-prd-rh02/kustomization.yaml
+++ b/components/kueue/production/kflux-prd-rh02/kustomization.yaml
@@ -1,0 +1,16 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../base
+- queue-config
+
+patches:
+  - target:
+      kind: MutatingWebhookConfiguration
+      name: tekton-kueue-mutating-webhook-configuration
+    patch: |-
+      - op: replace
+        path: /webhooks/0/namespaceSelector
+        value:
+          matchLabels:
+            kubernetes.io/metadata.name: mintmaker

--- a/components/kueue/production/kflux-prd-rh02/queue-config/cluster-queue.yaml
+++ b/components/kueue/production/kflux-prd-rh02/queue-config/cluster-queue.yaml
@@ -1,0 +1,176 @@
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: ResourceFlavor
+metadata:
+  name: default-flavor
+---
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: ClusterQueue
+metadata:
+  name: cluster-pipeline-queue
+spec:
+  flavorFungibility:
+    whenCanBorrow: Borrow
+    whenCanPreempt: TryNextFlavor
+  namespaceSelector: {}
+  preemption:
+    borrowWithinCohort:
+      policy: Never
+    reclaimWithinCohort: Never
+    withinClusterQueue: Never
+  queueingStrategy: BestEffortFIFO
+  stopPolicy: None
+  resourceGroups:
+  - coveredResources:
+    - tekton.dev/pipelineruns
+    - cpu
+    - memory
+    flavors:
+    - name: default-flavor
+      resources:
+      - name: tekton.dev/pipelineruns
+        nominalQuota: '500'
+      - name: cpu
+        nominalQuota: 1k
+      - name: memory
+        nominalQuota: 500Ti
+  - coveredResources:
+    - linux-amd64
+    - linux-arm64
+    - linux-c2xlarge-amd64
+    - linux-c2xlarge-arm64
+    - linux-c4xlarge-amd64
+    - linux-c4xlarge-arm64
+    - linux-c6gd2xlarge-arm64
+    - linux-c8xlarge-amd64
+    - linux-c8xlarge-arm64
+    - linux-cxlarge-amd64
+    - linux-cxlarge-arm64
+    - linux-d160-m2xlarge-amd64
+    - linux-d160-m2xlarge-arm64
+    - linux-d160-m4xlarge-amd64
+    - linux-d160-m4xlarge-arm64
+    - linux-d160-m8xlarge-amd64
+    flavors:
+    - name: platform-group-1
+      resources:
+      - name: linux-amd64
+        nominalQuota: '30'
+      - name: linux-arm64
+        nominalQuota: '70'
+      - name: linux-c2xlarge-amd64
+        nominalQuota: '5'
+      - name: linux-c2xlarge-arm64
+        nominalQuota: '5'
+      - name: linux-c4xlarge-amd64
+        nominalQuota: '5'
+      - name: linux-c4xlarge-arm64
+        nominalQuota: '5'
+      - name: linux-c6gd2xlarge-arm64
+        nominalQuota: '5'
+      - name: linux-c8xlarge-amd64
+        nominalQuota: '5'
+      - name: linux-c8xlarge-arm64
+        nominalQuota: '5'
+      - name: linux-cxlarge-amd64
+        nominalQuota: '5'
+      - name: linux-cxlarge-arm64
+        nominalQuota: '5'
+      - name: linux-d160-m2xlarge-amd64
+        nominalQuota: '5'
+      - name: linux-d160-m2xlarge-arm64
+        nominalQuota: '5'
+      - name: linux-d160-m4xlarge-amd64
+        nominalQuota: '5'
+      - name: linux-d160-m4xlarge-arm64
+        nominalQuota: '5'
+      - name: linux-d160-m8xlarge-amd64
+        nominalQuota: '5'
+  - coveredResources:
+    - linux-d160-m8xlarge-arm64
+    - linux-extra-fast-amd64
+    - linux-fast-amd64
+    - linux-g6xlarge-amd64
+    - linux-m2xlarge-amd64
+    - linux-m2xlarge-arm64
+    - linux-m4xlarge-amd64
+    - linux-m4xlarge-arm64
+    - linux-m8xlarge-amd64
+    - linux-m8xlarge-arm64
+    - linux-mlarge-amd64
+    - linux-mlarge-arm64
+    - linux-mxlarge-amd64
+    - linux-mxlarge-arm64
+    - linux-ppc64le
+    - linux-root-amd64
+    flavors:
+    - name: platform-group-2
+      resources:
+      - name: linux-d160-m8xlarge-arm64
+        nominalQuota: '5'
+      - name: linux-extra-fast-amd64
+        nominalQuota: '5'
+      - name: linux-fast-amd64
+        nominalQuota: '5'
+      - name: linux-g6xlarge-amd64
+        nominalQuota: '5'
+      - name: linux-m2xlarge-amd64
+        nominalQuota: '5'
+      - name: linux-m2xlarge-arm64
+        nominalQuota: '5'
+      - name: linux-m4xlarge-amd64
+        nominalQuota: '5'
+      - name: linux-m4xlarge-arm64
+        nominalQuota: '5'
+      - name: linux-m8xlarge-amd64
+        nominalQuota: '5'
+      - name: linux-m8xlarge-arm64
+        nominalQuota: '5'
+      - name: linux-mlarge-amd64
+        nominalQuota: '5'
+      - name: linux-mlarge-arm64
+        nominalQuota: '5'
+      - name: linux-mxlarge-amd64
+        nominalQuota: '5'
+      - name: linux-mxlarge-arm64
+        nominalQuota: '5'
+      - name: linux-ppc64le
+        nominalQuota: '64'
+      - name: linux-root-amd64
+        nominalQuota: '5'
+  - coveredResources:
+    - linux-root-arm64
+    - linux-s390x
+    - linux-x86-64
+    - local
+    - localhost
+    flavors:
+    - name: platform-group-3
+      resources:
+      - name: linux-root-arm64
+        nominalQuota: '5'
+      - name: linux-s390x
+        nominalQuota: '64'
+      - name: linux-x86-64
+        nominalQuota: '1000'
+      - name: local
+        nominalQuota: '1000'
+      - name: localhost
+        nominalQuota: '1000'
+---
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: ResourceFlavor
+metadata:
+  name: platform-group-1
+spec: {}
+---
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: ResourceFlavor
+metadata:
+  name: platform-group-2
+spec: {}
+---
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: ResourceFlavor
+metadata:
+  name: platform-group-3
+spec: {}

--- a/components/kueue/production/kflux-prd-rh02/queue-config/kustomization.yaml
+++ b/components/kueue/production/kflux-prd-rh02/queue-config/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- cluster-queue.yaml
+- ../../base/queue-config
+
+# ensure that installation starts after the installation of kueue complete
+commonAnnotations:
+  argocd.argoproj.io/sync-wave: "10"

--- a/components/kueue/production/kflux-prd-rh03/kustomization.yaml
+++ b/components/kueue/production/kflux-prd-rh03/kustomization.yaml
@@ -1,0 +1,16 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../base
+- queue-config
+
+patches:
+  - target:
+      kind: MutatingWebhookConfiguration
+      name: tekton-kueue-mutating-webhook-configuration
+    patch: |-
+      - op: replace
+        path: /webhooks/0/namespaceSelector
+        value:
+          matchLabels:
+            kubernetes.io/metadata.name: mintmaker

--- a/components/kueue/production/kflux-prd-rh03/queue-config/cluster-queue.yaml
+++ b/components/kueue/production/kflux-prd-rh03/queue-config/cluster-queue.yaml
@@ -1,0 +1,170 @@
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: ResourceFlavor
+metadata:
+  name: default-flavor
+---
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: ClusterQueue
+metadata:
+  name: cluster-pipeline-queue
+spec:
+  flavorFungibility:
+    whenCanBorrow: Borrow
+    whenCanPreempt: TryNextFlavor
+  namespaceSelector: {}
+  preemption:
+    borrowWithinCohort:
+      policy: Never
+    reclaimWithinCohort: Never
+    withinClusterQueue: Never
+  queueingStrategy: BestEffortFIFO
+  stopPolicy: None
+  resourceGroups:
+  - coveredResources:
+    - tekton.dev/pipelineruns
+    - cpu
+    - memory
+    flavors:
+    - name: default-flavor
+      resources:
+      - name: tekton.dev/pipelineruns
+        nominalQuota: '500'
+      - name: cpu
+        nominalQuota: 1k
+      - name: memory
+        nominalQuota: 500Ti
+  - coveredResources:
+    - linux-amd64
+    - linux-arm64
+    - linux-c2xlarge-amd64
+    - linux-c2xlarge-arm64
+    - linux-c4xlarge-amd64
+    - linux-c4xlarge-arm64
+    - linux-c6gd2xlarge-arm64
+    - linux-c8xlarge-amd64
+    - linux-c8xlarge-arm64
+    - linux-cxlarge-amd64
+    - linux-cxlarge-arm64
+    - linux-d160-c8xlarge-amd64
+    - linux-d160-c8xlarge-arm64
+    - linux-d160-m2xlarge-amd64
+    - linux-d160-m2xlarge-arm64
+    - linux-extra-fast-amd64
+    flavors:
+    - name: platform-group-1
+      resources:
+      - name: linux-amd64
+        nominalQuota: '30'
+      - name: linux-arm64
+        nominalQuota: '70'
+      - name: linux-c2xlarge-amd64
+        nominalQuota: '5'
+      - name: linux-c2xlarge-arm64
+        nominalQuota: '5'
+      - name: linux-c4xlarge-amd64
+        nominalQuota: '5'
+      - name: linux-c4xlarge-arm64
+        nominalQuota: '5'
+      - name: linux-c6gd2xlarge-arm64
+        nominalQuota: '5'
+      - name: linux-c8xlarge-amd64
+        nominalQuota: '5'
+      - name: linux-c8xlarge-arm64
+        nominalQuota: '5'
+      - name: linux-cxlarge-amd64
+        nominalQuota: '5'
+      - name: linux-cxlarge-arm64
+        nominalQuota: '5'
+      - name: linux-d160-c8xlarge-amd64
+        nominalQuota: '10'
+      - name: linux-d160-c8xlarge-arm64
+        nominalQuota: '20'
+      - name: linux-d160-m2xlarge-amd64
+        nominalQuota: '5'
+      - name: linux-d160-m2xlarge-arm64
+        nominalQuota: '5'
+      - name: linux-extra-fast-amd64
+        nominalQuota: '5'
+  - coveredResources:
+    - linux-fast-amd64
+    - linux-g6xlarge-amd64
+    - linux-m2xlarge-amd64
+    - linux-m2xlarge-arm64
+    - linux-m4xlarge-amd64
+    - linux-m4xlarge-arm64
+    - linux-m8xlarge-amd64
+    - linux-m8xlarge-arm64
+    - linux-mlarge-amd64
+    - linux-mlarge-arm64
+    - linux-mxlarge-amd64
+    - linux-mxlarge-arm64
+    - linux-ppc64le
+    - linux-root-amd64
+    - linux-root-arm64
+    - linux-s390x
+    flavors:
+    - name: platform-group-2
+      resources:
+      - name: linux-fast-amd64
+        nominalQuota: '5'
+      - name: linux-g6xlarge-amd64
+        nominalQuota: '5'
+      - name: linux-m2xlarge-amd64
+        nominalQuota: '5'
+      - name: linux-m2xlarge-arm64
+        nominalQuota: '5'
+      - name: linux-m4xlarge-amd64
+        nominalQuota: '5'
+      - name: linux-m4xlarge-arm64
+        nominalQuota: '5'
+      - name: linux-m8xlarge-amd64
+        nominalQuota: '5'
+      - name: linux-m8xlarge-arm64
+        nominalQuota: '5'
+      - name: linux-mlarge-amd64
+        nominalQuota: '5'
+      - name: linux-mlarge-arm64
+        nominalQuota: '5'
+      - name: linux-mxlarge-amd64
+        nominalQuota: '5'
+      - name: linux-mxlarge-arm64
+        nominalQuota: '5'
+      - name: linux-ppc64le
+        nominalQuota: '64'
+      - name: linux-root-amd64
+        nominalQuota: '5'
+      - name: linux-root-arm64
+        nominalQuota: '5'
+      - name: linux-s390x
+        nominalQuota: '56'
+  - coveredResources:
+    - linux-x86-64
+    - local
+    - localhost
+    flavors:
+    - name: platform-group-3
+      resources:
+      - name: linux-x86-64
+        nominalQuota: '1000'
+      - name: local
+        nominalQuota: '1000'
+      - name: localhost
+        nominalQuota: '1000'
+---
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: ResourceFlavor
+metadata:
+  name: platform-group-1
+spec: {}
+---
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: ResourceFlavor
+metadata:
+  name: platform-group-2
+spec: {}
+---
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: ResourceFlavor
+metadata:
+  name: platform-group-3
+spec: {}

--- a/components/kueue/production/kflux-prd-rh03/queue-config/kustomization.yaml
+++ b/components/kueue/production/kflux-prd-rh03/queue-config/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- cluster-queue.yaml
+- ../../base/queue-config
+
+# ensure that installation starts after the installation of kueue complete
+commonAnnotations:
+  argocd.argoproj.io/sync-wave: "10"

--- a/hack/kueue-vm-quotas/generate-queue-config.sh
+++ b/hack/kueue-vm-quotas/generate-queue-config.sh
@@ -40,6 +40,8 @@ main() {
     local -A queue_configs=(
         ["components/multi-platform-controller/staging/host-config.yaml"]="components/kueue/staging/stone-stg-rh01/queue-config/cluster-queue.yaml"
         ["components/multi-platform-controller/staging-downstream/host-config.yaml"]="components/kueue/staging/stone-stage-p01/queue-config/cluster-queue.yaml"
+        ["components/multi-platform-controller/production/kflux-prd-rh02/host-config.yaml"]="components/kueue/production/kflux-prd-rh02/queue-config/cluster-queue.yaml"
+        ["components/multi-platform-controller/production/kflux-prd-rh03/host-config.yaml"]="components/kueue/production/kflux-prd-rh03/queue-config/cluster-queue.yaml"
     )
     
     # Generate queue configurations


### PR DESCRIPTION
- All the files in production/base are a copy of the files from staging/base. Duplicate the files in order to have precise control on staging and production configurations.

- Enable the mutating webhook only on mintmaker pipelines until https://issues.redhat.com/browse/SRVKP-8255 is resolved.

- Don't deploy the external admission check controller since it's not ready for production yet.

- Update the script which generated the cluster queue nominal quotas from the host-config to include rh02 and rh03.

- Deploy an empty overlay for the rest of the production clusters in order to gradually deploy Kueue.