### PR TITLE
feat(/SPRE-1819) Latency metric api server

### DIFF
--- a/components/monitoring/prometheus/production/base/monitoringstack/endpoints-params.yaml
+++ b/components/monitoring/prometheus/production/base/monitoringstack/endpoints-params.yaml
@@ -206,3 +206,4 @@
     - '{__name__="write:apiserver_request_total:rate5m"}'
     - '{__name__="read:apiserver_request_total:rate5m"}'
     - '{__name__="cluster:apiserver_tls_handshake_errors_total:rate5m"}'
+    - '{__name__="verb:apiserver_request_duration_seconds_bucket:rate5m"}'

--- a/components/monitoring/prometheus/staging/base/monitoringstack/endpoints-params.yaml
+++ b/components/monitoring/prometheus/staging/base/monitoringstack/endpoints-params.yaml
@@ -206,3 +206,4 @@
     - '{__name__="write:apiserver_request_total:rate5m"}'
     - '{__name__="read:apiserver_request_total:rate5m"}'
     - '{__name__="cluster:apiserver_tls_handshake_errors_total:rate5m"}'
+    - '{__name__="verb:apiserver_request_duration_seconds_bucket:rate5m"}'


### PR DESCRIPTION
Based on the actual recording rules created on cluster-based grafana instances, we are adding a useful recording rule to measure latency (P95,p99, verb latency, etc) which is needed in order to complete the dashboard to monitor API Server performance.