### PR TITLE
reduce MintMaker freq in prod p02

### DIFF
--- a/components/mintmaker/production/stone-prod-p02/create-dependency-update-check-cron-patch.yaml
+++ b/components/mintmaker/production/stone-prod-p02/create-dependency-update-check-cron-patch.yaml
@@ -1,0 +1,7 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: create-dependencyupdatecheck
+  namespace: mintmaker
+spec:
+  schedule: "0 4,16 * * *" # at 4AM and 4PM

--- a/components/mintmaker/production/stone-prod-p02/kustomization.yaml
+++ b/components/mintmaker/production/stone-prod-p02/kustomization.yaml
@@ -11,3 +11,4 @@ patches:
       version: v1
       kind: ExternalSecret
   - path: manager_patch.yaml
+  - path: create-dependency-update-check-cron-patch.yaml


### PR DESCRIPTION
p02 needs more time to process the PipelineRuns MintMaker creates in each shift. This is causing a constant high number of queued PipelineRuns.

To prevent customers from being affected by this load we want to temporarily reduce the MintMaker's frequency so the cluster has more time to process the MintMaker's queued PipelineRuns.

Signed-off-by: Francesco Ilario <filario@redhat.com>
