### PR TITLE
test: install konflux using the operator and run e2e tests

### DIFF
--- a/components/konflux-operator/ci/openshift-overlay-e2e/README.md
+++ b/components/konflux-operator/ci/openshift-overlay-e2e/README.md
@@ -12,14 +12,14 @@ step refs (`konflux-ci-install-konflux`, `redhat-appstudio-conformance-tests`).
 |------|------|
 | `Dockerfile` | Unified CI image (`konflux-overlay-install`): task-runner + Go 1.26 from ubi10/go-toolset |
 | `ci-common.sh` | Shared cluster login (temp kubeconfig copy) and ephemeral git credentials |
-| `install.sh` | Cluster bootstrap (`preview --operator-overlay`), secrets, SprayProxy |
-| `run-e2e.sh` | Clone konflux-ci @ pinned ref and run conformance tests |
+| `install.sh` | `hack/bootstrap-cluster.sh preview --operator-overlay`, QE secrets, SprayProxy, `e2e-secrets` quay pull secret |
+| `run-e2e.sh` | Clone konflux-ci @ ref from `invariant/kustomization.yaml`; `prepare-conformance-env` + `run-conformance-tests.sh` in `default-tenant` (no `deploy-test-resources.sh`) |
 
 ## CI flow (both steps use the same pattern)
 
 1. ci-operator builds `konflux-overlay-install` from `Dockerfile` (per job, not promoted to `ci/`).
 2. Install and e2e steps both use `from: konflux-overlay-install` in openshift/release.
-3. Shared entrypoint `redhat-appstudio-operator-overlay-install-commands.sh` clones `infra-deployments`, merges the PR when applicable, and calls `ci-common.sh`.
+3. Shared entrypoint `redhat-appstudio-operator-overlay-commands.sh` clones `infra-deployments`, merges the PR when applicable, and calls `ci-common.sh`.
 4. The e2e step sets `OVERLAY_E2E_SCRIPT_NAME=run-e2e.sh` and sources that same entrypoint.
 5. `install.sh` or `run-e2e.sh` runs the phase-specific logic.
 

--- a/components/konflux-operator/ci/openshift-overlay-e2e/ci-common.sh
+++ b/components/konflux-operator/ci/openshift-overlay-e2e/ci-common.sh
@@ -14,6 +14,7 @@ _ci_git_config_global_original=""
 _ci_git_config_nosystem_was_set=false
 _ci_git_config_nosystem_original=""
 
+# Remove the temporary kubeconfig copy and restore KUBECONFIG to the path the step had on entry.
 _ci_cleanup_kubeconfig_copy() {
   if [[ -n "${_ci_kubeconfig_copy}" ]]; then
     rm -f "${_ci_kubeconfig_copy}"
@@ -24,6 +25,7 @@ _ci_cleanup_kubeconfig_copy() {
   fi
 }
 
+# Tear down isolated git config/credential files and restore GIT_CONFIG_* env from before ci_configure_git_credentials.
 _ci_cleanup_git_credentials() {
   if [[ "${_ci_git_config_global_was_set}" == true ]]; then
     export GIT_CONFIG_GLOBAL="${_ci_git_config_global_original}"
@@ -46,11 +48,16 @@ _ci_cleanup_git_credentials() {
   _ci_git_creds_path=""
 }
 
+# EXIT trap handler: run all ephemeral credential and kubeconfig cleanup.
 _ci_cleanup() {
   _ci_cleanup_git_credentials
   _ci_cleanup_kubeconfig_copy
 }
 
+# Log into the claimed cluster without mutating the original KUBECONFIG file.
+# Copies KUBECONFIG to a temp file, relaxes TLS verification on the copy (Hive pool parity with other Konflux CI steps),
+# reads kubeadmin password from KUBEADMIN_PASSWORD_FILE or SHARED_DIR, and retries oc login for up to 5 minutes.
+# Registers _ci_cleanup on EXIT.
 ci_prepare_cluster_access() {
   local openshift_api openshift_password cluster_name
 
@@ -91,6 +98,9 @@ ci_prepare_cluster_access() {
 EOF
 }
 
+# Configure ephemeral git identity and HTTPS credentials for github.com using GITHUB_TOKEN.
+# Uses a private temp gitconfig and credential store (mode 600) so the runner user's ~/.gitconfig is untouched.
+# Registers _ci_cleanup on EXIT.
 ci_configure_git_credentials() {
   local github_user="${GITHUB_USER:-x-access-token}"
 
@@ -123,4 +133,149 @@ ci_configure_git_credentials() {
   git config --global credential.helper "store --file ${_ci_git_creds_path}"
 
   trap _ci_cleanup EXIT
+}
+
+# Parse the konflux-ci operator install git ref from invariant/kustomization.yaml
+# (the ?ref= on the konflux-ci/operator/config/default remote resource).
+# Prints the ref to stdout; returns non-zero if the file or ref is missing.
+ci_parse_konflux_ci_ref() {
+  local kustomization="${1:?kustomization path required}"
+  local ref
+
+  if [[ ! -f "${kustomization}" ]]; then
+    echo "ERROR: kustomization not found: ${kustomization}" >&2
+    return 1
+  fi
+
+  ref="$(grep -E 'konflux-ci/konflux-ci/operator/config/default\?ref=' "${kustomization}" \
+    | head -1 \
+    | sed -n 's/.*ref=\([^[:space:]]*\).*/\1/p')"
+  if [[ -z "${ref}" ]]; then
+    echo "ERROR: could not parse konflux-ci ref from ${kustomization}" >&2
+    return 1
+  fi
+  printf '%s\n' "${ref}"
+}
+
+# Choose a GitHub user:token pair from konflux-ci-secrets github_accounts by highest API rate limit.
+# Exports GITHUB_USER and GITHUB_TOKEN for subsequent git and preview bootstrap operations.
+ci_select_github_account() {
+  local secrets_dir="${1:?secrets dir required}"
+  local accounts_file="${secrets_dir}/github_accounts"
+  local account github_user github_token rate previous_rate=0
+
+  if [[ ! -s "${accounts_file}" ]]; then
+    echo "ERROR: ${accounts_file} is missing or empty" >&2
+    return 1
+  fi
+
+  IFS=',' read -r -a _ci_github_accounts <<< "$(cat "${accounts_file}")"
+  for account in "${_ci_github_accounts[@]}"; do
+    IFS=':' read -r github_user github_token <<< "${account}"
+    if rate="$(curl --fail --silent --max-time 10 \
+      -H "Accept: application/vnd.github+json" \
+      -H "Authorization: Bearer ${github_token}" \
+      https://api.github.com/rate_limit | jq -er '.rate.remaining')"; then
+      echo "[INFO] GitHub user ${github_user}: ${rate} requests remaining"
+      if [[ "${rate}" -ge "${previous_rate}" ]]; then
+        GITHUB_USER="${github_user}"
+        GITHUB_TOKEN="${github_token}"
+        previous_rate="${rate}"
+      fi
+    else
+      echo "[WARN] Failed to get rate limit for user: ${github_user}" >&2
+    fi
+  done
+
+  if [[ -z "${GITHUB_USER:-}" || -z "${GITHUB_TOKEN:-}" ]]; then
+    echo "ERROR: No valid GitHub credentials found in ${accounts_file}" >&2
+    return 1
+  fi
+  export GITHUB_USER GITHUB_TOKEN
+  echo "[INFO] Selected GitHub user: ${GITHUB_USER}"
+}
+
+# Load QE secret files and export environment variables expected by hack/preview.sh and hack/bootstrap-cluster.sh.
+# Selects the best GitHub account, wires the redhat-appstudio-qe fork remote, and sets Quay, PAC, Smee, and
+# PREVIEW_WAIT_KONFLUX_CR_READY. Requires INFRA_DEPLOYMENTS_ROOT (the cloned infra-deployments tree).
+ci_export_preview_install_env() {
+  local secrets_dir="${1:?secrets dir required}"
+
+  : "${INFRA_DEPLOYMENTS_ROOT:?INFRA_DEPLOYMENTS_ROOT must be set}"
+  cd "${INFRA_DEPLOYMENTS_ROOT}" || return 1
+
+  ci_select_github_account "${secrets_dir}"
+
+  git remote add origin "https://github.com/redhat-appstudio-qe/infra-deployments.git" 2>/dev/null || true
+  git fetch origin main 2>/dev/null || true
+
+  export MY_GITHUB_ORG="${MY_GITHUB_ORG:-redhat-appstudio-qe}"
+  export MY_GITHUB_TOKEN="${GITHUB_TOKEN}"
+  export MY_GIT_FORK_REMOTE="${MY_GIT_FORK_REMOTE:-origin}"
+  export TEST_BRANCH_ID="${TEST_BRANCH_ID:-$(head /dev/urandom | tr -dc a-z0-9 | head -c 4)}"
+  export QUAY_TOKEN
+  QUAY_TOKEN="$(cat "${secrets_dir}/quay-token")"
+  export IMAGE_CONTROLLER_QUAY_ORG="${IMAGE_CONTROLLER_QUAY_ORG:-redhat-appstudio-qe}"
+  export IMAGE_CONTROLLER_QUAY_TOKEN
+  IMAGE_CONTROLLER_QUAY_TOKEN="$(cat "${secrets_dir}/default-quay-org-token")"
+  export BUILD_SERVICE_IMAGE_TAG_EXPIRATION="${BUILD_SERVICE_IMAGE_TAG_EXPIRATION:-5d}"
+  export PAC_GITHUB_APP_ID
+  PAC_GITHUB_APP_ID="$(cat "${secrets_dir}/pac-github-app-id")"
+  export PAC_GITHUB_APP_PRIVATE_KEY
+  PAC_GITHUB_APP_PRIVATE_KEY="$(cat "${secrets_dir}/pac-github-app-private-key")"
+  export PAC_GITHUB_APP_WEBHOOK_SECRET
+  PAC_GITHUB_APP_WEBHOOK_SECRET="$(cat "${secrets_dir}/pac-github-app-webhook-secret")"
+  export SMEE_CHANNEL
+  SMEE_CHANNEL="$(cat "${secrets_dir}/smee-channel")"
+  export PREVIEW_WAIT_KONFLUX_CR_READY="${PREVIEW_WAIT_KONFLUX_CR_READY:-true}"
+}
+
+# Register the cluster's Pipelines-as-Code controller route with the shared QE SprayProxy service
+# so GitHub webhooks reach PAC during install and e2e. Reads qe-sprayproxy-* from secrets_dir.
+ci_register_sprayproxy_pac_route() {
+  local secrets_dir="${1:?secrets dir required}"
+  local sprayproxy_host sprayproxy_token pac_route http_code
+
+  sprayproxy_host="$(cat "${secrets_dir}/qe-sprayproxy-host")"
+  sprayproxy_token="$(cat "${secrets_dir}/qe-sprayproxy-token")"
+
+  pac_route="$(oc get route pipelines-as-code-controller -n openshift-pipelines -o jsonpath='{.spec.host}')"
+  if [[ -z "${pac_route}" ]]; then
+    echo "ERROR: PAC route pipelines-as-code-controller not found in openshift-pipelines" >&2
+    return 1
+  fi
+
+  echo "[INFO] Registering PAC route https://${pac_route} with SprayProxy..."
+  http_code="$(curl -s -o /dev/null -w "%{http_code}" \
+    --connect-timeout 10 \
+    --max-time 30 \
+    --retry 3 \
+    -X POST \
+    -H "Authorization: Bearer ${sprayproxy_token}" \
+    -H "Content-Type: application/json" \
+    -d "{\"url\":\"https://${pac_route}\"}" \
+    "${sprayproxy_host}/backends")"
+
+  if [[ "${http_code}" =~ ^(200|201|302)$ ]]; then
+    echo "[INFO] SprayProxy registration succeeded (HTTP ${http_code})"
+    return 0
+  fi
+  echo "ERROR: SprayProxy registration failed (HTTP ${http_code})" >&2
+  return 1
+}
+
+# Create or update the e2e-secrets/quay-repository docker-registry secret from a base64-encoded QUAY_TOKEN
+# (same pattern as legacy appstudio e2e install). Used by tests that pull from the QE Quay org.
+ci_create_e2e_quay_secret() {
+  local quay_token="${1:?quay token required}"
+  local temp_dockerconfig
+
+  temp_dockerconfig="$(mktemp)"
+  echo "${quay_token}" | base64 -d > "${temp_dockerconfig}"
+  oc create namespace e2e-secrets --dry-run=client -o yaml | oc apply -f -
+  oc create secret docker-registry quay-repository \
+    -n e2e-secrets \
+    --from-file=.dockerconfigjson="${temp_dockerconfig}" \
+    --dry-run=client -o yaml | oc apply -f -
+  rm -f "${temp_dockerconfig}"
 }

--- a/components/konflux-operator/ci/openshift-overlay-e2e/install.sh
+++ b/components/konflux-operator/ci/openshift-overlay-e2e/install.sh
@@ -1,7 +1,31 @@
 #!/usr/bin/env bash
-# Phase 2: bootstrap cluster with development-operator overlay (hack/bootstrap-cluster.sh preview --operator-overlay),
-# secrets, SprayProxy, optional Konflux CR wait.
+# Bootstrap the claimed OpenShift cluster with development-operator overlay preview.
 set -euo pipefail
 
-echo "[openshift-operator-overlay-e2e] install.sh placeholder: noop (implementation pending)"
-echo "  Expected later: hack/bootstrap-cluster.sh preview --operator-overlay and QE secrets"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SECRETS_DIR="${KONFLUX_CI_SECRETS_DIR:-/usr/local/konflux-ci-secrets-new/redhat-appstudio-qe}"
+
+: "${INFRA_DEPLOYMENTS_ROOT:?INFRA_DEPLOYMENTS_ROOT must be set by the CI entrypoint}"
+
+# shellcheck source=ci-common.sh
+source "${SCRIPT_DIR}/ci-common.sh"
+
+cd "${INFRA_DEPLOYMENTS_ROOT}"
+
+echo "[INFO] Configuring preview install environment from QE secrets..."
+ci_export_preview_install_env "${SECRETS_DIR}"
+
+echo "[INFO] Marking control-plane nodes schedulable (small CI clusters)..."
+oc patch scheduler cluster --type=merge -p '{"spec":{"mastersSchedulable":true}}' 2>&1 \
+  || echo "[WARN] Could not patch scheduler (may be HyperShift)"
+
+echo "[INFO] Running hack/bootstrap-cluster.sh preview --operator-overlay..."
+./hack/bootstrap-cluster.sh preview --operator-overlay
+
+echo "[INFO] Creating e2e-secrets/quay-repository..."
+ci_create_e2e_quay_secret "${QUAY_TOKEN}"
+
+echo "[INFO] Registering PAC with SprayProxy..."
+ci_register_sprayproxy_pac_route "${SECRETS_DIR}"
+
+echo "[INFO] install.sh complete (development-operator overlay)"

--- a/components/konflux-operator/ci/openshift-overlay-e2e/run-e2e.sh
+++ b/components/konflux-operator/ci/openshift-overlay-e2e/run-e2e.sh
@@ -1,6 +1,57 @@
 #!/usr/bin/env bash
-# Phase 2: clone konflux-ci/konflux-ci at ref from invariant/kustomization.yaml and run conformance (go test).
+# Run konflux-ci conformance tests against the operator overlay cluster.
 set -euo pipefail
 
-echo "[openshift-operator-overlay-e2e] run-e2e.sh placeholder: noop (implementation pending)"
-echo "  Expected later: konflux-ci conformance in E2E_APPLICATIONS_NAMESPACE=default-tenant"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+INVARIANT_KUSTOMIZATION="components/konflux-operator/development/invariant/kustomization.yaml"
+KONFLUX_CI_REPO="${KONFLUX_CI_REPO:-konflux-ci/konflux-ci}"
+
+: "${INFRA_DEPLOYMENTS_ROOT:?INFRA_DEPLOYMENTS_ROOT must be set by the CI entrypoint}"
+: "${GITHUB_TOKEN:?GITHUB_TOKEN must be set by the CI entrypoint}"
+
+# shellcheck source=ci-common.sh
+source "${SCRIPT_DIR}/ci-common.sh"
+
+cd "${INFRA_DEPLOYMENTS_ROOT}"
+
+if ! command -v kubectl &>/dev/null && command -v oc &>/dev/null; then
+  kubectl() { oc "$@"; }
+  export -f kubectl
+fi
+
+KONFLUX_CI_REF="$(ci_parse_konflux_ci_ref "${INVARIANT_KUSTOMIZATION}")"
+echo "[INFO] konflux-ci ref from ${INVARIANT_KUSTOMIZATION}: ${KONFLUX_CI_REF}"
+
+KONFLUX_CI_DIR="$(mktemp -d)/konflux-ci"
+echo "[INFO] Cloning ${KONFLUX_CI_REPO}..."
+git clone --origin upstream --branch main \
+  "https://${GITHUB_TOKEN}@github.com/${KONFLUX_CI_REPO}.git" "${KONFLUX_CI_DIR}"
+
+cd "${KONFLUX_CI_DIR}"
+if [[ "${KONFLUX_CI_REF}" != "main" ]]; then
+  git fetch --tags upstream 2>/dev/null || git fetch upstream
+  git checkout "${KONFLUX_CI_REF}" || {
+    echo "ERROR: failed to checkout konflux-ci ref ${KONFLUX_CI_REF}" >&2
+    exit 1
+  }
+fi
+
+export GH_ORG="${MY_GITHUB_ORG:-redhat-appstudio-qe}"
+export GH_TOKEN="${GITHUB_TOKEN}"
+export E2E_APPLICATIONS_NAMESPACE="${E2E_APPLICATIONS_NAMESPACE:-default-tenant}"
+
+if [[ -n "${GINKGO_LABEL_FILTER:-}" ]]; then
+  export E2E_CONFORMANCE_GO_TEST_EXTRA_ARGS="-ginkgo.label-filter=${GINKGO_LABEL_FILTER}"
+fi
+
+echo "[INFO] Preparing conformance environment (pipeline bundle pin)..."
+# prepare-conformance-env.sh prints export lines when not in GitHub Actions.
+eval "$(bash scripts/operator-e2e/prepare-conformance-env.sh "${KONFLUX_CI_DIR}")"
+
+JUNIT_REPORT="${ARTIFACT_DIR:-/tmp}/junit-conformance.xml"
+mkdir -p "$(dirname "${JUNIT_REPORT}")"
+
+echo "[INFO] Running conformance tests (namespace=${E2E_APPLICATIONS_NAMESPACE})..."
+bash scripts/operator-e2e/run-conformance-tests.sh "${KONFLUX_CI_DIR}" "${JUNIT_REPORT}"
+
+echo "[INFO] run-e2e.sh complete"

--- a/hack/build/setup-pac-integration.sh
+++ b/hack/build/setup-pac-integration.sh
@@ -126,7 +126,7 @@ setup-pac-app() (
         sleep $ROUTE_WAIT_INTERVAL
         retry=$((retry+1))
     done
-    
+
     pac_host=$(oc get -n $PAC_NAMESPACE route pipelines-as-code-controller -o go-template="{{ .spec.host }}")
     log_success "PAC route is available: https://$pac_host"
 
@@ -134,7 +134,7 @@ setup-pac-app() (
     log_substep "Updating GitHub App webhook configuration"
     log_debug "  - Webhook URL: https://$pac_host"
     log_debug "  - GitHub App ID: $PAC_GITHUB_APP_ID"
-    
+
     local curl_response curl_status
     curl_response=$(curl -s -w "\n%{http_code}" \
         -X PATCH \
@@ -142,9 +142,9 @@ setup-pac-app() (
         -H "Authorization: Bearer $token" \
         https://api.github.com/app/hook/config \
         -d "{\"content_type\":\"json\",\"insecure_ssl\":\"1\",\"secret\":\"$webhook_secret\",\"url\":\"https://$pac_host\"}")
-    
+
     curl_status=$(echo "$curl_response" | tail -n1)
-    
+
     if [ "$curl_status" -ge 200 ] && [ "$curl_status" -lt 300 ]; then
         log_success "GitHub App webhook configuration updated successfully"
     else
@@ -173,7 +173,7 @@ create_namespace_if_needed() {
 create_pac_secret() {
     local namespace=$1
     local secret_data=$2
-    
+
     log_substep "Creating PAC secret in namespace '$namespace'"
     if eval "oc -n '$namespace' create secret generic '$PAC_SECRET_NAME' $secret_data -o yaml --dry-run=client" | oc apply -f-; then
         log_success "PAC secret configured in '$namespace'"
@@ -203,7 +203,7 @@ GITLAB_WEBHOOK_DATA=""
 if [ -n "${PAC_GITHUB_APP_ID}" ] && [ -n "${PAC_GITHUB_APP_PRIVATE_KEY}" ]; then
     log_info "Authentication method: GitHub App"
     log_info "  - GitHub App ID: $PAC_GITHUB_APP_ID"
-    
+
     # if using the existing QE sprayproxy, we suppose the setup between sprayproxy and github App is already done
     if [ -n "${PAC_GITHUB_APP_WEBHOOK_SECRET}" ]; then
         log_info "Using existing QE sprayproxy configuration (webhook secret provided)"
@@ -217,14 +217,14 @@ if [ -n "${PAC_GITHUB_APP_ID}" ] && [ -n "${PAC_GITHUB_APP_PRIVATE_KEY}" ]; then
             exit 1
         fi
     fi
-    
+
     GITHUB_APP_PRIVATE_KEY=$(echo "$PAC_GITHUB_APP_PRIVATE_KEY" | base64 -d)
     if [ -z "$GITHUB_APP_PRIVATE_KEY" ]; then
         log_error "Failed to decode GitHub App private key"
         log_error "ACTION REQUIRED: Verify PAC_GITHUB_APP_PRIVATE_KEY is valid base64-encoded PEM key"
         exit 1
     fi
-    
+
     GITHUB_APP_DATA="--from-literal github-private-key='$GITHUB_APP_PRIVATE_KEY' --from-literal github-application-id='${PAC_GITHUB_APP_ID}' --from-literal webhook.secret='$WEBHOOK_SECRET'"
     log_success "GitHub App credentials configured"
 else
@@ -266,8 +266,15 @@ create_pac_secret "$PAC_NAMESPACE" "$FULL_SECRET_DATA"
 create_pac_secret "build-service" "$FULL_SECRET_DATA"
 create_pac_secret "$INTEGRATION_NAMESPACE" "$FULL_SECRET_DATA"
 
-# Mintmaker only needs GitHub App data (no webhook tokens)
-create_pac_secret "mintmaker" "$GITHUB_APP_DATA"
+# Mintmaker only needs GitHub App data (no webhook tokens). development-operator
+# overlay does not deploy mintmaker.
+PAC_CONFIGURED_NAMESPACES=("$PAC_NAMESPACE" "build-service" "$INTEGRATION_NAMESPACE")
+if [ "${TARGET_PREVIEW_OVERLAY:-development}" != "development-operator" ]; then
+    create_pac_secret "mintmaker" "$GITHUB_APP_DATA"
+    PAC_CONFIGURED_NAMESPACES+=("mintmaker")
+else
+    log_info "Skipping mintmaker PAC secret (development-operator overlay excludes mintmaker)"
+fi
 
 log_info "============================================================================="
 log_success "PAC Integration Setup Complete"
@@ -276,8 +283,11 @@ log_info "Configured namespaces:"
 log_info "  - $PAC_NAMESPACE (PAC controller)"
 log_info "  - build-service (Build Service)"
 log_info "  - $INTEGRATION_NAMESPACE (Integration Service)"
-log_info "  - mintmaker (Mintmaker)"
+if [[ " ${PAC_CONFIGURED_NAMESPACES[*]} " == *" mintmaker "* ]]; then
+    log_info "  - mintmaker (Mintmaker)"
+fi
 
 # Output summary for LLM parsing
+PAC_NAMESPACES_JSON=$(printf '%s\n' "${PAC_CONFIGURED_NAMESPACES[@]}" | jq -R . | jq -sc .)
 echo ""
-echo "[PAC_SETUP_JSON] {\"status\":\"success\",\"namespaces\":[\"$PAC_NAMESPACE\",\"build-service\",\"$INTEGRATION_NAMESPACE\",\"mintmaker\"],\"github_app_configured\":$([ -n "$GITHUB_APP_DATA" ] && echo "true" || echo "false"),\"github_token_configured\":$([ -n "$GITHUB_WEBHOOK_DATA" ] && echo "true" || echo "false"),\"gitlab_token_configured\":$([ -n "$GITLAB_WEBHOOK_DATA" ] && echo "true" || echo "false")}"
+echo "[PAC_SETUP_JSON] {\"status\":\"success\",\"namespaces\":${PAC_NAMESPACES_JSON},\"github_app_configured\":$([ -n "$GITHUB_APP_DATA" ] && echo "true" || echo "false"),\"github_token_configured\":$([ -n "$GITHUB_WEBHOOK_DATA" ] && echo "true" || echo "false"),\"gitlab_token_configured\":$([ -n "$GITLAB_WEBHOOK_DATA" ] && echo "true" || echo "false")}"

--- a/hack/preview.sh
+++ b/hack/preview.sh
@@ -1155,7 +1155,7 @@ wait_for_tekton_crds
 # =============================================================================
 if [ "$TARGET_PREVIEW_OVERLAY" = "development" ] || [ "$TARGET_PREVIEW_OVERLAY" = "development-operator" ]; then
     log_step "Configuring Pipelines as Code integration"
-    $ROOT/hack/build/setup-pac-integration.sh
+    TARGET_PREVIEW_OVERLAY="$TARGET_PREVIEW_OVERLAY" "$ROOT/hack/build/setup-pac-integration.sh"
     log_success "Pipelines as Code configured"
 else
     log_info "Skipping Pipelines as Code integration for '$TARGET_PREVIEW_OVERLAY'"


### PR DESCRIPTION
This change provides the scripting required for OpenShift CI tests to install Konflux using the operator and run e2e tests.

Assisted-by: Cursor