### PR TITLE
Update kaexporter ref to prevent truncation of resources

### DIFF
--- a/components/monitoring/exporters/kaexporter/staging/base/kustomization.yaml
+++ b/components/monitoring/exporters/kaexporter/staging/base/kustomization.yaml
@@ -1,9 +1,9 @@
 resources:
   - rbac
   - external-secrets
-  - https://github.com/redhat-appstudio/o11y/config/exporters/monitoring/kaexporter/base?ref=ba0e3f48c0a85cb0d59a3812faefb4da9cd8f763
+  - https://github.com/redhat-appstudio/o11y/config/exporters/monitoring/kaexporter/base?ref=cd48a7ad17234ef50526134e0ad628ce30894b5a
 
 images:
   - name: quay.io/redhat-appstudio/o11y
     newName: quay.io/redhat-appstudio/o11y
-    newTag: ba0e3f48c0a85cb0d59a3812faefb4da9cd8f763
+    newTag: cd48a7ad17234ef50526134e0ad628ce30894b5a


### PR DESCRIPTION
Updating kaexporter git ref to include changes for the increase in Max Items during Cold Start to avoid truncation of PLRs and Resource. This setting change is required to accommodate namespaces with high pipeline volume during the initial 30-day backfill.