### PR TITLE
KONFLUX-12943 Update kyverno production images to fix JOSE CVE (ring 2)

### DIFF
--- a/components/kyverno/production/kflux-fedora-01/kustomization.yaml
+++ b/components/kyverno/production/kflux-fedora-01/kustomization.yaml
@@ -9,19 +9,19 @@ generators:
 images:
   - name: reg.kyverno.io/kyverno/kyverno
     newName: quay.io/konflux-ci/kyverno/kyverno
-    newTag: 6f4277e0ec31e2e272b68f64dc1f8bef257fd77b
+    newTag: 98fb01cc292a1089bb92e1de884e534e21b671fe
   - name: reg.kyverno.io/kyverno/kyvernopre
     newName: quay.io/konflux-ci/kyverno/kyverno-init
-    newTag: 6f4277e0ec31e2e272b68f64dc1f8bef257fd77b
+    newTag: 98fb01cc292a1089bb92e1de884e534e21b671fe
   - name: reg.kyverno.io/kyverno/background-controller
     newName: quay.io/konflux-ci/kyverno/kyverno-background
-    newTag: 6f4277e0ec31e2e272b68f64dc1f8bef257fd77b
+    newTag: 98fb01cc292a1089bb92e1de884e534e21b671fe
   - name: reg.kyverno.io/kyverno/cleanup-controller
     newName: quay.io/konflux-ci/kyverno/kyverno-cleanup
-    newTag: 6f4277e0ec31e2e272b68f64dc1f8bef257fd77b
+    newTag: 98fb01cc292a1089bb92e1de884e534e21b671fe
   - name: reg.kyverno.io/kyverno/kyverno-cli
     newName: quay.io/konflux-ci/kyverno/kyverno-cli
-    newTag: 6f4277e0ec31e2e272b68f64dc1f8bef257fd77b
+    newTag: 98fb01cc292a1089bb92e1de884e534e21b671fe
 
 # set resources to jobs
 patches:

--- a/components/kyverno/production/kflux-ocp-p01/kustomization.yaml
+++ b/components/kyverno/production/kflux-ocp-p01/kustomization.yaml
@@ -9,19 +9,19 @@ generators:
 images:
   - name: reg.kyverno.io/kyverno/kyverno
     newName: quay.io/konflux-ci/kyverno/kyverno
-    newTag: 6f4277e0ec31e2e272b68f64dc1f8bef257fd77b
+    newTag: 98fb01cc292a1089bb92e1de884e534e21b671fe
   - name: reg.kyverno.io/kyverno/kyvernopre
     newName: quay.io/konflux-ci/kyverno/kyverno-init
-    newTag: 6f4277e0ec31e2e272b68f64dc1f8bef257fd77b
+    newTag: 98fb01cc292a1089bb92e1de884e534e21b671fe
   - name: reg.kyverno.io/kyverno/background-controller
     newName: quay.io/konflux-ci/kyverno/kyverno-background
-    newTag: 6f4277e0ec31e2e272b68f64dc1f8bef257fd77b
+    newTag: 98fb01cc292a1089bb92e1de884e534e21b671fe
   - name: reg.kyverno.io/kyverno/cleanup-controller
     newName: quay.io/konflux-ci/kyverno/kyverno-cleanup
-    newTag: 6f4277e0ec31e2e272b68f64dc1f8bef257fd77b
+    newTag: 98fb01cc292a1089bb92e1de884e534e21b671fe
   - name: reg.kyverno.io/kyverno/kyverno-cli
     newName: quay.io/konflux-ci/kyverno/kyverno-cli
-    newTag: 6f4277e0ec31e2e272b68f64dc1f8bef257fd77b
+    newTag: 98fb01cc292a1089bb92e1de884e534e21b671fe
 
 # set resources to jobs
 patches:

--- a/components/kyverno/production/kflux-osp-p01/kustomization.yaml
+++ b/components/kyverno/production/kflux-osp-p01/kustomization.yaml
@@ -9,19 +9,19 @@ generators:
 images:
   - name: reg.kyverno.io/kyverno/kyverno
     newName: quay.io/konflux-ci/kyverno/kyverno
-    newTag: 6f4277e0ec31e2e272b68f64dc1f8bef257fd77b
+    newTag: 98fb01cc292a1089bb92e1de884e534e21b671fe
   - name: reg.kyverno.io/kyverno/kyvernopre
     newName: quay.io/konflux-ci/kyverno/kyverno-init
-    newTag: 6f4277e0ec31e2e272b68f64dc1f8bef257fd77b
+    newTag: 98fb01cc292a1089bb92e1de884e534e21b671fe
   - name: reg.kyverno.io/kyverno/background-controller
     newName: quay.io/konflux-ci/kyverno/kyverno-background
-    newTag: 6f4277e0ec31e2e272b68f64dc1f8bef257fd77b
+    newTag: 98fb01cc292a1089bb92e1de884e534e21b671fe
   - name: reg.kyverno.io/kyverno/cleanup-controller
     newName: quay.io/konflux-ci/kyverno/kyverno-cleanup
-    newTag: 6f4277e0ec31e2e272b68f64dc1f8bef257fd77b
+    newTag: 98fb01cc292a1089bb92e1de884e534e21b671fe
   - name: reg.kyverno.io/kyverno/kyverno-cli
     newName: quay.io/konflux-ci/kyverno/kyverno-cli
-    newTag: 6f4277e0ec31e2e272b68f64dc1f8bef257fd77b
+    newTag: 98fb01cc292a1089bb92e1de884e534e21b671fe
 
 # set resources to jobs
 patches:

--- a/components/kyverno/production/kflux-prd-rh02/kustomization.yaml
+++ b/components/kyverno/production/kflux-prd-rh02/kustomization.yaml
@@ -9,19 +9,19 @@ generators:
 images:
   - name: reg.kyverno.io/kyverno/kyverno
     newName: quay.io/konflux-ci/kyverno/kyverno
-    newTag: 6f4277e0ec31e2e272b68f64dc1f8bef257fd77b
+    newTag: 98fb01cc292a1089bb92e1de884e534e21b671fe
   - name: reg.kyverno.io/kyverno/kyvernopre
     newName: quay.io/konflux-ci/kyverno/kyverno-init
-    newTag: 6f4277e0ec31e2e272b68f64dc1f8bef257fd77b
+    newTag: 98fb01cc292a1089bb92e1de884e534e21b671fe
   - name: reg.kyverno.io/kyverno/background-controller
     newName: quay.io/konflux-ci/kyverno/kyverno-background
-    newTag: 6f4277e0ec31e2e272b68f64dc1f8bef257fd77b
+    newTag: 98fb01cc292a1089bb92e1de884e534e21b671fe
   - name: reg.kyverno.io/kyverno/cleanup-controller
     newName: quay.io/konflux-ci/kyverno/kyverno-cleanup
-    newTag: 6f4277e0ec31e2e272b68f64dc1f8bef257fd77b
+    newTag: 98fb01cc292a1089bb92e1de884e534e21b671fe
   - name: reg.kyverno.io/kyverno/kyverno-cli
     newName: quay.io/konflux-ci/kyverno/kyverno-cli
-    newTag: 6f4277e0ec31e2e272b68f64dc1f8bef257fd77b
+    newTag: 98fb01cc292a1089bb92e1de884e534e21b671fe
 
 # set resources to jobs
 patches:

--- a/components/kyverno/production/kflux-prd-rh03/kustomization.yaml
+++ b/components/kyverno/production/kflux-prd-rh03/kustomization.yaml
@@ -9,19 +9,19 @@ generators:
 images:
   - name: reg.kyverno.io/kyverno/kyverno
     newName: quay.io/konflux-ci/kyverno/kyverno
-    newTag: 6f4277e0ec31e2e272b68f64dc1f8bef257fd77b
+    newTag: 98fb01cc292a1089bb92e1de884e534e21b671fe
   - name: reg.kyverno.io/kyverno/kyvernopre
     newName: quay.io/konflux-ci/kyverno/kyverno-init
-    newTag: 6f4277e0ec31e2e272b68f64dc1f8bef257fd77b
+    newTag: 98fb01cc292a1089bb92e1de884e534e21b671fe
   - name: reg.kyverno.io/kyverno/background-controller
     newName: quay.io/konflux-ci/kyverno/kyverno-background
-    newTag: 6f4277e0ec31e2e272b68f64dc1f8bef257fd77b
+    newTag: 98fb01cc292a1089bb92e1de884e534e21b671fe
   - name: reg.kyverno.io/kyverno/cleanup-controller
     newName: quay.io/konflux-ci/kyverno/kyverno-cleanup
-    newTag: 6f4277e0ec31e2e272b68f64dc1f8bef257fd77b
+    newTag: 98fb01cc292a1089bb92e1de884e534e21b671fe
   - name: reg.kyverno.io/kyverno/kyverno-cli
     newName: quay.io/konflux-ci/kyverno/kyverno-cli
-    newTag: 6f4277e0ec31e2e272b68f64dc1f8bef257fd77b
+    newTag: 98fb01cc292a1089bb92e1de884e534e21b671fe
 
 # set resources to jobs
 patches:

--- a/components/kyverno/production/kflux-rhel-p01/kustomization.yaml
+++ b/components/kyverno/production/kflux-rhel-p01/kustomization.yaml
@@ -9,19 +9,19 @@ generators:
 images:
   - name: reg.kyverno.io/kyverno/kyverno
     newName: quay.io/konflux-ci/kyverno/kyverno
-    newTag: 6f4277e0ec31e2e272b68f64dc1f8bef257fd77b
+    newTag: 98fb01cc292a1089bb92e1de884e534e21b671fe
   - name: reg.kyverno.io/kyverno/kyvernopre
     newName: quay.io/konflux-ci/kyverno/kyverno-init
-    newTag: 6f4277e0ec31e2e272b68f64dc1f8bef257fd77b
+    newTag: 98fb01cc292a1089bb92e1de884e534e21b671fe
   - name: reg.kyverno.io/kyverno/background-controller
     newName: quay.io/konflux-ci/kyverno/kyverno-background
-    newTag: 6f4277e0ec31e2e272b68f64dc1f8bef257fd77b
+    newTag: 98fb01cc292a1089bb92e1de884e534e21b671fe
   - name: reg.kyverno.io/kyverno/cleanup-controller
     newName: quay.io/konflux-ci/kyverno/kyverno-cleanup
-    newTag: 6f4277e0ec31e2e272b68f64dc1f8bef257fd77b
+    newTag: 98fb01cc292a1089bb92e1de884e534e21b671fe
   - name: reg.kyverno.io/kyverno/kyverno-cli
     newName: quay.io/konflux-ci/kyverno/kyverno-cli
-    newTag: 6f4277e0ec31e2e272b68f64dc1f8bef257fd77b
+    newTag: 98fb01cc292a1089bb92e1de884e534e21b671fe
 
 # set resources to jobs
 patches:

--- a/components/kyverno/production/stone-prod-p02/kustomization.yaml
+++ b/components/kyverno/production/stone-prod-p02/kustomization.yaml
@@ -9,19 +9,19 @@ generators:
 images:
   - name: reg.kyverno.io/kyverno/kyverno
     newName: quay.io/konflux-ci/kyverno/kyverno
-    newTag: 6f4277e0ec31e2e272b68f64dc1f8bef257fd77b
+    newTag: 98fb01cc292a1089bb92e1de884e534e21b671fe
   - name: reg.kyverno.io/kyverno/kyvernopre
     newName: quay.io/konflux-ci/kyverno/kyverno-init
-    newTag: 6f4277e0ec31e2e272b68f64dc1f8bef257fd77b
+    newTag: 98fb01cc292a1089bb92e1de884e534e21b671fe
   - name: reg.kyverno.io/kyverno/background-controller
     newName: quay.io/konflux-ci/kyverno/kyverno-background
-    newTag: 6f4277e0ec31e2e272b68f64dc1f8bef257fd77b
+    newTag: 98fb01cc292a1089bb92e1de884e534e21b671fe
   - name: reg.kyverno.io/kyverno/cleanup-controller
     newName: quay.io/konflux-ci/kyverno/kyverno-cleanup
-    newTag: 6f4277e0ec31e2e272b68f64dc1f8bef257fd77b
+    newTag: 98fb01cc292a1089bb92e1de884e534e21b671fe
   - name: reg.kyverno.io/kyverno/kyverno-cli
     newName: quay.io/konflux-ci/kyverno/kyverno-cli
-    newTag: 6f4277e0ec31e2e272b68f64dc1f8bef257fd77b
+    newTag: 98fb01cc292a1089bb92e1de884e534e21b671fe
 
 patches:
   - path: job_resources.yaml

--- a/hack/new-cluster/templates/kyverno/kustomization.yaml
+++ b/hack/new-cluster/templates/kyverno/kustomization.yaml
@@ -9,19 +9,19 @@ generators:
 images:
   - name: reg.kyverno.io/kyverno/kyverno
     newName: quay.io/konflux-ci/kyverno/kyverno
-    newTag: 6f4277e0ec31e2e272b68f64dc1f8bef257fd77b
+    newTag: 98fb01cc292a1089bb92e1de884e534e21b671fe
   - name: reg.kyverno.io/kyverno/kyvernopre
     newName: quay.io/konflux-ci/kyverno/kyverno-init
-    newTag: 6f4277e0ec31e2e272b68f64dc1f8bef257fd77b
+    newTag: 98fb01cc292a1089bb92e1de884e534e21b671fe
   - name: reg.kyverno.io/kyverno/background-controller
     newName: quay.io/konflux-ci/kyverno/kyverno-background
-    newTag: 6f4277e0ec31e2e272b68f64dc1f8bef257fd77b
+    newTag: 98fb01cc292a1089bb92e1de884e534e21b671fe
   - name: reg.kyverno.io/kyverno/cleanup-controller
     newName: quay.io/konflux-ci/kyverno/kyverno-cleanup
-    newTag: 6f4277e0ec31e2e272b68f64dc1f8bef257fd77b
+    newTag: 98fb01cc292a1089bb92e1de884e534e21b671fe
   - name: reg.kyverno.io/kyverno/kyverno-cli
     newName: quay.io/konflux-ci/kyverno/kyverno-cli
-    newTag: 6f4277e0ec31e2e272b68f64dc1f8bef257fd77b
+    newTag: 98fb01cc292a1089bb92e1de884e534e21b671fe
 
 # set resources to jobs
 patches:


### PR DESCRIPTION
## What

Update kyverno images on the remaining 7 production clusters and new-cluster template, from `6f4277e0` to `98fb01cc292a1089bb92e1de884e534e21b671fe`:
- `kflux-fedora-01`
- `kflux-ocp-p01`
- `kflux-osp-p01`
- `kflux-prd-rh02`
- `kflux-prd-rh03`
- `kflux-rhel-p01`
- `stone-prod-p02`
- `hack/new-cluster/templates/kyverno/`

All 5 kyverno images are updated: kyverno, kyverno-init, kyverno-background, kyverno-cleanup, kyverno-cli.

Jira: [KONFLUX-12943](https://redhat.atlassian.net/browse/KONFLUX-12943)

## Why

The new image includes updated go-jose dependencies which fix the JOSE CVE. This is a ring-2 rollout covering the remaining production clusters after ring 1 was validated.

## Validation

- Staging PR: #11316
- Ring 1 PR: #11323

### Deployed image verification (from ring 1)

Pulled and inspected the go-jose version embedded in the binaries of the kyverno images.

```bash
$ go version -m /tmp/kyverno-binary | grep -i jose
      dep     github.com/go-jose/go-jose/v3   v3.0.5
      dep     github.com/go-jose/go-jose/v4   v4.1.4

$ go version -m /tmp/kyverno-background-binary | grep -i jose
      dep     github.com/go-jose/go-jose/v3   v3.0.5
      dep     github.com/go-jose/go-jose/v4   v4.1.4

$ go version -m /tmp/kyverno-cleanup-binary | grep -i jose
      dep     github.com/go-jose/go-jose/v3   v3.0.5
      dep     github.com/go-jose/go-jose/v4   v4.1.4
```

**Result:** All components running `go-jose/v3` v3.0.5 and `go-jose/v4` v4.1.4. JOSE CVE is fixed.

### Ring 1 health verification (`stone-prod-p01`, `stone-prd-rh01`)

All 9/9 pods Running (1/1 Ready, 0 restarts) on both clusters. All deployments 3/3 available. Both clusters confirmed running image tag `98fb01cc292a1089bb92e1de884e534e21b671fe`. No warning events in `konflux-kyverno` namespace on either cluster.

## Risk Assessment

**Risk Level:** Low

**Rollback:** Revert image tags to `6f4277e0ec31e2e272b68f64dc1f8bef257fd77b` in all affected kustomization.yaml files.

Ring 1 has been running on 2 production clusters for 45+ hours with no issues. The image update only bumps dependency versions (JOSE CVE fix) with no functional changes.

[KONFLUX-12943]: https://redhat.atlassian.net/browse/KONFLUX-12943?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ