### PR TITLE
feat(KFLUXVNGD-906): development-operator overlay for Konflux operator

### DIFF
--- a/.github/workflows/forbid-clusterpolicies.yaml
+++ b/.github/workflows/forbid-clusterpolicies.yaml
@@ -27,6 +27,7 @@ jobs:
         run: |
           find argo-cd-apps components -name 'kustomization.yaml' \
             ! -path '*/k-components/*' \
+            ! -path '*konflux-operator/*/cr/overlay-patches/*' \
             ! -path 'components/policies/*' \
             ! -path 'components/repository-validator/staging/*' \
             ! -path 'components/repository-validator/production/*' \

--- a/.github/workflows/kube-linter.yaml
+++ b/.github/workflows/kube-linter.yaml
@@ -28,6 +28,7 @@ jobs:
         run: |
           find argo-cd-apps components -name 'kustomization.yaml' \
             ! -path '*/k-components/*' \
+            ! -path '*konflux-operator/*/cr/overlay-patches/*' \
             ! -path 'components/repository-validator/staging/*' \
             ! -path 'components/repository-validator/production/*' \
             ! -path 'components/monitoring/blackbox/staging/*' \

--- a/argo-cd-apps/app-of-app-sets/development-operator/change-source-path.yaml
+++ b/argo-cd-apps/app-of-app-sets/development-operator/change-source-path.yaml
@@ -1,0 +1,4 @@
+---
+- op: replace
+  path: /spec/source/path
+  value: argo-cd-apps/overlays/development-operator

--- a/argo-cd-apps/app-of-app-sets/development-operator/change-target-namespace.yaml
+++ b/argo-cd-apps/app-of-app-sets/development-operator/change-target-namespace.yaml
@@ -1,0 +1,4 @@
+---
+- op: replace
+  path: /spec/destination/namespace
+  value: openshift-gitops

--- a/argo-cd-apps/app-of-app-sets/development-operator/kustomization.yaml
+++ b/argo-cd-apps/app-of-app-sets/development-operator/kustomization.yaml
@@ -1,0 +1,18 @@
+# Root Argo CD Application for OpenShift preview: points member clusters at the
+# development-operator overlay (see argo-cd-apps/overlays/development-operator).
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../base
+patches:
+  - path: change-source-path.yaml
+    target:
+      group: argoproj.io
+      version: v1alpha1
+      kind: Application
+  - path: change-target-namespace.yaml
+    target:
+      group: argoproj.io
+      version: v1alpha1
+      kind: Application
+namespace: openshift-gitops

--- a/argo-cd-apps/base/member/infra-deployments/konflux-operator/konflux-operator.yaml
+++ b/argo-cd-apps/base/member/infra-deployments/konflux-operator/konflux-operator.yaml
@@ -1,0 +1,42 @@
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: konflux-operator
+spec:
+  generators:
+    - merge:
+        mergeKeys:
+          - nameNormalized
+        generators:
+          - clusters:
+              values:
+                sourceRoot: components/konflux-operator
+                environment: staging
+                clusterDir: base
+          - list:
+              elements: []
+  template:
+    metadata:
+      name: konflux-operator-{{nameNormalized}}
+    spec:
+      project: default
+      source:
+        path: '{{values.sourceRoot}}/{{values.environment}}/{{values.clusterDir}}'
+        repoURL: https://github.com/redhat-appstudio/infra-deployments.git
+        targetRevision: main
+      destination:
+        namespace: konflux-operator
+        server: '{{server}}'
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
+        syncOptions:
+          - CreateNamespace=true
+          - SkipDryRunOnMissingResource=true
+        retry:
+          limit: -1
+          backoff:
+            duration: 10s
+            factor: 2
+            maxDuration: 3m

--- a/argo-cd-apps/base/member/infra-deployments/konflux-operator/kustomization.yaml
+++ b/argo-cd-apps/base/member/infra-deployments/konflux-operator/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - konflux-operator.yaml
+components:
+  - ../../../../k-components/deploy-to-member-cluster-merge-generator
+  - ../../../../k-components/inject-infra-deployments-repo-details

--- a/argo-cd-apps/overlays/development-operator/delete-legacy-konflux-member-appsets.yaml
+++ b/argo-cd-apps/overlays/development-operator/delete-legacy-konflux-member-appsets.yaml
@@ -1,0 +1,98 @@
+# Strategic-merge deletes: remove these Argo CD ApplicationSets from the
+# effective ../development graph. Used by the development-operator overlay on
+# OpenShift so GitOps still installs shared platform apps but not the older
+# per-microservice Konflux ApplicationSets superseded by the Konflux operator.
+#
+# Only ApplicationSets that actually appear in ../development can be deleted here
+# (Kustomize requires a merge target). konflux-ui and namespace-lister are not in
+# that graph, so no delete entries for them.
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: application-api
+$patch: delete
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: has
+$patch: delete
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: release
+$patch: delete
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: integration
+$patch: delete
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: build-service
+$patch: delete
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: build-templates
+$patch: delete
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: image-controller
+$patch: delete
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: multi-platform-controller
+$patch: delete
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: project-controller
+$patch: delete
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: mintmaker
+$patch: delete
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: internal-services
+$patch: delete
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: konflux-info
+$patch: delete
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: konflux-rbac
+$patch: delete
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: enterprise-contract
+$patch: delete
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: konflux-kite
+$patch: delete

--- a/argo-cd-apps/overlays/development-operator/development-operator-generator-patch.yaml
+++ b/argo-cd-apps/overlays/development-operator/development-operator-generator-patch.yaml
@@ -1,0 +1,7 @@
+---
+- op: add
+  path: /spec/generators/0/merge/generators/0/clusters/values/environment
+  value: development
+- op: add
+  path: /spec/generators/0/merge/generators/0/clusters/values/clusterDir
+  value: ""

--- a/argo-cd-apps/overlays/development-operator/kustomization.yaml
+++ b/argo-cd-apps/overlays/development-operator/kustomization.yaml
@@ -1,0 +1,19 @@
+# OpenShift GitOps: member-cluster preview overlay for Konflux operator work.
+# Reuses everything from ../development (platform ApplicationSets, secrets,
+# policies, pipeline-service, etc.) and deletes only the legacy Konflux
+# microservice ApplicationSets listed in delete-legacy-konflux-member-appsets.yaml
+# so those workloads are not deployed alongside the operator-managed stack.
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../development
+  - ../../base/member/infra-deployments/konflux-operator
+patchesStrategicMerge:
+  - delete-legacy-konflux-member-appsets.yaml
+patches:
+  - path: development-operator-generator-patch.yaml
+    target:
+      kind: ApplicationSet
+      version: v1alpha1
+      name: konflux-operator
+namespace: openshift-gitops

--- a/components/konflux-operator/OWNERS
+++ b/components/konflux-operator/OWNERS
@@ -1,0 +1,8 @@
+# See the OWNERS docs: https://go.k8s.io/owners
+
+approvers:
+- ifireball
+- gbenhaim
+- amisstea
+- yftacherzog
+- avi-biton

--- a/components/konflux-operator/README.md
+++ b/components/konflux-operator/README.md
@@ -1,0 +1,85 @@
+# Konflux Operator Component
+
+This directory holds the **manifests** used by Argo CD on OpenShift to install the
+[Konflux operator](https://github.com/konflux-ci/konflux-ci) and to define a default
+`Konflux` custom resource (instance configuration). Cluster operators and maintainers
+edit these files; reviewers use this file to understand layout and promotion rules.
+
+The operator install bundle is consumed as **plain Kubernetes manifests** (CRDs, RBAC,
+Deployment, and so on), not as OLM `Subscription` / `ClusterServiceVersion` objects.
+
+## Directory layout per environment
+
+Each **environment** (for example `development/`, and later `staging-ring-a/` or
+similar) is a self-contained Kustomize root that Argo syncs. The layout is the same for
+every environment:
+
+| Path | Purpose |
+|------|--------|
+| `invariant/` | Operator pin (remote ref + `images`) plus **cluster-invariant** `Konflux` CR fragments. This is the **only** directory you replace as a unit when promoting a release line from one environment to another. |
+| `cr/overlay-patches/<team>/` | **Per-environment or per-team** strategic-merge fragments for the same `Konflux` object (`metadata.name: konflux`). These files are **not** overwritten during a normal promotion. |
+
+Example (`development/`):
+
+```text
+development/
+  kustomization.yaml          # resources: [invariant]; components: cr/overlay-patches/...
+  invariant/
+    kustomization.yaml        # remote operator + images + local CR inputs
+    konflux.yaml              # minimal Konflux CR shell
+    release-config.yaml       # merged spec shared across clusters for this release line
+  cr/
+    overlay-patches/
+      build/
+      konflux-ui/
+      ...
+```
+
+You may split a subtree such as `spec.buildService` across **`invariant/`**
+(release-wide defaults) and **`overlay-patches/build/`** (environment- or team-specific
+keys), as long as you avoid conflicting duplicate leaf values; see Kustomize
+strategic-merge ordering if two patches touch the same field.
+
+## Promoting to another environment
+
+1. Copy or reconcile **only** `<target-env>/invariant/` with the content from
+`<source-env>/invariant/` (or edit those files so the pull request shows exactly what
+changed).
+2. Leave `<target-env>/cr/overlay-patches/` unchanged unless the target cluster
+genuinely needs different patches.
+3. **Rollback** is a normal Git operation (`git revert`, or restore `invariant/` from
+an earlier revision).
+
+Adding a new environment: create a sibling directory with the same shape as
+`development/`, seed `invariant/` once from the environment you trust, then maintain
+`cr/overlay-patches/` for that cluster class.
+
+## Preview script and `Konflux` readiness
+
+`hack/preview.sh` supports **`--operator-overlay`** (OpenShift preview using the
+`development-operator` Argo overlay). **By default it does not wait** for the cluster
+`Konflux` object `konflux` to become ready, so preview can finish after Argo CD sync
+while the operator and instance are still converging.
+
+To **gate** preview on a healthy instance (same checks as
+`konflux-ci/scripts/deploy-local.sh`), set **`PREVIEW_WAIT_KONFLUX_CR_READY=true`**
+for that run.
+
+## Applying manifests locally (optional)
+
+From the repository root, after logging in to a cluster:
+
+`kubectl apply -k components/konflux-operator/development`
+
+To sync **only** the operator controller and CRDs without applying the `Konflux`
+instance, temporarily remove the CR inputs from `invariant/kustomization.yaml`
+(for example `konflux.yaml` and the `patches` entry that references
+`release-config.yaml`), apply, then restore those lines when you want the instance.
+
+## Konflux CR ownership
+
+- **`invariant/konflux.yaml`** — minimal `Konflux` object.
+- **`invariant/release-config.yaml`** — cluster-invariant `spec` carried with the
+operator pin for that release line.
+- **`cr/overlay-patches/*/OWNERS`** — team ownership for overlay fragments under each
+subdirectory.

--- a/components/konflux-operator/development/cr/overlay-patches/build/OWNERS
+++ b/components/konflux-operator/development/cr/overlay-patches/build/OWNERS
@@ -1,0 +1,18 @@
+# See the OWNERS docs: https://go.k8s.io/owners
+# Should be kept in sync with components/monitoring/grafana/base/dashboards/build-service/OWNERS
+
+approvers:
+- mmorhun
+- rcerven
+- mkosiarc
+- tisutisu
+- chmeliik
+- MartinBasti
+
+reviewers:
+- mmorhun
+- rcerven
+- mkosiarc
+- tisutisu
+- chmeliik
+- MartinBasti

--- a/components/konflux-operator/development/cr/overlay-patches/build/build-service.yaml
+++ b/components/konflux-operator/development/cr/overlay-patches/build/build-service.yaml
@@ -1,0 +1,20 @@
+apiVersion: konflux.konflux-ci.dev/v1alpha1
+kind: Konflux
+metadata:
+  name: konflux
+spec:
+  buildService:
+    spec:
+      buildControllerManager:
+        replicas: 1
+        manager:
+          env:
+            - name: PAC_WEBHOOK_INSECURE_SSL
+              value: "1"
+          resources:
+            requests:
+              cpu: 30m
+              memory: 128Mi
+            limits:
+              cpu: 30m
+              memory: 128Mi

--- a/components/konflux-operator/development/cr/overlay-patches/build/kustomization.yaml
+++ b/components/konflux-operator/development/cr/overlay-patches/build/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+patches:
+  - path: build-service.yaml

--- a/components/konflux-operator/development/cr/overlay-patches/image-controller/OWNERS
+++ b/components/konflux-operator/development/cr/overlay-patches/image-controller/OWNERS
@@ -1,0 +1,17 @@
+# See the OWNERS docs: https://go.k8s.io/owners
+
+approvers:
+- mmorhun
+- rcerven
+- mkosiarc
+- tisutisu
+- chmeliik
+- MartinBasti
+
+reviewers:
+- mmorhun
+- mkosiarc
+- rcerven
+- tisutisu
+- chmeliik
+- MartinBasti

--- a/components/konflux-operator/development/cr/overlay-patches/image-controller/image-controller.yaml
+++ b/components/konflux-operator/development/cr/overlay-patches/image-controller/image-controller.yaml
@@ -1,0 +1,7 @@
+apiVersion: konflux.konflux-ci.dev/v1alpha1
+kind: Konflux
+metadata:
+  name: konflux
+spec:
+  imageController:
+    enabled: true

--- a/components/konflux-operator/development/cr/overlay-patches/image-controller/kustomization.yaml
+++ b/components/konflux-operator/development/cr/overlay-patches/image-controller/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+patches:
+  - path: image-controller.yaml

--- a/components/konflux-operator/development/cr/overlay-patches/integration/OWNERS
+++ b/components/konflux-operator/development/cr/overlay-patches/integration/OWNERS
@@ -1,0 +1,21 @@
+# See the OWNERS docs: https://go.k8s.io/owners
+
+approvers:
+- dirgim
+- jsztuka
+- kasemAlem
+- sonam1412
+- Josh-Everett
+- 14rcole
+- jencull
+- NigelByrne1
+
+reviewers:
+- dirgim
+- jsztuka
+- kasemAlem
+- sonam1412
+- Josh-Everett
+- 14rcole
+- jencull
+- NigelByrne1

--- a/components/konflux-operator/development/cr/overlay-patches/integration/integration-service.yaml
+++ b/components/konflux-operator/development/cr/overlay-patches/integration/integration-service.yaml
@@ -1,0 +1,17 @@
+apiVersion: konflux.konflux-ci.dev/v1alpha1
+kind: Konflux
+metadata:
+  name: konflux
+spec:
+  integrationService:
+    spec:
+      integrationControllerManager:
+        replicas: 1
+        manager:
+          resources:
+            requests:
+              cpu: 30m
+              memory: 128Mi
+            limits:
+              cpu: 30m
+              memory: 128Mi

--- a/components/konflux-operator/development/cr/overlay-patches/integration/kustomization.yaml
+++ b/components/konflux-operator/development/cr/overlay-patches/integration/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+patches:
+  - path: integration-service.yaml

--- a/components/konflux-operator/development/cr/overlay-patches/konflux-info/OWNERS
+++ b/components/konflux-operator/development/cr/overlay-patches/konflux-info/OWNERS
@@ -1,0 +1,47 @@
+# See the OWNERS docs: https://go.k8s.io/owners
+
+approvers:
+# infra-team
+- sadlerap
+- eisraeli
+- filariow
+- gbenhaim
+- hugares
+- manish-jangra
+# sre-team
+- dgregor
+- jdcasey
+# ui-team
+- abhinandan13jan
+- caugello
+- CryptoRodeo
+- JoaoPedroPP
+- Katka92
+- sahil143
+- rrosatti
+- StanislavJochman
+# others
+- arewm
+
+reviewers:
+# infra-team
+- sadlerap
+- eisraeli
+- filariow
+- gbenhaim
+- hugares
+- manish-jangra
+# sre-team
+- dgregor
+- jdcasey
+# ui-team
+- abhinandan13jan
+- caugello
+- CryptoRodeo
+- JoaoPedroPP
+- Katka92
+- sahil143
+- rrosatti
+- StanislavJochman
+# others
+- arewm

--- a/components/konflux-operator/development/cr/overlay-patches/konflux-info/konflux-info.yaml
+++ b/components/konflux-operator/development/cr/overlay-patches/konflux-info/konflux-info.yaml
@@ -1,0 +1,14 @@
+apiVersion: konflux.konflux-ci.dev/v1alpha1
+kind: Konflux
+metadata:
+  name: konflux
+spec:
+  info:
+    spec:
+      publicInfo:
+        environment: development
+        visibility: public
+      banner:
+        items:
+          - summary: "Welcome to Konflux-CI! This is a development and testing environment."
+            type: danger

--- a/components/konflux-operator/development/cr/overlay-patches/konflux-info/kustomization.yaml
+++ b/components/konflux-operator/development/cr/overlay-patches/konflux-info/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+patches:
+  - path: konflux-info.yaml

--- a/components/konflux-operator/development/cr/overlay-patches/konflux-ui/OWNERS
+++ b/components/konflux-operator/development/cr/overlay-patches/konflux-ui/OWNERS
@@ -1,0 +1,47 @@
+# See the OWNERS docs: https://go.k8s.io/owners
+
+approvers:
+# infra-team
+- sadlerap
+- eisraeli
+- filariow
+- gbenhaim
+- hugares
+- manish-jangra
+# sre-team
+- dgregor
+- jdcasey
+# ui-team
+- abhinandan13jan
+- caugello
+- CryptoRodeo
+- JoaoPedroPP
+- Katka92
+- sahil143
+- rrosatti
+- StanislavJochman
+# others
+- arewm
+
+reviewers:
+# infra-team
+- sadlerap
+- eisraeli
+- filariow
+- gbenhaim
+- hugares
+- manish-jangra
+# sre-team
+- dgregor
+- jdcasey
+# ui-team
+- abhinandan13jan
+- caugello
+- CryptoRodeo
+- JoaoPedroPP
+- Katka92
+- sahil143
+- rrosatti
+- StanislavJochman
+# others
+- arewm

--- a/components/konflux-operator/development/cr/overlay-patches/konflux-ui/kustomization.yaml
+++ b/components/konflux-operator/development/cr/overlay-patches/konflux-ui/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+patches:
+  - path: ui.yaml

--- a/components/konflux-operator/development/cr/overlay-patches/konflux-ui/ui.yaml
+++ b/components/konflux-operator/development/cr/overlay-patches/konflux-ui/ui.yaml
@@ -1,0 +1,20 @@
+apiVersion: konflux.konflux-ci.dev/v1alpha1
+kind: Konflux
+metadata:
+  name: konflux
+spec:
+  ui:
+    spec:
+      ingress:
+        nodePortService:
+          httpsPort: 30011
+      proxy:
+        replicas: 1
+        nginx:
+          resources:
+            requests:
+              cpu: 30m
+              memory: 128Mi
+            limits:
+              cpu: 30m
+              memory: 128Mi

--- a/components/konflux-operator/development/cr/overlay-patches/namespace-lister/OWNERS
+++ b/components/konflux-operator/development/cr/overlay-patches/namespace-lister/OWNERS
@@ -1,0 +1,27 @@
+# See the OWNERS docs: https://go.k8s.io/owners
+
+approvers:
+- eisraeli
+- enkeefe00
+- filariow
+- gbenhaim
+- glevi-rh
+- hugares
+- manish-jangra
+- meyrevived
+- mshaposhnik
+- oswcab
+- sadlerap
+
+reviewers:
+- eisraeli
+- enkeefe00
+- filariow
+- gbenhaim
+- glevi-rh
+- hugares
+- manish-jangra
+- meyrevived
+- mshaposhnik
+- oswcab
+- sadlerap

--- a/components/konflux-operator/development/cr/overlay-patches/namespace-lister/kustomization.yaml
+++ b/components/konflux-operator/development/cr/overlay-patches/namespace-lister/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+patches:
+  - path: namespace-lister.yaml

--- a/components/konflux-operator/development/cr/overlay-patches/namespace-lister/namespace-lister.yaml
+++ b/components/konflux-operator/development/cr/overlay-patches/namespace-lister/namespace-lister.yaml
@@ -1,0 +1,17 @@
+apiVersion: konflux.konflux-ci.dev/v1alpha1
+kind: Konflux
+metadata:
+  name: konflux
+spec:
+  namespaceLister:
+    spec:
+      namespaceLister:
+        replicas: 1
+        namespaceLister:
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 256Mi

--- a/components/konflux-operator/development/cr/overlay-patches/release/OWNERS
+++ b/components/konflux-operator/development/cr/overlay-patches/release/OWNERS
@@ -1,0 +1,28 @@
+# See the OWNERS docs: https://go.k8s.io/owners
+
+approvers:
+- davidmogar
+- johnbieren
+- theflockers
+- mmalina
+- happybhati
+- seanconroy2021
+- filipnikolovski
+- elenagerman
+- midnightercz
+- querti
+- swickersh
+
+
+reviewers:
+- davidmogar
+- johnbieren
+- theflockers
+- mmalina
+- happybhati
+- seanconroy2021
+- filipnikolovski
+- elenagerman
+- midnightercz
+- querti
+- swickersh

--- a/components/konflux-operator/development/cr/overlay-patches/release/kustomization.yaml
+++ b/components/konflux-operator/development/cr/overlay-patches/release/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+patches:
+  - path: release-service.yaml

--- a/components/konflux-operator/development/cr/overlay-patches/release/release-service.yaml
+++ b/components/konflux-operator/development/cr/overlay-patches/release/release-service.yaml
@@ -1,0 +1,17 @@
+apiVersion: konflux.konflux-ci.dev/v1alpha1
+kind: Konflux
+metadata:
+  name: konflux
+spec:
+  releaseService:
+    spec:
+      releaseControllerManager:
+        replicas: 1
+        manager:
+          resources:
+            requests:
+              cpu: 30m
+              memory: 256Mi
+            limits:
+              cpu: 30m
+              memory: 256Mi

--- a/components/konflux-operator/development/invariant/konflux.yaml
+++ b/components/konflux-operator/development/invariant/konflux.yaml
@@ -1,0 +1,7 @@
+apiVersion: konflux.konflux-ci.dev/v1alpha1
+kind: Konflux
+metadata:
+  name: konflux
+spec:
+  # Base must remain environment-agnostic.
+  # Team-owned and environment-specific sections are layered via patches.

--- a/components/konflux-operator/development/invariant/kustomization.yaml
+++ b/components/konflux-operator/development/invariant/kustomization.yaml
@@ -1,0 +1,18 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# Env-invariant bundle for OpenShift GitOps: everything under this directory is
+# the payload to align across environments when promoting a Konflux operator
+# release (remote install source, operator image pin, shared Konflux spec).
+# Parent `../kustomization.yaml` adds per-team overlays from `../cr/overlay-patches/`.
+resources:
+  # Upstream operator config (konflux-ci builds install.yaml from this layout).
+  - https://github.com/konflux-ci/konflux-ci/operator/config/default?ref=0bace1e20ff164a00e9d6becfce52e310a921931
+  - konflux.yaml
+
+patches:
+  - path: release-config.yaml
+
+images:
+  - name: localhost/konflux-operator
+    newName: quay.io/konflux-ci/konflux-operator
+    newTag: 0bace1e20ff164a00e9d6becfce52e310a921931

--- a/components/konflux-operator/development/invariant/release-config.yaml
+++ b/components/konflux-operator/development/invariant/release-config.yaml
@@ -1,0 +1,12 @@
+apiVersion: konflux.konflux-ci.dev/v1alpha1
+kind: Konflux
+metadata:
+  name: konflux
+spec:
+  # Remaining non-team-owned sections for development.
+  certManager:
+    createClusterIssuer: true
+  internalRegistry:
+    enabled: true
+  defaultTenant:
+    enabled: true

--- a/components/konflux-operator/development/kustomization.yaml
+++ b/components/konflux-operator/development/kustomization.yaml
@@ -1,0 +1,19 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# OpenShift / Argo CD: this root builds the operator install plus one Konflux CR.
+# - `invariant/`: operator remote ref, image pin, and Konflux spec that should
+#   stay the same when promoting a release line to another environment (copy
+#   this directory as a unit).
+# - `cr/overlay-patches/*`: Kustomize components; team- or cluster-specific
+#   Konflux fragments. Update these when the target cluster or ownership
+#   contract changes, not on every operator bump.
+resources:
+  - invariant
+components:
+  - cr/overlay-patches/build
+  - cr/overlay-patches/image-controller
+  - cr/overlay-patches/integration
+  - cr/overlay-patches/konflux-info
+  - cr/overlay-patches/konflux-ui
+  - cr/overlay-patches/namespace-lister
+  - cr/overlay-patches/release

--- a/hack/bootstrap-cluster.sh
+++ b/hack/bootstrap-cluster.sh
@@ -37,7 +37,7 @@ log_step() {
 # =============================================================================
 
 main() {
-    local mode obo eaas
+    local mode obo eaas operator_overlay
     local start_time end_time total_time
     start_time=$(date +%s)
     
@@ -51,6 +51,10 @@ main() {
             ;;
         --eaas | -e)
             eaas="--eaas"
+            shift
+            ;;
+        --operator-overlay)
+            operator_overlay="--operator-overlay"
             shift
             ;;
         preview | upstream)
@@ -69,7 +73,7 @@ main() {
 
     log_step "Starting Konflux Cluster Bootstrap"
     log_info "Mode: ${mode:-upstream}"
-    log_info "Options: OBO=${obo:-disabled}, EAAS=${eaas:-disabled}"
+    log_info "Options: OBO=${obo:-disabled}, EAAS=${eaas:-disabled}, OPERATOR_OVERLAY=${operator_overlay:-disabled}"
     log_info "Start time: $(date '+%Y-%m-%d %H:%M:%S %Z')"
 
     # Deploy ArgoCD
@@ -117,7 +121,7 @@ main() {
         ;;
     "preview")
         log_info "Deploying preview configuration"
-        $ROOT/hack/preview.sh $obo $eaas
+        $ROOT/hack/preview.sh $obo $eaas $operator_overlay
         ;;
     esac
 
@@ -147,7 +151,7 @@ main() {
 }
 
 print_help() {
-    echo "Usage: $0 MODE [-o|--obo] [-e|--eaas] [-h|--help]"
+    echo "Usage: $0 MODE [-o|--obo] [-e|--eaas] [--operator-overlay] [-h|--help]"
     echo ""
     echo "Bootstrap a Konflux cluster with ArgoCD and required components."
     echo ""
@@ -159,12 +163,15 @@ print_help() {
     echo "                   (only applicable in preview mode)"
     echo "  -e, --eaas       Install Environment-as-a-Service components"
     echo "                   (only applicable in preview mode)"
+    echo "  --operator-overlay  Preview using development-operator (development minus legacy member appsets)"
+    echo "                      (only applicable in preview mode)"
     echo "  -h, --help       Show this help message and exit"
     echo ""
     echo "Examples:"
     echo "  $0                      # Bootstrap in upstream mode"
     echo "  $0 preview              # Bootstrap in preview mode"
-    echo "  $0 preview --obo --eaas # Preview mode with OBO and EaaS"
+    echo "  $0 preview --obo --eaas             # Preview mode with OBO and EaaS"
+    echo "  $0 preview --operator-overlay       # Preview mode with development-operator overlay"
     echo ""
     echo "Environment variables:"
     echo "  MY_GIT_FORK_REMOTE      Git remote name for your fork (required for preview)"

--- a/hack/preview.sh
+++ b/hack/preview.sh
@@ -256,13 +256,22 @@ dump_pending_apps_details() {
 # =============================================================================
 
 print_help() {
-    echo "Usage: $0 MODE [--obo] [--grafana] [--eaas] [-h|--help]"
+    echo "Usage: $0 MODE [--obo] [--grafana] [--eaas] [--operator-overlay] [-h|--help]"
     echo "  MODE             upstream/preview (default: upstream)"
     echo "  --obo        (only in preview mode) Install Observability operator and Prometheus instance for federation"
     echo "  --grafana    (only in preview mode) Enable Grafana dashboard (removed by default in dev)"
     echo "  --eaas       (only in preview mode) Install environment as a service components"
+    echo "  --operator-overlay  (preview mode) Use the development-operator Argo overlay: same platform apps as"
+    echo "                       development, but ApplicationSets for legacy Konflux microservices are removed."
     echo
-    echo "Example usage: \`$0 --obo --grafana --eaas"
+    echo "  With --operator-overlay, preview always waits for the Konflux operator controller Deployment to finish"
+    echo "  rolling out (namespace konflux-operator). That is independent of the Konflux CR Ready status."
+    echo
+    echo "Environment (optional):"
+    echo "  PREVIEW_WAIT_KONFLUX_CR_READY=true  When using --operator-overlay, additionally wait for the Konflux"
+    echo "                       custom resource konflux to exist and report Ready=True (off by default)."
+    echo
+    echo "Example: \`$0 preview --obo --grafana --eaas\`"
 }
 
 # Patch ArgoCD application files to point to fork
@@ -306,15 +315,16 @@ label_cluster_nodes() {
 
 # Filter applications based on DEPLOY_ONLY environment variable
 configure_deploy_only() {
+    [ "$TARGET_PREVIEW_OVERLAY" != "development" ] && [ "$TARGET_PREVIEW_OVERLAY" != "development-operator" ] && return
     [ -z "$DEPLOY_ONLY" ] && return
 
     log_step "Configuring selective deployment (DEPLOY_ONLY mode)"
     log_info "DEPLOY_ONLY is set, filtering applications to deploy only: $DEPLOY_ONLY"
 
     local applications deleted app
-    local delete_file="$ROOT/argo-cd-apps/overlays/development/delete-applications.yaml"
+    local delete_file="$TARGET_DELETE_FILE"
 
-    applications=$(oc kustomize argo-cd-apps/overlays/development | yq e --no-doc 'select(.kind == "ApplicationSet") | .metadata.name')
+    applications=$(oc kustomize "$TARGET_OVERLAY_PATH" | yq e --no-doc 'select(.kind == "ApplicationSet") | .metadata.name')
     deleted=$(yq e --no-doc .metadata.name "$delete_file")
 
     for app in $applications; do
@@ -333,6 +343,7 @@ configure_deploy_only() {
 
 # Disable Kueue for OCP versions < 4.16
 configure_kueue_for_ocp_version() {
+    [ "$TARGET_PREVIEW_OVERLAY" != "development" ] && [ "$TARGET_PREVIEW_OVERLAY" != "development-operator" ] && return
     log_step "Checking OCP version for Kueue compatibility"
 
     local ocp_version ocp_minor delete_file
@@ -349,7 +360,7 @@ configure_kueue_for_ocp_version() {
 
     log_warn "OCP version $ocp_version is below 4.16 - Kueue will be disabled"
 
-    delete_file="$ROOT/argo-cd-apps/overlays/development/delete-applications.yaml"
+    delete_file="$TARGET_DELETE_FILE"
 
     if ! grep -q "name: kueue" "$delete_file"; then
         log_substep "Adding Kueue to delete-applications.yaml"
@@ -497,8 +508,8 @@ deploy_and_wait_for_argocd() {
     local total_apps synced_apps pending_apps iteration=0
 
     # Create the root Application
-    log_substep "Applying root Application from: $ROOT/argo-cd-apps/app-of-app-sets/development"
-    oc apply -k $ROOT/argo-cd-apps/app-of-app-sets/development
+    log_substep "Applying root Application from: $TARGET_APP_OF_APPS_PATH"
+    oc apply -k "$TARGET_APP_OF_APPS_PATH"
     log_success "Root Application 'all-application-sets' created"
 
     # Wait for root application to sync
@@ -767,12 +778,118 @@ wait_for_tekton_crds() {
     done
 }
 
+# Wait for Konflux CR to exist and become Ready.
+wait_for_konflux_cr_ready() {
+    log_step "Waiting for Konflux CR to become ready"
+    log_info "Reference: https://github.com/konflux-ci/konflux-ci/blob/main/scripts/deploy-local.sh"
+
+    # Must match konflux-operator ApplicationSet destination.namespace.
+    local konflux_cr_namespace=konflux-operator
+    local timeout_seconds=900
+    local start_time elapsed_time
+    start_time=$(date +%s)
+
+    log_substep "Waiting for Konflux CR resource 'konflux/konflux' in namespace '$konflux_cr_namespace' to be created"
+    while ! kubectl get konflux konflux -n "$konflux_cr_namespace" >/dev/null 2>&1; do
+        elapsed_time=$(( $(date +%s) - start_time ))
+        if [ "$elapsed_time" -ge "$timeout_seconds" ]; then
+            log_error "Konflux CR was not created within $((timeout_seconds / 60)) minutes"
+            log_error "Debug with:"
+            log_error "  kubectl get applications.argoproj.io -n $ARGOCD_NAMESPACE | grep konflux-operator"
+            log_error "  kubectl get konflux -A"
+            log_error "  kubectl get konflux konflux -n $konflux_cr_namespace -o yaml"
+            log_error "  kubectl get events -n konflux-operator --sort-by='.lastTimestamp' | tail -20"
+            FAILED_APPS="konflux-operator"
+            print_execution_summary "failed" "KONFLUX_CR_NOT_FOUND"
+            exit 1
+        fi
+
+        local elapsed_min=$((elapsed_time / 60))
+        local elapsed_sec=$((elapsed_time % 60))
+        log_wait "Konflux CR not created yet (${elapsed_min}m ${elapsed_sec}s elapsed)"
+        sleep $SYNC_INTERVAL
+    done
+
+    log_substep "Waiting for Konflux CR Ready=True condition (namespace: $konflux_cr_namespace)"
+    if ! kubectl wait --for=condition=Ready=True konflux konflux -n "$konflux_cr_namespace" --timeout=15m 2>/dev/null; then
+        log_error "Konflux CR did not become Ready within 15 minutes"
+        log_error "Debug with:"
+        log_error "  kubectl get konflux konflux -n $konflux_cr_namespace -o yaml"
+        log_error "  kubectl get konflux konflux -n $konflux_cr_namespace -o jsonpath='{.status.conditions}'"
+        FAILED_APPS="konflux-operator"
+        print_execution_summary "failed" "KONFLUX_CR_NOT_READY"
+        exit 1
+    fi
+
+    log_success "Konflux CR is ready"
+}
+
+# Wait for the Konflux operator controller manager Deployment to exist and finish
+# rolling out. This validates the operator install without tying preview success
+# to Konflux CR reconciliation (see PREVIEW_WAIT_KONFLUX_CR_READY for that).
+wait_for_konflux_operator_controller_ready() {
+    log_step "Waiting for Konflux operator controller Deployment to become available"
+    log_info "This checks the operator controller only, not Konflux CR Ready status"
+
+    local ns=konflux-operator
+    # Same cap for (1) waiting until namespace + Deployment exist and (2) rollout status.
+    # Worst case is both phases back-to-back (up to twice this duration).
+    local operator_controller_wait_seconds=900
+    local start_time elapsed_time deploy_name
+    start_time=$(date +%s)
+    deploy_name=""
+
+    log_substep "Waiting for namespace '$ns' and controller Deployment"
+    while [ -z "$deploy_name" ]; do
+        elapsed_time=$(( $(date +%s) - start_time ))
+        if [ "$elapsed_time" -ge "$operator_controller_wait_seconds" ]; then
+            log_error "Konflux operator Deployment did not appear within $((operator_controller_wait_seconds / 60)) minutes"
+            log_error "Debug with:"
+            log_error "  oc get applications.argoproj.io -n $ARGOCD_NAMESPACE | grep konflux-operator"
+            log_error "  oc get deployment,pods -n $ns"
+            FAILED_APPS="konflux-operator"
+            print_execution_summary "failed" "KONFLUX_OPERATOR_DEPLOYMENT_MISSING"
+            exit 1
+        fi
+
+        if oc get namespace "$ns" &>/dev/null; then
+            if oc get deployment konflux-operator-controller-manager -n "$ns" &>/dev/null; then
+                deploy_name="konflux-operator-controller-manager"
+            else
+                deploy_name=$(oc get deploy -n "$ns" -l 'control-plane=controller-manager' -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)
+            fi
+        fi
+
+        if [ -z "$deploy_name" ]; then
+            local elapsed_min=$((elapsed_time / 60))
+            local elapsed_sec=$((elapsed_time % 60))
+            log_wait "Operator namespace or Deployment not ready yet (${elapsed_min}m ${elapsed_sec}s elapsed)"
+            sleep "$SYNC_INTERVAL"
+        fi
+    done
+
+    log_substep "Waiting for rollout of Deployment '$deploy_name' in namespace '$ns'"
+    if ! oc rollout status "deployment/$deploy_name" -n "$ns" --timeout="${operator_controller_wait_seconds}s"; then
+        log_error "Konflux operator Deployment did not finish rolling out within $((operator_controller_wait_seconds / 60)) minutes"
+        log_error "Debug with:"
+        log_error "  oc describe deployment/$deploy_name -n $ns"
+        log_error "  oc get pods -n $ns -o wide"
+        log_error "  oc logs -n $ns -l control-plane=controller-manager --tail=80 2>/dev/null || oc logs -n $ns deployment/$deploy_name --tail=80"
+        FAILED_APPS="konflux-operator"
+        print_execution_summary "failed" "KONFLUX_OPERATOR_DEPLOYMENT_NOT_ROLLED_OUT"
+        exit 1
+    fi
+
+    log_success "Konflux operator controller Deployment is available"
+}
+
 # =============================================================================
 # Argument Parsing
 # =============================================================================
 OBO=false
 EAAS=false
 GRAFANA=false
+OPERATOR_OVERLAY=false
 
 while [[ $# -gt 0 ]]; do
     key=$1
@@ -789,6 +906,10 @@ while [[ $# -gt 0 ]]; do
             GRAFANA=true
             shift
             ;;
+        --operator-overlay)
+            OPERATOR_OVERLAY=true
+            shift
+            ;;
         -h|--help)
             print_help
             exit 0
@@ -799,13 +920,25 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
+TARGET_PREVIEW_OVERLAY="development"
+if $OPERATOR_OVERLAY; then
+    TARGET_PREVIEW_OVERLAY="development-operator"
+fi
+TARGET_APP_OF_APPS_PATH="$ROOT/argo-cd-apps/app-of-app-sets/$TARGET_PREVIEW_OVERLAY"
+TARGET_OVERLAY_PATH="argo-cd-apps/overlays/$TARGET_PREVIEW_OVERLAY"
+TARGET_DELETE_FILE="$ROOT/argo-cd-apps/overlays/$TARGET_PREVIEW_OVERLAY/delete-applications.yaml"
+# development-operator kustomization inherits ../development; shared delete list.
+if [ "$TARGET_PREVIEW_OVERLAY" = "development-operator" ]; then
+    TARGET_DELETE_FILE="$ROOT/argo-cd-apps/overlays/development/delete-applications.yaml"
+fi
+
 # =============================================================================
 # Main Execution
 # =============================================================================
 
 log_step "Starting Konflux Preview Environment Setup"
 log_info "Script: $0"
-log_info "Options: OBO=$OBO, GRAFANA=$GRAFANA, EAAS=$EAAS"
+log_info "Options: OBO=$OBO, GRAFANA=$GRAFANA, EAAS=$EAAS, OVERLAY=$TARGET_PREVIEW_OVERLAY"
 log_info "Start time: $(date '+%Y-%m-%d %H:%M:%S %Z')"
 
 # =============================================================================
@@ -892,26 +1025,37 @@ log_success "All ArgoCD patch files updated"
 # Optional Components
 # =============================================================================
 if $OBO; then
+    if [ "$TARGET_PREVIEW_OVERLAY" != "development" ] && [ "$TARGET_PREVIEW_OVERLAY" != "development-operator" ]; then
+        log_warn "Ignoring --obo for overlay '$TARGET_PREVIEW_OVERLAY'"
+    else
     log_step "Enabling Observability (OBO) components"
     log_info "Adding Observability operator and Prometheus for federation"
     yq -i '.resources += ["monitoringstack/"]' $ROOT/components/monitoring/prometheus/development/kustomization.yaml
     log_success "Observability components enabled"
+    fi
 fi
 
 if $GRAFANA; then
+    if [ "$TARGET_PREVIEW_OVERLAY" != "development" ] && [ "$TARGET_PREVIEW_OVERLAY" != "development-operator" ]; then
+        log_warn "Ignoring --grafana for overlay '$TARGET_PREVIEW_OVERLAY'"
+    else
     log_step "Enabling Grafana dashboard"
     log_info "Removing monitoring-workload-grafana from delete-applications.yaml"
-    local delete_file="$ROOT/argo-cd-apps/overlays/development/delete-applications.yaml"
-    yq -i 'select(.metadata.name != "monitoring-workload-grafana")' "$delete_file"
+    yq -i 'select(.metadata.name != "monitoring-workload-grafana")' "$TARGET_DELETE_FILE"
     log_success "Grafana enabled: monitoring-workload-grafana will be deployed"
+    fi
 fi
 
 if $EAAS; then
+    if [ "$TARGET_PREVIEW_OVERLAY" != "development" ] && [ "$TARGET_PREVIEW_OVERLAY" != "development-operator" ]; then
+        log_warn "Ignoring --eaas for overlay '$TARGET_PREVIEW_OVERLAY'"
+    else
     log_step "Enabling Environment-as-a-Service (EaaS) components"
     log_info "Enabling EaaS cluster role assignment"
     yq -i '.components += ["../../../k-components/assign-eaas-role-to-local-cluster"]' \
         $ROOT/argo-cd-apps/base/local-cluster-secret/all-in-one/kustomization.yaml
     log_success "EaaS components enabled"
+    fi
 fi
 
 # =============================================================================
@@ -919,28 +1063,32 @@ fi
 # =============================================================================
 label_cluster_nodes
 
-configure_deploy_only
-configure_kueue_for_ocp_version
+if [ "$TARGET_PREVIEW_OVERLAY" = "development" ] || [ "$TARGET_PREVIEW_OVERLAY" = "development-operator" ]; then
+    configure_deploy_only
+    configure_kueue_for_ocp_version
 
-# Configure GitHub org
-log_step "Configuring GitHub organization"
-log_info "Setting GitHub org to: $MY_GITHUB_ORG"
-$ROOT/hack/util-set-github-org $MY_GITHUB_ORG
-log_success "GitHub organization configured"
+    # Configure GitHub org
+    log_step "Configuring GitHub organization"
+    log_info "Setting GitHub org to: $MY_GITHUB_ORG"
+    $ROOT/hack/util-set-github-org $MY_GITHUB_ORG
+    log_success "GitHub organization configured"
 
-# Configure Rekor server hostname
-log_step "Configuring Rekor server hostname"
-domain=$(oc get ingresses.config.openshift.io cluster --template={{.spec.domain}})
-rekor_server="rekor.$domain"
-log_info "Cluster domain: $domain"
-log_info "Rekor server hostname: $rekor_server"
-sed -i.bak "s/rekor-server.enterprise-contract-service.svc/$rekor_server/" $ROOT/argo-cd-apps/base/member/optional/helm/rekor/rekor.yaml && rm $ROOT/argo-cd-apps/base/member/optional/helm/rekor/rekor.yaml.bak
-log_success "Rekor server hostname configured"
+    # Configure Rekor server hostname
+    log_step "Configuring Rekor server hostname"
+    domain=$(oc get ingresses.config.openshift.io cluster --template={{.spec.domain}})
+    rekor_server="rekor.$domain"
+    log_info "Cluster domain: $domain"
+    log_info "Rekor server hostname: $rekor_server"
+    sed -i.bak "s/rekor-server.enterprise-contract-service.svc/$rekor_server/" $ROOT/argo-cd-apps/base/member/optional/helm/rekor/rekor.yaml && rm $ROOT/argo-cd-apps/base/member/optional/helm/rekor/rekor.yaml.bak
+    log_success "Rekor server hostname configured"
 
-# =============================================================================
-# Service Image Overrides
-# =============================================================================
-apply_service_image_overrides
+    # =============================================================================
+    # Service Image Overrides
+    # =============================================================================
+    apply_service_image_overrides
+else
+    log_info "Skipping full development overlay customizations for '$TARGET_PREVIEW_OVERLAY'"
+fi
 
 # =============================================================================
 # Commit and Push - INLINE (not in function) as per original script
@@ -960,6 +1108,18 @@ fi
 deploy_and_wait_for_argocd
 
 # =============================================================================
+# Wait for Konflux CR (development-operator overlay on OpenShift)
+# =============================================================================
+if [ "$TARGET_PREVIEW_OVERLAY" = "development-operator" ]; then
+    wait_for_konflux_operator_controller_ready
+    if [ "${PREVIEW_WAIT_KONFLUX_CR_READY:-}" = "true" ]; then
+        wait_for_konflux_cr_ready
+    else
+        log_info "Skipping wait for Konflux CR Ready=True (set PREVIEW_WAIT_KONFLUX_CR_READY=true to gate preview on the instance)"
+    fi
+fi
+
+# =============================================================================
 # Wait for Tekton
 # =============================================================================
 wait_for_tekton_ready
@@ -968,9 +1128,13 @@ wait_for_tekton_crds
 # =============================================================================
 # Final Configuration
 # =============================================================================
-log_step "Configuring Pipelines as Code integration"
-$ROOT/hack/build/setup-pac-integration.sh
-log_success "Pipelines as Code configured"
+if [ "$TARGET_PREVIEW_OVERLAY" = "development" ] || [ "$TARGET_PREVIEW_OVERLAY" = "development-operator" ]; then
+    log_step "Configuring Pipelines as Code integration"
+    $ROOT/hack/build/setup-pac-integration.sh
+    log_success "Pipelines as Code configured"
+else
+    log_info "Skipping Pipelines as Code integration for '$TARGET_PREVIEW_OVERLAY'"
+fi
 
 # =============================================================================
 # Complete


### PR DESCRIPTION
Introduce a development-operator Argo overlay to deploy the Konflux operator as the path that will eventually replace the individual Konflux microservice components.

The operator component splits an invariant baseline from per-environment material so we can evolve ring-style promotion without duplicating the same pins everywhere.

Today this overlay installs the operator only; follow-up work will add the Konflux CR here so the overlay drives full Konflux deployment via the operator.

Assisted-by: Cursor

Depends on https://github.com/redhat-appstudio/infra-deployments/pull/11683 to pass CI