### PR TITLE
chore: add permissions to squid

### DIFF
--- a/components/squid/base/kustomization.yaml
+++ b/components/squid/base/kustomization.yaml
@@ -2,7 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-- ../base
-
-generators:
-- squid-helm-generator.yaml
+- rbac.yaml

--- a/components/squid/base/rbac.yaml
+++ b/components/squid/base/rbac.yaml
@@ -1,0 +1,13 @@
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: konflux-vanguard-admins
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: konflux-vanguard
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: admin

--- a/components/squid/staging/kustomization.yaml
+++ b/components/squid/staging/kustomization.yaml
@@ -1,5 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
+resources:
+- ../base
+
 generators:
 - squid-helm-generator.yaml


### PR DESCRIPTION
Add permissions to squid

The CI is failing when using a helm-generator yaml file in base and directing the layouts to it, because both development and staging environments are referencing the same base kustomization file that contained the Helm generator. 
When the CI runs both environments in parallel, it tries to pull the same Helm chart into the same cache directory, causing a conflict.

Thats the reason we are using the same helm-generator yaml file in both development and staging.
BTW:
The values for staging will be modified later on.