### PR TITLE
Restore platform ApplicationSets on development-operator overlay.

### DIFF
--- a/argo-cd-apps/overlays/development-operator/delete-legacy-konflux-member-appsets.yaml
+++ b/argo-cd-apps/overlays/development-operator/delete-legacy-konflux-member-appsets.yaml
@@ -16,12 +16,6 @@ $patch: delete
 apiVersion: argoproj.io/v1alpha1
 kind: ApplicationSet
 metadata:
-  name: has
-$patch: delete
----
-apiVersion: argoproj.io/v1alpha1
-kind: ApplicationSet
-metadata:
   name: release
 $patch: delete
 ---
@@ -40,31 +34,7 @@ $patch: delete
 apiVersion: argoproj.io/v1alpha1
 kind: ApplicationSet
 metadata:
-  name: build-templates
-$patch: delete
----
-apiVersion: argoproj.io/v1alpha1
-kind: ApplicationSet
-metadata:
   name: image-controller
-$patch: delete
----
-apiVersion: argoproj.io/v1alpha1
-kind: ApplicationSet
-metadata:
-  name: multi-platform-controller
-$patch: delete
----
-apiVersion: argoproj.io/v1alpha1
-kind: ApplicationSet
-metadata:
-  name: project-controller
-$patch: delete
----
-apiVersion: argoproj.io/v1alpha1
-kind: ApplicationSet
-metadata:
-  name: mintmaker
 $patch: delete
 ---
 apiVersion: argoproj.io/v1alpha1
@@ -89,10 +59,4 @@ apiVersion: argoproj.io/v1alpha1
 kind: ApplicationSet
 metadata:
   name: enterprise-contract
-$patch: delete
----
-apiVersion: argoproj.io/v1alpha1
-kind: ApplicationSet
-metadata:
-  name: konflux-kite
 $patch: delete

--- a/hack/build/setup-pac-integration.sh
+++ b/hack/build/setup-pac-integration.sh
@@ -266,15 +266,10 @@ create_pac_secret "$PAC_NAMESPACE" "$FULL_SECRET_DATA"
 create_pac_secret "build-service" "$FULL_SECRET_DATA"
 create_pac_secret "$INTEGRATION_NAMESPACE" "$FULL_SECRET_DATA"
 
-# Mintmaker only needs GitHub App data (no webhook tokens). development-operator
-# overlay does not deploy mintmaker.
+# Mintmaker only needs GitHub App data (no webhook tokens).
 PAC_CONFIGURED_NAMESPACES=("$PAC_NAMESPACE" "build-service" "$INTEGRATION_NAMESPACE")
-if [ "${TARGET_PREVIEW_OVERLAY:-development}" != "development-operator" ]; then
-    create_pac_secret "mintmaker" "$GITHUB_APP_DATA"
-    PAC_CONFIGURED_NAMESPACES+=("mintmaker")
-else
-    log_info "Skipping mintmaker PAC secret (development-operator overlay excludes mintmaker)"
-fi
+create_pac_secret "mintmaker" "$GITHUB_APP_DATA"
+PAC_CONFIGURED_NAMESPACES+=("mintmaker")
 
 log_info "============================================================================="
 log_success "PAC Integration Setup Complete"


### PR DESCRIPTION
Re-enable has, build-templates, multi-platform-controller, project-controller, mintmaker, and konflux-kite alongside the Konflux operator while keeping operator-owned and internal-services ApplicationSets deleted. Always provision mintmaker PAC secrets during preview bootstrap.


Assisted-by: Cursor