### PR TITLE
Update release-service staging to 9775e0df9cb

### DIFF
--- a/components/monitoring/grafana/staging/dashboards/release/kustomization.yaml
+++ b/components/monitoring/grafana/staging/dashboards/release/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- https://github.com/konflux-ci/release-service/config/grafana/?ref=3abc5019c03b3b1b52eb3742b4a29ecf00784e0f
+- https://github.com/konflux-ci/release-service/config/grafana/?ref=9775e0df9cb3fc38026907595a821c87e62b1684

--- a/components/release/staging/kustomization.yaml
+++ b/components/release/staging/kustomization.yaml
@@ -4,7 +4,7 @@ resources:
   - ../base
   - ../base/monitor/staging
   - external-secrets/release-monitor-secret.yaml
-  - https://github.com/konflux-ci/release-service/config/default?ref=3abc5019c03b3b1b52eb3742b4a29ecf00784e0f
+  - https://github.com/konflux-ci/release-service/config/default?ref=9775e0df9cb3fc38026907595a821c87e62b1684
   - release_service_config.yaml
   - signing_configs.yaml
 
@@ -14,6 +14,6 @@ components:
 images:
   - name: quay.io/konflux-ci/release-service
     newName: quay.io/konflux-ci/release-service
-    newTag: 3abc5019c03b3b1b52eb3742b4a29ecf00784e0f
+    newTag: 9775e0df9cb3fc38026907595a821c87e62b1684
 
 namespace: release-service


### PR DESCRIPTION
This updates release-service in staging to match the deployment previously applied to development in PR #12468.

Included changes:
- feat([RELEASE-2122](https://redhat.atlassian.net/browse/RELEASE-2122)): add retry info to ReleasePlanAdmission status
- test([RELEASE-2122](https://redhat.atlassian.net/browse/RELEASE-2122)): add tests for controller and predicates  
- chore: add Qodo PR-Agent configuration
- chore(actions): bump securego/gosec
- chore(deps): update konflux references to a542b5a
- fix(deps): update coverport instrumentation digest to e33f1c6

## Validation
Development deployment has been running with these changes since PR #12468 was merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[RELEASE-2122]: https://redhat.atlassian.net/browse/RELEASE-2122?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RELEASE-2122]: https://redhat.atlassian.net/browse/RELEASE-2122?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ