### PR TITLE
STONEBLD-4604: onboard java-pipelines with PaC

### DIFF
--- a/components/konflux-ci/base/repository.yaml
+++ b/components/konflux-ci/base/repository.yaml
@@ -23,6 +23,13 @@ spec:
 apiVersion: pipelinesascode.tekton.dev/v1alpha1
 kind: Repository
 metadata:
+  name: java-pipelines
+spec:
+  url: "https://github.com/konflux-ci/java-pipelines"
+---
+apiVersion: pipelinesascode.tekton.dev/v1alpha1
+kind: Repository
+metadata:
   name: cachi2
 spec:
   url: "https://github.com/hermetoproject/hermeto"


### PR DESCRIPTION
Add konflux-ci/java-pipelines as a Pipelines as Code Repository so merges to main can publish Tekton bundles.