### PR TITLE
Fix gosmee payload size limit to handle MintMaker MRs > 1MB

### DIFF
--- a/components/smee-client/base/deployment.yaml
+++ b/components/smee-client/base/deployment.yaml
@@ -17,13 +17,15 @@ spec:
         - name: shared-health
           emptyDir: {}
       containers:
-        - image: "ghcr.io/chmouel/gosmee:v0.26.1"
+        - image: "ghcr.io/chmouel/gosmee:v0.28.0"
           imagePullPolicy: Always
           name: gosmee
           args:
             - "client"
             - TBA
             - "http://localhost:8080"
+            - "--sse-buffer-size"
+            - "2097152"
           volumeMounts:
             - name: shared-health
               mountPath: /shared

--- a/components/smee/base/deployment.yaml
+++ b/components/smee/base/deployment.yaml
@@ -19,10 +19,10 @@ spec:
         - name: shared-health
           emptyDir: {}
       containers:
-        - image: "ghcr.io/chmouel/gosmee:v0.26.1"
+        - image: "ghcr.io/chmouel/gosmee:v0.28.0"
           imagePullPolicy: Always
           name: gosmee
-          args: ["server", "--address", "0.0.0.0"]
+          args: ["server", "--address", "0.0.0.0", "--max-body-size", "2097152"]
           ports:
             - name: "gosmee-http"
               containerPort: 3333


### PR DESCRIPTION
Use --sse-buffer-size and --max-body-size flags from gosmee v0.28.0 to resolve https://issues.redhat.com/browse/KFLUXVNGD-447