### PR TITLE
Deploy PaC v0.48.0 to Konflux production - Ring 1

### DIFF
--- a/components/pipeline-service/production/kflux-fedora-01/deploy.yaml
+++ b/components/pipeline-service/production/kflux-fedora-01/deploy.yaml
@@ -2575,6 +2575,14 @@ spec:
       value: "false"
     - name: IMAGE_PIPELINES_CONTROLLER
       value: quay.io/openshift-pipeline/pipelines-resolvers-rhel9@sha256:7cd91bc4c0f3469ec4c39d08d818b00c90ce07456364910e49ad5e1430f3110a
+    - name: IMAGE_PAC_PAC_CONTROLLER
+      value: quay.io/openshift-pipeline/pipelines-pipelines-as-code-controller-rhel9@sha256:1b1e365cfdcc85646d5890232a04bad8c7ba9ebb0db36042eeda5961f8106567
+    - name: IMAGE_PAC_PAC_WEBHOOK
+      value: quay.io/openshift-pipeline/pipelines-pipelines-as-code-webhook-rhel9@sha256:0ccda15a17a405020fa199b3dce4a630e592da9dfdbd9778be1dcc9f4bdc3fbd
+    - name: IMAGE_PAC_PAC_WATCHER
+      value: quay.io/openshift-pipeline/pipelines-pipelines-as-code-watcher-rhel9@sha256:d100578068feb5482e2631b4fadc80b9687f129c7e303b55431ac41ce58f7758
+    - name: IMAGE_PAC_PAC_CLI
+      value: quay.io/openshift-pipeline/pipelines-pipelines-as-code-cli-rhel9@sha256:0fc0dd05236f14265e25cc770a7f9f3aeea2e27964a730dac39cf9f61d349bde
   name: openshift-pipelines-operator-rh
   source: custom-operators
   sourceNamespace: openshift-marketplace

--- a/components/pipeline-service/production/kflux-osp-p01/deploy.yaml
+++ b/components/pipeline-service/production/kflux-osp-p01/deploy.yaml
@@ -2562,6 +2562,14 @@ spec:
       value: "false"
     - name: IMAGE_PIPELINES_CONTROLLER
       value: quay.io/openshift-pipeline/pipelines-resolvers-rhel9@sha256:7cd91bc4c0f3469ec4c39d08d818b00c90ce07456364910e49ad5e1430f3110a
+    - name: IMAGE_PAC_PAC_CONTROLLER
+      value: quay.io/openshift-pipeline/pipelines-pipelines-as-code-controller-rhel9@sha256:1b1e365cfdcc85646d5890232a04bad8c7ba9ebb0db36042eeda5961f8106567
+    - name: IMAGE_PAC_PAC_WEBHOOK
+      value: quay.io/openshift-pipeline/pipelines-pipelines-as-code-webhook-rhel9@sha256:0ccda15a17a405020fa199b3dce4a630e592da9dfdbd9778be1dcc9f4bdc3fbd
+    - name: IMAGE_PAC_PAC_WATCHER
+      value: quay.io/openshift-pipeline/pipelines-pipelines-as-code-watcher-rhel9@sha256:d100578068feb5482e2631b4fadc80b9687f129c7e303b55431ac41ce58f7758
+    - name: IMAGE_PAC_PAC_CLI
+      value: quay.io/openshift-pipeline/pipelines-pipelines-as-code-cli-rhel9@sha256:0fc0dd05236f14265e25cc770a7f9f3aeea2e27964a730dac39cf9f61d349bde
   name: openshift-pipelines-operator-rh
   source: custom-operators
   sourceNamespace: openshift-marketplace

--- a/components/pipeline-service/production/rings/ring-1/kustomization.yaml
+++ b/components/pipeline-service/production/rings/ring-1/kustomization.yaml
@@ -8,4 +8,29 @@ kind: Kustomization
 resources:
   - ../../base
 
-patches: []
+patches:
+  - target:
+      kind: Subscription
+      name: openshift-pipelines-operator
+    patch: |-
+      # TODO: remove these when upgrading to a bundle including Pipelines as Code v0.48.0+
+      - op: add
+        path: /spec/config/env/-
+        value:
+          name: IMAGE_PAC_PAC_CONTROLLER
+          value: "quay.io/openshift-pipeline/pipelines-pipelines-as-code-controller-rhel9@sha256:1b1e365cfdcc85646d5890232a04bad8c7ba9ebb0db36042eeda5961f8106567"
+      - op: add
+        path: /spec/config/env/-
+        value:
+          name: IMAGE_PAC_PAC_WEBHOOK
+          value: "quay.io/openshift-pipeline/pipelines-pipelines-as-code-webhook-rhel9@sha256:0ccda15a17a405020fa199b3dce4a630e592da9dfdbd9778be1dcc9f4bdc3fbd"
+      - op: add
+        path: /spec/config/env/-
+        value:
+          name: IMAGE_PAC_PAC_WATCHER
+          value: "quay.io/openshift-pipeline/pipelines-pipelines-as-code-watcher-rhel9@sha256:d100578068feb5482e2631b4fadc80b9687f129c7e303b55431ac41ce58f7758"
+      - op: add
+        path: /spec/config/env/-
+        value:
+          name: IMAGE_PAC_PAC_CLI
+          value: "quay.io/openshift-pipeline/pipelines-pipelines-as-code-cli-rhel9@sha256:0fc0dd05236f14265e25cc770a7f9f3aeea2e27964a730dac39cf9f61d349bde"

--- a/components/pipeline-service/production/stone-prod-p01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prod-p01/deploy.yaml
@@ -2562,6 +2562,14 @@ spec:
       value: "false"
     - name: IMAGE_PIPELINES_CONTROLLER
       value: quay.io/openshift-pipeline/pipelines-resolvers-rhel9@sha256:7cd91bc4c0f3469ec4c39d08d818b00c90ce07456364910e49ad5e1430f3110a
+    - name: IMAGE_PAC_PAC_CONTROLLER
+      value: quay.io/openshift-pipeline/pipelines-pipelines-as-code-controller-rhel9@sha256:1b1e365cfdcc85646d5890232a04bad8c7ba9ebb0db36042eeda5961f8106567
+    - name: IMAGE_PAC_PAC_WEBHOOK
+      value: quay.io/openshift-pipeline/pipelines-pipelines-as-code-webhook-rhel9@sha256:0ccda15a17a405020fa199b3dce4a630e592da9dfdbd9778be1dcc9f4bdc3fbd
+    - name: IMAGE_PAC_PAC_WATCHER
+      value: quay.io/openshift-pipeline/pipelines-pipelines-as-code-watcher-rhel9@sha256:d100578068feb5482e2631b4fadc80b9687f129c7e303b55431ac41ce58f7758
+    - name: IMAGE_PAC_PAC_CLI
+      value: quay.io/openshift-pipeline/pipelines-pipelines-as-code-cli-rhel9@sha256:0fc0dd05236f14265e25cc770a7f9f3aeea2e27964a730dac39cf9f61d349bde
   name: openshift-pipelines-operator-rh
   source: custom-operators
   sourceNamespace: openshift-marketplace


### PR DESCRIPTION
Promotion of staging PR https://github.com/redhat-appstudio/infra-deployments/pull/12252

Ring PRs: 
- Ring 1: https://github.com/redhat-appstudio/infra-deployments/pull/12566 (this PR)
- Ring 2: https://github.com/redhat-appstudio/infra-deployments/pull/12567
- Ring 3: https://github.com/redhat-appstudio/infra-deployments/pull/12568

Overrides the Pipelines as Code images to use Security Release v0.48.0

Full changelog here: https://github.com/tektoncd/pipelines-as-code/releases/tag/v0.48.0
Additional Context here: 
- slack thread: https://redhat-internal.slack.com/archives/CG5GV6CJD/p1780607633123779?thread_ts=1780431728.634749&cid=CG5GV6CJD
- ticket: https://redhat.atlassian.net/browse/SRVKP-12455