### PR TITLE
Add ci-operator as owner for monitoring

### DIFF
--- a/components/monitoring/OWNERS
+++ b/components/monitoring/OWNERS
@@ -15,3 +15,4 @@ approvers:
 - FaisalAl-Rayes
 - mike-kingsbury
 - kubasikus
+- ci-operator


### PR DESCRIPTION
Josiah England (@ci-operator) is a member of the PVO11Y team and should be included in the OWNERS file for the monitoring component so he can approve monitoring PRs.