### PR TITLE
kueue: update nudge priorities in production

### DIFF
--- a/components/kueue/production/base/tekton-kueue/config.yaml
+++ b/components/kueue/production/base/tekton-kueue/config.yaml
@@ -94,6 +94,11 @@ cel:
 
     # Set the pipeline priority
     - |
+        has(pipelineRun.metadata.labels) &&
+        'build.appstudio.openshift.io/type' in pipelineRun.metadata.labels &&
+        pipelineRun.metadata.labels['build.appstudio.openshift.io/type'] == 'nudge' ?
+        priority('konflux-dependency-update') :
+
         pacEventType == 'push' ? priority('konflux-post-merge-build') :
         pacEventType == 'pull_request' ||
           pacEventType == "Merge_Request" ||
@@ -119,8 +124,8 @@ cel:
         has(pipelineRun.metadata.labels) &&
         'appstudio.openshift.io/service' in pipelineRun.metadata.labels &&
         pipelineRun.metadata.labels['appstudio.openshift.io/service'] == 'release' &&
-        'pipelines.appstudio.openshift.io/type' in pipelineRun.metadata.labels &&
-        pipelineRun.metadata.labels['pipelines.appstudio.openshift.io/type'] == 'tenant' ?
+        'release.appstudio.openshift.io/namespace' in pipelineRun.metadata.labels &&
+        pipelineRun.metadata.labels['release.appstudio.openshift.io/namespace'] == plrNamespace ?
         priority('konflux-tenant-release') :
 
         plrNamespace == 'mintmaker' ? priority('konflux-dependency-update') :

--- a/hack/test-tekton-kueue-config.py
+++ b/hack/test-tekton-kueue-config.py
@@ -1270,6 +1270,10 @@ TEST_COMBINATIONS: Dict[str, TestCombination] = {
         "pipelinerun_key": "gitlab_merge_request_test",
         "config_key": "production"
     },
+    "nudging_production": {
+        "pipelinerun_key": "nudge_pipelinerun",
+        "config_key": "production"
+    },
 
     # Test key PipelineRuns with production kflux-ocp-p01 config
     "multiplatform_new_production-kflux-ocp-p01": {


### PR DESCRIPTION
Deploys #10902 and #11334 to the production clusters (except kflux-ocp-p01).

Fixes: [KFLUXINFRA-3317](https://redhat.atlassian.net/browse/KFLUXINFRA-3317)

[KFLUXINFRA-3317]: https://redhat.atlassian.net/browse/KFLUXINFRA-3317?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ