### PR TITLE
KFLUXINFRA-3786: revoke Role write permissions from tenant admins (production)

### DIFF
--- a/components/konflux-rbac/production/base/konflux-admin-user-actions.yaml
+++ b/components/konflux-rbac/production/base/konflux-admin-user-actions.yaml
@@ -162,6 +162,14 @@ rules:
   - verbs:
       - get
       - list
+      - watch
+    apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - roles
+  - verbs:
+      - get
+      - list
       - create
       - update
       - patch
@@ -169,7 +177,6 @@ rules:
     apiGroups:
       - rbac.authorization.k8s.io
     resources:
-      - roles
       - rolebindings
   - verbs:
       - get


### PR DESCRIPTION
## Summary
- **`konflux-admin-user-actions`** (production): Split the combined `roles`+`rolebindings` RBAC rule so that `roles` is read-only (`get`/`list`/`watch`) while `rolebindings` retains full CRUD.
- Follows staging change merged in #11782.

## Test plan
- [ ] Verify production ArgoCD sync succeeds after merge
- [ ] Confirm tenant admin users can still create/manage RoleBindings in their namespaces
- [ ] Confirm tenant admin users can no longer create or patch Roles