### PR TITLE
info: add banner for planned cluster upgrades

### DIFF
--- a/components/konflux-info/production/kflux-prd-rh03/banner-content.yaml
+++ b/components/konflux-info/production/kflux-prd-rh03/banner-content.yaml
@@ -1,2 +1,11 @@
 - type: info
   summary: ✨ Hope you're having a great day. If you need a little whimsy, check out [this wonderful thing](https://videos.learning.redhat.com/media/A+whole+new+build/1_v9l8cton) shared by the ART team.
+- type: info
+  summary: "This cluster will be undergoing maintenance on **Thursday, September 4th at 13:00 UTC**.  The cluster will remain usable during this mainenance period."
+- type: info
+  summary: "🚨 This cluster is currently undergoing maintenance until 15:00 UTC and will remain usable during this mainenance period. 🚨"
+  startTime: "13:00"
+  endTime: "15:00"
+  year: 2025
+  month: 9
+  dayOfMonth: 4

--- a/components/konflux-info/production/stone-prd-rh01/banner-content.yaml
+++ b/components/konflux-info/production/stone-prd-rh01/banner-content.yaml
@@ -1,2 +1,11 @@
 - type: info
   summary: ✨ Hope you're having a great day. If you need a little whimsy, check out [this wonderful thing](https://videos.learning.redhat.com/media/A+whole+new+build/1_v9l8cton) shared by the ART team.
+- type: info
+  summary: "This cluster will be undergoing maintenance on **Thursday, September 4th at 13:00 UTC**.  The cluster will remain usable during this mainenance period."
+- type: info
+  summary: "🚨 This cluster is currently undergoing maintenance until 15:00 UTC and will remain usable during this mainenance period. 🚨"
+  startTime: "13:00"
+  endTime: "15:00"
+  year: 2025
+  month: 9
+  dayOfMonth: 4

--- a/components/konflux-info/production/stone-prod-p01/banner-content.yaml
+++ b/components/konflux-info/production/stone-prod-p01/banner-content.yaml
@@ -1,2 +1,11 @@
 - type: info
   summary: ✨ Hope you're having a great day. If you need a little whimsy, check out [this wonderful thing](https://videos.learning.redhat.com/media/A+whole+new+build/1_v9l8cton) shared by the ART team.
+- type: info
+  summary: "This cluster will be undergoing maintenance on **Thursday, September 4th at 13:00 UTC**.  The cluster will remain usable during this mainenance period."
+- type: info
+  summary: "🚨 This cluster is currently undergoing maintenance until 15:00 UTC and will remain usable during this mainenance period. 🚨"
+  startTime: "13:00"
+  endTime: "15:00"
+  year: 2025
+  month: 9
+  dayOfMonth: 4

--- a/components/konflux-info/production/stone-prod-p02/banner-content.yaml
+++ b/components/konflux-info/production/stone-prod-p02/banner-content.yaml
@@ -9,3 +9,12 @@
 
 - type: info
   summary: ✨ Hope you're having a great day. If you need a little whimsy, check out [this wonderful thing](https://videos.learning.redhat.com/media/A+whole+new+build/1_v9l8cton) shared by the ART team.
+- type: info
+  summary: "This cluster will be undergoing maintenance on **Thursday, September 4th at 13:00 UTC**.  The cluster will remain usable during this mainenance period."
+- type: info
+  summary: "🚨 This cluster is currently undergoing maintenance until 15:00 UTC and will remain usable during this mainenance period. 🚨"
+  startTime: "13:00"
+  endTime: "15:00"
+  year: 2025
+  month: 9
+  dayOfMonth: 4


### PR DESCRIPTION
Planned maintenance will be occurring on Thursday, September 4th, at 13:00 UTC.  An email was sent notifying users, but we would like to make this maintenance period more visible.

Add a banner to the UI to make users aware of the upcoming maintenance, and schedule an additional banner for when the maintenance is occurring.