### PR TITLE
KONFLUX-14906 Set default-imagepullbackoff-timeout to 15m

### DIFF
--- a/components/pipeline-service/development/main-pipeline-service-configuration.yaml
+++ b/components/pipeline-service/development/main-pipeline-service-configuration.yaml
@@ -1938,6 +1938,7 @@ spec:
                   value: "konflux-tenants"
                   effect: "NoSchedule"
             default-timeout-minutes: "120"
+            default-imagepullbackoff-timeout: "15m"
       deployments:
         tekton-operator-proxy-webhook:
           spec:

--- a/components/pipeline-service/staging/base/main-pipeline-service-configuration.yaml
+++ b/components/pipeline-service/staging/base/main-pipeline-service-configuration.yaml
@@ -1755,6 +1755,7 @@ spec:
                   value: "konflux-tenants"
                   effect: "NoSchedule"
             default-timeout-minutes: "120"
+            default-imagepullbackoff-timeout: "15m"
         config-leader-election-resolvers:
           data:
             buckets: "8"

--- a/components/pipeline-service/staging/stone-stage-p01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stage-p01/deploy.yaml
@@ -2304,6 +2304,7 @@ spec:
                 requests:
                   memory: "256Mi"
                   cpu: "100m"
+            default-imagepullbackoff-timeout: 15m
             default-pod-template: |
               nodeSelector:
                 konflux-ci.dev/workload: konflux-tenants

--- a/components/pipeline-service/staging/stone-stg-rh01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stg-rh01/deploy.yaml
@@ -2304,6 +2304,7 @@ spec:
                 requests:
                   memory: "256Mi"
                   cpu: "100m"
+            default-imagepullbackoff-timeout: 15m
             default-pod-template: |
               nodeSelector:
                 konflux-ci.dev/workload: konflux-tenants


### PR DESCRIPTION
## What

- Add `default-imagepullbackoff-timeout: "15m"` to the TektonConfig CR `config-defaults` in development and staging overlays
- Regenerate staging per-cluster `deploy.yaml` files

Clusters affected: development, stone-stg-rh01, stone-stage-p01

[KONFLUX-14906](https://redhat.atlassian.net/browse/KONFLUX-14906)

## Why

The current default of `0` causes Tekton to immediately fail TaskRuns on the first `ImagePullBackOff` event. Transient registry outages (e.g. quay.io) then cascade into mass PipelineRun failures. Setting a 15-minute timeout gives the kubelet time to retry image pulls with exponential back-off before Tekton marks the TaskRun as failed.

## Validation

- `kustomize build ./components/pipeline-service/development/` passes
- `./hack/generate-deploy-config.sh -c components/pipeline-service/staging` regenerated deploy.yaml files with the new setting

Made with [Cursor](https://cursor.com)

[KONFLUX-14906]: https://redhat.atlassian.net/browse/KONFLUX-14906?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ