### PR TITLE
fail on failures on etcd-shield webhook

### DIFF
--- a/components/etcd-shield/production/base/webhook.yaml
+++ b/components/etcd-shield/production/base/webhook.yaml
@@ -12,7 +12,7 @@ webhooks:
       name: etcd-shield
       namespace: etcd-shield
       path: /validate-resource
-  failurePolicy: Ignore
+  failurePolicy: Fail
   name: vpipelineruns.konflux-ci.dev
   rules:
   - apiGroups:


### PR DESCRIPTION
After the roll-out of `etcd-shield`'s breaking change to all production cluster is complete, we can roll-back to the `Fail` strategy.

Requires:
* [x] #11185
* [x] #11142
