### PR TITLE
image-rbac-proxy: replace appstudio-utils w/ task-runner

### DIFF
--- a/components/image-rbac-proxy/base/oauth/oauth-secret.yaml
+++ b/components/image-rbac-proxy/base/oauth/oauth-secret.yaml
@@ -88,7 +88,7 @@ spec:
             echo "skipping dex restart"
           fi
 
-        image: quay.io/konflux-ci/appstudio-utils:ab6b0b8e40e440158e7288c73aff1cf83a2cc8a9@sha256:24179f0efd06c65d16868c2d7eb82573cce8e43533de6cea14fec3b7446e0b14
+        image: quay.io/konflux-ci/task-runner:955c3525538ea50bf0f562dbd1f0cda330df9054@sha256:1c0582a85dae0949f3ec94aca95695c5d7698b371f1b76c5a78822a6249073dc
         imagePullPolicy: Always
         name: oauth-secret-generator
         resources:

--- a/components/image-rbac-proxy/development/kustomization.yaml
+++ b/components/image-rbac-proxy/development/kustomization.yaml
@@ -14,7 +14,3 @@ images:
 - name: memcached
   newName: quay.io/kubearchive/memcached
   newTag: 1.6.39
-- name: quay.io/konflux-ci/appstudio-utils
-  newName: quay.io/konflux-ci/task-runner
-  newTag: 955c3525538ea50bf0f562dbd1f0cda330df9054
-  digest: sha256:1c0582a85dae0949f3ec94aca95695c5d7698b371f1b76c5a78822a6249073dc

--- a/components/image-rbac-proxy/staging/base/kustomization.yaml
+++ b/components/image-rbac-proxy/staging/base/kustomization.yaml
@@ -10,7 +10,3 @@ images:
 - name: quay.io/konflux-ci/image-rbac-proxy
   newName: quay.io/konflux-ci/image-rbac-proxy
   newTag: 8fc718007abb984ee2f29acb860601f2bd1cdce6
-- name: quay.io/konflux-ci/appstudio-utils
-  newName: quay.io/konflux-ci/task-runner
-  newTag: 955c3525538ea50bf0f562dbd1f0cda330df9054
-  digest: sha256:1c0582a85dae0949f3ec94aca95695c5d7698b371f1b76c5a78822a6249073dc


### PR DESCRIPTION
The appstudio-utils image is deprecated, and the task-runner image is recommended as a replacement.

Fixes: [KFLUXINFRA-3808](https://redhat.atlassian.net/browse/KFLUXINFRA-3808)

[KFLUXINFRA-3808]: https://redhat.atlassian.net/browse/KFLUXINFRA-3808?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ