### PR TITLE
fix: strengthen Qodo ring-deployment false-positive suppression

### DIFF
--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -17,6 +17,12 @@ RING DEPLOYMENT PATTERN — Do NOT flag as a bug or incomplete change:
   each targeting different cluster directories under components/<name>/production/<cluster>/.
 - It is correct for a PR to only modify a subset of production cluster directories.
 - Do NOT suggest applying changes to additional clusters beyond those in the PR.
+- Do NOT flag "ring rollout" order, direction, or coverage as a bug.
+- Do NOT report that changes are missing from other ring directories.
+- The following titles are KNOWN FALSE POSITIVES — never report them:
+  "Ring rollout inverted", "Sync-rings reorders resources",
+  "Pipeline-service updates all rings", "only modifies a subset of clusters",
+  or any variation about incomplete ring coverage.
 
 PROMOTION ORDER:
 - Changes flow: development → staging → production.
@@ -32,5 +38,6 @@ security concerns, and reasonable resource/image specs.
 extra_instructions="""\
 Do not suggest applying production changes to additional cluster directories
 beyond those in the PR. This repo uses ring deployments — clusters are updated
-in separate PRs intentionally.
+in separate PRs intentionally. Do not suggest changes related to ring rollout
+order, coverage, or synchronization across rings.
 """


### PR DESCRIPTION
## Summary

- Adds explicit DO NOT flag instructions for ring rollout order, direction, and coverage
- Lists known false-positive finding titles by name so Qodo can pattern-match against them
- Adds ring-deployment suppression to `[pr_code_suggestions]` section as well

## Problem

Qodo AI reviews on infra-deployments PRs are generating false-positive bugs related to the ring deployment pattern (e.g. "Ring rollout inverted", "Sync-rings reorders resources", "Pipeline-service updates all rings"). The existing `.pr_agent.toml` instructions explain the pattern, but Qodo still flags these.

## Changes

Strengthened the `extra_instructions` in both `[pr_reviewer]` and `[pr_code_suggestions]` sections with:
- More explicit negative instructions ("Do NOT flag", "Do NOT report")
- Named examples of known false-positive titles
- Coverage of the code suggestions section (was missing ring-deployment guidance)

Co-Authored-By: Claude Opus 4.6 <eedri@redhat.com>