### PR TITLE
fix(PVO11Y-5132): Set GOMEMLIMIT for stage in-cluster Grafana

### DIFF
--- a/components/monitoring/grafana/staging/grafana-resources-patch.yaml
+++ b/components/monitoring/grafana/staging/grafana-resources-patch.yaml
@@ -10,3 +10,9 @@
       limits:
         cpu: "1"
         memory: "4Gi"
+    env:
+      - name: GOMEMLIMIT
+        valueFrom:
+          resourceFieldRef:
+            resource: limits.memory
+            divisor: "1.25"

--- a/components/monitoring/grafana/staging/grafana-resources-patch.yaml
+++ b/components/monitoring/grafana/staging/grafana-resources-patch.yaml
@@ -12,7 +12,4 @@
         memory: "4Gi"
     env:
       - name: GOMEMLIMIT
-        valueFrom:
-          resourceFieldRef:
-            resource: limits.memory
-            divisor: "1.25"
+        value: "3277MiB"


### PR DESCRIPTION
This is an attempt to prevent the in-cluster Grafana instances from being OOMKilled if a user run expensive queries. Setting GOMEMLIMIT to 80% of the container's resource limit. Applying and validating this change in stage clusters first.