### PR TITLE
Fix operational_config in loki

### DIFF
--- a/components/vector-kubearchive-log-collector/production/stone-prod-p02/loki-helm-prod-values.yaml
+++ b/components/vector-kubearchive-log-collector/production/stone-prod-p02/loki-helm-prod-values.yaml
@@ -47,11 +47,6 @@ loki:
       max_entries_limit_per_query: 100000
       increment_duplicate_timestamp: true
       allow_structured_metadata: true
-  operational_config:
-    log_stream_creation: true
-    log_push_request: true
-    log_push_request_streams: true
-    log_duplicate_stream_info: true
   ingester:
     chunk_target_size: 8388608        # 8MB 
     chunk_idle_period: 5m
@@ -137,6 +132,11 @@ distributor:
       memory: 1Gi
     limits:
       memory: 2Gi
+  extraArgs:
+    - "-operational-config.log-push-request=true"
+    - "-operational-config.log-push-request-streams=true"
+    - "-operational-config.log-stream-creation=true"
+    - "-operational-config.log-duplicate-stream-info=true"
   affinity: {}
 
 compactor:
@@ -189,7 +189,7 @@ memcachedIndexQueries:
 memcachedIndexWrites:
   enabled: true
 
-# Disable Minio - staging uses S3 with IAM role
+# Disable Minio
 minio:
   enabled: false
 


### PR DESCRIPTION
Latest PR didn't have effect on the deployments. Let's try the extra args with the argument names stated at [the docs](https://grafana.com/docs/loki/latest/configure/#operational_config)