### PR TITLE
Promote squid (caching) helm chart from staging to production

### DIFF
--- a/components/squid/production/squid-helm-generator.yaml
+++ b/components/squid/production/squid-helm-generator.yaml
@@ -4,7 +4,7 @@ metadata:
   name: squid-helm
 name: squid-helm
 repo: oci://quay.io/konflux-ci/caching
-version: 0.1.1409+5a80313
+version: 0.1.1506+abe1045
 valuesInline:
   installCertManagerComponents: false
   mirrord:


### PR DESCRIPTION
What/Why

Promote the caching helm chart to production to resolve 4 CVEs in the konflux-ci/squid component:

- [KONFLUX-13021](https://redhat.atlassian.net/browse/KONFLUX-13021): CVE-2026-33810 — Go crypto/x509 certificate validation bypass
- [KONFLUX-13024](https://redhat.atlassian.net/browse/KONFLUX-13024): CVE-2026-32282 — Root.Chmod symlink traversal
- [KONFLUX-13085](https://redhat.atlassian.net/browse/KONFLUX-13085): CVE-2026-32280 — Go x509 DoS in certificate chain building
- [KONFLUX-13088](https://redhat.atlassian.net/browse/KONFLUX-13088): CVE-2026-32283 — Go crypto/tls DoS via TLS 1.3 key update messages

Validation

CI status checks for commit abe1045:
https://github.com/konflux-ci/caching/commit/abe104589eef60f6d485cf31994227e843b23d24/checks

Risk Assessment

Risk Level: Low
Rollback: Revert the commit

Assisted-by: Claude claude-opus-4-6

[KONFLUX-13021]: https://redhat.atlassian.net/browse/KONFLUX-13021?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[KONFLUX-13024]: https://redhat.atlassian.net/browse/KONFLUX-13024?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[KONFLUX-13085]: https://redhat.atlassian.net/browse/KONFLUX-13085?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[KONFLUX-13088]: https://redhat.atlassian.net/browse/KONFLUX-13088?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ