### PR TITLE
KFLUXINFRA-3990 Fix oauth2-proxy image name to match Konflux-built image

### DIFF
--- a/components/konflux-ui/staging/base/kustomization.yaml
+++ b/components/konflux-ui/staging/base/kustomization.yaml
@@ -14,8 +14,7 @@ images:
   - name: quay.io/konflux-ci/konflux-ui
     newTag: 0bbc783b168bdc396eca145d54eb016b837a0d85
 
-  - name: quay.io/oauth2-proxy/oauth2-proxy
-    newName: quay.io/konflux-ci/oauth2-proxy
-    newTag: 87a8794d4bb98472fab47f14bb28e4d9ec24d7426107028bd1aa780e260ff8e3
+  - name: quay.io/konflux-ci/oauth2-proxy
+    digest: sha256:87a8794d4bb98472fab47f14bb28e4d9ec24d7426107028bd1aa780e260ff8e3
 
 namespace: konflux-ui

--- a/components/konflux-ui/staging/base/proxy/proxy.yaml
+++ b/components/konflux-ui/staging/base/proxy/proxy.yaml
@@ -235,7 +235,7 @@ spec:
           readOnlyRootFilesystem: true
           runAsNonRoot: true
           runAsUser: 1001
-      - image: quay.io/oauth2-proxy/oauth2-proxy@sha256:3da33b9670c67bd782277f99acadf7026f75b9507bfba2088eb2d497266ef7fc
+      - image: quay.io/konflux-ci/oauth2-proxy@sha256:87a8794d4bb98472fab47f14bb28e4d9ec24d7426107028bd1aa780e260ff8e3
         name: oauth2-proxy
         env:
         - name: OAUTH2_PROXY_CLIENT_SECRET


### PR DESCRIPTION
When oauth2-proxy was onboarded to Konflux, the image name in proxy.yaml was set as quay.io/oauth2-proxy/oauth2-proxy (the upstream name), and the kustomization used newName to remap it to quay.io/konflux-ci/oauth2-proxy when the upstream was built hermetically on Konflux.

This caused the automated release update script (RPA) to silently fail: the sed in the RPA matches `name: quay.io/oauth2-proxy/oauth2-proxy` and reads the next line expecting `digest:` or `newTag:`, but it hits the `newName:` line instead, so the substitution never fires. As a result, no new oauth2-proxy images have been promoted to staging for ~3 months despite new builds being released by Konflux.

Fix by using quay.io/konflux-ci/oauth2-proxy directly in both proxy.yaml files and dropping the newName indirection from the kustomizations. The corresponding RPA sed pattern is updated in a separate MR in konflux-release-data.

Associated change:
https://gitlab.cee.redhat.com/releng/konflux-release-data/-/merge_requests/19054

Closes: [KFLUXINFRA-3990](https://redhat.atlassian.net/browse/KFLUXINFRA-3990)

Assisted-by: Claude Code (claude.ai/code)

[KFLUXINFRA-3990]: https://redhat.atlassian.net/browse/KFLUXINFRA-3990?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ