### PR TITLE
feat(PVO11Y-5321): Forward KAExporter labels

### DIFF
--- a/components/monitoring/prometheus/production/base/federation/writeRelabelConfigs.yaml
+++ b/components/monitoring/prometheus/production/base/federation/writeRelabelConfigs.yaml
@@ -39,4 +39,4 @@
       health_status|dest_namespace|\
       hostname|label_app_kubernetes_io_managed_by|platform|scrape_job|slice|error|\
       resource_type|gin_errors|\
-      application|component|build_type|scenario|optional|test_type|automated"
+      application|component|build_type|scenario|optional|test_type|automated|exported_namespace"

--- a/components/monitoring/prometheus/production/base/federation/writeRelabelConfigs.yaml
+++ b/components/monitoring/prometheus/production/base/federation/writeRelabelConfigs.yaml
@@ -22,6 +22,7 @@
     # ArgoCD (RHTAPWATCH-88)
     # Monitoring infra (RHTAPWATCH-110, PVO11Y-4774)
     # KubeArchive
+    # KAExporter (PVO11Y-5274)
     regex: "__name__|source_environment|source_cluster|namespace|job|instance|pod|container|app|service|deployment|node|\
       phase|reason|type|resource|kind|name|role|status|state|resourcequota|image|finalizers|verb|request_kind|\
       persistentvolumeclaim|storageclass|volumename|\
@@ -37,4 +38,5 @@
       check|tested_cluster|tested_registry|unexpected_status|failure|severity|cache_status|\
       health_status|dest_namespace|\
       hostname|label_app_kubernetes_io_managed_by|platform|scrape_job|slice|error|\
-      resource_type|gin_errors"
+      resource_type|gin_errors|\
+      application|component|build_type|scenario|optional|test_type|automated"


### PR DESCRIPTION
## Summary

Enable forwarding of labels used in KAExporter to RHOBS for prod clusters after validation on stage (redhat-appstudio/infra-deployments#12874, redhat-appstudio/infra-deployments#12922). These labels are necessary to get an accurate tenant-level metrics.

## Risk Assessment

- Level: Low
- Description: This will just includes some additional labels in the forwarding. No changes to existing labels that are already being forwarded.
- Rollback: Revert this PR.

## Validation

-  These labels are being forwarded for staging clusters per redhat-appstudio/infra-deployments#12874 and redhat-appstudio/infra-deployments#12922. Verified through AppSRE grafana using our staging datasource that those labels are appearing for KAExporter metrics.