### PR TITLE
fix(etcd-shield): correct alert severity to match hysteresis filter (staging)

### DIFF
--- a/components/etcd-shield/base/etcd_shield_alerts.yaml
+++ b/components/etcd-shield/base/etcd_shield_alerts.yaml
@@ -12,7 +12,7 @@ spec:
       for: 2m
       keep_firing_for: 5m
       labels:
-        severity: warning
+        severity: critical
       annotations:
         summary: etcd-shield is denying admission
         description: Etcd is nearing capacity limits, so etcd-shield is denying admission


### PR DESCRIPTION
## What

Change EtcdShieldDenyAdmission alert severity from `warning` to `critical`.

## Why

The hysteresis branch of the recording rule checks `ALERTS{severity="critical"}`, but the alert was labeled `warning`. This meant the 70% deactivation threshold never matched — the shield would flap on/off at 80% instead of holding until the metric dropped below 70%.

Split from #11319 per review feedback for granular rollback.