### PR TITLE
Adding 'linux-test-arm64' platform to stone-stg-rh01 

### DIFF
--- a/components/kueue/staging/stone-stage-p01/queue-config/cluster-queue.yaml
+++ b/components/kueue/staging/stone-stage-p01/queue-config/cluster-queue.yaml
@@ -99,7 +99,6 @@ spec:
     - linux-root-amd64
     - linux-root-arm64
     - linux-s390x
-    - linux-test-arm64
     - linux-x86-64
     - local
     - localhost
@@ -126,8 +125,6 @@ spec:
         nominalQuota: '100'
       - name: linux-s390x
         nominalQuota: '2'
-      - name: linux-test-arm64
-        nominalQuota: '1'
       - name: linux-x86-64
         nominalQuota: '1000'
       - name: local

--- a/components/kueue/staging/stone-stg-rh01/queue-config/cluster-queue.yaml
+++ b/components/kueue/staging/stone-stg-rh01/queue-config/cluster-queue.yaml
@@ -100,6 +100,7 @@ spec:
     - linux-root-amd64
     - linux-root-arm64
     - linux-s390x
+    - linux-test-arm64
     - linux-x86-64
     - local
     - localhost
@@ -128,6 +129,8 @@ spec:
         nominalQuota: '10'
       - name: linux-s390x
         nominalQuota: '2'
+      - name: linux-test-arm64
+        nominalQuota: '1'
       - name: linux-x86-64
         nominalQuota: '1000'
       - name: local

--- a/components/multi-platform-controller/staging-downstream/host-config.yaml
+++ b/components/multi-platform-controller/staging-downstream/host-config.yaml
@@ -14,7 +14,6 @@ data:
     "
   dynamic-platforms: "\
     linux/arm64,\
-    linux-test/arm64,\
     linux-mlarge/amd64,\
     linux-mlarge/arm64,\
     linux-mxlarge/amd64,\
@@ -63,19 +62,6 @@ data:
   dynamic.linux-arm64.max-instances: "100"
   dynamic.linux-arm64.subnet-id: subnet-07597d1edafa2b9d3
   dynamic.linux-arm64.allocation-timeout: "1200"
-
-  dynamic.linux-test-arm64.type: aws
-  dynamic.linux-test-arm64.region: us-east-1
-  dynamic.linux-test-arm64.ami: ami-03d6a5256a46c9feb
-  dynamic.linux-test-arm64.instance-type: m6g.large
-  dynamic.linux-test-arm64.instance-tag: stage-arm64-test
-  dynamic.linux-test-arm64.key-name: konflux-stage-int-mab01
-  dynamic.linux-test-arm64.aws-secret: aws-account
-  dynamic.linux-test-arm64.ssh-secret: aws-ssh-key
-  dynamic.linux-test-arm64.security-group-id: sg-0482e8ccae008b240
-  dynamic.linux-test-arm64.max-instances: "1"
-  dynamic.linux-test-arm64.subnet-id: subnet-07597d1edafa2b9d3
-  dynamic.linux-test-arm64.allocation-timeout: "1200"
 
   dynamic.linux-mlarge-arm64.type: aws
   dynamic.linux-mlarge-arm64.region: us-east-1

--- a/components/multi-platform-controller/staging/host-config.yaml
+++ b/components/multi-platform-controller/staging/host-config.yaml
@@ -14,6 +14,7 @@ data:
     "
   dynamic-platforms: "\
     linux/arm64,\
+    linux-test/arm64,\
     linux-mlarge/amd64,\
     linux-mlarge/arm64,\
     linux-mxlarge/amd64,\
@@ -61,6 +62,18 @@ data:
   dynamic.linux-arm64.security-group-id: sg-05bc8dd0b52158567
   dynamic.linux-arm64.max-instances: "160"
   dynamic.linux-arm64.subnet-id: subnet-030738beb81d3863a
+
+  dynamic.linux-test-arm64.type: aws
+  dynamic.linux-test-arm64.region: us-east-1
+  dynamic.linux-test-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-test-arm64.instance-type: m6g.large
+  dynamic.linux-test-arm64.instance-tag: stage-arm64-test
+  dynamic.linux-test-arm64.key-name: konflux-stage-ext-mab01
+  dynamic.linux-test-arm64.aws-secret: aws-account
+  dynamic.linux-test-arm64.ssh-secret: aws-ssh-key
+  dynamic.linux-test-arm64.security-group-id: sg-05bc8dd0b52158567
+  dynamic.linux-test-arm64.max-instances: "1"
+  dynamic.linux-test-arm64.subnet-id: subnet-030738beb81d3863a
 
   dynamic.linux-mlarge-arm64.type: aws
   dynamic.linux-mlarge-arm64.region: us-east-1


### PR DESCRIPTION
## What
- Removed `linux-test-arm64` from downstream-staging (stone-stage-p01)
- Added `linux-test-arm64` to staging (stone-stg-rh01) and set `max-instances` to 1.
## Why
To test `multi_platform_controller_waiting_task` metric, I need to create a scenario of a taskrun that waiting for platform. I need it to be on `stone-stg-rh01` and not on `stone-stage-p01` because I need multiple repositories and it more simple and quick to achieve that using Github.  