### PR TITLE
Allow konflux-performance group to create SA tokens in perf-team-prometheus-reader

### DIFF
--- a/components/perf-team-prometheus-reader/base/core/kustomization.yaml
+++ b/components/perf-team-prometheus-reader/base/core/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
   - serviceaccount.yaml
   - serviceaccount-oomcrash.yaml
   - perf-team.yaml
+  - sa-token-rbac.yaml

--- a/components/perf-team-prometheus-reader/base/core/sa-token-rbac.yaml
+++ b/components/perf-team-prometheus-reader/base/core/sa-token-rbac.yaml
@@ -1,0 +1,29 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: perf-team-sa-token-creator
+  namespace: perf-team-prometheus-reader
+rules:
+  - verbs:
+      - create
+    apiGroups:
+      - ""
+    resources:
+      - serviceaccounts/token
+    resourceNames:
+      - perf-team-prometheus-reader-cluster-sa
+      - perf-team-prometheus-reader-oomcrash-sa
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: perf-team-sa-token-creator
+  namespace: perf-team-prometheus-reader
+subjects:
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: konflux-performance
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: perf-team-sa-token-creator


### PR DESCRIPTION
## Summary
- Add Role and RoleBinding granting the `konflux-performance` group permission to create tokens for `perf-team-prometheus-reader-cluster-sa` and `perf-team-prometheus-reader-oomcrash-sa` service accounts
- Added to `base/core` which is used by development and staging overlays only (production has its own standalone resources and is intentionally excluded until soak time validates the change)

## Risk Assessment
- **Level:** Low
- **Description:** Adds narrowly scoped RBAC (create on serviceaccounts/token for two specific SAs) to a single namespace. No existing permissions are modified.
- **Rollback plan:** Revert the PR

## Validation
- `kustomize build` passes for development and staging overlays
- Production overlay confirmed unaffected (0 references to the new resources)

🤖 Generated with [Claude Code](https://claude.com/claude-code)