### PR TITLE
PVO11Y-5268 Add source_environment label to tekton-ms

### DIFF
--- a/components/monitoring/prometheus/staging/tekton-ms/kustomization.yaml
+++ b/components/monitoring/prometheus/staging/tekton-ms/kustomization.yaml
@@ -24,6 +24,12 @@ patches:
       kind: MonitoringStack
       group: monitoring.rhobs
       version: v1alpha1
+  - path: source-environment-label.yaml
+    target:
+      name: appstudio-tekton-ms
+      kind: MonitoringStack
+      group: monitoring.rhobs
+      version: v1alpha1
 
 commonAnnotations:
   argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true

--- a/components/monitoring/prometheus/staging/tekton-ms/source-environment-label.yaml
+++ b/components/monitoring/prometheus/staging/tekton-ms/source-environment-label.yaml
@@ -1,0 +1,4 @@
+---
+- op: add
+  path: /spec/prometheusConfig/externalLabels/source_environment
+  value: staging-cluster


### PR DESCRIPTION
## Summary
- Add `source_environment: staging-cluster` as an external label on the tekton-ms MonitoringStack so metrics forwarded to RHOBS include the environment identifier, matching the federation pipeline's behavior

## Context
Metrics from the tekton-ms were arriving in RHOBS without `source_environment`, unlike those from the federation pipeline which sets it via ServiceMonitor relabeling. The label is already in the writeRelabelConfigs allowlist, so it just needed to be set on the MonitoringStack.

## Test plan
- [ ] Verify `source_environment=staging-cluster` appears on tekton metrics in RHOBS