### PR TITLE
KFLUXVNGD-985 Update konflux-operator and enable kite/kubearchive proxy endpoints in dev

### DIFF
--- a/components/konflux-kite/development/kustomization.yaml
+++ b/components/konflux-kite/development/kustomization.yaml
@@ -21,7 +21,7 @@ configMapGenerator:
     literals:
       - KITE_PROJECT_ENV=development
       - KITE_HOST=0.0.0.0
-      - KITE_PORT=8080
+      - KITE_PORT=8443
       - KITE_DB_SSL_MODE=disable
       - KITE_LOG_LEVEL=debug
       - KITE_LOG_FORMAT=text
@@ -38,33 +38,3 @@ configMapGenerator:
       - AUTH_IMPERSONATE=true
     behavior: replace
 
-patches:
-  - patch: |-
-      - op: replace
-        path: /spec/template/spec/containers/0/startupProbe/httpGet/scheme
-        value: "HTTP"
-      - op: replace
-        path: /spec/template/spec/containers/0/livenessProbe/httpGet/scheme
-        value: "HTTP"
-      - op: replace
-        path: /spec/template/spec/containers/0/readinessProbe/httpGet/scheme
-        value: "HTTP"
-      - op: replace
-        path: /spec/template/spec/containers/0/ports/0/containerPort
-        value: 8080
-    target:
-      version: v1
-      kind: Deployment
-      name: konflux-kite
-
-  - patch: |-
-      - op: replace
-        path: /spec/ports/0/port
-        value: 80
-      - op: replace
-        path: /spec/ports/0/targetPort
-        value: 8080
-    target:
-      version: v1
-      kind: Service
-      name: konflux-kite

--- a/components/konflux-kite/development/kustomization.yaml
+++ b/components/konflux-kite/development/kustomization.yaml
@@ -19,7 +19,7 @@ configMapGenerator:
   - name: kite-config
     namespace: konflux-kite
     literals:
-      - KITE_PROJECT_ENV=development
+      - KITE_PROJECT_ENV=staging
       - KITE_HOST=0.0.0.0
       - KITE_PORT=8443
       - KITE_DB_SSL_MODE=disable
@@ -37,4 +37,3 @@ configMapGenerator:
       - KITE_SHUTDOWN_TIMEOUT=10s
       - AUTH_IMPERSONATE=true
     behavior: replace
-

--- a/components/konflux-operator/development/cr/overlay-patches/konflux-ui/ui.yaml
+++ b/components/konflux-operator/development/cr/overlay-patches/konflux-ui/ui.yaml
@@ -9,6 +9,11 @@ spec:
         nodePortService:
           httpsPort: 30011
       proxy:
+        endpoints:
+          kite:
+            enabled: true
+          kubearchive:
+            enabled: true
         replicas: 1
         reverseProxy:
           resources:

--- a/components/konflux-operator/development/invariant/kustomization.yaml
+++ b/components/konflux-operator/development/invariant/kustomization.yaml
@@ -6,7 +6,7 @@ kind: Kustomization
 # Parent `../kustomization.yaml` adds per-team overlays from `../cr/overlay-patches/`.
 resources:
   # Upstream operator config (konflux-ci builds install.yaml from this layout).
-  - https://github.com/konflux-ci/konflux-ci/operator/config/default?ref=cf830f1aa94a94dace759e073d9874e3363baa0f
+  - https://github.com/konflux-ci/konflux-ci/operator/config/default?ref=72d73f696e8847edfd53bbf9d302d6f2f703cfef
   - konflux.yaml
 
 patches:
@@ -15,4 +15,4 @@ patches:
 images:
   - name: localhost/konflux-operator
     newName: quay.io/konflux-ci/konflux-operator
-    newTag: cf830f1aa94a94dace759e073d9874e3363baa0f
+    newTag: 72d73f696e8847edfd53bbf9d302d6f2f703cfef


### PR DESCRIPTION
## What

- Update konflux-operator to `72d73f696e8847edfd53bbf9d302d6f2f703cfef` in development invariant overlay
- Enable `kite` and `kubearchive` proxy endpoints in the development UI config

Clusters affected: development

[KFLUXVNGD-985](https://redhat.atlassian.net/browse/KFLUXVNGD-985)

## Why

Bump the konflux-operator to the latest version and enable kite and kubearchive proxy endpoints in the development environment UI.

Made with [Cursor](https://cursor.com)

[KFLUXVNGD-985]: https://redhat.atlassian.net/browse/KFLUXVNGD-985?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ