### PR TITLE
remove appstudio-pipelines-runner from new cluster templates

### DIFF
--- a/hack/new-cluster/templates/pipeline-service/resources/scc-rbac.yaml
+++ b/hack/new-cluster/templates/pipeline-service/resources/scc-rbac.yaml
@@ -1,20 +1,4 @@
 ---
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: appstudio-pipelines-runner
-  annotations:
-    argocd.argoproj.io/sync-wave: "0"
-rules:
-- apiGroups:
-  - security.openshift.io
-  resourceNames:
-  - appstudio-pipelines-scc
-  resources:
-  - securitycontextconstraints
-  verbs:
-  - use
----
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:


### PR DESCRIPTION
It's managed by konflux-rbac, so it shouldn't be a part of the templates for pipeline-service.