### PR TITLE
fix: remove release cleanup cronjob

### DIFF
--- a/components/release/base/cronjobs/remove-expired-releases.yaml
+++ b/components/release/base/cronjobs/remove-expired-releases.yaml
@@ -8,6 +8,7 @@ spec:
   schedule: "10 03 * * *"
   successfulJobsHistoryLimit: 7
   failedJobsHistoryLimit: 7
+  suspend: true
   jobTemplate:
     spec:
       template:


### PR DESCRIPTION
this PR suspends the cronjob to delete old
releases as kubearchive is now taking care
of it.