### PR TITLE
Enable proxy for gomod and pip on staging clusters

### DIFF
--- a/components/konflux-info/staging/stone-stage-p01/cluster-config.env
+++ b/components/konflux-info/staging/stone-stage-p01/cluster-config.env
@@ -3,5 +3,7 @@ http-proxy=squid.caching.svc.cluster.local:3128
 no-proxy=
 
 allow-package-registry-proxy=true
+package-registry-proxy-gomod-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/go-proxy
 package-registry-proxy-npm-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/npm-proxy
+package-registry-proxy-pip-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/pypi-proxy/simple
 package-registry-proxy-yarn-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/npm-proxy

--- a/components/konflux-info/staging/stone-stg-rh01/cluster-config.env
+++ b/components/konflux-info/staging/stone-stg-rh01/cluster-config.env
@@ -3,5 +3,7 @@ http-proxy=squid.caching.svc.cluster.local:3128
 no-proxy=
 
 allow-package-registry-proxy=true
+package-registry-proxy-gomod-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/go-proxy
 package-registry-proxy-npm-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/npm-proxy
+package-registry-proxy-pip-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/pypi-proxy/simple
 package-registry-proxy-yarn-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/npm-proxy


### PR DESCRIPTION
Enable use of the package registry proxy for Hermeto's gomod and pip backends on stage clusters (stone-stg-rh01, stone-stage-p01). This will allow Hermeto to route dependency prefetches through the package registry registry proxy for policy evaluation.

Production clusters will be enabled separately after validation in stage.

## Risk Assessment
**Risk Level:** Low
**Description:** Enables additional ecosystems for Nexus in stage
**Rollback:** Revert PR

## Validation
Already tested in individual build PLRs in stage. This just configures it globally in each cluster.