### PR TITLE
policies: rollout queue-config policy to prod

### DIFF
--- a/components/policies/production/policies/kueue/queue-config/.chainsaw-test/README.md
+++ b/components/policies/production/policies/kueue/queue-config/.chainsaw-test/README.md
@@ -1,7 +1,383 @@
 # Test: `kueue-bootstrap-queue-new-tenant-labeled-namespace`
 
 Tests that a LocalQueue is created in a namespace labeled with
-`konflux-ci.dev/type=tenant`.
+`konflux-ci.dev/type=tenant` and no `kueue.konflux-ci.dev/stop-policy`
+annotation.
+
+
+## Bindings
+
+| # | Name | Value |
+|:-:|---|---|
+| 1 | `suffix` | "labeled" |
+
+## Steps
+
+| # | Name | Bindings | Try | Catch | Finally | Cleanup |
+|:-:|---|:-:|:-:|:-:|:-:|:-:|
+| 1 | [given-localqueue-crd-exists](#step-given-localqueue-crd-exists) | 0 | 1 | 0 | 0 | 0 |
+| 2 | [given-kyverno-has-permission-on-resources](#step-given-kyverno-has-permission-on-resources) | 0 | 1 | 0 | 0 | 0 |
+| 3 | [given-cluster-policy-is-ready](#step-given-cluster-policy-is-ready) | 0 | 2 | 0 | 0 | 0 |
+| 4 | [when-tenant-labeled-namespace-is-created](#step-when-tenant-labeled-namespace-is-created) | 0 | 1 | 0 | 0 | 0 |
+| 5 | [then-localqueue-is-created](#step-then-localqueue-is-created) | 0 | 1 | 0 | 0 | 0 |
+
+### Step: `given-localqueue-crd-exists`
+
+Install the Kueue LocalQueue CRD so the API server accepts LocalQueue objects in the test cluster.
+
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `given-kyverno-has-permission-on-resources`
+
+Apply Kyverno RBAC so the policy engine can generate and reconcile LocalQueue resources.
+
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `given-cluster-policy-is-ready`
+
+Apply the queue bootstrap ClusterPolicy and assert Kyverno reports the policy as ready before exercising generation.
+
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+| 2 | `assert` | 0 | 0 | *No description* |
+
+### Step: `when-tenant-labeled-namespace-is-created`
+
+Create a namespace labeled konflux-ci.dev/type=tenant so the policy should generate a LocalQueue.
+
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `then-localqueue-is-created`
+
+Assert the expected pipelines-queue LocalQueue exists and matches the fixture (name and spec).
+
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `assert` | 0 | 0 | *No description* |
+
+---
+
+# Test: `kueue-bootstrap-queue-new-tenant-labeled-namespace-unpaused`
+
+Tests that a LocalQueue is created in a namespace labeled with
+`konflux-ci.dev/type=tenant` and the `kueue.konflux-ci.dev/stop-policy`
+annotation set to a value different from `hold`.
+
+
+## Bindings
+
+| # | Name | Value |
+|:-:|---|---|
+| 1 | `suffix` | "labeled-unpaused" |
+
+## Steps
+
+| # | Name | Bindings | Try | Catch | Finally | Cleanup |
+|:-:|---|:-:|:-:|:-:|:-:|:-:|
+| 1 | [given-localqueue-crd-exists](#step-given-localqueue-crd-exists) | 0 | 1 | 0 | 0 | 0 |
+| 2 | [given-kyverno-has-permission-on-resources](#step-given-kyverno-has-permission-on-resources) | 0 | 1 | 0 | 0 | 0 |
+| 3 | [given-cluster-policy-is-ready](#step-given-cluster-policy-is-ready) | 0 | 2 | 0 | 0 | 0 |
+| 4 | [when-tenant-labeled-namespace-is-created](#step-when-tenant-labeled-namespace-is-created) | 0 | 1 | 0 | 0 | 0 |
+| 5 | [then-localqueue-is-created](#step-then-localqueue-is-created) | 0 | 1 | 0 | 0 | 0 |
+
+### Step: `given-localqueue-crd-exists`
+
+Install the Kueue LocalQueue CRD so the API server accepts LocalQueue objects in the test cluster.
+
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `given-kyverno-has-permission-on-resources`
+
+Apply Kyverno RBAC so the policy engine can generate and reconcile LocalQueue resources.
+
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `given-cluster-policy-is-ready`
+
+Apply the queue bootstrap ClusterPolicy and assert Kyverno reports the policy as ready before exercising generation.
+
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+| 2 | `assert` | 0 | 0 | *No description* |
+
+### Step: `when-tenant-labeled-namespace-is-created`
+
+Create a namespace labeled konflux-ci.dev/type=tenant so the policy should generate a LocalQueue.
+
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `then-localqueue-is-created`
+
+Assert the expected pipelines-queue LocalQueue exists and matches the fixture (name and spec).
+
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `assert` | 0 | 0 | *No description* |
+
+---
+
+# Test: `kueue-bootstrap-queue-new-tenant-labeled-paused-namespace-resumed`
+
+Tests that a LocalQueue with `stopPolicy` set to `Hold` is created
+in a namespace labeled with `konflux-ci.dev/type=tenant` with the
+`kueue.konflux-ci.dev/stop-policy` annotation set to `hold`. The
+`stopPolicy` is then set to `None` when the annotation is removed
+from the namespace.
+
+
+## Bindings
+
+| # | Name | Value |
+|:-:|---|---|
+| 1 | `suffix` | "labeled-paused-unpaused" |
+
+## Steps
+
+| # | Name | Bindings | Try | Catch | Finally | Cleanup |
+|:-:|---|:-:|:-:|:-:|:-:|:-:|
+| 1 | [given-localqueue-crd-exists](#step-given-localqueue-crd-exists) | 0 | 1 | 0 | 0 | 0 |
+| 2 | [given-kyverno-has-permission-on-resources](#step-given-kyverno-has-permission-on-resources) | 0 | 1 | 0 | 0 | 0 |
+| 3 | [given-cluster-policy-is-ready](#step-given-cluster-policy-is-ready) | 0 | 2 | 0 | 0 | 0 |
+| 4 | [when-tenant-labeled-namespace-is-created-paused](#step-when-tenant-labeled-namespace-is-created-paused) | 0 | 1 | 0 | 0 | 0 |
+| 5 | [then-localqueue-is-created-paused](#step-then-localqueue-is-created-paused) | 0 | 1 | 0 | 0 | 0 |
+| 6 | [when-tenant-labeled-namespace-is-updated-to-unpause](#step-when-tenant-labeled-namespace-is-updated-to-unpause) | 0 | 1 | 0 | 0 | 0 |
+| 7 | [then-localqueue-is-unpaused](#step-then-localqueue-is-unpaused) | 0 | 1 | 0 | 0 | 0 |
+
+### Step: `given-localqueue-crd-exists`
+
+Install the Kueue LocalQueue CRD so the API server accepts LocalQueue objects in the test cluster.
+
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `given-kyverno-has-permission-on-resources`
+
+Apply Kyverno RBAC so the policy engine can generate and reconcile LocalQueue resources.
+
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `given-cluster-policy-is-ready`
+
+Apply the queue bootstrap ClusterPolicy and assert Kyverno reports the policy as ready before exercising generation.
+
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+| 2 | `assert` | 0 | 0 | *No description* |
+
+### Step: `when-tenant-labeled-namespace-is-created-paused`
+
+update a namespace labeled konflux-ci.dev/type=tenant so the policy should generate a LocalQueue.
+
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `then-localqueue-is-created-paused`
+
+Assert the expected pipelines-queue LocalQueue exists and matches the fixture (name and spec).
+
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `assert` | 0 | 0 | *No description* |
+
+### Step: `when-tenant-labeled-namespace-is-updated-to-unpause`
+
+Update the namespace to unpause it
+
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `update` | 0 | 0 | *No description* |
+
+### Step: `then-localqueue-is-unpaused`
+
+Assert the LocalQueue's StopPolicy is None
+
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `assert` | 0 | 0 | *No description* |
+
+---
+
+# Test: `kueue-bootstrap-queue-new-tenant-labeled-namespace-update-paused`
+
+Tests that a LocalQueue with `stopPolicy` set to `None` is created
+in a namespace labeled with `konflux-ci.dev/type=tenant` with no
+`kueue.konflux-ci.dev/stop-policy` annotation set. The `stopPolicy`
+is then set to `Hold` when the annotation is added to the namespace.
+
+
+## Bindings
+
+| # | Name | Value |
+|:-:|---|---|
+| 1 | `suffix` | "labeled-unpaused-paused" |
+
+## Steps
+
+| # | Name | Bindings | Try | Catch | Finally | Cleanup |
+|:-:|---|:-:|:-:|:-:|:-:|:-:|
+| 1 | [given-localqueue-crd-exists](#step-given-localqueue-crd-exists) | 0 | 1 | 0 | 0 | 0 |
+| 2 | [given-kyverno-has-permission-on-resources](#step-given-kyverno-has-permission-on-resources) | 0 | 1 | 0 | 0 | 0 |
+| 3 | [given-cluster-policy-is-ready](#step-given-cluster-policy-is-ready) | 0 | 2 | 0 | 0 | 0 |
+| 4 | [when-tenant-labeled-namespace-is-created](#step-when-tenant-labeled-namespace-is-created) | 0 | 1 | 0 | 0 | 0 |
+| 5 | [then-localqueue-is-created](#step-then-localqueue-is-created) | 0 | 1 | 0 | 0 | 0 |
+| 6 | [when-tenant-labeled-namespace-is-updated](#step-when-tenant-labeled-namespace-is-updated) | 0 | 1 | 0 | 0 | 0 |
+| 7 | [then-localqueue-is-updated](#step-then-localqueue-is-updated) | 0 | 1 | 0 | 0 | 0 |
+
+### Step: `given-localqueue-crd-exists`
+
+Install the Kueue LocalQueue CRD so the API server accepts LocalQueue objects in the test cluster.
+
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `given-kyverno-has-permission-on-resources`
+
+Apply Kyverno RBAC so the policy engine can generate and reconcile LocalQueue resources.
+
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `given-cluster-policy-is-ready`
+
+Apply the queue bootstrap ClusterPolicy and assert Kyverno reports the policy as ready before exercising generation.
+
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+| 2 | `assert` | 0 | 0 | *No description* |
+
+### Step: `when-tenant-labeled-namespace-is-created`
+
+Create a namespace labeled konflux-ci.dev/type=tenant so the policy should generate a LocalQueue.
+
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `then-localqueue-is-created`
+
+Assert the expected pipelines-queue LocalQueue exists and matches the fixture (name and spec).
+
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `assert` | 0 | 0 | *No description* |
+
+### Step: `when-tenant-labeled-namespace-is-updated`
+
+update a namespace labeled konflux-ci.dev/type=tenant so the policy should generate a LocalQueue.
+
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `then-localqueue-is-updated`
+
+Assert the expected pipelines-queue LocalQueue exists and matches the fixture (name and spec).
+
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `assert` | 0 | 0 | *No description* |
+
+---
+
+# Test: `kueue-bootstrap-queue-new-tenant-labeled-namespace-paused`
+
+Tests that a LocalQueue is created in a namespace labeled with
+`konflux-ci.dev/type=tenant` and with annotation to pause the
+LocalQueue.
 
 
 ## Bindings
@@ -407,6 +783,81 @@ Assert the expected pipelines-queue LocalQueue exists and matches the fixture (n
 
 ---
 
+# Test: `kueue-bootstrap-queue-kanary-namespace-before-policy`
+
+Tests that a LocalQueue is created for an existing
+`appstudio-kanary-exporter` namespace when the ClusterPolicy is
+applied (generateExisting, name-based match).
+
+
+## Steps
+
+| # | Name | Bindings | Try | Catch | Finally | Cleanup |
+|:-:|---|:-:|:-:|:-:|:-:|:-:|
+| 1 | [given-localqueue-crd-exists](#step-given-localqueue-crd-exists) | 0 | 1 | 0 | 0 | 0 |
+| 2 | [given-kanary-namespace-exists](#step-given-kanary-namespace-exists) | 0 | 1 | 0 | 0 | 0 |
+| 3 | [given-kyverno-has-permission-on-resources](#step-given-kyverno-has-permission-on-resources) | 0 | 1 | 0 | 0 | 0 |
+| 4 | [when-cluster-policy-is-ready](#step-when-cluster-policy-is-ready) | 0 | 2 | 0 | 0 | 0 |
+| 5 | [then-localqueue-is-created](#step-then-localqueue-is-created) | 0 | 1 | 0 | 0 | 0 |
+
+### Step: `given-localqueue-crd-exists`
+
+Install the Kueue LocalQueue CRD so the API server accepts LocalQueue objects in the test cluster.
+
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `given-kanary-namespace-exists`
+
+Create the appstudio-kanary-exporter namespace before policy install for name-based generateExisting.
+
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `given-kyverno-has-permission-on-resources`
+
+Apply Kyverno RBAC so the policy engine can generate and reconcile LocalQueue resources.
+
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `when-cluster-policy-is-ready`
+
+Apply the ClusterPolicy after the target namespace exists so generateExisting can backfill the LocalQueue.
+
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+| 2 | `assert` | 0 | 0 | *No description* |
+
+### Step: `then-localqueue-is-created`
+
+Assert the expected pipelines-queue LocalQueue exists and matches the fixture (name and spec).
+
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `assert` | 0 | 0 | *No description* |
+
+---
+
 # Test: `kueue-bootstrap-queue-mintmaker-by-name`
 
 Tests that a LocalQueue is created for the `mintmaker` namespace
@@ -460,6 +911,80 @@ Apply the queue bootstrap ClusterPolicy and assert Kyverno reports the policy as
 ### Step: `when-mintmaker-namespace-is-created`
 
 Create the mintmaker namespace after the policy is ready to verify name-based generation without the tenant label.
+
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `then-localqueue-is-created`
+
+Assert the expected pipelines-queue LocalQueue exists and matches the fixture (name and spec).
+
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `assert` | 0 | 0 | *No description* |
+
+---
+
+# Test: `kueue-bootstrap-queue-kanary-by-name`
+
+Tests that a LocalQueue is created for the `appstudio-kanary-exporter`
+namespace without the tenant label (name-based match).
+
+
+## Steps
+
+| # | Name | Bindings | Try | Catch | Finally | Cleanup |
+|:-:|---|:-:|:-:|:-:|:-:|:-:|
+| 1 | [given-localqueue-crd-exists](#step-given-localqueue-crd-exists) | 0 | 1 | 0 | 0 | 0 |
+| 2 | [given-kyverno-has-permission-on-resources](#step-given-kyverno-has-permission-on-resources) | 0 | 1 | 0 | 0 | 0 |
+| 3 | [given-cluster-policy-is-ready](#step-given-cluster-policy-is-ready) | 0 | 2 | 0 | 0 | 0 |
+| 4 | [when-kanary-namespace-is-created](#step-when-kanary-namespace-is-created) | 0 | 1 | 0 | 0 | 0 |
+| 5 | [then-localqueue-is-created](#step-then-localqueue-is-created) | 0 | 1 | 0 | 0 | 0 |
+
+### Step: `given-localqueue-crd-exists`
+
+Install the Kueue LocalQueue CRD so the API server accepts LocalQueue objects in the test cluster.
+
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `given-kyverno-has-permission-on-resources`
+
+Apply Kyverno RBAC so the policy engine can generate and reconcile LocalQueue resources.
+
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `given-cluster-policy-is-ready`
+
+Apply the queue bootstrap ClusterPolicy and assert Kyverno reports the policy as ready before exercising generation.
+
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+| 2 | `assert` | 0 | 0 | *No description* |
+
+### Step: `when-kanary-namespace-is-created`
+
+Create the appstudio-kanary-exporter namespace after the policy is ready to verify name-based generation.
 
 
 #### Try

--- a/components/policies/production/policies/kueue/queue-config/.chainsaw-test/chainsaw-test.yaml
+++ b/components/policies/production/policies/kueue/queue-config/.chainsaw-test/chainsaw-test.yaml
@@ -6,7 +6,8 @@ metadata:
 spec:
   description: |
     Tests that a LocalQueue is created in a namespace labeled with
-    `konflux-ci.dev/type=tenant`.
+    `konflux-ci.dev/type=tenant` and no `kueue.konflux-ci.dev/stop-policy`
+    annotation.
   concurrent: false
   namespace: kueue-queue-new
   bindings:
@@ -46,6 +47,241 @@ spec:
     try:
     - assert:
         file: resources/expected-localqueue.yaml
+        template: true
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: kueue-bootstrap-queue-new-tenant-labeled-namespace-unpaused
+spec:
+  description: |
+    Tests that a LocalQueue is created in a namespace labeled with
+    `konflux-ci.dev/type=tenant` and the `kueue.konflux-ci.dev/stop-policy`
+    annotation set to a value different from `hold`.
+  concurrent: false
+  namespace: kueue-queue-new
+  bindings:
+  - name: suffix
+    value: labeled-unpaused
+  steps:
+  - name: given-localqueue-crd-exists
+    description: |
+      Install the Kueue LocalQueue CRD so the API server accepts LocalQueue objects in the test cluster.
+    try:
+    - apply:
+        file: ./resources/localqueue-crd.yaml
+  - name: given-kyverno-has-permission-on-resources
+    description: |
+      Apply Kyverno RBAC so the policy engine can generate and reconcile LocalQueue resources.
+    try:
+    - apply:
+        file: ../kyverno-rbac.yaml
+  - name: given-cluster-policy-is-ready
+    description: |
+      Apply the queue bootstrap ClusterPolicy and assert Kyverno reports the policy as ready before exercising generation.
+    try:
+    - apply:
+        file: ../cluster-policy.yaml
+    - assert:
+        file: chainsaw-assert-clusterpolicy.yaml
+  - name: when-tenant-labeled-namespace-is-created
+    description: |
+      Create a namespace labeled konflux-ci.dev/type=tenant so the policy should generate a LocalQueue.
+    try:
+    - apply:
+        file: resources/namespace-tenant-unpaused.yaml
+        template: true
+  - name: then-localqueue-is-created
+    description: |
+      Assert the expected pipelines-queue LocalQueue exists and matches the fixture (name and spec).
+    try:
+    - assert:
+        file: resources/expected-localqueue.yaml
+        template: true
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: kueue-bootstrap-queue-new-tenant-labeled-paused-namespace-resumed
+spec:
+  description: |
+    Tests that a LocalQueue with `stopPolicy` set to `Hold` is created
+    in a namespace labeled with `konflux-ci.dev/type=tenant` with the
+    `kueue.konflux-ci.dev/stop-policy` annotation set to `hold`. The
+    `stopPolicy` is then set to `None` when the annotation is removed
+    from the namespace.
+  concurrent: false
+  namespace: kueue-queue-new
+  bindings:
+  - name: suffix
+    value: labeled-paused-unpaused
+  steps:
+  - name: given-localqueue-crd-exists
+    description: |
+      Install the Kueue LocalQueue CRD so the API server accepts LocalQueue objects in the test cluster.
+    try:
+    - apply:
+        file: ./resources/localqueue-crd.yaml
+  - name: given-kyverno-has-permission-on-resources
+    description: |
+      Apply Kyverno RBAC so the policy engine can generate and reconcile LocalQueue resources.
+    try:
+    - apply:
+        file: ../kyverno-rbac.yaml
+  - name: given-cluster-policy-is-ready
+    description: |
+      Apply the queue bootstrap ClusterPolicy and assert Kyverno reports the policy as ready before exercising generation.
+    try:
+    - apply:
+        file: ../cluster-policy.yaml
+    - assert:
+        file: chainsaw-assert-clusterpolicy.yaml
+  - name: when-tenant-labeled-namespace-is-created-paused
+    description: |
+      update a namespace labeled konflux-ci.dev/type=tenant so the policy should generate a LocalQueue.
+    try:
+    - apply:
+        file: resources/namespace-tenant-paused.yaml
+        template: true
+  - name: then-localqueue-is-created-paused
+    description: |
+      Assert the expected pipelines-queue LocalQueue exists and matches the fixture (name and spec).
+    try:
+    - assert:
+        file: resources/expected-localqueue-paused.yaml
+        template: true
+  - name: when-tenant-labeled-namespace-is-updated-to-unpause
+    description: |
+      Update the namespace to unpause it
+    try:
+    - update:
+        file: resources/namespace-tenant.yaml
+        template: true
+  - name: then-localqueue-is-unpaused
+    description: |
+      Assert the LocalQueue's StopPolicy is None
+    try:
+    - assert:
+        file: resources/expected-localqueue.yaml
+        template: true
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: kueue-bootstrap-queue-new-tenant-labeled-namespace-update-paused
+spec:
+  description: |
+    Tests that a LocalQueue with `stopPolicy` set to `None` is created
+    in a namespace labeled with `konflux-ci.dev/type=tenant` with no
+    `kueue.konflux-ci.dev/stop-policy` annotation set. The `stopPolicy`
+    is then set to `Hold` when the annotation is added to the namespace.
+  concurrent: false
+  namespace: kueue-queue-new
+  bindings:
+  - name: suffix
+    value: labeled-unpaused-paused
+  steps:
+  - name: given-localqueue-crd-exists
+    description: |
+      Install the Kueue LocalQueue CRD so the API server accepts LocalQueue objects in the test cluster.
+    try:
+    - apply:
+        file: ./resources/localqueue-crd.yaml
+  - name: given-kyverno-has-permission-on-resources
+    description: |
+      Apply Kyverno RBAC so the policy engine can generate and reconcile LocalQueue resources.
+    try:
+    - apply:
+        file: ../kyverno-rbac.yaml
+  - name: given-cluster-policy-is-ready
+    description: |
+      Apply the queue bootstrap ClusterPolicy and assert Kyverno reports the policy as ready before exercising generation.
+    try:
+    - apply:
+        file: ../cluster-policy.yaml
+    - assert:
+        file: chainsaw-assert-clusterpolicy.yaml
+  - name: when-tenant-labeled-namespace-is-created
+    description: |
+      Create a namespace labeled konflux-ci.dev/type=tenant so the policy should generate a LocalQueue.
+    try:
+    - apply:
+        file: resources/namespace-tenant.yaml
+        template: true
+  - name: then-localqueue-is-created
+    description: |
+      Assert the expected pipelines-queue LocalQueue exists and matches the fixture (name and spec).
+    try:
+    - assert:
+        file: resources/expected-localqueue.yaml
+        template: true
+  - name: when-tenant-labeled-namespace-is-updated
+    description: |
+      update a namespace labeled konflux-ci.dev/type=tenant so the policy should generate a LocalQueue.
+    try:
+    - apply:
+        file: resources/namespace-tenant-paused.yaml
+        template: true
+  - name: then-localqueue-is-updated
+    description: |
+      Assert the expected pipelines-queue LocalQueue exists and matches the fixture (name and spec).
+    try:
+    - assert:
+        file: resources/expected-localqueue-paused.yaml
+        template: true
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: kueue-bootstrap-queue-new-tenant-labeled-namespace-paused
+spec:
+  description: |
+    Tests that a LocalQueue is created in a namespace labeled with
+    `konflux-ci.dev/type=tenant` and with annotation to pause the
+    LocalQueue.
+  concurrent: false
+  namespace: kueue-queue-new
+  bindings:
+  - name: suffix
+    value: labeled
+  steps:
+  - name: given-localqueue-crd-exists
+    description: |
+      Install the Kueue LocalQueue CRD so the API server accepts LocalQueue objects in the test cluster.
+    try:
+    - apply:
+        file: ./resources/localqueue-crd.yaml
+  - name: given-kyverno-has-permission-on-resources
+    description: |
+      Apply Kyverno RBAC so the policy engine can generate and reconcile LocalQueue resources.
+    try:
+    - apply:
+        file: ../kyverno-rbac.yaml
+  - name: given-cluster-policy-is-ready
+    description: |
+      Apply the queue bootstrap ClusterPolicy and assert Kyverno reports the policy as ready before exercising generation.
+    try:
+    - apply:
+        file: ../cluster-policy.yaml
+    - assert:
+        file: chainsaw-assert-clusterpolicy.yaml
+  - name: when-tenant-labeled-namespace-is-created
+    description: |
+      Create a namespace labeled konflux-ci.dev/type=tenant so the policy should generate a LocalQueue.
+    try:
+    - apply:
+        file: resources/namespace-tenant-paused.yaml
+        template: true
+  - name: then-localqueue-is-created
+    description: |
+      Assert the expected pipelines-queue LocalQueue exists and matches the fixture (name and spec).
+    try:
+    - assert:
+        file: resources/expected-localqueue-paused.yaml
         template: true
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
@@ -266,6 +502,52 @@ spec:
 apiVersion: chainsaw.kyverno.io/v1alpha1
 kind: Test
 metadata:
+  name: kueue-bootstrap-queue-kanary-namespace-before-policy
+spec:
+  description: |
+    Tests that a LocalQueue is created for an existing
+    `appstudio-kanary-exporter` namespace when the ClusterPolicy is
+    applied (generateExisting, name-based match).
+  concurrent: false
+  namespace: kueue-queue-kanary-existing
+  steps:
+  - name: given-localqueue-crd-exists
+    description: |
+      Install the Kueue LocalQueue CRD so the API server accepts LocalQueue objects in the test cluster.
+    try:
+    - apply:
+        file: ./resources/localqueue-crd.yaml
+  - name: given-kanary-namespace-exists
+    description: |
+      Create the appstudio-kanary-exporter namespace before policy install for name-based generateExisting.
+    try:
+    - apply:
+        file: resources/namespace-kanary.yaml
+  - name: given-kyverno-has-permission-on-resources
+    description: |
+      Apply Kyverno RBAC so the policy engine can generate and reconcile LocalQueue resources.
+    try:
+    - apply:
+        file: ../kyverno-rbac.yaml
+  - name: when-cluster-policy-is-ready
+    description: |
+      Apply the ClusterPolicy after the target namespace exists so generateExisting can backfill the LocalQueue.
+    try:
+    - apply:
+        file: ../cluster-policy.yaml
+    - assert:
+        file: chainsaw-assert-clusterpolicy.yaml
+  - name: then-localqueue-is-created
+    description: |
+      Assert the expected pipelines-queue LocalQueue exists and matches the fixture (name and spec).
+    try:
+    - assert:
+        file: resources/expected-localqueue-kanary.yaml
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
   name: kueue-bootstrap-queue-mintmaker-by-name
 spec:
   description: |
@@ -306,6 +588,51 @@ spec:
     try:
     - assert:
         file: resources/expected-localqueue-mintmaker.yaml
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: kueue-bootstrap-queue-kanary-by-name
+spec:
+  description: |
+    Tests that a LocalQueue is created for the `appstudio-kanary-exporter`
+    namespace without the tenant label (name-based match).
+  concurrent: false
+  namespace: kueue-queue-kanary-test
+  steps:
+  - name: given-localqueue-crd-exists
+    description: |
+      Install the Kueue LocalQueue CRD so the API server accepts LocalQueue objects in the test cluster.
+    try:
+    - apply:
+        file: ./resources/localqueue-crd.yaml
+  - name: given-kyverno-has-permission-on-resources
+    description: |
+      Apply Kyverno RBAC so the policy engine can generate and reconcile LocalQueue resources.
+    try:
+    - apply:
+        file: ../kyverno-rbac.yaml
+  - name: given-cluster-policy-is-ready
+    description: |
+      Apply the queue bootstrap ClusterPolicy and assert Kyverno reports the policy as ready before exercising generation.
+    try:
+    - apply:
+        file: ../cluster-policy.yaml
+    - assert:
+        file: chainsaw-assert-clusterpolicy.yaml
+  - name: when-kanary-namespace-is-created
+    description: |
+      Create the appstudio-kanary-exporter namespace after the policy is ready to verify name-based generation.
+    try:
+    - apply:
+        file: resources/namespace-kanary.yaml
+  - name: then-localqueue-is-created
+    description: |
+      Assert the expected pipelines-queue LocalQueue exists and matches the fixture (name and spec).
+    try:
+    - assert:
+        file: resources/expected-localqueue-kanary.yaml
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
 apiVersion: chainsaw.kyverno.io/v1alpha1

--- a/components/policies/production/policies/kueue/queue-config/.chainsaw-test/resources/expected-localqueue-kanary.yaml
+++ b/components/policies/production/policies/kueue/queue-config/.chainsaw-test/resources/expected-localqueue-kanary.yaml
@@ -2,7 +2,7 @@ apiVersion: kueue.x-k8s.io/v1beta1
 kind: LocalQueue
 metadata:
   name: pipelines-queue
-  namespace: mintmaker
+  namespace: appstudio-kanary-exporter
 spec:
   clusterQueue: cluster-pipeline-queue
   stopPolicy: None

--- a/components/policies/production/policies/kueue/queue-config/.chainsaw-test/resources/expected-localqueue-paused.yaml
+++ b/components/policies/production/policies/kueue/queue-config/.chainsaw-test/resources/expected-localqueue-paused.yaml
@@ -2,7 +2,7 @@ apiVersion: kueue.x-k8s.io/v1beta1
 kind: LocalQueue
 metadata:
   name: pipelines-queue
-  namespace: mintmaker
+  namespace: (join('-', [$namespace, $suffix]))
 spec:
   clusterQueue: cluster-pipeline-queue
-  stopPolicy: None
+  stopPolicy: Hold

--- a/components/policies/production/policies/kueue/queue-config/.chainsaw-test/resources/expected-localqueue.yaml
+++ b/components/policies/production/policies/kueue/queue-config/.chainsaw-test/resources/expected-localqueue.yaml
@@ -5,3 +5,4 @@ metadata:
   namespace: (join('-', [$namespace, $suffix]))
 spec:
   clusterQueue: cluster-pipeline-queue
+  stopPolicy: None

--- a/components/policies/production/policies/kueue/queue-config/.chainsaw-test/resources/namespace-kanary.yaml
+++ b/components/policies/production/policies/kueue/queue-config/.chainsaw-test/resources/namespace-kanary.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: appstudio-kanary-exporter

--- a/components/policies/production/policies/kueue/queue-config/.chainsaw-test/resources/namespace-tenant-paused.yaml
+++ b/components/policies/production/policies/kueue/queue-config/.chainsaw-test/resources/namespace-tenant-paused.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: (join('-', [$namespace, $suffix]))
+  annotations:
+    kueue.konflux-ci.dev/stop-policy: hold
+  labels:
+    konflux-ci.dev/type: tenant

--- a/components/policies/production/policies/kueue/queue-config/.chainsaw-test/resources/namespace-tenant-unpaused.yaml
+++ b/components/policies/production/policies/kueue/queue-config/.chainsaw-test/resources/namespace-tenant-unpaused.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: (join('-', [$namespace, $suffix]))
+  annotations:
+    kueue.konflux-ci.dev/stop-policy: none
+  labels:
+    konflux-ci.dev/type: tenant

--- a/components/policies/production/policies/kueue/queue-config/cluster-policy.yaml
+++ b/components/policies/production/policies/kueue/queue-config/cluster-policy.yaml
@@ -20,6 +20,12 @@ spec:
           - Namespace
           names:
           - mintmaker
+          - appstudio-kanary-exporter
+    context:
+    - name: stopPolicy
+      variable:
+        jmesPath: >-
+          (request.object.metadata.annotations."kueue.konflux-ci.dev/stop-policy" || '') == 'hold' && 'Hold' || 'None'
     generate:
       generateExisting: true
       orphanDownstreamOnPolicyDelete: true
@@ -31,3 +37,4 @@ spec:
       data:
         spec:
           clusterQueue: cluster-pipeline-queue
+          stopPolicy: "{{stopPolicy}}"


### PR DESCRIPTION
It's been baking in staging for a few weeks, and no issues have been identified.  Synchronize the production policy with the staging policy.

One small change to the policy is required, however: production has not upgraded to the latest version of kueue, so the v1beta1 version of kueue's resources is required by this policy.

Fixes: KFLUXINFRA-3646