### PR TITLE
Prod Ring 2: Patch pipeline resolver container image for Konflux-14376 fix

### DIFF
--- a/components/pipeline-service/production/kflux-ocp-p01/deploy.yaml
+++ b/components/pipeline-service/production/kflux-ocp-p01/deploy.yaml
@@ -2548,6 +2548,8 @@ spec:
     env:
     - name: AUTOINSTALL_COMPONENTS
       value: "false"
+    - name: IMAGE_PIPELINES_CONTROLLER
+      value: quay.io/openshift-pipeline/pipelines-resolvers-rhel9@sha256:7cd91bc4c0f3469ec4c39d08d818b00c90ce07456364910e49ad5e1430f3110a
   name: openshift-pipelines-operator-rh
   source: custom-operators
   sourceNamespace: openshift-marketplace

--- a/components/pipeline-service/production/kflux-rhel-p01/deploy.yaml
+++ b/components/pipeline-service/production/kflux-rhel-p01/deploy.yaml
@@ -2548,6 +2548,8 @@ spec:
     env:
     - name: AUTOINSTALL_COMPONENTS
       value: "false"
+    - name: IMAGE_PIPELINES_CONTROLLER
+      value: quay.io/openshift-pipeline/pipelines-resolvers-rhel9@sha256:7cd91bc4c0f3469ec4c39d08d818b00c90ce07456364910e49ad5e1430f3110a
   name: openshift-pipelines-operator-rh
   source: custom-operators
   sourceNamespace: openshift-marketplace

--- a/components/pipeline-service/production/rings/ring-2/kustomization.yaml
+++ b/components/pipeline-service/production/rings/ring-2/kustomization.yaml
@@ -43,3 +43,15 @@ patches:
                           requests:
                             cpu: 200m
                             memory: 4096Mi
+  # TODO: Remove this once Pipelines 1.13.x is deployed
+  # NOTE: IMAGE_PIPELINES_CONTROLLER is the image used specifically by the resolvers,
+  # the pipelines-controller uses IMAGE_PIPELINES_TEKTON_PIPELINES_CONTROLLER
+  - target:
+      kind: Subscription
+      name: openshift-pipelines-operator
+    patch: |-
+      - op: add
+        path: /spec/config/env/-
+        value:
+          name: IMAGE_PIPELINES_CONTROLLER
+          value: "quay.io/openshift-pipeline/pipelines-resolvers-rhel9@sha256:7cd91bc4c0f3469ec4c39d08d818b00c90ce07456364910e49ad5e1430f3110a"

--- a/components/pipeline-service/production/stone-prod-p02/deploy.yaml
+++ b/components/pipeline-service/production/stone-prod-p02/deploy.yaml
@@ -2548,6 +2548,8 @@ spec:
     env:
     - name: AUTOINSTALL_COMPONENTS
       value: "false"
+    - name: IMAGE_PIPELINES_CONTROLLER
+      value: quay.io/openshift-pipeline/pipelines-resolvers-rhel9@sha256:7cd91bc4c0f3469ec4c39d08d818b00c90ce07456364910e49ad5e1430f3110a
   name: openshift-pipelines-operator-rh
   source: custom-operators
   sourceNamespace: openshift-marketplace


### PR DESCRIPTION
## What

Override the resolvers image on Ring 2 production clusters to include the fix for ResolutionRequests resolving all Tekton kinds.

Clusters affected: `stone-prod-p02`, `kflux-rhel-p01`, `kflux-ocp-p01`

[KONFLUX-14376](https://redhat.atlassian.net/browse/KONFLUX-14376)

## Why

Resolvers need to include [tektoncd/pipeline@829429b](https://github.com/tektoncd/pipeline/commit/829429b251abc0dd2dd055b893300f505780b70b) which allows ResolutionRequests to resolve all Tekton kinds, not just Pipelines, Tasks, and StepActions.

## Validation

- Staging PR merged: https://github.com/redhat-appstudio/infra-deployments/pull/12332
- Ring 1 PR: https://github.com/redhat-appstudio/infra-deployments/pull/12352
- `kustomize build` passes for all affected overlays
- deploy.yaml regenerated — only ring-2 clusters affected, ring-1/ring-3 unchanged

## Risk Assessment

**Risk Level:** Low
**What could go wrong:** Resolver image mismatch or incompatibility with the operator version
**Rollback:** Revert the PR (remove the Subscription env override from ring-2 kustomization)
**Blast radius:** 3 clusters (ring-2 only)

[KONFLUX-14376]: https://redhat.atlassian.net/browse/KONFLUX-14376?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ