### PR TITLE
Gate konflux-operator Argo health on Konflux CR readiness.

### DIFF
--- a/hack/argocd-operator-overlay-health-checks.yaml
+++ b/hack/argocd-operator-overlay-health-checks.yaml
@@ -1,0 +1,33 @@
+# Strategic-merge patch for openshift-gitops ArgoCD CR resourceHealthChecks.
+# Applied only for development-operator bootstrap (preview --operator-overlay).
+spec:
+  resourceHealthChecks:
+    - group: konflux.konflux-ci.dev
+      kind: Konflux
+      check: |
+        hs = {}
+        if obj.status == nil or obj.status.conditions == nil then
+          hs.status = "Progressing"
+          hs.message = "Waiting for Konflux status"
+          return hs
+        end
+        for i, condition in ipairs(obj.status.conditions) do
+          if condition.type == "Ready" then
+            if condition.status == "True" then
+              hs.status = "Healthy"
+              hs.message = condition.message
+              return hs
+            end
+            if condition.reason == "ComponentsNotReady" then
+              hs.status = "Progressing"
+              hs.message = condition.message
+              return hs
+            end
+            hs.status = "Degraded"
+            hs.message = condition.message
+            return hs
+          end
+        end
+        hs.status = "Progressing"
+        hs.message = "Ready condition not reported yet"
+        return hs

--- a/hack/bootstrap-cluster.sh
+++ b/hack/bootstrap-cluster.sh
@@ -120,6 +120,12 @@ main() {
         log_success "Upstream configuration deployed"
         ;;
     "preview")
+        if [ -n "$operator_overlay" ]; then
+            log_step "Configuring operator-overlay Argo CD health checks"
+            # shellcheck source=/dev/null
+            source "${ROOT}/hack/deploy-argocd.sh"
+            configure_operator_overlay_health_customizations
+        fi
         log_info "Deploying preview configuration"
         $ROOT/hack/preview.sh $obo $eaas $operator_overlay
         ;;

--- a/hack/deploy-argocd.sh
+++ b/hack/deploy-argocd.sh
@@ -238,6 +238,23 @@ spec:
     fi
 }
 
+configure_operator_overlay_health_customizations() {
+    log_substep "Configuring Konflux CR health check for development-operator overlay"
+
+    local patch_file="$ROOT/hack/argocd-operator-overlay-health-checks.yaml"
+    if [ ! -f "$patch_file" ]; then
+        log_error "Missing operator overlay Argo CD health patch file: $patch_file"
+        exit 1
+    fi
+
+    if kubectl patch argocd/openshift-gitops -n openshift-gitops --type=merge --patch-file "$patch_file"; then
+        log_success "Operator overlay Konflux CR health customization applied"
+    else
+        log_warn "Failed to apply operator overlay Konflux CR health customization"
+        return 1
+    fi
+}
+
 set_kustomize_build_options() {
     log_substep "Enabling Helm support in Kustomize builds"
     


### PR DESCRIPTION
Apply Konflux CR resourceHealthChecks only during preview --operator-overlay bootstrap so konflux-operator stays unhealthy until the Konflux instance Ready condition is True.


Assisted-by: Cursor