### PR TITLE
KFLUXINFRA-2150 - Update AWS AMIs for x86_64 and ARM64 architectures

### DIFF
--- a/components/multi-platform-controller/production-downstream/kflux-rhel-p01/host-config.yaml
+++ b/components/multi-platform-controller/production-downstream/kflux-rhel-p01/host-config.yaml
@@ -63,7 +63,7 @@ data:
   # cpu:memory (1:4)
   dynamic.linux-arm64.type: aws
   dynamic.linux-arm64.region: us-east-1
-  dynamic.linux-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-arm64.ami: ami-048b8750a6016535e # RHEL 9.6, kernel 5.14.0-570.41.1.el9_6
   dynamic.linux-arm64.instance-type: m6g.large
   dynamic.linux-arm64.instance-tag: prod-arm64
   dynamic.linux-arm64.key-name: kflux-rhel-p01-key-pair
@@ -75,7 +75,7 @@ data:
 
   dynamic.linux-mlarge-arm64.type: aws
   dynamic.linux-mlarge-arm64.region: us-east-1
-  dynamic.linux-mlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-mlarge-arm64.ami: ami-048b8750a6016535e
   dynamic.linux-mlarge-arm64.instance-type: m6g.large
   dynamic.linux-mlarge-arm64.instance-tag: prod-arm64-mlarge
   dynamic.linux-mlarge-arm64.key-name: kflux-rhel-p01-key-pair
@@ -87,7 +87,7 @@ data:
 
   dynamic.linux-d160-mlarge-arm64.type: aws
   dynamic.linux-d160-mlarge-arm64.region: us-east-1
-  dynamic.linux-d160-mlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-d160-mlarge-arm64.ami: ami-048b8750a6016535e
   dynamic.linux-d160-mlarge-arm64.instance-type: m6g.large
   dynamic.linux-d160-mlarge-arm64.instance-tag: prod-arm64-mlarge-d160
   dynamic.linux-d160-mlarge-arm64.key-name: kflux-rhel-p01-key-pair
@@ -100,7 +100,7 @@ data:
 
   dynamic.linux-mxlarge-arm64.type: aws
   dynamic.linux-mxlarge-arm64.region: us-east-1
-  dynamic.linux-mxlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-mxlarge-arm64.ami: ami-048b8750a6016535e
   dynamic.linux-mxlarge-arm64.instance-type: m6g.xlarge
   dynamic.linux-mxlarge-arm64.instance-tag: prod-arm64-mxlarge
   dynamic.linux-mxlarge-arm64.key-name: kflux-rhel-p01-key-pair
@@ -112,7 +112,7 @@ data:
 
   dynamic.linux-d160-mxlarge-arm64.type: aws
   dynamic.linux-d160-mxlarge-arm64.region: us-east-1
-  dynamic.linux-d160-mxlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-d160-mxlarge-arm64.ami: ami-048b8750a6016535e
   dynamic.linux-d160-mxlarge-arm64.instance-type: m6g.xlarge
   dynamic.linux-d160-mxlarge-arm64.instance-tag: prod-arm64-mxlarge-d160
   dynamic.linux-d160-mxlarge-arm64.key-name: kflux-rhel-p01-key-pair
@@ -125,7 +125,7 @@ data:
 
   dynamic.linux-m2xlarge-arm64.type: aws
   dynamic.linux-m2xlarge-arm64.region: us-east-1
-  dynamic.linux-m2xlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-m2xlarge-arm64.ami: ami-048b8750a6016535e
   dynamic.linux-m2xlarge-arm64.instance-type: m6g.2xlarge
   dynamic.linux-m2xlarge-arm64.instance-tag: prod-arm64-m2xlarge
   dynamic.linux-m2xlarge-arm64.key-name: kflux-rhel-p01-key-pair
@@ -137,7 +137,7 @@ data:
 
   dynamic.linux-d160-m2xlarge-arm64.type: aws
   dynamic.linux-d160-m2xlarge-arm64.region: us-east-1
-  dynamic.linux-d160-m2xlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-d160-m2xlarge-arm64.ami: ami-048b8750a6016535e
   dynamic.linux-d160-m2xlarge-arm64.instance-type: m6g.2xlarge
   dynamic.linux-d160-m2xlarge-arm64.instance-tag: prod-arm64-m2xlarge-d160
   dynamic.linux-d160-m2xlarge-arm64.key-name: kflux-rhel-p01-key-pair
@@ -150,7 +150,7 @@ data:
 
   dynamic.linux-m4xlarge-arm64.type: aws
   dynamic.linux-m4xlarge-arm64.region: us-east-1
-  dynamic.linux-m4xlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-m4xlarge-arm64.ami: ami-048b8750a6016535e
   dynamic.linux-m4xlarge-arm64.instance-type: m6g.4xlarge
   dynamic.linux-m4xlarge-arm64.instance-tag: prod-arm64-m4xlarge
   dynamic.linux-m4xlarge-arm64.key-name: kflux-rhel-p01-key-pair
@@ -162,7 +162,7 @@ data:
 
   dynamic.linux-d160-m4xlarge-arm64.type: aws
   dynamic.linux-d160-m4xlarge-arm64.region: us-east-1
-  dynamic.linux-d160-m4xlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-d160-m4xlarge-arm64.ami: ami-048b8750a6016535e
   dynamic.linux-d160-m4xlarge-arm64.instance-type: m6g.4xlarge
   dynamic.linux-d160-m4xlarge-arm64.instance-tag: prod-arm64-m4xlarge-d160
   dynamic.linux-d160-m4xlarge-arm64.key-name: kflux-rhel-p01-key-pair
@@ -175,7 +175,7 @@ data:
 
   dynamic.linux-m8xlarge-arm64.type: aws
   dynamic.linux-m8xlarge-arm64.region: us-east-1
-  dynamic.linux-m8xlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-m8xlarge-arm64.ami: ami-048b8750a6016535e
   dynamic.linux-m8xlarge-arm64.instance-type: m6g.8xlarge
   dynamic.linux-m8xlarge-arm64.instance-tag: prod-arm64-m8xlarge
   dynamic.linux-m8xlarge-arm64.key-name: kflux-rhel-p01-key-pair
@@ -187,7 +187,7 @@ data:
 
   dynamic.linux-d160-m8xlarge-arm64.type: aws
   dynamic.linux-d160-m8xlarge-arm64.region: us-east-1
-  dynamic.linux-d160-m8xlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-d160-m8xlarge-arm64.ami: ami-048b8750a6016535e
   dynamic.linux-d160-m8xlarge-arm64.instance-type: m6g.8xlarge
   dynamic.linux-d160-m8xlarge-arm64.instance-tag: prod-arm64-m8xlarge-d160
   dynamic.linux-d160-m8xlarge-arm64.key-name: kflux-rhel-p01-key-pair
@@ -200,7 +200,7 @@ data:
 
   dynamic.linux-c6gd2xlarge-arm64.type: aws
   dynamic.linux-c6gd2xlarge-arm64.region: us-east-1
-  dynamic.linux-c6gd2xlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-c6gd2xlarge-arm64.ami: ami-048b8750a6016535e
   dynamic.linux-c6gd2xlarge-arm64.instance-type: c6gd.2xlarge
   dynamic.linux-c6gd2xlarge-arm64.instance-tag: prod-arm64-c6gd2xlarge
   dynamic.linux-c6gd2xlarge-arm64.key-name: kflux-rhel-p01-key-pair
@@ -255,9 +255,9 @@ data:
      echo "Directory '/home/var-tmp' doesn't exist"
      mkdir -p /home/var-tmp /var/tmp
     fi
-    
+
     mount --bind /home/var-tmp /var/tmp
-    
+
     if [ -d "/home/ec2-user" ]; then
     echo "ec2-user home exists"
     else
@@ -276,7 +276,7 @@ data:
 
   dynamic.linux-amd64.type: aws
   dynamic.linux-amd64.region: us-east-1
-  dynamic.linux-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-amd64.ami: ami-0b010c16a8a4b9eac # RHEL 9.6, kernel 5.14.0-570.41.1.el9_6
   dynamic.linux-amd64.instance-type: m7a.large
   dynamic.linux-amd64.instance-tag: prod-amd64
   dynamic.linux-amd64.key-name: kflux-rhel-p01-key-pair
@@ -288,7 +288,7 @@ data:
 
   dynamic.linux-mlarge-amd64.type: aws
   dynamic.linux-mlarge-amd64.region: us-east-1
-  dynamic.linux-mlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-mlarge-amd64.ami: ami-0b010c16a8a4b9eac
   dynamic.linux-mlarge-amd64.instance-type: m7a.large
   dynamic.linux-mlarge-amd64.instance-tag: prod-amd64-mlarge
   dynamic.linux-mlarge-amd64.key-name: kflux-rhel-p01-key-pair
@@ -300,7 +300,7 @@ data:
 
   dynamic.linux-d160-mlarge-amd64.type: aws
   dynamic.linux-d160-mlarge-amd64.region: us-east-1
-  dynamic.linux-d160-mlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-d160-mlarge-amd64.ami: ami-0b010c16a8a4b9eac
   dynamic.linux-d160-mlarge-amd64.instance-type: m7a.large
   dynamic.linux-d160-mlarge-amd64.instance-tag: prod-amd64-mlarge-d160
   dynamic.linux-d160-mlarge-amd64.key-name: kflux-rhel-p01-key-pair
@@ -313,7 +313,7 @@ data:
 
   dynamic.linux-mxlarge-amd64.type: aws
   dynamic.linux-mxlarge-amd64.region: us-east-1
-  dynamic.linux-mxlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-mxlarge-amd64.ami: ami-0b010c16a8a4b9eac
   dynamic.linux-mxlarge-amd64.instance-type: m7a.xlarge
   dynamic.linux-mxlarge-amd64.instance-tag: prod-amd64-mxlarge
   dynamic.linux-mxlarge-amd64.key-name: kflux-rhel-p01-key-pair
@@ -325,7 +325,7 @@ data:
 
   dynamic.linux-d160-mxlarge-amd64.type: aws
   dynamic.linux-d160-mxlarge-amd64.region: us-east-1
-  dynamic.linux-d160-mxlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-d160-mxlarge-amd64.ami: ami-0b010c16a8a4b9eac
   dynamic.linux-d160-mxlarge-amd64.instance-type: m7a.xlarge
   dynamic.linux-d160-mxlarge-amd64.instance-tag: prod-amd64-mxlarge-d160
   dynamic.linux-d160-mxlarge-amd64.key-name: kflux-rhel-p01-key-pair
@@ -338,7 +338,7 @@ data:
 
   dynamic.linux-m2xlarge-amd64.type: aws
   dynamic.linux-m2xlarge-amd64.region: us-east-1
-  dynamic.linux-m2xlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-m2xlarge-amd64.ami: ami-0b010c16a8a4b9eac
   dynamic.linux-m2xlarge-amd64.instance-type: m7a.2xlarge
   dynamic.linux-m2xlarge-amd64.instance-tag: prod-amd64-m2xlarge
   dynamic.linux-m2xlarge-amd64.key-name: kflux-rhel-p01-key-pair
@@ -350,7 +350,7 @@ data:
 
   dynamic.linux-d160-m2xlarge-amd64.type: aws
   dynamic.linux-d160-m2xlarge-amd64.region: us-east-1
-  dynamic.linux-d160-m2xlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-d160-m2xlarge-amd64.ami: ami-0b010c16a8a4b9eac
   dynamic.linux-d160-m2xlarge-amd64.instance-type: m7a.2xlarge
   dynamic.linux-d160-m2xlarge-amd64.instance-tag: prod-amd64-m2xlarge-d160
   dynamic.linux-d160-m2xlarge-amd64.key-name: kflux-rhel-p01-key-pair
@@ -363,7 +363,7 @@ data:
 
   dynamic.linux-m4xlarge-amd64.type: aws
   dynamic.linux-m4xlarge-amd64.region: us-east-1
-  dynamic.linux-m4xlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-m4xlarge-amd64.ami: ami-0b010c16a8a4b9eac
   dynamic.linux-m4xlarge-amd64.instance-type: m7a.4xlarge
   dynamic.linux-m4xlarge-amd64.instance-tag: prod-amd64-m4xlarge
   dynamic.linux-m4xlarge-amd64.key-name: kflux-rhel-p01-key-pair
@@ -375,7 +375,7 @@ data:
 
   dynamic.linux-d160-m4xlarge-amd64.type: aws
   dynamic.linux-d160-m4xlarge-amd64.region: us-east-1
-  dynamic.linux-d160-m4xlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-d160-m4xlarge-amd64.ami: ami-0b010c16a8a4b9eac
   dynamic.linux-d160-m4xlarge-amd64.instance-type: m7a.4xlarge
   dynamic.linux-d160-m4xlarge-amd64.instance-tag: prod-amd64-m4xlarge-d160
   dynamic.linux-d160-m4xlarge-amd64.key-name: kflux-rhel-p01-key-pair
@@ -388,7 +388,7 @@ data:
 
   dynamic.linux-m8xlarge-amd64.type: aws
   dynamic.linux-m8xlarge-amd64.region: us-east-1
-  dynamic.linux-m8xlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-m8xlarge-amd64.ami: ami-0b010c16a8a4b9eac
   dynamic.linux-m8xlarge-amd64.instance-type: m7a.8xlarge
   dynamic.linux-m8xlarge-amd64.instance-tag: prod-amd64-m8xlarge
   dynamic.linux-m8xlarge-amd64.key-name: kflux-rhel-p01-key-pair
@@ -400,7 +400,7 @@ data:
 
   dynamic.linux-d160-m8xlarge-amd64.type: aws
   dynamic.linux-d160-m8xlarge-amd64.region: us-east-1
-  dynamic.linux-d160-m8xlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-d160-m8xlarge-amd64.ami: ami-0b010c16a8a4b9eac
   dynamic.linux-d160-m8xlarge-amd64.instance-type: m7a.8xlarge
   dynamic.linux-d160-m8xlarge-amd64.instance-tag: prod-amd64-m8xlarge-d160
   dynamic.linux-d160-m8xlarge-amd64.key-name: kflux-rhel-p01-key-pair
@@ -414,7 +414,7 @@ data:
   # cpu:memory (1:2)
   dynamic.linux-cxlarge-arm64.type: aws
   dynamic.linux-cxlarge-arm64.region: us-east-1
-  dynamic.linux-cxlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-cxlarge-arm64.ami: ami-048b8750a6016535e
   dynamic.linux-cxlarge-arm64.instance-type: c6g.xlarge
   dynamic.linux-cxlarge-arm64.instance-tag: prod-arm64-cxlarge
   dynamic.linux-cxlarge-arm64.key-name: kflux-rhel-p01-key-pair
@@ -426,7 +426,7 @@ data:
 
   dynamic.linux-c2xlarge-arm64.type: aws
   dynamic.linux-c2xlarge-arm64.region: us-east-1
-  dynamic.linux-c2xlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-c2xlarge-arm64.ami: ami-048b8750a6016535e
   dynamic.linux-c2xlarge-arm64.instance-type: c6g.2xlarge
   dynamic.linux-c2xlarge-arm64.instance-tag: prod-arm64-c2xlarge
   dynamic.linux-c2xlarge-arm64.key-name: kflux-rhel-p01-key-pair
@@ -438,7 +438,7 @@ data:
 
   dynamic.linux-c4xlarge-arm64.type: aws
   dynamic.linux-c4xlarge-arm64.region: us-east-1
-  dynamic.linux-c4xlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-c4xlarge-arm64.ami: ami-048b8750a6016535e
   dynamic.linux-c4xlarge-arm64.instance-type: c6g.4xlarge
   dynamic.linux-c4xlarge-arm64.instance-tag: prod-arm64-c4xlarge
   dynamic.linux-c4xlarge-arm64.key-name: kflux-rhel-p01-key-pair
@@ -450,7 +450,7 @@ data:
 
   dynamic.linux-c8xlarge-arm64.type: aws
   dynamic.linux-c8xlarge-arm64.region: us-east-1
-  dynamic.linux-c8xlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-c8xlarge-arm64.ami: ami-048b8750a6016535e
   dynamic.linux-c8xlarge-arm64.instance-type: c6g.8xlarge
   dynamic.linux-c8xlarge-arm64.instance-tag: prod-arm64-c8xlarge
   dynamic.linux-c8xlarge-arm64.key-name: kflux-rhel-p01-key-pair
@@ -462,7 +462,7 @@ data:
 
   dynamic.linux-cxlarge-amd64.type: aws
   dynamic.linux-cxlarge-amd64.region: us-east-1
-  dynamic.linux-cxlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-cxlarge-amd64.ami: ami-0b010c16a8a4b9eac
   dynamic.linux-cxlarge-amd64.instance-type: c6a.xlarge
   dynamic.linux-cxlarge-amd64.instance-tag: prod-amd64-cxlarge
   dynamic.linux-cxlarge-amd64.key-name: kflux-rhel-p01-key-pair
@@ -474,7 +474,7 @@ data:
 
   dynamic.linux-c2xlarge-amd64.type: aws
   dynamic.linux-c2xlarge-amd64.region: us-east-1
-  dynamic.linux-c2xlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-c2xlarge-amd64.ami: ami-0b010c16a8a4b9eac
   dynamic.linux-c2xlarge-amd64.instance-type: c6a.2xlarge
   dynamic.linux-c2xlarge-amd64.instance-tag: prod-amd64-c2xlarge
   dynamic.linux-c2xlarge-amd64.key-name: kflux-rhel-p01-key-pair
@@ -486,7 +486,7 @@ data:
 
   dynamic.linux-c4xlarge-amd64.type: aws
   dynamic.linux-c4xlarge-amd64.region: us-east-1
-  dynamic.linux-c4xlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-c4xlarge-amd64.ami: ami-0b010c16a8a4b9eac
   dynamic.linux-c4xlarge-amd64.instance-type: c6a.4xlarge
   dynamic.linux-c4xlarge-amd64.instance-tag: prod-amd64-c4xlarge
   dynamic.linux-c4xlarge-amd64.key-name: kflux-rhel-p01-key-pair
@@ -498,7 +498,7 @@ data:
 
   dynamic.linux-c8xlarge-amd64.type: aws
   dynamic.linux-c8xlarge-amd64.region: us-east-1
-  dynamic.linux-c8xlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-c8xlarge-amd64.ami: ami-0b010c16a8a4b9eac
   dynamic.linux-c8xlarge-amd64.instance-type: c6a.8xlarge
   dynamic.linux-c8xlarge-amd64.instance-tag: prod-amd64-c8xlarge
   dynamic.linux-c8xlarge-amd64.key-name: kflux-rhel-p01-key-pair
@@ -510,7 +510,7 @@ data:
 
   dynamic.linux-root-arm64.type: aws
   dynamic.linux-root-arm64.region: us-east-1
-  dynamic.linux-root-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-root-arm64.ami: ami-048b8750a6016535e
   dynamic.linux-root-arm64.instance-type: m6g.large
   dynamic.linux-root-arm64.instance-tag: prod-arm64-root
   dynamic.linux-root-arm64.key-name: kflux-rhel-p01-key-pair
@@ -527,7 +527,7 @@ data:
 
   dynamic.linux-fast-amd64.type: aws
   dynamic.linux-fast-amd64.region: us-east-1
-  dynamic.linux-fast-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-fast-amd64.ami: ami-0b010c16a8a4b9eac
   dynamic.linux-fast-amd64.instance-type: c7a.8xlarge
   dynamic.linux-fast-amd64.instance-tag: prod-amd64-fast
   dynamic.linux-fast-amd64.key-name: kflux-rhel-p01-key-pair
@@ -542,7 +542,7 @@ data:
 
   dynamic.linux-extra-fast-amd64.type: aws
   dynamic.linux-extra-fast-amd64.region: us-east-1
-  dynamic.linux-extra-fast-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-extra-fast-amd64.ami: ami-0b010c16a8a4b9eac
   dynamic.linux-extra-fast-amd64.instance-type: c7a.12xlarge
   dynamic.linux-extra-fast-amd64.instance-tag: prod-amd64-extra-fast
   dynamic.linux-extra-fast-amd64.key-name: kflux-rhel-p01-key-pair
@@ -557,7 +557,7 @@ data:
 
   dynamic.linux-root-amd64.type: aws
   dynamic.linux-root-amd64.region: us-east-1
-  dynamic.linux-root-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-root-amd64.ami: ami-0b010c16a8a4b9eac
   dynamic.linux-root-amd64.instance-type: m6idn.2xlarge
   dynamic.linux-root-amd64.instance-tag: prod-amd64-root
   dynamic.linux-root-amd64.key-name: kflux-rhel-p01-key-pair
@@ -613,9 +613,9 @@ data:
      echo "Directory '/home/var-tmp' doesn't exist"
      mkdir -p /home/var-tmp /var/tmp
     fi
-    
+
     mount --bind /home/var-tmp /var/tmp
-    
+
     if [ -d "/home/ec2-user" ]; then
     echo "ec2-user home exists"
     else


### PR DESCRIPTION
As part of the short-term strategy to fix the bug in reference, newer versions of the RHEL kernel are used in these images so that the RHEL team can verify if this fixes the issues they've been seeing. These images are based on RHEL 9.6 with kernel version 5.14.0-570.41.1.el9_6

Even if this is not the latest kernel, it matches what the static machines for IBM PowerPC use and it's not too far away from what the s390x machines are using, 5.14.0-570.37.1.el9_6.