### PR TITLE
Temporarily add new RHEL s390x VMs in FRA

### DIFF
--- a/components/kueue/production/kflux-rhel-p01/queue-config/cluster-queue.yaml
+++ b/components/kueue/production/kflux-rhel-p01/queue-config/cluster-queue.yaml
@@ -94,6 +94,8 @@ spec:
     - linux-root-amd64
     - linux-root-arm64
     - linux-s390x
+    - linux-s390xfra
+    - linux-s390xlargefra
     - linux-x86-64
     - local
     - localhost
@@ -122,6 +124,10 @@ spec:
         nominalQuota: '250'
       - name: linux-s390x
         nominalQuota: '12'
+      - name: linux-s390xfra
+        nominalQuota: '4'
+      - name: linux-s390xlargefra
+        nominalQuota: '4'
       - name: linux-x86-64
         nominalQuota: '1000'
       - name: local

--- a/components/multi-platform-controller/production-downstream/kflux-rhel-p01/external-secrets.yaml
+++ b/components/multi-platform-controller/production-downstream/kflux-rhel-p01/external-secrets.yaml
@@ -112,3 +112,49 @@ spec:
     creationPolicy: Owner
     deletionPolicy: Delete
     name: ibm-ppc64le-ssh-key
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: ibm-s390x-ssh-key-regular
+  namespace: multi-platform-controller
+  labels:
+    build.appstudio.redhat.com/multi-platform-secret: "true"
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  dataFrom:
+    - extract:
+        key: production/platform/terraform/generated/kflux-rhel-p01/ibm-s390x-ssh-key-i6r3
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: appsre-stonesoup-vault
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    name: ibm-s390x-ssh-key-regular
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: ibm-s390x-ssh-key-large-builder
+  namespace: multi-platform-controller
+  labels:
+    build.appstudio.redhat.com/multi-platform-secret: "true"
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  dataFrom:
+    - extract:
+        key: production/platform/terraform/generated/kflux-rhel-p01/ibm-s390x-ssh-key-wcrs
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: appsre-stonesoup-vault
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    name: ibm-s390x-ssh-key-large-builder

--- a/components/multi-platform-controller/production-downstream/kflux-rhel-p01/host-config.yaml
+++ b/components/multi-platform-controller/production-downstream/kflux-rhel-p01/host-config.yaml
@@ -511,6 +511,18 @@ data:
   host.s390x-static-3.secret: "ibm-s390x-ssh-key"
   host.s390x-static-3.concurrency: "4"
 
+  host.s390xfra-static-1.address: "10.130.130.9"
+  host.s390xfra-static-1.platform: "linux/s390xfra"
+  host.s390xfra-static-1.user: "root"
+  host.s390xfra-static-1.secret: "ibm-s390x-ssh-key-regular"
+  host.s390xfra-static-1.concurrency: "4"
+
+  host.s390xlargefra-static-1.address: "10.130.130.5"
+  host.s390xlargefra-static-1.platform: "linux/s390xlargefra"
+  host.s390xlargefra-static-1.user: "root"
+  host.s390xlargefra-static-1.secret: "ibm-s390x-ssh-key-large-builder"
+  host.s390xlargefra-static-1.concurrency: "4"
+
   # PPC64LE 4cores(32vCPU) / 128GiB RAM / 2TB disk
   host.ppc64le-static-0.address: "10.130.78.70"
   host.ppc64le-static-0.platform: "linux/ppc64le"


### PR DESCRIPTION
Before switching officially RHEL to the VMs in FRA datacenter, add one of each as a new platform so we can test them.

[KFLUXINFRA-2154](https://issues.redhat.com//browse/KFLUXINFRA-2154)