### PR TITLE
feat(PVO11Y-5283): forward Kueue admission wait sum and count

### DIFF
--- a/components/monitoring/prometheus/production/base/federation/endpoints-params.yaml
+++ b/components/monitoring/prometheus/production/base/federation/endpoints-params.yaml
@@ -202,6 +202,8 @@
     - '{__name__="tekton_kueue_cel_evaluations_total"}'
     - '{__name__="kueue_cluster_queue_status"}'
     - '{__name__="kueue_admission_wait_time_seconds_bucket"}'
+    - '{__name__="kueue_admission_wait_time_seconds_sum"}'
+    - '{__name__="kueue_admission_wait_time_seconds_count"}'
     - '{__name__="up", job=~".*kueue.*"}'
     - '{__name__="kueue_admitted_active_workloads", cluster_queue="cluster-pipeline-queue"}'
     - '{__name__="kueue_pending_workloads", cluster_queue="cluster-pipeline-queue"}'


### PR DESCRIPTION
## Summary

Include kueue_admission_wait_time_seconds sum and count for calculating average admission wait times for Kueue. These metrics are forwarded for staging clusters per redhat-appstudio/infra-deployments#12679. Forwarding these metrics for production clusters now.

## Risk Assessment

- Level: Low
- Description: This will just includes some additional metrics in the forwarding. No changes to existing metrics that are already being forwarded.
- Rollback: Revert this PR.

## Validation

-  These metrics are being forwarded for staging clusters per redhat-appstudio/infra-deployments#12679. Verified through AppSRE grafana that those metrics are being forwarded in our staging datasource.