### PR TITLE
KFLUXINFRA-2197: Change tenant backup schedule to every 4 hours

### DIFF
--- a/components/backup/base/member/schedules/backup-tenants-schedule.yaml
+++ b/components/backup/base/member/schedules/backup-tenants-schedule.yaml
@@ -5,7 +5,7 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
-  schedule: 30 1,13 * * * # every day 1:30, 13:30 UTC
+  schedule: 0 */4 * * * # every 4 hours at the top of the hour UTC
   template:
     excludedNamespaces:
       - kube-*


### PR DESCRIPTION
Updates the Velero schedule to run every 4 hours
on the hour, instead of twice daily.