### PR TITLE
KFLUXINFRA-3503: Fix PipelineRun custom metrics config in staging

### DIFF
--- a/components/monitoring/custom-kube-state-metrics/staging/custom-resource-state-config.yaml
+++ b/components/monitoring/custom-kube-state-metrics/staging/custom-resource-state-config.yaml
@@ -71,7 +71,8 @@ data:
                 type: Gauge
                 gauge:
                   path: [metadata, deletionTimestamp]
-            - name: "konflux_pipelinerun_finalizer"
+                  nilIsZero: true
+            - name: "konflux_pipelinerun_finalizer_info"
               help: "Finalizers present on a PipelineRun. One series per finalizer; label identifies the responsible service."
               each:
                 type: Info


### PR DESCRIPTION
## What
Fix two issues in the PipelineRun custom kube-state-metrics config deployed in [#11354](https://github.com/redhat-appstudio/infra-deployments/pull/11354).
[KFLUXINFRA-3503](https://redhat.atlassian.net/browse/KFLUXINFRA-3503)

1. Add `nilIsZero: true` to `konflux_pipelinerun_deletion_timestamp_seconds` gauge
2. Rename `konflux_pipelinerun_finalizer` → `konflux_pipelinerun_finalizer_info` to follow the `_info` suffix convention

## Why
After deploying #11354 to staging (`stone-stg-rh01`), kube-state-metrics logs show **525 errors** because most PipelineRuns don't have `metadata.deletionTimestamp` set (only the 19 stuck ones do):

```
E0424 17:34:46.999496 registry_factory.go:682] "kube_customresource_konflux_pipelinerun_deletion_timestamp_seconds" err="[metadata,deletionTimestamp]: got nil while resolving path"
```

The Info metric also logs a warning about missing `_info` suffix:
```
I0424 17:34:46.804451 registry_factory.go:76] "Info metric does not have _info suffix" gvk="tekton.dev_v1_PipelineRun" name="konflux_pipelinerun_finalizer"
```

With `nilIsZero: true`, PipelineRuns without `deletionTimestamp` emit `0` instead of erroring. Stuck PipelineRuns are then filtered with `> 0` in PromQL.

## Validation
- Errors observed in pod logs on `stone-stg-rh01` (525 nil-path errors in current pod lifetime)
- `kustomize build` passes for staging
- Previous PR: #11354

## Risk Assessment
**Risk Level:** Low
**Rollback:** Revert this commit
Staging only. Config-only change, no RBAC or deployment changes.

[KFLUXINFRA-3503]: https://redhat.atlassian.net/browse/KFLUXINFRA-3503?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ