### PR TITLE
Fix empty namespace in logging configmap

### DIFF
--- a/components/kubearchive/production/stone-prod-p02/kustomization.yaml
+++ b/components/kubearchive/production/stone-prod-p02/kustomization.yaml
@@ -19,6 +19,7 @@ patches:
         namespace: kubearchive
       data:
         POD_ID: "cel:metadata.uid"
+        NAMESPACE: "cel:metadata.namespace"
         START: "cel:status.?startTime == optional.none() ? int(now()-duration('1h'))*1000000000: status.startTime"
         END: "cel:status.?startTime == optional.none() ? int(now()+duration('1h'))*1000000000: int(timestamp(status.startTime)+duration('6h'))*1000000000" # temporary workaround until CONTAINER_NAME is allowed on CEL expressions as variable: 6 hours since the container started
         LOG_URL: "http://loki-gateway.product-kubearchive-logging.svc.cluster.local:80/loki/api/v1/query_range?query=%7Bstream%3D%22{NAMESPACE}%22%7D%20%7C%20pod_id%20%3D%20%60{POD_ID}%60%20%7C%20container%20%3D%20%60{CONTAINER_NAME}%60&start={START}&end={END}&direction=forward"

--- a/components/kubearchive/staging/base/kustomization.yaml
+++ b/components/kubearchive/staging/base/kustomization.yaml
@@ -14,6 +14,7 @@ patches:
         namespace: product-kubearchive
       data:
         POD_ID: "cel:metadata.uid"
+        NAMESPACE: "cel:metadata.namespace"
         START: "cel:status.?startTime == optional.none() ? int(now()-duration('1h'))*1000000000: status.startTime"
         END: "cel:status.?startTime == optional.none() ? int(now()+duration('1h'))*1000000000: int(timestamp(status.startTime)+duration('6h'))*1000000000" # temporary workaround until CONTAINER_NAME is allowed on CEL expressions as variable: 6 hours since the container started
         LOG_URL: "http://loki-gateway.product-kubearchive-logging.svc.cluster.local:80/loki/api/v1/query_range?query=%7Bstream%3D%22{NAMESPACE}%22%7D%20%7C%20pod_id%20%3D%20%60{POD_ID}%60%20%7C%20container%20%3D%20%60{CONTAINER_NAME}%60&start={START}&end={END}&direction=forward"


### PR DESCRIPTION
The namespace is empty, we need to properly declare it in the kubearchive-logging configmap