### PR TITLE
KFLUXINFRA-1654: Adding IBM Z Nodes for OpenStack Environment

### DIFF
--- a/components/kueue/production/kflux-osp-p01/queue-config/cluster-queue.yaml
+++ b/components/kueue/production/kflux-osp-p01/queue-config/cluster-queue.yaml
@@ -91,6 +91,7 @@ spec:
     - linux-ppc64le
     - linux-root-amd64
     - linux-root-arm64
+    - linux-s390x
     - linux-x86-64
     - local
     - localhost
@@ -119,6 +120,8 @@ spec:
         nominalQuota: '5'
       - name: linux-root-arm64
         nominalQuota: '5'
+      - name: linux-s390x
+        nominalQuota: '8'
       - name: linux-x86-64
         nominalQuota: '1000'
       - name: local

--- a/components/multi-platform-controller/production-downstream/kflux-osp-p01/host-config.yaml
+++ b/components/multi-platform-controller/production-downstream/kflux-osp-p01/host-config.yaml
@@ -491,7 +491,19 @@ data:
     restorecon -r /home/ec2-user
 
     --//--
+  # S390X 8vCPU / 32GiB RAM / 1TB disk
+  host.s390x-static-1.address: "10.130.78.4"
+  host.s390x-static-1.platform: "linux/s390x"
+  host.s390x-static-1.user: "root"
+  host.s390x-static-1.secret: "ibm-s390x-ssh-key"
+  host.s390x-static-1.concurrency: "4"
 
+  host.s390x-static-2.address: "10.130.78.20"
+  host.s390x-static-2.platform: "linux/s390x"
+  host.s390x-static-2.user: "root"
+  host.s390x-static-2.secret: "ibm-s390x-ssh-key"
+  host.s390x-static-2.concurrency: "4"
+  
   # PPC64LE 4cores(32vCPU) / 128GiB RAM / 2TB disk
   host.pi-static-x0.address: "10.130.81.249"
   host.pi-static-x0.platform: "linux/ppc64le"

--- a/components/multi-platform-controller/production/kflux-prd-rh03/host-config.yaml
+++ b/components/multi-platform-controller/production/kflux-prd-rh03/host-config.yaml
@@ -788,6 +788,9 @@ data:
 
     mkdir -p /etc/cdi
     chmod a+rwx /etc/cdi
+
+    setsebool container_use_devices 1
+    
     su - ec2-user
     nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml
     --//--


### PR DESCRIPTION
This commit will add IBM Z Nodes for OpenStack Environment and add a command in user-data for a gpu instance in RH03 Environment