### PR TITLE
kueue: add konflux-nudge priority class to prod

### DIFF
--- a/components/kueue/production/base/queue-config/workload-priority-class.yaml
+++ b/components/kueue/production/base/queue-config/workload-priority-class.yaml
@@ -2,9 +2,16 @@
 apiVersion: kueue.x-k8s.io/v1beta2
 kind: WorkloadPriorityClass
 metadata:
+  name: konflux-nudge
+value: 1100
+description: "Highest priority for component nudges"
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: WorkloadPriorityClass
+metadata:
   name: konflux-release
 value: 1000
-description: "Highest priority for release pipelines"
+description: "Higher priority for release pipelines"
 ---
 apiVersion: kueue.x-k8s.io/v1beta2
 kind: WorkloadPriorityClass

--- a/components/kueue/production/base/tekton-kueue/config.yaml
+++ b/components/kueue/production/base/tekton-kueue/config.yaml
@@ -95,9 +95,9 @@ cel:
     # Set the pipeline priority
     - |
         has(pipelineRun.metadata.labels) &&
-        'build.appstudio.openshift.io/type' in pipelineRun.metadata.labels &&
-        pipelineRun.metadata.labels['build.appstudio.openshift.io/type'] == 'nudge' ?
-        priority('konflux-dependency-update') :
+        'build.appstudio.redhat.com/type' in pipelineRun.metadata.labels &&
+        pipelineRun.metadata.labels['build.appstudio.redhat.com/type'] == 'nudge' ?
+        priority('konflux-nudge') :
 
         pacEventType == 'push' ? priority('konflux-post-merge-build') :
         pacEventType == 'pull_request' ||

--- a/components/kueue/production/kflux-ocp-p01/config.yaml
+++ b/components/kueue/production/kflux-ocp-p01/config.yaml
@@ -126,6 +126,11 @@ cel:
         'kueue.x-k8s.io/priority-class' in pipelineRun.metadata.labels ?
         priority(pipelineRun.metadata.labels['kueue.x-k8s.io/priority-class']) :
 
+        has(pipelineRun.metadata.labels) &&
+        'build.appstudio.redhat.com/type' in pipelineRun.metadata.labels &&
+        pipelineRun.metadata.labels['build.appstudio.redhat.com/type'] == 'nudge' ?
+        priority('konflux-nudge') :
+
         pacEventType == 'push' ? priority('konflux-post-merge-build') :
         pacEventType == 'pull_request'
           || pacEventType == "Merge_Request"

--- a/components/kueue/production/kflux-prd-rh02/config.yaml
+++ b/components/kueue/production/kflux-prd-rh02/config.yaml
@@ -101,9 +101,9 @@ cel:
     # Set the pipeline priority
     - |
         has(pipelineRun.metadata.labels) &&
-        'build.appstudio.openshift.io/type' in pipelineRun.metadata.labels &&
-        pipelineRun.metadata.labels['build.appstudio.openshift.io/type'] == 'nudge' ?
-        priority('konflux-dependency-update') :
+        'build.appstudio.redhat.com/type' in pipelineRun.metadata.labels &&
+        pipelineRun.metadata.labels['build.appstudio.redhat.com/type'] == 'nudge' ?
+        priority('konflux-nudge') :
 
         pacEventType == 'push' ? priority('konflux-post-merge-build') :
         pacEventType == 'pull_request' ||

--- a/components/kueue/production/kflux-rhel-p01/config.yaml
+++ b/components/kueue/production/kflux-rhel-p01/config.yaml
@@ -115,9 +115,9 @@ cel:
     # Set the pipeline priority
     - |
         has(pipelineRun.metadata.labels) &&
-        'build.appstudio.openshift.io/type' in pipelineRun.metadata.labels &&
-        pipelineRun.metadata.labels['build.appstudio.openshift.io/type'] == 'nudge' ?
-        priority('konflux-dependency-update') :
+        'build.appstudio.redhat.com/type' in pipelineRun.metadata.labels &&
+        pipelineRun.metadata.labels['build.appstudio.redhat.com/type'] == 'nudge' ?
+        priority('konflux-nudge') :
 
         pacEventType == 'push' ? priority('konflux-post-merge-build') :
         pacEventType == 'pull_request' ||

--- a/components/kueue/production/stone-prod-p01/config.yaml
+++ b/components/kueue/production/stone-prod-p01/config.yaml
@@ -101,9 +101,9 @@ cel:
     # Set the pipeline priority
     - |
         has(pipelineRun.metadata.labels) &&
-        'build.appstudio.openshift.io/type' in pipelineRun.metadata.labels &&
-        pipelineRun.metadata.labels['build.appstudio.openshift.io/type'] == 'nudge' ?
-        priority('konflux-dependency-update') :
+        'build.appstudio.redhat.com/type' in pipelineRun.metadata.labels &&
+        pipelineRun.metadata.labels['build.appstudio.redhat.com/type'] == 'nudge' ?
+        priority('konflux-nudge') :
 
         pacEventType == 'push' ? priority('konflux-post-merge-build') :
         pacEventType == 'pull_request' ||

--- a/components/kueue/production/stone-prod-p02/config.yaml
+++ b/components/kueue/production/stone-prod-p02/config.yaml
@@ -115,9 +115,9 @@ cel:
     # Set the pipeline priority
     - |
         has(pipelineRun.metadata.labels) &&
-        'build.appstudio.openshift.io/type' in pipelineRun.metadata.labels &&
-        pipelineRun.metadata.labels['build.appstudio.openshift.io/type'] == 'nudge' ?
-        priority('konflux-dependency-update') :
+        'build.appstudio.redhat.com/type' in pipelineRun.metadata.labels &&
+        pipelineRun.metadata.labels['build.appstudio.redhat.com/type'] == 'nudge' ?
+        priority('konflux-nudge') :
 
         pacEventType == 'push' ? priority('konflux-post-merge-build') :
         pacEventType == 'pull_request' ||

--- a/hack/test-tekton-kueue-config.py
+++ b/hack/test-tekton-kueue-config.py
@@ -511,7 +511,7 @@ PIPELINERUN_DEFINITIONS: Dict[str, PipelineRunTestData] = {
                 "name": "nudging-pipelinerun",
                 "namespace": "default",
                 "labels": {
-                    "build.appstudio.openshift.io/type": "nudge",
+                    "build.appstudio.redhat.com/type": "nudge",
                     # make sure the nudge type overrides this
                     "pipelinesascode.tekton.dev/event-type": "push"
                 }
@@ -526,7 +526,7 @@ PIPELINERUN_DEFINITIONS: Dict[str, PipelineRunTestData] = {
                 "kueue.konflux-ci.dev/requests-konflux-ci-dev-token": "2",
             },
             "labels": {
-                "build.appstudio.openshift.io/type": "nudge",
+                "build.appstudio.redhat.com/type": "nudge",
                 "kueue.x-k8s.io/queue-name": "pipelines-queue",
                 "kueue.x-k8s.io/priority-class": "konflux-nudge"
             }
@@ -1436,9 +1436,9 @@ TEST_COMBINATIONS: Dict[str, TestCombination] = {
         "expected": {
             "annotations": {},
             "labels": {
-                "build.appstudio.openshift.io/type": "nudge",
+                "build.appstudio.redhat.com/type": "nudge",
                 "kueue.x-k8s.io/queue-name": "pipelines-queue",
-                "kueue.x-k8s.io/priority-class": "konflux-dependency-update"
+                "kueue.x-k8s.io/priority-class": "konflux-nudge"
             }
         }
     },
@@ -1521,6 +1521,21 @@ TEST_COMBINATIONS: Dict[str, TestCombination] = {
             }
         }
     },
+    "nudging_kflux-ocp-p01": {
+        "pipelinerun_key": "nudge_pipelinerun",
+        "config_key": "production-kflux-ocp-p01",
+        "expected": {
+            "annotations": {
+                "kueue.konflux-ci.dev/requests-konflux-ci-dev-token": "1",
+            },
+            "labels": {
+                "build.appstudio.redhat.com/type": "nudge",
+                "kueue.x-k8s.io/queue-name": "pipelines-queue",
+                "kueue.x-k8s.io/priority-class": "konflux-nudge"
+            }
+        }
+    },
+
 
     # Example: Test the same PipelineRun with different configs to show reusability
     "user-specific-priority_and_mixed_platforms_production-kflux-ocp-p01": {
@@ -1678,9 +1693,9 @@ TEST_COMBINATIONS: Dict[str, TestCombination] = {
                 "kueue.konflux-ci.dev/requests-konflux-ci-dev-token": "1",
             },
             "labels": {
-                "build.appstudio.openshift.io/type": "nudge",
+                "build.appstudio.redhat.com/type": "nudge",
                 "kueue.x-k8s.io/queue-name": "pipelines-queue",
-                "kueue.x-k8s.io/priority-class": "konflux-dependency-update"
+                "kueue.x-k8s.io/priority-class": "konflux-nudge"
             }
         }
     },
@@ -1722,9 +1737,9 @@ TEST_COMBINATIONS: Dict[str, TestCombination] = {
                 "kueue.konflux-ci.dev/requests-konflux-ci-dev-token": "1",
             },
             "labels": {
-                "build.appstudio.openshift.io/type": "nudge",
+                "build.appstudio.redhat.com/type": "nudge",
                 "kueue.x-k8s.io/queue-name": "pipelines-queue",
-                "kueue.x-k8s.io/priority-class": "konflux-dependency-update"
+                "kueue.x-k8s.io/priority-class": "konflux-nudge"
             }
         }
     },


### PR DESCRIPTION
Nudges need to be prioritized over all other pipeline runs, since they trigger components to fire off rebuilds.  The pipelineruns themselves are very small, so this won't add significant load to the clusters.

Add a new priority class with a value of 1100 to make nudges the highest priority, and teach tekton-kueue to assign nudges to this new priority.

Fixes: [KFLUXINFRA-3877](https://redhat.atlassian.net/browse/KFLUXINFRA-3877)

[KFLUXINFRA-3877]: https://redhat.atlassian.net/browse/KFLUXINFRA-3877?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ