### PR TITLE
Eventing: rollback fixes in staging and dev

### DIFF
--- a/components/knative-eventing/base/kustomization.yaml
+++ b/components/knative-eventing/base/kustomization.yaml
@@ -17,10 +17,6 @@ patches:
         spec:
           containers:
             - name: eventing-controller
-              image: quay.io/kubearchive/eventing-controller:fix
-              env:
-              - name: APISERVER_RA_IMAGE
-                value: quay.io/kubearchive/eventing-adapter:fix
               resources:
                 requests:
                   cpu: 200m


### PR DESCRIPTION
We are experiencing some problems where the ApiServerSource ceases activity. We believe is due to the watchers being closed. We made some modifications to the code that are close enough to the first time we saw these activity problems. We are going back to the unmodified version of Knative Eventing on staging and development. This means that in these clusters Knative Eventing will performance Subject Access Reviews. We think this is acceptable in staging. We won't plan to reestablish Subject Access Reviews again on production clusters. If this works we will think of an alternative.