### PR TITLE
KFLUXVNGD-1121 Upgrade crossplane-control-plane in dev and staging

### DIFF
--- a/components/crossplane-control-plane/development/kustomization.yaml
+++ b/components/crossplane-control-plane/development/kustomization.yaml
@@ -1,9 +1,9 @@
 resources:
 - ../base
 - environment-config.yaml
-- https://github.com/konflux-ci/crossplane-control-plane/crossplane?ref=a91519bb2e0628895a351783c084dca911b1a4b4
-- https://github.com/konflux-ci/crossplane-control-plane/config?ref=a91519bb2e0628895a351783c084dca911b1a4b4
-- https://github.com/konflux-ci/crossplane-control-plane/examples/provider-kubernetes-in-cluster?ref=a91519bb2e0628895a351783c084dca911b1a4b4
+- https://github.com/konflux-ci/crossplane-control-plane/crossplane?ref=93468e78be8cb6980dec3cd97ef400de6d54064b
+- https://github.com/konflux-ci/crossplane-control-plane/config?ref=93468e78be8cb6980dec3cd97ef400de6d54064b
+- https://github.com/konflux-ci/crossplane-control-plane/examples/provider-kubernetes-in-cluster?ref=93468e78be8cb6980dec3cd97ef400de6d54064b
 
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/components/crossplane-control-plane/k-components/crossplane-resources/deployment-resources-patch.yaml
+++ b/components/crossplane-control-plane/k-components/crossplane-resources/deployment-resources-patch.yaml
@@ -1,0 +1,13 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: crossplane
+  namespace: crossplane-system
+spec:
+  template:
+    spec:
+      containers:
+        - name: crossplane
+          resources:
+            limits:
+              memory: 4Gi

--- a/components/crossplane-control-plane/k-components/crossplane-resources/kustomization.yaml
+++ b/components/crossplane-control-plane/k-components/crossplane-resources/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+patches:
+  - path: deployment-resources-patch.yaml

--- a/components/crossplane-control-plane/staging/base/kustomization.yaml
+++ b/components/crossplane-control-plane/staging/base/kustomization.yaml
@@ -5,20 +5,13 @@ resources:
 - ../../base
 - provider-config.yaml
 - testplatform-provider-config.yaml
-- https://github.com/konflux-ci/crossplane-control-plane/crossplane?ref=a91519bb2e0628895a351783c084dca911b1a4b4
-- https://github.com/konflux-ci/crossplane-control-plane/config?ref=a91519bb2e0628895a351783c084dca911b1a4b4
+- https://github.com/konflux-ci/crossplane-control-plane/crossplane?ref=93468e78be8cb6980dec3cd97ef400de6d54064b
+- https://github.com/konflux-ci/crossplane-control-plane/config?ref=93468e78be8cb6980dec3cd97ef400de6d54064b
 
 images:
   - name: quay.io/konflux-ci/task-runner
     newTag: v1
     digest: sha256:b9ef0479b57a494368a12a02886c650314c9ac7391c6228f21065865aab71c9e
 
-patches:
-  - patch: |-
-      - op: add
-        path: /spec/template/spec/containers/0/resources/limits/memory
-        value: 4Gi
-    target:
-      kind: Deployment
-      name: crossplane-helm
-      namespace: crossplane-system
+components:
+  - ../../k-components/crossplane-resources


### PR DESCRIPTION
Bump to a ref that includes the nameOverride fix, restoring the deployment name to crossplane. Replace the JSON patch that targeted crossplane-helm with a shared k-component using a strategic merge patch.

Assisted-by: Claude claude-opus-4-6