### PR TITLE
restrict release PLRs in OCP and RHEL clusters

### DIFF
--- a/components/kueue/production/kflux-ocp-p01/queue-config/cluster-queue.yaml
+++ b/components/kueue/production/kflux-ocp-p01/queue-config/cluster-queue.yaml
@@ -20,6 +20,7 @@ spec:
     - memory
     - aws-ip
     - mintmaker
+    - konflux-release
     flavors:
     - name: default-flavor
       resources:
@@ -33,6 +34,8 @@ spec:
         nominalQuota: '250'
       - name: mintmaker
         nominalQuota: '150'
+      - name: konflux-release
+        nominalQuota: '50'
   - coveredResources:
     - linux-amd64
     - linux-arm64

--- a/components/kueue/production/kflux-rhel-p01/config.yaml
+++ b/components/kueue/production/kflux-rhel-p01/config.yaml
@@ -113,21 +113,26 @@ cel:
         [resource('konflux-release', 1)] : []
 
     # Set the pipeline priority
-    # First condition is to check if the priority class is already set and keep it if it is
-    # We allow this since the cluster is dedicated to the OCP team.
     - |
         has(pipelineRun.metadata.labels) &&
-        'kueue.x-k8s.io/priority-class' in pipelineRun.metadata.labels ?
-        priority(pipelineRun.metadata.labels['kueue.x-k8s.io/priority-class']) :
+        'build.appstudio.openshift.io/type' in pipelineRun.metadata.labels &&
+        pipelineRun.metadata.labels['build.appstudio.openshift.io/type'] == 'nudge' ?
+        priority('konflux-dependency-update') :
 
         pacEventType == 'push' ? priority('konflux-post-merge-build') :
-        pacEventType == 'pull_request'
-          || pacEventType == "Merge_Request"
-          ? priority('konflux-pre-merge-build') :
+        pacEventType == 'pull_request' ||
+          pacEventType == "Merge_Request" ||
+          pacEventType == 'test-comment' ||
+          pacEventType == 'retest-comment' ||
+          pacEventType == 'retest-all-comment' ||
+          pacEventType == 'ok-to-test-comment'  ? priority('konflux-pre-merge-build') :
         pacTestEventType == 'push' ? priority('konflux-post-merge-test') :
-        pacTestEventType == 'pull_request'
-          || pacTestEventType == "Merge_Request"
-          ? priority('konflux-pre-merge-test') :
+        pacTestEventType == 'pull_request' ||
+          pacTestEventType == "Merge_Request" ||
+          pacTestEventType == 'test-comment' ||
+          pacTestEventType == 'retest-comment' ||
+          pacTestEventType == 'retest-all-comment' ||
+          pacTestEventType == 'ok-to-test-comment' ? priority('konflux-pre-merge-test') :
 
         has(pipelineRun.metadata.labels) &&
         'appstudio.openshift.io/service' in pipelineRun.metadata.labels &&
@@ -139,19 +144,9 @@ cel:
         has(pipelineRun.metadata.labels) &&
         'appstudio.openshift.io/service' in pipelineRun.metadata.labels &&
         pipelineRun.metadata.labels['appstudio.openshift.io/service'] == 'release' &&
-        'pipelines.appstudio.openshift.io/type' in pipelineRun.metadata.labels &&
-        pipelineRun.metadata.labels['pipelines.appstudio.openshift.io/type'] == 'tenant' ?
+        'release.appstudio.openshift.io/namespace' in pipelineRun.metadata.labels &&
+        pipelineRun.metadata.labels['release.appstudio.openshift.io/namespace'] == plrNamespace ?
         priority('konflux-tenant-release') :
-
-        has(pipelineRun.metadata.labels) &&
-        'release.appstudio.openshift.io/name' in pipelineRun.metadata.labels &&
-        pipelineRun.metadata.labels['release.appstudio.openshift.io/name'].contains('-prod-') ?
-        priority('konflux-prod-release') :
-
-        has(pipelineRun.metadata.labels) &&
-        'release.appstudio.openshift.io/name' in pipelineRun.metadata.labels &&
-        pipelineRun.metadata.labels['release.appstudio.openshift.io/name'].contains('-stage-') ?
-        priority('konflux-stage-release') :
 
         plrNamespace == 'mintmaker' ? priority('konflux-dependency-update') :
 

--- a/components/kueue/production/kflux-rhel-p01/kustomization.yaml
+++ b/components/kueue/production/kflux-rhel-p01/kustomization.yaml
@@ -6,3 +6,10 @@ resources:
 
 commonAnnotations:
   argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+
+configMapGenerator:
+  - name: tekton-kueue-config
+    namespace: tekton-kueue
+    behavior: replace
+    files:
+      - config.yaml

--- a/components/kueue/production/kflux-rhel-p01/queue-config/cluster-queue.yaml
+++ b/components/kueue/production/kflux-rhel-p01/queue-config/cluster-queue.yaml
@@ -20,6 +20,7 @@ spec:
     - memory
     - aws-ip
     - mintmaker
+    - konflux-release
     flavors:
     - name: default-flavor
       resources:
@@ -33,6 +34,8 @@ spec:
         nominalQuota: '250'
       - name: mintmaker
         nominalQuota: '150'
+      - name: konflux-release
+        nominalQuota: '50'
   - coveredResources:
     - linux-amd64
     - linux-arm64

--- a/hack/test-tekton-kueue-config.py
+++ b/hack/test-tekton-kueue-config.py
@@ -1422,7 +1422,16 @@ TEST_COMBINATIONS: Dict[str, TestCombination] = {
     },
     "release_managed_production-kflux-ocp-p01": {
         "pipelinerun_key": "release_managed",
-        "config_key": "production-kflux-ocp-p01"
+        "config_key": "production-kflux-ocp-p01",
+        "expected": {
+            "annotations": {
+                "kueue.konflux-ci.dev/requests-konflux-release": "1",
+            },
+            "labels": {
+                "kueue.x-k8s.io/queue-name": "pipelines-queue",
+                "kueue.x-k8s.io/priority-class": "konflux-release"
+            }
+        }
     },
     "mintmaker_production-kflux-ocp-p01": {
         "pipelinerun_key": "mintmaker",
@@ -1430,7 +1439,16 @@ TEST_COMBINATIONS: Dict[str, TestCombination] = {
     },
     "internal_pipelinerun_child_production-kflux-ocp-p01": {
         "pipelinerun_key": "internal_pipelinerun_child",
-        "config_key": "production-kflux-ocp-p01"
+        "config_key": "production-kflux-ocp-p01",
+        "expected": {
+            "annotations": {
+                "kueue.konflux-ci.dev/requests-konflux-release": "1",
+            },
+            "labels": {
+                "kueue.x-k8s.io/queue-name": "pipelines-queue",
+                "kueue.x-k8s.io/priority-class": "konflux-release"
+            }
+        }
     },
     "prefer_new_parameters_production-kflux-ocp-p01": {
         "pipelinerun_key": "prefer-new-parameters",


### PR DESCRIPTION
We are seeing too many release PipelineRuns. They are putting too much stress on other components.

With this change we want to be able to limit them independently from other kinds of PLRs.

Requires:
* [x] #12274
* [x] #12232

## Risk Assessment

**Risk Level:** Low
**What could go wrong:** kueue is not able to admit or too many release plrs are held
**Rollback:** Revert PR or increase the limit from 50 to an higher value

Signed-off-by: Francesco Ilario <filario@redhat.com>
