### PR TITLE
Fix operational_config in loki

### DIFF
--- a/components/vector-kubearchive-log-collector/production/stone-prod-p02/loki-helm-prod-values.yaml
+++ b/components/vector-kubearchive-log-collector/production/stone-prod-p02/loki-helm-prod-values.yaml
@@ -47,6 +47,13 @@ loki:
       max_entries_limit_per_query: 100000
       increment_duplicate_timestamp: true
       allow_structured_metadata: true
+  runtimeConfig:
+    configs:
+      kubearchive:
+        log-push-request: true
+        log-push-request-streams: true
+        log-stream-creation: true
+        log-duplicate-stream-info: true
   ingester:
     chunk_target_size: 8388608        # 8MB 
     chunk_idle_period: 5m
@@ -132,11 +139,6 @@ distributor:
       memory: 1Gi
     limits:
       memory: 2Gi
-  extraArgs:
-    - "-operational-config.log-push-request=true"
-    - "-operational-config.log-push-request-streams=true"
-    - "-operational-config.log-stream-creation=true"
-    - "-operational-config.log-duplicate-stream-info=true"
   affinity: {}
 
 compactor:


### PR DESCRIPTION
Retrying with the runtimeConfig as it seems that the cli options aren't supported by the distributor.

I'm setting the configurations under the tenant name, so now it should fit https://github.com/grafana/loki/blob/68d93954b39eb5a9706d84dcb09eb0ac0b013822/pkg/loki/runtime_config.go#L22-L22