### PR TITLE
ensure policies are installed at the end

### DIFF
--- a/argo-cd-apps/overlays/development/dev-application-sync-wave-disaster-recovery.yaml
+++ b/argo-cd-apps/overlays/development/dev-application-sync-wave-disaster-recovery.yaml
@@ -1,0 +1,9 @@
+---
+# DisasterRecovery needs to be installed after
+# * pipeline-service
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: disaster-recovery
+  annotations:
+    argocd.argoproj.io/sync-wave: "25"

--- a/argo-cd-apps/overlays/development/dev-application-sync-wave-kueue.yaml
+++ b/argo-cd-apps/overlays/development/dev-application-sync-wave-kueue.yaml
@@ -1,0 +1,6 @@
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: kueue
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"

--- a/argo-cd-apps/overlays/development/dev-application-sync-wave-kyverno.yaml
+++ b/argo-cd-apps/overlays/development/dev-application-sync-wave-kyverno.yaml
@@ -1,0 +1,6 @@
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: kyverno
+  annotations:
+    argocd.argoproj.io/sync-wave: "-2"

--- a/argo-cd-apps/overlays/development/dev-application-sync-wave-pipeline-service.yaml
+++ b/argo-cd-apps/overlays/development/dev-application-sync-wave-pipeline-service.yaml
@@ -1,0 +1,6 @@
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: pipeline-service
+  annotations:
+    argocd.argoproj.io/sync-wave: "-2"

--- a/argo-cd-apps/overlays/development/dev-application-sync-wave-policies.yaml
+++ b/argo-cd-apps/overlays/development/dev-application-sync-wave-policies.yaml
@@ -1,0 +1,11 @@
+---
+# policies needs to be installed after
+# * Kueue
+# * Kyverno
+# * pipeline-service
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: policies
+  annotations:
+    argocd.argoproj.io/sync-wave: "25"

--- a/argo-cd-apps/overlays/development/kustomization.yaml
+++ b/argo-cd-apps/overlays/development/kustomization.yaml
@@ -221,3 +221,29 @@ patches:
       kind: ApplicationSet
       version: v1alpha1
       name: dummy-deployment
+  # ensure installation order of ApplicationSets during all-application-sets sync
+  - path: dev-application-sync-wave-kyverno.yaml
+    target:
+      kind: ApplicationSet
+      version: v1alpha1
+      name: kyverno
+  - path: dev-application-sync-wave-kueue.yaml
+    target:
+      kind: ApplicationSet
+      version: v1alpha1
+      name: kueue
+  - path: dev-application-sync-wave-pipeline-service.yaml
+    target:
+      kind: ApplicationSet
+      version: v1alpha1
+      name: pipeline-service
+  - path: dev-application-sync-wave-policies.yaml
+    target:
+      kind: ApplicationSet
+      version: v1alpha1
+      name: policies
+  - path: dev-application-sync-wave-disaster-recovery.yaml
+    target:
+      kind: ApplicationSet
+      version: v1alpha1
+      name: disaster-recovery


### PR DESCRIPTION
We are noticing some flakiness in policies rollout in the development overlay.
As they are dependent on Konflux and Kyverno being already installed, with this change we ensure they are installed later in the setup process.

Signed-off-by: Francesco Ilario <filario@redhat.com>
