### PR TITLE
PVO11Y-5323 Fix --namespaces flag to use repeated args

### DIFF
--- a/components/monitoring/cardinality/base/resources/deployment.yaml
+++ b/components/monitoring/cardinality/base/resources/deployment.yaml
@@ -32,7 +32,8 @@ spec:
             # blocks /api/v1/status/tsdb (OBSDA-1356)
             - "--namespaces=openshift-monitoring"
             - "--namespaces=appstudio-tekton"
-            - "--regex=(prometheus-k8s|appstudio-tekton-ms-prometheus)"
+            - "--namespaces=appstudio-monitoring"
+            - "--regex=(prometheus-k8s|appstudio-tekton-ms-prometheus|appstudio-federate-ms-prometheus)"
             - "--auth=/etc/cardinality-exporter/auth.yaml"
           volumeMounts:
             - name: auth-config

--- a/components/monitoring/cardinality/base/resources/deployment.yaml
+++ b/components/monitoring/cardinality/base/resources/deployment.yaml
@@ -30,7 +30,8 @@ spec:
             - "--selector="
             # openshift-user-workload-monitoring excluded: its kube-rbac-proxy
             # blocks /api/v1/status/tsdb (OBSDA-1356)
-            - "--namespaces=openshift-monitoring,appstudio-tekton"
+            - "--namespaces=openshift-monitoring"
+            - "--namespaces=appstudio-tekton"
             - "--regex=(prometheus-k8s|appstudio-tekton-ms-prometheus)"
             - "--auth=/etc/cardinality-exporter/auth.yaml"
           volumeMounts:


### PR DESCRIPTION
## Summary

- Split `--namespaces=openshift-monitoring,appstudio-tekton` into two separate `--namespaces` flags. The go-flags library parses `[]string` slices by repeating the flag, not comma-separated — so the single arg was treated as one namespace `"openshift-monitoring,appstudio-tekton"` which doesn't exist, breaking all discovery.

## Risk Assessment

- **Level:** Critical fix
- **Description:** Discovery is completely broken on main — the exporter finds zero Prometheus instances. This restores Platform Prometheus scraping and enables Tekton Prometheus discovery.
- **Rollback:** Revert the commit.

## Validation

- Verified locally by building the exporter and testing flag parsing: comma-separated produces 1 namespace, repeated flags produces 2