### PR TITLE
chore(KFLUXVNGD-994): increase artifact-registry-proxy cache volume size

### DIFF
--- a/components/squid/staging/squid-helm-generator.yaml
+++ b/components/squid/staging/squid-helm-generator.yaml
@@ -30,7 +30,7 @@ valuesInline:
       allowList:
         # Cache all traffic to nexus repositories
         - ^/repository/
-      size: 51200
+      size: 102400
       ttl: 30d
     resources:
       requests:


### PR DESCRIPTION
With redirect caching enabled, nginx now caches actual artifact content from S3 rather than passing through 302 redirects. Increase the cache volume from 50GB to 100GB to accommodate the larger working set. Production will be increased to 1TB in a separate PR.

Note: This change requires manual intervention after ArgoCD sync fails. See [KFLUXVNGD-994](https://redhat.atlassian.net/browse/KFLUXVNGD-994) for the resize procedure.

Signed-off-by: Homaja Marisetty <hmariset@redhat.com>
Jira-Url: https://redhat.atlassian.net/browse/KFLUXVNGD-994
Co-Authored-By: Claude Opus 4.6

[KFLUXVNGD-994]: https://redhat.atlassian.net/browse/KFLUXVNGD-994?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ