### PR TITLE
Add cache_status label to production writeRelabelConfigs

### DIFF
--- a/components/monitoring/prometheus/production/base/monitoringstack/writeRelabelConfigs.yaml
+++ b/components/monitoring/prometheus/production/base/monitoringstack/writeRelabelConfigs.yaml
@@ -17,4 +17,4 @@
       policy_name|policy_background_mode|rule_type|policy_type|policy_validation_mode|\
       resource_request_operation|resource_kind|policy_change_type|event_type|\
       name|cluster_queue|quantile|slice|scrape_job|tested_registry|error|queue|\
-      priority_class|finalizers|severity"
+      priority_class|cache_status|finalizers|severity"


### PR DESCRIPTION
## Summary
- Add `cache_status` to the production `writeRelabelConfigs.yaml` LabelKeep regex
- The label was already present in staging but missing in production, causing Grafana cache performance dashboards to show no data in prod

## Risk Assessment
**Risk Level:** Low
**Rollback:** Revert this commit to restore previous writeRelabelConfigs
**Description:** Adds one label to the existing LabelKeep allowlist; no labels are removed or renamed

## Validation
- Staging dashboards already work with `cache_status` present in the staging writeRelabelConfigs
- Confirmed the label is the only diff between staging and production for this field