### PR TITLE
feat(KFLUXVNGD-1064): Migrate squid to caching-helm chart v0.1.1688

### DIFF
--- a/components/squid/production/stone-prd-rh01/caching-helm-generator.yaml
+++ b/components/squid/production/stone-prd-rh01/caching-helm-generator.yaml
@@ -1,11 +1,13 @@
 apiVersion: builtin
 kind: HelmChartInflationGenerator
 metadata:
-  name: squid-helm
-name: squid-helm
+  name: caching-helm
+name: caching-helm
 repo: oci://quay.io/konflux-ci/caching
-version: 0.1.1648+a6ad7bf
+version: 0.1.1688+a7def07
 valuesInline:
+  squid:
+    enabled: true
   installCertManagerComponents: false
   mirrord:
     enabled: false

--- a/components/squid/production/stone-prd-rh01/kustomization.yaml
+++ b/components/squid/production/stone-prd-rh01/kustomization.yaml
@@ -5,4 +5,4 @@ resources:
 - artifact-registry-credentials.yaml
 
 generators:
-- squid-helm-generator.yaml
+- caching-helm-generator.yaml


### PR DESCRIPTION
## What
Migrate squid component from squid-helm chart to caching-helm chart v0.1.1688+a7def07 on production stone-prd-rh01 cluster.

Cluster affected:
- stone-prd-rh01

## Why
The upstream caching chart was renamed from squid-helm to caching-helm in version 0.1.1688. This migration ensures consistent chart naming across all environments.

## Validation
- Chart version 0.1.1688+a7def07 validated in development and staging environments
- Dev/staging migration completed in PR #12933
- kflux-fedora-01 production migration completed in PR #12947

## Risk Assessment
**Risk Level:** Low
**Description:** Chart upgrade could introduce regression in squid or nginx proxy behavior.
**Rollback:** Revert this PR to return cluster to squid-helm 0.1.1648+a6ad7bf.