### PR TITLE
Revert kubearchive v1.21.3 upgrade in stone-prod-p02

### DIFF
--- a/components/kubearchive/production/stone-prod-p02/kubearchive.yaml
+++ b/components/kubearchive/production/stone-prod-p02/kubearchive.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: namespace
     app.kubernetes.io/name: kubearchive
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.21.3
+    app.kubernetes.io/version: v1.20.0
   name: kubearchive
 ---
 apiVersion: apiextensions.k8s.io/v1
@@ -552,7 +552,7 @@ metadata:
     app.kubernetes.io/component: api-server
     app.kubernetes.io/name: kubearchive-api-server
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.21.3
+    app.kubernetes.io/version: v1.20.0
   name: kubearchive-api-server
   namespace: kubearchive
 ---
@@ -563,7 +563,7 @@ metadata:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: kubearchive-vacuum
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.21.3
+    app.kubernetes.io/version: v1.20.0
   name: kubearchive-cluster-vacuum
   namespace: kubearchive
 ---
@@ -574,7 +574,7 @@ metadata:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: kubearchive-operator
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.21.3
+    app.kubernetes.io/version: v1.20.0
   name: kubearchive-operator
   namespace: kubearchive
 ---
@@ -585,7 +585,7 @@ metadata:
     app.kubernetes.io/component: sink
     app.kubernetes.io/name: kubearchive-sink
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.21.3
+    app.kubernetes.io/version: v1.20.0
   name: kubearchive-sink
   namespace: kubearchive
 ---
@@ -596,7 +596,7 @@ metadata:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: kubearchive-operator-leader-election
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.21.3
+    app.kubernetes.io/version: v1.20.0
   name: kubearchive-operator-leader-election
   namespace: kubearchive
 rules:
@@ -639,7 +639,7 @@ metadata:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: kubearchive-vacuum
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.21.3
+    app.kubernetes.io/version: v1.20.0
   name: kubearchive-vacuum
   namespace: kubearchive
 rules:
@@ -659,7 +659,7 @@ metadata:
     app.kubernetes.io/component: api-server
     app.kubernetes.io/name: kubearchive-api-server
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.21.3
+    app.kubernetes.io/version: v1.20.0
   name: kubearchive-api-server
 rules:
   - apiGroups:
@@ -677,7 +677,7 @@ metadata:
   labels:
     app.kubernetes.io/name: kubearchive-edit
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.21.3
+    app.kubernetes.io/version: v1.20.0
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
   name: kubearchive-edit
 rules:
@@ -791,7 +791,7 @@ metadata:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: kubearchive-operator-config-editor
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.21.3
+    app.kubernetes.io/version: v1.20.0
   name: kubearchive-operator-config-editor
 rules:
   - apiGroups:
@@ -820,7 +820,7 @@ metadata:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: kubearchive-operator-config-viewer
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.21.3
+    app.kubernetes.io/version: v1.20.0
   name: kubearchive-operator-config-viewer
 rules:
   - apiGroups:
@@ -844,7 +844,7 @@ metadata:
   labels:
     app.kubernetes.io/name: kubearchive-view
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.21.3
+    app.kubernetes.io/version: v1.20.0
     rbac.authorization.k8s.io/aggregate-to-view: "true"
   name: kubearchive-view
 rules:
@@ -868,7 +868,7 @@ metadata:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: kubearchive-operator-leader-election
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.21.3
+    app.kubernetes.io/version: v1.20.0
   name: kubearchive-operator-leader-election
   namespace: kubearchive
 roleRef:
@@ -887,7 +887,7 @@ metadata:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: kubearchive-vacuum
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.21.3
+    app.kubernetes.io/version: v1.20.0
   name: kubearchive-vacuum
   namespace: kubearchive
 roleRef:
@@ -906,7 +906,7 @@ metadata:
     app.kubernetes.io/component: api-server
     app.kubernetes.io/name: kubearchive-api-server
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.21.3
+    app.kubernetes.io/version: v1.20.0
   name: kubearchive-api-server
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -924,7 +924,7 @@ metadata:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: kubearchive-operator
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.21.3
+    app.kubernetes.io/version: v1.20.0
   name: kubearchive-operator
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -943,7 +943,7 @@ metadata:
     app.kubernetes.io/component: logging
     app.kubernetes.io/name: kubearchive-logging-reader
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.21.3
+    app.kubernetes.io/version: v1.20.0
   name: kubearchive-logging-reader
   namespace: kubearchive
 ---
@@ -955,7 +955,7 @@ metadata:
     app.kubernetes.io/component: logging
     app.kubernetes.io/name: kubearchive-logging-writer
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.21.3
+    app.kubernetes.io/version: v1.20.0
   name: kubearchive-logging-writer
   namespace: kubearchive
 ---
@@ -972,7 +972,7 @@ metadata:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: kubearchive-operator
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.21.3
+    app.kubernetes.io/version: v1.20.0
   name: kubearchive-operator
   namespace: kubearchive
 ---
@@ -980,7 +980,7 @@ apiVersion: v1
 data:
   DATABASE_DB: a3ViZWFyY2hpdmU=
   DATABASE_KIND: cG9zdGdyZXNxbA==
-  DATABASE_PASSWORD: RGF0IWFiYXNdM1Bhc3MqdzByZA== # gitleaks:allow
+  DATABASE_PASSWORD: RGF0IWFiYXNdM1Bhc3MqdzByZA==
   DATABASE_PORT: NTQzMg==
   DATABASE_URL: a3ViZWFyY2hpdmUtcncucG9zdGdyZXNxbC5zdmMuY2x1c3Rlci5sb2NhbA==
   DATABASE_USER: a3ViZWFyY2hpdmU=
@@ -990,7 +990,7 @@ metadata:
     app.kubernetes.io/component: database
     app.kubernetes.io/name: kubearchive-database-credentials
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.21.3
+    app.kubernetes.io/version: v1.20.0
   name: kubearchive-database-credentials
   namespace: kubearchive
 type: Opaque
@@ -1002,7 +1002,7 @@ metadata:
     app.kubernetes.io/component: logging
     app.kubernetes.io/name: kubearchive-logging
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.21.3
+    app.kubernetes.io/version: v1.20.0
   name: kubearchive-logging
   namespace: kubearchive
 stringData:
@@ -1016,7 +1016,7 @@ metadata:
     app.kubernetes.io/component: api-server
     app.kubernetes.io/name: kubearchive-api-server
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.21.3
+    app.kubernetes.io/version: v1.20.0
   name: kubearchive-api-server
   namespace: kubearchive
 spec:
@@ -1035,7 +1035,7 @@ metadata:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: kubearchive-operator-webhooks
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.21.3
+    app.kubernetes.io/version: v1.20.0
   name: kubearchive-operator-webhooks
   namespace: kubearchive
 spec:
@@ -1058,7 +1058,7 @@ metadata:
     app.kubernetes.io/component: sink
     app.kubernetes.io/name: kubearchive-sink
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.21.3
+    app.kubernetes.io/version: v1.20.0
   name: kubearchive-sink
   namespace: kubearchive
 spec:
@@ -1076,7 +1076,7 @@ metadata:
     app.kubernetes.io/component: api-server
     app.kubernetes.io/name: kubearchive-api-server
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.21.3
+    app.kubernetes.io/version: v1.20.0
   name: kubearchive-api-server
   namespace: kubearchive
 spec:
@@ -1130,7 +1130,7 @@ spec:
           envFrom:
             - secretRef:
                 name: kubearchive-database-credentials
-          image: quay.io/kubearchive/api:v1.21.3@sha256:5dfa9fff9df9df3fef6fe28f88047272f0a653b3ccfbea327a10e3052f1dddb4
+          image: quay.io/kubearchive/api:v1.20.0@sha256:43938bb7fabcc543cd3b5af0c9074196328f393d6e712f379572cca5ecfaab3c
           livenessProbe:
             httpGet:
               path: /livez
@@ -1182,7 +1182,7 @@ metadata:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: kubearchive-operator
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.21.3
+    app.kubernetes.io/version: v1.20.0
   name: kubearchive-operator
   namespace: kubearchive
 spec:
@@ -1232,7 +1232,7 @@ spec:
               valueFrom:
                 resourceFieldRef:
                   resource: limits.cpu
-          image: quay.io/kubearchive/operator:v1.21.3@sha256:e60f0a019d3b8a895e46caacc429dd0865c80fdb2af83f40d2b4d4c1e7803d52
+          image: quay.io/kubearchive/operator:v1.20.0@sha256:eb8b363f5cfddd190011aa1d0e7cdff5c50aefae0bd4207024755146b3840db9
           livenessProbe:
             httpGet:
               path: /healthz
@@ -1294,7 +1294,7 @@ metadata:
     app.kubernetes.io/component: sink
     app.kubernetes.io/name: kubearchive-sink
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.21.3
+    app.kubernetes.io/version: v1.20.0
   name: kubearchive-sink
   namespace: kubearchive
 spec:
@@ -1346,7 +1346,7 @@ spec:
           envFrom:
             - secretRef:
                 name: kubearchive-database-credentials
-          image: quay.io/kubearchive/sink:v1.21.3@sha256:cf197b6ecd5a98c3c92a2bed8d2a567b96590bf89783b1d3d5b501239514c422
+          image: quay.io/kubearchive/sink:v1.20.0@sha256:8a13e20ba373f00f7e8889af2a67a61c44d9e8bab74a5c0186f324f2eb0cb120
           livenessProbe:
             httpGet:
               path: /livez
@@ -1387,7 +1387,7 @@ metadata:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: kubearchive-vacuum
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.21.3
+    app.kubernetes.io/version: v1.20.0
   name: cluster-vacuum
   namespace: kubearchive
 spec:
@@ -1408,7 +1408,7 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
-              image: quay.io/kubearchive/vacuum:v1.21.3@sha256:47a52b1b649085fa73275bce45bda4ffba0c7a5c6bd8e3d5c380b1e485c1abb1
+              image: quay.io/kubearchive/vacuum:v1.20.0@sha256:fe373300d999379656f78860906d7a30d77af088d6ba3bfa37a102c422d45480
               name: vacuum
           restartPolicy: Never
           serviceAccount: kubearchive-cluster-vacuum
@@ -1422,7 +1422,7 @@ metadata:
     app.kubernetes.io/component: kubearchive
     app.kubernetes.io/name: kubearchive-schema-migration
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.21.3
+    app.kubernetes.io/version: v1.20.0
   name: kubearchive-schema-migration
   namespace: kubearchive
 spec:
@@ -1438,7 +1438,7 @@ spec:
           envFrom:
             - secretRef:
                 name: kubearchive-database-credentials
-          image: quay.io/kubearchive/postgresql:v1.21.3@sha256:2ce1545b19d29bd36c1022de13f451f14847aed04d62ab896a3254d74f7c0d39
+          image: quay.io/kubearchive/postgresql:v1.20.0@sha256:0aae85e8885295c87c3241915b8be86e08d5439f38ec9de9f95b012c67633874
           name: migration
           resources:
             limits:
@@ -1459,7 +1459,7 @@ metadata:
     app.kubernetes.io/component: api-server
     app.kubernetes.io/name: kubearchive-api-server-certificate
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.21.3
+    app.kubernetes.io/version: v1.20.0
   name: kubearchive-api-server-certificate
   namespace: kubearchive
 spec:
@@ -1493,7 +1493,7 @@ metadata:
     app.kubernetes.io/component: certs
     app.kubernetes.io/name: kubearchive-ca
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.21.3
+    app.kubernetes.io/version: v1.20.0
   name: kubearchive-ca
   namespace: kubearchive
 spec:
@@ -1515,7 +1515,7 @@ metadata:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: kubearchive-operator-certificate
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.21.3
+    app.kubernetes.io/version: v1.20.0
   name: kubearchive-operator-certificate
   namespace: kubearchive
 spec:
@@ -1534,7 +1534,7 @@ metadata:
     app.kubernetes.io/component: certs
     app.kubernetes.io/name: kubearchive
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.21.3
+    app.kubernetes.io/version: v1.20.0
   name: kubearchive
   namespace: kubearchive
 spec:
@@ -1548,7 +1548,7 @@ metadata:
     app.kubernetes.io/component: certs
     app.kubernetes.io/name: kubearchive-ca
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.21.3
+    app.kubernetes.io/version: v1.20.0
   name: kubearchive-ca
   namespace: kubearchive
 spec:
@@ -1563,7 +1563,7 @@ metadata:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: kubearchive-mutating-webhook-configuration
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.21.3
+    app.kubernetes.io/version: v1.20.0
   name: kubearchive-mutating-webhook-configuration
 webhooks:
   - admissionReviewVersions:
@@ -1676,7 +1676,7 @@ metadata:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: kubearchive-validating-webhook-configuration
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.21.3
+    app.kubernetes.io/version: v1.20.0
   name: kubearchive-validating-webhook-configuration
 webhooks:
   - admissionReviewVersions:

--- a/components/kubearchive/production/stone-prod-p02/kustomization.yaml
+++ b/components/kubearchive/production/stone-prod-p02/kustomization.yaml
@@ -23,7 +23,7 @@ configMapGenerator:
         annotations:
           argocd.argoproj.io/sync-wave: "-2"
       literals:
-        - MIGRATION_VERSION=13
+        - MIGRATION_VERSION=5
     - name: kubearchive-logging-writer
       literals:
           - |
@@ -111,7 +111,7 @@ patches:
               spec:
                 containers:
                   - name: vacuum
-                    image: quay.io/kubearchive/vacuum:v1.21.3
+                    image: quay.io/kubearchive/vacuum:v1.20.0
 
   - patch: |-
       apiVersion: batch/v1

--- a/components/kubearchive/production/stone-prod-p02/kustomization.yaml
+++ b/components/kubearchive/production/stone-prod-p02/kustomization.yaml
@@ -137,21 +137,6 @@ patches:
                       configMapKeyRef:
                         name: kubearchive-schema-version
                         key: MIGRATION_VERSION
-                  # Migration tuning: BATCH_SIZE is the number of resource IDs scanned per SQL query
-                  # (script default: 10000, documented default: 100000). SLEEP_INTERVAL is seconds
-                  # between batches (default: 0.1). Both are processed server-side in PostgreSQL;
-                  # the pod only receives INSERT count results.
-                  - name: BATCH_SIZE
-                    value: "300000"
-                  - name: SLEEP_INTERVAL
-                    value: "0"
-                resources:
-                  limits:
-                    cpu: 100m
-                    memory: 128Mi
-                  requests:
-                    cpu: 100m
-                    memory: 128Mi
                 securityContext:
                   runAsUser: null
   # We don't need the Secret as it will be created by the ExternalSecrets Operator


### PR DESCRIPTION
## Summary
- Revert #11458 (Upgrade kubearchive to v1.21.3 in stone-prod-p02)
- Revert #11581 (ITN-2026-00132 fix for the stale kubearchive DB migration job)
- Restores kubearchive to v1.20.0 with MIGRATION_VERSION=5

## Reason
The database migration (07_08_populate_label_tables) is processing ~225M resource IDs and requires 2+ days to complete. During the migration, the api-server and sink pods are down with `CreateContainerConfigError` / schema version mismatch because the DB has advanced past what v1.20.0 supports, and ArgoCD sync waves prevent updating the Deployments to v1.21.3 until the migration Job completes.
We shouldn't also for the deployments going to v1.21.3 until the migration isn't finished.

## Test plan
- [ ] ArgoCD syncs successfully for stone-prod-p02
- [ ] Migration job runs down migrations to roll back DB schema
- [ ] KubeArchive API, operator, and sink pods are running on v1.20.0
- [ ] Verify kubearchive API is functional

## Risk assessment
- The down migration drops the new label tables and restores the GIN index. No data loss — the label tables only contained derived data from existing resources.

🤖 Generated with [Claude Code](https://claude.com/claude-code)