### PR TITLE
staging: use exclusion lists for resources

### DIFF
--- a/components/backup/staging/stone-stage-p01/backup-tenants-patch.yaml
+++ b/components/backup/staging/stone-stage-p01/backup-tenants-patch.yaml
@@ -1,0 +1,12 @@
+apiVersion: velero.io/v1
+kind: Schedule
+metadata:
+  name: backup-tenants
+  namespace: openshift-adp
+spec:
+  template:
+    includedResources: []
+    excludedResources:
+    - pipelineruns.tekton.dev
+    - taskruns.tekton.dev
+    - pods

--- a/components/backup/staging/stone-stage-p01/kustomization.yaml
+++ b/components/backup/staging/stone-stage-p01/kustomization.yaml
@@ -23,3 +23,9 @@ patches:
     kind: DataProtectionApplication
     name: velero-aws
     version: v1alpha1
+- path: backup-tenants-patch.yaml
+  target:
+    group: velero.io
+    kind: Schedule
+    name: backup-tenants
+    version: v1

--- a/components/backup/staging/stone-stage-p01/kustomization.yaml
+++ b/components/backup/staging/stone-stage-p01/kustomization.yaml
@@ -1,25 +1,25 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ../../base/all-clusters
-  - ../../base/host/schedules
-  - ../../base/member/schedules
+- ../../base/all-clusters
+- ../../base/host/schedules
+- ../../base/member/schedules
 patches:
-  - target:
-      group: external-secrets.io
-      version: v1beta1
-      kind: ExternalSecret
-      name: backup-s3-credentials
-    path: backup-s3-credentials-patch.yaml
-  - target:
-      group: oadp.openshift.io
-      version: v1alpha1
-      kind: DataProtectionApplication
-      name: velero-aws
-    path: dpa-bucket-patch.yaml
-  - target:
-      group: oadp.openshift.io
-      version: v1alpha1
-      kind: DataProtectionApplication
-      name: velero-aws
-    path: dpa-kmskeyid-patch.yaml
+- path: backup-s3-credentials-patch.yaml
+  target:
+    group: external-secrets.io
+    kind: ExternalSecret
+    name: backup-s3-credentials
+    version: v1beta1
+- path: dpa-bucket-patch.yaml
+  target:
+    group: oadp.openshift.io
+    kind: DataProtectionApplication
+    name: velero-aws
+    version: v1alpha1
+- path: dpa-kmskeyid-patch.yaml
+  target:
+    group: oadp.openshift.io
+    kind: DataProtectionApplication
+    name: velero-aws
+    version: v1alpha1

--- a/components/backup/staging/stone-stg-rh01/backup-tenants-patch.yaml
+++ b/components/backup/staging/stone-stg-rh01/backup-tenants-patch.yaml
@@ -1,0 +1,12 @@
+apiVersion: velero.io/v1
+kind: Schedule
+metadata:
+  name: backup-tenants
+  namespace: openshift-adp
+spec:
+  template:
+    includedResources: []
+    excludedResources:
+    - pipelineruns.tekton.dev
+    - taskruns.tekton.dev
+    - pods

--- a/components/backup/staging/stone-stg-rh01/kustomization.yaml
+++ b/components/backup/staging/stone-stg-rh01/kustomization.yaml
@@ -1,30 +1,30 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ../../base/member
-  - image-repository-resource-modifier.yaml
+- ../../base/member
+- image-repository-resource-modifier.yaml
 patches:
-  - target:
-      group: external-secrets.io
-      version: v1beta1
-      kind: ExternalSecret
-      name: backup-s3-credentials
-    path: backup-s3-credentials-patch.yaml
-  - target:
-      group: oadp.openshift.io
-      version: v1alpha1
-      kind: DataProtectionApplication
-      name: velero-aws
-    path: dpa-bucket-patch.yaml
-  - target:
-      group: oadp.openshift.io
-      version: v1alpha1
-      kind: DataProtectionApplication
-      name: velero-aws
-    path: dpa-kmskeyid-patch.yaml
-  - target:
-      group: oadp.openshift.io
-      version: v1alpha1
-      kind: DataProtectionApplication
-      name: velero-aws
-    path: dpa-resource-modifier-patch.yaml
+- path: backup-s3-credentials-patch.yaml
+  target:
+    group: external-secrets.io
+    kind: ExternalSecret
+    name: backup-s3-credentials
+    version: v1beta1
+- path: dpa-bucket-patch.yaml
+  target:
+    group: oadp.openshift.io
+    kind: DataProtectionApplication
+    name: velero-aws
+    version: v1alpha1
+- path: dpa-kmskeyid-patch.yaml
+  target:
+    group: oadp.openshift.io
+    kind: DataProtectionApplication
+    name: velero-aws
+    version: v1alpha1
+- path: dpa-resource-modifier-patch.yaml
+  target:
+    group: oadp.openshift.io
+    kind: DataProtectionApplication
+    name: velero-aws
+    version: v1alpha1

--- a/components/backup/staging/stone-stg-rh01/kustomization.yaml
+++ b/components/backup/staging/stone-stg-rh01/kustomization.yaml
@@ -28,3 +28,9 @@ patches:
     kind: DataProtectionApplication
     name: velero-aws
     version: v1alpha1
+- path: backup-tenants-patch.yaml
+  target:
+    group: velero.io
+    kind: Schedule
+    version: v1
+    name: backup-tenants


### PR DESCRIPTION
Rather than only including a select few resources in our tenant backups, let's include everything and filter out the resources we don't want.  For now, that means excluding pipelineruns, taskruns, and pods.

The first commit (c569e94) is a formatting change so that the kustomization manifests play better with `kustomize edit`.

The second commit (2f321be) adds patches to implement this on the staging clusters.  Until we're confident in this change and have validated that it works, hold off on rolling this out to the production clusters.