### PR TITLE
fix(PVO11Y-5298): Add annotation to disable autogen

### DIFF
--- a/components/policies/development/cost-management/OWNERS
+++ b/components/policies/development/cost-management/OWNERS
@@ -1,0 +1,12 @@
+# See the OWNERS docs: https://go.k8s.io/owners
+
+approvers:
+- mftb
+- raks-tt
+- pacho-rh
+- martysp21
+- TominoFTW
+- FaisalAl-Rayes
+- kubasikus
+- pumahaka
+- ci-operator

--- a/components/policies/development/cost-management/propagate-cost-management-labels/propagate-cost-management-labels.yaml
+++ b/components/policies/development/cost-management/propagate-cost-management-labels/propagate-cost-management-labels.yaml
@@ -4,6 +4,7 @@ kind: ClusterPolicy
 metadata:
   name: propagate-cost-management-labels
   annotations:
+    pod-policies.kyverno.io/autogen-controllers: none
     policies.kyverno.io/title: Propagate Cost-Center from Namespace
     policies.kyverno.io/category: Cost Management
     policies.kyverno.io/severity: low

--- a/components/policies/staging/base/cost-management/OWNERS
+++ b/components/policies/staging/base/cost-management/OWNERS
@@ -1,0 +1,12 @@
+# See the OWNERS docs: https://go.k8s.io/owners
+
+approvers:
+- mftb
+- raks-tt
+- pacho-rh
+- martysp21
+- TominoFTW
+- FaisalAl-Rayes
+- kubasikus
+- pumahaka
+- ci-operator


### PR DESCRIPTION
propagate-cost-management-labels ClusterPolicy generates noisy errors on Jobs and StatefulSets, so adding annotation to disable that should fix the issue


Assisted-by: Claude Code (claude-opus-4-6), Anthropic