### PR TITLE
ci: upload lint artifacts only on failure

### DIFF
--- a/.github/workflows/kube-linter.yaml
+++ b/.github/workflows/kube-linter.yaml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Upload artifacts
         uses: actions/upload-artifacts@v4
-        if: steps.kube-linter-action-scan.outcome != "success"
+        if: steps.kube-linter-action-scan.outcome == 'failure'
         with:
           name: kustomize-manifests
           path: kustomizedfiles


### PR DESCRIPTION
A step's outcome can have four states:
- `success`
- `failure`
- `cancelled`
- `skipped`

Upload artifacts only when the outcome is `failure`, not when it isn't `success`.  `cancelled` and `skipped` steps don't produce anything meaningful for us to do.