### PR TITLE
mintmaker: re-enable renovate runs on Saturday

### DIFF
--- a/components/mintmaker/base/cronjobs/create-dependency-update-check.yaml
+++ b/components/mintmaker/base/cronjobs/create-dependency-update-check.yaml
@@ -4,7 +4,7 @@ metadata:
   name: create-dependencyupdatecheck
   namespace: mintmaker
 spec:
-  schedule: "0 */4 * * 0-5" # every 4 hours, except on Saturdays
+  schedule: "0 */4 * * *" # every 4 hours
   jobTemplate:
     spec:
       template:


### PR DESCRIPTION
This reverts commit b4bd31e2d653ceecf3c75dba5667cd3e0050052b, which disabled renovate runs on Saturday.

The blockers in the pipeline migration tool have been resolved, so we're fine to run tekton manager on Saturday.