### PR TITLE
Change Fedora k8s-group to use FAS folder

### DIFF
--- a/argo-cd-apps/base/all-clusters/internal-infra-deployments/k8s-groups/k8s-groups.yaml
+++ b/argo-cd-apps/base/all-clusters/internal-infra-deployments/k8s-groups/k8s-groups.yaml
@@ -14,7 +14,9 @@ spec:
                 environment: staging
                 useCaseDir: rover
           - list:
-              elements: []
+              elements:
+                - nameNormalized: kflux-fedora-01
+                  values.useCaseDir: fas
   template:
     metadata:
       name: k8s-groups-{{nameNormalized}}


### PR DESCRIPTION
Fedora should not use rover groups, use FAS ones.