### PR TITLE
bump etcd-shield in prod

### DIFF
--- a/components/etcd-shield/production/base/kustomization.yaml
+++ b/components/etcd-shield/production/base/kustomization.yaml
@@ -11,7 +11,7 @@ configMapGenerator:
 images:
   - name: etcd-shield
     newName: quay.io/konflux-ci/etcd-shield
-    newTag: 907dbd7ccdee9e6b4a61a87ab2a8f44308c02f29
+    newTag: 94885d051db284f214f43d76df2f9bd4c9fe993f
 namespace: etcd-shield
 resources:
   - deployment.yaml

--- a/components/etcd-shield/production/base/webhook.yaml
+++ b/components/etcd-shield/production/base/webhook.yaml
@@ -11,7 +11,7 @@ webhooks:
     service:
       name: etcd-shield
       namespace: etcd-shield
-      path: /validate-tekton-dev-v1-pipelinerun
+      path: /validate-resource
   failurePolicy: Ignore
   name: vpipelineruns.konflux-ci.dev
   rules:


### PR DESCRIPTION
This change promotes etcd-shield in production to the latest version already tested in staging.
The main promoted change is https://github.com/konflux-ci/etcd-shield/commit/a4de2db9f78035eb95ee7dc180264c1d0bc71ed7.
A change in the endpoint used in the webhook is needed accordingly.

Requires:
* [x] #11138
* [x] #11139
* [x] #11185

Signed-off-by: Francesco Ilario <filario@redhat.com>
