### PR TITLE
fix(policies): use request.namespace to avoid Kyverno autogen path rewrite

### DIFF
--- a/components/policies/development/cost-management/propagate-cost-management-labels/propagate-cost-management-labels.yaml
+++ b/components/policies/development/cost-management/propagate-cost-management-labels/propagate-cost-management-labels.yaml
@@ -41,8 +41,7 @@ spec:
         - name: costcenterLabel
           globalReference:
             name: namespaces
-            jmesPath: "[?metadata.name == '{{ request.object.metadata.namespace }}']\
-              \ | [0].metadata.labels.\"cost-center\""
+            jmesPath: "[?metadata.name == '{{ request.namespace }}'] | [0].metadata.labels.\"cost-center\""
       preconditions:
         all:
           - key: '{{ costcenterLabel }}'


### PR DESCRIPTION
Kyverno's autogen controller rewrites request.object.metadata.namespace to spec.template.metadata.namespace for pod controllers, which is an invalid path (namespace is never present in pod template metadata).
Switch to request.namespace, a top-level AdmissionReview field that is not subject to autogen translation, fixing the cost-center label lookup for autogen-generated rules targeting Deployments, StatefulSets, Jobs, and CronJobs.

request.namespace is a top-level AdmissionReview field, always populated for namespace resources.
Kyverno only rewrites paths prefixed with request.object — request.namespace is not subject to autogen translation
This is the official recommendation based on https://github.com/kyverno/kyverno/issues/7032