### PR TITLE
fix(KONFLUX-14438): Add push label filter in prod to restore notifications for all tenants

### DIFF
--- a/components/notification-controller/production/pipelinerun_filters.yaml
+++ b/components/notification-controller/production/pipelinerun_filters.yaml
@@ -2,5 +2,10 @@
 - op: add
   path: /spec/template/spec/containers/0/env/-
   value:
+    name: NOTIFICATION_FILTER_LABELS
+    value: "pipelinesascode.tekton.dev/event-type=push"
+- op: add
+  path: /spec/template/spec/containers/0/env/-
+  value:
     name: NOTIFICATION_FILTER_ANNOTATIONS
     value: "art-jenkins-job-url"


### PR DESCRIPTION
notification-controller only processing ART PipelineRuns, excluding ~100+ non-ART tenants and breaking SAST ingestion for Product Security.

**Root cause:** Setting only `NOTIFICATION_FILTER_ANNOTATIONS` bypassed the default push-label logic. The controller's OR logic requires both filters to be set to process both tenant types.
  
  ## Risk Assessment
  **Risk Level:** Low 
  **Description:** Fix has been validated in development environment and deployed to staging. The change only adds the missing filter; it does not modify existing behavior for ART PipelineRuns.
  **Rollback:** Revert PR to restore previous configuration (ART-only processing)

  ## Validation
  - ✅ Tested in development environment
  - ✅ Deployed to staging and validated

  **Staging PR:** https://github.com/redhat-appstudio/infra-deployments/pull/12417

Jira-Url: https://redhat.atlassian.net/browse/KONFLUX-14438
Assisted-By: Claude Code