### PR TITLE
priority lane for signing releases in prod

### DIFF
--- a/components/kueue/production/kflux-ocp-p01/config.yaml
+++ b/components/kueue/production/kflux-ocp-p01/config.yaml
@@ -93,10 +93,17 @@ cel:
         plrNamespace == 'mintmaker' ? [resource('mintmaker', 1)] : []
 
     # The token mechanism allows us to balance admitted PipelineRuns.
-    # Each PipelineRun requests 1 token. The token quota is set equal
-    # to the PLR limit so current behavior is unchanged.
+    # Each PipelineRun requests 1 token, except for internal-services PLRs.
+    # This is to guarantee there is always room for internal-services PLRs.
+    #
+    #
+    # WARNING: As a temporary measure, we are using tokens to provide a priority lane
+    # for internal-services PLRs. They'll be removed in some time and moved to the
+    # common clusters.
     - |
-        resource('konflux-ci-dev-token', 1)
+        has(pipelineRun.metadata.labels) &&
+        'internal-services.appstudio.openshift.io/pipelinerun-uid' in pipelineRun.metadata.labels ?
+        [] : [resource('konflux-ci-dev-token', 1)]
 
     # Add a resource to restrict the number of concurrent release pipelineruns
     - |
@@ -112,10 +119,6 @@ cel:
         pipelineRun.metadata.labels['appstudio.openshift.io/service'] == 'release' &&
         'release.appstudio.openshift.io/namespace' in pipelineRun.metadata.labels &&
         pipelineRun.metadata.labels['release.appstudio.openshift.io/namespace'] == plrNamespace ?
-        [resource('konflux-release', 1)] :
-
-        has(pipelineRun.metadata.labels) &&
-        'internal-services.appstudio.openshift.io/pipelinerun-uid' in pipelineRun.metadata.labels ?
         [resource('konflux-release', 1)] : []
 
     # Set the pipeline priority

--- a/components/kueue/production/kflux-ocp-p01/queue-config/cluster-queue.yaml
+++ b/components/kueue/production/kflux-ocp-p01/queue-config/cluster-queue.yaml
@@ -26,7 +26,7 @@ spec:
     - name: default-flavor
       resources:
       - name: tekton.dev/pipelineruns
-        nominalQuota: '250'
+        nominalQuota: '350'
       - name: konflux-ci-dev-token
         nominalQuota: '250'
       - name: cpu

--- a/components/kueue/production/kflux-rhel-p01/config.yaml
+++ b/components/kueue/production/kflux-rhel-p01/config.yaml
@@ -93,10 +93,17 @@ cel:
         plrNamespace == 'mintmaker' ? [resource('mintmaker', 1)] : []
 
     # The token mechanism allows us to balance admitted PipelineRuns.
-    # Each PipelineRun requests 1 token. The token quota is set equal
-    # to the PLR limit so current behavior is unchanged.
+    # Each PipelineRun requests 1 token, except for internal-services PLRs.
+    # This is to guarantee there is always room for internal-services PLRs.
+    #
+    #
+    # WARNING: As a temporary measure, we are using tokens to provide a priority lane
+    # for internal-services PLRs. They'll be removed in some time and moved to the
+    # common clusters.
     - |
-        resource('konflux-ci-dev-token', 1)
+        has(pipelineRun.metadata.labels) &&
+        'internal-services.appstudio.openshift.io/pipelinerun-uid' in pipelineRun.metadata.labels ?
+        [] : [resource('konflux-ci-dev-token', 1)]
 
     # Add a resource to restrict the number of concurrent release pipelineruns
     - |
@@ -112,10 +119,6 @@ cel:
         pipelineRun.metadata.labels['appstudio.openshift.io/service'] == 'release' &&
         'release.appstudio.openshift.io/namespace' in pipelineRun.metadata.labels &&
         pipelineRun.metadata.labels['release.appstudio.openshift.io/namespace'] == plrNamespace ?
-        [resource('konflux-release', 1)] :
-
-        has(pipelineRun.metadata.labels) &&
-        'internal-services.appstudio.openshift.io/pipelinerun-uid' in pipelineRun.metadata.labels ?
         [resource('konflux-release', 1)] : []
 
     # Set the pipeline priority

--- a/components/kueue/production/kflux-rhel-p01/queue-config/cluster-queue.yaml
+++ b/components/kueue/production/kflux-rhel-p01/queue-config/cluster-queue.yaml
@@ -26,7 +26,7 @@ spec:
     - name: default-flavor
       resources:
       - name: tekton.dev/pipelineruns
-        nominalQuota: '300'
+        nominalQuota: '400'
       - name: konflux-ci-dev-token
         nominalQuota: '300'
       - name: cpu

--- a/components/kueue/production/stone-prod-p02/config.yaml
+++ b/components/kueue/production/stone-prod-p02/config.yaml
@@ -93,10 +93,17 @@ cel:
         plrNamespace == 'mintmaker' ? [resource('mintmaker', 1)] : []
 
     # The token mechanism allows us to balance admitted PipelineRuns.
-    # Each PipelineRun requests 1 token. The token quota is set equal
-    # to the PLR limit so current behavior is unchanged.
+    # Each PipelineRun requests 1 token, except for internal-services PLRs.
+    # This is to guarantee there is always room for internal-services PLRs.
+    #
+    #
+    # WARNING: As a temporary measure, we are using tokens to provide a priority lane
+    # for internal-services PLRs. They'll be removed in some time and moved to the
+    # common clusters.
     - |
-        resource('konflux-ci-dev-token', 1)
+        has(pipelineRun.metadata.labels) &&
+        'internal-services.appstudio.openshift.io/pipelinerun-uid' in pipelineRun.metadata.labels ?
+        [] : [resource('konflux-ci-dev-token', 1)]
 
     # Add a resource to restrict the number of concurrent release pipelineruns
     - |
@@ -112,10 +119,6 @@ cel:
         pipelineRun.metadata.labels['appstudio.openshift.io/service'] == 'release' &&
         'release.appstudio.openshift.io/namespace' in pipelineRun.metadata.labels &&
         pipelineRun.metadata.labels['release.appstudio.openshift.io/namespace'] == plrNamespace ?
-        [resource('konflux-release', 1)] :
-
-        has(pipelineRun.metadata.labels) &&
-        'internal-services.appstudio.openshift.io/pipelinerun-uid' in pipelineRun.metadata.labels ?
         [resource('konflux-release', 1)] : []
 
     # Set the pipeline priority

--- a/components/kueue/production/stone-prod-p02/queue-config/cluster-queue.yaml
+++ b/components/kueue/production/stone-prod-p02/queue-config/cluster-queue.yaml
@@ -26,7 +26,7 @@ spec:
     - name: default-flavor
       resources:
       - name: tekton.dev/pipelineruns
-        nominalQuota: '300'
+        nominalQuota: '400'
       - name: konflux-ci-dev-token
         nominalQuota: '300'
       - name: cpu

--- a/hack/test-tekton-kueue-config.py
+++ b/hack/test-tekton-kueue-config.py
@@ -1543,10 +1543,7 @@ TEST_COMBINATIONS: Dict[str, TestCombination] = {
         "pipelinerun_key": "internal_pipelinerun_child",
         "config_key": "production-kflux-ocp-p01",
         "expected": {
-            "annotations": {
-                "kueue.konflux-ci.dev/requests-konflux-ci-dev-token": "1",
-                "kueue.konflux-ci.dev/requests-konflux-release": "1",
-            },
+            "annotations": {},
             "labels": {
                 "kueue.x-k8s.io/queue-name": "pipelines-queue",
                 "kueue.x-k8s.io/priority-class": "konflux-release"
@@ -1695,10 +1692,7 @@ TEST_COMBINATIONS: Dict[str, TestCombination] = {
         "pipelinerun_key": "internal_pipelinerun_child",
         "config_key": "production-stone-prod-p02",
         "expected": {
-            "annotations": {
-                "kueue.konflux-ci.dev/requests-konflux-ci-dev-token": "1",
-                "kueue.konflux-ci.dev/requests-konflux-release": "1",
-            },
+            "annotations": {},
             "labels": {
                 "kueue.x-k8s.io/queue-name": "pipelines-queue",
                 "kueue.x-k8s.io/priority-class": "konflux-release"
@@ -1742,10 +1736,7 @@ TEST_COMBINATIONS: Dict[str, TestCombination] = {
         "pipelinerun_key": "internal_pipelinerun_child",
         "config_key": "production-kflux-rhel-p01",
         "expected": {
-            "annotations": {
-                "kueue.konflux-ci.dev/requests-konflux-ci-dev-token": "1",
-                "kueue.konflux-ci.dev/requests-konflux-release": "1",
-            },
+            "annotations": {},
             "labels": {
                 "kueue.x-k8s.io/queue-name": "pipelines-queue",
                 "kueue.x-k8s.io/priority-class": "konflux-release"


### PR DESCRIPTION
Signing PLRs are created by the Release Pipelines.
Them competing for the same resource can cause deadlocks when burst of Release Pipelines are admitted.

We want to temporarily use tokens to create a priority lane for Signing PLRs.
We'll remove this when Signing PLRs are moved to common clusters.

Signed-off-by: Francesco Ilario <filario@redhat.com>

## Risk Assessment
**Risk Level:** Low
**Rollback:** Revert PR

## Validation
Tested on staging — no regressions observed.
Staging PR: #12979 
