### PR TITLE
export kubearchive traces to cluster otlp collector

### DIFF
--- a/components/knative-eventing/staging/stone-stg-rh01/kustomization.yaml
+++ b/components/knative-eventing/staging/stone-stg-rh01/kustomization.yaml
@@ -3,3 +3,15 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../base
+
+patches:
+  - patch: |-
+      apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: config-tracing
+        namespace: knative-eventing
+      data:
+        backend: "zipkin"
+        zipkin-endpoint: "http://otel-collector.product-kubearchive.svc.cluster.local:9411/api/v2/spans"
+        sample-rate: "0.1"

--- a/components/kubearchive/base/monitoring-otel-collector.yaml
+++ b/components/kubearchive/base/monitoring-otel-collector.yaml
@@ -32,6 +32,8 @@ spec:
       port: 8888
     - name: https
       port: 8443
+    - name: zipkin
+      port: 9411
   selector:
     app: otel-collector
 ---

--- a/components/kubearchive/staging/stone-stg-rh01/kustomization.yaml
+++ b/components/kubearchive/staging/stone-stg-rh01/kustomization.yaml
@@ -30,3 +30,53 @@ patches:
       kind: Service
       metadata:
         name: postgresql
+  # Only export otel traces that are sampled by parent
+  - patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: kubearchive-sink
+        namespace: kubearchive
+      spec:
+        template:
+          spec:
+            containers:
+              - name: kubearchive-sink
+                env:
+                - name: KUBEARCHIVE_OTEL_MODE
+                  value: delegated
+  - patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: kubearchive-api-server
+        namespace: kubearchive
+      spec:
+        template:
+          spec:
+            containers:
+              - name: kubearchive-api-server
+                env:
+                - name: KUBEARCHIVE_OTEL_MODE
+                  value: delegated
+  - patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: kubearchive-operator
+        namespace: kubearchive
+      spec:
+        template:
+          spec:
+            containers:
+              - name: manager
+                env:
+                - name: KUBEARCHIVE_OTEL_MODE
+                  value: delegated
+
+configMapGenerator:
+  - name: otel-collector-conf
+    behavior: replace
+    namespace: product-kubearchive
+    files:
+      - otel-collector-config.yaml

--- a/components/kubearchive/staging/stone-stg-rh01/otel-collector-config.yaml
+++ b/components/kubearchive/staging/stone-stg-rh01/otel-collector-config.yaml
@@ -5,6 +5,7 @@ receivers:
       http:
         endpoint: 0.0.0.0:4318
   zipkin:
+    endpoint: 0.0.0.0:9411
 
 processors:
   batch:
@@ -25,6 +26,6 @@ service:
       processors: [batch]
       exporters: [prometheus]
     traces:
-      receivers: [otlp]
+      receivers: [otlp, zipkin]
       processors: [batch]
-      exporters: [debug,otlp]
+      exporters: [debug, otlp]


### PR DESCRIPTION
export kubearchive traces to cluster otlp collector so traces can be viewed in signalfx