### PR TITLE
[MPC] Fix /var/tmp permissions for linux-root-{amd64,arm64} platforms

### DIFF
--- a/components/multi-platform-controller/staging/host-values.yaml
+++ b/components/multi-platform-controller/staging/host-values.yaml
@@ -165,12 +165,102 @@ dynamicConfigs:
       --//--
 
   linux-root-arm64:
-    sudoCommands: "/usr/bin/podman"
+    sudo-commands: "/usr/bin/podman"
     disk: "200"
+    user-data: |
+      Content-Type: multipart/mixed; boundary="//"
+      MIME-Version: 1.0
+
+      --//
+      Content-Type: text/cloud-config; charset="us-ascii"
+      MIME-Version: 1.0
+      Content-Transfer-Encoding: 7bit
+      Content-Disposition: attachment; filename="cloud-config.txt"
+
+      #cloud-config
+      cloud_final_modules:
+        - [scripts-user, always]
+
+      --//
+      Content-Type: text/x-shellscript; charset="us-ascii"
+      MIME-Version: 1.0
+      Content-Transfer-Encoding: 7bit
+      Content-Disposition: attachment; filename="userdata.txt"
+
+      #!/bin/bash -ex
+
+      # Format and mount NVMe disk
+      mkfs -t xfs /dev/nvme1n1
+      mount /dev/nvme1n1 /home
+
+      # Create required directories
+      mkdir -p /home/var-lib-containers /var/lib/containers /home/var-tmp /var/tmp /home/ec2-user/.ssh
+
+      # Setup bind mounts
+      mount --bind /home/var-lib-containers /var/lib/containers
+      mount --bind /home/var-tmp /var/tmp
+      chmod 1777 /home/var-tmp /var/tmp
+      chown root:root /home/var-tmp /var/tmp
+      restorecon -r /var/lib/containers /var/tmp
+
+      # Configure ec2-user SSH access
+      chown -R ec2-user /home/ec2-user
+      sed -n 's,.*\(ssh-.*\s\),\1,p' /root/.ssh/authorized_keys > /home/ec2-user/.ssh/authorized_keys
+      chown ec2-user /home/ec2-user/.ssh/authorized_keys
+      chmod 600 /home/ec2-user/.ssh/authorized_keys
+      chmod 700 /home/ec2-user/.ssh
+      restorecon -r /home/ec2-user
+
+      --//--
 
   linux-root-amd64:
-    sudoCommands: "/usr/bin/podman"
+    sudo-commands: "/usr/bin/podman"
     disk: "200"
+    user-data: |
+      Content-Type: multipart/mixed; boundary="//"
+      MIME-Version: 1.0
+
+      --//
+      Content-Type: text/cloud-config; charset="us-ascii"
+      MIME-Version: 1.0
+      Content-Transfer-Encoding: 7bit
+      Content-Disposition: attachment; filename="cloud-config.txt"
+
+      #cloud-config
+      cloud_final_modules:
+        - [scripts-user, always]
+
+      --//
+      Content-Type: text/x-shellscript; charset="us-ascii"
+      MIME-Version: 1.0
+      Content-Transfer-Encoding: 7bit
+      Content-Disposition: attachment; filename="userdata.txt"
+
+      #!/bin/bash -ex
+
+      # Format and mount NVMe disk
+      mkfs -t xfs /dev/nvme1n1
+      mount /dev/nvme1n1 /home
+
+      # Create required directories
+      mkdir -p /home/var-lib-containers /var/lib/containers /home/var-tmp /var/tmp /home/ec2-user/.ssh
+
+      # Setup bind mounts
+      mount --bind /home/var-lib-containers /var/lib/containers
+      mount --bind /home/var-tmp /var/tmp
+      chmod 1777 /home/var-tmp /var/tmp
+      chown root:root /home/var-tmp /var/tmp
+      restorecon -r /var/lib/containers /var/tmp
+
+      # Configure ec2-user SSH access
+      chown -R ec2-user /home/ec2-user
+      sed -n 's,.*\(ssh-.*\s\),\1,p' /root/.ssh/authorized_keys > /home/ec2-user/.ssh/authorized_keys
+      chown ec2-user /home/ec2-user/.ssh/authorized_keys
+      chmod 600 /home/ec2-user/.ssh/authorized_keys
+      chmod 700 /home/ec2-user/.ssh
+      restorecon -r /home/ec2-user
+
+      --//--
 
 # Static hosts configuration
 staticHosts:


### PR DESCRIPTION
## Summary

Fix `/var/tmp` permission issues for `linux-root-amd64` and `linux-root-arm64` build platforms by adding user-data initialization scripts with proper directory permissions.

## Problem

Builds using the `linux-root/amd64` platform are failing with permission errors:
```
Error: creating a temporary directory: mkdir /var/tmp/container_images_storage548378450: permission denied
```

This occurs because:
1. Remote build VMs run podman as `ec2-user` (uid 1001)
2. `/var/tmp` on these VMs doesn't have proper permissions for non-root users
3. Podman needs to create temporary storage directories when pulling images

This is blocking bootc image builds that require privileged-nested mode with `/dev/fuse` for fuse-overlayfs.

## Solution

Apply the same fix from PR #10595 (which fixed `linux-c6gd2xlarge-arm64`) to the `linux-root-{amd64,arm64}` platforms:

1. Add user-data initialization scripts that:
   - Mount NVMe storage to `/home`
   - Bind mount `/home/var-tmp` to `/var/tmp`
   - Set proper permissions: `chmod 1777 /var/tmp` (sticky bit + world writable)
   - Set ownership: `chown root:root /var/tmp`
   - Apply SELinux context with `restorecon`

2. Fix key naming from `sudoCommands` to `sudo-commands` to match conventions used in other platform configurations

## Changes

- Modified: `components/multi-platform-controller/staging/host-values.yaml`
  - Added `user-data` configuration for `linux-root-amd64`
  - Added `user-data` configuration for `linux-root-arm64`
  - Fixed parameter naming consistency

## Testing

After this change is deployed to staging:
1. Builds using `linux-root/amd64` platform should succeed
2. Podman image pulls on remote VMs should complete without permission errors
3. Bootc image builds with privileged-nested mode should work correctly

## Related

- Related to: #10595 (fixed same issue for `linux-c6gd2xlarge-arm64`)
- Fixes: automation-portal-bootc builds failing with `/var/tmp` permission denied
- Upstream issue: https://github.com/ansible-automation-platform/automation-portal-bootc-container (bootc builds requiring fuse-overlayfs)

## Deployment

This change affects:
- **Staging**: `components/multi-platform-controller/staging/`
- **Production**: Will need follow-up PRs for production environments after staging validation

<!-- Remove /hold after review and approval -->
