### PR TITLE
namespace-lister: bump to commit f014edd

### DIFF
--- a/components/namespace-lister/base/kustomization.yaml
+++ b/components/namespace-lister/base/kustomization.yaml
@@ -12,7 +12,7 @@ namespace: namespace-lister
 images:
 - name: namespace-lister
   newName: quay.io/konflux-ci/namespace-lister
-  newTag: feb825ba321734d8b26025f0830f2ba1f668e65a
+  newTag: f014eddfab7f50801ed43154cdd4969c3ab39b5d
 patches:
 - path: ./patches/with_cachenamespacelabelselector.yaml
   target:


### PR DESCRIPTION
List of changes:

```
Andy Sadler (1):
      renovate: add new package rules (#293)

Francesco Ilario (3):
      add metric for synch operation duration (#269)
      Renovate our linting setup (#271)
      do not log headers (#335)

Hector Oswaldo Caballero (7):
      fix: resolve golangci-lint 2.11.x issues (#305)
      chore(deps) Update go version to 1.25 (#306)
      fix(deps): bump google.golang.org/grpc to v1.79.3
      fix(deps): bump go.opentelemetry.io/otel/sdk to v1.40.0
      fix(deps): bump k8s.io/kubernetes to v1.34.2
      fix(deps): align golang.org/x/* versions in acceptance module
      fix(security): ignore Go stdlib CVEs pending go-toolset 1.26.x

Maksym Shaposhnyk (1):
      [KFLUXINFRA-3279] Move namespace-lister into konflux-infra tenant (#304)

msu8 (1):
      feat: Onboard unit test coverage to Codecov (#294)

red-hat-konflux[bot] (29):
      chore(deps): update github.com/timakin/bodyclose digest to 73d1f95 (#270)
      fix(deps): update k8s.io/utils digest to b8788ab (#275)
      chore(deps): update registry.access.redhat.com/ubi9/ubi-micro docker digest to 093a704 (#273)
      chore(deps): update registry.access.redhat.com/ubi9/go-toolset docker digest to 799cc02 (#272)
      chore(deps): update github.com/google/pprof digest to cb029da (#266)
      chore(deps): update module github.com/emicklei/go-restful/v3 to v3.13.0 (#262)
      chore(deps): update go-openapi packages (#251)
      chore(deps): update module cel.dev/expr to v0.25.1 (#252)
      fix(deps): update module github.com/spf13/pflag to v1.0.10 (#246)
      fix(deps): update module github.com/prometheus/client_model to v0.6.2 (#245)
      chore(deps): update module golang.org/x/oauth2 to v0.35.0 (#290)
      chore(deps): update registry.access.redhat.com/ubi9/ubi-micro docker digest to 2173487 (#299)
      chore(deps): update codecov/codecov-action action to v6 (#302)
      chore(deps): update registry.access.redhat.com/ubi9/go-toolset docker digest to 056bf34 (#295)
      chore(deps): update go-modules major (#298)
      chore(deps): update dependency golangci-lint to v2.11.4 (#278)
      chore(deps): update registry.access.redhat.com/ubi9/go-toolset docker tag to v1.25.8-1775491036 (#307)
      fix(deps): update go-modules controller-runtime and k8s (#297)
      chore(deps): update konflux references (#300)
      fix(deps): update go-modules minor
      chore(deps): update registry.access.redhat.com/ubi9/go-toolset docker tag to v1.25.8-1775651161
      chore(deps): update registry.access.redhat.com/ubi9/go-toolset docker tag to v1.25.8-1775724628
      chore(deps): update konflux references
      fix(deps): update go-modules minor
      chore(deps): update golang.org/x/exp digest to 746e56f (#319)
      chore(deps): update go-modules major
      chore(deps): update registry.access.redhat.com/ubi9/go-toolset docker tag to v1.25.8-1776084839
      chore(deps): update go-modules minor (#327)
      chore(deps): update konflux references to 1bd72f0 (#323)
```

[KFLUXINFRA-3279]: https://redhat.atlassian.net/browse/KFLUXINFRA-3279?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ