### PR TITLE
ci: bump kubelinter to v0.7.6

### DIFF
--- a/.github/workflows/kube-linter.yaml
+++ b/.github/workflows/kube-linter.yaml
@@ -38,7 +38,7 @@ jobs:
         uses: stackrox/kube-linter-action@v1.0.4
         id: kube-linter-action-scan
         with:
-          version: v0.7.2
+          version: v0.7.6
           # Adjust this directory to the location where your kubernetes resources and helm charts are located.
           directory: kustomizedfiles
           # The following two settings make kube-linter produce scan analysis in SARIF format which would then be

--- a/components/konflux-ui/production/kflux-ocp-p01/configure-oauth-proxy-secret.yaml
+++ b/components/konflux-ui/production/kflux-ocp-p01/configure-oauth-proxy-secret.yaml
@@ -48,6 +48,7 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-options: Force=true,Replace=true
 spec:
+  ttlSecondsAfterFinished: 60
   template:
     spec:
       containers:

--- a/components/konflux-ui/production/kflux-osp-p01/configure-oauth-proxy-secret.yaml
+++ b/components/konflux-ui/production/kflux-osp-p01/configure-oauth-proxy-secret.yaml
@@ -48,6 +48,7 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-options: Force=true,Replace=true
 spec:
+  ttlSecondsAfterFinished: 60
   template:
     spec:
       containers:

--- a/components/konflux-ui/production/kflux-prd-rh02/configure-oauth-proxy-secret.yaml
+++ b/components/konflux-ui/production/kflux-prd-rh02/configure-oauth-proxy-secret.yaml
@@ -48,6 +48,7 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-options: Force=true,Replace=true
 spec:
+  ttlSecondsAfterFinished: 60
   template:
     spec:
       containers:

--- a/components/konflux-ui/production/kflux-prd-rh03/configure-oauth-proxy-secret.yaml
+++ b/components/konflux-ui/production/kflux-prd-rh03/configure-oauth-proxy-secret.yaml
@@ -48,6 +48,7 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-options: Force=true,Replace=true
 spec:
+  ttlSecondsAfterFinished: 60
   template:
     spec:
       containers:

--- a/components/konflux-ui/production/kflux-rhel-p01/configure-oauth-proxy-secret.yaml
+++ b/components/konflux-ui/production/kflux-rhel-p01/configure-oauth-proxy-secret.yaml
@@ -48,6 +48,7 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-options: Force=true,Replace=true
 spec:
+  ttlSecondsAfterFinished: 60
   template:
     spec:
       containers:

--- a/components/konflux-ui/production/pentest-p01/configure-oauth-proxy-secret.yaml
+++ b/components/konflux-ui/production/pentest-p01/configure-oauth-proxy-secret.yaml
@@ -48,6 +48,7 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-options: Force=true,Replace=true
 spec:
+  ttlSecondsAfterFinished: 60
   template:
     spec:
       containers:

--- a/components/konflux-ui/production/stone-prd-rh01/configure-oauth-proxy-secret.yaml
+++ b/components/konflux-ui/production/stone-prd-rh01/configure-oauth-proxy-secret.yaml
@@ -48,6 +48,7 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-options: Force=true,Replace=true
 spec:
+  ttlSecondsAfterFinished: 60
   template:
     spec:
       containers:

--- a/components/konflux-ui/production/stone-prod-p01/configure-oauth-proxy-secret.yaml
+++ b/components/konflux-ui/production/stone-prod-p01/configure-oauth-proxy-secret.yaml
@@ -48,6 +48,7 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-options: Force=true,Replace=true
 spec:
+  ttlSecondsAfterFinished: 60
   template:
     spec:
       containers:

--- a/components/konflux-ui/production/stone-prod-p02/configure-oauth-proxy-secret.yaml
+++ b/components/konflux-ui/production/stone-prod-p02/configure-oauth-proxy-secret.yaml
@@ -48,6 +48,7 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-options: Force=true,Replace=true
 spec:
+  ttlSecondsAfterFinished: 60
   template:
     spec:
       containers:

--- a/components/konflux-ui/staging/stone-stage-p01/configure-oauth-proxy-secret.yaml
+++ b/components/konflux-ui/staging/stone-stage-p01/configure-oauth-proxy-secret.yaml
@@ -48,6 +48,7 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-options: Force=true,Replace=true
 spec:
+  ttlSecondsAfterFinished: 60
   template:
     spec:
       containers:

--- a/components/konflux-ui/staging/stone-stg-rh01/configure-oauth-proxy-secret.yaml
+++ b/components/konflux-ui/staging/stone-stg-rh01/configure-oauth-proxy-secret.yaml
@@ -48,6 +48,7 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-options: Force=true,Replace=true
 spec:
+  ttlSecondsAfterFinished: 60
   template:
     spec:
       containers:

--- a/components/kubearchive/base/migration-job.yaml
+++ b/components/kubearchive/base/migration-job.yaml
@@ -10,6 +10,7 @@ metadata:
 spec:
   parallelism: 1
   backoffLimit: 4
+  ttlSecondsAfterFinished: 60
   template:
     spec:
       containers:

--- a/components/kyverno/development/job_resources.yaml
+++ b/components/kyverno/development/job_resources.yaml
@@ -8,3 +8,6 @@
     limits:
       cpu: 400m
       memory: 256M
+- op: add
+  path: /spec/ttlSecondsAfterFinished
+  value: 60

--- a/components/kyverno/production/kflux-ocp-p01/job_resources.yaml
+++ b/components/kyverno/production/kflux-ocp-p01/job_resources.yaml
@@ -8,3 +8,6 @@
     limits:
       cpu: 400m
       memory: 256M
+- op: add
+  path: /spec/ttlSecondsAfterFinished
+  value: 60

--- a/components/kyverno/production/kflux-osp-p01/job_resources.yaml
+++ b/components/kyverno/production/kflux-osp-p01/job_resources.yaml
@@ -8,3 +8,6 @@
     limits:
       cpu: 400m
       memory: 256M
+- op: add
+  path: /spec/ttlSecondsAfterFinished
+  value: 60

--- a/components/kyverno/production/kflux-prd-rh02/job_resources.yaml
+++ b/components/kyverno/production/kflux-prd-rh02/job_resources.yaml
@@ -8,3 +8,6 @@
     limits:
       cpu: 400m
       memory: 256M
+- op: add
+  path: /spec/ttlSecondsAfterFinished
+  value: 60

--- a/components/kyverno/production/kflux-prd-rh03/job_resources.yaml
+++ b/components/kyverno/production/kflux-prd-rh03/job_resources.yaml
@@ -8,3 +8,6 @@
     limits:
       cpu: 400m
       memory: 256M
+- op: add
+  path: /spec/ttlSecondsAfterFinished
+  value: 60

--- a/components/kyverno/production/kflux-rhel-p01/job_resources.yaml
+++ b/components/kyverno/production/kflux-rhel-p01/job_resources.yaml
@@ -8,3 +8,6 @@
     limits:
       cpu: 400m
       memory: 256M
+- op: add
+  path: /spec/ttlSecondsAfterFinished
+  value: 60

--- a/components/kyverno/production/pentest-p01/job_resources.yaml
+++ b/components/kyverno/production/pentest-p01/job_resources.yaml
@@ -8,3 +8,6 @@
     limits:
       cpu: 400m
       memory: 256M
+- op: add
+  path: /spec/ttlSecondsAfterFinished
+  value: 60

--- a/components/kyverno/production/stone-prd-rh01/job_resources.yaml
+++ b/components/kyverno/production/stone-prd-rh01/job_resources.yaml
@@ -8,3 +8,6 @@
     limits:
       cpu: 400m
       memory: 256M
+- op: add
+  path: /spec/ttlSecondsAfterFinished
+  value: 60

--- a/components/kyverno/production/stone-prod-p01/job_resources.yaml
+++ b/components/kyverno/production/stone-prod-p01/job_resources.yaml
@@ -8,3 +8,6 @@
     limits:
       cpu: 400m
       memory: 256M
+- op: add
+  path: /spec/ttlSecondsAfterFinished
+  value: 60

--- a/components/kyverno/production/stone-prod-p02/job_resources.yaml
+++ b/components/kyverno/production/stone-prod-p02/job_resources.yaml
@@ -8,3 +8,6 @@
     limits:
       cpu: 400m
       memory: 256M
+- op: add
+  path: /spec/ttlSecondsAfterFinished
+  value: 60

--- a/components/kyverno/staging/stone-stage-p01/job_resources.yaml
+++ b/components/kyverno/staging/stone-stage-p01/job_resources.yaml
@@ -8,3 +8,6 @@
     limits:
       cpu: 400m
       memory: 256M
+- op: add
+  path: /spec/ttlSecondsAfterFinished
+  value: 60

--- a/components/kyverno/staging/stone-stg-rh01/job_resources.yaml
+++ b/components/kyverno/staging/stone-stg-rh01/job_resources.yaml
@@ -8,3 +8,6 @@
     limits:
       cpu: 400m
       memory: 256M
+- op: add
+  path: /spec/ttlSecondsAfterFinished
+  value: 60

--- a/components/pipeline-service/development/main-pipeline-service-configuration.yaml
+++ b/components/pipeline-service/development/main-pipeline-service-configuration.yaml
@@ -1690,6 +1690,7 @@ metadata:
   name: tekton-chains-signing-secret
   namespace: openshift-pipelines
 spec:
+  ttlSecondsAfterFinished: 60
   template:
     metadata:
       annotations:


### PR DESCRIPTION
Needed for #8216, since it appears the current version (v0.7.2) gives false warnings about pod disruption budgets.