### PR TITLE
Allow bigger chunks of logs in loki

### DIFF
--- a/components/vector-kubearchive-log-collector/production/stone-prod-p02/loki-helm-prod-values.yaml
+++ b/components/vector-kubearchive-log-collector/production/stone-prod-p02/loki-helm-prod-values.yaml
@@ -61,7 +61,17 @@ loki:
     chunk_encoding: snappy            # Compress data (reduces S3 transfer size)
     chunk_retain_period: 1h           # Keep chunks in memory after flush
     flush_op_timeout: 10m             # Add timeout for S3 operations
-
+  server:
+    grpc_server_max_recv_msg_size: 15728640  # 15MB
+    grpc_server_max_send_msg_size: 15728640
+  ingester_client:
+    grpc_client_config:
+      max_recv_msg_size: 15728640  # 15MB
+      max_send_msg_size: 15728640  # 15MB
+  query_scheduler:
+    grpc_client_config:
+      max_recv_msg_size: 15728640  # 15MB
+      max_send_msg_size: 15728640  # 15MB
   # Tuning for high-load queries
   querier:
     max_concurrent: 8


### PR DESCRIPTION
With the recent enabled logs we are now seeing the issue that was causing some logs to be missing:

```	
level=debug ts=2025-09-30T15:25:51.87843779Z caller=http.go:108 org_id=kubearchive msg="push request failed" code=500 err="rpc error: code = ResourceExhausted desc = grpc: received message larger than max (10361786 vs. 4194304)"
```

I'm updating the GRPC max size limits for server and client following the config shown in https://grafana.com/docs/loki/latest/configure/#grpc_client

Note that in vector we have the maximum chunk size to be sent to loki set in 10MB, so that is the main issue. If we find problems with this setup we will need to reduce the chunks sent from vector to loki.