### PR TITLE
PVO11Y-5128 Stop deploying monitoring-cardinality to public production

### DIFF
--- a/argo-cd-apps/overlays/konflux-public-production/delete-applications.yaml
+++ b/argo-cd-apps/overlays/konflux-public-production/delete-applications.yaml
@@ -17,6 +17,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: ApplicationSet
 metadata:
   name: monitoring-cardinality
+$patch: delete
 ---
 apiVersion: argoproj.io/v1alpha1
 kind: ApplicationSet


### PR DESCRIPTION
## Summary

- Add missing `$patch: delete` to the monitoring-cardinality entry in the public production `delete-applications.yaml`. The directive was lost when the disaster-recovery block was inserted above it in 554e94009, causing the cardinality exporter to deploy to production despite being staging-only.

## Risk Assessment

- **Level:** Low
- **Description:** Removes an unintended ApplicationSet from production. The cardinality exporter was already running on production clusters without issues, but it's not needed there.
- **Rollback:** Revert the commit.

## Validation

- production-downstream overlay already has the correct `$patch: delete` for this entry