### PR TITLE
reduce MintMaker frequency on p02

### DIFF
--- a/components/mintmaker/production/stone-prod-p02/create-dependencyupdatecheck-cronjob-frequency.yaml
+++ b/components/mintmaker/production/stone-prod-p02/create-dependencyupdatecheck-cronjob-frequency.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: create-dependencyupdatecheck
+  namespace: mintmaker
+spec:
+  schedule: 0 */6 * * *

--- a/components/mintmaker/production/stone-prod-p02/kustomization.yaml
+++ b/components/mintmaker/production/stone-prod-p02/kustomization.yaml
@@ -11,3 +11,9 @@ patches:
       version: v1
       kind: ExternalSecret
   - path: manager_patch.yaml
+  - path: create-dependencyupdatecheck-cronjob-frequency.yaml
+    target:
+      name: create-dependencyupdatecheck
+      group: batch
+      version: v1
+      kind: CronJob


### PR DESCRIPTION
MintMaker's PipelineRuns are piling up when the cluster is under stress.

In the meantime we improve the creation or recycling of these PLRs, we could need to reduce the MintMaker frequency.

Signed-off-by: Francesco Ilario <filario@redhat.com>

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED
