### PR TITLE
mintmaker: update controller image in some clusters

### DIFF
--- a/components/mintmaker/production/kflux-ocp-p01/kustomization.yaml
+++ b/components/mintmaker/production/kflux-ocp-p01/kustomization.yaml
@@ -3,6 +3,12 @@ kind: Kustomization
 resources:
 - ../base
 namespace: mintmaker
+
+images:
+  - name: quay.io/konflux-ci/mintmaker
+    newName: quay.io/konflux-ci/mintmaker
+    newTag: a3816e76f5e06ba3114731fc34fa14f76d442b6c
+
 patches:
   - path: pipelines-as-code-secret-path.yaml
     target:

--- a/components/mintmaker/production/kflux-osp-p01/kustomization.yaml
+++ b/components/mintmaker/production/kflux-osp-p01/kustomization.yaml
@@ -3,6 +3,12 @@ kind: Kustomization
 resources:
 - ../base
 namespace: mintmaker
+
+images:
+  - name: quay.io/konflux-ci/mintmaker
+    newName: quay.io/konflux-ci/mintmaker
+    newTag: a3816e76f5e06ba3114731fc34fa14f76d442b6c
+
 patches:
   - path: pipelines-as-code-secret-path.yaml
     target:

--- a/components/mintmaker/production/kflux-prd-rh02/kustomization.yaml
+++ b/components/mintmaker/production/kflux-prd-rh02/kustomization.yaml
@@ -3,6 +3,12 @@ kind: Kustomization
 resources:
 - ../base
 namespace: mintmaker
+
+images:
+  - name: quay.io/konflux-ci/mintmaker
+    newName: quay.io/konflux-ci/mintmaker
+    newTag: a3816e76f5e06ba3114731fc34fa14f76d442b6c
+
 patches:
   - path: pipelines-as-code-secret-path.yaml
     target:

--- a/components/mintmaker/production/kflux-prd-rh03/kustomization.yaml
+++ b/components/mintmaker/production/kflux-prd-rh03/kustomization.yaml
@@ -3,6 +3,12 @@ kind: Kustomization
 resources:
 - ../base
 namespace: mintmaker
+
+images:
+  - name: quay.io/konflux-ci/mintmaker
+    newName: quay.io/konflux-ci/mintmaker
+    newTag: a3816e76f5e06ba3114731fc34fa14f76d442b6c
+
 patches:
   - path: pipelines-as-code-secret-path.yaml
     target:

--- a/components/mintmaker/production/kflux-rhel-p01/kustomization.yaml
+++ b/components/mintmaker/production/kflux-rhel-p01/kustomization.yaml
@@ -3,6 +3,12 @@ kind: Kustomization
 resources:
 - ../base
 namespace: mintmaker
+
+images:
+  - name: quay.io/konflux-ci/mintmaker
+    newName: quay.io/konflux-ci/mintmaker
+    newTag: a3816e76f5e06ba3114731fc34fa14f76d442b6c
+
 patches:
   - path: pipelines-as-code-secret-path.yaml
     target:

--- a/components/mintmaker/production/stone-prod-p01/kustomization.yaml
+++ b/components/mintmaker/production/stone-prod-p01/kustomization.yaml
@@ -3,6 +3,12 @@ kind: Kustomization
 resources:
 - ../base
 namespace: mintmaker
+
+images:
+  - name: quay.io/konflux-ci/mintmaker
+    newName: quay.io/konflux-ci/mintmaker
+    newTag: a3816e76f5e06ba3114731fc34fa14f76d442b6c
+
 patches:
   - path: pipelines-as-code-secret-path.yaml
     target:


### PR DESCRIPTION
Kueue has been deployed to some clusters. Update the MintMaker controller in these clusters to stop updating PipelineRun status to work with Kueue.

This controller update is specifically for https://github.com/konflux-ci/mintmaker/pull/327