### PR TITLE
Fix image-controller and image-rbac-proxy Quay org for kflux-fedora-01

### DIFF
--- a/argo-cd-apps/base/member/infra-deployments/image-controller/image-controller.yaml
+++ b/argo-cd-apps/base/member/infra-deployments/image-controller/image-controller.yaml
@@ -17,6 +17,8 @@ spec:
               elements:
                 - nameNormalized: stone-prd-rh01
                   values.clusterDir: stone-prd-rh01
+                - nameNormalized: kflux-fedora-01
+                  values.clusterDir: kflux-fedora-01
   template:
     metadata:
       name: image-controller-{{nameNormalized}}

--- a/components/image-controller/production/kflux-fedora-01/image-pruner-token.yaml
+++ b/components/image-controller/production/kflux-fedora-01/image-pruner-token.yaml
@@ -1,0 +1,4 @@
+---
+- op: replace
+  path: /spec/dataFrom/0/extract/key
+  value: production/build/image-pruner-token-fedora

--- a/components/image-controller/production/kflux-fedora-01/kustomization.yaml
+++ b/components/image-controller/production/kflux-fedora-01/kustomization.yaml
@@ -1,0 +1,18 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../base
+
+patches:
+  - path: quaytoken.yaml
+    target:
+      name: quaytoken
+      kind: ExternalSecret
+      group: external-secrets.io
+      version: v1
+  - path: image-pruner-token.yaml
+    target:
+      name: image-pruner-token
+      kind: ExternalSecret
+      group: external-secrets.io
+      version: v1

--- a/components/image-controller/production/kflux-fedora-01/quaytoken.yaml
+++ b/components/image-controller/production/kflux-fedora-01/quaytoken.yaml
@@ -1,0 +1,4 @@
+---
+- op: replace
+  path: /spec/dataFrom/0/extract/key
+  value: production/build/image-controller-fedora

--- a/components/image-rbac-proxy/production/kflux-fedora-01/configmap.yaml
+++ b/components/image-rbac-proxy/production/kflux-fedora-01/configmap.yaml
@@ -4,7 +4,7 @@ metadata:
   name: image-rbac-proxy
   namespace: image-rbac-proxy
 data:
-  backend-namespace: redhat-user-workloads
+  backend-namespace: konflux-fedora
   cluster-url: https://api.kflux-fedora-01.84db.p1.openshiftapps.com:6443
   proxy-url: https://image-rbac-proxy.apps.kflux-fedora-01.84db.p1.openshiftapps.com
   dex-url: https://image-rbac-proxy.apps.kflux-fedora-01.84db.p1.openshiftapps.com/idp


### PR DESCRIPTION
## Summary

Fixes the wrong Quay organization (`redhat-user-workloads` instead of `konflux-fedora`) being used by the image-controller on the `kflux-fedora-01` cluster. This caused Tekton Chains to fail pushing attestations and signatures for newly created components.

- Add `kflux-fedora-01` to the image-controller ArgoCD ApplicationSet
- Create cluster-specific overlay pointing `quaytoken` to `production/build/image-controller-fedora`
- Override `image-pruner-token` to `production/build/image-pruner-token-fedora`
- Fix `image-rbac-proxy` `backend-namespace` from `redhat-user-workloads` to `konflux-fedora`

Resolves https://github.com/konflux-ci/support/issues/20

## Test plan

- [ ] Verify ExternalSecret `quaytoken` syncs with `organization: konflux-fedora` on `kflux-fedora-01`
- [ ] Verify ExternalSecret `image-pruner-token` syncs correctly
- [ ] Create a new component and confirm `ImageRepository` output uses `quay.io/konflux-fedora/`
- [ ] Run a build and verify `cosign tree` shows attestations and signatures
- [ ] Confirm image-rbac-proxy serves pulls from the `konflux-fedora` org


Made with [Cursor](https://cursor.com)