### PR TITLE
KFLUXVNGD-1024 Restructure squid production overlay - ring 2

### DIFF
--- a/argo-cd-apps/base/member/infra-deployments/squid/squid.yaml
+++ b/argo-cd-apps/base/member/infra-deployments/squid/squid.yaml
@@ -24,6 +24,12 @@ spec:
                   values.clusterDir: kflux-prd-rh02
                 - nameNormalized: stone-prod-p01
                   values.clusterDir: stone-prod-p01
+                - nameNormalized: kflux-osp-p01
+                  values.clusterDir: kflux-osp-p01
+                - nameNormalized: kflux-prd-rh03
+                  values.clusterDir: kflux-prd-rh03
+                - nameNormalized: stone-prod-p02
+                  values.clusterDir: stone-prod-p02
   template:
     metadata:
       name: squid-{{nameNormalized}}

--- a/components/squid/production/kflux-osp-p01/artifact-registry-credentials.yaml
+++ b/components/squid/production/kflux-osp-p01/artifact-registry-credentials.yaml
@@ -1,0 +1,22 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: artifact-registry-credentials
+  namespace: caching
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: appsre-stonesoup-vault
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    name: artifact-registry-credentials
+  data:
+    - secretKey: authorization
+      remoteRef:
+        key: production/vanguard/nexus/proxy-sa-1
+        property: authz_header

--- a/components/squid/production/kflux-osp-p01/kustomization.yaml
+++ b/components/squid/production/kflux-osp-p01/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../base
+- artifact-registry-credentials.yaml
+
+generators:
+- squid-helm-generator.yaml

--- a/components/squid/production/kflux-osp-p01/squid-helm-generator.yaml
+++ b/components/squid/production/kflux-osp-p01/squid-helm-generator.yaml
@@ -1,0 +1,101 @@
+apiVersion: builtin
+kind: HelmChartInflationGenerator
+metadata:
+  name: squid-helm
+name: squid-helm
+repo: oci://quay.io/konflux-ci/caching
+version: 0.1.1506+abe1045
+valuesInline:
+  installCertManagerComponents: false
+  mirrord:
+    enabled: false
+  nginx:
+    enabled: true
+    replicaCount: 3
+    name: artifact-registry-proxy
+    tls:
+      enabled: true
+      secretName: artifact-registry-proxy-tls
+    service:
+      port: 443
+      annotations:
+        service.beta.openshift.io/serving-cert-secret-name: artifact-registry-proxy-tls
+    upstream:
+      url: https://red-hat.repo.sonatype.app
+    auth:
+      enabled: true
+      secretName: artifact-registry-credentials
+    cache:
+      allowList:
+        # Cache all traffic to nexus repositories
+        - ^/repository/
+      size: 51200
+    resources:
+      requests:
+        cpu: "2"
+        memory: 2Gi
+      limits:
+        cpu: "2"
+        memory: 2Gi
+  test:
+    enabled: false
+  cert-manager:
+    enabled: false
+  environment: release
+  replicaCount: 3
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 200m
+      memory: 2Gi
+  icapServer:
+    resources:
+      requests:
+        cpu: 10m
+        memory: 32Mi
+      limits:
+        cpu: 100m
+        memory: 128Mi
+  squidExporter:
+    resources:
+      requests:
+        cpu: 10m
+        memory: 16Mi
+      limits:
+        cpu: 100m
+        memory: 64Mi
+  cache:
+    allowList:
+      - ^https://cdn([0-9]{2})?\.quay\.io/.+/sha256/.+/[a-f0-9]{64}
+      - ^https://s3\.[a-z0-9-]+\.amazonaws\.com/quayio-production-s3/sha256/.+/[a-f0-9]{64}
+      - ^https://quayio-production-s3\.s3[a-z0-9.-]*\.amazonaws\.com/sha256/.+/[a-f0-9]{64}
+      - ^https://production\.cloudflare\.docker\.com/registry-v2/docker/registry/v2/blobs/sha256/[a-f0-9]{2}/[a-f0-9]{64}/data
+      - ^https://docker-images-prod\.[a-f0-9]{32}\.r2\.cloudflarestorage\.com/registry-v2/docker/registry/v2/blobs/sha256/[a-f0-9]{2}/[a-f0-9]{64}/data
+      - ^https://docker-images-prod\.s3[a-z0-9.-]*\.amazonaws\.com/registry-v2/docker/registry/v2/blobs/sha256/[a-f0-9]{2}/[a-f0-9]{64}/data
+      - ^https://cdn\.registry\.fedoraproject\.org/v2/.+/blobs/sha256:[a-f0-9]{64}
+      - ^https://[a-f0-9]{32}\.r2\.cloudflarestorage\.com/app-ci-image-registry/docker/registry/v2/blobs/sha256/[a-f0-9]{2}/[a-f0-9]{64}/data
+      - ^https://layers\.nvcr\.io/registry/docker/registry/v2/blobs/sha256/[a-f0-9]{2}/[a-f0-9]{64}/data
+      - ^https://[a-z0-9]+\.cloudfront\.net/sha256/[a-f0-9]{2}/[a-f0-9]{64}
+    size: 51200
+    maxObjectSize: 1024
+  prometheus:
+    serviceMonitor:
+      nginxTLS:
+        ca:
+          configMapName: openshift-service-ca.crt
+          key: service-ca.crt
+  tlsOutgoingOptions:
+    caFile: /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
+  volumes:
+    - name: trusted-ca
+      configMap:
+        name: trusted-ca
+        items:
+          - key: ca-bundle.crt
+            path: tls-ca-bundle.pem
+  volumeMounts:
+    - name: trusted-ca
+      mountPath: /etc/pki/ca-trust/extracted/pem
+      readOnly: true

--- a/components/squid/production/kflux-prd-rh03/artifact-registry-credentials.yaml
+++ b/components/squid/production/kflux-prd-rh03/artifact-registry-credentials.yaml
@@ -1,0 +1,22 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: artifact-registry-credentials
+  namespace: caching
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: appsre-stonesoup-vault
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    name: artifact-registry-credentials
+  data:
+    - secretKey: authorization
+      remoteRef:
+        key: production/vanguard/nexus/proxy-sa-1
+        property: authz_header

--- a/components/squid/production/kflux-prd-rh03/kustomization.yaml
+++ b/components/squid/production/kflux-prd-rh03/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../base
+- artifact-registry-credentials.yaml
+
+generators:
+- squid-helm-generator.yaml

--- a/components/squid/production/kflux-prd-rh03/squid-helm-generator.yaml
+++ b/components/squid/production/kflux-prd-rh03/squid-helm-generator.yaml
@@ -1,0 +1,101 @@
+apiVersion: builtin
+kind: HelmChartInflationGenerator
+metadata:
+  name: squid-helm
+name: squid-helm
+repo: oci://quay.io/konflux-ci/caching
+version: 0.1.1506+abe1045
+valuesInline:
+  installCertManagerComponents: false
+  mirrord:
+    enabled: false
+  nginx:
+    enabled: true
+    replicaCount: 3
+    name: artifact-registry-proxy
+    tls:
+      enabled: true
+      secretName: artifact-registry-proxy-tls
+    service:
+      port: 443
+      annotations:
+        service.beta.openshift.io/serving-cert-secret-name: artifact-registry-proxy-tls
+    upstream:
+      url: https://red-hat.repo.sonatype.app
+    auth:
+      enabled: true
+      secretName: artifact-registry-credentials
+    cache:
+      allowList:
+        # Cache all traffic to nexus repositories
+        - ^/repository/
+      size: 51200
+    resources:
+      requests:
+        cpu: "2"
+        memory: 2Gi
+      limits:
+        cpu: "2"
+        memory: 2Gi
+  test:
+    enabled: false
+  cert-manager:
+    enabled: false
+  environment: release
+  replicaCount: 3
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 200m
+      memory: 2Gi
+  icapServer:
+    resources:
+      requests:
+        cpu: 10m
+        memory: 32Mi
+      limits:
+        cpu: 100m
+        memory: 128Mi
+  squidExporter:
+    resources:
+      requests:
+        cpu: 10m
+        memory: 16Mi
+      limits:
+        cpu: 100m
+        memory: 64Mi
+  cache:
+    allowList:
+      - ^https://cdn([0-9]{2})?\.quay\.io/.+/sha256/.+/[a-f0-9]{64}
+      - ^https://s3\.[a-z0-9-]+\.amazonaws\.com/quayio-production-s3/sha256/.+/[a-f0-9]{64}
+      - ^https://quayio-production-s3\.s3[a-z0-9.-]*\.amazonaws\.com/sha256/.+/[a-f0-9]{64}
+      - ^https://production\.cloudflare\.docker\.com/registry-v2/docker/registry/v2/blobs/sha256/[a-f0-9]{2}/[a-f0-9]{64}/data
+      - ^https://docker-images-prod\.[a-f0-9]{32}\.r2\.cloudflarestorage\.com/registry-v2/docker/registry/v2/blobs/sha256/[a-f0-9]{2}/[a-f0-9]{64}/data
+      - ^https://docker-images-prod\.s3[a-z0-9.-]*\.amazonaws\.com/registry-v2/docker/registry/v2/blobs/sha256/[a-f0-9]{2}/[a-f0-9]{64}/data
+      - ^https://cdn\.registry\.fedoraproject\.org/v2/.+/blobs/sha256:[a-f0-9]{64}
+      - ^https://[a-f0-9]{32}\.r2\.cloudflarestorage\.com/app-ci-image-registry/docker/registry/v2/blobs/sha256/[a-f0-9]{2}/[a-f0-9]{64}/data
+      - ^https://layers\.nvcr\.io/registry/docker/registry/v2/blobs/sha256/[a-f0-9]{2}/[a-f0-9]{64}/data
+      - ^https://[a-z0-9]+\.cloudfront\.net/sha256/[a-f0-9]{2}/[a-f0-9]{64}
+    size: 51200
+    maxObjectSize: 1024
+  prometheus:
+    serviceMonitor:
+      nginxTLS:
+        ca:
+          configMapName: openshift-service-ca.crt
+          key: service-ca.crt
+  tlsOutgoingOptions:
+    caFile: /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
+  volumes:
+    - name: trusted-ca
+      configMap:
+        name: trusted-ca
+        items:
+          - key: ca-bundle.crt
+            path: tls-ca-bundle.pem
+  volumeMounts:
+    - name: trusted-ca
+      mountPath: /etc/pki/ca-trust/extracted/pem
+      readOnly: true

--- a/components/squid/production/stone-prod-p02/artifact-registry-credentials.yaml
+++ b/components/squid/production/stone-prod-p02/artifact-registry-credentials.yaml
@@ -1,0 +1,22 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: artifact-registry-credentials
+  namespace: caching
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: appsre-stonesoup-vault
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    name: artifact-registry-credentials
+  data:
+    - secretKey: authorization
+      remoteRef:
+        key: production/vanguard/nexus/proxy-sa-1
+        property: authz_header

--- a/components/squid/production/stone-prod-p02/kustomization.yaml
+++ b/components/squid/production/stone-prod-p02/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../base
+- artifact-registry-credentials.yaml
+
+generators:
+- squid-helm-generator.yaml

--- a/components/squid/production/stone-prod-p02/squid-helm-generator.yaml
+++ b/components/squid/production/stone-prod-p02/squid-helm-generator.yaml
@@ -1,0 +1,101 @@
+apiVersion: builtin
+kind: HelmChartInflationGenerator
+metadata:
+  name: squid-helm
+name: squid-helm
+repo: oci://quay.io/konflux-ci/caching
+version: 0.1.1506+abe1045
+valuesInline:
+  installCertManagerComponents: false
+  mirrord:
+    enabled: false
+  nginx:
+    enabled: true
+    replicaCount: 3
+    name: artifact-registry-proxy
+    tls:
+      enabled: true
+      secretName: artifact-registry-proxy-tls
+    service:
+      port: 443
+      annotations:
+        service.beta.openshift.io/serving-cert-secret-name: artifact-registry-proxy-tls
+    upstream:
+      url: https://red-hat.repo.sonatype.app
+    auth:
+      enabled: true
+      secretName: artifact-registry-credentials
+    cache:
+      allowList:
+        # Cache all traffic to nexus repositories
+        - ^/repository/
+      size: 51200
+    resources:
+      requests:
+        cpu: "2"
+        memory: 2Gi
+      limits:
+        cpu: "2"
+        memory: 2Gi
+  test:
+    enabled: false
+  cert-manager:
+    enabled: false
+  environment: release
+  replicaCount: 3
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 200m
+      memory: 2Gi
+  icapServer:
+    resources:
+      requests:
+        cpu: 10m
+        memory: 32Mi
+      limits:
+        cpu: 100m
+        memory: 128Mi
+  squidExporter:
+    resources:
+      requests:
+        cpu: 10m
+        memory: 16Mi
+      limits:
+        cpu: 100m
+        memory: 64Mi
+  cache:
+    allowList:
+      - ^https://cdn([0-9]{2})?\.quay\.io/.+/sha256/.+/[a-f0-9]{64}
+      - ^https://s3\.[a-z0-9-]+\.amazonaws\.com/quayio-production-s3/sha256/.+/[a-f0-9]{64}
+      - ^https://quayio-production-s3\.s3[a-z0-9.-]*\.amazonaws\.com/sha256/.+/[a-f0-9]{64}
+      - ^https://production\.cloudflare\.docker\.com/registry-v2/docker/registry/v2/blobs/sha256/[a-f0-9]{2}/[a-f0-9]{64}/data
+      - ^https://docker-images-prod\.[a-f0-9]{32}\.r2\.cloudflarestorage\.com/registry-v2/docker/registry/v2/blobs/sha256/[a-f0-9]{2}/[a-f0-9]{64}/data
+      - ^https://docker-images-prod\.s3[a-z0-9.-]*\.amazonaws\.com/registry-v2/docker/registry/v2/blobs/sha256/[a-f0-9]{2}/[a-f0-9]{64}/data
+      - ^https://cdn\.registry\.fedoraproject\.org/v2/.+/blobs/sha256:[a-f0-9]{64}
+      - ^https://[a-f0-9]{32}\.r2\.cloudflarestorage\.com/app-ci-image-registry/docker/registry/v2/blobs/sha256/[a-f0-9]{2}/[a-f0-9]{64}/data
+      - ^https://layers\.nvcr\.io/registry/docker/registry/v2/blobs/sha256/[a-f0-9]{2}/[a-f0-9]{64}/data
+      - ^https://[a-z0-9]+\.cloudfront\.net/sha256/[a-f0-9]{2}/[a-f0-9]{64}
+    size: 51200
+    maxObjectSize: 1024
+  prometheus:
+    serviceMonitor:
+      nginxTLS:
+        ca:
+          configMapName: openshift-service-ca.crt
+          key: service-ca.crt
+  tlsOutgoingOptions:
+    caFile: /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
+  volumes:
+    - name: trusted-ca
+      configMap:
+        name: trusted-ca
+        items:
+          - key: ca-bundle.crt
+            path: tls-ca-bundle.pem
+  volumeMounts:
+    - name: trusted-ca
+      mountPath: /etc/pki/ca-trust/extracted/pem
+      readOnly: true


### PR DESCRIPTION
## Summary
- Add per-cluster production overlays for ring 2 clusters: kflux-osp-p01, kflux-prd-rh03, stone-prod-p02
- Each cluster directory is self-contained with its own kustomization.yaml, squid-helm-generator.yaml, and artifact-registry-credentials.yaml
- Update ApplicationSet to route ring 2 clusters to their per-cluster overlays

This is the second of three ring PRs to restructure squid production overlays for per-cluster configuration. Ring 1 was merged in #12018.

## Risk Assessment
- **Level:** Low
- **Description:** Adds per-cluster overlays for 3 production clusters. The overlay content is identical to the existing flat production configuration — only the directory structure changes. Unmigrated clusters continue using the flat `production/` directory via `clusterDir: ""` default.
- **Rollback:** Revert this PR to restore flat production path for these 3 clusters.

## Validation
- Ring 1 (#12018) was validated in production with no issues
- `kustomize build --enable-helm` on each new per-cluster overlay produces identical output to the flat production build
- Flat `production/` directory continues to build correctly for unmigrated clusters

Jira: https://redhat.atlassian.net/browse/KFLUXVNGD-1024

Assisted-by: Claude Code