### PR TITLE
Fix gosmee payload size limit to handle MintMaker MRs > 1MB in staging

### DIFF
--- a/components/smee-client/staging/gosmee-v0.28.0-patch.yaml
+++ b/components/smee-client/staging/gosmee-v0.28.0-patch.yaml
@@ -1,0 +1,7 @@
+---
+- op: replace
+  path: /spec/template/spec/containers/0/image
+  value: "ghcr.io/chmouel/gosmee:v0.28.0"
+- op: replace
+  path: /spec/template/spec/containers/0/args
+  value: ["client", "--sse-buffer-size", "2097152", "https://smee-smee.apps.stone-stg-host.qc0p.p1.openshiftapps.com/redhathook12", "http://localhost:8080"]

--- a/components/smee-client/staging/kustomization.yaml
+++ b/components/smee-client/staging/kustomization.yaml
@@ -17,3 +17,7 @@ patches:
     target:
       name: gosmee-client
       kind: Deployment
+  - path: gosmee-v0.28.0-patch.yaml
+    target:
+      name: gosmee-client
+      kind: Deployment

--- a/components/smee/staging/stone-stg-host/gosmee-v0.28.0-patch.yaml
+++ b/components/smee/staging/stone-stg-host/gosmee-v0.28.0-patch.yaml
@@ -1,0 +1,10 @@
+---
+- op: replace
+  path: /spec/template/spec/containers/0/image
+  value: "ghcr.io/chmouel/gosmee:v0.28.0"
+- op: replace
+  path: /spec/template/spec/containers/0/args
+  value: ["server", "--address", "0.0.0.0", "--max-body-size", "2097152"]
+- op: replace
+  path: /spec/template/spec/containers/1/image
+  value: "ghcr.io/chmouel/gosmee:v0.28.0"

--- a/components/smee/staging/stone-stg-host/kustomization.yaml
+++ b/components/smee/staging/stone-stg-host/kustomization.yaml
@@ -18,3 +18,7 @@ patches:
     target:
       name: gosmee
       kind: Deployment
+  - path: gosmee-v0.28.0-patch.yaml
+    target:
+      name: gosmee
+      kind: Deployment


### PR DESCRIPTION
Use gosmee v0.28.0 flags --sse-buffer-size and --max-body-size to resolve [KFLUXVNGD-447](https://issues.redhat.com//browse/KFLUXVNGD-447)