### PR TITLE
remove queue-config CP from dev/stg

### DIFF
--- a/components/policies/staging/policies/kueue/kustomization.yaml
+++ b/components/policies/staging/policies/kueue/kustomization.yaml
@@ -2,3 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - ../../../development/kueue/
+
+patchesStrategicMerge:
+  - ./patch_delete_queueconfig_clusterpolicy.yaml

--- a/components/policies/staging/policies/kueue/patch_delete_queueconfig_clusterpolicy.yaml
+++ b/components/policies/staging/policies/kueue/patch_delete_queueconfig_clusterpolicy.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: bootstrap-tenant-namespace-queue
+$patch: delete


### PR DESCRIPTION
remove queue-config CP from dev/stg

This is a prerequisite for #11325. It will be reverted from #11325.

cf. https://github.com/redhat-appstudio/infra-deployments/tree/main/components/policies#deletion-of-generated-resources-not-acceptable

Requires:
* [x] #11452

Signed-off-by: Francesco Ilario <filario@redhat.com>

