### PR TITLE
PVO11Y-5265 Update kanary vault secret paths to perfscale/shared

### DIFF
--- a/components/monitoring/kanary/staging/base/external-secrets/kanary-probe-credentials.yaml
+++ b/components/monitoring/kanary/staging/base/external-secrets/kanary-probe-credentials.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   dataFrom:
     - extract:
-        key: stonesoup/staging/monitoring/kanary/kanary-probe-credentials
+        key: stonesoup/staging/perfscale/shared
   refreshInterval: 15m
   secretStoreRef:
     kind: ClusterSecretStore

--- a/components/monitoring/kanary/staging/base/external-secrets/kanary-probe-prometheus-credentials.yaml
+++ b/components/monitoring/kanary/staging/base/external-secrets/kanary-probe-prometheus-credentials.yaml
@@ -1,14 +1,14 @@
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
-  name: kanary-probe-users-credentials
+  name: kanary-probe-prometheus-credentials
   annotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
     argocd.argoproj.io/sync-wave: "-1"
 spec:
   dataFrom:
     - extract:
-        key: stonesoup/staging/perfscale/shared/stone-stage-p01/konflux-perfscale-4-tenant
+        key: "" # Patched by cluster overlay to stonesoup/staging/perfscale/shared/<cluster>
   refreshInterval: 15m
   secretStoreRef:
     kind: ClusterSecretStore
@@ -16,4 +16,4 @@ spec:
   target:
     creationPolicy: Owner
     deletionPolicy: Delete
-    name: kanary-probe-users-credentials
+    name: kanary-probe-prometheus-credentials

--- a/components/monitoring/kanary/staging/base/external-secrets/kanary-probe-users-credentials.yaml
+++ b/components/monitoring/kanary/staging/base/external-secrets/kanary-probe-users-credentials.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   dataFrom:
     - extract:
-        key: stonesoup/staging/perfscale/shared/stone-stg-rh01/konflux-perfscale-4-tenant
+        key: "" # Patched by cluster overlay to stonesoup/staging/perfscale/shared/<cluster>/konflux-perfscale-4-tenant
   refreshInterval: 15m
   secretStoreRef:
     kind: ClusterSecretStore

--- a/components/monitoring/kanary/staging/base/external-secrets/kustomization.yaml
+++ b/components/monitoring/kanary/staging/base/external-secrets/kustomization.yaml
@@ -1,2 +1,4 @@
 resources:
   - kanary-probe-credentials.yaml
+  - kanary-probe-prometheus-credentials.yaml
+  - kanary-probe-users-credentials.yaml

--- a/components/monitoring/kanary/staging/base/tasks/run-kanary-tests.yaml
+++ b/components/monitoring/kanary/staging/base/tasks/run-kanary-tests.yaml
@@ -117,17 +117,17 @@ spec:
           valueFrom:
             secretKeyRef:
               name: kanary-probe-credentials
-              key: github-token
+              key: github_token
         - name: GITLAB_BOT_TOKEN
           valueFrom:
             secretKeyRef:
               name: kanary-probe-credentials
-              key: gitlab-bot-token
+              key: gitlab-cee-pipelines-as-code-secret
         - name: OCP_PROMETHEUS_TOKEN
           valueFrom:
             secretKeyRef:
-              name: kanary-probe-credentials
-              key: ocp-prometheus-token
+              name: kanary-probe-prometheus-credentials
+              key: prometheus_token
         - name: TENANT_NAMESPACE
           value: $(params.tenant-namespace)
         - name: SERVER_API_URL
@@ -162,8 +162,8 @@ spec:
         - name: OCP_PROMETHEUS_TOKEN
           valueFrom:
             secretKeyRef:
-              name: kanary-probe-credentials
-              key: ocp-prometheus-token
+              name: kanary-probe-prometheus-credentials
+              key: prometheus_token
       script: |
         #!/usr/bin/env bash
         # -e (errexit) is omitted so we can inspect the exit code

--- a/components/monitoring/kanary/staging/stone-stage-p01/external-secrets/kanary-db-credentials.yaml
+++ b/components/monitoring/kanary/staging/stone-stage-p01/external-secrets/kanary-db-credentials.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   dataFrom:
     - extract:
-        key: # will be added by the overlays
+        key: "" # will be added by the overlays
   refreshInterval: 15m
   secretStoreRef:
     kind: ClusterSecretStore

--- a/components/monitoring/kanary/staging/stone-stage-p01/external-secrets/kustomization.yaml
+++ b/components/monitoring/kanary/staging/stone-stage-p01/external-secrets/kustomization.yaml
@@ -1,3 +1,2 @@
 resources:
   - kanary-db-credentials.yaml
-  - kanary-probe-users-credentials.yaml

--- a/components/monitoring/kanary/staging/stone-stage-p01/external-secrets/patches/kanary-probe-prometheus-credentials-path.yaml
+++ b/components/monitoring/kanary/staging/stone-stage-p01/external-secrets/patches/kanary-probe-prometheus-credentials-path.yaml
@@ -1,0 +1,4 @@
+---
+- op: replace
+  path: /spec/dataFrom/0/extract/key
+  value: stonesoup/staging/perfscale/shared/stone-stage-p01

--- a/components/monitoring/kanary/staging/stone-stage-p01/external-secrets/patches/kanary-probe-users-credentials-path.yaml
+++ b/components/monitoring/kanary/staging/stone-stage-p01/external-secrets/patches/kanary-probe-users-credentials-path.yaml
@@ -1,0 +1,4 @@
+---
+- op: replace
+  path: /spec/dataFrom/0/extract/key
+  value: stonesoup/staging/perfscale/shared/stone-stage-p01/konflux-perfscale-4-tenant

--- a/components/monitoring/kanary/staging/stone-stage-p01/kustomization.yaml
+++ b/components/monitoring/kanary/staging/stone-stage-p01/kustomization.yaml
@@ -10,9 +10,23 @@ images:
     newTag: 1dc5cfb1178223522e5cf1fd1d629fa9c0ea2fdd
 
 patches:
+  # Kanary MVP
   - path: kanary-db-credentials-secret-path.yaml
     target:
       name: kanary-db-credentials
+      kind: ExternalSecret
+      group: external-secrets.io
+      version: v1
+  # Kanary V1
+  - path: external-secrets/patches/kanary-probe-prometheus-credentials-path.yaml
+    target:
+      name: kanary-probe-prometheus-credentials
+      kind: ExternalSecret
+      group: external-secrets.io
+      version: v1
+  - path: external-secrets/patches/kanary-probe-users-credentials-path.yaml
+    target:
+      name: kanary-probe-users-credentials
       kind: ExternalSecret
       group: external-secrets.io
       version: v1

--- a/components/monitoring/kanary/staging/stone-stg-rh01/external-secrets/kustomization.yaml
+++ b/components/monitoring/kanary/staging/stone-stg-rh01/external-secrets/kustomization.yaml
@@ -1,2 +1,0 @@
-resources:
-  - kanary-probe-users-credentials.yaml

--- a/components/monitoring/kanary/staging/stone-stg-rh01/external-secrets/patches/kanary-probe-prometheus-credentials-path.yaml
+++ b/components/monitoring/kanary/staging/stone-stg-rh01/external-secrets/patches/kanary-probe-prometheus-credentials-path.yaml
@@ -1,0 +1,4 @@
+---
+- op: replace
+  path: /spec/dataFrom/0/extract/key
+  value: stonesoup/staging/perfscale/shared/stone-stg-rh01

--- a/components/monitoring/kanary/staging/stone-stg-rh01/external-secrets/patches/kanary-probe-users-credentials-path.yaml
+++ b/components/monitoring/kanary/staging/stone-stg-rh01/external-secrets/patches/kanary-probe-users-credentials-path.yaml
@@ -1,0 +1,4 @@
+---
+- op: replace
+  path: /spec/dataFrom/0/extract/key
+  value: stonesoup/staging/perfscale/shared/stone-stg-rh01/konflux-perfscale-4-tenant

--- a/components/monitoring/kanary/staging/stone-stg-rh01/kustomization.yaml
+++ b/components/monitoring/kanary/staging/stone-stg-rh01/kustomization.yaml
@@ -1,4 +1,17 @@
 resources:
   - ../base
-  - external-secrets
   - cronjobs
+
+patches:
+  - path: external-secrets/patches/kanary-probe-prometheus-credentials-path.yaml
+    target:
+      name: kanary-probe-prometheus-credentials
+      kind: ExternalSecret
+      group: external-secrets.io
+      version: v1
+  - path: external-secrets/patches/kanary-probe-users-credentials-path.yaml
+    target:
+      name: kanary-probe-users-credentials
+      kind: ExternalSecret
+      group: external-secrets.io
+      version: v1


### PR DESCRIPTION
## Summary
- Update `kanary-probe-credentials` ExternalSecret to use `stonesoup/staging/perfscale/shared` vault path
- Update task secret key references: `github-token` → `github_token`, `gitlab-bot-token` → `gitlab-cee-pipelines-as-code-secret`
- Add cluster-specific ExternalSecret for `prometheus_token` from `stonesoup/staging/perfscale/shared/<cluster>` (previously bundled in the base credentials)

Jira: https://redhat.atlassian.net/browse/PVO11Y-5265

## Risk Assessment
**Risk Level:** Low
**Description:** Updates vault secret paths and key names to align with the perfscale shared vault structure
**Rollback:** Revert PR

## Validation
- [x] `kustomize build components/monitoring/kanary/staging/stone-stage-p01/` passes
- [x] `kustomize build components/monitoring/kanary/staging/stone-stg-rh01/` passes