### PR TITLE
PVO11Y-5342 Clean up kanary staging params and add pre-cleanup step

### DIFF
--- a/components/monitoring/kanary/staging/base/pipelines/kanary-otel-pipeline.yaml
+++ b/components/monitoring/kanary/staging/base/pipelines/kanary-otel-pipeline.yaml
@@ -9,19 +9,15 @@ spec:
       default: http://open-telemetry-opentelemetry-collector.konflux-otel.svc.cluster.local:4318
     - name: tested-cluster
       type: string
-      default: stone-stage-p01
     - name: test-type
       type: string
       default: container-single-arch
     - name: component-repo
       type: string
-      default: "https://gitlab.cee.redhat.com/jhutar/nodejs-devfile-sample4"
     - name: user-prefix
       type: string
-      default: "stagep01cs"
     - name: quay-repo
       type: string
-      default: "redhat-user-workloads-stage"
     - name: pipeline-repo-templating-source
       type: string
       default: "https://github.com/rhtap-perf-test/konflux-probe-test-templates"
@@ -37,10 +33,10 @@ spec:
     # Private clusters only (GitLab-based repos). Leave empty for public clusters.
     - name: fork-target
       type: string
-      default: "jhutar"
+      default: ""
     - name: gitlab-api-url
       type: string
-      default: "https://gitlab.cee.redhat.com/api/v4"
+      default: ""
     - name: member-cluster
       type: string
     - name: tenant-namespace

--- a/components/monitoring/kanary/staging/base/tasks/run-kanary-tests.yaml
+++ b/components/monitoring/kanary/staging/base/tasks/run-kanary-tests.yaml
@@ -6,19 +6,15 @@ spec:
   params:
     - name: tested-cluster
       type: string
-      default: stone-stage-p01
     - name: test-type
       type: string
       default: container-single-arch
     - name: component-repo
       type: string
-      default: "https://gitlab.cee.redhat.com/jhutar/nodejs-devfile-sample4"
     - name: user-prefix
       type: string
-      default: "stagep01cs"
     - name: quay-repo
       type: string
-      default: "redhat-user-workloads-stage"
     - name: pipeline-repo-templating-source
       type: string
       default: "https://github.com/rhtap-perf-test/konflux-probe-test-templates"
@@ -34,13 +30,12 @@ spec:
     # Private clusters only (GitLab-based repos). Leave empty for public clusters.
     - name: fork-target
       type: string
-      default: "jhutar"
+      default: ""
     - name: gitlab-api-url
       type: string
-      default: "https://gitlab.cee.redhat.com/api/v4"
+      default: ""
     - name: member-cluster
       type: string
-      default: "https://api.stone-stage-p01.hpmt.p1.openshiftapps.com:6443"
     - name: tenant-namespace
       type: string
       default: "konflux-perfscale-4-tenant"
@@ -67,6 +62,40 @@ spec:
           - key: token
             path: token
   steps:
+    - name: pre-cleanup
+      image: quay.io/redhat-user-workloads/konflux-perfscale-tenant/loadtest
+      volumeMounts:
+        - name: users-secret
+          mountPath: /opt/users-secret
+          readOnly: true
+      env:
+        - name: SERVER_API_URL
+          value: $(params.member-cluster)
+        - name: TENANT_NAMESPACE
+          value: $(params.tenant-namespace)
+        - name: RELEASE_MANAGED_NAMESPACE
+          value: $(params.release-managed-namespace)
+        - name: RELEASE_MANAGED_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: kanary-probe-prometheus-credentials
+              key: managed_sa_token
+      script: |
+        #!/usr/bin/env bash
+        set -uo pipefail
+        MAX_AGE=43200
+        echo "Pre-cleanup: removing orphaned resources older than $((MAX_AGE / 3600))h"
+        oc login --token="$(cat /opt/users-secret/token)" --server="$SERVER_API_URL" --insecure-skip-tls-verify 2>/dev/null
+        for resource in ReleasePlan IntegrationTestScenario Application; do
+          oc -n "$TENANT_NAMESPACE" get "$resource" -o json 2>/dev/null \
+            | jq -r --argjson max "$MAX_AGE" '.items[] | select((now - (.metadata.creationTimestamp | fromdateiso8601)) > $max) | .metadata.name' \
+            | xargs -r oc -n "$TENANT_NAMESPACE" delete "$resource" --wait=false 2>/dev/null || true
+        done
+        oc login --token="$RELEASE_MANAGED_TOKEN" --server="$SERVER_API_URL" --insecure-skip-tls-verify 2>/dev/null
+        oc -n "$RELEASE_MANAGED_NAMESPACE" get ReleasePlanAdmission -o json \
+          | jq -r --arg ns "$TENANT_NAMESPACE" --argjson max "$MAX_AGE" '.items[] | select(.spec.origin == $ns) | select((now - (.metadata.creationTimestamp | fromdateiso8601)) > $max) | .metadata.name' \
+          | xargs -r oc -n "$RELEASE_MANAGED_NAMESPACE" delete ReleasePlanAdmission --wait=false 2>/dev/null || true
+        echo "Pre-cleanup done"
     - name: run-test
       image: quay.io/redhat-user-workloads/konflux-perfscale-tenant/loadtest
       volumeMounts:

--- a/components/monitoring/kanary/staging/base/tasks/run-kanary-tests.yaml
+++ b/components/monitoring/kanary/staging/base/tasks/run-kanary-tests.yaml
@@ -82,19 +82,35 @@ spec:
               key: managed_sa_token
       script: |
         #!/usr/bin/env bash
-        set -uo pipefail
-        MAX_AGE=43200
-        echo "Pre-cleanup: removing orphaned resources older than $((MAX_AGE / 3600))h"
-        oc login --token="$(cat /opt/users-secret/token)" --server="$SERVER_API_URL" --insecure-skip-tls-verify 2>/dev/null
-        for resource in ReleasePlan IntegrationTestScenario Application; do
-          oc -n "$TENANT_NAMESPACE" get "$resource" -o json 2>/dev/null \
-            | jq -r --argjson max "$MAX_AGE" '.items[] | select((now - (.metadata.creationTimestamp | fromdateiso8601)) > $max) | .metadata.name' \
-            | xargs -r oc -n "$TENANT_NAMESPACE" delete "$resource" --wait=false 2>/dev/null || true
-        done
-        oc login --token="$RELEASE_MANAGED_TOKEN" --server="$SERVER_API_URL" --insecure-skip-tls-verify 2>/dev/null
-        oc -n "$RELEASE_MANAGED_NAMESPACE" get ReleasePlanAdmission -o json \
-          | jq -r --arg ns "$TENANT_NAMESPACE" --argjson max "$MAX_AGE" '.items[] | select(.spec.origin == $ns) | select((now - (.metadata.creationTimestamp | fromdateiso8601)) > $max) | .metadata.name' \
-          | xargs -r oc -n "$RELEASE_MANAGED_NAMESPACE" delete ReleasePlanAdmission --wait=false 2>/dev/null || true
+        set -u
+        MAX_AGE_SECONDS=43200
+        echo "Pre-cleanup: removing orphaned resources older than $((MAX_AGE_SECONDS / 3600))h"
+        if ! oc login --token="$(cat /opt/users-secret/token)" --server="$SERVER_API_URL" --insecure-skip-tls-verify; then
+          echo "WARNING: failed to login as tenant SA, skipping tenant cleanup"
+        else
+          for resource in ReleasePlan IntegrationTestScenario Application; do
+            names=$(oc -n "$TENANT_NAMESPACE" get "$resource" -o json 2>/dev/null \
+              | jq -r --argjson max "$MAX_AGE_SECONDS" '.items[] | select((now - (.metadata.creationTimestamp | fromdateiso8601)) > $max) | .metadata.name')
+            if [[ -n "$names" ]]; then
+              count=$(echo "$names" | wc -l)
+              echo "Deleting $count orphaned $resource in $TENANT_NAMESPACE:"
+              echo "$names" | sed 's/^/  /'
+              oc -n "$TENANT_NAMESPACE" delete "$resource" $names --wait=false
+            fi
+          done
+        fi
+        if ! oc login --token="$RELEASE_MANAGED_TOKEN" --server="$SERVER_API_URL" --insecure-skip-tls-verify; then
+          echo "WARNING: failed to login as managed SA, skipping RPA cleanup"
+        else
+          names=$(oc -n "$RELEASE_MANAGED_NAMESPACE" get ReleasePlanAdmission -o json \
+            | jq -r --arg ns "$TENANT_NAMESPACE" --argjson max "$MAX_AGE_SECONDS" '.items[] | select(.spec.origin == $ns) | select((now - (.metadata.creationTimestamp | fromdateiso8601)) > $max) | .metadata.name')
+          if [[ -n "$names" ]]; then
+            count=$(echo "$names" | wc -l)
+            echo "Deleting $count orphaned ReleasePlanAdmission in $RELEASE_MANAGED_NAMESPACE:"
+            echo "$names" | sed 's/^/  /'
+            oc -n "$RELEASE_MANAGED_NAMESPACE" delete ReleasePlanAdmission $names --wait=false
+          fi
+        fi
         echo "Pre-cleanup done"
     - name: run-test
       image: quay.io/redhat-user-workloads/konflux-perfscale-tenant/loadtest

--- a/components/monitoring/kanary/staging/base/tasks/run-kanary-tests.yaml
+++ b/components/monitoring/kanary/staging/base/tasks/run-kanary-tests.yaml
@@ -88,7 +88,7 @@ spec:
         if ! oc login --token="$(cat /opt/users-secret/token)" --server="$SERVER_API_URL" --insecure-skip-tls-verify; then
           echo "WARNING: failed to login as tenant SA, skipping tenant cleanup"
         else
-          for resource in ReleasePlan IntegrationTestScenario Application; do
+          for resource in ReleasePlan IntegrationTestScenario Application ImageRepository; do
             names=$(oc -n "$TENANT_NAMESPACE" get "$resource" -o json 2>/dev/null \
               | jq -r --argjson max "$MAX_AGE_SECONDS" '.items[] | select((now - (.metadata.creationTimestamp | fromdateiso8601)) > $max) | .metadata.name')
             if [[ -n "$names" ]]; then

--- a/components/monitoring/kanary/staging/stone-stage-p01/cronjobs/kanary-cronjob-multi-arch.yaml
+++ b/components/monitoring/kanary/staging/stone-stage-p01/cronjobs/kanary-cronjob-multi-arch.yaml
@@ -40,7 +40,6 @@ spec:
                     --param pipeline-repo-templating-source=https://github.com/rhtap-perf-test/konflux-probe-test-templates \
                     --param pipeline-repo-templating-source-dir=nodejs-devfile-sample-MultiArch/ \
                     --param release-pipeline-service-account=managed-konflux-perfscale-sa \
-                    --param release-managed-namespace=managed-konflux-perfscale-tenant \
                     --param fork-target=jhutar \
                     --param gitlab-api-url=https://gitlab.cee.redhat.com/api/v4 \
                     --param member-cluster=https://api.stone-stage-p01.hpmt.p1.openshiftapps.com:6443 \

--- a/components/monitoring/kanary/staging/stone-stage-p01/cronjobs/kanary-cronjob-single-arch.yaml
+++ b/components/monitoring/kanary/staging/stone-stage-p01/cronjobs/kanary-cronjob-single-arch.yaml
@@ -40,8 +40,7 @@ spec:
                     --param pipeline-repo-templating-source=https://github.com/rhtap-perf-test/konflux-probe-test-templates \
                     --param pipeline-repo-templating-source-dir=nodejs-devfile-sample-SingleArch/ \
                     --param release-pipeline-service-account=managed-konflux-perfscale-sa \
-                    --param release-managed-namespace=managed-konflux-perfscale-tenant \
                     --param fork-target=jhutar \
                     --param gitlab-api-url=https://gitlab.cee.redhat.com/api/v4 \
                     --param member-cluster=https://api.stone-stage-p01.hpmt.p1.openshiftapps.com:6443 \
-                    --prefix-name kanary-stone-stage-p01-
+                    --prefix-name kanary-stone-stage-p01-single-arch-

--- a/components/monitoring/kanary/staging/stone-stg-rh01/cronjobs/kanary-cronjob-multi-arch.yaml
+++ b/components/monitoring/kanary/staging/stone-stg-rh01/cronjobs/kanary-cronjob-multi-arch.yaml
@@ -40,7 +40,6 @@ spec:
                     --param pipeline-repo-templating-source=https://github.com/rhtap-perf-test/konflux-probe-test-templates \
                     --param pipeline-repo-templating-source-dir=nodejs-devfile-sample-MultiArch/ \
                     --param release-pipeline-service-account=managed-konflux-perfscale-sa \
-                    --param release-managed-namespace=managed-konflux-perfscale-tenant \
                     --param fork-target="" \
                     --param gitlab-api-url="" \
                     --param member-cluster=https://api.stone-stg-rh01.l2vh.p1.openshiftapps.com:6443 \

--- a/components/monitoring/kanary/staging/stone-stg-rh01/cronjobs/kanary-cronjob-single-arch.yaml
+++ b/components/monitoring/kanary/staging/stone-stg-rh01/cronjobs/kanary-cronjob-single-arch.yaml
@@ -40,8 +40,7 @@ spec:
                     --param pipeline-repo-templating-source=https://github.com/rhtap-perf-test/konflux-probe-test-templates \
                     --param pipeline-repo-templating-source-dir=nodejs-devfile-sample-SingleArch/ \
                     --param release-pipeline-service-account=managed-konflux-perfscale-sa \
-                    --param release-managed-namespace=managed-konflux-perfscale-tenant \
                     --param fork-target="" \
                     --param gitlab-api-url="" \
                     --param member-cluster=https://api.stone-stg-rh01.l2vh.p1.openshiftapps.com:6443 \
-                    --prefix-name kanary-stone-stg-rh01-
+                    --prefix-name kanary-stone-stg-rh01-single-arch-


### PR DESCRIPTION
## Summary

- Remove cluster-specific defaults from task/pipeline params (tested-cluster, component-repo, user-prefix, quay-repo, fork-target, gitlab-api-url, member-cluster) so cronjobs must set them explicitly
- Remove redundant `--param release-managed-namespace` from all cronjobs (already has a default in the task)
- Add `single-arch-` prefix to single-arch cronjob `--prefix-name` for consistency with multi-arch
- Add pre-cleanup step that removes orphaned resources older than 12h (ReleasePlans, IntegrationTestScenarios, Applications, RPAs) to prevent resource quota exhaustion

## Validation

- Staging only — no production changes
- `kustomize build` passes for both staging clusters (stone-stage-p01, stone-stg-rh01)

## JIRA

[PVO11Y-5342](https://redhat.atlassian.net/browse/PVO11Y-5342)

[PVO11Y-5342]: https://redhat.atlassian.net/browse/PVO11Y-5342?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ