### PR TITLE
Upgrade actions/checkout in pull_request_target - KFLUXINFRA-4156

### DIFF
--- a/.github/workflows/operator-changelog.yaml
+++ b/.github/workflows/operator-changelog.yaml
@@ -19,7 +19,7 @@ jobs:
       # Check out the BASE branch with full history (trusted code only).
       # fetch-depth: 0 is required so git worktree can check out the base SHA.
       # The binary is built here before we touch any PR-provided file content.
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # hash v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/pr-env-label.yaml
+++ b/.github/workflows/pr-env-label.yaml
@@ -30,7 +30,7 @@ jobs:
       contents: read
     steps:
       # Check out the BASE branch (trusted code) so we never execute fork code.
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # hash v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/pr-render-diff.yaml
+++ b/.github/workflows/pr-render-diff.yaml
@@ -12,7 +12,7 @@ jobs:
       contents: read
     steps:
       # Check out the BASE branch (trusted code) so we never execute fork code.
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # hash v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/verify-pipelines-configs.yaml
+++ b/.github/workflows/verify-pipelines-configs.yaml
@@ -19,11 +19,20 @@ jobs:
     outputs:
       has_errors: ${{ steps.check.outputs.has_errors }}
     steps:
-      - name: Checkout code
+      - name: Checkout base branch (scripts trusted)
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # hash v7
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          allow-unsafe-pr-checkout: true
+
+      - name: Overlay PR manifests
+        env:
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          git fetch --depth=1 origin "${PR_HEAD_SHA}"
+          git checkout "${PR_HEAD_SHA}" -- components/pipeline-service/
+          git checkout HEAD -- components/pipeline-service/production/sync-rings.sh
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add -A
+          git commit -m "overlay PR manifests" --allow-empty
 
       - name: Setup Kustomize
         uses: multani/action-setup-kustomize@v1

--- a/.github/workflows/verify-pipelines-configs.yaml
+++ b/.github/workflows/verify-pipelines-configs.yaml
@@ -20,9 +20,10 @@ jobs:
       has_errors: ${{ steps.check.outputs.has_errors }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # hash v7
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          allow-unsafe-pr-checkout: true
 
       - name: Setup Kustomize
         uses: multani/action-setup-kustomize@v1


### PR DESCRIPTION
As per the [Safer pull_request_target defaults github blog](https://github.blog/changelog/2026-06-18-safer-pull_request_target-defaults-for-github-actions-checkout/) updating workflows in infra-deployments repo that use pull_request_target, to v7 and configuring workflows that need checkout user-controlled commits.

- I've found only one case where is used and PR code is checkout (by the description and ref), allow-unsafe-pr-checkout=true used here
- The hash used for actions/checkout v7 taken from https://api.github.com/repos/actions/checkout/git/ref/tags/v7.0.0