### PR TITLE
KAR-893 remove from loadbalancer on kflux-prd-rh02 kflux-prd-rh03 kflux-rhel-p01

### DIFF
--- a/components/vector-kubearchive-log-collector/production/kflux-prd-rh02/loki-helm-prod-values.yaml
+++ b/components/vector-kubearchive-log-collector/production/kflux-prd-rh02/loki-helm-prod-values.yaml
@@ -5,7 +5,7 @@ global:
 
 gateway:
   service:
-    type: LoadBalancer
+    type: ClusterIP
   resources:
     requests:
       cpu: 100m

--- a/components/vector-kubearchive-log-collector/production/kflux-prd-rh02/loki-helm-values.yaml
+++ b/components/vector-kubearchive-log-collector/production/kflux-prd-rh02/loki-helm-values.yaml
@@ -2,7 +2,6 @@
 # simplified Loki configuration for staging
 deploymentMode: Distributed
 
- # This exposes the Loki gateway so it can be written to and queried externally
 gateway:
   image:
     registry: quay.io # Use Quay.io registry to prevent docker hub rate limit

--- a/components/vector-kubearchive-log-collector/production/kflux-prd-rh03/loki-helm-prod-values.yaml
+++ b/components/vector-kubearchive-log-collector/production/kflux-prd-rh03/loki-helm-prod-values.yaml
@@ -5,7 +5,7 @@ global:
 
 gateway:
   service:
-    type: LoadBalancer
+    type: ClusterIP
   resources:
     requests:
       cpu: 100m

--- a/components/vector-kubearchive-log-collector/production/kflux-prd-rh03/loki-helm-values.yaml
+++ b/components/vector-kubearchive-log-collector/production/kflux-prd-rh03/loki-helm-values.yaml
@@ -2,7 +2,6 @@
 # simplified Loki configuration for staging
 deploymentMode: Distributed
 
- # This exposes the Loki gateway so it can be written to and queried externally
 gateway:
   image:
     registry: quay.io # Use Quay.io registry to prevent docker hub rate limit

--- a/components/vector-kubearchive-log-collector/production/kflux-rhel-p01/loki-helm-prod-values.yaml
+++ b/components/vector-kubearchive-log-collector/production/kflux-rhel-p01/loki-helm-prod-values.yaml
@@ -5,7 +5,7 @@ global:
 
 gateway:
   service:
-    type: LoadBalancer
+    type: ClusterIP
   resources:
     requests:
       cpu: 100m

--- a/components/vector-kubearchive-log-collector/production/kflux-rhel-p01/loki-helm-values.yaml
+++ b/components/vector-kubearchive-log-collector/production/kflux-rhel-p01/loki-helm-values.yaml
@@ -2,7 +2,6 @@
 # simplified Loki configuration for staging
 deploymentMode: Distributed
 
- # This exposes the Loki gateway so it can be written to and queried externally
 gateway:
   image:
     registry: quay.io # Use Quay.io registry to prevent docker hub rate limit


### PR DESCRIPTION
## Summary
- Removes loki-gateway endpoint from external load-balancer

## Risk Assessment

**Risk Level:** Low
**Rollback:** Revert this PR.
**Description:** These values have been validated in staging. No impact on current cluster network is expected.

## Validation
- Staging validated with the same configuration (PR [12340](https://github.com/redhat-appstudio/infra-deployments/pull/12340))
