### PR TITLE
mintmaker: Remove cluster-specific controller image overrides

### DIFF
--- a/components/mintmaker/production/kflux-ocp-p01/kustomization.yaml
+++ b/components/mintmaker/production/kflux-ocp-p01/kustomization.yaml
@@ -3,12 +3,6 @@ kind: Kustomization
 resources:
 - ../base
 namespace: mintmaker
-
-images:
-  - name: quay.io/konflux-ci/mintmaker
-    newName: quay.io/konflux-ci/mintmaker
-    newTag: a3816e76f5e06ba3114731fc34fa14f76d442b6c
-
 patches:
   - path: pipelines-as-code-secret-path.yaml
     target:

--- a/components/mintmaker/production/kflux-osp-p01/kustomization.yaml
+++ b/components/mintmaker/production/kflux-osp-p01/kustomization.yaml
@@ -3,12 +3,6 @@ kind: Kustomization
 resources:
 - ../base
 namespace: mintmaker
-
-images:
-  - name: quay.io/konflux-ci/mintmaker
-    newName: quay.io/konflux-ci/mintmaker
-    newTag: a3816e76f5e06ba3114731fc34fa14f76d442b6c
-
 patches:
   - path: pipelines-as-code-secret-path.yaml
     target:

--- a/components/mintmaker/production/kflux-prd-rh02/kustomization.yaml
+++ b/components/mintmaker/production/kflux-prd-rh02/kustomization.yaml
@@ -3,12 +3,6 @@ kind: Kustomization
 resources:
 - ../base
 namespace: mintmaker
-
-images:
-  - name: quay.io/konflux-ci/mintmaker
-    newName: quay.io/konflux-ci/mintmaker
-    newTag: a3816e76f5e06ba3114731fc34fa14f76d442b6c
-
 patches:
   - path: pipelines-as-code-secret-path.yaml
     target:

--- a/components/mintmaker/production/kflux-prd-rh03/kustomization.yaml
+++ b/components/mintmaker/production/kflux-prd-rh03/kustomization.yaml
@@ -3,12 +3,6 @@ kind: Kustomization
 resources:
 - ../base
 namespace: mintmaker
-
-images:
-  - name: quay.io/konflux-ci/mintmaker
-    newName: quay.io/konflux-ci/mintmaker
-    newTag: a3816e76f5e06ba3114731fc34fa14f76d442b6c
-
 patches:
   - path: pipelines-as-code-secret-path.yaml
     target:

--- a/components/mintmaker/production/kflux-rhel-p01/kustomization.yaml
+++ b/components/mintmaker/production/kflux-rhel-p01/kustomization.yaml
@@ -3,12 +3,6 @@ kind: Kustomization
 resources:
 - ../base
 namespace: mintmaker
-
-images:
-  - name: quay.io/konflux-ci/mintmaker
-    newName: quay.io/konflux-ci/mintmaker
-    newTag: a3816e76f5e06ba3114731fc34fa14f76d442b6c
-
 patches:
   - path: pipelines-as-code-secret-path.yaml
     target:

--- a/components/mintmaker/production/stone-prod-p01/kustomization.yaml
+++ b/components/mintmaker/production/stone-prod-p01/kustomization.yaml
@@ -3,12 +3,6 @@ kind: Kustomization
 resources:
 - ../base
 namespace: mintmaker
-
-images:
-  - name: quay.io/konflux-ci/mintmaker
-    newName: quay.io/konflux-ci/mintmaker
-    newTag: a3816e76f5e06ba3114731fc34fa14f76d442b6c
-
 patches:
   - path: pipelines-as-code-secret-path.yaml
     target:


### PR DESCRIPTION
Since Kueue is now deployed to all clusters, a single, consistent controller image can be used across all production clusters. This reverts 8b2e6366 where the temporary override was applied for clusters with early Kueue deployments.