### PR TITLE
fix: configure ServiceMonitor CA for artifact-registry-proxy exporter TLS

### DIFF
--- a/components/squid/development/squid-helm-generator.yaml
+++ b/components/squid/development/squid-helm-generator.yaml
@@ -4,7 +4,7 @@ metadata:
   name: squid-helm
 name: squid-helm
 repo: oci://quay.io/konflux-ci/caching
-version: 0.1.1400+4a52f5d
+version: 0.1.1409+5a80313
 valuesInline:
   installCertManagerComponents: false
   mirrord:
@@ -68,6 +68,12 @@ valuesInline:
       - ^https://[a-z0-9]+\.cloudfront\.net/sha256/[a-f0-9]{2}/[a-f0-9]{64}
     size: 192
     maxObjectSize: 128
+  prometheus:
+    serviceMonitor:
+      nginxTLS:
+        ca:
+          configMapName: openshift-service-ca.crt
+          key: service-ca.crt
   tlsOutgoingOptions:
     caFile: /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
   volumes:

--- a/components/squid/staging/squid-helm-generator.yaml
+++ b/components/squid/staging/squid-helm-generator.yaml
@@ -4,7 +4,7 @@ metadata:
   name: squid-helm
 name: squid-helm
 repo: oci://quay.io/konflux-ci/caching
-version: 0.1.1400+4a52f5d
+version: 0.1.1409+5a80313
 valuesInline:
   installCertManagerComponents: false
   mirrord:
@@ -80,6 +80,12 @@ valuesInline:
       - ^https://[a-z0-9]+\.cloudfront\.net/sha256/[a-f0-9]{2}/[a-f0-9]{64}
     size: 51200
     maxObjectSize: 1024
+  prometheus:
+    serviceMonitor:
+      nginxTLS:
+        ca:
+          configMapName: openshift-service-ca.crt
+          key: service-ca.crt
   tlsOutgoingOptions:
     caFile: /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
   volumes:


### PR DESCRIPTION
The artifact-registry-proxy access-log-exporter now uses the same TLS certificate as the nginx container. Configure the ServiceMonitor to verify the exporter's certificate against the OpenShift service serving CA ConfigMap.

Also bump the caching helm chart version to 0.1.1409+5a80313 which includes the access-log-exporter TLS support.

Assisted-by: Claude Opus 4.6