### PR TITLE
Change RHEL AMIs to Cloud Access for Prod

### DIFF
--- a/components/multi-platform-controller/production-downstream/kflux-ocp-p01/host-config.yaml
+++ b/components/multi-platform-controller/production-downstream/kflux-ocp-p01/host-config.yaml
@@ -63,7 +63,7 @@ data:
   # cpu:memory (1:4)
   dynamic.linux-arm64.type: aws
   dynamic.linux-arm64.region: us-east-1
-  dynamic.linux-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-arm64.ami: ami-06f37afe6d4f43c47
   dynamic.linux-arm64.instance-type: m6g.large
   dynamic.linux-arm64.instance-tag: prod-arm64
   dynamic.linux-arm64.key-name: kflux-ocp-p01-key-pair
@@ -77,7 +77,7 @@ data:
    # same as default but with 160GB disk instead of default 40GB
   dynamic.linux-d160-arm64.type: aws
   dynamic.linux-d160-arm64.region: us-east-1
-  dynamic.linux-d160-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-d160-arm64.ami: ami-06f37afe6d4f43c47
   dynamic.linux-d160-arm64.instance-type: m6g.large
   dynamic.linux-d160-arm64.instance-tag: prod-arm64-d160
   dynamic.linux-d160-arm64.key-name: kflux-ocp-p01-key-pair
@@ -91,7 +91,7 @@ data:
 
   dynamic.linux-mlarge-arm64.type: aws
   dynamic.linux-mlarge-arm64.region: us-east-1
-  dynamic.linux-mlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-mlarge-arm64.ami: ami-06f37afe6d4f43c47
   dynamic.linux-mlarge-arm64.instance-type: m6g.large
   dynamic.linux-mlarge-arm64.instance-tag: prod-arm64-mlarge
   dynamic.linux-mlarge-arm64.key-name: kflux-ocp-p01-key-pair
@@ -104,7 +104,7 @@ data:
 
   dynamic.linux-mxlarge-arm64.type: aws
   dynamic.linux-mxlarge-arm64.region: us-east-1
-  dynamic.linux-mxlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-mxlarge-arm64.ami: ami-06f37afe6d4f43c47
   dynamic.linux-mxlarge-arm64.instance-type: m6g.xlarge
   dynamic.linux-mxlarge-arm64.instance-tag: prod-arm64-mxlarge
   dynamic.linux-mxlarge-arm64.key-name: kflux-ocp-p01-key-pair
@@ -117,7 +117,7 @@ data:
 
   dynamic.linux-m2xlarge-arm64.type: aws
   dynamic.linux-m2xlarge-arm64.region: us-east-1
-  dynamic.linux-m2xlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-m2xlarge-arm64.ami: ami-06f37afe6d4f43c47
   dynamic.linux-m2xlarge-arm64.instance-type: m6g.2xlarge
   dynamic.linux-m2xlarge-arm64.instance-tag: prod-arm64-m2xlarge
   dynamic.linux-m2xlarge-arm64.key-name: kflux-ocp-p01-key-pair
@@ -131,7 +131,7 @@ data:
   # same as linux-m2xlarge-arm64 but with 160GB disk instead of default 40GB
   dynamic.linux-d160-m2xlarge-arm64.type: aws
   dynamic.linux-d160-m2xlarge-arm64.region: us-east-1
-  dynamic.linux-d160-m2xlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-d160-m2xlarge-arm64.ami: ami-06f37afe6d4f43c47
   dynamic.linux-d160-m2xlarge-arm64.instance-type: m6g.2xlarge
   dynamic.linux-d160-m2xlarge-arm64.instance-tag: prod-arm64-m2xlarge-d160
   dynamic.linux-d160-m2xlarge-arm64.key-name: kflux-ocp-p01-key-pair
@@ -145,7 +145,7 @@ data:
 
   dynamic.linux-m4xlarge-arm64.type: aws
   dynamic.linux-m4xlarge-arm64.region: us-east-1
-  dynamic.linux-m4xlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-m4xlarge-arm64.ami: ami-06f37afe6d4f43c47
   dynamic.linux-m4xlarge-arm64.instance-type: m6g.4xlarge
   dynamic.linux-m4xlarge-arm64.instance-tag: prod-arm64-m4xlarge
   dynamic.linux-m4xlarge-arm64.key-name: kflux-ocp-p01-key-pair
@@ -158,7 +158,7 @@ data:
 
   dynamic.linux-d160-m4xlarge-arm64.type: aws
   dynamic.linux-d160-m4xlarge-arm64.region: us-east-1
-  dynamic.linux-d160-m4xlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-d160-m4xlarge-arm64.ami: ami-06f37afe6d4f43c47
   dynamic.linux-d160-m4xlarge-arm64.instance-type: m6g.4xlarge
   dynamic.linux-d160-m4xlarge-arm64.instance-tag: prod-arm64-m4xlarge-d160
   dynamic.linux-d160-m4xlarge-arm64.key-name: kflux-ocp-p01-key-pair
@@ -172,7 +172,7 @@ data:
 
   dynamic.linux-m8xlarge-arm64.type: aws
   dynamic.linux-m8xlarge-arm64.region: us-east-1
-  dynamic.linux-m8xlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-m8xlarge-arm64.ami: ami-06f37afe6d4f43c47
   dynamic.linux-m8xlarge-arm64.instance-type: m6g.8xlarge
   dynamic.linux-m8xlarge-arm64.instance-tag: prod-arm64-m8xlarge
   dynamic.linux-m8xlarge-arm64.key-name: kflux-ocp-p01-key-pair
@@ -185,7 +185,7 @@ data:
 
   dynamic.linux-d160-m8xlarge-arm64.type: aws
   dynamic.linux-d160-m8xlarge-arm64.region: us-east-1
-  dynamic.linux-d160-m8xlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-d160-m8xlarge-arm64.ami: ami-06f37afe6d4f43c47
   dynamic.linux-d160-m8xlarge-arm64.instance-type: m6g.8xlarge
   dynamic.linux-d160-m8xlarge-arm64.instance-tag: prod-arm64-m8xlarge-d160
   dynamic.linux-d160-m8xlarge-arm64.key-name: kflux-ocp-p01-key-pair
@@ -199,7 +199,7 @@ data:
 
   dynamic.linux-c6gd2xlarge-arm64.type: aws
   dynamic.linux-c6gd2xlarge-arm64.region: us-east-1
-  dynamic.linux-c6gd2xlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-c6gd2xlarge-arm64.ami: ami-06f37afe6d4f43c47
   dynamic.linux-c6gd2xlarge-arm64.instance-type: c6gd.2xlarge
   dynamic.linux-c6gd2xlarge-arm64.instance-tag: prod-arm64-c6gd2xlarge
   dynamic.linux-c6gd2xlarge-arm64.key-name: kflux-ocp-p01-key-pair
@@ -276,7 +276,7 @@ data:
 
   dynamic.linux-amd64.type: aws
   dynamic.linux-amd64.region: us-east-1
-  dynamic.linux-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-amd64.ami: ami-01aaf1c29c7e0f0af
   dynamic.linux-amd64.instance-type: m6a.large
   dynamic.linux-amd64.instance-tag: prod-amd64
   dynamic.linux-amd64.key-name: kflux-ocp-p01-key-pair
@@ -289,7 +289,7 @@ data:
 
   dynamic.linux-mlarge-amd64.type: aws
   dynamic.linux-mlarge-amd64.region: us-east-1
-  dynamic.linux-mlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-mlarge-amd64.ami: ami-01aaf1c29c7e0f0af
   dynamic.linux-mlarge-amd64.instance-type: m6a.large
   dynamic.linux-mlarge-amd64.instance-tag: prod-amd64-mlarge
   dynamic.linux-mlarge-amd64.key-name: kflux-ocp-p01-key-pair
@@ -302,7 +302,7 @@ data:
 
   dynamic.linux-mxlarge-amd64.type: aws
   dynamic.linux-mxlarge-amd64.region: us-east-1
-  dynamic.linux-mxlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-mxlarge-amd64.ami: ami-01aaf1c29c7e0f0af
   dynamic.linux-mxlarge-amd64.instance-type: m6a.xlarge
   dynamic.linux-mxlarge-amd64.instance-tag: prod-amd64-mxlarge
   dynamic.linux-mxlarge-amd64.key-name: kflux-ocp-p01-key-pair
@@ -315,7 +315,7 @@ data:
 
   dynamic.linux-m2xlarge-amd64.type: aws
   dynamic.linux-m2xlarge-amd64.region: us-east-1
-  dynamic.linux-m2xlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-m2xlarge-amd64.ami: ami-01aaf1c29c7e0f0af
   dynamic.linux-m2xlarge-amd64.instance-type: m6a.2xlarge
   dynamic.linux-m2xlarge-amd64.instance-tag: prod-amd64-m2xlarge
   dynamic.linux-m2xlarge-amd64.key-name: kflux-ocp-p01-key-pair
@@ -329,7 +329,7 @@ data:
   # same as linux-m2xlarge-amd64 but with 160GB disk instead of default 40GB
   dynamic.linux-d160-m2xlarge-amd64.type: aws
   dynamic.linux-d160-m2xlarge-amd64.region: us-east-1
-  dynamic.linux-d160-m2xlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-d160-m2xlarge-amd64.ami: ami-01aaf1c29c7e0f0af
   dynamic.linux-d160-m2xlarge-amd64.instance-type: m6a.2xlarge
   dynamic.linux-d160-m2xlarge-amd64.instance-tag: prod-amd64-m2xlarge-d160
   dynamic.linux-d160-m2xlarge-amd64.key-name: kflux-ocp-p01-key-pair
@@ -343,7 +343,7 @@ data:
 
   dynamic.linux-m4xlarge-amd64.type: aws
   dynamic.linux-m4xlarge-amd64.region: us-east-1
-  dynamic.linux-m4xlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-m4xlarge-amd64.ami: ami-01aaf1c29c7e0f0af
   dynamic.linux-m4xlarge-amd64.instance-type: m6a.4xlarge
   dynamic.linux-m4xlarge-amd64.instance-tag: prod-amd64-m4xlarge
   dynamic.linux-m4xlarge-amd64.key-name: kflux-ocp-p01-key-pair
@@ -356,7 +356,7 @@ data:
 
   dynamic.linux-d160-m4xlarge-amd64.type: aws
   dynamic.linux-d160-m4xlarge-amd64.region: us-east-1
-  dynamic.linux-d160-m4xlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-d160-m4xlarge-amd64.ami: ami-01aaf1c29c7e0f0af
   dynamic.linux-d160-m4xlarge-amd64.instance-type: m6a.4xlarge
   dynamic.linux-d160-m4xlarge-amd64.instance-tag: prod-amd64-m4xlarge-d160
   dynamic.linux-d160-m4xlarge-amd64.key-name: kflux-ocp-p01-key-pair
@@ -370,7 +370,7 @@ data:
 
   dynamic.linux-m8xlarge-amd64.type: aws
   dynamic.linux-m8xlarge-amd64.region: us-east-1
-  dynamic.linux-m8xlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-m8xlarge-amd64.ami: ami-01aaf1c29c7e0f0af
   dynamic.linux-m8xlarge-amd64.instance-type: m6a.8xlarge
   dynamic.linux-m8xlarge-amd64.instance-tag: prod-amd64-m8xlarge
   dynamic.linux-m8xlarge-amd64.key-name: kflux-ocp-p01-key-pair
@@ -383,7 +383,7 @@ data:
 
   dynamic.linux-d160-m8xlarge-amd64.type: aws
   dynamic.linux-d160-m8xlarge-amd64.region: us-east-1
-  dynamic.linux-d160-m8xlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-d160-m8xlarge-amd64.ami: ami-01aaf1c29c7e0f0af
   dynamic.linux-d160-m8xlarge-amd64.instance-type: m6a.8xlarge
   dynamic.linux-d160-m8xlarge-amd64.instance-tag: prod-amd64-m8xlarge-d160
   dynamic.linux-d160-m8xlarge-amd64.key-name: kflux-ocp-p01-key-pair
@@ -398,7 +398,7 @@ data:
   # cpu:memory (1:2)
   dynamic.linux-cxlarge-arm64.type: aws
   dynamic.linux-cxlarge-arm64.region: us-east-1
-  dynamic.linux-cxlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-cxlarge-arm64.ami: ami-06f37afe6d4f43c47
   dynamic.linux-cxlarge-arm64.instance-type: c6g.xlarge
   dynamic.linux-cxlarge-arm64.instance-tag: prod-arm64-cxlarge
   dynamic.linux-cxlarge-arm64.key-name: kflux-ocp-p01-key-pair
@@ -412,7 +412,7 @@ data:
   # same as linux-cxlarge-arm64 but with 160GB disk instead of default 40GB
   dynamic.linux-d160-cxlarge-arm64.type: aws
   dynamic.linux-d160-cxlarge-arm64.region: us-east-1
-  dynamic.linux-d160-cxlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-d160-cxlarge-arm64.ami: ami-06f37afe6d4f43c47
   dynamic.linux-d160-cxlarge-arm64.instance-type: c6g.xlarge
   dynamic.linux-d160-cxlarge-arm64.instance-tag: prod-arm64-d160-cxlarge
   dynamic.linux-d160-cxlarge-arm64.key-name: kflux-ocp-p01-key-pair
@@ -426,7 +426,7 @@ data:
 
   dynamic.linux-c2xlarge-arm64.type: aws
   dynamic.linux-c2xlarge-arm64.region: us-east-1
-  dynamic.linux-c2xlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-c2xlarge-arm64.ami: ami-06f37afe6d4f43c47
   dynamic.linux-c2xlarge-arm64.instance-type: c6g.2xlarge
   dynamic.linux-c2xlarge-arm64.instance-tag: prod-arm64-c2xlarge
   dynamic.linux-c2xlarge-arm64.key-name: kflux-ocp-p01-key-pair
@@ -439,7 +439,7 @@ data:
 
   dynamic.linux-c4xlarge-arm64.type: aws
   dynamic.linux-c4xlarge-arm64.region: us-east-1
-  dynamic.linux-c4xlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-c4xlarge-arm64.ami: ami-06f37afe6d4f43c47
   dynamic.linux-c4xlarge-arm64.instance-type: c6g.4xlarge
   dynamic.linux-c4xlarge-arm64.instance-tag: prod-arm64-c4xlarge
   dynamic.linux-c4xlarge-arm64.key-name: kflux-ocp-p01-key-pair
@@ -453,7 +453,7 @@ data:
   # Same as linux-c4xlarge-arm64, but with 160GB disk space
   dynamic.linux-d160-c4xlarge-arm64.type: aws
   dynamic.linux-d160-c4xlarge-arm64.region: us-east-1
-  dynamic.linux-d160-c4xlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-d160-c4xlarge-arm64.ami: ami-06f37afe6d4f43c47
   dynamic.linux-d160-c4xlarge-arm64.instance-type: c6g.4xlarge
   dynamic.linux-d160-c4xlarge-arm64.instance-tag: prod-arm64-c4xlarge-d160
   dynamic.linux-d160-c4xlarge-arm64.key-name: kflux-ocp-p01-key-pair
@@ -468,7 +468,7 @@ data:
   # Same as linux-c4xlarge-arm64, but with 320GB disk space
   dynamic.linux-d320-c4xlarge-arm64.type: aws
   dynamic.linux-d320-c4xlarge-arm64.region: us-east-1
-  dynamic.linux-d320-c4xlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-d320-c4xlarge-arm64.ami: ami-06f37afe6d4f43c47
   dynamic.linux-d320-c4xlarge-arm64.instance-type: c6g.4xlarge
   dynamic.linux-d320-c4xlarge-arm64.instance-tag: prod-arm64-c4xlarge-d320
   dynamic.linux-d320-c4xlarge-arm64.key-name: kflux-ocp-p01-key-pair
@@ -482,7 +482,7 @@ data:
 
   dynamic.linux-c8xlarge-arm64.type: aws
   dynamic.linux-c8xlarge-arm64.region: us-east-1
-  dynamic.linux-c8xlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-c8xlarge-arm64.ami: ami-06f37afe6d4f43c47
   dynamic.linux-c8xlarge-arm64.instance-type: c6g.8xlarge
   dynamic.linux-c8xlarge-arm64.instance-tag: prod-arm64-c8xlarge
   dynamic.linux-c8xlarge-arm64.key-name: kflux-ocp-p01-key-pair
@@ -495,7 +495,7 @@ data:
 
   dynamic.linux-cxlarge-amd64.type: aws
   dynamic.linux-cxlarge-amd64.region: us-east-1
-  dynamic.linux-cxlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-cxlarge-amd64.ami: ami-01aaf1c29c7e0f0af
   dynamic.linux-cxlarge-amd64.instance-type: c6a.xlarge
   dynamic.linux-cxlarge-amd64.instance-tag: prod-amd64-cxlarge
   dynamic.linux-cxlarge-amd64.key-name: kflux-ocp-p01-key-pair
@@ -508,7 +508,7 @@ data:
 
   dynamic.linux-c2xlarge-amd64.type: aws
   dynamic.linux-c2xlarge-amd64.region: us-east-1
-  dynamic.linux-c2xlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-c2xlarge-amd64.ami: ami-01aaf1c29c7e0f0af
   dynamic.linux-c2xlarge-amd64.instance-type: c6a.2xlarge
   dynamic.linux-c2xlarge-amd64.instance-tag: prod-amd64-c2xlarge
   dynamic.linux-c2xlarge-amd64.key-name: kflux-ocp-p01-key-pair
@@ -521,7 +521,7 @@ data:
 
   dynamic.linux-c4xlarge-amd64.type: aws
   dynamic.linux-c4xlarge-amd64.region: us-east-1
-  dynamic.linux-c4xlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-c4xlarge-amd64.ami: ami-01aaf1c29c7e0f0af
   dynamic.linux-c4xlarge-amd64.instance-type: c6a.4xlarge
   dynamic.linux-c4xlarge-amd64.instance-tag: prod-amd64-c4xlarge
   dynamic.linux-c4xlarge-amd64.key-name: kflux-ocp-p01-key-pair
@@ -535,7 +535,7 @@ data:
   # Same as linux-c4xlarge-amd64, but with 160 GB storage
   dynamic.linux-d160-c4xlarge-amd64.type: aws
   dynamic.linux-d160-c4xlarge-amd64.region: us-east-1
-  dynamic.linux-d160-c4xlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-d160-c4xlarge-amd64.ami: ami-01aaf1c29c7e0f0af
   dynamic.linux-d160-c4xlarge-amd64.instance-type: c6a.4xlarge
   dynamic.linux-d160-c4xlarge-amd64.instance-tag: prod-amd64-c4xlarge-d160
   dynamic.linux-d160-c4xlarge-amd64.key-name: kflux-ocp-p01-key-pair
@@ -550,7 +550,7 @@ data:
   # Same as linux-c4xlarge-amd64, but with 320 GB storage
   dynamic.linux-d320-c4xlarge-amd64.type: aws
   dynamic.linux-d320-c4xlarge-amd64.region: us-east-1
-  dynamic.linux-d320-c4xlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-d320-c4xlarge-amd64.ami: ami-01aaf1c29c7e0f0af
   dynamic.linux-d320-c4xlarge-amd64.instance-type: c6a.4xlarge
   dynamic.linux-d320-c4xlarge-amd64.instance-tag: prod-amd64-c4xlarge-d320
   dynamic.linux-d320-c4xlarge-amd64.key-name: kflux-ocp-p01-key-pair
@@ -564,7 +564,7 @@ data:
 
   dynamic.linux-c8xlarge-amd64.type: aws
   dynamic.linux-c8xlarge-amd64.region: us-east-1
-  dynamic.linux-c8xlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-c8xlarge-amd64.ami: ami-01aaf1c29c7e0f0af
   dynamic.linux-c8xlarge-amd64.instance-type: c6a.8xlarge
   dynamic.linux-c8xlarge-amd64.instance-tag: prod-amd64-c8xlarge
   dynamic.linux-c8xlarge-amd64.key-name: kflux-ocp-p01-key-pair
@@ -577,7 +577,7 @@ data:
 
   dynamic.linux-root-arm64.type: aws
   dynamic.linux-root-arm64.region: us-east-1
-  dynamic.linux-root-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-root-arm64.ami: ami-06f37afe6d4f43c47
   dynamic.linux-root-arm64.instance-type: m6g.large
   dynamic.linux-root-arm64.instance-tag: prod-arm64-root
   dynamic.linux-root-arm64.key-name: kflux-ocp-p01-key-pair
@@ -593,7 +593,7 @@ data:
 
   dynamic.linux-root-amd64.type: aws
   dynamic.linux-root-amd64.region: us-east-1
-  dynamic.linux-root-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-root-amd64.ami: ami-01aaf1c29c7e0f0af
   dynamic.linux-root-amd64.instance-type: m6idn.2xlarge
   dynamic.linux-root-amd64.instance-tag: prod-amd64-root
   dynamic.linux-root-amd64.key-name: kflux-ocp-p01-key-pair

--- a/components/multi-platform-controller/production-downstream/kflux-osp-p01/host-config.yaml
+++ b/components/multi-platform-controller/production-downstream/kflux-osp-p01/host-config.yaml
@@ -53,7 +53,7 @@ data:
   # cpu:memory (1:4)
   dynamic.linux-arm64.type: aws
   dynamic.linux-arm64.region: us-east-1
-  dynamic.linux-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-arm64.ami: ami-06f37afe6d4f43c47
   dynamic.linux-arm64.instance-type: m6g.large
   dynamic.linux-arm64.instance-tag: prod-arm64
   dynamic.linux-arm64.key-name: kflux-osp-p01-key-pair
@@ -65,7 +65,7 @@ data:
 
   dynamic.linux-mlarge-arm64.type: aws
   dynamic.linux-mlarge-arm64.region: us-east-1
-  dynamic.linux-mlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-mlarge-arm64.ami: ami-06f37afe6d4f43c47
   dynamic.linux-mlarge-arm64.instance-type: m6g.large
   dynamic.linux-mlarge-arm64.instance-tag: prod-arm64-mlarge
   dynamic.linux-mlarge-arm64.key-name: kflux-osp-p01-key-pair
@@ -77,7 +77,7 @@ data:
 
   dynamic.linux-mxlarge-arm64.type: aws
   dynamic.linux-mxlarge-arm64.region: us-east-1
-  dynamic.linux-mxlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-mxlarge-arm64.ami: ami-06f37afe6d4f43c47
   dynamic.linux-mxlarge-arm64.instance-type: m6g.xlarge
   dynamic.linux-mxlarge-arm64.instance-tag: prod-arm64-mxlarge
   dynamic.linux-mxlarge-arm64.key-name: kflux-osp-p01-key-pair
@@ -89,7 +89,7 @@ data:
 
   dynamic.linux-m2xlarge-arm64.type: aws
   dynamic.linux-m2xlarge-arm64.region: us-east-1
-  dynamic.linux-m2xlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-m2xlarge-arm64.ami: ami-06f37afe6d4f43c47
   dynamic.linux-m2xlarge-arm64.instance-type: m6g.2xlarge
   dynamic.linux-m2xlarge-arm64.instance-tag: prod-arm64-m2xlarge
   dynamic.linux-m2xlarge-arm64.key-name: kflux-osp-p01-key-pair
@@ -101,7 +101,7 @@ data:
 
   dynamic.linux-m4xlarge-arm64.type: aws
   dynamic.linux-m4xlarge-arm64.region: us-east-1
-  dynamic.linux-m4xlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-m4xlarge-arm64.ami: ami-06f37afe6d4f43c47
   dynamic.linux-m4xlarge-arm64.instance-type: m6g.4xlarge
   dynamic.linux-m4xlarge-arm64.instance-tag: prod-arm64-m4xlarge
   dynamic.linux-m4xlarge-arm64.key-name: kflux-osp-p01-key-pair
@@ -113,7 +113,7 @@ data:
 
   dynamic.linux-m8xlarge-arm64.type: aws
   dynamic.linux-m8xlarge-arm64.region: us-east-1
-  dynamic.linux-m8xlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-m8xlarge-arm64.ami: ami-06f37afe6d4f43c47
   dynamic.linux-m8xlarge-arm64.instance-type: m6g.8xlarge
   dynamic.linux-m8xlarge-arm64.instance-tag: prod-arm64-m8xlarge
   dynamic.linux-m8xlarge-arm64.key-name: kflux-osp-p01-key-pair
@@ -125,7 +125,7 @@ data:
 
   dynamic.linux-c6gd2xlarge-arm64.type: aws
   dynamic.linux-c6gd2xlarge-arm64.region: us-east-1
-  dynamic.linux-c6gd2xlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-c6gd2xlarge-arm64.ami: ami-06f37afe6d4f43c47
   dynamic.linux-c6gd2xlarge-arm64.instance-type: c6gd.2xlarge
   dynamic.linux-c6gd2xlarge-arm64.instance-tag: prod-arm64-c6gd2xlarge
   dynamic.linux-c6gd2xlarge-arm64.key-name: kflux-osp-p01-key-pair
@@ -201,7 +201,7 @@ data:
 
   dynamic.linux-amd64.type: aws
   dynamic.linux-amd64.region: us-east-1
-  dynamic.linux-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-amd64.ami: ami-01aaf1c29c7e0f0af
   dynamic.linux-amd64.instance-type: m6a.large
   dynamic.linux-amd64.instance-tag: prod-amd64
   dynamic.linux-amd64.key-name: kflux-osp-p01-key-pair
@@ -213,7 +213,7 @@ data:
 
   dynamic.linux-mlarge-amd64.type: aws
   dynamic.linux-mlarge-amd64.region: us-east-1
-  dynamic.linux-mlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-mlarge-amd64.ami: ami-01aaf1c29c7e0f0af
   dynamic.linux-mlarge-amd64.instance-type: m6a.large
   dynamic.linux-mlarge-amd64.instance-tag: prod-amd64-mlarge
   dynamic.linux-mlarge-amd64.key-name: kflux-osp-p01-key-pair
@@ -225,7 +225,7 @@ data:
 
   dynamic.linux-mxlarge-amd64.type: aws
   dynamic.linux-mxlarge-amd64.region: us-east-1
-  dynamic.linux-mxlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-mxlarge-amd64.ami: ami-01aaf1c29c7e0f0af
   dynamic.linux-mxlarge-amd64.instance-type: m6a.xlarge
   dynamic.linux-mxlarge-amd64.instance-tag: prod-amd64-mxlarge
   dynamic.linux-mxlarge-amd64.key-name: kflux-osp-p01-key-pair
@@ -237,7 +237,7 @@ data:
 
   dynamic.linux-m2xlarge-amd64.type: aws
   dynamic.linux-m2xlarge-amd64.region: us-east-1
-  dynamic.linux-m2xlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-m2xlarge-amd64.ami: ami-01aaf1c29c7e0f0af
   dynamic.linux-m2xlarge-amd64.instance-type: m6a.2xlarge
   dynamic.linux-m2xlarge-amd64.instance-tag: prod-amd64-m2xlarge
   dynamic.linux-m2xlarge-amd64.key-name: kflux-osp-p01-key-pair
@@ -249,7 +249,7 @@ data:
 
   dynamic.linux-m4xlarge-amd64.type: aws
   dynamic.linux-m4xlarge-amd64.region: us-east-1
-  dynamic.linux-m4xlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-m4xlarge-amd64.ami: ami-01aaf1c29c7e0f0af
   dynamic.linux-m4xlarge-amd64.instance-type: m6a.4xlarge
   dynamic.linux-m4xlarge-amd64.instance-tag: prod-amd64-m4xlarge
   dynamic.linux-m4xlarge-amd64.key-name: kflux-osp-p01-key-pair
@@ -261,7 +261,7 @@ data:
 
   dynamic.linux-m8xlarge-amd64.type: aws
   dynamic.linux-m8xlarge-amd64.region: us-east-1
-  dynamic.linux-m8xlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-m8xlarge-amd64.ami: ami-01aaf1c29c7e0f0af
   dynamic.linux-m8xlarge-amd64.instance-type: m6a.8xlarge
   dynamic.linux-m8xlarge-amd64.instance-tag: prod-amd64-m8xlarge
   dynamic.linux-m8xlarge-amd64.key-name: kflux-osp-p01-key-pair
@@ -274,7 +274,7 @@ data:
   # cpu:memory (1:2)
   dynamic.linux-cxlarge-arm64.type: aws
   dynamic.linux-cxlarge-arm64.region: us-east-1
-  dynamic.linux-cxlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-cxlarge-arm64.ami: ami-06f37afe6d4f43c47
   dynamic.linux-cxlarge-arm64.instance-type: c6g.xlarge
   dynamic.linux-cxlarge-arm64.instance-tag: prod-arm64-cxlarge
   dynamic.linux-cxlarge-arm64.key-name: kflux-osp-p01-key-pair
@@ -286,7 +286,7 @@ data:
 
   dynamic.linux-c2xlarge-arm64.type: aws
   dynamic.linux-c2xlarge-arm64.region: us-east-1
-  dynamic.linux-c2xlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-c2xlarge-arm64.ami: ami-06f37afe6d4f43c47
   dynamic.linux-c2xlarge-arm64.instance-type: c6g.2xlarge
   dynamic.linux-c2xlarge-arm64.instance-tag: prod-arm64-c2xlarge
   dynamic.linux-c2xlarge-arm64.key-name: kflux-osp-p01-key-pair
@@ -298,7 +298,7 @@ data:
 
   dynamic.linux-c4xlarge-arm64.type: aws
   dynamic.linux-c4xlarge-arm64.region: us-east-1
-  dynamic.linux-c4xlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-c4xlarge-arm64.ami: ami-06f37afe6d4f43c47
   dynamic.linux-c4xlarge-arm64.instance-type: c6g.4xlarge
   dynamic.linux-c4xlarge-arm64.instance-tag: prod-arm64-c4xlarge
   dynamic.linux-c4xlarge-arm64.key-name: kflux-osp-p01-key-pair
@@ -310,7 +310,7 @@ data:
 
   dynamic.linux-c8xlarge-arm64.type: aws
   dynamic.linux-c8xlarge-arm64.region: us-east-1
-  dynamic.linux-c8xlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-c8xlarge-arm64.ami: ami-06f37afe6d4f43c47
   dynamic.linux-c8xlarge-arm64.instance-type: c6g.8xlarge
   dynamic.linux-c8xlarge-arm64.instance-tag: prod-arm64-c8xlarge
   dynamic.linux-c8xlarge-arm64.key-name: kflux-osp-p01-key-pair
@@ -322,7 +322,7 @@ data:
 
   dynamic.linux-cxlarge-amd64.type: aws
   dynamic.linux-cxlarge-amd64.region: us-east-1
-  dynamic.linux-cxlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-cxlarge-amd64.ami: ami-01aaf1c29c7e0f0af
   dynamic.linux-cxlarge-amd64.instance-type: c6a.xlarge
   dynamic.linux-cxlarge-amd64.instance-tag: prod-amd64-cxlarge
   dynamic.linux-cxlarge-amd64.key-name: kflux-osp-p01-key-pair
@@ -334,7 +334,7 @@ data:
 
   dynamic.linux-c2xlarge-amd64.type: aws
   dynamic.linux-c2xlarge-amd64.region: us-east-1
-  dynamic.linux-c2xlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-c2xlarge-amd64.ami: ami-01aaf1c29c7e0f0af
   dynamic.linux-c2xlarge-amd64.instance-type: c6a.2xlarge
   dynamic.linux-c2xlarge-amd64.instance-tag: prod-amd64-c2xlarge
   dynamic.linux-c2xlarge-amd64.key-name: kflux-osp-p01-key-pair
@@ -346,7 +346,7 @@ data:
 
   dynamic.linux-c4xlarge-amd64.type: aws
   dynamic.linux-c4xlarge-amd64.region: us-east-1
-  dynamic.linux-c4xlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-c4xlarge-amd64.ami: ami-01aaf1c29c7e0f0af
   dynamic.linux-c4xlarge-amd64.instance-type: c6a.4xlarge
   dynamic.linux-c4xlarge-amd64.instance-tag: prod-amd64-c4xlarge
   dynamic.linux-c4xlarge-amd64.key-name: kflux-osp-p01-key-pair
@@ -358,7 +358,7 @@ data:
 
   dynamic.linux-c8xlarge-amd64.type: aws
   dynamic.linux-c8xlarge-amd64.region: us-east-1
-  dynamic.linux-c8xlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-c8xlarge-amd64.ami: ami-01aaf1c29c7e0f0af
   dynamic.linux-c8xlarge-amd64.instance-type: c6a.8xlarge
   dynamic.linux-c8xlarge-amd64.instance-tag: prod-amd64-c8xlarge
   dynamic.linux-c8xlarge-amd64.key-name: kflux-osp-p01-key-pair
@@ -370,7 +370,7 @@ data:
 
   dynamic.linux-root-arm64.type: aws
   dynamic.linux-root-arm64.region: us-east-1
-  dynamic.linux-root-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-root-arm64.ami: ami-06f37afe6d4f43c47
   dynamic.linux-root-arm64.instance-type: m6g.large
   dynamic.linux-root-arm64.instance-tag: prod-arm64-root
   dynamic.linux-root-arm64.key-name: kflux-osp-p01-key-pair
@@ -387,7 +387,7 @@ data:
 
   dynamic.linux-fast-amd64.type: aws
   dynamic.linux-fast-amd64.region: us-east-1
-  dynamic.linux-fast-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-fast-amd64.ami: ami-01aaf1c29c7e0f0af
   dynamic.linux-fast-amd64.instance-type: c7a.8xlarge
   dynamic.linux-fast-amd64.instance-tag: prod-amd64-fast
   dynamic.linux-fast-amd64.key-name: kflux-osp-p01-key-pair
@@ -402,7 +402,7 @@ data:
 
   dynamic.linux-extra-fast-amd64.type: aws
   dynamic.linux-extra-fast-amd64.region: us-east-1
-  dynamic.linux-extra-fast-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-extra-fast-amd64.ami: ami-01aaf1c29c7e0f0af
   dynamic.linux-extra-fast-amd64.instance-type: c7a.12xlarge
   dynamic.linux-extra-fast-amd64.instance-tag: prod-amd64-extra-fast
   dynamic.linux-extra-fast-amd64.key-name: kflux-osp-p01-key-pair
@@ -417,7 +417,7 @@ data:
 
   dynamic.linux-root-amd64.type: aws
   dynamic.linux-root-amd64.region: us-east-1
-  dynamic.linux-root-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-root-amd64.ami: ami-01aaf1c29c7e0f0af
   dynamic.linux-root-amd64.instance-type: m6idn.2xlarge
   dynamic.linux-root-amd64.instance-tag: prod-amd64-root
   dynamic.linux-root-amd64.key-name: kflux-osp-p01-key-pair

--- a/components/multi-platform-controller/production-downstream/pentest-p01/host-config.yaml
+++ b/components/multi-platform-controller/production-downstream/pentest-p01/host-config.yaml
@@ -53,7 +53,7 @@ data:
   # cpu:memory (1:4)
   dynamic.linux-arm64.type: aws
   dynamic.linux-arm64.region: us-east-1
-  dynamic.linux-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-arm64.ami: ami-06f37afe6d4f43c47
   dynamic.linux-arm64.instance-type: m6g.large
   dynamic.linux-arm64.instance-tag: prod-arm64
   dynamic.linux-arm64.key-name: pentest-p01-key-pair
@@ -65,7 +65,7 @@ data:
 
   dynamic.linux-mlarge-arm64.type: aws
   dynamic.linux-mlarge-arm64.region: us-east-1
-  dynamic.linux-mlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-mlarge-arm64.ami: ami-06f37afe6d4f43c47
   dynamic.linux-mlarge-arm64.instance-type: m6g.large
   dynamic.linux-mlarge-arm64.instance-tag: prod-arm64-mlarge
   dynamic.linux-mlarge-arm64.key-name: pentest-p01-key-pair
@@ -77,7 +77,7 @@ data:
 
   dynamic.linux-mxlarge-arm64.type: aws
   dynamic.linux-mxlarge-arm64.region: us-east-1
-  dynamic.linux-mxlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-mxlarge-arm64.ami: ami-06f37afe6d4f43c47
   dynamic.linux-mxlarge-arm64.instance-type: m6g.xlarge
   dynamic.linux-mxlarge-arm64.instance-tag: prod-arm64-mxlarge
   dynamic.linux-mxlarge-arm64.key-name: pentest-p01-key-pair
@@ -89,7 +89,7 @@ data:
 
   dynamic.linux-m2xlarge-arm64.type: aws
   dynamic.linux-m2xlarge-arm64.region: us-east-1
-  dynamic.linux-m2xlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-m2xlarge-arm64.ami: ami-06f37afe6d4f43c47
   dynamic.linux-m2xlarge-arm64.instance-type: m6g.2xlarge
   dynamic.linux-m2xlarge-arm64.instance-tag: prod-arm64-m2xlarge
   dynamic.linux-m2xlarge-arm64.key-name: pentest-p01-key-pair
@@ -101,7 +101,7 @@ data:
 
   dynamic.linux-m4xlarge-arm64.type: aws
   dynamic.linux-m4xlarge-arm64.region: us-east-1
-  dynamic.linux-m4xlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-m4xlarge-arm64.ami: ami-06f37afe6d4f43c47
   dynamic.linux-m4xlarge-arm64.instance-type: m6g.4xlarge
   dynamic.linux-m4xlarge-arm64.instance-tag: prod-arm64-m4xlarge
   dynamic.linux-m4xlarge-arm64.key-name: pentest-p01-key-pair
@@ -113,7 +113,7 @@ data:
 
   dynamic.linux-m8xlarge-arm64.type: aws
   dynamic.linux-m8xlarge-arm64.region: us-east-1
-  dynamic.linux-m8xlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-m8xlarge-arm64.ami: ami-06f37afe6d4f43c47
   dynamic.linux-m8xlarge-arm64.instance-type: m6g.8xlarge
   dynamic.linux-m8xlarge-arm64.instance-tag: prod-arm64-m8xlarge
   dynamic.linux-m8xlarge-arm64.key-name: pentest-p01-key-pair
@@ -125,7 +125,7 @@ data:
 
   dynamic.linux-c6gd2xlarge-arm64.type: aws
   dynamic.linux-c6gd2xlarge-arm64.region: us-east-1
-  dynamic.linux-c6gd2xlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-c6gd2xlarge-arm64.ami: ami-06f37afe6d4f43c47
   dynamic.linux-c6gd2xlarge-arm64.instance-type: c6gd.2xlarge
   dynamic.linux-c6gd2xlarge-arm64.instance-tag: prod-arm64-c6gd2xlarge
   dynamic.linux-c6gd2xlarge-arm64.key-name: pentest-p01-key-pair
@@ -201,7 +201,7 @@ data:
 
   dynamic.linux-amd64.type: aws
   dynamic.linux-amd64.region: us-east-1
-  dynamic.linux-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-amd64.ami: ami-01aaf1c29c7e0f0af
   dynamic.linux-amd64.instance-type: m6a.large
   dynamic.linux-amd64.instance-tag: prod-amd64
   dynamic.linux-amd64.key-name: pentest-p01-key-pair
@@ -213,7 +213,7 @@ data:
 
   dynamic.linux-mlarge-amd64.type: aws
   dynamic.linux-mlarge-amd64.region: us-east-1
-  dynamic.linux-mlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-mlarge-amd64.ami: ami-01aaf1c29c7e0f0af
   dynamic.linux-mlarge-amd64.instance-type: m6a.large
   dynamic.linux-mlarge-amd64.instance-tag: prod-amd64-mlarge
   dynamic.linux-mlarge-amd64.key-name: pentest-p01-key-pair
@@ -225,7 +225,7 @@ data:
 
   dynamic.linux-mxlarge-amd64.type: aws
   dynamic.linux-mxlarge-amd64.region: us-east-1
-  dynamic.linux-mxlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-mxlarge-amd64.ami: ami-01aaf1c29c7e0f0af
   dynamic.linux-mxlarge-amd64.instance-type: m6a.xlarge
   dynamic.linux-mxlarge-amd64.instance-tag: prod-amd64-mxlarge
   dynamic.linux-mxlarge-amd64.key-name: pentest-p01-key-pair
@@ -237,7 +237,7 @@ data:
 
   dynamic.linux-m2xlarge-amd64.type: aws
   dynamic.linux-m2xlarge-amd64.region: us-east-1
-  dynamic.linux-m2xlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-m2xlarge-amd64.ami: ami-01aaf1c29c7e0f0af
   dynamic.linux-m2xlarge-amd64.instance-type: m6a.2xlarge
   dynamic.linux-m2xlarge-amd64.instance-tag: prod-amd64-m2xlarge
   dynamic.linux-m2xlarge-amd64.key-name: pentest-p01-key-pair
@@ -249,7 +249,7 @@ data:
 
   dynamic.linux-m4xlarge-amd64.type: aws
   dynamic.linux-m4xlarge-amd64.region: us-east-1
-  dynamic.linux-m4xlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-m4xlarge-amd64.ami: ami-01aaf1c29c7e0f0af
   dynamic.linux-m4xlarge-amd64.instance-type: m6a.4xlarge
   dynamic.linux-m4xlarge-amd64.instance-tag: prod-amd64-m4xlarge
   dynamic.linux-m4xlarge-amd64.key-name: pentest-p01-key-pair
@@ -261,7 +261,7 @@ data:
 
   dynamic.linux-m8xlarge-amd64.type: aws
   dynamic.linux-m8xlarge-amd64.region: us-east-1
-  dynamic.linux-m8xlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-m8xlarge-amd64.ami: ami-01aaf1c29c7e0f0af
   dynamic.linux-m8xlarge-amd64.instance-type: m6a.8xlarge
   dynamic.linux-m8xlarge-amd64.instance-tag: prod-amd64-m8xlarge
   dynamic.linux-m8xlarge-amd64.key-name: pentest-p01-key-pair
@@ -274,7 +274,7 @@ data:
   # cpu:memory (1:2)
   dynamic.linux-cxlarge-arm64.type: aws
   dynamic.linux-cxlarge-arm64.region: us-east-1
-  dynamic.linux-cxlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-cxlarge-arm64.ami: ami-06f37afe6d4f43c47
   dynamic.linux-cxlarge-arm64.instance-type: c6g.xlarge
   dynamic.linux-cxlarge-arm64.instance-tag: prod-arm64-cxlarge
   dynamic.linux-cxlarge-arm64.key-name: pentest-p01-key-pair
@@ -286,7 +286,7 @@ data:
 
   dynamic.linux-c2xlarge-arm64.type: aws
   dynamic.linux-c2xlarge-arm64.region: us-east-1
-  dynamic.linux-c2xlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-c2xlarge-arm64.ami: ami-06f37afe6d4f43c47
   dynamic.linux-c2xlarge-arm64.instance-type: c6g.2xlarge
   dynamic.linux-c2xlarge-arm64.instance-tag: prod-arm64-c2xlarge
   dynamic.linux-c2xlarge-arm64.key-name: pentest-p01-key-pair
@@ -298,7 +298,7 @@ data:
 
   dynamic.linux-c4xlarge-arm64.type: aws
   dynamic.linux-c4xlarge-arm64.region: us-east-1
-  dynamic.linux-c4xlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-c4xlarge-arm64.ami: ami-06f37afe6d4f43c47
   dynamic.linux-c4xlarge-arm64.instance-type: c6g.4xlarge
   dynamic.linux-c4xlarge-arm64.instance-tag: prod-arm64-c4xlarge
   dynamic.linux-c4xlarge-arm64.key-name: pentest-p01-key-pair
@@ -310,7 +310,7 @@ data:
 
   dynamic.linux-c8xlarge-arm64.type: aws
   dynamic.linux-c8xlarge-arm64.region: us-east-1
-  dynamic.linux-c8xlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-c8xlarge-arm64.ami: ami-06f37afe6d4f43c47
   dynamic.linux-c8xlarge-arm64.instance-type: c6g.8xlarge
   dynamic.linux-c8xlarge-arm64.instance-tag: prod-arm64-c8xlarge
   dynamic.linux-c8xlarge-arm64.key-name: pentest-p01-key-pair
@@ -322,7 +322,7 @@ data:
 
   dynamic.linux-cxlarge-amd64.type: aws
   dynamic.linux-cxlarge-amd64.region: us-east-1
-  dynamic.linux-cxlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-cxlarge-amd64.ami: ami-01aaf1c29c7e0f0af
   dynamic.linux-cxlarge-amd64.instance-type: c6a.xlarge
   dynamic.linux-cxlarge-amd64.instance-tag: prod-amd64-cxlarge
   dynamic.linux-cxlarge-amd64.key-name: pentest-p01-key-pair
@@ -334,7 +334,7 @@ data:
 
   dynamic.linux-c2xlarge-amd64.type: aws
   dynamic.linux-c2xlarge-amd64.region: us-east-1
-  dynamic.linux-c2xlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-c2xlarge-amd64.ami: ami-01aaf1c29c7e0f0af
   dynamic.linux-c2xlarge-amd64.instance-type: c6a.2xlarge
   dynamic.linux-c2xlarge-amd64.instance-tag: prod-amd64-c2xlarge
   dynamic.linux-c2xlarge-amd64.key-name: pentest-p01-key-pair
@@ -346,7 +346,7 @@ data:
 
   dynamic.linux-c4xlarge-amd64.type: aws
   dynamic.linux-c4xlarge-amd64.region: us-east-1
-  dynamic.linux-c4xlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-c4xlarge-amd64.ami: ami-01aaf1c29c7e0f0af
   dynamic.linux-c4xlarge-amd64.instance-type: c6a.4xlarge
   dynamic.linux-c4xlarge-amd64.instance-tag: prod-amd64-c4xlarge
   dynamic.linux-c4xlarge-amd64.key-name: pentest-p01-key-pair
@@ -358,7 +358,7 @@ data:
 
   dynamic.linux-c8xlarge-amd64.type: aws
   dynamic.linux-c8xlarge-amd64.region: us-east-1
-  dynamic.linux-c8xlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-c8xlarge-amd64.ami: ami-01aaf1c29c7e0f0af
   dynamic.linux-c8xlarge-amd64.instance-type: c6a.8xlarge
   dynamic.linux-c8xlarge-amd64.instance-tag: prod-amd64-c8xlarge
   dynamic.linux-c8xlarge-amd64.key-name: pentest-p01-key-pair
@@ -370,7 +370,7 @@ data:
 
   dynamic.linux-root-arm64.type: aws
   dynamic.linux-root-arm64.region: us-east-1
-  dynamic.linux-root-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-root-arm64.ami: ami-06f37afe6d4f43c47
   dynamic.linux-root-arm64.instance-type: m6g.large
   dynamic.linux-root-arm64.instance-tag: prod-arm64-root
   dynamic.linux-root-arm64.key-name: pentest-p01-key-pair
@@ -387,7 +387,7 @@ data:
 
   dynamic.linux-fast-amd64.type: aws
   dynamic.linux-fast-amd64.region: us-east-1
-  dynamic.linux-fast-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-fast-amd64.ami: ami-01aaf1c29c7e0f0af
   dynamic.linux-fast-amd64.instance-type: c7a.8xlarge
   dynamic.linux-fast-amd64.instance-tag: prod-amd64-fast
   dynamic.linux-fast-amd64.key-name: pentest-p01-key-pair
@@ -402,7 +402,7 @@ data:
 
   dynamic.linux-extra-fast-amd64.type: aws
   dynamic.linux-extra-fast-amd64.region: us-east-1
-  dynamic.linux-extra-fast-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-extra-fast-amd64.ami: ami-01aaf1c29c7e0f0af
   dynamic.linux-extra-fast-amd64.instance-type: c7a.12xlarge
   dynamic.linux-extra-fast-amd64.instance-tag: prod-amd64-extra-fast
   dynamic.linux-extra-fast-amd64.key-name: pentest-p01-key-pair
@@ -417,7 +417,7 @@ data:
 
   dynamic.linux-root-amd64.type: aws
   dynamic.linux-root-amd64.region: us-east-1
-  dynamic.linux-root-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-root-amd64.ami: ami-01aaf1c29c7e0f0af
   dynamic.linux-root-amd64.instance-type: m6idn.2xlarge
   dynamic.linux-root-amd64.instance-tag: prod-amd64-root
   dynamic.linux-root-amd64.key-name: pentest-p01-key-pair

--- a/components/multi-platform-controller/production-downstream/stone-prod-p01/host-config.yaml
+++ b/components/multi-platform-controller/production-downstream/stone-prod-p01/host-config.yaml
@@ -57,7 +57,7 @@ data:
   # cpu:memory (1:4)
   dynamic.linux-arm64.type: aws
   dynamic.linux-arm64.region: us-east-1
-  dynamic.linux-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-arm64.ami: ami-06f37afe6d4f43c47
   dynamic.linux-arm64.instance-type: m6g.large
   dynamic.linux-arm64.instance-tag: prod-arm64
   dynamic.linux-arm64.key-name: konflux-prod-int-mab01
@@ -70,7 +70,7 @@ data:
 
   dynamic.linux-mlarge-arm64.type: aws
   dynamic.linux-mlarge-arm64.region: us-east-1
-  dynamic.linux-mlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-mlarge-arm64.ami: ami-06f37afe6d4f43c47
   dynamic.linux-mlarge-arm64.instance-type: m6g.large
   dynamic.linux-mlarge-arm64.instance-tag: prod-arm64-mlarge
   dynamic.linux-mlarge-arm64.key-name: konflux-prod-int-mab01
@@ -83,7 +83,7 @@ data:
 
   dynamic.linux-mxlarge-arm64.type: aws
   dynamic.linux-mxlarge-arm64.region: us-east-1
-  dynamic.linux-mxlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-mxlarge-arm64.ami: ami-06f37afe6d4f43c47
   dynamic.linux-mxlarge-arm64.instance-type: m6g.xlarge
   dynamic.linux-mxlarge-arm64.instance-tag: prod-arm64-mxlarge
   dynamic.linux-mxlarge-arm64.key-name: konflux-prod-int-mab01
@@ -96,7 +96,7 @@ data:
 
   dynamic.linux-m2xlarge-arm64.type: aws
   dynamic.linux-m2xlarge-arm64.region: us-east-1
-  dynamic.linux-m2xlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-m2xlarge-arm64.ami: ami-06f37afe6d4f43c47
   dynamic.linux-m2xlarge-arm64.instance-type: m6g.2xlarge
   dynamic.linux-m2xlarge-arm64.instance-tag: prod-arm64-m2xlarge
   dynamic.linux-m2xlarge-arm64.key-name: konflux-prod-int-mab01
@@ -109,7 +109,7 @@ data:
 
   dynamic.linux-d160-m2xlarge-arm64.type: aws
   dynamic.linux-d160-m2xlarge-arm64.region: us-east-1
-  dynamic.linux-d160-m2xlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-d160-m2xlarge-arm64.ami: ami-06f37afe6d4f43c47
   dynamic.linux-d160-m2xlarge-arm64.instance-type: m6g.2xlarge
   dynamic.linux-d160-m2xlarge-arm64.instance-tag: prod-arm64-m2xlarge-d160
   dynamic.linux-d160-m2xlarge-arm64.key-name: konflux-prod-int-mab01
@@ -123,7 +123,7 @@ data:
 
   dynamic.linux-m4xlarge-arm64.type: aws
   dynamic.linux-m4xlarge-arm64.region: us-east-1
-  dynamic.linux-m4xlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-m4xlarge-arm64.ami: ami-06f37afe6d4f43c47
   dynamic.linux-m4xlarge-arm64.instance-type: m6g.4xlarge
   dynamic.linux-m4xlarge-arm64.instance-tag: prod-arm64-m4xlarge
   dynamic.linux-m4xlarge-arm64.key-name: konflux-prod-int-mab01
@@ -136,7 +136,7 @@ data:
 
   dynamic.linux-d160-m4xlarge-arm64.type: aws
   dynamic.linux-d160-m4xlarge-arm64.region: us-east-1
-  dynamic.linux-d160-m4xlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-d160-m4xlarge-arm64.ami: ami-06f37afe6d4f43c47
   dynamic.linux-d160-m4xlarge-arm64.instance-type: m6g.4xlarge
   dynamic.linux-d160-m4xlarge-arm64.instance-tag: prod-arm64-m4xlarge-d160
   dynamic.linux-d160-m4xlarge-arm64.key-name: konflux-prod-int-mab01
@@ -150,7 +150,7 @@ data:
 
   dynamic.linux-m8xlarge-arm64.type: aws
   dynamic.linux-m8xlarge-arm64.region: us-east-1
-  dynamic.linux-m8xlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-m8xlarge-arm64.ami: ami-06f37afe6d4f43c47
   dynamic.linux-m8xlarge-arm64.instance-type: m6g.8xlarge
   dynamic.linux-m8xlarge-arm64.instance-tag: prod-arm64-m8xlarge
   dynamic.linux-m8xlarge-arm64.key-name: konflux-prod-int-mab01
@@ -163,7 +163,7 @@ data:
 
   dynamic.linux-d160-m8xlarge-arm64.type: aws
   dynamic.linux-d160-m8xlarge-arm64.region: us-east-1
-  dynamic.linux-d160-m8xlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-d160-m8xlarge-arm64.ami: ami-06f37afe6d4f43c47
   dynamic.linux-d160-m8xlarge-arm64.instance-type: m6g.8xlarge
   dynamic.linux-d160-m8xlarge-arm64.instance-tag: prod-arm64-m8xlarge-d160
   dynamic.linux-d160-m8xlarge-arm64.key-name: konflux-prod-int-mab01
@@ -177,7 +177,7 @@ data:
   
   dynamic.linux-c6gd2xlarge-arm64.type: aws
   dynamic.linux-c6gd2xlarge-arm64.region: us-east-1
-  dynamic.linux-c6gd2xlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-c6gd2xlarge-arm64.ami: ami-06f37afe6d4f43c47
   dynamic.linux-c6gd2xlarge-arm64.instance-type: c6gd.2xlarge
   dynamic.linux-c6gd2xlarge-arm64.instance-tag: prod-arm64-c6gd2xlarge
   dynamic.linux-c6gd2xlarge-arm64.key-name: konflux-prod-int-mab01
@@ -254,7 +254,7 @@ data:
 
   dynamic.linux-amd64.type: aws
   dynamic.linux-amd64.region: us-east-1
-  dynamic.linux-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-amd64.ami: ami-01aaf1c29c7e0f0af
   dynamic.linux-amd64.instance-type: m6a.large
   dynamic.linux-amd64.instance-tag: prod-amd64
   dynamic.linux-amd64.key-name: konflux-prod-int-mab01
@@ -267,7 +267,7 @@ data:
 
   dynamic.linux-mlarge-amd64.type: aws
   dynamic.linux-mlarge-amd64.region: us-east-1
-  dynamic.linux-mlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-mlarge-amd64.ami: ami-01aaf1c29c7e0f0af
   dynamic.linux-mlarge-amd64.instance-type: m6a.large
   dynamic.linux-mlarge-amd64.instance-tag: prod-amd64-mlarge
   dynamic.linux-mlarge-amd64.key-name: konflux-prod-int-mab01
@@ -280,7 +280,7 @@ data:
 
   dynamic.linux-mxlarge-amd64.type: aws
   dynamic.linux-mxlarge-amd64.region: us-east-1
-  dynamic.linux-mxlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-mxlarge-amd64.ami: ami-01aaf1c29c7e0f0af
   dynamic.linux-mxlarge-amd64.instance-type: m6a.xlarge
   dynamic.linux-mxlarge-amd64.instance-tag: prod-amd64-mxlarge
   dynamic.linux-mxlarge-amd64.key-name: konflux-prod-int-mab01
@@ -293,7 +293,7 @@ data:
 
   dynamic.linux-m2xlarge-amd64.type: aws
   dynamic.linux-m2xlarge-amd64.region: us-east-1
-  dynamic.linux-m2xlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-m2xlarge-amd64.ami: ami-01aaf1c29c7e0f0af
   dynamic.linux-m2xlarge-amd64.instance-type: m6a.2xlarge
   dynamic.linux-m2xlarge-amd64.instance-tag: prod-amd64-m2xlarge
   dynamic.linux-m2xlarge-amd64.key-name: konflux-prod-int-mab01
@@ -306,7 +306,7 @@ data:
 
   dynamic.linux-d160-m2xlarge-amd64.type: aws
   dynamic.linux-d160-m2xlarge-amd64.region: us-east-1
-  dynamic.linux-d160-m2xlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-d160-m2xlarge-amd64.ami: ami-01aaf1c29c7e0f0af
   dynamic.linux-d160-m2xlarge-amd64.instance-type: m6a.2xlarge
   dynamic.linux-d160-m2xlarge-amd64.instance-tag: prod-amd64-m2xlarge-d160
   dynamic.linux-d160-m2xlarge-amd64.key-name: konflux-prod-int-mab01
@@ -320,7 +320,7 @@ data:
 
   dynamic.linux-m4xlarge-amd64.type: aws
   dynamic.linux-m4xlarge-amd64.region: us-east-1
-  dynamic.linux-m4xlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-m4xlarge-amd64.ami: ami-01aaf1c29c7e0f0af
   dynamic.linux-m4xlarge-amd64.instance-type: m6a.4xlarge
   dynamic.linux-m4xlarge-amd64.instance-tag: prod-amd64-m4xlarge
   dynamic.linux-m4xlarge-amd64.key-name: konflux-prod-int-mab01
@@ -333,7 +333,7 @@ data:
 
   dynamic.linux-d160-m4xlarge-amd64.type: aws
   dynamic.linux-d160-m4xlarge-amd64.region: us-east-1
-  dynamic.linux-d160-m4xlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-d160-m4xlarge-amd64.ami: ami-01aaf1c29c7e0f0af
   dynamic.linux-d160-m4xlarge-amd64.instance-type: m6a.4xlarge
   dynamic.linux-d160-m4xlarge-amd64.instance-tag: prod-amd64-m4xlarge-d160
   dynamic.linux-d160-m4xlarge-amd64.key-name: konflux-prod-int-mab01
@@ -347,7 +347,7 @@ data:
 
   dynamic.linux-m8xlarge-amd64.type: aws
   dynamic.linux-m8xlarge-amd64.region: us-east-1
-  dynamic.linux-m8xlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-m8xlarge-amd64.ami: ami-01aaf1c29c7e0f0af
   dynamic.linux-m8xlarge-amd64.instance-type: m6a.8xlarge
   dynamic.linux-m8xlarge-amd64.instance-tag: prod-amd64-m8xlarge
   dynamic.linux-m8xlarge-amd64.key-name: konflux-prod-int-mab01
@@ -360,7 +360,7 @@ data:
 
   dynamic.linux-d160-m8xlarge-amd64.type: aws
   dynamic.linux-d160-m8xlarge-amd64.region: us-east-1
-  dynamic.linux-d160-m8xlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-d160-m8xlarge-amd64.ami: ami-01aaf1c29c7e0f0af
   dynamic.linux-d160-m8xlarge-amd64.instance-type: m6a.8xlarge
   dynamic.linux-d160-m8xlarge-amd64.instance-tag: prod-amd64-m8xlarge-d160
   dynamic.linux-d160-m8xlarge-amd64.key-name: konflux-prod-int-mab01
@@ -375,7 +375,7 @@ data:
   # cpu:memory (1:2)
   dynamic.linux-cxlarge-arm64.type: aws
   dynamic.linux-cxlarge-arm64.region: us-east-1
-  dynamic.linux-cxlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-cxlarge-arm64.ami: ami-06f37afe6d4f43c47
   dynamic.linux-cxlarge-arm64.instance-type: c6g.xlarge
   dynamic.linux-cxlarge-arm64.instance-tag: prod-arm64-cxlarge
   dynamic.linux-cxlarge-arm64.key-name: konflux-prod-int-mab01
@@ -388,7 +388,7 @@ data:
 
   dynamic.linux-c2xlarge-arm64.type: aws
   dynamic.linux-c2xlarge-arm64.region: us-east-1
-  dynamic.linux-c2xlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-c2xlarge-arm64.ami: ami-06f37afe6d4f43c47
   dynamic.linux-c2xlarge-arm64.instance-type: c6g.2xlarge
   dynamic.linux-c2xlarge-arm64.instance-tag: prod-arm64-c2xlarge
   dynamic.linux-c2xlarge-arm64.key-name: konflux-prod-int-mab01
@@ -401,7 +401,7 @@ data:
 
   dynamic.linux-c4xlarge-arm64.type: aws
   dynamic.linux-c4xlarge-arm64.region: us-east-1
-  dynamic.linux-c4xlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-c4xlarge-arm64.ami: ami-06f37afe6d4f43c47
   dynamic.linux-c4xlarge-arm64.instance-type: c6g.4xlarge
   dynamic.linux-c4xlarge-arm64.instance-tag: prod-arm64-c4xlarge
   dynamic.linux-c4xlarge-arm64.key-name: konflux-prod-int-mab01
@@ -414,7 +414,7 @@ data:
 
   dynamic.linux-c8xlarge-arm64.type: aws
   dynamic.linux-c8xlarge-arm64.region: us-east-1
-  dynamic.linux-c8xlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-c8xlarge-arm64.ami: ami-06f37afe6d4f43c47
   dynamic.linux-c8xlarge-arm64.instance-type: c6g.8xlarge
   dynamic.linux-c8xlarge-arm64.instance-tag: prod-arm64-c8xlarge
   dynamic.linux-c8xlarge-arm64.key-name: konflux-prod-int-mab01
@@ -427,7 +427,7 @@ data:
 
   dynamic.linux-cxlarge-amd64.type: aws
   dynamic.linux-cxlarge-amd64.region: us-east-1
-  dynamic.linux-cxlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-cxlarge-amd64.ami: ami-01aaf1c29c7e0f0af
   dynamic.linux-cxlarge-amd64.instance-type: c6a.xlarge
   dynamic.linux-cxlarge-amd64.instance-tag: prod-amd64-cxlarge
   dynamic.linux-cxlarge-amd64.key-name: konflux-prod-int-mab01
@@ -440,7 +440,7 @@ data:
 
   dynamic.linux-c2xlarge-amd64.type: aws
   dynamic.linux-c2xlarge-amd64.region: us-east-1
-  dynamic.linux-c2xlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-c2xlarge-amd64.ami: ami-01aaf1c29c7e0f0af
   dynamic.linux-c2xlarge-amd64.instance-type: c6a.2xlarge
   dynamic.linux-c2xlarge-amd64.instance-tag: prod-amd64-c2xlarge
   dynamic.linux-c2xlarge-amd64.key-name: konflux-prod-int-mab01
@@ -453,7 +453,7 @@ data:
 
   dynamic.linux-c4xlarge-amd64.type: aws
   dynamic.linux-c4xlarge-amd64.region: us-east-1
-  dynamic.linux-c4xlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-c4xlarge-amd64.ami: ami-01aaf1c29c7e0f0af
   dynamic.linux-c4xlarge-amd64.instance-type: c6a.4xlarge
   dynamic.linux-c4xlarge-amd64.instance-tag: prod-amd64-c4xlarge
   dynamic.linux-c4xlarge-amd64.key-name: konflux-prod-int-mab01
@@ -466,7 +466,7 @@ data:
 
   dynamic.linux-c8xlarge-amd64.type: aws
   dynamic.linux-c8xlarge-amd64.region: us-east-1
-  dynamic.linux-c8xlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-c8xlarge-amd64.ami: ami-01aaf1c29c7e0f0af
   dynamic.linux-c8xlarge-amd64.instance-type: c6a.8xlarge
   dynamic.linux-c8xlarge-amd64.instance-tag: prod-amd64-c8xlarge
   dynamic.linux-c8xlarge-amd64.key-name: konflux-prod-int-mab01
@@ -479,7 +479,7 @@ data:
 
   dynamic.linux-root-arm64.type: aws
   dynamic.linux-root-arm64.region: us-east-1
-  dynamic.linux-root-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-root-arm64.ami: ami-06f37afe6d4f43c47
   dynamic.linux-root-arm64.instance-type: m6g.large
   dynamic.linux-root-arm64.instance-tag: prod-arm64-root
   dynamic.linux-root-arm64.key-name: konflux-prod-int-mab01
@@ -495,7 +495,7 @@ data:
 
   dynamic.linux-root-amd64.type: aws
   dynamic.linux-root-amd64.region: us-east-1
-  dynamic.linux-root-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-root-amd64.ami: ami-01aaf1c29c7e0f0af
   dynamic.linux-root-amd64.instance-type: m6idn.2xlarge
   dynamic.linux-root-amd64.instance-tag: prod-amd64-root
   dynamic.linux-root-amd64.key-name: konflux-prod-int-mab01

--- a/components/multi-platform-controller/production-downstream/stone-prod-p02/host-config.yaml
+++ b/components/multi-platform-controller/production-downstream/stone-prod-p02/host-config.yaml
@@ -59,7 +59,7 @@ data:
   # cpu:memory (1:4)
   dynamic.linux-arm64.type: aws
   dynamic.linux-arm64.region: us-east-1
-  dynamic.linux-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-arm64.ami: ami-06f37afe6d4f43c47
   dynamic.linux-arm64.instance-type: m6g.large
   dynamic.linux-arm64.instance-tag: prod-arm64
   dynamic.linux-arm64.key-name: konflux-prod-int-mab01
@@ -72,7 +72,7 @@ data:
 
   dynamic.linux-mlarge-arm64.type: aws
   dynamic.linux-mlarge-arm64.region: us-east-1
-  dynamic.linux-mlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-mlarge-arm64.ami: ami-06f37afe6d4f43c47
   dynamic.linux-mlarge-arm64.instance-type: m6g.large
   dynamic.linux-mlarge-arm64.instance-tag: prod-arm64-mlarge
   dynamic.linux-mlarge-arm64.key-name: konflux-prod-int-mab01
@@ -85,7 +85,7 @@ data:
 
   dynamic.linux-mxlarge-arm64.type: aws
   dynamic.linux-mxlarge-arm64.region: us-east-1
-  dynamic.linux-mxlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-mxlarge-arm64.ami: ami-06f37afe6d4f43c47
   dynamic.linux-mxlarge-arm64.instance-type: m6g.xlarge
   dynamic.linux-mxlarge-arm64.instance-tag: prod-arm64-mxlarge
   dynamic.linux-mxlarge-arm64.key-name: konflux-prod-int-mab01
@@ -98,7 +98,7 @@ data:
 
   dynamic.linux-m2xlarge-arm64.type: aws
   dynamic.linux-m2xlarge-arm64.region: us-east-1
-  dynamic.linux-m2xlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-m2xlarge-arm64.ami: ami-06f37afe6d4f43c47
   dynamic.linux-m2xlarge-arm64.instance-type: m6g.2xlarge
   dynamic.linux-m2xlarge-arm64.instance-tag: prod-arm64-m2xlarge
   dynamic.linux-m2xlarge-arm64.key-name: konflux-prod-int-mab01
@@ -111,7 +111,7 @@ data:
 
   dynamic.linux-d160-m2xlarge-arm64.type: aws
   dynamic.linux-d160-m2xlarge-arm64.region: us-east-1
-  dynamic.linux-d160-m2xlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-d160-m2xlarge-arm64.ami: ami-06f37afe6d4f43c47
   dynamic.linux-d160-m2xlarge-arm64.instance-type: m6g.2xlarge
   dynamic.linux-d160-m2xlarge-arm64.instance-tag: prod-arm64-m2xlarge-d160
   dynamic.linux-d160-m2xlarge-arm64.key-name: konflux-prod-int-mab01
@@ -125,7 +125,7 @@ data:
 
   dynamic.linux-m4xlarge-arm64.type: aws
   dynamic.linux-m4xlarge-arm64.region: us-east-1
-  dynamic.linux-m4xlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-m4xlarge-arm64.ami: ami-06f37afe6d4f43c47
   dynamic.linux-m4xlarge-arm64.instance-type: m6g.4xlarge
   dynamic.linux-m4xlarge-arm64.instance-tag: prod-arm64-m4xlarge
   dynamic.linux-m4xlarge-arm64.key-name: konflux-prod-int-mab01
@@ -138,7 +138,7 @@ data:
 
   dynamic.linux-c6gd2xlarge-arm64.type: aws
   dynamic.linux-c6gd2xlarge-arm64.region: us-east-1
-  dynamic.linux-c6gd2xlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-c6gd2xlarge-arm64.ami: ami-06f37afe6d4f43c47
   dynamic.linux-c6gd2xlarge-arm64.instance-type: c6gd.2xlarge
   dynamic.linux-c6gd2xlarge-arm64.instance-tag: prod-arm64-c6gd2xlarge
   dynamic.linux-c6gd2xlarge-arm64.key-name: konflux-prod-int-mab01
@@ -216,7 +216,7 @@ data:
   # same as m4xlarge-arm64 but with 160G disk
   dynamic.linux-d160-m4xlarge-arm64.type: aws
   dynamic.linux-d160-m4xlarge-arm64.region: us-east-1
-  dynamic.linux-d160-m4xlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-d160-m4xlarge-arm64.ami: ami-06f37afe6d4f43c47
   dynamic.linux-d160-m4xlarge-arm64.instance-type: m6g.4xlarge
   dynamic.linux-d160-m4xlarge-arm64.instance-tag: prod-arm64-4xlarge-d160
   dynamic.linux-d160-m4xlarge-arm64.key-name: konflux-prod-int-mab01
@@ -230,7 +230,7 @@ data:
 
   dynamic.linux-m8xlarge-arm64.type: aws
   dynamic.linux-m8xlarge-arm64.region: us-east-1
-  dynamic.linux-m8xlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-m8xlarge-arm64.ami: ami-06f37afe6d4f43c47
   dynamic.linux-m8xlarge-arm64.instance-type: m6g.8xlarge
   dynamic.linux-m8xlarge-arm64.instance-tag: prod-arm64-m8xlarge
   dynamic.linux-m8xlarge-arm64.key-name: konflux-prod-int-mab01
@@ -243,7 +243,7 @@ data:
 
   dynamic.linux-d160-m8xlarge-arm64.type: aws
   dynamic.linux-d160-m8xlarge-arm64.region: us-east-1
-  dynamic.linux-d160-m8xlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-d160-m8xlarge-arm64.ami: ami-06f37afe6d4f43c47
   dynamic.linux-d160-m8xlarge-arm64.instance-type: m6g.8xlarge
   dynamic.linux-d160-m8xlarge-arm64.instance-tag: prod-arm64-m8xlarge-d160
   dynamic.linux-d160-m8xlarge-arm64.key-name: konflux-prod-int-mab01
@@ -257,7 +257,7 @@ data:
 
   dynamic.linux-amd64.type: aws
   dynamic.linux-amd64.region: us-east-1
-  dynamic.linux-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-amd64.ami: ami-01aaf1c29c7e0f0af
   dynamic.linux-amd64.instance-type: m6a.large
   dynamic.linux-amd64.instance-tag: prod-amd64
   dynamic.linux-amd64.key-name: konflux-prod-int-mab01
@@ -270,7 +270,7 @@ data:
 
   dynamic.linux-mlarge-amd64.type: aws
   dynamic.linux-mlarge-amd64.region: us-east-1
-  dynamic.linux-mlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-mlarge-amd64.ami: ami-01aaf1c29c7e0f0af
   dynamic.linux-mlarge-amd64.instance-type: m6a.large
   dynamic.linux-mlarge-amd64.instance-tag: prod-amd64-mlarge
   dynamic.linux-mlarge-amd64.key-name: konflux-prod-int-mab01
@@ -283,7 +283,7 @@ data:
 
   dynamic.linux-mxlarge-amd64.type: aws
   dynamic.linux-mxlarge-amd64.region: us-east-1
-  dynamic.linux-mxlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-mxlarge-amd64.ami: ami-01aaf1c29c7e0f0af
   dynamic.linux-mxlarge-amd64.instance-type: m6a.xlarge
   dynamic.linux-mxlarge-amd64.instance-tag: prod-amd64-mxlarge
   dynamic.linux-mxlarge-amd64.key-name: konflux-prod-int-mab01
@@ -296,7 +296,7 @@ data:
 
   dynamic.linux-m2xlarge-amd64.type: aws
   dynamic.linux-m2xlarge-amd64.region: us-east-1
-  dynamic.linux-m2xlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-m2xlarge-amd64.ami: ami-01aaf1c29c7e0f0af
   dynamic.linux-m2xlarge-amd64.instance-type: m6a.2xlarge
   dynamic.linux-m2xlarge-amd64.instance-tag: prod-amd64-m2xlarge
   dynamic.linux-m2xlarge-amd64.key-name: konflux-prod-int-mab01
@@ -309,7 +309,7 @@ data:
 
   dynamic.linux-d160-m2xlarge-amd64.type: aws
   dynamic.linux-d160-m2xlarge-amd64.region: us-east-1
-  dynamic.linux-d160-m2xlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-d160-m2xlarge-amd64.ami: ami-01aaf1c29c7e0f0af
   dynamic.linux-d160-m2xlarge-amd64.instance-type: m6a.2xlarge
   dynamic.linux-d160-m2xlarge-amd64.instance-tag: prod-amd64-m2xlarge-d160
   dynamic.linux-d160-m2xlarge-amd64.key-name: konflux-prod-int-mab01
@@ -323,7 +323,7 @@ data:
 
   dynamic.linux-m4xlarge-amd64.type: aws
   dynamic.linux-m4xlarge-amd64.region: us-east-1
-  dynamic.linux-m4xlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-m4xlarge-amd64.ami: ami-01aaf1c29c7e0f0af
   dynamic.linux-m4xlarge-amd64.instance-type: m6a.4xlarge
   dynamic.linux-m4xlarge-amd64.instance-tag: prod-amd64-m4xlarge
   dynamic.linux-m4xlarge-amd64.key-name: konflux-prod-int-mab01
@@ -337,7 +337,7 @@ data:
   # same as m4xlarge-amd64 bug 160G disk
   dynamic.linux-d160-m4xlarge-amd64.type: aws
   dynamic.linux-d160-m4xlarge-amd64.region: us-east-1
-  dynamic.linux-d160-m4xlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-d160-m4xlarge-amd64.ami: ami-01aaf1c29c7e0f0af
   dynamic.linux-d160-m4xlarge-amd64.instance-type: m6a.4xlarge
   dynamic.linux-d160-m4xlarge-amd64.instance-tag: prod-amd64-m4xlarge-d160
   dynamic.linux-d160-m4xlarge-amd64.key-name: konflux-prod-int-mab01
@@ -351,7 +351,7 @@ data:
 
   dynamic.linux-m8xlarge-amd64.type: aws
   dynamic.linux-m8xlarge-amd64.region: us-east-1
-  dynamic.linux-m8xlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-m8xlarge-amd64.ami: ami-01aaf1c29c7e0f0af
   dynamic.linux-m8xlarge-amd64.instance-type: m6a.8xlarge
   dynamic.linux-m8xlarge-amd64.instance-tag: prod-amd64-m8xlarge
   dynamic.linux-m8xlarge-amd64.key-name: konflux-prod-int-mab01
@@ -364,7 +364,7 @@ data:
 
   dynamic.linux-d160-m8xlarge-amd64.type: aws
   dynamic.linux-d160-m8xlarge-amd64.region: us-east-1
-  dynamic.linux-d160-m8xlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-d160-m8xlarge-amd64.ami: ami-01aaf1c29c7e0f0af
   dynamic.linux-d160-m8xlarge-amd64.instance-type: m6a.8xlarge
   dynamic.linux-d160-m8xlarge-amd64.instance-tag: prod-amd64-m8xlarge-d160
   dynamic.linux-d160-m8xlarge-amd64.key-name: konflux-prod-int-mab01
@@ -378,7 +378,7 @@ data:
 
   dynamic.linux-fast-amd64.type: aws
   dynamic.linux-fast-amd64.region: us-east-1
-  dynamic.linux-fast-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-fast-amd64.ami: ami-01aaf1c29c7e0f0af
   dynamic.linux-fast-amd64.instance-type: c7a.8xlarge
   dynamic.linux-fast-amd64.instance-tag: prod-amd64-fast
   dynamic.linux-fast-amd64.key-name: konflux-prod-int-mab01
@@ -391,7 +391,7 @@ data:
 
   dynamic.linux-extra-fast-amd64.type: aws
   dynamic.linux-extra-fast-amd64.region: us-east-1
-  dynamic.linux-extra-fast-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-extra-fast-amd64.ami: ami-01aaf1c29c7e0f0af
   dynamic.linux-extra-fast-amd64.instance-type: c7a.12xlarge
   dynamic.linux-extra-fast-amd64.instance-tag: prod-amd64-extra-fast
   dynamic.linux-extra-fast-amd64.key-name: konflux-prod-int-mab01
@@ -405,7 +405,7 @@ data:
   # cpu:memory (1:2)
   dynamic.linux-cxlarge-arm64.type: aws
   dynamic.linux-cxlarge-arm64.region: us-east-1
-  dynamic.linux-cxlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-cxlarge-arm64.ami: ami-06f37afe6d4f43c47
   dynamic.linux-cxlarge-arm64.instance-type: c6g.xlarge
   dynamic.linux-cxlarge-arm64.instance-tag: prod-arm64-cxlarge
   dynamic.linux-cxlarge-arm64.key-name: konflux-prod-int-mab01
@@ -418,7 +418,7 @@ data:
 
   dynamic.linux-c2xlarge-arm64.type: aws
   dynamic.linux-c2xlarge-arm64.region: us-east-1
-  dynamic.linux-c2xlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-c2xlarge-arm64.ami: ami-06f37afe6d4f43c47
   dynamic.linux-c2xlarge-arm64.instance-type: c6g.2xlarge
   dynamic.linux-c2xlarge-arm64.instance-tag: prod-arm64-c2xlarge
   dynamic.linux-c2xlarge-arm64.key-name: konflux-prod-int-mab01
@@ -431,7 +431,7 @@ data:
 
   dynamic.linux-c4xlarge-arm64.type: aws
   dynamic.linux-c4xlarge-arm64.region: us-east-1
-  dynamic.linux-c4xlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-c4xlarge-arm64.ami: ami-06f37afe6d4f43c47
   dynamic.linux-c4xlarge-arm64.instance-type: c6g.4xlarge
   dynamic.linux-c4xlarge-arm64.instance-tag: prod-arm64-c4xlarge
   dynamic.linux-c4xlarge-arm64.key-name: konflux-prod-int-mab01
@@ -444,7 +444,7 @@ data:
 
   dynamic.linux-c8xlarge-arm64.type: aws
   dynamic.linux-c8xlarge-arm64.region: us-east-1
-  dynamic.linux-c8xlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-c8xlarge-arm64.ami: ami-06f37afe6d4f43c47
   dynamic.linux-c8xlarge-arm64.instance-type: c6g.8xlarge
   dynamic.linux-c8xlarge-arm64.instance-tag: prod-arm64-c8xlarge
   dynamic.linux-c8xlarge-arm64.key-name: konflux-prod-int-mab01
@@ -457,7 +457,7 @@ data:
 
   dynamic.linux-cxlarge-amd64.type: aws
   dynamic.linux-cxlarge-amd64.region: us-east-1
-  dynamic.linux-cxlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-cxlarge-amd64.ami: ami-01aaf1c29c7e0f0af
   dynamic.linux-cxlarge-amd64.instance-type: c6a.xlarge
   dynamic.linux-cxlarge-amd64.instance-tag: prod-amd64-cxlarge
   dynamic.linux-cxlarge-amd64.key-name: konflux-prod-int-mab01
@@ -470,7 +470,7 @@ data:
 
   dynamic.linux-c2xlarge-amd64.type: aws
   dynamic.linux-c2xlarge-amd64.region: us-east-1
-  dynamic.linux-c2xlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-c2xlarge-amd64.ami: ami-01aaf1c29c7e0f0af
   dynamic.linux-c2xlarge-amd64.instance-type: c6a.2xlarge
   dynamic.linux-c2xlarge-amd64.instance-tag: prod-amd64-c2xlarge
   dynamic.linux-c2xlarge-amd64.key-name: konflux-prod-int-mab01
@@ -483,7 +483,7 @@ data:
 
   dynamic.linux-c4xlarge-amd64.type: aws
   dynamic.linux-c4xlarge-amd64.region: us-east-1
-  dynamic.linux-c4xlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-c4xlarge-amd64.ami: ami-01aaf1c29c7e0f0af
   dynamic.linux-c4xlarge-amd64.instance-type: c6a.4xlarge
   dynamic.linux-c4xlarge-amd64.instance-tag: prod-amd64-c4xlarge
   dynamic.linux-c4xlarge-amd64.key-name: konflux-prod-int-mab01
@@ -496,7 +496,7 @@ data:
 
   dynamic.linux-c8xlarge-amd64.type: aws
   dynamic.linux-c8xlarge-amd64.region: us-east-1
-  dynamic.linux-c8xlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-c8xlarge-amd64.ami: ami-01aaf1c29c7e0f0af
   dynamic.linux-c8xlarge-amd64.instance-type: c6a.8xlarge
   dynamic.linux-c8xlarge-amd64.instance-tag: prod-amd64-c8xlarge
   dynamic.linux-c8xlarge-amd64.key-name: konflux-prod-int-mab01
@@ -509,7 +509,7 @@ data:
 
   dynamic.linux-root-arm64.type: aws
   dynamic.linux-root-arm64.region: us-east-1
-  dynamic.linux-root-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-root-arm64.ami: ami-06f37afe6d4f43c47
   dynamic.linux-root-arm64.instance-type: m6g.large
   dynamic.linux-root-arm64.instance-tag: prod-arm64-root
   dynamic.linux-root-arm64.key-name: konflux-prod-int-mab01
@@ -525,7 +525,7 @@ data:
 
   dynamic.linux-root-amd64.type: aws
   dynamic.linux-root-amd64.region: us-east-1
-  dynamic.linux-root-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-root-amd64.ami: ami-01aaf1c29c7e0f0af
   dynamic.linux-root-amd64.instance-type: m6idn.2xlarge
   dynamic.linux-root-amd64.instance-tag: prod-amd64-root
   dynamic.linux-root-amd64.key-name: konflux-prod-int-mab01

--- a/components/multi-platform-controller/production/kflux-prd-rh02/host-config.yaml
+++ b/components/multi-platform-controller/production/kflux-prd-rh02/host-config.yaml
@@ -59,7 +59,7 @@ data:
   # cpu:memory (1:4)
   dynamic.linux-arm64.type: aws
   dynamic.linux-arm64.region: us-east-1
-  dynamic.linux-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-arm64.ami: ami-06f37afe6d4f43c47
   dynamic.linux-arm64.instance-type: m6g.large
   dynamic.linux-arm64.instance-tag: prod-arm64
   dynamic.linux-arm64.key-name: kflux-prd-multi-rh02-key-pair
@@ -71,7 +71,7 @@ data:
 
   dynamic.linux-mlarge-arm64.type: aws
   dynamic.linux-mlarge-arm64.region: us-east-1
-  dynamic.linux-mlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-mlarge-arm64.ami: ami-06f37afe6d4f43c47
   dynamic.linux-mlarge-arm64.instance-type: m6g.large
   dynamic.linux-mlarge-arm64.instance-tag: prod-arm64-mlarge
   dynamic.linux-mlarge-arm64.key-name: kflux-prd-multi-rh02-key-pair
@@ -83,7 +83,7 @@ data:
 
   dynamic.linux-mxlarge-arm64.type: aws
   dynamic.linux-mxlarge-arm64.region: us-east-1
-  dynamic.linux-mxlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-mxlarge-arm64.ami: ami-06f37afe6d4f43c47
   dynamic.linux-mxlarge-arm64.instance-type: m6g.xlarge
   dynamic.linux-mxlarge-arm64.instance-tag: prod-arm64-mxlarge
   dynamic.linux-mxlarge-arm64.key-name: kflux-prd-multi-rh02-key-pair
@@ -95,7 +95,7 @@ data:
 
   dynamic.linux-m2xlarge-arm64.type: aws
   dynamic.linux-m2xlarge-arm64.region: us-east-1
-  dynamic.linux-m2xlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-m2xlarge-arm64.ami: ami-06f37afe6d4f43c47
   dynamic.linux-m2xlarge-arm64.instance-type: m6g.2xlarge
   dynamic.linux-m2xlarge-arm64.instance-tag: prod-arm64-m2xlarge
   dynamic.linux-m2xlarge-arm64.key-name: kflux-prd-multi-rh02-key-pair
@@ -107,7 +107,7 @@ data:
 
   dynamic.linux-d160-m2xlarge-arm64.type: aws
   dynamic.linux-d160-m2xlarge-arm64.region: us-east-1
-  dynamic.linux-d160-m2xlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-d160-m2xlarge-arm64.ami: ami-06f37afe6d4f43c47
   dynamic.linux-d160-m2xlarge-arm64.instance-type: m6g.2xlarge
   dynamic.linux-d160-m2xlarge-arm64.instance-tag: prod-arm64-m2xlarge-d160
   dynamic.linux-d160-m2xlarge-arm64.key-name: kflux-prd-multi-rh02-key-pair
@@ -120,7 +120,7 @@ data:
 
   dynamic.linux-m4xlarge-arm64.type: aws
   dynamic.linux-m4xlarge-arm64.region: us-east-1
-  dynamic.linux-m4xlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-m4xlarge-arm64.ami: ami-06f37afe6d4f43c47
   dynamic.linux-m4xlarge-arm64.instance-type: m6g.4xlarge
   dynamic.linux-m4xlarge-arm64.instance-tag: prod-arm64-m4xlarge
   dynamic.linux-m4xlarge-arm64.key-name: kflux-prd-multi-rh02-key-pair
@@ -132,7 +132,7 @@ data:
 
   dynamic.linux-d160-m4xlarge-arm64.type: aws
   dynamic.linux-d160-m4xlarge-arm64.region: us-east-1
-  dynamic.linux-d160-m4xlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-d160-m4xlarge-arm64.ami: ami-06f37afe6d4f43c47
   dynamic.linux-d160-m4xlarge-arm64.instance-type: m6g.4xlarge
   dynamic.linux-d160-m4xlarge-arm64.instance-tag: prod-arm64-m4xlarge-d160
   dynamic.linux-d160-m4xlarge-arm64.key-name: kflux-prd-multi-rh02-key-pair
@@ -145,7 +145,7 @@ data:
 
   dynamic.linux-m8xlarge-arm64.type: aws
   dynamic.linux-m8xlarge-arm64.region: us-east-1
-  dynamic.linux-m8xlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-m8xlarge-arm64.ami: ami-06f37afe6d4f43c47
   dynamic.linux-m8xlarge-arm64.instance-type: m6g.8xlarge
   dynamic.linux-m8xlarge-arm64.instance-tag: prod-arm64-m8xlarge
   dynamic.linux-m8xlarge-arm64.key-name: kflux-prd-multi-rh02-key-pair
@@ -157,7 +157,7 @@ data:
 
   dynamic.linux-d160-m8xlarge-arm64.type: aws
   dynamic.linux-d160-m8xlarge-arm64.region: us-east-1
-  dynamic.linux-d160-m8xlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-d160-m8xlarge-arm64.ami: ami-06f37afe6d4f43c47
   dynamic.linux-d160-m8xlarge-arm64.instance-type: m6g.8xlarge
   dynamic.linux-d160-m8xlarge-arm64.instance-tag: prod-arm64-m8xlarge-d160
   dynamic.linux-d160-m8xlarge-arm64.key-name: kflux-prd-multi-rh02-key-pair
@@ -170,7 +170,7 @@ data:
 
   dynamic.linux-c6gd2xlarge-arm64.type: aws
   dynamic.linux-c6gd2xlarge-arm64.region: us-east-1
-  dynamic.linux-c6gd2xlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-c6gd2xlarge-arm64.ami: ami-06f37afe6d4f43c47
   dynamic.linux-c6gd2xlarge-arm64.instance-type: c6gd.2xlarge
   dynamic.linux-c6gd2xlarge-arm64.instance-tag: prod-arm64-c6gd2xlarge
   dynamic.linux-c6gd2xlarge-arm64.key-name: kflux-prd-multi-rh02-key-pair
@@ -246,7 +246,7 @@ data:
 
   dynamic.linux-amd64.type: aws
   dynamic.linux-amd64.region: us-east-1
-  dynamic.linux-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-amd64.ami: ami-01aaf1c29c7e0f0af
   dynamic.linux-amd64.instance-type: m6a.large
   dynamic.linux-amd64.instance-tag: prod-amd64
   dynamic.linux-amd64.key-name: kflux-prd-multi-rh02-key-pair
@@ -258,7 +258,7 @@ data:
 
   dynamic.linux-mlarge-amd64.type: aws
   dynamic.linux-mlarge-amd64.region: us-east-1
-  dynamic.linux-mlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-mlarge-amd64.ami: ami-01aaf1c29c7e0f0af
   dynamic.linux-mlarge-amd64.instance-type: m6a.large
   dynamic.linux-mlarge-amd64.instance-tag: prod-amd64-mlarge
   dynamic.linux-mlarge-amd64.key-name: kflux-prd-multi-rh02-key-pair
@@ -270,7 +270,7 @@ data:
 
   dynamic.linux-mxlarge-amd64.type: aws
   dynamic.linux-mxlarge-amd64.region: us-east-1
-  dynamic.linux-mxlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-mxlarge-amd64.ami: ami-01aaf1c29c7e0f0af
   dynamic.linux-mxlarge-amd64.instance-type: m6a.xlarge
   dynamic.linux-mxlarge-amd64.instance-tag: prod-amd64-mxlarge
   dynamic.linux-mxlarge-amd64.key-name: kflux-prd-multi-rh02-key-pair
@@ -282,7 +282,7 @@ data:
 
   dynamic.linux-m2xlarge-amd64.type: aws
   dynamic.linux-m2xlarge-amd64.region: us-east-1
-  dynamic.linux-m2xlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-m2xlarge-amd64.ami: ami-01aaf1c29c7e0f0af
   dynamic.linux-m2xlarge-amd64.instance-type: m6a.2xlarge
   dynamic.linux-m2xlarge-amd64.instance-tag: prod-amd64-m2xlarge
   dynamic.linux-m2xlarge-amd64.key-name: kflux-prd-multi-rh02-key-pair
@@ -294,7 +294,7 @@ data:
 
   dynamic.linux-d160-m2xlarge-amd64.type: aws
   dynamic.linux-d160-m2xlarge-amd64.region: us-east-1
-  dynamic.linux-d160-m2xlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-d160-m2xlarge-amd64.ami: ami-01aaf1c29c7e0f0af
   dynamic.linux-d160-m2xlarge-amd64.instance-type: m6a.2xlarge
   dynamic.linux-d160-m2xlarge-amd64.instance-tag: prod-amd64-m2xlarge-d160
   dynamic.linux-d160-m2xlarge-amd64.key-name: kflux-prd-multi-rh02-key-pair
@@ -307,7 +307,7 @@ data:
 
   dynamic.linux-m4xlarge-amd64.type: aws
   dynamic.linux-m4xlarge-amd64.region: us-east-1
-  dynamic.linux-m4xlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-m4xlarge-amd64.ami: ami-01aaf1c29c7e0f0af
   dynamic.linux-m4xlarge-amd64.instance-type: m6a.4xlarge
   dynamic.linux-m4xlarge-amd64.instance-tag: prod-amd64-m4xlarge
   dynamic.linux-m4xlarge-amd64.key-name: kflux-prd-multi-rh02-key-pair
@@ -319,7 +319,7 @@ data:
 
   dynamic.linux-d160-m4xlarge-amd64.type: aws
   dynamic.linux-d160-m4xlarge-amd64.region: us-east-1
-  dynamic.linux-d160-m4xlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-d160-m4xlarge-amd64.ami: ami-01aaf1c29c7e0f0af
   dynamic.linux-d160-m4xlarge-amd64.instance-type: m6a.4xlarge
   dynamic.linux-d160-m4xlarge-amd64.instance-tag: prod-amd64-m4xlarge-d160
   dynamic.linux-d160-m4xlarge-amd64.key-name: kflux-prd-multi-rh02-key-pair
@@ -332,7 +332,7 @@ data:
 
   dynamic.linux-m8xlarge-amd64.type: aws
   dynamic.linux-m8xlarge-amd64.region: us-east-1
-  dynamic.linux-m8xlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-m8xlarge-amd64.ami: ami-01aaf1c29c7e0f0af
   dynamic.linux-m8xlarge-amd64.instance-type: m6a.8xlarge
   dynamic.linux-m8xlarge-amd64.instance-tag: prod-amd64-m8xlarge
   dynamic.linux-m8xlarge-amd64.key-name: kflux-prd-multi-rh02-key-pair
@@ -344,7 +344,7 @@ data:
 
   dynamic.linux-d160-m8xlarge-amd64.type: aws
   dynamic.linux-d160-m8xlarge-amd64.region: us-east-1
-  dynamic.linux-d160-m8xlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-d160-m8xlarge-amd64.ami: ami-01aaf1c29c7e0f0af
   dynamic.linux-d160-m8xlarge-amd64.instance-type: m6a.8xlarge
   dynamic.linux-d160-m8xlarge-amd64.instance-tag: prod-amd64-m8xlarge-d160
   dynamic.linux-d160-m8xlarge-amd64.key-name: kflux-prd-multi-rh02-key-pair
@@ -358,7 +358,7 @@ data:
   # cpu:memory (1:2)
   dynamic.linux-cxlarge-arm64.type: aws
   dynamic.linux-cxlarge-arm64.region: us-east-1
-  dynamic.linux-cxlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-cxlarge-arm64.ami: ami-06f37afe6d4f43c47
   dynamic.linux-cxlarge-arm64.instance-type: c6g.xlarge
   dynamic.linux-cxlarge-arm64.instance-tag: prod-arm64-cxlarge
   dynamic.linux-cxlarge-arm64.key-name: kflux-prd-multi-rh02-key-pair
@@ -370,7 +370,7 @@ data:
 
   dynamic.linux-c2xlarge-arm64.type: aws
   dynamic.linux-c2xlarge-arm64.region: us-east-1
-  dynamic.linux-c2xlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-c2xlarge-arm64.ami: ami-06f37afe6d4f43c47
   dynamic.linux-c2xlarge-arm64.instance-type: c6g.2xlarge
   dynamic.linux-c2xlarge-arm64.instance-tag: prod-arm64-c2xlarge
   dynamic.linux-c2xlarge-arm64.key-name: kflux-prd-multi-rh02-key-pair
@@ -382,7 +382,7 @@ data:
 
   dynamic.linux-c4xlarge-arm64.type: aws
   dynamic.linux-c4xlarge-arm64.region: us-east-1
-  dynamic.linux-c4xlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-c4xlarge-arm64.ami: ami-06f37afe6d4f43c47
   dynamic.linux-c4xlarge-arm64.instance-type: c6g.4xlarge
   dynamic.linux-c4xlarge-arm64.instance-tag: prod-arm64-c4xlarge
   dynamic.linux-c4xlarge-arm64.key-name: kflux-prd-multi-rh02-key-pair
@@ -394,7 +394,7 @@ data:
 
   dynamic.linux-c8xlarge-arm64.type: aws
   dynamic.linux-c8xlarge-arm64.region: us-east-1
-  dynamic.linux-c8xlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-c8xlarge-arm64.ami: ami-06f37afe6d4f43c47
   dynamic.linux-c8xlarge-arm64.instance-type: c6g.8xlarge
   dynamic.linux-c8xlarge-arm64.instance-tag: prod-arm64-c8xlarge
   dynamic.linux-c8xlarge-arm64.key-name: kflux-prd-multi-rh02-key-pair
@@ -406,7 +406,7 @@ data:
 
   dynamic.linux-cxlarge-amd64.type: aws
   dynamic.linux-cxlarge-amd64.region: us-east-1
-  dynamic.linux-cxlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-cxlarge-amd64.ami: ami-01aaf1c29c7e0f0af
   dynamic.linux-cxlarge-amd64.instance-type: c6a.xlarge
   dynamic.linux-cxlarge-amd64.instance-tag: prod-amd64-cxlarge
   dynamic.linux-cxlarge-amd64.key-name: kflux-prd-multi-rh02-key-pair
@@ -418,7 +418,7 @@ data:
 
   dynamic.linux-c2xlarge-amd64.type: aws
   dynamic.linux-c2xlarge-amd64.region: us-east-1
-  dynamic.linux-c2xlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-c2xlarge-amd64.ami: ami-01aaf1c29c7e0f0af
   dynamic.linux-c2xlarge-amd64.instance-type: c6a.2xlarge
   dynamic.linux-c2xlarge-amd64.instance-tag: prod-amd64-c2xlarge
   dynamic.linux-c2xlarge-amd64.key-name: kflux-prd-multi-rh02-key-pair
@@ -430,7 +430,7 @@ data:
 
   dynamic.linux-c4xlarge-amd64.type: aws
   dynamic.linux-c4xlarge-amd64.region: us-east-1
-  dynamic.linux-c4xlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-c4xlarge-amd64.ami: ami-01aaf1c29c7e0f0af
   dynamic.linux-c4xlarge-amd64.instance-type: c6a.4xlarge
   dynamic.linux-c4xlarge-amd64.instance-tag: prod-amd64-c4xlarge
   dynamic.linux-c4xlarge-amd64.key-name: kflux-prd-multi-rh02-key-pair
@@ -442,7 +442,7 @@ data:
 
   dynamic.linux-c8xlarge-amd64.type: aws
   dynamic.linux-c8xlarge-amd64.region: us-east-1
-  dynamic.linux-c8xlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-c8xlarge-amd64.ami: ami-01aaf1c29c7e0f0af
   dynamic.linux-c8xlarge-amd64.instance-type: c6a.8xlarge
   dynamic.linux-c8xlarge-amd64.instance-tag: prod-amd64-c8xlarge
   dynamic.linux-c8xlarge-amd64.key-name: kflux-prd-multi-rh02-key-pair
@@ -454,7 +454,7 @@ data:
 
   dynamic.linux-root-arm64.type: aws
   dynamic.linux-root-arm64.region: us-east-1
-  dynamic.linux-root-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-root-arm64.ami: ami-06f37afe6d4f43c47
   dynamic.linux-root-arm64.instance-type: m6g.large
   dynamic.linux-root-arm64.instance-tag: prod-arm64-root
   dynamic.linux-root-arm64.key-name: kflux-prd-multi-rh02-key-pair
@@ -471,7 +471,7 @@ data:
 
   dynamic.linux-fast-amd64.type: aws
   dynamic.linux-fast-amd64.region: us-east-1
-  dynamic.linux-fast-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-fast-amd64.ami: ami-01aaf1c29c7e0f0af
   dynamic.linux-fast-amd64.instance-type: c7a.8xlarge
   dynamic.linux-fast-amd64.instance-tag: prod-amd64-fast
   dynamic.linux-fast-amd64.key-name: kflux-prd-multi-rh02-key-pair
@@ -486,7 +486,7 @@ data:
 
   dynamic.linux-extra-fast-amd64.type: aws
   dynamic.linux-extra-fast-amd64.region: us-east-1
-  dynamic.linux-extra-fast-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-extra-fast-amd64.ami: ami-01aaf1c29c7e0f0af
   dynamic.linux-extra-fast-amd64.instance-type: c7a.12xlarge
   dynamic.linux-extra-fast-amd64.instance-tag: prod-amd64-extra-fast
   dynamic.linux-extra-fast-amd64.key-name: kflux-prd-multi-rh02-key-pair
@@ -501,7 +501,7 @@ data:
 
   dynamic.linux-root-amd64.type: aws
   dynamic.linux-root-amd64.region: us-east-1
-  dynamic.linux-root-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-root-amd64.ami: ami-01aaf1c29c7e0f0af
   dynamic.linux-root-amd64.instance-type: m6idn.2xlarge
   dynamic.linux-root-amd64.instance-tag: prod-amd64-root
   dynamic.linux-root-amd64.key-name: kflux-prd-multi-rh02-key-pair

--- a/components/multi-platform-controller/production/kflux-prd-rh03/host-config.yaml
+++ b/components/multi-platform-controller/production/kflux-prd-rh03/host-config.yaml
@@ -59,7 +59,7 @@ data:
   # cpu:memory (1:4)
   dynamic.linux-arm64.type: aws
   dynamic.linux-arm64.region: us-east-1
-  dynamic.linux-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-arm64.ami: ami-06f37afe6d4f43c47
   dynamic.linux-arm64.instance-type: m6g.large
   dynamic.linux-arm64.instance-tag: prod-arm64
   dynamic.linux-arm64.key-name: kflux-prd-rh03-key-pair
@@ -71,7 +71,7 @@ data:
 
   dynamic.linux-mlarge-arm64.type: aws
   dynamic.linux-mlarge-arm64.region: us-east-1
-  dynamic.linux-mlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-mlarge-arm64.ami: ami-06f37afe6d4f43c47
   dynamic.linux-mlarge-arm64.instance-type: m6g.large
   dynamic.linux-mlarge-arm64.instance-tag: prod-arm64-mlarge
   dynamic.linux-mlarge-arm64.key-name: kflux-prd-rh03-key-pair
@@ -83,7 +83,7 @@ data:
 
   dynamic.linux-mxlarge-arm64.type: aws
   dynamic.linux-mxlarge-arm64.region: us-east-1
-  dynamic.linux-mxlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-mxlarge-arm64.ami: ami-06f37afe6d4f43c47
   dynamic.linux-mxlarge-arm64.instance-type: m6g.xlarge
   dynamic.linux-mxlarge-arm64.instance-tag: prod-arm64-mxlarge
   dynamic.linux-mxlarge-arm64.key-name: kflux-prd-rh03-key-pair
@@ -95,7 +95,7 @@ data:
 
   dynamic.linux-m2xlarge-arm64.type: aws
   dynamic.linux-m2xlarge-arm64.region: us-east-1
-  dynamic.linux-m2xlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-m2xlarge-arm64.ami: ami-06f37afe6d4f43c47
   dynamic.linux-m2xlarge-arm64.instance-type: m6g.2xlarge
   dynamic.linux-m2xlarge-arm64.instance-tag: prod-arm64-m2xlarge
   dynamic.linux-m2xlarge-arm64.key-name: kflux-prd-rh03-key-pair
@@ -107,7 +107,7 @@ data:
 
   dynamic.linux-d160-m2xlarge-arm64.type: aws
   dynamic.linux-d160-m2xlarge-arm64.region: us-east-1
-  dynamic.linux-d160-m2xlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-d160-m2xlarge-arm64.ami: ami-06f37afe6d4f43c47
   dynamic.linux-d160-m2xlarge-arm64.instance-type: m6g.2xlarge
   dynamic.linux-d160-m2xlarge-arm64.instance-tag: prod-arm64-m2xlarge-d160
   dynamic.linux-d160-m2xlarge-arm64.key-name: kflux-prd-rh03-key-pair
@@ -120,7 +120,7 @@ data:
 
   dynamic.linux-m4xlarge-arm64.type: aws
   dynamic.linux-m4xlarge-arm64.region: us-east-1
-  dynamic.linux-m4xlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-m4xlarge-arm64.ami: ami-06f37afe6d4f43c47
   dynamic.linux-m4xlarge-arm64.instance-type: m6g.4xlarge
   dynamic.linux-m4xlarge-arm64.instance-tag: prod-arm64-m4xlarge
   dynamic.linux-m4xlarge-arm64.key-name: kflux-prd-rh03-key-pair
@@ -132,7 +132,7 @@ data:
 
   dynamic.linux-m8xlarge-arm64.type: aws
   dynamic.linux-m8xlarge-arm64.region: us-east-1
-  dynamic.linux-m8xlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-m8xlarge-arm64.ami: ami-06f37afe6d4f43c47
   dynamic.linux-m8xlarge-arm64.instance-type: m6g.8xlarge
   dynamic.linux-m8xlarge-arm64.instance-tag: prod-arm64-m8xlarge
   dynamic.linux-m8xlarge-arm64.key-name: kflux-prd-rh03-key-pair
@@ -144,7 +144,7 @@ data:
 
   dynamic.linux-d160-m8-8xlarge-arm64.type: aws
   dynamic.linux-d160-m8-8xlarge-arm64.region: us-east-1
-  dynamic.linux-d160-m8-8xlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-d160-m8-8xlarge-arm64.ami: ami-06f37afe6d4f43c47
   dynamic.linux-d160-m8-8xlarge-arm64.instance-type: m8g.8xlarge
   dynamic.linux-d160-m8-8xlarge-arm64.instance-tag: prod-arm64-m8-8xlarge-d160
   dynamic.linux-d160-m8-8xlarge-arm64.key-name: kflux-prd-rh03-key-pair
@@ -157,7 +157,7 @@ data:
 
   dynamic.linux-c6gd2xlarge-arm64.type: aws
   dynamic.linux-c6gd2xlarge-arm64.region: us-east-1
-  dynamic.linux-c6gd2xlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-c6gd2xlarge-arm64.ami: ami-06f37afe6d4f43c47
   dynamic.linux-c6gd2xlarge-arm64.instance-type: c6gd.2xlarge
   dynamic.linux-c6gd2xlarge-arm64.instance-tag: prod-arm64-c6gd2xlarge
   dynamic.linux-c6gd2xlarge-arm64.key-name: kflux-prd-rh03-key-pair
@@ -233,7 +233,7 @@ data:
 
   dynamic.linux-amd64.type: aws
   dynamic.linux-amd64.region: us-east-1
-  dynamic.linux-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-amd64.ami: ami-01aaf1c29c7e0f0af
   dynamic.linux-amd64.instance-type: m6a.large
   dynamic.linux-amd64.instance-tag: prod-amd64
   dynamic.linux-amd64.key-name: kflux-prd-rh03-key-pair
@@ -245,7 +245,7 @@ data:
 
   dynamic.linux-mlarge-amd64.type: aws
   dynamic.linux-mlarge-amd64.region: us-east-1
-  dynamic.linux-mlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-mlarge-amd64.ami: ami-01aaf1c29c7e0f0af
   dynamic.linux-mlarge-amd64.instance-type: m6a.large
   dynamic.linux-mlarge-amd64.instance-tag: prod-amd64-mlarge
   dynamic.linux-mlarge-amd64.key-name: kflux-prd-rh03-key-pair
@@ -257,7 +257,7 @@ data:
 
   dynamic.linux-mxlarge-amd64.type: aws
   dynamic.linux-mxlarge-amd64.region: us-east-1
-  dynamic.linux-mxlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-mxlarge-amd64.ami: ami-01aaf1c29c7e0f0af
   dynamic.linux-mxlarge-amd64.instance-type: m6a.xlarge
   dynamic.linux-mxlarge-amd64.instance-tag: prod-amd64-mxlarge
   dynamic.linux-mxlarge-amd64.key-name: kflux-prd-rh03-key-pair
@@ -269,7 +269,7 @@ data:
 
   dynamic.linux-m2xlarge-amd64.type: aws
   dynamic.linux-m2xlarge-amd64.region: us-east-1
-  dynamic.linux-m2xlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-m2xlarge-amd64.ami: ami-01aaf1c29c7e0f0af
   dynamic.linux-m2xlarge-amd64.instance-type: m6a.2xlarge
   dynamic.linux-m2xlarge-amd64.instance-tag: prod-amd64-m2xlarge
   dynamic.linux-m2xlarge-amd64.key-name: kflux-prd-rh03-key-pair
@@ -281,7 +281,7 @@ data:
 
   dynamic.linux-d160-m2xlarge-amd64.type: aws
   dynamic.linux-d160-m2xlarge-amd64.region: us-east-1
-  dynamic.linux-d160-m2xlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-d160-m2xlarge-amd64.ami: ami-01aaf1c29c7e0f0af
   dynamic.linux-d160-m2xlarge-amd64.instance-type: m6a.2xlarge
   dynamic.linux-d160-m2xlarge-amd64.instance-tag: prod-amd64-m2xlarge-d160
   dynamic.linux-d160-m2xlarge-amd64.key-name: kflux-prd-rh03-key-pair
@@ -294,7 +294,7 @@ data:
 
   dynamic.linux-m4xlarge-amd64.type: aws
   dynamic.linux-m4xlarge-amd64.region: us-east-1
-  dynamic.linux-m4xlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-m4xlarge-amd64.ami: ami-01aaf1c29c7e0f0af
   dynamic.linux-m4xlarge-amd64.instance-type: m6a.4xlarge
   dynamic.linux-m4xlarge-amd64.instance-tag: prod-amd64-m4xlarge
   dynamic.linux-m4xlarge-amd64.key-name: kflux-prd-rh03-key-pair
@@ -306,7 +306,7 @@ data:
 
   dynamic.linux-m8xlarge-amd64.type: aws
   dynamic.linux-m8xlarge-amd64.region: us-east-1
-  dynamic.linux-m8xlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-m8xlarge-amd64.ami: ami-01aaf1c29c7e0f0af
   dynamic.linux-m8xlarge-amd64.instance-type: m6a.8xlarge
   dynamic.linux-m8xlarge-amd64.instance-tag: prod-amd64-m8xlarge
   dynamic.linux-m8xlarge-amd64.key-name: kflux-prd-rh03-key-pair
@@ -318,7 +318,7 @@ data:
 
   dynamic.linux-d160-m7-8xlarge-amd64.type: aws
   dynamic.linux-d160-m7-8xlarge-amd64.region: us-east-1
-  dynamic.linux-d160-m7-8xlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-d160-m7-8xlarge-amd64.ami: ami-01aaf1c29c7e0f0af
   dynamic.linux-d160-m7-8xlarge-amd64.instance-type: m7a.8xlarge
   dynamic.linux-d160-m7-8xlarge-amd64.instance-tag: prod-amd64-m7-8xlarge-d160
   dynamic.linux-d160-m7-8xlarge-amd64.key-name: kflux-prd-rh03-key-pair
@@ -332,7 +332,7 @@ data:
   # cpu:memory (1:2)
   dynamic.linux-cxlarge-arm64.type: aws
   dynamic.linux-cxlarge-arm64.region: us-east-1
-  dynamic.linux-cxlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-cxlarge-arm64.ami: ami-06f37afe6d4f43c47
   dynamic.linux-cxlarge-arm64.instance-type: c6g.xlarge
   dynamic.linux-cxlarge-arm64.instance-tag: prod-arm64-cxlarge
   dynamic.linux-cxlarge-arm64.key-name: kflux-prd-rh03-key-pair
@@ -344,7 +344,7 @@ data:
 
   dynamic.linux-c2xlarge-arm64.type: aws
   dynamic.linux-c2xlarge-arm64.region: us-east-1
-  dynamic.linux-c2xlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-c2xlarge-arm64.ami: ami-06f37afe6d4f43c47
   dynamic.linux-c2xlarge-arm64.instance-type: c6g.2xlarge
   dynamic.linux-c2xlarge-arm64.instance-tag: prod-arm64-c2xlarge
   dynamic.linux-c2xlarge-arm64.key-name: kflux-prd-rh03-key-pair
@@ -356,7 +356,7 @@ data:
 
   dynamic.linux-c4xlarge-arm64.type: aws
   dynamic.linux-c4xlarge-arm64.region: us-east-1
-  dynamic.linux-c4xlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-c4xlarge-arm64.ami: ami-06f37afe6d4f43c47
   dynamic.linux-c4xlarge-arm64.instance-type: c6g.4xlarge
   dynamic.linux-c4xlarge-arm64.instance-tag: prod-arm64-c4xlarge
   dynamic.linux-c4xlarge-arm64.key-name: kflux-prd-rh03-key-pair
@@ -368,7 +368,7 @@ data:
 
   dynamic.linux-c8xlarge-arm64.type: aws
   dynamic.linux-c8xlarge-arm64.region: us-east-1
-  dynamic.linux-c8xlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-c8xlarge-arm64.ami: ami-06f37afe6d4f43c47
   dynamic.linux-c8xlarge-arm64.instance-type: c6g.8xlarge
   dynamic.linux-c8xlarge-arm64.instance-tag: prod-arm64-c8xlarge
   dynamic.linux-c8xlarge-arm64.key-name: kflux-prd-rh03-key-pair
@@ -380,7 +380,7 @@ data:
 
   dynamic.linux-d160-c8xlarge-arm64.type: aws
   dynamic.linux-d160-c8xlarge-arm64.region: us-east-1
-  dynamic.linux-d160-c8xlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-d160-c8xlarge-arm64.ami: ami-06f37afe6d4f43c47
   dynamic.linux-d160-c8xlarge-arm64.instance-type: c6g.8xlarge
   dynamic.linux-d160-c8xlarge-arm64.instance-tag: prod-arm64-c8xlarge-d160
   dynamic.linux-d160-c8xlarge-arm64.key-name: kflux-prd-rh03-key-pair
@@ -393,7 +393,7 @@ data:
 
   dynamic.linux-cxlarge-amd64.type: aws
   dynamic.linux-cxlarge-amd64.region: us-east-1
-  dynamic.linux-cxlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-cxlarge-amd64.ami: ami-01aaf1c29c7e0f0af
   dynamic.linux-cxlarge-amd64.instance-type: c6a.xlarge
   dynamic.linux-cxlarge-amd64.instance-tag: prod-amd64-cxlarge
   dynamic.linux-cxlarge-amd64.key-name: kflux-prd-rh03-key-pair
@@ -405,7 +405,7 @@ data:
 
   dynamic.linux-c2xlarge-amd64.type: aws
   dynamic.linux-c2xlarge-amd64.region: us-east-1
-  dynamic.linux-c2xlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-c2xlarge-amd64.ami: ami-01aaf1c29c7e0f0af
   dynamic.linux-c2xlarge-amd64.instance-type: c6a.2xlarge
   dynamic.linux-c2xlarge-amd64.instance-tag: prod-amd64-c2xlarge
   dynamic.linux-c2xlarge-amd64.key-name: kflux-prd-rh03-key-pair
@@ -417,7 +417,7 @@ data:
 
   dynamic.linux-c4xlarge-amd64.type: aws
   dynamic.linux-c4xlarge-amd64.region: us-east-1
-  dynamic.linux-c4xlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-c4xlarge-amd64.ami: ami-01aaf1c29c7e0f0af
   dynamic.linux-c4xlarge-amd64.instance-type: c6a.4xlarge
   dynamic.linux-c4xlarge-amd64.instance-tag: prod-amd64-c4xlarge
   dynamic.linux-c4xlarge-amd64.key-name: kflux-prd-rh03-key-pair
@@ -429,7 +429,7 @@ data:
 
   dynamic.linux-c8xlarge-amd64.type: aws
   dynamic.linux-c8xlarge-amd64.region: us-east-1
-  dynamic.linux-c8xlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-c8xlarge-amd64.ami: ami-01aaf1c29c7e0f0af
   dynamic.linux-c8xlarge-amd64.instance-type: c6a.8xlarge
   dynamic.linux-c8xlarge-amd64.instance-tag: prod-amd64-c8xlarge
   dynamic.linux-c8xlarge-amd64.key-name: kflux-prd-rh03-key-pair
@@ -441,7 +441,7 @@ data:
 
   dynamic.linux-d160-c8xlarge-amd64.type: aws
   dynamic.linux-d160-c8xlarge-amd64.region: us-east-1
-  dynamic.linux-d160-c8xlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-d160-c8xlarge-amd64.ami: ami-01aaf1c29c7e0f0af
   dynamic.linux-d160-c8xlarge-amd64.instance-type: c6a.8xlarge
   dynamic.linux-d160-c8xlarge-amd64.instance-tag: prod-amd64-c8xlarge-d160
   dynamic.linux-d160-c8xlarge-amd64.key-name: kflux-prd-rh03-key-pair
@@ -454,7 +454,7 @@ data:
 
   dynamic.linux-root-arm64.type: aws
   dynamic.linux-root-arm64.region: us-east-1
-  dynamic.linux-root-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-root-arm64.ami: ami-06f37afe6d4f43c47
   dynamic.linux-root-arm64.instance-type: m6g.large
   dynamic.linux-root-arm64.instance-tag: prod-arm64-root
   dynamic.linux-root-arm64.key-name: kflux-prd-rh03-key-pair
@@ -471,7 +471,7 @@ data:
 
   dynamic.linux-fast-amd64.type: aws
   dynamic.linux-fast-amd64.region: us-east-1
-  dynamic.linux-fast-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-fast-amd64.ami: ami-01aaf1c29c7e0f0af
   dynamic.linux-fast-amd64.instance-type: c7a.8xlarge
   dynamic.linux-fast-amd64.instance-tag: prod-amd64-fast
   dynamic.linux-fast-amd64.key-name: kflux-prd-rh03-key-pair
@@ -486,7 +486,7 @@ data:
 
   dynamic.linux-extra-fast-amd64.type: aws
   dynamic.linux-extra-fast-amd64.region: us-east-1
-  dynamic.linux-extra-fast-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-extra-fast-amd64.ami: ami-01aaf1c29c7e0f0af
   dynamic.linux-extra-fast-amd64.instance-type: c7a.12xlarge
   dynamic.linux-extra-fast-amd64.instance-tag: prod-amd64-extra-fast
   dynamic.linux-extra-fast-amd64.key-name: kflux-prd-rh03-key-pair
@@ -501,7 +501,7 @@ data:
 
   dynamic.linux-root-amd64.type: aws
   dynamic.linux-root-amd64.region: us-east-1
-  dynamic.linux-root-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-root-amd64.ami: ami-01aaf1c29c7e0f0af
   dynamic.linux-root-amd64.instance-type: m6idn.2xlarge
   dynamic.linux-root-amd64.instance-tag: prod-amd64-root
   dynamic.linux-root-amd64.key-name: kflux-prd-rh03-key-pair

--- a/hack/new-cluster/templates/multi-platform-controller/host-config.yaml
+++ b/hack/new-cluster/templates/multi-platform-controller/host-config.yaml
@@ -64,7 +64,7 @@ data:
   # cpu:memory (1:4)
   dynamic.linux-arm64.type: aws
   dynamic.linux-arm64.region: us-east-1
-  dynamic.linux-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-arm64.ami: ami-06f37afe6d4f43c47
   dynamic.linux-arm64.instance-type: m6g.large
   dynamic.linux-arm64.instance-tag: {{cuteenv}}-arm64
   dynamic.linux-arm64.key-name: kflux-{{cutestenv}}-multi-{{ cutename }}-key-pair
@@ -76,7 +76,7 @@ data:
 
   dynamic.linux-mlarge-arm64.type: aws
   dynamic.linux-mlarge-arm64.region: us-east-1
-  dynamic.linux-mlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-mlarge-arm64.ami: ami-06f37afe6d4f43c47
   dynamic.linux-mlarge-arm64.instance-type: m6g.large
   dynamic.linux-mlarge-arm64.instance-tag: {{cuteenv}}-arm64-mlarge
   dynamic.linux-mlarge-arm64.key-name: kflux-{{cutestenv}}-multi-{{ cutename }}-key-pair
@@ -88,7 +88,7 @@ data:
 
   dynamic.linux-mxlarge-arm64.type: aws
   dynamic.linux-mxlarge-arm64.region: us-east-1
-  dynamic.linux-mxlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-mxlarge-arm64.ami: ami-06f37afe6d4f43c47
   dynamic.linux-mxlarge-arm64.instance-type: m6g.xlarge
   dynamic.linux-mxlarge-arm64.instance-tag: {{cuteenv}}-arm64-mxlarge
   dynamic.linux-mxlarge-arm64.key-name: kflux-{{cutestenv}}-multi-{{ cutename }}-key-pair
@@ -100,7 +100,7 @@ data:
 
   dynamic.linux-m2xlarge-arm64.type: aws
   dynamic.linux-m2xlarge-arm64.region: us-east-1
-  dynamic.linux-m2xlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-m2xlarge-arm64.ami: ami-06f37afe6d4f43c47
   dynamic.linux-m2xlarge-arm64.instance-type: m6g.2xlarge
   dynamic.linux-m2xlarge-arm64.instance-tag: {{cuteenv}}-arm64-m2xlarge
   dynamic.linux-m2xlarge-arm64.key-name: kflux-{{cutestenv}}-multi-{{ cutename }}-key-pair
@@ -112,7 +112,7 @@ data:
 
   dynamic.linux-m4xlarge-arm64.type: aws
   dynamic.linux-m4xlarge-arm64.region: us-east-1
-  dynamic.linux-m4xlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-m4xlarge-arm64.ami: ami-06f37afe6d4f43c47
   dynamic.linux-m4xlarge-arm64.instance-type: m6g.4xlarge
   dynamic.linux-m4xlarge-arm64.instance-tag: {{cuteenv}}-arm64-m4xlarge
   dynamic.linux-m4xlarge-arm64.key-name: kflux-{{cutestenv}}-multi-{{ cutename }}-key-pair
@@ -124,7 +124,7 @@ data:
 
   dynamic.linux-m8xlarge-arm64.type: aws
   dynamic.linux-m8xlarge-arm64.region: us-east-1
-  dynamic.linux-m8xlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-m8xlarge-arm64.ami: ami-06f37afe6d4f43c47
   dynamic.linux-m8xlarge-arm64.instance-type: m6g.8xlarge
   dynamic.linux-m8xlarge-arm64.instance-tag: {{cuteenv}}-arm64-m8xlarge
   dynamic.linux-m8xlarge-arm64.key-name: kflux-{{cutestenv}}-multi-{{ cutename }}-key-pair
@@ -136,7 +136,7 @@ data:
 
   dynamic.linux-c6gd2xlarge-arm64.type: aws
   dynamic.linux-c6gd2xlarge-arm64.region: us-east-1
-  dynamic.linux-c6gd2xlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-c6gd2xlarge-arm64.ami: ami-06f37afe6d4f43c47
   dynamic.linux-c6gd2xlarge-arm64.instance-type: c6gd.2xlarge
   dynamic.linux-c6gd2xlarge-arm64.instance-tag: {{cuteenv}}-arm64-c6gd2xlarge
   dynamic.linux-c6gd2xlarge-arm64.key-name: kflux-{{cutestenv}}-multi-{{ cutename }}-key-pair
@@ -212,7 +212,7 @@ data:
 
   dynamic.linux-amd64.type: aws
   dynamic.linux-amd64.region: us-east-1
-  dynamic.linux-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-amd64.ami: ami-01aaf1c29c7e0f0af
   dynamic.linux-amd64.instance-type: m6a.large
   dynamic.linux-amd64.instance-tag: {{cuteenv}}-amd64
   dynamic.linux-amd64.key-name: kflux-{{cutestenv}}-multi-{{ cutename }}-key-pair
@@ -224,7 +224,7 @@ data:
 
   dynamic.linux-mlarge-amd64.type: aws
   dynamic.linux-mlarge-amd64.region: us-east-1
-  dynamic.linux-mlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-mlarge-amd64.ami: ami-01aaf1c29c7e0f0af
   dynamic.linux-mlarge-amd64.instance-type: m6a.large
   dynamic.linux-mlarge-amd64.instance-tag: {{cuteenv}}-amd64-mlarge
   dynamic.linux-mlarge-amd64.key-name: kflux-{{cutestenv}}-multi-{{ cutename }}-key-pair
@@ -236,7 +236,7 @@ data:
 
   dynamic.linux-mxlarge-amd64.type: aws
   dynamic.linux-mxlarge-amd64.region: us-east-1
-  dynamic.linux-mxlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-mxlarge-amd64.ami: ami-01aaf1c29c7e0f0af
   dynamic.linux-mxlarge-amd64.instance-type: m6a.xlarge
   dynamic.linux-mxlarge-amd64.instance-tag: {{cuteenv}}-amd64-mxlarge
   dynamic.linux-mxlarge-amd64.key-name: kflux-{{cutestenv}}-multi-{{ cutename }}-key-pair
@@ -248,7 +248,7 @@ data:
 
   dynamic.linux-m2xlarge-amd64.type: aws
   dynamic.linux-m2xlarge-amd64.region: us-east-1
-  dynamic.linux-m2xlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-m2xlarge-amd64.ami: ami-01aaf1c29c7e0f0af
   dynamic.linux-m2xlarge-amd64.instance-type: m6a.2xlarge
   dynamic.linux-m2xlarge-amd64.instance-tag: {{cuteenv}}-amd64-m2xlarge
   dynamic.linux-m2xlarge-amd64.key-name: kflux-{{cutestenv}}-multi-{{ cutename }}-key-pair
@@ -260,7 +260,7 @@ data:
 
   dynamic.linux-m4xlarge-amd64.type: aws
   dynamic.linux-m4xlarge-amd64.region: us-east-1
-  dynamic.linux-m4xlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-m4xlarge-amd64.ami: ami-01aaf1c29c7e0f0af
   dynamic.linux-m4xlarge-amd64.instance-type: m6a.4xlarge
   dynamic.linux-m4xlarge-amd64.instance-tag: {{cuteenv}}-amd64-m4xlarge
   dynamic.linux-m4xlarge-amd64.key-name: kflux-{{cutestenv}}-multi-{{ cutename }}-key-pair
@@ -272,7 +272,7 @@ data:
 
   dynamic.linux-m8xlarge-amd64.type: aws
   dynamic.linux-m8xlarge-amd64.region: us-east-1
-  dynamic.linux-m8xlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-m8xlarge-amd64.ami: ami-01aaf1c29c7e0f0af
   dynamic.linux-m8xlarge-amd64.instance-type: m6a.8xlarge
   dynamic.linux-m8xlarge-amd64.instance-tag: {{cuteenv}}-amd64-m8xlarge
   dynamic.linux-m8xlarge-amd64.key-name: kflux-{{cutestenv}}-multi-{{ cutename }}-key-pair
@@ -285,7 +285,7 @@ data:
   # cpu:memory (1:2)
   dynamic.linux-cxlarge-arm64.type: aws
   dynamic.linux-cxlarge-arm64.region: us-east-1
-  dynamic.linux-cxlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-cxlarge-arm64.ami: ami-06f37afe6d4f43c47
   dynamic.linux-cxlarge-arm64.instance-type: c6g.xlarge
   dynamic.linux-cxlarge-arm64.instance-tag: {{cuteenv}}-arm64-cxlarge
   dynamic.linux-cxlarge-arm64.key-name: kflux-{{cutestenv}}-multi-{{ cutename }}-key-pair
@@ -297,7 +297,7 @@ data:
 
   dynamic.linux-c2xlarge-arm64.type: aws
   dynamic.linux-c2xlarge-arm64.region: us-east-1
-  dynamic.linux-c2xlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-c2xlarge-arm64.ami: ami-06f37afe6d4f43c47
   dynamic.linux-c2xlarge-arm64.instance-type: c6g.2xlarge
   dynamic.linux-c2xlarge-arm64.instance-tag: {{cuteenv}}-arm64-c2xlarge
   dynamic.linux-c2xlarge-arm64.key-name: kflux-{{cutestenv}}-multi-{{ cutename }}-key-pair
@@ -309,7 +309,7 @@ data:
 
   dynamic.linux-c4xlarge-arm64.type: aws
   dynamic.linux-c4xlarge-arm64.region: us-east-1
-  dynamic.linux-c4xlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-c4xlarge-arm64.ami: ami-06f37afe6d4f43c47
   dynamic.linux-c4xlarge-arm64.instance-type: c6g.4xlarge
   dynamic.linux-c4xlarge-arm64.instance-tag: {{cuteenv}}-arm64-c4xlarge
   dynamic.linux-c4xlarge-arm64.key-name: kflux-{{cutestenv}}-multi-{{ cutename }}-key-pair
@@ -321,7 +321,7 @@ data:
 
   dynamic.linux-c8xlarge-arm64.type: aws
   dynamic.linux-c8xlarge-arm64.region: us-east-1
-  dynamic.linux-c8xlarge-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-c8xlarge-arm64.ami: ami-06f37afe6d4f43c47
   dynamic.linux-c8xlarge-arm64.instance-type: c6g.8xlarge
   dynamic.linux-c8xlarge-arm64.instance-tag: {{cuteenv}}-arm64-c8xlarge
   dynamic.linux-c8xlarge-arm64.key-name: kflux-{{cutestenv}}-multi-{{ cutename }}-key-pair
@@ -333,7 +333,7 @@ data:
 
   dynamic.linux-cxlarge-amd64.type: aws
   dynamic.linux-cxlarge-amd64.region: us-east-1
-  dynamic.linux-cxlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-cxlarge-amd64.ami: ami-01aaf1c29c7e0f0af
   dynamic.linux-cxlarge-amd64.instance-type: c6a.xlarge
   dynamic.linux-cxlarge-amd64.instance-tag: {{cuteenv}}-amd64-cxlarge
   dynamic.linux-cxlarge-amd64.key-name: kflux-{{cutestenv}}-multi-{{ cutename }}-key-pair
@@ -345,7 +345,7 @@ data:
 
   dynamic.linux-c2xlarge-amd64.type: aws
   dynamic.linux-c2xlarge-amd64.region: us-east-1
-  dynamic.linux-c2xlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-c2xlarge-amd64.ami: ami-01aaf1c29c7e0f0af
   dynamic.linux-c2xlarge-amd64.instance-type: c6a.2xlarge
   dynamic.linux-c2xlarge-amd64.instance-tag: {{cuteenv}}-amd64-c2xlarge
   dynamic.linux-c2xlarge-amd64.key-name: kflux-{{cutestenv}}-multi-{{ cutename }}-key-pair
@@ -357,7 +357,7 @@ data:
 
   dynamic.linux-c4xlarge-amd64.type: aws
   dynamic.linux-c4xlarge-amd64.region: us-east-1
-  dynamic.linux-c4xlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-c4xlarge-amd64.ami: ami-01aaf1c29c7e0f0af
   dynamic.linux-c4xlarge-amd64.instance-type: c6a.4xlarge
   dynamic.linux-c4xlarge-amd64.instance-tag: {{cuteenv}}-amd64-c4xlarge
   dynamic.linux-c4xlarge-amd64.key-name: kflux-{{cutestenv}}-multi-{{ cutename }}-key-pair
@@ -369,7 +369,7 @@ data:
 
   dynamic.linux-c8xlarge-amd64.type: aws
   dynamic.linux-c8xlarge-amd64.region: us-east-1
-  dynamic.linux-c8xlarge-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-c8xlarge-amd64.ami: ami-01aaf1c29c7e0f0af
   dynamic.linux-c8xlarge-amd64.instance-type: c6a.8xlarge
   dynamic.linux-c8xlarge-amd64.instance-tag: {{cuteenv}}-amd64-c8xlarge
   dynamic.linux-c8xlarge-amd64.key-name: kflux-{{cutestenv}}-multi-{{ cutename }}-key-pair
@@ -381,7 +381,7 @@ data:
 
   dynamic.linux-root-arm64.type: aws
   dynamic.linux-root-arm64.region: us-east-1
-  dynamic.linux-root-arm64.ami: ami-03d6a5256a46c9feb
+  dynamic.linux-root-arm64.ami: ami-06f37afe6d4f43c47
   dynamic.linux-root-arm64.instance-type: m6g.large
   dynamic.linux-root-arm64.instance-tag: {{cuteenv}}-arm64-root
   dynamic.linux-root-arm64.key-name: kflux-{{cutestenv}}-multi-{{ cutename }}-key-pair
@@ -398,7 +398,7 @@ data:
 
   dynamic.linux-fast-amd64.type: aws
   dynamic.linux-fast-amd64.region: us-east-1
-  dynamic.linux-fast-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-fast-amd64.ami: ami-01aaf1c29c7e0f0af
   dynamic.linux-fast-amd64.instance-type: c7a.8xlarge
   dynamic.linux-fast-amd64.instance-tag: {{cuteenv}}-amd64-fast
   dynamic.linux-fast-amd64.key-name: kflux-{{cutestenv}}-multi-{{ cutename }}-key-pair
@@ -413,7 +413,7 @@ data:
 
   dynamic.linux-extra-fast-amd64.type: aws
   dynamic.linux-extra-fast-amd64.region: us-east-1
-  dynamic.linux-extra-fast-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-extra-fast-amd64.ami: ami-01aaf1c29c7e0f0af
   dynamic.linux-extra-fast-amd64.instance-type: c7a.12xlarge
   dynamic.linux-extra-fast-amd64.instance-tag: {{cuteenv}}-amd64-extra-fast
   dynamic.linux-extra-fast-amd64.key-name: kflux-{{cutestenv}}-multi-{{ cutename }}-key-pair
@@ -428,7 +428,7 @@ data:
 
   dynamic.linux-root-amd64.type: aws
   dynamic.linux-root-amd64.region: us-east-1
-  dynamic.linux-root-amd64.ami: ami-026ebd4cfe2c043b2
+  dynamic.linux-root-amd64.ami: ami-01aaf1c29c7e0f0af
   dynamic.linux-root-amd64.instance-type: m6idn.2xlarge
   dynamic.linux-root-amd64.instance-tag: {{cuteenv}}-amd64-root
   dynamic.linux-root-amd64.key-name: kflux-{{cutestenv}}-multi-{{ cutename }}-key-pair


### PR DESCRIPTION
Use Red Hat Cloud Access (BYOS) AMIs instead of regular PAYG AMIs that incur licensing fees.
The following changes were made:

ami-026ebd4cfe2c043b2 (RHEL-9.2.0_HVM-20230503-x86_64-41-Hourly2-GP2) -> ami-01aaf1c29c7e0f0af (RHEL-9.6.0_HVM-20250910-x86_64-0-Access2-GP3)

ami-03d6a5256a46c9feb (RHEL-9.2.0_HVM-20230503-arm64-41-Hourly2-GP2) -> ami-06f37afe6d4f43c47 (RHEL-9.6.0_HVM-20250910-arm64-0-Access2-GP3)

This PR continues the work started in https://github.com/redhat-appstudio/infra-deployments/pull/8251 and https://github.com/redhat-appstudio/infra-deployments/pull/8284.