### PR TITLE
update konflux-ci/group-sync-operator image references in helm chart and prod

### DIFF
--- a/components/authentication/helm-charts/group-sync-operator-chart/values.yaml
+++ b/components/authentication/helm-charts/group-sync-operator-chart/values.yaml
@@ -8,7 +8,7 @@ image:
   repository: quay.io/konflux-ci/group-sync-operator
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  version: sha256:9bfebf0f27a393dc7254ba8e7b88278ce1f7b31a8470267da5a3489c64f8d64a
+  version: sha256:4f384c760c7821be60c8f2d9b46152c986af8723f71ad6bfc5cc8372a7c658b8
 
 imagePullSecrets: []
 nameOverride: ""

--- a/components/authentication/production/base/kustomization.yaml
+++ b/components/authentication/production/base/kustomization.yaml
@@ -3,6 +3,9 @@ kind: Kustomization
 resources:
   - ../../base
   - ../../helm-charts
+images:
+  - name: quay.io/konflux-ci/group-sync-operator
+    digest: sha256:4f384c760c7821be60c8f2d9b46152c986af8723f71ad6bfc5cc8372a7c658b8
 patches:
   - path: rhtap-infra-secrets-patch.yaml
     target:


### PR DESCRIPTION
## What
Update konflux-ci/group-sync-operator image references in helm chart and production Base
## Why
Keep group-sync up-to-date
## Validation
It's working fine on staging clusters, here are some evidence:
- Staging PR - #10849
- Claude report:
<img width="1867" height="586" alt="image" src="https://github.com/user-attachments/assets/534cafb1-a4eb-4b33-80eb-645aabdc713f" />

## Risk Assessment
**Risk Level:** Low
**Rollback:** Revert PR and redeploy previous image tag

> NOTE: We probably can apply it all at once because group-sync has issues in public clusters (it's work on progress), so effectively only 2 clusters will be influenced 