### PR TITLE
PVO11Y-5361 Fix production OCI_STORAGE for kanary

### DIFF
--- a/components/monitoring/kanary/production/base/pipelines/kanary-otel-pipeline.yaml
+++ b/components/monitoring/kanary/production/base/pipelines/kanary-otel-pipeline.yaml
@@ -34,6 +34,8 @@ spec:
     - name: release-managed-namespace
       type: string
       default: "managed-konflux-perfscale-tenant"
+    - name: oci-storage
+      type: string
     # Private clusters only (GitLab-based repos). Leave empty for public clusters.
     - name: fork-target
       type: string
@@ -81,6 +83,8 @@ spec:
           value: $(params.release-pipeline-service-account)
         - name: release-managed-namespace
           value: $(params.release-managed-namespace)
+        - name: oci-storage
+          value: $(params.oci-storage)
         - name: fork-target
           value: $(params.fork-target)
         - name: gitlab-api-url

--- a/components/monitoring/kanary/production/base/tasks/run-kanary-tests.yaml
+++ b/components/monitoring/kanary/production/base/tasks/run-kanary-tests.yaml
@@ -31,6 +31,8 @@ spec:
     - name: release-managed-namespace
       type: string
       default: "managed-konflux-perfscale-tenant"
+    - name: oci-storage
+      type: string
     # Private clusters only (GitLab-based repos). Leave empty for public clusters.
     - name: fork-target
       type: string
@@ -106,6 +108,8 @@ spec:
           value: "production"
         - name: RELEASE_PIPELINE_PATH
           value: "pipelines/managed/e2e/e2e.yaml"
+        - name: OCI_STORAGE
+          value: $(params.oci-storage)
         - name: RELEASE_PIPELINE_SERVICE_ACCOUNT
           value: $(params.release-pipeline-service-account)
         - name: RELEASE_MANAGED_NAMESPACE

--- a/components/monitoring/kanary/production/kflux-fedora-01/cronjobs/kanary-cronjob-multi-arch.yaml
+++ b/components/monitoring/kanary/production/kflux-fedora-01/cronjobs/kanary-cronjob-multi-arch.yaml
@@ -39,6 +39,7 @@ spec:
                     --param quay-repo=konflux-fedora \
                     --param pipeline-repo-templating-source=https://github.com/rhtap-perf-test/konflux-probe-test-templates \
                     --param pipeline-repo-templating-source-dir=nodejs-devfile-sample-MultiArch/ \
+                    --param oci-storage=quay.io/rhtap-perf-test/perf-release-service-trusted-artifacts \
                     --param release-pipeline-service-account=managed-konflux-perfscale-sa \
                     --param fork-target="" \
                     --param gitlab-api-url="" \

--- a/components/monitoring/kanary/production/kflux-fedora-01/cronjobs/kanary-cronjob-single-arch.yaml
+++ b/components/monitoring/kanary/production/kflux-fedora-01/cronjobs/kanary-cronjob-single-arch.yaml
@@ -39,6 +39,7 @@ spec:
                     --param quay-repo=konflux-fedora \
                     --param pipeline-repo-templating-source=https://github.com/rhtap-perf-test/konflux-probe-test-templates \
                     --param pipeline-repo-templating-source-dir=nodejs-devfile-sample-SingleArch/ \
+                    --param oci-storage=quay.io/rhtap-perf-test/perf-release-service-trusted-artifacts \
                     --param release-pipeline-service-account=managed-konflux-perfscale-sa \
                     --param fork-target="" \
                     --param gitlab-api-url="" \

--- a/components/monitoring/kanary/production/kflux-ocp-p01/cronjobs/kanary-cronjob-multi-arch.yaml
+++ b/components/monitoring/kanary/production/kflux-ocp-p01/cronjobs/kanary-cronjob-multi-arch.yaml
@@ -39,6 +39,7 @@ spec:
                     --param quay-repo=redhat-user-workloads \
                     --param pipeline-repo-templating-source=https://github.com/rhtap-perf-test/konflux-probe-test-templates \
                     --param pipeline-repo-templating-source-dir=nodejs-devfile-sample-MultiArch/ \
+                    --param oci-storage=quay.io/rhtap-perf-test/perf-release-service-trusted-artifacts \
                     --param release-pipeline-service-account=managed-konflux-perfscale-sa \
                     --param fork-target="jhutar" \
                     --param gitlab-api-url="https://gitlab.cee.redhat.com/api/v4" \

--- a/components/monitoring/kanary/production/kflux-ocp-p01/cronjobs/kanary-cronjob-single-arch.yaml
+++ b/components/monitoring/kanary/production/kflux-ocp-p01/cronjobs/kanary-cronjob-single-arch.yaml
@@ -39,6 +39,7 @@ spec:
                     --param quay-repo=redhat-user-workloads \
                     --param pipeline-repo-templating-source=https://github.com/rhtap-perf-test/konflux-probe-test-templates \
                     --param pipeline-repo-templating-source-dir=nodejs-devfile-sample-SingleArch/ \
+                    --param oci-storage=quay.io/rhtap-perf-test/perf-release-service-trusted-artifacts \
                     --param release-pipeline-service-account=managed-konflux-perfscale-sa \
                     --param fork-target="jhutar" \
                     --param gitlab-api-url="https://gitlab.cee.redhat.com/api/v4" \

--- a/components/monitoring/kanary/production/kflux-prd-rh02/cronjobs/kanary-cronjob-multi-arch.yaml
+++ b/components/monitoring/kanary/production/kflux-prd-rh02/cronjobs/kanary-cronjob-multi-arch.yaml
@@ -39,6 +39,7 @@ spec:
                     --param quay-repo=redhat-user-workloads \
                     --param pipeline-repo-templating-source=https://github.com/rhtap-perf-test/konflux-probe-test-templates \
                     --param pipeline-repo-templating-source-dir=nodejs-devfile-sample-MultiArch/ \
+                    --param oci-storage=quay.io/rhtap-perf-test/perf-release-service-trusted-artifacts \
                     --param release-pipeline-service-account=managed-konflux-perfscale-sa \
                     --param fork-target="" \
                     --param gitlab-api-url="" \

--- a/components/monitoring/kanary/production/kflux-prd-rh02/cronjobs/kanary-cronjob-single-arch.yaml
+++ b/components/monitoring/kanary/production/kflux-prd-rh02/cronjobs/kanary-cronjob-single-arch.yaml
@@ -39,6 +39,7 @@ spec:
                     --param quay-repo=redhat-user-workloads \
                     --param pipeline-repo-templating-source=https://github.com/rhtap-perf-test/konflux-probe-test-templates \
                     --param pipeline-repo-templating-source-dir=nodejs-devfile-sample-SingleArch/ \
+                    --param oci-storage=quay.io/rhtap-perf-test/perf-release-service-trusted-artifacts \
                     --param release-pipeline-service-account=managed-konflux-perfscale-sa \
                     --param fork-target="" \
                     --param gitlab-api-url="" \

--- a/components/monitoring/kanary/production/kflux-prd-rh03/cronjobs/kanary-cronjob-multi-arch.yaml
+++ b/components/monitoring/kanary/production/kflux-prd-rh03/cronjobs/kanary-cronjob-multi-arch.yaml
@@ -39,6 +39,7 @@ spec:
                     --param quay-repo=redhat-user-workloads \
                     --param pipeline-repo-templating-source=https://github.com/rhtap-perf-test/konflux-probe-test-templates \
                     --param pipeline-repo-templating-source-dir=nodejs-devfile-sample-MultiArch/ \
+                    --param oci-storage=quay.io/rhtap-perf-test/perf-release-service-trusted-artifacts \
                     --param release-pipeline-service-account=managed-konflux-perfscale-sa \
                     --param fork-target="" \
                     --param gitlab-api-url="" \

--- a/components/monitoring/kanary/production/kflux-prd-rh03/cronjobs/kanary-cronjob-single-arch.yaml
+++ b/components/monitoring/kanary/production/kflux-prd-rh03/cronjobs/kanary-cronjob-single-arch.yaml
@@ -39,6 +39,7 @@ spec:
                     --param quay-repo=redhat-user-workloads \
                     --param pipeline-repo-templating-source=https://github.com/rhtap-perf-test/konflux-probe-test-templates \
                     --param pipeline-repo-templating-source-dir=nodejs-devfile-sample-SingleArch/ \
+                    --param oci-storage=quay.io/rhtap-perf-test/perf-release-service-trusted-artifacts \
                     --param release-pipeline-service-account=managed-konflux-perfscale-sa \
                     --param fork-target="" \
                     --param gitlab-api-url="" \

--- a/components/monitoring/kanary/production/kflux-rhel-p01/cronjobs/kanary-cronjob-multi-arch.yaml
+++ b/components/monitoring/kanary/production/kflux-rhel-p01/cronjobs/kanary-cronjob-multi-arch.yaml
@@ -39,6 +39,7 @@ spec:
                     --param quay-repo=redhat-user-workloads \
                     --param pipeline-repo-templating-source=https://github.com/rhtap-perf-test/konflux-probe-test-templates \
                     --param pipeline-repo-templating-source-dir=nodejs-devfile-sample-MultiArch/ \
+                    --param oci-storage=quay.io/rhtap-perf-test/perf-release-service-trusted-artifacts \
                     --param release-pipeline-service-account=managed-konflux-perfscale-sa \
                     --param fork-target="jhutar" \
                     --param gitlab-api-url="https://gitlab.cee.redhat.com/api/v4" \

--- a/components/monitoring/kanary/production/kflux-rhel-p01/cronjobs/kanary-cronjob-single-arch.yaml
+++ b/components/monitoring/kanary/production/kflux-rhel-p01/cronjobs/kanary-cronjob-single-arch.yaml
@@ -39,6 +39,7 @@ spec:
                     --param quay-repo=redhat-user-workloads \
                     --param pipeline-repo-templating-source=https://github.com/rhtap-perf-test/konflux-probe-test-templates \
                     --param pipeline-repo-templating-source-dir=nodejs-devfile-sample-SingleArch/ \
+                    --param oci-storage=quay.io/rhtap-perf-test/perf-release-service-trusted-artifacts \
                     --param release-pipeline-service-account=managed-konflux-perfscale-sa \
                     --param fork-target="jhutar" \
                     --param gitlab-api-url="https://gitlab.cee.redhat.com/api/v4" \

--- a/components/monitoring/kanary/production/stone-prd-rh01/cronjobs/kanary-cronjob-multi-arch.yaml
+++ b/components/monitoring/kanary/production/stone-prd-rh01/cronjobs/kanary-cronjob-multi-arch.yaml
@@ -39,6 +39,7 @@ spec:
                     --param quay-repo=redhat-user-workloads \
                     --param pipeline-repo-templating-source=https://github.com/rhtap-perf-test/konflux-probe-test-templates \
                     --param pipeline-repo-templating-source-dir=nodejs-devfile-sample-MultiArch/ \
+                    --param oci-storage=quay.io/rhtap-perf-test/perf-release-service-trusted-artifacts \
                     --param release-pipeline-service-account=managed-konflux-perfscale-sa \
                     --param fork-target="" \
                     --param gitlab-api-url="" \

--- a/components/monitoring/kanary/production/stone-prd-rh01/cronjobs/kanary-cronjob-single-arch.yaml
+++ b/components/monitoring/kanary/production/stone-prd-rh01/cronjobs/kanary-cronjob-single-arch.yaml
@@ -39,6 +39,7 @@ spec:
                     --param quay-repo=redhat-user-workloads \
                     --param pipeline-repo-templating-source=https://github.com/rhtap-perf-test/konflux-probe-test-templates \
                     --param pipeline-repo-templating-source-dir=nodejs-devfile-sample-SingleArch/ \
+                    --param oci-storage=quay.io/rhtap-perf-test/perf-release-service-trusted-artifacts \
                     --param release-pipeline-service-account=managed-konflux-perfscale-sa \
                     --param fork-target="" \
                     --param gitlab-api-url="" \

--- a/components/monitoring/kanary/production/stone-prod-p01/cronjobs/kanary-cronjob-multi-arch.yaml
+++ b/components/monitoring/kanary/production/stone-prod-p01/cronjobs/kanary-cronjob-multi-arch.yaml
@@ -39,6 +39,7 @@ spec:
                     --param quay-repo=redhat-user-workloads \
                     --param pipeline-repo-templating-source=https://github.com/rhtap-perf-test/konflux-probe-test-templates \
                     --param pipeline-repo-templating-source-dir=nodejs-devfile-sample-MultiArch-only-ARM-and-AMD/ \
+                    --param oci-storage=quay.io/rhtap-perf-test/perf-release-service-trusted-artifacts \
                     --param release-pipeline-service-account=managed-konflux-perfscale-sa \
                     --param fork-target="jhutar" \
                     --param gitlab-api-url="https://gitlab.cee.redhat.com/api/v4" \

--- a/components/monitoring/kanary/production/stone-prod-p01/cronjobs/kanary-cronjob-single-arch.yaml
+++ b/components/monitoring/kanary/production/stone-prod-p01/cronjobs/kanary-cronjob-single-arch.yaml
@@ -39,6 +39,7 @@ spec:
                     --param quay-repo=redhat-user-workloads \
                     --param pipeline-repo-templating-source=https://github.com/rhtap-perf-test/konflux-probe-test-templates \
                     --param pipeline-repo-templating-source-dir=nodejs-devfile-sample-SingleArch/ \
+                    --param oci-storage=quay.io/rhtap-perf-test/perf-release-service-trusted-artifacts \
                     --param release-pipeline-service-account=managed-konflux-perfscale-sa \
                     --param fork-target="jhutar" \
                     --param gitlab-api-url="https://gitlab.cee.redhat.com/api/v4" \

--- a/components/monitoring/kanary/production/stone-prod-p02/cronjobs/kanary-cronjob-multi-arch.yaml
+++ b/components/monitoring/kanary/production/stone-prod-p02/cronjobs/kanary-cronjob-multi-arch.yaml
@@ -39,6 +39,7 @@ spec:
                     --param quay-repo=redhat-user-workloads \
                     --param pipeline-repo-templating-source=https://github.com/rhtap-perf-test/konflux-probe-test-templates \
                     --param pipeline-repo-templating-source-dir=nodejs-devfile-sample-MultiArch/ \
+                    --param oci-storage=quay.io/rhtap-perf-test/perf-release-service-trusted-artifacts \
                     --param release-pipeline-service-account=managed-konflux-perfscale-sa \
                     --param fork-target="jhutar" \
                     --param gitlab-api-url="https://gitlab.cee.redhat.com/api/v4" \

--- a/components/monitoring/kanary/production/stone-prod-p02/cronjobs/kanary-cronjob-single-arch.yaml
+++ b/components/monitoring/kanary/production/stone-prod-p02/cronjobs/kanary-cronjob-single-arch.yaml
@@ -39,6 +39,7 @@ spec:
                     --param quay-repo=redhat-user-workloads \
                     --param pipeline-repo-templating-source=https://github.com/rhtap-perf-test/konflux-probe-test-templates \
                     --param pipeline-repo-templating-source-dir=nodejs-devfile-sample-SingleArch/ \
+                    --param oci-storage=quay.io/rhtap-perf-test/perf-release-service-trusted-artifacts \
                     --param release-pipeline-service-account=managed-konflux-perfscale-sa \
                     --param fork-target="jhutar" \
                     --param gitlab-api-url="https://gitlab.cee.redhat.com/api/v4" \


### PR DESCRIPTION
## Summary

Add `oci-storage` as an explicit param (no default) to the production kanary task and pipeline. All production cronjobs now pass `--param oci-storage=quay.io/rhtap-perf-test/perf-release-service-trusted-artifacts` explicitly.

Without this, the loadtest `run.sh` default uses the staging repo (`perf-release-service-trusted-artifacts-stage`), causing the production robot account to push trusted artifacts to the wrong quay repo.

See [KONFLUX-14805](https://redhat.atlassian.net/browse/KONFLUX-14805) for context.

## Risk Assessment

- **Level**: Low
- **Description**: Adds an explicit env var to the production kanary task to use the correct quay repo. The staging repo workaround (granting prod robot access to stage repo) can be reverted after this merges.
- **Rollback**: Remove the `oci-storage` param and env var from the production task

## Validation

Jenkins production probes already use this exact `OCI_STORAGE` value and work correctly.

## JIRA

[PVO11Y-5361](https://redhat.atlassian.net/browse/PVO11Y-5361)
[KONFLUX-14805](https://redhat.atlassian.net/browse/KONFLUX-14805)

[KONFLUX-14805]: https://redhat.atlassian.net/browse/KONFLUX-14805?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PVO11Y-5361]: https://redhat.atlassian.net/browse/PVO11Y-5361?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[KONFLUX-14805]: https://redhat.atlassian.net/browse/KONFLUX-14805?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ