### PR TITLE
chore(KONFLUX-13284): replace appstudio-utils by task-runner in konflux ui stage

### DIFF
--- a/components/konflux-ui/staging/stone-stage-p01/configure-oauth-proxy-secret.yaml
+++ b/components/konflux-ui/staging/stone-stage-p01/configure-oauth-proxy-secret.yaml
@@ -102,7 +102,7 @@ spec:
             echo "skipping dex restart"
           fi
 
-        image: quay.io/konflux-ci/appstudio-utils:ab6b0b8e40e440158e7288c73aff1cf83a2cc8a9@sha256:24179f0efd06c65d16868c2d7eb82573cce8e43533de6cea14fec3b7446e0b14
+        image: quay.io/konflux-ci/task-runner:955c3525538ea50bf0f562dbd1f0cda330df9054@sha256:1c0582a85dae0949f3ec94aca95695c5d7698b371f1b76c5a78822a6249073dc
         imagePullPolicy: Always
         name: konflux-oauth-client-secret-generation
         resources:

--- a/components/konflux-ui/staging/stone-stg-rh01/configure-oauth-proxy-secret.yaml
+++ b/components/konflux-ui/staging/stone-stg-rh01/configure-oauth-proxy-secret.yaml
@@ -102,7 +102,7 @@ spec:
             echo "skipping dex restart"
           fi
 
-        image: quay.io/konflux-ci/appstudio-utils:ab6b0b8e40e440158e7288c73aff1cf83a2cc8a9@sha256:24179f0efd06c65d16868c2d7eb82573cce8e43533de6cea14fec3b7446e0b14
+        image: quay.io/konflux-ci/task-runner:955c3525538ea50bf0f562dbd1f0cda330df9054@sha256:1c0582a85dae0949f3ec94aca95695c5d7698b371f1b76c5a78822a6249073dc
         imagePullPolicy: Always
         name: konflux-oauth-client-secret-generation
         resources:


### PR DESCRIPTION
Replace `appstudio-utils` image reference in Konflux UI resources by `task-runner` image. This change is only for stage environment. Production should come after validation in stage in separated PR.

Jira [KONFLUX-13284](https://redhat.atlassian.net/browse/KONFLUX-13284)

[KONFLUX-13284]: https://redhat.atlassian.net/browse/KONFLUX-13284?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ