### PR TITLE
feat(KONFLUX-14375): Allow deploying ExternalSecrets in managed NS for Konflux perf&scale probe runs

### DIFF
--- a/components/cluster-secret-store/staging/perfscale-namespaces-patch.yaml
+++ b/components/cluster-secret-store/staging/perfscale-namespaces-patch.yaml
@@ -11,3 +11,6 @@
 - op: add
   path: /spec/conditions/0/namespaces/-
   value: konflux-perfscale-4-tenant
+- op: add
+  path: /spec/conditions/0/namespaces/-
+  value: managed-konflux-perfscale-tenant


### PR DESCRIPTION
We are migrating to run release pipeline runs in separate managed NS and we want to use `ExternalSecrets` to manage Quay push secret.

Details: https://redhat.atlassian.net/browse/KONFLUX-14375