### PR TITLE
feat(PVO11Y-5321): Forward exported_namespace label stg

### DIFF
--- a/components/monitoring/prometheus/staging/base/federation/writeRelabelConfigs.yaml
+++ b/components/monitoring/prometheus/staging/base/federation/writeRelabelConfigs.yaml
@@ -41,4 +41,4 @@
       hostname|label_app_kubernetes_io_managed_by|platform|scrape_job|slice|error|\
       resource_type|gin_errors|\
       metric|label|label_pair|scraped_instance|sharded_instance|instance_namespace|\
-      application|component|build_type|scenario|optional|test_type|automated"
+      application|component|build_type|scenario|optional|test_type|automated|exported_namespace"


### PR DESCRIPTION
We'll need this for KAExporter metrics to label which series are for what Konflux tenants.