### PR TITLE
Allow release team repos on internal staging

### DIFF
--- a/components/repository-validator/staging/kustomization.yaml
+++ b/components/repository-validator/staging/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - https://github.com/konflux-ci/repository-validator/config/ocp?ref=1a1bd5856c7caf40ebf3d9a24fce209ba8a74bd9
-  - https://github.com/redhat-appstudio/internal-infra-deployments/components/repository-validator/staging?ref=562a984dab626267ff53d23c7033b49d601d9589
+  - https://github.com/redhat-appstudio/internal-infra-deployments/components/repository-validator/staging?ref=7ebcfe9785918b2bfb857eff9aaa79cee914b669
 images:
   - name: controller
     newName: quay.io/redhat-user-workloads/konflux-infra-tenant/repository-validator/repository-validator


### PR DESCRIPTION
Temporarily, to migrate internal services from appsre clusters to konflux common clusters, release team need stone-stage-p01 to access GH repos to validate things by running their e2e tests using those GH repos.