### PR TITLE
Add event-reading RBAC to perf-team-prometheus-reader production

### DIFF
--- a/components/perf-team-prometheus-reader/production/base/kustomization.yaml
+++ b/components/perf-team-prometheus-reader/production/base/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: perf-team-prometheus-reader
 resources:
   - serviceaccount.yaml
   - serviceaccount-oomcrash.yaml
   - perf-team.yaml
+  - tenants-rbac

--- a/components/perf-team-prometheus-reader/production/base/tenants-rbac/konflux-perfscale-1-tenant/kustomization.yaml
+++ b/components/perf-team-prometheus-reader/production/base/tenants-rbac/konflux-perfscale-1-tenant/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - tenant-rbac.yaml

--- a/components/perf-team-prometheus-reader/production/base/tenants-rbac/konflux-perfscale-1-tenant/tenant-rbac.yaml
+++ b/components/perf-team-prometheus-reader/production/base/tenants-rbac/konflux-perfscale-1-tenant/tenant-rbac.yaml
@@ -1,0 +1,24 @@
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: perf-team-event-reader-role
+  namespace: konflux-perfscale-1-tenant
+rules:
+- apiGroups: [""]
+  resources: ["events"]
+  verbs: ["get", "list", "watch"]
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: perf-team-event-reader-binding
+  namespace: konflux-perfscale-1-tenant
+subjects:
+- kind: ServiceAccount
+  name: konflux-bot-0
+  namespace: konflux-perfscale-1-tenant
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: perf-team-event-reader-role

--- a/components/perf-team-prometheus-reader/production/base/tenants-rbac/konflux-perfscale-2-tenant/kustomization.yaml
+++ b/components/perf-team-prometheus-reader/production/base/tenants-rbac/konflux-perfscale-2-tenant/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - tenant-rbac.yaml

--- a/components/perf-team-prometheus-reader/production/base/tenants-rbac/konflux-perfscale-2-tenant/tenant-rbac.yaml
+++ b/components/perf-team-prometheus-reader/production/base/tenants-rbac/konflux-perfscale-2-tenant/tenant-rbac.yaml
@@ -1,0 +1,24 @@
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: perf-team-event-reader-role
+  namespace: konflux-perfscale-2-tenant
+rules:
+- apiGroups: [""]
+  resources: ["events"]
+  verbs: ["get", "list", "watch"]
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: perf-team-event-reader-binding
+  namespace: konflux-perfscale-2-tenant
+subjects:
+- kind: ServiceAccount
+  name: konflux-bot-0
+  namespace: konflux-perfscale-2-tenant
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: perf-team-event-reader-role

--- a/components/perf-team-prometheus-reader/production/base/tenants-rbac/konflux-perfscale-3-tenant/kustomization.yaml
+++ b/components/perf-team-prometheus-reader/production/base/tenants-rbac/konflux-perfscale-3-tenant/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - tenant-rbac.yaml

--- a/components/perf-team-prometheus-reader/production/base/tenants-rbac/konflux-perfscale-3-tenant/tenant-rbac.yaml
+++ b/components/perf-team-prometheus-reader/production/base/tenants-rbac/konflux-perfscale-3-tenant/tenant-rbac.yaml
@@ -1,0 +1,24 @@
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: perf-team-event-reader-role
+  namespace: konflux-perfscale-3-tenant
+rules:
+- apiGroups: [""]
+  resources: ["events"]
+  verbs: ["get", "list", "watch"]
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: perf-team-event-reader-binding
+  namespace: konflux-perfscale-3-tenant
+subjects:
+- kind: ServiceAccount
+  name: konflux-bot-0
+  namespace: konflux-perfscale-3-tenant
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: perf-team-event-reader-role

--- a/components/perf-team-prometheus-reader/production/base/tenants-rbac/kustomization.yaml
+++ b/components/perf-team-prometheus-reader/production/base/tenants-rbac/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - konflux-perfscale-1-tenant
+  - konflux-perfscale-2-tenant
+  - konflux-perfscale-3-tenant


### PR DESCRIPTION
## Summary
- Backport tenants-rbac from staging to production, granting `konflux-bot-0` permission to read events in `konflux-perfscale-{1,2,3}-tenant` namespaces
- Remove the `namespace` directive from production kustomization since all resources already specify their namespaces explicitly (it would conflict with per-tenant namespaces in tenants-rbac)

## Risk Assessment
- **Level:** Low
- **Description:** Adds read-only RBAC (get/list/watch on events) for an existing SA in tenant namespaces. No existing permissions are modified. The `namespace` directive removal is a no-op since all resources already have explicit namespaces.
- **Rollback plan:** Revert the PR

## Validation
- Already deployed and validated in [staging](https://github.com/redhat-appstudio/infra-deployments/pull/11592)
- `kustomize build` passes for production overlay
- Production output verified: existing resources unchanged, tenant Roles/RoleBindings correctly namespaced

🤖 Generated with [Claude Code](https://claude.com/claude-code)