### PR TITLE
KONFLUX-9160 - Recommended lease configuration for kyverno

### DIFF
--- a/components/kyverno/production/kflux-ocp-p01/kyverno-helm-values.yaml
+++ b/components/kyverno/production/kflux-ocp-p01/kyverno-helm-values.yaml
@@ -20,6 +20,8 @@ admissionController:
         drop:
         - "ALL"
   container:
+    extraArgs:
+      leaderElectionRetryPeriod: 26s
     resources:
       requests:
         cpu: 4000m
@@ -42,6 +44,8 @@ admissionController:
     secure: false
 backgroundController:
   replicas: 3
+  extraArgs:
+    leaderElectionRetryPeriod: 26s
   resources:
     requests:
       cpu: 4000m
@@ -64,6 +68,8 @@ backgroundController:
     secure: false
 cleanupController:
   replicas: 3
+  extraArgs:
+    leaderElectionRetryPeriod: 26s
   resources:
     requests:
       cpu: 500m

--- a/components/kyverno/production/kflux-osp-p01/kyverno-helm-values.yaml
+++ b/components/kyverno/production/kflux-osp-p01/kyverno-helm-values.yaml
@@ -18,6 +18,8 @@ admissionController:
         drop:
         - "ALL"
   container:
+    extraArgs:
+      leaderElectionRetryPeriod: 26s
     resources:
       requests:
         cpu: 4000m
@@ -34,6 +36,8 @@ admissionController:
         - "ALL"
 backgroundController:
   replicas: 3
+  extraArgs:
+    leaderElectionRetryPeriod: 26s
   resources:
     requests:
       cpu: 4000m
@@ -50,6 +54,8 @@ backgroundController:
       - "ALL"
 cleanupController:
   replicas: 3
+  extraArgs:
+    leaderElectionRetryPeriod: 26s
   resources:
     requests:
       cpu: 500m

--- a/components/kyverno/production/kflux-prd-rh02/kyverno-helm-values.yaml
+++ b/components/kyverno/production/kflux-prd-rh02/kyverno-helm-values.yaml
@@ -20,6 +20,8 @@ admissionController:
         drop:
         - "ALL"
   container:
+    extraArgs:
+      leaderElectionRetryPeriod: 26s
     resources:
       requests:
         cpu: 4000m
@@ -42,6 +44,8 @@ admissionController:
     secure: false
 backgroundController:
   replicas: 3
+  extraArgs:
+    leaderElectionRetryPeriod: 26s
   resources:
     requests:
       cpu: 4000m
@@ -64,6 +68,8 @@ backgroundController:
     secure: false
 cleanupController:
   replicas: 3
+  extraArgs:
+    leaderElectionRetryPeriod: 26s
   resources:
     requests:
       cpu: 500m

--- a/components/kyverno/production/kflux-prd-rh03/kyverno-helm-values.yaml
+++ b/components/kyverno/production/kflux-prd-rh03/kyverno-helm-values.yaml
@@ -20,6 +20,8 @@ admissionController:
         drop:
         - "ALL"
   container:
+    extraArgs:
+      leaderElectionRetryPeriod: 26s
     resources:
       requests:
         cpu: 4000m
@@ -42,6 +44,8 @@ admissionController:
     secure: false
 backgroundController:
   replicas: 3
+  extraArgs:
+    leaderElectionRetryPeriod: 26s
   resources:
     requests:
       cpu: 4000m
@@ -64,6 +68,8 @@ backgroundController:
     secure: false
 cleanupController:
   replicas: 3
+  extraArgs:
+    leaderElectionRetryPeriod: 26s
   resources:
     requests:
       cpu: 500m

--- a/components/kyverno/production/kflux-rhel-p01/kyverno-helm-values.yaml
+++ b/components/kyverno/production/kflux-rhel-p01/kyverno-helm-values.yaml
@@ -20,6 +20,8 @@ admissionController:
         drop:
         - "ALL"
   container:
+    extraArgs:
+      leaderElectionRetryPeriod: 26s
     resources:
       requests:
         cpu: 4000m
@@ -42,6 +44,8 @@ admissionController:
     secure: false
 backgroundController:
   replicas: 3
+  extraArgs:
+    leaderElectionRetryPeriod: 26s
   resources:
     requests:
       cpu: 4000m
@@ -64,6 +68,8 @@ backgroundController:
     secure: false
 cleanupController:
   replicas: 3
+  extraArgs:
+    leaderElectionRetryPeriod: 26s
   resources:
     requests:
       cpu: 500m

--- a/components/kyverno/production/pentest-p01/kyverno-helm-values.yaml
+++ b/components/kyverno/production/pentest-p01/kyverno-helm-values.yaml
@@ -11,6 +11,8 @@ admissionController:
         drop:
         - "ALL"
   container:
+    extraArgs:
+      leaderElectionRetryPeriod: 26s
     resources:
       requests:
         cpu: 500m
@@ -27,6 +29,8 @@ admissionController:
         - "ALL"
 backgroundController:
   replicas: 3
+  extraArgs:
+    leaderElectionRetryPeriod: 26s
   resources:
     requests:
       cpu: 500m
@@ -43,6 +47,8 @@ backgroundController:
       - "ALL"
 cleanupController:
   replicas: 3
+  extraArgs:
+    leaderElectionRetryPeriod: 26s
   resources:
     limits:
       cpu: 500m

--- a/components/kyverno/production/stone-prd-rh01/kyverno-helm-values.yaml
+++ b/components/kyverno/production/stone-prd-rh01/kyverno-helm-values.yaml
@@ -22,7 +22,7 @@ admissionController:
         - "ALL"
   container:
     extraArgs:
-      leaderElectionRetryPeriod: 5s
+      leaderElectionRetryPeriod: 26s
     resources:
       requests:
         cpu: 6000m
@@ -48,7 +48,7 @@ backgroundController:
   extraArgs:
     clientRateLimitBurst: 2000
     clientRateLimitQPS: 2000
-    leaderElectionRetryPeriod: 5s
+    leaderElectionRetryPeriod: 26s
   resources:
     requests:
       cpu: 6000m
@@ -79,7 +79,7 @@ cleanupController:
       cpu: 500m
       memory: 128Mi
   extraArgs:
-    leaderElectionRetryPeriod: 5s
+    leaderElectionRetryPeriod: 26s
   securityContext:
     allowPrivilegeEscalation: false
     readOnlyRootFilesystem: true

--- a/components/kyverno/production/stone-prod-p01/kyverno-helm-values.yaml
+++ b/components/kyverno/production/stone-prod-p01/kyverno-helm-values.yaml
@@ -20,6 +20,8 @@ admissionController:
         drop:
         - "ALL"
   container:
+    extraArgs:
+      leaderElectionRetryPeriod: 26s
     resources:
       requests:
         cpu: 4000m
@@ -42,6 +44,8 @@ admissionController:
     secure: false
 backgroundController:
   replicas: 3
+  extraArgs:
+    leaderElectionRetryPeriod: 26s
   resources:
     requests:
       cpu: 4000m
@@ -64,6 +68,8 @@ backgroundController:
     secure: false
 cleanupController:
   replicas: 3
+  extraArgs:
+    leaderElectionRetryPeriod: 26s
   resources:
     requests:
       cpu: 500m

--- a/components/kyverno/production/stone-prod-p02/kyverno-helm-values.yaml
+++ b/components/kyverno/production/stone-prod-p02/kyverno-helm-values.yaml
@@ -22,7 +22,7 @@ admissionController:
         - "ALL"
   container:
     extraArgs:
-      leaderElectionRetryPeriod: 5s
+      leaderElectionRetryPeriod: 26s
     resources:
       requests:
         cpu: 6000m
@@ -48,7 +48,7 @@ backgroundController:
   extraArgs:
     clientRateLimitBurst: 2000
     clientRateLimitQPS: 2000
-    leaderElectionRetryPeriod: 5s
+    leaderElectionRetryPeriod: 26s
   resources:
     requests:
       cpu: 6000m
@@ -79,7 +79,7 @@ cleanupController:
       cpu: 500m
       memory: 128Mi
   extraArgs:
-    leaderElectionRetryPeriod: 5s
+    leaderElectionRetryPeriod: 26s
   securityContext:
     allowPrivilegeEscalation: false
     readOnlyRootFilesystem: true


### PR DESCRIPTION
As reported in the bug in reference, the frequent restarts in kyverno pods seem related to the controllers being unable to communicate consistently with the cluster API server. A related investigation ([KONFLUX-7952](https://issues.redhat.com//browse/KONFLUX-7952)) found a correlation between these incidents and etcd going through a defragmentation.

This commit modifies the only available parameter in kyverno to control the leader election process, increasing 'leaderElectionRetryPeriod' to 26 seconds as recommended by the OpenShift convention document  [1]. Setting this value modifies the LeaseDuration to 156 seconds and the RenewDeadline to 130 seconds according to the kyverno source code [2].

[1] https://github.com/openshift/enhancements/blob/0f916a52af1a6fbdab0c5b80ae0e66c7a27efb6a/CONVENTIONS.md#handling-kube-apiserver-disruption
[2] https://github.com/kyverno/kyverno/blob/418a845ff6cbc9c3c064ee56a633dd306a317ed8/pkg/leaderelection/leaderelection.go#L77-L78