### PR TITLE
Revert "[KFLUXINFRA-2483] Read audit logs from syslog, not from file"

### DIFF
--- a/components/multi-platform-controller/base/logcollector/otelcollector.yaml
+++ b/components/multi-platform-controller/base/logcollector/otelcollector.yaml
@@ -93,15 +93,12 @@ spec:
                   os.type:
                     enabled: true
           receivers:
-            journald/{{ .index }}_audit:
-              start_at: end
+            filelog/{{ .index }}_audit:
+              include:
+                - /var/log/audit/audit.log
+              include_file_path: true
+              exclude_older_than: 86400s
               operators:
-                - type: filter
-                  id: audit_filter
-                  expr: |
-                    attributes["SYSLOG_IDENTIFIER"] == "audit" ||
-                    attributes["SYSLOG_IDENTIFIER"] == "auditd" ||
-                    attributes["MESSAGE"] matches "^type="
                 - type: add
                   id: {{ .index }}_idx
                   field: attributes["com.splunk.index"]
@@ -156,7 +153,7 @@ spec:
                   - transform/common
                 receivers:
                   # List all your receivers here
-                  - journald/{{ .index }}_audit
+                  - filelog/{{ .index }}_audit
                   - journald/{{ .index }}_messages
                   - journald/{{ .index }}_secure
                 exporters:


### PR DESCRIPTION
Unfortunately, this is not working...
Reverts redhat-appstudio/infra-deployments#10050