### PR TITLE
Deploy custom-kube-state-metrics to production

### DIFF
--- a/argo-cd-apps/overlays/konflux-public-production/delete-applications.yaml
+++ b/argo-cd-apps/overlays/konflux-public-production/delete-applications.yaml
@@ -12,12 +12,6 @@ metadata:
   name: nvme-storage-configurator
 $patch: delete
 ---
-apiVersion: argoproj.io/v1alpha1
-kind: ApplicationSet
-metadata:
-  name: monitoring-workload-custom-kube-state-metrics
-$patch: delete
----
 # Cardinality exporter is staging-only
 apiVersion: argoproj.io/v1alpha1
 kind: ApplicationSet

--- a/argo-cd-apps/overlays/konflux-public-production/kustomization.yaml
+++ b/argo-cd-apps/overlays/konflux-public-production/kustomization.yaml
@@ -90,6 +90,11 @@ patches:
     target:
       kind: ApplicationSet
       version: v1alpha1
+      name: monitoring-workload-custom-kube-state-metrics
+  - path: production-overlay-patch.yaml
+    target:
+      kind: ApplicationSet
+      version: v1alpha1
       name: cluster-secret-store-rh
   - path: production-overlay-patch.yaml
     target:

--- a/argo-cd-apps/overlays/production-downstream/delete-applications.yaml
+++ b/argo-cd-apps/overlays/production-downstream/delete-applications.yaml
@@ -11,12 +11,6 @@ metadata:
   name: quality-dashboard
 $patch: delete
 ---
-apiVersion: argoproj.io/v1alpha1
-kind: ApplicationSet
-metadata:
-  name: monitoring-workload-custom-kube-state-metrics
-$patch: delete
----
 # Cardinality exporter is staging-only
 apiVersion: argoproj.io/v1alpha1
 kind: ApplicationSet

--- a/argo-cd-apps/overlays/production-downstream/kustomization.yaml
+++ b/argo-cd-apps/overlays/production-downstream/kustomization.yaml
@@ -89,6 +89,11 @@ patches:
     target:
       kind: ApplicationSet
       version: v1alpha1
+      name: monitoring-workload-custom-kube-state-metrics
+  - path: production-overlay-patch.yaml
+    target:
+      kind: ApplicationSet
+      version: v1alpha1
       name: cluster-secret-store-rh
   - path: production-overlay-patch.yaml
     target:

--- a/components/monitoring/custom-kube-state-metrics/production/kustomization.yaml
+++ b/components/monitoring/custom-kube-state-metrics/production/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../base
+
+patches:
+  - path: resource-patch.yaml
+    target:
+      name: custom-kube-state-metrics
+      kind: Deployment

--- a/components/monitoring/custom-kube-state-metrics/production/kustomization.yaml
+++ b/components/monitoring/custom-kube-state-metrics/production/kustomization.yaml
@@ -4,6 +4,9 @@ kind: Kustomization
 resources:
   - ../base
 
+commonAnnotations:
+  argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+
 patches:
   - path: resource-patch.yaml
     target:

--- a/components/monitoring/custom-kube-state-metrics/production/resource-patch.yaml
+++ b/components/monitoring/custom-kube-state-metrics/production/resource-patch.yaml
@@ -1,0 +1,7 @@
+---
+- op: replace
+  path: /spec/template/spec/containers/0/resources/requests/memory
+  value: 512Mi
+- op: replace
+  path: /spec/template/spec/containers/0/resources/limits/memory
+  value: 512Mi


### PR DESCRIPTION
Related Issue:
[PVO11Y-5051](https://redhat.atlassian.net/browse/PVO11Y-5051)
Deployment to stage:
https://github.com/redhat-appstudio/infra-deployments/pull/10636

What:
Deploys custom-kube-state-metrics to production allowing us to consume production data. 

Evidence:
The custom collector is returning requested metrics that can be consumed.
We can see the metric in the openshift metrics tab:
<img width="625" height="652" alt="image" src="https://github.com/user-attachments/assets/f893aa44-0815-4647-aea2-a8864de8e267" />




[PVO11Y-5051]: https://redhat.atlassian.net/browse/PVO11Y-5051?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ