### PR TITLE
KFLUXINFRA-3973: add token resource to kueue in production (ring 2)

### DIFF
--- a/components/kueue/production/kflux-osp-p01/config.yaml
+++ b/components/kueue/production/kflux-osp-p01/config.yaml
@@ -98,26 +98,6 @@ cel:
     - |
         resource('konflux-ci-dev-token', 1)
 
-    # Add a resource to restrict the number of concurrent release pipelineruns
-    - |
-        has(pipelineRun.metadata.labels) &&
-        'appstudio.openshift.io/service' in pipelineRun.metadata.labels &&
-        pipelineRun.metadata.labels['appstudio.openshift.io/service'] == 'release' &&
-        'pipelines.appstudio.openshift.io/type' in pipelineRun.metadata.labels &&
-        pipelineRun.metadata.labels['pipelines.appstudio.openshift.io/type'] == 'managed' ?
-        [resource('konflux-release', 1)] :
-
-        has(pipelineRun.metadata.labels) &&
-        'appstudio.openshift.io/service' in pipelineRun.metadata.labels &&
-        pipelineRun.metadata.labels['appstudio.openshift.io/service'] == 'release' &&
-        'release.appstudio.openshift.io/namespace' in pipelineRun.metadata.labels &&
-        pipelineRun.metadata.labels['release.appstudio.openshift.io/namespace'] == plrNamespace ?
-        [resource('konflux-release', 1)] :
-
-        has(pipelineRun.metadata.labels) &&
-        'internal-services.appstudio.openshift.io/pipelinerun-uid' in pipelineRun.metadata.labels ?
-        [resource('konflux-release', 1)] : []
-
     # Set the pipeline priority
     - |
         has(pipelineRun.metadata.labels) &&

--- a/components/kueue/production/kflux-osp-p01/kustomization.yaml
+++ b/components/kueue/production/kflux-osp-p01/kustomization.yaml
@@ -6,3 +6,10 @@ resources:
 
 commonAnnotations:
   argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+
+configMapGenerator:
+  - name: tekton-kueue-config
+    namespace: tekton-kueue
+    behavior: replace
+    files:
+      - config.yaml

--- a/components/kueue/production/kflux-osp-p01/queue-config/cluster-queue.yaml
+++ b/components/kueue/production/kflux-osp-p01/queue-config/cluster-queue.yaml
@@ -16,6 +16,7 @@ spec:
   resourceGroups:
   - coveredResources:
     - tekton.dev/pipelineruns
+    - konflux-ci-dev-token
     - cpu
     - memory
     - aws-ip
@@ -24,6 +25,8 @@ spec:
     - name: default-flavor
       resources:
       - name: tekton.dev/pipelineruns
+        nominalQuota: '30'
+      - name: konflux-ci-dev-token
         nominalQuota: '30'
       - name: cpu
         nominalQuota: 1k

--- a/components/kueue/production/kflux-prd-rh03/config.yaml
+++ b/components/kueue/production/kflux-prd-rh03/config.yaml
@@ -98,26 +98,6 @@ cel:
     - |
         resource('konflux-ci-dev-token', 1)
 
-    # Add a resource to restrict the number of concurrent release pipelineruns
-    - |
-        has(pipelineRun.metadata.labels) &&
-        'appstudio.openshift.io/service' in pipelineRun.metadata.labels &&
-        pipelineRun.metadata.labels['appstudio.openshift.io/service'] == 'release' &&
-        'pipelines.appstudio.openshift.io/type' in pipelineRun.metadata.labels &&
-        pipelineRun.metadata.labels['pipelines.appstudio.openshift.io/type'] == 'managed' ?
-        [resource('konflux-release', 1)] :
-
-        has(pipelineRun.metadata.labels) &&
-        'appstudio.openshift.io/service' in pipelineRun.metadata.labels &&
-        pipelineRun.metadata.labels['appstudio.openshift.io/service'] == 'release' &&
-        'release.appstudio.openshift.io/namespace' in pipelineRun.metadata.labels &&
-        pipelineRun.metadata.labels['release.appstudio.openshift.io/namespace'] == plrNamespace ?
-        [resource('konflux-release', 1)] :
-
-        has(pipelineRun.metadata.labels) &&
-        'internal-services.appstudio.openshift.io/pipelinerun-uid' in pipelineRun.metadata.labels ?
-        [resource('konflux-release', 1)] : []
-
     # Set the pipeline priority
     - |
         has(pipelineRun.metadata.labels) &&

--- a/components/kueue/production/kflux-prd-rh03/kustomization.yaml
+++ b/components/kueue/production/kflux-prd-rh03/kustomization.yaml
@@ -6,3 +6,10 @@ resources:
 
 commonAnnotations:
   argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+
+configMapGenerator:
+  - name: tekton-kueue-config
+    namespace: tekton-kueue
+    behavior: replace
+    files:
+      - config.yaml

--- a/components/kueue/production/kflux-prd-rh03/queue-config/cluster-queue.yaml
+++ b/components/kueue/production/kflux-prd-rh03/queue-config/cluster-queue.yaml
@@ -16,6 +16,7 @@ spec:
   resourceGroups:
   - coveredResources:
     - tekton.dev/pipelineruns
+    - konflux-ci-dev-token
     - cpu
     - memory
     - aws-ip
@@ -24,6 +25,8 @@ spec:
     - name: default-flavor
       resources:
       - name: tekton.dev/pipelineruns
+        nominalQuota: '350'
+      - name: konflux-ci-dev-token
         nominalQuota: '350'
       - name: cpu
         nominalQuota: 1k

--- a/components/kueue/production/stone-prod-p02/queue-config/cluster-queue.yaml
+++ b/components/kueue/production/stone-prod-p02/queue-config/cluster-queue.yaml
@@ -16,6 +16,7 @@ spec:
   resourceGroups:
   - coveredResources:
     - tekton.dev/pipelineruns
+    - konflux-ci-dev-token
     - cpu
     - memory
     - aws-ip
@@ -25,6 +26,8 @@ spec:
     - name: default-flavor
       resources:
       - name: tekton.dev/pipelineruns
+        nominalQuota: '300'
+      - name: konflux-ci-dev-token
         nominalQuota: '300'
       - name: cpu
         nominalQuota: 1k

--- a/hack/test-tekton-kueue-config.py
+++ b/hack/test-tekton-kueue-config.py
@@ -1619,6 +1619,7 @@ TEST_COMBINATIONS: Dict[str, TestCombination] = {
         "config_key": "production-stone-prod-p02",
         "expected": {
             "annotations": {
+                "kueue.konflux-ci.dev/requests-konflux-ci-dev-token": "1",
                 "kueue.konflux-ci.dev/requests-konflux-release": "1",
             },
             "labels": {
@@ -1632,6 +1633,7 @@ TEST_COMBINATIONS: Dict[str, TestCombination] = {
         "config_key": "production-stone-prod-p02",
         "expected": {
             "annotations": {
+                "kueue.konflux-ci.dev/requests-konflux-ci-dev-token": "1",
                 "kueue.konflux-ci.dev/requests-konflux-release": "1",
             },
             "labels": {
@@ -1645,6 +1647,7 @@ TEST_COMBINATIONS: Dict[str, TestCombination] = {
         "config_key": "production-stone-prod-p02",
         "expected": {
             "annotations": {
+                "kueue.konflux-ci.dev/requests-konflux-ci-dev-token": "1",
                 "kueue.konflux-ci.dev/requests-konflux-release": "1",
             },
             "labels": {


### PR DESCRIPTION
Add the `konflux-ci.dev/token` ephemeral resource to ring 2 production clusters: kflux-osp-p01, kflux-prd-rh03, stone-prod-p02.

Each PipelineRun requests 1 token with the token quota set equal to the PLR limit, so current cluster behavior is unchanged.

Token quotas: kflux-osp-p01=30, kflux-prd-rh03=350, stone-prod-p02=300.

kflux-osp-p01 and kflux-prd-rh03 inherit the token expression from the base config (updated in ring 1). stone-prod-p02 has its own config override which is updated here.

Contributes to: [KFLUXINFRA-3973](https://redhat.atlassian.net/browse/KFLUXINFRA-3973)

Assisted-by: Claude Code (claude-opus-4-6)

[KFLUXINFRA-3973]: https://redhat.atlassian.net/browse/KFLUXINFRA-3973?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ