### PR TITLE
fix: OIDC auth, add patch coverage config

### DIFF
--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -39,7 +39,7 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Python
         uses: actions/setup-python@v4

--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -10,7 +10,7 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Go
         uses: actions/setup-go@v5

--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -1,12 +1,16 @@
 name: Generate Codecov Report
 on:
-  pull_request_target:
+  push:
+    branches: [main]
+  pull_request:
     types: [opened, synchronize, reopened]
 jobs:
   go-tests:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     steps:
-      - uses: actions/checkout@main
+      - uses: actions/checkout@v4
 
       - name: Setup Go
         uses: actions/setup-go@v5
@@ -26,14 +30,16 @@ jobs:
       - name: Upload Go coverage to Codecov
         uses: codecov/codecov-action@v5
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+          use_oidc: true
           flags: go
           files: ./go-coverage.txt,./coverage.txt
 
   python-tests:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     steps:
-      - uses: actions/checkout@main
+      - uses: actions/checkout@v4
 
       - name: Setup Python
         uses: actions/setup-python@v4
@@ -71,6 +77,6 @@ jobs:
       - name: Upload Python coverage to Codecov
         uses: codecov/codecov-action@v5
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+          use_oidc: true
           flags: python
           files: ./coverage.xml

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,13 @@
+coverage:
+  status:
+    patch:
+      default:
+        target: auto
+
+comment:
+  layout: "reach,diff,flags,components"
+  behavior: default
+
 ignore:
   # main() functions are CLI entrypoints that cannot be unit tested.
   - "infra-tools/cmd/*/main.go"


### PR DESCRIPTION
* Switch from pull_request_target with token to pull_request with OIDC, eliminating the security risk of running untrusted PR code with secrets
* Add push trigger on main for baseline coverage
* Enable explicit patch coverage status and PR comment layout in codecov.yml.