### PR TITLE
Revert "Add MPC VM to test new s390x base image (#7794)"

### DIFF
--- a/components/kueue/production/kflux-rhel-p01/queue-config/cluster-queue.yaml
+++ b/components/kueue/production/kflux-rhel-p01/queue-config/cluster-queue.yaml
@@ -91,7 +91,6 @@ spec:
     - linux-root-amd64
     - linux-root-arm64
     - linux-s390x
-    - linux-s390xrhel96
     - linux-x86-64
     - local
     - localhost
@@ -120,8 +119,6 @@ spec:
         nominalQuota: '5'
       - name: linux-s390x
         nominalQuota: '12'
-      - name: linux-s390xrhel96
-        nominalQuota: '1'
       - name: linux-x86-64
         nominalQuota: '1000'
       - name: local

--- a/components/multi-platform-controller/production-downstream/kflux-rhel-p01/host-config.yaml
+++ b/components/multi-platform-controller/production-downstream/kflux-rhel-p01/host-config.yaml
@@ -511,12 +511,6 @@ data:
   host.s390x-static-3.secret: "ibm-s390x-ssh-key"
   host.s390x-static-3.concurrency: "4"
 
-  host.s390xrhel96-static-4.address: "10.130.79.100"
-  host.s390xrhel96-static-4.platform: "linux/s390xrhel96"
-  host.s390xrhel96-static-4.user: "root"
-  host.s390xrhel96-static-4.secret: "ibm-s390x-ssh-key"
-  host.s390xrhel96-static-4.concurrency: "1"
-
   # PPC64LE 4cores(32vCPU) / 128GiB RAM / 2TB disk
   host.ppc64le-static-0.address: "10.130.78.70"
   host.ppc64le-static-0.platform: "linux/ppc64le"


### PR DESCRIPTION
This reverts commit ee3c81c581d1bcc3451d103d388810c126cb2249. That change was temporary to test a base image, it is no longer needed.

[KFLUXINFRA-2149](https://issues.redhat.com//browse/KFLUXINFRA-2149)