### PR TITLE
rhel: remove all member-operator components

### DIFF
--- a/components/sandbox/toolchain-member-operator/production/kflux-rhel-p01/kustomization.yaml
+++ b/components/sandbox/toolchain-member-operator/production/kflux-rhel-p01/kustomization.yaml
@@ -1,12 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- ../base
-patches:
-- patch: |
-    $patch: delete
-    apiVersion: operators.coreos.com/v1alpha1
-    kind: Subscription
-    metadata:
-      name: dev-sandbox-member
-      namespace: toolchain-member-operator
+- ns.yaml

--- a/components/sandbox/toolchain-member-operator/production/kflux-rhel-p01/ns.yaml
+++ b/components/sandbox/toolchain-member-operator/production/kflux-rhel-p01/ns.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: toolchain-member-operator


### PR DESCRIPTION
The next step to removing kubesaw from a cluster after the member-operator deployment has deleted is to remove all other resources managed by the sandbox component.  We can make this change for the rhel cluster.