### PR TITLE
refactor(KONFLUX-13283): use task-runner for claim cleaner in stage

### DIFF
--- a/components/crossplane-control-plane/development/kustomization.yaml
+++ b/components/crossplane-control-plane/development/kustomization.yaml
@@ -6,3 +6,9 @@ resources:
 
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+
+images:
+  - name: quay.io/konflux-ci/appstudio-utils
+    newName: quay.io/konflux-ci/task-runner
+    newTag: v1
+    digest: sha256:b9ef0479b57a494368a12a02886c650314c9ac7391c6228f21065865aab71c9e

--- a/components/crossplane-control-plane/staging/kustomization.yaml
+++ b/components/crossplane-control-plane/staging/kustomization.yaml
@@ -8,6 +8,12 @@ resources:
 - https://github.com/konflux-ci/crossplane-control-plane/crossplane?ref=436006583e5203a6de0850569e76483aafbf6ea6
 - https://github.com/konflux-ci/crossplane-control-plane/config?ref=436006583e5203a6de0850569e76483aafbf6ea6
 
+images:
+  - name: quay.io/konflux-ci/appstudio-utils
+    newName: quay.io/konflux-ci/task-runner
+    newTag: v1
+    digest: sha256:b9ef0479b57a494368a12a02886c650314c9ac7391c6228f21065865aab71c9e
+
 patches:
   - patch: |-
       - op: add


### PR DESCRIPTION
Swap appstudio-utils for task-runner:v1 (digest-pinned) via kustomize images in development/ and staging/ kustomization.yaml only. base/ and production/ are unchanged so production keeps appstudio-utils until a follow-up PR.

Next steps (not to break enforce-ring-deployment):

PR 2: same images block in production/kustomization.yaml.
PR 3: set base/cronjob.yaml to task-runner with digest pinned (kustomizations will be noops).
PR 4: set dev and stage kustomizations to use
`name: quay.io/konflux-ci/task-runner`.
PR 5: apply the same to production + remove digest from base.

Assisted-by: Cursor