### PR TITLE
Fix ServiceMonitor CA for artifact-registry-proxy exporter TLS (production)

### DIFF
--- a/components/squid/production/squid-helm-generator.yaml
+++ b/components/squid/production/squid-helm-generator.yaml
@@ -4,7 +4,7 @@ metadata:
   name: squid-helm
 name: squid-helm
 repo: oci://quay.io/konflux-ci/caching
-version: 0.1.1400+4a52f5d
+version: 0.1.1409+5a80313
 valuesInline:
   installCertManagerComponents: false
   mirrord:
@@ -80,6 +80,12 @@ valuesInline:
       - ^https://[a-z0-9]+\.cloudfront\.net/sha256/[a-f0-9]{2}/[a-f0-9]{64}
     size: 51200
     maxObjectSize: 1024
+  prometheus:
+    serviceMonitor:
+      nginxTLS:
+        ca:
+          configMapName: openshift-service-ca.crt
+          key: service-ca.crt
   tlsOutgoingOptions:
     caFile: /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
   volumes:


### PR DESCRIPTION
## What / Why

The artifact-registry-proxy access-log-exporter now serves metrics over TLS using the same serving certificate as the nginx container.

This PR promotes the changes from #11283 to production:
- Bumps the caching helm chart to `0.1.1409+5a80313` (includes fixes for access-log-exporter TLS support)
- Configures the ServiceMonitor to verify the exporter's TLS certificate against
  the `openshift-service-ca.crt` ConfigMap

## Validation

- Staging PR: #11283 (merged and deployed)
- All 3 `artifact-registry-proxy` ServiceMonitor targets confirmed **up** on
  `stone-stg-rh01` via Prometheus federate endpoint
  (`up{job="artifact-registry-proxy", namespace="caching"} = 1`)

## Risk Assessment

**Low** — It's a relatively new service with no active users yet.