### PR TITLE
Fix disabling of self-provisioning

### DIFF
--- a/configs/disable-self-provisioning-for-all-cluster/self-provisioners_clusterrolebinding.yaml
+++ b/configs/disable-self-provisioning-for-all-cluster/self-provisioners_clusterrolebinding.yaml
@@ -2,7 +2,10 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   annotations:
-    argocd.argoproj.io/sync-options: ServerSideApply=true
     rbac.authorization.kubernetes.io/autoupdate: 'false'
   name: self-provisioners
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: self-provisioner
 subjects: [] # no one is allowed here


### PR DESCRIPTION
In fa6e3ce9b73051eca7105b366bdf577f6414bb6a, the intent was to patch self-provisioning clusterrolebingind to clear the subjects. This does not work for clusters where the CRB does not exists. Instead of doing different change base on cluster, if we do client side apply with a complete CRB in argo, it will work in both cases, when CRB exist and when it does not.