### PR TITLE
Update pipelines to next nightly build in dev/staging 5.0.5-819

### DIFF
--- a/components/pipeline-service/development/main-pipeline-service-configuration.yaml
+++ b/components/pipeline-service/development/main-pipeline-service-configuration.yaml
@@ -2243,7 +2243,7 @@ metadata:
   namespace: openshift-marketplace
 spec:
   displayName: custom-operators
-  image: quay.io/openshift-pipeline/pipelines-index-4.18@sha256:d4d3f6210a384da6bfb11214a860e72e52d0a38b73037b8135c0571a6365d2a1
+  image: quay.io/openshift-pipeline/pipelines-index-4.18@sha256:7a6ffa6b08f3ec1ef6bf6b704e8d8a07621ec55e3f146779c786d8b174ca9107
   sourceType: grpc
   updateStrategy:
     registryPoll:

--- a/components/pipeline-service/staging/base/main-pipeline-service-configuration.yaml
+++ b/components/pipeline-service/staging/base/main-pipeline-service-configuration.yaml
@@ -2073,7 +2073,7 @@ metadata:
   namespace: openshift-marketplace
 spec:
   displayName: custom-operators
-  image: quay.io/openshift-pipeline/pipelines-index-4.18@sha256:d4d3f6210a384da6bfb11214a860e72e52d0a38b73037b8135c0571a6365d2a1
+  image: quay.io/openshift-pipeline/pipelines-index-4.18@sha256:7a6ffa6b08f3ec1ef6bf6b704e8d8a07621ec55e3f146779c786d8b174ca9107
   sourceType: grpc
   updateStrategy:
     registryPoll:

--- a/components/pipeline-service/staging/stone-stage-p01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stage-p01/deploy.yaml
@@ -2649,7 +2649,7 @@ metadata:
   namespace: openshift-marketplace
 spec:
   displayName: custom-operators
-  image: quay.io/openshift-pipeline/pipelines-index-4.18@sha256:d4d3f6210a384da6bfb11214a860e72e52d0a38b73037b8135c0571a6365d2a1
+  image: quay.io/openshift-pipeline/pipelines-index-4.18@sha256:7a6ffa6b08f3ec1ef6bf6b704e8d8a07621ec55e3f146779c786d8b174ca9107
   sourceType: grpc
   updateStrategy:
     registryPoll:

--- a/components/pipeline-service/staging/stone-stg-rh01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stg-rh01/deploy.yaml
@@ -2661,7 +2661,7 @@ metadata:
   namespace: openshift-marketplace
 spec:
   displayName: custom-operators
-  image: quay.io/openshift-pipeline/pipelines-index-4.18@sha256:d4d3f6210a384da6bfb11214a860e72e52d0a38b73037b8135c0571a6365d2a1
+  image: quay.io/openshift-pipeline/pipelines-index-4.18@sha256:7a6ffa6b08f3ec1ef6bf6b704e8d8a07621ec55e3f146779c786d8b174ca9107
   sourceType: grpc
   updateStrategy:
     registryPoll:


### PR DESCRIPTION
# OpenShift Pipelines Release Notes
**Index:** `5.0.5-806` → `5.0.5-819`
**Previous image:** `quay.io/openshift-pipeline/pipelines-index-4.18@sha256:d4d3f6210a384da6bfb11214a860e72e52d0a38b73037b8135c0571a6365d2a1`
**New image:** `quay.io/openshift-pipeline/pipelines-index-4.18@sha256:7a6ffa6b08f3ec1ef6bf6b704e8d8a07621ec55e3f146779c786d8b174ca9107`

---

## Components Updated

| Component | Previous Upstream Commit | New Upstream Commit | Upstream Repo |
|---|---|---|---|
| Tekton Pipeline | `8d33f2ae` | `aed2bc5a` | tektoncd/pipeline |
| Pipelines as Code | `d7802a47` (v0.44.0) | `7425faf7` (v0.46.0) | tektoncd/pipelines-as-code |
| Tekton Chains | `bee7519e` | `a51457de` | tektoncd/chains |
| Tekton CLI (tkn) | `2e0e4030` | `feb2d5ad` (v0.44.1) | tektoncd/cli |
| Tekton Operator | `dd3b702c` | `c79fc555` | tektoncd/operator |
| Tekton Hub | `974a1066` | `c79258f3` | tektoncd/hub |
| Tekton Pruner | `7b7814fc` | `3a1779e6` | tektoncd/pruner |
| Tekton Caches | `4cdb9fad` | `208a38a0` | openshift-pipelines/tekton-caches |

**Unchanged:** Triggers (v0.35.0), Manual Approval Gate

---

## Tekton Pipeline

> Upstream commits: [`8d33f2ae...aed2bc5a`](https://github.com/tektoncd/pipeline/compare/8d33f2ae87e5a20bce798055da0f3bfb6a08a46d...aed2bc5aac6c6473758a06c203501bebc0780097)
> Includes upstream releases **v1.11.0** and **v1.12.0**

### New Features
- **TaskRun pending status** — TaskRuns can now be created in a pending state, matching existing PipelineRun behavior. Lifecycle transitions and e2e coverage included.
- **PVC auto-cleanup annotation** — Optional annotation to automatically clean up PVCs when a workspace is no longer needed (`feat: add optional PVC auto-cleanup annotation for workspaces mode`).
- **Hub Resolver multi-URL support** — Hub Resolver now accepts multiple upstream URLs and a per-resolution `url` param, enabling use of private Hub instances.
- **Multiple Git credentials on same host** — Added `useHttpPath` and SSH host alias support so multiple credentials can coexist for the same Git host.
- **TaskRun & PipelineRun notifications controller** — Two new controllers (TEP-0137) emit notifications for TaskRun and PipelineRun lifecycle events, replacing the deprecated `send-cloudevents-for-runs` feature flag.
- **OpenTelemetry metrics migration** — Metrics backend migrated from OpenCensus to OpenTelemetry; pod latency metric converted to a histogram.

### Bug Fixes
- Propagate PipelineRun `tasks`/`finally` timeout to child TaskRuns (`d1379f8f`).
- Fix `running_taskruns` metric overcounting TaskRuns with no condition (`5c260410`).
- Fix nil panic in `GenerateDeterministicNameFromSpec` with long resolver names (`5eead3f8`).
- Use hashed volume names to prevent credential volume name collisions (`a8fc41ba`).
- Fix context key collision and ownerRef nil panic in resolution framework (`24afb9b8`).
- Fix cache race with singleflight; remove corrupted cache entries on type error (`5f157733`, `5df99a05`).
- Record metrics for cancelled PipelineRuns (`24766ef9`).
- Fix cluster resolver namespace access control (whitespace and wildcard bugs) (`273875b8`).
- Replace silent "default" namespace fallback with explicit error in GetNameAndNamespace (`dbb065f1`).
- Make step-init symlink creation idempotent (`bc5524c8`).
- Surface specific TaskRun failure reasons for pod eviction, OOM, and init failures (`a468b412`).
- Surface clear errors when completed tasks miss referenced results (`1d50b07b`).
- Fix default tracing endpoint to OTLP protobuf endpoint (`04c0c7f5`).
- Validate data is a Tekton object in the resolver framework (`03014232`).
- Revert mistaken metadata changes in resolvers `config-observability` (`cd0046cc`).

### Security Fixes
- **GHSA-94jr-7pqp-xhcq**: Prevent git argument injection via `revision` parameter (`0967cc8e`).
- Prevent path traversal in git resolver `pathInRepo` parameter (`961388fc`).
- Reject system API token with user-controlled `serverURL` (`e964bce1`).
- Normalize VolumeMount paths before `/tekton/` restriction check (`c8cc73a2`).
- Limit HTTP resolver response body size to prevent OOM DoS (`d4ba8cae`).
- Trim whitespace from source URI before pattern matching (`37f9657b`).
- Strip resolver prefixes and use non-capturing group for pattern anchoring (`b8905600`).

### Performance Improvements
- Hoist `VerificationPolicy` list out of per-task loop in `resolvePipelineState` (`2c398711`).
- Use `maps.Equal` instead of `reflect.DeepEqual` for label/annotation comparison (`770a6f72`).
- Reduce reconcile churn for completed PipelineRuns (`fec12730`).
- Remove unnecessary `SetDefaults` from TaskRun done path (`8709b510`).

---

## Pipelines as Code

> Upstream commits: [`d7802a47...7425faf7`](https://github.com/tektoncd/pipelines-as-code/compare/d7802a479d0b3ae7ea3b0941187c80d5dd6a1efe...7425faf706dd3ba5e98e296b188a64b283237c50)
> **v0.44.0 → v0.46.0** (two minor releases)

### New Features
- **Configurable GitOps command prefix** — GitHub provider now supports a custom prefix for GitOps commands (e.g. `/pac-test` instead of `/test`) via `gitops_command_prefix` setting (`870b15ba`).
- **GraphQL batch fetching for `.tekton` directory** — Fetching pipeline definitions from `.tekton` now uses batched GraphQL queries, significantly reducing GitHub API calls (`b8ed1407`).
- **Recursive `.tekton` retrieval for Forgejo** — Forgejo provider now supports recursive directory retrieval for nested `.tekton` structures (`c51c085a`).
- **Forgejo commit status support** — Implemented `GetCommitStatuses` for the Forgejo provider (`6a4a5b05`).
- **Forgejo CEL header auto-detection** — CLI can now auto-detect Forgejo providers via CEL expression on headers (`5c096488`).
- **OpenTelemetry tracing** — Tracing enabled for webhooks and PipelineRun execution; migrated from OpenCensus (`baaf5e18`, `bd9f4687`).
- **Informer cache optimization** — Added `TransformFuncs` to reduce cache memory usage (`88926919`).
- **GitHub check-run cache** — `getPullRequest` and check-run lookups are now cached with retry to reduce API pressure (`ef35fcc7`, `perf`).

### Bug Fixes
- Fix missing `http` suffix in provider URL for Forgejo (`04412319`).
- Fix GHE instance detection for URL validation (`de692bad`).
- Fix `/ok-to-test` not triggering CI on GitHub PRs (`532790b4`).
- Fix re-run button on GitHub Pull Requests (`ef85098c`).
- Clear pending check-run on `/ok-to-test` (`74b0d283`).
- Guard nil response and cap comment pagination in ACL checks (`0f22da73`).
- Restrict same-repo ACL permission to trusted context (`a6e4aab5`).
- Prevent duplicate repository CR on trailing slash in webhook URL (`c9be9d68`).
- Fix relative task path resolution for repository paths (`ece5326d`).
- Populate `DefaultBranch` for incoming webhooks (`501ba3bc`).
- Fix data race on shared event field in adapter (`0faad247`).
- Fix `/ok-to-test` status update to only apply to Forgejo (`45aa2f7d`).
- GitLab: fallback to commit status on `/retest` (`30fddf4c`).
- GitLab: pin commit statuses to same pipeline (`b0bcbacb`).
- GitLab: map skipped status correctly (`738cc027`).
- GitLab: update `/ok-to-test` status to success (`3c896398`).
- Bitbucket Cloud: resolve CEL expression failure on push events (`7c46558d`).
- Bitbucket Cloud: fix status key handling for build statuses (`eda53316`).
- Use pull request number from issue comment payload (`c37a2139`).
- Use provided target ref in `GetFileInsideRepo` for GitHub (`68c5f1df`).
- Fix dynamic prefix in retest error message (`e40416cc`).

---

## Tekton Operator

> Upstream commits: [`dd3b702c...c79fc555`](https://github.com/tektoncd/operator/compare/dd3b702ce1619e7e8b737b4d956e988f447c56c7...c79fc555811025d5d2c8cafac1e993184689d832)

### New Features
- **Centralized TLS configuration** — New infrastructure for centralized `WEBHOOK_*` TLS configuration; enabled for TektonResult (`243ea3b1`, `18df1de6`).
- **Conditional Console Plugin image selection** — Console Plugin image is now selected conditionally based on OCP version (`4db29a4a`).
- **OpenAPI v3 schemas for all CRDs** — Generated using `controller-gen` (`7c96af4c`).
- **OpenTelemetry metrics migration** — Operator metrics migrated from OpenCensus to OpenTelemetry (`161a1c4a`).
- **Component version bumps** — Pipeline v1.11.0→v1.12.0, Chains v0.26.2→v0.26.3, Hub v1.23.9→v1.23.10, PAC updated to tektoncd org.

### Bug Fixes
- Fix Syncer Service Transformer (`6df3de15`).
- Fix helm automation with correct version (`c79fc555`).
- Fix CEL expression for release trigger pipeline (`66f8f289`).
- Fix missing subjects in attestation; capture UUID instead of rekor index (`694775da`).
- Fix correct fully qualified image names in release pipeline (`ef452640`).
- Fix `source-subpath`/`release-subpath` params in `create-draft-release` task (`ac736e5e`).

### Security Fixes
- **CVE-2026-34986** — Fix go-jose DoS vulnerability (`66f8f289`).

---

## Tekton Chains

> Upstream commits: [`bee7519e...a51457de`](https://github.com/tektoncd/chains/compare/bee7519eb20a587f8e063ff2016725970c1d1b7c...a51457de691e0edb45a4588a8e0c85cfa9df16eb)

### Security Fixes
- **CVE-2026-34986, CVE-2026-33211, CVE-2026-33186** — Multiple CVE fixes (`868c3598`).

### Bug Fixes
- Update Tekton Pipelines dependency to v1.6.2 (`a51457de`).

---

## Tekton CLI (tkn)

> Upstream commits: [`2e0e4030...feb2d5ad`](https://github.com/tektoncd/cli/compare/2e0e4030f8b1f55f8b728dc8b37381f695a0e791...feb2d5adf424a1d8bcc71959e20cc674a5546ed4)
> **v0.44.0 → v0.44.1** (patch release)

### Security Fixes
- Bump `github.com/go-jose/go-jose/v4` from 4.1.3 to 4.1.4 (DoS fix) (`649f6481`).

### Bug Fixes
- Bump `google.golang.org/grpc` from 1.78.0 to 1.79.3 (`0762bf91`).
- Bump `github.com/tektoncd/pipeline` from 1.9.1 to 1.9.2 (`1a65dd65`).

---

## Tekton Hub

> Upstream commits: [`974a1066...c79258f3`](https://github.com/tektoncd/hub/compare/974a10662414ac7d7161a44957391230e4efa7cc...c79258f31206144684357447b12621e2a67338a7)

### Security Fixes
- **CVE-2026-4800** — Bump UI and swagger packages to fix multiple CVEs (`c79258f3`).

### Bug Fixes
- Bump `google.golang.org/grpc` to 1.79.3 (`74023f02`).
- Bump `tektoncd/pipeline` to v1.9.2 (`eb086e1f`).

---

## Tekton Pruner

> Upstream commits: [`7b7814fc...3a1779e6`](https://github.com/tektoncd/pruner/compare/7b7814fce640d5b1b1f930fa3da7ccb39e9868d9...3a1779e6db52fcf7a311bd52862dbe9ec889ed37)

### Security Fixes
- Fix multiple CVEs (`3a1779e6`).

---

## Tekton Caches

> Upstream commits: [`4cdb9fad...208a38a0`](https://github.com/openshift-pipelines/tekton-caches/compare/4cdb9fad1f66da787f7f3ffc45dd5a5cdbe25d7c...208a38a0fa5c0745065f110e8866b728c814ef2c)

### Security Fixes
- **CVE-2026-33186** — gRPC-Go: Authorization bypass due to improper HTTP/2 path validation (`6f8e0519`).

### Improvements
- Upgrade Tekton Pipelines dependency (`0d3e9dfa`).

---
