### PR TITLE
fix: add pipelineruns/status RBAC for PAC watcher

### DIFF
--- a/components/pipeline-service/base/rbac/openshift-pipelines/kustomization.yaml
+++ b/components/pipeline-service/base/rbac/openshift-pipelines/kustomization.yaml
@@ -4,3 +4,4 @@ namespace: openshift-pipelines
 resources:
   - pipeline-service-sre.yaml
   - resolution-req-perms-exporter.yaml
+  - pac-watcher-pipelinerun-status-workaround.yaml

--- a/components/pipeline-service/base/rbac/openshift-pipelines/pac-watcher-pipelinerun-status-workaround.yaml
+++ b/components/pipeline-service/base/rbac/openshift-pipelines/pac-watcher-pipelinerun-status-workaround.yaml
@@ -1,0 +1,31 @@
+# Temporary workaround: TektonInstallerSet-managed PAC watcher ClusterRole cannot be
+# patched (operator reconciles it). Remove this ClusterRole/Binding once upstream PAC
+# grants pipelineruns/status to pipelines-as-code-watcher.
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: pac-watcher-pipelinerun-status-workaround
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+    description: Temporary until upstream Pipelines-as-Code includes pipelineruns/status in the watcher ClusterRole.
+rules:
+  - apiGroups: ["tekton.dev"]
+    resources: ["pipelineruns/status"]
+    verbs: ["update", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: pac-watcher-pipelinerun-status-workaround
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+    description: Temporary until upstream Pipelines-as-Code includes pipelineruns/status in the watcher ClusterRole.
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: pac-watcher-pipelinerun-status-workaround
+subjects:
+  - kind: ServiceAccount
+    name: pipelines-as-code-watcher
+    namespace: openshift-pipelines


### PR DESCRIPTION
PAC v0.46.0 (PR tektoncd/pipelines-as-code#2667) introduced informer cache transforms that strip PipelineRun Status fields. This causes the Knative-generated reconciler to call UpdateStatus() on the /status subresource, which the operator-managed watcher ClusterRole doesn't grant.

Add a supplementary ClusterRole/Binding as a workaround until the upstream PAC fix lands in config/202-watcher-role.yaml.