### PR TITLE
Revert "KFLUXVNGD-1064 Migrate squid to caching-helm chart v0.1.1688"

### DIFF
--- a/components/squid/production/kflux-fedora-01/kustomization.yaml
+++ b/components/squid/production/kflux-fedora-01/kustomization.yaml
@@ -5,4 +5,4 @@ resources:
 - artifact-registry-credentials.yaml
 
 generators:
-- caching-helm-generator.yaml
+- squid-helm-generator.yaml

--- a/components/squid/production/kflux-fedora-01/squid-helm-generator.yaml
+++ b/components/squid/production/kflux-fedora-01/squid-helm-generator.yaml
@@ -1,14 +1,11 @@
 apiVersion: builtin
 kind: HelmChartInflationGenerator
 metadata:
-  name: caching-helm
-name: caching-helm
-releaseName: squid
+  name: squid-helm
+name: squid-helm
 repo: oci://quay.io/konflux-ci/caching
-version: 0.1.1688+a7def07
+version: 0.1.1648+a6ad7bf
 valuesInline:
-  squid:
-    enabled: true
   installCertManagerComponents: false
   mirrord:
     enabled: false


### PR DESCRIPTION
Reverts redhat-appstudio/infra-deployments#12947