### PR TITLE
fix invalid otel-collector config

### DIFF
--- a/components/tracing/otel-collector/staging/otel-collector-helm-values.yaml
+++ b/components/tracing/otel-collector/staging/otel-collector-helm-values.yaml
@@ -76,9 +76,10 @@ config:
         level: basic
         readers:
         - pull:
-            exporter: prometheus
-            host: 0.0.0.0
-            port: 8888
+            exporter:
+              prometheus:
+                host: 0.0.0.0
+                port: 8888
 
 # Configuration for ports
 ports:


### PR DESCRIPTION
exporter is a map, not a string. prometheus is also a map and port, host should be keys of that map.

I made this change based on the logs I was seeing the otel-collector pods and [this example from the otel helm charts repo](https://github.com/open-telemetry/opentelemetry-helm-charts/blob/main/charts/opentelemetry-collector/values.yaml#L176). My assumption is that we want the `- pulls` section, so the yaml just needed to follow the schema.

Feel free to close if this is not the correct path to take