### PR TITLE
chore: bump repository-validator prod commit ref

### DIFF
--- a/components/repository-validator/production/kustomization.yaml
+++ b/components/repository-validator/production/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - https://github.com/konflux-ci/repository-validator/config/ocp?ref=1a1bd5856c7caf40ebf3d9a24fce209ba8a74bd9
-  - https://github.com/redhat-appstudio/internal-infra-deployments/components/repository-validator/production?ref=58d28801c655f2cd4a8f6448b70aa50bd976f6d1
+  - https://github.com/redhat-appstudio/internal-infra-deployments/components/repository-validator/production?ref=a40e6a95826c0cc782fc55f35c87c44bd88a08ad
 images:
   - name: controller
     newName: quay.io/redhat-user-workloads/konflux-infra-tenant/repository-validator/repository-validator


### PR DESCRIPTION
This reverts the change that allowed the release service team to use test repos on internal production.