### PR TITLE
Promote oauth2-proxy to production

### DIFF
--- a/components/konflux-ui/production/base/kustomization.yaml
+++ b/components/konflux-ui/production/base/kustomization.yaml
@@ -14,6 +14,7 @@ images:
     newTag: b89e3f953b6da5196e23c5f9db17e73c10629ff7
 
   - name: quay.io/oauth2-proxy/oauth2-proxy
-    digest: sha256:3da33b9670c67bd782277f99acadf7026f75b9507bfba2088eb2d497266ef7fc
+    newName: quay.io/konflux-ci/oauth2-proxy
+    newTag: 87a8794d4bb98472fab47f14bb28e4d9ec24d7426107028bd1aa780e260ff8e3
 
 namespace: konflux-ui


### PR DESCRIPTION
Currently, we build the upstream image of oauth2-proxy hermetically on Konflux and this version has been deployed and verified in staging for the last 3 months.

## Risk Assessment
**Risk Level:** Low
**Description:** Image has been running successfully on staging for 3 months
**Rollback:** Revert PR and redeploy previous image tag

## Validation
Tested on staging — no regressions observed.
Staging PR: https://github.com/redhat-appstudio/infra-deployments/pull/10510

Contributes to: [KFLUXINFRA-3990](https://redhat.atlassian.net/browse/KFLUXINFRA-3990)


[KFLUXINFRA-3990]: https://redhat.atlassian.net/browse/KFLUXINFRA-3990?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ