### PR TITLE
KubeArchive: fix staging traces exporter URL

### DIFF
--- a/components/kubearchive/staging/stone-stg-rh01/otel-collector-config.yaml
+++ b/components/kubearchive/staging/stone-stg-rh01/otel-collector-config.yaml
@@ -16,7 +16,7 @@ exporters:
     send_timestamps: true
     add_metric_suffixes: false
   otlp:  # otlp collector that sends traces to signalfx
-    endpoint: open-telemetry-opentelemetry-collector.konflux-otel.svc.cluster.local:4318
+    endpoint: http://open-telemetry-opentelemetry-collector.konflux-otel.svc.cluster.local:4318/v1/traces
   debug:
 
 service:


### PR DESCRIPTION
Trying another URL based off of other projects.