### PR TITLE
Updating the kubearchive-logging CM

### DIFF
--- a/components/kubearchive/staging/base/kustomization.yaml
+++ b/components/kubearchive/staging/base/kustomization.yaml
@@ -16,7 +16,7 @@ patches:
         POD_ID: "cel:metadata.uid"
         START: "cel:status.?startTime == optional.none() ? int(now()-duration('1h'))*1000000000: status.startTime"
         END: "cel:status.?startTime == optional.none() ? int(now()+duration('1h'))*1000000000: int(timestamp(status.startTime)+duration('6h'))*1000000000" # temporary workaround until CONTAINER_NAME is allowed on CEL expressions as variable: 6 hours since the container started
-        LOG_URL: "http://loki-headless.product-kubearchive-logging.svc.cluster.local:3100/loki/api/v1/query_range?query=%7Bpod_id%3D%22{POD_ID}%22%2C%20container%3D%22{CONTAINER_NAME}%22%7D%20%7C%20json%20%7C%20line_format%20%22%7B%7B.message%7D%7D%22&start={START}&end={END}&direction=forward"
+        LOG_URL: "http://loki-gateway.product-kubearchive-logging.svc.cluster.local:80/loki/api/v1/query_range?query=%7Bpod_id%3D%22{POD_ID}%22%2C%20container%3D%22{CONTAINER_NAME}%22%7D&start={START}&end={END}&direction=forward"
         LOG_URL_JSONPATH: "$.data.result[*].values[*][1]"
   - patch: |-
       $patch: delete


### PR DESCRIPTION
The loki endpoint is different now in distributed mode and we also use plain text instead of json so the query is changed too