### PR TITLE
production Ring 2: upgrade pipelines 5.0.5-830

### DIFF
--- a/components/pipeline-service/production/kflux-ocp-p01/deploy.yaml
+++ b/components/pipeline-service/production/kflux-ocp-p01/deploy.yaml
@@ -2327,6 +2327,19 @@ spec:
                 }
               }
       deployments:
+        tekton-events-controller:
+          spec:
+            template:
+              spec:
+                containers:
+                - name: tekton-events-controller
+                  resources:
+                    limits:
+                      cpu: 200m
+                      memory: 256Mi
+                    requests:
+                      cpu: 200m
+                      memory: 256Mi
         tekton-operator-proxy-webhook:
           spec:
             replicas: 2
@@ -2515,7 +2528,7 @@ metadata:
   namespace: openshift-marketplace
 spec:
   displayName: custom-operators
-  image: quay.io/openshift-pipeline/pipelines-index-4.18@sha256:d4d3f6210a384da6bfb11214a860e72e52d0a38b73037b8135c0571a6365d2a1
+  image: quay.io/openshift-pipeline/pipelines-index-4.18@sha256:a4aa211a70b0a92c98c885cca8fed2cce490e3fec656ad1ea68bf7e7c3c18304
   sourceType: grpc
   updateStrategy:
     registryPoll:

--- a/components/pipeline-service/production/kflux-rhel-p01/deploy.yaml
+++ b/components/pipeline-service/production/kflux-rhel-p01/deploy.yaml
@@ -2327,6 +2327,19 @@ spec:
                 }
               }
       deployments:
+        tekton-events-controller:
+          spec:
+            template:
+              spec:
+                containers:
+                - name: tekton-events-controller
+                  resources:
+                    limits:
+                      cpu: 200m
+                      memory: 256Mi
+                    requests:
+                      cpu: 200m
+                      memory: 256Mi
         tekton-operator-proxy-webhook:
           spec:
             replicas: 2
@@ -2515,7 +2528,7 @@ metadata:
   namespace: openshift-marketplace
 spec:
   displayName: custom-operators
-  image: quay.io/openshift-pipeline/pipelines-index-4.18@sha256:d4d3f6210a384da6bfb11214a860e72e52d0a38b73037b8135c0571a6365d2a1
+  image: quay.io/openshift-pipeline/pipelines-index-4.18@sha256:a4aa211a70b0a92c98c885cca8fed2cce490e3fec656ad1ea68bf7e7c3c18304
   sourceType: grpc
   updateStrategy:
     registryPoll:

--- a/components/pipeline-service/production/stone-prod-p02/deploy.yaml
+++ b/components/pipeline-service/production/stone-prod-p02/deploy.yaml
@@ -2327,6 +2327,19 @@ spec:
                 }
               }
       deployments:
+        tekton-events-controller:
+          spec:
+            template:
+              spec:
+                containers:
+                - name: tekton-events-controller
+                  resources:
+                    limits:
+                      cpu: 200m
+                      memory: 256Mi
+                    requests:
+                      cpu: 200m
+                      memory: 256Mi
         tekton-operator-proxy-webhook:
           spec:
             replicas: 2
@@ -2515,7 +2528,7 @@ metadata:
   namespace: openshift-marketplace
 spec:
   displayName: custom-operators
-  image: quay.io/openshift-pipeline/pipelines-index-4.18@sha256:d4d3f6210a384da6bfb11214a860e72e52d0a38b73037b8135c0571a6365d2a1
+  image: quay.io/openshift-pipeline/pipelines-index-4.18@sha256:a4aa211a70b0a92c98c885cca8fed2cce490e3fec656ad1ea68bf7e7c3c18304
   sourceType: grpc
   updateStrategy:
     registryPoll:


### PR DESCRIPTION
## Summary

- Update CatalogSource index image to 5.0.5-830 on Ring 2 clusters
- Add tekton-events-controller with 256Mi memory (fixes OOMKills)
- Ring 2: stone-prod-p02, kflux-ocp-p01, kflux-rhel-p01

Depends on [Ring 1 PR](https://github.com/redhat-appstudio/infra-deployments/pull/12065) being merged and validated first.

## Risk Assessment

**Risk Level:** Medium
**Description:** Upgrades OpenShift Pipelines index from 5.0.5-806 to 5.0.5-830. Includes PAC OTel migration, events-controller memory fix, and multiple CVE patches. Image soaked in staging for 7 days+.
**Rollback:** Release a new Index image with the fix included.