### PR TITLE
Make vector logs available in Splunk

### DIFF
--- a/components/vector-kubearchive-log-collector/production/stone-prod-p02/vector-helm-prod-values.yaml
+++ b/components/vector-kubearchive-log-collector/production/stone-prod-p02/vector-helm-prod-values.yaml
@@ -11,8 +11,7 @@ customConfig:
   sources:
     k8s_logs:
       extra_label_selector: "app.kubernetes.io/managed-by in (tekton-pipelines,pipelinesascode.tekton.dev)"
-      exclude_namespace:
-        - product-kubearchive-logging
+      extra_field_selector: "metadata.namespace!=product-kubearchive-logging"
 
 podLabels:
   vector.dev/exclude: "false"

--- a/components/vector-kubearchive-log-collector/staging/stone-stg-rh01/vector-helm-stg-values.yaml
+++ b/components/vector-kubearchive-log-collector/staging/stone-stg-rh01/vector-helm-stg-values.yaml
@@ -11,8 +11,7 @@ customConfig:
   sources:
     k8s_logs:
       extra_label_selector: "app.kubernetes.io/managed-by in (tekton-pipelines,pipelinesascode.tekton.dev)"
-      exclude_namespace:
-        - product-kubearchive-logging
+      extra_field_selector: "metadata.namespace!=product-kubearchive-logging"
 
 podLabels:
   vector.dev/exclude: "false"


### PR DESCRIPTION
Fix a mistake introduced in: https://github.com/redhat-appstudio/infra-deployments/pull/8085

The field config didn't exist, we should use [extra_field_selector](https://vector.dev/docs/reference/configuration/sources/kubernetes_logs/#extra_field_selector) instead.