### PR TITLE
MintMaker: promote manual update to prod

### DIFF
--- a/components/mintmaker/production/base/kustomization.yaml
+++ b/components/mintmaker/production/base/kustomization.yaml
@@ -3,8 +3,8 @@ kind: Kustomization
 resources:
   - ../../base
   - ../../base/external-secrets
-  - https://github.com/konflux-ci/mintmaker/config/default?ref=ed27b4872df93a19641348240f243065adcd90d9
-  - https://github.com/konflux-ci/mintmaker/config/renovate?ref=ed27b4872df93a19641348240f243065adcd90d9
+  - https://github.com/konflux-ci/mintmaker/config/default?ref=0df3af434b36f4ec547def124487c3ced00a41f7
+  - https://github.com/konflux-ci/mintmaker/config/renovate?ref=0df3af434b36f4ec547def124487c3ced00a41f7
 
 namespace: mintmaker
 


### PR DESCRIPTION
This is a change to remove the tekton schedule limitation, in response to an emergency raised by users