### PR TITLE
disable etcd-defrag in stg

### DIFF
--- a/configs/etcd-defrag/staging/base/cronjob.yaml
+++ b/configs/etcd-defrag/staging/base/cronjob.yaml
@@ -5,6 +5,7 @@ metadata:
   name: etcd-maintenance
   namespace: etcd-maintenance
 spec:
+  suspend: true
   schedule: "*/10 * * * *"
   successfulJobsHistoryLimit: 50
   jobTemplate:


### PR DESCRIPTION
This is a temporary change to investigate the effect on etcd's 'in-use' metric.

Signed-off-by: Francesco Ilario <filario@redhat.com>

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED
