### PR TITLE
KFLUXINFRA-3328: Swap temporary ppc64le nodes to permanent and re-enable pipelineruns on kflux-ocp-p01

### DIFF
--- a/components/kueue/production/kflux-ocp-p01/config.yaml
+++ b/components/kueue/production/kflux-ocp-p01/config.yaml
@@ -27,7 +27,6 @@ cel:
               'linux/ppc64le',
               'linux/s390x',
               'linux/x86_64',
-              'linux-temp/ppc64le',
               'local',
               'localhost',
             ]
@@ -77,7 +76,6 @@ cel:
             'linux/ppc64le',
             'linux/s390x',
             'linux/x86_64',
-            'linux-temp/ppc64le',
             'local',
             'localhost',
           ]

--- a/components/kueue/production/kflux-ocp-p01/queue-config/cluster-queue.yaml
+++ b/components/kueue/production/kflux-ocp-p01/queue-config/cluster-queue.yaml
@@ -24,7 +24,7 @@ spec:
     - name: default-flavor
       resources:
       - name: tekton.dev/pipelineruns
-        nominalQuota: '0'
+        nominalQuota: '300'
       - name: cpu
         nominalQuota: 1k
       - name: memory
@@ -149,7 +149,6 @@ spec:
     - linux-root-amd64
     - linux-root-arm64
     - linux-s390x
-    - linux-temp-ppc64le
     - linux-x86-64
     - local
     - localhost
@@ -178,8 +177,6 @@ spec:
         nominalQuota: '250'
       - name: linux-s390x
         nominalQuota: '56'
-      - name: linux-temp-ppc64le
-        nominalQuota: '64'
       - name: linux-x86-64
         nominalQuota: '1000'
       - name: local

--- a/components/multi-platform-controller/production-downstream/kflux-ocp-p01/host-values.yaml
+++ b/components/multi-platform-controller/production-downstream/kflux-ocp-p01/host-values.yaml
@@ -114,117 +114,60 @@ dynamicConfigs:
 
 # Static hosts configuration
 staticHosts:
-  # PPC
+  # PPC (from kflux-ocp-p01-ppc-workspace-wdc)
   ppc64le-pi-static-x0:
-    address: "10.130.107.23"
+    address: "10.130.72.76"
     concurrency: "8"
     platform: "linux/ppc64le"
-    secret: "ibm-ppc64le-ssh-key"
+    secret: "ibm-ppc64le-ssh-key-wdc"
     user: "root"
 
   ppc64le-pi-static-x1:
-    address: "10.130.107.27"
+    address: "10.130.72.93"
     concurrency: "8"
     platform: "linux/ppc64le"
-    secret: "ibm-ppc64le-ssh-key"
+    secret: "ibm-ppc64le-ssh-key-wdc"
     user: "root"
 
   ppc64le-pi-static-x2:
-    address: "10.130.107.11"
+    address: "10.130.72.75"
     concurrency: "8"
     platform: "linux/ppc64le"
-    secret: "ibm-ppc64le-ssh-key"
+    secret: "ibm-ppc64le-ssh-key-wdc"
     user: "root"
 
   ppc64le-pi-static-x3:
-    address: "10.130.107.19"
+    address: "10.130.72.71"
     concurrency: "8"
     platform: "linux/ppc64le"
-    secret: "ibm-ppc64le-ssh-key"
+    secret: "ibm-ppc64le-ssh-key-wdc"
     user: "root"
 
   ppc64le-pi-static-x4:
-    address: "10.130.107.6"
+    address: "10.130.72.73"
     concurrency: "8"
     platform: "linux/ppc64le"
-    secret: "ibm-ppc64le-ssh-key"
+    secret: "ibm-ppc64le-ssh-key-wdc"
     user: "root"
 
   ppc64le-pi-static-x5:
-    address: "10.130.107.13"
+    address: "10.130.72.85"
     concurrency: "8"
     platform: "linux/ppc64le"
-    secret: "ibm-ppc64le-ssh-key"
+    secret: "ibm-ppc64le-ssh-key-wdc"
     user: "root"
 
   ppc64le-pi-static-x6:
-    address: "10.130.107.30"
+    address: "10.130.72.90"
     concurrency: "8"
     platform: "linux/ppc64le"
-    secret: "ibm-ppc64le-ssh-key"
+    secret: "ibm-ppc64le-ssh-key-wdc"
     user: "root"
 
   ppc64le-pi-static-x7:
-    address: "10.130.107.29"
-    concurrency: "8"
-    platform: "linux/ppc64le"
-    secret: "ibm-ppc64le-ssh-key"
-    user: "root"
-
-  # Temporary PPC nodes from kflux-ocp-p01-ppc-workspace-wdc
-  ppc64le-temp-1:
-    address: "10.130.72.76"
-    concurrency: "8"
-    platform: "linux-temp/ppc64le"
-    secret: "ibm-ppc64le-ssh-key-wdc"
-    user: "root"
-
-  ppc64le-temp-2:
-    address: "10.130.72.93"
-    concurrency: "8"
-    platform: "linux-temp/ppc64le"
-    secret: "ibm-ppc64le-ssh-key-wdc"
-    user: "root"
-
-  ppc64le-temp-3:
-    address: "10.130.72.75"
-    concurrency: "8"
-    platform: "linux-temp/ppc64le"
-    secret: "ibm-ppc64le-ssh-key-wdc"
-    user: "root"
-
-  ppc64le-temp-4:
-    address: "10.130.72.71"
-    concurrency: "8"
-    platform: "linux-temp/ppc64le"
-    secret: "ibm-ppc64le-ssh-key-wdc"
-    user: "root"
-
-  ppc64le-temp-5:
-    address: "10.130.72.73"
-    concurrency: "8"
-    platform: "linux-temp/ppc64le"
-    secret: "ibm-ppc64le-ssh-key-wdc"
-    user: "root"
-
-  ppc64le-temp-6:
-    address: "10.130.72.85"
-    concurrency: "8"
-    platform: "linux-temp/ppc64le"
-    secret: "ibm-ppc64le-ssh-key-wdc"
-    user: "root"
-
-  ppc64le-temp-7:
-    address: "10.130.72.90"
-    concurrency: "8"
-    platform: "linux-temp/ppc64le"
-    secret: "ibm-ppc64le-ssh-key-wdc"
-    user: "root"
-
-  ppc64le-temp-8:
     address: "10.130.72.91"
     concurrency: "8"
-    platform: "linux-temp/ppc64le"
+    platform: "linux/ppc64le"
     secret: "ibm-ppc64le-ssh-key-wdc"
     user: "root"
 


### PR DESCRIPTION
## What

* Remove the old ppc64le static nodes (`ppc64le-pi-static-x0` through `x7`) from `kflux-ocp-p01-ppc-workspace` (10.130.107.x)
* Promote the 8 temporary WDC ppc64le nodes (`kflux-ocp-p01-ppc-workspace-wdc`, 10.130.72.x) to permanent static hosts, renaming from `ppc64le-temp-*` to `ppc64le-static-*`
* Change platform from `linux-temp/ppc64le` to `linux/ppc64le` to remove the temporary naming context
* Remove `linux-temp/ppc64le` from Kueue CEL `aws-ip` exclusion lists (no longer needed since the platform name is now standard `linux/ppc64le`)
* Regenerate Kueue ClusterQueue — removes `linux-temp-ppc64le` resource, `linux-ppc64le` quota remains at `64`
* Re-enable pipelinerun admissions (reverts the `nominalQuota: 0` set in #11194)

## Why

The old ppc64le nodes from `kflux-ocp-p01-ppc-workspace` are being decommissioned. The WDC nodes that were added temporarily in #11101 are now the permanent replacements. This PR completes the node swap and restores normal pipelinerun scheduling after the maintenance window.

**Note:** This PR should be merged after #11194.

## Validation

* Verify ppc64le builds route to the WDC nodes (10.130.72.x) with `linux/ppc64le` platform
* Verify pipelinerun admissions are restored on `kflux-ocp-p01`
* Verify Kueue ClusterQueue no longer references `linux-temp-ppc64le`

## Risk Assessment

**Risk Level:** Low
**Rollback:** Revert PR and redeploy previous configuration

Made with [Cursor](https://cursor.com)