### PR TITLE
KFLUXINFRA-3503: Fix PipelineRun metric labels — replace controller with finalizers

### DIFF
--- a/components/monitoring/custom-kube-state-metrics/staging/custom-resource-state-config.yaml
+++ b/components/monitoring/custom-kube-state-metrics/staging/custom-resource-state-config.yaml
@@ -65,7 +65,7 @@ data:
             pipelinerun: [metadata, name]
             namespace: [metadata, namespace]
             pipeline: [metadata, labels, tekton.dev/pipeline]
-            controller: [metadata, labels, appstudio.openshift.io/service]
+            finalizers: [metadata, finalizers]
           metrics:
             - name: "konflux_pipelinerun_deletion_timestamp_seconds"
               help: "Unix timestamp when deletion was requested (0 = not deleted). Use > 0 to find stuck PipelineRuns."

--- a/components/monitoring/custom-kube-state-metrics/staging/custom-resource-state-config.yaml
+++ b/components/monitoring/custom-kube-state-metrics/staging/custom-resource-state-config.yaml
@@ -65,7 +65,7 @@ data:
             pipelinerun: [metadata, name]
             namespace: [metadata, namespace]
             pipeline: [metadata, labels, tekton.dev/pipeline]
-            konflux_service: [metadata, labels, appstudio.openshift.io/service]
+            controller: [metadata, labels, appstudio.openshift.io/service]
           metrics:
             - name: "konflux_pipelinerun_deletion_timestamp_seconds"
               help: "Unix timestamp when deletion was requested (0 = not deleted). Use > 0 to find stuck PipelineRuns."

--- a/components/monitoring/prometheus/staging/base/monitoringstack/writeRelabelConfigs.yaml
+++ b/components/monitoring/prometheus/staging/base/monitoringstack/writeRelabelConfigs.yaml
@@ -17,4 +17,4 @@
       policy_name|policy_background_mode|rule_type|policy_type|policy_validation_mode|\
       resource_request_operation|resource_kind|policy_change_type|event_type|\
       name|cluster_queue|quantile|slice|scrape_job|tested_registry|error|queue|\
-      priority_class|cache_status"
+      priority_class|cache_status|finalizers"


### PR DESCRIPTION
## What
[KFLUXINFRA-3503](https://redhat.atlassian.net/browse/KFLUXINFRA-3503): Replace `konflux_service`/`controller` label with `finalizers` in the custom kube-state-metrics PipelineRun metric config (staging only). Also add `finalizers` to the `LabelKeep` write relabel allow-list.

## Why
- The `konflux_service` label was stripped by the observatorium's [`LabelKeep` write relabel allow-list](https://github.com/redhat-appstudio/infra-deployments/blob/main/components/monitoring/prometheus/staging/base/monitoringstack/writeRelabelConfigs.yaml) before metrics reached Grafana.
- Renaming to `controller` (which is in the allow-list) only showed `release` or empty — not useful for identifying which controller failed.
- The `finalizers` label exposes `metadata.finalizers` directly, allowing us to identify exactly which controller failed to remove its finalizer when a PipelineRun is stuck (e.g. `[appstudio.redhat.com/release-finalizer]`).

## Validation
- Previous PRs: #11354, #11440, #11447
- Tested locally with Docker running kube-state-metrics v2.11.0 against staging cluster — confirmed `finalizers` label appears correctly as a Gauge metric
- Confirmed Prometheus accepts the metric (type `gauge`, not `info`)
- Added `finalizers` to the `LabelKeep` allow-list to ensure it passes through to Grafana
- Will verify label appears in Grafana after ArgoCD sync

## Risk Assessment
**Risk Level:** Low
**Rollback:** Revert this commit
Staging only. Changes a label name in a ConfigMap and adds one entry to the write relabel allow-list. No new resources, no RBAC changes. Pod restart required for config pickup (ArgoCD handles this).

[KFLUXINFRA-3503]: https://redhat.atlassian.net/browse/KFLUXINFRA-3503?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ