### PR TITLE
Add ibm public key to key viewer rb

### DIFF
--- a/components/pipeline-service/production/base/main-pipeline-service-configuration.yaml
+++ b/components/pipeline-service/production/base/main-pipeline-service-configuration.yaml
@@ -70,15 +70,15 @@ metadata:
   name: tekton-results-info
   namespace: tekton-results
 rules:
-  - apiGroups:
-      - ""
-    resourceNames:
-      - tekton-results-info
-    resources:
-      - configmaps
-    verbs:
-      - get
-      - describe
+- apiGroups:
+  - ""
+  resourceNames:
+  - tekton-results-info
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - describe
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -88,36 +88,36 @@ metadata:
     argocd.argoproj.io/sync-wave: "0"
   name: openshift-gitops-apply-tekton-config-parameters
 rules:
-  - apiGroups:
-      - monitoring.coreos.com
-    resources:
-      - servicemonitors
-    verbs:
-      - get
-      - list
-      - patch
-      - create
-      - delete
-  - apiGroups:
-      - operator.tekton.dev
-    resources:
-      - tektonconfigs
-    verbs:
-      - get
-      - list
-      - patch
-      - create
-      - delete
-  - apiGroups:
-      - security.openshift.io
-    resources:
-      - securitycontextconstraints
-    verbs:
-      - get
-      - list
-      - patch
-      - create
-      - delete
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - servicemonitors
+  verbs:
+  - get
+  - list
+  - patch
+  - create
+  - delete
+- apiGroups:
+  - operator.tekton.dev
+  resources:
+  - tektonconfigs
+  verbs:
+  - get
+  - list
+  - patch
+  - create
+  - delete
+- apiGroups:
+  - security.openshift.io
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - get
+  - list
+  - patch
+  - create
+  - delete
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -127,16 +127,16 @@ metadata:
     argocd.argoproj.io/sync-wave: "0"
   name: openshift-gitops-jobs-admin
 rules:
-  - apiGroups:
-      - batch
-    resources:
-      - jobs
-    verbs:
-      - get
-      - list
-      - patch
-      - create
-      - delete
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - get
+  - list
+  - patch
+  - create
+  - delete
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -146,37 +146,37 @@ metadata:
     argocd.argoproj.io/sync-wave: "0"
   name: pipeline-service-exporter-reader
 rules:
-  - apiGroups:
-      - ""
-    resources:
-      - pods
-      - services
-      - namespaces
-      - endpoints
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - apiextensions.k8s.io
-    resources:
-      - customresourcedefinitions
-    verbs:
-      - get
-  - apiGroups:
-      - tekton.dev
-    resources:
-      - pipelineruns
-      - taskruns
-    verbs:
-      - get
-      - list
-      - watch
-      - patch
-  - nonResourceURLs:
-      - /metrics
-    verbs:
-      - get
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - services
+  - namespaces
+  - endpoints
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+- apiGroups:
+  - tekton.dev
+  resources:
+  - pipelineruns
+  - taskruns
+  verbs:
+  - get
+  - list
+  - watch
+  - patch
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -186,17 +186,17 @@ metadata:
     argocd.argoproj.io/sync-wave: "0"
   name: tekton-chains-public-key-viewer
 rules:
-  - apiGroups:
-      - ""
-    resourceNames:
-      - public-key
-      - ibm-public-key
-    resources:
-      - secrets
-    verbs:
-      - get
-      - list
-      - watch
+- apiGroups:
+  - ""
+  resourceNames:
+  - public-key
+  - ibm-public-key
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -209,18 +209,18 @@ metadata:
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
   name: tekton-results-admin
 rules:
-  - apiGroups:
-      - results.tekton.dev
-    resources:
-      - results
-      - records
-      - logs
-    verbs:
-      - create
-      - update
-      - get
-      - list
-      - delete
+- apiGroups:
+  - results.tekton.dev
+  resources:
+  - results
+  - records
+  - logs
+  verbs:
+  - create
+  - update
+  - get
+  - list
+  - delete
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -232,18 +232,18 @@ metadata:
     app.kubernetes.io/version: devel
   name: tekton-results-api
 rules:
-  - apiGroups:
-      - authentication.k8s.io
-    resources:
-      - tokenreviews
-    verbs:
-      - create
-  - apiGroups:
-      - authorization.k8s.io
-    resources:
-      - subjectaccessreviews
-    verbs:
-      - create
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -257,16 +257,16 @@ metadata:
     rbac.authorization.k8s.io/aggregate-to-view: "true"
   name: tekton-results-readonly
 rules:
-  - apiGroups:
-      - results.tekton.dev
-    resources:
-      - results
-      - records
-      - logs
-      - summary
-    verbs:
-      - get
-      - list
+- apiGroups:
+  - results.tekton.dev
+  resources:
+  - results
+  - records
+  - logs
+  - summary
+  verbs:
+  - get
+  - list
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -278,17 +278,17 @@ metadata:
     app.kubernetes.io/version: devel
   name: tekton-results-readwrite
 rules:
-  - apiGroups:
-      - results.tekton.dev
-    resources:
-      - results
-      - records
-      - logs
-    verbs:
-      - create
-      - update
-      - get
-      - list
+- apiGroups:
+  - results.tekton.dev
+  resources:
+  - results
+  - records
+  - logs
+  verbs:
+  - create
+  - update
+  - get
+  - list
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -298,10 +298,10 @@ metadata:
     argocd.argoproj.io/sync-wave: "0"
   name: tekton-results-service-metrics-reader
 rules:
-  - nonResourceURLs:
-      - /metrics
-    verbs:
-      - get
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -313,73 +313,73 @@ metadata:
     app.kubernetes.io/version: devel
   name: tekton-results-watcher
 rules:
-  - apiGroups:
-      - results.tekton.dev
-    resources:
-      - logs
-      - results
-      - records
-    verbs:
-      - create
-      - get
-      - update
-  - apiGroups:
-      - tekton.dev
-    resources:
-      - pipelineruns
-      - taskruns
-    verbs:
-      - get
-      - list
-      - patch
-      - update
-      - watch
-      - delete
-  - apiGroups:
-      - ""
-    resources:
-      - configmaps
-      - pods
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - ""
-    resources:
-      - pods/log
-    verbs:
-      - get
-  - apiGroups:
-      - ""
-    resources:
-      - events
-    verbs:
-      - get
-      - list
-      - create
-      - update
-      - delete
-      - patch
-      - watch
-  - apiGroups:
-      - tekton.dev
-    resources:
-      - pipelines
-    verbs:
-      - get
-  - apiGroups:
-      - coordination.k8s.io
-    resources:
-      - leases
-    verbs:
-      - get
-      - list
-      - create
-      - update
-      - delete
-      - patch
-      - watch
+- apiGroups:
+  - results.tekton.dev
+  resources:
+  - logs
+  - results
+  - records
+  verbs:
+  - create
+  - get
+  - update
+- apiGroups:
+  - tekton.dev
+  resources:
+  - pipelineruns
+  - taskruns
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - delete
+  - patch
+  - watch
+- apiGroups:
+  - tekton.dev
+  resources:
+  - pipelines
+  verbs:
+  - get
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - delete
+  - patch
+  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -389,18 +389,18 @@ metadata:
     argocd.argoproj.io/sync-wave: "0"
   name: tekton-results-watcher-rbac
 rules:
-  - apiGroups:
-      - authentication.k8s.io
-    resources:
-      - tokenreviews
-    verbs:
-      - create
-  - apiGroups:
-      - authorization.k8s.io
-    resources:
-      - subjectaccessreviews
-    verbs:
-      - create
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -415,9 +415,9 @@ roleRef:
   kind: ClusterRole
   name: tekton-chains-public-key-viewer
 subjects:
-  - apiGroup: rbac.authorization.k8s.io
-    kind: Group
-    name: system:authenticated
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:authenticated
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -435,9 +435,9 @@ roleRef:
   kind: Role
   name: tekton-results-info
 subjects:
-  - apiGroup: rbac.authorization.k8s.io
-    kind: Group
-    name: system:authenticated
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:authenticated
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -451,9 +451,9 @@ roleRef:
   kind: ClusterRole
   name: openshift-gitops-apply-tekton-config-parameters
 subjects:
-  - kind: ServiceAccount
-    name: openshift-gitops-argocd-application-controller
-    namespace: openshift-gitops
+- kind: ServiceAccount
+  name: openshift-gitops-argocd-application-controller
+  namespace: openshift-gitops
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -467,9 +467,9 @@ roleRef:
   kind: ClusterRole
   name: openshift-gitops-jobs-admin
 subjects:
-  - kind: ServiceAccount
-    name: openshift-gitops-argocd-application-controller
-    namespace: openshift-gitops
+- kind: ServiceAccount
+  name: openshift-gitops-argocd-application-controller
+  namespace: openshift-gitops
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -483,9 +483,9 @@ roleRef:
   kind: ClusterRole
   name: pipeline-service-exporter-reader
 subjects:
-  - kind: ServiceAccount
-    name: pipeline-service-exporter
-    namespace: openshift-pipelines
+- kind: ServiceAccount
+  name: pipeline-service-exporter
+  namespace: openshift-pipelines
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -499,9 +499,9 @@ roleRef:
   kind: ClusterRole
   name: tekton-results-service-metrics-reader
 subjects:
-  - kind: ServiceAccount
-    name: metrics-reader
-    namespace: tekton-results
+- kind: ServiceAccount
+  name: metrics-reader
+  namespace: tekton-results
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -517,9 +517,9 @@ roleRef:
   kind: ClusterRole
   name: tekton-results-api
 subjects:
-  - kind: ServiceAccount
-    name: tekton-results-api
-    namespace: tekton-results
+- kind: ServiceAccount
+  name: tekton-results-api
+  namespace: tekton-results
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -535,9 +535,9 @@ roleRef:
   kind: ClusterRole
   name: tekton-results-watcher
 subjects:
-  - kind: ServiceAccount
-    name: tekton-results-watcher
-    namespace: tekton-results
+- kind: ServiceAccount
+  name: tekton-results-watcher
+  namespace: tekton-results
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -551,9 +551,9 @@ roleRef:
   kind: ClusterRole
   name: tekton-results-admin
 subjects:
-  - kind: ServiceAccount
-    name: tekton-results-watcher
-    namespace: tekton-results
+- kind: ServiceAccount
+  name: tekton-results-watcher
+  namespace: tekton-results
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -567,9 +567,9 @@ roleRef:
   kind: ClusterRole
   name: tekton-results-watcher-rbac
 subjects:
-  - kind: ServiceAccount
-    name: tekton-results-watcher
-    namespace: tekton-results
+- kind: ServiceAccount
+  name: tekton-results-watcher
+  namespace: tekton-results
 ---
 apiVersion: v1
 data:
@@ -812,10 +812,10 @@ metadata:
   namespace: openshift-pipelines
 spec:
   ports:
-    - name: metrics
-      port: 9117
-      protocol: TCP
-      targetPort: 9117
+  - name: metrics
+    port: 9117
+    protocol: TCP
+    targetPort: 9117
   selector:
     app: pipeline-metrics-exporter
 ---
@@ -825,8 +825,7 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
     argocd.argoproj.io/sync-wave: "0"
-    ignore-check.kube-linter.io/dangling-service:
-      This service is not dangling, it
+    ignore-check.kube-linter.io/dangling-service: This service is not dangling, it
       exposes metric for an OSP deployment
   labels:
     app: tekton-chains-controller
@@ -836,10 +835,10 @@ metadata:
   namespace: openshift-pipelines
 spec:
   ports:
-    - name: metrics
-      port: 9090
-      protocol: TCP
-      targetPort: 9090
+  - name: metrics
+    port: 9090
+    protocol: TCP
+    targetPort: 9090
   selector:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: default
@@ -862,18 +861,18 @@ metadata:
   namespace: tekton-results
 spec:
   ports:
-    - name: server
-      port: 8080
-      protocol: TCP
-      targetPort: 8080
-    - name: metrics
-      port: 9443
-      protocol: TCP
-      targetPort: metrics
-    - name: profiling
-      port: 6060
-      protocol: TCP
-      targetPort: 6060
+  - name: server
+    port: 8080
+    protocol: TCP
+    targetPort: 8080
+  - name: metrics
+    port: 9443
+    protocol: TCP
+    targetPort: metrics
+  - name: profiling
+    port: 6060
+    protocol: TCP
+    targetPort: 6060
   selector:
     app.kubernetes.io/name: tekton-results-api-for-watcher
 ---
@@ -894,18 +893,18 @@ metadata:
   namespace: tekton-results
 spec:
   ports:
-    - name: server
-      port: 8080
-      protocol: TCP
-      targetPort: 8080
-    - name: metrics
-      port: 9443
-      protocol: TCP
-      targetPort: metrics
-    - name: profiling
-      port: 6060
-      protocol: TCP
-      targetPort: 6060
+  - name: server
+    port: 8080
+    protocol: TCP
+    targetPort: 8080
+  - name: metrics
+    port: 9443
+    protocol: TCP
+    targetPort: metrics
+  - name: profiling
+    port: 6060
+    protocol: TCP
+    targetPort: 6060
   selector:
     app.kubernetes.io/name: tekton-results-api
 ---
@@ -925,11 +924,11 @@ metadata:
   namespace: tekton-results
 spec:
   ports:
-    - name: watchermetrics
-      port: 8443
-      targetPort: watchermetrics
-    - name: profiling
-      port: 8008
+  - name: watchermetrics
+    port: 8443
+    targetPort: watchermetrics
+  - name: profiling
+    port: 8008
   selector:
     app.kubernetes.io/name: tekton-results-watcher
 ---
@@ -954,24 +953,24 @@ spec:
         app: pipeline-metrics-exporter
     spec:
       containers:
-        - args:
-            - -pprof-address
-            - "6060"
-          image: quay.io/konflux-ci/pipeline-service-exporter:9d2439c8a77d2ce0527cc5aea3fc6561b7671b48
-          name: pipeline-metrics-exporter
-          ports:
-            - containerPort: 9117
-              name: metrics
-          resources:
-            limits:
-              cpu: 500m
-              memory: 8Gi
-            requests:
-              cpu: 250m
-              memory: 8Gi
-          securityContext:
-            readOnlyRootFilesystem: true
-            runAsNonRoot: true
+      - args:
+        - -pprof-address
+        - "6060"
+        image: quay.io/konflux-ci/pipeline-service-exporter:9d2439c8a77d2ce0527cc5aea3fc6561b7671b48
+        name: pipeline-metrics-exporter
+        ports:
+        - containerPort: 9117
+          name: metrics
+        resources:
+          limits:
+            cpu: 500m
+            memory: 8Gi
+          requests:
+            cpu: 250m
+            memory: 8Gi
+        securityContext:
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
       restartPolicy: Always
       serviceAccountName: pipeline-service-exporter
 ---
@@ -1019,151 +1018,151 @@ spec:
                 topologyKey: kubernetes.io/hostname
               weight: 100
       containers:
-        - args:
-            - --secure-listen-address=0.0.0.0:9443
-            - --upstream=http://127.0.0.1:9090/
-            - --logtostderr=true
-            - --v=6
-          image: registry.redhat.io/openshift4/ose-kube-rbac-proxy:v4.12
-          name: kube-rbac-proxy
-          ports:
-            - containerPort: 9443
-              name: metrics
-              protocol: TCP
-          resources:
-            limits:
-              cpu: 500m
-              memory: 128Mi
-            requests:
-              cpu: 5m
-              memory: 64Mi
-          securityContext:
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop:
-                - ALL
-            readOnlyRootFilesystem: true
-            runAsNonRoot: true
-            seccompProfile:
-              type: RuntimeDefault
-        - env:
-            - name: LOGS_API
-              value: "true"
-            - name: LOGS_TYPE
-              value: blob
-            - name: S3_HOSTNAME_IMMUTABLE
-              value: "true"
-            - name: AWS_ACCESS_KEY_ID
-              valueFrom:
-                secretKeyRef:
-                  key: aws_access_key_id
-                  name: tekton-results-s3
-            - name: AWS_SECRET_ACCESS_KEY
-              valueFrom:
-                secretKeyRef:
-                  key: aws_secret_access_key
-                  name: tekton-results-s3
-            - name: AWS_REGION
-              valueFrom:
-                secretKeyRef:
-                  key: aws_region
-                  name: tekton-results-s3
-            - name: S3_BUCKET_NAME
-              valueFrom:
-                secretKeyRef:
-                  key: bucket
-                  name: tekton-results-s3
-            - name: AWS_ENDPOINT_URL
-              valueFrom:
-                secretKeyRef:
-                  key: endpoint
-                  name: tekton-results-s3
-            - name: LOGGING_PLUGIN_API_URL
-              valueFrom:
-                secretKeyRef:
-                  key: s3_url
-                  name: tekton-results-s3
-            - name: DB_USER
-              valueFrom:
-                secretKeyRef:
-                  key: db.user
-                  name: tekton-results-database
-            - name: DB_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  key: db.password
-                  name: tekton-results-database
-            - name: DB_HOST
-              valueFrom:
-                secretKeyRef:
-                  key: db.host
-                  name: tekton-results-database
-            - name: DB_NAME
-              valueFrom:
-                secretKeyRef:
-                  key: db.name
-                  name: tekton-results-database
-          image: quay.io/konflux-ci/tekton-results-api:99db802a56c3d62e823e162feee9811e55ed1f5b
-          livenessProbe:
-            httpGet:
-              path: /healthz
-              port: 8080
-              scheme: HTTPS
-            initialDelaySeconds: 5
-            periodSeconds: 10
-          name: api
-          readinessProbe:
-            httpGet:
-              path: /healthz
-              port: 8080
-              scheme: HTTPS
-            initialDelaySeconds: 5
-            periodSeconds: 10
-          resources:
-            limits:
-              cpu: 3000m
-              memory: 1Gi
-            requests:
-              cpu: 1000m
-              memory: 500Mi
-          securityContext:
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop:
-                - ALL
-            readOnlyRootFilesystem: true
-            runAsNonRoot: true
-            seccompProfile:
-              type: RuntimeDefault
-          startupProbe:
-            failureThreshold: 10
-            httpGet:
-              path: /healthz
-              port: 8080
-              scheme: HTTPS
-            initialDelaySeconds: 5
-            periodSeconds: 10
-          volumeMounts:
-            - mountPath: /etc/tls/db
-              name: db-tls-ca
-              readOnly: true
-            - mountPath: /etc/tekton/results
-              name: config
-              readOnly: true
-            - mountPath: /etc/tls
-              name: tls
-              readOnly: true
+      - args:
+        - --secure-listen-address=0.0.0.0:9443
+        - --upstream=http://127.0.0.1:9090/
+        - --logtostderr=true
+        - --v=6
+        image: registry.redhat.io/openshift4/ose-kube-rbac-proxy:v4.12
+        name: kube-rbac-proxy
+        ports:
+        - containerPort: 9443
+          name: metrics
+          protocol: TCP
+        resources:
+          limits:
+            cpu: 500m
+            memory: 128Mi
+          requests:
+            cpu: 5m
+            memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          seccompProfile:
+            type: RuntimeDefault
+      - env:
+        - name: LOGS_API
+          value: "true"
+        - name: LOGS_TYPE
+          value: blob
+        - name: S3_HOSTNAME_IMMUTABLE
+          value: "true"
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              key: aws_access_key_id
+              name: tekton-results-s3
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              key: aws_secret_access_key
+              name: tekton-results-s3
+        - name: AWS_REGION
+          valueFrom:
+            secretKeyRef:
+              key: aws_region
+              name: tekton-results-s3
+        - name: S3_BUCKET_NAME
+          valueFrom:
+            secretKeyRef:
+              key: bucket
+              name: tekton-results-s3
+        - name: AWS_ENDPOINT_URL
+          valueFrom:
+            secretKeyRef:
+              key: endpoint
+              name: tekton-results-s3
+        - name: LOGGING_PLUGIN_API_URL
+          valueFrom:
+            secretKeyRef:
+              key: s3_url
+              name: tekton-results-s3
+        - name: DB_USER
+          valueFrom:
+            secretKeyRef:
+              key: db.user
+              name: tekton-results-database
+        - name: DB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: db.password
+              name: tekton-results-database
+        - name: DB_HOST
+          valueFrom:
+            secretKeyRef:
+              key: db.host
+              name: tekton-results-database
+        - name: DB_NAME
+          valueFrom:
+            secretKeyRef:
+              key: db.name
+              name: tekton-results-database
+        image: quay.io/konflux-ci/tekton-results-api:99db802a56c3d62e823e162feee9811e55ed1f5b
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+            scheme: HTTPS
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        name: api
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+            scheme: HTTPS
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        resources:
+          limits:
+            cpu: 3000m
+            memory: 1Gi
+          requests:
+            cpu: 1000m
+            memory: 500Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          seccompProfile:
+            type: RuntimeDefault
+        startupProbe:
+          failureThreshold: 10
+          httpGet:
+            path: /healthz
+            port: 8080
+            scheme: HTTPS
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        volumeMounts:
+        - mountPath: /etc/tls/db
+          name: db-tls-ca
+          readOnly: true
+        - mountPath: /etc/tekton/results
+          name: config
+          readOnly: true
+        - mountPath: /etc/tls
+          name: tls
+          readOnly: true
       serviceAccountName: tekton-results-api
       volumes:
-        - configMap:
-            name: rds-root-crt
-          name: db-tls-ca
-        - configMap:
-            name: tekton-results-api-config
-          name: config
-        - name: tls
-          secret:
-            secretName: tekton-results-for-watcher-tls
+      - configMap:
+          name: rds-root-crt
+        name: db-tls-ca
+      - configMap:
+          name: tekton-results-api-config
+        name: config
+      - name: tls
+        secret:
+          secretName: tekton-results-for-watcher-tls
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -1209,151 +1208,151 @@ spec:
                 topologyKey: kubernetes.io/hostname
               weight: 100
       containers:
-        - args:
-            - --secure-listen-address=0.0.0.0:9443
-            - --upstream=http://127.0.0.1:9090/
-            - --logtostderr=true
-            - --v=6
-          image: registry.redhat.io/openshift4/ose-kube-rbac-proxy:v4.12
-          name: kube-rbac-proxy
-          ports:
-            - containerPort: 9443
-              name: metrics
-              protocol: TCP
-          resources:
-            limits:
-              cpu: 500m
-              memory: 128Mi
-            requests:
-              cpu: 5m
-              memory: 64Mi
-          securityContext:
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop:
-                - ALL
-            readOnlyRootFilesystem: true
-            runAsNonRoot: true
-            seccompProfile:
-              type: RuntimeDefault
-        - env:
-            - name: LOGS_API
-              value: "true"
-            - name: LOGS_TYPE
-              value: blob
-            - name: S3_HOSTNAME_IMMUTABLE
-              value: "true"
-            - name: AWS_ACCESS_KEY_ID
-              valueFrom:
-                secretKeyRef:
-                  key: aws_access_key_id
-                  name: tekton-results-s3
-            - name: AWS_SECRET_ACCESS_KEY
-              valueFrom:
-                secretKeyRef:
-                  key: aws_secret_access_key
-                  name: tekton-results-s3
-            - name: AWS_REGION
-              valueFrom:
-                secretKeyRef:
-                  key: aws_region
-                  name: tekton-results-s3
-            - name: S3_BUCKET_NAME
-              valueFrom:
-                secretKeyRef:
-                  key: bucket
-                  name: tekton-results-s3
-            - name: AWS_ENDPOINT_URL
-              valueFrom:
-                secretKeyRef:
-                  key: endpoint
-                  name: tekton-results-s3
-            - name: LOGGING_PLUGIN_API_URL
-              valueFrom:
-                secretKeyRef:
-                  key: s3_url
-                  name: tekton-results-s3
-            - name: DB_USER
-              valueFrom:
-                secretKeyRef:
-                  key: db.user
-                  name: tekton-results-database
-            - name: DB_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  key: db.password
-                  name: tekton-results-database
-            - name: DB_HOST
-              valueFrom:
-                secretKeyRef:
-                  key: db.host
-                  name: tekton-results-database
-            - name: DB_NAME
-              valueFrom:
-                secretKeyRef:
-                  key: db.name
-                  name: tekton-results-database
-          image: quay.io/konflux-ci/tekton-results-api:99db802a56c3d62e823e162feee9811e55ed1f5b
-          livenessProbe:
-            httpGet:
-              path: /healthz
-              port: 8080
-              scheme: HTTPS
-            initialDelaySeconds: 5
-            periodSeconds: 10
-          name: api
-          readinessProbe:
-            httpGet:
-              path: /healthz
-              port: 8080
-              scheme: HTTPS
-            initialDelaySeconds: 5
-            periodSeconds: 10
-          resources:
-            limits:
-              cpu: 3000m
-              memory: 1Gi
-            requests:
-              cpu: 1000m
-              memory: 500Mi
-          securityContext:
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop:
-                - ALL
-            readOnlyRootFilesystem: true
-            runAsNonRoot: true
-            seccompProfile:
-              type: RuntimeDefault
-          startupProbe:
-            failureThreshold: 10
-            httpGet:
-              path: /healthz
-              port: 8080
-              scheme: HTTPS
-            initialDelaySeconds: 5
-            periodSeconds: 10
-          volumeMounts:
-            - mountPath: /etc/tls/db
-              name: db-tls-ca
-              readOnly: true
-            - mountPath: /etc/tekton/results
-              name: config
-              readOnly: true
-            - mountPath: /etc/tls
-              name: tls
-              readOnly: true
+      - args:
+        - --secure-listen-address=0.0.0.0:9443
+        - --upstream=http://127.0.0.1:9090/
+        - --logtostderr=true
+        - --v=6
+        image: registry.redhat.io/openshift4/ose-kube-rbac-proxy:v4.12
+        name: kube-rbac-proxy
+        ports:
+        - containerPort: 9443
+          name: metrics
+          protocol: TCP
+        resources:
+          limits:
+            cpu: 500m
+            memory: 128Mi
+          requests:
+            cpu: 5m
+            memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          seccompProfile:
+            type: RuntimeDefault
+      - env:
+        - name: LOGS_API
+          value: "true"
+        - name: LOGS_TYPE
+          value: blob
+        - name: S3_HOSTNAME_IMMUTABLE
+          value: "true"
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              key: aws_access_key_id
+              name: tekton-results-s3
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              key: aws_secret_access_key
+              name: tekton-results-s3
+        - name: AWS_REGION
+          valueFrom:
+            secretKeyRef:
+              key: aws_region
+              name: tekton-results-s3
+        - name: S3_BUCKET_NAME
+          valueFrom:
+            secretKeyRef:
+              key: bucket
+              name: tekton-results-s3
+        - name: AWS_ENDPOINT_URL
+          valueFrom:
+            secretKeyRef:
+              key: endpoint
+              name: tekton-results-s3
+        - name: LOGGING_PLUGIN_API_URL
+          valueFrom:
+            secretKeyRef:
+              key: s3_url
+              name: tekton-results-s3
+        - name: DB_USER
+          valueFrom:
+            secretKeyRef:
+              key: db.user
+              name: tekton-results-database
+        - name: DB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: db.password
+              name: tekton-results-database
+        - name: DB_HOST
+          valueFrom:
+            secretKeyRef:
+              key: db.host
+              name: tekton-results-database
+        - name: DB_NAME
+          valueFrom:
+            secretKeyRef:
+              key: db.name
+              name: tekton-results-database
+        image: quay.io/konflux-ci/tekton-results-api:99db802a56c3d62e823e162feee9811e55ed1f5b
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+            scheme: HTTPS
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        name: api
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+            scheme: HTTPS
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        resources:
+          limits:
+            cpu: 3000m
+            memory: 1Gi
+          requests:
+            cpu: 1000m
+            memory: 500Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          seccompProfile:
+            type: RuntimeDefault
+        startupProbe:
+          failureThreshold: 10
+          httpGet:
+            path: /healthz
+            port: 8080
+            scheme: HTTPS
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        volumeMounts:
+        - mountPath: /etc/tls/db
+          name: db-tls-ca
+          readOnly: true
+        - mountPath: /etc/tekton/results
+          name: config
+          readOnly: true
+        - mountPath: /etc/tls
+          name: tls
+          readOnly: true
       serviceAccountName: tekton-results-api
       volumes:
-        - configMap:
-            name: rds-root-crt
-          name: db-tls-ca
-        - configMap:
-            name: tekton-results-api-config
-          name: config
-        - name: tls
-          secret:
-            secretName: tekton-results-tls
+      - configMap:
+          name: rds-root-crt
+        name: db-tls-ca
+      - configMap:
+          name: tekton-results-api-config
+        name: config
+      - name: tls
+        secret:
+          secretName: tekton-results-tls
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -1378,56 +1377,56 @@ spec:
         app.kubernetes.io/version: devel
     spec:
       containers:
-        - env:
-            - name: SYSTEM_NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
-            - name: CONFIG_LOGGING_NAME
-              value: tekton-results-config-logging
-            - name: DB_USER
-              valueFrom:
-                secretKeyRef:
-                  key: POSTGRES_USER
-                  name: tekton-results-postgres
-            - name: DB_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  key: POSTGRES_PASSWORD
-                  name: tekton-results-postgres
-          image: quay.io/konflux-ci/tekton-results-retention-policy-agent:99db802a56c3d62e823e162feee9811e55ed1f5b
-          name: retention-policy-agent
-          resources:
-            limits:
-              cpu: 500m
-              memory: 128Mi
-            requests:
-              cpu: 5m
-              memory: 64Mi
-          securityContext:
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop:
-                - ALL
-            readOnlyRootFilesystem: true
-            runAsNonRoot: true
-            seccompProfile:
-              type: RuntimeDefault
-          volumeMounts:
-            - mountPath: /etc/tekton/results
-              name: config
-              readOnly: true
-            - mountPath: /etc/tls
-              name: tls
-              readOnly: true
+      - env:
+        - name: SYSTEM_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: CONFIG_LOGGING_NAME
+          value: tekton-results-config-logging
+        - name: DB_USER
+          valueFrom:
+            secretKeyRef:
+              key: POSTGRES_USER
+              name: tekton-results-postgres
+        - name: DB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: POSTGRES_PASSWORD
+              name: tekton-results-postgres
+        image: quay.io/konflux-ci/tekton-results-retention-policy-agent:99db802a56c3d62e823e162feee9811e55ed1f5b
+        name: retention-policy-agent
+        resources:
+          limits:
+            cpu: 500m
+            memory: 128Mi
+          requests:
+            cpu: 5m
+            memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          seccompProfile:
+            type: RuntimeDefault
+        volumeMounts:
+        - mountPath: /etc/tekton/results
+          name: config
+          readOnly: true
+        - mountPath: /etc/tls
+          name: tls
+          readOnly: true
       serviceAccountName: tekton-results-watcher
       volumes:
-        - configMap:
-            name: tekton-results-api-config
-          name: config
-        - name: tls
-          secret:
-            secretName: tekton-results-tls
+      - configMap:
+          name: tekton-results-api-config
+        name: config
+      - name: tls
+        secret:
+          secretName: tekton-results-tls
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -1459,113 +1458,113 @@ spec:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
-              - matchExpressions:
-                  - key: kubernetes.io/os
-                    operator: NotIn
-                    values:
-                      - windows
+            - matchExpressions:
+              - key: kubernetes.io/os
+                operator: NotIn
+                values:
+                - windows
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
-            - podAffinityTerm:
-                labelSelector:
-                  matchLabels:
-                    app.kubernetes.io/name: tekton-results-watcher
-                topologyKey: kubernetes.io/hostname
-              weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/name: tekton-results-watcher
+              topologyKey: kubernetes.io/hostname
+            weight: 100
       containers:
-        - args:
-            - --secure-listen-address=0.0.0.0:8443
-            - --upstream=http://127.0.0.1:9090/
-            - --logtostderr=true
-            - --v=6
-          image: registry.redhat.io/openshift4/ose-kube-rbac-proxy:v4.12
-          name: kube-rbac-proxy
-          ports:
-            - containerPort: 8443
-              name: watchermetrics
-              protocol: TCP
-          resources:
-            limits:
-              cpu: 500m
-              memory: 128Mi
-            requests:
-              cpu: 5m
-              memory: 64Mi
-          securityContext:
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop:
-                - ALL
-            readOnlyRootFilesystem: true
-            runAsNonRoot: true
-            seccompProfile:
-              type: RuntimeDefault
-        - args:
-            - -api_addr
-            - tekton-results-api-service-for-watcher.tekton-results.svc.cluster.local:8080
-            - -auth_mode
-            - token
-            - -check_owner=false
-            - -completed_run_grace_period=5m
-            - -requeue_interval=2m
-            - -store_deadline=240m
-            - -forward_buffer=1m
-            - -qps=50
-            - -burst=50
-            - -threadiness=32
-            - -logs_api=true
-            - -disable_storing_incomplete_runs=true
-          env:
-            - name: SYSTEM_NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
-            - name: CONFIG_LOGGING_NAME
-              value: tekton-results-config-logging
-            - name: CONFIG_LEADERELECTION_NAME
-              value: tekton-results-config-leader-election
-            - name: CONFIG_OBSERVABILITY_NAME
-              value: tekton-results-config-observability
-            - name: METRICS_DOMAIN
-              value: tekton.dev/results
-            - name: TEKTON_RESULTS_API_SERVICE
-              value: tekton-results-api-service-for-watcher.tekton-results.svc.cluster.local:8080
-            - name: AUTH_MODE
-              value: token
-            - name: KUBERNETES_MIN_VERSION
-              value: "v1.28.0"
-          image: quay.io/konflux-ci/tekton-results-watcher:99db802a56c3d62e823e162feee9811e55ed1f5b
-          name: watcher
-          ports:
-            - containerPort: 9090
-              name: metrics
-            - containerPort: 8008
-              name: profiling
-          resources:
-            limits:
-              cpu: 3000m
-              memory: 8Gi
-            requests:
-              cpu: 1000m
-              memory: 8Gi
-          securityContext:
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop:
-                - ALL
-            readOnlyRootFilesystem: true
-            runAsNonRoot: true
-            seccompProfile:
-              type: RuntimeDefault
-          volumeMounts:
-            - mountPath: /etc/tls
-              name: tls
-              readOnly: true
+      - args:
+        - --secure-listen-address=0.0.0.0:8443
+        - --upstream=http://127.0.0.1:9090/
+        - --logtostderr=true
+        - --v=6
+        image: registry.redhat.io/openshift4/ose-kube-rbac-proxy:v4.12
+        name: kube-rbac-proxy
+        ports:
+        - containerPort: 8443
+          name: watchermetrics
+          protocol: TCP
+        resources:
+          limits:
+            cpu: 500m
+            memory: 128Mi
+          requests:
+            cpu: 5m
+            memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          seccompProfile:
+            type: RuntimeDefault
+      - args:
+        - -api_addr
+        - tekton-results-api-service-for-watcher.tekton-results.svc.cluster.local:8080
+        - -auth_mode
+        - token
+        - -check_owner=false
+        - -completed_run_grace_period=5m
+        - -requeue_interval=2m
+        - -store_deadline=240m
+        - -forward_buffer=1m
+        - -qps=50
+        - -burst=50
+        - -threadiness=32
+        - -logs_api=true
+        - -disable_storing_incomplete_runs=true
+        env:
+        - name: SYSTEM_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: CONFIG_LOGGING_NAME
+          value: tekton-results-config-logging
+        - name: CONFIG_LEADERELECTION_NAME
+          value: tekton-results-config-leader-election
+        - name: CONFIG_OBSERVABILITY_NAME
+          value: tekton-results-config-observability
+        - name: METRICS_DOMAIN
+          value: tekton.dev/results
+        - name: TEKTON_RESULTS_API_SERVICE
+          value: tekton-results-api-service-for-watcher.tekton-results.svc.cluster.local:8080
+        - name: AUTH_MODE
+          value: token
+        - name: KUBERNETES_MIN_VERSION
+          value: "v1.28.0"
+        image: quay.io/konflux-ci/tekton-results-watcher:99db802a56c3d62e823e162feee9811e55ed1f5b
+        name: watcher
+        ports:
+        - containerPort: 9090
+          name: metrics
+        - containerPort: 8008
+          name: profiling
+        resources:
+          limits:
+            cpu: 3000m
+            memory: 8Gi
+          requests:
+            cpu: 1000m
+            memory: 8Gi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          seccompProfile:
+            type: RuntimeDefault
+        volumeMounts:
+        - mountPath: /etc/tls
+          name: tls
+          readOnly: true
       serviceAccountName: tekton-results-watcher
       volumes:
-        - name: tls
-          secret:
-            secretName: tekton-results-for-watcher-tls
+      - name: tls
+        secret:
+          secretName: tekton-results-for-watcher-tls
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
@@ -1577,15 +1576,15 @@ metadata:
   namespace: openshift-pipelines
 spec:
   endpoints:
-    - honorLabels: true
-      interval: 15s
-      path: /metrics
-      port: metrics
-      scheme: http
+  - honorLabels: true
+    interval: 15s
+    path: /metrics
+    port: metrics
+    scheme: http
   jobLabel: app
   namespaceSelector:
     matchNames:
-      - openshift-pipelines
+    - openshift-pipelines
   selector:
     matchLabels:
       app: pipeline-metrics-exporter
@@ -1600,24 +1599,24 @@ metadata:
   namespace: openshift-pipelines
 spec:
   endpoints:
-    - honorLabels: true
-      interval: 15s
-      path: /metrics
-      port: metrics
-      scheme: http
+  - honorLabels: true
+    interval: 15s
+    path: /metrics
+    port: metrics
+    scheme: http
   jobLabel: app.kubernetes.io/name
   namespaceSelector:
     matchNames:
-      - openshift-pipelines
+    - openshift-pipelines
   selector:
     matchLabels:
       app: tekton-chains-controller
       app.kubernetes.io/component: metrics
       app.kubernetes.io/part-of: tekton-chains
   targetLabels:
-    - app
-    - app.kubernetes.io/component
-    - app.kubernetes.io/part-of
+  - app
+  - app.kubernetes.io/component
+  - app.kubernetes.io/part-of
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
@@ -1629,14 +1628,14 @@ metadata:
   namespace: tekton-results
 spec:
   endpoints:
-    - bearerTokenSecret:
-        key: token
-        name: metrics-reader
-      path: /metrics
-      port: metrics
-      scheme: https
-      tlsConfig:
-        insecureSkipVerify: true
+  - bearerTokenSecret:
+      key: token
+      name: metrics-reader
+    path: /metrics
+    port: metrics
+    scheme: https
+    tlsConfig:
+      insecureSkipVerify: true
   jobLabel: app
   selector:
     matchLabels:
@@ -1653,14 +1652,14 @@ metadata:
   namespace: tekton-results
 spec:
   endpoints:
-    - bearerTokenSecret:
-        key: token
-        name: metrics-reader
-      path: /metrics
-      port: watchermetrics
-      scheme: https
-      tlsConfig:
-        insecureSkipVerify: true
+  - bearerTokenSecret:
+      key: token
+      name: metrics-reader
+    path: /metrics
+    port: watchermetrics
+    scheme: https
+    tlsConfig:
+      insecureSkipVerify: true
   selector:
     matchLabels:
       app.kubernetes.io/name: tekton-results-watcher
@@ -1694,10 +1693,10 @@ spec:
                     name: tekton-chains-controller
     transparency.enabled: "false"
   params:
-    - name: createRbacResource
-      value: "false"
-    - name: createCABundleConfigMaps
-      value: "false"
+  - name: createRbacResource
+    value: "false"
+  - name: createCABundleConfigMaps
+    value: "false"
   pipeline:
     default-service-account: default
     enable-api-fields: alpha
@@ -1761,27 +1760,27 @@ spec:
             template:
               spec:
                 containers:
-                  - name: proxy
-                    resources:
-                      limits:
-                        cpu: 500m
-                        memory: 500Mi
-                      requests:
-                        cpu: 100m
-                        memory: 100Mi
+                - name: proxy
+                  resources:
+                    limits:
+                      cpu: 500m
+                      memory: 500Mi
+                    requests:
+                      cpu: 100m
+                      memory: 100Mi
         tekton-pipelines-webhook:
           spec:
             template:
               spec:
                 containers:
-                  - name: webhook
-                    resources:
-                      limits:
-                        cpu: "1"
-                        memory: 1Gi
-                      requests:
-                        cpu: 400m
-                        memory: 1Gi
+                - name: webhook
+                  resources:
+                    limits:
+                      cpu: "1"
+                      memory: 1Gi
+                    requests:
+                      cpu: 400m
+                      memory: 1Gi
         # TODO: uncomment once values have been validated in staging
         # pipelines-as-code-controller:
         #   spec:
@@ -1955,35 +1954,35 @@ spec:
           spec:
             maxReplicas: 6
             metrics:
-              - resource:
-                  name: cpu
-                  target:
-                    averageUtilization: 100
-                    type: Utilization
-                type: Resource
-              - resource:
-                  name: memory
-                  target:
-                    averageUtilization: 100
-                    type: Utilization
-                type: Resource
+            - resource:
+                name: cpu
+                target:
+                  averageUtilization: 100
+                  type: Utilization
+              type: Resource
+            - resource:
+                name: memory
+                target:
+                  averageUtilization: 100
+                  type: Utilization
+              type: Resource
             minReplicas: 2
         tekton-pipelines-webhook:
           spec:
             maxReplicas: 6
             metrics:
-              - resource:
-                  name: cpu
-                  target:
-                    averageUtilization: 100
-                    type: Utilization
-                type: Resource
-              - resource:
-                  name: memory
-                  target:
-                    averageUtilization: 100
-                    type: Utilization
-                type: Resource
+            - resource:
+                name: cpu
+                target:
+                  averageUtilization: 100
+                  type: Utilization
+              type: Resource
+            - resource:
+                name: memory
+                target:
+                  averageUtilization: 100
+                  type: Utilization
+              type: Resource
             minReplicas: 6
     performance:
       buckets: 4
@@ -2011,7 +2010,7 @@ spec:
     keep-since: 80
     resources:
       - pipelinerun
-    schedule: "*/30 * * * *"
+    schedule: '*/30 * * * *'
   result:
     disabled: true
   targetNamespace: openshift-pipelines
@@ -2124,13 +2123,13 @@ allowHostPorts: false
 allowPrivilegeEscalation: false
 allowPrivilegedContainer: false
 allowedCapabilities:
-  - SETFCAP
+- SETFCAP
 apiVersion: security.openshift.io/v1
 defaultAddCapabilities: null
 fsGroup:
   type: MustRunAs
 groups:
-  - system:cluster-admins
+- system:cluster-admins
 kind: SecurityContextConstraints
 metadata:
   annotations:
@@ -2140,7 +2139,7 @@ metadata:
 priority: 10
 readOnlyRootFilesystem: false
 requiredDropCapabilities:
-  - MKNOD
+- MKNOD
 runAsUser:
   type: RunAsAny
 seLinuxContext:
@@ -2149,9 +2148,9 @@ supplementalGroups:
   type: RunAsAny
 users: []
 volumes:
-  - configMap
-  - downwardAPI
-  - emptyDir
-  - persistentVolumeClaim
-  - projected
-  - secret
+- configMap
+- downwardAPI
+- emptyDir
+- persistentVolumeClaim
+- projected
+- secret

--- a/components/pipeline-service/production/base/main-pipeline-service-configuration.yaml
+++ b/components/pipeline-service/production/base/main-pipeline-service-configuration.yaml
@@ -70,15 +70,15 @@ metadata:
   name: tekton-results-info
   namespace: tekton-results
 rules:
-- apiGroups:
-  - ""
-  resourceNames:
-  - tekton-results-info
-  resources:
-  - configmaps
-  verbs:
-  - get
-  - describe
+  - apiGroups:
+      - ""
+    resourceNames:
+      - tekton-results-info
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - describe
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -88,36 +88,36 @@ metadata:
     argocd.argoproj.io/sync-wave: "0"
   name: openshift-gitops-apply-tekton-config-parameters
 rules:
-- apiGroups:
-  - monitoring.coreos.com
-  resources:
-  - servicemonitors
-  verbs:
-  - get
-  - list
-  - patch
-  - create
-  - delete
-- apiGroups:
-  - operator.tekton.dev
-  resources:
-  - tektonconfigs
-  verbs:
-  - get
-  - list
-  - patch
-  - create
-  - delete
-- apiGroups:
-  - security.openshift.io
-  resources:
-  - securitycontextconstraints
-  verbs:
-  - get
-  - list
-  - patch
-  - create
-  - delete
+  - apiGroups:
+      - monitoring.coreos.com
+    resources:
+      - servicemonitors
+    verbs:
+      - get
+      - list
+      - patch
+      - create
+      - delete
+  - apiGroups:
+      - operator.tekton.dev
+    resources:
+      - tektonconfigs
+    verbs:
+      - get
+      - list
+      - patch
+      - create
+      - delete
+  - apiGroups:
+      - security.openshift.io
+    resources:
+      - securitycontextconstraints
+    verbs:
+      - get
+      - list
+      - patch
+      - create
+      - delete
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -127,16 +127,16 @@ metadata:
     argocd.argoproj.io/sync-wave: "0"
   name: openshift-gitops-jobs-admin
 rules:
-- apiGroups:
-  - batch
-  resources:
-  - jobs
-  verbs:
-  - get
-  - list
-  - patch
-  - create
-  - delete
+  - apiGroups:
+      - batch
+    resources:
+      - jobs
+    verbs:
+      - get
+      - list
+      - patch
+      - create
+      - delete
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -146,37 +146,37 @@ metadata:
     argocd.argoproj.io/sync-wave: "0"
   name: pipeline-service-exporter-reader
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  - services
-  - namespaces
-  - endpoints
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - apiextensions.k8s.io
-  resources:
-  - customresourcedefinitions
-  verbs:
-  - get
-- apiGroups:
-  - tekton.dev
-  resources:
-  - pipelineruns
-  - taskruns
-  verbs:
-  - get
-  - list
-  - watch
-  - patch
-- nonResourceURLs:
-  - /metrics
-  verbs:
-  - get
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - services
+      - namespaces
+      - endpoints
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - get
+  - apiGroups:
+      - tekton.dev
+    resources:
+      - pipelineruns
+      - taskruns
+    verbs:
+      - get
+      - list
+      - watch
+      - patch
+  - nonResourceURLs:
+      - /metrics
+    verbs:
+      - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -186,16 +186,17 @@ metadata:
     argocd.argoproj.io/sync-wave: "0"
   name: tekton-chains-public-key-viewer
 rules:
-- apiGroups:
-  - ""
-  resourceNames:
-  - public-key
-  resources:
-  - secrets
-  verbs:
-  - get
-  - list
-  - watch
+  - apiGroups:
+      - ""
+    resourceNames:
+      - public-key
+      - ibm-public-key
+    resources:
+      - secrets
+    verbs:
+      - get
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -208,18 +209,18 @@ metadata:
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
   name: tekton-results-admin
 rules:
-- apiGroups:
-  - results.tekton.dev
-  resources:
-  - results
-  - records
-  - logs
-  verbs:
-  - create
-  - update
-  - get
-  - list
-  - delete
+  - apiGroups:
+      - results.tekton.dev
+    resources:
+      - results
+      - records
+      - logs
+    verbs:
+      - create
+      - update
+      - get
+      - list
+      - delete
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -231,18 +232,18 @@ metadata:
     app.kubernetes.io/version: devel
   name: tekton-results-api
 rules:
-- apiGroups:
-  - authentication.k8s.io
-  resources:
-  - tokenreviews
-  verbs:
-  - create
-- apiGroups:
-  - authorization.k8s.io
-  resources:
-  - subjectaccessreviews
-  verbs:
-  - create
+  - apiGroups:
+      - authentication.k8s.io
+    resources:
+      - tokenreviews
+    verbs:
+      - create
+  - apiGroups:
+      - authorization.k8s.io
+    resources:
+      - subjectaccessreviews
+    verbs:
+      - create
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -256,16 +257,16 @@ metadata:
     rbac.authorization.k8s.io/aggregate-to-view: "true"
   name: tekton-results-readonly
 rules:
-- apiGroups:
-  - results.tekton.dev
-  resources:
-  - results
-  - records
-  - logs
-  - summary
-  verbs:
-  - get
-  - list
+  - apiGroups:
+      - results.tekton.dev
+    resources:
+      - results
+      - records
+      - logs
+      - summary
+    verbs:
+      - get
+      - list
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -277,17 +278,17 @@ metadata:
     app.kubernetes.io/version: devel
   name: tekton-results-readwrite
 rules:
-- apiGroups:
-  - results.tekton.dev
-  resources:
-  - results
-  - records
-  - logs
-  verbs:
-  - create
-  - update
-  - get
-  - list
+  - apiGroups:
+      - results.tekton.dev
+    resources:
+      - results
+      - records
+      - logs
+    verbs:
+      - create
+      - update
+      - get
+      - list
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -297,10 +298,10 @@ metadata:
     argocd.argoproj.io/sync-wave: "0"
   name: tekton-results-service-metrics-reader
 rules:
-- nonResourceURLs:
-  - /metrics
-  verbs:
-  - get
+  - nonResourceURLs:
+      - /metrics
+    verbs:
+      - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -312,73 +313,73 @@ metadata:
     app.kubernetes.io/version: devel
   name: tekton-results-watcher
 rules:
-- apiGroups:
-  - results.tekton.dev
-  resources:
-  - logs
-  - results
-  - records
-  verbs:
-  - create
-  - get
-  - update
-- apiGroups:
-  - tekton.dev
-  resources:
-  - pipelineruns
-  - taskruns
-  verbs:
-  - get
-  - list
-  - patch
-  - update
-  - watch
-  - delete
-- apiGroups:
-  - ""
-  resources:
-  - configmaps
-  - pods
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - pods/log
-  verbs:
-  - get
-- apiGroups:
-  - ""
-  resources:
-  - events
-  verbs:
-  - get
-  - list
-  - create
-  - update
-  - delete
-  - patch
-  - watch
-- apiGroups:
-  - tekton.dev
-  resources:
-  - pipelines
-  verbs:
-  - get
-- apiGroups:
-  - coordination.k8s.io
-  resources:
-  - leases
-  verbs:
-  - get
-  - list
-  - create
-  - update
-  - delete
-  - patch
-  - watch
+  - apiGroups:
+      - results.tekton.dev
+    resources:
+      - logs
+      - results
+      - records
+    verbs:
+      - create
+      - get
+      - update
+  - apiGroups:
+      - tekton.dev
+    resources:
+      - pipelineruns
+      - taskruns
+    verbs:
+      - get
+      - list
+      - patch
+      - update
+      - watch
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - pods/log
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - get
+      - list
+      - create
+      - update
+      - delete
+      - patch
+      - watch
+  - apiGroups:
+      - tekton.dev
+    resources:
+      - pipelines
+    verbs:
+      - get
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - get
+      - list
+      - create
+      - update
+      - delete
+      - patch
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -388,18 +389,18 @@ metadata:
     argocd.argoproj.io/sync-wave: "0"
   name: tekton-results-watcher-rbac
 rules:
-- apiGroups:
-  - authentication.k8s.io
-  resources:
-  - tokenreviews
-  verbs:
-  - create
-- apiGroups:
-  - authorization.k8s.io
-  resources:
-  - subjectaccessreviews
-  verbs:
-  - create
+  - apiGroups:
+      - authentication.k8s.io
+    resources:
+      - tokenreviews
+    verbs:
+      - create
+  - apiGroups:
+      - authorization.k8s.io
+    resources:
+      - subjectaccessreviews
+    verbs:
+      - create
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -414,9 +415,9 @@ roleRef:
   kind: ClusterRole
   name: tekton-chains-public-key-viewer
 subjects:
-- apiGroup: rbac.authorization.k8s.io
-  kind: Group
-  name: system:authenticated
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: system:authenticated
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -434,9 +435,9 @@ roleRef:
   kind: Role
   name: tekton-results-info
 subjects:
-- apiGroup: rbac.authorization.k8s.io
-  kind: Group
-  name: system:authenticated
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: system:authenticated
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -450,9 +451,9 @@ roleRef:
   kind: ClusterRole
   name: openshift-gitops-apply-tekton-config-parameters
 subjects:
-- kind: ServiceAccount
-  name: openshift-gitops-argocd-application-controller
-  namespace: openshift-gitops
+  - kind: ServiceAccount
+    name: openshift-gitops-argocd-application-controller
+    namespace: openshift-gitops
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -466,9 +467,9 @@ roleRef:
   kind: ClusterRole
   name: openshift-gitops-jobs-admin
 subjects:
-- kind: ServiceAccount
-  name: openshift-gitops-argocd-application-controller
-  namespace: openshift-gitops
+  - kind: ServiceAccount
+    name: openshift-gitops-argocd-application-controller
+    namespace: openshift-gitops
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -482,9 +483,9 @@ roleRef:
   kind: ClusterRole
   name: pipeline-service-exporter-reader
 subjects:
-- kind: ServiceAccount
-  name: pipeline-service-exporter
-  namespace: openshift-pipelines
+  - kind: ServiceAccount
+    name: pipeline-service-exporter
+    namespace: openshift-pipelines
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -498,9 +499,9 @@ roleRef:
   kind: ClusterRole
   name: tekton-results-service-metrics-reader
 subjects:
-- kind: ServiceAccount
-  name: metrics-reader
-  namespace: tekton-results
+  - kind: ServiceAccount
+    name: metrics-reader
+    namespace: tekton-results
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -516,9 +517,9 @@ roleRef:
   kind: ClusterRole
   name: tekton-results-api
 subjects:
-- kind: ServiceAccount
-  name: tekton-results-api
-  namespace: tekton-results
+  - kind: ServiceAccount
+    name: tekton-results-api
+    namespace: tekton-results
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -534,9 +535,9 @@ roleRef:
   kind: ClusterRole
   name: tekton-results-watcher
 subjects:
-- kind: ServiceAccount
-  name: tekton-results-watcher
-  namespace: tekton-results
+  - kind: ServiceAccount
+    name: tekton-results-watcher
+    namespace: tekton-results
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -550,9 +551,9 @@ roleRef:
   kind: ClusterRole
   name: tekton-results-admin
 subjects:
-- kind: ServiceAccount
-  name: tekton-results-watcher
-  namespace: tekton-results
+  - kind: ServiceAccount
+    name: tekton-results-watcher
+    namespace: tekton-results
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -566,9 +567,9 @@ roleRef:
   kind: ClusterRole
   name: tekton-results-watcher-rbac
 subjects:
-- kind: ServiceAccount
-  name: tekton-results-watcher
-  namespace: tekton-results
+  - kind: ServiceAccount
+    name: tekton-results-watcher
+    namespace: tekton-results
 ---
 apiVersion: v1
 data:
@@ -811,10 +812,10 @@ metadata:
   namespace: openshift-pipelines
 spec:
   ports:
-  - name: metrics
-    port: 9117
-    protocol: TCP
-    targetPort: 9117
+    - name: metrics
+      port: 9117
+      protocol: TCP
+      targetPort: 9117
   selector:
     app: pipeline-metrics-exporter
 ---
@@ -824,7 +825,8 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
     argocd.argoproj.io/sync-wave: "0"
-    ignore-check.kube-linter.io/dangling-service: This service is not dangling, it
+    ignore-check.kube-linter.io/dangling-service:
+      This service is not dangling, it
       exposes metric for an OSP deployment
   labels:
     app: tekton-chains-controller
@@ -834,10 +836,10 @@ metadata:
   namespace: openshift-pipelines
 spec:
   ports:
-  - name: metrics
-    port: 9090
-    protocol: TCP
-    targetPort: 9090
+    - name: metrics
+      port: 9090
+      protocol: TCP
+      targetPort: 9090
   selector:
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: default
@@ -860,18 +862,18 @@ metadata:
   namespace: tekton-results
 spec:
   ports:
-  - name: server
-    port: 8080
-    protocol: TCP
-    targetPort: 8080
-  - name: metrics
-    port: 9443
-    protocol: TCP
-    targetPort: metrics
-  - name: profiling
-    port: 6060
-    protocol: TCP
-    targetPort: 6060
+    - name: server
+      port: 8080
+      protocol: TCP
+      targetPort: 8080
+    - name: metrics
+      port: 9443
+      protocol: TCP
+      targetPort: metrics
+    - name: profiling
+      port: 6060
+      protocol: TCP
+      targetPort: 6060
   selector:
     app.kubernetes.io/name: tekton-results-api-for-watcher
 ---
@@ -892,18 +894,18 @@ metadata:
   namespace: tekton-results
 spec:
   ports:
-  - name: server
-    port: 8080
-    protocol: TCP
-    targetPort: 8080
-  - name: metrics
-    port: 9443
-    protocol: TCP
-    targetPort: metrics
-  - name: profiling
-    port: 6060
-    protocol: TCP
-    targetPort: 6060
+    - name: server
+      port: 8080
+      protocol: TCP
+      targetPort: 8080
+    - name: metrics
+      port: 9443
+      protocol: TCP
+      targetPort: metrics
+    - name: profiling
+      port: 6060
+      protocol: TCP
+      targetPort: 6060
   selector:
     app.kubernetes.io/name: tekton-results-api
 ---
@@ -923,11 +925,11 @@ metadata:
   namespace: tekton-results
 spec:
   ports:
-  - name: watchermetrics
-    port: 8443
-    targetPort: watchermetrics
-  - name: profiling
-    port: 8008
+    - name: watchermetrics
+      port: 8443
+      targetPort: watchermetrics
+    - name: profiling
+      port: 8008
   selector:
     app.kubernetes.io/name: tekton-results-watcher
 ---
@@ -952,24 +954,24 @@ spec:
         app: pipeline-metrics-exporter
     spec:
       containers:
-      - args:
-        - -pprof-address
-        - "6060"
-        image: quay.io/konflux-ci/pipeline-service-exporter:9d2439c8a77d2ce0527cc5aea3fc6561b7671b48
-        name: pipeline-metrics-exporter
-        ports:
-        - containerPort: 9117
-          name: metrics
-        resources:
-          limits:
-            cpu: 500m
-            memory: 8Gi
-          requests:
-            cpu: 250m
-            memory: 8Gi
-        securityContext:
-          readOnlyRootFilesystem: true
-          runAsNonRoot: true
+        - args:
+            - -pprof-address
+            - "6060"
+          image: quay.io/konflux-ci/pipeline-service-exporter:9d2439c8a77d2ce0527cc5aea3fc6561b7671b48
+          name: pipeline-metrics-exporter
+          ports:
+            - containerPort: 9117
+              name: metrics
+          resources:
+            limits:
+              cpu: 500m
+              memory: 8Gi
+            requests:
+              cpu: 250m
+              memory: 8Gi
+          securityContext:
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
       restartPolicy: Always
       serviceAccountName: pipeline-service-exporter
 ---
@@ -1017,151 +1019,151 @@ spec:
                 topologyKey: kubernetes.io/hostname
               weight: 100
       containers:
-      - args:
-        - --secure-listen-address=0.0.0.0:9443
-        - --upstream=http://127.0.0.1:9090/
-        - --logtostderr=true
-        - --v=6
-        image: registry.redhat.io/openshift4/ose-kube-rbac-proxy:v4.12
-        name: kube-rbac-proxy
-        ports:
-        - containerPort: 9443
-          name: metrics
-          protocol: TCP
-        resources:
-          limits:
-            cpu: 500m
-            memory: 128Mi
-          requests:
-            cpu: 5m
-            memory: 64Mi
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop:
-            - ALL
-          readOnlyRootFilesystem: true
-          runAsNonRoot: true
-          seccompProfile:
-            type: RuntimeDefault
-      - env:
-        - name: LOGS_API
-          value: "true"
-        - name: LOGS_TYPE
-          value: blob
-        - name: S3_HOSTNAME_IMMUTABLE
-          value: "true"
-        - name: AWS_ACCESS_KEY_ID
-          valueFrom:
-            secretKeyRef:
-              key: aws_access_key_id
-              name: tekton-results-s3
-        - name: AWS_SECRET_ACCESS_KEY
-          valueFrom:
-            secretKeyRef:
-              key: aws_secret_access_key
-              name: tekton-results-s3
-        - name: AWS_REGION
-          valueFrom:
-            secretKeyRef:
-              key: aws_region
-              name: tekton-results-s3
-        - name: S3_BUCKET_NAME
-          valueFrom:
-            secretKeyRef:
-              key: bucket
-              name: tekton-results-s3
-        - name: AWS_ENDPOINT_URL
-          valueFrom:
-            secretKeyRef:
-              key: endpoint
-              name: tekton-results-s3
-        - name: LOGGING_PLUGIN_API_URL
-          valueFrom:
-            secretKeyRef:
-              key: s3_url
-              name: tekton-results-s3
-        - name: DB_USER
-          valueFrom:
-            secretKeyRef:
-              key: db.user
-              name: tekton-results-database
-        - name: DB_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              key: db.password
-              name: tekton-results-database
-        - name: DB_HOST
-          valueFrom:
-            secretKeyRef:
-              key: db.host
-              name: tekton-results-database
-        - name: DB_NAME
-          valueFrom:
-            secretKeyRef:
-              key: db.name
-              name: tekton-results-database
-        image: quay.io/konflux-ci/tekton-results-api:99db802a56c3d62e823e162feee9811e55ed1f5b
-        livenessProbe:
-          httpGet:
-            path: /healthz
-            port: 8080
-            scheme: HTTPS
-          initialDelaySeconds: 5
-          periodSeconds: 10
-        name: api
-        readinessProbe:
-          httpGet:
-            path: /healthz
-            port: 8080
-            scheme: HTTPS
-          initialDelaySeconds: 5
-          periodSeconds: 10
-        resources:
-          limits:
-            cpu: 3000m
-            memory: 1Gi
-          requests:
-            cpu: 1000m
-            memory: 500Mi
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop:
-            - ALL
-          readOnlyRootFilesystem: true
-          runAsNonRoot: true
-          seccompProfile:
-            type: RuntimeDefault
-        startupProbe:
-          failureThreshold: 10
-          httpGet:
-            path: /healthz
-            port: 8080
-            scheme: HTTPS
-          initialDelaySeconds: 5
-          periodSeconds: 10
-        volumeMounts:
-        - mountPath: /etc/tls/db
-          name: db-tls-ca
-          readOnly: true
-        - mountPath: /etc/tekton/results
-          name: config
-          readOnly: true
-        - mountPath: /etc/tls
-          name: tls
-          readOnly: true
+        - args:
+            - --secure-listen-address=0.0.0.0:9443
+            - --upstream=http://127.0.0.1:9090/
+            - --logtostderr=true
+            - --v=6
+          image: registry.redhat.io/openshift4/ose-kube-rbac-proxy:v4.12
+          name: kube-rbac-proxy
+          ports:
+            - containerPort: 9443
+              name: metrics
+              protocol: TCP
+          resources:
+            limits:
+              cpu: 500m
+              memory: 128Mi
+            requests:
+              cpu: 5m
+              memory: 64Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
+        - env:
+            - name: LOGS_API
+              value: "true"
+            - name: LOGS_TYPE
+              value: blob
+            - name: S3_HOSTNAME_IMMUTABLE
+              value: "true"
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  key: aws_access_key_id
+                  name: tekton-results-s3
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: aws_secret_access_key
+                  name: tekton-results-s3
+            - name: AWS_REGION
+              valueFrom:
+                secretKeyRef:
+                  key: aws_region
+                  name: tekton-results-s3
+            - name: S3_BUCKET_NAME
+              valueFrom:
+                secretKeyRef:
+                  key: bucket
+                  name: tekton-results-s3
+            - name: AWS_ENDPOINT_URL
+              valueFrom:
+                secretKeyRef:
+                  key: endpoint
+                  name: tekton-results-s3
+            - name: LOGGING_PLUGIN_API_URL
+              valueFrom:
+                secretKeyRef:
+                  key: s3_url
+                  name: tekton-results-s3
+            - name: DB_USER
+              valueFrom:
+                secretKeyRef:
+                  key: db.user
+                  name: tekton-results-database
+            - name: DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: db.password
+                  name: tekton-results-database
+            - name: DB_HOST
+              valueFrom:
+                secretKeyRef:
+                  key: db.host
+                  name: tekton-results-database
+            - name: DB_NAME
+              valueFrom:
+                secretKeyRef:
+                  key: db.name
+                  name: tekton-results-database
+          image: quay.io/konflux-ci/tekton-results-api:99db802a56c3d62e823e162feee9811e55ed1f5b
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+              scheme: HTTPS
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          name: api
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+              scheme: HTTPS
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            limits:
+              cpu: 3000m
+              memory: 1Gi
+            requests:
+              cpu: 1000m
+              memory: 500Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
+          startupProbe:
+            failureThreshold: 10
+            httpGet:
+              path: /healthz
+              port: 8080
+              scheme: HTTPS
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          volumeMounts:
+            - mountPath: /etc/tls/db
+              name: db-tls-ca
+              readOnly: true
+            - mountPath: /etc/tekton/results
+              name: config
+              readOnly: true
+            - mountPath: /etc/tls
+              name: tls
+              readOnly: true
       serviceAccountName: tekton-results-api
       volumes:
-      - configMap:
-          name: rds-root-crt
-        name: db-tls-ca
-      - configMap:
-          name: tekton-results-api-config
-        name: config
-      - name: tls
-        secret:
-          secretName: tekton-results-for-watcher-tls
+        - configMap:
+            name: rds-root-crt
+          name: db-tls-ca
+        - configMap:
+            name: tekton-results-api-config
+          name: config
+        - name: tls
+          secret:
+            secretName: tekton-results-for-watcher-tls
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -1207,151 +1209,151 @@ spec:
                 topologyKey: kubernetes.io/hostname
               weight: 100
       containers:
-      - args:
-        - --secure-listen-address=0.0.0.0:9443
-        - --upstream=http://127.0.0.1:9090/
-        - --logtostderr=true
-        - --v=6
-        image: registry.redhat.io/openshift4/ose-kube-rbac-proxy:v4.12
-        name: kube-rbac-proxy
-        ports:
-        - containerPort: 9443
-          name: metrics
-          protocol: TCP
-        resources:
-          limits:
-            cpu: 500m
-            memory: 128Mi
-          requests:
-            cpu: 5m
-            memory: 64Mi
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop:
-            - ALL
-          readOnlyRootFilesystem: true
-          runAsNonRoot: true
-          seccompProfile:
-            type: RuntimeDefault
-      - env:
-        - name: LOGS_API
-          value: "true"
-        - name: LOGS_TYPE
-          value: blob
-        - name: S3_HOSTNAME_IMMUTABLE
-          value: "true"
-        - name: AWS_ACCESS_KEY_ID
-          valueFrom:
-            secretKeyRef:
-              key: aws_access_key_id
-              name: tekton-results-s3
-        - name: AWS_SECRET_ACCESS_KEY
-          valueFrom:
-            secretKeyRef:
-              key: aws_secret_access_key
-              name: tekton-results-s3
-        - name: AWS_REGION
-          valueFrom:
-            secretKeyRef:
-              key: aws_region
-              name: tekton-results-s3
-        - name: S3_BUCKET_NAME
-          valueFrom:
-            secretKeyRef:
-              key: bucket
-              name: tekton-results-s3
-        - name: AWS_ENDPOINT_URL
-          valueFrom:
-            secretKeyRef:
-              key: endpoint
-              name: tekton-results-s3
-        - name: LOGGING_PLUGIN_API_URL
-          valueFrom:
-            secretKeyRef:
-              key: s3_url
-              name: tekton-results-s3
-        - name: DB_USER
-          valueFrom:
-            secretKeyRef:
-              key: db.user
-              name: tekton-results-database
-        - name: DB_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              key: db.password
-              name: tekton-results-database
-        - name: DB_HOST
-          valueFrom:
-            secretKeyRef:
-              key: db.host
-              name: tekton-results-database
-        - name: DB_NAME
-          valueFrom:
-            secretKeyRef:
-              key: db.name
-              name: tekton-results-database
-        image: quay.io/konflux-ci/tekton-results-api:99db802a56c3d62e823e162feee9811e55ed1f5b
-        livenessProbe:
-          httpGet:
-            path: /healthz
-            port: 8080
-            scheme: HTTPS
-          initialDelaySeconds: 5
-          periodSeconds: 10
-        name: api
-        readinessProbe:
-          httpGet:
-            path: /healthz
-            port: 8080
-            scheme: HTTPS
-          initialDelaySeconds: 5
-          periodSeconds: 10
-        resources:
-          limits:
-            cpu: 3000m
-            memory: 1Gi
-          requests:
-            cpu: 1000m
-            memory: 500Mi
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop:
-            - ALL
-          readOnlyRootFilesystem: true
-          runAsNonRoot: true
-          seccompProfile:
-            type: RuntimeDefault
-        startupProbe:
-          failureThreshold: 10
-          httpGet:
-            path: /healthz
-            port: 8080
-            scheme: HTTPS
-          initialDelaySeconds: 5
-          periodSeconds: 10
-        volumeMounts:
-        - mountPath: /etc/tls/db
-          name: db-tls-ca
-          readOnly: true
-        - mountPath: /etc/tekton/results
-          name: config
-          readOnly: true
-        - mountPath: /etc/tls
-          name: tls
-          readOnly: true
+        - args:
+            - --secure-listen-address=0.0.0.0:9443
+            - --upstream=http://127.0.0.1:9090/
+            - --logtostderr=true
+            - --v=6
+          image: registry.redhat.io/openshift4/ose-kube-rbac-proxy:v4.12
+          name: kube-rbac-proxy
+          ports:
+            - containerPort: 9443
+              name: metrics
+              protocol: TCP
+          resources:
+            limits:
+              cpu: 500m
+              memory: 128Mi
+            requests:
+              cpu: 5m
+              memory: 64Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
+        - env:
+            - name: LOGS_API
+              value: "true"
+            - name: LOGS_TYPE
+              value: blob
+            - name: S3_HOSTNAME_IMMUTABLE
+              value: "true"
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  key: aws_access_key_id
+                  name: tekton-results-s3
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: aws_secret_access_key
+                  name: tekton-results-s3
+            - name: AWS_REGION
+              valueFrom:
+                secretKeyRef:
+                  key: aws_region
+                  name: tekton-results-s3
+            - name: S3_BUCKET_NAME
+              valueFrom:
+                secretKeyRef:
+                  key: bucket
+                  name: tekton-results-s3
+            - name: AWS_ENDPOINT_URL
+              valueFrom:
+                secretKeyRef:
+                  key: endpoint
+                  name: tekton-results-s3
+            - name: LOGGING_PLUGIN_API_URL
+              valueFrom:
+                secretKeyRef:
+                  key: s3_url
+                  name: tekton-results-s3
+            - name: DB_USER
+              valueFrom:
+                secretKeyRef:
+                  key: db.user
+                  name: tekton-results-database
+            - name: DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: db.password
+                  name: tekton-results-database
+            - name: DB_HOST
+              valueFrom:
+                secretKeyRef:
+                  key: db.host
+                  name: tekton-results-database
+            - name: DB_NAME
+              valueFrom:
+                secretKeyRef:
+                  key: db.name
+                  name: tekton-results-database
+          image: quay.io/konflux-ci/tekton-results-api:99db802a56c3d62e823e162feee9811e55ed1f5b
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+              scheme: HTTPS
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          name: api
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+              scheme: HTTPS
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            limits:
+              cpu: 3000m
+              memory: 1Gi
+            requests:
+              cpu: 1000m
+              memory: 500Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
+          startupProbe:
+            failureThreshold: 10
+            httpGet:
+              path: /healthz
+              port: 8080
+              scheme: HTTPS
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          volumeMounts:
+            - mountPath: /etc/tls/db
+              name: db-tls-ca
+              readOnly: true
+            - mountPath: /etc/tekton/results
+              name: config
+              readOnly: true
+            - mountPath: /etc/tls
+              name: tls
+              readOnly: true
       serviceAccountName: tekton-results-api
       volumes:
-      - configMap:
-          name: rds-root-crt
-        name: db-tls-ca
-      - configMap:
-          name: tekton-results-api-config
-        name: config
-      - name: tls
-        secret:
-          secretName: tekton-results-tls
+        - configMap:
+            name: rds-root-crt
+          name: db-tls-ca
+        - configMap:
+            name: tekton-results-api-config
+          name: config
+        - name: tls
+          secret:
+            secretName: tekton-results-tls
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -1376,56 +1378,56 @@ spec:
         app.kubernetes.io/version: devel
     spec:
       containers:
-      - env:
-        - name: SYSTEM_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
-        - name: CONFIG_LOGGING_NAME
-          value: tekton-results-config-logging
-        - name: DB_USER
-          valueFrom:
-            secretKeyRef:
-              key: POSTGRES_USER
-              name: tekton-results-postgres
-        - name: DB_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              key: POSTGRES_PASSWORD
-              name: tekton-results-postgres
-        image: quay.io/konflux-ci/tekton-results-retention-policy-agent:99db802a56c3d62e823e162feee9811e55ed1f5b
-        name: retention-policy-agent
-        resources:
-          limits:
-            cpu: 500m
-            memory: 128Mi
-          requests:
-            cpu: 5m
-            memory: 64Mi
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop:
-            - ALL
-          readOnlyRootFilesystem: true
-          runAsNonRoot: true
-          seccompProfile:
-            type: RuntimeDefault
-        volumeMounts:
-        - mountPath: /etc/tekton/results
-          name: config
-          readOnly: true
-        - mountPath: /etc/tls
-          name: tls
-          readOnly: true
+        - env:
+            - name: SYSTEM_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: CONFIG_LOGGING_NAME
+              value: tekton-results-config-logging
+            - name: DB_USER
+              valueFrom:
+                secretKeyRef:
+                  key: POSTGRES_USER
+                  name: tekton-results-postgres
+            - name: DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: POSTGRES_PASSWORD
+                  name: tekton-results-postgres
+          image: quay.io/konflux-ci/tekton-results-retention-policy-agent:99db802a56c3d62e823e162feee9811e55ed1f5b
+          name: retention-policy-agent
+          resources:
+            limits:
+              cpu: 500m
+              memory: 128Mi
+            requests:
+              cpu: 5m
+              memory: 64Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
+          volumeMounts:
+            - mountPath: /etc/tekton/results
+              name: config
+              readOnly: true
+            - mountPath: /etc/tls
+              name: tls
+              readOnly: true
       serviceAccountName: tekton-results-watcher
       volumes:
-      - configMap:
-          name: tekton-results-api-config
-        name: config
-      - name: tls
-        secret:
-          secretName: tekton-results-tls
+        - configMap:
+            name: tekton-results-api-config
+          name: config
+        - name: tls
+          secret:
+            secretName: tekton-results-tls
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -1457,113 +1459,113 @@ spec:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
-            - matchExpressions:
-              - key: kubernetes.io/os
-                operator: NotIn
-                values:
-                - windows
+              - matchExpressions:
+                  - key: kubernetes.io/os
+                    operator: NotIn
+                    values:
+                      - windows
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app.kubernetes.io/name: tekton-results-watcher
-              topologyKey: kubernetes.io/hostname
-            weight: 100
+            - podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/name: tekton-results-watcher
+                topologyKey: kubernetes.io/hostname
+              weight: 100
       containers:
-      - args:
-        - --secure-listen-address=0.0.0.0:8443
-        - --upstream=http://127.0.0.1:9090/
-        - --logtostderr=true
-        - --v=6
-        image: registry.redhat.io/openshift4/ose-kube-rbac-proxy:v4.12
-        name: kube-rbac-proxy
-        ports:
-        - containerPort: 8443
-          name: watchermetrics
-          protocol: TCP
-        resources:
-          limits:
-            cpu: 500m
-            memory: 128Mi
-          requests:
-            cpu: 5m
-            memory: 64Mi
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop:
-            - ALL
-          readOnlyRootFilesystem: true
-          runAsNonRoot: true
-          seccompProfile:
-            type: RuntimeDefault
-      - args:
-        - -api_addr
-        - tekton-results-api-service-for-watcher.tekton-results.svc.cluster.local:8080
-        - -auth_mode
-        - token
-        - -check_owner=false
-        - -completed_run_grace_period=5m
-        - -requeue_interval=2m
-        - -store_deadline=240m
-        - -forward_buffer=1m
-        - -qps=50
-        - -burst=50
-        - -threadiness=32
-        - -logs_api=true
-        - -disable_storing_incomplete_runs=true
-        env:
-        - name: SYSTEM_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
-        - name: CONFIG_LOGGING_NAME
-          value: tekton-results-config-logging
-        - name: CONFIG_LEADERELECTION_NAME
-          value: tekton-results-config-leader-election
-        - name: CONFIG_OBSERVABILITY_NAME
-          value: tekton-results-config-observability
-        - name: METRICS_DOMAIN
-          value: tekton.dev/results
-        - name: TEKTON_RESULTS_API_SERVICE
-          value: tekton-results-api-service-for-watcher.tekton-results.svc.cluster.local:8080
-        - name: AUTH_MODE
-          value: token
-        - name: KUBERNETES_MIN_VERSION
-          value: "v1.28.0"
-        image: quay.io/konflux-ci/tekton-results-watcher:99db802a56c3d62e823e162feee9811e55ed1f5b
-        name: watcher
-        ports:
-        - containerPort: 9090
-          name: metrics
-        - containerPort: 8008
-          name: profiling
-        resources:
-          limits:
-            cpu: 3000m
-            memory: 8Gi
-          requests:
-            cpu: 1000m
-            memory: 8Gi
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop:
-            - ALL
-          readOnlyRootFilesystem: true
-          runAsNonRoot: true
-          seccompProfile:
-            type: RuntimeDefault
-        volumeMounts:
-        - mountPath: /etc/tls
-          name: tls
-          readOnly: true
+        - args:
+            - --secure-listen-address=0.0.0.0:8443
+            - --upstream=http://127.0.0.1:9090/
+            - --logtostderr=true
+            - --v=6
+          image: registry.redhat.io/openshift4/ose-kube-rbac-proxy:v4.12
+          name: kube-rbac-proxy
+          ports:
+            - containerPort: 8443
+              name: watchermetrics
+              protocol: TCP
+          resources:
+            limits:
+              cpu: 500m
+              memory: 128Mi
+            requests:
+              cpu: 5m
+              memory: 64Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
+        - args:
+            - -api_addr
+            - tekton-results-api-service-for-watcher.tekton-results.svc.cluster.local:8080
+            - -auth_mode
+            - token
+            - -check_owner=false
+            - -completed_run_grace_period=5m
+            - -requeue_interval=2m
+            - -store_deadline=240m
+            - -forward_buffer=1m
+            - -qps=50
+            - -burst=50
+            - -threadiness=32
+            - -logs_api=true
+            - -disable_storing_incomplete_runs=true
+          env:
+            - name: SYSTEM_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: CONFIG_LOGGING_NAME
+              value: tekton-results-config-logging
+            - name: CONFIG_LEADERELECTION_NAME
+              value: tekton-results-config-leader-election
+            - name: CONFIG_OBSERVABILITY_NAME
+              value: tekton-results-config-observability
+            - name: METRICS_DOMAIN
+              value: tekton.dev/results
+            - name: TEKTON_RESULTS_API_SERVICE
+              value: tekton-results-api-service-for-watcher.tekton-results.svc.cluster.local:8080
+            - name: AUTH_MODE
+              value: token
+            - name: KUBERNETES_MIN_VERSION
+              value: "v1.28.0"
+          image: quay.io/konflux-ci/tekton-results-watcher:99db802a56c3d62e823e162feee9811e55ed1f5b
+          name: watcher
+          ports:
+            - containerPort: 9090
+              name: metrics
+            - containerPort: 8008
+              name: profiling
+          resources:
+            limits:
+              cpu: 3000m
+              memory: 8Gi
+            requests:
+              cpu: 1000m
+              memory: 8Gi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
+          volumeMounts:
+            - mountPath: /etc/tls
+              name: tls
+              readOnly: true
       serviceAccountName: tekton-results-watcher
       volumes:
-      - name: tls
-        secret:
-          secretName: tekton-results-for-watcher-tls
+        - name: tls
+          secret:
+            secretName: tekton-results-for-watcher-tls
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
@@ -1575,15 +1577,15 @@ metadata:
   namespace: openshift-pipelines
 spec:
   endpoints:
-  - honorLabels: true
-    interval: 15s
-    path: /metrics
-    port: metrics
-    scheme: http
+    - honorLabels: true
+      interval: 15s
+      path: /metrics
+      port: metrics
+      scheme: http
   jobLabel: app
   namespaceSelector:
     matchNames:
-    - openshift-pipelines
+      - openshift-pipelines
   selector:
     matchLabels:
       app: pipeline-metrics-exporter
@@ -1598,24 +1600,24 @@ metadata:
   namespace: openshift-pipelines
 spec:
   endpoints:
-  - honorLabels: true
-    interval: 15s
-    path: /metrics
-    port: metrics
-    scheme: http
+    - honorLabels: true
+      interval: 15s
+      path: /metrics
+      port: metrics
+      scheme: http
   jobLabel: app.kubernetes.io/name
   namespaceSelector:
     matchNames:
-    - openshift-pipelines
+      - openshift-pipelines
   selector:
     matchLabels:
       app: tekton-chains-controller
       app.kubernetes.io/component: metrics
       app.kubernetes.io/part-of: tekton-chains
   targetLabels:
-  - app
-  - app.kubernetes.io/component
-  - app.kubernetes.io/part-of
+    - app
+    - app.kubernetes.io/component
+    - app.kubernetes.io/part-of
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
@@ -1627,14 +1629,14 @@ metadata:
   namespace: tekton-results
 spec:
   endpoints:
-  - bearerTokenSecret:
-      key: token
-      name: metrics-reader
-    path: /metrics
-    port: metrics
-    scheme: https
-    tlsConfig:
-      insecureSkipVerify: true
+    - bearerTokenSecret:
+        key: token
+        name: metrics-reader
+      path: /metrics
+      port: metrics
+      scheme: https
+      tlsConfig:
+        insecureSkipVerify: true
   jobLabel: app
   selector:
     matchLabels:
@@ -1651,14 +1653,14 @@ metadata:
   namespace: tekton-results
 spec:
   endpoints:
-  - bearerTokenSecret:
-      key: token
-      name: metrics-reader
-    path: /metrics
-    port: watchermetrics
-    scheme: https
-    tlsConfig:
-      insecureSkipVerify: true
+    - bearerTokenSecret:
+        key: token
+        name: metrics-reader
+      path: /metrics
+      port: watchermetrics
+      scheme: https
+      tlsConfig:
+        insecureSkipVerify: true
   selector:
     matchLabels:
       app.kubernetes.io/name: tekton-results-watcher
@@ -1692,10 +1694,10 @@ spec:
                     name: tekton-chains-controller
     transparency.enabled: "false"
   params:
-  - name: createRbacResource
-    value: "false"
-  - name: createCABundleConfigMaps
-    value: "false"
+    - name: createRbacResource
+      value: "false"
+    - name: createCABundleConfigMaps
+      value: "false"
   pipeline:
     default-service-account: default
     enable-api-fields: alpha
@@ -1759,27 +1761,27 @@ spec:
             template:
               spec:
                 containers:
-                - name: proxy
-                  resources:
-                    limits:
-                      cpu: 500m
-                      memory: 500Mi
-                    requests:
-                      cpu: 100m
-                      memory: 100Mi
+                  - name: proxy
+                    resources:
+                      limits:
+                        cpu: 500m
+                        memory: 500Mi
+                      requests:
+                        cpu: 100m
+                        memory: 100Mi
         tekton-pipelines-webhook:
           spec:
             template:
               spec:
                 containers:
-                - name: webhook
-                  resources:
-                    limits:
-                      cpu: "1"
-                      memory: 1Gi
-                    requests:
-                      cpu: 400m
-                      memory: 1Gi
+                  - name: webhook
+                    resources:
+                      limits:
+                        cpu: "1"
+                        memory: 1Gi
+                      requests:
+                        cpu: 400m
+                        memory: 1Gi
         # TODO: uncomment once values have been validated in staging
         # pipelines-as-code-controller:
         #   spec:
@@ -1953,35 +1955,35 @@ spec:
           spec:
             maxReplicas: 6
             metrics:
-            - resource:
-                name: cpu
-                target:
-                  averageUtilization: 100
-                  type: Utilization
-              type: Resource
-            - resource:
-                name: memory
-                target:
-                  averageUtilization: 100
-                  type: Utilization
-              type: Resource
+              - resource:
+                  name: cpu
+                  target:
+                    averageUtilization: 100
+                    type: Utilization
+                type: Resource
+              - resource:
+                  name: memory
+                  target:
+                    averageUtilization: 100
+                    type: Utilization
+                type: Resource
             minReplicas: 2
         tekton-pipelines-webhook:
           spec:
             maxReplicas: 6
             metrics:
-            - resource:
-                name: cpu
-                target:
-                  averageUtilization: 100
-                  type: Utilization
-              type: Resource
-            - resource:
-                name: memory
-                target:
-                  averageUtilization: 100
-                  type: Utilization
-              type: Resource
+              - resource:
+                  name: cpu
+                  target:
+                    averageUtilization: 100
+                    type: Utilization
+                type: Resource
+              - resource:
+                  name: memory
+                  target:
+                    averageUtilization: 100
+                    type: Utilization
+                type: Resource
             minReplicas: 6
     performance:
       buckets: 4
@@ -2009,7 +2011,7 @@ spec:
     keep-since: 80
     resources:
       - pipelinerun
-    schedule: '*/30 * * * *'
+    schedule: "*/30 * * * *"
   result:
     disabled: true
   targetNamespace: openshift-pipelines
@@ -2122,13 +2124,13 @@ allowHostPorts: false
 allowPrivilegeEscalation: false
 allowPrivilegedContainer: false
 allowedCapabilities:
-- SETFCAP
+  - SETFCAP
 apiVersion: security.openshift.io/v1
 defaultAddCapabilities: null
 fsGroup:
   type: MustRunAs
 groups:
-- system:cluster-admins
+  - system:cluster-admins
 kind: SecurityContextConstraints
 metadata:
   annotations:
@@ -2138,7 +2140,7 @@ metadata:
 priority: 10
 readOnlyRootFilesystem: false
 requiredDropCapabilities:
-- MKNOD
+  - MKNOD
 runAsUser:
   type: RunAsAny
 seLinuxContext:
@@ -2147,9 +2149,9 @@ supplementalGroups:
   type: RunAsAny
 users: []
 volumes:
-- configMap
-- downwardAPI
-- emptyDir
-- persistentVolumeClaim
-- projected
-- secret
+  - configMap
+  - downwardAPI
+  - emptyDir
+  - persistentVolumeClaim
+  - projected
+  - secret

--- a/components/pipeline-service/production/kflux-fedora-01/deploy.yaml
+++ b/components/pipeline-service/production/kflux-fedora-01/deploy.yaml
@@ -350,6 +350,7 @@ rules:
   - ""
   resourceNames:
   - public-key
+  - ibm-public-key
   resources:
   - secrets
   verbs:

--- a/components/pipeline-service/production/kflux-ocp-p01/deploy.yaml
+++ b/components/pipeline-service/production/kflux-ocp-p01/deploy.yaml
@@ -350,6 +350,7 @@ rules:
   - ""
   resourceNames:
   - public-key
+  - ibm-public-key
   resources:
   - secrets
   verbs:

--- a/components/pipeline-service/production/kflux-osp-p01/deploy.yaml
+++ b/components/pipeline-service/production/kflux-osp-p01/deploy.yaml
@@ -350,6 +350,7 @@ rules:
   - ""
   resourceNames:
   - public-key
+  - ibm-public-key
   resources:
   - secrets
   verbs:

--- a/components/pipeline-service/production/kflux-prd-rh02/deploy.yaml
+++ b/components/pipeline-service/production/kflux-prd-rh02/deploy.yaml
@@ -350,6 +350,7 @@ rules:
   - ""
   resourceNames:
   - public-key
+  - ibm-public-key
   resources:
   - secrets
   verbs:

--- a/components/pipeline-service/production/kflux-prd-rh03/deploy.yaml
+++ b/components/pipeline-service/production/kflux-prd-rh03/deploy.yaml
@@ -350,6 +350,7 @@ rules:
   - ""
   resourceNames:
   - public-key
+  - ibm-public-key
   resources:
   - secrets
   verbs:

--- a/components/pipeline-service/production/kflux-rhel-p01/deploy.yaml
+++ b/components/pipeline-service/production/kflux-rhel-p01/deploy.yaml
@@ -350,6 +350,7 @@ rules:
   - ""
   resourceNames:
   - public-key
+  - ibm-public-key
   resources:
   - secrets
   verbs:

--- a/components/pipeline-service/production/stone-prd-rh01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prd-rh01/deploy.yaml
@@ -350,6 +350,7 @@ rules:
   - ""
   resourceNames:
   - public-key
+  - ibm-public-key
   resources:
   - secrets
   verbs:

--- a/components/pipeline-service/production/stone-prod-p01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prod-p01/deploy.yaml
@@ -350,6 +350,7 @@ rules:
   - ""
   resourceNames:
   - public-key
+  - ibm-public-key
   resources:
   - secrets
   verbs:

--- a/components/pipeline-service/production/stone-prod-p02/deploy.yaml
+++ b/components/pipeline-service/production/stone-prod-p02/deploy.yaml
@@ -350,6 +350,7 @@ rules:
   - ""
   resourceNames:
   - public-key
+  - ibm-public-key
   resources:
   - secrets
   verbs:


### PR DESCRIPTION
We've added the ibm public key as a secret in the rhtap-releng-tenant, this is to make sure that konflux pipelines can access the key to validate when it's trying to access content for release