### PR TITLE
feat(KFLUXVNGD-1094): fetch and display per-service feat/fix commits in changelog comment

### DIFF
--- a/infra-tools/cmd/changelog-generator/main.go
+++ b/infra-tools/cmd/changelog-generator/main.go
@@ -1,10 +1,9 @@
 // Command changelog-generator posts a changelog comment on infra-deployments PRs
 // that bump the Konflux operator ref.
 //
-// This is step 3 (KFLUXVNGD-1024): it reads the operator ref at the base branch
-// and PR head, posts a compare link, and lists which upstream sub-services had
-// their pinned SHA bumped inside the operator repo. Commit-level details per
-// service are introduced in the next PR.
+// This is step 4 (KFLUXVNGD-1079): it reads the operator ref, lists upstream
+// sub-services whose pinned SHA changed, and fetches per-service feat/fix
+// conventional commits to display under each bump entry.
 package main
 
 import (
@@ -151,12 +150,39 @@ func computeBody(ctx context.Context, basePath, headPath string, comparer change
 	}
 	slog.Info("Service bumps detected", "count", len(bumps))
 
-	// Normalize nil (no bumps found) to empty slice so formatCompare can
-	// distinguish "found nothing" from "API call failed" (nil).
-	if bumps == nil {
-		bumps = []changelog.ServiceBump{}
+	enriched := enrichWithCommits(ctx, comparer, bumps)
+	return formatCompare(oldRef, newRef, enriched), nil
+}
+
+// bumpWithCommits pairs a ServiceBump with the conventional commits found
+// between its old and new SHAs.
+type bumpWithCommits struct {
+	Bump      changelog.ServiceBump
+	Commits   []changelog.ConventionalCommit
+	Failed    bool // true when the commit fetch API call failed
+	Truncated bool // true when AheadBy hit the 250-commit API limit
+}
+
+// enrichWithCommits fetches feat/fix commits for each bump and returns a
+// slice ready for rendering. API errors per service are logged and surfaced
+// as Failed=true so the bump header is still shown without commits.
+func enrichWithCommits(ctx context.Context, comparer changelog.RepoComparer, bumps []changelog.ServiceBump) []bumpWithCommits {
+	// Explicit empty (not nil) so formatCompare shows "no refs changed", not
+	// the degraded "detection unavailable" message.
+	if len(bumps) == 0 {
+		return []bumpWithCommits{}
 	}
-	return formatCompare(oldRef, newRef, bumps), nil
+	result := make([]bumpWithCommits, len(bumps))
+	for i, bump := range bumps {
+		commits, truncated, err := changelog.FetchServiceCommits(ctx, comparer, bump)
+		if err != nil {
+			slog.Warn("fetching service commits", "service", bump.Repo, "err", err)
+			result[i] = bumpWithCommits{Bump: bump, Failed: true}
+			continue
+		}
+		result[i] = bumpWithCommits{Bump: bump, Commits: commits, Truncated: truncated}
+	}
+	return result
 }
 
 // formatNoChange returns the comment body when the operator ref did not change.
@@ -164,12 +190,12 @@ func formatNoChange() string {
 	return commentMarker + "\n### Operator Changelog\n\nNo operator ref change detected in this PR.\n"
 }
 
-// formatCompare returns the comment body with the operator compare link and
-// the list of upstream service bumps.
+// formatCompare returns the comment body with the operator compare link, the
+// list of upstream service bumps, and per-service feat/fix commit summaries.
 //
 // bumps == nil means the service bump detection API call failed (degraded).
 // bumps == [] means the call succeeded but no sub-service SHAs changed.
-func formatCompare(oldRef, newRef string, bumps []changelog.ServiceBump) string {
+func formatCompare(oldRef, newRef string, bumps []bumpWithCommits) string {
 	const base = "https://github.com/konflux-ci/konflux-ci"
 	short := func(ref string) string {
 		if len(ref) > 12 {
@@ -193,7 +219,8 @@ func formatCompare(oldRef, newRef string, bumps []changelog.ServiceBump) string 
 	default:
 		fmt.Fprintln(&b, "#### Upstream Service Bumps")
 		fmt.Fprintln(&b)
-		for _, bump := range bumps {
+		for _, bwc := range bumps {
+			bump := bwc.Bump
 			compareURL := fmt.Sprintf("https://github.com/%s/%s/compare/%s...%s",
 				bump.Owner, bump.Repo, bump.OldSHA, bump.NewSHA)
 			oldURL := fmt.Sprintf("https://github.com/%s/%s/commit/%s", bump.Owner, bump.Repo, bump.OldSHA)
@@ -203,6 +230,26 @@ func formatCompare(oldRef, newRef string, bumps []changelog.ServiceBump) string 
 				short(bump.OldSHA), oldURL,
 				short(bump.NewSHA), newURL,
 				compareURL)
+
+			switch {
+			case bwc.Failed:
+				fmt.Fprintf(&b, "\n_Commit details unavailable._\n\n")
+			case len(bwc.Commits) == 0:
+				fmt.Fprintf(&b, "\n_No notable commits (feat/fix)._\n\n")
+			default:
+				fmt.Fprintln(&b)
+				for _, c := range bwc.Commits {
+					if c.Scope != "" {
+						fmt.Fprintf(&b, "- %s(%s): %s\n", c.Type, c.Scope, c.Subject)
+					} else {
+						fmt.Fprintf(&b, "- %s: %s\n", c.Type, c.Subject)
+					}
+				}
+				if bwc.Truncated {
+					fmt.Fprintf(&b, "\n_Showing first %d commits only — results may be incomplete._\n", changelog.CommitMaxFromCompare)
+				}
+				fmt.Fprintln(&b)
+			}
 		}
 	}
 

--- a/infra-tools/cmd/changelog-generator/main_test.go
+++ b/infra-tools/cmd/changelog-generator/main_test.go
@@ -35,19 +35,33 @@ func (f *fakeCommenter) UpsertCommentByMarker(_ context.Context, prNumber int, b
 }
 
 // fakeRepoComparer implements changelog.RepoComparer for testing.
-// Set files to return canned file changes; set err to simulate an API failure.
+// The operator compare call (repo == "konflux-ci") uses err and files.
+// Service compare calls (any other repo) use commitErr and commits/aheadBy.
 var _ changelog.RepoComparer = &fakeRepoComparer{}
 
 type fakeRepoComparer struct {
-	files []*gh.CommitFile
-	err   error
+	files     []*gh.CommitFile
+	commits   []*gh.RepositoryCommit
+	aheadBy   int
+	err       error // returned for the operator compare call
+	commitErr error // returned for service compare calls
 }
 
-func (f *fakeRepoComparer) CompareCommits(_ context.Context, _, _, _, _ string, _ *gh.ListOptions) (*gh.CommitsComparison, *gh.Response, error) {
-	if f.err != nil {
-		return nil, nil, f.err
+func (f *fakeRepoComparer) CompareCommits(_ context.Context, _, repo, _, _ string, _ *gh.ListOptions) (*gh.CommitsComparison, *gh.Response, error) {
+	if repo == "konflux-ci" {
+		if f.err != nil {
+			return nil, nil, f.err
+		}
+		return &gh.CommitsComparison{Files: f.files}, nil, nil
 	}
-	return &gh.CommitsComparison{Files: f.files}, nil, nil
+	// Service compare call
+	if f.commitErr != nil {
+		return nil, nil, f.commitErr
+	}
+	return &gh.CommitsComparison{
+		Commits: f.commits,
+		AheadBy: gh.Ptr(f.aheadBy),
+	}, nil, nil
 }
 
 func writeTempKustomization(t *testing.T, ref string) string {
@@ -214,6 +228,134 @@ func TestComputeBody_Error(t *testing.T) {
 	_, err := computeBody(context.Background(), "/nonexistent/kustomization.yaml", "/nonexistent/kustomization.yaml", &fakeRepoComparer{})
 	g.Expect(err).To(HaveOccurred())
 	g.Expect(err.Error()).To(ContainSubstring("extracting operator refs"))
+}
+
+// TestComputeBody_WithServiceCommits verifies that feat/fix conventional commits
+// fetched for a bumped service appear in the comment body, while chore/docs are
+// excluded.
+func TestComputeBody_WithServiceCommits(t *testing.T) {
+	g := NewWithT(t)
+	buildOldSHA := "cccccccccccccccccccccccccccccccccccccccc"
+	buildNewSHA := "dddddddddddddddddddddddddddddddddddddddd"
+
+	patch := "-  - https://github.com/konflux-ci/build-service/config/default?ref=" + buildOldSHA + "\n" +
+		"+  - https://github.com/konflux-ci/build-service/config/default?ref=" + buildNewSHA + "\n"
+
+	fake := &fakeRepoComparer{
+		files: []*gh.CommitFile{
+			{
+				Filename: gh.Ptr("operator/upstream-kustomizations/build-service/kustomization.yaml"),
+				Patch:    gh.Ptr(patch),
+			},
+		},
+		commits: []*gh.RepositoryCommit{
+			{SHA: gh.Ptr("e1e1e1e1e1e1"), Commit: &gh.Commit{Message: gh.Ptr("feat: add multi-arch support")}},
+			{SHA: gh.Ptr("f2f2f2f2f2f2"), Commit: &gh.Commit{Message: gh.Ptr("fix(pipeline): correct timeout handling")}},
+			{SHA: gh.Ptr("a3a3a3a3a3a3"), Commit: &gh.Commit{Message: gh.Ptr("chore: update deps")}},
+		},
+	}
+
+	basePath := writeTempKustomization(t, oldRef)
+	headPath := writeTempKustomization(t, newRef)
+	body, err := computeBody(context.Background(), basePath, headPath, fake)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(body).To(ContainSubstring("build-service"))
+	g.Expect(body).To(ContainSubstring("feat: add multi-arch support"))
+	g.Expect(body).To(ContainSubstring("fix(pipeline): correct timeout handling"))
+	g.Expect(body).NotTo(ContainSubstring("chore:"))
+}
+
+// TestComputeBody_ServiceCommitsFail verifies that when the commit fetch fails
+// for a service, the bump header is still shown with a "unavailable" note,
+// while the operator-level compare link is unaffected.
+func TestComputeBody_ServiceCommitsFail(t *testing.T) {
+	g := NewWithT(t)
+	buildOldSHA := "cccccccccccccccccccccccccccccccccccccccc"
+	buildNewSHA := "dddddddddddddddddddddddddddddddddddddddd"
+
+	patch := "-  - https://github.com/konflux-ci/build-service/config/default?ref=" + buildOldSHA + "\n" +
+		"+  - https://github.com/konflux-ci/build-service/config/default?ref=" + buildNewSHA + "\n"
+
+	fake := &fakeRepoComparer{
+		files: []*gh.CommitFile{
+			{
+				Filename: gh.Ptr("operator/upstream-kustomizations/build-service/kustomization.yaml"),
+				Patch:    gh.Ptr(patch),
+			},
+		},
+		commitErr: errors.New("rate limited"),
+	}
+
+	basePath := writeTempKustomization(t, oldRef)
+	headPath := writeTempKustomization(t, newRef)
+	body, err := computeBody(context.Background(), basePath, headPath, fake)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(body).To(ContainSubstring("build-service"))
+	g.Expect(body).To(ContainSubstring("compare/" + oldRef + "..." + newRef))
+	g.Expect(body).To(ContainSubstring("Commit details unavailable"))
+	g.Expect(body).NotTo(ContainSubstring("check manually")) // operator-level degradation message absent
+}
+
+// TestComputeBody_ServiceCommitsTruncated verifies that when AheadBy hits the
+// 250-commit API limit, a truncation note appears after the commit list.
+func TestComputeBody_ServiceCommitsTruncated(t *testing.T) {
+	g := NewWithT(t)
+	buildOldSHA := "cccccccccccccccccccccccccccccccccccccccc"
+	buildNewSHA := "dddddddddddddddddddddddddddddddddddddddd"
+
+	patch := "-  - https://github.com/konflux-ci/build-service/config/default?ref=" + buildOldSHA + "\n" +
+		"+  - https://github.com/konflux-ci/build-service/config/default?ref=" + buildNewSHA + "\n"
+
+	fake := &fakeRepoComparer{
+		files: []*gh.CommitFile{
+			{
+				Filename: gh.Ptr("operator/upstream-kustomizations/build-service/kustomization.yaml"),
+				Patch:    gh.Ptr(patch),
+			},
+		},
+		commits: []*gh.RepositoryCommit{
+			{SHA: gh.Ptr("e1e1e1e1e1e1"), Commit: &gh.Commit{Message: gh.Ptr("feat: add feature")}},
+		},
+		aheadBy: 250,
+	}
+
+	basePath := writeTempKustomization(t, oldRef)
+	headPath := writeTempKustomization(t, newRef)
+	body, err := computeBody(context.Background(), basePath, headPath, fake)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(body).To(ContainSubstring("feat: add feature"))
+	g.Expect(body).To(ContainSubstring("250 commits"))
+}
+
+// TestComputeBody_NoNotableCommits verifies that when service commits exist but
+// none are feat/fix conventional commits, a clear "no notable commits" note is shown.
+func TestComputeBody_NoNotableCommits(t *testing.T) {
+	g := NewWithT(t)
+	buildOldSHA := "cccccccccccccccccccccccccccccccccccccccc"
+	buildNewSHA := "dddddddddddddddddddddddddddddddddddddddd"
+
+	patch := "-  - https://github.com/konflux-ci/build-service/config/default?ref=" + buildOldSHA + "\n" +
+		"+  - https://github.com/konflux-ci/build-service/config/default?ref=" + buildNewSHA + "\n"
+
+	fake := &fakeRepoComparer{
+		files: []*gh.CommitFile{
+			{
+				Filename: gh.Ptr("operator/upstream-kustomizations/build-service/kustomization.yaml"),
+				Patch:    gh.Ptr(patch),
+			},
+		},
+		commits: []*gh.RepositoryCommit{
+			{SHA: gh.Ptr("a1a1a1"), Commit: &gh.Commit{Message: gh.Ptr("chore: bump go version")}},
+			{SHA: gh.Ptr("b2b2b2"), Commit: &gh.Commit{Message: gh.Ptr("Merge pull request #42")}},
+		},
+	}
+
+	basePath := writeTempKustomization(t, oldRef)
+	headPath := writeTempKustomization(t, newRef)
+	body, err := computeBody(context.Background(), basePath, headPath, fake)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(body).To(ContainSubstring("build-service"))
+	g.Expect(body).To(ContainSubstring("No notable commits"))
 }
 
 // TestBuildBody_Integration creates a real git repo with two commits that have

--- a/infra-tools/internal/changelog/bumps.go
+++ b/infra-tools/internal/changelog/bumps.go
@@ -25,8 +25,10 @@ var (
 // for kustomization files under operator/upstream-kustomizations/ that have
 // a ?ref=<sha> change, and returns one ServiceBump per bumped service.
 //
-// Duplicate (owner, repo) pairs are deduplicated — only the first occurrence
-// is kept, since the same service can appear in multiple kustomization files.
+// A single kustomization file can reference multiple upstream repositories;
+// all changed pairs within a file are detected, not just the first one.
+// Duplicate (owner, repo) pairs across files are deduplicated — only the
+// first occurrence is kept.
 //
 // The second return value is true when one or more upstream kustomization files
 // had an empty patch (GitHub omits patch data for very large or renamed files).
@@ -47,23 +49,22 @@ func ExtractServiceBumps(files []FileChange) ([]ServiceBump, bool) {
 			hasSkipped = true
 			continue
 		}
-		matchedBase, oldSHA, newSHA := extractRefChange(f.Patch)
-		if oldSHA == "" || newSHA == "" {
-			continue
+		// Iterate ALL ref changes in the patch — a kustomization file can pin
+		// several upstream services; each changed URL base is its own bump.
+		for _, change := range extractRefChanges(f.Patch) {
+			// Derive owner/repo from the specific URL that changed, not from any
+			// github.com URL in the diff — prevents misattribution.
+			owner, repo := extractGitHubRepoFromURL(change.base)
+			if owner == "" || repo == "" {
+				continue
+			}
+			key := owner + "/" + repo
+			if seen[key] {
+				continue
+			}
+			seen[key] = true
+			bumps = append(bumps, ServiceBump{Owner: owner, Repo: repo, OldSHA: change.oldSHA, NewSHA: change.newSHA})
 		}
-		// Derive owner/repo from the specific URL that changed, not from any
-		// github.com URL in the diff — prevents misattribution when a file
-		// references multiple repositories.
-		owner, repo := extractGitHubRepoFromURL(matchedBase)
-		if owner == "" || repo == "" {
-			continue
-		}
-		key := owner + "/" + repo
-		if seen[key] {
-			continue
-		}
-		seen[key] = true
-		bumps = append(bumps, ServiceBump{Owner: owner, Repo: repo, OldSHA: oldSHA, NewSHA: newSHA})
 	}
 	return bumps, hasSkipped
 }
@@ -75,18 +76,27 @@ func isUpstreamKustomization(filename string) bool {
 		(strings.HasSuffix(filename, "/kustomization.yaml") || strings.HasSuffix(filename, "/kustomization.yml"))
 }
 
-// extractRefChange scans a unified diff for a removed (-) and added (+)
-// ?ref=<40-char-sha> pair that share the same URL base (everything before ?ref=).
-// Pairing by URL base avoids false matches when a file contains multiple resource
-// URLs that change independently.
+// refChange holds one matched old→new SHA pair found in a patch, together with
+// the URL base (everything before ?ref=) that identifies which resource changed.
+type refChange struct {
+	base   string
+	oldSHA string
+	newSHA string
+}
+
+// extractRefChanges scans a unified diff and returns ALL removed(-)/added(+)
+// ?ref=<40-char-sha> pairs that share the same URL base.
 //
-// Returns the matched URL base together with the old and new SHAs so callers
-// can derive owner/repo from the exact URL that changed. Returns ("","","") if
-// no matching pair is found.
-func extractRefChange(patch string) (matchedBase, oldSHA, newSHA string) {
+// Pairing by URL base is the key correctness invariant: it ensures that when a
+// kustomization file lists several upstream services, each service's old→new SHA
+// is matched to its own URL rather than to a SHA from a different service.
+//
+// The `removed` map is consumed as matches are found, so the same base cannot
+// produce multiple pairs even if the diff is malformed.
+func extractRefChanges(patch string) []refChange {
 	lines := strings.Split(patch, "\n")
 
-	// First pass: collect removed refs keyed by URL base.
+	// First pass: collect every removed (-) ref, keyed by URL base.
 	removed := make(map[string]string) // urlBase → sha
 	for _, line := range lines {
 		if len(line) == 0 || line[0] != '-' {
@@ -101,7 +111,10 @@ func extractRefChange(patch string) (matchedBase, oldSHA, newSHA string) {
 		}
 	}
 
-	// Second pass: find an added ref whose URL base matches a removed one.
+	// Second pass: collect every added (+) ref whose URL base was also removed,
+	// and whose SHA actually changed. Deleting from `removed` after each match
+	// prevents the same base from being emitted more than once.
+	var changes []refChange
 	for _, line := range lines {
 		if len(line) == 0 || line[0] != '+' {
 			continue
@@ -112,11 +125,12 @@ func extractRefChange(patch string) (matchedBase, oldSHA, newSHA string) {
 		}
 		if base := urlBase(line); base != "" {
 			if old, ok := removed[base]; ok && old != m[1] {
-				return base, old, m[1]
+				changes = append(changes, refChange{base: base, oldSHA: old, newSHA: m[1]})
+				delete(removed, base)
 			}
 		}
 	}
-	return "", "", ""
+	return changes
 }
 
 // urlBase returns the portion of a diff line before the ?ref= query parameter,

--- a/infra-tools/internal/changelog/bumps_test.go
+++ b/infra-tools/internal/changelog/bumps_test.go
@@ -141,6 +141,40 @@ func TestExtractServiceBumps_NoGitHubURL(t *testing.T) {
 	g.Expect(bumps).To(BeEmpty())
 }
 
+// TestExtractServiceBumps_MultipleBumpsInOnePatch verifies that when a single
+// kustomization file references multiple upstream services and both SHAs change,
+// both bumps are detected — not just the first one.
+func TestExtractServiceBumps_MultipleBumpsInOnePatch(t *testing.T) {
+	g := NewWithT(t)
+	intOldSHA := "cccccccccccccccccccccccccccccccccccccccc"
+	intNewSHA := "dddddddddddddddddddddddddddddddddddddddd"
+	// Both build-service and integration-service refs change in the same file.
+	patch := "-  - https://github.com/konflux-ci/build-service/config?ref=" + buildOldSHA + "\n" +
+		"+  - https://github.com/konflux-ci/build-service/config?ref=" + buildNewSHA + "\n" +
+		"-  - https://github.com/konflux-ci/integration-service/config?ref=" + intOldSHA + "\n" +
+		"+  - https://github.com/konflux-ci/integration-service/config?ref=" + intNewSHA + "\n"
+	files := []changelog.FileChange{
+		{
+			Filename: "operator/upstream-kustomizations/combined/kustomization.yaml",
+			Patch:    patch,
+		},
+	}
+	bumps, skipped := changelog.ExtractServiceBumps(files)
+	g.Expect(skipped).To(BeFalse())
+	g.Expect(bumps).To(HaveLen(2))
+
+	byRepo := make(map[string]changelog.ServiceBump)
+	for _, b := range bumps {
+		byRepo[b.Repo] = b
+	}
+	g.Expect(byRepo).To(HaveKey("build-service"))
+	g.Expect(byRepo["build-service"].OldSHA).To(Equal(buildOldSHA))
+	g.Expect(byRepo["build-service"].NewSHA).To(Equal(buildNewSHA))
+	g.Expect(byRepo).To(HaveKey("integration-service"))
+	g.Expect(byRepo["integration-service"].OldSHA).To(Equal(intOldSHA))
+	g.Expect(byRepo["integration-service"].NewSHA).To(Equal(intNewSHA))
+}
+
 // TestExtractServiceBumps_MultipleURLsSameFile verifies that when a kustomization
 // file has two resource URLs and only one changes, the correct SHA pair is returned
 // and the owner/repo is derived from the URL that actually changed — not from any

--- a/infra-tools/internal/changelog/commits.go
+++ b/infra-tools/internal/changelog/commits.go
@@ -1,0 +1,93 @@
+package changelog
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+
+	gh "github.com/google/go-github/v68/github"
+)
+
+// conventionalPattern matches conventional commit subject lines.
+// Captures: type (feat|fix), optional (scope), optional !, and the message.
+var conventionalPattern = regexp.MustCompile(`^(feat|fix)(\([^)]+\))?!?: (.+)`)
+
+// CommitMaxFromCompare is the GitHub compare API hard limit on returned commits.
+// When AheadBy hits this value the result may be incomplete; callers should
+// note truncation in the output rather than silently omitting commits.
+const CommitMaxFromCompare = 250
+
+// ConventionalCommit holds a parsed conventional commit entry.
+type ConventionalCommit struct {
+	Type    string // "feat" or "fix"
+	Scope   string // optional scope, e.g. "pipeline"; empty if not present
+	Subject string // message after the type/scope prefix
+	SHA     string // 12-char short SHA for traceability
+}
+
+// FetchServiceCommits calls the GitHub compare API for bump.Owner/bump.Repo
+// between bump.OldSHA and bump.NewSHA and returns filtered conventional commits.
+//
+// Reuses the RepoComparer interface so the same retry and auth logic from
+// FetchOperatorCompare applies here — no separate client or interface needed.
+// The second return value is true when AheadBy hit the 250-commit API limit,
+// indicating results may be incomplete.
+func FetchServiceCommits(ctx context.Context, c RepoComparer, bump ServiceBump) ([]ConventionalCommit, bool, error) {
+	var comparison *gh.CommitsComparison
+	err := retryDo(ctx, 3, func() error {
+		var e error
+		comparison, _, e = c.CompareCommits(ctx, bump.Owner, bump.Repo, bump.OldSHA, bump.NewSHA, nil)
+		return e
+	})
+	if err != nil {
+		return nil, false, fmt.Errorf("comparing %s/%s %s...%s: %w",
+			bump.Owner, bump.Repo, refShort(bump.OldSHA), refShort(bump.NewSHA), err)
+	}
+	commits := filterConventional(comparison.Commits)
+	truncated := comparison.GetAheadBy() >= CommitMaxFromCompare
+	return commits, truncated, nil
+}
+
+// filterConventional returns only feat/fix conventional commits, taking only
+// the first line of each commit message to avoid multi-paragraph bodies.
+func filterConventional(raw []*gh.RepositoryCommit) []ConventionalCommit {
+	var out []ConventionalCommit
+	for _, c := range raw {
+		if c == nil || c.Commit == nil || c.Commit.Message == nil {
+			continue
+		}
+		subject := firstLine(*c.Commit.Message)
+		typ, scope, msg, ok := parseConventionalCommit(subject)
+		if !ok {
+			continue
+		}
+		out = append(out, ConventionalCommit{
+			Type:    typ,
+			Scope:   scope,
+			Subject: msg,
+			SHA:     refShort(c.GetSHA()),
+		})
+	}
+	return out
+}
+
+// parseConventionalCommit parses a conventional commit subject line of the form
+// "feat: msg", "fix(scope): msg", "feat!: msg", or "fix(scope)!: msg".
+// Returns (type, scope, message, true) on a match, or ("","","",false) otherwise.
+func parseConventionalCommit(subject string) (typ, scope, msg string, ok bool) {
+	m := conventionalPattern.FindStringSubmatch(subject)
+	if m == nil {
+		return "", "", "", false
+	}
+	// m[1]=type, m[2]="(scope)" with parens (empty string if absent), m[3]=message
+	return m[1], strings.Trim(m[2], "()"), m[3], true
+}
+
+// firstLine returns the first line of a potentially multi-line string.
+func firstLine(s string) string {
+	if idx := strings.Index(s, "\n"); idx >= 0 {
+		return s[:idx]
+	}
+	return s
+}

--- a/infra-tools/internal/changelog/commits_test.go
+++ b/infra-tools/internal/changelog/commits_test.go
@@ -1,0 +1,135 @@
+package changelog_test
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+
+	gh "github.com/google/go-github/v68/github"
+	. "github.com/onsi/gomega"
+
+	"github.com/redhat-appstudio/infra-deployments/infra-tools/internal/changelog"
+)
+
+// makeCommit creates a RepositoryCommit with the given SHA and message.
+func makeCommit(sha, message string) *gh.RepositoryCommit {
+	return &gh.RepositoryCommit{
+		SHA:    gh.Ptr(sha),
+		Commit: &gh.Commit{Message: gh.Ptr(message)},
+	}
+}
+
+// testBump is a reusable ServiceBump for commit tests.
+var testBump = changelog.ServiceBump{
+	Owner:  "konflux-ci",
+	Repo:   "build-service",
+	OldSHA: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+	NewSHA: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+}
+
+func TestFetchServiceCommits_ReturnsFilteredCommits(t *testing.T) {
+	g := NewWithT(t)
+	fake := &fakeComparer{
+		commits: []*gh.RepositoryCommit{
+			makeCommit("cccccccccccc", "feat: add retry support"),
+			makeCommit("dddddddddddd", "fix(pipeline): correct timeout"),
+			makeCommit("eeeeeeeeeeee", "chore: update deps"),
+			makeCommit("ffffffffffff", "Merge pull request #123"),
+		},
+	}
+	commits, truncated, err := changelog.FetchServiceCommits(context.Background(), fake, testBump)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(truncated).To(BeFalse())
+	g.Expect(commits).To(HaveLen(2))
+	g.Expect(commits[0].Type).To(Equal("feat"))
+	g.Expect(commits[0].Subject).To(Equal("add retry support"))
+	g.Expect(commits[0].Scope).To(BeEmpty())
+	g.Expect(commits[1].Type).To(Equal("fix"))
+	g.Expect(commits[1].Scope).To(Equal("pipeline"))
+	g.Expect(commits[1].Subject).To(Equal("correct timeout"))
+}
+
+func TestFetchServiceCommits_EmptyWhenNoConventional(t *testing.T) {
+	g := NewWithT(t)
+	fake := &fakeComparer{
+		commits: []*gh.RepositoryCommit{
+			makeCommit("aaaa", "chore: update deps"),
+			makeCommit("bbbb", "Update readme"),
+			makeCommit("cccc", "Merge pull request #123"),
+		},
+	}
+	commits, _, err := changelog.FetchServiceCommits(context.Background(), fake, testBump)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(commits).To(BeEmpty())
+}
+
+func TestFetchServiceCommits_TruncatedWhenAheadByMax(t *testing.T) {
+	g := NewWithT(t)
+	fake := &fakeComparer{aheadBy: 250}
+	_, truncated, err := changelog.FetchServiceCommits(context.Background(), fake, testBump)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(truncated).To(BeTrue())
+}
+
+func TestFetchServiceCommits_NotTruncatedBeforeMax(t *testing.T) {
+	g := NewWithT(t)
+	fake := &fakeComparer{aheadBy: 249}
+	_, truncated, err := changelog.FetchServiceCommits(context.Background(), fake, testBump)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(truncated).To(BeFalse())
+}
+
+func TestFetchServiceCommits_APIError(t *testing.T) {
+	g := NewWithT(t)
+	// failTimes=3 — all attempts fail, error is returned with service name in message.
+	fake := &fakeComparer{err: errors.New("network error"), failTimes: 3}
+	_, _, err := changelog.FetchServiceCommits(context.Background(), fake, testBump)
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err.Error()).To(ContainSubstring("build-service"))
+	g.Expect(fake.calls).To(Equal(3))
+}
+
+// TestFetchServiceCommits_NonRetryableErrorFastFails verifies that a 404 does
+// not trigger retries — only one call should be made.
+func TestFetchServiceCommits_NonRetryableErrorFastFails(t *testing.T) {
+	g := NewWithT(t)
+	notFound := &gh.ErrorResponse{
+		Response: &http.Response{StatusCode: http.StatusNotFound},
+	}
+	fake := &fakeComparer{err: notFound, failTimes: 3}
+	_, _, err := changelog.FetchServiceCommits(context.Background(), fake, testBump)
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(fake.calls).To(Equal(1))
+}
+
+// TestFetchServiceCommits_TakesFirstLineOnly verifies that only the subject
+// line of a multi-paragraph commit message is parsed.
+func TestFetchServiceCommits_TakesFirstLineOnly(t *testing.T) {
+	g := NewWithT(t)
+	fake := &fakeComparer{
+		commits: []*gh.RepositoryCommit{
+			makeCommit("aaaa", "feat: add feature\n\nThis is the body.\nWith multiple lines."),
+		},
+	}
+	commits, _, err := changelog.FetchServiceCommits(context.Background(), fake, testBump)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(commits).To(HaveLen(1))
+	g.Expect(commits[0].Subject).To(Equal("add feature"))
+}
+
+// TestFetchServiceCommits_BreakingChangeStripsExclamation verifies that the
+// breaking change marker (!) is stripped and the commit is still captured.
+func TestFetchServiceCommits_BreakingChangeStripsExclamation(t *testing.T) {
+	g := NewWithT(t)
+	fake := &fakeComparer{
+		commits: []*gh.RepositoryCommit{
+			makeCommit("aaaa", "feat!: breaking API change"),
+		},
+	}
+	commits, _, err := changelog.FetchServiceCommits(context.Background(), fake, testBump)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(commits).To(HaveLen(1))
+	g.Expect(commits[0].Type).To(Equal("feat"))
+	g.Expect(commits[0].Subject).To(Equal("breaking API change"))
+}

--- a/infra-tools/internal/changelog/upstream_test.go
+++ b/infra-tools/internal/changelog/upstream_test.go
@@ -17,6 +17,8 @@ import (
 // failTimes controls how many calls return err before the call succeeds.
 type fakeComparer struct {
 	files     []*gh.CommitFile
+	commits   []*gh.RepositoryCommit // returned in CommitsComparison.Commits
+	aheadBy   int                    // returned in CommitsComparison.AheadBy
 	err       error
 	failTimes int // number of initial calls that return err before succeeding
 	calls     int // tracks total calls made
@@ -27,7 +29,11 @@ func (f *fakeComparer) CompareCommits(_ context.Context, _, _, _, _ string, _ *g
 	if f.failTimes > 0 && f.calls <= f.failTimes {
 		return nil, nil, f.err
 	}
-	return &gh.CommitsComparison{Files: f.files}, nil, nil
+	return &gh.CommitsComparison{
+		Files:   f.files,
+		Commits: f.commits,
+		AheadBy: gh.Ptr(f.aheadBy),
+	}, nil, nil
 }
 
 func TestFetchOperatorCompare_ReturnsConvertedFiles(t *testing.T) {


### PR DESCRIPTION
For each upstream service bumped by the operator, fetch and display feat/fix conventional commits in the PR comment; also fix a bug where only the first ref change in a kustomization file was detected, causing additional services in the same file to be silently dropped