### PR TITLE
Make sink restart on kubearchive-logging CM change

### DIFF
--- a/components/kubearchive/development/kustomization.yaml
+++ b/components/kubearchive/development/kustomization.yaml
@@ -22,6 +22,25 @@ secretGenerator:
     namespace: kubearchive
     type: Opaque
 
+# Generate kubearchive-logging ConfigMap with hash for automatic restarts
+# Due to quoting limitations of generators we need to introduce the values with the |
+# See https://github.com/kubernetes-sigs/kustomize/issues/4845#issuecomment-1671570428
+configMapGenerator:
+  - name: kubearchive-logging
+    literals:
+      - |
+        POD_ID=cel:metadata.uid
+      - |
+        NAMESPACE=cel:metadata.namespace
+      - |
+        START=cel:status.?startTime == optional.none() ? int(now()-duration('1h'))*1000000000: status.startTime
+      - |
+        END=cel:status.?startTime == optional.none() ? int(now()+duration('1h'))*1000000000: int(timestamp(status.startTime)+duration('6h'))*1000000000
+      - |
+        LOG_URL=http://loki-gateway.product-kubearchive-logging.svc.cluster.local:80/loki/api/v1/query_range?query=%7Bstream%3D%22{NAMESPACE}%22%7D%20%7C%20pod_id%20%3D%20%60{POD_ID}%60%20%7C%20container%20%3D%20%60{CONTAINER_NAME}%60&start={START}&end={END}&direction=forward
+      - |
+        LOG_URL_JSONPATH=$.data.result[*].values[*][1]
+
 patches:
   - patch: |-
       apiVersion: batch/v1
@@ -162,6 +181,7 @@ patches:
                     cpu: 200m
                     memory: 128Mi
 
+
   # We don't need this CronJob as it is suspended, we can enable it later
   - patch: |-
       $patch: delete
@@ -205,4 +225,12 @@ patches:
       kind: Certificate
       metadata:
         name: "kubearchive-operator-certificate"
+        namespace: kubearchive
+  # Delete the original ConfigMap since we're generating it with configMapGenerator
+  - patch: |-
+      $patch: delete
+      apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: kubearchive-logging
         namespace: kubearchive

--- a/components/kubearchive/production/stone-prod-p02/kustomization.yaml
+++ b/components/kubearchive/production/stone-prod-p02/kustomization.yaml
@@ -9,21 +9,34 @@ resources:
 
 namespace: product-kubearchive
 
-patches:
+# Generate kubearchive-logging ConfigMap with hash for automatic restarts
+# Due to quoting limitations of generators we need to introduce the values with the |
+# See https://github.com/kubernetes-sigs/kustomize/issues/4845#issuecomment-1671570428
+configMapGenerator:
+    - name: kubearchive-logging
+      literals:
+          - |
+              POD_ID=cel:metadata.uid
+          - |
+              NAMESPACE=cel:metadata.namespace
+          - |
+              START=cel:status.?startTime == optional.none() ? int(now()-duration('1h'))*1000000000: status.startTime
+          - |
+              END=cel:status.?startTime == optional.none() ? int(now()+duration('1h'))*1000000000: int(timestamp(status.startTime)+duration('6h'))*1000000000
+          - |
+              LOG_URL=http://loki-gateway.product-kubearchive-logging.svc.cluster.local:80/loki/api/v1/query_range?query=%7Bstream%3D%22{NAMESPACE}%22%7D%20%7C%20pod_id%20%3D%20%60{POD_ID}%60%20%7C%20container%20%3D%20%60{CONTAINER_NAME}%60&start={START}&end={END}&direction=forward
+          - |
+              LOG_URL_JSONPATH=$.data.result[*].values[*][1]
 
+patches:
   - patch: |-
+      $patch: delete
       apiVersion: v1
       kind: ConfigMap
       metadata:
         name: kubearchive-logging
         namespace: kubearchive
-      data:
-        POD_ID: "cel:metadata.uid"
-        NAMESPACE: "cel:metadata.namespace"
-        START: "cel:status.?startTime == optional.none() ? int(now()-duration('1h'))*1000000000: status.startTime"
-        END: "cel:status.?startTime == optional.none() ? int(now()+duration('1h'))*1000000000: int(timestamp(status.startTime)+duration('6h'))*1000000000" # temporary workaround until CONTAINER_NAME is allowed on CEL expressions as variable: 6 hours since the container started
-        LOG_URL: "http://loki-gateway.product-kubearchive-logging.svc.cluster.local:80/loki/api/v1/query_range?query=%7Bstream%3D%22{NAMESPACE}%22%7D%20%7C%20pod_id%20%3D%20%60{POD_ID}%60%20%7C%20container%20%3D%20%60{CONTAINER_NAME}%60&start={START}&end={END}&direction=forward"
-        LOG_URL_JSONPATH: "$.data.result[*].values[*][1]"
+
   - patch: |-
       $patch: delete
       apiVersion: v1

--- a/components/kubearchive/staging/base/kustomization.yaml
+++ b/components/kubearchive/staging/base/kustomization.yaml
@@ -7,19 +7,6 @@ resources:
 
 patches:
   - patch: |-
-      apiVersion: v1
-      kind: ConfigMap
-      metadata:
-        name: kubearchive-logging
-        namespace: product-kubearchive
-      data:
-        POD_ID: "cel:metadata.uid"
-        NAMESPACE: "cel:metadata.namespace"
-        START: "cel:status.?startTime == optional.none() ? int(now()-duration('1h'))*1000000000: status.startTime"
-        END: "cel:status.?startTime == optional.none() ? int(now()+duration('1h'))*1000000000: int(timestamp(status.startTime)+duration('6h'))*1000000000" # temporary workaround until CONTAINER_NAME is allowed on CEL expressions as variable: 6 hours since the container started
-        LOG_URL: "http://loki-gateway.product-kubearchive-logging.svc.cluster.local:80/loki/api/v1/query_range?query=%7Bstream%3D%22{NAMESPACE}%22%7D%20%7C%20pod_id%20%3D%20%60{POD_ID}%60%20%7C%20container%20%3D%20%60{CONTAINER_NAME}%60&start={START}&end={END}&direction=forward"
-        LOG_URL_JSONPATH: "$.data.result[*].values[*][1]"
-  - patch: |-
       $patch: delete
       apiVersion: v1
       kind: Secret


### PR DESCRIPTION
If the configmap `kubearchive-logging` changes, it's important for kubearchive to rollout restart the sink, otherwise the changes won't be properly applied on the database.

We can't control the exact moment of the PR merges so the best way to handle this is to make it automatic. We can take advantage of kustomize `configmapgenerator` that generates the configmap with a suffix based on the hash of its contents.

Then, the volume in the kubearchive-sink will change making argoCD automatically sync and redeploy the proper pods.

I am not doing that for the api-server and the kubearchive-logging secret but that's due to the usage of External Secret Operator and its [current limitation to do that](https://github.com/external-secrets/external-secrets/issues/3218). Also, it's not that critical for us, if we forgot to do the kubearchive-api-server restart we just do it afterwards and everything should start working as expected.
