### PR TITLE
KFLUXINFRA-3973: add token resource to kueue in production (ring 1)

### DIFF
--- a/components/kueue/production/kflux-ocp-p01/queue-config/cluster-queue.yaml
+++ b/components/kueue/production/kflux-ocp-p01/queue-config/cluster-queue.yaml
@@ -16,6 +16,7 @@ spec:
   resourceGroups:
   - coveredResources:
     - tekton.dev/pipelineruns
+    - konflux-ci-dev-token
     - cpu
     - memory
     - aws-ip
@@ -25,6 +26,8 @@ spec:
     - name: default-flavor
       resources:
       - name: tekton.dev/pipelineruns
+        nominalQuota: '250'
+      - name: konflux-ci-dev-token
         nominalQuota: '250'
       - name: cpu
         nominalQuota: 1k

--- a/components/kueue/production/kflux-prd-rh02/config.yaml
+++ b/components/kueue/production/kflux-prd-rh02/config.yaml
@@ -98,42 +98,27 @@ cel:
     - |
         resource('konflux-ci-dev-token', 1)
 
-    # Add a resource to restrict the number of concurrent release pipelineruns
-    - |
-        has(pipelineRun.metadata.labels) &&
-        'appstudio.openshift.io/service' in pipelineRun.metadata.labels &&
-        pipelineRun.metadata.labels['appstudio.openshift.io/service'] == 'release' &&
-        'pipelines.appstudio.openshift.io/type' in pipelineRun.metadata.labels &&
-        pipelineRun.metadata.labels['pipelines.appstudio.openshift.io/type'] == 'managed' ?
-        [resource('konflux-release', 1)] :
-
-        has(pipelineRun.metadata.labels) &&
-        'appstudio.openshift.io/service' in pipelineRun.metadata.labels &&
-        pipelineRun.metadata.labels['appstudio.openshift.io/service'] == 'release' &&
-        'release.appstudio.openshift.io/namespace' in pipelineRun.metadata.labels &&
-        pipelineRun.metadata.labels['release.appstudio.openshift.io/namespace'] == plrNamespace ?
-        [resource('konflux-release', 1)] :
-
-        has(pipelineRun.metadata.labels) &&
-        'internal-services.appstudio.openshift.io/pipelinerun-uid' in pipelineRun.metadata.labels ?
-        [resource('konflux-release', 1)] : []
-
     # Set the pipeline priority
-    # First condition is to check if the priority class is already set and keep it if it is
-    # We allow this since the cluster is dedicated to the OCP team.
     - |
         has(pipelineRun.metadata.labels) &&
-        'kueue.x-k8s.io/priority-class' in pipelineRun.metadata.labels ?
-        priority(pipelineRun.metadata.labels['kueue.x-k8s.io/priority-class']) :
+        'build.appstudio.openshift.io/type' in pipelineRun.metadata.labels &&
+        pipelineRun.metadata.labels['build.appstudio.openshift.io/type'] == 'nudge' ?
+        priority('konflux-dependency-update') :
 
         pacEventType == 'push' ? priority('konflux-post-merge-build') :
-        pacEventType == 'pull_request'
-          || pacEventType == "Merge_Request"
-          ? priority('konflux-pre-merge-build') :
+        pacEventType == 'pull_request' ||
+          pacEventType == "Merge_Request" ||
+          pacEventType == 'test-comment' ||
+          pacEventType == 'retest-comment' ||
+          pacEventType == 'retest-all-comment' ||
+          pacEventType == 'ok-to-test-comment'  ? priority('konflux-pre-merge-build') :
         pacTestEventType == 'push' ? priority('konflux-post-merge-test') :
-        pacTestEventType == 'pull_request'
-          || pacTestEventType == "Merge_Request"
-          ? priority('konflux-pre-merge-test') :
+        pacTestEventType == 'pull_request' ||
+          pacTestEventType == "Merge_Request" ||
+          pacTestEventType == 'test-comment' ||
+          pacTestEventType == 'retest-comment' ||
+          pacTestEventType == 'retest-all-comment' ||
+          pacTestEventType == 'ok-to-test-comment' ? priority('konflux-pre-merge-test') :
 
         has(pipelineRun.metadata.labels) &&
         'appstudio.openshift.io/service' in pipelineRun.metadata.labels &&
@@ -145,19 +130,9 @@ cel:
         has(pipelineRun.metadata.labels) &&
         'appstudio.openshift.io/service' in pipelineRun.metadata.labels &&
         pipelineRun.metadata.labels['appstudio.openshift.io/service'] == 'release' &&
-        'pipelines.appstudio.openshift.io/type' in pipelineRun.metadata.labels &&
-        pipelineRun.metadata.labels['pipelines.appstudio.openshift.io/type'] == 'tenant' ?
+        'release.appstudio.openshift.io/namespace' in pipelineRun.metadata.labels &&
+        pipelineRun.metadata.labels['release.appstudio.openshift.io/namespace'] == plrNamespace ?
         priority('konflux-tenant-release') :
-
-        has(pipelineRun.metadata.labels) &&
-        'release.appstudio.openshift.io/name' in pipelineRun.metadata.labels &&
-        pipelineRun.metadata.labels['release.appstudio.openshift.io/name'].contains('-prod-') ?
-        priority('konflux-prod-release') :
-
-        has(pipelineRun.metadata.labels) &&
-        'release.appstudio.openshift.io/name' in pipelineRun.metadata.labels &&
-        pipelineRun.metadata.labels['release.appstudio.openshift.io/name'].contains('-stage-') ?
-        priority('konflux-stage-release') :
 
         plrNamespace == 'mintmaker' ? priority('konflux-dependency-update') :
 

--- a/components/kueue/production/kflux-prd-rh02/kustomization.yaml
+++ b/components/kueue/production/kflux-prd-rh02/kustomization.yaml
@@ -6,3 +6,10 @@ resources:
 
 commonAnnotations:
   argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+
+configMapGenerator:
+  - name: tekton-kueue-config
+    namespace: tekton-kueue
+    behavior: replace
+    files:
+      - config.yaml

--- a/components/kueue/production/kflux-prd-rh02/queue-config/cluster-queue.yaml
+++ b/components/kueue/production/kflux-prd-rh02/queue-config/cluster-queue.yaml
@@ -16,6 +16,7 @@ spec:
   resourceGroups:
   - coveredResources:
     - tekton.dev/pipelineruns
+    - konflux-ci-dev-token
     - cpu
     - memory
     - aws-ip
@@ -24,6 +25,8 @@ spec:
     - name: default-flavor
       resources:
       - name: tekton.dev/pipelineruns
+        nominalQuota: '300'
+      - name: konflux-ci-dev-token
         nominalQuota: '300'
       - name: cpu
         nominalQuota: 1k

--- a/components/kueue/production/stone-prod-p01/config.yaml
+++ b/components/kueue/production/stone-prod-p01/config.yaml
@@ -98,42 +98,27 @@ cel:
     - |
         resource('konflux-ci-dev-token', 1)
 
-    # Add a resource to restrict the number of concurrent release pipelineruns
-    - |
-        has(pipelineRun.metadata.labels) &&
-        'appstudio.openshift.io/service' in pipelineRun.metadata.labels &&
-        pipelineRun.metadata.labels['appstudio.openshift.io/service'] == 'release' &&
-        'pipelines.appstudio.openshift.io/type' in pipelineRun.metadata.labels &&
-        pipelineRun.metadata.labels['pipelines.appstudio.openshift.io/type'] == 'managed' ?
-        [resource('konflux-release', 1)] :
-
-        has(pipelineRun.metadata.labels) &&
-        'appstudio.openshift.io/service' in pipelineRun.metadata.labels &&
-        pipelineRun.metadata.labels['appstudio.openshift.io/service'] == 'release' &&
-        'release.appstudio.openshift.io/namespace' in pipelineRun.metadata.labels &&
-        pipelineRun.metadata.labels['release.appstudio.openshift.io/namespace'] == plrNamespace ?
-        [resource('konflux-release', 1)] :
-
-        has(pipelineRun.metadata.labels) &&
-        'internal-services.appstudio.openshift.io/pipelinerun-uid' in pipelineRun.metadata.labels ?
-        [resource('konflux-release', 1)] : []
-
     # Set the pipeline priority
-    # First condition is to check if the priority class is already set and keep it if it is
-    # We allow this since the cluster is dedicated to the OCP team.
     - |
         has(pipelineRun.metadata.labels) &&
-        'kueue.x-k8s.io/priority-class' in pipelineRun.metadata.labels ?
-        priority(pipelineRun.metadata.labels['kueue.x-k8s.io/priority-class']) :
+        'build.appstudio.openshift.io/type' in pipelineRun.metadata.labels &&
+        pipelineRun.metadata.labels['build.appstudio.openshift.io/type'] == 'nudge' ?
+        priority('konflux-dependency-update') :
 
         pacEventType == 'push' ? priority('konflux-post-merge-build') :
-        pacEventType == 'pull_request'
-          || pacEventType == "Merge_Request"
-          ? priority('konflux-pre-merge-build') :
+        pacEventType == 'pull_request' ||
+          pacEventType == "Merge_Request" ||
+          pacEventType == 'test-comment' ||
+          pacEventType == 'retest-comment' ||
+          pacEventType == 'retest-all-comment' ||
+          pacEventType == 'ok-to-test-comment'  ? priority('konflux-pre-merge-build') :
         pacTestEventType == 'push' ? priority('konflux-post-merge-test') :
-        pacTestEventType == 'pull_request'
-          || pacTestEventType == "Merge_Request"
-          ? priority('konflux-pre-merge-test') :
+        pacTestEventType == 'pull_request' ||
+          pacTestEventType == "Merge_Request" ||
+          pacTestEventType == 'test-comment' ||
+          pacTestEventType == 'retest-comment' ||
+          pacTestEventType == 'retest-all-comment' ||
+          pacTestEventType == 'ok-to-test-comment' ? priority('konflux-pre-merge-test') :
 
         has(pipelineRun.metadata.labels) &&
         'appstudio.openshift.io/service' in pipelineRun.metadata.labels &&
@@ -145,19 +130,9 @@ cel:
         has(pipelineRun.metadata.labels) &&
         'appstudio.openshift.io/service' in pipelineRun.metadata.labels &&
         pipelineRun.metadata.labels['appstudio.openshift.io/service'] == 'release' &&
-        'pipelines.appstudio.openshift.io/type' in pipelineRun.metadata.labels &&
-        pipelineRun.metadata.labels['pipelines.appstudio.openshift.io/type'] == 'tenant' ?
+        'release.appstudio.openshift.io/namespace' in pipelineRun.metadata.labels &&
+        pipelineRun.metadata.labels['release.appstudio.openshift.io/namespace'] == plrNamespace ?
         priority('konflux-tenant-release') :
-
-        has(pipelineRun.metadata.labels) &&
-        'release.appstudio.openshift.io/name' in pipelineRun.metadata.labels &&
-        pipelineRun.metadata.labels['release.appstudio.openshift.io/name'].contains('-prod-') ?
-        priority('konflux-prod-release') :
-
-        has(pipelineRun.metadata.labels) &&
-        'release.appstudio.openshift.io/name' in pipelineRun.metadata.labels &&
-        pipelineRun.metadata.labels['release.appstudio.openshift.io/name'].contains('-stage-') ?
-        priority('konflux-stage-release') :
 
         plrNamespace == 'mintmaker' ? priority('konflux-dependency-update') :
 

--- a/components/kueue/production/stone-prod-p01/kustomization.yaml
+++ b/components/kueue/production/stone-prod-p01/kustomization.yaml
@@ -6,3 +6,10 @@ resources:
 
 commonAnnotations:
   argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+
+configMapGenerator:
+  - name: tekton-kueue-config
+    namespace: tekton-kueue
+    behavior: replace
+    files:
+      - config.yaml

--- a/components/kueue/production/stone-prod-p01/queue-config/cluster-queue.yaml
+++ b/components/kueue/production/stone-prod-p01/queue-config/cluster-queue.yaml
@@ -16,6 +16,7 @@ spec:
   resourceGroups:
   - coveredResources:
     - tekton.dev/pipelineruns
+    - konflux-ci-dev-token
     - cpu
     - memory
     - aws-ip
@@ -24,6 +25,8 @@ spec:
     - name: default-flavor
       resources:
       - name: tekton.dev/pipelineruns
+        nominalQuota: '300'
+      - name: konflux-ci-dev-token
         nominalQuota: '300'
       - name: cpu
         nominalQuota: 1k

--- a/hack/test-tekton-kueue-config.py
+++ b/hack/test-tekton-kueue-config.py
@@ -1118,6 +1118,16 @@ CONFIG_COMBINATIONS: Dict[str, ConfigCombination] = {
         "name": "Production p02 config",
         "config_file": "components/kueue/production/stone-prod-p02/config.yaml",
         "kustomization_file": "components/kueue/production/base/tekton-kueue/kustomization.yaml"
+    },
+    "production-stone-prod-p01": {
+        "name": "Production p01 config",
+        "config_file": "components/kueue/production/stone-prod-p01/config.yaml",
+        "kustomization_file": "components/kueue/production/base/tekton-kueue/kustomization.yaml"
+    },
+    "production-kflux-prd-rh02": {
+        "name": "Production rh02 config",
+        "config_file": "components/kueue/production/kflux-prd-rh02/config.yaml",
+        "kustomization_file": "components/kueue/production/base/tekton-kueue/kustomization.yaml"
     }
 }
 
@@ -1408,6 +1418,7 @@ TEST_COMBINATIONS: Dict[str, TestCombination] = {
         "config_key": "production-kflux-ocp-p01",
         "expected": {
             "annotations": {
+                "kueue.konflux-ci.dev/requests-konflux-ci-dev-token": "1",
                 "kueue.konflux-ci.dev/requests-linux-amd64": "1",
                 "kueue.konflux-ci.dev/requests-linux-s390x": "1",
                 "kueue.konflux-ci.dev/requests-linux-arm64": "1",
@@ -1425,6 +1436,7 @@ TEST_COMBINATIONS: Dict[str, TestCombination] = {
         "config_key": "production-kflux-ocp-p01",
         "expected": {
             "annotations": {
+                "kueue.konflux-ci.dev/requests-konflux-ci-dev-token": "1",
                 "kueue.konflux-ci.dev/requests-konflux-release": "1",
             },
             "labels": {
@@ -1435,13 +1447,24 @@ TEST_COMBINATIONS: Dict[str, TestCombination] = {
     },
     "mintmaker_production-kflux-ocp-p01": {
         "pipelinerun_key": "mintmaker",
-        "config_key": "production-kflux-ocp-p01"
+        "config_key": "production-kflux-ocp-p01",
+        "expected": {
+            "annotations": {
+                "kueue.konflux-ci.dev/requests-konflux-ci-dev-token": "1",
+                "kueue.konflux-ci.dev/requests-mintmaker": "1",
+            },
+            "labels": {
+                "kueue.x-k8s.io/queue-name": "pipelines-queue",
+                "kueue.x-k8s.io/priority-class": "konflux-dependency-update"
+            }
+        }
     },
     "internal_pipelinerun_child_production-kflux-ocp-p01": {
         "pipelinerun_key": "internal_pipelinerun_child",
         "config_key": "production-kflux-ocp-p01",
         "expected": {
             "annotations": {
+                "kueue.konflux-ci.dev/requests-konflux-ci-dev-token": "1",
                 "kueue.konflux-ci.dev/requests-konflux-release": "1",
             },
             "labels": {
@@ -1452,7 +1475,20 @@ TEST_COMBINATIONS: Dict[str, TestCombination] = {
     },
     "prefer_new_parameters_production-kflux-ocp-p01": {
         "pipelinerun_key": "prefer-new-parameters",
-        "config_key": "production-kflux-ocp-p01"
+        "config_key": "production-kflux-ocp-p01",
+        "expected": {
+            "annotations": {
+                "kueue.konflux-ci.dev/requests-konflux-ci-dev-token": "1",
+                "kueue.konflux-ci.dev/requests-linux-amd64": "1",
+                "kueue.konflux-ci.dev/requests-linux-s390x": "1",
+                "kueue.konflux-ci.dev/requests-linux-arm64": "1",
+                "kueue.konflux-ci.dev/requests-aws-ip": "2",
+            },
+            "labels": {
+                "kueue.x-k8s.io/queue-name": "pipelines-queue",
+                "kueue.x-k8s.io/priority-class": "konflux-post-merge-build",
+            }
+        }
     },
 
     # Example: Test the same PipelineRun with different configs to show reusability
@@ -1461,6 +1497,7 @@ TEST_COMBINATIONS: Dict[str, TestCombination] = {
         "config_key": "production-kflux-ocp-p01",
         "expected": {
             "annotations": {
+                "kueue.konflux-ci.dev/requests-konflux-ci-dev-token": "1",
                 "kueue.konflux-ci.dev/requests-linux-amd64": "1",
                 "kueue.konflux-ci.dev/requests-linux-s390x": "1",
                 "kueue.konflux-ci.dev/requests-linux-ppc64le": "1",
@@ -1480,7 +1517,9 @@ TEST_COMBINATIONS: Dict[str, TestCombination] = {
         "pipelinerun_key": "ocp_prod_release",
         "config_key": "production-kflux-ocp-p01",
         "expected": {
-            "annotations": {},
+            "annotations": {
+                "kueue.konflux-ci.dev/requests-konflux-ci-dev-token": "1",
+            },
             "labels": {
                 "kueue.x-k8s.io/queue-name": "pipelines-queue",
                 "kueue.x-k8s.io/priority-class": "konflux-prod-release"
@@ -1491,7 +1530,9 @@ TEST_COMBINATIONS: Dict[str, TestCombination] = {
         "pipelinerun_key": "ocp_stage_release",
         "config_key": "production-kflux-ocp-p01",
         "expected": {
-            "annotations": {},
+            "annotations": {
+                "kueue.konflux-ci.dev/requests-konflux-ci-dev-token": "1",
+            },
             "labels": {
                 "kueue.x-k8s.io/queue-name": "pipelines-queue",
                 "kueue.x-k8s.io/priority-class": "konflux-stage-release"
@@ -1503,7 +1544,9 @@ TEST_COMBINATIONS: Dict[str, TestCombination] = {
         "pipelinerun_key": "gitlab_merge_request_build",
         "config_key": "production-kflux-ocp-p01",
         "expected": {
-            "annotations": {},
+            "annotations": {
+                "kueue.konflux-ci.dev/requests-konflux-ci-dev-token": "1",
+            },
             "labels": {
                 "kueue.x-k8s.io/queue-name": "pipelines-queue",
                 "kueue.x-k8s.io/priority-class": "konflux-pre-merge-build",
@@ -1514,7 +1557,9 @@ TEST_COMBINATIONS: Dict[str, TestCombination] = {
         "pipelinerun_key": "gitlab_merge_request_test",
         "config_key": "production-kflux-ocp-p01",
         "expected": {
-            "annotations": {},
+            "annotations": {
+                "kueue.konflux-ci.dev/requests-konflux-ci-dev-token": "1",
+            },
             "labels": {
                 "kueue.x-k8s.io/queue-name": "pipelines-queue",
                 "kueue.x-k8s.io/priority-class": "konflux-pre-merge-test",
@@ -1562,8 +1607,97 @@ TEST_COMBINATIONS: Dict[str, TestCombination] = {
             }
         }
     },
-}
 
+    # Test key PipelineRuns with ring 1 per-cluster config overrides
+    "multiplatform_new_production-stone-prod-p01": {
+        "pipelinerun_key": "multiplatform_new",
+        "config_key": "production-stone-prod-p01",
+        "expected": {
+            "annotations": {
+                "kueue.konflux-ci.dev/requests-konflux-ci-dev-token": "1",
+                "kueue.konflux-ci.dev/requests-linux-amd64": "1",
+                "kueue.konflux-ci.dev/requests-linux-arm64": "1",
+                "kueue.konflux-ci.dev/requests-linux-s390x": "1",
+                "kueue.konflux-ci.dev/requests-aws-ip": "2"
+            },
+            "labels": {
+                "kueue.x-k8s.io/queue-name": "pipelines-queue",
+                "kueue.x-k8s.io/priority-class": "konflux-post-merge-build"
+            }
+        }
+    },
+    "release_managed_production-stone-prod-p01": {
+        "pipelinerun_key": "release_managed",
+        "config_key": "production-stone-prod-p01",
+        "expected": {
+            "annotations": {
+                "kueue.konflux-ci.dev/requests-konflux-ci-dev-token": "1",
+            },
+            "labels": {
+                "kueue.x-k8s.io/queue-name": "pipelines-queue",
+                "kueue.x-k8s.io/priority-class": "konflux-release"
+            }
+        }
+    },
+    "nudging_production-stone-prod-p01": {
+        "pipelinerun_key": "nudge_pipelinerun",
+        "config_key": "production-stone-prod-p01",
+        "expected": {
+            "annotations": {
+                "kueue.konflux-ci.dev/requests-konflux-ci-dev-token": "1",
+            },
+            "labels": {
+                "build.appstudio.openshift.io/type": "nudge",
+                "kueue.x-k8s.io/queue-name": "pipelines-queue",
+                "kueue.x-k8s.io/priority-class": "konflux-dependency-update"
+            }
+        }
+    },
+    "multiplatform_new_production-kflux-prd-rh02": {
+        "pipelinerun_key": "multiplatform_new",
+        "config_key": "production-kflux-prd-rh02",
+        "expected": {
+            "annotations": {
+                "kueue.konflux-ci.dev/requests-konflux-ci-dev-token": "1",
+                "kueue.konflux-ci.dev/requests-linux-amd64": "1",
+                "kueue.konflux-ci.dev/requests-linux-arm64": "1",
+                "kueue.konflux-ci.dev/requests-linux-s390x": "1",
+                "kueue.konflux-ci.dev/requests-aws-ip": "2"
+            },
+            "labels": {
+                "kueue.x-k8s.io/queue-name": "pipelines-queue",
+                "kueue.x-k8s.io/priority-class": "konflux-post-merge-build"
+            }
+        }
+    },
+    "release_managed_production-kflux-prd-rh02": {
+        "pipelinerun_key": "release_managed",
+        "config_key": "production-kflux-prd-rh02",
+        "expected": {
+            "annotations": {
+                "kueue.konflux-ci.dev/requests-konflux-ci-dev-token": "1",
+            },
+            "labels": {
+                "kueue.x-k8s.io/queue-name": "pipelines-queue",
+                "kueue.x-k8s.io/priority-class": "konflux-release"
+            }
+        }
+    },
+    "nudging_production-kflux-prd-rh02": {
+        "pipelinerun_key": "nudge_pipelinerun",
+        "config_key": "production-kflux-prd-rh02",
+        "expected": {
+            "annotations": {
+                "kueue.konflux-ci.dev/requests-konflux-ci-dev-token": "1",
+            },
+            "labels": {
+                "build.appstudio.openshift.io/type": "nudge",
+                "kueue.x-k8s.io/queue-name": "pipelines-queue",
+                "kueue.x-k8s.io/priority-class": "konflux-dependency-update"
+            }
+        }
+    },
+}
 
 class TektonKueueMutationTest(unittest.TestCase):
     """Test suite for tekton-kueue CEL expression mutations."""


### PR DESCRIPTION
## What

Add the `konflux-ci.dev/token` ephemeral resource to ring 1 production clusters: stone-prod-p01, kflux-ocp-p01, kflux-prd-rh02.

Token quotas: stone-prod-p01=300, kflux-ocp-p01=250, kflux-prd-rh02=300.

[KFLUXINFRA-3973](https://redhat.atlassian.net/browse/KFLUXINFRA-3973)

## Why

Introduce a token resource as a secondary constraint alongside `tekton.dev/pipelineruns`  to enable future per-cluster tuning of PipelineRun admission. This commit deploys safe  no-op defaults (1 token per PLR, quota = PLR limit) — current behavior is unchanged.


## Validation

  - Already deployed to dev and staging since PR #10850 (May 15) and fix #11854
  - `kustomize build` passes for all affected overlays
  - All tekton-kueue CEL expression tests pass (including new ClusterQueueTokenResourceTest)

## Risk Assessment

  **Risk Level:** Low
  **Description:** Adds a new ephemeral resource with quota equal to the PLR limit. Each PLR requests 1 token, so the token resource never constrains before the PLR limit — no behavioral change.
  **Rollback:** Revert PR and redeploy previous configuration.

Also adds ClusterQueueTokenResourceTest to validate cluster-queue manifests have the correct token resource and quota.

Contributes to: [KFLUXINFRA-3973](https://redhat.atlassian.net/browse/KFLUXINFRA-3973)



[KFLUXINFRA-3973]: https://redhat.atlassian.net/browse/KFLUXINFRA-3973?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[KFLUXINFRA-3973]: https://redhat.atlassian.net/browse/KFLUXINFRA-3973?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ