### PR TITLE
Upgrade kubearchive staging to v1.21.4

### DIFF
--- a/components/kubearchive/README.md
+++ b/components/kubearchive/README.md
@@ -22,47 +22,47 @@ Deleted Releases are archived in KubeArchive and can still be accessed through t
 
 ## Upgrading
 
-To upgrade start by upgrading development, which also upgrades staging. First replace the current `kubearchive.yaml` manifest
-with the one from the new version, then the change the `kustomization.yaml` file so the diff looks like this:
+To upgrade start by upgrading development, which also upgrades staging:
 
-```diff
-diff --git a/components/kubearchive/development/kustomization.yaml b/components/kubearchive/development/kustomization.yaml
-index 98bf1d721..ee330ff5a 100644
---- a/components/kubearchive/development/kustomization.yaml
-+++ b/components/kubearchive/development/kustomization.yaml
-@@ -56,7 +56,7 @@ patches:
-               spec:
-                 containers:
-                   - name: vacuum
--                    image: quay.io/kubearchive/vacuum:v1.14.0
-+                    image: quay.io/kubearchive/vacuum:v1.15.0
-   - patch: |-
-       apiVersion: batch/v1
-       kind: CronJob
-@@ -69,7 +69,7 @@ patches:
-               spec:
-                 containers:
-                   - name: vacuum
--                    image: quay.io/kubearchive/vacuum:v1.14.0
-+                    image: quay.io/kubearchive/vacuum:v1.15.0
-   - patch: |-
-       apiVersion: batch/v1
-       kind: CronJob
-@@ -82,7 +82,7 @@ patches:
-               spec:
-                 containers:
-                   - name: vacuum
--                    image: quay.io/kubearchive/vacuum:v1.14.0
-+                    image: quay.io/kubearchive/vacuum:v1.15.0
-```
+1. Replace `development/kubearchive.yaml` with the manifest from the new release.
+2. Update the vacuum image tags in `development/kustomization.yaml`.
+3. If the new release includes a schema change:
+   * Bump `MIGRATION_VERSION` in both configmaps in `development/kustomization.yaml`:
+     `kubearchive-schema-version` (used by the migration Job) and
+     `kubearchive-deployment-schema-version` (used by api-server and sink).
+   * Update the Job name suffix in `development/kustomization.yaml` to match
+     (e.g. `kubearchive-schema-migration-v14`).
 
-So the version should change at:
+All changes go in a single commit. ArgoCD sync waves handle the ordering:
+the migration Job (wave -1) runs before deployments (wave 0) pick up the new
+version.
 
-* Patches that change the KubeArchive vacuum image for vacuum CronJobs.
+If the release introduces a breaking schema change that requires deployments
+to be upgraded between two migration phases, split the work into two commits:
+first bump `kubearchive-schema-version` and the Job name suffix, then after
+migration completes bump `kubearchive-deployment-schema-version`.
 
-Then after the upgrade is successful, you can start upgrading production clusters.
-Make sure to review the changes inside the KubeArchive YAML pulled from GitHub. Some
-resources may change so some patches may not be useful/wrong after upgrading.
+### Schema version configmaps
+
+There are two configmaps for `MIGRATION_VERSION`:
+
+* `kubearchive-schema-version` (sync-wave -2) — used by the migration Job.
+* `kubearchive-deployment-schema-version` (no sync-wave) — used by api-server
+  and sink deployments. Protects running deployments from restarting during
+  migration if the configmap hash changes.
+
+### Versioned Job name
+
+A versioned Job name suffix (e.g. `kubearchive-schema-migration-v13`) is used
+so that ArgoCD resyncs do not restart the immutable migration Job. When
+changing `MIGRATION_VERSION`, update the suffix in
+`development/kustomization.yaml` to match.
+
+### Production
+
+After the staging upgrade is successful, start upgrading production clusters.
+Make sure to review the changes inside the KubeArchive YAML pulled from GitHub.
+Some resources may change so some patches may not be useful/wrong after upgrading.
 
 ### Upgrade Script
 
@@ -70,10 +70,21 @@ There is a simple bash script you can use to upgrade, run it as follows:
 
 ```
 cd infra-deployments/
-bash components/kubearchive/upgrade.sh <current-version> <new-version>
-# For example: bash components/kubearchive/upgrade.sh v1.14.0 v1.15.0
+bash components/kubearchive/upgrade.sh <current-version> <new-version> [<new-migration-version>]
 ```
 
-This script downloads the new manifests from the GitHub repository
-and replaces (using `sed`) the `<current-version>` string with the
-`<new-version>` string on all `kustomization.yaml` files.
+Examples:
+
+```bash
+# No schema change:
+bash components/kubearchive/upgrade.sh v1.21.3 v1.21.4
+
+# With schema change (migration version bumps to 14):
+bash components/kubearchive/upgrade.sh v1.21.4 v1.22.0 14
+```
+
+The script downloads the new manifests from the GitHub repository
+and replaces the `<current-version>` string with the `<new-version>`
+string on all `kustomization.yaml` files. When `<new-migration-version>`
+is provided, it also updates `MIGRATION_VERSION` in both configmaps and
+the Job name suffix in `development/kustomization.yaml`.

--- a/components/kubearchive/development/kubearchive.yaml
+++ b/components/kubearchive/development/kubearchive.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: namespace
     app.kubernetes.io/name: kubearchive
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.21.3
+    app.kubernetes.io/version: v1.21.4
   name: kubearchive
 ---
 apiVersion: apiextensions.k8s.io/v1
@@ -552,7 +552,7 @@ metadata:
     app.kubernetes.io/component: api-server
     app.kubernetes.io/name: kubearchive-api-server
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.21.3
+    app.kubernetes.io/version: v1.21.4
   name: kubearchive-api-server
   namespace: kubearchive
 ---
@@ -563,7 +563,7 @@ metadata:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: kubearchive-vacuum
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.21.3
+    app.kubernetes.io/version: v1.21.4
   name: kubearchive-cluster-vacuum
   namespace: kubearchive
 ---
@@ -574,7 +574,7 @@ metadata:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: kubearchive-operator
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.21.3
+    app.kubernetes.io/version: v1.21.4
   name: kubearchive-operator
   namespace: kubearchive
 ---
@@ -585,7 +585,7 @@ metadata:
     app.kubernetes.io/component: sink
     app.kubernetes.io/name: kubearchive-sink
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.21.3
+    app.kubernetes.io/version: v1.21.4
   name: kubearchive-sink
   namespace: kubearchive
 ---
@@ -596,7 +596,7 @@ metadata:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: kubearchive-operator-leader-election
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.21.3
+    app.kubernetes.io/version: v1.21.4
   name: kubearchive-operator-leader-election
   namespace: kubearchive
 rules:
@@ -639,7 +639,7 @@ metadata:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: kubearchive-vacuum
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.21.3
+    app.kubernetes.io/version: v1.21.4
   name: kubearchive-vacuum
   namespace: kubearchive
 rules:
@@ -659,7 +659,7 @@ metadata:
     app.kubernetes.io/component: api-server
     app.kubernetes.io/name: kubearchive-api-server
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.21.3
+    app.kubernetes.io/version: v1.21.4
   name: kubearchive-api-server
 rules:
   - apiGroups:
@@ -677,7 +677,7 @@ metadata:
   labels:
     app.kubernetes.io/name: kubearchive-edit
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.21.3
+    app.kubernetes.io/version: v1.21.4
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
   name: kubearchive-edit
 rules:
@@ -791,7 +791,7 @@ metadata:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: kubearchive-operator-config-editor
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.21.3
+    app.kubernetes.io/version: v1.21.4
   name: kubearchive-operator-config-editor
 rules:
   - apiGroups:
@@ -820,7 +820,7 @@ metadata:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: kubearchive-operator-config-viewer
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.21.3
+    app.kubernetes.io/version: v1.21.4
   name: kubearchive-operator-config-viewer
 rules:
   - apiGroups:
@@ -844,7 +844,7 @@ metadata:
   labels:
     app.kubernetes.io/name: kubearchive-view
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.21.3
+    app.kubernetes.io/version: v1.21.4
     rbac.authorization.k8s.io/aggregate-to-view: "true"
   name: kubearchive-view
 rules:
@@ -868,7 +868,7 @@ metadata:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: kubearchive-operator-leader-election
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.21.3
+    app.kubernetes.io/version: v1.21.4
   name: kubearchive-operator-leader-election
   namespace: kubearchive
 roleRef:
@@ -887,7 +887,7 @@ metadata:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: kubearchive-vacuum
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.21.3
+    app.kubernetes.io/version: v1.21.4
   name: kubearchive-vacuum
   namespace: kubearchive
 roleRef:
@@ -906,7 +906,7 @@ metadata:
     app.kubernetes.io/component: api-server
     app.kubernetes.io/name: kubearchive-api-server
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.21.3
+    app.kubernetes.io/version: v1.21.4
   name: kubearchive-api-server
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -924,7 +924,7 @@ metadata:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: kubearchive-operator
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.21.3
+    app.kubernetes.io/version: v1.21.4
   name: kubearchive-operator
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -943,7 +943,7 @@ metadata:
     app.kubernetes.io/component: logging
     app.kubernetes.io/name: kubearchive-logging-reader
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.21.3
+    app.kubernetes.io/version: v1.21.4
   name: kubearchive-logging-reader
   namespace: kubearchive
 ---
@@ -955,7 +955,7 @@ metadata:
     app.kubernetes.io/component: logging
     app.kubernetes.io/name: kubearchive-logging-writer
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.21.3
+    app.kubernetes.io/version: v1.21.4
   name: kubearchive-logging-writer
   namespace: kubearchive
 ---
@@ -972,7 +972,7 @@ metadata:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: kubearchive-operator
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.21.3
+    app.kubernetes.io/version: v1.21.4
   name: kubearchive-operator
   namespace: kubearchive
 ---
@@ -980,7 +980,7 @@ apiVersion: v1
 data:
   DATABASE_DB: a3ViZWFyY2hpdmU=
   DATABASE_KIND: cG9zdGdyZXNxbA==
-  DATABASE_PASSWORD: RGF0IWFiYXNdM1Bhc3MqdzByZA==
+  DATABASE_PASSWORD: RGF0IWFiYXNdM1Bhc3MqdzByZA== # gitleaks:allow
   DATABASE_PORT: NTQzMg==
   DATABASE_URL: a3ViZWFyY2hpdmUtcncucG9zdGdyZXNxbC5zdmMuY2x1c3Rlci5sb2NhbA==
   DATABASE_USER: a3ViZWFyY2hpdmU=
@@ -990,7 +990,7 @@ metadata:
     app.kubernetes.io/component: database
     app.kubernetes.io/name: kubearchive-database-credentials
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.21.3
+    app.kubernetes.io/version: v1.21.4
   name: kubearchive-database-credentials
   namespace: kubearchive
 type: Opaque
@@ -1002,7 +1002,7 @@ metadata:
     app.kubernetes.io/component: logging
     app.kubernetes.io/name: kubearchive-logging
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.21.3
+    app.kubernetes.io/version: v1.21.4
   name: kubearchive-logging
   namespace: kubearchive
 stringData:
@@ -1016,7 +1016,7 @@ metadata:
     app.kubernetes.io/component: api-server
     app.kubernetes.io/name: kubearchive-api-server
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.21.3
+    app.kubernetes.io/version: v1.21.4
   name: kubearchive-api-server
   namespace: kubearchive
 spec:
@@ -1035,7 +1035,7 @@ metadata:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: kubearchive-operator-webhooks
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.21.3
+    app.kubernetes.io/version: v1.21.4
   name: kubearchive-operator-webhooks
   namespace: kubearchive
 spec:
@@ -1058,7 +1058,7 @@ metadata:
     app.kubernetes.io/component: sink
     app.kubernetes.io/name: kubearchive-sink
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.21.3
+    app.kubernetes.io/version: v1.21.4
   name: kubearchive-sink
   namespace: kubearchive
 spec:
@@ -1076,7 +1076,7 @@ metadata:
     app.kubernetes.io/component: api-server
     app.kubernetes.io/name: kubearchive-api-server
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.21.3
+    app.kubernetes.io/version: v1.21.4
   name: kubearchive-api-server
   namespace: kubearchive
 spec:
@@ -1130,7 +1130,7 @@ spec:
           envFrom:
             - secretRef:
                 name: kubearchive-database-credentials
-          image: quay.io/kubearchive/api:v1.21.3@sha256:5dfa9fff9df9df3fef6fe28f88047272f0a653b3ccfbea327a10e3052f1dddb4
+          image: quay.io/kubearchive/api:v1.21.4@sha256:b176b1651fe024ecd94207f690e727eb246f57436957115274647c2947494dc8
           livenessProbe:
             httpGet:
               path: /livez
@@ -1182,7 +1182,7 @@ metadata:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: kubearchive-operator
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.21.3
+    app.kubernetes.io/version: v1.21.4
   name: kubearchive-operator
   namespace: kubearchive
 spec:
@@ -1232,7 +1232,7 @@ spec:
               valueFrom:
                 resourceFieldRef:
                   resource: limits.cpu
-          image: quay.io/kubearchive/operator:v1.21.3@sha256:e60f0a019d3b8a895e46caacc429dd0865c80fdb2af83f40d2b4d4c1e7803d52
+          image: quay.io/kubearchive/operator:v1.21.4@sha256:2beeaeb53a17056249b666e8f9bd67a9a237d3394a66a651cb5caca3f8ac4901
           livenessProbe:
             httpGet:
               path: /healthz
@@ -1294,7 +1294,7 @@ metadata:
     app.kubernetes.io/component: sink
     app.kubernetes.io/name: kubearchive-sink
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.21.3
+    app.kubernetes.io/version: v1.21.4
   name: kubearchive-sink
   namespace: kubearchive
 spec:
@@ -1346,7 +1346,7 @@ spec:
           envFrom:
             - secretRef:
                 name: kubearchive-database-credentials
-          image: quay.io/kubearchive/sink:v1.21.3@sha256:cf197b6ecd5a98c3c92a2bed8d2a567b96590bf89783b1d3d5b501239514c422
+          image: quay.io/kubearchive/sink:v1.21.4@sha256:3b6603fa0cdd9daf99142573a0cdddce3467cdd8d180fd795e465209584c14b0
           livenessProbe:
             httpGet:
               path: /livez
@@ -1387,7 +1387,7 @@ metadata:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: kubearchive-vacuum
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.21.3
+    app.kubernetes.io/version: v1.21.4
   name: cluster-vacuum
   namespace: kubearchive
 spec:
@@ -1408,7 +1408,7 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
-              image: quay.io/kubearchive/vacuum:v1.21.3@sha256:47a52b1b649085fa73275bce45bda4ffba0c7a5c6bd8e3d5c380b1e485c1abb1
+              image: quay.io/kubearchive/vacuum:v1.21.4@sha256:3ededff190a125e51f2f675ae55d0559295580bda715bb2e3406d1cec7aac339
               name: vacuum
           restartPolicy: Never
           serviceAccount: kubearchive-cluster-vacuum
@@ -1422,7 +1422,7 @@ metadata:
     app.kubernetes.io/component: kubearchive
     app.kubernetes.io/name: kubearchive-schema-migration
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.21.3
+    app.kubernetes.io/version: v1.21.4
   name: kubearchive-schema-migration
   namespace: kubearchive
 spec:
@@ -1438,7 +1438,7 @@ spec:
           envFrom:
             - secretRef:
                 name: kubearchive-database-credentials
-          image: quay.io/kubearchive/postgresql:v1.21.3@sha256:2ce1545b19d29bd36c1022de13f451f14847aed04d62ab896a3254d74f7c0d39
+          image: quay.io/kubearchive/postgresql:v1.21.4@sha256:58bcad4798c71746b0c9d11eb482a1075a9b073cbc146187fe2670df16b6d785
           name: migration
           resources:
             limits:
@@ -1459,7 +1459,7 @@ metadata:
     app.kubernetes.io/component: api-server
     app.kubernetes.io/name: kubearchive-api-server-certificate
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.21.3
+    app.kubernetes.io/version: v1.21.4
   name: kubearchive-api-server-certificate
   namespace: kubearchive
 spec:
@@ -1493,7 +1493,7 @@ metadata:
     app.kubernetes.io/component: certs
     app.kubernetes.io/name: kubearchive-ca
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.21.3
+    app.kubernetes.io/version: v1.21.4
   name: kubearchive-ca
   namespace: kubearchive
 spec:
@@ -1515,7 +1515,7 @@ metadata:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: kubearchive-operator-certificate
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.21.3
+    app.kubernetes.io/version: v1.21.4
   name: kubearchive-operator-certificate
   namespace: kubearchive
 spec:
@@ -1534,7 +1534,7 @@ metadata:
     app.kubernetes.io/component: certs
     app.kubernetes.io/name: kubearchive
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.21.3
+    app.kubernetes.io/version: v1.21.4
   name: kubearchive
   namespace: kubearchive
 spec:
@@ -1548,7 +1548,7 @@ metadata:
     app.kubernetes.io/component: certs
     app.kubernetes.io/name: kubearchive-ca
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.21.3
+    app.kubernetes.io/version: v1.21.4
   name: kubearchive-ca
   namespace: kubearchive
 spec:
@@ -1563,7 +1563,7 @@ metadata:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: kubearchive-mutating-webhook-configuration
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.21.3
+    app.kubernetes.io/version: v1.21.4
   name: kubearchive-mutating-webhook-configuration
 webhooks:
   - admissionReviewVersions:
@@ -1676,7 +1676,7 @@ metadata:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: kubearchive-validating-webhook-configuration
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.21.3
+    app.kubernetes.io/version: v1.21.4
   name: kubearchive-validating-webhook-configuration
 webhooks:
   - admissionReviewVersions:

--- a/components/kubearchive/development/kustomization.yaml
+++ b/components/kubearchive/development/kustomization.yaml
@@ -96,7 +96,7 @@ patches:
               spec:
                 containers:
                   - name: vacuum
-                    image: quay.io/kubearchive/vacuum:v1.21.3
+                    image: quay.io/kubearchive/vacuum:v1.21.4
   - patch: |-
       apiVersion: batch/v1
       kind: CronJob
@@ -109,7 +109,7 @@ patches:
               spec:
                 containers:
                   - name: vacuum
-                    image: quay.io/kubearchive/vacuum:v1.21.3
+                    image: quay.io/kubearchive/vacuum:v1.21.4
   - patch: |-
       apiVersion: batch/v1
       kind: CronJob
@@ -122,7 +122,7 @@ patches:
               spec:
                 containers:
                   - name: vacuum
-                    image: quay.io/kubearchive/vacuum:v1.21.3
+                    image: quay.io/kubearchive/vacuum:v1.21.4
   # Ensure database is ready before schema-migration job runs
   - patch: |-
       apiVersion: apps/v1

--- a/components/kubearchive/development/kustomization.yaml
+++ b/components/kubearchive/development/kustomization.yaml
@@ -34,6 +34,9 @@ configMapGenerator:
         argocd.argoproj.io/sync-wave: "-2"
     literals:
       - MIGRATION_VERSION=13
+  - name: kubearchive-deployment-schema-version
+    literals:
+      - MIGRATION_VERSION=13
   - name: kubearchive-logging-writer
     literals:
       - |
@@ -153,8 +156,6 @@ patches:
         name: kubearchive-schema-migration
         namespace: kubearchive
         annotations:
-          # Needed if just the command is changed, otherwise the job needs to be deleted manually
-          argocd.argoproj.io/sync-options: Force=true,Replace=true
           argocd.argoproj.io/sync-wave: "-1"
           ignore-check.kube-linter.io/no-read-only-root-fs: >
             "This job needs to clone a repository to do its job, so it needs write access to the FS."
@@ -174,6 +175,16 @@ patches:
                     value: "1000"
                 securityContext:
                   runAsUser: null
+  # Add version suffix so syncs with unchanged version are a no-op
+  # (immutable Job, same name = nothing to do). On upgrade, new name = new Job
+  # created, old completed one pruned. Update suffix when changing MIGRATION_VERSION.
+  - target:
+      kind: Job
+      name: kubearchive-schema-migration
+    patch: |-
+      - op: replace
+        path: /metadata/name
+        value: kubearchive-schema-migration-v13
   # These patches add an annotation so an OpenShift service
   # creates the TLS secrets instead of Cert Manager
   - patch: |-
@@ -238,7 +249,7 @@ patches:
                 - name: MIGRATION_VERSION
                   valueFrom:
                     configMapKeyRef:
-                      name: kubearchive-schema-version
+                      name: kubearchive-deployment-schema-version
                       key: MIGRATION_VERSION
                 securityContext:
                   readOnlyRootFilesystem: true
@@ -297,7 +308,7 @@ patches:
                 - name: MIGRATION_VERSION
                   valueFrom:
                     configMapKeyRef:
-                      name: kubearchive-schema-version
+                      name: kubearchive-deployment-schema-version
                       key: MIGRATION_VERSION
                 securityContext:
                   readOnlyRootFilesystem: true

--- a/components/kubearchive/staging/base/kustomization.yaml
+++ b/components/kubearchive/staging/base/kustomization.yaml
@@ -7,16 +7,6 @@ resources:
   - prometheusrule.yaml
 
 patches:
-  # Ensure schema-migration job runs after ExternalSecrets (wave -2) but before Deployments (wave 0)
-  - patch: |-
-      apiVersion: batch/v1
-      kind: Job
-      metadata:
-        name: kubearchive-schema-migration
-        namespace: kubearchive
-        annotations:
-          argocd.argoproj.io/sync-wave: "-1"
-
   - patch: |-
       $patch: delete
       apiVersion: v1

--- a/components/kubearchive/upgrade.sh
+++ b/components/kubearchive/upgrade.sh
@@ -1,8 +1,16 @@
 #!/bin/bash -e
 
-echo "Upgrading KubeArchive from $1 to $2..."
+# Usage: upgrade.sh <old-version> <new-version> [<new-migration-version>]
+# Example: upgrade.sh v1.21.3 v1.21.4
+# Example: upgrade.sh v1.21.4 v1.22.0 14
 
-curl -Lo components/kubearchive/development/kubearchive.yaml https://github.com/kubearchive/kubearchive/releases/download/$2/kubearchive.yaml
+OLD_VERSION=$1
+NEW_VERSION=$2
+NEW_MIGRATION_VERSION=$3
+
+echo "Upgrading KubeArchive from $OLD_VERSION to $NEW_VERSION..."
+
+curl -Lo components/kubearchive/development/kubearchive.yaml https://github.com/kubearchive/kubearchive/releases/download/$NEW_VERSION/kubearchive.yaml
 cp components/kubearchive/development/kubearchive.yaml components/kubearchive/production/kflux-fedora-01/kubearchive.yaml
 cp components/kubearchive/development/kubearchive.yaml components/kubearchive/production/kflux-ocp-p01/kubearchive.yaml
 cp components/kubearchive/development/kubearchive.yaml components/kubearchive/production/kflux-osp-p01/kubearchive.yaml
@@ -12,4 +20,14 @@ cp components/kubearchive/development/kubearchive.yaml components/kubearchive/pr
 cp components/kubearchive/development/kubearchive.yaml components/kubearchive/production/stone-prd-rh01/kubearchive.yaml
 cp components/kubearchive/development/kubearchive.yaml components/kubearchive/production/stone-prod-p01/kubearchive.yaml
 cp components/kubearchive/development/kubearchive.yaml components/kubearchive/production/stone-prod-p02/kubearchive.yaml
-sed -i "s/$1/$2/g" components/kubearchive/production/**/kustomization.yaml components/kubearchive/development/kustomization.yaml
+sed -i "s/$OLD_VERSION/$NEW_VERSION/g" components/kubearchive/production/**/kustomization.yaml components/kubearchive/development/kustomization.yaml
+
+if [ -n "$NEW_MIGRATION_VERSION" ]; then
+  DEV_KUSTOMIZATION=components/kubearchive/development/kustomization.yaml
+  OLD_MIGRATION_VERSION=$(grep -m1 'MIGRATION_VERSION=' "$DEV_KUSTOMIZATION" | sed 's/.*MIGRATION_VERSION=//')
+
+  echo "Updating schema migration from v$OLD_MIGRATION_VERSION to v$NEW_MIGRATION_VERSION..."
+
+  sed -i "s/MIGRATION_VERSION=$OLD_MIGRATION_VERSION/MIGRATION_VERSION=$NEW_MIGRATION_VERSION/g" "$DEV_KUSTOMIZATION"
+  sed -i "s/kubearchive-schema-migration-v$OLD_MIGRATION_VERSION/kubearchive-schema-migration-v$NEW_MIGRATION_VERSION/g" "$DEV_KUSTOMIZATION"
+fi


### PR DESCRIPTION
## Summary
- Upgrade kubearchive images from v1.21.3 to v1.21.4 in development (staging inherits)
- Split `MIGRATION_VERSION` into two configmaps: `kubearchive-schema-version` (migration Job) and `kubearchive-deployment-schema-version` (api-server/sink deployments), so deployments are protected from restarts during migration
- Add versioned Job name suffix (`kubearchive-schema-migration-v13`) to prevent ArgoCD resyncs from restarting the immutable migration Job, replacing the `Force=true,Replace=true` approach
- Update `upgrade.sh` to accept an optional `<new-migration-version>` argument
- Update upgrade docs in README.md

## Test plan
- [ ] Verify staging ArgoCD sync applies resources in correct wave order: configmaps (wave -2) → migration Job (wave -1) → deployments (wave 0)
- [ ] Verify resync does not restart the migration Job when version is unchanged
- [ ] Verify deployment rollout uses the correct `kubearchive-deployment-schema-version` configmap

🤖 Generated with [Claude Code](https://claude.com/claude-code)