### PR TITLE
 KFLUXINFRA-4007: Rename authentication-rd components

### DIFF
--- a/argo-cd-apps/base/all-clusters/infra-deployments/authentication/authentication.yaml
+++ b/argo-cd-apps/base/all-clusters/infra-deployments/authentication/authentication.yaml
@@ -36,9 +36,9 @@ spec:
         namespace: authentication
         server: '{{server}}'
       syncPolicy:
-        automated:
-          prune: true
-          selfHeal: true
+        # automated:
+        #   prune: true
+        #   selfHeal: true
         syncOptions:
         - CreateNamespace=true
         retry:

--- a/argo-cd-apps/base/ring-deployments/authentication-rd/authentication-rd.yaml
+++ b/argo-cd-apps/base/ring-deployments/authentication-rd/authentication-rd.yaml
@@ -27,9 +27,9 @@ spec:
         namespace: authentication-rd
         server: '{{server}}'
       syncPolicy:
-        automated:
-          prune: true
-          selfHeal: true
+        # automated:
+        #   prune: true
+        #   selfHeal: true
         syncOptions:
         - CreateNamespace=true
         retry:

--- a/components/authentication-rd/base/admin-checker/kustomization.yaml
+++ b/components/authentication-rd/base/admin-checker/kustomization.yaml
@@ -1,6 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: admin-checker-rd
+namespace: admin-checker
 resources:
   - cronjob.yaml
   - namespace.yaml

--- a/components/authentication-rd/base/admin-checker/namespace.yaml
+++ b/components/authentication-rd/base/admin-checker/namespace.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: admin-checker-rd
+  name: admin-checker

--- a/components/authentication-rd/base/admin-checker/rbac/admin-checker-sa.yaml
+++ b/components/authentication-rd/base/admin-checker/rbac/admin-checker-sa.yaml
@@ -7,7 +7,7 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: groups-reader-rd
+  name: groups-reader
 rules:
 - apiGroups:
     - "user.openshift.io"
@@ -21,12 +21,12 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: admin-checker-group-reader-rd
+  name: admin-checker-group-reader
 subjects:
 - kind: ServiceAccount
   name: admin-checker-sa
-  namespace: admin-checker-rd
+  namespace: admin-checker
 roleRef:
   kind: ClusterRole
-  name: groups-reader-rd
+  name: groups-reader
   apiGroup: rbac.authorization.k8s.io

--- a/components/authentication-rd/base/rbac/component-maintainer-cr.yaml
+++ b/components/authentication-rd/base/rbac/component-maintainer-cr.yaml
@@ -1,7 +1,7 @@
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: component-maintainer-rd
+  name: component-maintainer
 rules:
   - apiGroups:
       - operators.coreos.com

--- a/components/authentication-rd/base/rbac/everyone-can-view-crs.yaml
+++ b/components/authentication-rd/base/rbac/everyone-can-view-crs.yaml
@@ -1,7 +1,7 @@
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: view-appstudio-rd
+  name: view-appstudio
 rules:
 - apiGroups:
   - kubearchive.org
@@ -100,7 +100,7 @@ rules:
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: view-cluster-version-rd
+  name: view-cluster-version
 rules:
 - apiGroups:
   - config.openshift.io
@@ -114,7 +114,7 @@ rules:
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: view-compute-rd
+  name: view-compute
 rules:
 - apiGroups:
   - ''
@@ -155,7 +155,7 @@ rules:
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: everyone-view-rd
+  name: everyone-view
 subjects: [] # added by patch to avoid duplicating the groups
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -165,27 +165,27 @@ roleRef:
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: everyone-view-appstudio-rd
+  name: everyone-view-appstudio
 subjects: [] # added by patch to avoid duplicating the groups
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: view-appstudio-rd
+  name: view-appstudio
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: everyone-view-cluster-version-rd
+  name: everyone-view-cluster-version
 subjects: [] # added by patch to avoid duplicating the groups
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: view-cluster-version-rd
+  name: view-cluster-version
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: everyone-view-cluster-monitoring-rd
+  name: everyone-view-cluster-monitoring
 subjects: [] # added by patch to avoid duplicating the groups
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -195,9 +195,9 @@ roleRef:
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: everyone-view-compute-rd
+  name: everyone-view-compute
 subjects: [] # added by patch to avoid duplicating the groups
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: view-compute-rd
+  name: view-compute

--- a/components/authentication-rd/base/rbac/grafana-view-only-cr.yaml
+++ b/components/authentication-rd/base/rbac/grafana-view-only-cr.yaml
@@ -1,7 +1,7 @@
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: grafana-view-only-rd
+  name: grafana-view-only
 rules:
 - apiGroups: [""]
   resources: ["namespaces"]
@@ -19,5 +19,5 @@ subjects:
   apiGroup: rbac.authorization.k8s.io
 roleRef:
   kind: ClusterRole
-  name: grafana-view-only-rd
+  name: grafana-view-only
   apiGroup: rbac.authorization.k8s.io

--- a/components/authentication-rd/base/rbac/konflux-admins-cr.yaml
+++ b/components/authentication-rd/base/rbac/konflux-admins-cr.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: konflux-admins-rd
+  name: konflux-admins
   annotations:
     description: "Konflux admin role with cluster-admin permissions except secrets and internalrequests access"
 rules:
@@ -278,11 +278,11 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: konflux-admins-rd
+  name: konflux-admins
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: konflux-admins-rd
+  name: konflux-admins
 subjects:
   - apiGroup: rbac.authorization.k8s.io
     kind: Group

--- a/components/authentication-rd/base/rbac/konflux-admins-pod-admin-cr.yaml
+++ b/components/authentication-rd/base/rbac/konflux-admins-pod-admin-cr.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: konflux-admins-pod-admin-rd
+  name: konflux-admins-pod-admin
   annotations:
     description: "Additional permissions for konflux-admins to manage pods in specific namespaces"
 rules:
@@ -39,7 +39,7 @@ subjects:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: konflux-admins-pod-admin-rd
+  name: konflux-admins-pod-admin
 ---
 # RoleBinding for pod admin in openshift-etcd namespace
 apiVersion: rbac.authorization.k8s.io/v1
@@ -54,4 +54,4 @@ subjects:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: konflux-admins-pod-admin-rd
+  name: konflux-admins-pod-admin

--- a/components/authentication-rd/base/rbac/konflux-sre-cr.yaml
+++ b/components/authentication-rd/base/rbac/konflux-sre-cr.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: konflux-sre-rd
+  name: konflux-sre
 rules:
   # Grant READ-ONLY access (plus delete) to pod-related resources
   # Creating/exec'ing pods can be used to access secrets, so create/update/patch are blocked
@@ -32,11 +32,11 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: konflux-sre-rd
+  name: konflux-sre
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: konflux-sre-rd
+  name: konflux-sre
 subjects:
   - apiGroup: rbac.authorization.k8s.io
     kind: Group

--- a/components/authentication-rd/base/rbac/kustomization.yaml
+++ b/components/authentication-rd/base/rbac/kustomization.yaml
@@ -12,31 +12,31 @@ resources:
 patches:
   - path: patches/everyone-can-view-patch.yaml
     target:
-      name: everyone-view-rd
+      name: everyone-view
       kind: ClusterRoleBinding
       group: rbac.authorization.k8s.io
       version: v1
   - path: patches/everyone-can-view-patch.yaml
     target:
-      name: everyone-view-appstudio-rd
+      name: everyone-view-appstudio
       kind: ClusterRoleBinding
       group: rbac.authorization.k8s.io
       version: v1
   - path: patches/everyone-can-view-patch.yaml
     target:
-      name: everyone-view-cluster-version-rd
+      name: everyone-view-cluster-version
       kind: ClusterRoleBinding
       group: rbac.authorization.k8s.io
       version: v1
   - path: patches/everyone-can-view-patch.yaml
     target:
-      name: everyone-view-cluster-monitoring-rd
+      name: everyone-view-cluster-monitoring
       kind: ClusterRoleBinding
       group: rbac.authorization.k8s.io
       version: v1
   - path: patches/everyone-can-view-patch.yaml
     target:
-      name: everyone-view-compute-rd
+      name: everyone-view-compute
       kind: ClusterRoleBinding
       group: rbac.authorization.k8s.io
       version: v1

--- a/components/authentication-rd/base/rbac/view-testplatformclusters-cr.yaml
+++ b/components/authentication-rd/base/rbac/view-testplatformclusters-cr.yaml
@@ -1,7 +1,7 @@
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: view-testplatformclusters-rd
+  name: view-testplatformclusters
 rules:
 - apiGroups:
   - ci.openshift.org
@@ -24,7 +24,7 @@ rules:
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: test-platform-ci-admins-view-rd
+  name: test-platform-ci-admins-view
 subjects:
 - kind: Group
   apiGroup: rbac.authorization.k8s.io
@@ -32,4 +32,4 @@ subjects:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: view-testplatformclusters-rd
+  name: view-testplatformclusters


### PR DESCRIPTION
Remove '-rd' suffix from authentication-rd component names to keep the same resources as authentication.