### PR TITLE
Promote release-service and grafana-dashboard from staging to production

### DIFF
--- a/components/monitoring/grafana/production/dashboards/release/kustomization.yaml
+++ b/components/monitoring/grafana/production/dashboards/release/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- https://github.com/konflux-ci/release-service/config/grafana/?ref=4e4388d1ee2bc9d682e88c05e5f128bb57db3394
+- https://github.com/konflux-ci/release-service/config/grafana/?ref=a971d3c8d10d07257d4afc70e342a09e85a3a33e

--- a/components/release/production/kustomization.yaml
+++ b/components/release/production/kustomization.yaml
@@ -3,7 +3,7 @@ kind: Kustomization
 resources:
   - ../base
   - ../base/monitor/production
-  - https://github.com/konflux-ci/release-service/config/default?ref=4e4388d1ee2bc9d682e88c05e5f128bb57db3394
+  - https://github.com/konflux-ci/release-service/config/default?ref=a971d3c8d10d07257d4afc70e342a09e85a3a33e
   - release_service_config.yaml
   - signing_configs.yaml
 
@@ -13,6 +13,6 @@ components:
 images:
   - name: quay.io/konflux-ci/release-service
     newName: quay.io/konflux-ci/release-service
-    newTag: 4e4388d1ee2bc9d682e88c05e5f128bb57db3394
+    newTag: a971d3c8d10d07257d4afc70e342a09e85a3a33e
 
 namespace: release-service


### PR DESCRIPTION
Included PRs:
 - https://github.com/konflux-ci/release-service/pull/1688 
 - https://github.com/konflux-ci/release-service/pull/1679 
 - https://github.com/konflux-ci/release-service/pull/1678 

Risk Assessment
Risk Level: Low
Description: It has been in staging for 9 days without issue
Rollback: Put the commit ref back to what it was before this PR

Validation
Staging PR: https://github.com/redhat-appstudio/infra-deployments/pull/12655
