### PR TITLE
info: announce maintenance on Friday, May 15th

### DIFF
--- a/components/konflux-info/production/kflux-ocp-p01/banner-content.yaml
+++ b/components/konflux-info/production/kflux-ocp-p01/banner-content.yaml
@@ -1,2 +1,3 @@
 # Only the first banner will be displayed. Put the one to display at the top and remove any which are no longer relevant
-[]
+- summary: This cluster will see maintenance on May 15th, 2026, during which pipelineruns may be held from executing for a short time.
+  type: info

--- a/components/konflux-info/production/kflux-osp-p01/banner-content.yaml
+++ b/components/konflux-info/production/kflux-osp-p01/banner-content.yaml
@@ -1,2 +1,3 @@
 # Only the first banner will be displayed. Put the one to display at the top and remove any which are no longer relevant
-[]
+- summary: This cluster will see maintenance on May 15th, 2026, during which pipelineruns may be held from executing for a short time.
+  type: info

--- a/components/konflux-info/production/kflux-prd-rh02/banner-content.yaml
+++ b/components/konflux-info/production/kflux-prd-rh02/banner-content.yaml
@@ -1,2 +1,3 @@
 # Only the first banner will be displayed. Put the one to display at the top and remove any which are no longer relevant
-[]
+- summary: This cluster will see maintenance on May 15th, 2026, during which pipelineruns may be held from executing for a short time.
+  type: info

--- a/components/konflux-info/production/kflux-prd-rh03/banner-content.yaml
+++ b/components/konflux-info/production/kflux-prd-rh03/banner-content.yaml
@@ -1,2 +1,3 @@
 # Only the first banner will be displayed. Put the one to display at the top and remove any which are no longer relevant
-[]
+- summary: This cluster will see maintenance on May 15th, 2026, during which pipelineruns may be held from executing for a short time.
+  type: info

--- a/components/konflux-info/production/kflux-rhel-p01/banner-content.yaml
+++ b/components/konflux-info/production/kflux-rhel-p01/banner-content.yaml
@@ -1,2 +1,3 @@
 # Only the first banner will be displayed. Put the one to display at the top and remove any which are no longer relevant
-[]
+- summary: This cluster will see maintenance on May 15th, 2026, during which pipelineruns may be held from executing for a short time.
+  type: info

--- a/components/konflux-info/production/stone-prd-rh01/banner-content.yaml
+++ b/components/konflux-info/production/stone-prd-rh01/banner-content.yaml
@@ -1,2 +1,3 @@
 # Only the first banner will be displayed. Put the one to display at the top and remove any which are no longer relevant
-[]
+- summary: This cluster will see maintenance on May 15th, 2026, during which pipelineruns may be held from executing for a short time.
+  type: info

--- a/components/konflux-info/production/stone-prod-p01/banner-content.yaml
+++ b/components/konflux-info/production/stone-prod-p01/banner-content.yaml
@@ -1,2 +1,3 @@
 # Only the first banner will be displayed. Put the one to display at the top and remove any which are no longer relevant
-[]
+- summary: This cluster will see maintenance on May 15th, 2026, during which pipelineruns may be held from executing for a short time.
+  type: info

--- a/components/konflux-info/production/stone-prod-p02/banner-content.yaml
+++ b/components/konflux-info/production/stone-prod-p02/banner-content.yaml
@@ -1,2 +1,3 @@
 # Only the first banner will be displayed. Put the one to display at the top and remove any which are no longer relevant
-[]
+- summary: This cluster will see maintenance on May 15th, 2026, during which pipelineruns may be held from executing for a short time.
+  type: info


### PR DESCRIPTION
Some further maintenance items were identified following last week's maintenance, and some follow-up maintenance is required.

All production clusters except for the fedora cluster will be impacted by this maintenance.

Inform users that this maintenance will be occurring and that their pipelineruns may be held for a short time.