### PR TITLE
has: use production overlays in production clusters

### DIFF
--- a/argo-cd-apps/overlays/konflux-public-production/kustomization.yaml
+++ b/argo-cd-apps/overlays/konflux-public-production/kustomization.yaml
@@ -36,6 +36,7 @@ patches:
       kind: ApplicationSet
       version: v1alpha1
       name: has
+  - path: production-overlay-patch.yaml
     target:
       kind: ApplicationSet
       version: v1alpha1

--- a/argo-cd-apps/overlays/production-downstream/kustomization.yaml
+++ b/argo-cd-apps/overlays/production-downstream/kustomization.yaml
@@ -36,6 +36,7 @@ patches:
       kind: ApplicationSet
       version: v1alpha1
       name: has
+  - path: production-overlay-patch.yaml
     target:
       kind: ApplicationSet
       version: v1alpha1


### PR DESCRIPTION
The overlays defining public and private production were broken, resulting in the staging manifests for `has` getting applied to the produciton clusters.  Fix the overlay manifests so that has uses their production overlays on both the public and private production clusters.

<details><summary>Diff between staging and production manifests for has</summary>
<p>

```diff
--- /tmp/a.yaml	2025-10-06 14:21:52.938691119 -0500
+++ /tmp/b.yaml	2025-10-06 14:21:55.857667133 -0500
@@ -76,19 +76,6 @@ rules:
   - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: has-exec
-  namespace: application-service
-rules:
-- apiGroups:
-  - ""
-  resources:
-  - pods/exec
-  verbs:
-  - create
----
-apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
@@ -550,20 +537,6 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: has-exec
-  namespace: application-service
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: has-exec
-subjects:
-- apiGroup: rbac.authorization.k8s.io
-  kind: Group
-  name: konflux-integration
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
   name: view-konflux-integration-runner
   namespace: application-service
 roleRef:
@@ -663,7 +636,7 @@ metadata:
 ---
 apiVersion: v1
 data:
-  ENVIRONMENT: staging
+  ENVIRONMENT: production
 kind: ConfigMap
 metadata:
   name: application-service-feature-flag-config
@@ -671,7 +644,7 @@ metadata:
 ---
 apiVersion: v1
 data:
-  GITHUB_ORG: redhat-appstudio-appdata-staging
+  GITHUB_ORG: redhat-appstudio-appdata
 kind: ConfigMap
 metadata:
   name: application-service-github-config
@@ -885,7 +858,7 @@ metadata:
 spec:
   dataFrom:
   - extract:
-      key: staging/has/github-token
+      key: production/has/github-token
   refreshInterval: 1h
   secretStoreRef:
     kind: ClusterSecretStore

```

</p>
</details> 

Part of [KFLUXINFRA-2285](https://issues.redhat.com/browse/KFLUXINFRA-2285).