### PR TITLE
KFLUXVNGD-1000 Deploy redirect caching to production - batch 2

### DIFF
--- a/components/squid/production/kflux-fedora-01/squid-helm-generator.yaml
+++ b/components/squid/production/kflux-fedora-01/squid-helm-generator.yaml
@@ -18,6 +18,7 @@ valuesInline:
       secretName: artifact-registry-proxy-tls
     service:
       port: 443
+      trafficDistribution: PreferClose
       annotations:
         service.beta.openshift.io/serving-cert-secret-name: artifact-registry-proxy-tls
     upstream:
@@ -30,6 +31,7 @@ valuesInline:
         # Cache all traffic to nexus repositories
         - ^/repository/
       size: 1048576
+      ttl: 30d
     resources:
       requests:
         cpu: "2"

--- a/components/squid/production/kflux-prd-rh03/squid-helm-generator.yaml
+++ b/components/squid/production/kflux-prd-rh03/squid-helm-generator.yaml
@@ -18,6 +18,7 @@ valuesInline:
       secretName: artifact-registry-proxy-tls
     service:
       port: 443
+      trafficDistribution: PreferClose
       annotations:
         service.beta.openshift.io/serving-cert-secret-name: artifact-registry-proxy-tls
     upstream:
@@ -30,6 +31,7 @@ valuesInline:
         # Cache all traffic to nexus repositories
         - ^/repository/
       size: 1048576
+      ttl: 30d
     resources:
       requests:
         cpu: "2"

--- a/components/squid/production/kflux-rhel-p01/squid-helm-generator.yaml
+++ b/components/squid/production/kflux-rhel-p01/squid-helm-generator.yaml
@@ -18,6 +18,7 @@ valuesInline:
       secretName: artifact-registry-proxy-tls
     service:
       port: 443
+      trafficDistribution: PreferClose
       annotations:
         service.beta.openshift.io/serving-cert-secret-name: artifact-registry-proxy-tls
     upstream:
@@ -30,6 +31,7 @@ valuesInline:
         # Cache all traffic to nexus repositories
         - ^/repository/
       size: 1048576
+      ttl: 30d
     resources:
       requests:
         cpu: "2"

--- a/components/squid/production/stone-prd-rh01/squid-helm-generator.yaml
+++ b/components/squid/production/stone-prd-rh01/squid-helm-generator.yaml
@@ -18,6 +18,7 @@ valuesInline:
       secretName: artifact-registry-proxy-tls
     service:
       port: 443
+      trafficDistribution: PreferClose
       annotations:
         service.beta.openshift.io/serving-cert-secret-name: artifact-registry-proxy-tls
     upstream:
@@ -30,6 +31,7 @@ valuesInline:
         # Cache all traffic to nexus repositories
         - ^/repository/
       size: 1048576
+      ttl: 30d
     resources:
       requests:
         cpu: "2"

--- a/components/squid/production/stone-prod-p02/squid-helm-generator.yaml
+++ b/components/squid/production/stone-prod-p02/squid-helm-generator.yaml
@@ -18,6 +18,7 @@ valuesInline:
       secretName: artifact-registry-proxy-tls
     service:
       port: 443
+      trafficDistribution: PreferClose
       annotations:
         service.beta.openshift.io/serving-cert-secret-name: artifact-registry-proxy-tls
     upstream:
@@ -30,6 +31,7 @@ valuesInline:
         # Cache all traffic to nexus repositories
         - ^/repository/
       size: 1048576
+      ttl: 30d
     resources:
       requests:
         cpu: "2"


### PR DESCRIPTION
## Summary
- Add `nginx.cache.ttl: 30d` and `nginx.service.trafficDistribution: PreferClose` for remaining production clusters: kflux-prd-rh03, stone-prod-p02, kflux-fedora-01, kflux-rhel-p01, stone-prd-rh01
- Completes the redirect caching rollout to all production clusters, matching the configuration validated in staging ([KFLUXVNGD-997](https://redhat.atlassian.net/browse/KFLUXVNGD-997))

## Risk Assessment

**Risk Level:** Low
**Rollback:** Revert this PR to disable redirect caching and remove trafficDistribution.
**Description:** These values have been validated in staging and in production batch 1 (#12069). Adding TTL and trafficDistribution are additive configuration changes with no impact on existing proxy behavior.

## Validation
- Batch 1 (#12069) deployed successfully with no issues
- Staging validated with the same configuration

Jira: https://redhat.atlassian.net/browse/KFLUXVNGD-1000

Assisted-by: Claude Code

[KFLUXVNGD-997]: https://redhat.atlassian.net/browse/KFLUXVNGD-997?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ