### PR TITLE
Update banner on Konflux production cluster

### DIFF
--- a/components/konflux-info/production/kflux-ocp-p01/banner-content.yaml
+++ b/components/konflux-info/production/kflux-ocp-p01/banner-content.yaml
@@ -1,2 +1,8 @@
 # Only the first banner will be displayed. Put the one to display at the top and remove any which are no longer relevant
-[]
+- summary: "Some tekton task bundle images are currently unavailable causing build pipeline failures. We are working on restoring them. Please refer to **[ITN-2025-00224](https://web-rca.devshift.net/incident/ITN-2025-00224/events)**"
+  type: "info"
+  year: 2025
+  month: 9
+  dayOfMonth: 8
+  startTime: "10:36"
+  endTime: "00:00"

--- a/components/konflux-info/production/kflux-osp-p01/banner-content.yaml
+++ b/components/konflux-info/production/kflux-osp-p01/banner-content.yaml
@@ -1,2 +1,8 @@
 # Only the first banner will be displayed. Put the one to display at the top and remove any which are no longer relevant
-[]
+- summary: "Some tekton task bundle images are currently unavailable causing build pipeline failures. We are working on restoring them. Please refer to **[ITN-2025-00224](https://web-rca.devshift.net/incident/ITN-2025-00224/events)**"
+  type: "info"
+  year: 2025
+  month: 9
+  dayOfMonth: 8
+  startTime: "10:36"
+  endTime: "00:00"

--- a/components/konflux-info/production/kflux-prd-rh02/banner-content.yaml
+++ b/components/konflux-info/production/kflux-prd-rh02/banner-content.yaml
@@ -1,2 +1,8 @@
 # Only the first banner will be displayed. Put the one to display at the top and remove any which are no longer relevant
-[]
+- summary: "Some tekton task bundle images are currently unavailable causing build pipeline failures. We are working on restoring them. Please refer to **[ITN-2025-00224](https://web-rca.devshift.net/incident/ITN-2025-00224/events)**"
+  type: "info"
+  year: 2025
+  month: 9
+  dayOfMonth: 8
+  startTime: "10:36"
+  endTime: "00:00"

--- a/components/konflux-info/production/kflux-prd-rh03/banner-content.yaml
+++ b/components/konflux-info/production/kflux-prd-rh03/banner-content.yaml
@@ -1,2 +1,8 @@
 # Only the first banner will be displayed. Put the one to display at the top and remove any which are no longer relevant
-[]
+- summary: "Some tekton task bundle images are currently unavailable causing build pipeline failures. We are working on restoring them. Please refer to **[ITN-2025-00224](https://web-rca.devshift.net/incident/ITN-2025-00224/events)**"
+  type: "info"
+  year: 2025
+  month: 9
+  dayOfMonth: 8
+  startTime: "10:36"
+  endTime: "00:00"

--- a/components/konflux-info/production/kflux-rhel-p01/banner-content.yaml
+++ b/components/konflux-info/production/kflux-rhel-p01/banner-content.yaml
@@ -1,2 +1,8 @@
 # Only the first banner will be displayed. Put the one to display at the top and remove any which are no longer relevant
-[]
+- summary: "Some tekton task bundle images are currently unavailable causing build pipeline failures. We are working on restoring them. Please refer to **[ITN-2025-00224](https://web-rca.devshift.net/incident/ITN-2025-00224/events)**"
+  type: "info"
+  year: 2025
+  month: 9
+  dayOfMonth: 8
+  startTime: "10:36"
+  endTime: "00:00"

--- a/components/konflux-info/production/stone-prd-rh01/banner-content.yaml
+++ b/components/konflux-info/production/stone-prd-rh01/banner-content.yaml
@@ -1,2 +1,8 @@
 # Only the first banner will be displayed. Put the one to display at the top and remove any which are no longer relevant
-[]
+- summary: "Some tekton task bundle images are currently unavailable causing build pipeline failures. We are working on restoring them. Please refer to **[ITN-2025-00224](https://web-rca.devshift.net/incident/ITN-2025-00224/events)**"
+  type: "info"
+  year: 2025
+  month: 9
+  dayOfMonth: 8
+  startTime: "10:36"
+  endTime: "00:00"

--- a/components/konflux-info/production/stone-prod-p01/banner-content.yaml
+++ b/components/konflux-info/production/stone-prod-p01/banner-content.yaml
@@ -1,2 +1,8 @@
 # Only the first banner will be displayed. Put the one to display at the top and remove any which are no longer relevant
-[]
+- summary: "Some tekton task bundle images are currently unavailable causing build pipeline failures. We are working on restoring them. Please refer to **[ITN-2025-00224](https://web-rca.devshift.net/incident/ITN-2025-00224/events)**"
+  type: "info"
+  year: 2025
+  month: 9
+  dayOfMonth: 8
+  startTime: "10:36"
+  endTime: "00:00"

--- a/components/konflux-info/production/stone-prod-p02/banner-content.yaml
+++ b/components/konflux-info/production/stone-prod-p02/banner-content.yaml
@@ -1,2 +1,8 @@
 # Only the first banner will be displayed. Put the one to display at the top and remove any which are no longer relevant
-[]
+- summary: "Some tekton task bundle images are currently unavailable causing build pipeline failures. We are working on restoring them. Please refer to **[ITN-2025-00224](https://web-rca.devshift.net/incident/ITN-2025-00224/events)**"
+  type: "info"
+  year: 2025
+  month: 9
+  dayOfMonth: 8
+  startTime: "10:36"
+  endTime: "00:00"


### PR DESCRIPTION
Target cluster: All prod clusters
Type: New banner
Purpose: To inform users about an incident on the build failures