### PR TITLE
Disable mintmaker in staging

### DIFF
--- a/components/mintmaker/staging/base/kustomization.yaml
+++ b/components/mintmaker/staging/base/kustomization.yaml
@@ -33,6 +33,7 @@ patches:
   - path: manager-mount-config-patch.yaml
   - path: manager-set-resources-patch.yaml
   - path: manager-enable-pprof-patch.yaml
+  - path: suspend-dependency-check-patch.yaml
 
 configurations:
 - kustomizeconfig.yaml

--- a/components/mintmaker/staging/base/suspend-dependency-check-patch.yaml
+++ b/components/mintmaker/staging/base/suspend-dependency-check-patch.yaml
@@ -1,0 +1,7 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: create-dependencyupdatecheck
+  namespace: mintmaker
+spec:
+  suspend: true


### PR DESCRIPTION
We need to disable mintmaker in all Konflux cluster, testing in staging then a follow up change will be done for production.