### PR TITLE
Fix tekton-kueue image name in ring 1 per-cluster overlays

### DIFF
--- a/components/kueue/production/kflux-ocp-p01/kustomization.yaml
+++ b/components/kueue/production/kflux-ocp-p01/kustomization.yaml
@@ -8,7 +8,7 @@ commonAnnotations:
   argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 
 images:
-- name: konflux-ci/tekton-kueue
+- name: quay.io/konflux-ci/tekton-kueue
   newName: quay.io/konflux-ci/tekton-kueue
   newTag: 964790eef15cef723654b6f62b36b8cde867f9f7
 

--- a/components/kueue/production/kflux-osp-p01/kustomization.yaml
+++ b/components/kueue/production/kflux-osp-p01/kustomization.yaml
@@ -8,6 +8,6 @@ commonAnnotations:
   argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 
 images:
-- name: konflux-ci/tekton-kueue
+- name: quay.io/konflux-ci/tekton-kueue
   newName: quay.io/konflux-ci/tekton-kueue
   newTag: 964790eef15cef723654b6f62b36b8cde867f9f7

--- a/components/kueue/production/stone-prod-p01/kustomization.yaml
+++ b/components/kueue/production/stone-prod-p01/kustomization.yaml
@@ -8,6 +8,6 @@ commonAnnotations:
   argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 
 images:
-- name: konflux-ci/tekton-kueue
+- name: quay.io/konflux-ci/tekton-kueue
   newName: quay.io/konflux-ci/tekton-kueue
   newTag: 964790eef15cef723654b6f62b36b8cde867f9f7

--- a/components/kueue/production/stone-prod-p02/kustomization.yaml
+++ b/components/kueue/production/stone-prod-p02/kustomization.yaml
@@ -8,6 +8,6 @@ commonAnnotations:
   argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 
 images:
-- name: konflux-ci/tekton-kueue
+- name: quay.io/konflux-ci/tekton-kueue
   newName: quay.io/konflux-ci/tekton-kueue
   newTag: 964790eef15cef723654b6f62b36b8cde867f9f7


### PR DESCRIPTION
## Summary
- Fix the kustomize `images.name` field in 4 ring 1 per-cluster overlays from `konflux-ci/tekton-kueue` to `quay.io/konflux-ci/tekton-kueue`
- The name must match the already-transformed image from the base kustomization; without this fix, per-cluster tag overrides to `964790e` are silently ignored and clusters remain on `815dbf1`
- Affects clusters: kflux-ocp-p01, kflux-osp-p01, stone-prod-p01, stone-prod-p02

## Test plan
- [x] Verified `kustomize build` on all 4 affected cluster overlays produces `quay.io/konflux-ci/tekton-kueue:964790eef15cef723654b6f62b36b8cde867f9f7`
- [x] Verified ring 3 clusters (kflux-prd-rh02, kflux-prd-rh03, kflux-fedora-01) remain on base SHA `815dbf1`
- [ ] After merge, verify ArgoCD syncs and pods restart with the correct image on ring 1 clusters

🤖 Generated with [Claude Code](https://claude.com/claude-code)