### PR TITLE
feat(konflux-operator): update konflux-operator development layer

### DIFF
--- a/components/konflux-operator/development/cr/overlay-patches/build/build-service.yaml
+++ b/components/konflux-operator/development/cr/overlay-patches/build/build-service.yaml
@@ -5,16 +5,13 @@ metadata:
 spec:
   buildService:
     spec:
+      pacWebhookInsecureSSL: true
+      logEncoder: console
+      webhookURLs:
+        "https://codeberg.org": "SMEE_CHANNEL_PLACEHOLDER"
       buildControllerManager:
         replicas: 1
         manager:
           env:
-            - name: PAC_WEBHOOK_INSECURE_SSL
-              value: "1"
-          resources:
-            requests:
-              cpu: 30m
-              memory: 128Mi
-            limits:
-              cpu: 30m
-              memory: 128Mi
+            - name: IMAGE_TAG_ON_PR_EXPIRATION
+              value: ""

--- a/components/konflux-operator/development/cr/overlay-patches/enterprise-contract/ecp.yaml
+++ b/components/konflux-operator/development/cr/overlay-patches/enterprise-contract/ecp.yaml
@@ -1,0 +1,156 @@
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: EnterpriseContractPolicy
+metadata:
+  name: default
+  namespace: enterprise-contract-service
+  annotations:
+    argocd.argoproj.io/sync-wave: "10"
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  description: 'Includes rules for levels 1, 2 & 3 of SLSA v0.1. This is the default config used for new Konflux applications. Source: https://github.com/conforma/config/blob/main/default/policy.yaml'
+  name: Default
+  publicKey: k8s://openshift-pipelines/public-key
+  sources:
+    - config:
+        exclude: []
+        include:
+          - '@slsa3'
+      data:
+        - github.com/release-engineering/rhtap-ec-policy//data
+        - oci::quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest
+        - oci::quay.io/konflux-ci/konflux-vanguard/data-acceptable-bundles:latest
+        - oci::quay.io/konflux-ci/integration-service-catalog/data-acceptable-bundles:latest
+      name: Default
+      policy:
+        - oci::quay.io/enterprise-contract/ec-release-policy:konflux
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: EnterpriseContractPolicy
+metadata:
+  name: redhat-no-hermetic
+  namespace: enterprise-contract-service
+  annotations:
+    argocd.argoproj.io/sync-wave: "10"
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  description: 'Includes most of the rules and policies required internally by Red Hat when building Red Hat products. It excludes the requirement of hermetic builds. Source: https://github.com/conforma/config/blob/main/redhat-no-hermetic/policy.yaml'
+  name: Red Hat (non hermetic)
+  publicKey: k8s://openshift-pipelines/public-key
+  sources:
+    - config:
+        exclude:
+          - hermetic_build_task
+          - tasks.required_tasks_found:prefetch-dependencies
+        include:
+          - '@redhat'
+      data:
+        - github.com/release-engineering/rhtap-ec-policy//data
+        - oci::quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest
+        - oci::quay.io/konflux-ci/konflux-vanguard/data-acceptable-bundles:latest
+        - oci::quay.io/konflux-ci/integration-service-catalog/data-acceptable-bundles:latest
+      name: Default
+      policy:
+        - oci::quay.io/enterprise-contract/ec-release-policy:konflux
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: EnterpriseContractPolicy
+metadata:
+  name: redhat-rpms
+  namespace: enterprise-contract-service
+  annotations:
+    argocd.argoproj.io/sync-wave: "10"
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  description: 'For Red Hat RPM builds in Red Hat Konflux. Source: https://github.com/conforma/config/blob/main/redhat-rpms/policy.yaml'
+  name: Red Hat RPMs
+  publicKey: k8s://openshift-pipelines/public-key
+  sources:
+    - config:
+        exclude: []
+        include:
+          - '@redhat_rpms'
+      data:
+        - github.com/release-engineering/rhtap-ec-policy//data
+        - oci::quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest
+        - oci::quay.io/konflux-ci/konflux-vanguard/data-acceptable-bundles:latest
+        - oci::quay.io/konflux-ci/integration-service-catalog/data-acceptable-bundles:latest
+        - oci::quay.io/enterprise-contract/rpmbuild-data-acceptable-bundles:latest
+      name: Default
+      policy:
+        - oci::quay.io/enterprise-contract/ec-release-policy:konflux
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: EnterpriseContractPolicy
+metadata:
+  name: redhat
+  namespace: enterprise-contract-service
+  annotations:
+    argocd.argoproj.io/sync-wave: "10"
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  description: 'Includes the full set of rules and policies required internally by Red Hat when building Red Hat products. Source: https://github.com/conforma/config/blob/main/redhat/policy.yaml'
+  name: Red Hat
+  publicKey: k8s://openshift-pipelines/public-key
+  sources:
+    - config:
+        exclude: []
+        include:
+          - '@redhat'
+      data:
+        - github.com/release-engineering/rhtap-ec-policy//data
+        - oci::quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest
+        - oci::quay.io/konflux-ci/konflux-vanguard/data-acceptable-bundles:latest
+        - oci::quay.io/konflux-ci/integration-service-catalog/data-acceptable-bundles:latest
+      name: Default
+      policy:
+        - oci::quay.io/enterprise-contract/ec-release-policy:konflux
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: EnterpriseContractPolicy
+metadata:
+  name: slsa3
+  namespace: enterprise-contract-service
+  annotations:
+    argocd.argoproj.io/sync-wave: "10"
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  description: 'Rules specifically related to levels 1, 2 & 3 of SLSA v0.1, plus a set of basic checks that are expected to pass for all Konflux builds. Source: https://github.com/conforma/config/blob/main/slsa3/policy.yaml'
+  name: SLSA3
+  publicKey: k8s://openshift-pipelines/public-key
+  sources:
+    - config:
+        exclude: []
+        include:
+          - '@minimal'
+          - '@slsa3'
+      data:
+        - github.com/release-engineering/rhtap-ec-policy//data
+        - oci::quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest
+        - oci::quay.io/konflux-ci/konflux-vanguard/data-acceptable-bundles:latest
+        - oci::quay.io/konflux-ci/integration-service-catalog/data-acceptable-bundles:latest
+      name: Default
+      policy:
+        - oci::quay.io/enterprise-contract/ec-release-policy:konflux
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: EnterpriseContractPolicy
+metadata:
+  name: redhat-trusted-tasks
+  namespace: enterprise-contract-service
+  annotations:
+    argocd.argoproj.io/sync-wave: "10"
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  description: Rules used to verify Tekton Task definitions comply to Red Hat's standards.
+  name: Red Hat Trusted Tasks
+  sources:
+    - config:
+        exclude: []
+        include:
+          - kind
+      data:
+        - github.com/release-engineering/rhtap-ec-policy//data
+      name: Default
+      policy:
+        - oci::quay.io/enterprise-contract/ec-task-policy:konflux

--- a/components/konflux-operator/development/cr/overlay-patches/enterprise-contract/enterprise-contract.yaml
+++ b/components/konflux-operator/development/cr/overlay-patches/enterprise-contract/enterprise-contract.yaml
@@ -3,7 +3,5 @@ kind: Konflux
 metadata:
   name: konflux
 spec:
-  namespaceLister:
-    spec:
-      namespaceLister:
-        replicas: 1
+  enterpriseContract:
+    skipPolicies: true

--- a/components/konflux-operator/development/cr/overlay-patches/enterprise-contract/kustomization.yaml
+++ b/components/konflux-operator/development/cr/overlay-patches/enterprise-contract/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+resources:
+  - ecp.yaml
+patches:
+  - path: enterprise-contract.yaml

--- a/components/konflux-operator/development/cr/overlay-patches/image-controller/image-controller.yaml
+++ b/components/konflux-operator/development/cr/overlay-patches/image-controller/image-controller.yaml
@@ -7,3 +7,15 @@ spec:
     # patched by hack/preview.sh if IMAGE_CONTROLLER_QUAY_ORG and
     # IMAGE_CONTROLLER_QUAY_TOKEN are set
     enabled: false
+    spec:
+      logEncoder: console
+      imageControllerManager:
+        replicas: 1
+        manager:
+          resources:
+            requests:
+              cpu: 100m
+              memory: 20Mi
+            limits:
+              cpu: 500m
+              memory: 2Gi

--- a/components/konflux-operator/development/cr/overlay-patches/integration/integration-service.yaml
+++ b/components/konflux-operator/development/cr/overlay-patches/integration/integration-service.yaml
@@ -5,13 +5,17 @@ metadata:
 spec:
   integrationService:
     spec:
+      pipelineTimeout: "6h"
+      tasksTimeout: "4h"
+      finallyTimeout: "2h"
+      prSnapshotsToKeep: "10"
       integrationControllerManager:
         replicas: 1
         manager:
           resources:
             requests:
-              cpu: 30m
-              memory: 128Mi
+              cpu: 100m
+              memory: 20Mi
             limits:
-              cpu: 30m
-              memory: 128Mi
+              cpu: 500m
+              memory: 1Gi

--- a/components/konflux-operator/development/cr/overlay-patches/konflux-info/konflux-info.yaml
+++ b/components/konflux-operator/development/cr/overlay-patches/konflux-info/konflux-info.yaml
@@ -5,6 +5,9 @@ metadata:
 spec:
   info:
     spec:
+      clusterConfig:
+        data:
+          allowCacheProxy: false
       publicInfo:
         environment: development
         visibility: public

--- a/components/konflux-operator/development/cr/overlay-patches/release/release-service.yaml
+++ b/components/konflux-operator/development/cr/overlay-patches/release/release-service.yaml
@@ -5,13 +5,59 @@ metadata:
 spec:
   releaseService:
     spec:
+      debug: true
+      emptyDirOverrides:
+        - url: ".*"
+          revision: ".*"
+          pathInRepo: "pipelines/managed/fbc-release/fbc-release.yaml"
+        - url: ".*"
+          revision: ".*"
+          pathInRepo: "pipelines/managed/push-artifacts-to-cdn/push-artifacts-to-cdn.yaml"
+        - url: ".*"
+          revision: ".*"
+          pathInRepo: "pipelines/managed/push-disk-images-to-cdn/push-disk-images-to-cdn.yaml"
+        - url: ".*"
+          revision: ".*"
+          pathInRepo: "pipelines/managed/push-disk-images-to-marketplaces/push-disk-images-to-marketplaces.yaml"
+        - url: ".*"
+          revision: ".*"
+          pathInRepo: "pipelines/managed/push-oot-kmods/push-oot-kmods.yaml"
+        - url: ".*"
+          revision: ".*"
+          pathInRepo: "pipelines/managed/push-rpm-to-koji/push-rpm-to-koji.yaml"
+        - url: ".*"
+          revision: ".*"
+          pathInRepo: "pipelines/managed/push-tekton-task-bundles-to-external-registry/push-tekton-task-bundles-to-external-registry.yaml"
+        - url: ".*"
+          revision: ".*"
+          pathInRepo: "pipelines/managed/push-to-addons-registry/push-to-addons-registry.yaml"
+        - url: ".*"
+          revision: ".*"
+          pathInRepo: "pipelines/managed/push-to-external-registry/push-to-external-registry.yaml"
+        - url: ".*"
+          revision: ".*"
+          pathInRepo: "pipelines/managed/release-to-github/release-to-github.yaml"
+        - url: ".*"
+          revision: ".*"
+          pathInRepo: "pipelines/managed/release-to-mrrc/release-to-mrrc.yaml"
+        - url: ".*"
+          revision: ".*"
+          pathInRepo: "pipelines/managed/rh-advisories/rh-advisories.yaml"
+        - url: ".*"
+          revision: ".*"
+          pathInRepo: "pipelines/managed/rh-push-to-external-registry/rh-push-to-external-registry.yaml"
+        - url: ".*"
+          revision: ".*"
+          pathInRepo: "pipelines/managed/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io.yaml"
+        - url: ".*"
+          revision: ".*"
+          pathInRepo: "pipelines/managed/rhtap-service-push/rhtap-service-push.yaml"
+        - url: ".*"
+          revision: ".*"
+          pathInRepo: "pipelines/managed/push-rpms-to-pulp/push-rpms-to-pulp.yaml"
       releaseControllerManager:
         replicas: 1
         manager:
           resources:
-            requests:
-              cpu: 30m
-              memory: 256Mi
             limits:
-              cpu: 30m
               memory: 256Mi

--- a/components/konflux-operator/development/invariant/kustomization.yaml
+++ b/components/konflux-operator/development/invariant/kustomization.yaml
@@ -6,7 +6,7 @@ kind: Kustomization
 # Parent `../kustomization.yaml` adds per-team overlays from `../cr/overlay-patches/`.
 resources:
   # Upstream operator config (konflux-ci builds install.yaml from this layout).
-  - https://github.com/konflux-ci/konflux-ci/operator/config/default?ref=4c4eae1fac3d421a3a92fe82eb2cb205bd3f538b
+  - https://github.com/konflux-ci/konflux-ci/operator/config/default?ref=435372cc39119b265926200b8f8b9c259afaa258
   - konflux.yaml
 
 patches:
@@ -15,4 +15,4 @@ patches:
 images:
   - name: localhost/konflux-operator
     newName: quay.io/konflux-ci/konflux-operator
-    newTag: 4c4eae1fac3d421a3a92fe82eb2cb205bd3f538b
+    newTag: 435372cc39119b265926200b8f8b9c259afaa258

--- a/components/konflux-operator/development/kustomization.yaml
+++ b/components/konflux-operator/development/kustomization.yaml
@@ -18,3 +18,4 @@ components:
   - cr/overlay-patches/konflux-ui
   - cr/overlay-patches/namespace-lister
   - cr/overlay-patches/release
+  - cr/overlay-patches/enterprise-contract

--- a/components/policies/development/konflux-rbac/restrict-binding-system-authenticated/.chainsaw-test/chainsaw-test.yaml
+++ b/components/policies/development/konflux-rbac/restrict-binding-system-authenticated/.chainsaw-test/chainsaw-test.yaml
@@ -113,6 +113,47 @@ spec:
 apiVersion: chainsaw.kyverno.io/v1alpha1
 kind: Test
 metadata:
+  name: in-default-tenant-valid-rolebinding
+spec:
+  description: |
+    tests that any RoleBinding can be created in the
+    tenant namespace 'default-tenant'
+  concurrent: false
+  namespace: 'default-tenant'
+  steps:
+  - name: given-kyverno-has-permission-on-resources
+    try:
+    - apply:
+        file: ../kyverno_rbac.yaml
+  - name: given-cluster-policy-is-ready
+    try:
+    - apply:
+        file: ../validate-restrict-binding-system-authenticated-clusterpolicy.yaml
+    - assert:
+        file: chainsaw-assert-clusterpolicy.yaml
+  - name: given-tenant-namespace-exists
+    try:
+    - apply:
+        file: ./resources/tenant-namespace.yaml
+  - name: then-valid-rolebinding-can-be-created
+    try:
+    - apply:
+        file: ./resources/valid-systemauthenticated-rolebinding.yaml
+        expect:
+        - check:
+            ($error != null): false
+  - name: then-invalid-rolebinding-can-be-created
+    try:
+    - apply:
+        file: ./resources/invalid-systemauthenticated-rolebinding.yaml
+        expect:
+        - check:
+            ($error != null): false
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
   name: in-tenant-valid-rolebinding
 spec:
   description: |

--- a/components/policies/development/konflux-rbac/restrict-binding-system-authenticated/validate-restrict-binding-system-authenticated-clusterpolicy.yaml
+++ b/components/policies/development/konflux-rbac/restrict-binding-system-authenticated/validate-restrict-binding-system-authenticated-clusterpolicy.yaml
@@ -31,6 +31,7 @@ spec:
       - resources:
           namespaces:
           - rhtap-releng-tenant
+          - default-tenant
     preconditions:
       all:
       - key: "{{ request.object.subjects[].name }}"


### PR DESCRIPTION
Changes:
- Bump operator digest
- Add enterprise-contract overlay: deploy EnterpriseContractPolicy
  resources from ecp.yaml with skipPolicies=true so the operator
  handles CRDs/RBAC/namespace while policies are managed via GitOps.
  ArgoCD sync-wave annotation ensures policies sync after CRDs exist.
- Add allowCacheProxy=false to konflux-info clusterConfig
- Set logEncoder=console for image-controller
- Configure build-service, integration, release overlays with
  dev-appropriate resource limits, logging, and feature flags
- Add default-tenant to exclude list in restrict-binding-system-authenticated-clusterpolicy
- Update chainsaw-test

Assited-by: Cursor + Opus 4.6