### PR TITLE
policies: don't remove generated resources on deletion

### DIFF
--- a/components/policies/development/integration/bootstrap-namespace/.chainsaw-test/chainsaw-test.yaml
+++ b/components/policies/development/integration/bootstrap-namespace/.chainsaw-test/chainsaw-test.yaml
@@ -327,3 +327,74 @@ spec:
         expect:
         - check:
             ($error != null): true
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: orphan-resources-on-policy-deletion
+spec:
+  description: |
+    tests that resources created by this policy remain when the policy is deleted
+  concurrent: false
+  namespace: 'generate-new-namespace'
+  bindings:
+  - name: suffix
+    value: orphan
+  steps:
+  - name: given-konflux-integration-runner-clusterrole-exists
+    try:
+    - apply:
+        file: resources/actual-konflux-integration-runner-clusterrole.yaml
+  - name: given-kyverno-has-permission-on-resources
+    try:
+    - apply:
+        file: ../kyverno-rbac.yaml
+  - name: given-cluster-policy-is-ready
+    try:
+    - apply:
+        file: ../bootstrap-namespace.yaml
+    - assert:
+        file: chainsaw-assert-clusterpolicy.yaml
+  - name: when-konfluxcidev-labeled-namespace-is-created
+    try:
+    - apply:
+        file: resources/actual-namespace-konfluxcidev.yaml
+        template: true
+  - name: then-serviceaccount-is-created
+    try:
+    - assert:
+        file: resources/expected-integration-serviceaccount.yaml
+        template: true
+  - name: then-rolebinding-is-created
+    try:
+    - assert:
+        file: resources/expected-integration-rolebinding.yaml
+        template: true
+  - name: when-the-policy-is-deleted
+    try:
+    - delete:
+        file: ../bootstrap-namespace.yaml
+    - wait:
+        apiVersion: kyverno.io/v1
+        kind: ClusterPolicy
+        name: init-ns-integration
+        for:
+          deletion: {}
+    - script:
+        content: |
+          while true; do
+            if [ "$(kubectl get updaterequests -n konflux-kyverno -o yaml | yq '.items | length')" -eq 0 ]; then
+              exit 0
+            fi
+            sleep 1
+          done
+        timeout: 30s
+  - name: then-the-resouces-remain
+    try:
+    - assert:
+        file: resources/expected-integration-serviceaccount.yaml
+        template: true
+    - assert:
+        file: resources/expected-integration-rolebinding.yaml
+        template: true

--- a/components/policies/development/integration/bootstrap-namespace/bootstrap-namespace.yaml
+++ b/components/policies/development/integration/bootstrap-namespace/bootstrap-namespace.yaml
@@ -29,6 +29,7 @@ spec:
         value: "tenant"
     generate:
       generateExisting: true
+      orphanDownstreamOnPolicyDelete: true
       synchronize: false
       apiVersion: v1
       kind: ServiceAccount
@@ -54,6 +55,7 @@ spec:
         value: "tenant"
     generate:
       generateExisting: true
+      orphanDownstreamOnPolicyDelete: true
       synchronize: false
       apiVersion: rbac.authorization.k8s.io/v1
       kind: RoleBinding

--- a/components/policies/development/konflux-rbac/bootstrap-tenant-namespace/.chainsaw-test/chainsaw-test.yaml
+++ b/components/policies/development/konflux-rbac/bootstrap-tenant-namespace/.chainsaw-test/chainsaw-test.yaml
@@ -314,3 +314,85 @@ spec:
     - assert:
         file: resources/actual-existing-resources.yaml
         template: true
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: orphan-resources-on-policy-deletion
+spec:
+  description: |
+    tests that the resources remain in a tenant namespace when the cluster policy is deleted
+  concurrent: false
+  namespace: 'orphan-resources'
+  bindings:
+  - name: suffix
+    value: orphan
+  steps:
+  - name: given-appstudio-pipeline-clusterrole-exists
+    try:
+    - apply:
+        file: ./resources/actual-appstudio-pipeline-clusterrole.yaml
+  - name: given-kyverno-has-permission-on-resources
+    try:
+    - apply:
+        file: ../kyverno_rbac.yaml
+  - name: given-cluster-policies-are-ready
+    try:
+    - apply:
+        file: ../bootstrap-tenant-namespace-np-ocpconsole-clusterpolicy.yaml
+    - apply:
+        file: ../bootstrap-tenant-namespace-np-ocpingress-clusterpolicy.yaml
+    - apply:
+        file: ../bootstrap-tenant-namespace-np-ocpmonitoring-clusterpolicy.yaml
+    - apply:
+        file: ../bootstrap-tenant-namespace-np-olm-clusterpolicy.yaml
+    - apply:
+        file: ../bootstrap-tenant-namespace-np-samenamespace-clusterpolicy.yaml
+    - apply:
+        file: ../bootstrap-tenant-namespace-rbcm-clusterpolicy.yaml
+    - assert:
+        file: chainsaw-assert-clusterpolicy.yaml
+  - name: when-konfluxcidev-labeled-namespace-is-created
+    try:
+    - apply:
+        file: resources/actual-namespace-konfluxcidev.yaml
+        template: true
+  - name: then-resources-are-created
+    try:
+    - assert:
+        file: resources/expected-resources.yaml
+        template: true
+  - name: when-the-cluster-policy-is-deleted
+    try:
+    - delete:
+        file: ../bootstrap-tenant-namespace-np-ocpconsole-clusterpolicy.yaml
+    - delete:
+        file: ../bootstrap-tenant-namespace-np-ocpingress-clusterpolicy.yaml
+    - delete:
+        file: ../bootstrap-tenant-namespace-np-ocpmonitoring-clusterpolicy.yaml
+    - delete:
+        file: ../bootstrap-tenant-namespace-np-olm-clusterpolicy.yaml
+    - delete:
+        file: ../bootstrap-tenant-namespace-np-samenamespace-clusterpolicy.yaml
+    - delete:
+        file: ../bootstrap-tenant-namespace-rbcm-clusterpolicy.yaml
+    - wait:
+        apiVersion: kyverno.io/v1
+        kind: ClusterPolicy
+        for:
+          deletion: {}
+    - script:
+        content: |
+          while true; do
+            if [ "$(kubectl get updaterequests -n konflux-kyverno -o yaml | yq '.items | length')" -eq 0 ]; then
+              exit 0
+            fi
+            sleep 1
+          done
+        timeout: 30s
+  - name: then-the-resources-remain
+    try:
+    - assert:
+        file: resources/expected-resources.yaml
+        template: true

--- a/components/policies/development/konflux-rbac/bootstrap-tenant-namespace/bootstrap-tenant-namespace-np-ocpconsole-clusterpolicy.yaml
+++ b/components/policies/development/konflux-rbac/bootstrap-tenant-namespace/bootstrap-tenant-namespace-np-ocpconsole-clusterpolicy.yaml
@@ -17,6 +17,7 @@ spec:
               konflux-ci.dev/type: tenant
     generate:
       generateExisting: true
+      orphanDownstreamOnPolicyDelete: true
       synchronize: false
       apiVersion: networking.k8s.io/v1
       kind: NetworkPolicy

--- a/components/policies/development/konflux-rbac/bootstrap-tenant-namespace/bootstrap-tenant-namespace-np-ocpingress-clusterpolicy.yaml
+++ b/components/policies/development/konflux-rbac/bootstrap-tenant-namespace/bootstrap-tenant-namespace-np-ocpingress-clusterpolicy.yaml
@@ -17,6 +17,7 @@ spec:
               konflux-ci.dev/type: tenant
     generate:
       generateExisting: true
+      orphanDownstreamOnPolicyDelete: true
       synchronize: false
       apiVersion: networking.k8s.io/v1
       kind: NetworkPolicy

--- a/components/policies/development/konflux-rbac/bootstrap-tenant-namespace/bootstrap-tenant-namespace-np-ocpmonitoring-clusterpolicy.yaml
+++ b/components/policies/development/konflux-rbac/bootstrap-tenant-namespace/bootstrap-tenant-namespace-np-ocpmonitoring-clusterpolicy.yaml
@@ -17,6 +17,7 @@ spec:
               konflux-ci.dev/type: tenant
     generate:
       generateExisting: true
+      orphanDownstreamOnPolicyDelete: true
       synchronize: false
       apiVersion: networking.k8s.io/v1
       kind: NetworkPolicy

--- a/components/policies/development/konflux-rbac/bootstrap-tenant-namespace/bootstrap-tenant-namespace-np-olm-clusterpolicy.yaml
+++ b/components/policies/development/konflux-rbac/bootstrap-tenant-namespace/bootstrap-tenant-namespace-np-olm-clusterpolicy.yaml
@@ -17,6 +17,7 @@ spec:
               konflux-ci.dev/type: tenant
     generate:
       generateExisting: true
+      orphanDownstreamOnPolicyDelete: true
       synchronize: false
       apiVersion: networking.k8s.io/v1
       kind: NetworkPolicy

--- a/components/policies/development/konflux-rbac/bootstrap-tenant-namespace/bootstrap-tenant-namespace-np-samenamespace-clusterpolicy.yaml
+++ b/components/policies/development/konflux-rbac/bootstrap-tenant-namespace/bootstrap-tenant-namespace-np-samenamespace-clusterpolicy.yaml
@@ -17,6 +17,7 @@ spec:
               konflux-ci.dev/type: tenant
     generate:
       generateExisting: true
+      orphanDownstreamOnPolicyDelete: true
       synchronize: false
       apiVersion: networking.k8s.io/v1
       kind: NetworkPolicy

--- a/components/policies/development/konflux-rbac/bootstrap-tenant-namespace/bootstrap-tenant-namespace-rbcm-clusterpolicy.yaml
+++ b/components/policies/development/konflux-rbac/bootstrap-tenant-namespace/bootstrap-tenant-namespace-rbcm-clusterpolicy.yaml
@@ -17,6 +17,7 @@ spec:
               konflux-ci.dev/type: tenant
     generate:
       generateExisting: true
+      orphanDownstreamOnPolicyDelete: true
       synchronize: false
       apiVersion: v1
       kind: ConfigMap

--- a/components/policies/development/konflux-rbac/konflux-support-access/.chainsaw-test/chainsaw-test.yaml
+++ b/components/policies/development/konflux-rbac/konflux-support-access/.chainsaw-test/chainsaw-test.yaml
@@ -384,3 +384,169 @@ spec:
                 apiGroup: rbac.authorization.k8s.io
                 kind: ClusterRole
                 name: konflux-viewer-user-actions
+---
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: orphan-generated-resources
+spec:
+  concurrent: false
+  description: |
+    Tests that removal of the cluster policy doesn't delete the generated cluster role bindings
+  steps:
+    - name: given-kyverno-has-permission-on-resources
+      try:
+        - apply:
+            file: ../kyverno_rbac.yaml
+    - name: given-viewer-clusterrole-exists
+      try:
+        - apply:
+            resource:
+              apiVersion: rbac.authorization.k8s.io/v1
+              kind: ClusterRole
+              metadata:
+                name: konflux-viewer-user-actions
+              rules: []
+    - name: given-group-crd-exists
+      try:
+        - apply:
+            file: resources/group-crd.yaml
+        - assert:
+            resource:
+              apiVersion: apiextensions.k8s.io/v1
+              kind: CustomResourceDefinition
+              metadata:
+                name: groups.user.openshift.io
+              status:
+                conditions:
+                - type: NamesAccepted
+                  status: "True"
+                - type: Established
+                  status: "True"
+    - name: Apply Kyverno ClusterPolicy
+      try:
+        - apply:
+            file: ../generate-support-clusterrolebinding-clusterpolicy.yaml
+        - assert:
+            file: chainsaw-assert-clusterpolicy.yaml
+    - name: Create ai-konflux-user-support Group with users
+      try:
+        - create:
+            file: ./resources/group-with-users-ai-konflux-user-support.yaml
+    - name: Assert ai-konflux-user-support's support ClusterRoleBinding is created correctly
+      try:
+        - assert:
+            resource:
+              apiVersion: rbac.authorization.k8s.io/v1
+              kind: ClusterRoleBinding
+              metadata:
+                name: konflux-support-ai-konflux-user-support
+                labels:
+                  namespace-lister.konflux-ci.dev/use-for-access: 'true'
+              roleRef:
+                apiGroup: rbac.authorization.k8s.io
+                kind: ClusterRole
+                name: konflux-viewer-user-actions
+              subjects:
+                - apiGroup: rbac.authorization.k8s.io
+                  kind: User
+                  name: alice
+                - apiGroup: rbac.authorization.k8s.io
+                  kind: User
+                  name: bob
+                - apiGroup: rbac.authorization.k8s.io
+                  kind: User
+                  name: charlie
+    - name: Create konflux-sre Group with users
+      try:
+        - create:
+            file: ./resources/group-with-users-konflux-sre.yaml
+    - name: Assert konflux-sre's support ClusterRoleBinding is created correctly
+      try:
+        - assert:
+            resource:
+              apiVersion: rbac.authorization.k8s.io/v1
+              kind: ClusterRoleBinding
+              metadata:
+                name: konflux-support-konflux-sre
+                labels:
+                  namespace-lister.konflux-ci.dev/use-for-access: 'true'
+              roleRef:
+                apiGroup: rbac.authorization.k8s.io
+                kind: ClusterRole
+                name: konflux-viewer-user-actions
+              subjects:
+                - apiGroup: rbac.authorization.k8s.io
+                  kind: User
+                  name: dan
+                - apiGroup: rbac.authorization.k8s.io
+                  kind: User
+                  name: frank
+                - apiGroup: rbac.authorization.k8s.io
+                  kind: User
+                  name: john
+    - name: Delete the cluster policy
+      try:
+        - delete:
+            file: ../generate-support-clusterrolebinding-clusterpolicy.yaml
+        - wait:
+            apiVersion: kyverno.io/v1
+            kind: ClusterPolicy
+            name: generate-konflux-viewer-access
+            for:
+              deletion: {}
+        - script:
+            content: |
+              while true; do
+                if [ "$(kubectl get updaterequests -n konflux-kyverno -o yaml | yq '.items | length')" -eq 0 ]; then
+                  exit 0
+                fi
+                sleep 1
+              done
+            timeout: 30s
+    - name: Assert the cluster role bindings still exist
+      try:
+        - assert:
+            resource:
+              apiVersion: rbac.authorization.k8s.io/v1
+              kind: ClusterRoleBinding
+              metadata:
+                name: konflux-support-ai-konflux-user-support
+                labels:
+                  namespace-lister.konflux-ci.dev/use-for-access: 'true'
+              roleRef:
+                apiGroup: rbac.authorization.k8s.io
+                kind: ClusterRole
+                name: konflux-viewer-user-actions
+              subjects:
+                - apiGroup: rbac.authorization.k8s.io
+                  kind: User
+                  name: alice
+                - apiGroup: rbac.authorization.k8s.io
+                  kind: User
+                  name: bob
+                - apiGroup: rbac.authorization.k8s.io
+                  kind: User
+                  name: charlie
+        - assert:
+            resource:
+              apiVersion: rbac.authorization.k8s.io/v1
+              kind: ClusterRoleBinding
+              metadata:
+                name: konflux-support-konflux-sre
+                labels:
+                  namespace-lister.konflux-ci.dev/use-for-access: 'true'
+              roleRef:
+                apiGroup: rbac.authorization.k8s.io
+                kind: ClusterRole
+                name: konflux-viewer-user-actions
+              subjects:
+                - apiGroup: rbac.authorization.k8s.io
+                  kind: User
+                  name: dan
+                - apiGroup: rbac.authorization.k8s.io
+                  kind: User
+                  name: frank
+                - apiGroup: rbac.authorization.k8s.io
+                  kind: User
+                  name: john

--- a/components/policies/development/konflux-rbac/konflux-support-access/generate-support-clusterrolebinding-clusterpolicy.yaml
+++ b/components/policies/development/konflux-rbac/konflux-support-access/generate-support-clusterrolebinding-clusterpolicy.yaml
@@ -41,6 +41,7 @@ spec:
             jmesPath: "request.object.users[] | [].{kind: 'User', apiGroup: 'rbac.authorization.k8s.io', name: @}"
       generate:
         generateExisting: true
+        orphanDownstreamOnPolicyDelete: true
         synchronize: true
         apiVersion: rbac.authorization.k8s.io/v1
         kind: ClusterRoleBinding

--- a/components/policies/development/kubearchive/bootstrap-namespace/.chainsaw-test/chainsaw-test.yaml
+++ b/components/policies/development/kubearchive/bootstrap-namespace/.chainsaw-test/chainsaw-test.yaml
@@ -208,3 +208,66 @@ spec:
     - assert:
         file: resources/actual-kubeconfig-archive.yaml
         template: true
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: orphan-resource-on-policy-deletion
+spec:
+  description: |
+    tests that the KubeArchiveConfig remains when the cluster policy is deleted
+  concurrent: false
+  namespace: 'orphan-resources'
+  bindings:
+  - name: suffix
+    value: orphan
+  steps:
+  - name: given-kubearchiveconfig-crd-exists
+    try:
+    - apply:
+        file: resources/kubearchive-crd.yaml
+  - name: given-kyverno-has-permission-on-resources
+    try:
+    - apply:
+        file: ../kyverno_rbac.yaml
+  - name: given-cluster-policy-is-ready
+    try:
+    - apply:
+        file: ../bootstrap-namespace.yaml
+    - assert:
+        file: chainsaw-assert-clusterpolicy.yaml
+  - name: when-konfluxcidev-labeled-namespace-is-created
+    try:
+    - apply:
+        file: resources/actual-namespace-konfluxcidev.yaml
+        template: true
+  - name: then-kubearchiveconfig-is-created
+    try:
+    - assert:
+        file: resources/expected-kubearchiveconfig.yaml
+        template: true
+  - name: when-cluster-policy-is-deleted
+    try:
+    - delete:
+        file: ../bootstrap-namespace.yaml
+    - wait:
+        apiVersion: kyverno.io/v1
+        kind: ClusterPolicy
+        name: init-ns-kubearchiveconfig
+        for:
+          deletion: {}
+    - script:
+        content: |
+          while true; do
+            if [ "$(kubectl get updaterequests -n konflux-kyverno -o yaml | yq '.items | length')" -eq 0 ]; then
+              exit 0
+            fi
+            sleep 1
+          done
+        timeout: 30s
+  - name: then-kubearchiveconfig-remains
+    try:
+    - assert:
+        file: resources/expected-kubearchiveconfig.yaml
+        template: true

--- a/components/policies/development/kubearchive/bootstrap-namespace/bootstrap-namespace.yaml
+++ b/components/policies/development/kubearchive/bootstrap-namespace/bootstrap-namespace.yaml
@@ -16,6 +16,7 @@ spec:
               konflux-ci.dev/type: tenant
     generate:
       generateExisting: true
+      orphanDownstreamOnPolicyDelete: true
       apiVersion: kubearchive.org/v1
       kind: KubeArchiveConfig
       name: kubearchive

--- a/components/policies/development/kueue/queue-config/.chainsaw-test/chainsaw-test.yaml
+++ b/components/policies/development/kueue/queue-config/.chainsaw-test/chainsaw-test.yaml
@@ -397,3 +397,80 @@ spec:
     try:
     - assert:
         file: resources/expected-localqueue-kanary.yaml
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: ensure-kueue-remains-on-policy-deletion
+spec:
+  description: |
+    Tests that a LocalQueue is not removed when the associated policy is deleted.
+  concurrent: false
+  namespace: kueue-queue-preserved
+  bindings:
+  - name: suffix
+    value: orphan
+  steps:
+  - name: given-localqueue-crd-exists
+    description: |
+      Install the Kueue LocalQueue CRD so the API server accepts LocalQueue objects in the test cluster.
+    try:
+    - apply:
+        file: ./resources/localqueue-crd.yaml
+  - name: given-kyverno-has-permission-on-resources
+    description: |
+      Apply Kyverno RBAC so the policy engine can generate and reconcile LocalQueue resources.
+    try:
+    - apply:
+        file: ../kyverno-rbac.yaml
+  - name: given-cluster-policy-is-ready
+    description: |
+      Apply the queue bootstrap ClusterPolicy and assert Kyverno reports the policy as ready before exercising generation.
+    try:
+    - apply:
+        file: ../cluster-policy.yaml
+    - assert:
+        file: chainsaw-assert-clusterpolicy.yaml
+  - name: when-tenant-labeled-namespace-is-created
+    description: |
+      Create a namespace labeled konflux-ci.dev/type=tenant so the policy should generate a LocalQueue.
+    try:
+    - apply:
+        file: resources/namespace-tenant.yaml
+        template: true
+  - name: then-localqueue-is-created
+    description: |
+      Assert the expected pipelines-queue LocalQueue exists and matches the fixture (name and spec).
+    try:
+    - assert:
+        file: resources/expected-localqueue.yaml
+        template: true
+  - name: when-policy-is-deleted
+    description: |
+      Remove the policy from the cluster.
+    try:
+    - delete:
+        file: ../cluster-policy.yaml
+    - wait:
+        apiVersion: kyverno.io/v1
+        kind: ClusterPolicy
+        name: bootstrap-tenant-namespace-queue
+        for:
+          deletion: {}
+    - script:
+        content: |
+          while true; do
+            if [ "$(kubectl get updaterequests -n konflux-kyverno -o yaml | yq '.items | length')" -eq 0 ]; then
+              exit 0
+            fi
+            sleep 1
+          done
+        timeout: 30s
+  - name: then-localqueue-exists
+    description: |
+      Assert the LocalQueue created earlier still exists
+    try:
+    - assert:
+        file: resources/expected-localqueue.yaml
+        template: true


### PR DESCRIPTION
If a generation policy needs to be deleted (which happens anytime we need to update it, since they're immutable), kyverno by default will delete all generated resources.  In pretty much all circumstances, these deletions will cause disruption for users and break some assumptions some components have.

However, kyverno does support leaving these generated resources in place with the `generate.orphanDownstreamOnPolicyDelete` field set to `true`.  Set that field for all generation policies in the staging/development overlays.

Fixes: [KFLUXINFRA-3318](https://redhat.atlassian.net/browse/KFLUXINFRA-3318)

[KFLUXINFRA-3318]: https://redhat.atlassian.net/browse/KFLUXINFRA-3318?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ