### PR TITLE
dev+staging - Allow Pipelines SREs CRUD access to TektonInstallerSets

### DIFF
--- a/components/pipeline-service/base/rbac/cluster-role/pipeline-service-sre.yaml
+++ b/components/pipeline-service/base/rbac/cluster-role/pipeline-service-sre.yaml
@@ -49,6 +49,20 @@ rules:
       - patch
       - update
       - watch
+  # Grant full access to limited tekton operator related resources
+  # Deleting TektonInstallerSets is required to apply hotfixes when the new image given as a subscription override
+  - apiGroups:
+      - operator.tekton.dev
+    resources:
+      - "tektoninstallersets"
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
   # This rule is needed to be able to diagnose Cluster Health. A diagnosis can be made in situations like
   # PipelineRun Execution/Scheduling Overhead alert starts firing.
   - apiGroups:

--- a/components/pipeline-service/production/base/kustomization.yaml
+++ b/components/pipeline-service/production/base/kustomization.yaml
@@ -20,3 +20,7 @@ patches:
     target:
       kind: TektonConfig
       name: config
+  - path: remove-tektoninstallerset-permissions.yaml
+    target:
+      kind: ClusterRole
+      name: pipeline-service-sre

--- a/components/pipeline-service/production/base/remove-tektoninstallerset-permissions.yaml
+++ b/components/pipeline-service/production/base/remove-tektoninstallerset-permissions.yaml
@@ -1,0 +1,5 @@
+---
+# Temporarily remove tektoninstallersets permissions from production
+# until we're ready to roll out to all production clusters
+- op: remove
+  path: /rules/4

--- a/components/pipeline-service/staging/stone-stage-p01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stage-p01/deploy.yaml
@@ -302,6 +302,18 @@ rules:
   - update
   - watch
 - apiGroups:
+  - operator.tekton.dev
+  resources:
+  - tektoninstallersets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - ""
   resources:
   - nodes

--- a/components/pipeline-service/staging/stone-stg-rh01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stg-rh01/deploy.yaml
@@ -302,6 +302,18 @@ rules:
   - update
   - watch
 - apiGroups:
+  - operator.tekton.dev
+  resources:
+  - tektoninstallersets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - ""
   resources:
   - nodes


### PR DESCRIPTION
Deleting TektonInstallerSets is required to apply hotfixes when the new image given as a subscription override. 