### PR TITLE
Fix kanary pipeline to match ArgoCD expected spec

### DIFF
--- a/components/monitoring/kanary/staging/base/pipelines/kanary-otel-pipeline.yaml
+++ b/components/monitoring/kanary/staging/base/pipelines/kanary-otel-pipeline.yaml
@@ -52,8 +52,9 @@ spec:
       default: ""
   tasks:
     - name: run-kanary-tests
-      timeout: "1h"
+      timeout: "1h0m0s"
       taskRef:
+        kind: Task
         name: run-kanary-tests
       params:
         - name: tested-cluster


### PR DESCRIPTION
Normalize timeout format to "1h0m0s" and add explicit "kind: Task" to taskRef to prevent reconciliation drift.