### PR TITLE
fix(RELEASE-1828): use time-based pruning to avoid PVC quota hits

### DIFF
--- a/components/pipeline-service/production/base/main-pipeline-service-configuration.yaml
+++ b/components/pipeline-service/production/base/main-pipeline-service-configuration.yaml
@@ -2004,7 +2004,7 @@ spec:
   profile: all
   pruner:
     disabled: false
-    keep-since: 240
+    keep-since: 80
     resources:
       - pipelinerun
     schedule: '*/30 * * * *'

--- a/components/pipeline-service/production/kflux-ocp-p01/deploy.yaml
+++ b/components/pipeline-service/production/kflux-ocp-p01/deploy.yaml
@@ -2469,7 +2469,7 @@ spec:
   profile: all
   pruner:
     disabled: false
-    keep-since: 240
+    keep-since: 80
     resources:
     - pipelinerun
     schedule: '*/30 * * * *'

--- a/components/pipeline-service/production/kflux-osp-p01/deploy.yaml
+++ b/components/pipeline-service/production/kflux-osp-p01/deploy.yaml
@@ -2484,7 +2484,7 @@ spec:
   profile: all
   pruner:
     disabled: false
-    keep-since: 240
+    keep-since: 80
     resources:
     - pipelinerun
     schedule: '*/30 * * * *'

--- a/components/pipeline-service/production/kflux-prd-rh02/deploy.yaml
+++ b/components/pipeline-service/production/kflux-prd-rh02/deploy.yaml
@@ -2500,7 +2500,7 @@ spec:
   profile: all
   pruner:
     disabled: false
-    keep-since: 240
+    keep-since: 80
     resources:
     - pipelinerun
     schedule: '*/30 * * * *'

--- a/components/pipeline-service/production/kflux-prd-rh03/deploy.yaml
+++ b/components/pipeline-service/production/kflux-prd-rh03/deploy.yaml
@@ -2500,7 +2500,7 @@ spec:
   profile: all
   pruner:
     disabled: false
-    keep-since: 240
+    keep-since: 80
     resources:
     - pipelinerun
     schedule: '*/30 * * * *'

--- a/components/pipeline-service/production/kflux-rhel-p01/deploy.yaml
+++ b/components/pipeline-service/production/kflux-rhel-p01/deploy.yaml
@@ -2500,7 +2500,7 @@ spec:
   profile: all
   pruner:
     disabled: false
-    keep-since: 240
+    keep-since: 80
     resources:
     - pipelinerun
     schedule: '*/30 * * * *'

--- a/components/pipeline-service/production/pentest-p01/deploy.yaml
+++ b/components/pipeline-service/production/pentest-p01/deploy.yaml
@@ -2480,7 +2480,7 @@ spec:
   profile: all
   pruner:
     disabled: false
-    keep-since: 240
+    keep-since: 80
     resources:
     - pipelinerun
     schedule: '*/30 * * * *'

--- a/components/pipeline-service/production/stone-prd-rh01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prd-rh01/deploy.yaml
@@ -2469,7 +2469,7 @@ spec:
   profile: all
   pruner:
     disabled: false
-    keep-since: 240
+    keep-since: 80
     resources:
     - pipelinerun
     schedule: '*/30 * * * *'

--- a/components/pipeline-service/production/stone-prod-p01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prod-p01/deploy.yaml
@@ -2469,7 +2469,7 @@ spec:
   profile: all
   pruner:
     disabled: false
-    keep-since: 240
+    keep-since: 80
     resources:
     - pipelinerun
     schedule: '*/30 * * * *'

--- a/components/pipeline-service/production/stone-prod-p02/deploy.yaml
+++ b/components/pipeline-service/production/stone-prod-p02/deploy.yaml
@@ -2469,7 +2469,7 @@ spec:
   profile: all
   pruner:
     disabled: false
-    keep-since: 240
+    keep-since: 80
     resources:
     - pipelinerun
     schedule: '*/30 * * * *'


### PR DESCRIPTION
Reduce Tekton pruner retention from 240m to 80m.
This should help prevent “Failed to create PVC for PR” by ensuring
cleanup happens before the 90-PVC quota is reached.

Each Release Service PR creates a PVC; the previous 240m window
has being causing PVC quoata to be hit.

Slack here: https://redhat-internal.slack.com/archives/C04F4NE15U1/p1757007973059989
