### PR TITLE
add custom-console-url-namespace in prod

### DIFF
--- a/components/pipeline-service/production/base/update-tekton-config-pac.yaml
+++ b/components/pipeline-service/production/base/update-tekton-config-pac.yaml
@@ -5,6 +5,7 @@
     application-name: Red Hat Konflux
     custom-console-name: Red Hat Konflux
     custom-console-url: https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/
+    custom-console-url-namespace: https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/{{ namespace }}
     custom-console-url-pr-details: https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/{{ namespace }}/pipelinerun/{{ pr }}
     custom-console-url-pr-tasklog: https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/{{ namespace }}/pipelinerun/{{ pr }}/logs/{{ task }}
     remember-ok-to-test: "false"

--- a/components/pipeline-service/production/kflux-ocp-p01/deploy.yaml
+++ b/components/pipeline-service/production/kflux-ocp-p01/deploy.yaml
@@ -2455,6 +2455,8 @@ spec:
           application-name: Konflux OCP
           custom-console-name: Konflux OCP
           custom-console-url: https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com
+          custom-console-url-namespace: https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/{{
+            namespace }}
           custom-console-url-pr-details: https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/{{
             namespace }}/pipelinerun/{{ pr }}
           custom-console-url-pr-tasklog: https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/{{

--- a/components/pipeline-service/production/kflux-ocp-p01/resources/update-tekton-config-pac.yaml
+++ b/components/pipeline-service/production/kflux-ocp-p01/resources/update-tekton-config-pac.yaml
@@ -5,6 +5,7 @@
     application-name: Konflux OCP
     custom-console-name: Konflux OCP
     custom-console-url: https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com
+    custom-console-url-namespace: https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/{{ namespace }}
     custom-console-url-pr-details: https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/{{ namespace }}/pipelinerun/{{ pr }}
     custom-console-url-pr-tasklog: https://konflux-ui.apps.kflux-ocp-p01.7ayg.p1.openshiftapps.com/ns/{{ namespace }}/pipelinerun/{{ pr }}/logs/{{ task }}
     secret-github-app-token-scoped: "false"

--- a/components/pipeline-service/production/kflux-osp-p01/deploy.yaml
+++ b/components/pipeline-service/production/kflux-osp-p01/deploy.yaml
@@ -2486,6 +2486,8 @@ spec:
           application-name: Konflux kflux-osp-p01
           custom-console-name: Konflux kflux-osp-p01
           custom-console-url: https://konflux-ui.apps.kflux-osp-p01.yt45.p1.openshiftapps.com
+          custom-console-url-namespace: https://konflux-ui.apps.kflux-osp-p01.yt45.p1.openshiftapps.com/ns/{{
+            namespace }}
           custom-console-url-pr-details: https://konflux-ui.apps.kflux-osp-p01.yt45.p1.openshiftapps.com/ns/{{
             namespace }}/pipelinerun/{{ pr }}
           custom-console-url-pr-tasklog: https://konflux-ui.apps.kflux-osp-p01.yt45.p1.openshiftapps.com/ns/{{

--- a/components/pipeline-service/production/kflux-osp-p01/resources/update-tekton-config-pac.yaml
+++ b/components/pipeline-service/production/kflux-osp-p01/resources/update-tekton-config-pac.yaml
@@ -5,6 +5,7 @@
     application-name: Konflux kflux-osp-p01
     custom-console-name: Konflux kflux-osp-p01
     custom-console-url: https://konflux-ui.apps.kflux-osp-p01.yt45.p1.openshiftapps.com
+    custom-console-url-namespace: https://konflux-ui.apps.kflux-osp-p01.yt45.p1.openshiftapps.com/ns/{{ namespace }}
     custom-console-url-pr-details: https://konflux-ui.apps.kflux-osp-p01.yt45.p1.openshiftapps.com/ns/{{ namespace }}/pipelinerun/{{ pr }}
     custom-console-url-pr-tasklog: https://konflux-ui.apps.kflux-osp-p01.yt45.p1.openshiftapps.com/ns/{{ namespace }}/pipelinerun/{{ pr }}/logs/{{ task }}
     remember-ok-to-test: "false"

--- a/components/pipeline-service/production/kflux-prd-rh02/deploy.yaml
+++ b/components/pipeline-service/production/kflux-prd-rh02/deploy.yaml
@@ -2486,6 +2486,8 @@ spec:
           application-name: Konflux kflux-prd-rh02
           custom-console-name: Konflux kflux-prd-rh02
           custom-console-url: https://konflux-ui.apps.kflux-prd-rh02.0fk9.p1.openshiftapps.com
+          custom-console-url-namespace: https://konflux-ui.apps.kflux-prd-rh02.0fk9.p1.openshiftapps.com/ns/{{
+            namespace }}
           custom-console-url-pr-details: https://konflux-ui.apps.kflux-prd-rh02.0fk9.p1.openshiftapps.com/ns/{{
             namespace }}/pipelinerun/{{ pr }}
           custom-console-url-pr-tasklog: https://konflux-ui.apps.kflux-prd-rh02.0fk9.p1.openshiftapps.com/ns/{{

--- a/components/pipeline-service/production/kflux-prd-rh02/resources/update-tekton-config-pac.yaml
+++ b/components/pipeline-service/production/kflux-prd-rh02/resources/update-tekton-config-pac.yaml
@@ -5,6 +5,7 @@
     application-name: Konflux kflux-prd-rh02 
     custom-console-name: Konflux kflux-prd-rh02
     custom-console-url: https://konflux-ui.apps.kflux-prd-rh02.0fk9.p1.openshiftapps.com
+    custom-console-url-namespace: https://konflux-ui.apps.kflux-prd-rh02.0fk9.p1.openshiftapps.com/ns/{{ namespace }}
     custom-console-url-pr-details: https://konflux-ui.apps.kflux-prd-rh02.0fk9.p1.openshiftapps.com/ns/{{ namespace }}/pipelinerun/{{ pr }}
     custom-console-url-pr-tasklog: https://konflux-ui.apps.kflux-prd-rh02.0fk9.p1.openshiftapps.com/ns/{{ namespace }}/pipelinerun/{{ pr }}/logs/{{ task }}
     secret-github-app-token-scoped: "false"

--- a/components/pipeline-service/production/kflux-prd-rh03/deploy.yaml
+++ b/components/pipeline-service/production/kflux-prd-rh03/deploy.yaml
@@ -2486,6 +2486,8 @@ spec:
           application-name: Konflux kflux-prd-rh03
           custom-console-name: Konflux kflux-prd-rh03
           custom-console-url: https://konflux-ui.apps.kflux-prd-rh03.nnv1.p1.openshiftapps.com
+          custom-console-url-namespace: https://konflux-ui.apps.kflux-prd-rh03.nnv1.p1.openshiftapps.com/ns/{{
+            namespace }}
           custom-console-url-pr-details: https://konflux-ui.apps.kflux-prd-rh03.nnv1.p1.openshiftapps.com/ns/{{
             namespace }}/pipelinerun/{{ pr }}
           custom-console-url-pr-tasklog: https://konflux-ui.apps.kflux-prd-rh03.nnv1.p1.openshiftapps.com/ns/{{

--- a/components/pipeline-service/production/kflux-prd-rh03/resources/update-tekton-config-pac.yaml
+++ b/components/pipeline-service/production/kflux-prd-rh03/resources/update-tekton-config-pac.yaml
@@ -5,6 +5,7 @@
     application-name: Konflux kflux-prd-rh03
     custom-console-name: Konflux kflux-prd-rh03
     custom-console-url: https://konflux-ui.apps.kflux-prd-rh03.nnv1.p1.openshiftapps.com
+    custom-console-url-namespace: https://konflux-ui.apps.kflux-prd-rh03.nnv1.p1.openshiftapps.com/ns/{{ namespace }}
     custom-console-url-pr-details: https://konflux-ui.apps.kflux-prd-rh03.nnv1.p1.openshiftapps.com/ns/{{ namespace }}/pipelinerun/{{ pr }}
     custom-console-url-pr-tasklog: https://konflux-ui.apps.kflux-prd-rh03.nnv1.p1.openshiftapps.com/ns/{{ namespace }}/pipelinerun/{{ pr }}/logs/{{ task }}
     secret-github-app-token-scoped: "false"

--- a/components/pipeline-service/production/kflux-rhel-p01/deploy.yaml
+++ b/components/pipeline-service/production/kflux-rhel-p01/deploy.yaml
@@ -2486,6 +2486,8 @@ spec:
           application-name: Konflux kflux-rhel-p01
           custom-console-name: Konflux kflux-rhel-p01
           custom-console-url: https://konflux-ui.apps.kflux-rhel-p01.fc38.p1.openshiftapps.com
+          custom-console-url-namespace: https://konflux-ui.apps.kflux-rhel-p01.fc38.p1.openshiftapps.com/ns/{{
+            namespace }}
           custom-console-url-pr-details: https://konflux-ui.apps.kflux-rhel-p01.fc38.p1.openshiftapps.com/ns/{{
             namespace }}/pipelinerun/{{ pr }}
           custom-console-url-pr-tasklog: https://konflux-ui.apps.kflux-rhel-p01.fc38.p1.openshiftapps.com/ns/{{

--- a/components/pipeline-service/production/kflux-rhel-p01/resources/update-tekton-config-pac.yaml
+++ b/components/pipeline-service/production/kflux-rhel-p01/resources/update-tekton-config-pac.yaml
@@ -5,6 +5,7 @@
     application-name: Konflux kflux-rhel-p01
     custom-console-name: Konflux kflux-rhel-p01
     custom-console-url: https://konflux-ui.apps.kflux-rhel-p01.fc38.p1.openshiftapps.com
+    custom-console-url-namespace: https://konflux-ui.apps.kflux-rhel-p01.fc38.p1.openshiftapps.com/ns/{{ namespace }}
     custom-console-url-pr-details: https://konflux-ui.apps.kflux-rhel-p01.fc38.p1.openshiftapps.com/ns/{{ namespace }}/pipelinerun/{{ pr }}
     custom-console-url-pr-tasklog: https://konflux-ui.apps.kflux-rhel-p01.fc38.p1.openshiftapps.com/ns/{{ namespace }}/pipelinerun/{{ pr }}/logs/{{ task }}
     remember-ok-to-test: "false"

--- a/components/pipeline-service/production/stone-prd-rh01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prd-rh01/deploy.yaml
@@ -2455,6 +2455,8 @@ spec:
           application-name: Red Hat Konflux
           custom-console-name: Red Hat Konflux
           custom-console-url: https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/
+          custom-console-url-namespace: https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/{{
+            namespace }}
           custom-console-url-pr-details: https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/{{
             namespace }}/pipelinerun/{{ pr }}
           custom-console-url-pr-tasklog: https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/{{

--- a/components/pipeline-service/production/stone-prod-p01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prod-p01/deploy.yaml
@@ -2455,6 +2455,8 @@ spec:
           application-name: Konflux Production Internal
           custom-console-name: Konflux Production Internal
           custom-console-url: https://konflux-ui.apps.stone-prod-p01.wcfb.p1.openshiftapps.com
+          custom-console-url-namespace: https://konflux-ui.apps.stone-prod-p01.wcfb.p1.openshiftapps.com/ns/{{
+            namespace }}
           custom-console-url-pr-details: https://konflux-ui.apps.stone-prod-p01.wcfb.p1.openshiftapps.com/ns/{{
             namespace }}/pipelinerun/{{ pr }}
           custom-console-url-pr-tasklog: https://konflux-ui.apps.stone-prod-p01.wcfb.p1.openshiftapps.com/ns/{{

--- a/components/pipeline-service/production/stone-prod-p01/resources/update-tekton-config-pac.yaml
+++ b/components/pipeline-service/production/stone-prod-p01/resources/update-tekton-config-pac.yaml
@@ -5,6 +5,7 @@
     application-name: Konflux Production Internal
     custom-console-name: Konflux Production Internal
     custom-console-url: https://konflux-ui.apps.stone-prod-p01.wcfb.p1.openshiftapps.com
+    custom-console-url-namespace: https://konflux-ui.apps.stone-prod-p01.wcfb.p1.openshiftapps.com/ns/{{ namespace }}
     custom-console-url-pr-details: https://konflux-ui.apps.stone-prod-p01.wcfb.p1.openshiftapps.com/ns/{{ namespace }}/pipelinerun/{{ pr }}
     custom-console-url-pr-tasklog: https://konflux-ui.apps.stone-prod-p01.wcfb.p1.openshiftapps.com/ns/{{ namespace }}/pipelinerun/{{ pr }}/logs/{{ task }}
     remember-ok-to-test: "false"

--- a/components/pipeline-service/production/stone-prod-p02/deploy.yaml
+++ b/components/pipeline-service/production/stone-prod-p02/deploy.yaml
@@ -2455,6 +2455,8 @@ spec:
           application-name: Konflux Production Internal
           custom-console-name: Konflux Production Internal
           custom-console-url: https://konflux-ui.apps.stone-prod-p02.hjvn.p1.openshiftapps.com
+          custom-console-url-namespace: https://konflux-ui.apps.stone-prod-p02.hjvn.p1.openshiftapps.com/ns/{{
+            namespace }}
           custom-console-url-pr-details: https://konflux-ui.apps.stone-prod-p02.hjvn.p1.openshiftapps.com/ns/{{
             namespace }}/pipelinerun/{{ pr }}
           custom-console-url-pr-tasklog: https://konflux-ui.apps.stone-prod-p02.hjvn.p1.openshiftapps.com/ns/{{

--- a/components/pipeline-service/production/stone-prod-p02/resources/update-tekton-config-pac.yaml
+++ b/components/pipeline-service/production/stone-prod-p02/resources/update-tekton-config-pac.yaml
@@ -5,6 +5,7 @@
     application-name: Konflux Production Internal
     custom-console-name: Konflux Production Internal
     custom-console-url: https://konflux-ui.apps.stone-prod-p02.hjvn.p1.openshiftapps.com
+    custom-console-url-namespace: https://konflux-ui.apps.stone-prod-p02.hjvn.p1.openshiftapps.com/ns/{{ namespace }}
     custom-console-url-pr-details: https://konflux-ui.apps.stone-prod-p02.hjvn.p1.openshiftapps.com/ns/{{ namespace }}/pipelinerun/{{ pr }}
     custom-console-url-pr-tasklog: https://konflux-ui.apps.stone-prod-p02.hjvn.p1.openshiftapps.com/ns/{{ namespace }}/pipelinerun/{{ pr }}/logs/{{ task }}
     remember-ok-to-test: "false"


### PR DESCRIPTION
'Namespace' link in PRs check's Details is broken. This change will fix it.

Example PR: https://github.com/konflux-ci/namespace-lister/pull/154/checks?check_run_id=47756929239
* Actual value in Namespace Field: https://detailurl.setting.custom-console-url-namespace.is.not.configured/
* Desired value: https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/konflux-tenant-ops-tenant

Signed-off-by: Francesco Ilario <filario@redhat.com>
