### PR TITLE
KFLUXINFRA-3534 Revert staging etcd-defrag cronjob to previous config

### DIFF
--- a/configs/etcd-defrag/staging/base/cronjob.yaml
+++ b/configs/etcd-defrag/staging/base/cronjob.yaml
@@ -19,19 +19,22 @@ spec:
               imagePullPolicy: IfNotPresent
               env:
               - name: IMAGE
-                value: quay.io/konflux-ci/etcd-defrag@sha256:220a12563504cef95f2298097f696b681f09aacf407ab2a29a40c25766069d69
-              - name: MAX_FRAGMENTED_PERCENTAGE
-                value: "50"
-              - name: MIN_DEFRAG_MB
-                value: "120"
+                value: quay.io/konflux-ci/etcd-defrag@sha256:7a19f7b9b7bbdeb4f8d51e06d3319ac5c0555094fcbf2093d6e4d71f136afb55
+              - name: FRAGMENTATION_THRESHOLD
+                value: "30"
+              - name: DISK_USAGE_THRESHOLD
+                value: "75" # threshold of etcd-shield is 80% so we only defrag if we get close to that
+              - name: RECLAIM_SPACE_THRESHOLD
+                value: "1024"
               command:
                 - /bin/sh
                 - -c
                 - |
                   etcd_pod=$(oc get pod -l app=etcd -oname -n openshift-etcd | awk -F"/" 'NR==1{ print $2 }')
                   oc -n openshift-etcd debug pod/${etcd_pod} \
-                    maxFragmentedPercentage="${MAX_FRAGMENTED_PERCENTAGE}" \
-                    minDefragMB="${MIN_DEFRAG_MB}" \
+                    fragmentationThreshold="${FRAGMENTATION_THRESHOLD}" \
+                    diskUsageThreshold="${DISK_USAGE_THRESHOLD}" \
+                    reclaimSpaceThreshold="${RECLAIM_SPACE_THRESHOLD}" \
                     --image="${IMAGE}" \
                     --one-container=true \
                     -- /bin/sh -c "chmod +x /opt/defrag.sh && /opt/defrag.sh"


### PR DESCRIPTION
## What
Reverts the staging etcd-defrag cronjob to the configuration before fbbc893ae, restoring the `FRAGMENTATION_THRESHOLD`, `DISK_USAGE_THRESHOLD`, and `RECLAIM_SPACE_THRESHOLD` env vars. Updates the image to `sha256:7a19f7b9b7bbdeb4f8d51e06d3319ac5c0555094fcbf2093d6e4d71f136afb55` and sets `DISK_USAGE_THRESHOLD` to 75 (just below etcd-shield's 80% threshold).

## Why
The built-in etcd-defrag of the etcd-operator doesn't handle well the case of an overloaded cluster with low fragmentation percentage.

## Validation
We had an outage in `stone-prd-rh01` and reverting to this configuration fixed the issues. Deploying to staging first to validate before rolling out to production.

## Risk Assessment
**Risk Level:** Low

Reverting to a previously known-good configuration in staging only. etcd-shield is confirmed deployed to staging clusters and will provide protection at the 80% threshold.