### PR TITLE
Allow konflux-performance group to create SA tokens in production

### DIFF
--- a/components/perf-team-prometheus-reader/production/base/kustomization.yaml
+++ b/components/perf-team-prometheus-reader/production/base/kustomization.yaml
@@ -4,4 +4,5 @@ resources:
   - serviceaccount.yaml
   - serviceaccount-oomcrash.yaml
   - perf-team.yaml
+  - sa-token-rbac.yaml
   - tenants-rbac

--- a/components/perf-team-prometheus-reader/production/base/sa-token-rbac.yaml
+++ b/components/perf-team-prometheus-reader/production/base/sa-token-rbac.yaml
@@ -1,0 +1,29 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: perf-team-sa-token-creator
+  namespace: perf-team-prometheus-reader
+rules:
+  - verbs:
+      - create
+    apiGroups:
+      - ""
+    resources:
+      - serviceaccounts/token
+    resourceNames:
+      - perf-team-prometheus-reader-cluster-sa
+      - perf-team-prometheus-reader-oomcrash-sa
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: perf-team-sa-token-creator
+  namespace: perf-team-prometheus-reader
+subjects:
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: konflux-performance
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: perf-team-sa-token-creator


### PR DESCRIPTION
## Summary
- Backport sa-token-rbac from staging (cdcaa5f) to production, granting the `konflux-performance` group permission to create tokens for `perf-team-prometheus-reader-cluster-sa` and `perf-team-prometheus-reader-oomcrash-sa` service accounts

## Risk Assessment
- **Level:** Low
- **Description:** Identical copy of what has been running in staging since cdcaa5f. Adds narrowly scoped RBAC (create on serviceaccounts/token for two specific SAs) to a single namespace. No existing permissions are modified.
- **Rollback plan:** Revert the PR

## Validation
- Validated in staging since cdcaa5f19dbfcbaec34b34ed4a07cb35d18d3264
- `kustomize build` passes for production overlay

🤖 Generated with [Claude Code](https://claude.com/claude-code)