### PR TITLE
Upgrade multi-platform-controller on production (Ring 2)

### DIFF
--- a/components/multi-platform-controller/production-downstream/base/kustomization.yaml
+++ b/components/multi-platform-controller/production-downstream/base/kustomization.yaml
@@ -7,8 +7,8 @@ resources:
 - ../../base/common
 - ../../base/rbac
 - ../../base/logcollector
-- https://github.com/konflux-ci/multi-platform-controller/deploy/operator?ref=93c18de0be493a99a6f08f8f5fb9ab373c838ad8
-- https://github.com/konflux-ci/multi-platform-controller/deploy/otp?ref=93c18de0be493a99a6f08f8f5fb9ab373c838ad8
+- https://github.com/konflux-ci/multi-platform-controller/deploy/operator?ref=aa3768e389f13388943f00e2e69dfe760ba4a2fe
+- https://github.com/konflux-ci/multi-platform-controller/deploy/otp?ref=aa3768e389f13388943f00e2e69dfe760ba4a2fe
 
 components:
   - ../../k-components/manager-resources
@@ -16,7 +16,7 @@ components:
 images:
 - name: multi-platform-controller
   newName: quay.io/konflux-ci/multi-platform-controller
-  newTag: 93c18de0be493a99a6f08f8f5fb9ab373c838ad8
+  newTag: aa3768e389f13388943f00e2e69dfe760ba4a2fe
 - name: multi-platform-otp-server
   newName: quay.io/konflux-ci/multi-platform-controller-otp-service
-  newTag: 93c18de0be493a99a6f08f8f5fb9ab373c838ad8
+  newTag: aa3768e389f13388943f00e2e69dfe760ba4a2fe

--- a/components/multi-platform-controller/production-downstream/kflux-osp-p01/kustomization.yaml
+++ b/components/multi-platform-controller/production-downstream/kflux-osp-p01/kustomization.yaml
@@ -4,23 +4,8 @@ kind: Kustomization
 namespace: multi-platform-controller
 
 resources:
-- ../../base/common
-- ../../base/rbac
-- ../../base/logcollector
-- https://github.com/konflux-ci/multi-platform-controller/deploy/operator?ref=aa3768e389f13388943f00e2e69dfe760ba4a2fe
-- https://github.com/konflux-ci/multi-platform-controller/deploy/otp?ref=aa3768e389f13388943f00e2e69dfe760ba4a2fe
+- ../base
 - external-secrets.yaml
-
-components:
-  - ../../k-components/manager-resources
-
-images:
-- name: multi-platform-controller
-  newName: quay.io/konflux-ci/multi-platform-controller
-  newTag: aa3768e389f13388943f00e2e69dfe760ba4a2fe
-- name: multi-platform-otp-server
-  newName: quay.io/konflux-ci/multi-platform-controller-otp-service
-  newTag: aa3768e389f13388943f00e2e69dfe760ba4a2fe
 
 patches:
   - path: manager_resources_patch.yaml

--- a/components/multi-platform-controller/production-downstream/stone-prod-p01/kustomization.yaml
+++ b/components/multi-platform-controller/production-downstream/stone-prod-p01/kustomization.yaml
@@ -4,23 +4,8 @@ kind: Kustomization
 namespace: multi-platform-controller
 
 resources:
-- ../../base/common
-- ../../base/rbac
-- ../../base/logcollector
-- https://github.com/konflux-ci/multi-platform-controller/deploy/operator?ref=aa3768e389f13388943f00e2e69dfe760ba4a2fe
-- https://github.com/konflux-ci/multi-platform-controller/deploy/otp?ref=aa3768e389f13388943f00e2e69dfe760ba4a2fe
+- ../base
 - external-secrets.yaml
-
-components:
-  - ../../k-components/manager-resources
-
-images:
-- name: multi-platform-controller
-  newName: quay.io/konflux-ci/multi-platform-controller
-  newTag: aa3768e389f13388943f00e2e69dfe760ba4a2fe
-- name: multi-platform-otp-server
-  newName: quay.io/konflux-ci/multi-platform-controller-otp-service
-  newTag: aa3768e389f13388943f00e2e69dfe760ba4a2fe
 
 helmGlobals:
   chartHome: ../../base

--- a/components/multi-platform-controller/production/base/kustomization.yaml
+++ b/components/multi-platform-controller/production/base/kustomization.yaml
@@ -7,8 +7,8 @@ resources:
   - ../../base/common
   - ../../base/rbac
   - ../../base/logcollector
-  - https://github.com/konflux-ci/multi-platform-controller/deploy/operator?ref=93c18de0be493a99a6f08f8f5fb9ab373c838ad8
-  - https://github.com/konflux-ci/multi-platform-controller/deploy/otp?ref=93c18de0be493a99a6f08f8f5fb9ab373c838ad8
+  - https://github.com/konflux-ci/multi-platform-controller/deploy/operator?ref=aa3768e389f13388943f00e2e69dfe760ba4a2fe
+  - https://github.com/konflux-ci/multi-platform-controller/deploy/otp?ref=aa3768e389f13388943f00e2e69dfe760ba4a2fe
 
 components:
   - ../../k-components/manager-resources
@@ -16,7 +16,7 @@ components:
 images:
   - name: multi-platform-controller
     newName: quay.io/konflux-ci/multi-platform-controller
-    newTag: 93c18de0be493a99a6f08f8f5fb9ab373c838ad8
+    newTag: aa3768e389f13388943f00e2e69dfe760ba4a2fe
   - name: multi-platform-otp-server
     newName: quay.io/konflux-ci/multi-platform-controller-otp-service
-    newTag: 93c18de0be493a99a6f08f8f5fb9ab373c838ad8
+    newTag: aa3768e389f13388943f00e2e69dfe760ba4a2fe

--- a/components/multi-platform-controller/production/kflux-fedora-01/kustomization.yaml
+++ b/components/multi-platform-controller/production/kflux-fedora-01/kustomization.yaml
@@ -4,23 +4,8 @@ kind: Kustomization
 namespace: multi-platform-controller
 
 resources:
-  - ../../base/common
-  - ../../base/rbac
-  - ../../base/logcollector
-  - https://github.com/konflux-ci/multi-platform-controller/deploy/operator?ref=aa3768e389f13388943f00e2e69dfe760ba4a2fe
-  - https://github.com/konflux-ci/multi-platform-controller/deploy/otp?ref=aa3768e389f13388943f00e2e69dfe760ba4a2fe
-  - external-secrets.yaml
-
-components:
-  - ../../k-components/manager-resources
-
-images:
-  - name: multi-platform-controller
-    newName: quay.io/konflux-ci/multi-platform-controller
-    newTag: aa3768e389f13388943f00e2e69dfe760ba4a2fe
-  - name: multi-platform-otp-server
-    newName: quay.io/konflux-ci/multi-platform-controller-otp-service
-    newTag: aa3768e389f13388943f00e2e69dfe760ba4a2fe
+- ../base
+- external-secrets.yaml
 
 patches:
   - path: manager_resources_patch.yaml

--- a/components/multi-platform-controller/production/kflux-prd-rh02/kustomization.yaml
+++ b/components/multi-platform-controller/production/kflux-prd-rh02/kustomization.yaml
@@ -4,23 +4,8 @@ kind: Kustomization
 namespace: multi-platform-controller
 
 resources:
-  - ../../base/common
-  - ../../base/rbac
-  - ../../base/logcollector
-  - https://github.com/konflux-ci/multi-platform-controller/deploy/operator?ref=aa3768e389f13388943f00e2e69dfe760ba4a2fe
-  - https://github.com/konflux-ci/multi-platform-controller/deploy/otp?ref=aa3768e389f13388943f00e2e69dfe760ba4a2fe
+  - ../base
   - external-secrets.yaml
-
-components:
-  - ../../k-components/manager-resources
-
-images:
-  - name: multi-platform-controller
-    newName: quay.io/konflux-ci/multi-platform-controller
-    newTag: aa3768e389f13388943f00e2e69dfe760ba4a2fe
-  - name: multi-platform-otp-server
-    newName: quay.io/konflux-ci/multi-platform-controller-otp-service
-    newTag: aa3768e389f13388943f00e2e69dfe760ba4a2fe
 
 patches:
   - path: manager_resources_patch.yaml

--- a/components/multi-platform-controller/production/kflux-prd-rh03/kustomization.yaml
+++ b/components/multi-platform-controller/production/kflux-prd-rh03/kustomization.yaml
@@ -4,23 +4,8 @@ kind: Kustomization
 namespace: multi-platform-controller
 
 resources:
-  - ../../base/common
-  - ../../base/rbac
-  - ../../base/logcollector
-  - https://github.com/konflux-ci/multi-platform-controller/deploy/operator?ref=aa3768e389f13388943f00e2e69dfe760ba4a2fe
-  - https://github.com/konflux-ci/multi-platform-controller/deploy/otp?ref=aa3768e389f13388943f00e2e69dfe760ba4a2fe
+  - ../base
   - external-secrets.yaml
-
-components:
-  - ../../k-components/manager-resources
-
-images:
-  - name: multi-platform-controller
-    newName: quay.io/konflux-ci/multi-platform-controller
-    newTag: aa3768e389f13388943f00e2e69dfe760ba4a2fe
-  - name: multi-platform-otp-server
-    newName: quay.io/konflux-ci/multi-platform-controller-otp-service
-    newTag: aa3768e389f13388943f00e2e69dfe760ba4a2fe
 
 patches:
   - path: manager_resources_patch.yaml


### PR DESCRIPTION
## What

Promote multi-platform-controller to \`aa3768e389f13388943f00e2e69dfe760ba4a2fe\` on all remaining production clusters by updating the base kustomizations.

Clusters newly upgraded in this ring:
- stone-prd-rh01
- kflux-ocp-p01
- kflux-rhel-p01
- stone-prod-p02

Also removes the per-cluster inline overrides added during Ring 1 (kflux-fedora-01, kflux-prd-rh02, kflux-prd-rh03, kflux-osp-p01, stone-prod-p01), which now inherit from the updated base.

## Why

Ring 2 of the phased production rollout following successful Ring 1 deployment in #12295.

## Validation

- `kustomize build --enable-helm` passes for all 9 production overlays:
  - `production/kflux-fedora-01`, `production/kflux-prd-rh02`, `production/kflux-prd-rh03`, `production/stone-prd-rh01`
  - `production-downstream/kflux-osp-p01`, `production-downstream/stone-prod-p01`, `production-downstream/kflux-ocp-p01`, `production-downstream/kflux-rhel-p01`, `production-downstream/stone-prod-p02`
- Ring 1 validated in #12295

## Risk Assessment

**Risk Level:** Medium

**What could go wrong:** MPC manages remote build hosts; a bad upgrade could break multi-arch or remote-platform builds on the affected clusters.

**Rollback:** Revert this PR. Ring 2 clusters return to \`93c18de0\` via base; Ring 1 clusters were already running \`aa3768e\` successfully.

**Blast radius:** Completes upgrade for the remaining 4 production clusters. All 9 production clusters will be on \`aa3768e\` after merge.

Made with [Cursor](https://cursor.com)