### PR TITLE
Add some more AWS quotas for AMD(160) and ARM(160) on p02

### DIFF
--- a/components/kueue/production/stone-prod-p02/queue-config/cluster-queue.yaml
+++ b/components/kueue/production/stone-prod-p02/queue-config/cluster-queue.yaml
@@ -50,7 +50,7 @@ spec:
       - name: linux-amd64
         nominalQuota: '30'
       - name: linux-arm64
-        nominalQuota: '70'
+        nominalQuota: '50'
       - name: linux-c2xlarge-amd64
         nominalQuota: '5'
       - name: linux-c2xlarge-arm64
@@ -70,13 +70,13 @@ spec:
       - name: linux-cxlarge-arm64
         nominalQuota: '5'
       - name: linux-d160-m2xlarge-amd64
-        nominalQuota: '5'
+        nominalQuota: '10'
       - name: linux-d160-m2xlarge-arm64
-        nominalQuota: '5'
+        nominalQuota: '10'
       - name: linux-d160-m4xlarge-amd64
-        nominalQuota: '5'
+        nominalQuota: '10'
       - name: linux-d160-m4xlarge-arm64
-        nominalQuota: '5'
+        nominalQuota: '10'
       - name: linux-d160-m8xlarge-amd64
         nominalQuota: '5'
   - coveredResources:

--- a/components/multi-platform-controller/production-downstream/stone-prod-p02/host-config.yaml
+++ b/components/multi-platform-controller/production-downstream/stone-prod-p02/host-config.yaml
@@ -66,7 +66,7 @@ data:
   dynamic.linux-arm64.aws-secret: aws-account
   dynamic.linux-arm64.ssh-secret: aws-ssh-key
   dynamic.linux-arm64.security-group-id: sg-0903aedd465be979e
-  dynamic.linux-arm64.max-instances: "70"
+  dynamic.linux-arm64.max-instances: "50"
   dynamic.linux-arm64.subnet-id: subnet-02c476f8d2a4ae05e
   dynamic.linux-arm64.allocation-timeout: "1200"
 
@@ -118,7 +118,7 @@ data:
   dynamic.linux-d160-m2xlarge-arm64.aws-secret: aws-account
   dynamic.linux-d160-m2xlarge-arm64.ssh-secret: aws-ssh-key
   dynamic.linux-d160-m2xlarge-arm64.security-group-id: sg-0903aedd465be979e
-  dynamic.linux-d160-m2xlarge-arm64.max-instances: "5"
+  dynamic.linux-d160-m2xlarge-arm64.max-instances: "10"
   dynamic.linux-d160-m2xlarge-arm64.subnet-id: subnet-02c476f8d2a4ae05e
   dynamic.linux-d160-m2xlarge-arm64.allocation-timeout: "1200"
   dynamic.linux-d160-m2xlarge-arm64.disk: "160"
@@ -223,7 +223,7 @@ data:
   dynamic.linux-d160-m4xlarge-arm64.aws-secret: aws-account
   dynamic.linux-d160-m4xlarge-arm64.ssh-secret: aws-ssh-key
   dynamic.linux-d160-m4xlarge-arm64.security-group-id: sg-0903aedd465be979e
-  dynamic.linux-d160-m4xlarge-arm64.max-instances: "5"
+  dynamic.linux-d160-m4xlarge-arm64.max-instances: "10"
   dynamic.linux-d160-m4xlarge-arm64.subnet-id: subnet-02c476f8d2a4ae05e
   dynamic.linux-d160-m4xlarge-arm64.allocation-timeout: "1200"
   dynamic.linux-d160-m4xlarge-arm64.disk: "160"
@@ -316,7 +316,7 @@ data:
   dynamic.linux-d160-m2xlarge-amd64.aws-secret: aws-account
   dynamic.linux-d160-m2xlarge-amd64.ssh-secret: aws-ssh-key
   dynamic.linux-d160-m2xlarge-amd64.security-group-id: sg-0903aedd465be979e
-  dynamic.linux-d160-m2xlarge-amd64.max-instances: "5"
+  dynamic.linux-d160-m2xlarge-amd64.max-instances: "10"
   dynamic.linux-d160-m2xlarge-amd64.subnet-id: subnet-02c476f8d2a4ae05e
   dynamic.linux-d160-m2xlarge-amd64.allocation-timeout: "1200"
   dynamic.linux-d160-m2xlarge-amd64.disk: "160"
@@ -344,7 +344,7 @@ data:
   dynamic.linux-d160-m4xlarge-amd64.aws-secret: aws-account
   dynamic.linux-d160-m4xlarge-amd64.ssh-secret: aws-ssh-key
   dynamic.linux-d160-m4xlarge-amd64.security-group-id: sg-0903aedd465be979e
-  dynamic.linux-d160-m4xlarge-amd64.max-instances: "5"
+  dynamic.linux-d160-m4xlarge-amd64.max-instances: "10"
   dynamic.linux-d160-m4xlarge-amd64.subnet-id: subnet-02c476f8d2a4ae05e
   dynamic.linux-d160-m4xlarge-amd64.allocation-timeout: "1200"
   dynamic.linux-d160-m4xlarge-amd64.disk: "160"


### PR DESCRIPTION
p02 is a very busy cluster so raising some populat platfrom (m2x-160 and m4x-160) quotas a bit (+5 VM);
Due to IP number limit, it is has to be decreased from the general arm64 limit.