### PR TITLE
Refactor nginx config in prod

### DIFF
--- a/components/konflux-ui/production/base/proxy/auth.conf
+++ b/components/konflux-ui/production/base/proxy/auth.conf
@@ -1,0 +1,5 @@
+# Auth configuration with impersonation enabled
+auth_request_set $user  $upstream_http_x_auth_request_email;
+proxy_set_header Impersonate-User $user;
+proxy_set_header Impersonate-Group system:authenticated;
+proxy_set_header Authorization "Bearer __BEARER_TOKEN__";

--- a/components/konflux-ui/production/base/proxy/kubearchive.conf
+++ b/components/konflux-ui/production/base/proxy/kubearchive.conf
@@ -1,0 +1,7 @@
+location /api/k8s/plugins/kubearchive/ {
+    auth_request /oauth2/auth;
+    rewrite /api/k8s/plugins/kubearchive/(.+) /$1 break;
+    proxy_read_timeout 30m;
+    proxy_pass https://kubearchive-api-server.product-kubearchive.svc.cluster.local:8081;
+    include /mnt/nginx-generated-config/auth.conf;
+}

--- a/components/konflux-ui/production/base/proxy/kustomization.yaml
+++ b/components/konflux-ui/production/base/proxy/kustomization.yaml
@@ -7,3 +7,11 @@ configMapGenerator:
   - name: proxy
     files:
       - nginx.conf
+  - name: proxy-nginx-templates
+    files:
+      - auth.conf
+  - name: proxy-nginx-static
+    files:
+      - tekton-results.conf
+      - tekton-results-workspaces.conf
+      - kubearchive.conf

--- a/components/konflux-ui/production/base/proxy/nginx.conf
+++ b/components/konflux-ui/production/base/proxy/nginx.conf
@@ -139,24 +139,7 @@ http {
             include /mnt/nginx-generated-config/auth.conf;
         }
 
-        # Deprecated
-        location /api/k8s/plugins/tekton-results/workspaces/ {
-            auth_request /oauth2/auth;
 
-            rewrite /api/k8s/plugins/tekton-results/workspaces/.+?/(.+) /$1 break;
-            proxy_read_timeout 30m;
-            include /mnt/nginx-generated-config/tekton-results.conf;
-            include /mnt/nginx-generated-config/auth.conf;
-        }
-
-        location /api/k8s/plugins/tekton-results/ {
-            auth_request /oauth2/auth;
-
-            rewrite /api/k8s/plugins/tekton-results/(.+) /$1 break;
-            proxy_read_timeout 30m;
-            include /mnt/nginx-generated-config/tekton-results.conf;
-            include /mnt/nginx-generated-config/auth.conf;
-        }
 
         # GET requests to /api/k8s/api/v1/namespaces and /api/k8s/api/v1/namespaces/
         # are handled from the namespace-lister.
@@ -200,6 +183,5 @@ http {
         }
 
         include /mnt/nginx-additional-location-configs/*.conf;
-        include /mnt/nginx-generated-config/kubearchive.conf;
     }
 }

--- a/components/konflux-ui/production/base/proxy/proxy.yaml
+++ b/components/konflux-ui/production/base/proxy/proxy.yaml
@@ -54,48 +54,23 @@ spec:
             memory: 64Mi
       - name: generate-nginx-configs
         image: registry.access.redhat.com/ubi9/ubi@sha256:66233eebd72bb5baa25190d4f55e1dc3fff3a9b77186c1f91a0abdb274452072
-        envFrom:
-          - configMapRef:
-              name: proxy-init-config
         command:
           - sh
           - -c
           - |
             set -e
 
-            auth_conf=/mnt/nginx-generated-config/auth.conf
-            
-            if [[ "$IMPERSONATE" == "true" ]]; then
-              token=$(cat /mnt/api-token/token)
-              echo 'auth_request_set $user  $upstream_http_x_auth_request_email;' > "$auth_conf"
-              echo 'proxy_set_header Impersonate-User $user;' >> "$auth_conf"
-              echo 'proxy_set_header Impersonate-Group system:authenticated;' >> "$auth_conf"
-              echo "proxy_set_header Authorization \"Bearer $token\";" >> "$auth_conf"
-            else
-              echo "# impersonation was disabled by config" > "$auth_conf"
-            fi
+            # Generate auth.conf with bearer token replacement
+            token=$(cat /mnt/api-token/token)
+            sed "s/__BEARER_TOKEN__/$token/g" /mnt/nginx-templates/auth.conf > /mnt/nginx-generated-config/auth.conf
 
-            chmod 640 "$auth_conf"
-
-            echo \
-              "proxy_pass ${TEKTON_RESULTS_URL:?tekton results url must be provided};" \
-              > /mnt/nginx-generated-config/tekton-results.conf
-
-            if [[ "$KUBEARCHIVE_URL" != "" ]]; then
-              echo "location /api/k8s/plugins/kubearchive/ {" > /mnt/nginx-generated-config/kubearchive.conf
-              echo "auth_request /oauth2/auth;" >> /mnt/nginx-generated-config/kubearchive.conf
-              echo "rewrite /api/k8s/plugins/kubearchive/(.+) /\$1 break;" >> /mnt/nginx-generated-config/kubearchive.conf
-              echo "proxy_read_timeout 30m;" >> /mnt/nginx-generated-config/kubearchive.conf
-              echo "proxy_pass ${KUBEARCHIVE_URL};" >> /mnt/nginx-generated-config/kubearchive.conf
-              echo "include /mnt/nginx-generated-config/auth.conf;" >> /mnt/nginx-generated-config/kubearchive.conf
-              echo "}" >> /mnt/nginx-generated-config/kubearchive.conf
-            else
-              echo "# KubeArchive disabled by config" > /mnt/nginx-generated-config/kubearchive.conf
-            fi
+            chmod 640 /mnt/nginx-generated-config/auth.conf
 
         volumeMounts:
         - name: nginx-generated-config
           mountPath: /mnt/nginx-generated-config
+        - name: nginx-templates
+          mountPath: /mnt/nginx-templates
         - name: api-token
           mountPath: /mnt/api-token
         securityContext:
@@ -167,6 +142,8 @@ spec:
             mountPath: /mnt
           - name: nginx-generated-config
             mountPath: /mnt/nginx-generated-config
+          - name: nginx-static
+            mountPath: /mnt/nginx-additional-location-configs
           - name: static-content
             mountPath: /opt/app-root/src/static-content
         securityContext:
@@ -228,6 +205,14 @@ spec:
               - key: nginx.conf
                 path: nginx.conf 
           name: proxy
+        - configMap:
+            defaultMode: 420
+            name: proxy-nginx-templates
+          name: nginx-templates
+        - configMap:
+            defaultMode: 420
+            name: proxy-nginx-static
+          name: nginx-static
         - name: logs
           emptyDir: {}
         - name: nginx-tmp

--- a/components/konflux-ui/production/base/proxy/tekton-results-workspaces.conf
+++ b/components/konflux-ui/production/base/proxy/tekton-results-workspaces.conf
@@ -1,0 +1,9 @@
+# Deprecated
+location /api/k8s/plugins/tekton-results/workspaces/ {
+    auth_request /oauth2/auth;
+
+    rewrite /api/k8s/plugins/tekton-results/workspaces/.+?/(.+) /$1 break;
+    proxy_read_timeout 30m;
+    proxy_pass https://tekton-results-api-service.tekton-results.svc.cluster.local:8080;
+    include /mnt/nginx-generated-config/auth.conf;
+}

--- a/components/konflux-ui/production/base/proxy/tekton-results.conf
+++ b/components/konflux-ui/production/base/proxy/tekton-results.conf
@@ -1,0 +1,8 @@
+location /api/k8s/plugins/tekton-results/ {
+    auth_request /oauth2/auth;
+
+    rewrite /api/k8s/plugins/tekton-results/(.+) /$1 break;
+    proxy_read_timeout 30m;
+    proxy_pass https://tekton-results-api-service.tekton-results.svc.cluster.local:8080;
+    include /mnt/nginx-generated-config/auth.conf;
+}

--- a/components/konflux-ui/production/kflux-ocp-p01/kustomization.yaml
+++ b/components/konflux-ui/production/kflux-ocp-p01/kustomization.yaml
@@ -9,11 +9,6 @@ configMapGenerator:
   - name: dex
     files:
       - dex-config.yaml
-  - name: proxy-init-config
-    literals:
-      - IMPERSONATE=true
-      - TEKTON_RESULTS_URL=https://tekton-results-api-service.tekton-results.svc.cluster.local:8080
-      - KUBEARCHIVE_URL=https://kubearchive-api-server.product-kubearchive.svc.cluster.local:8081
 
 patches:
   - path: add-service-certs-patch.yaml

--- a/components/konflux-ui/production/kflux-osp-p01/kubearchive.conf
+++ b/components/konflux-ui/production/kflux-osp-p01/kubearchive.conf
@@ -1,0 +1,1 @@
+# KubeArchive disabled by config

--- a/components/konflux-ui/production/kflux-osp-p01/kustomization.yaml
+++ b/components/konflux-ui/production/kflux-osp-p01/kustomization.yaml
@@ -8,10 +8,10 @@ configMapGenerator:
   - name: dex
     files:
       - dex-config.yaml
-  - name: proxy-init-config
-    literals:
-      - IMPERSONATE=true
-      - TEKTON_RESULTS_URL=https://tekton-results-api-service.tekton-results.svc.cluster.local:8080
+  - name: proxy-nginx-static
+    files:
+      - kubearchive.conf
+    behavior: merge
 
 patches:
   - path: add-service-certs-patch.yaml

--- a/components/konflux-ui/production/kflux-prd-rh02/kubearchive.conf
+++ b/components/konflux-ui/production/kflux-prd-rh02/kubearchive.conf
@@ -1,0 +1,1 @@
+# KubeArchive disabled by config

--- a/components/konflux-ui/production/kflux-prd-rh02/kustomization.yaml
+++ b/components/konflux-ui/production/kflux-prd-rh02/kustomization.yaml
@@ -9,10 +9,10 @@ configMapGenerator:
   - name: dex
     files:
       - dex-config.yaml
-  - name: proxy-init-config
-    literals:
-      - IMPERSONATE=true
-      - TEKTON_RESULTS_URL=https://tekton-results-api-service.tekton-results.svc.cluster.local:8080
+  - name: proxy-nginx-static
+    files:
+      - kubearchive.conf
+    behavior: merge
 
 patches:
   - path: add-service-certs-patch.yaml

--- a/components/konflux-ui/production/kflux-prd-rh03/kustomization.yaml
+++ b/components/konflux-ui/production/kflux-prd-rh03/kustomization.yaml
@@ -8,11 +8,6 @@ configMapGenerator:
   - name: dex
     files:
       - dex-config.yaml
-  - name: proxy-init-config
-    literals:
-      - IMPERSONATE=true
-      - TEKTON_RESULTS_URL=https://tekton-results-api-service.tekton-results.svc.cluster.local:8080
-      - KUBEARCHIVE_URL=https://kubearchive-api-server.product-kubearchive.svc.cluster.local:8081
 
 patches:
   - path: add-service-certs-patch.yaml

--- a/components/konflux-ui/production/kflux-rhel-p01/kustomization.yaml
+++ b/components/konflux-ui/production/kflux-rhel-p01/kustomization.yaml
@@ -8,11 +8,6 @@ configMapGenerator:
   - name: dex
     files:
       - dex-config.yaml
-  - name: proxy-init-config
-    literals:
-      - IMPERSONATE=true
-      - TEKTON_RESULTS_URL=https://tekton-results-api-service.tekton-results.svc.cluster.local:8080
-      - KUBEARCHIVE_URL=https://kubearchive-api-server.product-kubearchive.svc.cluster.local:8081
 
 patches:
   - path: add-service-certs-patch.yaml

--- a/components/konflux-ui/production/stone-prd-rh01/kubearchive.conf
+++ b/components/konflux-ui/production/stone-prd-rh01/kubearchive.conf
@@ -1,0 +1,1 @@
+# KubeArchive disabled by config

--- a/components/konflux-ui/production/stone-prd-rh01/kustomization.yaml
+++ b/components/konflux-ui/production/stone-prd-rh01/kustomization.yaml
@@ -9,10 +9,10 @@ configMapGenerator:
   - name: dex
     files:
       - dex-config.yaml
-  - name: proxy-init-config
-    literals:
-      - IMPERSONATE=true
-      - TEKTON_RESULTS_URL=https://tekton-results-api-service.tekton-results.svc.cluster.local:8080
+  - name: proxy-nginx-static
+    files:
+      - kubearchive.conf
+    behavior: merge
 
 patches:
   - path: add-service-certs-patch.yaml

--- a/components/konflux-ui/production/stone-prod-p01/kubearchive.conf
+++ b/components/konflux-ui/production/stone-prod-p01/kubearchive.conf
@@ -1,0 +1,1 @@
+# KubeArchive disabled by config

--- a/components/konflux-ui/production/stone-prod-p01/kustomization.yaml
+++ b/components/konflux-ui/production/stone-prod-p01/kustomization.yaml
@@ -9,10 +9,10 @@ configMapGenerator:
   - name: dex
     files:
       - dex-config.yaml
-  - name: proxy-init-config
-    literals:
-      - IMPERSONATE=true
-      - TEKTON_RESULTS_URL=https://tekton-results-api-service.tekton-results.svc.cluster.local:8080
+  - name: proxy-nginx-static
+    files:
+      - kubearchive.conf
+    behavior: merge
 
 patches:
   - path: add-service-certs-patch.yaml

--- a/components/konflux-ui/production/stone-prod-p02/kustomization.yaml
+++ b/components/konflux-ui/production/stone-prod-p02/kustomization.yaml
@@ -9,11 +9,6 @@ configMapGenerator:
   - name: dex
     files:
       - dex-config.yaml
-  - name: proxy-init-config
-    literals:
-      - IMPERSONATE=true
-      - TEKTON_RESULTS_URL=https://tekton-results-api-service.tekton-results.svc.cluster.local:8080
-      - KUBEARCHIVE_URL=https://kubearchive-api-server.product-kubearchive.svc.cluster.local:8081
 
 patches:
   - path: add-service-certs-patch.yaml


### PR DESCRIPTION
After applying the changes in https://github.com/redhat-appstudio/infra-deployments/pull/7417 the nginx pod failed to start with the following error:

```
nginx: [emerg] open() "/mnt/nginx-generated-config/tekton-results.conf" failed (2: No such file or directory) in /mnt/nginx-additional-location-configs/tekton-results-workspaces.conf:7
```

This refactor was then reverted in https://github.com/redhat-appstudio/infra-deployments/pull/7706

In this PR I am reapplying the initial refactor with the needed fix to prevent the error.
Note that the 7th line in `components/konflux-ui/production/base/proxy/tekton-results-workspaces.conf` now shows 

`proxy_pass https://tekton-results-api-service.tekton-results.svc.cluster.local:8080;`

instead of 

`include /mnt/nginx-generated-config/tekton-results.conf;`