### PR TITLE
KFLUXINFRA-3009: Sync Let's Encrypt cert to manual routes on kflux-fedora-01

### DIFF
--- a/components/konflux-ui/production/kflux-fedora-01/letsencrypt/kustomization.yaml
+++ b/components/konflux-ui/production/kflux-fedora-01/letsencrypt/kustomization.yaml
@@ -4,5 +4,6 @@ resources:
 - certificate-secret-reader.yaml
 - certificate.yaml
 - issuer.yaml
+- route-cert-sync-cronjob.yaml
 - secret-reader-binding.yaml
 namespace: konflux-ui

--- a/components/konflux-ui/production/kflux-fedora-01/letsencrypt/route-cert-sync-cronjob.yaml
+++ b/components/konflux-ui/production/kflux-fedora-01/letsencrypt/route-cert-sync-cronjob.yaml
@@ -102,10 +102,10 @@ spec:
                               f"timeout after {OC_TIMEOUT}s: {' '.join(cmd)}",
                               file=sys.stderr,
                           )
-                          if exc.stdout:
-                              print(f"stdout:\n{exc.stdout}", file=sys.stderr)
-                          if exc.stderr:
-                              print(f"stderr:\n{exc.stderr}", file=sys.stderr)
+                          print(
+                              "command output omitted from logs to avoid leaking TLS material",
+                              file=sys.stderr,
+                          )
                           raise SystemExit(1) from exc
 
 

--- a/components/konflux-ui/production/kflux-fedora-01/letsencrypt/route-cert-sync-cronjob.yaml
+++ b/components/konflux-ui/production/kflux-fedora-01/letsencrypt/route-cert-sync-cronjob.yaml
@@ -51,6 +51,7 @@ spec:
   failedJobsHistoryLimit: 3
   jobTemplate:
     spec:
+      activeDeadlineSeconds: 300
       backoffLimit: 2
       template:
         spec:
@@ -63,6 +64,11 @@ spec:
           containers:
             - name: sync
               image: registry.redhat.io/openshift4/ose-cli:v4.12
+              env:
+                - name: POD_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
               command:
                 - /bin/sh
                 - -c
@@ -71,21 +77,36 @@ spec:
                   python3 <<'PY'
                   import base64
                   import json
+                  import os
                   import subprocess
                   import sys
 
-                  NS = "konflux-ui"
+                  NS = os.environ["POD_NAMESPACE"]
                   SECRET = "konflux-ci-certificate"
                   ROUTES = ("konflux-nice", "konflux-nice-idp")
+                  OC_TIMEOUT = 60
 
 
                   def oc(*args):
-                      return subprocess.run(
-                          ["oc", *args],
-                          capture_output=True,
-                          text=True,
-                          check=True,
-                      )
+                      cmd = ["oc", *args]
+                      try:
+                          return subprocess.run(
+                              cmd,
+                              capture_output=True,
+                              text=True,
+                              check=True,
+                              timeout=OC_TIMEOUT,
+                          )
+                      except subprocess.TimeoutExpired as exc:
+                          print(
+                              f"timeout after {OC_TIMEOUT}s: {' '.join(cmd)}",
+                              file=sys.stderr,
+                          )
+                          if exc.stdout:
+                              print(f"stdout:\n{exc.stdout}", file=sys.stderr)
+                          if exc.stderr:
+                              print(f"stderr:\n{exc.stderr}", file=sys.stderr)
+                          raise SystemExit(1) from exc
 
 
                   secret = json.loads(

--- a/components/konflux-ui/production/kflux-fedora-01/letsencrypt/route-cert-sync-cronjob.yaml
+++ b/components/konflux-ui/production/kflux-fedora-01/letsencrypt/route-cert-sync-cronjob.yaml
@@ -1,0 +1,138 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: konflux-ci-route-cert-sync
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: konflux-ci-route-cert-sync
+rules:
+  - apiGroups:
+      - ""
+    resourceNames:
+      - konflux-ci-certificate
+    resources:
+      - secrets
+    verbs:
+      - get
+  - apiGroups:
+      - route.openshift.io
+    resourceNames:
+      - konflux-nice
+      - konflux-nice-idp
+    resources:
+      - routes
+    verbs:
+      - get
+      - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: konflux-ci-route-cert-sync
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: konflux-ci-route-cert-sync
+subjects:
+  - kind: ServiceAccount
+    name: konflux-ci-route-cert-sync
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: konflux-ci-route-cert-sync
+spec:
+  schedule: "0 6 * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      template:
+        spec:
+          serviceAccountName: konflux-ci-route-cert-sync
+          restartPolicy: OnFailure
+          securityContext:
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
+          containers:
+            - name: sync
+              image: registry.redhat.io/openshift4/ose-cli:v4.12
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  set -eu
+                  python3 <<'PY'
+                  import base64
+                  import json
+                  import subprocess
+                  import sys
+
+                  NS = "konflux-ui"
+                  SECRET = "konflux-ci-certificate"
+                  ROUTES = ("konflux-nice", "konflux-nice-idp")
+
+
+                  def oc(*args):
+                      return subprocess.run(
+                          ["oc", *args],
+                          capture_output=True,
+                          text=True,
+                          check=True,
+                      )
+
+
+                  secret = json.loads(
+                      oc("get", "secret", SECRET, "-n", NS, "-o", "json").stdout
+                  )
+                  cert = base64.b64decode(secret["data"]["tls.crt"]).decode()
+                  key = base64.b64decode(secret["data"]["tls.key"]).decode()
+                  patch = json.dumps({"spec": {"tls": {"certificate": cert, "key": key}}})
+
+                  updated = 0
+                  for route in ROUTES:
+                      current = oc("get", "route", route, "-n", NS, "-o", "json").stdout
+                      route_cert = (
+                          json.loads(current)
+                          .get("spec", {})
+                          .get("tls", {})
+                          .get("certificate", "")
+                      )
+                      if route_cert.strip() == cert.strip():
+                          print(f"{route}: already in sync")
+                          continue
+                      oc(
+                          "patch",
+                          "route",
+                          route,
+                          "-n",
+                          NS,
+                          "--type=merge",
+                          "-p",
+                          patch,
+                      )
+                      print(f"{route}: updated")
+                      updated += 1
+
+                  print(f"done: {updated} route(s) updated")
+                  PY
+              resources:
+                requests:
+                  cpu: 50m
+                  memory: 64Mi
+                limits:
+                  cpu: 100m
+                  memory: 128Mi
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+                readOnlyRootFilesystem: true
+                runAsNonRoot: true


### PR DESCRIPTION
## What

- Add `konflux-ci-route-cert-sync` CronJob to copy renewed TLS material from the cert-manager secret (`konflux-ci-certificate`) into the manually managed routes (`konflux-nice`, `konflux-nice-idp`)
- Runs daily at 06:00 UTC; only patches routes when the inline cert differs from the secret

Clusters affected: kflux-fedora-01

[KFLUXINFRA-3009](https://redhat.atlassian.net/browse/KFLUXINFRA-3009)

## Why

cert-manager successfully renews the Let's Encrypt certificate, but `RouteExternalCertificate` is disabled on this cluster. The custom-domain routes are managed manually with inline certs, so renewed secret data is never picked up by the router and the public cert expires.

## Validation

- `kustomize build --enable-helm components/konflux-ui/production/kflux-fedora-01/letsencrypt/` passes locally
- After sync, trigger a one-off run: `oc create job -n konflux-ui --from=cronjob/konflux-ci-route-cert-sync konflux-ci-route-cert-sync-now`

## Risk Assessment

**Risk Level:** Low

**What could go wrong:** CronJob fails to patch routes (RBAC, missing routes) leaving the site on a stale cert until the next run; incorrect patch could briefly disrupt TLS on the two custom-domain routes.

**Rollback:** Revert this PR and remove the CronJob; restore route certs manually from the secret if needed.

**Blast radius:** kflux-fedora-01 only — `konflux-ui` namespace, two routes (`konflux-nice`, `konflux-nice-idp`).

Made with [Cursor](https://cursor.com)

[KFLUXINFRA-3009]: https://redhat.atlassian.net/browse/KFLUXINFRA-3009?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ