### PR TITLE
PVO11Y-5279 Deploy KubeArchive exporter to staging

### DIFF
--- a/argo-cd-apps/base/member/infra-deployments/kustomization.yaml
+++ b/argo-cd-apps/base/member/infra-deployments/kustomization.yaml
@@ -45,5 +45,6 @@ resources:
   - konflux-kite
   - dummy-deployment
   - monitoring-workload-kanary
+  - monitoring-konflux-o11y-exporters
 components:
   - ../../../k-components/inject-infra-deployments-repo-details

--- a/argo-cd-apps/base/member/infra-deployments/monitoring-konflux-o11y-exporters/kustomization.yaml
+++ b/argo-cd-apps/base/member/infra-deployments/monitoring-konflux-o11y-exporters/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - monitoring-workload-konflux-o11y-exporters.yaml
+components:
+  - ../../../../k-components/deploy-to-member-cluster-merge-generator

--- a/argo-cd-apps/base/member/infra-deployments/monitoring-konflux-o11y-exporters/monitoring-workload-konflux-o11y-exporters.yaml
+++ b/argo-cd-apps/base/member/infra-deployments/monitoring-konflux-o11y-exporters/monitoring-workload-konflux-o11y-exporters.yaml
@@ -1,0 +1,43 @@
+kind: ApplicationSet
+apiVersion: argoproj.io/v1alpha1
+metadata:
+  name: monitoring-workload-konflux-o11y-kaexporter
+spec:
+  generators:
+    - merge:
+        mergeKeys:
+          - nameNormalized
+        generators:
+          - clusters:
+              values:
+                sourceRoot: components/monitoring/exporters/kaexporter
+                environment: staging
+                clusterDir: ""
+          - list:
+              elements:
+                - nameNormalized: stone-stage-p01
+                  values.clusterDir: stone-stage-p01
+                - nameNormalized: stone-stg-rh01
+                  values.clusterDir: stone-stg-rh01
+  template:
+    metadata:
+      name: konflux-o11y-kaexporter-{{nameNormalized}}
+    spec:
+      project: default
+      source:
+        path: '{{values.sourceRoot}}/{{values.environment}}/{{values.clusterDir}}'
+        repoURL: https://github.com/redhat-appstudio/infra-deployments.git
+        targetRevision: main
+      destination:
+        namespace: konflux-o11y-exporters
+        server: '{{server}}'
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
+        syncOptions:
+        - CreateNamespace=true
+        retry:
+          limit: 50
+          backoff:
+            duration: 15s

--- a/argo-cd-apps/overlays/development/delete-applications.yaml
+++ b/argo-cd-apps/overlays/development/delete-applications.yaml
@@ -114,3 +114,9 @@ kind: ApplicationSet
 metadata:
   name: monitoring-workload-kanary
 $patch: delete
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: monitoring-workload-konflux-o11y-kaexporter
+$patch: delete

--- a/argo-cd-apps/overlays/konflux-public-production/kustomization.yaml
+++ b/argo-cd-apps/overlays/konflux-public-production/kustomization.yaml
@@ -301,3 +301,8 @@ patches:
       kind: ApplicationSet
       version: v1alpha1
       name: monitoring-workload-kanary
+  - path: production-overlay-patch.yaml
+    target:
+      kind: ApplicationSet
+      version: v1alpha1
+      name: monitoring-workload-konflux-o11y-kaexporter

--- a/argo-cd-apps/overlays/production-downstream/kustomization.yaml
+++ b/argo-cd-apps/overlays/production-downstream/kustomization.yaml
@@ -310,3 +310,8 @@ patches:
       kind: ApplicationSet
       version: v1alpha1
       name: internal-services
+  - path: production-overlay-patch.yaml
+    target:
+      kind: ApplicationSet
+      version: v1alpha1
+      name: monitoring-workload-konflux-o11y-kaexporter

--- a/components/monitoring/exporters/kaexporter/production/kustomization.yaml
+++ b/components/monitoring/exporters/kaexporter/production/kustomization.yaml
@@ -1,0 +1,1 @@
+resources: []

--- a/components/monitoring/exporters/kaexporter/staging/base/external-secrets/ka-kubearchive-credentials.yaml
+++ b/components/monitoring/exporters/kaexporter/staging/base/external-secrets/ka-kubearchive-credentials.yaml
@@ -1,0 +1,19 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: ka-kubearchive-credentials
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  dataFrom:
+    - extract:
+        key: stonesoup/staging/monitoring/exporters/kaexporter
+  refreshInterval: 15m
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: appsre-stonesoup-vault
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    name: ka-kubearchive-credentials

--- a/components/monitoring/exporters/kaexporter/staging/base/external-secrets/kustomization.yaml
+++ b/components/monitoring/exporters/kaexporter/staging/base/external-secrets/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - ka-kubearchive-credentials.yaml

--- a/components/monitoring/exporters/kaexporter/staging/base/kustomization.yaml
+++ b/components/monitoring/exporters/kaexporter/staging/base/kustomization.yaml
@@ -1,0 +1,9 @@
+resources:
+  - rbac
+  - external-secrets
+  - https://github.com/redhat-appstudio/o11y/config/exporters/monitoring/kaexporter/base?ref=091fc2808ef6064fd26a83eed49726d2a7fc741a
+
+images:
+  - name: quay.io/redhat-appstudio/o11y
+    newName: quay.io/redhat-appstudio/o11y
+    newTag: 091fc2808ef6064fd26a83eed49726d2a7fc741a

--- a/components/monitoring/exporters/kaexporter/staging/base/rbac/kaexporter-maintainers.yaml
+++ b/components/monitoring/exporters/kaexporter/staging/base/rbac/kaexporter-maintainers.yaml
@@ -1,0 +1,11 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: appstudio-ka-exporter-maintainers
+subjects:
+  - kind: Group
+    name: konflux-o11y
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: component-maintainer

--- a/components/monitoring/exporters/kaexporter/staging/base/rbac/kustomization.yaml
+++ b/components/monitoring/exporters/kaexporter/staging/base/rbac/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - kaexporter-maintainers.yaml

--- a/components/monitoring/exporters/kaexporter/staging/stone-stage-p01/kustomization.yaml
+++ b/components/monitoring/exporters/kaexporter/staging/stone-stage-p01/kustomization.yaml
@@ -1,0 +1,11 @@
+resources:
+  - ../base
+
+patches:
+  - target:
+      kind: ExternalSecret
+      name: ka-kubearchive-credentials
+    patch: |
+      - op: replace
+        path: /spec/dataFrom/0/extract/key
+        value: stonesoup/staging/monitoring/exporters/kaexporter/stone-stage-p01

--- a/components/monitoring/exporters/kaexporter/staging/stone-stg-rh01/kustomization.yaml
+++ b/components/monitoring/exporters/kaexporter/staging/stone-stg-rh01/kustomization.yaml
@@ -1,0 +1,11 @@
+resources:
+  - ../base
+
+patches:
+  - target:
+      kind: ExternalSecret
+      name: ka-kubearchive-credentials
+    patch: |
+      - op: replace
+        path: /spec/dataFrom/0/extract/key
+        value: stonesoup/staging/monitoring/exporters/kaexporter/stone-stg-rh01


### PR DESCRIPTION
## What

- Add `components/monitoring/exporters/kaexporter/` with base, staging, and production overlays
- Add ArgoCD ApplicationSet `monitoring-workload-konflux-o11y-kaexporter` under `member/infra-deployments/monitoring-konflux-o11y-exporters/` using the standard merge generator + `deploy-to-member-cluster-merge-generator` component
- Namespace: `konflux-o11y-exporters` — shared namespace for all o11y exporters
- Production overlay deploys base only (namespace + RBAC); staging overlay adds the full exporter deployment via remote o11y kustomize reference at `1d9094f8f881fc2e5f8b39e6d09cfb07d32e7a25`
- Standard `production-overlay-patch.yaml` entries in both production overlays

Clusters affected: all member clusters (staging and production)

[PVO11Y-5279](https://redhat.atlassian.net/browse/PVO11Y-5279)

## Why

Deploy the KubeArchive exporter to staging so it can begin its 30-day cold start bootstrap and start serving pipeline metrics (build/integration/release duration and success rate) into RHOBS.

The `monitoring/exporters/<exporter>/` structure is designed so adding a future exporter is straightforward — add a new ApplicationSet YAML to the same directory:

```
monitoring-konflux-o11y-exporters/
  kustomization.yaml
  monitoring-workload-konflux-o11y-exporters.yaml   ← kaexporter (this PR)
  # Later:
  # monitoring-workload-konflux-o11y-registry.yaml  ← registry exporter
```

## Validation

- [ ] `kustomize build` passes for all affected overlays
- [ ] Vault path for `ka-kubearchive-credentials` ExternalSecret is provisioned

[PVO11Y-5279]: https://redhat.atlassian.net/browse/PVO11Y-5279?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ