### PR TITLE
PVO11Y-5364 [3/3] Restore kueue ClusterPolicy on fedora

### DIFF
--- a/components/policies/production/kflux-fedora-01/kustomization.yaml
+++ b/components/policies/production/kflux-fedora-01/kustomization.yaml
@@ -3,3 +3,4 @@ kind: Kustomization
 resources:
 - ../base
 - ../policies/kubearchive/
+- ../policies/kueue/


### PR DESCRIPTION
## Summary

Restore the kueue policy to kflux-fedora-01 after it was pruned in step 2. Kyverno will load the policy fresh with the updated match field including `appstudio-kanary-exporter`, and `generateExisting: true` will create the LocalQueue for the kanary namespace.

**Step 3 of 3** — merge only after step 2 ([#13011](https://github.com/redhat-appstudio/infra-deployments/pull/13011)) is merged and the ClusterPolicy is confirmed deleted on the cluster.

## Risk Assessment

- **Level**: Low
- **Description**: Restores the kueue ClusterPolicy to kflux-fedora-01 with `synchronize: true`. Kyverno will recreate LocalQueues for all matched namespaces including the new `appstudio-kanary-exporter`.
- **Rollback**: Remove `../policies/kueue/` from the kustomization

## Validation

This change cannot be validated in staging as it targets a cluster-specific kyverno ClusterPolicy on kflux-fedora-01. The 3-step process follows the documented [ClusterPolicy update procedure](https://github.com/redhat-appstudio/infra-deployments/tree/main/components/policies#how-to-update-an-existing-clusterpolicy) and was previously validated on staging clusters in [#11106](https://github.com/redhat-appstudio/infra-deployments/pull/11106), [#11107](https://github.com/redhat-appstudio/infra-deployments/pull/11107), [#11108](https://github.com/redhat-appstudio/infra-deployments/pull/11108).

## JIRA

[PVO11Y-5342](https://redhat.atlassian.net/browse/PVO11Y-5342)

[PVO11Y-5342]: https://redhat.atlassian.net/browse/PVO11Y-5342?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ