### PR TITLE
fix(PVO11Y-5132): Stg in-cluster grafana requests.memory as soft-limit

### DIFF
--- a/components/monitoring/grafana/staging/grafana-resources-patch.yaml
+++ b/components/monitoring/grafana/staging/grafana-resources-patch.yaml
@@ -9,7 +9,9 @@
         memory: "4Gi"
       limits:
         cpu: "1"
-        memory: "4Gi"
+        memory: "5Gi"
     env:
       - name: GOMEMLIMIT
-        value: "3277MiB"
+        valueFrom:
+          resourceFieldRef:
+            resource: requests.memory


### PR DESCRIPTION
For in-cluster grafana, use requests.memory as the soft-limit enforced by GOMEMLIMIT. Leveraging the value defined there instead of including yet another hardcoded value to account for.