### PR TITLE
add konflux-tester-internalbot-actions in stg

### DIFF
--- a/components/konflux-rbac/staging/base/konflux-tester-internalbot-actions.yaml
+++ b/components/konflux-rbac/staging/base/konflux-tester-internalbot-actions.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: konflux-tester-bot-actions
+  name: konflux-tester-internalbot-actions
 rules:
 - apiGroups:
   - appstudio.redhat.com

--- a/components/konflux-rbac/staging/base/kustomization.yaml
+++ b/components/konflux-rbac/staging/base/kustomization.yaml
@@ -6,6 +6,9 @@ resources:
   - konflux-maintainer-user-actions.yaml
   - konflux-contributor-user-actions.yaml
   - konflux-viewer-user-actions.yaml
+  # can be bound to konflux-bot-* ServiceAccounts
+  # and exposed outside the cluster
   - konflux-builder-bot-actions.yaml
   - konflux-releaser-bot-actions.yaml
-  - konflux-tester-bot-actions.yaml
+  # can NOT be bound to konflux-bot-* ServiceAccounts
+  - konflux-tester-internalbot-actions.yaml


### PR DESCRIPTION
To harden security we agreed not to allow to provide these permissions to ServiceAccounts for which Konflux Tenants can mint tokens.

Signed-off-by: Francesco Ilario <filario@redhat.com>
