### PR TITLE
Enable proxy for pnpm on staging clusters

### DIFF
--- a/components/konflux-info/staging/stone-stage-p01/cluster-config.env
+++ b/components/konflux-info/staging/stone-stage-p01/cluster-config.env
@@ -6,4 +6,5 @@ allow-package-registry-proxy=true
 package-registry-proxy-gomod-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/go-proxy
 package-registry-proxy-npm-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/npm-proxy
 package-registry-proxy-pip-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/pypi-proxy/simple
+package-registry-proxy-pnpm-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/npm-proxy
 package-registry-proxy-yarn-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/npm-proxy

--- a/components/konflux-info/staging/stone-stg-rh01/cluster-config.env
+++ b/components/konflux-info/staging/stone-stg-rh01/cluster-config.env
@@ -6,4 +6,5 @@ allow-package-registry-proxy=true
 package-registry-proxy-gomod-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/go-proxy
 package-registry-proxy-npm-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/npm-proxy
 package-registry-proxy-pip-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/pypi-proxy/simple
+package-registry-proxy-pnpm-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/npm-proxy
 package-registry-proxy-yarn-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/npm-proxy


### PR DESCRIPTION
Enable use of the package registry proxy for Hermeto's pnpm backend on stage clusters (stone-stg-rh01, stone-stage-p01). This will allow Hermeto to route dependency prefetches through the package registry registry proxy for policy evaluation.

Production clusters will be enabled separately after validation in stage.

This follows https://github.com/redhat-appstudio/infra-deployments/pull/12528

## Risk Assessment
**Risk Level:** Low
**Description:** Enables pnpm for Nexus in stage. There are currently zero users for Hermeto+pnpm because the feature has not been announced/released yet.
**Rollback:** Revert PR

## Validation
Already tested in individual build PLRs in stage. This just configures it globally in each cluster.