### PR TITLE
KONFLUX-13356: upgrade kueue operator and tekton-kueue for prod ring 2

### DIFF
--- a/components/kueue/production/kflux-osp-p01/kustomization.yaml
+++ b/components/kueue/production/kflux-osp-p01/kustomization.yaml
@@ -1,8 +1,20 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- ../base
+- ../base/kueue
+- ../base-ring1-tekton-kueue
+- ../base/tekton-kueue-monitoring
 - queue-config
 
 commonAnnotations:
   argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+
+patches:
+- target:
+    kind: Subscription
+    name: openshift-kueue-operator
+    namespace: openshift-kueue-operator
+  patch: |-
+    - op: replace
+      path: /spec/channel
+      value: stable-v1.3

--- a/components/kueue/production/kflux-osp-p01/queue-config/cluster-queue.yaml
+++ b/components/kueue/production/kflux-osp-p01/queue-config/cluster-queue.yaml
@@ -4,7 +4,7 @@ metadata:
   name: cluster-pipeline-queue
 spec:
   flavorFungibility:
-    whenCanBorrow: Borrow
+    whenCanBorrow: MayStopSearch
     whenCanPreempt: TryNextFlavor
   namespaceSelector: {}
   preemption:
@@ -144,7 +144,6 @@ spec:
       resources:
       - name: localhost
         nominalQuota: '1000'
-  stopPolicy: None
 ---
 apiVersion: kueue.x-k8s.io/v1beta1
 kind: ResourceFlavor

--- a/components/kueue/production/kflux-prd-rh03/kustomization.yaml
+++ b/components/kueue/production/kflux-prd-rh03/kustomization.yaml
@@ -1,8 +1,20 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- ../base
+- ../base/kueue
+- ../base-ring1-tekton-kueue
+- ../base/tekton-kueue-monitoring
 - queue-config
 
 commonAnnotations:
   argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+
+patches:
+- target:
+    kind: Subscription
+    name: openshift-kueue-operator
+    namespace: openshift-kueue-operator
+  patch: |-
+    - op: replace
+      path: /spec/channel
+      value: stable-v1.3

--- a/components/kueue/production/kflux-prd-rh03/queue-config/cluster-queue.yaml
+++ b/components/kueue/production/kflux-prd-rh03/queue-config/cluster-queue.yaml
@@ -4,7 +4,7 @@ metadata:
   name: cluster-pipeline-queue
 spec:
   flavorFungibility:
-    whenCanBorrow: Borrow
+    whenCanBorrow: MayStopSearch
     whenCanPreempt: TryNextFlavor
   namespaceSelector: {}
   preemption:
@@ -168,7 +168,6 @@ spec:
         nominalQuota: '1000'
       - name: localhost
         nominalQuota: '1000'
-  stopPolicy: None
 ---
 apiVersion: kueue.x-k8s.io/v1beta1
 kind: ResourceFlavor

--- a/components/kueue/production/stone-prod-p02/kustomization.yaml
+++ b/components/kueue/production/stone-prod-p02/kustomization.yaml
@@ -1,8 +1,20 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- ../base
+- ../base/kueue
+- ../base-ring1-tekton-kueue
+- ../base/tekton-kueue-monitoring
 - queue-config
 
 commonAnnotations:
   argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+
+patches:
+- target:
+    kind: Subscription
+    name: openshift-kueue-operator
+    namespace: openshift-kueue-operator
+  patch: |-
+    - op: replace
+      path: /spec/channel
+      value: stable-v1.3

--- a/components/kueue/production/stone-prod-p02/queue-config/cluster-queue.yaml
+++ b/components/kueue/production/stone-prod-p02/queue-config/cluster-queue.yaml
@@ -4,7 +4,7 @@ metadata:
   name: cluster-pipeline-queue
 spec:
   flavorFungibility:
-    whenCanBorrow: Borrow
+    whenCanBorrow: MayStopSearch
     whenCanPreempt: TryNextFlavor
   namespaceSelector: {}
   preemption:
@@ -186,7 +186,6 @@ spec:
         nominalQuota: '5'
       - name: windows-4xlarge-amd64
         nominalQuota: '5'
-  stopPolicy: None
 ---
 apiVersion: kueue.x-k8s.io/v1beta1
 kind: ResourceFlavor


### PR DESCRIPTION
## What

[KONFLUX-13356](https://issues.redhat.com/browse/KONFLUX-13356)

Ring 2 operator upgrade for clusters: kflux-osp-p01, kflux-prd-rh03, stone-prod-p02.

- Switch tekton-kueue to `base-ring1-tekton-kueue` (resources ref + image pinned to cec0b3c8)
- Patch Subscription channel from `stable-v1.2` to `stable-v1.3`
- Fix ClusterQueue drift: `whenCanBorrow: Borrow` → `MayStopSearch`, remove `stopPolicy: None`

## Why

Continuing the kueue stack upgrade across production rings. Ring 1 (#11803) is complete and stable. Same pattern applied to ring 2 clusters.

## Validation

- `kustomize build` passes for all 3 ring 2 clusters. Ring 3 clusters remain unaffected.
- Same changes as ring 1 operator upgrade (#11803) and CRs migration (#11842), both merged and running successfully.

## Risk Assessment

**Risk Level:** Medium
**Rollback:** Revert PR
Affects 3 production clusters. Ring 1 (#11803) has been running the same changes successfully, reducing risk. Ring 3 remains on previous version.

[KONFLUX-13356]: https://redhat.atlassian.net/browse/KONFLUX-13356?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ