### PR TITLE
Give users permission to view Kueue Workloads

### DIFF
--- a/components/konflux-rbac/production/base/konflux-admin-user-actions.yaml
+++ b/components/konflux-rbac/production/base/konflux-admin-user-actions.yaml
@@ -199,3 +199,11 @@ rules:
       - pulp.konflux-ci.dev
     resources:
       - pulpaccessrequests
+  - verbs:
+      - get
+      - list
+      - watch
+    apiGroups:
+      - kueue.x-k8s.io
+    resources:
+      - workloads

--- a/components/konflux-rbac/production/base/konflux-contributor-user-actions.yaml
+++ b/components/konflux-rbac/production/base/konflux-contributor-user-actions.yaml
@@ -139,3 +139,11 @@ rules:
       - rbac.authorization.k8s.io
     resources:
       - rolebindings
+  - verbs:
+      - get
+      - list
+      - watch
+    apiGroups:
+      - kueue.x-k8s.io
+    resources:
+      - workloads

--- a/components/konflux-rbac/production/base/konflux-maintainer-user-actions.yaml
+++ b/components/konflux-rbac/production/base/konflux-maintainer-user-actions.yaml
@@ -156,3 +156,11 @@ rules:
       - rbac.authorization.k8s.io
     resources:
       - rolebindings
+  - verbs:
+      - get
+      - list
+      - watch
+    apiGroups:
+      - kueue.x-k8s.io
+    resources:
+      - workloads

--- a/components/konflux-rbac/production/base/konflux-viewer-user-actions.yaml
+++ b/components/konflux-rbac/production/base/konflux-viewer-user-actions.yaml
@@ -125,3 +125,11 @@ rules:
     resources:
       - cronjobs
       - jobs
+  - verbs:
+      - get
+      - list
+      - watch
+    apiGroups:
+      - kueue.x-k8s.io
+    resources:
+      - workloads

--- a/components/konflux-rbac/staging/base/konflux-admin-user-actions.yaml
+++ b/components/konflux-rbac/staging/base/konflux-admin-user-actions.yaml
@@ -199,3 +199,11 @@ rules:
       - pulp.konflux-ci.dev
     resources:
       - pulpaccessrequests
+  - verbs:
+      - get
+      - list
+      - watch
+    apiGroups:
+      - kueue.x-k8s.io
+    resources:
+      - workloads

--- a/components/konflux-rbac/staging/base/konflux-contributor-user-actions.yaml
+++ b/components/konflux-rbac/staging/base/konflux-contributor-user-actions.yaml
@@ -139,3 +139,11 @@ rules:
       - pulp.konflux-ci.dev
     resources:
       - pulpaccessrequests
+  - verbs:
+      - get
+      - list
+      - watch
+    apiGroups:
+      - kueue.x-k8s.io
+    resources:
+      - workloads

--- a/components/konflux-rbac/staging/base/konflux-maintainer-user-actions.yaml
+++ b/components/konflux-rbac/staging/base/konflux-maintainer-user-actions.yaml
@@ -156,3 +156,11 @@ rules:
       - pulp.konflux-ci.dev
     resources:
       - pulpaccessrequests
+  - verbs:
+      - get
+      - list
+      - watch
+    apiGroups:
+      - kueue.x-k8s.io
+    resources:
+      - workloads

--- a/components/konflux-rbac/staging/base/konflux-viewer-user-actions.yaml
+++ b/components/konflux-rbac/staging/base/konflux-viewer-user-actions.yaml
@@ -125,3 +125,11 @@ rules:
     resources:
       - cronjobs
       - jobs
+  - verbs:
+      - get
+      - list
+      - watch
+    apiGroups:
+      - kueue.x-k8s.io
+    resources:
+      - workloads


### PR DESCRIPTION
Until we get the status of the Workload copied into the status of the Pipelinerun, let users see Workloads so they can understand the status of the Pipelinerun in the context of queuing.