### PR TITLE
PVO11Y-4876: Enable prometheus exporter/pipeline for Konflux opentelemetry in staging

### DIFF
--- a/components/tracing/otel-collector/staging/otel-collector-helm-values.yaml
+++ b/components/tracing/otel-collector/staging/otel-collector-helm-values.yaml
@@ -71,6 +71,15 @@ config:
         - batch
         exporters:
         - prometheus
+    telemetry:
+      metrics:
+        level: basic
+        readers:
+        - pull:
+            exporter: prometheus
+            host: 0.0.0.0
+            port: 8888
+
 # Configuration for ports
 ports:
   otlp:

--- a/components/tracing/otel-collector/staging/otel-collector-helm-values.yaml
+++ b/components/tracing/otel-collector/staging/otel-collector-helm-values.yaml
@@ -8,6 +8,8 @@ config:
       realm: "us1"
       api_url: "https://api.us1.signalfx.com"
       access_token: ${env:SIGNALFX_API_TOKEN} 
+    prometheus:
+      endpoint: 0.0.0.0:8889
   extensions:
     # The health_check extension is mandatory for this chart.
     # Without the health_check extension the collector will fail the readiness and liveliness probes.
@@ -61,7 +63,14 @@ config:
           - attributes/stage
         receivers:
           - otlp
-      metrics: null
+      metrics:
+        receivers:
+        - otlp
+        processors:
+        - memory_limiter
+        - batch
+        exporters:
+        - prometheus
 # Configuration for ports
 ports:
   otlp:


### PR DESCRIPTION
Configure otel-konflux opentelemetry deployment with pipeline for metrics export.