### PR TITLE
add konflux-tester-internalbot-actions to prod

### DIFF
--- a/components/konflux-rbac/production/base/konflux-tester-bot-actions.yaml
+++ b/components/konflux-rbac/production/base/konflux-tester-bot-actions.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: konflux-tester-bot-actions
+rules:
+- apiGroups:
+  - appstudio.redhat.com
+  resources:
+  - snapshots
+  verbs:
+  - get
+  - watch
+  - list
+  - update
+  - patch

--- a/components/konflux-rbac/production/base/konflux-tester-internalbot-actions.yaml
+++ b/components/konflux-rbac/production/base/konflux-tester-internalbot-actions.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: konflux-tester-bot-actions
+  name: konflux-tester-internalbot-actions
 rules:
 - apiGroups:
   - appstudio.redhat.com

--- a/components/konflux-rbac/production/base/kustomization.yaml
+++ b/components/konflux-rbac/production/base/kustomization.yaml
@@ -1,11 +1,14 @@
 kind: Kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 resources:
+- ../../base
 - konflux-admin-user-actions.yaml
 - konflux-maintainer-user-actions.yaml
 - konflux-contributor-user-actions.yaml
 - konflux-viewer-user-actions.yaml
+# can be bound to konflux-bot-* ServiceAccounts
+# and exposed outside the cluster
 - konflux-builder-bot-actions.yaml
 - konflux-releaser-bot-actions.yaml
-- konflux-tester-bot-actions.yaml
-- ../../base
+# can NOT be bound to konflux-bot-* ServiceAccounts
+- konflux-tester-internalbot-actions.yaml

--- a/components/konflux-rbac/production/base/kustomization.yaml
+++ b/components/konflux-rbac/production/base/kustomization.yaml
@@ -7,4 +7,5 @@ resources:
 - konflux-viewer-user-actions.yaml
 - konflux-builder-bot-actions.yaml
 - konflux-releaser-bot-actions.yaml
+- konflux-tester-bot-actions.yaml
 - ../../base


### PR DESCRIPTION
we need to add a ClusterRole to use for triggering periodic integration tests.

Staging PR: https://github.com/redhat-appstudio/infra-deployments/pull/12790

## Risk Assessment

**Risk level:** low

**What could go wrong:** nothing

**Rollback plan:** Revert the PR and redeploy. No data migration involved.

**Testing:** Validated in staging for 12 hours with no issues.

Signed-off-by: Francesco Ilario <filario@redhat.com>

rh-pre-commit.version: 2.4.0
rh-pre-commit.check-secrets: ENABLED
