### PR TITLE
Upgrade crossplane-control-plane in dev and staging

### DIFF
--- a/components/crossplane-control-plane/development/kustomization.yaml
+++ b/components/crossplane-control-plane/development/kustomization.yaml
@@ -1,8 +1,8 @@
 resources:
 - ../base
-- https://github.com/konflux-ci/crossplane-control-plane/crossplane?ref=1563d850a1331ed68796ddc7e3849de5ee011579
-- https://github.com/konflux-ci/crossplane-control-plane/config?ref=1563d850a1331ed68796ddc7e3849de5ee011579
-- https://github.com/konflux-ci/crossplane-control-plane/examples/provider-kubernetes-in-cluster?ref=1563d850a1331ed68796ddc7e3849de5ee011579
+- https://github.com/konflux-ci/crossplane-control-plane/crossplane?ref=bd3da0eff408eb329bfb5d7306b2aa3016d1a906
+- https://github.com/konflux-ci/crossplane-control-plane/config?ref=bd3da0eff408eb329bfb5d7306b2aa3016d1a906
+- https://github.com/konflux-ci/crossplane-control-plane/examples/provider-kubernetes-in-cluster?ref=bd3da0eff408eb329bfb5d7306b2aa3016d1a906
 
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/components/crossplane-control-plane/staging/kustomization.yaml
+++ b/components/crossplane-control-plane/staging/kustomization.yaml
@@ -5,8 +5,8 @@ resources:
 - ../base
 - provider-config.yaml
 - testplatform-provider-config.yaml
-- https://github.com/konflux-ci/crossplane-control-plane/crossplane?ref=1563d850a1331ed68796ddc7e3849de5ee011579
-- https://github.com/konflux-ci/crossplane-control-plane/config?ref=1563d850a1331ed68796ddc7e3849de5ee011579
+- https://github.com/konflux-ci/crossplane-control-plane/crossplane?ref=bd3da0eff408eb329bfb5d7306b2aa3016d1a906
+- https://github.com/konflux-ci/crossplane-control-plane/config?ref=bd3da0eff408eb329bfb5d7306b2aa3016d1a906
 
 patches:
   - patch: |-


### PR DESCRIPTION
Upstream changes (1563d850..bd3da0ef):
- Read cluster credentials from a Secret instead of the EphemeralCluster status

Assisted-by: Claude claude-opus-4-6