### PR TITLE
Make queue generation script output deterministic

### DIFF
--- a/components/kueue/production/kflux-ocp-p01/queue-config/cluster-queue.yaml
+++ b/components/kueue/production/kflux-ocp-p01/queue-config/cluster-queue.yaml
@@ -1,9 +1,4 @@
 apiVersion: kueue.x-k8s.io/v1beta1
-kind: ResourceFlavor
-metadata:
-  name: default-flavor
----
-apiVersion: kueue.x-k8s.io/v1beta1
 kind: ClusterQueue
 metadata:
   name: cluster-pipeline-queue
@@ -18,7 +13,6 @@ spec:
     reclaimWithinCohort: Never
     withinClusterQueue: Never
   queueingStrategy: BestEffortFIFO
-  stopPolicy: None
   resourceGroups:
   - coveredResources:
     - tekton.dev/pipelineruns
@@ -168,6 +162,12 @@ spec:
         nominalQuota: '1000'
       - name: localhost
         nominalQuota: '1000'
+  stopPolicy: None
+---
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: ResourceFlavor
+metadata:
+  name: default-flavor
 ---
 apiVersion: kueue.x-k8s.io/v1beta1
 kind: ResourceFlavor

--- a/components/kueue/production/kflux-osp-p01/queue-config/cluster-queue.yaml
+++ b/components/kueue/production/kflux-osp-p01/queue-config/cluster-queue.yaml
@@ -1,9 +1,4 @@
 apiVersion: kueue.x-k8s.io/v1beta1
-kind: ResourceFlavor
-metadata:
-  name: default-flavor
----
-apiVersion: kueue.x-k8s.io/v1beta1
 kind: ClusterQueue
 metadata:
   name: cluster-pipeline-queue
@@ -18,7 +13,6 @@ spec:
     reclaimWithinCohort: Never
     withinClusterQueue: Never
   queueingStrategy: BestEffortFIFO
-  stopPolicy: None
   resourceGroups:
   - coveredResources:
     - tekton.dev/pipelineruns
@@ -131,6 +125,12 @@ spec:
         nominalQuota: '1000'
       - name: localhost
         nominalQuota: '1000'
+  stopPolicy: None
+---
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: ResourceFlavor
+metadata:
+  name: default-flavor
 ---
 apiVersion: kueue.x-k8s.io/v1beta1
 kind: ResourceFlavor

--- a/components/kueue/production/kflux-prd-rh02/queue-config/cluster-queue.yaml
+++ b/components/kueue/production/kflux-prd-rh02/queue-config/cluster-queue.yaml
@@ -1,9 +1,4 @@
 apiVersion: kueue.x-k8s.io/v1beta1
-kind: ResourceFlavor
-metadata:
-  name: default-flavor
----
-apiVersion: kueue.x-k8s.io/v1beta1
 kind: ClusterQueue
 metadata:
   name: cluster-pipeline-queue
@@ -18,7 +13,6 @@ spec:
     reclaimWithinCohort: Never
     withinClusterQueue: Never
   queueingStrategy: BestEffortFIFO
-  stopPolicy: None
   resourceGroups:
   - coveredResources:
     - tekton.dev/pipelineruns
@@ -156,6 +150,12 @@ spec:
         nominalQuota: '1000'
       - name: localhost
         nominalQuota: '1000'
+  stopPolicy: None
+---
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: ResourceFlavor
+metadata:
+  name: default-flavor
 ---
 apiVersion: kueue.x-k8s.io/v1beta1
 kind: ResourceFlavor

--- a/components/kueue/production/kflux-prd-rh03/queue-config/cluster-queue.yaml
+++ b/components/kueue/production/kflux-prd-rh03/queue-config/cluster-queue.yaml
@@ -1,9 +1,4 @@
 apiVersion: kueue.x-k8s.io/v1beta1
-kind: ResourceFlavor
-metadata:
-  name: default-flavor
----
-apiVersion: kueue.x-k8s.io/v1beta1
 kind: ClusterQueue
 metadata:
   name: cluster-pipeline-queue
@@ -18,7 +13,6 @@ spec:
     reclaimWithinCohort: Never
     withinClusterQueue: Never
   queueingStrategy: BestEffortFIFO
-  stopPolicy: None
   resourceGroups:
   - coveredResources:
     - tekton.dev/pipelineruns
@@ -49,7 +43,7 @@ spec:
     - linux-d160-c8xlarge-arm64
     - linux-d160-m2xlarge-amd64
     - linux-d160-m2xlarge-arm64
-    - linux-extra-fast-amd64
+    - linux-d160-m7-8xlarge-amd64
     flavors:
     - name: platform-group-1
       resources:
@@ -83,9 +77,11 @@ spec:
         nominalQuota: '5'
       - name: linux-d160-m2xlarge-arm64
         nominalQuota: '5'
-      - name: linux-extra-fast-amd64
+      - name: linux-d160-m7-8xlarge-amd64
         nominalQuota: '5'
   - coveredResources:
+    - linux-d160-m8-8xlarge-arm64
+    - linux-extra-fast-amd64
     - linux-fast-amd64
     - linux-g64xlarge-amd64
     - linux-m2xlarge-amd64
@@ -100,11 +96,13 @@ spec:
     - linux-mxlarge-arm64
     - linux-ppc64le
     - linux-root-amd64
-    - linux-root-arm64
-    - linux-s390x
     flavors:
     - name: platform-group-2
       resources:
+      - name: linux-d160-m8-8xlarge-arm64
+        nominalQuota: '5'
+      - name: linux-extra-fast-amd64
+        nominalQuota: '5'
       - name: linux-fast-amd64
         nominalQuota: '5'
       - name: linux-g64xlarge-amd64
@@ -133,23 +131,31 @@ spec:
         nominalQuota: '64'
       - name: linux-root-amd64
         nominalQuota: '5'
-      - name: linux-root-arm64
-        nominalQuota: '5'
-      - name: linux-s390x
-        nominalQuota: '56'
   - coveredResources:
+    - linux-root-arm64
+    - linux-s390x
     - linux-x86-64
     - local
     - localhost
     flavors:
     - name: platform-group-3
       resources:
+      - name: linux-root-arm64
+        nominalQuota: '5'
+      - name: linux-s390x
+        nominalQuota: '56'
       - name: linux-x86-64
         nominalQuota: '1000'
       - name: local
         nominalQuota: '1000'
       - name: localhost
         nominalQuota: '1000'
+  stopPolicy: None
+---
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: ResourceFlavor
+metadata:
+  name: default-flavor
 ---
 apiVersion: kueue.x-k8s.io/v1beta1
 kind: ResourceFlavor

--- a/components/kueue/production/kflux-rhel-p01/queue-config/cluster-queue.yaml
+++ b/components/kueue/production/kflux-rhel-p01/queue-config/cluster-queue.yaml
@@ -1,9 +1,4 @@
 apiVersion: kueue.x-k8s.io/v1beta1
-kind: ResourceFlavor
-metadata:
-  name: default-flavor
----
-apiVersion: kueue.x-k8s.io/v1beta1
 kind: ClusterQueue
 metadata:
   name: cluster-pipeline-queue
@@ -18,7 +13,6 @@ spec:
     reclaimWithinCohort: Never
     withinClusterQueue: Never
   queueingStrategy: BestEffortFIFO
-  stopPolicy: None
   resourceGroups:
   - coveredResources:
     - tekton.dev/pipelineruns
@@ -131,6 +125,12 @@ spec:
         nominalQuota: '1000'
       - name: localhost
         nominalQuota: '1000'
+  stopPolicy: None
+---
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: ResourceFlavor
+metadata:
+  name: default-flavor
 ---
 apiVersion: kueue.x-k8s.io/v1beta1
 kind: ResourceFlavor

--- a/components/kueue/production/stone-prd-rh01/queue-config/cluster-queue.yaml
+++ b/components/kueue/production/stone-prd-rh01/queue-config/cluster-queue.yaml
@@ -1,9 +1,4 @@
 apiVersion: kueue.x-k8s.io/v1beta1
-kind: ResourceFlavor
-metadata:
-  name: default-flavor
----
-apiVersion: kueue.x-k8s.io/v1beta1
 kind: ClusterQueue
 metadata:
   name: cluster-pipeline-queue
@@ -18,7 +13,6 @@ spec:
     reclaimWithinCohort: Never
     withinClusterQueue: Never
   queueingStrategy: BestEffortFIFO
-  stopPolicy: None
   resourceGroups:
   - coveredResources:
     - tekton.dev/pipelineruns
@@ -156,6 +150,12 @@ spec:
         nominalQuota: '1000'
       - name: localhost
         nominalQuota: '1000'
+  stopPolicy: None
+---
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: ResourceFlavor
+metadata:
+  name: default-flavor
 ---
 apiVersion: kueue.x-k8s.io/v1beta1
 kind: ResourceFlavor

--- a/components/kueue/production/stone-prod-p01/queue-config/cluster-queue.yaml
+++ b/components/kueue/production/stone-prod-p01/queue-config/cluster-queue.yaml
@@ -1,9 +1,4 @@
 apiVersion: kueue.x-k8s.io/v1beta1
-kind: ResourceFlavor
-metadata:
-  name: default-flavor
----
-apiVersion: kueue.x-k8s.io/v1beta1
 kind: ClusterQueue
 metadata:
   name: cluster-pipeline-queue
@@ -18,7 +13,6 @@ spec:
     reclaimWithinCohort: Never
     withinClusterQueue: Never
   queueingStrategy: BestEffortFIFO
-  stopPolicy: None
   resourceGroups:
   - coveredResources:
     - tekton.dev/pipelineruns
@@ -144,6 +138,12 @@ spec:
       resources:
       - name: localhost
         nominalQuota: '1000'
+  stopPolicy: None
+---
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: ResourceFlavor
+metadata:
+  name: default-flavor
 ---
 apiVersion: kueue.x-k8s.io/v1beta1
 kind: ResourceFlavor

--- a/components/kueue/production/stone-prod-p02/queue-config/cluster-queue.yaml
+++ b/components/kueue/production/stone-prod-p02/queue-config/cluster-queue.yaml
@@ -1,9 +1,4 @@
 apiVersion: kueue.x-k8s.io/v1beta1
-kind: ResourceFlavor
-metadata:
-  name: default-flavor
----
-apiVersion: kueue.x-k8s.io/v1beta1
 kind: ClusterQueue
 metadata:
   name: cluster-pipeline-queue
@@ -18,7 +13,6 @@ spec:
     reclaimWithinCohort: Never
     withinClusterQueue: Never
   queueingStrategy: BestEffortFIFO
-  stopPolicy: None
   resourceGroups:
   - coveredResources:
     - tekton.dev/pipelineruns
@@ -156,6 +150,12 @@ spec:
         nominalQuota: '1000'
       - name: localhost
         nominalQuota: '1000'
+  stopPolicy: None
+---
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: ResourceFlavor
+metadata:
+  name: default-flavor
 ---
 apiVersion: kueue.x-k8s.io/v1beta1
 kind: ResourceFlavor

--- a/components/kueue/staging/stone-stage-p01/queue-config/cluster-queue.yaml
+++ b/components/kueue/staging/stone-stage-p01/queue-config/cluster-queue.yaml
@@ -1,9 +1,4 @@
 apiVersion: kueue.x-k8s.io/v1beta1
-kind: ResourceFlavor
-metadata:
-  name: default-flavor
----
-apiVersion: kueue.x-k8s.io/v1beta1
 kind: AdmissionCheck
 metadata:
   name: static-admission
@@ -27,7 +22,6 @@ spec:
     reclaimWithinCohort: Never
     withinClusterQueue: Never
   queueingStrategy: BestEffortFIFO
-  stopPolicy: None
   resourceGroups:
   - coveredResources:
     - tekton.dev/pipelineruns
@@ -137,6 +131,12 @@ spec:
         nominalQuota: '1000'
       - name: localhost
         nominalQuota: '1000'
+  stopPolicy: None
+---
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: ResourceFlavor
+metadata:
+  name: default-flavor
 ---
 apiVersion: kueue.x-k8s.io/v1beta1
 kind: ResourceFlavor

--- a/components/kueue/staging/stone-stg-rh01/queue-config/cluster-queue.yaml
+++ b/components/kueue/staging/stone-stg-rh01/queue-config/cluster-queue.yaml
@@ -1,9 +1,4 @@
 apiVersion: kueue.x-k8s.io/v1beta1
-kind: ResourceFlavor
-metadata:
-  name: default-flavor
----
-apiVersion: kueue.x-k8s.io/v1beta1
 kind: AdmissionCheck
 metadata:
   name: static-admission
@@ -27,7 +22,6 @@ spec:
     reclaimWithinCohort: Never
     withinClusterQueue: Never
   queueingStrategy: BestEffortFIFO
-  stopPolicy: None
   resourceGroups:
   - coveredResources:
     - tekton.dev/pipelineruns
@@ -140,6 +134,12 @@ spec:
         nominalQuota: '1000'
       - name: localhost
         nominalQuota: '1000'
+  stopPolicy: None
+---
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: ResourceFlavor
+metadata:
+  name: default-flavor
 ---
 apiVersion: kueue.x-k8s.io/v1beta1
 kind: ResourceFlavor


### PR DESCRIPTION
Sort the data produced by update-kueue-vm-quotas.py in order to get a consistent output.

Update all the cluster queue as well.

Assisted-By: Cursor