### PR TITLE
KFLUXINFRA-3732: add AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,35 @@
+# infra-deployments
+
+GitOps monorepo deploying 50+ Kubernetes components across multiple clusters via Kustomize and ArgoCD ApplicationSets.
+
+## Quick Commands
+
+| Action         | Command                                    |
+|----------------|--------------------------------------------|
+| Build overlay  | `kustomize build components/<name>/<env>/` |
+| Lint YAML      | `yamllint .`                               |
+| K8s lint       | `kube-linter lint <path>`                  |
+| Chainsaw tests | `chainsaw test`                            |
+| infra-tools    | `cd infra-tools && make build test lint`   |
+
+## Project Layout
+
+- `components/<name>/{base,development,staging,production}/` — per-component Kustomize overlays; production is further split per-cluster
+- `argo-cd-apps/overlays/` — maps to deployment targets (development, staging-downstream, production-downstream, etc.)
+- `hack/` — deployment and utility scripts
+- `infra-tools/` — Go CLI tools (env-detector, render-diff) with their own Makefile
+
+## Key Conventions
+
+- Prefer using scripts in `hack/` over manual steps when available
+- Promotion order: development/staging → production; changes must be validated in dev/staging before promoting to production
+- Production has per-cluster overlay directories; rollouts must be split into rings (subsets of clusters), not applied to all at once
+- All changes via PR; CODEOWNERS approval required
+- Production PRs must include `## Risk Assessment` (level, description, rollback plan) and `## Validation` (staging evidence if applicable)
+- Commits - Jira ID at start (e.g., `KFLUXINFRA-1234 description`). Interactive sessions: Use the -s flag and `Assisted-by:` trailer. Agentic workflow: `Authored-by:` trailer. Include agent name and tool.
+
+## Gotchas
+
+- E2E tests are conditional — they only run on dev/staging PRs when specific files change. Production PRs do not run E2E; rely on prior dev/staging validation
+- E2E tests frequently fail due to intermittent infrastructure issues. If the PR looks correct and E2E logs show no relevant errors, comment `/retest` to re-trigger
+- When updating component images, also update image references in `hack/new-cluster/templates/` as part of the production ring deployments — new clusters are bootstrapped from these and won't get ArgoCD-synced versions

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
## What
Add `AGENTS.md` with agent-agnostic guidance and a root `CLAUDE.md` pointing to it.

[KFLUXINFRA-3732](https://redhat.atlassian.net/browse/KFLUXINFRA-3732)

## Why
AI agents working in this repo need concise guidance that can't be inferred from reading the code — promotion order, production PR requirements, E2E test behavior, and ring rollout expectations.

## Validation
- `AGENTS.md` is 35 lines
- A new Claude code session did a great job and was way faster than a new session without the `AGENTS.md`, the given prompt was:
```
Update the kyverno controller image to
sha256:k0k0hazamar93cc93792f6be096ae3faekyvernooo4l1fe901f5bb0b4dcdcf01022892c52c8a49e5fce3
in staging and production. Create the commits and suggest the PR descriptions, but don't open the PRs.
``` 

## Risk Assessment
**Risk Level:** Low
**Rollback:** Revert PR
Documentation-only change — no impact on deployed infrastructure.

[KFLUXINFRA-3732]: https://redhat.atlassian.net/browse/KFLUXINFRA-3732?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ