### PR TITLE
KFLUXINFRA-2097: Host-Config Tuning for P02

### DIFF
--- a/components/kueue/production/stone-prod-p02/queue-config/cluster-queue.yaml
+++ b/components/kueue/production/stone-prod-p02/queue-config/cluster-queue.yaml
@@ -48,7 +48,7 @@ spec:
     - name: platform-group-1
       resources:
       - name: linux-amd64
-        nominalQuota: '30'
+        nominalQuota: '15'
       - name: linux-arm64
         nominalQuota: '100'
       - name: linux-c6gd2xlarge-arm64
@@ -66,7 +66,7 @@ spec:
       - name: linux-d160-m8xlarge-arm64
         nominalQuota: '5'
       - name: linux-extra-fast-amd64
-        nominalQuota: '15'
+        nominalQuota: '30'
       - name: linux-fast-amd64
         nominalQuota: '5'
       - name: linux-g6xlarge-amd64

--- a/components/multi-platform-controller/production-downstream/stone-prod-p02/host-config.yaml
+++ b/components/multi-platform-controller/production-downstream/stone-prod-p02/host-config.yaml
@@ -195,7 +195,7 @@ data:
   dynamic.linux-amd64.aws-secret: aws-account
   dynamic.linux-amd64.ssh-secret: aws-ssh-key
   dynamic.linux-amd64.security-group-id: sg-0903aedd465be979e
-  dynamic.linux-amd64.max-instances: "30"
+  dynamic.linux-amd64.max-instances: "15"
   dynamic.linux-amd64.subnet-id: subnet-02c476f8d2a4ae05e
   dynamic.linux-amd64.allocation-timeout: "1200"
 
@@ -265,7 +265,7 @@ data:
   dynamic.linux-extra-fast-amd64.ssh-secret: aws-ssh-key
   dynamic.linux-extra-fast-amd64.security-group-id: sg-0903aedd465be979e
   dynamic.linux-extra-fast-amd64.subnet-id: subnet-02c476f8d2a4ae05e
-  dynamic.linux-extra-fast-amd64.max-instances: "15"
+  dynamic.linux-extra-fast-amd64.max-instances: "30"
   dynamic.linux-extra-fast-amd64.disk: "200"
 
   # cpu:memory (1:2)


### PR DESCRIPTION
This commit will remove unused mulri-platform builder profiles from stone-prod-p02 host configuration based on Grafana dashboard analysis showing no usage in the last week. Grafana Queries can be found in the Jira Ticket Description.