### PR TITLE
Increase resources for artifact-registry-proxy in staging

### DIFF
--- a/components/squid/staging/squid-helm-generator.yaml
+++ b/components/squid/staging/squid-helm-generator.yaml
@@ -32,10 +32,10 @@ valuesInline:
       size: 51200
     resources:
       requests:
-        cpu: 100m
-        memory: 128Mi
+        cpu: "2"
+        memory: 2Gi
       limits:
-        cpu: 200m
+        cpu: "2"
         memory: 2Gi
   test:
     enabled: false


### PR DESCRIPTION
This also sets memory requests==limits which is a best practice for scheduling purposes.