### PR TITLE
[KFLUXINFRA-3210] Update OADP channel to stable for kflux-prd-rh02

### DIFF
--- a/components/backup/production/kflux-prd-rh02/kustomization.yaml
+++ b/components/backup/production/kflux-prd-rh02/kustomization.yaml
@@ -21,3 +21,9 @@ patches:
       kind: DataProtectionApplication
       name: velero-aws
     path: dpa-kmskeyid-patch.yaml
+  - target:
+      group: operators.coreos.com
+      version: v1alpha1
+      kind: Subscription
+      name: redhat-oadp-operator
+    path: oadp-channel-patch.yaml

--- a/components/backup/production/kflux-prd-rh02/oadp-channel-patch.yaml
+++ b/components/backup/production/kflux-prd-rh02/oadp-channel-patch.yaml
@@ -1,0 +1,3 @@
+- op: replace
+  path: /spec/channel
+  value: stable


### PR DESCRIPTION
**Summary**

Switch OADP Subscription channel from stable-1.4 to stable (OADP 1.5.x) for kflux-prd-rh02, now upgraded to OCP 4.19.

OCP 4.19 redhat-operators catalog no longer ships the stable-1.4 channel, causing OLM ResolutionFailed and backup components to go Degraded.

Same change as 12364, 12483 and 12861

Risk Assessment

**Risk Level**: Low
**Description**: Channel change for OADP operator subscription. The DPA already uses OADP 1.5 format (nodeAgent / uploaderType: kopia). Same patch was successfully applied to staging clusters and
kflux-rhel-p01, kflux-fedora-01, kflux-osp-p01 in production.
**Rollback Plan**: Revert this PR. Note: reverting to stable-1.4 will fail on OCP 4.19 since the channel no longer exists, so the operator will remain on the installed version.

Test plan
- [ ] Verified on staging clusters (stone-stg-rh01, stone-stage-p01) — OADP 1.5.5, healthy
- [ ]  Verified on kflux-rhel-p01 (PR https://github.com/redhat-appstudio/infra-deployments/pull/12364) — OADP 1.5.x, healthy
- [ ]  After merge, confirm ArgoCD sync on both clusters
- [ ]  Verify OADP operator upgraded and backup DPA is not Degraded
