### PR TITLE
KFLUXVNGD-900: Promote crossplane-control-plane from staging to production

### DIFF
--- a/components/crossplane-control-plane/production/kustomization.yaml
+++ b/components/crossplane-control-plane/production/kustomization.yaml
@@ -5,8 +5,8 @@ resources:
 - ../base
 - provider-config.yaml
 - testplatform-provider-config.yaml
-- https://github.com/konflux-ci/crossplane-control-plane/crossplane?ref=21e0a14dd119966e396cfcab18b5085552da9304
-- https://github.com/konflux-ci/crossplane-control-plane/config?ref=21e0a14dd119966e396cfcab18b5085552da9304
+- https://github.com/konflux-ci/crossplane-control-plane/crossplane?ref=bd3da0eff408eb329bfb5d7306b2aa3016d1a906
+- https://github.com/konflux-ci/crossplane-control-plane/config?ref=bd3da0eff408eb329bfb5d7306b2aa3016d1a906
 
 patches:
   - patch: |-


### PR DESCRIPTION
What/Why

Changes since the last production ref (21e0a14):

- Read cluster credentials from a Secret instead of the EphemeralCluster status ([KFLUXVNGD-899](https://redhat.atlassian.net/browse/KFLUXVNGD-899))
- Remove PR dependency from XTestPlatformCluster
- Enable watch on EphemeralCluster Object resource ([KFLUXVNGD-836](https://redhat.atlassian.net/browse/KFLUXVNGD-836))
- Update Crossplane helm release to v2.2.0
- Update provider-kubernetes to v1.2.1
- Update function-patch-and-transform to v0.10.3
- Update function-auto-ready to v0.6.3
- Update function-go-templating to v0.12.0

Validation

Tested E2E with an IntegrationTestScneario on the stone-stg-rh01 cluster: https://github.com/amisstea/devfile-sample-go-basic/pull/30/checks

Risk Assessment

Risk Level: Low
Rollback: Revert the commit

Assisted-by: Claude claude-opus-4-6

[KFLUXVNGD-899]: https://redhat.atlassian.net/browse/KFLUXVNGD-899?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[KFLUXVNGD-836]: https://redhat.atlassian.net/browse/KFLUXVNGD-836?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ