### PR TITLE
Fix tekton-kueue image name in ring 2 per-cluster overlays

### DIFF
--- a/components/kueue/production/kflux-rhel-p01/kustomization.yaml
+++ b/components/kueue/production/kflux-rhel-p01/kustomization.yaml
@@ -8,6 +8,6 @@ commonAnnotations:
   argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 
 images:
-- name: konflux-ci/tekton-kueue
+- name: quay.io/konflux-ci/tekton-kueue
   newName: quay.io/konflux-ci/tekton-kueue
   newTag: 964790eef15cef723654b6f62b36b8cde867f9f7

--- a/components/kueue/production/stone-prd-rh01/kustomization.yaml
+++ b/components/kueue/production/stone-prd-rh01/kustomization.yaml
@@ -8,6 +8,6 @@ commonAnnotations:
   argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 
 images:
-- name: konflux-ci/tekton-kueue
+- name: quay.io/konflux-ci/tekton-kueue
   newName: quay.io/konflux-ci/tekton-kueue
   newTag: 964790eef15cef723654b6f62b36b8cde867f9f7


### PR DESCRIPTION
## Description:
Same fix as ring 1: use quay.io/konflux-ci/tekton-kueue as the kustomize images name to match the base-transformed image.

## Changes included (815dbf1..964790e):
- 964790e accept QPS and Burst from flags (#400)
- 7ee9a37 Add godoc documentation to controller, webhook, and config packages
- 67d5fa2 Fix: set response.patch to nil when all patches are filtered out (#392)
- b6c7575 Add unit tests for controller and common packages
- 46aef57 fix: return error instead of panicking on invalid resource annotations
- 5912671 feat: Add e2e test coverage collection with coverport (#326)
- fadaf9a fix: filter leaked zero-value fields from webhook admission patches (#329)
- 8bddfb1 Fix CVE: GHSA-9h8m-3fm2-qjrq (#337)

## Affected clusters:
- stone-prd-rh01
- kflux-rhel-p01

## Risk Assessment
**Risk Level:** Low
**Rollback:** Revert PR and redeploy previous image tag

## Validation
Tested on staging — no regressions observed.
Staging PR: https://github.com/redhat-appstudio/infra-deployments/pull/11566

Tested on production ring 1 — no regressions observed.
[Prod Ring 1 PR: https://github.com/redhat-appstudio/infra-deployments/pull/11577](https://github.com/redhat-appstudio/infra-deployments/pull/11594)

Verified with kustomize build on both ring 2 clusters.