### PR TITLE
pause localqueues with namespace annotations

### DIFF
--- a/components/policies/development/kueue/queue-config/.chainsaw-test/README.md
+++ b/components/policies/development/kueue/queue-config/.chainsaw-test/README.md
@@ -1,7 +1,383 @@
 # Test: `kueue-bootstrap-queue-new-tenant-labeled-namespace`
 
 Tests that a LocalQueue is created in a namespace labeled with
-`konflux-ci.dev/type=tenant`.
+`konflux-ci.dev/type=tenant` and no `kueue.konflux-ci.dev/stop-policy`
+annotation.
+
+
+## Bindings
+
+| # | Name | Value |
+|:-:|---|---|
+| 1 | `suffix` | "labeled" |
+
+## Steps
+
+| # | Name | Bindings | Try | Catch | Finally | Cleanup |
+|:-:|---|:-:|:-:|:-:|:-:|:-:|
+| 1 | [given-localqueue-crd-exists](#step-given-localqueue-crd-exists) | 0 | 1 | 0 | 0 | 0 |
+| 2 | [given-kyverno-has-permission-on-resources](#step-given-kyverno-has-permission-on-resources) | 0 | 1 | 0 | 0 | 0 |
+| 3 | [given-cluster-policy-is-ready](#step-given-cluster-policy-is-ready) | 0 | 2 | 0 | 0 | 0 |
+| 4 | [when-tenant-labeled-namespace-is-created](#step-when-tenant-labeled-namespace-is-created) | 0 | 1 | 0 | 0 | 0 |
+| 5 | [then-localqueue-is-created](#step-then-localqueue-is-created) | 0 | 1 | 0 | 0 | 0 |
+
+### Step: `given-localqueue-crd-exists`
+
+Install the Kueue LocalQueue CRD so the API server accepts LocalQueue objects in the test cluster.
+
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `given-kyverno-has-permission-on-resources`
+
+Apply Kyverno RBAC so the policy engine can generate and reconcile LocalQueue resources.
+
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `given-cluster-policy-is-ready`
+
+Apply the queue bootstrap ClusterPolicy and assert Kyverno reports the policy as ready before exercising generation.
+
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+| 2 | `assert` | 0 | 0 | *No description* |
+
+### Step: `when-tenant-labeled-namespace-is-created`
+
+Create a namespace labeled konflux-ci.dev/type=tenant so the policy should generate a LocalQueue.
+
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `then-localqueue-is-created`
+
+Assert the expected pipelines-queue LocalQueue exists and matches the fixture (name and spec).
+
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `assert` | 0 | 0 | *No description* |
+
+---
+
+# Test: `kueue-bootstrap-queue-new-tenant-labeled-namespace-unpaused`
+
+Tests that a LocalQueue is created in a namespace labeled with
+`konflux-ci.dev/type=tenant` and the `kueue.konflux-ci.dev/stop-policy`
+annotation set to a value different from `hold`.
+
+
+## Bindings
+
+| # | Name | Value |
+|:-:|---|---|
+| 1 | `suffix` | "labeled-unpaused" |
+
+## Steps
+
+| # | Name | Bindings | Try | Catch | Finally | Cleanup |
+|:-:|---|:-:|:-:|:-:|:-:|:-:|
+| 1 | [given-localqueue-crd-exists](#step-given-localqueue-crd-exists) | 0 | 1 | 0 | 0 | 0 |
+| 2 | [given-kyverno-has-permission-on-resources](#step-given-kyverno-has-permission-on-resources) | 0 | 1 | 0 | 0 | 0 |
+| 3 | [given-cluster-policy-is-ready](#step-given-cluster-policy-is-ready) | 0 | 2 | 0 | 0 | 0 |
+| 4 | [when-tenant-labeled-namespace-is-created](#step-when-tenant-labeled-namespace-is-created) | 0 | 1 | 0 | 0 | 0 |
+| 5 | [then-localqueue-is-created](#step-then-localqueue-is-created) | 0 | 1 | 0 | 0 | 0 |
+
+### Step: `given-localqueue-crd-exists`
+
+Install the Kueue LocalQueue CRD so the API server accepts LocalQueue objects in the test cluster.
+
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `given-kyverno-has-permission-on-resources`
+
+Apply Kyverno RBAC so the policy engine can generate and reconcile LocalQueue resources.
+
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `given-cluster-policy-is-ready`
+
+Apply the queue bootstrap ClusterPolicy and assert Kyverno reports the policy as ready before exercising generation.
+
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+| 2 | `assert` | 0 | 0 | *No description* |
+
+### Step: `when-tenant-labeled-namespace-is-created`
+
+Create a namespace labeled konflux-ci.dev/type=tenant so the policy should generate a LocalQueue.
+
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `then-localqueue-is-created`
+
+Assert the expected pipelines-queue LocalQueue exists and matches the fixture (name and spec).
+
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `assert` | 0 | 0 | *No description* |
+
+---
+
+# Test: `kueue-bootstrap-queue-new-tenant-labeled-paused-namespace-resumed`
+
+Tests that a LocalQueue with `stopPolicy` set to `Hold` is created
+in a namespace labeled with `konflux-ci.dev/type=tenant` with the
+`kueue.konflux-ci.dev/stop-policy` annotation set to `hold`. The
+`stopPolicy` is then set to `None` when the annotation is removed
+from the namespace.
+
+
+## Bindings
+
+| # | Name | Value |
+|:-:|---|---|
+| 1 | `suffix` | "labeled-paused-unpaused" |
+
+## Steps
+
+| # | Name | Bindings | Try | Catch | Finally | Cleanup |
+|:-:|---|:-:|:-:|:-:|:-:|:-:|
+| 1 | [given-localqueue-crd-exists](#step-given-localqueue-crd-exists) | 0 | 1 | 0 | 0 | 0 |
+| 2 | [given-kyverno-has-permission-on-resources](#step-given-kyverno-has-permission-on-resources) | 0 | 1 | 0 | 0 | 0 |
+| 3 | [given-cluster-policy-is-ready](#step-given-cluster-policy-is-ready) | 0 | 2 | 0 | 0 | 0 |
+| 4 | [when-tenant-labeled-namespace-is-created-paused](#step-when-tenant-labeled-namespace-is-created-paused) | 0 | 1 | 0 | 0 | 0 |
+| 5 | [then-localqueue-is-created-paused](#step-then-localqueue-is-created-paused) | 0 | 1 | 0 | 0 | 0 |
+| 6 | [when-tenant-labeled-namespace-is-updated-to-unpause](#step-when-tenant-labeled-namespace-is-updated-to-unpause) | 0 | 1 | 0 | 0 | 0 |
+| 7 | [then-localqueue-is-unpaused](#step-then-localqueue-is-unpaused) | 0 | 1 | 0 | 0 | 0 |
+
+### Step: `given-localqueue-crd-exists`
+
+Install the Kueue LocalQueue CRD so the API server accepts LocalQueue objects in the test cluster.
+
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `given-kyverno-has-permission-on-resources`
+
+Apply Kyverno RBAC so the policy engine can generate and reconcile LocalQueue resources.
+
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `given-cluster-policy-is-ready`
+
+Apply the queue bootstrap ClusterPolicy and assert Kyverno reports the policy as ready before exercising generation.
+
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+| 2 | `assert` | 0 | 0 | *No description* |
+
+### Step: `when-tenant-labeled-namespace-is-created-paused`
+
+update a namespace labeled konflux-ci.dev/type=tenant so the policy should generate a LocalQueue.
+
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `then-localqueue-is-created-paused`
+
+Assert the expected pipelines-queue LocalQueue exists and matches the fixture (name and spec).
+
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `assert` | 0 | 0 | *No description* |
+
+### Step: `when-tenant-labeled-namespace-is-updated-to-unpause`
+
+Update the namespace to unpause it
+
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `update` | 0 | 0 | *No description* |
+
+### Step: `then-localqueue-is-unpaused`
+
+Assert the LocalQueue's StopPolicy is None
+
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `assert` | 0 | 0 | *No description* |
+
+---
+
+# Test: `kueue-bootstrap-queue-new-tenant-labeled-namespace-update-paused`
+
+Tests that a LocalQueue with `stopPolicy` set to `None` is created
+in a namespace labeled with `konflux-ci.dev/type=tenant` with no
+`kueue.konflux-ci.dev/stop-policy` annotation set. The `stopPolicy`
+is then set to `Hold` when the annotation is added to the namespace.
+
+
+## Bindings
+
+| # | Name | Value |
+|:-:|---|---|
+| 1 | `suffix` | "labeled-unpaused-paused" |
+
+## Steps
+
+| # | Name | Bindings | Try | Catch | Finally | Cleanup |
+|:-:|---|:-:|:-:|:-:|:-:|:-:|
+| 1 | [given-localqueue-crd-exists](#step-given-localqueue-crd-exists) | 0 | 1 | 0 | 0 | 0 |
+| 2 | [given-kyverno-has-permission-on-resources](#step-given-kyverno-has-permission-on-resources) | 0 | 1 | 0 | 0 | 0 |
+| 3 | [given-cluster-policy-is-ready](#step-given-cluster-policy-is-ready) | 0 | 2 | 0 | 0 | 0 |
+| 4 | [when-tenant-labeled-namespace-is-created](#step-when-tenant-labeled-namespace-is-created) | 0 | 1 | 0 | 0 | 0 |
+| 5 | [then-localqueue-is-created](#step-then-localqueue-is-created) | 0 | 1 | 0 | 0 | 0 |
+| 6 | [when-tenant-labeled-namespace-is-updated](#step-when-tenant-labeled-namespace-is-updated) | 0 | 1 | 0 | 0 | 0 |
+| 7 | [then-localqueue-is-updated](#step-then-localqueue-is-updated) | 0 | 1 | 0 | 0 | 0 |
+
+### Step: `given-localqueue-crd-exists`
+
+Install the Kueue LocalQueue CRD so the API server accepts LocalQueue objects in the test cluster.
+
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `given-kyverno-has-permission-on-resources`
+
+Apply Kyverno RBAC so the policy engine can generate and reconcile LocalQueue resources.
+
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `given-cluster-policy-is-ready`
+
+Apply the queue bootstrap ClusterPolicy and assert Kyverno reports the policy as ready before exercising generation.
+
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+| 2 | `assert` | 0 | 0 | *No description* |
+
+### Step: `when-tenant-labeled-namespace-is-created`
+
+Create a namespace labeled konflux-ci.dev/type=tenant so the policy should generate a LocalQueue.
+
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `then-localqueue-is-created`
+
+Assert the expected pipelines-queue LocalQueue exists and matches the fixture (name and spec).
+
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `assert` | 0 | 0 | *No description* |
+
+### Step: `when-tenant-labeled-namespace-is-updated`
+
+update a namespace labeled konflux-ci.dev/type=tenant so the policy should generate a LocalQueue.
+
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `then-localqueue-is-updated`
+
+Assert the expected pipelines-queue LocalQueue exists and matches the fixture (name and spec).
+
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `assert` | 0 | 0 | *No description* |
+
+---
+
+# Test: `kueue-bootstrap-queue-new-tenant-labeled-namespace-paused`
+
+Tests that a LocalQueue is created in a namespace labeled with
+`konflux-ci.dev/type=tenant` and with annotation to pause the
+LocalQueue.
 
 
 ## Bindings

--- a/components/policies/development/kueue/queue-config/.chainsaw-test/chainsaw-test.yaml
+++ b/components/policies/development/kueue/queue-config/.chainsaw-test/chainsaw-test.yaml
@@ -6,7 +6,8 @@ metadata:
 spec:
   description: |
     Tests that a LocalQueue is created in a namespace labeled with
-    `konflux-ci.dev/type=tenant`.
+    `konflux-ci.dev/type=tenant` and no `kueue.konflux-ci.dev/stop-policy`
+    annotation.
   concurrent: false
   namespace: kueue-queue-new
   bindings:
@@ -46,6 +47,241 @@ spec:
     try:
     - assert:
         file: resources/expected-localqueue.yaml
+        template: true
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: kueue-bootstrap-queue-new-tenant-labeled-namespace-unpaused
+spec:
+  description: |
+    Tests that a LocalQueue is created in a namespace labeled with
+    `konflux-ci.dev/type=tenant` and the `kueue.konflux-ci.dev/stop-policy`
+    annotation set to a value different from `hold`.
+  concurrent: false
+  namespace: kueue-queue-new
+  bindings:
+  - name: suffix
+    value: labeled-unpaused
+  steps:
+  - name: given-localqueue-crd-exists
+    description: |
+      Install the Kueue LocalQueue CRD so the API server accepts LocalQueue objects in the test cluster.
+    try:
+    - apply:
+        file: ./resources/localqueue-crd.yaml
+  - name: given-kyverno-has-permission-on-resources
+    description: |
+      Apply Kyverno RBAC so the policy engine can generate and reconcile LocalQueue resources.
+    try:
+    - apply:
+        file: ../kyverno-rbac.yaml
+  - name: given-cluster-policy-is-ready
+    description: |
+      Apply the queue bootstrap ClusterPolicy and assert Kyverno reports the policy as ready before exercising generation.
+    try:
+    - apply:
+        file: ../cluster-policy.yaml
+    - assert:
+        file: chainsaw-assert-clusterpolicy.yaml
+  - name: when-tenant-labeled-namespace-is-created
+    description: |
+      Create a namespace labeled konflux-ci.dev/type=tenant so the policy should generate a LocalQueue.
+    try:
+    - apply:
+        file: resources/namespace-tenant-unpaused.yaml
+        template: true
+  - name: then-localqueue-is-created
+    description: |
+      Assert the expected pipelines-queue LocalQueue exists and matches the fixture (name and spec).
+    try:
+    - assert:
+        file: resources/expected-localqueue.yaml
+        template: true
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: kueue-bootstrap-queue-new-tenant-labeled-paused-namespace-resumed
+spec:
+  description: |
+    Tests that a LocalQueue with `stopPolicy` set to `Hold` is created
+    in a namespace labeled with `konflux-ci.dev/type=tenant` with the
+    `kueue.konflux-ci.dev/stop-policy` annotation set to `hold`. The
+    `stopPolicy` is then set to `None` when the annotation is removed
+    from the namespace.
+  concurrent: false
+  namespace: kueue-queue-new
+  bindings:
+  - name: suffix
+    value: labeled-paused-unpaused
+  steps:
+  - name: given-localqueue-crd-exists
+    description: |
+      Install the Kueue LocalQueue CRD so the API server accepts LocalQueue objects in the test cluster.
+    try:
+    - apply:
+        file: ./resources/localqueue-crd.yaml
+  - name: given-kyverno-has-permission-on-resources
+    description: |
+      Apply Kyverno RBAC so the policy engine can generate and reconcile LocalQueue resources.
+    try:
+    - apply:
+        file: ../kyverno-rbac.yaml
+  - name: given-cluster-policy-is-ready
+    description: |
+      Apply the queue bootstrap ClusterPolicy and assert Kyverno reports the policy as ready before exercising generation.
+    try:
+    - apply:
+        file: ../cluster-policy.yaml
+    - assert:
+        file: chainsaw-assert-clusterpolicy.yaml
+  - name: when-tenant-labeled-namespace-is-created-paused
+    description: |
+      update a namespace labeled konflux-ci.dev/type=tenant so the policy should generate a LocalQueue.
+    try:
+    - apply:
+        file: resources/namespace-tenant-paused.yaml
+        template: true
+  - name: then-localqueue-is-created-paused
+    description: |
+      Assert the expected pipelines-queue LocalQueue exists and matches the fixture (name and spec).
+    try:
+    - assert:
+        file: resources/expected-localqueue-paused.yaml
+        template: true
+  - name: when-tenant-labeled-namespace-is-updated-to-unpause
+    description: |
+      Update the namespace to unpause it
+    try:
+    - update:
+        file: resources/namespace-tenant.yaml
+        template: true
+  - name: then-localqueue-is-unpaused
+    description: |
+      Assert the LocalQueue's StopPolicy is None
+    try:
+    - assert:
+        file: resources/expected-localqueue.yaml
+        template: true
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: kueue-bootstrap-queue-new-tenant-labeled-namespace-update-paused
+spec:
+  description: |
+    Tests that a LocalQueue with `stopPolicy` set to `None` is created
+    in a namespace labeled with `konflux-ci.dev/type=tenant` with no
+    `kueue.konflux-ci.dev/stop-policy` annotation set. The `stopPolicy`
+    is then set to `Hold` when the annotation is added to the namespace.
+  concurrent: false
+  namespace: kueue-queue-new
+  bindings:
+  - name: suffix
+    value: labeled-unpaused-paused
+  steps:
+  - name: given-localqueue-crd-exists
+    description: |
+      Install the Kueue LocalQueue CRD so the API server accepts LocalQueue objects in the test cluster.
+    try:
+    - apply:
+        file: ./resources/localqueue-crd.yaml
+  - name: given-kyverno-has-permission-on-resources
+    description: |
+      Apply Kyverno RBAC so the policy engine can generate and reconcile LocalQueue resources.
+    try:
+    - apply:
+        file: ../kyverno-rbac.yaml
+  - name: given-cluster-policy-is-ready
+    description: |
+      Apply the queue bootstrap ClusterPolicy and assert Kyverno reports the policy as ready before exercising generation.
+    try:
+    - apply:
+        file: ../cluster-policy.yaml
+    - assert:
+        file: chainsaw-assert-clusterpolicy.yaml
+  - name: when-tenant-labeled-namespace-is-created
+    description: |
+      Create a namespace labeled konflux-ci.dev/type=tenant so the policy should generate a LocalQueue.
+    try:
+    - apply:
+        file: resources/namespace-tenant.yaml
+        template: true
+  - name: then-localqueue-is-created
+    description: |
+      Assert the expected pipelines-queue LocalQueue exists and matches the fixture (name and spec).
+    try:
+    - assert:
+        file: resources/expected-localqueue.yaml
+        template: true
+  - name: when-tenant-labeled-namespace-is-updated
+    description: |
+      update a namespace labeled konflux-ci.dev/type=tenant so the policy should generate a LocalQueue.
+    try:
+    - apply:
+        file: resources/namespace-tenant-paused.yaml
+        template: true
+  - name: then-localqueue-is-updated
+    description: |
+      Assert the expected pipelines-queue LocalQueue exists and matches the fixture (name and spec).
+    try:
+    - assert:
+        file: resources/expected-localqueue-paused.yaml
+        template: true
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: kueue-bootstrap-queue-new-tenant-labeled-namespace-paused
+spec:
+  description: |
+    Tests that a LocalQueue is created in a namespace labeled with
+    `konflux-ci.dev/type=tenant` and with annotation to pause the
+    LocalQueue.
+  concurrent: false
+  namespace: kueue-queue-new
+  bindings:
+  - name: suffix
+    value: labeled
+  steps:
+  - name: given-localqueue-crd-exists
+    description: |
+      Install the Kueue LocalQueue CRD so the API server accepts LocalQueue objects in the test cluster.
+    try:
+    - apply:
+        file: ./resources/localqueue-crd.yaml
+  - name: given-kyverno-has-permission-on-resources
+    description: |
+      Apply Kyverno RBAC so the policy engine can generate and reconcile LocalQueue resources.
+    try:
+    - apply:
+        file: ../kyverno-rbac.yaml
+  - name: given-cluster-policy-is-ready
+    description: |
+      Apply the queue bootstrap ClusterPolicy and assert Kyverno reports the policy as ready before exercising generation.
+    try:
+    - apply:
+        file: ../cluster-policy.yaml
+    - assert:
+        file: chainsaw-assert-clusterpolicy.yaml
+  - name: when-tenant-labeled-namespace-is-created
+    description: |
+      Create a namespace labeled konflux-ci.dev/type=tenant so the policy should generate a LocalQueue.
+    try:
+    - apply:
+        file: resources/namespace-tenant-paused.yaml
+        template: true
+  - name: then-localqueue-is-created
+    description: |
+      Assert the expected pipelines-queue LocalQueue exists and matches the fixture (name and spec).
+    try:
+    - assert:
+        file: resources/expected-localqueue-paused.yaml
         template: true
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json

--- a/components/policies/development/kueue/queue-config/.chainsaw-test/resources/expected-localqueue-kanary.yaml
+++ b/components/policies/development/kueue/queue-config/.chainsaw-test/resources/expected-localqueue-kanary.yaml
@@ -5,3 +5,4 @@ metadata:
   namespace: appstudio-kanary-exporter
 spec:
   clusterQueue: cluster-pipeline-queue
+  stopPolicy: None

--- a/components/policies/development/kueue/queue-config/.chainsaw-test/resources/expected-localqueue-paused.yaml
+++ b/components/policies/development/kueue/queue-config/.chainsaw-test/resources/expected-localqueue-paused.yaml
@@ -2,7 +2,7 @@ apiVersion: kueue.x-k8s.io/v1beta1
 kind: LocalQueue
 metadata:
   name: pipelines-queue
-  namespace: mintmaker
+  namespace: (join('-', [$namespace, $suffix]))
 spec:
   clusterQueue: cluster-pipeline-queue
-  stopPolicy: None
+  stopPolicy: Hold

--- a/components/policies/development/kueue/queue-config/.chainsaw-test/resources/expected-localqueue.yaml
+++ b/components/policies/development/kueue/queue-config/.chainsaw-test/resources/expected-localqueue.yaml
@@ -5,3 +5,4 @@ metadata:
   namespace: (join('-', [$namespace, $suffix]))
 spec:
   clusterQueue: cluster-pipeline-queue
+  stopPolicy: None

--- a/components/policies/development/kueue/queue-config/.chainsaw-test/resources/namespace-tenant-paused.yaml
+++ b/components/policies/development/kueue/queue-config/.chainsaw-test/resources/namespace-tenant-paused.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: (join('-', [$namespace, $suffix]))
+  annotations:
+    kueue.konflux-ci.dev/stop-policy: hold
+  labels:
+    konflux-ci.dev/type: tenant

--- a/components/policies/development/kueue/queue-config/.chainsaw-test/resources/namespace-tenant-unpaused.yaml
+++ b/components/policies/development/kueue/queue-config/.chainsaw-test/resources/namespace-tenant-unpaused.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: (join('-', [$namespace, $suffix]))
+  annotations:
+    kueue.konflux-ci.dev/stop-policy: none
+  labels:
+    konflux-ci.dev/type: tenant

--- a/components/policies/development/kueue/queue-config/cluster-policy.yaml
+++ b/components/policies/development/kueue/queue-config/cluster-policy.yaml
@@ -21,10 +21,15 @@ spec:
           names:
           - mintmaker
           - appstudio-kanary-exporter
+    context:
+    - name: stopPolicy
+      variable:
+        jmesPath: >-
+          (request.object.metadata.annotations."kueue.konflux-ci.dev/stop-policy" || '') == 'hold' && 'Hold' || 'None'
     generate:
       generateExisting: true
       orphanDownstreamOnPolicyDelete: true
-      synchronize: false
+      synchronize: true
       apiVersion: kueue.x-k8s.io/v1beta1
       kind: LocalQueue
       name: pipelines-queue
@@ -32,3 +37,4 @@ spec:
       data:
         spec:
           clusterQueue: cluster-pipeline-queue
+          stopPolicy: "{{stopPolicy}}"

--- a/components/policies/staging/policies/kueue/kustomization.yaml
+++ b/components/policies/staging/policies/kueue/kustomization.yaml
@@ -2,3 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - ../../../development/kueue/
+
+patchesStrategicMerge:
+  - ./patch_delete_queueconfig_clusterpolicy.yaml

--- a/components/policies/staging/policies/kueue/kustomization.yaml
+++ b/components/policies/staging/policies/kueue/kustomization.yaml
@@ -2,6 +2,3 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - ../../../development/kueue/
-
-patchesStrategicMerge:
-  - ./patch_delete_queueconfig_clusterpolicy.yaml

--- a/components/policies/staging/policies/kueue/patch_delete_queueconfig_clusterpolicy.yaml
+++ b/components/policies/staging/policies/kueue/patch_delete_queueconfig_clusterpolicy.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: bootstrap-tenant-namespace-queue
+$patch: delete

--- a/components/policies/staging/policies/kueue/patch_delete_queueconfig_clusterpolicy.yaml
+++ b/components/policies/staging/policies/kueue/patch_delete_queueconfig_clusterpolicy.yaml
@@ -1,6 +1,0 @@
----
-apiVersion: kyverno.io/v1
-kind: ClusterPolicy
-metadata:
-  name: bootstrap-tenant-namespace-queue
-$patch: delete


### PR DESCRIPTION
This PR proposes to add support for a Namespace annotation to use to drive the value of the LocalQueue's `spec.stopPolicy` field.
With this we can allow/disallow admission of Workloads at tenant namespace level.

The release of this change needs to go through the 3-phases rollout strategy described at https://github.com/redhat-appstudio/infra-deployments/tree/main/components/policies\#deletion-of-generated-resources-not-acceptable

Requires:
* [x] #11452
* [x] #11453 

Signed-off-by: Francesco Ilario <filario@redhat.com>
