### PR TITLE
Fix allowed namespaces in clustersecretstore

### DIFF
--- a/components/cluster-secret-store-rh/production/stone-prod-p02/insights-conditions-patch.yaml
+++ b/components/cluster-secret-store-rh/production/stone-prod-p02/insights-conditions-patch.yaml
@@ -6,4 +6,6 @@ metadata:
 spec:
   conditions:
     - namespaces:
+        - insights-management-tenant
+        - hcm-eng-prod-tenant
         - hcc-platex-services-tenant


### PR DESCRIPTION
In 2c6b79e5497869fabb4d9f9dd178214de0031cb5, insights-appsre-vault was officially deployed to p02, i.e. deployed from ArgoCD thus replacing the stale left over version sitting in the cluster.

The new managed version only allowed one namespace to use this store but there was other namespaces using it. Add back the other namespaces to the allowed list.

[KFLUXSPRT-7749](https://redhat.atlassian.net/browse/KFLUXSPRT-7749)

[KFLUXSPRT-7749]: https://redhat.atlassian.net/browse/KFLUXSPRT-7749?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Risk Assessment
**Risk Level:** low
**Description:** Fix allowed namespaces in clustersecretstore
**Rollback:** Revert PR but this will not happen

## Validation
This store only exist on prod but this is a simple allowed namespace changes, zero risk of breaking something