### PR TITLE
PVO11Y-5262 Remove platform Prometheus pod latency metric drop from staging

### DIFF
--- a/components/monitoring/prometheus/staging/base/kustomization.yaml
+++ b/components/monitoring/prometheus/staging/base/kustomization.yaml
@@ -5,7 +5,6 @@ resources:
 - ../../base/external-secrets
 - ../../base/observability-operator
 - ../../base/rbac
-- ../../base/custom-modifications
 - federation/
 
 patches:

--- a/components/monitoring/prometheus/staging/kflux-stg-es01/kustomization.yaml
+++ b/components/monitoring/prometheus/staging/kflux-stg-es01/kustomization.yaml
@@ -2,9 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - ../base
-components:
-  - ../../base/custom-modifications/k-components/undo-metric-drop/
-
 patches:
   - path: cluster-id-label.yaml
     target:


### PR DESCRIPTION
## What

Remove the `taskruns_pod_latency_milliseconds` metric drop from platform Prometheus in staging. Removes the `custom-modifications` reference from staging base and the `undo-metric-drop` component from the EaaS staging overlay.

Clusters affected: staging (stone-stage-p01, stone-stg-rh01, kflux-stg-es01)

[PVO11Y-5262](https://redhat.atlassian.net/browse/PVO11Y-5262)

## Why

The upstream cardinality issue is resolved (https://github.com/tektoncd/pipeline/issues/9393) and Phase 1 (PR #12410, tekton-ms drop removal) has been running in staging since June 15 without issues. Production changes will follow in a separate PR.

## Validation

- `kustomize build` passes for all staging and production overlays
- Staging rendered output no longer references the drop rule
- Production overlays unaffected by this change

[PVO11Y-5262]: https://redhat.atlassian.net/browse/PVO11Y-5262?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ