### PR TITLE
PVO11Y-5128 Allow cardinality exporter labels through remote-write

### DIFF
--- a/components/monitoring/prometheus/staging/base/federation/writeRelabelConfigs.yaml
+++ b/components/monitoring/prometheus/staging/base/federation/writeRelabelConfigs.yaml
@@ -17,4 +17,5 @@
       policy_name|policy_background_mode|rule_type|policy_type|policy_validation_mode|\
       resource_request_operation|resource_kind|policy_change_type|event_type|\
       name|cluster_queue|quantile|slice|scrape_job|tested_registry|error|queue|\
-      priority_class|cache_status|finalizers|severity"
+      priority_class|cache_status|finalizers|severity|\
+      metric|label|label_pair|scraped_instance|sharded_instance|instance_namespace"


### PR DESCRIPTION
## Summary

- Add 6 cardinality exporter labels (`metric`, `label`, `label_pair`, `scraped_instance`, `sharded_instance`, `instance_namespace`) to the staging `writeRelabelConfigs` LabelKeep allowlist so they survive remote-write to RHOBS.

## Risk Assessment

- **Level:** Low
- **Description:** Adds label names to an existing allowlist. Only affects series that already have these labels — no new series are created.
- **Rollback:** Revert the commit.

## Validation

- Verified the 6 labels exist in the exporter source code (`cardinality/metrics.go`)
- Currently all cardinality exporter metrics reach RHOBS with their dimension labels stripped, making the data unusable