### PR TITLE
PVO11Y-5268 Enable honorLabels on tekton-ms ServiceMonitor

### DIFF
--- a/components/monitoring/prometheus/base/tekton-ms/servicemonitor.yaml
+++ b/components/monitoring/prometheus/base/tekton-ms/servicemonitor.yaml
@@ -16,3 +16,4 @@ spec:
   endpoints:
   - port: http-metrics
     interval: 15s
+    honorLabels: true


### PR DESCRIPTION
## Summary
- Enable `honorLabels: true` on the tekton-ms ServiceMonitor so Prometheus preserves the metric's own `namespace` label instead of overwriting it with the target namespace (`openshift-pipelines`)

## Context
After deploying the tekton-ms remote-write, all metrics in RHOBS show `namespace=openshift-pipelines` regardless of which tenant namespace the PipelineRun ran in. This is because Prometheus defaults to overwriting the `namespace` label with the scrape target's namespace.

## Test plan
- [ ] Verify metrics in RHOBS show per-tenant namespace labels (e.g., `namespace=some-tenant`) instead of `namespace=openshift-pipelines`