### PR TITLE
Promote release-service and grafana-dashboard from development to staging

### DIFF
--- a/components/monitoring/grafana/staging/dashboards/release/kustomization.yaml
+++ b/components/monitoring/grafana/staging/dashboards/release/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- https://github.com/konflux-ci/release-service/config/grafana/?ref=8d113fa685bfa3b4188d74896762c377ece81987
+- https://github.com/konflux-ci/release-service/config/grafana/?ref=6d9abf25ac73986731ba7dbdb1ac459af54999b0

--- a/components/release/staging/kustomization.yaml
+++ b/components/release/staging/kustomization.yaml
@@ -4,7 +4,7 @@ resources:
   - ../base
   - ../base/monitor/staging
   - external-secrets/release-monitor-secret.yaml
-  - https://github.com/konflux-ci/release-service/config/default?ref=8d113fa685bfa3b4188d74896762c377ece81987
+  - https://github.com/konflux-ci/release-service/config/default?ref=6d9abf25ac73986731ba7dbdb1ac459af54999b0
   - release_service_config.yaml
   - signing_configs.yaml
 
@@ -14,6 +14,6 @@ components:
 images:
   - name: quay.io/konflux-ci/release-service
     newName: quay.io/konflux-ci/release-service
-    newTag: 8d113fa685bfa3b4188d74896762c377ece81987
+    newTag: 6d9abf25ac73986731ba7dbdb1ac459af54999b0
 
 namespace: release-service


### PR DESCRIPTION
Included PRs:
 - https://github.com/konflux-ci/release-service/pull/1723 
 - https://github.com/konflux-ci/release-service/pull/1720 
 - https://github.com/konflux-ci/release-service/pull/1715 
 - https://github.com/konflux-ci/release-service/pull/1721 
 - https://github.com/konflux-ci/release-service/pull/1722 
 - https://github.com/konflux-ci/release-service/pull/1719 
 - https://github.com/konflux-ci/release-service/pull/1709 
