### PR TITLE
KFLUXVNGD-999: increase cache TTL and add service traffic distribution to artifact-registry-proxy

### DIFF
--- a/components/squid/development/squid-helm-generator.yaml
+++ b/components/squid/development/squid-helm-generator.yaml
@@ -16,6 +16,7 @@ valuesInline:
       enabled: true
       secretName: artifact-registry-proxy-tls
     service:
+      trafficDistribution: PreferClose
       annotations:
         service.beta.openshift.io/serving-cert-secret-name: artifact-registry-proxy-tls
     upstream:
@@ -26,6 +27,7 @@ valuesInline:
         - ^/.+/@v/.* # <module>/@v/<version>.info|.mod|.zip and <module>/@v/list
         - ^/sumdb/.* # checksum database (e.g. sum.golang.org)
       size: 1024
+      ttl: 30d
   test:
     enabled: false
   cert-manager:

--- a/components/squid/staging/squid-helm-generator.yaml
+++ b/components/squid/staging/squid-helm-generator.yaml
@@ -18,6 +18,7 @@ valuesInline:
       secretName: artifact-registry-proxy-tls
     service:
       port: 443
+      trafficDistribution: PreferClose
       annotations:
         service.beta.openshift.io/serving-cert-secret-name: artifact-registry-proxy-tls
     upstream:
@@ -30,6 +31,7 @@ valuesInline:
         # Cache all traffic to nexus repositories
         - ^/repository/
       size: 51200
+      ttl: 30d
     resources:
       requests:
         cpu: "2"


### PR DESCRIPTION
Increase nginx cache TTL to 30d so cached S3 redirect responses are considered fresh for 30 days before being marked stale. Enable PreferClose traffic distribution to route requests to the nearest proxy replica, reducing cross-zone latency.

Assisted-by: Claude claude-opus-4-6