### PR TITLE
rh02: remove member components

### DIFF
--- a/components/sandbox/toolchain-member-operator/production/kflux-prd-rh02/kustomization.yaml
+++ b/components/sandbox/toolchain-member-operator/production/kflux-prd-rh02/kustomization.yaml
@@ -1,12 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- ../base
-patches:
-- patch: |
-    $patch: delete
-    apiVersion: operators.coreos.com/v1alpha1
-    kind: Subscription
-    metadata:
-      name: dev-sandbox-member
-      namespace: toolchain-member-operator
+- ns.yaml

--- a/components/sandbox/toolchain-member-operator/production/kflux-prd-rh02/ns.yaml
+++ b/components/sandbox/toolchain-member-operator/production/kflux-prd-rh02/ns.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: toolchain-member-operator


### PR DESCRIPTION
Once we've removed the member-operator deployments, we can remove the rest of the resources managed by the member-operator component in argo except for the namespace.