### PR TITLE
Enable package registry proxy on select production clusters

### DIFF
--- a/components/konflux-info/production/kflux-prd-rh02/cluster-config.env
+++ b/components/konflux-info/production/kflux-prd-rh02/cluster-config.env
@@ -1,3 +1,7 @@
 allow-cache-proxy=true
 http-proxy=squid.caching.svc.cluster.local:3128
 no-proxy=
+
+allow-package-registry-proxy=true
+package-registry-proxy-npm-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/npm-proxy
+package-registry-proxy-yarn-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/npm-proxy

--- a/components/konflux-info/production/stone-prod-p01/cluster-config.env
+++ b/components/konflux-info/production/stone-prod-p01/cluster-config.env
@@ -1,3 +1,7 @@
 allow-cache-proxy=true
 http-proxy=squid.caching.svc.cluster.local:3128
 no-proxy=
+
+allow-package-registry-proxy=true
+package-registry-proxy-npm-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/npm-proxy
+package-registry-proxy-yarn-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/npm-proxy


### PR DESCRIPTION
Reviews are welcome, but please hold off merging this until after the change is announced on Apr-30.

- [ ] konflux-announce email sent

Enable use of the package registry proxy for select production clusters (stone-prod-p01, kflux-prd-rh02). This sets the allow-package-registry-proxy feature flag to true and configures the npm/yarn proxy URLs, which will allow Hermeto to route dependency prefetches through the package registry proxy for policy evaluation.

Remaining production clusters will be enabled after a soak period.

See ADR: https://github.com/konflux-ci/architecture/blob/0f9b9bf6ae267aa059e68478d6d7b80e7afc5676/ADR/0064-hermeto-package-registry-proxy.md

The infra team controls this flag per-cluster via the cluster-config ConfigMap. Setting allow-package-registry-proxy to false disables proxy usage across all build pipelines on the cluster (e.g. during a proxy outage).

## Validation
We successfully tested this in stage with ~100 parallel prefetch-dependencies tasks for a large (~1500 deps) project.
Staging PR: https://github.com/redhat-appstudio/infra-deployments/pull/11368
Test Results: https://konflux-ui.apps.stone-stg-rh01.l2vh.p1.openshiftapps.com/ns/tmadore-tenant/applications/hermeto-registry-proxy-testing/pipelineruns/express-migration-on-pull-request-qb5nw


## Risk Assessment
Risk Level: Medium

Description: Once merged, all users who have migrated to the 0.3.2 versions of the prefetch-dependencies task and who prefetch dependencies for the `npm` and `yarn` modern (v2+) package managers will have their dependency prefetches routed through the package registry proxy (Nexus) by default. If individual users encounter issues and need to opt-out temporarily with an exception, they can do so by setting the `enable-package-registry-proxy` pipeline param to `false` in their build pipelines. 
(Broad scope, but easy rollback. User exception/opt-out path)

Rollback plan: Revert the commit or change `allow-package-registry-proxy` to `false` in these `cluster-config` ConfigMaps to disable use of the package-registry-proxy globally on a per-cluster basis.