### PR TITLE
Reduce component-maintainer permissions

### DIFF
--- a/components/authentication/base/component-maintainer.yaml
+++ b/components/authentication/base/component-maintainer.yaml
@@ -21,22 +21,6 @@ rules:
       - serviceaccounts
     resourceNames:
       - pipeline # TODO: figure out how to 'gitops' this.
-  - verbs:
-      - create
-      - get
-      - list
-      - watch
-      - delete
-    apiGroups:
-      - ''
-    resources:
-      - secrets
-  - verbs:
-      - '*' # needed till we figure out how to cleanup workspaces.
-    apiGroups:
-      - 'tekton.dev'
-    resources:
-      - 'pipelineruns'
   - apiGroups:
       - results.tekton.dev
     resources:
@@ -58,5 +42,4 @@ rules:
       - deployments
     verbs:
       - get
-      - patch
       - delete


### PR DESCRIPTION
Remove secrets and pipelineruns permissions. No one should have access to secrets and pilelineruns by default (which indirectly grant access to secrets).

 Also remove patch on deployment which was allowing mutation of pod specs that already consume Secrets and enabling runtime exfiltration via existing network endpoints.


[KFLUXINFRA-3647](https://redhat.atlassian.net/browse/KFLUXINFRA-3647)

[KFLUXINFRA-3647]: https://redhat.atlassian.net/browse/KFLUXINFRA-3647?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Risk Assessment
**Risk Level:** Low
**Description:** Reduce component-maintainer permissions — no user-facing changes
**Rollback:** Revert PR

## Validation
This change is targeting all environments at once and this is intentional. This is a simple RBAC change affecting Konflux developers and we need to do this change to comply with least privilege principle