### PR TITLE
KONFLUX-14935 Fix cert-manager Namespace drift blocking e2e

### DIFF
--- a/argo-cd-apps/base/member/infra-deployments/cert-manager/cert-manager.yaml
+++ b/argo-cd-apps/base/member/infra-deployments/cert-manager/cert-manager.yaml
@@ -52,12 +52,20 @@ spec:
       destination:
         namespace: cert-manager-operator
         server: '{{server}}'
+      ignoreDifferences:
+        - group: ""
+          kind: Namespace
+          name: cert-manager
+          jsonPointers:
+            - /metadata/labels
+            - /metadata/annotations
       syncPolicy:
         automated:
           prune: true
           selfHeal: false
         syncOptions:
           - CreateNamespace=true
+          - RespectIgnoreDifferences=true
         retry:
           limit: -1
           backoff:


### PR DESCRIPTION
## What

**Hotfix** — cert-manager OutOfSync drift is blocking e2e on all dev PRs.

- Add `ignoreDifferences` for the `cert-manager` Namespace (labels/annotations) to the cert-manager ApplicationSet
- Add `RespectIgnoreDifferences=true` to syncOptions

[KONFLUX-14935](https://redhat.atlassian.net/browse/KONFLUX-14935)

## Why

The OCP cert-manager operator modifies the `cert-manager` namespace labels/annotations after ArgoCD syncs it, causing persistent OutOfSync drift. This blocks e2e install for 45 minutes until timeout (44/45 apps sync, only `cert-manager-in-cluster-local` stays stuck).

This likely started with PR #12858 (July 2), which added `namespace-label.yaml` declaring the `cert-manager` Namespace as a managed ArgoCD resource. Before that change, ArgoCD wasn't managing the namespace object directly, so the operator's modifications were invisible.

## Validation

- `kustomize build` passes for all affected overlays (development, staging-downstream, production-downstream, konflux-public-production)
- Follows the same pattern used in `knative-eventing.yaml` for similar operator-driven drift

## Risk Assessment

**Risk Level:** Low
**What could go wrong:** ArgoCD stops detecting legitimate namespace changes — but we're only ignoring labels/annotations on the `cert-manager` Namespace, which are owned by the OCP operator, not by us.
**Rollback:** Revert PR
**Blast radius:** All clusters (ApplicationSet base template change), but the change is purely diff-suppression — no deployed resources are modified.

[KONFLUX-14935]: https://redhat.atlassian.net/browse/KONFLUX-14935?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ