### PR TITLE
chore(PVO11Y-5178): update kanary exporter ref in stone-prod-p02

### DIFF
--- a/components/monitoring/kanary/production/stone-prod-p02/kustomization.yaml
+++ b/components/monitoring/kanary/production/stone-prod-p02/kustomization.yaml
@@ -2,12 +2,12 @@ resources:
   - ../base
   - rbac
   - external-secrets
-  - https://github.com/redhat-appstudio/o11y/config/exporters/monitoring/kanary/base?ref=52d8abfebdbe01bee10a9ee36ba88cc95bbb095d
+  - https://github.com/redhat-appstudio/o11y/config/exporters/monitoring/kanary/base?ref=1dc5cfb1178223522e5cf1fd1d629fa9c0ea2fdd
 
 images:
   - name: quay.io/redhat-appstudio/o11y
     newName: quay.io/redhat-appstudio/o11y
-    newTag: 52d8abfebdbe01bee10a9ee36ba88cc95bbb095d
+    newTag: 1dc5cfb1178223522e5cf1fd1d629fa9c0ea2fdd
 
 patches:
   - path: kanary-db-credentials-secret-path.yaml


### PR DESCRIPTION
Point to the o11y commit that switches Horreum filtering from
.repo_type to .parameters.options.ComponentRepoUrl.

checked from https://github.com/redhat-appstudio/infra-deployments/pull/11297

Issue: [PVO11Y-5178](https://redhat.atlassian.net/browse/PVO11Y-5178)

### What is being done:
- kanary mvp is no longer depending on the .repo_type json key to determine the type of the test that is running instead it will use .parameters.options.ComponentRepoUrl.

### Why:
- Because the kanary was unable to determine the type of the tests because due to some Horreum issues to how it applies functions to the json values which led the kanary mvp to think there are no tests uploaded that matches a given type (single arch, multi arch, rpm). using .parameters.options.ComponentRepoUrl is more robust

### Test confirmation:
- The pods of the kanary mvp now show that the last tests have been a few hours ago (which is true) instead of hundreds of hours ago. Check the log of the pods [here](https://console-openshift-console.apps.stone-stage-p01.hpmt.p1.openshiftapps.com/k8s/ns/appstudio-kanary-exporter/deployments/kanary-exporter-service-deployment/pods)

[PVO11Y-5178]: https://redhat.atlassian.net/browse/PVO11Y-5178?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ