### PR TITLE
Enable package registry proxy on staging clusters

### DIFF
--- a/components/konflux-info/staging/stone-stage-p01/cluster-config.env
+++ b/components/konflux-info/staging/stone-stage-p01/cluster-config.env
@@ -1,3 +1,7 @@
 allow-cache-proxy=true
 http-proxy=squid.caching.svc.cluster.local:3128
 no-proxy=
+
+allow-package-registry-proxy=true
+package-registry-proxy-npm-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/npm-proxy
+package-registry-proxy-yarn-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/npm-proxy

--- a/components/konflux-info/staging/stone-stg-rh01/cluster-config.env
+++ b/components/konflux-info/staging/stone-stg-rh01/cluster-config.env
@@ -1,3 +1,7 @@
 allow-cache-proxy=true
 http-proxy=squid.caching.svc.cluster.local:3128
 no-proxy=
+
+allow-package-registry-proxy=true
+package-registry-proxy-npm-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/npm-proxy
+package-registry-proxy-yarn-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/npm-proxy


### PR DESCRIPTION
Enable use of the package registry proxy for stage clusters (stone-stg-rh01, stone-stage-p01). This sets the `allow-package-registry-proxy` feature flag to `true` and configures the npm/yarn proxy URLs, which will allow Hermeto to route dependency prefetches through the package registry registry proxy for policy evaluation.

Production clusters will be enabled separately after validation in stage.

See ADR: https://github.com/konflux-ci/architecture/blob/0f9b9bf6ae267aa059e68478d6d7b80e7afc5676/ADR/0064-hermeto-package-registry-proxy.md

The infra team controls this flag per-cluster via the cluster-config ConfigMap. Setting `allow-package-registry-proxy` to `false` disables proxy usage across all build pipelines on the cluster (e.g. during a proxy outage).