### PR TITLE
KFLUXINFRA-2310: Add GPU Profile for all the Environments

### DIFF
--- a/components/kueue/production/kflux-ocp-p01/queue-config/cluster-queue.yaml
+++ b/components/kueue/production/kflux-ocp-p01/queue-config/cluster-queue.yaml
@@ -91,7 +91,7 @@ spec:
     - linux-d160-m8xlarge-arm64
     - linux-d320-c4xlarge-amd64
     - linux-d320-c4xlarge-arm64
-    - linux-g6xlarge-amd64
+    - linux-g64xlarge-amd64
     - linux-m2xlarge-amd64
     - linux-m2xlarge-arm64
     - linux-m4xlarge-amd64
@@ -118,7 +118,7 @@ spec:
         nominalQuota: '250'
       - name: linux-d320-c4xlarge-arm64
         nominalQuota: '250'
-      - name: linux-g6xlarge-amd64
+      - name: linux-g64xlarge-amd64
         nominalQuota: '250'
       - name: linux-m2xlarge-amd64
         nominalQuota: '250'

--- a/components/kueue/production/kflux-osp-p01/queue-config/cluster-queue.yaml
+++ b/components/kueue/production/kflux-osp-p01/queue-config/cluster-queue.yaml
@@ -44,7 +44,7 @@ spec:
     - linux-cxlarge-arm64
     - linux-extra-fast-amd64
     - linux-fast-amd64
-    - linux-g6xlarge-amd64
+    - linux-g64xlarge-amd64
     - linux-m2xlarge-amd64
     - linux-m2xlarge-arm64
     flavors:
@@ -76,7 +76,7 @@ spec:
         nominalQuota: '250'
       - name: linux-fast-amd64
         nominalQuota: '250'
-      - name: linux-g6xlarge-amd64
+      - name: linux-g64xlarge-amd64
         nominalQuota: '250'
       - name: linux-m2xlarge-amd64
         nominalQuota: '250'

--- a/components/kueue/production/kflux-prd-rh02/queue-config/cluster-queue.yaml
+++ b/components/kueue/production/kflux-prd-rh02/queue-config/cluster-queue.yaml
@@ -86,7 +86,7 @@ spec:
     - linux-d160-m8xlarge-arm64
     - linux-extra-fast-amd64
     - linux-fast-amd64
-    - linux-g6xlarge-amd64
+    - linux-g64xlarge-amd64
     - linux-m2xlarge-amd64
     - linux-m2xlarge-arm64
     - linux-m4xlarge-amd64
@@ -108,7 +108,7 @@ spec:
         nominalQuota: '250'
       - name: linux-fast-amd64
         nominalQuota: '250'
-      - name: linux-g6xlarge-amd64
+      - name: linux-g64xlarge-amd64
         nominalQuota: '250'
       - name: linux-m2xlarge-amd64
         nominalQuota: '250'

--- a/components/kueue/production/kflux-rhel-p01/queue-config/cluster-queue.yaml
+++ b/components/kueue/production/kflux-rhel-p01/queue-config/cluster-queue.yaml
@@ -90,7 +90,7 @@ spec:
     - linux-d160-mxlarge-arm64
     - linux-extra-fast-amd64
     - linux-fast-amd64
-    - linux-g6xlarge-amd64
+    - linux-g64xlarge-amd64
     - linux-large-s390x
     - linux-m2xlarge-amd64
     - linux-m2xlarge-arm64
@@ -116,7 +116,7 @@ spec:
         nominalQuota: '250'
       - name: linux-fast-amd64
         nominalQuota: '250'
-      - name: linux-g6xlarge-amd64
+      - name: linux-g64xlarge-amd64
         nominalQuota: '250'
       - name: linux-large-s390x
         nominalQuota: '12'

--- a/components/kueue/production/stone-prd-rh01/queue-config/cluster-queue.yaml
+++ b/components/kueue/production/stone-prd-rh01/queue-config/cluster-queue.yaml
@@ -86,7 +86,7 @@ spec:
     - linux-d160-m8xlarge-arm64
     - linux-extra-fast-amd64
     - linux-fast-amd64
-    - linux-g6xlarge-amd64
+    - linux-g64xlarge-amd64
     - linux-m2xlarge-amd64
     - linux-m2xlarge-arm64
     - linux-m4xlarge-amd64
@@ -108,7 +108,7 @@ spec:
         nominalQuota: '250'
       - name: linux-fast-amd64
         nominalQuota: '250'
-      - name: linux-g6xlarge-amd64
+      - name: linux-g64xlarge-amd64
         nominalQuota: '250'
       - name: linux-m2xlarge-amd64
         nominalQuota: '250'

--- a/components/kueue/production/stone-prod-p01/queue-config/cluster-queue.yaml
+++ b/components/kueue/production/stone-prod-p01/queue-config/cluster-queue.yaml
@@ -84,7 +84,7 @@ spec:
         nominalQuota: '250'
   - coveredResources:
     - linux-d160-m8xlarge-arm64
-    - linux-g6xlarge-amd64
+    - linux-g64xlarge-amd64
     - linux-m2xlarge-amd64
     - linux-m2xlarge-arm64
     - linux-m4xlarge-amd64
@@ -104,7 +104,7 @@ spec:
       resources:
       - name: linux-d160-m8xlarge-arm64
         nominalQuota: '250'
-      - name: linux-g6xlarge-amd64
+      - name: linux-g64xlarge-amd64
         nominalQuota: '250'
       - name: linux-m2xlarge-amd64
         nominalQuota: '250'

--- a/components/kueue/production/stone-prod-p02/queue-config/cluster-queue.yaml
+++ b/components/kueue/production/stone-prod-p02/queue-config/cluster-queue.yaml
@@ -88,7 +88,7 @@ spec:
     - linux-d320-c4xlarge-arm64
     - linux-extra-fast-amd64
     - linux-fast-amd64
-    - linux-g6xlarge-amd64
+    - linux-g64xlarge-amd64
     - linux-m2xlarge-amd64
     - linux-m2xlarge-arm64
     - linux-m4xlarge-amd64
@@ -112,7 +112,7 @@ spec:
         nominalQuota: '250'
       - name: linux-fast-amd64
         nominalQuota: '250'
-      - name: linux-g6xlarge-amd64
+      - name: linux-g64xlarge-amd64
         nominalQuota: '250'
       - name: linux-m2xlarge-amd64
         nominalQuota: '250'

--- a/components/kueue/staging/stone-stage-p01/queue-config/cluster-queue.yaml
+++ b/components/kueue/staging/stone-stage-p01/queue-config/cluster-queue.yaml
@@ -51,7 +51,7 @@ spec:
     - linux-c8xlarge-arm64
     - linux-cxlarge-amd64
     - linux-cxlarge-arm64
-    - linux-g6xlarge-amd64
+    - linux-g64xlarge-amd64
     - linux-m2xlarge-amd64
     - linux-m2xlarge-arm64
     - linux-m4xlarge-amd64
@@ -81,7 +81,7 @@ spec:
         nominalQuota: '250'
       - name: linux-cxlarge-arm64
         nominalQuota: '250'
-      - name: linux-g6xlarge-amd64
+      - name: linux-g64xlarge-amd64
         nominalQuota: '250'
       - name: linux-m2xlarge-amd64
         nominalQuota: '250'

--- a/components/kueue/staging/stone-stg-rh01/queue-config/cluster-queue.yaml
+++ b/components/kueue/staging/stone-stg-rh01/queue-config/cluster-queue.yaml
@@ -52,10 +52,10 @@ spec:
     - linux-cxlarge-amd64
     - linux-cxlarge-arm64
     - linux-g64xlarge-amd64
-    - linux-g6xlarge-amd64
     - linux-m2xlarge-amd64
     - linux-m2xlarge-arm64
     - linux-m4xlarge-amd64
+    - linux-m4xlarge-arm64
     flavors:
     - name: platform-group-1
       resources:
@@ -83,16 +83,15 @@ spec:
         nominalQuota: '250'
       - name: linux-g64xlarge-amd64
         nominalQuota: '250'
-      - name: linux-g6xlarge-amd64
-        nominalQuota: '250'
       - name: linux-m2xlarge-amd64
         nominalQuota: '250'
       - name: linux-m2xlarge-arm64
         nominalQuota: '250'
       - name: linux-m4xlarge-amd64
         nominalQuota: '250'
+      - name: linux-m4xlarge-arm64
+        nominalQuota: '250'
   - coveredResources:
-    - linux-m4xlarge-arm64
     - linux-m8xlarge-amd64
     - linux-m8xlarge-arm64
     - linux-mlarge-amd64
@@ -109,8 +108,6 @@ spec:
     flavors:
     - name: platform-group-2
       resources:
-      - name: linux-m4xlarge-arm64
-        nominalQuota: '250'
       - name: linux-m8xlarge-amd64
         nominalQuota: '250'
       - name: linux-m8xlarge-arm64

--- a/components/multi-platform-controller/production-downstream/kflux-ocp-p01/host-values.yaml
+++ b/components/multi-platform-controller/production-downstream/kflux-ocp-p01/host-values.yaml
@@ -127,9 +127,9 @@ dynamicConfigs:
 
   linux-g4xlarge-amd64: {}
 
-  linux-g6xlarge-amd64:
-    ami: "ami-0ad6c6b0ac6c36199"
-    user-data: |-
+  linux-g64xlarge-amd64:
+    ami: "ami-0133ba5e6e6d57a02"
+    user-data: |
       Content-Type: multipart/mixed; boundary="//"
       MIME-Version: 1.0
 
@@ -156,7 +156,7 @@ dynamicConfigs:
       mount /dev/nvme1n1 /home
 
       # Create required directories
-      mkdir -p /home/var-lib-containers /var/lib/containers /home/var-tmp /var/tmp /home/ec2-user/.ssh /etc/cdi
+      mkdir -p /home/var-lib-containers /var/lib/containers /home/var-tmp /var/tmp /home/ec2-user/.ssh
 
       # Setup bind mounts
       mount --bind /home/var-lib-containers /var/lib/containers
@@ -172,8 +172,11 @@ dynamicConfigs:
       restorecon -r /home/ec2-user
 
       # GPU setup
-      chmod a+rwx /etc/cdi
+      mkdir -p /etc/cdi /var/run/cdi
+      chmod a+rwx /etc/cdi /var/run/cdi
+      setsebool container_use_devices 1 2>/dev/null || true
       nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml
+      chmod a+rw /etc/cdi/nvidia.yaml
       --//--
 
   linux-root-arm64:

--- a/components/multi-platform-controller/production-downstream/kflux-osp-p01/host-values.yaml
+++ b/components/multi-platform-controller/production-downstream/kflux-osp-p01/host-values.yaml
@@ -101,8 +101,8 @@ dynamicConfigs:
 
   linux-g4xlarge-amd64: {}
 
-  linux-g6xlarge-amd64:
-    ami: "ami-0ad6c6b0ac6c36199"
+  linux-g64xlarge-amd64:
+    ami: "ami-0133ba5e6e6d57a02"
     user-data: |
       Content-Type: multipart/mixed; boundary="//"
       MIME-Version: 1.0
@@ -130,7 +130,7 @@ dynamicConfigs:
       mount /dev/nvme1n1 /home
 
       # Create required directories
-      mkdir -p /home/var-lib-containers /var/lib/containers /home/var-tmp /var/tmp /home/ec2-user/.ssh /etc/cdi
+      mkdir -p /home/var-lib-containers /var/lib/containers /home/var-tmp /var/tmp /home/ec2-user/.ssh
 
       # Setup bind mounts
       mount --bind /home/var-lib-containers /var/lib/containers
@@ -146,8 +146,11 @@ dynamicConfigs:
       restorecon -r /home/ec2-user
 
       # GPU setup
-      chmod a+rwx /etc/cdi
+      mkdir -p /etc/cdi /var/run/cdi
+      chmod a+rwx /etc/cdi /var/run/cdi
+      setsebool container_use_devices 1 2>/dev/null || true
       nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml
+      chmod a+rw /etc/cdi/nvidia.yaml
       --//--
 
   linux-root-arm64:

--- a/components/multi-platform-controller/production-downstream/kflux-rhel-p01/host-values.yaml
+++ b/components/multi-platform-controller/production-downstream/kflux-rhel-p01/host-values.yaml
@@ -131,8 +131,8 @@ dynamicConfigs:
 
   linux-g4xlarge-amd64: {}
 
-  linux-g6xlarge-amd64:
-    ami: "ami-0ad6c6b0ac6c36199"
+  linux-g64xlarge-amd64:
+    ami: "ami-0133ba5e6e6d57a02"
     user-data: |
       Content-Type: multipart/mixed; boundary="//"
       MIME-Version: 1.0
@@ -160,7 +160,7 @@ dynamicConfigs:
       mount /dev/nvme1n1 /home
 
       # Create required directories
-      mkdir -p /home/var-lib-containers /var/lib/containers /home/var-tmp /var/tmp /home/ec2-user/.ssh /etc/cdi
+      mkdir -p /home/var-lib-containers /var/lib/containers /home/var-tmp /var/tmp /home/ec2-user/.ssh
 
       # Setup bind mounts
       mount --bind /home/var-lib-containers /var/lib/containers
@@ -176,8 +176,11 @@ dynamicConfigs:
       restorecon -r /home/ec2-user
 
       # GPU setup
-      chmod a+rwx /etc/cdi
+      mkdir -p /etc/cdi /var/run/cdi
+      chmod a+rwx /etc/cdi /var/run/cdi
+      setsebool container_use_devices 1 2>/dev/null || true
       nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml
+      chmod a+rw /etc/cdi/nvidia.yaml
       --//--
 
   linux-root-arm64:

--- a/components/multi-platform-controller/production-downstream/stone-prod-p01/host-values.yaml
+++ b/components/multi-platform-controller/production-downstream/stone-prod-p01/host-values.yaml
@@ -112,8 +112,8 @@ dynamicConfigs:
 
   linux-g4xlarge-amd64: {}
 
-  linux-g6xlarge-amd64:
-    ami: "ami-0ad6c6b0ac6c36199"
+  linux-g64xlarge-amd64:
+    ami: "ami-0133ba5e6e6d57a02"
     user-data: |
       Content-Type: multipart/mixed; boundary="//"
       MIME-Version: 1.0
@@ -141,7 +141,7 @@ dynamicConfigs:
       mount /dev/nvme1n1 /home
 
       # Create required directories
-      mkdir -p /home/var-lib-containers /var/lib/containers /home/var-tmp /var/tmp /home/ec2-user/.ssh /etc/cdi
+      mkdir -p /home/var-lib-containers /var/lib/containers /home/var-tmp /var/tmp /home/ec2-user/.ssh
 
       # Setup bind mounts
       mount --bind /home/var-lib-containers /var/lib/containers
@@ -157,8 +157,11 @@ dynamicConfigs:
       restorecon -r /home/ec2-user
 
       # GPU setup
-      chmod a+rwx /etc/cdi
+      mkdir -p /etc/cdi /var/run/cdi
+      chmod a+rwx /etc/cdi /var/run/cdi
+      setsebool container_use_devices 1 2>/dev/null || true
       nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml
+      chmod a+rw /etc/cdi/nvidia.yaml
       --//--
 
   linux-root-arm64:

--- a/components/multi-platform-controller/production-downstream/stone-prod-p02/host-values.yaml
+++ b/components/multi-platform-controller/production-downstream/stone-prod-p02/host-values.yaml
@@ -120,8 +120,8 @@ dynamicConfigs:
 
   linux-g4xlarge-amd64: {}
 
-  linux-g6xlarge-amd64:
-    ami: "ami-0ad6c6b0ac6c36199"
+  linux-g64xlarge-amd64:
+    ami: "ami-0133ba5e6e6d57a02"
     user-data: |
       Content-Type: multipart/mixed; boundary="//"
       MIME-Version: 1.0
@@ -149,7 +149,7 @@ dynamicConfigs:
       mount /dev/nvme1n1 /home
 
       # Create required directories
-      mkdir -p /home/var-lib-containers /var/lib/containers /home/var-tmp /var/tmp /home/ec2-user/.ssh /etc/cdi
+      mkdir -p /home/var-lib-containers /var/lib/containers /home/var-tmp /var/tmp /home/ec2-user/.ssh
 
       # Setup bind mounts
       mount --bind /home/var-lib-containers /var/lib/containers
@@ -165,8 +165,11 @@ dynamicConfigs:
       restorecon -r /home/ec2-user
 
       # GPU setup
-      chmod a+rwx /etc/cdi
+      mkdir -p /etc/cdi /var/run/cdi
+      chmod a+rwx /etc/cdi /var/run/cdi
+      setsebool container_use_devices 1 2>/dev/null || true
       nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml
+      chmod a+rw /etc/cdi/nvidia.yaml
       --//--
 
   linux-root-arm64:

--- a/components/multi-platform-controller/production/kflux-prd-rh02/host-values.yaml
+++ b/components/multi-platform-controller/production/kflux-prd-rh02/host-values.yaml
@@ -113,8 +113,8 @@ dynamicConfigs:
 
   linux-g4xlarge-amd64: {}
 
-  linux-g6xlarge-amd64:
-    ami: "ami-0ad6c6b0ac6c36199"
+  linux-g64xlarge-amd64:
+    ami: "ami-0133ba5e6e6d57a02"
     user-data: |
       Content-Type: multipart/mixed; boundary="//"
       MIME-Version: 1.0
@@ -142,7 +142,7 @@ dynamicConfigs:
       mount /dev/nvme1n1 /home
 
       # Create required directories
-      mkdir -p /home/var-lib-containers /var/lib/containers /home/var-tmp /var/tmp /home/ec2-user/.ssh /etc/cdi
+      mkdir -p /home/var-lib-containers /var/lib/containers /home/var-tmp /var/tmp /home/ec2-user/.ssh
 
       # Setup bind mounts
       mount --bind /home/var-lib-containers /var/lib/containers
@@ -158,8 +158,11 @@ dynamicConfigs:
       restorecon -r /home/ec2-user
 
       # GPU setup
-      chmod a+rwx /etc/cdi
+      mkdir -p /etc/cdi /var/run/cdi
+      chmod a+rwx /etc/cdi /var/run/cdi
+      setsebool container_use_devices 1 2>/dev/null || true
       nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml
+      chmod a+rw /etc/cdi/nvidia.yaml
       --//--
 
   linux-root-arm64:

--- a/components/multi-platform-controller/production/kflux-prd-rh03/host-values.yaml
+++ b/components/multi-platform-controller/production/kflux-prd-rh03/host-values.yaml
@@ -141,7 +141,7 @@ dynamicConfigs:
       mount /dev/nvme1n1 /home
 
       # Create required directories
-      mkdir -p /home/var-lib-containers /var/lib/containers /home/var-tmp /var/tmp /home/ec2-user/.ssh /etc/cdi /var/run/cdi
+      mkdir -p /home/var-lib-containers /var/lib/containers /home/var-tmp /var/tmp /home/ec2-user/.ssh
 
       # Setup bind mounts
       mount --bind /home/var-lib-containers /var/lib/containers
@@ -157,6 +157,7 @@ dynamicConfigs:
       restorecon -r /home/ec2-user
 
       # GPU setup
+      mkdir -p /etc/cdi /var/run/cdi
       chmod a+rwx /etc/cdi /var/run/cdi
       setsebool container_use_devices 1 2>/dev/null || true
       nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml

--- a/components/multi-platform-controller/production/stone-prd-rh01/host-values.yaml
+++ b/components/multi-platform-controller/production/stone-prd-rh01/host-values.yaml
@@ -113,8 +113,8 @@ dynamicConfigs:
 
   linux-g4xlarge-amd64: {}
 
-  linux-g6xlarge-amd64:
-    ami: "ami-0ad6c6b0ac6c36199"
+  linux-g64xlarge-amd64:
+    ami: "ami-0133ba5e6e6d57a02"
     user-data: |
       Content-Type: multipart/mixed; boundary="//"
       MIME-Version: 1.0
@@ -127,7 +127,7 @@ dynamicConfigs:
 
       #cloud-config
       cloud_final_modules:
-        - scripts-user
+        - [scripts-user, always]
 
       --//
       Content-Type: text/x-shellscript; charset="us-ascii"
@@ -142,7 +142,7 @@ dynamicConfigs:
       mount /dev/nvme1n1 /home
 
       # Create required directories
-      mkdir -p /home/var-lib-containers /var/lib/containers /home/var-tmp /var/tmp /home/ec2-user/.ssh /etc/cdi
+      mkdir -p /home/var-lib-containers /var/lib/containers /home/var-tmp /var/tmp /home/ec2-user/.ssh
 
       # Setup bind mounts
       mount --bind /home/var-lib-containers /var/lib/containers
@@ -158,8 +158,11 @@ dynamicConfigs:
       restorecon -r /home/ec2-user
 
       # GPU setup
-      chmod a+rwx /etc/cdi
+      mkdir -p /etc/cdi /var/run/cdi
+      chmod a+rwx /etc/cdi /var/run/cdi
+      setsebool container_use_devices 1 2>/dev/null || true
       nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml
+      chmod a+rw /etc/cdi/nvidia.yaml
       --//--
 
   linux-root-arm64:

--- a/components/multi-platform-controller/staging-downstream/host-values.yaml
+++ b/components/multi-platform-controller/staging-downstream/host-values.yaml
@@ -111,8 +111,8 @@ dynamicConfigs:
 
   linux-g4xlarge-amd64: {}
 
-  linux-g6xlarge-amd64:
-    ami: "ami-0ad6c6b0ac6c36199"
+  linux-g64xlarge-amd64:
+    ami: "ami-0133ba5e6e6d57a02"
     user-data: |
       Content-Type: multipart/mixed; boundary="//"
       MIME-Version: 1.0
@@ -140,7 +140,7 @@ dynamicConfigs:
       mount /dev/nvme1n1 /home
 
       # Create required directories
-      mkdir -p /home/var-lib-containers /var/lib/containers /home/var-tmp /var/tmp /home/ec2-user/.ssh /etc/cdi
+      mkdir -p /home/var-lib-containers /var/lib/containers /home/var-tmp /var/tmp /home/ec2-user/.ssh
 
       # Setup bind mounts
       mount --bind /home/var-lib-containers /var/lib/containers
@@ -156,8 +156,11 @@ dynamicConfigs:
       restorecon -r /home/ec2-user
 
       # GPU setup
-      chmod a+rwx /etc/cdi
+      mkdir -p /etc/cdi /var/run/cdi
+      chmod a+rwx /etc/cdi /var/run/cdi
+      setsebool container_use_devices 1 2>/dev/null || true
       nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml
+      chmod a+rw /etc/cdi/nvidia.yaml
       --//--
 
   linux-root-arm64:

--- a/components/multi-platform-controller/staging/host-values.yaml
+++ b/components/multi-platform-controller/staging/host-values.yaml
@@ -109,10 +109,8 @@ dynamicConfigs:
 
   linux-c8xlarge-amd64: {}
 
-  linux-g64xlarge-amd64: {}
-
-  linux-g6xlarge-amd64:
-    ami: "ami-0ad6c6b0ac6c36199"
+  linux-g64xlarge-amd64:
+    ami: "ami-0133ba5e6e6d57a02"
     user-data: |
       Content-Type: multipart/mixed; boundary="//"
       MIME-Version: 1.0
@@ -140,7 +138,7 @@ dynamicConfigs:
       mount /dev/nvme1n1 /home
 
       # Create required directories
-      mkdir -p /home/var-lib-containers /var/lib/containers /home/var-tmp /var/tmp /home/ec2-user/.ssh /etc/cdi
+      mkdir -p /home/var-lib-containers /var/lib/containers /home/var-tmp /var/tmp /home/ec2-user/.ssh
 
       # Setup bind mounts
       mount --bind /home/var-lib-containers /var/lib/containers
@@ -156,8 +154,11 @@ dynamicConfigs:
       restorecon -r /home/ec2-user
 
       # GPU setup
-      chmod a+rwx /etc/cdi
+      mkdir -p /etc/cdi /var/run/cdi
+      chmod a+rwx /etc/cdi /var/run/cdi
+      setsebool container_use_devices 1 2>/dev/null || true
       nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml
+      chmod a+rw /etc/cdi/nvidia.yaml
       --//--
 
   linux-root-arm64:


### PR DESCRIPTION
This commit will add **linux-g64xlarge-amd64** profile to all the Konflux Environment as well as add a command 

_mkdir -p /etc/cdi /var/run/cdi_