### PR TITLE
Upgrade pipelines nightly version in production 5.0.5-806

### DIFF
--- a/components/monitoring/grafana/base/dashboards/pipeline-service/grafana-config.yaml
+++ b/components/monitoring/grafana/base/dashboards/pipeline-service/grafana-config.yaml
@@ -1305,7 +1305,7 @@ data:
               "targets": [
                 {
                   "exemplar": true,
-                  "expr": "avg(tekton_pipelines_controller_workqueue_depth)",
+                  "expr": "avg(kn_workqueue_depth{job='tekton-pipelines-controller'})",
                   "interval": "",
                   "legendFormat": "",
                   "refId": "A"
@@ -1472,7 +1472,7 @@ data:
               "targets": [
                 {
                   "exemplar": true,
-                  "expr": "rate(tekton_pipelines_controller_client_results[1h])*3600",
+                  "expr": "rate(kn_k8s_client_http_response_status_code_total{job='tekton-pipelines-controller'}[1h])*3600",
                   "interval": "",
                   "legendFormat": "",
                   "refId": "A"

--- a/components/pipeline-service/production/base/main-pipeline-service-configuration.yaml
+++ b/components/pipeline-service/production/base/main-pipeline-service-configuration.yaml
@@ -2059,7 +2059,7 @@ metadata:
   namespace: openshift-marketplace
 spec:
   displayName: custom-operators
-  image: quay.io/openshift-pipeline/pipelines-index-4.17@sha256:37a8e3ad71ba0ebb52e177b521e5adaae1725f1fa21677572618285432904200
+  image: quay.io/openshift-pipeline/pipelines-index-4.18@sha256:d4d3f6210a384da6bfb11214a860e72e52d0a38b73037b8135c0571a6365d2a1
   sourceType: grpc
   updateStrategy:
     registryPoll:

--- a/components/pipeline-service/production/kflux-fedora-01/deploy.yaml
+++ b/components/pipeline-service/production/kflux-fedora-01/deploy.yaml
@@ -2528,7 +2528,7 @@ metadata:
   namespace: openshift-marketplace
 spec:
   displayName: custom-operators
-  image: quay.io/openshift-pipeline/pipelines-index-4.17@sha256:37a8e3ad71ba0ebb52e177b521e5adaae1725f1fa21677572618285432904200
+  image: quay.io/openshift-pipeline/pipelines-index-4.18@sha256:d4d3f6210a384da6bfb11214a860e72e52d0a38b73037b8135c0571a6365d2a1
   sourceType: grpc
   updateStrategy:
     registryPoll:

--- a/components/pipeline-service/production/kflux-ocp-p01/deploy.yaml
+++ b/components/pipeline-service/production/kflux-ocp-p01/deploy.yaml
@@ -2515,7 +2515,7 @@ metadata:
   namespace: openshift-marketplace
 spec:
   displayName: custom-operators
-  image: quay.io/openshift-pipeline/pipelines-index-4.17@sha256:37a8e3ad71ba0ebb52e177b521e5adaae1725f1fa21677572618285432904200
+  image: quay.io/openshift-pipeline/pipelines-index-4.18@sha256:d4d3f6210a384da6bfb11214a860e72e52d0a38b73037b8135c0571a6365d2a1
   sourceType: grpc
   updateStrategy:
     registryPoll:

--- a/components/pipeline-service/production/kflux-osp-p01/deploy.yaml
+++ b/components/pipeline-service/production/kflux-osp-p01/deploy.yaml
@@ -793,21 +793,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   annotations:
-    argocd.argoproj.io/sync-wave: "0"
-  name: tekton-pipelines-controller-konflux-scc
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: appstudio-pipelines-runner
-subjects:
-- kind: ServiceAccount
-  name: tekton-pipelines-controller
-  namespace: openshift-pipelines
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  annotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
   labels:
     app.kubernetes.io/part-of: tekton-results
@@ -2530,7 +2515,7 @@ metadata:
   namespace: openshift-marketplace
 spec:
   displayName: custom-operators
-  image: quay.io/openshift-pipeline/pipelines-index-4.17@sha256:37a8e3ad71ba0ebb52e177b521e5adaae1725f1fa21677572618285432904200
+  image: quay.io/openshift-pipeline/pipelines-index-4.18@sha256:d4d3f6210a384da6bfb11214a860e72e52d0a38b73037b8135c0571a6365d2a1
   sourceType: grpc
   updateStrategy:
     registryPoll:

--- a/components/pipeline-service/production/kflux-prd-rh02/deploy.yaml
+++ b/components/pipeline-service/production/kflux-prd-rh02/deploy.yaml
@@ -349,22 +349,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   annotations:
-    argocd.argoproj.io/sync-wave: "0"
-  name: tekton-pipelines-controller-konflux-scc
-rules:
-- apiGroups:
-  - security.openshift.io
-  resourceNames:
-  - appstudio-pipelines-scc
-  resources:
-  - securitycontextconstraints
-  verbs:
-  - use
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  annotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
   labels:
     app.kubernetes.io/part-of: tekton-results
@@ -804,21 +788,6 @@ subjects:
 - kind: ServiceAccount
   name: metrics-reader
   namespace: tekton-results
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  annotations:
-    argocd.argoproj.io/sync-wave: "0"
-  name: tekton-pipelines-controller-konflux-scc
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: tekton-pipelines-controller-konflux-scc
-subjects:
-- kind: ServiceAccount
-  name: tekton-pipelines-controller
-  namespace: openshift-pipelines
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -2546,7 +2515,7 @@ metadata:
   namespace: openshift-marketplace
 spec:
   displayName: custom-operators
-  image: quay.io/openshift-pipeline/pipelines-index-4.17@sha256:37a8e3ad71ba0ebb52e177b521e5adaae1725f1fa21677572618285432904200
+  image: quay.io/openshift-pipeline/pipelines-index-4.18@sha256:d4d3f6210a384da6bfb11214a860e72e52d0a38b73037b8135c0571a6365d2a1
   sourceType: grpc
   updateStrategy:
     registryPoll:

--- a/components/pipeline-service/production/kflux-prd-rh03/deploy.yaml
+++ b/components/pipeline-service/production/kflux-prd-rh03/deploy.yaml
@@ -349,22 +349,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   annotations:
-    argocd.argoproj.io/sync-wave: "0"
-  name: tekton-pipelines-controller-konflux-scc
-rules:
-- apiGroups:
-  - security.openshift.io
-  resourceNames:
-  - appstudio-pipelines-scc
-  resources:
-  - securitycontextconstraints
-  verbs:
-  - use
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  annotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
   labels:
     app.kubernetes.io/part-of: tekton-results
@@ -804,21 +788,6 @@ subjects:
 - kind: ServiceAccount
   name: metrics-reader
   namespace: tekton-results
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  annotations:
-    argocd.argoproj.io/sync-wave: "0"
-  name: tekton-pipelines-controller-konflux-scc
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: tekton-pipelines-controller-konflux-scc
-subjects:
-- kind: ServiceAccount
-  name: tekton-pipelines-controller
-  namespace: openshift-pipelines
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -2546,7 +2515,7 @@ metadata:
   namespace: openshift-marketplace
 spec:
   displayName: custom-operators
-  image: quay.io/openshift-pipeline/pipelines-index-4.17@sha256:37a8e3ad71ba0ebb52e177b521e5adaae1725f1fa21677572618285432904200
+  image: quay.io/openshift-pipeline/pipelines-index-4.18@sha256:d4d3f6210a384da6bfb11214a860e72e52d0a38b73037b8135c0571a6365d2a1
   sourceType: grpc
   updateStrategy:
     registryPoll:

--- a/components/pipeline-service/production/kflux-rhel-p01/deploy.yaml
+++ b/components/pipeline-service/production/kflux-rhel-p01/deploy.yaml
@@ -349,22 +349,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   annotations:
-    argocd.argoproj.io/sync-wave: "0"
-  name: tekton-pipelines-controller-konflux-scc
-rules:
-- apiGroups:
-  - security.openshift.io
-  resourceNames:
-  - appstudio-pipelines-scc
-  resources:
-  - securitycontextconstraints
-  verbs:
-  - use
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  annotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
   labels:
     app.kubernetes.io/part-of: tekton-results
@@ -804,21 +788,6 @@ subjects:
 - kind: ServiceAccount
   name: metrics-reader
   namespace: tekton-results
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  annotations:
-    argocd.argoproj.io/sync-wave: "0"
-  name: tekton-pipelines-controller-konflux-scc
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: tekton-pipelines-controller-konflux-scc
-subjects:
-- kind: ServiceAccount
-  name: tekton-pipelines-controller
-  namespace: openshift-pipelines
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -2546,7 +2515,7 @@ metadata:
   namespace: openshift-marketplace
 spec:
   displayName: custom-operators
-  image: quay.io/openshift-pipeline/pipelines-index-4.17@sha256:37a8e3ad71ba0ebb52e177b521e5adaae1725f1fa21677572618285432904200
+  image: quay.io/openshift-pipeline/pipelines-index-4.18@sha256:d4d3f6210a384da6bfb11214a860e72e52d0a38b73037b8135c0571a6365d2a1
   sourceType: grpc
   updateStrategy:
     registryPoll:

--- a/components/pipeline-service/production/stone-prd-rh01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prd-rh01/deploy.yaml
@@ -2515,7 +2515,7 @@ metadata:
   namespace: openshift-marketplace
 spec:
   displayName: custom-operators
-  image: quay.io/openshift-pipeline/pipelines-index-4.17@sha256:37a8e3ad71ba0ebb52e177b521e5adaae1725f1fa21677572618285432904200
+  image: quay.io/openshift-pipeline/pipelines-index-4.18@sha256:d4d3f6210a384da6bfb11214a860e72e52d0a38b73037b8135c0571a6365d2a1
   sourceType: grpc
   updateStrategy:
     registryPoll:

--- a/components/pipeline-service/production/stone-prod-p01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prod-p01/deploy.yaml
@@ -2515,7 +2515,7 @@ metadata:
   namespace: openshift-marketplace
 spec:
   displayName: custom-operators
-  image: quay.io/openshift-pipeline/pipelines-index-4.17@sha256:37a8e3ad71ba0ebb52e177b521e5adaae1725f1fa21677572618285432904200
+  image: quay.io/openshift-pipeline/pipelines-index-4.18@sha256:d4d3f6210a384da6bfb11214a860e72e52d0a38b73037b8135c0571a6365d2a1
   sourceType: grpc
   updateStrategy:
     registryPoll:

--- a/components/pipeline-service/production/stone-prod-p02/deploy.yaml
+++ b/components/pipeline-service/production/stone-prod-p02/deploy.yaml
@@ -2515,7 +2515,7 @@ metadata:
   namespace: openshift-marketplace
 spec:
   displayName: custom-operators
-  image: quay.io/openshift-pipeline/pipelines-index-4.17@sha256:37a8e3ad71ba0ebb52e177b521e5adaae1725f1fa21677572618285432904200
+  image: quay.io/openshift-pipeline/pipelines-index-4.18@sha256:d4d3f6210a384da6bfb11214a860e72e52d0a38b73037b8135c0571a6365d2a1
   sourceType: grpc
   updateStrategy:
     registryPoll:


### PR DESCRIPTION
## Release Notes: OpenShift Pipelines 5.0.5-806

### Tekton Pipeline

#### Features
- Migrate PipelineRun and TaskRun metrics from OpenCensus to OpenTelemetry
- Add SHA-256 support for Git resolver revision validation
- Allow pipeline param defaults to use non-param variables
- Include results and artifacts from failed tasks in pipeline results
- Accept `featureFlags.EnableTektonOCIBundles` to fix unknown field error

#### Bug Fixes
- Align cache configstore with framework implementation (resolvers)
- Remove redundant shortNames from ResolutionRequest CRD
- Revert mistaken metadata changes in resolvers config-observability
- Fixed a race condition in the resolver cache by implementing a singleflight mechanism, ensuring only one in-flight resolution occurs per cache key for concurrent requests
- Fixed an issue where corrupted cache entries (type assertion failures) remained in the cache; they are now removed immediately to trigger fresh resolution
- Fixed `running_taskruns` metric overcounting by ensuring TaskRuns are only counted as running if they have a `ConditionUnknown` status
- Fixed a potential nil pointer dereference in PipelineRun metrics when the succeeded condition is guarded

### Pipelines as Code (PAC)

#### Features
- Add update comment strategy for GitHub, GitLab, and Forgejo providers
- Document update comment strategy
- Add GitOps lightweight tag support (`tag:` prefix for branch vs tag parsing)
- Cache changed files in Gitea provider (performance improvement)
- Allow custom user agent for Forgejo/Gitea

#### Bug Fixes
- Fix duplicate GitHub comment creation (workaround + restrict editing to PAC-owned comments)
- Fix variables substitution issue on commit comment in GitLab
- Fix `/retest` with nothing to retest (improved message)
- Fix retest for pushed commits: resolve `pull_request_number` correctly
- Honor `target-namespace` annotation for explicit commands
- Skip PipelineRun when target-ns repo cannot be found
- Only report CEL validation errors once
- Set PipelineURL for cached pipelines to resolve relative task paths
- Fix webhook feedback loop on no-ops comment events
- Enforce webhook signature for Forgejo
- Workaround the GitLab diff API limit when necessary
- Fix correct name for failed checkruns on retest
- Preserve `source_url` on retest comment reruns (Gitea)
- Enable skip-CI for GitLab merge requests
- Handle non-http(s) URLs in `assembleTaskFQDNs`
- Set the correct custom hub catalog type

#### Performance
- Skip comment edit when body is already up to date (GitHub)

**Release: v0.43.0**

### Tekton Operator

#### Features
- Onboard MulticlusterProxyAAE, syncer-service component
- Disable watcher and retention-policy-agent on Hub clusters (Results)
- Enable authorization for Services in Console Plugin
- Add self-healing for CA bundle configmaps in user namespaces
- Add TektonScheduler and TektonMulticlusterProxyAAE CRDs to Helm chart

#### Bug Fixes
- Fix TektonInstallerSet deadlock when resources have `deletionTimestamp`
- Fix console-plugin: update proxy-aae service port to 443
- Make multi-cluster-role case-insensitive (scheduler)
- Propagate TektonConfig config to TektonResult CR
- Pass httpClient to PAC SyncConfig
- Override `WORKERS_SECRET_NAMESPACE` for OpenShift (proxy-aae)
- Downgrade repetitive Info-level logs to Debug to reduce noise
- Fixed an invalid authorization field configuration in `pipeline_console_plugin.yaml`
- Resolved minor stability issues and updated various production dependencies including cert-manager to v1.20.0 
---

### Validation

The changes have been verified on staging clusters and are working as expected.

**Evidence**
- Staging PR: #11073
- [Pipelines Upgrade v5.0.5-806 — Manual Metrics Verification](https://docs.google.com/document/d/1ldBdIwzXmkPG6KgjELvseCQGPLCAWg2lQI7ENhcPNzU/edit?tab=t.0)
- Release test pipeline executed successfully for the index image. [View Pipeline Run](https://konflux-ui.apps.kflux-prd-rh02.0fk9.p1.openshiftapps.com/ns/tekton-ecosystem-tenant/applications/openshift-pipelines-index-next/pipelineruns/openshift-pipelines-index-next-release-tests-amd64-2khf8?integrationTestName=openshift-pipelines-index-next-release-tests-amd64)
- [x] Konflux announce email sent

---

### Risk Assessment

- **Risk Level:** Medium