### PR TITLE
Fix /rerun trigger to be anywhere in the comment

### DIFF
--- a/.github/workflows/pr-rerun-checks.yaml
+++ b/.github/workflows/pr-rerun-checks.yaml
@@ -1,7 +1,7 @@
 name: Rerun failed checks
 
 # Lets contributors with read-only repo access re-trigger failed GitHub Actions
-# checks by commenting `/rerun` on the pull request.
+# checks by commenting `/rerun` anywhere in a pull request comment.
 #
 # This reruns failed or cancelled GitHub Actions workflow runs on the PR head commit.
 # Prow / OpenShift CI E2E checks are not affected — use `/retest` for those.
@@ -15,7 +15,7 @@ jobs:
   rerun-workflows:
     if: |
       github.event.issue.pull_request &&
-      github.event.comment.body == '/rerun'
+      contains(github.event.comment.body, '/rerun')
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:


### PR DESCRIPTION
Before, the comment needed to match perfectly /rerun, no extra space, no extra characters. Change the trigger to check if message contain /rerun instead, making this more flexible and useful.

[KFLUXINFRA-4149](https://redhat.atlassian.net/browse/KFLUXINFRA-4149)

[KFLUXINFRA-4149]: https://redhat.atlassian.net/browse/KFLUXINFRA-4149?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ