### PR TITLE
refactor(KONFLUX-13283): use task-runner for claim cleaner in prod

### DIFF
--- a/components/crossplane-control-plane/production/kustomization.yaml
+++ b/components/crossplane-control-plane/production/kustomization.yaml
@@ -8,6 +8,12 @@ resources:
 - https://github.com/konflux-ci/crossplane-control-plane/crossplane?ref=bd3da0eff408eb329bfb5d7306b2aa3016d1a906
 - https://github.com/konflux-ci/crossplane-control-plane/config?ref=bd3da0eff408eb329bfb5d7306b2aa3016d1a906
 
+images:
+  - name: quay.io/konflux-ci/appstudio-utils
+    newName: quay.io/konflux-ci/task-runner
+    newTag: v1
+    digest: sha256:b9ef0479b57a494368a12a02886c650314c9ac7391c6228f21065865aab71c9e
+
 patches:
   - patch: |-
       apiVersion: apps/v1


### PR DESCRIPTION
Swap appstudio-utils for task-runner:v1 (digest-pinned) via kustomize images in production/ kustomization.yaml.

This is following the same pattern as in dev and stage.

Next steps (not to break enforce-ring-deployment):

PR 3: set base/cronjob.yaml to task-runner with digest pinned (kustomizations will be noops).
PR 4: set dev and stage kustomizations to use
name: quay.io/konflux-ci/task-runner.
PR 5: apply the same to production + remove digest from base.

Assisted-by: Cursor

The change was verified in staging after [this PR](https://github.com/redhat-appstudio/infra-deployments/pull/12312) was merged.

I verified that the cronjob is running with the new image and providing the expected results for when claims are to be deleted and when they are not. I create [this PR](https://github.com/yftacherzog/testrepo-staging/pull/54) which triggered the creation of an orphan claim (so it will not be garbage collected) and watched the cronjob being triggered every hour and the claim deleted after the 4th hour.

Risk assessment: **low**. No logic changes. The image is pulled and behaving correctly in staging. the cronjob is a backup mechanism for deleting claims, so suppose that something is not working, we'll have some time to evaluate and fix it before this becomes an issue (no apparent reason it should behave differently than in stage).