### PR TITLE
gpu instances: make /var/run/cdi world-writable

### DIFF
--- a/components/multi-platform-controller/production/kflux-prd-rh03/host-config.yaml
+++ b/components/multi-platform-controller/production/kflux-prd-rh03/host-config.yaml
@@ -786,11 +786,10 @@ data:
     chmod 700 /home/ec2-user/.ssh
     restorecon -r /home/ec2-user
 
-    mkdir -p /etc/cdi
-    chmod a+rwx /etc/cdi
+    mkdir -p /etc/cdi /var/run/cdi
+    chmod a+rwx /etc/cdi /var/run/cdi
 
     setsebool container_use_devices 1
-    
-    su - ec2-user
+
     nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml
     --//--


### PR DESCRIPTION
Both `/etc/cdi` and `/var/run/cdi` are valid locations for CDI config, with the latter overriding the former. Make both world-writable so config can be modified by users as necessary.

No need to `su - ec2-user`, Konflux workloads run as a newly-created random user. Making the directory world-writable is sufficient.