### PR TITLE
Set memory request and limits to same values for ESO

### DIFF
--- a/components/external-secrets-operator/base/operator-config.yaml
+++ b/components/external-secrets-operator/base/operator-config.yaml
@@ -13,7 +13,7 @@ spec:
   resources:
    requests:
      cpu: 100m
-     memory: 128Mi
+     memory: 512Mi
    limits:
      memory: 512Mi
   certController:
@@ -22,11 +22,11 @@ spec:
         cpu: 100m
         memory: 128Mi
       limits:
-        memory: 512Mi
+        memory: 128Mi
   webhook:
     resources:
       requests:
         cpu: 100m
         memory: 128Mi
       limits:
-        memory: 512Mi
+        memory: 128Mi


### PR DESCRIPTION
The main pod is getting OOMkilled due to it's usage above requests even if below limit. Increase the request to 512Mi to make this guaranteed allocation. Also reduce limit of other 2 pods to match their request.

Those number were tuned based on production rh01 and p02 where we have the most load.

[KONFLUX-9158](https://issues.redhat.com//browse/KONFLUX-9158)