### PR TITLE
Eventing: use latest patch image on staging

### DIFF
--- a/components/knative-eventing/base/kustomization.yaml
+++ b/components/knative-eventing/base/kustomization.yaml
@@ -17,9 +17,10 @@ patches:
         spec:
           containers:
             - name: eventing-controller
+              image: quay.io/kubearchive/eventing-controller:remove-sar
               env:
                 - name: APISERVER_RA_IMAGE
-                  value: quay.io/kubearchive/eventing-adapter:v1.16.7-verbose
+                  value: quay.io/kubearchive/eventing-adapter:remove-sar
               resources:
                 requests:
                   cpu: 200m


### PR DESCRIPTION
Changes: https://github.com/knative/eventing/compare/knative-v1.16.7...kubearchive:eventing:knative-v1.16.8