### PR TITLE
KFLUXINFRA-3652 Restrict serviceaccounts/token to approved SAs

### DIFF
--- a/components/konflux-rbac/production/base/konflux-admin-user-actions.yaml
+++ b/components/konflux-rbac/production/base/konflux-admin-user-actions.yaml
@@ -188,6 +188,10 @@ rules:
       - ""
     resources:
       - serviceaccounts/token
+    resourceNames:
+      - konflux-bot-0
+      - konflux-bot-1
+      - konflux-bot-2
   - verbs:
       - get
       - list

--- a/components/konflux-rbac/staging/base/konflux-admin-user-actions.yaml
+++ b/components/konflux-rbac/staging/base/konflux-admin-user-actions.yaml
@@ -188,6 +188,10 @@ rules:
       - ""
     resources:
       - serviceaccounts/token
+    resourceNames:
+      - konflux-bot-0
+      - konflux-bot-1
+      - konflux-bot-2
   - verbs:
       - get
       - list


### PR DESCRIPTION
Add resourceNames to the serviceaccounts/token rule in the konflux-admin-user-actions ClusterRole so that tenant users can only create tokens for konflux-bot-0, konflux-bot-1, and konflux-bot-2.

This prevents users from creating tokens for system service accounts and limits the set of service accounts that need to be deleted and recreated if token invalidation is required.

Made-with: Cursor