### PR TITLE
Upgrade MCE to 2.11 for EaaS in dev and staging

### DIFF
--- a/components/cluster-as-a-service/development/add-hypershift-params.yaml
+++ b/components/cluster-as-a-service/development/add-hypershift-params.yaml
@@ -9,7 +9,7 @@
   path: /spec/template/spec/source/helm/parameters/-
   value:
     name: hypershiftImage
-    value: registry.redhat.io/multicluster-engine/hypershift-rhel9-operator:v2.10@sha256:1cceec46246ea7bef481549dce1ce91880d19a5650c9a6bc0f71f0d4092a6f95
+    value: registry.redhat.io/multicluster-engine/hypershift-rhel9-operator:v2.11@sha256:44df0f376c6dbc3d4dee359198218c6d19ff78199e114976af593afd3c43dd04
 
 - op: add
   path: /spec/template/spec/source/helm/parameters/-

--- a/components/cluster-as-a-service/development/kustomization.yaml
+++ b/components/cluster-as-a-service/development/kustomization.yaml
@@ -20,4 +20,4 @@ patches:
     patch: |-
       - op: replace
         path: /spec/channel
-        value: stable-2.10
+        value: stable-2.11

--- a/components/cluster-as-a-service/staging/add-hypershift-params.yaml
+++ b/components/cluster-as-a-service/staging/add-hypershift-params.yaml
@@ -9,7 +9,7 @@
   path: /spec/template/spec/source/helm/parameters/-
   value:
     name: hypershiftImage
-    value: registry.redhat.io/multicluster-engine/hypershift-rhel9-operator:v2.10@sha256:1cceec46246ea7bef481549dce1ce91880d19a5650c9a6bc0f71f0d4092a6f95
+    value: registry.redhat.io/multicluster-engine/hypershift-rhel9-operator:v2.11@sha256:44df0f376c6dbc3d4dee359198218c6d19ff78199e114976af593afd3c43dd04
 
 - op: add
   path: /spec/template/spec/source/helm/parameters/-

--- a/components/cluster-as-a-service/staging/kustomization.yaml
+++ b/components/cluster-as-a-service/staging/kustomization.yaml
@@ -17,4 +17,4 @@ patches:
     patch: |-
       - op: replace
         path: /spec/channel
-        value: stable-2.10
+        value: stable-2.11


### PR DESCRIPTION
## Summary
- Upgrade MCE operator subscription channel from `stable-2.10` to `stable-2.11` in dev and staging
- Update `hypershift-rhel9-operator` image to `v2.11` with pinned digest
- This enables provisioning OCP 4.21 HyperShift clusters per the [MCE 2.11 support matrix](https://access.redhat.com/articles/7136929)

## Changes
- `development/kustomization.yaml` — MCE channel `stable-2.10` → `stable-2.11`
- `staging/kustomization.yaml` — MCE channel `stable-2.10` → `stable-2.11`
- `development/add-hypershift-params.yaml` — hypershift image `v2.10` → `v2.11`
- `staging/add-hypershift-params.yaml` — hypershift image `v2.10` → `v2.11`

## Validation
- Image digest verified via `skopeo inspect` against `registry.redhat.io`
- Chart version (`0.1.9`) unchanged — already at latest
- Production upgrade will follow in a separate PR after dev/staging validation

JIRA: https://redhat.atlassian.net/browse/KFLUXVNGD-1023
Assisted-by: Claude Code