### PR TITLE
KONFLUX-13198 disable kyverno reports controller on kflux-osp-p01

### DIFF
--- a/components/kyverno/production/kflux-osp-p01/kyverno-helm-values.yaml
+++ b/components/kyverno/production/kflux-osp-p01/kyverno-helm-values.yaml
@@ -86,22 +86,7 @@ cleanupController:
     minAvailable: null
     unhealthyPodEvictionPolicy: AlwaysAllow
 reportsController:
-  replicas: 3
-  resources:
-    limits:
-      cpu: 500m
-  securityContext:
-    allowPrivilegeEscalation: false
-    readOnlyRootFilesystem: true
-    runAsNonRoot: true
-    capabilities:
-      drop:
-      - "ALL"
-  podDisruptionBudget:
-    enabled: true
-    maxUnavailable: 2
-    minAvailable: null
-    unhealthyPodEvictionPolicy: AlwaysAllow
+  enabled: false
 policyReportsCleanup:
   image:
     registry: mirror.gcr.io


### PR DESCRIPTION
## What

Disable Kyverno's reports controller on kflux-osp-p01

Clusters affected: kflux-osp-p01

[KONFLUX-13198](https://issues.redhat.com/browse/KONFLUX-13198)

## Why

Reduce load — the reports controller was already disabled on all other clusters but was missed on kflux-osp-p01.

Reference: https://github.com/redhat-appstudio/infra-deployments/pull/6485

## Validation

- `kustomize build --enable-helm components/kyverno/production/kflux-osp-p01/` passes
- Verified all other clusters already have `reportsController: enabled: false`

## Risk Assessment

**Risk Level:** Low
**What could go wrong:** Reports controller is already unused (all reporting features are disabled)
**Rollback:** Revert PR

[KONFLUX-13198]: https://redhat.atlassian.net/browse/KONFLUX-13198?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ