### PR TITLE
PVO11Y-5151 Use empty-base as default clusterDir for kanary appset

### DIFF
--- a/argo-cd-apps/base/member/infra-deployments/monitoring-workload-kanary/monitoring-workload-kanary.yaml
+++ b/argo-cd-apps/base/member/infra-deployments/monitoring-workload-kanary/monitoring-workload-kanary.yaml
@@ -12,7 +12,7 @@ spec:
               values:
                 sourceRoot: components/monitoring/kanary
                 environment: staging
-                clusterDir: base
+                clusterDir: empty-base
           - list:
               elements:
                 - nameNormalized: stone-stage-p01

--- a/components/monitoring/kanary/production/empty-base/kustomization.yaml
+++ b/components/monitoring/kanary/production/empty-base/kustomization.yaml
@@ -1,0 +1,3 @@
+kind: Kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+resources: []

--- a/components/monitoring/kanary/staging/empty-base/kustomization.yaml
+++ b/components/monitoring/kanary/staging/empty-base/kustomization.yaml
@@ -1,0 +1,3 @@
+kind: Kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+resources: []


### PR DESCRIPTION
## Summary
Add `empty-base` directories (with `resources: []`) to both staging and production kanary overlays, and set `clusterDir: empty-base` as the default in the ApplicationSet. This ensures clusters without an explicit override (e.g. `kflux-osp-p01` which does not have kanary probes configured) do not get any kanary resources deployed.

Follows the pattern used by `konflux-rbac` component.

Jira: https://redhat.atlassian.net/browse/PVO11Y-5151

## Risk Assessment
**Risk Level:** Low
**Description:** Changes default from deploying base resources to deploying nothing for non-overridden clusters
**Rollback:** Revert PR