### PR TITLE
chore(KONFLUX-13283): prod claim cleaner image overrides

### DIFF
--- a/components/crossplane-control-plane/base/cronjob.yaml
+++ b/components/crossplane-control-plane/base/cronjob.yaml
@@ -11,7 +11,7 @@ spec:
         spec:
           containers:
             - name: namespace-claim-cleaner
-              image: quay.io/konflux-ci/task-runner:v1@sha256:b9ef0479b57a494368a12a02886c650314c9ac7391c6228f21065865aab71c9e
+              image: quay.io/konflux-ci/task-runner:set-by-overlay
               command:
                 - /bin/bash
                 - /scripts/namespace-claim-cleaner.sh

--- a/components/crossplane-control-plane/production/kustomization.yaml
+++ b/components/crossplane-control-plane/production/kustomization.yaml
@@ -9,8 +9,7 @@ resources:
 - https://github.com/konflux-ci/crossplane-control-plane/config?ref=bd3da0eff408eb329bfb5d7306b2aa3016d1a906
 
 images:
-  - name: quay.io/konflux-ci/appstudio-utils
-    newName: quay.io/konflux-ci/task-runner
+  - name: quay.io/konflux-ci/task-runner
     newTag: v1
     digest: sha256:b9ef0479b57a494368a12a02886c650314c9ac7391c6228f21065865aab71c9e
 


### PR DESCRIPTION
In previous changes, the task-runner image was used in kustomizations to override the deprecated appstudio-utils image. Later the image on the base overlay was changed to the task-runner image, which made the kustomizations a no-op.

Lastly, the staging override was adjusted to fit the new image so that the kustomizations are effective again.

This change is the fifth and should be the last in the series and it repeats the same change for the production overlay and also remove the pin from the base overlay.

Assisted-by: Cursor

## Risk Assessment

**Risk Level:** Low

**Description:** This PR updates the production overlay to target `quay.io/konflux-ci/task-runner` directly (as done for dev/staging in #12476) and removes tag/digest from the base manifest. Overlays remain the source of truth for the pinned image.

I verified with `kustomize build --enable-helm` that outputs for development, staging, and production are identical before and after the change. The CronJob image on all clusters should remain `task-runner:v1@sha256:b9ef…`.

The claim cleaner is a backup mechanism: EaaS namespace claims are usually garbage-collected when their owning PipelineRuns are removed. Staging and production were already validated on `task-runner` (image swap, hourly job health, and delete path via an orphan claim). If the CronJob regresses, failed or misconfigured jobs should be visible in logs before aged claims accumulate.

**Rollback:** revert this PR and merge the reverting PR.

## Validation

Staging PR: https://github.com/redhat-appstudio/infra-deployments/pull/12476

Prior image rollout validation:
- Staging: #12312
- Production: #12318

## Environment Separation

This PR changes the shared base manifest and the production overlay. Dev/staging overlays were updated separately in #12476. Although base is shared, `kustomize build` output is unchanged for all environments; only production receives a new overlay change. An alternative of duplicating base per environment would be riskier and harder to maintain.

## Qodo Response

**Production change lacks ring scoping** — This is expected as we touch the base manifests with a change that is essentially a no-op. This is similar to https://github.com/redhat-appstudio/infra-deployments/pull/12462 in both why it is done and how it done.