### PR TITLE
feat(SPRE-5500): add ServiceMonitor for cert-manager in production

### DIFF
--- a/components/cert-manager/production/base/kustomization.yaml
+++ b/components/cert-manager/production/base/kustomization.yaml
@@ -2,5 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - operator.yaml
-
-namespace: cert-manager-operator
+- monitoring/

--- a/components/cert-manager/production/base/monitoring/kustomization.yaml
+++ b/components/cert-manager/production/base/monitoring/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: cert-manager
+resources:
+- namespace-label.yaml
+- monitoring-rbac.yaml
+- servicemonitor.yaml

--- a/components/cert-manager/production/base/monitoring/monitoring-rbac.yaml
+++ b/components/cert-manager/production/base/monitoring/monitoring-rbac.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cert-manager-metrics-reader
+  namespace: cert-manager
+rules:
+- apiGroups: [""]
+  resources: ["pods", "services", "endpoints"]
+  verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cert-manager-metrics-reader
+  namespace: cert-manager
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cert-manager-metrics-reader
+subjects:
+- kind: ServiceAccount
+  name: prometheus-k8s
+  namespace: openshift-monitoring

--- a/components/cert-manager/production/base/monitoring/namespace-label.yaml
+++ b/components/cert-manager/production/base/monitoring/namespace-label.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cert-manager
+  labels:
+    openshift.io/cluster-monitoring: "true"

--- a/components/cert-manager/production/base/monitoring/servicemonitor.yaml
+++ b/components/cert-manager/production/base/monitoring/servicemonitor.yaml
@@ -1,0 +1,14 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: cert-manager-metrics
+  namespace: cert-manager
+spec:
+  endpoints:
+  - port: tcp-prometheus-servicemonitor
+    interval: 30s
+    path: /metrics
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: controller
+      app.kubernetes.io/instance: cert-manager

--- a/components/cert-manager/production/base/operator.yaml
+++ b/components/cert-manager/production/base/operator.yaml
@@ -3,6 +3,7 @@ apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:
   name: openshift-cert-manager-operator
+  namespace: cert-manager-operator
   annotations:
     argocd.argoproj.io/sync-wave: "-2"
 spec:
@@ -12,6 +13,7 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
   name: openshift-cert-manager-operator
+  namespace: cert-manager-operator
   annotations:
     argocd.argoproj.io/sync-wave: "-1"
 spec:


### PR DESCRIPTION
## Summary
  Deploy cert-manager ServiceMonitor and monitoring RBAC to production clusters.

  Identical to staging/dev PR #12858 — now promoting to production.

  ## Changes
  - Add ServiceMonitor targeting cert-manager controller metrics (port 9402)
  - Add RBAC for prometheus-k8s to scrape cert-manager namespace
  - Label cert-manager namespace for cluster monitoring
  - Move namespace from kustomization.yaml to operator.yaml resources

  ## Testing
  - Verified in staging via PR #12858 (merged 2026-07-02)
  
 ## Risk Assessment
  **Risk Level:** Low
  **Description:** Additive monitoring resources only — ServiceMonitor and read-only RBAC. No impact on cert-manager or cluster workloads. Validated in staging via
  PR #12858 since 2026-07-02.
  **Rollback:** Revert this PR.
  
  
  ## Validation

  Staging PR: https://github.com/redhat-appstudio/infra-deployments/pull/12858


  
  https://redhat.atlassian.net/browse/SPRE-5500