### PR TITLE
Stop alerts on pentest cluster by disabling metrics export

### DIFF
--- a/argo-cd-apps/base/all-clusters/infra-deployments/monitoring-workload-prometheus/monitoring-workload-prometheus.yaml
+++ b/argo-cd-apps/base/all-clusters/infra-deployments/monitoring-workload-prometheus/monitoring-workload-prometheus.yaml
@@ -43,8 +43,6 @@ spec:
                   values.clusterDir: kflux-rhel-p01
                 - nameNormalized: kflux-osp-p01
                   values.clusterDir: kflux-osp-p01
-                - nameNormalized: pentest-p01
-                  values.clusterDir: pentest-p01
   template:
     metadata:
       name: monitoring-workload-prometheus-{{nameNormalized}}


### PR DESCRIPTION
This was requested in konflux-o11y forum Slack discussion. By disabling metric export, no alerts should fire for this cluster, as no metrics will be available in RHOBS.