### PR TITLE
feat(KONFLUX-14043): Enable appsre-stonesoup-vault for perfscale-2 and perfscale-3 tenants in prod

### DIFF
--- a/components/cluster-secret-store/production/kustomization.yaml
+++ b/components/cluster-secret-store/production/kustomization.yaml
@@ -9,6 +9,12 @@ patches:
       kind: ClusterSecretStore
       group: external-secrets.io
       version: v1
+  - path: perfscale-namespaces-patch.yaml
+    target:
+      name: appsre-stonesoup-vault
+      kind: ClusterSecretStore
+      group: external-secrets.io
+      version: v1
   - path: approle-id-patch.yaml
     target:
       name: appsre-vault

--- a/components/cluster-secret-store/production/perfscale-namespaces-patch.yaml
+++ b/components/cluster-secret-store/production/perfscale-namespaces-patch.yaml
@@ -1,0 +1,7 @@
+---
+- op: add
+  path: /spec/conditions/0/namespaces/-
+  value: konflux-perfscale-2-tenant
+- op: add
+  path: /spec/conditions/0/namespaces/-
+  value: konflux-perfscale-3-tenant


### PR DESCRIPTION
Move konflux-perfscale-2-tenant and konflux-perfscale-3-tenant namespaces from the staging overlay patch into the base ClusterSecretStore, making them available in all environments including production.

Generated-by: Claude

## Risk Assessment
**Risk Level:** Low
**Description:** Just adding two more namespaces
**Rollback:** Revert PR

## Validation
Tested on staging — no regressions observed.

Staging PR: https://github.com/redhat-appstudio/infra-deployments/pull/11875