### PR TITLE
Remove releaseName from dev/staging caching-helm generators

### DIFF
--- a/components/squid/development/caching-helm-generator.yaml
+++ b/components/squid/development/caching-helm-generator.yaml
@@ -3,7 +3,6 @@ kind: HelmChartInflationGenerator
 metadata:
   name: caching-helm
 name: caching-helm
-releaseName: squid
 repo: oci://quay.io/konflux-ci/caching
 version: 0.1.1688+a7def07
 valuesInline:

--- a/components/squid/staging/caching-helm-generator.yaml
+++ b/components/squid/staging/caching-helm-generator.yaml
@@ -3,7 +3,6 @@ kind: HelmChartInflationGenerator
 metadata:
   name: caching-helm
 name: caching-helm
-releaseName: squid
 repo: oci://quay.io/konflux-ci/caching
 version: 0.1.1688+a7def07
 valuesInline:


### PR DESCRIPTION
The releaseName field is not needed as the chart name itself will be used as the Helm release name.

Jira-Url: https://redhat.atlassian.net/browse/KFLUXVNGD-1064