### PR TITLE
PVO11Y-5280 Deploy KubeArchive exporter to production

### DIFF
--- a/argo-cd-apps/base/member/infra-deployments/monitoring-konflux-o11y-exporters/monitoring-workload-konflux-o11y-exporters.yaml
+++ b/argo-cd-apps/base/member/infra-deployments/monitoring-konflux-o11y-exporters/monitoring-workload-konflux-o11y-exporters.yaml
@@ -19,6 +19,24 @@ spec:
                   values.clusterDir: stone-stage-p01
                 - nameNormalized: stone-stg-rh01
                   values.clusterDir: stone-stg-rh01
+                - nameNormalized: stone-prd-rh01
+                  values.clusterDir: stone-prd-rh01
+                - nameNormalized: stone-prod-p01
+                  values.clusterDir: stone-prod-p01
+                - nameNormalized: stone-prod-p02
+                  values.clusterDir: stone-prod-p02
+                - nameNormalized: kflux-ocp-p01
+                  values.clusterDir: kflux-ocp-p01
+                - nameNormalized: kflux-prd-rh02
+                  values.clusterDir: kflux-prd-rh02
+                - nameNormalized: kflux-prd-rh03
+                  values.clusterDir: kflux-prd-rh03
+                - nameNormalized: kflux-rhel-p01
+                  values.clusterDir: kflux-rhel-p01
+                - nameNormalized: kflux-osp-p01
+                  values.clusterDir: kflux-osp-p01
+                - nameNormalized: kflux-fedora-01
+                  values.clusterDir: kflux-fedora-01
   template:
     metadata:
       name: konflux-o11y-kaexporter-{{nameNormalized}}

--- a/components/monitoring/exporters/kaexporter/production/base/external-secrets/ka-kubearchive-credentials.yaml
+++ b/components/monitoring/exporters/kaexporter/production/base/external-secrets/ka-kubearchive-credentials.yaml
@@ -1,0 +1,19 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: ka-kubearchive-credentials
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  dataFrom:
+    - extract:
+        key: stonesoup/production/monitoring/exporters/kaexporter
+  refreshInterval: 15m
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: appsre-stonesoup-vault
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    name: ka-kubearchive-credentials

--- a/components/monitoring/exporters/kaexporter/production/base/external-secrets/kustomization.yaml
+++ b/components/monitoring/exporters/kaexporter/production/base/external-secrets/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - ka-kubearchive-credentials.yaml

--- a/components/monitoring/exporters/kaexporter/production/base/kustomization.yaml
+++ b/components/monitoring/exporters/kaexporter/production/base/kustomization.yaml
@@ -1,0 +1,9 @@
+resources:
+  - rbac
+  - external-secrets
+  - https://github.com/redhat-appstudio/o11y/config/exporters/monitoring/kaexporter/base?ref=ba0e3f48c0a85cb0d59a3812faefb4da9cd8f763
+
+images:
+  - name: quay.io/redhat-appstudio/o11y
+    newName: quay.io/redhat-appstudio/o11y
+    newTag: ba0e3f48c0a85cb0d59a3812faefb4da9cd8f763

--- a/components/monitoring/exporters/kaexporter/production/base/rbac/kaexporter-maintainers.yaml
+++ b/components/monitoring/exporters/kaexporter/production/base/rbac/kaexporter-maintainers.yaml
@@ -1,0 +1,11 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: appstudio-ka-exporter-maintainers
+subjects:
+  - kind: Group
+    name: konflux-o11y
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: component-maintainer

--- a/components/monitoring/exporters/kaexporter/production/base/rbac/kustomization.yaml
+++ b/components/monitoring/exporters/kaexporter/production/base/rbac/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - kaexporter-maintainers.yaml

--- a/components/monitoring/exporters/kaexporter/production/kflux-fedora-01/kustomization.yaml
+++ b/components/monitoring/exporters/kaexporter/production/kflux-fedora-01/kustomization.yaml
@@ -1,0 +1,11 @@
+resources:
+  - ../base
+
+patches:
+  - target:
+      kind: ExternalSecret
+      name: ka-kubearchive-credentials
+    patch: |
+      - op: replace
+        path: /spec/dataFrom/0/extract/key
+        value: stonesoup/production/monitoring/exporters/kaexporter/kflux-fedora-01

--- a/components/monitoring/exporters/kaexporter/production/kflux-ocp-p01/kustomization.yaml
+++ b/components/monitoring/exporters/kaexporter/production/kflux-ocp-p01/kustomization.yaml
@@ -1,0 +1,11 @@
+resources:
+  - ../base
+
+patches:
+  - target:
+      kind: ExternalSecret
+      name: ka-kubearchive-credentials
+    patch: |
+      - op: replace
+        path: /spec/dataFrom/0/extract/key
+        value: stonesoup/production/monitoring/exporters/kaexporter/kflux-ocp-p01

--- a/components/monitoring/exporters/kaexporter/production/kflux-osp-p01/kustomization.yaml
+++ b/components/monitoring/exporters/kaexporter/production/kflux-osp-p01/kustomization.yaml
@@ -1,0 +1,11 @@
+resources:
+  - ../base
+
+patches:
+  - target:
+      kind: ExternalSecret
+      name: ka-kubearchive-credentials
+    patch: |
+      - op: replace
+        path: /spec/dataFrom/0/extract/key
+        value: stonesoup/production/monitoring/exporters/kaexporter/kflux-osp-p01

--- a/components/monitoring/exporters/kaexporter/production/kflux-prd-rh02/kustomization.yaml
+++ b/components/monitoring/exporters/kaexporter/production/kflux-prd-rh02/kustomization.yaml
@@ -1,0 +1,11 @@
+resources:
+  - ../base
+
+patches:
+  - target:
+      kind: ExternalSecret
+      name: ka-kubearchive-credentials
+    patch: |
+      - op: replace
+        path: /spec/dataFrom/0/extract/key
+        value: stonesoup/production/monitoring/exporters/kaexporter/kflux-prd-rh02

--- a/components/monitoring/exporters/kaexporter/production/kflux-prd-rh03/kustomization.yaml
+++ b/components/monitoring/exporters/kaexporter/production/kflux-prd-rh03/kustomization.yaml
@@ -1,0 +1,11 @@
+resources:
+  - ../base
+
+patches:
+  - target:
+      kind: ExternalSecret
+      name: ka-kubearchive-credentials
+    patch: |
+      - op: replace
+        path: /spec/dataFrom/0/extract/key
+        value: stonesoup/production/monitoring/exporters/kaexporter/kflux-prd-rh03

--- a/components/monitoring/exporters/kaexporter/production/kflux-rhel-p01/kustomization.yaml
+++ b/components/monitoring/exporters/kaexporter/production/kflux-rhel-p01/kustomization.yaml
@@ -1,0 +1,11 @@
+resources:
+  - ../base
+
+patches:
+  - target:
+      kind: ExternalSecret
+      name: ka-kubearchive-credentials
+    patch: |
+      - op: replace
+        path: /spec/dataFrom/0/extract/key
+        value: stonesoup/production/monitoring/exporters/kaexporter/kflux-rhel-p01

--- a/components/monitoring/exporters/kaexporter/production/kustomization.yaml
+++ b/components/monitoring/exporters/kaexporter/production/kustomization.yaml
@@ -1,1 +1,0 @@
-resources: []

--- a/components/monitoring/exporters/kaexporter/production/stone-prd-rh01/kustomization.yaml
+++ b/components/monitoring/exporters/kaexporter/production/stone-prd-rh01/kustomization.yaml
@@ -1,0 +1,11 @@
+resources:
+  - ../base
+
+patches:
+  - target:
+      kind: ExternalSecret
+      name: ka-kubearchive-credentials
+    patch: |
+      - op: replace
+        path: /spec/dataFrom/0/extract/key
+        value: stonesoup/production/monitoring/exporters/kaexporter/stone-prd-rh01

--- a/components/monitoring/exporters/kaexporter/production/stone-prod-p01/kustomization.yaml
+++ b/components/monitoring/exporters/kaexporter/production/stone-prod-p01/kustomization.yaml
@@ -1,0 +1,11 @@
+resources:
+  - ../base
+
+patches:
+  - target:
+      kind: ExternalSecret
+      name: ka-kubearchive-credentials
+    patch: |
+      - op: replace
+        path: /spec/dataFrom/0/extract/key
+        value: stonesoup/production/monitoring/exporters/kaexporter/stone-prod-p01

--- a/components/monitoring/exporters/kaexporter/production/stone-prod-p02/kustomization.yaml
+++ b/components/monitoring/exporters/kaexporter/production/stone-prod-p02/kustomization.yaml
@@ -1,0 +1,11 @@
+resources:
+  - ../base
+
+patches:
+  - target:
+      kind: ExternalSecret
+      name: ka-kubearchive-credentials
+    patch: |
+      - op: replace
+        path: /spec/dataFrom/0/extract/key
+        value: stonesoup/production/monitoring/exporters/kaexporter/stone-prod-p02


### PR DESCRIPTION
## Summary

- Add production overlays for kaexporter with per-cluster vault paths
- Add 8 production clusters to the ApplicationSet list elements
- Replace empty `production/kustomization.yaml` with full `production/base/` structure (same pattern as staging)

## Structure

```
production/
├── base/                    ← o11y remote ref, RBAC, ExternalSecret (generic vault path)
├── stone-prd-rh01/          ← patches vault key to cluster-specific path
├── stone-prod-p01/
├── stone-prod-p02/
├── kflux-ocp-p01/
├── kflux-prd-rh02/
├── kflux-prd-rh03/
├── kflux-rhel-p01/
└── kflux-fedora-01/
```

## Prerequisites

Before merging, ensure:
- [ ] Vault paths are populated for each production cluster: `stonesoup/production/monitoring/exporters/kaexporter/<cluster-name>` with `ka-host` key
- [ ] Staging exporter has been validated (PVO11Y-5279)

## Validation

- [ ] `kustomize build` passes for all production overlays
- [ ] Exporter pods start and scrape successfully on production clusters

[PVO11Y-5280](https://redhat.atlassian.net/browse/PVO11Y-5280)

[PVO11Y-5280]: https://redhat.atlassian.net/browse/PVO11Y-5280?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ