### PR TITLE
Promote multi-platform-controller from staging to production-downstream

### DIFF
--- a/components/multi-platform-controller/production-downstream/base/kustomization.yaml
+++ b/components/multi-platform-controller/production-downstream/base/kustomization.yaml
@@ -7,8 +7,8 @@ resources:
 - ../../base/common
 - ../../base/rbac
 - ../../base/logcollector
-- https://github.com/konflux-ci/multi-platform-controller/deploy/operator?ref=29a9fa5a07fa6145eda5e6b48a992a84e67b9c2c
-- https://github.com/konflux-ci/multi-platform-controller/deploy/otp?ref=29a9fa5a07fa6145eda5e6b48a992a84e67b9c2c
+- https://github.com/konflux-ci/multi-platform-controller/deploy/operator?ref=93c18de0be493a99a6f08f8f5fb9ab373c838ad8
+- https://github.com/konflux-ci/multi-platform-controller/deploy/otp?ref=93c18de0be493a99a6f08f8f5fb9ab373c838ad8
 
 components:
   - ../../k-components/manager-resources
@@ -16,7 +16,7 @@ components:
 images:
 - name: multi-platform-controller
   newName: quay.io/konflux-ci/multi-platform-controller
-  newTag: 29a9fa5a07fa6145eda5e6b48a992a84e67b9c2c
+  newTag: 93c18de0be493a99a6f08f8f5fb9ab373c838ad8
 - name: multi-platform-otp-server
   newName: quay.io/konflux-ci/multi-platform-controller-otp-service
-  newTag: 29a9fa5a07fa6145eda5e6b48a992a84e67b9c2c
+  newTag: 93c18de0be493a99a6f08f8f5fb9ab373c838ad8


### PR DESCRIPTION
## What

Promotes multi-platform-controller from staging to production-downstream (ring 2). Bumps the component ref from `29a9fa5a` to `93c18de0` in the production-downstream base kustomization, updating the deploy/operator, deploy/otp resource refs and the image tags for both `multi-platform-controller` and `multi-platform-otp-server`.

This is the ring-2 follow-up to **PR #11320** which already promoted the same changes to the ring-1 production overlays (external clusters): https://github.com/redhat-appstudio/infra-deployments/pull/11320

Included PRs:
 - https://github.com/redhat-appstudio/infra-deployments/pull/11268

## Why

The new version has been validated in staging and successfully rolled out to production ring-1 (external clusters) via PR #11320. It is now ready for production-downstream (internal/downstream clusters).

## Changelog (`29a9fa5a` → `93c18de0`)

### Bug Fixes
| Commit | PR | Description | Author |
|--------|----|-------------|--------|
| `9eb23047f537` | [#844](https://github.com/konflux-ci/multi-platform-controller/pull/844) | **fix([KONFLUX-12884](https://redhat.atlassian.net/browse/KONFLUX-12884)): resolve OTP server intermittent retrieval failures** — adds `--fail` to curl in all provision scripts, fixes nil error logged for "no OTP found", fixes no-op `WriteHeader(500)` after `Write()`, adds structured logging with map size | Manish Kumar |

### Features / Improvements
| Commit | PR | Description | Author |
|--------|----|-------------|--------|
| `d2073677efa1` | [#837](https://github.com/konflux-ci/multi-platform-controller/pull/837) | Update MPC windows AMI | Maksym Shaposhnyk |
| `8f4b18430afb` | [#845](https://github.com/konflux-ci/multi-platform-controller/pull/845) | Remove unused taskgen code | Maksym Shaposhnyk |
| `894add7f950e` | [#859](https://github.com/konflux-ci/multi-platform-controller/pull/859) | Update rpms-signature-scan to fix releases | Francesco Ilario |
| `bc51a0b9e0d1` | [#835](https://github.com/konflux-ci/multi-platform-controller/pull/835) | Onboard e2e testing to codecov using coverport | Ladislav Lipka |

### Dependency Updates / CI Housekeeping
| Commit | PR | Description | Author |
|--------|----|-------------|--------|
| `8334c550befa` | [#830](https://github.com/konflux-ci/multi-platform-controller/pull/830) | renovate: add new package rules | Andy Sadler |
| `4c9da3010bae` | [#839](https://github.com/konflux-ci/multi-platform-controller/pull/839) | renovate: Constraint the go version to 1.25 | Hector Oswaldo Caballero |
| `e526930eac37` | [#803](https://github.com/konflux-ci/multi-platform-controller/pull/803) | chore(deps): update ubi9/ubi-minimal docker tag to v9.7-1775623882 | red-hat-konflux[bot] |
| `aa8fa6b20ac1` | [#842](https://github.com/konflux-ci/multi-platform-controller/pull/842) | Bump codecov/codecov-action from 5 to 6 | dependabot[bot] |
| `770ac54927da` | [#816](https://github.com/konflux-ci/multi-platform-controller/pull/816) | Bump actions/upload-artifact from 6 to 7 | dependabot[bot] |
| `633139676bef` | [#834](https://github.com/konflux-ci/multi-platform-controller/pull/834) | chore(deps): update konflux references | red-hat-konflux[bot] |
| `93c18de0be49` | [#857](https://github.com/konflux-ci/multi-platform-controller/pull/857) | Bump aws-actions/configure-aws-credentials from 6.0.0 to 6.1.0 | dependabot[bot] |

## Risk Assessment

**Overall Risk Level:** Low

- **Ring-1 production validation:** These exact changes have been running in production ring-1 (external clusters) since PR #11320 was merged on Apr 22, 2026, with no issues observed.
- **The primary functional change** is [PR #844](https://github.com/konflux-ci/multi-platform-controller/pull/844) — a targeted bug fix for [KONFLUX-12884](https://redhat.atlassian.net/browse/KONFLUX-12884) addressing OTP server retrieval failures (~8% failure rate on `stone-prod-p02`). It hardens error handling in curl calls, fixes misleading nil error logs, and corrects silently ignored `WriteHeader(500)` calls. All changes have unit tests and were validated in staging.
- **Windows AMI update** ([#837](https://github.com/konflux-ci/multi-platform-controller/pull/837)) — routine AMI refresh.
- **Remaining changes** are dependency bumps, CI housekeeping, and code cleanup — no behavioral impact on production.
- No maintenance window or user alert should be needed.

## Validation

- Ring-1 production PR: https://github.com/redhat-appstudio/infra-deployments/pull/11320 — merged and running in production since Apr 22, 2026
- Staging PR: https://github.com/redhat-appstudio/infra-deployments/pull/11268 — merged and verified in staging/development environments
- Changes are a direct mirror of the ring-1 production bump applied to the production-downstream base kustomization
- Full diff: https://github.com/konflux-ci/multi-platform-controller/compare/29a9fa5a...93c18de0

Made with [Cursor](https://cursor.com)

[KONFLUX-12884]: https://redhat.atlassian.net/browse/KONFLUX-12884?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ