### PR TITLE
kflux-ocp-p01: fix object too large errors

### DIFF
--- a/components/vector-kubearchive-log-collector/production/kflux-ocp-p01/loki-helm-prod-values.yaml
+++ b/components/vector-kubearchive-log-collector/production/kflux-ocp-p01/loki-helm-prod-values.yaml
@@ -31,7 +31,7 @@ loki:
       ingestion_burst_size_mb: 100
       ingestion_rate_strategy: "local"
       max_streams_per_user: 0
-      max_line_size: 2097152
+      max_line_size: 3145728
       per_stream_rate_limit: 50M
       per_stream_rate_limit_burst: 200M
       reject_old_samples: false


### PR DESCRIPTION
Signed-off-by: obetsun <obetsun@redhat.com>

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED