### PR TITLE
TEST COMMIT

### DIFF
--- a/components/monitoring/grafana/base/dashboards/performance/kustomization.yaml
+++ b/components/monitoring/grafana/base/dashboards/performance/kustomization.yaml
@@ -2,4 +2,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - https://github.com/redhat-appstudio/perfscale/grafana/?ref=5b189cfab2e132d8365be08d529f031f70dddbb5
+  - https://github.com/redhat-appstudio/perfscale/grafana/?ref=66a1c0209636bf815b0945cf45215c5d03ae4413


### PR DESCRIPTION
This commit reverts to older dashboards to check if the https://github.com/redhat-appstudio/infra-deployments/pull/7426 failures could be caused by issues with grafana dashboard definitions