### PR TITLE
fix: prevent ArgoCD from restarting kubearchive migration Job in stone-prod-p02

### DIFF
--- a/components/kubearchive/production/stone-prod-p02/kustomization.yaml
+++ b/components/kubearchive/production/stone-prod-p02/kustomization.yaml
@@ -120,8 +120,6 @@ patches:
         name: kubearchive-schema-migration
         namespace: kubearchive
         annotations:
-          # Needed if just the command is changed, otherwise the job needs to be deleted manually
-          argocd.argoproj.io/sync-options: Force=true,Replace=true
           argocd.argoproj.io/sync-wave: "-1"
           ignore-check.kube-linter.io/no-read-only-root-fs: >
             "This job needs to clone a repository to do its job, so it needs write access to the FS."
@@ -139,6 +137,16 @@ patches:
                         key: MIGRATION_VERSION
                 securityContext:
                   runAsUser: null
+  # Add version suffix to Job name so syncs with unchanged version are a no-op
+  # (immutable Job, same name = nothing to do). On upgrade, new name = new Job
+  # created, old completed one pruned. Update suffix when changing MIGRATION_VERSION.
+  - target:
+      kind: Job
+      name: kubearchive-schema-migration
+    patch: |-
+      - op: replace
+        path: /metadata/name
+        value: kubearchive-schema-migration-v13
   # We don't need the Secret as it will be created by the ExternalSecrets Operator
   - patch: |-
       $patch: delete


### PR DESCRIPTION
## Summary
- Remove `Force=true,Replace=true` annotation from the schema migration Job in `stone-prod-p02`
- Add a version suffix (`-v13`) to the Job name tied to `MIGRATION_VERSION`

When ArgoCD syncs (auto-sync, self-heal, or retry), `Force=true,Replace=true` causes the Job to be deleted and recreated, restarting the migration from scratch. For long-running migrations (2+ days for 222M records), this means the migration never completes.

With this change, syncs with the same version are a no-op (immutable Job, same name = nothing to do). On upgrade, the new Job name creates a fresh Job and the old completed one is pruned.

**Important:** the suffix must be updated together with `MIGRATION_VERSION` on each upgrade.

## Test plan
- [ ] ArgoCD sync completes successfully for stone-prod-p02
- [ ] Schema migration Job is created with the versioned name (`kubearchive-schema-migration-v13`)
- [ ] Subsequent ArgoCD syncs do not restart the migration Job
- [ ] Migration completes successfully

## Risk assessment
- Low. Only changes the Job name and removes the force-replace annotation. No impact on the migration logic or other kubearchive components.
- This is a specific change to enable the success of https://github.com/fullsend-ai/fullsend/pull/474. There is no previous change on staging because in staging the amount of data doesn't take that amount of time to perform the migration

Signed-off-by: Marta Anon <manon@redhat.com>