### PR TITLE
Dev+staging Patch pipelines resolver container image for KONFLUX-14376

### DIFF
--- a/components/pipeline-service/development/main-pipeline-service-configuration.yaml
+++ b/components/pipeline-service/development/main-pipeline-service-configuration.yaml
@@ -2275,6 +2275,11 @@ spec:
         value: "quay.io/openshift-pipeline/pipelines-pipelines-as-code-watcher-rhel9@sha256:d100578068feb5482e2631b4fadc80b9687f129c7e303b55431ac41ce58f7758"
       - name: IMAGE_PAC_PAC_CLI
         value: "quay.io/openshift-pipeline/pipelines-pipelines-as-code-cli-rhel9@sha256:0fc0dd05236f14265e25cc770a7f9f3aeea2e27964a730dac39cf9f61d349bde"
+      # TODO: Remove this once Pipelines 1.13.x is deployed
+      # NOTE: IMAGE_PIPELINES_CONTROLLER is the image used specifically by the resolvers,
+      # the controller uses IMAGE_PIPELINES_TEKTON_PIPELINES_CONTROLLER
+      - name: IMAGE_PIPELINES_CONTROLLER
+        value: "quay.io/openshift-pipeline/pipelines-resolvers-rhel9@sha256:7cd91bc4c0f3469ec4c39d08d818b00c90ce07456364910e49ad5e1430f3110a"
 ---
 apiVersion: route.openshift.io/v1
 kind: Route

--- a/components/pipeline-service/staging/base/main-pipeline-service-configuration.yaml
+++ b/components/pipeline-service/staging/base/main-pipeline-service-configuration.yaml
@@ -2105,6 +2105,12 @@ spec:
         value: "quay.io/openshift-pipeline/pipelines-pipelines-as-code-watcher-rhel9@sha256:d100578068feb5482e2631b4fadc80b9687f129c7e303b55431ac41ce58f7758"
       - name: IMAGE_PAC_PAC_CLI
         value: "quay.io/openshift-pipeline/pipelines-pipelines-as-code-cli-rhel9@sha256:0fc0dd05236f14265e25cc770a7f9f3aeea2e27964a730dac39cf9f61d349bde"
+      # TODO: Remove this once Pipelines 1.13.x is deployed
+      # NOTE: IMAGE_PIPELINES_CONTROLLER is the image used specifically by the resolvers,
+      # the pipelines-controller uses IMAGE_PIPELINES_TEKTON_PIPELINES_CONTROLLER
+      - name: IMAGE_PIPELINES_CONTROLLER
+        value: "quay.io/openshift-pipeline/pipelines-resolvers-rhel9@sha256:7cd91bc4c0f3469ec4c39d08d818b00c90ce07456364910e49ad5e1430f3110a"
+
 ---
 apiVersion: route.openshift.io/v1
 kind: Route

--- a/components/pipeline-service/staging/stone-stage-p01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stage-p01/deploy.yaml
@@ -2677,6 +2677,8 @@ spec:
       value: quay.io/openshift-pipeline/pipelines-pipelines-as-code-watcher-rhel9@sha256:d100578068feb5482e2631b4fadc80b9687f129c7e303b55431ac41ce58f7758
     - name: IMAGE_PAC_PAC_CLI
       value: quay.io/openshift-pipeline/pipelines-pipelines-as-code-cli-rhel9@sha256:0fc0dd05236f14265e25cc770a7f9f3aeea2e27964a730dac39cf9f61d349bde
+    - name: IMAGE_PIPELINES_CONTROLLER
+      value: quay.io/openshift-pipeline/pipelines-resolvers-rhel9@sha256:7cd91bc4c0f3469ec4c39d08d818b00c90ce07456364910e49ad5e1430f3110a
   name: openshift-pipelines-operator-rh
   source: custom-operators
   sourceNamespace: openshift-marketplace

--- a/components/pipeline-service/staging/stone-stg-rh01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stg-rh01/deploy.yaml
@@ -2689,6 +2689,8 @@ spec:
       value: quay.io/openshift-pipeline/pipelines-pipelines-as-code-watcher-rhel9@sha256:d100578068feb5482e2631b4fadc80b9687f129c7e303b55431ac41ce58f7758
     - name: IMAGE_PAC_PAC_CLI
       value: quay.io/openshift-pipeline/pipelines-pipelines-as-code-cli-rhel9@sha256:0fc0dd05236f14265e25cc770a7f9f3aeea2e27964a730dac39cf9f61d349bde
+    - name: IMAGE_PIPELINES_CONTROLLER
+      value: quay.io/openshift-pipeline/pipelines-resolvers-rhel9@sha256:7cd91bc4c0f3469ec4c39d08d818b00c90ce07456364910e49ad5e1430f3110a
   name: openshift-pipelines-operator-rh
   source: custom-operators
   sourceNamespace: openshift-marketplace


### PR DESCRIPTION
Override the Resolvers image to include this change: https://github.com/tektoncd/pipeline/commit/829429b251abc0dd2dd055b893300f505780b70b

<details>
<summary>Full list of commits between images</summary>

```
commit 829429b251abc0dd2dd055b893300f505780b70b
Author: Andrew Thorp <athorp@redhat.com>
Date:   Wed Jun 10 11:52:24 2026 -0400

    fix(resolvers): Allow ResolutionRequests to resolve all Tekton kinds
    
    Tekton controllers only create ResolutionRequests for Pipelines, Tasks,
    and StepActions, however other cluster services only use Tekton
    Resolvers to fetch things like PipelineRun definitions. This is arguably
    a reasonable use-case and previously-supported (though undocumented)
    behaviour.
    
    The security model of the original commit was to ensure irrelevant
    objects or sensitive data (such as source code, Secrets on disk, or
    binaries) would not be written into the ResolutionRequest's status.data
    field. This change preserves that security model while allowing the
    resolvers to remain somewhat flexible for synergistic use-cases.
    
    See also: 0c1a6dea9bf5ba6533fa6ddc45f9e5d1cefc1d1f
    
    (cherry picked from commit 7a6c28c678839f22d273b84d829a7eab9c848b59)

commit 2046a4c4c6cff75a9940c97055328deaa0fb08f7
Author: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
Date:   Tue Jun 9 20:04:13 2026 +0000

    build(deps): bump the all group in /tekton with 4 updates
    
    Bumps the all group in /tekton with 4 updates: [chainguard/crane](https://github.com/chainguard-images/images), [chainguard/go](https://github.com/chainguard-images/images), [tektoncd/plumbing/ko](https://github.com/tektoncd/plumbing) and [tektoncd/plumbing/koparse](https://github.com/tektoncd/plumbing).
    
    
    Updates `chainguard/crane` from `7469bb7` to `0cb513f`
    - [Commits](https://github.com/chainguard-images/images/commits)
    
    Updates `chainguard/go` from `df345ed` to `3cb640a`
    - [Commits](https://github.com/chainguard-images/images/commits)
    
    Updates `tektoncd/plumbing/ko` from `cee71b8` to `0e959bc`
    - [Commits](https://github.com/tektoncd/plumbing/commits)
    
    Updates `tektoncd/plumbing/koparse` from `3edbb5e` to `dcb3257`
    - [Commits](https://github.com/tektoncd/plumbing/commits)
    
    ---
    updated-dependencies:
    - dependency-name: chainguard/crane
      dependency-version: latest-dev
      dependency-type: direct:production
      dependency-group: all
    - dependency-name: chainguard/go
      dependency-version: latest-dev
      dependency-type: direct:production
      dependency-group: all
    - dependency-name: tektoncd/plumbing/ko
      dependency-version: 0e959bc6297d4779093ca6fa264b45756e03faaaf4ba311d35de10e78baddccd
      dependency-type: direct:production
      dependency-group: all
    - dependency-name: tektoncd/plumbing/koparse
      dependency-version: dcb3257a663a079de5b61426c0b18a2aae24002cc044fec63da10d39f965d469
      dependency-type: direct:production
      dependency-group: all
    ...
    
    Signed-off-by: dependabot[bot] <support@github.com>

commit b8f43bacc98d1df12ae9a46448ccbe5b0c20d7e6
Author: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
Date:   Tue Jun 9 20:03:48 2026 +0000

    build(deps): bump chainguard-dev/actions from 1.6.21 to 1.6.22
    
    Bumps [chainguard-dev/actions](https://github.com/chainguard-dev/actions) from 1.6.21 to 1.6.22.
    - [Release notes](https://github.com/chainguard-dev/actions/releases)
    - [Commits](https://github.com/chainguard-dev/actions/compare/05fbd381f7c158bd33c9bbf3a28f67852269fdf8...3b7bbeebc3a5d2bc37aa008350202651c32a26e1)
    
    ---
    updated-dependencies:
    - dependency-name: chainguard-dev/actions
      dependency-version: 1.6.22
      dependency-type: direct:production
      update-type: version-update:semver-patch
    ...
    
    Signed-off-by: dependabot[bot] <support@github.com>

commit 64ec216727460e1c54b4ead4a74a6ba0b37a2cbb
Author: Vincent Demeester <vdemeest@redhat.com>
Date:   Mon Jun 8 10:38:44 2026 +0200

    fix: add automated draft release support to release pipeline
    
    - Add draft release tasks (wait-for-chains, prepare-draft-release,
      create-draft-release) with proper subpath params instead of symlinks
    - Fetch full Rekor UUID from API instead of just logIndex number
    
    Cherry-pick of #10203, #9420 adapted for release-v1.12.x.
    
    Co-Authored-By: Claude <noreply@anthropic.com>
    Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

commit aedbed09f540dc56fe689fac95ab5e374cf193c0
Author: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
Date:   Wed Jun 3 03:19:05 2026 +0000

    build(deps): bump github.com/sigstore/sigstore from 1.10.6 to 1.10.8
    
    Bumps [github.com/sigstore/sigstore](https://github.com/sigstore/sigstore) from 1.10.6 to 1.10.8.
    - [Release notes](https://github.com/sigstore/sigstore/releases)
    - [Commits](https://github.com/sigstore/sigstore/compare/v1.10.6...v1.10.8)
    
    ---
    updated-dependencies:
    - dependency-name: github.com/sigstore/sigstore
      dependency-version: 1.10.8
      dependency-type: direct:production
      update-type: version-update:semver-patch
    ...
    
    Signed-off-by: dependabot[bot] <support@github.com>

commit 13e58210145bea6d80bee8ac906ef5aecf962f56
Author: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
Date:   Fri Jun 5 08:30:43 2026 +0000

    build(deps): bump chainguard-dev/actions from 1.6.19 to 1.6.21
    
    Bumps [chainguard-dev/actions](https://github.com/chainguard-dev/actions) from 1.6.19 to 1.6.21.
    - [Release notes](https://github.com/chainguard-dev/actions/releases)
    - [Commits](https://github.com/chainguard-dev/actions/compare/c69a264ec2a5934c3186c618f368fc1c86f16cff...05fbd381f7c158bd33c9bbf3a28f67852269fdf8)
    
    ---
    updated-dependencies:
    - dependency-name: chainguard-dev/actions
      dependency-version: 1.6.21
      dependency-type: direct:production
      update-type: version-update:semver-patch
    ...
    
    Signed-off-by: dependabot[bot] <support@github.com>

commit 1e0b0e7f65029088285634bf03b030ec46b4dfe0
Author: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
Date:   Thu Jun 4 18:34:31 2026 +0000

    build(deps): bump the all group in /tekton with 4 updates
    
    Bumps the all group in /tekton with 4 updates: [chainguard/crane](https://github.com/chainguard-images/images), [chainguard/go](https://github.com/chainguard-images/images), [tektoncd/plumbing/ko](https://github.com/tektoncd/plumbing) and [tektoncd/plumbing/koparse](https://github.com/tektoncd/plumbing).
    
    
    Updates `chainguard/crane` from `c265d96` to `7469bb7`
    - [Commits](https://github.com/chainguard-images/images/commits)
    
    Updates `chainguard/go` from `5b88981` to `df345ed`
    - [Commits](https://github.com/chainguard-images/images/commits)
    
    Updates `tektoncd/plumbing/ko` from `05f1fd6` to `cee71b8`
    - [Commits](https://github.com/tektoncd/plumbing/commits)
    
    Updates `tektoncd/plumbing/koparse` from `f383e55` to `3edbb5e`
    - [Commits](https://github.com/tektoncd/plumbing/commits)
    
    ---
    updated-dependencies:
    - dependency-name: chainguard/crane
      dependency-version: latest-dev
      dependency-type: direct:production
      dependency-group: all
    - dependency-name: chainguard/go
      dependency-version: latest-dev
      dependency-type: direct:production
      dependency-group: all
    - dependency-name: tektoncd/plumbing/ko
      dependency-version: cee71b88f5ab890171b55603c1b20390bd508f733ce9fb10ed421d272f6976f7
      dependency-type: direct:production
      dependency-group: all
    - dependency-name: tektoncd/plumbing/koparse
      dependency-version: 3edbb5e1bf53821be5fe3482e5ddbbbec1ef9fdcc177ac9895bb90209282f5af
      dependency-type: direct:production
      dependency-group: all
    ...
    
    Signed-off-by: dependabot[bot] <support@github.com>

commit 25e1258cc7f02ff2a4a13df135097dc710aff53b
Author: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
Date:   Thu Jun 4 18:42:11 2026 +0000

    build(deps): bump actions/checkout from 6.0.2 to 6.0.3
    
    Bumps [actions/checkout](https://github.com/actions/checkout) from 6.0.2 to 6.0.3.
    - [Release notes](https://github.com/actions/checkout/releases)
    - [Changelog](https://github.com/actions/checkout/blob/main/CHANGELOG.md)
    - [Commits](https://github.com/actions/checkout/compare/de0fac2e4500dabe0009e67214ff5f5447ce83dd...df4cb1c069e1874edd31b4311f1884172cec0e10)
    
    ---
    updated-dependencies:
    - dependency-name: actions/checkout
      dependency-version: 6.0.3
      dependency-type: direct:production
      update-type: version-update:semver-patch
    ...
    
    Signed-off-by: dependabot[bot] <support@github.com>

commit 7121dd9a9fdcd626b4318163c43ffd33821b95c2
Author: Vincent Demeester <vdemeest@redhat.com>
Date:   Wed Jun 3 09:48:22 2026 +0200

    fix: TaskRun stuck in Running when init container is OOMKilled with enableKubernetesSidecar
    
    When enableKubernetesSidecar is true, areInitContainersCompleted() is
    used to gate the completion check. However, it only accepted PodRunning
    or PodSucceeded phases, returning false for PodFailed. This caused the
    overall 'complete' flag to be false even though the pod had clearly
    failed (e.g. init container OOMKilled), leaving the TaskRun stuck in
    Running until the pipeline timeout.
    
    Rename areInitContainersCompleted to areInitContainersDone and add an
    early return for PodFailed: when the pod has failed, nothing else will
    run, so there is nothing left to wait for.
    
    Fixes #10170

commit a7e231d3d03e5b1afd0cbc9e00e71eb843b8b39b
Author: Vincent Demeester <vdemeest@redhat.com>
Date:   Fri May 29 16:31:32 2026 +0200

    fix: prevent controller CPU variant from leaking into platform commands
    
    When the controller runs on ARM (e.g., arm64/v8) and resolves the
    entrypoint for a single-platform image of a different architecture,
    imageInfo() was calling platforms.NewPlatform() which picks up the
    controller's CPU variant, then only overriding OS and Architecture
    from the image config. This caused the variant to leak into the
    TEKTON_PLATFORM_COMMANDS map key (e.g., 'linux/amd64/v8'), which
    the entrypoint on an amd64 node couldn't match against 'linux/amd64'.
    
    Fix by constructing the Platform directly from the image's config
    metadata without including the controller's runtime variant.
    
    Fixes #10073

commit 803d921af40e2cb1b1539a5f102ca3e97b20de11
Author: ab-ghosh <abghosh@redhat.com>
Date:   Fri Mar 20 01:09:19 2026 +0530

    Fix PipelineRun premature failure when TaskRun recovers after pod eviction
    
    Signed-off-by: ab-ghosh <abghosh@redhat.com>

commit aefd05809c7662c0d49912775a49bd6635156103
Author: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
Date:   Mon Jun 1 11:01:55 2026 +0000

    build(deps): bump github.com/sigstore/sigstore/pkg/signature/kms/azure
    
    Bumps [github.com/sigstore/sigstore/pkg/signature/kms/azure](https://github.com/sigstore/sigstore) from 1.10.6 to 1.10.8.
    - [Release notes](https://github.com/sigstore/sigstore/releases)
    - [Commits](https://github.com/sigstore/sigstore/compare/v1.10.6...v1.10.8)
    
    ---
    updated-dependencies:
    - dependency-name: github.com/sigstore/sigstore/pkg/signature/kms/azure
      dependency-version: 1.10.8
      dependency-type: direct:production
      update-type: version-update:semver-patch
    ...
    
    Signed-off-by: dependabot[bot] <support@github.com>

commit eec64125128639066dcca2866cdab37c87b52c84
Author: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
Date:   Mon Jun 1 07:18:44 2026 +0000

    build(deps): bump github.com/spiffe/spire-api-sdk from 1.14.6 to 1.14.7
    
    Bumps [github.com/spiffe/spire-api-sdk](https://github.com/spiffe/spire-api-sdk) from 1.14.6 to 1.14.7.
    - [Commits](https://github.com/spiffe/spire-api-sdk/compare/v1.14.6...v1.14.7)
    
    ---
    updated-dependencies:
    - dependency-name: github.com/spiffe/spire-api-sdk
      dependency-version: 1.14.7
      dependency-type: direct:production
      update-type: version-update:semver-patch
    ...
    
    Signed-off-by: dependabot[bot] <support@github.com>

commit ca0ab0fad4002d94994cef7f4ed5651513894a0d
Author: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
Date:   Mon Jun 1 07:18:53 2026 +0000

    build(deps): bump github.com/sigstore/sigstore/pkg/signature/kms/gcp
    
    Bumps [github.com/sigstore/sigstore/pkg/signature/kms/gcp](https://github.com/sigstore/sigstore) from 1.10.6 to 1.10.8.
    - [Release notes](https://github.com/sigstore/sigstore/releases)
    - [Commits](https://github.com/sigstore/sigstore/compare/v1.10.6...v1.10.8)
    
    ---
    updated-dependencies:
    - dependency-name: github.com/sigstore/sigstore/pkg/signature/kms/gcp
      dependency-version: 1.10.8
      dependency-type: direct:production
      update-type: version-update:semver-patch
    ...
    
    Signed-off-by: dependabot[bot] <support@github.com>

commit c79a835aff94e2ab39abf37ac82467554120f45e
Author: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
Date:   Fri May 29 21:42:47 2026 +0000

    build(deps): bump github.com/sigstore/sigstore/pkg/signature/kms/aws
    
    Bumps [github.com/sigstore/sigstore/pkg/signature/kms/aws](https://github.com/sigstore/sigstore) from 1.10.6 to 1.10.8.
    - [Release notes](https://github.com/sigstore/sigstore/releases)
    - [Commits](https://github.com/sigstore/sigstore/compare/v1.10.6...v1.10.8)
    
    ---
    updated-dependencies:
    - dependency-name: github.com/sigstore/sigstore/pkg/signature/kms/aws
      dependency-version: 1.10.8
      dependency-type: direct:production
      update-type: version-update:semver-patch
    ...
    
    Signed-off-by: dependabot[bot] <support@github.com>

commit a9b0ad62599429861e7421bda76f38424d240034
Author: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
Date:   Fri May 29 21:43:11 2026 +0000

    build(deps): bump github.com/sigstore/sigstore/pkg/signature/kms/hashivault
    
    Bumps [github.com/sigstore/sigstore/pkg/signature/kms/hashivault](https://github.com/sigstore/sigstore) from 1.10.6 to 1.10.8.
    - [Release notes](https://github.com/sigstore/sigstore/releases)
    - [Commits](https://github.com/sigstore/sigstore/compare/v1.10.6...v1.10.8)
    
    ---
    updated-dependencies:
    - dependency-name: github.com/sigstore/sigstore/pkg/signature/kms/hashivault
      dependency-version: 1.10.8
      dependency-type: direct:production
      update-type: version-update:semver-patch
    ...
    
    Signed-off-by: dependabot[bot] <support@github.com>

commit 9c0a33a8ab7b2ccb358fc8073716ab1e7da09e98
Author: Vincent Demeester <vdemeest@redhat.com>
Date:   Thu Apr 9 10:51:08 2026 +0200

    fix: truncate affinity assistant volume names to 63 characters
    
    - Prevent StatefulSet pod creation failure when volumeClaimTemplate
      names exceed Kubernetes' 63-char volume name limit
    - Add sanitizeVolumeName helper that truncates with a hash suffix
      to preserve uniqueness, matching the existing pattern used for
      StatefulSet names
    
    Fixes #9739
    
    Signed-off-by: Vincent Demeester <vdemeest@redhat.com>

commit 808dd47b8b7ce0b64cbf9f38799c27ce6f52f2d4
Author: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
Date:   Thu May 28 20:31:17 2026 +0000

    build(deps): bump golangci/golangci-lint-action from 9.2.0 to 9.2.1
    
    Bumps [golangci/golangci-lint-action](https://github.com/golangci/golangci-lint-action) from 9.2.0 to 9.2.1.
    - [Release notes](https://github.com/golangci/golangci-lint-action/releases)
    - [Commits](https://github.com/golangci/golangci-lint-action/compare/1e7e51e771db61008b38414a730f564565cf7c20...82606bf257cbaff209d206a39f5134f0cfbfd2ee)
    
    ---
    updated-dependencies:
    - dependency-name: golangci/golangci-lint-action
      dependency-version: 9.2.1
      dependency-type: direct:production
      update-type: version-update:semver-patch
    ...
    
    Signed-off-by: dependabot[bot] <support@github.com>

commit e327252addfb70dacfb0072a69e762faec12b94d
Author: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
Date:   Thu May 28 20:40:03 2026 +0000

    build(deps): bump the all group in /tekton with 4 updates
    
    Bumps the all group in /tekton with 4 updates: [chainguard/crane](https://github.com/chainguard-images/images), [chainguard/go](https://github.com/chainguard-images/images), [tektoncd/plumbing/ko](https://github.com/tektoncd/plumbing) and [tektoncd/plumbing/koparse](https://github.com/tektoncd/plumbing).
    
    
    Updates `chainguard/crane` from `47d17b6` to `c265d96`
    - [Commits](https://github.com/chainguard-images/images/commits)
    
    Updates `chainguard/go` from `28e361b` to `5b88981`
    - [Commits](https://github.com/chainguard-images/images/commits)
    
    Updates `tektoncd/plumbing/ko` from `7bf898b` to `05f1fd6`
    - [Commits](https://github.com/tektoncd/plumbing/commits)
    
    Updates `tektoncd/plumbing/koparse` from `b03f7c8` to `f383e55`
    - [Commits](https://github.com/tektoncd/plumbing/commits)
    
    ---
    updated-dependencies:
    - dependency-name: chainguard/crane
      dependency-version: latest-dev
      dependency-type: direct:production
      dependency-group: all
    - dependency-name: chainguard/go
      dependency-version: latest-dev
      dependency-type: direct:production
      dependency-group: all
    - dependency-name: tektoncd/plumbing/ko
      dependency-version: 05f1fd6e4f3a20bf47132671323fd8a82b210ee95314cd6585c19e3dd4a005b3
      dependency-type: direct:production
      dependency-group: all
    - dependency-name: tektoncd/plumbing/koparse
      dependency-version: f383e5581b6c912ba7bb5a057d718637cec735ed3deb1fa216596ca86403fcd8
      dependency-type: direct:production
      dependency-group: all
    ...
    
    Signed-off-by: dependabot[bot] <support@github.com>

commit f3548d27dd11c30f8fa1434602b0ad4824cad21b
Author: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
Date:   Wed May 27 06:38:54 2026 +0000

    build(deps): bump github.com/sigstore/sigstore/pkg/signature/kms/hashivault
    
    Bumps [github.com/sigstore/sigstore/pkg/signature/kms/hashivault](https://github.com/sigstore/sigstore) from 1.10.5 to 1.10.6.
    - [Release notes](https://github.com/sigstore/sigstore/releases)
    - [Commits](https://github.com/sigstore/sigstore/compare/v1.10.5...v1.10.6)
    
    ---
    updated-dependencies:
    - dependency-name: github.com/sigstore/sigstore/pkg/signature/kms/hashivault
      dependency-version: 1.10.6
      dependency-type: direct:production
      update-type: version-update:semver-patch
    ...
    
    Signed-off-by: dependabot[bot] <support@github.com>

commit c57450536585a27ea7a58d0911ae6782fcf6f62e
Author: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
Date:   Wed May 27 06:38:58 2026 +0000

    build(deps): bump github.com/sigstore/sigstore from 1.10.5 to 1.10.6
    
    Bumps [github.com/sigstore/sigstore](https://github.com/sigstore/sigstore) from 1.10.5 to 1.10.6.
    - [Release notes](https://github.com/sigstore/sigstore/releases)
    - [Commits](https://github.com/sigstore/sigstore/compare/v1.10.5...v1.10.6)
    
    ---
    updated-dependencies:
    - dependency-name: github.com/sigstore/sigstore
      dependency-version: 1.10.6
      dependency-type: direct:production
      update-type: version-update:semver-patch
    ...
    
    Signed-off-by: dependabot[bot] <support@github.com>

commit 62ff508fdee4205866e94657651eaf36423ebfb1
Author: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
Date:   Fri May 22 21:29:19 2026 +0000

    build(deps): bump github.com/sigstore/sigstore/pkg/signature/kms/aws
    
    Bumps [github.com/sigstore/sigstore/pkg/signature/kms/aws](https://github.com/sigstore/sigstore) from 1.10.5 to 1.10.6.
    - [Release notes](https://github.com/sigstore/sigstore/releases)
    - [Commits](https://github.com/sigstore/sigstore/compare/v1.10.5...v1.10.6)
    
    ---
    updated-dependencies:
    - dependency-name: github.com/sigstore/sigstore/pkg/signature/kms/aws
      dependency-version: 1.10.6
      dependency-type: direct:production
      update-type: version-update:semver-patch
    ...
    
    Signed-off-by: dependabot[bot] <support@github.com>
```
</details>