### PR TITLE
Exclude imagestreams from OADP backup schedule

### DIFF
--- a/components/backup/base/member/schedules/backup-tenants-schedule.yaml
+++ b/components/backup/base/member/schedules/backup-tenants-schedule.yaml
@@ -35,6 +35,7 @@ spec:
       - release-service
       - tekton-results
     excludedResources:
+      - imagestreams.image.openshift.io
       - pipelineruns.tekton.dev
       - pods
       - resolutionrequests.resolution.tekton.dev

--- a/components/backup/staging/stone-stage-p01/exclude-imagestreams-patch.yaml
+++ b/components/backup/staging/stone-stage-p01/exclude-imagestreams-patch.yaml
@@ -1,3 +1,0 @@
-- op: add
-  path: /spec/template/excludedResources/-
-  value: imagestreams.image.openshift.io

--- a/components/backup/staging/stone-stage-p01/kustomization.yaml
+++ b/components/backup/staging/stone-stage-p01/kustomization.yaml
@@ -27,9 +27,3 @@ patches:
     kind: Subscription
     name: redhat-oadp-operator
     version: v1alpha1
-- path: exclude-imagestreams-patch.yaml
-  target:
-    group: velero.io
-    kind: Schedule
-    name: backup-tenants
-    version: v1

--- a/components/backup/staging/stone-stg-rh01/exclude-imagestreams-patch.yaml
+++ b/components/backup/staging/stone-stg-rh01/exclude-imagestreams-patch.yaml
@@ -1,3 +1,0 @@
-- op: add
-  path: /spec/template/excludedResources/-
-  value: imagestreams.image.openshift.io

--- a/components/backup/staging/stone-stg-rh01/kustomization.yaml
+++ b/components/backup/staging/stone-stg-rh01/kustomization.yaml
@@ -27,9 +27,3 @@ patches:
     kind: Subscription
     name: redhat-oadp-operator
     version: v1alpha1
-- path: exclude-imagestreams-patch.yaml
-  target:
-    group: velero.io
-    kind: Schedule
-    name: backup-tenants
-    version: v1


### PR DESCRIPTION
## Summary
- Adds `imagestreams.image.openshift.io` to `excludedResources` in the base Velero backup schedule, propagating to all environments
- Removes the now-redundant staging overlay patches from PR #12550

## Problem
The OADP openshift velero plugin (`OPENSHIFT_IMAGESTREAM_BACKUP=true`) attempts to copy imagestream image layers during backup. When an imagestream exists in a non-excluded namespace (e.g. `art-cd` in `art-pipelines-tenant`), the plugin incorrectly resolves the backup registry to `registry-1.docker.io` instead of the internal OpenShift registry, causing a `500 Internal Server Error`.

On `kflux-ocp-p01`, every scheduled backup (every 4 hours) has reported `PartiallyFailed` with 1 error since the imagestream was created on May 15.

## Fix
Exclude `imagestreams.image.openshift.io` from the base backup schedule's `excludedResources`. ImageStreams are build artifacts that can be rebuilt from source (BuildConfigs + git), so excluding them does not result in meaningful data loss.

## Why base overlay instead of per-environment patches
The imagestream exclusion is not environment-specific — the OADP plugin's registry resolution bug affects all clusters equally. A single change in the base keeps the configuration DRY, avoids duplicating the same patch across 11 overlay directories, and ensures any new cluster onboarded in the future automatically inherits the fix.

## Jira
- [KFLUXINFRA-4001](https://redhat.atlassian.net/browse/KFLUXINFRA-4001)

## Risk Assessment

**Risk Level:** Low
**Description:** This change only excludes ImageStream resources from Velero backup. ImageStreams reference images stored in the internal registry and can be recreated from existing BuildConfigs and source repositories. No persistent data, secrets, or application state is affected. The backup schedule, frequency, and all other backed-up resources remain unchanged.
**Rollback:** Revert the one-line addition in `components/backup/base/member/schedules/backup-tenants-schedule.yaml` and re-add the staging overlay patches, then let ArgoCD sync.

## Validation

Staging PR: https://github.com/redhat-appstudio/infra-deployments/pull/12550

## Test plan
- [x] Verify kustomize build succeeds for staging and production overlays
- [x] Staging PR #12550 merged and validated
- [ ] After ArgoCD sync, verify backups on production clusters complete without `PartiallyFailed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[KFLUXINFRA-4001]: https://redhat.atlassian.net/browse/KFLUXINFRA-4001?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ