### PR TITLE
ci: upgrade base image for konflux operator dockerfile

### DIFF
--- a/components/konflux-operator/ci/openshift-overlay-e2e/Dockerfile
+++ b/components/konflux-operator/ci/openshift-overlay-e2e/Dockerfile
@@ -3,9 +3,9 @@
 # ci-operator/config/redhat-appstudio/infra-deployments/.
 #
 # - task-runner: oc, kubectl, jq, yq, git, skopeo, oras, buildah, … (bootstrap/preview)
-# - ubi10/go-toolset @ digest: Go 1.26 for konflux-ci conformance (go test)
+# - ubi10/go-toolset @ digest: Go 1.26.4 for konflux-ci conformance (go test)
 
-FROM registry.access.redhat.com/ubi10/go-toolset@sha256:420e5156ac65cc5c32ba1a2ae7e0fa3bc369728cc8d1740db134a76af7d6c471 AS go-toolset
+FROM registry.access.redhat.com/ubi10/go-toolset@sha256:120c56d15943f96f84c7d415432fc82a9212ea58f6cbebf516587fb854d8631a AS go-toolset
 
 FROM quay.io/konflux-ci/task-runner@sha256:1abfe4e50d4e961d0fd9790202565f93ee650fe8dfc50932c94989acba10485f
 

--- a/components/konflux-operator/ci/openshift-overlay-e2e/README.md
+++ b/components/konflux-operator/ci/openshift-overlay-e2e/README.md
@@ -10,7 +10,7 @@ step refs (`konflux-ci-install-konflux`, `redhat-appstudio-conformance-tests`).
 
 | File | Role |
 |------|------|
-| `Dockerfile` | Unified CI image (`konflux-overlay-install`): task-runner + Go 1.26 from ubi10/go-toolset |
+| `Dockerfile` | Unified CI image (`konflux-overlay-install`): task-runner + Go 1.26.4 from ubi10/go-toolset |
 | `ci-common.sh` | Shared cluster login (temp kubeconfig copy) and ephemeral git credentials |
 | `install.sh` | `hack/bootstrap-cluster.sh preview --operator-overlay`, QE secrets, SprayProxy, `e2e-secrets` quay pull secret |
 | `run-e2e.sh` | Clone konflux-ci @ ref from `invariant/kustomization.yaml`; `prepare-conformance-env` + `test/e2e/run-e2e.sh` (deploy test resources, proxy integration tests, then conformance in `default-tenant`) |


### PR DESCRIPTION
Some dependency upgrades in the upstream test code now require go 1.26.4. Tests will fail here if we don't upgrade.