### PR TITLE
Use v1.21.3 migration image for DB schema rollback

### DIFF
--- a/components/kubearchive/production/stone-prod-p02/kustomization.yaml
+++ b/components/kubearchive/production/stone-prod-p02/kustomization.yaml
@@ -131,6 +131,7 @@ patches:
           spec:
             containers:
               - name: migration
+                image: quay.io/kubearchive/postgresql:v1.21.3@sha256:2ce1545b19d29bd36c1022de13f451f14847aed04d62ab896a3254d74f7c0d39
                 env:
                   - name: MIGRATION_VERSION
                     valueFrom:


### PR DESCRIPTION
## Summary
- Override migration job image to v1.21.3 so it can run the down migrations from schema version 7 back to 5
- The v1.20.0 image (restored by #11582) doesn't contain the down migration scripts for version 7

## Reason
After reverting the v1.21.3 upgrade (#11582), the migration job panics because the v1.20.0 image doesn't have the down migration files needed to roll back from schema version 7 to 5. The v1.21.3 migration image has all the required scripts.

## Test plan
- [ ] Migration job starts and runs down migrations successfully
- [ ] DB schema version returns to 5
- [ ] KubeArchive API and sink pods start on v1.20.0

## Risk assessment
- Low. Only the migration job image is changed. Once the rollback completes, this image override can be removed in a follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)