### PR TITLE
Promote notification-service from staging to production

### DIFF
--- a/components/notification-controller/production/kustomization.yaml
+++ b/components/notification-controller/production/kustomization.yaml
@@ -2,13 +2,13 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-- https://github.com/konflux-ci/notification-service/config/default?ref=4c07f5d3bf6dc3fa556da8c9510d643775803fed
+- https://github.com/konflux-ci/notification-service/config/default?ref=813f902b2df56da644170ecbab5b438fc88dd9be
 - ../base/external-secrets
 
 images:
   - name: quay.io/konflux-ci/notification-service
     newName: quay.io/konflux-ci/notification-service
-    newTag: 4c07f5d3bf6dc3fa556da8c9510d643775803fed
+    newTag: 813f902b2df56da644170ecbab5b438fc88dd9be
 
 namespace: notification-controller
 


### PR DESCRIPTION
## What/Why

Changes since the last production ref (4c07f5d):

- Make PipelineRun filtering configurable ([KONFLUX-13346](https://redhat.atlassian.net/browse/KONFLUX-13346))

## Validation

Merged and tested in staging: https://github.com/redhat-appstudio/infra-deployments/pull/11650

## Risk Assessment

Risk Level: Low
Rollback: Revert the commit

Assisted-by: Claude Code

[KONFLUX-13346]: https://redhat.atlassian.net/browse/KONFLUX-13346?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ