### PR TITLE
Update PAC on staging

### DIFF
--- a/components/pipeline-service/staging/base/main-pipeline-service-configuration.yaml
+++ b/components/pipeline-service/staging/base/main-pipeline-service-configuration.yaml
@@ -2000,7 +2000,7 @@ spec:
           deployments:
             pipelines-as-code-watcher:
               spec:
-                replicas: 1
+                replicas: 2
             pipelines-as-code-webhook:
               spec:
                 replicas: 2

--- a/components/pipeline-service/staging/base/main-pipeline-service-configuration.yaml
+++ b/components/pipeline-service/staging/base/main-pipeline-service-configuration.yaml
@@ -2094,11 +2094,11 @@ spec:
       - name: IMAGE_ADDONS_TKN_CLI_SERVE
         value: registry.redhat.io/openshift-pipelines/pipelines-serve-tkn-cli-rhel9@sha256:d055d2b35a663aef3e1aafdbed0b12957867c0670c946ebae66e9c44a768bda2
       - name: IMAGE_PAC_PAC_CONTROLLER
-        value: ghcr.io/gbenhaim/pipelines-as-code/pipelines-as-code-controller@sha256:dea65f29afcecdd837b0b7389c6824d546b5098bf98ba98f02f27d6a85b0b376
+        value: quay.io/openshift-pipeline/pipelines-pipelines-as-code-controller-rhel9:03e2807aa027874d603600712005820a7cf0961a454344cf5e2e3b70148379de
       - name: IMAGE_PAC_PAC_WATCHER
-        value: ghcr.io/gbenhaim/pipelines-as-code/pipelines-as-code-watcher@sha256:09964eff749f2fb620ae1500cfc538d0765cf0e29fb2f177abb3521400fad403
+        value: quay.io/openshift-pipeline/pipelines-pipelines-as-code-watcher-rhel9:5887db9658dc4f148e3c515577a365c0934ce3de39f8769dcf07e62e3fa9e2af
       - name: IMAGE_PAC_PAC_WEBHOOK
-        value: ghcr.io/gbenhaim/pipelines-as-code/pipelines-as-code-webhook@sha256:440d6f9311d23b994ef68ffe0513eba832b891fdfb6360385bb635ba154f7526
+        value: quay.io/openshift-pipeline/pipelines-pipelines-as-code-webhook-rhel9:6d6122ec424d243e72d465e936a26c24576ee98df1da3335b59452f9275521ef
 ---
 apiVersion: route.openshift.io/v1
 kind: Route

--- a/components/pipeline-service/staging/stone-stage-p01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stage-p01/deploy.yaml
@@ -2677,11 +2677,11 @@ spec:
     - name: IMAGE_ADDONS_TKN_CLI_SERVE
       value: registry.redhat.io/openshift-pipelines/pipelines-serve-tkn-cli-rhel9@sha256:d055d2b35a663aef3e1aafdbed0b12957867c0670c946ebae66e9c44a768bda2
     - name: IMAGE_PAC_PAC_CONTROLLER
-      value: ghcr.io/gbenhaim/pipelines-as-code/pipelines-as-code-controller@sha256:dea65f29afcecdd837b0b7389c6824d546b5098bf98ba98f02f27d6a85b0b376
+      value: quay.io/openshift-pipeline/pipelines-pipelines-as-code-controller-rhel9:03e2807aa027874d603600712005820a7cf0961a454344cf5e2e3b70148379de
     - name: IMAGE_PAC_PAC_WATCHER
-      value: ghcr.io/gbenhaim/pipelines-as-code/pipelines-as-code-watcher@sha256:09964eff749f2fb620ae1500cfc538d0765cf0e29fb2f177abb3521400fad403
+      value: quay.io/openshift-pipeline/pipelines-pipelines-as-code-watcher-rhel9:5887db9658dc4f148e3c515577a365c0934ce3de39f8769dcf07e62e3fa9e2af
     - name: IMAGE_PAC_PAC_WEBHOOK
-      value: ghcr.io/gbenhaim/pipelines-as-code/pipelines-as-code-webhook@sha256:440d6f9311d23b994ef68ffe0513eba832b891fdfb6360385bb635ba154f7526
+      value: quay.io/openshift-pipeline/pipelines-pipelines-as-code-webhook-rhel9:6d6122ec424d243e72d465e936a26c24576ee98df1da3335b59452f9275521ef
   name: openshift-pipelines-operator-rh
   source: custom-operators
   sourceNamespace: openshift-marketplace

--- a/components/pipeline-service/staging/stone-stage-p01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stage-p01/deploy.yaml
@@ -2585,7 +2585,7 @@ spec:
           deployments:
             pipelines-as-code-watcher:
               spec:
-                replicas: 1
+                replicas: 2
             pipelines-as-code-webhook:
               spec:
                 replicas: 2

--- a/components/pipeline-service/staging/stone-stg-rh01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stg-rh01/deploy.yaml
@@ -2597,7 +2597,7 @@ spec:
           deployments:
             pipelines-as-code-watcher:
               spec:
-                replicas: 1
+                replicas: 2
             pipelines-as-code-webhook:
               spec:
                 replicas: 2

--- a/components/pipeline-service/staging/stone-stg-rh01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stg-rh01/deploy.yaml
@@ -2689,11 +2689,11 @@ spec:
     - name: IMAGE_ADDONS_TKN_CLI_SERVE
       value: registry.redhat.io/openshift-pipelines/pipelines-serve-tkn-cli-rhel9@sha256:d055d2b35a663aef3e1aafdbed0b12957867c0670c946ebae66e9c44a768bda2
     - name: IMAGE_PAC_PAC_CONTROLLER
-      value: ghcr.io/gbenhaim/pipelines-as-code/pipelines-as-code-controller@sha256:dea65f29afcecdd837b0b7389c6824d546b5098bf98ba98f02f27d6a85b0b376
+      value: quay.io/openshift-pipeline/pipelines-pipelines-as-code-controller-rhel9:03e2807aa027874d603600712005820a7cf0961a454344cf5e2e3b70148379de
     - name: IMAGE_PAC_PAC_WATCHER
-      value: ghcr.io/gbenhaim/pipelines-as-code/pipelines-as-code-watcher@sha256:09964eff749f2fb620ae1500cfc538d0765cf0e29fb2f177abb3521400fad403
+      value: quay.io/openshift-pipeline/pipelines-pipelines-as-code-watcher-rhel9:5887db9658dc4f148e3c515577a365c0934ce3de39f8769dcf07e62e3fa9e2af
     - name: IMAGE_PAC_PAC_WEBHOOK
-      value: ghcr.io/gbenhaim/pipelines-as-code/pipelines-as-code-webhook@sha256:440d6f9311d23b994ef68ffe0513eba832b891fdfb6360385bb635ba154f7526
+      value: quay.io/openshift-pipeline/pipelines-pipelines-as-code-webhook-rhel9:6d6122ec424d243e72d465e936a26c24576ee98df1da3335b59452f9275521ef
   name: openshift-pipelines-operator-rh
   source: custom-operators
   sourceNamespace: openshift-marketplace


### PR DESCRIPTION
- revert previous change which made PAC's watcher to have a single replica (it was done for testing and isn't needed anymore).

- update PAC images in staging. The PAC image contains a fix needed for running Kueue on all pipelineruns. https://issues.redhat.com/browse/SRVKP-8255
