### PR TITLE
adding custom-kube-metric concurrentPLR stage - KFLUXINFRA-3577

### DIFF
--- a/components/monitoring/custom-kube-state-metrics/staging/custom-resource-state-config.yaml
+++ b/components/monitoring/custom-kube-state-metrics/staging/custom-resource-state-config.yaml
@@ -75,7 +75,7 @@ data:
                   path: [metadata, deletionTimestamp]
                   nilIsZero: true
         ###############################################################################
-        # Measures the number of concurrent PipelineRuns in an unfinished or Unknown  
+        # Measures the number of concurrent PipelineRuns in an unfinished or Unknown
         # status
         ###############################################################################
             - name: "konflux_pipelinerun_status"

--- a/components/monitoring/custom-kube-state-metrics/staging/custom-resource-state-config.yaml
+++ b/components/monitoring/custom-kube-state-metrics/staging/custom-resource-state-config.yaml
@@ -84,4 +84,4 @@ data:
                 type: Gauge
                 gauge:
                   path: [status, completionTime]
-                  nilIsZero: true                    
+                  nilIsZero: true

--- a/components/monitoring/custom-kube-state-metrics/staging/custom-resource-state-config.yaml
+++ b/components/monitoring/custom-kube-state-metrics/staging/custom-resource-state-config.yaml
@@ -75,18 +75,13 @@ data:
                   path: [metadata, deletionTimestamp]
                   nilIsZero: true
         ###############################################################################
-        # Measures the number of concurrent PipelineRuns in an unfinished or Unknown
-        # status
+        # Fetchs the concurrent PipelineRuns in an unfinished or Unknown state filtering
+        # the ones with completionTime unset (equal to zero)
         ###############################################################################
             - name: "konflux_pipelinerun_status"
-              help: "1 if PipelineRun is running (status=Unknown), 0 if finished (succeeded or failed). Sum to count concurrent runs."
+              help: "PipelineRun completion time with status label; 0 means still running. Filter status=Unknown for concurrent runs."
               each:
                 type: Gauge
                 gauge:
-                  path: [status, conditions, "[type=Succeeded]", status]
-                  nilIsZero: true
-                  valueMap:
-                    Unknown: 1
-                    True: 0
-                    False: 0
-                    
+                  path: [status, completionTime]
+                  nilIsZero: true                    

--- a/components/monitoring/custom-kube-state-metrics/staging/custom-resource-state-config.yaml
+++ b/components/monitoring/custom-kube-state-metrics/staging/custom-resource-state-config.yaml
@@ -79,10 +79,13 @@ data:
         # status
         ###############################################################################
             - name: "konflux_pipelinerun_status"
-              help: "PipelineRun status: Unknown=running, True=succeeded, False=failed. Count status=Unknown for concurrent runs."
+              help: "1 if PipelineRun is running (status=Unknown), 0 if finished (succeeded or failed). Sum to count concurrent runs."
               each:
-                type: StateSet
-                stateSet:
-                  labelName: status
+                type: Gauge
+                gauge:
                   path: [status, conditions, "[type=Succeeded]", status]
-                  list: [Unknown, True, False]
+                  nilIsZero: true
+                  valueMap:
+                    Unknown: 1
+                    True: 0
+                    False: 0

--- a/components/monitoring/custom-kube-state-metrics/staging/custom-resource-state-config.yaml
+++ b/components/monitoring/custom-kube-state-metrics/staging/custom-resource-state-config.yaml
@@ -79,7 +79,7 @@ data:
         # the ones with completionTime unset (equal to zero)
         ###############################################################################
             - name: "konflux_pipelinerun_status"
-              help: "PipelineRun completion time with status label; 0 means still running. Filter status=Unknown for concurrent runs."
+              help: "fetchs PipelineRun completionTime with status label; 0 means still running"
               each:
                 type: Gauge
                 gauge:

--- a/components/monitoring/custom-kube-state-metrics/staging/custom-resource-state-config.yaml
+++ b/components/monitoring/custom-kube-state-metrics/staging/custom-resource-state-config.yaml
@@ -74,3 +74,15 @@ data:
                 gauge:
                   path: [metadata, deletionTimestamp]
                   nilIsZero: true
+        ###############################################################################
+        # Measures the number of concurrent PipelineRuns in an unfinished or Unknown  
+        # status
+        ###############################################################################
+            - name: "konflux_pipelinerun_status"
+              help: "PipelineRun status: Unknown=running, True=succeeded, False=failed. Count status=Unknown for concurrent runs."
+              each:
+                type: StateSet
+                stateSet:
+                  labelName: status
+                  path: [status, conditions, "[type=Succeeded]", status]
+                  list: [Unknown, True, False]

--- a/components/monitoring/custom-kube-state-metrics/staging/custom-resource-state-config.yaml
+++ b/components/monitoring/custom-kube-state-metrics/staging/custom-resource-state-config.yaml
@@ -66,6 +66,7 @@ data:
             namespace: [metadata, namespace]
             pipeline: [metadata, labels, tekton.dev/pipeline]
             finalizers: [metadata, finalizers]
+            status: [status, conditions, "[type=Succeeded]", reason]
           metrics:
             - name: "konflux_pipelinerun_deletion_timestamp_seconds"
               help: "Unix timestamp when deletion was requested (0 = not deleted). Use > 0 to find stuck PipelineRuns."

--- a/components/monitoring/custom-kube-state-metrics/staging/custom-resource-state-config.yaml
+++ b/components/monitoring/custom-kube-state-metrics/staging/custom-resource-state-config.yaml
@@ -89,3 +89,4 @@ data:
                     Unknown: 1
                     True: 0
                     False: 0
+                    


### PR DESCRIPTION
Adding a new metric to get the concurrent PLR in an specific NS based in custom-kube-state-metric. It would record the amount of unfinished PLR for a NS in an specific time.
This is to be able to get information to check if the limit to concurrent PLR of 5000 for mintmaker is reached [KFLUXINFRA-3577](https://redhat.atlassian.net/browse/KFLUXINFRA-3577)

[KFLUXINFRA-3577]: https://redhat.atlassian.net/browse/KFLUXINFRA-3577?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

If goes OK in stage will be implemented in Production too