### PR TITLE
fix(KONFLUX-9951): kubearchive trunkates bigger logs

### DIFF
--- a/components/vector-kubearchive-log-collector/staging/stone-stg-rh01/vector-helm-values.yaml
+++ b/components/vector-kubearchive-log-collector/staging/stone-stg-rh01/vector-helm-values.yaml
@@ -53,11 +53,6 @@ customConfig:
         } else {
           .message = "no_message"
         }
-        # Basic data sanitization to prevent 400 errors
-        # Truncate very long messages
-        if length(.message) > 32768 {
-          .message = slice!(.message, 0, 32768) + "...[TRUNCATED]"
-        }
         # Clean up temporary fields
         del(.tmp)
   sinks:


### PR DESCRIPTION
Signed-off-by: obetsun <obetsun@redhat.com>

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED