### PR TITLE
SPRE-4610: bump internal-infra-deployments ref for production nexus probes

### DIFF
--- a/components/monitoring/blackbox/production/kflux-fedora-01/kustomization.yaml
+++ b/components/monitoring/blackbox/production/kflux-fedora-01/kustomization.yaml
@@ -1,6 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
- - https://github.com/redhat-appstudio/internal-infra-deployments/components/monitoring/blackbox-exporter/production/public/kflux-fedora-01?ref=57ee9093ab7539f7f273b0754e0d66375aa32205
+ - https://github.com/redhat-appstudio/internal-infra-deployments/components/monitoring/blackbox-exporter/production/public/kflux-fedora-01?ref=1ba403cfaba09e313e3b9061aee926b8435f14c2
 
 namespace: appstudio-monitoring

--- a/components/monitoring/blackbox/production/kflux-ocp-p01/kustomization.yaml
+++ b/components/monitoring/blackbox/production/kflux-ocp-p01/kustomization.yaml
@@ -1,6 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
- - https://github.com/redhat-appstudio/internal-infra-deployments/components/monitoring/blackbox-exporter/production/private/kflux-ocp-p01?ref=57ee9093ab7539f7f273b0754e0d66375aa32205
+ - https://github.com/redhat-appstudio/internal-infra-deployments/components/monitoring/blackbox-exporter/production/private/kflux-ocp-p01?ref=1ba403cfaba09e313e3b9061aee926b8435f14c2
 
 namespace: appstudio-monitoring

--- a/components/monitoring/blackbox/production/kflux-osp-p01/kustomization.yaml
+++ b/components/monitoring/blackbox/production/kflux-osp-p01/kustomization.yaml
@@ -1,6 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
- - https://github.com/redhat-appstudio/internal-infra-deployments/components/monitoring/blackbox-exporter/production/private/kflux-osp-p01?ref=57ee9093ab7539f7f273b0754e0d66375aa32205
+ - https://github.com/redhat-appstudio/internal-infra-deployments/components/monitoring/blackbox-exporter/production/private/kflux-osp-p01?ref=1ba403cfaba09e313e3b9061aee926b8435f14c2
 
 namespace: appstudio-monitoring

--- a/components/monitoring/blackbox/production/kflux-prd-rh02/kustomization.yaml
+++ b/components/monitoring/blackbox/production/kflux-prd-rh02/kustomization.yaml
@@ -1,6 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
- - https://github.com/redhat-appstudio/internal-infra-deployments/components/monitoring/blackbox-exporter/production/public/kflux-prd-rh02?ref=57ee9093ab7539f7f273b0754e0d66375aa32205
+ - https://github.com/redhat-appstudio/internal-infra-deployments/components/monitoring/blackbox-exporter/production/public/kflux-prd-rh02?ref=1ba403cfaba09e313e3b9061aee926b8435f14c2
 
 namespace: appstudio-monitoring

--- a/components/monitoring/blackbox/production/kflux-prd-rh03/kustomization.yaml
+++ b/components/monitoring/blackbox/production/kflux-prd-rh03/kustomization.yaml
@@ -1,6 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
- - https://github.com/redhat-appstudio/internal-infra-deployments/components/monitoring/blackbox-exporter/production/public/kflux-prd-rh03?ref=57ee9093ab7539f7f273b0754e0d66375aa32205
+ - https://github.com/redhat-appstudio/internal-infra-deployments/components/monitoring/blackbox-exporter/production/public/kflux-prd-rh03?ref=1ba403cfaba09e313e3b9061aee926b8435f14c2
 
 namespace: appstudio-monitoring

--- a/components/monitoring/blackbox/production/kflux-rhel-p01/kustomization.yaml
+++ b/components/monitoring/blackbox/production/kflux-rhel-p01/kustomization.yaml
@@ -1,6 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
- - https://github.com/redhat-appstudio/internal-infra-deployments/components/monitoring/blackbox-exporter/production/private/kflux-rhel-p01?ref=57ee9093ab7539f7f273b0754e0d66375aa32205
+ - https://github.com/redhat-appstudio/internal-infra-deployments/components/monitoring/blackbox-exporter/production/private/kflux-rhel-p01?ref=1ba403cfaba09e313e3b9061aee926b8435f14c2
 
 namespace: appstudio-monitoring

--- a/components/monitoring/blackbox/production/stone-prd-rh01/kustomization.yaml
+++ b/components/monitoring/blackbox/production/stone-prd-rh01/kustomization.yaml
@@ -1,6 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
- - https://github.com/redhat-appstudio/internal-infra-deployments/components/monitoring/blackbox-exporter/production/public/stone-prd-rh01?ref=57ee9093ab7539f7f273b0754e0d66375aa32205
+ - https://github.com/redhat-appstudio/internal-infra-deployments/components/monitoring/blackbox-exporter/production/public/stone-prd-rh01?ref=1ba403cfaba09e313e3b9061aee926b8435f14c2
 
 namespace: appstudio-monitoring

--- a/components/monitoring/blackbox/production/stone-prod-p01/kustomization.yaml
+++ b/components/monitoring/blackbox/production/stone-prod-p01/kustomization.yaml
@@ -1,6 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
- - https://github.com/redhat-appstudio/internal-infra-deployments/components/monitoring/blackbox-exporter/production/private/stone-prod-p01?ref=57ee9093ab7539f7f273b0754e0d66375aa32205
+ - https://github.com/redhat-appstudio/internal-infra-deployments/components/monitoring/blackbox-exporter/production/private/stone-prod-p01?ref=1ba403cfaba09e313e3b9061aee926b8435f14c2
 
 namespace: appstudio-monitoring

--- a/components/monitoring/blackbox/production/stone-prod-p02/kustomization.yaml
+++ b/components/monitoring/blackbox/production/stone-prod-p02/kustomization.yaml
@@ -1,6 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
- - https://github.com/redhat-appstudio/internal-infra-deployments/components/monitoring/blackbox-exporter/production/private/stone-prod-p02?ref=57ee9093ab7539f7f273b0754e0d66375aa32205
+ - https://github.com/redhat-appstudio/internal-infra-deployments/components/monitoring/blackbox-exporter/production/private/stone-prod-p02?ref=1ba403cfaba09e313e3b9061aee926b8435f14c2
 
 namespace: appstudio-monitoring


### PR DESCRIPTION
● ## Summary
   
  Updates the `internal-infra-deployments` kustomization ref for all 9 production
  clusters to `1ba403cfaba09e313e3b9061aee926b8435f14c2`.

  This picks up Nexus blackbox probes covering two distinct failure modes: Nexus
  process going down entirely, and Nexus entering read-only mode due to a full disk.
  Both endpoints return `200 OK` without credentials and are publicly accessible.

  Changes included in this ref:

  - `nexus-liveness-probe` - `jobName: "nexus-liveness"` - probes `/service/rest/v1/status`
  - `nexus-writable-probe` - `jobName: "nexus-writable"` - probes `/service/rest/v1/status/writable`

  ## Risk Assessment

  **Risk Level:** Low

  **Description:** Read-only addition of monitoring resources. No service availability
  is affected. New `probe_success` series will be established with `job="nexus-liveness"`
  and `job="nexus-writable"` labels per cluster.

  **Rollback Plan:** Revert the kustomization ref back to
  `57ee9093ab7539f7f273b0754e0d66375aa32205` in all 9 production cluster
  kustomization files.

  ## Validation

  Staging changes were applied and merged successfully before this production PR.

  Staging PR merged successfully: [redhat-appstudio/internal-infra-deployments#98](https://github.com/redhat-appstudio/internal-infra-deployments/pull/98)
  Refs: [SPRE-4610](https://redhat.atlassian.net/browse/SPRE-4610)

[SPRE-4610]: https://redhat.atlassian.net/browse/SPRE-4610?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ