### PR TITLE
image-rbac-proxy: use task-runner image in stg/dev

### DIFF
--- a/components/image-rbac-proxy/development/kustomization.yaml
+++ b/components/image-rbac-proxy/development/kustomization.yaml
@@ -14,3 +14,7 @@ images:
 - name: memcached
   newName: quay.io/kubearchive/memcached
   newTag: 1.6.39
+- name: quay.io/konflux-ci/appstudio-utils
+  newName: quay.io/konflux-ci/task-runner
+  newTag: 955c3525538ea50bf0f562dbd1f0cda330df9054
+  digest: sha256:1c0582a85dae0949f3ec94aca95695c5d7698b371f1b76c5a78822a6249073dc

--- a/components/image-rbac-proxy/staging/base/kustomization.yaml
+++ b/components/image-rbac-proxy/staging/base/kustomization.yaml
@@ -10,3 +10,7 @@ images:
 - name: quay.io/konflux-ci/image-rbac-proxy
   newName: quay.io/konflux-ci/image-rbac-proxy
   newTag: 8fc718007abb984ee2f29acb860601f2bd1cdce6
+- name: quay.io/konflux-ci/appstudio-utils
+  newName: quay.io/konflux-ci/task-runner
+  newTag: 955c3525538ea50bf0f562dbd1f0cda330df9054
+  digest: sha256:1c0582a85dae0949f3ec94aca95695c5d7698b371f1b76c5a78822a6249073dc


### PR DESCRIPTION
The appstudio-utils image is being deprecated, and the task-runner image is recommended as its replacement.  Replace its usage in both the staging and development overlays.

Fixes: [KFLUXINFRA-3808](https://redhat.atlassian.net/browse/KFLUXINFRA-3808)

[KFLUXINFRA-3808]: https://redhat.atlassian.net/browse/KFLUXINFRA-3808?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ