### PR TITLE
Revert "Temporarily disable s390x-static-1 on kflux-ocp-p01 due to failure state"

### DIFF
--- a/components/kueue/production/kflux-ocp-p01/queue-config/cluster-queue.yaml
+++ b/components/kueue/production/kflux-ocp-p01/queue-config/cluster-queue.yaml
@@ -182,7 +182,7 @@ spec:
       - name: linux-root-arm64
         nominalQuota: '250'
       - name: linux-s390x
-        nominalQuota: '52'
+        nominalQuota: '56'
       - name: linux-x86-64
         nominalQuota: 1k
       - name: local

--- a/components/multi-platform-controller/production-downstream/kflux-ocp-p01/host-values.yaml
+++ b/components/multi-platform-controller/production-downstream/kflux-ocp-p01/host-values.yaml
@@ -171,12 +171,12 @@ staticHosts:
     user: "root"
 
  # s390
-  # s390x-static-1:
-  #   address: "10.130.85.132"
-  #   concurrency: "4"
-  #   platform: "linux/s390x"
-  #   secret: "ibm-s390x-ssh-key"
-  #   user: "cloud-user"  # Changed from root per IBM Cloud Jan 2026 announcement
+  s390x-static-1:
+    address: "10.130.85.132"
+    concurrency: "4"
+    platform: "linux/s390x"
+    secret: "ibm-s390x-ssh-key"
+    user: "cloud-user"  # Changed from root per IBM Cloud Jan 2026 announcement
 
   s390x-static-2:
     address: "10.130.85.133"


### PR DESCRIPTION
Reverts redhat-appstudio/infra-deployments#12640 since machine is back into service

## Risk Assessment
Risk Level: Low
Description: Undo Disable failed machine
Rollback: Revert PR

## Validation
Not needed
