### PR TITLE
konflux-ui: replace static dex-client SA token with dynamic projected SA token (staging-p01 only)

### DIFF
--- a/components/konflux-ui/staging/base/kustomization.yaml
+++ b/components/konflux-ui/staging/base/kustomization.yaml
@@ -1,7 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - dex
   - proxy
   - route-and-oauth.yaml
   - ../../base

--- a/components/konflux-ui/staging/stone-stage-p01/base/dex/dex.yaml
+++ b/components/konflux-ui/staging/stone-stage-p01/base/dex/dex.yaml
@@ -1,0 +1,164 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: dex
+  name: dex
+  annotations:
+    ignore-check.kube-linter.io/no-anti-affinity: "Using topologySpreadConstraints"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: dex
+  template:
+    metadata:
+      labels:
+        app: dex
+    spec:
+      serviceAccountName: dex
+      topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: topology.kubernetes.io/zone
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app: dex
+      containers:
+      - image: quay.io/konflux-ci/dex:latest
+        name: dex
+        command: ["/usr/local/bin/run-dex.sh"]
+        securityContext:
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+        resources:
+          limits:
+            cpu: 100m
+            memory: 256Mi
+          requests:
+            cpu: 100m
+            memory: 256Mi
+        ports:
+        - name: https
+          containerPort: 9443
+        - name: telemetry
+          containerPort: 5558
+          protocol: TCP
+        volumeMounts:
+        - name: tmp # writeable tmp folder
+          mountPath: /tmp
+          readOnly: false
+        - name: dex-token
+          mountPath: /var/run/secrets/konflux-ci.dev/serviceaccount/
+        - name: run-dex
+          mountPath: /usr/local/bin/run-dex.sh
+          subPath: "run-dex.sh"
+        - name: dex
+          mountPath: /etc/dex/cfg
+        - name: tls
+          mountPath: /etc/dex/tls
+        livenessProbe:
+          initialDelaySeconds: 10
+          httpGet:
+            path: /healthz/ready
+            port: telemetry
+        readinessProbe:
+          initialDelaySeconds: 10
+          httpGet:
+            path: /healthz/ready
+            port: telemetry
+        env:
+        - name: GODEBUG
+          value: "http2server=0"
+        - name: TOKEN_PATH
+          value: /var/run/secrets/konflux-ci.dev/serviceaccount/token
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: POD_SERVICE_ACCOUNT
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
+        - name: OAUTH2_CLIENT_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: oauth2-proxy-client-secret
+              key: client-secret
+      volumes:
+      - name: tmp
+        emptyDir:
+          medium: Memory
+      - name: dex-token
+        projected:
+          defaultMode: 0440
+          sources:
+          - serviceAccountToken:
+              expirationSeconds: 600
+              path: token
+      - name: dex
+        configMap:
+          name: dex
+          defaultMode: 420
+          items:
+          - key: dex-config.yaml
+            path: config.yaml
+      - name: run-dex
+        configMap:
+          name: run-dex
+          defaultMode: 0755
+          items:
+          - key: run-dex.sh
+            path: run-dex.sh
+      - name: tls
+        secret:
+          secretName: dex-cert
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: dex
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: dex-cert
+spec:
+  type: ClusterIP
+  ports:
+  - name: dex
+    port: 9443
+    protocol: TCP
+    targetPort: 9443
+  selector:
+    app: dex
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: dex
+  name: dex
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: dex
+rules:
+- apiGroups: ["dex.coreos.com"] # API group created by dex
+  resources: ["*"]
+  verbs: ["*"]
+- apiGroups: ["apiextensions.k8s.io"]
+  resources: ["customresourcedefinitions"]
+  verbs: ["create"] # To manage its own resources, dex must be able to create customresourcedefinitions
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: dex
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: dex
+subjects:
+- kind: ServiceAccount
+  name: dex           # Service account assigned to the dex pod, created above
+  namespace: konflux-ui  # The namespace dex is running in

--- a/components/konflux-ui/staging/stone-stage-p01/base/dex/kustomization.yaml
+++ b/components/konflux-ui/staging/stone-stage-p01/base/dex/kustomization.yaml
@@ -1,0 +1,15 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- dex.yaml
+
+images:
+- name: quay.io/konflux-ci/dex
+  newTag: 2fbe7f0936f3b0e31b09690b3327d610efcb5a77
+
+configMapGenerator:
+- name: run-dex
+  files:
+  - run-dex.sh
+  options:
+    disableNameSuffixHash: false

--- a/components/konflux-ui/staging/stone-stage-p01/base/dex/run-dex.sh
+++ b/components/konflux-ui/staging/stone-stage-p01/base/dex/run-dex.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+
+set -euo pipefail
+
+ORIGINAL_TOKEN=/tmp/var/run/secrets/dex/serviceaccount/token
+TOKEN_PATH=${TOKEN_PATH:-/var/run/secrets/kubernetes.io/serviceaccount/token}
+WAIT_TIME=10
+HALT_TIMEOUT=100
+MAX_JITTER_TIME=10
+
+# auxiliary log function
+log() { printf "%s: %s\n" "$(date -Iseconds)" "$*"; }
+
+# forward SIGTERM/SIGINT for graceful shutdown
+#
+# shellcheck disable=SC2329
+# ShellCheck is currently bad at figuring out functions that are invoked via trap
+shutdown() {
+  log "received signal, shutting down"
+  if [ -n "${dex_pid:-}" ] && [ -d "/proc/${dex_pid}" ]; then
+    kill -s TERM "${dex_pid}" 2>/dev/null || true
+    wait_for_halt || true
+  fi
+  exit 143
+}
+
+wait_for_halt() (
+  counter=0
+  while [ -d "/proc/${dex_pid}" ] && [ $(( counter++ )) -le "${HALT_TIMEOUT}" ]; do 
+    sleep 1
+  done
+
+  if [ -d "/proc/${dex_pid}" ]; then
+    return 1
+  fi
+  return 0
+)
+
+start_with_reload() {
+  while true; do
+    # copy the original token for later use
+    log "copying the token to ${ORIGINAL_TOKEN}"
+    mkdir -p "$(dirname "${ORIGINAL_TOKEN}")"
+    rm "${ORIGINAL_TOKEN}" || true
+    cp "${TOKEN_PATH}" "${ORIGINAL_TOKEN}"
+
+    # run dex in a subprocess
+    OPENSHIFT_OAUTH_CLIENT_SECRET="$(cat "${ORIGINAL_TOKEN}")" \
+    OPENSHIFT_OAUTH_CLIENT_ID="${OPENSHIFT_OAUTH_CLIENT_ID:-system:serviceaccount:${NAMESPACE}:${POD_SERVICE_ACCOUNT}}" \
+      /usr/local/bin/dex serve /etc/dex/cfg/config.yaml &
+    dex_pid="$!"
+    log "run Dex in background with pid ${dex_pid}"
+
+    # wait for the token to be refresh by kubelet
+    log "waiting for the token to be refreshed"
+    while [ "$(cksum < "${ORIGINAL_TOKEN}")" = "$(cksum < "${TOKEN_PATH}")" ]; do sleep "${WAIT_TIME}"; done
+
+    # reduce likelihood of having all replicas refreshing at the same time
+    jitter="$(( $(od -An -N2 -i /dev/urandom) % MAX_JITTER_TIME ))"
+    log "sleeping ${jitter} seconds to prevent all replicas to restart at the same time"
+    sleep "${jitter}"
+
+    # Send SIGTERM to Dex
+    log "token refreshed, halting Dex via SIGTERM"
+    if [ -d "/proc/${dex_pid}" ]; then
+      kill -s TERM "${dex_pid}" || true
+    fi
+
+    # Wait for Dex to halt
+    log "waiting for Dex to gracefully stop"
+    if ! wait_for_halt; then
+      log "Dex didn't stop in ${HALT_TIMEOUT} seconds, breaking"
+      exit 1
+    fi
+  done
+
+  log "the loop broke unexpectedly"
+  exit 1
+}
+
+main() {
+  trap shutdown TERM INT
+
+  start_with_reload
+}
+
+main

--- a/components/konflux-ui/staging/stone-stage-p01/dex-config.yaml
+++ b/components/konflux-ui/staging/stone-stage-p01/dex-config.yaml
@@ -29,6 +29,6 @@ connectors:
       # OpenShift API
       issuer: https://api.stone-stage-p01.hpmt.p1.openshiftapps.com:6443
       # Credentials can be string literals or pulled from the environment.
-      clientID: system:serviceaccount:konflux-ui:dex-client
+      clientID: $OPENSHIFT_OAUTH_CLIENT_ID
       clientSecret: $OPENSHIFT_OAUTH_CLIENT_SECRET
       redirectURI: https://konflux-ui.apps.stone-stage-p01.hpmt.p1.openshiftapps.com/idp/callback

--- a/components/konflux-ui/staging/stone-stage-p01/kustomization.yaml
+++ b/components/konflux-ui/staging/stone-stage-p01/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - ../base
+- ./base/dex
 # Remove this comment to rotate dex and proxy secrets
 # - ./configure-oauth-proxy-secret.yaml
 
@@ -43,10 +44,18 @@ patches:
 - path: set-redirect-uri.yaml
   target:
     kind: ServiceAccount
-    name: dex-client
+    name: dex
 - path: set-hostname.yaml
   target:
     kind: Route
     version: v1
+- path: remove-dex-client.yaml
+  target:
+    kind: ServiceAccount
+    name: dex-client
+- path: remove-dex-client-secret.yaml
+  target:
+    kind: Secret
+    name: dex-client
 
 namespace: konflux-ui

--- a/components/konflux-ui/staging/stone-stage-p01/remove-dex-client-secret.yaml
+++ b/components/konflux-ui/staging/stone-stage-p01/remove-dex-client-secret.yaml
@@ -1,0 +1,5 @@
+$patch: delete
+apiVersion: v1
+kind: Secret
+metadata:
+  name: dex-client

--- a/components/konflux-ui/staging/stone-stage-p01/remove-dex-client.yaml
+++ b/components/konflux-ui/staging/stone-stage-p01/remove-dex-client.yaml
@@ -1,0 +1,5 @@
+$patch: delete
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: dex-client

--- a/components/konflux-ui/staging/stone-stg-rh01/kustomization.yaml
+++ b/components/konflux-ui/staging/stone-stg-rh01/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - ../base
+- ../base/dex
 # Remove this comment to rotate dex and proxy secrets
 # - ./configure-oauth-proxy-secret.yaml
 - backstage-serviceaccount.yaml


### PR DESCRIPTION
## What

- Switch dex from a static long-lived \`dex-client\` SA token to a short-lived projected ServiceAccount token (600s TTL)
- Replace dex image with \`quay.io/konflux-ci/dex:latest\` (bundles \`run-dex.sh\`)
- Switch dex entrypoint to \`run-dex.sh\`: reads the projected SA token as \`OPENSHIFT_OAUTH_CLIENT_SECRET\`, auto-restarts dex on token rotation
- Add \`TOKEN_PATH\`, \`NAMESPACE\`, \`POD_SERVICE_ACCOUNT\` env vars; add \`tmp\`, \`dex-token\`, \`run-dex\` volumes
- Change dex connector \`clientID\` to \`\$OPENSHIFT_OAUTH_CLIENT_ID\` (dynamically resolved from the pod SA)
- Redirect the \`oauth-redirecturi\` annotation patch to the \`dex\` SA
- Remove the obsolete \`dex-client\` SA and static token Secret from the staging base

Clusters affected: stone-stage-p01

## Why

Static long-lived SA tokens are a security concern and require manual rotation. Projected SA tokens rotate automatically every 600s with no manual intervention, and tie the OAuth client identity to the pod's own SA.

## Validation

- \`kustomize build --enable-helm components/konflux-ui/staging/stone-stage-p01/\` passes
- \`kustomize build --enable-helm components/konflux-ui/staging/stone-stg-rh01/\` passes
- \`dex-client\` SA and Secret absent from rendered output for both clusters