### PR TITLE
[KFLUXDP-883] Add GH Action to warn if prod is affected by stage changes

### DIFF
--- a/.github/workflows/enforce-ring-deployment.yaml
+++ b/.github/workflows/enforce-ring-deployment.yaml
@@ -1,0 +1,83 @@
+name: Enforce Ring Deployment
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+    branches: [main]
+    paths:
+      - 'components/**'
+      - 'argo-cd-apps/**'
+      - 'configs/**'
+      - '.github/workflows/enforce-ring-deployment.yaml'
+
+jobs:
+  ring-deployment-check:
+    name: Check ring deployment policy
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+    steps:
+      # Check out the BASE branch (trusted code) so we never execute PR code.
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: infra-tools/go.mod
+          cache-dependency-path: infra-tools/go.sum
+
+      - name: Setup Kustomize
+        uses: multani/action-setup-kustomize@v1
+        with:
+          version: 5.6.0
+
+      # Build from the trusted base branch before switching to PR code.
+      - name: Build env-detector (from base branch)
+        working-directory: infra-tools
+        run: go build -o bin/env-detector ./cmd/env-detector
+
+      # Fetch the GitHub-synthesized merge commit so the tool analyses the
+      # post-merge state, while the binary remains the trusted base build.
+      - name: Checkout PR merge ref
+        run: |
+          git fetch origin pull/${{ github.event.pull_request.number }}/merge:pr-merge
+          git checkout pr-merge
+
+      - name: Check ring deployment policy
+        id: ring-check
+        continue-on-error: true
+        working-directory: infra-tools
+        run: |
+          ./bin/env-detector \
+            --repo-root=.. \
+            --base-ref=origin/${{ github.event.pull_request.base.ref }} \
+            --enforce-ring-deployment \
+            --ring-report-file=/tmp/ring-report.md \
+            --dry-run
+
+      - name: Post or update PR comment
+        if: always() && steps.ring-check.outcome != 'skipped'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          COMMENT_MARKER="<!-- ring-deployment-check -->"
+
+          # Delete any previous comment from this workflow
+          gh api "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" \
+            --paginate --jq ".[] | select(.body | contains(\"${COMMENT_MARKER}\")) | .id" \
+            | xargs -r -I {} gh api "repos/${{ github.repository }}/issues/comments/{}" -X DELETE
+
+          # Post a new comment only if the report file was generated
+          if [ -s /tmp/ring-report.md ]; then
+            echo "${COMMENT_MARKER}" >> /tmp/ring-report.md
+            gh pr comment ${{ github.event.pull_request.number }} \
+              --repo ${{ github.repository }} \
+              --body-file /tmp/ring-report.md
+          fi
+
+      - name: Fail on ring deployment violation
+        if: always() && steps.ring-check.outcome == 'failure'
+        run: exit 1

--- a/docs/_data/navigation.yml
+++ b/docs/_data/navigation.yml
@@ -25,6 +25,8 @@ docs-en:
     children:
       - title: Staging Environment
         url: /docs/deployment/stage.html
+      - title: Ring Deployment Policy
+        url: /docs/deployment/ring-deployment.html
       - title: Multi-Cluster Deployment
         url: /docs/deployment/multi-cluster.html
       - title: Extending The Service

--- a/docs/deployment/ring-deployment.md
+++ b/docs/deployment/ring-deployment.md
@@ -1,0 +1,73 @@
+---
+title: Ring Deployment Policy
+---
+
+## Overview
+
+This repository enforces a ring deployment model where **staging is ring 0**.
+Changes must be validated in staging before they can be promoted to production.
+To enforce this, a CI check prevents PRs from modifying both staging and
+production overlays at the same time.
+
+## How it works
+
+The `enforce-ring-deployment` GitHub Actions workflow runs on every PR that
+touches files under `components/`, `argo-cd-apps/`, or `configs/`. It uses
+the `env-detector` tool to:
+
+1. Determine which environments (staging, production) are affected by the PR.
+2. Classify changed files as belonging directly to a staging overlay, a
+   production overlay, or neither (shared base files).
+3. **Block** the PR if files under both staging and production directories are
+   directly modified.
+4. **Warn** (but allow) the PR if only shared base files are changed and both
+   environments are indirectly affected through kustomize dependency trees.
+
+### Directory classification
+
+A file is classified as a direct staging or production change based on whether
+its path passes through one of these directory names:
+
+| Directory segment             | Environment |
+|-------------------------------|-------------|
+| `staging`                     | staging     |
+| `staging-downstream`          | staging     |
+| `konflux-public-staging`      | staging     |
+| `production`                  | production  |
+| `production-downstream`       | production  |
+| `konflux-public-production`   | production  |
+
+This applies under `components/` (including nested components like
+`monitoring/grafana/staging/`), any subtree of `argo-cd-apps/` (e.g.
+`overlays/`, `app-of-app-sets/`, `k-components/`), and `configs/`.
+
+Files under `base/`, `development/`, or other directories that are not
+environment-specific are not classified as direct staging or production changes.
+
+## Workflow for making changes
+
+### Staging-only changes (normal path)
+
+Modify files under `components/<service>/staging/` (and/or related staging
+overlay directories). The CI check passes and the PR can be merged after
+review.
+
+### Production promotion
+
+After changes are validated in staging, create a **separate PR** that modifies
+the corresponding `production/` overlay. The CI check passes because only
+production files are touched.
+
+### Shared base changes
+
+If you modify files under `components/<service>/base/` that are referenced by
+both staging and production overlays, the CI check will pass with a **warning**
+explaining that both environments are affected. The preferred approach is to rework the change into a staging-only one and once that's verified, opening a second PR that reverts the staging-only change and makes the change in the shared base files.
+
+### What to do if the check fails
+
+If the CI check blocks your PR, split it into two PRs:
+
+1. **First PR**: Contains only the staging overlay changes. Merge and validate.
+2. **Second PR**: Contains only the production overlay changes. Create this
+   after staging validation confirms the changes work correctly.

--- a/infra-tools/cmd/env-detector/main.go
+++ b/infra-tools/cmd/env-detector/main.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"slices"
 	"sort"
+	"strings"
 	"syscall"
 
 	charmlog "github.com/charmbracelet/log"
@@ -24,15 +25,17 @@ import (
 
 func main() {
 	var (
-		repoRoot      = flag.String("repo-root", ".", "Path to the repository root")
-		baseRef       = flag.String("base-ref", "main", "Base git ref to compare against")
-		overlaysDir   = flag.String("overlays-dir", "argo-cd-apps/overlays", "Path to overlays directory relative to repo root")
-		dryRun        = flag.Bool("dry-run", false, "Print results without calling GitHub API")
-		prNumber      = flag.Int("pr-number", 0, "PR number to label (required if not --dry-run)")
-		githubToken   = flag.String("github-token", "", "GitHub token (required if not --dry-run)")
-		repo          = flag.String("repo", "", "GitHub repository in owner/repo format (required if not --dry-run)")
-		clusterLabels = flag.Bool("cluster-labels", false, "Include cluster/<name> labels in addition to environment labels")
-		logFile       = flag.String("log-file", "", "Write debug-level logs to this file (in addition to INFO-level logs on stdout)")
+		repoRoot             = flag.String("repo-root", ".", "Path to the repository root")
+		baseRef              = flag.String("base-ref", "main", "Base git ref to compare against")
+		overlaysDir          = flag.String("overlays-dir", "argo-cd-apps/overlays", "Path to overlays directory relative to repo root")
+		dryRun               = flag.Bool("dry-run", false, "Print results without calling GitHub API")
+		prNumber             = flag.Int("pr-number", 0, "PR number to label (required if not --dry-run)")
+		githubToken          = flag.String("github-token", "", "GitHub token (required if not --dry-run)")
+		repo                 = flag.String("repo", "", "GitHub repository in owner/repo format (required if not --dry-run)")
+		clusterLabels        = flag.Bool("cluster-labels", false, "Include cluster/<name> labels in addition to environment labels")
+		logFile              = flag.String("log-file", "", "Write debug-level logs to this file (in addition to INFO-level logs on stdout)")
+		enforceRingDeploy    = flag.Bool("enforce-ring-deployment", false, "Fail when both staging and production overlays are directly modified in the same PR")
+		ringReportFile       = flag.String("ring-report-file", "", "Write ring deployment check result (markdown) to this file for external consumers like PR comments")
 	)
 	flag.Parse()
 
@@ -136,15 +139,32 @@ func main() {
 
 	printSummary(result, labels, headSHA, baseSHA)
 
-	if *dryRun {
-		return
+	if !*dryRun {
+		// Step 5: Sync labels via GitHub API
+		slog.Info("Syncing labels...")
+		if err := syncLabels(ctx, *githubToken, *repo, *prNumber, labels); err != nil {
+			fatal("syncing labels", "err", err)
+		}
 	}
 
-	// Step 5: Sync labels via GitHub API
-	slog.Info("Syncing labels...")
-	if err := syncLabels(ctx, *githubToken, *repo, *prNumber, labels); err != nil {
-		fatal("syncing labels", "err", err)
+	// Step 6: Ring deployment enforcement (runs in both dry-run and normal mode)
+	if *enforceRingDeploy {
+		ringResult := detector.CheckRingDeployment(changedFiles, result.AffectedEnvironments)
+		if ringResult.DirectConflict {
+			msg := formatRingViolation(ringResult)
+			fmt.Println(msg)
+			writeStepSummary(msg)
+			writeReportFile(*ringReportFile, msg)
+			os.Exit(1)
+		}
+		if ringResult.IndirectConflict {
+			msg := formatRingWarning()
+			fmt.Println(msg)
+			writeStepSummary(msg)
+			writeReportFile(*ringReportFile, msg)
+		}
 	}
+
 	slog.Info("Done!")
 }
 
@@ -277,4 +297,63 @@ func syncLabels(ctx context.Context, token, repoName string, prNumber int, label
 		return err
 	}
 	return client.SyncLabels(ctx, prNumber, labels)
+}
+
+// formatRingViolation returns a markdown message for a direct staging+production conflict.
+func formatRingViolation(r *detector.RingCheckResult) string {
+	var b strings.Builder
+	b.WriteString("\n## Ring Deployment Violation\n\n")
+	b.WriteString("This PR modifies both **staging** and **production** overlays, which violates the ring deployment policy.\n")
+	b.WriteString("Changes must be validated in staging before promoting to production.\n\n")
+	b.WriteString("Please split this PR into two:\n")
+	b.WriteString("1. First PR: staging changes only\n")
+	b.WriteString("2. Second PR: production changes (after staging is validated)\n")
+
+	b.WriteString("\n### Staging files\n")
+	for _, f := range r.StagingFiles {
+		fmt.Fprintf(&b, "- `%s`\n", f)
+	}
+	b.WriteString("\n### Production files\n")
+	for _, f := range r.ProductionFiles {
+		fmt.Fprintf(&b, "- `%s`\n", f)
+	}
+	return b.String()
+}
+
+// formatRingWarning returns a markdown message for an indirect (base-only) conflict.
+func formatRingWarning() string {
+	var b strings.Builder
+	b.WriteString("\n## Ring Deployment Warning\n\n")
+	b.WriteString("This PR modifies shared base files that affect both **staging** and **production** environments.\n\n")
+	b.WriteString("If possible, split this PR into two:\n")
+	b.WriteString("1. First PR: staging changes only\n")
+	b.WriteString("2. Second PR: revert staging-only changes and apply changes to the shared base files (after staging is validated)\n\n")
+	b.WriteString("If this is not possible, **excercise extreme caution**!\n")
+	return b.String()
+}
+
+// writeReportFile writes markdown to a report file for use by external
+// consumers (e.g. a workflow step that posts a PR comment).
+func writeReportFile(path, markdown string) {
+	if path == "" {
+		return
+	}
+	if err := os.WriteFile(path, []byte(markdown), 0600); err != nil {
+		slog.Warn("failed to write ring report file", "path", path, "err", err)
+	}
+}
+
+// writeStepSummary appends markdown to the GitHub Actions step summary file.
+func writeStepSummary(markdown string) {
+	summaryFile := os.Getenv("GITHUB_STEP_SUMMARY")
+	if summaryFile == "" {
+		return
+	}
+	f, err := os.OpenFile(summaryFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		slog.Warn("failed to open GITHUB_STEP_SUMMARY", "err", err)
+		return
+	}
+	defer f.Close()
+	fmt.Fprintln(f, markdown)
 }

--- a/infra-tools/internal/detector/ring.go
+++ b/infra-tools/internal/detector/ring.go
@@ -1,0 +1,77 @@
+package detector
+
+import (
+	"sort"
+	"strings"
+)
+
+// segmentEnvironment maps directory names that appear as path segments to
+// their environment. This covers both component overlay directories (e.g.
+// staging/, production/) and ArgoCD overlay directories (e.g.
+// konflux-public-staging/).
+var segmentEnvironment = map[string]Environment{
+	"staging":                   Staging,
+	"staging-downstream":        Staging,
+	"konflux-public-staging":    Staging,
+	"production":                Production,
+	"production-downstream":     Production,
+	"konflux-public-production": Production,
+}
+
+// RingCheckResult holds the outcome of the ring deployment validation.
+type RingCheckResult struct {
+	// DirectConflict is true when changed files directly modify both staging
+	// and production overlay directories in the same PR.
+	DirectConflict bool
+	// IndirectConflict is true when both environments are affected (via
+	// kustomize dependency trees) but no changed file directly lives in
+	// both a staging and a production overlay directory.
+	IndirectConflict bool
+	// StagingFiles lists changed files that directly belong to staging overlays.
+	StagingFiles []string
+	// ProductionFiles lists changed files that directly belong to production overlays.
+	ProductionFiles []string
+}
+
+// CheckRingDeployment determines whether a set of changed files violates the
+// ring deployment policy.
+//
+// A direct conflict means files under both staging and production directories
+// are modified — the PR must be split. An indirect conflict means both
+// environments are affected (per the detector's kustomize analysis) but only
+// through shared base files — this is allowed with a warning.
+func CheckRingDeployment(changedFiles []string, affectedEnvs map[Environment]bool) *RingCheckResult {
+	result := &RingCheckResult{}
+
+	for _, f := range changedFiles {
+		switch ClassifyFileEnv(f) {
+		case Staging:
+			result.StagingFiles = append(result.StagingFiles, f)
+		case Production:
+			result.ProductionFiles = append(result.ProductionFiles, f)
+		}
+	}
+
+	sort.Strings(result.StagingFiles)
+	sort.Strings(result.ProductionFiles)
+
+	if len(result.StagingFiles) > 0 && len(result.ProductionFiles) > 0 {
+		result.DirectConflict = true
+	} else if affectedEnvs[Staging] && affectedEnvs[Production] {
+		result.IndirectConflict = true
+	}
+
+	return result
+}
+
+// ClassifyFileEnv returns the environment a file directly belongs to based
+// on its path segments, or "" if the file is not in an environment-specific
+// overlay directory.
+func ClassifyFileEnv(path string) Environment {
+	for _, segment := range strings.Split(path, "/") {
+		if env, ok := segmentEnvironment[segment]; ok {
+			return env
+		}
+	}
+	return ""
+}

--- a/infra-tools/internal/detector/ring_test.go
+++ b/infra-tools/internal/detector/ring_test.go
@@ -1,0 +1,302 @@
+package detector_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/redhat-appstudio/infra-deployments/infra-tools/internal/detector"
+)
+
+// ---------------------------------------------------------------------------
+// ClassifyFileEnv
+// ---------------------------------------------------------------------------
+
+func TestClassifyFileEnv_StagingComponent(t *testing.T) {
+	g := NewWithT(t)
+	g.Expect(detector.ClassifyFileEnv("components/build-service/staging/base/deploy.yaml")).To(Equal(detector.Staging))
+}
+
+func TestClassifyFileEnv_ProductionComponent(t *testing.T) {
+	g := NewWithT(t)
+	g.Expect(detector.ClassifyFileEnv("components/build-service/production/base/deploy.yaml")).To(Equal(detector.Production))
+}
+
+func TestClassifyFileEnv_StagingDownstream(t *testing.T) {
+	g := NewWithT(t)
+	g.Expect(detector.ClassifyFileEnv("components/multi-platform-controller/staging-downstream/kustomization.yaml")).To(Equal(detector.Staging))
+}
+
+func TestClassifyFileEnv_ProductionDownstream(t *testing.T) {
+	g := NewWithT(t)
+	g.Expect(detector.ClassifyFileEnv("components/multi-platform-controller/production-downstream/kustomization.yaml")).To(Equal(detector.Production))
+}
+
+func TestClassifyFileEnv_NestedStagingComponent(t *testing.T) {
+	g := NewWithT(t)
+	g.Expect(detector.ClassifyFileEnv("components/monitoring/grafana/staging/base/datasources.yaml")).To(Equal(detector.Staging))
+}
+
+func TestClassifyFileEnv_NestedProductionComponent(t *testing.T) {
+	g := NewWithT(t)
+	g.Expect(detector.ClassifyFileEnv("components/monitoring/prometheus/production/base/monitoringstack/endpoints-params.yaml")).To(Equal(detector.Production))
+}
+
+func TestClassifyFileEnv_ArgoCDOverlayStagingDownstream(t *testing.T) {
+	g := NewWithT(t)
+	g.Expect(detector.ClassifyFileEnv("argo-cd-apps/overlays/staging-downstream/kustomization.yaml")).To(Equal(detector.Staging))
+}
+
+func TestClassifyFileEnv_ArgoCDOverlayKonfluxPublicProduction(t *testing.T) {
+	g := NewWithT(t)
+	g.Expect(detector.ClassifyFileEnv("argo-cd-apps/overlays/konflux-public-production/production-overlay-patch.yaml")).To(Equal(detector.Production))
+}
+
+func TestClassifyFileEnv_ArgoCDOverlayKonfluxPublicStaging(t *testing.T) {
+	g := NewWithT(t)
+	g.Expect(detector.ClassifyFileEnv("argo-cd-apps/overlays/konflux-public-staging/kustomization.yaml")).To(Equal(detector.Staging))
+}
+
+func TestClassifyFileEnv_BaseFile(t *testing.T) {
+	g := NewWithT(t)
+	g.Expect(detector.ClassifyFileEnv("components/build-service/base/deploy.yaml")).To(Equal(detector.Environment("")))
+}
+
+func TestClassifyFileEnv_RootFile(t *testing.T) {
+	g := NewWithT(t)
+	g.Expect(detector.ClassifyFileEnv("README.md")).To(Equal(detector.Environment("")))
+}
+
+func TestClassifyFileEnv_DevelopmentFile(t *testing.T) {
+	g := NewWithT(t)
+	g.Expect(detector.ClassifyFileEnv("components/build-service/development/kustomization.yaml")).To(Equal(detector.Environment("")))
+}
+
+func TestClassifyFileEnv_ConfigsDir(t *testing.T) {
+	g := NewWithT(t)
+	g.Expect(detector.ClassifyFileEnv("configs/etcd-defrag/staging/config.yaml")).To(Equal(detector.Staging))
+}
+
+// ---------------------------------------------------------------------------
+// CheckRingDeployment — direct conflict
+// ---------------------------------------------------------------------------
+
+func TestCheckRingDeployment_DirectConflict(t *testing.T) {
+	g := NewWithT(t)
+
+	changed := []string{
+		"components/build-service/staging/base/deploy.yaml",
+		"components/build-service/production/base/deploy.yaml",
+	}
+	affected := map[detector.Environment]bool{detector.Staging: true, detector.Production: true}
+
+	result := detector.CheckRingDeployment(changed, affected)
+
+	g.Expect(result.DirectConflict).To(BeTrue())
+	g.Expect(result.IndirectConflict).To(BeFalse())
+	g.Expect(result.StagingFiles).To(ConsistOf("components/build-service/staging/base/deploy.yaml"))
+	g.Expect(result.ProductionFiles).To(ConsistOf("components/build-service/production/base/deploy.yaml"))
+}
+
+func TestCheckRingDeployment_DirectConflictMixedComponents(t *testing.T) {
+	g := NewWithT(t)
+
+	changed := []string{
+		"components/integration/staging/base/kustomization.yaml",
+		"components/pipeline-service/production/base/kustomization.yaml",
+	}
+	affected := map[detector.Environment]bool{detector.Staging: true, detector.Production: true}
+
+	result := detector.CheckRingDeployment(changed, affected)
+
+	g.Expect(result.DirectConflict).To(BeTrue())
+	g.Expect(result.StagingFiles).To(HaveLen(1))
+	g.Expect(result.ProductionFiles).To(HaveLen(1))
+}
+
+func TestCheckRingDeployment_DirectConflictDownstream(t *testing.T) {
+	g := NewWithT(t)
+
+	changed := []string{
+		"components/multi-platform-controller/staging-downstream/kustomization.yaml",
+		"components/multi-platform-controller/production-downstream/kustomization.yaml",
+	}
+	affected := map[detector.Environment]bool{detector.Staging: true, detector.Production: true}
+
+	result := detector.CheckRingDeployment(changed, affected)
+
+	g.Expect(result.DirectConflict).To(BeTrue())
+}
+
+func TestCheckRingDeployment_DirectConflictArgoCDOverlays(t *testing.T) {
+	g := NewWithT(t)
+
+	changed := []string{
+		"argo-cd-apps/overlays/konflux-public-staging/kustomization.yaml",
+		"argo-cd-apps/overlays/konflux-public-production/production-overlay-patch.yaml",
+	}
+	affected := map[detector.Environment]bool{detector.Staging: true, detector.Production: true}
+
+	result := detector.CheckRingDeployment(changed, affected)
+
+	g.Expect(result.DirectConflict).To(BeTrue())
+}
+
+func TestCheckRingDeployment_DirectConflictNestedComponent(t *testing.T) {
+	g := NewWithT(t)
+
+	changed := []string{
+		"components/monitoring/grafana/staging/base/datasources.yaml",
+		"components/monitoring/prometheus/production/base/endpoints-params.yaml",
+	}
+	affected := map[detector.Environment]bool{detector.Staging: true, detector.Production: true}
+
+	result := detector.CheckRingDeployment(changed, affected)
+
+	g.Expect(result.DirectConflict).To(BeTrue())
+}
+
+// ---------------------------------------------------------------------------
+// CheckRingDeployment — indirect conflict (base-only changes)
+// ---------------------------------------------------------------------------
+
+func TestCheckRingDeployment_IndirectConflict(t *testing.T) {
+	g := NewWithT(t)
+
+	changed := []string{
+		"components/build-service/base/deploy.yaml",
+	}
+	affected := map[detector.Environment]bool{detector.Staging: true, detector.Production: true}
+
+	result := detector.CheckRingDeployment(changed, affected)
+
+	g.Expect(result.DirectConflict).To(BeFalse())
+	g.Expect(result.IndirectConflict).To(BeTrue())
+	g.Expect(result.StagingFiles).To(BeEmpty())
+	g.Expect(result.ProductionFiles).To(BeEmpty())
+}
+
+func TestCheckRingDeployment_IndirectConflictMultipleBaseFiles(t *testing.T) {
+	g := NewWithT(t)
+
+	changed := []string{
+		"components/build-service/base/deploy.yaml",
+		"components/build-service/base/rbac.yaml",
+		"components/integration/base/kustomization.yaml",
+	}
+	affected := map[detector.Environment]bool{detector.Staging: true, detector.Production: true}
+
+	result := detector.CheckRingDeployment(changed, affected)
+
+	g.Expect(result.DirectConflict).To(BeFalse())
+	g.Expect(result.IndirectConflict).To(BeTrue())
+}
+
+// ---------------------------------------------------------------------------
+// CheckRingDeployment — staging-only (no conflict)
+// ---------------------------------------------------------------------------
+
+func TestCheckRingDeployment_StagingOnly(t *testing.T) {
+	g := NewWithT(t)
+
+	changed := []string{
+		"components/build-service/staging/base/deploy.yaml",
+		"components/build-service/staging/stone-stage-p01/patch.yaml",
+	}
+	affected := map[detector.Environment]bool{detector.Staging: true}
+
+	result := detector.CheckRingDeployment(changed, affected)
+
+	g.Expect(result.DirectConflict).To(BeFalse())
+	g.Expect(result.IndirectConflict).To(BeFalse())
+	g.Expect(result.StagingFiles).To(HaveLen(2))
+	g.Expect(result.ProductionFiles).To(BeEmpty())
+}
+
+// ---------------------------------------------------------------------------
+// CheckRingDeployment — production-only (no conflict)
+// ---------------------------------------------------------------------------
+
+func TestCheckRingDeployment_ProductionOnly(t *testing.T) {
+	g := NewWithT(t)
+
+	changed := []string{
+		"components/build-service/production/base/deploy.yaml",
+		"components/build-service/production/kflux-ocp-p01/patch.yaml",
+	}
+	affected := map[detector.Environment]bool{detector.Production: true}
+
+	result := detector.CheckRingDeployment(changed, affected)
+
+	g.Expect(result.DirectConflict).To(BeFalse())
+	g.Expect(result.IndirectConflict).To(BeFalse())
+	g.Expect(result.StagingFiles).To(BeEmpty())
+	g.Expect(result.ProductionFiles).To(HaveLen(2))
+}
+
+// ---------------------------------------------------------------------------
+// CheckRingDeployment — no environment affected
+// ---------------------------------------------------------------------------
+
+func TestCheckRingDeployment_NoEnvsAffected(t *testing.T) {
+	g := NewWithT(t)
+
+	changed := []string{"README.md", "docs/introduction/index.md"}
+	affected := map[detector.Environment]bool{}
+
+	result := detector.CheckRingDeployment(changed, affected)
+
+	g.Expect(result.DirectConflict).To(BeFalse())
+	g.Expect(result.IndirectConflict).To(BeFalse())
+	g.Expect(result.StagingFiles).To(BeEmpty())
+	g.Expect(result.ProductionFiles).To(BeEmpty())
+}
+
+// ---------------------------------------------------------------------------
+// CheckRingDeployment — staging direct + production indirect (no direct conflict)
+// ---------------------------------------------------------------------------
+
+func TestCheckRingDeployment_StagingDirectProductionIndirect(t *testing.T) {
+	g := NewWithT(t)
+
+	changed := []string{
+		"components/build-service/staging/base/deploy.yaml",
+		"components/build-service/base/common.yaml",
+	}
+	affected := map[detector.Environment]bool{detector.Staging: true, detector.Production: true}
+
+	result := detector.CheckRingDeployment(changed, affected)
+
+	g.Expect(result.DirectConflict).To(BeFalse(), "only staging files are directly changed; production is only indirectly affected")
+	g.Expect(result.IndirectConflict).To(BeTrue())
+	g.Expect(result.StagingFiles).To(HaveLen(1))
+	g.Expect(result.ProductionFiles).To(BeEmpty())
+}
+
+// ---------------------------------------------------------------------------
+// CheckRingDeployment — output is sorted
+// ---------------------------------------------------------------------------
+
+func TestCheckRingDeployment_OutputSorted(t *testing.T) {
+	g := NewWithT(t)
+
+	changed := []string{
+		"components/z-service/staging/b.yaml",
+		"components/a-service/staging/a.yaml",
+		"components/z-service/production/b.yaml",
+		"components/a-service/production/a.yaml",
+	}
+	affected := map[detector.Environment]bool{detector.Staging: true, detector.Production: true}
+
+	result := detector.CheckRingDeployment(changed, affected)
+
+	g.Expect(result.DirectConflict).To(BeTrue())
+	g.Expect(result.StagingFiles).To(Equal([]string{
+		"components/a-service/staging/a.yaml",
+		"components/z-service/staging/b.yaml",
+	}))
+	g.Expect(result.ProductionFiles).To(Equal([]string{
+		"components/a-service/production/a.yaml",
+		"components/z-service/production/b.yaml",
+	}))
+}


### PR DESCRIPTION
Our end goal is to implement ring deployment where ring 0 is stage.
Changes must be validated in staging before they can be promoted to production.

As an early step towards this goal, this change adds a new GH Action that checks if a PR is modifying both staging and production overlays at the same time.

The PR also has the policy document: docs/deployment/ring-deployment.md

| PR scope  | Action output |
| ------------- | ------------- |
| staging only  | Passes  |
| prod only  | Passes  |
| base files | Passes with warning |
| stage & prod | Fails with message |

Examples can be seen here:
https://github.com/p8r-the-gr8/infra-deployments/pulls