### PR TITLE
feat(PVO11Y-5279): Update kaexporter ref

### DIFF
--- a/components/monitoring/exporters/kaexporter/staging/base/kustomization.yaml
+++ b/components/monitoring/exporters/kaexporter/staging/base/kustomization.yaml
@@ -1,9 +1,9 @@
 resources:
   - rbac
   - external-secrets
-  - https://github.com/redhat-appstudio/o11y/config/exporters/monitoring/kaexporter/base?ref=7178afafdcf09c0ad70c3322fbe4c972c7901bc5
+  - https://github.com/redhat-appstudio/o11y/config/exporters/monitoring/kaexporter/base?ref=f2a12ad5a81a2723fd8991203c521bea6f42ddc4
 
 images:
   - name: quay.io/redhat-appstudio/o11y
     newName: quay.io/redhat-appstudio/o11y
-    newTag: 7178afafdcf09c0ad70c3322fbe4c972c7901bc5
+    newTag: f2a12ad5a81a2723fd8991203c521bea6f42ddc4


### PR DESCRIPTION
Updated kaexporter git ref so it deploy the following changes:
- Increase steady-state per-namespace item cap from 1,000 to 1,500
- Rename duration metrics to follow standard naming convention:
  - mean_duration_30d_seconds ->  mean_duration_seconds_30d
  - mean_wait_30d_seconds -> mean_wait_seconds_30d
- Remove redundant success_rate_30d and failure_rate_30d metrics (can be derived from success_count_30d / total_count_30d)