### PR TITLE
 SPRE-4610: bump internal-infra-deployments ref to remove artifact-registry-proxy probe

### DIFF
--- a/components/monitoring/blackbox/staging/stone-stage-p01/kustomization.yaml
+++ b/components/monitoring/blackbox/staging/stone-stage-p01/kustomization.yaml
@@ -1,6 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - https://github.com/redhat-appstudio/internal-infra-deployments/components/monitoring/blackbox-exporter/staging/private/stone-stage-p01?ref=8f55b405b70eb275146777da82a94c49e35a5210
+  - https://github.com/redhat-appstudio/internal-infra-deployments/components/monitoring/blackbox-exporter/staging/private/stone-stage-p01?ref=038c6f90e6db623cdacf686de90ea4c52d3f6cea
 
 namespace: appstudio-monitoring

--- a/components/monitoring/blackbox/staging/stone-stg-rh01/kustomization.yaml
+++ b/components/monitoring/blackbox/staging/stone-stg-rh01/kustomization.yaml
@@ -1,6 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - https://github.com/redhat-appstudio/internal-infra-deployments/components/monitoring/blackbox-exporter/staging/public/stone-stg-rh01?ref=8f55b405b70eb275146777da82a94c49e35a5210
+  - https://github.com/redhat-appstudio/internal-infra-deployments/components/monitoring/blackbox-exporter/staging/public/stone-stg-rh01?ref=038c6f90e6db623cdacf686de90ea4c52d3f6cea
 
 namespace: appstudio-monitoring


### PR DESCRIPTION
  ## Summary
  
  Updates the `internal-infra-deployments` kustomization ref for both staging
  clusters to `038c6f90e6db623cdacf686de90ea4c52d3f6cea`.

  Changes included in this ref:
  
  - Removed `artifact-registry-proxy-probe` from staging. The proxy availability
    is already monitored via `nginx_up` metric collected by the ServiceMonitor
    deployed with the squid Helm chart. The `NginxProxyDown` alert in o11y fires
    when the proxy is down, making the blackbox probe redundant.

  Staging PR merged: https://github.com/redhat-appstudio/internal-infra-deployments/pull/116
  Refs: [SPRE-4610](https://redhat.atlassian.net/browse/SPRE-4610)



[SPRE-4610]: https://redhat.atlassian.net/browse/SPRE-4610?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ