### PR TITLE
KFLUXINFRA-2097: Host-Config Tuning RH01 and P02

### DIFF
--- a/components/kueue/production/stone-prd-rh01/queue-config/cluster-queue.yaml
+++ b/components/kueue/production/stone-prd-rh01/queue-config/cluster-queue.yaml
@@ -30,45 +30,29 @@ spec:
   - coveredResources:
     - linux-amd64
     - linux-arm64
-    - linux-c2xlarge-amd64
-    - linux-c2xlarge-arm64
-    - linux-c4xlarge-amd64
-    - linux-c4xlarge-arm64
     - linux-c6gd2xlarge-arm64
-    - linux-c8xlarge-amd64
-    - linux-c8xlarge-arm64
-    - linux-cxlarge-amd64
-    - linux-cxlarge-arm64
     - linux-d160-m2xlarge-amd64
     - linux-d160-m2xlarge-arm64
     - linux-d160-m4xlarge-amd64
     - linux-d160-m4xlarge-arm64
     - linux-d160-m8xlarge-amd64
+    - linux-d160-m8xlarge-arm64
+    - linux-extra-fast-amd64
+    - linux-fast-amd64
+    - linux-g6xlarge-amd64
+    - linux-m2xlarge-amd64
+    - linux-m4xlarge-amd64
+    - linux-m4xlarge-arm64
+    - linux-m8xlarge-amd64
     flavors:
     - name: platform-group-1
       resources:
       - name: linux-amd64
         nominalQuota: '30'
       - name: linux-arm64
-        nominalQuota: '70'
-      - name: linux-c2xlarge-amd64
-        nominalQuota: '5'
-      - name: linux-c2xlarge-arm64
-        nominalQuota: '5'
-      - name: linux-c4xlarge-amd64
-        nominalQuota: '5'
-      - name: linux-c4xlarge-arm64
-        nominalQuota: '5'
+        nominalQuota: '100'
       - name: linux-c6gd2xlarge-arm64
-        nominalQuota: '5'
-      - name: linux-c8xlarge-amd64
-        nominalQuota: '5'
-      - name: linux-c8xlarge-arm64
-        nominalQuota: '5'
-      - name: linux-cxlarge-amd64
-        nominalQuota: '5'
-      - name: linux-cxlarge-arm64
-        nominalQuota: '5'
+        nominalQuota: '25'
       - name: linux-d160-m2xlarge-amd64
         nominalQuota: '5'
       - name: linux-d160-m2xlarge-arm64
@@ -79,37 +63,15 @@ spec:
         nominalQuota: '5'
       - name: linux-d160-m8xlarge-amd64
         nominalQuota: '5'
-  - coveredResources:
-    - linux-d160-m8xlarge-arm64
-    - linux-extra-fast-amd64
-    - linux-fast-amd64
-    - linux-g6xlarge-amd64
-    - linux-m2xlarge-amd64
-    - linux-m2xlarge-arm64
-    - linux-m4xlarge-amd64
-    - linux-m4xlarge-arm64
-    - linux-m8xlarge-amd64
-    - linux-m8xlarge-arm64
-    - linux-mlarge-amd64
-    - linux-mlarge-arm64
-    - linux-mxlarge-amd64
-    - linux-mxlarge-arm64
-    - linux-ppc64le
-    - linux-root-amd64
-    flavors:
-    - name: platform-group-2
-      resources:
       - name: linux-d160-m8xlarge-arm64
         nominalQuota: '5'
       - name: linux-extra-fast-amd64
-        nominalQuota: '5'
+        nominalQuota: '25'
       - name: linux-fast-amd64
         nominalQuota: '5'
       - name: linux-g6xlarge-amd64
         nominalQuota: '5'
       - name: linux-m2xlarge-amd64
-        nominalQuota: '5'
-      - name: linux-m2xlarge-arm64
         nominalQuota: '5'
       - name: linux-m4xlarge-amd64
         nominalQuota: '5'
@@ -117,29 +79,27 @@ spec:
         nominalQuota: '5'
       - name: linux-m8xlarge-amd64
         nominalQuota: '5'
-      - name: linux-m8xlarge-arm64
-        nominalQuota: '5'
-      - name: linux-mlarge-amd64
-        nominalQuota: '5'
-      - name: linux-mlarge-arm64
-        nominalQuota: '5'
-      - name: linux-mxlarge-amd64
-        nominalQuota: '5'
-      - name: linux-mxlarge-arm64
-        nominalQuota: '5'
-      - name: linux-ppc64le
-        nominalQuota: '64'
-      - name: linux-root-amd64
-        nominalQuota: '5'
   - coveredResources:
+    - linux-mlarge-amd64
+    - linux-mxlarge-amd64
+    - linux-ppc64le
+    - linux-root-amd64
     - linux-root-arm64
     - linux-s390x
     - linux-x86-64
     - local
     - localhost
     flavors:
-    - name: platform-group-3
+    - name: platform-group-2
       resources:
+      - name: linux-mlarge-amd64
+        nominalQuota: '5'
+      - name: linux-mxlarge-amd64
+        nominalQuota: '5'
+      - name: linux-ppc64le
+        nominalQuota: '64'
+      - name: linux-root-amd64
+        nominalQuota: '5'
       - name: linux-root-arm64
         nominalQuota: '5'
       - name: linux-s390x

--- a/components/kueue/production/stone-prod-p02/queue-config/cluster-queue.yaml
+++ b/components/kueue/production/stone-prod-p02/queue-config/cluster-queue.yaml
@@ -30,118 +30,63 @@ spec:
   - coveredResources:
     - linux-amd64
     - linux-arm64
-    - linux-c2xlarge-amd64
-    - linux-c2xlarge-arm64
-    - linux-c4xlarge-amd64
-    - linux-c4xlarge-arm64
     - linux-c6gd2xlarge-arm64
-    - linux-c8xlarge-amd64
-    - linux-c8xlarge-arm64
-    - linux-cxlarge-amd64
-    - linux-cxlarge-arm64
     - linux-d160-m2xlarge-amd64
     - linux-d160-m2xlarge-arm64
     - linux-d160-m4xlarge-amd64
     - linux-d160-m4xlarge-arm64
     - linux-d160-m8xlarge-amd64
+    - linux-d160-m8xlarge-arm64
+    - linux-extra-fast-amd64
+    - linux-fast-amd64
+    - linux-g6xlarge-amd64
+    - linux-m2xlarge-arm64
+    - linux-ppc64le
+    - linux-root-amd64
+    - linux-root-arm64
     flavors:
     - name: platform-group-1
       resources:
       - name: linux-amd64
         nominalQuota: '30'
       - name: linux-arm64
-        nominalQuota: '50'
-      - name: linux-c2xlarge-amd64
-        nominalQuota: '5'
-      - name: linux-c2xlarge-arm64
-        nominalQuota: '5'
-      - name: linux-c4xlarge-amd64
-        nominalQuota: '5'
-      - name: linux-c4xlarge-arm64
-        nominalQuota: '5'
+        nominalQuota: '100'
       - name: linux-c6gd2xlarge-arm64
-        nominalQuota: '5'
-      - name: linux-c8xlarge-amd64
-        nominalQuota: '5'
-      - name: linux-c8xlarge-arm64
-        nominalQuota: '5'
-      - name: linux-cxlarge-amd64
-        nominalQuota: '5'
-      - name: linux-cxlarge-arm64
         nominalQuota: '5'
       - name: linux-d160-m2xlarge-amd64
         nominalQuota: '10'
       - name: linux-d160-m2xlarge-arm64
         nominalQuota: '10'
       - name: linux-d160-m4xlarge-amd64
-        nominalQuota: '10'
+        nominalQuota: '20'
       - name: linux-d160-m4xlarge-arm64
-        nominalQuota: '10'
+        nominalQuota: '20'
       - name: linux-d160-m8xlarge-amd64
         nominalQuota: '5'
-  - coveredResources:
-    - linux-d160-m8xlarge-arm64
-    - linux-extra-fast-amd64
-    - linux-fast-amd64
-    - linux-g6xlarge-amd64
-    - linux-m2xlarge-amd64
-    - linux-m2xlarge-arm64
-    - linux-m4xlarge-amd64
-    - linux-m4xlarge-arm64
-    - linux-m8xlarge-amd64
-    - linux-m8xlarge-arm64
-    - linux-mlarge-amd64
-    - linux-mlarge-arm64
-    - linux-mxlarge-amd64
-    - linux-mxlarge-arm64
-    - linux-ppc64le
-    - linux-root-amd64
-    flavors:
-    - name: platform-group-2
-      resources:
       - name: linux-d160-m8xlarge-arm64
         nominalQuota: '5'
       - name: linux-extra-fast-amd64
-        nominalQuota: '5'
+        nominalQuota: '15'
       - name: linux-fast-amd64
         nominalQuota: '5'
       - name: linux-g6xlarge-amd64
         nominalQuota: '5'
-      - name: linux-m2xlarge-amd64
-        nominalQuota: '5'
       - name: linux-m2xlarge-arm64
-        nominalQuota: '5'
-      - name: linux-m4xlarge-amd64
-        nominalQuota: '5'
-      - name: linux-m4xlarge-arm64
-        nominalQuota: '5'
-      - name: linux-m8xlarge-amd64
-        nominalQuota: '5'
-      - name: linux-m8xlarge-arm64
-        nominalQuota: '5'
-      - name: linux-mlarge-amd64
-        nominalQuota: '5'
-      - name: linux-mlarge-arm64
-        nominalQuota: '5'
-      - name: linux-mxlarge-amd64
-        nominalQuota: '5'
-      - name: linux-mxlarge-arm64
-        nominalQuota: '5'
+        nominalQuota: '15'
       - name: linux-ppc64le
         nominalQuota: '40'
       - name: linux-root-amd64
         nominalQuota: '5'
+      - name: linux-root-arm64
+        nominalQuota: '5'
   - coveredResources:
-    - linux-root-arm64
     - linux-s390x
     - linux-x86-64
     - local
     - localhost
     flavors:
-    - name: platform-group-3
+    - name: platform-group-2
       resources:
-      - name: linux-root-arm64
-        nominalQuota: '5'
       - name: linux-s390x
         nominalQuota: '40'
       - name: linux-x86-64

--- a/components/multi-platform-controller/production-downstream/stone-prod-p02/host-config.yaml
+++ b/components/multi-platform-controller/production-downstream/stone-prod-p02/host-config.yaml
@@ -14,31 +14,14 @@ data:
   dynamic-platforms: "\
     linux/arm64,\
     linux/amd64,\
-    linux-mlarge/amd64,\
-    linux-mlarge/arm64,\
-    linux-mxlarge/amd64,\
-    linux-mxlarge/arm64,\
-    linux-m2xlarge/amd64,\
     linux-m2xlarge/arm64,\
     linux-d160-m2xlarge/amd64,\
     linux-d160-m2xlarge/arm64,\
-    linux-m4xlarge/amd64,\
-    linux-m4xlarge/arm64,\
     linux-d160-m4xlarge/amd64,\
     linux-d160-m4xlarge/arm64,\
-    linux-m8xlarge/amd64,\
-    linux-m8xlarge/arm64,\
     linux-d160-m8xlarge/amd64,\
     linux-d160-m8xlarge/arm64,\
     linux-c6gd2xlarge/arm64,\
-    linux-cxlarge/amd64,\
-    linux-cxlarge/arm64,\
-    linux-c2xlarge/amd64,\
-    linux-c2xlarge/arm64,\
-    linux-c4xlarge/amd64,\
-    linux-c4xlarge/arm64,\
-    linux-c8xlarge/amd64,\
-    linux-c8xlarge/arm64,\
     linux-g6xlarge/amd64,\
     linux-root/arm64,\
     linux-root/amd64,\
@@ -66,35 +49,9 @@ data:
   dynamic.linux-arm64.aws-secret: aws-account
   dynamic.linux-arm64.ssh-secret: aws-ssh-key
   dynamic.linux-arm64.security-group-id: sg-0903aedd465be979e
-  dynamic.linux-arm64.max-instances: "50"
+  dynamic.linux-arm64.max-instances: "100"
   dynamic.linux-arm64.subnet-id: subnet-02c476f8d2a4ae05e
   dynamic.linux-arm64.allocation-timeout: "1200"
-
-  dynamic.linux-mlarge-arm64.type: aws
-  dynamic.linux-mlarge-arm64.region: us-east-1
-  dynamic.linux-mlarge-arm64.ami: ami-03d6a5256a46c9feb
-  dynamic.linux-mlarge-arm64.instance-type: m6g.large
-  dynamic.linux-mlarge-arm64.instance-tag: prod-arm64-mlarge
-  dynamic.linux-mlarge-arm64.key-name: konflux-prod-int-mab01
-  dynamic.linux-mlarge-arm64.aws-secret: aws-account
-  dynamic.linux-mlarge-arm64.ssh-secret: aws-ssh-key
-  dynamic.linux-mlarge-arm64.security-group-id: sg-0903aedd465be979e
-  dynamic.linux-mlarge-arm64.max-instances: "5"
-  dynamic.linux-mlarge-arm64.subnet-id: subnet-02c476f8d2a4ae05e
-  dynamic.linux-mlarge-arm64.allocation-timeout: "1200"
-
-  dynamic.linux-mxlarge-arm64.type: aws
-  dynamic.linux-mxlarge-arm64.region: us-east-1
-  dynamic.linux-mxlarge-arm64.ami: ami-03d6a5256a46c9feb
-  dynamic.linux-mxlarge-arm64.instance-type: m6g.xlarge
-  dynamic.linux-mxlarge-arm64.instance-tag: prod-arm64-mxlarge
-  dynamic.linux-mxlarge-arm64.key-name: konflux-prod-int-mab01
-  dynamic.linux-mxlarge-arm64.aws-secret: aws-account
-  dynamic.linux-mxlarge-arm64.ssh-secret: aws-ssh-key
-  dynamic.linux-mxlarge-arm64.security-group-id: sg-0903aedd465be979e
-  dynamic.linux-mxlarge-arm64.max-instances: "5"
-  dynamic.linux-mxlarge-arm64.subnet-id: subnet-02c476f8d2a4ae05e
-  dynamic.linux-mxlarge-arm64.allocation-timeout: "1200"
 
   dynamic.linux-m2xlarge-arm64.type: aws
   dynamic.linux-m2xlarge-arm64.region: us-east-1
@@ -105,7 +62,7 @@ data:
   dynamic.linux-m2xlarge-arm64.aws-secret: aws-account
   dynamic.linux-m2xlarge-arm64.ssh-secret: aws-ssh-key
   dynamic.linux-m2xlarge-arm64.security-group-id: sg-0903aedd465be979e
-  dynamic.linux-m2xlarge-arm64.max-instances: "5"
+  dynamic.linux-m2xlarge-arm64.max-instances: "15"
   dynamic.linux-m2xlarge-arm64.subnet-id: subnet-02c476f8d2a4ae05e
   dynamic.linux-m2xlarge-arm64.allocation-timeout: "1200"
 
@@ -122,19 +79,6 @@ data:
   dynamic.linux-d160-m2xlarge-arm64.subnet-id: subnet-02c476f8d2a4ae05e
   dynamic.linux-d160-m2xlarge-arm64.allocation-timeout: "1200"
   dynamic.linux-d160-m2xlarge-arm64.disk: "160"
-
-  dynamic.linux-m4xlarge-arm64.type: aws
-  dynamic.linux-m4xlarge-arm64.region: us-east-1
-  dynamic.linux-m4xlarge-arm64.ami: ami-03d6a5256a46c9feb
-  dynamic.linux-m4xlarge-arm64.instance-type: m6g.4xlarge
-  dynamic.linux-m4xlarge-arm64.instance-tag: prod-arm64-m4xlarge
-  dynamic.linux-m4xlarge-arm64.key-name: konflux-prod-int-mab01
-  dynamic.linux-m4xlarge-arm64.aws-secret: aws-account
-  dynamic.linux-m4xlarge-arm64.ssh-secret: aws-ssh-key
-  dynamic.linux-m4xlarge-arm64.security-group-id: sg-0903aedd465be979e
-  dynamic.linux-m4xlarge-arm64.max-instances: "5"
-  dynamic.linux-m4xlarge-arm64.subnet-id: subnet-02c476f8d2a4ae05e
-  dynamic.linux-m4xlarge-arm64.allocation-timeout: "1200"
 
   dynamic.linux-c6gd2xlarge-arm64.type: aws
   dynamic.linux-c6gd2xlarge-arm64.region: us-east-1
@@ -223,23 +167,10 @@ data:
   dynamic.linux-d160-m4xlarge-arm64.aws-secret: aws-account
   dynamic.linux-d160-m4xlarge-arm64.ssh-secret: aws-ssh-key
   dynamic.linux-d160-m4xlarge-arm64.security-group-id: sg-0903aedd465be979e
-  dynamic.linux-d160-m4xlarge-arm64.max-instances: "10"
+  dynamic.linux-d160-m4xlarge-arm64.max-instances: "20"
   dynamic.linux-d160-m4xlarge-arm64.subnet-id: subnet-02c476f8d2a4ae05e
   dynamic.linux-d160-m4xlarge-arm64.allocation-timeout: "1200"
   dynamic.linux-d160-m4xlarge-arm64.disk: "160"
-
-  dynamic.linux-m8xlarge-arm64.type: aws
-  dynamic.linux-m8xlarge-arm64.region: us-east-1
-  dynamic.linux-m8xlarge-arm64.ami: ami-03d6a5256a46c9feb
-  dynamic.linux-m8xlarge-arm64.instance-type: m6g.8xlarge
-  dynamic.linux-m8xlarge-arm64.instance-tag: prod-arm64-m8xlarge
-  dynamic.linux-m8xlarge-arm64.key-name: konflux-prod-int-mab01
-  dynamic.linux-m8xlarge-arm64.aws-secret: aws-account
-  dynamic.linux-m8xlarge-arm64.ssh-secret: aws-ssh-key
-  dynamic.linux-m8xlarge-arm64.security-group-id: sg-0903aedd465be979e
-  dynamic.linux-m8xlarge-arm64.max-instances: "5"
-  dynamic.linux-m8xlarge-arm64.subnet-id: subnet-02c476f8d2a4ae05e
-  dynamic.linux-m8xlarge-arm64.allocation-timeout: "1200"
 
   dynamic.linux-d160-m8xlarge-arm64.type: aws
   dynamic.linux-d160-m8xlarge-arm64.region: us-east-1
@@ -268,45 +199,6 @@ data:
   dynamic.linux-amd64.subnet-id: subnet-02c476f8d2a4ae05e
   dynamic.linux-amd64.allocation-timeout: "1200"
 
-  dynamic.linux-mlarge-amd64.type: aws
-  dynamic.linux-mlarge-amd64.region: us-east-1
-  dynamic.linux-mlarge-amd64.ami: ami-026ebd4cfe2c043b2
-  dynamic.linux-mlarge-amd64.instance-type: m6a.large
-  dynamic.linux-mlarge-amd64.instance-tag: prod-amd64-mlarge
-  dynamic.linux-mlarge-amd64.key-name: konflux-prod-int-mab01
-  dynamic.linux-mlarge-amd64.aws-secret: aws-account
-  dynamic.linux-mlarge-amd64.ssh-secret: aws-ssh-key
-  dynamic.linux-mlarge-amd64.security-group-id: sg-0903aedd465be979e
-  dynamic.linux-mlarge-amd64.max-instances: "5"
-  dynamic.linux-mlarge-amd64.subnet-id: subnet-02c476f8d2a4ae05e
-  dynamic.linux-mlarge-amd64.allocation-timeout: "1200"
-
-  dynamic.linux-mxlarge-amd64.type: aws
-  dynamic.linux-mxlarge-amd64.region: us-east-1
-  dynamic.linux-mxlarge-amd64.ami: ami-026ebd4cfe2c043b2
-  dynamic.linux-mxlarge-amd64.instance-type: m6a.xlarge
-  dynamic.linux-mxlarge-amd64.instance-tag: prod-amd64-mxlarge
-  dynamic.linux-mxlarge-amd64.key-name: konflux-prod-int-mab01
-  dynamic.linux-mxlarge-amd64.aws-secret: aws-account
-  dynamic.linux-mxlarge-amd64.ssh-secret: aws-ssh-key
-  dynamic.linux-mxlarge-amd64.security-group-id: sg-0903aedd465be979e
-  dynamic.linux-mxlarge-amd64.max-instances: "5"
-  dynamic.linux-mxlarge-amd64.subnet-id: subnet-02c476f8d2a4ae05e
-  dynamic.linux-mxlarge-amd64.allocation-timeout: "1200"
-
-  dynamic.linux-m2xlarge-amd64.type: aws
-  dynamic.linux-m2xlarge-amd64.region: us-east-1
-  dynamic.linux-m2xlarge-amd64.ami: ami-026ebd4cfe2c043b2
-  dynamic.linux-m2xlarge-amd64.instance-type: m6a.2xlarge
-  dynamic.linux-m2xlarge-amd64.instance-tag: prod-amd64-m2xlarge
-  dynamic.linux-m2xlarge-amd64.key-name: konflux-prod-int-mab01
-  dynamic.linux-m2xlarge-amd64.aws-secret: aws-account
-  dynamic.linux-m2xlarge-amd64.ssh-secret: aws-ssh-key
-  dynamic.linux-m2xlarge-amd64.security-group-id: sg-0903aedd465be979e
-  dynamic.linux-m2xlarge-amd64.max-instances: "5"
-  dynamic.linux-m2xlarge-amd64.subnet-id: subnet-02c476f8d2a4ae05e
-  dynamic.linux-m2xlarge-amd64.allocation-timeout: "1200"
-
   dynamic.linux-d160-m2xlarge-amd64.type: aws
   dynamic.linux-d160-m2xlarge-amd64.region: us-east-1
   dynamic.linux-d160-m2xlarge-amd64.ami: ami-026ebd4cfe2c043b2
@@ -321,19 +213,6 @@ data:
   dynamic.linux-d160-m2xlarge-amd64.allocation-timeout: "1200"
   dynamic.linux-d160-m2xlarge-amd64.disk: "160"
 
-  dynamic.linux-m4xlarge-amd64.type: aws
-  dynamic.linux-m4xlarge-amd64.region: us-east-1
-  dynamic.linux-m4xlarge-amd64.ami: ami-026ebd4cfe2c043b2
-  dynamic.linux-m4xlarge-amd64.instance-type: m6a.4xlarge
-  dynamic.linux-m4xlarge-amd64.instance-tag: prod-amd64-m4xlarge
-  dynamic.linux-m4xlarge-amd64.key-name: konflux-prod-int-mab01
-  dynamic.linux-m4xlarge-amd64.aws-secret: aws-account
-  dynamic.linux-m4xlarge-amd64.ssh-secret: aws-ssh-key
-  dynamic.linux-m4xlarge-amd64.security-group-id: sg-0903aedd465be979e
-  dynamic.linux-m4xlarge-amd64.max-instances: "5"
-  dynamic.linux-m4xlarge-amd64.subnet-id: subnet-02c476f8d2a4ae05e
-  dynamic.linux-m4xlarge-amd64.allocation-timeout: "1200"
-
   # same as m4xlarge-amd64 bug 160G disk
   dynamic.linux-d160-m4xlarge-amd64.type: aws
   dynamic.linux-d160-m4xlarge-amd64.region: us-east-1
@@ -344,23 +223,10 @@ data:
   dynamic.linux-d160-m4xlarge-amd64.aws-secret: aws-account
   dynamic.linux-d160-m4xlarge-amd64.ssh-secret: aws-ssh-key
   dynamic.linux-d160-m4xlarge-amd64.security-group-id: sg-0903aedd465be979e
-  dynamic.linux-d160-m4xlarge-amd64.max-instances: "10"
+  dynamic.linux-d160-m4xlarge-amd64.max-instances: "20"
   dynamic.linux-d160-m4xlarge-amd64.subnet-id: subnet-02c476f8d2a4ae05e
   dynamic.linux-d160-m4xlarge-amd64.allocation-timeout: "1200"
   dynamic.linux-d160-m4xlarge-amd64.disk: "160"
-
-  dynamic.linux-m8xlarge-amd64.type: aws
-  dynamic.linux-m8xlarge-amd64.region: us-east-1
-  dynamic.linux-m8xlarge-amd64.ami: ami-026ebd4cfe2c043b2
-  dynamic.linux-m8xlarge-amd64.instance-type: m6a.8xlarge
-  dynamic.linux-m8xlarge-amd64.instance-tag: prod-amd64-m8xlarge
-  dynamic.linux-m8xlarge-amd64.key-name: konflux-prod-int-mab01
-  dynamic.linux-m8xlarge-amd64.aws-secret: aws-account
-  dynamic.linux-m8xlarge-amd64.ssh-secret: aws-ssh-key
-  dynamic.linux-m8xlarge-amd64.security-group-id: sg-0903aedd465be979e
-  dynamic.linux-m8xlarge-amd64.max-instances: "5"
-  dynamic.linux-m8xlarge-amd64.subnet-id: subnet-02c476f8d2a4ae05e
-  dynamic.linux-m8xlarge-amd64.allocation-timeout: "1200"
 
   dynamic.linux-d160-m8xlarge-amd64.type: aws
   dynamic.linux-d160-m8xlarge-amd64.region: us-east-1
@@ -399,113 +265,10 @@ data:
   dynamic.linux-extra-fast-amd64.ssh-secret: aws-ssh-key
   dynamic.linux-extra-fast-amd64.security-group-id: sg-0903aedd465be979e
   dynamic.linux-extra-fast-amd64.subnet-id: subnet-02c476f8d2a4ae05e
-  dynamic.linux-extra-fast-amd64.max-instances: "5"
+  dynamic.linux-extra-fast-amd64.max-instances: "15"
   dynamic.linux-extra-fast-amd64.disk: "200"
 
   # cpu:memory (1:2)
-  dynamic.linux-cxlarge-arm64.type: aws
-  dynamic.linux-cxlarge-arm64.region: us-east-1
-  dynamic.linux-cxlarge-arm64.ami: ami-03d6a5256a46c9feb
-  dynamic.linux-cxlarge-arm64.instance-type: c6g.xlarge
-  dynamic.linux-cxlarge-arm64.instance-tag: prod-arm64-cxlarge
-  dynamic.linux-cxlarge-arm64.key-name: konflux-prod-int-mab01
-  dynamic.linux-cxlarge-arm64.aws-secret: aws-account
-  dynamic.linux-cxlarge-arm64.ssh-secret: aws-ssh-key
-  dynamic.linux-cxlarge-arm64.security-group-id: sg-0903aedd465be979e
-  dynamic.linux-cxlarge-arm64.max-instances: "5"
-  dynamic.linux-cxlarge-arm64.subnet-id: subnet-02c476f8d2a4ae05e
-  dynamic.linux-cxlarge-arm64.allocation-timeout: "1200"
-
-  dynamic.linux-c2xlarge-arm64.type: aws
-  dynamic.linux-c2xlarge-arm64.region: us-east-1
-  dynamic.linux-c2xlarge-arm64.ami: ami-03d6a5256a46c9feb
-  dynamic.linux-c2xlarge-arm64.instance-type: c6g.2xlarge
-  dynamic.linux-c2xlarge-arm64.instance-tag: prod-arm64-c2xlarge
-  dynamic.linux-c2xlarge-arm64.key-name: konflux-prod-int-mab01
-  dynamic.linux-c2xlarge-arm64.aws-secret: aws-account
-  dynamic.linux-c2xlarge-arm64.ssh-secret: aws-ssh-key
-  dynamic.linux-c2xlarge-arm64.security-group-id: sg-0903aedd465be979e
-  dynamic.linux-c2xlarge-arm64.max-instances: "5"
-  dynamic.linux-c2xlarge-arm64.subnet-id: subnet-02c476f8d2a4ae05e
-  dynamic.linux-c2xlarge-arm64.allocation-timeout: "1200"
-
-  dynamic.linux-c4xlarge-arm64.type: aws
-  dynamic.linux-c4xlarge-arm64.region: us-east-1
-  dynamic.linux-c4xlarge-arm64.ami: ami-03d6a5256a46c9feb
-  dynamic.linux-c4xlarge-arm64.instance-type: c6g.4xlarge
-  dynamic.linux-c4xlarge-arm64.instance-tag: prod-arm64-c4xlarge
-  dynamic.linux-c4xlarge-arm64.key-name: konflux-prod-int-mab01
-  dynamic.linux-c4xlarge-arm64.aws-secret: aws-account
-  dynamic.linux-c4xlarge-arm64.ssh-secret: aws-ssh-key
-  dynamic.linux-c4xlarge-arm64.security-group-id: sg-0903aedd465be979e
-  dynamic.linux-c4xlarge-arm64.max-instances: "5"
-  dynamic.linux-c4xlarge-arm64.subnet-id: subnet-02c476f8d2a4ae05e
-  dynamic.linux-c4xlarge-arm64.allocation-timeout: "1200"
-
-  dynamic.linux-c8xlarge-arm64.type: aws
-  dynamic.linux-c8xlarge-arm64.region: us-east-1
-  dynamic.linux-c8xlarge-arm64.ami: ami-03d6a5256a46c9feb
-  dynamic.linux-c8xlarge-arm64.instance-type: c6g.8xlarge
-  dynamic.linux-c8xlarge-arm64.instance-tag: prod-arm64-c8xlarge
-  dynamic.linux-c8xlarge-arm64.key-name: konflux-prod-int-mab01
-  dynamic.linux-c8xlarge-arm64.aws-secret: aws-account
-  dynamic.linux-c8xlarge-arm64.ssh-secret: aws-ssh-key
-  dynamic.linux-c8xlarge-arm64.security-group-id: sg-0903aedd465be979e
-  dynamic.linux-c8xlarge-arm64.max-instances: "5"
-  dynamic.linux-c8xlarge-arm64.subnet-id: subnet-02c476f8d2a4ae05e
-  dynamic.linux-c8xlarge-arm64.allocation-timeout: "1200"
-
-  dynamic.linux-cxlarge-amd64.type: aws
-  dynamic.linux-cxlarge-amd64.region: us-east-1
-  dynamic.linux-cxlarge-amd64.ami: ami-026ebd4cfe2c043b2
-  dynamic.linux-cxlarge-amd64.instance-type: c6a.xlarge
-  dynamic.linux-cxlarge-amd64.instance-tag: prod-amd64-cxlarge
-  dynamic.linux-cxlarge-amd64.key-name: konflux-prod-int-mab01
-  dynamic.linux-cxlarge-amd64.aws-secret: aws-account
-  dynamic.linux-cxlarge-amd64.ssh-secret: aws-ssh-key
-  dynamic.linux-cxlarge-amd64.security-group-id: sg-0903aedd465be979e
-  dynamic.linux-cxlarge-amd64.max-instances: "5"
-  dynamic.linux-cxlarge-amd64.subnet-id: subnet-02c476f8d2a4ae05e
-  dynamic.linux-cxlarge-amd64.allocation-timeout: "1200"
-
-  dynamic.linux-c2xlarge-amd64.type: aws
-  dynamic.linux-c2xlarge-amd64.region: us-east-1
-  dynamic.linux-c2xlarge-amd64.ami: ami-026ebd4cfe2c043b2
-  dynamic.linux-c2xlarge-amd64.instance-type: c6a.2xlarge
-  dynamic.linux-c2xlarge-amd64.instance-tag: prod-amd64-c2xlarge
-  dynamic.linux-c2xlarge-amd64.key-name: konflux-prod-int-mab01
-  dynamic.linux-c2xlarge-amd64.aws-secret: aws-account
-  dynamic.linux-c2xlarge-amd64.ssh-secret: aws-ssh-key
-  dynamic.linux-c2xlarge-amd64.security-group-id: sg-0903aedd465be979e
-  dynamic.linux-c2xlarge-amd64.max-instances: "5"
-  dynamic.linux-c2xlarge-amd64.subnet-id: subnet-02c476f8d2a4ae05e
-  dynamic.linux-c2xlarge-amd64.allocation-timeout: "1200"
-
-  dynamic.linux-c4xlarge-amd64.type: aws
-  dynamic.linux-c4xlarge-amd64.region: us-east-1
-  dynamic.linux-c4xlarge-amd64.ami: ami-026ebd4cfe2c043b2
-  dynamic.linux-c4xlarge-amd64.instance-type: c6a.4xlarge
-  dynamic.linux-c4xlarge-amd64.instance-tag: prod-amd64-c4xlarge
-  dynamic.linux-c4xlarge-amd64.key-name: konflux-prod-int-mab01
-  dynamic.linux-c4xlarge-amd64.aws-secret: aws-account
-  dynamic.linux-c4xlarge-amd64.ssh-secret: aws-ssh-key
-  dynamic.linux-c4xlarge-amd64.security-group-id: sg-0903aedd465be979e
-  dynamic.linux-c4xlarge-amd64.max-instances: "5"
-  dynamic.linux-c4xlarge-amd64.subnet-id: subnet-02c476f8d2a4ae05e
-  dynamic.linux-c4xlarge-amd64.allocation-timeout: "1200"
-
-  dynamic.linux-c8xlarge-amd64.type: aws
-  dynamic.linux-c8xlarge-amd64.region: us-east-1
-  dynamic.linux-c8xlarge-amd64.ami: ami-026ebd4cfe2c043b2
-  dynamic.linux-c8xlarge-amd64.instance-type: c6a.8xlarge
-  dynamic.linux-c8xlarge-amd64.instance-tag: prod-amd64-c8xlarge
-  dynamic.linux-c8xlarge-amd64.key-name: konflux-prod-int-mab01
-  dynamic.linux-c8xlarge-amd64.aws-secret: aws-account
-  dynamic.linux-c8xlarge-amd64.ssh-secret: aws-ssh-key
-  dynamic.linux-c8xlarge-amd64.security-group-id: sg-0903aedd465be979e
-  dynamic.linux-c8xlarge-amd64.max-instances: "5"
-  dynamic.linux-c8xlarge-amd64.subnet-id: subnet-02c476f8d2a4ae05e
-  dynamic.linux-c8xlarge-amd64.allocation-timeout: "1200"
 
   dynamic.linux-root-arm64.type: aws
   dynamic.linux-root-arm64.region: us-east-1

--- a/components/multi-platform-controller/production/stone-prd-rh01/host-config.yaml
+++ b/components/multi-platform-controller/production/stone-prd-rh01/host-config.yaml
@@ -14,31 +14,16 @@ data:
   dynamic-platforms: "\
     linux/arm64,\
     linux/amd64,\
-    linux-mlarge/arm64,\
     linux-mlarge/amd64,\
-    linux-mxlarge/amd64,\
-    linux-mxlarge/arm64,\
-    linux-m2xlarge/amd64,\
-    linux-m2xlarge/arm64,\
     linux-d160-m2xlarge/amd64,\
     linux-d160-m2xlarge/arm64,\
     linux-m4xlarge/amd64,\
     linux-m4xlarge/arm64,\
     linux-d160-m4xlarge/amd64,\
     linux-d160-m4xlarge/arm64,\
-    linux-m8xlarge/amd64,\
-    linux-m8xlarge/arm64,\
     linux-d160-m8xlarge/amd64,\
     linux-d160-m8xlarge/arm64,\
     linux-c6gd2xlarge/arm64,\
-    linux-cxlarge/amd64,\
-    linux-cxlarge/arm64,\
-    linux-c2xlarge/amd64,\
-    linux-c2xlarge/arm64,\
-    linux-c4xlarge/amd64,\
-    linux-c4xlarge/arm64,\
-    linux-c8xlarge/amd64,\
-    linux-c8xlarge/arm64,\
     linux-g6xlarge/amd64,\
     linux-root/arm64,\
     linux-root/amd64,\
@@ -66,44 +51,8 @@ data:
   dynamic.linux-arm64.aws-secret: aws-account
   dynamic.linux-arm64.ssh-secret: aws-ssh-key
   dynamic.linux-arm64.security-group-id: sg-0fbf35ced0d59fd4a
-  dynamic.linux-arm64.max-instances: "70"
+  dynamic.linux-arm64.max-instances: "100"
   dynamic.linux-arm64.subnet-id: subnet-0c39ff75f819abfc5
-
-  dynamic.linux-mlarge-arm64.type: aws
-  dynamic.linux-mlarge-arm64.region: us-east-1
-  dynamic.linux-mlarge-arm64.ami: ami-03d6a5256a46c9feb
-  dynamic.linux-mlarge-arm64.instance-type: m6g.large
-  dynamic.linux-mlarge-arm64.instance-tag: prod-arm64-mlarge
-  dynamic.linux-mlarge-arm64.key-name: konflux-prod-ext-mab01
-  dynamic.linux-mlarge-arm64.aws-secret: aws-account
-  dynamic.linux-mlarge-arm64.ssh-secret: aws-ssh-key
-  dynamic.linux-mlarge-arm64.security-group-id: sg-0fbf35ced0d59fd4a
-  dynamic.linux-mlarge-arm64.max-instances: "5"
-  dynamic.linux-mlarge-arm64.subnet-id: subnet-0c39ff75f819abfc5
-
-  dynamic.linux-mxlarge-arm64.type: aws
-  dynamic.linux-mxlarge-arm64.region: us-east-1
-  dynamic.linux-mxlarge-arm64.ami: ami-03d6a5256a46c9feb
-  dynamic.linux-mxlarge-arm64.instance-type: m6g.xlarge
-  dynamic.linux-mxlarge-arm64.instance-tag: prod-arm64-mxlarge
-  dynamic.linux-mxlarge-arm64.key-name: konflux-prod-ext-mab01
-  dynamic.linux-mxlarge-arm64.aws-secret: aws-account
-  dynamic.linux-mxlarge-arm64.ssh-secret: aws-ssh-key
-  dynamic.linux-mxlarge-arm64.security-group-id: sg-0fbf35ced0d59fd4a
-  dynamic.linux-mxlarge-arm64.max-instances: "5"
-  dynamic.linux-mxlarge-arm64.subnet-id: subnet-0c39ff75f819abfc5
-
-  dynamic.linux-m2xlarge-arm64.type: aws
-  dynamic.linux-m2xlarge-arm64.region: us-east-1
-  dynamic.linux-m2xlarge-arm64.ami: ami-03d6a5256a46c9feb
-  dynamic.linux-m2xlarge-arm64.instance-type: m6g.2xlarge
-  dynamic.linux-m2xlarge-arm64.instance-tag: prod-arm64-m2xlarge
-  dynamic.linux-m2xlarge-arm64.key-name: konflux-prod-ext-mab01
-  dynamic.linux-m2xlarge-arm64.aws-secret: aws-account
-  dynamic.linux-m2xlarge-arm64.ssh-secret: aws-ssh-key
-  dynamic.linux-m2xlarge-arm64.security-group-id: sg-0fbf35ced0d59fd4a
-  dynamic.linux-m2xlarge-arm64.max-instances: "5"
-  dynamic.linux-m2xlarge-arm64.subnet-id: subnet-0c39ff75f819abfc5
 
   dynamic.linux-d160-m2xlarge-arm64.type: aws
   dynamic.linux-d160-m2xlarge-arm64.region: us-east-1
@@ -130,18 +79,6 @@ data:
   dynamic.linux-m4xlarge-arm64.max-instances: "5"
   dynamic.linux-m4xlarge-arm64.subnet-id: subnet-0c39ff75f819abfc5
 
-  dynamic.linux-m8xlarge-arm64.type: aws
-  dynamic.linux-m8xlarge-arm64.region: us-east-1
-  dynamic.linux-m8xlarge-arm64.ami: ami-03d6a5256a46c9feb
-  dynamic.linux-m8xlarge-arm64.instance-type: m6g.8xlarge
-  dynamic.linux-m8xlarge-arm64.instance-tag: prod-arm64-m8xlarge
-  dynamic.linux-m8xlarge-arm64.key-name: konflux-prod-ext-mab01
-  dynamic.linux-m8xlarge-arm64.aws-secret: aws-account
-  dynamic.linux-m8xlarge-arm64.ssh-secret: aws-ssh-key
-  dynamic.linux-m8xlarge-arm64.security-group-id: sg-0fbf35ced0d59fd4a
-  dynamic.linux-m8xlarge-arm64.max-instances: "5"
-  dynamic.linux-m8xlarge-arm64.subnet-id: subnet-0c39ff75f819abfc5
-
   dynamic.linux-d160-m8xlarge-arm64.type: aws
   dynamic.linux-d160-m8xlarge-arm64.region: us-east-1
   dynamic.linux-d160-m8xlarge-arm64.ami: ami-03d6a5256a46c9feb
@@ -164,7 +101,7 @@ data:
   dynamic.linux-c6gd2xlarge-arm64.aws-secret: aws-account
   dynamic.linux-c6gd2xlarge-arm64.ssh-secret: aws-ssh-key
   dynamic.linux-c6gd2xlarge-arm64.security-group-id: sg-0fbf35ced0d59fd4a
-  dynamic.linux-c6gd2xlarge-arm64.max-instances: "5"
+  dynamic.linux-c6gd2xlarge-arm64.max-instances: "25"
   dynamic.linux-c6gd2xlarge-arm64.subnet-id: subnet-0c39ff75f819abfc5
   dynamic.linux-c6gd2xlarge-arm64.user-data: |-
     Content-Type: multipart/mixed; boundary="//"
@@ -360,101 +297,6 @@ data:
   dynamic.linux-d160-m8xlarge-amd64.disk: "160"
 
   # cpu:memory (1:2)
-  dynamic.linux-cxlarge-arm64.type: aws
-  dynamic.linux-cxlarge-arm64.region: us-east-1
-  dynamic.linux-cxlarge-arm64.ami: ami-03d6a5256a46c9feb
-  dynamic.linux-cxlarge-arm64.instance-type: c6g.xlarge
-  dynamic.linux-cxlarge-arm64.instance-tag: prod-arm64-cxlarge
-  dynamic.linux-cxlarge-arm64.key-name: konflux-prod-ext-mab01
-  dynamic.linux-cxlarge-arm64.aws-secret: aws-account
-  dynamic.linux-cxlarge-arm64.ssh-secret: aws-ssh-key
-  dynamic.linux-cxlarge-arm64.security-group-id: sg-0fbf35ced0d59fd4a
-  dynamic.linux-cxlarge-arm64.max-instances: "5"
-  dynamic.linux-cxlarge-arm64.subnet-id: subnet-0c39ff75f819abfc5
-
-  dynamic.linux-c2xlarge-arm64.type: aws
-  dynamic.linux-c2xlarge-arm64.region: us-east-1
-  dynamic.linux-c2xlarge-arm64.ami: ami-03d6a5256a46c9feb
-  dynamic.linux-c2xlarge-arm64.instance-type: c6g.2xlarge
-  dynamic.linux-c2xlarge-arm64.instance-tag: prod-arm64-c2xlarge
-  dynamic.linux-c2xlarge-arm64.key-name: konflux-prod-ext-mab01
-  dynamic.linux-c2xlarge-arm64.aws-secret: aws-account
-  dynamic.linux-c2xlarge-arm64.ssh-secret: aws-ssh-key
-  dynamic.linux-c2xlarge-arm64.security-group-id: sg-0fbf35ced0d59fd4a
-  dynamic.linux-c2xlarge-arm64.max-instances: "5"
-  dynamic.linux-c2xlarge-arm64.subnet-id: subnet-0c39ff75f819abfc5
-
-  dynamic.linux-c4xlarge-arm64.type: aws
-  dynamic.linux-c4xlarge-arm64.region: us-east-1
-  dynamic.linux-c4xlarge-arm64.ami: ami-03d6a5256a46c9feb
-  dynamic.linux-c4xlarge-arm64.instance-type: c6g.4xlarge
-  dynamic.linux-c4xlarge-arm64.instance-tag: prod-arm64-c4xlarge
-  dynamic.linux-c4xlarge-arm64.key-name: konflux-prod-ext-mab01
-  dynamic.linux-c4xlarge-arm64.aws-secret: aws-account
-  dynamic.linux-c4xlarge-arm64.ssh-secret: aws-ssh-key
-  dynamic.linux-c4xlarge-arm64.security-group-id: sg-0fbf35ced0d59fd4a
-  dynamic.linux-c4xlarge-arm64.max-instances: "5"
-  dynamic.linux-c4xlarge-arm64.subnet-id: subnet-0c39ff75f819abfc5
-
-  dynamic.linux-c8xlarge-arm64.type: aws
-  dynamic.linux-c8xlarge-arm64.region: us-east-1
-  dynamic.linux-c8xlarge-arm64.ami: ami-03d6a5256a46c9feb
-  dynamic.linux-c8xlarge-arm64.instance-type: c6g.8xlarge
-  dynamic.linux-c8xlarge-arm64.instance-tag: prod-arm64-c8xlarge
-  dynamic.linux-c8xlarge-arm64.key-name: konflux-prod-ext-mab01
-  dynamic.linux-c8xlarge-arm64.aws-secret: aws-account
-  dynamic.linux-c8xlarge-arm64.ssh-secret: aws-ssh-key
-  dynamic.linux-c8xlarge-arm64.security-group-id: sg-0fbf35ced0d59fd4a
-  dynamic.linux-c8xlarge-arm64.max-instances: "5"
-  dynamic.linux-c8xlarge-arm64.subnet-id: subnet-0c39ff75f819abfc5
-
-  dynamic.linux-cxlarge-amd64.type: aws
-  dynamic.linux-cxlarge-amd64.region: us-east-1
-  dynamic.linux-cxlarge-amd64.ami: ami-026ebd4cfe2c043b2
-  dynamic.linux-cxlarge-amd64.instance-type: c6a.xlarge
-  dynamic.linux-cxlarge-amd64.instance-tag: prod-amd64-cxlarge
-  dynamic.linux-cxlarge-amd64.key-name: konflux-prod-ext-mab01
-  dynamic.linux-cxlarge-amd64.aws-secret: aws-account
-  dynamic.linux-cxlarge-amd64.ssh-secret: aws-ssh-key
-  dynamic.linux-cxlarge-amd64.security-group-id: sg-0fbf35ced0d59fd4a
-  dynamic.linux-cxlarge-amd64.max-instances: "5"
-  dynamic.linux-cxlarge-amd64.subnet-id: subnet-0c39ff75f819abfc5
-
-  dynamic.linux-c2xlarge-amd64.type: aws
-  dynamic.linux-c2xlarge-amd64.region: us-east-1
-  dynamic.linux-c2xlarge-amd64.ami: ami-026ebd4cfe2c043b2
-  dynamic.linux-c2xlarge-amd64.instance-type: c6a.2xlarge
-  dynamic.linux-c2xlarge-amd64.instance-tag: prod-amd64-c2xlarge
-  dynamic.linux-c2xlarge-amd64.key-name: konflux-prod-ext-mab01
-  dynamic.linux-c2xlarge-amd64.aws-secret: aws-account
-  dynamic.linux-c2xlarge-amd64.ssh-secret: aws-ssh-key
-  dynamic.linux-c2xlarge-amd64.security-group-id: sg-0fbf35ced0d59fd4a
-  dynamic.linux-c2xlarge-amd64.max-instances: "5"
-  dynamic.linux-c2xlarge-amd64.subnet-id: subnet-0c39ff75f819abfc5
-
-  dynamic.linux-c4xlarge-amd64.type: aws
-  dynamic.linux-c4xlarge-amd64.region: us-east-1
-  dynamic.linux-c4xlarge-amd64.ami: ami-026ebd4cfe2c043b2
-  dynamic.linux-c4xlarge-amd64.instance-type: c6a.4xlarge
-  dynamic.linux-c4xlarge-amd64.instance-tag: prod-amd64-c4xlarge
-  dynamic.linux-c4xlarge-amd64.key-name: konflux-prod-ext-mab01
-  dynamic.linux-c4xlarge-amd64.aws-secret: aws-account
-  dynamic.linux-c4xlarge-amd64.ssh-secret: aws-ssh-key
-  dynamic.linux-c4xlarge-amd64.security-group-id: sg-0fbf35ced0d59fd4a
-  dynamic.linux-c4xlarge-amd64.max-instances: "5"
-  dynamic.linux-c4xlarge-amd64.subnet-id: subnet-0c39ff75f819abfc5
-
-  dynamic.linux-c8xlarge-amd64.type: aws
-  dynamic.linux-c8xlarge-amd64.region: us-east-1
-  dynamic.linux-c8xlarge-amd64.ami: ami-026ebd4cfe2c043b2
-  dynamic.linux-c8xlarge-amd64.instance-type: c6a.8xlarge
-  dynamic.linux-c8xlarge-amd64.instance-tag: prod-amd64-c8xlarge
-  dynamic.linux-c8xlarge-amd64.key-name: konflux-prod-ext-mab01
-  dynamic.linux-c8xlarge-amd64.aws-secret: aws-account
-  dynamic.linux-c8xlarge-amd64.ssh-secret: aws-ssh-key
-  dynamic.linux-c8xlarge-amd64.security-group-id: sg-0fbf35ced0d59fd4a
-  dynamic.linux-c8xlarge-amd64.max-instances: "5"
-  dynamic.linux-c8xlarge-amd64.subnet-id: subnet-0c39ff75f819abfc5
 
   dynamic.linux-root-arm64.type: aws
   dynamic.linux-root-arm64.region: us-east-1
@@ -498,7 +340,7 @@ data:
   dynamic.linux-extra-fast-amd64.ssh-secret: aws-ssh-key
   dynamic.linux-extra-fast-amd64.security-group-id: sg-0fbf35ced0d59fd4a
   dynamic.linux-extra-fast-amd64.subnet-id: subnet-0c39ff75f819abfc5
-  dynamic.linux-extra-fast-amd64.max-instances: "5"
+  dynamic.linux-extra-fast-amd64.max-instances: "25"
   dynamic.linux-extra-fast-amd64.disk: "200"
   # dynamic.linux-extra-fast-amd64.iops: "16000"
   # dynamic.linux-extra-fast-amd64.throughput: "1000"


### PR DESCRIPTION
This commit will remove unused mulri-platform builder profiles from `stone-prod-p02` and `stone-prd-rh01` host configuration based on Grafana dashboard analysis showing no usage in the last week. Grafana Queries can be found in the Jira Ticket Description.