### PR TITLE
KFLUXINFRA-2236: Use docker-build-oci-ta-min pipeline for DR e2e tests

### DIFF
--- a/tests/disaster-recovery/backup_infra.go
+++ b/tests/disaster-recovery/backup_infra.go
@@ -27,6 +27,7 @@ import (
 	"github.com/konflux-ci/e2e-tests/pkg/constants"
 	"github.com/konflux-ci/e2e-tests/pkg/framework"
 	"github.com/konflux-ci/e2e-tests/pkg/utils"
+	"github.com/konflux-ci/e2e-tests/pkg/utils/build"
 	tektonutils "github.com/konflux-ci/release-service/tekton/utils"
 )
 
@@ -144,7 +145,8 @@ func createTenant(fw *framework.Framework, t Tenant) {
 			},
 		}
 
-		_, err = fw.AsKubeAdmin.HasController.CreateComponent(spec, t.Namespace, "", "", t.AppName, false, nil)
+		_, err = fw.AsKubeAdmin.HasController.CreateComponent(spec, t.Namespace, "", "", t.AppName, false,
+			build.GetBuildPipelineBundleAnnotation(constants.DockerBuildOciTAMin))
 		Expect(err).ShouldNot(HaveOccurred(), "failed to create Component %s in namespace %s", comp.Name, t.Namespace)
 	}
 

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -56,6 +56,7 @@ require (
 	github.com/codeready-toolchain/toolchain-common v0.0.0-20220523142428-2558e76260fb // indirect
 	github.com/codeready-toolchain/toolchain-e2e v0.0.0-20220525131508-60876bfb99d3 // indirect
 	github.com/containerd/stargz-snapshotter/estargz v0.18.2 // indirect
+	github.com/containerd/typeurl/v2 v2.2.2 // indirect
 	github.com/cyphar/filepath-securejoin v0.6.1 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/davidmz/go-pageant v1.0.2 // indirect
@@ -140,6 +141,7 @@ require (
 	github.com/minio/md5-simd v1.1.2 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/mitchellh/go-wordwrap v1.0.1 // indirect
+	github.com/moby/buildkit v0.12.5 // indirect
 	github.com/moby/spdystream v0.5.0 // indirect
 	github.com/moby/term v0.5.2 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
@@ -152,6 +154,7 @@ require (
 	github.com/openshift-pipelines/pipelines-as-code v0.34.0 // indirect
 	github.com/openshift/api v0.0.0-20260112161841-5b45879294d5 // indirect
 	github.com/openshift/client-go v0.0.0-20260108185524-48f4ccfc4e13 // indirect
+	github.com/openshift/library-go v0.0.0-20220525173854-9b950a41acdc // indirect
 	github.com/operator-framework/operator-lib v0.19.0 // indirect
 	github.com/patrickmn/go-cache v2.1.0+incompatible // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -1530,6 +1530,8 @@ github.com/conforma/crds/api v0.1.7 h1:IBsIw35A5QkP5i1Se6/BASaFvTnW+xTlWEqJMdX7E
 github.com/conforma/crds/api v0.1.7/go.mod h1:vaUCN54r99HME4555KRKOUPGJxBNAlX1agZ4jlGI2YA=
 github.com/containerd/stargz-snapshotter/estargz v0.18.2 h1:yXkZFYIzz3eoLwlTUZKz2iQ4MrckBxJjkmD16ynUTrw=
 github.com/containerd/stargz-snapshotter/estargz v0.18.2/go.mod h1:XyVU5tcJ3PRpkA9XS2T5us6Eg35yM0214Y+wvrZTBrY=
+github.com/containerd/typeurl/v2 v2.2.2 h1:3jN/k2ysKuPCsln5Qv8bzR9cxal8XjkxPogJfSNO31k=
+github.com/containerd/typeurl/v2 v2.2.2/go.mod h1:95ljDnPfD3bAbDJRugOiShd/DlAAsxGtUBhJxIn7SCk=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/etcd v3.3.13+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
@@ -2240,6 +2242,8 @@ github.com/mitchellh/mapstructure v0.0.0-20160808181253-ca63d7c062ee/go.mod h1:F
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/mapstructure v1.4.1/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mitchellh/reflectwalk v1.0.0/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
+github.com/moby/buildkit v0.12.5 h1:RNHH1l3HDhYyZafr5EgstEu8aGNCwyfvMtrQDtjH9T0=
+github.com/moby/buildkit v0.12.5/go.mod h1:YGwjA2loqyiYfZeEo8FtI7z4x5XponAaIWsWcSjWwso=
 github.com/moby/spdystream v0.5.0 h1:7r0J1Si3QO/kjRitvSLVVFUjxMEb/YLj6S9FF62JBCU=
 github.com/moby/spdystream v0.5.0/go.mod h1:xBAYlnt/ay+11ShkdFKNAG7LsyK/tmNBVvVOwrfMgdI=
 github.com/moby/term v0.5.0/go.mod h1:8FzsFHVUBGZdbDsJw/ot+X+d5HLUbvklYLJ9uGfcI3Y=
@@ -2348,6 +2352,8 @@ github.com/openshift/client-go v0.0.0-20210831095141-e19a065e79f7/go.mod h1:D6P8
 github.com/openshift/client-go v0.0.0-20260108185524-48f4ccfc4e13 h1:6rd4zSo2UaWQcAPZfHK9yzKVqH0BnMv1hqMzqXZyTds=
 github.com/openshift/client-go v0.0.0-20260108185524-48f4ccfc4e13/go.mod h1:YvOmPmV7wcJxpfhTDuFqqs2Xpb3M3ovsM6Qs/i2ptq4=
 github.com/openshift/library-go v0.0.0-20220211144658-96cd7a701be1/go.mod h1:5TSPiu4ZEPW5NwUspgqYqjSD/wF86JWGy+x8jB+9oB4=
+github.com/openshift/library-go v0.0.0-20220525173854-9b950a41acdc h1:j+upvKc1uLzuL+q/JXie8+IMohOooTCaEC9w+4d1Ztk=
+github.com/openshift/library-go v0.0.0-20220525173854-9b950a41acdc/go.mod h1:AMZwYwSdbvALDl3QobEzcJ2IeDO7DYLsr42izKzh524=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/openzipkin/zipkin-go v0.4.3 h1:9EGwpqkgnwdEIJ+Od7QVSEIH+ocmm5nPat0G7sjsSdg=
 github.com/openzipkin/zipkin-go v0.4.3/go.mod h1:M9wCJZFWCo2RiY+o1eBCEMe0Dp2S5LDHcMZmk3RmK7c=
@@ -2666,6 +2672,7 @@ go.opencensus.io v0.24.0/go.mod h1:vNK8G9p7aAivkbmorf4v+7Hgx+Zs0yY+0fOtgBfjQKo=
 go.opentelemetry.io/auto/sdk v1.1.0/go.mod h1:3wSPjt5PWp2RhlCcmmOial7AvC4DQqZb7a7wCow3W8A=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=
 go.opentelemetry.io/auto/sdk v1.2.1/go.mod h1:KRTj+aOaElaLi+wW1kO/DZRXwkF4C5xPbEe3ZiIhN7Y=
+go.opentelemetry.io/contrib v0.20.0 h1:ubFQUn0VCZ0gPwIoJfBJVpeBlyRMxu8Mm/huKWYd9p0=
 go.opentelemetry.io/contrib/detectors/gcp v1.31.0/go.mod h1:tzQL6E1l+iV44YFTkcAeNQqzXUiekSYP9jjJjXwEd00=
 go.opentelemetry.io/contrib/detectors/gcp v1.32.0/go.mod h1:TVqo0Sda4Cv8gCIixd7LuLwW4EylumVWfhjZJjDD4DU=
 go.opentelemetry.io/contrib/detectors/gcp v1.34.0/go.mod h1:cV4BMFcscUR/ckqLkbfQmF0PRsq8w/lMGzdbCSveBHo=
@@ -2699,6 +2706,7 @@ go.opentelemetry.io/otel v1.34.0/go.mod h1:OWFPOQ+h4G8xpyjgqo4SxJYdDQ/qmRH+wivy7
 go.opentelemetry.io/otel v1.35.0/go.mod h1:UEqy8Zp11hpkUrL73gSlELM0DupHoiq72dR+Zqel/+Y=
 go.opentelemetry.io/otel v1.40.0 h1:oA5YeOcpRTXq6NN7frwmwFR0Cn3RhTVZvXsP4duvCms=
 go.opentelemetry.io/otel v1.40.0/go.mod h1:IMb+uXZUKkMXdPddhwAHm6UfOwJyh4ct1ybIlV14J0g=
+go.opentelemetry.io/otel/exporters/otlp v0.20.0 h1:PTNgq9MRmQqqJY0REVbZFvwkYOA85vbdQU/nVfxDyqg=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.27.0/go.mod h1:OQFyQVrDlbe+R7xrEyDr/2Wr67Ol0hRUgsfA+V5A95s=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.28.0/go.mod h1:s75jGIWA9OfCMzF0xr+ZgfrB5FEbbV7UuYo32ahUiFI=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.34.0/go.mod h1:7Bept48yIeqxP2OZ9/AqIpYS94h2or0aB4FypJTc8ZM=


### PR DESCRIPTION
## Summary

Switch the DR e2e tests to use the `docker-build-oci-ta-min` (minimal resources) build pipeline instead of the default `docker-build-oci-ta` pipeline when creating Components.

## Problem

The DR e2e CI job consistently fails with `FailedScheduling` errors because the default `docker-build-oci-ta` pipeline tasks exceed the available CPU and memory on the CI cluster:

```
dr-test-kokohazamar-backwards-compat-dr  FailedScheduling  pod/mathwizz-frontend-on-pull-request-n4vfk-clair-scan-pod
  0/7 nodes are available: 5 Insufficient cpu, 7 Insufficient memory.

dr-test-moshekipod-backwards-compat-dr   FailedScheduling  pod/mathwizz-frontend-on-pull-request-d5fq7-sast-snyk-check-pod
  0/7 nodes are available: 3 Insufficient cpu, 7 Insufficient memory.
```

## Solution

Use `docker-build-oci-ta-min` — the minimal resources variant of the build pipeline, explicitly designed for testing:

> *"Use minimal resources pipeline to build container images. This version is good for testing and demonstration purposes."*
> — `components/build-service/base/build-pipeline-config/build-pipeline-config.yaml`

This is the same pattern used by the build-service e2e tests ([example](https://github.com/konflux-ci/build-service/blob/main/e2e-tests/tests/multi_component.go#L64)) via `build.GetBuildPipelineBundleAnnotation(constants.DockerBuildOciTAMin)`.

## Changes

| File | Change |
|------|--------|
| `tests/disaster-recovery/backup_infra.go` | Pass `docker-build-oci-ta-min` annotation to `CreateComponent()` instead of `nil` |
| `tests/go.mod` / `tests/go.sum` | Add transitive dependencies for `pkg/utils/build` import |

## Risk Assessment

- **Level:** Low
- **Description:** Only changes which build pipeline variant is used during DR tests. The DR backup/restore logic being tested is unaffected — it backs up and restores the same Kubernetes resources regardless of which pipeline built the images.
- **Rollback plan:** Revert this PR to restore default pipeline usage.

## Related

- Parent PR: [KFLUXINFRA-2236: Add DR e2e test scaffold to infra-deployments](https://github.com/redhat-appstudio/infra-deployments/pull/12272)
- Companion PR (openshift/release): [KFLUXINFRA-2236: Point DR ginkgo at infra-deployments test directory](https://github.com/openshift/release/pull/80198)
- Jira: [KFLUXINFRA-2236](https://issues.redhat.com/browse/KFLUXINFRA-2236)


Made with [Cursor](https://cursor.com)

[KFLUXINFRA-2236]: https://redhat.atlassian.net/browse/KFLUXINFRA-2236?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ