### PR TITLE
Fix incorrect namespace in KubeArchive ClusterRoleBinding subject

### DIFF
--- a/components/kubearchive/development/kustomization.yaml
+++ b/components/kubearchive/development/kustomization.yaml
@@ -204,3 +204,13 @@ patches:
       metadata:
         name: "kubearchive-operator-certificate"
         namespace: kubearchive
+  # set the correct namespace for the subject
+  - patch: |-
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRoleBinding
+      metadata:
+        name: kubearchive-a13e
+      subjects:
+        - kind: ServiceAccount
+          name: kubearchive-a13e
+          namespace: product-kubearchive


### PR DESCRIPTION
change namespace for the ServiceAccount subject to product-kubearchive