### PR TITLE
Eventing: add klog verbose flag on the image

### DIFF
--- a/components/knative-eventing/base/kustomization.yaml
+++ b/components/knative-eventing/base/kustomization.yaml
@@ -17,6 +17,9 @@ patches:
         spec:
           containers:
             - name: eventing-controller
+              env:
+                - name: APISERVER_RA_IMAGE
+                  value: quay.io/kubearchive/eventing-adapter:v1.16.7-verbose
               resources:
                 requests:
                   cpu: 200m


### PR DESCRIPTION
Image was modified from v1.16.7 to increase the verbose flag for `klog`, which is used by the k8s golang library. With this will be able to see more logs related to the watchers.