### PR TITLE
disable namespace-lister's group support in prod

### DIFF
--- a/components/namespace-lister/base/kustomization.yaml
+++ b/components/namespace-lister/base/kustomization.yaml
@@ -26,9 +26,12 @@ patches:
     kind: Deployment
     name: namespace-lister
     namespace: namespace-lister
-- path: ./patches/with_header_auth_groups.yaml
-  target:
-    group: apps
-    kind: Deployment
-    name: namespace-lister
-    namespace: namespace-lister
+# uncomment this line to add support for groups forwarded through
+# a custom header
+#
+# - path: ./patches/with_header_auth_groups.yaml
+#   target:
+#     group: apps
+#     kind: Deployment
+#     name: namespace-lister
+#     namespace: namespace-lister

--- a/components/namespace-lister/production/base/kustomization.yaml
+++ b/components/namespace-lister/production/base/kustomization.yaml
@@ -26,9 +26,12 @@ patches:
     kind: Deployment
     name: namespace-lister
     namespace: namespace-lister
-- path: ./patches/with_header_auth_groups.yaml
-  target:
-    group: apps
-    kind: Deployment
-    name: namespace-lister
-    namespace: namespace-lister
+# uncomment this line to add support for groups forwarded through
+# a custom header
+#
+# - path: ./patches/with_header_auth_groups.yaml
+#   target:
+#     group: apps
+#     kind: Deployment
+#     name: namespace-lister
+#     namespace: namespace-lister


### PR DESCRIPTION
Requires:
* #7924

We don't want to return the list of all namespaces shared with the `system:authenticated` group (the only group supported nowadays).

We just want to show the list of namespaces directly shared with the user.

