### PR TITLE
KFLUXINFRA-4007: (onboarding) Removing old staging Authentication apps for Kargo

### DIFF
--- a/argo-cd-apps/base/all-clusters/infra-deployments/authentication/authentication.yaml
+++ b/argo-cd-apps/base/all-clusters/infra-deployments/authentication/authentication.yaml
@@ -17,8 +17,6 @@ spec:
               elements:
                 - nameNormalized: kflux-ocp-p01
                   values.clusterDir: kflux-ocp-p01
-                - nameNormalized: stone-stage-p01
-                  values.clusterDir: stone-stage-p01
                 - nameNormalized: stone-prod-p01
                   values.clusterDir: stone-prod-p01
                 - nameNormalized: stone-prod-p02

--- a/argo-cd-apps/base/ring-deployments/authentication-rd/authentication-rd.yaml
+++ b/argo-cd-apps/base/ring-deployments/authentication-rd/authentication-rd.yaml
@@ -31,9 +31,9 @@ spec:
         namespace: authentication
         server: '{{server}}'
       syncPolicy:
-        # automated:
-        #   prune: true
-        #   selfHeal: true
+        automated:
+          prune: true
+          selfHeal: true
         syncOptions:
         - CreateNamespace=true
         retry:

--- a/argo-cd-apps/overlays/konflux-public-staging/delete-applications.yaml
+++ b/argo-cd-apps/overlays/konflux-public-staging/delete-applications.yaml
@@ -11,3 +11,9 @@ kind: ApplicationSet
 metadata:
   name: nvme-storage-configurator
 $patch: delete
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: authentication
+$patch: delete


### PR DESCRIPTION
This commit deletes the old authentication appset and updates the authentication-rd appset to enable automated syncing to ArgoCD.

