### PR TITLE
STONEINTG-1682: Add temporary RBAC for nudge migration on staging

### DIFF
--- a/components/authentication/base/rbac/everyone-can-view-crs.yaml
+++ b/components/authentication/base/rbac/everyone-can-view-crs.yaml
@@ -23,6 +23,7 @@ rules:
   - imagerepositories
   - integrationtestscenarios
   - internalrequests
+  - nudgeconfigs
   - promotionruns
   - releaseplanadmissions
   - releaseplans

--- a/components/authentication/rings/ring-1/base/kustomization.yaml
+++ b/components/authentication/rings/ring-1/base/kustomization.yaml
@@ -2,3 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - base-snapshot
+  - nudge-migration-rbac.yaml

--- a/components/authentication/rings/ring-1/base/nudge-migration-rbac.yaml
+++ b/components/authentication/rings/ring-1/base/nudge-migration-rbac.yaml
@@ -1,0 +1,30 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: nudge-migration
+  annotations:
+    konflux-ci.dev/temporary: "STONEINTG-1682 -- remove after nudge-migrate.sh has been run on all clusters"
+rules:
+- apiGroups:
+  - appstudio.redhat.com
+  resources:
+  - nudgeconfigs
+  verbs:
+  - create
+  - patch
+  - update
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: nudge-migration
+  annotations:
+    konflux-ci.dev/temporary: "STONEINTG-1682 -- remove after nudge-migrate.sh has been run on all clusters"
+subjects:
+- kind: Group
+  apiGroup: rbac.authorization.k8s.io
+  name: konflux-integration
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: nudge-migration


### PR DESCRIPTION
Grant the konflux-integration group permissions to run the one-time
build-nudges-ref to NudgeConfig migration script on staging clusters.

Add nudgeconfigs to the view-appstudio ClusterRole for permanent read
access (get/list/watch), consistent with other appstudio.redhat.com
resources. Temporary ClusterRole grants only nudgeconfigs create/update
to the konflux-integration group, scoped to staging via ring-1 in the
authentication component.

Remove the temporary ClusterRole/ClusterRoleBinding after
nudge-migrate.sh has been run on all clusters.

Jira-ticket: https://redhat.atlassian.net/browse/STONEINTG-1682