### PR TITLE
Upgrade kubearchive to v1.22.2 on kflux-prd-rh03

### DIFF
--- a/components/kubearchive/production/kflux-prd-rh03/kubearchive.yaml
+++ b/components/kubearchive/production/kflux-prd-rh03/kubearchive.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: namespace
     app.kubernetes.io/name: kubearchive
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.20.0
+    app.kubernetes.io/version: v1.22.2
   name: kubearchive
 ---
 apiVersion: apiextensions.k8s.io/v1
@@ -552,7 +552,7 @@ metadata:
     app.kubernetes.io/component: api-server
     app.kubernetes.io/name: kubearchive-api-server
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.20.0
+    app.kubernetes.io/version: v1.22.2
   name: kubearchive-api-server
   namespace: kubearchive
 ---
@@ -563,7 +563,7 @@ metadata:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: kubearchive-vacuum
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.20.0
+    app.kubernetes.io/version: v1.22.2
   name: kubearchive-cluster-vacuum
   namespace: kubearchive
 ---
@@ -574,7 +574,7 @@ metadata:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: kubearchive-operator
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.20.0
+    app.kubernetes.io/version: v1.22.2
   name: kubearchive-operator
   namespace: kubearchive
 ---
@@ -585,7 +585,7 @@ metadata:
     app.kubernetes.io/component: sink
     app.kubernetes.io/name: kubearchive-sink
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.20.0
+    app.kubernetes.io/version: v1.22.2
   name: kubearchive-sink
   namespace: kubearchive
 ---
@@ -596,7 +596,7 @@ metadata:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: kubearchive-operator-leader-election
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.20.0
+    app.kubernetes.io/version: v1.22.2
   name: kubearchive-operator-leader-election
   namespace: kubearchive
 rules:
@@ -639,7 +639,7 @@ metadata:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: kubearchive-vacuum
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.20.0
+    app.kubernetes.io/version: v1.22.2
   name: kubearchive-vacuum
   namespace: kubearchive
 rules:
@@ -659,7 +659,7 @@ metadata:
     app.kubernetes.io/component: api-server
     app.kubernetes.io/name: kubearchive-api-server
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.20.0
+    app.kubernetes.io/version: v1.22.2
   name: kubearchive-api-server
 rules:
   - apiGroups:
@@ -677,7 +677,7 @@ metadata:
   labels:
     app.kubernetes.io/name: kubearchive-edit
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.20.0
+    app.kubernetes.io/version: v1.22.2
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
   name: kubearchive-edit
 rules:
@@ -791,7 +791,7 @@ metadata:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: kubearchive-operator-config-editor
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.20.0
+    app.kubernetes.io/version: v1.22.2
   name: kubearchive-operator-config-editor
 rules:
   - apiGroups:
@@ -820,7 +820,7 @@ metadata:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: kubearchive-operator-config-viewer
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.20.0
+    app.kubernetes.io/version: v1.22.2
   name: kubearchive-operator-config-viewer
 rules:
   - apiGroups:
@@ -844,7 +844,7 @@ metadata:
   labels:
     app.kubernetes.io/name: kubearchive-view
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.20.0
+    app.kubernetes.io/version: v1.22.2
     rbac.authorization.k8s.io/aggregate-to-view: "true"
   name: kubearchive-view
 rules:
@@ -868,7 +868,7 @@ metadata:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: kubearchive-operator-leader-election
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.20.0
+    app.kubernetes.io/version: v1.22.2
   name: kubearchive-operator-leader-election
   namespace: kubearchive
 roleRef:
@@ -887,7 +887,7 @@ metadata:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: kubearchive-vacuum
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.20.0
+    app.kubernetes.io/version: v1.22.2
   name: kubearchive-vacuum
   namespace: kubearchive
 roleRef:
@@ -906,7 +906,7 @@ metadata:
     app.kubernetes.io/component: api-server
     app.kubernetes.io/name: kubearchive-api-server
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.20.0
+    app.kubernetes.io/version: v1.22.2
   name: kubearchive-api-server
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -924,7 +924,7 @@ metadata:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: kubearchive-operator
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.20.0
+    app.kubernetes.io/version: v1.22.2
   name: kubearchive-operator
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -943,7 +943,7 @@ metadata:
     app.kubernetes.io/component: logging
     app.kubernetes.io/name: kubearchive-logging-reader
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.20.0
+    app.kubernetes.io/version: v1.22.2
   name: kubearchive-logging-reader
   namespace: kubearchive
 ---
@@ -955,7 +955,7 @@ metadata:
     app.kubernetes.io/component: logging
     app.kubernetes.io/name: kubearchive-logging-writer
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.20.0
+    app.kubernetes.io/version: v1.22.2
   name: kubearchive-logging-writer
   namespace: kubearchive
 ---
@@ -972,7 +972,7 @@ metadata:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: kubearchive-operator
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.20.0
+    app.kubernetes.io/version: v1.22.2
   name: kubearchive-operator
   namespace: kubearchive
 ---
@@ -980,7 +980,7 @@ apiVersion: v1
 data:
   DATABASE_DB: a3ViZWFyY2hpdmU=
   DATABASE_KIND: cG9zdGdyZXNxbA==
-  DATABASE_PASSWORD: RGF0IWFiYXNdM1Bhc3MqdzByZA==
+  DATABASE_PASSWORD: RGF0IWFiYXNdM1Bhc3MqdzByZA== # gitleaks:allow
   DATABASE_PORT: NTQzMg==
   DATABASE_URL: a3ViZWFyY2hpdmUtcncucG9zdGdyZXNxbC5zdmMuY2x1c3Rlci5sb2NhbA==
   DATABASE_USER: a3ViZWFyY2hpdmU=
@@ -990,7 +990,7 @@ metadata:
     app.kubernetes.io/component: database
     app.kubernetes.io/name: kubearchive-database-credentials
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.20.0
+    app.kubernetes.io/version: v1.22.2
   name: kubearchive-database-credentials
   namespace: kubearchive
 type: Opaque
@@ -1002,7 +1002,7 @@ metadata:
     app.kubernetes.io/component: logging
     app.kubernetes.io/name: kubearchive-logging
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.20.0
+    app.kubernetes.io/version: v1.22.2
   name: kubearchive-logging
   namespace: kubearchive
 stringData:
@@ -1016,7 +1016,7 @@ metadata:
     app.kubernetes.io/component: api-server
     app.kubernetes.io/name: kubearchive-api-server
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.20.0
+    app.kubernetes.io/version: v1.22.2
   name: kubearchive-api-server
   namespace: kubearchive
 spec:
@@ -1035,7 +1035,7 @@ metadata:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: kubearchive-operator-webhooks
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.20.0
+    app.kubernetes.io/version: v1.22.2
   name: kubearchive-operator-webhooks
   namespace: kubearchive
 spec:
@@ -1058,7 +1058,7 @@ metadata:
     app.kubernetes.io/component: sink
     app.kubernetes.io/name: kubearchive-sink
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.20.0
+    app.kubernetes.io/version: v1.22.2
   name: kubearchive-sink
   namespace: kubearchive
 spec:
@@ -1076,7 +1076,7 @@ metadata:
     app.kubernetes.io/component: api-server
     app.kubernetes.io/name: kubearchive-api-server
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.20.0
+    app.kubernetes.io/version: v1.22.2
   name: kubearchive-api-server
   namespace: kubearchive
 spec:
@@ -1130,7 +1130,7 @@ spec:
           envFrom:
             - secretRef:
                 name: kubearchive-database-credentials
-          image: quay.io/kubearchive/api:v1.20.0@sha256:43938bb7fabcc543cd3b5af0c9074196328f393d6e712f379572cca5ecfaab3c
+          image: quay.io/kubearchive/api:v1.22.2@sha256:e68a90000c9d78b2c63e01c8edd0b870cfbda5a3e518817c4d0590bc57aaa0d7
           livenessProbe:
             httpGet:
               path: /livez
@@ -1182,7 +1182,7 @@ metadata:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: kubearchive-operator
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.20.0
+    app.kubernetes.io/version: v1.22.2
   name: kubearchive-operator
   namespace: kubearchive
 spec:
@@ -1232,7 +1232,7 @@ spec:
               valueFrom:
                 resourceFieldRef:
                   resource: limits.cpu
-          image: quay.io/kubearchive/operator:v1.20.0@sha256:eb8b363f5cfddd190011aa1d0e7cdff5c50aefae0bd4207024755146b3840db9
+          image: quay.io/kubearchive/operator:v1.22.2@sha256:5f35ebd89eb8c7637d2b45d9587fa8920192258c14e78b8c23574375fdbb1303
           livenessProbe:
             httpGet:
               path: /healthz
@@ -1294,7 +1294,7 @@ metadata:
     app.kubernetes.io/component: sink
     app.kubernetes.io/name: kubearchive-sink
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.20.0
+    app.kubernetes.io/version: v1.22.2
   name: kubearchive-sink
   namespace: kubearchive
 spec:
@@ -1346,7 +1346,7 @@ spec:
           envFrom:
             - secretRef:
                 name: kubearchive-database-credentials
-          image: quay.io/kubearchive/sink:v1.20.0@sha256:8a13e20ba373f00f7e8889af2a67a61c44d9e8bab74a5c0186f324f2eb0cb120
+          image: quay.io/kubearchive/sink:v1.22.2@sha256:a52a10ce7219398f17b8b6ac43e62700087e7313b2418db2c4b8cc713a447f4e
           livenessProbe:
             httpGet:
               path: /livez
@@ -1387,7 +1387,7 @@ metadata:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: kubearchive-vacuum
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.20.0
+    app.kubernetes.io/version: v1.22.2
   name: cluster-vacuum
   namespace: kubearchive
 spec:
@@ -1408,7 +1408,7 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
-              image: quay.io/kubearchive/vacuum:v1.20.0@sha256:fe373300d999379656f78860906d7a30d77af088d6ba3bfa37a102c422d45480
+              image: quay.io/kubearchive/vacuum:1.22.2@sha256:9e61f19686a463e2468eaf82bc29e5165b57f8f77f69c7146d7a4c4e3035dd2f
               name: vacuum
           restartPolicy: Never
           serviceAccount: kubearchive-cluster-vacuum
@@ -1422,7 +1422,7 @@ metadata:
     app.kubernetes.io/component: kubearchive
     app.kubernetes.io/name: kubearchive-schema-migration
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.20.0
+    app.kubernetes.io/version: v1.22.2
   name: kubearchive-schema-migration
   namespace: kubearchive
 spec:
@@ -1438,7 +1438,7 @@ spec:
           envFrom:
             - secretRef:
                 name: kubearchive-database-credentials
-          image: quay.io/kubearchive/postgresql:v1.20.0@sha256:0aae85e8885295c87c3241915b8be86e08d5439f38ec9de9f95b012c67633874
+          image: quay.io/kubearchive/postgresql:v1.22.2@sha256:c8068879b345360213123aa03b6eeb7f9f1e22e58f6e2d258c751dafc6a4f7d4
           name: migration
           resources:
             limits:
@@ -1459,7 +1459,7 @@ metadata:
     app.kubernetes.io/component: api-server
     app.kubernetes.io/name: kubearchive-api-server-certificate
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.20.0
+    app.kubernetes.io/version: v1.22.2
   name: kubearchive-api-server-certificate
   namespace: kubearchive
 spec:
@@ -1493,7 +1493,7 @@ metadata:
     app.kubernetes.io/component: certs
     app.kubernetes.io/name: kubearchive-ca
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.20.0
+    app.kubernetes.io/version: v1.22.2
   name: kubearchive-ca
   namespace: kubearchive
 spec:
@@ -1515,7 +1515,7 @@ metadata:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: kubearchive-operator-certificate
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.20.0
+    app.kubernetes.io/version: v1.22.2
   name: kubearchive-operator-certificate
   namespace: kubearchive
 spec:
@@ -1534,7 +1534,7 @@ metadata:
     app.kubernetes.io/component: certs
     app.kubernetes.io/name: kubearchive
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.20.0
+    app.kubernetes.io/version: v1.22.2
   name: kubearchive
   namespace: kubearchive
 spec:
@@ -1548,7 +1548,7 @@ metadata:
     app.kubernetes.io/component: certs
     app.kubernetes.io/name: kubearchive-ca
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.20.0
+    app.kubernetes.io/version: v1.22.2
   name: kubearchive-ca
   namespace: kubearchive
 spec:
@@ -1563,7 +1563,7 @@ metadata:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: kubearchive-mutating-webhook-configuration
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.20.0
+    app.kubernetes.io/version: v1.22.2
   name: kubearchive-mutating-webhook-configuration
 webhooks:
   - admissionReviewVersions:
@@ -1676,7 +1676,7 @@ metadata:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: kubearchive-validating-webhook-configuration
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.20.0
+    app.kubernetes.io/version: v1.22.2
   name: kubearchive-validating-webhook-configuration
 webhooks:
   - admissionReviewVersions:

--- a/components/kubearchive/production/kflux-prd-rh03/kustomization.yaml
+++ b/components/kubearchive/production/kflux-prd-rh03/kustomization.yaml
@@ -23,7 +23,10 @@ configMapGenerator:
         annotations:
           argocd.argoproj.io/sync-wave: "-2"
       literals:
-        - MIGRATION_VERSION=5
+        - MIGRATION_VERSION=13
+    - name: kubearchive-deployment-schema-version
+      literals:
+        - MIGRATION_VERSION=13
     - name: kubearchive-logging-writer
       literals:
           - |
@@ -111,7 +114,7 @@ patches:
               spec:
                 containers:
                   - name: vacuum
-                    image: quay.io/kubearchive/vacuum:v1.20.0
+                    image: quay.io/kubearchive/vacuum:v1.22.2
 
   - patch: |-
       apiVersion: batch/v1
@@ -137,8 +140,18 @@ patches:
                       configMapKeyRef:
                         name: kubearchive-schema-version
                         key: MIGRATION_VERSION
+                  - name: BATCH_SIZE
+                    value: "10000"
                 securityContext:
                   runAsUser: null
+  - target:
+      kind: Job
+      name: kubearchive-schema-migration
+    patch: |-
+      - op: replace
+        path: /metadata/name
+        value: kubearchive-schema-migration-v13-v1.22.2
+
   # We don't need the Secret as it will be created by the ExternalSecrets Operator
   - patch: |-
       $patch: delete
@@ -222,7 +235,7 @@ patches:
                 - name: MIGRATION_VERSION
                   valueFrom:
                     configMapKeyRef:
-                      name: kubearchive-schema-version
+                      name: kubearchive-deployment-schema-version
                       key: MIGRATION_VERSION
                 securityContext:
                   readOnlyRootFilesystem: true
@@ -283,7 +296,7 @@ patches:
                 - name: MIGRATION_VERSION
                   valueFrom:
                     configMapKeyRef:
-                      name: kubearchive-schema-version
+                      name: kubearchive-deployment-schema-version
                       key: MIGRATION_VERSION
                 securityContext:
                   readOnlyRootFilesystem: true


### PR DESCRIPTION
## Summary
- Upgrade kubearchive from v1.20.0 to v1.22.2 in the `kflux-prd-rh03` production cluster
- Split `MIGRATION_VERSION` into two configmaps following the staging pattern: `kubearchive-schema-version` (migration Job) and `kubearchive-deployment-schema-version` (api-server/sink deployments), so deployments are protected from restarts during migration
- Update `MIGRATION_VERSION` from 5 to 13
- Update vacuum image to v1.22.2
- Add `BATCH_SIZE=10000` to the migration Job
- Add migration Job suffix `-v13`
- Improved performance of reads with the new DB normalized schema introduced in v1.21
[KONFLUX-14504](https://redhat.atlassian.net/browse/KONFLUX-14504)
[KAR-906](https://redhat.atlassian.net/browse/KAR-906)

## Test plan
- [ ] ArgoCD sync completes successfully for stone-prod-p02
- [ ] Schema migration job runs and completes
- [ ] KubeArchive API, operator, and sink pods are running
- [ ] Verify vacuum CronJob uses the correct image

## Risk assessment
- Low. Same upgrade that was reverted previously due to migration issues, now with `BATCH_SIZE` tuning and the two-configmap pattern from staging to protect deployments during migration. A rollback can be done by reverting this PR.

## Validation
- Staging PR: https://github.com/redhat-appstudio/infra-deployments/pull/12241
- Staging successfully running since May 11

[KONFLUX-14504]: https://redhat.atlassian.net/browse/KONFLUX-14504?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[KAR-906]: https://redhat.atlassian.net/browse/KAR-906?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ