### PR TITLE
Upgrade MCE to 2.11 for EaaS in production

### DIFF
--- a/components/cluster-as-a-service/base/multicluster-engine.yaml
+++ b/components/cluster-as-a-service/base/multicluster-engine.yaml
@@ -27,7 +27,7 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "-1"
 spec:
-  channel: stable-2.10
+  channel: stable-2.11
   installPlanApproval: Automatic
   name: multicluster-engine
   source: redhat-operators

--- a/components/cluster-as-a-service/production/add-hypershift-params.yaml
+++ b/components/cluster-as-a-service/production/add-hypershift-params.yaml
@@ -9,7 +9,7 @@
   path: /spec/template/spec/source/helm/parameters/-
   value:
     name: hypershiftImage
-    value: registry.redhat.io/multicluster-engine/hypershift-rhel9-operator:v2.10@sha256:1cceec46246ea7bef481549dce1ce91880d19a5650c9a6bc0f71f0d4092a6f95
+    value: registry.redhat.io/multicluster-engine/hypershift-rhel9-operator:v2.11@sha256:44df0f376c6dbc3d4dee359198218c6d19ff78199e114976af593afd3c43dd04
 
 - op: add
   path: /spec/template/spec/source/helm/parameters/-


### PR DESCRIPTION
This should allow for provisioning OCP 4.21 HyperShift clusters.

## Risk Assessment

**Risk Level:** Low — identical change already validated in dev and staging via #12049

**Rollback:** Revert this PR to restore `stable-2.10` channel and `v2.10` hypershift image

JIRA: https://redhat.atlassian.net/browse/KFLUXVNGD-1023
Assisted-by: Claude Code