### PR TITLE
dev/stage move PaC config from "spec.platforms.openshift" to "spec.platforms.kubernetes"

### DIFF
--- a/components/pipeline-service/development/main-pipeline-service-configuration.yaml
+++ b/components/pipeline-service/development/main-pipeline-service-configuration.yaml
@@ -2180,7 +2180,7 @@ spec:
       threads-per-controller: 32
       statefulset-ordinals: true
   platforms:
-    openshift:
+    kubernetes:
       pipelinesAsCode:
         enable: true
         options:

--- a/components/pipeline-service/staging/base/main-pipeline-service-configuration.yaml
+++ b/components/pipeline-service/staging/base/main-pipeline-service-configuration.yaml
@@ -1998,7 +1998,7 @@ spec:
       threads-per-controller: 32
       statefulset-ordinals: true
   platforms:
-    openshift:
+    kubernetes:
       pipelinesAsCode:
         enable: true
         options:

--- a/components/pipeline-service/staging/stone-stage-p01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stage-p01/deploy.yaml
@@ -2573,7 +2573,7 @@ spec:
       statefulset-ordinals: true
       threads-per-controller: 32
   platforms:
-    openshift:
+    kubernetes:
       pipelinesAsCode:
         enable: true
         options:

--- a/components/pipeline-service/staging/stone-stage-p01/resources/update-tekton-config-pac.yaml
+++ b/components/pipeline-service/staging/stone-stage-p01/resources/update-tekton-config-pac.yaml
@@ -1,6 +1,6 @@
 ---
 - op: add
-  path: /spec/platforms/openshift/pipelinesAsCode/settings
+  path: /spec/platforms/kubernetes/pipelinesAsCode/settings
   value:
     application-name: Konflux Staging Internal
     custom-console-name: Konflux Staging Internal

--- a/components/pipeline-service/staging/stone-stg-rh01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stg-rh01/deploy.yaml
@@ -2585,7 +2585,7 @@ spec:
       statefulset-ordinals: true
       threads-per-controller: 32
   platforms:
-    openshift:
+    kubernetes:
       pipelinesAsCode:
         enable: true
         options:


### PR DESCRIPTION
Both are supposed to be supported, but PaC uninstalled when the below change was applied:

See: https://github.com/tektoncd/operator/pull/3337
https://redhat-internal.slack.com/archives/C06GFP9JJBV/p1778615280508879