### PR TITLE
chore(KONFLUX-13284): replace appstudio-utils by task-runner in konflux ui prod

### DIFF
--- a/components/konflux-ui/production/kflux-fedora-01/configure-oauth-proxy-secret.yaml
+++ b/components/konflux-ui/production/kflux-fedora-01/configure-oauth-proxy-secret.yaml
@@ -102,7 +102,7 @@ spec:
             echo "skipping dex restart"
           fi
 
-        image: quay.io/konflux-ci/appstudio-utils:2b13f3d1921be90df96ae0c6f8d14ca7936ebb6b@sha256:8c923e6d93d5f4541bc5bc9a19e92c42413f48f57490df595488c27ecdf80f9c
+        image: quay.io/konflux-ci/task-runner:955c3525538ea50bf0f562dbd1f0cda330df9054@sha256:1c0582a85dae0949f3ec94aca95695c5d7698b371f1b76c5a78822a6249073dc
         imagePullPolicy: Always
         name: konflux-oauth-client-secret-generation
         resources:

--- a/components/konflux-ui/production/kflux-ocp-p01/configure-oauth-proxy-secret.yaml
+++ b/components/konflux-ui/production/kflux-ocp-p01/configure-oauth-proxy-secret.yaml
@@ -102,7 +102,7 @@ spec:
             echo "skipping dex restart"
           fi
 
-        image: quay.io/konflux-ci/appstudio-utils:ab6b0b8e40e440158e7288c73aff1cf83a2cc8a9@sha256:24179f0efd06c65d16868c2d7eb82573cce8e43533de6cea14fec3b7446e0b14
+        image: quay.io/konflux-ci/task-runner:955c3525538ea50bf0f562dbd1f0cda330df9054@sha256:1c0582a85dae0949f3ec94aca95695c5d7698b371f1b76c5a78822a6249073dc
         imagePullPolicy: Always
         name: konflux-oauth-client-secret-generation
         resources:

--- a/components/konflux-ui/production/kflux-osp-p01/configure-oauth-proxy-secret.yaml
+++ b/components/konflux-ui/production/kflux-osp-p01/configure-oauth-proxy-secret.yaml
@@ -102,7 +102,7 @@ spec:
             echo "skipping dex restart"
           fi
 
-        image: quay.io/konflux-ci/appstudio-utils:610e03266bfd0b30e53fc51dbdd56debb33cbe5b@sha256:ecc156d6fb19032ba817a8c4bc41e7453a061db173655f0500afbe8d68dcaf59
+        image: quay.io/konflux-ci/task-runner:955c3525538ea50bf0f562dbd1f0cda330df9054@sha256:1c0582a85dae0949f3ec94aca95695c5d7698b371f1b76c5a78822a6249073dc
         imagePullPolicy: Always
         name: konflux-oauth-client-secret-generation
         resources:

--- a/components/konflux-ui/production/kflux-prd-rh02/configure-oauth-proxy-secret.yaml
+++ b/components/konflux-ui/production/kflux-prd-rh02/configure-oauth-proxy-secret.yaml
@@ -102,7 +102,7 @@ spec:
             echo "skipping dex restart"
           fi
 
-        image: quay.io/konflux-ci/appstudio-utils:ab6b0b8e40e440158e7288c73aff1cf83a2cc8a9@sha256:24179f0efd06c65d16868c2d7eb82573cce8e43533de6cea14fec3b7446e0b14
+        image: quay.io/konflux-ci/task-runner:955c3525538ea50bf0f562dbd1f0cda330df9054@sha256:1c0582a85dae0949f3ec94aca95695c5d7698b371f1b76c5a78822a6249073dc
         imagePullPolicy: Always
         name: konflux-oauth-client-secret-generation
         resources:

--- a/components/konflux-ui/production/kflux-prd-rh03/configure-oauth-proxy-secret.yaml
+++ b/components/konflux-ui/production/kflux-prd-rh03/configure-oauth-proxy-secret.yaml
@@ -102,7 +102,7 @@ spec:
             echo "skipping dex restart"
           fi
 
-        image: quay.io/konflux-ci/appstudio-utils:ab6b0b8e40e440158e7288c73aff1cf83a2cc8a9@sha256:24179f0efd06c65d16868c2d7eb82573cce8e43533de6cea14fec3b7446e0b14
+        image: quay.io/konflux-ci/task-runner:955c3525538ea50bf0f562dbd1f0cda330df9054@sha256:1c0582a85dae0949f3ec94aca95695c5d7698b371f1b76c5a78822a6249073dc
         imagePullPolicy: Always
         name: konflux-oauth-client-secret-generation
         resources:

--- a/components/konflux-ui/production/kflux-rhel-p01/configure-oauth-proxy-secret.yaml
+++ b/components/konflux-ui/production/kflux-rhel-p01/configure-oauth-proxy-secret.yaml
@@ -102,7 +102,7 @@ spec:
             echo "skipping dex restart"
           fi
 
-        image: quay.io/konflux-ci/appstudio-utils:832a8c1360cfbb68db63813bd5cfa0c6c2a9b54d@sha256:c06432ceda6fe759c548b19c9784d34c63101909be98d82203be9d04656f6d78
+        image: quay.io/konflux-ci/task-runner:955c3525538ea50bf0f562dbd1f0cda330df9054@sha256:1c0582a85dae0949f3ec94aca95695c5d7698b371f1b76c5a78822a6249073dc
         imagePullPolicy: Always
         name: konflux-oauth-client-secret-generation
         resources:

--- a/components/konflux-ui/production/stone-prd-rh01/configure-oauth-proxy-secret.yaml
+++ b/components/konflux-ui/production/stone-prd-rh01/configure-oauth-proxy-secret.yaml
@@ -102,7 +102,7 @@ spec:
             echo "skipping dex restart"
           fi
 
-        image: quay.io/konflux-ci/appstudio-utils:ab6b0b8e40e440158e7288c73aff1cf83a2cc8a9@sha256:24179f0efd06c65d16868c2d7eb82573cce8e43533de6cea14fec3b7446e0b14
+        image: quay.io/konflux-ci/task-runner:955c3525538ea50bf0f562dbd1f0cda330df9054@sha256:1c0582a85dae0949f3ec94aca95695c5d7698b371f1b76c5a78822a6249073dc
         imagePullPolicy: Always
         name: konflux-oauth-client-secret-generation
         resources:

--- a/components/konflux-ui/production/stone-prod-p01/configure-oauth-proxy-secret.yaml
+++ b/components/konflux-ui/production/stone-prod-p01/configure-oauth-proxy-secret.yaml
@@ -102,7 +102,7 @@ spec:
             echo "skipping dex restart"
           fi
 
-        image: quay.io/konflux-ci/appstudio-utils:ab6b0b8e40e440158e7288c73aff1cf83a2cc8a9@sha256:24179f0efd06c65d16868c2d7eb82573cce8e43533de6cea14fec3b7446e0b14
+        image: quay.io/konflux-ci/task-runner:955c3525538ea50bf0f562dbd1f0cda330df9054@sha256:1c0582a85dae0949f3ec94aca95695c5d7698b371f1b76c5a78822a6249073dc
         imagePullPolicy: Always
         name: konflux-oauth-client-secret-generation
         resources:

--- a/components/konflux-ui/production/stone-prod-p02/configure-oauth-proxy-secret.yaml
+++ b/components/konflux-ui/production/stone-prod-p02/configure-oauth-proxy-secret.yaml
@@ -102,7 +102,7 @@ spec:
             echo "skipping dex restart"
           fi
 
-        image: quay.io/konflux-ci/appstudio-utils:ab6b0b8e40e440158e7288c73aff1cf83a2cc8a9@sha256:24179f0efd06c65d16868c2d7eb82573cce8e43533de6cea14fec3b7446e0b14
+        image: quay.io/konflux-ci/task-runner:955c3525538ea50bf0f562dbd1f0cda330df9054@sha256:1c0582a85dae0949f3ec94aca95695c5d7698b371f1b76c5a78822a6249073dc
         imagePullPolicy: Always
         name: konflux-oauth-client-secret-generation
         resources:


### PR DESCRIPTION
Replace appstudio-utils image reference in Konflux UI resources by task-runner image in prod environment.

## Risk Assessment

**Risk Level:** Low
**Description:** Client secret not renewed and user lost access to UI
**Rollback:** Revert this commit should be enough. If not apply the script in updated task to apply secrets manually for each cluster.

Local and stage tests suggests the image was able to run the job correctly and renew secrets

Stage PR: #11966 

Jira [KONFLUX-13284](https://redhat.atlassian.net/browse/KONFLUX-13284)

[KONFLUX-13284]: https://redhat.atlassian.net/browse/KONFLUX-13284?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ