### PR TITLE
fix: token resource sanitized name

### DIFF
--- a/components/kueue/development/queue-config/cluster-queue.yaml
+++ b/components/kueue/development/queue-config/cluster-queue.yaml
@@ -32,7 +32,7 @@ spec:
     resourceGroups:
     - coveredResources:
       - tekton.dev/pipelineruns
-      - konflux-ci.dev/token
+      - konflux-ci-dev-token
       - cpu
       - memory
       - linux-arm64
@@ -46,7 +46,7 @@ spec:
         resources:
         - name: tekton.dev/pipelineruns
           nominalQuota: "500"
-        - name: konflux-ci.dev/token
+        - name: konflux-ci-dev-token
           nominalQuota: "600"
         - name: linux-arm64
           nominalQuota: "10"

--- a/components/kueue/staging/stone-stage-p01/queue-config/cluster-queue.yaml
+++ b/components/kueue/staging/stone-stage-p01/queue-config/cluster-queue.yaml
@@ -26,7 +26,7 @@ spec:
   resourceGroups:
   - coveredResources:
     - tekton.dev/pipelineruns
-    - konflux-ci.dev/token
+    - konflux-ci-dev-token
     - cpu
     - memory
     - aws-ip
@@ -36,7 +36,7 @@ spec:
       resources:
       - name: tekton.dev/pipelineruns
         nominalQuota: '500'
-      - name: konflux-ci.dev/token
+      - name: konflux-ci-dev-token
         nominalQuota: '600'
       - name: cpu
         nominalQuota: 1k

--- a/components/kueue/staging/stone-stg-rh01/queue-config/cluster-queue.yaml
+++ b/components/kueue/staging/stone-stg-rh01/queue-config/cluster-queue.yaml
@@ -26,7 +26,7 @@ spec:
   resourceGroups:
   - coveredResources:
     - tekton.dev/pipelineruns
-    - konflux-ci.dev/token
+    - konflux-ci-dev-token
     - cpu
     - memory
     - aws-ip
@@ -36,7 +36,7 @@ spec:
       resources:
       - name: tekton.dev/pipelineruns
         nominalQuota: '500'
-      - name: konflux-ci.dev/token
+      - name: konflux-ci-dev-token
         nominalQuota: '600'
       - name: cpu
         nominalQuota: 1k


### PR DESCRIPTION
Tekton-Kueue sanitizes and normalizes the resource names as it needs to use them in an annotation's key.
The normalized name needs to be used in the ClusterQueue.

Fixes: https://github.com/redhat-appstudio/infra-deployments/pull/10850

Signed-off-by: Francesco Ilario <filario@redhat.com>

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED
