### PR TITLE
feat(kite): use specific SHA for tag

### DIFF
--- a/components/konflux-kite/base/kustomization.yaml
+++ b/components/konflux-kite/base/kustomization.yaml
@@ -10,6 +10,13 @@ resources:
 
 namespace: konflux-kite
 
+images:
+  - name: quay.io/konflux-ci/kite-prod
+    newTag: ef9cf97e2949abd49b725958250b40c59b63b8c9
+
+  - name: quay.io/konflux-ci/kite-init
+    newTag: ef9cf97e2949abd49b725958250b40c59b63b8c9
+
 configMapGenerator:
   - name: kite-config
     namespace: konflux-kite


### PR DESCRIPTION
Use a specific SHA for the tag. This should enable auto-tag updates as well?

Relies on #7445 