### PR TITLE
PVO11Y-5290 Switch staging pipeline-service dashboard to tekton-ms datasource

### DIFF
--- a/components/monitoring/grafana/development/dashboards/pipeline-service/grafana-config.yaml
+++ b/components/monitoring/grafana/development/dashboards/pipeline-service/grafana-config.yaml
@@ -409,6 +409,7 @@ data:
             "wideLayout": true
           },
           "pluginVersion": "10.4.3",
+          "datasource": "prometheus-tekton-ms-ds",
           "targets": [
             {
               "editorMode": "code",
@@ -552,6 +553,7 @@ data:
               "spaceLength": 10,
               "stack": true,
               "steppedLine": false,
+              "datasource": "prometheus-tekton-ms-ds",
               "targets": [
                 {
                   "exemplar": true,
@@ -641,6 +643,7 @@ data:
                 "textMode": "auto"
               },
               "pluginVersion": "9.1.6",
+              "datasource": "prometheus-tekton-ms-ds",
               "targets": [
                 {
                   "exemplar": true,
@@ -715,6 +718,7 @@ data:
               "spaceLength": 10,
               "stack": true,
               "steppedLine": false,
+              "datasource": "prometheus-tekton-ms-ds",
               "targets": [
                 {
                   "exemplar": true,
@@ -803,6 +807,7 @@ data:
                 "textMode": "auto"
               },
               "pluginVersion": "9.1.6",
+              "datasource": "prometheus-tekton-ms-ds",
               "targets": [
                 {
                   "exemplar": true,
@@ -1075,6 +1080,7 @@ data:
                 "textMode": "auto"
               },
               "pluginVersion": "9.1.6",
+              "datasource": "prometheus-tekton-ms-ds",
               "targets": [
                 {
                   "exemplar": true,
@@ -1133,6 +1139,7 @@ data:
                 "textMode": "auto"
               },
               "pluginVersion": "9.1.6",
+              "datasource": "prometheus-tekton-ms-ds",
               "targets": [
                 {
                   "exemplar": true,
@@ -1302,6 +1309,7 @@ data:
                 }
               },
               "pluginVersion": "7.5.17",
+              "datasource": "prometheus-tekton-ms-ds",
               "targets": [
                 {
                   "exemplar": true,
@@ -1354,6 +1362,7 @@ data:
               "spaceLength": 10,
               "stack": false,
               "steppedLine": false,
+              "datasource": "prometheus-tekton-ms-ds",
               "targets": [
                 {
                   "exemplar": true,
@@ -1469,6 +1478,7 @@ data:
                 }
               },
               "pluginVersion": "7.5.17",
+              "datasource": "prometheus-tekton-ms-ds",
               "targets": [
                 {
                   "exemplar": true,
@@ -1543,6 +1553,7 @@ data:
                 "text": {}
               },
               "pluginVersion": "9.1.6",
+              "datasource": "prometheus-tekton-ms-ds",
               "targets": [
                 {
                   "exemplar": true,
@@ -1661,6 +1672,7 @@ data:
                 "text": {}
               },
               "pluginVersion": "9.1.6",
+              "datasource": "prometheus-tekton-ms-ds",
               "targets": [
                 {
                   "exemplar": true,
@@ -1720,6 +1732,7 @@ data:
                 "text": {}
               },
               "pluginVersion": "9.1.6",
+              "datasource": "prometheus-tekton-ms-ds",
               "targets": [
                 {
                   "exemplar": true,
@@ -1779,6 +1792,7 @@ data:
                 "text": {}
               },
               "pluginVersion": "9.1.6",
+              "datasource": "prometheus-tekton-ms-ds",
               "targets": [
                 {
                   "exemplar": true,
@@ -1838,6 +1852,7 @@ data:
                 "text": {}
               },
               "pluginVersion": "9.1.6",
+              "datasource": "prometheus-tekton-ms-ds",
               "targets": [
                 {
                   "exemplar": true,
@@ -1890,6 +1905,7 @@ data:
               "spaceLength": 10,
               "stack": false,
               "steppedLine": false,
+              "datasource": "prometheus-tekton-ms-ds",
               "targets": [
                 {
                   "exemplar": true,
@@ -1969,6 +1985,7 @@ data:
               "spaceLength": 10,
               "stack": false,
               "steppedLine": false,
+              "datasource": "prometheus-tekton-ms-ds",
               "targets": [
                 {
                   "exemplar": true,

--- a/components/monitoring/grafana/staging/dashboards/pipeline-service/grafana-config.yaml
+++ b/components/monitoring/grafana/staging/dashboards/pipeline-service/grafana-config.yaml
@@ -409,6 +409,7 @@ data:
             "wideLayout": true
           },
           "pluginVersion": "10.4.3",
+          "datasource": "prometheus-tekton-ms-ds",
           "targets": [
             {
               "editorMode": "code",
@@ -552,6 +553,7 @@ data:
               "spaceLength": 10,
               "stack": true,
               "steppedLine": false,
+              "datasource": "prometheus-tekton-ms-ds",
               "targets": [
                 {
                   "exemplar": true,
@@ -641,6 +643,7 @@ data:
                 "textMode": "auto"
               },
               "pluginVersion": "9.1.6",
+              "datasource": "prometheus-tekton-ms-ds",
               "targets": [
                 {
                   "exemplar": true,
@@ -715,6 +718,7 @@ data:
               "spaceLength": 10,
               "stack": true,
               "steppedLine": false,
+              "datasource": "prometheus-tekton-ms-ds",
               "targets": [
                 {
                   "exemplar": true,
@@ -803,6 +807,7 @@ data:
                 "textMode": "auto"
               },
               "pluginVersion": "9.1.6",
+              "datasource": "prometheus-tekton-ms-ds",
               "targets": [
                 {
                   "exemplar": true,
@@ -1075,6 +1080,7 @@ data:
                 "textMode": "auto"
               },
               "pluginVersion": "9.1.6",
+              "datasource": "prometheus-tekton-ms-ds",
               "targets": [
                 {
                   "exemplar": true,
@@ -1133,6 +1139,7 @@ data:
                 "textMode": "auto"
               },
               "pluginVersion": "9.1.6",
+              "datasource": "prometheus-tekton-ms-ds",
               "targets": [
                 {
                   "exemplar": true,
@@ -1302,6 +1309,7 @@ data:
                 }
               },
               "pluginVersion": "7.5.17",
+              "datasource": "prometheus-tekton-ms-ds",
               "targets": [
                 {
                   "exemplar": true,
@@ -1354,6 +1362,7 @@ data:
               "spaceLength": 10,
               "stack": false,
               "steppedLine": false,
+              "datasource": "prometheus-tekton-ms-ds",
               "targets": [
                 {
                   "exemplar": true,
@@ -1469,6 +1478,7 @@ data:
                 }
               },
               "pluginVersion": "7.5.17",
+              "datasource": "prometheus-tekton-ms-ds",
               "targets": [
                 {
                   "exemplar": true,
@@ -1543,6 +1553,7 @@ data:
                 "text": {}
               },
               "pluginVersion": "9.1.6",
+              "datasource": "prometheus-tekton-ms-ds",
               "targets": [
                 {
                   "exemplar": true,
@@ -1661,6 +1672,7 @@ data:
                 "text": {}
               },
               "pluginVersion": "9.1.6",
+              "datasource": "prometheus-tekton-ms-ds",
               "targets": [
                 {
                   "exemplar": true,
@@ -1720,6 +1732,7 @@ data:
                 "text": {}
               },
               "pluginVersion": "9.1.6",
+              "datasource": "prometheus-tekton-ms-ds",
               "targets": [
                 {
                   "exemplar": true,
@@ -1779,6 +1792,7 @@ data:
                 "text": {}
               },
               "pluginVersion": "9.1.6",
+              "datasource": "prometheus-tekton-ms-ds",
               "targets": [
                 {
                   "exemplar": true,
@@ -1838,6 +1852,7 @@ data:
                 "text": {}
               },
               "pluginVersion": "9.1.6",
+              "datasource": "prometheus-tekton-ms-ds",
               "targets": [
                 {
                   "exemplar": true,
@@ -1890,6 +1905,7 @@ data:
               "spaceLength": 10,
               "stack": false,
               "steppedLine": false,
+              "datasource": "prometheus-tekton-ms-ds",
               "targets": [
                 {
                   "exemplar": true,
@@ -1969,6 +1985,7 @@ data:
               "spaceLength": 10,
               "stack": false,
               "steppedLine": false,
+              "datasource": "prometheus-tekton-ms-ds",
               "targets": [
                 {
                   "exemplar": true,


### PR DESCRIPTION
## What

- Switch 17 panels in the staging pipeline-service dashboard from `prometheus-appstudio-ds` to `prometheus-tekton-ms-ds`

Clusters affected: staging clusters only

[PVO11Y-5290](https://redhat.atlassian.net/browse/PVO11Y-5290)

## Why

The tekton-ms Prometheus now scrapes both the pipelines controller and the pipeline-metrics-exporter. Staging panels should query `prometheus-tekton-ms-ds` directly instead of going through the in-cluster Thanos.

## Validation

- `kustomize build` passes for staging overlays
- Production and development dashboards are unaffected (separate overlays after #12956 and #12960)
- Tested on staging cluster: [Pipeline Service - jmicanek test](https://grafana-access-appstudio-grafana.apps.stone-stg-rh01.l2vh.p1.openshiftapps.com/d/02ebfdefeeed166624895c36b0c1af4ed3006cee/pipeline-service-jmicanek-test?from=now-12h&to=now&var-datasource=d56348f1-77d7-4896-a34f-495c93f4d0be&refresh=10s)
  - **Pipelineruns Running / Taskruns Running** — gauges showing current counts from tekton-ms
  - **PipelineRuns Per Hour / TaskRuns Per Hour** — rates by status from tekton-ms
  - **TaskRun Controller kickoff** (deadlock formula) — mixed query combining pipeline-exporter and controller metrics, both from tekton-ms
  - **Workqueue Depth** — kn_workqueue_depth from controller
  - **Taskruns Throttled by Node/Quota** — throttling gauges

[PVO11Y-5290]: https://redhat.atlassian.net/browse/PVO11Y-5290?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ