### PR TITLE
fix(etcd-shield): raise thresholds, add total_size check, and fix severity — production

### DIFF
--- a/components/etcd-shield/production/base/etcd_shield_alerts.yaml
+++ b/components/etcd-shield/production/base/etcd_shield_alerts.yaml
@@ -12,14 +12,16 @@ spec:
       for: 2m
       keep_firing_for: 5m
       labels:
-        severity: warning
+        severity: critical
       annotations:
         summary: etcd-shield is denying admission
         description: Etcd is nearing capacity limits, so etcd-shield is denying admission
     - record: etcd_shield_trigger
       expr: |
         (((etcd_mvcc_db_total_size_in_use_in_bytes >= bool (etcd_server_quota_backend_bytes * 0.80)) == 1) or
-            ((((etcd_mvcc_db_total_size_in_use_in_bytes) >= bool (etcd_server_quota_backend_bytes * 0.70)) == 1) and
+            ((etcd_mvcc_db_total_size_in_bytes >= bool (etcd_server_quota_backend_bytes * 0.80)) == 1) or
+            ((((etcd_mvcc_db_total_size_in_use_in_bytes >= bool (etcd_server_quota_backend_bytes * 0.70)) == 1) or
+                ((etcd_mvcc_db_total_size_in_bytes >= bool (etcd_server_quota_backend_bytes * 0.70)) == 1)) and
                 (count without (alertname, alertstate, severity)
                       (ALERTS{
                         alertname="EtcdShieldDenyAdmission",

--- a/components/etcd-shield/rings/ring-0/base/base-snapshot/etcd_shield_alerts.yaml
+++ b/components/etcd-shield/rings/ring-0/base/base-snapshot/etcd_shield_alerts.yaml
@@ -18,8 +18,10 @@ spec:
         description: Etcd is nearing capacity limits, so etcd-shield is denying admission
     - record: etcd_shield_trigger
       expr: |
-        (((etcd_mvcc_db_total_size_in_use_in_bytes >= bool (etcd_server_quota_backend_bytes * 0.80)) == 1) or
-            ((((etcd_mvcc_db_total_size_in_use_in_bytes) >= bool (etcd_server_quota_backend_bytes * 0.70)) == 1) and
+        (((etcd_mvcc_db_total_size_in_use_in_bytes >= bool (etcd_server_quota_backend_bytes * 0.85)) == 1) or
+            ((etcd_mvcc_db_total_size_in_bytes >= bool (etcd_server_quota_backend_bytes * 0.90)) == 1) or
+            ((((etcd_mvcc_db_total_size_in_use_in_bytes >= bool (etcd_server_quota_backend_bytes * 0.75)) == 1) or
+                ((etcd_mvcc_db_total_size_in_bytes >= bool (etcd_server_quota_backend_bytes * 0.80)) == 1)) and
                 (count without (alertname, alertstate, severity)
                       (ALERTS{
                         alertname="EtcdShieldDenyAdmission",

--- a/components/etcd-shield/rings/ring-1/base/base-snapshot/etcd_shield_alerts.yaml
+++ b/components/etcd-shield/rings/ring-1/base/base-snapshot/etcd_shield_alerts.yaml
@@ -18,8 +18,10 @@ spec:
         description: Etcd is nearing capacity limits, so etcd-shield is denying admission
     - record: etcd_shield_trigger
       expr: |
-        (((etcd_mvcc_db_total_size_in_use_in_bytes >= bool (etcd_server_quota_backend_bytes * 0.80)) == 1) or
-            ((((etcd_mvcc_db_total_size_in_use_in_bytes) >= bool (etcd_server_quota_backend_bytes * 0.70)) == 1) and
+        (((etcd_mvcc_db_total_size_in_use_in_bytes >= bool (etcd_server_quota_backend_bytes * 0.85)) == 1) or
+            ((etcd_mvcc_db_total_size_in_bytes >= bool (etcd_server_quota_backend_bytes * 0.90)) == 1) or
+            ((((etcd_mvcc_db_total_size_in_use_in_bytes >= bool (etcd_server_quota_backend_bytes * 0.75)) == 1) or
+                ((etcd_mvcc_db_total_size_in_bytes >= bool (etcd_server_quota_backend_bytes * 0.80)) == 1)) and
                 (count without (alertname, alertstate, severity)
                       (ALERTS{
                         alertname="EtcdShieldDenyAdmission",

--- a/components/etcd-shield/rings/ring-2/base/base-snapshot/etcd_shield_alerts.yaml
+++ b/components/etcd-shield/rings/ring-2/base/base-snapshot/etcd_shield_alerts.yaml
@@ -18,8 +18,10 @@ spec:
         description: Etcd is nearing capacity limits, so etcd-shield is denying admission
     - record: etcd_shield_trigger
       expr: |
-        (((etcd_mvcc_db_total_size_in_use_in_bytes >= bool (etcd_server_quota_backend_bytes * 0.80)) == 1) or
-            ((((etcd_mvcc_db_total_size_in_use_in_bytes) >= bool (etcd_server_quota_backend_bytes * 0.70)) == 1) and
+        (((etcd_mvcc_db_total_size_in_use_in_bytes >= bool (etcd_server_quota_backend_bytes * 0.85)) == 1) or
+            ((etcd_mvcc_db_total_size_in_bytes >= bool (etcd_server_quota_backend_bytes * 0.90)) == 1) or
+            ((((etcd_mvcc_db_total_size_in_use_in_bytes >= bool (etcd_server_quota_backend_bytes * 0.75)) == 1) or
+                ((etcd_mvcc_db_total_size_in_bytes >= bool (etcd_server_quota_backend_bytes * 0.80)) == 1)) and
                 (count without (alertname, alertstate, severity)
                       (ALERTS{
                         alertname="EtcdShieldDenyAdmission",

--- a/components/etcd-shield/rings/ring-3/base/base-snapshot/etcd_shield_alerts.yaml
+++ b/components/etcd-shield/rings/ring-3/base/base-snapshot/etcd_shield_alerts.yaml
@@ -18,8 +18,10 @@ spec:
         description: Etcd is nearing capacity limits, so etcd-shield is denying admission
     - record: etcd_shield_trigger
       expr: |
-        (((etcd_mvcc_db_total_size_in_use_in_bytes >= bool (etcd_server_quota_backend_bytes * 0.80)) == 1) or
-            ((((etcd_mvcc_db_total_size_in_use_in_bytes) >= bool (etcd_server_quota_backend_bytes * 0.70)) == 1) and
+        (((etcd_mvcc_db_total_size_in_use_in_bytes >= bool (etcd_server_quota_backend_bytes * 0.85)) == 1) or
+            ((etcd_mvcc_db_total_size_in_bytes >= bool (etcd_server_quota_backend_bytes * 0.90)) == 1) or
+            ((((etcd_mvcc_db_total_size_in_use_in_bytes >= bool (etcd_server_quota_backend_bytes * 0.75)) == 1) or
+                ((etcd_mvcc_db_total_size_in_bytes >= bool (etcd_server_quota_backend_bytes * 0.80)) == 1)) and
                 (count without (alertname, alertstate, severity)
                       (ALERTS{
                         alertname="EtcdShieldDenyAdmission",

--- a/components/etcd-shield/rings/ring-4/base/base-snapshot/etcd_shield_alerts.yaml
+++ b/components/etcd-shield/rings/ring-4/base/base-snapshot/etcd_shield_alerts.yaml
@@ -18,8 +18,10 @@ spec:
         description: Etcd is nearing capacity limits, so etcd-shield is denying admission
     - record: etcd_shield_trigger
       expr: |
-        (((etcd_mvcc_db_total_size_in_use_in_bytes >= bool (etcd_server_quota_backend_bytes * 0.80)) == 1) or
-            ((((etcd_mvcc_db_total_size_in_use_in_bytes) >= bool (etcd_server_quota_backend_bytes * 0.70)) == 1) and
+        (((etcd_mvcc_db_total_size_in_use_in_bytes >= bool (etcd_server_quota_backend_bytes * 0.85)) == 1) or
+            ((etcd_mvcc_db_total_size_in_bytes >= bool (etcd_server_quota_backend_bytes * 0.90)) == 1) or
+            ((((etcd_mvcc_db_total_size_in_use_in_bytes >= bool (etcd_server_quota_backend_bytes * 0.75)) == 1) or
+                ((etcd_mvcc_db_total_size_in_bytes >= bool (etcd_server_quota_backend_bytes * 0.80)) == 1)) and
                 (count without (alertname, alertstate, severity)
                       (ALERTS{
                         alertname="EtcdShieldDenyAdmission",


### PR DESCRIPTION
## What

Raise etcd-shield recording rule thresholds, add `etcd_mvcc_db_total_size_in_bytes` (physical DB size) check, and fix alert severity — production overlay only.

## Changes

| Metric | Activate | Deactivate |
|--------|----------|------------|
| `in_use` | 80% → 85% | 70% → 75% |
| `total_size` (new) | 90% | 80% |
| severity | warning → critical | — |

## Why

- Busy clusters routinely reach 75% `in_use`, causing unnecessary shield activation at the old 80%/70% thresholds (per staging review feedback).
- Physical DB size (`total_size`) can exceed quota undetected when only `in_use` is checked — fragmentation fills the gap.
- Severity fix: hysteresis branch checks `ALERTS{severity="critical"}` but alert was labeled `warning`, making the 70% deactivation threshold dead code.
- Thresholds now match staging PR #11319.

## Validation

- Staging PR: #11319 (thresholds), #12471 (severity fix, merged)
- Tested against live Prometheus on stone-prd-rh01. All conditions verified.

## Risk Assessment

**Risk Level:** Low — validated in staging, single revert, thresholds are more conservative than quota limits.