### PR TITLE
Add Konflux status page urls to info.json

### DIFF
--- a/components/konflux-info/production/kflux-ocp-p01/info.json
+++ b/components/konflux-info/production/kflux-ocp-p01/info.json
@@ -51,5 +51,6 @@
             }
         }
     ],
+    "statusPageUrl": "https://grafana.app-sre.devshift.net/d/aes1ns0htwni8a/konflux-status-page?var-cluster=kflux-ocp-p01",
     "visibility": "private"
 }

--- a/components/konflux-info/production/kflux-osp-p01/info.json
+++ b/components/konflux-info/production/kflux-osp-p01/info.json
@@ -50,5 +50,6 @@
                 "name": "konflux-contributor-user-actions"
             }
         }
-    ]
+    ],
+    "statusPageUrl": "https://grafana.app-sre.devshift.net/d/aes1ns0htwni8a/konflux-status-page?var-cluster=kflux-osp-p01"
 }

--- a/components/konflux-info/production/kflux-prd-rh02/info.json
+++ b/components/konflux-info/production/kflux-prd-rh02/info.json
@@ -51,5 +51,6 @@
             }
         }
     ],
+    "statusPageUrl": "https://grafana.app-sre.devshift.net/d/aes1ns0htwni8a/konflux-status-page?var-cluster=kflux-prd-rh02",
     "visibility": "public"
 }

--- a/components/konflux-info/production/kflux-prd-rh03/info.json
+++ b/components/konflux-info/production/kflux-prd-rh03/info.json
@@ -51,5 +51,6 @@
             }
         }
     ],
+    "statusPageUrl": "https://grafana.app-sre.devshift.net/d/aes1ns0htwni8a/konflux-status-page?var-cluster=kflux-prd-rh03",
     "visibility": "public"
 }

--- a/components/konflux-info/production/kflux-rhel-p01/info.json
+++ b/components/konflux-info/production/kflux-rhel-p01/info.json
@@ -50,5 +50,6 @@
             }
         }
     ],
+    "statusPageUrl": "https://grafana.app-sre.devshift.net/d/aes1ns0htwni8a/konflux-status-page?var-cluster=kflux-rhel-p01",
     "visibility": "private"
 }

--- a/components/konflux-info/production/pentest-p01/info.json
+++ b/components/konflux-info/production/pentest-p01/info.json
@@ -51,5 +51,6 @@
             }
         }
     ],
+    "statusPageUrl": "https://grafana.app-sre.devshift.net/d/aes1ns0htwni8a/konflux-status-page?var-cluster=pentest-p01",
     "visibility": "public"
 }

--- a/components/konflux-info/production/stone-prd-rh01/info.json
+++ b/components/konflux-info/production/stone-prd-rh01/info.json
@@ -51,5 +51,6 @@
             }
         }
     ],
+    "statusPageUrl": "https://grafana.app-sre.devshift.net/d/aes1ns0htwni8a/konflux-status-page?var-cluster=stone-prd-rh01",
     "visibility": "public"
 }

--- a/components/konflux-info/production/stone-prod-p01/info.json
+++ b/components/konflux-info/production/stone-prod-p01/info.json
@@ -51,5 +51,6 @@
             }
         }
     ],
+    "statusPageUrl": "https://grafana.app-sre.devshift.net/d/aes1ns0htwni8a/konflux-status-page?var-cluster=stone-prod-p01",
     "visibility": "private"
 }

--- a/components/konflux-info/production/stone-prod-p02/info.json
+++ b/components/konflux-info/production/stone-prod-p02/info.json
@@ -51,5 +51,6 @@
             }
         }
     ],
+    "statusPageUrl": "https://grafana.app-sre.devshift.net/d/aes1ns0htwni8a/konflux-status-page?var-cluster=stone-prod-p02",
     "visibility": "private"
 }

--- a/components/konflux-info/staging/stone-stage-p01/info.json
+++ b/components/konflux-info/staging/stone-stage-p01/info.json
@@ -51,5 +51,6 @@
             }
         }
     ],
+    "statusPageUrl": "https://grafana.app-sre.devshift.net/d/aes1ns0htwni8a/konflux-status-page?var-cluster=stone-stage-p01",
     "visibility": "private"
 }

--- a/components/konflux-info/staging/stone-stg-rh01/info.json
+++ b/components/konflux-info/staging/stone-stg-rh01/info.json
@@ -51,5 +51,6 @@
             }
         }
     ],
+    "statusPageUrl": "https://grafana.app-sre.devshift.net/d/aes1ns0htwni8a/konflux-status-page?var-cluster=stone-stg-rh01",
     "visibility": "public"
 }


### PR DESCRIPTION
This will enable the status page card in the Konflux landing page which provide users to a link to the Konflux status page for the specific cluster. This was added to Konflux UI with https://github.com/konflux-ci/konflux-ui/pull/371.

Jira: PVO11Y-4872