### PR TITLE
feat: collect metrics from nginx in proxy pod

### DIFF
--- a/components/konflux-ui/staging/base/proxy/nginx.conf
+++ b/components/konflux-ui/staging/base/proxy/nginx.conf
@@ -34,6 +34,7 @@ http {
     }
 
     server {
+        listen 8888;
         listen 9443 ssl;
         ssl_certificate /mnt/tls.crt;
         ssl_certificate_key /mnt/tls.key;
@@ -43,6 +44,12 @@ http {
         location / {
             alias /opt/app-root/src/static-content/;
             try_files $uri /index.html;
+        }
+
+        location /nginx_status {
+            stub_status;
+            allow 127.0.0.1;
+            deny all;
         }
 
         location = /404.html {

--- a/components/konflux-ui/staging/base/proxy/nginx.conf
+++ b/components/konflux-ui/staging/base/proxy/nginx.conf
@@ -34,7 +34,6 @@ http {
     }
 
     server {
-        listen 8888;
         listen 9443 ssl;
         ssl_certificate /mnt/tls.crt;
         ssl_certificate_key /mnt/tls.key;
@@ -44,12 +43,6 @@ http {
         location / {
             alias /opt/app-root/src/static-content/;
             try_files $uri /index.html;
-        }
-
-        location /nginx_status {
-            stub_status;
-            allow 127.0.0.1;
-            deny all;
         }
 
         location = /404.html {
@@ -135,5 +128,21 @@ http {
         }
 
         include /mnt/nginx-additional-location-configs/*.conf;
+    }
+
+    server {
+        listen 9090;
+        server_name _;
+
+        location /metrics {
+            stub_status on;
+            access_log off;
+            allow all;
+        }
+
+        location /health {
+            return 200 'healthy';
+            add_header Content-Type text/plain;
+        }
     }
 }

--- a/components/konflux-ui/staging/base/proxy/proxy.yaml
+++ b/components/konflux-ui/staging/base/proxy/proxy.yaml
@@ -117,9 +117,6 @@ spec:
         - containerPort: 8080
           name: web
           protocol: TCP
-        - containerPort: 8888
-          name: web-metrics
-          protocol: TCP
         - containerPort: 9443
           name: web-tls
           protocol: TCP
@@ -179,6 +176,26 @@ spec:
           requests:
             cpu: 30m
             memory: 128Mi
+        securityContext:
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 1001
+      - image: nginx/nginx-prometheus-exporter:1.1.0
+        name: nginx-prometheus-exporter
+        args:
+          - -nginx.scrape-uri=http://localhost:9090/metrics
+          - -web.listen-address=:9113
+        ports:
+          - containerPort: 9113
+            name: exporter
+            protocol: TCP
+        resources:
+          limits:
+            cpu: 100m
+            memory: 64Mi
+          requests:
+            cpu: 10m
+            memory: 32Mi
         securityContext:
           readOnlyRootFilesystem: true
           runAsNonRoot: true
@@ -303,3 +320,19 @@ subjects:
 - kind: ServiceAccount
   name: proxy
   namespace: konflux-ui
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: proxy-nginx-metrics
+  labels:
+    app: proxy
+spec:
+  endpoints:
+  - port: exporter
+    path: /metrics
+    interval: 30s
+    scheme: http
+  selector:
+    matchLabels:
+      app: proxy

--- a/components/konflux-ui/staging/base/proxy/proxy.yaml
+++ b/components/konflux-ui/staging/base/proxy/proxy.yaml
@@ -117,6 +117,9 @@ spec:
         - containerPort: 8080
           name: web
           protocol: TCP
+        - containerPort: 8888
+          name: web-metrics
+          protocol: TCP
         - containerPort: 9443
           name: web-tls
           protocol: TCP


### PR DESCRIPTION
Add `/nginx_status` to collect HTTP metrics from Konflux UI pod