### PR TITLE
Add createCABundleConfigMaps : false to prod

### DIFF
--- a/components/pipeline-service/production/base/main-pipeline-service-configuration.yaml
+++ b/components/pipeline-service/production/base/main-pipeline-service-configuration.yaml
@@ -1694,6 +1694,8 @@ spec:
   params:
   - name: createRbacResource
     value: "false"
+  - name: createCABundleConfigMaps
+    value: "false"
   pipeline:
     default-service-account: appstudio-pipeline
     enable-api-fields: alpha

--- a/components/pipeline-service/production/kflux-ocp-p01/deploy.yaml
+++ b/components/pipeline-service/production/kflux-ocp-p01/deploy.yaml
@@ -2277,6 +2277,8 @@ spec:
   params:
   - name: createRbacResource
     value: "false"
+  - name: createCABundleConfigMaps
+    value: "false"
   pipeline:
     default-service-account: appstudio-pipeline
     enable-api-fields: alpha

--- a/components/pipeline-service/production/kflux-osp-p01/deploy.yaml
+++ b/components/pipeline-service/production/kflux-osp-p01/deploy.yaml
@@ -2308,6 +2308,8 @@ spec:
   params:
   - name: createRbacResource
     value: "false"
+  - name: createCABundleConfigMaps
+    value: "false"
   pipeline:
     default-service-account: appstudio-pipeline
     enable-api-fields: alpha

--- a/components/pipeline-service/production/kflux-prd-rh02/deploy.yaml
+++ b/components/pipeline-service/production/kflux-prd-rh02/deploy.yaml
@@ -2308,6 +2308,8 @@ spec:
   params:
   - name: createRbacResource
     value: "false"
+  - name: createCABundleConfigMaps
+    value: "false"
   pipeline:
     default-service-account: appstudio-pipeline
     enable-api-fields: alpha

--- a/components/pipeline-service/production/kflux-prd-rh03/deploy.yaml
+++ b/components/pipeline-service/production/kflux-prd-rh03/deploy.yaml
@@ -2308,6 +2308,8 @@ spec:
   params:
   - name: createRbacResource
     value: "false"
+  - name: createCABundleConfigMaps
+    value: "false"
   pipeline:
     default-service-account: appstudio-pipeline
     enable-api-fields: alpha

--- a/components/pipeline-service/production/kflux-rhel-p01/deploy.yaml
+++ b/components/pipeline-service/production/kflux-rhel-p01/deploy.yaml
@@ -2308,6 +2308,8 @@ spec:
   params:
   - name: createRbacResource
     value: "false"
+  - name: createCABundleConfigMaps
+    value: "false"
   pipeline:
     default-service-account: appstudio-pipeline
     enable-api-fields: alpha

--- a/components/pipeline-service/production/stone-prd-rh01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prd-rh01/deploy.yaml
@@ -2277,6 +2277,8 @@ spec:
   params:
   - name: createRbacResource
     value: "false"
+  - name: createCABundleConfigMaps
+    value: "false"
   pipeline:
     default-service-account: appstudio-pipeline
     enable-api-fields: alpha

--- a/components/pipeline-service/production/stone-prod-p01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prod-p01/deploy.yaml
@@ -2277,6 +2277,8 @@ spec:
   params:
   - name: createRbacResource
     value: "false"
+  - name: createCABundleConfigMaps
+    value: "false"
   pipeline:
     default-service-account: appstudio-pipeline
     enable-api-fields: alpha

--- a/components/pipeline-service/production/stone-prod-p02/deploy.yaml
+++ b/components/pipeline-service/production/stone-prod-p02/deploy.yaml
@@ -2277,6 +2277,8 @@ spec:
   params:
   - name: createRbacResource
     value: "false"
+  - name: createCABundleConfigMaps
+    value: "false"
   pipeline:
     default-service-account: appstudio-pipeline
     enable-api-fields: alpha


### PR DESCRIPTION
**Issue Summary:**
There was a breaking change in recent Tekton Pipelines where the behavior of createRbacResource: false changed. Previously, setting createRbacResource: false would prevent the creation of CA bundle ConfigMaps in every namespace. However, this is no longer the case.

**Required Action:**
Users who were previously relying on createRbacResource: false to avoid creating CA bundle ConfigMaps in every namespace must now explicitly set createCABundleConfigMaps: false to achieve the same behavior.

**Current Impact:**
https://issues.redhat.com/browse/KONFLUX-9459
Tekton-operator-proxy-webhook hangs indefinitely when trying to check for OpenShift CA ConfigMaps (config-trusted-cabundle and config-service-cabundle) in certain namespaces

**Solution:**
Disable the createCABundleConfigMaps setting by setting it to false in the pipeline service configuration to restore the previous behavior and prevent unnecessary ConfigMap creation across namespaces.
https://issues.redhat.com/browse/SRVKP-8327

**Related PR for stage and dev**
https://github.com/redhat-appstudio/infra-deployments/pull/7591