### PR TITLE
feat: Pipelines Service Ring deployments 

### DIFF
--- a/.github/workflows/verify-pipelines-configs.yaml
+++ b/.github/workflows/verify-pipelines-configs.yaml
@@ -46,6 +46,7 @@ jobs:
           function check_changes() {
             ENVIRONMENT="${1}"
             ./hack/generate-deploy-config.sh -c "components/pipeline-service/${ENVIRONMENT}" || fail "Error generating configuration for ${ENVIRONMENT}"
+            ./components/pipeline-service/production/sync-rings.sh || fail "Error syncing production ring configuration"
 
             if [ -n "$(git status --porcelain components/pipeline-service/${ENVIRONMENT})" ]; then
               body="Please rebuild with kustomize following [the README](https://github.com/redhat-appstudio/infra-deployments/tree/main/components/pipeline-service#update-procedure). If the change is unexpected, use git-blame to identify the source of the change and confirm with the author that the change is safe."

--- a/components/pipeline-service/README.md
+++ b/components/pipeline-service/README.md
@@ -78,7 +78,9 @@ $ git status
 
 - For production overlay:
 
-Same as 'stage' overlay, though you'll deal with the yaml files under the 'production' subdirectory, and the 
+By default production changes are done using a Ring deployment, for which details are included below.
+If you're making changes which do not require a ring deployment, the change can be made
+the same as the 'stage' overlay, though you'll deal with the yaml files under the 'production' subdirectory, and the
 use of 'generate-deploy-config.sh' similarily is tweaked to update the 'production' overlay.
 
 ```shell
@@ -86,4 +88,106 @@ use of 'generate-deploy-config.sh' similarily is tweaked to update the 'producti
 $ ./hack/generate-deploy-config.sh -c components/pipeline-service/production
 # to see if your updates made it to the deploy.yaml files
 $ git status
+```
+
+## Production Ring Deployments
+
+Production clusters are organized into three rings for gradual rollout to minimize blast radius:
+
+- **Ring 1**: Early adopter clusters (smallest blast radius)
+- **Ring 2**: Mid-tier clusters
+- **Ring 3**: Remaining production clusters
+
+See `./components/pipeline-service/production/ring-mappings.yaml` for current cluster membership.
+
+### Updating procedure for Ring Deployments
+
+1. Apply the change as a patch in ring-1's kustomization file. For example:
+```yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources: []
+patches:
+  - target:
+      kind: CatalogSource
+      name: custom-operators
+    patch: |-
+      - op: replace
+        path: /spec/image
+        value: quay.io/openshift-pipeline/pipelines-index-4.18@sha256:d4d3f6210a384da6bfb11214a860e72e52d0a38b73037b8135c0571a6365d2a1
+```
+
+2. Sync ring configuration and regenerate deploy.yaml files
+```bash
+# Sync ring references to all clusters
+./components/pipeline-service/production/sync-rings.sh
+
+# Regenerate all deploy.yaml files
+./hack/generate-deploy-config.sh -c components/pipeline-service/production
+```
+
+3. Deploy the changes
+
+4. After the ring has been deployed and validated, repeat steps 1 through 3 for the next ring.
+
+5. Once the change is ready to deploy on all clusters, apply the change to `components/pipeline-service/production/base/main-pipeline-service-configuration.yaml` and remove the patch from the rings' `kustomization.yaml` files.
+
+6. Sync the ring configuration and regenerate `deploy.yaml` files. There should be no changes to the `deploy.yaml` files.
+
+
+### Managing Ring Membership
+
+To add a cluster to a ring or move it between rings, edit `production/ring-mappings.yaml`:
+
+```yaml
+ring-1:
+  - kflux-fedora-01
+  - stone-prod-p01
+  - new-cluster-01  # Add new cluster here
+
+ring-2:
+  - stone-prod-p02
+  - kflux-rhel-p01
+```
+
+Then run `./components/pipeline-service/production/sync-rings.sh` to apply the changes. The script will validate that all mapped clusters exist and all cluster directories are mapped to a ring.
+
+### Common Ring Deployment Patterns
+
+**Index update:**
+```yaml
+patches:
+  - target:
+      kind: CatalogSource
+      name: custom-operators
+    patch: |-
+      - op: replace
+        path: /spec/image
+        value: quay.io/openshift-pipeline/pipelines-index-4.18@sha256:d4d3f6210a384da6bfb11214a860e72e52d0a38b73037b8135c0571a6365d2a1
+```
+
+**Image override:**
+```yaml
+patches:
+  - target:
+      kind: Subscription
+      name: openshift-pipelines-operator
+    patch: |-
+      - op: add
+        path: /spec/config/env
+        value: {"name": "IMAGE_PAC_PAC_CLI", "value": "quay.io/openshift-pipeline/pipelines-pipelines-as-code-cli-rhel9@sha256:0fc0dd05236f14265e25cc770a7f9f3aeea2e27964a730dac39cf9f61d349bde"}
+```
+
+**Resource limit adjustment:**
+```yaml
+patches:
+  - target:
+      kind: TektonConfig
+      name: config
+    patch: |-
+      - op: replace
+        path: /spec/pipeline/options/statefulSets/tekton-pipelines-remote-resolvers/spec/template/spec/
+containers/0/resources/limits/memory
+        value: 12G
 ```

--- a/components/pipeline-service/production/base/main-pipeline-service-configuration.yaml
+++ b/components/pipeline-service/production/base/main-pipeline-service-configuration.yaml
@@ -1846,19 +1846,19 @@ spec:
         #               requests:
         #                 cpu: 1500m
         #                 memory: 8Gi
-        tekton-events-controller:
-          spec:
-            template:
-              spec:
-                containers:
-                  - name: tekton-events-controller
-                    resources:
-                      limits:
-                        cpu: 200m
-                        memory: 4096Mi
-                      requests:
-                        cpu: 200m
-                        memory: 4096Mi
+        # tekton-events-controller:
+        #   spec:
+        #     template:
+        #       spec:
+        #         containers:
+        #           - name: tekton-events-controller
+        #             resources:
+        #               limits:
+        #                 cpu: 200m
+        #                 memory: 4096Mi
+        #               requests:
+        #                 cpu: 200m
+        #                 memory: 4096Mi
         # tekton-triggers-controller:
         #   spec:
         #     template:
@@ -2059,7 +2059,7 @@ metadata:
   namespace: openshift-marketplace
 spec:
   displayName: custom-operators
-  image: quay.io/openshift-pipeline/pipelines-index-4.18@sha256:a4aa211a70b0a92c98c885cca8fed2cce490e3fec656ad1ea68bf7e7c3c18304
+  image: quay.io/openshift-pipeline/pipelines-index-4.18@sha256:d4d3f6210a384da6bfb11214a860e72e52d0a38b73037b8135c0571a6365d2a1
   sourceType: grpc
   updateStrategy:
     registryPoll:

--- a/components/pipeline-service/production/kflux-fedora-01/resources/kustomization.yaml
+++ b/components/pipeline-service/production/kflux-fedora-01/resources/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ../../base
+  - ../../rings/ring-1
   - scc-rbac.yaml
 patches:
   - path: tekton-chains-public-key-path.yaml

--- a/components/pipeline-service/production/kflux-ocp-p01/resources/kustomization.yaml
+++ b/components/pipeline-service/production/kflux-ocp-p01/resources/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ../../base
+  - ../../rings/ring-2
 patches:
   - path: tekton-chains-public-key-path.yaml
     target:

--- a/components/pipeline-service/production/kflux-osp-p01/resources/kustomization.yaml
+++ b/components/pipeline-service/production/kflux-osp-p01/resources/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ../../base
+  - ../../rings/ring-1
 patches:
   - path: tekton-chains-public-key-path.yaml
     target:

--- a/components/pipeline-service/production/kflux-prd-rh02/resources/kustomization.yaml
+++ b/components/pipeline-service/production/kflux-prd-rh02/resources/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ../../base
+  - ../../rings/ring-3
 patches:
   - path: tekton-chains-public-key-path.yaml
     target:

--- a/components/pipeline-service/production/kflux-prd-rh03/resources/kustomization.yaml
+++ b/components/pipeline-service/production/kflux-prd-rh03/resources/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ../../base
+  - ../../rings/ring-3
 patches:
   - path: tekton-chains-public-key-path.yaml
     target:

--- a/components/pipeline-service/production/kflux-rhel-p01/resources/kustomization.yaml
+++ b/components/pipeline-service/production/kflux-rhel-p01/resources/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ../../base
+  - ../../rings/ring-2
 patches:
   - path: tekton-chains-public-key-path.yaml
     target:

--- a/components/pipeline-service/production/ring-mappings.yaml
+++ b/components/pipeline-service/production/ring-mappings.yaml
@@ -1,0 +1,17 @@
+# Ring membership for pipeline-service production clusters
+# Used to apply ring-specific patches during staged rollouts
+
+ring-1:
+  - "kflux-fedora-01"
+  - "stone-prod-p01"
+  - "kflux-osp-p01"
+
+ring-2:
+  - "stone-prod-p02"
+  - "kflux-rhel-p01"
+  - "kflux-ocp-p01"
+
+ring-3:
+  - "stone-prd-rh01"
+  - "kflux-prd-rh02"
+  - "kflux-prd-rh03"

--- a/components/pipeline-service/production/rings/ring-1/kustomization.yaml
+++ b/components/pipeline-service/production/rings/ring-1/kustomization.yaml
@@ -8,4 +8,38 @@ kind: Kustomization
 resources:
   - ../../base
 
-patches: []
+patches:
+  # Upgrade index
+  - target:
+      kind: CatalogSource
+      name: custom-operators
+    patch: |-
+      - op: replace
+        path: /spec/image
+        value: quay.io/openshift-pipeline/pipelines-index-4.18@sha256:a4aa211a70b0a92c98c885cca8fed2cce490e3fec656ad1ea68bf7e7c3c18304
+  # Increase tekton events controller resources
+  - target:
+      kind: TektonConfig
+      name: config
+    patch: |-
+      apiVersion: operator.tekton.dev/v1alpha1
+      kind: TektonConfig
+      metadata:
+        name: config
+      spec:
+        pipeline:
+          options:
+            deployments:
+              tekton-events-controller:
+                spec:
+                  template:
+                    spec:
+                      containers:
+                      - name: tekton-events-controller
+                        resources:
+                          limits:
+                            cpu: 200m
+                            memory: 4096Mi
+                          requests:
+                            cpu: 200m
+                            memory: 4096Mi

--- a/components/pipeline-service/production/rings/ring-1/kustomization.yaml
+++ b/components/pipeline-service/production/rings/ring-1/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# Ring 1 production rollout patches
+# Add patches here when deploying to ring 1 clusters
+# Clear this file (leave only these comments) after promoting to all rings
+
+resources:
+  - ../../base
+
+patches: []

--- a/components/pipeline-service/production/rings/ring-2/kustomization.yaml
+++ b/components/pipeline-service/production/rings/ring-2/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# Ring 2 production rollout patches
+# Add patches here when deploying to ring 2 clusters
+# Clear this file (leave only these comments) after promoting to all rings
+
+resources:
+  - ../../base
+patches: []

--- a/components/pipeline-service/production/rings/ring-2/kustomization.yaml
+++ b/components/pipeline-service/production/rings/ring-2/kustomization.yaml
@@ -7,4 +7,39 @@ kind: Kustomization
 
 resources:
   - ../../base
-patches: []
+
+patches:
+  # Upgrade index
+  - target:
+      kind: CatalogSource
+      name: custom-operators
+    patch: |-
+      - op: replace
+        path: /spec/image
+        value: quay.io/openshift-pipeline/pipelines-index-4.18@sha256:a4aa211a70b0a92c98c885cca8fed2cce490e3fec656ad1ea68bf7e7c3c18304
+  # Increase tekton events controller resources
+  - target:
+      kind: TektonConfig
+      name: config
+    patch: |-
+      apiVersion: operator.tekton.dev/v1alpha1
+      kind: TektonConfig
+      metadata:
+        name: config
+      spec:
+        pipeline:
+          options:
+            deployments:
+              tekton-events-controller:
+                spec:
+                  template:
+                    spec:
+                      containers:
+                      - name: tekton-events-controller
+                        resources:
+                          limits:
+                            cpu: 200m
+                            memory: 4096Mi
+                          requests:
+                            cpu: 200m
+                            memory: 4096Mi

--- a/components/pipeline-service/production/rings/ring-3/kustomization.yaml
+++ b/components/pipeline-service/production/rings/ring-3/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# Ring 3 production rollout patches
+# Add patches here when deploying to ring 3 clusters
+# Clear this file (leave only these comments) after promoting to all rings
+
+resources:
+  - ../../base
+
+patches: []

--- a/components/pipeline-service/production/stone-prd-rh01/resources/kustomization.yaml
+++ b/components/pipeline-service/production/stone-prd-rh01/resources/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ../../base
+  - ../../rings/ring-3
 patches:
   - path: tekton-chains-public-key-path.yaml
     target:

--- a/components/pipeline-service/production/stone-prod-p01/resources/kustomization.yaml
+++ b/components/pipeline-service/production/stone-prod-p01/resources/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ../../base
+  - ../../rings/ring-1
 patches:
   - path: tekton-chains-public-key-path.yaml
     target:

--- a/components/pipeline-service/production/stone-prod-p02/resources/kustomization.yaml
+++ b/components/pipeline-service/production/stone-prod-p02/resources/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ../../base
+  - ../../rings/ring-2
 patches:
   - path: tekton-chains-public-key-path.yaml
     target:

--- a/components/pipeline-service/production/sync-rings.sh
+++ b/components/pipeline-service/production/sync-rings.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+# Setup ring-specific overlays for pipeline-service production clusters
+# This script adds ring overlay references to each cluster's kustomization.yaml
+
+set -euo pipefail
+# nullglob allows for easier error handling when listing all clusters
+shopt -s nullglob
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROD_DIR="${SCRIPT_DIR}"
+RINGS_FILE="${PROD_DIR}/ring-mappings.yaml"
+
+# Validate that all clusters are defined in ring-mappings.yaml
+function validate_all_clusters_mapped() {
+  echo "Validating cluster coverage..."
+  mapped_clusters=$(yq eval '.[] | .[]' "$RINGS_FILE" | sort -u)
+  missing_clusters=()
+
+  for cluster in $mapped_clusters; do
+    if [[ ! -d "${PROD_DIR}/${cluster}" ]]; then
+      missing_clusters+=("$cluster doesn't exist")
+    fi
+  done
+
+  for cluster_dir in "${PROD_DIR}"/*/; do
+    cluster=$(basename "$cluster_dir")
+    # Skip non-cluster directories
+    [[ "$cluster" == "base" || "$cluster" == "rings" ]] && continue
+
+    if ! echo "$mapped_clusters" | grep -qx "$cluster"; then
+      missing_clusters+=("$cluster unmapped")
+    fi
+  done
+
+
+  if [[ ${#missing_clusters[@]} -gt 0 ]]; then
+    echo "❌ Error: Cluster Ring configuration validation failed:" >&2
+    printf '  - %s\n' "${missing_clusters[@]}" >&2
+    return 1
+  fi
+
+  echo "✓ All clusters are mapped in ring-mappings.yaml"
+  echo ""
+}
+
+
+function sync_rings() {
+  # First pass: remove all existing ring references from all clusters
+  echo "Removing existing ring references..."
+  for kustomization in "${PROD_DIR}"/*/resources/kustomization.yaml; do
+    cluster=$(basename "$(dirname "$(dirname "$kustomization")")")
+    echo "  - Removing from ${cluster}"
+    yq eval -i '.resources = (.resources // [] | map(select(. | test("rings/ring-") | not)))' "$kustomization"
+  done
+
+  echo "Setting up pipeline-service ring overlays..."
+
+  # Second pass: add correct ring reference to each cluster
+  for ring in $(yq eval 'keys | .[]' "$RINGS_FILE"); do
+    echo "  - Processing ${ring}..."
+
+    # Get all clusters for this ring
+    clusters=$(yq eval ".${ring}[]" "$RINGS_FILE")
+
+    for cluster in $clusters; do
+      kustomization="${PROD_DIR}/${cluster}/resources/kustomization.yaml"
+
+      if [[ ! -f "$kustomization" ]]; then
+        echo "    ⚠️  Skipping ${cluster}: kustomization.yaml not found" >&2
+        continue
+      fi
+
+      # Add the ring overlay at the beginning of resources array
+      yq eval -i ".resources = [\"../../rings/${ring}\"] + (.resources // [])" "$kustomization"
+      echo "    ✓ Configured ${cluster} with ${ring}"
+    done
+  done
+
+  echo ""
+  echo "✅ Ring overlays configured. Run hack/generate-deploy-config.sh to regenerate deploy.yaml files"
+}
+
+validate_all_clusters_mapped
+sync_rings


### PR DESCRIPTION
Add automation to create three deployment rings. Each Production cluster is assigned a ring and each ring has a separate kustomization resource that patches the production base layer. 
This lets the CI ensure that all clusters' configurations are in sync with kustomize so long as they're in sync with their ring. The `sync-rings.sh` script manages which clusters are assigned to which rings for maintenance, and also ensures that every production cluster is assigned to a ring, which is enforced by CI.

Documentation is also updated accordingly. See the README changes for more details.

## Risk Assessment

**Risk Level:** Low
**Description:** Not applicable, no changes to production `deploy.yaml` in any clusters, only to Kustomization structure
**Rollback:** Revert the commit

## Validation

Staging PR: Not Applicable