### PR TITLE
chore(KONFLUX-13283): adjust claim cleaner image overrides

### DIFF
--- a/components/crossplane-control-plane/development/kustomization.yaml
+++ b/components/crossplane-control-plane/development/kustomization.yaml
@@ -8,7 +8,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 images:
-  - name: quay.io/konflux-ci/appstudio-utils
-    newName: quay.io/konflux-ci/task-runner
+  - name: quay.io/konflux-ci/task-runner
     newTag: v1
     digest: sha256:b9ef0479b57a494368a12a02886c650314c9ac7391c6228f21065865aab71c9e

--- a/components/crossplane-control-plane/staging/kustomization.yaml
+++ b/components/crossplane-control-plane/staging/kustomization.yaml
@@ -9,8 +9,7 @@ resources:
 - https://github.com/konflux-ci/crossplane-control-plane/config?ref=436006583e5203a6de0850569e76483aafbf6ea6
 
 images:
-  - name: quay.io/konflux-ci/appstudio-utils
-    newName: quay.io/konflux-ci/task-runner
+  - name: quay.io/konflux-ci/task-runner
     newTag: v1
     digest: sha256:b9ef0479b57a494368a12a02886c650314c9ac7391c6228f21065865aab71c9e
 


### PR DESCRIPTION
In previous changes, the task-runner image was used in kustomizations to override the deprecated appstudio-utils image. Later the image on the base overlay was changed to the task-runner image, which made the kustomizations a no-op.

This change now adjusts the override to fit the new image so that the kustomizations are effective again, and can be used in the future to override the image (e.g. when image is updated to a new version).

This is the fourth PR in this effort. Next steps:

PR 5: apply the same to production + remove digest from base.

Assisted-by: Cursor