### PR TITLE
KONFLUX-14156 Update multi-platform-controller on production (ring-1)

### DIFF
--- a/components/multi-platform-controller/production-downstream/kflux-osp-p01/kustomization.yaml
+++ b/components/multi-platform-controller/production-downstream/kflux-osp-p01/kustomization.yaml
@@ -4,8 +4,23 @@ kind: Kustomization
 namespace: multi-platform-controller
 
 resources:
-- ../base
+- ../../base/common
+- ../../base/rbac
+- ../../production/logcollector-ring1
+- https://github.com/konflux-ci/multi-platform-controller/deploy/operator?ref=a5285b319d913f46dc0617fa54fb07817dff7593
+- https://github.com/konflux-ci/multi-platform-controller/deploy/otp?ref=a5285b319d913f46dc0617fa54fb07817dff7593
 - external-secrets.yaml
+
+components:
+  - ../../k-components/manager-resources
+
+images:
+- name: multi-platform-controller
+  newName: quay.io/konflux-ci/multi-platform-controller
+  newTag: a5285b319d913f46dc0617fa54fb07817dff7593
+- name: multi-platform-otp-server
+  newName: quay.io/konflux-ci/multi-platform-controller-otp-service
+  newTag: a5285b319d913f46dc0617fa54fb07817dff7593
 
 patches:
   - path: manager_resources_patch.yaml

--- a/components/multi-platform-controller/production-downstream/stone-prod-p01/kustomization.yaml
+++ b/components/multi-platform-controller/production-downstream/stone-prod-p01/kustomization.yaml
@@ -4,8 +4,23 @@ kind: Kustomization
 namespace: multi-platform-controller
 
 resources:
-- ../base
+- ../../base/common
+- ../../base/rbac
+- ../../production/logcollector-ring1
+- https://github.com/konflux-ci/multi-platform-controller/deploy/operator?ref=a5285b319d913f46dc0617fa54fb07817dff7593
+- https://github.com/konflux-ci/multi-platform-controller/deploy/otp?ref=a5285b319d913f46dc0617fa54fb07817dff7593
 - external-secrets.yaml
+
+components:
+  - ../../k-components/manager-resources
+
+images:
+- name: multi-platform-controller
+  newName: quay.io/konflux-ci/multi-platform-controller
+  newTag: a5285b319d913f46dc0617fa54fb07817dff7593
+- name: multi-platform-otp-server
+  newName: quay.io/konflux-ci/multi-platform-controller-otp-service
+  newTag: a5285b319d913f46dc0617fa54fb07817dff7593
 
 helmGlobals:
   chartHome: ../../base

--- a/components/multi-platform-controller/production/kflux-fedora-01/kustomization.yaml
+++ b/components/multi-platform-controller/production/kflux-fedora-01/kustomization.yaml
@@ -4,8 +4,23 @@ kind: Kustomization
 namespace: multi-platform-controller
 
 resources:
-- ../base
+- ../../base/common
+- ../../base/rbac
+- ../logcollector-ring1
+- https://github.com/konflux-ci/multi-platform-controller/deploy/operator?ref=a5285b319d913f46dc0617fa54fb07817dff7593
+- https://github.com/konflux-ci/multi-platform-controller/deploy/otp?ref=a5285b319d913f46dc0617fa54fb07817dff7593
 - external-secrets.yaml
+
+components:
+  - ../../k-components/manager-resources
+
+images:
+- name: multi-platform-controller
+  newName: quay.io/konflux-ci/multi-platform-controller
+  newTag: a5285b319d913f46dc0617fa54fb07817dff7593
+- name: multi-platform-otp-server
+  newName: quay.io/konflux-ci/multi-platform-controller-otp-service
+  newTag: a5285b319d913f46dc0617fa54fb07817dff7593
 
 patches:
   - path: manager_resources_patch.yaml

--- a/components/multi-platform-controller/production/kflux-prd-rh02/kustomization.yaml
+++ b/components/multi-platform-controller/production/kflux-prd-rh02/kustomization.yaml
@@ -4,8 +4,23 @@ kind: Kustomization
 namespace: multi-platform-controller
 
 resources:
-  - ../base
+  - ../../base/common
+  - ../../base/rbac
+  - ../logcollector-ring1
+  - https://github.com/konflux-ci/multi-platform-controller/deploy/operator?ref=a5285b319d913f46dc0617fa54fb07817dff7593
+  - https://github.com/konflux-ci/multi-platform-controller/deploy/otp?ref=a5285b319d913f46dc0617fa54fb07817dff7593
   - external-secrets.yaml
+
+components:
+  - ../../k-components/manager-resources
+
+images:
+  - name: multi-platform-controller
+    newName: quay.io/konflux-ci/multi-platform-controller
+    newTag: a5285b319d913f46dc0617fa54fb07817dff7593
+  - name: multi-platform-otp-server
+    newName: quay.io/konflux-ci/multi-platform-controller-otp-service
+    newTag: a5285b319d913f46dc0617fa54fb07817dff7593
 
 patches:
   - path: manager_resources_patch.yaml

--- a/components/multi-platform-controller/production/kflux-prd-rh03/kustomization.yaml
+++ b/components/multi-platform-controller/production/kflux-prd-rh03/kustomization.yaml
@@ -4,8 +4,23 @@ kind: Kustomization
 namespace: multi-platform-controller
 
 resources:
-  - ../base
+  - ../../base/common
+  - ../../base/rbac
+  - ../logcollector-ring1
+  - https://github.com/konflux-ci/multi-platform-controller/deploy/operator?ref=a5285b319d913f46dc0617fa54fb07817dff7593
+  - https://github.com/konflux-ci/multi-platform-controller/deploy/otp?ref=a5285b319d913f46dc0617fa54fb07817dff7593
   - external-secrets.yaml
+
+components:
+  - ../../k-components/manager-resources
+
+images:
+  - name: multi-platform-controller
+    newName: quay.io/konflux-ci/multi-platform-controller
+    newTag: a5285b319d913f46dc0617fa54fb07817dff7593
+  - name: multi-platform-otp-server
+    newName: quay.io/konflux-ci/multi-platform-controller-otp-service
+    newTag: a5285b319d913f46dc0617fa54fb07817dff7593
 
 patches:
   - path: manager_resources_patch.yaml

--- a/components/multi-platform-controller/production/logcollector-ring1/kustomization.yaml
+++ b/components/multi-platform-controller/production/logcollector-ring1/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - otelcollector.yaml

--- a/components/multi-platform-controller/production/logcollector-ring1/otelcollector.yaml
+++ b/components/multi-platform-controller/production/logcollector-ring1/otelcollector.yaml
@@ -1,0 +1,173 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: otelcol-config
+  namespace: multi-platform-controller
+  labels:
+    build.appstudio.redhat.com/multi-platform-secret: "true"
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  data:
+    - secretKey: endpoint
+      remoteRef:
+        key: production/infrastructure/splunk/external_endpoint
+        property: splunk_endpoint
+    - secretKey: token
+      remoteRef:
+        key: production/infrastructure/splunk/external_endpoint
+        property: splunk_hec_token
+    - secretKey: index
+      remoteRef:
+        key: production/infrastructure/splunk/external_endpoint
+        property: splunk_index
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: appsre-stonesoup-vault
+  target:
+    name: otelcol-config
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    template:
+      type: Opaque
+      data:
+        config.yaml: |
+          exporters:
+            splunk_hec/corp:
+              endpoint: {{ .endpoint }}
+              token: {{ .token }}
+              disable_compression: false
+              sending_queue:
+                storage: file_storage/otc
+                enabled: true
+                num_consumers: 2
+                queue_size: 10
+                sizer: items
+                batch:
+                  max_size: 100
+                  min_size: 1
+                  flush_timeout: 1s
+              retry_on_failure:
+                enabled: true
+                initial_interval: 10s
+                max_interval: 60s
+                max_elapsed_time: 10m
+          extensions:
+            file_storage/otc:
+              directory: /tmp/otelcollector/oteltmp
+              timeout: 10s
+              create_directory: true
+          processors:
+            transform/common:
+              error_mode: ignore
+              log_statements:
+                - context: log
+                  statements:
+                    - set(attributes["com.splunk.source"], attributes["log.file.path"])
+                    - set(attributes["host.name"], resource.attributes["host.name"])
+                    - set(attributes["appcode"], resource.attributes["appcode"])
+                    - set(attributes["instance.tag"], resource.attributes["instance.tag"])
+                    - keep_keys(attributes, ["com.splunk.source", "host.name", "appcode", "instance.tag", "com.splunk.index", "com.splunk.sourcetype"])
+            resource/add_appcode:
+              attributes:
+                - action: insert
+                  key: appcode
+                  value: "ASSH-001"
+            resource/add_instance_tag:
+              attributes:
+                - action: insert
+                  key: instance.tag
+                  value: ${env:INST_TAG:-default}
+            resourcedetection/system:
+              detectors:
+                - system
+              override: true
+              system:
+                hostname_sources:
+                  - os
+                resource_attributes:
+                  host.id:
+                    enabled: false
+                  host.name:
+                    enabled: true
+                  os.type:
+                    enabled: true
+          receivers:
+            filelog/{{ .index }}_audit:
+              include:
+                - /var/log/audit/audit.log
+              include_file_path: true
+              exclude_older_than: 86400s
+              operators:
+                - type: add
+                  id: {{ .index }}_idx
+                  field: attributes["com.splunk.index"]
+                  value: {{ .index }}
+                  on_error: send
+                - type: add
+                  id: rh_assh-001_audit_st
+                  field: attributes["com.splunk.sourcetype"]
+                  value: audit
+                  on_error: send
+            journald/{{ .index }}_messages:
+              operators:
+                  # Prevent logs feedback loop
+                - type: filter
+                  id: drop_otelcol
+                  expr: 'attributes["_SYSTEMD_UNIT"] == nil || attributes["_SYSTEMD_UNIT"] != "otelcol-contrib.service"'
+                - type: filter
+                  id: messages_filter
+                  expr: 'attributes["SYSLOG_IDENTIFIER"] != nil'
+                - type: add
+                  id: {{ .index }}_idx
+                  field: attributes["com.splunk.index"]
+                  value: {{ .index }}
+                  on_error: send
+                - type: add
+                  id: rh_assh-001_messages_st
+                  field: attributes["com.splunk.sourcetype"]
+                  value: messages
+                  on_error: send
+            journald/{{ .index }}_secure:
+              operators:
+                - type: filter
+                  id: secure_filter
+                  expr: |
+                    attributes["SYSLOG_IDENTIFIER"] == "sshd" ||
+                    attributes["SYSLOG_IDENTIFIER"] == "sudo" ||
+                    attributes["SYSLOG_FACILITY"] == 4 ||
+                    attributes["SYSLOG_FACILITY"] == 10
+                - type: add
+                  id: {{ .index }}_idx
+                  field: attributes["com.splunk.index"]
+                  value: {{ .index }}
+                  on_error: send
+                - type: add
+                  id: rh_assh-001_secure_st
+                  field: attributes["com.splunk.sourcetype"]
+                  value: secure
+                  on_error: send
+          service:
+            extensions:
+              - file_storage/otc
+            telemetry:
+              logs:
+                level: error
+                disable_stacktrace: true
+            pipelines:
+              logs:
+                processors:
+                  - resource/add_appcode
+                  - resource/add_instance_tag
+                  - resourcedetection/system
+                  - transform/common
+                receivers:
+                  # List all your receivers here
+                  - filelog/{{ .index }}_audit
+                  - journald/{{ .index }}_messages
+                  - journald/{{ .index }}_secure
+                exporters:
+                  - splunk_hec/corp


### PR DESCRIPTION
## What

Promote multi-platform-controller from `aa3768e3` to `a5285b319d913f46dc0617fa54fb07817dff7593` on Ring 1 clusters.

Per-cluster kustomization overrides include both deploy resource refs (`deploy/operator`, `deploy/otp`) and container image tags.

Also removes deprecated `resourcedetection/system` `attributes` block from otelcollector config for ring 1 clusters via `production/logcollector-ring1/` overlay

Clusters affected:
- kflux-fedora-01
- kflux-prd-rh02
- kflux-prd-rh03
- kflux-osp-p01
- stone-prod-p01

[KONFLUX-14156](https://issues.redhat.com/browse/KONFLUX-14156)

## Why

Ring 1 of the phased production rollout for the MPC version currently deployed to dev/staging (`a5285b3`). Includes curl retry loop for transient DNS errors in OTP server calls under high concurrency ([multi-platform-controller#951](https://github.com/konflux-ci/multi-platform-controller/pull/951)).

## Validation

- `kustomize build --enable-helm` passes for all five affected overlays:
  - `components/multi-platform-controller/production/kflux-fedora-01`
  - `components/multi-platform-controller/production/kflux-prd-rh02`
  - `components/multi-platform-controller/production/kflux-prd-rh03`
  - `components/multi-platform-controller/production-downstream/kflux-osp-p01`
  - `components/multi-platform-controller/production-downstream/stone-prod-p01`
- Rendered output verified to contain `a5285b3` image tags for both controller and otp-service
- Rendered output verified that deprecated `resourcedetection/system` `attributes` block is removed
- `diff` between `base/logcollector/otelcollector.yaml` and `production/logcollector-ring1/otelcollector.yaml` confirms the only difference is the removal of the deprecated `attributes` block (lines 85-87)
- Staging PR: https://github.com/redhat-appstudio/infra-deployments/pull/12907
- Staging verification on stone-stage-p01:
  - Both deployments running `a5285b3` image
  - `otp-utils.sh` present in all provision ConfigMaps with `curl_otp_store_key` retry function
  - Provisioning scripts source `otp-utils.sh` at line 6
  - Recent provisioning TaskRuns completing successfully
  - No retry warnings in logs (expected — DNS failures are a ~1% rate under 200 concurrent builds)

## Risk Assessment

**Risk Level:** Medium

**Staging PR:** https://github.com/redhat-appstudio/infra-deployments/pull/12907

**What could go wrong:** MPC manages remote build hosts; a bad upgrade could break multi-arch or remote-platform builds on the affected clusters. The otelcollector config change fixes a broken config — without it, otelcol-contrib won't start.

**Rollback:** Revert this PR. Ring 1 clusters will fall back to `aa3768e3` via `production/base` and `production-downstream/base`.

**Blast radius:** 5 of 9 production clusters (Ring 1 only). Remaining clusters unchanged until Ring 2.

[KONFLUX-14156]: https://redhat.atlassian.net/browse/KONFLUX-14156?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ