### PR TITLE
PVO11Y-5364 [1/3] Prepare kueue ClusterPolicy for recreation on fedora

### DIFF
--- a/components/policies/production/kflux-fedora-01/kustomization.yaml
+++ b/components/policies/production/kflux-fedora-01/kustomization.yaml
@@ -4,3 +4,10 @@ resources:
 - ../base
 - ../policies/kubearchive/
 - ../policies/kueue/
+patches:
+- path: patches/kueue-policy-prepare-recreate.yaml
+  target:
+    group: kyverno.io
+    version: v1
+    kind: ClusterPolicy
+    name: bootstrap-tenant-namespace-queue

--- a/components/policies/production/kflux-fedora-01/patches/kueue-policy-prepare-recreate.yaml
+++ b/components/policies/production/kflux-fedora-01/patches/kueue-policy-prepare-recreate.yaml
@@ -1,0 +1,3 @@
+- op: replace
+  path: /spec/rules/0/generate/synchronize
+  value: false


### PR DESCRIPTION
## Summary

Set `synchronize: false` on the kueue ClusterPolicy for kflux-fedora-01 so existing LocalQueues are preserved when the policy is deleted and recreated in steps 2 and 3.

**Step 1 of 3** — follows the [ClusterPolicy update process](https://github.com/redhat-appstudio/infra-deployments/tree/main/components/policies#how-to-update-an-existing-clusterpolicy) for generate rules where deletion of generated resources is not acceptable.

## Context

The kueue ClusterPolicy on kflux-fedora-01 has a stale cached version in kyverno that doesn't include `appstudio-kanary-exporter` in the match field. ArgoCD shows "Synced" but kyverno ignores the update because it's an immutable field change. The 3-step process forces kyverno to reload the policy fresh.

## Risk Assessment

- **Level**: Low
- **Description**: Only changes `synchronize` from true to false on kflux-fedora-01. Existing LocalQueues continue to function — they just won't be auto-updated by the policy until step 3 restores synchronize.
- **Rollback**: Remove the patch file and revert the kustomization

## Validation

This change cannot be validated in staging as it targets a cluster-specific kyverno ClusterPolicy on kflux-fedora-01. The 3-step process follows the documented [ClusterPolicy update procedure](https://github.com/redhat-appstudio/infra-deployments/tree/main/components/policies#how-to-update-an-existing-clusterpolicy) and was previously validated on staging clusters in [#11106](https://github.com/redhat-appstudio/infra-deployments/pull/11106), [#11107](https://github.com/redhat-appstudio/infra-deployments/pull/11107), [#11108](https://github.com/redhat-appstudio/infra-deployments/pull/11108).

## JIRA

[PVO11Y-5342](https://redhat.atlassian.net/browse/PVO11Y-5342)

[PVO11Y-5342]: https://redhat.atlassian.net/browse/PVO11Y-5342?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ