### PR TITLE
feat: Also enable ExternalSecrets in managed-konflux-perfscale-tenant NS in prod

### DIFF
--- a/components/cluster-secret-store/production/perfscale-namespaces-patch.yaml
+++ b/components/cluster-secret-store/production/perfscale-namespaces-patch.yaml
@@ -11,3 +11,6 @@
 - op: add
   path: /spec/conditions/0/namespaces/-
   value: konflux-perfscale-4-tenant
+- op: add
+  path: /spec/conditions/0/namespaces/-
+  value: managed-konflux-perfscale-tenant


### PR DESCRIPTION
We are migrating to run release pipeline runs in separate managed NS and we want to use ExternalSecrets to manage Quay push secret.

## Risk Assessment
**Risk Level:** Low
**Description:** Enables ExternalSecrets operator for another NS — no user-facing changes
**Rollback:** Revert the PR

## Validation
Tested on staging — no regressions observed.
Staging PR: https://github.com/redhat-appstudio/infra-deployments/pull/12652