### PR TITLE
chore(PVO11Y-5208): Update Openshift Logging Operator to 6.3 first fo…

### DIFF
--- a/components/monitoring/logging/staging/base/kustomization.yaml
+++ b/components/monitoring/logging/staging/base/kustomization.yaml
@@ -43,4 +43,4 @@ patches:
     patch: |
       - op: replace
         path: /spec/channel
-        value: "stable-6.4"
+        value: "stable-6.3"


### PR DESCRIPTION
…r stage

Previously tried to update the OpenShift Logging Operator from 6.1 to 6.4 with redhat-appstudio/infra-deployments#11528. Reading the upgrade guide for OpenShift logging, looks like at most N+2 version updates are supported. Trying to upgrade to 6.3 first before jumping up to 6.4.