### PR TITLE
Disable the Tekton Events controller in Production - Ring 3

### DIFF
--- a/components/pipeline-service/production/base/main-pipeline-service-configuration.yaml
+++ b/components/pipeline-service/production/base/main-pipeline-service-configuration.yaml
@@ -1852,17 +1852,6 @@ spec:
         # events in the future, the controller can be re-enabled
         tekton-events-controller:
           spec:
-            template:
-              spec:
-                containers:
-                  - name: tekton-events-controller
-                    resources:
-                      limits:
-                        cpu: 200m
-                        memory: 4Gi
-                      requests:
-                        cpu: 200m
-                        memory: 4Gi
             replicas: 0
         # tekton-triggers-controller:
         #   spec:

--- a/components/pipeline-service/production/kflux-fedora-01/deploy.yaml
+++ b/components/pipeline-service/production/kflux-fedora-01/deploy.yaml
@@ -2357,17 +2357,6 @@ spec:
         tekton-events-controller:
           spec:
             replicas: 0
-            template:
-              spec:
-                containers:
-                - name: tekton-events-controller
-                  resources:
-                    limits:
-                      cpu: 200m
-                      memory: 4Gi
-                    requests:
-                      cpu: 200m
-                      memory: 4Gi
         tekton-operator-proxy-webhook:
           spec:
             replicas: 2

--- a/components/pipeline-service/production/kflux-ocp-p01/deploy.yaml
+++ b/components/pipeline-service/production/kflux-ocp-p01/deploy.yaml
@@ -2342,17 +2342,6 @@ spec:
         tekton-events-controller:
           spec:
             replicas: 0
-            template:
-              spec:
-                containers:
-                - name: tekton-events-controller
-                  resources:
-                    limits:
-                      cpu: 200m
-                      memory: 4Gi
-                    requests:
-                      cpu: 200m
-                      memory: 4Gi
         tekton-operator-proxy-webhook:
           spec:
             replicas: 2

--- a/components/pipeline-service/production/kflux-osp-p01/deploy.yaml
+++ b/components/pipeline-service/production/kflux-osp-p01/deploy.yaml
@@ -2342,17 +2342,6 @@ spec:
         tekton-events-controller:
           spec:
             replicas: 0
-            template:
-              spec:
-                containers:
-                - name: tekton-events-controller
-                  resources:
-                    limits:
-                      cpu: 200m
-                      memory: 4Gi
-                    requests:
-                      cpu: 200m
-                      memory: 4Gi
         tekton-operator-proxy-webhook:
           spec:
             replicas: 2

--- a/components/pipeline-service/production/kflux-prd-rh02/deploy.yaml
+++ b/components/pipeline-service/production/kflux-prd-rh02/deploy.yaml
@@ -2341,17 +2341,7 @@ spec:
       deployments:
         tekton-events-controller:
           spec:
-            template:
-              spec:
-                containers:
-                - name: tekton-events-controller
-                  resources:
-                    limits:
-                      cpu: 200m
-                      memory: 4Gi
-                    requests:
-                      cpu: 200m
-                      memory: 4Gi
+            replicas: 0
         tekton-operator-proxy-webhook:
           spec:
             replicas: 2

--- a/components/pipeline-service/production/kflux-prd-rh03/deploy.yaml
+++ b/components/pipeline-service/production/kflux-prd-rh03/deploy.yaml
@@ -2341,17 +2341,7 @@ spec:
       deployments:
         tekton-events-controller:
           spec:
-            template:
-              spec:
-                containers:
-                - name: tekton-events-controller
-                  resources:
-                    limits:
-                      cpu: 200m
-                      memory: 4Gi
-                    requests:
-                      cpu: 200m
-                      memory: 4Gi
+            replicas: 0
         tekton-operator-proxy-webhook:
           spec:
             replicas: 2

--- a/components/pipeline-service/production/kflux-rhel-p01/deploy.yaml
+++ b/components/pipeline-service/production/kflux-rhel-p01/deploy.yaml
@@ -2342,17 +2342,6 @@ spec:
         tekton-events-controller:
           spec:
             replicas: 0
-            template:
-              spec:
-                containers:
-                - name: tekton-events-controller
-                  resources:
-                    limits:
-                      cpu: 200m
-                      memory: 4Gi
-                    requests:
-                      cpu: 200m
-                      memory: 4Gi
         tekton-operator-proxy-webhook:
           spec:
             replicas: 2

--- a/components/pipeline-service/production/rings/ring-2/kustomization.yaml
+++ b/components/pipeline-service/production/rings/ring-2/kustomization.yaml
@@ -8,12 +8,4 @@ kind: Kustomization
 resources:
   - ../../base
 
-patches:
-  # TODO: Remove this patch to deploy the change to Ring 2
-  - target:
-      kind: TektonConfig
-      name: config
-    patch: |-
-      - op: remove
-        path: /spec/pipeline/options/deployments/tekton-events-controller/spec/replicas
-
+patches: []

--- a/components/pipeline-service/production/rings/ring-3/kustomization.yaml
+++ b/components/pipeline-service/production/rings/ring-3/kustomization.yaml
@@ -8,11 +8,4 @@ kind: Kustomization
 resources:
   - ../../base
 
-patches:
-  # TODO: Remove this patch to deploy the change
-  - target:
-      kind: TektonConfig
-      name: config
-    patch: |-
-      - op: remove
-        path: /spec/pipeline/options/deployments/tekton-events-controller/spec/replicas
+patches: []

--- a/components/pipeline-service/production/stone-prd-rh01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prd-rh01/deploy.yaml
@@ -2341,17 +2341,7 @@ spec:
       deployments:
         tekton-events-controller:
           spec:
-            template:
-              spec:
-                containers:
-                - name: tekton-events-controller
-                  resources:
-                    limits:
-                      cpu: 200m
-                      memory: 4Gi
-                    requests:
-                      cpu: 200m
-                      memory: 4Gi
+            replicas: 0
         tekton-operator-proxy-webhook:
           spec:
             replicas: 2

--- a/components/pipeline-service/production/stone-prod-p01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prod-p01/deploy.yaml
@@ -2342,17 +2342,6 @@ spec:
         tekton-events-controller:
           spec:
             replicas: 0
-            template:
-              spec:
-                containers:
-                - name: tekton-events-controller
-                  resources:
-                    limits:
-                      cpu: 200m
-                      memory: 4Gi
-                    requests:
-                      cpu: 200m
-                      memory: 4Gi
         tekton-operator-proxy-webhook:
           spec:
             replicas: 2

--- a/components/pipeline-service/production/stone-prod-p02/deploy.yaml
+++ b/components/pipeline-service/production/stone-prod-p02/deploy.yaml
@@ -2342,17 +2342,6 @@ spec:
         tekton-events-controller:
           spec:
             replicas: 0
-            template:
-              spec:
-                containers:
-                - name: tekton-events-controller
-                  resources:
-                    limits:
-                      cpu: 200m
-                      memory: 4Gi
-                    requests:
-                      cpu: 200m
-                      memory: 4Gi
         tekton-operator-proxy-webhook:
           spec:
             replicas: 2


### PR DESCRIPTION
Disable the Tekton Events controller in Production - Ring 3
Depends on Ring 1 and Ring 2 deployment

The Tekton Events Controller watches every PipelineRun and TaskRun, but there are no CloudEvent sinks configured so the events controller does not emit any events, it's just a no-op. 

Promotion of https://github.com/redhat-appstudio/infra-deployments/pull/12298

Risk: minimal. This controller is unused by Konflux and has been disabled in Dev+Staging since 2026.06.15

Ring deployments:

- Ring 1: https://github.com/redhat-appstudio/infra-deployments/pull/12573
- Ring 2: https://github.com/redhat-appstudio/infra-deployments/pull/12574
- Ring 3: https://github.com/redhat-appstudio/infra-deployments/pull/12575

[SRVKP-12264](https://redhat.atlassian.net/browse/SRVKP-12264)



[SRVKP-12264]: https://redhat.atlassian.net/browse/SRVKP-12264?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ