### PR TITLE
SPRE-4610: bump internal-infra-deployments ref for nexus GET endpoint…

### DIFF
--- a/components/monitoring/blackbox/staging/stone-stage-p01/kustomization.yaml
+++ b/components/monitoring/blackbox/staging/stone-stage-p01/kustomization.yaml
@@ -1,6 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - https://github.com/redhat-appstudio/internal-infra-deployments/components/monitoring/blackbox-exporter/staging/private/stone-stage-p01?ref=05eb151e7800b6a3983a42b22311f8a5ff63ed1b
+  - https://github.com/redhat-appstudio/internal-infra-deployments/components/monitoring/blackbox-exporter/staging/private/stone-stage-p01?ref=3d10ce126660e7fbd80660908ebe50a0e595f29d
 
 namespace: appstudio-monitoring

--- a/components/monitoring/blackbox/staging/stone-stg-rh01/kustomization.yaml
+++ b/components/monitoring/blackbox/staging/stone-stg-rh01/kustomization.yaml
@@ -1,6 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - https://github.com/redhat-appstudio/internal-infra-deployments/components/monitoring/blackbox-exporter/staging/public/stone-stg-rh01?ref=05eb151e7800b6a3983a42b22311f8a5ff63ed1b
+  - https://github.com/redhat-appstudio/internal-infra-deployments/components/monitoring/blackbox-exporter/staging/public/stone-stg-rh01?ref=3d10ce126660e7fbd80660908ebe50a0e595f29d
 
 namespace: appstudio-monitoring


### PR DESCRIPTION
  Updates the `internal-infra-deployments` kustomization ref for both staging
  clusters to `3d10ce126660e7fbd80660908ebe50a0e595f29d`.

  Changes included in this ref:
  
  - Switch `nexus-repos-health-probe` from `POST /health-check` (wrong endpoint)
    to `GET /v1/repositories/{name}` with `http_2xx` module
  - Remove unused `http_2xx_post` module from base and private configmaps
  - Fix ExternalSecret path in `staging/private/base` so `stone-stage-p01`
    receives the `nexus-sa-credentials` Secret
