### PR TITLE
policies: apply argocd replacement label to policies

### DIFF
--- a/components/policies/development/integration/bootstrap-namespace/bootstrap-namespace.yaml
+++ b/components/policies/development/integration/bootstrap-namespace/bootstrap-namespace.yaml
@@ -29,6 +29,7 @@ spec:
         value: "tenant"
     generate:
       generateExisting: true
+      orphanDownstreamOnPolicyDelete: true
       synchronize: false
       apiVersion: v1
       kind: ServiceAccount
@@ -54,6 +55,7 @@ spec:
         value: "tenant"
     generate:
       generateExisting: true
+      orphanDownstreamOnPolicyDelete: true
       synchronize: false
       apiVersion: rbac.authorization.k8s.io/v1
       kind: RoleBinding

--- a/components/policies/development/konflux-rbac/bootstrap-tenant-namespace/bootstrap-tenant-namespace-np-ocpconsole-clusterpolicy.yaml
+++ b/components/policies/development/konflux-rbac/bootstrap-tenant-namespace/bootstrap-tenant-namespace-np-ocpconsole-clusterpolicy.yaml
@@ -17,6 +17,7 @@ spec:
               konflux-ci.dev/type: tenant
     generate:
       generateExisting: true
+      orphanDownstreamOnPolicyDelete: true
       synchronize: false
       apiVersion: networking.k8s.io/v1
       kind: NetworkPolicy

--- a/components/policies/development/konflux-rbac/bootstrap-tenant-namespace/bootstrap-tenant-namespace-np-ocpingress-clusterpolicy.yaml
+++ b/components/policies/development/konflux-rbac/bootstrap-tenant-namespace/bootstrap-tenant-namespace-np-ocpingress-clusterpolicy.yaml
@@ -17,6 +17,7 @@ spec:
               konflux-ci.dev/type: tenant
     generate:
       generateExisting: true
+      orphanDownstreamOnPolicyDelete: true
       synchronize: false
       apiVersion: networking.k8s.io/v1
       kind: NetworkPolicy

--- a/components/policies/development/konflux-rbac/bootstrap-tenant-namespace/bootstrap-tenant-namespace-np-ocpmonitoring-clusterpolicy.yaml
+++ b/components/policies/development/konflux-rbac/bootstrap-tenant-namespace/bootstrap-tenant-namespace-np-ocpmonitoring-clusterpolicy.yaml
@@ -17,6 +17,7 @@ spec:
               konflux-ci.dev/type: tenant
     generate:
       generateExisting: true
+      orphanDownstreamOnPolicyDelete: true
       synchronize: false
       apiVersion: networking.k8s.io/v1
       kind: NetworkPolicy

--- a/components/policies/development/konflux-rbac/bootstrap-tenant-namespace/bootstrap-tenant-namespace-np-olm-clusterpolicy.yaml
+++ b/components/policies/development/konflux-rbac/bootstrap-tenant-namespace/bootstrap-tenant-namespace-np-olm-clusterpolicy.yaml
@@ -17,6 +17,7 @@ spec:
               konflux-ci.dev/type: tenant
     generate:
       generateExisting: true
+      orphanDownstreamOnPolicyDelete: true
       synchronize: false
       apiVersion: networking.k8s.io/v1
       kind: NetworkPolicy

--- a/components/policies/development/konflux-rbac/bootstrap-tenant-namespace/bootstrap-tenant-namespace-np-samenamespace-clusterpolicy.yaml
+++ b/components/policies/development/konflux-rbac/bootstrap-tenant-namespace/bootstrap-tenant-namespace-np-samenamespace-clusterpolicy.yaml
@@ -17,6 +17,7 @@ spec:
               konflux-ci.dev/type: tenant
     generate:
       generateExisting: true
+      orphanDownstreamOnPolicyDelete: true
       synchronize: false
       apiVersion: networking.k8s.io/v1
       kind: NetworkPolicy

--- a/components/policies/development/konflux-rbac/bootstrap-tenant-namespace/bootstrap-tenant-namespace-rbcm-clusterpolicy.yaml
+++ b/components/policies/development/konflux-rbac/bootstrap-tenant-namespace/bootstrap-tenant-namespace-rbcm-clusterpolicy.yaml
@@ -17,6 +17,7 @@ spec:
               konflux-ci.dev/type: tenant
     generate:
       generateExisting: true
+      orphanDownstreamOnPolicyDelete: true
       synchronize: false
       apiVersion: v1
       kind: ConfigMap

--- a/components/policies/development/konflux-rbac/konflux-support-access/generate-support-clusterrolebinding-clusterpolicy.yaml
+++ b/components/policies/development/konflux-rbac/konflux-support-access/generate-support-clusterrolebinding-clusterpolicy.yaml
@@ -40,6 +40,7 @@ spec:
             jmesPath: "request.object.users[] | [].{kind: 'User', apiGroup: 'rbac.authorization.k8s.io', name: @}"
       generate:
         generateExisting: true
+        orphanDownstreamOnPolicyDelete: true
         synchronize: true
         apiVersion: rbac.authorization.k8s.io/v1
         kind: ClusterRoleBinding

--- a/components/policies/development/kubearchive/bootstrap-namespace/bootstrap-namespace.yaml
+++ b/components/policies/development/kubearchive/bootstrap-namespace/bootstrap-namespace.yaml
@@ -16,6 +16,7 @@ spec:
               konflux-ci.dev/type: tenant
     generate:
       generateExisting: true
+      orphanDownstreamOnPolicyDelete: true
       apiVersion: kubearchive.org/v1
       kind: KubeArchiveConfig
       name: kubearchive

--- a/components/policies/development/kueue/queue-config/cluster-policy.yaml
+++ b/components/policies/development/kueue/queue-config/cluster-policy.yaml
@@ -23,6 +23,7 @@ spec:
           - appstudio-kanary-exporter
     generate:
       generateExisting: true
+      orphanDownstreamOnPolicyDelete: true
       synchronize: true
       apiVersion: kueue.x-k8s.io/v1beta1
       kind: LocalQueue

--- a/components/policies/development/kustomization.yaml
+++ b/components/policies/development/kustomization.yaml
@@ -10,3 +10,24 @@ resources:
 - integration/
 - kubearchive/
 - kueue/
+patches:
+- patch: |-
+    apiVersion: kyverno.io/v1
+    kind: ClusterPolicy
+    metadata:
+      annotations:
+        argocd.argoproj.io/sync-options: Replace=true
+      name: not-used
+  target:
+    group: kyverno.io
+    kind: ClusterPolicy
+- patch: |-
+    apiVersion: kyverno.io/v1
+    kind: ValidatingPolicy
+    metadata:
+      annotations:
+        argocd.argoproj.io/sync-options: Replace=true
+      name: not-used
+  target:
+    group: kyverno.io
+    kind: ValidatingPolicy

--- a/components/policies/staging/stone-stage-p01/kustomization.yaml
+++ b/components/policies/staging/stone-stage-p01/kustomization.yaml
@@ -4,3 +4,24 @@ resources:
 - ../base/
 - ../policies/kubearchive/
 - ../policies/kueue/
+patches:
+- patch: |-
+    apiVersion: kyverno.io/v1
+    kind: ClusterPolicy
+    metadata:
+      annotations:
+        argocd.argoproj.io/sync-options: Replace=true
+      name: not-used
+  target:
+    group: kyverno.io
+    kind: ClusterPolicy
+- patch: |-
+    apiVersion: kyverno.io/v1
+    kind: ValidatingPolicy
+    metadata:
+      annotations:
+        argocd.argoproj.io/sync-options: Replace=true
+      name: not-used
+  target:
+    group: kyverno.io
+    kind: ValidatingPolicy

--- a/components/policies/staging/stone-stg-rh01/kustomization.yaml
+++ b/components/policies/staging/stone-stg-rh01/kustomization.yaml
@@ -4,3 +4,24 @@ resources:
 - ../base/
 - ../policies/kubearchive/
 - ../policies/kueue/
+patches:
+- patch: |-
+    apiVersion: kyverno.io/v1
+    kind: ClusterPolicy
+    metadata:
+      annotations:
+        argocd.argoproj.io/sync-options: Replace=true
+      name: not-used
+  target:
+    group: kyverno.io
+    kind: ClusterPolicy
+- patch: |-
+    apiVersion: kyverno.io/v1
+    kind: ValidatingPolicy
+    metadata:
+      annotations:
+        argocd.argoproj.io/sync-options: Replace=true
+      name: not-used
+  target:
+    group: kyverno.io
+    kind: ValidatingPolicy


### PR DESCRIPTION
Kyverno enforces that instances of its policy types are immutable.  This causes problems with our gitops methods, since making changes to the underlying git repositories makes argocd fail when attempting to apply those changes.  However, by instructing argocd to replace these resources using `kubectl replace`, we can mostly sidestep this problem.

Instruct argocd to replace kyverno's policies when they see changes.