### PR TITLE
Add NOTIFICATION_FILTER_ANNOTATIONS env var for production

### DIFF
--- a/components/notification-controller/production/kustomization.yaml
+++ b/components/notification-controller/production/kustomization.yaml
@@ -27,3 +27,7 @@ patches:
     target:
       name: notification-controller-controller-manager
       kind: Deployment
+  - path: pipelinerun_filters.yaml
+    target:
+      name: notification-controller-controller-manager
+      kind: Deployment

--- a/components/notification-controller/production/pipelinerun_filters.yaml
+++ b/components/notification-controller/production/pipelinerun_filters.yaml
@@ -1,0 +1,6 @@
+---
+- op: add
+  path: /spec/template/spec/containers/0/env/-
+  value:
+    name: NOTIFICATION_FILTER_ANNOTATIONS
+    value: "art-jenkins-job-url"


### PR DESCRIPTION
What/Why

Add NOTIFICATION_FILTER_ANNOTATIONS environment variable to the notification-controller deployment for production.

ART-initiated PipelineRuns were previously filtered out because they lack the pipelinesascode.tekton.dev/event-type=push label. This configures the annotation filter to match art-jenkins-job-url, enabling notification processing for ART builds.

Validation

Merged and tested in notification-service: https://github.com/konflux-ci/notification-service/pull/724
Stage PR: https://github.com/redhat-appstudio/infra-deployments/pull/11666

Risk Assessment

Risk Level: Low
Rollback: Revert the commit

Assisted-by: Claude Code