### PR TITLE
OADP: upgrade channel to stable for kflux-rhel-p01

### DIFF
--- a/components/backup/production/kflux-rhel-p01/kustomization.yaml
+++ b/components/backup/production/kflux-rhel-p01/kustomization.yaml
@@ -21,3 +21,9 @@ patches:
       kind: DataProtectionApplication
       name: velero-aws
     path: dpa-kmskeyid-patch.yaml
+  - target:
+      group: operators.coreos.com
+      version: v1alpha1
+      kind: Subscription
+      name: redhat-oadp-operator
+    path: oadp-channel-patch.yaml

--- a/components/backup/production/kflux-rhel-p01/oadp-channel-patch.yaml
+++ b/components/backup/production/kflux-rhel-p01/oadp-channel-patch.yaml
@@ -1,0 +1,3 @@
+- op: replace
+  path: /spec/channel
+  value: stable


### PR DESCRIPTION
**Summary**
Switch OADP Subscription channel from `stable-1.4` to `stable` for kflux-rhel-p01 after OCP 4.19 upgrade.

OADP 1.4 is not supported on OCP 4.19 — the `stable-1.4` channel no longer exists in the `redhat-operators` catalog, causing OLM `ResolutionFailed`. This is the same fix applied to staging clusters in [#12143](https://github.com/redhat-appstudio/infra-deployments/pull/12143).
  
**Changes**
- Added `oadp-channel-patch.yaml` to `components/backup/production/kflux-rhel-p01/`
- Updated `kustomization.yaml` to apply the Subscription channel patch

**Related**
  - [KFLUXINFRA-3861](https://redhat.atlassian.net/browse/KFLUXINFRA-3861)
  - Staging PR: [#12143](https://github.com/redhat-appstudio/infra-deployments/pull/12143)
  - KB: https://access.redhat.com/articles/7142781


[KFLUXINFRA-3861]: https://redhat.atlassian.net/browse/KFLUXINFRA-3861?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Risk Assessment
**Risk Level:** Low
**Description:** Update backup operator to a version compatible with OCP version, this is the procedure rehearsed and tested on staging
**Rollback:** No rollback will be needed, this will work :) 