### PR TITLE
Allow up to 250 VMs of each AWS type

### DIFF
--- a/components/kueue/production/stone-prod-p02/queue-config/cluster-queue.yaml
+++ b/components/kueue/production/stone-prod-p02/queue-config/cluster-queue.yaml
@@ -48,37 +48,37 @@ spec:
     - name: platform-group-1
       resources:
       - name: linux-amd64
-        nominalQuota: '15'
+        nominalQuota: '250'
       - name: linux-arm64
-        nominalQuota: '50'
+        nominalQuota: '250'
       - name: linux-c2xlarge-amd64
-        nominalQuota: '5'
+        nominalQuota: '250'
       - name: linux-c2xlarge-arm64
-        nominalQuota: '5'
+        nominalQuota: '250'
       - name: linux-c4xlarge-amd64
-        nominalQuota: '5'
+        nominalQuota: '250'
       - name: linux-c4xlarge-arm64
-        nominalQuota: '5'
+        nominalQuota: '250'
       - name: linux-c6gd2xlarge-arm64
-        nominalQuota: '5'
+        nominalQuota: '250'
       - name: linux-c8xlarge-amd64
-        nominalQuota: '5'
+        nominalQuota: '250'
       - name: linux-c8xlarge-arm64
-        nominalQuota: '5'
+        nominalQuota: '250'
       - name: linux-cxlarge-amd64
-        nominalQuota: '5'
+        nominalQuota: '250'
       - name: linux-cxlarge-arm64
-        nominalQuota: '5'
+        nominalQuota: '250'
       - name: linux-d160-m2xlarge-amd64
-        nominalQuota: '10'
+        nominalQuota: '250'
       - name: linux-d160-m2xlarge-arm64
-        nominalQuota: '10'
+        nominalQuota: '250'
       - name: linux-d160-m4xlarge-amd64
-        nominalQuota: '10'
+        nominalQuota: '250'
       - name: linux-d160-m4xlarge-arm64
-        nominalQuota: '10'
+        nominalQuota: '250'
       - name: linux-d160-m8xlarge-amd64
-        nominalQuota: '5'
+        nominalQuota: '250'
   - coveredResources:
     - linux-d160-m8xlarge-arm64
     - linux-extra-fast-amd64
@@ -100,37 +100,37 @@ spec:
     - name: platform-group-2
       resources:
       - name: linux-d160-m8xlarge-arm64
-        nominalQuota: '5'
+        nominalQuota: '250'
       - name: linux-extra-fast-amd64
-        nominalQuota: '20'
+        nominalQuota: '250'
       - name: linux-fast-amd64
-        nominalQuota: '5'
+        nominalQuota: '250'
       - name: linux-g6xlarge-amd64
-        nominalQuota: '5'
+        nominalQuota: '250'
       - name: linux-m2xlarge-amd64
-        nominalQuota: '5'
+        nominalQuota: '250'
       - name: linux-m2xlarge-arm64
-        nominalQuota: '5'
+        nominalQuota: '250'
       - name: linux-m4xlarge-amd64
-        nominalQuota: '5'
+        nominalQuota: '250'
       - name: linux-m4xlarge-arm64
-        nominalQuota: '5'
+        nominalQuota: '250'
       - name: linux-m8xlarge-amd64
-        nominalQuota: '5'
+        nominalQuota: '250'
       - name: linux-m8xlarge-arm64
-        nominalQuota: '5'
+        nominalQuota: '250'
       - name: linux-mlarge-amd64
-        nominalQuota: '5'
+        nominalQuota: '250'
       - name: linux-mlarge-arm64
-        nominalQuota: '5'
+        nominalQuota: '250'
       - name: linux-mxlarge-amd64
-        nominalQuota: '5'
+        nominalQuota: '250'
       - name: linux-mxlarge-arm64
-        nominalQuota: '5'
+        nominalQuota: '250'
       - name: linux-ppc64le
         nominalQuota: '40'
       - name: linux-root-amd64
-        nominalQuota: '5'
+        nominalQuota: '250'
   - coveredResources:
     - linux-root-arm64
     - linux-s390x
@@ -141,7 +141,7 @@ spec:
     - name: platform-group-3
       resources:
       - name: linux-root-arm64
-        nominalQuota: '5'
+        nominalQuota: '250'
       - name: linux-s390x
         nominalQuota: '40'
       - name: linux-x86-64

--- a/components/multi-platform-controller/production-downstream/stone-prod-p02/host-config.yaml
+++ b/components/multi-platform-controller/production-downstream/stone-prod-p02/host-config.yaml
@@ -66,7 +66,7 @@ data:
   dynamic.linux-arm64.aws-secret: aws-account
   dynamic.linux-arm64.ssh-secret: aws-ssh-key
   dynamic.linux-arm64.security-group-id: sg-0903aedd465be979e
-  dynamic.linux-arm64.max-instances: "50"
+  dynamic.linux-arm64.max-instances: "250"
   dynamic.linux-arm64.subnet-id: subnet-02c476f8d2a4ae05e
   dynamic.linux-arm64.allocation-timeout: "1200"
 
@@ -79,7 +79,7 @@ data:
   dynamic.linux-mlarge-arm64.aws-secret: aws-account
   dynamic.linux-mlarge-arm64.ssh-secret: aws-ssh-key
   dynamic.linux-mlarge-arm64.security-group-id: sg-0903aedd465be979e
-  dynamic.linux-mlarge-arm64.max-instances: "5"
+  dynamic.linux-mlarge-arm64.max-instances: "250"
   dynamic.linux-mlarge-arm64.subnet-id: subnet-02c476f8d2a4ae05e
   dynamic.linux-mlarge-arm64.allocation-timeout: "1200"
 
@@ -92,7 +92,7 @@ data:
   dynamic.linux-mxlarge-arm64.aws-secret: aws-account
   dynamic.linux-mxlarge-arm64.ssh-secret: aws-ssh-key
   dynamic.linux-mxlarge-arm64.security-group-id: sg-0903aedd465be979e
-  dynamic.linux-mxlarge-arm64.max-instances: "5"
+  dynamic.linux-mxlarge-arm64.max-instances: "250"
   dynamic.linux-mxlarge-arm64.subnet-id: subnet-02c476f8d2a4ae05e
   dynamic.linux-mxlarge-arm64.allocation-timeout: "1200"
 
@@ -105,7 +105,7 @@ data:
   dynamic.linux-m2xlarge-arm64.aws-secret: aws-account
   dynamic.linux-m2xlarge-arm64.ssh-secret: aws-ssh-key
   dynamic.linux-m2xlarge-arm64.security-group-id: sg-0903aedd465be979e
-  dynamic.linux-m2xlarge-arm64.max-instances: "5"
+  dynamic.linux-m2xlarge-arm64.max-instances: "250"
   dynamic.linux-m2xlarge-arm64.subnet-id: subnet-02c476f8d2a4ae05e
   dynamic.linux-m2xlarge-arm64.allocation-timeout: "1200"
 
@@ -118,7 +118,7 @@ data:
   dynamic.linux-d160-m2xlarge-arm64.aws-secret: aws-account
   dynamic.linux-d160-m2xlarge-arm64.ssh-secret: aws-ssh-key
   dynamic.linux-d160-m2xlarge-arm64.security-group-id: sg-0903aedd465be979e
-  dynamic.linux-d160-m2xlarge-arm64.max-instances: "10"
+  dynamic.linux-d160-m2xlarge-arm64.max-instances: "250"
   dynamic.linux-d160-m2xlarge-arm64.subnet-id: subnet-02c476f8d2a4ae05e
   dynamic.linux-d160-m2xlarge-arm64.allocation-timeout: "1200"
   dynamic.linux-d160-m2xlarge-arm64.disk: "160"
@@ -132,7 +132,7 @@ data:
   dynamic.linux-m4xlarge-arm64.aws-secret: aws-account
   dynamic.linux-m4xlarge-arm64.ssh-secret: aws-ssh-key
   dynamic.linux-m4xlarge-arm64.security-group-id: sg-0903aedd465be979e
-  dynamic.linux-m4xlarge-arm64.max-instances: "5"
+  dynamic.linux-m4xlarge-arm64.max-instances: "250"
   dynamic.linux-m4xlarge-arm64.subnet-id: subnet-02c476f8d2a4ae05e
   dynamic.linux-m4xlarge-arm64.allocation-timeout: "1200"
 
@@ -145,7 +145,7 @@ data:
   dynamic.linux-c6gd2xlarge-arm64.aws-secret: aws-account
   dynamic.linux-c6gd2xlarge-arm64.ssh-secret: aws-ssh-key
   dynamic.linux-c6gd2xlarge-arm64.security-group-id: sg-0903aedd465be979e
-  dynamic.linux-c6gd2xlarge-arm64.max-instances: "5"
+  dynamic.linux-c6gd2xlarge-arm64.max-instances: "250"
   dynamic.linux-c6gd2xlarge-arm64.subnet-id: subnet-02c476f8d2a4ae05e
   dynamic.linux-c6gd2xlarge-arm64.allocation-timeout: "1200"
   dynamic.linux-c6gd2xlarge-arm64.user-data: |-
@@ -223,7 +223,7 @@ data:
   dynamic.linux-d160-m4xlarge-arm64.aws-secret: aws-account
   dynamic.linux-d160-m4xlarge-arm64.ssh-secret: aws-ssh-key
   dynamic.linux-d160-m4xlarge-arm64.security-group-id: sg-0903aedd465be979e
-  dynamic.linux-d160-m4xlarge-arm64.max-instances: "10"
+  dynamic.linux-d160-m4xlarge-arm64.max-instances: "250"
   dynamic.linux-d160-m4xlarge-arm64.subnet-id: subnet-02c476f8d2a4ae05e
   dynamic.linux-d160-m4xlarge-arm64.allocation-timeout: "1200"
   dynamic.linux-d160-m4xlarge-arm64.disk: "160"
@@ -237,7 +237,7 @@ data:
   dynamic.linux-m8xlarge-arm64.aws-secret: aws-account
   dynamic.linux-m8xlarge-arm64.ssh-secret: aws-ssh-key
   dynamic.linux-m8xlarge-arm64.security-group-id: sg-0903aedd465be979e
-  dynamic.linux-m8xlarge-arm64.max-instances: "5"
+  dynamic.linux-m8xlarge-arm64.max-instances: "250"
   dynamic.linux-m8xlarge-arm64.subnet-id: subnet-02c476f8d2a4ae05e
   dynamic.linux-m8xlarge-arm64.allocation-timeout: "1200"
 
@@ -250,7 +250,7 @@ data:
   dynamic.linux-d160-m8xlarge-arm64.aws-secret: aws-account
   dynamic.linux-d160-m8xlarge-arm64.ssh-secret: aws-ssh-key
   dynamic.linux-d160-m8xlarge-arm64.security-group-id: sg-0903aedd465be979e
-  dynamic.linux-d160-m8xlarge-arm64.max-instances: "5"
+  dynamic.linux-d160-m8xlarge-arm64.max-instances: "250"
   dynamic.linux-d160-m8xlarge-arm64.subnet-id: subnet-02c476f8d2a4ae05e
   dynamic.linux-d160-m8xlarge-arm64.allocation-timeout: "1200"
   dynamic.linux-d160-m8xlarge-arm64.disk: "160"
@@ -264,7 +264,7 @@ data:
   dynamic.linux-amd64.aws-secret: aws-account
   dynamic.linux-amd64.ssh-secret: aws-ssh-key
   dynamic.linux-amd64.security-group-id: sg-0903aedd465be979e
-  dynamic.linux-amd64.max-instances: "15"
+  dynamic.linux-amd64.max-instances: "250"
   dynamic.linux-amd64.subnet-id: subnet-02c476f8d2a4ae05e
   dynamic.linux-amd64.allocation-timeout: "1200"
 
@@ -277,7 +277,7 @@ data:
   dynamic.linux-mlarge-amd64.aws-secret: aws-account
   dynamic.linux-mlarge-amd64.ssh-secret: aws-ssh-key
   dynamic.linux-mlarge-amd64.security-group-id: sg-0903aedd465be979e
-  dynamic.linux-mlarge-amd64.max-instances: "5"
+  dynamic.linux-mlarge-amd64.max-instances: "250"
   dynamic.linux-mlarge-amd64.subnet-id: subnet-02c476f8d2a4ae05e
   dynamic.linux-mlarge-amd64.allocation-timeout: "1200"
 
@@ -290,7 +290,7 @@ data:
   dynamic.linux-mxlarge-amd64.aws-secret: aws-account
   dynamic.linux-mxlarge-amd64.ssh-secret: aws-ssh-key
   dynamic.linux-mxlarge-amd64.security-group-id: sg-0903aedd465be979e
-  dynamic.linux-mxlarge-amd64.max-instances: "5"
+  dynamic.linux-mxlarge-amd64.max-instances: "250"
   dynamic.linux-mxlarge-amd64.subnet-id: subnet-02c476f8d2a4ae05e
   dynamic.linux-mxlarge-amd64.allocation-timeout: "1200"
 
@@ -303,7 +303,7 @@ data:
   dynamic.linux-m2xlarge-amd64.aws-secret: aws-account
   dynamic.linux-m2xlarge-amd64.ssh-secret: aws-ssh-key
   dynamic.linux-m2xlarge-amd64.security-group-id: sg-0903aedd465be979e
-  dynamic.linux-m2xlarge-amd64.max-instances: "5"
+  dynamic.linux-m2xlarge-amd64.max-instances: "250"
   dynamic.linux-m2xlarge-amd64.subnet-id: subnet-02c476f8d2a4ae05e
   dynamic.linux-m2xlarge-amd64.allocation-timeout: "1200"
 
@@ -316,7 +316,7 @@ data:
   dynamic.linux-d160-m2xlarge-amd64.aws-secret: aws-account
   dynamic.linux-d160-m2xlarge-amd64.ssh-secret: aws-ssh-key
   dynamic.linux-d160-m2xlarge-amd64.security-group-id: sg-0903aedd465be979e
-  dynamic.linux-d160-m2xlarge-amd64.max-instances: "10"
+  dynamic.linux-d160-m2xlarge-amd64.max-instances: "250"
   dynamic.linux-d160-m2xlarge-amd64.subnet-id: subnet-02c476f8d2a4ae05e
   dynamic.linux-d160-m2xlarge-amd64.allocation-timeout: "1200"
   dynamic.linux-d160-m2xlarge-amd64.disk: "160"
@@ -330,7 +330,7 @@ data:
   dynamic.linux-m4xlarge-amd64.aws-secret: aws-account
   dynamic.linux-m4xlarge-amd64.ssh-secret: aws-ssh-key
   dynamic.linux-m4xlarge-amd64.security-group-id: sg-0903aedd465be979e
-  dynamic.linux-m4xlarge-amd64.max-instances: "5"
+  dynamic.linux-m4xlarge-amd64.max-instances: "250"
   dynamic.linux-m4xlarge-amd64.subnet-id: subnet-02c476f8d2a4ae05e
   dynamic.linux-m4xlarge-amd64.allocation-timeout: "1200"
 
@@ -344,7 +344,7 @@ data:
   dynamic.linux-d160-m4xlarge-amd64.aws-secret: aws-account
   dynamic.linux-d160-m4xlarge-amd64.ssh-secret: aws-ssh-key
   dynamic.linux-d160-m4xlarge-amd64.security-group-id: sg-0903aedd465be979e
-  dynamic.linux-d160-m4xlarge-amd64.max-instances: "10"
+  dynamic.linux-d160-m4xlarge-amd64.max-instances: "250"
   dynamic.linux-d160-m4xlarge-amd64.subnet-id: subnet-02c476f8d2a4ae05e
   dynamic.linux-d160-m4xlarge-amd64.allocation-timeout: "1200"
   dynamic.linux-d160-m4xlarge-amd64.disk: "160"
@@ -358,7 +358,7 @@ data:
   dynamic.linux-m8xlarge-amd64.aws-secret: aws-account
   dynamic.linux-m8xlarge-amd64.ssh-secret: aws-ssh-key
   dynamic.linux-m8xlarge-amd64.security-group-id: sg-0903aedd465be979e
-  dynamic.linux-m8xlarge-amd64.max-instances: "5"
+  dynamic.linux-m8xlarge-amd64.max-instances: "250"
   dynamic.linux-m8xlarge-amd64.subnet-id: subnet-02c476f8d2a4ae05e
   dynamic.linux-m8xlarge-amd64.allocation-timeout: "1200"
 
@@ -371,7 +371,7 @@ data:
   dynamic.linux-d160-m8xlarge-amd64.aws-secret: aws-account
   dynamic.linux-d160-m8xlarge-amd64.ssh-secret: aws-ssh-key
   dynamic.linux-d160-m8xlarge-amd64.security-group-id: sg-0903aedd465be979e
-  dynamic.linux-d160-m8xlarge-amd64.max-instances: "5"
+  dynamic.linux-d160-m8xlarge-amd64.max-instances: "250"
   dynamic.linux-d160-m8xlarge-amd64.subnet-id: subnet-02c476f8d2a4ae05e
   dynamic.linux-d160-m8xlarge-amd64.allocation-timeout: "1200"
   dynamic.linux-d160-m8xlarge-amd64.disk: "160"
@@ -386,7 +386,7 @@ data:
   dynamic.linux-fast-amd64.ssh-secret: aws-ssh-key
   dynamic.linux-fast-amd64.security-group-id: sg-0903aedd465be979e
   dynamic.linux-fast-amd64.subnet-id: subnet-02c476f8d2a4ae05e
-  dynamic.linux-fast-amd64.max-instances: "5"
+  dynamic.linux-fast-amd64.max-instances: "250"
   dynamic.linux-fast-amd64.disk: "200"
 
   dynamic.linux-extra-fast-amd64.type: aws
@@ -399,7 +399,7 @@ data:
   dynamic.linux-extra-fast-amd64.ssh-secret: aws-ssh-key
   dynamic.linux-extra-fast-amd64.security-group-id: sg-0903aedd465be979e
   dynamic.linux-extra-fast-amd64.subnet-id: subnet-02c476f8d2a4ae05e
-  dynamic.linux-extra-fast-amd64.max-instances: "20"
+  dynamic.linux-extra-fast-amd64.max-instances: "250"
   dynamic.linux-extra-fast-amd64.disk: "200"
 
   # cpu:memory (1:2)
@@ -412,7 +412,7 @@ data:
   dynamic.linux-cxlarge-arm64.aws-secret: aws-account
   dynamic.linux-cxlarge-arm64.ssh-secret: aws-ssh-key
   dynamic.linux-cxlarge-arm64.security-group-id: sg-0903aedd465be979e
-  dynamic.linux-cxlarge-arm64.max-instances: "5"
+  dynamic.linux-cxlarge-arm64.max-instances: "250"
   dynamic.linux-cxlarge-arm64.subnet-id: subnet-02c476f8d2a4ae05e
   dynamic.linux-cxlarge-arm64.allocation-timeout: "1200"
 
@@ -425,7 +425,7 @@ data:
   dynamic.linux-c2xlarge-arm64.aws-secret: aws-account
   dynamic.linux-c2xlarge-arm64.ssh-secret: aws-ssh-key
   dynamic.linux-c2xlarge-arm64.security-group-id: sg-0903aedd465be979e
-  dynamic.linux-c2xlarge-arm64.max-instances: "5"
+  dynamic.linux-c2xlarge-arm64.max-instances: "250"
   dynamic.linux-c2xlarge-arm64.subnet-id: subnet-02c476f8d2a4ae05e
   dynamic.linux-c2xlarge-arm64.allocation-timeout: "1200"
 
@@ -438,7 +438,7 @@ data:
   dynamic.linux-c4xlarge-arm64.aws-secret: aws-account
   dynamic.linux-c4xlarge-arm64.ssh-secret: aws-ssh-key
   dynamic.linux-c4xlarge-arm64.security-group-id: sg-0903aedd465be979e
-  dynamic.linux-c4xlarge-arm64.max-instances: "5"
+  dynamic.linux-c4xlarge-arm64.max-instances: "250"
   dynamic.linux-c4xlarge-arm64.subnet-id: subnet-02c476f8d2a4ae05e
   dynamic.linux-c4xlarge-arm64.allocation-timeout: "1200"
 
@@ -451,7 +451,7 @@ data:
   dynamic.linux-c8xlarge-arm64.aws-secret: aws-account
   dynamic.linux-c8xlarge-arm64.ssh-secret: aws-ssh-key
   dynamic.linux-c8xlarge-arm64.security-group-id: sg-0903aedd465be979e
-  dynamic.linux-c8xlarge-arm64.max-instances: "5"
+  dynamic.linux-c8xlarge-arm64.max-instances: "250"
   dynamic.linux-c8xlarge-arm64.subnet-id: subnet-02c476f8d2a4ae05e
   dynamic.linux-c8xlarge-arm64.allocation-timeout: "1200"
 
@@ -464,7 +464,7 @@ data:
   dynamic.linux-cxlarge-amd64.aws-secret: aws-account
   dynamic.linux-cxlarge-amd64.ssh-secret: aws-ssh-key
   dynamic.linux-cxlarge-amd64.security-group-id: sg-0903aedd465be979e
-  dynamic.linux-cxlarge-amd64.max-instances: "5"
+  dynamic.linux-cxlarge-amd64.max-instances: "250"
   dynamic.linux-cxlarge-amd64.subnet-id: subnet-02c476f8d2a4ae05e
   dynamic.linux-cxlarge-amd64.allocation-timeout: "1200"
 
@@ -477,7 +477,7 @@ data:
   dynamic.linux-c2xlarge-amd64.aws-secret: aws-account
   dynamic.linux-c2xlarge-amd64.ssh-secret: aws-ssh-key
   dynamic.linux-c2xlarge-amd64.security-group-id: sg-0903aedd465be979e
-  dynamic.linux-c2xlarge-amd64.max-instances: "5"
+  dynamic.linux-c2xlarge-amd64.max-instances: "250"
   dynamic.linux-c2xlarge-amd64.subnet-id: subnet-02c476f8d2a4ae05e
   dynamic.linux-c2xlarge-amd64.allocation-timeout: "1200"
 
@@ -490,7 +490,7 @@ data:
   dynamic.linux-c4xlarge-amd64.aws-secret: aws-account
   dynamic.linux-c4xlarge-amd64.ssh-secret: aws-ssh-key
   dynamic.linux-c4xlarge-amd64.security-group-id: sg-0903aedd465be979e
-  dynamic.linux-c4xlarge-amd64.max-instances: "5"
+  dynamic.linux-c4xlarge-amd64.max-instances: "250"
   dynamic.linux-c4xlarge-amd64.subnet-id: subnet-02c476f8d2a4ae05e
   dynamic.linux-c4xlarge-amd64.allocation-timeout: "1200"
 
@@ -503,7 +503,7 @@ data:
   dynamic.linux-c8xlarge-amd64.aws-secret: aws-account
   dynamic.linux-c8xlarge-amd64.ssh-secret: aws-ssh-key
   dynamic.linux-c8xlarge-amd64.security-group-id: sg-0903aedd465be979e
-  dynamic.linux-c8xlarge-amd64.max-instances: "5"
+  dynamic.linux-c8xlarge-amd64.max-instances: "250"
   dynamic.linux-c8xlarge-amd64.subnet-id: subnet-02c476f8d2a4ae05e
   dynamic.linux-c8xlarge-amd64.allocation-timeout: "1200"
 
@@ -517,7 +517,7 @@ data:
   dynamic.linux-root-arm64.ssh-secret: aws-ssh-key
   dynamic.linux-root-arm64.security-group-id: sg-0903aedd465be979e
   dynamic.linux-root-arm64.subnet-id: subnet-02c476f8d2a4ae05e
-  dynamic.linux-root-arm64.max-instances: "5"
+  dynamic.linux-root-arm64.max-instances: "250"
   dynamic.linux-root-arm64.sudo-commands: "/usr/bin/podman, /usr/bin/rm /usr/share/containers/mounts.conf"
   dynamic.linux-root-arm64.disk: "200"
   dynamic.linux-root-arm64.iops: "16000"
@@ -533,7 +533,7 @@ data:
   dynamic.linux-root-amd64.ssh-secret: aws-ssh-key
   dynamic.linux-root-amd64.security-group-id: sg-0903aedd465be979e
   dynamic.linux-root-amd64.subnet-id: subnet-02c476f8d2a4ae05e
-  dynamic.linux-root-amd64.max-instances: "5"
+  dynamic.linux-root-amd64.max-instances: "250"
   dynamic.linux-root-amd64.sudo-commands: "/usr/bin/podman, /usr/bin/rm /usr/share/containers/mounts.conf"
   dynamic.linux-root-amd64.user-data: |-
     Content-Type: multipart/mixed; boundary="//"
@@ -702,7 +702,7 @@ data:
   dynamic.linux-g6xlarge-amd64.ssh-secret: aws-ssh-key
   dynamic.linux-g6xlarge-amd64.security-group-id: sg-0903aedd465be979e
   dynamic.linux-g6xlarge-amd64.subnet-id: subnet-02c476f8d2a4ae05e
-  dynamic.linux-g6xlarge-amd64.max-instances: "5"
+  dynamic.linux-g6xlarge-amd64.max-instances: "250"
   dynamic.linux-g6xlarge-amd64.allocation-timeout: "1200"
   dynamic.linux-g6xlarge-amd64.instance-tag: prod-amd64-g6xlarge
   dynamic.linux-g6xlarge-amd64.user-data: |-


### PR DESCRIPTION
The reason we reduced number of VMs was for the sum of them all to not exceed 250, which is the number of IPs we have on AWS side for MPC VMs.

The problem is this is artificially creating queues and user build are stuck in pending stated for up to hours sometime. We are working on a change to have a resource queue to make sure we do not create more than 250 VMs at the time otherwise we will get into provisioning issue because of lack of IPs.

We were supposed to land resource queue counting IPs before allowing MPC to create more VMs but the problem of long waiting time in the queue is worse than original problem being solved. For that reason, allow right away MPC to create up to 250 VMs of each type to unblock users and ip queue change will follow soon after.

Do the change on p02 first, other clusters will be change in another change.