### PR TITLE
full read permissions on RoleBindings

### DIFF
--- a/components/konflux-rbac/production/base/konflux-admin-user-actions.yaml
+++ b/components/konflux-rbac/production/base/konflux-admin-user-actions.yaml
@@ -162,6 +162,7 @@ rules:
   - verbs:
       - get
       - list
+      - watch
       - create
       - update
       - patch

--- a/components/konflux-rbac/production/base/konflux-contributor-user-actions.yaml
+++ b/components/konflux-rbac/production/base/konflux-contributor-user-actions.yaml
@@ -134,7 +134,9 @@ rules:
     resources:
       - pulpaccessrequests
   - verbs:
+      - get
       - list
+      - watch
     apiGroups:
       - rbac.authorization.k8s.io
     resources:

--- a/components/konflux-rbac/production/base/konflux-maintainer-user-actions.yaml
+++ b/components/konflux-rbac/production/base/konflux-maintainer-user-actions.yaml
@@ -151,7 +151,9 @@ rules:
     resources:
       - pulpaccessrequests
   - verbs:
+      - get
       - list
+      - watch
     apiGroups:
       - rbac.authorization.k8s.io
     resources:

--- a/components/konflux-rbac/staging/base/konflux-admin-user-actions.yaml
+++ b/components/konflux-rbac/staging/base/konflux-admin-user-actions.yaml
@@ -162,6 +162,7 @@ rules:
   - verbs:
       - get
       - list
+      - watch
       - create
       - update
       - patch

--- a/components/konflux-rbac/staging/base/konflux-contributor-user-actions.yaml
+++ b/components/konflux-rbac/staging/base/konflux-contributor-user-actions.yaml
@@ -126,7 +126,9 @@ rules:
       - cronjobs
       - jobs
   - verbs:
+      - get
       - list
+      - watch
     apiGroups:
       - rbac.authorization.k8s.io
     resources:

--- a/components/konflux-rbac/staging/base/konflux-maintainer-user-actions.yaml
+++ b/components/konflux-rbac/staging/base/konflux-maintainer-user-actions.yaml
@@ -140,7 +140,9 @@ rules:
       - cronjobs
       - jobs
   - verbs:
+      - get
       - list
+      - watch
     apiGroups:
       - rbac.authorization.k8s.io
     resources:


### PR DESCRIPTION
This change provides full read access to RoleBindings to all personas which were already allowed to `list` RoleBindings.

Signed-off-by: Francesco Ilario <filario@redhat.com>
