### PR TITLE
KONFLUX-13356: migrate kueue CRs to v1beta2 for prod ring 1

### DIFF
--- a/components/kueue/production/base-ring1-queue-config/kustomization.yaml
+++ b/components/kueue/production/base-ring1-queue-config/kustomization.yaml
@@ -1,8 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- cluster-queue.yaml
-- ../../base-ring1-queue-config
+- workload-priority-class.yaml
 
 # ensure that installation starts after the installation of kueue complete
 commonAnnotations:

--- a/components/kueue/production/base-ring1-queue-config/workload-priority-class.yaml
+++ b/components/kueue/production/base-ring1-queue-config/workload-priority-class.yaml
@@ -1,0 +1,56 @@
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: WorkloadPriorityClass
+metadata:
+  name: konflux-release
+value: 1000
+description: "Highest priority for release pipelines"
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: WorkloadPriorityClass
+metadata:
+  name: konflux-tenant-release
+value: 900
+description: "High priority for tenant release pipelines"
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: WorkloadPriorityClass
+metadata:
+  name: konflux-post-merge-test
+value: 800
+description: "Priority for post-merge tests"
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: WorkloadPriorityClass
+metadata:
+  name: konflux-post-merge-build
+value: 700
+description: "Priority for post-merge builds"
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: WorkloadPriorityClass
+metadata:
+  name: konflux-pre-merge-test
+value: 600
+description: "Priority for pre-merge tests"
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: WorkloadPriorityClass
+metadata:
+  name: konflux-pre-merge-build
+value: 500
+description: "Priority for pre-merge builds"
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: WorkloadPriorityClass
+metadata:
+  name: konflux-default
+value: 400
+description: "Default priority for konflux pipelines"
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: WorkloadPriorityClass
+metadata:
+  name: konflux-dependency-update
+value: 300
+description: "Lower priority for dependency updates"

--- a/components/kueue/production/kflux-ocp-p01/queue-config/cluster-queue.yaml
+++ b/components/kueue/production/kflux-ocp-p01/queue-config/cluster-queue.yaml
@@ -1,4 +1,4 @@
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: ClusterQueue
 metadata:
   name: cluster-pipeline-queue
@@ -178,30 +178,30 @@ spec:
       - name: linux-s390x
         nominalQuota: '56'
       - name: linux-x86-64
-        nominalQuota: '1000'
+        nominalQuota: 1k
       - name: local
-        nominalQuota: '1000'
+        nominalQuota: 1k
       - name: localhost
-        nominalQuota: '1000'
+        nominalQuota: 1k
 ---
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: ResourceFlavor
 metadata:
   name: default-flavor
 ---
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: ResourceFlavor
 metadata:
   name: platform-group-1
 spec: {}
 ---
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: ResourceFlavor
 metadata:
   name: platform-group-2
 spec: {}
 ---
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: ResourceFlavor
 metadata:
   name: platform-group-3

--- a/components/kueue/production/kflux-ocp-p01/queue-config/kustomization.yaml
+++ b/components/kueue/production/kflux-ocp-p01/queue-config/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - cluster-queue.yaml
-- ../../base/queue-config
+- ../../base-ring1-queue-config
 - ocp-build-workload-priority-class.yaml
 
 # ensure that installation starts after the installation of kueue complete

--- a/components/kueue/production/kflux-ocp-p01/queue-config/ocp-build-workload-priority-class.yaml
+++ b/components/kueue/production/kflux-ocp-p01/queue-config/ocp-build-workload-priority-class.yaml
@@ -1,82 +1,82 @@
 ---
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: WorkloadPriorityClass
 metadata:
   name: konflux-prod-release
 value: 950
 description: "High priority for OCP prod release pipelines which should supersede all releases"
 ---
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: WorkloadPriorityClass
 metadata:
   name: konflux-stage-release
 value: 925
 description: "High priority for OCP stage release pipelines which should supersede all other stage auto releases"
 ---
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: WorkloadPriorityClass
 metadata:
   name: build-priority-1
 value: 410
 description: "Priority level 1 (highest)"
 ---
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: WorkloadPriorityClass
 metadata:
   name: build-priority-2
 value: 409
 description: "Priority level 2"
 ---
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: WorkloadPriorityClass
 metadata:
   name: build-priority-3
 value: 408
 description: "Priority level 3"
 ---
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: WorkloadPriorityClass
 metadata:
   name: build-priority-4
 value: 407
 description: "Priority level 4"
 ---
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: WorkloadPriorityClass
 metadata:
   name: build-priority-5
 value: 406
 description: "Priority level 5"
 ---
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: WorkloadPriorityClass
 metadata:
   name: build-priority-6
 value: 405
 description: "Priority level 6"
 ---
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: WorkloadPriorityClass
 metadata:
   name: build-priority-7
 value: 404
 description: "Priority level 7"
 ---
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: WorkloadPriorityClass
 metadata:
   name: build-priority-8
 value: 403
 description: "Priority level 8"
 ---
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: WorkloadPriorityClass
 metadata:
   name: build-priority-9
 value: 402
 description: "Priority level 9"
 ---
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: WorkloadPriorityClass
 metadata:
   name: build-priority-10

--- a/components/kueue/production/kflux-prd-rh02/queue-config/cluster-queue.yaml
+++ b/components/kueue/production/kflux-prd-rh02/queue-config/cluster-queue.yaml
@@ -1,4 +1,4 @@
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: ClusterQueue
 metadata:
   name: cluster-pipeline-queue
@@ -163,30 +163,30 @@ spec:
       - name: linux-s390x
         nominalQuota: '64'
       - name: linux-x86-64
-        nominalQuota: '1000'
+        nominalQuota: 1k
       - name: local
-        nominalQuota: '1000'
+        nominalQuota: 1k
       - name: localhost
-        nominalQuota: '1000'
+        nominalQuota: 1k
 ---
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: ResourceFlavor
 metadata:
   name: default-flavor
 ---
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: ResourceFlavor
 metadata:
   name: platform-group-1
 spec: {}
 ---
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: ResourceFlavor
 metadata:
   name: platform-group-2
 spec: {}
 ---
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: ResourceFlavor
 metadata:
   name: platform-group-3

--- a/components/kueue/production/stone-prod-p01/queue-config/cluster-queue.yaml
+++ b/components/kueue/production/stone-prod-p01/queue-config/cluster-queue.yaml
@@ -1,4 +1,4 @@
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: ClusterQueue
 metadata:
   name: cluster-pipeline-queue
@@ -151,30 +151,30 @@ spec:
       - name: linux-root-arm64
         nominalQuota: '250'
       - name: linux-x86-64
-        nominalQuota: '1000'
+        nominalQuota: 1k
       - name: local
-        nominalQuota: '1000'
+        nominalQuota: 1k
       - name: localhost
-        nominalQuota: '1000'
+        nominalQuota: 1k
 ---
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: ResourceFlavor
 metadata:
   name: default-flavor
 ---
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: ResourceFlavor
 metadata:
   name: platform-group-1
 spec: {}
 ---
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: ResourceFlavor
 metadata:
   name: platform-group-2
 spec: {}
 ---
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: ResourceFlavor
 metadata:
   name: platform-group-3

--- a/components/kueue/production/stone-prod-p01/queue-config/kustomization.yaml
+++ b/components/kueue/production/stone-prod-p01/queue-config/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - cluster-queue.yaml
-- ../../base/queue-config
+- ../../base-ring1-queue-config
 
 # ensure that installation starts after the installation of kueue complete
 commonAnnotations:


### PR DESCRIPTION
## What
Migrate all kueue custom resources from v1beta1 to v1beta2 for ring 1 production clusters: stone-prod-p01, kflux-ocp-p01, kflux-prd-rh02.

- ClusterQueue, ResourceFlavor, WorkloadPriorityClass apiVersion v1beta1 → v1beta2
- `base-ring1-queue-config` directory with v1beta2 WorkloadPriorityClasses, ring 1 clusters reference this instead of `base/queue-config`
- OCP-specific WorkloadPriorityClasses (kflux-ocp-p01) v1beta1 → v1beta2
- `nominalQuota: '1000'` → `1k` (canonical `resource.Quantity` form)

Part of [KONFLUX-13356](https://issues.redhat.com/browse/KONFLUX-13356).

## Why
Ring 1 clusters are now on kueue v1.3 (via #11803). The v1beta2 conversion webhook normalizes deprecated v1beta1 fields, causing ArgoCD drift. Migrating CRs to v1beta2 eliminates this drift.

A separate `base-ring1-queue-config` is needed because `base/queue-config` (with v1beta1 WorkloadPriorityClasses) is shared across all production clusters — changing it would affect ring 2 clusters still on v1.2. The WorkloadPriorityClasses can't go in `base-ring1-tekton-kueue` because its `namespace: tekton-kueue` setting would incorrectly apply a namespace to these cluster-scoped resources.

Previous PRs:
- #11588 — dev/staging operator upgrade
- #11692 — staging v1beta2 CR migration
- #11803 — prod ring 1 operator upgrade

## Validation
- `kustomize build` passes for all 3 ring 1 clusters and all 6 ring 2 clusters
- Ring 1 renders all CRs as v1beta2, ring 2 stays v1beta1
- Same migration pattern as staging (#11692), verified healthy on staging clusters

## Risk Assessment
**Risk Level:** Low
**Rollback:** Revert apiVersion changes back to v1beta1. v1beta1 is still served by kueue v1.3 so rollback is safe.
Drift-only change — no behavioral impact, just aligns manifests with what the conversion webhook produces.

[KONFLUX-13356]: https://redhat.atlassian.net/browse/KONFLUX-13356?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ