### PR TITLE
KONFLUX-14639 query pods OOMKills staging changes

### DIFF
--- a/components/vector-kubearchive-log-collector/staging/stone-stage-p01/loki-helm-stg-values.yaml
+++ b/components/vector-kubearchive-log-collector/staging/stone-stage-p01/loki-helm-stg-values.yaml
@@ -92,6 +92,8 @@ loki:
     max_entries_limit_per_query: 100000
     increment_duplicate_timestamp: true
     allow_structured_metadata: true
+    max_query_length: 6h
+    query_timeout: 5m
   runtimeConfig:
     configs:
       kubearchive:
@@ -188,9 +190,9 @@ queryFrontend:
   resources:
     requests:
       cpu: 200m
-      memory: 512Mi
+      memory: 2Gi
     limits:
-      memory: 1Gi
+      memory: 4Gi
 
 queryScheduler:
   replicas: 2

--- a/components/vector-kubearchive-log-collector/staging/stone-stg-rh01/loki-helm-stg-values.yaml
+++ b/components/vector-kubearchive-log-collector/staging/stone-stg-rh01/loki-helm-stg-values.yaml
@@ -92,6 +92,8 @@ loki:
     max_entries_limit_per_query: 100000
     increment_duplicate_timestamp: true
     allow_structured_metadata: true
+    max_query_length: 6h
+    query_timeout: 5m
   runtimeConfig:
     configs:
       kubearchive:
@@ -188,9 +190,9 @@ queryFrontend:
   resources:
     requests:
       cpu: 200m
-      memory: 512Mi
+      memory: 2Gi
     limits:
-      memory: 1Gi
+      memory: 4Gi
 
 queryScheduler:
   replicas: 2


### PR DESCRIPTION
Assisted-by: Claude

## Summary
- Increases loki-querier and loki-query-frontend memory request/response to prevent OOM errors.
- introduces max query lenght and query timeout settings
[KONFLUX-14639](https://redhat.atlassian.net/browse/KONFLUX-14639)](https://redhat.atlassian.net/browse/KONFLUX-14639)


## Risk assessment
- Low. In bad case scenario logs won't be visible in Konflux UI for a limited amount of time, no data loss is expected.


## Validation
Staging validated with the same configuration

[KONFLUX-14639]: https://redhat.atlassian.net/browse/KONFLUX-14639?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ