### PR TITLE
KubeArchive: fix trace sending to konflux-otel

### DIFF
--- a/components/kubearchive/staging/stone-stg-rh01/otel-collector-config.yaml
+++ b/components/kubearchive/staging/stone-stg-rh01/otel-collector-config.yaml
@@ -16,7 +16,7 @@ exporters:
     send_timestamps: true
     add_metric_suffixes: false
   otlp:  # otlp collector that sends traces to signalfx
-    endpoint: open-telemetry-opentelemetry-collector.konflux-otel.svc.cluster.local:4318
+    endpoint: open-telemetry-opentelemetry-collector.konflux-otel.svc.cluster.local:4317
     tls:
       insecure: true
   debug:


### PR DESCRIPTION
Looks like the endpoint is expected to be a GRPC:

```
2025-08-08T09:03:54.488Z info internal/retry_sender.go:133 Exporting failed. Will retry the request after interval. {"error": "rpc error: code = Unavailable desc = connection error: desc = \"error reading server preface: http2: frame too large\"", "interval": "3.074100606s"}
```