### PR TITLE
fix: use newTag instead of digest for image references

### DIFF
--- a/components/external-secrets-operator/staging/kustomization.yaml
+++ b/components/external-secrets-operator/staging/kustomization.yaml
@@ -22,4 +22,4 @@ helmCharts:
 images:
 - name: ghcr.io/external-secrets/external-secrets
   newName: quay.io/konflux-ci/external-secrets-operator
-  digest: sha256:993ef0aec0688bba8fc5b428b215ed46eef4d49f6dea0db8e5d37058606f762e
+  newTag: 81c0813fffc8a65f05376d7d80e1cfd39676a6a3

--- a/components/konflux-ui/staging/base/kustomization.yaml
+++ b/components/konflux-ui/staging/base/kustomization.yaml
@@ -15,6 +15,6 @@ images:
     newTag: 0bbc783b168bdc396eca145d54eb016b837a0d85
 
   - name: quay.io/konflux-ci/oauth2-proxy
-    digest: sha256:87a8794d4bb98472fab47f14bb28e4d9ec24d7426107028bd1aa780e260ff8e3
+    newTag: 7857e1959daed4df06263532c42d1da41acc00d8
 
 namespace: konflux-ui


### PR DESCRIPTION
The kustomization files for external-secrets-operator and oauth2-proxy were using digest: fields to pin container images. The release automation (infra-deployment-update-script in the RPAs) writes {{ revision }} — a git commit SHA — into these fields, producing invalid image references (a bare 40-char hex string instead of sha256:<64-char>). This caused kube-linter latest-tag failures on every release PR.

Switch both to newTag: with the git SHA tag that points to the same image, consistent with all other Konflux infra components.

No image version change: the newTag values resolve to the exact same container images as the previous digests:
- external-secrets-operator: 81c0813f... -> sha256:993ef0ae...
- oauth2-proxy: 7857e195... -> sha256:87a8794d...

Related MR on konflux-release-data: https://gitlab.cee.redhat.com/releng/konflux-release-data/-/merge_requests/19254
