### PR TITLE
Disable member-operator on ocp-p01

### DIFF
--- a/components/sandbox/toolchain-member-operator/production/kflux-ocp-p01/kustomization.yaml
+++ b/components/sandbox/toolchain-member-operator/production/kflux-ocp-p01/kustomization.yaml
@@ -2,3 +2,11 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - ../base
+patches:
+- patch: |
+    $patch: delete
+    apiVersion: operators.coreos.com/v1alpha1
+    kind: Subscription
+    metadata:
+      name: dev-sandbox-member
+      namespace: toolchain-member-operator


### PR DESCRIPTION
To safely remove kubesaw, we need to first remove its subscription from this repository. Since the applicationset is not configured to automatically prune resources, the subscription will remain until we're ready to fully delete it.