### PR TITLE
ignore failures on etcd-shield webhook

### DIFF
--- a/components/etcd-shield/production/base/webhook.yaml
+++ b/components/etcd-shield/production/base/webhook.yaml
@@ -12,7 +12,7 @@ webhooks:
       name: etcd-shield
       namespace: etcd-shield
       path: /validate-tekton-dev-v1-pipelinerun
-  failurePolicy: Fail
+  failurePolicy: Ignore
   name: vpipelineruns.konflux-ci.dev
   rules:
   - apiGroups:


### PR DESCRIPTION
This is required to roll-out a breaking change to the production clusters without breaking customers

this is required just to roll-out the new version without breaking customers. It is enforced here, required for https://github.com/redhat-appstudio/infra-deployments/pull/11142, rolled-back by https://github.com/redhat-appstudio/infra-deployments/pull/11186


Signed-off-by: Francesco Ilario <filario@redhat.com>

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED
