### PR TITLE
Make kubearchive admins of the product-kubearchive-logging component

### DIFF
--- a/components/vector-kubearchive-log-collector/base/kustomization.yaml
+++ b/components/vector-kubearchive-log-collector/base/kustomization.yaml
@@ -6,3 +6,4 @@ commonAnnotations:
 
 resources:
 - vector-pre.yaml
+- rbac.yaml

--- a/components/vector-kubearchive-log-collector/base/rbac.yaml
+++ b/components/vector-kubearchive-log-collector/base/rbac.yaml
@@ -1,0 +1,28 @@
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: kubearchive-logging-component-maintainers
+  namespace: product-kubearchive-logging
+subjects:
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: konflux-kubearchive  # rover group
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: component-maintainer
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: kubearchive-logging-admin
+  namespace: product-kubearchive-logging
+subjects:
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: konflux-kubearchive  # rover group
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: admin


### PR DESCRIPTION
The kubearchive team should be able to check logs, do port-forwards and manipulate resources to troubleshoot potential issues in this component.