### PR TITLE
Revert "KubeArchive: using watchers instead of informers"

### DIFF
--- a/components/kubearchive/development/kubearchive.yaml
+++ b/components/kubearchive/development/kubearchive.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: namespace
     app.kubernetes.io/name: kubearchive
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: watchers-1d5d067
+    app.kubernetes.io/version: no-eventing-1a13a90
   name: kubearchive
 ---
 apiVersion: apiextensions.k8s.io/v1
@@ -601,7 +601,7 @@ metadata:
     app.kubernetes.io/component: api-server
     app.kubernetes.io/name: kubearchive-api-server
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: watchers-1d5d067
+    app.kubernetes.io/version: no-eventing-1a13a90
   name: kubearchive-api-server
   namespace: kubearchive
 ---
@@ -612,7 +612,7 @@ metadata:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: kubearchive-vacuum
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: watchers-1d5d067
+    app.kubernetes.io/version: no-eventing-1a13a90
   name: kubearchive-cluster-vacuum
   namespace: kubearchive
 ---
@@ -623,7 +623,7 @@ metadata:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: kubearchive-operator
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: watchers-1d5d067
+    app.kubernetes.io/version: no-eventing-1a13a90
   name: kubearchive-operator
   namespace: kubearchive
 ---
@@ -634,7 +634,7 @@ metadata:
     app.kubernetes.io/component: sink
     app.kubernetes.io/name: kubearchive-sink
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: watchers-1d5d067
+    app.kubernetes.io/version: no-eventing-1a13a90
   name: kubearchive-sink
   namespace: kubearchive
 ---
@@ -645,7 +645,7 @@ metadata:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: kubearchive-vacuum
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: watchers-1d5d067
+    app.kubernetes.io/version: no-eventing-1a13a90
   name: kubearchive-cluster-vacuum
   namespace: kubearchive
 rules:
@@ -665,7 +665,7 @@ metadata:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: kubearchive-operator-leader-election
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: watchers-1d5d067
+    app.kubernetes.io/version: no-eventing-1a13a90
   name: kubearchive-operator-leader-election
   namespace: kubearchive
 rules:
@@ -708,7 +708,7 @@ metadata:
     app.kubernetes.io/component: sink
     app.kubernetes.io/name: kubearchive-sink-watch
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: watchers-1d5d067
+    app.kubernetes.io/version: no-eventing-1a13a90
   name: kubearchive-sink-watch
   namespace: kubearchive
 rules:
@@ -728,7 +728,7 @@ metadata:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: kubearchive-vacuum
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: watchers-1d5d067
+    app.kubernetes.io/version: no-eventing-1a13a90
   name: clusterkubearchiveconfig-read
 rules:
   - apiGroups:
@@ -746,7 +746,7 @@ metadata:
     app.kubernetes.io/component: api-server
     app.kubernetes.io/name: kubearchive-api-server
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: watchers-1d5d067
+    app.kubernetes.io/version: no-eventing-1a13a90
   name: kubearchive-api-server
 rules:
   - apiGroups:
@@ -764,7 +764,7 @@ metadata:
   labels:
     app.kubernetes.io/name: kubearchive-edit
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: watchers-1d5d067
+    app.kubernetes.io/version: no-eventing-1a13a90
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
   name: kubearchive-edit
 rules:
@@ -936,7 +936,7 @@ metadata:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: kubearchive-operator-config-editor
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: watchers-1d5d067
+    app.kubernetes.io/version: no-eventing-1a13a90
   name: kubearchive-operator-config-editor
 rules:
   - apiGroups:
@@ -965,7 +965,7 @@ metadata:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: kubearchive-operator-config-viewer
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: watchers-1d5d067
+    app.kubernetes.io/version: no-eventing-1a13a90
   name: kubearchive-operator-config-viewer
 rules:
   - apiGroups:
@@ -989,7 +989,7 @@ metadata:
   labels:
     app.kubernetes.io/name: kubearchive-view
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: watchers-1d5d067
+    app.kubernetes.io/version: no-eventing-1a13a90
     rbac.authorization.k8s.io/aggregate-to-view: "true"
   name: kubearchive-view
 rules:
@@ -1009,7 +1009,7 @@ metadata:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: kubearchive-vacuum
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: watchers-1d5d067
+    app.kubernetes.io/version: no-eventing-1a13a90
   name: kubearchive-cluster-vacuum
   namespace: kubearchive
 roleRef:
@@ -1028,7 +1028,7 @@ metadata:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: kubearchive-operator-leader-election
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: watchers-1d5d067
+    app.kubernetes.io/version: no-eventing-1a13a90
   name: kubearchive-operator-leader-election
   namespace: kubearchive
 roleRef:
@@ -1047,7 +1047,7 @@ metadata:
     app.kubernetes.io/component: sink
     app.kubernetes.io/name: kubearchive-sink-watch
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: watchers-1d5d067
+    app.kubernetes.io/version: no-eventing-1a13a90
   name: kubearchive-sink-watch
   namespace: kubearchive
 roleRef:
@@ -1066,7 +1066,7 @@ metadata:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: kubearchive-vacuum
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: watchers-1d5d067
+    app.kubernetes.io/version: no-eventing-1a13a90
   name: clusterkubearchiveconfig-read
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -1084,7 +1084,7 @@ metadata:
     app.kubernetes.io/component: api-server
     app.kubernetes.io/name: kubearchive-api-server
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: watchers-1d5d067
+    app.kubernetes.io/version: no-eventing-1a13a90
   name: kubearchive-api-server
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -1102,7 +1102,7 @@ metadata:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: kubearchive-operator
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: watchers-1d5d067
+    app.kubernetes.io/version: no-eventing-1a13a90
   name: kubearchive-operator
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -1121,7 +1121,7 @@ metadata:
     app.kubernetes.io/component: logging
     app.kubernetes.io/name: kubearchive-logging
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: watchers-1d5d067
+    app.kubernetes.io/version: no-eventing-1a13a90
   name: kubearchive-logging
   namespace: kubearchive
 ---
@@ -1139,7 +1139,7 @@ metadata:
     app.kubernetes.io/component: database
     app.kubernetes.io/name: kubearchive-database-credentials
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: watchers-1d5d067
+    app.kubernetes.io/version: no-eventing-1a13a90
   name: kubearchive-database-credentials
   namespace: kubearchive
 type: Opaque
@@ -1153,7 +1153,7 @@ metadata:
     app.kubernetes.io/component: logging
     app.kubernetes.io/name: kubearchive-logging
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: watchers-1d5d067
+    app.kubernetes.io/version: no-eventing-1a13a90
   name: kubearchive-logging
   namespace: kubearchive
 type: Opaque
@@ -1165,7 +1165,7 @@ metadata:
     app.kubernetes.io/component: api-server
     app.kubernetes.io/name: kubearchive-api-server
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: watchers-1d5d067
+    app.kubernetes.io/version: no-eventing-1a13a90
   name: kubearchive-api-server
   namespace: kubearchive
 spec:
@@ -1184,7 +1184,7 @@ metadata:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: kubearchive-operator-webhooks
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: watchers-1d5d067
+    app.kubernetes.io/version: no-eventing-1a13a90
   name: kubearchive-operator-webhooks
   namespace: kubearchive
 spec:
@@ -1207,7 +1207,7 @@ metadata:
     app.kubernetes.io/component: sink
     app.kubernetes.io/name: kubearchive-sink
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: watchers-1d5d067
+    app.kubernetes.io/version: no-eventing-1a13a90
   name: kubearchive-sink
   namespace: kubearchive
 spec:
@@ -1225,7 +1225,7 @@ metadata:
     app.kubernetes.io/component: api-server
     app.kubernetes.io/name: kubearchive-api-server
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: watchers-1d5d067
+    app.kubernetes.io/version: no-eventing-1a13a90
   name: kubearchive-api-server
   namespace: kubearchive
 spec:
@@ -1275,7 +1275,7 @@ spec:
           envFrom:
             - secretRef:
                 name: kubearchive-database-credentials
-          image: quay.io/kubearchive/api:watchers-1d5d067@sha256:d5a57c1e09bd41ad02f6b9d811188500dc721aee5dc6dd585791f363f9cdb995
+          image: quay.io/kubearchive/api:no-eventing-1a13a90@sha256:2b556bdf36aeb2d3aa83bac858dcaa4f410ff4237eff2457eba411e8dc9f3076
           livenessProbe:
             httpGet:
               path: /livez
@@ -1285,9 +1285,6 @@ spec:
           ports:
             - containerPort: 8081
               name: server
-              protocol: TCP
-            - containerPort: 8888
-              name: pprof
               protocol: TCP
           readinessProbe:
             httpGet:
@@ -1323,7 +1320,7 @@ metadata:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: kubearchive-operator
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: watchers-1d5d067
+    app.kubernetes.io/version: no-eventing-1a13a90
   name: kubearchive-operator
   namespace: kubearchive
 spec:
@@ -1369,7 +1366,7 @@ spec:
               valueFrom:
                 resourceFieldRef:
                   resource: limits.cpu
-          image: quay.io/kubearchive/operator:watchers-1d5d067@sha256:9d425c9e7a632cef2905baa5b56ca8c6866188286cb55e4ac67e050699d4ed72
+          image: quay.io/kubearchive/operator:no-eventing-1a13a90@sha256:8b5cf29fb25aaaa0095214ea67a7ad93f59aed5d3129c3dd84a75b1ff32b3823
           livenessProbe:
             httpGet:
               path: /healthz
@@ -1381,7 +1378,7 @@ spec:
             - containerPort: 9443
               name: webhook-server
               protocol: TCP
-            - containerPort: 8888
+            - containerPort: 8082
               name: pprof-server
               protocol: TCP
           readinessProbe:
@@ -1423,7 +1420,7 @@ metadata:
     app.kubernetes.io/component: sink
     app.kubernetes.io/name: kubearchive-sink
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: watchers-1d5d067
+    app.kubernetes.io/version: no-eventing-1a13a90
   name: kubearchive-sink
   namespace: kubearchive
 spec:
@@ -1471,7 +1468,7 @@ spec:
           envFrom:
             - secretRef:
                 name: kubearchive-database-credentials
-          image: quay.io/kubearchive/sink:watchers-1d5d067@sha256:ae23449bad321ca9a6d5b25b0ae2898029f1b4e7cff94aca9c8d203215a286ec
+          image: quay.io/kubearchive/sink:no-eventing-1a13a90@sha256:97ef2da6b1c09d13622a99e09f042195374b2a1c93b7f06f5c035d735edebe52
           livenessProbe:
             httpGet:
               path: /livez
@@ -1480,9 +1477,6 @@ spec:
           ports:
             - containerPort: 8080
               name: sink
-              protocol: TCP
-            - containerPort: 8888
-              name: pprof
               protocol: TCP
           readinessProbe:
             httpGet:
@@ -1512,7 +1506,7 @@ metadata:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: kubearchive-vacuum
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: watchers-1d5d067
+    app.kubernetes.io/version: no-eventing-1a13a90
   name: cluster-vacuum
   namespace: kubearchive
 spec:
@@ -1533,7 +1527,7 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
-              image: quay.io/kubearchive/vacuum:watchers-1d5d067@sha256:4ca3354b802e11b511fdee6586b47c4ba30b5e48a13c94e0dc42e3bfd95d1f81
+              image: quay.io/kubearchive/vacuum:no-eventing-1a13a90@sha256:94d11ead23780dd3cb1384ecc583566e3df85f8ad693a2d08055b567c841d31f
               name: vacuum
           restartPolicy: Never
           serviceAccount: kubearchive-cluster-vacuum
@@ -1547,7 +1541,7 @@ metadata:
     app.kubernetes.io/component: kubearchive
     app.kubernetes.io/name: kubearchive-schema-migration
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: watchers-1d5d067
+    app.kubernetes.io/version: no-eventing-1a13a90
   name: kubearchive-schema-migration
   namespace: kubearchive
 spec:
@@ -1569,7 +1563,7 @@ spec:
             - -c
           env:
             - name: KUBEARCHIVE_VERSION
-              value: watchers-1d5d067
+              value: no-eventing-1a13a90
             - name: MIGRATE_VERSION
               value: v4.18.3
           envFrom:
@@ -1595,7 +1589,7 @@ metadata:
     app.kubernetes.io/component: api-server
     app.kubernetes.io/name: kubearchive-api-server-certificate
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: watchers-1d5d067
+    app.kubernetes.io/version: no-eventing-1a13a90
   name: kubearchive-api-server-certificate
   namespace: kubearchive
 spec:
@@ -1629,7 +1623,7 @@ metadata:
     app.kubernetes.io/component: certs
     app.kubernetes.io/name: kubearchive-ca
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: watchers-1d5d067
+    app.kubernetes.io/version: no-eventing-1a13a90
   name: kubearchive-ca
   namespace: kubearchive
 spec:
@@ -1651,7 +1645,7 @@ metadata:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: kubearchive-operator-certificate
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: watchers-1d5d067
+    app.kubernetes.io/version: no-eventing-1a13a90
   name: kubearchive-operator-certificate
   namespace: kubearchive
 spec:
@@ -1670,7 +1664,7 @@ metadata:
     app.kubernetes.io/component: certs
     app.kubernetes.io/name: kubearchive
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: watchers-1d5d067
+    app.kubernetes.io/version: no-eventing-1a13a90
   name: kubearchive
   namespace: kubearchive
 spec:
@@ -1684,7 +1678,7 @@ metadata:
     app.kubernetes.io/component: certs
     app.kubernetes.io/name: kubearchive-ca
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: watchers-1d5d067
+    app.kubernetes.io/version: no-eventing-1a13a90
   name: kubearchive-ca
   namespace: kubearchive
 spec:
@@ -1699,7 +1693,7 @@ metadata:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: kubearchive-mutating-webhook-configuration
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: watchers-1d5d067
+    app.kubernetes.io/version: no-eventing-1a13a90
   name: kubearchive-mutating-webhook-configuration
 webhooks:
   - admissionReviewVersions:
@@ -1812,7 +1806,7 @@ metadata:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: kubearchive-validating-webhook-configuration
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: watchers-1d5d067
+    app.kubernetes.io/version: no-eventing-1a13a90
   name: kubearchive-validating-webhook-configuration
 webhooks:
   - admissionReviewVersions:


### PR DESCRIPTION
Reverts redhat-appstudio/infra-deployments#8475 as the implementation went crazy logging some issues. I'm not sure what is happening but it is logging 72k lines per minute, so I will revert it.