### PR TITLE
PVO11Y-5366 Add prometheus_replica to staging writeRelabelConfigs

### DIFF
--- a/components/monitoring/prometheus/staging/base/federation/writeRelabelConfigs.yaml
+++ b/components/monitoring/prometheus/staging/base/federation/writeRelabelConfigs.yaml
@@ -24,7 +24,7 @@
     # KubeArchive
     # Cardinality exporter (PVO11Y-5128)
     # KAExporter (PVO11Y-5274)
-    regex: "__name__|source_environment|source_cluster|namespace|job|instance|pod|container|app|service|deployment|node|\
+    regex: "__name__|source_environment|source_cluster|namespace|job|instance|pod|container|app|service|deployment|node|prometheus_replica|\
       phase|reason|type|resource|kind|name|role|status|state|resourcequota|image|finalizers|verb|request_kind|\
       persistentvolumeclaim|storageclass|volumename|\
       method|code|http_method|http_route|http_status_code|grpc_service|grpc_code|grpc_method|sp|\


### PR DESCRIPTION
## Summary

- Add `prometheus_replica` to the staging LabelKeep allowlist. Without it, the two federation Prometheus replicas produce indistinguishable samples, causing Thanos Receive to reject ~2000 samples/min with HTTP 409 conflicts.

Cherry-picked from infra-common-deployments [da6e073](https://github.com/redhat-appstudio/infra-common-deployments/commit/da6e07322f36405fd5e15c5afe178abab662c4c1). Production to follow after staging validation.

Jira: https://redhat.atlassian.net/browse/PVO11Y-5366

## Risk Assessment

- **Level:** Low
- **Description:** Adds one label to the existing allowlist. Reduces sample rejection, does not change which metrics are forwarded.
- **Rollback:** Revert the commit.