### PR TITLE
[test] Prod Ring 1: Patch pipeline resolver container image for KONFLUX-14376

### DIFF
--- a/components/pipeline-service/production/kflux-fedora-01/deploy.yaml
+++ b/components/pipeline-service/production/kflux-fedora-01/deploy.yaml
@@ -2561,6 +2561,8 @@ spec:
     env:
     - name: AUTOINSTALL_COMPONENTS
       value: "false"
+    - name: IMAGE_PIPELINES_CONTROLLER
+      value: quay.io/openshift-pipeline/pipelines-resolvers-rhel9@sha256:7cd91bc4c0f3469ec4c39d08d818b00c90ce07456364910e49ad5e1430f3110a
   name: openshift-pipelines-operator-rh
   source: custom-operators
   sourceNamespace: openshift-marketplace

--- a/components/pipeline-service/production/kflux-osp-p01/deploy.yaml
+++ b/components/pipeline-service/production/kflux-osp-p01/deploy.yaml
@@ -2548,6 +2548,8 @@ spec:
     env:
     - name: AUTOINSTALL_COMPONENTS
       value: "false"
+    - name: IMAGE_PIPELINES_CONTROLLER
+      value: quay.io/openshift-pipeline/pipelines-resolvers-rhel9@sha256:7cd91bc4c0f3469ec4c39d08d818b00c90ce07456364910e49ad5e1430f3110a
   name: openshift-pipelines-operator-rh
   source: custom-operators
   sourceNamespace: openshift-marketplace

--- a/components/pipeline-service/production/rings/ring-1/kustomization.yaml
+++ b/components/pipeline-service/production/rings/ring-1/kustomization.yaml
@@ -43,3 +43,26 @@ patches:
                           requests:
                             cpu: 200m
                             memory: 4096Mi
+  # TODO: Remove this once Pipelines 1.13.x is deployed
+  # NOTE: IMAGE_PIPELINES_CONTROLLER is the image used specifically by the resolvers,
+  # the pipelines-controller uses IMAGE_PIPELINES_TEKTON_PIPELINES_CONTROLLER
+  - target:
+      kind: Subscription
+      name: openshift-pipelines-operator
+    patch: |-
+      apiVersion: operators.coreos.com/v1alpha1
+      kind: Subscription
+      metadata:
+        name: openshift-pipelines-operator
+        namespace: openshift-operators
+      spec:
+        channel: pipelines-5.0
+        name: openshift-pipelines-operator-rh
+        source: custom-operators
+        sourceNamespace: openshift-marketplace
+        config:
+          env:
+            - name: AUTOINSTALL_COMPONENTS
+              value: "false"
+            - name: IMAGE_PIPELINES_CONTROLLER
+              value: "quay.io/openshift-pipeline/pipelines-resolvers-rhel9@sha256:7cd91bc4c0f3469ec4c39d08d818b00c90ce07456364910e49ad5e1430f3110a"

--- a/components/pipeline-service/production/stone-prod-p01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prod-p01/deploy.yaml
@@ -2548,6 +2548,8 @@ spec:
     env:
     - name: AUTOINSTALL_COMPONENTS
       value: "false"
+    - name: IMAGE_PIPELINES_CONTROLLER
+      value: quay.io/openshift-pipeline/pipelines-resolvers-rhel9@sha256:7cd91bc4c0f3469ec4c39d08d818b00c90ce07456364910e49ad5e1430f3110a
   name: openshift-pipelines-operator-rh
   source: custom-operators
   sourceNamespace: openshift-marketplace


### PR DESCRIPTION
Add IMAGE_PIPELINES_CONTROLLER override to patch the pipelines resolver on Ring 1 production clusters (stone-prod-p01, kflux-osp-p01, kflux-fedora-01). Same pattern as the staging fix in #12332.

Resolvers image to include this change: https://github.com/tektoncd/pipeline/commit/829429b251abc0dd2dd055b893300f505780b70b

