### PR TITLE
Enable proxy for go, pip, pnpm on select prod clusters

### DIFF
--- a/components/konflux-info/production/kflux-prd-rh02/cluster-config.env
+++ b/components/konflux-info/production/kflux-prd-rh02/cluster-config.env
@@ -3,5 +3,8 @@ http-proxy=squid.caching.svc.cluster.local:3128
 no-proxy=
 
 allow-package-registry-proxy=true
+package-registry-proxy-gomod-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/go-proxy
 package-registry-proxy-npm-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/npm-proxy
+package-registry-proxy-pip-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/pypi-proxy/simple
+package-registry-proxy-pnpm-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/npm-proxy
 package-registry-proxy-yarn-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/npm-proxy

--- a/components/konflux-info/production/stone-prod-p01/cluster-config.env
+++ b/components/konflux-info/production/stone-prod-p01/cluster-config.env
@@ -3,5 +3,8 @@ http-proxy=squid.caching.svc.cluster.local:3128
 no-proxy=
 
 allow-package-registry-proxy=true
+package-registry-proxy-gomod-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/go-proxy
 package-registry-proxy-npm-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/npm-proxy
+package-registry-proxy-pip-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/pypi-proxy/simple
+package-registry-proxy-pnpm-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/npm-proxy
 package-registry-proxy-yarn-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/npm-proxy


### PR DESCRIPTION
Reviews are welcome, but please do not merge this until June 26.

Enable use of the package registry proxy for Hermeto's go, pip, and pnpm backends on select prod clusters (stone-prod-p01, kflux-prd-rh02). This will allow Hermeto to route dependency prefetches through the package registry proxy for policy evaluation.

## Risk Assessment
**Risk Level:** Medium
**Description:** Enables additional package ecosystems to be proxied through Nexus by Hermeto. The user impact is to build pipelines using Go and pip. Pnpm is brand-new to Hermeto and is not currently used by product teams.
**Rollback:** Revert PR

## Validation
Tested in stage:
- https://github.com/redhat-appstudio/infra-deployments/pull/12528
- https://konflux-ui.apps.stone-stg-rh01.l2vh.p1.openshiftapps.com/ns/tmadore-tenant/applications/hermeto-integration-tests/pipelineruns/gomod-e2e-proxy-on-push-hntrl
- https://konflux-ui.apps.stone-stg-rh01.l2vh.p1.openshiftapps.com/ns/tmadore-tenant/applications/hermeto-integration-tests/pipelineruns/pip-e2e-proxy-on-push-vjrjx