### PR TITLE
add ClusterPolicy to deny reserved virtual domain

### DIFF
--- a/components/policies/development/namespace-lister/deny-virtual-domain/.chainsaw-test/chainsaw-assert-clusterpolicy.yaml
+++ b/components/policies/development/namespace-lister/deny-virtual-domain/.chainsaw-test/chainsaw-assert-clusterpolicy.yaml
@@ -1,0 +1,9 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: deny-virtual-domain
+status:
+  conditions:
+  - reason: Succeeded
+    status: "True"
+    type: Ready

--- a/components/policies/development/namespace-lister/deny-virtual-domain/.chainsaw-test/chainsaw-test.yaml
+++ b/components/policies/development/namespace-lister/deny-virtual-domain/.chainsaw-test/chainsaw-test.yaml
@@ -1,0 +1,355 @@
+---
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: allow-namespace-without-virtual-label-and-annotation
+spec:
+  concurrent: false
+  description: |
+    Tests that the creation of a tenant namespace neither labeled
+    nor annotated with domain `virtual.konflux-ci.dev` is allowed
+  steps:
+    - name: Apply Kyverno Cluster Policy and assert it exists
+      try:
+        - apply:
+            file: ../deny-virtual-domain.yaml
+        - assert:
+            file: chainsaw-assert-clusterpolicy.yaml
+    - name: Create a tenant namespace without virtual domain label
+      try:
+        - create:
+            file: ./resources/namespace-no-labels.yaml
+            template: true
+            bindings:
+              - name: namespace
+                value: namespace-no-labels
+            expect:
+              - match:
+                  kind: Namespace
+                check:
+                  ($error == null): true
+---
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: allow-tenant-namespace-without-virtual-label-and-annotation
+spec:
+  concurrent: false
+  description: |
+    Tests that creation of a namespace neither labeled nor annotated
+    with `virtual.konflux-ci.dev` is allowed
+  steps:
+    - name: Apply Kyverno Cluster Policy and assert it exists
+      try:
+        - apply:
+            file: ../deny-virtual-domain.yaml
+        - assert:
+            file: chainsaw-assert-clusterpolicy.yaml
+    - name: Create a namespace without labels
+      try:
+        - create:
+            file: ./resources/tenant-namespace.yaml
+            template: true
+            bindings:
+              - name: namespace
+                value: tenant-namespace-allow
+            expect:
+              - match:
+                  kind: Namespace
+                check:
+                  ($error == null): true
+## Annotations
+---
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: allow-namespace-with-virtual-annotation
+spec:
+  concurrent: false
+  description: |
+    Tests that creation of a namespace annotated with
+    `virtual.konflux-ci.dev` is allowed
+  steps:
+    - name: Apply Kyverno Cluster Policy and assert it exists
+      try:
+        - apply:
+            file: ../deny-virtual-domain.yaml
+        - assert:
+            file: chainsaw-assert-clusterpolicy.yaml
+    - name: Create a namespace with virtual label
+      try:
+        - create:
+            file: ./resources/namespace-with-virtual-annotation.yaml
+            template: true
+            bindings:
+              - name: namespace
+                value: namespace-annotation-allow
+            expect:
+              - match:
+                  kind: Namespace
+                check:
+                  ($error == null): true
+---
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: deny-tenant-namespace-with-virtual-annotation
+spec:
+  concurrent: false
+  description: |
+    Tests that creation of a tenant namespace annotated with
+    `virtual.konflux-ci.dev` is denied
+  steps:
+    - name: Apply Kyverno Cluster Policy and assert it exists
+      try:
+        - apply:
+            file: ../deny-virtual-domain.yaml
+        - assert:
+            file: chainsaw-assert-clusterpolicy.yaml
+    - name: Create a tenant namespace with virtual annotation
+      try:
+        - create:
+            file: ./resources/tenant-namespace-with-virtual-annotation.yaml
+            template: true
+            bindings:
+              - name: namespace
+                value: tenant-namespace-annotation-deny
+            expect:
+              - match:
+                  kind: Namespace
+                check:
+                  ($error == null): false
+---
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: deny-promoted-tenant-namespace-with-virtual-annotation
+spec:
+  concurrent: false
+  description: |
+    Tests that a namespace annotated with `virtual.konflux-ci.dev` can not
+    be promoted to tenant namespace
+  steps:
+    - name: Apply Kyverno Cluster Policy and assert it exists
+      try:
+        - apply:
+            file: ../deny-virtual-domain.yaml
+        - assert:
+            file: chainsaw-assert-clusterpolicy.yaml
+    - name: Create a namespace with virtual annotation
+      try:
+        - create:
+            file: ./resources/namespace-with-virtual-annotation.yaml
+            template: true
+            bindings:
+              - name: namespace
+                value: promoted-tenant-namespace-annotation-deny
+            expect:
+              - match:
+                  kind: Namespace
+                check:
+                  ($error == null): true
+    - name: Promote namespace with virtual annotation to tenant namespace
+      try:
+        - apply:
+            file: ./resources/tenant-namespace-with-virtual-annotation.yaml
+            template: true
+            bindings:
+              - name: namespace
+                value: promoted-tenant-namespace-annotation-deny
+            expect:
+              - match:
+                  kind: Namespace
+                check:
+                  ($error == null): false
+---
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: deny-update-existing-tenant-namespace-with-virtual-annotation
+spec:
+  concurrent: false
+  description: |
+    Tests that an existing tenant namespace cannot be updated to add
+    an annotation with `virtual.konflux-ci.dev` domain.
+  steps:
+    - name: Apply Kyverno Cluster Policy and assert it exists
+      try:
+        - apply:
+            file: ../deny-virtual-domain.yaml
+        - assert:
+            file: chainsaw-assert-clusterpolicy.yaml
+    - name: Create a tenant namespace without virtual annotations
+      try:
+        - create:
+            file: ./resources/tenant-namespace.yaml
+            template: true
+            bindings:
+              - name: namespace
+                value: existing-tenant-annotation-deny
+            expect:
+              - match:
+                  kind: Namespace
+                check:
+                  ($error == null): true
+    - name: Update existing tenant namespace with virtual annotation
+      try:
+        - apply:
+            file: ./resources/tenant-namespace-with-virtual-annotation.yaml
+            template: true
+            bindings:
+              - name: namespace
+                value: existing-tenant-annotation-deny
+            expect:
+              - match:
+                  kind: Namespace
+                check:
+                  ($error == null): false
+## Labels
+---
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: allow-namespace-with-virtual-label
+spec:
+  concurrent: false
+  description: |
+    Tests that creation of a namespace labeled with
+    `virtual.konflux-ci.dev` is allowed
+  steps:
+    - name: Apply Kyverno Cluster Policy and assert it exists
+      try:
+        - apply:
+            file: ../deny-virtual-domain.yaml
+        - assert:
+            file: chainsaw-assert-clusterpolicy.yaml
+    - name: Create a namespace with virtual label
+      try:
+        - create:
+            file: ./resources/namespace-with-virtual-label.yaml
+            template: true
+            bindings:
+              - name: namespace
+                value: tenant-namespace-label-allow
+            expect:
+              - match:
+                  kind: Namespace
+                check:
+                  ($error == null): true
+---
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: deny-tenant-namespace-with-virtual-label
+spec:
+  concurrent: false
+  description: |
+    Tests that creation of a tenant namespace labeled with
+    `virtual.konflux-ci.dev` is denied
+  steps:
+    - name: Apply Kyverno Cluster Policy and assert it exists
+      try:
+        - apply:
+            file: ../deny-virtual-domain.yaml
+        - assert:
+            file: chainsaw-assert-clusterpolicy.yaml
+    - name: Create a tenant namespace with virtual labels
+      try:
+        - create:
+            file: ./resources/tenant-namespace-with-virtual-label.yaml
+            template: true
+            bindings:
+              - name: namespace
+                value: tenant-namespace-label-deny
+            expect:
+              - match:
+                  kind: Namespace
+                check:
+                  ($error == null): false
+---
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: deny-promoted-tenant-namespace-with-virtual-label
+spec:
+  concurrent: false
+  description: |
+    Tests that a namespace labeled with `virtual.konflux-ci.dev` can not
+    be promoted to tenant namespace
+  steps:
+    - name: Apply Kyverno Cluster Policy and assert it exists
+      try:
+        - apply:
+            file: ../deny-virtual-domain.yaml
+        - assert:
+            file: chainsaw-assert-clusterpolicy.yaml
+    - name: Create a namespace with virtual labels
+      try:
+        - create:
+            file: ./resources/namespace-with-virtual-label.yaml
+            template: true
+            bindings:
+              - name: namespace
+                value: promoted-tenant-namespace-label-deny
+            expect:
+              - match:
+                  kind: Namespace
+                check:
+                  ($error == null): true
+    - name: Promote namespace with virtual labels to tenant namespace
+      try:
+        - apply:
+            file: ./resources/tenant-namespace-with-virtual-label.yaml
+            template: true
+            bindings:
+              - name: namespace
+                value: promoted-tenant-namespace-label-deny
+            expect:
+              - match:
+                  kind: Namespace
+                check:
+                  ($error == null): false
+---
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: deny-update-existing-tenant-namespace-with-virtual-label
+spec:
+  concurrent: false
+  description: |
+    Tests that an existing tenant namespace cannot be updated to add
+    a label with `virtual.konflux-ci.dev` domain.
+  steps:
+    - name: Apply Kyverno Cluster Policy and assert it exists
+      try:
+        - apply:
+            file: ../deny-virtual-domain.yaml
+        - assert:
+            file: chainsaw-assert-clusterpolicy.yaml
+    - name: Create a tenant namespace without virtual labels
+      try:
+        - create:
+            file: ./resources/tenant-namespace.yaml
+            template: true
+            bindings:
+              - name: namespace
+                value: existing-tenant-label-deny
+            expect:
+              - match:
+                  kind: Namespace
+                check:
+                  ($error == null): true
+    - name: Update existing tenant namespace with virtual label
+      try:
+        - apply:
+            file: ./resources/tenant-namespace-with-virtual-label.yaml
+            template: true
+            bindings:
+              - name: namespace
+                value: existing-tenant-label-deny
+            expect:
+              - match:
+                  kind: Namespace
+                check:
+                  ($error == null): false
+

--- a/components/policies/development/namespace-lister/deny-virtual-domain/.chainsaw-test/resources/namespace-no-labels.yaml
+++ b/components/policies/development/namespace-lister/deny-virtual-domain/.chainsaw-test/resources/namespace-no-labels.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ($namespace)

--- a/components/policies/development/namespace-lister/deny-virtual-domain/.chainsaw-test/resources/namespace-with-virtual-annotation.yaml
+++ b/components/policies/development/namespace-lister/deny-virtual-domain/.chainsaw-test/resources/namespace-with-virtual-annotation.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ($namespace)
+  annotations:
+    virtual.konflux-ci.dev/example: example

--- a/components/policies/development/namespace-lister/deny-virtual-domain/.chainsaw-test/resources/namespace-with-virtual-label.yaml
+++ b/components/policies/development/namespace-lister/deny-virtual-domain/.chainsaw-test/resources/namespace-with-virtual-label.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ($namespace)
+  labels:
+    virtual.konflux-ci.dev/example: example

--- a/components/policies/development/namespace-lister/deny-virtual-domain/.chainsaw-test/resources/tenant-namespace-with-virtual-annotation.yaml
+++ b/components/policies/development/namespace-lister/deny-virtual-domain/.chainsaw-test/resources/tenant-namespace-with-virtual-annotation.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ($namespace)
+  labels:
+    konflux-ci.dev/type: tenant
+  annotations:
+    virtual.konflux-ci.dev/example: example

--- a/components/policies/development/namespace-lister/deny-virtual-domain/.chainsaw-test/resources/tenant-namespace-with-virtual-label.yaml
+++ b/components/policies/development/namespace-lister/deny-virtual-domain/.chainsaw-test/resources/tenant-namespace-with-virtual-label.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ($namespace)
+  labels:
+    konflux-ci.dev/type: tenant
+    virtual.konflux-ci.dev/example: example

--- a/components/policies/development/namespace-lister/deny-virtual-domain/.chainsaw-test/resources/tenant-namespace.yaml
+++ b/components/policies/development/namespace-lister/deny-virtual-domain/.chainsaw-test/resources/tenant-namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ($namespace)
+  labels:
+    konflux-ci.dev/type: tenant

--- a/components/policies/development/namespace-lister/deny-virtual-domain/deny-virtual-domain.yaml
+++ b/components/policies/development/namespace-lister/deny-virtual-domain/deny-virtual-domain.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: deny-virtual-domain
+spec:
+  validationFailureAction: Enforce
+  rules:
+  - name: deny-virtual-domain-labels-annotations
+    skipBackgroundRequests: true
+    match:
+      any:
+      - resources:
+          kinds:
+          - Namespace
+          selector:
+            matchLabels:
+              konflux-ci.dev/type: tenant
+          operations:
+          - CREATE
+          - UPDATE
+    validate:
+      allowExistingViolations: true
+      cel:
+        expressions:
+        - expression: '!object.metadata.labels.exists(key, key.startsWith("virtual.konflux-ci.dev/"))'
+          message: "Tenant namespaces can not have labels with domain 'virtual.konflux-ci.dev'"
+        - expression: '!has(object.metadata.annotations) || !object.metadata.annotations.exists(key, key.startsWith("virtual.konflux-ci.dev/"))'
+          message: "Tenant namespaces can not have annotations with domain 'virtual.konflux-ci.dev'"

--- a/components/policies/development/namespace-lister/deny-virtual-domain/kustomization.yaml
+++ b/components/policies/development/namespace-lister/deny-virtual-domain/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- deny-virtual-domain.yaml

--- a/components/policies/development/namespace-lister/kustomization.yaml
+++ b/components/policies/development/namespace-lister/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namePrefix: namespace-lister-
+resources:
+- deny-virtual-domain

--- a/components/policies/staging/base/kustomization.yaml
+++ b/components/policies/staging/base/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
 - integration
 - konflux-rbac
 - ../empty-base
+- namespace-lister

--- a/components/policies/staging/base/namespace-lister/kustomization.yaml
+++ b/components/policies/staging/base/namespace-lister/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../../development/namespace-lister/


### PR DESCRIPTION
The namespace-lister is adding virtual labels and annotations to namespaces. We want to prevent other users to use them too.

Signed-off-by: Francesco Ilario <filario@redhat.com>
