### PR TITLE
konflux-ci: add tenant label in staging overlay

### DIFF
--- a/components/konflux-ci/staging/kustomization.yaml
+++ b/components/konflux-ci/staging/kustomization.yaml
@@ -3,3 +3,5 @@ kind: Kustomization
 resources:
 - ../base
 - ../base/external-secrets
+patches:
+- path: namespace.yaml

--- a/components/konflux-ci/staging/namespace.yaml
+++ b/components/konflux-ci/staging/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: konflux-ci
+  labels:
+    konflux-ci.dev/type: tenant


### PR DESCRIPTION
Since kueue has been deployed, pipelineruns will now fail to move out of pending due to a lack of a LocalQueue resource in the namespace.  The easiest method for getting a LocalQueue into this namespace is to make it a pseudo-tenant and give it the tenant label.

For now, only apply this label to the staging clusters, so we can properly assess and test whether this approach will work for this namespace.