### PR TITLE
Align prod-p02 kyverno config with prd-rh01 one

### DIFF
--- a/components/kyverno/production/stone-prod-p02/kyverno-helm-values.yaml
+++ b/components/kyverno/production/stone-prod-p02/kyverno-helm-values.yaml
@@ -21,13 +21,15 @@ admissionController:
         drop:
         - "ALL"
   container:
+    extraArgs:
+      leaderElectionRetryPeriod: 5s
     resources:
       requests:
-        cpu: 4000m
-        memory: 2Gi
+        cpu: 6000m
+        memory: 4Gi
       limits:
-        cpu: 4000m
-        memory: 2Gi
+        cpu: 6000m
+        memory: 4Gi
     securityContext:
       allowPrivilegeEscalation: false
       readOnlyRootFilesystem: true
@@ -43,13 +45,17 @@ admissionController:
     secure: false
 backgroundController:
   replicas: 3
+  extraArgs:
+    clientRateLimitBurst: 2000
+    clientRateLimitQPS: 2000
+    leaderElectionRetryPeriod: 5s
   resources:
     requests:
       cpu: 6000m
-      memory: 2Gi
+      memory: 4Gi
     limits:
       cpu: 6000m
-      memory: 2Gi
+      memory: 4Gi
   securityContext:
     allowPrivilegeEscalation: false
     readOnlyRootFilesystem: true
@@ -72,6 +78,8 @@ cleanupController:
     limits:
       cpu: 500m
       memory: 128Mi
+  extraArgs:
+    leaderElectionRetryPeriod: 5s
   securityContext:
     allowPrivilegeEscalation: false
     readOnlyRootFilesystem: true


### PR DESCRIPTION
Kyverno was tuned on rh01 where is we have the highest load so align the configuration of p02 with rh01.

The main reason is to address ongoing issues where background controller is getting OOMKilled but also to get all other fixes/tuning done on rh01.