### PR TITLE
KFLUXINFRA-2182: Deprecated Restic Backups in OADP 1.5.0

### DIFF
--- a/components/backup/base/all-clusters/oadp/dpa.yaml
+++ b/components/backup/base/all-clusters/oadp/dpa.yaml
@@ -21,9 +21,10 @@ spec:
           prefix: velero
         provider: aws
   configuration:
-    restic:
-      enable: false
     velero:
       defaultPlugins:
         - openshift
         - aws
+    nodeAgent:
+      enable: true
+      uploaderType: kopia


### PR DESCRIPTION
https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html/backup_and_restore/oadp-application-backup-and-restore#deprecated-features-1-5-0_oadp-1-5-release-notes