### PR TITLE
CVE-2026-33186: Update production etcd defrag CronJob image

### DIFF
--- a/configs/etcd-defrag/production/base/cronjob.yaml
+++ b/configs/etcd-defrag/production/base/cronjob.yaml
@@ -19,7 +19,7 @@ spec:
               imagePullPolicy: IfNotPresent
               env:
               - name: IMAGE
-                value: quay.io/konflux-ci/etcd-defrag@sha256:825638235a85f80f9161b03bfe24666d57d8521ec154a673617ea7b08b07d379
+                value: quay.io/konflux-ci/etcd-defrag@sha256:220a12563504cef95f2298097f696b681f09aacf407ab2a29a40c25766069d69
               - name: MAX_FRAGMENTED_PERCENTAGE
                 value: "50"
               - name: MIN_DEFRAG_MB


### PR DESCRIPTION
### Changes

Changes are from https://github.com/redhat-appstudio/infrastructure/pull/89
- Upgrade Go version from 1.22 -> 1.24
- Upgrade gRPC-Go module from 1.59.0 -> 1.79.3 for security vulnerabilities

**Does not deploy to stone-prd-rh01**

 ### Testing

Deployed to staging on April 7th in https://github.com/redhat-appstudio/infra-deployments/pull/11167 and the `CronJob` has been healthily running ever since. 

## Risk Assessment
**Risk Level:** Low
**Description:** No changes to code, only dependency module updates. That makes this unlikely to cause issues in production.
**Rollback:** Revert PR and redeploy previous image tag

## Validation

Staging PR:  https://github.com/redhat-appstudio/infra-deployments/pull/11167
