### PR TITLE
KubeArchive: install v1.6.0 on production clusters

### DIFF
--- a/components/kubearchive/production/kflux-ocp-p01/kustomization.yaml
+++ b/components/kubearchive/production/kflux-ocp-p01/kustomization.yaml
@@ -4,7 +4,7 @@ kind: Kustomization
 resources:
   - ../../base
   - ../base
-  - https://github.com/kubearchive/kubearchive/releases/download/v1.5.0/kubearchive.yaml?timeout=90
+  - https://github.com/kubearchive/kubearchive/releases/download/v1.6.0/kubearchive.yaml?timeout=90
 
 namespace: product-kubearchive
 
@@ -21,7 +21,7 @@ patches:
               - name: migration
                 env:
                   - name: KUBEARCHIVE_VERSION
-                    value: v1.5.0
+                    value: v1.6.0
   # We don't need the Secret as it will be created by the ExternalSecrets Operator
   - patch: |-
       $patch: delete

--- a/components/kubearchive/production/kflux-prd-rh03/kustomization.yaml
+++ b/components/kubearchive/production/kflux-prd-rh03/kustomization.yaml
@@ -4,7 +4,7 @@ kind: Kustomization
 resources:
   - ../../base
   - ../base
-  - https://github.com/kubearchive/kubearchive/releases/download/v1.5.0/kubearchive.yaml?timeout=90
+  - https://github.com/kubearchive/kubearchive/releases/download/v1.6.0/kubearchive.yaml?timeout=90
 
 namespace: product-kubearchive
 
@@ -21,7 +21,7 @@ patches:
               - name: migration
                 env:
                   - name: KUBEARCHIVE_VERSION
-                    value: v1.5.0
+                    value: v1.6.0
   # We don't need the Secret as it will be created by the ExternalSecrets Operator
   - patch: |-
       $patch: delete

--- a/components/kubearchive/production/kflux-rhel-p01/kustomization.yaml
+++ b/components/kubearchive/production/kflux-rhel-p01/kustomization.yaml
@@ -4,7 +4,7 @@ kind: Kustomization
 resources:
   - ../../base
   - ../base
-  - https://github.com/kubearchive/kubearchive/releases/download/v1.5.0/kubearchive.yaml?timeout=90
+  - https://github.com/kubearchive/kubearchive/releases/download/v1.6.0/kubearchive.yaml?timeout=90
 
 namespace: product-kubearchive
 
@@ -21,7 +21,7 @@ patches:
               - name: migration
                 env:
                   - name: KUBEARCHIVE_VERSION
-                    value: v1.5.0
+                    value: v1.6.0
   # We don't need the Secret as it will be created by the ExternalSecrets Operator
   - patch: |-
       $patch: delete

--- a/components/kubearchive/production/stone-prod-p02/kustomization.yaml
+++ b/components/kubearchive/production/stone-prod-p02/kustomization.yaml
@@ -4,7 +4,7 @@ kind: Kustomization
 resources:
   - ../../base
   - ../base
-  - https://github.com/kubearchive/kubearchive/releases/download/v1.5.0/kubearchive.yaml?timeout=90
+  - https://github.com/kubearchive/kubearchive/releases/download/v1.6.0/kubearchive.yaml?timeout=90
 
 namespace: product-kubearchive
 
@@ -21,7 +21,7 @@ patches:
               - name: migration
                 env:
                   - name: KUBEARCHIVE_VERSION
-                    value: v1.5.0
+                    value: v1.6.0
   # We don't need the Secret as it will be created by the ExternalSecrets Operator
   - patch: |-
       $patch: delete


### PR DESCRIPTION
Upgrading KubeArchive to v1.6.0 for some production clusters. This solves a problem with latencies.