### PR TITLE
PVO11Y-5323 Forward Tekton Prometheus TSDB head metrics to RHOBS

### DIFF
--- a/components/monitoring/prometheus/staging/tekton-ms/writeRelabelConfigs.yaml
+++ b/components/monitoring/prometheus/staging/tekton-ms/writeRelabelConfigs.yaml
@@ -13,6 +13,8 @@
       |tekton_pipelines_controller_taskrun_total\
       |tekton_pipelines_controller_running_taskruns\
       |tekton_pipelines_controller_running_taskruns_throttled_by_node\
-      |tekton_pipelines_controller_running_taskruns_throttled_by_quota"
+      |tekton_pipelines_controller_running_taskruns_throttled_by_quota\
+      |prometheus_tsdb_head_series\
+      |prometheus_tsdb_head_chunks"
   - action: LabelKeep
     regex: "__name__|source_environment|source_cluster|namespace|job|instance|pipeline|status|task"


### PR DESCRIPTION
## Summary

- Add `prometheus_tsdb_head_series` and `prometheus_tsdb_head_chunks` to the Tekton MS remote-write Keep allowlist so we can monitor the Tekton Prometheus cardinality from RHOBS. No new labels needed — these metrics only use the base labels already in the LabelKeep regex.

## Risk Assessment

- **Level:** Low
- **Description:** Adds 2 metric names to the existing allowlist. Minimal cardinality increase (2 series per metric).
- **Rollback:** Revert the commit.