### PR TITLE
PVO11Y-5265 Fix stone-prod-p01 kanary multi-arch template

### DIFF
--- a/components/monitoring/kanary/production/stone-prod-p01/cronjobs/kanary-cronjob-multi-arch.yaml
+++ b/components/monitoring/kanary/production/stone-prod-p01/cronjobs/kanary-cronjob-multi-arch.yaml
@@ -38,7 +38,7 @@ spec:
                     --param user-prefix=prodp01cm \
                     --param quay-repo=redhat-user-workloads \
                     --param pipeline-repo-templating-source=https://github.com/rhtap-perf-test/konflux-probe-test-templates \
-                    --param pipeline-repo-templating-source-dir=nodejs-devfile-sample-MultiArch/ \
+                    --param pipeline-repo-templating-source-dir=nodejs-devfile-sample-MultiArch-only-ARM-and-AMD/ \
                     --param release-pipeline-service-account=managed-konflux-perfscale-sa \
                     --param fork-target="jhutar" \
                     --param gitlab-api-url="https://gitlab.cee.redhat.com/api/v4" \


### PR DESCRIPTION
## Summary

- Use `nodejs-devfile-sample-MultiArch-only-ARM-and-AMD/` template for kanary multi-arch on stone-prod-p01
- This cluster lacks ppc64le/s390x Kueue resources, so builds requesting all four architectures get stuck in PipelineRunPending indefinitely
- Aligns kanary with what Jenkins already uses for multi-arch on this cluster

## Risk Assessment

- **Level**: Low
- **Description**: Changes only the kanary multi-arch cronjob template on stone-prod-p01, matching the Jenkins configuration that already works
- **Rollback**: Revert the template path back to `nodejs-devfile-sample-MultiArch/`

## Validation

- Jenkins multi-arch probes on stone-prod-p01 use `nodejs-devfile-sample-MultiArch-only-ARM-and-AMD/` and run successfully
- Kanary multi-arch was stuck with `resource linux-ppc64le unavailable in ClusterQueue` using the full template

## JIRA

[PVO11Y-5265](https://issues.redhat.com/browse/PVO11Y-5265)

[PVO11Y-5265]: https://redhat.atlassian.net/browse/PVO11Y-5265?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ