### PR TITLE
KFLUXINFRA-3861: Upgrade OADP channel to stable on staging clusters

### DIFF
--- a/components/backup/staging/stone-stage-p01/kustomization.yaml
+++ b/components/backup/staging/stone-stage-p01/kustomization.yaml
@@ -21,3 +21,9 @@ patches:
     kind: DataProtectionApplication
     name: velero-aws
     version: v1alpha1
+- path: oadp-channel-patch.yaml
+  target:
+    group: operators.coreos.com
+    kind: Subscription
+    name: redhat-oadp-operator
+    version: v1alpha1

--- a/components/backup/staging/stone-stage-p01/oadp-channel-patch.yaml
+++ b/components/backup/staging/stone-stage-p01/oadp-channel-patch.yaml
@@ -1,0 +1,3 @@
+- op: replace
+  path: /spec/channel
+  value: stable

--- a/components/backup/staging/stone-stg-rh01/kustomization.yaml
+++ b/components/backup/staging/stone-stg-rh01/kustomization.yaml
@@ -21,3 +21,9 @@ patches:
     kind: DataProtectionApplication
     name: velero-aws
     version: v1alpha1
+- path: oadp-channel-patch.yaml
+  target:
+    group: operators.coreos.com
+    kind: Subscription
+    name: redhat-oadp-operator
+    version: v1alpha1

--- a/components/backup/staging/stone-stg-rh01/oadp-channel-patch.yaml
+++ b/components/backup/staging/stone-stg-rh01/oadp-channel-patch.yaml
@@ -1,0 +1,3 @@
+- op: replace
+  path: /spec/channel
+  value: stable


### PR DESCRIPTION
## Summary

OADP 1.4 is not supported on OCP 4.19 ([support matrix](https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html/backup_and_restore/oadp-application-backup-and-restore#oadp-support-matrix_oadp-api)). Both staging clusters (stone-stg-rh01 and stone-stage-p01) have degraded backup components after the 4.19 upgrade.

This PR switches the OADP Subscription channel from `stable-1.4` to `stable` (OADP 1.5) **on staging only** via per-cluster overlay patches, leaving production clusters unchanged until the prod 4.19 upgrade.

The existing DPA configuration already uses the OADP 1.5 format (`spec.configuration.nodeAgent` with `uploaderType: kopia`), so no DPA changes are needed.

## Changes

- Added `oadp-channel-patch.yaml` to both staging overlays (stone-stg-rh01, stone-stage-p01)
- Updated staging `kustomization.yaml` files to apply the Subscription channel patch

## Verification

After merge, confirm the backup ArgoCD apps for both staging clusters are no longer in Degraded state:
- [backup-stone-stg-rh01](https://argocd-server-konflux-public-staging.apps.rosa.appsres09ue1.24ep.p3.openshiftapps.com/applications/konflux-public-staging/backup-stone-stg-rh01)
- [backup-stone-stage-p01](https://argocd-server-argocd-staging.apps.rosa.appsres09ue1.24ep.p3.openshiftapps.com/applications/argocd-staging/backup-stone-stage-p01)

Jira: [KFLUXINFRA-3861](https://redhat.atlassian.net/browse/KFLUXINFRA-3861)

[KFLUXINFRA-3861]: https://redhat.atlassian.net/browse/KFLUXINFRA-3861?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ