### PR TITLE
kueue: use correct label for nudge pipelineruns in stage

### DIFF
--- a/components/kueue/development/tekton-kueue/config.yaml
+++ b/components/kueue/development/tekton-kueue/config.yaml
@@ -140,8 +140,8 @@ cel:
     # Set the pipeline priority
     - |
         has(pipelineRun.metadata.labels) &&
-        'build.appstudio.openshift.io/type' in pipelineRun.metadata.labels &&
-        pipelineRun.metadata.labels['build.appstudio.openshift.io/type'] == 'nudge' ?
+        'build.appstudio.redhat.com/type' in pipelineRun.metadata.labels &&
+        pipelineRun.metadata.labels['build.appstudio.redhat.com/type'] == 'nudge' ?
         priority('konflux-nudge') :
 
         pacEventType == 'push' ? priority('konflux-post-merge-build') :

--- a/components/kueue/staging/base/tekton-kueue/config.yaml
+++ b/components/kueue/staging/base/tekton-kueue/config.yaml
@@ -140,8 +140,8 @@ cel:
     # Set the pipeline priority
     - |
         has(pipelineRun.metadata.labels) &&
-        'build.appstudio.openshift.io/type' in pipelineRun.metadata.labels &&
-        pipelineRun.metadata.labels['build.appstudio.openshift.io/type'] == 'nudge' ?
+        'build.appstudio.redhat.com/type' in pipelineRun.metadata.labels &&
+        pipelineRun.metadata.labels['build.appstudio.redhat.com/type'] == 'nudge' ?
         priority('konflux-nudge') :
 
         pacEventType == 'push' ? priority('konflux-post-merge-build') :

--- a/hack/test-tekton-kueue-config.py
+++ b/hack/test-tekton-kueue-config.py
@@ -480,6 +480,37 @@ PIPELINERUN_DEFINITIONS: Dict[str, PipelineRunTestData] = {
                 "name": "nudging-pipelinerun",
                 "namespace": "default",
                 "labels": {
+                    "build.appstudio.redhat.com/type": "nudge",
+                    # make sure the nudge type overrides this
+                    "pipelinesascode.tekton.dev/event-type": "push"
+                }
+            },
+            "spec": {
+                "pipelineRef": {"name": "renovate"},
+                "workspaces": [{"name": "shared-workspace", "emptyDir": {}}]
+            }
+        },
+        "expected": {
+            "annotations": {
+                "kueue.konflux-ci.dev/requests-konflux-ci-dev-token": "2",
+            },
+            "labels": {
+                "build.appstudio.redhat.com/type": "nudge",
+                "kueue.x-k8s.io/queue-name": "pipelines-queue",
+                "kueue.x-k8s.io/priority-class": "konflux-nudge"
+            }
+        }
+    },
+
+    "nudge_pipelinerun_prod": {
+        "name": "Multi-platform pipeline with user-specific priority (new style)",
+        "pipelinerun": {
+            "apiVersion": "tekton.dev/v1",
+            "kind": "PipelineRun",
+            "metadata": {
+                "name": "nudging-pipelinerun",
+                "namespace": "default",
+                "labels": {
                     "build.appstudio.openshift.io/type": "nudge",
                     # make sure the nudge type overrides this
                     "pipelinesascode.tekton.dev/event-type": "push"
@@ -1400,7 +1431,7 @@ TEST_COMBINATIONS: Dict[str, TestCombination] = {
         }
     },
     "nudging_production": {
-        "pipelinerun_key": "nudge_pipelinerun",
+        "pipelinerun_key": "nudge_pipelinerun_prod",
         "config_key": "production",
         "expected": {
             "annotations": {},
@@ -1640,7 +1671,7 @@ TEST_COMBINATIONS: Dict[str, TestCombination] = {
         }
     },
     "nudging_production-stone-prod-p01": {
-        "pipelinerun_key": "nudge_pipelinerun",
+        "pipelinerun_key": "nudge_pipelinerun_prod",
         "config_key": "production-stone-prod-p01",
         "expected": {
             "annotations": {
@@ -1684,7 +1715,7 @@ TEST_COMBINATIONS: Dict[str, TestCombination] = {
         }
     },
     "nudging_production-kflux-prd-rh02": {
-        "pipelinerun_key": "nudge_pipelinerun",
+        "pipelinerun_key": "nudge_pipelinerun_prod",
         "config_key": "production-kflux-prd-rh02",
         "expected": {
             "annotations": {


### PR DESCRIPTION
Nudging pipelineruns get the `build.appstudio.redhat.com/type=nudge` label, not `build.appstudio.openshift.io/type=nudge`.  Adjust our staging/development overlays to use the correct label.

Fixes: [KFLUXINFRA-3877](https://redhat.atlassian.net/browse/KFLUXINFRA-3877)

[KFLUXINFRA-3877]: https://redhat.atlassian.net/browse/KFLUXINFRA-3877?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ