### PR TITLE
KFLUXINFRA-3861: Update OADP channel to stable for kflux-fedora-01 and kflux-osp-p01

### DIFF
--- a/components/backup/production/kflux-fedora-01/kustomization.yaml
+++ b/components/backup/production/kflux-fedora-01/kustomization.yaml
@@ -21,3 +21,9 @@ patches:
       kind: DataProtectionApplication
       name: velero-aws
     path: dpa-kmskeyid-patch.yaml
+  - target:
+      group: operators.coreos.com
+      version: v1alpha1
+      kind: Subscription
+      name: redhat-oadp-operator
+    path: oadp-channel-patch.yaml

--- a/components/backup/production/kflux-fedora-01/oadp-channel-patch.yaml
+++ b/components/backup/production/kflux-fedora-01/oadp-channel-patch.yaml
@@ -1,0 +1,3 @@
+- op: replace
+  path: /spec/channel
+  value: stable

--- a/components/backup/production/kflux-osp-p01/kustomization.yaml
+++ b/components/backup/production/kflux-osp-p01/kustomization.yaml
@@ -21,3 +21,9 @@ patches:
       kind: DataProtectionApplication
       name: velero-aws
     path: dpa-kmskeyid-patch.yaml
+  - target:
+      group: operators.coreos.com
+      version: v1alpha1
+      kind: Subscription
+      name: redhat-oadp-operator
+    path: oadp-channel-patch.yaml

--- a/components/backup/production/kflux-osp-p01/oadp-channel-patch.yaml
+++ b/components/backup/production/kflux-osp-p01/oadp-channel-patch.yaml
@@ -1,0 +1,3 @@
+- op: replace
+  path: /spec/channel
+  value: stable


### PR DESCRIPTION
**Summary**
  
Switch OADP Subscription channel from `stable-1.4` to `stable` (OADP 1.5.x) for kflux-fedora-01 and kflux-osp-p01, now upgraded to OCP 4.19.
  
OCP 4.19 `redhat-operators` catalog no longer ships the `stable-1.4` channel, causing OLM `ResolutionFailed` and backup components to go Degraded.
  
Same change as #12364 (kflux-rhel-p01).
  
Risk Assessment
  
- **Risk Level:** Low
- **Description:** Channel change for OADP operator subscription. The DPA already uses OADP 1.5 format (`nodeAgent` / `uploaderType: kopia`). Same patch was successfully applied to staging clusters and
  kflux-rhel-p01 in production.
- **Rollback Plan:** Revert this PR. Note: reverting to `stable-1.4` will fail on OCP 4.19 since the channel no longer exists, so the operator will remain on the installed version.

Test plan
  
- [x] Verified on staging clusters (stone-stg-rh01, stone-stage-p01) — OADP 1.5.5, healthy
- [x] Verified on kflux-rhel-p01 (PR #12364) — OADP 1.5.x, healthy
- [x] After merge, confirm ArgoCD sync on both clusters
- [x] Verify OADP operator upgraded and backup DPA is not Degraded
