### PR TITLE
feat(KFLUXINFRA-4192) Increase kueue konflux-release concurrency.

### DIFF
--- a/components/kueue/production/kflux-ocp-p01/queue-config/cluster-queue.yaml
+++ b/components/kueue/production/kflux-ocp-p01/queue-config/cluster-queue.yaml
@@ -38,7 +38,7 @@ spec:
       - name: mintmaker
         nominalQuota: '150'
       - name: konflux-release
-        nominalQuota: '50'
+        nominalQuota: '100'
   - coveredResources:
     - linux-amd64
     - linux-arm64

--- a/components/kueue/production/kflux-rhel-p01/queue-config/cluster-queue.yaml
+++ b/components/kueue/production/kflux-rhel-p01/queue-config/cluster-queue.yaml
@@ -38,7 +38,7 @@ spec:
       - name: mintmaker
         nominalQuota: '150'
       - name: konflux-release
-        nominalQuota: '50'
+        nominalQuota: '100'
   - coveredResources:
     - linux-amd64
     - linux-arm64

--- a/components/kueue/production/stone-prod-p02/queue-config/cluster-queue.yaml
+++ b/components/kueue/production/stone-prod-p02/queue-config/cluster-queue.yaml
@@ -38,7 +38,7 @@ spec:
       - name: mintmaker
         nominalQuota: '150'
       - name: konflux-release
-        nominalQuota: '50'
+        nominalQuota: '100'
   - coveredResources:
     - linux-amd64
     - linux-arm64


### PR DESCRIPTION
## Description
- Update kueue konflux-release quota to 100 in prod clusters (p02,rhel-p01 and ocp-p01).

## Validation
Kueue setup previously deployed in stage.

## Risk Assessment
**Risk Level:** Medium
**Description:**  Kueue will restrict more capacity for releases.
**Rollback:** Revert PR and redeploy previous kueue configuration