### PR TITLE
forbid new long-lived legacy tokens in prod

### DIFF
--- a/components/policies/production/base/konflux-rbac/deny-serviceaccount-token-secrets/.chainsaw-test/chainsaw-assert-policy.yaml
+++ b/components/policies/production/base/konflux-rbac/deny-serviceaccount-token-secrets/.chainsaw-test/chainsaw-assert-policy.yaml
@@ -1,0 +1,7 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: deny-serviceaccount-token-secrets.konflux-ci.dev
+status:
+  observedGeneration: 1
+  typeChecking: {}

--- a/components/policies/production/base/konflux-rbac/deny-serviceaccount-token-secrets/.chainsaw-test/resources/secret_legacy_serviceaccount_token.yaml
+++ b/components/policies/production/base/konflux-rbac/deny-serviceaccount-token-secrets/.chainsaw-test/resources/secret_legacy_serviceaccount_token.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: chainsaw-legacy-sa-token-secret
+  annotations:
+    kubernetes.io/service-account.name: chainsaw-token-test
+type: kubernetes.io/service-account-token

--- a/components/policies/production/base/konflux-rbac/deny-serviceaccount-token-secrets/.chainsaw-test/resources/secret_opaque.yaml
+++ b/components/policies/production/base/konflux-rbac/deny-serviceaccount-token-secrets/.chainsaw-test/resources/secret_opaque.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: chainsaw-opaque-secret
+type: Opaque
+stringData:
+  key: value

--- a/components/policies/production/base/konflux-rbac/deny-serviceaccount-token-secrets/.chainsaw-test/resources/serviceaccount.yaml
+++ b/components/policies/production/base/konflux-rbac/deny-serviceaccount-token-secrets/.chainsaw-test/resources/serviceaccount.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: chainsaw-token-test

--- a/components/policies/production/base/konflux-rbac/deny-serviceaccount-token-secrets/.chainsaw-test/test-in-tenant/README.md
+++ b/components/policies/production/base/konflux-rbac/deny-serviceaccount-token-secrets/.chainsaw-test/test-in-tenant/README.md
@@ -1,0 +1,105 @@
+# Test: `in-tenant-create-opaque-secret-allowed`
+
+Creates an Opaque Secret in a tenant namespace while the policy is active.
+
+
+## Steps
+
+| # | Name | Bindings | Try | Catch | Finally | Cleanup |
+|:-:|---|:-:|:-:|:-:|:-:|:-:|
+| 1 | [ensure-namespace-is-labeled](#step-ensure-namespace-is-labeled) | 0 | 1 | 0 | 0 | 0 |
+| 2 | [given-validatingadmissionpolicy-is-installed](#step-given-validatingadmissionpolicy-is-installed) | 0 | 3 | 0 | 0 | 0 |
+| 3 | [then-opaque-secret-can-be-created](#step-then-opaque-secret-can-be-created) | 0 | 1 | 0 | 0 | 0 |
+
+### Step: `ensure-namespace-is-labeled`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `given-validatingadmissionpolicy-is-installed`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+| 2 | `apply` | 0 | 0 | *No description* |
+| 3 | `assert` | 0 | 0 | *No description* |
+
+### Step: `then-opaque-secret-can-be-created`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `create` | 0 | 0 | *No description* |
+
+---
+
+# Test: `in-tenant-deny-legacy-serviceaccount-token-secret`
+
+Fails to create a Secret of type kubernetes.io/service-account-token in a tenant namespace.
+
+
+## Steps
+
+| # | Name | Bindings | Try | Catch | Finally | Cleanup |
+|:-:|---|:-:|:-:|:-:|:-:|:-:|
+| 1 | [ensure-namespace-is-labeled](#step-ensure-namespace-is-labeled) | 0 | 1 | 0 | 0 | 0 |
+| 2 | [given-validatingadmissionpolicy-is-installed](#step-given-validatingadmissionpolicy-is-installed) | 0 | 3 | 0 | 0 | 0 |
+| 3 | [given-serviceaccount-exists](#step-given-serviceaccount-exists) | 0 | 1 | 0 | 0 | 0 |
+| 4 | [then-legacy-sa-token-secret-can-not-be-created](#step-then-legacy-sa-token-secret-can-not-be-created) | 0 | 1 | 0 | 0 | 0 |
+
+### Step: `ensure-namespace-is-labeled`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `given-validatingadmissionpolicy-is-installed`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+| 2 | `apply` | 0 | 0 | *No description* |
+| 3 | `assert` | 0 | 0 | *No description* |
+
+### Step: `given-serviceaccount-exists`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `create` | 0 | 0 | *No description* |
+
+### Step: `then-legacy-sa-token-secret-can-not-be-created`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `error` | 0 | 0 | *No description* |
+
+---
+

--- a/components/policies/production/base/konflux-rbac/deny-serviceaccount-token-secrets/.chainsaw-test/test-in-tenant/chainsaw-test.yaml
+++ b/components/policies/production/base/konflux-rbac/deny-serviceaccount-token-secrets/.chainsaw-test/test-in-tenant/chainsaw-test.yaml
@@ -1,0 +1,70 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: in-tenant-create-opaque-secret-allowed
+spec:
+  description: |
+    Creates an Opaque Secret in a tenant namespace while the policy is active.
+  concurrent: false
+  steps:
+  - name: ensure-namespace-is-labeled
+    try:
+    - apply:
+        resource:
+          apiVersion: v1
+          kind: Namespace
+          metadata:
+            name: ($namespace)
+            labels:
+              konflux-ci.dev/type: tenant
+  - name: given-validatingadmissionpolicy-is-installed
+    try:
+    - apply:
+        file: ../../deny-serviceaccount-token-secrets-validationadmissionpolicy.yaml
+    - apply:
+        file: ../../deny-serviceaccount-token-secrets-validationadmissionpolicybinding.yaml
+    - assert:
+        file: ../chainsaw-assert-policy.yaml
+  - name: then-opaque-secret-can-be-created
+    try:
+    - create:
+        file: ../resources/secret_opaque.yaml
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: in-tenant-deny-legacy-serviceaccount-token-secret
+spec:
+  description: |
+    Fails to create a Secret of type kubernetes.io/service-account-token in a tenant namespace.
+  concurrent: false
+  steps:
+  - name: ensure-namespace-is-labeled
+    try:
+    - apply:
+        resource:
+          apiVersion: v1
+          kind: Namespace
+          metadata:
+            name: ($namespace)
+            labels:
+              konflux-ci.dev/type: tenant
+  - name: given-validatingadmissionpolicy-is-installed
+    try:
+    - apply:
+        file: ../../deny-serviceaccount-token-secrets-validationadmissionpolicy.yaml
+    - apply:
+        file: ../../deny-serviceaccount-token-secrets-validationadmissionpolicybinding.yaml
+    - assert:
+        file: ../chainsaw-assert-policy.yaml
+  - name: given-serviceaccount-exists
+    try:
+    - create:
+        file: ../resources/serviceaccount.yaml
+  - name: then-legacy-sa-token-secret-can-not-be-created
+    try:
+    - error:
+        file: ../resources/secret_legacy_serviceaccount_token.yaml

--- a/components/policies/production/base/konflux-rbac/deny-serviceaccount-token-secrets/.chainsaw-test/test-outside-tenant/README.md
+++ b/components/policies/production/base/konflux-rbac/deny-serviceaccount-token-secrets/.chainsaw-test/test-outside-tenant/README.md
@@ -1,0 +1,48 @@
+# Test: `outside-tenant-create-legacy-serviceaccount-token-secret-allowed`
+
+Creates a Secret of type kubernetes.io/service-account-token in a namespace that is not
+labeled as a tenant; the binding must not apply.
+
+
+## Steps
+
+| # | Name | Bindings | Try | Catch | Finally | Cleanup |
+|:-:|---|:-:|:-:|:-:|:-:|:-:|
+| 1 | [given-validatingadmissionpolicy-is-installed](#step-given-validatingadmissionpolicy-is-installed) | 0 | 3 | 0 | 0 | 0 |
+| 2 | [given-serviceaccount-exists](#step-given-serviceaccount-exists) | 0 | 1 | 0 | 0 | 0 |
+| 3 | [then-legacy-sa-token-secret-can-be-created](#step-then-legacy-sa-token-secret-can-be-created) | 0 | 1 | 0 | 0 | 0 |
+
+### Step: `given-validatingadmissionpolicy-is-installed`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+| 2 | `apply` | 0 | 0 | *No description* |
+| 3 | `assert` | 0 | 0 | *No description* |
+
+### Step: `given-serviceaccount-exists`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `create` | 0 | 0 | *No description* |
+
+### Step: `then-legacy-sa-token-secret-can-be-created`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `create` | 0 | 0 | *No description* |
+
+---
+

--- a/components/policies/production/base/konflux-rbac/deny-serviceaccount-token-secrets/.chainsaw-test/test-outside-tenant/chainsaw-test.yaml
+++ b/components/policies/production/base/konflux-rbac/deny-serviceaccount-token-secrets/.chainsaw-test/test-outside-tenant/chainsaw-test.yaml
@@ -1,0 +1,28 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: outside-tenant-create-legacy-serviceaccount-token-secret-allowed
+spec:
+  description: |
+    Creates a Secret of type kubernetes.io/service-account-token in a namespace that is not
+    labeled as a tenant; the binding must not apply.
+  concurrent: false
+  steps:
+  - name: given-validatingadmissionpolicy-is-installed
+    try:
+    - apply:
+        file: ../../deny-serviceaccount-token-secrets-validationadmissionpolicy.yaml
+    - apply:
+        file: ../../deny-serviceaccount-token-secrets-validationadmissionpolicybinding.yaml
+    - assert:
+        file: ../chainsaw-assert-policy.yaml
+  - name: given-serviceaccount-exists
+    try:
+    - create:
+        file: ../resources/serviceaccount.yaml
+  - name: then-legacy-sa-token-secret-can-be-created
+    try:
+    - create:
+        file: ../resources/secret_legacy_serviceaccount_token.yaml

--- a/components/policies/production/base/konflux-rbac/deny-serviceaccount-token-secrets/deny-serviceaccount-token-secrets-validationadmissionpolicy.yaml
+++ b/components/policies/production/base/konflux-rbac/deny-serviceaccount-token-secrets/deny-serviceaccount-token-secrets-validationadmissionpolicy.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: deny-serviceaccount-token-secrets.konflux-ci.dev
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+    - apiGroups: [""]
+      apiVersions: ["v1"]
+      operations: ["CREATE"]
+      resources: ["secrets"]
+      scope: "Namespaced"
+  validations:
+  - expression: '!has(object.type) || object.type != "kubernetes.io/service-account-token"'
+    reason: Forbidden
+    message: >
+      Creating Secrets of type kubernetes.io/service-account-token is not allowed in tenant
+      namespaces. Use projected service account tokens, the TokenRequest API, or
+      `kubectl create token` instead of long-lived legacy token Secrets.

--- a/components/policies/production/base/konflux-rbac/deny-serviceaccount-token-secrets/deny-serviceaccount-token-secrets-validationadmissionpolicybinding.yaml
+++ b/components/policies/production/base/konflux-rbac/deny-serviceaccount-token-secrets/deny-serviceaccount-token-secrets-validationadmissionpolicybinding.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: deny-serviceaccount-token-secrets.konflux-ci.dev
+spec:
+  policyName: "deny-serviceaccount-token-secrets.konflux-ci.dev"
+  validationActions: [Deny]
+  matchResources:
+    namespaceSelector:
+      matchLabels:
+        konflux-ci.dev/type: tenant

--- a/components/policies/production/base/konflux-rbac/deny-serviceaccount-token-secrets/kustomization.yaml
+++ b/components/policies/production/base/konflux-rbac/deny-serviceaccount-token-secrets/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- deny-serviceaccount-token-secrets-validationadmissionpolicy.yaml
+- deny-serviceaccount-token-secrets-validationadmissionpolicybinding.yaml

--- a/components/policies/production/base/konflux-rbac/kustomization.yaml
+++ b/components/policies/production/base/konflux-rbac/kustomization.yaml
@@ -1,6 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+- deny-serviceaccount-token-secrets/
 - bootstrap-tenant-namespace/
 - konflux-support-access/
 - restrict-binding-sysauth/


### PR DESCRIPTION
In the spirit of migrating to Short-Lived tokens, let's forbid the creation of new Long-Lived tokens in tenant namespaces.

Already existing long-lived tokens won't be impacted.

Promotes #11377 to all production clusters.

Signed-off-by: Francesco Ilario <filario@redhat.com>
