### PR TITLE
feat(KFLUXVNGD-1079): detect and list upstream service bumps in changelog comment

### DIFF
--- a/infra-tools/cmd/changelog-generator/main.go
+++ b/infra-tools/cmd/changelog-generator/main.go
@@ -1,9 +1,10 @@
 // Command changelog-generator posts a changelog comment on infra-deployments PRs
-// that bump the Konflux operator SHA.
+// that bump the Konflux operator ref.
 //
-// This is step 2 (KFLUXVNGD-1023): it reads the operator SHA at the base branch
-// and PR head, then posts a comment with the compare link. Upstream service
-// changes are introduced in subsequent PRs.
+// This is step 3 (KFLUXVNGD-1024): it reads the operator ref at the base branch
+// and PR head, posts a compare link, and lists which upstream sub-services had
+// their pinned SHA bumped inside the operator repo. Commit-level details per
+// service are introduced in the next PR.
 package main
 
 import (
@@ -14,6 +15,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"strings"
 	"syscall"
 
 	"github.com/redhat-appstudio/infra-deployments/infra-tools/internal/changelog"
@@ -22,7 +24,7 @@ import (
 )
 
 // kustomizationPath is the path, relative to the repo root, of the
-// kustomization.yaml file that pins the operator SHA.
+// kustomization.yaml file that pins the operator ref.
 const kustomizationPath = "components/konflux-operator/development/invariant/kustomization.yaml"
 
 // commentMarker identifies the changelog comment for idempotent updates.
@@ -46,7 +48,9 @@ func main() {
 	repo := os.Getenv("GITHUB_REPOSITORY")
 	prStr := os.Getenv("PR_NUMBER")
 
-	body, err := buildBody(ctx, *repoRoot, *baseRef)
+	comparer := changelog.NewRepoComparer(token)
+
+	body, err := buildBody(ctx, *repoRoot, *baseRef, comparer)
 	if err != nil {
 		slog.Error("building changelog body", "err", err)
 		os.Exit(1)
@@ -80,8 +84,9 @@ func main() {
 	}
 }
 
-// buildBody extracts the old and new operator SHAs and returns the comment body.
-func buildBody(ctx context.Context, repoRoot, baseRef string) (string, error) {
+// buildBody resolves the repo root and base ref, creates a git worktree for the
+// base ref, then delegates all comment logic to computeBody.
+func buildBody(ctx context.Context, repoRoot, baseRef string, comparer changelog.RepoComparer) (string, error) {
 	absRoot, err := resolveRepoRoot(ctx, repoRoot)
 	if err != nil {
 		return "", fmt.Errorf("resolving repo root: %w", err)
@@ -104,32 +109,54 @@ func buildBody(ctx context.Context, repoRoot, baseRef string) (string, error) {
 	basePath := filepath.Join(worktreePath, kustomizationPath)
 	headPath := filepath.Join(absRoot, kustomizationPath)
 
-	return computeBody(basePath, headPath)
+	return computeBody(ctx, basePath, headPath, comparer)
 }
 
-// computeBody extracts refs from the two kustomization files and returns the
-// appropriate comment body. It is the testable core of buildBody — all git
-// setup happens in buildBody; this function only does file I/O and formatting.
-func computeBody(basePath, headPath string) (string, error) {
+// computeBody extracts operator refs from the two kustomization files and returns
+// the appropriate comment body. It is the testable core of buildBody — all git
+// setup happens in buildBody; this function only does file I/O, API calls, and
+// formatting.
+//
+// If the GitHub API call to fetch operator file diffs fails, the comment still
+// includes the compare link but notes that service bump detection was unavailable.
+func computeBody(ctx context.Context, basePath, headPath string, comparer changelog.RepoComparer) (string, error) {
 	oldRef, newRef, err := changelog.ExtractRefs(basePath, headPath)
 	if err != nil {
 		return "", fmt.Errorf("extracting operator refs: %w", err)
 	}
 
-	if oldRef != newRef {
-		slog.Info("Operator ref bumped", "old", oldRef, "new", newRef)
-	} else {
-		slog.Info("Operator ref unchanged — no changelog needed")
-	}
-	return selectBody(oldRef, newRef), nil
-}
-
-// selectBody returns the appropriate comment body based on whether the ref changed.
-func selectBody(oldRef, newRef string) string {
 	if oldRef == newRef {
-		return formatNoChange()
+		slog.Info("Operator ref unchanged — no changelog needed")
+		return formatNoChange(), nil
 	}
-	return formatCompare(oldRef, newRef)
+	slog.Info("Operator ref bumped", "old", oldRef, "new", newRef)
+
+	compare, err := changelog.FetchOperatorCompare(ctx, comparer, oldRef, newRef)
+	if err != nil {
+		slog.Warn("fetching operator compare; service bumps unavailable", "err", err)
+		return formatCompare(oldRef, newRef, nil), nil
+	}
+	if compare.Truncated {
+		slog.Warn("operator compare truncated (≥300 files); service bump detection unavailable")
+		return formatCompare(oldRef, newRef, nil), nil
+	}
+
+	bumps, hasSkipped := changelog.ExtractServiceBumps(compare.Files)
+	if hasSkipped {
+		// One or more upstream kustomization files had no patch data — we cannot
+		// confidently say "no service refs changed", so degrade the same way we
+		// do for API failures rather than risk a misleading empty-bumps message.
+		slog.Warn("some upstream kustomization patches were empty; service bump detection may be incomplete")
+		return formatCompare(oldRef, newRef, nil), nil
+	}
+	slog.Info("Service bumps detected", "count", len(bumps))
+
+	// Normalize nil (no bumps found) to empty slice so formatCompare can
+	// distinguish "found nothing" from "API call failed" (nil).
+	if bumps == nil {
+		bumps = []changelog.ServiceBump{}
+	}
+	return formatCompare(oldRef, newRef, bumps), nil
 }
 
 // formatNoChange returns the comment body when the operator ref did not change.
@@ -137,9 +164,12 @@ func formatNoChange() string {
 	return commentMarker + "\n### Operator Changelog\n\nNo operator ref change detected in this PR.\n"
 }
 
-// formatCompare returns the comment body with a compare link between the two refs.
-// Upstream service changes will be added in the next PR.
-func formatCompare(oldRef, newRef string) string {
+// formatCompare returns the comment body with the operator compare link and
+// the list of upstream service bumps.
+//
+// bumps == nil means the service bump detection API call failed (degraded).
+// bumps == [] means the call succeeded but no sub-service SHAs changed.
+func formatCompare(oldRef, newRef string, bumps []changelog.ServiceBump) string {
 	const base = "https://github.com/konflux-ci/konflux-ci"
 	short := func(ref string) string {
 		if len(ref) > 12 {
@@ -147,13 +177,36 @@ func formatCompare(oldRef, newRef string) string {
 		}
 		return ref
 	}
-	return fmt.Sprintf(
-		"%s\n### Operator Changelog\n\nComparing [`%s`](%s/commit/%s) → [`%s`](%s/commit/%s)\n\n[Full diff](%s/compare/%s...%s)\n\n_Upstream service changes coming in the next PR._\n",
-		commentMarker,
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s\n### Operator Changelog\n\n", commentMarker)
+	fmt.Fprintf(&b, "Comparing [`%s`](%s/commit/%s) → [`%s`](%s/commit/%s)\n\n",
 		short(oldRef), base, oldRef,
-		short(newRef), base, newRef,
-		base, oldRef, newRef,
-	)
+		short(newRef), base, newRef)
+	fmt.Fprintf(&b, "[Full diff](%s/compare/%s...%s)\n\n", base, oldRef, newRef)
+
+	switch {
+	case bumps == nil:
+		fmt.Fprintln(&b, "_Upstream service bump detection unavailable — check manually._")
+	case len(bumps) == 0:
+		fmt.Fprintln(&b, "_No upstream service refs changed._")
+	default:
+		fmt.Fprintln(&b, "#### Upstream Service Bumps")
+		fmt.Fprintln(&b)
+		for _, bump := range bumps {
+			compareURL := fmt.Sprintf("https://github.com/%s/%s/compare/%s...%s",
+				bump.Owner, bump.Repo, bump.OldSHA, bump.NewSHA)
+			oldURL := fmt.Sprintf("https://github.com/%s/%s/commit/%s", bump.Owner, bump.Repo, bump.OldSHA)
+			newURL := fmt.Sprintf("https://github.com/%s/%s/commit/%s", bump.Owner, bump.Repo, bump.NewSHA)
+			fmt.Fprintf(&b, "**%s** [`%s`](%s) → [`%s`](%s) ([compare](%s))\n",
+				bump.Repo,
+				short(bump.OldSHA), oldURL,
+				short(bump.NewSHA), newURL,
+				compareURL)
+		}
+	}
+
+	return b.String()
 }
 
 // resolveRepoRoot returns the absolute path to the repository root.

--- a/infra-tools/cmd/changelog-generator/main_test.go
+++ b/infra-tools/cmd/changelog-generator/main_test.go
@@ -2,13 +2,17 @@ package main
 
 import (
 	"context"
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
 
+	gh "github.com/google/go-github/v68/github"
 	. "github.com/onsi/gomega"
+
+	"github.com/redhat-appstudio/infra-deployments/infra-tools/internal/changelog"
 )
 
 const (
@@ -28,6 +32,22 @@ func (f *fakeCommenter) UpsertCommentByMarker(_ context.Context, prNumber int, b
 	f.body = body
 	f.marker = marker
 	return nil
+}
+
+// fakeRepoComparer implements changelog.RepoComparer for testing.
+// Set files to return canned file changes; set err to simulate an API failure.
+var _ changelog.RepoComparer = &fakeRepoComparer{}
+
+type fakeRepoComparer struct {
+	files []*gh.CommitFile
+	err   error
+}
+
+func (f *fakeRepoComparer) CompareCommits(_ context.Context, _, _, _, _ string, _ *gh.ListOptions) (*gh.CommitsComparison, *gh.Response, error) {
+	if f.err != nil {
+		return nil, nil, f.err
+	}
+	return &gh.CommitsComparison{Files: f.files}, nil, nil
 }
 
 func writeTempKustomization(t *testing.T, ref string) string {
@@ -61,7 +81,7 @@ func TestPost_PassesCorrectMarkerAndBody(t *testing.T) {
 // are not truncated — the short() helper takes a different branch.
 func TestFormatCompare_ShortRef(t *testing.T) {
 	g := NewWithT(t)
-	body := formatCompare("main", "feature-x")
+	body := formatCompare("main", "feature-x", nil)
 	g.Expect(body).To(ContainSubstring("main"))
 	g.Expect(body).To(ContainSubstring("feature-x"))
 }
@@ -71,7 +91,7 @@ func TestFormatCompare_ShortRef(t *testing.T) {
 func TestComputeBody_Unchanged(t *testing.T) {
 	g := NewWithT(t)
 	path := writeTempKustomization(t, oldRef)
-	body, err := computeBody(path, path)
+	body, err := computeBody(context.Background(), path, path, &fakeRepoComparer{})
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(body).To(ContainSubstring(commentMarker))
 	g.Expect(body).To(ContainSubstring("### Operator Changelog"))
@@ -79,25 +99,119 @@ func TestComputeBody_Unchanged(t *testing.T) {
 }
 
 // TestComputeBody_Changed verifies that different kustomization files produce
-// a compare comment containing both refs, short display refs, and a compare URL.
+// a compare comment containing both refs and a compare URL. No service bumps
+// in this case because the fake comparer returns no files.
 func TestComputeBody_Changed(t *testing.T) {
 	g := NewWithT(t)
 	basePath := writeTempKustomization(t, oldRef)
 	headPath := writeTempKustomization(t, newRef)
-	body, err := computeBody(basePath, headPath)
+	body, err := computeBody(context.Background(), basePath, headPath, &fakeRepoComparer{})
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(body).To(ContainSubstring(commentMarker))
 	g.Expect(body).To(ContainSubstring(oldRef))
 	g.Expect(body).To(ContainSubstring(newRef))
 	g.Expect(body).To(ContainSubstring(oldRef[:12]))
 	g.Expect(body).To(ContainSubstring("konflux-ci/konflux-ci/compare/" + oldRef + "..." + newRef))
+	g.Expect(body).To(ContainSubstring("No upstream service refs changed"))
 	g.Expect(body).NotTo(ContainSubstring("No operator ref change"))
+}
+
+// TestComputeBody_WithServiceBumps verifies that a fake comparer returning a
+// build-service ref change causes "build-service" and its compare link to
+// appear in the comment body.
+func TestComputeBody_WithServiceBumps(t *testing.T) {
+	g := NewWithT(t)
+	buildOldSHA := "cccccccccccccccccccccccccccccccccccccccc"
+	buildNewSHA := "dddddddddddddddddddddddddddddddddddddddd"
+
+	patch := "-  - https://github.com/konflux-ci/build-service/config/default?ref=" + buildOldSHA + "\n" +
+		"+  - https://github.com/konflux-ci/build-service/config/default?ref=" + buildNewSHA + "\n"
+
+	fake := &fakeRepoComparer{
+		files: []*gh.CommitFile{
+			{
+				Filename: gh.Ptr("operator/upstream-kustomizations/build-service/kustomization.yaml"),
+				Patch:    gh.Ptr(patch),
+			},
+		},
+	}
+
+	basePath := writeTempKustomization(t, oldRef)
+	headPath := writeTempKustomization(t, newRef)
+	body, err := computeBody(context.Background(), basePath, headPath, fake)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(body).To(ContainSubstring("build-service"))
+	g.Expect(body).To(ContainSubstring(buildOldSHA[:12]))
+	g.Expect(body).To(ContainSubstring(buildNewSHA[:12]))
+	g.Expect(body).To(ContainSubstring("build-service/compare/" + buildOldSHA + "..." + buildNewSHA))
+}
+
+// TestComputeBody_APIFailureDegrades verifies that when the comparer returns an
+// error, the comment still includes the operator compare link (not an error page),
+// and notes that service bump detection was unavailable.
+func TestComputeBody_APIFailureDegrades(t *testing.T) {
+	g := NewWithT(t)
+	basePath := writeTempKustomization(t, oldRef)
+	headPath := writeTempKustomization(t, newRef)
+	fake := &fakeRepoComparer{err: errors.New("rate limited")}
+	body, err := computeBody(context.Background(), basePath, headPath, fake)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(body).To(ContainSubstring("compare/" + oldRef + "..." + newRef))
+	g.Expect(body).To(ContainSubstring("unavailable"))
+}
+
+// TestComputeBody_TruncatedDegrades verifies that when the compare API signals
+// truncation (≥300 files), the comment still includes the operator compare link
+// but notes that service bump detection was unavailable.
+func TestComputeBody_TruncatedDegrades(t *testing.T) {
+	g := NewWithT(t)
+	basePath := writeTempKustomization(t, oldRef)
+	headPath := writeTempKustomization(t, newRef)
+
+	// Return exactly 300 files to trigger the truncated flag.
+	files := make([]*gh.CommitFile, 300)
+	for i := range files {
+		files[i] = &gh.CommitFile{Filename: gh.Ptr("file.yaml"), Patch: gh.Ptr("diff")}
+	}
+	fake := &fakeRepoComparer{files: files}
+
+	body, err := computeBody(context.Background(), basePath, headPath, fake)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(body).To(ContainSubstring("compare/" + oldRef + "..." + newRef))
+	g.Expect(body).To(ContainSubstring("unavailable"))
+}
+
+// TestComputeBody_EmptyPatchDegrades verifies that when an upstream kustomization
+// file is returned by the compare API but has no patch data, the comment still
+// includes the operator compare link but notes that service bump detection was
+// unavailable — preventing a misleading "no upstream service refs changed" message.
+func TestComputeBody_EmptyPatchDegrades(t *testing.T) {
+	g := NewWithT(t)
+	basePath := writeTempKustomization(t, oldRef)
+	headPath := writeTempKustomization(t, newRef)
+
+	// The file is an upstream kustomization but its patch is empty — GitHub omits
+	// patch data for very large or renamed files.
+	fake := &fakeRepoComparer{
+		files: []*gh.CommitFile{
+			{
+				Filename: gh.Ptr("operator/upstream-kustomizations/build-service/kustomization.yaml"),
+				Patch:    gh.Ptr(""),
+			},
+		},
+	}
+
+	body, err := computeBody(context.Background(), basePath, headPath, fake)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(body).To(ContainSubstring("compare/" + oldRef + "..." + newRef))
+	g.Expect(body).To(ContainSubstring("unavailable"))
+	g.Expect(body).NotTo(ContainSubstring("No upstream service refs changed"))
 }
 
 // TestComputeBody_Error verifies that an unreadable file returns an error.
 func TestComputeBody_Error(t *testing.T) {
 	g := NewWithT(t)
-	_, err := computeBody("/nonexistent/kustomization.yaml", "/nonexistent/kustomization.yaml")
+	_, err := computeBody(context.Background(), "/nonexistent/kustomization.yaml", "/nonexistent/kustomization.yaml", &fakeRepoComparer{})
 	g.Expect(err).To(HaveOccurred())
 	g.Expect(err.Error()).To(ContainSubstring("extracting operator refs"))
 }
@@ -108,7 +222,6 @@ func TestComputeBody_Error(t *testing.T) {
 func TestBuildBody_Integration(t *testing.T) {
 	g := NewWithT(t)
 
-	// Set up a bare git repo with minimal config.
 	dir := t.TempDir()
 	gitRun(t, dir, "init")
 	gitRun(t, dir, "config", "user.email", "test@example.com")
@@ -127,15 +240,14 @@ func TestBuildBody_Integration(t *testing.T) {
 	gitRun(t, dir, "add", ".")
 	gitRun(t, dir, "commit", "-m", "bump operator ref")
 
-	// buildBody should detect the change and return a compare body.
-	body, err := buildBody(context.Background(), dir, baseCommit)
+	// Use a fake comparer so the test does not make real GitHub API calls.
+	body, err := buildBody(context.Background(), dir, baseCommit, &fakeRepoComparer{})
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(body).To(ContainSubstring(oldRef))
 	g.Expect(body).To(ContainSubstring(newRef))
 	g.Expect(body).To(ContainSubstring("compare"))
 }
 
-// gitRun runs a git command in dir and fails the test on error.
 func gitRun(t *testing.T, dir string, args ...string) {
 	t.Helper()
 	cmd := exec.CommandContext(context.Background(), "git", args...)
@@ -145,7 +257,6 @@ func gitRun(t *testing.T, dir string, args ...string) {
 	}
 }
 
-// gitOutput runs a git command and returns its stdout.
 func gitOutput(t *testing.T, dir string, args ...string) string {
 	t.Helper()
 	cmd := exec.CommandContext(context.Background(), "git", args...)
@@ -157,7 +268,6 @@ func gitOutput(t *testing.T, dir string, args ...string) string {
 	return string(out)
 }
 
-// writeKustomizationFile writes a minimal kustomization.yaml with the given ref.
 func writeKustomizationFile(t *testing.T, path, ref string) {
 	t.Helper()
 	content := "apiVersion: kustomize.config.k8s.io/v1beta1\nkind: Kustomization\nresources:\n" +

--- a/infra-tools/internal/changelog/bumps.go
+++ b/infra-tools/internal/changelog/bumps.go
@@ -1,0 +1,141 @@
+package changelog
+
+import (
+	"regexp"
+	"strings"
+)
+
+// ServiceBump describes an upstream sub-service whose pinned SHA changed
+// between the old and new operator versions.
+type ServiceBump struct {
+	Owner  string // GitHub org, e.g. "konflux-ci"
+	Repo   string // repository name, e.g. "build-service"
+	OldSHA string // previously pinned 40-char commit SHA
+	NewSHA string // newly pinned 40-char commit SHA
+}
+
+var (
+	// refPattern matches ?ref=<40-char-sha> in a unified diff line.
+	refPattern = regexp.MustCompile(`\?ref=([0-9a-f]{40})`)
+	// githubRepoPattern extracts owner and repo from a github.com URL.
+	githubRepoPattern = regexp.MustCompile(`github\.com/([^/]+)/([^/]+)/`)
+)
+
+// ExtractServiceBumps scans file changes from the operator repo comparison
+// for kustomization files under operator/upstream-kustomizations/ that have
+// a ?ref=<sha> change, and returns one ServiceBump per bumped service.
+//
+// Duplicate (owner, repo) pairs are deduplicated — only the first occurrence
+// is kept, since the same service can appear in multiple kustomization files.
+//
+// The second return value is true when one or more upstream kustomization files
+// had an empty patch (GitHub omits patch data for very large or renamed files).
+// Callers should treat this the same way they treat an API failure — detection
+// may be incomplete, so "no bumps found" cannot be stated with confidence.
+func ExtractServiceBumps(files []FileChange) ([]ServiceBump, bool) {
+	seen := make(map[string]bool)
+	var bumps []ServiceBump
+	hasSkipped := false
+
+	for _, f := range files {
+		if !isUpstreamKustomization(f.Filename) {
+			continue
+		}
+		if f.Patch == "" {
+			// Upstream kustomization file present but patch data unavailable —
+			// we cannot tell whether its ref changed, so flag incomplete results.
+			hasSkipped = true
+			continue
+		}
+		matchedBase, oldSHA, newSHA := extractRefChange(f.Patch)
+		if oldSHA == "" || newSHA == "" {
+			continue
+		}
+		// Derive owner/repo from the specific URL that changed, not from any
+		// github.com URL in the diff — prevents misattribution when a file
+		// references multiple repositories.
+		owner, repo := extractGitHubRepoFromURL(matchedBase)
+		if owner == "" || repo == "" {
+			continue
+		}
+		key := owner + "/" + repo
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		bumps = append(bumps, ServiceBump{Owner: owner, Repo: repo, OldSHA: oldSHA, NewSHA: newSHA})
+	}
+	return bumps, hasSkipped
+}
+
+// isUpstreamKustomization reports whether path is a kustomization file under
+// operator/upstream-kustomizations/ in the operator repo.
+func isUpstreamKustomization(filename string) bool {
+	return strings.HasPrefix(filename, "operator/upstream-kustomizations/") &&
+		(strings.HasSuffix(filename, "/kustomization.yaml") || strings.HasSuffix(filename, "/kustomization.yml"))
+}
+
+// extractRefChange scans a unified diff for a removed (-) and added (+)
+// ?ref=<40-char-sha> pair that share the same URL base (everything before ?ref=).
+// Pairing by URL base avoids false matches when a file contains multiple resource
+// URLs that change independently.
+//
+// Returns the matched URL base together with the old and new SHAs so callers
+// can derive owner/repo from the exact URL that changed. Returns ("","","") if
+// no matching pair is found.
+func extractRefChange(patch string) (matchedBase, oldSHA, newSHA string) {
+	lines := strings.Split(patch, "\n")
+
+	// First pass: collect removed refs keyed by URL base.
+	removed := make(map[string]string) // urlBase → sha
+	for _, line := range lines {
+		if len(line) == 0 || line[0] != '-' {
+			continue
+		}
+		m := refPattern.FindStringSubmatch(line)
+		if m == nil {
+			continue
+		}
+		if base := urlBase(line); base != "" && removed[base] == "" {
+			removed[base] = m[1]
+		}
+	}
+
+	// Second pass: find an added ref whose URL base matches a removed one.
+	for _, line := range lines {
+		if len(line) == 0 || line[0] != '+' {
+			continue
+		}
+		m := refPattern.FindStringSubmatch(line)
+		if m == nil {
+			continue
+		}
+		if base := urlBase(line); base != "" {
+			if old, ok := removed[base]; ok && old != m[1] {
+				return base, old, m[1]
+			}
+		}
+	}
+	return "", "", ""
+}
+
+// urlBase returns the portion of a diff line before the ?ref= query parameter,
+// stripping the leading +/- diff marker and surrounding whitespace.
+func urlBase(line string) string {
+	idx := strings.Index(line, "?ref=")
+	if idx < 0 {
+		return ""
+	}
+	return strings.TrimSpace(line[1:idx]) // line[0] is +/-
+}
+
+// extractGitHubRepoFromURL extracts the owner and repository name from a
+// github.com URL string (e.g. "https://github.com/konflux-ci/build-service/config").
+// Returns ("","") when the URL is not a github.com URL or does not match the
+// expected path structure.
+func extractGitHubRepoFromURL(rawURL string) (owner, repo string) {
+	if m := githubRepoPattern.FindStringSubmatch(rawURL); m != nil {
+		return m[1], m[2]
+	}
+	return "", ""
+}

--- a/infra-tools/internal/changelog/bumps_test.go
+++ b/infra-tools/internal/changelog/bumps_test.go
@@ -1,0 +1,170 @@
+package changelog_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/redhat-appstudio/infra-deployments/infra-tools/internal/changelog"
+)
+
+const (
+	buildOldSHA = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	buildNewSHA = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+)
+
+// buildServicePatch returns a realistic unified diff snippet for the build-service
+// kustomization file, showing a ref bump from oldSHA to newSHA.
+// The URL base is identical on both lines — only ?ref= changes, matching real
+// kustomization diffs.
+func buildServicePatch(oldSHA, newSHA string) string {
+	return "-  - https://github.com/konflux-ci/build-service/config/default?ref=" + oldSHA + "\n" +
+		"+  - https://github.com/konflux-ci/build-service/config/default?ref=" + newSHA + "\n"
+}
+
+func TestExtractServiceBumps_SingleBump(t *testing.T) {
+	g := NewWithT(t)
+	files := []changelog.FileChange{
+		{
+			Filename: "operator/upstream-kustomizations/build-service/kustomization.yaml",
+			Patch:    buildServicePatch(buildOldSHA, buildNewSHA),
+		},
+	}
+	bumps, skipped := changelog.ExtractServiceBumps(files)
+	g.Expect(skipped).To(BeFalse())
+	g.Expect(bumps).To(HaveLen(1))
+	g.Expect(bumps[0].Owner).To(Equal("konflux-ci"))
+	g.Expect(bumps[0].Repo).To(Equal("build-service"))
+	g.Expect(bumps[0].OldSHA).To(Equal(buildOldSHA))
+	g.Expect(bumps[0].NewSHA).To(Equal(buildNewSHA))
+}
+
+func TestExtractServiceBumps_SkipsNonUpstreamFiles(t *testing.T) {
+	g := NewWithT(t)
+	files := []changelog.FileChange{
+		{
+			Filename: "operator/config/default/kustomization.yaml",
+			Patch:    buildServicePatch(buildOldSHA, buildNewSHA),
+		},
+		{
+			Filename: "operator/upstream-kustomizations/build-service/other.yaml",
+			Patch:    buildServicePatch(buildOldSHA, buildNewSHA),
+		},
+	}
+	bumps, skipped := changelog.ExtractServiceBumps(files)
+	g.Expect(skipped).To(BeFalse())
+	g.Expect(bumps).To(BeEmpty())
+}
+
+func TestExtractServiceBumps_SkipsUnchangedRef(t *testing.T) {
+	g := NewWithT(t)
+	files := []changelog.FileChange{
+		{
+			Filename: "operator/upstream-kustomizations/build-service/kustomization.yaml",
+			Patch:    buildServicePatch(buildOldSHA, buildOldSHA), // same SHA on both sides
+		},
+	}
+	bumps, skipped := changelog.ExtractServiceBumps(files)
+	g.Expect(skipped).To(BeFalse())
+	g.Expect(bumps).To(BeEmpty())
+}
+
+func TestExtractServiceBumps_DeduplicatesSameRepo(t *testing.T) {
+	g := NewWithT(t)
+	files := []changelog.FileChange{
+		{
+			Filename: "operator/upstream-kustomizations/build-service/kustomization.yaml",
+			Patch:    buildServicePatch(buildOldSHA, buildNewSHA),
+		},
+		{
+			Filename: "operator/upstream-kustomizations/build-service/extra/kustomization.yaml",
+			Patch:    buildServicePatch(buildOldSHA, buildNewSHA),
+		},
+	}
+	bumps, skipped := changelog.ExtractServiceBumps(files)
+	g.Expect(skipped).To(BeFalse())
+	g.Expect(bumps).To(HaveLen(1))
+}
+
+func TestExtractServiceBumps_MultipleBumps(t *testing.T) {
+	g := NewWithT(t)
+	intOldSHA := "cccccccccccccccccccccccccccccccccccccccc"
+	intNewSHA := "dddddddddddddddddddddddddddddddddddddddd"
+	files := []changelog.FileChange{
+		{
+			Filename: "operator/upstream-kustomizations/build-service/kustomization.yaml",
+			Patch:    buildServicePatch(buildOldSHA, buildNewSHA),
+		},
+		{
+			Filename: "operator/upstream-kustomizations/integration-service/kustomization.yaml",
+			Patch: "-  - https://github.com/konflux-ci/integration-service/...?ref=" + intOldSHA + "\n" +
+				"+  - https://github.com/konflux-ci/integration-service/...?ref=" + intNewSHA + "\n",
+		},
+	}
+	bumps, skipped := changelog.ExtractServiceBumps(files)
+	g.Expect(skipped).To(BeFalse())
+	g.Expect(bumps).To(HaveLen(2))
+}
+
+// TestExtractServiceBumps_EmptyPatch verifies that an upstream kustomization with
+// an empty patch (GitHub omits patch for very large or renamed files) sets the
+// hasSkipped flag so callers can degrade gracefully instead of claiming "no bumps".
+func TestExtractServiceBumps_EmptyPatch(t *testing.T) {
+	g := NewWithT(t)
+	files := []changelog.FileChange{
+		{
+			Filename: "operator/upstream-kustomizations/build-service/kustomization.yaml",
+			Patch:    "",
+		},
+	}
+	bumps, skipped := changelog.ExtractServiceBumps(files)
+	g.Expect(skipped).To(BeTrue())
+	g.Expect(bumps).To(BeEmpty())
+}
+
+// TestExtractServiceBumps_NoGitHubURL verifies that a kustomization file where
+// the ?ref= SHA changes but the URL is not on github.com is skipped — the bump
+// cannot be attributed to a GitHub repository.
+func TestExtractServiceBumps_NoGitHubURL(t *testing.T) {
+	g := NewWithT(t)
+	// The resource URL is not on github.com, so we cannot build a ServiceBump.
+	patch := "-  - https://quay.io/some-org/some-image?ref=" + buildOldSHA + "\n" +
+		"+  - https://quay.io/some-org/some-image?ref=" + buildNewSHA + "\n"
+	files := []changelog.FileChange{
+		{
+			Filename: "operator/upstream-kustomizations/some-service/kustomization.yaml",
+			Patch:    patch,
+		},
+	}
+	bumps, skipped := changelog.ExtractServiceBumps(files)
+	g.Expect(skipped).To(BeFalse())
+	g.Expect(bumps).To(BeEmpty())
+}
+
+// TestExtractServiceBumps_MultipleURLsSameFile verifies that when a kustomization
+// file has two resource URLs and only one changes, the correct SHA pair is returned
+// and the owner/repo is derived from the URL that actually changed — not from any
+// other github.com URL that happens to appear on a + line.
+func TestExtractServiceBumps_MultipleURLsSameFile(t *testing.T) {
+	g := NewWithT(t)
+	// service-a's SHA did NOT change (context line, no +/- prefix).
+	// build-service's SHA DID change.
+	serviceARef := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	serviceBOld := "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	serviceBNew := "cccccccccccccccccccccccccccccccccccccccc"
+	patch := "   - https://github.com/konflux-ci/service-a/config?ref=" + serviceARef + "\n" +
+		"-  - https://github.com/konflux-ci/build-service/config?ref=" + serviceBOld + "\n" +
+		"+  - https://github.com/konflux-ci/build-service/config?ref=" + serviceBNew + "\n"
+	files := []changelog.FileChange{
+		{
+			Filename: "operator/upstream-kustomizations/build-service/kustomization.yaml",
+			Patch:    patch,
+		},
+	}
+	bumps, skipped := changelog.ExtractServiceBumps(files)
+	g.Expect(skipped).To(BeFalse())
+	g.Expect(bumps).To(HaveLen(1))
+	g.Expect(bumps[0].Repo).To(Equal("build-service"))
+	g.Expect(bumps[0].OldSHA).To(Equal(serviceBOld))
+	g.Expect(bumps[0].NewSHA).To(Equal(serviceBNew))
+}

--- a/infra-tools/internal/changelog/upstream.go
+++ b/infra-tools/internal/changelog/upstream.go
@@ -1,0 +1,129 @@
+// Package changelog provides logic for generating a human-readable changelog
+// when the Konflux operator ref is bumped in infra-deployments.
+package changelog
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+
+	gh "github.com/google/go-github/v68/github"
+)
+
+// RepoComparer is the GitHub compare API surface used to fetch file diffs
+// between two refs in a repository. Defined as an interface so tests can
+// inject a fake without making real network calls.
+type RepoComparer interface {
+	CompareCommits(ctx context.Context, owner, repo, base, head string, opts *gh.ListOptions) (*gh.CommitsComparison, *gh.Response, error)
+}
+
+// FileChange holds the fields we need from a file changed in a comparison.
+type FileChange struct {
+	Filename string
+	Patch    string // unified diff; may be empty for binary or very large files
+}
+
+// OperatorCompare holds the changed files from comparing two operator refs.
+type OperatorCompare struct {
+	Files     []FileChange
+	Truncated bool // true when the API returned the 300-file maximum, indicating possible truncation
+}
+
+// maxCompareFiles is the GitHub compare API hard limit on returned files.
+// When the response hits this limit the result may be incomplete; callers
+// should treat Truncated == true the same way they treat an API failure.
+const maxCompareFiles = 300
+
+// NewRepoComparer creates a RepoComparer backed by the real GitHub REST API.
+// Pass an empty token to use unauthenticated access (60 req/hour limit).
+// In CI, always pass the GITHUB_TOKEN.
+func NewRepoComparer(token string) RepoComparer {
+	client := gh.NewClient(nil)
+	if token != "" {
+		client = client.WithAuthToken(token)
+	}
+	return client.Repositories
+}
+
+// FetchOperatorCompare calls the GitHub compare API for konflux-ci/konflux-ci
+// between oldRef and newRef and returns the changed files. The call is retried
+// up to three times with exponential backoff to survive transient failures.
+//
+// When the API returns exactly maxCompareFiles files the result is marked
+// Truncated; callers should degrade in the same way they handle API errors.
+func FetchOperatorCompare(ctx context.Context, c RepoComparer, oldRef, newRef string) (*OperatorCompare, error) {
+	var comparison *gh.CommitsComparison
+	err := retryDo(ctx, 3, func() error {
+		var e error
+		comparison, _, e = c.CompareCommits(ctx, "konflux-ci", "konflux-ci", oldRef, newRef, nil)
+		return e
+	})
+	if err != nil {
+		return nil, fmt.Errorf("comparing %s...%s in konflux-ci/konflux-ci: %w",
+			refShort(oldRef), refShort(newRef), err)
+	}
+	files := convertFiles(comparison.Files)
+	return &OperatorCompare{
+		Files:     files,
+		Truncated: len(files) >= maxCompareFiles,
+	}, nil
+}
+
+// retryDo calls fn up to maxAttempts times. Between attempts it sleeps for
+// 2^attempt seconds (1 s, 2 s, …), honouring context cancellation.
+// Only retryable errors (network failures, 429, 5xx) are retried — permanent
+// errors like 401 or 404 fail immediately without waiting.
+func retryDo(ctx context.Context, maxAttempts int, fn func() error) error {
+	var err error
+	for attempt := 0; attempt < maxAttempts; attempt++ {
+		if err = fn(); err == nil {
+			return nil
+		}
+		if attempt == maxAttempts-1 || !isRetryable(err) {
+			break
+		}
+		wait := time.Duration(1<<attempt) * time.Second // 1 s, 2 s, …
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(wait):
+		}
+	}
+	return err
+}
+
+// isRetryable returns true for errors worth retrying: network-level errors and
+// GitHub HTTP errors with status 429 (rate limited) or 5xx (server error).
+// Permanent errors such as 401 Unauthorized or 404 Not Found are not retried.
+func isRetryable(err error) bool {
+	var ghErr *gh.ErrorResponse
+	if errors.As(err, &ghErr) {
+		code := ghErr.Response.StatusCode
+		return code == http.StatusTooManyRequests || (code >= 500 && code <= 599)
+	}
+	return true // network / timeout errors are always retryable
+}
+
+func convertFiles(raw []*gh.CommitFile) []FileChange {
+	out := make([]FileChange, 0, len(raw))
+	for _, f := range raw {
+		if f == nil {
+			continue
+		}
+		out = append(out, FileChange{
+			Filename: f.GetFilename(),
+			Patch:    f.GetPatch(),
+		})
+	}
+	return out
+}
+
+// refShort returns the first 12 characters of ref, or the full string if shorter.
+func refShort(ref string) string {
+	if len(ref) > 12 {
+		return ref[:12]
+	}
+	return ref
+}

--- a/infra-tools/internal/changelog/upstream_test.go
+++ b/infra-tools/internal/changelog/upstream_test.go
@@ -1,0 +1,143 @@
+package changelog_test
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+
+	gh "github.com/google/go-github/v68/github"
+	. "github.com/onsi/gomega"
+
+	"github.com/redhat-appstudio/infra-deployments/infra-tools/internal/changelog"
+)
+
+// fakeComparer implements RepoComparer for testing.
+// failTimes controls how many calls return err before the call succeeds.
+type fakeComparer struct {
+	files     []*gh.CommitFile
+	err       error
+	failTimes int // number of initial calls that return err before succeeding
+	calls     int // tracks total calls made
+}
+
+func (f *fakeComparer) CompareCommits(_ context.Context, _, _, _, _ string, _ *gh.ListOptions) (*gh.CommitsComparison, *gh.Response, error) {
+	f.calls++
+	if f.failTimes > 0 && f.calls <= f.failTimes {
+		return nil, nil, f.err
+	}
+	return &gh.CommitsComparison{Files: f.files}, nil, nil
+}
+
+func TestFetchOperatorCompare_ReturnsConvertedFiles(t *testing.T) {
+	g := NewWithT(t)
+	fake := &fakeComparer{
+		files: []*gh.CommitFile{
+			{
+				Filename: gh.Ptr("operator/upstream-kustomizations/build-service/kustomization.yaml"),
+				Patch:    gh.Ptr("-old\n+new"),
+			},
+			{Filename: gh.Ptr("other/file.yaml"), Patch: gh.Ptr("unchanged")},
+		},
+	}
+	result, err := changelog.FetchOperatorCompare(context.Background(), fake, "oldref", "newref")
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(result.Files).To(HaveLen(2))
+	g.Expect(result.Truncated).To(BeFalse())
+	g.Expect(result.Files[0].Filename).To(Equal("operator/upstream-kustomizations/build-service/kustomization.yaml"))
+	g.Expect(result.Files[0].Patch).To(Equal("-old\n+new"))
+}
+
+func TestFetchOperatorCompare_APIError(t *testing.T) {
+	g := NewWithT(t)
+	// Use 40-char SHAs so the error message exercises refShort's truncation path.
+	oldSHA := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	newSHA := "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	// failTimes=3 means all 3 attempts fail — the error should be returned.
+	fake := &fakeComparer{err: errors.New("rate limited"), failTimes: 3}
+	_, err := changelog.FetchOperatorCompare(context.Background(), fake, oldSHA, newSHA)
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("konflux-ci/konflux-ci"))
+	g.Expect(err.Error()).To(ContainSubstring("rate limited"))
+	// refShort truncates to 12 chars — verify the error contains the truncated SHA.
+	g.Expect(err.Error()).To(ContainSubstring("aaaaaaaaaaaa"))
+	g.Expect(fake.calls).To(Equal(3))
+}
+
+func TestFetchOperatorCompare_RetriesOnTransientError(t *testing.T) {
+	g := NewWithT(t)
+	// Fail the first attempt, succeed on the second.
+	fake := &fakeComparer{
+		err:       errors.New("transient"),
+		failTimes: 1,
+		files: []*gh.CommitFile{
+			{Filename: gh.Ptr("file.yaml"), Patch: gh.Ptr("diff")},
+		},
+	}
+	result, err := changelog.FetchOperatorCompare(context.Background(), fake, "a", "b")
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(result.Files).To(HaveLen(1))
+	g.Expect(fake.calls).To(Equal(2))
+}
+
+func TestFetchOperatorCompare_TruncatedWhenMaxFiles(t *testing.T) {
+	g := NewWithT(t)
+	// Build exactly 300 files — the API maximum.
+	files := make([]*gh.CommitFile, 300)
+	for i := range files {
+		files[i] = &gh.CommitFile{Filename: gh.Ptr("file.yaml"), Patch: gh.Ptr("diff")}
+	}
+	fake := &fakeComparer{files: files}
+	result, err := changelog.FetchOperatorCompare(context.Background(), fake, "a", "b")
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(result.Truncated).To(BeTrue())
+}
+
+func TestFetchOperatorCompare_NotTruncatedBeforeMax(t *testing.T) {
+	g := NewWithT(t)
+	files := make([]*gh.CommitFile, 299)
+	for i := range files {
+		files[i] = &gh.CommitFile{Filename: gh.Ptr("file.yaml"), Patch: gh.Ptr("diff")}
+	}
+	fake := &fakeComparer{files: files}
+	result, err := changelog.FetchOperatorCompare(context.Background(), fake, "a", "b")
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(result.Truncated).To(BeFalse())
+}
+
+func TestFetchOperatorCompare_NilFilesIgnored(t *testing.T) {
+	g := NewWithT(t)
+	fake := &fakeComparer{
+		files: []*gh.CommitFile{nil, {Filename: gh.Ptr("file.yaml"), Patch: gh.Ptr("diff")}},
+	}
+	result, err := changelog.FetchOperatorCompare(context.Background(), fake, "a", "b")
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(result.Files).To(HaveLen(1))
+}
+
+func TestFetchOperatorCompare_NonRetryableErrorFastFails(t *testing.T) {
+	g := NewWithT(t)
+	// A 404 is a permanent error — retrying won't help and burns time.
+	notFound := &gh.ErrorResponse{
+		Response: &http.Response{StatusCode: http.StatusNotFound},
+	}
+	fake := &fakeComparer{err: notFound, failTimes: 3}
+	_, err := changelog.FetchOperatorCompare(context.Background(), fake, "a", "b")
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(fake.calls).To(Equal(1)) // only one attempt — no retries for 404
+}
+
+func TestFetchOperatorCompare_ContextCancelledDuringRetry(t *testing.T) {	g := NewWithT(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	// Cancel immediately so the retry wait is interrupted.
+	cancel()
+	fake := &fakeComparer{err: errors.New("transient"), failTimes: 3}
+	_, err := changelog.FetchOperatorCompare(ctx, fake, "a", "b")
+	g.Expect(err).To(HaveOccurred())
+	// Either context error or the API error — both are acceptable.
+	isExpected := strings.Contains(err.Error(), "context") ||
+		strings.Contains(err.Error(), "transient") ||
+		strings.Contains(err.Error(), "konflux-ci")
+	g.Expect(isExpected).To(BeTrue())
+}


### PR DESCRIPTION
- Calls the GitHub compare API on `konflux-ci/konflux-ci` between the old and new operator refs
- Scans changed files under `operator/upstream-kustomizations/` for `?ref=` SHA changes
- Lists each bumped service with old→new SHA and a compare link in the PR comment
In case of API failure the operator compare link is still posted but the service bumps section notes detection was unavailable.