### PR TITLE
chore(KFLUXVNGD-751): Add cache_status label to staging writeRelabelConfigs

### DIFF
--- a/components/monitoring/prometheus/staging/base/monitoringstack/writeRelabelConfigs.yaml
+++ b/components/monitoring/prometheus/staging/base/monitoringstack/writeRelabelConfigs.yaml
@@ -17,4 +17,4 @@
       policy_name|policy_background_mode|rule_type|policy_type|policy_validation_mode|\
       resource_request_operation|resource_kind|policy_change_type|event_type|\
       name|cluster_queue|quantile|slice|scrape_job|tested_registry|error|queue|\
-      priority_class"
+      priority_class|cache_status"


### PR DESCRIPTION
Allow cache_status label to be preserved in remote write for cache metrics.