### PR TITLE
KFLUXINFRA-4171: Update ring-1 ArgoCD Application configuration

### DIFF
--- a/argo-cd-apps/app-of-app-sets/ring-1/kustomization.yaml
+++ b/argo-cd-apps/app-of-app-sets/ring-1/kustomization.yaml
@@ -8,10 +8,18 @@ patches:
       group: argoproj.io
       version: v1alpha1
       kind: Application
+  - path: patches/argocd-namespace-patch.yaml
+    target:
+      group: argoproj.io
+      version: v1alpha1
+      kind: Application
+      name: all-application-sets
+  # Must be the last patch since it patches the name of the application
   - path: patches/name-patch.yaml
     target:
       group: argoproj.io
       version: v1alpha1
       kind: Application
       name: all-application-sets
-namespace: argocd-staging
+
+namespace: argocd-infra-deployments

--- a/argo-cd-apps/app-of-app-sets/ring-1/patches/argocd-namespace-patch.yaml
+++ b/argo-cd-apps/app-of-app-sets/ring-1/patches/argocd-namespace-patch.yaml
@@ -1,0 +1,3 @@
+- op: replace
+  path: /spec/destination/namespace
+  value: argocd-infra-deployments

--- a/argo-cd-apps/app-of-app-sets/ring-1/patches/name-patch.yaml
+++ b/argo-cd-apps/app-of-app-sets/ring-1/patches/name-patch.yaml
@@ -1,4 +1,4 @@
 ---
 - op: replace
   path: /metadata/name
-  value: ring-1-all-application-sets
+  value: all-application-sets-ring-1

--- a/argo-cd-apps/base/ring-deployments/authentication-rd/authentication-rd.yaml
+++ b/argo-cd-apps/base/ring-deployments/authentication-rd/authentication-rd.yaml
@@ -9,6 +9,9 @@ spec:
           - nameNormalized
         generators:
           - clusters:
+              selector:
+                matchLabels:
+                  appstudio.redhat.com/is-tenant-cluster: "true"
               values:
                 sourceRoot: components/authentication-rd
                 ring: "ring-0"

--- a/argo-cd-apps/overlays/ring-1/kustomization.yaml
+++ b/argo-cd-apps/overlays/ring-1/kustomization.yaml
@@ -3,7 +3,7 @@ kind: Kustomization
 resources:
   - ../../base/ring-deployments
 
-namespace: argocd-staging
+namespace: argocd-infra-deployments
 patches:
   - path: patches/ring-patch.yaml
     target:


### PR DESCRIPTION
 This points the ring-1 overlay to the new ArgoCD instance hosted on the internal staging common cluster.