### PR TITLE
Update gosmee server webhooks

### DIFF
--- a/components/build-service/production/kflux-osp-p01/webhook-config.json
+++ b/components/build-service/production/kflux-osp-p01/webhook-config.json
@@ -1,4 +1,4 @@
 {
-    "https://github.com": "https://smee-smee.apps.stone-prd-host1.wdlc.p1.openshiftapps.com/redhathookospp01",
-    "https://gitlab.com": "https://smee-smee.apps.stone-prd-host1.wdlc.p1.openshiftapps.com/redhathookospp01"
+    "https://github.com": "https://smee-smee.apps.rosa.kflux-c-prd-e01.yo5u.p3.openshiftapps.com/redhathookospp01",
+    "https://gitlab.com": "https://smee-smee.apps.rosa.kflux-c-prd-e01.yo5u.p3.openshiftapps.com/redhathookospp01"
 }

--- a/components/build-service/production/stone-prod-p01/webhook-config.json
+++ b/components/build-service/production/stone-prod-p01/webhook-config.json
@@ -1,4 +1,4 @@
 {
-    "https://github.com": "https://smee-smee.apps.stone-prd-host1.wdlc.p1.openshiftapps.com/redhathook12",
-    "https://gitlab.com": "https://smee-smee.apps.stone-prd-host1.wdlc.p1.openshiftapps.com/redhathook12"
+    "https://github.com": "https://smee-smee.apps.rosa.kflux-c-prd-e01.yo5u.p3.openshiftapps.com/redhathookprodp01",
+    "https://gitlab.com": "https://smee-smee.apps.rosa.kflux-c-prd-e01.yo5u.p3.openshiftapps.com/redhathookprodp01"
 }

--- a/components/smee-client/production/kflux-osp-p01/sever-url-patch.yaml
+++ b/components/smee-client/production/kflux-osp-p01/sever-url-patch.yaml
@@ -1,7 +1,7 @@
 ---
 - op: replace
   path: /spec/template/spec/containers/0/args/3
-  value: "https://smee-smee.apps.stone-prd-host1.wdlc.p1.openshiftapps.com/redhathookospp01"
+  value: "https://smee-smee.apps.rosa.kflux-c-prd-e01.yo5u.p3.openshiftapps.com/redhathookospp01"
 - op: replace
   path: /spec/template/spec/containers/1/env/1/value
-  value: "https://smee-smee.apps.stone-prd-host1.wdlc.p1.openshiftapps.com/redhathookospp01"
+  value: "https://smee-smee.apps.rosa.kflux-c-prd-e01.yo5u.p3.openshiftapps.com/redhathookospp01"

--- a/components/smee-client/production/stone-prod-p01/sever-url-patch.yaml
+++ b/components/smee-client/production/stone-prod-p01/sever-url-patch.yaml
@@ -1,7 +1,7 @@
 ---
 - op: replace
   path: /spec/template/spec/containers/0/args/3
-  value: https://smee-smee.apps.stone-prd-host1.wdlc.p1.openshiftapps.com/redhathook12
+  value: https://smee-smee.apps.rosa.kflux-c-prd-e01.yo5u.p3.openshiftapps.com/redhathookprodp01
 - op: replace
   path: /spec/template/spec/containers/1/env/1/value
-  value: https://smee-smee.apps.stone-prd-host1.wdlc.p1.openshiftapps.com/redhathook12
+  value: https://smee-smee.apps.rosa.kflux-c-prd-e01.yo5u.p3.openshiftapps.com/redhathookprodp01


### PR DESCRIPTION
[KFLUXINFRA-1786](https://issues.redhat.com//browse/KFLUXINFRA-1786)

Update the stone-prod-p01 and kflux-osp-p01 clusters's gosmee webhooks to point to the new gosmee server on the common external production cluster.