### PR TITLE
KONFLUX-14156 Update multi-platform-controller to a5285b3

### DIFF
--- a/components/multi-platform-controller/base/kustomization.yaml
+++ b/components/multi-platform-controller/base/kustomization.yaml
@@ -6,13 +6,13 @@ namespace: multi-platform-controller
 resources:
 - common
 - rbac
-- https://github.com/konflux-ci/multi-platform-controller/deploy/operator?ref=2e08f8fe2a98660a39b78b9f8860caaea041823f
-- https://github.com/konflux-ci/multi-platform-controller/deploy/otp?ref=2e08f8fe2a98660a39b78b9f8860caaea041823f
+- https://github.com/konflux-ci/multi-platform-controller/deploy/operator?ref=a5285b319d913f46dc0617fa54fb07817dff7593
+- https://github.com/konflux-ci/multi-platform-controller/deploy/otp?ref=a5285b319d913f46dc0617fa54fb07817dff7593
 
 images:
 - name: multi-platform-controller
   newName: quay.io/konflux-ci/multi-platform-controller
-  newTag: 2e08f8fe2a98660a39b78b9f8860caaea041823f
+  newTag: a5285b319d913f46dc0617fa54fb07817dff7593
 - name: multi-platform-otp-server
   newName: quay.io/konflux-ci/multi-platform-controller-otp-service
-  newTag: 2e08f8fe2a98660a39b78b9f8860caaea041823f
+  newTag: a5285b319d913f46dc0617fa54fb07817dff7593


### PR DESCRIPTION
## What

Update multi-platform-controller base kustomization to a5285b3.

- [konflux-ci/multi-platform-controller#951](https://github.com/konflux-ci/multi-platform-controller/pull/951) ([a5285b3](https://github.com/konflux-ci/multi-platform-controller/commit/a5285b319d913f46dc0617fa54fb07817dff7593))

Clusters affected: development, staging

[KONFLUX-14156](https://issues.redhat.com/browse/KONFLUX-14156)

## Why

PR #12802 listed this commit in its description but did not actually include it — the ref pointed to `2e08f8f` which is one commit behind.

## Validation

- `kustomize build components/multi-platform-controller/base/` passes
- Image exists on Quay: https://quay.io/repository/konflux-ci/multi-platform-controller?tab=tags&tag=a5285b319d913f46dc0617fa54fb07817dff7593
- Commit: https://github.com/konflux-ci/multi-platform-controller/commit/a5285b319d913f46dc0617fa54fb07817dff7593

[KONFLUX-14156]: https://redhat.atlassian.net/browse/KONFLUX-14156?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ