### PR TITLE
fix CVE-2026-33186, CVE-2026-4645 for KubeArchive opentelemetry

### DIFF
--- a/components/kubearchive/base/monitoring-otel-collector.yaml
+++ b/components/kubearchive/base/monitoring-otel-collector.yaml
@@ -76,7 +76,7 @@ spec:
             readOnlyRootFilesystem: true
             runAsNonRoot: true
         - name: otel-collector
-          image: quay.io/kubearchive/opentelemetry-collector:0.123.0
+          image: quay.io/kubearchive/opentelemetry-collector:0.151.0
           command:
             - '/otelcol'
             - '--config=/conf/otel-collector-config.yaml'


### PR DESCRIPTION

[KONFLUX-12789](https://redhat.atlassian.net/browse/KONFLUX-12789)

[KONFLUX-12711](https://redhat.atlassian.net/browse/KONFLUX-12711)

[KONFLUX-12789]: https://redhat.atlassian.net/browse/KONFLUX-12789?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[KONFLUX-12711]: https://redhat.atlassian.net/browse/KONFLUX-12711?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ