### PR TITLE
SPRE-5502: Update cert-manager RHOBS federation based on actual clust…

### DIFF
--- a/components/monitoring/prometheus/staging/base/federation/endpoints-params.yaml
+++ b/components/monitoring/prometheus/staging/base/federation/endpoints-params.yaml
@@ -137,10 +137,12 @@
     - '{__name__="certmanager_certificate_ready_status", namespace="cert-manager"}'
     - '{__name__="certmanager_certificate_expiration_timestamp_seconds", namespace="cert-manager"}'
     - '{__name__="certmanager_certificate_renewal_timestamp_seconds", namespace="cert-manager"}'
+    - '{__name__="certmanager_certificate_not_after_timestamp_seconds", namespace="cert-manager"}'
+    - '{__name__="certmanager_certificate_not_before_timestamp_seconds", namespace="cert-manager"}'
     - '{__name__="certmanager_controller_sync_call_count", namespace="cert-manager"}'
     - '{__name__="certmanager_controller_sync_error_count", namespace="cert-manager"}'
-    - '{__name__="certmanager_http_acme_client_request_count", namespace="cert-manager"}'
-    - '{__name__="certmanager_http_acme_client_request_duration_seconds", namespace="cert-manager"}'
+    - '{__name__="certmanager_clusterissuer_ready_status", namespace="cert-manager"}'
+    - '{__name__="certmanager_issuer_ready_status", namespace="cert-manager"}'
 
     ## Container Metrics
     - '{__name__="kube_pod_container_status_waiting_reason", namespace!~".*-tenant|openshift-.*|kube-.*"}'

--- a/components/monitoring/prometheus/staging/base/federation/writeRelabelConfigs.yaml
+++ b/components/monitoring/prometheus/staging/base/federation/writeRelabelConfigs.yaml
@@ -43,4 +43,4 @@
       resource_type|gin_errors|\
       metric|label|label_pair|scraped_instance|sharded_instance|instance_namespace|\
       application|component|build_type|scenario|optional|test_type|automated|exported_namespace|\
-      condition|issuer_name|issuer_kind|issuer_group|scheme|host|action"
+      condition|issuer_name|issuer_kind|issuer_group"


### PR DESCRIPTION
Summary
  
Update cert-manager metrics in the staging RHOBS federation based on actual cluster data from stone-stage-p01.
Part of epic [SPRE-5499](https://redhat.atlassian.net/browse/SPRE-5499) (https://redhat.atlassian.net/browse/SPRE-5499) — cert-manager Monitoring: Metrics, Alerts, Dashboard & SOPs.
  

Why

- PR #12937 (https://github.com/redhat-appstudio/infra-deployments/pull/12937) added the initial cert-manager metrics but included ACME metrics that don't exist on
cluster and missed metrics that do. This PR corrects the list based on actual metrics verified on stone-stage-p01.
  
How it was tested
  
 - Metrics verified against {__name__=~"certmanager.*"} query on stone-stage-p01 OpenShift console
 - kustomize build passes for all staging federation overlays

[SPRE-5499]: https://redhat.atlassian.net/browse/SPRE-5499?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ