### PR TITLE
use Group/Version/Kind in deny-virtual-domain

### DIFF
--- a/components/policies/development/namespace-lister/deny-virtual-domain/deny-virtual-domain.yaml
+++ b/components/policies/development/namespace-lister/deny-virtual-domain/deny-virtual-domain.yaml
@@ -12,7 +12,7 @@ spec:
       any:
       - resources:
           kinds:
-          - Namespace
+          - /v1/Namespace
           selector:
             matchLabels:
               konflux-ci.dev/type: tenant


### PR DESCRIPTION
We are facing the validation error `admission webhook "validate-policy.kyverno.svc" denied the request: no unique match for kind Namespace`.

This change adds Group and Version in the ClusterPolicy's match.

Follows up to #7600

Signed-off-by: Francesco Ilario <filario@redhat.com>
