### PR TITLE
KFLUXINFRA-3277 Add separate yamllint warnings step in CI

### DIFF
--- a/.github/workflows/yamllint.yaml
+++ b/.github/workflows/yamllint.yaml
@@ -13,4 +13,9 @@ jobs:
       - uses: actions/checkout@v4
       - name: Lint yaml manifests
         run: |
-          yamllint -f github .
+          yamllint -f github --no-warnings .
+      - name: Check for yaml lint warnings
+        if: always()
+        continue-on-error: true
+        run: |
+          yamllint -f github -s .


### PR DESCRIPTION
## What
[KFLUXINFRA-3277](https://redhat.atlassian.net/browse/KFLUXINFRA-3277)

Split yamllint CI into two steps:
- **Lint yaml manifests** — errors only (`--no-warnings`), blocks the PR
- **Check for yaml lint warnings** — strict mode (`-s`), always runs, non-blocking (`continue-on-error`)

## Why
The yamllint CI check was mixing errors and warnings in the same output, polluting the view. This separates them so warnings are visible in a dedicated step without blocking PRs.

## Validation
- CI run on PR #11040 validated the warnings step works correctly
- Visual proof that the `yamllint` task is passing and the warnings can be viewed in a different step (not like in the [previous state](https://github.com/redhat-appstudio/infra-deployments/actions/runs/23637102563/job/68848639297?pr=11040)):
<img width="1036" height="490" alt="image" src="https://github.com/user-attachments/assets/ad298018-0cf0-4686-8c3b-4d9b9b48e18f" />

## Risk Assessment
**Risk Level:** Low
**Rollback:** Revert the PR
Only a CI workflow change — no functional changes to any manifests.

[KFLUXINFRA-3277]: https://redhat.atlassian.net/browse/KFLUXINFRA-3277?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ