### PR TITLE
chore: bump kubearchive staging to v1.22.1

### DIFF
--- a/components/kubearchive/development/kubearchive.yaml
+++ b/components/kubearchive/development/kubearchive.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: namespace
     app.kubernetes.io/name: kubearchive
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.21.4
+    app.kubernetes.io/version: v1.22.1
   name: kubearchive
 ---
 apiVersion: apiextensions.k8s.io/v1
@@ -552,7 +552,7 @@ metadata:
     app.kubernetes.io/component: api-server
     app.kubernetes.io/name: kubearchive-api-server
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.21.4
+    app.kubernetes.io/version: v1.22.1
   name: kubearchive-api-server
   namespace: kubearchive
 ---
@@ -563,7 +563,7 @@ metadata:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: kubearchive-vacuum
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.21.4
+    app.kubernetes.io/version: v1.22.1
   name: kubearchive-cluster-vacuum
   namespace: kubearchive
 ---
@@ -574,7 +574,7 @@ metadata:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: kubearchive-operator
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.21.4
+    app.kubernetes.io/version: v1.22.1
   name: kubearchive-operator
   namespace: kubearchive
 ---
@@ -585,7 +585,7 @@ metadata:
     app.kubernetes.io/component: sink
     app.kubernetes.io/name: kubearchive-sink
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.21.4
+    app.kubernetes.io/version: v1.22.1
   name: kubearchive-sink
   namespace: kubearchive
 ---
@@ -596,7 +596,7 @@ metadata:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: kubearchive-operator-leader-election
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.21.4
+    app.kubernetes.io/version: v1.22.1
   name: kubearchive-operator-leader-election
   namespace: kubearchive
 rules:
@@ -639,7 +639,7 @@ metadata:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: kubearchive-vacuum
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.21.4
+    app.kubernetes.io/version: v1.22.1
   name: kubearchive-vacuum
   namespace: kubearchive
 rules:
@@ -659,7 +659,7 @@ metadata:
     app.kubernetes.io/component: api-server
     app.kubernetes.io/name: kubearchive-api-server
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.21.4
+    app.kubernetes.io/version: v1.22.1
   name: kubearchive-api-server
 rules:
   - apiGroups:
@@ -677,7 +677,7 @@ metadata:
   labels:
     app.kubernetes.io/name: kubearchive-edit
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.21.4
+    app.kubernetes.io/version: v1.22.1
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
   name: kubearchive-edit
 rules:
@@ -791,7 +791,7 @@ metadata:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: kubearchive-operator-config-editor
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.21.4
+    app.kubernetes.io/version: v1.22.1
   name: kubearchive-operator-config-editor
 rules:
   - apiGroups:
@@ -820,7 +820,7 @@ metadata:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: kubearchive-operator-config-viewer
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.21.4
+    app.kubernetes.io/version: v1.22.1
   name: kubearchive-operator-config-viewer
 rules:
   - apiGroups:
@@ -844,7 +844,7 @@ metadata:
   labels:
     app.kubernetes.io/name: kubearchive-view
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.21.4
+    app.kubernetes.io/version: v1.22.1
     rbac.authorization.k8s.io/aggregate-to-view: "true"
   name: kubearchive-view
 rules:
@@ -868,7 +868,7 @@ metadata:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: kubearchive-operator-leader-election
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.21.4
+    app.kubernetes.io/version: v1.22.1
   name: kubearchive-operator-leader-election
   namespace: kubearchive
 roleRef:
@@ -887,7 +887,7 @@ metadata:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: kubearchive-vacuum
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.21.4
+    app.kubernetes.io/version: v1.22.1
   name: kubearchive-vacuum
   namespace: kubearchive
 roleRef:
@@ -906,7 +906,7 @@ metadata:
     app.kubernetes.io/component: api-server
     app.kubernetes.io/name: kubearchive-api-server
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.21.4
+    app.kubernetes.io/version: v1.22.1
   name: kubearchive-api-server
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -924,7 +924,7 @@ metadata:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: kubearchive-operator
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.21.4
+    app.kubernetes.io/version: v1.22.1
   name: kubearchive-operator
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -943,7 +943,7 @@ metadata:
     app.kubernetes.io/component: logging
     app.kubernetes.io/name: kubearchive-logging-reader
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.21.4
+    app.kubernetes.io/version: v1.22.1
   name: kubearchive-logging-reader
   namespace: kubearchive
 ---
@@ -955,7 +955,7 @@ metadata:
     app.kubernetes.io/component: logging
     app.kubernetes.io/name: kubearchive-logging-writer
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.21.4
+    app.kubernetes.io/version: v1.22.1
   name: kubearchive-logging-writer
   namespace: kubearchive
 ---
@@ -972,7 +972,7 @@ metadata:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: kubearchive-operator
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.21.4
+    app.kubernetes.io/version: v1.22.1
   name: kubearchive-operator
   namespace: kubearchive
 ---
@@ -990,7 +990,7 @@ metadata:
     app.kubernetes.io/component: database
     app.kubernetes.io/name: kubearchive-database-credentials
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.21.4
+    app.kubernetes.io/version: v1.22.1
   name: kubearchive-database-credentials
   namespace: kubearchive
 type: Opaque
@@ -1002,7 +1002,7 @@ metadata:
     app.kubernetes.io/component: logging
     app.kubernetes.io/name: kubearchive-logging
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.21.4
+    app.kubernetes.io/version: v1.22.1
   name: kubearchive-logging
   namespace: kubearchive
 stringData:
@@ -1016,7 +1016,7 @@ metadata:
     app.kubernetes.io/component: api-server
     app.kubernetes.io/name: kubearchive-api-server
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.21.4
+    app.kubernetes.io/version: v1.22.1
   name: kubearchive-api-server
   namespace: kubearchive
 spec:
@@ -1035,7 +1035,7 @@ metadata:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: kubearchive-operator-webhooks
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.21.4
+    app.kubernetes.io/version: v1.22.1
   name: kubearchive-operator-webhooks
   namespace: kubearchive
 spec:
@@ -1058,7 +1058,7 @@ metadata:
     app.kubernetes.io/component: sink
     app.kubernetes.io/name: kubearchive-sink
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.21.4
+    app.kubernetes.io/version: v1.22.1
   name: kubearchive-sink
   namespace: kubearchive
 spec:
@@ -1076,7 +1076,7 @@ metadata:
     app.kubernetes.io/component: api-server
     app.kubernetes.io/name: kubearchive-api-server
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.21.4
+    app.kubernetes.io/version: v1.22.1
   name: kubearchive-api-server
   namespace: kubearchive
 spec:
@@ -1130,7 +1130,7 @@ spec:
           envFrom:
             - secretRef:
                 name: kubearchive-database-credentials
-          image: quay.io/kubearchive/api:v1.21.4@sha256:b176b1651fe024ecd94207f690e727eb246f57436957115274647c2947494dc8
+          image: quay.io/kubearchive/api:v1.22.1@sha256:f8d51f53cca320c04ee90c607dc7ddf4e0dc1060b5fd05349c8cdb9d61bab83e
           livenessProbe:
             httpGet:
               path: /livez
@@ -1182,7 +1182,7 @@ metadata:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: kubearchive-operator
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.21.4
+    app.kubernetes.io/version: v1.22.1
   name: kubearchive-operator
   namespace: kubearchive
 spec:
@@ -1232,7 +1232,7 @@ spec:
               valueFrom:
                 resourceFieldRef:
                   resource: limits.cpu
-          image: quay.io/kubearchive/operator:v1.21.4@sha256:2beeaeb53a17056249b666e8f9bd67a9a237d3394a66a651cb5caca3f8ac4901
+          image: quay.io/kubearchive/operator:v1.22.1@sha256:8e50b5bb60058722910a7b073b80c92635683eb50a86191dc5994c4ecea0cbbf
           livenessProbe:
             httpGet:
               path: /healthz
@@ -1294,7 +1294,7 @@ metadata:
     app.kubernetes.io/component: sink
     app.kubernetes.io/name: kubearchive-sink
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.21.4
+    app.kubernetes.io/version: v1.22.1
   name: kubearchive-sink
   namespace: kubearchive
 spec:
@@ -1346,7 +1346,7 @@ spec:
           envFrom:
             - secretRef:
                 name: kubearchive-database-credentials
-          image: quay.io/kubearchive/sink:v1.21.4@sha256:3b6603fa0cdd9daf99142573a0cdddce3467cdd8d180fd795e465209584c14b0
+          image: quay.io/kubearchive/sink:v1.22.1@sha256:33d01159261fafb309119df22d3b0ba1ca5b39a1476a75e6c1cdff13f890b78d
           livenessProbe:
             httpGet:
               path: /livez
@@ -1387,7 +1387,7 @@ metadata:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: kubearchive-vacuum
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.21.4
+    app.kubernetes.io/version: v1.22.1
   name: cluster-vacuum
   namespace: kubearchive
 spec:
@@ -1408,7 +1408,7 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
-              image: quay.io/kubearchive/vacuum:v1.21.4@sha256:3ededff190a125e51f2f675ae55d0559295580bda715bb2e3406d1cec7aac339
+              image: quay.io/kubearchive/vacuum:v1.22.1@sha256:5dfbbb5c4f66b0573f0a42f40bc1e508dce835881b176fd397455299bfa32bfb
               name: vacuum
           restartPolicy: Never
           serviceAccount: kubearchive-cluster-vacuum
@@ -1422,7 +1422,7 @@ metadata:
     app.kubernetes.io/component: kubearchive
     app.kubernetes.io/name: kubearchive-schema-migration
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.21.4
+    app.kubernetes.io/version: v1.22.1
   name: kubearchive-schema-migration
   namespace: kubearchive
 spec:
@@ -1438,7 +1438,7 @@ spec:
           envFrom:
             - secretRef:
                 name: kubearchive-database-credentials
-          image: quay.io/kubearchive/postgresql:v1.21.4@sha256:58bcad4798c71746b0c9d11eb482a1075a9b073cbc146187fe2670df16b6d785
+          image: quay.io/kubearchive/postgresql:v1.22.1@sha256:806e2c585a998ed51d14a87fac8667bdc27077a5f47d25df1a951a66f1ebacb5
           name: migration
           resources:
             limits:
@@ -1459,7 +1459,7 @@ metadata:
     app.kubernetes.io/component: api-server
     app.kubernetes.io/name: kubearchive-api-server-certificate
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.21.4
+    app.kubernetes.io/version: v1.22.1
   name: kubearchive-api-server-certificate
   namespace: kubearchive
 spec:
@@ -1493,7 +1493,7 @@ metadata:
     app.kubernetes.io/component: certs
     app.kubernetes.io/name: kubearchive-ca
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.21.4
+    app.kubernetes.io/version: v1.22.1
   name: kubearchive-ca
   namespace: kubearchive
 spec:
@@ -1515,7 +1515,7 @@ metadata:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: kubearchive-operator-certificate
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.21.4
+    app.kubernetes.io/version: v1.22.1
   name: kubearchive-operator-certificate
   namespace: kubearchive
 spec:
@@ -1534,7 +1534,7 @@ metadata:
     app.kubernetes.io/component: certs
     app.kubernetes.io/name: kubearchive
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.21.4
+    app.kubernetes.io/version: v1.22.1
   name: kubearchive
   namespace: kubearchive
 spec:
@@ -1548,7 +1548,7 @@ metadata:
     app.kubernetes.io/component: certs
     app.kubernetes.io/name: kubearchive-ca
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.21.4
+    app.kubernetes.io/version: v1.22.1
   name: kubearchive-ca
   namespace: kubearchive
 spec:
@@ -1563,7 +1563,7 @@ metadata:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: kubearchive-mutating-webhook-configuration
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.21.4
+    app.kubernetes.io/version: v1.22.1
   name: kubearchive-mutating-webhook-configuration
 webhooks:
   - admissionReviewVersions:
@@ -1676,7 +1676,7 @@ metadata:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: kubearchive-validating-webhook-configuration
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.21.4
+    app.kubernetes.io/version: v1.22.1
   name: kubearchive-validating-webhook-configuration
 webhooks:
   - admissionReviewVersions:

--- a/components/kubearchive/development/kustomization.yaml
+++ b/components/kubearchive/development/kustomization.yaml
@@ -99,7 +99,7 @@ patches:
               spec:
                 containers:
                   - name: vacuum
-                    image: quay.io/kubearchive/vacuum:v1.21.4
+                    image: quay.io/kubearchive/vacuum:v1.22.1
   - patch: |-
       apiVersion: batch/v1
       kind: CronJob
@@ -112,7 +112,7 @@ patches:
               spec:
                 containers:
                   - name: vacuum
-                    image: quay.io/kubearchive/vacuum:v1.21.4
+                    image: quay.io/kubearchive/vacuum:v1.22.1
   - patch: |-
       apiVersion: batch/v1
       kind: CronJob
@@ -125,7 +125,7 @@ patches:
               spec:
                 containers:
                   - name: vacuum
-                    image: quay.io/kubearchive/vacuum:v1.21.4
+                    image: quay.io/kubearchive/vacuum:v1.22.1
   # Ensure database is ready before schema-migration job runs
   - patch: |-
       apiVersion: apps/v1


### PR DESCRIPTION
## Summary
- Upgrade kubearchive staging from v1.21.4 to v1.22.1
- Updates `development/kubearchive.yaml` release manifest (images + version labels)
- Bumps vacuum image tags in `development/kustomization.yaml`
- No schema migration version change needed

## Test plan
- [ ] Verify ArgoCD syncs successfully on staging clusters
- [ ] Confirm kubearchive pods start with v1.22.1 images

🤖 Generated with [Claude Code](https://claude.com/claude-code)