### PR TITLE
chore(KONFLUX-13283): update claim cleaner image

### DIFF
--- a/components/crossplane-control-plane/base/cronjob.yaml
+++ b/components/crossplane-control-plane/base/cronjob.yaml
@@ -11,7 +11,7 @@ spec:
         spec:
           containers:
             - name: namespace-claim-cleaner
-              image: quay.io/konflux-ci/appstudio-utils:e9578e46aefbe58bf77de1f154fbb846fcbdacec@sha256:2094a997c17bc168264209deb43504adcda4b97b64602041e4886f086856301d
+              image: quay.io/konflux-ci/task-runner:v1@sha256:b9ef0479b57a494368a12a02886c650314c9ac7391c6228f21065865aab71c9e
               command:
                 - /bin/bash
                 - /scripts/namespace-claim-cleaner.sh


### PR DESCRIPTION
The image was updated from appstudio-utils to task-runner with kustomize image overrides in all envs. This change now aligns the image in the base manifest to point to the task-runner as well.

This temporarily makes the previous overrides no-ops.

This is the third PR in this effort. Next steps:

PR 4: set dev and stage kustomizations to use
name: quay.io/konflux-ci/task-runner.
PR 5: apply the same to production + remove digest from base.

Assisted-by: Cursor

Risk assessment: No manifest changes are expected in this change. I verified that `kustomize build` generates the same outputs for all envs before and after the change.


## Risk Assessment

**Risk Level:** Low

**Description:** Previous PRs have applied per-overlay (identical) overrides for the image being used for the claim cleanup cronjob. This was done in order to replace a deprecated image with a new one. This PR is changing the image in the base manifest from the deprecated one to the new one. This will make the override into a no-op, both because it will make the override redundant and because the image in base manifest will no longer be matched by the override. Later PRs will restore the overrides functionality, but instead of overriding `old-image -> new-image+digest`, it will be `new-image -> new-image+digest` which is the common pattern we use for overrides.

I ran `kustomize build` for all overlay types before and after the change and the result was that before and after are identical (as expected), but there's a slight chance that I (and the approvers) did not take into account some reasoning for which this will stop working.

Having said that, this change is in the path of making future changes more straightforward and clear. Moreover, when testing the new image on stage and prod, I noticed that it's serving as a backup mechanism that is not actually utilized most of the time, as claims are usually garbage-collected when their owning pipelineruns are removed. I had to specifically create a claim without owner reference for it to endure until it had to be deleted by the job.

So, if the cronjob is broken after the change, we will most likely be able to tell that it's not able to run before it is actually required, and even when required, it will take time for things to start failing due to claims not being deleted.

**Rollback:** click revert on this PR and merge the reverting PR

## Validation

Staging PR: https://github.com/redhat-appstudio/infra-deployments/pull/12312
Production PR: https://github.com/redhat-appstudio/infra-deployments/pull/12318

## Environment Separation

The actual changes in manifests reaching ArgoCD were made in the PRs above. The current PR should be a no-op in terms of manifests pushed to the clusters. An alternative that will allow us not touching the common base will require duplicating the base which will be a riskier change (while I expect should be possible to split between the overlays).

## Qodo Response

**Kustomize override no-op** — This is an expected risk and this is what this PR is about. Next PRs will change the image overrides, one overlay at a time -- again, with no change in the manifests pushed to the clusters. This will make the overrides functional again.