### PR TITLE
deploy restrict-binding-sysauth to production

### DIFF
--- a/components/policies/production/base/konflux-rbac/kustomization.yaml
+++ b/components/policies/production/base/konflux-rbac/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - bootstrap-tenant-namespace/
+- restrict-binding-sysauth/
 - restrict-binding-system-authenticated/
 - restrict-binding-system-authenticated-releng/
 - validate-rolebindings/

--- a/components/policies/production/base/konflux-rbac/restrict-binding-sysauth/.chainsaw-test/chainsaw-assert-clusterpolicy.yaml
+++ b/components/policies/production/base/konflux-rbac/restrict-binding-sysauth/.chainsaw-test/chainsaw-assert-clusterpolicy.yaml
@@ -1,0 +1,9 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: validate-restrict-binding-sysauth
+status:
+  conditions:
+  - reason: Succeeded
+    status: "True"
+    type: Ready

--- a/components/policies/production/base/konflux-rbac/restrict-binding-sysauth/.chainsaw-test/chainsaw-test.yaml
+++ b/components/policies/production/base/konflux-rbac/restrict-binding-sysauth/.chainsaw-test/chainsaw-test.yaml
@@ -1,0 +1,139 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: in-tenant-invalid-rolebinding
+spec:
+  description: |
+    tests that the a invalid RoleBinding can NOT be created
+    in a tenant namespace
+  concurrent: false
+  namespace: 'invalid-systemauthenticated-rb-tenant-namespace'
+  steps:
+  - name: given-kyverno-has-permission-on-resources
+    try:
+    - apply:
+        file: ../kyverno_rbac.yaml
+  - name: given-cluster-policy-is-ready
+    try:
+    - apply:
+        file: ../validate-restrict-binding-sysauth-clusterpolicy.yaml
+    - assert:
+        file: chainsaw-assert-clusterpolicy.yaml
+  - name: given-tenant-namespace-exists
+    try:
+    - apply:
+        file: ./resources/tenant-namespace.yaml
+  - name: then-invalid-rolebinding-can-not-be-created
+    try:
+    - apply:
+        file: ./resources/invalid-systemauthenticated-rolebinding.yaml
+        expect:
+        - check:
+            ($error != null): true
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: in-tenant-valid-rolebinding
+spec:
+  description: |
+    tests that the a any RoleBinding can be created in the
+    tenant namespace 'rhtap-releng-tenant'
+  concurrent: false
+  namespace: 'rhtap-releng-tenant'
+  steps:
+  - name: given-kyverno-has-permission-on-resources
+    try:
+    - apply:
+        file: ../kyverno_rbac.yaml
+  - name: given-cluster-policy-is-ready
+    try:
+    - apply:
+        file: ../validate-restrict-binding-sysauth-clusterpolicy.yaml
+    - assert:
+        file: chainsaw-assert-clusterpolicy.yaml
+  - name: given-tenant-namespace-exists
+    try:
+    - apply:
+        file: ./resources/tenant-namespace.yaml
+  - name: then-valid-rolebinding-can-be-created
+    try:
+    - apply:
+        file: ./resources/valid-systemauthenticated-rolebinding.yaml
+        expect:
+        - check:
+            ($error != null): false
+  - name: then-invalid-rolebinding-can-be-created
+    try:
+    - apply:
+        file: ./resources/invalid-systemauthenticated-rolebinding.yaml
+        expect:
+        - check:
+            ($error != null): false
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: in-tenant-valid-rolebinding
+spec:
+  description: |
+    tests that the a valid RoleBinding can be created in a 
+    tenant namespace
+  concurrent: false
+  namespace: 'valid-systemauthenticated-rb-tenant-namespace'
+  steps:
+  - name: given-kyverno-has-permission-on-resources
+    try:
+    - apply:
+        file: ../kyverno_rbac.yaml
+  - name: given-cluster-policy-is-ready
+    try:
+    - apply:
+        file: ../validate-restrict-binding-sysauth-clusterpolicy.yaml
+    - assert:
+        file: chainsaw-assert-clusterpolicy.yaml
+  - name: given-tenant-namespace-exists
+    try:
+    - apply:
+        file: ./resources/tenant-namespace.yaml
+  - name: then-valid-rolebinding-can-be-created
+    try:
+    - apply:
+        file: ./resources/valid-systemauthenticated-rolebinding.yaml
+        expect:
+        - check:
+            ($error != null): false
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: out-of-tenant-rolebinding
+spec:
+  description: |
+    tests that the whatever RoleBinding can be created in a 
+    non-tenant namespace
+  concurrent: false
+  namespace: 'valid-systemauthenticated-rb-namespace'
+  steps:
+  - name: given-kyverno-has-permission-on-resources
+    try:
+    - apply:
+        file: ../kyverno_rbac.yaml
+  - name: given-cluster-policy-is-ready
+    try:
+    - apply:
+        file: ../validate-restrict-binding-sysauth-clusterpolicy.yaml
+    - assert:
+        file: chainsaw-assert-clusterpolicy.yaml
+  - name: then-rolebinding-can-be-created-in-a-nontenant-namespace
+    try:
+    - apply:
+        file: ./resources/valid-systemauthenticated-rolebinding.yaml
+        expect:
+        - check:
+            ($error != null): false

--- a/components/policies/production/base/konflux-rbac/restrict-binding-sysauth/.chainsaw-test/resources/invalid-systemauthenticated-rolebinding.yaml
+++ b/components/policies/production/base/konflux-rbac/restrict-binding-sysauth/.chainsaw-test/resources/invalid-systemauthenticated-rolebinding.yaml
@@ -1,0 +1,18 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: invalid-systemauthenticated-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: not-konflux-viewer-user-actions
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:authenticated
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: my-user
+- apiGroup: ""
+  kind: ServiceAccount
+  name: my-serviceaccount

--- a/components/policies/production/base/konflux-rbac/restrict-binding-sysauth/.chainsaw-test/resources/tenant-namespace.yaml
+++ b/components/policies/production/base/konflux-rbac/restrict-binding-sysauth/.chainsaw-test/resources/tenant-namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ($namespace)
+  labels:
+    konflux-ci.dev/type: tenant

--- a/components/policies/production/base/konflux-rbac/restrict-binding-sysauth/.chainsaw-test/resources/valid-systemauthenticated-rolebinding.yaml
+++ b/components/policies/production/base/konflux-rbac/restrict-binding-sysauth/.chainsaw-test/resources/valid-systemauthenticated-rolebinding.yaml
@@ -1,0 +1,18 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: valid-systemauthenticated-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: konflux-viewer-user-actions
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:authenticated
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: my-user
+- apiGroup: ""
+  kind: ServiceAccount
+  name: my-serviceaccount

--- a/components/policies/production/base/konflux-rbac/restrict-binding-sysauth/kustomization.yaml
+++ b/components/policies/production/base/konflux-rbac/restrict-binding-sysauth/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namePrefix: konflux-rbac-
+resources:
+- validate-restrict-binding-sysauth-clusterpolicy.yaml
+- kyverno_rbac.yaml

--- a/components/policies/production/base/konflux-rbac/restrict-binding-sysauth/kyverno_rbac.yaml
+++ b/components/policies/production/base/konflux-rbac/restrict-binding-sysauth/kyverno_rbac.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kyverno-admission:restrict-binding-sysauth
+  labels:
+    rbac.kyverno.io/aggregate-to-admission-controller: "true"
+rules:
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - rolebindings
+  verbs:
+  - list
+  - get
+  - watch
+---

--- a/components/policies/production/base/konflux-rbac/restrict-binding-sysauth/validate-restrict-binding-sysauth-clusterpolicy.yaml
+++ b/components/policies/production/base/konflux-rbac/restrict-binding-sysauth/validate-restrict-binding-sysauth-clusterpolicy.yaml
@@ -1,0 +1,46 @@
+---
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: validate-restrict-binding-sysauth
+  annotations:
+    policies.kyverno.io/title: Restrict Binding System Groups
+    policies.kyverno.io/category: Security
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: RoleBinding, RBAC
+    policies.kyverno.io/description: >-
+      We don't want users to bind system:authenticated group with any role
+      except for the konflux-viewer-user-actions ClusterRole.
+spec:
+  rules:
+  - name: restrict-authenticated
+    skipBackgroundRequests: true
+    match:
+      any:
+      - resources:
+          kinds:
+          - RoleBinding
+          namespaceSelector:
+            matchLabels:
+              konflux-ci.dev/type: tenant
+    exclude:
+      any:
+      - resources:
+          namespaces:
+          - rhtap-releng-tenant
+    preconditions:
+      all:
+      - key: "{{ request.object.subjects[].name }}"
+        operator: AnyIn
+        value: "system:authenticated"
+      - key: "{{ request.object.roleRef.kind }}"
+        operator: Equals
+        value: "ClusterRole"
+      - key: "{{ request.object.roleRef.name }}"
+        operator: NotEquals
+        value: "konflux-viewer-user-actions"
+    validate:
+      allowExistingViolations: true
+      failureAction: Enforce
+      message: "Only ClusterRole konflux-viewer-user-actions can be bound to system:authenticated."
+      deny: {}


### PR DESCRIPTION
We want to allow to bind the `system:authenticated` Group to the `enterprisecontractpolicy-viewer-role` ClusterRole in the namespace `rhtap-releng-tenant`.

This is the second phase of the rollout. It requires:
- [x] #8017

With this PR we introduce the new version of the `validate-restrict-binding-system-authenticated` ClusterPolicy without removing the previous version.
The previous version is more restrictive than then new one.

To avoid issues with rollout of the new version, we'll remove the previous version only when the new one is up and running.

Signed-off-by: Francesco Ilario <filario@redhat.com>
