### PR TITLE
KFLUXINFRA-3503: Fix PipelineRun metrics - drop Info type, add labels

### DIFF
--- a/components/monitoring/custom-kube-state-metrics/staging/custom-resource-state-config.yaml
+++ b/components/monitoring/custom-kube-state-metrics/staging/custom-resource-state-config.yaml
@@ -64,19 +64,13 @@ data:
           labelsFromPath:
             pipelinerun: [metadata, name]
             namespace: [metadata, namespace]
+            pipeline: [metadata, labels, tekton.dev/pipeline]
+            konflux_service: [metadata, labels, appstudio.openshift.io/service]
           metrics:
             - name: "konflux_pipelinerun_deletion_timestamp_seconds"
-              help: "Unix timestamp when deletion was requested. Only emitted when deletionTimestamp is set, meaning a finalizer is blocking garbage collection."
+              help: "Unix timestamp when deletion was requested (0 = not deleted). Use > 0 to find stuck PipelineRuns."
               each:
                 type: Gauge
                 gauge:
                   path: [metadata, deletionTimestamp]
                   nilIsZero: true
-            - name: "konflux_pipelinerun_finalizer_info"
-              help: "Finalizers present on a PipelineRun. One series per finalizer; label identifies the responsible service."
-              each:
-                type: Info
-                info:
-                  path: [metadata, finalizers]
-                  labelsFromPath:
-                    finalizer: []


### PR DESCRIPTION
## What
Fix PipelineRun custom kube-state-metrics scraping in staging.
[KFLUXINFRA-3503](https://redhat.atlassian.net/browse/KFLUXINFRA-3503)

1. Remove `konflux_pipelinerun_finalizer_info` (Info type metric)
2. Add `pipeline` and `konflux_service` labels to `konflux_pipelinerun_deletion_timestamp_seconds`

## Why
The `Info` metric type (`# TYPE ... info`) is only valid in OpenMetrics format, but
kube-state-metrics v2.11.0 serves Prometheus text format (`text/plain; version=0.0.4`)
by default. Prometheus rejects the entire scrape response when it encounters
`invalid metric type "info"`, causing **all metrics** on port 8080 to stop being ingested —
including the deletion timestamp gauge and velero metrics.

Evidence from the cluster scrape target on `stone-stg-rh01`:
```
health: down
lastError: invalid metric type "info"
```

The finalizer info is replaced by adding `pipeline` and `konflux_service` labels (from PipelineRun
metadata labels) directly to the deletion timestamp gauge, providing enough context for
actionable alerts without needing a separate Info metric.

> Note: `konflux_service` is used instead of `service` to avoid collision with the Prometheus
> target `service` label, which would cause renaming to `exported_service` when `honorLabels`
> is not set on the ServiceMonitor.

### Local verification (kube-state-metrics v2.11.0 against stone-stg-rh01)
```
# Zero errors, all gauge types
$ curl -s http://localhost:8080/metrics | grep "^# TYPE"
# TYPE kube_customresource_konflux_pipelinerun_deletion_timestamp_seconds gauge
# TYPE kube_customresource_velero_schedule_paused gauge
# TYPE kube_customresource_velero_schedule_last_backup gauge

# Stuck PipelineRuns with pipeline/konflux_service labels
...{namespace="managed-release-team-tenant",pipeline="fbc-release",pipelinerun="managed-6dq8d",konflux_service="release"} 1.776877754e+09
...{namespace="managed-release-team-tenant",pipeline="rhtap-service-push",pipelinerun="managed-t52rl",konflux_service="release"} 1.777186218e+09
```

## Validation
- Local kube-state-metrics v2.11.0 tested against live cluster — zero errors, correct output
- `kustomize build` passes for staging
- Previous PRs: #11354, #11440

## Risk Assessment
**Risk Level:** Low
**Rollback:** Revert this commit
Staging only. Removes the metric that was breaking the scrape, adds labels to existing gauge.

[KFLUXINFRA-3503]: https://redhat.atlassian.net/browse/KFLUXINFRA-3503?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ