### PR TITLE
improve nvidia CDI configuration logic

### DIFF
--- a/components/multi-platform-controller/base/host-config-chart/files/linux-g64xlarge-amd64-init.sh
+++ b/components/multi-platform-controller/base/host-config-chart/files/linux-g64xlarge-amd64-init.sh
@@ -17,7 +17,29 @@ MIME-Version: 1.0
 Content-Transfer-Encoding: 7bit
 Content-Disposition: attachment; filename="userdata.txt"
 
-#!/bin/bash -ex
+#!/bin/bash
+
+set -xeuo pipefail
+
+configure_nvidia_cdi() {
+  # generate Nvdia CDI with retry
+  for i in {1..10}; do
+    su - ec2-user -c 'nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml'
+    su - ec2-user -c 'nvidia-ctk cdi generate --output=/var/run/cdi/nvidia.yaml'
+
+    # expect nvidia.com/gpu=all device to be in the generated list
+    if nvidia-ctk cdi list 2>/dev/null | grep -q 'nvidia.com/gpu=all'; then
+      echo "Nvidia CDI Ready"
+      return 0
+    fi
+
+    # sleep only if we'll be retrying again
+    [ "${i}" -lt "10" ] && sleep 1
+  done
+
+  echo "Nvidia CDI Failed"
+  return 1
+}
 
 # Format and mount NVMe disk
 mkfs -t xfs /dev/nvme1n1
@@ -36,9 +58,9 @@ restorecon -r /var/lib/containers /var/tmp
 mkdir -p /etc/cdi /var/run/cdi
 chmod a+rwx /etc/cdi /var/run/cdi
 setsebool container_use_devices 1 2>/dev/null || true
-su - ec2-user
-nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml
+configure_nvidia_cdi
 chmod a+rw /etc/cdi/nvidia.yaml
+chmod a+rw /var/run/cdi/nvidia.yaml
 
 # Configure ec2-user SSH access
 chown -R ec2-user /home/ec2-user

--- a/components/multi-platform-controller/staging/base/host-config-chart/files/linux-g64xlarge-amd64-init.sh
+++ b/components/multi-platform-controller/staging/base/host-config-chart/files/linux-g64xlarge-amd64-init.sh
@@ -5,7 +5,7 @@ set -xeuo pipefail
 configure_nvidia_cdi() {
   # generate Nvdia CDI with retry
   for i in {1..10}; do
-    su - ec2-user -c 'nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml' 
+    su - ec2-user -c 'nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml'
     su - ec2-user -c 'nvidia-ctk cdi generate --output=/var/run/cdi/nvidia.yaml'
 
     # expect nvidia.com/gpu=all device to be in the generated list


### PR DESCRIPTION
Follows-up to #12786

We want to improve the configuration of our g64 VM as we are experiencing some flakiness.

The change to the staging environment is just removing a whitespace from the end of a line.

## Risk Assessment

**Risk level:** low

**What could go wrong:** This change impacts just one VM type for which we don't see much usage.

**Rollback plan:** Revert the PR and redeploy. No data migration involved.

**Testing:** Validated in staging with no issues (#12786)

Signed-off-by: Francesco Ilario <filario@redhat.com>

rh-pre-commit.version: 2.4.0
rh-pre-commit.check-secrets: ENABLED
