### PR TITLE
Update pipelines to next nightly build in dev/staging 5.0.5-830

### DIFF
--- a/components/pipeline-service/development/main-pipeline-service-configuration.yaml
+++ b/components/pipeline-service/development/main-pipeline-service-configuration.yaml
@@ -2243,7 +2243,7 @@ metadata:
   namespace: openshift-marketplace
 spec:
   displayName: custom-operators
-  image: quay.io/openshift-pipeline/pipelines-index-4.18@sha256:7a6ffa6b08f3ec1ef6bf6b704e8d8a07621ec55e3f146779c786d8b174ca9107
+  image: quay.io/openshift-pipeline/pipelines-index-4.18@sha256:a4aa211a70b0a92c98c885cca8fed2cce490e3fec656ad1ea68bf7e7c3c18304
   sourceType: grpc
   updateStrategy:
     registryPoll:

--- a/components/pipeline-service/staging/base/main-pipeline-service-configuration.yaml
+++ b/components/pipeline-service/staging/base/main-pipeline-service-configuration.yaml
@@ -2073,7 +2073,7 @@ metadata:
   namespace: openshift-marketplace
 spec:
   displayName: custom-operators
-  image: quay.io/openshift-pipeline/pipelines-index-4.18@sha256:7a6ffa6b08f3ec1ef6bf6b704e8d8a07621ec55e3f146779c786d8b174ca9107
+  image: quay.io/openshift-pipeline/pipelines-index-4.18@sha256:a4aa211a70b0a92c98c885cca8fed2cce490e3fec656ad1ea68bf7e7c3c18304
   sourceType: grpc
   updateStrategy:
     registryPoll:

--- a/components/pipeline-service/staging/stone-stage-p01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stage-p01/deploy.yaml
@@ -2649,7 +2649,7 @@ metadata:
   namespace: openshift-marketplace
 spec:
   displayName: custom-operators
-  image: quay.io/openshift-pipeline/pipelines-index-4.18@sha256:7a6ffa6b08f3ec1ef6bf6b704e8d8a07621ec55e3f146779c786d8b174ca9107
+  image: quay.io/openshift-pipeline/pipelines-index-4.18@sha256:a4aa211a70b0a92c98c885cca8fed2cce490e3fec656ad1ea68bf7e7c3c18304
   sourceType: grpc
   updateStrategy:
     registryPoll:

--- a/components/pipeline-service/staging/stone-stg-rh01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stg-rh01/deploy.yaml
@@ -2661,7 +2661,7 @@ metadata:
   namespace: openshift-marketplace
 spec:
   displayName: custom-operators
-  image: quay.io/openshift-pipeline/pipelines-index-4.18@sha256:7a6ffa6b08f3ec1ef6bf6b704e8d8a07621ec55e3f146779c786d8b174ca9107
+  image: quay.io/openshift-pipeline/pipelines-index-4.18@sha256:a4aa211a70b0a92c98c885cca8fed2cce490e3fec656ad1ea68bf7e7c3c18304
   sourceType: grpc
   updateStrategy:
     registryPoll:


### PR DESCRIPTION
Update the OpenShift Pipelines OLM catalog index image in dev and staging environments.

v5.0.5-819 → v5.0.5-830

Key changes:
- PAC: v0.46.0 → v0.47.0 (label fixes, reconciler watcher regression fix, CEL extensions, Bitbucket/GitLab fixes)
- Pipeline: release-v1.12.x HEAD (+18 commits, includes generateName fix)
- Chains: CVE-2026-33814 fix (golang.org/x/net HTTP/2)
- CLI: v0.44.1 → v0.45.0
- Pruner: v0.3.5 → v0.4.0

Image: quay.io/openshift-pipeline/pipelines-index-4.18@sha256:a4aa211a70b0a92c98c885cca8fed2cce490e3fec656ad1ea68bf7e7c3c18304