### PR TITLE
reduce concurrent g6.4xlarge VMs in OSP cluster

### DIFF
--- a/components/kueue/production/kflux-osp-p01/queue-config/cluster-queue.yaml
+++ b/components/kueue/production/kflux-osp-p01/queue-config/cluster-queue.yaml
@@ -108,7 +108,7 @@ spec:
       - name: linux-fast-amd64
         nominalQuota: '250'
       - name: linux-g64xlarge-amd64
-        nominalQuota: '250'
+        nominalQuota: '2'
       - name: linux-m2xlarge-amd64
         nominalQuota: '250'
       - name: linux-m2xlarge-arm64

--- a/components/multi-platform-controller/production-downstream/kflux-osp-p01/host-values.yaml
+++ b/components/multi-platform-controller/production-downstream/kflux-osp-p01/host-values.yaml
@@ -71,6 +71,7 @@ dynamicConfigs:
 
   linux-g64xlarge-amd64:
     ami: "ami-0133ba5e6e6d57a02"
+    max-instances: 2
     # user-data loaded from base/host-config-chart/files/linux-g64xlarge-amd64-init.sh
 
   linux-root-arm64:


### PR DESCRIPTION
AWS is struggling providing `g6.4xlarge`.
We want to reduce the maximum number of concurrent `g6.4xlarge` VMs to a value that will reduce the likelihood of encountering AWS availability issues.

Signed-off-by: Francesco Ilario <filario@redhat.com>


## Risk Assessment

**Risk level:** low

**What could go wrong:** This change updates automatically generated config. Not much is expected to go wrong.

**Rollback plan:** Revert the PR and redeploy. No data migration involved.

**Testing:** N/A