### PR TITLE
feat(PVO11Y-5321): Forward KAExporter labels stage

### DIFF
--- a/components/monitoring/prometheus/staging/base/federation/writeRelabelConfigs.yaml
+++ b/components/monitoring/prometheus/staging/base/federation/writeRelabelConfigs.yaml
@@ -41,4 +41,4 @@
       hostname|label_app_kubernetes_io_managed_by|platform|scrape_job|slice|error|\
       resource_type|gin_errors|\
       metric|label|label_pair|scraped_instance|sharded_instance|instance_namespace|\
-      application|component|build_type|event_type|reason|scenario|optional|test_type|automated"
+      application|component|build_type|scenario|optional|test_type|automated"

--- a/components/monitoring/prometheus/staging/base/federation/writeRelabelConfigs.yaml
+++ b/components/monitoring/prometheus/staging/base/federation/writeRelabelConfigs.yaml
@@ -23,6 +23,7 @@
     # Monitoring infra (RHTAPWATCH-110, PVO11Y-4774)
     # KubeArchive
     # Cardinality exporter (PVO11Y-5128)
+    # KAExporter (PVO11Y-5274)
     regex: "__name__|source_environment|source_cluster|namespace|job|instance|pod|container|app|service|deployment|node|\
       phase|reason|type|resource|kind|name|role|status|state|resourcequota|image|finalizers|verb|request_kind|\
       persistentvolumeclaim|storageclass|volumename|\
@@ -39,4 +40,5 @@
       health_status|dest_namespace|\
       hostname|label_app_kubernetes_io_managed_by|platform|scrape_job|slice|error|\
       resource_type|gin_errors|\
-      metric|label|label_pair|scraped_instance|sharded_instance|instance_namespace"
+      metric|label|label_pair|scraped_instance|sharded_instance|instance_namespace|\
+      application|component|build_type|event_type|reason|scenario|optional|test_type|automated"


### PR DESCRIPTION
Enable forwarding of labels used in KAExporter to RHOBS. These labels are necessary to get an accurate tenant-level metrics.