### PR TITLE
Revert "Change RHEL AMIs to Cloud Access for prd-rh01 (#8284)"

### DIFF
--- a/components/multi-platform-controller/production/stone-prd-rh01/host-config.yaml
+++ b/components/multi-platform-controller/production/stone-prd-rh01/host-config.yaml
@@ -59,7 +59,7 @@ data:
   # cpu:memory (1:4)
   dynamic.linux-arm64.type: aws
   dynamic.linux-arm64.region: us-east-1
-  dynamic.linux-arm64.ami: ami-06f37afe6d4f43c47
+  dynamic.linux-arm64.ami: ami-03d6a5256a46c9feb
   dynamic.linux-arm64.instance-type: m6g.large
   dynamic.linux-arm64.instance-tag: prod-arm64
   dynamic.linux-arm64.key-name: konflux-prod-ext-mab01
@@ -71,7 +71,7 @@ data:
 
   dynamic.linux-mlarge-arm64.type: aws
   dynamic.linux-mlarge-arm64.region: us-east-1
-  dynamic.linux-mlarge-arm64.ami: ami-06f37afe6d4f43c47
+  dynamic.linux-mlarge-arm64.ami: ami-03d6a5256a46c9feb
   dynamic.linux-mlarge-arm64.instance-type: m6g.large
   dynamic.linux-mlarge-arm64.instance-tag: prod-arm64-mlarge
   dynamic.linux-mlarge-arm64.key-name: konflux-prod-ext-mab01
@@ -83,7 +83,7 @@ data:
 
   dynamic.linux-mxlarge-arm64.type: aws
   dynamic.linux-mxlarge-arm64.region: us-east-1
-  dynamic.linux-mxlarge-arm64.ami: ami-06f37afe6d4f43c47
+  dynamic.linux-mxlarge-arm64.ami: ami-03d6a5256a46c9feb
   dynamic.linux-mxlarge-arm64.instance-type: m6g.xlarge
   dynamic.linux-mxlarge-arm64.instance-tag: prod-arm64-mxlarge
   dynamic.linux-mxlarge-arm64.key-name: konflux-prod-ext-mab01
@@ -95,7 +95,7 @@ data:
 
   dynamic.linux-m2xlarge-arm64.type: aws
   dynamic.linux-m2xlarge-arm64.region: us-east-1
-  dynamic.linux-m2xlarge-arm64.ami: ami-06f37afe6d4f43c47
+  dynamic.linux-m2xlarge-arm64.ami: ami-03d6a5256a46c9feb
   dynamic.linux-m2xlarge-arm64.instance-type: m6g.2xlarge
   dynamic.linux-m2xlarge-arm64.instance-tag: prod-arm64-m2xlarge
   dynamic.linux-m2xlarge-arm64.key-name: konflux-prod-ext-mab01
@@ -107,7 +107,7 @@ data:
 
   dynamic.linux-d160-m2xlarge-arm64.type: aws
   dynamic.linux-d160-m2xlarge-arm64.region: us-east-1
-  dynamic.linux-d160-m2xlarge-arm64.ami: ami-06f37afe6d4f43c47
+  dynamic.linux-d160-m2xlarge-arm64.ami: ami-03d6a5256a46c9feb
   dynamic.linux-d160-m2xlarge-arm64.instance-type: m6g.2xlarge
   dynamic.linux-d160-m2xlarge-arm64.instance-tag: prod-arm64-m2xlarge-d160
   dynamic.linux-d160-m2xlarge-arm64.key-name: konflux-prod-ext-mab01
@@ -120,7 +120,7 @@ data:
 
   dynamic.linux-m4xlarge-arm64.type: aws
   dynamic.linux-m4xlarge-arm64.region: us-east-1
-  dynamic.linux-m4xlarge-arm64.ami: ami-06f37afe6d4f43c47
+  dynamic.linux-m4xlarge-arm64.ami: ami-03d6a5256a46c9feb
   dynamic.linux-m4xlarge-arm64.instance-type: m6g.4xlarge
   dynamic.linux-m4xlarge-arm64.instance-tag: prod-arm64-m4xlarge
   dynamic.linux-m4xlarge-arm64.key-name: konflux-prod-ext-mab01
@@ -132,7 +132,7 @@ data:
 
   dynamic.linux-m8xlarge-arm64.type: aws
   dynamic.linux-m8xlarge-arm64.region: us-east-1
-  dynamic.linux-m8xlarge-arm64.ami: ami-06f37afe6d4f43c47
+  dynamic.linux-m8xlarge-arm64.ami: ami-03d6a5256a46c9feb
   dynamic.linux-m8xlarge-arm64.instance-type: m6g.8xlarge
   dynamic.linux-m8xlarge-arm64.instance-tag: prod-arm64-m8xlarge
   dynamic.linux-m8xlarge-arm64.key-name: konflux-prod-ext-mab01
@@ -144,7 +144,7 @@ data:
 
   dynamic.linux-d160-m8xlarge-arm64.type: aws
   dynamic.linux-d160-m8xlarge-arm64.region: us-east-1
-  dynamic.linux-d160-m8xlarge-arm64.ami: ami-06f37afe6d4f43c47
+  dynamic.linux-d160-m8xlarge-arm64.ami: ami-03d6a5256a46c9feb
   dynamic.linux-d160-m8xlarge-arm64.instance-type: m6g.8xlarge
   dynamic.linux-d160-m8xlarge-arm64.instance-tag: prod-arm64-m8xlarge-d160
   dynamic.linux-d160-m8xlarge-arm64.key-name: konflux-prod-ext-mab01
@@ -157,7 +157,7 @@ data:
 
   dynamic.linux-c6gd2xlarge-arm64.type: aws
   dynamic.linux-c6gd2xlarge-arm64.region: us-east-1
-  dynamic.linux-c6gd2xlarge-arm64.ami: ami-06f37afe6d4f43c47
+  dynamic.linux-c6gd2xlarge-arm64.ami: ami-03d6a5256a46c9feb
   dynamic.linux-c6gd2xlarge-arm64.instance-type: c6gd.2xlarge
   dynamic.linux-c6gd2xlarge-arm64.instance-tag: prod-arm64-c6gd2xlarge
   dynamic.linux-c6gd2xlarge-arm64.key-name: konflux-prod-ext-mab01
@@ -234,7 +234,7 @@ data:
   # same as m4xlarge-arm64 but with 160G disk
   dynamic.linux-d160-m4xlarge-arm64.type: aws
   dynamic.linux-d160-m4xlarge-arm64.region: us-east-1
-  dynamic.linux-d160-m4xlarge-arm64.ami: ami-06f37afe6d4f43c47
+  dynamic.linux-d160-m4xlarge-arm64.ami: ami-03d6a5256a46c9feb
   dynamic.linux-d160-m4xlarge-arm64.instance-type: m6g.4xlarge
   dynamic.linux-d160-m4xlarge-arm64.instance-tag: prod-arm64-m4xlarge-d160
   dynamic.linux-d160-m4xlarge-arm64.key-name: konflux-prod-ext-mab01
@@ -248,7 +248,7 @@ data:
 
   dynamic.linux-amd64.type: aws
   dynamic.linux-amd64.region: us-east-1
-  dynamic.linux-amd64.ami: ami-01aaf1c29c7e0f0af
+  dynamic.linux-amd64.ami: ami-026ebd4cfe2c043b2
   dynamic.linux-amd64.instance-type: m6a.large
   dynamic.linux-amd64.instance-tag: prod-amd64
   dynamic.linux-amd64.key-name: konflux-prod-ext-mab01
@@ -260,7 +260,7 @@ data:
 
   dynamic.linux-mlarge-amd64.type: aws
   dynamic.linux-mlarge-amd64.region: us-east-1
-  dynamic.linux-mlarge-amd64.ami: ami-01aaf1c29c7e0f0af
+  dynamic.linux-mlarge-amd64.ami: ami-026ebd4cfe2c043b2
   dynamic.linux-mlarge-amd64.instance-type: m6a.large
   dynamic.linux-mlarge-amd64.instance-tag: prod-amd64-mlarge
   dynamic.linux-mlarge-amd64.key-name: konflux-prod-ext-mab01
@@ -272,7 +272,7 @@ data:
 
   dynamic.linux-mxlarge-amd64.type: aws
   dynamic.linux-mxlarge-amd64.region: us-east-1
-  dynamic.linux-mxlarge-amd64.ami: ami-01aaf1c29c7e0f0af
+  dynamic.linux-mxlarge-amd64.ami: ami-026ebd4cfe2c043b2
   dynamic.linux-mxlarge-amd64.instance-type: m6a.xlarge
   dynamic.linux-mxlarge-amd64.instance-tag: prod-amd64-mxlarge
   dynamic.linux-mxlarge-amd64.key-name: konflux-prod-ext-mab01
@@ -284,7 +284,7 @@ data:
 
   dynamic.linux-m2xlarge-amd64.type: aws
   dynamic.linux-m2xlarge-amd64.region: us-east-1
-  dynamic.linux-m2xlarge-amd64.ami: ami-01aaf1c29c7e0f0af
+  dynamic.linux-m2xlarge-amd64.ami: ami-026ebd4cfe2c043b2
   dynamic.linux-m2xlarge-amd64.instance-type: m6a.2xlarge
   dynamic.linux-m2xlarge-amd64.instance-tag: prod-amd64-m2xlarge
   dynamic.linux-m2xlarge-amd64.key-name: konflux-prod-ext-mab01
@@ -296,7 +296,7 @@ data:
 
   dynamic.linux-d160-m2xlarge-amd64.type: aws
   dynamic.linux-d160-m2xlarge-amd64.region: us-east-1
-  dynamic.linux-d160-m2xlarge-amd64.ami: ami-01aaf1c29c7e0f0af
+  dynamic.linux-d160-m2xlarge-amd64.ami: ami-026ebd4cfe2c043b2
   dynamic.linux-d160-m2xlarge-amd64.instance-type: m6a.2xlarge
   dynamic.linux-d160-m2xlarge-amd64.instance-tag: prod-amd64-m2xlarge-d160
   dynamic.linux-d160-m2xlarge-amd64.key-name: konflux-prod-ext-mab01
@@ -309,7 +309,7 @@ data:
 
   dynamic.linux-m4xlarge-amd64.type: aws
   dynamic.linux-m4xlarge-amd64.region: us-east-1
-  dynamic.linux-m4xlarge-amd64.ami: ami-01aaf1c29c7e0f0af
+  dynamic.linux-m4xlarge-amd64.ami: ami-026ebd4cfe2c043b2
   dynamic.linux-m4xlarge-amd64.instance-type: m6a.4xlarge
   dynamic.linux-m4xlarge-amd64.instance-tag: prod-amd64-m4xlarge
   dynamic.linux-m4xlarge-amd64.key-name: konflux-prod-ext-mab01
@@ -322,7 +322,7 @@ data:
   # same as m4xlarge-amd64 bug 160G disk
   dynamic.linux-d160-m4xlarge-amd64.type: aws
   dynamic.linux-d160-m4xlarge-amd64.region: us-east-1
-  dynamic.linux-d160-m4xlarge-amd64.ami: ami-01aaf1c29c7e0f0af
+  dynamic.linux-d160-m4xlarge-amd64.ami: ami-026ebd4cfe2c043b2
   dynamic.linux-d160-m4xlarge-amd64.instance-type: m6a.4xlarge
   dynamic.linux-d160-m4xlarge-amd64.instance-tag: prod-amd64-m4xlarge-d160
   dynamic.linux-d160-m4xlarge-amd64.key-name: konflux-prod-ext-mab01
@@ -336,7 +336,7 @@ data:
 
   dynamic.linux-m8xlarge-amd64.type: aws
   dynamic.linux-m8xlarge-amd64.region: us-east-1
-  dynamic.linux-m8xlarge-amd64.ami: ami-01aaf1c29c7e0f0af
+  dynamic.linux-m8xlarge-amd64.ami: ami-026ebd4cfe2c043b2
   dynamic.linux-m8xlarge-amd64.instance-type: m6a.8xlarge
   dynamic.linux-m8xlarge-amd64.instance-tag: prod-amd64-m8xlarge
   dynamic.linux-m8xlarge-amd64.key-name: konflux-prod-ext-mab01
@@ -348,7 +348,7 @@ data:
 
   dynamic.linux-d160-m8xlarge-amd64.type: aws
   dynamic.linux-d160-m8xlarge-amd64.region: us-east-1
-  dynamic.linux-d160-m8xlarge-amd64.ami: ami-01aaf1c29c7e0f0af
+  dynamic.linux-d160-m8xlarge-amd64.ami: ami-026ebd4cfe2c043b2
   dynamic.linux-d160-m8xlarge-amd64.instance-type: m6a.8xlarge
   dynamic.linux-d160-m8xlarge-amd64.instance-tag: prod-amd64-m8xlarge-d160
   dynamic.linux-d160-m8xlarge-amd64.key-name: konflux-prod-ext-mab01
@@ -362,7 +362,7 @@ data:
   # cpu:memory (1:2)
   dynamic.linux-cxlarge-arm64.type: aws
   dynamic.linux-cxlarge-arm64.region: us-east-1
-  dynamic.linux-cxlarge-arm64.ami: ami-06f37afe6d4f43c47
+  dynamic.linux-cxlarge-arm64.ami: ami-03d6a5256a46c9feb
   dynamic.linux-cxlarge-arm64.instance-type: c6g.xlarge
   dynamic.linux-cxlarge-arm64.instance-tag: prod-arm64-cxlarge
   dynamic.linux-cxlarge-arm64.key-name: konflux-prod-ext-mab01
@@ -374,7 +374,7 @@ data:
 
   dynamic.linux-c2xlarge-arm64.type: aws
   dynamic.linux-c2xlarge-arm64.region: us-east-1
-  dynamic.linux-c2xlarge-arm64.ami: ami-06f37afe6d4f43c47
+  dynamic.linux-c2xlarge-arm64.ami: ami-03d6a5256a46c9feb
   dynamic.linux-c2xlarge-arm64.instance-type: c6g.2xlarge
   dynamic.linux-c2xlarge-arm64.instance-tag: prod-arm64-c2xlarge
   dynamic.linux-c2xlarge-arm64.key-name: konflux-prod-ext-mab01
@@ -386,7 +386,7 @@ data:
 
   dynamic.linux-c4xlarge-arm64.type: aws
   dynamic.linux-c4xlarge-arm64.region: us-east-1
-  dynamic.linux-c4xlarge-arm64.ami: ami-06f37afe6d4f43c47
+  dynamic.linux-c4xlarge-arm64.ami: ami-03d6a5256a46c9feb
   dynamic.linux-c4xlarge-arm64.instance-type: c6g.4xlarge
   dynamic.linux-c4xlarge-arm64.instance-tag: prod-arm64-c4xlarge
   dynamic.linux-c4xlarge-arm64.key-name: konflux-prod-ext-mab01
@@ -398,7 +398,7 @@ data:
 
   dynamic.linux-c8xlarge-arm64.type: aws
   dynamic.linux-c8xlarge-arm64.region: us-east-1
-  dynamic.linux-c8xlarge-arm64.ami: ami-06f37afe6d4f43c47
+  dynamic.linux-c8xlarge-arm64.ami: ami-03d6a5256a46c9feb
   dynamic.linux-c8xlarge-arm64.instance-type: c6g.8xlarge
   dynamic.linux-c8xlarge-arm64.instance-tag: prod-arm64-c8xlarge
   dynamic.linux-c8xlarge-arm64.key-name: konflux-prod-ext-mab01
@@ -410,7 +410,7 @@ data:
 
   dynamic.linux-cxlarge-amd64.type: aws
   dynamic.linux-cxlarge-amd64.region: us-east-1
-  dynamic.linux-cxlarge-amd64.ami: ami-01aaf1c29c7e0f0af
+  dynamic.linux-cxlarge-amd64.ami: ami-026ebd4cfe2c043b2
   dynamic.linux-cxlarge-amd64.instance-type: c6a.xlarge
   dynamic.linux-cxlarge-amd64.instance-tag: prod-amd64-cxlarge
   dynamic.linux-cxlarge-amd64.key-name: konflux-prod-ext-mab01
@@ -422,7 +422,7 @@ data:
 
   dynamic.linux-c2xlarge-amd64.type: aws
   dynamic.linux-c2xlarge-amd64.region: us-east-1
-  dynamic.linux-c2xlarge-amd64.ami: ami-01aaf1c29c7e0f0af
+  dynamic.linux-c2xlarge-amd64.ami: ami-026ebd4cfe2c043b2
   dynamic.linux-c2xlarge-amd64.instance-type: c6a.2xlarge
   dynamic.linux-c2xlarge-amd64.instance-tag: prod-amd64-c2xlarge
   dynamic.linux-c2xlarge-amd64.key-name: konflux-prod-ext-mab01
@@ -434,7 +434,7 @@ data:
 
   dynamic.linux-c4xlarge-amd64.type: aws
   dynamic.linux-c4xlarge-amd64.region: us-east-1
-  dynamic.linux-c4xlarge-amd64.ami: ami-01aaf1c29c7e0f0af
+  dynamic.linux-c4xlarge-amd64.ami: ami-026ebd4cfe2c043b2
   dynamic.linux-c4xlarge-amd64.instance-type: c6a.4xlarge
   dynamic.linux-c4xlarge-amd64.instance-tag: prod-amd64-c4xlarge
   dynamic.linux-c4xlarge-amd64.key-name: konflux-prod-ext-mab01
@@ -446,7 +446,7 @@ data:
 
   dynamic.linux-c8xlarge-amd64.type: aws
   dynamic.linux-c8xlarge-amd64.region: us-east-1
-  dynamic.linux-c8xlarge-amd64.ami: ami-01aaf1c29c7e0f0af
+  dynamic.linux-c8xlarge-amd64.ami: ami-026ebd4cfe2c043b2
   dynamic.linux-c8xlarge-amd64.instance-type: c6a.8xlarge
   dynamic.linux-c8xlarge-amd64.instance-tag: prod-amd64-c8xlarge
   dynamic.linux-c8xlarge-amd64.key-name: konflux-prod-ext-mab01
@@ -458,7 +458,7 @@ data:
 
   dynamic.linux-root-arm64.type: aws
   dynamic.linux-root-arm64.region: us-east-1
-  dynamic.linux-root-arm64.ami: ami-06f37afe6d4f43c47
+  dynamic.linux-root-arm64.ami: ami-03d6a5256a46c9feb
   dynamic.linux-root-arm64.instance-type: m6g.large
   dynamic.linux-root-arm64.instance-tag: prod-arm64-root
   dynamic.linux-root-arm64.key-name: konflux-prod-ext-mab01
@@ -475,7 +475,7 @@ data:
 
   dynamic.linux-fast-amd64.type: aws
   dynamic.linux-fast-amd64.region: us-east-1
-  dynamic.linux-fast-amd64.ami: ami-01aaf1c29c7e0f0af
+  dynamic.linux-fast-amd64.ami: ami-026ebd4cfe2c043b2
   dynamic.linux-fast-amd64.instance-type: c7a.8xlarge
   dynamic.linux-fast-amd64.instance-tag: prod-amd64-fast
   dynamic.linux-fast-amd64.key-name: konflux-prod-ext-mab01
@@ -490,7 +490,7 @@ data:
 
   dynamic.linux-extra-fast-amd64.type: aws
   dynamic.linux-extra-fast-amd64.region: us-east-1
-  dynamic.linux-extra-fast-amd64.ami: ami-01aaf1c29c7e0f0af
+  dynamic.linux-extra-fast-amd64.ami: ami-026ebd4cfe2c043b2
   dynamic.linux-extra-fast-amd64.instance-type: c7a.12xlarge
   dynamic.linux-extra-fast-amd64.instance-tag: prod-amd64-extra-fast
   dynamic.linux-extra-fast-amd64.key-name: konflux-prod-ext-mab01
@@ -505,7 +505,7 @@ data:
 
   dynamic.linux-root-amd64.type: aws
   dynamic.linux-root-amd64.region: us-east-1
-  dynamic.linux-root-amd64.ami: ami-01aaf1c29c7e0f0af
+  dynamic.linux-root-amd64.ami: ami-026ebd4cfe2c043b2
   dynamic.linux-root-amd64.instance-type: m6idn.2xlarge
   dynamic.linux-root-amd64.instance-tag: prod-amd64-root
   dynamic.linux-root-amd64.key-name: konflux-prod-ext-mab01


### PR DESCRIPTION
This commit reverts PR #8284
I understand this has an impact as it is bringing back PAYG AMIs that incur licensing fees.
But it seems that this change has broken the build for our images, and we are currently blocked from doing a release, that needs to happen before Oct 1st.

We have started discussing this on a slack channel, and tried to ping the author and approver (@p8r-the-gr8 and @hugares) on it, but didn't have feedback.
See https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1758792674077519?thread_ts=1758621485.172029&cid=C04PZ7H0VA8

If no quick alternative is found to fix our problem, I strongly suggest to merge this until a proper fix is found.

Any suggestion is welcome.


## Full rationale
- we have a custom build task that is using one of those VMs (see: https://github.com/confidential-devhub/coco-podvm-scripts/blob/main/task/build-dm-verity-image/0.1/build-dm-verity-image.yaml)
- starting Wednesday Sept. 24th, this task has started to fail systematically
- the change that I am reverting here happened at 6:30pm on that day.
- the first PR that caused a build issue was created at 6:45pm on that day.
  See: https://github.com/confidential-devhub/coco-podvm-scripts/pull/87
- all subsequent build attempts, even on PRs that were passing before, have failed with the same error since then
- there was no code change in our task that can explain the error

The error happens during a "podman build" execution, and reports this message:
```
STEP 2/5: RUN subscription-manager register --org "$(cat /activation-key/org)" --activationkey "$(cat /activation-key/activationkey)"
/bin/sh: error while loading shared libraries: /lib64/libc.so.6: cannot apply additional memory protection after relocation: Permission denied
Error: building at STEP "RUN subscription-manager register --org "$(cat /activation-key/org)" --activationkey "$(cat /activation-key/activationkey)"": while running runtime: exit status 127
```

Based on the error message, we've tried to apply the workaround suggested by https://access.redhat.com/solutions/7021610
See https://github.com/confidential-devhub/coco-podvm-scripts/pull/88
But it didn't work.

In any case, I suspect that the fix should belong to the VM, and not to every task that are running on it.

