### PR TITLE
production Ring 1: upgrade to pipelines 5.0.5-830, bump events-controller memory, fix PaC metrics

### DIFF
--- a/components/monitoring/grafana/base/dashboards/pipeline-service/grafana-config.yaml
+++ b/components/monitoring/grafana/base/dashboards/pipeline-service/grafana-config.yaml
@@ -2310,7 +2310,7 @@ data:
               "targets": [
                 {
                   "exemplar": true,
-                  "expr": "sum by (event_type) (rate(pac_watcher_pipelines_as_code_pipelinerun_total[1h]))*3600",
+                  "expr": "sum by (event_type) (rate(pipelines_as_code_pipelinerun_count_total{job='pipelines-as-code-watcher'}[1h]))*3600",
                   "interval": "",
                   "legendFormat": "",
                   "refId": "A"
@@ -2391,7 +2391,7 @@ data:
               "targets": [
                 {
                   "exemplar": true,
-                  "expr": "avg(pac_watcher_workqueue_unfinished_work_seconds_count)",
+                  "expr": "avg(kn_workqueue_unfinished_work_seconds{job='pipelines-as-code-watcher'})",
                   "interval": "",
                   "legendFormat": "",
                   "refId": "A"
@@ -2472,7 +2472,7 @@ data:
               "targets": [
                 {
                   "exemplar": true,
-                  "expr": "rate(pac_watcher_client_results[1h])*3600",
+                  "expr": "rate(kn_k8s_client_http_response_status_code_total{job='pipelines-as-code-watcher'}[1h])*3600",
                   "interval": "",
                   "legendFormat": "",
                   "refId": "A"

--- a/components/monitoring/prometheus/production/base/monitoringstack/endpoints-params.yaml
+++ b/components/monitoring/prometheus/production/base/monitoringstack/endpoints-params.yaml
@@ -188,14 +188,14 @@
     - '{__name__="tekton_pipelines_controller_running_taskruns"}'
     - '{__name__="watcher_workqueue_depth"}'
     - '{__name__="watcher_client_latency_bucket"}'
-    - '{__name__="pac_watcher_work_queue_depth"}'
-    - '{__name__="pac_watcher_client_latency_bucket"}'
+    - '{__name__="kn_workqueue_depth", job="pipelines-as-code-watcher"}'
+    - '{__name__="http_client_request_duration_seconds_bucket", job="pipelines-as-code-watcher"}'
     - '{__name__="watcher_reconcile_latency_bucket", namespace="openshift-pipelines", job="tekton-chains"}'
     - '{__name__="watcher_workqueue_longest_running_processor_seconds_count", container="tekton-chains-controller", service="tekton-chains"}'
     - '{__name__="watcher_go_gc_cpu_fraction", namespace="openshift-pipelines",container="tekton-chains-controller", job="tekton-chains"}'
     - '{__name__="workqueue_depth", namespace="openshift-pipelines", service="pipeline-metrics-exporter-service", container="pipeline-metrics-exporter"}'
-    - '{__name__="pac_watcher_workqueue_unfinished_work_seconds_count"}'
-    - '{__name__="pac_watcher_client_results"}'
+    - '{__name__="kn_workqueue_unfinished_work_seconds", job="pipelines-as-code-watcher"}'
+    - '{__name__="kn_k8s_client_http_response_status_code_total", job="pipelines-as-code-watcher"}'
     - '{__name__="pipelinerun_failed_by_pvc_quota_count"}'
 
     ## Kueue Metrics

--- a/components/pipeline-service/production/base/main-pipeline-service-configuration.yaml
+++ b/components/pipeline-service/production/base/main-pipeline-service-configuration.yaml
@@ -1846,19 +1846,19 @@ spec:
         #               requests:
         #                 cpu: 1500m
         #                 memory: 8Gi
-        # tekton-events-controller:
-        #   spec:
-        #     template:
-        #       spec:
-        #         containers:
-        #           - name: tekton-events-controller
-        #             resources:
-        #               limits:
-        #                 cpu: 200m
-        #                 memory: 64Mi
-        #               requests:
-        #                 cpu: 200m
-        #                 memory: 64Mi
+        tekton-events-controller:
+          spec:
+            template:
+              spec:
+                containers:
+                  - name: tekton-events-controller
+                    resources:
+                      limits:
+                        cpu: 200m
+                        memory: 256Mi
+                      requests:
+                        cpu: 200m
+                        memory: 256Mi
         # tekton-triggers-controller:
         #   spec:
         #     template:
@@ -2059,7 +2059,7 @@ metadata:
   namespace: openshift-marketplace
 spec:
   displayName: custom-operators
-  image: quay.io/openshift-pipeline/pipelines-index-4.18@sha256:d4d3f6210a384da6bfb11214a860e72e52d0a38b73037b8135c0571a6365d2a1
+  image: quay.io/openshift-pipeline/pipelines-index-4.18@sha256:a4aa211a70b0a92c98c885cca8fed2cce490e3fec656ad1ea68bf7e7c3c18304
   sourceType: grpc
   updateStrategy:
     registryPoll:

--- a/components/pipeline-service/production/kflux-fedora-01/deploy.yaml
+++ b/components/pipeline-service/production/kflux-fedora-01/deploy.yaml
@@ -2342,6 +2342,19 @@ spec:
                 }
               }
       deployments:
+        tekton-events-controller:
+          spec:
+            template:
+              spec:
+                containers:
+                - name: tekton-events-controller
+                  resources:
+                    limits:
+                      cpu: 200m
+                      memory: 256Mi
+                    requests:
+                      cpu: 200m
+                      memory: 256Mi
         tekton-operator-proxy-webhook:
           spec:
             replicas: 2
@@ -2528,7 +2541,7 @@ metadata:
   namespace: openshift-marketplace
 spec:
   displayName: custom-operators
-  image: quay.io/openshift-pipeline/pipelines-index-4.18@sha256:d4d3f6210a384da6bfb11214a860e72e52d0a38b73037b8135c0571a6365d2a1
+  image: quay.io/openshift-pipeline/pipelines-index-4.18@sha256:a4aa211a70b0a92c98c885cca8fed2cce490e3fec656ad1ea68bf7e7c3c18304
   sourceType: grpc
   updateStrategy:
     registryPoll:

--- a/components/pipeline-service/production/kflux-osp-p01/deploy.yaml
+++ b/components/pipeline-service/production/kflux-osp-p01/deploy.yaml
@@ -2327,6 +2327,19 @@ spec:
                 }
               }
       deployments:
+        tekton-events-controller:
+          spec:
+            template:
+              spec:
+                containers:
+                - name: tekton-events-controller
+                  resources:
+                    limits:
+                      cpu: 200m
+                      memory: 256Mi
+                    requests:
+                      cpu: 200m
+                      memory: 256Mi
         tekton-operator-proxy-webhook:
           spec:
             replicas: 2
@@ -2515,7 +2528,7 @@ metadata:
   namespace: openshift-marketplace
 spec:
   displayName: custom-operators
-  image: quay.io/openshift-pipeline/pipelines-index-4.18@sha256:d4d3f6210a384da6bfb11214a860e72e52d0a38b73037b8135c0571a6365d2a1
+  image: quay.io/openshift-pipeline/pipelines-index-4.18@sha256:a4aa211a70b0a92c98c885cca8fed2cce490e3fec656ad1ea68bf7e7c3c18304
   sourceType: grpc
   updateStrategy:
     registryPoll:

--- a/components/pipeline-service/production/stone-prod-p01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prod-p01/deploy.yaml
@@ -2327,6 +2327,19 @@ spec:
                 }
               }
       deployments:
+        tekton-events-controller:
+          spec:
+            template:
+              spec:
+                containers:
+                - name: tekton-events-controller
+                  resources:
+                    limits:
+                      cpu: 200m
+                      memory: 256Mi
+                    requests:
+                      cpu: 200m
+                      memory: 256Mi
         tekton-operator-proxy-webhook:
           spec:
             replicas: 2
@@ -2515,7 +2528,7 @@ metadata:
   namespace: openshift-marketplace
 spec:
   displayName: custom-operators
-  image: quay.io/openshift-pipeline/pipelines-index-4.18@sha256:d4d3f6210a384da6bfb11214a860e72e52d0a38b73037b8135c0571a6365d2a1
+  image: quay.io/openshift-pipeline/pipelines-index-4.18@sha256:a4aa211a70b0a92c98c885cca8fed2cce490e3fec656ad1ea68bf7e7c3c18304
   sourceType: grpc
   updateStrategy:
     registryPoll:


### PR DESCRIPTION
- **Ring 1**: kflux-fedora-01, stone-prod-p01, kflux-osp-p01
- **Index image**: v5.0.5-806 → v5.0.5-830 (sha256:d4d3f621→a4aa211a)
- **tekton-events-controller**: memory 64Mi → 256Mi (fixes OOMKilled on stone-stg-rh01, applying same fix to prod)
- **Monitoring**: Rename 11 PaC metric references for OpenCensus→OpenTelemetry migration (PaC v0.47.0)

### Events controller memory
Uncommented and bumped in base, inserted in 9 cluster deploy.yaml overlays. Matches staging (PR #11762).

## Validation
- v5.0.5-830 validated in dev/staging (PR #12009, merged May 27)
- Events-controller fix validated in staging (PR #11762, merged May 12)

## Risk Assessment
**Risk Level:** Medium
**Description:** Upgrades OpenShift Pipelines index from 5.0.5-806 to 5.0.5-830. Includes PAC OTel migration (metric renames), events-controller memory fix, and multiple CVE patches. Image soaked in staging for 7 days+.
**Rollback:** Release a new Index image with the fix included.