### PR TITLE
KONFLUX-13349: Increase custom-kube-state-metrics staging memory to 1Gi

### DIFF
--- a/components/monitoring/custom-kube-state-metrics/staging/resource-patch.yaml
+++ b/components/monitoring/custom-kube-state-metrics/staging/resource-patch.yaml
@@ -1,7 +1,7 @@
 ---
 - op: replace
   path: /spec/template/spec/containers/0/resources/requests/memory
-  value: 512Mi
+  value: 1Gi
 - op: replace
   path: /spec/template/spec/containers/0/resources/limits/memory
-  value: 512Mi
+  value: 1Gi


### PR DESCRIPTION
The pod is repeatedly OOMKilled at 512Mi due to high-cardinality PipelineRun metrics. Double memory to 1Gi to address the immediate crashes.