### PR TITLE
feat(KFLUXVNGD-469): add trust-manager to development and staging

### DIFF
--- a/argo-cd-apps/base/member/infra-deployments/kustomization.yaml
+++ b/argo-cd-apps/base/member/infra-deployments/kustomization.yaml
@@ -35,6 +35,7 @@ resources:
   - namespace-lister
   - pulp-access-controller
   - cert-manager
+  - trust-manager
   - kueue
   - policies
   - konflux-kite

--- a/argo-cd-apps/base/member/infra-deployments/trust-manager/kustomization.yaml
+++ b/argo-cd-apps/base/member/infra-deployments/trust-manager/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- trust-manager.yaml

--- a/argo-cd-apps/base/member/infra-deployments/trust-manager/trust-manager.yaml
+++ b/argo-cd-apps/base/member/infra-deployments/trust-manager/trust-manager.yaml
@@ -1,0 +1,44 @@
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: trust-manager
+spec:
+  generators:
+    - merge:
+        mergeKeys:
+          - nameNormalized
+        generators:
+          - clusters:
+              selector:
+                matchLabels:
+                  appstudio.redhat.com/member-cluster: "true"
+              values:
+                sourceRoot: components/trust-manager
+                environment: staging
+                clusterDir: ""
+          - list:
+              elements: []
+  template:
+    metadata:
+      name: trust-manager-{{nameNormalized}}
+    spec:
+      project: default
+      source:
+        path: '{{values.sourceRoot}}/{{values.environment}}/{{values.clusterDir}}'
+        repoURL: https://github.com/redhat-appstudio/infra-deployments.git
+        targetRevision: main
+      destination:
+        namespace: cert-manager
+        server: '{{server}}'
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: false
+        syncOptions:
+          - CreateNamespace=true
+        retry:
+          limit: -1
+          backoff:
+            duration: 10s
+            factor: 2
+            maxDuration: 3m

--- a/argo-cd-apps/overlays/development/kustomization.yaml
+++ b/argo-cd-apps/overlays/development/kustomization.yaml
@@ -229,3 +229,8 @@ patches:
       kind: ApplicationSet
       version: v1alpha1
       name: konflux-kite
+  - path: development-overlay-patch.yaml
+    target:
+      kind: ApplicationSet
+      version: v1alpha1
+      name: trust-manager

--- a/argo-cd-apps/overlays/konflux-public-production/delete-applications.yaml
+++ b/argo-cd-apps/overlays/konflux-public-production/delete-applications.yaml
@@ -24,4 +24,9 @@ kind: ApplicationSet
 metadata:
   name: vector-kubearchive-log-collector
 $patch: delete
-
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: trust-manager
+$patch: delete

--- a/argo-cd-apps/overlays/production-downstream/delete-applications.yaml
+++ b/argo-cd-apps/overlays/production-downstream/delete-applications.yaml
@@ -35,3 +35,9 @@ kind: ApplicationSet
 metadata:
   name: konflux-kite
 $patch: delete
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: trust-manager
+$patch: delete

--- a/components/trust-manager/OWNERS
+++ b/components/trust-manager/OWNERS
@@ -1,0 +1,8 @@
+# See the OWNERS docs: https://go.k8s.io/owners
+
+approvers:
+- ifireball
+- gbenhaim
+- amisstea
+- yftacherzog
+- avi-biton

--- a/components/trust-manager/development/kustomization.yaml
+++ b/components/trust-manager/development/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+generators:
+- trust-manager-helm-generator.yaml

--- a/components/trust-manager/development/trust-manager-helm-generator.yaml
+++ b/components/trust-manager/development/trust-manager-helm-generator.yaml
@@ -1,0 +1,25 @@
+apiVersion: builtin
+kind: HelmChartInflationGenerator
+metadata:
+  name: trust-manager
+name: trust-manager
+repo: https://charts.jetstack.io
+version: 0.19.0
+namespace: cert-manager
+releaseName: trust-manager
+valuesInline:
+  resources:
+    requests:
+      cpu: 25m
+      memory: 64Mi
+    limits:
+      cpu: 25m
+      memory: 64Mi
+  defaultPackage:
+    resources:
+      requests:
+        cpu: 25m
+        memory: 64Mi
+      limits:
+        cpu: 25m
+        memory: 64Mi

--- a/components/trust-manager/staging/kustomization.yaml
+++ b/components/trust-manager/staging/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+generators:
+- trust-manager-helm-generator.yaml

--- a/components/trust-manager/staging/trust-manager-helm-generator.yaml
+++ b/components/trust-manager/staging/trust-manager-helm-generator.yaml
@@ -1,0 +1,25 @@
+apiVersion: builtin
+kind: HelmChartInflationGenerator
+metadata:
+  name: trust-manager
+name: trust-manager
+repo: https://charts.jetstack.io
+version: 0.19.0
+namespace: cert-manager
+releaseName: trust-manager
+valuesInline:
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 100m
+      memory: 128Mi
+  defaultPackage:
+    resources:
+      requests:
+        cpu: 100m
+        memory: 128Mi
+      limits:
+        cpu: 100m
+        memory: 128Mi


### PR DESCRIPTION
Trust Manager is a Kubernetes controller that distributes trust bundles (X.509 certificate authority certificates) across namespaces and automatically updates them when they change. It's part of the cert-manager ecosystem and helps with certificate management in Kubernetes clusters.

Adding trust-manager to development and staging environments

- add trust-manager development overlays
- add trust-manager kustomization
- using HelmChartInflationGenerator to install trust-manager
- add trust-manager argocd application set
- Use the cert-manager namespace
- update resources requests and limits in staging following Gamini review
- Not using base directory for the trust-manager component as it fails in the CI:
`Error when running kustomize build for components/trust-manager/base: Error: Error: failed to untar: a file or directory with the name /home/runner/work/infra-deployments/infra-deployments/components/trust-manager/base/charts/trust-manager-0.19.0/trust-manager-v0.19.0.tgz already exists`

We get this error because the CI is building both components/trust-manager/base and components/trust-manager/staging in parallel, and both are trying to create the same charts directory. 