### PR TITLE
Rename releases to improve readability

### DIFF
--- a/components/vector-kubearchive-log-collector/development/grafana-helm-generator.yaml
+++ b/components/vector-kubearchive-log-collector/development/grafana-helm-generator.yaml
@@ -5,6 +5,6 @@ metadata:
 name: grafana
 repo: https://grafana.github.io/helm-charts
 version: 9.2.6
-releaseName: vector-kubearchive-log-collector
+releaseName: grafana
 namespace: product-kubearchive-logging
 valuesFile: grafana-helm-values.yaml

--- a/components/vector-kubearchive-log-collector/development/loki-helm-generator.yaml
+++ b/components/vector-kubearchive-log-collector/development/loki-helm-generator.yaml
@@ -5,6 +5,6 @@ metadata:
 name: loki
 repo: https://grafana.github.io/helm-charts
 version: 6.30.1
-releaseName: vector-kubearchive-log-collector
+releaseName: loki
 namespace: product-kubearchive-logging
 valuesFile: loki-helm-values.yaml

--- a/components/vector-kubearchive-log-collector/development/vector-helm-generator.yaml
+++ b/components/vector-kubearchive-log-collector/development/vector-helm-generator.yaml
@@ -5,7 +5,7 @@ metadata:
 name: vector
 repo: https://helm.vector.dev
 version: 0.43.0
-releaseName: vector-kubearchive-log-collector
+releaseName: vector
 namespace: product-kubearchive-logging
 valuesFile: vector-helm-values.yaml
 

--- a/components/vector-kubearchive-log-collector/staging/stone-stg-rh01/grafana-helm-generator.yaml
+++ b/components/vector-kubearchive-log-collector/staging/stone-stg-rh01/grafana-helm-generator.yaml
@@ -5,6 +5,6 @@ metadata:
 name: grafana
 repo: https://grafana.github.io/helm-charts
 version: 9.2.6
-releaseName: vector-kubearchive-log-collector
+releaseName: grafana
 namespace: product-kubearchive-logging
 valuesFile: grafana-helm-values.yaml

--- a/components/vector-kubearchive-log-collector/staging/stone-stg-rh01/loki-helm-generator.yaml
+++ b/components/vector-kubearchive-log-collector/staging/stone-stg-rh01/loki-helm-generator.yaml
@@ -5,6 +5,6 @@ metadata:
 name: loki
 repo: https://grafana.github.io/helm-charts
 version: 6.30.1
-releaseName: vector-kubearchive-log-collector
+releaseName: loki
 namespace: product-kubearchive-logging
 valuesFile: loki-helm-values.yaml

--- a/components/vector-kubearchive-log-collector/staging/stone-stg-rh01/vector-helm-generator.yaml
+++ b/components/vector-kubearchive-log-collector/staging/stone-stg-rh01/vector-helm-generator.yaml
@@ -5,6 +5,6 @@ metadata:
 name: vector
 repo: https://helm.vector.dev
 version: 0.43.0
-releaseName: vector-kubearchive-log-collector
+releaseName: vector
 namespace: product-kubearchive-logging
 valuesFile: vector-helm-values.yaml


### PR DESCRIPTION
This also solves the problem of reaching
max length allowed in pod naming (63 chars)