### PR TITLE
feat: Add Argo application for the dummy deploy

### DIFF
--- a/argo-cd-apps/base/member/infra-deployments/dummy-deployment/dummy-deployment.yaml
+++ b/argo-cd-apps/base/member/infra-deployments/dummy-deployment/dummy-deployment.yaml
@@ -1,0 +1,40 @@
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: dummy-deployment
+spec:
+  generators:
+    - merge:
+        mergeKeys:
+          - nameNormalized
+        generators:
+          - clusters:
+              values:
+                sourceRoot: components/dummy-deployment/overlays
+                environment: staging
+          - list:
+              elements: []
+  template:
+    metadata:
+      name: dummy-deployment-{{nameNormalized}}
+    spec:
+      project: default
+      source:
+        path: '{{values.sourceRoot}}/{{values.environment}}'
+        repoURL: https://github.com/redhat-appstudio/infra-deployments.git
+        targetRevision: main
+      destination:
+        namespace: konflux-dummy-deploy
+        server: '{{server}}'
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
+        syncOptions:
+          - CreateNamespace=true
+        retry:
+          limit: -1
+          backoff:
+            duration: 10s
+            factor: 2
+            maxDuration: 3m

--- a/argo-cd-apps/base/member/infra-deployments/dummy-deployment/kustomization.yaml
+++ b/argo-cd-apps/base/member/infra-deployments/dummy-deployment/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - dummy-deployment.yaml
+components:
+  - ../../../../k-components/deploy-to-member-cluster-merge-generator

--- a/argo-cd-apps/base/member/infra-deployments/kustomization.yaml
+++ b/argo-cd-apps/base/member/infra-deployments/kustomization.yaml
@@ -43,5 +43,6 @@ resources:
   - kueue
   - policies
   - konflux-kite
+  - dummy-deployment
 components:
   - ../../../k-components/inject-infra-deployments-repo-details

--- a/argo-cd-apps/overlays/development/kustomization.yaml
+++ b/argo-cd-apps/overlays/development/kustomization.yaml
@@ -216,3 +216,8 @@ patches:
       kind: ApplicationSet
       version: v1alpha1
       name: perf-team-prometheus-reader
+  - path: development-overlay-patch.yaml
+    target:
+      kind: ApplicationSet
+      version: v1alpha1
+      name: dummy-deployment

--- a/argo-cd-apps/overlays/konflux-public-production/delete-applications.yaml
+++ b/argo-cd-apps/overlays/konflux-public-production/delete-applications.yaml
@@ -23,3 +23,9 @@ kind: ApplicationSet
 metadata:
   name: disaster-recovery
 $patch: delete
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: dummy-deployment
+$patch: delete

--- a/argo-cd-apps/overlays/production-downstream/delete-applications.yaml
+++ b/argo-cd-apps/overlays/production-downstream/delete-applications.yaml
@@ -23,3 +23,9 @@ kind: ApplicationSet
 metadata:
   name: disaster-recovery
 $patch: delete
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: dummy-deployment
+$patch: delete


### PR DESCRIPTION
  - Add dummy-deployment component with Kustomize overlays (development, staging) for practicing Kargo ring deployments
  - Register the ArgoCD ApplicationSet so the app is picked up by the cluster
  - Serves as a reference example for onboarding new components with proper security context, resource limits, and overlay structure

  Motivation

  We need a lightweight, well-structured deployment to practice Kargo-driven ring promotions (dev → staging) and to serve as a best-practices template for future component onboarding.

This PR is a follow from https://github.com/redhat-appstudio/infra-deployments/pull/11750