### PR TITLE
fix(PVO11Y-4928): Remove run as user in kustomize

### DIFF
--- a/components/konflux-ui/staging/stone-stage-p01/remove-run-as-user-proxy-patch.yaml
+++ b/components/konflux-ui/staging/stone-stage-p01/remove-run-as-user-proxy-patch.yaml
@@ -10,3 +10,6 @@
 
 - op: remove
   path: /spec/template/spec/containers/1/securityContext/runAsUser
+
+- op: remove
+  path: /spec/template/spec/containers/2/securityContext/runAsUser

--- a/components/konflux-ui/staging/stone-stg-rh01/remove-run-as-user-proxy-patch.yaml
+++ b/components/konflux-ui/staging/stone-stg-rh01/remove-run-as-user-proxy-patch.yaml
@@ -10,3 +10,6 @@
 
 - op: remove
   path: /spec/template/spec/containers/1/securityContext/runAsUser
+
+- op: remove
+  path: /spec/template/spec/containers/2/securityContext/runAsUser


### PR DESCRIPTION
After merged PR https://github.com/redhat-appstudio/infra-deployments/pull/8365
There was a problem with argoCD not allowing runAsUser directive, but this directive is enforced by GitLab linter. 
I need to update files to remove that directive when kustomize applies