### PR TITLE
KFLUXINFRA-3770: add AI skills for infra-deployments

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ GitOps monorepo deploying 50+ Kubernetes components across multiple clusters via
 
 | Action         | Command                                    |
 |----------------|--------------------------------------------|
-| Build overlay  | `kustomize build components/<name>/<env>/` |
+| Build overlay  | `kustomize build --enable-helm components/<name>/<env>/` |
 | Lint YAML      | `yamllint .`                               |
 | K8s lint       | `kube-linter lint <path>`                  |
 | Chainsaw tests | `./hack/chainsaw/chainsaw-prepare.sh` and `chainsaw test <path to .chainsaw-test folder>` |
@@ -35,3 +35,9 @@ GitOps monorepo deploying 50+ Kubernetes components across multiple clusters via
 - E2E tests are conditional — they only run on dev/staging PRs when specific files change. Production PRs do not run E2E; rely on prior dev/staging validation
 - E2E tests frequently fail due to intermittent infrastructure issues. If the PR looks correct and E2E logs show no relevant errors, comment `/retest` to re-trigger
 - When updating component images, also update image references in `hack/new-cluster/templates/` as part of the production ring deployments — new clusters are bootstrapped from these and won't get ArgoCD-synced versions
+
+## Skills
+
+- Before opening a PR, writing a PR description, or interpreting CI results, read `skills/pr-workflow.md`
+- When a CI check fails on a PR, read `skills/ci-troubleshooting.md`
+- When working interactively on new features or significant changes, read `skills/brainstorming-workflow.md` before making changes

--- a/skills/brainstorming-workflow.md
+++ b/skills/brainstorming-workflow.md
@@ -1,0 +1,64 @@
+---
+name: brainstorming-workflow
+description: >
+  Use when in an interactive session and the user requests a new feature, significant
+  change, rollout strategy, or migration in infra-deployments. Provides a structured
+  process choice before any changes are made. Skip when dispatched with a complete task.
+---
+
+# Brainstorming Workflow
+
+Discipline for interactive sessions involving new features, rollout planning, overlay restructuring, migrations, or other significant changes.
+
+## Context Detection
+
+- **Interactive session** (human in CLI/IDE): follow this workflow.
+- **Dispatched with a complete task** (sub-agent, automation, explicit spec): skip entirely and execute.
+
+## First Message
+
+Before making any changes, ask exactly ONE question:
+
+> I can approach this a few ways:
+>
+> A) Jump straight to making changes
+> B) Discuss approaches first, then make changes
+> C) Full design process — explore approaches, write up a plan, then execute
+>
+> Which works for you?
+
+If the human says "just do it", gives a direct instruction, or otherwise signals urgency, treat as **A**.
+
+## Path A — Jump to Changes
+
+Proceed directly. All existing conventions still apply (pr-workflow, kustomize build validation). No additional ceremony.
+
+## Path B — Discuss Approaches
+
+1. **Understand the problem**: what is being changed, why, and any constraints.
+2. **Propose 2-3 approaches** with trade-offs (blast radius, complexity, number of PRs, ring strategy).
+3. **Lead with a recommendation** and explain why.
+4. Let the human choose, then execute.
+
+Infra-deployments examples where this helps:
+- Choosing between simple vs temp-ring base approach for a production rollout
+- Deciding whether a change should go through staging first or can use the hotfix bypass
+- Planning how to restructure component overlays across clusters
+- Evaluating whether a shared base change is safe or needs staging-first validation
+
+Ask one question at a time. Prefer multiple choice over open-ended questions.
+
+## Path C — Full Design Process
+
+Everything in Path B, plus:
+
+1. **Write up the plan** — what changes in which files, which clusters, how many PRs/rings.
+2. **Break into ordered steps** with dependencies (e.g., staging PR first, then ring 1, then ring 2).
+3. Get human approval before executing.
+
+## Key Principles
+
+- **One question at a time.** Never pile up multiple questions in one message.
+- **Prefer multiple choice.** Easier for the human to decide quickly.
+- **Human decides the process, not the agent.** Respect the chosen path.
+- **"Just do it" means just do it.** Don't add process the human didn't ask for.

--- a/skills/ci-troubleshooting.md
+++ b/skills/ci-troubleshooting.md
@@ -1,0 +1,96 @@
+---
+name: ci-troubleshooting
+description: >
+  Use when a CI check fails on a PR in infra-deployments and you need to
+  understand what failed, how to read the logs, and how to fix it.
+---
+
+# CI Troubleshooting
+
+## Overview
+
+How to investigate and fix CI failures on infra-deployments PRs.
+
+## When to Use
+
+- A CI check failed on your PR
+- You need to understand what a CI comment or status means
+- You want to re-trigger a flaky test
+
+## Prerequisites
+
+Verify `gh` CLI is installed and authenticated:
+
+```bash
+gh auth status
+```
+
+All CI investigation commands below depend on it.
+
+## Reading CI Logs
+
+### GitHub Actions checks
+
+```bash
+gh pr checks <PR-number> --repo redhat-appstudio/infra-deployments
+```
+
+To investigate a failed check:
+
+```bash
+gh run view <run-id> --repo redhat-appstudio/infra-deployments
+gh run view <run-id> --repo redhat-appstudio/infra-deployments --log-failed
+```
+
+### Prow checks (E2E tests)
+
+Prow check statuses include a `target_url` with the build ID and job name. To find them:
+
+```bash
+gh api repos/redhat-appstudio/infra-deployments/commits/<sha>/statuses \
+  --jq '.[] | select(.state == "failure") | "\(.context) — \(.target_url)"'
+```
+
+If a Prow job failed, fetch the log directly:
+
+```
+https://prow.ci.openshift.org/log?container=test&id=<build-id>&job=<job-name>
+```
+
+## Common Failures
+
+### yamllint
+
+YAML formatting errors (trailing whitespace, wrong indentation, missing newline at end of file). The CI logs usually show the exact file and line — fix those directly. If the logs aren't clear, run `yamllint .` locally.
+
+### Render-diff
+
+Not a pass/fail check — it posts a PR comment showing the rendered Kubernetes manifest diff. Review it to verify your kustomize changes produce the expected output.
+
+If it shows a "merge conflicts" error, rebase your PR.
+
+### Ring enforcement
+
+Blocks PRs that modify both staging and production files in the same PR.
+
+Fix: split into separate staging and production PRs. For emergencies, apply the `skip-ring-deployment/hotfix` label.
+
+### Chainsaw tests
+
+Path-triggered on `components/kyverno/**` and `components/policies/**` changes. Often flaky due to infrastructure issues.
+
+If logs show no relevant errors and the PR looks correct, comment `/retest`. If the logs don't help identify the issue, run locally with `hack/chainsaw/chainsaw-prepare.sh` then `chainsaw test <path>`.
+
+### kube-linter
+
+Scans Kubernetes manifests for security and best practice violations. Check the logs for specific rule violations.
+
+### Prow E2E tests (dev PRs only)
+
+`ci/prow/appstudio-e2e-tests` and `ci/prow/appstudio-operator-overlay-e2e-tests` run on OpenShift CI. These only trigger on dev PRs, not staging or production.
+
+If failed, fetch the log and check whether the failure is an intermittent infrastructure issue (cluster provisioning timeout, image pull failure, TLS handshake errors) or a real test failure. If intermittent, `/retest`.
+
+## Retesting
+
+Comment `/retest` on the PR to re-trigger failed checks. Only use when the failure looks flaky or infrastructure-related, not when your code has actual issues.

--- a/skills/ci-troubleshooting.md
+++ b/skills/ci-troubleshooting.md
@@ -73,13 +73,13 @@ If it shows a "merge conflicts" error, rebase your PR.
 
 Blocks PRs that modify both staging and production files in the same PR.
 
-Fix: split into separate staging and production PRs. For emergencies, apply the `skip-ring-deployment/hotfix` label.
+Fix: split into separate staging and production PRs. For hotfixes that need to roll out fast in production, apply the `skip-ring-deployment/hotfix` label.
 
 ### Chainsaw tests
 
 Path-triggered on `components/kyverno/**` and `components/policies/**` changes. Often flaky due to infrastructure issues.
 
-If logs show no relevant errors and the PR looks correct, comment `/retest`. If the logs don't help identify the issue, run locally with `hack/chainsaw/chainsaw-prepare.sh` then `chainsaw test <path>`.
+If logs show no relevant errors and the PR looks correct, find the failed run ID from `gh pr checks <PR-number> --repo redhat-appstudio/infra-deployments` and rerun it with `gh run rerun <run-id> --repo redhat-appstudio/infra-deployments --failed`. If the logs don't help identify the issue, run locally with `hack/chainsaw/chainsaw-prepare.sh` to set up a Kind cluster, then `chainsaw test <path>`.
 
 ### kube-linter
 
@@ -91,6 +91,3 @@ Scans Kubernetes manifests for security and best practice violations. Check the 
 
 If failed, fetch the log and check whether the failure is an intermittent infrastructure issue (cluster provisioning timeout, image pull failure, TLS handshake errors) or a real test failure. If intermittent, `/retest`.
 
-## Retesting
-
-Comment `/retest` on the PR to re-trigger failed checks. Only use when the failure looks flaky or infrastructure-related, not when your code has actual issues.

--- a/skills/pr-workflow.md
+++ b/skills/pr-workflow.md
@@ -18,21 +18,27 @@ PRs always target the upstream repository (`redhat-appstudio/infra-deployments`)
 ## When to Use
 
 - About to open a PR or write a PR description
-- CI check failed and you need to interpret it
 - Preparing a production change and unsure about ring requirements
 - Promoting a change from dev/staging to production
 
 ## Branch Setup
 
-If a dedicated branch already exists for this work, use it. Otherwise, start from a clean, synced main:
+If a dedicated branch already exists for this work, use it. Otherwise, create a branch from the latest main of `redhat-appstudio/infra-deployments`.
+
+First, find which remote points to `redhat-appstudio/infra-deployments`:
 
 ```bash
-git checkout main
-git fetch upstream
-git merge upstream/main
-git push origin main
-git checkout -b <branch-name>
+git remote -v | grep redhat-appstudio/infra-deployments
 ```
+
+Then fetch and branch from it:
+
+```bash
+git fetch <remote>
+git checkout -b <branch-name> <remote>/main --no-track
+```
+
+Common setups: fork-based workflows typically name it `upstream`, while direct clones use `origin`.
 
 Never branch from an old or diverged main.
 
@@ -55,12 +61,13 @@ Clusters affected: <list clusters>
 
 ## Validation
 
-- `kustomize build` passes for all affected overlays
+- `kustomize build --enable-helm` passes for all affected overlays
 - <staging evidence, links to prior ring PRs, test results>
 
 ## Risk Assessment
 
-**Risk Level:** Low / Medium / High
+**Risk Level:** Low / Medium / High / Very High
+**What could go wrong:** <describe what breaks if this change is incorrect>
 **Rollback:** Revert PR / <specific rollback steps>
 <blast radius — how many clusters, which environments>
 ```
@@ -85,7 +92,7 @@ Trailers (at end of commit message body). Use the actual agent/tool identity:
 
 ## Pre-Push Validation
 
-Run `kustomize build --enable-helm` on each affected directory containing a `kustomization.yaml`. Mention the results in the Validation section of the PR body.
+Run `kustomize build --enable-helm` on each affected directory containing a `kustomization.yaml`. The render-diff PR comment also shows the rendered manifest diff — review it to verify your changes produce the expected output. Mention the results in the Validation section of the PR body.
 
 ## Key CI Checks
 
@@ -93,7 +100,7 @@ Run `kustomize build --enable-helm` on each affected directory containing a `kus
 |-------|-------------|--------------|
 | **Ring deployment enforcement** | `components/`, `argo-cd-apps/`, `configs/` | Enforces staging/prod separation — fails if staging and production changes are mixed in the same PR. Apply `skip-ring-deployment/hotfix` label to bypass for critical hotfixes. |
 | **Render-diff** | All PRs | Posts a rendered Kubernetes manifest diff as a PR comment. |
-| **Chainsaw E2E tests** | `components/kyverno/**`, `components/policies/**` | Runs integration tests in a Kind cluster. Path-triggered — runs on any PR changing these paths regardless of environment. Can also be run locally with `hack/chainsaw/chainsaw-prepare.sh`. |
+| **Chainsaw E2E tests** | `components/kyverno/**`, `components/policies/**` | Runs integration tests in a Kind cluster. Path-triggered — runs on any PR changing these paths regardless of environment. Can also be run locally — set up a Kind cluster with `hack/chainsaw/chainsaw-prepare.sh`, then run `chainsaw test <path>`. |
 | **Kyverno policy tests** | `components/kyverno/**`, `components/policies/**` | CLI-based Kyverno policy validation. |
 | **Tekton-Kueue config tests** | `components/kueue/**` | Validates CEL expressions in Tekton-Kueue integration. |
 | **Pipeline-service verify** | `components/pipeline-service/**` | Ensures kustomize output matches committed manifests. |
@@ -104,7 +111,7 @@ Run `kustomize build --enable-helm` on each affected directory containing a `kus
 
 ## Production Ring Rollouts
 
-Production changes must be split into 3 ring PRs covering subsets of clusters. Never apply a production change to all clusters in a single PR.
+Production changes must be split into 3 ring PRs covering subsets of clusters. Never apply a production change to all clusters in a single PR — unless it's a hotfix using the `skip-ring-deployment/hotfix` label.
 
 - Each ring PR title includes the ring number:
   `KFLUXINFRA-1234: short description of the change (ring-1)`
@@ -114,7 +121,7 @@ Production changes must be split into 3 ring PRs covering subsets of clusters. N
 
 ## Production PR Requirements
 
-- **Risk Assessment** section is mandatory (level, rollback plan, blast radius).
+- **Risk Assessment** section is mandatory (level, what could go wrong, rollback plan, blast radius).
 - Follow the ring rollout pattern above.
 - When updating component images, check if corresponding references exist in `hack/new-cluster/templates/` — if so, update them and include this in the PR's **What** section. New clusters are bootstrapped from these templates and won't get ArgoCD-synced versions.
 

--- a/skills/pr-workflow.md
+++ b/skills/pr-workflow.md
@@ -92,7 +92,13 @@ Trailers (at end of commit message body). Use the actual agent/tool identity:
 
 ## Pre-Push Validation
 
-Run `kustomize build --enable-helm` on each affected directory containing a `kustomization.yaml`. The render-diff PR comment also shows the rendered manifest diff — review it to verify your changes produce the expected output. Mention the results in the Validation section of the PR body.
+Run `kustomize build --enable-helm` on each affected directory containing a `kustomization.yaml`. You can also run `render-diff` locally to see the full rendered manifest delta across affected components:
+
+```bash
+cd infra-tools && make build && ./bin/render-diff
+```
+
+Mention the results in the Validation section of the PR body.
 
 ## Key CI Checks
 

--- a/skills/pr-workflow.md
+++ b/skills/pr-workflow.md
@@ -1,0 +1,140 @@
+---
+name: pr-workflow
+description: >
+  Use when opening, monitoring, or iterating on a pull request in infra-deployments,
+  including PR body template, CI interpretation, production ring requirements,
+  commit conventions, and environment-specific validation.
+---
+
+# PR Workflow
+
+Full lifecycle reference for pull requests in the infra-deployments repository.
+
+## Overview
+
+infra-deployments is a GitOps monorepo deploying 50+ Kubernetes components via Kustomize and ArgoCD.
+PRs always target the upstream repository (`redhat-appstudio/infra-deployments`), never the fork.
+
+## When to Use
+
+- About to open a PR or write a PR description
+- CI check failed and you need to interpret it
+- Preparing a production change and unsure about ring requirements
+- Promoting a change from dev/staging to production
+
+## Branch Setup
+
+If a dedicated branch already exists for this work, use it. Otherwise, start from a clean, synced main:
+
+```bash
+git checkout main
+git fetch upstream
+git merge upstream/main
+git push origin main
+git checkout -b <branch-name>
+```
+
+Never branch from an old or diverged main.
+
+## PR Body Template
+
+Every PR follows this structure:
+
+```markdown
+## What
+
+<concise list of what changed>
+
+Clusters affected: <list clusters>
+
+[KFLUXINFRA-1234](https://redhat.atlassian.net/browse/KFLUXINFRA-1234)
+
+## Why
+
+<motivation — why this change is needed>
+
+## Validation
+
+- `kustomize build` passes for all affected overlays
+- <staging evidence, links to prior ring PRs, test results>
+
+## Risk Assessment
+
+**Risk Level:** Low / Medium / High
+**Rollback:** Revert PR / <specific rollback steps>
+<blast radius — how many clusters, which environments>
+```
+
+**Rules:**
+- **What** — Concise change list, affected clusters, Jira link at the bottom. Don't explain why here.
+- **Why** — Motivation only. Keep it brief.
+- **Validation** — Proof, not explanation. kustomize build results, staging links, prior ring PRs.
+- **Risk Assessment** — Required for production PRs. May be omitted for dev/staging.
+
+## Commit Conventions
+
+Prefix every commit with the Jira key:
+
+```
+KFLUXINFRA-1234 short description of the change
+```
+
+Trailers (at end of commit message body). Use the actual agent/tool identity:
+- Interactive sessions (human + agent): `Assisted-by:` trailer
+- Agentic workflow (autonomous): `Authored-by:` trailer
+
+## Pre-Push Validation
+
+Run `kustomize build --enable-helm` on each affected directory containing a `kustomization.yaml`. Mention the results in the Validation section of the PR body.
+
+## Key CI Checks
+
+| Check | Triggers On | What It Does |
+|-------|-------------|--------------|
+| **Ring deployment enforcement** | `components/`, `argo-cd-apps/`, `configs/` | Enforces staging/prod separation — fails if staging and production changes are mixed in the same PR. Apply `skip-ring-deployment/hotfix` label to bypass for critical hotfixes. |
+| **Render-diff** | All PRs | Posts a rendered Kubernetes manifest diff as a PR comment. |
+| **Chainsaw E2E tests** | `components/kyverno/**`, `components/policies/**` | Runs integration tests in a Kind cluster. Path-triggered — runs on any PR changing these paths regardless of environment. Can also be run locally with `hack/chainsaw/chainsaw-prepare.sh`. |
+| **Kyverno policy tests** | `components/kyverno/**`, `components/policies/**` | CLI-based Kyverno policy validation. |
+| **Tekton-Kueue config tests** | `components/kueue/**` | Validates CEL expressions in Tekton-Kueue integration. |
+| **Pipeline-service verify** | `components/pipeline-service/**` | Ensures kustomize output matches committed manifests. |
+
+**E2E test caveats:**
+- Chainsaw tests can be run locally — use `hack/chainsaw/chainsaw-prepare.sh` to set up a Kind cluster with Kyverno, then `chainsaw test <path>`.
+- E2E tests frequently fail in CI due to intermittent infrastructure issues. If the PR looks correct and logs show no relevant errors, comment `/retest` to re-trigger.
+
+## Production Ring Rollouts
+
+Production changes must be split into 3 ring PRs covering subsets of clusters. Never apply a production change to all clusters in a single PR.
+
+- Each ring PR title includes the ring number:
+  `KFLUXINFRA-1234: short description of the change (ring-1)`
+- The **What** section lists the specific clusters included in this ring.
+- Later ring PRs reference earlier ring PRs in **Validation** as evidence of success.
+- This is a team convention — CI does not enforce ring splitting, but the ring enforcement check does prevent mixing staging and production changes.
+
+## Production PR Requirements
+
+- **Risk Assessment** section is mandatory (level, rollback plan, blast radius).
+- Follow the ring rollout pattern above.
+- When updating component images, check if corresponding references exist in `hack/new-cluster/templates/` — if so, update them and include this in the PR's **What** section. New clusters are bootstrapped from these templates and won't get ArgoCD-synced versions.
+
+## Promotion Flow
+
+Changes flow: **development/staging** then **production**.
+
+Validate changes in dev/staging before promoting to production. Production PRs should reference the staging PR or evidence in their Validation section.
+
+## Interactive Sessions
+
+In interactive sessions (human + agent), always confirm with the human before pushing and opening the PR. Show them the commit message, PR title, and PR body for approval first. Never push or create a PR without explicit approval.
+
+## Common Mistakes
+
+| Mistake | Fix |
+|---------|-----|
+| Forgetting Risk Assessment on a production PR | Add the section — reviewers will block without it |
+| Changing all production clusters in one PR | Split into 3 ring PRs |
+| Not running `kustomize build` before pushing | Run it on all affected overlays, mention in Validation |
+| Skipping `hack/new-cluster/templates/` sync | Update template image references when changing component images |
+| Putting explanation in Validation instead of proof | Validation = evidence (build output, staging links). Why = explanation. |
+| Branching from a stale main | Always fetch and reset from upstream before branching |


### PR DESCRIPTION
## What

Add `skills/` directory with three repo-specific AI skills and a Skills section in AGENTS.md pointing agents to them:

- `skills/pr-workflow.md` — PR body template, CI checks, commit conventions, ring PR titles, interactive session gate
- `skills/brainstorming-workflow.md` — A/B/C process choice for interactive sessions
- `skills/ci-troubleshooting.md` — how to read CI/Prow logs, common failures, when to /retest

Also updates `kustomize build` command in AGENTS.md to include `--enable-helm`.

[KFLUXINFRA-3770](https://redhat.atlassian.net/browse/KFLUXINFRA-3770)

## Why

Manual and highly-repeatable workflows (PR creation, CI debugging) benefit from codified skills that AI agents can reference. Without these, agents miss PR template structure, can't access Prow logs, or retry deterministic failures.

## Validation

- RED/GREEN tested all three skills with subagents:
  - pr-workflow: without skill agent put all 9 clusters in one PR; with skill correct 3-ring split and template
  - ci-troubleshooting: without skill agent couldn't fetch Prow logs; with skill used correct URL pattern and identified TLS/infra flakes

[KFLUXINFRA-3770]: https://redhat.atlassian.net/browse/KFLUXINFRA-3770?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ