### PR TITLE
KFLUXVNGD-932: Upgrade squid helm chart to 0.1.1579+32fdfe0 in production (Ring 1)

### DIFF
--- a/components/squid/production/kflux-fedora-01/squid-helm-generator.yaml
+++ b/components/squid/production/kflux-fedora-01/squid-helm-generator.yaml
@@ -4,7 +4,7 @@ metadata:
   name: squid-helm
 name: squid-helm
 repo: oci://quay.io/konflux-ci/caching
-version: 0.1.1521+3e9d8b9
+version: 0.1.1579+32fdfe0
 valuesInline:
   installCertManagerComponents: false
   mirrord:

--- a/components/squid/production/kflux-ocp-p01/squid-helm-generator.yaml
+++ b/components/squid/production/kflux-ocp-p01/squid-helm-generator.yaml
@@ -4,7 +4,7 @@ metadata:
   name: squid-helm
 name: squid-helm
 repo: oci://quay.io/konflux-ci/caching
-version: 0.1.1521+3e9d8b9
+version: 0.1.1579+32fdfe0
 valuesInline:
   installCertManagerComponents: false
   mirrord:

--- a/components/squid/production/kflux-osp-p01/squid-helm-generator.yaml
+++ b/components/squid/production/kflux-osp-p01/squid-helm-generator.yaml
@@ -4,7 +4,7 @@ metadata:
   name: squid-helm
 name: squid-helm
 repo: oci://quay.io/konflux-ci/caching
-version: 0.1.1521+3e9d8b9
+version: 0.1.1579+32fdfe0
 valuesInline:
   installCertManagerComponents: false
   mirrord:

--- a/components/squid/production/kflux-prd-rh02/squid-helm-generator.yaml
+++ b/components/squid/production/kflux-prd-rh02/squid-helm-generator.yaml
@@ -4,7 +4,7 @@ metadata:
   name: squid-helm
 name: squid-helm
 repo: oci://quay.io/konflux-ci/caching
-version: 0.1.1521+3e9d8b9
+version: 0.1.1579+32fdfe0
 valuesInline:
   installCertManagerComponents: false
   mirrord:

--- a/components/squid/production/kflux-prd-rh03/squid-helm-generator.yaml
+++ b/components/squid/production/kflux-prd-rh03/squid-helm-generator.yaml
@@ -4,7 +4,7 @@ metadata:
   name: squid-helm
 name: squid-helm
 repo: oci://quay.io/konflux-ci/caching
-version: 0.1.1521+3e9d8b9
+version: 0.1.1579+32fdfe0
 valuesInline:
   installCertManagerComponents: false
   mirrord:

--- a/components/squid/production/kflux-rhel-p01/squid-helm-generator.yaml
+++ b/components/squid/production/kflux-rhel-p01/squid-helm-generator.yaml
@@ -4,7 +4,7 @@ metadata:
   name: squid-helm
 name: squid-helm
 repo: oci://quay.io/konflux-ci/caching
-version: 0.1.1521+3e9d8b9
+version: 0.1.1579+32fdfe0
 valuesInline:
   installCertManagerComponents: false
   mirrord:

--- a/components/squid/production/stone-prod-p01/squid-helm-generator.yaml
+++ b/components/squid/production/stone-prod-p01/squid-helm-generator.yaml
@@ -4,7 +4,7 @@ metadata:
   name: squid-helm
 name: squid-helm
 repo: oci://quay.io/konflux-ci/caching
-version: 0.1.1521+3e9d8b9
+version: 0.1.1579+32fdfe0
 valuesInline:
   installCertManagerComponents: false
   mirrord:


### PR DESCRIPTION
## What

  Upgrade squid helm chart from 0.1.1521+3e9d8b9 to 0.1.1579+32fdfe0 on 7 production clusters (Ring 1).

  Clusters upgraded in this ring:
  - kflux-fedora-01
  - kflux-ocp-p01
  - kflux-osp-p01
  - kflux-prd-rh02
  - kflux-prd-rh03
  - kflux-rhel-p01
  - stone-prod-p01

  Excluded (Ring 2):
  - stone-prd-rh01
  - stone-prod-p02

  After deployment, the self-signed CA cert must be manually renewed on each upgraded cluster.

## Why

The self-signed CA certificate used by the squid proxy needs its lifespan extended. These clusters were chosen for Ring 1 because there is no active usage of the proxy on them.

## Validation

  - [CI status for 32fdfe0](https://github.com/konflux-ci/caching/commit/32fdfe0)

##  Risk Assessment

  Risk Level: Low
  Rollback: Revert this PR to return upgraded clusters to 0.1.1521+3e9d8b9.