### PR TITLE
dummy-deployment update | Ring 0

### DIFF
--- a/components/dummy-deployment/overlays/development/kustomization.yaml
+++ b/components/dummy-deployment/overlays/development/kustomization.yaml
@@ -1,20 +1,16 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-
 resources:
-  - ../../base
-  - https://github.com/flacatus/konflux-dummy-deploy//k8s?ref=6581c25de3b4979c7d4653fc48c9e01818493d4a
-
+- ../../base
+- https://github.com/flacatus/konflux-dummy-deploy//k8s?ref=dc87f05445031d218b6b66a583513d051ce0ef84
 images:
-  - name: quay.io/redhat-appstudio-qe/dummy-deployment
-    newName: quay.io/redhat-appstudio-qe/dummy-deployment
-    newTag: 6581c25de3b4979c7d4653fc48c9e01818493d4a
-
+- name: quay.io/redhat-appstudio-qe/dummy-deployment
+  newTag: dc87f05445031d218b6b66a583513d051ce0ef84
 patches:
-  - target:
-      kind: ConfigMap
-      name: dummy-deployment-config
-    patch: |
-      - op: replace
-        path: /data/DISPLAY_TEXT
-        value: "Hello from DEVELOPMENT!"
+- target:
+    kind: ConfigMap
+    name: dummy-deployment-config
+  patch: |
+    - op: replace
+      path: /data/DISPLAY_TEXT
+      value: "Hello from DEVELOPMENT!"

--- a/components/dummy-deployment/overlays/staging/kustomization.yaml
+++ b/components/dummy-deployment/overlays/staging/kustomization.yaml
@@ -1,20 +1,16 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-
 resources:
-  - ../../base
-  - https://github.com/flacatus/konflux-dummy-deploy//k8s?ref=6581c25de3b4979c7d4653fc48c9e01818493d4a
-
+- ../../base
+- https://github.com/flacatus/konflux-dummy-deploy//k8s?ref=dc87f05445031d218b6b66a583513d051ce0ef84
 images:
-  - name: quay.io/redhat-appstudio-qe/dummy-deployment
-    newName: quay.io/redhat-appstudio-qe/dummy-deployment
-    newTag: 6581c25de3b4979c7d4653fc48c9e01818493d4a
-
+- name: quay.io/redhat-appstudio-qe/dummy-deployment
+  newTag: dc87f05445031d218b6b66a583513d051ce0ef84
 patches:
-  - target:
-      kind: ConfigMap
-      name: dummy-deployment-config
-    patch: |
-      - op: replace
-        path: /data/DISPLAY_TEXT
-        value: "Hello from STAGE!"
+- target:
+    kind: ConfigMap
+    name: dummy-deployment-config
+  patch: |
+    - op: replace
+      path: /data/DISPLAY_TEXT
+      value: "Hello from STAGE!"


### PR DESCRIPTION
## Changelog
- [`d80aaf7`](https://github.com/flacatus/konflux-dummy-deploy/commit/d80aaf72de6ddecb50fbf514a8323e3ce0af8dcd) Update README.md - Flavius Lacatusu
- [`d6d4823`](https://github.com/flacatus/konflux-dummy-deploy/commit/d6d48232f7cee944fe917617bfb3ca50dae84b5f) feat: add build date tag to the dockerfile - flacatus
- [`130080e`](https://github.com/flacatus/konflux-dummy-deploy/commit/130080e687e54989894e303b99b50bf9e3ad4ff1) Update main.go - Flavius Lacatusu
- [`35db9ec`](https://github.com/flacatus/konflux-dummy-deploy/commit/35db9ecfb345998292c6310df330e365f1afba94) Fix typo in default display text for ring 0 - Flavius Lacatusu
- [`ea0d723`](https://github.com/flacatus/konflux-dummy-deploy/commit/ea0d723a7e5bbd15d09e870b459ad87c4086b79a) trigger a new build - Flavius Lacatusu
- [`0ef13ed`](https://github.com/flacatus/konflux-dummy-deploy/commit/0ef13edf7fbafac1611c94579a2dad3f038f16b5) trigger new build - Flavius Lacatusu
- [`64dc606`](https://github.com/flacatus/konflux-dummy-deploy/commit/64dc606ba38c442563b757a74af0a0d91f1fe167) trigger ring deployment - Flavius Lacatusu
- [`32fadf7`](https://github.com/flacatus/konflux-dummy-deploy/commit/32fadf7866c85b399dfd17849db284ab96fc2775) trigger first Ring deployment - Flavius Lacatusu
- [`55d9c3f`](https://github.com/flacatus/konflux-dummy-deploy/commit/55d9c3fb276b549d6244831bb9b9296a4c23bbf6) Trigger second ring 0 deployment - Flavius Lacatusu
- [`dc87f05`](https://github.com/flacatus/konflux-dummy-deploy/commit/dc87f05445031d218b6b66a583513d051ce0ef84) trigger third ring commit - Flavius Lacatusu

Previous: `6581c25`
Diff: https://github.com/flacatus/konflux-dummy-deploy/compare/6581c25de3b4979c7d4653fc48c9e01818493d4a...dc87f05445031d218b6b66a583513d051ce0ef84