### PR TITLE
Enable SLSA v1.0 attestations on stone-stage-p01

### DIFF
--- a/components/pipeline-service/staging/stone-stage-p01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stage-p01/deploy.yaml
@@ -2262,10 +2262,11 @@ spec:
   chain:
     artifacts.oci.storage: oci
     artifacts.pipelinerun.enable-deep-inspection: "true"
-    artifacts.pipelinerun.format: in-toto
+    artifacts.pipelinerun.format: slsa/v2alpha3
     artifacts.pipelinerun.storage: oci
     artifacts.taskrun.format: in-toto
     artifacts.taskrun.storage: ""
+    builddefinition.buildtype: https://tekton.dev/chains/v2/slsa-tekton
     options:
       deployments:
         tekton-chains-controller:

--- a/components/pipeline-service/staging/stone-stage-p01/resources/kustomization.yaml
+++ b/components/pipeline-service/staging/stone-stage-p01/resources/kustomization.yaml
@@ -37,3 +37,9 @@ patches:
     target:
       kind: TektonConfig
       name: config
+  - path: tekton-chains-slsa-v1.yaml
+    target:
+      name: config
+      group: operator.tekton.dev
+      version: v1alpha1
+      kind: TektonConfig

--- a/components/pipeline-service/staging/stone-stage-p01/resources/tekton-chains-slsa-v1.yaml
+++ b/components/pipeline-service/staging/stone-stage-p01/resources/tekton-chains-slsa-v1.yaml
@@ -1,0 +1,7 @@
+---
+- op: replace
+  path: /spec/chain/artifacts.pipelinerun.format
+  value: "slsa/v2alpha3"
+- op: add
+  path: /spec/chain/builddefinition.buildtype
+  value: "https://tekton.dev/chains/v2/slsa-tekton"


### PR DESCRIPTION
Switch Tekton Chains pipelinerun attestation format from `in-toto` (SLSA v0.2) to `slsa/v2alpha3` (SLSA v1.0) on stone-stage-p01 and set the build type for enriched provenance.

Changes:
- Set `artifacts.pipelinerun.format` to `slsa/v2alpha3`
- Add `builddefinition.buildtype: https://tekton.dev/chains/v2/slsa-tekton`

Same change as the companion PR for stone-stg-rh01 (#13032), applied to the second staging cluster.

Ref: [EC-1675](https://redhat.atlassian.net/browse/EC-1675)

[EC-1675]: https://redhat.atlassian.net/browse/EC-1675?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ