### PR TITLE
removing stage api metric

### DIFF
--- a/components/monitoring/prometheus/staging/base/monitoringstack/endpoints-params.yaml
+++ b/components/monitoring/prometheus/staging/base/monitoringstack/endpoints-params.yaml
@@ -205,5 +205,4 @@
     - '{__name__="process_resident_memory_bytes", job="apiserver"}'
     - '{__name__="write:apiserver_request_total:rate5m"}'
     - '{__name__="read:apiserver_request_total:rate5m"}'
-    - '{__name__="resource:apiserver_longrunning_requests:sum"}'
     - '{__name__="cluster:apiserver_tls_handshake_errors_total:rate5m"}'


### PR DESCRIPTION
Testing metrics in stage exposed a metric that produces cardinality and stage has not the same timeseries limit as production.