### PR TITLE
Add kubearchive-logging to staging

### DIFF
--- a/components/kubearchive/staging/base/external-secret.yaml
+++ b/components/kubearchive/staging/base/external-secret.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: kubearchive-logging
+  namespace: product-kubearchive
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  dataFrom:
+    - extract:
+        key: staging/kubearchive/logging
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: appsre-stonesoup-vault
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    name: kubearchive-logging

--- a/components/kubearchive/staging/base/kustomization.yaml
+++ b/components/kubearchive/staging/base/kustomization.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../development
+  - external-secret.yaml
+
+patches:
+  - patch: |-
+      apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: kubearchive-logging
+        namespace: product-kubearchive
+      data:
+        POD_ID: "cel:metadata.uid"
+        START: "cel:status.?startTime == optional.none() ? int(now()-duration('1h'))*1000000000: status.startTime"
+        END: "cel:status.?startTime == optional.none() ? int(now()+duration('1h'))*1000000000: int(timestamp(status.startTime)+duration('6h'))*1000000000" # temporary workaround until CONTAINER_NAME is allowed on CEL expressions as variable: 6 hours since the container started
+        LOG_URL: "http://loki-headless.product-kubearchive-logging.svc.cluster.local:3100/loki/api/v1/query_range?query=%7Bpod_id%3D%22{POD_ID}%22%2C%20container%3D%22{CONTAINER_NAME}%22%7D%20%7C%20json%20%7C%20line_format%20%22%7B%7B.message%7D%7D%22&start={START}&end={END}&direction=forward"
+        LOG_URL_JSONPATH: "$.data.result[*].values[*][1]"

--- a/components/kubearchive/staging/stone-stg-rh01/kustomization.yaml
+++ b/components/kubearchive/staging/stone-stg-rh01/kustomization.yaml
@@ -2,7 +2,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ../../development
+  - ../base
   - kubearchive-routes.yaml
   - database-secret.yaml
 


### PR DESCRIPTION
Now that Konflux includes the tekton related logs in an in-cluster loki (managed under the `vector-kubearchive-log-collector` component, we need to set up kubearchive to be able to retrieve logs from there through its API.