### PR TITLE
PVO11Y-5323 Anchor cardinality exporter --regex to match exact service names

### DIFF
--- a/components/monitoring/cardinality/base/resources/deployment.yaml
+++ b/components/monitoring/cardinality/base/resources/deployment.yaml
@@ -33,7 +33,7 @@ spec:
             - "--namespaces=openshift-monitoring"
             - "--namespaces=appstudio-tekton"
             - "--namespaces=appstudio-monitoring"
-            - "--regex=(prometheus-k8s|appstudio-tekton-ms-prometheus|appstudio-federate-ms-prometheus)"
+            - "--regex=^(prometheus-k8s|appstudio-tekton-ms-prometheus|appstudio-federate-ms-prometheus)$"
             - "--auth=/etc/cardinality-exporter/auth.yaml"
           volumeMounts:
             - name: auth-config


### PR DESCRIPTION
## Summary

- Anchor the `--regex` with `^...$` to force exact service name matching. The exporter uses Go's `regexp.MatchString` which does substring matching, so `prometheus-k8s` was also matching `prometheus-k8s-thanos-sidecar`, causing repeated TLS errors in the logs.

## Risk Assessment

- **Level:** Low
- **Description:** Tightens the regex to exclude the Thanos sidecar endpoints. No change to which Prometheus instances are scraped.
- **Rollback:** Revert the commit.

## Validation

- Tested regex locally: `prometheus-k8s` matches, `prometheus-k8s-thanos-sidecar` does not