### PR TITLE
feat(KFLUXVNGD-907): add konflux operator CR

### DIFF
--- a/argo-cd-apps/overlays/development-operator/kustomization.yaml
+++ b/argo-cd-apps/overlays/development-operator/kustomization.yaml
@@ -3,6 +3,8 @@
 # policies, pipeline-service, etc.) and deletes only the legacy Konflux
 # microservice ApplicationSets listed in delete-legacy-konflux-member-appsets.yaml
 # so those workloads are not deployed alongside the operator-managed stack.
+# pipeline-service uses components/pipeline-service/development-operator/ (no
+# appstudio-pipelines-scc); the operator build-service component owns that SCC.
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
@@ -10,10 +12,15 @@ resources:
   - ../../base/member/infra-deployments/konflux-operator
 patchesStrategicMerge:
   - delete-legacy-konflux-member-appsets.yaml
+namespace: openshift-gitops
 patches:
   - path: development-operator-generator-patch.yaml
     target:
       kind: ApplicationSet
       version: v1alpha1
       name: konflux-operator
-namespace: openshift-gitops
+  - path: pipeline-service-operator-patch.yaml
+    target:
+      kind: ApplicationSet
+      version: v1alpha1
+      name: pipeline-service

--- a/argo-cd-apps/overlays/development-operator/pipeline-service-operator-patch.yaml
+++ b/argo-cd-apps/overlays/development-operator/pipeline-service-operator-patch.yaml
@@ -1,0 +1,4 @@
+---
+- op: replace
+  path: /spec/generators/0/merge/generators/0/clusters/values/environment
+  value: development-operator

--- a/components/konflux-operator/development/cr/overlay-patches/default-tenant/default-tenant.yaml
+++ b/components/konflux-operator/development/cr/overlay-patches/default-tenant/default-tenant.yaml
@@ -1,0 +1,7 @@
+apiVersion: konflux.konflux-ci.dev/v1alpha1
+kind: Konflux
+metadata:
+  name: konflux
+spec:
+  defaultTenant:
+    enabled: true

--- a/components/konflux-operator/development/cr/overlay-patches/default-tenant/kustomization.yaml
+++ b/components/konflux-operator/development/cr/overlay-patches/default-tenant/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+patches:
+  - path: default-tenant.yaml

--- a/components/konflux-operator/development/cr/overlay-patches/image-controller/image-controller.yaml
+++ b/components/konflux-operator/development/cr/overlay-patches/image-controller/image-controller.yaml
@@ -4,4 +4,6 @@ metadata:
   name: konflux
 spec:
   imageController:
-    enabled: true
+    # patched by hack/preview.sh if IMAGE_CONTROLLER_QUAY_ORG and
+    # IMAGE_CONTROLLER_QUAY_TOKEN are set
+    enabled: false

--- a/components/konflux-operator/development/cr/overlay-patches/konflux-ui/ui.yaml
+++ b/components/konflux-operator/development/cr/overlay-patches/konflux-ui/ui.yaml
@@ -10,7 +10,7 @@ spec:
           httpsPort: 30011
       proxy:
         replicas: 1
-        nginx:
+        reverseProxy:
           resources:
             requests:
               cpu: 30m

--- a/components/konflux-operator/development/invariant/release-config.yaml
+++ b/components/konflux-operator/development/invariant/release-config.yaml
@@ -7,6 +7,6 @@ spec:
   certManager:
     createClusterIssuer: true
   internalRegistry:
-    enabled: true
+    enabled: false
   defaultTenant:
-    enabled: true
+    enabled: false

--- a/components/konflux-operator/development/kustomization.yaml
+++ b/components/konflux-operator/development/kustomization.yaml
@@ -10,6 +10,7 @@ kind: Kustomization
 resources:
   - invariant
 components:
+  - cr/overlay-patches/default-tenant
   - cr/overlay-patches/build
   - cr/overlay-patches/image-controller
   - cr/overlay-patches/integration

--- a/components/pipeline-service/development-operator/kustomization.yaml
+++ b/components/pipeline-service/development-operator/kustomization.yaml
@@ -1,0 +1,24 @@
+# Used when Konflux is installed via the operator (development-operator Argo overlay).
+# Reuses development Tekton/pipeline-service configuration but omits
+# appstudio-pipelines-scc so build-service (operator) can own it with ownerReferences.
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../development
+
+# This overlay is applied as live kustomize. Staging/production pipeline-service often
+# uses per-cluster deploy.yaml (see components/pipeline-service/README.md); operator
+# overlays there require the same SCC omission in whatever path Argo actually syncs.
+patches:
+  - target:
+      group: security.openshift.io
+      version: v1
+      kind: SecurityContextConstraints
+      name: appstudio-pipelines-scc
+    patch: |
+      apiVersion: security.openshift.io/v1
+      kind: SecurityContextConstraints
+      metadata:
+        name: appstudio-pipelines-scc
+      $patch: delete

--- a/hack/preview.sh
+++ b/hack/preview.sh
@@ -270,6 +270,8 @@ print_help() {
     echo "Environment (optional):"
     echo "  PREVIEW_WAIT_KONFLUX_CR_READY=true  When using --operator-overlay, additionally wait for the Konflux"
     echo "                       custom resource konflux to exist and report Ready=True (off by default)."
+    echo "  IMAGE_CONTROLLER_QUAY_ORG, IMAGE_CONTROLLER_QUAY_TOKEN  With --operator-overlay, both must be set in"
+    echo "                       hack/preview.env to enable image-controller on the Konflux CR (off by default)."
     echo
     echo "Example: \`$0 preview --obo --grafana --eaas\`"
 }
@@ -376,6 +378,28 @@ configure_kueue_for_ocp_version() {
 
     yq -i 'del(.resources[] | select(test("^kueue/?$")))' "$ROOT/components/policies/development/kustomization.yaml"
     log_success "Kueue disabled for OCP version $ocp_version"
+}
+
+# Enable Konflux CR image-controller only when Quay credentials are provided (operator overlay).
+configure_operator_image_controller() {
+    [ "$TARGET_PREVIEW_OVERLAY" != "development-operator" ] && return
+
+    local cr_patch="$ROOT/components/konflux-operator/development/cr/overlay-patches/image-controller/image-controller.yaml"
+
+    log_step "Configuring Konflux operator image-controller (Quay credentials)"
+
+    if [[ -n "${IMAGE_CONTROLLER_QUAY_ORG}" && -n "${IMAGE_CONTROLLER_QUAY_TOKEN}" ]]; then
+        log_info "IMAGE_CONTROLLER_QUAY_ORG and IMAGE_CONTROLLER_QUAY_TOKEN are set"
+        log_info "  - Quay organization: ${IMAGE_CONTROLLER_QUAY_ORG}"
+        yq -i '.spec.imageController.enabled = true' "$cr_patch"
+        log_success "Konflux CR image-controller: enabled (operator will deploy image-controller)"
+    else
+        log_info "IMAGE_CONTROLLER_QUAY_ORG and/or IMAGE_CONTROLLER_QUAY_TOKEN are not set"
+        [ -z "${IMAGE_CONTROLLER_QUAY_ORG}" ] && log_info "  - IMAGE_CONTROLLER_QUAY_ORG: not set"
+        [ -z "${IMAGE_CONTROLLER_QUAY_TOKEN}" ] && log_info "  - IMAGE_CONTROLLER_QUAY_TOKEN: not set"
+        yq -i '.spec.imageController.enabled = false' "$cr_patch"
+        log_warn "Konflux CR image-controller: disabled (set both Quay variables in hack/preview.env to enable)"
+    fi
 }
 
 # Apply service image overrides from environment variables
@@ -1066,6 +1090,7 @@ label_cluster_nodes
 if [ "$TARGET_PREVIEW_OVERLAY" = "development" ] || [ "$TARGET_PREVIEW_OVERLAY" = "development-operator" ]; then
     configure_deploy_only
     configure_kueue_for_ocp_version
+    configure_operator_image_controller
 
     # Configure GitHub org
     log_step "Configuring GitHub organization"


### PR DESCRIPTION
Finalize the development overlay CR for the Konflux Operator.

Also drop the appstudio-pipelines-scc from the pipeline-service for the development-operator overlay, as it is deployed by the operator.

This allows deploying Konflux using the operator in dev environments.

Assisted-by: Cursor