### PR TITLE
add konflux-tester-bot-actions to stg

### DIFF
--- a/components/konflux-rbac/staging/base/konflux-tester-bot-actions.yaml
+++ b/components/konflux-rbac/staging/base/konflux-tester-bot-actions.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: konflux-tester-bot-actions
+rules:
+- apiGroups:
+  - appstudio.redhat.com
+  resources:
+  - snapshots
+  verbs:
+  - get
+  - watch
+  - list
+  - update
+  - patch

--- a/components/konflux-rbac/staging/base/kustomization.yaml
+++ b/components/konflux-rbac/staging/base/kustomization.yaml
@@ -8,3 +8,4 @@ resources:
   - konflux-viewer-user-actions.yaml
   - konflux-builder-bot-actions.yaml
   - konflux-releaser-bot-actions.yaml
+  - konflux-tester-bot-actions.yaml


### PR DESCRIPTION
we need to add a ClusterRole to use for triggering periodic integration tests.

Signed-off-by: Francesco Ilario <filario@redhat.com>

rh-pre-commit.version: 2.4.0
rh-pre-commit.check-secrets: ENABLED
