### PR TITLE
fix(KFLUXSPRT-5193): admins can view repositories

### DIFF
--- a/components/konflux-rbac/production/base/konflux-admin-user-actions.yaml
+++ b/components/konflux-rbac/production/base/konflux-admin-user-actions.yaml
@@ -207,3 +207,11 @@ rules:
       - kueue.x-k8s.io
     resources:
       - workloads
+  - verbs:
+    - get
+    - list
+    - watch
+    apiGroups:
+      - pipelinesascode.tekton.dev
+    resources:
+      - repositories

--- a/components/konflux-rbac/staging/base/konflux-admin-user-actions.yaml
+++ b/components/konflux-rbac/staging/base/konflux-admin-user-actions.yaml
@@ -207,3 +207,11 @@ rules:
       - kueue.x-k8s.io
     resources:
       - workloads
+  - verbs:
+    - get
+    - list
+    - watch
+    apiGroups:
+      - pipelinesascode.tekton.dev
+    resources:
+      - repositories


### PR DESCRIPTION
- admins should be able to view their Repository CRs to help with PaC debugging.
- this RBAC used to be part of the `everyone-can-view` role but seems to been removed.
- adding it to admins role since it is better scoped to that persona