### PR TITLE
fix(PVO11Y-5150): add 1h timeout on run-kanary-tests task

### DIFF
--- a/components/monitoring/kanary/staging/base/pipelines/kanary-otel-pipeline.yaml
+++ b/components/monitoring/kanary/staging/base/pipelines/kanary-otel-pipeline.yaml
@@ -52,6 +52,7 @@ spec:
       default: ""
   tasks:
     - name: run-kanary-tests
+      timeout: "1h"
       taskRef:
         name: run-kanary-tests
       params:


### PR DESCRIPTION
### Why
This is to ensure that the finally task runs given that pipelineruns have a 2h timeout.
Some results/metrics were not being pushed to RHOBS (through the otel collector) because the whole pipeline would timeout on the first task (running the kanary/load tests).

Issue: [PVO11Y-5150](https://redhat.atlassian.net/browse/PVO11Y-5150)

[PVO11Y-5150]: https://redhat.atlassian.net/browse/PVO11Y-5150?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ