### PR TITLE
KFLUXINFRA-3827: Remove group-sync resources

### DIFF
--- a/argo-cd-apps/overlays/konflux-public-production/group-sync-namespace-patch.yaml
+++ b/argo-cd-apps/overlays/konflux-public-production/group-sync-namespace-patch.yaml
@@ -1,4 +1,0 @@
----
-- op: add
-  path: /spec/template/spec/destination/namespace
-  value: group-sync-operator

--- a/argo-cd-apps/overlays/konflux-public-production/kustomization.yaml
+++ b/argo-cd-apps/overlays/konflux-public-production/kustomization.yaml
@@ -46,11 +46,6 @@ patches:
       kind: ApplicationSet
       version: v1alpha1
       name: authentication
-  - path: group-sync-namespace-patch.yaml
-    target:
-      kind: ApplicationSet
-      version: v1alpha1
-      name: authentication
   - path: production-overlay-patch.yaml
     target:
       kind: ApplicationSet

--- a/argo-cd-apps/overlays/production-downstream/group-sync-namespace-patch.yaml
+++ b/argo-cd-apps/overlays/production-downstream/group-sync-namespace-patch.yaml
@@ -1,4 +1,0 @@
----
-- op: add
-  path: /spec/template/spec/destination/namespace
-  value: group-sync-operator

--- a/argo-cd-apps/overlays/production-downstream/kustomization.yaml
+++ b/argo-cd-apps/overlays/production-downstream/kustomization.yaml
@@ -45,11 +45,6 @@ patches:
       kind: ApplicationSet
       version: v1alpha1
       name: authentication
-  - path: group-sync-namespace-patch.yaml
-    target:
-      kind: ApplicationSet
-      version: v1alpha1
-      name: authentication
   - path: production-overlay-patch.yaml
     target:
       kind: ApplicationSet

--- a/components/authentication/production/base/kustomization.yaml
+++ b/components/authentication/production/base/kustomization.yaml
@@ -1,27 +1,11 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ../../base
-  - ../../helm-charts
-images:
-  - name: quay.io/konflux-ci/group-sync-operator
-    digest: sha256:4f384c760c7821be60c8f2d9b46152c986af8723f71ad6bfc5cc8372a7c658b8
+  - ../../base/authentication
 patches:
   - path: rhtap-infra-secrets-patch.yaml
     target:
       name: rhtap-infra-secrets
-      kind: ExternalSecret
-      group: external-secrets.io
-      version: v1
-  - path: konflux-ldap-sa-patch.yaml
-    target:
-      name: konflux-ldap-sa
-      kind: ExternalSecret
-      group: external-secrets.io
-      version: v1
-  - path: mtls-ca-validators-patch.yaml
-    target:
-      name: mtls-ca-validators
       kind: ExternalSecret
       group: external-secrets.io
       version: v1

--- a/components/authentication/production/kflux-ocp-p01/kustomization.yaml
+++ b/components/authentication/production/kflux-ocp-p01/kustomization.yaml
@@ -2,5 +2,3 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../base
-components:
-  - ../../k-components/ldap-url-patch

--- a/components/authentication/production/kflux-osp-p01/kustomization.yaml
+++ b/components/authentication/production/kflux-osp-p01/kustomization.yaml
@@ -2,5 +2,3 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../base
-components:
-  - ../../k-components/ldap-url-patch

--- a/components/authentication/production/kflux-rhel-p01/kustomization.yaml
+++ b/components/authentication/production/kflux-rhel-p01/kustomization.yaml
@@ -2,5 +2,3 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../base
-components:
-  - ../../k-components/ldap-url-patch

--- a/components/authentication/production/stone-prod-p01/kustomization.yaml
+++ b/components/authentication/production/stone-prod-p01/kustomization.yaml
@@ -2,5 +2,3 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../base
-components:
-  - ../../k-components/ldap-url-patch

--- a/components/authentication/production/stone-prod-p02/kustomization.yaml
+++ b/components/authentication/production/stone-prod-p02/kustomization.yaml
@@ -2,5 +2,3 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../base
-components:
-  - ../../k-components/ldap-url-patch


### PR DESCRIPTION
## Context

Since k8s-groups has been successfully deployed on all tenant Konflux clusters (https://github.com/redhat-appstudio/infra-deployments/pull/11835 & https://github.com/redhat-appstudio/infra-deployments/pull/11816), the Group Sync Operator is no longer needed. This commit deletes all Group Sync related resources (which are no longer deployed on any tenant clusters).

## Risk
**Level**: Low
**Explanation**:  These resources aren't deployed on any clusters anyway, so deleting them from the repository shouldn't have any averse affects. Additionally, the generated resource files from the `kustomize build` command have been compared from before and after this commit; no components should be drastically affected.