### PR TITLE
prod: remove sprayproxy from host clusters

### DIFF
--- a/argo-cd-apps/overlays/konflux-public-production/delete-applications.yaml
+++ b/argo-cd-apps/overlays/konflux-public-production/delete-applications.yaml
@@ -30,3 +30,9 @@ kind: ApplicationSet
 metadata:
   name: squid
 $patch: delete
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: sprayproxy
+$patch: delete


### PR DESCRIPTION
We no longer need sprayproxy on the production host cluster, so this is safe to remove.

Removal of the sprayproxy component itself will come in a follow-up PR.