### PR TITLE
limit operations on restrict binding sys:auth in staging

### DIFF
--- a/components/policies/development/konflux-rbac/restrict-binding-system-authenticated-releng/.chainsaw-test/chainsaw-test.yaml
+++ b/components/policies/development/konflux-rbac/restrict-binding-system-authenticated-releng/.chainsaw-test/chainsaw-test.yaml
@@ -37,6 +37,41 @@ spec:
 apiVersion: chainsaw.kyverno.io/v1alpha1
 kind: Test
 metadata:
+  name: in-rhtap-releng-tenant-delete-existing-invalid-rolebinding
+spec:
+  description: |
+    tests that the an existing invalid RoleBinding can be deleted
+    in a tenant namespace
+  concurrent: false
+  namespace: 'rhtap-releng-tenant'
+  steps:
+  - name: given-tenant-namespace-exists
+    try:
+    - apply:
+        file: ./resources/tenant-namespace.yaml
+  - name: given-invalid-rolebindings-exists
+    try:
+    - create:
+        file: ./resources/invalid-systemauthenticated-rolebinding.yaml
+  - name: given-kyverno-has-permission-on-resources
+    try:
+    - apply:
+        file: ../kyverno_rbac.yaml
+  - name: when-cluster-policy-is-ready
+    try:
+    - apply:
+        file: ../validate-restrict-binding-system-authenticated-releng-clusterpolicy.yaml
+    - assert:
+        file: chainsaw-assert-clusterpolicy.yaml
+  - name: then-invalid-rolebindings-can-be-deleted
+    try:
+    - delete:
+        file: ./resources/invalid-systemauthenticated-rolebinding.yaml
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
   name: in-rhtap-releng-tenant-valid-rolebinding
 spec:
   description: |

--- a/components/policies/development/konflux-rbac/restrict-binding-system-authenticated-releng/validate-restrict-binding-system-authenticated-releng-clusterpolicy.yaml
+++ b/components/policies/development/konflux-rbac/restrict-binding-system-authenticated-releng/validate-restrict-binding-system-authenticated-releng-clusterpolicy.yaml
@@ -22,6 +22,9 @@ spec:
           - RoleBinding
           namespaces:
           - rhtap-releng-tenant
+          operations:
+          - CREATE
+          - UPDATE
     preconditions:
       all:
       - key: "{{ request.object.subjects[].name }}"

--- a/components/policies/development/konflux-rbac/restrict-binding-system-authenticated/.chainsaw-test/chainsaw-test.yaml
+++ b/components/policies/development/konflux-rbac/restrict-binding-system-authenticated/.chainsaw-test/chainsaw-test.yaml
@@ -37,6 +37,41 @@ spec:
 apiVersion: chainsaw.kyverno.io/v1alpha1
 kind: Test
 metadata:
+  name: in-tenant-delete-invalid-existing-rolebinding
+spec:
+  description: |
+    tests that the an existing invalid RoleBinding can be deleted
+    in a tenant namespace
+  concurrent: false
+  namespace: 'existing-invalid-sysauth-rb-tenant-namespace'
+  steps:
+  - name: given-tenant-namespace-exists
+    try:
+    - apply:
+        file: ./resources/tenant-namespace.yaml
+  - name: given-invalid-rolebinding-exists
+    try:
+    - create:
+        file: ./resources/invalid-systemauthenticated-rolebinding.yaml
+  - name: given-kyverno-has-permission-on-resources
+    try:
+    - apply:
+        file: ../kyverno_rbac.yaml
+  - name: when-cluster-policy-is-ready
+    try:
+    - apply:
+        file: ../validate-restrict-binding-system-authenticated-clusterpolicy.yaml
+    - assert:
+        file: chainsaw-assert-clusterpolicy.yaml
+  - name: then-invalid-rolebinding-can-be-deleted
+    try:
+    - delete:
+        file: ./resources/invalid-systemauthenticated-rolebinding.yaml
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
   name: in-tenant-valid-rolebinding
 spec:
   description: |

--- a/components/policies/development/konflux-rbac/restrict-binding-system-authenticated/validate-restrict-binding-system-authenticated-clusterpolicy.yaml
+++ b/components/policies/development/konflux-rbac/restrict-binding-system-authenticated/validate-restrict-binding-system-authenticated-clusterpolicy.yaml
@@ -23,6 +23,9 @@ spec:
           namespaceSelector:
             matchLabels:
               konflux-ci.dev/type: tenant
+          operations:
+          - CREATE
+          - UPDATE
     exclude:
       any:
       - resources:


### PR DESCRIPTION
The current version of the ClusterPolicy is preventing us from deleting existing invalid RoleBindings.

Signed-off-by: Francesco Ilario <filario@redhat.com>

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED
