### PR TITLE
Fix helm chart 404 and applicationset delete permission in dev and staging for caas operator

### DIFF
--- a/components/cluster-as-a-service/development/add-hypershift-params.yaml
+++ b/components/cluster-as-a-service/development/add-hypershift-params.yaml
@@ -18,5 +18,9 @@
     value: ""
 
 - op: replace
+  path: /spec/template/spec/source/repoURL
+  value: https://konflux-ci.dev/cluster-template-charts
+
+- op: replace
   path: /spec/template/spec/source/targetRevision
   value: 0.1.9

--- a/components/cluster-as-a-service/development/cluster-aas-operator-rbac.yaml
+++ b/components/cluster-as-a-service/development/cluster-aas-operator-rbac.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cluster-aas-operator-applicationset-manager
+  namespace: cluster-aas-operator
+rules:
+- apiGroups:
+  - argoproj.io
+  resources:
+  - applicationsets
+  verbs:
+  - delete
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cluster-aas-operator-applicationset-manager
+  namespace: cluster-aas-operator
+subjects:
+- kind: ServiceAccount
+  name: cluster-aas-operator-controller-manager
+  namespace: openshift-operators
+roleRef:
+  kind: Role
+  name: cluster-aas-operator-applicationset-manager
+  apiGroup: rbac.authorization.k8s.io

--- a/components/cluster-as-a-service/development/kustomization.yaml
+++ b/components/cluster-as-a-service/development/kustomization.yaml
@@ -3,6 +3,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../base
+  - cluster-aas-operator-rbac.yaml
   - klusterlet-config.yaml
 patches:
   - path: add-hypershift-params.yaml

--- a/components/cluster-as-a-service/staging/add-hypershift-params.yaml
+++ b/components/cluster-as-a-service/staging/add-hypershift-params.yaml
@@ -18,5 +18,9 @@
     value: arn:aws:iam::767397671005:role/eaas-hypershift-cli-role
 
 - op: replace
+  path: /spec/template/spec/source/repoURL
+  value: https://konflux-ci.dev/cluster-template-charts
+
+- op: replace
   path: /spec/template/spec/source/targetRevision
   value: 0.1.9

--- a/components/cluster-as-a-service/staging/cluster-aas-operator-rbac.yaml
+++ b/components/cluster-as-a-service/staging/cluster-aas-operator-rbac.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cluster-aas-operator-applicationset-manager
+  namespace: cluster-aas-operator
+rules:
+- apiGroups:
+  - argoproj.io
+  resources:
+  - applicationsets
+  verbs:
+  - delete
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cluster-aas-operator-applicationset-manager
+  namespace: cluster-aas-operator
+subjects:
+- kind: ServiceAccount
+  name: cluster-aas-operator-controller-manager
+  namespace: openshift-operators
+roleRef:
+  kind: Role
+  name: cluster-aas-operator-applicationset-manager
+  apiGroup: rbac.authorization.k8s.io

--- a/components/cluster-as-a-service/staging/kustomization.yaml
+++ b/components/cluster-as-a-service/staging/kustomization.yaml
@@ -4,6 +4,7 @@ kind: Kustomization
 resources:
   - ../base
   - ../../openshift-gitops
+  - cluster-aas-operator-rbac.yaml
   - external-secrets.yaml
 patches:
   - path: add-hypershift-params.yaml


### PR DESCRIPTION
## Summary
- Remove trailing slash from the `repoURL` for the `hypershift-aws-template` helm chart. The trailing slash caused a double-slash in the index.yaml request path, resulting in 404  errors that contribute to crash-looping the `cluster-aas-operator-controller-manager` pod.
- Grant the `cluster-aas-operator-controller-manager` service account permission to delete `applicationsets` in the `cluster-aas-operator`. The missing permission caused repeated reconciler errors.

Both fixes are scoped to development and staging only.

## Verification
- Deployed the staging overlay to a local CRC cluster and confirmed:
- The `ApplicationSet` was created with the correct `repoURL` (no trailing slash)
- The RBAC `Role` and `RoleBinding` were created and `oc auth can-i` confirmed the service account can delete applicationsets
- The operator logs showed no `forbidden` or `ERROR` messages

[KONFLUX-12098](https://redhat.atlassian.net/browse/KONFLUX-12098)

[KONFLUX-12098]: https://redhat.atlassian.net/browse/KONFLUX-12098?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ