### PR TITLE
SPRE-5502: Add cert-manager metrics to staging RHOBS federation

### DIFF
--- a/components/monitoring/prometheus/staging/base/federation/endpoints-params.yaml
+++ b/components/monitoring/prometheus/staging/base/federation/endpoints-params.yaml
@@ -130,6 +130,18 @@
     - '{__name__="kube_deployment_status_replicas_updated", namespace="tekton-kueue"}'
     - '{__name__="kube_deployment_spec_replicas", namespace="tekton-kueue"}'
 
+    # Namespace: cert-manager
+    - '{__name__="kube_deployment_status_replicas_ready", namespace="cert-manager"}'
+    - '{__name__="kube_deployment_status_replicas_available", namespace="cert-manager"}'
+    - '{__name__="kube_deployment_spec_replicas", namespace="cert-manager"}'
+    - '{__name__="certmanager_certificate_ready_status", namespace="cert-manager"}'
+    - '{__name__="certmanager_certificate_expiration_timestamp_seconds", namespace="cert-manager"}'
+    - '{__name__="certmanager_certificate_renewal_timestamp_seconds", namespace="cert-manager"}'
+    - '{__name__="certmanager_controller_sync_call_count", namespace="cert-manager"}'
+    - '{__name__="certmanager_controller_sync_error_count", namespace="cert-manager"}'
+    - '{__name__="certmanager_http_acme_client_request_count", namespace="cert-manager"}'
+    - '{__name__="certmanager_http_acme_client_request_duration_seconds", namespace="cert-manager"}'
+
     ## Container Metrics
     - '{__name__="kube_pod_container_status_waiting_reason", namespace!~".*-tenant|openshift-.*|kube-.*"}'
     - '{__name__="kube_pod_container_resource_limits", namespace=~"release-service|rhtap-releng-tenant"}'

--- a/components/monitoring/prometheus/staging/base/federation/writeRelabelConfigs.yaml
+++ b/components/monitoring/prometheus/staging/base/federation/writeRelabelConfigs.yaml
@@ -24,6 +24,7 @@
     # KubeArchive
     # Cardinality exporter (PVO11Y-5128)
     # KAExporter (PVO11Y-5274)
+    # cert-manager (SPRE-5502)
     regex: "__name__|source_environment|source_cluster|namespace|job|instance|pod|container|app|service|deployment|node|\
       phase|reason|type|resource|kind|name|role|status|state|resourcequota|image|finalizers|verb|request_kind|\
       persistentvolumeclaim|storageclass|volumename|\
@@ -41,4 +42,5 @@
       hostname|label_app_kubernetes_io_managed_by|platform|scrape_job|slice|error|\
       resource_type|gin_errors|\
       metric|label|label_pair|scraped_instance|sharded_instance|instance_namespace|\
-      application|component|build_type|scenario|optional|test_type|automated|exported_namespace"
+      application|component|build_type|scenario|optional|test_type|automated|exported_namespace|\
+      condition|issuer_name|issuer_kind|issuer_group|scheme|host|action"


### PR DESCRIPTION
Summary

Add cert-manager metrics to the staging RHOBS federation so they are available for alerting and dashboards in Thanos/Grafana.

Part of epic [SPRE-5499](https://redhat.atlassian.net/browse/SPRE-5499) (https://redhat.atlassian.net/browse/SPRE-5499) — cert-manager monitoring.

Changes

endpoints-params.yaml: Added 10 cert-manager metrics (certificate health, controller sync, ACME client) to the platform Prometheus federation match list.
writeRelabelConfigs.yaml: Added 7 cert-manager labels (condition, issuer_name, issuer_kind, issuer_group, scheme, host, action) to the remote-write allowlist.

How it was tested

kustomize build passes for all staging overlays.
Metrics selection follows the same pattern as existing namespaces (e.g., etcd, build-service).

Dependencies

Depends on #12858 (https://github.com/redhat-appstudio/infra-deployments/pull/12858) ([SPRE-5500](https://redhat.atlassian.net/browse/SPRE-5500) — ServiceMonitor deployment) being merged first.

[SPRE-5499]: https://redhat.atlassian.net/browse/SPRE-5499?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SPRE-5500]: https://redhat.atlassian.net/browse/SPRE-5500?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ