### PR TITLE
sandbox: remove host subscription from prod-p01

### DIFF
--- a/components/sandbox/toolchain-host-operator/production/stone-prod-p01/kustomization.yaml
+++ b/components/sandbox/toolchain-host-operator/production/stone-prod-p01/kustomization.yaml
@@ -7,3 +7,10 @@ resources:
 - ../../../tiers/production
 patches:
 - path: patch_resources.yaml
+- patch: |
+    $patch: delete
+    apiVersion: operators.coreos.com/v1alpha1
+    kind: Subscription
+    metadata:
+      name: dev-sandbox-host
+      namespace: toolchain-host-operator


### PR DESCRIPTION
Needed for safely removing kubesaw from the cluster.