### PR TITLE
KONFLUX-14375 Add perf-team SA for reading releases in managed-release-team-tenant

### DIFF
--- a/components/perf-team-prometheus-reader/base/tenants-rbac/kustomization.yaml
+++ b/components/perf-team-prometheus-reader/base/tenants-rbac/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
   - konflux-perfscale-2-tenant
   - konflux-perfscale-3-tenant
   - konflux-perfscale-4-tenant
+  - managed-release-team-tenant

--- a/components/perf-team-prometheus-reader/base/tenants-rbac/managed-release-team-tenant/kustomization.yaml
+++ b/components/perf-team-prometheus-reader/base/tenants-rbac/managed-release-team-tenant/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - tenant-rbac.yaml
+  - sa-token-rbac.yaml

--- a/components/perf-team-prometheus-reader/base/tenants-rbac/managed-release-team-tenant/sa-token-rbac.yaml
+++ b/components/perf-team-prometheus-reader/base/tenants-rbac/managed-release-team-tenant/sa-token-rbac.yaml
@@ -1,0 +1,28 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: perf-team-release-reader-token-creator
+  namespace: managed-release-team-tenant
+rules:
+  - verbs:
+      - create
+    apiGroups:
+      - ""
+    resources:
+      - serviceaccounts/token
+    resourceNames:
+      - perf-team-release-reader-sa
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: perf-team-release-reader-token-creator
+  namespace: managed-release-team-tenant
+subjects:
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: konflux-performance
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: perf-team-release-reader-token-creator

--- a/components/perf-team-prometheus-reader/base/tenants-rbac/managed-release-team-tenant/tenant-rbac.yaml
+++ b/components/perf-team-prometheus-reader/base/tenants-rbac/managed-release-team-tenant/tenant-rbac.yaml
@@ -1,0 +1,37 @@
+# SA for loadtest to collect manifests and logs from managed-release-team-tenant NS
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: perf-team-release-reader-sa
+  namespace: managed-release-team-tenant
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: perf-team-release-reader-role
+  namespace: managed-release-team-tenant
+rules:
+- apiGroups: ["tekton.dev"]
+  resources: ["pipelineruns", "taskruns"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: [""]
+  resources: ["pods/log"]
+  verbs: ["get"]
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: perf-team-release-reader-binding
+  namespace: managed-release-team-tenant
+subjects:
+- kind: ServiceAccount
+  name: perf-team-release-reader-sa
+  namespace: managed-release-team-tenant
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: perf-team-release-reader-role

--- a/components/perf-team-prometheus-reader/development/namespaces/kustomization.yaml
+++ b/components/perf-team-prometheus-reader/development/namespaces/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
   - konflux-perfscale-2-tenant.yaml
   - konflux-perfscale-3-tenant.yaml
   - konflux-perfscale-4-tenant.yaml
+  - managed-release-team-tenant.yaml

--- a/components/perf-team-prometheus-reader/development/namespaces/managed-release-team-tenant.yaml
+++ b/components/perf-team-prometheus-reader/development/namespaces/managed-release-team-tenant.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: managed-release-team-tenant


### PR DESCRIPTION
## What

Add ServiceAccount, Role, and RoleBinding for the perf team to read
pipeline resources in the `managed-release-team-tenant` namespace.

Clusters affected: development, staging

[KONFLUX-14375](https://issues.redhat.com/browse/KONFLUX-14375)

## Why

Loadtest needs to collect manifests and logs from the
managed-release-team-tenant namespace.

## Validation

- `kustomize build components/perf-team-prometheus-reader/development/` passes
- `kustomize build components/perf-team-prometheus-reader/staging/base/` passes
- `kustomize build components/perf-team-prometheus-reader/production/base/` passes (unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[KONFLUX-14375]: https://redhat.atlassian.net/browse/KONFLUX-14375?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ