### PR TITLE
Test nginx-prometheus-exporter for konflux-ui to capture request metrics

### DIFF
--- a/components/konflux-ui/staging/base/proxy/nginx.conf
+++ b/components/konflux-ui/staging/base/proxy/nginx.conf
@@ -127,23 +127,12 @@ http {
             return 200;
         }
 
-        include /mnt/nginx-additional-location-configs/*.conf;
-    }
-
-    # Metrics server block
-    server {
-        listen 9090;
-        server_name _;
-
         location /metrics {
             stub_status on;
             access_log off;
             allow all;
         }
 
-        location /health {
-            return 200 'healthy';
-            add_header Content-Type text/plain;
-        }
+        include /mnt/nginx-additional-location-configs/*.conf;
     }
 }

--- a/components/konflux-ui/staging/base/proxy/proxy.yaml
+++ b/components/konflux-ui/staging/base/proxy/proxy.yaml
@@ -120,9 +120,6 @@ spec:
         - containerPort: 9443
           name: web-tls
           protocol: TCP
-        - containerPort: 9090
-          name: metrics
-          protocol: TCP
         resources:
           limits:
             cpu: 300m
@@ -186,8 +183,9 @@ spec:
       - image: nginx/nginx-prometheus-exporter:1.1.0
         name: nginx-prometheus-exporter
         args:
-          - -nginx.scrape-uri=http://localhost:9090/metrics
-          - -web.listen-address=:9113
+          - --nginx.scrape-uri=https://localhost:9443/metrics
+          - --nginx.ssl-verify=false
+          - --web.listen-address=:9113
         ports:
           - containerPort: 9113
             name: exporter
@@ -202,7 +200,7 @@ spec:
         securityContext:
           readOnlyRootFilesystem: true
           runAsNonRoot: true
-          runAsUser: 1001
+          runAsUser:
       volumes:
         - configMap:
             defaultMode: 420
@@ -250,17 +248,13 @@ spec:
   ipFamilyPolicy: SingleStack
   ports:
     - name: web
-      port: 8888
+      port: 8080
       protocol: TCP
       targetPort: web
     - name: web-tls
       port: 9443
       protocol: TCP
       targetPort: web-tls
-    - name: metrics
-      port: 9090
-      protocol: TCP
-      targetPort: metrics
     - name: exporter
       port: 9113
       protocol: TCP


### PR DESCRIPTION
As part of this investigation PVO11Y-4928 for feature: [KONFLUX-5285](https://issues.redhat.com//browse/KONFLUX-5285)

Included prometheus exporter at deployment and enabled stub_status  in configs