### PR TITLE
test(KFLUXVNGD-1098): update konflux-operator and test monitoring

### DIFF
--- a/components/konflux-operator/ci/openshift-overlay-e2e/README.md
+++ b/components/konflux-operator/ci/openshift-overlay-e2e/README.md
@@ -13,7 +13,7 @@ step refs (`konflux-ci-install-konflux`, `redhat-appstudio-conformance-tests`).
 | `Dockerfile` | Unified CI image (`konflux-overlay-install`): task-runner + Go 1.26.4 from ubi10/go-toolset |
 | `ci-common.sh` | Shared cluster login (temp kubeconfig copy) and ephemeral git credentials |
 | `install.sh` | `hack/bootstrap-cluster.sh preview --operator-overlay`, QE secrets, SprayProxy, `e2e-secrets` quay pull secret |
-| `run-e2e.sh` | Clone konflux-ci @ ref from `invariant/kustomization.yaml`; `prepare-conformance-env` + `test/e2e/run-e2e.sh` (deploy test resources, proxy integration tests, then conformance in `default-tenant`) |
+| `run-e2e.sh` | Clone konflux-ci @ ref from `rings/ring-0/base/invariant/kustomization.yaml`; `prepare-conformance-env` + `test/e2e/run-e2e.sh` (OpenShift UWM metrics when applicable, proxy integration tests, conformance in `default-tenant`) |
 
 ## CI flow (both steps use the same pattern)
 
@@ -47,6 +47,10 @@ original kubeconfig file is not modified. While the step runs, `KUBECONFIG` poin
 a temp credential store file so your `~/.gitconfig` is not modified and the PAT is removed on
 `EXIT`. For interactive testing, run via a wrapper script or subshell so env vars from the step do
 not linger mid-session.
+
+OpenShift UWM metrics tests run inside `test/e2e/run-e2e.sh` when the cluster has user-workload
+monitoring. Preview already enables UWM via the `monitoring-workload-prometheus` Argo app; the
+`dummy-service` canary namespace triggers the default canary wait in metricsopenshift `BeforeSuite`.
 
 ```bash
 ./components/konflux-operator/ci/openshift-overlay-e2e/install.sh

--- a/components/konflux-operator/ci/openshift-overlay-e2e/run-e2e.sh
+++ b/components/konflux-operator/ci/openshift-overlay-e2e/run-e2e.sh
@@ -62,7 +62,7 @@ if [[ -n "${GINKGO_LABEL_FILTER:-}" ]]; then
   CONFORMANCE_ARGS+=(-ginkgo.label-filter="${GINKGO_LABEL_FILTER}")
 fi
 
-echo "[INFO] Running test/e2e/run-e2e.sh (deploy test resources, proxy integration tests, conformance; namespace=${E2E_APPLICATIONS_NAMESPACE})..."
+echo "[INFO] Running test/e2e/run-e2e.sh (OpenShift UWM metrics, deploy test resources, proxy integration tests, conformance; namespace=${E2E_APPLICATIONS_NAMESPACE})..."
 bash test/e2e/run-e2e.sh "${CONFORMANCE_ARGS[@]}"
 
 echo "[INFO] run-e2e.sh complete"

--- a/components/konflux-operator/rings/ring-0/base/invariant/kustomization.yaml
+++ b/components/konflux-operator/rings/ring-0/base/invariant/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - https://github.com/konflux-ci/konflux-ci/operator/config/default?ref=72d73f696e8847edfd53bbf9d302d6f2f703cfef
+  - https://github.com/konflux-ci/konflux-ci/operator/config/default?ref=6e991d87d286af2ffa3248cde827371b37540881
   - konflux.yaml
 
 patches:
@@ -10,4 +10,4 @@ patches:
 images:
   - name: localhost/konflux-operator
     newName: quay.io/konflux-ci/konflux-operator
-    newTag: 72d73f696e8847edfd53bbf9d302d6f2f703cfef
+    newTag: 6e991d87d286af2ffa3248cde827371b37540881


### PR DESCRIPTION
The Konflux Operator now enable monitoring for the Operator itself, and some of the operands. This commit updates the operator reference in dev so it uses that new functionality and also enabled tests for the service monitors.

Assisted-by: Cursor