### PR TITLE
KONFLUX-14639 querier pods OOMKilled staging fix

### DIFF
--- a/components/vector-kubearchive-log-collector/staging/stone-stage-p01/loki-helm-stg-values.yaml
+++ b/components/vector-kubearchive-log-collector/staging/stone-stage-p01/loki-helm-stg-values.yaml
@@ -92,6 +92,8 @@ loki:
     max_entries_limit_per_query: 100000
     increment_duplicate_timestamp: true
     allow_structured_metadata: true
+    max_query_length: 6h
+    query_timeout: 5m
   runtimeConfig:
     configs:
       kubearchive:
@@ -188,9 +190,9 @@ queryFrontend:
   resources:
     requests:
       cpu: 200m
-      memory: 512Mi
+      memory: 2Gi
     limits:
-      memory: 1Gi
+      memory: 4Gi
 
 queryScheduler:
   replicas: 2

--- a/components/vector-kubearchive-log-collector/staging/stone-stage-p01/loki-helm-stg-values.yaml
+++ b/components/vector-kubearchive-log-collector/staging/stone-stage-p01/loki-helm-stg-values.yaml
@@ -92,8 +92,6 @@ loki:
     max_entries_limit_per_query: 100000
     increment_duplicate_timestamp: true
     allow_structured_metadata: true
-    max_query_length: 6h
-    query_timeout: 5m
   runtimeConfig:
     configs:
       kubearchive:
@@ -101,6 +99,10 @@ loki:
         log_push_request_streams: true
         log_stream_creation: true
         log_duplicate_stream_info: true
+        tsdb_max_query_parallelism: 16
+        split_queries_by_interval: 1h
+        query_timeout: 5m
+
   ingester:
     autoforget_unhealthy: true
     chunk_target_size: 8388608        # 8MB

--- a/components/vector-kubearchive-log-collector/staging/stone-stage-p01/loki-helm-stg-values.yaml
+++ b/components/vector-kubearchive-log-collector/staging/stone-stage-p01/loki-helm-stg-values.yaml
@@ -102,9 +102,6 @@ loki:
         log_push_request_streams: true
         log_stream_creation: true
         log_duplicate_stream_info: true
-        tsdb_max_query_parallelism: 16
-        split_queries_by_interval: 1h
-        query_timeout: 5m
   ingester:
     autoforget_unhealthy: true
     chunk_target_size: 8388608        # 8MB

--- a/components/vector-kubearchive-log-collector/staging/stone-stage-p01/loki-helm-stg-values.yaml
+++ b/components/vector-kubearchive-log-collector/staging/stone-stage-p01/loki-helm-stg-values.yaml
@@ -92,6 +92,9 @@ loki:
     max_entries_limit_per_query: 100000
     increment_duplicate_timestamp: true
     allow_structured_metadata: true
+    tsdb_max_query_parallelism: 16
+    split_queries_by_interval: 1h
+    query_timeout: 5m
   runtimeConfig:
     configs:
       kubearchive:
@@ -99,9 +102,6 @@ loki:
         log_push_request_streams: true
         log_stream_creation: true
         log_duplicate_stream_info: true
-        tsdb_max_query_parallelism: 16
-        split_queries_by_interval: 1h
-        query_timeout: 5m
   ingester:
     autoforget_unhealthy: true
     chunk_target_size: 8388608        # 8MB

--- a/components/vector-kubearchive-log-collector/staging/stone-stage-p01/loki-helm-stg-values.yaml
+++ b/components/vector-kubearchive-log-collector/staging/stone-stage-p01/loki-helm-stg-values.yaml
@@ -102,7 +102,6 @@ loki:
         tsdb_max_query_parallelism: 16
         split_queries_by_interval: 1h
         query_timeout: 5m
-
   ingester:
     autoforget_unhealthy: true
     chunk_target_size: 8388608        # 8MB

--- a/components/vector-kubearchive-log-collector/staging/stone-stg-rh01/loki-helm-stg-values.yaml
+++ b/components/vector-kubearchive-log-collector/staging/stone-stg-rh01/loki-helm-stg-values.yaml
@@ -92,6 +92,8 @@ loki:
     max_entries_limit_per_query: 100000
     increment_duplicate_timestamp: true
     allow_structured_metadata: true
+    max_query_length: 6h
+    query_timeout: 5m
   runtimeConfig:
     configs:
       kubearchive:
@@ -188,9 +190,9 @@ queryFrontend:
   resources:
     requests:
       cpu: 200m
-      memory: 512Mi
+      memory: 2Gi
     limits:
-      memory: 1Gi
+      memory: 4Gi
 
 queryScheduler:
   replicas: 2

--- a/components/vector-kubearchive-log-collector/staging/stone-stg-rh01/loki-helm-stg-values.yaml
+++ b/components/vector-kubearchive-log-collector/staging/stone-stg-rh01/loki-helm-stg-values.yaml
@@ -92,8 +92,6 @@ loki:
     max_entries_limit_per_query: 100000
     increment_duplicate_timestamp: true
     allow_structured_metadata: true
-    max_query_length: 6h
-    query_timeout: 5m
   runtimeConfig:
     configs:
       kubearchive:
@@ -101,6 +99,11 @@ loki:
         log_push_request_streams: true
         log_stream_creation: true
         log_duplicate_stream_info: true
+        tsdb_max_query_parallelism: 16
+        split_queries_by_interval: 1h
+        query_timeout: 5m   
+
+        
   ingester:
     autoforget_unhealthy: true
     chunk_target_size: 8388608        # 8MB

--- a/components/vector-kubearchive-log-collector/staging/stone-stg-rh01/loki-helm-stg-values.yaml
+++ b/components/vector-kubearchive-log-collector/staging/stone-stg-rh01/loki-helm-stg-values.yaml
@@ -102,9 +102,6 @@ loki:
         log_push_request_streams: true
         log_stream_creation: true
         log_duplicate_stream_info: true
-        tsdb_max_query_parallelism: 16
-        split_queries_by_interval: 1h
-        query_timeout: 5m
   ingester:
     autoforget_unhealthy: true
     chunk_target_size: 8388608        # 8MB

--- a/components/vector-kubearchive-log-collector/staging/stone-stg-rh01/loki-helm-stg-values.yaml
+++ b/components/vector-kubearchive-log-collector/staging/stone-stg-rh01/loki-helm-stg-values.yaml
@@ -92,6 +92,9 @@ loki:
     max_entries_limit_per_query: 100000
     increment_duplicate_timestamp: true
     allow_structured_metadata: true
+    tsdb_max_query_parallelism: 16
+    split_queries_by_interval: 1h
+    query_timeout: 5m
   runtimeConfig:
     configs:
       kubearchive:
@@ -99,9 +102,6 @@ loki:
         log_push_request_streams: true
         log_stream_creation: true
         log_duplicate_stream_info: true
-        tsdb_max_query_parallelism: 16
-        split_queries_by_interval: 1h
-        query_timeout: 5m
   ingester:
     autoforget_unhealthy: true
     chunk_target_size: 8388608        # 8MB

--- a/components/vector-kubearchive-log-collector/staging/stone-stg-rh01/loki-helm-stg-values.yaml
+++ b/components/vector-kubearchive-log-collector/staging/stone-stg-rh01/loki-helm-stg-values.yaml
@@ -101,9 +101,7 @@ loki:
         log_duplicate_stream_info: true
         tsdb_max_query_parallelism: 16
         split_queries_by_interval: 1h
-        query_timeout: 5m   
-
-        
+        query_timeout: 5m
   ingester:
     autoforget_unhealthy: true
     chunk_target_size: 8388608        # 8MB


### PR DESCRIPTION
## Summary
- Increases loki-querier and loki-query-frontend memory request/response to prevent OOM errors.
- introduces max query lenght and query timeout settings
[KONFLUX-14639](https://redhat.atlassian.net/browse/KONFLUX-14639)](https://redhat.atlassian.net/browse/KONFLUX-14639)


## Risk assessment
- Medium. Some resources logs can be lost.


[KONFLUX-14639]: https://redhat.atlassian.net/browse/KONFLUX-14639?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ