### PR TITLE
Upgrade multi-platform-controller on production (Ring 1)

### DIFF
--- a/components/multi-platform-controller/production-downstream/kflux-osp-p01/kustomization.yaml
+++ b/components/multi-platform-controller/production-downstream/kflux-osp-p01/kustomization.yaml
@@ -4,8 +4,23 @@ kind: Kustomization
 namespace: multi-platform-controller
 
 resources:
-- ../base
+- ../../base/common
+- ../../base/rbac
+- ../../base/logcollector
+- https://github.com/konflux-ci/multi-platform-controller/deploy/operator?ref=aa3768e389f13388943f00e2e69dfe760ba4a2fe
+- https://github.com/konflux-ci/multi-platform-controller/deploy/otp?ref=aa3768e389f13388943f00e2e69dfe760ba4a2fe
 - external-secrets.yaml
+
+components:
+  - ../../k-components/manager-resources
+
+images:
+- name: multi-platform-controller
+  newName: quay.io/konflux-ci/multi-platform-controller
+  newTag: aa3768e389f13388943f00e2e69dfe760ba4a2fe
+- name: multi-platform-otp-server
+  newName: quay.io/konflux-ci/multi-platform-controller-otp-service
+  newTag: aa3768e389f13388943f00e2e69dfe760ba4a2fe
 
 patches:
   - path: manager_resources_patch.yaml

--- a/components/multi-platform-controller/production-downstream/stone-prod-p01/kustomization.yaml
+++ b/components/multi-platform-controller/production-downstream/stone-prod-p01/kustomization.yaml
@@ -4,8 +4,23 @@ kind: Kustomization
 namespace: multi-platform-controller
 
 resources:
-- ../base
+- ../../base/common
+- ../../base/rbac
+- ../../base/logcollector
+- https://github.com/konflux-ci/multi-platform-controller/deploy/operator?ref=aa3768e389f13388943f00e2e69dfe760ba4a2fe
+- https://github.com/konflux-ci/multi-platform-controller/deploy/otp?ref=aa3768e389f13388943f00e2e69dfe760ba4a2fe
 - external-secrets.yaml
+
+components:
+  - ../../k-components/manager-resources
+
+images:
+- name: multi-platform-controller
+  newName: quay.io/konflux-ci/multi-platform-controller
+  newTag: aa3768e389f13388943f00e2e69dfe760ba4a2fe
+- name: multi-platform-otp-server
+  newName: quay.io/konflux-ci/multi-platform-controller-otp-service
+  newTag: aa3768e389f13388943f00e2e69dfe760ba4a2fe
 
 helmGlobals:
   chartHome: ../../base

--- a/components/multi-platform-controller/production/kflux-fedora-01/kustomization.yaml
+++ b/components/multi-platform-controller/production/kflux-fedora-01/kustomization.yaml
@@ -4,8 +4,23 @@ kind: Kustomization
 namespace: multi-platform-controller
 
 resources:
-- ../base
-- external-secrets.yaml
+  - ../../base/common
+  - ../../base/rbac
+  - ../../base/logcollector
+  - https://github.com/konflux-ci/multi-platform-controller/deploy/operator?ref=aa3768e389f13388943f00e2e69dfe760ba4a2fe
+  - https://github.com/konflux-ci/multi-platform-controller/deploy/otp?ref=aa3768e389f13388943f00e2e69dfe760ba4a2fe
+  - external-secrets.yaml
+
+components:
+  - ../../k-components/manager-resources
+
+images:
+  - name: multi-platform-controller
+    newName: quay.io/konflux-ci/multi-platform-controller
+    newTag: aa3768e389f13388943f00e2e69dfe760ba4a2fe
+  - name: multi-platform-otp-server
+    newName: quay.io/konflux-ci/multi-platform-controller-otp-service
+    newTag: aa3768e389f13388943f00e2e69dfe760ba4a2fe
 
 patches:
   - path: manager_resources_patch.yaml

--- a/components/multi-platform-controller/production/kflux-prd-rh02/kustomization.yaml
+++ b/components/multi-platform-controller/production/kflux-prd-rh02/kustomization.yaml
@@ -4,8 +4,23 @@ kind: Kustomization
 namespace: multi-platform-controller
 
 resources:
-  - ../base
+  - ../../base/common
+  - ../../base/rbac
+  - ../../base/logcollector
+  - https://github.com/konflux-ci/multi-platform-controller/deploy/operator?ref=aa3768e389f13388943f00e2e69dfe760ba4a2fe
+  - https://github.com/konflux-ci/multi-platform-controller/deploy/otp?ref=aa3768e389f13388943f00e2e69dfe760ba4a2fe
   - external-secrets.yaml
+
+components:
+  - ../../k-components/manager-resources
+
+images:
+  - name: multi-platform-controller
+    newName: quay.io/konflux-ci/multi-platform-controller
+    newTag: aa3768e389f13388943f00e2e69dfe760ba4a2fe
+  - name: multi-platform-otp-server
+    newName: quay.io/konflux-ci/multi-platform-controller-otp-service
+    newTag: aa3768e389f13388943f00e2e69dfe760ba4a2fe
 
 patches:
   - path: manager_resources_patch.yaml

--- a/components/multi-platform-controller/production/kflux-prd-rh03/kustomization.yaml
+++ b/components/multi-platform-controller/production/kflux-prd-rh03/kustomization.yaml
@@ -4,8 +4,23 @@ kind: Kustomization
 namespace: multi-platform-controller
 
 resources:
-  - ../base
+  - ../../base/common
+  - ../../base/rbac
+  - ../../base/logcollector
+  - https://github.com/konflux-ci/multi-platform-controller/deploy/operator?ref=aa3768e389f13388943f00e2e69dfe760ba4a2fe
+  - https://github.com/konflux-ci/multi-platform-controller/deploy/otp?ref=aa3768e389f13388943f00e2e69dfe760ba4a2fe
   - external-secrets.yaml
+
+components:
+  - ../../k-components/manager-resources
+
+images:
+  - name: multi-platform-controller
+    newName: quay.io/konflux-ci/multi-platform-controller
+    newTag: aa3768e389f13388943f00e2e69dfe760ba4a2fe
+  - name: multi-platform-otp-server
+    newName: quay.io/konflux-ci/multi-platform-controller-otp-service
+    newTag: aa3768e389f13388943f00e2e69dfe760ba4a2fe
 
 patches:
   - path: manager_resources_patch.yaml


### PR DESCRIPTION
## What

Promote multi-platform-controller from `93c18de0` to `aa3768e389f13388943f00e2e69dfe760ba4a2fe` on Ring 1 clusters.

Per-cluster kustomization overrides include both deploy resource refs (`deploy/operator`, `deploy/otp`) and container image tags.

Clusters affected:
- kflux-fedora-01
- kflux-prd-rh02
- kflux-prd-rh03
- kflux-osp-p01
- stone-prod-p01

## Why

Ring 1 of the phased production rollout for the MPC version currently deployed to dev/staging (`aa3768e389f13388943f00e2e69dfe760ba4a2fe`).

## Validation

- `kustomize build --enable-helm` passes for all five affected overlays:
  - `components/multi-platform-controller/production/kflux-fedora-01`
  - `components/multi-platform-controller/production/kflux-prd-rh02`
  - `components/multi-platform-controller/production/kflux-prd-rh03`
  - `components/multi-platform-controller/production-downstream/kflux-osp-p01`
  - `components/multi-platform-controller/production-downstream/stone-prod-p01`
- Version validated in dev/staging via `components/multi-platform-controller/base/kustomization.yaml`

## Risk Assessment

**Risk Level:** Medium

**Staging PR:**  https://github.com/redhat-appstudio/infra-deployments/pull/12193

**What could go wrong:** MPC manages remote build hosts; a bad upgrade could break multi-arch or remote-platform builds on the affected clusters.

**Rollback:** Revert this PR. Ring 1 clusters will fall back to `93c18de0` via `production/base` and `production-downstream/base`.

**Blast radius:** 5 of 9 production clusters (Ring 1 only). Remaining clusters unchanged until Ring 2.

Made with [Cursor](https://cursor.com)