### PR TITLE
Deploy latest crossplane-control-plane updates to dev and staging

### DIFF
--- a/components/crossplane-control-plane/development/kustomization.yaml
+++ b/components/crossplane-control-plane/development/kustomization.yaml
@@ -1,8 +1,8 @@
 resources:
 - ../base
-- https://github.com/konflux-ci/crossplane-control-plane/crossplane?ref=21e0a14dd119966e396cfcab18b5085552da9304
-- https://github.com/konflux-ci/crossplane-control-plane/config?ref=21e0a14dd119966e396cfcab18b5085552da9304
-- https://github.com/konflux-ci/crossplane-control-plane/examples/provider-kubernetes-in-cluster?ref=21e0a14dd119966e396cfcab18b5085552da9304
+- https://github.com/konflux-ci/crossplane-control-plane/crossplane?ref=1563d850a1331ed68796ddc7e3849de5ee011579
+- https://github.com/konflux-ci/crossplane-control-plane/config?ref=1563d850a1331ed68796ddc7e3849de5ee011579
+- https://github.com/konflux-ci/crossplane-control-plane/examples/provider-kubernetes-in-cluster?ref=1563d850a1331ed68796ddc7e3849de5ee011579
 
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/components/crossplane-control-plane/staging/kustomization.yaml
+++ b/components/crossplane-control-plane/staging/kustomization.yaml
@@ -5,8 +5,8 @@ resources:
 - ../base
 - provider-config.yaml
 - testplatform-provider-config.yaml
-- https://github.com/konflux-ci/crossplane-control-plane/crossplane?ref=21e0a14dd119966e396cfcab18b5085552da9304
-- https://github.com/konflux-ci/crossplane-control-plane/config?ref=21e0a14dd119966e396cfcab18b5085552da9304
+- https://github.com/konflux-ci/crossplane-control-plane/crossplane?ref=1563d850a1331ed68796ddc7e3849de5ee011579
+- https://github.com/konflux-ci/crossplane-control-plane/config?ref=1563d850a1331ed68796ddc7e3849de5ee011579
 
 patches:
   - patch: |-


### PR DESCRIPTION
Promote crossplane-control-plane from 21e0a14 to 1563d85 in development and staging environments to pick up the latest merged changes from konflux-ci/crossplane-control-plane.

Assisted-by: Claude claude-opus-4-6