### PR TITLE
Promote caching from staging to production

### DIFF
--- a/components/squid/production/squid-helm-generator.yaml
+++ b/components/squid/production/squid-helm-generator.yaml
@@ -4,7 +4,7 @@ metadata:
   name: squid-helm
 name: squid-helm
 repo: oci://quay.io/konflux-ci/caching
-version: 0.1.1394+a886353
+version: 0.1.1400+4a52f5d
 valuesInline:
   installCertManagerComponents: false
   mirrord:


### PR DESCRIPTION
What:
Update squid Helm chart to 0.1.1400+4a52f5d

Why:
- Fix ServiceMonitor certificate verification issue
- Tested and validated on staging clusters

Validation:
- Working fine on staging ([stage PR](https://github.com/redhat-appstudio/infra-deployments/pull/11212))
- Related PR: konflux-ci/caching#769