### PR TITLE
KFLUXINFRA-4007 fix: restore missing list generator and repo-details injection to rd-dev konflux-operator appset

### DIFF
--- a/argo-cd-apps/overlays/rd-dev/konflux-operator/konflux-operator-appset.yaml
+++ b/argo-cd-apps/overlays/rd-dev/konflux-operator/konflux-operator-appset.yaml
@@ -16,6 +16,8 @@ spec:
                 sourceRoot: components/konflux-operator
                 ring: "ring-0"
                 clusterDir: base
+          - list:
+              elements: []
 
   template:
     metadata:

--- a/argo-cd-apps/overlays/rd-dev/konflux-operator/kustomization.yaml
+++ b/argo-cd-apps/overlays/rd-dev/konflux-operator/kustomization.yaml
@@ -3,3 +3,5 @@ kind: Kustomization
 
 resources:
   - konflux-operator-appset.yaml
+components:
+  - ../../../k-components/inject-infra-deployments-repo-details


### PR DESCRIPTION


PR #12998 removed the empty list generator from the merge generator and dropped the inject-infra-deployments-repo-details component. The merge generator requires at least two child generators; without the list element it silently produces no applications. The missing component causes the preview bootstrap to use the wrong repoURL/targetRevision, breaking the operator-overlay e2e.

