### PR TITLE
sandbox: remove host sub from prod-p02

### DIFF
--- a/components/sandbox/toolchain-host-operator/production/stone-prod-p02/kustomization.yaml
+++ b/components/sandbox/toolchain-host-operator/production/stone-prod-p02/kustomization.yaml
@@ -8,3 +8,10 @@ resources:
 - ../../../tiers/production
 patches:
 - path: patch_resources.yaml
+- patch: |
+    $patch: delete
+    apiVersion: operators.coreos.com/v1alpha1
+    kind: Subscription
+    metadata:
+      name: dev-sandbox-host
+      namespace: toolchain-host-operator


### PR DESCRIPTION
Needed to safely remove kubesaw from this cluster.