### PR TITLE
RELEASE-2389 Promote release-service to staging

### DIFF
--- a/components/release/staging/kustomization.yaml
+++ b/components/release/staging/kustomization.yaml
@@ -4,7 +4,7 @@ resources:
   - ../base
   - ../base/monitor/staging
   - external-secrets/release-monitor-secret.yaml
-  - https://github.com/konflux-ci/release-service/config/default?ref=6d9abf25ac73986731ba7dbdb1ac459af54999b0
+  - https://github.com/konflux-ci/release-service/config/default?ref=e2ea734989e61089a1738821c66f11fab829cb0f
   - release_service_config.yaml
   - signing_configs.yaml
 
@@ -14,7 +14,7 @@ components:
 images:
   - name: quay.io/konflux-ci/release-service
     newName: quay.io/konflux-ci/release-service
-    newTag: 6d9abf25ac73986731ba7dbdb1ac459af54999b0
+    newTag: e2ea734989e61089a1738821c66f11fab829cb0f
 
 namespace: release-service
 


### PR DESCRIPTION
Bump release-service staging from `6d9abf25` → `e2ea7349`

[RELEASE-2389](https://redhat.atlassian.net/browse/RELEASE-2389)

[RELEASE-2389]: https://redhat.atlassian.net/browse/RELEASE-2389?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ