### PR TITLE
Make argo ignore the secret updates

### DIFF
--- a/components/kubearchive/staging/base/external-secret.yaml
+++ b/components/kubearchive/staging/base/external-secret.yaml
@@ -23,3 +23,4 @@ spec:
       metadata:
         annotations:
           argocd.argoproj.io/sync-options: Prune=false
+          argocd.argoproj.io/compare-options: IgnoreExtraneous


### PR DESCRIPTION
This is a follow up to https://github.com/redhat-appstudio/infra-deployments/pull/7601
because argo is still trying to sync the secret.