### PR TITLE
chore(PVO11Y-5208): Update Logging Operator to 6.4 in stg again

### DIFF
--- a/components/monitoring/logging/staging/base/kustomization.yaml
+++ b/components/monitoring/logging/staging/base/kustomization.yaml
@@ -43,4 +43,4 @@ patches:
     patch: |
       - op: replace
         path: /spec/channel
-        value: "stable-6.3"
+        value: "stable-6.4"


### PR DESCRIPTION
Upgrade to 6.3 with redhat-appstudio/infra-deployments#11529 was successful. Now setting the channel to 6.4 once more to finish the upgrade.