### PR TITLE
priority lane for signing releases to dev and stg

### DIFF
--- a/components/kueue/development/queue-config/cluster-queue.yaml
+++ b/components/kueue/development/queue-config/cluster-queue.yaml
@@ -36,9 +36,9 @@ spec:
       - name: default-flavor
         resources:
         - name: tekton.dev/pipelineruns
-          nominalQuota: "500"
-        - name: konflux-ci-dev-token
           nominalQuota: "600"
+        - name: konflux-ci-dev-token
+          nominalQuota: "500"
         - name: linux-arm64
           nominalQuota: "10"
         - name: linux-amd64
@@ -52,7 +52,7 @@ spec:
         - name: mintmaker
           nominalQuota: "150"
         - name: konflux-release
-          nominalQuota: '50'
+          nominalQuota: '100'
         # When a Workload doesn't have cpu or memory requests, if there is a limit range
         # in the namespace, Kueue will assign the requests from it to the Workload.
         # We don't care about the cpu/memory for PipelineRuns, thus setting a high value for both.

--- a/components/kueue/development/tekton-kueue/config.yaml
+++ b/components/kueue/development/tekton-kueue/config.yaml
@@ -116,10 +116,6 @@ cel:
         pipelineRun.metadata.labels['appstudio.openshift.io/service'] == 'release' &&
         'release.appstudio.openshift.io/namespace' in pipelineRun.metadata.labels &&
         pipelineRun.metadata.labels['release.appstudio.openshift.io/namespace'] == plrNamespace ?
-        [resource('konflux-release', 1)] :
-
-        has(pipelineRun.metadata.labels) &&
-        'internal-services.appstudio.openshift.io/pipelinerun-uid' in pipelineRun.metadata.labels ?
         [resource('konflux-release', 1)] : []
 
     # The token mechanism allows us to balance admitted PipelineRuns.
@@ -137,15 +133,15 @@ cel:
     # * 200 Build PipelineRuns + 200 Non-Build PipelineRuns
     # * 100 Build PipelineRuns + 400 Non-Build PipelineRuns
     # * 600 Non-Build PipelineRuns
+    #
+    #
+    # WARNING: As a temporary measure, we are using tokens to provide a priority lane
+    # for internal-services PLRs. They'll be removed in some time and moved to the
+    # common clusters.
     - |
-        pacEventType == 'push' ||
-          pacEventType == 'pull_request' ||
-          pacEventType == "Merge_Request" ||
-          pacEventType == 'test-comment' ||
-          pacEventType == 'retest-comment' ||
-          pacEventType == 'retest-all-comment' ||
-          pacEventType == 'ok-to-test-comment'  ? resource('konflux-ci-dev-token', 2) :
-        resource('konflux-ci-dev-token', 1)
+        has(pipelineRun.metadata.labels) &&
+        'internal-services.appstudio.openshift.io/pipelinerun-uid' in pipelineRun.metadata.labels ?
+        [] : [resource('konflux-ci-dev-token', 1)]
 
     # Set the pipeline priority
     - |

--- a/components/kueue/staging/base/tekton-kueue/config.yaml
+++ b/components/kueue/staging/base/tekton-kueue/config.yaml
@@ -116,10 +116,6 @@ cel:
         pipelineRun.metadata.labels['appstudio.openshift.io/service'] == 'release' &&
         'release.appstudio.openshift.io/namespace' in pipelineRun.metadata.labels &&
         pipelineRun.metadata.labels['release.appstudio.openshift.io/namespace'] == plrNamespace ?
-        [resource('konflux-release', 1)] :
-
-        has(pipelineRun.metadata.labels) &&
-        'internal-services.appstudio.openshift.io/pipelinerun-uid' in pipelineRun.metadata.labels ?
         [resource('konflux-release', 1)] : []
 
     # The token mechanism allows us to balance admitted PipelineRuns.
@@ -137,15 +133,15 @@ cel:
     # * 200 Build PipelineRuns + 200 Non-Build PipelineRuns
     # * 100 Build PipelineRuns + 400 Non-Build PipelineRuns
     # * 600 Non-Build PipelineRuns
+    #
+    #
+    # WARNING: As a temporary measure, we are using tokens to provide a priority lane
+    # for internal-services PLRs. They'll be removed in some time and moved to the
+    # common clusters.
     - |
-        pacEventType == 'push' ||
-          pacEventType == 'pull_request' ||
-          pacEventType == "Merge_Request" ||
-          pacEventType == 'test-comment' ||
-          pacEventType == 'retest-comment' ||
-          pacEventType == 'retest-all-comment' ||
-          pacEventType == 'ok-to-test-comment'  ? resource('konflux-ci-dev-token', 2) :
-        resource('konflux-ci-dev-token', 1)
+        has(pipelineRun.metadata.labels) &&
+        'internal-services.appstudio.openshift.io/pipelinerun-uid' in pipelineRun.metadata.labels ?
+        [] : [resource('konflux-ci-dev-token', 1)]
 
     # Set the pipeline priority
     - |

--- a/components/kueue/staging/stone-stage-p01/queue-config/cluster-queue.yaml
+++ b/components/kueue/staging/stone-stage-p01/queue-config/cluster-queue.yaml
@@ -26,9 +26,9 @@ spec:
     - name: default-flavor
       resources:
       - name: tekton.dev/pipelineruns
-        nominalQuota: '500'
-      - name: konflux-ci-dev-token
         nominalQuota: '600'
+      - name: konflux-ci-dev-token
+        nominalQuota: '500'
       - name: cpu
         nominalQuota: 1k
       - name: memory

--- a/components/kueue/staging/stone-stg-rh01/queue-config/cluster-queue.yaml
+++ b/components/kueue/staging/stone-stg-rh01/queue-config/cluster-queue.yaml
@@ -26,9 +26,9 @@ spec:
     - name: default-flavor
       resources:
       - name: tekton.dev/pipelineruns
-        nominalQuota: '500'
-      - name: konflux-ci-dev-token
         nominalQuota: '600'
+      - name: konflux-ci-dev-token
+        nominalQuota: '500'
       - name: cpu
         nominalQuota: 1k
       - name: memory

--- a/hack/test-tekton-kueue-config.py
+++ b/hack/test-tekton-kueue-config.py
@@ -205,7 +205,7 @@ PIPELINERUN_DEFINITIONS: Dict[str, PipelineRunTestData] = {
         },
         "expected": {
             "annotations": {
-                "kueue.konflux-ci.dev/requests-konflux-ci-dev-token": "2",
+                "kueue.konflux-ci.dev/requests-konflux-ci-dev-token": "1",
                 "kueue.konflux-ci.dev/requests-linux-amd64": "1",
                 "kueue.konflux-ci.dev/requests-linux-arm64": "1",
                 "kueue.konflux-ci.dev/requests-linux-s390x": "1",
@@ -254,7 +254,7 @@ PIPELINERUN_DEFINITIONS: Dict[str, PipelineRunTestData] = {
         },
         "expected": {
             "annotations": {
-                "kueue.konflux-ci.dev/requests-konflux-ci-dev-token": "2",
+                "kueue.konflux-ci.dev/requests-konflux-ci-dev-token": "1",
                 "kueue.konflux-ci.dev/requests-linux-amd64": "1",
                 "kueue.konflux-ci.dev/requests-linux-arm64": "1",
                 "kueue.konflux-ci.dev/requests-aws-ip": "2"
@@ -287,7 +287,7 @@ PIPELINERUN_DEFINITIONS: Dict[str, PipelineRunTestData] = {
         },
         "expected": {
             "annotations": {
-                "kueue.konflux-ci.dev/requests-konflux-ci-dev-token": "2",
+                "kueue.konflux-ci.dev/requests-konflux-ci-dev-token": "1",
             },
             "labels": {
                 "kueue.x-k8s.io/queue-name": "pipelines-queue",
@@ -318,7 +318,7 @@ PIPELINERUN_DEFINITIONS: Dict[str, PipelineRunTestData] = {
         },
         "expected": {
             "annotations": {
-                "kueue.konflux-ci.dev/requests-konflux-ci-dev-token": "2",
+                "kueue.konflux-ci.dev/requests-konflux-ci-dev-token": "1",
             },
             "labels": {
                 "kueue.x-k8s.io/queue-name": "pipelines-queue",
@@ -347,7 +347,7 @@ PIPELINERUN_DEFINITIONS: Dict[str, PipelineRunTestData] = {
         },
         "expected": {
             "annotations": {
-                "kueue.konflux-ci.dev/requests-konflux-ci-dev-token": "2",
+                "kueue.konflux-ci.dev/requests-konflux-ci-dev-token": "1",
             },
             "labels": {
                 "kueue.x-k8s.io/queue-name": "pipelines-queue",
@@ -492,7 +492,7 @@ PIPELINERUN_DEFINITIONS: Dict[str, PipelineRunTestData] = {
         },
         "expected": {
             "annotations": {
-                "kueue.konflux-ci.dev/requests-konflux-ci-dev-token": "2",
+                "kueue.konflux-ci.dev/requests-konflux-ci-dev-token": "1",
             },
             "labels": {
                 "build.appstudio.redhat.com/type": "nudge",
@@ -523,7 +523,7 @@ PIPELINERUN_DEFINITIONS: Dict[str, PipelineRunTestData] = {
         },
         "expected": {
             "annotations": {
-                "kueue.konflux-ci.dev/requests-konflux-ci-dev-token": "2",
+                "kueue.konflux-ci.dev/requests-konflux-ci-dev-token": "1",
             },
             "labels": {
                 "build.appstudio.redhat.com/type": "nudge",
@@ -552,7 +552,7 @@ PIPELINERUN_DEFINITIONS: Dict[str, PipelineRunTestData] = {
         },
         "expected": {
             "annotations": {
-                "kueue.konflux-ci.dev/requests-konflux-ci-dev-token": "2",
+                "kueue.konflux-ci.dev/requests-konflux-ci-dev-token": "1",
             },
             "labels": {
                 "kueue.x-k8s.io/queue-name": "pipelines-queue",
@@ -581,7 +581,7 @@ PIPELINERUN_DEFINITIONS: Dict[str, PipelineRunTestData] = {
         },
         "expected": {
             "annotations": {
-                "kueue.konflux-ci.dev/requests-konflux-ci-dev-token": "2",
+                "kueue.konflux-ci.dev/requests-konflux-ci-dev-token": "1",
             },
             "labels": {
                 "kueue.x-k8s.io/queue-name": "pipelines-queue",
@@ -610,7 +610,7 @@ PIPELINERUN_DEFINITIONS: Dict[str, PipelineRunTestData] = {
         },
         "expected": {
             "annotations": {
-                "kueue.konflux-ci.dev/requests-konflux-ci-dev-token": "2",
+                "kueue.konflux-ci.dev/requests-konflux-ci-dev-token": "1",
             },
             "labels": {
                 "kueue.x-k8s.io/queue-name": "pipelines-queue",
@@ -639,7 +639,7 @@ PIPELINERUN_DEFINITIONS: Dict[str, PipelineRunTestData] = {
         },
         "expected": {
             "annotations": {
-                "kueue.konflux-ci.dev/requests-konflux-ci-dev-token": "2",
+                "kueue.konflux-ci.dev/requests-konflux-ci-dev-token": "1",
             },
             "labels": {
                 "kueue.x-k8s.io/queue-name": "pipelines-queue",
@@ -876,10 +876,7 @@ PIPELINERUN_DEFINITIONS: Dict[str, PipelineRunTestData] = {
             }
         },
         "expected": {
-            "annotations": {
-                "kueue.konflux-ci.dev/requests-konflux-ci-dev-token": "1",
-                "kueue.konflux-ci.dev/requests-konflux-release": "1",
-            },
+            "annotations": {},
             "labels": {
                 "kueue.x-k8s.io/queue-name": "pipelines-queue",
                 "kueue.x-k8s.io/priority-class": "konflux-release"
@@ -914,7 +911,7 @@ PIPELINERUN_DEFINITIONS: Dict[str, PipelineRunTestData] = {
         "expected": {
             "annotations": {
                 "tekton-kueue.konflux-ci.dev/validation-error": "build-platforms parameter must be an array of platform strings, got a non-array value",
-                "kueue.konflux-ci.dev/requests-konflux-ci-dev-token": "2",
+                "kueue.konflux-ci.dev/requests-konflux-ci-dev-token": "1",
             },
             "labels": {
                 "kueue.x-k8s.io/queue-name": "pipelines-queue",
@@ -949,7 +946,7 @@ PIPELINERUN_DEFINITIONS: Dict[str, PipelineRunTestData] = {
         },
         "expected": {
             "annotations": {
-                "kueue.konflux-ci.dev/requests-konflux-ci-dev-token": "2",
+                "kueue.konflux-ci.dev/requests-konflux-ci-dev-token": "1",
                 "kueue.konflux-ci.dev/requests-linux-arm64": "1",
                 "kueue.konflux-ci.dev/requests-darwin-amd64": "1",
                 "kueue.konflux-ci.dev/requests-windows-amd64": "1",
@@ -987,7 +984,7 @@ PIPELINERUN_DEFINITIONS: Dict[str, PipelineRunTestData] = {
         },
         "expected": {
             "annotations": {
-                "kueue.konflux-ci.dev/requests-konflux-ci-dev-token": "2",
+                "kueue.konflux-ci.dev/requests-konflux-ci-dev-token": "1",
                 "kueue.konflux-ci.dev/requests-linux-amd64": "1",
                 "kueue.konflux-ci.dev/requests-linux-s390x": "1",
                 "kueue.konflux-ci.dev/requests-linux-ppc64le": "1",
@@ -1028,7 +1025,7 @@ PIPELINERUN_DEFINITIONS: Dict[str, PipelineRunTestData] = {
         },
         "expected": {
             "annotations": {
-                "kueue.konflux-ci.dev/requests-konflux-ci-dev-token": "2",
+                "kueue.konflux-ci.dev/requests-konflux-ci-dev-token": "1",
                 "kueue.konflux-ci.dev/requests-linux-amd64": "1",
                 "kueue.konflux-ci.dev/requests-linux-s390x": "1",
                 "kueue.konflux-ci.dev/requests-linux-ppc64le": "1",
@@ -1089,7 +1086,7 @@ PIPELINERUN_DEFINITIONS: Dict[str, PipelineRunTestData] = {
         },
         "expected": {
             "annotations": {
-                "kueue.konflux-ci.dev/requests-konflux-ci-dev-token": "2",
+                "kueue.konflux-ci.dev/requests-konflux-ci-dev-token": "1",
                 "kueue.konflux-ci.dev/requests-linux-amd64": "1",
                 "kueue.konflux-ci.dev/requests-linux-s390x": "1",
                 "kueue.konflux-ci.dev/requests-linux-arm64": "1",


### PR DESCRIPTION
Signing PLRs are created by the Release Pipelines. Them competing for the same resource can cause deadlocks when burst of Release Pipelines are admitted.

We want to temporarily use tokens to create a priority lane for Signing PLRs. 
We'll remove this when Signing PLRs are moved to common clusters.

Signed-off-by: Francesco Ilario <filario@redhat.com>

rh-pre-commit.version: 2.4.0
rh-pre-commit.check-secrets: ENABLED
