### PR TITLE
convert pipelines staging PaC units from Gi to Mi

### DIFF
--- a/components/pipeline-service/staging/base/main-pipeline-service-configuration.yaml
+++ b/components/pipeline-service/staging/base/main-pipeline-service-configuration.yaml
@@ -1795,10 +1795,10 @@ spec:
                     resources:
                       limits:
                         cpu: 500m
-                        memory: 2.5Gi
+                        memory: 2560Mi
                       requests:
                         cpu: 500m
-                        memory: 2.5Gi
+                        memory: 2560Mi
         pipelines-as-code-watcher:
           spec:
             template:

--- a/components/pipeline-service/staging/stone-stage-p01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stage-p01/deploy.yaml
@@ -2343,10 +2343,10 @@ spec:
                   resources:
                     limits:
                       cpu: 500m
-                      memory: 2.5Gi
+                      memory: 2560Mi
                     requests:
                       cpu: 500m
-                      memory: 2.5Gi
+                      memory: 2560Mi
         pipelines-as-code-watcher:
           spec:
             template:

--- a/components/pipeline-service/staging/stone-stg-rh01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stg-rh01/deploy.yaml
@@ -2343,10 +2343,10 @@ spec:
                   resources:
                     limits:
                       cpu: 500m
-                      memory: 2.5Gi
+                      memory: 2560Mi
                     requests:
                       cpu: 500m
-                      memory: 2.5Gi
+                      memory: 2560Mi
         pipelines-as-code-watcher:
           spec:
             template:


### PR DESCRIPTION
For some reason 2.5Gi was not syncing when the value was 2560Mi, however it was still being considered "out of sync" and causing an alert to fire

<img width="1950" height="976" alt="image" src="https://github.com/user-attachments/assets/e36643f5-76f2-4e3a-bf07-1abf0910694d" />
