### PR TITLE
PVO11Y-5361 Add oci-storage param to staging kanary

### DIFF
--- a/components/monitoring/kanary/staging/base/pipelines/kanary-otel-pipeline.yaml
+++ b/components/monitoring/kanary/staging/base/pipelines/kanary-otel-pipeline.yaml
@@ -30,6 +30,8 @@ spec:
     - name: release-managed-namespace
       type: string
       default: "managed-konflux-perfscale-tenant"
+    - name: oci-storage
+      type: string
     # Private clusters only (GitLab-based repos). Leave empty for public clusters.
     - name: fork-target
       type: string
@@ -77,6 +79,8 @@ spec:
           value: $(params.release-pipeline-service-account)
         - name: release-managed-namespace
           value: $(params.release-managed-namespace)
+        - name: oci-storage
+          value: $(params.oci-storage)
         - name: fork-target
           value: $(params.fork-target)
         - name: gitlab-api-url

--- a/components/monitoring/kanary/staging/base/tasks/run-kanary-tests.yaml
+++ b/components/monitoring/kanary/staging/base/tasks/run-kanary-tests.yaml
@@ -27,6 +27,8 @@ spec:
     - name: release-managed-namespace
       type: string
       default: "managed-konflux-perfscale-tenant"
+    - name: oci-storage
+      type: string
     # Private clusters only (GitLab-based repos). Leave empty for public clusters.
     - name: fork-target
       type: string
@@ -151,6 +153,8 @@ spec:
           value: "production"
         - name: RELEASE_PIPELINE_PATH
           value: "pipelines/managed/e2e/e2e.yaml"
+        - name: OCI_STORAGE
+          value: $(params.oci-storage)
         - name: RELEASE_PIPELINE_SERVICE_ACCOUNT
           value: $(params.release-pipeline-service-account)
         - name: RELEASE_MANAGED_NAMESPACE

--- a/components/monitoring/kanary/staging/stone-stage-p01/cronjobs/kanary-cronjob-multi-arch.yaml
+++ b/components/monitoring/kanary/staging/stone-stage-p01/cronjobs/kanary-cronjob-multi-arch.yaml
@@ -39,6 +39,7 @@ spec:
                     --param quay-repo=redhat-user-workloads-stage \
                     --param pipeline-repo-templating-source=https://github.com/rhtap-perf-test/konflux-probe-test-templates \
                     --param pipeline-repo-templating-source-dir=nodejs-devfile-sample-MultiArch/ \
+                    --param oci-storage=quay.io/rhtap-perf-test/perf-release-service-trusted-artifacts-stage \
                     --param release-pipeline-service-account=managed-konflux-perfscale-sa \
                     --param fork-target=jhutar \
                     --param gitlab-api-url=https://gitlab.cee.redhat.com/api/v4 \

--- a/components/monitoring/kanary/staging/stone-stage-p01/cronjobs/kanary-cronjob-single-arch.yaml
+++ b/components/monitoring/kanary/staging/stone-stage-p01/cronjobs/kanary-cronjob-single-arch.yaml
@@ -39,6 +39,7 @@ spec:
                     --param quay-repo=redhat-user-workloads-stage \
                     --param pipeline-repo-templating-source=https://github.com/rhtap-perf-test/konflux-probe-test-templates \
                     --param pipeline-repo-templating-source-dir=nodejs-devfile-sample-SingleArch/ \
+                    --param oci-storage=quay.io/rhtap-perf-test/perf-release-service-trusted-artifacts-stage \
                     --param release-pipeline-service-account=managed-konflux-perfscale-sa \
                     --param fork-target=jhutar \
                     --param gitlab-api-url=https://gitlab.cee.redhat.com/api/v4 \

--- a/components/monitoring/kanary/staging/stone-stg-rh01/cronjobs/kanary-cronjob-multi-arch.yaml
+++ b/components/monitoring/kanary/staging/stone-stg-rh01/cronjobs/kanary-cronjob-multi-arch.yaml
@@ -39,6 +39,7 @@ spec:
                     --param quay-repo=redhat-user-workloads-stage \
                     --param pipeline-repo-templating-source=https://github.com/rhtap-perf-test/konflux-probe-test-templates \
                     --param pipeline-repo-templating-source-dir=nodejs-devfile-sample-MultiArch/ \
+                    --param oci-storage=quay.io/rhtap-perf-test/perf-release-service-trusted-artifacts-stage \
                     --param release-pipeline-service-account=managed-konflux-perfscale-sa \
                     --param fork-target="" \
                     --param gitlab-api-url="" \

--- a/components/monitoring/kanary/staging/stone-stg-rh01/cronjobs/kanary-cronjob-single-arch.yaml
+++ b/components/monitoring/kanary/staging/stone-stg-rh01/cronjobs/kanary-cronjob-single-arch.yaml
@@ -39,6 +39,7 @@ spec:
                     --param quay-repo=redhat-user-workloads-stage \
                     --param pipeline-repo-templating-source=https://github.com/rhtap-perf-test/konflux-probe-test-templates \
                     --param pipeline-repo-templating-source-dir=nodejs-devfile-sample-SingleArch/ \
+                    --param oci-storage=quay.io/rhtap-perf-test/perf-release-service-trusted-artifacts-stage \
                     --param release-pipeline-service-account=managed-konflux-perfscale-sa \
                     --param fork-target="" \
                     --param gitlab-api-url="" \


### PR DESCRIPTION
## Summary

Add `oci-storage` as an explicit param (no default) to the staging kanary task and pipeline. All staging cronjobs now pass `--param oci-storage=quay.io/rhtap-perf-test/perf-release-service-trusted-artifacts-stage` explicitly, matching the production pattern from #13035.

This ensures the OCI storage repo is always set explicitly by the cronjob rather than relying on the loadtest `run.sh` default, preventing environment mismatches.

## Validation

- `kustomize build` passes for both staging clusters (stone-stage-p01, stone-stg-rh01)
- No functional change — staging was already using the correct repo via the run.sh default, this just makes it explicit

## JIRA

[PVO11Y-5361](https://redhat.atlassian.net/browse/PVO11Y-5361)

[PVO11Y-5361]: https://redhat.atlassian.net/browse/PVO11Y-5361?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ