### PR TITLE
Enable proxy for go and pnpm on all prod clusters

### DIFF
--- a/components/konflux-info/production/kflux-ocp-p01/cluster-config.env
+++ b/components/konflux-info/production/kflux-ocp-p01/cluster-config.env
@@ -3,5 +3,7 @@ http-proxy=squid.caching.svc.cluster.local:3128
 no-proxy=
 
 allow-package-registry-proxy=true
+package-registry-proxy-gomod-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/go-proxy
 package-registry-proxy-npm-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/npm-proxy
+package-registry-proxy-pnpm-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/npm-proxy
 package-registry-proxy-yarn-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/npm-proxy

--- a/components/konflux-info/production/kflux-osp-p01/cluster-config.env
+++ b/components/konflux-info/production/kflux-osp-p01/cluster-config.env
@@ -3,5 +3,7 @@ http-proxy=squid.caching.svc.cluster.local:3128
 no-proxy=
 
 allow-package-registry-proxy=true
+package-registry-proxy-gomod-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/go-proxy
 package-registry-proxy-npm-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/npm-proxy
+package-registry-proxy-pnpm-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/npm-proxy
 package-registry-proxy-yarn-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/npm-proxy

--- a/components/konflux-info/production/kflux-prd-rh02/cluster-config.env
+++ b/components/konflux-info/production/kflux-prd-rh02/cluster-config.env
@@ -3,5 +3,7 @@ http-proxy=squid.caching.svc.cluster.local:3128
 no-proxy=
 
 allow-package-registry-proxy=true
+package-registry-proxy-gomod-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/go-proxy
 package-registry-proxy-npm-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/npm-proxy
+package-registry-proxy-pnpm-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/npm-proxy
 package-registry-proxy-yarn-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/npm-proxy

--- a/components/konflux-info/production/kflux-prd-rh03/cluster-config.env
+++ b/components/konflux-info/production/kflux-prd-rh03/cluster-config.env
@@ -3,5 +3,7 @@ http-proxy=squid.caching.svc.cluster.local:3128
 no-proxy=
 
 allow-package-registry-proxy=true
+package-registry-proxy-gomod-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/go-proxy
 package-registry-proxy-npm-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/npm-proxy
+package-registry-proxy-pnpm-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/npm-proxy
 package-registry-proxy-yarn-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/npm-proxy

--- a/components/konflux-info/production/kflux-rhel-p01/cluster-config.env
+++ b/components/konflux-info/production/kflux-rhel-p01/cluster-config.env
@@ -3,5 +3,7 @@ http-proxy=squid.caching.svc.cluster.local:3128
 no-proxy=
 
 allow-package-registry-proxy=true
+package-registry-proxy-gomod-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/go-proxy
 package-registry-proxy-npm-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/npm-proxy
+package-registry-proxy-pnpm-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/npm-proxy
 package-registry-proxy-yarn-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/npm-proxy

--- a/components/konflux-info/production/stone-prd-rh01/cluster-config.env
+++ b/components/konflux-info/production/stone-prd-rh01/cluster-config.env
@@ -3,5 +3,7 @@ http-proxy=squid.caching.svc.cluster.local:3128
 no-proxy=
 
 allow-package-registry-proxy=true
+package-registry-proxy-gomod-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/go-proxy
 package-registry-proxy-npm-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/npm-proxy
+package-registry-proxy-pnpm-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/npm-proxy
 package-registry-proxy-yarn-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/npm-proxy

--- a/components/konflux-info/production/stone-prod-p01/cluster-config.env
+++ b/components/konflux-info/production/stone-prod-p01/cluster-config.env
@@ -3,5 +3,7 @@ http-proxy=squid.caching.svc.cluster.local:3128
 no-proxy=
 
 allow-package-registry-proxy=true
+package-registry-proxy-gomod-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/go-proxy
 package-registry-proxy-npm-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/npm-proxy
+package-registry-proxy-pnpm-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/npm-proxy
 package-registry-proxy-yarn-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/npm-proxy

--- a/components/konflux-info/production/stone-prod-p02/cluster-config.env
+++ b/components/konflux-info/production/stone-prod-p02/cluster-config.env
@@ -3,5 +3,7 @@ http-proxy=squid.caching.svc.cluster.local:3128
 no-proxy=
 
 allow-package-registry-proxy=true
+package-registry-proxy-gomod-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/go-proxy
 package-registry-proxy-npm-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/npm-proxy
+package-registry-proxy-pnpm-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/npm-proxy
 package-registry-proxy-yarn-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/npm-proxy


### PR DESCRIPTION
Enable use of the package registry proxy for Hermeto's go and pnpm backends on all prod clusters. This will allow Hermeto to route dependency prefetches through the package registry proxy for policy evaluation.

We found an issue impacting ~20% of pip users on the limited rollout listed in the Validation section, so we are deferring adding pip to the backends that are proxied until the corrected prefetch task has rolled-out to users. No issues were observed for the Go backend, so we will proceed with that alone for now.

## Risk Assessment
**Risk Level:** Medium
**Description:** Enables additional package ecosystems to be proxied through Nexus by Hermeto. The user impact is to build pipelines using Go. Pnpm is brand-new to Hermeto and is not currently used by product teams.
**Rollback:** Revert PR

## Validation
Staging PR: https://github.com/redhat-appstudio/infra-deployments/pull/12528

## Additional Validation
Limited prod deployment:
- https://github.com/redhat-appstudio/infra-deployments/pull/12757
- https://konflux-ui.apps.kflux-prd-rh02.0fk9.p1.openshiftapps.com/ns/lightspeed-core-tenant/applications/dataverse-exporter/taskruns/dataverse-exporter-on-pull-request-rxcsp-prefetch-dependencies/logs
- https://konflux-ui.apps.kflux-prd-rh02.0fk9.p1.openshiftapps.com/ns/dpu-kit-for-nvidia-operator-tenant/applications/dpf-hcp-provisioner-operator/taskruns/dpf-hcp-p3b75a8114f71d20fcea5b8ef2ac4281f-prefetch-dependencies/logs

Tested in stage:
- https://github.com/redhat-appstudio/infra-deployments/pull/12528
- https://konflux-ui.apps.stone-stg-rh01.l2vh.p1.openshiftapps.com/ns/tmadore-tenant/applications/hermeto-integration-tests/pipelineruns/gomod-e2e-proxy-on-push-hntrl
- https://konflux-ui.apps.stone-stg-rh01.l2vh.p1.openshiftapps.com/ns/tmadore-tenant/applications/hermeto-integration-tests/pipelineruns/pip-e2e-proxy-on-push-vjrjx


## Qodo Response
**Proxy URLs publicly readable** — False positive. The URLs are generic, public, and not a security concern
**cluster-config.env spans multiple rings** — Accepted risk. Gomod and pnpm were already successfully deployed in a previous ring deployment. The problematic one was pip, which was removed.