### PR TITLE
KONFLUX-14639 query pods OOMKills development changes

### DIFF
--- a/components/vector-kubearchive-log-collector/development/loki-helm-dev-values.yaml
+++ b/components/vector-kubearchive-log-collector/development/loki-helm-dev-values.yaml
@@ -118,6 +118,8 @@ loki:
     max_entries_limit_per_query: 100000
     increment_duplicate_timestamp: true
     allow_structured_metadata: true
+    max_query_length: 6h
+    query_timeout: 5m
     # Query timeout configuration to prevent context canceled errors
     max_query_length: 721h      # Maximum time range for queries (30 days)
     max_query_parallelism: 32  # Maximum number of parallel queries

--- a/components/vector-kubearchive-log-collector/development/loki-helm-dev-values.yaml
+++ b/components/vector-kubearchive-log-collector/development/loki-helm-dev-values.yaml
@@ -118,6 +118,8 @@ loki:
     max_entries_limit_per_query: 100000
     increment_duplicate_timestamp: true
     allow_structured_metadata: true
+    tsdb_max_query_parallelism: 16
+    split_queries_by_interval: 1h
   runtimeConfig:
     configs:
       kubearchive:

--- a/components/vector-kubearchive-log-collector/development/loki-helm-dev-values.yaml
+++ b/components/vector-kubearchive-log-collector/development/loki-helm-dev-values.yaml
@@ -120,6 +120,7 @@ loki:
     allow_structured_metadata: true
     tsdb_max_query_parallelism: 16
     split_queries_by_interval: 1h
+    query_timeout: 5m
   runtimeConfig:
     configs:
       kubearchive:
@@ -127,8 +128,6 @@ loki:
         log_push_request_streams: false
         log_stream_creation: false
         log_duplicate_stream_info: false
-        query_timeout: 5m
-
   ingester:
     autoforget_unhealthy: true
     chunk_encoding: snappy

--- a/components/vector-kubearchive-log-collector/development/loki-helm-dev-values.yaml
+++ b/components/vector-kubearchive-log-collector/development/loki-helm-dev-values.yaml
@@ -125,8 +125,6 @@ loki:
         log_push_request_streams: false
         log_stream_creation: false
         log_duplicate_stream_info: false
-        tsdb_max_query_parallelism: 16
-        split_queries_by_interval: 1h
         query_timeout: 5m
 
   ingester:

--- a/components/vector-kubearchive-log-collector/development/loki-helm-dev-values.yaml
+++ b/components/vector-kubearchive-log-collector/development/loki-helm-dev-values.yaml
@@ -118,12 +118,6 @@ loki:
     max_entries_limit_per_query: 100000
     increment_duplicate_timestamp: true
     allow_structured_metadata: true
-    max_query_length: 6h
-    query_timeout: 5m
-    # Query timeout configuration to prevent context canceled errors
-    max_query_length: 721h      # Maximum time range for queries (30 days)
-    max_query_parallelism: 32  # Maximum number of parallel queries
-    query_timeout: 10m         # Timeout for individual queries (10 minutes)
   runtimeConfig:
     configs:
       kubearchive:
@@ -131,6 +125,10 @@ loki:
         log_push_request_streams: false
         log_stream_creation: false
         log_duplicate_stream_info: false
+        tsdb_max_query_parallelism: 16
+        split_queries_by_interval: 1h
+        query_timeout: 5m
+
   ingester:
     autoforget_unhealthy: true
     chunk_encoding: snappy


### PR DESCRIPTION
## Summary
- Increases loki-querier and loki-query-frontend memory request/response to prevent OOM errors.
- introduces max query lenght and query timeout settings
[KONFLUX-14639](https://redhat.atlassian.net/browse/KONFLUX-14639)](https://redhat.atlassian.net/browse/KONFLUX-14639)


## Risk assessment
- Low. In bad case scenario logs won't be visible in Konflux UI for a limited amount of time, no data loss is expected.


[KONFLUX-14639]: https://redhat.atlassian.net/browse/KONFLUX-14639?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ