### PR TITLE
Increase artifact registry proxy resources in production

### DIFF
--- a/components/squid/production/squid-helm-generator.yaml
+++ b/components/squid/production/squid-helm-generator.yaml
@@ -32,10 +32,10 @@ valuesInline:
       size: 51200
     resources:
       requests:
-        cpu: 100m
-        memory: 128Mi
+        cpu: "2"
+        memory: 2Gi
       limits:
-        cpu: 200m
+        cpu: "2"
         memory: 2Gi
   test:
     enabled: false


### PR DESCRIPTION
**What/Why**

Increase artifact registry proxy resources in production.

This also sets memory requests==limits which is a best practice for scheduling purposes.

Assisted-by: Claude claude-opus-4-6

**Validation**

These limits allowed for _at least_ 100 parallel req/s in staging without error. Further performance testing will be performed.

**Risk Assessment**

Risk Level: Low
Description: An increase in resources should be harmless
Rollback: Revert the commit