### PR TITLE
Stop alerts on pentest cluster by disabling metrics export v2

### DIFF
--- a/components/monitoring/prometheus/production/pentest-p01/cluster-id-label.yaml
+++ b/components/monitoring/prometheus/production/pentest-p01/cluster-id-label.yaml
@@ -1,4 +1,0 @@
----
-- op: add
-  path: /spec/prometheusConfig/externalLabels/source_cluster
-  value: pentest-p01

--- a/components/monitoring/prometheus/production/pentest-p01/kustomization.yaml
+++ b/components/monitoring/prometheus/production/pentest-p01/kustomization.yaml
@@ -1,12 +1,3 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-resources:
-- ../base
-
-patches:
-  - path: cluster-id-label.yaml
-    target:
-      name: appstudio-federate-ms
-      kind: MonitoringStack
-      group: monitoring.rhobs
-      version: v1alpha1
+resources: []


### PR DESCRIPTION
Previous attempt to stop metric export did not work, as removing the cluster name from the list only caused the clusterDir value to not be set. The Application is still generated via the 'clusters' generator. Attempt to create an Application that manages no resources by modifying the cluster-specific component kustomization.