### PR TITLE
KubeArchive: debug watchers errors

### DIFF
--- a/components/kubearchive/development/kubearchive.yaml
+++ b/components/kubearchive/development/kubearchive.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: namespace
     app.kubernetes.io/name: kubearchive
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: watchers-1d5d067
+    app.kubernetes.io/version: watchers-93d8a87
   name: kubearchive
 ---
 apiVersion: apiextensions.k8s.io/v1
@@ -601,7 +601,7 @@ metadata:
     app.kubernetes.io/component: api-server
     app.kubernetes.io/name: kubearchive-api-server
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: watchers-1d5d067
+    app.kubernetes.io/version: watchers-93d8a87
   name: kubearchive-api-server
   namespace: kubearchive
 ---
@@ -612,7 +612,7 @@ metadata:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: kubearchive-vacuum
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: watchers-1d5d067
+    app.kubernetes.io/version: watchers-93d8a87
   name: kubearchive-cluster-vacuum
   namespace: kubearchive
 ---
@@ -623,7 +623,7 @@ metadata:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: kubearchive-operator
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: watchers-1d5d067
+    app.kubernetes.io/version: watchers-93d8a87
   name: kubearchive-operator
   namespace: kubearchive
 ---
@@ -634,7 +634,7 @@ metadata:
     app.kubernetes.io/component: sink
     app.kubernetes.io/name: kubearchive-sink
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: watchers-1d5d067
+    app.kubernetes.io/version: watchers-93d8a87
   name: kubearchive-sink
   namespace: kubearchive
 ---
@@ -645,7 +645,7 @@ metadata:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: kubearchive-vacuum
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: watchers-1d5d067
+    app.kubernetes.io/version: watchers-93d8a87
   name: kubearchive-cluster-vacuum
   namespace: kubearchive
 rules:
@@ -665,7 +665,7 @@ metadata:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: kubearchive-operator-leader-election
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: watchers-1d5d067
+    app.kubernetes.io/version: watchers-93d8a87
   name: kubearchive-operator-leader-election
   namespace: kubearchive
 rules:
@@ -708,7 +708,7 @@ metadata:
     app.kubernetes.io/component: sink
     app.kubernetes.io/name: kubearchive-sink-watch
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: watchers-1d5d067
+    app.kubernetes.io/version: watchers-93d8a87
   name: kubearchive-sink-watch
   namespace: kubearchive
 rules:
@@ -728,7 +728,7 @@ metadata:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: kubearchive-vacuum
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: watchers-1d5d067
+    app.kubernetes.io/version: watchers-93d8a87
   name: clusterkubearchiveconfig-read
 rules:
   - apiGroups:
@@ -746,7 +746,7 @@ metadata:
     app.kubernetes.io/component: api-server
     app.kubernetes.io/name: kubearchive-api-server
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: watchers-1d5d067
+    app.kubernetes.io/version: watchers-93d8a87
   name: kubearchive-api-server
 rules:
   - apiGroups:
@@ -764,7 +764,7 @@ metadata:
   labels:
     app.kubernetes.io/name: kubearchive-edit
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: watchers-1d5d067
+    app.kubernetes.io/version: watchers-93d8a87
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
   name: kubearchive-edit
 rules:
@@ -936,7 +936,7 @@ metadata:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: kubearchive-operator-config-editor
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: watchers-1d5d067
+    app.kubernetes.io/version: watchers-93d8a87
   name: kubearchive-operator-config-editor
 rules:
   - apiGroups:
@@ -965,7 +965,7 @@ metadata:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: kubearchive-operator-config-viewer
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: watchers-1d5d067
+    app.kubernetes.io/version: watchers-93d8a87
   name: kubearchive-operator-config-viewer
 rules:
   - apiGroups:
@@ -989,7 +989,7 @@ metadata:
   labels:
     app.kubernetes.io/name: kubearchive-view
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: watchers-1d5d067
+    app.kubernetes.io/version: watchers-93d8a87
     rbac.authorization.k8s.io/aggregate-to-view: "true"
   name: kubearchive-view
 rules:
@@ -1009,7 +1009,7 @@ metadata:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: kubearchive-vacuum
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: watchers-1d5d067
+    app.kubernetes.io/version: watchers-93d8a87
   name: kubearchive-cluster-vacuum
   namespace: kubearchive
 roleRef:
@@ -1028,7 +1028,7 @@ metadata:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: kubearchive-operator-leader-election
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: watchers-1d5d067
+    app.kubernetes.io/version: watchers-93d8a87
   name: kubearchive-operator-leader-election
   namespace: kubearchive
 roleRef:
@@ -1047,7 +1047,7 @@ metadata:
     app.kubernetes.io/component: sink
     app.kubernetes.io/name: kubearchive-sink-watch
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: watchers-1d5d067
+    app.kubernetes.io/version: watchers-93d8a87
   name: kubearchive-sink-watch
   namespace: kubearchive
 roleRef:
@@ -1066,7 +1066,7 @@ metadata:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: kubearchive-vacuum
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: watchers-1d5d067
+    app.kubernetes.io/version: watchers-93d8a87
   name: clusterkubearchiveconfig-read
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -1084,7 +1084,7 @@ metadata:
     app.kubernetes.io/component: api-server
     app.kubernetes.io/name: kubearchive-api-server
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: watchers-1d5d067
+    app.kubernetes.io/version: watchers-93d8a87
   name: kubearchive-api-server
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -1102,7 +1102,7 @@ metadata:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: kubearchive-operator
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: watchers-1d5d067
+    app.kubernetes.io/version: watchers-93d8a87
   name: kubearchive-operator
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -1121,7 +1121,7 @@ metadata:
     app.kubernetes.io/component: logging
     app.kubernetes.io/name: kubearchive-logging
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: watchers-1d5d067
+    app.kubernetes.io/version: watchers-93d8a87
   name: kubearchive-logging
   namespace: kubearchive
 ---
@@ -1139,7 +1139,7 @@ metadata:
     app.kubernetes.io/component: database
     app.kubernetes.io/name: kubearchive-database-credentials
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: watchers-1d5d067
+    app.kubernetes.io/version: watchers-93d8a87
   name: kubearchive-database-credentials
   namespace: kubearchive
 type: Opaque
@@ -1153,7 +1153,7 @@ metadata:
     app.kubernetes.io/component: logging
     app.kubernetes.io/name: kubearchive-logging
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: watchers-1d5d067
+    app.kubernetes.io/version: watchers-93d8a87
   name: kubearchive-logging
   namespace: kubearchive
 type: Opaque
@@ -1165,7 +1165,7 @@ metadata:
     app.kubernetes.io/component: api-server
     app.kubernetes.io/name: kubearchive-api-server
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: watchers-1d5d067
+    app.kubernetes.io/version: watchers-93d8a87
   name: kubearchive-api-server
   namespace: kubearchive
 spec:
@@ -1184,7 +1184,7 @@ metadata:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: kubearchive-operator-webhooks
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: watchers-1d5d067
+    app.kubernetes.io/version: watchers-93d8a87
   name: kubearchive-operator-webhooks
   namespace: kubearchive
 spec:
@@ -1207,7 +1207,7 @@ metadata:
     app.kubernetes.io/component: sink
     app.kubernetes.io/name: kubearchive-sink
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: watchers-1d5d067
+    app.kubernetes.io/version: watchers-93d8a87
   name: kubearchive-sink
   namespace: kubearchive
 spec:
@@ -1225,7 +1225,7 @@ metadata:
     app.kubernetes.io/component: api-server
     app.kubernetes.io/name: kubearchive-api-server
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: watchers-1d5d067
+    app.kubernetes.io/version: watchers-93d8a87
   name: kubearchive-api-server
   namespace: kubearchive
 spec:
@@ -1275,7 +1275,7 @@ spec:
           envFrom:
             - secretRef:
                 name: kubearchive-database-credentials
-          image: quay.io/kubearchive/api:watchers-1d5d067@sha256:d5a57c1e09bd41ad02f6b9d811188500dc721aee5dc6dd585791f363f9cdb995
+          image: quay.io/kubearchive/api:watchers-93d8a87@sha256:9535a7f0916f6749dbf2034c634444de69b217c63a37cb842114f9f3a05d35b8
           livenessProbe:
             httpGet:
               path: /livez
@@ -1323,7 +1323,7 @@ metadata:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: kubearchive-operator
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: watchers-1d5d067
+    app.kubernetes.io/version: watchers-93d8a87
   name: kubearchive-operator
   namespace: kubearchive
 spec:
@@ -1369,7 +1369,7 @@ spec:
               valueFrom:
                 resourceFieldRef:
                   resource: limits.cpu
-          image: quay.io/kubearchive/operator:watchers-1d5d067@sha256:9d425c9e7a632cef2905baa5b56ca8c6866188286cb55e4ac67e050699d4ed72
+          image: quay.io/kubearchive/operator:watchers-93d8a87@sha256:618af0dfd327ca8dbb1c8f56d77d673da5544f25247f2737d3c5a22acb098114
           livenessProbe:
             httpGet:
               path: /healthz
@@ -1423,7 +1423,7 @@ metadata:
     app.kubernetes.io/component: sink
     app.kubernetes.io/name: kubearchive-sink
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: watchers-1d5d067
+    app.kubernetes.io/version: watchers-93d8a87
   name: kubearchive-sink
   namespace: kubearchive
 spec:
@@ -1471,7 +1471,7 @@ spec:
           envFrom:
             - secretRef:
                 name: kubearchive-database-credentials
-          image: quay.io/kubearchive/sink:watchers-1d5d067@sha256:ae23449bad321ca9a6d5b25b0ae2898029f1b4e7cff94aca9c8d203215a286ec
+          image: quay.io/kubearchive/sink:watchers-93d8a87@sha256:9d16aa0679293598fe12e90e61f882e077b4efde34af55826c145a7662a99e20
           livenessProbe:
             httpGet:
               path: /livez
@@ -1512,7 +1512,7 @@ metadata:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: kubearchive-vacuum
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: watchers-1d5d067
+    app.kubernetes.io/version: watchers-93d8a87
   name: cluster-vacuum
   namespace: kubearchive
 spec:
@@ -1533,7 +1533,7 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
-              image: quay.io/kubearchive/vacuum:watchers-1d5d067@sha256:4ca3354b802e11b511fdee6586b47c4ba30b5e48a13c94e0dc42e3bfd95d1f81
+              image: quay.io/kubearchive/vacuum:watchers-93d8a87@sha256:335f98f6a1e6a82cb39ebd5a153df789ea185488c60afda5047ef5a1a7e00dcc
               name: vacuum
           restartPolicy: Never
           serviceAccount: kubearchive-cluster-vacuum
@@ -1547,7 +1547,7 @@ metadata:
     app.kubernetes.io/component: kubearchive
     app.kubernetes.io/name: kubearchive-schema-migration
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: watchers-1d5d067
+    app.kubernetes.io/version: watchers-93d8a87
   name: kubearchive-schema-migration
   namespace: kubearchive
 spec:
@@ -1569,7 +1569,7 @@ spec:
             - -c
           env:
             - name: KUBEARCHIVE_VERSION
-              value: watchers-1d5d067
+              value: watchers-93d8a87
             - name: MIGRATE_VERSION
               value: v4.18.3
           envFrom:
@@ -1595,7 +1595,7 @@ metadata:
     app.kubernetes.io/component: api-server
     app.kubernetes.io/name: kubearchive-api-server-certificate
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: watchers-1d5d067
+    app.kubernetes.io/version: watchers-93d8a87
   name: kubearchive-api-server-certificate
   namespace: kubearchive
 spec:
@@ -1629,7 +1629,7 @@ metadata:
     app.kubernetes.io/component: certs
     app.kubernetes.io/name: kubearchive-ca
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: watchers-1d5d067
+    app.kubernetes.io/version: watchers-93d8a87
   name: kubearchive-ca
   namespace: kubearchive
 spec:
@@ -1651,7 +1651,7 @@ metadata:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: kubearchive-operator-certificate
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: watchers-1d5d067
+    app.kubernetes.io/version: watchers-93d8a87
   name: kubearchive-operator-certificate
   namespace: kubearchive
 spec:
@@ -1670,7 +1670,7 @@ metadata:
     app.kubernetes.io/component: certs
     app.kubernetes.io/name: kubearchive
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: watchers-1d5d067
+    app.kubernetes.io/version: watchers-93d8a87
   name: kubearchive
   namespace: kubearchive
 spec:
@@ -1684,7 +1684,7 @@ metadata:
     app.kubernetes.io/component: certs
     app.kubernetes.io/name: kubearchive-ca
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: watchers-1d5d067
+    app.kubernetes.io/version: watchers-93d8a87
   name: kubearchive-ca
   namespace: kubearchive
 spec:
@@ -1699,7 +1699,7 @@ metadata:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: kubearchive-mutating-webhook-configuration
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: watchers-1d5d067
+    app.kubernetes.io/version: watchers-93d8a87
   name: kubearchive-mutating-webhook-configuration
 webhooks:
   - admissionReviewVersions:
@@ -1812,7 +1812,7 @@ metadata:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: kubearchive-validating-webhook-configuration
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: watchers-1d5d067
+    app.kubernetes.io/version: watchers-93d8a87
   name: kubearchive-validating-webhook-configuration
 webhooks:
   - admissionReviewVersions:


### PR DESCRIPTION
The new changes we are testing are failing without printing errors, I have an idea but I need to confirm it by introducing this change that prints the error type.