### PR TITLE
feat(KFLUXVNGD-1022): add operator changelog workflow and placeholder comment

### DIFF
--- a/.github/workflows/operator-changelog.yaml
+++ b/.github/workflows/operator-changelog.yaml
@@ -1,0 +1,39 @@
+name: Operator Changelog
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+    paths:
+      - 'components/konflux-operator/development/invariant/kustomization.yaml'
+
+jobs:
+  changelog:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: operator-changelog-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
+    permissions:
+      pull-requests: write
+      contents: read
+    steps:
+      # Check out the BASE branch (trusted code) so we never execute fork code.
+      # The binary is built here with the elevated GITHUB_TOKEN — a malicious
+      # fork cannot inject code into this step.
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: infra-tools/go.mod
+          cache-dependency-path: infra-tools/go.sum
+
+      - name: Build changelog-generator
+        working-directory: infra-tools
+        run: go build -o bin/changelog-generator ./cmd/changelog-generator
+
+      - name: Run changelog-generator
+        working-directory: infra-tools
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: ./bin/changelog-generator

--- a/infra-tools/Makefile
+++ b/infra-tools/Makefile
@@ -58,6 +58,7 @@ lint-fix: golangci-lint ## Run golangci-lint linter and perform fixes.
 build: fmt vet ## Build all binaries.
 	go build -o $(LOCALBIN)/env-detector ./cmd/env-detector
 	go build -o $(LOCALBIN)/render-diff ./cmd/render-diff
+	go build -o $(LOCALBIN)/changelog-generator ./cmd/changelog-generator
 
 .PHONY: clean
 clean: ## Remove build artifacts.

--- a/infra-tools/cmd/changelog-generator/main.go
+++ b/infra-tools/cmd/changelog-generator/main.go
@@ -1,0 +1,81 @@
+// Command changelog-generator posts a changelog comment on infra-deployments PRs
+// that bump the Konflux operator SHA.
+//
+// This is the initial placeholder (KFLUXVNGD-1022). It proves the workflow
+// trigger and comment pipeline work end-to-end on real PRs before any
+// changelog logic is added. SHA extraction, upstream comparison, and full
+// formatting are introduced in subsequent PRs.
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/signal"
+	"syscall"
+
+	ghclient "github.com/redhat-appstudio/infra-deployments/infra-tools/internal/github"
+)
+
+// commentMarker identifies the changelog comment for idempotent updates.
+// This string is permanent — changing it would orphan existing comments on
+// open PRs. It moves to internal/changelog/formatter.go in a later PR;
+// the string itself never changes.
+const commentMarker = "<!-- changelog-generator-comment -->"
+
+// commenter is the subset of the GitHub comment API used by this binary.
+// Defined as an interface so tests can inject a fake without network calls.
+type commenter interface {
+	UpsertCommentByMarker(ctx context.Context, prNumber int, body, marker string) error
+}
+
+func main() {
+	dryRun := flag.Bool("dry-run", false, "Print comment to stdout instead of posting")
+	flag.Parse()
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	token := os.Getenv("GITHUB_TOKEN")
+	repo := os.Getenv("GITHUB_REPOSITORY")
+	prStr := os.Getenv("PR_NUMBER")
+
+	body := commentMarker + "\n### Operator Changelog\n\n" +
+		"_This comment will show operator commits and upstream service changes in upcoming PRs._\n"
+
+	if *dryRun {
+		fmt.Print(body)
+		return
+	}
+
+	if token == "" || repo == "" || prStr == "" {
+		slog.Error("missing required env vars", "GITHUB_TOKEN_set", token != "", "GITHUB_REPOSITORY_set", repo != "", "PR_NUMBER_set", prStr != "")
+		os.Exit(1)
+	}
+
+	prNumber := 0
+	if _, err := fmt.Sscanf(prStr, "%d", &prNumber); err != nil || prNumber == 0 {
+		slog.Error("invalid PR number", "pr", prStr)
+		os.Exit(1)
+	}
+
+	client, err := ghclient.NewCommentClient(token, repo)
+	if err != nil {
+		slog.Error("creating GitHub client", "err", err)
+		os.Exit(1)
+	}
+
+	if err := post(ctx, client, prNumber, body); err != nil {
+		slog.Error("posting PR comment", "err", err)
+		os.Exit(1)
+	}
+}
+
+// post delivers body as a PR comment using the provided commenter.
+// Keeping the commenter as an injected interface allows tests to verify
+// the correct body and PR number are passed without making real API calls.
+func post(ctx context.Context, c commenter, prNumber int, body string) error {
+	return c.UpsertCommentByMarker(ctx, prNumber, body, commentMarker)
+}

--- a/infra-tools/internal/github/comments.go
+++ b/infra-tools/internal/github/comments.go
@@ -2,6 +2,7 @@ package github
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"strings"
@@ -44,14 +45,23 @@ func NewCommentClient(token, repoFullName string) (*CommentClient, error) {
 // UpsertComment creates or updates a PR comment identified by CommentMarker.
 // If a comment with the marker exists, it is updated; otherwise a new comment is created.
 func (c *CommentClient) UpsertComment(ctx context.Context, prNumber int, body string) error {
-	// Find existing comment
-	existingID, err := c.findMarkedComment(ctx, prNumber)
+	return c.UpsertCommentByMarker(ctx, prNumber, body, CommentMarker)
+}
+
+// UpsertCommentByMarker creates or updates a PR comment identified by the
+// given marker string. This allows multiple tools to each maintain their own
+// idempotent comment on the same PR without interfering with each other.
+func (c *CommentClient) UpsertCommentByMarker(ctx context.Context, prNumber int, body, marker string) error {
+	if marker == "" {
+		return errors.New("marker must not be empty")
+	}
+	existingID, err := c.findCommentByMarker(ctx, prNumber, marker)
 	if err != nil {
 		return fmt.Errorf("finding existing comment: %w", err)
 	}
 
 	if existingID != 0 {
-		slog.Info("Updating existing render-diff comment", "comment_id", existingID)
+		slog.Info("Updating existing comment", "marker", marker, "comment_id", existingID)
 		_, _, err = c.comments.EditComment(ctx, c.owner, c.repo, existingID, &gh.IssueComment{
 			Body: gh.Ptr(body),
 		})
@@ -61,7 +71,7 @@ func (c *CommentClient) UpsertComment(ctx context.Context, prNumber int, body st
 		return nil
 	}
 
-	slog.Info("Creating new render-diff comment")
+	slog.Info("Creating new comment", "marker", marker)
 	_, _, err = c.comments.CreateComment(ctx, c.owner, c.repo, prNumber, &gh.IssueComment{
 		Body: gh.Ptr(body),
 	})
@@ -71,8 +81,8 @@ func (c *CommentClient) UpsertComment(ctx context.Context, prNumber int, body st
 	return nil
 }
 
-// findMarkedComment searches for a comment containing the CommentMarker.
-func (c *CommentClient) findMarkedComment(ctx context.Context, prNumber int) (int64, error) {
+// findCommentByMarker searches PR comments for one containing the given marker string.
+func (c *CommentClient) findCommentByMarker(ctx context.Context, prNumber int, marker string) (int64, error) {
 	opts := &gh.IssueListCommentsOptions{
 		ListOptions: gh.ListOptions{PerPage: 100},
 	}
@@ -82,7 +92,7 @@ func (c *CommentClient) findMarkedComment(ctx context.Context, prNumber int) (in
 			return 0, err
 		}
 		for _, comment := range comments {
-			if comment.Body != nil && strings.Contains(*comment.Body, CommentMarker) {
+			if comment.Body != nil && strings.Contains(*comment.Body, marker) {
 				return comment.GetID(), nil
 			}
 		}

--- a/infra-tools/internal/github/comments_test.go
+++ b/infra-tools/internal/github/comments_test.go
@@ -93,3 +93,65 @@ func TestUpsertComment_IgnoresUnrelatedComments(t *testing.T) {
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(fake.created).To(HaveLen(1)) // created new, didn't update existing
 }
+
+// --- UpsertCommentByMarker ---
+
+func TestUpsertCommentByMarker_CreatesWithCustomMarker(t *testing.T) {
+	g := NewWithT(t)
+
+	fake := newFakeCommentsService()
+	client := &CommentClient{comments: fake, owner: "org", repo: "repo"}
+
+	const myMarker = "<!-- my-tool-comment -->"
+	body := myMarker + "\nhello from my tool"
+	err := client.UpsertCommentByMarker(context.Background(), 1, body, myMarker)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(fake.created).To(HaveLen(1))
+	g.Expect(*fake.created[0].Body).To(Equal(body))
+}
+
+func TestUpsertCommentByMarker_UpdatesExistingWithCustomMarker(t *testing.T) {
+	g := NewWithT(t)
+
+	fake := newFakeCommentsService()
+	const myMarker = "<!-- my-tool-comment -->"
+	fake.comments = []*gh.IssueComment{
+		{ID: gh.Ptr(int64(7)), Body: gh.Ptr(myMarker + "\nold content")},
+	}
+	client := &CommentClient{comments: fake, owner: "org", repo: "repo"}
+
+	updated := myMarker + "\nnew content"
+	err := client.UpsertCommentByMarker(context.Background(), 1, updated, myMarker)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(fake.created).To(BeEmpty())
+	g.Expect(fake.edited).To(HaveKey(int64(7)))
+	g.Expect(*fake.edited[7].Body).To(Equal(updated))
+}
+
+func TestUpsertCommentByMarker_DoesNotMatchDifferentMarker(t *testing.T) {
+	g := NewWithT(t)
+
+	// Two tools each post with their own marker — they must not interfere.
+	fake := newFakeCommentsService()
+	fake.comments = []*gh.IssueComment{
+		{ID: gh.Ptr(int64(1)), Body: gh.Ptr("<!-- tool-a-comment -->\ntool A content")},
+	}
+	client := &CommentClient{comments: fake, owner: "org", repo: "repo"}
+
+	// Tool B posts with its own marker — should create, not update tool A's comment.
+	err := client.UpsertCommentByMarker(context.Background(), 1, "<!-- tool-b-comment -->\ntool B", "<!-- tool-b-comment -->")
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(fake.created).To(HaveLen(1))
+	g.Expect(fake.edited).To(BeEmpty())
+}
+
+func TestUpsertCommentByMarker_RejectsEmptyMarker(t *testing.T) {
+	g := NewWithT(t)
+
+	fake := newFakeCommentsService()
+	client := &CommentClient{comments: fake, owner: "org", repo: "repo"}
+
+	err := client.UpsertCommentByMarker(context.Background(), 1, "body", "")
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("marker must not be empty"))
+}


### PR DESCRIPTION
Adds the changelog-generator workflow and a minimal binary that posts a placeholder comment on any PR that bumps the operator SHA, proving the trigger-to-comment pipeline before changelog logic is added in subsequent PRs.