### PR TITLE
KFLUXINFRA-2965: Add missing components to kflux-fedora-01

### DIFF
--- a/argo-cd-apps/base/member/infra-deployments/etcd-defrag/etcd-defrag.yaml
+++ b/argo-cd-apps/base/member/infra-deployments/etcd-defrag/etcd-defrag.yaml
@@ -34,6 +34,8 @@ spec:
                   values.clusterDir: kflux-rhel-p01
                 - nameNormalized: kflux-osp-p01
                   values.clusterDir: kflux-osp-p01
+                - nameNormalized: kflux-fedora-01
+                  values.clusterDir: kflux-fedora-01
   template:
     metadata:
       name: etcd-defrag-{{nameNormalized}}

--- a/components/cert-manager/production/kflux-fedora-01/kustomization.yaml
+++ b/components/cert-manager/production/kflux-fedora-01/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../base

--- a/components/kueue/production/kflux-fedora-01/kustomization.yaml
+++ b/components/kueue/production/kflux-fedora-01/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../base
+- queue-config
+
+commonAnnotations:
+  argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true

--- a/components/kueue/production/kflux-fedora-01/queue-config/cluster-queue.yaml
+++ b/components/kueue/production/kflux-fedora-01/queue-config/cluster-queue.yaml
@@ -1,0 +1,194 @@
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: ClusterQueue
+metadata:
+  name: cluster-pipeline-queue
+spec:
+  flavorFungibility:
+    whenCanBorrow: Borrow
+    whenCanPreempt: TryNextFlavor
+  namespaceSelector: {}
+  preemption:
+    borrowWithinCohort:
+      policy: Never
+    reclaimWithinCohort: Never
+    withinClusterQueue: Never
+  queueingStrategy: BestEffortFIFO
+  resourceGroups:
+  - coveredResources:
+    - tekton.dev/pipelineruns
+    - cpu
+    - memory
+    - aws-ip
+    - mintmaker
+    flavors:
+    - name: default-flavor
+      resources:
+      - name: tekton.dev/pipelineruns
+        nominalQuota: '300'
+      - name: cpu
+        nominalQuota: 1k
+      - name: memory
+        nominalQuota: 500Ti
+      - name: aws-ip
+        nominalQuota: '250'
+      - name: mintmaker
+        nominalQuota: '150'
+  - coveredResources:
+    - linux-amd64
+    - linux-arm64
+    - linux-cxlarge-amd64
+    - linux-cxlarge-arm64
+    - linux-c2xlarge-amd64
+    - linux-c2xlarge-arm64
+    - linux-c4xlarge-amd64
+    - linux-c4xlarge-arm64
+    - linux-c8xlarge-amd64
+    - linux-c8xlarge-arm64
+    - linux-c6gd2xlarge-arm64
+    - linux-d160-c8xlarge-amd64
+    - linux-d160-c8xlarge-arm64
+    flavors:
+    - name: platform-group-1
+      resources:
+      - name: linux-amd64
+        nominalQuota: '250'
+      - name: linux-arm64
+        nominalQuota: '250'
+      - name: linux-cxlarge-amd64
+        nominalQuota: '250'
+      - name: linux-cxlarge-arm64
+        nominalQuota: '250'
+      - name: linux-c2xlarge-amd64
+        nominalQuota: '250'
+      - name: linux-c2xlarge-arm64
+        nominalQuota: '250'
+      - name: linux-c4xlarge-amd64
+        nominalQuota: '250'
+      - name: linux-c4xlarge-arm64
+        nominalQuota: '250'
+      - name: linux-c8xlarge-amd64
+        nominalQuota: '250'
+      - name: linux-c8xlarge-arm64
+        nominalQuota: '250'
+      - name: linux-c6gd2xlarge-arm64
+        nominalQuota: '250'
+      - name: linux-d160-c8xlarge-amd64
+        nominalQuota: '250'
+      - name: linux-d160-c8xlarge-arm64
+        nominalQuota: '250'
+  - coveredResources:
+    - linux-m2xlarge-amd64
+    - linux-m2xlarge-arm64
+    - linux-m4xlarge-amd64
+    - linux-m4xlarge-arm64
+    - linux-m8xlarge-amd64
+    - linux-d160-m2xlarge-amd64
+    - linux-d160-m2xlarge-arm64
+    - linux-d160-m4xlarge-amd64
+    - linux-d160-m4xlarge-arm64
+    - linux-d160-m8xlarge-amd64
+    - linux-d160-m8xlarge-arm64
+    - linux-g4xlarge-amd64
+    - linux-g6xlarge-amd64
+    - linux-g6xlarge-arm64
+    flavors:
+    - name: platform-group-2
+      resources:
+      - name: linux-m2xlarge-amd64
+        nominalQuota: '250'
+      - name: linux-m2xlarge-arm64
+        nominalQuota: '250'
+      - name: linux-m4xlarge-amd64
+        nominalQuota: '250'
+      - name: linux-m4xlarge-arm64
+        nominalQuota: '250'
+      - name: linux-m8xlarge-amd64
+        nominalQuota: '250'
+      - name: linux-d160-m2xlarge-amd64
+        nominalQuota: '250'
+      - name: linux-d160-m2xlarge-arm64
+        nominalQuota: '250'
+      - name: linux-d160-m4xlarge-amd64
+        nominalQuota: '250'
+      - name: linux-d160-m4xlarge-arm64
+        nominalQuota: '250'
+      - name: linux-d160-m8xlarge-amd64
+        nominalQuota: '250'
+      - name: linux-d160-m8xlarge-arm64
+        nominalQuota: '250'
+      - name: linux-g4xlarge-amd64
+        nominalQuota: '250'
+      - name: linux-g6xlarge-amd64
+        nominalQuota: '250'
+      - name: linux-g6xlarge-arm64
+        nominalQuota: '250'
+  - coveredResources:
+    - linux-mlarge-amd64
+    - linux-mlarge-arm64
+    - linux-mxlarge-amd64
+    - linux-mxlarge-arm64
+    - linux-m8xlarge-arm64
+    - linux-ppc64le
+    - linux-root-amd64
+    - linux-root-arm64
+    - linux-s390x
+    - linux-x86-64
+    - local
+    - localhost
+    - linux-fast-amd64
+    - linux-extra-fast-amd64
+    flavors:
+    - name: platform-group-3
+      resources:
+      - name: linux-mlarge-amd64
+        nominalQuota: '250'
+      - name: linux-mlarge-arm64
+        nominalQuota: '250'
+      - name: linux-mxlarge-amd64
+        nominalQuota: '250'
+      - name: linux-mxlarge-arm64
+        nominalQuota: '250'
+      - name: linux-m8xlarge-arm64
+        nominalQuota: '250'
+      - name: linux-ppc64le
+        nominalQuota: '64'
+      - name: linux-root-amd64
+        nominalQuota: '250'
+      - name: linux-root-arm64
+        nominalQuota: '250'
+      - name: linux-s390x
+        nominalQuota: '56'
+      - name: linux-x86-64
+        nominalQuota: '1000'
+      - name: local
+        nominalQuota: '1000'
+      - name: localhost
+        nominalQuota: '1000'
+      - name: linux-fast-amd64
+        nominalQuota: '250'
+      - name: linux-extra-fast-amd64
+        nominalQuota: '250'
+  stopPolicy: None
+---
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: ResourceFlavor
+metadata:
+  name: default-flavor
+---
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: ResourceFlavor
+metadata:
+  name: platform-group-1
+spec: {}
+---
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: ResourceFlavor
+metadata:
+  name: platform-group-2
+spec: {}
+---
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: ResourceFlavor
+metadata:
+  name: platform-group-3
+spec: {}

--- a/components/kueue/production/kflux-fedora-01/queue-config/kustomization.yaml
+++ b/components/kueue/production/kflux-fedora-01/queue-config/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- cluster-queue.yaml
+- ../../base/queue-config
+
+# ensure that installation starts after the installation of kueue complete
+commonAnnotations:
+  argocd.argoproj.io/sync-wave: "10"


### PR DESCRIPTION
Add the cert-manager and kueue components that were not generated by the new-cluster Ansible playbook.

[KFLUXINFRA-2965](https://issues.redhat.com/browse/KFLUXINFRA-2965)