### PR TITLE
Use server-side apply in Grafana Application

### DIFF
--- a/argo-cd-apps/base/all-clusters/infra-deployments/monitoring-workload-grafana/monitoring-workload-grafana.yaml
+++ b/argo-cd-apps/base/all-clusters/infra-deployments/monitoring-workload-grafana/monitoring-workload-grafana.yaml
@@ -33,6 +33,7 @@ spec:
           selfHeal: true
         syncOptions:
         - CreateNamespace=true
+        - ServerSideApply=true
         retry:
           limit: 50
           backoff:


### PR DESCRIPTION
In PR #7426, an attempt was made to deploy updated Grafana dashboard. This update started failing the Grafana Application deployment via the CI system. Upon investigation of ArgoCD within the CI cluster, this error message was found: ConfigMap controllers-overview-dc566k7t25 is invalid: metadata.annotations: Too long: must have at most 262144 bytes. Retrying attempt #28 at 3:06PM.

Investigation of ArgoCD documentation shows that using the ServerSideApply option should fix issues such as this. While there is an option for users to apply this label on per-resource level, it would require us to investigate every time the CI would fail because of this. So instead, let's set ServerSideApply on the whole application to fix any future dashboard issues.
