### PR TITLE
Enable proxy for pip on select prod clusters

### DIFF
--- a/components/konflux-info/production/kflux-prd-rh02/cluster-config.env
+++ b/components/konflux-info/production/kflux-prd-rh02/cluster-config.env
@@ -5,5 +5,6 @@ no-proxy=
 allow-package-registry-proxy=true
 package-registry-proxy-gomod-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/go-proxy
 package-registry-proxy-npm-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/npm-proxy
+package-registry-proxy-pip-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/pypi-proxy/simple
 package-registry-proxy-pnpm-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/npm-proxy
 package-registry-proxy-yarn-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/npm-proxy

--- a/components/konflux-info/production/stone-prod-p01/cluster-config.env
+++ b/components/konflux-info/production/stone-prod-p01/cluster-config.env
@@ -5,5 +5,6 @@ no-proxy=
 allow-package-registry-proxy=true
 package-registry-proxy-gomod-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/go-proxy
 package-registry-proxy-npm-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/npm-proxy
+package-registry-proxy-pip-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/pypi-proxy/simple
 package-registry-proxy-pnpm-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/npm-proxy
 package-registry-proxy-yarn-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/npm-proxy


### PR DESCRIPTION
Enable use of the package registry proxy for Hermeto's pip backend on select prod clusters (stone-prod-p01, kflux-prd-rh02). This will allow Hermeto to route dependency prefetches through the package registry proxy for policy evaluation.

Re-enabling Nexus for pip on ring 1.

We found an issue impacting ~20% of pip users on the limited rollout listed in the Validation section, so we deferred adding pip to the backends that are proxied until the corrected prefetch task has rolled-out to users. Version 0.4.0 of the prefetch-dependencies task was rolled out to users over the weekend.

## Risk Assessment
**Risk Level:** Medium
**Description:** Enables pip requests to be proxied through Nexus by Hermeto.
**Rollback:** Revert PR

## Validation
Staging PR: https://github.com/redhat-appstudio/infra-deployments/pull/12528

## Additional Validation
Limited prod deployment:
- https://github.com/redhat-appstudio/infra-deployments/pull/12757
- https://konflux-ui.apps.kflux-prd-rh02.0fk9.p1.openshiftapps.com/ns/lightspeed-core-tenant/applications/dataverse-exporter/taskruns/dataverse-exporter-on-pull-request-rxcsp-prefetch-dependencies/logs

Tested in stage:
- https://konflux-ui.apps.stone-stg-rh01.l2vh.p1.openshiftapps.com/ns/tmadore-tenant/applications/hermeto-integration-tests/pipelineruns/pip-e2e-proxy-on-push-vjrjx