### PR TITLE
Make vector logs available in Splunk

### DIFF
--- a/components/vector-kubearchive-log-collector/production/stone-prod-p02/vector-helm-prod-values.yaml
+++ b/components/vector-kubearchive-log-collector/production/stone-prod-p02/vector-helm-prod-values.yaml
@@ -11,3 +11,8 @@ customConfig:
   sources:
     k8s_logs:
       extra_label_selector: "app.kubernetes.io/managed-by in (tekton-pipelines,pipelinesascode.tekton.dev)"
+      exclude_namespace:
+        - product-kubearchive-logging
+
+podLabels:
+  vector.dev/exclude: "false"

--- a/components/vector-kubearchive-log-collector/staging/stone-stg-rh01/vector-helm-stg-values.yaml
+++ b/components/vector-kubearchive-log-collector/staging/stone-stg-rh01/vector-helm-stg-values.yaml
@@ -11,3 +11,8 @@ customConfig:
   sources:
     k8s_logs:
       extra_label_selector: "app.kubernetes.io/managed-by in (tekton-pipelines,pipelinesascode.tekton.dev)"
+      exclude_namespace:
+        - product-kubearchive-logging
+
+podLabels:
+  vector.dev/exclude: "false"


### PR DESCRIPTION
The vector logs aren't currently being forwarded to Splunk and the initial guess is that they are being filtered due to the default label: `vector.dev/exclude: "true"`

This PR modifies this label in staging and production where we are already filtering only the logs from pipelines. Note that the label is set by default to prevent vector entering in a loop of processing its own logs.

To be extra secure I've excluded the namespace `product-kubearchive-logging`