### PR TITLE
SPRE-4610: bump internal-infra-deployments ref for nexus repo target …

### DIFF
--- a/components/monitoring/blackbox/staging/stone-stage-p01/kustomization.yaml
+++ b/components/monitoring/blackbox/staging/stone-stage-p01/kustomization.yaml
@@ -1,6 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - https://github.com/redhat-appstudio/internal-infra-deployments/components/monitoring/blackbox-exporter/staging/private/stone-stage-p01?ref=32a353b0b06a6cd97a4ac44cc406f17843c5b6ca
+  - https://github.com/redhat-appstudio/internal-infra-deployments/components/monitoring/blackbox-exporter/staging/private/stone-stage-p01?ref=6a1460e226111283b77b279f2bb471e150aca222
 
 namespace: appstudio-monitoring

--- a/components/monitoring/blackbox/staging/stone-stg-rh01/kustomization.yaml
+++ b/components/monitoring/blackbox/staging/stone-stg-rh01/kustomization.yaml
@@ -1,6 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - https://github.com/redhat-appstudio/internal-infra-deployments/components/monitoring/blackbox-exporter/staging/public/stone-stg-rh01?ref=32a353b0b06a6cd97a4ac44cc406f17843c5b6ca
+  - https://github.com/redhat-appstudio/internal-infra-deployments/components/monitoring/blackbox-exporter/staging/public/stone-stg-rh01?ref=6a1460e226111283b77b279f2bb471e150aca222
 
 namespace: appstudio-monitoring


### PR DESCRIPTION
  Updates the `internal-infra-deployments` kustomization ref for both staging
  clusters to `6a1460e226111283b77b279f2bb471e150aca222`.

  Changes included in this ref:
  
  - `nexus-repos-health-probe` now sets the `target` label to the repository
    name (e.g. `maven-proxy`, `npm-proxy`) extracted from the instance URL
    via `metricRelabelings`. This allows each repository to be individually
    identifiable in the Grafana dashboard instead of all 14 showing as `health`.