### PR TITLE
PVO11Y-5159 Drop high cardinality metric and label

### DIFF
--- a/components/monitoring/prometheus/base/tekton-ms/servicemonitor.yaml
+++ b/components/monitoring/prometheus/base/tekton-ms/servicemonitor.yaml
@@ -16,3 +16,7 @@ spec:
   endpoints:
   - port: http-metrics
     interval: 15s
+    metricRelabelings:
+    - sourceLabels: [__name__]
+      regex: tekton_pipelines_controller_taskruns_pod_latency_milliseconds
+      action: drop

--- a/components/monitoring/prometheus/staging/base/kustomization.yaml
+++ b/components/monitoring/prometheus/staging/base/kustomization.yaml
@@ -7,7 +7,6 @@ resources:
 - ../../base/rbac
 - ../../base/custom-modifications
 - monitoringstack/
-- ../../base/tekton-ms
 
 patches:
   - path: rhobs-secret-path.yaml

--- a/components/monitoring/prometheus/staging/stone-stage-p01/kustomization.yaml
+++ b/components/monitoring/prometheus/staging/stone-stage-p01/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - ../base
+- ../../base/tekton-ms
 
 patches:
   - path: cluster-id-label.yaml

--- a/components/monitoring/prometheus/staging/stone-stg-rh01/kustomization.yaml
+++ b/components/monitoring/prometheus/staging/stone-stg-rh01/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - ../base
+- ../../base/tekton-ms
 
 patches:
   - path: cluster-id-label.yaml


### PR DESCRIPTION
This metric is known to have high cardinality due to the pod label. It is also not useful, so it will be dropped entirely.

Assisted-by: Cursor