### PR TITLE
KONFLUX-12943 Update kyverno production images to fix JOSE CVE (ring 1)

### DIFF
--- a/components/kyverno/production/stone-prd-rh01/kustomization.yaml
+++ b/components/kyverno/production/stone-prd-rh01/kustomization.yaml
@@ -9,19 +9,19 @@ generators:
 images:
   - name: reg.kyverno.io/kyverno/kyverno
     newName: quay.io/konflux-ci/kyverno/kyverno
-    newTag: 6f4277e0ec31e2e272b68f64dc1f8bef257fd77b
+    newTag: 98fb01cc292a1089bb92e1de884e534e21b671fe
   - name: reg.kyverno.io/kyverno/kyvernopre
     newName: quay.io/konflux-ci/kyverno/kyverno-init
-    newTag: 6f4277e0ec31e2e272b68f64dc1f8bef257fd77b
+    newTag: 98fb01cc292a1089bb92e1de884e534e21b671fe
   - name: reg.kyverno.io/kyverno/background-controller
     newName: quay.io/konflux-ci/kyverno/kyverno-background
-    newTag: 6f4277e0ec31e2e272b68f64dc1f8bef257fd77b
+    newTag: 98fb01cc292a1089bb92e1de884e534e21b671fe
   - name: reg.kyverno.io/kyverno/cleanup-controller
     newName: quay.io/konflux-ci/kyverno/kyverno-cleanup
-    newTag: 6f4277e0ec31e2e272b68f64dc1f8bef257fd77b
+    newTag: 98fb01cc292a1089bb92e1de884e534e21b671fe
   - name: reg.kyverno.io/kyverno/kyverno-cli
     newName: quay.io/konflux-ci/kyverno/kyverno-cli
-    newTag: 6f4277e0ec31e2e272b68f64dc1f8bef257fd77b
+    newTag: 98fb01cc292a1089bb92e1de884e534e21b671fe
 
 # set resources to jobs
 patches:

--- a/components/kyverno/production/stone-prod-p01/kustomization.yaml
+++ b/components/kyverno/production/stone-prod-p01/kustomization.yaml
@@ -9,19 +9,19 @@ generators:
 images:
   - name: reg.kyverno.io/kyverno/kyverno
     newName: quay.io/konflux-ci/kyverno/kyverno
-    newTag: 6f4277e0ec31e2e272b68f64dc1f8bef257fd77b
+    newTag: 98fb01cc292a1089bb92e1de884e534e21b671fe
   - name: reg.kyverno.io/kyverno/kyvernopre
     newName: quay.io/konflux-ci/kyverno/kyverno-init
-    newTag: 6f4277e0ec31e2e272b68f64dc1f8bef257fd77b
+    newTag: 98fb01cc292a1089bb92e1de884e534e21b671fe
   - name: reg.kyverno.io/kyverno/background-controller
     newName: quay.io/konflux-ci/kyverno/kyverno-background
-    newTag: 6f4277e0ec31e2e272b68f64dc1f8bef257fd77b
+    newTag: 98fb01cc292a1089bb92e1de884e534e21b671fe
   - name: reg.kyverno.io/kyverno/cleanup-controller
     newName: quay.io/konflux-ci/kyverno/kyverno-cleanup
-    newTag: 6f4277e0ec31e2e272b68f64dc1f8bef257fd77b
+    newTag: 98fb01cc292a1089bb92e1de884e534e21b671fe
   - name: reg.kyverno.io/kyverno/kyverno-cli
     newName: quay.io/konflux-ci/kyverno/kyverno-cli
-    newTag: 6f4277e0ec31e2e272b68f64dc1f8bef257fd77b
+    newTag: 98fb01cc292a1089bb92e1de884e534e21b671fe
 
 patches:
   - path: job_resources.yaml


### PR DESCRIPTION
## What

Update kyverno images on 2 production clusters as ring 1, from `6f4277e0` to `98fb01cc292a1089bb92e1de884e534e21b671fe`:
- `stone-prd-rh01` (public)
- `stone-prod-p01` (private)

All 5 kyverno images are updated: kyverno, kyverno-init, kyverno-background, kyverno-cleanup, kyverno-cli.

Jira: [KONFLUX-12943](https://redhat.atlassian.net/browse/KONFLUX-12943)

## Why

The new image includes updated go-jose dependencies which fix the JOSE CVE. This is a ring-1 rollout targeting one public and one private production cluster first before rolling out to the remaining clusters.

## Validation

Staging PR - #11316

### Deployed image verification

Pulled and inspected the go-jose version embedded in the binaries of the kyverno images.

**Step 1: Pull images**

```bash
$ podman pull quay.io/konflux-ci/kyverno/kyverno:98fb01cc292a1089bb92e1de884e534e21b671fe
$ podman pull quay.io/konflux-ci/kyverno/kyverno-background:98fb01cc292a1089bb92e1de884e534e21b671fe
$ podman pull quay.io/konflux-ci/kyverno/kyverno-cleanup:98fb01cc292a1089bb92e1de884e534e21b671fe
```

**Step 2: Extract binaries and inspect go-jose version**

```bash
$ CID=$(podman create <image>) && podman cp $CID:/<binary> /tmp/<name>-binary && podman rm $CID
```

```bash
$ go version -m /tmp/kyverno-binary | grep -i jose
      dep     github.com/go-jose/go-jose/v3   v3.0.5  h1:BLLJWbC4nMZOfuPVxoZIxeYsn6Nl2r1fITaJ78UQlVQ=
      dep     github.com/go-jose/go-jose/v4   v4.1.4  h1:moDMcTHmvE6Groj34emNPLs/qtYXRVcd6S7NHbHz3kA=

$ go version -m /tmp/kyverno-background-binary | grep -i jose
      dep     github.com/go-jose/go-jose/v3   v3.0.5  h1:BLLJWbC4nMZOfuPVxoZIxeYsn6Nl2r1fITaJ78UQlVQ=
      dep     github.com/go-jose/go-jose/v4   v4.1.4  h1:moDMcTHmvE6Groj34emNPLs/qtYXRVcd6S7NHbHz3kA=

$ go version -m /tmp/kyverno-cleanup-binary | grep -i jose
      dep     github.com/go-jose/go-jose/v3   v3.0.5  h1:BLLJWbC4nMZOfuPVxoZIxeYsn6Nl2r1fITaJ78UQlVQ=
      dep     github.com/go-jose/go-jose/v4   v4.1.4  h1:moDMcTHmvE6Groj34emNPLs/qtYXRVcd6S7NHbHz3kA=
```

**Result:** All 3 deployed components are running `go-jose/v3` v3.0.5 and `go-jose/v4` v4.1.4. JOSE CVE is fixed.

## Risk Assessment

**Risk Level:** Low

This is a ring-1 rollout limited to 2 production clusters — one public (`stone-prd-rh01`) and one private (`stone-prod-p01`). The image update bumps dependency versions (JOSE CVE fix) with no functional changes. Remaining production clusters will be updated in a follow-up ring-2 PR after verifying stability.

[KONFLUX-12943]: https://redhat.atlassian.net/browse/KONFLUX-12943?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ