### PR TITLE
Upgrade MCE operator to 2.9 in dev & staging

### DIFF
--- a/components/cluster-as-a-service/development/add-hypershift-params.yaml
+++ b/components/cluster-as-a-service/development/add-hypershift-params.yaml
@@ -9,7 +9,7 @@
   path: /spec/template/spec/source/helm/parameters/-
   value:
     name: hypershiftImage
-    value: registry.redhat.io/multicluster-engine/hypershift-rhel9-operator:v2.8
+    value: registry.redhat.io/multicluster-engine/hypershift-rhel9-operator:v2.9.0-1@sha256:f8c3898e29f8c0a20c3be92bc4ee5a9443b9fc8218db95ba541fe3e57a89c40d
 
 - op: add
   path: /spec/template/spec/source/helm/parameters/-

--- a/components/cluster-as-a-service/development/kustomization.yaml
+++ b/components/cluster-as-a-service/development/kustomization.yaml
@@ -20,4 +20,4 @@ patches:
     patch: |-
       - op: replace
         path: /spec/channel
-        value: stable-2.8
+        value: stable-2.9

--- a/components/cluster-as-a-service/staging/add-hypershift-params.yaml
+++ b/components/cluster-as-a-service/staging/add-hypershift-params.yaml
@@ -9,7 +9,7 @@
   path: /spec/template/spec/source/helm/parameters/-
   value:
     name: hypershiftImage
-    value: registry.redhat.io/multicluster-engine/hypershift-rhel9-operator:v2.8
+    value: registry.redhat.io/multicluster-engine/hypershift-rhel9-operator:v2.9.0-1@sha256:f8c3898e29f8c0a20c3be92bc4ee5a9443b9fc8218db95ba541fe3e57a89c40d
 
 - op: add
   path: /spec/template/spec/source/helm/parameters/-

--- a/components/cluster-as-a-service/staging/kustomization.yaml
+++ b/components/cluster-as-a-service/staging/kustomization.yaml
@@ -17,4 +17,4 @@ patches:
     patch: |-
       - op: replace
         path: /spec/channel
-        value: stable-2.8
+        value: stable-2.9


### PR DESCRIPTION
This adds support for provisioning OCP 4.19 with EaaS.