### PR TITLE
feat(SPRE-5084): Update IBM probes for kflux-ocp-p01

### DIFF
--- a/components/monitoring/blackbox/production/kflux-ocp-p01/kustomization.yaml
+++ b/components/monitoring/blackbox/production/kflux-ocp-p01/kustomization.yaml
@@ -1,6 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
- - https://github.com/redhat-appstudio/internal-infra-deployments/components/monitoring/blackbox-exporter/production/private/kflux-ocp-p01?ref=5e48bb6dca3eb756f5de24fe2664e14dbf55388f
+ - https://github.com/redhat-appstudio/internal-infra-deployments/components/monitoring/blackbox-exporter/production/private/kflux-ocp-p01?ref=b95d219fbbcad59b5509d9d450e708e05d7a6a0e
 
 namespace: appstudio-monitoring


### PR DESCRIPTION
## What
Update reference to updated probes for IBM cloud in `kflux-ocp-p01`  
Relevant ticket: https://redhat.atlassian.net/browse/SPRE-5084  

## Why
Existing ppc64le instances were replaced as part of [KFLUXINFRA-3328](https://github.com/redhat-appstudio/infra-deployments/pull/11195)  

## Validation
`kustomize build` works both from internal-infra-deployments and when using a local path for this updated reference.  
No equivalent staging cluster/env to test.  

## Risk Assessment
**Risk Level:** Low
**Rollback:** Revert PR

[KFLUXINFRA-3328]: https://redhat.atlassian.net/browse/KFLUXINFRA-3328?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ