### PR TITLE
PVO11Y-5150: Add RBAC for o11y team to create PipelineRuns in kanary

### DIFF
--- a/components/monitoring/kanary/staging/base/rbac/kanary-o11y-cronjob-trigger-rbac.yaml
+++ b/components/monitoring/kanary/staging/base/rbac/kanary-o11y-cronjob-trigger-rbac.yaml
@@ -1,23 +1,23 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: kanary-o11y-pipelinerun-runner
+  name: kanary-o11y-cronjob-trigger
 rules:
-  - apiGroups: ["tekton.dev"]
-    resources: ["pipelineruns"]
-    verbs: ["create", "get"]
-  - apiGroups: ["tekton.dev"]
-    resources: ["pipelines"]
+  - apiGroups: ["batch"]
+    resources: ["cronjobs"]
     verbs: ["get"]
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
+    verbs: ["create"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: kanary-o11y-pipelinerun-runner
+  name: kanary-o11y-cronjob-trigger
 subjects:
   - kind: Group
     name: konflux-o11y
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: kanary-o11y-pipelinerun-runner
+  name: kanary-o11y-cronjob-trigger

--- a/components/monitoring/kanary/staging/base/rbac/kanary-o11y-pipelinerun-rbac.yaml
+++ b/components/monitoring/kanary/staging/base/rbac/kanary-o11y-pipelinerun-rbac.yaml
@@ -1,0 +1,23 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: kanary-o11y-pipelinerun-runner
+rules:
+  - apiGroups: ["tekton.dev"]
+    resources: ["pipelineruns"]
+    verbs: ["create", "get"]
+  - apiGroups: ["tekton.dev"]
+    resources: ["pipelines"]
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: kanary-o11y-pipelinerun-runner
+subjects:
+  - kind: Group
+    name: konflux-o11y
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: kanary-o11y-pipelinerun-runner

--- a/components/monitoring/kanary/staging/base/rbac/kustomization.yaml
+++ b/components/monitoring/kanary/staging/base/rbac/kustomization.yaml
@@ -1,4 +1,4 @@
 resources:
   - kanary-cronjob-rbac.yaml
   - kanary-maintainers.yaml
-  - kanary-o11y-pipelinerun-rbac.yaml
+  - kanary-o11y-cronjob-trigger-rbac.yaml

--- a/components/monitoring/kanary/staging/base/rbac/kustomization.yaml
+++ b/components/monitoring/kanary/staging/base/rbac/kustomization.yaml
@@ -1,3 +1,4 @@
 resources:
   - kanary-cronjob-rbac.yaml
   - kanary-maintainers.yaml
+  - kanary-o11y-pipelinerun-rbac.yaml


### PR DESCRIPTION
## Summary
- Adds a Role and RoleBinding allowing the `konflux-o11y` group to manually trigger existing CronJobs in the kanary namespace via `kubectl create job --from=cronjob/<name>`
- Grants only `get` on `batch/cronjobs` and `create` on `batch/jobs` — avoids granting `create` on `tekton.dev/pipelineruns` which would allow running arbitrary workloads that can mount namespace secrets

Ref: PVO11Y-5150

## Test plan
- [ ] Verify the RBAC resources are created in the kanary namespace after deployment
- [ ] Confirm a member of the `konflux-o11y` group can trigger a canary job via `kubectl create job <name> --from=cronjob/<cronjob-name> -n kanary`

🤖 Generated with [Claude Code](https://claude.com/claude-code)