### PR TITLE
KONFLUX-13356: upgrade kueue operator and tekton-kueue for prod ring 1

### DIFF
--- a/components/kueue/production/base-ring1-tekton-kueue/config.yaml
+++ b/components/kueue/production/base-ring1-tekton-kueue/config.yaml
@@ -1,0 +1,137 @@
+queueName: pipelines-queue
+cel:
+  expressions:
+    # Set resource requests for multi platform pipelines
+    - |
+        has(pipelineRun.spec.params) &&
+        pipelineRun.spec.params.exists(p, p.name == 'build-platforms') ?
+        pipelineRun.spec.params.filter(
+          p,
+          p.name == 'build-platforms')[0]
+        .value.map(
+          p,
+          resource(replace(replace(p, "/", "-"), "_", "-"), 1)
+        ) : []
+
+    # Request AWS IP for AWS-based platforms
+    - |
+        has(pipelineRun.spec.params) &&
+        pipelineRun.spec.params.exists(p, p.name == 'build-platforms') ?
+        pipelineRun.spec.params.filter(
+          p,
+          p.name == 'build-platforms')[0]
+        .value.filter(
+          p,
+          !(
+            p in [
+              'linux/ppc64le',
+              'linux/s390x',
+              'linux/x86_64',
+              'local',
+              'localhost',
+            ]
+          )
+        ).map(
+          p,
+          resource('aws-ip', 1)
+        ) : []
+
+    # Set resource requests for multi platform pipelines which doesn't use the build-platforms parameter (old style)
+    - |
+      !(
+        has(pipelineRun.spec.params) &&
+        pipelineRun.spec.params.exists(p, p.name == 'build-platforms')
+      ) &&
+      has(pipelineRun.spec.pipelineSpec) &&
+      has(pipelineRun.spec.pipelineSpec.tasks) &&
+      pipelineRun.spec.pipelineSpec.tasks.size() > 0 ?
+      pipelineRun.spec.pipelineSpec.tasks.map(
+        task,
+        has(task.params) ? task.params.filter(p, p.name == 'PLATFORM') : []
+      )
+      .filter(p, p.size() > 0)
+      .map(
+        p,
+        resource(replace(replace(p[0].value, "/", "-"), "_", "-"), 1)
+      ) : []
+
+    # Request AWS IP for AWS-based platforms which doesn't use the build-platforms parameter (old style)
+    - |
+      !(
+        has(pipelineRun.spec.params) &&
+        pipelineRun.spec.params.exists(p, p.name == 'build-platforms')
+      ) &&
+      has(pipelineRun.spec.pipelineSpec) &&
+      has(pipelineRun.spec.pipelineSpec.tasks) &&
+      pipelineRun.spec.pipelineSpec.tasks.size() > 0 ?
+      pipelineRun.spec.pipelineSpec.tasks.map(
+        task,
+        has(task.params) ? task.params.filter(p, p.name == 'PLATFORM') : []
+      )
+      .filter(p, p.size() > 0)
+      .filter(
+        p,
+        !(
+          p[0].value in [
+            'linux/ppc64le',
+            'linux/s390x',
+            'linux/x86_64',
+            'local',
+            'localhost',
+          ]
+        )
+      )
+      .map(
+        p,
+        resource('aws-ip', 1)
+      ) : []
+
+    # Set mintmaker resource requests.
+    # Necessary since mintmaker refreshes can overload clusters without a
+    # bottleneck on the number of pipelineruns running.
+    - |
+        plrNamespace == 'mintmaker' ? [resource('mintmaker', 1)] : []
+
+    # Set the pipeline priority
+    - |
+        has(pipelineRun.metadata.labels) &&
+        'build.appstudio.openshift.io/type' in pipelineRun.metadata.labels &&
+        pipelineRun.metadata.labels['build.appstudio.openshift.io/type'] == 'nudge' ?
+        priority('konflux-dependency-update') :
+
+        pacEventType == 'push' ? priority('konflux-post-merge-build') :
+        pacEventType == 'pull_request' ||
+          pacEventType == "Merge_Request" ||
+          pacEventType == 'test-comment' ||
+          pacEventType == 'retest-comment' ||
+          pacEventType == 'retest-all-comment' ||
+          pacEventType == 'ok-to-test-comment'  ? priority('konflux-pre-merge-build') :
+        pacTestEventType == 'push' ? priority('konflux-post-merge-test') :
+        pacTestEventType == 'pull_request' ||
+          pacTestEventType == "Merge_Request" ||
+          pacTestEventType == 'test-comment' ||
+          pacTestEventType == 'retest-comment' ||
+          pacTestEventType == 'retest-all-comment' ||
+          pacTestEventType == 'ok-to-test-comment' ? priority('konflux-pre-merge-test') :
+
+        has(pipelineRun.metadata.labels) &&
+        'appstudio.openshift.io/service' in pipelineRun.metadata.labels &&
+        pipelineRun.metadata.labels['appstudio.openshift.io/service'] == 'release' &&
+        'pipelines.appstudio.openshift.io/type' in pipelineRun.metadata.labels &&
+        pipelineRun.metadata.labels['pipelines.appstudio.openshift.io/type'] == 'managed' ?
+        priority('konflux-release') :
+
+        has(pipelineRun.metadata.labels) &&
+        'appstudio.openshift.io/service' in pipelineRun.metadata.labels &&
+        pipelineRun.metadata.labels['appstudio.openshift.io/service'] == 'release' &&
+        'release.appstudio.openshift.io/namespace' in pipelineRun.metadata.labels &&
+        pipelineRun.metadata.labels['release.appstudio.openshift.io/namespace'] == plrNamespace ?
+        priority('konflux-tenant-release') :
+
+        plrNamespace == 'mintmaker' ? priority('konflux-dependency-update') :
+
+        has(pipelineRun.metadata.labels) &&
+        'internal-services.appstudio.openshift.io/pipelinerun-uid' in pipelineRun.metadata.labels ?
+        priority('konflux-release') :
+
+        priority('konflux-default')

--- a/components/kueue/production/base-ring1-tekton-kueue/controller-patch.yaml
+++ b/components/kueue/production/base-ring1-tekton-kueue/controller-patch.yaml
@@ -1,0 +1,49 @@
+---
+- op: replace
+  path: /spec/replicas
+  value: 2
+
+- op: add
+  path: /metadata/annotations/ignore-check.kube-linter.io~1no-anti-affinity
+  value: "Using topologySpreadConstraints"
+
+- op: add
+  path: /spec/strategy
+  value:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 0
+
+- op: add
+  path: /spec/template/spec/topologySpreadConstraints
+  value:
+    - maxSkew: 1
+      topologyKey: topology.kubernetes.io/zone
+      whenUnsatisfiable: ScheduleAnyway
+      labelSelector:
+        matchLabels:
+          app.kubernetes.io/name: tekton-kueue
+
+- op: add
+  path: /spec/template/spec/containers/0/resources/requests
+  value:
+    cpu: 500m
+    memory: 2Gi
+
+- op: add
+  path: /spec/template/spec/containers/0/resources/limits
+  value:
+    cpu: 500m
+    memory: 2Gi
+
+- op: add
+  path: /spec/template/spec/containers/0/args/-
+  value: "--leader-elect-lease-duration=137s"
+
+- op: add
+  path: /spec/template/spec/containers/0/args/-
+  value: "--leader-elect-renew-deadline=107s"
+
+- op: add
+  path: /spec/template/spec/containers/0/args/-
+  value: "--leader-elect-retry-period=26s"

--- a/components/kueue/production/base-ring1-tekton-kueue/kustomization.yaml
+++ b/components/kueue/production/base-ring1-tekton-kueue/kustomization.yaml
@@ -1,0 +1,45 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- https://github.com/konflux-ci/tekton-kueue/config/default?ref=cec0b3c8a240a289bb7aff4313ea647b292d96cc
+
+images:
+- name: konflux-ci/tekton-kueue
+  newName: quay.io/konflux-ci/tekton-kueue
+  newTag: cec0b3c8a240a289bb7aff4313ea647b292d96cc
+
+namespace: tekton-kueue
+# ensure that installation starts after the installation of kueue complete
+commonAnnotations:
+  argocd.argoproj.io/sync-wave: "10"
+
+configMapGenerator:
+  - name: tekton-kueue-config
+    namespace: tekton-kueue
+    behavior: replace
+    files:
+      - config.yaml
+
+generatorOptions:
+  disableNameSuffixHash: true
+
+patches:
+- path: webhook-patch.yaml
+  target:
+    group: apps
+    kind: Deployment
+    name: tekton-kueue-webhook
+    version: v1
+- path: controller-patch.yaml
+  target:
+    group: apps
+    kind: Deployment
+    name: tekton-kueue-controller-manager
+    version: v1
+- target:
+    kind: Namespace
+    name: tekton-kueue
+  patch: |-
+    - op: add
+      path: /metadata/labels/openshift.io~1cluster-monitoring
+      value: "true"

--- a/components/kueue/production/base-ring1-tekton-kueue/webhook-patch.yaml
+++ b/components/kueue/production/base-ring1-tekton-kueue/webhook-patch.yaml
@@ -1,0 +1,41 @@
+---
+- op: replace
+  path: /spec/replicas
+  value: 3
+
+- op: add
+  path: /metadata/annotations/ignore-check.kube-linter.io~1no-anti-affinity
+  value: "Using topologySpreadConstraints"
+
+- op: add
+  path: /spec/strategy
+  value:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 0
+
+- op: add
+  path: /spec/template/spec/topologySpreadConstraints
+  value:
+    - maxSkew: 1
+      topologyKey: topology.kubernetes.io/zone
+      whenUnsatisfiable: ScheduleAnyway
+      labelSelector:
+        matchLabels:
+          app.kubernetes.io/name: tekton-kueue-webhook
+
+- op: add
+  path: /spec/template/spec/containers/0/resources/requests
+  value:
+    cpu: 200m
+    memory: 256Mi
+
+- op: add
+  path: /spec/template/spec/containers/0/resources/limits
+  value:
+    cpu: 200m
+    memory: 256Mi
+
+- op: add
+  path: /spec/template/spec/containers/0/args/-
+  value: --zap-log-level=5

--- a/components/kueue/production/kflux-ocp-p01/kustomization.yaml
+++ b/components/kueue/production/kflux-ocp-p01/kustomization.yaml
@@ -1,7 +1,9 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- ../base
+- ../base/kueue
+- ../base-ring1-tekton-kueue
+- ../base/tekton-kueue-monitoring
 - queue-config
 
 commonAnnotations:
@@ -13,3 +15,13 @@ configMapGenerator:
     behavior: replace
     files:
       - config.yaml
+
+patches:
+- target:
+    kind: Subscription
+    name: openshift-kueue-operator
+    namespace: openshift-kueue-operator
+  patch: |-
+    - op: replace
+      path: /spec/channel
+      value: stable-v1.3

--- a/components/kueue/production/kflux-ocp-p01/queue-config/cluster-queue.yaml
+++ b/components/kueue/production/kflux-ocp-p01/queue-config/cluster-queue.yaml
@@ -4,7 +4,7 @@ metadata:
   name: cluster-pipeline-queue
 spec:
   flavorFungibility:
-    whenCanBorrow: Borrow
+    whenCanBorrow: MayStopSearch
     whenCanPreempt: TryNextFlavor
   namespaceSelector: {}
   preemption:
@@ -183,7 +183,6 @@ spec:
         nominalQuota: '1000'
       - name: localhost
         nominalQuota: '1000'
-  stopPolicy: None
 ---
 apiVersion: kueue.x-k8s.io/v1beta1
 kind: ResourceFlavor

--- a/components/kueue/production/kflux-prd-rh02/kustomization.yaml
+++ b/components/kueue/production/kflux-prd-rh02/kustomization.yaml
@@ -1,8 +1,20 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- ../base
+- ../base/kueue
+- ../base-ring1-tekton-kueue
+- ../base/tekton-kueue-monitoring
 - queue-config
 
 commonAnnotations:
   argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+
+patches:
+- target:
+    kind: Subscription
+    name: openshift-kueue-operator
+    namespace: openshift-kueue-operator
+  patch: |-
+    - op: replace
+      path: /spec/channel
+      value: stable-v1.3

--- a/components/kueue/production/kflux-prd-rh02/queue-config/cluster-queue.yaml
+++ b/components/kueue/production/kflux-prd-rh02/queue-config/cluster-queue.yaml
@@ -4,7 +4,7 @@ metadata:
   name: cluster-pipeline-queue
 spec:
   flavorFungibility:
-    whenCanBorrow: Borrow
+    whenCanBorrow: MayStopSearch
     whenCanPreempt: TryNextFlavor
   namespaceSelector: {}
   preemption:
@@ -168,7 +168,6 @@ spec:
         nominalQuota: '1000'
       - name: localhost
         nominalQuota: '1000'
-  stopPolicy: None
 ---
 apiVersion: kueue.x-k8s.io/v1beta1
 kind: ResourceFlavor

--- a/components/kueue/production/stone-prod-p01/kustomization.yaml
+++ b/components/kueue/production/stone-prod-p01/kustomization.yaml
@@ -1,8 +1,20 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- ../base
+- ../base/kueue
+- ../base-ring1-tekton-kueue
+- ../base/tekton-kueue-monitoring
 - queue-config
 
 commonAnnotations:
   argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+
+patches:
+- target:
+    kind: Subscription
+    name: openshift-kueue-operator
+    namespace: openshift-kueue-operator
+  patch: |-
+    - op: replace
+      path: /spec/channel
+      value: stable-v1.3

--- a/components/kueue/production/stone-prod-p01/queue-config/cluster-queue.yaml
+++ b/components/kueue/production/stone-prod-p01/queue-config/cluster-queue.yaml
@@ -4,7 +4,7 @@ metadata:
   name: cluster-pipeline-queue
 spec:
   flavorFungibility:
-    whenCanBorrow: Borrow
+    whenCanBorrow: MayStopSearch
     whenCanPreempt: TryNextFlavor
   namespaceSelector: {}
   preemption:
@@ -156,7 +156,6 @@ spec:
         nominalQuota: '1000'
       - name: localhost
         nominalQuota: '1000'
-  stopPolicy: None
 ---
 apiVersion: kueue.x-k8s.io/v1beta1
 kind: ResourceFlavor


### PR DESCRIPTION
## What
Upgrade kueue operator (stable-v1.2 → stable-v1.3) and tekton-kueue to cec0b3c8 for production ring 1 clusters: stone-prod-p01, kflux-ocp-p01, kflux-prd-rh02.

- `base-ring1-tekton-kueue` directory pinned to cec0b3c8 (resources ref + image tag). Ring 1 clusters reference base components individually, using this instead of the shared base tekton-kueue
- Per-cluster kustomize patch overrides the Subscription channel from stable-v1.2 to stable-v1.3
- ClusterQueue specs updated: `whenCanBorrow: Borrow` → `MayStopSearch`, removed `stopPolicy: None` to prevent ArgoCD drift from the v1beta2 conversion webhook

Part of [KONFLUX-13356](https://issues.redhat.com/browse/KONFLUX-13356).

## Why
Kueue v1.2 has a known CVE. The v1.3 operator (RHBoK, kueue 0.16.x) resolves it.
This is a ring deployment — ring 1 first, ring 2 in a follow-up PR.

Previous PRs:
- #11588 — dev/staging operator upgrade
- #11692 — staging v1beta2 CR migration

## Validation
- `kustomize build` passes for all 3 ring 1 clusters
- `base-ring1-tekton-kueue` is an exact copy of `base/tekton-kueue` — only difference is the two SHA references in `kustomization.yaml` (resources ref and image tag)
- Diff of rendered manifests between ring 1 (stone-prod-p01) and ring 2 (stone-prod-p02) shows only expected changes: tekton-kueue image tag, Subscription channel, whenCanBorrow/stopPolicy drift fixes, WorkloadPriorityClass apiVersion v1beta1→v1beta2 (from the new resources ref), and per-cluster queue config differences
- Staging clusters (stone-stg-rh01, stone-stage-p01) verified healthy after #11588 and #11692 merges — operator running v1.3.1, ClusterQueues Active, workloads admitting and completing
- Post-merge: CSV remediation plan for ring 1 clusters (operator CSV cleanup)

## Risk Assessment
**Risk Level:** Medium
**Rollback:** Revert kustomize patches to restore `stable-v1.2` channel and old tekton-kueue image tag. OLM will not auto-downgrade — manual CSV intervention needed.
Ring deployment limits blast radius to 3 production clusters. Ring 2 clusters are completely unaffected (base is untouched).

[KONFLUX-13356]: https://redhat.atlassian.net/browse/KONFLUX-13356?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ