### PR TITLE
feat: Add kargo ring deployments universal layout

### DIFF
--- a/docs/ring-deployments/architecture.md
+++ b/docs/ring-deployments/architecture.md
@@ -1,0 +1,838 @@
+# Kargo-Based Ring Deployments for Konflux
+
+> **Warning**
+> Ring deployments are still under active development. This documentation may change as the implementation evolves.
+
+Ring-based promotion pipeline for [infra-deployments](https://github.com/redhat-appstudio/infra-deployments) and [infra-common-deployments](https://github.com/redhat-appstudio/infra-common-deployments) using [Kargo](https://kargo.io).
+
+## Table of Contents
+
+1. [Objective](#1-objective)
+2. [Motivation](#2-motivation)
+3. [Proposed Architecture](#3-proposed-architecture)
+   - 3.1 [Kargo Project and Pipeline Structure](#31-kargo-project-and-pipeline-structure)
+   - 3.2 [Cluster Segmentation Strategy](#32-cluster-segmentation-strategy)
+   - 3.3 [CI and Artifact Ingestion](#33-ci-and-artifact-ingestion)
+   - 3.4 [Ring 0 — Development](#34-ring-0--development-automated-inner-loop)
+   - 3.5 [Ring 1 — Staging](#35-ring-1--staging-convergence-and-extended-verification)
+   - 3.6 [Ring N to N+1 — Gated Production](#36-ring-n-to-n1--gated-production-promotion)
+   - 3.7 [Verification Strategy](#37-verification-strategy)
+   - 3.8 [Rollback and Reliability](#38-rollback-and-reliability)
+   - 3.9 [Observability and Auditability](#39-observability-and-auditability)
+4. [Component Interaction Model](#4-component-interaction-model)
+5. [Freight Lifecycle](#5-freight-lifecycle)
+6. [Kargo Resource Examples](#6-kargo-resource-examples)
+7. [Failure Mode Analysis](#7-failure-mode-analysis)
+8. [Definitions](#8-definitions)
+
+---
+
+## 1. Objective
+
+Implement an automated, ring-based deployment pipeline for Konflux components using [Kargo](https://kargo.io) to improve deployment safety, reduce manual effort, and ensure continuous availability. The pipeline leverages Kargo's native promotion engine—Warehouses, Freight, Stages, and Promotions—to model ring-based progressive delivery as a first-class GitOps workflow.
+
+---
+
+## 2. Motivation
+
+Without ring-based delivery, changes to Konflux components would be promoted to all production clusters simultaneously after staging validation. That model is:
+
+- **Time-consuming**: Each promotion requires human coordination across multiple clusters.
+- **Error-prone**: Manual steps introduce configuration drift and inconsistency.
+- **High-risk**: A broken deployment affects all clusters simultaneously. Rollback is particularly dangerous because the broken version of Konflux may be required to build and ship the fix itself—creating a circular dependency where the deployment tool is degraded by its own deployment.
+
+### Without Rings vs. With Rings
+
+```mermaid
+graph LR
+    subgraph "Without Rings"
+        A[Developer Merge] --> B[Manual Staging Deploy]
+        B --> C[Manual Validation]
+        C --> D[Simultaneous Production Deploy to ALL Clusters]
+        D --> E{Problem?}
+        E -->|Yes| F["Manual Rollback (All Clusters)"]
+        E -->|No| G[Done]
+    end
+
+    style D fill:#ff6b6b,color:#fff
+    style F fill:#ff6b6b,color:#fff
+```
+
+```mermaid
+graph LR
+    subgraph "With Rings"
+        A2[Developer Merge] --> B2[Auto Ring 0 Dev]
+        B2 --> C2[Auto Ring 1 Staging]
+        C2 --> D2[Gated Ring N Prod]
+        D2 --> E2[Gated Ring N+1 Critical Prod]
+        E2 --> F2{Problem at any ring?}
+        F2 -->|Yes| G2["Rollback affected ring only"]
+        F2 -->|No| H2[Done]
+    end
+
+    style B2 fill:#51cf66,color:#fff
+    style C2 fill:#51cf66,color:#fff
+    style D2 fill:#ffd43b,color:#000
+    style E2 fill:#ffd43b,color:#000
+```
+
+A ring-based model isolates blast radius, preserves build infrastructure availability, and automates the promotion lifecycle while retaining human oversight at critical boundaries.
+
+---
+
+## 3. Proposed Architecture
+
+### 3.1 Kargo Project and Pipeline Structure
+
+Each Konflux infrastructure repository is modeled as a **Kargo Project**—the unit of tenancy that scopes all pipeline resources (Warehouses, Stages, Promotions, Freight) to a single Kubernetes namespace. The two primary Kargo Projects map to the existing infrastructure repos:
+
+- **[infra-deployments](https://github.com/redhat-appstudio/infra-deployments)** — Application-level component deployments (Konflux services, operators, controllers).
+- **[infra-common-deployments](https://github.com/redhat-appstudio/infra-common-deployments)** — Shared infrastructure and platform-level resources (cluster config, RBAC, networking, observability).
+
+This separation provides:
+
+- **Isolation**: RBAC boundaries per infrastructure repository pipeline.
+- **Independent Cadence**: Application components and shared infrastructure advance through rings at their own pace without blocking each other.
+- **Auditability**: All promotion activity is scoped and queryable per project.
+
+Both repositories follow a **canonical directory layout** that ensures every component is structured identically across all rings and clusters. Kargo PromotionTasks write to a single, computable path per ring — the Tier 2 ring base (`components/{component}/rings/ring-N/base/kustomization.yaml`). For the full directory standard, tier definitions, and Kustomize layering rules, see the [Canonical Directory Layout](directory-layout.md) specification.
+
+Within each Project, the ring topology is modeled as a directed acyclic graph (DAG) of **Stages**, where each Stage represents a ring (or a subset of clusters within a ring). Freight flows from inner rings to outer rings through automated or gated Promotions.
+
+```mermaid
+graph TD
+    subgraph "Kargo Project: konflux-component-x"
+        WH["Warehouse<br/>(Quay + Helm + Git)"]
+
+        WH --> R0["Stage: ring-0-dev<br/>AutoPromote: ✅<br/>Soak: none"]
+
+        R0 --> R1["Stage: ring-1-staging<br/>AutoPromote: ✅<br/>Soak: none"]
+
+        R1 --> RN["Stage: ring-n-prod<br/>AutoPromote: ❌<br/>Approval: required<br/>Soak: 24h"]
+
+        RN --> RN1["Stage: ring-n1-critical<br/>AutoPromote: ❌<br/>Approval: required<br/>Soak: 72h"]
+    end
+
+    style WH fill:#4dabf7,color:#fff
+    style R0 fill:#51cf66,color:#fff
+    style R1 fill:#94d82d,color:#fff
+    style RN fill:#ffd43b,color:#000
+    style RN1 fill:#ff922b,color:#fff
+```
+
+### 3.2 Cluster Segmentation Strategy
+
+Rings are defined by a risk-based grouping strategy. Clusters are assigned to specific rings based on blast-radius potential and workload criticality:
+
+| Ring | Scope | Criteria | Gate | Soak |
+|------|-------|----------|------|------|
+| **Ring 0** | Development | Low tenant impact, fast feedback loops | Fully automated | None |
+| **Ring 1** | Staging | Pre-production validation, broader integration testing, Argo CD sync/health validation, production metric comparison (memory, CPU, latency baselines) | Automated with verification gates | None |
+| **Ring N** | Non-critical Production | Moderate tenant count, no self-hosting dependencies | Manual approval + soak period | 24h |
+| **Ring N+1** | Critical Production | High-risk tenants (e.g., RHEL), mission-critical workloads, self-hosting infrastructure | Manual approval + extended soak | 72h |
+
+```mermaid
+graph LR
+    subgraph "Ring 0 — Development"
+        D1[dev-cluster]
+    end
+
+    subgraph "Ring 1 — Staging"
+        S1[stone-stg-rh01]
+        S2[stone-stage-p01]
+        S3[kflux-stg-es01]
+    end
+
+    subgraph "Ring N — Non-critical Prod"
+        P1[prod-cluster-a]
+        P2[prod-cluster-b]
+        P3[prod-cluster-c]
+    end
+
+    subgraph "Ring N+1 — Critical Prod"
+        C1["kflux-rhel-p01 (RHEL builds)"]
+        C2["kflux-prd-rh02 (Konflux self-host)"]
+    end
+
+    style D1 fill:#51cf66,color:#fff
+    style S1 fill:#94d82d,color:#fff
+    style S2 fill:#94d82d,color:#fff
+    style S3 fill:#94d82d,color:#fff
+    style P1 fill:#ffd43b,color:#000
+    style P2 fill:#ffd43b,color:#000
+    style P3 fill:#ffd43b,color:#000
+    style C1 fill:#ff922b,color:#fff
+    style C2 fill:#ff922b,color:#fff
+```
+
+### 3.3 CI and Artifact Ingestion
+
+The pipeline begins with artifact creation and discovery:
+
+**Code Merge & Build**: Merging a component change triggers a Konflux build pipeline, producing versioned container images, Helm charts, and/or Git manifest commits.
+
+**Kargo Warehouse**: A Warehouse is configured per artifact source (OCI registry, Helm repository, or Git repository). Each Warehouse defines **subscriptions** that specify:
+
+- The artifact source URL (e.g., Quay registry, Helm repo, Git repo)
+- The discovery strategy: **SemVer** (semantic version ordering), **Lexical** (string-based), **Digest** (content-addressable), or **NewestBuild** (timestamp-based)
+- Optional filtering (e.g., SemVer constraints, path filters, allow/ignore lists)
+- The polling interval (default: 5 minutes)
+
+**Freight Creation**: When a Warehouse detects new artifact versions matching its subscriptions, it generates a new **Freight**—an immutable, content-addressed bundle that captures the exact combination of:
+
+- Container image references (registry + tag + digest)
+- Helm chart references (repository + name + version)
+- Git commit references (repository URL + branch + commit SHA)
+
+Freight is identified by a SHA-1 hash of its origin Warehouse and artifact versions, ensuring that identical inputs always produce the same Freight ID. This guarantees reproducibility and makes promotion decisions deterministic.
+
+The Warehouse's `FreightCreationPolicy` controls whether Freight is created automatically upon discovery or requires an explicit manual trigger.
+
+A Git-subscription Warehouse can also detect changes in the `new-base/` directory — a ring-safe mechanism for promoting Tier 1 (`base/`) changes. Kargo copies `new-base/` ring-by-ring and renames it to `base/` at the destination, avoiding the all-rings-at-once merge path. See [Canonical Directory Layout — Tier 1](directory-layout.md#41-tier-1--component-base) for details.
+
+```mermaid
+sequenceDiagram
+    participant Dev as Developer
+    participant KFX as Konflux Build
+    participant Quay as Quay Registry
+    participant WH as Kargo Warehouse
+    participant FR as Freight
+
+    Dev->>KFX: Merge PR
+    KFX->>Quay: Push image v1.2.3
+    KFX->>Quay: Push Helm chart v1.2.3
+
+    loop Every 5 minutes
+        WH->>Quay: Poll for new versions
+        Quay-->>WH: New image v1.2.3 detected
+    end
+
+    WH->>FR: Create Freight (SHA: abc123)
+    Note over FR: Immutable bundle:<br/>Image: quay.io/konflux/comp:v1.2.3<br/>Chart: konflux-comp-1.2.3<br/>Commit: main@a1b2c3d
+```
+
+### 3.4 Ring 0 — Development (Automated Inner Loop)
+
+Ring 0 targets development clusters with **auto-promotion enabled**. When new Freight appears from the Warehouse, the pipeline proceeds automatically:
+
+1. **Auto-Promotion**: The Stage's promotion policy (`autoPromotionEnabled: true`) triggers a Promotion immediately when new Freight is available. The selection strategy (`NewestFreight`) ensures the latest verified Freight is promoted.
+
+2. **Promotion Execution**: Kargo creates a **Promotion** resource and executes its ordered **promotion steps**. For GitOps-based deployments, a typical step sequence is:
+   - `git-clone` — Clone the environment's configuration repository
+   - `yaml-update` / `kustomize-set-image` / `helm-template` — Update manifests to reference the new Freight's artifact versions
+   - `git-commit` + `git-push` — Commit and push the changes
+   - `git-open-pr` — Open a Pull Request against the target branch
+   - `git-merge-pr` — Merge the PR
+
+3. **Verification**: After the Promotion succeeds, the Stage runs **Verification** using Argo Rollouts AnalysisRuns. These can execute:
+   - Smoke tests and integration tests
+   - Health endpoint checks
+   - Custom metric queries (Prometheus, Datadog, etc.)
+   - Webhook-based external test triggers
+
+4. **Freight Marked as Verified**: Upon successful verification, the Freight's status is updated to record `VerifiedIn: ring-0-dev`, making it eligible for promotion to Ring 1.
+
+Promotions within a Stage are **serialized**—only one Promotion runs at a time per Stage, with subsequent Promotions queued by creation time. This prevents deployment collisions and ensures each release completes its full verification cycle before the next begins.
+
+```mermaid
+sequenceDiagram
+    participant FR as Freight (v1.2.3)
+    participant S0 as Stage: ring-0-dev
+    participant PR as Promotion
+    participant Git as Git Repo
+    participant ArgoCD as Argo CD
+    participant VER as Verification
+
+    FR->>S0: New Freight available
+    S0->>PR: Auto-create Promotion
+
+    activate PR
+    PR->>Git: git-clone
+    PR->>Git: yaml-update (image → v1.2.3)
+    PR->>Git: git-commit + git-push
+    PR->>Git: git-open-pr
+    PR->>Git: git-merge-pr
+    Git-->>PR: PR merged
+    deactivate PR
+
+    PR->>VER: Trigger AnalysisRun
+    activate VER
+    VER->>VER: Run smoke tests
+    VER->>VER: Check health endpoints
+    VER-->>FR: Mark VerifiedIn: ring-0-dev ✅
+    deactivate VER
+```
+
+### 3.5 Ring 1 — Staging (Convergence and Extended Verification)
+
+Ring 1 targets staging clusters and accepts Freight that has been `VerifiedIn` Ring 0. This ring validates changes under more realistic conditions before any production exposure.
+
+When multiple upstream Stages exist (e.g., multiple Ring 0 environments), the Stage's **availability strategy** determines the gate:
+
+- `All` — Freight must be verified in every upstream Stage before it becomes available.
+- `OneOf` — Verification in any single upstream Stage is sufficient.
+
+Promotion in Ring 1 may be auto-promoted or require manual trigger depending on the risk profile. The promotion step sequence mirrors Ring 0 but targets Ring 1's cluster configuration repositories.
+
+After promotion, Ring 1 runs its own verification suite—typically broader integration tests that validate cross-component interactions under more realistic conditions.
+
+### 3.6 Ring N to N+1 — Gated Production Promotion
+
+Outer rings introduce two additional gates:
+
+**Manual Approval**: Freight must be explicitly approved before it can be promoted to a production ring. Approval is recorded at the Freight level (`Freight.Status.ApprovedFor[stage-name]`) and can be granted by authorized users through the Kargo UI, CLI, or API. Approval can also bypass upstream verification requirements when emergency hotfixes are needed.
+
+**Soak Period**: Each Stage can define a `RequiredSoakTime` (e.g., `24h`, `72h`). Freight must remain stable in the current ring for the specified duration before becoming eligible for the next ring. The soak timer starts when the Freight is first deployed to the Stage (`CurrentlyIn` timestamp) and is tracked continuously. This ensures:
+
+- Long-tail issues (memory leaks, gradual degradation, intermittent failures) surface before wider rollout.
+- The system observes real-world load patterns across business cycles (daily peaks, batch jobs, etc.).
+- Confidence in the release increases proportionally with exposure time.
+
+The combination of manual approval and soak periods creates a layered defense: automated systems validate functional correctness, while human judgment and time-based observation validate operational stability.
+
+```mermaid
+sequenceDiagram
+    participant FR as Freight (v1.2.3)
+    participant RN as Stage: ring-n-prod
+    participant OP as Operator
+    participant SOAK as Soak Timer
+    participant RN1 as Stage: ring-n1-critical
+
+    Note over FR: VerifiedIn: ring-1-staging ✅
+
+    FR->>RN: Available for promotion
+    OP->>FR: Manual Approval for ring-n-prod
+    RN->>RN: Execute Promotion steps
+    RN-->>FR: Mark CurrentlyIn: ring-n-prod
+
+    activate SOAK
+    SOAK->>SOAK: 24h soak period begins
+    Note over SOAK: Monitor: error rates,<br/>latency, resource usage
+    SOAK-->>FR: Soak complete → VerifiedIn: ring-n-prod ✅
+    deactivate SOAK
+
+    FR->>RN1: Available for promotion
+    OP->>FR: Manual Approval for ring-n1-critical
+    RN1->>RN1: Execute Promotion steps
+
+    activate SOAK
+    SOAK->>SOAK: 72h soak period begins
+    SOAK-->>FR: Soak complete → VerifiedIn: ring-n1-critical ✅
+    deactivate SOAK
+
+    Note over FR: Fully promoted across all rings
+```
+
+### 3.7 Verification Strategy
+
+Verification is a first-class concept in Kargo, executed after each successful Promotion via Argo Rollouts AnalysisRuns. The verification strategy should be tiered by ring:
+
+| Ring | Verification Scope | Examples | Duration |
+|------|-------------------|----------|----------|
+| Ring 0 | Functional correctness | Unit test suites, API contract tests, build pipeline smoke tests | ~10 min |
+| Ring 1 | Integration stability | Cross-component integration tests, end-to-end workflow validation | ~30 min |
+| Ring N | Operational readiness | Performance baselines, error rate thresholds, SLO compliance checks | 24h soak |
+| Ring N+1 | Self-hosting integrity | Konflux's ability to build and promote its own components | 72h soak |
+
+Each verification produces a pass/fail result. Failed verification prevents the Freight from being marked as `VerifiedIn` for that Stage, blocking downstream promotion automatically.
+
+```mermaid
+graph TD
+    subgraph "Verification Pipeline per Ring"
+        V1["Pre-Promotion Checks<br/>(CI on PR)"]
+        V2["Post-Promotion Health<br/>(Argo CD Sync Status)"]
+        V3["AnalysisRun<br/>(Argo Rollouts)"]
+        V4["Soak Period<br/>(Time-based)"]
+
+        V1 --> V2 --> V3 --> V4
+    end
+
+    V4 -->|All Pass| PASS["VerifiedIn: stage ✅"]
+    V3 -->|Fail| FAIL["Blocked ❌<br/>No downstream promotion"]
+    V4 -->|Degradation during soak| FAIL
+
+    style PASS fill:#51cf66,color:#fff
+    style FAIL fill:#ff6b6b,color:#fff
+```
+
+### 3.8 Rollback and Reliability
+
+Kargo does not have a dedicated "rollback" primitive. Instead, rollback is achieved by **creating a new Promotion to a previously verified Freight**. This is architecturally consistent: every state change is a forward promotion through the same pipeline, ensuring auditability and avoiding out-of-band state mutations.
+
+**Standard Rollback**: Identify the last known-good Freight from the Stage's Freight history (`Stage.Status.FreightHistory`). Create a new Promotion targeting that Freight. The promotion executes the same step sequence, updating manifests to reference the previous artifact versions. Only the affected ring is rolled back — downstream rings that haven't received the bad promotion are unaffected.
+
+```bash
+# Promote a specific known-good Freight to a Stage (rollback)
+kargo promote --project <project> --freight <freight-id> --stage <stage>
+
+# Or reference by alias
+kargo promote --project <project> --freight-alias <alias> --stage <stage>
+```
+
+**Emergency Hotfix Path**: For critical failures where the standard pipeline is too slow or where Konflux itself is degraded:
+
+1. Authorized operators can **manually approve** Freight for any Stage, bypassing upstream verification and soak requirements. This lets Freight skip intermediate rings entirely.
+2. The hotfix Freight is promoted directly to the affected ring(s) using the same promotion steps, maintaining GitOps consistency.
+3. This path is audited — manual approvals are recorded with timestamps and approver identity in the Freight status (`Freight.Status.ApprovedFor`).
+
+```bash
+# Manually approve Freight for a Stage (bypasses pipeline gates)
+kargo approve --project <project> --freight <freight-id> --stage <stage>
+```
+
+**Via the Kargo UI**: click the three dots on the Freight in the timeline → "Manually Approve" → select the target Stage → "Approve". Then promote by clicking the truck icon on the Stage header → "Promote" → select the approved Freight → confirm.
+
+Approval does not automatically create a Promotion — it only marks the Freight as eligible. A separate promotion (manual or auto) is still required.
+
+**Reverification**: If a verification process fails or is inconclusive, it can be re-run on demand without re-promoting:
+
+```bash
+kargo verify stage <stage> --project <project>
+
+# Abort a running verification
+kargo verify stage <stage> --project <project> --abort
+```
+
+**Abort In-Flight Promotions**: Running Promotions can be aborted via the `kargo.akuity.io/abort` annotation. This immediately halts step execution, marks the Promotion as `Aborted`, and frees the Stage to accept the next queued Promotion (e.g., a rollback).
+
+```mermaid
+flowchart TD
+    INCIDENT["🚨 Incident Detected"]
+    INCIDENT --> ASSESS{Severity?}
+
+    ASSESS -->|Standard| STD["Standard Rollback"]
+    STD --> FIND["Find last-known-good Freight<br/>from Stage.Status.FreightHistory"]
+    FIND --> PROMOTE["Create new Promotion<br/>targeting previous Freight"]
+    PROMOTE --> EXEC["Execute same promotion steps<br/>(git-update → PR → ArgoCD sync)"]
+
+    ASSESS -->|Critical / Konflux degraded| EMRG["Emergency Hotfix"]
+    EMRG --> ABORT["Abort in-flight Promotion<br/>(kargo.akuity.io/abort)"]
+    ABORT --> APPROVE["Manual Freight Approval<br/>(bypasses all gates)"]
+    APPROVE --> DIRECT["Direct promote to<br/>affected ring(s)"]
+    DIRECT --> AUDIT["Audit trail recorded<br/>in Freight.Status"]
+
+    style INCIDENT fill:#ff6b6b,color:#fff
+    style EMRG fill:#ff922b,color:#fff
+    style STD fill:#ffd43b,color:#000
+```
+
+### 3.9 Observability and Auditability
+
+Kargo provides built-in observability through its resource status model:
+
+- **Freight Status**: Tracks which Stages a Freight is `CurrentlyIn`, `VerifiedIn`, and `ApprovedFor`—providing a real-time map of what version is deployed where and its verification state.
+- **Promotion History**: Each Stage records its `CurrentPromotion` and `LastPromotion`, along with the full `FreightHistory` of recent deployments.
+- **Step-level Telemetry**: Promotion status includes per-step execution metadata: start/finish times, retry counts, error messages, and state carried between reconciliation cycles.
+
+Additional observability requirements:
+
+- Grafana dashboards for ring transition latency, promotion success rates, and soak period compliance.
+- Alerting on promotion failures, verification failures, and Freight stuck in a ring beyond expected soak windows.
+- Integration with existing Konflux monitoring for correlated deployment-to-incident analysis.
+
+```mermaid
+graph LR
+    subgraph "Data Sources"
+        KS["Kargo Status<br/>(Freight, Promotion, Stage)"]
+        AC["Argo CD<br/>(Sync + Health)"]
+        AR["Argo Rollouts<br/>(AnalysisRun results)"]
+        PM["Prometheus<br/>(App metrics)"]
+    end
+
+    subgraph "Observability Layer"
+        GF["Grafana Dashboards"]
+        AL["Alert Manager"]
+    end
+
+    subgraph "Dashboards"
+        D1["Ring Transition Map"]
+        D2["Freight Lineage"]
+        D3["Promotion Success Rate"]
+        D4["Soak Period Tracker"]
+    end
+
+    KS --> GF
+    AC --> GF
+    AR --> GF
+    PM --> GF
+    KS --> AL
+    GF --> D1
+    GF --> D2
+    GF --> D3
+    GF --> D4
+```
+
+---
+
+## 4. Component Interaction Model
+
+This section maps how Kargo resources interact with external systems during the promotion lifecycle.
+
+```mermaid
+graph TB
+    subgraph "External Systems"
+        QUAY["Quay.io<br/>(OCI Registry)"]
+        HELM["Helm Repo"]
+        GITREPO["Git Repo<br/>(Manifests)"]
+        ROLLOUTS["Argo Rollouts"]
+    end
+
+    subgraph "Kargo Control Plane"
+        WH["Warehouse Controller"]
+        SC["Stage Controller"]
+        PC["Promotion Controller"]
+        ORCH["Promotion Orchestrator"]
+    end
+
+    subgraph "Kargo Resources (per Project namespace)"
+        WHR["Warehouse"]
+        FRT["Freight"]
+        STG["Stage"]
+        PRM["Promotion"]
+        PCT["ProjectConfig"]
+    end
+
+    QUAY -.->|subscribe| WH
+    HELM -.->|subscribe| WH
+    GITREPO -.->|subscribe| WH
+
+    WH -->|creates| FRT
+    WH -->|reconciles| WHR
+
+    SC -->|reconciles| STG
+    SC -->|checks Freight availability| FRT
+    SC -->|creates Promotion<br/>if auto-promote| PRM
+    SC -->|reads policies| PCT
+
+    PC -->|reconciles| PRM
+    PC -->|delegates to| ORCH
+
+    ORCH -->|git-clone, git-push, git-open-pr, git-merge-pr| GITREPO
+
+    SC -->|creates AnalysisRun| ROLLOUTS
+    ROLLOUTS -->|verification result| FRT
+
+    style WH fill:#4dabf7,color:#fff
+    style SC fill:#4dabf7,color:#fff
+    style PC fill:#4dabf7,color:#fff
+    style ORCH fill:#4dabf7,color:#fff
+```
+
+### Data Flow Summary
+
+| Step | Source | Action | Target | Trigger |
+|------|--------|--------|--------|---------|
+| 1 | Quay / Helm / Git | Poll for new versions | Warehouse | Timer (5m interval) |
+| 2 | Warehouse | Create immutable Freight | Freight | New artifact detected |
+| 3 | Stage Controller | Check Freight availability | Freight Status | Freight creation event |
+| 4 | Stage Controller | Create Promotion | Promotion | Auto-promote policy or manual |
+| 5 | Promotion Controller | Execute promotion steps | Git Repo, Argo CD | Promotion created |
+| 6 | Argo CD | Sync manifests to cluster | Kubernetes | Git repo updated |
+| 7 | Stage Controller | Create AnalysisRun | Argo Rollouts | Promotion succeeded |
+| 8 | Argo Rollouts | Report verification result | Freight Status | AnalysisRun complete |
+
+---
+
+## 5. Freight Lifecycle
+
+Freight is the central artifact in the promotion pipeline. Its status transitions drive the entire ring progression.
+
+### State Machine
+
+```mermaid
+stateDiagram-v2
+    [*] --> Created: Warehouse discovers new artifacts
+
+    Created --> CurrentlyIn_Ring0: Auto-Promotion to Ring 0
+    CurrentlyIn_Ring0 --> VerifiedIn_Ring0: Verification passes
+
+    VerifiedIn_Ring0 --> CurrentlyIn_Ring1: Auto-Promotion to Ring 1
+    CurrentlyIn_Ring1 --> VerifiedIn_Ring1: Verification passes
+
+    VerifiedIn_Ring1 --> ApprovedFor_RingN: Manual approval granted
+    ApprovedFor_RingN --> CurrentlyIn_RingN: Promotion executes
+    CurrentlyIn_RingN --> VerifiedIn_RingN: Soak period (24h) passes + healthy
+
+    VerifiedIn_RingN --> ApprovedFor_RingN1: Manual approval granted
+    ApprovedFor_RingN1 --> CurrentlyIn_RingN1: Promotion executes
+    CurrentlyIn_RingN1 --> VerifiedIn_RingN1: Soak period (72h) passes + healthy
+
+    VerifiedIn_RingN1 --> [*]: Fully rolled out
+
+    CurrentlyIn_Ring0 --> Superseded: Newer Freight promoted, replacing this one
+    CurrentlyIn_Ring1 --> Superseded: Newer Freight promoted, replacing this one
+    CurrentlyIn_RingN --> Superseded: Rollback promotes older Freight, replacing this one
+
+    note right of Created
+        Immutable, content-addressed
+        SHA-1(origin + artifact versions)
+    end note
+
+    note right of ApprovedFor_RingN
+        Approval can bypass upstream
+        verification for hotfixes
+    end note
+```
+
+### Status Fields Reference
+
+```
+Freight.Status:
+├── CurrentlyIn:           # Map of Stages where Freight is actively deployed
+│   └── <stage-name>:
+│       └── Since: <timestamp>     # Used for soak time calculation
+│
+├── VerifiedIn:            # Map of Stages where verification + soak passed
+│   └── <stage-name>:
+│       └── LongestCompletedSoak: <duration>
+│
+├── ApprovedFor:           # Map of Stages with manual approval
+│   └── <stage-name>:
+│       └── ApprovedAt: <timestamp>
+│
+└── Metadata:              # Arbitrary key-value data shared across steps/stages
+```
+
+---
+
+## 6. Kargo Resource Examples
+
+### 6.1 Warehouse — Image Subscription
+
+```yaml
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Warehouse
+metadata:
+  name: konflux-component-x
+  namespace: konflux-component-x
+spec:
+  interval: 5m
+  freightCreationPolicy: Automatic
+  subscriptions:
+    - image:
+        repoURL: quay.io/konflux/component-x
+        semverConstraint: ">=1.0.0"
+        discoveryLimit: 5
+    - chart:
+        repoURL: https://charts.konflux.dev
+        name: component-x
+        semverConstraint: ">=1.0.0"
+```
+
+### 6.2 Stage — Ring 0 (Development, Auto-Promote)
+
+```yaml
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Stage
+metadata:
+  name: ring-0-dev
+  namespace: konflux-component-x
+spec:
+  requestedFreight:
+    - origin:
+        kind: Warehouse
+        name: konflux-component-x
+      sources:
+        direct: true
+  promotionTemplate:
+    spec:
+      steps:
+        - uses: git-clone
+          config:
+            repoURL: https://github.com/redhat-appstudio/infra-deployments
+            checkout:
+              branch: main
+            path: ./src
+        - uses: kustomize-set-image
+          config:
+            path: ./src/components/component-x/rings/ring-0/base
+            images:
+              - image: quay.io/konflux/component-x
+        - uses: git-commit
+          config:
+            path: ./src
+            message: "chore: promote component-x to dev"
+        - uses: git-push
+          config:
+            path: ./src
+        - uses: git-open-pr
+          config:
+            repoURL: https://github.com/redhat-appstudio/infra-deployments
+            sourceBranch: kargo/ring-0-dev/promotion
+            targetBranch: main
+            createTargetBranch: false
+        - uses: git-merge-pr
+          config:
+            repoURL: https://github.com/redhat-appstudio/infra-deployments
+            provider: github
+  verification:
+    analysisTemplates:
+      - name: smoke-tests
+    analysisRunMetadata:
+      labels:
+        ring: "0"
+        env: development
+---
+apiVersion: kargo.akuity.io/v1alpha1
+kind: ProjectConfig
+metadata:
+  name: konflux-component-x
+  namespace: konflux-component-x
+spec:
+  promotionPolicies:
+    - stage: ring-0-dev
+      autoPromotionEnabled: true
+```
+
+### 6.3 Stage — Ring N (Production, Gated)
+
+```yaml
+apiVersion: kargo.akuity.io/v1alpha1
+kind: Stage
+metadata:
+  name: ring-n-prod
+  namespace: konflux-component-x
+spec:
+  requestedFreight:
+    - origin:
+        kind: Warehouse
+        name: konflux-component-x
+      sources:
+        stages:
+          - ring-1-staging
+      requiredSoakTime: 24h
+  promotionTemplate:
+    spec:
+      steps:
+        - uses: git-clone
+          config:
+            repoURL: https://github.com/redhat-appstudio/infra-deployments
+            checkout:
+              branch: main
+            path: ./src
+        - uses: kustomize-set-image
+          config:
+            path: ./src/components/component-x/rings/ring-n/base
+            images:
+              - image: quay.io/konflux/component-x
+        - uses: git-commit
+          config:
+            path: ./src
+            message: "chore: promote component-x to prod ring-n"
+        - uses: git-push
+          config:
+            path: ./src
+        - uses: git-open-pr
+          config:
+            repoURL: https://github.com/redhat-appstudio/infra-deployments
+            sourceBranch: kargo/ring-n-prod/promotion
+            targetBranch: main
+        - uses: git-merge-pr
+          config:
+            repoURL: https://github.com/redhat-appstudio/infra-deployments
+            provider: github
+  verification:
+    analysisTemplates:
+      - name: slo-compliance-check
+      - name: error-rate-threshold
+---
+apiVersion: kargo.akuity.io/v1alpha1
+kind: ProjectConfig
+metadata:
+  name: konflux-component-x
+  namespace: konflux-component-x
+spec:
+  promotionPolicies:
+    - stage: ring-n-prod
+      autoPromotionEnabled: false   # Requires manual approval
+```
+
+### 6.4 AnalysisTemplate — Smoke Tests
+
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: AnalysisTemplate
+metadata:
+  name: smoke-tests
+  namespace: konflux-component-x
+spec:
+  metrics:
+    - name: smoke-test-suite
+      provider:
+        job:
+          spec:
+            backoffLimit: 0
+            template:
+              spec:
+                containers:
+                  - name: tests
+                    image: quay.io/konflux/test-runner:latest
+                    command: ["/bin/sh", "-c"]
+                    args:
+                      - |
+                        run-smoke-tests --target=$STAGE_URL
+                restartPolicy: Never
+      count: 1
+      successCondition: result.exitCode == 0
+      failureLimit: 0
+```
+
+---
+
+## 7. Failure Mode Analysis
+
+This section catalogs expected failure scenarios and the system's behavior in each case.
+
+| Failure Mode | Impact | Detection | Automated Response | Human Action Required |
+|-------------|--------|-----------|-------------------|----------------------|
+| **Promotion step fails** (e.g., PR conflict) | Blocked promotion in one ring | Promotion phase → `Failed` | Retry on next reconciliation. Queue preserves ordering. | Investigate and resolve conflict; re-trigger Promotion |
+| **Verification fails** (AnalysisRun) | Freight not marked `VerifiedIn`; downstream rings blocked | AnalysisRun phase → `Failed` | No downstream promotion occurs automatically | Review test results; fix component or adjust test thresholds |
+| **Soak period degradation** | Freight fails stability check during soak | Metric thresholds breached | Freight remains `CurrentlyIn` but never reaches `VerifiedIn` | Initiate rollback via new Promotion to previous Freight |
+| **Argo CD sync failure** | Cluster out of desired state | ArgoCD Application reports `OutOfSync` or `Degraded` | ArgoCD retries sync automatically | Check Argo CD Application health; resolve sync errors |
+| **Warehouse polling failure** | New artifacts not discovered | Warehouse status shows error | Retries on next interval | Check registry credentials and connectivity |
+| **Concurrent Freight arrival** | Multiple Freight compete for same Stage | Normal operation — queue serializes | Only one Promotion runs; next waits | None — by design |
+| **Self-hosting ring failure** | Konflux cannot build fixes | Ring N+1 health checks fail | Inner rings unaffected (still on previous version) | Use emergency hotfix path: manual approval + direct promote |
+| **Controller crash / restart** | Temporary reconciliation pause | Kubernetes pod restart | Controller resumes from persisted state (Promotion.Status.State) | Monitor controller pod health |
+
+### Self-Hosting Circular Dependency — Mitigation
+
+The most critical failure mode is when a bad release reaches the self-hosting ring (Ring N+1), degrading Konflux's ability to build the fix:
+
+```mermaid
+flowchart TD
+    BAD["Bad release reaches Ring N+1<br/>(self-hosting clusters)"]
+    BAD --> Q1{Can Konflux still build?}
+
+    Q1 -->|Yes, partially| FIX1["Build fix using degraded Konflux"]
+    FIX1 --> PROMOTE1["Promote fix through rings<br/>(may skip gates via manual approval)"]
+
+    Q1 -->|No, fully broken| FIX2["Use pre-built emergency image<br/>or build from external CI"]
+    FIX2 --> APPROVE["Manual Freight approval<br/>bypasses all gates"]
+    APPROVE --> DIRECT["Direct promote fix<br/>to Ring N+1"]
+    DIRECT --> RESTORE["Self-hosting restored"]
+    RESTORE --> NORMAL["Resume normal pipeline<br/>for remaining rings"]
+
+    style BAD fill:#ff6b6b,color:#fff
+    style RESTORE fill:#51cf66,color:#fff
+```
+
+**Key design constraint**: Ring N+1 (self-hosting) always receives releases last. Even if every other ring is updated, the build infrastructure stays on the prior known-good version until the new release has soaked for 72+ hours in production.
+
+---
+
+## 8. Definitions
+
+| Term | Definition |
+|------|-----------|
+| **Project** | The unit of tenancy in Kargo. A cluster-scoped resource associated with a Kubernetes namespace that contains all pipeline resources (Warehouses, Stages, Promotions, Freight) for a component or group of components. |
+| **Warehouse** | A Kargo resource that monitors external artifact sources—OCI registries, Helm repositories, Git repositories—for new versions. Warehouses define subscriptions with discovery strategies (SemVer, Lexical, Digest) and produce Freight when new artifacts are detected. |
+| **Freight** | An immutable, content-addressed "unit of release" produced by a Warehouse. Encapsulates the exact versions of container images, Helm charts, and Git commits that constitute a deployable change. Freight carries provenance metadata and tracks its verification and approval status across all Stages. |
+| **Stage** | A promotion target representing a logical deployment environment or ring. Stages define what Freight they accept (from which Warehouses or upstream Stages), how to promote it (promotion step templates), and how to verify it (AnalysisRun templates). Stages form a DAG that models the ring topology. |
+| **Promotion** | A request to deploy a specific Freight to a specific Stage. Promotions execute an ordered sequence of steps (Git operations, Argo CD updates, Helm operations, etc.) and are serialized per Stage to prevent conflicts. |
+| **PromotionTask** | A reusable, parameterized sequence of promotion steps defined as a Kargo CRD (`PromotionTask` or `ClusterPromotionTask`). Each component has its own PromotionTask per ring, defining how Kargo updates the Git repo for that component. The canonical directory layout keeps PromotionTask definitions simple — the target path is computable from `{component}` and `{ring}`. |
+| **Promotion Steps** | The ordered actions executed during a Promotion: cloning repos, updating manifests, opening PRs, waiting for merges, triggering Argo CD syncs, etc. Kargo provides 30+ built-in step types covering Git, Helm, Kustomize, Argo CD, HTTP, and more. |
+| **Verification** | A post-promotion validation phase using Argo Rollouts AnalysisRuns. Verification determines whether Freight is marked as `VerifiedIn` a Stage, gating promotion to downstream rings. |
+| **Soak Period** | A time-based stability requirement. Freight must remain deployed and healthy in a Stage for the configured duration before becoming eligible for promotion to the next ring. |
+| **Ring** | A logical deployment stage representing a blast-radius zone. Modeled as one or more Kargo Stages. Inner rings (low risk) validate changes before outer rings (high risk) receive them. |
+| **Auto-Promotion** | A per-Stage policy that automatically creates Promotions when new eligible Freight becomes available, removing the need for manual promotion triggers in lower-risk rings. |
+| **Progressive Delivery** | An architectural pattern characterized by the staged promotion of software changes through multiple Rings, leveraging automated health signals and mandatory soak periods to detect and isolate failures early. |

--- a/docs/ring-deployments/directory-layout.md
+++ b/docs/ring-deployments/directory-layout.md
@@ -1,0 +1,489 @@
+# Canonical Directory Layout — Ring-Based Multi-Cluster Deployments
+
+> **Warning**
+> Ring deployments are still under active development. This documentation may change as the implementation evolves.
+
+The standard directory structure every component in infra-deployments must follow.
+
+## Table of Contents
+
+1. [Why This Exists](#1-why-this-exists)
+2. [How It Works: Kargo + ArgoCD](#2-how-it-works-kargo--argocd)
+3. [The Canonical Layout](#3-the-canonical-layout)
+4. [Tier Definitions](#4-tier-definitions)
+   - 4.1 [Tier 1 — Component Base](#41-tier-1--component-base)
+   - 4.2 [Tier 2 — Ring Base](#42-tier-2--ring-base)
+   - 4.3 [Tier 3 — Cluster Overlay](#43-tier-3--cluster-overlay)
+   - 4.4 [Tier 4 — Features](#44-tier-4--features)
+5. [File Conventions](#5-file-conventions)
+   - 5.1 [File Naming](#51-file-naming)
+   - 5.2 [One Resource Per File](#52-one-resource-per-file)
+   - 5.3 [Patches Directory](#53-patches-directory)
+6. [Validation](#6-validation)
+
+---
+
+## 1. Why This Exists
+
+### The Problem
+
+Konflux deploys the same components across multiple clusters — development, staging, production, and critical production. Without a controlled rollout mechanism, changes to infra-deployments land on all clusters simultaneously when they merge. A bad configuration change can break production within minutes of merging. There is no safe, gradual rollout path.
+
+### The Solution: Ring-Based Progressive Delivery
+
+We adopt a **ring-based progressive delivery model**. Changes roll out through a sequence of rings, starting from lower-risk environments and advancing toward production:
+
+| Ring | Purpose | What Happens Here |
+|------|---------|-------------------|
+| **Ring 0** | Development | First real deployment. Conformance tests run in the PR before merge. |
+| **Ring 1** | Staging | Staging clusters. Verified with live conformance tests, ArgoCD sync health, and metrics. |
+| **Ring N** | ... | Each additional ring follows the same pattern — promoted only after Ring N-1 passes all verification gates. Higher rings can add stricter or additional verification steps as needed. |
+
+A change must pass verification in Ring N before it is promoted to Ring N+1. Between rings, a **soak time** is enforced — a mandatory waiting period after verification passes, allowing the change to run in the current ring long enough to surface issues that tests alone cannot catch. The number of rings is not fixed. If verification fails at any ring, promotion stops — higher rings are never exposed to a change that broke a lower one.
+
+---
+
+## 2. How It Works: Kargo + ArgoCD
+
+**ArgoCD** syncs the Git repository to each cluster. Each cluster has an ArgoCD Application pointing at its specific directory path in infra-deployments. At scale, **argocd-agent** (available in OpenShift GitOps) enables managing hundreds of spoke clusters from a central hub.
+
+**[Kargo](https://kargo.io)** is the promotion engine that layers on top of ArgoCD. Without Kargo, ArgoCD alone would deploy changes to every cluster the moment they merge — there would be no controlled, ring-by-ring rollout. Kargo watches for new component versions — container image tags, upstream Git commits, Helm charts, or commits in infra-deployments itself (e.g. RBACs and other resources authored directly in the repo that need ring-by-ring rollout) — and promotes them ring-by-ring by updating the Git repo. Kargo serializes promotions within each Stage — it queues them and processes one at a time, with verification blocking subsequent promotions. This ensures each change is individually verified before the next one lands.
+
+**Why this matters for directory structure:** Kargo writes to a single, computable path per ring. Given a component name and ring number, the path is always `components/{component}/rings/ring-N/base/kustomization.yaml`. Each component has its own [PromotionTask](architecture.md#8-definitions) per ring, but the canonical layout means all PromotionTasks follow the same pattern — the path is computable from `{component}` and `ring-N`, keeping PromotionTask definitions simple and consistent.
+
+**How promotion works:** Kargo does not commit directly to `main`. Instead, it pushes to a branch, opens a PR, and either auto-merges (staging rings) or waits for manual merge approval (production rings). This means every promotion is a reviewable PR — production changes require human approval before they reach the cluster.
+
+---
+
+## 3. The Canonical Layout
+
+One structure. Every component. No exceptions. Given a component name, a ring number, and a cluster name, the path to any `kustomization.yaml` is computable without looking it up.
+
+```
+components/{component-name}/
+│
+├── base/                              # TIER 1
+│   ├── kustomization.yaml
+│   ├── allow-argocd-to-manage-cr.yaml
+│   └── monitoring/
+│       ├── controller-sm.yaml
+│       └── slo-alerts-pr.yaml
+│
+├── new-base/                          # TIER 1 (ring-promoted copy of base/ — see §4.1)
+│
+├── features/                           # TIER 4 (library — not a layer; referenced via components:)
+│   ├── rh-certs/
+│   │   └── kustomization.yaml
+│   ├── debug/
+│   │   └── kustomization.yaml
+│   └── high-availability/
+│       └── kustomization.yaml
+│
+├── rings/
+│   ├── ring-0/                        # Development
+│   │   └── base/                      # TIER 2
+│   │       ├── kustomization.yaml     # ← Kargo writes here (image tags, Git SHAs, Helm charts, ...)
+│   │       ├── ...                    # ← Helm values, Chart.yaml, or other config Kargo manages
+│   │       ├── rbac/                  # ← Human-authored in first ring, promoted by Kargo to next rings
+│   │       │   └── build-pipeline-runner-rb.yaml
+│   │       └── patches/               # ← Human-authored
+│   │           └── resource-limits-patch.yaml
+│   │
+│   ├── ring-1/                        # Staging
+│   │   ├── base/                      # TIER 2
+│   │   │   ├── kustomization.yaml     # ← Kargo writes here (image tags, Git SHAs, Helm charts, ...)
+│   │   │   ├── ...                    # ← Helm values, Chart.yaml, or other config Kargo manages
+│   │   │   ├── rbac/                  # ← Human-authored in first ring, promoted by Kargo to next rings
+│   │   │   │   └── build-pipeline-runner-rb.yaml
+│   │   │   └── patches/               # ← Human-authored
+│   │   │       └── resource-limits-patch.yaml
+│   │   ├── stone-stg-rh01/            # TIER 3
+│   │   │   ├── kustomization.yaml
+│   │   │   ├── webhook-config.json
+│   │   │   └── patches/
+│   │   │       └── external-secret-path-patch.yaml
+│   │   └── stone-stage-p01/            # TIER 3
+│   │       ├── kustomization.yaml
+│   │       └── patches/
+│   │           └── external-secret-path-patch.yaml
+│   │
+│   ├── ring-N/                        # Ring N (same structure)
+│   │   ├── base/                      # TIER 2
+│   │   │   ├── kustomization.yaml     # ← Kargo writes here (image tags, Git SHAs, Helm charts, ...)
+│   │   │   ├── ...                    # ← Helm values, Chart.yaml, or other config Kargo manages
+│   │   │   ├── rbac/                  # ← Human-authored in first ring, promoted by Kargo to next rings
+│   │   │   └── patches/               # ← Human-authored
+│   │   ├── {cluster-a}/               # TIER 3
+│   │   │   └── kustomization.yaml
+│   │   └── {cluster-b}/               # TIER 3
+│   │       └── kustomization.yaml
+│
+├── OWNERS
+└── README.md
+```
+
+> **Minimum Viable Layout — Single-Ring Component**
+>
+> Components that deploy to only one ring (e.g. a dev-only tool) still follow the canonical structure — just with one ring and one cluster directory:
+>
+> ```
+> components/{dev-tool}/
+> ├── base/                              # Tier 1
+> ├── rings/
+> │   └── ring-0/
+> │       ├── base/                      # Tier 2
+> │       │   └── kustomization.yaml
+> │       └── {cluster}/                 # Tier 3
+> │           └── kustomization.yaml
+> └── OWNERS
+> ```
+>
+> Don't create empty ring directories for rings the component doesn't deploy to.
+
+> **Where Kargo Writes**
+>
+> Kargo **primarily** writes to Tier 2: `components/{component}/rings/ring-N/base/`. The path is computable from `{component}` and `ring-N`, enabling a single generic [PromotionTask](architecture.md#8-definitions). When Tier 1 (`base/`) changes need ring-by-ring rollout, Kargo promotes them via `new-base/` — a copy of `base/` that travels ring-by-ring and is renamed to `base/` at the destination.
+>
+> **Where does my change go?** Two questions:
+>
+> 1. **Is it the same everywhere and non-disruptive?** → **Tier 1**. Merges to all rings at once. Examples: ArgoCD sync permissions, monitoring ServiceMonitors.
+> 2. **Does it differ?** Then ask: *at what level?*
+>    - **Differs between rings, but same across all clusters within a ring** → **Tier 2**. This covers two cases with different lifecycles: (a) **promoted content** like image tags and upstream refs — authored in the first ring, Kargo copies them forward; and (b) **ring-authored config** like ExternalSecret vault paths or feature flags — authored independently in each ring because the values differ (e.g., staging vault path ≠ production vault path). Both live in Tier 2 because they apply uniformly to all clusters in the ring.
+>    - **Differs between individual clusters within the same ring** → **Tier 3**. Examples: a webhook endpoint unique to one cluster, resource sizing for a differently-shaped cluster, a TLS certificate specific to one cluster's domain.
+
+---
+
+## 4. Tier Definitions
+
+Every component follows the same four tiers. Tiers can be minimal but must exist. No skipping tiers, no alternative layouts. Consistency over cleverness.
+
+### Tier Overview
+
+| Tier | Path | Owns | Changed By |
+|------|------|------|------------|
+| **Tier 1** base/ | `components/{c}/base/` | Infra-authored: ArgoCD permissions, platform-level RBACs, monitoring | Component team — manual PR |
+| **Tier 2** ring base | `components/{c}/rings/ring-N/base/` | Promoted: component versions, namespace, upstream refs. Ring-authored: ExternalSecret vault paths, feature flags, resource baselines | Kargo promotes versions; ring-authored config is written independently per ring |
+| **Tier 3** cluster | `components/{c}/rings/ring-N/{cluster}/` | Only what differs between clusters in the same ring: unique webhook endpoints, per-cluster resource sizing, cluster-specific TLS | Manual PR |
+| **Tier 4** features | `components/{c}/features/{name}/` | Opt-in capabilities (certs, debug, HA). Referenced via `components:` in any tier. | Component team — manual PR |
+
+### 4.1 Tier 1 — Component Base
+
+**The Foundation.**
+
+Changes here bypass ring promotion entirely — they hit every ring simultaneously on merge. Only non-disruptive, infra-level resources belong here: ArgoCD sync permissions, monitoring. Nothing that impacts users or running workloads should be in Tier 1 — if a change could break a component or affect tenants, it must go through the rings via Tier 2.
+
+> **Promoting base changes through rings (`new-base/`)**
+>
+> When a Tier 1 change needs ring-by-ring rollout (e.g., it could impact workloads), create a `new-base/` directory alongside `base/`. Kargo promotes `new-base/` ring-by-ring like any Tier 2 content, and at the destination ring it is renamed to `base/`. This gives you the safety of ring promotion for changes that would otherwise hit every ring at once.
+
+```yaml
+# components/build-service/base/kustomization.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- allow-argocd-to-manage-cr.yaml           # ArgoCD sync permission
+- monitoring.yaml                          # ServiceMonitors, alerts
+- rbac/                                    # Platform-level RBACs
+- build-pipeline-config/build-pipeline-config.yaml
+
+commonAnnotations:
+  argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+```
+
+Rules:
+
+- **Must exist** for every component, even if it contains a single resource.
+- **Infra-level resources only.** ArgoCD permissions, monitoring. Any resource that could impact workloads or tenants — including RBACs that grant new permissions — belongs in Tier 2, not here.
+- **Never contains** `images:`, `namespace:`, environment URLs, or cluster-specific secrets.
+- **Changed by** the component team via manual PR.
+
+### 4.2 Tier 2 — Ring Base
+
+**The Ring-Wide Shared Layer.**
+
+This is the ring's shared foundation — every resource that must be consistent across all clusters in a ring lives here. Tier 2 holds two types of content with different lifecycles:
+
+1. **Promoted content** — component versions (image tags, upstream refs), RBACs, and other resources that Kargo copies from ring to ring. Authored in the first ring, promoted automatically to subsequent rings.
+2. **Ring-authored config** — configuration that is the same for every cluster in the ring but differs between rings, such as ExternalSecret vault paths, environment-specific feature flags, or resource baselines. These are authored independently in each ring's Tier 2 because the values are ring-specific — Kargo does not promote them.
+
+Tier 2 pulls in Tier 1, pins the component version (however the component manages that), and sets the namespace. Only ring-common objects belong here; anything that differs between individual clusters within a ring belongs in Tier 3. **This is the primary tier Kargo writes to.**
+
+**Directory convention** — separate promoted from ring-authored content visually:
+
+```
+rings/ring-1/base/
+├── kustomization.yaml              # images, upstream refs — Kargo writes here (promoted)
+├── rbac/                           # RBACs authored in first ring, promoted by Kargo
+│   ├── role.yaml
+│   └── rolebinding.yaml
+├── external-secrets/               # ring-authored — Kargo ignores, authored per ring
+│   └── pipelines-as-code.yaml
+└── patches/                        # ring-wide patches
+    └── resource-limits-patch.yaml
+```
+
+Promoted resources (RBACs, CRDs, additional manifests) and ring-authored resources (ExternalSecrets, feature flags) both live in Tier 2 but in their own subdirectories for clarity.
+
+```yaml
+# components/build-service/rings/ring-1/base/kustomization.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- ../../../base                                                    # ← Tier 1
+- rbac/                                                            # ← promoted: Kargo copies ring-to-ring
+- external-secrets/                                                # ← ring-authored: Kargo ignores
+- https://github.com/konflux-ci/build-service/config/default?ref=04a4744  # ← promoted: upstream ref
+
+namespace: build-service
+
+images:                                                            # ← promoted: Kargo writes HERE
+- name: quay.io/konflux-ci/build-service
+  newName: quay.io/konflux-ci/build-service
+  newTag: 04a4744321a7fb747f796da783d51fc322aef598
+
+components:
+- ../../../features/rh-certs                                       # ← Tier 4 opt-in
+
+patches:
+- path: patches/resource-limits-patch.yaml
+```
+
+Rules:
+
+- **All clusters in a ring run the same versions.** Image tags, Helm chart versions, Git refs — whatever the component pins, every cluster in the ring gets the same set. No per-cluster version overrides.
+- **Upstream resource refs** (`?ref=SHA`) live here. The upstream ref pulls in all component resources — Deployments, RBACs, Services, CRDs — so they are promoted ring-by-ring with the component version.
+- **RBACs and additional manifests can be promoted.** If a component needs extra Roles, RoleBindings, or ServiceAccounts authored in infra-deployments (not upstream), place them in a subdirectory (e.g. `rbac/`). Kargo promotes these ring-to-ring via Git Warehouse subscriptions — author once in the first ring, and they flow forward automatically.
+- **Ring-authored config lives here too.** ExternalSecret vault paths, feature flags, resource baselines — if it's the same for every cluster in the ring but differs between rings, it's Tier 2. Place ring-authored resources in their own subdirectory (e.g. `external-secrets/`). These are authored independently in each ring (not promoted by Kargo). Don't duplicate them across Tier 3 directories.
+- **Only ring-common patches.** Patches in Tier 2 must apply to all clusters in the ring. Patches that differ between individual clusters within the same ring belong in Tier 3.
+- **Kargo promotes** image tags, upstream `?ref=SHA`, Helm chart versions, Git commits in infra-deployments itself (via [Git Warehouse subscriptions](https://docs.kargo.io/user-guide/how-to-guides/working-with-warehouses#git-repository-subscriptions)), and any manifests authored directly in the first ring's Tier 2 (like RBACs).
+- **Path formula:** `components/{component}/rings/ring-N/base/kustomization.yaml` — always.
+
+> **Helm-Based Components**
+>
+> For components deployed via Helm charts, the `HelmChartInflationGenerator` and its `valuesInline` live in Tier 2 alongside `kustomization.yaml`. Kargo promotes Helm components by updating the generator file — writing the chart `version` and image tags inside `valuesInline`:
+>
+> ```
+> rings/ring-1/base/
+> ├── kustomization.yaml                  # generators: [kargo-helm-generator.yaml]
+> └── kargo-helm-generator.yaml           # ← Kargo writes version + valuesInline.image.tag here
+> ```
+>
+> ```yaml
+> # kargo-helm-generator.yaml — Kargo updates version and image tags
+> apiVersion: builtin
+> kind: HelmChartInflationGenerator
+> metadata:
+>   name: kargo
+> name: kargo
+> repo: oci://ghcr.io/akuity/kargo-charts
+> version: 1.10.7                         # ← Kargo writes chart version
+> namespace: kargo
+> releaseName: kargo
+> valuesInline:
+>   image:
+>     repository: quay.io/konflux-ci/kargo
+>     tag: 1.10-2cd30bc                   # ← Kargo writes image tag
+> ```
+>
+> The PromotionTask uses `yaml-update` steps to write these fields. Ring-authored Helm values (environment-specific endpoints, OIDC config) are part of the same file — they stay in Tier 2 and are authored independently per ring, just like ExternalSecrets.
+
+### 4.3 Tier 3 — Cluster Overlay
+
+**The Leaf Node — Where ArgoCD Points.**
+
+Each ring can contain multiple clusters. ArgoCD ApplicationSets point at Tier 3 — one directory per cluster within a ring. This layer pulls in the ring base (Tier 2) and adds only what truly differs between individual clusters in the same ring. If a value is the same for every cluster in the ring, it belongs in Tier 2 — not duplicated across Tier 3 directories. Tier 3 is narrower than it might seem: most environment-level config (secret vault paths, feature flags) is ring-level and belongs in Tier 2. Tier 3 is for cluster-specific overrides like a webhook endpoint unique to one cluster, resource sizing for a differently-shaped node, or a TLS certificate tied to a specific domain. ExternalSecret resources are defined in Tier 2; Tier 3 patches only cluster-specific fields such as a vault path segment that includes the cluster name.
+
+```yaml
+# components/build-service/rings/ring-1/stone-stg-rh01/kustomization.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- ../base                                                          # ← Tier 2
+
+patches:
+- path: patches/external-secret-path-patch.yaml                    # cluster-specific secret vault
+  target:
+    name: pipelines-as-code-secret
+    kind: ExternalSecret
+
+configMapGenerator:
+- name: webhook-config                                             # cluster-specific webhook endpoint
+  files:
+  - webhook-config.json
+```
+
+Rules:
+
+- **Must exist** for every deployed cluster. ArgoCD ApplicationSets target Tier 3 — without a cluster directory, ArgoCD has nothing to sync.
+- **Must reference `../base`.** A cluster kustomization that doesn't include its ring base is a broken deployment.
+- **Never sets image tags.** The application version is owned by Tier 2.
+- **Changed by** manual PR.
+- **Adding a cluster** requires two steps: (1) create a subdirectory with a `kustomization.yaml` referencing `../base`, and (2) ensure the ArgoCD ApplicationSet generator includes the new cluster (see `argo-cd-apps/overlays/` for ring overlay definitions). Without step 2, the directory exists but ArgoCD won't create an Application for it.
+- **Removing a cluster** — reverse the process: remove the ArgoCD Application (or update the ApplicationSet generator), verify no active workloads remain, then delete the directory.
+
+### 4.4 Tier 4 — Features
+
+**Opt-In Capabilities.**
+
+Kustomize Components for optional cross-cutting concerns. Any tier (1, 2, or 3) can opt in by adding a `components:` reference. Use for capabilities that not every ring or cluster needs — RH certificates, debug mode, high-availability patches, profiling. Features are never mandatory.
+
+**Why not in `base/`?** Resources in Tier 1 apply to every ring and cluster unconditionally. Features exist separately because not all environments need them — `debug/` belongs only in Ring 0, `high-availability/` only in production rings, `rh-certs/` only on Red Hat-hosted clusters. Keeping them in `features/` lets each ring or cluster opt in selectively without forcing the capability on environments where it is unnecessary or harmful.
+
+```yaml
+# components/build-service/features/rh-certs/kustomization.yaml
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component                                                    # ← Kustomize Component, not Kustomization
+
+patches:
+- path: add-rh-certs-patch.yaml
+  target:
+    name: build-service-controller-manager
+    kind: Deployment
+
+configMapGenerator:
+- name: trusted-ca
+  options:
+    labels:
+      config.openshift.io/inject-trusted-cabundle: "true"
+
+namespace: build-service
+```
+
+Rules:
+
+- **Kind is `Component`**, not `Kustomization`. Referenced via `components:`, not `resources:`.
+- **Any tier can opt in:** Ring 1 can enable `rh-certs` while Ring 0 doesn't. A specific cluster can enable `debug` while others in the same ring don't.
+- **Changed by** the component team via manual PR.
+
+> **Reference Direction — Always Upward**
+>
+> References always go upward: Tier 3 → Tier 2 (`../base`), Tier 2 → Tier 1 (`../../../base`). ArgoCD ApplicationSets point at Tier 3 — the leaf. Each leaf assembles the full stack by pulling its parents.
+
+---
+
+## 5. File Conventions
+
+### 5.1 File Naming
+
+Every resource file is named `{resource-name}-{type-abbreviation}.yaml`. The resource name comes first, followed by a short abbreviation of the Kubernetes resource type. This makes `ls` output self-documenting — you know what each file contains without opening it.
+
+| Resource Kind | Abbreviation | Example Filename |
+|--------------|-------------|-----------------|
+| ServiceAccount | `sa` | `konflux-ui-sa.yaml` |
+| Role | `role` | `pod-logs-reader-role.yaml` |
+| ClusterRole | `cr` | `test-runner-cr.yaml` |
+| RoleBinding | `rb` | `pipeline-runner-rb.yaml` |
+| ClusterRoleBinding | `crb` | `argocd-manager-crb.yaml` |
+| ConfigMap | `cm` | `build-pipeline-config-cm.yaml` |
+| Service | `svc` | `webhook-svc.yaml` |
+| Deployment | `deploy` | `controller-deploy.yaml` |
+| Namespace | `ns` | `build-service-ns.yaml` |
+| ExternalSecret | `es` | `pipelines-as-code-es.yaml` |
+| ServiceMonitor | `sm` | `controller-sm.yaml` |
+| PrometheusRule | `pr` | `slo-alerts-pr.yaml` |
+
+For custom resources without a standard abbreviation, use a short descriptive suffix: `release-plan-admission-rpa.yaml`, `build-pipeline-selector-bps.yaml`. When no sensible abbreviation exists, the full kind in lowercase is acceptable: `pac-repository.yaml`.
+
+### 5.2 One Resource Per File
+
+Each Kubernetes resource lives in its own YAML file. No multi-document files (`---` separators), no bundled manifests. This makes diffs atomic — a PR that modifies a RoleBinding only touches the RoleBinding file.
+
+Correct — one resource per file:
+
+```
+base/
+├── kustomization.yaml
+├── build-service-ns.yaml                # Namespace
+├── allow-argocd-to-manage-cr.yaml       # ClusterRole
+├── pipeline-runner-rb.yaml              # RoleBinding
+├── controller-sm.yaml                   # ServiceMonitor
+└── external-secrets/                    # subdirectory for related group
+    ├── kustomization.yaml
+    ├── pipelines-as-code-es.yaml
+    └── snyk-token-es.yaml
+```
+
+Wrong — multiple resources in one file:
+
+```
+base/
+├── kustomization.yaml
+└── resources.yaml                       # 4 resources with --- separators
+```
+
+- **Exception:** CRDs or upstream manifests pulled via `?ref=SHA` are not split — they are consumed as-is from upstream.
+- **Subdirectories** for related groups (e.g. `external-secrets/`, `rbac/`, `monitoring/`) are encouraged when a tier has more than ~6 resource files.
+
+### 5.3 Patches Directory
+
+Strategic merge patches and JSON patches live in a `patches/` subdirectory, not mixed in with resource files. This separates *what gets deployed* (resources) from *what gets modified* (patches). When scanning a directory, you immediately know which files create resources and which modify them.
+
+```
+rings/ring-1/base/
+├── kustomization.yaml
+└── patches/
+    ├── resource-limits-patch.yaml         # CPU/memory overrides
+    ├── replica-count-patch.yaml           # Ring-specific replica count
+    └── env-config-patch.yaml              # Environment-specific env vars
+```
+
+```
+rings/ring-1/stone-stg-rh01/
+├── kustomization.yaml
+└── patches/
+    ├── external-secret-path-patch.yaml    # Cluster-specific vault path
+    └── deployment-resources-patch.yaml    # Cluster-specific resource sizing
+```
+
+Reference in kustomization.yaml:
+
+```yaml
+patches:
+- path: patches/resource-limits-patch.yaml
+  target:
+    kind: Deployment
+    name: controller-manager
+- path: patches/replica-count-patch.yaml
+  target:
+    kind: Deployment
+```
+
+Rules:
+
+- **Patch files end with `-patch.yaml`** — distinguishes them from resource files at a glance.
+- **One patch per concern.** Don't bundle resource limits and replica counts in the same patch file.
+- **Inline patches** (the `patch: |-` form in kustomization.yaml) are acceptable for single-line changes. Move to a file in `patches/` when the patch exceeds ~5 lines.
+- **When a directory has only one patch**, the `patches/` subdirectory is still preferred for consistency, but a single patch file at the directory root (e.g. `resources_patch.yaml`) is tolerated.
+
+> **Legacy Naming**
+>
+> Existing files like `resources_patch.yaml` at the directory root predate this convention. New components must follow the `patches/` directory pattern. Existing components should migrate when next modified — don't create PRs solely to rename files.
+
+---
+
+## 6. Validation
+
+Before submitting a PR, verify that every tier builds successfully. Run `kustomize build` at the leaf (Tier 3) — this exercises the full chain (Tier 3 → Tier 2 → Tier 1 + Tier 4 features):
+
+```bash
+# Build a specific cluster overlay (Tier 3)
+kustomize build --enable-helm components/{component}/rings/ring-N/{cluster}/
+
+# Build the ring base (Tier 2) — useful when no Tier 3 exists yet
+kustomize build --enable-helm components/{component}/rings/ring-N/base/
+
+# Build the component base (Tier 1) — sanity check
+kustomize build components/{component}/base/
+```
+
+If any of these fail, the layout is broken. Common errors:
+
+- **`resource not found`** — a `resources:` entry references a file or directory that doesn't exist.
+- **`no such file or directory`** — a `patches:` path is wrong, or `../base` reference points to the wrong level.
+- **`namespace mismatch`** — a Component sets a different `namespace:` than its parent kustomization.
+- **`multiple matches`** — a `target:` selector in a patch matches more than one resource. Narrow it with `name:` or `group:`.
+
+For rollback and hotfix procedures, see [Rollback and Reliability](architecture.md#38-rollback-and-reliability) in the architecture doc.


### PR DESCRIPTION
## Summary

Adds ring deployment standards documentation migrated from the konflux-ring-deployments architecture repo into infra-deployments where it belongs — next to the code it governs.

### Docs added

**1. [Canonical Directory Layout](docs/ring-deployments/directory-layout.md)** — normative standard for component directory structure

- **4-tier component structure:** Tier 1 (base/), Tier 2 (rings/ring-{n}/base/ — where Kargo writes), Tier 3 (rings/ring-{n}/{cluster}/ — where ArgoCD points), Tier 4 (features/)
- **"Where does my change go?"** decision guide
- **File conventions** — resource naming table, one-resource-per-file rule, `patches/` directory pattern
- **"In This Repo" mapping** — maps current `development/staging/production/` structure to canonical `rings/ring-{n}/` layout with real examples
- Every new component **must** follow this layout from day one

**2. [Architecture](docs/ring-deployments/architecture.md)** — full Kargo ring deployment pipeline design

- Ring-based progressive delivery model (Ring 0 → Ring N+1)
- Kargo Project structure, cluster segmentation strategy
- CI artifact ingestion (Warehouse, Freight creation)
- Per-ring promotion flow (auto-promote in dev/staging, gated in production)
- Verification strategy (tiered by ring: smoke tests → integration → SLO compliance → self-hosting integrity)
- Rollback model (promote-to-previous-Freight, emergency hotfix path)
- Observability and auditability
- Component interaction model and Freight lifecycle state machine (Mermaid diagrams)
- Kargo resource examples (Warehouse, Stage, AnalysisTemplate YAMLs)
- Failure mode analysis table including self-hosting circular dependency mitigation
- Glossary of all Kargo terms

## Risk Assessment

**Level:** Low
**Description:** Documentation-only change. Adds new Markdown files under `docs/ring-deployments/`. No code, no manifests, no deployment changes.
**Rollback:** Delete the files.

## Validation

N/A — documentation only. No staging deployment required.