### PR TITLE
kueue: add konflux-nudge priority class

### DIFF
--- a/components/kueue/development/queue-config/workload-priority-class.yaml
+++ b/components/kueue/development/queue-config/workload-priority-class.yaml
@@ -2,9 +2,16 @@
 apiVersion: kueue.x-k8s.io/v1beta2
 kind: WorkloadPriorityClass
 metadata:
+  name: konflux-nudge
+value: 1100
+description: "Highest priority for component nudges"
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: WorkloadPriorityClass
+metadata:
   name: konflux-release
 value: 1000
-description: "Highest priority for release pipelines"
+description: "Higher priority for release pipelines"
 ---
 apiVersion: kueue.x-k8s.io/v1beta2
 kind: WorkloadPriorityClass

--- a/components/kueue/development/tekton-kueue/config.yaml
+++ b/components/kueue/development/tekton-kueue/config.yaml
@@ -142,7 +142,7 @@ cel:
         has(pipelineRun.metadata.labels) &&
         'build.appstudio.openshift.io/type' in pipelineRun.metadata.labels &&
         pipelineRun.metadata.labels['build.appstudio.openshift.io/type'] == 'nudge' ?
-        priority('konflux-dependency-update') :
+        priority('konflux-nudge') :
 
         pacEventType == 'push' ? priority('konflux-post-merge-build') :
         pacEventType == 'pull_request' ||

--- a/components/kueue/staging/base/queue-config/workload-priority-class.yaml
+++ b/components/kueue/staging/base/queue-config/workload-priority-class.yaml
@@ -2,9 +2,16 @@
 apiVersion: kueue.x-k8s.io/v1beta2
 kind: WorkloadPriorityClass
 metadata:
+  name: konflux-nudge
+value: 1100
+description: "Highest priority for component nudges"
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: WorkloadPriorityClass
+metadata:
   name: konflux-release
 value: 1000
-description: "Highest priority for release pipelines"
+description: "Higher priority for release pipelines"
 ---
 apiVersion: kueue.x-k8s.io/v1beta2
 kind: WorkloadPriorityClass

--- a/components/kueue/staging/base/tekton-kueue/config.yaml
+++ b/components/kueue/staging/base/tekton-kueue/config.yaml
@@ -142,7 +142,7 @@ cel:
         has(pipelineRun.metadata.labels) &&
         'build.appstudio.openshift.io/type' in pipelineRun.metadata.labels &&
         pipelineRun.metadata.labels['build.appstudio.openshift.io/type'] == 'nudge' ?
-        priority('konflux-dependency-update') :
+        priority('konflux-nudge') :
 
         pacEventType == 'push' ? priority('konflux-post-merge-build') :
         pacEventType == 'pull_request' ||

--- a/hack/test-tekton-kueue-config.py
+++ b/hack/test-tekton-kueue-config.py
@@ -497,7 +497,7 @@ PIPELINERUN_DEFINITIONS: Dict[str, PipelineRunTestData] = {
             "labels": {
                 "build.appstudio.openshift.io/type": "nudge",
                 "kueue.x-k8s.io/queue-name": "pipelines-queue",
-                "kueue.x-k8s.io/priority-class": "konflux-dependency-update"
+                "kueue.x-k8s.io/priority-class": "konflux-nudge"
             }
         }
     },


### PR DESCRIPTION
Nudges need to be prioritized over all other pipeline runs, since they trigger components to fire off rebuilds.  The pipelineruns themselves are very small, so this won't add significant load to the clusters.

Add a new priority class with a value of 1100 to make nudges the highest priority, and teach tekton-kueue to assign nudges to this new priority.

Fixes: [KFLUXINFRA-3877](https://redhat.atlassian.net/browse/KFLUXINFRA-3877)

[KFLUXINFRA-3877]: https://redhat.atlassian.net/browse/KFLUXINFRA-3877?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ