### PR TITLE
SPRE-4610: bump internal-infra-deployments ref for nexus repo health fix

### DIFF
--- a/components/monitoring/blackbox/staging/stone-stage-p01/kustomization.yaml
+++ b/components/monitoring/blackbox/staging/stone-stage-p01/kustomization.yaml
@@ -1,6 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - https://github.com/redhat-appstudio/internal-infra-deployments/components/monitoring/blackbox-exporter/staging/private/stone-stage-p01?ref=3e477cc43651ab06c53c214cde861b1e7c0c44d0
+  - https://github.com/redhat-appstudio/internal-infra-deployments/components/monitoring/blackbox-exporter/staging/private/stone-stage-p01?ref=05eb151e7800b6a3983a42b22311f8a5ff63ed1b
 
 namespace: appstudio-monitoring

--- a/components/monitoring/blackbox/staging/stone-stg-rh01/kustomization.yaml
+++ b/components/monitoring/blackbox/staging/stone-stg-rh01/kustomization.yaml
@@ -1,6 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - https://github.com/redhat-appstudio/internal-infra-deployments/components/monitoring/blackbox-exporter/staging/public/stone-stg-rh01?ref=3e477cc43651ab06c53c214cde861b1e7c0c44d0
+  - https://github.com/redhat-appstudio/internal-infra-deployments/components/monitoring/blackbox-exporter/staging/public/stone-stg-rh01?ref=05eb151e7800b6a3983a42b22311f8a5ff63ed1b
 
 namespace: appstudio-monitoring


### PR DESCRIPTION
Update blackbox exporter ref for staging clusters to include fix for nexus-repos-health-probe using POST method and http_2xx_post module.