### PR TITLE
feat: split IS into per-environment overlays

### DIFF
--- a/argo-cd-apps/base/member/infra-deployments/internal-services/internal-services.yaml
+++ b/argo-cd-apps/base/member/infra-deployments/internal-services/internal-services.yaml
@@ -1,17 +1,28 @@
+---
 apiVersion: argoproj.io/v1alpha1
 kind: ApplicationSet
 metadata:
   name: internal-services
 spec:
   generators:
-    - clusters: {}
+    - merge:
+        mergeKeys:
+          - nameNormalized
+        generators:
+          - clusters:
+              values:
+                sourceRoot: components/internal-services
+                environment: staging
+                clusterDir: ""
+          - list:
+              elements: []
   template:
     metadata:
       name: internal-services-{{nameNormalized}}
     spec:
       project: default
       source:
-        path: components/internal-services
+        path: '{{values.sourceRoot}}/{{values.environment}}/{{values.clusterDir}}'
         repoURL: https://github.com/redhat-appstudio/infra-deployments.git
         targetRevision: main
       destination:

--- a/argo-cd-apps/base/member/infra-deployments/internal-services/kustomization.yaml
+++ b/argo-cd-apps/base/member/infra-deployments/internal-services/kustomization.yaml
@@ -1,6 +1,7 @@
+---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - internal-services.yaml
 components:
-  - ../../../../k-components/deploy-to-member-cluster
+  - ../../../../k-components/deploy-to-member-cluster-merge-generator

--- a/argo-cd-apps/overlays/development/kustomization.yaml
+++ b/argo-cd-apps/overlays/development/kustomization.yaml
@@ -226,6 +226,11 @@ patches:
       kind: ApplicationSet
       version: v1alpha1
       name: application-api
+  - path: development-overlay-patch.yaml
+    target:
+      kind: ApplicationSet
+      version: v1alpha1
+      name: internal-services
   # ensure installation order of ApplicationSets during all-application-sets sync
   - path: dev-application-sync-wave-kyverno.yaml
     target:

--- a/argo-cd-apps/overlays/konflux-public-production/kustomization.yaml
+++ b/argo-cd-apps/overlays/konflux-public-production/kustomization.yaml
@@ -291,3 +291,8 @@ patches:
       kind: ApplicationSet
       version: v1alpha1
       name: application-api
+  - path: production-overlay-patch.yaml
+    target:
+      kind: ApplicationSet
+      version: v1alpha1
+      name: internal-services

--- a/argo-cd-apps/overlays/production-downstream/kustomization.yaml
+++ b/argo-cd-apps/overlays/production-downstream/kustomization.yaml
@@ -305,3 +305,8 @@ patches:
       kind: ApplicationSet
       version: v1alpha1
       name: application-api
+  - path: production-overlay-patch.yaml
+    target:
+      kind: ApplicationSet
+      version: v1alpha1
+      name: internal-services

--- a/components/internal-services/OWNERS
+++ b/components/internal-services/OWNERS
@@ -7,7 +7,6 @@ approvers:
 - mmalina
 - happybhati
 - seanconroy2021
-- jinqi7
 - filipnikolovski
 - elenagerman
 - midnightercz
@@ -21,7 +20,6 @@ reviewers:
 - mmalina
 - happybhati
 - seanconroy2021
-- jinqi7
 - filipnikolovski
 - elenagerman
 - midnightercz

--- a/components/internal-services/base/internal-services.yaml
+++ b/components/internal-services/base/internal-services.yaml
@@ -1,3 +1,4 @@
+---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/components/internal-services/base/internal_service_request_role.yaml
+++ b/components/internal-services/base/internal_service_request_role.yaml
@@ -1,3 +1,4 @@
+---
 # permissions for end users to view applications.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/components/internal-services/base/internal_service_request_role_binding.yaml
+++ b/components/internal-services/base/internal_service_request_role_binding.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/components/internal-services/base/internal_service_request_service_account.yaml
+++ b/components/internal-services/base/internal_service_request_service_account.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/components/internal-services/base/internal_service_service_account_token.yaml
+++ b/components/internal-services/base/internal_service_service_account_token.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: Secret
 metadata:

--- a/components/internal-services/base/kustomization.yaml
+++ b/components/internal-services/base/kustomization.yaml
@@ -1,12 +1,11 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 resources:
 - internal_service_request_role.yaml
 - internal_service_request_role_binding.yaml
 - internal_service_request_service_account.yaml
 - internal_service_service_account_token.yaml
 - internal-services.yaml
-- https://github.com/konflux-ci/internal-services/config/crd?ref=bbba2e6340a3c014adf32c770db98e9237543da6
-
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
 
 namespace: internal-services

--- a/components/internal-services/development/kustomization.yaml
+++ b/components/internal-services/development/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../base
+  - https://github.com/konflux-ci/internal-services/config/crd?ref=bbba2e6340a3c014adf32c770db98e9237543da6

--- a/components/internal-services/production/base/internal-services.yaml
+++ b/components/internal-services/production/base/internal-services.yaml
@@ -1,0 +1,27 @@
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: internal-services
+  namespace: internal-services
+subjects:
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: konflux-release-team
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: component-maintainer
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: internal-services
+subjects:
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: konflux-release-team
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: internal-service-request-role

--- a/components/internal-services/production/base/internal_service_request_role.yaml
+++ b/components/internal-services/production/base/internal_service_request_role.yaml
@@ -1,0 +1,33 @@
+---
+# permissions for end users to view applications.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: internal-service-request-role
+rules:
+  - apiGroups:
+      - appstudio.redhat.com
+    resources:
+      - internalrequests
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - appstudio.redhat.com
+    resources:
+      - internalrequests/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - appstudio.redhat.com
+    resources:
+      - internalrequests/status
+    verbs:
+      - get
+      - patch
+      - update

--- a/components/internal-services/production/base/internal_service_request_role_binding.yaml
+++ b/components/internal-services/production/base/internal_service_request_role_binding.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: internal-service-request-role-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: internal-service-request-role
+subjects:
+  - kind: ServiceAccount
+    name: internal-service-request-service-account
+    namespace: internal-services

--- a/components/internal-services/production/base/internal_service_request_service_account.yaml
+++ b/components/internal-services/production/base/internal_service_request_service_account.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: internal-service-request-service-account
+  namespace: internal-services

--- a/components/internal-services/production/base/internal_service_service_account_token.yaml
+++ b/components/internal-services/production/base/internal_service_service_account_token.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: internal-service-request-service-account-secret
+  annotations:
+    kubernetes.io/service-account.name: internal-service-request-service-account
+  namespace: internal-services
+type: kubernetes.io/service-account-token

--- a/components/internal-services/production/base/kustomization.yaml
+++ b/components/internal-services/production/base/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- internal_service_request_role.yaml
+- internal_service_request_role_binding.yaml
+- internal_service_request_service_account.yaml
+- internal_service_service_account_token.yaml
+- internal-services.yaml
+
+namespace: internal-services

--- a/components/internal-services/production/kustomization.yaml
+++ b/components/internal-services/production/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../base
+  - https://github.com/konflux-ci/internal-services/config/crd?ref=bbba2e6340a3c014adf32c770db98e9237543da6

--- a/components/internal-services/staging/kustomization.yaml
+++ b/components/internal-services/staging/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../base
+  - https://github.com/konflux-ci/internal-services/config/crd?ref=bbba2e6340a3c014adf32c770db98e9237543da6


### PR DESCRIPTION
IS had one kustomization.yaml for all environments so the CRD ref was always updated everywhere at once. This PR split the deployment into 3 env.

Assisted-by: Cursor