### PR TITLE
fix(KONFLUX-13555): upgrade otel collector to 0.155.0 in stone prod clusters (1/3)

### DIFF
--- a/components/kubearchive/production/stone-prd-rh01/kustomization.yaml
+++ b/components/kubearchive/production/stone-prd-rh01/kustomization.yaml
@@ -366,4 +366,4 @@ patches:
           spec:
             containers:
               - name: otel-collector
-                image: quay.io/kubearchive/opentelemetry-collector@sha256:74edb825a429b415262e7eb7a99ed77685c9b2b7238ef69fb42a3625df75458f
+                image: quay.io/kubearchive/opentelemetry-collector@sha256:1f8c9a186c56f5ab4ffdd937ecce621aef116868f6022f3652c5d285b5788f8a

--- a/components/kubearchive/production/stone-prod-p01/kustomization.yaml
+++ b/components/kubearchive/production/stone-prod-p01/kustomization.yaml
@@ -348,5 +348,5 @@ patches:
           spec:
             containers:
               - name: otel-collector
-                image: quay.io/kubearchive/opentelemetry-collector@sha256:74edb825a429b415262e7eb7a99ed77685c9b2b7238ef69fb42a3625df75458f
+                image: quay.io/kubearchive/opentelemetry-collector@sha256:1f8c9a186c56f5ab4ffdd937ecce621aef116868f6022f3652c5d285b5788f8a
 

--- a/components/kubearchive/production/stone-prod-p02/kustomization.yaml
+++ b/components/kubearchive/production/stone-prod-p02/kustomization.yaml
@@ -361,5 +361,5 @@ patches:
           spec:
             containers:
               - name: otel-collector
-                image: quay.io/kubearchive/opentelemetry-collector@sha256:74edb825a429b415262e7eb7a99ed77685c9b2b7238ef69fb42a3625df75458f
+                image: quay.io/kubearchive/opentelemetry-collector@sha256:1f8c9a186c56f5ab4ffdd937ecce621aef116868f6022f3652c5d285b5788f8a
 


### PR DESCRIPTION
## What                                                                            
 This PR updates opentelemetry-collector from 0.123.0 to 0.155.0 in the production overlays:
- stone-prd-rh01
- stone-prod-p01
- stone-prod-p02 
to remediate [CVE-2026-41636](https://github.com/advisories/GHSA-r67j-r569-jrwp).
                                                                                                                                                                        
 ## Why             
Remediates CVE-2026-41636 for opentelemetry-collector.
               
Closes:                                                                            
                                                                                   
[KONFLUX-13555](https://redhat.atlassian.net/browse/KONFLUX-13555)                 
                                                                                
## Risk Assessment                                                                 
                                                                                    
**Risk Level:** Low                                                                
**Description:** Some KubeArchive performance metrics data can be lost during the rollout.   
**Rollback:** Revert the image reference in `stone-prd-rh01/kustomization.yaml`, `stone-prod-p01/kustomization.yaml`, `stone-prod-p02/kustomization.yaml` to the previous version (0.123.0 / sha256:74edb825...) and the older otel-collector will be deployed.                            

## Validation
Ran 
```
kustomize build --enable-helm components/kubearchive/production/stone-prod-p01/
kustomize build --enable-helm components/kubearchive/production/stone-prod-p02/
kustomize build --enable-helm components/kubearchive/production/stone-prd-rh01/
```
output rendered successfully.
Deployed a local cluster using KubeArchive with the new image and verified everything works correctly.
```
kubectl logs -n kubearchive -l app=otel-collector -c otel-collector --tail=20
2026-06-30T13:45:01.160Z	info	otelconftelemetry/tracer.go:47	Internal trace telemetry disabled	{"resource": {..., "service.version": "0.155.0"}}
2026-06-30T13:45:01.164Z	info	service@v0.155.0/service.go:256	Starting otelcol-contrib...	{"Version": "0.155.0", "NumCPU": 22}
2026-06-30T13:45:01.165Z	info	otlpreceiver@v0.155.0/otlp.go:175	Starting HTTP server	{"endpoint": "[::]:4318"}
2026-06-30T13:45:01.165Z	info	service@v0.155.0/service.go:279	Everything is ready. Begin running and processing data.
```
PR merged in [staging](https://github.com/redhat-appstudio/infra-deployments/pull/12943)
PR merged in [development](https://github.com/redhat-appstudio/infra-deployments/pull/12919)
[KONFLUX-13555]: https://redhat.atlassian.net/browse/KONFLUX-13555