### PR TITLE
PVO11Y-5149 Update kanary probe user credentials vault path for Kanary V1

### DIFF
--- a/components/monitoring/kanary/staging/stone-stage-p01/external-secrets/kanary-probe-users-credentials.yaml
+++ b/components/monitoring/kanary/staging/stone-stage-p01/external-secrets/kanary-probe-users-credentials.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   dataFrom:
     - extract:
-        key: stonesoup/staging/monitoring/kanary/kanary-probe-users-credentials/stone-stage-p01
+        key: stonesoup/staging/perfscale/shared/stone-stage-p01/konflux-perfscale-4-tenant
   refreshInterval: 15m
   secretStoreRef:
     kind: ClusterSecretStore

--- a/components/monitoring/kanary/staging/stone-stg-rh01/external-secrets/kanary-probe-users-credentials.yaml
+++ b/components/monitoring/kanary/staging/stone-stg-rh01/external-secrets/kanary-probe-users-credentials.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   dataFrom:
     - extract:
-        key: stonesoup/staging/monitoring/kanary/kanary-probe-users-credentials/stone-stg-rh01
+        key: stonesoup/staging/perfscale/shared/stone-stg-rh01/konflux-perfscale-4-tenant
   refreshInterval: 15m
   secretStoreRef:
     kind: ClusterSecretStore


### PR DESCRIPTION
## Summary
- Update the ExternalSecret vault paths for kanary probe user credentials to point to the new perfscale shared location under `konflux-perfscale-4-tenant` for both staging clusters (`stone-stg-rh01` and `stone-stage-p01`)

Jira: https://redhat.atlassian.net/browse/PVO11Y-5149

## Risk Assessment
**Risk Level:** Low
**Description:** Updates vault secret paths for kanary probe user credentials to use the dedicated tenant 4 namespace
**Rollback:** Revert PR

## Validation
- [x] `kustomize build components/monitoring/kanary/staging/stone-stg-rh01/` passes
- [x] `kustomize build components/monitoring/kanary/staging/stone-stage-p01/` passes