### PR TITLE
PVO11Y-5265 Fix kanary run script path

### DIFF
--- a/components/monitoring/kanary/staging/base/tasks/run-kanary-tests.yaml
+++ b/components/monitoring/kanary/staging/base/tasks/run-kanary-tests.yaml
@@ -145,7 +145,7 @@ spec:
           --arg NAMESPACE "$TENANT_NAMESPACE" \
           --rawfile USER_TOKEN /opt/users-secret/token \
           '[{apiurl: $SERVER_API_URL, namespace: $NAMESPACE, token: ($USER_TOKEN | rtrimstr("\n")), verified: true}]' > users.json
-        ./run-stage.sh
+        ./ci-scripts/run-probe/run.sh
         cp -f started ended /tmp/artifacts/
     - name: collect-results
       image: quay.io/redhat-user-workloads/konflux-perfscale-tenant/loadtest


### PR DESCRIPTION
## Summary
- Fix the kanary tekton task run script path: `./run-stage.sh` does not exist in the current loadtest image — the correct path is `ci-scripts/run-probe/run.sh`

Jira: https://redhat.atlassian.net/browse/PVO11Y-5265

## Risk Assessment
**Risk Level:** Low
**Description:** Fixes a broken script path introduced in #12437
**Rollback:** Revert PR

## Validation
- [x] `kustomize build components/monitoring/kanary/staging/stone-stage-p01/` passes
- [x] `kustomize build components/monitoring/kanary/staging/stone-stg-rh01/` passes