### PR TITLE
KFLUXINFRA-2359 - Add bigger disk instance to all production clusters

### DIFF
--- a/components/kueue/production/kflux-ocp-p01/queue-config/cluster-queue.yaml
+++ b/components/kueue/production/kflux-ocp-p01/queue-config/cluster-queue.yaml
@@ -91,14 +91,14 @@ spec:
     - linux-d160-m8xlarge-arm64
     - linux-d320-c4xlarge-amd64
     - linux-d320-c4xlarge-arm64
+    - linux-d320-m8xlarge-amd64
+    - linux-d320-m8xlarge-arm64
     - linux-g64xlarge-amd64
     - linux-m2xlarge-amd64
     - linux-m2xlarge-arm64
     - linux-m4xlarge-amd64
     - linux-m4xlarge-arm64
     - linux-m8xlarge-amd64
-    - linux-m8xlarge-arm64
-    - linux-mlarge-amd64
     flavors:
     - name: platform-group-2
       resources:
@@ -118,6 +118,10 @@ spec:
         nominalQuota: '250'
       - name: linux-d320-c4xlarge-arm64
         nominalQuota: '250'
+      - name: linux-d320-m8xlarge-amd64
+        nominalQuota: '250'
+      - name: linux-d320-m8xlarge-arm64
+        nominalQuota: '250'
       - name: linux-g64xlarge-amd64
         nominalQuota: '250'
       - name: linux-m2xlarge-amd64
@@ -130,11 +134,9 @@ spec:
         nominalQuota: '250'
       - name: linux-m8xlarge-amd64
         nominalQuota: '250'
-      - name: linux-m8xlarge-arm64
-        nominalQuota: '250'
-      - name: linux-mlarge-amd64
-        nominalQuota: '250'
   - coveredResources:
+    - linux-m8xlarge-arm64
+    - linux-mlarge-amd64
     - linux-mlarge-arm64
     - linux-mxlarge-amd64
     - linux-mxlarge-arm64
@@ -148,6 +150,10 @@ spec:
     flavors:
     - name: platform-group-3
       resources:
+      - name: linux-m8xlarge-arm64
+        nominalQuota: '250'
+      - name: linux-mlarge-amd64
+        nominalQuota: '250'
       - name: linux-mlarge-arm64
         nominalQuota: '250'
       - name: linux-mxlarge-amd64

--- a/components/kueue/production/kflux-osp-p01/queue-config/cluster-queue.yaml
+++ b/components/kueue/production/kflux-osp-p01/queue-config/cluster-queue.yaml
@@ -42,11 +42,11 @@ spec:
     - linux-c8xlarge-arm64
     - linux-cxlarge-amd64
     - linux-cxlarge-arm64
+    - linux-d320-m8xlarge-amd64
+    - linux-d320-m8xlarge-arm64
     - linux-extra-fast-amd64
     - linux-fast-amd64
     - linux-g64xlarge-amd64
-    - linux-m2xlarge-amd64
-    - linux-m2xlarge-arm64
     flavors:
     - name: platform-group-1
       resources:
@@ -72,17 +72,19 @@ spec:
         nominalQuota: '250'
       - name: linux-cxlarge-arm64
         nominalQuota: '250'
+      - name: linux-d320-m8xlarge-amd64
+        nominalQuota: '250'
+      - name: linux-d320-m8xlarge-arm64
+        nominalQuota: '250'
       - name: linux-extra-fast-amd64
         nominalQuota: '250'
       - name: linux-fast-amd64
         nominalQuota: '250'
       - name: linux-g64xlarge-amd64
         nominalQuota: '250'
-      - name: linux-m2xlarge-amd64
-        nominalQuota: '250'
-      - name: linux-m2xlarge-arm64
-        nominalQuota: '250'
   - coveredResources:
+    - linux-m2xlarge-amd64
+    - linux-m2xlarge-arm64
     - linux-m4xlarge-amd64
     - linux-m4xlarge-arm64
     - linux-m8xlarge-amd64
@@ -99,6 +101,10 @@ spec:
     flavors:
     - name: platform-group-2
       resources:
+      - name: linux-m2xlarge-amd64
+        nominalQuota: '250'
+      - name: linux-m2xlarge-arm64
+        nominalQuota: '250'
       - name: linux-m4xlarge-amd64
         nominalQuota: '250'
       - name: linux-m4xlarge-arm64

--- a/components/kueue/production/kflux-prd-rh02/queue-config/cluster-queue.yaml
+++ b/components/kueue/production/kflux-prd-rh02/queue-config/cluster-queue.yaml
@@ -84,6 +84,8 @@ spec:
         nominalQuota: '250'
   - coveredResources:
     - linux-d160-m8xlarge-arm64
+    - linux-d320-m8xlarge-amd64
+    - linux-d320-m8xlarge-arm64
     - linux-extra-fast-amd64
     - linux-fast-amd64
     - linux-g64xlarge-amd64
@@ -97,12 +99,14 @@ spec:
     - linux-mlarge-arm64
     - linux-mxlarge-amd64
     - linux-mxlarge-arm64
-    - linux-ppc64le
-    - linux-root-amd64
     flavors:
     - name: platform-group-2
       resources:
       - name: linux-d160-m8xlarge-arm64
+        nominalQuota: '250'
+      - name: linux-d320-m8xlarge-amd64
+        nominalQuota: '250'
+      - name: linux-d320-m8xlarge-arm64
         nominalQuota: '250'
       - name: linux-extra-fast-amd64
         nominalQuota: '250'
@@ -130,11 +134,9 @@ spec:
         nominalQuota: '250'
       - name: linux-mxlarge-arm64
         nominalQuota: '250'
-      - name: linux-ppc64le
-        nominalQuota: '64'
-      - name: linux-root-amd64
-        nominalQuota: '250'
   - coveredResources:
+    - linux-ppc64le
+    - linux-root-amd64
     - linux-root-arm64
     - linux-s390x
     - linux-x86-64
@@ -143,6 +145,10 @@ spec:
     flavors:
     - name: platform-group-3
       resources:
+      - name: linux-ppc64le
+        nominalQuota: '64'
+      - name: linux-root-amd64
+        nominalQuota: '250'
       - name: linux-root-arm64
         nominalQuota: '250'
       - name: linux-s390x

--- a/components/kueue/production/kflux-prd-rh03/queue-config/cluster-queue.yaml
+++ b/components/kueue/production/kflux-prd-rh03/queue-config/cluster-queue.yaml
@@ -84,6 +84,8 @@ spec:
         nominalQuota: '250'
   - coveredResources:
     - linux-d160-m8-8xlarge-arm64
+    - linux-d320-m8xlarge-amd64
+    - linux-d320-m8xlarge-arm64
     - linux-extra-fast-amd64
     - linux-fast-amd64
     - linux-g64xlarge-amd64
@@ -97,12 +99,14 @@ spec:
     - linux-mlarge-arm64
     - linux-mxlarge-amd64
     - linux-mxlarge-arm64
-    - linux-ppc64le
-    - linux-root-amd64
     flavors:
     - name: platform-group-2
       resources:
       - name: linux-d160-m8-8xlarge-arm64
+        nominalQuota: '250'
+      - name: linux-d320-m8xlarge-amd64
+        nominalQuota: '250'
+      - name: linux-d320-m8xlarge-arm64
         nominalQuota: '250'
       - name: linux-extra-fast-amd64
         nominalQuota: '250'
@@ -130,11 +134,9 @@ spec:
         nominalQuota: '250'
       - name: linux-mxlarge-arm64
         nominalQuota: '250'
-      - name: linux-ppc64le
-        nominalQuota: '64'
-      - name: linux-root-amd64
-        nominalQuota: '250'
   - coveredResources:
+    - linux-ppc64le
+    - linux-root-amd64
     - linux-root-arm64
     - linux-s390x
     - linux-x86-64
@@ -143,6 +145,10 @@ spec:
     flavors:
     - name: platform-group-3
       resources:
+      - name: linux-ppc64le
+        nominalQuota: '64'
+      - name: linux-root-amd64
+        nominalQuota: '250'
       - name: linux-root-arm64
         nominalQuota: '250'
       - name: linux-s390x

--- a/components/kueue/production/kflux-rhel-p01/queue-config/cluster-queue.yaml
+++ b/components/kueue/production/kflux-rhel-p01/queue-config/cluster-queue.yaml
@@ -88,6 +88,8 @@ spec:
     - linux-d160-mlarge-arm64
     - linux-d160-mxlarge-amd64
     - linux-d160-mxlarge-arm64
+    - linux-d320-m8xlarge-amd64
+    - linux-d320-m8xlarge-arm64
     - linux-extra-fast-amd64
     - linux-fast-amd64
     - linux-g64xlarge-amd64
@@ -97,8 +99,6 @@ spec:
     - linux-m4xlarge-amd64
     - linux-m4xlarge-arm64
     - linux-m8xlarge-amd64
-    - linux-m8xlarge-arm64
-    - linux-mlarge-amd64
     flavors:
     - name: platform-group-2
       resources:
@@ -111,6 +111,10 @@ spec:
       - name: linux-d160-mxlarge-amd64
         nominalQuota: '250'
       - name: linux-d160-mxlarge-arm64
+        nominalQuota: '250'
+      - name: linux-d320-m8xlarge-amd64
+        nominalQuota: '250'
+      - name: linux-d320-m8xlarge-arm64
         nominalQuota: '250'
       - name: linux-extra-fast-amd64
         nominalQuota: '250'
@@ -130,11 +134,9 @@ spec:
         nominalQuota: '250'
       - name: linux-m8xlarge-amd64
         nominalQuota: '250'
-      - name: linux-m8xlarge-arm64
-        nominalQuota: '250'
-      - name: linux-mlarge-amd64
-        nominalQuota: '250'
   - coveredResources:
+    - linux-m8xlarge-arm64
+    - linux-mlarge-amd64
     - linux-mlarge-arm64
     - linux-mxlarge-amd64
     - linux-mxlarge-arm64
@@ -148,6 +150,10 @@ spec:
     flavors:
     - name: platform-group-3
       resources:
+      - name: linux-m8xlarge-arm64
+        nominalQuota: '250'
+      - name: linux-mlarge-amd64
+        nominalQuota: '250'
       - name: linux-mlarge-arm64
         nominalQuota: '250'
       - name: linux-mxlarge-amd64

--- a/components/kueue/production/stone-prd-rh01/queue-config/cluster-queue.yaml
+++ b/components/kueue/production/stone-prd-rh01/queue-config/cluster-queue.yaml
@@ -84,6 +84,8 @@ spec:
         nominalQuota: '250'
   - coveredResources:
     - linux-d160-m8xlarge-arm64
+    - linux-d320-m8xlarge-amd64
+    - linux-d320-m8xlarge-arm64
     - linux-extra-fast-amd64
     - linux-fast-amd64
     - linux-g64xlarge-amd64
@@ -97,12 +99,14 @@ spec:
     - linux-mlarge-arm64
     - linux-mxlarge-amd64
     - linux-mxlarge-arm64
-    - linux-ppc64le
-    - linux-root-amd64
     flavors:
     - name: platform-group-2
       resources:
       - name: linux-d160-m8xlarge-arm64
+        nominalQuota: '250'
+      - name: linux-d320-m8xlarge-amd64
+        nominalQuota: '250'
+      - name: linux-d320-m8xlarge-arm64
         nominalQuota: '250'
       - name: linux-extra-fast-amd64
         nominalQuota: '250'
@@ -130,11 +134,9 @@ spec:
         nominalQuota: '250'
       - name: linux-mxlarge-arm64
         nominalQuota: '250'
-      - name: linux-ppc64le
-        nominalQuota: '64'
-      - name: linux-root-amd64
-        nominalQuota: '250'
   - coveredResources:
+    - linux-ppc64le
+    - linux-root-amd64
     - linux-root-arm64
     - linux-s390x
     - linux-x86-64
@@ -143,6 +145,10 @@ spec:
     flavors:
     - name: platform-group-3
       resources:
+      - name: linux-ppc64le
+        nominalQuota: '64'
+      - name: linux-root-amd64
+        nominalQuota: '250'
       - name: linux-root-arm64
         nominalQuota: '250'
       - name: linux-s390x

--- a/components/kueue/production/stone-prod-p01/queue-config/cluster-queue.yaml
+++ b/components/kueue/production/stone-prod-p01/queue-config/cluster-queue.yaml
@@ -84,6 +84,8 @@ spec:
         nominalQuota: '250'
   - coveredResources:
     - linux-d160-m8xlarge-arm64
+    - linux-d320-m8xlarge-amd64
+    - linux-d320-m8xlarge-arm64
     - linux-g64xlarge-amd64
     - linux-m2xlarge-amd64
     - linux-m2xlarge-arm64
@@ -97,12 +99,14 @@ spec:
     - linux-mxlarge-arm64
     - linux-root-amd64
     - linux-root-arm64
-    - linux-x86-64
-    - local
     flavors:
     - name: platform-group-2
       resources:
       - name: linux-d160-m8xlarge-arm64
+        nominalQuota: '250'
+      - name: linux-d320-m8xlarge-amd64
+        nominalQuota: '250'
+      - name: linux-d320-m8xlarge-arm64
         nominalQuota: '250'
       - name: linux-g64xlarge-amd64
         nominalQuota: '250'
@@ -130,15 +134,17 @@ spec:
         nominalQuota: '250'
       - name: linux-root-arm64
         nominalQuota: '250'
-      - name: linux-x86-64
-        nominalQuota: '1000'
-      - name: local
-        nominalQuota: '1000'
   - coveredResources:
+    - linux-x86-64
+    - local
     - localhost
     flavors:
     - name: platform-group-3
       resources:
+      - name: linux-x86-64
+        nominalQuota: '1000'
+      - name: local
+        nominalQuota: '1000'
       - name: localhost
         nominalQuota: '1000'
   stopPolicy: None

--- a/components/kueue/production/stone-prod-p02/queue-config/cluster-queue.yaml
+++ b/components/kueue/production/stone-prod-p02/queue-config/cluster-queue.yaml
@@ -86,6 +86,8 @@ spec:
     - linux-d160-m8xlarge-arm64
     - linux-d320-c4xlarge-amd64
     - linux-d320-c4xlarge-arm64
+    - linux-d320-m8xlarge-amd64
+    - linux-d320-m8xlarge-arm64
     - linux-extra-fast-amd64
     - linux-fast-amd64
     - linux-g64xlarge-amd64
@@ -97,8 +99,6 @@ spec:
     - linux-m8xlarge-arm64
     - linux-mlarge-amd64
     - linux-mlarge-arm64
-    - linux-mxlarge-amd64
-    - linux-mxlarge-arm64
     flavors:
     - name: platform-group-2
       resources:
@@ -107,6 +107,10 @@ spec:
       - name: linux-d320-c4xlarge-amd64
         nominalQuota: '250'
       - name: linux-d320-c4xlarge-arm64
+        nominalQuota: '250'
+      - name: linux-d320-m8xlarge-amd64
+        nominalQuota: '250'
+      - name: linux-d320-m8xlarge-arm64
         nominalQuota: '250'
       - name: linux-extra-fast-amd64
         nominalQuota: '250'
@@ -130,11 +134,9 @@ spec:
         nominalQuota: '250'
       - name: linux-mlarge-arm64
         nominalQuota: '250'
-      - name: linux-mxlarge-amd64
-        nominalQuota: '250'
-      - name: linux-mxlarge-arm64
-        nominalQuota: '250'
   - coveredResources:
+    - linux-mxlarge-amd64
+    - linux-mxlarge-arm64
     - linux-ppc64le
     - linux-root-amd64
     - linux-root-arm64
@@ -145,6 +147,10 @@ spec:
     flavors:
     - name: platform-group-3
       resources:
+      - name: linux-mxlarge-amd64
+        nominalQuota: '250'
+      - name: linux-mxlarge-arm64
+        nominalQuota: '250'
       - name: linux-ppc64le
         nominalQuota: '40'
       - name: linux-root-amd64

--- a/components/multi-platform-controller/base/host-config-chart/templates/host-config.yaml
+++ b/components/multi-platform-controller/base/host-config-chart/templates/host-config.yaml
@@ -731,6 +731,40 @@ data:
   dynamic.linux-d320-c4xlarge-amd64.allocation-timeout: "1200"
   {{ end }}
 
+  {{- if hasKey .Values.dynamicConfigs "linux-d320-m8xlarge-arm64" }}
+  {{- $config := index .Values.dynamicConfigs "linux-d320-m8xlarge-arm64" | default (dict) }}
+  dynamic.linux-d320-m8xlarge-arm64.type: {{ index $config "type" | default "aws" | quote }}
+  dynamic.linux-d320-m8xlarge-arm64.region: {{ index $config "region" | default "us-east-1" | quote }}
+  dynamic.linux-d320-m8xlarge-arm64.ami: {{ default (index $arm "ami") $config.ami | quote }}
+  dynamic.linux-d320-m8xlarge-arm64.instance-type: {{ (index $config "instance-type") | default "m6g.8xlarge" | quote }}
+  dynamic.linux-d320-m8xlarge-arm64.instance-tag: {{ (index $config "instance-tag") | default (printf "%s-arm64-m8xlarge-d320" $environment) | quote }}
+  dynamic.linux-d320-m8xlarge-arm64.key-name: {{ default (index $arm "key-name") ((index $config "key-name")) | quote }}
+  dynamic.linux-d320-m8xlarge-arm64.aws-secret: {{ (index $config "aws-secret") | default "aws-account" | quote }}
+  dynamic.linux-d320-m8xlarge-arm64.ssh-secret: {{ (index $config "ssh-secret") | default "aws-ssh-key" | quote }}
+  dynamic.linux-d320-m8xlarge-arm64.security-group-id: {{ default (index $arm "security-group-id") ((index $config "security-group-id")) | quote }}
+  dynamic.linux-d320-m8xlarge-arm64.max-instances: {{ (index $config "max-instances") | default "250" | quote }}
+  dynamic.linux-d320-m8xlarge-arm64.subnet-id: {{ default (index $arm "subnet-id") ((index $config "subnet-id")) | quote }}
+  dynamic.linux-d320-m8xlarge-arm64.disk: "320"
+  dynamic.linux-d320-m8xlarge-arm64.allocation-timeout: "1200"
+  {{ end }}
+
+  {{- if hasKey .Values.dynamicConfigs "linux-d320-m8xlarge-amd64" }}
+  {{- $config := index .Values.dynamicConfigs "linux-d320-m8xlarge-amd64" | default (dict) }}
+  dynamic.linux-d320-m8xlarge-amd64.type: {{ index $config "type" | default "aws" | quote }}
+  dynamic.linux-d320-m8xlarge-amd64.region: {{ index $config "region" | default "us-east-1" | quote }}
+  dynamic.linux-d320-m8xlarge-amd64.ami: {{ default (index $amd "ami") $config.ami | quote }}
+  dynamic.linux-d320-m8xlarge-amd64.instance-type: {{ (index $config "instance-type") | default "m6a.8xlarge" | quote }}
+  dynamic.linux-d320-m8xlarge-amd64.instance-tag: {{ (index $config "instance-tag") | default (printf "%s-amd64-m8xlarge-d320" $environment) | quote }}
+  dynamic.linux-d320-m8xlarge-amd64.key-name: {{ default (index $amd "key-name") ((index $config "key-name")) | quote }}
+  dynamic.linux-d320-m8xlarge-amd64.aws-secret: {{ (index $config "aws-secret") | default "aws-account" | quote }}
+  dynamic.linux-d320-m8xlarge-amd64.ssh-secret: {{ (index $config "ssh-secret") | default "aws-ssh-key" | quote }}
+  dynamic.linux-d320-m8xlarge-amd64.security-group-id: {{ default (index $amd "security-group-id") ((index $config "security-group-id")) | quote }}
+  dynamic.linux-d320-m8xlarge-amd64.max-instances: {{ (index $config "max-instances") | default "250" | quote }}
+  dynamic.linux-d320-m8xlarge-amd64.subnet-id: {{ default (index $amd "subnet-id") ((index $config "subnet-id")) | quote }}
+  dynamic.linux-d320-m8xlarge-amd64.disk: "320"
+  dynamic.linux-d320-m8xlarge-amd64.allocation-timeout: "1200"
+  {{ end }}
+
   {{- if hasKey .Values.dynamicConfigs "linux-c8xlarge-arm64" }}
   {{- $config := index .Values.dynamicConfigs "linux-c8xlarge-arm64" | default (dict) }}
   dynamic.linux-c8xlarge-arm64.type: {{ index $config "type" | default "aws" | quote }}

--- a/components/multi-platform-controller/production-downstream/kflux-ocp-p01/host-values.yaml
+++ b/components/multi-platform-controller/production-downstream/kflux-ocp-p01/host-values.yaml
@@ -45,6 +45,10 @@ dynamicConfigs:
 
   linux-d160-m4xlarge-amd64: {}
 
+  linux-d320-m8xlarge-arm64: {}
+
+  linux-d320-m8xlarge-amd64: {}
+
   linux-m8xlarge-arm64: {}
 
   linux-m8xlarge-amd64: {}
@@ -192,36 +196,36 @@ dynamicConfigs:
     user-data: |-
       Content-Type: multipart/mixed; boundary="//"
       MIME-Version: 1.0
-      
+
       --//
       Content-Type: text/cloud-config; charset="us-ascii"
       MIME-Version: 1.0
       Content-Transfer-Encoding: 7bit
       Content-Disposition: attachment; filename="cloud-config.txt"
-      
+
       #cloud-config
       cloud_final_modules:
         - [scripts-user, always]
-      
+
       --//
       Content-Type: text/x-shellscript; charset="us-ascii"
       MIME-Version: 1.0
       Content-Transfer-Encoding: 7bit
       Content-Disposition: attachment; filename="userdata.txt"
-      
+
       #!/bin/bash -ex
-      
+
       # Format and mount NVMe disk
       mkfs -t xfs /dev/nvme1n1
       mount /dev/nvme1n1 /home
-      
+
       # Create required directories
       mkdir -p /home/var-lib-containers /var/lib/containers /home/var-tmp /var/tmp /home/ec2-user/.ssh
-      
+
       # Setup bind mounts
       mount --bind /home/var-lib-containers /var/lib/containers
       mount --bind /home/var-tmp /var/tmp
-      
+
       # Configure ec2-user SSH access
       chown -R ec2-user /home/ec2-user
       sed -n 's,.*\(ssh-.*\s\),\1,p' /root/.ssh/authorized_keys > /home/ec2-user/.ssh/authorized_keys
@@ -229,7 +233,7 @@ dynamicConfigs:
       chmod 600 /home/ec2-user/.ssh/authorized_keys
       chmod 700 /home/ec2-user/.ssh
       restorecon -r /home/ec2-user
-      
+
       --//--
 
 # Static hosts configuration

--- a/components/multi-platform-controller/production-downstream/kflux-osp-p01/host-values.yaml
+++ b/components/multi-platform-controller/production-downstream/kflux-osp-p01/host-values.yaml
@@ -35,6 +35,10 @@ dynamicConfigs:
 
   linux-m4xlarge-amd64: {}
 
+  linux-d320-m8xlarge-arm64: {}
+
+  linux-d320-m8xlarge-amd64: {}
+
   linux-m8xlarge-arm64: {}
 
   linux-m8xlarge-amd64: {}
@@ -166,36 +170,36 @@ dynamicConfigs:
     user-data: |-
       Content-Type: multipart/mixed; boundary="//"
       MIME-Version: 1.0
-      
+
       --//
       Content-Type: text/cloud-config; charset="us-ascii"
       MIME-Version: 1.0
       Content-Transfer-Encoding: 7bit
       Content-Disposition: attachment; filename="cloud-config.txt"
-      
+
       #cloud-config
       cloud_final_modules:
         - [scripts-user, always]
-      
+
       --//
       Content-Type: text/x-shellscript; charset="us-ascii"
       MIME-Version: 1.0
       Content-Transfer-Encoding: 7bit
       Content-Disposition: attachment; filename="userdata.txt"
-      
+
       #!/bin/bash -ex
-      
+
       # Format and mount NVMe disk
       mkfs -t xfs /dev/nvme1n1
       mount /dev/nvme1n1 /home
-      
+
       # Create required directories
       mkdir -p /home/var-lib-containers /var/lib/containers /home/var-tmp /var/tmp /home/ec2-user/.ssh
-      
+
       # Setup bind mounts
       mount --bind /home/var-lib-containers /var/lib/containers
       mount --bind /home/var-tmp /var/tmp
-      
+
       # Configure ec2-user SSH access
       chown -R ec2-user /home/ec2-user
       sed -n 's,.*\(ssh-.*\s\),\1,p' /root/.ssh/authorized_keys > /home/ec2-user/.ssh/authorized_keys
@@ -203,7 +207,7 @@ dynamicConfigs:
       chmod 600 /home/ec2-user/.ssh/authorized_keys
       chmod 700 /home/ec2-user/.ssh
       restorecon -r /home/ec2-user
-      
+
       --//--
 
   linux-fast-amd64: {}

--- a/components/multi-platform-controller/production-downstream/kflux-rhel-p01/host-values.yaml
+++ b/components/multi-platform-controller/production-downstream/kflux-rhel-p01/host-values.yaml
@@ -59,6 +59,10 @@ dynamicConfigs:
   linux-d160-m4xlarge-amd64:
     instance-type: "m7a.4xlarge"
 
+  linux-d320-m8xlarge-arm64: {}
+
+  linux-d320-m8xlarge-amd64: {}
+
   linux-d160-m8xlarge-arm64: {}
 
   linux-d160-m8xlarge-amd64:
@@ -196,36 +200,36 @@ dynamicConfigs:
     user-data: |-
       Content-Type: multipart/mixed; boundary="//"
       MIME-Version: 1.0
-      
+
       --//
       Content-Type: text/cloud-config; charset="us-ascii"
       MIME-Version: 1.0
       Content-Transfer-Encoding: 7bit
       Content-Disposition: attachment; filename="cloud-config.txt"
-      
+
       #cloud-config
       cloud_final_modules:
         - [scripts-user, always]
-      
+
       --//
       Content-Type: text/x-shellscript; charset="us-ascii"
       MIME-Version: 1.0
       Content-Transfer-Encoding: 7bit
       Content-Disposition: attachment; filename="userdata.txt"
-      
+
       #!/bin/bash -ex
-      
+
       # Format and mount NVMe disk
       mkfs -t xfs /dev/nvme1n1
       mount /dev/nvme1n1 /home
-      
+
       # Create required directories
       mkdir -p /home/var-lib-containers /var/lib/containers /home/var-tmp /var/tmp /home/ec2-user/.ssh
-      
+
       # Setup bind mounts
       mount --bind /home/var-lib-containers /var/lib/containers
       mount --bind /home/var-tmp /var/tmp
-      
+
       # Configure ec2-user SSH access
       chown -R ec2-user /home/ec2-user
       sed -n 's,.*\(ssh-.*\s\),\1,p' /root/.ssh/authorized_keys > /home/ec2-user/.ssh/authorized_keys
@@ -233,7 +237,7 @@ dynamicConfigs:
       chmod 600 /home/ec2-user/.ssh/authorized_keys
       chmod 700 /home/ec2-user/.ssh
       restorecon -r /home/ec2-user
-      
+
       --//--
 
   linux-fast-amd64: {}

--- a/components/multi-platform-controller/production-downstream/pentest-p01/host-values.yaml
+++ b/components/multi-platform-controller/production-downstream/pentest-p01/host-values.yaml
@@ -35,6 +35,10 @@ dynamicConfigs:
 
   linux-m4xlarge-amd64: {}
 
+  linux-d320-m8xlarge-arm64: {}
+
+  linux-d320-m8xlarge-amd64: {}
+
   linux-m8xlarge-arm64: {}
 
   linux-m8xlarge-amd64: {}
@@ -165,36 +169,36 @@ dynamicConfigs:
     user-data: |-
       Content-Type: multipart/mixed; boundary="//"
       MIME-Version: 1.0
-      
+
       --//
       Content-Type: text/cloud-config; charset="us-ascii"
       MIME-Version: 1.0
       Content-Transfer-Encoding: 7bit
       Content-Disposition: attachment; filename="cloud-config.txt"
-      
+
       #cloud-config
       cloud_final_modules:
         - [scripts-user, always]
-      
+
       --//
       Content-Type: text/x-shellscript; charset="us-ascii"
       MIME-Version: 1.0
       Content-Transfer-Encoding: 7bit
       Content-Disposition: attachment; filename="userdata.txt"
-      
+
       #!/bin/bash -ex
-      
+
       # Format and mount NVMe disk
       mkfs -t xfs /dev/nvme1n1
       mount /dev/nvme1n1 /home
-      
+
       # Create required directories
       mkdir -p /home/var-lib-containers /var/lib/containers /home/var-tmp /var/tmp /home/ec2-user/.ssh
-      
+
       # Setup bind mounts
       mount --bind /home/var-lib-containers /var/lib/containers
       mount --bind /home/var-tmp /var/tmp
-      
+
       # Configure ec2-user SSH access
       chown -R ec2-user /home/ec2-user
       sed -n 's,.*\(ssh-.*\s\),\1,p' /root/.ssh/authorized_keys > /home/ec2-user/.ssh/authorized_keys
@@ -202,7 +206,7 @@ dynamicConfigs:
       chmod 600 /home/ec2-user/.ssh/authorized_keys
       chmod 700 /home/ec2-user/.ssh
       restorecon -r /home/ec2-user
-      
+
       --//--
 
   linux-fast-amd64: {}

--- a/components/multi-platform-controller/production-downstream/stone-prod-p01/host-values.yaml
+++ b/components/multi-platform-controller/production-downstream/stone-prod-p01/host-values.yaml
@@ -42,6 +42,10 @@ dynamicConfigs:
 
   linux-d160-m4xlarge-amd64: {}
 
+  linux-d320-m8xlarge-arm64: {}
+
+  linux-d320-m8xlarge-amd64: {}
+
   linux-m8xlarge-arm64: {}
 
   linux-m8xlarge-amd64: {}
@@ -177,36 +181,36 @@ dynamicConfigs:
     user-data: |-
       Content-Type: multipart/mixed; boundary="//"
       MIME-Version: 1.0
-      
+
       --//
       Content-Type: text/cloud-config; charset="us-ascii"
       MIME-Version: 1.0
       Content-Transfer-Encoding: 7bit
       Content-Disposition: attachment; filename="cloud-config.txt"
-      
+
       #cloud-config
       cloud_final_modules:
         - [scripts-user, always]
-      
+
       --//
       Content-Type: text/x-shellscript; charset="us-ascii"
       MIME-Version: 1.0
       Content-Transfer-Encoding: 7bit
       Content-Disposition: attachment; filename="userdata.txt"
-      
+
       #!/bin/bash -ex
-      
+
       # Format and mount NVMe disk
       mkfs -t xfs /dev/nvme1n1
       mount /dev/nvme1n1 /home
-      
+
       # Create required directories
       mkdir -p /home/var-lib-containers /var/lib/containers /home/var-tmp /var/tmp /home/ec2-user/.ssh
-      
+
       # Setup bind mounts
       mount --bind /home/var-lib-containers /var/lib/containers
       mount --bind /home/var-tmp /var/tmp
-      
+
       # Configure ec2-user SSH access
       chown -R ec2-user /home/ec2-user
       sed -n 's,.*\(ssh-.*\s\),\1,p' /root/.ssh/authorized_keys > /home/ec2-user/.ssh/authorized_keys
@@ -214,7 +218,7 @@ dynamicConfigs:
       chmod 600 /home/ec2-user/.ssh/authorized_keys
       chmod 700 /home/ec2-user/.ssh
       restorecon -r /home/ec2-user
-      
+
       --//--
 
 # Static hosts configuration

--- a/components/multi-platform-controller/production-downstream/stone-prod-p02/host-values.yaml
+++ b/components/multi-platform-controller/production-downstream/stone-prod-p02/host-values.yaml
@@ -54,6 +54,10 @@ dynamicConfigs:
 
   linux-d320-c4xlarge-arm64: {}
 
+  linux-d320-m8xlarge-amd64: {}
+
+  linux-d320-m8xlarge-arm64: {}
+
   linux-fast-amd64: {}
 
   linux-extra-fast-amd64: {}

--- a/components/multi-platform-controller/production/kflux-prd-rh02/host-values.yaml
+++ b/components/multi-platform-controller/production/kflux-prd-rh02/host-values.yaml
@@ -43,6 +43,10 @@ dynamicConfigs:
 
   linux-d160-m4xlarge-amd64: {}
 
+  linux-d320-m8xlarge-arm64: {}
+
+  linux-d320-m8xlarge-amd64: {}
+
   linux-m8xlarge-arm64: {}
 
   linux-m8xlarge-amd64: {}
@@ -178,36 +182,36 @@ dynamicConfigs:
     user-data: |-
       Content-Type: multipart/mixed; boundary="//"
       MIME-Version: 1.0
-      
+
       --//
       Content-Type: text/cloud-config; charset="us-ascii"
       MIME-Version: 1.0
       Content-Transfer-Encoding: 7bit
       Content-Disposition: attachment; filename="cloud-config.txt"
-      
+
       #cloud-config
       cloud_final_modules:
         - [scripts-user, always]
-      
+
       --//
       Content-Type: text/x-shellscript; charset="us-ascii"
       MIME-Version: 1.0
       Content-Transfer-Encoding: 7bit
       Content-Disposition: attachment; filename="userdata.txt"
-      
+
       #!/bin/bash -ex
-      
+
       # Format and mount NVMe disk
       mkfs -t xfs /dev/nvme1n1
       mount /dev/nvme1n1 /home
-      
+
       # Create required directories
       mkdir -p /home/var-lib-containers /var/lib/containers /home/var-tmp /var/tmp /home/ec2-user/.ssh
-      
+
       # Setup bind mounts
       mount --bind /home/var-lib-containers /var/lib/containers
       mount --bind /home/var-tmp /var/tmp
-      
+
       # Configure ec2-user SSH access
       chown -R ec2-user /home/ec2-user
       sed -n 's,.*\(ssh-.*\s\),\1,p' /root/.ssh/authorized_keys > /home/ec2-user/.ssh/authorized_keys
@@ -215,7 +219,7 @@ dynamicConfigs:
       chmod 600 /home/ec2-user/.ssh/authorized_keys
       chmod 700 /home/ec2-user/.ssh
       restorecon -r /home/ec2-user
-      
+
       --//--
 
   linux-fast-amd64: {}

--- a/components/multi-platform-controller/production/kflux-prd-rh03/host-values.yaml
+++ b/components/multi-platform-controller/production/kflux-prd-rh03/host-values.yaml
@@ -38,6 +38,10 @@ dynamicConfigs:
 
   linux-m4xlarge-amd64: {}
 
+  linux-d320-m8xlarge-arm64: {}
+
+  linux-d320-m8xlarge-amd64: {}
+
   linux-m8xlarge-arm64: {}
 
   linux-m8xlarge-amd64: {}
@@ -177,36 +181,36 @@ dynamicConfigs:
     user-data: |-
       Content-Type: multipart/mixed; boundary="//"
       MIME-Version: 1.0
-      
+
       --//
       Content-Type: text/cloud-config; charset="us-ascii"
       MIME-Version: 1.0
       Content-Transfer-Encoding: 7bit
       Content-Disposition: attachment; filename="cloud-config.txt"
-      
+
       #cloud-config
       cloud_final_modules:
         - [scripts-user, always]
-      
+
       --//
       Content-Type: text/x-shellscript; charset="us-ascii"
       MIME-Version: 1.0
       Content-Transfer-Encoding: 7bit
       Content-Disposition: attachment; filename="userdata.txt"
-      
+
       #!/bin/bash -ex
-      
+
       # Format and mount NVMe disk
       mkfs -t xfs /dev/nvme1n1
       mount /dev/nvme1n1 /home
-      
+
       # Create required directories
       mkdir -p /home/var-lib-containers /var/lib/containers /home/var-tmp /var/tmp /home/ec2-user/.ssh
-      
+
       # Setup bind mounts
       mount --bind /home/var-lib-containers /var/lib/containers
       mount --bind /home/var-tmp /var/tmp
-      
+
       # Configure ec2-user SSH access
       chown -R ec2-user /home/ec2-user
       sed -n 's,.*\(ssh-.*\s\),\1,p' /root/.ssh/authorized_keys > /home/ec2-user/.ssh/authorized_keys
@@ -214,9 +218,9 @@ dynamicConfigs:
       chmod 600 /home/ec2-user/.ssh/authorized_keys
       chmod 700 /home/ec2-user/.ssh
       restorecon -r /home/ec2-user
-      
+
       --//--
-  
+
 
   linux-fast-amd64: {}
 

--- a/components/multi-platform-controller/production/stone-prd-rh01/host-values.yaml
+++ b/components/multi-platform-controller/production/stone-prd-rh01/host-values.yaml
@@ -43,6 +43,10 @@ dynamicConfigs:
 
   linux-d160-m4xlarge-amd64: {}
 
+  linux-d320-m8xlarge-arm64: {}
+
+  linux-d320-m8xlarge-amd64: {}
+
   linux-m8xlarge-arm64: {}
 
   linux-m8xlarge-amd64: {}
@@ -178,36 +182,36 @@ dynamicConfigs:
     user-data: |-
       Content-Type: multipart/mixed; boundary="//"
       MIME-Version: 1.0
-      
+
       --//
       Content-Type: text/cloud-config; charset="us-ascii"
       MIME-Version: 1.0
       Content-Transfer-Encoding: 7bit
       Content-Disposition: attachment; filename="cloud-config.txt"
-      
+
       #cloud-config
       cloud_final_modules:
         - [scripts-user, always]
-      
+
       --//
       Content-Type: text/x-shellscript; charset="us-ascii"
       MIME-Version: 1.0
       Content-Transfer-Encoding: 7bit
       Content-Disposition: attachment; filename="userdata.txt"
-      
+
       #!/bin/bash -ex
-      
+
       # Format and mount NVMe disk
       mkfs -t xfs /dev/nvme1n1
       mount /dev/nvme1n1 /home
-      
+
       # Create required directories
       mkdir -p /home/var-lib-containers /var/lib/containers /home/var-tmp /var/tmp /home/ec2-user/.ssh
-      
+
       # Setup bind mounts
       mount --bind /home/var-lib-containers /var/lib/containers
       mount --bind /home/var-tmp /var/tmp
-      
+
       # Configure ec2-user SSH access
       chown -R ec2-user /home/ec2-user
       sed -n 's,.*\(ssh-.*\s\),\1,p' /root/.ssh/authorized_keys > /home/ec2-user/.ssh/authorized_keys
@@ -215,7 +219,7 @@ dynamicConfigs:
       chmod 600 /home/ec2-user/.ssh/authorized_keys
       chmod 700 /home/ec2-user/.ssh
       restorecon -r /home/ec2-user
-      
+
       --//--
 
   linux-fast-amd64: {}


### PR DESCRIPTION
As an initial test to check if increasing the VM disk space will resolve a tenant problem, two instances with more disk space, linux-d320-c4xlarge- arm64 and linux-d320-c4xlarge-amd64 were added to cluster 'stone-prod-p02' in commit 2f21a4d1768f58. Unfortunately, these instances provide less CPU and memory than the initially used so the build fails before the step where it was running out of space.

This change adds new instances that have the same CPU and memory as the previously used but doubling the space in disk.