### PR TITLE
SPRE-5349: add kube_deployment_status_replicas_updated metric for tekton-kueue

### DIFF
--- a/components/monitoring/prometheus/staging/base/monitoringstack/endpoints-params.yaml
+++ b/components/monitoring/prometheus/staging/base/monitoringstack/endpoints-params.yaml
@@ -127,6 +127,7 @@
     # Namespace: tekton-kueue
     - '{__name__="kube_deployment_status_replicas_ready", namespace="tekton-kueue"}'
     - '{__name__="kube_deployment_status_replicas_available", namespace="tekton-kueue"}'
+    - '{__name__="kube_deployment_status_replicas_updated", namespace="tekton-kueue"}'
     - '{__name__="kube_deployment_spec_replicas", namespace="tekton-kueue"}'
 
     # Namespace: kueue-external-admission


### PR DESCRIPTION
  - Add kube_deployment_status_replicas_updated to the staging scrape config for tekton-kueue namespace
  - This metric is required by the TektonKueueRolloutStuck alert (o11y PR #1148) to detect stuck rollouts where new pods fail to start while old pods continue serving
  - Without this metric in the endpoints-params, the alert cannot evaluate in RHOBS since the metric is not forwarded via remote write
