### PR TITLE
pulp access controller new tbr secret

### DIFF
--- a/components/pulp-access-controller/base/external-secrets/kustomization.yaml
+++ b/components/pulp-access-controller/base/external-secrets/kustomization.yaml
@@ -1,5 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: pulp-access-controller
 resources:
-  - external-secrets
+  - pulp-access-controller-cert.yaml

--- a/components/pulp-access-controller/base/external-secrets/pulp-access-controller-cert.yaml
+++ b/components/pulp-access-controller/base/external-secrets/pulp-access-controller-cert.yaml
@@ -1,0 +1,21 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: pulp-access-controller-cert
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  dataFrom:
+    - extract:
+        conversionStrategy: Default
+        decodingStrategy: None
+        key: staging/pulp-access-controller/pulp-access-controller-tbr-cert
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: appsre-stonesoup-vault
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    name: pulp-access-controller-cert

--- a/components/pulp-access-controller/production/kustomization.yaml
+++ b/components/pulp-access-controller/production/kustomization.yaml
@@ -3,3 +3,10 @@ kind: Kustomization
 resources:
   - ../base
   - https://github.com/pulp/pulp-access-controller/config/manifests/production?ref=a3228f9289e94fb8b1fc44337038cb547a45d04f
+patches:
+  - path: pulp-access-controller-cert-patch.yaml
+    target:
+      name: pulp-access-controller-cert
+      kind: ExternalSecret
+      group: external-secrets.io
+      version: v1

--- a/components/pulp-access-controller/production/pulp-access-controller-cert-patch.yaml
+++ b/components/pulp-access-controller/production/pulp-access-controller-cert-patch.yaml
@@ -1,0 +1,4 @@
+---
+- op: add
+  path: /spec/dataFrom/0/extract/key
+  value: production/pulp-access-controller/pulp-access-controller-tbr-cert


### PR DESCRIPTION
We need to create a new secret for the pulp access controller
The secret will store the certificate and private key which we use to access the terms based registry for automatic account creation