### PR TITLE
KubeArchive: make ApiServerSource monitor all the namespaces

### DIFF
--- a/components/kubearchive/development/kubearchive.yaml
+++ b/components/kubearchive/development/kubearchive.yaml
@@ -1,0 +1,1899 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    app.kubernetes.io/component: namespace
+    app.kubernetes.io/name: kubearchive
+    app.kubernetes.io/part-of: kubearchive
+    app.kubernetes.io/version: watcher-problems-2e49be9
+  name: kubearchive
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: kubearchive/kubearchive-operator-certificate
+    controller-gen.kubebuilder.io/version: v0.14.0
+  name: clusterkubearchiveconfigs.kubearchive.org
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: webhook-service
+          namespace: kubearchive
+          path: /convert
+      conversionReviewVersions:
+        - v1
+  group: kubearchive.org
+  names:
+    kind: ClusterKubeArchiveConfig
+    listKind: ClusterKubeArchiveConfigList
+    plural: clusterkubearchiveconfigs
+    shortNames:
+      - ckac
+      - ckacs
+    singular: clusterkubearchiveconfig
+  scope: Cluster
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: ClusterKubeArchiveConfig is the Schema for the clusterkubearchiveconfigs API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: ClusterKubeArchiveConfigSpec defines the desired state of ClusterKubeArchiveConfig
+              properties:
+                resources:
+                  items:
+                    properties:
+                      archiveOnDelete:
+                        type: string
+                      archiveWhen:
+                        type: string
+                      deleteWhen:
+                        type: string
+                      selector:
+                        description: APIVersionKindSelector is an APIVersion Kind tuple with a LabelSelector.
+                        properties:
+                          apiVersion:
+                            description: APIVersion - the API version of the resource to watch.
+                            type: string
+                          kind:
+                            description: |-
+                              Kind of the resource to watch.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                            type: string
+                          selector:
+                            description: |-
+                              LabelSelector filters this source to objects to those resources pass the
+                              label selector.
+                              More info: http://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                items:
+                                  description: |-
+                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector applies to.
+                                      type: string
+                                    operator:
+                                      description: |-
+                                        operator represents a key's relationship to a set of values.
+                                        Valid operators are In, NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: |-
+                                        values is an array of string values. If the operator is In or NotIn,
+                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                        the values array must be empty. This array is replaced during a strategic
+                                        merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  required:
+                                    - key
+                                    - operator
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                type: object
+                            type: object
+                            x-kubernetes-map-type: atomic
+                        required:
+                          - apiVersion
+                          - kind
+                        type: object
+                    type: object
+                  type: array
+              required:
+                - resources
+              type: object
+            status:
+              description: ClusterKubeArchiveConfigStatus defines the observed state of ClusterKubeArchiveConfig
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: kubearchive/kubearchive-operator-certificate
+    controller-gen.kubebuilder.io/version: v0.14.0
+  name: clustervacuumconfigs.kubearchive.org
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: webhook-service
+          namespace: kubearchive
+          path: /convert
+      conversionReviewVersions:
+        - v1
+  group: kubearchive.org
+  names:
+    kind: ClusterVacuumConfig
+    listKind: ClusterVacuumConfigList
+    plural: clustervacuumconfigs
+    shortNames:
+      - cvc
+      - cvcs
+    singular: clustervacuumconfig
+  scope: Namespaced
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: ClusterVacuumConfig is the Schema for the clustervacuumconfigs API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: ClusterVacuumConfigSpec defines the desired state of ClusterVacuumConfig resource
+              properties:
+                namespaces:
+                  additionalProperties:
+                    properties:
+                      resources:
+                        items:
+                          description: APIVersionKind is an APIVersion and Kind tuple.
+                          properties:
+                            apiVersion:
+                              description: APIVersion - the API version of the resource to watch.
+                              type: string
+                            kind:
+                              description: |-
+                                Kind of the resource to watch.
+                                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                              type: string
+                          required:
+                            - apiVersion
+                            - kind
+                          type: object
+                        type: array
+                    type: object
+                  type: object
+              type: object
+            status:
+              description: ClusterVacuumConfigStatus defines the observed state of ClusterVacuumConfig resource
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: kubearchive/kubearchive-operator-certificate
+    controller-gen.kubebuilder.io/version: v0.14.0
+  name: kubearchiveconfigs.kubearchive.org
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: webhook-service
+          namespace: kubearchive
+          path: /convert
+      conversionReviewVersions:
+        - v1
+  group: kubearchive.org
+  names:
+    kind: KubeArchiveConfig
+    listKind: KubeArchiveConfigList
+    plural: kubearchiveconfigs
+    shortNames:
+      - kac
+      - kacs
+    singular: kubearchiveconfig
+  scope: Namespaced
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: KubeArchiveConfig is the Schema for the kubearchiveconfigs API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: KubeArchiveConfigSpec defines the desired state of KubeArchiveConfig
+              properties:
+                resources:
+                  items:
+                    properties:
+                      archiveOnDelete:
+                        type: string
+                      archiveWhen:
+                        type: string
+                      deleteWhen:
+                        type: string
+                      selector:
+                        description: APIVersionKindSelector is an APIVersion Kind tuple with a LabelSelector.
+                        properties:
+                          apiVersion:
+                            description: APIVersion - the API version of the resource to watch.
+                            type: string
+                          kind:
+                            description: |-
+                              Kind of the resource to watch.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                            type: string
+                          selector:
+                            description: |-
+                              LabelSelector filters this source to objects to those resources pass the
+                              label selector.
+                              More info: http://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                items:
+                                  description: |-
+                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector applies to.
+                                      type: string
+                                    operator:
+                                      description: |-
+                                        operator represents a key's relationship to a set of values.
+                                        Valid operators are In, NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: |-
+                                        values is an array of string values. If the operator is In or NotIn,
+                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                        the values array must be empty. This array is replaced during a strategic
+                                        merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  required:
+                                    - key
+                                    - operator
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                type: object
+                            type: object
+                            x-kubernetes-map-type: atomic
+                        required:
+                          - apiVersion
+                          - kind
+                        type: object
+                    type: object
+                  type: array
+              required:
+                - resources
+              type: object
+            status:
+              description: KubeArchiveConfigStatus defines the observed state of KubeArchiveConfig
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: kubearchive/kubearchive-operator-certificate
+    controller-gen.kubebuilder.io/version: v0.14.0
+  name: namespacevacuumconfigs.kubearchive.org
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: webhook-service
+          namespace: kubearchive
+          path: /convert
+      conversionReviewVersions:
+        - v1
+  group: kubearchive.org
+  names:
+    kind: NamespaceVacuumConfig
+    listKind: NamespaceVacuumConfigList
+    plural: namespacevacuumconfigs
+    shortNames:
+      - nvc
+      - nvcs
+    singular: namespacevacuumconfig
+  scope: Namespaced
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: NamespaceVacuumConfig is the Schema for the namespacevacuumconfigs API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: VacuumListSpec defines the desired state of VacuumList resource
+              properties:
+                resources:
+                  items:
+                    description: APIVersionKind is an APIVersion and Kind tuple.
+                    properties:
+                      apiVersion:
+                        description: APIVersion - the API version of the resource to watch.
+                        type: string
+                      kind:
+                        description: |-
+                          Kind of the resource to watch.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                        type: string
+                    required:
+                      - apiVersion
+                      - kind
+                    type: object
+                  type: array
+              type: object
+            status:
+              description: NamespaceVacuumConfigStatus defines the observed state of NamespaceVacuumConfig resource
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: kubearchive/kubearchive-operator-certificate
+    controller-gen.kubebuilder.io/version: v0.14.0
+  name: sinkfilters.kubearchive.org
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: webhook-service
+          namespace: kubearchive
+          path: /convert
+      conversionReviewVersions:
+        - v1
+  group: kubearchive.org
+  names:
+    kind: SinkFilter
+    listKind: SinkFilterList
+    plural: sinkfilters
+    shortNames:
+      - sf
+      - sfs
+    singular: sinkfilter
+  scope: Namespaced
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: SinkFilter is the Schema for the sinkfilters API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: SinkFilterSpec defines the desired state of SinkFilter resource
+              properties:
+                namespaces:
+                  additionalProperties:
+                    items:
+                      properties:
+                        archiveOnDelete:
+                          type: string
+                        archiveWhen:
+                          type: string
+                        deleteWhen:
+                          type: string
+                        selector:
+                          description: APIVersionKindSelector is an APIVersion Kind tuple with a LabelSelector.
+                          properties:
+                            apiVersion:
+                              description: APIVersion - the API version of the resource to watch.
+                              type: string
+                            kind:
+                              description: |-
+                                Kind of the resource to watch.
+                                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                              type: string
+                            selector:
+                              description: |-
+                                LabelSelector filters this source to objects to those resources pass the
+                                label selector.
+                                More info: http://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the selector applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: |-
+                                          values is an array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. This array is replaced during a strategic
+                                          merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                      - key
+                                      - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          required:
+                            - apiVersion
+                            - kind
+                          type: object
+                      type: object
+                    type: array
+                  type: object
+              required:
+                - namespaces
+              type: object
+            status:
+              description: SinkFilterStatus defines the observed state of SinkFilter resource
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/component: api-server
+    app.kubernetes.io/name: kubearchive-api-server
+    app.kubernetes.io/part-of: kubearchive
+    app.kubernetes.io/version: watcher-problems-2e49be9
+  name: kubearchive-api-server
+  namespace: kubearchive
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/component: operator
+    app.kubernetes.io/name: kubearchive-vacuum
+    app.kubernetes.io/part-of: kubearchive
+    app.kubernetes.io/version: watcher-problems-2e49be9
+  name: kubearchive-cluster-vacuum
+  namespace: kubearchive
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/component: operator
+    app.kubernetes.io/name: kubearchive-operator
+    app.kubernetes.io/part-of: kubearchive
+    app.kubernetes.io/version: watcher-problems-2e49be9
+  name: kubearchive-operator
+  namespace: kubearchive
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/component: sink
+    app.kubernetes.io/name: kubearchive-sink
+    app.kubernetes.io/part-of: kubearchive
+    app.kubernetes.io/version: watcher-problems-2e49be9
+  name: kubearchive-sink
+  namespace: kubearchive
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/component: operator
+    app.kubernetes.io/name: kubearchive-vacuum
+    app.kubernetes.io/part-of: kubearchive
+    app.kubernetes.io/version: watcher-problems-2e49be9
+  name: kubearchive-cluster-vacuum
+  namespace: kubearchive
+rules:
+  - apiGroups:
+      - eventing.knative.dev
+    resources:
+      - brokers
+    verbs:
+      - get
+      - list
+  - apiGroups:
+      - kubearchive.org
+    resources:
+      - sinkfilters
+      - clustervacuumconfigs
+    verbs:
+      - get
+      - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/component: operator
+    app.kubernetes.io/name: kubearchive-operator-leader-election
+    app.kubernetes.io/part-of: kubearchive
+    app.kubernetes.io/version: watcher-problems-2e49be9
+  name: kubearchive-operator-leader-election
+  namespace: kubearchive
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/component: sink
+    app.kubernetes.io/name: kubearchive-sink-watch
+    app.kubernetes.io/part-of: kubearchive
+    app.kubernetes.io/version: watcher-problems-2e49be9
+  name: kubearchive-sink-watch
+  namespace: kubearchive
+rules:
+  - apiGroups:
+      - kubearchive.org
+    resources:
+      - sinkfilters
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: operator
+    app.kubernetes.io/name: kubearchive-vacuum
+    app.kubernetes.io/part-of: kubearchive
+    app.kubernetes.io/version: watcher-problems-2e49be9
+  name: clusterkubearchiveconfig-read
+rules:
+  - apiGroups:
+      - kubearchive.org
+    resources:
+      - clusterkubearchiveconfigs
+    verbs:
+      - get
+      - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: api-server
+    app.kubernetes.io/name: kubearchive-api-server
+    app.kubernetes.io/part-of: kubearchive
+    app.kubernetes.io/version: watcher-problems-2e49be9
+  name: kubearchive-api-server
+rules:
+  - apiGroups:
+      - authorization.k8s.io
+      - authentication.k8s.io
+    resources:
+      - subjectaccessreviews
+      - tokenreviews
+    verbs:
+      - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: kubearchive-edit
+    app.kubernetes.io/part-of: kubearchive
+    app.kubernetes.io/version: watcher-problems-2e49be9
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+  name: kubearchive-edit
+rules:
+  - apiGroups:
+      - kubearchive.org
+    resources:
+      - '*'
+    verbs:
+      - create
+      - update
+      - patch
+      - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kubearchive-operator
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+    verbs:
+      - get
+      - list
+      - update
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - serviceaccounts
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - update
+      - watch
+  - apiGroups:
+      - kubearchive.org
+    resources:
+      - clusterkubearchiveconfigs
+      - clustervacuums
+      - namespacevacuums
+      - sinkfilters
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - kubearchive.org
+    resources:
+      - clusterkubearchiveconfigs/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - kubearchive.org
+    resources:
+      - clusterkubearchiveconfigs/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - kubearchive.org
+    resources:
+      - clustervacuums
+      - kubearchiveconfigs
+      - namespacevacuums
+      - sinkfilters
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - kubearchive.org
+    resources:
+      - kubearchiveconfigs/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - kubearchive.org
+    resources:
+      - kubearchiveconfigs/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - clusterrolebindings
+      - clusterroles
+      - rolebindings
+      - roles
+    verbs:
+      - bind
+      - create
+      - delete
+      - escalate
+      - get
+      - list
+      - update
+      - watch
+  - apiGroups:
+      - sources.knative.dev
+    resources:
+      - apiserversources
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - update
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: operator
+    app.kubernetes.io/name: kubearchive-operator-config-editor
+    app.kubernetes.io/part-of: kubearchive
+    app.kubernetes.io/version: watcher-problems-2e49be9
+  name: kubearchive-operator-config-editor
+rules:
+  - apiGroups:
+      - kubearchive.org
+    resources:
+      - kubearchiveconfigs
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - kubearchive.org
+    resources:
+      - kubearchiveconfigs/status
+    verbs:
+      - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: operator
+    app.kubernetes.io/name: kubearchive-operator-config-viewer
+    app.kubernetes.io/part-of: kubearchive
+    app.kubernetes.io/version: watcher-problems-2e49be9
+  name: kubearchive-operator-config-viewer
+rules:
+  - apiGroups:
+      - kubearchive.org
+    resources:
+      - kubearchiveconfigs
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - kubearchive.org
+    resources:
+      - kubearchiveconfigs/status
+    verbs:
+      - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: kubearchive-view
+    app.kubernetes.io/part-of: kubearchive
+    app.kubernetes.io/version: watcher-problems-2e49be9
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+  name: kubearchive-view
+rules:
+  - apiGroups:
+      - kubearchive.org
+    resources:
+      - '*'
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/component: operator
+    app.kubernetes.io/name: kubearchive-vacuum
+    app.kubernetes.io/part-of: kubearchive
+    app.kubernetes.io/version: watcher-problems-2e49be9
+  name: kubearchive-cluster-vacuum
+  namespace: kubearchive
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: kubearchive-cluster-vacuum
+subjects:
+  - kind: ServiceAccount
+    name: kubearchive-cluster-vacuum
+    namespace: kubearchive
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/component: operator
+    app.kubernetes.io/name: kubearchive-operator-leader-election
+    app.kubernetes.io/part-of: kubearchive
+    app.kubernetes.io/version: watcher-problems-2e49be9
+  name: kubearchive-operator-leader-election
+  namespace: kubearchive
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: kubearchive-operator-leader-election
+subjects:
+  - kind: ServiceAccount
+    name: kubearchive-operator
+    namespace: kubearchive
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/component: sink
+    app.kubernetes.io/name: kubearchive-sink-watch
+    app.kubernetes.io/part-of: kubearchive
+    app.kubernetes.io/version: watcher-problems-2e49be9
+  name: kubearchive-sink-watch
+  namespace: kubearchive
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: kubearchive-sink-watch
+subjects:
+  - kind: ServiceAccount
+    name: kubearchive-sink
+    namespace: kubearchive
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/component: operator
+    app.kubernetes.io/name: kubearchive-vacuum
+    app.kubernetes.io/part-of: kubearchive
+    app.kubernetes.io/version: watcher-problems-2e49be9
+  name: clusterkubearchiveconfig-read
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: clusterkubearchiveconfig-read
+subjects:
+  - kind: ServiceAccount
+    name: kubearchive-cluster-vacuum
+    namespace: kubearchive
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/component: apiserversource
+    app.kubernetes.io/name: kubearchive-a13e
+    app.kubernetes.io/part-of: kubearchive
+    app.kubernetes.io/version: watcher-problems-2e49be9
+  name: kubearchive-a13e
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kubearchive-a13e
+subjects:
+  - kind: ServiceAccount
+    name: kubearchive-a13e
+    namespace: kubearchive
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/component: api-server
+    app.kubernetes.io/name: kubearchive-api-server
+    app.kubernetes.io/part-of: kubearchive
+    app.kubernetes.io/version: watcher-problems-2e49be9
+  name: kubearchive-api-server
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kubearchive-api-server
+subjects:
+  - kind: ServiceAccount
+    name: kubearchive-api-server
+    namespace: kubearchive
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/component: operator
+    app.kubernetes.io/name: kubearchive-operator
+    app.kubernetes.io/part-of: kubearchive
+    app.kubernetes.io/version: watcher-problems-2e49be9
+  name: kubearchive-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kubearchive-operator
+subjects:
+  - kind: ServiceAccount
+    name: kubearchive-operator
+    namespace: kubearchive
+---
+apiVersion: v1
+data: null
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/component: logging
+    app.kubernetes.io/name: kubearchive-logging
+    app.kubernetes.io/part-of: kubearchive
+    app.kubernetes.io/version: watcher-problems-2e49be9
+  name: kubearchive-logging
+  namespace: kubearchive
+---
+apiVersion: v1
+data:
+  DATABASE_DB: a3ViZWFyY2hpdmU=
+  DATABASE_KIND: cG9zdGdyZXNxbA==
+  DATABASE_PASSWORD: RGF0YWJhczNQYXNzdzByZA==
+  DATABASE_PORT: NTQzMg==
+  DATABASE_URL: a3ViZWFyY2hpdmUtcncucG9zdGdyZXNxbC5zdmMuY2x1c3Rlci5sb2NhbA==
+  DATABASE_USER: a3ViZWFyY2hpdmU=
+kind: Secret
+metadata:
+  labels:
+    app.kubernetes.io/component: database
+    app.kubernetes.io/name: kubearchive-database-credentials
+    app.kubernetes.io/part-of: kubearchive
+    app.kubernetes.io/version: watcher-problems-2e49be9
+  name: kubearchive-database-credentials
+  namespace: kubearchive
+type: Opaque
+---
+apiVersion: v1
+data:
+  Authorization: QmFzaWMgWVdSdGFXNDZjR0Z6YzNkdmNtUT0=
+kind: Secret
+metadata:
+  labels:
+    app.kubernetes.io/component: logging
+    app.kubernetes.io/name: kubearchive-logging
+    app.kubernetes.io/part-of: kubearchive
+    app.kubernetes.io/version: watcher-problems-2e49be9
+  name: kubearchive-logging
+  namespace: kubearchive
+type: Opaque
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: api-server
+    app.kubernetes.io/name: kubearchive-api-server
+    app.kubernetes.io/part-of: kubearchive
+    app.kubernetes.io/version: watcher-problems-2e49be9
+  name: kubearchive-api-server
+  namespace: kubearchive
+spec:
+  ports:
+    - name: server
+      port: 8081
+      protocol: TCP
+      targetPort: 8081
+  selector:
+    app: kubearchive-api-server
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: operator
+    app.kubernetes.io/name: kubearchive-operator-webhooks
+    app.kubernetes.io/part-of: kubearchive
+    app.kubernetes.io/version: watcher-problems-2e49be9
+  name: kubearchive-operator-webhooks
+  namespace: kubearchive
+spec:
+  ports:
+    - name: webhook-server
+      port: 443
+      protocol: TCP
+      targetPort: 9443
+    - name: pprof-server
+      port: 8082
+      protocol: TCP
+      targetPort: 8082
+  selector:
+    control-plane: controller-manager
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: sink
+    app.kubernetes.io/name: kubearchive-sink
+    app.kubernetes.io/part-of: kubearchive
+    app.kubernetes.io/version: watcher-problems-2e49be9
+  name: kubearchive-sink
+  namespace: kubearchive
+spec:
+  ports:
+    - port: 80
+      protocol: TCP
+      targetPort: 8080
+  selector:
+    app: kubearchive-sink
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/component: api-server
+    app.kubernetes.io/name: kubearchive-api-server
+    app.kubernetes.io/part-of: kubearchive
+    app.kubernetes.io/version: watcher-problems-2e49be9
+  name: kubearchive-api-server
+  namespace: kubearchive
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kubearchive-api-server
+  template:
+    metadata:
+      labels:
+        app: kubearchive-api-server
+    spec:
+      containers:
+        - env:
+            - name: KUBEARCHIVE_ENABLE_PPROF
+              value: "true"
+            - name: LOG_LEVEL
+              value: INFO
+            - name: GIN_MODE
+              value: release
+            - name: KUBEARCHIVE_OTEL_MODE
+              value: disabled
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: ""
+            - name: KUBEARCHIVE_OTLP_SEND_LOGS
+              value: "false"
+            - name: OTEL_GO_X_DEPRECATED_RUNTIME_METRICS
+              value: "false"
+            - name: GOMEMLIMIT
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.memory
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.cpu
+            - name: CACHE_EXPIRATION_AUTHORIZED
+              value: 10m
+            - name: CACHE_EXPIRATION_UNAUTHORIZED
+              value: 1m
+            - name: KUBEARCHIVE_LOGGING_DIR
+              value: /data/logging
+            - name: AUTH_IMPERSONATE
+              value: "false"
+          envFrom:
+            - secretRef:
+                name: kubearchive-database-credentials
+          image: quay.io/kubearchive/api:watcher-problems-2e49be9@sha256:86d0c314ab3062950d38a6c7c44ed44894a20a304f5c328d19a2b430356d4dcb
+          livenessProbe:
+            httpGet:
+              path: /livez
+              port: 8081
+              scheme: HTTPS
+          name: kubearchive-api-server
+          ports:
+            - containerPort: 8081
+              name: server
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 8081
+              scheme: HTTPS
+          resources:
+            limits:
+              cpu: 700m
+              memory: 256Mi
+            requests:
+              cpu: 200m
+              memory: 230Mi
+          volumeMounts:
+            - mountPath: /etc/kubearchive/ssl/
+              name: tls-secret
+              readOnly: true
+            - mountPath: /data/logging
+              name: logging-secret
+      serviceAccountName: kubearchive-api-server
+      volumes:
+        - name: tls-secret
+          secret:
+            secretName: kubearchive-api-server-tls
+        - name: logging-secret
+          secret:
+            secretName: kubearchive-logging
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/component: operator
+    app.kubernetes.io/name: kubearchive-operator
+    app.kubernetes.io/part-of: kubearchive
+    app.kubernetes.io/version: watcher-problems-2e49be9
+  name: kubearchive-operator
+  namespace: kubearchive
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      control-plane: controller-manager
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: manager
+      labels:
+        control-plane: controller-manager
+    spec:
+      containers:
+        - args:
+            - --health-probe-bind-address=:8081
+            - --leader-elect
+          env:
+            - name: KUBEARCHIVE_ENABLE_PPROF
+              value: "true"
+            - name: LOG_LEVEL
+              value: INFO
+            - name: KUBEARCHIVE_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: KUBEARCHIVE_OTEL_MODE
+              value: disabled
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: ""
+            - name: KUBEARCHIVE_OTLP_SEND_LOGS
+              value: "false"
+            - name: OTEL_GO_X_DEPRECATED_RUNTIME_METRICS
+              value: "false"
+            - name: GOMEMLIMIT
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.memory
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.cpu
+          image: quay.io/kubearchive/operator:watcher-problems-2e49be9@sha256:79b50d83a41fa1628fbaa6f4328bc0b6b7b560c6d8c68be0baaada7eaa0a67bc
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8081
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          name: manager
+          ports:
+            - containerPort: 9443
+              name: webhook-server
+              protocol: TCP
+            - containerPort: 8082
+              name: pprof-server
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 8081
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            limits:
+              cpu: 500m
+              memory: 128Mi
+            requests:
+              cpu: 10m
+              memory: 64Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - mountPath: /tmp/k8s-webhook-server/serving-certs
+              name: cert
+              readOnly: true
+      securityContext:
+        runAsNonRoot: true
+      serviceAccountName: kubearchive-operator
+      terminationGracePeriodSeconds: 10
+      volumes:
+        - name: cert
+          secret:
+            defaultMode: 420
+            secretName: kubearchive-operator-tls
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/component: sink
+    app.kubernetes.io/name: kubearchive-sink
+    app.kubernetes.io/part-of: kubearchive
+    app.kubernetes.io/version: watcher-problems-2e49be9
+  name: kubearchive-sink
+  namespace: kubearchive
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kubearchive-sink
+  template:
+    metadata:
+      labels:
+        app: kubearchive-sink
+    spec:
+      containers:
+        - env:
+            - name: KUBEARCHIVE_ENABLE_PPROF
+              value: "true"
+            - name: GIN_MODE
+              value: release
+            - name: LOG_LEVEL
+              value: INFO
+            - name: KUBEARCHIVE_OTEL_MODE
+              value: disabled
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: ""
+            - name: KUBEARCHIVE_OTLP_SEND_LOGS
+              value: "false"
+            - name: OTEL_GO_X_DEPRECATED_RUNTIME_METRICS
+              value: "false"
+            - name: GOMEMLIMIT
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.memory
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.cpu
+            - name: KUBEARCHIVE_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: KUBEARCHIVE_LOGGING_DIR
+              value: /data/logging
+          envFrom:
+            - secretRef:
+                name: kubearchive-database-credentials
+          image: quay.io/kubearchive/sink:watcher-problems-2e49be9@sha256:ed5286ccf7435e939b7d59b3710e78770a012fa45e87b7505e6d3650af8f4fcc
+          livenessProbe:
+            httpGet:
+              path: /livez
+              port: 8080
+          name: kubearchive-sink
+          ports:
+            - containerPort: 8080
+              name: sink
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 8080
+            timeoutSeconds: 4
+          resources:
+            limits:
+              cpu: 200m
+              memory: 256Mi
+            requests:
+              cpu: 200m
+              memory: 230Mi
+          volumeMounts:
+            - mountPath: /data/logging
+              name: logging-config
+      serviceAccountName: kubearchive-sink
+      volumes:
+        - configMap:
+            name: kubearchive-logging
+          name: logging-config
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  labels:
+    app.kubernetes.io/component: operator
+    app.kubernetes.io/name: kubearchive-vacuum
+    app.kubernetes.io/part-of: kubearchive
+    app.kubernetes.io/version: watcher-problems-2e49be9
+  name: cluster-vacuum
+  namespace: kubearchive
+spec:
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+            - args:
+                - --type
+                - cluster
+                - --config
+                - cluster-vacuum
+              command:
+                - /ko-app/vacuum
+              env:
+                - name: KUBEARCHIVE_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+              image: quay.io/kubearchive/vacuum:watcher-problems-2e49be9@sha256:6d7f05175e17e30abc9ee6434bf75ce86524bb05640ae9ae11ea453b1ff323ab
+              name: vacuum
+          restartPolicy: Never
+          serviceAccount: kubearchive-cluster-vacuum
+  schedule: '* */3 * * *'
+  suspend: true
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  labels:
+    app.kubernetes.io/component: api-server
+    app.kubernetes.io/name: kubearchive-api-server-certificate
+    app.kubernetes.io/part-of: kubearchive
+    app.kubernetes.io/version: watcher-problems-2e49be9
+  name: kubearchive-api-server-certificate
+  namespace: kubearchive
+spec:
+  commonName: kubearchive-api-server
+  dnsNames:
+    - localhost
+    - kubearchive-api-server
+    - kubearchive-api-server.kubearchive.svc
+  duration: 720h
+  isCA: false
+  issuerRef:
+    group: cert-manager.io
+    kind: Issuer
+    name: kubearchive
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  renewBefore: 360h
+  secretName: kubearchive-api-server-tls
+  subject:
+    organizations:
+      - kubearchive
+  usages:
+    - digital signature
+    - key encipherment
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  labels:
+    app.kubernetes.io/component: certs
+    app.kubernetes.io/name: kubearchive-ca
+    app.kubernetes.io/part-of: kubearchive
+    app.kubernetes.io/version: watcher-problems-2e49be9
+  name: kubearchive-ca
+  namespace: kubearchive
+spec:
+  commonName: kubearchive-ca-certificate
+  isCA: true
+  issuerRef:
+    group: cert-manager.io
+    kind: Issuer
+    name: kubearchive-ca
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  secretName: kubearchive-ca
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  labels:
+    app.kubernetes.io/component: operator
+    app.kubernetes.io/name: kubearchive-operator-certificate
+    app.kubernetes.io/part-of: kubearchive
+    app.kubernetes.io/version: watcher-problems-2e49be9
+  name: kubearchive-operator-certificate
+  namespace: kubearchive
+spec:
+  dnsNames:
+    - kubearchive-operator-webhooks.kubearchive.svc
+    - kubearchive-operator-webhooks.kubearchive.svc.cluster.local
+  issuerRef:
+    kind: Issuer
+    name: kubearchive
+  secretName: kubearchive-operator-tls
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  labels:
+    app.kubernetes.io/component: certs
+    app.kubernetes.io/name: kubearchive
+    app.kubernetes.io/part-of: kubearchive
+    app.kubernetes.io/version: watcher-problems-2e49be9
+  name: kubearchive
+  namespace: kubearchive
+spec:
+  ca:
+    secretName: kubearchive-ca
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  labels:
+    app.kubernetes.io/component: certs
+    app.kubernetes.io/name: kubearchive-ca
+    app.kubernetes.io/part-of: kubearchive
+    app.kubernetes.io/version: watcher-problems-2e49be9
+  name: kubearchive-ca
+  namespace: kubearchive
+spec:
+  selfSigned: {}
+---
+apiVersion: eventing.knative.dev/v1
+kind: Broker
+metadata:
+  labels:
+    app.kubernetes.io/component: sink
+    app.kubernetes.io/name: kubearchive-broker
+    app.kubernetes.io/part-of: kubearchive
+    app.kubernetes.io/version: watcher-problems-2e49be9
+  name: kubearchive-broker
+  namespace: kubearchive
+spec:
+  delivery:
+    backoffDelay: PT0.5S
+    backoffPolicy: linear
+    deadLetterSink:
+      ref:
+        apiVersion: eventing.knative.dev/v1
+        kind: Broker
+        name: kubearchive-dls
+    retry: 4
+---
+apiVersion: eventing.knative.dev/v1
+kind: Broker
+metadata:
+  labels:
+    app.kubernetes.io/component: sink
+    app.kubernetes.io/name: kubearchive-dls
+    app.kubernetes.io/part-of: kubearchive
+    app.kubernetes.io/version: watcher-problems-2e49be9
+  name: kubearchive-dls
+  namespace: kubearchive
+spec:
+  delivery:
+    backoffDelay: PT0.5S
+    backoffPolicy: linear
+    retry: 4
+---
+apiVersion: eventing.knative.dev/v1
+kind: Trigger
+metadata:
+  labels:
+    app.kubernetes.io/component: sink
+    app.kubernetes.io/name: kubearchive-sink
+    app.kubernetes.io/part-of: kubearchive
+    app.kubernetes.io/version: watcher-problems-2e49be9
+  name: kubearchive-sink
+  namespace: kubearchive
+spec:
+  broker: kubearchive-broker
+  subscriber:
+    ref:
+      apiVersion: v1
+      kind: Service
+      name: kubearchive-sink
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: kubearchive/kubearchive-operator-certificate
+  labels:
+    app.kubernetes.io/component: operator
+    app.kubernetes.io/name: kubearchive-mutating-webhook-configuration
+    app.kubernetes.io/part-of: kubearchive
+    app.kubernetes.io/version: watcher-problems-2e49be9
+  name: kubearchive-mutating-webhook-configuration
+webhooks:
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      service:
+        name: kubearchive-operator-webhooks
+        namespace: kubearchive
+        path: /mutate-kubearchive-org-v1-kubearchiveconfig
+    failurePolicy: Fail
+    name: mkubearchiveconfig.kb.io
+    rules:
+      - apiGroups:
+          - kubearchive.org
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - kubearchiveconfigs
+    sideEffects: None
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      service:
+        name: kubearchive-operator-webhooks
+        namespace: kubearchive
+        path: /mutate-kubearchive-org-v1-clusterkubearchiveconfig
+    failurePolicy: Fail
+    name: mclusterkubearchiveconfig.kb.io
+    rules:
+      - apiGroups:
+          - kubearchive.org
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - clusterkubearchiveconfigs
+    sideEffects: None
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      service:
+        name: kubearchive-operator-webhooks
+        namespace: kubearchive
+        path: /mutate-kubearchive-org-v1-sinkfilter
+    failurePolicy: Fail
+    name: msinkfilter.kb.io
+    rules:
+      - apiGroups:
+          - kubearchive.org
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - sinkfilters
+    sideEffects: None
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      service:
+        name: kubearchive-operator-webhooks
+        namespace: kubearchive
+        path: /mutate-kubearchive-org-v1-namespacevacuumconfig
+    failurePolicy: Fail
+    name: mnamespacevacuumconfig.kb.io
+    rules:
+      - apiGroups:
+          - kubearchive.org
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - namespacevacuumconfigs
+    sideEffects: None
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      service:
+        name: kubearchive-operator-webhooks
+        namespace: kubearchive
+        path: /mutate-kubearchive-org-v1-clustervacuumconfig
+    failurePolicy: Fail
+    name: mclustervacuumconfig.kb.io
+    rules:
+      - apiGroups:
+          - kubearchive.org
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - clustervacuumconfigs
+    sideEffects: None
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: kubearchive/kubearchive-operator-certificate
+  labels:
+    app.kubernetes.io/component: operator
+    app.kubernetes.io/name: kubearchive-validating-webhook-configuration
+    app.kubernetes.io/part-of: kubearchive
+    app.kubernetes.io/version: watcher-problems-2e49be9
+  name: kubearchive-validating-webhook-configuration
+webhooks:
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      service:
+        name: kubearchive-operator-webhooks
+        namespace: kubearchive
+        path: /validate-kubearchive-org-v1-kubearchiveconfig
+    failurePolicy: Fail
+    name: vkubearchiveconfig.kb.io
+    rules:
+      - apiGroups:
+          - kubearchive.org
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - kubearchiveconfigs
+    sideEffects: None
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      service:
+        name: kubearchive-operator-webhooks
+        namespace: kubearchive
+        path: /validate-kubearchive-org-v1-clusterkubearchiveconfig
+    failurePolicy: Fail
+    name: vclusterkubearchiveconfig.kb.io
+    rules:
+      - apiGroups:
+          - kubearchive.org
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - clusterkubearchiveconfigs
+    sideEffects: None
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      service:
+        name: kubearchive-operator-webhooks
+        namespace: kubearchive
+        path: /validate-kubearchive-org-v1-sinkfilter
+    failurePolicy: Fail
+    name: vsinkfilter.kb.io
+    rules:
+      - apiGroups:
+          - kubearchive.org
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - sinkfilters
+    sideEffects: None
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      service:
+        name: kubearchive-operator-webhooks
+        namespace: kubearchive
+        path: /validate-kubearchive-org-v1-namespacevacuumconfig
+    failurePolicy: Fail
+    name: vnamespacevacuumconfig.kb.io
+    rules:
+      - apiGroups:
+          - kubearchive.org
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - namespacevacuumconfigs
+    sideEffects: None
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      service:
+        name: kubearchive-operator-webhooks
+        namespace: kubearchive
+        path: /validate-kubearchive-org-v1-clustervacuumconfig
+    failurePolicy: Fail
+    name: vclustervacuumconfig.kb.io
+    rules:
+      - apiGroups:
+          - kubearchive.org
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - clustervacuumconfigs
+    sideEffects: None
+
+---

--- a/components/kubearchive/development/kustomization.yaml
+++ b/components/kubearchive/development/kustomization.yaml
@@ -6,7 +6,7 @@ resources:
   - postgresql.yaml
   - vacuum.yaml
   - release-vacuum.yaml
-  - https://github.com/kubearchive/kubearchive/releases/download/v1.6.0/kubearchive.yaml?timeout=90
+  - kubearchive.yaml
 
 namespace: product-kubearchive
 secretGenerator:


### PR DESCRIPTION
This PR changes KubeArchive to the version published in this branch: https://github.com/rh-hemartin/kubearchive/tree/watchers-problems. Images and installation manifest created by hemartin. The changes applies only to staging clusters.