### PR TITLE
fix ClusterQueue in stg-rh01

### DIFF
--- a/components/kueue/staging/stone-stg-rh01/queue-config/cluster-queue.yaml
+++ b/components/kueue/staging/stone-stg-rh01/queue-config/cluster-queue.yaml
@@ -3,9 +3,6 @@ kind: ClusterQueue
 metadata:
   name: cluster-pipeline-queue
 spec:
-  admissionChecksStrategy:
-    admissionChecks:
-    - name: static-admission
   flavorFungibility:
     whenCanBorrow: MayStopSearch
     whenCanPreempt: TryNextFlavor


### PR DESCRIPTION
PR #11827 removed the kueue-external-admission component.
A left-over was left in stg-rh01's ClusterQueue. PLRs are not getting admitted.

Signed-off-by: Francesco Ilario <filario@redhat.com>

rh-pre-commit.version: 2.4.0
rh-pre-commit.check-secrets: ENABLED
