### PR TITLE
Add serviceaccounttoken-manager RBAC for managed-konflux-perfscale-tenant

### DIFF
--- a/components/perf-team-prometheus-reader/base/tenants-rbac/kustomization.yaml
+++ b/components/perf-team-prometheus-reader/base/tenants-rbac/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
   - konflux-perfscale-2-tenant
   - konflux-perfscale-3-tenant
   - konflux-perfscale-4-tenant
+  - managed-konflux-perfscale-tenant

--- a/components/perf-team-prometheus-reader/base/tenants-rbac/managed-konflux-perfscale-tenant/kustomization.yaml
+++ b/components/perf-team-prometheus-reader/base/tenants-rbac/managed-konflux-perfscale-tenant/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - tenant-rbac.yaml

--- a/components/perf-team-prometheus-reader/base/tenants-rbac/managed-konflux-perfscale-tenant/tenant-rbac.yaml
+++ b/components/perf-team-prometheus-reader/base/tenants-rbac/managed-konflux-perfscale-tenant/tenant-rbac.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: serviceaccounttoken-manager
+  namespace: managed-konflux-perfscale-tenant
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts/token
+  verbs:
+  - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: serviceaccounttoken-manager:konflux-perfscale
+  namespace: managed-konflux-perfscale-tenant
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: serviceaccounttoken-manager
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: konflux-performance

--- a/components/perf-team-prometheus-reader/development/namespaces/kustomization.yaml
+++ b/components/perf-team-prometheus-reader/development/namespaces/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
   - konflux-perfscale-2-tenant.yaml
   - konflux-perfscale-3-tenant.yaml
   - konflux-perfscale-4-tenant.yaml
+  - managed-konflux-perfscale-tenant.yaml

--- a/components/perf-team-prometheus-reader/development/namespaces/managed-konflux-perfscale-tenant.yaml
+++ b/components/perf-team-prometheus-reader/development/namespaces/managed-konflux-perfscale-tenant.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: managed-konflux-perfscale-tenant


### PR DESCRIPTION
## What

- Add `managed-konflux-perfscale-tenant` namespace in the development overlay
- Add Role and RoleBinding for `serviceaccounttoken-manager` in the
  `managed-konflux-perfscale-tenant` namespace (dev + staging via shared base),
  allowing the `konflux-performance` group to create `serviceaccounts/tokens`

Clusters affected: development, staging

## Why

The perf team needs the ability to create service account tokens in the
managed-konflux-perfscale-tenant namespace.

## Validation

- `kustomize build components/perf-team-prometheus-reader/development/` passes
- `kustomize build components/perf-team-prometheus-reader/staging/base/` passes

## Follow-up

Production PR with copies of these resources into `production/base/` will follow
after soaking in staging.