### PR TITLE
chore(PVO11Y-5178): update kanary exporter ref in stone-stage-p01

### DIFF
--- a/components/monitoring/kanary/staging/stone-stage-p01/kustomization.yaml
+++ b/components/monitoring/kanary/staging/stone-stage-p01/kustomization.yaml
@@ -7,7 +7,7 @@ resources:
 images:
   - name: quay.io/redhat-appstudio/o11y
     newName: quay.io/redhat-appstudio/o11y
-    newTag: 52d8abfebdbe01bee10a9ee36ba88cc95bbb095d
+    newTag: 1dc5cfb1178223522e5cf1fd1d629fa9c0ea2fdd
 
 patches:
   - path: kanary-db-credentials-secret-path.yaml


### PR DESCRIPTION
Point to the o11y commit that switches Horreum filtering from .repo_type to .parameters.options.ComponentRepoUrl.