### PR TITLE
Update image-controller notification-resetter cronjob resources in prod

### DIFF
--- a/components/image-controller/production/base/kustomization.yaml
+++ b/components/image-controller/production/base/kustomization.yaml
@@ -27,3 +27,4 @@ patches:
       group: external-secrets.io
       version: v1
   - path: ./pruner_cronjob_resources_patch.yaml
+  - path: ./notification_resetter_cronjob_resources_patch.yaml

--- a/components/image-controller/production/base/notification_resetter_cronjob_resources_patch.yaml
+++ b/components/image-controller/production/base/notification_resetter_cronjob_resources_patch.yaml
@@ -1,0 +1,19 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: image-controller-notification-resetter-cronjob
+  namespace: image-controller-system
+spec:
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: notification-resetter
+            resources:
+              limits:
+                cpu: 500m
+                memory: 1Gi
+              requests:
+                cpu: 150m
+                memory: 1Gi


### PR DESCRIPTION
Patch for notification-resetter cronjob resources to mitigate instability in prod environments.

Closes [KONFLUX-13244](https://redhat.atlassian.net/browse/KONFLUX-13244)

## Risk Assessment

**Risk Level:** Low
**Description:** Cronjob memory resources increase
**Rollback:** Remove this config from kustomization and deploy with cronjob default values

## Validation

Staging PR: https://github.com/redhat-appstudio/infra-deployments/pull/11552

[KONFLUX-13244]: https://redhat.atlassian.net/browse/KONFLUX-13244?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ