### PR TITLE
feat(KONFLUX-14043): Enable appsre-stonesoup-vault in remaining NSs to be able to use ExternalSecrets from there

### DIFF
--- a/components/cluster-secret-store/staging/rhtap-promotion-staging-patch.yaml
+++ b/components/cluster-secret-store/staging/rhtap-promotion-staging-patch.yaml
@@ -2,3 +2,9 @@
 - op: add
   path: /spec/conditions/0/namespaces/-
   value: rhtap-promotion-staging
+- op: add
+  path: /spec/conditions/0/namespaces/-
+  value: konflux-perfscale-2-tenant
+- op: add
+  path: /spec/conditions/0/namespaces/-
+  value: konflux-perfscale-3-tenant


### PR DESCRIPTION
To be able to use ExternalSecrets from `konflux-perfscale-2-tenant` and `konflux-perfscale-3-tenant` (not only `konflux-perfscale-2-tenant`), we need to enable access to the secrets storage from there.

Once this is merged and validate, will create a followup PR to update it in Production overlay as well.

## Risk Assessment
**Risk Level:** Low
**Description:** Just adding two more namespaces to already established list
**Rollback:** Revert PR

## Validation
This is to test in Staging overlay.