### PR TITLE
Disable tekton events controller in staging and development

### DIFF
--- a/components/pipeline-service/development/main-pipeline-service-configuration.yaml
+++ b/components/pipeline-service/development/main-pipeline-service-configuration.yaml
@@ -2033,17 +2033,7 @@ spec:
                         memory: 128Mi
         tekton-events-controller:
           spec:
-            template:
-              spec:
-                containers:
-                  - name: tekton-events-controller
-                    resources:
-                      limits:
-                        cpu: 100m
-                        memory: 100Mi
-                      requests:
-                        cpu: 50m
-                        memory: 64Mi
+            replicas: 0
         tekton-triggers-controller:
           spec:
             template:

--- a/components/pipeline-service/staging/base/main-pipeline-service-configuration.yaml
+++ b/components/pipeline-service/staging/base/main-pipeline-service-configuration.yaml
@@ -1853,17 +1853,7 @@ spec:
                         memory: 8Gi
         tekton-events-controller:
           spec:
-            template:
-              spec:
-                containers:
-                  - name: tekton-events-controller
-                    resources:
-                      limits:
-                        cpu: 200m
-                        memory: 256Mi
-                      requests:
-                        cpu: 200m
-                        memory: 256Mi
+            replicas: 0
         tekton-triggers-controller:
           spec:
             template:

--- a/components/pipeline-service/staging/stone-stage-p01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stage-p01/deploy.yaml
@@ -2401,17 +2401,7 @@ spec:
                       memory: 8Gi
         tekton-events-controller:
           spec:
-            template:
-              spec:
-                containers:
-                - name: tekton-events-controller
-                  resources:
-                    limits:
-                      cpu: 200m
-                      memory: 256Mi
-                    requests:
-                      cpu: 200m
-                      memory: 256Mi
+            replicas: 0
         tekton-operator-proxy-webhook:
           spec:
             replicas: 2

--- a/components/pipeline-service/staging/stone-stg-rh01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stg-rh01/deploy.yaml
@@ -2401,17 +2401,7 @@ spec:
                       memory: 8Gi
         tekton-events-controller:
           spec:
-            template:
-              spec:
-                containers:
-                - name: tekton-events-controller
-                  resources:
-                    limits:
-                      cpu: 200m
-                      memory: 256Mi
-                    requests:
-                      cpu: 200m
-                      memory: 256Mi
+            replicas: 0
         tekton-operator-proxy-webhook:
           spec:
             replicas: 2


### PR DESCRIPTION
The Tekton Events Controller watches every PipelineRun and TaskRun, but there are no CloudEvent sinks configured so the events controller does not emit any events, it's just a no-op. 

[SRVKP-12264](https://redhat.atlassian.net/browse/SRVKP-12264)

[SRVKP-12264]: https://redhat.atlassian.net/browse/SRVKP-12264?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ