### PR TITLE
KFLUXVNGD-994 Increase nginx cache volume to 1TB - ring 3

### DIFF
--- a/components/squid/production/kflux-fedora-01/squid-helm-generator.yaml
+++ b/components/squid/production/kflux-fedora-01/squid-helm-generator.yaml
@@ -4,7 +4,7 @@ metadata:
   name: squid-helm
 name: squid-helm
 repo: oci://quay.io/konflux-ci/caching
-version: 0.1.1506+abe1045
+version: 0.1.1521+3e9d8b9
 valuesInline:
   installCertManagerComponents: false
   mirrord:
@@ -29,7 +29,7 @@ valuesInline:
       allowList:
         # Cache all traffic to nexus repositories
         - ^/repository/
-      size: 51200
+      size: 1048576
     resources:
       requests:
         cpu: "2"

--- a/components/squid/production/kflux-rhel-p01/squid-helm-generator.yaml
+++ b/components/squid/production/kflux-rhel-p01/squid-helm-generator.yaml
@@ -4,7 +4,7 @@ metadata:
   name: squid-helm
 name: squid-helm
 repo: oci://quay.io/konflux-ci/caching
-version: 0.1.1506+abe1045
+version: 0.1.1521+3e9d8b9
 valuesInline:
   installCertManagerComponents: false
   mirrord:
@@ -29,7 +29,7 @@ valuesInline:
       allowList:
         # Cache all traffic to nexus repositories
         - ^/repository/
-      size: 51200
+      size: 1048576
     resources:
       requests:
         cpu: "2"

--- a/components/squid/production/stone-prd-rh01/squid-helm-generator.yaml
+++ b/components/squid/production/stone-prd-rh01/squid-helm-generator.yaml
@@ -4,7 +4,7 @@ metadata:
   name: squid-helm
 name: squid-helm
 repo: oci://quay.io/konflux-ci/caching
-version: 0.1.1506+abe1045
+version: 0.1.1521+3e9d8b9
 valuesInline:
   installCertManagerComponents: false
   mirrord:
@@ -29,7 +29,7 @@ valuesInline:
       allowList:
         # Cache all traffic to nexus repositories
         - ^/repository/
-      size: 51200
+      size: 1048576
     resources:
       requests:
         cpu: "2"


### PR DESCRIPTION
## Summary
- Increase `nginx.cache.size` from 51200 (50 GB) to 1048576 (1 TB) for ring 3 production clusters: kflux-fedora-01, kflux-rhel-p01, stone-prd-rh01
- Update chart version to `0.1.1521+3e9d8b9` which includes the `int` rendering fix for large values (PR konflux-ci/caching#849)

With redirect caching enabled ([KFLUXVNGD-997](https://redhat.atlassian.net/browse/KFLUXVNGD-997)), nginx now caches actual artifact content fetched from S3 rather than just passing through 302 redirects. This significantly increases cache disk usage.

## Risk Assessment

**Risk Level:** Medium
**Rollback:** Revert this PR. Note: PVC size cannot be reduced, only the nginx `max_size` config would revert.
**Description**: Increases PVC size for nginx cache. The resize is non-destructive (PVC expansion only). Proxy continues serving traffic during the resize. ArgoCD sync will be stuck until manual intervention to recreate the StatefulSet.

## Validation
- Ring 1 (#12052) and ring 2 (#12061) completed successfully with no downtime
- `kustomize build --enable-helm` confirms `storage: 1048576Mi` and `max_size=1048576m` render correctly (no scientific notation)

Jira: https://redhat.atlassian.net/browse/KFLUXVNGD-994

Assisted-by: Claude Code

[KFLUXVNGD-997]: https://redhat.atlassian.net/browse/KFLUXVNGD-997?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ