### PR TITLE
pause mintmaker in staging

### DIFF
--- a/components/kueue/staging/stone-stage-p01/queue-config/cluster-queue.yaml
+++ b/components/kueue/staging/stone-stage-p01/queue-config/cluster-queue.yaml
@@ -41,7 +41,7 @@ spec:
       - name: aws-ip
         nominalQuota: '250'
       - name: mintmaker
-        nominalQuota: '150'
+        nominalQuota: '0'
   - coveredResources:
     - linux-amd64
     - linux-arm64

--- a/components/kueue/staging/stone-stg-rh01/queue-config/cluster-queue.yaml
+++ b/components/kueue/staging/stone-stg-rh01/queue-config/cluster-queue.yaml
@@ -41,7 +41,7 @@ spec:
       - name: aws-ip
         nominalQuota: '250'
       - name: mintmaker
-        nominalQuota: '150'
+        nominalQuota: '0'
   - coveredResources:
     - linux-amd64
     - linux-arm64


### PR DESCRIPTION
As a part of planned maintenance, we will need to reduce the number of pipelineruns in our clusters temporarily.  Reduce the number of allowed mintmaker pipelineruns to 0 to reduce the number of pipelineruns running and to give existing pipelineruns more resources to complete.

Fixes: KFLUXINFRA-3646