### PR TITLE
UI proxy: replace long-lived token with rotated short-lived tokens (production)

### DIFF
--- a/components/konflux-ui/production/base/proxy/kustomization.yaml
+++ b/components/konflux-ui/production/base/proxy/kustomization.yaml
@@ -10,6 +10,13 @@ configMapGenerator:
   - name: proxy-nginx-templates
     files:
       - auth.conf
+  - name: proxy-nginx-run
+    files:
+      - proxy-nginx-run.sh=scripts/proxy-nginx-run.sh
+  - name: proxy-nginx-generate-loop
+    files:
+      - proxy-nginx-generate-loop.sh=scripts/proxy-nginx-generate-loop.sh
+      - proxy-nginx-generate-loop-probe.sh=scripts/proxy-nginx-generate-loop-probe.sh
   - name: proxy-nginx-static
     files:
       - tekton-results.conf

--- a/components/konflux-ui/production/base/proxy/proxy.yaml
+++ b/components/konflux-ui/production/base/proxy/proxy.yaml
@@ -61,18 +61,19 @@ spec:
             set -e
 
             # Generate auth.conf with bearer token replacement
-            token=$(cat /mnt/api-token/token)
+            token=$(cat /var/run/secrets/konflux-ci.dev/serviceaccount/token)
             sed "s/__BEARER_TOKEN__/$token/g" /mnt/nginx-templates/auth.conf > /mnt/nginx-generated-config/auth.conf
 
             chmod 640 /mnt/nginx-generated-config/auth.conf
 
         volumeMounts:
+        - mountPath: /var/run/secrets/konflux-ci.dev/serviceaccount
+          name: kube-api-token
+          readOnly: true
         - name: nginx-generated-config
           mountPath: /mnt/nginx-generated-config
         - name: nginx-templates
           mountPath: /mnt/nginx-templates
-        - name: api-token
-          mountPath: /mnt/api-token
         securityContext:
           readOnlyRootFilesystem: true
           runAsNonRoot: true
@@ -85,14 +86,48 @@ spec:
             cpu: 10m
             memory: 64Mi
       containers:
+      - name: generate-nginx-configs-loop
+        image: quay.io/konflux-ci/konflux-ui:68500b32e57278bf33ac18d4ef631ef243abb579
+        command:
+          - bash
+        args:
+          - "/var/run/scripts/konflux-ci.dev/proxy-nginx-generate-loop.sh"
+        livenessProbe:
+          exec:
+            command:
+            - bash
+            - "/var/run/scripts/konflux-ci.dev/proxy-nginx-generate-loop-probe.sh"
+          initialDelaySeconds: 30
+          periodSeconds: 30
+          failureThreshold: 3
+        volumeMounts:
+        - mountPath: /var/run/scripts/konflux-ci.dev/
+          name: proxy-generate-loop-script
+          readOnly: true
+        - mountPath: /var/run/secrets/konflux-ci.dev/serviceaccount
+          name: kube-api-token
+          readOnly: true
+        - name: nginx-generated-config
+          mountPath: /mnt/nginx-generated-config
+        - name: nginx-templates
+          mountPath: /mnt/nginx-templates
+        securityContext:
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 1001
+        resources:
+          limits:
+            cpu: 50m
+            memory: 128Mi
+          requests:
+            cpu: 10m
+            memory: 64Mi
       - image: registry.access.redhat.com/ubi9/nginx-124@sha256:b924363ff07ee0f8fd4f680497da774ac0721722a119665998ff5b2111098ad1
         name: nginx
         command:
-          - nginx
-          - "-g"
-          - "daemon off;"
-          - -c
-          - /etc/nginx/nginx.conf
+          - bash
+        args:
+          - "/var/run/scripts/konflux-ci.dev/proxy-nginx-run.sh"
         livenessProbe:
           failureThreshold: 3
           httpGet:
@@ -128,6 +163,9 @@ spec:
             cpu: 30m
             memory: 128Mi
         volumeMounts:
+          - mountPath: /var/run/scripts/konflux-ci.dev/
+            name: proxy-nginx-run-script
+            readOnly: true
           - mountPath: /etc/nginx/nginx.conf
             subPath: nginx.conf
             name: proxy
@@ -238,6 +276,29 @@ spec:
             cpu: 50m
             memory: 128Mi
       volumes:
+        - name: proxy-generate-loop-script
+          configMap:
+            defaultMode: 0750
+            name: proxy-nginx-generate-loop
+            items:
+              - key: proxy-nginx-generate-loop.sh
+                path: proxy-nginx-generate-loop.sh
+              - key: proxy-nginx-generate-loop-probe.sh
+                path: proxy-nginx-generate-loop-probe.sh
+        - name: proxy-nginx-run-script
+          configMap:
+            defaultMode: 0750
+            name: proxy-nginx-run
+            items:
+              - key: proxy-nginx-run.sh
+                path: proxy-nginx-run.sh
+        - name: kube-api-token
+          projected:
+            defaultMode: 420
+            sources:
+            - serviceAccountToken:
+                expirationSeconds: 600
+                path: token
         - configMap:
             defaultMode: 420
             name: proxy
@@ -264,9 +325,6 @@ spec:
             secretName: serving-cert
         - name: nginx-generated-config
           emptyDir: {}
-        - name: api-token
-          secret:
-            secretName: proxy
         - name: static-content
           emptyDir: {}
         - configMap:
@@ -309,14 +367,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: proxy
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: proxy
-  annotations:
-    kubernetes.io/service-account.name: proxy
-type: kubernetes.io/service-account-token
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/components/konflux-ui/production/base/proxy/scripts/proxy-nginx-generate-loop-probe.sh
+++ b/components/konflux-ui/production/base/proxy/scripts/proxy-nginx-generate-loop-probe.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -euo pipefail
+
+for cmd in date stat; do
+  command -v "${cmd}" >/dev/null 2>&1 || { echo "required command not found: ${cmd}"; exit 1; }
+done
+
+AUTH_CONF_FILE=/mnt/nginx-generated-config/auth.conf
+AUTH_CONF_NEW_FILE=/mnt/nginx-generated-config/auth.conf.new
+
+{ [ -f "${AUTH_CONF_NEW_FILE}" ] && [ $(( $(date +%s) - $(stat -c %Y "${AUTH_CONF_NEW_FILE}") )) -lt 60 ]; } || \
+  { [ -f "${AUTH_CONF_FILE}" ] && [ $(( $(date +%s) - $(stat -c %Y "${AUTH_CONF_FILE}") )) -lt 60 ]; }

--- a/components/konflux-ui/production/base/proxy/scripts/proxy-nginx-generate-loop.sh
+++ b/components/konflux-ui/production/base/proxy/scripts/proxy-nginx-generate-loop.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+set -euo pipefail
+
+RETRY_INTERVAL=10
+TOKEN_FILEPATH=/var/run/secrets/konflux-ci.dev/serviceaccount/token
+AUTH_CONF_FILE=/mnt/nginx-generated-config/auth.conf.new
+AUTH_CONF_TMP_FILE=/mnt/nginx-generated-config/auth.conf.new.tmp
+AUTH_CONF_TEMPLATE_FILE=/mnt/nginx-templates/auth.conf
+
+for cmd in cat sed chmod mv sleep date; do
+  command -v "${cmd}" >/dev/null 2>&1 || { echo "required command not found: ${cmd}"; exit 1; }
+done
+
+log() { echo "$(date -Iseconds) generate-loop: $*"; }
+
+log "starting"
+
+produceToken() (
+  # Copy the auth.conf template and replace the bearer token
+  token=$(cat "${TOKEN_FILEPATH}")
+
+  # Produce a tmp file
+  sed "s/__BEARER_TOKEN__/${token}/" "${AUTH_CONF_TEMPLATE_FILE}" > "${AUTH_CONF_TMP_FILE}"
+  chmod 640 "${AUTH_CONF_TMP_FILE}"
+
+  # Rename (atomic) the file to avoid sync issues
+  mv "${AUTH_CONF_TMP_FILE}" "${AUTH_CONF_FILE}"
+)
+
+produceTokenWithRetry() (
+  produceToken || \
+    { sleep 3; produceToken; } || \
+    { sleep 5; produceToken; }
+)
+
+while produceTokenWithRetry; do sleep "${RETRY_INTERVAL}"; done
+
+echo "loop broke, crashing"
+exit 1

--- a/components/konflux-ui/production/base/proxy/scripts/proxy-nginx-run.sh
+++ b/components/konflux-ui/production/base/proxy/scripts/proxy-nginx-run.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+
+set -euo pipefail
+
+NGINX_AUTH_CONF_FILE='/mnt/nginx-generated-config/auth.conf'
+NGINX_NEW_AUTH_CONF_FILE='/mnt/nginx-generated-config/auth.conf.new'
+
+NGINX_CONF_FILE='/etc/nginx/nginx.conf'
+RETRY_INTERVAL=10
+
+for cmd in nginx cksum mv sleep date; do
+  command -v "${cmd}" >/dev/null 2>&1 || { echo "required command not found: ${cmd}"; exit 1; }
+done
+
+log() { echo "$(date -Iseconds) proxy-nginx-run: $*"; }
+
+log "starting"
+
+# test configuration
+nginx -g "daemon off;" -c "${NGINX_CONF_FILE}" -t
+
+# run the hot-reload loop in background
+(
+  # wait for nginx to start before first reload attempt
+  while [ ! -f /run/nginx.pid ]; do sleep 1; done
+
+  log "hot-reload loop started"
+
+  # retries hot reloading the nginx configuration multiple
+  # times with increasing timeouts before returning the error
+  reloadWithRetry() {
+    if [ -f "${NGINX_NEW_AUTH_CONF_FILE}" ] && \
+      [ "$(cksum < "${NGINX_NEW_AUTH_CONF_FILE}")" != "$(cksum < "${NGINX_AUTH_CONF_FILE}")" ]; then
+      log "config changed, reloading nginx"
+      # Move (atomic) the new configuration and reload it in NGINX
+      mv "${NGINX_NEW_AUTH_CONF_FILE}" "${NGINX_AUTH_CONF_FILE}" && \
+        {
+          nginx -s reload || \
+            { sleep 3; nginx -s reload; } || \
+            { sleep 5; nginx -s reload; }
+        }
+    fi
+  }
+
+  # hot reload infinite loop
+  while reloadWithRetry; do sleep "${RETRY_INTERVAL}"; done
+
+  log "loop broke, crashing"
+  exit 1
+) &
+RELOAD_PID=$!
+
+# run the nginx server in background
+(
+  nginx -g "daemon off;" -c "${NGINX_CONF_FILE}"
+  log "nginx crashed"
+  exit 1
+) &
+# forward SIGTERM/SIGINT for graceful shutdown
+trap 'log "received signal, shutting down"; nginx -s quit 2>/dev/null; kill "${RELOAD_PID}" 2>/dev/null; wait; exit 0' TERM INT
+
+# wait for any of the background tasks to crash
+wait -n
+EXIT_CODE=$?
+log "child exited with code ${EXIT_CODE}, terminating"
+exit "${EXIT_CODE}"

--- a/components/konflux-ui/production/kflux-fedora-01/oauth2-proxy-args-patch.yaml
+++ b/components/konflux-ui/production/kflux-fedora-01/oauth2-proxy-args-patch.yaml
@@ -1,6 +1,6 @@
 ---
 - op: replace
-  path: /spec/template/spec/containers/2/args
+  path: /spec/template/spec/containers/3/args
   value:
     - --provider
     - oidc

--- a/components/konflux-ui/production/kflux-fedora-01/remove-run-as-user-proxy-patch.yaml
+++ b/components/konflux-ui/production/kflux-fedora-01/remove-run-as-user-proxy-patch.yaml
@@ -16,3 +16,6 @@
 
 - op: remove
   path: /spec/template/spec/containers/3/securityContext/runAsUser
+
+- op: remove
+  path: /spec/template/spec/containers/4/securityContext/runAsUser

--- a/components/konflux-ui/production/kflux-ocp-p01/oauth2-proxy-args-patch.yaml
+++ b/components/konflux-ui/production/kflux-ocp-p01/oauth2-proxy-args-patch.yaml
@@ -1,6 +1,6 @@
 ---
 - op: replace
-  path: /spec/template/spec/containers/2/args
+  path: /spec/template/spec/containers/3/args
   value:
     - --provider
     - oidc

--- a/components/konflux-ui/production/kflux-ocp-p01/remove-run-as-user-proxy-patch.yaml
+++ b/components/konflux-ui/production/kflux-ocp-p01/remove-run-as-user-proxy-patch.yaml
@@ -16,3 +16,6 @@
 
 - op: remove
   path: /spec/template/spec/containers/3/securityContext/runAsUser
+
+- op: remove
+  path: /spec/template/spec/containers/4/securityContext/runAsUser

--- a/components/konflux-ui/production/kflux-osp-p01/oauth2-proxy-args-patch.yaml
+++ b/components/konflux-ui/production/kflux-osp-p01/oauth2-proxy-args-patch.yaml
@@ -1,6 +1,6 @@
 ---
 - op: replace
-  path: /spec/template/spec/containers/2/args
+  path: /spec/template/spec/containers/3/args
   value:
     - --provider
     - oidc

--- a/components/konflux-ui/production/kflux-osp-p01/remove-run-as-user-proxy-patch.yaml
+++ b/components/konflux-ui/production/kflux-osp-p01/remove-run-as-user-proxy-patch.yaml
@@ -16,3 +16,6 @@
 
 - op: remove
   path: /spec/template/spec/containers/3/securityContext/runAsUser
+
+- op: remove
+  path: /spec/template/spec/containers/4/securityContext/runAsUser

--- a/components/konflux-ui/production/kflux-prd-rh02/oauth2-proxy-args-patch.yaml
+++ b/components/konflux-ui/production/kflux-prd-rh02/oauth2-proxy-args-patch.yaml
@@ -1,6 +1,6 @@
 ---
 - op: replace
-  path: /spec/template/spec/containers/2/args
+  path: /spec/template/spec/containers/3/args
   value:
     - --provider
     - oidc

--- a/components/konflux-ui/production/kflux-prd-rh02/remove-run-as-user-proxy-patch.yaml
+++ b/components/konflux-ui/production/kflux-prd-rh02/remove-run-as-user-proxy-patch.yaml
@@ -16,3 +16,6 @@
 
 - op: remove
   path: /spec/template/spec/containers/3/securityContext/runAsUser
+
+- op: remove
+  path: /spec/template/spec/containers/4/securityContext/runAsUser

--- a/components/konflux-ui/production/kflux-prd-rh03/oauth2-proxy-args-patch.yaml
+++ b/components/konflux-ui/production/kflux-prd-rh03/oauth2-proxy-args-patch.yaml
@@ -1,6 +1,6 @@
 ---
 - op: replace
-  path: /spec/template/spec/containers/2/args
+  path: /spec/template/spec/containers/3/args
   value:
     - --provider
     - oidc

--- a/components/konflux-ui/production/kflux-prd-rh03/remove-run-as-user-proxy-patch.yaml
+++ b/components/konflux-ui/production/kflux-prd-rh03/remove-run-as-user-proxy-patch.yaml
@@ -16,3 +16,6 @@
 
 - op: remove
   path: /spec/template/spec/containers/3/securityContext/runAsUser
+
+- op: remove
+  path: /spec/template/spec/containers/4/securityContext/runAsUser

--- a/components/konflux-ui/production/kflux-rhel-p01/oauth2-proxy-args-patch.yaml
+++ b/components/konflux-ui/production/kflux-rhel-p01/oauth2-proxy-args-patch.yaml
@@ -1,6 +1,6 @@
 ---
 - op: replace
-  path: /spec/template/spec/containers/2/args
+  path: /spec/template/spec/containers/3/args
   value:
     - --provider
     - oidc

--- a/components/konflux-ui/production/kflux-rhel-p01/remove-run-as-user-proxy-patch.yaml
+++ b/components/konflux-ui/production/kflux-rhel-p01/remove-run-as-user-proxy-patch.yaml
@@ -16,3 +16,6 @@
 
 - op: remove
   path: /spec/template/spec/containers/3/securityContext/runAsUser
+
+- op: remove
+  path: /spec/template/spec/containers/4/securityContext/runAsUser

--- a/components/konflux-ui/production/stone-prd-rh01/oauth2-proxy-args-patch.yaml
+++ b/components/konflux-ui/production/stone-prd-rh01/oauth2-proxy-args-patch.yaml
@@ -1,6 +1,6 @@
 ---
 - op: replace
-  path: /spec/template/spec/containers/2/args
+  path: /spec/template/spec/containers/3/args
   value:
     - --provider
     - oidc

--- a/components/konflux-ui/production/stone-prd-rh01/remove-run-as-user-proxy-patch.yaml
+++ b/components/konflux-ui/production/stone-prd-rh01/remove-run-as-user-proxy-patch.yaml
@@ -16,3 +16,6 @@
 
 - op: remove
   path: /spec/template/spec/containers/3/securityContext/runAsUser
+
+- op: remove
+  path: /spec/template/spec/containers/4/securityContext/runAsUser

--- a/components/konflux-ui/production/stone-prod-p01/oauth2-proxy-args-patch.yaml
+++ b/components/konflux-ui/production/stone-prod-p01/oauth2-proxy-args-patch.yaml
@@ -1,6 +1,6 @@
 ---
 - op: replace
-  path: /spec/template/spec/containers/2/args
+  path: /spec/template/spec/containers/3/args
   value:
     - --provider
     - oidc

--- a/components/konflux-ui/production/stone-prod-p01/remove-run-as-user-proxy-patch.yaml
+++ b/components/konflux-ui/production/stone-prod-p01/remove-run-as-user-proxy-patch.yaml
@@ -16,3 +16,6 @@
 
 - op: remove
   path: /spec/template/spec/containers/3/securityContext/runAsUser
+
+- op: remove
+  path: /spec/template/spec/containers/4/securityContext/runAsUser

--- a/components/konflux-ui/production/stone-prod-p02/oauth2-proxy-args-patch.yaml
+++ b/components/konflux-ui/production/stone-prod-p02/oauth2-proxy-args-patch.yaml
@@ -1,6 +1,6 @@
 ---
 - op: replace
-  path: /spec/template/spec/containers/2/args
+  path: /spec/template/spec/containers/3/args
   value:
     - --provider
     - oidc

--- a/components/konflux-ui/production/stone-prod-p02/remove-run-as-user-proxy-patch.yaml
+++ b/components/konflux-ui/production/stone-prod-p02/remove-run-as-user-proxy-patch.yaml
@@ -16,3 +16,6 @@
 
 - op: remove
   path: /spec/template/spec/containers/3/securityContext/runAsUser
+
+- op: remove
+  path: /spec/template/spec/containers/4/securityContext/runAsUser

--- a/hack/new-cluster/templates/konflux-ui/oauth2-proxy-args-patch.yaml
+++ b/hack/new-cluster/templates/konflux-ui/oauth2-proxy-args-patch.yaml
@@ -1,6 +1,6 @@
 ---
 - op: replace
-  path: /spec/template/spec/containers/2/args
+  path: /spec/template/spec/containers/3/args
   value:
     - --provider
     - oidc

--- a/hack/new-cluster/templates/konflux-ui/remove-run-as-user-proxy-patch.yaml
+++ b/hack/new-cluster/templates/konflux-ui/remove-run-as-user-proxy-patch.yaml
@@ -16,3 +16,6 @@
 
 - op: remove
   path: /spec/template/spec/containers/3/securityContext/runAsUser
+
+- op: remove
+  path: /spec/template/spec/containers/4/securityContext/runAsUser


### PR DESCRIPTION
## Summary

- Replace long-lived ServiceAccount token secret with short-lived projected token (600s TTL) for the UI proxy in production
- Add `generate-nginx-configs-loop` sidecar container for continuous token rotation and hot-reload
- Replace direct `nginx` command with bash wrapper script (`proxy-nginx-run.sh`) enabling config hot-reload
- Remove the long-lived SA token Secret (`kubernetes.io/service-account-token`)
- Port bug fixes from upstream konflux-ci/konflux-ci#6780:
  - Fix liveness probe: use `command` instead of `args` for exec probes
  - Replace `cmp` with `cksum` (unavailable in `ubi9/nginx-124` image)
  - Add command validation and startup/reload logging to all scripts
  - Add SIGTERM forwarding for graceful nginx shutdown
  - Add `initialDelaySeconds` to generate-loop liveness probe
- Fix container index references in all 9 production overlay patches and new-cluster templates

Mirrors the staging changes from #11604.

## Test plan

- [ ] Verify `kustomize build` passes for all production overlays
- [ ] Deploy to a staging/test cluster and observe token rotation at ~8-minute intervals
- [ ] Confirm nginx reload triggers exactly once per rotation
- [ ] Verify pod remains healthy through multiple rotations

Made with [Cursor](https://cursor.com)