### PR TITLE
KFLUXINFRA-1948: Add GPU Image and GPU Instance for RH03 Environment

### DIFF
--- a/components/multi-platform-controller/production/kflux-prd-rh03/host-config.yaml
+++ b/components/multi-platform-controller/production/kflux-prd-rh03/host-config.yaml
@@ -37,7 +37,7 @@ data:
     linux-c8xlarge/arm64,\
     linux-d160-c8xlarge/amd64,\
     linux-d160-c8xlarge/arm64,\
-    linux-g6xlarge/amd64,\
+    linux-g64xlarge/amd64,\
     linux-root/arm64,\
     linux-root/amd64,\
     linux-fast/amd64,\
@@ -683,18 +683,18 @@ data:
   host.ppc64le-static-8.concurrency: "8"
 
 # GPU Instances
-  dynamic.linux-g6xlarge-amd64.type: aws
-  dynamic.linux-g6xlarge-amd64.region: us-east-1
-  dynamic.linux-g6xlarge-amd64.ami: ami-0ad6c6b0ac6c36199
-  dynamic.linux-g6xlarge-amd64.instance-type: g6.xlarge
-  dynamic.linux-g6xlarge-amd64.key-name: kflux-prd-rh03-key-pair
-  dynamic.linux-g6xlarge-amd64.aws-secret: aws-account
-  dynamic.linux-g6xlarge-amd64.ssh-secret: aws-ssh-key
-  dynamic.linux-g6xlarge-amd64.security-group-id: sg-0759f4a43faada557
-  dynamic.linux-g6xlarge-amd64.max-instances: "5"
-  dynamic.linux-g6xlarge-amd64.subnet-id: subnet-0263af86f44821eac
-  dynamic.linux-g6xlarge-amd64.instance-tag: prod-amd64-g6xlarge
-  dynamic.linux-g6xlarge-amd64.user-data: |-
+  dynamic.linux-g64xlarge-amd64.type: aws
+  dynamic.linux-g64xlarge-amd64.region: us-east-1
+  dynamic.linux-g64xlarge-amd64.ami: ami-0ab4e056cf67d0396
+  dynamic.linux-g64xlarge-amd64.instance-type: g6.4xlarge
+  dynamic.linux-g64xlarge-amd64.key-name: kflux-prd-rh03-key-pair
+  dynamic.linux-g64xlarge-amd64.aws-secret: aws-account
+  dynamic.linux-g64xlarge-amd64.ssh-secret: aws-ssh-key
+  dynamic.linux-g64xlarge-amd64.security-group-id: sg-0759f4a43faada557
+  dynamic.linux-g64xlarge-amd64.max-instances: "5"
+  dynamic.linux-g64xlarge-amd64.subnet-id: subnet-0263af86f44821eac
+  dynamic.linux-g64xlarge-amd64.instance-tag: prod-amd64-g6xlarge
+  dynamic.linux-g64xlarge-amd64.user-data: |-
     Content-Type: multipart/mixed; boundary="//"
     MIME-Version: 1.0
 


### PR DESCRIPTION
This commit will add the followings -
1. New GPU Instance g6.4xlarge
2. New RHEL Image with NVIDIA GPU Drivers Installed