### PR TITLE
disable job autocleanup

### DIFF
--- a/.kube-linter.yaml
+++ b/.kube-linter.yaml
@@ -3,3 +3,6 @@ checks:
   - liveness-port
   - readiness-port
   - startup-port
+  # disabled because removed jobs will get recreated by argo, causing them to
+  # run more frequently than intended
+  - job-ttl-seconds-after-finished

--- a/components/konflux-ui/production/kflux-ocp-p01/configure-oauth-proxy-secret.yaml
+++ b/components/konflux-ui/production/kflux-ocp-p01/configure-oauth-proxy-secret.yaml
@@ -48,7 +48,6 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-options: Force=true,Replace=true
 spec:
-  ttlSecondsAfterFinished: 60
   template:
     spec:
       containers:

--- a/components/konflux-ui/production/kflux-osp-p01/configure-oauth-proxy-secret.yaml
+++ b/components/konflux-ui/production/kflux-osp-p01/configure-oauth-proxy-secret.yaml
@@ -48,7 +48,6 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-options: Force=true,Replace=true
 spec:
-  ttlSecondsAfterFinished: 60
   template:
     spec:
       containers:

--- a/components/konflux-ui/production/kflux-prd-rh02/configure-oauth-proxy-secret.yaml
+++ b/components/konflux-ui/production/kflux-prd-rh02/configure-oauth-proxy-secret.yaml
@@ -48,7 +48,6 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-options: Force=true,Replace=true
 spec:
-  ttlSecondsAfterFinished: 60
   template:
     spec:
       containers:

--- a/components/konflux-ui/production/kflux-prd-rh03/configure-oauth-proxy-secret.yaml
+++ b/components/konflux-ui/production/kflux-prd-rh03/configure-oauth-proxy-secret.yaml
@@ -48,7 +48,6 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-options: Force=true,Replace=true
 spec:
-  ttlSecondsAfterFinished: 60
   template:
     spec:
       containers:

--- a/components/konflux-ui/production/kflux-rhel-p01/configure-oauth-proxy-secret.yaml
+++ b/components/konflux-ui/production/kflux-rhel-p01/configure-oauth-proxy-secret.yaml
@@ -48,7 +48,6 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-options: Force=true,Replace=true
 spec:
-  ttlSecondsAfterFinished: 60
   template:
     spec:
       containers:

--- a/components/konflux-ui/production/pentest-p01/configure-oauth-proxy-secret.yaml
+++ b/components/konflux-ui/production/pentest-p01/configure-oauth-proxy-secret.yaml
@@ -48,7 +48,6 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-options: Force=true,Replace=true
 spec:
-  ttlSecondsAfterFinished: 60
   template:
     spec:
       containers:

--- a/components/konflux-ui/production/stone-prd-rh01/configure-oauth-proxy-secret.yaml
+++ b/components/konflux-ui/production/stone-prd-rh01/configure-oauth-proxy-secret.yaml
@@ -48,7 +48,6 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-options: Force=true,Replace=true
 spec:
-  ttlSecondsAfterFinished: 60
   template:
     spec:
       containers:

--- a/components/konflux-ui/production/stone-prod-p01/configure-oauth-proxy-secret.yaml
+++ b/components/konflux-ui/production/stone-prod-p01/configure-oauth-proxy-secret.yaml
@@ -48,7 +48,6 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-options: Force=true,Replace=true
 spec:
-  ttlSecondsAfterFinished: 60
   template:
     spec:
       containers:

--- a/components/konflux-ui/production/stone-prod-p02/configure-oauth-proxy-secret.yaml
+++ b/components/konflux-ui/production/stone-prod-p02/configure-oauth-proxy-secret.yaml
@@ -48,7 +48,6 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-options: Force=true,Replace=true
 spec:
-  ttlSecondsAfterFinished: 60
   template:
     spec:
       containers:

--- a/components/konflux-ui/staging/stone-stage-p01/configure-oauth-proxy-secret.yaml
+++ b/components/konflux-ui/staging/stone-stage-p01/configure-oauth-proxy-secret.yaml
@@ -48,7 +48,6 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-options: Force=true,Replace=true
 spec:
-  ttlSecondsAfterFinished: 60
   template:
     spec:
       containers:

--- a/components/konflux-ui/staging/stone-stg-rh01/configure-oauth-proxy-secret.yaml
+++ b/components/konflux-ui/staging/stone-stg-rh01/configure-oauth-proxy-secret.yaml
@@ -48,7 +48,6 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-options: Force=true,Replace=true
 spec:
-  ttlSecondsAfterFinished: 60
   template:
     spec:
       containers:

--- a/components/kubearchive/base/migration-job.yaml
+++ b/components/kubearchive/base/migration-job.yaml
@@ -10,7 +10,6 @@ metadata:
 spec:
   parallelism: 1
   backoffLimit: 4
-  ttlSecondsAfterFinished: 60
   template:
     spec:
       containers:

--- a/components/kyverno/development/job_resources.yaml
+++ b/components/kyverno/development/job_resources.yaml
@@ -8,6 +8,3 @@
     limits:
       cpu: 400m
       memory: 256M
-- op: add
-  path: /spec/ttlSecondsAfterFinished
-  value: 60

--- a/components/kyverno/production/kflux-ocp-p01/job_resources.yaml
+++ b/components/kyverno/production/kflux-ocp-p01/job_resources.yaml
@@ -8,6 +8,3 @@
     limits:
       cpu: 400m
       memory: 256M
-- op: add
-  path: /spec/ttlSecondsAfterFinished
-  value: 60

--- a/components/kyverno/production/kflux-osp-p01/job_resources.yaml
+++ b/components/kyverno/production/kflux-osp-p01/job_resources.yaml
@@ -8,6 +8,3 @@
     limits:
       cpu: 400m
       memory: 256M
-- op: add
-  path: /spec/ttlSecondsAfterFinished
-  value: 60

--- a/components/kyverno/production/kflux-prd-rh02/job_resources.yaml
+++ b/components/kyverno/production/kflux-prd-rh02/job_resources.yaml
@@ -8,6 +8,3 @@
     limits:
       cpu: 400m
       memory: 256M
-- op: add
-  path: /spec/ttlSecondsAfterFinished
-  value: 60

--- a/components/kyverno/production/kflux-prd-rh03/job_resources.yaml
+++ b/components/kyverno/production/kflux-prd-rh03/job_resources.yaml
@@ -8,6 +8,3 @@
     limits:
       cpu: 400m
       memory: 256M
-- op: add
-  path: /spec/ttlSecondsAfterFinished
-  value: 60

--- a/components/kyverno/production/kflux-rhel-p01/job_resources.yaml
+++ b/components/kyverno/production/kflux-rhel-p01/job_resources.yaml
@@ -8,6 +8,3 @@
     limits:
       cpu: 400m
       memory: 256M
-- op: add
-  path: /spec/ttlSecondsAfterFinished
-  value: 60

--- a/components/kyverno/production/pentest-p01/job_resources.yaml
+++ b/components/kyverno/production/pentest-p01/job_resources.yaml
@@ -8,6 +8,3 @@
     limits:
       cpu: 400m
       memory: 256M
-- op: add
-  path: /spec/ttlSecondsAfterFinished
-  value: 60

--- a/components/kyverno/production/stone-prd-rh01/job_resources.yaml
+++ b/components/kyverno/production/stone-prd-rh01/job_resources.yaml
@@ -8,6 +8,3 @@
     limits:
       cpu: 400m
       memory: 256M
-- op: add
-  path: /spec/ttlSecondsAfterFinished
-  value: 60

--- a/components/kyverno/production/stone-prod-p01/job_resources.yaml
+++ b/components/kyverno/production/stone-prod-p01/job_resources.yaml
@@ -8,6 +8,3 @@
     limits:
       cpu: 400m
       memory: 256M
-- op: add
-  path: /spec/ttlSecondsAfterFinished
-  value: 60

--- a/components/kyverno/production/stone-prod-p02/job_resources.yaml
+++ b/components/kyverno/production/stone-prod-p02/job_resources.yaml
@@ -8,6 +8,3 @@
     limits:
       cpu: 400m
       memory: 256M
-- op: add
-  path: /spec/ttlSecondsAfterFinished
-  value: 60

--- a/components/kyverno/staging/stone-stage-p01/job_resources.yaml
+++ b/components/kyverno/staging/stone-stage-p01/job_resources.yaml
@@ -8,6 +8,3 @@
     limits:
       cpu: 400m
       memory: 256M
-- op: add
-  path: /spec/ttlSecondsAfterFinished
-  value: 60

--- a/components/kyverno/staging/stone-stg-rh01/job_resources.yaml
+++ b/components/kyverno/staging/stone-stg-rh01/job_resources.yaml
@@ -8,6 +8,3 @@
     limits:
       cpu: 400m
       memory: 256M
-- op: add
-  path: /spec/ttlSecondsAfterFinished
-  value: 60

--- a/components/pipeline-service/development/main-pipeline-service-configuration.yaml
+++ b/components/pipeline-service/development/main-pipeline-service-configuration.yaml
@@ -1690,7 +1690,6 @@ metadata:
   name: tekton-chains-signing-secret
   namespace: openshift-pipelines
 spec:
-  ttlSecondsAfterFinished: 60
   template:
     metadata:
       annotations:


### PR DESCRIPTION
These were added on recommendation from a kube-linter check.  However, these fields have issues with gitops-style deployments through ArgoCD.

When jobs finish, they will automatically delete themselves, which ArgoCD picks up on.  It will try to recreate these jobs, since they're a part of the Application's manifests, which means all of the jobs in this repository are running far more frequently than intended.

To fix, remove all the ttl autoremoval fields for jobs added in #8233 and disable the warning in kube-linter entirely.

Fixes: 4912f74d2 ("ci: bump kubelinter to v0.7.6 (#8233)")