### PR TITLE
KubeArchive: increase memory assigned to the operator

### DIFF
--- a/components/kubearchive/staging/stone-stage-p01/kustomization.yaml
+++ b/components/kubearchive/staging/stone-stage-p01/kustomization.yaml
@@ -70,6 +70,13 @@ patches:
           spec:
             containers:
               - name: manager
+                resources:
+                  limits:
+                    cpu: 100m
+                    memory: 512Mi
+                  requests:
+                    cpu: 100m
+                    memory: 512Mi
                 env:
                 - name: KUBEARCHIVE_OTEL_MODE
                   value: delegated

--- a/components/kubearchive/staging/stone-stg-rh01/kustomization.yaml
+++ b/components/kubearchive/staging/stone-stg-rh01/kustomization.yaml
@@ -70,6 +70,13 @@ patches:
           spec:
             containers:
               - name: manager
+                resources:
+                  limits:
+                    cpu: 100m
+                    memory: 512Mi
+                  requests:
+                    cpu: 100m
+                    memory: 512Mi
                 env:
                 - name: KUBEARCHIVE_OTEL_MODE
                   value: delegated


### PR DESCRIPTION
The operator now creates watchers, so it is getting OOM.