### PR TITLE
feat(SPRE-1268): updated stage monitoringstack endpoints for kube_pod_container_status_terminated_reason

### DIFF
--- a/components/monitoring/prometheus/staging/base/monitoringstack/endpoints-params.yaml
+++ b/components/monitoring/prometheus/staging/base/monitoringstack/endpoints-params.yaml
@@ -94,7 +94,7 @@
     ## Container Metrics
     - '{__name__="kube_pod_container_status_waiting_reason", namespace!~".*-tenant|openshift-.*|kube-.*"}'
     - '{__name__="kube_pod_container_resource_limits", namespace="release-service"}'
-    - '{__name__="kube_pod_container_status_terminated_reason", namespace="release-service"}'
+    - '{__name__="kube_pod_container_status_terminated_reason", namespace=~"release-service|openshift-etcd|openshift-kube-apiserver|build-service|image-controller|integration-service|konflux-ui|product-kubearchive|openshift-kueue-operator|tekton-kueue|kueue-external-admission|mintmaker|multi-platform-controller|namespace-lister|openshift-pipelines|tekton-results|project-controller|smee|smee-client"}'
     - '{__name__="kube_pod_container_status_last_terminated_reason", namespace="release-service"}'
     - '{__name__="kube_pod_container_status_ready", namespace=~"release-service|tekton-kueue|kueue-external-admission|openshift-kueue-operator"}'
     - '{__name__="container_cpu_usage_seconds_total", namespace=~"release-service|openshift-etcd"}'


### PR DESCRIPTION
this is so we can check for OOM events from multiple stage namespaces and not just one