### PR TITLE
Set common-secret=true on e2e-test pull secret

### DIFF
--- a/components/build-templates/production/e2e-registry-redhat-io-pull-secret.yaml
+++ b/components/build-templates/production/e2e-registry-redhat-io-pull-secret.yaml
@@ -21,5 +21,8 @@ spec:
     template:
       engineVersion: v2
       type: kubernetes.io/dockerconfigjson
+      metadata:
+        labels:
+          build.appstudio.openshift.io/common-secret: 'true'
       data:
         .dockerconfigjson: "{{ .config }}"


### PR DESCRIPTION
The 'registry-redhat-io-pull-secret' is needed for e2e test pipelines that pull base images from registry.redhat.io. Previously, this secret was linked to the 'appstudio-pipeline' Service Account.

After recent changes that remove appstudio-pipeline compatiblity, it has become necessary to turn this secret into a "common" secret so that it gets linked to all Service Accounts created for e2e tests.