### PR TITLE
PVO11Y-5262 Re-enable taskruns_pod_latency_milliseconds metric in tekton-ms

### DIFF
--- a/components/monitoring/prometheus/base/tekton-ms/servicemonitor.yaml
+++ b/components/monitoring/prometheus/base/tekton-ms/servicemonitor.yaml
@@ -16,7 +16,3 @@ spec:
   endpoints:
   - port: http-metrics
     interval: 15s
-    metricRelabelings:
-    - sourceLabels: [__name__]
-      regex: tekton_pipelines_controller_taskruns_pod_latency_milliseconds
-      action: drop


### PR DESCRIPTION
## What

Remove the metricRelabelings drop rule for `tekton_pipelines_controller_taskruns_pod_latency_milliseconds` from the tekton-ms ServiceMonitor.

Clusters affected: staging clusters with tekton-ms deployed (stone-stage-p01, stone-stg-rh01)

[PVO11Y-5262](https://redhat.atlassian.net/browse/PVO11Y-5262)

## Why

The upstream cardinality issue has been resolved (https://github.com/tektoncd/pipeline/issues/9393). The metric can now be safely collected without causing scrape timeouts or high memory usage.

## Validation

- `kustomize build components/monitoring/prometheus/staging/stone-stage-p01/` passes
- Rendered ServiceMonitor no longer contains the drop rule

[PVO11Y-5262]: https://redhat.atlassian.net/browse/PVO11Y-5262?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ