### PR TITLE
Disable loki structured metadata

### DIFF
--- a/components/vector-kubearchive-log-collector/development/loki-helm-dev-values.yaml
+++ b/components/vector-kubearchive-log-collector/development/loki-helm-dev-values.yaml
@@ -53,7 +53,6 @@ loki:
     reject_old_samples: true
     reject_old_samples_max_age: 6h  # Reduce from 168h
     discover_service_name: []
-    allow_structured_metadata: true
     volume_enabled: true
     max_global_streams_per_user: 10000  # Reduce from 50000
     max_entries_limit_per_query: 100000

--- a/components/vector-kubearchive-log-collector/production/stone-prod-p02/loki-helm-prod-values.yaml
+++ b/components/vector-kubearchive-log-collector/production/stone-prod-p02/loki-helm-prod-values.yaml
@@ -34,7 +34,6 @@ loki:
       reject_old_samples: false
       reject_old_samples_max_age: 168h
       discover_service_name: []
-      allow_structured_metadata: true
       volume_enabled: true
       max_global_streams_per_user: 50000
       max_entries_limit_per_query: 100000

--- a/components/vector-kubearchive-log-collector/staging/stone-stg-rh01/loki-helm-stg-values.yaml
+++ b/components/vector-kubearchive-log-collector/staging/stone-stg-rh01/loki-helm-stg-values.yaml
@@ -33,7 +33,6 @@ loki:
       reject_old_samples: false
       reject_old_samples_max_age: 168h
       discover_service_name: []
-      allow_structured_metadata: true
       volume_enabled: true
       max_global_streams_per_user: 50000
       max_entries_limit_per_query: 100000


### PR DESCRIPTION
We are sending the logs reduced and in text format so there is no metadata sent. We should disable the `allow_structured_metadata` config parameter of loki (default value) 

More info in https://grafana.com/docs/loki/latest/send-data/promtail/stages/structured_metadata/