### PR TITLE
Allow 25 more PLR on stone-prod-p02

### DIFF
--- a/components/kueue/production/stone-prod-p02/queue-config/cluster-queue.yaml
+++ b/components/kueue/production/stone-prod-p02/queue-config/cluster-queue.yaml
@@ -26,9 +26,9 @@ spec:
     - name: default-flavor
       resources:
       - name: tekton.dev/pipelineruns
-        nominalQuota: '400'
+        nominalQuota: '425'
       - name: konflux-ci-dev-token
-        nominalQuota: '300'
+        nominalQuota: '325'
       - name: cpu
         nominalQuota: 1k
       - name: memory


### PR DESCRIPTION
This is a change part of a series to tune kueue in order to reduce the time we are at PLR limit, mainly caused by Mintmaker, thus reducing the admission wait time of all the priority classes other than konflux-dependency-update.

The changes will be small, one at the time to make sure we improve situation while not filling ETCD.

## Risk Assessment
**Risk Level:** Low
**Description:** P02 kueue tuning to improve admission wait time
**Rollback:** Revert PR 