### PR TITLE
Exclude imagestreams from OADP backup schedule (staging)

### DIFF
--- a/components/backup/staging/stone-stage-p01/exclude-imagestreams-patch.yaml
+++ b/components/backup/staging/stone-stage-p01/exclude-imagestreams-patch.yaml
@@ -1,0 +1,3 @@
+- op: add
+  path: /spec/template/excludedResources/-
+  value: imagestreams.image.openshift.io

--- a/components/backup/staging/stone-stage-p01/kustomization.yaml
+++ b/components/backup/staging/stone-stage-p01/kustomization.yaml
@@ -27,3 +27,9 @@ patches:
     kind: Subscription
     name: redhat-oadp-operator
     version: v1alpha1
+- path: exclude-imagestreams-patch.yaml
+  target:
+    group: velero.io
+    kind: Schedule
+    name: backup-tenants
+    version: v1

--- a/components/backup/staging/stone-stg-rh01/exclude-imagestreams-patch.yaml
+++ b/components/backup/staging/stone-stg-rh01/exclude-imagestreams-patch.yaml
@@ -1,0 +1,3 @@
+- op: add
+  path: /spec/template/excludedResources/-
+  value: imagestreams.image.openshift.io

--- a/components/backup/staging/stone-stg-rh01/kustomization.yaml
+++ b/components/backup/staging/stone-stg-rh01/kustomization.yaml
@@ -27,3 +27,9 @@ patches:
     kind: Subscription
     name: redhat-oadp-operator
     version: v1alpha1
+- path: exclude-imagestreams-patch.yaml
+  target:
+    group: velero.io
+    kind: Schedule
+    name: backup-tenants
+    version: v1


### PR DESCRIPTION
## Summary
- Adds `imagestreams.image.openshift.io` to `excludedResources` in the Velero backup schedule for staging clusters (`stone-stage-p01`, `stone-stg-rh01`)
- Prevents OADP backups from reporting `PartiallyFailed` due to imagestream copy failures

## Problem
The OADP openshift velero plugin (`OPENSHIFT_IMAGESTREAM_BACKUP=true`) attempts to copy imagestream image layers during backup. When an imagestream exists in a non-excluded namespace (e.g. `art-cd` in `art-pipelines-tenant` on production), the plugin incorrectly resolves the backup registry to `registry-1.docker.io` instead of the internal OpenShift registry, causing a `500 Internal Server Error`.

This was observed on the production cluster `kflux-ocp-p01`, where every scheduled backup (every 4 hours) has reported `PartiallyFailed` with 1 error since the imagestream was created on May 15. This PR applies the fix to staging first per the environment separation process.

## Fix
Exclude `imagestreams.image.openshift.io` from the backup schedule's `excludedResources` via a kustomize patch in each staging overlay. ImageStreams are build artifacts that can be rebuilt from source (BuildConfigs + git), so excluding them does not result in meaningful data loss.

## Jira
- [KFLUXINFRA-4001](https://redhat.atlassian.net/browse/KFLUXINFRA-4001)

## Risk Assessment

**Risk Level:** Low
**Description:** This change only excludes ImageStream resources from Velero backup. ImageStreams are build artifacts that reference images already stored in the internal registry and can be recreated from existing BuildConfigs and source repositories. No persistent data, secrets, or application state is affected. The backup schedule, frequency, and all other backed-up resources remain unchanged.
**Rollback:** Remove the `exclude-imagestreams-patch.yaml` files and the corresponding patch entries from the staging kustomization files, then let ArgoCD sync.

## Validation

Staging PR: https://github.com/redhat-appstudio/infra-deployments/pull/12550

## Test plan
- [x] Verify kustomize build succeeds for staging overlays
- [ ] After ArgoCD sync, trigger a manual Velero backup on a staging cluster and confirm `Completed` status (no `PartiallyFailed`)
- [ ] Verify the next scheduled backup completes without errors
- [ ] After 1-day soak, open production PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[KFLUXINFRA-4001]: https://redhat.atlassian.net/browse/KFLUXINFRA-4001?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ