### PR TITLE
update tekton-kueue in staging

### DIFF
--- a/components/kueue/staging/base/tekton-kueue/kustomization.yaml
+++ b/components/kueue/staging/base/tekton-kueue/kustomization.yaml
@@ -1,12 +1,12 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- https://github.com/konflux-ci/tekton-kueue/config/default?ref=815dbf158b0e39df568eb901dcf05e759099991a
+- https://github.com/konflux-ci/tekton-kueue/config/default?ref=964790eef15cef723654b6f62b36b8cde867f9f7
 
 images:
 - name: konflux-ci/tekton-kueue
   newName: quay.io/konflux-ci/tekton-kueue
-  newTag: 815dbf158b0e39df568eb901dcf05e759099991a
+  newTag: 964790eef15cef723654b6f62b36b8cde867f9f7
 
 namespace: tekton-kueue
 # ensure that installation starts after the installation of kueue complete


### PR DESCRIPTION
Follows-up to #11530

```
* 964790e accept QPS and Burst from flags (#400)
* 7ee9a37 Add godoc documentation to controller, webhook, and config packages
* f173be2 chore(deps): update module go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp to v0.68.0
* 67d5fa2 Fix: set response.patch to nil when all patches are filtered out (#392)
* b6c7575 Add unit tests for controller and common packages
* 46aef57 fix: return error instead of panicking on invalid resource annotations
* 5912671 feat: Add e2e test coverage collection with coverport (#326)
* 1f9856d chore(deps): update module github.com/prometheus/procfs to v0.20.1 (#385)
* fadaf9a fix: filter leaked zero-value fields from webhook admission patches (#329)
* 36becee chore(deps): update module github.com/grpc-ecosystem/grpc-gateway/v2 to v2.28.0 (#366)
* e54b834 Generated best practices file (#280)
* 38df841 chore(deps): update go-openapi packages (#358)
* dc085f9 Block incompatible dependency upgrades in Renovate/MintMaker (#376)
* ea823cf Remove obsolete cel-go replace directive (#374)
* 74581a0 Configure Renovate for weekly schedule with release age filter (#375)
* 830b4b0 Update compatible Go dependencies (#355)
* 65b6a7a chore(deps): update konflux references (#318)
* 1932e55 chore(deps): update registry.access.redhat.com/ubi9/go-toolset docker tag to v1.25.8-1775042950 (#321)
* 6ebcc33 chore(deps): update module github.com/emicklei/go-restful/v3 to v3.13.0 (#354)
* ede0cca KFLUXINFRA-3175: Fix approval labels and remove minor grouping (#350)
* 8bddfb1 Fix CVE: GHSA-9h8m-3fm2-qjrq (#337)
* 26cab2a KFLUXINFRA-3176: Add AI-assisted dependency impact analysis for minor/major bumps (#327)
* 6d8e2ce KFLUXINFRA-3175: Add dependency PR auto-triage (labels, grouping, auto-merge) (#324)
* ea171f3 feat: Onboard to codecov (#312)
* 99f4819 chore(deps): update registry.access.redhat.com/ubi9-micro docker digest to 2173487 (#315)
* b36c7c8 chore(deps): update registry.access.redhat.com/ubi9/go-toolset docker tag to v1.25.7-1773851748 (#314)
* 3351486 chore(deps): update konflux references (#311)
* 863e629 chore(deps): update registry.access.redhat.com/ubi9/go-toolset docker tag to v1.25.7-1773318690 (#309)
* de7be94 chore(deps): update registry.access.redhat.com/ubi9/go-toolset docker tag to v1.25.7-1773088126 (#307)
* ff8775e chore(deps): update registry.access.redhat.com/ubi9/go-toolset docker tag to v1.25.7-1773016755 (#305)
* 9c55e5a chore(deps): update konflux references (#303)
* a6381d2 chore(deps): update registry.access.redhat.com/ubi9/go-toolset docker tag to v1.25.7-1772728670 (#300)
* c6d90da chore(deps): update registry.access.redhat.com/ubi9/go-toolset docker tag to v1.25.7-1772454089 (#298)
* b25496e chore(deps): update registry.access.redhat.com/ubi9/go-toolset docker tag to v1.25.7-1772411495 (#296)
* 5e8cf62 chore(deps): update konflux references (#294)
* f6c0017 chore(deps): update konflux references (#292)
* a86a137 chore(deps): update registry.access.redhat.com/ubi9/go-toolset docker tag to v1.25.7-1771417345 (#289)
* 42bf399 chore(deps): update registry.access.redhat.com/ubi9-micro docker digest to 093a704 (#288)
* 72e4d93 chore(deps): update registry.access.redhat.com/ubi9/go-toolset docker tag to v1.25.7-1771271449 (#286)

```

Signed-off-by: Francesco Ilario <filario@redhat.com>

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED
