### PR TITLE
Disable adding the extra label detected_level

### DIFF
--- a/components/vector-kubearchive-log-collector/development/loki-helm-dev-values.yaml
+++ b/components/vector-kubearchive-log-collector/development/loki-helm-dev-values.yaml
@@ -53,6 +53,7 @@ loki:
     reject_old_samples: true
     reject_old_samples_max_age: 6h  # Reduce from 168h
     discover_service_name: []
+    discover_log_levels: false
     volume_enabled: true
     max_global_streams_per_user: 10000  # Reduce from 50000
     max_entries_limit_per_query: 100000

--- a/components/vector-kubearchive-log-collector/production/stone-prod-p02/loki-helm-prod-values.yaml
+++ b/components/vector-kubearchive-log-collector/production/stone-prod-p02/loki-helm-prod-values.yaml
@@ -34,6 +34,7 @@ loki:
       reject_old_samples: false
       reject_old_samples_max_age: 168h
       discover_service_name: []
+      discover_log_levels: false
       volume_enabled: true
       max_global_streams_per_user: 50000
       max_entries_limit_per_query: 100000

--- a/components/vector-kubearchive-log-collector/staging/stone-stg-rh01/loki-helm-stg-values.yaml
+++ b/components/vector-kubearchive-log-collector/staging/stone-stg-rh01/loki-helm-stg-values.yaml
@@ -33,6 +33,7 @@ loki:
       reject_old_samples: false
       reject_old_samples_max_age: 168h
       discover_service_name: []
+      discover_log_levels: false
       volume_enabled: true
       max_global_streams_per_user: 50000
       max_entries_limit_per_query: 100000


### PR DESCRIPTION
The logs of each containers are sometimes considered for different streams and this is due to the created "detected_level" label that loki automatically ingests to the logs.

With this we are ensuring that the stream of a container is unique.

Related docs: https://grafana.com/docs/loki/latest/configure/#limits_config