### PR TITLE
KubeArchive: fix DB path for stone-stage-p01

### DIFF
--- a/components/kubearchive/staging/stone-stage-p01/database-secret.yaml
+++ b/components/kubearchive/staging/stone-stage-p01/database-secret.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   dataFrom:
     - extract:
-        key: integrations-output/external-resources/appsres09ue1/stone-stage-p01/kube-archive-staging-rds
+        key: integrations-output/external-resources/appsres09ue1/stone-stage-p01/stone-stage-p01-kube-archive
   refreshInterval: 1h
   secretStoreRef:
     kind: ClusterSecretStore


### PR DESCRIPTION
Path for the DB secret was not correct.