### PR TITLE
remove duplicate appstudio-pipelines-runner

### DIFF
--- a/components/pipeline-service/production/kflux-osp-p01/deploy.yaml
+++ b/components/pipeline-service/production/kflux-osp-p01/deploy.yaml
@@ -143,22 +143,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   annotations:
-    argocd.argoproj.io/sync-wave: "0"
-  name: appstudio-pipelines-runner
-rules:
-- apiGroups:
-  - security.openshift.io
-  resourceNames:
-  - appstudio-pipelines-scc
-  resources:
-  - securitycontextconstraints
-  verbs:
-  - use
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  annotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
     argocd.argoproj.io/sync-wave: "0"
   name: openshift-gitops-apply-tekton-config-parameters

--- a/components/pipeline-service/production/kflux-osp-p01/resources/scc-rbac.yaml
+++ b/components/pipeline-service/production/kflux-osp-p01/resources/scc-rbac.yaml
@@ -1,20 +1,4 @@
 ---
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: appstudio-pipelines-runner
-  annotations:
-    argocd.argoproj.io/sync-wave: "0"
-rules:
-- apiGroups:
-  - security.openshift.io
-  resourceNames:
-  - appstudio-pipelines-scc
-  resources:
-  - securitycontextconstraints
-  verbs:
-  - use
----
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/components/pipeline-service/production/pentest-p01/deploy.yaml
+++ b/components/pipeline-service/production/pentest-p01/deploy.yaml
@@ -143,22 +143,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   annotations:
-    argocd.argoproj.io/sync-wave: "0"
-  name: appstudio-pipelines-runner
-rules:
-- apiGroups:
-  - security.openshift.io
-  resourceNames:
-  - appstudio-pipelines-scc
-  resources:
-  - securitycontextconstraints
-  verbs:
-  - use
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  annotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
     argocd.argoproj.io/sync-wave: "0"
   name: openshift-gitops-apply-tekton-config-parameters

--- a/components/pipeline-service/production/pentest-p01/resources/scc-rbac.yaml
+++ b/components/pipeline-service/production/pentest-p01/resources/scc-rbac.yaml
@@ -1,20 +1,4 @@
 ---
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: appstudio-pipelines-runner
-  annotations:
-    argocd.argoproj.io/sync-wave: "0"
-rules:
-- apiGroups:
-  - security.openshift.io
-  resourceNames:
-  - appstudio-pipelines-scc
-  resources:
-  - securitycontextconstraints
-  verbs:
-  - use
----
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:


### PR DESCRIPTION
These resources are duplicated across the pipelines-service and konflux-rbac components.  konflux-rbac is the definitive home for these resources, so remove them from pipelines-runner.