### PR TITLE
Disable unneeded ruler

### DIFF
--- a/components/vector-kubearchive-log-collector/development/loki-helm-dev-values.yaml
+++ b/components/vector-kubearchive-log-collector/development/loki-helm-dev-values.yaml
@@ -29,7 +29,6 @@ loki:
   storage:
     bucketNames:
       chunks: loki-data
-      ruler: loki-data
       admin: loki-data
     s3:
       endpoint: http://minio:9000
@@ -156,9 +155,6 @@ indexGateway:
     limits:
       memory: 256Mi  # Reduce from 512Mi
   affinity: {}
-
-ruler:
-  replicas: 0  # Disable ruler - not essential for basic log functionality
 
 # Disable all cache components to avoid Pending issues in development
 chunksCache:

--- a/components/vector-kubearchive-log-collector/development/loki-helm-values.yaml
+++ b/components/vector-kubearchive-log-collector/development/loki-helm-values.yaml
@@ -77,4 +77,6 @@ bloomGateway:
 lokiCanary:
   enabled: false
 
-
+# Disable the ruler - not needed as we aren't using metrics
+ruler:
+  enabled: false

--- a/components/vector-kubearchive-log-collector/production/stone-prod-p02/loki-helm-generator.yaml
+++ b/components/vector-kubearchive-log-collector/production/stone-prod-p02/loki-helm-generator.yaml
@@ -21,7 +21,6 @@ valuesInline:
     storage:
       bucketNames:
         chunks: stone-prod-p02-loki-storage
-        ruler: stone-prod-p02-loki-storage
         admin: stone-prod-p02-loki-storage
     storage_config:
       aws:

--- a/components/vector-kubearchive-log-collector/production/stone-prod-p02/loki-helm-prod-values.yaml
+++ b/components/vector-kubearchive-log-collector/production/stone-prod-p02/loki-helm-prod-values.yaml
@@ -50,13 +50,6 @@ loki:
   query_range:
     # split_queries_by_interval deprecated in Loki 3.x - removed
     parallelise_shardable_queries: true
-  # Configure ruler storage to use local filesystem
-  ruler:
-    rule_path: /var/loki/ruler
-    storage:
-      type: local
-      local:
-        directory: /var/loki/ruler
 
 # Distributed components configuration
 ingester:
@@ -149,15 +142,6 @@ indexGateway:
     limits:
       memory: 1Gi
   affinity: {}
-
-ruler:
-  replicas: 1
-  resources:
-    requests:
-      cpu: 100m
-      memory: 256Mi
-    limits:
-      memory: 512Mi
 
 # Enable Memcached caches for performance
 chunksCache:

--- a/components/vector-kubearchive-log-collector/production/stone-prod-p02/loki-helm-values.yaml
+++ b/components/vector-kubearchive-log-collector/production/stone-prod-p02/loki-helm-values.yaml
@@ -77,3 +77,7 @@ bloomGateway:
 # Disable lokiCanary - not essential for core functionality
 lokiCanary:
   enabled: false
+
+# Disable the ruler - not needed as we aren't using metrics
+ruler:
+  enabled: false

--- a/components/vector-kubearchive-log-collector/staging/stone-stg-rh01/loki-helm-generator.yaml
+++ b/components/vector-kubearchive-log-collector/staging/stone-stg-rh01/loki-helm-generator.yaml
@@ -21,7 +21,6 @@ valuesInline:
     storage:
       bucketNames:
         chunks: stone-stg-rh01-loki-storage
-        ruler: stone-stg-rh01-loki-storage
         admin: stone-stg-rh01-loki-storage
     storage_config:
       aws:

--- a/components/vector-kubearchive-log-collector/staging/stone-stg-rh01/loki-helm-stg-values.yaml
+++ b/components/vector-kubearchive-log-collector/staging/stone-stg-rh01/loki-helm-stg-values.yaml
@@ -50,13 +50,6 @@ loki:
   query_range:
     # split_queries_by_interval deprecated in Loki 3.x - removed
     parallelise_shardable_queries: true
-  # Configure ruler storage to use local filesystem
-  ruler:
-    rule_path: /var/loki/ruler
-    storage:
-      type: local
-      local:
-        directory: /var/loki/ruler
 
 # Distributed components configuration
 ingester:
@@ -149,15 +142,6 @@ indexGateway:
     limits:
       memory: 1Gi
   affinity: {}
-
-ruler:
-  replicas: 1
-  resources:
-    requests:
-      cpu: 100m
-      memory: 256Mi
-    limits:
-      memory: 512Mi
 
 # Enable Memcached caches for performance
 chunksCache:

--- a/components/vector-kubearchive-log-collector/staging/stone-stg-rh01/loki-helm-values.yaml
+++ b/components/vector-kubearchive-log-collector/staging/stone-stg-rh01/loki-helm-values.yaml
@@ -76,3 +76,7 @@ bloomGateway:
 # Disable lokiCanary - not essential for core functionality
 lokiCanary:
   enabled: false
+
+# Disable the ruler - not needed as we aren't using metrics
+ruler:
+  enabled: false


### PR DESCRIPTION
We don't need the ruler as we are not using metrics, we just want the simplest loki feature for storing the logs. With this change we want to simplify the deployment as well as reducing the amount of used resources.