### PR TITLE
Promote release-service and grafana-dashboard from staging to production

### DIFF
--- a/components/monitoring/grafana/production/dashboards/release/kustomization.yaml
+++ b/components/monitoring/grafana/production/dashboards/release/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- https://github.com/konflux-ci/release-service/config/grafana/?ref=a971d3c8d10d07257d4afc70e342a09e85a3a33e
+- https://github.com/konflux-ci/release-service/config/grafana/?ref=6d9abf25ac73986731ba7dbdb1ac459af54999b0

--- a/components/release/production/kustomization.yaml
+++ b/components/release/production/kustomization.yaml
@@ -3,7 +3,7 @@ kind: Kustomization
 resources:
   - ../base
   - ../base/monitor/production
-  - https://github.com/konflux-ci/release-service/config/default?ref=a971d3c8d10d07257d4afc70e342a09e85a3a33e
+  - https://github.com/konflux-ci/release-service/config/default?ref=6d9abf25ac73986731ba7dbdb1ac459af54999b0
   - release_service_config.yaml
   - signing_configs.yaml
 
@@ -13,6 +13,6 @@ components:
 images:
   - name: quay.io/konflux-ci/release-service
     newName: quay.io/konflux-ci/release-service
-    newTag: a971d3c8d10d07257d4afc70e342a09e85a3a33e
+    newTag: 6d9abf25ac73986731ba7dbdb1ac459af54999b0
 
 namespace: release-service


### PR DESCRIPTION
Included PRs:
 - https://github.com/konflux-ci/release-service/pull/1723 
 - https://github.com/konflux-ci/release-service/pull/1720 
 - https://github.com/konflux-ci/release-service/pull/1715 
 - https://github.com/konflux-ci/release-service/pull/1721 
 - https://github.com/konflux-ci/release-service/pull/1722 
 - https://github.com/konflux-ci/release-service/pull/1719 
 - https://github.com/konflux-ci/release-service/pull/1709 
 - https://github.com/konflux-ci/release-service/pull/1712 
 - https://github.com/konflux-ci/release-service/pull/1713 
 - https://github.com/konflux-ci/release-service/pull/1718 
 - https://github.com/konflux-ci/release-service/pull/1711 
 - https://github.com/konflux-ci/release-service/pull/1717 
 - https://github.com/konflux-ci/release-service/pull/1714 
 - https://github.com/konflux-ci/release-service/pull/1716 

Stage: https://github.com/redhat-appstudio/infra-deployments/pull/12768
Risk: low been in stage +3 weeks