### PR TITLE
kfluxinfra-2359 - Add instance with bigger disk to 'stone-prod-p02'

### DIFF
--- a/components/kueue/production/stone-prod-p02/queue-config/cluster-queue.yaml
+++ b/components/kueue/production/stone-prod-p02/queue-config/cluster-queue.yaml
@@ -84,6 +84,8 @@ spec:
         nominalQuota: '250'
   - coveredResources:
     - linux-d160-m8xlarge-arm64
+    - linux-d320-c4xlarge-amd64
+    - linux-d320-c4xlarge-arm64
     - linux-extra-fast-amd64
     - linux-fast-amd64
     - linux-g6xlarge-amd64
@@ -97,12 +99,14 @@ spec:
     - linux-mlarge-arm64
     - linux-mxlarge-amd64
     - linux-mxlarge-arm64
-    - linux-ppc64le
-    - linux-root-amd64
     flavors:
     - name: platform-group-2
       resources:
       - name: linux-d160-m8xlarge-arm64
+        nominalQuota: '250'
+      - name: linux-d320-c4xlarge-amd64
+        nominalQuota: '250'
+      - name: linux-d320-c4xlarge-arm64
         nominalQuota: '250'
       - name: linux-extra-fast-amd64
         nominalQuota: '250'
@@ -130,11 +134,9 @@ spec:
         nominalQuota: '250'
       - name: linux-mxlarge-arm64
         nominalQuota: '250'
-      - name: linux-ppc64le
-        nominalQuota: '40'
-      - name: linux-root-amd64
-        nominalQuota: '250'
   - coveredResources:
+    - linux-ppc64le
+    - linux-root-amd64
     - linux-root-arm64
     - linux-s390x
     - linux-x86-64
@@ -143,6 +145,10 @@ spec:
     flavors:
     - name: platform-group-3
       resources:
+      - name: linux-ppc64le
+        nominalQuota: '40'
+      - name: linux-root-amd64
+        nominalQuota: '250'
       - name: linux-root-arm64
         nominalQuota: '250'
       - name: linux-s390x

--- a/components/multi-platform-controller/production-downstream/stone-prod-p02/host-values.yaml
+++ b/components/multi-platform-controller/production-downstream/stone-prod-p02/host-values.yaml
@@ -50,6 +50,10 @@ dynamicConfigs:
 
   linux-d160-m8xlarge-amd64: {}
 
+  linux-d320-c4xlarge-amd64: {}
+
+  linux-d320-c4xlarge-arm64: {}
+
   linux-fast-amd64: {}
 
   linux-extra-fast-amd64: {}
@@ -178,36 +182,36 @@ dynamicConfigs:
     user-data: |-
       Content-Type: multipart/mixed; boundary="//"
       MIME-Version: 1.0
-      
+
       --//
       Content-Type: text/cloud-config; charset="us-ascii"
       MIME-Version: 1.0
       Content-Transfer-Encoding: 7bit
       Content-Disposition: attachment; filename="cloud-config.txt"
-      
+
       #cloud-config
       cloud_final_modules:
         - [scripts-user, always]
-      
+
       --//
       Content-Type: text/x-shellscript; charset="us-ascii"
       MIME-Version: 1.0
       Content-Transfer-Encoding: 7bit
       Content-Disposition: attachment; filename="userdata.txt"
-      
+
       #!/bin/bash -ex
-      
+
       # Format and mount NVMe disk
       mkfs -t xfs /dev/nvme1n1
       mount /dev/nvme1n1 /home
-      
+
       # Create required directories
       mkdir -p /home/var-lib-containers /var/lib/containers /home/var-tmp /var/tmp /home/ec2-user/.ssh
-      
+
       # Setup bind mounts
       mount --bind /home/var-lib-containers /var/lib/containers
       mount --bind /home/var-tmp /var/tmp
-      
+
       # Configure ec2-user SSH access
       chown -R ec2-user /home/ec2-user
       sed -n 's,.*\(ssh-.*\s\),\1,p' /root/.ssh/authorized_keys > /home/ec2-user/.ssh/authorized_keys
@@ -215,7 +219,7 @@ dynamicConfigs:
       chmod 600 /home/ec2-user/.ssh/authorized_keys
       chmod 700 /home/ec2-user/.ssh
       restorecon -r /home/ec2-user
-      
+
       --//--
 
 # Static hosts configuration


### PR DESCRIPTION
As part of the investigation of a user ticket where the VM seems to have run out of space while building [1],one of the agreed debug actions is to provide a VM with bigger disk to see if this fixes their problem. If it does, we would probably create a new instance with this amount of disk space but in a type m instance, as they're using now.

[1] https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1759754081471249?thread_ts=1759330105.097669&cid=C04PZ7H0VA8