### PR TITLE
KFLUXINFRA-4168: Update ring namespaces to argocd-infra-deployments

### DIFF
--- a/argo-cd-apps/app-of-app-sets/ring-2/patches/target-namespace-patch.yaml
+++ b/argo-cd-apps/app-of-app-sets/ring-2/patches/target-namespace-patch.yaml
@@ -1,4 +1,4 @@
 ---
 - op: replace
   path: /spec/destination/namespace
-  value: argocd
+  value: argocd-infra-deployments

--- a/argo-cd-apps/app-of-app-sets/ring-3/patches/target-namespace-patch.yaml
+++ b/argo-cd-apps/app-of-app-sets/ring-3/patches/target-namespace-patch.yaml
@@ -1,4 +1,4 @@
 ---
 - op: replace
   path: /spec/destination/namespace
-  value: argocd
+  value: argocd-infra-deployments

--- a/argo-cd-apps/app-of-app-sets/ring-4/patches/target-namespace-patch.yaml
+++ b/argo-cd-apps/app-of-app-sets/ring-4/patches/target-namespace-patch.yaml
@@ -1,4 +1,4 @@
 ---
 - op: replace
   path: /spec/destination/namespace
-  value: argocd
+  value: argocd-infra-deployments

--- a/argo-cd-apps/overlays/ring-2/kustomization.yaml
+++ b/argo-cd-apps/overlays/ring-2/kustomization.yaml
@@ -3,7 +3,7 @@ kind: Kustomization
 resources:
   - ../../base/ring-deployments
 
-namespace: argocd
+namespace: argocd-infra-deployments
 patches:
   - path: patches/ring-patch.yaml
     target:

--- a/argo-cd-apps/overlays/ring-3/kustomization.yaml
+++ b/argo-cd-apps/overlays/ring-3/kustomization.yaml
@@ -3,7 +3,7 @@ kind: Kustomization
 resources:
   - ../../base/ring-deployments
 
-namespace: argocd
+namespace: argocd-infra-deployments
 patches:
   - path: patches/ring-patch.yaml
     target:

--- a/argo-cd-apps/overlays/ring-4/kustomization.yaml
+++ b/argo-cd-apps/overlays/ring-4/kustomization.yaml
@@ -3,7 +3,7 @@ kind: Kustomization
 resources:
   - ../../base/ring-deployments
 
-namespace: argocd
+namespace: argocd-infra-deployments
 patches:
   - path: patches/ring-patch.yaml
     target:


### PR DESCRIPTION
This matches the namespaces in the new infra-deployments ArgoCD instances.