### PR TITLE
KONFLUX-13356: Migrate kueue CRs to v1beta2 in dev and staging

### DIFF
--- a/.github/workflows/verify-kueue-queue-configs.yaml
+++ b/.github/workflows/verify-kueue-queue-configs.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install PyYAML
+          pip install PyYAML kubernetes
 
       - name: Verify Kueue queue configurations are up to date
         run: |

--- a/components/kueue/development/queue-config/cluster-queue.yaml
+++ b/components/kueue/development/queue-config/cluster-queue.yaml
@@ -1,17 +1,17 @@
 ---
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: ResourceFlavor
 metadata:
   name: "default-flavor"
 ---
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: AdmissionCheck
 metadata:
   name: static-admission
 spec:
   controllerName: konflux-ci.dev/kueue-external-admission
 ---
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: ClusterQueue
 metadata:
   name: cluster-pipeline-queue

--- a/components/kueue/development/queue-config/workload-priority-class.yaml
+++ b/components/kueue/development/queue-config/workload-priority-class.yaml
@@ -1,54 +1,54 @@
 ---
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: WorkloadPriorityClass
 metadata:
   name: konflux-release
 value: 1000
 description: "Highest priority for release pipelines"
 ---
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: WorkloadPriorityClass
 metadata:
   name: konflux-tenant-release
 value: 900
 description: "High priority for tenant release pipelines"
 ---
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: WorkloadPriorityClass
 metadata:
   name: konflux-post-merge-test
 value: 800
 description: "Priority for post-merge tests"
 ---
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: WorkloadPriorityClass
 metadata:
   name: konflux-post-merge-build
 value: 700
 description: "Priority for post-merge builds"
 ---
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: WorkloadPriorityClass
 metadata:
   name: konflux-pre-merge-test
 value: 600
 description: "Priority for pre-merge tests"
 ---
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: WorkloadPriorityClass
 metadata:
   name: konflux-pre-merge-build
 value: 500
 description: "Priority for pre-merge builds"
 ---
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: WorkloadPriorityClass
 metadata:
   name: konflux-default
 value: 400
 description: "Default priority for konflux pipelines"
 ---
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: WorkloadPriorityClass
 metadata:
   name: konflux-dependency-update

--- a/components/kueue/staging/base/queue-config/workload-priority-class.yaml
+++ b/components/kueue/staging/base/queue-config/workload-priority-class.yaml
@@ -1,54 +1,54 @@
 ---
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: WorkloadPriorityClass
 metadata:
   name: konflux-release
 value: 1000
 description: "Highest priority for release pipelines"
 ---
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: WorkloadPriorityClass
 metadata:
   name: konflux-tenant-release
 value: 900
 description: "High priority for tenant release pipelines"
 ---
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: WorkloadPriorityClass
 metadata:
   name: konflux-post-merge-test
 value: 800
 description: "Priority for post-merge tests"
 ---
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: WorkloadPriorityClass
 metadata:
   name: konflux-post-merge-build
 value: 700
 description: "Priority for post-merge builds"
 ---
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: WorkloadPriorityClass
 metadata:
   name: konflux-pre-merge-test
 value: 600
 description: "Priority for pre-merge tests"
 ---
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: WorkloadPriorityClass
 metadata:
   name: konflux-pre-merge-build
 value: 500
 description: "Priority for pre-merge builds"
 ---
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: WorkloadPriorityClass
 metadata:
   name: konflux-default
 value: 400
 description: "Default priority for konflux pipelines"
 ---
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: WorkloadPriorityClass
 metadata:
   name: konflux-dependency-update

--- a/components/kueue/staging/stone-stage-p01/queue-config/cluster-queue.yaml
+++ b/components/kueue/staging/stone-stage-p01/queue-config/cluster-queue.yaml
@@ -140,11 +140,11 @@ spec:
       - name: linux-s390x
         nominalQuota: '2'
       - name: linux-x86-64
-        nominalQuota: '1000'
+        nominalQuota: 1k
       - name: local
-        nominalQuota: '1000'
+        nominalQuota: 1k
       - name: localhost
-        nominalQuota: '1000'
+        nominalQuota: 1k
       - name: macos-mac2metal-arm64
         nominalQuota: '5'
   - coveredResources:

--- a/components/kueue/staging/stone-stage-p01/queue-config/cluster-queue.yaml
+++ b/components/kueue/staging/stone-stage-p01/queue-config/cluster-queue.yaml
@@ -1,17 +1,18 @@
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: AdmissionCheck
 metadata:
   name: static-admission
 spec:
   controllerName: konflux-ci.dev/kueue-external-admission
 ---
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: ClusterQueue
 metadata:
   name: cluster-pipeline-queue
 spec:
-  admissionChecks:
-  - static-admission
+  admissionChecksStrategy:
+    admissionChecks:
+    - name: static-admission
   flavorFungibility:
     whenCanBorrow: MayStopSearch
     whenCanPreempt: TryNextFlavor
@@ -154,24 +155,24 @@ spec:
       - name: windows-4xlarge-amd64
         nominalQuota: '5'
 ---
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: ResourceFlavor
 metadata:
   name: default-flavor
 ---
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: ResourceFlavor
 metadata:
   name: platform-group-1
 spec: {}
 ---
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: ResourceFlavor
 metadata:
   name: platform-group-2
 spec: {}
 ---
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: ResourceFlavor
 metadata:
   name: platform-group-3

--- a/components/kueue/staging/stone-stg-rh01/queue-config/cluster-queue.yaml
+++ b/components/kueue/staging/stone-stg-rh01/queue-config/cluster-queue.yaml
@@ -1,17 +1,18 @@
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: AdmissionCheck
 metadata:
   name: static-admission
 spec:
   controllerName: konflux-ci.dev/kueue-external-admission
 ---
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: ClusterQueue
 metadata:
   name: cluster-pipeline-queue
 spec:
-  admissionChecks:
-  - static-admission
+  admissionChecksStrategy:
+    admissionChecks:
+    - name: static-admission
   flavorFungibility:
     whenCanBorrow: MayStopSearch
     whenCanPreempt: TryNextFlavor
@@ -144,24 +145,24 @@ spec:
       - name: localhost
         nominalQuota: '1000'
 ---
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: ResourceFlavor
 metadata:
   name: default-flavor
 ---
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: ResourceFlavor
 metadata:
   name: platform-group-1
 spec: {}
 ---
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: ResourceFlavor
 metadata:
   name: platform-group-2
 spec: {}
 ---
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: ResourceFlavor
 metadata:
   name: platform-group-3

--- a/components/kueue/staging/stone-stg-rh01/queue-config/cluster-queue.yaml
+++ b/components/kueue/staging/stone-stg-rh01/queue-config/cluster-queue.yaml
@@ -139,11 +139,11 @@ spec:
       - name: linux-s390x
         nominalQuota: '2'
       - name: linux-x86-64
-        nominalQuota: '1000'
+        nominalQuota: 1k
       - name: local
-        nominalQuota: '1000'
+        nominalQuota: 1k
       - name: localhost
-        nominalQuota: '1000'
+        nominalQuota: 1k
 ---
 apiVersion: kueue.x-k8s.io/v1beta2
 kind: ResourceFlavor

--- a/hack/kueue-vm-quotas/README.md
+++ b/hack/kueue-vm-quotas/README.md
@@ -128,6 +128,7 @@ When updating multi-platform-controller host configurations:
 
 - Python 3.6+
 - PyYAML (`pip install PyYAML`)
+- kubernetes (`pip install kubernetes`) — used for `format_quantity()` to emit canonical `resource.Quantity` notation
 
 ## Files
 

--- a/hack/kueue-vm-quotas/update-kueue-vm-quotas.py
+++ b/hack/kueue-vm-quotas/update-kueue-vm-quotas.py
@@ -23,9 +23,12 @@ See README.md for detailed usage examples and workflow integration.
 import yaml
 import sys
 import argparse
+from decimal import Decimal
 from pathlib import Path
 from typing import Dict, List, Any
 from dataclasses import dataclass
+
+from kubernetes.utils.quantity import format_quantity
 
 
 @dataclass
@@ -154,17 +157,29 @@ def distribute_platforms(platforms: List[PlatformQuota], max_per_group: int = 16
     return groups
 
 
-def create_platform_resource_group(platforms: List[PlatformQuota]) -> ResourceGroup:
+def format_quota(quota: int) -> str:
+    """Format quota using Kubernetes resource.Quantity canonical form.
+
+    Kubernetes normalizes 1000 -> '1k' when storing resource.Quantity values.
+    Using canonical form prevents ArgoCD drift on v1beta2 ClusterQueues.
+    """
+    if quota % 1000 == 0 and quota >= 1000:
+        return format_quantity(Decimal(quota), 'k', quantize=Decimal(1))
+    return str(quota)
+
+
+def create_platform_resource_group(platforms: List[PlatformQuota], is_v1beta2: bool = False) -> ResourceGroup:
     """Create a resource group for a list of platforms."""
-    # Only include platform names in covered resources (no tekton.dev/pipelineruns)
     covered_resources = [p.name for p in sorted(platforms, key=lambda p: p.name)]
-    
-    # Create individual platform resources
+
     resources = [
-        ResourceSpec(name=p.name, nominal_quota=str(p.quota))
+        ResourceSpec(
+            name=p.name,
+            nominal_quota=format_quota(p.quota) if is_v1beta2 else str(p.quota),
+        )
         for p in sorted(platforms, key=lambda p: p.name)
     ]
-    
+
     return ResourceGroup(covered_resources, resources)
 
 
@@ -254,25 +269,26 @@ def process_cluster_queue_update(cluster_queue_path: str, platform_quotas: Dict[
     # Find main documents
     cluster_queue_doc = find_document_by_kind(documents, 'ClusterQueue')
     existing_flavors = get_existing_flavor_names(documents)
-    
+    is_v1beta2 = cluster_queue_doc.get('apiVersion', '').endswith('/v1beta2')
+
     # Preserve base resource group
     existing_groups = cluster_queue_doc.get('spec', {}).get('resourceGroups', [])
     new_resource_groups = preserve_base_resource_group(existing_groups)
-    
+
     # Create platform resource groups
     platform_list = list(platform_quotas.values())
     platform_groups = distribute_platforms(platform_list)
-    
+
     for group_index, platforms in enumerate(platform_groups, start=1):
         flavor_name = f'platform-group-{group_index}'
-        
+
         # Create ResourceFlavor if needed
         if flavor_name not in existing_flavors:
             documents.append(create_resource_flavor(flavor_name))
             print(f"Created ResourceFlavor: {flavor_name}")
-        
+
         # Create resource group
-        resource_group = create_platform_resource_group(platforms)
+        resource_group = create_platform_resource_group(platforms, is_v1beta2)
         group_dict = resource_group_to_dict(resource_group, flavor_name)
         new_resource_groups.append(group_dict)
         


### PR DESCRIPTION
## What
Migrate all kueue custom resources from `v1beta1` to `v1beta2` apiVersion in development and staging:
- ClusterQueue, ResourceFlavor, AdmissionCheck, WorkloadPriorityClass
- Switch staging ClusterQueues from `admissionChecks` to `admissionChecksStrategy` (prevents ArgoCD drift from conversion webhook)
- Normalize `nominalQuota: '1000'` to `1k` (Kubernetes `resource.Quantity` canonical form) to resolve ArgoCD drift on `linux-x86-64`, `local`, and `localhost` platform quotas
- Update `update-kueue-vm-quotas.py` to emit canonical `1k` notation for v1beta2 ClusterQueues while preserving string form (`'1000'`) for v1beta1 (production) files

[KONFLUX-13356](https://issues.redhat.com/browse/KONFLUX-13356)

## Why
Follow-up to PR #11588 which upgraded RHBoK to v1.3 (kueue 0.16.x). The new kueue version uses v1beta2 as the storage version. The conversion webhook round-trips v1beta1 resources through v1beta2, causing field mutations that lead to ArgoCD drift. Migrating CRs to v1beta2 eliminates the conversion layer entirely.

The `'1000'` → `1k` fix aligns the manifest with the Kubernetes `resource.Quantity` canonical form — the API server stores `1000` as `1k`, so using the canonical notation prevents drift.

## Validation
- `kustomize build` passes for all affected paths
- Chainsaw tests already updated for v1beta2 in PR #11588
- Status of staging clusters:
```
stone-stg-rh01:
- CSV: kueue-operator.v1.3.1 — Succeeded
- Operator pods: 2/2 Running 
- kueue-controller-manager: 2/2 Running
- tekton-kueue: all 5 pods Running
- ClusterQueue: 7 pending workloads being processed
- Workloads: actively being admitted and finishing
- API: kueue.x-k8s.io/v1beta2

stone-stage-p01:
- CSV: kueue-operator.v1.3.1 — Succeeded
- Operator pods: 2/2 Running
- kueue-controller-manager: 2/2 Running
- tekton-kueue: all 5 pods Running, 0 restarts
- ClusterQueue: 0 pending (all caught up)
- Workloads: actively admitted and finishing
- API: kueue.x-k8s.io/v1beta2
```

## Risk Assessment
**Risk Level:** Low
**Rollback:** Revert apiVersion back to `v1beta1` and `admissionChecksStrategy` back to `admissionChecks`
Development and staging only — no production impact. v1beta2 is the storage version in kueue 0.16.x, so this aligns manifests with how resources are actually stored.

[KONFLUX-13356]: https://redhat.atlassian.net/browse/KONFLUX-13356?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ