### PR TITLE
Permissions for integration-runner in rhtap-build

### DIFF
--- a/components/build-templates/base/e2e/role.yaml
+++ b/components/build-templates/base/e2e/role.yaml
@@ -57,3 +57,22 @@ rules:
       - list
       - watch
       - delete
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: application-manager
+  namespace: build-templates-e2e
+rules:
+  - apiGroups:
+      - appstudio.redhat.com
+    resources:
+      - applications
+    verbs:
+      - get
+      - list
+      - create
+      - watch
+      - update
+      - patch
+      - delete

--- a/components/build-templates/base/e2e/rolebinding.yaml
+++ b/components/build-templates/base/e2e/rolebinding.yaml
@@ -96,4 +96,31 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: build-admin
-  
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: konflux-integration-runner-rolebinding
+  namespace: build-templates-e2e
+subjects:
+  - kind: ServiceAccount
+    name: konflux-integration-runner
+    namespace: rhtap-build-tenant
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: konflux-integration-runner
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: application-manager-konflux-integration-runner
+  namespace: build-templates-e2e
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: application-manager
+subjects:
+- kind: ServiceAccount
+  name: konflux-integration-runner
+  namespace: rhtap-build-tenant

--- a/components/has/base/rbac/has.yaml
+++ b/components/has/base/rbac/has.yaml
@@ -11,3 +11,17 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: component-maintainer
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: view-konflux-integration-runner
+  namespace: application-service
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: view
+subjects:
+- kind: ServiceAccount
+  name: konflux-integration-runner
+  namespace: rhtap-build-tenant


### PR DESCRIPTION
konflux-integration-runner ServiceAccount in rhtap-build-tenant runs e2e-tests that require access to build-templates-e2e namespace and application-service.

Previously the tests would be ran by appstudio-pipeline SA which had tons of permissions, now the permissions are more granular and have to be added explicitly.