### PR TITLE
KONFLUX-13356: migrate kueue CRs from v1beta1 to v1beta2 for prod ring 2

### DIFF
--- a/components/kueue/production/kflux-osp-p01/queue-config/cluster-queue.yaml
+++ b/components/kueue/production/kflux-osp-p01/queue-config/cluster-queue.yaml
@@ -1,4 +1,4 @@
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: ClusterQueue
 metadata:
   name: cluster-pipeline-queue
@@ -134,35 +134,35 @@ spec:
       - name: linux-root-arm64
         nominalQuota: '250'
       - name: linux-x86-64
-        nominalQuota: '1000'
+        nominalQuota: 1k
       - name: local
-        nominalQuota: '1000'
+        nominalQuota: 1k
   - coveredResources:
     - localhost
     flavors:
     - name: platform-group-3
       resources:
       - name: localhost
-        nominalQuota: '1000'
+        nominalQuota: 1k
 ---
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: ResourceFlavor
 metadata:
   name: default-flavor
 ---
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: ResourceFlavor
 metadata:
   name: platform-group-1
 spec: {}
 ---
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: ResourceFlavor
 metadata:
   name: platform-group-2
 spec: {}
 ---
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: ResourceFlavor
 metadata:
   name: platform-group-3

--- a/components/kueue/production/kflux-osp-p01/queue-config/kustomization.yaml
+++ b/components/kueue/production/kflux-osp-p01/queue-config/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - cluster-queue.yaml
-- ../../base/queue-config
+- ../../base-ring1-queue-config
 
 # ensure that installation starts after the installation of kueue complete
 commonAnnotations:

--- a/components/kueue/production/kflux-prd-rh03/queue-config/cluster-queue.yaml
+++ b/components/kueue/production/kflux-prd-rh03/queue-config/cluster-queue.yaml
@@ -1,4 +1,4 @@
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: ClusterQueue
 metadata:
   name: cluster-pipeline-queue
@@ -163,30 +163,30 @@ spec:
       - name: linux-s390x
         nominalQuota: '56'
       - name: linux-x86-64
-        nominalQuota: '1000'
+        nominalQuota: 1k
       - name: local
-        nominalQuota: '1000'
+        nominalQuota: 1k
       - name: localhost
-        nominalQuota: '1000'
+        nominalQuota: 1k
 ---
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: ResourceFlavor
 metadata:
   name: default-flavor
 ---
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: ResourceFlavor
 metadata:
   name: platform-group-1
 spec: {}
 ---
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: ResourceFlavor
 metadata:
   name: platform-group-2
 spec: {}
 ---
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: ResourceFlavor
 metadata:
   name: platform-group-3

--- a/components/kueue/production/kflux-prd-rh03/queue-config/kustomization.yaml
+++ b/components/kueue/production/kflux-prd-rh03/queue-config/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - cluster-queue.yaml
-- ../../base/queue-config
+- ../../base-ring1-queue-config
 
 # ensure that installation starts after the installation of kueue complete
 commonAnnotations:

--- a/components/kueue/production/stone-prod-p02/queue-config/cluster-queue.yaml
+++ b/components/kueue/production/stone-prod-p02/queue-config/cluster-queue.yaml
@@ -1,4 +1,4 @@
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: ClusterQueue
 metadata:
   name: cluster-pipeline-queue
@@ -177,34 +177,34 @@ spec:
       - name: linux-s390x
         nominalQuota: '72'
       - name: linux-x86-64
-        nominalQuota: '1000'
+        nominalQuota: 1k
       - name: local
-        nominalQuota: '1000'
+        nominalQuota: 1k
       - name: localhost
-        nominalQuota: '1000'
+        nominalQuota: 1k
       - name: macos-mac2metal-arm64
         nominalQuota: '5'
       - name: windows-4xlarge-amd64
         nominalQuota: '5'
 ---
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: ResourceFlavor
 metadata:
   name: default-flavor
 ---
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: ResourceFlavor
 metadata:
   name: platform-group-1
 spec: {}
 ---
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: ResourceFlavor
 metadata:
   name: platform-group-2
 spec: {}
 ---
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: ResourceFlavor
 metadata:
   name: platform-group-3

--- a/components/kueue/production/stone-prod-p02/queue-config/kustomization.yaml
+++ b/components/kueue/production/stone-prod-p02/queue-config/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - cluster-queue.yaml
-- ../../base/queue-config
+- ../../base-ring1-queue-config
 
 # ensure that installation starts after the installation of kueue complete
 commonAnnotations:


### PR DESCRIPTION
## What

[KONFLUX-13356](https://issues.redhat.com/browse/KONFLUX-13356)

Ring 2 CRs migration for clusters: kflux-osp-p01, kflux-prd-rh03, stone-prod-p02.

- ClusterQueue and ResourceFlavor apiVersion `v1beta1` → `v1beta2`
- `'1000'` → `1k` (canonical resource.Quantity to prevent ArgoCD drift)
- Reference `base-ring1-queue-config` for v1beta2 WorkloadPriorityClasses

## Why

The v1beta2 conversion webhook normalizes deprecated v1beta1 fields, causing ArgoCD to detect drift on every sync. Migrating CRs to v1beta2 eliminates this drift. Same pattern as ring 1 (#11842).

## Validation

- `kustomize build` passes for all 3 ring 2 clusters. Ring 3 clusters remain unaffected.
- Same changes as ring 1 CRs migration (#11842), merged and running successfully.

## Risk Assessment

**Risk Level:** Medium
**Rollback:** Revert PR
Affects 3 production clusters. Depends on operator upgrade PR (#11935) being merged first. Ring 1 (#11842) has been running the same changes successfully.

[KONFLUX-13356]: https://redhat.atlassian.net/browse/KONFLUX-13356?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ