### PR TITLE
Update MintMaker code owners

### DIFF
--- a/components/mintmaker/OWNERS
+++ b/components/mintmaker/OWNERS
@@ -3,7 +3,6 @@
 approvers:
 - scoheb
 - staticf0x
-- querti
 - FernandesMF
 - HozifaWasfy
 - KristianTkacik
@@ -12,7 +11,6 @@ approvers:
 reviewers:
 - scoheb
 - staticf0x
-- querti
 - FernandesMF
 - HozifaWasfy
 - KristianTkacik


### PR DESCRIPTION
The user querti no longer contributes to MintMaker, so this change will prevent reviews being assigned to them.