### PR TITLE
kflux-osp-p01: remove member operator installation

### DIFF
--- a/components/sandbox/toolchain-member-operator/production/kflux-osp-p01/kustomization.yaml
+++ b/components/sandbox/toolchain-member-operator/production/kflux-osp-p01/kustomization.yaml
@@ -1,12 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- ../base
-patches:
-- patch: |
-    $patch: delete
-    apiVersion: operators.coreos.com/v1alpha1
-    kind: Subscription
-    metadata:
-      name: dev-sandbox-member
-      namespace: toolchain-member-operator
+- ns.yaml

--- a/components/sandbox/toolchain-member-operator/production/kflux-osp-p01/ns.yaml
+++ b/components/sandbox/toolchain-member-operator/production/kflux-osp-p01/ns.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: toolchain-member-operator


### PR DESCRIPTION
Removes all components and resources from the member sandbox component for kflux-osp-p01 except for the namespace, which will be removed at a later date.