### PR TITLE
[KONFLUX-14240] env-detector: Calculate merge base

### DIFF
--- a/infra-tools/cmd/env-detector/main.go
+++ b/infra-tools/cmd/env-detector/main.go
@@ -65,19 +65,29 @@ func main() {
 		fatal("resolving repo root", "err", err)
 	}
 
-	// Resolve HEAD and base-ref to short commit SHAs for the summary.
+	// Resolve base ref: use merge-base so the diff only contains the PR's
+	// own changes, even when the branch is not rebased on top of base-ref
+	// or the GitHub merge ref is stale.  This mirrors the approach used by
+	// render-diff.
+	effectiveBaseRef, err := git.MergeBase(ctx, absRepoRoot, *baseRef)
+	if err != nil {
+		fatal("computing merge-base", "ref", *baseRef, "err", err)
+	}
+	slog.Debug("Resolved merge-base", "baseRef", *baseRef, "mergeBase", effectiveBaseRef)
+
+	// Resolve HEAD and effective base to short commit SHAs for the summary.
 	headSHA, err := git.ResolveRef(ctx, absRepoRoot, "HEAD")
 	if err != nil {
 		fatal("resolving HEAD", "err", err)
 	}
-	baseSHA, err := git.ResolveRef(ctx, absRepoRoot, *baseRef)
+	baseSHA, err := git.ResolveRef(ctx, absRepoRoot, effectiveBaseRef)
 	if err != nil {
 		fatal("resolving base ref", "err", err)
 	}
 
 	// Step 1: Get changed files via git diff
 	slog.Info("Getting changed files...")
-	changedFiles, err := git.ChangedFiles(ctx, absRepoRoot, *baseRef)
+	changedFiles, err := git.ChangedFiles(ctx, absRepoRoot, effectiveBaseRef)
 	if err != nil {
 		fatal("getting changed files", "err", err)
 	}
@@ -91,9 +101,9 @@ func main() {
 		return
 	}
 
-	// Step 2: Create a temporary git worktree at base-ref
-	slog.Info("Creating worktree...", "ref", *baseRef)
-	worktreePath, cleanup, err := git.CreateWorktree(ctx, absRepoRoot, *baseRef)
+	// Step 2: Create a temporary git worktree at the merge-base
+	slog.Info("Creating worktree...", "ref", effectiveBaseRef)
+	worktreePath, cleanup, err := git.CreateWorktree(ctx, absRepoRoot, effectiveBaseRef)
 	if err != nil {
 		fatal("creating worktree", "err", err)
 	}

--- a/infra-tools/internal/git/git.go
+++ b/infra-tools/internal/git/git.go
@@ -35,9 +35,9 @@ func ResolveRef(ctx context.Context, repoRoot, ref string) (string, error) {
 
 // ChangedFiles returns the list of files changed between baseRef and HEAD.
 // It uses a two-point diff (baseRef HEAD) which compares the full trees.
-// For accurate results the caller should ensure HEAD is a merge commit that
-// incorporates baseRef (e.g. GitHub's refs/pull/N/merge), so the diff
-// naturally contains only the PR's own changes.
+// Callers should pass the merge-base commit (see MergeBase) rather than a
+// branch name so the diff only contains the current branch's own changes,
+// regardless of whether the branch has been rebased.
 func ChangedFiles(ctx context.Context, repoRoot, baseRef string) ([]string, error) {
 	cmd := exec.CommandContext(ctx, "git", "diff", "--name-only", baseRef, "HEAD")
 	cmd.Dir = repoRoot


### PR DESCRIPTION
The merge base by Github can become stale, leading to incorrect output.
The git module already contained a function (MergeBase) to calculate the effective merge base and was used by the 'render-diff' tool but not by 'env-detector'.

This change updates the behaviour of 'env-detector' so issues caused by stale ref can be avoided.