### PR TITLE
KFLUXVNGD-1121 Promote crossplane-control-plane upgrade to production (ring 1)

### DIFF
--- a/components/crossplane-control-plane/production/base/kustomization.yaml
+++ b/components/crossplane-control-plane/production/base/kustomization.yaml
@@ -5,26 +5,8 @@ resources:
 - ../../base
 - provider-config.yaml
 - testplatform-provider-config.yaml
-- https://github.com/konflux-ci/crossplane-control-plane/crossplane?ref=bd3da0eff408eb329bfb5d7306b2aa3016d1a906
-- https://github.com/konflux-ci/crossplane-control-plane/config?ref=bd3da0eff408eb329bfb5d7306b2aa3016d1a906
 
 images:
   - name: quay.io/konflux-ci/task-runner
     newTag: v1
     digest: sha256:b9ef0479b57a494368a12a02886c650314c9ac7391c6228f21065865aab71c9e
-
-patches:
-  - patch: |-
-      apiVersion: apps/v1
-      kind: Deployment
-      metadata:
-        name: crossplane
-        namespace: crossplane-system
-      spec:
-        template:
-          spec:
-            containers:
-              - name: crossplane
-                resources:
-                  limits:
-                    memory: 4Gi

--- a/components/crossplane-control-plane/production/kflux-fedora-01/environment-config.yaml
+++ b/components/crossplane-control-plane/production/kflux-fedora-01/environment-config.yaml
@@ -1,0 +1,8 @@
+apiVersion: apiextensions.crossplane.io/v1beta1
+kind: EnvironmentConfig
+metadata:
+  name: envcfg
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+data:
+  clusterName: kflux-fedora-01

--- a/components/crossplane-control-plane/production/kflux-fedora-01/kustomization.yaml
+++ b/components/crossplane-control-plane/production/kflux-fedora-01/kustomization.yaml
@@ -3,3 +3,9 @@ kind: Kustomization
 
 resources:
 - ../base
+- environment-config.yaml
+- https://github.com/konflux-ci/crossplane-control-plane/crossplane?ref=93468e78be8cb6980dec3cd97ef400de6d54064b
+- https://github.com/konflux-ci/crossplane-control-plane/config?ref=93468e78be8cb6980dec3cd97ef400de6d54064b
+
+components:
+  - ../../k-components/crossplane-resources

--- a/components/crossplane-control-plane/production/kflux-ocp-p01/kustomization.yaml
+++ b/components/crossplane-control-plane/production/kflux-ocp-p01/kustomization.yaml
@@ -3,3 +3,8 @@ kind: Kustomization
 
 resources:
 - ../base
+- https://github.com/konflux-ci/crossplane-control-plane/crossplane?ref=bd3da0eff408eb329bfb5d7306b2aa3016d1a906
+- https://github.com/konflux-ci/crossplane-control-plane/config?ref=bd3da0eff408eb329bfb5d7306b2aa3016d1a906
+
+components:
+  - ../../k-components/crossplane-resources

--- a/components/crossplane-control-plane/production/kflux-osp-p01/kustomization.yaml
+++ b/components/crossplane-control-plane/production/kflux-osp-p01/kustomization.yaml
@@ -3,3 +3,8 @@ kind: Kustomization
 
 resources:
 - ../base
+- https://github.com/konflux-ci/crossplane-control-plane/crossplane?ref=bd3da0eff408eb329bfb5d7306b2aa3016d1a906
+- https://github.com/konflux-ci/crossplane-control-plane/config?ref=bd3da0eff408eb329bfb5d7306b2aa3016d1a906
+
+components:
+  - ../../k-components/crossplane-resources

--- a/components/crossplane-control-plane/production/kflux-prd-rh02/kustomization.yaml
+++ b/components/crossplane-control-plane/production/kflux-prd-rh02/kustomization.yaml
@@ -3,3 +3,8 @@ kind: Kustomization
 
 resources:
 - ../base
+- https://github.com/konflux-ci/crossplane-control-plane/crossplane?ref=bd3da0eff408eb329bfb5d7306b2aa3016d1a906
+- https://github.com/konflux-ci/crossplane-control-plane/config?ref=bd3da0eff408eb329bfb5d7306b2aa3016d1a906
+
+components:
+  - ../../k-components/crossplane-resources

--- a/components/crossplane-control-plane/production/kflux-prd-rh03/kustomization.yaml
+++ b/components/crossplane-control-plane/production/kflux-prd-rh03/kustomization.yaml
@@ -3,3 +3,8 @@ kind: Kustomization
 
 resources:
 - ../base
+- https://github.com/konflux-ci/crossplane-control-plane/crossplane?ref=bd3da0eff408eb329bfb5d7306b2aa3016d1a906
+- https://github.com/konflux-ci/crossplane-control-plane/config?ref=bd3da0eff408eb329bfb5d7306b2aa3016d1a906
+
+components:
+  - ../../k-components/crossplane-resources

--- a/components/crossplane-control-plane/production/kflux-rhel-p01/kustomization.yaml
+++ b/components/crossplane-control-plane/production/kflux-rhel-p01/kustomization.yaml
@@ -3,3 +3,8 @@ kind: Kustomization
 
 resources:
 - ../base
+- https://github.com/konflux-ci/crossplane-control-plane/crossplane?ref=bd3da0eff408eb329bfb5d7306b2aa3016d1a906
+- https://github.com/konflux-ci/crossplane-control-plane/config?ref=bd3da0eff408eb329bfb5d7306b2aa3016d1a906
+
+components:
+  - ../../k-components/crossplane-resources

--- a/components/crossplane-control-plane/production/stone-prd-rh01/kustomization.yaml
+++ b/components/crossplane-control-plane/production/stone-prd-rh01/kustomization.yaml
@@ -3,3 +3,8 @@ kind: Kustomization
 
 resources:
 - ../base
+- https://github.com/konflux-ci/crossplane-control-plane/crossplane?ref=bd3da0eff408eb329bfb5d7306b2aa3016d1a906
+- https://github.com/konflux-ci/crossplane-control-plane/config?ref=bd3da0eff408eb329bfb5d7306b2aa3016d1a906
+
+components:
+  - ../../k-components/crossplane-resources

--- a/components/crossplane-control-plane/production/stone-prod-p01/kustomization.yaml
+++ b/components/crossplane-control-plane/production/stone-prod-p01/kustomization.yaml
@@ -3,3 +3,8 @@ kind: Kustomization
 
 resources:
 - ../base
+- https://github.com/konflux-ci/crossplane-control-plane/crossplane?ref=bd3da0eff408eb329bfb5d7306b2aa3016d1a906
+- https://github.com/konflux-ci/crossplane-control-plane/config?ref=bd3da0eff408eb329bfb5d7306b2aa3016d1a906
+
+components:
+  - ../../k-components/crossplane-resources

--- a/components/crossplane-control-plane/production/stone-prod-p02/kustomization.yaml
+++ b/components/crossplane-control-plane/production/stone-prod-p02/kustomization.yaml
@@ -3,3 +3,8 @@ kind: Kustomization
 
 resources:
 - ../base
+- https://github.com/konflux-ci/crossplane-control-plane/crossplane?ref=bd3da0eff408eb329bfb5d7306b2aa3016d1a906
+- https://github.com/konflux-ci/crossplane-control-plane/config?ref=bd3da0eff408eb329bfb5d7306b2aa3016d1a906
+
+components:
+  - ../../k-components/crossplane-resources


### PR DESCRIPTION
## What

  Promote crossplane-control-plane upgrade to production ring 1 (kflux-fedora-01).

  - Move crossplane refs from production base into per-cluster overlays to enable independent version control per ring
  - Replace the inline memory limit patch with the `crossplane-resources` k-component in each overlay (can't be declared in the base because kustomize resolves base components before overlay resources are visible)
  - Upgrade kflux-fedora-01 to ref `93468e78` and add its EnvironmentConfig for cluster-aware Compositions
  - Non-fedora clusters remain on ref `bd3da0ef` with identical kustomize output

  Clusters affected: kflux-fedora-01

  [KFLUXVNGD-1121](https://issues.redhat.com/browse/KFLUXVNGD-1121)

  ## Why

  Deploy composition changes that enable ephemeral cluster provisioning with openshift-ci using shared Konflux cluster profiles. The updated Compositions require cluster name context at runtime via EnvironmentConfig.

  ## Validation

  - `kustomize build --enable-helm` passes for kflux-fedora-01 and all non-fedora overlays
  - Non-fedora kustomize output diffed against pre-change output — zero diff
  - Ephemeral cluster successfully provisioned in the staging environment
  - Staging PR: https://github.com/redhat-appstudio/infra-deployments/pull/13020

  ## Risk Assessment

  **Risk Level:** Low
  **What could go wrong:** Crossplane deployment on kflux-fedora-01 could fail to start if the new ref has an issue not caught in staging, or the EnvironmentConfig could be malformed.
  **Rollback:** Revert PR
  **Blast radius:** 1 cluster (kflux-fedora-01)

[KFLUXVNGD-1121]: https://redhat.atlassian.net/browse/KFLUXVNGD-1121?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ