### PR TITLE
give konflux admins rights on crds and webhooks

### DIFF
--- a/components/authentication/base/konflux-admins.yaml
+++ b/components/authentication/base/konflux-admins.yaml
@@ -325,8 +325,13 @@ rules:
     resources:
       - customresourcedefinitions
     verbs:
-      - list
+      - create
       - get
+      - list
+      - watch
+      - patch
+      - update
+      - delete
   - apiGroups:
       - kyverno.io
     resources:
@@ -374,6 +379,18 @@ rules:
       - '*'
     verbs:
       - '*'
+  - apiGroups:
+      - admissionregistration.k8s.io
+    resources:
+      - validatingwebhookconfigurations
+    verbs:
+      - create
+      - get
+      - list
+      - watch
+      - patch
+      - update
+      - delete
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
As a part of the kubesaw removal, we're going to need to be able to make changes to CRDs and ValidatingWebhookConfigurations on the clusters (mostly deleting a handful, but read permissions would make things easier).  We could take a few approaches to this, including defining a Job to automate this removal process, but if anything goes wrong, admins need to be able to step in and restore things on the clusters. Therefore, give members of the konflux-admins group more permissions to administrate these resources.