### PR TITLE
chore(PVO11Y-5178): update kanary exporter ref in stone-stage-p01

### DIFF
--- a/components/monitoring/kanary/staging/stone-stage-p01/kustomization.yaml
+++ b/components/monitoring/kanary/staging/stone-stage-p01/kustomization.yaml
@@ -2,7 +2,7 @@ resources:
   - ../base
   - external-secrets
   - cronjobs
-  - https://github.com/redhat-appstudio/o11y/config/exporters/monitoring/kanary/base?ref=52d8abfebdbe01bee10a9ee36ba88cc95bbb095d
+  - https://github.com/redhat-appstudio/o11y/config/exporters/monitoring/kanary/base?ref=1dc5cfb1178223522e5cf1fd1d629fa9c0ea2fdd
 
 images:
   - name: quay.io/redhat-appstudio/o11y


### PR DESCRIPTION
Point to the o11y commit that switches Horreum filtering from .repo_type to .parameters.options.ComponentRepoUrl.

Related PR: https://github.com/redhat-appstudio/o11y/pull/1076

Issue: [PVO11Y-5178](https://redhat.atlassian.net/browse/PVO11Y-5178)

[PVO11Y-5178]: https://redhat.atlassian.net/browse/PVO11Y-5178?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ