### PR TITLE
fix(KONFLUX-11582): ingesters oomkilled - kflux-ocp-p01 configuration…

### DIFF
--- a/components/vector-kubearchive-log-collector/production/kflux-ocp-p01/loki-helm-prod-values.yaml
+++ b/components/vector-kubearchive-log-collector/production/kflux-ocp-p01/loki-helm-prod-values.yaml
@@ -1,7 +1,7 @@
 ---
 global:
   extraArgs:
-    - "-log.level=debug"
+    - "-log.level=info"
 
 gateway:
   service:
@@ -68,17 +68,17 @@ loki:
   runtimeConfig:
     configs:
       kubearchive:
-        log_push_request: true
-        log_push_request_streams: true
-        log_stream_creation: true
-        log_duplicate_stream_info: true
+        log_push_request: false
+        log_push_request_streams: false
+        log_stream_creation: false
+        log_duplicate_stream_info: false
   ingester:
     autoforget_unhealthy: true
-    chunk_target_size: 8388608        # 8MB
-    chunk_idle_period: 1h
-    max_chunk_age: 2h
+    chunk_target_size: 4194304        # 4MB (reduced from 8MB to lower per-chunk memory)
+    chunk_idle_period: 30m            # Flush idle chunks sooner (was 1h)
+    max_chunk_age: 1h                 # Reduce max chunk lifetime (was 2h)
     chunk_encoding: snappy            # Compress data (reduces S3 transfer size)
-    chunk_retain_period: 1h           # Keep chunks in memory after flush
+    chunk_retain_period: 15m          # Reduced from 1h to free memory faster after flush
     flush_op_timeout: 10m             # Add timeout for S3 operations
     lifecycler:
       ring:
@@ -88,7 +88,7 @@ loki:
       dir: /var/loki/wal
       checkpoint_duration: 5m          # Create checkpoints every 5 minutes
       flush_on_shutdown: true          # Ensure data is flushed before shutdown
-      replay_memory_ceiling: 2GB       # 75% of 6Gi limit - PREVENTS OOM during replay
+      replay_memory_ceiling: 4GB       # ~33% of 12Gi limit - prevents OOM during WAL replay
   server:
     grpc_server_max_recv_msg_size: 15728640  # 15MB
     grpc_server_max_send_msg_size: 15728640
@@ -112,16 +112,17 @@ ingester:
   replicas: 3
   autoscaling:
     enabled: true
+    minReplicas: 2
   zoneAwareReplication:
     enabled: true
   maxUnavailable: 1
   resources:
     requests:
       cpu: 500m
-      memory: 6Gi
+      memory: 8Gi
     limits:
       cpu: 2000m
-      memory: 8Gi
+      memory: 12Gi
   persistence:
     enabled: true
     size: 10Gi


### PR DESCRIPTION
Assisted-by: Claude

##Summary

This changes are meant to fix loki-ingester OOMKilled errors by modifying the memory and WAL settings:

  Changes :
  - Debug level reduced to info
  - WAL replay_memory_ceiling: 2GB → 4GB
  - chunk_idle_period: 1h → 30m
  - max_chunk_age: 2h → 1h
  - chunk_retain_period: 1h → 30m
  - chunk_target_size: 4194304

Jira: [KONFLUX-11582](https://redhat.atlassian.net/browse/KONFLUX-11582)

## Validation

Tested on staging: https://github.com/redhat-appstudio/infra-deployments/pull/12074
Tested on development: https://github.com/redhat-appstudio/infra-deployments/pull/12064

## Risk Assessment

**Risk Level:** Low
**Rollback:** Revert this PR to reset the WAL settings back.
**Description:** These values have been validated in development

Jira: https://redhat.atlassian.net/browse/KONFLUX-11582

[KONFLUX-11582]: https://redhat.atlassian.net/browse/KONFLUX-11582?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ