### PR TITLE
Promoting component image-controller from stage to prod

### DIFF
--- a/components/image-controller/production/base/kustomization.yaml
+++ b/components/image-controller/production/base/kustomization.yaml
@@ -3,12 +3,12 @@ kind: Kustomization
 resources:
 - ../../base
 - ../../base/external-secrets
-- https://github.com/konflux-ci/image-controller/config/default?ref=292f181e2ab5575c13f41ddf6aae446344f59783
+- https://github.com/konflux-ci/image-controller/config/default?ref=9097a5b3ec10db9d827bf365bbb7c188339eb912
 
 images:
 - name: quay.io/konflux-ci/image-controller
   newName: quay.io/konflux-ci/image-controller
-  newTag: 292f181e2ab5575c13f41ddf6aae446344f59783
+  newTag: 9097a5b3ec10db9d827bf365bbb7c188339eb912
 
 namespace: image-controller
 


### PR DESCRIPTION
## What
Promoting component image-controller from stage to prod.

## Validation
Staging PRs:
 - #11070
 - #11088
 - #11173
 - #11224

## Risk Assessment
**Risk Level:** Low
**Rollback:** Revert PR and redeploy previous image tag and reference the original production Base folder
