### PR TITLE
UI proxy: replace long-lived token with rotated short-lived tokens (production ring 1)

### DIFF
--- a/components/konflux-ui/production/base-ring2/dex/dex.yaml
+++ b/components/konflux-ui/production/base-ring2/dex/dex.yaml
@@ -1,0 +1,128 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: dex
+  name: dex
+  annotations:
+    ignore-check.kube-linter.io/no-anti-affinity: "Using topologySpreadConstraints"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: dex
+  template:
+    metadata:
+      labels:
+        app: dex
+    spec:
+      serviceAccountName: dex
+      topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: topology.kubernetes.io/zone
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app: dex
+      containers:
+      - image: ghcr.io/dexidp/dex:v2.32.0
+        name: dex
+        command: ["/usr/local/bin/dex", "serve", "/etc/dex/cfg/config.yaml"]
+        securityContext:
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+        resources:
+          limits:
+            cpu: 100m
+            memory: 256Mi
+          requests:
+            cpu: 100m
+            memory: 256Mi
+        ports:
+        - name: https
+          containerPort: 9443
+        - name: telemetry
+          containerPort: 5558
+          protocol: TCP
+        volumeMounts:
+        - name: dex
+          mountPath: /etc/dex/cfg
+        - name: tls
+          mountPath: /etc/dex/tls
+        readinessProbe:
+          httpGet:
+            path: /healthz/ready
+            port: telemetry
+        env:
+        - name: GODEBUG
+          value: "http2server=0"
+        - name: OPENSHIFT_OAUTH_CLIENT_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: dex-client
+              key: token
+        - name: OAUTH2_CLIENT_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: oauth2-proxy-client-secret
+              key: client-secret
+      volumes:
+      - name: dex
+        configMap:
+          name: dex
+          defaultMode: 420
+          items:
+          - key: dex-config.yaml
+            path: config.yaml
+      - name: tls
+        secret:
+          secretName: dex-cert
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: dex
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: dex-cert
+spec:
+  type: ClusterIP
+  ports:
+  - name: dex
+    port: 9443
+    protocol: TCP
+    targetPort: 9443
+  selector:
+    app: dex
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: dex
+  name: dex
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: dex
+rules:
+- apiGroups: ["dex.coreos.com"] # API group created by dex
+  resources: ["*"]
+  verbs: ["*"]
+- apiGroups: ["apiextensions.k8s.io"]
+  resources: ["customresourcedefinitions"]
+  verbs: ["create"] # To manage its own resources, dex must be able to create customresourcedefinitions
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: dex
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: dex
+subjects:
+- kind: ServiceAccount
+  name: dex           # Service account assigned to the dex pod, created above
+  namespace: konflux-ui  # The namespace dex is running in

--- a/components/konflux-ui/production/base-ring2/dex/kustomization.yaml
+++ b/components/konflux-ui/production/base-ring2/dex/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - dex.yaml

--- a/components/konflux-ui/production/base-ring2/kustomization.yaml
+++ b/components/konflux-ui/production/base-ring2/kustomization.yaml
@@ -1,0 +1,19 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - dex
+  - proxy
+  - route-and-oauth.yaml
+  - ../../base
+
+images:
+  - name: quay.io/konflux-ci/workspace-manager
+    digest: sha256:48df30520a766101473e80e7a4abbf59ce06097a5f5919e15075afaa86bd1a2d
+
+  - name: quay.io/konflux-ci/konflux-ui
+    newTag: ed23c9b83394454b5822049748939a26a5626093
+
+  - name: quay.io/oauth2-proxy/oauth2-proxy
+    digest: sha256:3da33b9670c67bd782277f99acadf7026f75b9507bfba2088eb2d497266ef7fc
+
+namespace: konflux-ui

--- a/components/konflux-ui/production/base-ring2/proxy/auth.conf
+++ b/components/konflux-ui/production/base-ring2/proxy/auth.conf
@@ -1,0 +1,5 @@
+# Auth configuration with impersonation enabled
+auth_request_set $user  $upstream_http_x_auth_request_email;
+proxy_set_header Impersonate-User $user;
+proxy_set_header Impersonate-Group system:authenticated;
+proxy_set_header Authorization "Bearer __BEARER_TOKEN__";

--- a/components/konflux-ui/production/base-ring2/proxy/kite.conf
+++ b/components/konflux-ui/production/base-ring2/proxy/kite.conf
@@ -1,0 +1,9 @@
+location /api/k8s/plugins/kite/ {
+    auth_request /oauth2/auth;
+    rewrite /api/k8s/plugins/kite/(.+) /$1 break;
+    proxy_read_timeout 30m;
+    proxy_pass https://konflux-kite.konflux-kite.svc.cluster.local;
+    include /mnt/nginx-generated-config/auth.conf;
+}
+
+

--- a/components/konflux-ui/production/base-ring2/proxy/kubearchive.conf
+++ b/components/konflux-ui/production/base-ring2/proxy/kubearchive.conf
@@ -1,0 +1,7 @@
+location /api/k8s/plugins/kubearchive/ {
+    auth_request /oauth2/auth;
+    rewrite /api/k8s/plugins/kubearchive/(.+) /$1 break;
+    proxy_read_timeout 30m;
+    proxy_pass https://kubearchive-api-server.product-kubearchive.svc.cluster.local:8081;
+    include /mnt/nginx-generated-config/auth.conf;
+}

--- a/components/konflux-ui/production/base-ring2/proxy/kustomization.yaml
+++ b/components/konflux-ui/production/base-ring2/proxy/kustomization.yaml
@@ -10,13 +10,6 @@ configMapGenerator:
   - name: proxy-nginx-templates
     files:
       - auth.conf
-  - name: proxy-nginx-run
-    files:
-      - proxy-nginx-run.sh=scripts/proxy-nginx-run.sh
-  - name: proxy-nginx-generate-loop
-    files:
-      - proxy-nginx-generate-loop.sh=scripts/proxy-nginx-generate-loop.sh
-      - proxy-nginx-generate-loop-probe.sh=scripts/proxy-nginx-generate-loop-probe.sh
   - name: proxy-nginx-static
     files:
       - tekton-results.conf

--- a/components/konflux-ui/production/base-ring2/proxy/nginx.conf
+++ b/components/konflux-ui/production/base-ring2/proxy/nginx.conf
@@ -1,0 +1,190 @@
+worker_processes auto;
+error_log /var/log/nginx/error.log;
+pid /run/nginx.pid;
+
+# Load dynamic modules. See /usr/share/doc/nginx/README.dynamic.
+include /usr/share/nginx/modules/*.conf;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    log_format upstreamlog '[$time_local] $remote_addr - $remote_user - $server_name $host to: $proxy_host  $upstream_addr: $request $status upstream_response_time $upstream_response_time msec $msec request_time $request_time';
+    access_log /dev/stderr upstreamlog;
+    error_log /dev/stderr;
+
+    log_format combined_custom '$remote_addr - $remote_user [$time_local] "$request" $status $body_bytes_sent "$http_referer" "$http_user_agent"';
+    access_log /var/log/nginx/access.log combined_custom;
+    
+    sendfile on;
+    tcp_nopush on;
+    tcp_nodelay on;
+    keepalive_timeout 65;
+    types_hash_max_size 4096;
+
+    default_type application/octet-stream;
+    include /etc/nginx/mime.types;
+
+    map $http_upgrade $connection_upgrade {
+        default upgrade;
+        '' close;
+    }
+
+    map $request_method $ns_target {
+        GET     @namespacelister;
+        default @kubeapi;
+    }
+
+    server {
+        listen 9443 ssl;
+        ssl_certificate /mnt/tls.crt;
+        ssl_certificate_key /mnt/tls.key;
+        server_name _;
+        root /opt/app-root/src;
+
+        location / {
+            alias /opt/app-root/src/static-content/;
+            try_files $uri /index.html;
+        }
+
+        location = /404.html {
+        }
+
+        location = /oauth2/auth {
+            internal;
+            proxy_pass       http://127.0.0.1:6000;
+            proxy_set_header Host             $host;
+            proxy_set_header X-Real-IP        $remote_addr;
+            proxy_set_header X-Scheme         $scheme;
+            # nginx auth_request includes headers but not body
+            proxy_set_header Content-Length   "";
+            proxy_pass_request_body           off;
+        }
+
+        location /oauth2/ {
+            proxy_pass       http://127.0.0.1:6000/oauth2/;
+            proxy_set_header Host             $host;
+            proxy_set_header X-Real-IP        $remote_addr;
+            proxy_set_header X-Scheme         $scheme;
+        }
+
+        location /api/k8s/registration/ {
+           # Registration Service registration endpoint
+            auth_request_set $email  $upstream_http_x_auth_request_email;
+            proxy_set_header X-Email $email;
+            auth_request_set $user  $upstream_http_x_auth_request_user;
+            proxy_set_header X-User  $user;
+            auth_request_set $username  $upstream_http_x_auth_request_preferred_username;
+            proxy_set_header X-Auth-Request-Preferred-Username $username;
+            auth_request_set $groups  $upstream_http_x_auth_request_groups;
+            proxy_set_header X-Auth-Request-Groups  $user;
+
+            auth_request /oauth2/auth;
+            proxy_pass http://127.0.0.1:5000/;
+        }
+
+        location /api/k8s/apis/toolchain.dev.openshift.com/v1alpha1/workspaces {
+           # Registration Service workspaces endpoint
+            auth_request_set $email  $upstream_http_x_auth_request_email;
+            proxy_set_header X-Email $email;
+            auth_request_set $user  $upstream_http_x_auth_request_user;
+            proxy_set_header X-User  $user;
+            auth_request_set $username  $upstream_http_x_auth_request_preferred_username;
+            proxy_set_header X-Auth-Request-Preferred-Username $username;
+            auth_request_set $groups  $upstream_http_x_auth_request_groups;
+            proxy_set_header X-Auth-Request-Groups  $user;
+
+            auth_request /oauth2/auth;
+            proxy_pass http://127.0.0.1:5000/workspaces;
+        }
+
+        location /api/k8s/workspaces/ {
+            # Kube-API
+            auth_request /oauth2/auth;
+
+            rewrite /api/k8s/workspaces/.+?/(.+) /$1 break;
+            proxy_pass https://kubernetes.default.svc;
+            proxy_read_timeout 30m;
+            include /mnt/nginx-generated-config/auth.conf;
+        }
+
+        location /wss/k8s/workspaces/ {
+            auth_request /oauth2/auth;
+
+            rewrite /wss/k8s/workspaces/.+?/(.+) /$1 break;
+            proxy_pass https://kubernetes.default.svc/;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection $connection_upgrade;
+            proxy_read_timeout 30m;
+            include /mnt/nginx-generated-config/auth.conf;
+        }
+
+        location /api/k8s/ {
+            # Kube-API
+            auth_request /oauth2/auth;
+
+            proxy_pass https://kubernetes.default.svc/;
+            proxy_read_timeout 30m;
+            include /mnt/nginx-generated-config/auth.conf;
+        }
+
+        location /wss/k8s/ {
+            auth_request /oauth2/auth;
+
+            rewrite /wss/k8s/(.+) /$1 break;
+            proxy_pass https://kubernetes.default.svc/;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection $connection_upgrade;
+            proxy_read_timeout 30m;
+            include /mnt/nginx-generated-config/auth.conf;
+        }
+
+
+
+        # GET requests to /api/k8s/api/v1/namespaces and /api/k8s/api/v1/namespaces/
+        # are handled from the namespace-lister.
+        # Requests with other methods are handled by the Kube-API
+        location = /api/k8s/api/v1/namespaces {
+            try_files /dev/null $ns_target;
+        }
+        location = /api/k8s/api/v1/namespaces/ {
+            try_files /dev/null $ns_target;
+        }
+
+        location @namespacelister {
+            auth_request_set $email  $upstream_http_x_auth_request_email;
+            auth_request /oauth2/auth;
+            proxy_read_timeout 30m;
+            proxy_set_header X-User $email;
+            proxy_set_header X-Group system:authenticated;
+            proxy_hide_header X-Correlation-ID;
+
+            rewrite ^.*$ /api/v1/namespaces break;
+
+            proxy_pass https://namespace-lister.namespace-lister.svc.cluster.local:8080;
+        }
+
+        location @kubeapi {
+            auth_request_set $email  $upstream_http_x_auth_request_email;
+            auth_request /oauth2/auth;
+            proxy_read_timeout 30m;
+            proxy_set_header X-Email $email;
+
+            rewrite ^/api/k8s/(.*)/$ /$1 break;
+
+            proxy_pass https://kubernetes.default.svc;
+            proxy_set_header Impersonate-User $email;
+            include /mnt/nginx-generated-config/auth.conf;
+        }
+
+        location /health {
+            # Used for liveness probes
+            return 200;
+        }
+
+        include /mnt/nginx-additional-location-configs/*.conf;
+    }
+}

--- a/components/konflux-ui/production/base-ring2/proxy/otel-collector-config.yaml
+++ b/components/konflux-ui/production/base-ring2/proxy/otel-collector-config.yaml
@@ -1,0 +1,59 @@
+receivers:
+  filelog/nginx:
+    include:
+      - /var/log/nginx/access.log
+    start_at: end
+    operators:
+      - type: regex_parser
+        regex: '^(?P<remote_addr>[^ ]*) - (?P<remote_user>[^ ]*) \[(?P<time_local>[^\]]*)\] "(?P<method>[^ ]*) (?P<path>[^ ]*) (?P<protocol>[^"]*)" (?P<status>\d+) (?P<body_bytes_sent>\d+) "(?P<http_referer>[^"]*)" "(?P<http_user_agent>[^"]*)"$'
+      - type: time_parser
+        parse_from: attributes.time_local
+        layout: '%d/%b/%Y:%H:%M:%S %z'
+        to_timestamp: true
+
+processors:
+  transform/status_to_int:
+    log_statements:
+      - context: log
+        statements:
+          - set(attributes["status_int"], Int(attributes["status"]))
+  deltatocumulative:
+    max_stale: 10m
+    max_streams: 10000
+  batch:
+    timeout: 10s
+    send_batch_size: 100
+    send_batch_max_size: 200
+
+extensions:
+  health_check:
+    endpoint: "0.0.0.0:13133"
+
+exporters:
+  prometheus:
+    endpoint: "0.0.0.0:8889"
+
+connectors:
+  count:
+    logs:
+      nginx_otel_http_request_errors:
+        description: HTTP 4xx and 5xx errors from NGINX
+        conditions:
+          - 'attributes["status_int"] >= 400 and attributes["status_int"] < 600'
+        attributes:
+          - key: method
+            value: attributes["method"]
+          - key: status
+            value: attributes["status"]
+
+service:
+  extensions: [health_check]
+  pipelines:
+    logs:
+      receivers: [filelog/nginx]
+      processors: [transform/status_to_int, batch]
+      exporters: [count]
+    metrics:
+      receivers: [count]
+      processors: [deltatocumulative, batch]
+      exporters: [prometheus]

--- a/components/konflux-ui/production/base-ring2/proxy/proxy.yaml
+++ b/components/konflux-ui/production/base-ring2/proxy/proxy.yaml
@@ -61,19 +61,18 @@ spec:
             set -e
 
             # Generate auth.conf with bearer token replacement
-            token=$(cat /var/run/secrets/konflux-ci.dev/serviceaccount/token)
+            token=$(cat /mnt/api-token/token)
             sed "s/__BEARER_TOKEN__/$token/g" /mnt/nginx-templates/auth.conf > /mnt/nginx-generated-config/auth.conf
 
             chmod 640 /mnt/nginx-generated-config/auth.conf
 
         volumeMounts:
-        - mountPath: /var/run/secrets/konflux-ci.dev/serviceaccount
-          name: kube-api-token
-          readOnly: true
         - name: nginx-generated-config
           mountPath: /mnt/nginx-generated-config
         - name: nginx-templates
           mountPath: /mnt/nginx-templates
+        - name: api-token
+          mountPath: /mnt/api-token
         securityContext:
           readOnlyRootFilesystem: true
           runAsNonRoot: true
@@ -86,48 +85,14 @@ spec:
             cpu: 10m
             memory: 64Mi
       containers:
-      - name: generate-nginx-configs-loop
-        image: quay.io/konflux-ci/konflux-ui:68500b32e57278bf33ac18d4ef631ef243abb579
-        command:
-          - bash
-        args:
-          - "/var/run/scripts/konflux-ci.dev/proxy-nginx-generate-loop.sh"
-        livenessProbe:
-          exec:
-            command:
-            - bash
-            - "/var/run/scripts/konflux-ci.dev/proxy-nginx-generate-loop-probe.sh"
-          initialDelaySeconds: 30
-          periodSeconds: 30
-          failureThreshold: 3
-        volumeMounts:
-        - mountPath: /var/run/scripts/konflux-ci.dev/
-          name: proxy-generate-loop-script
-          readOnly: true
-        - mountPath: /var/run/secrets/konflux-ci.dev/serviceaccount
-          name: kube-api-token
-          readOnly: true
-        - name: nginx-generated-config
-          mountPath: /mnt/nginx-generated-config
-        - name: nginx-templates
-          mountPath: /mnt/nginx-templates
-        securityContext:
-          readOnlyRootFilesystem: true
-          runAsNonRoot: true
-          runAsUser: 1001
-        resources:
-          limits:
-            cpu: 50m
-            memory: 128Mi
-          requests:
-            cpu: 10m
-            memory: 64Mi
       - image: registry.access.redhat.com/ubi9/nginx-124@sha256:b924363ff07ee0f8fd4f680497da774ac0721722a119665998ff5b2111098ad1
         name: nginx
         command:
-          - bash
-        args:
-          - "/var/run/scripts/konflux-ci.dev/proxy-nginx-run.sh"
+          - nginx
+          - "-g"
+          - "daemon off;"
+          - -c
+          - /etc/nginx/nginx.conf
         livenessProbe:
           failureThreshold: 3
           httpGet:
@@ -163,9 +128,6 @@ spec:
             cpu: 30m
             memory: 128Mi
         volumeMounts:
-          - mountPath: /var/run/scripts/konflux-ci.dev/
-            name: proxy-nginx-run-script
-            readOnly: true
           - mountPath: /etc/nginx/nginx.conf
             subPath: nginx.conf
             name: proxy
@@ -276,29 +238,6 @@ spec:
             cpu: 50m
             memory: 128Mi
       volumes:
-        - name: proxy-generate-loop-script
-          configMap:
-            defaultMode: 0750
-            name: proxy-nginx-generate-loop
-            items:
-              - key: proxy-nginx-generate-loop.sh
-                path: proxy-nginx-generate-loop.sh
-              - key: proxy-nginx-generate-loop-probe.sh
-                path: proxy-nginx-generate-loop-probe.sh
-        - name: proxy-nginx-run-script
-          configMap:
-            defaultMode: 0750
-            name: proxy-nginx-run
-            items:
-              - key: proxy-nginx-run.sh
-                path: proxy-nginx-run.sh
-        - name: kube-api-token
-          projected:
-            defaultMode: 420
-            sources:
-            - serviceAccountToken:
-                expirationSeconds: 600
-                path: token
         - configMap:
             defaultMode: 420
             name: proxy
@@ -325,6 +264,9 @@ spec:
             secretName: serving-cert
         - name: nginx-generated-config
           emptyDir: {}
+        - name: api-token
+          secret:
+            secretName: proxy
         - name: static-content
           emptyDir: {}
         - configMap:
@@ -367,6 +309,14 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: proxy
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: proxy
+  annotations:
+    kubernetes.io/service-account.name: proxy
+type: kubernetes.io/service-account-token
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/components/konflux-ui/production/base-ring2/proxy/tekton-results-workspaces.conf
+++ b/components/konflux-ui/production/base-ring2/proxy/tekton-results-workspaces.conf
@@ -1,0 +1,9 @@
+# Deprecated
+location /api/k8s/plugins/tekton-results/workspaces/ {
+    auth_request /oauth2/auth;
+
+    rewrite /api/k8s/plugins/tekton-results/workspaces/.+?/(.+) /$1 break;
+    proxy_read_timeout 30m;
+    proxy_pass https://tekton-results-api-service.tekton-results.svc.cluster.local:8080;
+    include /mnt/nginx-generated-config/auth.conf;
+}

--- a/components/konflux-ui/production/base-ring2/proxy/tekton-results.conf
+++ b/components/konflux-ui/production/base-ring2/proxy/tekton-results.conf
@@ -1,0 +1,8 @@
+location /api/k8s/plugins/tekton-results/ {
+    auth_request /oauth2/auth;
+
+    rewrite /api/k8s/plugins/tekton-results/(.+) /$1 break;
+    proxy_read_timeout 30m;
+    proxy_pass https://tekton-results-api-service.tekton-results.svc.cluster.local:8080;
+    include /mnt/nginx-generated-config/auth.conf;
+}

--- a/components/konflux-ui/production/base-ring2/route-and-oauth.yaml
+++ b/components/konflux-ui/production/base-ring2/route-and-oauth.yaml
@@ -1,0 +1,52 @@
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: konflux
+  annotations:
+    # Needed for running a local development env for the Konflux UI
+    haproxy.router.openshift.io/set-forwarded-headers: if-none
+spec:
+  host: tba
+  path: /
+  port:
+    targetPort: web-tls
+  tls:
+    insecureEdgeTerminationPolicy: Redirect
+    termination: reencrypt
+  to:
+    kind: Service
+    name: proxy
+    weight: 100
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: konflux-idp
+spec:
+  host: tba
+  path: /idp
+  port:
+    targetPort: dex
+  tls:
+    insecureEdgeTerminationPolicy: Redirect
+    termination: reencrypt
+  to:
+    kind: Service
+    name: dex
+    weight: 100
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: dex-client
+  annotations:
+    serviceaccounts.openshift.io/oauth-redirecturi.konflux: tba
+---
+kind: Secret
+apiVersion: v1
+metadata:
+  name: dex-client
+  annotations:
+    kubernetes.io/service-account.name: dex-client
+type: kubernetes.io/service-account-token

--- a/components/konflux-ui/production/base/proxy/scripts/proxy-nginx-generate-loop-probe.sh
+++ b/components/konflux-ui/production/base/proxy/scripts/proxy-nginx-generate-loop-probe.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -euo pipefail
+
+for cmd in date stat; do
+  command -v "${cmd}" >/dev/null 2>&1 || { echo "required command not found: ${cmd}"; exit 1; }
+done
+
+AUTH_CONF_FILE=/mnt/nginx-generated-config/auth.conf
+AUTH_CONF_NEW_FILE=/mnt/nginx-generated-config/auth.conf.new
+
+{ [ -f "${AUTH_CONF_NEW_FILE}" ] && [ $(( $(date +%s) - $(stat -c %Y "${AUTH_CONF_NEW_FILE}") )) -lt 60 ]; } || \
+  { [ -f "${AUTH_CONF_FILE}" ] && [ $(( $(date +%s) - $(stat -c %Y "${AUTH_CONF_FILE}") )) -lt 60 ]; }

--- a/components/konflux-ui/production/base/proxy/scripts/proxy-nginx-generate-loop.sh
+++ b/components/konflux-ui/production/base/proxy/scripts/proxy-nginx-generate-loop.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+set -euo pipefail
+
+RETRY_INTERVAL=10
+TOKEN_FILEPATH=/var/run/secrets/konflux-ci.dev/serviceaccount/token
+AUTH_CONF_FILE=/mnt/nginx-generated-config/auth.conf.new
+AUTH_CONF_TMP_FILE=/mnt/nginx-generated-config/auth.conf.new.tmp
+AUTH_CONF_TEMPLATE_FILE=/mnt/nginx-templates/auth.conf
+
+for cmd in cat sed chmod mv sleep date; do
+  command -v "${cmd}" >/dev/null 2>&1 || { echo "required command not found: ${cmd}"; exit 1; }
+done
+
+log() { echo "$(date -Iseconds) generate-loop: $*"; }
+
+log "starting"
+
+produceToken() (
+  # Copy the auth.conf template and replace the bearer token
+  token=$(cat "${TOKEN_FILEPATH}")
+
+  # Produce a tmp file
+  sed "s/__BEARER_TOKEN__/${token}/" "${AUTH_CONF_TEMPLATE_FILE}" > "${AUTH_CONF_TMP_FILE}"
+  chmod 640 "${AUTH_CONF_TMP_FILE}"
+
+  # Rename (atomic) the file to avoid sync issues
+  mv "${AUTH_CONF_TMP_FILE}" "${AUTH_CONF_FILE}"
+)
+
+produceTokenWithRetry() (
+  produceToken || \
+    { sleep 3; produceToken; } || \
+    { sleep 5; produceToken; }
+)
+
+while produceTokenWithRetry; do sleep "${RETRY_INTERVAL}"; done
+
+echo "loop broke, crashing"
+exit 1

--- a/components/konflux-ui/production/base/proxy/scripts/proxy-nginx-run.sh
+++ b/components/konflux-ui/production/base/proxy/scripts/proxy-nginx-run.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+
+set -euo pipefail
+
+NGINX_AUTH_CONF_FILE='/mnt/nginx-generated-config/auth.conf'
+NGINX_NEW_AUTH_CONF_FILE='/mnt/nginx-generated-config/auth.conf.new'
+
+NGINX_CONF_FILE='/etc/nginx/nginx.conf'
+RETRY_INTERVAL=10
+
+for cmd in nginx cksum mv sleep date; do
+  command -v "${cmd}" >/dev/null 2>&1 || { echo "required command not found: ${cmd}"; exit 1; }
+done
+
+log() { echo "$(date -Iseconds) proxy-nginx-run: $*"; }
+
+log "starting"
+
+# test configuration
+nginx -g "daemon off;" -c "${NGINX_CONF_FILE}" -t
+
+# run the hot-reload loop in background
+(
+  # wait for nginx to start before first reload attempt
+  while [ ! -f /run/nginx.pid ]; do sleep 1; done
+
+  log "hot-reload loop started"
+
+  # retries hot reloading the nginx configuration multiple
+  # times with increasing timeouts before returning the error
+  reloadWithRetry() {
+    if [ -f "${NGINX_NEW_AUTH_CONF_FILE}" ] && \
+      [ "$(cksum < "${NGINX_NEW_AUTH_CONF_FILE}")" != "$(cksum < "${NGINX_AUTH_CONF_FILE}")" ]; then
+      log "config changed, reloading nginx"
+      # Move (atomic) the new configuration and reload it in NGINX
+      mv "${NGINX_NEW_AUTH_CONF_FILE}" "${NGINX_AUTH_CONF_FILE}" && \
+        {
+          nginx -s reload || \
+            { sleep 3; nginx -s reload; } || \
+            { sleep 5; nginx -s reload; }
+        }
+    fi
+  }
+
+  # hot reload infinite loop
+  while reloadWithRetry; do sleep "${RETRY_INTERVAL}"; done
+
+  log "loop broke, crashing"
+  exit 1
+) &
+RELOAD_PID=$!
+
+# run the nginx server in background
+(
+  nginx -g "daemon off;" -c "${NGINX_CONF_FILE}"
+  log "nginx crashed"
+  exit 1
+) &
+# forward SIGTERM/SIGINT for graceful shutdown
+trap 'log "received signal, shutting down"; nginx -s quit 2>/dev/null; kill "${RELOAD_PID}" 2>/dev/null; wait; exit 0' TERM INT
+
+# wait for any of the background tasks to crash
+wait -n
+EXIT_CODE=$?
+log "child exited with code ${EXIT_CODE}, terminating"
+exit "${EXIT_CODE}"

--- a/components/konflux-ui/production/kflux-fedora-01/oauth2-proxy-args-patch.yaml
+++ b/components/konflux-ui/production/kflux-fedora-01/oauth2-proxy-args-patch.yaml
@@ -1,6 +1,6 @@
 ---
 - op: replace
-  path: /spec/template/spec/containers/2/args
+  path: /spec/template/spec/containers/3/args
   value:
     - --provider
     - oidc

--- a/components/konflux-ui/production/kflux-fedora-01/remove-run-as-user-proxy-patch.yaml
+++ b/components/konflux-ui/production/kflux-fedora-01/remove-run-as-user-proxy-patch.yaml
@@ -16,3 +16,5 @@
 
 - op: remove
   path: /spec/template/spec/containers/3/securityContext/runAsUser
+- op: remove
+  path: /spec/template/spec/containers/4/securityContext/runAsUser

--- a/components/konflux-ui/production/kflux-ocp-p01/kustomization.yaml
+++ b/components/konflux-ui/production/kflux-ocp-p01/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ../base
+  - ../base-ring2
 # Remove this comment to rotate dex and proxy secrets
 # - configure-oauth-proxy-secret.yaml
 

--- a/components/konflux-ui/production/kflux-osp-p01/oauth2-proxy-args-patch.yaml
+++ b/components/konflux-ui/production/kflux-osp-p01/oauth2-proxy-args-patch.yaml
@@ -1,6 +1,6 @@
 ---
 - op: replace
-  path: /spec/template/spec/containers/2/args
+  path: /spec/template/spec/containers/3/args
   value:
     - --provider
     - oidc

--- a/components/konflux-ui/production/kflux-osp-p01/remove-run-as-user-proxy-patch.yaml
+++ b/components/konflux-ui/production/kflux-osp-p01/remove-run-as-user-proxy-patch.yaml
@@ -16,3 +16,5 @@
 
 - op: remove
   path: /spec/template/spec/containers/3/securityContext/runAsUser
+- op: remove
+  path: /spec/template/spec/containers/4/securityContext/runAsUser

--- a/components/konflux-ui/production/kflux-prd-rh02/oauth2-proxy-args-patch.yaml
+++ b/components/konflux-ui/production/kflux-prd-rh02/oauth2-proxy-args-patch.yaml
@@ -1,6 +1,6 @@
 ---
 - op: replace
-  path: /spec/template/spec/containers/2/args
+  path: /spec/template/spec/containers/3/args
   value:
     - --provider
     - oidc

--- a/components/konflux-ui/production/kflux-prd-rh02/remove-run-as-user-proxy-patch.yaml
+++ b/components/konflux-ui/production/kflux-prd-rh02/remove-run-as-user-proxy-patch.yaml
@@ -16,3 +16,5 @@
 
 - op: remove
   path: /spec/template/spec/containers/3/securityContext/runAsUser
+- op: remove
+  path: /spec/template/spec/containers/4/securityContext/runAsUser

--- a/components/konflux-ui/production/kflux-prd-rh03/oauth2-proxy-args-patch.yaml
+++ b/components/konflux-ui/production/kflux-prd-rh03/oauth2-proxy-args-patch.yaml
@@ -1,6 +1,6 @@
 ---
 - op: replace
-  path: /spec/template/spec/containers/2/args
+  path: /spec/template/spec/containers/3/args
   value:
     - --provider
     - oidc

--- a/components/konflux-ui/production/kflux-prd-rh03/remove-run-as-user-proxy-patch.yaml
+++ b/components/konflux-ui/production/kflux-prd-rh03/remove-run-as-user-proxy-patch.yaml
@@ -16,3 +16,5 @@
 
 - op: remove
   path: /spec/template/spec/containers/3/securityContext/runAsUser
+- op: remove
+  path: /spec/template/spec/containers/4/securityContext/runAsUser

--- a/components/konflux-ui/production/kflux-rhel-p01/oauth2-proxy-args-patch.yaml
+++ b/components/konflux-ui/production/kflux-rhel-p01/oauth2-proxy-args-patch.yaml
@@ -1,6 +1,6 @@
 ---
 - op: replace
-  path: /spec/template/spec/containers/2/args
+  path: /spec/template/spec/containers/3/args
   value:
     - --provider
     - oidc

--- a/components/konflux-ui/production/kflux-rhel-p01/remove-run-as-user-proxy-patch.yaml
+++ b/components/konflux-ui/production/kflux-rhel-p01/remove-run-as-user-proxy-patch.yaml
@@ -16,3 +16,5 @@
 
 - op: remove
   path: /spec/template/spec/containers/3/securityContext/runAsUser
+- op: remove
+  path: /spec/template/spec/containers/4/securityContext/runAsUser

--- a/components/konflux-ui/production/stone-prd-rh01/kustomization.yaml
+++ b/components/konflux-ui/production/stone-prd-rh01/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ../base
+  - ../base-ring2
 # Remove this comment to rotate dex and proxy secrets
 #  - configure-oauth-proxy-secret.yaml
 

--- a/components/konflux-ui/production/stone-prod-p01/oauth2-proxy-args-patch.yaml
+++ b/components/konflux-ui/production/stone-prod-p01/oauth2-proxy-args-patch.yaml
@@ -1,6 +1,6 @@
 ---
 - op: replace
-  path: /spec/template/spec/containers/2/args
+  path: /spec/template/spec/containers/3/args
   value:
     - --provider
     - oidc

--- a/components/konflux-ui/production/stone-prod-p01/remove-run-as-user-proxy-patch.yaml
+++ b/components/konflux-ui/production/stone-prod-p01/remove-run-as-user-proxy-patch.yaml
@@ -16,3 +16,5 @@
 
 - op: remove
   path: /spec/template/spec/containers/3/securityContext/runAsUser
+- op: remove
+  path: /spec/template/spec/containers/4/securityContext/runAsUser

--- a/components/konflux-ui/production/stone-prod-p02/kustomization.yaml
+++ b/components/konflux-ui/production/stone-prod-p02/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ../base
+  - ../base-ring2
 # Remove this comment to rotate dex and proxy secrets
 #  - configure-oauth-proxy-secret.yaml
 

--- a/hack/new-cluster/templates/konflux-ui/oauth2-proxy-args-patch.yaml
+++ b/hack/new-cluster/templates/konflux-ui/oauth2-proxy-args-patch.yaml
@@ -1,6 +1,6 @@
 ---
 - op: replace
-  path: /spec/template/spec/containers/2/args
+  path: /spec/template/spec/containers/3/args
   value:
     - --provider
     - oidc

--- a/hack/new-cluster/templates/konflux-ui/remove-run-as-user-proxy-patch.yaml
+++ b/hack/new-cluster/templates/konflux-ui/remove-run-as-user-proxy-patch.yaml
@@ -16,3 +16,5 @@
 
 - op: remove
   path: /spec/template/spec/containers/3/securityContext/runAsUser
+- op: remove
+  path: /spec/template/spec/containers/4/securityContext/runAsUser


### PR DESCRIPTION
## Summary

Replace long-lived ServiceAccount token with short-lived projected tokens (600s TTL) for the UI proxy in production — **ring 1 of 2**.

### Ring 1 clusters (this PR)
kflux-fedora-01, kflux-osp-p01, kflux-prd-rh02, kflux-prd-rh03, kflux-rhel-p01, stone-prod-p01

### Ring 2 clusters (follow-up PR)
stone-prd-rh01, stone-prod-p02, kflux-ocp-p01 — temporarily point to `base-ring2` (copy of the old base) to preserve current behavior until ring 1 is validated.

### Changes
- Add `generate-nginx-configs-loop` sidecar container for continuous token rotation
- Replace direct `nginx` command with bash wrapper script for hot-reload
- Replace long-lived SA token secret with projected token (600s TTL)
- Remove long-lived SA token Secret (`kubernetes.io/service-account-token`)
- Port bug fixes from konflux-ci/konflux-ci#6780
- Fix container index in overlay patches for ring 1 clusters and new-cluster templates
- Create temporary `base-ring2` for ring 2 clusters

Mirrors the staging changes from #11604.

## Risk Assessment

**Risk Level:** Low
**Description:** UI might log out user pericodically
**Rollback:** Revert the PR

## Validation

Staging PR: https://github.com/redhat-appstudio/infra-deployments/pull/11604

## Qodo Response

**Groups header miswired** — Qodo reacts on file moving, no changes were actually made in nginx.conf
**Probe misses token rotation** - only hypothetical issue, this workflow is well reviewed and tested 

## Test plan

- [ ] Verify `kustomize build` passes for all 9 production overlays
- [ ] Deploy ring 1 clusters and observe token rotation at ~8-minute intervals
- [ ] Confirm nginx reload triggers exactly once per rotation
- [ ] Verify pods remain healthy through multiple rotations
- [ ] After validation, merge ring 2 PR

Made with [Cursor](https://cursor.com)