### PR TITLE
SPRE-4610: bump internal-infra-deployments ref for final staging nexus fixes

### DIFF
--- a/components/monitoring/blackbox/staging/stone-stage-p01/kustomization.yaml
+++ b/components/monitoring/blackbox/staging/stone-stage-p01/kustomization.yaml
@@ -1,6 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - https://github.com/redhat-appstudio/internal-infra-deployments/components/monitoring/blackbox-exporter/staging/private/stone-stage-p01?ref=3d10ce126660e7fbd80660908ebe50a0e595f29d
+  - https://github.com/redhat-appstudio/internal-infra-deployments/components/monitoring/blackbox-exporter/staging/private/stone-stage-p01?ref=32a353b0b06a6cd97a4ac44cc406f17843c5b6ca
 
 namespace: appstudio-monitoring

--- a/components/monitoring/blackbox/staging/stone-stg-rh01/kustomization.yaml
+++ b/components/monitoring/blackbox/staging/stone-stg-rh01/kustomization.yaml
@@ -1,6 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - https://github.com/redhat-appstudio/internal-infra-deployments/components/monitoring/blackbox-exporter/staging/public/stone-stg-rh01?ref=3d10ce126660e7fbd80660908ebe50a0e595f29d
+  - https://github.com/redhat-appstudio/internal-infra-deployments/components/monitoring/blackbox-exporter/staging/public/stone-stg-rh01?ref=32a353b0b06a6cd97a4ac44cc406f17843c5b6ca
 
 namespace: appstudio-monitoring


### PR DESCRIPTION
[SPRE-4610](https://redhat.atlassian.net/browse/SPRE-4610): bump internal-infra-deployments ref for final staging nexus fixes

Update blackbox exporter ref for staging clusters to include:
- http_2xx_nexus module with credential files (volume mount from Secret)
- All three Nexus probes consolidated in shared staging base
- ExternalSecret duplicate fix for stone-stage-p01
- Secret volume marked optional to prevent pod startup blocking

[SPRE-4610]: https://redhat.atlassian.net/browse/SPRE-4610?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ