### PR TITLE
Update pipelines to next nightly build in dev/staging 5.0.5-849

### DIFF
--- a/components/pipeline-service/development/main-pipeline-service-configuration.yaml
+++ b/components/pipeline-service/development/main-pipeline-service-configuration.yaml
@@ -2244,7 +2244,7 @@ metadata:
   namespace: openshift-marketplace
 spec:
   displayName: custom-operators
-  image: quay.io/openshift-pipeline/pipelines-index-4.18@sha256:a4aa211a70b0a92c98c885cca8fed2cce490e3fec656ad1ea68bf7e7c3c18304
+  image: quay.io/openshift-pipeline/pipelines-index-4.19@sha256:d33de5fb02ab99f6d93bdec9592400d0c8fd2622354446c4c043fa1dcba4e72e
   sourceType: grpc
   updateStrategy:
     registryPoll:
@@ -2267,20 +2267,6 @@ spec:
     env:
       - name: AUTOINSTALL_COMPONENTS
         value: "false"
-      # TODO: remove these when upgrading to a bundle including Pipelines as Code v0.48.0+
-      - name: IMAGE_PAC_PAC_CONTROLLER
-        value: "quay.io/openshift-pipeline/pipelines-pipelines-as-code-controller-rhel9@sha256:1b1e365cfdcc85646d5890232a04bad8c7ba9ebb0db36042eeda5961f8106567"
-      - name: IMAGE_PAC_PAC_WEBHOOK
-        value: "quay.io/openshift-pipeline/pipelines-pipelines-as-code-webhook-rhel9@sha256:0ccda15a17a405020fa199b3dce4a630e592da9dfdbd9778be1dcc9f4bdc3fbd"
-      - name: IMAGE_PAC_PAC_WATCHER
-        value: "quay.io/openshift-pipeline/pipelines-pipelines-as-code-watcher-rhel9@sha256:d100578068feb5482e2631b4fadc80b9687f129c7e303b55431ac41ce58f7758"
-      - name: IMAGE_PAC_PAC_CLI
-        value: "quay.io/openshift-pipeline/pipelines-pipelines-as-code-cli-rhel9@sha256:0fc0dd05236f14265e25cc770a7f9f3aeea2e27964a730dac39cf9f61d349bde"
-      # TODO: Remove this once Pipelines 1.13.x is deployed
-      # NOTE: IMAGE_PIPELINES_CONTROLLER is the image used specifically by the resolvers,
-      # the controller uses IMAGE_PIPELINES_TEKTON_PIPELINES_CONTROLLER
-      - name: IMAGE_PIPELINES_CONTROLLER
-        value: "quay.io/openshift-pipeline/pipelines-resolvers-rhel9@sha256:7cd91bc4c0f3469ec4c39d08d818b00c90ce07456364910e49ad5e1430f3110a"
 ---
 apiVersion: route.openshift.io/v1
 kind: Route

--- a/components/pipeline-service/staging/base/main-pipeline-service-configuration.yaml
+++ b/components/pipeline-service/staging/base/main-pipeline-service-configuration.yaml
@@ -2074,7 +2074,7 @@ metadata:
   namespace: openshift-marketplace
 spec:
   displayName: custom-operators
-  image: quay.io/openshift-pipeline/pipelines-index-4.18@sha256:a4aa211a70b0a92c98c885cca8fed2cce490e3fec656ad1ea68bf7e7c3c18304
+  image: quay.io/openshift-pipeline/pipelines-index-4.19@sha256:d33de5fb02ab99f6d93bdec9592400d0c8fd2622354446c4c043fa1dcba4e72e
   sourceType: grpc
   updateStrategy:
     registryPoll:
@@ -2097,20 +2097,6 @@ spec:
     env:
       - name: AUTOINSTALL_COMPONENTS
         value: "false"
-      # TODO: remove these when upgrading to a bundle including Pipelines as Code v0.48.0+
-      - name: IMAGE_PAC_PAC_CONTROLLER
-        value: "quay.io/openshift-pipeline/pipelines-pipelines-as-code-controller-rhel9@sha256:1b1e365cfdcc85646d5890232a04bad8c7ba9ebb0db36042eeda5961f8106567"
-      - name: IMAGE_PAC_PAC_WEBHOOK
-        value: "quay.io/openshift-pipeline/pipelines-pipelines-as-code-webhook-rhel9@sha256:0ccda15a17a405020fa199b3dce4a630e592da9dfdbd9778be1dcc9f4bdc3fbd"
-      - name: IMAGE_PAC_PAC_WATCHER
-        value: "quay.io/openshift-pipeline/pipelines-pipelines-as-code-watcher-rhel9@sha256:d100578068feb5482e2631b4fadc80b9687f129c7e303b55431ac41ce58f7758"
-      - name: IMAGE_PAC_PAC_CLI
-        value: "quay.io/openshift-pipeline/pipelines-pipelines-as-code-cli-rhel9@sha256:0fc0dd05236f14265e25cc770a7f9f3aeea2e27964a730dac39cf9f61d349bde"
-      # TODO: Remove this once Pipelines 1.13.x is deployed
-      # NOTE: IMAGE_PIPELINES_CONTROLLER is the image used specifically by the resolvers,
-      # the pipelines-controller uses IMAGE_PIPELINES_TEKTON_PIPELINES_CONTROLLER
-      - name: IMAGE_PIPELINES_CONTROLLER
-        value: "quay.io/openshift-pipeline/pipelines-resolvers-rhel9@sha256:7cd91bc4c0f3469ec4c39d08d818b00c90ce07456364910e49ad5e1430f3110a"
 
 ---
 apiVersion: route.openshift.io/v1

--- a/components/pipeline-service/staging/stone-stage-p01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stage-p01/deploy.yaml
@@ -2662,7 +2662,7 @@ metadata:
   namespace: openshift-marketplace
 spec:
   displayName: custom-operators
-  image: quay.io/openshift-pipeline/pipelines-index-4.18@sha256:a4aa211a70b0a92c98c885cca8fed2cce490e3fec656ad1ea68bf7e7c3c18304
+  image: quay.io/openshift-pipeline/pipelines-index-4.19@sha256:d33de5fb02ab99f6d93bdec9592400d0c8fd2622354446c4c043fa1dcba4e72e
   sourceType: grpc
   updateStrategy:
     registryPoll:
@@ -2682,16 +2682,6 @@ spec:
     env:
     - name: AUTOINSTALL_COMPONENTS
       value: "false"
-    - name: IMAGE_PAC_PAC_CONTROLLER
-      value: quay.io/openshift-pipeline/pipelines-pipelines-as-code-controller-rhel9@sha256:1b1e365cfdcc85646d5890232a04bad8c7ba9ebb0db36042eeda5961f8106567
-    - name: IMAGE_PAC_PAC_WEBHOOK
-      value: quay.io/openshift-pipeline/pipelines-pipelines-as-code-webhook-rhel9@sha256:0ccda15a17a405020fa199b3dce4a630e592da9dfdbd9778be1dcc9f4bdc3fbd
-    - name: IMAGE_PAC_PAC_WATCHER
-      value: quay.io/openshift-pipeline/pipelines-pipelines-as-code-watcher-rhel9@sha256:d100578068feb5482e2631b4fadc80b9687f129c7e303b55431ac41ce58f7758
-    - name: IMAGE_PAC_PAC_CLI
-      value: quay.io/openshift-pipeline/pipelines-pipelines-as-code-cli-rhel9@sha256:0fc0dd05236f14265e25cc770a7f9f3aeea2e27964a730dac39cf9f61d349bde
-    - name: IMAGE_PIPELINES_CONTROLLER
-      value: quay.io/openshift-pipeline/pipelines-resolvers-rhel9@sha256:7cd91bc4c0f3469ec4c39d08d818b00c90ce07456364910e49ad5e1430f3110a
   name: openshift-pipelines-operator-rh
   source: custom-operators
   sourceNamespace: openshift-marketplace

--- a/components/pipeline-service/staging/stone-stg-rh01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stg-rh01/deploy.yaml
@@ -2674,7 +2674,7 @@ metadata:
   namespace: openshift-marketplace
 spec:
   displayName: custom-operators
-  image: quay.io/openshift-pipeline/pipelines-index-4.18@sha256:a4aa211a70b0a92c98c885cca8fed2cce490e3fec656ad1ea68bf7e7c3c18304
+  image: quay.io/openshift-pipeline/pipelines-index-4.19@sha256:d33de5fb02ab99f6d93bdec9592400d0c8fd2622354446c4c043fa1dcba4e72e
   sourceType: grpc
   updateStrategy:
     registryPoll:
@@ -2694,16 +2694,6 @@ spec:
     env:
     - name: AUTOINSTALL_COMPONENTS
       value: "false"
-    - name: IMAGE_PAC_PAC_CONTROLLER
-      value: quay.io/openshift-pipeline/pipelines-pipelines-as-code-controller-rhel9@sha256:1b1e365cfdcc85646d5890232a04bad8c7ba9ebb0db36042eeda5961f8106567
-    - name: IMAGE_PAC_PAC_WEBHOOK
-      value: quay.io/openshift-pipeline/pipelines-pipelines-as-code-webhook-rhel9@sha256:0ccda15a17a405020fa199b3dce4a630e592da9dfdbd9778be1dcc9f4bdc3fbd
-    - name: IMAGE_PAC_PAC_WATCHER
-      value: quay.io/openshift-pipeline/pipelines-pipelines-as-code-watcher-rhel9@sha256:d100578068feb5482e2631b4fadc80b9687f129c7e303b55431ac41ce58f7758
-    - name: IMAGE_PAC_PAC_CLI
-      value: quay.io/openshift-pipeline/pipelines-pipelines-as-code-cli-rhel9@sha256:0fc0dd05236f14265e25cc770a7f9f3aeea2e27964a730dac39cf9f61d349bde
-    - name: IMAGE_PIPELINES_CONTROLLER
-      value: quay.io/openshift-pipeline/pipelines-resolvers-rhel9@sha256:7cd91bc4c0f3469ec4c39d08d818b00c90ce07456364910e49ad5e1430f3110a
   name: openshift-pipelines-operator-rh
   source: custom-operators
   sourceNamespace: openshift-marketplace


### PR DESCRIPTION
## Summary

Update CatalogSource image from `pipelines-index-4.18` (5.0.5-830) to `pipelines-index-4.19` (5.0.5-849) across dev and staging environments. Also removes obsolete PAC and Pipeline resolvers image overrides

Files changed:
- `components/pipeline-service/development/main-pipeline-service-configuration.yaml`
- `components/pipeline-service/staging/base/main-pipeline-service-configuration.yaml`
- `components/pipeline-service/staging/stone-stage-p01/deploy.yaml`
- `components/pipeline-service/staging/stone-stg-rh01/deploy.yaml`

Clusters affected: development, staging (stone-stage-p01, stone-stg-rh01)

## Validation
- Pick up the latest nightly index build (5.0.5-849) with significant component upgrades for the 4.19 cycle.
- Konflux build #75170 succeeded (build + EC test passed)
- Tenant release PLR succeeded (image mirrored to `quay.io/openshift-pipeline/pipelines-index-4.19`)
- `osp-index-info` validation: 39/40 images have metadata (only `pipelines-serve-tkn-cli-rhel9` missing — expected)
- All component upstream SHAs verified against expected versions
- Override image versions verified: PAC at v0.48.0, Pipeline resolvers at release-v1.12.x (cherry-picks)

## Changelog: 4.18 (830) → 4.19 (849)

Index: `5.0.5-830` → `5.0.5-849`

### Component Summary

| Component | Previously Deployed | 849 (4.19) | Change |
|-----------|-------------------|-----------|--------|
| Pipeline | 829429b2 (release-v1.12.x, override) / b150ab2d (controller, bundle) | 8afd0f7d (v1.14.0) | +166 commits (branch change) |
| PAC | 0b6c4870 (v0.48.0, override) | 25d67107 (v0.49.0) | +47 commits |
| Chains | dbad7be6 (v0.26.4) | 24246ee8 (~v0.27.3) | +150 commits (branch change) |
| Operator | 4fec2970 | 6ce06ca7 | +99 commits |

### Pipeline (release-v1.12.x → v1.14.0, +166 commits)

[Compare](https://github.com/tektoncd/pipeline/compare/829429b251abc0dd2dd055b893300f505780b70b...8afd0f7d5aae3504267eb42bf342847911b7b4d1)

> **Note:** The resolvers image was overridden to `829429b2` (release-v1.12.x + 5 cherry-picks). The main controller was on `b150ab2d` (830 bundle). With v1.14.0, both are unified on the same commit.

**Already deployed via override (not net-new):**
- Fix PipelineRun premature failure after pod eviction (PR #9640)
- TaskRun stuck in Running when init container is OOMKilled
- Truncate affinity assistant volume names to 63 characters
- Prevent controller CPU variant from leaking into platform commands
- Allow ResolutionRequests to resolve all Tekton kinds

**New Features:**
- TEP-0056: Support PipelineRef in PipelineTask
- TEP-0137: Activate formats field in config-events
- Compress termination messages to fit more results in 4KB limit
- 8 tracing/observability additions (spans for TaskRun, PipelineRun, CustomRun reconcilers)

**Bug Fixes (net-new):**
- Allow finally tasks to run when tasks timeout is exceeded
- Prevent concurrent map writes when resolving StepAction refs
- Resolve goroutine leak from unbuffered channels in resolver reconcilers
- Skip re-resolution of already resolved requests
- Respect per-resolver TTL override in cache
- Cache native sidecar discovery; memoize probe with sync.OnceValues
- Set default resource requirements on internal containers

**Security:** Go 1.26.4

### PAC (v0.48.0 → v0.49.0, +47 commits)

[Compare](https://github.com/tektoncd/pipelines-as-code/compare/0b6c487085a583f015c620e135fd3b3015bf1037...25d6710721897afddda94e405c82b87a117629a1)

> **Note:** PAC images were overridden to v0.48.0 (`0b6c4870`). The changelog starts from the override version, not the 4.18 bundle version.

**New Features:**
- Bitbucket DC: allow service accounts not to require a user
- Forgejo: cache org teams in policy check
- Automatic GitLab access rotation
- Forgejo CLI webhook setup

**Bug Fixes:**
- Bitbucket API tokens instead of app-passwords
- Discard label removal events on GitLab merge requests
- Avoid shared state in reconciler
- Direct OTel SDK setup for chain-coherent sampling
- Run default AI roles on completed PipelineRuns
- Downgrade 404 API responses from error to debug log level

**Security:** 5 CVE fixes — 58 stdlib CVEs via Go upgrades + CVE-2026-33022 via Pipeline bump to v1.14.0

### Chains (v0.26.4 → ~v0.27.3, +150 commits)

[Compare](https://github.com/tektoncd/chains/compare/dbad7be669c3ad3150d8863e63b703e2e96ec815...24246ee86bd0c7fde8135f6b2302511cabd69be9)

**New Features:**
- Insecure OCI registry support
- OCI artifact signing for ARTIFACT_OUTPUTS
- OpenCensus → OpenTelemetry migration

**Bug Fixes:**
- Fix duplicate .att/.sig OCI layers for same-digest type hints

### Operator (+99 commits)

[Compare](https://github.com/tektoncd/operator/compare/4fec29706965e08a1b891996ae043294595ee546...6ce06ca7b21044838918f74bfb32d4dc880b7e2c)

**TLS Expansion:** Full central TLS rollout across ALL webhooks (pipelines, triggers, PAC, pruner, MAG, console-plugin)

**New Features:**
- NetworkPolicyConfig API type
- Helm OCI publishing

**Security:** 3 CVE fixes

### Flags

- Chains is 1 commit behind v0.27.3
- CLI is 12 commits past v0.45.0 with no release tag — unreleased HEAD
