### PR TITLE
Change RHEL AMIs to Cloud Access

### DIFF
--- a/components/multi-platform-controller/staging-downstream/host-config.yaml
+++ b/components/multi-platform-controller/staging-downstream/host-config.yaml
@@ -52,7 +52,7 @@ data:
   # cpu:memory (1:4)
   dynamic.linux-arm64.type: aws
   dynamic.linux-arm64.region: us-east-1
-  dynamic.linux-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-arm64.ami: ami-06f37afe6d4f43c47
   dynamic.linux-arm64.instance-type: m6g.large
   dynamic.linux-arm64.instance-tag: stage-arm64
   dynamic.linux-arm64.key-name: konflux-stage-int-mab01
@@ -65,7 +65,7 @@ data:
 
   dynamic.linux-mlarge-arm64.type: aws
   dynamic.linux-mlarge-arm64.region: us-east-1
-  dynamic.linux-mlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-mlarge-arm64.ami: ami-06f37afe6d4f43c47
   dynamic.linux-mlarge-arm64.instance-type: m6g.large
   dynamic.linux-mlarge-arm64.instance-tag: stage-arm64-mlarge
   dynamic.linux-mlarge-arm64.key-name: konflux-stage-int-mab01
@@ -78,7 +78,7 @@ data:
 
   dynamic.linux-mxlarge-arm64.type: aws
   dynamic.linux-mxlarge-arm64.region: us-east-1
-  dynamic.linux-mxlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-mxlarge-arm64.ami: ami-06f37afe6d4f43c47
   dynamic.linux-mxlarge-arm64.instance-type: m6g.xlarge
   dynamic.linux-mxlarge-arm64.instance-tag: stage-arm64-mxlarge
   dynamic.linux-mxlarge-arm64.key-name: konflux-stage-int-mab01
@@ -91,7 +91,7 @@ data:
 
   dynamic.linux-m2xlarge-arm64.type: aws
   dynamic.linux-m2xlarge-arm64.region: us-east-1
-  dynamic.linux-m2xlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-m2xlarge-arm64.ami: ami-06f37afe6d4f43c47
   dynamic.linux-m2xlarge-arm64.instance-type: m6g.2xlarge
   dynamic.linux-m2xlarge-arm64.instance-tag: stage-arm64-m2xlarge
   dynamic.linux-m2xlarge-arm64.key-name: konflux-stage-int-mab01
@@ -104,7 +104,7 @@ data:
 
   dynamic.linux-m4xlarge-arm64.type: aws
   dynamic.linux-m4xlarge-arm64.region: us-east-1
-  dynamic.linux-m4xlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-m4xlarge-arm64.ami: ami-06f37afe6d4f43c47
   dynamic.linux-m4xlarge-arm64.instance-type: m6g.4xlarge
   dynamic.linux-m4xlarge-arm64.instance-tag: stage-arm64-m4xlarge
   dynamic.linux-m4xlarge-arm64.key-name: konflux-stage-int-mab01
@@ -117,7 +117,7 @@ data:
 
   dynamic.linux-m8xlarge-arm64.type: aws
   dynamic.linux-m8xlarge-arm64.region: us-east-1
-  dynamic.linux-m8xlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-m8xlarge-arm64.ami: ami-06f37afe6d4f43c47
   dynamic.linux-m8xlarge-arm64.instance-type: m6g.8xlarge
   dynamic.linux-m8xlarge-arm64.instance-tag: stage-arm64-m8xlarge
   dynamic.linux-m8xlarge-arm64.key-name: konflux-stage-int-mab01
@@ -131,7 +131,7 @@ data:
 
   dynamic.linux-amd64.type: aws
   dynamic.linux-amd64.region: us-east-1
-  dynamic.linux-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-amd64.ami: ami-01aaf1c29c7e0f0af
   dynamic.linux-amd64.instance-type: m6a.large
   dynamic.linux-amd64.instance-tag: stage-amd64
   dynamic.linux-amd64.key-name: konflux-stage-int-mab01
@@ -144,7 +144,7 @@ data:
 
   dynamic.linux-mlarge-amd64.type: aws
   dynamic.linux-mlarge-amd64.region: us-east-1
-  dynamic.linux-mlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-mlarge-amd64.ami: ami-01aaf1c29c7e0f0af
   dynamic.linux-mlarge-amd64.instance-type: m6a.large
   dynamic.linux-mlarge-amd64.instance-tag: stage-amd64-mlarge
   dynamic.linux-mlarge-amd64.key-name: konflux-stage-int-mab01
@@ -157,7 +157,7 @@ data:
 
   dynamic.linux-mxlarge-amd64.type: aws
   dynamic.linux-mxlarge-amd64.region: us-east-1
-  dynamic.linux-mxlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-mxlarge-amd64.ami: ami-01aaf1c29c7e0f0af
   dynamic.linux-mxlarge-amd64.instance-type: m6a.xlarge
   dynamic.linux-mxlarge-amd64.instance-tag: stage-amd64-mxlarge
   dynamic.linux-mxlarge-amd64.key-name: konflux-stage-int-mab01
@@ -170,7 +170,7 @@ data:
 
   dynamic.linux-m2xlarge-amd64.type: aws
   dynamic.linux-m2xlarge-amd64.region: us-east-1
-  dynamic.linux-m2xlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-m2xlarge-amd64.ami: ami-01aaf1c29c7e0f0af
   dynamic.linux-m2xlarge-amd64.instance-type: m6a.2xlarge
   dynamic.linux-m2xlarge-amd64.instance-tag: stage-amd64-m2xlarge
   dynamic.linux-m2xlarge-amd64.key-name: konflux-stage-int-mab01
@@ -183,7 +183,7 @@ data:
 
   dynamic.linux-m4xlarge-amd64.type: aws
   dynamic.linux-m4xlarge-amd64.region: us-east-1
-  dynamic.linux-m4xlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-m4xlarge-amd64.ami: ami-01aaf1c29c7e0f0af
   dynamic.linux-m4xlarge-amd64.instance-type: m6a.4xlarge
   dynamic.linux-m4xlarge-amd64.instance-tag: stage-amd64-m4xlarge-
   dynamic.linux-m4xlarge-amd64.key-name: konflux-stage-int-mab01
@@ -196,7 +196,7 @@ data:
 
   dynamic.linux-m8xlarge-amd64.type: aws
   dynamic.linux-m8xlarge-amd64.region: us-east-1
-  dynamic.linux-m8xlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-m8xlarge-amd64.ami: ami-01aaf1c29c7e0f0af
   dynamic.linux-m8xlarge-amd64.instance-type: m6a.8xlarge
   dynamic.linux-m8xlarge-amd64.instance-tag: stage-amd64-m8xlarge
   dynamic.linux-m8xlarge-amd64.key-name: konflux-stage-int-mab01
@@ -209,7 +209,7 @@ data:
 
   dynamic.linux-c6gd2xlarge-arm64.type: aws
   dynamic.linux-c6gd2xlarge-arm64.region: us-east-1
-  dynamic.linux-c6gd2xlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-c6gd2xlarge-arm64.ami: ami-06f37afe6d4f43c47
   dynamic.linux-c6gd2xlarge-arm64.instance-type: c6gd.2xlarge
   dynamic.linux-c6gd2xlarge-arm64.instance-tag: stage-arm64-m8xlarge
   dynamic.linux-c6gd2xlarge-arm64.key-name: konflux-stage-int-mab01
@@ -287,7 +287,7 @@ data:
   # cpu:memory (1:2)
   dynamic.linux-cxlarge-arm64.type: aws
   dynamic.linux-cxlarge-arm64.region: us-east-1
-  dynamic.linux-cxlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-cxlarge-arm64.ami: ami-06f37afe6d4f43c47
   dynamic.linux-cxlarge-arm64.instance-type: c6g.xlarge
   dynamic.linux-cxlarge-arm64.instance-tag: stage-arm64-cxlarge
   dynamic.linux-cxlarge-arm64.key-name: konflux-stage-int-mab01
@@ -300,7 +300,7 @@ data:
 
   dynamic.linux-c2xlarge-arm64.type: aws
   dynamic.linux-c2xlarge-arm64.region: us-east-1
-  dynamic.linux-c2xlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-c2xlarge-arm64.ami: ami-06f37afe6d4f43c47
   dynamic.linux-c2xlarge-arm64.instance-type: c6g.2xlarge
   dynamic.linux-c2xlarge-arm64.instance-tag: stage-arm64-c2xlarge
   dynamic.linux-c2xlarge-arm64.key-name: konflux-stage-int-mab01
@@ -313,7 +313,7 @@ data:
 
   dynamic.linux-c4xlarge-arm64.type: aws
   dynamic.linux-c4xlarge-arm64.region: us-east-1
-  dynamic.linux-c4xlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-c4xlarge-arm64.ami: ami-06f37afe6d4f43c47
   dynamic.linux-c4xlarge-arm64.instance-type: c6g.4xlarge
   dynamic.linux-c4xlarge-arm64.instance-tag: stage-arm64-c4xlarge
   dynamic.linux-c4xlarge-arm64.key-name: konflux-stage-int-mab01
@@ -326,7 +326,7 @@ data:
 
   dynamic.linux-c8xlarge-arm64.type: aws
   dynamic.linux-c8xlarge-arm64.region: us-east-1
-  dynamic.linux-c8xlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-c8xlarge-arm64.ami: ami-06f37afe6d4f43c47
   dynamic.linux-c8xlarge-arm64.instance-type: c6g.8xlarge
   dynamic.linux-c8xlarge-arm64.instance-tag: stage-arm64-c8xlarge
   dynamic.linux-c8xlarge-arm64.key-name: konflux-stage-int-mab01
@@ -339,7 +339,7 @@ data:
 
   dynamic.linux-cxlarge-amd64.type: aws
   dynamic.linux-cxlarge-amd64.region: us-east-1
-  dynamic.linux-cxlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-cxlarge-amd64.ami: ami-01aaf1c29c7e0f0af
   dynamic.linux-cxlarge-amd64.instance-type: c6a.xlarge
   dynamic.linux-cxlarge-amd64.instance-tag: stage-amd64-cxlarge
   dynamic.linux-cxlarge-amd64.key-name: konflux-stage-int-mab01
@@ -352,7 +352,7 @@ data:
 
   dynamic.linux-c2xlarge-amd64.type: aws
   dynamic.linux-c2xlarge-amd64.region: us-east-1
-  dynamic.linux-c2xlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-c2xlarge-amd64.ami: ami-01aaf1c29c7e0f0af
   dynamic.linux-c2xlarge-amd64.instance-type: c6a.2xlarge
   dynamic.linux-c2xlarge-amd64.instance-tag: stage-amd64-c2xlarge
   dynamic.linux-c2xlarge-amd64.key-name: konflux-stage-int-mab01
@@ -365,7 +365,7 @@ data:
 
   dynamic.linux-c4xlarge-amd64.type: aws
   dynamic.linux-c4xlarge-amd64.region: us-east-1
-  dynamic.linux-c4xlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-c4xlarge-amd64.ami: ami-01aaf1c29c7e0f0af
   dynamic.linux-c4xlarge-amd64.instance-type: c6a.4xlarge
   dynamic.linux-c4xlarge-amd64.instance-tag: stage-amd64-c4xlarge
   dynamic.linux-c4xlarge-amd64.key-name: konflux-stage-int-mab01
@@ -378,7 +378,7 @@ data:
 
   dynamic.linux-c8xlarge-amd64.type: aws
   dynamic.linux-c8xlarge-amd64.region: us-east-1
-  dynamic.linux-c8xlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-c8xlarge-amd64.ami: ami-01aaf1c29c7e0f0af
   dynamic.linux-c8xlarge-amd64.instance-tag: stage-amd64-c8xlarge
   dynamic.linux-c8xlarge-amd64.instance-type: c6a.8xlarge
   dynamic.linux-c8xlarge-amd64.key-name: konflux-stage-int-mab01
@@ -391,7 +391,7 @@ data:
 
   dynamic.linux-root-arm64.type: aws
   dynamic.linux-root-arm64.region: us-east-1
-  dynamic.linux-root-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-root-arm64.ami: ami-06f37afe6d4f43c47
   dynamic.linux-root-arm64.instance-type: t4g.large
   dynamic.linux-root-arm64.instance-tag: stage-arm64-root
   dynamic.linux-root-arm64.key-name: konflux-stage-int-mab01
@@ -406,7 +406,7 @@ data:
 
   dynamic.linux-root-amd64.type: aws
   dynamic.linux-root-amd64.region: us-east-1
-  dynamic.linux-root-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-root-amd64.ami: ami-01aaf1c29c7e0f0af
   dynamic.linux-root-amd64.instance-type: m5.large
   dynamic.linux-root-amd64.instance-tag: stage-amd64-root
   dynamic.linux-root-amd64.key-name: konflux-stage-int-mab01

--- a/components/multi-platform-controller/staging/host-config.yaml
+++ b/components/multi-platform-controller/staging/host-config.yaml
@@ -52,7 +52,7 @@ data:
   # cpu:memory (1:4)
   dynamic.linux-arm64.type: aws
   dynamic.linux-arm64.region: us-east-1
-  dynamic.linux-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-arm64.ami: ami-06f37afe6d4f43c47
   dynamic.linux-arm64.instance-type: m6g.large
   dynamic.linux-arm64.instance-tag: stage-arm64
   dynamic.linux-arm64.key-name: konflux-stage-ext-mab01
@@ -64,7 +64,7 @@ data:
 
   dynamic.linux-mlarge-arm64.type: aws
   dynamic.linux-mlarge-arm64.region: us-east-1
-  dynamic.linux-mlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-mlarge-arm64.ami: ami-06f37afe6d4f43c47
   dynamic.linux-mlarge-arm64.instance-type: m6g.large
   dynamic.linux-mlarge-arm64.instance-tag: stage-arm64-mlarge
   dynamic.linux-mlarge-arm64.key-name: konflux-stage-ext-mab01
@@ -76,7 +76,7 @@ data:
 
   dynamic.linux-mxlarge-arm64.type: aws
   dynamic.linux-mxlarge-arm64.region: us-east-1
-  dynamic.linux-mxlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-mxlarge-arm64.ami: ami-06f37afe6d4f43c47
   dynamic.linux-mxlarge-arm64.instance-type: m6g.xlarge
   dynamic.linux-mxlarge-arm64.instance-tag: stage-arm64-mxlarge
   dynamic.linux-mxlarge-arm64.key-name: konflux-stage-ext-mab01
@@ -88,7 +88,7 @@ data:
 
   dynamic.linux-m2xlarge-arm64.type: aws
   dynamic.linux-m2xlarge-arm64.region: us-east-1
-  dynamic.linux-m2xlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-m2xlarge-arm64.ami: ami-06f37afe6d4f43c47
   dynamic.linux-m2xlarge-arm64.instance-type: m6g.2xlarge
   dynamic.linux-m2xlarge-arm64.instance-tag: stage-arm64-m2xlarge
   dynamic.linux-m2xlarge-arm64.key-name: konflux-stage-ext-mab01
@@ -100,7 +100,7 @@ data:
 
   dynamic.linux-m4xlarge-arm64.type: aws
   dynamic.linux-m4xlarge-arm64.region: us-east-1
-  dynamic.linux-m4xlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-m4xlarge-arm64.ami: ami-06f37afe6d4f43c47
   dynamic.linux-m4xlarge-arm64.instance-type: m6g.4xlarge
   dynamic.linux-m4xlarge-arm64.instance-tag: stage-arm64-m4xlarge
   dynamic.linux-m4xlarge-arm64.key-name: konflux-stage-ext-mab01
@@ -112,7 +112,7 @@ data:
 
   dynamic.linux-m8xlarge-arm64.type: aws
   dynamic.linux-m8xlarge-arm64.region: us-east-1
-  dynamic.linux-m8xlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-m8xlarge-arm64.ami: ami-06f37afe6d4f43c47
   dynamic.linux-m8xlarge-arm64.instance-type: m6g.8xlarge
   dynamic.linux-m8xlarge-arm64.instance-tag: stage-arm64-m8xlarge
   dynamic.linux-m8xlarge-arm64.key-name: konflux-stage-ext-mab01
@@ -124,7 +124,7 @@ data:
 
   dynamic.linux-c6gd2xlarge-arm64.type: aws
   dynamic.linux-c6gd2xlarge-arm64.region: us-east-1
-  dynamic.linux-c6gd2xlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-c6gd2xlarge-arm64.ami: ami-06f37afe6d4f43c47
   dynamic.linux-c6gd2xlarge-arm64.instance-type: c6gd.2xlarge
   dynamic.linux-c6gd2xlarge-arm64.instance-tag: stage-arm64-c6gd2xlarge
   dynamic.linux-c6gd2xlarge-arm64.key-name: konflux-stage-ext-mab01
@@ -200,7 +200,7 @@ data:
 
   dynamic.linux-amd64.type: aws
   dynamic.linux-amd64.region: us-east-1
-  dynamic.linux-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-amd64.ami: ami-01aaf1c29c7e0f0af
   dynamic.linux-amd64.instance-type: m6a.large
   dynamic.linux-amd64.instance-tag: stage-amd64
   dynamic.linux-amd64.key-name: konflux-stage-ext-mab01
@@ -212,7 +212,7 @@ data:
 
   dynamic.linux-mlarge-amd64.type: aws
   dynamic.linux-mlarge-amd64.region: us-east-1
-  dynamic.linux-mlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-mlarge-amd64.ami: ami-01aaf1c29c7e0f0af
   dynamic.linux-mlarge-amd64.instance-type: m6a.large
   dynamic.linux-mlarge-amd64.instance-tag: stage-amd64-mlarge
   dynamic.linux-mlarge-amd64.key-name: konflux-stage-ext-mab01
@@ -224,7 +224,7 @@ data:
 
   dynamic.linux-mxlarge-amd64.type: aws
   dynamic.linux-mxlarge-amd64.region: us-east-1
-  dynamic.linux-mxlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-mxlarge-amd64.ami: ami-01aaf1c29c7e0f0af
   dynamic.linux-mxlarge-amd64.instance-type: m6a.xlarge
   dynamic.linux-mxlarge-amd64.instance-tag: stage-amd64-mxlarge
   dynamic.linux-mxlarge-amd64.key-name: konflux-stage-ext-mab01
@@ -236,7 +236,7 @@ data:
 
   dynamic.linux-m2xlarge-amd64.type: aws
   dynamic.linux-m2xlarge-amd64.region: us-east-1
-  dynamic.linux-m2xlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-m2xlarge-amd64.ami: ami-01aaf1c29c7e0f0af
   dynamic.linux-m2xlarge-amd64.instance-type: m6a.2xlarge
   dynamic.linux-m2xlarge-amd64.instance-tag: stage-amd64-m2xlarge
   dynamic.linux-m2xlarge-amd64.key-name: konflux-stage-ext-mab01
@@ -248,7 +248,7 @@ data:
 
   dynamic.linux-m4xlarge-amd64.type: aws
   dynamic.linux-m4xlarge-amd64.region: us-east-1
-  dynamic.linux-m4xlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-m4xlarge-amd64.ami: ami-01aaf1c29c7e0f0af
   dynamic.linux-m4xlarge-amd64.instance-type: m6a.4xlarge
   dynamic.linux-m4xlarge-amd64.instance-tag: stage-amd64-m4xlarge
   dynamic.linux-m4xlarge-amd64.key-name: konflux-stage-ext-mab01
@@ -260,7 +260,7 @@ data:
 
   dynamic.linux-m8xlarge-amd64.type: aws
   dynamic.linux-m8xlarge-amd64.region: us-east-1
-  dynamic.linux-m8xlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-m8xlarge-amd64.ami: ami-01aaf1c29c7e0f0af
   dynamic.linux-m8xlarge-amd64.instance-type: m6a.8xlarge
   dynamic.linux-m8xlarge-amd64.instance-tag: stage-amd64-m8xlarge
   dynamic.linux-m8xlarge-amd64.key-name: konflux-stage-ext-mab01
@@ -273,7 +273,7 @@ data:
   # cpu:memory (1:2)
   dynamic.linux-cxlarge-arm64.type: aws
   dynamic.linux-cxlarge-arm64.region: us-east-1
-  dynamic.linux-cxlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-cxlarge-arm64.ami: ami-06f37afe6d4f43c47
   dynamic.linux-cxlarge-arm64.instance-type: c6g.xlarge
   dynamic.linux-cxlarge-arm64.instance-tag: stage-arm64-cxlarge
   dynamic.linux-cxlarge-arm64.key-name: konflux-stage-ext-mab01
@@ -285,7 +285,7 @@ data:
 
   dynamic.linux-c2xlarge-arm64.type: aws
   dynamic.linux-c2xlarge-arm64.region: us-east-1
-  dynamic.linux-c2xlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-c2xlarge-arm64.ami: ami-06f37afe6d4f43c47
   dynamic.linux-c2xlarge-arm64.instance-type: c6g.2xlarge
   dynamic.linux-c2xlarge-arm64.instance-tag: stage-arm64-c2xlarge
   dynamic.linux-c2xlarge-arm64.key-name: konflux-stage-ext-mab01
@@ -297,7 +297,7 @@ data:
 
   dynamic.linux-c4xlarge-arm64.type: aws
   dynamic.linux-c4xlarge-arm64.region: us-east-1
-  dynamic.linux-c4xlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-c4xlarge-arm64.ami: ami-06f37afe6d4f43c47
   dynamic.linux-c4xlarge-arm64.instance-type: c6g.4xlarge
   dynamic.linux-c4xlarge-arm64.instance-tag: stage-arm64-c4xlarge
   dynamic.linux-c4xlarge-arm64.key-name: konflux-stage-ext-mab01
@@ -309,7 +309,7 @@ data:
 
   dynamic.linux-c8xlarge-arm64.type: aws
   dynamic.linux-c8xlarge-arm64.region: us-east-1
-  dynamic.linux-c8xlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-c8xlarge-arm64.ami: ami-06f37afe6d4f43c47
   dynamic.linux-c8xlarge-arm64.instance-type: c6g.8xlarge
   dynamic.linux-c8xlarge-arm64.instance-tag: stage-arm64-c8xlarge
   dynamic.linux-c8xlarge-arm64.key-name: konflux-stage-ext-mab01
@@ -321,7 +321,7 @@ data:
 
   dynamic.linux-cxlarge-amd64.type: aws
   dynamic.linux-cxlarge-amd64.region: us-east-1
-  dynamic.linux-cxlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-cxlarge-amd64.ami: ami-01aaf1c29c7e0f0af
   dynamic.linux-cxlarge-amd64.instance-type: c6a.xlarge
   dynamic.linux-cxlarge-amd64.instance-tag: stage-amd64-cxlarge
   dynamic.linux-cxlarge-amd64.key-name: konflux-stage-ext-mab01
@@ -333,7 +333,7 @@ data:
 
   dynamic.linux-c2xlarge-amd64.type: aws
   dynamic.linux-c2xlarge-amd64.region: us-east-1
-  dynamic.linux-c2xlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-c2xlarge-amd64.ami: ami-01aaf1c29c7e0f0af
   dynamic.linux-c2xlarge-amd64.instance-type: c6a.2xlarge
   dynamic.linux-c2xlarge-amd64.instance-tag: stage-amd64-c2xlarge
   dynamic.linux-c2xlarge-amd64.key-name: konflux-stage-ext-mab01
@@ -345,7 +345,7 @@ data:
 
   dynamic.linux-c4xlarge-amd64.type: aws
   dynamic.linux-c4xlarge-amd64.region: us-east-1
-  dynamic.linux-c4xlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-c4xlarge-amd64.ami: ami-01aaf1c29c7e0f0af
   dynamic.linux-c4xlarge-amd64.instance-type: c6a.4xlarge
   dynamic.linux-c4xlarge-amd64.instance-tag: stage-amd64-c4xlarge
   dynamic.linux-c4xlarge-amd64.key-name: konflux-stage-ext-mab01
@@ -357,7 +357,7 @@ data:
 
   dynamic.linux-c8xlarge-amd64.type: aws
   dynamic.linux-c8xlarge-amd64.region: us-east-1
-  dynamic.linux-c8xlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-c8xlarge-amd64.ami: ami-01aaf1c29c7e0f0af
   dynamic.linux-c8xlarge-amd64.instance-type: c6a.8xlarge
   dynamic.linux-c8xlarge-amd64.instance-tag: stage-amd64-c8xlarge
   dynamic.linux-c8xlarge-amd64.key-name: konflux-stage-ext-mab01
@@ -369,7 +369,7 @@ data:
 
   dynamic.linux-g4xlarge-amd64.type: aws
   dynamic.linux-g4xlarge-amd64.region: us-east-1
-  dynamic.linux-g4xlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-g4xlarge-amd64.ami: ami-01aaf1c29c7e0f0af
   dynamic.linux-g4xlarge-amd64.instance-type: g6.4xlarge
   dynamic.linux-g4xlarge-amd64.instance-tag: stage-amd64-g4xlarge
   dynamic.linux-g4xlarge-amd64.key-name: konflux-stage-ext-mab01
@@ -382,7 +382,7 @@ data:
   #root
   dynamic.linux-root-arm64.type: aws
   dynamic.linux-root-arm64.region: us-east-1
-  dynamic.linux-root-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-root-arm64.ami: ami-06f37afe6d4f43c47
   dynamic.linux-root-arm64.instance-type: t4g.large
   dynamic.linux-root-arm64.instance-tag: stage-arm64-root
   dynamic.linux-root-arm64.key-name: konflux-stage-ext-mab01
@@ -396,7 +396,7 @@ data:
 
   dynamic.linux-root-amd64.type: aws
   dynamic.linux-root-amd64.region: us-east-1
-  dynamic.linux-root-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-root-amd64.ami: ami-01aaf1c29c7e0f0af
   dynamic.linux-root-amd64.instance-type: m5.2xlarge
   dynamic.linux-root-amd64.instance-tag: stage-amd64-root
   dynamic.linux-root-amd64.key-name: konflux-stage-ext-mab01


### PR DESCRIPTION
Use Red Hat Cloud Access (BYOS) AMIs instead of regular PAYG AMIs that incur licensing fees.
The following changes were made:

ami-026ebd4cfe2c043b2 (RHEL-9.2.0_HVM-20230503-x86_64-41-Hourly2-GP2) -> ami-01aaf1c29c7e0f0af (RHEL-9.6.0_HVM-20250910-x86_64-0-Access2-GP3)

ami-03d6a5256a46c9feb (RHEL-9.2.0_HVM-20230503-arm64-41-Hourly2-GP2) -> ami-06f37afe6d4f43c47 (RHEL-9.6.0_HVM-20250910-arm64-0-Access2-GP3)