### PR TITLE
disable failing s390x machines on rh02

### DIFF
--- a/components/kueue/production/kflux-prd-rh02/queue-config/cluster-queue.yaml
+++ b/components/kueue/production/kflux-prd-rh02/queue-config/cluster-queue.yaml
@@ -164,7 +164,7 @@ spec:
       - name: linux-root-arm64
         nominalQuota: '250'
       - name: linux-s390x
-        nominalQuota: '64'
+        nominalQuota: '48'
       - name: linux-x86-64
         nominalQuota: 1k
       - name: local

--- a/components/multi-platform-controller/production/kflux-prd-rh02/host-values.yaml
+++ b/components/multi-platform-controller/production/kflux-prd-rh02/host-values.yaml
@@ -245,30 +245,30 @@ staticHosts:
     secret: "ibm-s390x-ssh-key"
     user: "cloud-user"  # Changed from root per IBM Cloud Jan 2026 announcement
 
-  s390x-static-13:
-    address: "10.250.67.6"
-    concurrency: "4"
-    platform: "linux/s390x"
-    secret: "ibm-s390x-ssh-key"
-    user: "cloud-user"  # Changed from root per IBM Cloud Jan 2026 announcement
-
-  s390x-static-14:
-    address: "10.250.67.7"
-    concurrency: "4"
-    platform: "linux/s390x"
-    secret: "ibm-s390x-ssh-key"
-    user: "cloud-user"  # Changed from root per IBM Cloud Jan 2026 announcement
-
-  s390x-static-15:
-    address: "10.250.67.8"
-    concurrency: "4"
-    platform: "linux/s390x"
-    secret: "ibm-s390x-ssh-key"
-    user: "cloud-user"  # Changed from root per IBM Cloud Jan 2026 announcement
-
-  s390x-static-16:
-    address: "10.250.67.9"
-    concurrency: "4"
-    platform: "linux/s390x"
-    secret: "ibm-s390x-ssh-key"
-    user: "cloud-user"  # Changed from root per IBM Cloud Jan 2026 announcement
+  # s390x-static-13:
+  #   address: "10.250.67.6"
+  #   concurrency: "4"
+  #   platform: "linux/s390x"
+  #   secret: "ibm-s390x-ssh-key"
+  #   user: "cloud-user"  # Changed from root per IBM Cloud Jan 2026 announcement
+  #
+  # s390x-static-14:
+  #   address: "10.250.67.7"
+  #   concurrency: "4"
+  #   platform: "linux/s390x"
+  #   secret: "ibm-s390x-ssh-key"
+  #   user: "cloud-user"  # Changed from root per IBM Cloud Jan 2026 announcement
+  #
+  # s390x-static-15:
+  #   address: "10.250.67.8"
+  #   concurrency: "4"
+  #   platform: "linux/s390x"
+  #   secret: "ibm-s390x-ssh-key"
+  #   user: "cloud-user"  # Changed from root per IBM Cloud Jan 2026 announcement
+  #
+  # s390x-static-16:
+  #   address: "10.250.67.9"
+  #   concurrency: "4"
+  #   platform: "linux/s390x"
+  #   secret: "ibm-s390x-ssh-key"
+  #   user: "cloud-user"  # Changed from root per IBM Cloud Jan 2026 announcement


### PR DESCRIPTION
Some s390x are failing, we want to temporarily disable them until they are recovered.

Signed-off-by: Francesco Ilario <filario@redhat.com>

rh-pre-commit.version: 2.4.0
rh-pre-commit.check-secrets: ENABLED
