### PR TITLE
Fix tekton-kueue image name in ring 1 per-cluster overlays

### DIFF
--- a/components/kueue/production/kflux-ocp-p01/kustomization.yaml
+++ b/components/kueue/production/kflux-ocp-p01/kustomization.yaml
@@ -8,7 +8,7 @@ commonAnnotations:
   argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 
 images:
-- name: konflux-ci/tekton-kueue
+- name: quay.io/konflux-ci/tekton-kueue
   newName: quay.io/konflux-ci/tekton-kueue
   newTag: 964790eef15cef723654b6f62b36b8cde867f9f7
 

--- a/components/kueue/production/kflux-osp-p01/kustomization.yaml
+++ b/components/kueue/production/kflux-osp-p01/kustomization.yaml
@@ -8,6 +8,6 @@ commonAnnotations:
   argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 
 images:
-- name: konflux-ci/tekton-kueue
+- name: quay.io/konflux-ci/tekton-kueue
   newName: quay.io/konflux-ci/tekton-kueue
   newTag: 964790eef15cef723654b6f62b36b8cde867f9f7

--- a/components/kueue/production/stone-prod-p01/kustomization.yaml
+++ b/components/kueue/production/stone-prod-p01/kustomization.yaml
@@ -8,6 +8,6 @@ commonAnnotations:
   argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 
 images:
-- name: konflux-ci/tekton-kueue
+- name: quay.io/konflux-ci/tekton-kueue
   newName: quay.io/konflux-ci/tekton-kueue
   newTag: 964790eef15cef723654b6f62b36b8cde867f9f7

--- a/components/kueue/production/stone-prod-p02/kustomization.yaml
+++ b/components/kueue/production/stone-prod-p02/kustomization.yaml
@@ -8,6 +8,6 @@ commonAnnotations:
   argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 
 images:
-- name: konflux-ci/tekton-kueue
+- name: quay.io/konflux-ci/tekton-kueue
   newName: quay.io/konflux-ci/tekton-kueue
   newTag: 964790eef15cef723654b6f62b36b8cde867f9f7


### PR DESCRIPTION
## Description:
The kustomize images name field must match the already-transformed image from the base (quay.io/konflux-ci/tekton-kueue), not the short form (konflux-ci/tekton-kueue). Without this fix, per-cluster image tag overrides are silently ignored and clusters stay on the base SHA instead of the intended 964790e.

## Changes included (815dbf1..964790e):
- 964790e accept QPS and Burst from flags (#400)
- 7ee9a37 Add godoc documentation to controller, webhook, and config packages
- 67d5fa2 Fix: set response.patch to nil when all patches are filtered out (#392)
- b6c7575 Add unit tests for controller and common packages
- 46aef57 fix: return error instead of panicking on invalid resource annotations
- 5912671 feat: Add e2e test coverage collection with coverport (#326)
- fadaf9a fix: filter leaked zero-value fields from webhook admission patches (#329)
- 8bddfb1 Fix CVE: GHSA-9h8m-3fm2-qjrq (#337)

## Affected clusters:
- kflux-ocp-p01
- kflux-osp-p01
- stone-prod-p01
- stone-prod-p02

## Risk Assessment
**Risk Level:** Medium
**Rollback:** Revert PR and redeploy previous image tag

## Validation
Tested on staging — no regressions observed.
Staging PR: https://github.com/redhat-appstudio/infra-deployments/pull/11566

Verified with kustomize build on all 4 ring 1 clusters.