### PR TITLE
MintMaker: manually update stage config

### DIFF
--- a/components/mintmaker/staging/base/kustomization.yaml
+++ b/components/mintmaker/staging/base/kustomization.yaml
@@ -4,8 +4,8 @@ resources:
 - ../../base
 - ../../base/external-secrets
 - ../blackbox
-- https://github.com/konflux-ci/mintmaker/config/default?ref=ed27b4872df93a19641348240f243065adcd90d9
-- https://github.com/konflux-ci/mintmaker/config/renovate?ref=ed27b4872df93a19641348240f243065adcd90d9
+- https://github.com/konflux-ci/mintmaker/config/default?ref=0df3af434b36f4ec547def124487c3ced00a41f7
+- https://github.com/konflux-ci/mintmaker/config/renovate?ref=0df3af434b36f4ec547def124487c3ced00a41f7
 
 namespace: mintmaker
 


### PR DESCRIPTION
This is a change to remove the tekton schedule limitation, in response to an emergency raised by users.