### PR TITLE
fix image-controller and build-service promotion pipelines

### DIFF
--- a/.tekton/build-service-prod-overlay-update.yaml
+++ b/.tekton/build-service-prod-overlay-update.yaml
@@ -38,7 +38,8 @@ spec:
           - name: name
             value: slack-webhook-notification
           - name: kind
-            value: Task
+            value: task
+          resolver: bundles
         when:
         - input: $(tasks.status)
           operator: in

--- a/.tekton/image-controller-prod-overlay-update.yaml
+++ b/.tekton/image-controller-prod-overlay-update.yaml
@@ -37,7 +37,8 @@ spec:
           - name: name
             value: slack-webhook-notification
           - name: kind
-            value: Task
+            value: task
+          resolver: bundles
         when:
         - input: $(tasks.status)
           operator: in


### PR DESCRIPTION
[STONEBLD-4574](https://redhat.atlassian.net/browse/STONEBLD-4574)

[STONEBLD-4574]: https://redhat.atlassian.net/browse/STONEBLD-4574?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## What:
fix for image-controller and build-service promotion pipelines

## Why:
pipelines are failing with: cannot find referenced task

## Validation:
claude validated pipelines

## Risk Assessment
**Risk Level:** Low
**Description:** updates broken promotion pipelines — no user-facing changes
**Rollback:** Revert PR