### PR TITLE
unroll build-service update, which contains change to Repository CR

### DIFF
--- a/components/build-service/production/base/kustomization.yaml
+++ b/components/build-service/production/base/kustomization.yaml
@@ -3,7 +3,7 @@ kind: Kustomization
 resources:
 - ../../base
 - ../../base/external-secrets
-- https://github.com/konflux-ci/build-service/config/default?ref=b1d1753245617e47679b3366b2baa0e4ea6b8007
+- https://github.com/konflux-ci/build-service/config/default?ref=1da4f0fa542a61f212a15c2789f478610db31133
 
 namespace: build-service
 


### PR DESCRIPTION
naming

which causes issue when PaC is adding repository label to pipeline run and trimming it to 62 chars which can result at starting '.' which isn't valid value