### PR TITLE
Upgrade MCE operator to 2.9 in prod

### DIFF
--- a/components/cluster-as-a-service/base/multicluster-engine.yaml
+++ b/components/cluster-as-a-service/base/multicluster-engine.yaml
@@ -27,7 +27,7 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "-1"
 spec:
-  channel: stable-2.8
+  channel: stable-2.9
   installPlanApproval: Automatic
   name: multicluster-engine
   source: redhat-operators

--- a/components/cluster-as-a-service/production/add-hypershift-params.yaml
+++ b/components/cluster-as-a-service/production/add-hypershift-params.yaml
@@ -9,7 +9,7 @@
   path: /spec/template/spec/source/helm/parameters/-
   value:
     name: hypershiftImage
-    value: registry.redhat.io/multicluster-engine/hypershift-rhel9-operator:v2.8
+    value: registry.redhat.io/multicluster-engine/hypershift-rhel9-operator:v2.9.0-1@sha256:f8c3898e29f8c0a20c3be92bc4ee5a9443b9fc8218db95ba541fe3e57a89c40d
 
 - op: add
   path: /spec/template/spec/source/helm/parameters/-


### PR DESCRIPTION
This adds support for provisioning OCP 4.19 with EaaS.