### PR TITLE
fix(KONFLUX-14215): update otel collector to 0.153.0 on kflux-prd-rh02

### DIFF
--- a/components/kubearchive/production/kflux-prd-rh02/kustomization.yaml
+++ b/components/kubearchive/production/kflux-prd-rh02/kustomization.yaml
@@ -348,4 +348,4 @@ patches:
           spec:
             containers:
               - name: otel-collector
-                image: quay.io/kubearchive/opentelemetry-collector@sha256:b17fec48359d78477cfdeb758bb5d71c86ef70e08a6b3944d70d038352211d03
+                image: quay.io/kubearchive/opentelemetry-collector@sha256:74edb825a429b415262e7eb7a99ed77685c9b2b7238ef69fb42a3625df75458f


### PR DESCRIPTION
Signed-off-by: obetsun <obetsun@redhat.com>

## Summary

This PR is for updating the opentelemetry-collector to the version 0.153.0 to remediate CVE-2026-33186, CVE-2026-4645.

Remediates CVE-2026-43869 CVE-2026-41606 for opentelemetry-collector Closes:

[KONFLUX-14215](https://redhat.atlassian.net/browse/KONFLUX-14215) [KONFLUX-13499](https://redhat.atlassian.net/browse/KONFLUX-13499)


## Validation
Tested on staging: https://github.com/redhat-appstudio/infra-deployments/pull/12048
Tested on development: https://github.com/redhat-appstudio/infra-deployments/pull/12047

## Risk Assessment

**Risk Level:** Low
**Description:** some of the KubeArchive performance metrics data can be lost 
**Rollback:** Remove the patch from kustomization files and the older version of otel-collector will be deployed.i


[KONFLUX-14215]: https://redhat.atlassian.net/browse/KONFLUX-14215?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[KONFLUX-13499]: https://redhat.atlassian.net/browse/KONFLUX-13499?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ