### PR TITLE
mintmaker: set GOMEMLIMIT to avoid controller OOMKilled crashes

### DIFF
--- a/components/mintmaker/production/base/manager_patch.yaml
+++ b/components/mintmaker/production/base/manager_patch.yaml
@@ -15,3 +15,6 @@ spec:
           requests:
             cpu: 100m
             memory: 8Gi
+        env:
+        - name: GOMEMLIMIT
+          value: "7GiB"


### PR DESCRIPTION
Set GOMEMLIMIT=7GiB so the Go runtime respects Kubernetes memory limits. Although the controller is allocated 8GiB memory, in large clusters (e.g., p02 with 5000+ components) it can still be OOMKilled, possibly due to the Go runtime ignoring container limits.