### PR TITLE
PVO11Y-5287 Add konflux-perfscale-4-tenant to production secret store

### DIFF
--- a/components/cluster-secret-store/production/perfscale-namespaces-patch.yaml
+++ b/components/cluster-secret-store/production/perfscale-namespaces-patch.yaml
@@ -8,3 +8,6 @@
 - op: add
   path: /spec/conditions/0/namespaces/-
   value: konflux-perfscale-3-tenant
+- op: add
+  path: /spec/conditions/0/namespaces/-
+  value: konflux-perfscale-4-tenant


### PR DESCRIPTION
## Summary
- Add `konflux-perfscale-4-tenant` to the production cluster secret store perfscale namespaces patch so the namespace can access Vault secrets via ExternalSecrets on production clusters

Jira: https://redhat.atlassian.net/browse/PVO11Y-5287

## Risk Assessment
**Risk Level:** Low
**Description:** Adds a new namespace to the production secret store allowed list, following the existing pattern of tenants 1-3
**Rollback:** Revert PR

## Validation
- Staging PR merged and validated: https://github.com/redhat-appstudio/infra-deployments/pull/12120
- [x] `kustomize build components/cluster-secret-store/production/` passes