### PR TITLE
Upgrade pipelines nightly version in production kflux-fedora-01 5.0.5-806

### DIFF
--- a/components/pipeline-service/production/kflux-fedora-01/deploy.yaml
+++ b/components/pipeline-service/production/kflux-fedora-01/deploy.yaml
@@ -2528,7 +2528,7 @@ metadata:
   namespace: openshift-marketplace
 spec:
   displayName: custom-operators
-  image: quay.io/openshift-pipeline/pipelines-index-4.17@sha256:37a8e3ad71ba0ebb52e177b521e5adaae1725f1fa21677572618285432904200
+  image: quay.io/openshift-pipeline/pipelines-index-4.18@sha256:d4d3f6210a384da6bfb11214a860e72e52d0a38b73037b8135c0571a6365d2a1
   sourceType: grpc
   updateStrategy:
     registryPoll:

--- a/components/pipeline-service/production/kflux-fedora-01/resources/kustomization.yaml
+++ b/components/pipeline-service/production/kflux-fedora-01/resources/kustomization.yaml
@@ -38,3 +38,7 @@ patches:
     target:
       kind: TektonConfig
       name: config
+  - path: update-catalog-source-image.yaml
+    target:
+      kind: CatalogSource
+      name: custom-operators

--- a/components/pipeline-service/production/kflux-fedora-01/resources/update-catalog-source-image.yaml
+++ b/components/pipeline-service/production/kflux-fedora-01/resources/update-catalog-source-image.yaml
@@ -1,0 +1,4 @@
+---
+- op: replace
+  path: /spec/image
+  value: quay.io/openshift-pipeline/pipelines-index-4.18@sha256:d4d3f6210a384da6bfb11214a860e72e52d0a38b73037b8135c0571a6365d2a1


### PR DESCRIPTION
## Summary

- Upgrades the OpenShift Pipelines CatalogSource image for **kflux-fedora-01** production cluster to version **5.0.5-806** (`pipelines-index-4.18`), matching what was rolled out to dev and staging in PR #11073.
- Uses a **cluster-specific kustomize patch** on the `CatalogSource` resource so that **no other production clusters are affected**.
- Only 3 files changed: 1 new patch file, 1 kustomization edit, 1 regenerated `deploy.yaml`.

## Changes

| File | Change |
|------|--------|
| `kflux-fedora-01/resources/update-catalog-source-image.yaml` | **New** -- JSON 6902 patch replacing `CatalogSource` image |
| `kflux-fedora-01/resources/kustomization.yaml` | Added patch entry targeting `CatalogSource/custom-operators` |
| `kflux-fedora-01/deploy.yaml` | Regenerated -- single line diff (`pipelines-index-4.17` -> `pipelines-index-4.18`) |

## Test plan

- [ ] Verify kustomize render diff in CI shows only the CatalogSource image change for kflux-fedora-01
- [ ] Confirm no other production cluster deploy.yaml files are modified
- [ ] After merge, verify ArgoCD syncs the new CatalogSource to kflux-fedora-01