### PR TITLE
KONFLUX-13356: Upgrade RHBoK operator and tekton-kueue in dev and staging

### DIFF
--- a/components/kueue/development/kueue/operator.yaml
+++ b/components/kueue/development/kueue/operator.yaml
@@ -24,7 +24,7 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "-1"
 spec:
-  channel: stable-v1.2
+  channel: stable-v1.3
   installPlanApproval: Automatic
   name: kueue-operator
   source: redhat-operators

--- a/components/kueue/development/kueue/operator.yaml
+++ b/components/kueue/development/kueue/operator.yaml
@@ -8,22 +8,6 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "-4"
 ---
-apiVersion: operators.coreos.com/v1alpha1
-kind: CatalogSource
-metadata:
-  annotations:
-    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
-    argocd.argoproj.io/sync-wave: "-3"
-  name: redhat-operators-1-18
-  namespace: openshift-kueue-operator
-spec:
-  displayName: redhat-operators-1-18
-  image: registry.redhat.io/redhat/redhat-operator-index:v4.18
-  sourceType: grpc
-  updateStrategy:
-    registryPoll:
-      interval: 30m
----
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:
@@ -43,5 +27,5 @@ spec:
   channel: stable-v1.3
   installPlanApproval: Automatic
   name: kueue-operator
-  source: redhat-operators-1-18
-  sourceNamespace: openshift-kueue-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace

--- a/components/kueue/development/kueue/operator.yaml
+++ b/components/kueue/development/kueue/operator.yaml
@@ -8,6 +8,22 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "-4"
 ---
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-3"
+  name: redhat-operators-1-18
+  namespace: openshift-kueue-operator
+spec:
+  displayName: redhat-operators-1-18
+  image: registry.redhat.io/redhat/redhat-operator-index:v4.18
+  sourceType: grpc
+  updateStrategy:
+    registryPoll:
+      interval: 30m
+---
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:
@@ -27,5 +43,5 @@ spec:
   channel: stable-v1.3
   installPlanApproval: Automatic
   name: kueue-operator
-  source: redhat-operators
-  sourceNamespace: openshift-marketplace
+  source: redhat-operators-1-18
+  sourceNamespace: openshift-kueue-operator

--- a/components/kueue/development/queue-config/cluster-queue.yaml
+++ b/components/kueue/development/queue-config/cluster-queue.yaml
@@ -16,8 +16,9 @@ kind: ClusterQueue
 metadata:
   name: cluster-pipeline-queue
 spec:
-    admissionChecks:
-    - static-admission
+    admissionChecksStrategy:
+      admissionChecks:
+      - name: static-admission
     flavorFungibility:
       whenCanBorrow: MayStopSearch
       whenCanPreempt: TryNextFlavor

--- a/components/kueue/development/queue-config/cluster-queue.yaml
+++ b/components/kueue/development/queue-config/cluster-queue.yaml
@@ -19,7 +19,7 @@ spec:
     admissionChecks:
     - static-admission
     flavorFungibility:
-      whenCanBorrow: Borrow
+      whenCanBorrow: MayStopSearch
       whenCanPreempt: TryNextFlavor
     namespaceSelector: {}
     preemption:
@@ -28,7 +28,6 @@ spec:
       reclaimWithinCohort: Never
       withinClusterQueue: Never
     queueingStrategy: BestEffortFIFO
-    stopPolicy: None
     resourceGroups:
     - coveredResources:
       - tekton.dev/pipelineruns

--- a/components/kueue/development/tekton-kueue/kustomization.yaml
+++ b/components/kueue/development/tekton-kueue/kustomization.yaml
@@ -1,12 +1,12 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- https://github.com/konflux-ci/tekton-kueue/config/default?ref=964790eef15cef723654b6f62b36b8cde867f9f7
+- https://github.com/konflux-ci/tekton-kueue/config/default?ref=cec0b3c8a240a289bb7aff4313ea647b292d96cc
 
 images:
 - name: konflux-ci/tekton-kueue
   newName: quay.io/konflux-ci/tekton-kueue
-  newTag: 964790eef15cef723654b6f62b36b8cde867f9f7
+  newTag: cec0b3c8a240a289bb7aff4313ea647b292d96cc
 
 namespace: tekton-kueue
 # ensure that installation starts after the installation of kueue complete

--- a/components/kueue/staging/base/kueue/operator.yaml
+++ b/components/kueue/staging/base/kueue/operator.yaml
@@ -40,7 +40,7 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "-1"
 spec:
-  channel: stable-v1.2
+  channel: stable-v1.3
   installPlanApproval: Automatic
   name: kueue-operator
   source: redhat-operators-1-18

--- a/components/kueue/staging/base/tekton-kueue/kustomization.yaml
+++ b/components/kueue/staging/base/tekton-kueue/kustomization.yaml
@@ -1,12 +1,12 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- https://github.com/konflux-ci/tekton-kueue/config/default?ref=964790eef15cef723654b6f62b36b8cde867f9f7
+- https://github.com/konflux-ci/tekton-kueue/config/default?ref=cec0b3c8a240a289bb7aff4313ea647b292d96cc
 
 images:
 - name: konflux-ci/tekton-kueue
   newName: quay.io/konflux-ci/tekton-kueue
-  newTag: 964790eef15cef723654b6f62b36b8cde867f9f7
+  newTag: cec0b3c8a240a289bb7aff4313ea647b292d96cc
 
 namespace: tekton-kueue
 # ensure that installation starts after the installation of kueue complete

--- a/components/kueue/staging/stone-stage-p01/queue-config/cluster-queue.yaml
+++ b/components/kueue/staging/stone-stage-p01/queue-config/cluster-queue.yaml
@@ -13,7 +13,7 @@ spec:
   admissionChecks:
   - static-admission
   flavorFungibility:
-    whenCanBorrow: Borrow
+    whenCanBorrow: MayStopSearch
     whenCanPreempt: TryNextFlavor
   namespaceSelector: {}
   preemption:
@@ -153,7 +153,6 @@ spec:
       resources:
       - name: windows-4xlarge-amd64
         nominalQuota: '5'
-  stopPolicy: None
 ---
 apiVersion: kueue.x-k8s.io/v1beta1
 kind: ResourceFlavor

--- a/components/kueue/staging/stone-stg-rh01/queue-config/cluster-queue.yaml
+++ b/components/kueue/staging/stone-stg-rh01/queue-config/cluster-queue.yaml
@@ -13,7 +13,7 @@ spec:
   admissionChecks:
   - static-admission
   flavorFungibility:
-    whenCanBorrow: Borrow
+    whenCanBorrow: MayStopSearch
     whenCanPreempt: TryNextFlavor
   namespaceSelector: {}
   preemption:
@@ -143,7 +143,6 @@ spec:
         nominalQuota: '1000'
       - name: localhost
         nominalQuota: '1000'
-  stopPolicy: None
 ---
 apiVersion: kueue.x-k8s.io/v1beta1
 kind: ResourceFlavor

--- a/components/policies/development/kueue/queue-config/.chainsaw-test/resources/expected-localqueue-kanary.yaml
+++ b/components/policies/development/kueue/queue-config/.chainsaw-test/resources/expected-localqueue-kanary.yaml
@@ -1,4 +1,4 @@
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: LocalQueue
 metadata:
   name: pipelines-queue

--- a/components/policies/development/kueue/queue-config/.chainsaw-test/resources/expected-localqueue-mintmaker.yaml
+++ b/components/policies/development/kueue/queue-config/.chainsaw-test/resources/expected-localqueue-mintmaker.yaml
@@ -1,4 +1,4 @@
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: LocalQueue
 metadata:
   name: pipelines-queue

--- a/components/policies/development/kueue/queue-config/.chainsaw-test/resources/expected-localqueue-paused.yaml
+++ b/components/policies/development/kueue/queue-config/.chainsaw-test/resources/expected-localqueue-paused.yaml
@@ -1,4 +1,4 @@
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: LocalQueue
 metadata:
   name: pipelines-queue

--- a/components/policies/development/kueue/queue-config/.chainsaw-test/resources/expected-localqueue.yaml
+++ b/components/policies/development/kueue/queue-config/.chainsaw-test/resources/expected-localqueue.yaml
@@ -1,4 +1,4 @@
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: LocalQueue
 metadata:
   name: pipelines-queue

--- a/components/policies/development/kueue/queue-config/.chainsaw-test/resources/localqueue-crd.yaml
+++ b/components/policies/development/kueue/queue-config/.chainsaw-test/resources/localqueue-crd.yaml
@@ -11,7 +11,7 @@ spec:
     singular: localqueue
   scope: Namespaced
   versions:
-  - name: v1beta1
+  - name: v1beta2
     served: true
     storage: true
     schema:

--- a/components/policies/development/kueue/queue-config/cluster-policy.yaml
+++ b/components/policies/development/kueue/queue-config/cluster-policy.yaml
@@ -30,7 +30,7 @@ spec:
       generateExisting: true
       orphanDownstreamOnPolicyDelete: true
       synchronize: true
-      apiVersion: kueue.x-k8s.io/v1beta1
+      apiVersion: kueue.x-k8s.io/v1beta2
       kind: LocalQueue
       name: pipelines-queue
       namespace: '{{request.object.metadata.name}}'


### PR DESCRIPTION
## What
Upgrade the kueue stack in development and staging and align CRs with kueue 0.16.x conversion webhook behavior:
- Update RHBoK (Kueue operator) channel from `stable-v1.2` to `stable-v1.3`
- Update tekton-kueue to `cec0b3c` (built against kueue v0.16.6 / k8s.io v0.35.3)
- Align ClusterQueue fields with v1beta2 conversion webhook output to prevent ArgoCD drift:
  - `Borrow` (deprecated) → `MayStopSearch`
  - Remove `stopPolicy: None` (default value, not set by the webhook)
- Update Kyverno LocalQueue policy apiVersion to `v1beta2`
- Update chainsaw tests for v1beta2
- Pin CatalogSource (`redhat-operator-index:v4.18`) in development to ensure `stable-v1.3` channel availability (matching staging pattern)

CRs remain on `apiVersion: v1beta1` — full v1beta2 migration will follow in a separate PR.

[KONFLUX-13356](https://issues.redhat.com/browse/KONFLUX-13356)

## Why
To fix CVE-2026-40938 in tekton-kueue, we need to bump `tektoncd/pipeline` from v1.10.2 to v1.11.1. This bump pulls in `k8s.io` v0.35+, which breaks kueue v0.14.x due to breaking API changes in the k8s libraries.

RHBoK 1.3 is based on kueue v0.16.6, which serves v1beta2 (new storage version), v1beta1 (still supported), and v1 APIs. Additionally, RHBoK 1.2 is now out of support (per #forum-ocp-kueue).

The kueue 0.16.x conversion webhook round-trips v1beta1 resources through v1beta2, mutating deprecated field values (`Borrow` → `MayStopSearch`) and stripping defaults (`stopPolicy: None`). Without aligning the manifests to the post-conversion values, ArgoCD sees perpetual drift.

The development overlay previously relied on the default `redhat-operators` catalog, which may not include `stable-v1.3` on all OCP 4.18.x cluster versions. A pinned CatalogSource (same as staging) guarantees channel availability.

Rollout plan:
1. **Upgrade operator + tekton-kueue + align CR fields** (this PR)
2. **Migrate CRs apiVersion to v1beta2** (follow-up PR)
3. Bump tektoncd/pipeline to v1.11.1
4. Update Renovate rules

## Validation
- `kustomize build` passes for all affected paths:
  - `components/kueue/development/kueue/`
  - `components/kueue/development/tekton-kueue/`
  - `components/kueue/development/queue-config/`
  - `components/kueue/staging/base/kueue/`
  - `components/kueue/staging/base/tekton-kueue/`
  - `components/kueue/staging/stone-stage-p01/queue-config/`
  - `components/kueue/staging/stone-stg-rh01/queue-config/`
  - `components/policies/development/kueue/`
- Chainsaw tests updated for v1beta2 (mock CRD + expected LocalQueue assertions)
- tekton-kueue image verified at `quay.io/konflux-ci/tekton-kueue:cec0b3c8a240a289bb7aff4313ea647b292d96cc`
- tekton-kueue kueue v0.16.6 bump PR: https://github.com/konflux-ci/tekton-kueue/pull/416
- Production is intentionally excluded — will be promoted after validation in dev/staging

## Risk Assessment
**Risk Level:** Low-Medium
**Rollback:** Revert the channel back to `stable-v1.2`, tekton-kueue ref to `964790e`, CR fields to original values, and remove the CatalogSource
Development and staging only — no production impact. The operator upgrade is managed by OLM with automatic install plan approval. CRs stay on v1beta1 apiVersion (still fully supported in kueue 0.16.x). The field changes (`MayStopSearch`, removing `stopPolicy: None`) are semantically equivalent — `MayStopSearch` replaces the deprecated `Borrow` with identical behavior, and `None` is the default `stopPolicy`.

[KONFLUX-13356]: https://redhat.atlassian.net/browse/KONFLUX-13356?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ