### PR TITLE
Migrate squid component to caching-helm chart

### DIFF
--- a/components/squid/development/caching-helm-generator.yaml
+++ b/components/squid/development/caching-helm-generator.yaml
@@ -1,57 +1,48 @@
 apiVersion: builtin
 kind: HelmChartInflationGenerator
 metadata:
-  name: squid-helm
-name: squid-helm
+  name: caching-helm
+name: caching-helm
+releaseName: squid
 repo: oci://quay.io/konflux-ci/caching
-version: 0.1.1648+a6ad7bf
+version: 0.1.1688+a7def07
 valuesInline:
+  squid:
+    enabled: true
   installCertManagerComponents: false
   mirrord:
     enabled: false
   nginx:
     enabled: true
-    replicaCount: 3
     name: artifact-registry-proxy
     tls:
       enabled: true
       secretName: artifact-registry-proxy-tls
     service:
-      port: 443
       trafficDistribution: PreferClose
       annotations:
         service.beta.openshift.io/serving-cert-secret-name: artifact-registry-proxy-tls
     upstream:
-      url: https://red-hat.repo.sonatype.app
-    auth:
-      enabled: true
-      secretName: artifact-registry-credentials
+      # No nexus instance in development, use standard Go module proxy
+      url: https://proxy.golang.org
     cache:
       allowList:
-        # Cache all traffic to nexus repositories
-        - ^/repository/
-      size: 102400
+        - ^/.+/@v/.* # <module>/@v/<version>.info|.mod|.zip and <module>/@v/list
+        - ^/sumdb/.* # checksum database (e.g. sum.golang.org)
+      size: 1024
       ttl: 30d
-    resources:
-      requests:
-        cpu: "2"
-        memory: 2Gi
-      limits:
-        cpu: "2"
-        memory: 2Gi
   test:
     enabled: false
   cert-manager:
     enabled: false
   environment: release
-  replicaCount: 3
   resources:
     requests:
       cpu: 100m
       memory: 128Mi
     limits:
       cpu: 200m
-      memory: 2Gi
+      memory: 256Mi
   icapServer:
     resources:
       requests:
@@ -80,8 +71,8 @@ valuesInline:
       - ^https://[a-f0-9]{32}\.r2\.cloudflarestorage\.com/app-ci-image-registry/docker/registry/v2/blobs/sha256/[a-f0-9]{2}/[a-f0-9]{64}/data
       - ^https://layers\.nvcr\.io/registry/docker/registry/v2/blobs/sha256/[a-f0-9]{2}/[a-f0-9]{64}/data
       - ^https://[a-z0-9]+\.cloudfront\.net/sha256/[a-f0-9]{2}/[a-f0-9]{64}
-    size: 51200
-    maxObjectSize: 1024
+    size: 192
+    maxObjectSize: 128
   prometheus:
     serviceMonitor:
       nginxTLS:

--- a/components/squid/development/kustomization.yaml
+++ b/components/squid/development/kustomization.yaml
@@ -5,4 +5,4 @@ resources:
 - ../base
 
 generators:
-- squid-helm-generator.yaml
+- caching-helm-generator.yaml

--- a/components/squid/staging/caching-helm-generator.yaml
+++ b/components/squid/staging/caching-helm-generator.yaml
@@ -1,45 +1,60 @@
 apiVersion: builtin
 kind: HelmChartInflationGenerator
 metadata:
-  name: squid-helm
-name: squid-helm
+  name: caching-helm
+name: caching-helm
+releaseName: squid
 repo: oci://quay.io/konflux-ci/caching
-version: 0.1.1648+a6ad7bf
+version: 0.1.1688+a7def07
 valuesInline:
+  squid:
+    enabled: true
   installCertManagerComponents: false
   mirrord:
     enabled: false
   nginx:
     enabled: true
+    replicaCount: 3
     name: artifact-registry-proxy
     tls:
       enabled: true
       secretName: artifact-registry-proxy-tls
     service:
+      port: 443
       trafficDistribution: PreferClose
       annotations:
         service.beta.openshift.io/serving-cert-secret-name: artifact-registry-proxy-tls
     upstream:
-      # No nexus instance in development, use standard Go module proxy
-      url: https://proxy.golang.org
+      url: https://red-hat.repo.sonatype.app
+    auth:
+      enabled: true
+      secretName: artifact-registry-credentials
     cache:
       allowList:
-        - ^/.+/@v/.* # <module>/@v/<version>.info|.mod|.zip and <module>/@v/list
-        - ^/sumdb/.* # checksum database (e.g. sum.golang.org)
-      size: 1024
+        # Cache all traffic to nexus repositories
+        - ^/repository/
+      size: 102400
       ttl: 30d
+    resources:
+      requests:
+        cpu: "2"
+        memory: 2Gi
+      limits:
+        cpu: "2"
+        memory: 2Gi
   test:
     enabled: false
   cert-manager:
     enabled: false
   environment: release
+  replicaCount: 3
   resources:
     requests:
       cpu: 100m
       memory: 128Mi
     limits:
       cpu: 200m
-      memory: 256Mi
+      memory: 2Gi
   icapServer:
     resources:
       requests:
@@ -68,8 +83,8 @@ valuesInline:
       - ^https://[a-f0-9]{32}\.r2\.cloudflarestorage\.com/app-ci-image-registry/docker/registry/v2/blobs/sha256/[a-f0-9]{2}/[a-f0-9]{64}/data
       - ^https://layers\.nvcr\.io/registry/docker/registry/v2/blobs/sha256/[a-f0-9]{2}/[a-f0-9]{64}/data
       - ^https://[a-z0-9]+\.cloudfront\.net/sha256/[a-f0-9]{2}/[a-f0-9]{64}
-    size: 192
-    maxObjectSize: 128
+    size: 51200
+    maxObjectSize: 1024
   prometheus:
     serviceMonitor:
       nginxTLS:

--- a/components/squid/staging/kustomization.yaml
+++ b/components/squid/staging/kustomization.yaml
@@ -6,4 +6,4 @@ resources:
 - artifact-registry-credentials.yaml
 
 generators:
-- squid-helm-generator.yaml
+- caching-helm-generator.yaml


### PR DESCRIPTION
Update HelmChartInflationGenerator for development and staging:
- Change chart name from squid-helm to caching-helm
- Add releaseName: squid to preserve Helm release name for upgrade path
- Enable squid component with squid.enabled: true

This ensures Helm treats the deployment as an upgrade of the existing 'squid' release, preventing resource conflicts and downtime.

Assisted-by: Claude Sonnet 4.5

Jira-Url: https://redhat.atlassian.net/browse/KFLUXVNGD-1064