### PR TITLE
KFLUXINFRA-3732: address AGENTS.md review feedback

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,13 +9,14 @@ GitOps monorepo deploying 50+ Kubernetes components across multiple clusters via
 | Build overlay  | `kustomize build components/<name>/<env>/` |
 | Lint YAML      | `yamllint .`                               |
 | K8s lint       | `kube-linter lint <path>`                  |
-| Chainsaw tests | `chainsaw test`                            |
+| Chainsaw tests | `./hack/chainsaw/chainsaw-prepare.sh` and `chainsaw test <path to .chainsaw-test folder>` |
 | infra-tools    | `cd infra-tools && make build test lint`   |
 
 ## Project Layout
 
-- `components/<name>/{base,development,staging,production}/` — per-component Kustomize overlays; production is further split per-cluster
+- `components/<name>/{base,development,staging,production}/` — per-component Kustomize overlays; staging and production are often further split per-cluster
 - `argo-cd-apps/overlays/` — maps to deployment targets (development, staging-downstream, production-downstream, etc.)
+- `configs/` — cluster-level configurations (etcd-defrag, kubelet settings)
 - `hack/` — deployment and utility scripts
 - `infra-tools/` — Go CLI tools (env-detector, render-diff) with their own Makefile
 
@@ -30,6 +31,7 @@ GitOps monorepo deploying 50+ Kubernetes components across multiple clusters via
 
 ## Gotchas
 
+- E2E tests are designed to validate in an isolated environment in GitHub Actions CI and should not be run locally
 - E2E tests are conditional — they only run on dev/staging PRs when specific files change. Production PRs do not run E2E; rely on prior dev/staging validation
 - E2E tests frequently fail due to intermittent infrastructure issues. If the PR looks correct and E2E logs show no relevant errors, comment `/retest` to re-trigger
 - When updating component images, also update image references in `hack/new-cluster/templates/` as part of the production ring deployments — new clusters are bootstrapped from these and won't get ArgoCD-synced versions


### PR DESCRIPTION
## What
Address review feedback from #11843.

[KFLUXINFRA-3732](https://redhat.atlassian.net/browse/KFLUXINFRA-3732)

- Fix chainsaw command to include `chainsaw-prepare.sh` and path argument
- Clarify that staging is also often split per-cluster, not just production
- Add missing `configs/` directory to Project Layout
- Note that E2E tests run in CI only and should not be run locally

## Validation
- `kustomize build` not applicable (documentation-only change)

## Risk Assessment
**Risk Level:** Low
**Rollback:** Revert PR
Documentation-only change — no impact on deployed infrastructure.

[KFLUXINFRA-3732]: https://redhat.atlassian.net/browse/KFLUXINFRA-3732?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ