### PR TITLE
KONFLUX-11582 ingester pods oomkilled prod fix

### DIFF
--- a/components/vector-kubearchive-log-collector/production/base/kustomization.yaml
+++ b/components/vector-kubearchive-log-collector/production/base/kustomization.yaml
@@ -31,3 +31,15 @@ patches:
       version: v1
       kind: PodDisruptionBudget
       labelSelector: app.kubernetes.io/name=loki
+  - patch: |-
+      - op: add
+        path: /spec/persistentVolumeClaimRetentionPolicy
+        value:
+          whenDeleted: Delete
+          whenScaled: Delete
+    target:
+      group: apps
+      version: v1
+      kind: StatefulSet
+      namespace: product-kubearchive-logging
+      labelSelector: app.kubernetes.io/name=loki,app.kubernetes.io/component=ingester

--- a/components/vector-kubearchive-log-collector/production/kflux-fedora-01/loki-helm-prod-values.yaml
+++ b/components/vector-kubearchive-log-collector/production/kflux-fedora-01/loki-helm-prod-values.yaml
@@ -75,11 +75,20 @@ loki:
   ingester:
     autoforget_unhealthy: true
     chunk_target_size: 8388608        # 8MB
-    chunk_idle_period: 5m
+    chunk_idle_period: 1h
     max_chunk_age: 2h
     chunk_encoding: snappy            # Compress data (reduces S3 transfer size)
     chunk_retain_period: 1h           # Keep chunks in memory after flush
     flush_op_timeout: 10m             # Add timeout for S3 operations
+    lifecycler:
+      ring:
+        heartbeat_timeout: 10m
+    wal:
+      enabled: true
+      dir: /var/loki/wal
+      checkpoint_duration: 5m
+      flush_on_shutdown: true
+      replay_memory_ceiling: 2GB
   server:
     grpc_server_max_recv_msg_size: 15728640  # 15MB
     grpc_server_max_send_msg_size: 15728640

--- a/components/vector-kubearchive-log-collector/production/kflux-ocp-p01/loki-helm-prod-values.yaml
+++ b/components/vector-kubearchive-log-collector/production/kflux-ocp-p01/loki-helm-prod-values.yaml
@@ -88,7 +88,7 @@ loki:
       dir: /var/loki/wal
       checkpoint_duration: 5m          # Create checkpoints every 5 minutes
       flush_on_shutdown: true          # Ensure data is flushed before shutdown
-      replay_memory_ceiling: 4GB       # 75% of 6Gi limit - PREVENTS OOM during replay
+      replay_memory_ceiling: 2GB       # 75% of 6Gi limit - PREVENTS OOM during replay
   server:
     grpc_server_max_recv_msg_size: 15728640  # 15MB
     grpc_server_max_send_msg_size: 15728640

--- a/components/vector-kubearchive-log-collector/production/kflux-osp-p01/loki-helm-prod-values.yaml
+++ b/components/vector-kubearchive-log-collector/production/kflux-osp-p01/loki-helm-prod-values.yaml
@@ -75,11 +75,20 @@ loki:
   ingester:
     autoforget_unhealthy: true
     chunk_target_size: 8388608        # 8MB
-    chunk_idle_period: 5m
+    chunk_idle_period: 1h
     max_chunk_age: 2h
     chunk_encoding: snappy            # Compress data (reduces S3 transfer size)
     chunk_retain_period: 1h           # Keep chunks in memory after flush
     flush_op_timeout: 10m             # Add timeout for S3 operations
+    lifecycler:
+      ring:
+        heartbeat_timeout: 10m
+    wal:
+      enabled: true
+      dir: /var/loki/wal
+      checkpoint_duration: 5m
+      flush_on_shutdown: true
+      replay_memory_ceiling: 2GB
   server:
     grpc_server_max_recv_msg_size: 15728640  # 15MB
     grpc_server_max_send_msg_size: 15728640

--- a/components/vector-kubearchive-log-collector/production/kflux-prd-rh02/loki-helm-prod-values.yaml
+++ b/components/vector-kubearchive-log-collector/production/kflux-prd-rh02/loki-helm-prod-values.yaml
@@ -75,11 +75,20 @@ loki:
   ingester:
     autoforget_unhealthy: true
     chunk_target_size: 8388608        # 8MB
-    chunk_idle_period: 5m
+    chunk_idle_period: 1h
     max_chunk_age: 2h
     chunk_encoding: snappy            # Compress data (reduces S3 transfer size)
     chunk_retain_period: 1h           # Keep chunks in memory after flush
     flush_op_timeout: 10m             # Add timeout for S3 operations
+    lifecycler:
+      ring:
+        heartbeat_timeout: 10m
+    wal:
+      enabled: true
+      dir: /var/loki/wal
+      checkpoint_duration: 5m
+      flush_on_shutdown: true
+      replay_memory_ceiling: 2GB
   server:
     grpc_server_max_recv_msg_size: 15728640  # 15MB
     grpc_server_max_send_msg_size: 15728640

--- a/components/vector-kubearchive-log-collector/production/kflux-prd-rh03/loki-helm-prod-values.yaml
+++ b/components/vector-kubearchive-log-collector/production/kflux-prd-rh03/loki-helm-prod-values.yaml
@@ -75,11 +75,20 @@ loki:
   ingester:
     autoforget_unhealthy: true
     chunk_target_size: 8388608        # 8MB
-    chunk_idle_period: 5m
+    chunk_idle_period: 1h
     max_chunk_age: 2h
     chunk_encoding: snappy            # Compress data (reduces S3 transfer size)
     chunk_retain_period: 1h           # Keep chunks in memory after flush
     flush_op_timeout: 10m             # Add timeout for S3 operations
+    lifecycler:
+      ring:
+        heartbeat_timeout: 10m
+    wal:
+      enabled: true
+      dir: /var/loki/wal
+      checkpoint_duration: 5m
+      flush_on_shutdown: true
+      replay_memory_ceiling: 2GB
   server:
     grpc_server_max_recv_msg_size: 15728640  # 15MB
     grpc_server_max_send_msg_size: 15728640

--- a/components/vector-kubearchive-log-collector/production/kflux-rhel-p01/loki-helm-prod-values.yaml
+++ b/components/vector-kubearchive-log-collector/production/kflux-rhel-p01/loki-helm-prod-values.yaml
@@ -75,11 +75,20 @@ loki:
   ingester:
     autoforget_unhealthy: true
     chunk_target_size: 8388608        # 8MB
-    chunk_idle_period: 5m
+    chunk_idle_period: 1h
     max_chunk_age: 2h
     chunk_encoding: snappy            # Compress data (reduces S3 transfer size)
     chunk_retain_period: 1h           # Keep chunks in memory after flush
     flush_op_timeout: 10m             # Add timeout for S3 operations
+    lifecycler:
+      ring:
+        heartbeat_timeout: 10m
+    wal:
+      enabled: true
+      dir: /var/loki/wal
+      checkpoint_duration: 5m
+      flush_on_shutdown: true
+      replay_memory_ceiling: 2GB
   server:
     grpc_server_max_recv_msg_size: 15728640  # 15MB
     grpc_server_max_send_msg_size: 15728640

--- a/components/vector-kubearchive-log-collector/production/stone-prd-rh01/loki-helm-prod-values.yaml
+++ b/components/vector-kubearchive-log-collector/production/stone-prd-rh01/loki-helm-prod-values.yaml
@@ -88,7 +88,7 @@ loki:
       dir: /var/loki/wal
       checkpoint_duration: 5m
       flush_on_shutdown: true
-      replay_memory_ceiling: 4GB
+      replay_memory_ceiling: 2GB
   server:
     grpc_server_max_recv_msg_size: 15728640  # 15MB
     grpc_server_max_send_msg_size: 15728640

--- a/components/vector-kubearchive-log-collector/production/stone-prod-p01/loki-helm-prod-values.yaml
+++ b/components/vector-kubearchive-log-collector/production/stone-prod-p01/loki-helm-prod-values.yaml
@@ -80,6 +80,15 @@ loki:
     chunk_encoding: snappy            # Compress data (reduces S3 transfer size)
     chunk_retain_period: 1h           # Keep chunks in memory after flush
     flush_op_timeout: 10m             # Add timeout for S3 operations
+    lifecycler:
+      ring:
+        heartbeat_timeout: 10m
+    wal:
+      enabled: true
+      dir: /var/loki/wal
+      checkpoint_duration: 5m
+      flush_on_shutdown: true
+      replay_memory_ceiling: 2GB
   server:
     grpc_server_max_recv_msg_size: 15728640  # 15MB
     grpc_server_max_send_msg_size: 15728640

--- a/components/vector-kubearchive-log-collector/production/stone-prod-p02/loki-helm-prod-values.yaml
+++ b/components/vector-kubearchive-log-collector/production/stone-prod-p02/loki-helm-prod-values.yaml
@@ -88,7 +88,7 @@ loki:
       dir: /var/loki/wal
       checkpoint_duration: 5m
       flush_on_shutdown: true
-      replay_memory_ceiling: 4GB
+      replay_memory_ceiling: 2GB
   server:
     grpc_server_max_recv_msg_size: 15728640  # 15MB
     grpc_server_max_send_msg_size: 15728640

--- a/components/vector-kubearchive-log-collector/staging/base/kustomization.yaml
+++ b/components/vector-kubearchive-log-collector/staging/base/kustomization.yaml
@@ -33,5 +33,3 @@ patches:
       kind: StatefulSet
       namespace: product-kubearchive-logging
       labelSelector: app.kubernetes.io/name=loki,app.kubernetes.io/component=ingester
-
-

--- a/components/vector-kubearchive-log-collector/staging/base/kustomization.yaml
+++ b/components/vector-kubearchive-log-collector/staging/base/kustomization.yaml
@@ -34,3 +34,4 @@ patches:
       namespace: product-kubearchive-logging
       labelSelector: app.kubernetes.io/name=loki,app.kubernetes.io/component=ingester
 
+

--- a/components/vector-kubearchive-log-collector/staging/base/kustomization.yaml
+++ b/components/vector-kubearchive-log-collector/staging/base/kustomization.yaml
@@ -33,3 +33,4 @@ patches:
       kind: StatefulSet
       namespace: product-kubearchive-logging
       labelSelector: app.kubernetes.io/name=loki,app.kubernetes.io/component=ingester
+


### PR DESCRIPTION
Issue: [KONFLUX-11582](https://redhat.atlassian.net/browse/KONFLUX-11582)
What:
WAL policy settings for Loki ingesters are introduced as a fix for OOMkilled errors:
 - persistentVolumeClaimRetentionPolicy - both whenDeleted and whenScaled set to Delete
 - chunk_idle_period is set to 1h(should not be less then chunk_retain_period)
 - replay_memory_ceiling is reduced from 4GB to 2GB 

Why:
To prevent Loki Ingester pods from failing which looks like OOM when WAL PVs got full.

Testing info:
The settings are tested on dev and staging clusters, introduced by this PR: https://github.com/redhat-appstudio/infra-deployments/pull/11230

[KONFLUX-11582]: https://redhat.atlassian.net/browse/KONFLUX-11582?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Staging PR: https://github.com/redhat-appstudio/infra-deployments/pull/11230