### PR TITLE
PVO11Y-5279 Update kaexporter ref to include honorLabels fix

### DIFF
--- a/components/monitoring/exporters/kaexporter/staging/base/kustomization.yaml
+++ b/components/monitoring/exporters/kaexporter/staging/base/kustomization.yaml
@@ -1,9 +1,9 @@
 resources:
   - rbac
   - external-secrets
-  - https://github.com/redhat-appstudio/o11y/config/exporters/monitoring/kaexporter/base?ref=59edde5269d5713c4e00e989176728741c4c8772
+  - https://github.com/redhat-appstudio/o11y/config/exporters/monitoring/kaexporter/base?ref=7178afafdcf09c0ad70c3322fbe4c972c7901bc5
 
 images:
   - name: quay.io/redhat-appstudio/o11y
     newName: quay.io/redhat-appstudio/o11y
-    newTag: 59edde5269d5713c4e00e989176728741c4c8772
+    newTag: 7178afafdcf09c0ad70c3322fbe4c972c7901bc5


### PR DESCRIPTION
## Summary

Update o11y commit ref from `59edde52` to `7178afaf` in staging kaexporter kustomization.

## Why

The previous ref did not include `honorLabels: true` in the ServiceMonitor ([o11y PR #1212](https://github.com/redhat-appstudio/o11y/pull/1212)). Without it, Prometheus overwrites the exporter's `namespace` label with the pod's namespace (`konflux-o11y-exporters`), hiding the actual tenant namespace from the metrics.

[PVO11Y-5279](https://redhat.atlassian.net/browse/PVO11Y-5279)

[PVO11Y-5279]: https://redhat.atlassian.net/browse/PVO11Y-5279?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ