### PR TITLE
Update kyverno production images (ring 1)

### DIFF
--- a/components/kyverno/production/stone-prd-rh01/kustomization.yaml
+++ b/components/kyverno/production/stone-prd-rh01/kustomization.yaml
@@ -9,19 +9,19 @@ generators:
 images:
   - name: reg.kyverno.io/kyverno/kyverno
     newName: quay.io/konflux-ci/kyverno/kyverno
-    newTag: b28cf7b437a5fb8f805b19da1fd63df4c518113d
+    newTag: 6f4277e0ec31e2e272b68f64dc1f8bef257fd77b
   - name: reg.kyverno.io/kyverno/kyvernopre
     newName: quay.io/konflux-ci/kyverno/kyverno-init
-    newTag: b28cf7b437a5fb8f805b19da1fd63df4c518113d
+    newTag: 6f4277e0ec31e2e272b68f64dc1f8bef257fd77b
   - name: reg.kyverno.io/kyverno/background-controller
     newName: quay.io/konflux-ci/kyverno/kyverno-background
-    newTag: b28cf7b437a5fb8f805b19da1fd63df4c518113d
+    newTag: 6f4277e0ec31e2e272b68f64dc1f8bef257fd77b
   - name: reg.kyverno.io/kyverno/cleanup-controller
     newName: quay.io/konflux-ci/kyverno/kyverno-cleanup
-    newTag: b28cf7b437a5fb8f805b19da1fd63df4c518113d
+    newTag: 6f4277e0ec31e2e272b68f64dc1f8bef257fd77b
   - name: reg.kyverno.io/kyverno/kyverno-cli
     newName: quay.io/konflux-ci/kyverno/kyverno-cli
-    newTag: b28cf7b437a5fb8f805b19da1fd63df4c518113d
+    newTag: 6f4277e0ec31e2e272b68f64dc1f8bef257fd77b
 
 # set resources to jobs
 patches:

--- a/components/kyverno/production/stone-prod-p01/kustomization.yaml
+++ b/components/kyverno/production/stone-prod-p01/kustomization.yaml
@@ -9,19 +9,19 @@ generators:
 images:
   - name: reg.kyverno.io/kyverno/kyverno
     newName: quay.io/konflux-ci/kyverno/kyverno
-    newTag: b28cf7b437a5fb8f805b19da1fd63df4c518113d
+    newTag: 6f4277e0ec31e2e272b68f64dc1f8bef257fd77b
   - name: reg.kyverno.io/kyverno/kyvernopre
     newName: quay.io/konflux-ci/kyverno/kyverno-init
-    newTag: b28cf7b437a5fb8f805b19da1fd63df4c518113d
+    newTag: 6f4277e0ec31e2e272b68f64dc1f8bef257fd77b
   - name: reg.kyverno.io/kyverno/background-controller
     newName: quay.io/konflux-ci/kyverno/kyverno-background
-    newTag: b28cf7b437a5fb8f805b19da1fd63df4c518113d
+    newTag: 6f4277e0ec31e2e272b68f64dc1f8bef257fd77b
   - name: reg.kyverno.io/kyverno/cleanup-controller
     newName: quay.io/konflux-ci/kyverno/kyverno-cleanup
-    newTag: b28cf7b437a5fb8f805b19da1fd63df4c518113d
+    newTag: 6f4277e0ec31e2e272b68f64dc1f8bef257fd77b
   - name: reg.kyverno.io/kyverno/kyverno-cli
     newName: quay.io/konflux-ci/kyverno/kyverno-cli
-    newTag: b28cf7b437a5fb8f805b19da1fd63df4c518113d
+    newTag: 6f4277e0ec31e2e272b68f64dc1f8bef257fd77b
 
 patches:
   - path: job_resources.yaml


### PR DESCRIPTION
## What

Update kyverno images on 2 production clusters as ring 1, from `b28cf7b` to `6f4277e0ec31e2e272b68f64dc1f8bef257fd77b`:
- `stone-prd-rh01` (public)
- `stone-prod-p01` (private)

All 5 kyverno images are updated: kyverno, kyverno-init, kyverno-background, kyverno-cleanup, kyverno-cli.

Jira: [KONFLUX-12774](https://redhat.atlassian.net/browse/KONFLUX-12774)

## Why

The new image includes gRPC-Go v1.79.3 which fixes a CVE. This is a ring-1 rollout targeting one public and one private production cluster first before rolling out to the remaining clusters.

## Validation

Staging PR - #11198

Validation in Staging clusters:

### Deployed image verification

Verified the gRPC-Go version embedded in the binaries of all deployed kyverno images in the `konflux-kyverno` namespace.

**Step 1: Identify deployed images**

```bash
$ oc get deployments -n konflux-kyverno -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.spec.template.spec.containers[0].image}{"\n"}{end}'
kyverno-admission-controller  quay.io/konflux-ci/kyverno/kyverno:6f4277e0ec31e2e272b68f64dc1f8bef257fd77b
kyverno-background-controller quay.io/konflux-ci/kyverno/kyverno-background:6f4277e0ec31e2e272b68f64dc1f8bef257fd77b
kyverno-cleanup-controller    quay.io/konflux-ci/kyverno/kyverno-cleanup:6f4277e0ec31e2e272b68f64dc1f8bef257fd77b
```

**Step 2: Pull images and extract binaries**

```bash
$ podman pull quay.io/konflux-ci/kyverno/kyverno:6f4277e0ec31e2e272b68f64dc1f8bef257fd77b
$ podman pull quay.io/konflux-ci/kyverno/kyverno-background:6f4277e0ec31e2e272b68f64dc1f8bef257fd77b
$ podman pull quay.io/konflux-ci/kyverno/kyverno-cleanup:6f4277e0ec31e2e272b68f64dc1f8bef257fd77b

$ CID=$(podman create <image>) && podman cp $CID:/<binary> /tmp/<name>-binary && podman rm $CID
```

**Step 3: Inspect gRPC-Go version in each binary**

```bash
$ go version -m /tmp/kyverno-binary | grep 'google.golang.org/grpc\b'
      dep     google.golang.org/grpc  v1.79.3 h1:sybAEdRIEtvcD68Gx7dmnwjZKlyfuc61Dyo9pGXXkKE=

$ go version -m /tmp/kyverno-background-binary | grep 'google.golang.org/grpc\b'
      dep     google.golang.org/grpc  v1.79.3 h1:sybAEdRIEtvcD68Gx7dmnwjZKlyfuc61Dyo9pGXXkKE=

$ go version -m /tmp/kyverno-cleanup-binary | grep 'google.golang.org/grpc\b'
      dep     google.golang.org/grpc  v1.79.3 h1:sybAEdRIEtvcD68Gx7dmnwjZKlyfuc61Dyo9pGXXkKE=
```

**Result:** All 3 deployed components are running `google.golang.org/grpc` v1.79.3 (>= v1.79.3 required). CVE is fixed.

## Risk Assessment

**Risk Level:** Low

This is a ring-1 rollout limited to 2 production clusters — one public (`stone-prd-rh01`) and one private (`stone-prod-p01`). The image update only bumps dependency versions (gRPC-Go CVE fix) with no functional changes. Remaining production clusters will be updated in a follow-up ring-2 PR after verifying stability.


[KONFLUX-12774]: https://redhat.atlassian.net/browse/KONFLUX-12774?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ