### PR TITLE
chore: bump repository-validator staging commit ref

### DIFF
--- a/components/repository-validator/staging/kustomization.yaml
+++ b/components/repository-validator/staging/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - https://github.com/konflux-ci/repository-validator/config/ocp?ref=1a1bd5856c7caf40ebf3d9a24fce209ba8a74bd9
-  - https://github.com/redhat-appstudio/internal-infra-deployments/components/repository-validator/staging?ref=7ebcfe9785918b2bfb857eff9aaa79cee914b669
+  - https://github.com/redhat-appstudio/internal-infra-deployments/components/repository-validator/staging?ref=da151a856b711f28e49a42658d6c17fec5d228dd
 images:
   - name: controller
     newName: quay.io/redhat-user-workloads/konflux-infra-tenant/repository-validator/repository-validator


### PR DESCRIPTION
This reverts the change that allowed the release service team to use test repos on internal staging.