### PR TITLE
PVO11Y-5291 Update kanary pipeline to use managed release namespace

### DIFF
--- a/components/monitoring/kanary/staging/base/pipelines/kanary-otel-pipeline.yaml
+++ b/components/monitoring/kanary/staging/base/pipelines/kanary-otel-pipeline.yaml
@@ -30,7 +30,10 @@ spec:
       default: "nodejs-devfile-sample-SingleArch/"
     - name: release-pipeline-service-account
       type: string
-      default: "loadtest-probe-serviceaccount"
+      default: "managed-konflux-perfscale-sa"
+    - name: release-managed-namespace
+      type: string
+      default: "managed-konflux-perfscale-tenant"
     # Private clusters only (GitLab-based repos). Leave empty for public clusters.
     - name: fork-target
       type: string
@@ -76,6 +79,8 @@ spec:
           value: $(params.pipeline-repo-templating-source-dir)
         - name: release-pipeline-service-account
           value: $(params.release-pipeline-service-account)
+        - name: release-managed-namespace
+          value: $(params.release-managed-namespace)
         - name: fork-target
           value: $(params.fork-target)
         - name: gitlab-api-url

--- a/components/monitoring/kanary/staging/base/tasks/run-kanary-tests.yaml
+++ b/components/monitoring/kanary/staging/base/tasks/run-kanary-tests.yaml
@@ -27,7 +27,10 @@ spec:
       default: "nodejs-devfile-sample-SingleArch/"
     - name: release-pipeline-service-account
       type: string
-      default: "loadtest-probe-serviceaccount"
+      default: "managed-konflux-perfscale-sa"
+    - name: release-managed-namespace
+      type: string
+      default: "managed-konflux-perfscale-tenant"
     # Private clusters only (GitLab-based repos). Leave empty for public clusters.
     - name: fork-target
       type: string
@@ -105,6 +108,13 @@ spec:
           value: "pipelines/managed/e2e/e2e.yaml"
         - name: RELEASE_PIPELINE_SERVICE_ACCOUNT
           value: $(params.release-pipeline-service-account)
+        - name: RELEASE_MANAGED_NAMESPACE
+          value: $(params.release-managed-namespace)
+        - name: RELEASE_MANAGED_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: kanary-probe-prometheus-credentials
+              key: managed_sa_token
         - name: FORK_TARGET
           value: $(params.fork-target)
         - name: GITLAB_API_URL

--- a/components/monitoring/kanary/staging/stone-stage-p01/cronjobs/kanary-cronjob-multi-arch.yaml
+++ b/components/monitoring/kanary/staging/stone-stage-p01/cronjobs/kanary-cronjob-multi-arch.yaml
@@ -39,7 +39,8 @@ spec:
                     --param quay-repo=redhat-user-workloads-stage \
                     --param pipeline-repo-templating-source=https://github.com/rhtap-perf-test/konflux-probe-test-templates \
                     --param pipeline-repo-templating-source-dir=nodejs-devfile-sample-MultiArch/ \
-                    --param release-pipeline-service-account=loadtest-probe-serviceaccount \
+                    --param release-pipeline-service-account=managed-konflux-perfscale-sa \
+                    --param release-managed-namespace=managed-konflux-perfscale-tenant \
                     --param fork-target=jhutar \
                     --param gitlab-api-url=https://gitlab.cee.redhat.com/api/v4 \
                     --param member-cluster=https://api.stone-stage-p01.hpmt.p1.openshiftapps.com:6443 \

--- a/components/monitoring/kanary/staging/stone-stage-p01/cronjobs/kanary-cronjob-single-arch.yaml
+++ b/components/monitoring/kanary/staging/stone-stage-p01/cronjobs/kanary-cronjob-single-arch.yaml
@@ -39,7 +39,8 @@ spec:
                     --param quay-repo=redhat-user-workloads-stage \
                     --param pipeline-repo-templating-source=https://github.com/rhtap-perf-test/konflux-probe-test-templates \
                     --param pipeline-repo-templating-source-dir=nodejs-devfile-sample-SingleArch/ \
-                    --param release-pipeline-service-account=loadtest-probe-serviceaccount \
+                    --param release-pipeline-service-account=managed-konflux-perfscale-sa \
+                    --param release-managed-namespace=managed-konflux-perfscale-tenant \
                     --param fork-target=jhutar \
                     --param gitlab-api-url=https://gitlab.cee.redhat.com/api/v4 \
                     --param member-cluster=https://api.stone-stage-p01.hpmt.p1.openshiftapps.com:6443 \

--- a/components/monitoring/kanary/staging/stone-stg-rh01/cronjobs/kanary-cronjob-multi-arch.yaml
+++ b/components/monitoring/kanary/staging/stone-stg-rh01/cronjobs/kanary-cronjob-multi-arch.yaml
@@ -39,7 +39,8 @@ spec:
                     --param quay-repo=redhat-user-workloads-stage \
                     --param pipeline-repo-templating-source=https://github.com/rhtap-perf-test/konflux-probe-test-templates \
                     --param pipeline-repo-templating-source-dir=nodejs-devfile-sample-MultiArch/ \
-                    --param release-pipeline-service-account=release-serviceaccount \
+                    --param release-pipeline-service-account=managed-konflux-perfscale-sa \
+                    --param release-managed-namespace=managed-konflux-perfscale-tenant \
                     --param fork-target="" \
                     --param gitlab-api-url="" \
                     --param member-cluster=https://api.stone-stg-rh01.l2vh.p1.openshiftapps.com:6443 \

--- a/components/monitoring/kanary/staging/stone-stg-rh01/cronjobs/kanary-cronjob-single-arch.yaml
+++ b/components/monitoring/kanary/staging/stone-stg-rh01/cronjobs/kanary-cronjob-single-arch.yaml
@@ -39,7 +39,8 @@ spec:
                     --param quay-repo=redhat-user-workloads-stage \
                     --param pipeline-repo-templating-source=https://github.com/rhtap-perf-test/konflux-probe-test-templates \
                     --param pipeline-repo-templating-source-dir=nodejs-devfile-sample-SingleArch/ \
-                    --param release-pipeline-service-account=release-serviceaccount \
+                    --param release-pipeline-service-account=managed-konflux-perfscale-sa \
+                    --param release-managed-namespace=managed-konflux-perfscale-tenant \
                     --param fork-target="" \
                     --param gitlab-api-url="" \
                     --param member-cluster=https://api.stone-stg-rh01.l2vh.p1.openshiftapps.com:6443 \


### PR DESCRIPTION
## Summary

Update the Kanary V1 tekton pipeline to use the managed release namespace pattern introduced by the perf&scale team.

### Changes

- **Task**: Add `release-managed-namespace` param and `RELEASE_MANAGED_NAMESPACE` / `RELEASE_MANAGED_TOKEN` env vars. The managed token is sourced from the per-cluster `kanary-probe-prometheus-credentials` secret (vault path `perfscale/shared/<cluster>`, key `managed_sa_token`). Update default `release-pipeline-service-account` to `managed-konflux-perfscale-sa`.
- **Pipeline**: Add `release-managed-namespace` param with pass-through to task, update default SA.
- **Cronjobs**: Explicitly pass `--param release-pipeline-service-account=managed-konflux-perfscale-sa` and `--param release-managed-namespace=managed-konflux-perfscale-tenant` on all 4 cronjobs.

### Why

Releases now run in a separate managed namespace (`managed-konflux-perfscale-tenant`) with a dedicated SA (`managed-konflux-perfscale-sa`), avoiding the `konflux-bot-0` SA that was recently restricted by security hardening. This aligns with the Release team's supported setup and matches how the perf&scale Jenkins jobs are configured.

Jira: https://redhat.atlassian.net/browse/PVO11Y-5291

## Risk Assessment
**Risk Level:** Low
**Description:** Adds new env vars and params for the managed release namespace. Existing release flow is unchanged if params are not provided (defaults apply).
**Rollback:** Revert PR

## Validation
- [x] `kustomize build components/monitoring/kanary/staging/stone-stage-p01/` passes
- [x] `kustomize build components/monitoring/kanary/staging/stone-stg-rh01/` passes