### PR TITLE
Update pentest-p01 gosmee server webhook

### DIFF
--- a/components/build-service/production/pentest-p01/webhook-config.json
+++ b/components/build-service/production/pentest-p01/webhook-config.json
@@ -1,4 +1,4 @@
 {
-    "https://github.com": "https://smee-smee.apps.stone-prd-host1.wdlc.p1.openshiftapps.com/redhathookpentestp01",
-    "https://gitlab.com": "https://smee-smee.apps.stone-prd-host1.wdlc.p1.openshiftapps.com/redhathookpentestp01"
+    "https://github.com": "https://smee-smee.apps.rosa.kflux-c-prd-e01.yo5u.p3.openshiftapps.com/redhathookpentestp01",
+    "https://gitlab.com": "https://smee-smee.apps.rosa.kflux-c-prd-e01.yo5u.p3.openshiftapps.com/redhathookpentestp01"
 }

--- a/components/smee-client/production/pentest-p01/sever-url-patch.yaml
+++ b/components/smee-client/production/pentest-p01/sever-url-patch.yaml
@@ -1,4 +1,4 @@
 ---
 - op: replace
   path: /spec/template/spec/containers/0/args/3
-  value: "https://smee-smee.apps.stone-prd-host1.wdlc.p1.openshiftapps.com/redhathookpentestp01"
+  value: "https://smee-smee.apps.rosa.kflux-c-prd-e01.yo5u.p3.openshiftapps.com/redhathookpentestp01"


### PR DESCRIPTION
[KFLUXINFRA-1786](https://issues.redhat.com//browse/KFLUXINFRA-1786)

Update the pentest-p01 cluster's gosmee webhook to point to the new gosmee server on the common external production cluster.