### PR TITLE
KFLUXINFRA-3328: Disable new pipelineruns on kflux-ocp-p01 for planned maintenance

### DIFF
--- a/components/kueue/production/kflux-ocp-p01/queue-config/cluster-queue.yaml
+++ b/components/kueue/production/kflux-ocp-p01/queue-config/cluster-queue.yaml
@@ -24,7 +24,7 @@ spec:
     - name: default-flavor
       resources:
       - name: tekton.dev/pipelineruns
-        nominalQuota: '300'
+        nominalQuota: '0'
       - name: cpu
         nominalQuota: 1k
       - name: memory


### PR DESCRIPTION
## What

* Set `tekton.dev/pipelineruns` `nominalQuota` to `0` in the Kueue ClusterQueue for `kflux-ocp-p01` to prevent new pipeline runs from being scheduled during planned maintenance.

## Why

The `kflux-ocp-p01` cluster needs to undergo planned maintenance. Disabling new PipelineRun admissions ensures no new workloads are scheduled during the maintenance window while allowing existing in-progress PipelineRuns to complete unaffected.

## Validation

* Verify no new PipelineRuns are admitted on `kflux-ocp-p01` after merge
* Confirm existing in-progress PipelineRuns are unaffected
* Revert `nominalQuota` back to `300` after maintenance is complete

## Risk Assessment

**Risk Level:** Low
**Rollback:** Revert PR and redeploy previous configuration

Made with [Cursor](https://cursor.com)