### PR TITLE
SPRE-4610: bump internal-infra-deployments ref for staging blackbox fixes

### DIFF
--- a/components/monitoring/blackbox/staging/stone-stage-p01/kustomization.yaml
+++ b/components/monitoring/blackbox/staging/stone-stage-p01/kustomization.yaml
@@ -1,6 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - https://github.com/redhat-appstudio/internal-infra-deployments/components/monitoring/blackbox-exporter/staging/private/stone-stage-p01?ref=6a1460e226111283b77b279f2bb471e150aca222
+  - https://github.com/redhat-appstudio/internal-infra-deployments/components/monitoring/blackbox-exporter/staging/private/stone-stage-p01?ref=8f55b405b70eb275146777da82a94c49e35a5210
 
 namespace: appstudio-monitoring

--- a/components/monitoring/blackbox/staging/stone-stg-rh01/kustomization.yaml
+++ b/components/monitoring/blackbox/staging/stone-stg-rh01/kustomization.yaml
@@ -1,6 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - https://github.com/redhat-appstudio/internal-infra-deployments/components/monitoring/blackbox-exporter/staging/public/stone-stg-rh01?ref=6a1460e226111283b77b279f2bb471e150aca222
+  - https://github.com/redhat-appstudio/internal-infra-deployments/components/monitoring/blackbox-exporter/staging/public/stone-stg-rh01?ref=8f55b405b70eb275146777da82a94c49e35a5210
 
 namespace: appstudio-monitoring


### PR DESCRIPTION
Updates ref for both staging clusters to 8f55b405b70eb275146777da82a94c49e35a5210.

Changes included:
- http_2xx_nexus module moved to global base configmap
- staging/base/nexus-configmap-patch.yaml removed
- artifact-registry-proxy-probe added to staging private probes
- target: health removed from nexus-repos-health-probe