### PR TITLE
info: fix invalid kustomization manifest

### DIFF
--- a/components/konflux-info/production/kflux-rhel-p01/kustomization.yaml
+++ b/components/konflux-info/production/kflux-rhel-p01/kustomization.yaml
@@ -10,8 +10,6 @@ configMapGenerator:
   - name: konflux-public-info
     files:
       - info.json
-
-configMapGenerator:
   - name: konflux-banner-configmap
     files:
       - banner-content.yaml


### PR DESCRIPTION
YAML doesn't allow duplicate keys, but kustomize doesn't provide any warnings for these.  This causes the konflux-banner-content configmap to get dropped from the built manifests.

Remove the duplicate key from the kustomization manifest to generate these manifests correctly.

Split from #8461.