### PR TITLE
Add NOTIFICATION_FILTER_ANNOTATIONS env var for dev and staging

### DIFF
--- a/components/notification-controller/README.md
+++ b/components/notification-controller/README.md
@@ -35,6 +35,7 @@ List of environment variables:
 | -- | -- |
 | NOTIFICATION_REGION | define the AWS region to use
 | NOTIFICATION_TOPIC_ARN | the topic arn the messages will be sent to
+| NOTIFICATION_FILTER_ANNOTATIONS | comma-separated annotation keys to match PipelineRuns for notification processing
 
 These environment variables will be used to define the `SNS topic` which the messages will be sent to 
 and the `region` of the AWS account.

--- a/components/notification-controller/development/kustomization.yaml
+++ b/components/notification-controller/development/kustomization.yaml
@@ -16,3 +16,7 @@ patches:
     target:
       name: notification-controller-controller-manager
       kind: Deployment
+  - path: pipelinerun_filters.yaml
+    target:
+      name: notification-controller-controller-manager
+      kind: Deployment

--- a/components/notification-controller/development/pipelinerun_filters.yaml
+++ b/components/notification-controller/development/pipelinerun_filters.yaml
@@ -1,0 +1,6 @@
+---
+- op: add
+  path: /spec/template/spec/containers/0/env/-
+  value:
+    name: NOTIFICATION_FILTER_ANNOTATIONS
+    value: "art-jenkins-job-url"

--- a/components/notification-controller/staging/kustomization.yaml
+++ b/components/notification-controller/staging/kustomization.yaml
@@ -23,3 +23,7 @@ patches:
     target:
       name: notification-controller-controller-manager
       kind: Deployment
+  - path: pipelinerun_filters.yaml
+    target:
+      name: notification-controller-controller-manager
+      kind: Deployment

--- a/components/notification-controller/staging/pipelinerun_filters.yaml
+++ b/components/notification-controller/staging/pipelinerun_filters.yaml
@@ -1,0 +1,6 @@
+---
+- op: add
+  path: /spec/template/spec/containers/0/env/-
+  value:
+    name: NOTIFICATION_FILTER_ANNOTATIONS
+    value: "art-jenkins-job-url"


### PR DESCRIPTION
Enable ART-initiated PipelineRun processing by configuring the annotation filter to match art-jenkins-job-url.

Assisted-by: Claude Code