### PR TITLE
chore(KFLUXVNGD-906): add operator CI overlay to ring test

### DIFF
--- a/infra-tools/internal/detector/detector.go
+++ b/infra-tools/internal/detector/detector.go
@@ -25,6 +25,7 @@ var (
 // Multiple overlays can map to the same environment.
 var OverlayEnvironment = map[string]Environment{
 	"development":               Development,
+	"development-operator":      Development,
 	"konflux-public-staging":    Staging,
 	"staging-downstream":        Staging,
 	"konflux-public-production": Production,


### PR DESCRIPTION
PR https://github.com/redhat-appstudio/infra-deployments/pull/11672 adds a new overlay for Konflux operator in CI. To allow it to pass CI, we need to add it first to the CI test that detects the validity of the change for ring deployments.