### PR TITLE
Grant konflux-vanguard group viewer permissions

### DIFF
--- a/components/authentication/base/everyone-can-view-patch.yaml
+++ b/components/authentication/base/everyone-can-view-patch.yaml
@@ -59,3 +59,6 @@
     - kind: Group
       apiGroup: rbac.authorization.k8s.io
       name: 'konflux-support'
+    - kind: Group
+      apiGroup: rbac.authorization.k8s.io
+      name: 'konflux-vanguard'


### PR DESCRIPTION
This wasn't an issue until now because all members were included in other groups.