### PR TITLE
pause mintmaker in production

### DIFF
--- a/components/kueue/production/kflux-ocp-p01/queue-config/cluster-queue.yaml
+++ b/components/kueue/production/kflux-ocp-p01/queue-config/cluster-queue.yaml
@@ -32,7 +32,7 @@ spec:
       - name: aws-ip
         nominalQuota: '250'
       - name: mintmaker
-        nominalQuota: '150'
+        nominalQuota: '0'
   - coveredResources:
     - linux-amd64
     - linux-arm64

--- a/components/kueue/production/kflux-osp-p01/queue-config/cluster-queue.yaml
+++ b/components/kueue/production/kflux-osp-p01/queue-config/cluster-queue.yaml
@@ -32,7 +32,7 @@ spec:
       - name: aws-ip
         nominalQuota: '250'
       - name: mintmaker
-        nominalQuota: '5'
+        nominalQuota: '0'
   - coveredResources:
     - linux-amd64
     - linux-arm64

--- a/components/kueue/production/kflux-prd-rh02/queue-config/cluster-queue.yaml
+++ b/components/kueue/production/kflux-prd-rh02/queue-config/cluster-queue.yaml
@@ -32,7 +32,7 @@ spec:
       - name: aws-ip
         nominalQuota: '250'
       - name: mintmaker
-        nominalQuota: '150'
+        nominalQuota: '0'
   - coveredResources:
     - linux-amd64
     - linux-arm64

--- a/components/kueue/production/kflux-prd-rh03/queue-config/cluster-queue.yaml
+++ b/components/kueue/production/kflux-prd-rh03/queue-config/cluster-queue.yaml
@@ -32,7 +32,7 @@ spec:
       - name: aws-ip
         nominalQuota: '500'
       - name: mintmaker
-        nominalQuota: '150'
+        nominalQuota: '0'
   - coveredResources:
     - linux-amd64
     - linux-arm64

--- a/components/kueue/production/kflux-rhel-p01/queue-config/cluster-queue.yaml
+++ b/components/kueue/production/kflux-rhel-p01/queue-config/cluster-queue.yaml
@@ -32,7 +32,7 @@ spec:
       - name: aws-ip
         nominalQuota: '250'
       - name: mintmaker
-        nominalQuota: '150'
+        nominalQuota: '0'
   - coveredResources:
     - linux-amd64
     - linux-arm64

--- a/components/kueue/production/stone-prd-rh01/queue-config/cluster-queue.yaml
+++ b/components/kueue/production/stone-prd-rh01/queue-config/cluster-queue.yaml
@@ -32,7 +32,7 @@ spec:
       - name: aws-ip
         nominalQuota: '250'
       - name: mintmaker
-        nominalQuota: '150'
+        nominalQuota: '0'
   - coveredResources:
     - linux-amd64
     - linux-arm64

--- a/components/kueue/production/stone-prod-p01/queue-config/cluster-queue.yaml
+++ b/components/kueue/production/stone-prod-p01/queue-config/cluster-queue.yaml
@@ -32,7 +32,7 @@ spec:
       - name: aws-ip
         nominalQuota: '250'
       - name: mintmaker
-        nominalQuota: '150'
+        nominalQuota: '0'
   - coveredResources:
     - linux-amd64
     - linux-arm64

--- a/components/kueue/production/stone-prod-p02/queue-config/cluster-queue.yaml
+++ b/components/kueue/production/stone-prod-p02/queue-config/cluster-queue.yaml
@@ -32,7 +32,7 @@ spec:
       - name: aws-ip
         nominalQuota: '250'
       - name: mintmaker
-        nominalQuota: '150'
+        nominalQuota: '0'
   - coveredResources:
     - linux-amd64
     - linux-arm64


### PR DESCRIPTION
As a part of planned maintenance, we will need to reduce the number of pipelineruns in our clusters temporarily.  Reduce the number of allowed mintmaker pipelineruns to 0 to reduce the number of pipelineruns running and to give existing pipelineruns more resources to complete.

Fixes: KFLUXINFRA-3646