### PR TITLE
MPC Host Config Changes for OpenStack and RH03 Environments

### DIFF
--- a/components/kueue/production/kflux-osp-p01/queue-config/cluster-queue.yaml
+++ b/components/kueue/production/kflux-osp-p01/queue-config/cluster-queue.yaml
@@ -97,9 +97,6 @@ spec:
     - linux-ppc64le
     - linux-root-amd64
     - linux-root-arm64
-    - linux-x86-64
-    - local
-    - localhost
     - linux-s390x
     flavors:
     - name: platform-group-2
@@ -126,14 +123,21 @@ spec:
         nominalQuota: '5'
       - name: linux-root-arm64
         nominalQuota: '5'
+      - name: linux-s390x
+        nominalQuota: '8'
+  - coveredResources:
+    - linux-x86-64
+    - local
+    - localhost
+    flavors:
+    - name: platform-group-3
+      resources:
       - name: linux-x86-64
         nominalQuota: '1000'
       - name: local
         nominalQuota: '1000'
       - name: localhost
         nominalQuota: '1000'
-      - name: linux-s390x
-        nominalQuota: '8'
 ---
 apiVersion: kueue.x-k8s.io/v1beta1
 kind: ResourceFlavor

--- a/components/kueue/production/kflux-osp-p01/queue-config/cluster-queue.yaml
+++ b/components/kueue/production/kflux-osp-p01/queue-config/cluster-queue.yaml
@@ -100,6 +100,7 @@ spec:
     - linux-x86-64
     - local
     - localhost
+    - linux-s390x
     flavors:
     - name: platform-group-2
       resources:
@@ -131,6 +132,8 @@ spec:
         nominalQuota: '1000'
       - name: localhost
         nominalQuota: '1000'
+      - name: linux-s390x
+        nominalQuota: '8'
 ---
 apiVersion: kueue.x-k8s.io/v1beta1
 kind: ResourceFlavor

--- a/components/kueue/production/kflux-prd-rh03/queue-config/cluster-queue.yaml
+++ b/components/kueue/production/kflux-prd-rh03/queue-config/cluster-queue.yaml
@@ -98,6 +98,8 @@ spec:
     - linux-mlarge-arm64
     - linux-mxlarge-amd64
     - linux-mxlarge-arm64
+    - linux-d160-m8-8xlarge-arm64
+    - linux-d160-m7-8xlarge-amd64
     - linux-ppc64le
     - linux-root-amd64
     - linux-root-arm64
@@ -128,6 +130,10 @@ spec:
       - name: linux-mxlarge-amd64
         nominalQuota: '5'
       - name: linux-mxlarge-arm64
+        nominalQuota: '5'
+      - name: linux-d160-m8-8xlarge-arm64
+        nominalQuota: '5'
+      - name: linux-d160-m7-8xlarge-amd64
         nominalQuota: '5'
       - name: linux-ppc64le
         nominalQuota: '64'

--- a/components/multi-platform-controller/production-downstream/kflux-osp-p01/host-config.yaml
+++ b/components/multi-platform-controller/production-downstream/kflux-osp-p01/host-config.yaml
@@ -492,7 +492,7 @@ data:
 
     --//--
 
-  # S390X 16vCPU / 64GiB RAM / 1TB disk
+  # S390X 8vCPU / 32GiB RAM / 1TB disk
   host.s390x-static-1.address: "10.130.78.4"
   host.s390x-static-1.platform: "linux/s390x"
   host.s390x-static-1.user: "root"

--- a/components/multi-platform-controller/production-downstream/kflux-osp-p01/host-config.yaml
+++ b/components/multi-platform-controller/production-downstream/kflux-osp-p01/host-config.yaml
@@ -492,6 +492,19 @@ data:
 
     --//--
 
+  # S390X 16vCPU / 64GiB RAM / 1TB disk
+  host.s390x-static-1.address: "10.130.78.4"
+  host.s390x-static-1.platform: "linux/s390x"
+  host.s390x-static-1.user: "root"
+  host.s390x-static-1.secret: "ibm-s390x-ssh-key"
+  host.s390x-static-1.concurrency: "4"
+
+  host.s390x-static-2.address: "10.130.78.20"
+  host.s390x-static-2.platform: "linux/s390x"
+  host.s390x-static-2.user: "root"
+  host.s390x-static-2.secret: "ibm-s390x-ssh-key"
+  host.s390x-static-2.concurrency: "4"
+
   # PPC64LE 4cores(32vCPU) / 128GiB RAM / 2TB disk
   host.pi-static-x0.address: "10.130.81.249"
   host.pi-static-x0.platform: "linux/ppc64le"

--- a/components/multi-platform-controller/production/kflux-prd-rh03/host-config.yaml
+++ b/components/multi-platform-controller/production/kflux-prd-rh03/host-config.yaml
@@ -788,6 +788,9 @@ data:
 
     mkdir -p /etc/cdi
     chmod a+rwx /etc/cdi
+
+    setsebool container_use_devices 1
+    
     su - ec2-user
     nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml
     --//--


### PR DESCRIPTION
These commits will make the following changes -

1. Add IBM Z (s390x) Machines for OpenStack Cluster
2. Add `setsebool container_use_devices 1` in user-data for a gpu-instance.