### PR TITLE
Update kyverno production images (ring 2)

### DIFF
--- a/components/kyverno/production/kflux-fedora-01/kustomization.yaml
+++ b/components/kyverno/production/kflux-fedora-01/kustomization.yaml
@@ -9,19 +9,19 @@ generators:
 images:
   - name: reg.kyverno.io/kyverno/kyverno
     newName: quay.io/konflux-ci/kyverno/kyverno
-    newTag: b28cf7b437a5fb8f805b19da1fd63df4c518113d
+    newTag: 6f4277e0ec31e2e272b68f64dc1f8bef257fd77b
   - name: reg.kyverno.io/kyverno/kyvernopre
     newName: quay.io/konflux-ci/kyverno/kyverno-init
-    newTag: b28cf7b437a5fb8f805b19da1fd63df4c518113d
+    newTag: 6f4277e0ec31e2e272b68f64dc1f8bef257fd77b
   - name: reg.kyverno.io/kyverno/background-controller
     newName: quay.io/konflux-ci/kyverno/kyverno-background
-    newTag: b28cf7b437a5fb8f805b19da1fd63df4c518113d
+    newTag: 6f4277e0ec31e2e272b68f64dc1f8bef257fd77b
   - name: reg.kyverno.io/kyverno/cleanup-controller
     newName: quay.io/konflux-ci/kyverno/kyverno-cleanup
-    newTag: b28cf7b437a5fb8f805b19da1fd63df4c518113d
+    newTag: 6f4277e0ec31e2e272b68f64dc1f8bef257fd77b
   - name: reg.kyverno.io/kyverno/kyverno-cli
     newName: quay.io/konflux-ci/kyverno/kyverno-cli
-    newTag: b28cf7b437a5fb8f805b19da1fd63df4c518113d
+    newTag: 6f4277e0ec31e2e272b68f64dc1f8bef257fd77b
 
 # set resources to jobs
 patches:

--- a/components/kyverno/production/kflux-ocp-p01/kustomization.yaml
+++ b/components/kyverno/production/kflux-ocp-p01/kustomization.yaml
@@ -9,19 +9,19 @@ generators:
 images:
   - name: reg.kyverno.io/kyverno/kyverno
     newName: quay.io/konflux-ci/kyverno/kyverno
-    newTag: b28cf7b437a5fb8f805b19da1fd63df4c518113d
+    newTag: 6f4277e0ec31e2e272b68f64dc1f8bef257fd77b
   - name: reg.kyverno.io/kyverno/kyvernopre
     newName: quay.io/konflux-ci/kyverno/kyverno-init
-    newTag: b28cf7b437a5fb8f805b19da1fd63df4c518113d
+    newTag: 6f4277e0ec31e2e272b68f64dc1f8bef257fd77b
   - name: reg.kyverno.io/kyverno/background-controller
     newName: quay.io/konflux-ci/kyverno/kyverno-background
-    newTag: b28cf7b437a5fb8f805b19da1fd63df4c518113d
+    newTag: 6f4277e0ec31e2e272b68f64dc1f8bef257fd77b
   - name: reg.kyverno.io/kyverno/cleanup-controller
     newName: quay.io/konflux-ci/kyverno/kyverno-cleanup
-    newTag: b28cf7b437a5fb8f805b19da1fd63df4c518113d
+    newTag: 6f4277e0ec31e2e272b68f64dc1f8bef257fd77b
   - name: reg.kyverno.io/kyverno/kyverno-cli
     newName: quay.io/konflux-ci/kyverno/kyverno-cli
-    newTag: b28cf7b437a5fb8f805b19da1fd63df4c518113d
+    newTag: 6f4277e0ec31e2e272b68f64dc1f8bef257fd77b
 
 # set resources to jobs
 patches:

--- a/components/kyverno/production/kflux-osp-p01/kustomization.yaml
+++ b/components/kyverno/production/kflux-osp-p01/kustomization.yaml
@@ -9,19 +9,19 @@ generators:
 images:
   - name: reg.kyverno.io/kyverno/kyverno
     newName: quay.io/konflux-ci/kyverno/kyverno
-    newTag: b28cf7b437a5fb8f805b19da1fd63df4c518113d
+    newTag: 6f4277e0ec31e2e272b68f64dc1f8bef257fd77b
   - name: reg.kyverno.io/kyverno/kyvernopre
     newName: quay.io/konflux-ci/kyverno/kyverno-init
-    newTag: b28cf7b437a5fb8f805b19da1fd63df4c518113d
+    newTag: 6f4277e0ec31e2e272b68f64dc1f8bef257fd77b
   - name: reg.kyverno.io/kyverno/background-controller
     newName: quay.io/konflux-ci/kyverno/kyverno-background
-    newTag: b28cf7b437a5fb8f805b19da1fd63df4c518113d
+    newTag: 6f4277e0ec31e2e272b68f64dc1f8bef257fd77b
   - name: reg.kyverno.io/kyverno/cleanup-controller
     newName: quay.io/konflux-ci/kyverno/kyverno-cleanup
-    newTag: b28cf7b437a5fb8f805b19da1fd63df4c518113d
+    newTag: 6f4277e0ec31e2e272b68f64dc1f8bef257fd77b
   - name: reg.kyverno.io/kyverno/kyverno-cli
     newName: quay.io/konflux-ci/kyverno/kyverno-cli
-    newTag: b28cf7b437a5fb8f805b19da1fd63df4c518113d
+    newTag: 6f4277e0ec31e2e272b68f64dc1f8bef257fd77b
 
 # set resources to jobs
 patches:

--- a/components/kyverno/production/kflux-prd-rh02/kustomization.yaml
+++ b/components/kyverno/production/kflux-prd-rh02/kustomization.yaml
@@ -9,19 +9,19 @@ generators:
 images:
   - name: reg.kyverno.io/kyverno/kyverno
     newName: quay.io/konflux-ci/kyverno/kyverno
-    newTag: b28cf7b437a5fb8f805b19da1fd63df4c518113d
+    newTag: 6f4277e0ec31e2e272b68f64dc1f8bef257fd77b
   - name: reg.kyverno.io/kyverno/kyvernopre
     newName: quay.io/konflux-ci/kyverno/kyverno-init
-    newTag: b28cf7b437a5fb8f805b19da1fd63df4c518113d
+    newTag: 6f4277e0ec31e2e272b68f64dc1f8bef257fd77b
   - name: reg.kyverno.io/kyverno/background-controller
     newName: quay.io/konflux-ci/kyverno/kyverno-background
-    newTag: b28cf7b437a5fb8f805b19da1fd63df4c518113d
+    newTag: 6f4277e0ec31e2e272b68f64dc1f8bef257fd77b
   - name: reg.kyverno.io/kyverno/cleanup-controller
     newName: quay.io/konflux-ci/kyverno/kyverno-cleanup
-    newTag: b28cf7b437a5fb8f805b19da1fd63df4c518113d
+    newTag: 6f4277e0ec31e2e272b68f64dc1f8bef257fd77b
   - name: reg.kyverno.io/kyverno/kyverno-cli
     newName: quay.io/konflux-ci/kyverno/kyverno-cli
-    newTag: b28cf7b437a5fb8f805b19da1fd63df4c518113d
+    newTag: 6f4277e0ec31e2e272b68f64dc1f8bef257fd77b
 
 # set resources to jobs
 patches:

--- a/components/kyverno/production/kflux-prd-rh03/kustomization.yaml
+++ b/components/kyverno/production/kflux-prd-rh03/kustomization.yaml
@@ -9,19 +9,19 @@ generators:
 images:
   - name: reg.kyverno.io/kyverno/kyverno
     newName: quay.io/konflux-ci/kyverno/kyverno
-    newTag: b28cf7b437a5fb8f805b19da1fd63df4c518113d
+    newTag: 6f4277e0ec31e2e272b68f64dc1f8bef257fd77b
   - name: reg.kyverno.io/kyverno/kyvernopre
     newName: quay.io/konflux-ci/kyverno/kyverno-init
-    newTag: b28cf7b437a5fb8f805b19da1fd63df4c518113d
+    newTag: 6f4277e0ec31e2e272b68f64dc1f8bef257fd77b
   - name: reg.kyverno.io/kyverno/background-controller
     newName: quay.io/konflux-ci/kyverno/kyverno-background
-    newTag: b28cf7b437a5fb8f805b19da1fd63df4c518113d
+    newTag: 6f4277e0ec31e2e272b68f64dc1f8bef257fd77b
   - name: reg.kyverno.io/kyverno/cleanup-controller
     newName: quay.io/konflux-ci/kyverno/kyverno-cleanup
-    newTag: b28cf7b437a5fb8f805b19da1fd63df4c518113d
+    newTag: 6f4277e0ec31e2e272b68f64dc1f8bef257fd77b
   - name: reg.kyverno.io/kyverno/kyverno-cli
     newName: quay.io/konflux-ci/kyverno/kyverno-cli
-    newTag: b28cf7b437a5fb8f805b19da1fd63df4c518113d
+    newTag: 6f4277e0ec31e2e272b68f64dc1f8bef257fd77b
 
 # set resources to jobs
 patches:

--- a/components/kyverno/production/kflux-rhel-p01/kustomization.yaml
+++ b/components/kyverno/production/kflux-rhel-p01/kustomization.yaml
@@ -9,19 +9,19 @@ generators:
 images:
   - name: reg.kyverno.io/kyverno/kyverno
     newName: quay.io/konflux-ci/kyverno/kyverno
-    newTag: b28cf7b437a5fb8f805b19da1fd63df4c518113d
+    newTag: 6f4277e0ec31e2e272b68f64dc1f8bef257fd77b
   - name: reg.kyverno.io/kyverno/kyvernopre
     newName: quay.io/konflux-ci/kyverno/kyverno-init
-    newTag: b28cf7b437a5fb8f805b19da1fd63df4c518113d
+    newTag: 6f4277e0ec31e2e272b68f64dc1f8bef257fd77b
   - name: reg.kyverno.io/kyverno/background-controller
     newName: quay.io/konflux-ci/kyverno/kyverno-background
-    newTag: b28cf7b437a5fb8f805b19da1fd63df4c518113d
+    newTag: 6f4277e0ec31e2e272b68f64dc1f8bef257fd77b
   - name: reg.kyverno.io/kyverno/cleanup-controller
     newName: quay.io/konflux-ci/kyverno/kyverno-cleanup
-    newTag: b28cf7b437a5fb8f805b19da1fd63df4c518113d
+    newTag: 6f4277e0ec31e2e272b68f64dc1f8bef257fd77b
   - name: reg.kyverno.io/kyverno/kyverno-cli
     newName: quay.io/konflux-ci/kyverno/kyverno-cli
-    newTag: b28cf7b437a5fb8f805b19da1fd63df4c518113d
+    newTag: 6f4277e0ec31e2e272b68f64dc1f8bef257fd77b
 
 # set resources to jobs
 patches:

--- a/components/kyverno/production/stone-prod-p02/kustomization.yaml
+++ b/components/kyverno/production/stone-prod-p02/kustomization.yaml
@@ -9,19 +9,19 @@ generators:
 images:
   - name: reg.kyverno.io/kyverno/kyverno
     newName: quay.io/konflux-ci/kyverno/kyverno
-    newTag: b28cf7b437a5fb8f805b19da1fd63df4c518113d
+    newTag: 6f4277e0ec31e2e272b68f64dc1f8bef257fd77b
   - name: reg.kyverno.io/kyverno/kyvernopre
     newName: quay.io/konflux-ci/kyverno/kyverno-init
-    newTag: b28cf7b437a5fb8f805b19da1fd63df4c518113d
+    newTag: 6f4277e0ec31e2e272b68f64dc1f8bef257fd77b
   - name: reg.kyverno.io/kyverno/background-controller
     newName: quay.io/konflux-ci/kyverno/kyverno-background
-    newTag: b28cf7b437a5fb8f805b19da1fd63df4c518113d
+    newTag: 6f4277e0ec31e2e272b68f64dc1f8bef257fd77b
   - name: reg.kyverno.io/kyverno/cleanup-controller
     newName: quay.io/konflux-ci/kyverno/kyverno-cleanup
-    newTag: b28cf7b437a5fb8f805b19da1fd63df4c518113d
+    newTag: 6f4277e0ec31e2e272b68f64dc1f8bef257fd77b
   - name: reg.kyverno.io/kyverno/kyverno-cli
     newName: quay.io/konflux-ci/kyverno/kyverno-cli
-    newTag: b28cf7b437a5fb8f805b19da1fd63df4c518113d
+    newTag: 6f4277e0ec31e2e272b68f64dc1f8bef257fd77b
 
 patches:
   - path: job_resources.yaml

--- a/hack/new-cluster/templates/kyverno/kustomization.yaml
+++ b/hack/new-cluster/templates/kyverno/kustomization.yaml
@@ -9,19 +9,19 @@ generators:
 images:
   - name: reg.kyverno.io/kyverno/kyverno
     newName: quay.io/konflux-ci/kyverno/kyverno
-    newTag: b28cf7b437a5fb8f805b19da1fd63df4c518113d
+    newTag: 6f4277e0ec31e2e272b68f64dc1f8bef257fd77b
   - name: reg.kyverno.io/kyverno/kyvernopre
     newName: quay.io/konflux-ci/kyverno/kyverno-init
-    newTag: b28cf7b437a5fb8f805b19da1fd63df4c518113d
+    newTag: 6f4277e0ec31e2e272b68f64dc1f8bef257fd77b
   - name: reg.kyverno.io/kyverno/background-controller
     newName: quay.io/konflux-ci/kyverno/kyverno-background
-    newTag: b28cf7b437a5fb8f805b19da1fd63df4c518113d
+    newTag: 6f4277e0ec31e2e272b68f64dc1f8bef257fd77b
   - name: reg.kyverno.io/kyverno/cleanup-controller
     newName: quay.io/konflux-ci/kyverno/kyverno-cleanup
-    newTag: b28cf7b437a5fb8f805b19da1fd63df4c518113d
+    newTag: 6f4277e0ec31e2e272b68f64dc1f8bef257fd77b
   - name: reg.kyverno.io/kyverno/kyverno-cli
     newName: quay.io/konflux-ci/kyverno/kyverno-cli
-    newTag: b28cf7b437a5fb8f805b19da1fd63df4c518113d
+    newTag: 6f4277e0ec31e2e272b68f64dc1f8bef257fd77b
 
 # set resources to jobs
 patches:


### PR DESCRIPTION
## What

Update kyverno images on the remaining 7 production clusters (ring 2) and the new-cluster template, from `b28cf7b` to `6f4277e0ec31e2e272b68f64dc1f8bef257fd77b`:
- `kflux-fedora-01`
- `kflux-ocp-p01`
- `kflux-osp-p01`
- `kflux-prd-rh02`
- `kflux-prd-rh03`
- `kflux-rhel-p01`
- `stone-prod-p02`

All 5 kyverno images are updated: kyverno, kyverno-init, kyverno-background, kyverno-cleanup, kyverno-cli.

Jira: [KONFLUX-12774](https://redhat.atlassian.net/browse/KONFLUX-12774)

## Why

The new image includes gRPC-Go v1.79.3 which fixes a CVE. Ring 1 (`stone-prd-rh01`, `stone-prod-p01`) was deployed and verified successfully. This completes the rollout to all remaining production clusters.

## Validation

### Ring 1 deployment verification on `stone-prd-rh01`

Verified the ring 1 deployment is running successfully with the new images on `stone-prd-rh01`.

**Step 1: Identify deployed images**

```bash
$ oc get deployments -n konflux-kyverno -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.spec.template.spec.containers[0].image}{"\n"}{end}'
kyverno-admission-controller	quay.io/konflux-ci/kyverno/kyverno:6f4277e0ec31e2e272b68f64dc1f8bef257fd77b
kyverno-background-controller	quay.io/konflux-ci/kyverno/kyverno-background:6f4277e0ec31e2e272b68f64dc1f8bef257fd77b
kyverno-cleanup-controller	quay.io/konflux-ci/kyverno/kyverno-cleanup:6f4277e0ec31e2e272b68f64dc1f8bef257fd77b
```

### gRPC-Go version verification (from ring 1)

```bash
$ go version -m /tmp/kyverno-binary | grep 'google.golang.org/grpc\b'
      dep     google.golang.org/grpc  v1.79.3 h1:sybAEdRIEtvcD68Gx7dmnwjZKlyfuc61Dyo9pGXXkKE=

$ go version -m /tmp/kyverno-background-binary | grep 'google.golang.org/grpc\b'
      dep     google.golang.org/grpc  v1.79.3 h1:sybAEdRIEtvcD68Gx7dmnwjZKlyfuc61Dyo9pGXXkKE=

$ go version -m /tmp/kyverno-cleanup-binary | grep 'google.golang.org/grpc\b'
      dep     google.golang.org/grpc  v1.79.3 h1:sybAEdRIEtvcD68Gx7dmnwjZKlyfuc61Dyo9pGXXkKE=
```

**Result:** All 3 deployed components on `stone-prd-rh01` are running `google.golang.org/grpc` v1.79.3 (>= v1.79.3 required). CVE is fixed. Ring 1 is stable — proceeding with ring 2.

## Risk Assessment

**Risk Level:** Low

Ring 1 has been deployed and verified on `stone-prd-rh01` and `stone-prod-p01`. The same images are being rolled out to the remaining clusters. The update only bumps dependency versions (gRPC-Go CVE fix) with no functional changes.


[KONFLUX-12774]: https://redhat.atlassian.net/browse/KONFLUX-12774?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ