### PR TITLE
PVO11Y-5268 Allow appstudio-tekton namespace to access vault in staging

### DIFF
--- a/components/cluster-secret-store/staging/kustomization.yaml
+++ b/components/cluster-secret-store/staging/kustomization.yaml
@@ -21,3 +21,9 @@ patches:
       kind: ClusterSecretStore
       group: external-secrets.io
       version: v1
+  - path: observability-namespaces-patch.yaml
+    target:
+      name: appsre-stonesoup-vault
+      kind: ClusterSecretStore
+      group: external-secrets.io
+      version: v1

--- a/components/cluster-secret-store/staging/observability-namespaces-patch.yaml
+++ b/components/cluster-secret-store/staging/observability-namespaces-patch.yaml
@@ -1,0 +1,4 @@
+---
+- op: add
+  path: /spec/conditions/0/namespaces/-
+  value: appstudio-tekton


### PR DESCRIPTION
## Summary
- Add `appstudio-tekton` to the ClusterSecretStore namespace allowlist in staging so the tekton-ms ExternalSecret can retrieve RHOBS credentials from vault

## Context
The tekton-ms MonitoringStack remote-write was merged but the ExternalSecret is failing with "could not get secret data from provider" because `appstudio-tekton` is not in the `appsre-stonesoup-vault` namespace condition.

## Test plan
- [ ] Verify ExternalSecret `rhobs` in `appstudio-tekton` namespace transitions to `SecretSynced`
- [ ] Verify `rhobs` secret is created in `appstudio-tekton` namespace