### PR TITLE
PVO11Y-5150 Rename kanary metrics and add metric_expiration to staging otel

### DIFF
--- a/components/monitoring/kanary/staging/base/tasks/push-kanary-metrics.yaml
+++ b/components/monitoring/kanary/staging/base/tasks/push-kanary-metrics.yaml
@@ -71,15 +71,15 @@ spec:
         labels_error = {"tested_cluster": tested_cluster, "type": test_type, "reason": "infrastructure"}
 
         kanary_up = meter.create_gauge(
-            "kanary_up_poc",
+            "kanary_up",
             description="Kanary signal: 1 if the e2e test passed, 0 if it failed",
         )
         kanary_error = meter.create_gauge(
-            "kanary_error_poc",
+            "kanary_error",
             description="Binary indicator of an infrastructure error preventing test execution",
         )
         kanary_timestamp = meter.create_gauge(
-            "kanary_last_push_timestamp_poc",
+            "kanary_last_push_timestamp",
             description="Epoch timestamp of the last kanary metrics push",
         )
 

--- a/components/tracing/otel-collector/staging/otel-collector-helm-values.yaml
+++ b/components/tracing/otel-collector/staging/otel-collector-helm-values.yaml
@@ -10,6 +10,7 @@ config:
       access_token: ${env:SIGNALFX_API_TOKEN}
     prometheus:
       endpoint: 0.0.0.0:8889
+      metric_expiration: 45m
   extensions:
     # The health_check extension is mandatory for this chart.
     # Without the health_check extension the collector will fail the readiness and liveliness probes.


### PR DESCRIPTION
## Summary
- Rename kanary metrics to remove `_poc` suffix: `kanary_up`, `kanary_error`, `kanary_last_push_timestamp`
- Add `metric_expiration: 45m` to staging otel collector prometheus exporter so metrics survive between cronjob runs

Jira: https://redhat.atlassian.net/browse/PVO11Y-5150

## Risk Assessment
**Risk Level:** Low
**Description:** Renames POC metrics to production names and increases metric retention on staging otel collector
**Rollback:** Revert PR

## Validation
- [x] `kustomize build components/monitoring/kanary/staging/stone-stage-p01/` passes
- [x] `kustomize build components/monitoring/kanary/staging/stone-stg-rh01/` passes
- [x] `kustomize build components/tracing/otel-collector/staging/` passes