### PR TITLE
Increase resources for loki distributor

### DIFF
--- a/components/vector-kubearchive-log-collector/production/stone-prod-p02/loki-helm-prod-values.yaml
+++ b/components/vector-kubearchive-log-collector/production/stone-prod-p02/loki-helm-prod-values.yaml
@@ -27,13 +27,13 @@ loki:
   # Configure ingestion limits to handle Vector's data volume
   limits_config:
       retention_period: 744h  # 31 days retention
-      ingestion_rate_mb: 50
-      ingestion_burst_size_mb: 100
+      ingestion_rate_mb: 100
+      ingestion_burst_size_mb: 300
       ingestion_rate_strategy: "local"
       max_streams_per_user: 0
       max_line_size: 2097152
-      per_stream_rate_limit: 50M
-      per_stream_rate_limit_burst: 200M
+      per_stream_rate_limit: 100M
+      per_stream_rate_limit_burst: 400M
       reject_old_samples: false
       reject_old_samples_max_age: 168h
       discover_service_name: []
@@ -115,16 +115,19 @@ queryScheduler:
       memory: 512Mi
 
 distributor:
-  replicas: 3
+  replicas: 5
   autoscaling:
     enabled: true
+    minReplicas: 5
+    maxReplicas: 10
+    targetCPUUtilizationPercentage: 70
   maxUnavailable: 1
   resources:
     requests:
-      cpu: 300m
-      memory: 512Mi
-    limits:
+      cpu: 500m
       memory: 1Gi
+    limits:
+      memory: 2Gi
   affinity: {}
 
 compactor:


### PR DESCRIPTION
This intends fixing the following consistent errors in the p02 cluster (the one where we are deployed with more activity)

<img width="1883" height="902" alt="image" src="https://github.com/user-attachments/assets/1b642c22-9485-4bd6-a11a-f372f38fffbc" />


We are also missing some random logs and after some troubleshooting the only thing that we could found were these 500 errors in the loki's gateway and distributor with no reason so let's see how things go with more resources.