### PR TITLE
KFLUXVNGD-1000 Deploy redirect caching to production - batch 1

### DIFF
--- a/components/squid/production/kflux-ocp-p01/squid-helm-generator.yaml
+++ b/components/squid/production/kflux-ocp-p01/squid-helm-generator.yaml
@@ -18,6 +18,7 @@ valuesInline:
       secretName: artifact-registry-proxy-tls
     service:
       port: 443
+      trafficDistribution: PreferClose
       annotations:
         service.beta.openshift.io/serving-cert-secret-name: artifact-registry-proxy-tls
     upstream:
@@ -30,6 +31,7 @@ valuesInline:
         # Cache all traffic to nexus repositories
         - ^/repository/
       size: 1048576
+      ttl: 30d
     resources:
       requests:
         cpu: "2"

--- a/components/squid/production/kflux-osp-p01/squid-helm-generator.yaml
+++ b/components/squid/production/kflux-osp-p01/squid-helm-generator.yaml
@@ -18,6 +18,7 @@ valuesInline:
       secretName: artifact-registry-proxy-tls
     service:
       port: 443
+      trafficDistribution: PreferClose
       annotations:
         service.beta.openshift.io/serving-cert-secret-name: artifact-registry-proxy-tls
     upstream:
@@ -30,6 +31,7 @@ valuesInline:
         # Cache all traffic to nexus repositories
         - ^/repository/
       size: 1048576
+      ttl: 30d
     resources:
       requests:
         cpu: "2"

--- a/components/squid/production/kflux-prd-rh02/squid-helm-generator.yaml
+++ b/components/squid/production/kflux-prd-rh02/squid-helm-generator.yaml
@@ -18,6 +18,7 @@ valuesInline:
       secretName: artifact-registry-proxy-tls
     service:
       port: 443
+      trafficDistribution: PreferClose
       annotations:
         service.beta.openshift.io/serving-cert-secret-name: artifact-registry-proxy-tls
     upstream:
@@ -30,6 +31,7 @@ valuesInline:
         # Cache all traffic to nexus repositories
         - ^/repository/
       size: 1048576
+      ttl: 30d
     resources:
       requests:
         cpu: "2"

--- a/components/squid/production/stone-prod-p01/squid-helm-generator.yaml
+++ b/components/squid/production/stone-prod-p01/squid-helm-generator.yaml
@@ -18,6 +18,7 @@ valuesInline:
       secretName: artifact-registry-proxy-tls
     service:
       port: 443
+      trafficDistribution: PreferClose
       annotations:
         service.beta.openshift.io/serving-cert-secret-name: artifact-registry-proxy-tls
     upstream:
@@ -30,6 +31,7 @@ valuesInline:
         # Cache all traffic to nexus repositories
         - ^/repository/
       size: 1048576
+      ttl: 30d
     resources:
       requests:
         cpu: "2"


### PR DESCRIPTION
## Summary
- Add `nginx.cache.ttl: 30d` and `nginx.service.trafficDistribution: PreferClose` for production clusters: kflux-ocp-p01, kflux-prd-rh02, stone-prod-p01, kflux-osp-p01
- Enables redirect caching in production, matching the configuration validated in staging ([KFLUXVNGD-997](https://redhat.atlassian.net/browse/KFLUXVNGD-997))

## Risk Assessment

**Risk Level:** Low
**Rollback:** Revert this PR to disable redirect caching and remove trafficDistribution.
**Description:** These values have been validated in staging. The chart version already includes redirect interception support. Adding TTL and trafficDistribution are additive configuration changes with no impact on existing proxy behavior.

## Validation
- Staging validated with the same configuration (PR #11940)
- Grafana dashboards confirm healthy cache hit ratio and no performance degradation in staging

Jira: https://redhat.atlassian.net/browse/KFLUXVNGD-1000

Assisted-by: Claude Code

[KFLUXVNGD-997]: https://redhat.atlassian.net/browse/KFLUXVNGD-997?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ