### PR TITLE
Increase the max global streams in prod

### DIFF
--- a/components/vector-kubearchive-log-collector/production/stone-prod-p02/loki-helm-prod-values.yaml
+++ b/components/vector-kubearchive-log-collector/production/stone-prod-p02/loki-helm-prod-values.yaml
@@ -36,7 +36,7 @@ loki:
       discover_service_name: []
       discover_log_levels: false
       volume_enabled: true
-      max_global_streams_per_user: 50000
+      max_global_streams_per_user: 75000
       max_entries_limit_per_query: 100000
       increment_duplicate_timestamp: true
   ingester:


### PR DESCRIPTION
To prevent this errors seen in prod:

	
level=warn ts=2025-09-13T09:23:32.678944981Z caller=grpc_logging.go:76 method=/logproto.Pusher/Push duration=123.525µs msg=gRPC err="rpc error: code = Code(429) desc = Maximum active stream limit exceeded when trying to create stream {stream=\"93e2e14a-22ad-411f-9e41-919660f87269-place-scripts\"}, reduce the number of active streams (reduce labels or reduce label values), or contact your Loki administrator to see if the limit can be increased, user: 'kubearchive'"

I'm increasing the maximum number of streams.

I cannot decrease the cardinality because I need to have a label per container and we already have the minimum streams needed.