### PR TITLE
PVO11Y-5323 Increase cardinality exporter scrape frequency

### DIFF
--- a/components/monitoring/cardinality/base/resources/deployment.yaml
+++ b/components/monitoring/cardinality/base/resources/deployment.yaml
@@ -26,7 +26,7 @@ spec:
             runAsNonRoot: true
           args:
             - "--service_discovery"
-            - "--freq=1"
+            - "--freq=0.1"
             - "--selector="
             # openshift-user-workload-monitoring excluded: its kube-rbac-proxy
             # blocks /api/v1/status/tsdb (OBSDA-1356)

--- a/components/monitoring/cardinality/base/resources/servicemonitor.yaml
+++ b/components/monitoring/cardinality/base/resources/servicemonitor.yaml
@@ -9,8 +9,7 @@ spec:
   endpoints:
     - port: http
       path: /metrics
-      # Exporter runs every couple of hours. No need for frequent scraping.
-      interval: 10m
+      interval: 2m
   selector:
     matchLabels:
       app: prometheus-cardinality-exporter


### PR DESCRIPTION
## Summary

- Increase cardinality exporter TSDB fetch frequency from 1 hour to ~6 minutes (`--freq=0.1`)
- Reduce ServiceMonitor scrape interval from 10m to 2m to match

## Risk Assessment

- **Level:** Low
- **Description:** More frequent scraping of Prometheus TSDB status API. The API call is lightweight.
- **Rollback:** Revert the commit.