### PR TITLE
KFLUXVNGD-1121 Promote crossplane-control-plane upgrade to production

### DIFF
--- a/components/crossplane-control-plane/production/base/kustomization.yaml
+++ b/components/crossplane-control-plane/production/base/kustomization.yaml
@@ -5,8 +5,8 @@ resources:
 - ../../base
 - provider-config.yaml
 - testplatform-provider-config.yaml
-- https://github.com/konflux-ci/crossplane-control-plane/crossplane?ref=bd3da0eff408eb329bfb5d7306b2aa3016d1a906
-- https://github.com/konflux-ci/crossplane-control-plane/config?ref=bd3da0eff408eb329bfb5d7306b2aa3016d1a906
+- https://github.com/konflux-ci/crossplane-control-plane/crossplane?ref=a91519bb2e0628895a351783c084dca911b1a4b4
+- https://github.com/konflux-ci/crossplane-control-plane/config?ref=a91519bb2e0628895a351783c084dca911b1a4b4
 
 images:
   - name: quay.io/konflux-ci/task-runner

--- a/components/crossplane-control-plane/production/kflux-fedora-01/environment-config.yaml
+++ b/components/crossplane-control-plane/production/kflux-fedora-01/environment-config.yaml
@@ -1,0 +1,8 @@
+apiVersion: apiextensions.crossplane.io/v1beta1
+kind: EnvironmentConfig
+metadata:
+  name: envcfg
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+data:
+  clusterName: kflux-fedora-01

--- a/components/crossplane-control-plane/production/kflux-fedora-01/kustomization.yaml
+++ b/components/crossplane-control-plane/production/kflux-fedora-01/kustomization.yaml
@@ -3,3 +3,4 @@ kind: Kustomization
 
 resources:
 - ../base
+- environment-config.yaml

--- a/components/crossplane-control-plane/production/kflux-ocp-p01/environment-config.yaml
+++ b/components/crossplane-control-plane/production/kflux-ocp-p01/environment-config.yaml
@@ -1,0 +1,8 @@
+apiVersion: apiextensions.crossplane.io/v1beta1
+kind: EnvironmentConfig
+metadata:
+  name: envcfg
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+data:
+  clusterName: kflux-ocp-p01

--- a/components/crossplane-control-plane/production/kflux-ocp-p01/kustomization.yaml
+++ b/components/crossplane-control-plane/production/kflux-ocp-p01/kustomization.yaml
@@ -3,3 +3,4 @@ kind: Kustomization
 
 resources:
 - ../base
+- environment-config.yaml

--- a/components/crossplane-control-plane/production/kflux-osp-p01/environment-config.yaml
+++ b/components/crossplane-control-plane/production/kflux-osp-p01/environment-config.yaml
@@ -1,0 +1,8 @@
+apiVersion: apiextensions.crossplane.io/v1beta1
+kind: EnvironmentConfig
+metadata:
+  name: envcfg
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+data:
+  clusterName: kflux-osp-p01

--- a/components/crossplane-control-plane/production/kflux-osp-p01/kustomization.yaml
+++ b/components/crossplane-control-plane/production/kflux-osp-p01/kustomization.yaml
@@ -3,3 +3,4 @@ kind: Kustomization
 
 resources:
 - ../base
+- environment-config.yaml

--- a/components/crossplane-control-plane/production/kflux-prd-rh02/environment-config.yaml
+++ b/components/crossplane-control-plane/production/kflux-prd-rh02/environment-config.yaml
@@ -1,0 +1,8 @@
+apiVersion: apiextensions.crossplane.io/v1beta1
+kind: EnvironmentConfig
+metadata:
+  name: envcfg
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+data:
+  clusterName: kflux-prd-rh02

--- a/components/crossplane-control-plane/production/kflux-prd-rh02/kustomization.yaml
+++ b/components/crossplane-control-plane/production/kflux-prd-rh02/kustomization.yaml
@@ -3,3 +3,4 @@ kind: Kustomization
 
 resources:
 - ../base
+- environment-config.yaml

--- a/components/crossplane-control-plane/production/kflux-prd-rh03/environment-config.yaml
+++ b/components/crossplane-control-plane/production/kflux-prd-rh03/environment-config.yaml
@@ -1,0 +1,8 @@
+apiVersion: apiextensions.crossplane.io/v1beta1
+kind: EnvironmentConfig
+metadata:
+  name: envcfg
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+data:
+  clusterName: kflux-prd-rh03

--- a/components/crossplane-control-plane/production/kflux-prd-rh03/kustomization.yaml
+++ b/components/crossplane-control-plane/production/kflux-prd-rh03/kustomization.yaml
@@ -3,3 +3,4 @@ kind: Kustomization
 
 resources:
 - ../base
+- environment-config.yaml

--- a/components/crossplane-control-plane/production/kflux-rhel-p01/environment-config.yaml
+++ b/components/crossplane-control-plane/production/kflux-rhel-p01/environment-config.yaml
@@ -1,0 +1,8 @@
+apiVersion: apiextensions.crossplane.io/v1beta1
+kind: EnvironmentConfig
+metadata:
+  name: envcfg
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+data:
+  clusterName: kflux-rhel-p01

--- a/components/crossplane-control-plane/production/kflux-rhel-p01/kustomization.yaml
+++ b/components/crossplane-control-plane/production/kflux-rhel-p01/kustomization.yaml
@@ -3,3 +3,4 @@ kind: Kustomization
 
 resources:
 - ../base
+- environment-config.yaml

--- a/components/crossplane-control-plane/production/stone-prd-rh01/environment-config.yaml
+++ b/components/crossplane-control-plane/production/stone-prd-rh01/environment-config.yaml
@@ -1,0 +1,8 @@
+apiVersion: apiextensions.crossplane.io/v1beta1
+kind: EnvironmentConfig
+metadata:
+  name: envcfg
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+data:
+  clusterName: stone-prd-rh01

--- a/components/crossplane-control-plane/production/stone-prd-rh01/kustomization.yaml
+++ b/components/crossplane-control-plane/production/stone-prd-rh01/kustomization.yaml
@@ -3,3 +3,4 @@ kind: Kustomization
 
 resources:
 - ../base
+- environment-config.yaml

--- a/components/crossplane-control-plane/production/stone-prod-p01/environment-config.yaml
+++ b/components/crossplane-control-plane/production/stone-prod-p01/environment-config.yaml
@@ -1,0 +1,8 @@
+apiVersion: apiextensions.crossplane.io/v1beta1
+kind: EnvironmentConfig
+metadata:
+  name: envcfg
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+data:
+  clusterName: stone-prod-p01

--- a/components/crossplane-control-plane/production/stone-prod-p01/kustomization.yaml
+++ b/components/crossplane-control-plane/production/stone-prod-p01/kustomization.yaml
@@ -3,3 +3,4 @@ kind: Kustomization
 
 resources:
 - ../base
+- environment-config.yaml

--- a/components/crossplane-control-plane/production/stone-prod-p02/environment-config.yaml
+++ b/components/crossplane-control-plane/production/stone-prod-p02/environment-config.yaml
@@ -1,0 +1,8 @@
+apiVersion: apiextensions.crossplane.io/v1beta1
+kind: EnvironmentConfig
+metadata:
+  name: envcfg
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+data:
+  clusterName: stone-prod-p02

--- a/components/crossplane-control-plane/production/stone-prod-p02/kustomization.yaml
+++ b/components/crossplane-control-plane/production/stone-prod-p02/kustomization.yaml
@@ -3,3 +3,4 @@ kind: Kustomization
 
 resources:
 - ../base
+- environment-config.yaml


### PR DESCRIPTION
  ## What

  Promote crossplane-control-plane from `bd3da0eff408eb329bfb5d7306b2aa3016d1a906` to `a91519bb2e0628895a351783c084dca911b1a4b4` in the production base overlay. Add an `EnvironmentConfig` to each per-cluster overlay to provide cluster name context at runtime.

  Clusters affected:
  - kflux-fedora-01
  - kflux-ocp-p01
  - kflux-osp-p01
  - kflux-prd-rh02
  - kflux-prd-rh03
  - kflux-rhel-p01
  - stone-prd-rh01
  - stone-prod-p01
  - stone-prod-p02

  [KFLUXVNGD-1121](https://redhat.atlassian.net/browse/KFLUXVNGD-1121)

  ## Why

  The updated Compositions require cluster name context at runtime via an EnvironmentConfig. This was validated in dev/staging and is now being promoted to production.

  ## Validation

  - `kustomize build` passes for all affected production overlays
  - An ephemeral cluster was successfully provisioned via OpenShift-CI in the staging environment with these changes
  - Staging PR: https://github.com/redhat-appstudio/infra-deployments/pull/12948

  ## Risk Assessment

  **Risk Level:** Low
  **Rollback:** Revert PR

[KFLUXVNGD-1121]: https://redhat.atlassian.net/browse/KFLUXVNGD-1121?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ