### PR TITLE
KubeArchive: increase API replicas to 2

### DIFF
--- a/components/kubearchive/development/kustomization.yaml
+++ b/components/kubearchive/development/kustomization.yaml
@@ -140,7 +140,10 @@ patches:
       metadata:
         name: kubearchive-api-server
         namespace: kubearchive
+        annotations:
+          ignore-check.kube-linter.io/no-anti-affinity: "not needed"
       spec:
+        replicas: 2
         template:
           spec:
             containers:


### PR DESCRIPTION
We saw that with 30 concurrent users firing requests non-stop to the KubeArchive API errors started to appear. To prevent that we will increase replicas to 2 and test again, errors should appear later.