### PR TITLE
PVO11Y-5290 Add pipeline-metrics-exporter to tekton-ms

### DIFF
--- a/components/monitoring/prometheus/base/tekton-ms/kustomization.yaml
+++ b/components/monitoring/prometheus/base/tekton-ms/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
 - monitoringstack.yaml
 - rbac.yaml
 - servicemonitor.yaml
+- servicemonitor-pipeline-exporter.yaml
 - external-secrets/
 
 commonAnnotations:

--- a/components/monitoring/prometheus/base/tekton-ms/servicemonitor-pipeline-exporter.yaml
+++ b/components/monitoring/prometheus/base/tekton-ms/servicemonitor-pipeline-exporter.yaml
@@ -1,0 +1,18 @@
+apiVersion: monitoring.rhobs/v1
+kind: ServiceMonitor
+metadata:
+  name: appstudio-tekton-pipeline-exporter-smon
+  namespace: appstudio-tekton
+  labels:
+    monitoring.rhobs/stack: appstudio-tekton-ms
+spec:
+  namespaceSelector:
+    matchNames:
+    - openshift-pipelines
+  selector:
+    matchLabels:
+      app: pipeline-metrics-exporter
+  endpoints:
+  - port: metrics
+    interval: 15s
+    honorLabels: true


### PR DESCRIPTION
## Summary
- Add pipeline-metrics-exporter ServiceMonitor to the tekton-ms MonitoringStack so both controller and exporter metrics are available in a single datasource

## Context
The pipeline-service in-cluster dashboard combines tekton_pipelines_controller metrics with pipeline-exporter metrics (e.g. the deadlock detection formula subtracts throttling counts from pending counts). Having both in the same Prometheus avoids mixed-datasource workarounds when switching the dashboard to `prometheus-tekton-ms-ds`.

## Test plan
- [ ] Verify pipeline-metrics-exporter metrics appear in `prometheus-tekton-ms-ds` via Grafana Explore
- [ ] Verify existing dashboard panels still work on `prometheus-appstudio-ds` (no disruption)