### PR TITLE
PVO11Y-5279 Update kaexporter ref to include KubeArchive RBAC

### DIFF
--- a/components/monitoring/exporters/kaexporter/staging/base/kustomization.yaml
+++ b/components/monitoring/exporters/kaexporter/staging/base/kustomization.yaml
@@ -1,9 +1,9 @@
 resources:
   - rbac
   - external-secrets
-  - https://github.com/redhat-appstudio/o11y/config/exporters/monitoring/kaexporter/base?ref=091fc2808ef6064fd26a83eed49726d2a7fc741a
+  - https://github.com/redhat-appstudio/o11y/config/exporters/monitoring/kaexporter/base?ref=59edde5269d5713c4e00e989176728741c4c8772
 
 images:
   - name: quay.io/redhat-appstudio/o11y
     newName: quay.io/redhat-appstudio/o11y
-    newTag: 091fc2808ef6064fd26a83eed49726d2a7fc741a
+    newTag: 59edde5269d5713c4e00e989176728741c4c8772


### PR DESCRIPTION
## Summary

- Update o11y commit ref from `091fc280` to `59edde52` in staging kaexporter kustomization

## Why

The previous ref did not include the `kaexporter-kubearchive-reader` ClusterRole ([o11y PR #1211](https://github.com/redhat-appstudio/o11y/pull/1211)). Without it, the exporter's ServiceAccount cannot access KubeArchive resources, causing 401 errors on all API calls:

```
releases fetch namespace "abiton-tenant": API returned status 401: {"message":"unauthorized"}
```

The updated ref includes a ClusterRole granting `list` on namespaces, PipelineRuns, and Releases — the minimum permissions needed for KubeArchive's SubjectAccessReview authorization.

[PVO11Y-5279](https://redhat.atlassian.net/browse/PVO11Y-5279)

[PVO11Y-5279]: https://redhat.atlassian.net/browse/PVO11Y-5279?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ