### PR TITLE
KONFLUX-14906 Set default-imagepullbackoff-timeout to 15m in production

### DIFF
--- a/components/pipeline-service/production/base/main-pipeline-service-configuration.yaml
+++ b/components/pipeline-service/production/base/main-pipeline-service-configuration.yaml
@@ -1749,6 +1749,7 @@ spec:
                   value: "konflux-tenants"
                   effect: "NoSchedule"
             default-timeout-minutes: "120"
+            default-imagepullbackoff-timeout: "15m"
         config-leader-election-resolvers:
           data:
             buckets: "8"

--- a/components/pipeline-service/production/kflux-fedora-01/deploy.yaml
+++ b/components/pipeline-service/production/kflux-fedora-01/deploy.yaml
@@ -2312,6 +2312,7 @@ spec:
       configMaps:
         config-defaults:
           data:
+            default-imagepullbackoff-timeout: 15m
             default-pod-template: |
               nodeSelector:
                 konflux-ci.dev/workload: konflux-tenants

--- a/components/pipeline-service/production/kflux-ocp-p01/deploy.yaml
+++ b/components/pipeline-service/production/kflux-ocp-p01/deploy.yaml
@@ -2297,6 +2297,7 @@ spec:
       configMaps:
         config-defaults:
           data:
+            default-imagepullbackoff-timeout: 15m
             default-pod-template: |
               nodeSelector:
                 konflux-ci.dev/workload: konflux-tenants

--- a/components/pipeline-service/production/kflux-osp-p01/deploy.yaml
+++ b/components/pipeline-service/production/kflux-osp-p01/deploy.yaml
@@ -2297,6 +2297,7 @@ spec:
       configMaps:
         config-defaults:
           data:
+            default-imagepullbackoff-timeout: 15m
             default-pod-template: |
               nodeSelector:
                 konflux-ci.dev/workload: konflux-tenants

--- a/components/pipeline-service/production/kflux-prd-rh02/deploy.yaml
+++ b/components/pipeline-service/production/kflux-prd-rh02/deploy.yaml
@@ -2297,6 +2297,7 @@ spec:
       configMaps:
         config-defaults:
           data:
+            default-imagepullbackoff-timeout: 15m
             default-pod-template: |
               nodeSelector:
                 konflux-ci.dev/workload: konflux-tenants

--- a/components/pipeline-service/production/kflux-prd-rh03/deploy.yaml
+++ b/components/pipeline-service/production/kflux-prd-rh03/deploy.yaml
@@ -2297,6 +2297,7 @@ spec:
       configMaps:
         config-defaults:
           data:
+            default-imagepullbackoff-timeout: 15m
             default-pod-template: |
               nodeSelector:
                 konflux-ci.dev/workload: konflux-tenants

--- a/components/pipeline-service/production/kflux-rhel-p01/deploy.yaml
+++ b/components/pipeline-service/production/kflux-rhel-p01/deploy.yaml
@@ -2297,6 +2297,7 @@ spec:
       configMaps:
         config-defaults:
           data:
+            default-imagepullbackoff-timeout: 15m
             default-pod-template: |
               nodeSelector:
                 konflux-ci.dev/workload: konflux-tenants

--- a/components/pipeline-service/production/stone-prd-rh01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prd-rh01/deploy.yaml
@@ -2297,6 +2297,7 @@ spec:
       configMaps:
         config-defaults:
           data:
+            default-imagepullbackoff-timeout: 15m
             default-pod-template: |
               nodeSelector:
                 konflux-ci.dev/workload: konflux-tenants

--- a/components/pipeline-service/production/stone-prod-p01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prod-p01/deploy.yaml
@@ -2297,6 +2297,7 @@ spec:
       configMaps:
         config-defaults:
           data:
+            default-imagepullbackoff-timeout: 15m
             default-pod-template: |
               nodeSelector:
                 konflux-ci.dev/workload: konflux-tenants

--- a/components/pipeline-service/production/stone-prod-p02/deploy.yaml
+++ b/components/pipeline-service/production/stone-prod-p02/deploy.yaml
@@ -2297,6 +2297,7 @@ spec:
       configMaps:
         config-defaults:
           data:
+            default-imagepullbackoff-timeout: 15m
             default-pod-template: |
               nodeSelector:
                 konflux-ci.dev/workload: konflux-tenants


### PR DESCRIPTION
## What

- Add `default-imagepullbackoff-timeout: "15m"` to the TektonConfig CR `config-defaults` in the production base overlay
- Regenerate all production per-cluster `deploy.yaml` files

Clusters affected: all production (kflux-fedora-01, stone-prod-p01, kflux-osp-p01, stone-prod-p02, kflux-rhel-p01, kflux-ocp-p01, stone-prd-rh01, kflux-prd-rh02, kflux-prd-rh03)

[KONFLUX-14906](https://redhat.atlassian.net/browse/KONFLUX-14906)

## Why

The current default of `0` causes Tekton to immediately fail TaskRuns on the first `ImagePullBackOff` event. Transient registry outages (e.g. quay.io) then cascade into mass PipelineRun failures. Setting a 15-minute timeout gives the kubelet time to retry image pulls with exponential back-off before Tekton marks the TaskRun as failed.

## Validation

- `kustomize build ./components/pipeline-service/production/base` passes
- `./hack/generate-deploy-config.sh -c components/pipeline-service/production` regenerated deploy.yaml files with the new setting
- Dev/staging PR: https://github.com/redhat-appstudio/infra-deployments/pull/12976

**Staging validation: `default-imagepullbackoff-timeout: "15m"` (2026-07-12)**

A PipelineRun (`test-nonexistent-image-jw2sc`) was created in `gbenhaim-tenant` on staging (`stone-stg-rh01`) with a non-existent image (`quay.io/totally-fake-org/this-image-does-not-exist:v999`). The TaskRun remained active for ~16 minutes, with the kubelet performing 5 image pull attempts across 66 back-off cycles, before Tekton terminated it with `TaskRunImagePullFailed`. Previously (with the default timeout: `0`), the same scenario failed in ~13 seconds on the first `ImagePullBackOff`. This confirms the configuration is effective and would allow builds to survive transient registry outages (e.g., quay.io) lasting up to 15 minutes without user-visible failures.

## Risk Assessment

**Risk Level:** Low
**What could go wrong:** TaskRuns with genuinely broken images (e.g. typo in image name) take up to 15 minutes to fail instead of failing immediately. This only affects the failure reporting latency — no builds that would otherwise succeed are impacted.
**Rollback:** Revert PR
**Blast radius:** All production clusters — but the change only adds a timeout to tolerate transient failures. No images, operators, or structural resources are modified.

Made with [Cursor](https://cursor.com)

[KONFLUX-14906]: https://redhat.atlassian.net/browse/KONFLUX-14906?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ