### PR TITLE
fix(SPRE-5072): Rollback etcd defrag to use lower diff threshold in p02

### DIFF
--- a/configs/etcd-defrag/production/stone-prod-p02/base/cluster-role.yaml
+++ b/configs/etcd-defrag/production/stone-prod-p02/base/cluster-role.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: etcd-maintenance-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - list
+  - get
+  - create
+  - delete
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods/attach
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get

--- a/configs/etcd-defrag/production/stone-prod-p02/base/cronjob.yaml
+++ b/configs/etcd-defrag/production/stone-prod-p02/base/cronjob.yaml
@@ -1,0 +1,40 @@
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: etcd-maintenance
+  namespace: etcd-maintenance
+spec:
+  schedule: "*/5 * * * *"
+  successfulJobsHistoryLimit: 50
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          serviceAccountName: etcd-maintenance
+          restartPolicy: OnFailure
+          containers:
+            - name: etcd-maintenance
+              image: registry.redhat.io/openshift4/ose-cli
+              imagePullPolicy: IfNotPresent
+              env:
+              - name: IMAGE
+                value: quay.io/konflux-ci/etcd-defrag@sha256:7539e569f085540b65759f70fe07f399c9d06511349087f8ae559be3ccd484dc
+              - name: FRAGMENTATION_THRESHOLD
+                value: "30"
+              - name: DISK_USAGE_THRESHOLD
+                value: "75" # threshold of etcd-shield is 80% so we only defrag if we get close to that
+              - name: RECLAIM_SPACE_THRESHOLD
+                value: "1024"
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  etcd_pod=$(oc get pod -l app=etcd -oname -n openshift-etcd | awk -F"/" 'NR==1{ print $2 }')
+                  oc -n openshift-etcd debug pod/${etcd_pod} \
+                    fragmentationThreshold="${FRAGMENTATION_THRESHOLD}"\
+                    diskUsageThreshold="${DISK_USAGE_THRESHOLD}" \
+                    reclaimSpaceThreshold="${RECLAIM_SPACE_THRESHOLD}" \
+                    --image="${IMAGE}" \
+                    --one-container=true \
+                    -- /bin/sh -c "chmod +x /opt/defrag.sh && /opt/defrag.sh"

--- a/configs/etcd-defrag/production/stone-prod-p02/base/kustomization.yaml
+++ b/configs/etcd-defrag/production/stone-prod-p02/base/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - cluster-role.yaml
+  - role-binding.yaml
+  - serviceaccount.yaml
+  - cronjob.yaml

--- a/configs/etcd-defrag/production/stone-prod-p02/base/namespace.yaml
+++ b/configs/etcd-defrag/production/stone-prod-p02/base/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: etcd-maintenance

--- a/configs/etcd-defrag/production/stone-prod-p02/base/role-binding.yaml
+++ b/configs/etcd-defrag/production/stone-prod-p02/base/role-binding.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: etcd-maintenance-binding
+  namespace: etcd-maintenance
+subjects:
+- kind: ServiceAccount
+  name: etcd-maintenance
+  namespace: etcd-maintenance
+roleRef:
+  kind: ClusterRole
+  name: etcd-maintenance-role
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: etcd-maintenance-binding
+  namespace: openshift-etcd
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: etcd-maintenance-role
+subjects:
+- kind: ServiceAccount
+  name: etcd-maintenance
+  namespace: etcd-maintenance

--- a/configs/etcd-defrag/production/stone-prod-p02/base/serviceaccount.yaml
+++ b/configs/etcd-defrag/production/stone-prod-p02/base/serviceaccount.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: etcd-maintenance
+  namespace: etcd-maintenance

--- a/configs/etcd-defrag/production/stone-prod-p02/kustomization.yaml
+++ b/configs/etcd-defrag/production/stone-prod-p02/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- ../base
+- base


### PR DESCRIPTION
What
- Rollback change to use lower threshold in p02 cluster.
- Change based on [rh01 PR](https://github.com/redhat-appstudio/infra-deployments/pull/11207/changes)  

Why

Avoid p02 etcd full storage due to high usage of cluster.

Validation
Comparison with fix applied in rh01 (similar scenario)

Risk Assessment
Risk Level: Medium
Rollback: Revert PR (use base etcd defrag script config)