### PR TITLE
chore(STONEINTG-1633): update integration-service

### DIFF
--- a/components/integration/development/kustomization.yaml
+++ b/components/integration/development/kustomization.yaml
@@ -2,13 +2,13 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - ../base
-- https://github.com/konflux-ci/integration-service/config/default?ref=0b5e7ce35c6698db5b70eba6209c57ac6c7a33be
-- https://github.com/konflux-ci/integration-service/config/snapshotgc?ref=0b5e7ce35c6698db5b70eba6209c57ac6c7a33be
+- https://github.com/konflux-ci/integration-service/config/default?ref=bd638fb264185d87276c1c53f915fdc8ccb5f82d
+- https://github.com/konflux-ci/integration-service/config/snapshotgc?ref=bd638fb264185d87276c1c53f915fdc8ccb5f82d
 
 images:
 - name: quay.io/konflux-ci/integration-service
   newName: quay.io/konflux-ci/integration-service
-  newTag: 0b5e7ce35c6698db5b70eba6209c57ac6c7a33be
+  newTag: bd638fb264185d87276c1c53f915fdc8ccb5f82d
 
 configMapGenerator:
 - name: integration-config

--- a/components/integration/staging/base/kustomization.yaml
+++ b/components/integration/staging/base/kustomization.yaml
@@ -3,13 +3,13 @@ kind: Kustomization
 resources:
 - ../../base
 - ../../base/external-secrets
-- https://github.com/konflux-ci/integration-service/config/default?ref=0b5e7ce35c6698db5b70eba6209c57ac6c7a33be
-- https://github.com/konflux-ci/integration-service/config/snapshotgc?ref=0b5e7ce35c6698db5b70eba6209c57ac6c7a33be
+- https://github.com/konflux-ci/integration-service/config/default?ref=bd638fb264185d87276c1c53f915fdc8ccb5f82d
+- https://github.com/konflux-ci/integration-service/config/snapshotgc?ref=bd638fb264185d87276c1c53f915fdc8ccb5f82d
 
 images:
 - name: quay.io/konflux-ci/integration-service
   newName: quay.io/konflux-ci/integration-service
-  newTag: 0b5e7ce35c6698db5b70eba6209c57ac6c7a33be
+  newTag: bd638fb264185d87276c1c53f915fdc8ccb5f82d
 
 configMapGenerator:
 - name: integration-config


### PR DESCRIPTION
* Deploy the commit [bd638fb264185d87276c1c53f915fdc8ccb5f82d](https://github.com/konflux-ci/integration-service/commit/bd638fb264185d87276c1c53f915fdc8ccb5f82d) which contains the fix for the [STONEINTG-1633](https://redhat.atlassian.net/browse/STONEINTG-1633) issue to the development and staging environments

Signed-off-by: dirgim <kpavic@redhat.com>

[STONEINTG-1633]: https://redhat.atlassian.net/browse/STONEINTG-1633?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ