### PR TITLE
KFLUXINFRA-2177: Create a Velero resource-modifier for ImageRepository

### DIFF
--- a/components/backup/staging/stone-stg-rh01/dpa-resource-modifier-patch.yaml
+++ b/components/backup/staging/stone-stg-rh01/dpa-resource-modifier-patch.yaml
@@ -1,0 +1,9 @@
+apiVersion: oadp.openshift.io/v1alpha1
+kind: DataProtectionApplication
+metadata:
+  name: velero-aws
+spec:
+  configuration:
+    velero:
+      args:
+        restore-resource-modifiers-configmap-name: image-repository-resource-modifier

--- a/components/backup/staging/stone-stg-rh01/image-repository-resource-modifier.yaml
+++ b/components/backup/staging/stone-stg-rh01/image-repository-resource-modifier.yaml
@@ -1,0 +1,19 @@
+# https://velero.io/docs/v1.16/restore-resource-modifiers
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: image-repository-resource-modifier
+  namespace: openshift-adp
+  labels:
+    velero.io/plugin-config: ""
+    velero.io/restore-resource-modifier: "true"
+data:
+  imagerepository-modifier.yaml: |
+    version: v1
+    resourceModifierRules:
+    - conditions:
+        groupResource: imagerepositories.appstudio.redhat.com
+      patches:
+      - operation: remove
+        path: "/metadata/finalizers"
+        description: "Remove finalizers from all restored Flux ImageRepositories."

--- a/components/backup/staging/stone-stg-rh01/kustomization.yaml
+++ b/components/backup/staging/stone-stg-rh01/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../base/member
+  - image-repository-resource-modifier.yaml
 patches:
   - target:
       group: external-secrets.io
@@ -21,3 +22,9 @@ patches:
       kind: DataProtectionApplication
       name: velero-aws
     path: dpa-kmskeyid-patch.yaml
+  - target:
+      group: oadp.openshift.io
+      version: v1alpha1
+      kind: DataProtectionApplication
+      name: velero-aws
+    path: dpa-resource-modifier-patch.yaml


### PR DESCRIPTION
The modifier will run during a Velero restore and
remove all the finalizers from the ImageRepository CRDs.