### PR TITLE
feat(KFLUXUI-635): expose konflux-ui metrics RHOBS

### DIFF
--- a/components/monitoring/prometheus/production/base/monitoringstack/endpoints-params.yaml
+++ b/components/monitoring/prometheus/production/base/monitoringstack/endpoints-params.yaml
@@ -80,6 +80,13 @@
     - '{__name__="kube_endpoint_address", namespace="konflux-ui"}'
     - '{__name__="kube_pod_container_status_restarts_total", namespace="konflux-ui"}'
 
+    - '{__name__="kube_pod_container_info", namespace="konflux-ui"}'
+    - '{__name__="kube_pod_container_status_ready", namespace="konflux-ui"}'
+    - '{__name__="kube_pod_container_status_running", namespace="konflux-ui"}'
+    - '{__name__="kube_pod_init_container_info", namespace="konflux-ui"}'
+    - '{__name__="kube_pod_init_container_status_ready", namespace="konflux-ui"}'
+    - '{__name__="kube_pod_init_container_status_running", namespace="konflux-ui"}'
+
     # Namespace (expression):  "mintmaker"
     - '{__name__="kube_deployment_status_replicas_ready", namespace="mintmaker"}'
     - '{__name__="kube_deployment_status_replicas_available", namespace="mintmaker"}'

--- a/components/monitoring/prometheus/staging/base/monitoringstack/endpoints-params.yaml
+++ b/components/monitoring/prometheus/staging/base/monitoringstack/endpoints-params.yaml
@@ -80,6 +80,13 @@
     - '{__name__="kube_endpoint_address", namespace="konflux-ui"}'
     - '{__name__="kube_pod_container_status_restarts_total", namespace="konflux-ui"}'
 
+    - '{__name__="kube_pod_container_info", namespace="konflux-ui"}'
+    - '{__name__="kube_pod_container_status_ready", namespace="konflux-ui"}'
+    - '{__name__="kube_pod_container_status_running", namespace="konflux-ui"}'
+    - '{__name__="kube_pod_init_container_info", namespace="konflux-ui"}'
+    - '{__name__="kube_pod_init_container_status_ready", namespace="konflux-ui"}'
+    - '{__name__="kube_pod_init_container_status_running", namespace="konflux-ui"}'
+
     # Namespace (expression):  "mintmaker"
     - '{__name__="kube_deployment_status_replicas_ready", namespace="mintmaker"}'
     - '{__name__="kube_deployment_status_replicas_available", namespace="mintmaker"}'


### PR DESCRIPTION
Expose container metrics for Konflux UI in order to give visibility for pod/container level

Jira [KFLUXUI-635](https://issues.redhat.com//browse/KFLUXUI-635)

[KFLUXUI-635]: https://redhat.atlassian.net/browse/KFLUXUI-635?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ