### PR TITLE
feat(perf-team): Populate konflux-performance group on kflux-fedora-01

### DIFF
--- a/argo-cd-apps/base/member/infra-deployments/perf-team-prometheus-reader/perf-team-prometheus-reader.yaml
+++ b/argo-cd-apps/base/member/infra-deployments/perf-team-prometheus-reader/perf-team-prometheus-reader.yaml
@@ -14,7 +14,9 @@ spec:
                 environment: staging
                 clusterDir: base
           - list:
-              elements: []
+              elements:
+                - nameNormalized: kflux-fedora-01
+                  values.clusterDir: kflux-fedora-01
   template:
     metadata:
       name: perf-team-prometheus-reader-{{nameNormalized}}

--- a/components/perf-team-prometheus-reader/production/kflux-fedora-01/fedora-access.yaml
+++ b/components/perf-team-prometheus-reader/production/kflux-fedora-01/fedora-access.yaml
@@ -1,0 +1,8 @@
+apiVersion: user.openshift.io/v1
+kind: Group
+metadata:
+  name: konflux-performance
+users:
+  - jhutar
+  - mcharanrm
+  - smodak-rh

--- a/components/perf-team-prometheus-reader/production/kflux-fedora-01/kustomization.yaml
+++ b/components/perf-team-prometheus-reader/production/kflux-fedora-01/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../base
+  - fedora-access.yaml


### PR DESCRIPTION
The kflux-fedora-01 cluster uses the Fedora Account System (FAS) rather than standard Rover groups. As a result, the existing konflux-performance group used for component-maintainer access was empty, denying access to the performance team.

This commit creates a dedicated kflux-fedora-01 overlay for the component, defining an OpenShift Group named `konflux-performance` manually populated with the team members from the OWNERS file. Because this shares the same name as the group used by standard clusters, it securely re-uses the existing RoleBindings for component maintainer access and cluster-wide view permissions.

Generated-by: Gemini