### PR TITLE
Revert "Disable mintmaker in production (#12269)"

### DIFF
--- a/components/mintmaker/production/base/kustomization.yaml
+++ b/components/mintmaker/production/base/kustomization.yaml
@@ -36,7 +36,6 @@ patches:
       group: external-secrets.io
       version: v1
   - path: manager-set-resources-patch.yaml
-  - path: suspend-dependency-check-patch.yaml
 
 configurations:
 - kustomizeconfig.yaml

--- a/components/mintmaker/production/base/suspend-dependency-check-patch.yaml
+++ b/components/mintmaker/production/base/suspend-dependency-check-patch.yaml
@@ -1,7 +1,0 @@
-apiVersion: batch/v1
-kind: CronJob
-metadata:
-  name: create-dependencyupdatecheck
-  namespace: mintmaker
-spec:
-  suspend: true


### PR DESCRIPTION
This reverts commit 519f7ad5bf5a4db58054c44e294a7737c1c04702.