### PR TITLE
Disable tekton events controller in production Ring 1

### DIFF
--- a/components/pipeline-service/production/base/main-pipeline-service-configuration.yaml
+++ b/components/pipeline-service/production/base/main-pipeline-service-configuration.yaml
@@ -1846,6 +1846,10 @@ spec:
         #               requests:
         #                 cpu: 1500m
         #                 memory: 8Gi
+        # The events controller is unused by Konflux but requires not-insignificant resources
+        # since it watches all PipelineRuns and TaskRuns in the cluster
+        # Disabling it saves resources. If Konflux requires CloudEvents for Tekton *Run lifecycle
+        # events in the future, the controller can be re-enabled
         tekton-events-controller:
           spec:
             template:
@@ -1859,6 +1863,7 @@ spec:
                       requests:
                         cpu: 200m
                         memory: 4Gi
+            replicas: 0
         # tekton-triggers-controller:
         #   spec:
         #     template:

--- a/components/pipeline-service/production/kflux-fedora-01/deploy.yaml
+++ b/components/pipeline-service/production/kflux-fedora-01/deploy.yaml
@@ -2356,6 +2356,7 @@ spec:
       deployments:
         tekton-events-controller:
           spec:
+            replicas: 0
             template:
               spec:
                 containers:

--- a/components/pipeline-service/production/kflux-osp-p01/deploy.yaml
+++ b/components/pipeline-service/production/kflux-osp-p01/deploy.yaml
@@ -2341,6 +2341,7 @@ spec:
       deployments:
         tekton-events-controller:
           spec:
+            replicas: 0
             template:
               spec:
                 containers:

--- a/components/pipeline-service/production/rings/ring-2/kustomization.yaml
+++ b/components/pipeline-service/production/rings/ring-2/kustomization.yaml
@@ -8,4 +8,12 @@ kind: Kustomization
 resources:
   - ../../base
 
-patches: []
+patches:
+  # TODO: Remove this patch to deploy the change to Ring 2
+  - target:
+      kind: TektonConfig
+      name: config
+    patch: |-
+      - op: remove
+        path: /spec/pipeline/options/deployments/tekton-events-controller/spec/replicas
+

--- a/components/pipeline-service/production/rings/ring-3/kustomization.yaml
+++ b/components/pipeline-service/production/rings/ring-3/kustomization.yaml
@@ -8,4 +8,11 @@ kind: Kustomization
 resources:
   - ../../base
 
-patches: []
+patches:
+  # TODO: Remove this patch to deploy the change
+  - target:
+      kind: TektonConfig
+      name: config
+    patch: |-
+      - op: remove
+        path: /spec/pipeline/options/deployments/tekton-events-controller/spec/replicas

--- a/components/pipeline-service/production/stone-prod-p01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prod-p01/deploy.yaml
@@ -2341,6 +2341,7 @@ spec:
       deployments:
         tekton-events-controller:
           spec:
+            replicas: 0
             template:
               spec:
                 containers:


### PR DESCRIPTION
Disable the Tekton Events controller in Production - Ring 1

The Tekton Events Controller watches every PipelineRun and TaskRun, but there are no CloudEvent sinks configured so the events controller does not emit any events, it's just a no-op. 

Promotion of https://github.com/redhat-appstudio/infra-deployments/pull/12298

Risk: minimal. This controller is unused by Konflux and has been disabled in Dev+Staging since 2026.06.15

Ring deployments:

- Ring 1: https://github.com/redhat-appstudio/infra-deployments/pull/12573
- Ring 2: https://github.com/redhat-appstudio/infra-deployments/pull/12574
- Ring 3: https://github.com/redhat-appstudio/infra-deployments/pull/12575

[SRVKP-12264](https://redhat.atlassian.net/browse/SRVKP-12264)



[SRVKP-12264]: https://redhat.atlassian.net/browse/SRVKP-12264?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ