### PR TITLE
Fix tekton-kueue image name in ring 2 per-cluster overlays

### DIFF
--- a/components/kueue/production/kflux-rhel-p01/kustomization.yaml
+++ b/components/kueue/production/kflux-rhel-p01/kustomization.yaml
@@ -8,6 +8,6 @@ commonAnnotations:
   argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 
 images:
-- name: konflux-ci/tekton-kueue
+- name: quay.io/konflux-ci/tekton-kueue
   newName: quay.io/konflux-ci/tekton-kueue
   newTag: 964790eef15cef723654b6f62b36b8cde867f9f7

--- a/components/kueue/production/stone-prd-rh01/kustomization.yaml
+++ b/components/kueue/production/stone-prd-rh01/kustomization.yaml
@@ -8,6 +8,6 @@ commonAnnotations:
   argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 
 images:
-- name: konflux-ci/tekton-kueue
+- name: quay.io/konflux-ci/tekton-kueue
   newName: quay.io/konflux-ci/tekton-kueue
   newTag: 964790eef15cef723654b6f62b36b8cde867f9f7


### PR DESCRIPTION
## Summary
- Fix the kustomize `images.name` field in 2 ring 2 per-cluster overlays from `konflux-ci/tekton-kueue` to `quay.io/konflux-ci/tekton-kueue`
- Same issue as ring 1 fix (#11603): the name must match the already-transformed image from the base kustomization; without this fix, per-cluster tag overrides to `964790e` are silently ignored
- Affects clusters: stone-prd-rh01, kflux-rhel-p01

## Test plan
- [x] Verified `kustomize build` on both affected cluster overlays produces `quay.io/konflux-ci/tekton-kueue:964790eef15cef723654b6f62b36b8cde867f9f7`
- [x] Ring 1 fix verified in production (#11603)
- [ ] After merge, verify ArgoCD syncs and pods restart with the correct image on ring 2 clusters

🤖 Generated with [Claude Code](https://claude.com/claude-code)