### PR TITLE
KFLUXVNGD-1000 Restructure squid production overlay - ring 1

### DIFF
--- a/argo-cd-apps/base/member/infra-deployments/squid/squid.yaml
+++ b/argo-cd-apps/base/member/infra-deployments/squid/squid.yaml
@@ -17,7 +17,13 @@ spec:
                 environment: staging
                 clusterDir: ""
           - list:
-              elements: []
+              elements:
+                - nameNormalized: kflux-ocp-p01
+                  values.clusterDir: kflux-ocp-p01
+                - nameNormalized: kflux-prd-rh02
+                  values.clusterDir: kflux-prd-rh02
+                - nameNormalized: stone-prod-p01
+                  values.clusterDir: stone-prod-p01
   template:
     metadata:
       name: squid-{{nameNormalized}}

--- a/components/squid/production/kflux-ocp-p01/artifact-registry-credentials.yaml
+++ b/components/squid/production/kflux-ocp-p01/artifact-registry-credentials.yaml
@@ -1,0 +1,22 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: artifact-registry-credentials
+  namespace: caching
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: appsre-stonesoup-vault
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    name: artifact-registry-credentials
+  data:
+    - secretKey: authorization
+      remoteRef:
+        key: production/vanguard/nexus/proxy-sa-1
+        property: authz_header

--- a/components/squid/production/kflux-ocp-p01/kustomization.yaml
+++ b/components/squid/production/kflux-ocp-p01/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../base
+- artifact-registry-credentials.yaml
+
+generators:
+- squid-helm-generator.yaml

--- a/components/squid/production/kflux-ocp-p01/squid-helm-generator.yaml
+++ b/components/squid/production/kflux-ocp-p01/squid-helm-generator.yaml
@@ -1,0 +1,101 @@
+apiVersion: builtin
+kind: HelmChartInflationGenerator
+metadata:
+  name: squid-helm
+name: squid-helm
+repo: oci://quay.io/konflux-ci/caching
+version: 0.1.1506+abe1045
+valuesInline:
+  installCertManagerComponents: false
+  mirrord:
+    enabled: false
+  nginx:
+    enabled: true
+    replicaCount: 3
+    name: artifact-registry-proxy
+    tls:
+      enabled: true
+      secretName: artifact-registry-proxy-tls
+    service:
+      port: 443
+      annotations:
+        service.beta.openshift.io/serving-cert-secret-name: artifact-registry-proxy-tls
+    upstream:
+      url: https://red-hat.repo.sonatype.app
+    auth:
+      enabled: true
+      secretName: artifact-registry-credentials
+    cache:
+      allowList:
+        # Cache all traffic to nexus repositories
+        - ^/repository/
+      size: 51200
+    resources:
+      requests:
+        cpu: "2"
+        memory: 2Gi
+      limits:
+        cpu: "2"
+        memory: 2Gi
+  test:
+    enabled: false
+  cert-manager:
+    enabled: false
+  environment: release
+  replicaCount: 3
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 200m
+      memory: 2Gi
+  icapServer:
+    resources:
+      requests:
+        cpu: 10m
+        memory: 32Mi
+      limits:
+        cpu: 100m
+        memory: 128Mi
+  squidExporter:
+    resources:
+      requests:
+        cpu: 10m
+        memory: 16Mi
+      limits:
+        cpu: 100m
+        memory: 64Mi
+  cache:
+    allowList:
+      - ^https://cdn([0-9]{2})?\.quay\.io/.+/sha256/.+/[a-f0-9]{64}
+      - ^https://s3\.[a-z0-9-]+\.amazonaws\.com/quayio-production-s3/sha256/.+/[a-f0-9]{64}
+      - ^https://quayio-production-s3\.s3[a-z0-9.-]*\.amazonaws\.com/sha256/.+/[a-f0-9]{64}
+      - ^https://production\.cloudflare\.docker\.com/registry-v2/docker/registry/v2/blobs/sha256/[a-f0-9]{2}/[a-f0-9]{64}/data
+      - ^https://docker-images-prod\.[a-f0-9]{32}\.r2\.cloudflarestorage\.com/registry-v2/docker/registry/v2/blobs/sha256/[a-f0-9]{2}/[a-f0-9]{64}/data
+      - ^https://docker-images-prod\.s3[a-z0-9.-]*\.amazonaws\.com/registry-v2/docker/registry/v2/blobs/sha256/[a-f0-9]{2}/[a-f0-9]{64}/data
+      - ^https://cdn\.registry\.fedoraproject\.org/v2/.+/blobs/sha256:[a-f0-9]{64}
+      - ^https://[a-f0-9]{32}\.r2\.cloudflarestorage\.com/app-ci-image-registry/docker/registry/v2/blobs/sha256/[a-f0-9]{2}/[a-f0-9]{64}/data
+      - ^https://layers\.nvcr\.io/registry/docker/registry/v2/blobs/sha256/[a-f0-9]{2}/[a-f0-9]{64}/data
+      - ^https://[a-z0-9]+\.cloudfront\.net/sha256/[a-f0-9]{2}/[a-f0-9]{64}
+    size: 51200
+    maxObjectSize: 1024
+  prometheus:
+    serviceMonitor:
+      nginxTLS:
+        ca:
+          configMapName: openshift-service-ca.crt
+          key: service-ca.crt
+  tlsOutgoingOptions:
+    caFile: /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
+  volumes:
+    - name: trusted-ca
+      configMap:
+        name: trusted-ca
+        items:
+          - key: ca-bundle.crt
+            path: tls-ca-bundle.pem
+  volumeMounts:
+    - name: trusted-ca
+      mountPath: /etc/pki/ca-trust/extracted/pem
+      readOnly: true

--- a/components/squid/production/kflux-prd-rh02/artifact-registry-credentials.yaml
+++ b/components/squid/production/kflux-prd-rh02/artifact-registry-credentials.yaml
@@ -1,0 +1,22 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: artifact-registry-credentials
+  namespace: caching
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: appsre-stonesoup-vault
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    name: artifact-registry-credentials
+  data:
+    - secretKey: authorization
+      remoteRef:
+        key: production/vanguard/nexus/proxy-sa-1
+        property: authz_header

--- a/components/squid/production/kflux-prd-rh02/kustomization.yaml
+++ b/components/squid/production/kflux-prd-rh02/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../base
+- artifact-registry-credentials.yaml
+
+generators:
+- squid-helm-generator.yaml

--- a/components/squid/production/kflux-prd-rh02/squid-helm-generator.yaml
+++ b/components/squid/production/kflux-prd-rh02/squid-helm-generator.yaml
@@ -1,0 +1,101 @@
+apiVersion: builtin
+kind: HelmChartInflationGenerator
+metadata:
+  name: squid-helm
+name: squid-helm
+repo: oci://quay.io/konflux-ci/caching
+version: 0.1.1506+abe1045
+valuesInline:
+  installCertManagerComponents: false
+  mirrord:
+    enabled: false
+  nginx:
+    enabled: true
+    replicaCount: 3
+    name: artifact-registry-proxy
+    tls:
+      enabled: true
+      secretName: artifact-registry-proxy-tls
+    service:
+      port: 443
+      annotations:
+        service.beta.openshift.io/serving-cert-secret-name: artifact-registry-proxy-tls
+    upstream:
+      url: https://red-hat.repo.sonatype.app
+    auth:
+      enabled: true
+      secretName: artifact-registry-credentials
+    cache:
+      allowList:
+        # Cache all traffic to nexus repositories
+        - ^/repository/
+      size: 51200
+    resources:
+      requests:
+        cpu: "2"
+        memory: 2Gi
+      limits:
+        cpu: "2"
+        memory: 2Gi
+  test:
+    enabled: false
+  cert-manager:
+    enabled: false
+  environment: release
+  replicaCount: 3
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 200m
+      memory: 2Gi
+  icapServer:
+    resources:
+      requests:
+        cpu: 10m
+        memory: 32Mi
+      limits:
+        cpu: 100m
+        memory: 128Mi
+  squidExporter:
+    resources:
+      requests:
+        cpu: 10m
+        memory: 16Mi
+      limits:
+        cpu: 100m
+        memory: 64Mi
+  cache:
+    allowList:
+      - ^https://cdn([0-9]{2})?\.quay\.io/.+/sha256/.+/[a-f0-9]{64}
+      - ^https://s3\.[a-z0-9-]+\.amazonaws\.com/quayio-production-s3/sha256/.+/[a-f0-9]{64}
+      - ^https://quayio-production-s3\.s3[a-z0-9.-]*\.amazonaws\.com/sha256/.+/[a-f0-9]{64}
+      - ^https://production\.cloudflare\.docker\.com/registry-v2/docker/registry/v2/blobs/sha256/[a-f0-9]{2}/[a-f0-9]{64}/data
+      - ^https://docker-images-prod\.[a-f0-9]{32}\.r2\.cloudflarestorage\.com/registry-v2/docker/registry/v2/blobs/sha256/[a-f0-9]{2}/[a-f0-9]{64}/data
+      - ^https://docker-images-prod\.s3[a-z0-9.-]*\.amazonaws\.com/registry-v2/docker/registry/v2/blobs/sha256/[a-f0-9]{2}/[a-f0-9]{64}/data
+      - ^https://cdn\.registry\.fedoraproject\.org/v2/.+/blobs/sha256:[a-f0-9]{64}
+      - ^https://[a-f0-9]{32}\.r2\.cloudflarestorage\.com/app-ci-image-registry/docker/registry/v2/blobs/sha256/[a-f0-9]{2}/[a-f0-9]{64}/data
+      - ^https://layers\.nvcr\.io/registry/docker/registry/v2/blobs/sha256/[a-f0-9]{2}/[a-f0-9]{64}/data
+      - ^https://[a-z0-9]+\.cloudfront\.net/sha256/[a-f0-9]{2}/[a-f0-9]{64}
+    size: 51200
+    maxObjectSize: 1024
+  prometheus:
+    serviceMonitor:
+      nginxTLS:
+        ca:
+          configMapName: openshift-service-ca.crt
+          key: service-ca.crt
+  tlsOutgoingOptions:
+    caFile: /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
+  volumes:
+    - name: trusted-ca
+      configMap:
+        name: trusted-ca
+        items:
+          - key: ca-bundle.crt
+            path: tls-ca-bundle.pem
+  volumeMounts:
+    - name: trusted-ca
+      mountPath: /etc/pki/ca-trust/extracted/pem
+      readOnly: true

--- a/components/squid/production/stone-prod-p01/artifact-registry-credentials.yaml
+++ b/components/squid/production/stone-prod-p01/artifact-registry-credentials.yaml
@@ -1,0 +1,22 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: artifact-registry-credentials
+  namespace: caching
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: appsre-stonesoup-vault
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    name: artifact-registry-credentials
+  data:
+    - secretKey: authorization
+      remoteRef:
+        key: production/vanguard/nexus/proxy-sa-1
+        property: authz_header

--- a/components/squid/production/stone-prod-p01/kustomization.yaml
+++ b/components/squid/production/stone-prod-p01/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../base
+- artifact-registry-credentials.yaml
+
+generators:
+- squid-helm-generator.yaml

--- a/components/squid/production/stone-prod-p01/squid-helm-generator.yaml
+++ b/components/squid/production/stone-prod-p01/squid-helm-generator.yaml
@@ -1,0 +1,101 @@
+apiVersion: builtin
+kind: HelmChartInflationGenerator
+metadata:
+  name: squid-helm
+name: squid-helm
+repo: oci://quay.io/konflux-ci/caching
+version: 0.1.1506+abe1045
+valuesInline:
+  installCertManagerComponents: false
+  mirrord:
+    enabled: false
+  nginx:
+    enabled: true
+    replicaCount: 3
+    name: artifact-registry-proxy
+    tls:
+      enabled: true
+      secretName: artifact-registry-proxy-tls
+    service:
+      port: 443
+      annotations:
+        service.beta.openshift.io/serving-cert-secret-name: artifact-registry-proxy-tls
+    upstream:
+      url: https://red-hat.repo.sonatype.app
+    auth:
+      enabled: true
+      secretName: artifact-registry-credentials
+    cache:
+      allowList:
+        # Cache all traffic to nexus repositories
+        - ^/repository/
+      size: 51200
+    resources:
+      requests:
+        cpu: "2"
+        memory: 2Gi
+      limits:
+        cpu: "2"
+        memory: 2Gi
+  test:
+    enabled: false
+  cert-manager:
+    enabled: false
+  environment: release
+  replicaCount: 3
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 200m
+      memory: 2Gi
+  icapServer:
+    resources:
+      requests:
+        cpu: 10m
+        memory: 32Mi
+      limits:
+        cpu: 100m
+        memory: 128Mi
+  squidExporter:
+    resources:
+      requests:
+        cpu: 10m
+        memory: 16Mi
+      limits:
+        cpu: 100m
+        memory: 64Mi
+  cache:
+    allowList:
+      - ^https://cdn([0-9]{2})?\.quay\.io/.+/sha256/.+/[a-f0-9]{64}
+      - ^https://s3\.[a-z0-9-]+\.amazonaws\.com/quayio-production-s3/sha256/.+/[a-f0-9]{64}
+      - ^https://quayio-production-s3\.s3[a-z0-9.-]*\.amazonaws\.com/sha256/.+/[a-f0-9]{64}
+      - ^https://production\.cloudflare\.docker\.com/registry-v2/docker/registry/v2/blobs/sha256/[a-f0-9]{2}/[a-f0-9]{64}/data
+      - ^https://docker-images-prod\.[a-f0-9]{32}\.r2\.cloudflarestorage\.com/registry-v2/docker/registry/v2/blobs/sha256/[a-f0-9]{2}/[a-f0-9]{64}/data
+      - ^https://docker-images-prod\.s3[a-z0-9.-]*\.amazonaws\.com/registry-v2/docker/registry/v2/blobs/sha256/[a-f0-9]{2}/[a-f0-9]{64}/data
+      - ^https://cdn\.registry\.fedoraproject\.org/v2/.+/blobs/sha256:[a-f0-9]{64}
+      - ^https://[a-f0-9]{32}\.r2\.cloudflarestorage\.com/app-ci-image-registry/docker/registry/v2/blobs/sha256/[a-f0-9]{2}/[a-f0-9]{64}/data
+      - ^https://layers\.nvcr\.io/registry/docker/registry/v2/blobs/sha256/[a-f0-9]{2}/[a-f0-9]{64}/data
+      - ^https://[a-z0-9]+\.cloudfront\.net/sha256/[a-f0-9]{2}/[a-f0-9]{64}
+    size: 51200
+    maxObjectSize: 1024
+  prometheus:
+    serviceMonitor:
+      nginxTLS:
+        ca:
+          configMapName: openshift-service-ca.crt
+          key: service-ca.crt
+  tlsOutgoingOptions:
+    caFile: /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
+  volumes:
+    - name: trusted-ca
+      configMap:
+        name: trusted-ca
+        items:
+          - key: ca-bundle.crt
+            path: tls-ca-bundle.pem
+  volumeMounts:
+    - name: trusted-ca
+      mountPath: /etc/pki/ca-trust/extracted/pem
+      readOnly: true


### PR DESCRIPTION
## Summary
- Add per-cluster production overlays for set 1 clusters: kflux-ocp-p01, kflux-prd-rh02, stone-prod-p01
- Each overlay is self-contained with its own helm generator and credentials (follows kyverno pattern)
- Existing flat production files are kept — unmigrated clusters continue deploying from them
- Update ApplicationSet to route set 1 clusters to their per-cluster overlays

Other clusters update will follow in subsequent PRs. No functional change — set 1 clusters deploy identical config via their own overlay instead of the shared flat directory.

Assisted-by: Claude Code

## Risk Assessment
- **Level:** Low
- **Description:** Set 1 clusters switch from `production/` to `production/<cluster>/` but the rendered manifests are identical (verified via kustomize build checksum). Remaining clusters are unaffected.
- **Rollback plan:** Revert the PR

## Validation
- `kustomize build --enable-helm` verified for all 3 set 1 overlays — identical output to flat production (md5: `3d15b6f7b3e884a2b60c3f94e20a1603`)
- Flat `production/` still builds correctly for unmigrated clusters