### PR TITLE
KubeArchive: another fix for the DB path

### DIFF
--- a/components/kubearchive/staging/stone-stage-p01/database-secret.yaml
+++ b/components/kubearchive/staging/stone-stage-p01/database-secret.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   dataFrom:
     - extract:
-        key: integrations-output/external-resources/appsres09ue1/stone-stage-p01/stone-stage-p01-kube-archive
+        key: integrations-output/external-resources/appsres09ue1/stone-stage-p01/stone-stage-p01-kube-archive-rds
   refreshInterval: 1h
   secretStoreRef:
     kind: ClusterSecretStore


### PR DESCRIPTION
I missed the `-rds` part