### PR TITLE
reduce the number of concurrent PLRs on ocp-p01

### DIFF
--- a/components/kueue/production/kflux-ocp-p01/queue-config/cluster-queue.yaml
+++ b/components/kueue/production/kflux-ocp-p01/queue-config/cluster-queue.yaml
@@ -24,7 +24,7 @@ spec:
     - name: default-flavor
       resources:
       - name: tekton.dev/pipelineruns
-        nominalQuota: '300'
+        nominalQuota: '250'
       - name: cpu
         nominalQuota: 1k
       - name: memory


### PR DESCRIPTION
We noticed some performance issue with etcd in this cluster recently.
This change temporarily reduces the maximum number of concurrent PLRs to `250`.

Signed-off-by: Francesco Ilario <filario@redhat.com>
