### PR TITLE
fix kyverno background permission for integration policies

### DIFF
--- a/components/policies/development/integration/bootstrap-namespace/kyverno-rbac.yaml
+++ b/components/policies/development/integration/bootstrap-namespace/kyverno-rbac.yaml
@@ -24,3 +24,20 @@ rules:
   - get
   - list
   - watch
+---
+# To allow kyverno to create the RoleBinding,
+# the kyverno-background-controller's ServiceAccount
+# needs to have the same permissions it wants to assign
+# to someone else
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kyverno-background:konflux-integration-runner
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: konflux-integration-runner
+subjects:
+- kind: ServiceAccount
+  namespace: konflux-kyverno
+  name: kyverno-background-controller


### PR DESCRIPTION
To allow kyverno to create the RoleBinding, the kyverno-background-controller's ServiceAccount needs to have the same permissions it wants to assign to someone else.

This change binds the Kyverno's background ServiceAccount to the `konflux-integration-runner` ClusterRole.

Signed-off-by: Francesco Ilario <filario@redhat.com>
