### PR TITLE
Deploy PaC v0.48.0 to Konflux production and disable Tekton Events Controller - Ring 3

### DIFF
--- a/components/pipeline-service/production/base/main-pipeline-service-configuration.yaml
+++ b/components/pipeline-service/production/base/main-pipeline-service-configuration.yaml
@@ -2092,6 +2092,15 @@ spec:
       # the pipelines-controller uses IMAGE_PIPELINES_TEKTON_PIPELINES_CONTROLLER
       - name: IMAGE_PIPELINES_CONTROLLER
         value: quay.io/openshift-pipeline/pipelines-resolvers-rhel9@sha256:7cd91bc4c0f3469ec4c39d08d818b00c90ce07456364910e49ad5e1430f3110a
+      # TODO: remove these when upgrading to a bundle including Pipelines as Code v0.48.0+
+      - name: IMAGE_PAC_PAC_CONTROLLER
+        value: "quay.io/openshift-pipeline/pipelines-pipelines-as-code-controller-rhel9@sha256:1b1e365cfdcc85646d5890232a04bad8c7ba9ebb0db36042eeda5961f8106567"
+      - name: IMAGE_PAC_PAC_WEBHOOK
+        value: "quay.io/openshift-pipeline/pipelines-pipelines-as-code-webhook-rhel9@sha256:0ccda15a17a405020fa199b3dce4a630e592da9dfdbd9778be1dcc9f4bdc3fbd"
+      - name: IMAGE_PAC_PAC_WATCHER
+        value: "quay.io/openshift-pipeline/pipelines-pipelines-as-code-watcher-rhel9@sha256:d100578068feb5482e2631b4fadc80b9687f129c7e303b55431ac41ce58f7758"
+      - name: IMAGE_PAC_PAC_CLI
+        value: "quay.io/openshift-pipeline/pipelines-pipelines-as-code-cli-rhel9@sha256:0fc0dd05236f14265e25cc770a7f9f3aeea2e27964a730dac39cf9f61d349bde"
 ---
 apiVersion: route.openshift.io/v1
 kind: Route

--- a/components/pipeline-service/production/base/main-pipeline-service-configuration.yaml
+++ b/components/pipeline-service/production/base/main-pipeline-service-configuration.yaml
@@ -1852,17 +1852,6 @@ spec:
         # events in the future, the controller can be re-enabled
         tekton-events-controller:
           spec:
-            template:
-              spec:
-                containers:
-                  - name: tekton-events-controller
-                    resources:
-                      limits:
-                        cpu: 200m
-                        memory: 4Gi
-                      requests:
-                        cpu: 200m
-                        memory: 4Gi
             replicas: 0
         # tekton-triggers-controller:
         #   spec:

--- a/components/pipeline-service/production/kflux-fedora-01/deploy.yaml
+++ b/components/pipeline-service/production/kflux-fedora-01/deploy.yaml
@@ -2357,17 +2357,6 @@ spec:
         tekton-events-controller:
           spec:
             replicas: 0
-            template:
-              spec:
-                containers:
-                - name: tekton-events-controller
-                  resources:
-                    limits:
-                      cpu: 200m
-                      memory: 4Gi
-                    requests:
-                      cpu: 200m
-                      memory: 4Gi
         tekton-operator-proxy-webhook:
           spec:
             replicas: 2

--- a/components/pipeline-service/production/kflux-ocp-p01/deploy.yaml
+++ b/components/pipeline-service/production/kflux-ocp-p01/deploy.yaml
@@ -2342,17 +2342,6 @@ spec:
         tekton-events-controller:
           spec:
             replicas: 0
-            template:
-              spec:
-                containers:
-                - name: tekton-events-controller
-                  resources:
-                    limits:
-                      cpu: 200m
-                      memory: 4Gi
-                    requests:
-                      cpu: 200m
-                      memory: 4Gi
         tekton-operator-proxy-webhook:
           spec:
             replicas: 2

--- a/components/pipeline-service/production/kflux-osp-p01/deploy.yaml
+++ b/components/pipeline-service/production/kflux-osp-p01/deploy.yaml
@@ -2342,17 +2342,6 @@ spec:
         tekton-events-controller:
           spec:
             replicas: 0
-            template:
-              spec:
-                containers:
-                - name: tekton-events-controller
-                  resources:
-                    limits:
-                      cpu: 200m
-                      memory: 4Gi
-                    requests:
-                      cpu: 200m
-                      memory: 4Gi
         tekton-operator-proxy-webhook:
           spec:
             replicas: 2

--- a/components/pipeline-service/production/kflux-prd-rh02/deploy.yaml
+++ b/components/pipeline-service/production/kflux-prd-rh02/deploy.yaml
@@ -2562,6 +2562,14 @@ spec:
       value: "false"
     - name: IMAGE_PIPELINES_CONTROLLER
       value: quay.io/openshift-pipeline/pipelines-resolvers-rhel9@sha256:7cd91bc4c0f3469ec4c39d08d818b00c90ce07456364910e49ad5e1430f3110a
+    - name: IMAGE_PAC_PAC_CONTROLLER
+      value: quay.io/openshift-pipeline/pipelines-pipelines-as-code-controller-rhel9@sha256:1b1e365cfdcc85646d5890232a04bad8c7ba9ebb0db36042eeda5961f8106567
+    - name: IMAGE_PAC_PAC_WEBHOOK
+      value: quay.io/openshift-pipeline/pipelines-pipelines-as-code-webhook-rhel9@sha256:0ccda15a17a405020fa199b3dce4a630e592da9dfdbd9778be1dcc9f4bdc3fbd
+    - name: IMAGE_PAC_PAC_WATCHER
+      value: quay.io/openshift-pipeline/pipelines-pipelines-as-code-watcher-rhel9@sha256:d100578068feb5482e2631b4fadc80b9687f129c7e303b55431ac41ce58f7758
+    - name: IMAGE_PAC_PAC_CLI
+      value: quay.io/openshift-pipeline/pipelines-pipelines-as-code-cli-rhel9@sha256:0fc0dd05236f14265e25cc770a7f9f3aeea2e27964a730dac39cf9f61d349bde
   name: openshift-pipelines-operator-rh
   source: custom-operators
   sourceNamespace: openshift-marketplace

--- a/components/pipeline-service/production/kflux-prd-rh02/deploy.yaml
+++ b/components/pipeline-service/production/kflux-prd-rh02/deploy.yaml
@@ -2341,17 +2341,7 @@ spec:
       deployments:
         tekton-events-controller:
           spec:
-            template:
-              spec:
-                containers:
-                - name: tekton-events-controller
-                  resources:
-                    limits:
-                      cpu: 200m
-                      memory: 4Gi
-                    requests:
-                      cpu: 200m
-                      memory: 4Gi
+            replicas: 0
         tekton-operator-proxy-webhook:
           spec:
             replicas: 2

--- a/components/pipeline-service/production/kflux-prd-rh03/deploy.yaml
+++ b/components/pipeline-service/production/kflux-prd-rh03/deploy.yaml
@@ -2562,6 +2562,14 @@ spec:
       value: "false"
     - name: IMAGE_PIPELINES_CONTROLLER
       value: quay.io/openshift-pipeline/pipelines-resolvers-rhel9@sha256:7cd91bc4c0f3469ec4c39d08d818b00c90ce07456364910e49ad5e1430f3110a
+    - name: IMAGE_PAC_PAC_CONTROLLER
+      value: quay.io/openshift-pipeline/pipelines-pipelines-as-code-controller-rhel9@sha256:1b1e365cfdcc85646d5890232a04bad8c7ba9ebb0db36042eeda5961f8106567
+    - name: IMAGE_PAC_PAC_WEBHOOK
+      value: quay.io/openshift-pipeline/pipelines-pipelines-as-code-webhook-rhel9@sha256:0ccda15a17a405020fa199b3dce4a630e592da9dfdbd9778be1dcc9f4bdc3fbd
+    - name: IMAGE_PAC_PAC_WATCHER
+      value: quay.io/openshift-pipeline/pipelines-pipelines-as-code-watcher-rhel9@sha256:d100578068feb5482e2631b4fadc80b9687f129c7e303b55431ac41ce58f7758
+    - name: IMAGE_PAC_PAC_CLI
+      value: quay.io/openshift-pipeline/pipelines-pipelines-as-code-cli-rhel9@sha256:0fc0dd05236f14265e25cc770a7f9f3aeea2e27964a730dac39cf9f61d349bde
   name: openshift-pipelines-operator-rh
   source: custom-operators
   sourceNamespace: openshift-marketplace

--- a/components/pipeline-service/production/kflux-prd-rh03/deploy.yaml
+++ b/components/pipeline-service/production/kflux-prd-rh03/deploy.yaml
@@ -2341,17 +2341,7 @@ spec:
       deployments:
         tekton-events-controller:
           spec:
-            template:
-              spec:
-                containers:
-                - name: tekton-events-controller
-                  resources:
-                    limits:
-                      cpu: 200m
-                      memory: 4Gi
-                    requests:
-                      cpu: 200m
-                      memory: 4Gi
+            replicas: 0
         tekton-operator-proxy-webhook:
           spec:
             replicas: 2

--- a/components/pipeline-service/production/kflux-rhel-p01/deploy.yaml
+++ b/components/pipeline-service/production/kflux-rhel-p01/deploy.yaml
@@ -2342,17 +2342,6 @@ spec:
         tekton-events-controller:
           spec:
             replicas: 0
-            template:
-              spec:
-                containers:
-                - name: tekton-events-controller
-                  resources:
-                    limits:
-                      cpu: 200m
-                      memory: 4Gi
-                    requests:
-                      cpu: 200m
-                      memory: 4Gi
         tekton-operator-proxy-webhook:
           spec:
             replicas: 2

--- a/components/pipeline-service/production/rings/ring-1/kustomization.yaml
+++ b/components/pipeline-service/production/rings/ring-1/kustomization.yaml
@@ -8,29 +8,4 @@ kind: Kustomization
 resources:
   - ../../base
 
-patches:
-  - target:
-      kind: Subscription
-      name: openshift-pipelines-operator
-    patch: |-
-      # TODO: remove these when upgrading to a bundle including Pipelines as Code v0.48.0+
-      - op: add
-        path: /spec/config/env/-
-        value:
-          name: IMAGE_PAC_PAC_CONTROLLER
-          value: "quay.io/openshift-pipeline/pipelines-pipelines-as-code-controller-rhel9@sha256:1b1e365cfdcc85646d5890232a04bad8c7ba9ebb0db36042eeda5961f8106567"
-      - op: add
-        path: /spec/config/env/-
-        value:
-          name: IMAGE_PAC_PAC_WEBHOOK
-          value: "quay.io/openshift-pipeline/pipelines-pipelines-as-code-webhook-rhel9@sha256:0ccda15a17a405020fa199b3dce4a630e592da9dfdbd9778be1dcc9f4bdc3fbd"
-      - op: add
-        path: /spec/config/env/-
-        value:
-          name: IMAGE_PAC_PAC_WATCHER
-          value: "quay.io/openshift-pipeline/pipelines-pipelines-as-code-watcher-rhel9@sha256:d100578068feb5482e2631b4fadc80b9687f129c7e303b55431ac41ce58f7758"
-      - op: add
-        path: /spec/config/env/-
-        value:
-          name: IMAGE_PAC_PAC_CLI
-          value: "quay.io/openshift-pipeline/pipelines-pipelines-as-code-cli-rhel9@sha256:0fc0dd05236f14265e25cc770a7f9f3aeea2e27964a730dac39cf9f61d349bde"
+patches: []

--- a/components/pipeline-service/production/rings/ring-2/kustomization.yaml
+++ b/components/pipeline-service/production/rings/ring-2/kustomization.yaml
@@ -8,29 +8,4 @@ kind: Kustomization
 resources:
   - ../../base
 
-patches:
-  - target:
-      kind: Subscription
-      name: openshift-pipelines-operator
-    patch: |-
-      # TODO: remove these when upgrading to a bundle including Pipelines as Code v0.48.0+
-      - op: add
-        path: /spec/config/env/-
-        value:
-          name: IMAGE_PAC_PAC_CONTROLLER
-          value: "quay.io/openshift-pipeline/pipelines-pipelines-as-code-controller-rhel9@sha256:1b1e365cfdcc85646d5890232a04bad8c7ba9ebb0db36042eeda5961f8106567"
-      - op: add
-        path: /spec/config/env/-
-        value:
-          name: IMAGE_PAC_PAC_WEBHOOK
-          value: "quay.io/openshift-pipeline/pipelines-pipelines-as-code-webhook-rhel9@sha256:0ccda15a17a405020fa199b3dce4a630e592da9dfdbd9778be1dcc9f4bdc3fbd"
-      - op: add
-        path: /spec/config/env/-
-        value:
-          name: IMAGE_PAC_PAC_WATCHER
-          value: "quay.io/openshift-pipeline/pipelines-pipelines-as-code-watcher-rhel9@sha256:d100578068feb5482e2631b4fadc80b9687f129c7e303b55431ac41ce58f7758"
-      - op: add
-        path: /spec/config/env/-
-        value:
-          name: IMAGE_PAC_PAC_CLI
-          value: "quay.io/openshift-pipeline/pipelines-pipelines-as-code-cli-rhel9@sha256:0fc0dd05236f14265e25cc770a7f9f3aeea2e27964a730dac39cf9f61d349bde"
+patches: []

--- a/components/pipeline-service/production/rings/ring-3/kustomization.yaml
+++ b/components/pipeline-service/production/rings/ring-3/kustomization.yaml
@@ -8,11 +8,4 @@ kind: Kustomization
 resources:
   - ../../base
 
-patches:
-  # TODO: Remove this patch to deploy the change
-  - target:
-      kind: TektonConfig
-      name: config
-    patch: |-
-      - op: remove
-        path: /spec/pipeline/options/deployments/tekton-events-controller/spec/replicas
+patches: []

--- a/components/pipeline-service/production/stone-prd-rh01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prd-rh01/deploy.yaml
@@ -2562,6 +2562,14 @@ spec:
       value: "false"
     - name: IMAGE_PIPELINES_CONTROLLER
       value: quay.io/openshift-pipeline/pipelines-resolvers-rhel9@sha256:7cd91bc4c0f3469ec4c39d08d818b00c90ce07456364910e49ad5e1430f3110a
+    - name: IMAGE_PAC_PAC_CONTROLLER
+      value: quay.io/openshift-pipeline/pipelines-pipelines-as-code-controller-rhel9@sha256:1b1e365cfdcc85646d5890232a04bad8c7ba9ebb0db36042eeda5961f8106567
+    - name: IMAGE_PAC_PAC_WEBHOOK
+      value: quay.io/openshift-pipeline/pipelines-pipelines-as-code-webhook-rhel9@sha256:0ccda15a17a405020fa199b3dce4a630e592da9dfdbd9778be1dcc9f4bdc3fbd
+    - name: IMAGE_PAC_PAC_WATCHER
+      value: quay.io/openshift-pipeline/pipelines-pipelines-as-code-watcher-rhel9@sha256:d100578068feb5482e2631b4fadc80b9687f129c7e303b55431ac41ce58f7758
+    - name: IMAGE_PAC_PAC_CLI
+      value: quay.io/openshift-pipeline/pipelines-pipelines-as-code-cli-rhel9@sha256:0fc0dd05236f14265e25cc770a7f9f3aeea2e27964a730dac39cf9f61d349bde
   name: openshift-pipelines-operator-rh
   source: custom-operators
   sourceNamespace: openshift-marketplace

--- a/components/pipeline-service/production/stone-prd-rh01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prd-rh01/deploy.yaml
@@ -2341,17 +2341,7 @@ spec:
       deployments:
         tekton-events-controller:
           spec:
-            template:
-              spec:
-                containers:
-                - name: tekton-events-controller
-                  resources:
-                    limits:
-                      cpu: 200m
-                      memory: 4Gi
-                    requests:
-                      cpu: 200m
-                      memory: 4Gi
+            replicas: 0
         tekton-operator-proxy-webhook:
           spec:
             replicas: 2

--- a/components/pipeline-service/production/stone-prod-p01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prod-p01/deploy.yaml
@@ -2342,17 +2342,6 @@ spec:
         tekton-events-controller:
           spec:
             replicas: 0
-            template:
-              spec:
-                containers:
-                - name: tekton-events-controller
-                  resources:
-                    limits:
-                      cpu: 200m
-                      memory: 4Gi
-                    requests:
-                      cpu: 200m
-                      memory: 4Gi
         tekton-operator-proxy-webhook:
           spec:
             replicas: 2

--- a/components/pipeline-service/production/stone-prod-p02/deploy.yaml
+++ b/components/pipeline-service/production/stone-prod-p02/deploy.yaml
@@ -2342,17 +2342,6 @@ spec:
         tekton-events-controller:
           spec:
             replicas: 0
-            template:
-              spec:
-                containers:
-                - name: tekton-events-controller
-                  resources:
-                    limits:
-                      cpu: 200m
-                      memory: 4Gi
-                    requests:
-                      cpu: 200m
-                      memory: 4Gi
         tekton-operator-proxy-webhook:
           spec:
             replicas: 2


### PR DESCRIPTION
# Deploying PaC v0.48.0
Promotion of staging PR https://github.com/redhat-appstudio/infra-deployments/pull/12252. Depends on Ring 1 and Ring 2 deployment

Ring PRs: 
- Ring 1: https://github.com/redhat-appstudio/infra-deployments/pull/12566
- Ring 2: https://github.com/redhat-appstudio/infra-deployments/pull/12567
- Ring 3: https://github.com/redhat-appstudio/infra-deployments/pull/12568 (this PR)

Overrides the Pipelines as Code images to use Security Release v0.48.0

Full changelog here: https://github.com/tektoncd/pipelines-as-code/releases/tag/v0.48.0
Additional Context here: 
- slack thread: https://redhat-internal.slack.com/archives/CG5GV6CJD/p1780607633123779?thread_ts=1780431728.634749&cid=CG5GV6CJD
- ticket: https://redhat.atlassian.net/browse/SRVKP-12455

---

# Disabling Tekton Events Controller

*Superseding https://github.com/redhat-appstudio/infra-deployments/pull/12575 for deployment ease.*

Disable the Tekton Events controller in Production - Ring 3
Depends on Ring 1 and Ring 2 deployment

The Tekton Events Controller watches every PipelineRun and TaskRun, but there are no CloudEvent sinks configured so the events controller does not emit any events, it's just a no-op. 

Promotion of https://github.com/redhat-appstudio/infra-deployments/pull/12298

Risk: minimal. This controller is unused by Konflux and has been disabled in Dev+Staging since 2026.06.15

Ring deployments:

- Ring 1: https://github.com/redhat-appstudio/infra-deployments/pull/12573
- Ring 2: https://github.com/redhat-appstudio/infra-deployments/pull/12574
- Ring 3: https://github.com/redhat-appstudio/infra-deployments/pull/12575

[SRVKP-12264](https://redhat.atlassian.net/browse/SRVKP-12264)



[SRVKP-12264]: https://redhat.atlassian.net/browse/SRVKP-12264?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ