### PR TITLE
Add authorization config for kube-rbac-proxy 

### DIFF
--- a/components/monitoring/prometheus/staging/tekton-ms/kube-rbac-proxy.yaml
+++ b/components/monitoring/prometheus/staging/tekton-ms/kube-rbac-proxy.yaml
@@ -19,34 +19,6 @@ subjects:
     name: tekton-ms-kube-rbac-proxy
     namespace: appstudio-tekton
 ---
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: tekton-ms-metrics-reader
-rules:
-  - nonResourceURLs:
-      - /api/v1/query
-      - /api/v1/query_range
-      - /api/v1/labels
-      - /api/v1/label/*/values
-      - /api/v1/series
-      - /api/v1/metadata
-    verbs:
-      - get
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: tekton-ms-metrics-reader
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: tekton-ms-metrics-reader
-subjects:
-  - kind: ServiceAccount
-    name: metrics-reader
-    namespace: appstudio-grafana
----
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/components/monitoring/prometheus/staging/tekton-ms/kube-rbac-proxy.yaml
+++ b/components/monitoring/prometheus/staging/tekton-ms/kube-rbac-proxy.yaml
@@ -19,6 +19,34 @@ subjects:
     name: tekton-ms-kube-rbac-proxy
     namespace: appstudio-tekton
 ---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: tekton-ms-metrics-reader
+rules:
+  - nonResourceURLs:
+      - /api/v1/query
+      - /api/v1/query_range
+      - /api/v1/labels
+      - /api/v1/label/*/values
+      - /api/v1/series
+      - /api/v1/metadata
+    verbs:
+      - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: tekton-ms-metrics-reader
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: tekton-ms-metrics-reader
+subjects:
+  - kind: ServiceAccount
+    name: metrics-reader
+    namespace: appstudio-grafana
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -28,8 +56,9 @@ data:
   config.yaml: |
     authorization:
       resourceAttributes:
-        apiGroup: ""
-        resource: namespaces
+        apiGroup: monitoring.coreos.com
+        resource: prometheuses/api
+        name: k8s
         verb: get
 ---
 apiVersion: apps/v1

--- a/components/monitoring/prometheus/staging/tekton-ms/kube-rbac-proxy.yaml
+++ b/components/monitoring/prometheus/staging/tekton-ms/kube-rbac-proxy.yaml
@@ -19,6 +19,19 @@ subjects:
     name: tekton-ms-kube-rbac-proxy
     namespace: appstudio-tekton
 ---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: tekton-ms-kube-rbac-proxy-config
+  namespace: appstudio-tekton
+data:
+  config.yaml: |
+    authorization:
+      resourceAttributes:
+        apiGroup: ""
+        resource: namespaces
+        verb: get
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -43,6 +56,7 @@ spec:
           args:
             - '--secure-listen-address=0.0.0.0:9091'
             - '--upstream=http://appstudio-tekton-ms-prometheus.appstudio-tekton.svc:9090/'
+            - '--config-file=/etc/kube-rbac-proxy/config.yaml'
             - '--tls-cert-file=/etc/tls/private/tls.crt'
             - '--tls-private-key-file=/etc/tls/private/tls.key'
             - '--logtostderr=true'
@@ -68,10 +82,16 @@ spec:
             - name: tls
               mountPath: /etc/tls/private
               readOnly: true
+            - name: config
+              mountPath: /etc/kube-rbac-proxy
+              readOnly: true
       volumes:
         - name: tls
           secret:
             secretName: tekton-ms-kube-rbac-proxy-tls
+        - name: config
+          configMap:
+            name: tekton-ms-kube-rbac-proxy-config
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
Without a --config-file, kube-rbac-proxy defaults to checking "create" on an empty resource, which the metrics-reader SA does not have. This adds a ConfigMap with a resourceAttributes check for "get namespaces", which metrics-reader already has via cluster-monitoring-view.
