### PR TITLE
Add pod debugging permissions to mintmaker team

### DIFF
--- a/components/mintmaker/base/rbac/mintmaker-team.yaml
+++ b/components/mintmaker/base/rbac/mintmaker-team.yaml
@@ -8,6 +8,9 @@ rules:
       - ''
     resources:
       - pods
+      - pods/attach
+      - pods/exec
+      - pods/log
       - secrets
       - configmaps
     verbs:


### PR DESCRIPTION
Adds pods/attach, pods/exec, and pods/log subresources to enable debugging capabilities for the konflux-mintmaker-team.