### PR TITLE
Enable SLSA v1.0 attestations on stone-stg-rh01

### DIFF
--- a/components/pipeline-service/staging/stone-stg-rh01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stg-rh01/deploy.yaml
@@ -2262,10 +2262,11 @@ spec:
   chain:
     artifacts.oci.storage: oci
     artifacts.pipelinerun.enable-deep-inspection: "true"
-    artifacts.pipelinerun.format: in-toto
+    artifacts.pipelinerun.format: slsa/v2alpha3
     artifacts.pipelinerun.storage: oci
     artifacts.taskrun.format: in-toto
     artifacts.taskrun.storage: ""
+    builddefinition.buildtype: https://tekton.dev/chains/v2/slsa-tekton
     options:
       deployments:
         tekton-chains-controller:

--- a/components/pipeline-service/staging/stone-stg-rh01/resources/kustomization.yaml
+++ b/components/pipeline-service/staging/stone-stg-rh01/resources/kustomization.yaml
@@ -28,3 +28,9 @@ patches:
       version: v1
       kind: ExternalSecret
   - path: update-tekton-controller-resources.yaml
+  - path: tekton-chains-slsa-v1.yaml
+    target:
+      name: config
+      group: operator.tekton.dev
+      version: v1alpha1
+      kind: TektonConfig

--- a/components/pipeline-service/staging/stone-stg-rh01/resources/tekton-chains-slsa-v1.yaml
+++ b/components/pipeline-service/staging/stone-stg-rh01/resources/tekton-chains-slsa-v1.yaml
@@ -1,0 +1,7 @@
+---
+- op: replace
+  path: /spec/chain/artifacts.pipelinerun.format
+  value: "slsa/v2alpha3"
+- op: add
+  path: /spec/chain/builddefinition.buildtype
+  value: "https://tekton.dev/chains/v2/slsa-tekton"


### PR DESCRIPTION
Switch Tekton Chains pipelinerun attestation format from `in-toto` (SLSA v0.2) to `slsa/v2alpha3` (SLSA v1.0) on stone-stg-rh01 and set the build type for enriched provenance.

Changes:
- Set `artifacts.pipelinerun.format` to `slsa/v2alpha3`
- Add `builddefinition.buildtype: https://tekton.dev/chains/v2/slsa-tekton`

This was previously attempted and reverted (#10630) while downstream consumers (Bombino, Mobster) were not yet ready for SLSA v1. Both are now resolved (ISV-6755, [ISV-6756](https://redhat.atlassian.net/browse/ISV-6756)).

Ref: [EC-1675](https://redhat.atlassian.net/browse/EC-1675)

[ISV-6756]: https://redhat.atlassian.net/browse/ISV-6756?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[EC-1675]: https://redhat.atlassian.net/browse/EC-1675?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ