### PR TITLE
KubeArchive: add more changes for the watchers problems

### DIFF
--- a/components/kubearchive/development/kubearchive.yaml
+++ b/components/kubearchive/development/kubearchive.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: namespace
     app.kubernetes.io/name: kubearchive
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: watcher-problems-2e49be9
+    app.kubernetes.io/version: watcher-problems-85e4859
   name: kubearchive
 ---
 apiVersion: apiextensions.k8s.io/v1
@@ -601,7 +601,7 @@ metadata:
     app.kubernetes.io/component: api-server
     app.kubernetes.io/name: kubearchive-api-server
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: watcher-problems-2e49be9
+    app.kubernetes.io/version: watcher-problems-85e4859
   name: kubearchive-api-server
   namespace: kubearchive
 ---
@@ -612,7 +612,7 @@ metadata:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: kubearchive-vacuum
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: watcher-problems-2e49be9
+    app.kubernetes.io/version: watcher-problems-85e4859
   name: kubearchive-cluster-vacuum
   namespace: kubearchive
 ---
@@ -623,7 +623,7 @@ metadata:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: kubearchive-operator
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: watcher-problems-2e49be9
+    app.kubernetes.io/version: watcher-problems-85e4859
   name: kubearchive-operator
   namespace: kubearchive
 ---
@@ -634,7 +634,7 @@ metadata:
     app.kubernetes.io/component: sink
     app.kubernetes.io/name: kubearchive-sink
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: watcher-problems-2e49be9
+    app.kubernetes.io/version: watcher-problems-85e4859
   name: kubearchive-sink
   namespace: kubearchive
 ---
@@ -645,7 +645,7 @@ metadata:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: kubearchive-vacuum
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: watcher-problems-2e49be9
+    app.kubernetes.io/version: watcher-problems-85e4859
   name: kubearchive-cluster-vacuum
   namespace: kubearchive
 rules:
@@ -672,7 +672,7 @@ metadata:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: kubearchive-operator-leader-election
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: watcher-problems-2e49be9
+    app.kubernetes.io/version: watcher-problems-85e4859
   name: kubearchive-operator-leader-election
   namespace: kubearchive
 rules:
@@ -715,7 +715,7 @@ metadata:
     app.kubernetes.io/component: sink
     app.kubernetes.io/name: kubearchive-sink-watch
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: watcher-problems-2e49be9
+    app.kubernetes.io/version: watcher-problems-85e4859
   name: kubearchive-sink-watch
   namespace: kubearchive
 rules:
@@ -735,7 +735,7 @@ metadata:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: kubearchive-vacuum
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: watcher-problems-2e49be9
+    app.kubernetes.io/version: watcher-problems-85e4859
   name: clusterkubearchiveconfig-read
 rules:
   - apiGroups:
@@ -753,7 +753,7 @@ metadata:
     app.kubernetes.io/component: api-server
     app.kubernetes.io/name: kubearchive-api-server
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: watcher-problems-2e49be9
+    app.kubernetes.io/version: watcher-problems-85e4859
   name: kubearchive-api-server
 rules:
   - apiGroups:
@@ -771,7 +771,7 @@ metadata:
   labels:
     app.kubernetes.io/name: kubearchive-edit
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: watcher-problems-2e49be9
+    app.kubernetes.io/version: watcher-problems-85e4859
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
   name: kubearchive-edit
 rules:
@@ -903,7 +903,7 @@ metadata:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: kubearchive-operator-config-editor
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: watcher-problems-2e49be9
+    app.kubernetes.io/version: watcher-problems-85e4859
   name: kubearchive-operator-config-editor
 rules:
   - apiGroups:
@@ -932,7 +932,7 @@ metadata:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: kubearchive-operator-config-viewer
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: watcher-problems-2e49be9
+    app.kubernetes.io/version: watcher-problems-85e4859
   name: kubearchive-operator-config-viewer
 rules:
   - apiGroups:
@@ -956,7 +956,7 @@ metadata:
   labels:
     app.kubernetes.io/name: kubearchive-view
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: watcher-problems-2e49be9
+    app.kubernetes.io/version: watcher-problems-85e4859
     rbac.authorization.k8s.io/aggregate-to-view: "true"
   name: kubearchive-view
 rules:
@@ -976,7 +976,7 @@ metadata:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: kubearchive-vacuum
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: watcher-problems-2e49be9
+    app.kubernetes.io/version: watcher-problems-85e4859
   name: kubearchive-cluster-vacuum
   namespace: kubearchive
 roleRef:
@@ -995,7 +995,7 @@ metadata:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: kubearchive-operator-leader-election
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: watcher-problems-2e49be9
+    app.kubernetes.io/version: watcher-problems-85e4859
   name: kubearchive-operator-leader-election
   namespace: kubearchive
 roleRef:
@@ -1014,7 +1014,7 @@ metadata:
     app.kubernetes.io/component: sink
     app.kubernetes.io/name: kubearchive-sink-watch
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: watcher-problems-2e49be9
+    app.kubernetes.io/version: watcher-problems-85e4859
   name: kubearchive-sink-watch
   namespace: kubearchive
 roleRef:
@@ -1033,7 +1033,7 @@ metadata:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: kubearchive-vacuum
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: watcher-problems-2e49be9
+    app.kubernetes.io/version: watcher-problems-85e4859
   name: clusterkubearchiveconfig-read
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -1048,28 +1048,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    app.kubernetes.io/component: apiserversource
-    app.kubernetes.io/name: kubearchive-a13e
-    app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: watcher-problems-2e49be9
-  name: kubearchive-a13e
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: kubearchive-a13e
-subjects:
-  - kind: ServiceAccount
-    name: kubearchive-a13e
-    namespace: kubearchive
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  labels:
     app.kubernetes.io/component: api-server
     app.kubernetes.io/name: kubearchive-api-server
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: watcher-problems-2e49be9
+    app.kubernetes.io/version: watcher-problems-85e4859
   name: kubearchive-api-server
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -1087,7 +1069,7 @@ metadata:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: kubearchive-operator
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: watcher-problems-2e49be9
+    app.kubernetes.io/version: watcher-problems-85e4859
   name: kubearchive-operator
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -1106,7 +1088,7 @@ metadata:
     app.kubernetes.io/component: logging
     app.kubernetes.io/name: kubearchive-logging
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: watcher-problems-2e49be9
+    app.kubernetes.io/version: watcher-problems-85e4859
   name: kubearchive-logging
   namespace: kubearchive
 ---
@@ -1124,7 +1106,7 @@ metadata:
     app.kubernetes.io/component: database
     app.kubernetes.io/name: kubearchive-database-credentials
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: watcher-problems-2e49be9
+    app.kubernetes.io/version: watcher-problems-85e4859
   name: kubearchive-database-credentials
   namespace: kubearchive
 type: Opaque
@@ -1138,7 +1120,7 @@ metadata:
     app.kubernetes.io/component: logging
     app.kubernetes.io/name: kubearchive-logging
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: watcher-problems-2e49be9
+    app.kubernetes.io/version: watcher-problems-85e4859
   name: kubearchive-logging
   namespace: kubearchive
 type: Opaque
@@ -1150,7 +1132,7 @@ metadata:
     app.kubernetes.io/component: api-server
     app.kubernetes.io/name: kubearchive-api-server
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: watcher-problems-2e49be9
+    app.kubernetes.io/version: watcher-problems-85e4859
   name: kubearchive-api-server
   namespace: kubearchive
 spec:
@@ -1169,7 +1151,7 @@ metadata:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: kubearchive-operator-webhooks
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: watcher-problems-2e49be9
+    app.kubernetes.io/version: watcher-problems-85e4859
   name: kubearchive-operator-webhooks
   namespace: kubearchive
 spec:
@@ -1192,7 +1174,7 @@ metadata:
     app.kubernetes.io/component: sink
     app.kubernetes.io/name: kubearchive-sink
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: watcher-problems-2e49be9
+    app.kubernetes.io/version: watcher-problems-85e4859
   name: kubearchive-sink
   namespace: kubearchive
 spec:
@@ -1210,7 +1192,7 @@ metadata:
     app.kubernetes.io/component: api-server
     app.kubernetes.io/name: kubearchive-api-server
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: watcher-problems-2e49be9
+    app.kubernetes.io/version: watcher-problems-85e4859
   name: kubearchive-api-server
   namespace: kubearchive
 spec:
@@ -1258,7 +1240,7 @@ spec:
           envFrom:
             - secretRef:
                 name: kubearchive-database-credentials
-          image: quay.io/kubearchive/api:watcher-problems-2e49be9@sha256:86d0c314ab3062950d38a6c7c44ed44894a20a304f5c328d19a2b430356d4dcb
+          image: quay.io/kubearchive/api:watcher-problems-85e4859@sha256:96f98d3dd9e089b47b02b695049e5f12b0f1d8cfe023e600bd123bf1280a9cf1
           livenessProbe:
             httpGet:
               path: /livez
@@ -1303,7 +1285,7 @@ metadata:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: kubearchive-operator
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: watcher-problems-2e49be9
+    app.kubernetes.io/version: watcher-problems-85e4859
   name: kubearchive-operator
   namespace: kubearchive
 spec:
@@ -1323,6 +1305,8 @@ spec:
             - --health-probe-bind-address=:8081
             - --leader-elect
           env:
+            - name: KUBEARCHIVE_MONITOR_ALL_NAMESPACES
+              value: "false"
             - name: KUBEARCHIVE_ENABLE_PPROF
               value: "true"
             - name: LOG_LEVEL
@@ -1347,7 +1331,7 @@ spec:
               valueFrom:
                 resourceFieldRef:
                   resource: limits.cpu
-          image: quay.io/kubearchive/operator:watcher-problems-2e49be9@sha256:79b50d83a41fa1628fbaa6f4328bc0b6b7b560c6d8c68be0baaada7eaa0a67bc
+          image: quay.io/kubearchive/operator:watcher-problems-85e4859@sha256:b960f0c00f131dcdc954dc47555c7a16cab9bb751922951da261cfb46cd39c0e
           livenessProbe:
             httpGet:
               path: /healthz
@@ -1401,7 +1385,7 @@ metadata:
     app.kubernetes.io/component: sink
     app.kubernetes.io/name: kubearchive-sink
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: watcher-problems-2e49be9
+    app.kubernetes.io/version: watcher-problems-85e4859
   name: kubearchive-sink
   namespace: kubearchive
 spec:
@@ -1447,7 +1431,7 @@ spec:
           envFrom:
             - secretRef:
                 name: kubearchive-database-credentials
-          image: quay.io/kubearchive/sink:watcher-problems-2e49be9@sha256:ed5286ccf7435e939b7d59b3710e78770a012fa45e87b7505e6d3650af8f4fcc
+          image: quay.io/kubearchive/sink:watcher-problems-85e4859@sha256:6ca165ea711b1f01b82d89305309a8c0d967155381168077e6e778f4ac36f8d1
           livenessProbe:
             httpGet:
               path: /livez
@@ -1485,7 +1469,7 @@ metadata:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: kubearchive-vacuum
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: watcher-problems-2e49be9
+    app.kubernetes.io/version: watcher-problems-85e4859
   name: cluster-vacuum
   namespace: kubearchive
 spec:
@@ -1506,7 +1490,7 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
-              image: quay.io/kubearchive/vacuum:watcher-problems-2e49be9@sha256:6d7f05175e17e30abc9ee6434bf75ce86524bb05640ae9ae11ea453b1ff323ab
+              image: quay.io/kubearchive/vacuum:watcher-problems-85e4859@sha256:3d2a184a6f25df73ab486f07ff2c63b37f25ed4d65830fb50f1b8b7fa573aeb3
               name: vacuum
           restartPolicy: Never
           serviceAccount: kubearchive-cluster-vacuum
@@ -1520,7 +1504,7 @@ metadata:
     app.kubernetes.io/component: api-server
     app.kubernetes.io/name: kubearchive-api-server-certificate
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: watcher-problems-2e49be9
+    app.kubernetes.io/version: watcher-problems-85e4859
   name: kubearchive-api-server-certificate
   namespace: kubearchive
 spec:
@@ -1554,7 +1538,7 @@ metadata:
     app.kubernetes.io/component: certs
     app.kubernetes.io/name: kubearchive-ca
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: watcher-problems-2e49be9
+    app.kubernetes.io/version: watcher-problems-85e4859
   name: kubearchive-ca
   namespace: kubearchive
 spec:
@@ -1576,7 +1560,7 @@ metadata:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: kubearchive-operator-certificate
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: watcher-problems-2e49be9
+    app.kubernetes.io/version: watcher-problems-85e4859
   name: kubearchive-operator-certificate
   namespace: kubearchive
 spec:
@@ -1595,7 +1579,7 @@ metadata:
     app.kubernetes.io/component: certs
     app.kubernetes.io/name: kubearchive
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: watcher-problems-2e49be9
+    app.kubernetes.io/version: watcher-problems-85e4859
   name: kubearchive
   namespace: kubearchive
 spec:
@@ -1609,7 +1593,7 @@ metadata:
     app.kubernetes.io/component: certs
     app.kubernetes.io/name: kubearchive-ca
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: watcher-problems-2e49be9
+    app.kubernetes.io/version: watcher-problems-85e4859
   name: kubearchive-ca
   namespace: kubearchive
 spec:
@@ -1622,7 +1606,7 @@ metadata:
     app.kubernetes.io/component: sink
     app.kubernetes.io/name: kubearchive-broker
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: watcher-problems-2e49be9
+    app.kubernetes.io/version: watcher-problems-85e4859
   name: kubearchive-broker
   namespace: kubearchive
 spec:
@@ -1643,7 +1627,7 @@ metadata:
     app.kubernetes.io/component: sink
     app.kubernetes.io/name: kubearchive-dls
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: watcher-problems-2e49be9
+    app.kubernetes.io/version: watcher-problems-85e4859
   name: kubearchive-dls
   namespace: kubearchive
 spec:
@@ -1659,7 +1643,7 @@ metadata:
     app.kubernetes.io/component: sink
     app.kubernetes.io/name: kubearchive-sink
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: watcher-problems-2e49be9
+    app.kubernetes.io/version: watcher-problems-85e4859
   name: kubearchive-sink
   namespace: kubearchive
 spec:
@@ -1679,7 +1663,7 @@ metadata:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: kubearchive-mutating-webhook-configuration
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: watcher-problems-2e49be9
+    app.kubernetes.io/version: watcher-problems-85e4859
   name: kubearchive-mutating-webhook-configuration
 webhooks:
   - admissionReviewVersions:
@@ -1792,7 +1776,7 @@ metadata:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: kubearchive-validating-webhook-configuration
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: watcher-problems-2e49be9
+    app.kubernetes.io/version: watcher-problems-85e4859
   name: kubearchive-validating-webhook-configuration
 webhooks:
   - admissionReviewVersions:

--- a/components/kubearchive/development/kustomization.yaml
+++ b/components/kubearchive/development/kustomization.yaml
@@ -116,6 +116,8 @@ patches:
               - name: manager
                 args: [--health-probe-bind-address=:8081]
                 env:
+                - name: KUBEARCHIVE_MONITOR_ALL_NAMESPACES
+                  value: "true"
                 - name: KUBEARCHIVE_OTEL_MODE
                   value: enabled
                 - name: OTEL_EXPORTER_OTLP_ENDPOINT
@@ -204,13 +206,3 @@ patches:
       metadata:
         name: "kubearchive-operator-certificate"
         namespace: kubearchive
-  # set the correct namespace for the subject
-  - patch: |-
-      apiVersion: rbac.authorization.k8s.io/v1
-      kind: ClusterRoleBinding
-      metadata:
-        name: kubearchive-a13e
-      subjects:
-        - kind: ServiceAccount
-          name: kubearchive-a13e
-          namespace: product-kubearchive


### PR DESCRIPTION
Changing the images again. Now the ClusterRoleBinding is created by the operator, so I'm removing it. So the patch is not needed anymore.