### PR TITLE
KubeArchive: increase memory for operator in staging

### DIFF
--- a/components/kubearchive/staging/stone-stg-rh01/kustomization.yaml
+++ b/components/kubearchive/staging/stone-stg-rh01/kustomization.yaml
@@ -73,10 +73,10 @@ patches:
                 resources:
                   limits:
                     cpu: 200m
-                    memory: 1500Mi
+                    memory: 3072Mi
                   requests:
                     cpu: 200m
-                    memory: 1500Mi
+                    memory: 3072Mi
                 env:
                 - name: KUBEARCHIVE_OTEL_MODE
                   value: delegated


### PR DESCRIPTION
increase memory limit from 1500Mi to 3072Mi (3Gi)