### PR TITLE
feat(SPRE:4608) moving vault probe to production

### DIFF
--- a/components/monitoring/blackbox/production/kflux-fedora-01/kustomization.yaml
+++ b/components/monitoring/blackbox/production/kflux-fedora-01/kustomization.yaml
@@ -1,6 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
- - https://github.com/redhat-appstudio/internal-infra-deployments/components/monitoring/blackbox-exporter/production/public/kflux-fedora-01?ref=86797d1ff34bc9fa9619172f05e56f4b4476e210
+ - https://github.com/redhat-appstudio/internal-infra-deployments/components/monitoring/blackbox-exporter/production/public/kflux-fedora-01?ref=9e93f8d6adea08bfdc7e7c0da8eba35729cbe843
 
 namespace: appstudio-monitoring

--- a/components/monitoring/blackbox/production/kflux-osp-p01/kustomization.yaml
+++ b/components/monitoring/blackbox/production/kflux-osp-p01/kustomization.yaml
@@ -1,6 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
- - https://github.com/redhat-appstudio/internal-infra-deployments/components/monitoring/blackbox-exporter/production/private/kflux-osp-p01?ref=5e48bb6dca3eb756f5de24fe2664e14dbf55388f
+ - https://github.com/redhat-appstudio/internal-infra-deployments/components/monitoring/blackbox-exporter/production/private/kflux-osp-p01?ref=9e93f8d6adea08bfdc7e7c0da8eba35729cbe843
 
 namespace: appstudio-monitoring

--- a/components/monitoring/blackbox/production/kflux-prd-rh02/kustomization.yaml
+++ b/components/monitoring/blackbox/production/kflux-prd-rh02/kustomization.yaml
@@ -1,6 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
- - https://github.com/redhat-appstudio/internal-infra-deployments/components/monitoring/blackbox-exporter/production/public/kflux-prd-rh02?ref=5e48bb6dca3eb756f5de24fe2664e14dbf55388f
+ - https://github.com/redhat-appstudio/internal-infra-deployments/components/monitoring/blackbox-exporter/production/public/kflux-prd-rh02?ref=9e93f8d6adea08bfdc7e7c0da8eba35729cbe843
 
 namespace: appstudio-monitoring

--- a/components/monitoring/blackbox/production/kflux-prd-rh03/kustomization.yaml
+++ b/components/monitoring/blackbox/production/kflux-prd-rh03/kustomization.yaml
@@ -1,6 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
- - https://github.com/redhat-appstudio/internal-infra-deployments/components/monitoring/blackbox-exporter/production/public/kflux-prd-rh03?ref=5e48bb6dca3eb756f5de24fe2664e14dbf55388f
+ - https://github.com/redhat-appstudio/internal-infra-deployments/components/monitoring/blackbox-exporter/production/public/kflux-prd-rh03?ref=9e93f8d6adea08bfdc7e7c0da8eba35729cbe843
 
 namespace: appstudio-monitoring

--- a/components/monitoring/blackbox/production/kflux-rhel-p01/kustomization.yaml
+++ b/components/monitoring/blackbox/production/kflux-rhel-p01/kustomization.yaml
@@ -1,6 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
- - https://github.com/redhat-appstudio/internal-infra-deployments/components/monitoring/blackbox-exporter/production/private/kflux-rhel-p01?ref=5e48bb6dca3eb756f5de24fe2664e14dbf55388f
+ - https://github.com/redhat-appstudio/internal-infra-deployments/components/monitoring/blackbox-exporter/production/private/kflux-rhel-p01?ref=9e93f8d6adea08bfdc7e7c0da8eba35729cbe843
 
 namespace: appstudio-monitoring

--- a/components/monitoring/blackbox/production/stone-prd-rh01/kustomization.yaml
+++ b/components/monitoring/blackbox/production/stone-prd-rh01/kustomization.yaml
@@ -1,6 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
- - https://github.com/redhat-appstudio/internal-infra-deployments/components/monitoring/blackbox-exporter/production/public/stone-prd-rh01?ref=5e48bb6dca3eb756f5de24fe2664e14dbf55388f
+ - https://github.com/redhat-appstudio/internal-infra-deployments/components/monitoring/blackbox-exporter/production/public/stone-prd-rh01?ref=9e93f8d6adea08bfdc7e7c0da8eba35729cbe843
 
 namespace: appstudio-monitoring

--- a/components/monitoring/blackbox/production/stone-prod-p01/kustomization.yaml
+++ b/components/monitoring/blackbox/production/stone-prod-p01/kustomization.yaml
@@ -1,6 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
- - https://github.com/redhat-appstudio/internal-infra-deployments/components/monitoring/blackbox-exporter/production/private/stone-prod-p01?ref=5e48bb6dca3eb756f5de24fe2664e14dbf55388f
+ - https://github.com/redhat-appstudio/internal-infra-deployments/components/monitoring/blackbox-exporter/production/private/stone-prod-p01?ref=9e93f8d6adea08bfdc7e7c0da8eba35729cbe843
 
 namespace: appstudio-monitoring

--- a/components/monitoring/blackbox/production/stone-prod-p02/kustomization.yaml
+++ b/components/monitoring/blackbox/production/stone-prod-p02/kustomization.yaml
@@ -1,6 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
- - https://github.com/redhat-appstudio/internal-infra-deployments/components/monitoring/blackbox-exporter/production/private/stone-prod-p02?ref=5e48bb6dca3eb756f5de24fe2664e14dbf55388f
+ - https://github.com/redhat-appstudio/internal-infra-deployments/components/monitoring/blackbox-exporter/production/private/stone-prod-p02?ref=9e93f8d6adea08bfdc7e7c0da8eba35729cbe843
 
 namespace: appstudio-monitoring


### PR DESCRIPTION

### What - 
Adding vault probe.
[Jira](https://redhat.atlassian.net/browse/SPRE-4608)

### Why - 
For black box monitoring.
impact- We will monitor external dependancy for konflux.

### Validation -
It is working file on staging cluster 
[PR](https://github.com/redhat-appstudio/internal-infra-deployments/pull/56)
[Grafana](https://grafana.stage.devshift.net/d/er4ndj1yq8upcf/konflux-probes?orgId=1&from=now-6h&to=now&timezone=UTC&var-datasource=PDCCF087A30F0737B&var-cluster=$__all&var-probe=vault-external&var-target=$__all)
kustomize build works both from internal-infra-deployments and when using a local path for this updated reference.

### Risk Assessment-
Risk Level: Low
Rollback: Revert PR