### PR TITLE
fix(KONFLUX-12721): Bump notification-controller

### DIFF
--- a/components/notification-controller/production/kustomization.yaml
+++ b/components/notification-controller/production/kustomization.yaml
@@ -2,13 +2,13 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-- https://github.com/konflux-ci/notification-service/config/default?ref=074907fc9ce72ad1d9dd489b9026b697745e7175
+- https://github.com/konflux-ci/notification-service/config/default?ref=4c07f5d3bf6dc3fa556da8c9510d643775803fed
 - ../base/external-secrets
 
 images:
   - name: quay.io/konflux-ci/notification-service
     newName: quay.io/konflux-ci/notification-service
-    newTag: 074907fc9ce72ad1d9dd489b9026b697745e7175
+    newTag: 4c07f5d3bf6dc3fa556da8c9510d643775803fed
 
 namespace: notification-controller
 


### PR DESCRIPTION
Bump notification-controller in Production.
This version includes a fix for `CVE-2026-33211`

It was merged and tested in staging:
https://github.com/redhat-appstudio/infra-deployments/pull/11187