### PR TITLE
PVO11Y-5151 Enable metrics pipeline on production otel collector

### DIFF
--- a/components/tracing/otel-collector/production/kustomization.yaml
+++ b/components/tracing/otel-collector/production/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../base
+  - servicemonitors
 patches:
   - path: signalfx-api-key-secret-path.yaml
     target:

--- a/components/tracing/otel-collector/production/otel-collector-helm-values.yaml
+++ b/components/tracing/otel-collector/production/otel-collector-helm-values.yaml
@@ -119,7 +119,7 @@ image:
   repository: quay.io/konflux-ci/opentelemetry-collector-k8s
   pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "0.110.0"
+  tag: "0.113.0"
 # OpenTelemetry Collector executable
 command:
   # The operator prepends '/' to the command name...no idea why.

--- a/components/tracing/otel-collector/production/otel-collector-helm-values.yaml
+++ b/components/tracing/otel-collector/production/otel-collector-helm-values.yaml
@@ -8,6 +8,9 @@ config:
       realm: "us1"
       api_url: "https://api.us1.signalfx.com"
       access_token: ${env:SIGNALFX_API_TOKEN}
+    prometheus:
+      endpoint: 0.0.0.0:8889
+      metric_expiration: 45m
   extensions:
     # The health_check extension is mandatory for this chart.
     # Without the health_check extension the collector will fail the readiness and liveliness probes.
@@ -61,7 +64,24 @@ config:
           - attributes/prod
         receivers:
           - otlp
-      metrics: null
+      metrics:
+        receivers:
+        - otlp
+        processors:
+        - memory_limiter
+        - batch
+        exporters:
+        - prometheus
+    telemetry:
+      metrics:
+        level: basic
+        readers:
+        - pull:
+            exporter:
+              prometheus:
+                host: 0.0.0.0
+                port: 8888
+
 # Configuration for ports
 ports:
   otlp:
@@ -75,6 +95,11 @@ ports:
     containerPort: 4318
     servicePort: 4318
     hostPort: 4318
+    protocol: TCP
+  prometheus:
+    enabled: true
+    containerPort: 8889
+    servicePort: 8889
     protocol: TCP
   jaeger-compact:
     enabled: false

--- a/components/tracing/otel-collector/production/servicemonitors/kustomization.yaml
+++ b/components/tracing/otel-collector/production/servicemonitors/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - otel-collector-kanary-servicemonitor.yaml

--- a/components/tracing/otel-collector/production/servicemonitors/otel-collector-kanary-servicemonitor.yaml
+++ b/components/tracing/otel-collector/production/servicemonitors/otel-collector-kanary-servicemonitor.yaml
@@ -1,0 +1,17 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: otel-collector-kanary-metrics
+  namespace: konflux-otel
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: opentelemetry-collector
+  endpoints:
+    - port: prometheus
+      interval: 15s
+      path: /metrics
+      metricRelabelings:
+        - sourceLabels: [__name__]
+          regex: 'kanary_.*'
+          action: keep


### PR DESCRIPTION
## Summary
- Enable metrics pipeline on production otel collector (was trace-only) with prometheus exporter and `metric_expiration: 45m`
- Add servicemonitor for kanary metrics scraping in production
- Add telemetry self-monitoring config

Jira: https://redhat.atlassian.net/browse/PVO11Y-5151

## Risk Assessment
**Risk Level:** Low
**Description:** Enables an additional pipeline (metrics) on the production otel collector. Trace pipeline is unchanged.
**Rollback:** Revert PR

## Validation
- Staging PR merged and validated: https://github.com/redhat-appstudio/infra-deployments/pull/12776
- [x] `kustomize build components/tracing/otel-collector/production/` passes