### PR TITLE
fix(KAR-893) remove gateway from loadbalancer on kflux-prd-rh03

### DIFF
--- a/components/vector-kubearchive-log-collector/production/kflux-prd-rh03/loki-helm-prod-values.yaml
+++ b/components/vector-kubearchive-log-collector/production/kflux-prd-rh03/loki-helm-prod-values.yaml
@@ -5,7 +5,7 @@ global:
 
 gateway:
   service:
-    type: LoadBalancer
+    type: ClusterIP
   resources:
     requests:
       cpu: 100m


### PR DESCRIPTION
## Summary
- Removes loki-gateway endpoint from external load-balancer

## Risk Assessment

**Risk Level:** Low
**Rollback:** Revert this PR.
**Description:** These values have been validated in staging. No impact on current cluster network is expected.

## Validation
- Staging validated with the same configuration (PR #12340)

Jira: https://redhat.atlassian.net/browse/KAR-893