### PR TITLE
PVO11Y-5265 Add konflux-o11y group to tenant-4 token manager

### DIFF
--- a/components/perf-team-prometheus-reader/base/tenants-rbac/konflux-perfscale-4-tenant/serviceaccount-loadtest.yaml
+++ b/components/perf-team-prometheus-reader/base/tenants-rbac/konflux-perfscale-4-tenant/serviceaccount-loadtest.yaml
@@ -49,3 +49,6 @@ subjects:
 - apiGroup: rbac.authorization.k8s.io
   kind: Group
   name: konflux-performance
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: konflux-o11y


### PR DESCRIPTION
## Summary
- Add `konflux-o11y` group to the `serviceaccounttoken-manager` RoleBinding in `konflux-perfscale-4-tenant` so the o11y team can create tokens for the `serviceaccount-loadtest` SA

### Why
The Kanary V1 pipeline needs a `serviceaccount-loadtest` token to authenticate against the tenant namespace and run load tests. This token is currently stored in Vault and must be manually created and rotated. By granting the `konflux-o11y` group access to the `serviceaccounttoken-manager` Role, o11y team members can create short-lived tokens on demand for:
- Populating/rotating the Vault secret (`oc create token serviceaccount-loadtest -n konflux-perfscale-4-tenant`)

Jira: https://redhat.atlassian.net/browse/PVO11Y-5265

## Risk Assessment
**Risk Level:** Low
**Description:** Adds an additional group to an existing RoleBinding
**Rollback:** Revert PR

## Validation
- [x] `kustomize build components/perf-team-prometheus-reader/base/` passes