### PR TITLE
SPRE-5349: add kube_deployment_status_replicas_updated metric for tekton-kueue  in production

### DIFF
--- a/components/monitoring/prometheus/production/base/monitoringstack/endpoints-params.yaml
+++ b/components/monitoring/prometheus/production/base/monitoringstack/endpoints-params.yaml
@@ -113,6 +113,7 @@
     # Namespace: tekton-kueue
     - '{__name__="kube_deployment_status_replicas_ready", namespace="tekton-kueue"}'
     - '{__name__="kube_deployment_status_replicas_available", namespace="tekton-kueue"}'
+    - '{__name__="kube_deployment_status_replicas_updated", namespace="tekton-kueue"}'
     - '{__name__="kube_deployment_spec_replicas", namespace="tekton-kueue"}'
 
     # Namespace: kueue-external-admission


### PR DESCRIPTION
###  **What**
   
  Add kube_deployment_status_replicas_updated metric to production scrape config for tekton-kueue namespace.

  ### **Why**

 Required by the TektonKueueRolloutStuck alert (o11y PR [#1148) ](https://github.com/redhat-appstudio/o11y/pull/1148)to detect stuck rollouts where new pods fail to start while old pods continue serving. Without this metric in the endpoints-params, the alert cannot evaluate in RHOBS since the metric is not forwarded via remote write.

###   **Validation**

  Validated in staging clusters, metric is flowing correctly to RHOBS:

  - [Staging PR - add kube_deployment_status_replicas_updated metric for tekton-kueue ](https://github.com/redhat-appstudio/infra-deployments/pull/11901)
  

### **Risk Assessment**

**Risk Level:** Low
 **Rollback:** Revert PR. This only adds a new metric to the scrape config; no existing metrics or alerts are affected.

