### PR TITLE
override pac version to v0.36.0 in dev/staging

### DIFF
--- a/components/pipeline-service/development/main-pipeline-service-configuration.yaml
+++ b/components/pipeline-service/development/main-pipeline-service-configuration.yaml
@@ -2266,6 +2266,13 @@ spec:
         value: "false"
       - name: IMAGE_ADDONS_TKN_CLI_SERVE
         value: registry.redhat.io/openshift-pipelines/pipelines-serve-tkn-cli-rhel9@sha256:d055d2b35a663aef3e1aafdbed0b12957867c0670c946ebae66e9c44a768bda2
+      # TODO: These override the nightly build to use PaC v0.36.0. Remove these at a later date
+      - name: IMAGE_PAC_PAC_CONTROLLER
+        value: quay.io/openshift-pipeline/pipelines-pipelines-as-code-controller-rhel9@sha256:574a2eb9014ee937307c7cfcb31490a80c8f259c13271dd759e9b74a8d54c5d2
+      - name: IMAGE_PAC_PAC_WEBHOOK
+        value: quay.io/openshift-pipeline/pipelines-pipelines-as-code-webhook-rhel9@sha256:ca6285148d6a6ece681b5583cf4724da98228f97d73cc27e90464425b41ff986
+      - name: IMAGE_PAC_PAC_WATCHER
+        value: quay.io/openshift-pipeline/pipelines-pipelines-as-code-watcher-rhel9@sha256:5bdbc16185dc0def4f9bb1d1b67f5bd83363f8c4285d91597641099322d2a030
 ---
 apiVersion: route.openshift.io/v1
 kind: Route

--- a/components/pipeline-service/staging/base/main-pipeline-service-configuration.yaml
+++ b/components/pipeline-service/staging/base/main-pipeline-service-configuration.yaml
@@ -2093,12 +2093,20 @@ spec:
         value: "false"
       - name: IMAGE_ADDONS_TKN_CLI_SERVE
         value: registry.redhat.io/openshift-pipelines/pipelines-serve-tkn-cli-rhel9@sha256:d055d2b35a663aef3e1aafdbed0b12957867c0670c946ebae66e9c44a768bda2
+      # TODO: These override the nightly build to use PaC v0.36.0. Remove these at a later date
       - name: IMAGE_PAC_PAC_CONTROLLER
-        value: ghcr.io/gbenhaim/pipelines-as-code/pipelines-as-code-controller@sha256:dea65f29afcecdd837b0b7389c6824d546b5098bf98ba98f02f27d6a85b0b376
-      - name: IMAGE_PAC_PAC_WATCHER
-        value: ghcr.io/gbenhaim/pipelines-as-code/pipelines-as-code-watcher@sha256:09964eff749f2fb620ae1500cfc538d0765cf0e29fb2f177abb3521400fad403
+        value: quay.io/openshift-pipeline/pipelines-pipelines-as-code-controller-rhel9@sha256:574a2eb9014ee937307c7cfcb31490a80c8f259c13271dd759e9b74a8d54c5d2
       - name: IMAGE_PAC_PAC_WEBHOOK
-        value: ghcr.io/gbenhaim/pipelines-as-code/pipelines-as-code-webhook@sha256:440d6f9311d23b994ef68ffe0513eba832b891fdfb6360385bb635ba154f7526
+        value: quay.io/openshift-pipeline/pipelines-pipelines-as-code-webhook-rhel9@sha256:ca6285148d6a6ece681b5583cf4724da98228f97d73cc27e90464425b41ff986
+      - name: IMAGE_PAC_PAC_WATCHER
+        value: quay.io/openshift-pipeline/pipelines-pipelines-as-code-watcher-rhel9@sha256:5bdbc16185dc0def4f9bb1d1b67f5bd83363f8c4285d91597641099322d2a030
+      # TODO: images used for Kueue testing @gbenhaim
+      # - name: IMAGE_PAC_PAC_CONTROLLER
+      #   value: ghcr.io/gbenhaim/pipelines-as-code/pipelines-as-code-controller@sha256:dea65f29afcecdd837b0b7389c6824d546b5098bf98ba98f02f27d6a85b0b376
+      # - name: IMAGE_PAC_PAC_WATCHER
+      #   value: ghcr.io/gbenhaim/pipelines-as-code/pipelines-as-code-watcher@sha256:09964eff749f2fb620ae1500cfc538d0765cf0e29fb2f177abb3521400fad403
+      # - name: IMAGE_PAC_PAC_WEBHOOK
+      #   value: ghcr.io/gbenhaim/pipelines-as-code/pipelines-as-code-webhook@sha256:440d6f9311d23b994ef68ffe0513eba832b891fdfb6360385bb635ba154f7526
 ---
 apiVersion: route.openshift.io/v1
 kind: Route

--- a/components/pipeline-service/staging/stone-stage-p01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stage-p01/deploy.yaml
@@ -2677,11 +2677,11 @@ spec:
     - name: IMAGE_ADDONS_TKN_CLI_SERVE
       value: registry.redhat.io/openshift-pipelines/pipelines-serve-tkn-cli-rhel9@sha256:d055d2b35a663aef3e1aafdbed0b12957867c0670c946ebae66e9c44a768bda2
     - name: IMAGE_PAC_PAC_CONTROLLER
-      value: ghcr.io/gbenhaim/pipelines-as-code/pipelines-as-code-controller@sha256:dea65f29afcecdd837b0b7389c6824d546b5098bf98ba98f02f27d6a85b0b376
-    - name: IMAGE_PAC_PAC_WATCHER
-      value: ghcr.io/gbenhaim/pipelines-as-code/pipelines-as-code-watcher@sha256:09964eff749f2fb620ae1500cfc538d0765cf0e29fb2f177abb3521400fad403
+      value: quay.io/openshift-pipeline/pipelines-pipelines-as-code-controller-rhel9@sha256:574a2eb9014ee937307c7cfcb31490a80c8f259c13271dd759e9b74a8d54c5d2
     - name: IMAGE_PAC_PAC_WEBHOOK
-      value: ghcr.io/gbenhaim/pipelines-as-code/pipelines-as-code-webhook@sha256:440d6f9311d23b994ef68ffe0513eba832b891fdfb6360385bb635ba154f7526
+      value: quay.io/openshift-pipeline/pipelines-pipelines-as-code-webhook-rhel9@sha256:ca6285148d6a6ece681b5583cf4724da98228f97d73cc27e90464425b41ff986
+    - name: IMAGE_PAC_PAC_WATCHER
+      value: quay.io/openshift-pipeline/pipelines-pipelines-as-code-watcher-rhel9@sha256:5bdbc16185dc0def4f9bb1d1b67f5bd83363f8c4285d91597641099322d2a030
   name: openshift-pipelines-operator-rh
   source: custom-operators
   sourceNamespace: openshift-marketplace

--- a/components/pipeline-service/staging/stone-stg-rh01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stg-rh01/deploy.yaml
@@ -2689,11 +2689,11 @@ spec:
     - name: IMAGE_ADDONS_TKN_CLI_SERVE
       value: registry.redhat.io/openshift-pipelines/pipelines-serve-tkn-cli-rhel9@sha256:d055d2b35a663aef3e1aafdbed0b12957867c0670c946ebae66e9c44a768bda2
     - name: IMAGE_PAC_PAC_CONTROLLER
-      value: ghcr.io/gbenhaim/pipelines-as-code/pipelines-as-code-controller@sha256:dea65f29afcecdd837b0b7389c6824d546b5098bf98ba98f02f27d6a85b0b376
-    - name: IMAGE_PAC_PAC_WATCHER
-      value: ghcr.io/gbenhaim/pipelines-as-code/pipelines-as-code-watcher@sha256:09964eff749f2fb620ae1500cfc538d0765cf0e29fb2f177abb3521400fad403
+      value: quay.io/openshift-pipeline/pipelines-pipelines-as-code-controller-rhel9@sha256:574a2eb9014ee937307c7cfcb31490a80c8f259c13271dd759e9b74a8d54c5d2
     - name: IMAGE_PAC_PAC_WEBHOOK
-      value: ghcr.io/gbenhaim/pipelines-as-code/pipelines-as-code-webhook@sha256:440d6f9311d23b994ef68ffe0513eba832b891fdfb6360385bb635ba154f7526
+      value: quay.io/openshift-pipeline/pipelines-pipelines-as-code-webhook-rhel9@sha256:ca6285148d6a6ece681b5583cf4724da98228f97d73cc27e90464425b41ff986
+    - name: IMAGE_PAC_PAC_WATCHER
+      value: quay.io/openshift-pipeline/pipelines-pipelines-as-code-watcher-rhel9@sha256:5bdbc16185dc0def4f9bb1d1b67f5bd83363f8c4285d91597641099322d2a030
   name: openshift-pipelines-operator-rh
   source: custom-operators
   sourceNamespace: openshift-marketplace


### PR DESCRIPTION
The nightly build should be using PaC `v0.36.X`, however some automation seems to have caused the nightly build to switch back to `v0.35.X` several days after it updated to `v0.36.X`.

This PR overrides the PaC images to those which point to `v0.36.0`