### PR TITLE
Standardize tekton-events-controller memory to 2048Mi across all production clusters

### DIFF
--- a/components/pipeline-service/production/base/main-pipeline-service-configuration.yaml
+++ b/components/pipeline-service/production/base/main-pipeline-service-configuration.yaml
@@ -1855,10 +1855,10 @@ spec:
                     resources:
                       limits:
                         cpu: 200m
-                        memory: 4096Mi
+                        memory: 2048Mi
                       requests:
                         cpu: 200m
-                        memory: 4096Mi
+                        memory: 2048Mi
         # tekton-triggers-controller:
         #   spec:
         #     template:

--- a/components/pipeline-service/production/kflux-fedora-01/deploy.yaml
+++ b/components/pipeline-service/production/kflux-fedora-01/deploy.yaml
@@ -2351,10 +2351,10 @@ spec:
                   resources:
                     limits:
                       cpu: 200m
-                      memory: 4096Mi
+                      memory: 2048Mi
                     requests:
                       cpu: 200m
-                      memory: 4096Mi
+                      memory: 2048Mi
         tekton-operator-proxy-webhook:
           spec:
             replicas: 2

--- a/components/pipeline-service/production/kflux-ocp-p01/deploy.yaml
+++ b/components/pipeline-service/production/kflux-ocp-p01/deploy.yaml
@@ -2336,10 +2336,10 @@ spec:
                   resources:
                     limits:
                       cpu: 200m
-                      memory: 4096Mi
+                      memory: 2048Mi
                     requests:
                       cpu: 200m
-                      memory: 4096Mi
+                      memory: 2048Mi
         tekton-operator-proxy-webhook:
           spec:
             replicas: 2

--- a/components/pipeline-service/production/kflux-osp-p01/deploy.yaml
+++ b/components/pipeline-service/production/kflux-osp-p01/deploy.yaml
@@ -2336,10 +2336,10 @@ spec:
                   resources:
                     limits:
                       cpu: 200m
-                      memory: 4096Mi
+                      memory: 2048Mi
                     requests:
                       cpu: 200m
-                      memory: 4096Mi
+                      memory: 2048Mi
         tekton-operator-proxy-webhook:
           spec:
             replicas: 2

--- a/components/pipeline-service/production/kflux-prd-rh02/deploy.yaml
+++ b/components/pipeline-service/production/kflux-prd-rh02/deploy.yaml
@@ -2327,6 +2327,19 @@ spec:
                 }
               }
       deployments:
+        tekton-events-controller:
+          spec:
+            template:
+              spec:
+                containers:
+                - name: tekton-events-controller
+                  resources:
+                    limits:
+                      cpu: 200m
+                      memory: 2048Mi
+                    requests:
+                      cpu: 200m
+                      memory: 2048Mi
         tekton-operator-proxy-webhook:
           spec:
             replicas: 2
@@ -2515,7 +2528,7 @@ metadata:
   namespace: openshift-marketplace
 spec:
   displayName: custom-operators
-  image: quay.io/openshift-pipeline/pipelines-index-4.18@sha256:d4d3f6210a384da6bfb11214a860e72e52d0a38b73037b8135c0571a6365d2a1
+  image: quay.io/openshift-pipeline/pipelines-index-4.18@sha256:a4aa211a70b0a92c98c885cca8fed2cce490e3fec656ad1ea68bf7e7c3c18304
   sourceType: grpc
   updateStrategy:
     registryPoll:

--- a/components/pipeline-service/production/kflux-prd-rh03/deploy.yaml
+++ b/components/pipeline-service/production/kflux-prd-rh03/deploy.yaml
@@ -2327,6 +2327,19 @@ spec:
                 }
               }
       deployments:
+        tekton-events-controller:
+          spec:
+            template:
+              spec:
+                containers:
+                - name: tekton-events-controller
+                  resources:
+                    limits:
+                      cpu: 200m
+                      memory: 2048Mi
+                    requests:
+                      cpu: 200m
+                      memory: 2048Mi
         tekton-operator-proxy-webhook:
           spec:
             replicas: 2
@@ -2515,7 +2528,7 @@ metadata:
   namespace: openshift-marketplace
 spec:
   displayName: custom-operators
-  image: quay.io/openshift-pipeline/pipelines-index-4.18@sha256:d4d3f6210a384da6bfb11214a860e72e52d0a38b73037b8135c0571a6365d2a1
+  image: quay.io/openshift-pipeline/pipelines-index-4.18@sha256:a4aa211a70b0a92c98c885cca8fed2cce490e3fec656ad1ea68bf7e7c3c18304
   sourceType: grpc
   updateStrategy:
     registryPoll:

--- a/components/pipeline-service/production/kflux-rhel-p01/deploy.yaml
+++ b/components/pipeline-service/production/kflux-rhel-p01/deploy.yaml
@@ -2336,10 +2336,10 @@ spec:
                   resources:
                     limits:
                       cpu: 200m
-                      memory: 4096Mi
+                      memory: 2048Mi
                     requests:
                       cpu: 200m
-                      memory: 4096Mi
+                      memory: 2048Mi
         tekton-operator-proxy-webhook:
           spec:
             replicas: 2

--- a/components/pipeline-service/production/stone-prd-rh01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prd-rh01/deploy.yaml
@@ -2327,6 +2327,19 @@ spec:
                 }
               }
       deployments:
+        tekton-events-controller:
+          spec:
+            template:
+              spec:
+                containers:
+                - name: tekton-events-controller
+                  resources:
+                    limits:
+                      cpu: 200m
+                      memory: 2048Mi
+                    requests:
+                      cpu: 200m
+                      memory: 2048Mi
         tekton-operator-proxy-webhook:
           spec:
             replicas: 2
@@ -2515,7 +2528,7 @@ metadata:
   namespace: openshift-marketplace
 spec:
   displayName: custom-operators
-  image: quay.io/openshift-pipeline/pipelines-index-4.18@sha256:d4d3f6210a384da6bfb11214a860e72e52d0a38b73037b8135c0571a6365d2a1
+  image: quay.io/openshift-pipeline/pipelines-index-4.18@sha256:a4aa211a70b0a92c98c885cca8fed2cce490e3fec656ad1ea68bf7e7c3c18304
   sourceType: grpc
   updateStrategy:
     registryPoll:

--- a/components/pipeline-service/production/stone-prod-p01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prod-p01/deploy.yaml
@@ -2336,10 +2336,10 @@ spec:
                   resources:
                     limits:
                       cpu: 200m
-                      memory: 4096Mi
+                      memory: 2048Mi
                     requests:
                       cpu: 200m
-                      memory: 4096Mi
+                      memory: 2048Mi
         tekton-operator-proxy-webhook:
           spec:
             replicas: 2

--- a/components/pipeline-service/production/stone-prod-p02/deploy.yaml
+++ b/components/pipeline-service/production/stone-prod-p02/deploy.yaml
@@ -2336,10 +2336,10 @@ spec:
                   resources:
                     limits:
                       cpu: 200m
-                      memory: 4096Mi
+                      memory: 2048Mi
                     requests:
                       cpu: 200m
-                      memory: 4096Mi
+                      memory: 2048Mi
         tekton-operator-proxy-webhook:
           spec:
             replicas: 2


### PR DESCRIPTION
The events-controller was temporarily bumped to 4096Mi during the v5.0.5-830
rollout. Now that all clusters are healthy,
reduce to 2048Mi as a safe baseline that avoids OOMKills without over-provisioning.