### PR TITLE
KFLUXINFRA-2177: Create a Velero resource-modifier for ImageRepository

### DIFF
--- a/components/backup/base/all-clusters/image-repository-resource-modifier-config.yaml
+++ b/components/backup/base/all-clusters/image-repository-resource-modifier-config.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: image-repository-resource-modifier-config
+  namespace: openshift-adp
+  labels:
+    velero.io/plugin-config: ""
+    velero.io/restore-resource-modifier: "true"
+data:
+  imagerepository-modifier.yaml: |
+    version: v1
+    resourceModifierRules:
+    - conditions:
+        groupResource: imagerepositories.appstudio.redhat.com
+      patches:
+      - operation: test
+        path: "/metadata/finalizers"
+      - operation: remove
+        path: "/metadata/finalizers"


### PR DESCRIPTION
The modifier will run during a Velero restore and remove all the finalizers from the ImageRepository CRDs.