### PR TITLE
Update image-controller notification-resetter cronjob resources in stage

### DIFF
--- a/components/image-controller/staging/base/kustomization.yaml
+++ b/components/image-controller/staging/base/kustomization.yaml
@@ -15,3 +15,4 @@ namespace: image-controller
 patches:
   - path: ./manager_resources_patch.yaml
   - path: ./pruner_cronjob_resources_patch.yaml
+  - path: ./notification_resetter_cronjob_resources_patch.yaml

--- a/components/image-controller/staging/base/notification_resetter_cronjob_resources_patch.yaml
+++ b/components/image-controller/staging/base/notification_resetter_cronjob_resources_patch.yaml
@@ -1,0 +1,19 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: image-controller-notification-resetter-cronjob
+  namespace: image-controller-system
+spec:
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: notification-resetter
+            resources:
+              limits:
+                cpu: 500m
+                memory: 1Gi
+              requests:
+                cpu: 150m
+                memory: 1Gi


### PR DESCRIPTION
Patch for notification-resetter cronjob resources to mitigate instability in stage environments.

## Risk Assessment

**Risk Level:** Low
**Description:** Cronjob memory resources increase
**Rollback:** Remove this config from kustomization and deploy with cronjob default values

Closes [KONFLUX-13244](https://redhat.atlassian.net/browse/KONFLUX-13244)

[KONFLUX-13244]: https://redhat.atlassian.net/browse/KONFLUX-13244?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ