### PR TITLE
feat(PVO11Y-5279): Update kaexporter ref for startupProbe

### DIFF
--- a/components/monitoring/exporters/kaexporter/staging/base/kustomization.yaml
+++ b/components/monitoring/exporters/kaexporter/staging/base/kustomization.yaml
@@ -1,9 +1,9 @@
 resources:
   - rbac
   - external-secrets
-  - https://github.com/redhat-appstudio/o11y/config/exporters/monitoring/kaexporter/base?ref=f2a12ad5a81a2723fd8991203c521bea6f42ddc4
+  - https://github.com/redhat-appstudio/o11y/config/exporters/monitoring/kaexporter/base?ref=ba0e3f48c0a85cb0d59a3812faefb4da9cd8f763
 
 images:
   - name: quay.io/redhat-appstudio/o11y
     newName: quay.io/redhat-appstudio/o11y
-    newTag: f2a12ad5a81a2723fd8991203c521bea6f42ddc4
+    newTag: ba0e3f48c0a85cb0d59a3812faefb4da9cd8f763


### PR DESCRIPTION
Updating kaexporter git ref to include changes where startupProbe is set. The startupProbe is needed to give the exporter time to do a cold start-up.