### PR TITLE
feat(KFLUXVNGD-918): add changelog generation library and client extension

### DIFF
--- a/infra-tools/internal/changelog/bumps.go
+++ b/infra-tools/internal/changelog/bumps.go
@@ -1,0 +1,125 @@
+package changelog
+
+import (
+	"regexp"
+	"strings"
+)
+
+// ServiceBump describes a sub-service whose pinned commit SHA changed between
+// the old and new operator versions.
+type ServiceBump struct {
+	// Owner is the GitHub organisation that owns the service repo (e.g. "konflux-ci").
+	Owner string
+	// Repo is the GitHub repository name (e.g. "build-service", "integration-service").
+	Repo string
+	// OldSHA is the previously pinned commit.
+	OldSHA string
+	// NewSHA is the newly pinned commit.
+	NewSHA string
+}
+
+// refPattern matches a ?ref=<40-char-sha> in a unified diff line.
+var refPattern = regexp.MustCompile(`\?ref=([0-9a-f]{40})`)
+
+// githubRepoPattern extracts the owner and repo from a github.com URL.
+// Matches: https://github.com/{owner}/{repo}/...
+var githubRepoPattern = regexp.MustCompile(`github\.com/([^/]+)/([^/]+)/`)
+
+// ExtractServiceBumps scans a list of FileChanges (from the operator compare)
+// for kustomization files under operator/upstream-kustomizations/ that contain
+// ?ref= SHA changes, and returns one ServiceBump per service that moved.
+//
+// A file is considered a bump when a removed diff line (-) and an added diff
+// line (+) each contain a ?ref=<sha> and the SHAs differ.
+//
+// Duplicate (owner, repo) pairs are deduplicated — only the first occurrence
+// is kept, since the same service can be referenced from multiple kustomization
+// files (e.g. core/ and internal-services/).
+func ExtractServiceBumps(files []FileChange) []ServiceBump {
+	seen := make(map[string]bool) // key: "owner/repo"
+	var bumps []ServiceBump
+
+	for _, f := range files {
+		if !isUpstreamKustomization(f.Filename) {
+			continue
+		}
+		if f.Patch == "" {
+			continue
+		}
+
+		oldSHA, newSHA := extractRefChange(f.Patch)
+		if oldSHA == "" || newSHA == "" || oldSHA == newSHA {
+			continue
+		}
+
+		owner, repo := extractGitHubRepo(f.Patch)
+		if owner == "" || repo == "" {
+			continue
+		}
+
+		key := owner + "/" + repo
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+
+		bumps = append(bumps, ServiceBump{
+			Owner:  owner,
+			Repo:   repo,
+			OldSHA: oldSHA,
+			NewSHA: newSHA,
+		})
+	}
+
+	return bumps
+}
+
+// isUpstreamKustomization reports whether the given file path is a
+// kustomization file under operator/upstream-kustomizations/.
+func isUpstreamKustomization(filename string) bool {
+	if !strings.HasPrefix(filename, "operator/upstream-kustomizations/") {
+		return false
+	}
+	return strings.HasSuffix(filename, "/kustomization.yaml") || strings.HasSuffix(filename, "/kustomization.yml")
+}
+
+// extractRefChange scans unified diff patch lines for a removed (-) and added
+// (+) ?ref=<sha> pair. Returns ("", "") if no such pair is found.
+func extractRefChange(patch string) (oldSHA, newSHA string) {
+	for _, line := range strings.Split(patch, "\n") {
+		if len(line) == 0 {
+			continue
+		}
+		matches := refPattern.FindStringSubmatch(line)
+		if matches == nil {
+			continue
+		}
+		sha := matches[1]
+		switch line[0] {
+		case '-':
+			if oldSHA == "" {
+				oldSHA = sha
+			}
+		case '+':
+			if newSHA == "" {
+				newSHA = sha
+			}
+		}
+	}
+	return oldSHA, newSHA
+}
+
+// extractGitHubRepo scans the patch for a github.com URL on an added (+) line
+// and returns the owner and repo.
+func extractGitHubRepo(patch string) (owner, repo string) {
+	for _, line := range strings.Split(patch, "\n") {
+		if len(line) == 0 || line[0] != '+' {
+			continue
+		}
+		matches := githubRepoPattern.FindStringSubmatch(line)
+		if matches != nil {
+			return matches[1], matches[2]
+		}
+	}
+	return "", ""
+}

--- a/infra-tools/internal/changelog/bumps_test.go
+++ b/infra-tools/internal/changelog/bumps_test.go
@@ -1,0 +1,151 @@
+package changelog
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+// buildServicePatch is a representative patch from the real compare data.
+const buildServicePatch = `@@ -1,7 +1,7 @@
+ apiVersion: kustomize.config.k8s.io/v1beta1
+ kind: Kustomization
+ resources:
+- - https://github.com/konflux-ci/build-service/config/default?ref=211140a26c96e8f028a0595fb779ea13210ed5c8
++ - https://github.com/konflux-ci/build-service/config/default?ref=04a4744321a7fb747f796da783d51fc322aef598
+ - build-pipeline-config.yaml
+ namespace: build-service
+ images:
+ - name: quay.io/konflux-ci/build-service
+   newName: quay.io/konflux-ci/build-service
+- newTag: 211140a26c96e8f028a0595fb779ea13210ed5c8
++ newTag: 04a4744321a7fb747f796da783d51fc322aef598`
+
+const integrationPatch = `@@ -1,8 +1,8 @@
+ apiVersion: kustomize.config.k8s.io/v1beta1
+ kind: Kustomization
+ resources:
+-- https://github.com/konflux-ci/integration-service/config/default?ref=ec001afe3986d224f5247fd6e9ad3162e8a52cde
+-- https://github.com/konflux-ci/integration-service/config/snapshotgc?ref=ec001afe3986d224f5247fd6e9ad3162e8a52cde
++- https://github.com/konflux-ci/integration-service/config/default?ref=ef2610ecd344292fb85e01321f7b613c7e621ec5
++- https://github.com/konflux-ci/integration-service/config/snapshotgc?ref=ef2610ecd344292fb85e01321f7b613c7e621ec5`
+
+func TestExtractServiceBumps_SingleService(t *testing.T) {
+	g := NewWithT(t)
+
+	files := []FileChange{
+		{
+			Filename: "operator/upstream-kustomizations/build-service/core/kustomization.yaml",
+			Patch:    buildServicePatch,
+			Status:   "modified",
+		},
+	}
+
+	bumps := ExtractServiceBumps(files)
+	g.Expect(bumps).To(HaveLen(1))
+	g.Expect(bumps[0].Owner).To(Equal("konflux-ci"))
+	g.Expect(bumps[0].Repo).To(Equal("build-service"))
+	g.Expect(bumps[0].OldSHA).To(Equal("211140a26c96e8f028a0595fb779ea13210ed5c8"))
+	g.Expect(bumps[0].NewSHA).To(Equal("04a4744321a7fb747f796da783d51fc322aef598"))
+}
+
+func TestExtractServiceBumps_DeduplicatesSameRepo(t *testing.T) {
+	g := NewWithT(t)
+
+	// Same repo referenced from two kustomization files (e.g. core/ and another subdir)
+	files := []FileChange{
+		{
+			Filename: "operator/upstream-kustomizations/build-service/core/kustomization.yaml",
+			Patch:    buildServicePatch,
+			Status:   "modified",
+		},
+		{
+			Filename: "operator/upstream-kustomizations/build-service/extra/kustomization.yaml",
+			Patch:    buildServicePatch,
+			Status:   "modified",
+		},
+	}
+
+	bumps := ExtractServiceBumps(files)
+	g.Expect(bumps).To(HaveLen(1))
+}
+
+func TestExtractServiceBumps_MultipleServices(t *testing.T) {
+	g := NewWithT(t)
+
+	files := []FileChange{
+		{
+			Filename: "operator/upstream-kustomizations/build-service/core/kustomization.yaml",
+			Patch:    buildServicePatch,
+			Status:   "modified",
+		},
+		{
+			Filename: "operator/upstream-kustomizations/integration/core/kustomization.yaml",
+			Patch:    integrationPatch,
+			Status:   "modified",
+		},
+	}
+
+	bumps := ExtractServiceBumps(files)
+	g.Expect(bumps).To(HaveLen(2))
+
+	repos := []string{bumps[0].Repo, bumps[1].Repo}
+	g.Expect(repos).To(ConsistOf("build-service", "integration-service"))
+}
+
+func TestExtractServiceBumps_IgnoresNonKustomizationFiles(t *testing.T) {
+	g := NewWithT(t)
+
+	files := []FileChange{
+		{
+			Filename: "operator/upstream-kustomizations/build-service/core/some-patch.yaml",
+			Patch:    buildServicePatch,
+			Status:   "modified",
+		},
+		{
+			Filename: ".github/workflows/foo.yaml",
+			Patch:    buildServicePatch,
+			Status:   "modified",
+		},
+	}
+
+	bumps := ExtractServiceBumps(files)
+	g.Expect(bumps).To(BeEmpty())
+}
+
+func TestExtractServiceBumps_IgnoresUnchangedRef(t *testing.T) {
+	g := NewWithT(t)
+
+	// Patch where the SHA didn't change (only other fields changed)
+	patch := `@@ -5,6 +5,6 @@
+ namespace: build-service
+-somefield: old
++somefield: new`
+
+	files := []FileChange{
+		{
+			Filename: "operator/upstream-kustomizations/build-service/core/kustomization.yaml",
+			Patch:    patch,
+			Status:   "modified",
+		},
+	}
+
+	bumps := ExtractServiceBumps(files)
+	g.Expect(bumps).To(BeEmpty())
+}
+
+func TestExtractServiceBumps_IgnoresEmptyPatch(t *testing.T) {
+	g := NewWithT(t)
+
+	files := []FileChange{
+		{
+			Filename: "operator/upstream-kustomizations/build-service/core/kustomization.yaml",
+			Patch:    "",
+			Status:   "modified",
+		},
+	}
+
+	bumps := ExtractServiceBumps(files)
+	g.Expect(bumps).To(BeEmpty())
+}
+

--- a/infra-tools/internal/changelog/extractor.go
+++ b/infra-tools/internal/changelog/extractor.go
@@ -1,0 +1,75 @@
+// Package changelog provides logic for generating a human-readable changelog
+// when the Konflux operator SHA is bumped in infra-deployments.
+package changelog
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+
+	"gopkg.in/yaml.v3"
+)
+
+// operatorImageName is the kustomize image name used to pin the operator.
+const operatorImageName = "localhost/konflux-operator"
+
+// shaPattern matches a valid 40-character lowercase hex SHA.
+var shaPattern = regexp.MustCompile(`^[0-9a-f]{40}$`)
+
+// kustomization is a minimal representation of the fields we need from the
+// operator kustomization.yaml. Only the images block is parsed.
+type kustomization struct {
+	Images []kustomizeImage `yaml:"images"`
+}
+
+type kustomizeImage struct {
+	Name    string `yaml:"name"`
+	NewName string `yaml:"newName"`
+	NewTag  string `yaml:"newTag"`
+}
+
+// ExtractSHA reads the kustomization.yaml at the given path and returns the
+// operator commit SHA from the newTag field of the localhost/konflux-operator
+// image entry.
+//
+// Returns an error if the file cannot be read, the YAML cannot be parsed, the
+// expected image entry is missing, or the tag is not a 40-character hex SHA.
+func ExtractSHA(path string) (string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("reading %s: %w", path, err)
+	}
+
+	var k kustomization
+	if err := yaml.Unmarshal(data, &k); err != nil {
+		return "", fmt.Errorf("parsing %s: %w", path, err)
+	}
+
+	for _, img := range k.Images {
+		if img.Name == operatorImageName {
+			if !shaPattern.MatchString(img.NewTag) {
+				return "", fmt.Errorf("%s: newTag %q is not a 40-character hex SHA", path, img.NewTag)
+			}
+			return img.NewTag, nil
+		}
+	}
+
+	return "", fmt.Errorf("%s: no image entry found with name %q", path, operatorImageName)
+}
+
+// ExtractSHAs reads the kustomization.yaml at both basePath (base branch) and
+// headPath (PR branch) and returns (oldSHA, newSHA, error). When the two SHAs
+// are equal the operator was not bumped and changelog generation can be skipped.
+func ExtractSHAs(basePath, headPath string) (string, string, error) {
+	oldSHA, err := ExtractSHA(basePath)
+	if err != nil {
+		return "", "", fmt.Errorf("extracting base SHA: %w", err)
+	}
+
+	newSHA, err := ExtractSHA(headPath)
+	if err != nil {
+		return "", "", fmt.Errorf("extracting head SHA: %w", err)
+	}
+
+	return oldSHA, newSHA, nil
+}

--- a/infra-tools/internal/changelog/extractor_test.go
+++ b/infra-tools/internal/changelog/extractor_test.go
@@ -1,0 +1,145 @@
+package changelog
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+const realSHA = "0bace1e20ff164a00e9d6becfce52e310a921931"
+
+// validKustomization is a minimal kustomization.yaml matching the real file.
+const validKustomization = `apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - https://github.com/konflux-ci/konflux-ci/operator/config/default?ref=0bace1e20ff164a00e9d6becfce52e310a921931
+  - konflux.yaml
+patches:
+  - path: release-config.yaml
+images:
+  - name: localhost/konflux-operator
+    newName: quay.io/konflux-ci/konflux-operator
+    newTag: 0bace1e20ff164a00e9d6becfce52e310a921931
+`
+
+func writeTemp(t *testing.T, content string) string {
+	t.Helper()
+	f, err := os.CreateTemp(t.TempDir(), "kustomization-*.yaml")
+	if err != nil {
+		t.Fatalf("creating temp file: %v", err)
+	}
+	if _, err := f.WriteString(content); err != nil {
+		t.Fatalf("writing temp file: %v", err)
+	}
+	_ = f.Close()
+	return f.Name()
+}
+
+func TestExtractSHA_ValidFile(t *testing.T) {
+	g := NewWithT(t)
+	path := writeTemp(t, validKustomization)
+	sha, err := ExtractSHA(path)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(sha).To(Equal(realSHA))
+}
+
+func TestExtractSHA_RealFile(t *testing.T) {
+	g := NewWithT(t)
+	// Walk up from this test file to the repo root and find the real overlay.
+	path := filepath.Join("..", "..", "..", "components",
+		"konflux-operator", "development", "invariant", "kustomization.yaml")
+	sha, err := ExtractSHA(path)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(sha).To(MatchRegexp(`^[0-9a-f]{40}$`))
+}
+
+func TestExtractSHA_FileNotFound(t *testing.T) {
+	g := NewWithT(t)
+	_, err := ExtractSHA("/nonexistent/path/kustomization.yaml")
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("reading"))
+}
+
+func TestExtractSHA_InvalidYAML(t *testing.T) {
+	g := NewWithT(t)
+	path := writeTemp(t, "this: is: not: valid: yaml: ][")
+	_, err := ExtractSHA(path)
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("parsing"))
+}
+
+func TestExtractSHA_MissingImageEntry(t *testing.T) {
+	g := NewWithT(t)
+	content := `apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+images:
+  - name: some-other-image
+    newTag: 0bace1e20ff164a00e9d6becfce52e310a921931
+`
+	path := writeTemp(t, content)
+	_, err := ExtractSHA(path)
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("no image entry found"))
+}
+
+func TestExtractSHA_InvalidSHAFormat(t *testing.T) {
+	g := NewWithT(t)
+	content := `apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+images:
+  - name: localhost/konflux-operator
+    newName: quay.io/konflux-ci/konflux-operator
+    newTag: not-a-sha
+`
+	path := writeTemp(t, content)
+	_, err := ExtractSHA(path)
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("not a 40-character hex SHA"))
+}
+
+func TestExtractSHAs_Unchanged(t *testing.T) {
+	g := NewWithT(t)
+	path := writeTemp(t, validKustomization)
+	old, new, err := ExtractSHAs(path, path)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(old).To(Equal(realSHA))
+	g.Expect(new).To(Equal(realSHA))
+}
+
+func TestExtractSHAs_Changed(t *testing.T) {
+	g := NewWithT(t)
+
+	updatedSHA := "9f8e7d6c5b4a3f2e1d0c9b8a7f6e5d4c3b2a1f09"
+	newContent := `apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+images:
+  - name: localhost/konflux-operator
+    newName: quay.io/konflux-ci/konflux-operator
+    newTag: 9f8e7d6c5b4a3f2e1d0c9b8a7f6e5d4c3b2a1f09
+`
+	basePath := writeTemp(t, validKustomization)
+	headPath := writeTemp(t, newContent)
+
+	old, new, err := ExtractSHAs(basePath, headPath)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(old).To(Equal(realSHA))
+	g.Expect(new).To(Equal(updatedSHA))
+}
+
+func TestExtractSHAs_BaseError(t *testing.T) {
+	g := NewWithT(t)
+	headPath := writeTemp(t, validKustomization)
+	_, _, err := ExtractSHAs("/nonexistent/kustomization.yaml", headPath)
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("base SHA"))
+}
+
+func TestExtractSHAs_HeadError(t *testing.T) {
+	g := NewWithT(t)
+	basePath := writeTemp(t, validKustomization)
+	_, _, err := ExtractSHAs(basePath, "/nonexistent/kustomization.yaml")
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("head SHA"))
+}

--- a/infra-tools/internal/changelog/filter.go
+++ b/infra-tools/internal/changelog/filter.go
@@ -1,0 +1,61 @@
+package changelog
+
+import "strings"
+
+// CommitFilter is a pluggable function that decides which commits from a
+// repository are worth including in the changelog. It receives the full list
+// of commits between two SHAs and returns the subset to display.
+//
+// The interface is intentionally simple so it can be swapped per-service
+// without changing any other code. The conventional commits implementation
+// below is the default.
+type CommitFilter func(commits []CommitInfo) []CommitInfo
+
+// ConventionalCommitsFilter is the default CommitFilter. It returns commits
+// whose subject line starts with "feat" or "fix", excluding merge commits.
+// This works well for repositories that follow the conventional commits spec.
+//
+// Sub-service repositories that do not follow conventional commits should use
+// AllNonMergeCommitsFilter instead.
+func ConventionalCommitsFilter(commits []CommitInfo) []CommitInfo {
+	var out []CommitInfo
+	for _, c := range commits {
+		if c.IsMerge {
+			continue
+		}
+		subject := strings.ToLower(c.Subject())
+		if strings.HasPrefix(subject, "feat") || strings.HasPrefix(subject, "fix") {
+			out = append(out, c)
+		}
+	}
+	return out
+}
+
+// FilterResult holds the output of filtering commits for the operator repo.
+// Operator commits are split into two tiers for display.
+type FilterResult struct {
+	// Notable contains feat: and fix: commits — shown prominently at the top.
+	Notable []CommitInfo
+	// Remaining contains every non-merge commit that is NOT already in Notable —
+	// shown in a collapsible block so nothing is hidden but the view stays clean.
+	Remaining []CommitInfo
+}
+
+// FilterOperatorCommits applies two-tier filtering to the operator repo commits.
+// Notable (feat/fix) are surfaced prominently; every other non-merge commit goes
+// into Remaining so reviewers can expand the block to see the full picture.
+func FilterOperatorCommits(commits []CommitInfo) FilterResult {
+	var notable, remaining []CommitInfo
+	for _, c := range commits {
+		if c.IsMerge {
+			continue
+		}
+		subject := strings.ToLower(c.Subject())
+		if strings.HasPrefix(subject, "feat") || strings.HasPrefix(subject, "fix") {
+			notable = append(notable, c)
+		} else {
+			remaining = append(remaining, c)
+		}
+	}
+	return FilterResult{Notable: notable, Remaining: remaining}
+}

--- a/infra-tools/internal/changelog/filter_test.go
+++ b/infra-tools/internal/changelog/filter_test.go
@@ -1,0 +1,127 @@
+package changelog
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func makeCI(subject string, isMerge bool) CommitInfo {
+	return CommitInfo{
+		SHA:     "abc0000000000000000000000000000000000000",
+		Message: subject,
+		HTMLURL: "https://example.com",
+		IsMerge: isMerge,
+	}
+}
+
+// --- ConventionalCommitsFilter ---
+
+func TestConventionalCommitsFilter_KeepsFeatAndFix(t *testing.T) {
+	g := NewWithT(t)
+	commits := []CommitInfo{
+		makeCI("feat: add new thing", false),
+		makeCI("fix: broken stuff", false),
+		makeCI("feat(scope): scoped feature", false),
+		makeCI("fix(#123): issue fix", false),
+	}
+	result := ConventionalCommitsFilter(commits)
+	g.Expect(result).To(HaveLen(4))
+}
+
+func TestConventionalCommitsFilter_ExcludesChoreAndDocs(t *testing.T) {
+	g := NewWithT(t)
+	commits := []CommitInfo{
+		makeCI("chore: update deps", false),
+		makeCI("chore(deps): renovate update", false),
+		makeCI("docs: update readme", false),
+		makeCI("ci: add workflow", false),
+		makeCI("refactor: clean up", false),
+		makeCI("test: add tests", false),
+	}
+	result := ConventionalCommitsFilter(commits)
+	g.Expect(result).To(BeEmpty())
+}
+
+func TestConventionalCommitsFilter_ExcludesMergeCommits(t *testing.T) {
+	g := NewWithT(t)
+	commits := []CommitInfo{
+		makeCI("feat: real feature", false),
+		makeCI("Merge pull request #42 from foo/bar", true),
+		makeCI("feat: another feature", true), // merge commit even with feat prefix
+	}
+	result := ConventionalCommitsFilter(commits)
+	g.Expect(result).To(HaveLen(1))
+	g.Expect(result[0].Subject()).To(Equal("feat: real feature"))
+}
+
+func TestConventionalCommitsFilter_EmptyInput(t *testing.T) {
+	g := NewWithT(t)
+	result := ConventionalCommitsFilter(nil)
+	g.Expect(result).To(BeEmpty())
+}
+
+func TestConventionalCommitsFilter_CaseInsensitive(t *testing.T) {
+	g := NewWithT(t)
+	commits := []CommitInfo{
+		makeCI("Feat: uppercase feature", false),
+		makeCI("FIX: uppercase fix", false),
+	}
+	result := ConventionalCommitsFilter(commits)
+	g.Expect(result).To(HaveLen(2))
+}
+
+// --- FilterOperatorCommits ---
+
+func TestFilterOperatorCommits_SplitsIntoTiers(t *testing.T) {
+	g := NewWithT(t)
+	commits := []CommitInfo{
+		makeCI("feat: new feature", false),
+		makeCI("fix: bug fix", false),
+		makeCI("chore: deps update", false),
+		makeCI("chore: sync manifests", false),
+		makeCI("Merge pull request #1", true),
+	}
+
+	result := FilterOperatorCommits(commits)
+
+	// Notable: only feat and fix
+	g.Expect(result.Notable).To(HaveLen(2))
+	g.Expect(result.Notable[0].Subject()).To(Equal("feat: new feature"))
+	g.Expect(result.Notable[1].Subject()).To(Equal("fix: bug fix"))
+
+	// Remaining: non-merge, non-notable only (the two chore commits)
+	g.Expect(result.Remaining).To(HaveLen(2))
+	g.Expect(result.Remaining[0].Subject()).To(Equal("chore: deps update"))
+	g.Expect(result.Remaining[1].Subject()).To(Equal("chore: sync manifests"))
+}
+
+func TestFilterOperatorCommits_AllNotable(t *testing.T) {
+	g := NewWithT(t)
+	commits := []CommitInfo{
+		makeCI("feat: feature", false),
+		makeCI("fix: fix", false),
+	}
+	result := FilterOperatorCommits(commits)
+	// When all commits are feat/fix, Remaining is empty
+	g.Expect(result.Notable).To(HaveLen(2))
+	g.Expect(result.Remaining).To(BeEmpty())
+}
+
+func TestFilterOperatorCommits_EmptyInput(t *testing.T) {
+	g := NewWithT(t)
+	result := FilterOperatorCommits(nil)
+	g.Expect(result.Notable).To(BeEmpty())
+	g.Expect(result.Remaining).To(BeEmpty())
+}
+
+func TestFilterOperatorCommits_OnlyMergeCommits(t *testing.T) {
+	g := NewWithT(t)
+	commits := []CommitInfo{
+		makeCI("Merge pull request #1", true),
+		makeCI("Merge pull request #2", true),
+	}
+	result := FilterOperatorCommits(commits)
+	g.Expect(result.Notable).To(BeEmpty())
+	g.Expect(result.Remaining).To(BeEmpty())
+}

--- a/infra-tools/internal/changelog/formatter.go
+++ b/infra-tools/internal/changelog/formatter.go
@@ -1,0 +1,142 @@
+package changelog
+
+import (
+	"fmt"
+	"strings"
+)
+
+// CommentMarker is the HTML comment used to identify changelog PR comments
+// for idempotent updates. When the tool runs again on a force-push it finds
+// this marker and updates the existing comment rather than creating a new one.
+const CommentMarker = "<!-- changelog-generator-comment -->"
+
+// ChangelogData holds all the processed data needed to render a changelog.
+type ChangelogData struct {
+	// OldSHA and NewSHA are the operator commit SHAs being compared.
+	OldSHA string
+	NewSHA string
+	// OperatorResult is the filtered set of operator repo commits.
+	OperatorResult FilterResult
+	// ServiceChanges maps each bumped service to its filtered commits.
+	ServiceChanges []ServiceChange
+}
+
+// ServiceChange pairs a ServiceBump with the filtered commits for that service.
+type ServiceChange struct {
+	Bump    ServiceBump
+	Commits []CommitInfo
+}
+
+// Format renders the changelog as a markdown string suitable for a GitHub PR
+// comment. The CommentMarker is always the first line so UpsertComment can
+// find and update it.
+func Format(data ChangelogData) string {
+	var b strings.Builder
+
+	fmt.Fprintln(&b, CommentMarker)
+	fmt.Fprintln(&b, "### Operator Changelog")
+	fmt.Fprintln(&b)
+	fmt.Fprintf(&b, "Comparing [`%s`](https://github.com/konflux-ci/konflux-ci/commit/%s) → [`%s`](https://github.com/konflux-ci/konflux-ci/commit/%s)\n",
+		data.OldSHA[:12], data.OldSHA, data.NewSHA[:12], data.NewSHA)
+	fmt.Fprintln(&b)
+
+	writeServiceChanges(&b, data.ServiceChanges)
+	writeOperatorChanges(&b, data.OperatorResult, data.OldSHA, data.NewSHA)
+
+	return b.String()
+}
+
+// FormatNoChange renders a minimal comment when the operator SHA did not
+// change in the PR — so reviewers can see the tool ran and found nothing.
+func FormatNoChange() string {
+	var b strings.Builder
+	fmt.Fprintln(&b, CommentMarker)
+	fmt.Fprintln(&b, "### Operator Changelog")
+	fmt.Fprintln(&b)
+	fmt.Fprintln(&b, "No operator SHA change detected in this PR.")
+	return b.String()
+}
+
+// FormatError renders a degraded comment when the changelog could not be
+// fully generated due to an API error. runURL is a link to the workflow run
+// for debugging; pass empty string if unavailable.
+func FormatError(err error, runURL string) string {
+	var b strings.Builder
+	fmt.Fprintln(&b, CommentMarker)
+	fmt.Fprintln(&b, "### Operator Changelog")
+	fmt.Fprintln(&b)
+	fmt.Fprintln(&b, "⚠️ Changelog generation failed. Please check the changes manually.")
+	if runURL != "" {
+		fmt.Fprintf(&b, "\n[View workflow run](%s) for details.\n", runURL)
+	}
+	fmt.Fprintf(&b, "\n```\n%v\n```\n", err)
+	return b.String()
+}
+
+// writeServiceChanges renders the "Underlying Service Changes" section.
+func writeServiceChanges(b *strings.Builder, changes []ServiceChange) {
+	if len(changes) == 0 {
+		return
+	}
+
+	fmt.Fprintln(b, "#### Underlying Service Changes")
+	fmt.Fprintln(b)
+
+	for _, sc := range changes {
+		compareURL := fmt.Sprintf("https://github.com/%s/%s/compare/%s...%s",
+			sc.Bump.Owner, sc.Bump.Repo, sc.Bump.OldSHA, sc.Bump.NewSHA)
+
+		fmt.Fprintf(b, "**%s** — [`%s`](%s) → [`%s`](%s) ([compare](%s))\n",
+			sc.Bump.Repo,
+			sc.Bump.OldSHA[:12],
+			fmt.Sprintf("https://github.com/%s/%s/commit/%s", sc.Bump.Owner, sc.Bump.Repo, sc.Bump.OldSHA),
+			sc.Bump.NewSHA[:12],
+			fmt.Sprintf("https://github.com/%s/%s/commit/%s", sc.Bump.Owner, sc.Bump.Repo, sc.Bump.NewSHA),
+			compareURL,
+		)
+
+		if len(sc.Commits) == 0 {
+			fmt.Fprintln(b, "_No notable commits found._")
+		} else {
+			for _, c := range sc.Commits {
+				fmt.Fprintf(b, "- [`%s`](%s) %s\n", c.SHA[:8], c.HTMLURL, c.Subject())
+			}
+		}
+		fmt.Fprintln(b)
+	}
+}
+
+// writeOperatorChanges renders the "Operator Changes" section with two tiers:
+// notable (feat/fix) shown directly, remaining commits in a collapsible block.
+func writeOperatorChanges(b *strings.Builder, result FilterResult, oldSHA, newSHA string) {
+	compareURL := fmt.Sprintf("https://github.com/konflux-ci/konflux-ci/compare/%s...%s", oldSHA, newSHA)
+
+	if len(result.Notable) == 0 && len(result.Remaining) == 0 {
+		fmt.Fprintln(b, "#### Operator Changes")
+		fmt.Fprintln(b)
+		fmt.Fprintf(b, "_No operator commits found. [View full comparison](%s)_\n", compareURL)
+		return
+	}
+
+	fmt.Fprintln(b, "#### Operator Changes")
+	fmt.Fprintln(b)
+
+	if len(result.Notable) > 0 {
+		for _, c := range result.Notable {
+			fmt.Fprintf(b, "- [`%s`](%s) %s\n", c.SHA[:8], c.HTMLURL, c.Subject())
+		}
+		fmt.Fprintln(b)
+	}
+
+	if len(result.Remaining) > 0 {
+		summary := fmt.Sprintf("Other commits (%d)", len(result.Remaining))
+		fmt.Fprintf(b, "<details>\n<summary>%s</summary>\n\n", summary)
+		for _, c := range result.Remaining {
+			fmt.Fprintf(b, "- [`%s`](%s) %s\n", c.SHA[:8], c.HTMLURL, c.Subject())
+		}
+		fmt.Fprintf(b, "\n[View full comparison](%s)\n", compareURL)
+		fmt.Fprintln(b, "</details>")
+	} else {
+		fmt.Fprintf(b, "[View full comparison](%s)\n", compareURL)
+	}
+}

--- a/infra-tools/internal/changelog/formatter_test.go
+++ b/infra-tools/internal/changelog/formatter_test.go
@@ -1,0 +1,173 @@
+package changelog
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+const (
+	testOldSHA = "0bace1e20ff164a00e9d6becfce52e310a921931"
+	testNewSHA = "9f8e7d6c5b4a3f2e1d0c9b8a7f6e5d4c3b2a1f09"
+)
+
+func makeServiceChange(owner, repo, oldSHA, newSHA string, commits []CommitInfo) ServiceChange {
+	return ServiceChange{
+		Bump: ServiceBump{
+			Owner:  owner,
+			Repo:   repo,
+			OldSHA: oldSHA,
+			NewSHA: newSHA,
+		},
+		Commits: commits,
+	}
+}
+
+// --- Format ---
+
+func TestFormat_ContainsCompareLink(t *testing.T) {
+	g := NewWithT(t)
+	data := ChangelogData{OldSHA: testOldSHA, NewSHA: testNewSHA}
+	result := Format(data)
+	g.Expect(result).To(ContainSubstring("0bace1e20ff1"))
+	g.Expect(result).To(ContainSubstring("9f8e7d6c5b4a"))
+}
+
+func TestFormat_WithServiceChanges(t *testing.T) {
+	g := NewWithT(t)
+
+	commits := []CommitInfo{
+		{SHA: "abc1234500000000000000000000000000000000", Message: "fix: CVE patch", HTMLURL: "https://github.com/org/svc/commit/abc12345"},
+	}
+	data := ChangelogData{
+		OldSHA: testOldSHA,
+		NewSHA: testNewSHA,
+		ServiceChanges: []ServiceChange{
+			makeServiceChange("konflux-ci", "build-service",
+				"211140a26c96e8f028a0595fb779ea13210ed5c8",
+				"04a4744321a7fb747f796da783d51fc322aef598",
+				commits),
+		},
+	}
+
+	result := Format(data)
+	g.Expect(result).To(ContainSubstring("build-service"))
+	g.Expect(result).To(ContainSubstring("fix: CVE patch"))
+	g.Expect(result).To(ContainSubstring("211140a26c96"))
+	g.Expect(result).To(ContainSubstring("04a4744321a7"))
+	g.Expect(result).To(ContainSubstring("compare"))
+}
+
+func TestFormat_ServiceChangeNoCommits(t *testing.T) {
+	g := NewWithT(t)
+
+	data := ChangelogData{
+		OldSHA: testOldSHA,
+		NewSHA: testNewSHA,
+		ServiceChanges: []ServiceChange{
+			makeServiceChange("konflux-ci", "namespace-lister",
+				"bb70d9ec086170b825194574208c579263452743",
+				"19c8344f1f897ba84a4182c087e84de9e8cd603b",
+				nil),
+		},
+	}
+
+	result := Format(data)
+	g.Expect(result).To(ContainSubstring("No notable commits found"))
+}
+
+func TestFormat_WithOperatorNotableCommits(t *testing.T) {
+	g := NewWithT(t)
+
+	data := ChangelogData{
+		OldSHA: testOldSHA,
+		NewSHA: testNewSHA,
+		OperatorResult: FilterResult{
+			Notable: []CommitInfo{
+				{SHA: "feat123400000000000000000000000000000000", Message: "feat: new CRD field", HTMLURL: "https://github.com/org/repo/commit/feat1234"},
+				{SHA: "fix567800000000000000000000000000000000", Message: "fix: nil pointer", HTMLURL: "https://github.com/org/repo/commit/fix5678"},
+			},
+			Remaining: []CommitInfo{
+				{SHA: "chore12300000000000000000000000000000000", Message: "chore: update deps", HTMLURL: "https://github.com/org/repo/commit/chore123"},
+			},
+		},
+	}
+
+	result := Format(data)
+	g.Expect(result).To(ContainSubstring("feat: new CRD field"))
+	g.Expect(result).To(ContainSubstring("fix: nil pointer"))
+	g.Expect(result).To(ContainSubstring("chore: update deps"))
+	g.Expect(result).To(ContainSubstring("<details>"))
+	g.Expect(result).To(ContainSubstring("Other commits (1)"))
+	g.Expect(result).To(ContainSubstring("</details>"))
+}
+
+func TestFormat_NotableOnlyNoRemaining(t *testing.T) {
+	g := NewWithT(t)
+
+	data := ChangelogData{
+		OldSHA: testOldSHA,
+		NewSHA: testNewSHA,
+		OperatorResult: FilterResult{
+			Notable: []CommitInfo{
+				{SHA: "feat123400000000000000000000000000000000", Message: "feat: new feature", HTMLURL: "https://github.com/org/repo/commit/feat1234"},
+			},
+		},
+	}
+	result := Format(data)
+	g.Expect(result).To(ContainSubstring("feat: new feature"))
+	g.Expect(result).NotTo(ContainSubstring("<details>"))
+	g.Expect(result).To(ContainSubstring("View full comparison"))
+}
+
+func TestFormat_NoOperatorCommits(t *testing.T) {
+	g := NewWithT(t)
+
+	data := ChangelogData{OldSHA: testOldSHA, NewSHA: testNewSHA}
+	result := Format(data)
+	g.Expect(result).To(ContainSubstring("No operator commits found"))
+	g.Expect(result).To(ContainSubstring("View full comparison"))
+}
+
+// --- FormatNoChange ---
+
+func TestFormatNoChange_ContainsMarkerAndMessage(t *testing.T) {
+	g := NewWithT(t)
+	result := FormatNoChange()
+	g.Expect(result).To(HavePrefix(CommentMarker))
+	g.Expect(result).To(ContainSubstring("No operator SHA change detected"))
+}
+
+// --- FormatError ---
+
+func TestFormatError_ContainsMarkerAndError(t *testing.T) {
+	g := NewWithT(t)
+	result := FormatError(errors.New("API rate limit exceeded"), "")
+	g.Expect(result).To(HavePrefix(CommentMarker))
+	g.Expect(result).To(ContainSubstring("API rate limit exceeded"))
+	g.Expect(result).To(ContainSubstring("failed"))
+}
+
+func TestFormatError_IncludesRunURLWhenProvided(t *testing.T) {
+	g := NewWithT(t)
+	result := FormatError(errors.New("timeout"), "https://github.com/org/repo/actions/runs/123")
+	g.Expect(result).To(ContainSubstring("https://github.com/org/repo/actions/runs/123"))
+}
+
+func TestFormatError_NoRunURLOmitsLink(t *testing.T) {
+	g := NewWithT(t)
+	result := FormatError(errors.New("timeout"), "")
+	g.Expect(result).NotTo(ContainSubstring("View workflow run"))
+}
+
+// --- Structure sanity check ---
+
+func TestFormat_MarkerIsFirstLine(t *testing.T) {
+	g := NewWithT(t)
+	data := ChangelogData{OldSHA: testOldSHA, NewSHA: testNewSHA}
+	result := Format(data)
+	firstLine := strings.SplitN(result, "\n", 2)[0]
+	g.Expect(firstLine).To(Equal(CommentMarker))
+}

--- a/infra-tools/internal/changelog/upstream.go
+++ b/infra-tools/internal/changelog/upstream.go
@@ -1,0 +1,115 @@
+package changelog
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	gh "github.com/google/go-github/v68/github"
+)
+
+// RepoComparer is the subset of the GitHub Repositories API used by this
+// package. Defined as an interface so tests can inject a fake implementation
+// without making real network calls.
+type RepoComparer interface {
+	CompareCommits(ctx context.Context, owner, repo, base, head string, opts *gh.ListOptions) (*gh.CommitsComparison, *gh.Response, error)
+}
+
+// CommitInfo holds the fields we need from a single commit in a comparison.
+type CommitInfo struct {
+	SHA     string
+	Message string // full commit message
+	HTMLURL string
+	IsMerge bool // true when the commit has two or more parents (merge commit)
+}
+
+// Subject returns the first line of the commit message.
+func (c CommitInfo) Subject() string {
+	return strings.SplitN(c.Message, "\n", 2)[0]
+}
+
+// FileChange holds the fields we need from a file changed in a comparison.
+type FileChange struct {
+	Filename string
+	Patch    string // unified diff patch; may be empty for binary files
+	Status   string // added, modified, removed, renamed
+}
+
+// OperatorCompare holds the raw data returned by the operator repo compare call.
+// Both Commits and Files cover the full range between the two SHAs.
+type OperatorCompare struct {
+	Commits []CommitInfo
+	Files   []FileChange
+}
+
+// NewRepoComparer creates a RepoComparer backed by the real GitHub API.
+// Pass an empty token to use unauthenticated access (rate-limited to 60/hour).
+// In CI, always pass the GITHUB_TOKEN.
+func NewRepoComparer(token string) RepoComparer {
+	client := gh.NewClient(nil)
+	if token != "" {
+		client = client.WithAuthToken(token)
+	}
+	return client.Repositories
+}
+
+// FetchOperatorCompare calls the GitHub compare API for the operator repo
+// (konflux-ci/konflux-ci) between oldSHA and newSHA, and returns the full
+// commit list and changed file list.
+func FetchOperatorCompare(ctx context.Context, c RepoComparer, oldSHA, newSHA string) (*OperatorCompare, error) {
+	comparison, _, err := c.CompareCommits(ctx, "konflux-ci", "konflux-ci", oldSHA, newSHA, nil)
+	if err != nil {
+		return nil, fmt.Errorf("comparing %s...%s in konflux-ci/konflux-ci: %w", oldSHA[:12], newSHA[:12], err)
+	}
+
+	result := &OperatorCompare{
+		Commits: convertCommits(comparison.Commits),
+		Files:   convertFiles(comparison.Files),
+	}
+	return result, nil
+}
+
+// FetchServiceCommits calls the GitHub compare API for a sub-service repo
+// (e.g. konflux-ci/build-service) and returns the commit list. Merge commits
+// are included; callers should use filter.go to remove them if needed.
+func FetchServiceCommits(ctx context.Context, c RepoComparer, owner, repo, oldSHA, newSHA string) ([]CommitInfo, error) {
+	comparison, _, err := c.CompareCommits(ctx, owner, repo, oldSHA, newSHA, nil)
+	if err != nil {
+		return nil, fmt.Errorf("comparing %s...%s in %s/%s: %w", oldSHA[:12], newSHA[:12], owner, repo, err)
+	}
+	return convertCommits(comparison.Commits), nil
+}
+
+// convertCommits maps the go-github RepositoryCommit slice into our leaner type.
+func convertCommits(raw []*gh.RepositoryCommit) []CommitInfo {
+	out := make([]CommitInfo, 0, len(raw))
+	for _, c := range raw {
+		if c == nil || c.Commit == nil {
+			continue
+		}
+		info := CommitInfo{
+			SHA:     c.GetSHA(),
+			Message: c.Commit.GetMessage(),
+			HTMLURL: c.GetHTMLURL(),
+			IsMerge: len(c.Parents) >= 2,
+		}
+		out = append(out, info)
+	}
+	return out
+}
+
+// convertFiles maps the go-github CommitFile slice into our leaner type.
+func convertFiles(raw []*gh.CommitFile) []FileChange {
+	out := make([]FileChange, 0, len(raw))
+	for _, f := range raw {
+		if f == nil {
+			continue
+		}
+		out = append(out, FileChange{
+			Filename: f.GetFilename(),
+			Patch:    f.GetPatch(),
+			Status:   f.GetStatus(),
+		})
+	}
+	return out
+}

--- a/infra-tools/internal/changelog/upstream_test.go
+++ b/infra-tools/internal/changelog/upstream_test.go
@@ -1,0 +1,162 @@
+package changelog
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	gh "github.com/google/go-github/v68/github"
+)
+
+// fakeRepoComparer implements RepoComparer for testing without network calls.
+type fakeRepoComparer struct {
+	comparison *gh.CommitsComparison
+	err        error
+}
+
+func (f *fakeRepoComparer) CompareCommits(_ context.Context, _, _, _, _ string, _ *gh.ListOptions) (*gh.CommitsComparison, *gh.Response, error) {
+	return f.comparison, &gh.Response{}, f.err
+}
+
+// makeCommit builds a minimal *gh.RepositoryCommit for use in tests.
+func makeCommit(sha, message, htmlURL string, parentCount int) *gh.RepositoryCommit {
+	parents := make([]*gh.Commit, parentCount)
+	for i := range parents {
+		parents[i] = &gh.Commit{}
+	}
+	return &gh.RepositoryCommit{
+		SHA:     gh.Ptr(sha),
+		HTMLURL: gh.Ptr(htmlURL),
+		Commit: &gh.Commit{
+			Message: gh.Ptr(message),
+		},
+		Parents: parents,
+	}
+}
+
+func makeFile(filename, patch, status string) *gh.CommitFile {
+	return &gh.CommitFile{
+		Filename: gh.Ptr(filename),
+		Patch:    gh.Ptr(patch),
+		Status:   gh.Ptr(status),
+	}
+}
+
+// --- FetchOperatorCompare tests ---
+
+func TestFetchOperatorCompare_ReturnsCommitsAndFiles(t *testing.T) {
+	g := NewWithT(t)
+
+	fake := &fakeRepoComparer{
+		comparison: &gh.CommitsComparison{
+			Commits: []*gh.RepositoryCommit{
+				makeCommit("abc1234500000000000000000000000000000000", "feat: add thing", "https://github.com/org/repo/commit/abc12345", 1),
+				makeCommit("def5678900000000000000000000000000000000", "fix: broken stuff", "https://github.com/org/repo/commit/def56789", 1),
+			},
+			Files: []*gh.CommitFile{
+				makeFile("operator/foo.go", "@@ -1 +1 @@\n-old\n+new", "modified"),
+			},
+		},
+	}
+
+	result, err := FetchOperatorCompare(context.Background(), fake, "abc1234500000000000000000000000000000000", "def5678900000000000000000000000000000000")
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(result.Commits).To(HaveLen(2))
+	g.Expect(result.Files).To(HaveLen(1))
+	g.Expect(result.Commits[0].Subject()).To(Equal("feat: add thing"))
+	g.Expect(result.Commits[1].Subject()).To(Equal("fix: broken stuff"))
+	g.Expect(result.Files[0].Filename).To(Equal("operator/foo.go"))
+	g.Expect(result.Files[0].Status).To(Equal("modified"))
+}
+
+func TestFetchOperatorCompare_APIError(t *testing.T) {
+	g := NewWithT(t)
+
+	fake := &fakeRepoComparer{err: errors.New("API unavailable")}
+	_, err := FetchOperatorCompare(context.Background(), fake, "abc1234500000000000000000000000000000000", "def5678900000000000000000000000000000000")
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("konflux-ci/konflux-ci"))
+}
+
+func TestFetchOperatorCompare_EmptyResponse(t *testing.T) {
+	g := NewWithT(t)
+
+	fake := &fakeRepoComparer{
+		comparison: &gh.CommitsComparison{},
+	}
+	result, err := FetchOperatorCompare(context.Background(), fake, "abc1234500000000000000000000000000000000", "def5678900000000000000000000000000000000")
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(result.Commits).To(BeEmpty())
+	g.Expect(result.Files).To(BeEmpty())
+}
+
+// --- FetchServiceCommits tests ---
+
+func TestFetchServiceCommits_ReturnsCommits(t *testing.T) {
+	g := NewWithT(t)
+
+	fake := &fakeRepoComparer{
+		comparison: &gh.CommitsComparison{
+			Commits: []*gh.RepositoryCommit{
+				makeCommit("aaa0000000000000000000000000000000000000", "fix: CVE patch", "https://github.com/org/svc/commit/aaa", 1),
+				makeCommit("bbb0000000000000000000000000000000000000", "Merge pull request #42", "https://github.com/org/svc/commit/bbb", 2),
+			},
+		},
+	}
+
+	commits, err := FetchServiceCommits(context.Background(), fake, "konflux-ci", "build-service", "aaa0000000000000000000000000000000000000", "bbb0000000000000000000000000000000000000")
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(commits).To(HaveLen(2))
+	g.Expect(commits[0].IsMerge).To(BeFalse())
+	g.Expect(commits[1].IsMerge).To(BeTrue())
+}
+
+func TestFetchServiceCommits_APIError(t *testing.T) {
+	g := NewWithT(t)
+
+	fake := &fakeRepoComparer{err: errors.New("not found")}
+	_, err := FetchServiceCommits(context.Background(), fake, "konflux-ci", "build-service", "aaa0000000000000000000000000000000000000", "bbb0000000000000000000000000000000000000")
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("build-service"))
+}
+
+// --- convertFiles tests ---
+
+func TestConvertFiles_MapsFields(t *testing.T) {
+	g := NewWithT(t)
+	raw := []*gh.CommitFile{
+		makeFile("operator/foo.go", "@@ -1 +1 @@\n-old\n+new", "modified"),
+		makeFile("operator/bar.yaml", "", "added"),
+	}
+	result := convertFiles(raw)
+	g.Expect(result).To(HaveLen(2))
+	g.Expect(result[0].Filename).To(Equal("operator/foo.go"))
+	g.Expect(result[0].Patch).To(ContainSubstring("-old"))
+	g.Expect(result[0].Status).To(Equal("modified"))
+	g.Expect(result[1].Filename).To(Equal("operator/bar.yaml"))
+	g.Expect(result[1].Patch).To(BeEmpty())
+	g.Expect(result[1].Status).To(Equal("added"))
+}
+
+func TestConvertFiles_SkipsNilEntries(t *testing.T) {
+	g := NewWithT(t)
+	raw := []*gh.CommitFile{nil, makeFile("foo.go", "", "modified"), nil}
+	result := convertFiles(raw)
+	g.Expect(result).To(HaveLen(1))
+}
+
+// --- convertCommits tests ---
+
+func TestConvertCommits_SkipsNilEntries(t *testing.T) {
+	g := NewWithT(t)
+	raw := []*gh.RepositoryCommit{
+		nil,
+		makeCommit("abc0000000000000000000000000000000000000", "fix: real commit", "https://example.com", 1),
+		nil,
+	}
+	result := convertCommits(raw)
+	g.Expect(result).To(HaveLen(1))
+	g.Expect(result[0].Subject()).To(Equal("fix: real commit"))
+}

--- a/infra-tools/internal/github/comments.go
+++ b/infra-tools/internal/github/comments.go
@@ -44,14 +44,20 @@ func NewCommentClient(token, repoFullName string) (*CommentClient, error) {
 // UpsertComment creates or updates a PR comment identified by CommentMarker.
 // If a comment with the marker exists, it is updated; otherwise a new comment is created.
 func (c *CommentClient) UpsertComment(ctx context.Context, prNumber int, body string) error {
-	// Find existing comment
-	existingID, err := c.findMarkedComment(ctx, prNumber)
+	return c.UpsertCommentByMarker(ctx, prNumber, body, CommentMarker)
+}
+
+// UpsertCommentByMarker creates or updates a PR comment identified by the
+// given HTML marker string. This allows multiple tools to manage their own
+// idempotent comments on the same PR using different markers.
+func (c *CommentClient) UpsertCommentByMarker(ctx context.Context, prNumber int, body, marker string) error {
+	existingID, err := c.findCommentByMarker(ctx, prNumber, marker)
 	if err != nil {
 		return fmt.Errorf("finding existing comment: %w", err)
 	}
 
 	if existingID != 0 {
-		slog.Info("Updating existing render-diff comment", "comment_id", existingID)
+		slog.Info("Updating existing comment", "comment_id", existingID, "marker", marker)
 		_, _, err = c.comments.EditComment(ctx, c.owner, c.repo, existingID, &gh.IssueComment{
 			Body: gh.Ptr(body),
 		})
@@ -61,7 +67,7 @@ func (c *CommentClient) UpsertComment(ctx context.Context, prNumber int, body st
 		return nil
 	}
 
-	slog.Info("Creating new render-diff comment")
+	slog.Info("Creating new comment", "marker", marker)
 	_, _, err = c.comments.CreateComment(ctx, c.owner, c.repo, prNumber, &gh.IssueComment{
 		Body: gh.Ptr(body),
 	})
@@ -71,8 +77,8 @@ func (c *CommentClient) UpsertComment(ctx context.Context, prNumber int, body st
 	return nil
 }
 
-// findMarkedComment searches for a comment containing the CommentMarker.
-func (c *CommentClient) findMarkedComment(ctx context.Context, prNumber int) (int64, error) {
+// findCommentByMarker searches for a PR comment whose body contains marker.
+func (c *CommentClient) findCommentByMarker(ctx context.Context, prNumber int, marker string) (int64, error) {
 	opts := &gh.IssueListCommentsOptions{
 		ListOptions: gh.ListOptions{PerPage: 100},
 	}
@@ -82,7 +88,7 @@ func (c *CommentClient) findMarkedComment(ctx context.Context, prNumber int) (in
 			return 0, err
 		}
 		for _, comment := range comments {
-			if comment.Body != nil && strings.Contains(*comment.Body, CommentMarker) {
+			if comment.Body != nil && strings.Contains(*comment.Body, marker) {
 				return comment.GetID(), nil
 			}
 		}


### PR DESCRIPTION
For [KFLUXVNGD-918](https://redhat.atlassian.net/browse/KFLUXVNGD-918) (generate changelog for infra-deployments PRs).

Adds the core library under `infra-tools/internal/changelog/`:
- `extractor.go` — reads the operator image SHA from `kustomization.yaml` at two git refs via a worktree
- `bumps.go` — detects sub-service `?ref=` changes from a GitHub compare patch
- `upstream.go` — fetches commit comparisons from GitHub (network behind an interface, so tests need no network)
- `filter.go` — conventional commits filter and two-tier operator commit splitter (notable vs collapsible remaining)
- `formatter.go` — renders everything into the final markdown comment
Also adds `UpsertCommentByMarker` to `internal/github/comments.go` so the binary (PR 2) can post idempotent comments with a custom marker.



[KFLUXVNGD-918]: https://redhat.atlassian.net/browse/KFLUXVNGD-918?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ