### PR TITLE
PVO11Y-5244 Add konflux-perfscale-4-tenant namespace for Kanary V1

### DIFF
--- a/components/cluster-secret-store/base/appsre-stonesoup-vault-secret-store.yaml
+++ b/components/cluster-secret-store/base/appsre-stonesoup-vault-secret-store.yaml
@@ -75,5 +75,6 @@ spec:
         - pulp-access-controller
         - konflux-vanguard-tenant
         - konflux-perfscale-1-tenant
+        - konflux-perfscale-4-tenant
         - konflux-kite
         - caching

--- a/components/cluster-secret-store/production/perfscale-namespaces-patch.yaml
+++ b/components/cluster-secret-store/production/perfscale-namespaces-patch.yaml
@@ -5,3 +5,6 @@
 - op: add
   path: /spec/conditions/0/namespaces/-
   value: konflux-perfscale-3-tenant
+- op: add
+  path: /spec/conditions/0/namespaces/-
+  value: konflux-perfscale-4-tenant

--- a/components/cluster-secret-store/staging/rhtap-promotion-staging-patch.yaml
+++ b/components/cluster-secret-store/staging/rhtap-promotion-staging-patch.yaml
@@ -8,3 +8,6 @@
 - op: add
   path: /spec/conditions/0/namespaces/-
   value: konflux-perfscale-3-tenant
+- op: add
+  path: /spec/conditions/0/namespaces/-
+  value: konflux-perfscale-4-tenant

--- a/components/perf-team-prometheus-reader/base/tenants-rbac/konflux-perfscale-4-tenant/kustomization.yaml
+++ b/components/perf-team-prometheus-reader/base/tenants-rbac/konflux-perfscale-4-tenant/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - tenant-rbac.yaml

--- a/components/perf-team-prometheus-reader/base/tenants-rbac/konflux-perfscale-4-tenant/tenant-rbac.yaml
+++ b/components/perf-team-prometheus-reader/base/tenants-rbac/konflux-perfscale-4-tenant/tenant-rbac.yaml
@@ -1,0 +1,24 @@
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: perf-team-event-reader-role
+  namespace: konflux-perfscale-4-tenant
+rules:
+- apiGroups: [""]
+  resources: ["events"]
+  verbs: ["get", "list", "watch"]
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: perf-team-event-reader-binding
+  namespace: konflux-perfscale-4-tenant
+subjects:
+- kind: ServiceAccount
+  name: konflux-bot-0
+  namespace: konflux-perfscale-4-tenant
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: perf-team-event-reader-role

--- a/components/perf-team-prometheus-reader/base/tenants-rbac/kustomization.yaml
+++ b/components/perf-team-prometheus-reader/base/tenants-rbac/kustomization.yaml
@@ -4,3 +4,4 @@ resources:
   - konflux-perfscale-1-tenant
   - konflux-perfscale-2-tenant
   - konflux-perfscale-3-tenant
+  - konflux-perfscale-4-tenant


### PR DESCRIPTION
## Summary
- Add dedicated `konflux-perfscale-4-tenant` namespace for the Kanary V1 Tekton pipeline to avoid race conditions with existing perf&scale load test tenants (1-3)
- Adds RBAC (Role + RoleBinding) for `konflux-bot-0` service account in the new namespace
- Adds the namespace to the cluster secret store (base, staging patch, and production patch)

Jira: https://redhat.atlassian.net/browse/PVO11Y-5244

## Test plan
- [x] `kustomize build components/perf-team-prometheus-reader/base/` passes
- [x] `kustomize build components/cluster-secret-store/base/` passes
- [x] `kustomize build components/cluster-secret-store/staging/` passes
- [x] `kustomize build components/cluster-secret-store/production/` passes