### PR TITLE
KFLUXVNGD-932: Upgrade squid helm chart to 0.1.1579+32fdfe0 in production (Ring 2)

### DIFF
--- a/components/squid/production/stone-prd-rh01/squid-helm-generator.yaml
+++ b/components/squid/production/stone-prd-rh01/squid-helm-generator.yaml
@@ -4,7 +4,7 @@ metadata:
   name: squid-helm
 name: squid-helm
 repo: oci://quay.io/konflux-ci/caching
-version: 0.1.1521+3e9d8b9
+version: 0.1.1579+32fdfe0
 valuesInline:
   installCertManagerComponents: false
   mirrord:

--- a/components/squid/production/stone-prod-p02/squid-helm-generator.yaml
+++ b/components/squid/production/stone-prod-p02/squid-helm-generator.yaml
@@ -4,7 +4,7 @@ metadata:
   name: squid-helm
 name: squid-helm
 repo: oci://quay.io/konflux-ci/caching
-version: 0.1.1521+3e9d8b9
+version: 0.1.1579+32fdfe0
 valuesInline:
   installCertManagerComponents: false
   mirrord:


### PR DESCRIPTION
## What

Promote the squid version to the remaining production clusters that were excluded from [Ring 1](https://github.com/redhat-appstudio/infra-deployments/pull/12527).

After deployment, the self-signed CA cert must be manually renewed on each upgraded cluster.

## Why

The self-signed CA certificate used by the squid proxy needs its lifespan extended.

## Validation

The ring 1 deployment was successful. The CA cert was renewed on each cluster without issue.

## Risk Assessment

Risk Level: Low
Rollback: Revert this PR to return upgraded clusters to 0.1.1521+3e9d8b9