### PR TITLE
set Prune=false on core ClusterPolicies in prod

### DIFF
--- a/components/policies/production/base/konflux-rbac/kustomization.yaml
+++ b/components/policies/production/base/konflux-rbac/kustomization.yaml
@@ -5,3 +5,5 @@ resources:
 - restrict-binding-sysauth/
 - restrict-binding-system-authenticated-releng/
 - validate-rolebindings/
+commonAnnotations:
+  argocd.argoproj.io/sync-options: Prune=false

--- a/components/policies/production/base/namespace-lister/deny-virtual-domain/kustomization.yaml
+++ b/components/policies/production/base/namespace-lister/deny-virtual-domain/kustomization.yaml
@@ -2,3 +2,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - deny-virtual-domain.yaml
+commonAnnotations:
+  argocd.argoproj.io/sync-options: Prune=false


### PR DESCRIPTION
Requires:
- [x] #8131


Deleting these policies can cause security problems.

After this change is merged, to remove these policies, either a manual intervention or an extra step to remove the annotation is required.

Signed-off-by: Francesco Ilario filario@redhat.com

