### PR TITLE
chore(PVO11Y-5208): Update Openshift Logging Operator to 6.4 for stage

### DIFF
--- a/components/monitoring/logging/staging/base/kustomization.yaml
+++ b/components/monitoring/logging/staging/base/kustomization.yaml
@@ -35,3 +35,12 @@ patches:
       version: v1
       kind: ClusterLogForwarder
       name: instance
+  - target:
+      group: operators.coreos.com
+      version: v1alpha1
+      kind: Subscription
+      name: cluster-logging
+    patch: |
+      - op: replace
+        path: /spec/channel
+        value: "stable-6.4"


### PR DESCRIPTION
OpenShift Logging Operator will need to be updated from 6.1 to enable Konflux cluster upgrade to a newer version of OCP.