### PR TITLE
konflux-ci: add gangway-token & link to SA

### DIFF
--- a/components/cluster-secret-store/base/kustomization.yaml
+++ b/components/cluster-secret-store/base/kustomization.yaml
@@ -3,3 +3,4 @@ kind: Kustomization
 resources:
   - appsre-stonesoup-vault-secret-store.yaml
   - appsre-vault-secret-store.yml
+  - testplatform-vault-secret-store.yaml

--- a/components/cluster-secret-store/base/testplatform-vault-secret-store.yaml
+++ b/components/cluster-secret-store/base/testplatform-vault-secret-store.yaml
@@ -1,0 +1,67 @@
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ClusterSecretStore
+metadata:
+  name: testplatform-vault
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  provider:
+    vault:
+      server: "https://vault.ci.ext.devshift.net"
+      path: stonesoup
+      version: v2
+      auth:
+        # VaultAppRole authenticates with Vault using the
+        # App Role auth mechanism
+        # https://www.vaultproject.io/docs/auth/approle
+        appRole:
+          # Path where the App Role authentication backend is mounted
+          path: approle
+          # RoleID configured in the App Role authentication backend
+          roleId: d2d9c931-5fce-7b40-bf69-f4ee411ee891
+          # Reference to a key in a K8 Secret that contains the App Role SecretId
+          secretRef:
+            name: appsre-vault
+            key: secret-id
+            namespace: appsre-vault
+  conditions:
+    - namespaces:
+        - build-templates
+        - build-templates-e2e
+        - build-service
+        - tekton-ci
+        - konflux-ci
+        - image-controller
+        - multi-platform-controller
+        - openshift-logging
+        - quality-dashboard
+        - sprayproxy
+        - appstudio-monitoring
+        - appstudio-kanary-exporter
+        - openshift-pipelines
+        - rhtap-servicerelease-tenant
+        - rhtap-build-tenant
+        - rhtap-o11y-tenant
+        - admin-checker
+        - integration-service
+        - release-service
+        - ci-helper-app
+        - mintmaker
+        - konflux-otel
+        - local-cluster
+        - clusters
+        - crossplane-system
+        - konflux-qe-team-tenant
+        - rhtap-shared-team-tenant
+        - notification-controller
+        - rhtap-integration-tenant
+        - rhtap-release-2-tenant
+        - rhtap-releng-tenant
+        - costmanagement-metrics-operator
+        - openshift-adp
+        - tekton-logging
+        - tekton-results
+        - openshift-adp
+        - product-kubearchive
+        - pulp-access-controller

--- a/components/konflux-ci/base/external-secrets/gangway-token.yaml
+++ b/components/konflux-ci/base/external-secrets/gangway-token.yaml
@@ -1,0 +1,19 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: gangway-token
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  dataFrom:
+    - extract:
+        key: production/openshift-ci/gangway-token
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: testplatform-vault
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    name: gangway-token

--- a/components/konflux-ci/base/external-secrets/kustomization.yaml
+++ b/components/konflux-ci/base/external-secrets/kustomization.yaml
@@ -10,4 +10,5 @@ resources:
 - clair-in-ci-db-github-token.yaml
 - registry-redhat-io-pull-secret.yaml
 - test-artifacts-push-secret.yaml
+- gangway-token.yaml
 namespace: konflux-ci

--- a/components/konflux-ci/base/serviceaccount.yaml
+++ b/components/konflux-ci/base/serviceaccount.yaml
@@ -5,6 +5,7 @@ metadata:
 secrets:
   - name: quay-push-secret-konflux-ci
   - name: registry-redhat-io-pull-secret
+  - name: gangway-token
 imagePullSecrets:
   - name: quay-push-secret-konflux-ci
   - name: registry-redhat-io-pull-secret


### PR DESCRIPTION
After this PR is merged, there is no need to manually add the gangway token in the users namespace and the pipelines that will run the [run-prowjob](https://github.com/openshift/konflux-tasks/tree/main/tasks/run-prowjob) task will use this token.