### PR TITLE
KFLUXINFRA-3200 - let default etcd-defrag kick-in on staging clusters

### DIFF
--- a/configs/etcd-defrag/staging/base/cronjob.yaml
+++ b/configs/etcd-defrag/staging/base/cronjob.yaml
@@ -19,22 +19,19 @@ spec:
               imagePullPolicy: IfNotPresent
               env:
               - name: IMAGE
-                value: quay.io/konflux-ci/etcd-defrag@sha256:7539e569f085540b65759f70fe07f399c9d06511349087f8ae559be3ccd484dc
-              - name: FRAGMENTATION_THRESHOLD
-                value: "30"
-              - name: DISK_USAGE_THRESHOLD
-                value: "60"
-              - name: RECLAIM_SPACE_THRESHOLD
-                value: "1024"
+                value: quay.io/konflux-ci/etcd-defrag@sha256:825638235a85f80f9161b03bfe24666d57d8521ec154a673617ea7b08b07d379
+              - name: MAX_FRAGMENTED_PERCENTAGE
+                value: "50"
+              - name: MIN_DEFRAG_MB
+                value: "120"
               command:
                 - /bin/sh
                 - -c
                 - |
                   etcd_pod=$(oc get pod -l app=etcd -oname -n openshift-etcd | awk -F"/" 'NR==1{ print $2 }')
                   oc -n openshift-etcd debug pod/${etcd_pod} \
-                    fragmentationThreshold="${FRAGMENTATION_THRESHOLD}"\
-                    diskUsageThreshold="${DISK_USAGE_THRESHOLD}" \
-                    reclaimSpaceThreshold="${RECLAIM_SPACE_THRESHOLD}" \
+                    maxFragmentedPercentage="${MAX_FRAGMENTED_PERCENTAGE}" \
+                    minDefragMB="${MIN_DEFRAG_MB}" \
                     --image="${IMAGE}" \
                     --one-container=true \
                     -- /bin/sh -c "chmod +x /opt/defrag.sh && /opt/defrag.sh"


### PR DESCRIPTION
## What
- Commented out old etcd-defrag thresholds
-  updated image reference
## Why
The old `defrag.sh` creates a lot of pod failures, to let the built-in defrag kick in and test it, we need to have a new image that contains the new defrag.sh logic

## Resources
- [defrag.sh](https://github.com/redhat-appstudio/infrastructure/blob/main/maintenance/etcd/defrag.sh)
- [New image](https://quay.io/repository/konflux-ci/etcd-defrag/manifest/sha256:825638235a85f80f9161b03bfe24666d57d8521ec154a673617ea7b08b07d379)
- Jira task - [KFLUXINFRA-3200](https://redhat.atlassian.net/browse/KFLUXINFRA-3200)
- Related bug - [KONFLUX-12109](https://redhat.atlassian.net/browse/KONFLUX-12109)

[KFLUXINFRA-3200]: https://redhat.atlassian.net/browse/KFLUXINFRA-3200?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[KONFLUX-12109]: https://redhat.atlassian.net/browse/KONFLUX-12109?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ