### PR TITLE
fix(PVO11Y-4905): Enable larger results via sidecar logs for stage

### DIFF
--- a/components/pipeline-service/staging/base/main-pipeline-service-configuration.yaml
+++ b/components/pipeline-service/staging/base/main-pipeline-service-configuration.yaml
@@ -202,6 +202,19 @@ kind: ClusterRole
 metadata:
   annotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "0"
+  name: tekton-pipelines-controller-pod-log-access
+rules:
+  - apiGroups: [""]
+    # Controller needs to get the logs of the results sidecar created by TaskRuns to extract results.
+    resources: ["pods/log"]
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
   labels:
     app.kubernetes.io/part-of: tekton-results
     app.kubernetes.io/version: devel
@@ -501,6 +514,22 @@ subjects:
 - kind: ServiceAccount
   name: metrics-reader
   namespace: tekton-results
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "0"
+  name: tekton-pipelines-controller-pod-log-access
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: tekton-pipelines-controller-pod-log-access
+subjects:
+- kind: ServiceAccount
+  name: tekton-pipelines-controller
+  namespace: tekton-pipelines
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -1708,6 +1737,8 @@ spec:
     enable-step-actions: true
     metrics.pipelinerun.level: pipeline
     metrics.taskrun.level: task
+    results-from: sidecar-logs
+    max-result-size: 1572863
     options:
       configMaps:
         config-logging:

--- a/components/pipeline-service/staging/base/main-pipeline-service-configuration.yaml
+++ b/components/pipeline-service/staging/base/main-pipeline-service-configuration.yaml
@@ -529,7 +529,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: tekton-pipelines-controller
-  namespace: tekton-pipelines
+  namespace: openshift-pipelines
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/components/pipeline-service/staging/stone-stage-p01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stage-p01/deploy.yaml
@@ -365,10 +365,12 @@ metadata:
     argocd.argoproj.io/sync-wave: "0"
   name: tekton-pipelines-controller-pod-log-access
 rules:
-  - apiGroups: [""]
-    # Controller needs to get the logs of the results sidecar created by TaskRuns to extract results.
-    resources: ["pods/log"]
-    verbs: ["get"]
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -814,8 +816,8 @@ subjects:
   name: metrics-reader
   namespace: tekton-results
 ---
-kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
 metadata:
   annotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
@@ -828,7 +830,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: tekton-pipelines-controller
-  namespace: tekton-pipelines
+  namespace: openshift-pipelines
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -2322,10 +2324,9 @@ spec:
     enable-hub-resolver: true
     enable-param-enum: true
     enable-step-actions: true
+    max-result-size: 1572863
     metrics.pipelinerun.level: pipeline
     metrics.taskrun.level: task
-    results-from: sidecar-logs
-    max-result-size: 1572863
     options:
       configMaps:
         bundleresolver-config:
@@ -2616,6 +2617,7 @@ spec:
       replicas: 4
       statefulset-ordinals: true
       threads-per-controller: 32
+    results-from: sidecar-logs
   platforms:
     openshift:
       pipelinesAsCode:

--- a/components/pipeline-service/staging/stone-stage-p01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stage-p01/deploy.yaml
@@ -362,6 +362,19 @@ kind: ClusterRole
 metadata:
   annotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "0"
+  name: tekton-pipelines-controller-pod-log-access
+rules:
+  - apiGroups: [""]
+    # Controller needs to get the logs of the results sidecar created by TaskRuns to extract results.
+    resources: ["pods/log"]
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
   labels:
     app.kubernetes.io/part-of: tekton-results
     app.kubernetes.io/version: devel
@@ -800,6 +813,22 @@ subjects:
 - kind: ServiceAccount
   name: metrics-reader
   namespace: tekton-results
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "0"
+  name: tekton-pipelines-controller-pod-log-access
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: tekton-pipelines-controller-pod-log-access
+subjects:
+- kind: ServiceAccount
+  name: tekton-pipelines-controller
+  namespace: tekton-pipelines
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -2295,6 +2324,8 @@ spec:
     enable-step-actions: true
     metrics.pipelinerun.level: pipeline
     metrics.taskrun.level: task
+    results-from: sidecar-logs
+    max-result-size: 1572863
     options:
       configMaps:
         bundleresolver-config:

--- a/components/pipeline-service/staging/stone-stg-rh01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stg-rh01/deploy.yaml
@@ -365,10 +365,12 @@ metadata:
     argocd.argoproj.io/sync-wave: "0"
   name: tekton-pipelines-controller-pod-log-access
 rules:
-  - apiGroups: [""]
-    # Controller needs to get the logs of the results sidecar created by TaskRuns to extract results.
-    resources: ["pods/log"]
-    verbs: ["get"]
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -814,8 +816,8 @@ subjects:
   name: metrics-reader
   namespace: tekton-results
 ---
-kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
 metadata:
   annotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
@@ -828,7 +830,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: tekton-pipelines-controller
-  namespace: tekton-pipelines
+  namespace: openshift-pipelines
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -2322,10 +2324,9 @@ spec:
     enable-hub-resolver: true
     enable-param-enum: true
     enable-step-actions: true
+    max-result-size: 1572863
     metrics.pipelinerun.level: pipeline
     metrics.taskrun.level: task
-    results-from: sidecar-logs
-    max-result-size: 1572863
     options:
       configMaps:
         bundleresolver-config:
@@ -2628,6 +2629,7 @@ spec:
       replicas: 4
       statefulset-ordinals: true
       threads-per-controller: 32
+    results-from: sidecar-logs
   platforms:
     openshift:
       pipelinesAsCode:

--- a/components/pipeline-service/staging/stone-stg-rh01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stg-rh01/deploy.yaml
@@ -362,6 +362,19 @@ kind: ClusterRole
 metadata:
   annotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "0"
+  name: tekton-pipelines-controller-pod-log-access
+rules:
+  - apiGroups: [""]
+    # Controller needs to get the logs of the results sidecar created by TaskRuns to extract results.
+    resources: ["pods/log"]
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
   labels:
     app.kubernetes.io/part-of: tekton-results
     app.kubernetes.io/version: devel
@@ -800,6 +813,22 @@ subjects:
 - kind: ServiceAccount
   name: metrics-reader
   namespace: tekton-results
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "0"
+  name: tekton-pipelines-controller-pod-log-access
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: tekton-pipelines-controller-pod-log-access
+subjects:
+- kind: ServiceAccount
+  name: tekton-pipelines-controller
+  namespace: tekton-pipelines
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -2295,6 +2324,8 @@ spec:
     enable-step-actions: true
     metrics.pipelinerun.level: pipeline
     metrics.taskrun.level: task
+    results-from: sidecar-logs
+    max-result-size: 1572863
     options:
       configMaps:
         bundleresolver-config:


### PR DESCRIPTION
Task results larger than 4096 bytes become truncated due to limitations with container termination messages. Tekton Pipeline provides a sidecar-logs feature flag which works around this limitation (See [TEP-0127](https://github.com/tektoncd/community/blob/main/teps/0127-larger-results-via-sidecar-logs.md)). Enabling this feature flag in stage clusters first to test this feature before applying it to production clusters.