### PR TITLE
PVO11Y-5094 Deploy Tekton Prometheus to production (ring 1)

### DIFF
--- a/components/cluster-secret-store/production/kustomization.yaml
+++ b/components/cluster-secret-store/production/kustomization.yaml
@@ -21,3 +21,9 @@ patches:
       kind: ClusterSecretStore
       group: external-secrets.io
       version: v1
+  - path: observability-namespaces-patch.yaml
+    target:
+      name: appsre-stonesoup-vault
+      kind: ClusterSecretStore
+      group: external-secrets.io
+      version: v1

--- a/components/cluster-secret-store/production/observability-namespaces-patch.yaml
+++ b/components/cluster-secret-store/production/observability-namespaces-patch.yaml
@@ -1,0 +1,4 @@
+---
+- op: add
+  path: /spec/conditions/0/namespaces/-
+  value: appstudio-tekton

--- a/components/monitoring/prometheus/production/stone-prod-p01/kustomization.yaml
+++ b/components/monitoring/prometheus/production/stone-prod-p01/kustomization.yaml
@@ -2,11 +2,18 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - ../base
+- ../tekton-ms
 
 patches:
   - path: cluster-id-label.yaml
     target:
       name: appstudio-federate-ms
+      kind: MonitoringStack
+      group: monitoring.rhobs
+      version: v1alpha1
+  - path: cluster-id-label.yaml
+    target:
+      name: appstudio-tekton-ms
       kind: MonitoringStack
       group: monitoring.rhobs
       version: v1alpha1

--- a/components/monitoring/prometheus/production/tekton-ms/base/kustomization.yaml
+++ b/components/monitoring/prometheus/production/tekton-ms/base/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- namespace.yaml
+- monitoringstack.yaml
+- rbac.yaml
+- servicemonitor.yaml
+- servicemonitor-pipeline-exporter.yaml
+
+commonAnnotations:
+  argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true

--- a/components/monitoring/prometheus/production/tekton-ms/base/monitoringstack.yaml
+++ b/components/monitoring/prometheus/production/tekton-ms/base/monitoringstack.yaml
@@ -1,0 +1,31 @@
+apiVersion: monitoring.rhobs/v1alpha1
+kind: MonitoringStack
+metadata:
+  name: appstudio-tekton-ms
+  namespace: appstudio-tekton
+spec:
+  resourceSelector:
+    matchLabels:
+      monitoring.rhobs/stack: appstudio-tekton-ms
+  logLevel: info
+  retention: 7d
+  retentionSize: 15GB
+  alertmanagerConfig:
+    disabled: true
+  resources:
+    requests:
+      cpu: 200m
+      memory: 8Gi
+    limits:
+      memory: 8Gi
+  prometheusConfig:
+    externalLabels: {} # added by overlays (source_cluster, source_environment)
+    replicas: 2
+    persistentVolumeClaim:
+      storageClassName: gp3
+      accessModes:
+        - ReadWriteOnce
+      resources:
+        requests:
+          storage: 20Gi
+    remoteWrite: [] # defined entirely by overlays

--- a/components/monitoring/prometheus/production/tekton-ms/base/namespace.yaml
+++ b/components/monitoring/prometheus/production/tekton-ms/base/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: appstudio-tekton

--- a/components/monitoring/prometheus/production/tekton-ms/base/rbac.yaml
+++ b/components/monitoring/prometheus/production/tekton-ms/base/rbac.yaml
@@ -1,0 +1,30 @@
+# Need specific permissions for Tekton Prometheus to scrape metrics.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: appstudio-tekton-ms-discovery
+  namespace: openshift-pipelines
+  labels:
+    monitoring.rhobs/stack: appstudio-tekton-ms
+rules:
+- apiGroups: [""]
+  resources: [services, endpoints, pods]
+  verbs: [get, list, watch]
+---
+# Grant permission to Tekton Prometheus SA to scrape Services/Endpoints only in
+# openshift-pipelines. Enforces principle of least privilege.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: appstudio-tekton-ms-discovery
+  namespace: openshift-pipelines
+  labels:
+    monitoring.rhobs/stack: appstudio-tekton-ms
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: appstudio-tekton-ms-discovery
+subjects:
+- kind: ServiceAccount
+  name: appstudio-tekton-ms-prometheus
+  namespace: appstudio-tekton

--- a/components/monitoring/prometheus/production/tekton-ms/base/servicemonitor-pipeline-exporter.yaml
+++ b/components/monitoring/prometheus/production/tekton-ms/base/servicemonitor-pipeline-exporter.yaml
@@ -1,0 +1,18 @@
+apiVersion: monitoring.rhobs/v1
+kind: ServiceMonitor
+metadata:
+  name: appstudio-tekton-pipeline-exporter-smon
+  namespace: appstudio-tekton
+  labels:
+    monitoring.rhobs/stack: appstudio-tekton-ms
+spec:
+  namespaceSelector:
+    matchNames:
+    - openshift-pipelines
+  selector:
+    matchLabels:
+      app: pipeline-metrics-exporter
+  endpoints:
+  - port: metrics
+    interval: 15s
+    honorLabels: true

--- a/components/monitoring/prometheus/production/tekton-ms/base/servicemonitor.yaml
+++ b/components/monitoring/prometheus/production/tekton-ms/base/servicemonitor.yaml
@@ -1,0 +1,19 @@
+apiVersion: monitoring.rhobs/v1
+kind: ServiceMonitor
+metadata:
+  name: appstudio-tekton-pipelines-smon
+  namespace: appstudio-tekton
+  labels:
+    monitoring.rhobs/stack: appstudio-tekton-ms
+spec:
+  namespaceSelector:
+    matchNames:
+    - openshift-pipelines
+  selector:
+    matchLabels:
+      app: tekton-pipelines-controller
+      app.kubernetes.io/component: controller
+  endpoints:
+  - port: http-metrics
+    interval: 15s
+    honorLabels: true

--- a/components/monitoring/prometheus/production/tekton-ms/external-secrets/kustomization.yaml
+++ b/components/monitoring/prometheus/production/tekton-ms/external-secrets/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- rhobs.yaml

--- a/components/monitoring/prometheus/production/tekton-ms/external-secrets/rhobs.yaml
+++ b/components/monitoring/prometheus/production/tekton-ms/external-secrets/rhobs.yaml
@@ -1,0 +1,20 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: rhobs
+  namespace: appstudio-tekton
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  dataFrom:
+    - extract:
+        key: production/monitoring/rhobs
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: appsre-stonesoup-vault
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    name: rhobs

--- a/components/monitoring/prometheus/production/tekton-ms/kube-rbac-proxy.yaml
+++ b/components/monitoring/prometheus/production/tekton-ms/kube-rbac-proxy.yaml
@@ -1,0 +1,112 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: tekton-ms-kube-rbac-proxy
+  namespace: appstudio-tekton
+---
+# Required so kube-rbac-proxy can create tokenreviews and subjectaccessreviews
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: tekton-ms-kube-rbac-proxy-auth-delegator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:auth-delegator
+subjects:
+  - kind: ServiceAccount
+    name: tekton-ms-kube-rbac-proxy
+    namespace: appstudio-tekton
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: tekton-ms-kube-rbac-proxy-config
+  namespace: appstudio-tekton
+data:
+  config.yaml: |
+    authorization:
+      resourceAttributes:
+        apiGroup: monitoring.coreos.com
+        resource: prometheuses/api
+        name: k8s
+        verb: get
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tekton-ms-kube-rbac-proxy
+  namespace: appstudio-tekton
+  labels:
+    app: tekton-ms-kube-rbac-proxy
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: tekton-ms-kube-rbac-proxy
+  template:
+    metadata:
+      labels:
+        app: tekton-ms-kube-rbac-proxy
+    spec:
+      serviceAccountName: tekton-ms-kube-rbac-proxy
+      containers:
+        - name: kube-rbac-proxy
+          image: registry.redhat.io/openshift4/ose-kube-rbac-proxy:v4.15
+          args:
+            - '--secure-listen-address=0.0.0.0:9091'
+            - '--upstream=http://appstudio-tekton-ms-prometheus.appstudio-tekton.svc:9090/'
+            - '--config-file=/etc/kube-rbac-proxy/config.yaml'
+            - '--tls-cert-file=/etc/tls/private/tls.crt'
+            - '--tls-private-key-file=/etc/tls/private/tls.key'
+            - '--logtostderr=true'
+            - '--v=3'
+          ports:
+            - containerPort: 9091
+              name: https
+          resources:
+            limits:
+              cpu: 10m
+              memory: 64Mi
+            requests:
+              cpu: 10m
+              memory: 64Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+          volumeMounts:
+            - name: tls
+              mountPath: /etc/tls/private
+              readOnly: true
+            - name: config
+              mountPath: /etc/kube-rbac-proxy
+              readOnly: true
+      volumes:
+        - name: tls
+          secret:
+            secretName: tekton-ms-kube-rbac-proxy-tls
+        - name: config
+          configMap:
+            name: tekton-ms-kube-rbac-proxy-config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: tekton-ms-kube-rbac-proxy
+  namespace: appstudio-tekton
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: tekton-ms-kube-rbac-proxy-tls
+  labels:
+    app: tekton-ms-kube-rbac-proxy
+spec:
+  ports:
+    - name: https
+      port: 9091
+      targetPort: https
+  selector:
+    app: tekton-ms-kube-rbac-proxy

--- a/components/monitoring/prometheus/production/tekton-ms/kustomization.yaml
+++ b/components/monitoring/prometheus/production/tekton-ms/kustomization.yaml
@@ -1,19 +1,24 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- ../base
-- ../tekton-ms
+  - base
+  - kube-rbac-proxy.yaml
+  - networkpolicy.yaml
+  - external-secrets/
 
 patches:
-  - path: cluster-id-label.yaml
-    target:
-      name: appstudio-federate-ms
-      kind: MonitoringStack
-      group: monitoring.rhobs
-      version: v1alpha1
-  - path: cluster-id-label.yaml
+  - path: remote-write-env-details.yaml
     target:
       name: appstudio-tekton-ms
       kind: MonitoringStack
       group: monitoring.rhobs
       version: v1alpha1
+  - path: source-environment-label.yaml
+    target:
+      name: appstudio-tekton-ms
+      kind: MonitoringStack
+      group: monitoring.rhobs
+      version: v1alpha1
+
+commonAnnotations:
+  argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true

--- a/components/monitoring/prometheus/production/tekton-ms/networkpolicy.yaml
+++ b/components/monitoring/prometheus/production/tekton-ms/networkpolicy.yaml
@@ -1,0 +1,26 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: tekton-ms-prometheus-restrict-http
+  namespace: appstudio-tekton
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/instance: appstudio-tekton-ms
+      app.kubernetes.io/name: prometheus
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app: tekton-ms-kube-rbac-proxy
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: appstudio-cardinality-exporter
+          podSelector:
+            matchLabels:
+              app: prometheus-cardinality-exporter
+      ports:
+        - protocol: TCP
+          port: 9090

--- a/components/monitoring/prometheus/production/tekton-ms/remote-write-env-details.yaml
+++ b/components/monitoring/prometheus/production/tekton-ms/remote-write-env-details.yaml
@@ -1,0 +1,66 @@
+---
+- op: replace
+  path: /spec/prometheusConfig/remoteWrite
+  value:
+    # Tekton pipeline metrics
+    - url: https://observatorium-mst.api.openshift.com/api/metrics/v1/rhtap/api/v1/receive
+      oauth2:
+        clientId:
+          secret:
+            key: client-id
+            name: rhobs
+        clientSecret:
+          key: client-secret
+          name: rhobs
+        endpointParams:
+          audience: observatorium-osd
+        tokenUrl: https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token
+      writeRelabelConfigs:
+        - action: Keep
+          sourceLabels: [__name__]
+          regex: "tekton_pipelines_controller_pipelinerun_total\
+            |tekton_pipelines_controller_pipelinerun_duration_seconds_sum\
+            |tekton_pipelines_controller_pipelinerun_duration_seconds_count\
+            |tekton_pipelines_controller_running_pipelineruns\
+            |tekton_pipelines_controller_running_pipelineruns_waiting_on_pipeline_resolution\
+            |tekton_pipelines_controller_running_pipelineruns_waiting_on_task_resolution\
+            |tekton_pipelines_controller_taskrun_total\
+            |tekton_pipelines_controller_running_taskruns\
+            |tekton_pipelines_controller_running_taskruns_throttled_by_node\
+            |tekton_pipelines_controller_running_taskruns_throttled_by_quota"
+        - action: LabelKeep
+          regex: "__name__|source_environment|source_cluster|namespace|job|instance|pipeline|status|task"
+    # Prometheus self-monitoring metrics
+    - url: https://observatorium-mst.api.openshift.com/api/metrics/v1/rhtap/api/v1/receive
+      oauth2:
+        clientId:
+          secret:
+            key: client-id
+            name: rhobs
+        clientSecret:
+          key: client-secret
+          name: rhobs
+        endpointParams:
+          audience: observatorium-osd
+        tokenUrl: https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token
+      writeRelabelConfigs:
+        - action: Keep
+          sourceLabels: [__name__]
+          regex: "prometheus_ready\
+            |prometheus_build_info\
+            |prometheus_engine_query_duration_seconds\
+            |prometheus_engine_query_duration_seconds_count\
+            |prometheus_sd_discovered_targets\
+            |prometheus_target_interval_length_seconds_count\
+            |prometheus_target_interval_length_seconds_sum\
+            |prometheus_target_scrapes_exceeded_sample_limit_total\
+            |prometheus_target_scrapes_sample_duplicate_timestamp_total\
+            |prometheus_target_scrapes_sample_out_of_bounds_total\
+            |prometheus_target_scrapes_sample_out_of_order_total\
+            |prometheus_target_sync_length_seconds_sum\
+            |prometheus_tsdb_head_series\
+            |prometheus_tsdb_head_chunks\
+            |prometheus_tsdb_head_samples_appended_total\
+            |process_start_time_seconds"
+        - action: LabelKeep
+          regex: "__name__|source_environment|source_cluster|namespace|job|instance|version|quantile|slice|scrape_job"

--- a/components/monitoring/prometheus/production/tekton-ms/source-environment-label.yaml
+++ b/components/monitoring/prometheus/production/tekton-ms/source-environment-label.yaml
@@ -1,0 +1,4 @@
+---
+- op: add
+  path: /spec/prometheusConfig/externalLabels/source_environment
+  value: production-cluster


### PR DESCRIPTION
## Summary

Deploy the dedicated Tekton Prometheus (MonitoringStack) to production ring 1 clusters (stone-prod-p01, kflux-prd-rh02):

1. Grant vault access to `appstudio-tekton` namespace in production ClusterSecretStore
2. Create self-contained production tekton-ms overlay (`production/tekton-ms/`) with its own `base/` containing the MonitoringStack (2 replicas for HA), RBAC, ServiceMonitors, and namespace. Overlay adds production RHOBS remote-write config, ExternalSecret with production vault path, kube-rbac-proxy, and NetworkPolicy.
3. Add `../tekton-ms` to ring 1 cluster kustomizations (stone-prod-p01, kflux-prd-rh02) with `source_cluster` label patching

The metric drop from Platform Prometheus will follow in a separate PR after confirming the Tekton Prometheus is working correctly.

## Risk Assessment

- **Level:** Medium
- **Description:** Deploys a new MonitoringStack to 2 production clusters. Creates a new Prometheus instance that scrapes tekton-pipelines-controller and pipeline-metrics-exporter. Does not modify the existing Platform Prometheus scraping — both will scrape tekton metrics until the metric drop PR.
- **Rollback:** Remove `../tekton-ms` from the ring 1 cluster kustomizations.

## Validation

- Tekton Prometheus validated in staging since March 2026 on stone-stg-rh01 and stone-stage-p01
- `kustomize build` for both ring 1 clusters renders correctly with 2 replicas, production RHOBS URL
- Follows the same per-cluster overlay pattern as the federation Prometheus and the staging tekton-ms refactor (#13028)