### PR TITLE
fix: add pipelineruns/status RBAC for PaC watcher (dev/staging only)

### DIFF
--- a/components/pipeline-service/development/kustomization.yaml
+++ b/components/pipeline-service/development/kustomization.yaml
@@ -11,6 +11,7 @@ resources:
   - github.com/minio/operator?ref=v5.0.15  # when updating the tag, update also the patches below
   - main-pipeline-service-configuration.yaml
   - dev-only-pipeline-service-storage-configuration.yaml
+  - pac-watcher-pipelinerun-status-workaround.yaml
   - ../base/rbac
 
 patches:

--- a/components/pipeline-service/development/pac-watcher-pipelinerun-status-workaround.yaml
+++ b/components/pipeline-service/development/pac-watcher-pipelinerun-status-workaround.yaml
@@ -1,0 +1,29 @@
+# Temporary workaround: TektonInstallerSet-managed PAC watcher ClusterRole cannot be
+# patched (operator reconciles it). Remove this ClusterRole/Binding once upstream PAC
+# grants pipelineruns/status to pipelines-as-code-watcher.
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: pac-watcher-pipelinerun-status-workaround
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+rules:
+  - apiGroups: ["tekton.dev"]
+    resources: ["pipelineruns/status"]
+    verbs: ["update", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: pac-watcher-pipelinerun-status-workaround
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: pac-watcher-pipelinerun-status-workaround
+subjects:
+  - kind: ServiceAccount
+    name: pipelines-as-code-watcher
+    namespace: openshift-pipelines

--- a/components/pipeline-service/staging/base/kustomization.yaml
+++ b/components/pipeline-service/staging/base/kustomization.yaml
@@ -10,6 +10,7 @@ commonAnnotations:
 resources:
   - main-pipeline-service-configuration.yaml
   - pipelines-as-code-secret.yaml
+  - pac-watcher-pipelinerun-status-workaround.yaml
   - ../../base/external-secrets
   - ../../base/testing
   - ../../base/rbac

--- a/components/pipeline-service/staging/base/pac-watcher-pipelinerun-status-workaround.yaml
+++ b/components/pipeline-service/staging/base/pac-watcher-pipelinerun-status-workaround.yaml
@@ -1,0 +1,29 @@
+# Temporary workaround: TektonInstallerSet-managed PAC watcher ClusterRole cannot be
+# patched (operator reconciles it). Remove this ClusterRole/Binding once upstream PAC
+# grants pipelineruns/status to pipelines-as-code-watcher.
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: pac-watcher-pipelinerun-status-workaround
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+rules:
+  - apiGroups: ["tekton.dev"]
+    resources: ["pipelineruns/status"]
+    verbs: ["update", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: pac-watcher-pipelinerun-status-workaround
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: pac-watcher-pipelinerun-status-workaround
+subjects:
+  - kind: ServiceAccount
+    name: pipelines-as-code-watcher
+    namespace: openshift-pipelines

--- a/components/pipeline-service/staging/stone-stage-p01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stage-p01/deploy.yaml
@@ -203,6 +203,22 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
     argocd.argoproj.io/sync-wave: "0"
+  name: pac-watcher-pipelinerun-status-workaround
+rules:
+- apiGroups:
+  - tekton.dev
+  resources:
+  - pipelineruns/status
+  verbs:
+  - update
+  - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "0"
   name: pipeline-service-exporter-reader
 rules:
 - apiGroups:
@@ -725,6 +741,22 @@ subjects:
 - kind: ServiceAccount
   name: openshift-gitops-argocd-application-controller
   namespace: openshift-gitops
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "0"
+  name: pac-watcher-pipelinerun-status-workaround
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: pac-watcher-pipelinerun-status-workaround
+subjects:
+- kind: ServiceAccount
+  name: pipelines-as-code-watcher
+  namespace: openshift-pipelines
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/components/pipeline-service/staging/stone-stg-rh01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stg-rh01/deploy.yaml
@@ -203,6 +203,22 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
     argocd.argoproj.io/sync-wave: "0"
+  name: pac-watcher-pipelinerun-status-workaround
+rules:
+- apiGroups:
+  - tekton.dev
+  resources:
+  - pipelineruns/status
+  verbs:
+  - update
+  - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "0"
   name: pipeline-service-exporter-reader
 rules:
 - apiGroups:
@@ -725,6 +741,22 @@ subjects:
 - kind: ServiceAccount
   name: openshift-gitops-argocd-application-controller
   namespace: openshift-gitops
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "0"
+  name: pac-watcher-pipelinerun-status-workaround
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: pac-watcher-pipelinerun-status-workaround
+subjects:
+- kind: ServiceAccount
+  name: pipelines-as-code-watcher
+  namespace: openshift-pipelines
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
PaC v0.46.0 (PR tektoncd/pipelines-as-code#2667) introduced informer cache transforms that strip PipelineRun Status fields. This causes the Knative-generated reconciler to call UpdateStatus() on the /status subresource, which the operator-managed watcher ClusterRole doesn't grant.

Add a supplementary ClusterRole/Binding to dev and staging overlays as a workaround until the upstream PaC fix lands.