### PR TITLE
staging: remove sprayproxy from host clusters

### DIFF
--- a/argo-cd-apps/overlays/konflux-public-staging/delete-applications.yaml
+++ b/argo-cd-apps/overlays/konflux-public-staging/delete-applications.yaml
@@ -11,3 +11,9 @@ kind: ApplicationSet
 metadata:
   name: nvme-storage-configurator
 $patch: delete
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: sprayproxy
+$patch: delete

--- a/argo-cd-apps/overlays/production-downstream/delete-applications.yaml
+++ b/argo-cd-apps/overlays/production-downstream/delete-applications.yaml
@@ -1,11 +1,4 @@
 ---
-# Downstream deployment has the host and member operators deployed on the same cluster
-apiVersion: argoproj.io/v1alpha1
-kind: ApplicationSet
-metadata:
-  name: sprayproxy
-$patch: delete
----
 apiVersion: argoproj.io/v1alpha1
 kind: ApplicationSet
 metadata:

--- a/argo-cd-apps/overlays/staging-downstream/delete-applications.yaml
+++ b/argo-cd-apps/overlays/staging-downstream/delete-applications.yaml
@@ -1,11 +1,4 @@
 ---
-# Downstream deployment has the host and member operators deployed on the same cluster
-apiVersion: argoproj.io/v1alpha1
-kind: ApplicationSet
-metadata:
-  name: sprayproxy
-$patch: delete
----
 apiVersion: argoproj.io/v1alpha1
 kind: ApplicationSet
 metadata:


### PR DESCRIPTION
With the completion of [KFLUXINFRA-1790](https://issues.redhat.com//browse/KFLUXINFRA-1790)[^1], we no longer need sprayproxy on the host clusters.

Remove it from the staging overlay.

[^1]: https://issues.redhat.com/browse/KFLUXINFRA-1790

Part of [KFLUXINFRA-2240](https://issues.redhat.com/browse/KFLUXINFRA-2240).