### PR TITLE
kueue: update checks for tenant-release priority in prod

### DIFF
--- a/components/kueue/production/base/tekton-kueue/config.yaml
+++ b/components/kueue/production/base/tekton-kueue/config.yaml
@@ -113,8 +113,8 @@ cel:
         has(pipelineRun.metadata.labels) &&
         'appstudio.openshift.io/service' in pipelineRun.metadata.labels &&
         pipelineRun.metadata.labels['appstudio.openshift.io/service'] == 'release' &&
-        'pipelines.appstudio.openshift.io/type' in pipelineRun.metadata.labels &&
-        pipelineRun.metadata.labels['pipelines.appstudio.openshift.io/type'] == 'tenant' ?
+        'release.appstudio.openshift.io/namespace' in pipelineRun.metadata.labels &&
+        pipelineRun.metadata.labels['release.appstudio.openshift.io/namespace'] == plrNamespace ?
         priority('konflux-tenant-release') :
 
         plrNamespace == 'mintmaker' ? priority('konflux-dependency-update') :


### PR DESCRIPTION
The checks for a release pipeline in a tenant namespace are too strict, since users can see the `pipelines.appstudio.openshift.io/type` label to take values such as `tenant-collectors` or `final`.  These pipelines should be assigned the konflux-tenant-release priority instead of falling through to the default priority.

Furthermore, there's a better check for a release pipeline in a tenant: the value of the `release.appstudio.openshift.io/namespace` label should match the namespace of the pipelinerun.  Release pipelines running in the dedicated release namespace will fail this check.

Update the conditions for the `konflux-tenant-release` priority to only check for the namespace condition as well as the release service label.

* * *

Production version of #10902.