### PR TITLE
feat: add the infra team as owners

### DIFF
--- a/components/konflux-ui/OWNERS
+++ b/components/konflux-ui/OWNERS
@@ -1,6 +1,18 @@
 # See the OWNERS docs: https://go.k8s.io/owners
 
 approvers:
+# infra-team
+- sadlerap
+- eisraeli
+- filariow
+- gbenhaim
+- hugares
+- manish-jangra
+- dperaza4dustbit
+# sre-team
+- dgregor
+- jdcasey
+# ui-team
 - abhinandan13jan
 - caugello
 - CryptoRodeo
@@ -8,12 +20,23 @@ approvers:
 - Katka92
 - sahil143
 - testcara
-- dperaza4dustbit
-- filariow
-- sadlerap
 - rrosatti
+# others
+- arewm
 
 reviewers:
+# infra-team
+- sadlerap
+- eisraeli
+- filariow
+- gbenhaim
+- hugares
+- manish-jangra
+- dperaza4dustbit
+# sre-team
+- dgregor
+- jdcasey
+# ui-team
 - abhinandan13jan
 - caugello
 - CryptoRodeo
@@ -21,7 +44,6 @@ reviewers:
 - Katka92
 - sahil143
 - testcara
-- dperaza4dustbit
-- filariow
-- sadlerap
 - rrosatti
+# others
+- arewm


### PR DESCRIPTION
To ensure the review does not reply on UI team, let us expand the owners.