### PR TITLE
create separate external secret for image-controller image pruner

### DIFF
--- a/components/image-controller/base/external-secrets/image-pruner-token.yaml
+++ b/components/image-controller/base/external-secrets/image-pruner-token.yaml
@@ -1,0 +1,19 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: image-pruner-token
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  dataFrom:
+    - extract:
+        key: staging/build/image-pruner-token
+  refreshInterval: 30m
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: appsre-stonesoup-vault
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    name: image-pruner-token

--- a/components/image-controller/base/external-secrets/kustomization.yaml
+++ b/components/image-controller/base/external-secrets/kustomization.yaml
@@ -2,4 +2,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - quaytoken.yaml
+- image-pruner-token.yaml
 namespace: image-controller

--- a/components/image-controller/production/base/image-pruner-token.yaml
+++ b/components/image-controller/production/base/image-pruner-token.yaml
@@ -1,0 +1,4 @@
+---
+- op: add
+  path: /spec/dataFrom/0/extract/key
+  value: production/build/image-pruner-token

--- a/components/image-controller/production/base/kustomization.yaml
+++ b/components/image-controller/production/base/kustomization.yaml
@@ -20,4 +20,10 @@ patches:
       kind: ExternalSecret
       group: external-secrets.io
       version: v1
+  - path: image-pruner-token.yaml
+    target:
+      name: image-pruner-token
+      kind: ExternalSecret
+      group: external-secrets.io
+      version: v1
   - path: ./pruner_cronjob_resources_patch.yaml


### PR DESCRIPTION
[STONEBLD-4643](https://redhat.atlassian.net/browse/STONEBLD-4643)

[STONEBLD-4643]: https://redhat.atlassian.net/browse/STONEBLD-4643?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## What:
creation of separate external secret for image-controller image pruner job

## Why:
currently pruner is sharing secret with image-controller

## Validation:
this PR is only creating external secret based on vault
image pruner job will use it once we bump image-controller to new version
Check Kubernetes YAMLs with kube-linter / scan ci task passed
Staging PR: https://github.com/redhat-appstudio/infra-deployments/pull/11391

## Risk Assessment
**Risk Level:** Low
**Description:** creates external secrets which aren't used yet — no user-facing changes
**Rollback:** Revert PR
