### PR TITLE
KubeArchive loki: remove second tmp folder

### DIFF
--- a/components/vector-kubearchive-log-collector/OWNERS
+++ b/components/vector-kubearchive-log-collector/OWNERS
@@ -1,0 +1,17 @@
+# See the OWNERS docs: https://go.k8s.io/owners
+
+approvers:
+- rh-hemartin
+- skoved
+- ggallen
+- maruiz93
+- mafh314
+- olegbet
+
+reviewers:
+- rh-hemartin
+- skoved
+- ggallen
+- maruiz93
+- mafh314
+- olegbet

--- a/components/vector-kubearchive-log-collector/staging/stone-stg-rh01/loki-helm-values.yaml
+++ b/components/vector-kubearchive-log-collector/staging/stone-stg-rh01/loki-helm-values.yaml
@@ -35,12 +35,8 @@ singleBinary:
   extraVolumeMounts:
     - name: loki-storage
       mountPath: /var/loki
-    - name: tmp-storage
-      mountPath: /tmp
   extraVolumes:
     - name: loki-storage
-      emptyDir: {}
-    - name: tmp-storage
       emptyDir: {}
 
 # Basic Loki configuration with S3 storage


### PR DESCRIPTION
Remove a tmp folder because there are two things trying to mount into `/tmp`. Added OWNER files as well.