### PR TITLE
removing konflux_pipelinerun_status metric - KFLUXINFRA-3577

### DIFF
--- a/components/monitoring/custom-kube-state-metrics/staging/custom-resource-state-config.yaml
+++ b/components/monitoring/custom-kube-state-metrics/staging/custom-resource-state-config.yaml
@@ -66,7 +66,6 @@ data:
             namespace: [metadata, namespace]
             pipeline: [metadata, labels, tekton.dev/pipeline]
             finalizers: [metadata, finalizers]
-            status: [status, conditions, "[type=Succeeded]", reason]
           metrics:
             - name: "konflux_pipelinerun_deletion_timestamp_seconds"
               help: "Unix timestamp when deletion was requested (0 = not deleted). Use > 0 to find stuck PipelineRuns."
@@ -75,14 +74,4 @@ data:
                 gauge:
                   path: [metadata, deletionTimestamp]
                   nilIsZero: true
-        ###############################################################################
-        # Fetchs the concurrent PipelineRuns in an unfinished or Unknown state filtering
-        # the ones with completionTime unset (equal to zero)
-        ###############################################################################
-            - name: "konflux_pipelinerun_status"
-              help: "fetchs PipelineRun completionTime with status label; 0 means still running"
-              each:
-                type: Gauge
-                gauge:
-                  path: [status, completionTime]
-                  nilIsZero: true
+


### PR DESCRIPTION
Removing the metric konflux_pipelinerun_status added in https://github.com/redhat-appstudio/infra-deployments/pull/11933  - [KFLUXINFRA-3577](https://redhat.atlassian.net/browse/KFLUXINFRA-3577):
- O11Y have concerns of this metric saturating unnecessarily Prometheus server, so it would need to be refined a lot, the problem is that at this point was not possible
- The metric is not working anyway
- The kube_resourcequota configured to restrict the amount of PLRs activates a metric that provides the set quota (hard) and current value (used) that serve perfectly for this purpose

[KFLUXINFRA-3577]: https://redhat.atlassian.net/browse/KFLUXINFRA-3577?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ