### PR TITLE
KFLUXVNGD-1122 Upgrade crossplane-control-plane to latest in dev and staging

### DIFF
--- a/components/crossplane-control-plane/development/environment-config.yaml
+++ b/components/crossplane-control-plane/development/environment-config.yaml
@@ -1,0 +1,8 @@
+apiVersion: apiextensions.crossplane.io/v1beta1
+kind: EnvironmentConfig
+metadata:
+  name: envcfg
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+data:
+  clusterName: dev-cluster

--- a/components/crossplane-control-plane/development/kustomization.yaml
+++ b/components/crossplane-control-plane/development/kustomization.yaml
@@ -1,8 +1,9 @@
 resources:
 - ../base
-- https://github.com/konflux-ci/crossplane-control-plane/crossplane?ref=436006583e5203a6de0850569e76483aafbf6ea6
-- https://github.com/konflux-ci/crossplane-control-plane/config?ref=436006583e5203a6de0850569e76483aafbf6ea6
-- https://github.com/konflux-ci/crossplane-control-plane/examples/provider-kubernetes-in-cluster?ref=436006583e5203a6de0850569e76483aafbf6ea6
+- environment-config.yaml
+- https://github.com/konflux-ci/crossplane-control-plane/crossplane?ref=a91519bb2e0628895a351783c084dca911b1a4b4
+- https://github.com/konflux-ci/crossplane-control-plane/config?ref=a91519bb2e0628895a351783c084dca911b1a4b4
+- https://github.com/konflux-ci/crossplane-control-plane/examples/provider-kubernetes-in-cluster?ref=a91519bb2e0628895a351783c084dca911b1a4b4
 
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/components/crossplane-control-plane/staging/base/kustomization.yaml
+++ b/components/crossplane-control-plane/staging/base/kustomization.yaml
@@ -5,8 +5,8 @@ resources:
 - ../../base
 - provider-config.yaml
 - testplatform-provider-config.yaml
-- https://github.com/konflux-ci/crossplane-control-plane/crossplane?ref=436006583e5203a6de0850569e76483aafbf6ea6
-- https://github.com/konflux-ci/crossplane-control-plane/config?ref=436006583e5203a6de0850569e76483aafbf6ea6
+- https://github.com/konflux-ci/crossplane-control-plane/crossplane?ref=a91519bb2e0628895a351783c084dca911b1a4b4
+- https://github.com/konflux-ci/crossplane-control-plane/config?ref=a91519bb2e0628895a351783c084dca911b1a4b4
 
 images:
   - name: quay.io/konflux-ci/task-runner

--- a/components/crossplane-control-plane/staging/stone-stage-p01/environment-config.yaml
+++ b/components/crossplane-control-plane/staging/stone-stage-p01/environment-config.yaml
@@ -1,0 +1,8 @@
+apiVersion: apiextensions.crossplane.io/v1beta1
+kind: EnvironmentConfig
+metadata:
+  name: envcfg
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+data:
+  clusterName: stone-stage-p01

--- a/components/crossplane-control-plane/staging/stone-stage-p01/kustomization.yaml
+++ b/components/crossplane-control-plane/staging/stone-stage-p01/kustomization.yaml
@@ -3,3 +3,4 @@ kind: Kustomization
 
 resources:
 - ../base
+- environment-config.yaml

--- a/components/crossplane-control-plane/staging/stone-stg-rh01/environment-config.yaml
+++ b/components/crossplane-control-plane/staging/stone-stg-rh01/environment-config.yaml
@@ -1,0 +1,8 @@
+apiVersion: apiextensions.crossplane.io/v1beta1
+kind: EnvironmentConfig
+metadata:
+  name: envcfg
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+data:
+  clusterName: stone-stg-rh01

--- a/components/crossplane-control-plane/staging/stone-stg-rh01/kustomization.yaml
+++ b/components/crossplane-control-plane/staging/stone-stg-rh01/kustomization.yaml
@@ -3,3 +3,4 @@ kind: Kustomization
 
 resources:
 - ../base
+- environment-config.yaml


### PR DESCRIPTION
Deploy the latest crossplane-control-plane ref to development and staging overlays. The updated Compositions require cluster name context at runtime, so an EnvironmentConfig is added to each cluster overlay.

Assisted-by: Claude claude-opus-4-6