### PR TITLE
promote project-controller from STAGE to PROD

### DIFF
--- a/components/project-controller/production/kustomization.yaml
+++ b/components/project-controller/production/kustomization.yaml
@@ -2,11 +2,11 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../base
-  - https://github.com/konflux-ci/project-controller/config/default?ref=61825fbec8924330d5814f6a485fb70cea2757dd
+  - https://github.com/konflux-ci/project-controller/config/default?ref=b252edc9e91cb5e5ffb1834dd2c91bdcaa1d0569
 
 images:
 - name: konflux-project-controller
   newName: quay.io/konflux-ci/project-controller
-  newTag: 61825fbec8924330d5814f6a485fb70cea2757dd
+  newTag: b252edc9e91cb5e5ffb1834dd2c91bdcaa1d0569
 
 namespace: project-controller


### PR DESCRIPTION
Update production deployment to use STAGE SHA b252edc9e91cb5e5ffb1834dd2c91bdcaa1d0569

This promotes 22 commits from STAGE including:
- Improved CRD comments and API documentation
- Fixed configure-pac loops (KFLUXVNGF-433)
- Multiple dependency updates and infrastructure improvements

Assisted-By: Cursor (Default model)