### PR TITLE
promote release-service-monitor to staging

### DIFF
--- a/components/release/base/monitor/staging/configmap.yaml
+++ b/components/release/base/monitor/staging/configmap.yaml
@@ -11,7 +11,7 @@ data:
         - name: github
           url: https://github.com/konflux-ci/release-service-catalog
           revision: development
-          path: pipelines/fbc-release/fbc-release.yaml
+          path: pipelines/managed/fbc-release/fbc-release.yaml
       quay:
         - name: quayio
           tags:

--- a/components/release/base/monitor/staging/kustomization.yaml
+++ b/components/release/base/monitor/staging/kustomization.yaml
@@ -2,12 +2,12 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - configmap.yaml
-  - https://github.com/hacbs-release/release-service-monitor/config/default?ref=73e63a3db71ab5084150b31277710aabff613b03
+  - https://github.com/hacbs-release/release-service-monitor/config/default?ref=d69c564debaef8c0d9260a406ca8de9ee5ed8be7
 
 images:
   - name: quay.io/konflux-ci/release-service-monitor
     newName: quay.io/konflux-ci/release-service-monitor
-    newTag: 73e63a3db71ab5084150b31277710aabff613b03
+    newTag: d69c564debaef8c0d9260a406ca8de9ee5ed8be7
 
 patches:
   - path: patches/env-secrets-patch.yaml


### PR DESCRIPTION
Promote release-service-monitor to staging. Also, fixed the path to the pipeline in the service-config configmap. 