### PR TITLE
feat: add Qodo rule to nudge authors for missing staging PR link

### DIFF
--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -1,0 +1,19 @@
+[pr_reviewer]
+extra_instructions = """
+Check if this PR includes a staging validation link.
+
+The link must appear somewhere in the PR description or in a PR comment, in one of these formats:
+- A `## Validation` section containing `Staging PR: <full GitHub PR URL>`
+- A line starting with `Staging PR:` or `Stage PR:` followed by a full GitHub PR URL
+
+If no staging PR link is found, post a comment that:
+1. Mentions the PR author with @
+2. States the PR is missing a staging validation link
+3. Shows the exact format to use:
+
+## Validation
+
+Staging PR: <your-staging-pr-url>
+
+Note: The production approval dashboard requires the full GitHub PR URL (not a PR number) to verify the staging PR is merged and calculate soak time.
+"""


### PR DESCRIPTION
## Summary

- Adds `.pr_agent.toml` with a `[pr_reviewer]` rule that instructs Qodo to check every PR for a staging validation link
- If no link is found, Qodo posts a comment mentioning the author and showing the expected format
- This moves the staging PR nudge earlier in the review cycle (at Qodo review time) rather than requiring a manual click in the production approval dashboard
- The dashboard nudge button is kept as a fallback for repos that don't have Qodo or this rule configured

## Expected Qodo behavior

When a PR is missing a staging PR link in the format:
```
## Validation

Staging PR: https://github.com/.../pull/NNN
```
Qodo will post a comment asking the author to add one.

## Test plan

- [ ] Open a test PR without a staging PR link → trigger `/review` → verify Qodo comments with the nudge
- [ ] Open a test PR with a valid `Staging PR: <url>` line → trigger `/review` → verify Qodo does not post a staging nudge

🤖 Generated with [Claude Code](https://claude.com/claude-code)