### PR TITLE
disable synchronize on queue-config CP in dev/stg

### DIFF
--- a/components/policies/development/kueue/queue-config/cluster-policy.yaml
+++ b/components/policies/development/kueue/queue-config/cluster-policy.yaml
@@ -24,7 +24,7 @@ spec:
     generate:
       generateExisting: true
       orphanDownstreamOnPolicyDelete: true
-      synchronize: true
+      synchronize: false
       apiVersion: kueue.x-k8s.io/v1beta1
       kind: LocalQueue
       name: pipelines-queue


### PR DESCRIPTION
This change is a prerequisite for #11325. It will be reverted by #11325.

cf. https://github.com/redhat-appstudio/infra-deployments/tree/main/components/policies#deletion-of-generated-resources-not-acceptable

Signed-off-by: Francesco Ilario <filario@redhat.com>

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED
