### PR TITLE
kyverno: bump to v1.15.2 on staging

### DIFF
--- a/components/kyverno/staging/stone-stage-p01/kustomization.yaml
+++ b/components/kyverno/staging/stone-stage-p01/kustomization.yaml
@@ -4,36 +4,13 @@ kind: Kustomization
 namespace: konflux-kyverno
 
 generators:
-  - kyverno-helm-generator.yaml
-
-replacements:
-  # enforce serviceAccountName is used instead of serviceAccount in Jobs
-  # TODO: these replacements can be removed when bumping to kyverno:1.14
-  # https://github.com/kyverno/kyverno/pull/12158
-  - source:
-      group: batch
-      version: v1
-      kind: Job
-      name: konflux-kyverno-migrate-resources
-      namespace: konflux-kyverno
-      fieldPath: spec.template.spec.serviceAccount
-    targets:
-      - select:
-          group: batch
-          version: v1
-          kind: Job
-          namespace: konflux-kyverno
-          name: konflux-kyverno-migrate-resources
-        fieldPaths:
-          - spec.template.spec.serviceAccountName
-        options:
-          create: true
+- kyverno-helm-generator.yaml
 
 # set resources to jobs
 patches:
-  - path: job_resources.yaml
-    target:
-      group: batch
-      version: v1
-      kind: Job
-      name: konflux-kyverno-migrate-resources
+- path: job_resources.yaml
+  target:
+    group: batch
+    kind: Job
+    name: konflux-kyverno-migrate-resources
+    version: v1

--- a/components/kyverno/staging/stone-stage-p01/kyverno-helm-generator.yaml
+++ b/components/kyverno/staging/stone-stage-p01/kyverno-helm-generator.yaml
@@ -4,10 +4,7 @@ metadata:
   name: kyverno
 name: kyverno
 repo: https://kyverno.github.io/kyverno/
-# TODO: when bumping to kyverno:1.14 we can remove ServiceAccountName 
-# replacements from the kustomization.yaml file
-# https://github.com/kyverno/kyverno/pull/12158
-version: 3.3.7
+version: 3.5.2
 namespace: konflux-kyverno
 valuesFile: kyverno-helm-values.yaml
 releaseName: kyverno

--- a/components/kyverno/staging/stone-stage-p01/kyverno-helm-values.yaml
+++ b/components/kyverno/staging/stone-stage-p01/kyverno-helm-values.yaml
@@ -38,6 +38,11 @@ admissionController:
         - "ALL"
   metering:
     disabled: false
+  podDisruptionBudget:
+    enabled: true
+    maxUnavailable: 2
+    minAvailable: null
+    unhealthyPodEvictionPolicy: AlwaysAllow
   serviceMonitor:
     enabled: true
     # kyverno doesn't seem to support HTTPS on metrics
@@ -62,6 +67,11 @@ backgroundController:
       - "ALL"
   metering:
     disabled: false
+  podDisruptionBudget:
+    enabled: true
+    maxUnavailable: 2
+    minAvailable: null
+    unhealthyPodEvictionPolicy: AlwaysAllow
   serviceMonitor:
     enabled: true
     # kyverno doesn't seem to support HTTPS on metrics
@@ -86,6 +96,11 @@ cleanupController:
       - "ALL"
   metering:
     disabled: false
+  podDisruptionBudget:
+    enabled: true
+    maxUnavailable: 2
+    minAvailable: null
+    unhealthyPodEvictionPolicy: AlwaysAllow
   serviceMonitor:
     enabled: true
     # kyverno doesn't seem to support HTTPS on metrics

--- a/components/kyverno/staging/stone-stg-rh01/kustomization.yaml
+++ b/components/kyverno/staging/stone-stg-rh01/kustomization.yaml
@@ -6,29 +6,6 @@ namespace: konflux-kyverno
 generators:
   - kyverno-helm-generator.yaml
 
-replacements:
-  # enforce serviceAccountName is used instead of serviceAccount in Jobs
-  # TODO: these replacements can be removed when bumping to kyverno:1.14
-  # https://github.com/kyverno/kyverno/pull/12158
-  - source:
-      group: batch
-      version: v1
-      kind: Job
-      name: konflux-kyverno-migrate-resources
-      namespace: konflux-kyverno
-      fieldPath: spec.template.spec.serviceAccount
-    targets:
-      - select:
-          group: batch
-          version: v1
-          kind: Job
-          namespace: konflux-kyverno
-          name: konflux-kyverno-migrate-resources
-        fieldPaths:
-          - spec.template.spec.serviceAccountName
-        options:
-          create: true
-
 # set resources to jobs
 patches:
   - path: job_resources.yaml
@@ -37,3 +14,12 @@ patches:
       version: v1
       kind: Job
       name: konflux-kyverno-migrate-resources
+  - patch: |
+      - op: add
+        path: /spec/unhealthyPodEvictionPolicy
+        value: AlwaysAllow
+    target:
+      group: policy
+      version: v1
+      kind: PodDisruptionBudget
+      labelSelector: app.kubernetes.io/part-of=konflux-kyverno

--- a/components/kyverno/staging/stone-stg-rh01/kyverno-helm-generator.yaml
+++ b/components/kyverno/staging/stone-stg-rh01/kyverno-helm-generator.yaml
@@ -4,10 +4,7 @@ metadata:
   name: kyverno
 name: kyverno
 repo: https://kyverno.github.io/kyverno/
-# TODO: when bumping to kyverno:1.14 we can remove ServiceAccountName 
-# replacements from the kustomization.yaml file
-# https://github.com/kyverno/kyverno/pull/12158
-version: 3.3.7
+version: 3.5.2
 namespace: konflux-kyverno
 valuesFile: kyverno-helm-values.yaml
 releaseName: kyverno

--- a/components/kyverno/staging/stone-stg-rh01/kyverno-helm-values.yaml
+++ b/components/kyverno/staging/stone-stg-rh01/kyverno-helm-values.yaml
@@ -39,6 +39,11 @@ admissionController:
         - "ALL"
   metering:
     disabled: false
+  podDisruptionBudget:
+    enabled: true
+    maxUnavailable: 2
+    minAvailable: null
+    unhealthyPodEvictionPolicy: AlwaysAllow
   serviceMonitor:
     enabled: true
     # kyverno doesn't seem to support HTTPS on metrics
@@ -65,6 +70,11 @@ backgroundController:
       - "ALL"
   metering:
     disabled: false
+  podDisruptionBudget:
+    enabled: true
+    maxUnavailable: 2
+    minAvailable: null
+    unhealthyPodEvictionPolicy: AlwaysAllow
   serviceMonitor:
     enabled: true
     # kyverno doesn't seem to support HTTPS on metrics
@@ -89,6 +99,11 @@ cleanupController:
       - "ALL"
   metering:
     disabled: false
+  podDisruptionBudget:
+    enabled: true
+    maxUnavailable: 2
+    minAvailable: null
+    unhealthyPodEvictionPolicy: AlwaysAllow
   serviceMonitor:
     enabled: true
     # kyverno doesn't seem to support HTTPS on metrics


### PR DESCRIPTION
Upgrade kyverno from v1.13.4 to v1.15.2 on the staging clusters.

The PodDisruptionBudgets were having a hard time passing `kube-linter` checks (kube-linter wasn't happy with the `minAvailable` field), so modifications were needed to ensure they pass without issue.