### PR TITLE
fix: Update postgre helm charts to oci registry

### DIFF
--- a/components/pipeline-service/development/dev-only-pipeline-service-storage-configuration.yaml
+++ b/components/pipeline-service/development/dev-only-pipeline-service-storage-configuration.yaml
@@ -101,8 +101,8 @@ spec:
       - name: shmVolume.enabled
         value: "false"
       releaseName: postgres
-    repoURL: https://charts.bitnami.com/bitnami
-    targetRevision: 14.0.5
+    repoURL: registry-1.docker.io/bitnamichartssecure
+    targetRevision: 17.0.2
   syncPolicy:
     automated:
       prune: true
@@ -116,6 +116,21 @@ spec:
     syncOptions:
     - CreateNamespace=false
     - Validate=false
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: repo-bitnami-postgre
+  namespace: openshift-gitops
+  labels:
+    argocd.argoproj.io/secret-type: repository
+data:
+  enableOCI: true
+  name: bitnamisecure
+  project: default
+  type: helm
+  url: registry-1.docker.io/bitnamichartssecure
+type: Opaque
 ---
 apiVersion: minio.min.io/v2
 kind: Tenant


### PR DESCRIPTION
This pull request updates the storage configuration for the pipeline results service, primarily by switching the Helm chart repository for PostgreSQL to a secure OCI registry and adding a corresponding ArgoCD repository secret. 

Repository and chart configuration updates:

* Changed the PostgreSQL Helm chart source from `https://charts.bitnami.com/bitnami` (version 14.0.5) to the secure OCI registry `registry-1.docker.io/bitnamichartssecure` (version 17.0.2) in `dev-only-pipeline-service-storage-configuration.yaml`.

ArgoCD integration:

* Added a new Kubernetes `Secret` of type `repository` for ArgoCD, enabling access to the new secure Bitnami Helm chart registry under the `openshift-gitops` namespace.