### PR TITLE
Remove adm64 from local platforms on staging

### DIFF
--- a/components/kueue/staging/stone-stage-p01/queue-config/cluster-queue.yaml
+++ b/components/kueue/staging/stone-stage-p01/queue-config/cluster-queue.yaml
@@ -60,7 +60,7 @@ spec:
     - name: platform-group-1
       resources:
       - name: linux-amd64
-        nominalQuota: '1000'
+        nominalQuota: '250'
       - name: linux-arm64
         nominalQuota: '250'
       - name: linux-c2xlarge-amd64

--- a/components/kueue/staging/stone-stg-rh01/queue-config/cluster-queue.yaml
+++ b/components/kueue/staging/stone-stg-rh01/queue-config/cluster-queue.yaml
@@ -60,7 +60,7 @@ spec:
     - name: platform-group-1
       resources:
       - name: linux-amd64
-        nominalQuota: '1000'
+        nominalQuota: '250'
       - name: linux-arm64
         nominalQuota: '250'
       - name: linux-c2xlarge-amd64

--- a/components/multi-platform-controller/staging-downstream/host-config.yaml
+++ b/components/multi-platform-controller/staging-downstream/host-config.yaml
@@ -7,12 +7,12 @@ metadata:
   namespace: multi-platform-controller
 data:
   local-platforms: "\
-    linux/amd64,\
     linux/x86_64,\
     local,\
     localhost,\
     "
   dynamic-platforms: "\
+    linux/amd64,\
     linux/arm64,\
     linux-mlarge/amd64,\
     linux-mlarge/arm64,\
@@ -76,19 +76,6 @@ data:
   dynamic.linux-mlarge-arm64.subnet-id: subnet-07597d1edafa2b9d3
   dynamic.linux-mlarge-arm64.allocation-timeout: "1200"
 
-  dynamic.linux-mlarge-amd64.type: aws
-  dynamic.linux-mlarge-amd64.region: us-east-1
-  dynamic.linux-mlarge-amd64.ami: ami-026ebd4cfe2c043b2
-  dynamic.linux-mlarge-amd64.instance-type: m6a.large
-  dynamic.linux-mlarge-amd64.instance-tag: stage-amd64-mlarge
-  dynamic.linux-mlarge-amd64.key-name: konflux-stage-int-mab01
-  dynamic.linux-mlarge-amd64.aws-secret: aws-account
-  dynamic.linux-mlarge-amd64.ssh-secret: aws-ssh-key
-  dynamic.linux-mlarge-amd64.security-group-id: sg-0482e8ccae008b240
-  dynamic.linux-mlarge-amd64.max-instances: "250"
-  dynamic.linux-mlarge-amd64.subnet-id: subnet-07597d1edafa2b9d3
-  dynamic.linux-mlarge-amd64.allocation-timeout: "1200"
-
   dynamic.linux-mxlarge-arm64.type: aws
   dynamic.linux-mxlarge-arm64.region: us-east-1
   dynamic.linux-mxlarge-arm64.ami: ami-03d6a5256a46c9feb
@@ -140,6 +127,33 @@ data:
   dynamic.linux-m8xlarge-arm64.max-instances: "250"
   dynamic.linux-m8xlarge-arm64.subnet-id: subnet-07597d1edafa2b9d3
   dynamic.linux-m8xlarge-arm64.allocation-timeout: "1200"
+
+
+  dynamic.linux-amd64.type: aws
+  dynamic.linux-amd64.region: us-east-1
+  dynamic.linux-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-amd64.instance-type: m6a.large
+  dynamic.linux-amd64.instance-tag: stage-amd64
+  dynamic.linux-amd64.key-name: konflux-stage-int-mab01
+  dynamic.linux-amd64.aws-secret: aws-account
+  dynamic.linux-amd64.ssh-secret: aws-ssh-key
+  dynamic.linux-amd64.security-group-id: sg-0482e8ccae008b240
+  dynamic.linux-amd64.max-instances: "250"
+  dynamic.linux-amd64.subnet-id: subnet-07597d1edafa2b9d3
+  dynamic.linux-amd64.allocation-timeout: "1200"
+
+  dynamic.linux-mlarge-amd64.type: aws
+  dynamic.linux-mlarge-amd64.region: us-east-1
+  dynamic.linux-mlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-mlarge-amd64.instance-type: m6a.large
+  dynamic.linux-mlarge-amd64.instance-tag: stage-amd64-mlarge
+  dynamic.linux-mlarge-amd64.key-name: konflux-stage-int-mab01
+  dynamic.linux-mlarge-amd64.aws-secret: aws-account
+  dynamic.linux-mlarge-amd64.ssh-secret: aws-ssh-key
+  dynamic.linux-mlarge-amd64.security-group-id: sg-0482e8ccae008b240
+  dynamic.linux-mlarge-amd64.max-instances: "250"
+  dynamic.linux-mlarge-amd64.subnet-id: subnet-07597d1edafa2b9d3
+  dynamic.linux-mlarge-amd64.allocation-timeout: "1200"
 
   dynamic.linux-mxlarge-amd64.type: aws
   dynamic.linux-mxlarge-amd64.region: us-east-1

--- a/components/multi-platform-controller/staging/host-config.yaml
+++ b/components/multi-platform-controller/staging/host-config.yaml
@@ -7,12 +7,12 @@ metadata:
   namespace: multi-platform-controller
 data:
   local-platforms: "\
-    linux/amd64,\
     linux/x86_64,\
     local,\
     localhost,\
     "
   dynamic-platforms: "\
+    linux/amd64,\
     linux/arm64,\
     linux-mlarge/amd64,\
     linux-mlarge/arm64,\
@@ -73,18 +73,6 @@ data:
   dynamic.linux-mlarge-arm64.security-group-id: sg-05bc8dd0b52158567
   dynamic.linux-mlarge-arm64.max-instances: "250"
   dynamic.linux-mlarge-arm64.subnet-id: subnet-030738beb81d3863a
-
-  dynamic.linux-mlarge-amd64.type: aws
-  dynamic.linux-mlarge-amd64.region: us-east-1
-  dynamic.linux-mlarge-amd64.ami: ami-026ebd4cfe2c043b2
-  dynamic.linux-mlarge-amd64.instance-type: m6a.large
-  dynamic.linux-mlarge-amd64.instance-tag: stage-amd64-mlarge
-  dynamic.linux-mlarge-amd64.key-name: konflux-stage-ext-mab01
-  dynamic.linux-mlarge-amd64.aws-secret: aws-account
-  dynamic.linux-mlarge-amd64.ssh-secret: aws-ssh-key
-  dynamic.linux-mlarge-amd64.security-group-id: sg-05bc8dd0b52158567
-  dynamic.linux-mlarge-amd64.max-instances: "250"
-  dynamic.linux-mlarge-amd64.subnet-id: subnet-030738beb81d3863a
 
   dynamic.linux-mxlarge-arm64.type: aws
   dynamic.linux-mxlarge-arm64.region: us-east-1
@@ -209,6 +197,30 @@ data:
     restorecon -r /home/ec2-user
 
     --//--
+
+  dynamic.linux-amd64.type: aws
+  dynamic.linux-amd64.region: us-east-1
+  dynamic.linux-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-amd64.instance-type: m6a.large
+  dynamic.linux-amd64.instance-tag: stage-amd64
+  dynamic.linux-amd64.key-name: konflux-stage-ext-mab01
+  dynamic.linux-amd64.aws-secret: aws-account
+  dynamic.linux-amd64.ssh-secret: aws-ssh-key
+  dynamic.linux-amd64.security-group-id: sg-05bc8dd0b52158567
+  dynamic.linux-amd64.max-instances: "250"
+  dynamic.linux-amd64.subnet-id: subnet-030738beb81d3863a
+
+  dynamic.linux-mlarge-amd64.type: aws
+  dynamic.linux-mlarge-amd64.region: us-east-1
+  dynamic.linux-mlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-mlarge-amd64.instance-type: m6a.large
+  dynamic.linux-mlarge-amd64.instance-tag: stage-amd64-mlarge
+  dynamic.linux-mlarge-amd64.key-name: konflux-stage-ext-mab01
+  dynamic.linux-mlarge-amd64.aws-secret: aws-account
+  dynamic.linux-mlarge-amd64.ssh-secret: aws-ssh-key
+  dynamic.linux-mlarge-amd64.security-group-id: sg-05bc8dd0b52158567
+  dynamic.linux-mlarge-amd64.max-instances: "250"
+  dynamic.linux-mlarge-amd64.subnet-id: subnet-030738beb81d3863a
 
   dynamic.linux-mxlarge-amd64.type: aws
   dynamic.linux-mxlarge-amd64.region: us-east-1


### PR DESCRIPTION
The intent was to migrate amd64 to local platforms but the migration was never completed, it was only done on staging. Revert that back to staging and prod are configured the same way.