### PR TITLE
Increase the chunk size to be flushed to s3

### DIFF
--- a/components/vector-kubearchive-log-collector/production/stone-prod-p02/loki-helm-prod-values.yaml
+++ b/components/vector-kubearchive-log-collector/production/stone-prod-p02/loki-helm-prod-values.yaml
@@ -40,7 +40,7 @@ loki:
       max_entries_limit_per_query: 100000
       increment_duplicate_timestamp: true
   ingester:
-    chunk_target_size: 1536000
+    chunk_target_size: 4194304        # 4MB
     chunk_idle_period: 1m
     max_chunk_age: 1h
     chunk_encoding: snappy            # Compress data (reduces S3 transfer size)

--- a/components/vector-kubearchive-log-collector/staging/stone-stg-rh01/loki-helm-stg-values.yaml
+++ b/components/vector-kubearchive-log-collector/staging/stone-stg-rh01/loki-helm-stg-values.yaml
@@ -39,7 +39,7 @@ loki:
       max_entries_limit_per_query: 100000
       increment_duplicate_timestamp: true
   ingester:
-    chunk_target_size: 1048576
+    chunk_target_size: 4194304  # 4MB
     chunk_idle_period: 5m
     max_chunk_age: 2h
     chunk_retain_period: 1h


### PR DESCRIPTION
To stop getting messages like this:

level=error ts=2025-09-15T09:26:19.457202573Z caller=flush.go:261 component=ingester loop=21 org_id=kubearchive msg="failed to flush" retries=0 err="failed to flush chunks: store put chunk: SlowDown: Please reduce your request rate.\n\tstatus code: 503,

I'm increasing the chunk size