### PR TITLE
KFLUXINFRA-3200 update etcd-defrag for Ring 1 production clusters

### DIFF
--- a/configs/etcd-defrag/production/kflux-ocp-p01/kustomization.yaml
+++ b/configs/etcd-defrag/production/kflux-ocp-p01/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- ../base
+- ../ring1-base

--- a/configs/etcd-defrag/production/kflux-osp-p01/kustomization.yaml
+++ b/configs/etcd-defrag/production/kflux-osp-p01/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- ../base
+- ../ring1-base

--- a/configs/etcd-defrag/production/kflux-rhel-p01/kustomization.yaml
+++ b/configs/etcd-defrag/production/kflux-rhel-p01/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- ../base
+- ../ring1-base

--- a/configs/etcd-defrag/production/ring1-base/cronjob-patch.yaml
+++ b/configs/etcd-defrag/production/ring1-base/cronjob-patch.yaml
@@ -1,0 +1,22 @@
+- op: replace
+  path: /spec/jobTemplate/spec/template/spec/containers/0/env
+  value:
+  - name: IMAGE
+    value: "quay.io/konflux-ci/etcd-defrag@sha256:825638235a85f80f9161b03bfe24666d57d8521ec154a673617ea7b08b07d379"
+  - name: MAX_FRAGMENTED_PERCENTAGE
+    value: "50"
+  - name: MIN_DEFRAG_MB
+    value: "120"
+- op: replace
+  path: /spec/jobTemplate/spec/template/spec/containers/0/command
+  value:
+  - /bin/sh
+  - -c
+  - |
+    etcd_pod=$(oc get pod -l app=etcd -oname -n openshift-etcd | awk -F"/" 'NR==1{ print $2 }')
+    oc -n openshift-etcd debug pod/${etcd_pod} \
+      maxFragmentedPercentage="${MAX_FRAGMENTED_PERCENTAGE}" \
+      minDefragMB="${MIN_DEFRAG_MB}" \
+      --image="${IMAGE}" \
+      --one-container=true \
+      -- /bin/sh -c "chmod +x /opt/defrag.sh && /opt/defrag.sh"

--- a/configs/etcd-defrag/production/ring1-base/kustomization.yaml
+++ b/configs/etcd-defrag/production/ring1-base/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../base
+patches:
+- path: cronjob-patch.yaml
+  target:
+    kind: CronJob
+    name: etcd-maintenance

--- a/configs/etcd-defrag/production/stone-prod-p01/kustomization.yaml
+++ b/configs/etcd-defrag/production/stone-prod-p01/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- ../base
+- ../ring1-base


### PR DESCRIPTION
## What
- Created `cronjob-patch` with the new etcd-defrag image with built-in defrag thresholds (`maxFragmentedPercentage=50`, `minDefragMB=120`)
- Created a temp `ring1-base` for containing the patch (to reduce duplicated code)
- Update Ring 1 production clusters (`kflux-rhel-p01`, `stone-prod-p01`, `kflux-ocp-p01`, `kflux-osp-p01`) to use `ring1-base`.
## Why
The old `defrag.sh` creates a lot of pod failures, to let the built-in defrag kick in and test it, we need to have a new image that contains the new defrag.sh logic.
**NOTE: The clusters that were chosen are with a low frequency of etcd defrag, you can see the numbers [here](https://redhat.atlassian.net/browse/KFLUXINFRA-3200?focusedCommentId=16567967)**

## Resources
- [defrag.sh](https://github.com/redhat-appstudio/infrastructure/blob/main/maintenance/etcd/defrag.sh)
- [New image](https://quay.io/repository/konflux-ci/etcd-defrag/manifest/sha256:825638235a85f80f9161b03bfe24666d57d8521ec154a673617ea7b08b07d379)
- Jira task - [KFLUXINFRA-3200](https://redhat.atlassian.net/browse/KFLUXINFRA-3200)
- Related bug - [KONFLUX-12109](https://redhat.atlassian.net/browse/KONFLUX-12109)

## Validation
- Staging PR - #11060
- etcd-health-check.sh report are good, it only shows that we're pretty close to etcd-defrag:
```========================================
  etcd Health Check Report
  2026-03-30 10:44:01 UTC
========================================

Cluster: https://api.stone-stg-rh01.l2vh.p1.openshiftapps.com:6443
Thanos:  thanos-querier-openshift-monitoring.apps.stone-stg-rh01.l2vh.p1.openshiftapps.com

--- Per-Member DB Status ---
  MEMBER                                   DB SIZE      IN USE       QUOTA        QUOTA USAGE     FRAG RATIO   RECLAIMABLE 
  -----------------------------------------------------------------------------------------------------------------------
  etcd-ip-10-202-25-206.ec2.internal       3178.8       1784.2       8192.0       38.80           43.87        1394.6      
  etcd-ip-10-202-27-132.ec2.internal       3086.7       1788.2       8192.0       37.68           42.07        1298.6      
  etcd-ip-10-202-28-137.ec2.internal       3103.0       1784.9       8192.0       37.88           42.48        1318.1      

--- KPI Health Scores ---

  1. DB Quota Usage (worst)                     38.80%               HEALTHY
  2. Fragmentation Ratio (worst)                43.87%               WARNING
  3. Reclaimable Space (worst)                  1394.6MB             CRITICAL
  4. Disk Fsync Latency (p99)                   3.9ms                HEALTHY
  5. Backend Commit Latency (p99)               6.3ms                HEALTHY
  6. Proposal Failure Rate                      0.0/hr               HEALTHY
  7. Peer Network RTT (p99)                     12.7ms               HEALTHY
  8. Leader Changes (10m)                       0                    HEALTHY
  9. Cluster Member Count                       3                    HEALTHY
  10. Leader Status                             Has leader           HEALTHY

========================================
  Check complete
========================================
```
- Grafana graphs shows nothing really changed during are change of `defrag.sh` thresholds (a little bit before 30/3 00:00): 
<img width="1632" height="1215" alt="image" src="https://github.com/user-attachments/assets/63c653bf-9f4f-4172-8c30-37bcdad2c2b7" />

## Risk Assessment
**Risk Level:** Low
**Rollback:** Revert PR and redeploy previous image tag and reference the original production Base folder


[KFLUXINFRA-3200]: https://redhat.atlassian.net/browse/KFLUXINFRA-3200?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[KONFLUX-12109]: https://redhat.atlassian.net/browse/KONFLUX-12109?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ