### PR TITLE
Increase quota for linux extra fast on rh01

### DIFF
--- a/components/kueue/production/stone-prd-rh01/queue-config/cluster-queue.yaml
+++ b/components/kueue/production/stone-prd-rh01/queue-config/cluster-queue.yaml
@@ -48,7 +48,7 @@ spec:
     - name: platform-group-1
       resources:
       - name: linux-amd64
-        nominalQuota: '30'
+        nominalQuota: '25'
       - name: linux-arm64
         nominalQuota: '70'
       - name: linux-c2xlarge-amd64
@@ -102,7 +102,7 @@ spec:
       - name: linux-d160-m8xlarge-arm64
         nominalQuota: '5'
       - name: linux-extra-fast-amd64
-        nominalQuota: '5'
+        nominalQuota: '10'
       - name: linux-fast-amd64
         nominalQuota: '5'
       - name: linux-g6xlarge-amd64

--- a/components/multi-platform-controller/production/stone-prd-rh01/host-config.yaml
+++ b/components/multi-platform-controller/production/stone-prd-rh01/host-config.yaml
@@ -255,7 +255,7 @@ data:
   dynamic.linux-amd64.aws-secret: aws-account
   dynamic.linux-amd64.ssh-secret: aws-ssh-key
   dynamic.linux-amd64.security-group-id: sg-0fbf35ced0d59fd4a
-  dynamic.linux-amd64.max-instances: "30"
+  dynamic.linux-amd64.max-instances: "25"
   dynamic.linux-amd64.subnet-id: subnet-0c39ff75f819abfc5
 
   dynamic.linux-mlarge-amd64.type: aws
@@ -498,7 +498,7 @@ data:
   dynamic.linux-extra-fast-amd64.ssh-secret: aws-ssh-key
   dynamic.linux-extra-fast-amd64.security-group-id: sg-0fbf35ced0d59fd4a
   dynamic.linux-extra-fast-amd64.subnet-id: subnet-0c39ff75f819abfc5
-  dynamic.linux-extra-fast-amd64.max-instances: "5"
+  dynamic.linux-extra-fast-amd64.max-instances: "10"
   dynamic.linux-extra-fast-amd64.disk: "200"
   # dynamic.linux-extra-fast-amd64.iops: "16000"
   # dynamic.linux-extra-fast-amd64.throughput: "1000"


### PR DESCRIPTION
This one is hitting 100% usage quite often so double it up until we have the real fix which is to not limit individual profile but limit at the subnet level instead.