### PR TITLE
SPRE-4610: bump internal-infra-deployments ref for staging nexus probes

### DIFF
--- a/components/monitoring/blackbox/staging/stone-stage-p01/kustomization.yaml
+++ b/components/monitoring/blackbox/staging/stone-stage-p01/kustomization.yaml
@@ -1,6 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - https://github.com/redhat-appstudio/internal-infra-deployments/components/monitoring/blackbox-exporter/staging/private/stone-stage-p01?ref=ed2ae7d7b2cd7ce20b66aaa2be3f405da5b91858
+  - https://github.com/redhat-appstudio/internal-infra-deployments/components/monitoring/blackbox-exporter/staging/private/stone-stage-p01?ref=dcbc471cd89d98e4012e9d723e9c978ebd3ad6c0
 
 namespace: appstudio-monitoring

--- a/components/monitoring/blackbox/staging/stone-stg-rh01/kustomization.yaml
+++ b/components/monitoring/blackbox/staging/stone-stg-rh01/kustomization.yaml
@@ -1,6 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - https://github.com/redhat-appstudio/internal-infra-deployments/components/monitoring/blackbox-exporter/staging/public/stone-stg-rh01?ref=ed2ae7d7b2cd7ce20b66aaa2be3f405da5b91858
+  - https://github.com/redhat-appstudio/internal-infra-deployments/components/monitoring/blackbox-exporter/staging/public/stone-stg-rh01?ref=dcbc471cd89d98e4012e9d723e9c978ebd3ad6c0
 
 namespace: appstudio-monitoring


### PR DESCRIPTION
Update blackbox exporter ref for stone-stage-p01 and stone-stg-rh01 to include Nexus liveness and writable probes.