### PR TITLE
KFLUXINFRA-3596: Add k8s groups component

### DIFF
--- a/argo-cd-apps/base/k8s-groups/k8s-groups.yaml
+++ b/argo-cd-apps/base/k8s-groups/k8s-groups.yaml
@@ -1,0 +1,41 @@
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: k8s-groups
+spec:
+  generators:
+    - merge:
+        mergeKeys:
+          - nameNormalized
+        generators:
+          - clusters:
+              values:
+                sourceRoot: components/k8s-groups
+                environment: staging
+                useCaseDir: rover
+          - list:
+              elements: []
+  template:
+    metadata:
+      name: k8s-groups-{{nameNormalized}}
+    spec:
+      project: default
+      source:
+        path: '{{values.sourceRoot}}/{{values.environment}}/{{values.useCaseDir}}'
+        repoURL: https://github.com/redhat-appstudio/internal-infra-deployments.git
+        targetRevision: main
+      destination:
+        namespace: k8s-groups
+        server: '{{server}}'
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: false
+        syncOptions:
+          - CreateNamespace=true
+        retry:
+          limit: -1
+          backoff:
+            duration: 10s
+            factor: 2
+            maxDuration: 3m

--- a/argo-cd-apps/base/k8s-groups/kustomization.yaml
+++ b/argo-cd-apps/base/k8s-groups/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- k8s-groups.yaml

--- a/argo-cd-apps/overlays/konflux-public-staging/kustomization.yaml
+++ b/argo-cd-apps/overlays/konflux-public-staging/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
   - ../../base/eaas
   - ../../base/monitoring-blackbox
   - ../../base/monitoring-workload-kanary
+  - ../../base/k8s-groups
 
 namespace: konflux-public-staging
 patchesStrategicMerge:

--- a/argo-cd-apps/overlays/production-downstream/delete-applications.yaml
+++ b/argo-cd-apps/overlays/production-downstream/delete-applications.yaml
@@ -29,3 +29,10 @@ kind: ApplicationSet
 metadata:
   name: dummy-deployment
 $patch: delete
+# k8s-groups is being tested on staging clusters for now
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: k8s-groups
+$patch: delete


### PR DESCRIPTION
## Summary

Add a new component to deploy the k8s groups located in the [internal-infra-deployments repository](https://github.com/redhat-appstudio/internal-infra-deployments/tree/main/components/k8s-groups) to the tenant Konflux clusters. Also add the component to the exclusion paths for the forbid-cluster policies and kube-linter workflows since this component references a Kustomize file in the internal-infra-deployments repository,
which is internal and thus not accessible in regular GitHub Actions. Only deploy to staging clusters for now.

## Risk Assessment

**Risk**: Low
**Explanation**: This is a new component that is only being deployed to staging clusters. At worst, errors regarding the inability to create k8s `Group` resources will occur; no functionality should be impaired.