### PR TITLE
KubeArchive: do not deploy a DB on staging

### DIFF
--- a/components/kubearchive/staging/stone-stg-rh01/kustomization.yaml
+++ b/components/kubearchive/staging/stone-stg-rh01/kustomization.yaml
@@ -16,3 +16,17 @@ patches:
       metadata:
         name: kubearchive-database-credentials
         namespace: kubearchive
+  # We don't need the development DB on staging
+  - patch: |-
+      $patch: delete
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: postgresql
+  # We don't need the development DB service on staging
+  - patch: |-
+      $patch: delete
+      apiVersion: v1
+      kind: Service
+      metadata:
+        name: postgresql


### PR DESCRIPTION
Because staging is inheriting from development we are currently deploying a postgresql instance which we don't need, as we are using the one on AWS.