### PR TITLE
feat(SPRE-5381): Include label severity for blackbox monitoring in prod

### DIFF
--- a/components/monitoring/prometheus/production/base/monitoringstack/writeRelabelConfigs.yaml
+++ b/components/monitoring/prometheus/production/base/monitoringstack/writeRelabelConfigs.yaml
@@ -17,4 +17,4 @@
       policy_name|policy_background_mode|rule_type|policy_type|policy_validation_mode|\
       resource_request_operation|resource_kind|policy_change_type|event_type|\
       name|cluster_queue|quantile|slice|scrape_job|tested_registry|error|queue|\
-      priority_class|finalizers"
+      priority_class|finalizers|severity"


### PR DESCRIPTION
## Description
- Include new label to production to be used with blackbox probes and different alert severities.

## Validation
- Validation: Tested in [stage](https://github.com/redhat-appstudio/infra-deployments/pull/11660/changes).

## Risk Assessment
**Risk Level:** Low
**Rollback:** Revert PR