### PR TITLE
PVO11Y-5323 Enable cardinality monitoring for Tekton Prometheus

### DIFF
--- a/components/monitoring/cardinality/base/resources/deployment.yaml
+++ b/components/monitoring/cardinality/base/resources/deployment.yaml
@@ -27,8 +27,11 @@ spec:
           args:
             - "--service_discovery"
             - "--freq=1"
-            - "--selector=app.kubernetes.io/component=prometheus"
-            - "--regex=prometheus[a-zA-Z0-9_-]*"
+            - "--selector="
+            # openshift-user-workload-monitoring excluded: its kube-rbac-proxy
+            # blocks /api/v1/status/tsdb (OBSDA-1356)
+            - "--namespaces=openshift-monitoring,appstudio-tekton"
+            - "--regex=(prometheus-k8s|appstudio-tekton-ms-prometheus)"
             - "--auth=/etc/cardinality-exporter/auth.yaml"
           volumeMounts:
             - name: auth-config

--- a/components/monitoring/prometheus/staging/tekton-ms/networkpolicy.yaml
+++ b/components/monitoring/prometheus/staging/tekton-ms/networkpolicy.yaml
@@ -15,6 +15,12 @@ spec:
         - podSelector:
             matchLabels:
               app: tekton-ms-kube-rbac-proxy
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: appstudio-cardinality-exporter
+          podSelector:
+            matchLabels:
+              app: prometheus-cardinality-exporter
       ports:
         - protocol: TCP
           port: 9090


### PR DESCRIPTION
## Summary

- Update the NetworkPolicy to allow the cardinality exporter pod cross-namespace access to the Tekton Prometheus on port 9090
- Switch the exporter from label-based discovery to explicit namespace + regex filtering so it finds both Platform Prometheus and the OBO-managed Tekton Prometheus

The exporter connects to port 9090 directly rather than going through the kube-rbac-proxy on 9091. The proxy is a standalone deployment (not a sidecar), so its pod IP differs from the Prometheus pod IP that the exporter discovers — making it unreachable without code changes. Native TLS via the observability operator's `webTLSConfig` was also considered but requires manual cert provisioning. Since port 9090 is already restricted by NetworkPolicy to only the proxy and now the exporter, direct access is acceptable short-term.

## Risk Assessment

- **Level:** Low
- **Description:** Adds a NetworkPolicy exception for a single pod and changes discovery args. No impact on existing Platform Prometheus scraping.
- **Rollback:** Revert the commits.

## Validation

- Verify exporter logs show discovery of the Tekton Prometheus instance
- Verify `cardinality_exporter_series_count_by_metric_name_total{instance_namespace="appstudio-tekton"}` appears in the exporter's `/metrics` endpoint