### PR TITLE
rhel: remove member-operator subscription

### DIFF
--- a/components/sandbox/toolchain-member-operator/production/kflux-rhel-p01/kustomization.yaml
+++ b/components/sandbox/toolchain-member-operator/production/kflux-rhel-p01/kustomization.yaml
@@ -2,3 +2,11 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - ../base
+patches:
+- patch: |
+    $patch: delete
+    apiVersion: operators.coreos.com/v1alpha1
+    kind: Subscription
+    metadata:
+      name: dev-sandbox-member
+      namespace: toolchain-member-operator


### PR DESCRIPTION
Same as #7726, but for the RHEL cluster.

Part of [KFLUXINFRA-2121](https://issues.redhat.com/browse/KFLUXINFRA-2121).