### PR TITLE
promote restrict-binding policy for releng tenant to prod

### DIFF
--- a/components/policies/production/base/konflux-rbac/kustomization.yaml
+++ b/components/policies/production/base/konflux-rbac/kustomization.yaml
@@ -3,4 +3,5 @@ kind: Kustomization
 resources:
 - bootstrap-tenant-namespace/
 - restrict-binding-system-authenticated/
+- restrict-binding-system-authenticated-releng/
 - validate-rolebindings/

--- a/components/policies/production/base/konflux-rbac/restrict-binding-system-authenticated-releng/.chainsaw-test/chainsaw-assert-clusterpolicy.yaml
+++ b/components/policies/production/base/konflux-rbac/restrict-binding-system-authenticated-releng/.chainsaw-test/chainsaw-assert-clusterpolicy.yaml
@@ -1,0 +1,9 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: validate-restrict-binding-sysauth-releng
+status:
+  conditions:
+  - reason: Succeeded
+    status: "True"
+    type: Ready

--- a/components/policies/production/base/konflux-rbac/restrict-binding-system-authenticated-releng/.chainsaw-test/chainsaw-test.yaml
+++ b/components/policies/production/base/konflux-rbac/restrict-binding-system-authenticated-releng/.chainsaw-test/chainsaw-test.yaml
@@ -1,0 +1,103 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: in-rhtap-releng-tenant-invalid-rolebinding
+spec:
+  description: |
+    tests that the a invalid RoleBinding can NOT be created
+    in a tenant namespace
+  concurrent: false
+  namespace: 'rhtap-releng-tenant'
+  steps:
+  - name: given-kyverno-has-permission-on-resources
+    try:
+    - apply:
+        file: ../kyverno_rbac.yaml
+  - name: given-cluster-policy-is-ready
+    try:
+    - apply:
+        file: ../validate-restrict-binding-system-authenticated-releng-clusterpolicy.yaml
+    - assert:
+        file: chainsaw-assert-clusterpolicy.yaml
+  - name: given-tenant-namespace-exists
+    try:
+    - apply:
+        file: ./resources/tenant-namespace.yaml
+  - name: then-invalid-rolebindings-can-not-be-created
+    try:
+    - apply:
+        file: ./resources/invalid-systemauthenticated-rolebinding.yaml
+        expect:
+        - check:
+            ($error != null): true
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: in-rhtap-releng-tenant-valid-rolebinding
+spec:
+  description: |
+    tests that the a valid RoleBinding can be created in a 
+    tenant namespace
+  concurrent: false
+  namespace: 'rhtap-releng-tenant'
+  steps:
+  - name: given-kyverno-has-permission-on-resources
+    try:
+    - apply:
+        file: ../kyverno_rbac.yaml
+  - name: given-cluster-policy-is-ready
+    try:
+    - apply:
+        file: ../validate-restrict-binding-system-authenticated-releng-clusterpolicy.yaml
+    - assert:
+        file: chainsaw-assert-clusterpolicy.yaml
+  - name: given-tenant-namespace-exists
+    try:
+    - apply:
+        file: ./resources/tenant-namespace.yaml
+  - name: then-valid-rolebindings-can-be-created
+    try:
+    - apply:
+        file: ./resources/valid-systemauthenticated-rolebinding.yaml
+        expect:
+        - check:
+            ($error != null): false
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: out-of-rhtap-releng-tenant-rolebinding
+spec:
+  description: |
+    tests that the whatever RoleBinding can be created in a 
+    non-tenant namespace
+  concurrent: false
+  namespace: 'non-rhtap-releng-tenant'
+  steps:
+  - name: given-kyverno-has-permission-on-resources
+    try:
+    - apply:
+        file: ../kyverno_rbac.yaml
+  - name: given-cluster-policy-is-ready
+    try:
+    - apply:
+        file: ../validate-restrict-binding-system-authenticated-releng-clusterpolicy.yaml
+    - assert:
+        file: chainsaw-assert-clusterpolicy.yaml
+  - name: then-rolebindings-can-be-created-in-a-nontenant-namespace
+    try:
+    - apply:
+        file: ./resources/valid-systemauthenticated-rolebinding.yaml
+        expect:
+        - check:
+            ($error != null): false
+    - apply:
+        file: ./resources/invalid-systemauthenticated-rolebinding.yaml
+        expect:
+        - check:
+            ($error != null): false

--- a/components/policies/production/base/konflux-rbac/restrict-binding-system-authenticated-releng/.chainsaw-test/resources/invalid-systemauthenticated-rolebinding.yaml
+++ b/components/policies/production/base/konflux-rbac/restrict-binding-system-authenticated-releng/.chainsaw-test/resources/invalid-systemauthenticated-rolebinding.yaml
@@ -1,0 +1,18 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: invalid-systemauthenticated-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: not-allowed-clusterrole
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:authenticated
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: my-user
+- apiGroup: ""
+  kind: ServiceAccount
+  name: my-serviceaccount

--- a/components/policies/production/base/konflux-rbac/restrict-binding-system-authenticated-releng/.chainsaw-test/resources/tenant-namespace.yaml
+++ b/components/policies/production/base/konflux-rbac/restrict-binding-system-authenticated-releng/.chainsaw-test/resources/tenant-namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ($namespace)
+  labels:
+    konflux-ci.dev/type: tenant

--- a/components/policies/production/base/konflux-rbac/restrict-binding-system-authenticated-releng/.chainsaw-test/resources/valid-systemauthenticated-rolebinding.yaml
+++ b/components/policies/production/base/konflux-rbac/restrict-binding-system-authenticated-releng/.chainsaw-test/resources/valid-systemauthenticated-rolebinding.yaml
@@ -1,0 +1,37 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: valid-systemauthenticated-konflux-viewer
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: konflux-viewer-user-actions
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:authenticated
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: my-user
+- apiGroup: ""
+  kind: ServiceAccount
+  name: my-serviceaccount
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: valid-systemauthenticated-enterprise-contract-viewer
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: enterprisecontractpolicy-viewer-role
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:authenticated
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: my-user
+- apiGroup: ""
+  kind: ServiceAccount
+  name: my-serviceaccount

--- a/components/policies/production/base/konflux-rbac/restrict-binding-system-authenticated-releng/kustomization.yaml
+++ b/components/policies/production/base/konflux-rbac/restrict-binding-system-authenticated-releng/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namePrefix: konflux-rbac-
+resources:
+- validate-restrict-binding-system-authenticated-releng-clusterpolicy.yaml
+- kyverno_rbac.yaml

--- a/components/policies/production/base/konflux-rbac/restrict-binding-system-authenticated-releng/kyverno_rbac.yaml
+++ b/components/policies/production/base/konflux-rbac/restrict-binding-system-authenticated-releng/kyverno_rbac.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kyverno-adm:restrict-binding-sysauth-releng
+  labels:
+    rbac.kyverno.io/aggregate-to-admission-controller: "true"
+rules:
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - rolebindings
+  verbs:
+  - list
+  - get
+  - watch
+---

--- a/components/policies/production/base/konflux-rbac/restrict-binding-system-authenticated-releng/validate-restrict-binding-system-authenticated-releng-clusterpolicy.yaml
+++ b/components/policies/production/base/konflux-rbac/restrict-binding-system-authenticated-releng/validate-restrict-binding-system-authenticated-releng-clusterpolicy.yaml
@@ -1,0 +1,42 @@
+---
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: validate-restrict-binding-sysauth-releng
+  annotations:
+    policies.kyverno.io/title: Restrict Binding System Groups
+    policies.kyverno.io/category: Security
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: RoleBinding, RBAC
+    policies.kyverno.io/description: >-
+      We don't want users to bind system:authenticated group with any role
+      except for the konflux-viewer-user-actions ClusterRole.
+spec:
+  rules:
+  - name: restrict-authenticated
+    skipBackgroundRequests: true
+    match:
+      any:
+      - resources:
+          kinds:
+          - RoleBinding
+          namespaces:
+          - rhtap-releng-tenant
+    preconditions:
+      all:
+      - key: "{{ request.object.subjects[].name }}"
+        operator: AnyIn
+        value: "system:authenticated"
+      - key: "{{ request.object.roleRef.kind }}"
+        operator: Equals
+        value: "ClusterRole"
+      - key: "{{ request.object.roleRef.name }}"
+        operator: AllNotIn
+        value: 
+          - konflux-viewer-user-actions
+          - enterprisecontractpolicy-viewer-role
+    validate:
+      allowExistingViolations: true
+      failureAction: Enforce
+      message: "Only ClusterRoles 'konflux-viewer-user-actions' and 'enterprisecontractpolicy-viewer-role' can be bound to 'system:authenticated' in namespace 'rhtap-releng-tenant'."
+      deny: {}


### PR DESCRIPTION
we want to allow to bind the `system:authenticated` Group to the `enterprisecontractpolicy-viewer-role` ClusterRole in the namespace `rhtap-releng-tenant`.

This is the first phase of the rollout.

Signed-off-by: Francesco Ilario <filario@redhat.com>
