### PR TITLE
Reduce kyverno background controller CPU from 7 to 6 on rh01

### DIFF
--- a/components/kyverno/production/stone-prd-rh01/kyverno-helm-values.yaml
+++ b/components/kyverno/production/stone-prd-rh01/kyverno-helm-values.yaml
@@ -51,10 +51,10 @@ backgroundController:
     leaderElectionRetryPeriod: 5s
   resources:
     requests:
-      cpu: 7000m
+      cpu: 6000m
       memory: 4Gi
     limits:
-      cpu: 7000m
+      cpu: 6000m
       memory: 4Gi
   securityContext:
     allowPrivilegeEscalation: false


### PR DESCRIPTION
Based on usage data, it peaks at 5 so reduce it to 6, keeping a buffer of 1. The main reason for this change is to allow us to align kyverno configuration of all the clusters with prd-rh01, which is where the config was tuned for highest load. All the clusters except rh01 have workers of 8 CPU so a 7 CPU pod does not fit on them. Reducing it to 6 will make it fit and allow us to have the exact same config on all the clusters which will be done in a follow up change.