### PR TITLE
Fix missing Prometheus RBAC in staging kubearchive-logging

### DIFF
--- a/components/vector-kubearchive-log-collector/staging/base/kustomization.yaml
+++ b/components/vector-kubearchive-log-collector/staging/base/kustomization.yaml
@@ -16,6 +16,7 @@ resources:
 - namespace.yaml
 - loki-secret.yaml
 - sa.yaml
+- rbac.yaml
 - prometheus-rules.yaml
 
 patchesStrategicMerge:


### PR DESCRIPTION
The staging monitoring setup PR #11726 created rbac.yaml but forgot to add it to kustomization.yaml resources, causing Prometheus to lack permissions to scrape the product-kubearchive-logging namespace.