### PR TITLE
Make argo ignore the secret updates

### DIFF
--- a/components/kubearchive/staging/base/external-secret.yaml
+++ b/components/kubearchive/staging/base/external-secret.yaml
@@ -19,3 +19,7 @@ spec:
     creationPolicy: Owner
     deletionPolicy: Delete
     name: kubearchive-logging
+    template:
+      metadata:
+        annotations:
+          argocd.argoproj.io/sync-options: Prune=false


### PR DESCRIPTION
Updates should be managed by
the external secret operator