### PR TITLE
KFLUXINFRA-3596: Deploy k8s-groups to production clusters

### DIFF
--- a/argo-cd-apps/overlays/konflux-public-production/delete-applications.yaml
+++ b/argo-cd-apps/overlays/konflux-public-production/delete-applications.yaml
@@ -29,10 +29,3 @@ kind: ApplicationSet
 metadata:
   name: dummy-deployment
 $patch: delete
-# k8s-groups is being tested on staging clusters for now
----
-apiVersion: argoproj.io/v1alpha1
-kind: ApplicationSet
-metadata:
-  name: k8s-groups
-$patch: delete

--- a/argo-cd-apps/overlays/konflux-public-production/kustomization.yaml
+++ b/argo-cd-apps/overlays/konflux-public-production/kustomization.yaml
@@ -286,3 +286,8 @@ patches:
       kind: ApplicationSet
       version: v1alpha1
       name: perf-team-prometheus-reader
+  - path: production-overlay-patch.yaml
+    target:
+      kind: ApplicationSet
+      version: v1alpha1
+      name: k8s-groups

--- a/argo-cd-apps/overlays/production-downstream/delete-applications.yaml
+++ b/argo-cd-apps/overlays/production-downstream/delete-applications.yaml
@@ -29,10 +29,3 @@ kind: ApplicationSet
 metadata:
   name: dummy-deployment
 $patch: delete
-# k8s-groups is being tested on staging clusters for now
----
-apiVersion: argoproj.io/v1alpha1
-kind: ApplicationSet
-metadata:
-  name: k8s-groups
-$patch: delete

--- a/argo-cd-apps/overlays/production-downstream/kustomization.yaml
+++ b/argo-cd-apps/overlays/production-downstream/kustomization.yaml
@@ -300,4 +300,8 @@ patches:
       kind: ApplicationSet
       version: v1alpha1
       name: perf-team-prometheus-reader
-
+  - path: production-overlay-patch.yaml
+    target:
+      kind: ApplicationSet
+      version: v1alpha1
+      name: k8s-groups


### PR DESCRIPTION
## Summary

Deploy the new k8s-groups component to production clusters after [success in staging](https://github.com/redhat-appstudio/infra-deployments/pull/11786).

## Risk Assessment
**Risk**: Low
**Explanation**: Success on staging clusters was evident by these commits and their associated updates via ArgoCD:
- [Change users in group](https://github.com/redhat-appstudio/internal-infra-deployments/commit/2734f1ad6e3ce7a7b8e4bfcbe2cff28c7ef654a6)
- [Create new non-konflux group](https://github.com/redhat-appstudio/internal-infra-deployments/commit/c613c05714aa1e6e34b6d922f6be45560ecbbf24)

 At worst, errors regarding the inability to create k8s Group resources will occur; no functionality should be impaired.