### PR TITLE
add token resource to kueue in production

### DIFF
--- a/components/kueue/production/base/tekton-kueue/config.yaml
+++ b/components/kueue/production/base/tekton-kueue/config.yaml
@@ -92,6 +92,31 @@ cel:
     - |
         plrNamespace == 'mintmaker' ? [resource('mintmaker', 1)] : []
 
+    # The token mechanism allows us to balance admitted PipelineRuns.
+    # Here we want to state that each PipelineRuns needs one token, but
+    # Build PipelineRuns are usually heavier, so they need 2.
+    #
+    # The total amount of PipelineRuns executing in the system at the same time
+    # will be decided by the first to saturate between `tekton.dev/pipelineruns`
+    # and `konflux-ci.dev/token`. This way we can tune the percentage of usually
+    # heavier PipelineRuns with respect to lighter ones.
+    #
+    # As an example, if both `tekton.dev/pipelineruns` and `konflux-ci.dev/token`
+    # are 600, we could have:
+    # * 300 Build PipelineRuns
+    # * 200 Build PipelineRuns + 200 Non-Build PipelineRuns
+    # * 100 Build PipelineRuns + 400 Non-Build PipelineRuns
+    # * 600 Non-Build PipelineRuns
+    - |
+        pacEventType == 'push' ||
+          pacEventType == 'pull_request' ||
+          pacEventType == "Merge_Request" ||
+          pacEventType == 'test-comment' ||
+          pacEventType == 'retest-comment' ||
+          pacEventType == 'retest-all-comment' ||
+          pacEventType == 'ok-to-test-comment'  ? resource('konflux-ci-dev-token', 2) :
+        resource('konflux-ci-dev-token', 1)
+
     # Set the pipeline priority
     - |
         has(pipelineRun.metadata.labels) &&

--- a/components/kueue/production/kflux-fedora-01/queue-config/cluster-queue.yaml
+++ b/components/kueue/production/kflux-fedora-01/queue-config/cluster-queue.yaml
@@ -16,6 +16,7 @@ spec:
   resourceGroups:
   - coveredResources:
     - tekton.dev/pipelineruns
+    - konflux-ci-dev-token
     - cpu
     - memory
     - aws-ip
@@ -25,6 +26,8 @@ spec:
       resources:
       - name: tekton.dev/pipelineruns
         nominalQuota: '300'
+      - name: konflux-ci-dev-token
+        nominalQuota: '600'
       - name: cpu
         nominalQuota: 1k
       - name: memory

--- a/components/kueue/production/kflux-ocp-p01/queue-config/cluster-queue.yaml
+++ b/components/kueue/production/kflux-ocp-p01/queue-config/cluster-queue.yaml
@@ -16,6 +16,7 @@ spec:
   resourceGroups:
   - coveredResources:
     - tekton.dev/pipelineruns
+    - konflux-ci-dev-token
     - cpu
     - memory
     - aws-ip
@@ -26,6 +27,8 @@ spec:
       resources:
       - name: tekton.dev/pipelineruns
         nominalQuota: '250'
+      - name: konflux-ci-dev-token
+        nominalQuota: '500'
       - name: cpu
         nominalQuota: 1k
       - name: memory

--- a/components/kueue/production/kflux-osp-p01/config.yaml
+++ b/components/kueue/production/kflux-osp-p01/config.yaml
@@ -92,67 +92,32 @@ cel:
     - |
         plrNamespace == 'mintmaker' ? [resource('mintmaker', 1)] : []
 
-    # Add a resource to restrict the number of concurrent release pipelineruns
-    - |
-        has(pipelineRun.metadata.labels) &&
-        'appstudio.openshift.io/service' in pipelineRun.metadata.labels &&
-        pipelineRun.metadata.labels['appstudio.openshift.io/service'] == 'release' &&
-        'pipelines.appstudio.openshift.io/type' in pipelineRun.metadata.labels &&
-        pipelineRun.metadata.labels['pipelines.appstudio.openshift.io/type'] == 'managed' ?
-        [resource('konflux-release', 1)] :
-
-        has(pipelineRun.metadata.labels) &&
-        'appstudio.openshift.io/service' in pipelineRun.metadata.labels &&
-        pipelineRun.metadata.labels['appstudio.openshift.io/service'] == 'release' &&
-        'release.appstudio.openshift.io/namespace' in pipelineRun.metadata.labels &&
-        pipelineRun.metadata.labels['release.appstudio.openshift.io/namespace'] == plrNamespace ?
-        [resource('konflux-release', 1)] :
-
-        has(pipelineRun.metadata.labels) &&
-        'internal-services.appstudio.openshift.io/pipelinerun-uid' in pipelineRun.metadata.labels ?
-        [resource('konflux-release', 1)] : []
-
     # The token mechanism allows us to balance admitted PipelineRuns.
-    # Here we want to state that each PipelineRuns needs one token, but
-    # Build PipelineRuns are usually heavier, so they need 2.
-    #
-    # The total amount of PipelineRuns executing in the system at the same time
-    # will be decided by the first to saturate between `tekton.dev/pipelineruns`
-    # and `konflux-ci.dev/token`. This way we can tune the percentage of usually
-    # heavier PipelineRuns with respect to lighter ones.
-    #
-    # As an example, if both `tekton.dev/pipelineruns` and `konflux-ci.dev/token`
-    # are 600, we could have:
-    # * 300 Build PipelineRuns
-    # * 200 Build PipelineRuns + 200 Non-Build PipelineRuns
-    # * 100 Build PipelineRuns + 400 Non-Build PipelineRuns
-    # * 600 Non-Build PipelineRuns
+    # On the OSP cluster, each PipelineRun requests 1 token regardless of type.
     - |
-        pacEventType == 'push' ||
-          pacEventType == 'pull_request' ||
+        resource('konflux-ci-dev-token', 1)
+
+    # Set the pipeline priority
+    - |
+        has(pipelineRun.metadata.labels) &&
+        'build.appstudio.openshift.io/type' in pipelineRun.metadata.labels &&
+        pipelineRun.metadata.labels['build.appstudio.openshift.io/type'] == 'nudge' ?
+        priority('konflux-dependency-update') :
+
+        pacEventType == 'push' ? priority('konflux-post-merge-build') :
+        pacEventType == 'pull_request' ||
           pacEventType == "Merge_Request" ||
           pacEventType == 'test-comment' ||
           pacEventType == 'retest-comment' ||
           pacEventType == 'retest-all-comment' ||
-          pacEventType == 'ok-to-test-comment'  ? resource('konflux-ci-dev-token', 2) :
-        resource('konflux-ci-dev-token', 1)
-
-    # Set the pipeline priority
-    # First condition is to check if the priority class is already set and keep it if it is
-    # We allow this since the cluster is dedicated to the OCP team.
-    - |
-        has(pipelineRun.metadata.labels) &&
-        'kueue.x-k8s.io/priority-class' in pipelineRun.metadata.labels ?
-        priority(pipelineRun.metadata.labels['kueue.x-k8s.io/priority-class']) :
-
-        pacEventType == 'push' ? priority('konflux-post-merge-build') :
-        pacEventType == 'pull_request'
-          || pacEventType == "Merge_Request"
-          ? priority('konflux-pre-merge-build') :
+          pacEventType == 'ok-to-test-comment'  ? priority('konflux-pre-merge-build') :
         pacTestEventType == 'push' ? priority('konflux-post-merge-test') :
-        pacTestEventType == 'pull_request'
-          || pacTestEventType == "Merge_Request"
-          ? priority('konflux-pre-merge-test') :
+        pacTestEventType == 'pull_request' ||
+          pacTestEventType == "Merge_Request" ||
+          pacTestEventType == 'test-comment' ||
+          pacTestEventType == 'retest-comment' ||
+          pacTestEventType == 'retest-all-comment' ||
+          pacTestEventType == 'ok-to-test-comment' ? priority('konflux-pre-merge-test') :
 
         has(pipelineRun.metadata.labels) &&
         'appstudio.openshift.io/service' in pipelineRun.metadata.labels &&
@@ -164,19 +129,9 @@ cel:
         has(pipelineRun.metadata.labels) &&
         'appstudio.openshift.io/service' in pipelineRun.metadata.labels &&
         pipelineRun.metadata.labels['appstudio.openshift.io/service'] == 'release' &&
-        'pipelines.appstudio.openshift.io/type' in pipelineRun.metadata.labels &&
-        pipelineRun.metadata.labels['pipelines.appstudio.openshift.io/type'] == 'tenant' ?
+        'release.appstudio.openshift.io/namespace' in pipelineRun.metadata.labels &&
+        pipelineRun.metadata.labels['release.appstudio.openshift.io/namespace'] == plrNamespace ?
         priority('konflux-tenant-release') :
-
-        has(pipelineRun.metadata.labels) &&
-        'release.appstudio.openshift.io/name' in pipelineRun.metadata.labels &&
-        pipelineRun.metadata.labels['release.appstudio.openshift.io/name'].contains('-prod-') ?
-        priority('konflux-prod-release') :
-
-        has(pipelineRun.metadata.labels) &&
-        'release.appstudio.openshift.io/name' in pipelineRun.metadata.labels &&
-        pipelineRun.metadata.labels['release.appstudio.openshift.io/name'].contains('-stage-') ?
-        priority('konflux-stage-release') :
 
         plrNamespace == 'mintmaker' ? priority('konflux-dependency-update') :
 

--- a/components/kueue/production/kflux-osp-p01/kustomization.yaml
+++ b/components/kueue/production/kflux-osp-p01/kustomization.yaml
@@ -6,3 +6,10 @@ resources:
 
 commonAnnotations:
   argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+
+configMapGenerator:
+  - name: tekton-kueue-config
+    namespace: tekton-kueue
+    behavior: replace
+    files:
+      - config.yaml

--- a/components/kueue/production/kflux-osp-p01/queue-config/cluster-queue.yaml
+++ b/components/kueue/production/kflux-osp-p01/queue-config/cluster-queue.yaml
@@ -16,6 +16,7 @@ spec:
   resourceGroups:
   - coveredResources:
     - tekton.dev/pipelineruns
+    - konflux-ci-dev-token
     - cpu
     - memory
     - aws-ip
@@ -24,6 +25,8 @@ spec:
     - name: default-flavor
       resources:
       - name: tekton.dev/pipelineruns
+        nominalQuota: '30'
+      - name: konflux-ci-dev-token
         nominalQuota: '30'
       - name: cpu
         nominalQuota: 1k

--- a/components/kueue/production/kflux-prd-rh02/queue-config/cluster-queue.yaml
+++ b/components/kueue/production/kflux-prd-rh02/queue-config/cluster-queue.yaml
@@ -16,6 +16,7 @@ spec:
   resourceGroups:
   - coveredResources:
     - tekton.dev/pipelineruns
+    - konflux-ci-dev-token
     - cpu
     - memory
     - aws-ip
@@ -25,6 +26,8 @@ spec:
       resources:
       - name: tekton.dev/pipelineruns
         nominalQuota: '300'
+      - name: konflux-ci-dev-token
+        nominalQuota: '600'
       - name: cpu
         nominalQuota: 1k
       - name: memory

--- a/components/kueue/production/kflux-prd-rh03/queue-config/cluster-queue.yaml
+++ b/components/kueue/production/kflux-prd-rh03/queue-config/cluster-queue.yaml
@@ -16,6 +16,7 @@ spec:
   resourceGroups:
   - coveredResources:
     - tekton.dev/pipelineruns
+    - konflux-ci-dev-token
     - cpu
     - memory
     - aws-ip
@@ -25,6 +26,8 @@ spec:
       resources:
       - name: tekton.dev/pipelineruns
         nominalQuota: '350'
+      - name: konflux-ci-dev-token
+        nominalQuota: '700'
       - name: cpu
         nominalQuota: 1k
       - name: memory

--- a/components/kueue/production/kflux-rhel-p01/config.yaml
+++ b/components/kueue/production/kflux-rhel-p01/config.yaml
@@ -92,6 +92,31 @@ cel:
     - |
         plrNamespace == 'mintmaker' ? [resource('mintmaker', 1)] : []
 
+    # The token mechanism allows us to balance admitted PipelineRuns.
+    # Here we want to state that each PipelineRuns needs one token, but
+    # Build PipelineRuns are usually heavier, so they need 2.
+    #
+    # The total amount of PipelineRuns executing in the system at the same time
+    # will be decided by the first to saturate between `tekton.dev/pipelineruns`
+    # and `konflux-ci.dev/token`. This way we can tune the percentage of usually
+    # heavier PipelineRuns with respect to lighter ones.
+    #
+    # As an example, if both `tekton.dev/pipelineruns` and `konflux-ci.dev/token`
+    # are 600, we could have:
+    # * 300 Build PipelineRuns
+    # * 200 Build PipelineRuns + 200 Non-Build PipelineRuns
+    # * 100 Build PipelineRuns + 400 Non-Build PipelineRuns
+    # * 600 Non-Build PipelineRuns
+    - |
+        pacEventType == 'push' ||
+          pacEventType == 'pull_request' ||
+          pacEventType == "Merge_Request" ||
+          pacEventType == 'test-comment' ||
+          pacEventType == 'retest-comment' ||
+          pacEventType == 'retest-all-comment' ||
+          pacEventType == 'ok-to-test-comment'  ? resource('konflux-ci-dev-token', 2) :
+        resource('konflux-ci-dev-token', 1)
+
     # Add a resource to restrict the number of concurrent release pipelineruns
     - |
         has(pipelineRun.metadata.labels) &&

--- a/components/kueue/production/kflux-rhel-p01/queue-config/cluster-queue.yaml
+++ b/components/kueue/production/kflux-rhel-p01/queue-config/cluster-queue.yaml
@@ -16,6 +16,7 @@ spec:
   resourceGroups:
   - coveredResources:
     - tekton.dev/pipelineruns
+    - konflux-ci-dev-token
     - cpu
     - memory
     - aws-ip
@@ -26,6 +27,8 @@ spec:
       resources:
       - name: tekton.dev/pipelineruns
         nominalQuota: '300'
+      - name: konflux-ci-dev-token
+        nominalQuota: '600'
       - name: cpu
         nominalQuota: 1k
       - name: memory

--- a/components/kueue/production/stone-prd-rh01/queue-config/cluster-queue.yaml
+++ b/components/kueue/production/stone-prd-rh01/queue-config/cluster-queue.yaml
@@ -16,6 +16,7 @@ spec:
   resourceGroups:
   - coveredResources:
     - tekton.dev/pipelineruns
+    - konflux-ci-dev-token
     - cpu
     - memory
     - aws-ip
@@ -25,6 +26,8 @@ spec:
       resources:
       - name: tekton.dev/pipelineruns
         nominalQuota: '300'
+      - name: konflux-ci-dev-token
+        nominalQuota: '600'
       - name: cpu
         nominalQuota: 1k
       - name: memory

--- a/components/kueue/production/stone-prod-p01/queue-config/cluster-queue.yaml
+++ b/components/kueue/production/stone-prod-p01/queue-config/cluster-queue.yaml
@@ -16,6 +16,7 @@ spec:
   resourceGroups:
   - coveredResources:
     - tekton.dev/pipelineruns
+    - konflux-ci-dev-token
     - cpu
     - memory
     - aws-ip
@@ -25,6 +26,8 @@ spec:
       resources:
       - name: tekton.dev/pipelineruns
         nominalQuota: '300'
+      - name: konflux-ci-dev-token
+        nominalQuota: '600'
       - name: cpu
         nominalQuota: 1k
       - name: memory

--- a/components/kueue/production/stone-prod-p02/config.yaml
+++ b/components/kueue/production/stone-prod-p02/config.yaml
@@ -92,6 +92,31 @@ cel:
     - |
         plrNamespace == 'mintmaker' ? [resource('mintmaker', 1)] : []
 
+    # The token mechanism allows us to balance admitted PipelineRuns.
+    # Here we want to state that each PipelineRuns needs one token, but
+    # Build PipelineRuns are usually heavier, so they need 2.
+    #
+    # The total amount of PipelineRuns executing in the system at the same time
+    # will be decided by the first to saturate between `tekton.dev/pipelineruns`
+    # and `konflux-ci.dev/token`. This way we can tune the percentage of usually
+    # heavier PipelineRuns with respect to lighter ones.
+    #
+    # As an example, if both `tekton.dev/pipelineruns` and `konflux-ci.dev/token`
+    # are 600, we could have:
+    # * 300 Build PipelineRuns
+    # * 200 Build PipelineRuns + 200 Non-Build PipelineRuns
+    # * 100 Build PipelineRuns + 400 Non-Build PipelineRuns
+    # * 600 Non-Build PipelineRuns
+    - |
+        pacEventType == 'push' ||
+          pacEventType == 'pull_request' ||
+          pacEventType == "Merge_Request" ||
+          pacEventType == 'test-comment' ||
+          pacEventType == 'retest-comment' ||
+          pacEventType == 'retest-all-comment' ||
+          pacEventType == 'ok-to-test-comment'  ? resource('konflux-ci-dev-token', 2) :
+        resource('konflux-ci-dev-token', 1)
+
     # Add a resource to restrict the number of concurrent release pipelineruns
     - |
         has(pipelineRun.metadata.labels) &&

--- a/components/kueue/production/stone-prod-p02/queue-config/cluster-queue.yaml
+++ b/components/kueue/production/stone-prod-p02/queue-config/cluster-queue.yaml
@@ -16,6 +16,7 @@ spec:
   resourceGroups:
   - coveredResources:
     - tekton.dev/pipelineruns
+    - konflux-ci-dev-token
     - cpu
     - memory
     - aws-ip
@@ -26,6 +27,8 @@ spec:
       resources:
       - name: tekton.dev/pipelineruns
         nominalQuota: '300'
+      - name: konflux-ci-dev-token
+        nominalQuota: '600'
       - name: cpu
         nominalQuota: 1k
       - name: memory

--- a/hack/test-tekton-kueue-config.py
+++ b/hack/test-tekton-kueue-config.py
@@ -1118,6 +1118,16 @@ CONFIG_COMBINATIONS: Dict[str, ConfigCombination] = {
         "name": "Production p02 config",
         "config_file": "components/kueue/production/stone-prod-p02/config.yaml",
         "kustomization_file": "components/kueue/production/base/tekton-kueue/kustomization.yaml"
+    },
+    "production-kflux-osp-p01": {
+        "name": "Production OSP config",
+        "config_file": "components/kueue/production/kflux-osp-p01/config.yaml",
+        "kustomization_file": "components/kueue/production/base/tekton-kueue/kustomization.yaml"
+    },
+    "production-kflux-rhel-p01": {
+        "name": "Production RHEL config",
+        "config_file": "components/kueue/production/kflux-rhel-p01/config.yaml",
+        "kustomization_file": "components/kueue/production/base/tekton-kueue/kustomization.yaml"
     }
 }
 
@@ -1304,6 +1314,7 @@ TEST_COMBINATIONS: Dict[str, TestCombination] = {
         "config_key": "production",
         "expected": {
             "annotations": {
+                "kueue.konflux-ci.dev/requests-konflux-ci-dev-token": "2",
                 "kueue.konflux-ci.dev/requests-linux-amd64": "1",
                 "kueue.konflux-ci.dev/requests-linux-arm64": "1",
                 "kueue.konflux-ci.dev/requests-linux-s390x": "1",
@@ -1319,7 +1330,9 @@ TEST_COMBINATIONS: Dict[str, TestCombination] = {
         "pipelinerun_key": "release_managed",
         "config_key": "production",
         "expected": {
-            "annotations": {},
+            "annotations": {
+                "kueue.konflux-ci.dev/requests-konflux-ci-dev-token": "1",
+            },
             "labels": {
                 "kueue.x-k8s.io/queue-name": "pipelines-queue",
                 "kueue.x-k8s.io/priority-class": "konflux-release"
@@ -1331,6 +1344,7 @@ TEST_COMBINATIONS: Dict[str, TestCombination] = {
         "config_key": "production",
         "expected": {
             "annotations": {
+                "kueue.konflux-ci.dev/requests-konflux-ci-dev-token": "1",
                 "kueue.konflux-ci.dev/requests-mintmaker": "1",
             },
             "labels": {
@@ -1343,7 +1357,9 @@ TEST_COMBINATIONS: Dict[str, TestCombination] = {
         "pipelinerun_key": "internal_pipelinerun_child",
         "config_key": "production",
         "expected": {
-            "annotations": {},
+            "annotations": {
+                "kueue.konflux-ci.dev/requests-konflux-ci-dev-token": "1",
+            },
             "labels": {
                 "kueue.x-k8s.io/queue-name": "pipelines-queue",
                 "kueue.x-k8s.io/priority-class": "konflux-release"
@@ -1356,6 +1372,7 @@ TEST_COMBINATIONS: Dict[str, TestCombination] = {
         "config_key": "production",
         "expected": {
             "annotations": {
+                "kueue.konflux-ci.dev/requests-konflux-ci-dev-token": "2",
                 "kueue.konflux-ci.dev/requests-linux-amd64": "1",
                 "kueue.konflux-ci.dev/requests-linux-s390x": "1",
                 "kueue.konflux-ci.dev/requests-linux-arm64": "1",
@@ -1371,7 +1388,9 @@ TEST_COMBINATIONS: Dict[str, TestCombination] = {
         "pipelinerun_key": "gitlab_merge_request_build",
         "config_key": "production",
         "expected": {
-            "annotations": {},
+            "annotations": {
+                "kueue.konflux-ci.dev/requests-konflux-ci-dev-token": "2",
+            },
             "labels": {
                 "kueue.x-k8s.io/queue-name": "pipelines-queue",
                 "kueue.x-k8s.io/priority-class": "konflux-pre-merge-build",
@@ -1382,7 +1401,9 @@ TEST_COMBINATIONS: Dict[str, TestCombination] = {
         "pipelinerun_key": "gitlab_merge_request_test",
         "config_key": "production",
         "expected": {
-            "annotations": {},
+            "annotations": {
+                "kueue.konflux-ci.dev/requests-konflux-ci-dev-token": "1",
+            },
             "labels": {
                 "kueue.x-k8s.io/queue-name": "pipelines-queue",
                 "kueue.x-k8s.io/priority-class": "konflux-pre-merge-test",
@@ -1393,7 +1414,9 @@ TEST_COMBINATIONS: Dict[str, TestCombination] = {
         "pipelinerun_key": "nudge_pipelinerun",
         "config_key": "production",
         "expected": {
-            "annotations": {},
+            "annotations": {
+                "kueue.konflux-ci.dev/requests-konflux-ci-dev-token": "2",
+            },
             "labels": {
                 "build.appstudio.openshift.io/type": "nudge",
                 "kueue.x-k8s.io/queue-name": "pipelines-queue",
@@ -1408,6 +1431,7 @@ TEST_COMBINATIONS: Dict[str, TestCombination] = {
         "config_key": "production-kflux-ocp-p01",
         "expected": {
             "annotations": {
+                "kueue.konflux-ci.dev/requests-konflux-ci-dev-token": "2",
                 "kueue.konflux-ci.dev/requests-linux-amd64": "1",
                 "kueue.konflux-ci.dev/requests-linux-s390x": "1",
                 "kueue.konflux-ci.dev/requests-linux-arm64": "1",
@@ -1425,6 +1449,7 @@ TEST_COMBINATIONS: Dict[str, TestCombination] = {
         "config_key": "production-kflux-ocp-p01",
         "expected": {
             "annotations": {
+                "kueue.konflux-ci.dev/requests-konflux-ci-dev-token": "1",
                 "kueue.konflux-ci.dev/requests-konflux-release": "1",
             },
             "labels": {
@@ -1442,6 +1467,7 @@ TEST_COMBINATIONS: Dict[str, TestCombination] = {
         "config_key": "production-kflux-ocp-p01",
         "expected": {
             "annotations": {
+                "kueue.konflux-ci.dev/requests-konflux-ci-dev-token": "1",
                 "kueue.konflux-ci.dev/requests-konflux-release": "1",
             },
             "labels": {
@@ -1461,6 +1487,7 @@ TEST_COMBINATIONS: Dict[str, TestCombination] = {
         "config_key": "production-kflux-ocp-p01",
         "expected": {
             "annotations": {
+                "kueue.konflux-ci.dev/requests-konflux-ci-dev-token": "2",
                 "kueue.konflux-ci.dev/requests-linux-amd64": "1",
                 "kueue.konflux-ci.dev/requests-linux-s390x": "1",
                 "kueue.konflux-ci.dev/requests-linux-ppc64le": "1",
@@ -1480,7 +1507,9 @@ TEST_COMBINATIONS: Dict[str, TestCombination] = {
         "pipelinerun_key": "ocp_prod_release",
         "config_key": "production-kflux-ocp-p01",
         "expected": {
-            "annotations": {},
+            "annotations": {
+                "kueue.konflux-ci.dev/requests-konflux-ci-dev-token": "1",
+            },
             "labels": {
                 "kueue.x-k8s.io/queue-name": "pipelines-queue",
                 "kueue.x-k8s.io/priority-class": "konflux-prod-release"
@@ -1491,7 +1520,9 @@ TEST_COMBINATIONS: Dict[str, TestCombination] = {
         "pipelinerun_key": "ocp_stage_release",
         "config_key": "production-kflux-ocp-p01",
         "expected": {
-            "annotations": {},
+            "annotations": {
+                "kueue.konflux-ci.dev/requests-konflux-ci-dev-token": "1",
+            },
             "labels": {
                 "kueue.x-k8s.io/queue-name": "pipelines-queue",
                 "kueue.x-k8s.io/priority-class": "konflux-stage-release"
@@ -1503,7 +1534,9 @@ TEST_COMBINATIONS: Dict[str, TestCombination] = {
         "pipelinerun_key": "gitlab_merge_request_build",
         "config_key": "production-kflux-ocp-p01",
         "expected": {
-            "annotations": {},
+            "annotations": {
+                "kueue.konflux-ci.dev/requests-konflux-ci-dev-token": "2",
+            },
             "labels": {
                 "kueue.x-k8s.io/queue-name": "pipelines-queue",
                 "kueue.x-k8s.io/priority-class": "konflux-pre-merge-build",
@@ -1514,7 +1547,9 @@ TEST_COMBINATIONS: Dict[str, TestCombination] = {
         "pipelinerun_key": "gitlab_merge_request_test",
         "config_key": "production-kflux-ocp-p01",
         "expected": {
-            "annotations": {},
+            "annotations": {
+                "kueue.konflux-ci.dev/requests-konflux-ci-dev-token": "1",
+            },
             "labels": {
                 "kueue.x-k8s.io/queue-name": "pipelines-queue",
                 "kueue.x-k8s.io/priority-class": "konflux-pre-merge-test",
@@ -1528,6 +1563,7 @@ TEST_COMBINATIONS: Dict[str, TestCombination] = {
         "config_key": "production-stone-prod-p02",
         "expected": {
             "annotations": {
+                "kueue.konflux-ci.dev/requests-konflux-ci-dev-token": "1",
                 "kueue.konflux-ci.dev/requests-konflux-release": "1",
             },
             "labels": {
@@ -1541,6 +1577,7 @@ TEST_COMBINATIONS: Dict[str, TestCombination] = {
         "config_key": "production-stone-prod-p02",
         "expected": {
             "annotations": {
+                "kueue.konflux-ci.dev/requests-konflux-ci-dev-token": "1",
                 "kueue.konflux-ci.dev/requests-konflux-release": "1",
             },
             "labels": {
@@ -1554,11 +1591,175 @@ TEST_COMBINATIONS: Dict[str, TestCombination] = {
         "config_key": "production-stone-prod-p02",
         "expected": {
             "annotations": {
+                "kueue.konflux-ci.dev/requests-konflux-ci-dev-token": "1",
                 "kueue.konflux-ci.dev/requests-konflux-release": "1",
             },
             "labels": {
                 "kueue.x-k8s.io/queue-name": "pipelines-queue",
                 "kueue.x-k8s.io/priority-class": "konflux-release"
+            }
+        }
+    },
+
+    "nudging_production_stone_prod_p02": {
+        "pipelinerun_key": "nudge_pipelinerun",
+        "config_key": "production-stone-prod-p02",
+        "expected": {
+            "annotations": {
+                "kueue.konflux-ci.dev/requests-konflux-ci-dev-token": "2",
+            },
+            "labels": {
+                "build.appstudio.openshift.io/type": "nudge",
+                "kueue.x-k8s.io/queue-name": "pipelines-queue",
+                "kueue.x-k8s.io/priority-class": "konflux-dependency-update"
+            }
+        }
+    },
+
+    # Test key PipelineRuns with production kflux-osp-p01 config
+    # OSP cluster uses 1 token for all PLRs (no build distinction)
+    "multiplatform_new_production-kflux-osp-p01": {
+        "pipelinerun_key": "multiplatform_new",
+        "config_key": "production-kflux-osp-p01",
+        "expected": {
+            "annotations": {
+                "kueue.konflux-ci.dev/requests-konflux-ci-dev-token": "1",
+                "kueue.konflux-ci.dev/requests-linux-amd64": "1",
+                "kueue.konflux-ci.dev/requests-linux-arm64": "1",
+                "kueue.konflux-ci.dev/requests-linux-s390x": "1",
+                "kueue.konflux-ci.dev/requests-aws-ip": "2"
+            },
+            "labels": {
+                "kueue.x-k8s.io/queue-name": "pipelines-queue",
+                "kueue.x-k8s.io/priority-class": "konflux-post-merge-build"
+            }
+        }
+    },
+    "release_managed_production-kflux-osp-p01": {
+        "pipelinerun_key": "release_managed",
+        "config_key": "production-kflux-osp-p01",
+        "expected": {
+            "annotations": {
+                "kueue.konflux-ci.dev/requests-konflux-ci-dev-token": "1",
+            },
+            "labels": {
+                "kueue.x-k8s.io/queue-name": "pipelines-queue",
+                "kueue.x-k8s.io/priority-class": "konflux-release"
+            }
+        }
+    },
+    "gitlab_merge_request_production-kflux-osp-p01": {
+        "pipelinerun_key": "gitlab_merge_request_build",
+        "config_key": "production-kflux-osp-p01",
+        "expected": {
+            "annotations": {
+                "kueue.konflux-ci.dev/requests-konflux-ci-dev-token": "1",
+            },
+            "labels": {
+                "kueue.x-k8s.io/queue-name": "pipelines-queue",
+                "kueue.x-k8s.io/priority-class": "konflux-pre-merge-build",
+            }
+        }
+    },
+    "gitlab_merge_request_test_production-kflux-osp-p01": {
+        "pipelinerun_key": "gitlab_merge_request_test",
+        "config_key": "production-kflux-osp-p01",
+        "expected": {
+            "annotations": {
+                "kueue.konflux-ci.dev/requests-konflux-ci-dev-token": "1",
+            },
+            "labels": {
+                "kueue.x-k8s.io/queue-name": "pipelines-queue",
+                "kueue.x-k8s.io/priority-class": "konflux-pre-merge-test",
+            }
+        }
+    },
+
+    "nudging_production-kflux-osp-p01": {
+        "pipelinerun_key": "nudge_pipelinerun",
+        "config_key": "production-kflux-osp-p01",
+        "expected": {
+            "annotations": {
+                "kueue.konflux-ci.dev/requests-konflux-ci-dev-token": "1",
+            },
+            "labels": {
+                "build.appstudio.openshift.io/type": "nudge",
+                "kueue.x-k8s.io/queue-name": "pipelines-queue",
+                "kueue.x-k8s.io/priority-class": "konflux-dependency-update"
+            }
+        }
+    },
+
+    # Test key PipelineRuns with production kflux-rhel-p01 config
+    "multiplatform_new_production-kflux-rhel-p01": {
+        "pipelinerun_key": "multiplatform_new",
+        "config_key": "production-kflux-rhel-p01",
+        "expected": {
+            "annotations": {
+                "kueue.konflux-ci.dev/requests-konflux-ci-dev-token": "2",
+                "kueue.konflux-ci.dev/requests-linux-amd64": "1",
+                "kueue.konflux-ci.dev/requests-linux-arm64": "1",
+                "kueue.konflux-ci.dev/requests-linux-s390x": "1",
+                "kueue.konflux-ci.dev/requests-aws-ip": "2"
+            },
+            "labels": {
+                "kueue.x-k8s.io/queue-name": "pipelines-queue",
+                "kueue.x-k8s.io/priority-class": "konflux-post-merge-build"
+            }
+        }
+    },
+    "release_managed_production-kflux-rhel-p01": {
+        "pipelinerun_key": "release_managed",
+        "config_key": "production-kflux-rhel-p01",
+        "expected": {
+            "annotations": {
+                "kueue.konflux-ci.dev/requests-konflux-ci-dev-token": "1",
+                "kueue.konflux-ci.dev/requests-konflux-release": "1",
+            },
+            "labels": {
+                "kueue.x-k8s.io/queue-name": "pipelines-queue",
+                "kueue.x-k8s.io/priority-class": "konflux-release"
+            }
+        }
+    },
+    "internal_pipelinerun_child_production-kflux-rhel-p01": {
+        "pipelinerun_key": "internal_pipelinerun_child",
+        "config_key": "production-kflux-rhel-p01",
+        "expected": {
+            "annotations": {
+                "kueue.konflux-ci.dev/requests-konflux-ci-dev-token": "1",
+                "kueue.konflux-ci.dev/requests-konflux-release": "1",
+            },
+            "labels": {
+                "kueue.x-k8s.io/queue-name": "pipelines-queue",
+                "kueue.x-k8s.io/priority-class": "konflux-release"
+            }
+        }
+    },
+    "nudging_production-kflux-rhel-p01": {
+        "pipelinerun_key": "nudge_pipelinerun",
+        "config_key": "production-kflux-rhel-p01",
+        "expected": {
+            "annotations": {
+                "kueue.konflux-ci.dev/requests-konflux-ci-dev-token": "2",
+            },
+            "labels": {
+                "build.appstudio.openshift.io/type": "nudge",
+                "kueue.x-k8s.io/queue-name": "pipelines-queue",
+                "kueue.x-k8s.io/priority-class": "konflux-dependency-update"
+            }
+        }
+    },
+    "gitlab_merge_request_test_production-kflux-rhel-p01": {
+        "pipelinerun_key": "gitlab_merge_request_test",
+        "config_key": "production-kflux-rhel-p01",
+        "expected": {
+            "annotations": {
+                "kueue.konflux-ci.dev/requests-konflux-ci-dev-token": "1",
+            },
+            "labels": {
+                "kueue.x-k8s.io/queue-name": "pipelines-queue",
+                "kueue.x-k8s.io/priority-class": "konflux-pre-merge-test",
             }
         }
     },
@@ -1673,6 +1874,81 @@ class TektonKueueMutationTest(unittest.TestCase):
         """Test all tekton-kueue mutation scenarios."""
         for test_key, test_combination in TEST_COMBINATIONS.items():
             self.validate_mutation_result(test_key, test_combination)
+
+
+# Expected token quota configuration per production cluster.
+# Formula: token_quota = plr_quota * max_token_cost_per_plr
+# OSP uses 1 token per PLR (no build distinction), all others use 2 for builds.
+EXPECTED_TOKEN_QUOTAS: Dict[str, Dict[str, str]] = {
+    "kflux-osp-p01":  {"plr": "30",  "token": "30"},
+    "kflux-ocp-p01":  {"plr": "250", "token": "500"},
+    "kflux-prd-rh03": {"plr": "350", "token": "700"},
+    "kflux-fedora-01": {"plr": "300", "token": "600"},
+    "kflux-prd-rh02": {"plr": "300", "token": "600"},
+    "kflux-rhel-p01": {"plr": "300", "token": "600"},
+    "stone-prd-rh01": {"plr": "300", "token": "600"},
+    "stone-prod-p01": {"plr": "300", "token": "600"},
+    "stone-prod-p02": {"plr": "300", "token": "600"},
+}
+
+
+class ClusterQueueTokenResourceTest(unittest.TestCase):
+    """Validate that production cluster-queue manifests include the token resource correctly."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.repo_root = Path(__file__).parent.parent
+
+    def _load_cluster_queue(self, cluster: str) -> Dict[str, Any]:
+        path = self.repo_root / f"components/kueue/production/{cluster}/queue-config/cluster-queue.yaml"
+        with open(path) as f:
+            docs = list(yaml.safe_load_all(f))
+        for doc in docs:
+            if doc and doc.get("kind") == "ClusterQueue":
+                return doc
+        self.fail(f"No ClusterQueue found in {path}")
+
+    def _find_resource_group_with(self, cluster_queue: Dict, resource_name: str):
+        for rg in cluster_queue["spec"]["resourceGroups"]:
+            if resource_name in rg.get("coveredResources", []):
+                return rg
+        return None
+
+    def _find_flavor_resource(self, resource_group: Dict, resource_name: str):
+        for flavor in resource_group.get("flavors", []):
+            for res in flavor.get("resources", []):
+                if res["name"] == resource_name:
+                    return res
+        return None
+
+    def test_token_resource_in_all_production_clusters(self):
+        """Every production cluster-queue must have konflux-ci-dev-token with correct quota."""
+        for cluster, expected in EXPECTED_TOKEN_QUOTAS.items():
+            with self.subTest(cluster=cluster):
+                cq = self._load_cluster_queue(cluster)
+
+                rg = self._find_resource_group_with(cq, "tekton.dev/pipelineruns")
+                self.assertIsNotNone(rg, f"{cluster}: no resourceGroup with tekton.dev/pipelineruns")
+
+                self.assertIn(
+                    "konflux-ci-dev-token", rg["coveredResources"],
+                    f"{cluster}: konflux-ci-dev-token missing from coveredResources"
+                )
+
+                plr_res = self._find_flavor_resource(rg, "tekton.dev/pipelineruns")
+                self.assertIsNotNone(plr_res, f"{cluster}: tekton.dev/pipelineruns not in flavor resources")
+                self.assertEqual(
+                    str(plr_res["nominalQuota"]), expected["plr"],
+                    f"{cluster}: unexpected tekton.dev/pipelineruns quota"
+                )
+
+                token_res = self._find_flavor_resource(rg, "konflux-ci-dev-token")
+                self.assertIsNotNone(token_res, f"{cluster}: konflux-ci-dev-token not in flavor resources")
+                self.assertEqual(
+                    str(token_res["nominalQuota"]), expected["token"],
+                    f"{cluster}: expected token quota {expected['token']} "
+                    f"(PLR {expected['plr']} x max_cost), got {token_res['nominalQuota']}"
+                )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Introduce the `konflux-ci.dev/token` ephemeral resource across all production clusters. This mirrors the token mechanism already deployed to dev and staging (PR #10850, fix #11854).

The token resource acts as a secondary constraint alongside the existing `tekton.dev/pipelineruns` limit, allowing us to weight PipelineRuns by type. Build PipelineRuns (identified by pacEventType) request 2 tokens while all other PipelineRuns request 1. Since the token quota is set to PLR_limit × 2, the `tekton.dev/pipelineruns` limit remains the binding constraint in all scenarios. This means the current cluster behavior is unchanged — this commit deploys safe, no-op defaults only.

The groundwork is now in place for future per-cluster tuning (e.g. adjusting token quotas or per-type costs on clusters like rh03 that run mixed heavy-build and light-test workloads) after analyzing each cluster's requirements and load patterns.

Token quotas per cluster:
- kflux-osp-p01: 30 tokens (1 per PLR, no build distinction, PLR=30)
- kflux-ocp-p01: 500 tokens (PLR=250)
- kflux-prd-rh03: 700 tokens (PLR=350)
- All others: 600 tokens (PLR=300)

The OSP cluster (kflux-osp-p01) uses a dedicated config override with a simpler 1-token-for-all expression, since it has a small PLR limit and doesn't need build/non-build differentiation.

Note: the ClusterQueue resource name is `konflux-ci-dev-token` (not `konflux-ci.dev/token`) because tekton-kueue sanitizes resource names for use in annotation keys, replacing dots and slashes with dashes.

Also adds ClusterQueueTokenResourceTest to validate that all production cluster-queue manifests have the konflux-ci-dev-token resource in coveredResources with the correct nominalQuota (PLR_limit x max_cost).

Closes: [KFLUXINFRA-3973](https://redhat.atlassian.net/browse/KFLUXINFRA-3973)

Assisted-by: Claude Code (claude-opus-4-6)

[KFLUXINFRA-3973]: https://redhat.atlassian.net/browse/KFLUXINFRA-3973?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ