### PR TITLE
Add o11y team members

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -23,3 +23,6 @@ approvers:
 - arewm
 - psturc
 - ralphbean
+- kubasikus
+- pacho-rh
+- mftb


### PR DESCRIPTION
Allow o11y to approve changes related to their service ApplicationSets, which are located outside of the component folders.