### PR TITLE
PVO11Y-5279 Allow konflux-o11y-exporters in ClusterSecretStore

### DIFF
--- a/components/cluster-secret-store/base/appsre-stonesoup-vault-secret-store.yaml
+++ b/components/cluster-secret-store/base/appsre-stonesoup-vault-secret-store.yaml
@@ -73,4 +73,5 @@ spec:
         - pulp-access-controller
         - konflux-vanguard-tenant
         - konflux-kite
+        - konflux-o11y-exporters
         - caching


### PR DESCRIPTION
## What

Add `konflux-o11y-exporters` to the allowed namespaces list in the `appsre-stonesoup-vault` ClusterSecretStore.

## Why

The KubeArchive exporter deployed in [PR #12649](https://github.com/redhat-appstudio/infra-deployments/pull/12649) uses an ExternalSecret in the `konflux-o11y-exporters` namespace to fetch KubeArchive credentials from Vault. Without this namespace in the allowed list, the ExternalSecret fails with:

```
error processing spec.dataFrom[0].extract, err: using cluster store "appsre-stonesoup-vault" is not allowed from namespace "konflux-o11y-exporters": denied by spec.condition
```

[PVO11Y-5279](https://redhat.atlassian.net/browse/PVO11Y-5279)

[PVO11Y-5279]: https://redhat.atlassian.net/browse/PVO11Y-5279?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ