### PR TITLE
fix(KFLUXSPRT-4896): increase pod requests/limits

### DIFF
--- a/components/release/base/cronjobs/remove-expired-releases.yaml
+++ b/components/release/base/cronjobs/remove-expired-releases.yaml
@@ -63,11 +63,11 @@ spec:
                   name: temp-directory
               resources:
                 limits:
-                  cpu: 200m
-                  memory: 1024Mi
+                  cpu: 1
+                  memory: 4096Mi
                 requests:
-                  cpu: 100m
-                  memory: 1024Mi
+                  cpu: 500m
+                  memory: 4096Mi
               securityContext:
                 allowPrivilegeEscalation: false
                 capabilities:


### PR DESCRIPTION
this PR increases the limits of the pod that deletes old releases from the namespaces