### PR TITLE
ci: Add GH workflow to ensure pipelines new index image is an upgrade

### DIFF
--- a/.github/workflows/pipelines-ci.yaml
+++ b/.github/workflows/pipelines-ci.yaml
@@ -1,0 +1,48 @@
+name: Openshift Pipelines CI
+
+on:
+  pull_request:
+    paths:
+      - 'components/pipeline-service/**/main-pipeline-service-configuration.yaml'
+      - 'components/pipeline-service/**/deploy.yaml'
+
+jobs:
+  validate-pipelines-index:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
+    steps:
+      - name: Checkout pull request head
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          path: head
+          sparse-checkout: components/pipeline-service
+
+      - name: Checkout pull request base
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          path: base
+          sparse-checkout: components/pipeline-service
+
+      - name: Compare pipelines indexes
+        id: compare_indexes
+        run: head/components/pipeline-service/ci/check_bundle_is_upgrade.sh
+
+      - name: Comment warnings
+        if: ${{ steps.compare_indexes.outputs.comment != '' }}
+        uses: actions/github-script@v8
+        env:
+          MESSAGE: ${{steps.compare_indexes.outputs.comment}}
+        with:
+          script: |
+            const message = process.env.MESSAGE.replace(/\\n/g, "\n");
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `Openshift Pipelines CI found warnings\n${message}`,
+            });

--- a/components/pipeline-service/ci/check_bundle_is_upgrade.sh
+++ b/components/pipeline-service/ci/check_bundle_is_upgrade.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+#
+# Compare the changed pipelines bundle index images in two copies of the
+# the repository: one at ./head and one at ./base.
+# Emits any warnings to stdout and $GITHUB_OUTPUT.
+
+# Easiest way to identify all nested deploy.yaml files
+shopt -s globstar
+
+function extract_index_catalog() {
+    IMAGE_REF="${1}"
+    CONTAINER=$(podman create "${IMAGE_REF}")
+    tmpdir=$(mktemp -d)
+    podman cp "${CONTAINER}:/configs/openshift-pipelines-operator-rh/catalog.json" "${tmpdir}"
+    podman container rm "${CONTAINER}" >/dev/null
+    cat "${tmpdir}/catalog.json"
+}
+
+export OUTPUT=""
+
+for f in head/components/pipeline-service/**/deploy.yaml; do
+    CONFIG=$(echo "${f}" | cut -d '/' -f2-)
+    NEW_CONFIG="${f}"
+    OLD_CONFIG="base/${CONFIG}"
+    if [[ ! -e "${OLD_CONFIG}" ]]; then
+        echo "No corresponding manifest found for ${CONFIG} in base revision. Either the cluster is new or this is a CI bug. Skipping..."
+        continue
+    fi
+
+    OLD_INDEX_IMAGE=$(yq 'select(.kind == "CatalogSource") | .spec.image' "${OLD_CONFIG}")
+    NEW_INDEX_IMAGE=$(yq 'select(.kind == "CatalogSource") | .spec.image' "${NEW_CONFIG}")
+
+    if [[ "${OLD_INDEX_IMAGE}" == "${NEW_INDEX_IMAGE}" ]]; then
+        echo "No change in index image for ${CONFIG}"
+        continue
+    fi
+
+
+    OLD_CATALOG=$(extract_index_catalog "${OLD_INDEX_IMAGE}")
+    NEW_CATALOG=$(extract_index_catalog "${NEW_INDEX_IMAGE}")
+
+    OLD_BUILD_VERSION=$(echo "${OLD_CATALOG}" | jq -r 'select(.name | startswith("openshift-pipelines-operator-rh.v5.0.5")) | .properties.[] | select(.type == "olm.package") | .value.version')
+    NEW_BUILD_VERSION=$(echo "${NEW_CATALOG}" | jq -r 'select(.name | startswith("openshift-pipelines-operator-rh.v5.0.5")) | .properties.[] | select(.type == "olm.package") | .value.version')
+
+    echo "Comparing old build ${OLD_BUILD_VERSION} to new build ${NEW_BUILD_VERSION}"
+
+    OLD_BUILD_ID=$(echo "${OLD_BUILD_VERSION}" | cut -d '-' -f2)
+    NEW_BUILD_ID=$(echo "${NEW_BUILD_VERSION}" | cut -d '-' -f2)
+
+    if [ "${OLD_BUILD_ID}" -ge "${NEW_BUILD_ID}" ]; then
+        OUTPUT="${OUTPUT}- :warning: New index image in ${CONFIG} uses a operator version (${NEW_BUILD_VERSION}) which is not higher than current version (${OLD_BUILD_VERSION}). If applied, operator won't upgrade to new version\n"
+        LINE_NUMBER=$(grep --line-number "image: ${NEW_INDEX_IMAGE}" "${NEW_CONFIG}" | cut -d ':' -f1)
+        echo "::warning file=${CONFIG},line=${LINE_NUMBER}::Index references operator version ${NEW_BUILD_VERSION} which is not higher than previous operator version ${OLD_BUILD_VERSION}. If applied, operator won't upgrade to new version"
+    fi
+
+done
+
+echo "comment=${OUTPUT}" | tee -a "${GITHUB_OUTPUT:-out}"
+


### PR DESCRIPTION
Pipelines nightly builds use an incrementing build number to determine when to upgrade. If an index is used which has a lower build number than the currently-deployed build, the operator silently skips the upgrade.

This adds a CI job which runs any time a pipelines index is changed and warns the the PR author when a new index will not result in an upgrade.

An example of the output can be seen [in this PR](https://github.com/aThorp96/infra-deployments/pull/2/files):
<img width="937" height="320" alt="image" src="https://github.com/user-attachments/assets/f377ac2e-2912-41c9-b500-980338f1274c" />
<img width="1373" height="464" alt="image" src="https://github.com/user-attachments/assets/f7b1bf3a-a4c5-404c-ba00-59ebdd7fafae" />
