### PR TITLE
SPRE-5503: Add cert-manager metrics to production RHOBS federation

### DIFF
--- a/components/monitoring/prometheus/production/base/federation/endpoints-params.yaml
+++ b/components/monitoring/prometheus/production/base/federation/endpoints-params.yaml
@@ -120,6 +120,20 @@
     - '{__name__="kube_deployment_spec_replicas", namespace="image-rbac-proxy"}'
     - '{__name__="kube_deployment_status_replicas_available", namespace="image-rbac-proxy"}'
 
+    # Namespace: cert-manager
+    - '{__name__="kube_deployment_status_replicas_ready", namespace="cert-manager"}'
+    - '{__name__="kube_deployment_status_replicas_available", namespace="cert-manager"}'
+    - '{__name__="kube_deployment_spec_replicas", namespace="cert-manager"}'
+    - '{__name__="certmanager_certificate_ready_status", namespace="cert-manager"}'
+    - '{__name__="certmanager_certificate_expiration_timestamp_seconds", namespace="cert-manager"}'
+    - '{__name__="certmanager_certificate_renewal_timestamp_seconds", namespace="cert-manager"}'
+    - '{__name__="certmanager_certificate_not_after_timestamp_seconds", namespace="cert-manager"}'
+    - '{__name__="certmanager_certificate_not_before_timestamp_seconds", namespace="cert-manager"}'
+    - '{__name__="certmanager_controller_sync_call_count", namespace="cert-manager"}'
+    - '{__name__="certmanager_controller_sync_error_count", namespace="cert-manager"}'
+    - '{__name__="certmanager_clusterissuer_ready_status", namespace="cert-manager"}'
+    - '{__name__="certmanager_issuer_ready_status", namespace="cert-manager"}'
+
     ## Container Metrics
     - '{__name__="kube_pod_container_status_waiting_reason", namespace!~".*-tenant|openshift-.*|kube-.*"}'
     - '{__name__="kube_pod_container_resource_limits", namespace=~"release-service|rhtap-releng-tenant"}'

--- a/components/monitoring/prometheus/production/base/federation/writeRelabelConfigs.yaml
+++ b/components/monitoring/prometheus/production/base/federation/writeRelabelConfigs.yaml
@@ -23,6 +23,7 @@
     # Monitoring infra (RHTAPWATCH-110, PVO11Y-4774)
     # KubeArchive
     # KAExporter (PVO11Y-5274)
+    # cert-manager (SPRE-5502)
     regex: "__name__|source_environment|source_cluster|namespace|job|instance|pod|container|app|service|deployment|node|\
       phase|reason|type|resource|kind|name|role|status|state|resourcequota|image|finalizers|verb|request_kind|\
       persistentvolumeclaim|storageclass|volumename|\
@@ -39,4 +40,5 @@
       health_status|dest_namespace|\
       hostname|label_app_kubernetes_io_managed_by|platform|scrape_job|slice|error|\
       resource_type|gin_errors|\
-      application|component|build_type|scenario|optional|test_type|automated|exported_namespace"
+      application|component|build_type|scenario|optional|test_type|automated|exported_namespace|\
+      condition|issuer_name|issuer_kind|issuer_group"


### PR DESCRIPTION
## Summary
  Expose cert-manager metrics to RHOBS (Thanos) in production clusters.

  Identical to staging PRs #12937 + #12953 — now promoting to production.

  ## Changes
  - Add cert-manager metrics to federation endpoints-params (deployment status, certificate status, issuer readiness, sync errors)
  - Add cert-manager label dimensions to writeRelabelConfigs (condition, issuer_name, issuer_kind, issuer_group)

  ## Testing
  - Verified in staging via PRs #12937 and #12953

  https://redhat.atlassian.net/browse/SPRE-5502