### PR TITLE
PVO11Y-5279 Remove honorLabels from kaexporter ServiceMonitor

### DIFF
--- a/components/monitoring/exporters/kaexporter/staging/base/kustomization.yaml
+++ b/components/monitoring/exporters/kaexporter/staging/base/kustomization.yaml
@@ -7,3 +7,11 @@ images:
   - name: quay.io/redhat-appstudio/o11y
     newName: quay.io/redhat-appstudio/o11y
     newTag: ba0e3f48c0a85cb0d59a3812faefb4da9cd8f763
+
+patches:
+  - target:
+      kind: ServiceMonitor
+      name: kaexporter-servicemonitor
+    patch: |
+      - op: remove
+        path: /spec/endpoints/0/honorLabels


### PR DESCRIPTION
## Summary

Patch out `honorLabels: true` from the kaexporter ServiceMonitor in staging.

## Why

With `honorLabels: true`, the exporter's `namespace` label (tenant namespace) overrides the scrape target namespace, causing label conflicts and unexpected metric behavior. Removing it lets Prometheus handle labels with its default behavior while we assess the correct approach for exposing tenant namespace labels.

[PVO11Y-5279](https://redhat.atlassian.net/browse/PVO11Y-5279)

[PVO11Y-5279]: https://redhat.atlassian.net/browse/PVO11Y-5279?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ