### PR TITLE
limit PipelineRuns in mintmaker namespace to 5000 in staging

### DIFF
--- a/components/mintmaker/development/kustomization.yaml
+++ b/components/mintmaker/development/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../base
+  - plrs-resource-quota.yaml
   - https://github.com/konflux-ci/mintmaker/config/default?ref=85962df3895522eb8df1d39438b0b85bcde3438a
   - https://github.com/konflux-ci/mintmaker/config/renovate?ref=85962df3895522eb8df1d39438b0b85bcde3438a
 

--- a/components/mintmaker/development/plrs-resource-quota.yaml
+++ b/components/mintmaker/development/plrs-resource-quota.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: pipelineruns-resource-quota
+  namespace: mintmaker
+spec:
+  hard:
+    count/pipelineruns.tekton.dev: "5000"

--- a/components/mintmaker/staging/base/kustomization.yaml
+++ b/components/mintmaker/staging/base/kustomization.yaml
@@ -4,6 +4,7 @@ resources:
 - ../../base
 - ../../base/external-secrets
 - ../blackbox
+- plrs-resource-quota.yaml
 - https://github.com/konflux-ci/mintmaker/config/default?ref=85962df3895522eb8df1d39438b0b85bcde3438a
 - https://github.com/konflux-ci/mintmaker/config/renovate?ref=85962df3895522eb8df1d39438b0b85bcde3438a
 

--- a/components/mintmaker/staging/base/plrs-resource-quota.yaml
+++ b/components/mintmaker/staging/base/plrs-resource-quota.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: pipelineruns-resource-quota
+  namespace: mintmaker
+spec:
+  hard:
+    count/pipelineruns.tekton.dev: "5000"


### PR DESCRIPTION
If the cluster is not able to process the MintMaker's PipelineRuns they will pile up harming the cluster stability. Enforcing a maximum number of concurrent PipelineRuns in the namespace could help mitigate this problem.

This change enforces a reasonably high value to avoid interfering with MintMaker's operativy and act as a safety net if something is going sideways.

Signed-off-by: Francesco Ilario <filario@redhat.com>

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED
