### PR TITLE
Prod Ring 3: upgrade pipelines 5.0.5-830 and patch resolver for Konflux-14376 fix

### DIFF
--- a/components/pipeline-service/production/kflux-prd-rh02/deploy.yaml
+++ b/components/pipeline-service/production/kflux-prd-rh02/deploy.yaml
@@ -2327,6 +2327,19 @@ spec:
                 }
               }
       deployments:
+        tekton-events-controller:
+          spec:
+            template:
+              spec:
+                containers:
+                - name: tekton-events-controller
+                  resources:
+                    limits:
+                      cpu: 200m
+                      memory: 4096Mi
+                    requests:
+                      cpu: 200m
+                      memory: 4096Mi
         tekton-operator-proxy-webhook:
           spec:
             replicas: 2
@@ -2515,7 +2528,7 @@ metadata:
   namespace: openshift-marketplace
 spec:
   displayName: custom-operators
-  image: quay.io/openshift-pipeline/pipelines-index-4.18@sha256:d4d3f6210a384da6bfb11214a860e72e52d0a38b73037b8135c0571a6365d2a1
+  image: quay.io/openshift-pipeline/pipelines-index-4.18@sha256:a4aa211a70b0a92c98c885cca8fed2cce490e3fec656ad1ea68bf7e7c3c18304
   sourceType: grpc
   updateStrategy:
     registryPoll:
@@ -2535,6 +2548,8 @@ spec:
     env:
     - name: AUTOINSTALL_COMPONENTS
       value: "false"
+    - name: IMAGE_PIPELINES_CONTROLLER
+      value: quay.io/openshift-pipeline/pipelines-resolvers-rhel9@sha256:7cd91bc4c0f3469ec4c39d08d818b00c90ce07456364910e49ad5e1430f3110a
   name: openshift-pipelines-operator-rh
   source: custom-operators
   sourceNamespace: openshift-marketplace

--- a/components/pipeline-service/production/kflux-prd-rh03/deploy.yaml
+++ b/components/pipeline-service/production/kflux-prd-rh03/deploy.yaml
@@ -2327,6 +2327,19 @@ spec:
                 }
               }
       deployments:
+        tekton-events-controller:
+          spec:
+            template:
+              spec:
+                containers:
+                - name: tekton-events-controller
+                  resources:
+                    limits:
+                      cpu: 200m
+                      memory: 4096Mi
+                    requests:
+                      cpu: 200m
+                      memory: 4096Mi
         tekton-operator-proxy-webhook:
           spec:
             replicas: 2
@@ -2515,7 +2528,7 @@ metadata:
   namespace: openshift-marketplace
 spec:
   displayName: custom-operators
-  image: quay.io/openshift-pipeline/pipelines-index-4.18@sha256:d4d3f6210a384da6bfb11214a860e72e52d0a38b73037b8135c0571a6365d2a1
+  image: quay.io/openshift-pipeline/pipelines-index-4.18@sha256:a4aa211a70b0a92c98c885cca8fed2cce490e3fec656ad1ea68bf7e7c3c18304
   sourceType: grpc
   updateStrategy:
     registryPoll:
@@ -2535,6 +2548,8 @@ spec:
     env:
     - name: AUTOINSTALL_COMPONENTS
       value: "false"
+    - name: IMAGE_PIPELINES_CONTROLLER
+      value: quay.io/openshift-pipeline/pipelines-resolvers-rhel9@sha256:7cd91bc4c0f3469ec4c39d08d818b00c90ce07456364910e49ad5e1430f3110a
   name: openshift-pipelines-operator-rh
   source: custom-operators
   sourceNamespace: openshift-marketplace

--- a/components/pipeline-service/production/rings/ring-3/kustomization.yaml
+++ b/components/pipeline-service/production/rings/ring-3/kustomization.yaml
@@ -8,4 +8,50 @@ kind: Kustomization
 resources:
   - ../../base
 
-patches: []
+patches:
+  # Upgrade index
+  - target:
+      kind: CatalogSource
+      name: custom-operators
+    patch: |-
+      - op: replace
+        path: /spec/image
+        value: quay.io/openshift-pipeline/pipelines-index-4.18@sha256:a4aa211a70b0a92c98c885cca8fed2cce490e3fec656ad1ea68bf7e7c3c18304
+  # Increase tekton events controller resources
+  - target:
+      kind: TektonConfig
+      name: config
+    patch: |-
+      apiVersion: operator.tekton.dev/v1alpha1
+      kind: TektonConfig
+      metadata:
+        name: config
+      spec:
+        pipeline:
+          options:
+            deployments:
+              tekton-events-controller:
+                spec:
+                  template:
+                    spec:
+                      containers:
+                      - name: tekton-events-controller
+                        resources:
+                          limits:
+                            cpu: 200m
+                            memory: 4096Mi
+                          requests:
+                            cpu: 200m
+                            memory: 4096Mi
+  # TODO: Remove this once Pipelines 1.13.x is deployed
+  # NOTE: IMAGE_PIPELINES_CONTROLLER is the image used specifically by the resolvers,
+  # the pipelines-controller uses IMAGE_PIPELINES_TEKTON_PIPELINES_CONTROLLER
+  - target:
+      kind: Subscription
+      name: openshift-pipelines-operator
+    patch: |-
+      - op: add
+        path: /spec/config/env/-
+        value:
+          name: IMAGE_PIPELINES_CONTROLLER
+          value: "quay.io/openshift-pipeline/pipelines-resolvers-rhel9@sha256:7cd91bc4c0f3469ec4c39d08d818b00c90ce07456364910e49ad5e1430f3110a"

--- a/components/pipeline-service/production/stone-prd-rh01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prd-rh01/deploy.yaml
@@ -2327,6 +2327,19 @@ spec:
                 }
               }
       deployments:
+        tekton-events-controller:
+          spec:
+            template:
+              spec:
+                containers:
+                - name: tekton-events-controller
+                  resources:
+                    limits:
+                      cpu: 200m
+                      memory: 4096Mi
+                    requests:
+                      cpu: 200m
+                      memory: 4096Mi
         tekton-operator-proxy-webhook:
           spec:
             replicas: 2
@@ -2515,7 +2528,7 @@ metadata:
   namespace: openshift-marketplace
 spec:
   displayName: custom-operators
-  image: quay.io/openshift-pipeline/pipelines-index-4.18@sha256:d4d3f6210a384da6bfb11214a860e72e52d0a38b73037b8135c0571a6365d2a1
+  image: quay.io/openshift-pipeline/pipelines-index-4.18@sha256:a4aa211a70b0a92c98c885cca8fed2cce490e3fec656ad1ea68bf7e7c3c18304
   sourceType: grpc
   updateStrategy:
     registryPoll:
@@ -2535,6 +2548,8 @@ spec:
     env:
     - name: AUTOINSTALL_COMPONENTS
       value: "false"
+    - name: IMAGE_PIPELINES_CONTROLLER
+      value: quay.io/openshift-pipeline/pipelines-resolvers-rhel9@sha256:7cd91bc4c0f3469ec4c39d08d818b00c90ce07456364910e49ad5e1430f3110a
   name: openshift-pipelines-operator-rh
   source: custom-operators
   sourceNamespace: openshift-marketplace


### PR DESCRIPTION
## What

- Update CatalogSource index image to 5.0.5-830 on Ring 3 clusters
- Add tekton-events-controller with 4096Mi memory (fixes OOMKills)
- Override resolver image with fix for ResolutionRequests resolving all Tekton kinds

Clusters affected: `stone-prd-rh01`, `kflux-prd-rh02`, `kflux-prd-rh03`

[KONFLUX-14376](https://redhat.atlassian.net/browse/KONFLUX-14376)

## Why

Completes the ring rollout of pipelines 5.0.5-830 (index upgrade, events-controller sizing) and applies the resolver image hotfix from [KONFLUX-14376](https://redhat.atlassian.net/browse/KONFLUX-14376) across all production rings.

## Validation

- Staging PR merged: https://github.com/redhat-appstudio/infra-deployments/pull/12332
- Ring 1 PR: https://github.com/redhat-appstudio/infra-deployments/pull/12352
- Ring 2 PR: https://github.com/redhat-appstudio/infra-deployments/pull/12353
- Ring 1 index upgrade: https://github.com/redhat-appstudio/infra-deployments/pull/12065
- Ring 2 index upgrade: https://github.com/redhat-appstudio/infra-deployments/pull/12254
- `kustomize build` passes for all affected overlays
- deploy.yaml regenerated from ring-3 kustomization patches

## Risk Assessment

**Risk Level:** Medium
**What could go wrong:** Upgrades OpenShift Pipelines index from 5.0.5-806 to 5.0.5-830. Includes PAC OTel migration, events-controller memory fix, and multiple CVE patches. Image soaked in staging for 7 days+.
**Rollback:** Revert the PR (restores ring-3 kustomization to `patches: []`)
**Blast radius:** 3 clusters (ring-3 only)

[KONFLUX-14376]: https://redhat.atlassian.net/browse/KONFLUX-14376?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ