### PR TITLE
kueue: fix manifest formatting

### DIFF
--- a/components/kueue/development/kueue/kueue.yaml
+++ b/components/kueue/development/kueue/kueue.yaml
@@ -14,8 +14,8 @@ spec:
   config:
     integrations:
       frameworks: # The operator requires at lest one framework to be enabled
-       - BatchJob
+      - BatchJob
       externalFrameworks:
-       -  group: tekton.dev
-          version: v1
-          resource: pipelineruns
+      - group: tekton.dev
+        version: v1
+        resource: pipelineruns

--- a/components/kueue/production/base/kueue/kueue.yaml
+++ b/components/kueue/production/base/kueue/kueue.yaml
@@ -14,8 +14,8 @@ spec:
   config:
     integrations:
       frameworks: # The operator requires at lest one framework to be enabled
-       - BatchJob
+      - BatchJob
       externalFrameworks:
-       -  group: tekton.dev
-          version: v1
-          resource: pipelineruns
+      - group: tekton.dev
+        version: v1
+        resource: pipelineruns

--- a/components/kueue/staging/base/kueue/kueue.yaml
+++ b/components/kueue/staging/base/kueue/kueue.yaml
@@ -14,8 +14,8 @@ spec:
   config:
     integrations:
       frameworks: # The operator requires at lest one framework to be enabled
-       - BatchJob
+      - BatchJob
       externalFrameworks:
-       -  group: tekton.dev
-          version: v1
-          resource: pipelineruns
+      - group: tekton.dev
+        version: v1
+        resource: pipelineruns


### PR DESCRIPTION
The kueue.yaml manifests have unusual indentation conventions, and they can cause issues with yaml autoformatting tools.  Adjust them to be more in line with standard conventions.

Split from #8461.