### PR TITLE
Promote release-service and grafana-dashboard from development to staging

### DIFF
--- a/components/monitoring/grafana/staging/dashboards/release/kustomization.yaml
+++ b/components/monitoring/grafana/staging/dashboards/release/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- https://github.com/konflux-ci/release-service/config/grafana/?ref=9775e0df9cb3fc38026907595a821c87e62b1684
+- https://github.com/konflux-ci/release-service/config/grafana/?ref=8d113fa685bfa3b4188d74896762c377ece81987

--- a/components/release/staging/kustomization.yaml
+++ b/components/release/staging/kustomization.yaml
@@ -4,7 +4,7 @@ resources:
   - ../base
   - ../base/monitor/staging
   - external-secrets/release-monitor-secret.yaml
-  - https://github.com/konflux-ci/release-service/config/default?ref=9775e0df9cb3fc38026907595a821c87e62b1684
+  - https://github.com/konflux-ci/release-service/config/default?ref=8d113fa685bfa3b4188d74896762c377ece81987
   - release_service_config.yaml
   - signing_configs.yaml
 
@@ -14,6 +14,6 @@ components:
 images:
   - name: quay.io/konflux-ci/release-service
     newName: quay.io/konflux-ci/release-service
-    newTag: 9775e0df9cb3fc38026907595a821c87e62b1684
+    newTag: 8d113fa685bfa3b4188d74896762c377ece81987
 
 namespace: release-service


### PR DESCRIPTION
Included PRs:
 - https://github.com/konflux-ci/release-service/pull/1712 
 - https://github.com/konflux-ci/release-service/pull/1713 
 - https://github.com/konflux-ci/release-service/pull/1718 
 - https://github.com/konflux-ci/release-service/pull/1711 
 - https://github.com/konflux-ci/release-service/pull/1717 
 - https://github.com/konflux-ci/release-service/pull/1714 
 - https://github.com/konflux-ci/release-service/pull/1716 
 - https://github.com/konflux-ci/release-service/pull/1688 
 - https://github.com/konflux-ci/release-service/pull/1679 
 - https://github.com/konflux-ci/release-service/pull/1678 
 - https://github.com/konflux-ci/release-service/pull/1681 
 - https://github.com/konflux-ci/release-service/pull/1708 
 - https://github.com/konflux-ci/release-service/pull/1693 
 - https://github.com/konflux-ci/release-service/pull/1707 
 - https://github.com/konflux-ci/release-service/pull/1704 
 - https://github.com/konflux-ci/release-service/pull/1696 
 - https://github.com/konflux-ci/release-service/pull/1698 
 - https://github.com/konflux-ci/release-service/pull/1703 
 - https://github.com/konflux-ci/release-service/pull/1697 
 - https://github.com/konflux-ci/release-service/pull/1702 
 - https://github.com/konflux-ci/release-service/pull/1692 
