### PR TITLE
authorization: add kueue subresources to everyone-can-view in staging

### DIFF
--- a/components/authentication/staging/base/kustomization.yaml
+++ b/components/authentication/staging/base/kustomization.yaml
@@ -1,8 +1,14 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ../../base
-  - ../../helm-charts
+- ../../base
+- ../../helm-charts
 images:
-  - name: quay.io/konflux-ci/group-sync-operator
-    digest: sha256:4f384c760c7821be60c8f2d9b46152c986af8723f71ad6bfc5cc8372a7c658b8
+- digest: sha256:4f384c760c7821be60c8f2d9b46152c986af8723f71ad6bfc5cc8372a7c658b8
+  name: quay.io/konflux-ci/group-sync-operator
+patches:
+- path: view-kueue-resources-patch.yaml
+  target:
+    group: rbac.authorization.k8s.io
+    name: view-appstudio
+    version: v1

--- a/components/authentication/staging/base/view-kueue-resources-patch.yaml
+++ b/components/authentication/staging/base/view-kueue-resources-patch.yaml
@@ -1,0 +1,13 @@
+---
+- op: add
+  path: /rules/-
+  value:
+    apiGroups:
+    - visibility.kueue.x-k8s.io
+    resources:
+    - clusterqueues/pendingworkloads
+    - localqueues/pendingworkloads
+    verbs:
+    - get
+    - list
+    - watch


### PR DESCRIPTION
Kueue maintains some subresources underneath clusterqueues and localqueues.  The information exposed in these resources can be useful for debugging issues with kueue and getting a better understanding of what it will be processing next.

Give permissions to konflux developers to view these resources.  Since this information exposes the identities of other tenants, these permissions should not be given to users and should not be aggregated to the view role.