### PR TITLE
stone-stage-p01: remove member operator resources

### DIFF
--- a/components/sandbox/toolchain-member-operator/staging/stone-stage-p01/kustomization.yaml
+++ b/components/sandbox/toolchain-member-operator/staging/stone-stage-p01/kustomization.yaml
@@ -1,12 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- ../base
-patches:
-- patch: |
-    $patch: delete
-    apiVersion: operators.coreos.com/v1alpha1
-    kind: Subscription
-    metadata:
-      name: dev-sandbox-member
-      namespace: toolchain-member-operator
+- ns.yaml

--- a/components/sandbox/toolchain-member-operator/staging/stone-stage-p01/ns.yaml
+++ b/components/sandbox/toolchain-member-operator/staging/stone-stage-p01/ns.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: toolchain-member-operator


### PR DESCRIPTION
Member operator has been removed from the toolchain-member-operator namespace, so we can clean up all the remaining resources.  Remove all resources from the toolchain-member-operator-stone-stage-p01 application (except the namespace, since argocd requires at least one resource).