### PR TITLE
limit max token duration in prod

### DIFF
--- a/components/policies/production/base/konflux-rbac/kustomization.yaml
+++ b/components/policies/production/base/konflux-rbac/kustomization.yaml
@@ -3,6 +3,8 @@ kind: Kustomization
 resources:
 - bootstrap-tenant-namespace/
 - konflux-support-access/
+- limit-pod-serviceaccount-token-expiration/
+- limit-serviceaccount-token-expiration/
 - restrict-binding-sysauth/
 - restrict-binding-system-authenticated-releng/
 - validate-rolebindings/

--- a/components/policies/production/base/konflux-rbac/limit-pod-serviceaccount-token-expiration/.chainsaw-test/chainsaw-assert-policy.yaml
+++ b/components/policies/production/base/konflux-rbac/limit-pod-serviceaccount-token-expiration/.chainsaw-test/chainsaw-assert-policy.yaml
@@ -1,0 +1,7 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: limit-pod-serviceaccount-token-expiration.konflux-ci.dev
+status:
+  observedGeneration: 1
+  typeChecking: {}

--- a/components/policies/production/base/konflux-rbac/limit-pod-serviceaccount-token-expiration/.chainsaw-test/resources/pod_projected_token_invalid_long.yaml
+++ b/components/policies/production/base/konflux-rbac/limit-pod-serviceaccount-token-expiration/.chainsaw-test/resources/pod_projected_token_invalid_long.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: chainsaw-pod-projected-long
+spec:
+  restartPolicy: Never
+  serviceAccountName: chainsaw-test-sa
+  securityContext:
+    runAsNonRoot: true
+  containers:
+  - name: c
+    image: registry.access.redhat.com/ubi10-micro:10.1
+    command: ["sh", "-c", "exit 0"]
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop: ["ALL"]
+    volumeMounts:
+    - name: tok
+      mountPath: /var/run/secrets/tokens
+  volumes:
+  - name: tok
+    projected:
+      sources:
+      - serviceAccountToken:
+          path: token
+          expirationSeconds: 31536001
+          audience: https://kubernetes.default.svc

--- a/components/policies/production/base/konflux-rbac/limit-pod-serviceaccount-token-expiration/.chainsaw-test/resources/pod_projected_token_valid_omit.yaml
+++ b/components/policies/production/base/konflux-rbac/limit-pod-serviceaccount-token-expiration/.chainsaw-test/resources/pod_projected_token_valid_omit.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: chainsaw-pod-projected-omit
+spec:
+  restartPolicy: Never
+  serviceAccountName: chainsaw-test-sa
+  securityContext:
+    runAsNonRoot: true
+  containers:
+  - name: c
+    image: registry.access.redhat.com/ubi10-micro:10.1
+    command: ["sh", "-c", "exit 0"]
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop: ["ALL"]
+    volumeMounts:
+    - name: tok
+      mountPath: /var/run/secrets/tokens
+  volumes:
+  - name: tok
+    projected:
+      sources:
+      - serviceAccountToken:
+          path: token
+          audience: https://kubernetes.default.svc

--- a/components/policies/production/base/konflux-rbac/limit-pod-serviceaccount-token-expiration/.chainsaw-test/resources/pod_projected_token_valid_short.yaml
+++ b/components/policies/production/base/konflux-rbac/limit-pod-serviceaccount-token-expiration/.chainsaw-test/resources/pod_projected_token_valid_short.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: chainsaw-pod-projected-short
+spec:
+  restartPolicy: Never
+  serviceAccountName: chainsaw-test-sa
+  securityContext:
+    runAsNonRoot: true
+  containers:
+  - name: c
+    image: registry.access.redhat.com/ubi10-micro:10.1
+    command: ["sh", "-c", "exit 0"]
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop: ["ALL"]
+    volumeMounts:
+    - name: tok
+      mountPath: /var/run/secrets/tokens
+  volumes:
+  - name: tok
+    projected:
+      sources:
+      - serviceAccountToken:
+          path: token
+          expirationSeconds: 3600
+          audience: https://kubernetes.default.svc

--- a/components/policies/production/base/konflux-rbac/limit-pod-serviceaccount-token-expiration/.chainsaw-test/resources/serviceaccount.yaml
+++ b/components/policies/production/base/konflux-rbac/limit-pod-serviceaccount-token-expiration/.chainsaw-test/resources/serviceaccount.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: chainsaw-test-sa

--- a/components/policies/production/base/konflux-rbac/limit-pod-serviceaccount-token-expiration/.chainsaw-test/test-in-tenant/chainsaw-test.yaml
+++ b/components/policies/production/base/konflux-rbac/limit-pod-serviceaccount-token-expiration/.chainsaw-test/test-in-tenant/chainsaw-test.yaml
@@ -1,0 +1,86 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: in-tenant-allows-valid-projected-sa-token-pods
+spec:
+  description: |
+    In a tenant namespace, Pods with projected serviceAccountToken expiration at or under
+    the limit (or omitting expirationSeconds) are admitted by the pod-only VAP.
+  concurrent: false
+  steps:
+  - name: ensure-namespace-is-labeled
+    try:
+    - apply:
+        resource:
+          apiVersion: v1
+          kind: Namespace
+          metadata:
+            name: ($namespace)
+            labels:
+              konflux-ci.dev/type: tenant
+  - name: given-pod-validatingadmissionpolicy-is-installed
+    try:
+    - apply:
+        file: ../../limit-pod-serviceaccount-token-expiration-validationadmissionpolicy.yaml
+    - apply:
+        file: ../../limit-pod-serviceaccount-token-expiration-validationadmissionpolicybinding.yaml
+    - assert:
+        file: ../chainsaw-assert-policy.yaml
+    - sleep:
+        # add a delay to make sure the APIServer successfully loaded the VAP
+        # so to reduce test flakiness
+        duration: 2s
+  - name: given-serviceaccount-exists
+    try:
+    - apply:
+        file: ../resources/serviceaccount.yaml
+  - name: then-valid-projected-token-pods-are-allowed
+    try:
+    - create:
+        file: ../resources/pod_projected_token_valid_short.yaml
+    - create:
+        file: ../resources/pod_projected_token_valid_omit.yaml
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: in-tenant-denies-long-projected-serviceaccount-token
+spec:
+  description: |
+    In a tenant namespace, a Pod requesting projected serviceAccountToken expirationSeconds
+    above the policy maximum is denied by the pod-only VAP.
+  concurrent: false
+  steps:
+  - name: ensure-namespace-is-labeled
+    try:
+    - apply:
+        resource:
+          apiVersion: v1
+          kind: Namespace
+          metadata:
+            name: ($namespace)
+            labels:
+              konflux-ci.dev/type: tenant
+  - name: given-pod-validatingadmissionpolicy-is-installed
+    try:
+    - apply:
+        file: ../../limit-pod-serviceaccount-token-expiration-validationadmissionpolicy.yaml
+    - apply:
+        file: ../../limit-pod-serviceaccount-token-expiration-validationadmissionpolicybinding.yaml
+    - assert:
+        file: ../chainsaw-assert-policy.yaml
+    - sleep:
+        # add a delay to make sure the APIServer successfully loaded the VAP
+        # so to reduce test flakiness
+        duration: 2s
+  - name: given-serviceaccount-exists
+    try:
+    - apply:
+        file: ../resources/serviceaccount.yaml
+  - name: then-long-projected-token-pod-is-denied
+    try:
+    - error:
+        file: ../resources/pod_projected_token_invalid_long.yaml

--- a/components/policies/production/base/konflux-rbac/limit-pod-serviceaccount-token-expiration/.chainsaw-test/test-outside-tenant/chainsaw-test.yaml
+++ b/components/policies/production/base/konflux-rbac/limit-pod-serviceaccount-token-expiration/.chainsaw-test/test-outside-tenant/chainsaw-test.yaml
@@ -1,0 +1,32 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: outside-tenant-allows-long-projected-token
+spec:
+  description: |
+    In a namespace without the tenant label, a Pod with a long projected serviceAccountToken
+    expiration is allowed because the policy binding does not match.
+  concurrent: false
+  steps:
+  - name: given-pod-validatingadmissionpolicy-is-installed
+    try:
+    - apply:
+        file: ../../limit-pod-serviceaccount-token-expiration-validationadmissionpolicy.yaml
+    - apply:
+        file: ../../limit-pod-serviceaccount-token-expiration-validationadmissionpolicybinding.yaml
+    - assert:
+        file: ../chainsaw-assert-policy.yaml
+    - sleep:
+        # add a delay to make sure the APIServer successfully loaded the VAP
+        # so to reduce test flakiness
+        duration: 2s
+  - name: given-serviceaccount-exists
+    try:
+    - apply:
+        file: ../resources/serviceaccount.yaml
+  - name: then-long-projected-token-pod-is-allowed
+    try:
+    - create:
+        file: ../resources/pod_projected_token_invalid_long.yaml

--- a/components/policies/production/base/konflux-rbac/limit-pod-serviceaccount-token-expiration/kustomization.yaml
+++ b/components/policies/production/base/konflux-rbac/limit-pod-serviceaccount-token-expiration/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- limit-pod-serviceaccount-token-expiration-validationadmissionpolicy.yaml
+- limit-pod-serviceaccount-token-expiration-validationadmissionpolicybinding.yaml

--- a/components/policies/production/base/konflux-rbac/limit-pod-serviceaccount-token-expiration/limit-pod-serviceaccount-token-expiration-validationadmissionpolicy.yaml
+++ b/components/policies/production/base/konflux-rbac/limit-pod-serviceaccount-token-expiration/limit-pod-serviceaccount-token-expiration-validationadmissionpolicy.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: limit-pod-serviceaccount-token-expiration.konflux-ci.dev
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+    - apiGroups: [""]
+      apiVersions: ["v1"]
+      operations: ["CREATE", "UPDATE"]
+      resources: ["pods"]
+      scope: "Namespaced"
+  variables:
+  - name: maxExpirationSeconds
+    expression: "31536000"
+  validations:
+  - expression: |
+      !has(object.spec.volumes) ||
+      object.spec.volumes.all(v,
+        !has(v.projected) ||
+        !has(v.projected.sources) ||
+        v.projected.sources.all(s,
+          !has(s.serviceAccountToken) ||
+          !has(s.serviceAccountToken.expirationSeconds) ||
+          s.serviceAccountToken.expirationSeconds <= variables.maxExpirationSeconds))
+    reason: Invalid
+    message: >
+      Projected serviceAccountToken expirationSeconds may not exceed 31536000 seconds (1 year)
+      in tenant namespaces. Omit the field to use the kubelet default, or choose a shorter lifetime.

--- a/components/policies/production/base/konflux-rbac/limit-pod-serviceaccount-token-expiration/limit-pod-serviceaccount-token-expiration-validationadmissionpolicybinding.yaml
+++ b/components/policies/production/base/konflux-rbac/limit-pod-serviceaccount-token-expiration/limit-pod-serviceaccount-token-expiration-validationadmissionpolicybinding.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: limit-pod-serviceaccount-token-expiration.konflux-ci.dev
+spec:
+  policyName: limit-pod-serviceaccount-token-expiration.konflux-ci.dev
+  validationActions: [Deny]
+  matchResources:
+    namespaceSelector:
+      matchLabels:
+        konflux-ci.dev/type: tenant

--- a/components/policies/production/base/konflux-rbac/limit-serviceaccount-token-expiration/.chainsaw-test/chainsaw-assert-policy.yaml
+++ b/components/policies/production/base/konflux-rbac/limit-serviceaccount-token-expiration/.chainsaw-test/chainsaw-assert-policy.yaml
@@ -1,0 +1,7 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: limit-serviceaccount-tokenrequest-expiration.konflux-ci.dev
+status:
+  observedGeneration: 1
+  typeChecking: {}

--- a/components/policies/production/base/konflux-rbac/limit-serviceaccount-token-expiration/.chainsaw-test/resources/serviceaccount.yaml
+++ b/components/policies/production/base/konflux-rbac/limit-serviceaccount-token-expiration/.chainsaw-test/resources/serviceaccount.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: chainsaw-test-sa

--- a/components/policies/production/base/konflux-rbac/limit-serviceaccount-token-expiration/.chainsaw-test/test-in-tenant/chainsaw-test.yaml
+++ b/components/policies/production/base/konflux-rbac/limit-serviceaccount-token-expiration/.chainsaw-test/test-in-tenant/chainsaw-test.yaml
@@ -1,0 +1,96 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: in-tenant-allows-short-kubectl-create-token
+spec:
+  description: |
+    In a tenant namespace, kubectl create token with a duration at or under the limit succeeds
+    under the TokenRequest VAP.
+  concurrent: false
+  steps:
+  - name: ensure-namespace-is-labeled
+    try:
+    - apply:
+        resource:
+          apiVersion: v1
+          kind: Namespace
+          metadata:
+            name: ($namespace)
+            labels:
+              konflux-ci.dev/type: tenant
+  - name: given-tokenrequest-validatingadmissionpolicy-is-installed
+    try:
+    - apply:
+        file: ../../limit-serviceaccount-tokenrequest-expiration-validationadmissionpolicy.yaml
+    - apply:
+        file: ../../limit-serviceaccount-tokenrequest-expiration-validationadmissionpolicybinding.yaml
+    - assert:
+        file: ../chainsaw-assert-policy.yaml
+    - sleep:
+        # add a delay to make sure the APIServer successfully loaded the VAP
+        # so to reduce test flakiness
+        duration: 2s
+  - name: given-serviceaccount-exists
+    try:
+    - apply:
+        file: ../resources/serviceaccount.yaml
+  - name: then-short-duration-token-request-succeeds
+    try:
+    - script:
+        skipLogOutput: true
+        env:
+        - name: NAMESPACE
+          value: ($namespace)
+        content: kubectl create token chainsaw-test-sa -n ${NAMESPACE} --duration=3600s >/dev/null
+        check:
+          ($error): ~
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: in-tenant-denies-long-kubectl-create-token
+spec:
+  description: |
+    In a tenant namespace, kubectl create token with a duration above the policy maximum fails
+    under the TokenRequest VAP.
+  concurrent: false
+  steps:
+  - name: ensure-namespace-is-labeled
+    try:
+    - apply:
+        resource:
+          apiVersion: v1
+          kind: Namespace
+          metadata:
+            name: ($namespace)
+            labels:
+              konflux-ci.dev/type: tenant
+  - name: given-tokenrequest-validatingadmissionpolicy-is-installed
+    try:
+    - apply:
+        file: ../../limit-serviceaccount-tokenrequest-expiration-validationadmissionpolicy.yaml
+    - apply:
+        file: ../../limit-serviceaccount-tokenrequest-expiration-validationadmissionpolicybinding.yaml
+    - assert:
+        file: ../chainsaw-assert-policy.yaml
+    - sleep:
+        # add a delay to make sure the APIServer successfully loaded the VAP
+        # so to reduce test flakiness
+        duration: 2s
+  - name: given-serviceaccount-exists
+    try:
+    - apply:
+        file: ../resources/serviceaccount.yaml
+  - name: then-long-duration-token-request-is-denied
+    try:
+    - script:
+        skipLogOutput: false
+        env:
+        - name: NAMESPACE
+          value: ($namespace)
+        content: kubectl create token chainsaw-test-sa -n ${NAMESPACE} --duration=31536001s >/dev/null
+        check:
+          ($error != null): true

--- a/components/policies/production/base/konflux-rbac/limit-serviceaccount-token-expiration/.chainsaw-test/test-outside-tenant/chainsaw-test.yaml
+++ b/components/policies/production/base/konflux-rbac/limit-serviceaccount-token-expiration/.chainsaw-test/test-outside-tenant/chainsaw-test.yaml
@@ -1,0 +1,38 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: outside-tenant-allows-long-kubectl-create-token
+spec:
+  description: |
+    In a namespace without the tenant label, kubectl create token with a long duration succeeds
+    because the policy binding does not match.
+  concurrent: false
+  steps:
+  - name: given-tokenrequest-validatingadmissionpolicy-is-installed
+    try:
+    - apply:
+        file: ../../limit-serviceaccount-tokenrequest-expiration-validationadmissionpolicy.yaml
+    - apply:
+        file: ../../limit-serviceaccount-tokenrequest-expiration-validationadmissionpolicybinding.yaml
+    - assert:
+        file: ../chainsaw-assert-policy.yaml
+    - sleep:
+        # add a delay to make sure the APIServer successfully loaded the VAP
+        # so to reduce test flakiness
+        duration: 2s
+  - name: given-serviceaccount-exists
+    try:
+    - apply:
+        file: ../resources/serviceaccount.yaml
+  - name: then-long-duration-token-request-succeeds
+    try:
+    - script:
+        skipLogOutput: true
+        env:
+        - name: NAMESPACE
+          value: ($namespace)
+        content: kubectl create token chainsaw-test-sa -n ${NAMESPACE} --duration=31536001s >/dev/null
+        check:
+          ($error): ~

--- a/components/policies/production/base/konflux-rbac/limit-serviceaccount-token-expiration/kustomization.yaml
+++ b/components/policies/production/base/konflux-rbac/limit-serviceaccount-token-expiration/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- limit-serviceaccount-tokenrequest-expiration-validationadmissionpolicy.yaml
+- limit-serviceaccount-tokenrequest-expiration-validationadmissionpolicybinding.yaml

--- a/components/policies/production/base/konflux-rbac/limit-serviceaccount-token-expiration/limit-serviceaccount-tokenrequest-expiration-validationadmissionpolicy.yaml
+++ b/components/policies/production/base/konflux-rbac/limit-serviceaccount-token-expiration/limit-serviceaccount-tokenrequest-expiration-validationadmissionpolicy.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: limit-serviceaccount-tokenrequest-expiration.konflux-ci.dev
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+    - apiGroups: [""]
+      apiVersions: ["v1"]
+      operations: ["CREATE"]
+      resources: ["serviceaccounts/token"]
+      scope: "Namespaced"
+  variables:
+  - name: maxExpirationSeconds
+    expression: "31536000"
+  validations:
+  - expression: |
+      !has(object.spec.expirationSeconds) ||
+      object.spec.expirationSeconds <= variables.maxExpirationSeconds
+    reason: Invalid
+    messageExpression: |
+      "Requested service account token expirationSeconds may not exceed " +
+      string(variables.maxExpirationSeconds) +
+      " seconds (1 year). Omit the field to use the API default, or choose a shorter lifetime."

--- a/components/policies/production/base/konflux-rbac/limit-serviceaccount-token-expiration/limit-serviceaccount-tokenrequest-expiration-validationadmissionpolicybinding.yaml
+++ b/components/policies/production/base/konflux-rbac/limit-serviceaccount-token-expiration/limit-serviceaccount-tokenrequest-expiration-validationadmissionpolicybinding.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: limit-serviceaccount-tokenrequest-expiration.konflux-ci.dev
+spec:
+  policyName: limit-serviceaccount-tokenrequest-expiration.konflux-ci.dev
+  validationActions: [Deny]
+  matchResources:
+    namespaceSelector:
+      matchLabels:
+        konflux-ci.dev/type: tenant


### PR DESCRIPTION
This change promotes #11374 to all production clusters.

Once this is merged, it won't be possible anymore to mint tokens with expiration longer than 1y in tenant namespaces.

Signed-off-by: Francesco Ilario <filario@redhat.com>

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED
