### PR TITLE
feat(KFLUXVNGD-1023): extract operator SHA and post compare link in changelog comment

### DIFF
--- a/.github/workflows/operator-changelog.yaml
+++ b/.github/workflows/operator-changelog.yaml
@@ -16,10 +16,12 @@ jobs:
       pull-requests: write
       contents: read
     steps:
-      # Check out the BASE branch (trusted code) so we never execute fork code.
-      # The binary is built here with the elevated GITHUB_TOKEN — a malicious
-      # fork cannot inject code into this step.
+      # Check out the BASE branch with full history (trusted code only).
+      # fetch-depth: 0 is required so git worktree can check out the base SHA.
+      # The binary is built here before we touch any PR-provided file content.
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-go@v5
         with:
@@ -30,10 +32,30 @@ jobs:
         working-directory: infra-tools
         run: go build -o bin/changelog-generator ./cmd/changelog-generator
 
+      # Switch the workspace to the PR merge ref so headPath reads the PR's
+      # kustomization.yaml. The binary was already built from trusted base-branch
+      # code above, so checking out PR content here is safe.
+      - name: Checkout PR merge ref
+        id: fetch-merge
+        continue-on-error: true
+        run: |
+          git fetch origin refs/pull/${{ github.event.pull_request.number }}/merge
+          git checkout FETCH_HEAD
+
+      - name: Warn about required PR rebase
+        if: ${{ always() && steps.fetch-merge.outcome == 'failure' }}
+        run: |
+          echo "ERROR: This PR has merge conflicts — please rebase before the changelog can be generated."
+          exit 1
+
       - name: Run changelog-generator
+        if: steps.fetch-merge.outcome == 'success'
         working-directory: infra-tools
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: ./bin/changelog-generator
+        run: |
+          ./bin/changelog-generator \
+            --repo-root=.. \
+            --base-ref=${{ github.event.pull_request.base.sha }}

--- a/infra-tools/cmd/changelog-generator/main.go
+++ b/infra-tools/cmd/changelog-generator/main.go
@@ -1,10 +1,9 @@
 // Command changelog-generator posts a changelog comment on infra-deployments PRs
 // that bump the Konflux operator SHA.
 //
-// This is the initial placeholder (KFLUXVNGD-1022). It proves the workflow
-// trigger and comment pipeline work end-to-end on real PRs before any
-// changelog logic is added. SHA extraction, upstream comparison, and full
-// formatting are introduced in subsequent PRs.
+// This is step 2 (KFLUXVNGD-1023): it reads the operator SHA at the base branch
+// and PR head, then posts a comment with the compare link. Upstream service
+// changes are introduced in subsequent PRs.
 package main
 
 import (
@@ -14,24 +13,29 @@ import (
 	"log/slog"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"syscall"
 
+	"github.com/redhat-appstudio/infra-deployments/infra-tools/internal/changelog"
+	"github.com/redhat-appstudio/infra-deployments/infra-tools/internal/git"
 	ghclient "github.com/redhat-appstudio/infra-deployments/infra-tools/internal/github"
 )
 
+// kustomizationPath is the path, relative to the repo root, of the
+// kustomization.yaml file that pins the operator SHA.
+const kustomizationPath = "components/konflux-operator/development/invariant/kustomization.yaml"
+
 // commentMarker identifies the changelog comment for idempotent updates.
-// This string is permanent — changing it would orphan existing comments on
-// open PRs. It moves to internal/changelog/formatter.go in a later PR;
-// the string itself never changes.
+// This string is permanent — changing it would orphan existing comments on open PRs.
 const commentMarker = "<!-- changelog-generator-comment -->"
 
-// commenter is the subset of the GitHub comment API used by this binary.
-// Defined as an interface so tests can inject a fake without network calls.
 type commenter interface {
 	UpsertCommentByMarker(ctx context.Context, prNumber int, body, marker string) error
 }
 
 func main() {
+	repoRoot := flag.String("repo-root", "", "Path to infra-deployments root (default: auto-detect via git)")
+	baseRef := flag.String("base-ref", "", "Base git ref to compare against (default: merge-base with main)")
 	dryRun := flag.Bool("dry-run", false, "Print comment to stdout instead of posting")
 	flag.Parse()
 
@@ -42,8 +46,11 @@ func main() {
 	repo := os.Getenv("GITHUB_REPOSITORY")
 	prStr := os.Getenv("PR_NUMBER")
 
-	body := commentMarker + "\n### Operator Changelog\n\n" +
-		"_This comment will show operator commits and upstream service changes in upcoming PRs._\n"
+	body, err := buildBody(ctx, *repoRoot, *baseRef)
+	if err != nil {
+		slog.Error("building changelog body", "err", err)
+		os.Exit(1)
+	}
 
 	if *dryRun {
 		fmt.Print(body)
@@ -73,9 +80,95 @@ func main() {
 	}
 }
 
+// buildBody extracts the old and new operator SHAs and returns the comment body.
+func buildBody(ctx context.Context, repoRoot, baseRef string) (string, error) {
+	absRoot, err := resolveRepoRoot(ctx, repoRoot)
+	if err != nil {
+		return "", fmt.Errorf("resolving repo root: %w", err)
+	}
+
+	effectiveBaseRef := baseRef
+	if effectiveBaseRef == "" {
+		effectiveBaseRef, err = git.MergeBase(ctx, absRoot, "origin/main")
+		if err != nil {
+			return "", fmt.Errorf("computing merge-base (pass --base-ref to override): %w", err)
+		}
+	}
+
+	worktreePath, cleanup, err := git.CreateWorktree(ctx, absRoot, effectiveBaseRef)
+	if err != nil {
+		return "", fmt.Errorf("creating worktree: %w", err)
+	}
+	defer cleanup()
+
+	basePath := filepath.Join(worktreePath, kustomizationPath)
+	headPath := filepath.Join(absRoot, kustomizationPath)
+
+	return computeBody(basePath, headPath)
+}
+
+// computeBody extracts refs from the two kustomization files and returns the
+// appropriate comment body. It is the testable core of buildBody — all git
+// setup happens in buildBody; this function only does file I/O and formatting.
+func computeBody(basePath, headPath string) (string, error) {
+	oldRef, newRef, err := changelog.ExtractRefs(basePath, headPath)
+	if err != nil {
+		return "", fmt.Errorf("extracting operator refs: %w", err)
+	}
+
+	if oldRef != newRef {
+		slog.Info("Operator ref bumped", "old", oldRef, "new", newRef)
+	} else {
+		slog.Info("Operator ref unchanged — no changelog needed")
+	}
+	return selectBody(oldRef, newRef), nil
+}
+
+// selectBody returns the appropriate comment body based on whether the ref changed.
+func selectBody(oldRef, newRef string) string {
+	if oldRef == newRef {
+		return formatNoChange()
+	}
+	return formatCompare(oldRef, newRef)
+}
+
+// formatNoChange returns the comment body when the operator ref did not change.
+func formatNoChange() string {
+	return commentMarker + "\n### Operator Changelog\n\nNo operator ref change detected in this PR.\n"
+}
+
+// formatCompare returns the comment body with a compare link between the two refs.
+// Upstream service changes will be added in the next PR.
+func formatCompare(oldRef, newRef string) string {
+	const base = "https://github.com/konflux-ci/konflux-ci"
+	short := func(ref string) string {
+		if len(ref) > 12 {
+			return ref[:12]
+		}
+		return ref
+	}
+	return fmt.Sprintf(
+		"%s\n### Operator Changelog\n\nComparing [`%s`](%s/commit/%s) → [`%s`](%s/commit/%s)\n\n[Full diff](%s/compare/%s...%s)\n\n_Upstream service changes coming in the next PR._\n",
+		commentMarker,
+		short(oldRef), base, oldRef,
+		short(newRef), base, newRef,
+		base, oldRef, newRef,
+	)
+}
+
+// resolveRepoRoot returns the absolute path to the repository root.
+func resolveRepoRoot(ctx context.Context, repoRoot string) (string, error) {
+	if repoRoot == "" {
+		detected, err := git.TopLevel(ctx)
+		if err != nil {
+			return "", fmt.Errorf("auto-detecting repo root (use --repo-root to override): %w", err)
+		}
+		repoRoot = detected
+	}
+	return filepath.Abs(repoRoot)
+}
+
 // post delivers body as a PR comment using the provided commenter.
-// Keeping the commenter as an injected interface allows tests to verify
-// the correct body and PR number are passed without making real API calls.
 func post(ctx context.Context, c commenter, prNumber int, body string) error {
 	return c.UpsertCommentByMarker(ctx, prNumber, body, commentMarker)
 }

--- a/infra-tools/cmd/changelog-generator/main_test.go
+++ b/infra-tools/cmd/changelog-generator/main_test.go
@@ -1,0 +1,168 @@
+package main
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+const (
+	oldRef = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	newRef = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+)
+
+// fakeCommenter records the most recent UpsertCommentByMarker call.
+type fakeCommenter struct {
+	prNumber int
+	body     string
+	marker   string
+}
+
+func (f *fakeCommenter) UpsertCommentByMarker(_ context.Context, prNumber int, body, marker string) error {
+	f.prNumber = prNumber
+	f.body = body
+	f.marker = marker
+	return nil
+}
+
+func writeTempKustomization(t *testing.T, ref string) string {
+	t.Helper()
+	content := "apiVersion: kustomize.config.k8s.io/v1beta1\nkind: Kustomization\nresources:\n" +
+		"  - https://github.com/konflux-ci/konflux-ci/operator/config/default?ref=" + ref + "\n"
+	f, err := os.CreateTemp(t.TempDir(), "kustomization-*.yaml")
+	if err != nil {
+		t.Fatalf("creating temp file: %v", err)
+	}
+	if _, err := f.WriteString(content); err != nil {
+		t.Fatalf("writing temp file: %v", err)
+	}
+	_ = f.Close()
+	return f.Name()
+}
+
+// TestPost_PassesCorrectMarkerAndBody verifies that post wires the permanent
+// commentMarker through to UpsertCommentByMarker, not some other value.
+func TestPost_PassesCorrectMarkerAndBody(t *testing.T) {
+	g := NewWithT(t)
+	fake := &fakeCommenter{}
+	err := post(context.Background(), fake, 42, "hello")
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(fake.prNumber).To(Equal(42))
+	g.Expect(fake.body).To(Equal("hello"))
+	g.Expect(fake.marker).To(Equal(commentMarker))
+}
+
+// TestFormatCompare_ShortRef verifies refs under 12 chars (e.g. branch names)
+// are not truncated — the short() helper takes a different branch.
+func TestFormatCompare_ShortRef(t *testing.T) {
+	g := NewWithT(t)
+	body := formatCompare("main", "feature-x")
+	g.Expect(body).To(ContainSubstring("main"))
+	g.Expect(body).To(ContainSubstring("feature-x"))
+}
+
+// TestComputeBody_Unchanged verifies that identical kustomization files produce
+// the no-change comment body with the required marker and heading.
+func TestComputeBody_Unchanged(t *testing.T) {
+	g := NewWithT(t)
+	path := writeTempKustomization(t, oldRef)
+	body, err := computeBody(path, path)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(body).To(ContainSubstring(commentMarker))
+	g.Expect(body).To(ContainSubstring("### Operator Changelog"))
+	g.Expect(body).To(ContainSubstring("No operator ref change"))
+}
+
+// TestComputeBody_Changed verifies that different kustomization files produce
+// a compare comment containing both refs, short display refs, and a compare URL.
+func TestComputeBody_Changed(t *testing.T) {
+	g := NewWithT(t)
+	basePath := writeTempKustomization(t, oldRef)
+	headPath := writeTempKustomization(t, newRef)
+	body, err := computeBody(basePath, headPath)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(body).To(ContainSubstring(commentMarker))
+	g.Expect(body).To(ContainSubstring(oldRef))
+	g.Expect(body).To(ContainSubstring(newRef))
+	g.Expect(body).To(ContainSubstring(oldRef[:12]))
+	g.Expect(body).To(ContainSubstring("konflux-ci/konflux-ci/compare/" + oldRef + "..." + newRef))
+	g.Expect(body).NotTo(ContainSubstring("No operator ref change"))
+}
+
+// TestComputeBody_Error verifies that an unreadable file returns an error.
+func TestComputeBody_Error(t *testing.T) {
+	g := NewWithT(t)
+	_, err := computeBody("/nonexistent/kustomization.yaml", "/nonexistent/kustomization.yaml")
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("extracting operator refs"))
+}
+
+// TestBuildBody_Integration creates a real git repo with two commits that have
+// different operator refs, then calls buildBody to validate the full git path:
+// worktree creation, kustomization parsing, and comment body selection.
+func TestBuildBody_Integration(t *testing.T) {
+	g := NewWithT(t)
+
+	// Set up a bare git repo with minimal config.
+	dir := t.TempDir()
+	gitRun(t, dir, "init")
+	gitRun(t, dir, "config", "user.email", "test@example.com")
+	gitRun(t, dir, "config", "user.name", "Test")
+
+	// Commit 1: kustomization with oldRef (this becomes the base).
+	kustPath := filepath.Join(dir, kustomizationPath)
+	g.Expect(os.MkdirAll(filepath.Dir(kustPath), 0755)).To(Succeed())
+	writeKustomizationFile(t, kustPath, oldRef)
+	gitRun(t, dir, "add", ".")
+	gitRun(t, dir, "commit", "-m", "initial")
+	baseCommit := strings.TrimSpace(gitOutput(t, dir, "rev-parse", "HEAD"))
+
+	// Commit 2: kustomization with newRef (this becomes HEAD).
+	writeKustomizationFile(t, kustPath, newRef)
+	gitRun(t, dir, "add", ".")
+	gitRun(t, dir, "commit", "-m", "bump operator ref")
+
+	// buildBody should detect the change and return a compare body.
+	body, err := buildBody(context.Background(), dir, baseCommit)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(body).To(ContainSubstring(oldRef))
+	g.Expect(body).To(ContainSubstring(newRef))
+	g.Expect(body).To(ContainSubstring("compare"))
+}
+
+// gitRun runs a git command in dir and fails the test on error.
+func gitRun(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.CommandContext(context.Background(), "git", args...)
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, out)
+	}
+}
+
+// gitOutput runs a git command and returns its stdout.
+func gitOutput(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.CommandContext(context.Background(), "git", args...)
+	cmd.Dir = dir
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("git %v: %v", args, err)
+	}
+	return string(out)
+}
+
+// writeKustomizationFile writes a minimal kustomization.yaml with the given ref.
+func writeKustomizationFile(t *testing.T, path, ref string) {
+	t.Helper()
+	content := "apiVersion: kustomize.config.k8s.io/v1beta1\nkind: Kustomization\nresources:\n" +
+		"  - https://github.com/konflux-ci/konflux-ci/operator/config/default?ref=" + ref + "\n"
+	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+		t.Fatalf("writing kustomization: %v", err)
+	}
+}

--- a/infra-tools/internal/changelog/extractor.go
+++ b/infra-tools/internal/changelog/extractor.go
@@ -1,0 +1,68 @@
+// Package changelog provides logic for generating a human-readable changelog
+// when the Konflux operator ref is bumped in infra-deployments.
+package changelog
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// operatorResourceURL is the prefix of the GitHub URL used in the resources
+// block to pin the operator source. The ?ref= query parameter holds the git ref.
+const operatorResourceURL = "https://github.com/konflux-ci/konflux-ci/"
+
+// kustomization is a minimal representation of the fields we need from the
+// operator kustomization.yaml. Only the resources block is parsed.
+type kustomization struct {
+	Resources []string `yaml:"resources"`
+}
+
+// ExtractRef reads the kustomization.yaml at the given path and returns the
+// git ref from the ?ref= query parameter of the operator resource URL.
+//
+// Returns an error if the file cannot be read, the YAML cannot be parsed, or
+// no operator resource URL is found. The ref value is returned as-is — format
+// validation happens later at the point of use.
+func ExtractRef(path string) (string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("reading %s: %w", path, err)
+	}
+
+	var k kustomization
+	if err := yaml.Unmarshal(data, &k); err != nil {
+		return "", fmt.Errorf("parsing %s: %w", path, err)
+	}
+
+	for _, resource := range k.Resources {
+		if !strings.Contains(resource, operatorResourceURL) {
+			continue
+		}
+		parts := strings.SplitN(resource, "?ref=", 2)
+		if len(parts) == 2 && parts[1] != "" {
+			return parts[1], nil
+		}
+	}
+
+	return "", fmt.Errorf("%s: no operator resource URL containing %q found", path, operatorResourceURL)
+}
+
+// ExtractRefs reads the kustomization.yaml at both basePath (base branch) and
+// headPath (PR branch) and returns (oldRef, newRef, error). When the two refs
+// are equal the operator was not bumped and changelog generation can be skipped.
+func ExtractRefs(basePath, headPath string) (string, string, error) {
+	oldRef, err := ExtractRef(basePath)
+	if err != nil {
+		return "", "", fmt.Errorf("extracting base ref: %w", err)
+	}
+
+	newRef, err := ExtractRef(headPath)
+	if err != nil {
+		return "", "", fmt.Errorf("extracting head ref: %w", err)
+	}
+
+	return oldRef, newRef, nil
+}

--- a/infra-tools/internal/changelog/extractor_test.go
+++ b/infra-tools/internal/changelog/extractor_test.go
@@ -1,0 +1,142 @@
+package changelog_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/redhat-appstudio/infra-deployments/infra-tools/internal/changelog"
+)
+
+const realRef = "0bace1e20ff164a00e9d6becfce52e310a921931"
+
+// validKustomization is a minimal kustomization.yaml matching the real file.
+const validKustomization = `apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - https://github.com/konflux-ci/konflux-ci/operator/config/default?ref=0bace1e20ff164a00e9d6becfce52e310a921931
+  - konflux.yaml
+patches:
+  - path: release-config.yaml
+images:
+  - name: localhost/konflux-operator
+    newName: quay.io/konflux-ci/konflux-operator
+    newTag: 0bace1e20ff164a00e9d6becfce52e310a921931
+`
+
+func writeTemp(t *testing.T, content string) string {
+	t.Helper()
+	f, err := os.CreateTemp(t.TempDir(), "kustomization-*.yaml")
+	if err != nil {
+		t.Fatalf("creating temp file: %v", err)
+	}
+	if _, err := f.WriteString(content); err != nil {
+		t.Fatalf("writing temp file: %v", err)
+	}
+	_ = f.Close()
+	return f.Name()
+}
+
+func TestExtractRef_ValidFile(t *testing.T) {
+	g := NewWithT(t)
+	path := writeTemp(t, validKustomization)
+	ref, err := changelog.ExtractRef(path)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(ref).To(Equal(realRef))
+}
+
+func TestExtractRef_RealFile(t *testing.T) {
+	g := NewWithT(t)
+	// Walk up from this test file to the repo root and find the real overlay.
+	path := filepath.Join("..", "..", "..", "components",
+		"konflux-operator", "development", "invariant", "kustomization.yaml")
+	ref, err := changelog.ExtractRef(path)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(ref).NotTo(BeEmpty())
+}
+
+func TestExtractRef_FileNotFound(t *testing.T) {
+	g := NewWithT(t)
+	_, err := changelog.ExtractRef("/nonexistent/path/kustomization.yaml")
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("reading"))
+}
+
+func TestExtractRef_InvalidYAML(t *testing.T) {
+	g := NewWithT(t)
+	path := writeTemp(t, "this: is: not: valid: yaml: ][")
+	_, err := changelog.ExtractRef(path)
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("parsing"))
+}
+
+func TestExtractRef_MissingResourceEntry(t *testing.T) {
+	g := NewWithT(t)
+	content := `apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - some-other-resource.yaml
+`
+	path := writeTemp(t, content)
+	_, err := changelog.ExtractRef(path)
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("no operator resource URL"))
+}
+
+func TestExtractRef_ResourceURLWithoutRef(t *testing.T) {
+	g := NewWithT(t)
+	content := `apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - https://github.com/konflux-ci/konflux-ci/operator/config/default
+`
+	path := writeTemp(t, content)
+	_, err := changelog.ExtractRef(path)
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("no operator resource URL"))
+}
+
+func TestExtractRefs_Unchanged(t *testing.T) {
+	g := NewWithT(t)
+	path := writeTemp(t, validKustomization)
+	old, new, err := changelog.ExtractRefs(path, path)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(old).To(Equal(realRef))
+	g.Expect(new).To(Equal(realRef))
+}
+
+func TestExtractRefs_Changed(t *testing.T) {
+	g := NewWithT(t)
+
+	updatedRef := "9f8e7d6c5b4a3f2e1d0c9b8a7f6e5d4c3b2a1f09"
+	newContent := `apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - https://github.com/konflux-ci/konflux-ci/operator/config/default?ref=9f8e7d6c5b4a3f2e1d0c9b8a7f6e5d4c3b2a1f09
+`
+	basePath := writeTemp(t, validKustomization)
+	headPath := writeTemp(t, newContent)
+
+	old, new, err := changelog.ExtractRefs(basePath, headPath)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(old).To(Equal(realRef))
+	g.Expect(new).To(Equal(updatedRef))
+}
+
+func TestExtractRefs_BaseError(t *testing.T) {
+	g := NewWithT(t)
+	headPath := writeTemp(t, validKustomization)
+	_, _, err := changelog.ExtractRefs("/nonexistent/kustomization.yaml", headPath)
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("base ref"))
+}
+
+func TestExtractRefs_HeadError(t *testing.T) {
+	g := NewWithT(t)
+	basePath := writeTemp(t, validKustomization)
+	_, _, err := changelog.ExtractRefs(basePath, "/nonexistent/kustomization.yaml")
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("head ref"))
+}


### PR DESCRIPTION
Reads the operator image SHA from kustomization.yaml at both the base branch and PR head, then updates the changelog comment with a compare link (old → new SHA) or a "no change" message. Introduces internal/changelog/extractor.go and updates the workflow to use full git history and the PR merge ref.