### PR TITLE
policies: rename localqueue bootstrap policy

### DIFF
--- a/components/policies/production/policies/kueue/queue-config/.chainsaw-test/chainsaw-assert-clusterpolicy.yaml
+++ b/components/policies/production/policies/kueue/queue-config/.chainsaw-test/chainsaw-assert-clusterpolicy.yaml
@@ -1,7 +1,7 @@
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
-  name: bootstrap-tenant-namespace-queue
+  name: bootstrap-tenant-namespace-localqueue
 status:
   conditions:
   - reason: Succeeded

--- a/components/policies/production/policies/kueue/queue-config/.chainsaw-test/chainsaw-test.yaml
+++ b/components/policies/production/policies/kueue/queue-config/.chainsaw-test/chainsaw-test.yaml
@@ -691,7 +691,7 @@ spec:
     - wait:
         apiVersion: kyverno.io/v1
         kind: ClusterPolicy
-        name: bootstrap-tenant-namespace-queue
+        name: bootstrap-tenant-namespace-localqueue
         for:
           deletion: {}
     - script:

--- a/components/policies/production/policies/kueue/queue-config/cluster-policy.yaml
+++ b/components/policies/production/policies/kueue/queue-config/cluster-policy.yaml
@@ -2,7 +2,7 @@
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
-  name: bootstrap-tenant-namespace-queue
+  name: bootstrap-tenant-namespace-localqueue
 spec:
   rules:
   - name: create-local-queue


### PR DESCRIPTION
We recently deployed an update to the cluster policy bootstrapping localqueues in tenant namespaces in #11787.  However, we modified immutable fields but did not change the name, so this change is failing to synchronize correctly.  Change the name of this policy to deploy it correctly.

Fixes: KFLUXINFRA-3646