### PR TITLE
Disable kubearchive from UI in pentest cluster

### DIFF
--- a/argo-cd-apps/base/member/infra-deployments/kubearchive/kubearchive.yaml
+++ b/argo-cd-apps/base/member/infra-deployments/kubearchive/kubearchive.yaml
@@ -27,6 +27,8 @@ spec:
                 #   values.clusterDir: stone-prod-p01
                 - nameNormalized: stone-prod-p02
                   values.clusterDir: stone-prod-p02
+                # - nameNormalized: pentest-p01
+                #   values.clusterDir: pentest-p01
                 # Public
                 # - nameNormalized: stone-prd-rh01
                 #   values.clusterDir: stone-prd-rh01

--- a/components/konflux-ui/production/pentest-p01/kubearchive.conf
+++ b/components/konflux-ui/production/pentest-p01/kubearchive.conf
@@ -1,0 +1,1 @@
+# KubeArchive disabled by config

--- a/components/konflux-ui/production/pentest-p01/kustomization.yaml
+++ b/components/konflux-ui/production/pentest-p01/kustomization.yaml
@@ -8,10 +8,10 @@ configMapGenerator:
   - name: dex
     files:
       - dex-config.yaml
-  - name: proxy-init-config
-    literals:
-      - IMPERSONATE=true
-      - TEKTON_RESULTS_URL=https://tekton-results-api-service.tekton-results.svc.cluster.local:8080
+  - name: proxy-nginx-static
+    files:
+      - kubearchive.conf
+    behavior: merge
 
 patches:
   - path: add-service-certs-patch.yaml


### PR DESCRIPTION
The recent `pentest-01` cluster doesn't have kubearchive on it.
The UI must include specific config file to disable it in the nginx reverse proxy.