### PR TITLE
kueue: make nudges the same priority as mintmaker pipelineruns

### DIFF
--- a/components/kueue/development/queue-config/workload-priority-class.yaml
+++ b/components/kueue/development/queue-config/workload-priority-class.yaml
@@ -16,13 +16,6 @@ description: "High priority for tenant release pipelines"
 apiVersion: kueue.x-k8s.io/v1beta1
 kind: WorkloadPriorityClass
 metadata:
-  name: konflux-nudge
-value: 850
-description: "Higher priority for component nudges"
----
-apiVersion: kueue.x-k8s.io/v1beta1
-kind: WorkloadPriorityClass
-metadata:
   name: konflux-post-merge-test
 value: 800
 description: "Priority for post-merge tests"

--- a/components/kueue/development/tekton-kueue/config.yaml
+++ b/components/kueue/development/tekton-kueue/config.yaml
@@ -94,6 +94,11 @@ cel:
 
     # Set the pipeline priority
     - |
+        has(pipelineRun.metadata.labels) &&
+        'build.appstudio.openshift.io/type' in pipelineRun.metadata.labels &&
+        pipelineRun.metadata.labels['build.appstudio.openshift.io/type'] == 'nudge' ?
+        priority('konflux-dependency-update') :
+
         pacEventType == 'push' ? priority('konflux-post-merge-build') :
         pacEventType == 'pull_request' ||
           pacEventType == "Merge_Request" ||

--- a/components/kueue/development/tekton-kueue/config.yaml
+++ b/components/kueue/development/tekton-kueue/config.yaml
@@ -126,11 +126,6 @@ cel:
         plrNamespace == 'mintmaker' ? priority('konflux-dependency-update') :
 
         has(pipelineRun.metadata.labels) &&
-        'build.appstudio.openshift.io/type' in pipelineRun.metadata.labels &&
-        pipelineRun.metadata.labels['build.appstudio.openshift.io/type'] == 'nudge' ?
-        priority('konflux-nudge') :
-
-        has(pipelineRun.metadata.labels) &&
         'internal-services.appstudio.openshift.io/pipelinerun-uid' in pipelineRun.metadata.labels ?
         priority('konflux-release') :
 

--- a/components/kueue/staging/base/tekton-kueue/config.yaml
+++ b/components/kueue/staging/base/tekton-kueue/config.yaml
@@ -94,6 +94,11 @@ cel:
 
     # Set the pipeline priority
     - |
+        has(pipelineRun.metadata.labels) &&
+        'build.appstudio.openshift.io/type' in pipelineRun.metadata.labels &&
+        pipelineRun.metadata.labels['build.appstudio.openshift.io/type'] == 'nudge' ?
+        priority('konflux-dependency-update') :
+
         pacEventType == 'push' ? priority('konflux-post-merge-build') :
         pacEventType == 'pull_request' ||
           pacEventType == "Merge_Request" ||

--- a/hack/test-tekton-kueue-config.py
+++ b/hack/test-tekton-kueue-config.py
@@ -453,6 +453,35 @@ PIPELINERUN_DEFINITIONS: Dict[str, PipelineRunTestData] = {
         }
     },
 
+    "nudge_pipelinerun": {
+        "name": "Multi-platform pipeline with user-specific priority (new style)",
+        "pipelinerun": {
+            "apiVersion": "tekton.dev/v1",
+            "kind": "PipelineRun",
+            "metadata": {
+                "name": "nudging-pipelinerun",
+                "namespace": "default",
+                "labels": {
+                    "build.appstudio.openshift.io/type": "nudge",
+                    # make sure the nudge type overrides this
+                    "pipelinesascode.tekton.dev/event-type": "push"
+                }
+            },
+            "spec": {
+                "pipelineRef": {"name": "renovate"},
+                "workspaces": [{"name": "shared-workspace", "emptyDir": {}}]
+            }
+        },
+        "expected": {
+            "annotations": {},
+            "labels": {
+                "build.appstudio.openshift.io/type": "nudge",
+                "kueue.x-k8s.io/queue-name": "pipelines-queue",
+                "kueue.x-k8s.io/priority-class": "konflux-dependency-update"
+            }
+        }
+    },
+
     "build-test-comment": {
         "name": "build pipeline triggered via /test comment",
         "pipelinerun": {
@@ -1127,6 +1156,10 @@ TEST_COMBINATIONS: Dict[str, TestCombination] = {
         "pipelinerun_key": "build-ok-to-test-comment",
         "config_key": "development"
     },
+    "nudging_dev": {
+        "pipelinerun_key": "nudge_pipelinerun",
+        "config_key": "development"
+    },
 
     # multiplatform_old edge cases
     "multiplatform_old_no_pipelineSpecTasks": {
@@ -1201,6 +1234,10 @@ TEST_COMBINATIONS: Dict[str, TestCombination] = {
     },
     "build_ok_to_test_comment_staging": {
         "pipelinerun_key": "build-ok-to-test-comment",
+        "config_key": "staging"
+    },
+    "nudging_staging": {
+        "pipelinerun_key": "nudge_pipelinerun",
         "config_key": "staging"
     },
 


### PR DESCRIPTION
There's not much difference between a mintmaker pipelinerun and a nudge.  Give them the same priority.

Fixes: [KFLUXINFRA-3317](https://redhat.atlassian.net/browse/KFLUXINFRA-3317)

[KFLUXINFRA-3317]: https://redhat.atlassian.net/browse/KFLUXINFRA-3317?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ