### PR TITLE
deleted 'linux-test-arm64' platform from stone-stg-rh01

### DIFF
--- a/components/kueue/staging/stone-stg-rh01/kustomization.yaml
+++ b/components/kueue/staging/stone-stg-rh01/kustomization.yaml
@@ -3,17 +3,3 @@ kind: Kustomization
 resources:
 - ../base
 - queue-config
-
-patches:
-  - target:
-      kind: MutatingWebhookConfiguration
-      name: tekton-kueue-mutating-webhook-configuration
-    patch: |-
-      - op: replace
-        path: /webhooks/0/namespaceSelector
-        value:
-          matchExpressions:
-            - key: kubernetes.io/metadata.name
-              operator: "NotIn"
-              values:
-                - "mshaposh-tenant"

--- a/components/kueue/staging/stone-stg-rh01/queue-config/cluster-queue.yaml
+++ b/components/kueue/staging/stone-stg-rh01/queue-config/cluster-queue.yaml
@@ -100,7 +100,6 @@ spec:
     - linux-root-amd64
     - linux-root-arm64
     - linux-s390x
-    - linux-test-arm64
     - linux-x86-64
     - local
     - localhost
@@ -129,8 +128,6 @@ spec:
         nominalQuota: '10'
       - name: linux-s390x
         nominalQuota: '2'
-      - name: linux-test-arm64
-        nominalQuota: '1'
       - name: linux-x86-64
         nominalQuota: '1000'
       - name: local

--- a/components/multi-platform-controller/staging/host-config.yaml
+++ b/components/multi-platform-controller/staging/host-config.yaml
@@ -14,7 +14,6 @@ data:
     "
   dynamic-platforms: "\
     linux/arm64,\
-    linux-test/arm64,\
     linux-mlarge/amd64,\
     linux-mlarge/arm64,\
     linux-mxlarge/amd64,\
@@ -62,18 +61,6 @@ data:
   dynamic.linux-arm64.security-group-id: sg-05bc8dd0b52158567
   dynamic.linux-arm64.max-instances: "160"
   dynamic.linux-arm64.subnet-id: subnet-030738beb81d3863a
-
-  dynamic.linux-test-arm64.type: aws
-  dynamic.linux-test-arm64.region: us-east-1
-  dynamic.linux-test-arm64.ami: ami-03d6a5256a46c9feb
-  dynamic.linux-test-arm64.instance-type: m6g.large
-  dynamic.linux-test-arm64.instance-tag: stage-arm64-test
-  dynamic.linux-test-arm64.key-name: konflux-stage-ext-mab01
-  dynamic.linux-test-arm64.aws-secret: aws-account
-  dynamic.linux-test-arm64.ssh-secret: aws-ssh-key
-  dynamic.linux-test-arm64.security-group-id: sg-05bc8dd0b52158567
-  dynamic.linux-test-arm64.max-instances: "1"
-  dynamic.linux-test-arm64.subnet-id: subnet-030738beb81d3863a
 
   dynamic.linux-mlarge-arm64.type: aws
   dynamic.linux-mlarge-arm64.region: us-east-1


### PR DESCRIPTION
## what
Revert the code addition in #7761 :
- Deleted `linux-test-arm64` platform from stone-stg-rh01 cluster
- Deleted patching of exclude `mshaposh-tenant` namespace from Kueue
## why
The `linux-test-arm64` is no longer needed, It was used for testing `multi_platform_controller_waiting_tasks` metric.