### PR TITLE
PVO11Y-5150 Stagger kanary cronjob schedules to reduce Kueue contention

### DIFF
--- a/components/monitoring/kanary/staging/stone-stage-p01/cronjobs/kanary-cronjob-multi-arch.yaml
+++ b/components/monitoring/kanary/staging/stone-stage-p01/cronjobs/kanary-cronjob-multi-arch.yaml
@@ -3,7 +3,7 @@ kind: CronJob
 metadata:
   name: kanary-trigger-multi-arch
 spec:
-  schedule: "0 * * * *"
+  schedule: "15,45 * * * *"
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 3

--- a/components/monitoring/kanary/staging/stone-stage-p01/cronjobs/kanary-cronjob-single-arch.yaml
+++ b/components/monitoring/kanary/staging/stone-stage-p01/cronjobs/kanary-cronjob-single-arch.yaml
@@ -3,7 +3,7 @@ kind: CronJob
 metadata:
   name: kanary-trigger-single-arch
 spec:
-  schedule: "0 * * * *"
+  schedule: "0,30 * * * *"
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 3

--- a/components/monitoring/kanary/staging/stone-stg-rh01/cronjobs/kanary-cronjob-multi-arch.yaml
+++ b/components/monitoring/kanary/staging/stone-stg-rh01/cronjobs/kanary-cronjob-multi-arch.yaml
@@ -3,7 +3,7 @@ kind: CronJob
 metadata:
   name: kanary-trigger-multi-arch
 spec:
-  schedule: "0 * * * *"
+  schedule: "15,45 * * * *"
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 3

--- a/components/monitoring/kanary/staging/stone-stg-rh01/cronjobs/kanary-cronjob-single-arch.yaml
+++ b/components/monitoring/kanary/staging/stone-stg-rh01/cronjobs/kanary-cronjob-single-arch.yaml
@@ -3,7 +3,7 @@ kind: CronJob
 metadata:
   name: kanary-trigger-single-arch
 spec:
-  schedule: "0 * * * *"
+  schedule: "0,30 * * * *"
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 3


### PR DESCRIPTION
## Summary
Stagger single-arch and multi-arch kanary cronjobs by 15 minutes to avoid Kueue quota contention when both run simultaneously in the same tenant namespace.

- **Single-arch:** `0,30 * * * *` (at :00 and :30)
- **Multi-arch:** `15,45 * * * *` (at :15 and :45)

### Why
Both cronjobs currently fire at `:00`, creating 8+ PipelineRuns competing for the same Kueue quota in `konflux-perfscale-4-tenant`. This causes a race condition where the loadtest's cleanup step blocks (waiting for Kueue-delayed PipelineRuns), while the real build PipelineRun completes and gets deleted by kubearchive (5m after completion). By the time the loadtest starts tracking the build, it's already gone.

Multi-arch runs alone succeed consistently (confirmed by manual trigger). The root cause analysis is in [KONFLUX-14652](https://redhat.atlassian.net/browse/KONFLUX-14652).

Jira: https://redhat.atlassian.net/browse/PVO11Y-5150

## Risk Assessment
**Risk Level:** Low
**Description:** Changes cronjob schedules only, no code changes
**Rollback:** Revert PR

## Validation
- [x] `kustomize build components/monitoring/kanary/staging/stone-stage-p01/` passes
- [x] `kustomize build components/monitoring/kanary/staging/stone-stg-rh01/` passes
- Multi-arch manual trigger succeeded (15m37s) when running alone

[KONFLUX-14652]: https://redhat.atlassian.net/browse/KONFLUX-14652?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ