### PR TITLE
removing apiserver stage metric

### DIFF
--- a/components/monitoring/prometheus/staging/base/monitoringstack/endpoints-params.yaml
+++ b/components/monitoring/prometheus/staging/base/monitoringstack/endpoints-params.yaml
@@ -203,6 +203,4 @@
     - '{__name__="container_network_receive_bytes_total", namespace=~"openshift-etcd|openshift-kube-apiserver|build-service|image-controller|integration-service|konflux-ui|product-kubearchive|openshift-kueue-operator|tekton-kueue|kueue-external-admission|mintmaker|multi-platform-controller|namespace-lister|openshift-pipelines|tekton-results|project-controller|smee|smee-client"}'
     - '{__name__="container_network_transmit_bytes_total", namespace=~"openshift-etcd|openshift-kube-apiserver|build-service|image-controller|integration-service|konflux-ui|product-kubearchive|openshift-kueue-operator|tekton-kueue|kueue-external-admission|mintmaker|multi-platform-controller|namespace-lister|openshift-pipelines|tekton-results|project-controller|smee|smee-client"}'
     - '{__name__="process_resident_memory_bytes", job="apiserver"}'
-    - '{__name__="write:apiserver_request_total:rate5m"}'
-    - '{__name__="read:apiserver_request_total:rate5m"}'
     - '{__name__="cluster:apiserver_tls_handshake_errors_total:rate5m"}'


### PR DESCRIPTION
Testing metrics in stage exposed a metric that produces cardinality and stage has not the same timeseries limit as production.