### PR TITLE
mintmaker: Fix YAML type error in mintmaker manager patch

### DIFF
--- a/components/mintmaker/staging/base/manager_patch.yaml
+++ b/components/mintmaker/staging/base/manager_patch.yaml
@@ -22,4 +22,4 @@ spec:
             memory: 256Mi
         env:
         - name: ENABLE_PROFILING
-          value: true
+          value: "true"


### PR DESCRIPTION
Change ENABLE_PROFILING env var value from boolean `true` to string `"true"` to resolve ArgoCD sync failure. Kubernetes env vars must be strings.