### PR TITLE
Fix readd grafana SA to staging

### DIFF
--- a/components/vector-kubearchive-log-collector/staging/base/kustomization.yaml
+++ b/components/vector-kubearchive-log-collector/staging/base/kustomization.yaml
@@ -14,6 +14,7 @@ commonAnnotations:
 resources:
 - ../../base
 - loki-secret.yaml
+- sa.yaml
 
 patches:
   - path: scc-patch.yaml

--- a/components/vector-kubearchive-log-collector/staging/base/sa.yaml
+++ b/components/vector-kubearchive-log-collector/staging/base/sa.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: grafana
+  namespace: product-kubearchive-logging
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"  # Before workloads


### PR DESCRIPTION
After the refactor made in https://github.com/redhat-appstudio/infra-deployments/pull/7886 I removed unwillingly the grafana service account in staging. 

This PR is fixing that.