### PR TITLE
sandbox: remove member sub from prd-rh03

### DIFF
--- a/components/sandbox/toolchain-member-operator/production/kflux-prd-rh03/kustomization.yaml
+++ b/components/sandbox/toolchain-member-operator/production/kflux-prd-rh03/kustomization.yaml
@@ -2,3 +2,11 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - ../base
+patches:
+- patch: |
+    $patch: delete
+    apiVersion: operators.coreos.com/v1alpha1
+    kind: Subscription
+    metadata:
+      name: dev-sandbox-member
+      namespace: toolchain-member-operator


### PR DESCRIPTION
Needed to safely remove kubesaw from this cluster.