### PR TITLE
Add kube-rbac-proxy and NetworkPolicy for tekton-ms Prometheus

### DIFF
--- a/components/monitoring/grafana/staging/tekton-ms-datasource/tekton-ms-datasource.yaml
+++ b/components/monitoring/grafana/staging/tekton-ms-datasource/tekton-ms-datasource.yaml
@@ -27,4 +27,4 @@ spec:
     secureJsonData:
       httpHeaderValue1: "Bearer ${token}"
     type: prometheus
-    url: 'https://appstudio-tekton-ms-prometheus.appstudio-tekton.svc:9090'
+    url: 'https://tekton-ms-kube-rbac-proxy.appstudio-tekton.svc:9091'

--- a/components/monitoring/prometheus/staging/stone-stage-p01/kustomization.yaml
+++ b/components/monitoring/prometheus/staging/stone-stage-p01/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
 - ../base
 - ../../base/tekton-ms
+- ../tekton-ms
 
 patches:
   - path: cluster-id-label.yaml

--- a/components/monitoring/prometheus/staging/stone-stg-rh01/kustomization.yaml
+++ b/components/monitoring/prometheus/staging/stone-stg-rh01/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
 - ../base
 - ../../base/tekton-ms
+- ../tekton-ms
 
 patches:
   - path: cluster-id-label.yaml

--- a/components/monitoring/prometheus/staging/tekton-ms/kube-rbac-proxy.yaml
+++ b/components/monitoring/prometheus/staging/tekton-ms/kube-rbac-proxy.yaml
@@ -1,0 +1,91 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: tekton-ms-kube-rbac-proxy
+  namespace: appstudio-tekton
+---
+# Required so kube-rbac-proxy can create tokenreviews and subjectaccessreviews
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: tekton-ms-kube-rbac-proxy-auth-delegator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:auth-delegator
+subjects:
+  - kind: ServiceAccount
+    name: tekton-ms-kube-rbac-proxy
+    namespace: appstudio-tekton
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tekton-ms-kube-rbac-proxy
+  namespace: appstudio-tekton
+  labels:
+    app: tekton-ms-kube-rbac-proxy
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: tekton-ms-kube-rbac-proxy
+  template:
+    metadata:
+      labels:
+        app: tekton-ms-kube-rbac-proxy
+    spec:
+      serviceAccountName: tekton-ms-kube-rbac-proxy
+      containers:
+        - name: kube-rbac-proxy
+          image: registry.redhat.io/openshift4/ose-kube-rbac-proxy:v4.15
+          args:
+            - '--secure-listen-address=0.0.0.0:9091'
+            - '--upstream=http://appstudio-tekton-ms-prometheus.appstudio-tekton.svc:9090/'
+            - '--tls-cert-file=/etc/tls/private/tls.crt'
+            - '--tls-private-key-file=/etc/tls/private/tls.key'
+            - '--logtostderr=true'
+            - '--v=3'
+          ports:
+            - containerPort: 9091
+              name: https
+          resources:
+            limits:
+              cpu: 10m
+              memory: 64Mi
+            requests:
+              cpu: 10m
+              memory: 64Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+          volumeMounts:
+            - name: tls
+              mountPath: /etc/tls/private
+              readOnly: true
+      volumes:
+        - name: tls
+          secret:
+            secretName: tekton-ms-kube-rbac-proxy-tls
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: tekton-ms-kube-rbac-proxy
+  namespace: appstudio-tekton
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: tekton-ms-kube-rbac-proxy-tls
+  labels:
+    app: tekton-ms-kube-rbac-proxy
+spec:
+  ports:
+    - name: https
+      port: 9091
+      targetPort: https
+  selector:
+    app: tekton-ms-kube-rbac-proxy

--- a/components/monitoring/prometheus/staging/tekton-ms/kustomization.yaml
+++ b/components/monitoring/prometheus/staging/tekton-ms/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - kube-rbac-proxy.yaml
+  - networkpolicy.yaml
+
+commonAnnotations:
+  argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true

--- a/components/monitoring/prometheus/staging/tekton-ms/networkpolicy.yaml
+++ b/components/monitoring/prometheus/staging/tekton-ms/networkpolicy.yaml
@@ -1,0 +1,20 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: tekton-ms-prometheus-restrict-http
+  namespace: appstudio-tekton
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/instance: appstudio-tekton-ms
+      app.kubernetes.io/name: prometheus
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app: tekton-ms-kube-rbac-proxy
+      ports:
+        - protocol: TCP
+          port: 9090


### PR DESCRIPTION
Staging only

Adds a kube-rbac-proxy sidecar that fronts the MonitoringStack Prometheus with HTTPS and bearer token authentication. A NetworkPolicy restricts direct HTTP access to Prometheus port 9090, allowing only the kube-rbac-proxy pod to connect. This ensures Prometheus metrics are only accessible through the authenticated HTTPS endpoint on port 9091.

The Grafana datasource URL is updated to point to the kube-rbac-proxy service.

Tested on development cluster.

