### PR TITLE
Remove releaseName from kflux-fedora-01 caching-helm generator

### DIFF
--- a/components/squid/production/kflux-fedora-01/caching-helm-generator.yaml
+++ b/components/squid/production/kflux-fedora-01/caching-helm-generator.yaml
@@ -3,7 +3,6 @@ kind: HelmChartInflationGenerator
 metadata:
   name: caching-helm
 name: caching-helm
-releaseName: squid
 repo: oci://quay.io/konflux-ci/caching
 version: 0.1.1688+a7def07
 valuesInline:


### PR DESCRIPTION
## What
Remove releaseName field from kflux-fedora-01 caching-helm generator.

## Cluster affected:
- kflux-fedora-01

## Why
The releaseName field is not needed as the chart name itself will be used as the Helm release name. This aligns with the configuration in development and staging environments.

## Validation
- Chart version 0.1.1688+a7def07 validated in development and staging environments
- Dev/staging releaseName removal completed in PR #12950

## Risk Assessment
Risk Level: Low
What could go wrong: Removing releaseName could cause Helm to create a new release instead of upgrading existing one, leading to resource conflicts.
Rollback: Revert this PR