### PR TITLE
fix(KAR-893) remove loki-gateway from external loadbalancer on staging

### DIFF
--- a/components/vector-kubearchive-log-collector/staging/stone-stage-p01/loki-helm-stg-values.yaml
+++ b/components/vector-kubearchive-log-collector/staging/stone-stage-p01/loki-helm-stg-values.yaml
@@ -5,7 +5,7 @@ global:
 
 gateway:
   service:
-    type: LoadBalancer
+    type: ClusterIP
   serviceAccount:
     create: false
     name: loki-gateway

--- a/components/vector-kubearchive-log-collector/staging/stone-stg-rh01/loki-helm-stg-values.yaml
+++ b/components/vector-kubearchive-log-collector/staging/stone-stg-rh01/loki-helm-stg-values.yaml
@@ -5,7 +5,7 @@ global:
 
 gateway:
   service:
-    type: LoadBalancer
+    type: ClusterIP
   serviceAccount:
     create: false
     name: loki-gateway


### PR DESCRIPTION
## Summary
- Removes loki-gateway endpoint from external load-balancer

## Risk Assessment

**Risk Level:** Low
**Rollback:** Revert this PR.
**Description:** These values have been validated in staging. No impact on current cluster network is expected.

## Validation
- Validated on development

Jira: https://redhat.atlassian.net/browse/KAR-893