### PR TITLE
mpc: remove default "any" remote address from ssh firewall

### DIFF
--- a/components/multi-platform-controller/base/host-config-chart/templates/_windows-init.ps1.tpl
+++ b/components/multi-platform-controller/base/host-config-chart/templates/_windows-init.ps1.tpl
@@ -333,7 +333,7 @@ Write-Host "Scoop installed successfully!"
 # OpenSSH Administrator Configuration & Service Start
 # ---------------------------------------------------
 {{- $addresses := (list) }}
-{{- range $entry := (index . "allowed-remote-addresses" | default (list)) }}
+{{- range $entry := (index . "allowed-remote-addresses" | required "Allowed remote addresses for the SSH firewall must be specified") }}
     {{- $addresses = (squote $entry | append $addresses) }}
 {{- end }}
 Remove-NetFirewallRule -Name 'OpenSSH-Server-In-TCP' -ErrorAction SilentlyContinue
@@ -344,7 +344,7 @@ New-NetFirewallRule -Name 'OpenSSH-Server-In-TCP' `
     -Protocol TCP `
     -Action Allow `
     -LocalPort 22 `
-    -RemoteAddress {{ join "," $addresses | default "any" }} | Out-Null
+    -RemoteAddress {{ join "," $addresses }} | Out-Null
 
 # Get public key from AWS Instance Metadata Service (IMDSv2)
 $MAGIC_IP = "169.254.169.254"


### PR DESCRIPTION
If we need to add windows support to a cluster in the future, defaulting our templates to allow any IPs is a security risk.  Instead, the template should fail to build and return an error when no firewall rules for windows VMs are specified.

Require that the rendered list of addresses in the SSH firewall rules is not empty.

Fixes: [KFLUXINFRA-3082](https://redhat.atlassian.net/browse/KFLUXINFRA-3082)

[KFLUXINFRA-3082]: https://redhat.atlassian.net/browse/KFLUXINFRA-3082?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ