### PR TITLE
KubeArchive: disable TLS for OTLP exporter

### DIFF
--- a/components/kubearchive/staging/stone-stg-rh01/otel-collector-config.yaml
+++ b/components/kubearchive/staging/stone-stg-rh01/otel-collector-config.yaml
@@ -16,7 +16,9 @@ exporters:
     send_timestamps: true
     add_metric_suffixes: false
   otlp:  # otlp collector that sends traces to signalfx
-    endpoint: http://open-telemetry-opentelemetry-collector.konflux-otel.svc.cluster.local:4318/v1/traces
+    endpoint: open-telemetry-opentelemetry-collector.konflux-otel.svc.cluster.local:4318
+    tls:
+      insecure: true
   debug:
 
 service:


### PR DESCRIPTION
Revert the last change and fix the real problem: TLS