### PR TITLE
chore(PVO11Y-5209): Update Logging Operator to 6.4

### DIFF
--- a/components/monitoring/logging/base/install-logging-operator.yaml
+++ b/components/monitoring/logging/base/install-logging-operator.yaml
@@ -9,7 +9,7 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "0"
 spec:
-  channel: "stable-6.1"
+  channel: "stable-6.4"
   name: cluster-logging
   source: redhat-operators
   sourceNamespace: openshift-marketplace

--- a/components/monitoring/logging/production/base/kustomization.yaml
+++ b/components/monitoring/logging/production/base/kustomization.yaml
@@ -34,13 +34,3 @@ patches:
       version: v1
       kind: ClusterLogForwarder
       name: instance
-  - target:
-      group: operators.coreos.com
-      version: v1alpha1
-      kind: Subscription
-      name: cluster-logging
-      namespace: openshift-logging
-    patch: |
-      - op: replace
-        path: /spec/channel
-        value: "stable-6.3"

--- a/components/monitoring/logging/staging/base/kustomization.yaml
+++ b/components/monitoring/logging/staging/base/kustomization.yaml
@@ -35,12 +35,3 @@ patches:
       version: v1
       kind: ClusterLogForwarder
       name: instance
-  - target:
-      group: operators.coreos.com
-      version: v1alpha1
-      kind: Subscription
-      name: cluster-logging
-    patch: |
-      - op: replace
-        path: /spec/channel
-        value: "stable-6.4"


### PR DESCRIPTION
Upgrade to OpenShift Logging Operator 6.3 for production has been successful (redhat-appstudio/infra-deployments#11570). Now we can upgrade to 6.4. Remove the env patches and updated the operator version at the base layer now that stage and prod will use the same version.

## Risk Assessment

**Risk Level:** Low
**Description:** Upgrade to Logging Operator resources may become stuck
**Rollback:** Revert changes made by this PR

## Validation

Staging PR: https://github.com/redhat-appstudio/infra-deployments/pull/11533