### PR TITLE
Remove clamav outage banner

### DIFF
--- a/components/konflux-info/production/kflux-ocp-p01/banner-content.yaml
+++ b/components/konflux-info/production/kflux-ocp-p01/banner-content.yaml
@@ -1,6 +1,4 @@
 - type: danger
   summary: "🚨 **Release pipelines are failing**: Release pipelines will fail due to an issue with image signing. The issue is being tracked in **[ITN-2025-00221](https://web-rca.devshift.net/incident/ITN-2025-00221)**."
-- type: warning
-  summary: "🚨 **ClamAV Task Issue**: There is a widespread issue in the clamav-task causing build failures with Rego parse errors. The issue is being tracked in **[KFLUXSPRT-4929](https://issues.redhat.com/browse/KFLUXSPRT-4929)**."
 - type: info
   summary: ✨ Hope you're having a great day. If you need a little whimsy, check out [this wonderful thing](https://videos.learning.redhat.com/media/A+whole+new+build/1_v9l8cton) shared by the ART team.

--- a/components/konflux-info/production/kflux-osp-p01/banner-content.yaml
+++ b/components/konflux-info/production/kflux-osp-p01/banner-content.yaml
@@ -1,6 +1,4 @@
 - type: danger
   summary: "🚨 **Release pipelines are failing**: Release pipelines will fail due to an issue with image signing. The issue is being tracked in **[ITN-2025-00221](https://web-rca.devshift.net/incident/ITN-2025-00221)**."
-- type: warning
-  summary: "🚨 **ClamAV Task Issue**: There is a widespread issue in the clamav-task causing build failures with Rego parse errors. The issue is being tracked in **[KFLUXSPRT-4929](https://issues.redhat.com/browse/KFLUXSPRT-4929)**."
 - type: info
   summary: ✨ Hope you're having a great day. If you need a little whimsy, check out [this wonderful thing](https://videos.learning.redhat.com/media/A+whole+new+build/1_v9l8cton) shared by the ART team.

--- a/components/konflux-info/production/kflux-prd-rh02/banner-content.yaml
+++ b/components/konflux-info/production/kflux-prd-rh02/banner-content.yaml
@@ -1,6 +1,4 @@
 - type: danger
   summary: "🚨 **Release pipelines are failing**: Release pipelines will fail due to an issue with image signing. The issue is being tracked in **[ITN-2025-00221](https://web-rca.devshift.net/incident/ITN-2025-00221)**."
-- type: warning
-  summary: "🚨 **ClamAV Task Issue**: There is a widespread issue in the clamav-task causing build failures with Rego parse errors. The issue is being tracked in **[KFLUXSPRT-4929](https://issues.redhat.com/browse/KFLUXSPRT-4929)**."
 - type: info
   summary: ✨ Hope you're having a great day. If you need a little whimsy, check out [this wonderful thing](https://videos.learning.redhat.com/media/A+whole+new+build/1_v9l8cton) shared by the ART team.

--- a/components/konflux-info/production/kflux-prd-rh03/banner-content.yaml
+++ b/components/konflux-info/production/kflux-prd-rh03/banner-content.yaml
@@ -1,7 +1,5 @@
 - type: danger
   summary: "🚨 **Release pipelines are failing**: Release pipelines will fail due to an issue with image signing. The issue is being tracked in **[ITN-2025-00221](https://web-rca.devshift.net/incident/ITN-2025-00221)**."
-- type: warning
-  summary: "🚨 **ClamAV Task Issue**: There is a widespread issue in the clamav-task causing build failures with Rego parse errors. The issue is being tracked in **[KFLUXSPRT-4929](https://issues.redhat.com/browse/KFLUXSPRT-4929)**."
 - type: info
   summary: ✨ Hope you're having a great day. If you need a little whimsy, check out [this wonderful thing](https://videos.learning.redhat.com/media/A+whole+new+build/1_v9l8cton) shared by the ART team.
 - type: info

--- a/components/konflux-info/production/kflux-rhel-p01/banner-content.yaml
+++ b/components/konflux-info/production/kflux-rhel-p01/banner-content.yaml
@@ -1,4 +1,2 @@
-- type: warning
-  summary: "🚨 **ClamAV Task Issue**: There is a widespread issue in the clamav-task causing build failures with Rego parse errors. The issue is being tracked in **[KFLUXSPRT-4929](https://issues.redhat.com/browse/KFLUXSPRT-4929)**."
 - type: info
   summary: ✨ Hope you're having a great day. If you need a little whimsy, check out [this wonderful thing](https://videos.learning.redhat.com/media/A+whole+new+build/1_v9l8cton) shared by the ART team.

--- a/components/konflux-info/production/stone-prd-rh01/banner-content.yaml
+++ b/components/konflux-info/production/stone-prd-rh01/banner-content.yaml
@@ -1,7 +1,5 @@
 - type: danger
   summary: "🚨 **Release pipelines are failing**: Release pipelines will fail due to an issue with image signing. The issue is being tracked in **[ITN-2025-00221](https://web-rca.devshift.net/incident/ITN-2025-00221)**."
-- type: warning
-  summary: "🚨 **ClamAV Task Issue**: There is a widespread issue in the clamav-task causing build failures with Rego parse errors. The issue is being tracked in **[KFLUXSPRT-4929](https://issues.redhat.com/browse/KFLUXSPRT-4929)**."
 - type: info
   summary: ✨ Hope you're having a great day. If you need a little whimsy, check out [this wonderful thing](https://videos.learning.redhat.com/media/A+whole+new+build/1_v9l8cton) shared by the ART team.
 - type: info

--- a/components/konflux-info/production/stone-prod-p01/banner-content.yaml
+++ b/components/konflux-info/production/stone-prod-p01/banner-content.yaml
@@ -1,7 +1,5 @@
 - type: danger
   summary: "🚨 **Release pipelines are failing**: Release pipelines will fail due to an issue with image signing. The issue is being tracked in **[ITN-2025-00221](https://web-rca.devshift.net/incident/ITN-2025-00221)**."
-- type: warning
-  summary: "🚨 **ClamAV Task Issue**: There is a widespread issue in the clamav-task causing build failures with Rego parse errors. The issue is being tracked in **[KFLUXSPRT-4929](https://issues.redhat.com/browse/KFLUXSPRT-4929)**."
 - type: info
   summary: ✨ Hope you're having a great day. If you need a little whimsy, check out [this wonderful thing](https://videos.learning.redhat.com/media/A+whole+new+build/1_v9l8cton) shared by the ART team.
 - type: info

--- a/components/konflux-info/production/stone-prod-p02/banner-content.yaml
+++ b/components/konflux-info/production/stone-prod-p02/banner-content.yaml
@@ -1,7 +1,5 @@
 - type: danger
   summary: "🚨 **Release pipelines are failing**: Release pipelines will fail due to an issue with image signing. The issue is being tracked in **[ITN-2025-00221](https://web-rca.devshift.net/incident/ITN-2025-00221)**."
-- type: warning
-  summary: "🚨 **ClamAV Task Issue**: There is a widespread issue in the clamav-task causing build failures with Rego parse errors. The issue is being tracked in **[KFLUXSPRT-4929](https://issues.redhat.com/browse/KFLUXSPRT-4929)**."
 - summary: "IBM Cloud PPC Re-provisioning: See Konflux announcement email 'IBM Cloud PPC Maintenance on stone-prod-p02' for more details. PPC Multi-Arch builds will be impacted."
   type: "warning"
   year: 2025

--- a/components/konflux-info/staging/stone-stage-p01/banner-content.yaml
+++ b/components/konflux-info/staging/stone-stage-p01/banner-content.yaml
@@ -1,5 +1,3 @@
-- type: warning
-  summary: "🚨 **ClamAV Task Issue**: There is a widespread issue in the clamav-task causing build failures with Rego parse errors. The issue is being tracked in **[KFLUXSPRT-4929](https://issues.redhat.com/browse/KFLUXSPRT-4929)**."
 - type: info
   summary: ✨ Hope you're having a great day. If you need a little whimsy, check out [this wonderful thing](https://videos.learning.redhat.com/media/A+whole+new+build/1_v9l8cton) shared by the ART team.
 - type: info

--- a/components/konflux-info/staging/stone-stg-rh01/banner-content.yaml
+++ b/components/konflux-info/staging/stone-stg-rh01/banner-content.yaml
@@ -1,5 +1,3 @@
-- type: warning
-  summary: "🚨 **ClamAV Task Issue**: There is a widespread issue in the clamav-task causing build failures with Rego parse errors. The issue is being tracked in **[KFLUXSPRT-4929](https://issues.redhat.com/browse/KFLUXSPRT-4929)**."
 - summary: "Konflux Maintenance Window Every Friday"
   type: "info"
   dayOfWeek: 5


### PR DESCRIPTION
The clamav outage is over, so the banner informing about it is no longer needed.