### PR TITLE
Promote tekton-kueue to production (ring 3)

### DIFF
--- a/components/kueue/production/base/tekton-kueue/kustomization.yaml
+++ b/components/kueue/production/base/tekton-kueue/kustomization.yaml
@@ -1,12 +1,12 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- https://github.com/konflux-ci/tekton-kueue/config/default?ref=815dbf158b0e39df568eb901dcf05e759099991a
+- https://github.com/konflux-ci/tekton-kueue/config/default?ref=964790eef15cef723654b6f62b36b8cde867f9f7
 
 images:
 - name: konflux-ci/tekton-kueue
   newName: quay.io/konflux-ci/tekton-kueue
-  newTag: 815dbf158b0e39df568eb901dcf05e759099991a
+  newTag: 964790eef15cef723654b6f62b36b8cde867f9f7
 
 namespace: tekton-kueue
 # ensure that installation starts after the installation of kueue complete

--- a/components/kueue/production/kflux-ocp-p01/kustomization.yaml
+++ b/components/kueue/production/kflux-ocp-p01/kustomization.yaml
@@ -7,11 +7,6 @@ resources:
 commonAnnotations:
   argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 
-images:
-- name: quay.io/konflux-ci/tekton-kueue
-  newName: quay.io/konflux-ci/tekton-kueue
-  newTag: 964790eef15cef723654b6f62b36b8cde867f9f7
-
 configMapGenerator:
   - name: tekton-kueue-config
     namespace: tekton-kueue

--- a/components/kueue/production/kflux-osp-p01/kustomization.yaml
+++ b/components/kueue/production/kflux-osp-p01/kustomization.yaml
@@ -6,8 +6,3 @@ resources:
 
 commonAnnotations:
   argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
-
-images:
-- name: quay.io/konflux-ci/tekton-kueue
-  newName: quay.io/konflux-ci/tekton-kueue
-  newTag: 964790eef15cef723654b6f62b36b8cde867f9f7

--- a/components/kueue/production/kflux-rhel-p01/kustomization.yaml
+++ b/components/kueue/production/kflux-rhel-p01/kustomization.yaml
@@ -6,8 +6,3 @@ resources:
 
 commonAnnotations:
   argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
-
-images:
-- name: quay.io/konflux-ci/tekton-kueue
-  newName: quay.io/konflux-ci/tekton-kueue
-  newTag: 964790eef15cef723654b6f62b36b8cde867f9f7

--- a/components/kueue/production/stone-prd-rh01/kustomization.yaml
+++ b/components/kueue/production/stone-prd-rh01/kustomization.yaml
@@ -6,8 +6,3 @@ resources:
 
 commonAnnotations:
   argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
-
-images:
-- name: quay.io/konflux-ci/tekton-kueue
-  newName: quay.io/konflux-ci/tekton-kueue
-  newTag: 964790eef15cef723654b6f62b36b8cde867f9f7

--- a/components/kueue/production/stone-prod-p01/kustomization.yaml
+++ b/components/kueue/production/stone-prod-p01/kustomization.yaml
@@ -6,8 +6,3 @@ resources:
 
 commonAnnotations:
   argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
-
-images:
-- name: quay.io/konflux-ci/tekton-kueue
-  newName: quay.io/konflux-ci/tekton-kueue
-  newTag: 964790eef15cef723654b6f62b36b8cde867f9f7

--- a/components/kueue/production/stone-prod-p02/kustomization.yaml
+++ b/components/kueue/production/stone-prod-p02/kustomization.yaml
@@ -6,8 +6,3 @@ resources:
 
 commonAnnotations:
   argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
-
-images:
-- name: quay.io/konflux-ci/tekton-kueue
-  newName: quay.io/konflux-ci/tekton-kueue
-  newTag: 964790eef15cef723654b6f62b36b8cde867f9f7


### PR DESCRIPTION
Affected clusters:
- kflux-prd-rh02
- kflux-prd-rh03
- kflux-fedora-01

Final ring of the phased rollout. Updates the production base from 815dbf1 to 964790e and removes per-cluster image overrides added in Ring 1 and Ring 2, so all clusters get the new version from the base.