### PR TITLE
Replace smee.io with hook.pipelinesascode.com in development config

### DIFF
--- a/components/smee-client/README.md
+++ b/components/smee-client/README.md
@@ -4,4 +4,13 @@ The `smee-client` component deploys [gosmee][gs] in client mode.
 
 This allows a cluster to consume webhooks forwarded via our Smee service.
 
+## Webhook forwarding service
+
+For development, use [hook.pipelinesascode.com][hpac] to create webhook
+forwarding channels. Do **not** use smee.io — it does not properly preserve
+webhook signatures, which causes Forgejo webhook signature validation to fail.
+hook.pipelinesascode.com runs gosmee on the server side and correctly forwards
+the original webhook headers and payload.
+
 [gs]: https://github.com/chmouel/gosmee
+[hpac]: https://hook.pipelinesascode.com

--- a/components/smee-client/development/sever-url-patch.yaml
+++ b/components/smee-client/development/sever-url-patch.yaml
@@ -1,10 +1,12 @@
 ---
-# Development smee.io channel for Forgejo/Codeberg webhook testing
+# Development webhook forwarding channel for Forgejo/Codeberg webhook testing
 # The URL can be configured via SMEE_CHANNEL environment variable in preview.sh
-# To use this, configure your Codeberg webhook to point to this smee.io URL
+# Create a channel at https://hook.pipelinesascode.com and provide the URL here
+# Note: Do not use smee.io - it breaks webhook signature validation for Forgejo.
+# hook.pipelinesascode.com uses gosmee which properly preserves webhook signatures.
 - op: replace
   path: /spec/template/spec/containers/0/args/3
-  value: "https://smee.io/REPLACE_ME"
+  value: "https://hook.pipelinesascode.com/REPLACE_ME"
 - op: replace
   path: /spec/template/spec/containers/1/env/1/value
-  value: "https://smee.io/REPLACE_ME"
+  value: "https://hook.pipelinesascode.com/REPLACE_ME"

--- a/hack/preview-template.env
+++ b/hack/preview-template.env
@@ -86,8 +86,9 @@ export PAC_GITHUB_TOKEN=
 export PAC_GITLAB_TOKEN=
 
 # Forgejo/Codeberg webhook integration
-# smee.io channel URL for forwarding webhooks to the cluster (required for Forgejo/Codeberg and GitLab on clusters without valid TLS)
-# Create a channel at https://smee.io and provide the URL here
+# Webhook forwarding channel URL for forwarding webhooks to the cluster (required for Forgejo/Codeberg and GitLab on clusters without valid TLS)
+# Create a channel at https://hook.pipelinesascode.com and provide the URL here
+# Note: Do not use smee.io - it breaks webhook signature validation for Forgejo.
 export SMEE_CHANNEL=
 
 ## Image Controller

--- a/hack/preview.sh
+++ b/hack/preview.sh
@@ -385,7 +385,7 @@ apply_service_image_overrides() {
     [ -n "${BUILD_SERVICE_IMAGE_TAG}" ] && yq -i e "(.images.[] | select(.name==\"quay.io/konflux-ci/build-service\")) |=.newTag=\"${BUILD_SERVICE_IMAGE_TAG}\"" $ROOT/components/build-service/development/kustomization.yaml
     [ -n "${BUILD_SERVICE_IMAGE_TAG_EXPIRATION}" ] && yq -i e "(.spec.template.spec.containers[].env[] | select(.name==\"IMAGE_TAG_ON_PR_EXPIRATION\") | .value) |= \"${BUILD_SERVICE_IMAGE_TAG_EXPIRATION}\"" $ROOT/components/build-service/development/image-expiration-patch.yaml
     [[ -n "${BUILD_SERVICE_PR_OWNER}" && "${BUILD_SERVICE_PR_SHA}" ]] && yq -i e "(.resources[] | select(. ==\"*github.com/konflux-ci/build-service*\")) |= \"https://github.com/${BUILD_SERVICE_PR_OWNER}/build-service/config/default?ref=${BUILD_SERVICE_PR_SHA}\"" $ROOT/components/build-service/development/kustomization.yaml
-    # Configure smee.io channel URL for webhook forwarding (used for Forgejo/Codeberg testing)
+    # Configure webhook forwarding channel URL (used for Forgejo/Codeberg testing, use hook.pipelinesascode.com not smee.io)
     [ -n "${SMEE_CHANNEL}" ] && yq -i e ".[].value = \"${SMEE_CHANNEL}\"" $ROOT/components/smee-client/development/sever-url-patch.yaml
     # Configure build-service webhook-config for Codeberg to use the smee channel
     [ -n "${SMEE_CHANNEL}" ] && sed -i.bak "s|SMEE_CHANNEL_PLACEHOLDER|${SMEE_CHANNEL}|g" $ROOT/components/build-service/development/webhook-config.json && rm -f $ROOT/components/build-service/development/webhook-config.json.bak


### PR DESCRIPTION
smee.io does not properly preserve webhook signatures, which causes Forgejo webhook signature validation to fail. hook.pipelinesascode.com uses gosmee on the server side and correctly forwards the original webhook headers and payload.