### PR TITLE
fix(etcd-shield): add total_size check and raise thresholds (staging)

### DIFF
--- a/components/etcd-shield/base/etcd_shield_alerts.yaml
+++ b/components/etcd-shield/base/etcd_shield_alerts.yaml
@@ -12,14 +12,16 @@ spec:
       for: 2m
       keep_firing_for: 5m
       labels:
-        severity: warning
+        severity: critical
       annotations:
         summary: etcd-shield is denying admission
         description: Etcd is nearing capacity limits, so etcd-shield is denying admission
     - record: etcd_shield_trigger
       expr: |
         (((etcd_mvcc_db_total_size_in_use_in_bytes >= bool (etcd_server_quota_backend_bytes * 0.80)) == 1) or
-            ((((etcd_mvcc_db_total_size_in_use_in_bytes) >= bool (etcd_server_quota_backend_bytes * 0.70)) == 1) and
+            ((etcd_mvcc_db_total_size_in_bytes >= bool (etcd_server_quota_backend_bytes * 0.80)) == 1) or
+            ((((etcd_mvcc_db_total_size_in_use_in_bytes >= bool (etcd_server_quota_backend_bytes * 0.70)) == 1) or
+                ((etcd_mvcc_db_total_size_in_bytes >= bool (etcd_server_quota_backend_bytes * 0.70)) == 1)) and
                 (count without (alertname, alertstate, severity)
                       (ALERTS{
                         alertname="EtcdShieldDenyAdmission",

--- a/components/etcd-shield/base/etcd_shield_alerts.yaml
+++ b/components/etcd-shield/base/etcd_shield_alerts.yaml
@@ -18,8 +18,10 @@ spec:
         description: Etcd is nearing capacity limits, so etcd-shield is denying admission
     - record: etcd_shield_trigger
       expr: |
-        (((etcd_mvcc_db_total_size_in_use_in_bytes >= bool (etcd_server_quota_backend_bytes * 0.80)) == 1) or
-            ((((etcd_mvcc_db_total_size_in_use_in_bytes) >= bool (etcd_server_quota_backend_bytes * 0.70)) == 1) and
+        (((etcd_mvcc_db_total_size_in_use_in_bytes >= bool (etcd_server_quota_backend_bytes * 0.85)) == 1) or
+            ((etcd_mvcc_db_total_size_in_bytes >= bool (etcd_server_quota_backend_bytes * 0.90)) == 1) or
+            ((((etcd_mvcc_db_total_size_in_use_in_bytes >= bool (etcd_server_quota_backend_bytes * 0.75)) == 1) or
+                ((etcd_mvcc_db_total_size_in_bytes >= bool (etcd_server_quota_backend_bytes * 0.80)) == 1)) and
                 (count without (alertname, alertstate, severity)
                       (ALERTS{
                         alertname="EtcdShieldDenyAdmission",


### PR DESCRIPTION
## What

Add `etcd_mvcc_db_total_size_in_bytes` (physical DB size) to the etcd-shield recording rule alongside the existing `in_use` check. Raise thresholds to reduce false triggers on busy clusters.

## Changes

| Metric | Activate | Deactivate |
|--------|----------|------------|
| `in_use` | 80% → 85% | 70% → 75% |
| `total_size` (new) | 90% | 80% |

## Why

- ITN-2026-00103: etcd-shield missed stone-prd-rh01 because only `in_use` bytes were checked — physical DB size hit capacity undetected.
- Busy clusters routinely reach 75% `in_use`, causing unnecessary shield activation at the old 80%/70% thresholds.
- Severity fix (`warning` → `critical`) split to separate PR #12471 per review feedback for granular rollback.