### PR TITLE
PVO11Y-5265 Fix collect-results script path in kanary task

### DIFF
--- a/components/monitoring/kanary/staging/base/tasks/run-kanary-tests.yaml
+++ b/components/monitoring/kanary/staging/base/tasks/run-kanary-tests.yaml
@@ -170,7 +170,7 @@ spec:
         # to distinguish test failures from script errors.
         set -uo pipefail
         KANARY_FAIL_CODE=42
-        ci-scripts/stage/collect-results-probe.sh --tests-dir . --exit-on-fail "$KANARY_FAIL_CODE"
+        ./ci-scripts/run-probe/collect-results.sh --tests-dir . --exit-on-fail "$KANARY_FAIL_CODE"
         exit_code=$?
         if [[ "$exit_code" -eq 0 ]]; then
           echo -n "passed" > $(results.test-outcome.path)


### PR DESCRIPTION
## Summary
- Fix collect-results script path: `ci-scripts/stage/collect-results-probe.sh` does not exist in the current loadtest image — the correct path is `./ci-scripts/run-probe/collect-results.sh`

Jira: https://redhat.atlassian.net/browse/PVO11Y-5265

## Risk Assessment
**Risk Level:** Low
**Description:** Fixes a broken script path in the collect-results step
**Rollback:** Revert PR

## Validation
- [x] `kustomize build components/monitoring/kanary/staging/stone-stage-p01/` passes
- [x] `kustomize build components/monitoring/kanary/staging/stone-stg-rh01/` passes