### PR TITLE
hack: replace appstudio-utils image w/ task-runner

### DIFF
--- a/hack/new-cluster/tasks/variables.yaml
+++ b/hack/new-cluster/tasks/variables.yaml
@@ -33,6 +33,6 @@
   include_tasks: tasks/quay/find-digest.yaml
   vars:
     registry: quay.io
-    repo: konflux-ci/appstudio-utils
+    repo: konflux-ci/task-runner
     tag: "{{ commit_id_build_definitions }}"
     varname: quay_digest_build_definitions

--- a/hack/new-cluster/templates/konflux-ui/configure-oauth-proxy-secret.yaml
+++ b/hack/new-cluster/templates/konflux-ui/configure-oauth-proxy-secret.yaml
@@ -103,7 +103,7 @@ spec:
             echo "skipping dex restart"
           fi
 
-        image: quay.io/konflux-ci/appstudio-utils:{{ commit_id_build_definitions }}@{{ quay_digest_build_definitions }}
+        image: quay.io/konflux-ci/task-runner:{{ commit_id_build_definitions }}@{{ quay_digest_build_definitions }}
         imagePullPolicy: Always
         name: konflux-oauth-client-secret-generation
         resources:


### PR DESCRIPTION
The `quay.io/konflux-ci/appstudio-utils` image is being deprecated in favor of `quay.io/konflux-ci/task-runner`, so let's use that instead.

Fixes: [KFLUXINFRA-3808](https://redhat.atlassian.net/browse/KFLUXINFRA-3808)

[KFLUXINFRA-3808]: https://redhat.atlassian.net/browse/KFLUXINFRA-3808?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ