### PR TITLE
add konflux-release kueue's flavor in staging

### DIFF
--- a/components/kueue/development/queue-config/cluster-queue.yaml
+++ b/components/kueue/development/queue-config/cluster-queue.yaml
@@ -31,6 +31,7 @@ spec:
       - linux-ppc64le
       - aws-ip
       - mintmaker
+      - konflux-release
       flavors:
       - name: default-flavor
         resources:
@@ -50,6 +51,8 @@ spec:
           nominalQuota: "250"
         - name: mintmaker
           nominalQuota: "150"
+        - name: konflux-release
+          nominalQuota: '50'
         # When a Workload doesn't have cpu or memory requests, if there is a limit range
         # in the namespace, Kueue will assign the requests from it to the Workload.
         # We don't care about the cpu/memory for PipelineRuns, thus setting a high value for both.

--- a/components/kueue/development/tekton-kueue/config.yaml
+++ b/components/kueue/development/tekton-kueue/config.yaml
@@ -92,6 +92,26 @@ cel:
     - |
         plrNamespace == 'mintmaker' ? [resource('mintmaker', 1)] : []
 
+    # Add a resource to restrict the number of concurrent release pipelineruns
+    - |
+        has(pipelineRun.metadata.labels) &&
+        'appstudio.openshift.io/service' in pipelineRun.metadata.labels &&
+        pipelineRun.metadata.labels['appstudio.openshift.io/service'] == 'release' &&
+        'pipelines.appstudio.openshift.io/type' in pipelineRun.metadata.labels &&
+        pipelineRun.metadata.labels['pipelines.appstudio.openshift.io/type'] == 'managed' ?
+        [resource('konflux-release', 1)] :
+
+        has(pipelineRun.metadata.labels) &&
+        'appstudio.openshift.io/service' in pipelineRun.metadata.labels &&
+        pipelineRun.metadata.labels['appstudio.openshift.io/service'] == 'release' &&
+        'release.appstudio.openshift.io/namespace' in pipelineRun.metadata.labels &&
+        pipelineRun.metadata.labels['release.appstudio.openshift.io/namespace'] == plrNamespace ?
+        [resource('konflux-release', 1)] :
+
+        has(pipelineRun.metadata.labels) &&
+        'internal-services.appstudio.openshift.io/pipelinerun-uid' in pipelineRun.metadata.labels ?
+        [resource('konflux-release', 1)] : []
+
     # The token mechanism allows us to balance admitted PipelineRuns.
     # Here we want to state that each PipelineRuns needs one token, but
     # Build PipelineRuns are usually heavier, so they need 2.

--- a/components/kueue/staging/base/tekton-kueue/config.yaml
+++ b/components/kueue/staging/base/tekton-kueue/config.yaml
@@ -92,6 +92,26 @@ cel:
     - |
         plrNamespace == 'mintmaker' ? [resource('mintmaker', 1)] : []
 
+    # Add a resource to restrict the number of concurrent release pipelineruns
+    - |
+        has(pipelineRun.metadata.labels) &&
+        'appstudio.openshift.io/service' in pipelineRun.metadata.labels &&
+        pipelineRun.metadata.labels['appstudio.openshift.io/service'] == 'release' &&
+        'pipelines.appstudio.openshift.io/type' in pipelineRun.metadata.labels &&
+        pipelineRun.metadata.labels['pipelines.appstudio.openshift.io/type'] == 'managed' ?
+        [resource('konflux-release', 1)] :
+
+        has(pipelineRun.metadata.labels) &&
+        'appstudio.openshift.io/service' in pipelineRun.metadata.labels &&
+        pipelineRun.metadata.labels['appstudio.openshift.io/service'] == 'release' &&
+        'release.appstudio.openshift.io/namespace' in pipelineRun.metadata.labels &&
+        pipelineRun.metadata.labels['release.appstudio.openshift.io/namespace'] == plrNamespace ?
+        [resource('konflux-release', 1)] :
+
+        has(pipelineRun.metadata.labels) &&
+        'internal-services.appstudio.openshift.io/pipelinerun-uid' in pipelineRun.metadata.labels ?
+        [resource('konflux-release', 1)] : []
+
     # The token mechanism allows us to balance admitted PipelineRuns.
     # Here we want to state that each PipelineRuns needs one token, but
     # Build PipelineRuns are usually heavier, so they need 2.

--- a/components/kueue/staging/stone-stage-p01/queue-config/cluster-queue.yaml
+++ b/components/kueue/staging/stone-stage-p01/queue-config/cluster-queue.yaml
@@ -21,6 +21,7 @@ spec:
     - memory
     - aws-ip
     - mintmaker
+    - konflux-release
     flavors:
     - name: default-flavor
       resources:
@@ -36,6 +37,8 @@ spec:
         nominalQuota: '250'
       - name: mintmaker
         nominalQuota: '150'
+      - name: konflux-release
+        nominalQuota: '50'
   - coveredResources:
     - linux-amd64
     - linux-arm64

--- a/components/kueue/staging/stone-stg-rh01/queue-config/cluster-queue.yaml
+++ b/components/kueue/staging/stone-stg-rh01/queue-config/cluster-queue.yaml
@@ -21,6 +21,7 @@ spec:
     - memory
     - aws-ip
     - mintmaker
+    - konflux-release
     flavors:
     - name: default-flavor
       resources:
@@ -36,6 +37,8 @@ spec:
         nominalQuota: '250'
       - name: mintmaker
         nominalQuota: '150'
+      - name: konflux-release
+        nominalQuota: '50'
   - coveredResources:
     - linux-amd64
     - linux-arm64

--- a/hack/test-tekton-kueue-config.py
+++ b/hack/test-tekton-kueue-config.py
@@ -406,6 +406,7 @@ PIPELINERUN_DEFINITIONS: Dict[str, PipelineRunTestData] = {
         "expected": {
             "annotations": {
                 "kueue.konflux-ci.dev/requests-konflux-ci-dev-token": "1",
+                "kueue.konflux-ci.dev/requests-konflux-release": "1",
             },
             "labels": {
                 "kueue.x-k8s.io/queue-name": "pipelines-queue",
@@ -435,6 +436,7 @@ PIPELINERUN_DEFINITIONS: Dict[str, PipelineRunTestData] = {
         "expected": {
             "annotations": {
                 "kueue.konflux-ci.dev/requests-konflux-ci-dev-token": "1",
+                "kueue.konflux-ci.dev/requests-konflux-release": "1",
             },
             "labels": {
                 "kueue.x-k8s.io/queue-name": "pipelines-queue",
@@ -845,6 +847,7 @@ PIPELINERUN_DEFINITIONS: Dict[str, PipelineRunTestData] = {
         "expected": {
             "annotations": {
                 "kueue.konflux-ci.dev/requests-konflux-ci-dev-token": "1",
+                "kueue.konflux-ci.dev/requests-konflux-release": "1",
             },
             "labels": {
                 "kueue.x-k8s.io/queue-name": "pipelines-queue",


### PR DESCRIPTION
We want to be able to restrict konflux-release PipelineRuns independently from the others.
This is to reduce pressure, when needed, on the signing infrastructure.

Signed-off-by: Francesco Ilario <filario@redhat.com>

rh-pre-commit.version: 2.4.0
rh-pre-commit.check-secrets: ENABLED
