### PR TITLE
KONFLUX-14700: OOM fix kflux-prd-rh02 kflux-prd-rh-03

### DIFF
--- a/components/vector-kubearchive-log-collector/production/kflux-prd-rh02/loki-helm-prod-values.yaml
+++ b/components/vector-kubearchive-log-collector/production/kflux-prd-rh02/loki-helm-prod-values.yaml
@@ -65,6 +65,9 @@ loki:
     max_entries_limit_per_query: 100000
     increment_duplicate_timestamp: true
     allow_structured_metadata: true
+    tsdb_max_query_parallelism: 16
+    split_queries_by_interval: 1h
+    query_timeout: 5m
   runtimeConfig:
     configs:
       kubearchive:
@@ -104,7 +107,7 @@ loki:
   querier:
     max_concurrent: 8
   query_range:
-    # split_queries_by_interval deprecated in Loki 3.x - removed
+    # split_queries_by_interval deprecated in query_range block in Loki 3.x - removed
     parallelise_shardable_queries: false
 
 # Distributed components configuration
@@ -150,9 +153,9 @@ querier:
   resources:
     requests:
       cpu: 500m
-      memory: 4Gi
-    limits:
       memory: 6Gi
+    limits:
+      memory: 10Gi
   affinity: {}
 
 queryFrontend:
@@ -161,9 +164,9 @@ queryFrontend:
   resources:
     requests:
       cpu: 200m
-      memory: 512Mi
+      memory: 2Gi
     limits:
-      memory: 1Gi
+      memory: 4Gi
 
 queryScheduler:
   replicas: 2

--- a/components/vector-kubearchive-log-collector/production/kflux-prd-rh03/loki-helm-prod-values.yaml
+++ b/components/vector-kubearchive-log-collector/production/kflux-prd-rh03/loki-helm-prod-values.yaml
@@ -65,6 +65,9 @@ loki:
     max_entries_limit_per_query: 100000
     increment_duplicate_timestamp: true
     allow_structured_metadata: true
+    tsdb_max_query_parallelism: 16
+    split_queries_by_interval: 1h
+    query_timeout: 5m
   runtimeConfig:
     configs:
       kubearchive:
@@ -104,7 +107,7 @@ loki:
   querier:
     max_concurrent: 8
   query_range:
-    # split_queries_by_interval deprecated in Loki 3.x - removed
+    # split_queries_by_interval deprecated in query_range blockin Loki 3.x - removed
     parallelise_shardable_queries: false
 
 # Distributed components configuration
@@ -150,9 +153,9 @@ querier:
   resources:
     requests:
       cpu: 500m
-      memory: 4Gi
-    limits:
       memory: 6Gi
+    limits:
+      memory: 10Gi
   affinity: {}
 
 queryFrontend:
@@ -161,9 +164,9 @@ queryFrontend:
   resources:
     requests:
       cpu: 200m
-      memory: 512Mi
+      memory: 2Gi
     limits:
-      memory: 1Gi
+      memory: 4Gi
 
 queryScheduler:
   replicas: 2


### PR DESCRIPTION
## Summary
- Increases loki-querier and loki-query-frontend memory request/response to prevent OOM errors.
- introduces max query lenght and query timeout settings
[KONFLUX-14700](https://redhat.atlassian.net/browse/KONFLUX-14700)(https://redhat.atlassian.net/browse/KONFLUX-14700)


## Risk assessment
- Medium. In bad case scenario logs for some resources could be lost.


## Validation
Staging validated with the same configuration: https://github.com/redhat-appstudio/infra-deployments/pull/12873
Development validated with: https://github.com/redhat-appstudio/infra-deployments/pull/12844

[KONFLUX-14700]: https://redhat.atlassian.net/browse/KONFLUX-14700?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ