### PR TITLE
convert pipelines production tekton-events-controller units from Mi to Gi

### DIFF
--- a/components/pipeline-service/production/kflux-fedora-01/deploy.yaml
+++ b/components/pipeline-service/production/kflux-fedora-01/deploy.yaml
@@ -2351,10 +2351,10 @@ spec:
                   resources:
                     limits:
                       cpu: 200m
-                      memory: 4096Mi
+                      memory: 4Gi
                     requests:
                       cpu: 200m
-                      memory: 4096Mi
+                      memory: 4Gi
         tekton-operator-proxy-webhook:
           spec:
             replicas: 2

--- a/components/pipeline-service/production/kflux-ocp-p01/deploy.yaml
+++ b/components/pipeline-service/production/kflux-ocp-p01/deploy.yaml
@@ -2336,10 +2336,10 @@ spec:
                   resources:
                     limits:
                       cpu: 200m
-                      memory: 4096Mi
+                      memory: 4Gi
                     requests:
                       cpu: 200m
-                      memory: 4096Mi
+                      memory: 4Gi
         tekton-operator-proxy-webhook:
           spec:
             replicas: 2

--- a/components/pipeline-service/production/kflux-osp-p01/deploy.yaml
+++ b/components/pipeline-service/production/kflux-osp-p01/deploy.yaml
@@ -2336,10 +2336,10 @@ spec:
                   resources:
                     limits:
                       cpu: 200m
-                      memory: 4096Mi
+                      memory: 4Gi
                     requests:
                       cpu: 200m
-                      memory: 4096Mi
+                      memory: 4Gi
         tekton-operator-proxy-webhook:
           spec:
             replicas: 2

--- a/components/pipeline-service/production/kflux-prd-rh02/deploy.yaml
+++ b/components/pipeline-service/production/kflux-prd-rh02/deploy.yaml
@@ -2336,10 +2336,10 @@ spec:
                   resources:
                     limits:
                       cpu: 200m
-                      memory: 4096Mi
+                      memory: 4Gi
                     requests:
                       cpu: 200m
-                      memory: 4096Mi
+                      memory: 4Gi
         tekton-operator-proxy-webhook:
           spec:
             replicas: 2

--- a/components/pipeline-service/production/kflux-prd-rh03/deploy.yaml
+++ b/components/pipeline-service/production/kflux-prd-rh03/deploy.yaml
@@ -2336,10 +2336,10 @@ spec:
                   resources:
                     limits:
                       cpu: 200m
-                      memory: 4096Mi
+                      memory: 4Gi
                     requests:
                       cpu: 200m
-                      memory: 4096Mi
+                      memory: 4Gi
         tekton-operator-proxy-webhook:
           spec:
             replicas: 2

--- a/components/pipeline-service/production/kflux-rhel-p01/deploy.yaml
+++ b/components/pipeline-service/production/kflux-rhel-p01/deploy.yaml
@@ -2336,10 +2336,10 @@ spec:
                   resources:
                     limits:
                       cpu: 200m
-                      memory: 4096Mi
+                      memory: 4Gi
                     requests:
                       cpu: 200m
-                      memory: 4096Mi
+                      memory: 4Gi
         tekton-operator-proxy-webhook:
           spec:
             replicas: 2

--- a/components/pipeline-service/production/rings/ring-1/kustomization.yaml
+++ b/components/pipeline-service/production/rings/ring-1/kustomization.yaml
@@ -39,10 +39,10 @@ patches:
                         resources:
                           limits:
                             cpu: 200m
-                            memory: 4096Mi
+                            memory: 4Gi
                           requests:
                             cpu: 200m
-                            memory: 4096Mi
+                            memory: 4Gi
   # TODO: Remove this once Pipelines 1.13.x is deployed
   # NOTE: IMAGE_PIPELINES_CONTROLLER is the image used specifically by the resolvers,
   # the pipelines-controller uses IMAGE_PIPELINES_TEKTON_PIPELINES_CONTROLLER

--- a/components/pipeline-service/production/rings/ring-2/kustomization.yaml
+++ b/components/pipeline-service/production/rings/ring-2/kustomization.yaml
@@ -39,10 +39,10 @@ patches:
                         resources:
                           limits:
                             cpu: 200m
-                            memory: 4096Mi
+                            memory: 4Gi
                           requests:
                             cpu: 200m
-                            memory: 4096Mi
+                            memory: 4Gi
   # TODO: Remove this once Pipelines 1.13.x is deployed
   # NOTE: IMAGE_PIPELINES_CONTROLLER is the image used specifically by the resolvers,
   # the pipelines-controller uses IMAGE_PIPELINES_TEKTON_PIPELINES_CONTROLLER

--- a/components/pipeline-service/production/rings/ring-3/kustomization.yaml
+++ b/components/pipeline-service/production/rings/ring-3/kustomization.yaml
@@ -39,10 +39,10 @@ patches:
                         resources:
                           limits:
                             cpu: 200m
-                            memory: 4096Mi
+                            memory: 4Gi
                           requests:
                             cpu: 200m
-                            memory: 4096Mi
+                            memory: 4Gi
   # TODO: Remove this once Pipelines 1.13.x is deployed
   # NOTE: IMAGE_PIPELINES_CONTROLLER is the image used specifically by the resolvers,
   # the pipelines-controller uses IMAGE_PIPELINES_TEKTON_PIPELINES_CONTROLLER

--- a/components/pipeline-service/production/stone-prd-rh01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prd-rh01/deploy.yaml
@@ -2336,10 +2336,10 @@ spec:
                   resources:
                     limits:
                       cpu: 200m
-                      memory: 4096Mi
+                      memory: 4Gi
                     requests:
                       cpu: 200m
-                      memory: 4096Mi
+                      memory: 4Gi
         tekton-operator-proxy-webhook:
           spec:
             replicas: 2

--- a/components/pipeline-service/production/stone-prod-p01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prod-p01/deploy.yaml
@@ -2336,10 +2336,10 @@ spec:
                   resources:
                     limits:
                       cpu: 200m
-                      memory: 4096Mi
+                      memory: 4Gi
                     requests:
                       cpu: 200m
-                      memory: 4096Mi
+                      memory: 4Gi
         tekton-operator-proxy-webhook:
           spec:
             replicas: 2

--- a/components/pipeline-service/production/stone-prod-p02/deploy.yaml
+++ b/components/pipeline-service/production/stone-prod-p02/deploy.yaml
@@ -2336,10 +2336,10 @@ spec:
                   resources:
                     limits:
                       cpu: 200m
-                      memory: 4096Mi
+                      memory: 4Gi
                     requests:
                       cpu: 200m
-                      memory: 4096Mi
+                      memory: 4Gi
         tekton-operator-proxy-webhook:
           spec:
             replicas: 2


### PR DESCRIPTION
4096Mi was not syncing when the value was 4Gi, however it was still being considered "out of sync" and causing an alert to fire
<img width="2310" height="1638" alt="image" src="https://github.com/user-attachments/assets/1e9f0443-bfa0-4f11-80b4-f1e7de5f036b" />
