### PR TITLE
feat(PVO11Y-5283): forward Kueue admission wait sum and count stg

### DIFF
--- a/components/monitoring/prometheus/staging/base/federation/endpoints-params.yaml
+++ b/components/monitoring/prometheus/staging/base/federation/endpoints-params.yaml
@@ -218,6 +218,8 @@
     - '{__name__="tekton_kueue_cel_evaluations_total"}'
     - '{__name__="kueue_cluster_queue_status"}'
     - '{__name__="kueue_admission_wait_time_seconds_bucket"}'
+    - '{__name__="kueue_admission_wait_time_seconds_sum"}'
+    - '{__name__="kueue_admission_wait_time_seconds_count"}'
     - '{__name__="up", job=~".*kueue.*"}'
     - '{__name__="kueue_admitted_active_workloads", cluster_queue="cluster-pipeline-queue"}'
     - '{__name__="kueue_pending_workloads", cluster_queue="cluster-pipeline-queue"}'


### PR DESCRIPTION
Include kueue_admission_wait_time_seconds sum and count for calculating average admission wait times for Kueue. Applying this for stage clusters first.