### PR TITLE
test(KFLUXVNGD-924): placeholder for openshift CI operator tests

### DIFF
--- a/components/konflux-operator/ci/openshift-overlay-e2e/README.md
+++ b/components/konflux-operator/ci/openshift-overlay-e2e/README.md
@@ -1,0 +1,10 @@
+# OpenShift CI: `development-operator` overlay E2E
+
+Placeholder scripts for the optional, on-demand Prow job
+`appstudio-operator-overlay-e2e-tests` (openshift/release).
+
+## Entrypoint
+
+```bash
+./components/konflux-operator/ci/openshift-overlay-e2e/run.sh
+```

--- a/components/konflux-operator/ci/openshift-overlay-e2e/run.sh
+++ b/components/konflux-operator/ci/openshift-overlay-e2e/run.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# OpenShift CI entrypoint for development-operator overlay E2E (conformance).
+# Invoked by openshift/release after cloning infra-deployments at the PR revision.
+#
+# Phase 1 (current): placeholder — wiring validation only.
+# Phase 2: bootstrap (preview --operator-overlay), konflux-ci conformance @ ref from
+#          invariant/kustomization.yaml, default-tenant namespace (no deploy-test-resources.sh).
+set -euo pipefail
+
+echo "[openshift-operator-overlay-e2e] placeholder: noop (implementation pending)"
+echo "  Expected later: bootstrap development-operator, konflux-ci conformance only,"
+echo "  E2E_APPLICATIONS_NAMESPACE=default-tenant (KonfluxDefaultTenant), no deploy-test-resources.sh"
+exit 0


### PR DESCRIPTION
Adding a placeholder entrypoint that will used by OpenShift CI to trigger e2e tests the Konflux Operator.

Assisted-by: Cursor