### PR TITLE
configure nvidia cdi with retry in stg

### DIFF
--- a/components/multi-platform-controller/staging/base/host-config-chart/files/linux-g64xlarge-amd64-init.sh
+++ b/components/multi-platform-controller/staging/base/host-config-chart/files/linux-g64xlarge-amd64-init.sh
@@ -2,6 +2,26 @@
 
 set -xeuo pipefail
 
+configure_nvidia_cdi() {
+  # generate Nvdia CDI with retry
+  for i in {1..10}; do
+    su - ec2-user -c 'nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml' 
+    su - ec2-user -c 'nvidia-ctk cdi generate --output=/var/run/cdi/nvidia.yaml'
+
+    # expect nvidia.com/gpu=all device to be in the generated list
+    if nvidia-ctk cdi list 2>/dev/null | grep -q 'nvidia.com/gpu=all'; then
+      echo "Nvidia CDI Ready"
+      return 0
+    fi
+
+    # sleep only if we'll be retrying again
+    [ "${i}" -lt "10" ] && sleep 1
+  done
+
+  echo "Nvidia CDI Failed"
+  return 1
+}
+
 # Format and mount NVMe disk
 mkfs -t xfs /dev/nvme1n1
 mount /dev/nvme1n1 /home
@@ -20,13 +40,9 @@ restorecon -r /var/lib/containers /var/tmp
 mkdir -p /etc/cdi /var/run/cdi
 chmod a+rwx /etc/cdi /var/run/cdi
 setsebool container_use_devices 1 2>/dev/null || true
-su - ec2-user -c 'nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml'
-if ! timeout 300s bash -c 'until nvidia-ctk cdi list 2>/dev/null | grep -q "nvidia.com/gpu=all"; do echo "Waiting for CDI..."; sleep 1; done'; then
-    echo "Timed out waiting for Nvidia CDI to get Ready"
-    exit 1
-fi
-echo "Nvidia CDI Ready"
+configure_nvidia_cdi
 chmod a+rw /etc/cdi/nvidia.yaml
+chmod a+rw /var/run/cdi/nvidia.yaml
 
 # Configure ec2-user SSH access
 chown -R ec2-user /home/ec2-user


### PR DESCRIPTION
We want to improve the configuration of our g64 VM as we are experiencing some flakiness.

Signed-off-by: Francesco Ilario <filario@redhat.com>

rh-pre-commit.version: 2.4.0
rh-pre-commit.check-secrets: ENABLED
