### PR TITLE
Switch back to ppc in us-east

### DIFF
--- a/components/multi-platform-controller/staging-downstream/external-secrets.yaml
+++ b/components/multi-platform-controller/staging-downstream/external-secrets.yaml
@@ -80,29 +80,6 @@ metadata:
 spec:
   dataFrom:
     - extract:
-        key: staging/infrastructure/multi-platform-controller/stone-stage-p01/ibm-ppc64le-ssh-key
-  refreshInterval: 1h
-  secretStoreRef:
-    kind: ClusterSecretStore
-    name: appsre-stonesoup-vault
-  target:
-    creationPolicy: Owner
-    deletionPolicy: Delete
-    name: ibm-ppc64le-ssh-key
----
-apiVersion: external-secrets.io/v1
-kind: ExternalSecret
-metadata:
-  name: ibm-ppc64le-ssh-key-us-east
-  namespace: multi-platform-controller
-  labels:
-    build.appstudio.redhat.com/multi-platform-secret: "true"
-  annotations:
-    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
-    argocd.argoproj.io/sync-wave: "-1"
-spec:
-  dataFrom:
-    - extract:
         key: staging/platform/terraform/generated/stone-stage-p01/ibm-ppc64le-ssh-key
   refreshInterval: 1h
   secretStoreRef:
@@ -111,7 +88,7 @@ spec:
   target:
     creationPolicy: Owner
     deletionPolicy: Delete
-    name: ibm-ppc64le-ssh-key-us-east
+    name: ibm-ppc64le-ssh-key
 ---
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret

--- a/components/multi-platform-controller/staging-downstream/host-values.yaml
+++ b/components/multi-platform-controller/staging-downstream/host-values.yaml
@@ -205,18 +205,11 @@ dynamicConfigs:
 # Static hosts configuration
 staticHosts:
   ppc64le-static-1:
-    address: "10.130.103.155"
+    address: "10.130.72.59"
     concurrency: "2"
     platform: "linux/ppc64le"
     secret: "ibm-ppc64le-ssh-key"
     user: "root"
-
-#  ppc64le-static-2:
-#    address: "10.130.72.59"
-#    concurrency: "1"
-#    platform: "linux/ppc64le"
-#    secret: "ibm-ppc64le-ssh-key-us-east"
-#    user: "root"
 
   s390x-static-1:
     address: "10.130.72.6"


### PR DESCRIPTION
We are done with testing in us-south, go back to us-east to be able to clean up IBMC resources in us-south.

Also clean up ssh key ExternalSecrets, since we no longer have 2 for ppc we can use standard name for the one left.

[KFLUXINFRA-3315](https://redhat.atlassian.net/browse/KFLUXINFRA-3315)

[KFLUXINFRA-3315]: https://redhat.atlassian.net/browse/KFLUXINFRA-3315?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ