### PR TITLE
Revert "Enable proxy for go, pip, pnpm on select prod clusters (#12757)"

### DIFF
--- a/components/konflux-info/production/kflux-prd-rh02/cluster-config.env
+++ b/components/konflux-info/production/kflux-prd-rh02/cluster-config.env
@@ -3,8 +3,5 @@ http-proxy=squid.caching.svc.cluster.local:3128
 no-proxy=
 
 allow-package-registry-proxy=true
-package-registry-proxy-gomod-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/go-proxy
 package-registry-proxy-npm-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/npm-proxy
-package-registry-proxy-pip-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/pypi-proxy/simple
-package-registry-proxy-pnpm-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/npm-proxy
 package-registry-proxy-yarn-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/npm-proxy

--- a/components/konflux-info/production/stone-prod-p01/cluster-config.env
+++ b/components/konflux-info/production/stone-prod-p01/cluster-config.env
@@ -3,8 +3,5 @@ http-proxy=squid.caching.svc.cluster.local:3128
 no-proxy=
 
 allow-package-registry-proxy=true
-package-registry-proxy-gomod-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/go-proxy
 package-registry-proxy-npm-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/npm-proxy
-package-registry-proxy-pip-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/pypi-proxy/simple
-package-registry-proxy-pnpm-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/npm-proxy
 package-registry-proxy-yarn-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/npm-proxy


### PR DESCRIPTION
This reverts commit 64305e755dc29b2f662bde30d21fc63dd349b912.

It was found out that the change has disproportionally affected builds which rely on custom indices, reverting until custom indices are handled correctly.