### PR TITLE
feat(KONFLUX-13271): Remove perfscale repo ref

### DIFF
--- a/components/monitoring/grafana/production/dashboards/perfscale/kustomization.yaml
+++ b/components/monitoring/grafana/production/dashboards/perfscale/kustomization.yaml
@@ -2,4 +2,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - https://github.com/redhat-appstudio/perfscale/grafana/?ref=4b4b9640667964558eb974f658d02d0546b65665
+  - https://github.com/konflux-ci/perfscale/grafana/?ref=4b4b9640667964558eb974f658d02d0546b65665


### PR DESCRIPTION
In [#11427](https://github.com/redhat-appstudio/infra-deployments/pull/11427) we merged this to staging, now it is time to rename the repo in prod as well.

## Risk Assessment
**Risk Level:** Low
**Description:** perfscale repo was renamed, changing the reference here now
**Rollback:** Revert PR

## Validation
Tested on staging — no regressions observed.
Staging PR: https://github.com/redhat-appstudio/infra-deployments/pull/11427