### PR TITLE
KONFLUX-6210 Add ibm-public-key secret access to release pipeline ClusterRole (dev/stage)

### DIFF
--- a/components/release/development/ibm-public-key-patch.yaml
+++ b/components/release/development/ibm-public-key-patch.yaml
@@ -1,0 +1,11 @@
+- op: add
+  path: /rules/-
+  value:
+    apiGroups:
+    - ""
+    resources:
+    - secrets
+    resourceNames:
+    - ibm-public-key
+    verbs:
+    - get

--- a/components/release/development/kustomization.yaml
+++ b/components/release/development/kustomization.yaml
@@ -20,3 +20,9 @@ patches:
       kind: Deployment
       name: release-service-controller-manager
     path: manager-memory-patch.yaml
+  - target:
+      group: rbac.authorization.k8s.io
+      version: v1
+      kind: ClusterRole
+      name: release-pipeline-resource-role
+    path: ibm-public-key-patch.yaml

--- a/components/release/staging/ibm-public-key-patch.yaml
+++ b/components/release/staging/ibm-public-key-patch.yaml
@@ -1,0 +1,11 @@
+- op: add
+  path: /rules/-
+  value:
+    apiGroups:
+    - ""
+    resources:
+    - secrets
+    resourceNames:
+    - ibm-public-key
+    verbs:
+    - get

--- a/components/release/staging/kustomization.yaml
+++ b/components/release/staging/kustomization.yaml
@@ -17,3 +17,11 @@ images:
     newTag: 6d9abf25ac73986731ba7dbdb1ac459af54999b0
 
 namespace: release-service
+
+patches:
+  - target:
+      group: rbac.authorization.k8s.io
+      version: v1
+      kind: ClusterRole
+      name: release-pipeline-resource-role
+    path: ibm-public-key-patch.yaml


### PR DESCRIPTION
## Summary
- Adds `get` access for the `ibm-public-key` secret to the `release-pipeline-resource-role` ClusterRole in **development and staging** overlays only
- Uses a JSON patch (RFC 6902) to append the rule, so the base resource is unchanged and production is unaffected
- This must merge before #12519 (which adds the same rule to `base/` for production)

## Context
Release pipelines need this secret to pull images signed with the IBM key. #12519 adds it to `base/` which affects all environments — this PR gates the change to dev/stage first for validation.

## Test plan
- [x] `kustomize build components/release/development` includes the `ibm-public-key` rule
- [x] `kustomize build components/release/staging` includes the `ibm-public-key` rule
- [x] `kustomize build components/release/production` does NOT include the rule
- [ ] Verify the ClusterRole change deploys successfully to dev/stage clusters
- [ ] Verify release pipelines can access the `ibm-public-key` secret in managed namespaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)