### PR TITLE
KONFLUX-14429 Promote squid helm chart to production

### DIFF
--- a/components/squid/production/kflux-fedora-01/squid-helm-generator.yaml
+++ b/components/squid/production/kflux-fedora-01/squid-helm-generator.yaml
@@ -4,7 +4,7 @@ metadata:
   name: squid-helm
 name: squid-helm
 repo: oci://quay.io/konflux-ci/caching
-version: 0.1.1579+32fdfe0
+version: 0.1.1648+a6ad7bf
 valuesInline:
   installCertManagerComponents: false
   mirrord:

--- a/components/squid/production/kflux-ocp-p01/squid-helm-generator.yaml
+++ b/components/squid/production/kflux-ocp-p01/squid-helm-generator.yaml
@@ -4,7 +4,7 @@ metadata:
   name: squid-helm
 name: squid-helm
 repo: oci://quay.io/konflux-ci/caching
-version: 0.1.1579+32fdfe0
+version: 0.1.1648+a6ad7bf
 valuesInline:
   installCertManagerComponents: false
   mirrord:

--- a/components/squid/production/kflux-osp-p01/squid-helm-generator.yaml
+++ b/components/squid/production/kflux-osp-p01/squid-helm-generator.yaml
@@ -4,7 +4,7 @@ metadata:
   name: squid-helm
 name: squid-helm
 repo: oci://quay.io/konflux-ci/caching
-version: 0.1.1579+32fdfe0
+version: 0.1.1648+a6ad7bf
 valuesInline:
   installCertManagerComponents: false
   mirrord:

--- a/components/squid/production/kflux-prd-rh02/squid-helm-generator.yaml
+++ b/components/squid/production/kflux-prd-rh02/squid-helm-generator.yaml
@@ -4,7 +4,7 @@ metadata:
   name: squid-helm
 name: squid-helm
 repo: oci://quay.io/konflux-ci/caching
-version: 0.1.1579+32fdfe0
+version: 0.1.1648+a6ad7bf
 valuesInline:
   installCertManagerComponents: false
   mirrord:

--- a/components/squid/production/kflux-prd-rh03/squid-helm-generator.yaml
+++ b/components/squid/production/kflux-prd-rh03/squid-helm-generator.yaml
@@ -4,7 +4,7 @@ metadata:
   name: squid-helm
 name: squid-helm
 repo: oci://quay.io/konflux-ci/caching
-version: 0.1.1579+32fdfe0
+version: 0.1.1648+a6ad7bf
 valuesInline:
   installCertManagerComponents: false
   mirrord:

--- a/components/squid/production/kflux-rhel-p01/squid-helm-generator.yaml
+++ b/components/squid/production/kflux-rhel-p01/squid-helm-generator.yaml
@@ -4,7 +4,7 @@ metadata:
   name: squid-helm
 name: squid-helm
 repo: oci://quay.io/konflux-ci/caching
-version: 0.1.1579+32fdfe0
+version: 0.1.1648+a6ad7bf
 valuesInline:
   installCertManagerComponents: false
   mirrord:

--- a/components/squid/production/stone-prd-rh01/squid-helm-generator.yaml
+++ b/components/squid/production/stone-prd-rh01/squid-helm-generator.yaml
@@ -4,7 +4,7 @@ metadata:
   name: squid-helm
 name: squid-helm
 repo: oci://quay.io/konflux-ci/caching
-version: 0.1.1579+32fdfe0
+version: 0.1.1648+a6ad7bf
 valuesInline:
   installCertManagerComponents: false
   mirrord:

--- a/components/squid/production/stone-prod-p01/squid-helm-generator.yaml
+++ b/components/squid/production/stone-prod-p01/squid-helm-generator.yaml
@@ -4,7 +4,7 @@ metadata:
   name: squid-helm
 name: squid-helm
 repo: oci://quay.io/konflux-ci/caching
-version: 0.1.1579+32fdfe0
+version: 0.1.1648+a6ad7bf
 valuesInline:
   installCertManagerComponents: false
   mirrord:

--- a/components/squid/production/stone-prod-p02/squid-helm-generator.yaml
+++ b/components/squid/production/stone-prod-p02/squid-helm-generator.yaml
@@ -4,7 +4,7 @@ metadata:
   name: squid-helm
 name: squid-helm
 repo: oci://quay.io/konflux-ci/caching
-version: 0.1.1579+32fdfe0
+version: 0.1.1648+a6ad7bf
 valuesInline:
   installCertManagerComponents: false
   mirrord:


### PR DESCRIPTION
  ## What

  Upgrade squid helm chart from 0.1.1579+32fdfe0 to 0.1.1648+a6ad7bf on all production clusters to mitigate CVE-2026-39821.

  Clusters affected:
  - kflux-fedora-01
  - kflux-ocp-p01
  - kflux-osp-p01
  - kflux-prd-rh02
  - kflux-prd-rh03
  - kflux-rhel-p01
  - stone-prod-p01
  - stone-prod-p02
  - stone-prd-rh01

  [KONFLUX-14429](https://issues.redhat.com/browse/KONFLUX-14429)

  ## Why

  Mitigate CVE-2026-39821. The fix is included in chart version 0.1.1648+a6ad7bf via [konflux-ci/caching#895](https://github.com/konflux-ci/caching/pull/895).

  ## Validation

  - [CI status for a6ad7bf](https://github.com/konflux-ci/caching/commit/a6ad7bf) — all checks passed (builds, lints, e2e, enterprise-contract)
  - Staged in [#12473](https://github.com/redhat-appstudio/infra-deployments/pull/12473) on 2026-06-26

  ## Risk Assessment

  **Risk Level:** Low
  **What could go wrong:** Container image update could introduce a regression in squid or nginx proxy behavior.
  **Rollback:** Revert this PR to return all clusters to 0.1.1579+32fdfe0.

[KONFLUX-14429]: https://redhat.atlassian.net/browse/KONFLUX-14429?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ