### PR TITLE
PVO11Y-5337 Drop tekton_pipelines_controller metrics from Platform Prometheus

### DIFF
--- a/components/monitoring/prometheus/staging/tekton-ms/kustomization.yaml
+++ b/components/monitoring/prometheus/staging/tekton-ms/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
   - kube-rbac-proxy.yaml
   - networkpolicy.yaml
   - external-secrets/
+  - openshift-pipelines-monitor-drop-tekton-controller.yaml
 
 patches:
   - path: remote-write-env-details.yaml

--- a/components/monitoring/prometheus/staging/tekton-ms/openshift-pipelines-monitor-drop-tekton-controller.yaml
+++ b/components/monitoring/prometheus/staging/tekton-ms/openshift-pipelines-monitor-drop-tekton-controller.yaml
@@ -1,0 +1,16 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: openshift-pipelines-monitor
+  namespace: openshift-pipelines
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  endpoints:
+  - honorLabels: true
+    interval: 10s
+    port: http-metrics
+    metricRelabelings:
+    - action: drop
+      sourceLabels: [__name__]
+      regex: 'tekton_pipelines_controller_.*'


### PR DESCRIPTION
## What

- Add metricRelabelings to the operator-managed `openshift-pipelines-monitor` ServiceMonitor to drop all `tekton_pipelines_controller_.*` metrics from Platform Prometheus

Clusters affected: staging clusters only (part of tekton-ms overlay)

[PVO11Y-5337](https://redhat.atlassian.net/browse/PVO11Y-5337)

## Why

The tekton-ms Prometheus now scrapes the pipelines controller directly, making these metrics redundant in Platform Prometheus. The high-cardinality histograms are a significant cost — `pipelinerun_taskrun_duration_seconds_bucket` alone accounts for 537K+ series (18% of the Platform Prometheus TSDB on staging).

## Validation

- `kustomize build` passes for staging overlays
- The same approach (metricRelabelings on operator-managed ServiceMonitor) was previously used for dropping `tekton_pipelines_controller_taskruns_pod_latency_milliseconds` and is confirmed working on the cluster

[PVO11Y-5337]: https://redhat.atlassian.net/browse/PVO11Y-5337?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ