### PR TITLE
SPRE-4610: bump internal-infra-deployments ref for production nexus p…

### DIFF
--- a/components/monitoring/blackbox/production/kflux-fedora-01/kustomization.yaml
+++ b/components/monitoring/blackbox/production/kflux-fedora-01/kustomization.yaml
@@ -1,6 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
- - https://github.com/redhat-appstudio/internal-infra-deployments/components/monitoring/blackbox-exporter/production/public/kflux-fedora-01?ref=1ba403cfaba09e313e3b9061aee926b8435f14c2
+ - https://github.com/redhat-appstudio/internal-infra-deployments/components/monitoring/blackbox-exporter/production/public/kflux-fedora-01?ref=53d323113f2b9b0bbcba9b08378fdac8a7d34a8e
 
 namespace: appstudio-monitoring

--- a/components/monitoring/blackbox/production/kflux-ocp-p01/kustomization.yaml
+++ b/components/monitoring/blackbox/production/kflux-ocp-p01/kustomization.yaml
@@ -1,6 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
- - https://github.com/redhat-appstudio/internal-infra-deployments/components/monitoring/blackbox-exporter/production/private/kflux-ocp-p01?ref=1ba403cfaba09e313e3b9061aee926b8435f14c2
+ - https://github.com/redhat-appstudio/internal-infra-deployments/components/monitoring/blackbox-exporter/production/private/kflux-ocp-p01?ref=53d323113f2b9b0bbcba9b08378fdac8a7d34a8e
 
 namespace: appstudio-monitoring

--- a/components/monitoring/blackbox/production/kflux-osp-p01/kustomization.yaml
+++ b/components/monitoring/blackbox/production/kflux-osp-p01/kustomization.yaml
@@ -1,6 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
- - https://github.com/redhat-appstudio/internal-infra-deployments/components/monitoring/blackbox-exporter/production/private/kflux-osp-p01?ref=1ba403cfaba09e313e3b9061aee926b8435f14c2
+ - https://github.com/redhat-appstudio/internal-infra-deployments/components/monitoring/blackbox-exporter/production/private/kflux-osp-p01?ref=53d323113f2b9b0bbcba9b08378fdac8a7d34a8e
 
 namespace: appstudio-monitoring

--- a/components/monitoring/blackbox/production/kflux-prd-rh02/kustomization.yaml
+++ b/components/monitoring/blackbox/production/kflux-prd-rh02/kustomization.yaml
@@ -1,6 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
- - https://github.com/redhat-appstudio/internal-infra-deployments/components/monitoring/blackbox-exporter/production/public/kflux-prd-rh02?ref=1ba403cfaba09e313e3b9061aee926b8435f14c2
+ - https://github.com/redhat-appstudio/internal-infra-deployments/components/monitoring/blackbox-exporter/production/public/kflux-prd-rh02?ref=53d323113f2b9b0bbcba9b08378fdac8a7d34a8e
 
 namespace: appstudio-monitoring

--- a/components/monitoring/blackbox/production/kflux-prd-rh03/kustomization.yaml
+++ b/components/monitoring/blackbox/production/kflux-prd-rh03/kustomization.yaml
@@ -1,6 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
- - https://github.com/redhat-appstudio/internal-infra-deployments/components/monitoring/blackbox-exporter/production/public/kflux-prd-rh03?ref=1ba403cfaba09e313e3b9061aee926b8435f14c2
+ - https://github.com/redhat-appstudio/internal-infra-deployments/components/monitoring/blackbox-exporter/production/public/kflux-prd-rh03?ref=53d323113f2b9b0bbcba9b08378fdac8a7d34a8e
 
 namespace: appstudio-monitoring

--- a/components/monitoring/blackbox/production/kflux-rhel-p01/kustomization.yaml
+++ b/components/monitoring/blackbox/production/kflux-rhel-p01/kustomization.yaml
@@ -1,6 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
- - https://github.com/redhat-appstudio/internal-infra-deployments/components/monitoring/blackbox-exporter/production/private/kflux-rhel-p01?ref=1ba403cfaba09e313e3b9061aee926b8435f14c2
+ - https://github.com/redhat-appstudio/internal-infra-deployments/components/monitoring/blackbox-exporter/production/private/kflux-rhel-p01?ref=53d323113f2b9b0bbcba9b08378fdac8a7d34a8e
 
 namespace: appstudio-monitoring

--- a/components/monitoring/blackbox/production/stone-prd-rh01/kustomization.yaml
+++ b/components/monitoring/blackbox/production/stone-prd-rh01/kustomization.yaml
@@ -1,6 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
- - https://github.com/redhat-appstudio/internal-infra-deployments/components/monitoring/blackbox-exporter/production/public/stone-prd-rh01?ref=1ba403cfaba09e313e3b9061aee926b8435f14c2
+ - https://github.com/redhat-appstudio/internal-infra-deployments/components/monitoring/blackbox-exporter/production/public/stone-prd-rh01?ref=53d323113f2b9b0bbcba9b08378fdac8a7d34a8e
 
 namespace: appstudio-monitoring

--- a/components/monitoring/blackbox/production/stone-prod-p01/kustomization.yaml
+++ b/components/monitoring/blackbox/production/stone-prod-p01/kustomization.yaml
@@ -1,6 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
- - https://github.com/redhat-appstudio/internal-infra-deployments/components/monitoring/blackbox-exporter/production/private/stone-prod-p01?ref=1ba403cfaba09e313e3b9061aee926b8435f14c2
+ - https://github.com/redhat-appstudio/internal-infra-deployments/components/monitoring/blackbox-exporter/production/private/stone-prod-p01?ref=53d323113f2b9b0bbcba9b08378fdac8a7d34a8e
 
 namespace: appstudio-monitoring

--- a/components/monitoring/blackbox/production/stone-prod-p02/kustomization.yaml
+++ b/components/monitoring/blackbox/production/stone-prod-p02/kustomization.yaml
@@ -1,6 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
- - https://github.com/redhat-appstudio/internal-infra-deployments/components/monitoring/blackbox-exporter/production/private/stone-prod-p02?ref=1ba403cfaba09e313e3b9061aee926b8435f14c2
+ - https://github.com/redhat-appstudio/internal-infra-deployments/components/monitoring/blackbox-exporter/production/private/stone-prod-p02?ref=53d323113f2b9b0bbcba9b08378fdac8a7d34a8e
 
 namespace: appstudio-monitoring


### PR DESCRIPTION
  ## Summary
  
  Updates the `internal-infra-deployments` kustomization ref for all 9 production
  clusters to `53d323113f2b9b0bbcba9b08378fdac8a7d34a8e`.
  
  Changes included in this ref:
  
  - `nexus-liveness` and `nexus-writable` probes moved from per-cluster directories
    to `production/base/probes/public/https` shared base
  - `nexus-repos-health` probe added with per-repository target labels via
    `metricRelabelings` for individual repository visibility in Grafana
  - ExternalSecret added pulling Nexus SA credentials from Vault at
    `production/monitoring/nexus-monitoring-sa`
  - `http_2xx_nexus` module added to `production/private/base/blackbox-configmap-patch.yaml`
    so private clusters retain the module despite their full configmap patch override

  ## Risk Assessment

  **Risk Level:** Low
  
  **Description:** Monitoring-only changes. No service availability is affected.
  Probes `nexus-liveness` and `nexus-writable` were already running per-cluster -
  this moves them to the shared base and adds `nexus-repos-health`. The ExternalSecret
  requires the Nexus SA credentials to be stored in Vault at
  `production/monitoring/nexus-monitoring-sa` before syncing.

  **Rollback Plan:** Revert the kustomization ref back to
  `1ba403cfaba09e313e3b9061aee926b8435f14c2` in all 9 production cluster
  kustomization files.
 
  ## Validation

  Staging equivalent changes merged and verified:
  - internal-infra-deployments staging PR: https://github.com/redhat-appstudio/internal-infra-deployments/pull/111
  - infra-deployments staging ref bump: merged successfully

  Refs: [SPRE-4610](https://redhat.atlassian.net/browse/SPRE-4610)



[SPRE-4610]: https://redhat.atlassian.net/browse/SPRE-4610?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ