### PR TITLE
Promote release-service and grafana-dashboard from staging to production

### DIFF
--- a/components/monitoring/grafana/production/dashboards/release/kustomization.yaml
+++ b/components/monitoring/grafana/production/dashboards/release/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- https://github.com/konflux-ci/release-service/config/grafana/?ref=3abc5019c03b3b1b52eb3742b4a29ecf00784e0f
+- https://github.com/konflux-ci/release-service/config/grafana/?ref=4e4388d1ee2bc9d682e88c05e5f128bb57db3394

--- a/components/release/production/kustomization.yaml
+++ b/components/release/production/kustomization.yaml
@@ -3,7 +3,7 @@ kind: Kustomization
 resources:
   - ../base
   - ../base/monitor/production
-  - https://github.com/konflux-ci/release-service/config/default?ref=3abc5019c03b3b1b52eb3742b4a29ecf00784e0f
+  - https://github.com/konflux-ci/release-service/config/default?ref=4e4388d1ee2bc9d682e88c05e5f128bb57db3394
   - release_service_config.yaml
   - signing_configs.yaml
 
@@ -13,6 +13,6 @@ components:
 images:
   - name: quay.io/konflux-ci/release-service
     newName: quay.io/konflux-ci/release-service
-    newTag: 3abc5019c03b3b1b52eb3742b4a29ecf00784e0f
+    newTag: 4e4388d1ee2bc9d682e88c05e5f128bb57db3394
 
 namespace: release-service


### PR DESCRIPTION
Included PRs:
 - https://github.com/konflux-ci/release-service/pull/1681 
 - https://github.com/konflux-ci/release-service/pull/1708 
 - https://github.com/konflux-ci/release-service/pull/1693 
 - https://github.com/konflux-ci/release-service/pull/1707 
 - https://github.com/konflux-ci/release-service/pull/1704 
 - https://github.com/konflux-ci/release-service/pull/1696 
 - https://github.com/konflux-ci/release-service/pull/1698 
 - https://github.com/konflux-ci/release-service/pull/1703 
 - https://github.com/konflux-ci/release-service/pull/1697 
 - https://github.com/konflux-ci/release-service/pull/1702 
 - https://github.com/konflux-ci/release-service/pull/1692 
 - https://github.com/konflux-ci/release-service/pull/1691 
 - https://github.com/konflux-ci/release-service/pull/1689 
 - https://github.com/konflux-ci/release-service/pull/1684 
 - https://github.com/konflux-ci/release-service/pull/1541 
 - https://github.com/konflux-ci/release-service/pull/1541 
 - https://github.com/konflux-ci/release-service/pull/1661 

Risk Assessment
Risk Level: Low
Description: It has been in staging for 12 days without issue
Rollback: Put the commit ref back to what it was before this PR

Validation
Staging PR: https://github.com/redhat-appstudio/infra-deployments/pull/12548