### PR TITLE
KFLUXVNGD-1121 Promote crossplane-control-plane upgrade to remaining production clusters

### DIFF
--- a/components/crossplane-control-plane/production/kflux-ocp-p01/environment-config.yaml
+++ b/components/crossplane-control-plane/production/kflux-ocp-p01/environment-config.yaml
@@ -1,0 +1,8 @@
+apiVersion: apiextensions.crossplane.io/v1beta1
+kind: EnvironmentConfig
+metadata:
+  name: envcfg
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+data:
+  clusterName: kflux-ocp-p01

--- a/components/crossplane-control-plane/production/kflux-ocp-p01/kustomization.yaml
+++ b/components/crossplane-control-plane/production/kflux-ocp-p01/kustomization.yaml
@@ -3,8 +3,9 @@ kind: Kustomization
 
 resources:
 - ../base
-- https://github.com/konflux-ci/crossplane-control-plane/crossplane?ref=bd3da0eff408eb329bfb5d7306b2aa3016d1a906
-- https://github.com/konflux-ci/crossplane-control-plane/config?ref=bd3da0eff408eb329bfb5d7306b2aa3016d1a906
+- environment-config.yaml
+- https://github.com/konflux-ci/crossplane-control-plane/crossplane?ref=93468e78be8cb6980dec3cd97ef400de6d54064b
+- https://github.com/konflux-ci/crossplane-control-plane/config?ref=93468e78be8cb6980dec3cd97ef400de6d54064b
 
 components:
   - ../../k-components/crossplane-resources

--- a/components/crossplane-control-plane/production/kflux-osp-p01/environment-config.yaml
+++ b/components/crossplane-control-plane/production/kflux-osp-p01/environment-config.yaml
@@ -1,0 +1,8 @@
+apiVersion: apiextensions.crossplane.io/v1beta1
+kind: EnvironmentConfig
+metadata:
+  name: envcfg
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+data:
+  clusterName: kflux-osp-p01

--- a/components/crossplane-control-plane/production/kflux-osp-p01/kustomization.yaml
+++ b/components/crossplane-control-plane/production/kflux-osp-p01/kustomization.yaml
@@ -3,8 +3,9 @@ kind: Kustomization
 
 resources:
 - ../base
-- https://github.com/konflux-ci/crossplane-control-plane/crossplane?ref=bd3da0eff408eb329bfb5d7306b2aa3016d1a906
-- https://github.com/konflux-ci/crossplane-control-plane/config?ref=bd3da0eff408eb329bfb5d7306b2aa3016d1a906
+- environment-config.yaml
+- https://github.com/konflux-ci/crossplane-control-plane/crossplane?ref=93468e78be8cb6980dec3cd97ef400de6d54064b
+- https://github.com/konflux-ci/crossplane-control-plane/config?ref=93468e78be8cb6980dec3cd97ef400de6d54064b
 
 components:
   - ../../k-components/crossplane-resources

--- a/components/crossplane-control-plane/production/kflux-prd-rh02/environment-config.yaml
+++ b/components/crossplane-control-plane/production/kflux-prd-rh02/environment-config.yaml
@@ -1,0 +1,8 @@
+apiVersion: apiextensions.crossplane.io/v1beta1
+kind: EnvironmentConfig
+metadata:
+  name: envcfg
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+data:
+  clusterName: kflux-prd-rh02

--- a/components/crossplane-control-plane/production/kflux-prd-rh02/kustomization.yaml
+++ b/components/crossplane-control-plane/production/kflux-prd-rh02/kustomization.yaml
@@ -3,8 +3,9 @@ kind: Kustomization
 
 resources:
 - ../base
-- https://github.com/konflux-ci/crossplane-control-plane/crossplane?ref=bd3da0eff408eb329bfb5d7306b2aa3016d1a906
-- https://github.com/konflux-ci/crossplane-control-plane/config?ref=bd3da0eff408eb329bfb5d7306b2aa3016d1a906
+- environment-config.yaml
+- https://github.com/konflux-ci/crossplane-control-plane/crossplane?ref=93468e78be8cb6980dec3cd97ef400de6d54064b
+- https://github.com/konflux-ci/crossplane-control-plane/config?ref=93468e78be8cb6980dec3cd97ef400de6d54064b
 
 components:
   - ../../k-components/crossplane-resources

--- a/components/crossplane-control-plane/production/kflux-prd-rh03/environment-config.yaml
+++ b/components/crossplane-control-plane/production/kflux-prd-rh03/environment-config.yaml
@@ -1,0 +1,8 @@
+apiVersion: apiextensions.crossplane.io/v1beta1
+kind: EnvironmentConfig
+metadata:
+  name: envcfg
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+data:
+  clusterName: kflux-prd-rh03

--- a/components/crossplane-control-plane/production/kflux-prd-rh03/kustomization.yaml
+++ b/components/crossplane-control-plane/production/kflux-prd-rh03/kustomization.yaml
@@ -3,8 +3,9 @@ kind: Kustomization
 
 resources:
 - ../base
-- https://github.com/konflux-ci/crossplane-control-plane/crossplane?ref=bd3da0eff408eb329bfb5d7306b2aa3016d1a906
-- https://github.com/konflux-ci/crossplane-control-plane/config?ref=bd3da0eff408eb329bfb5d7306b2aa3016d1a906
+- environment-config.yaml
+- https://github.com/konflux-ci/crossplane-control-plane/crossplane?ref=93468e78be8cb6980dec3cd97ef400de6d54064b
+- https://github.com/konflux-ci/crossplane-control-plane/config?ref=93468e78be8cb6980dec3cd97ef400de6d54064b
 
 components:
   - ../../k-components/crossplane-resources

--- a/components/crossplane-control-plane/production/kflux-rhel-p01/environment-config.yaml
+++ b/components/crossplane-control-plane/production/kflux-rhel-p01/environment-config.yaml
@@ -1,0 +1,8 @@
+apiVersion: apiextensions.crossplane.io/v1beta1
+kind: EnvironmentConfig
+metadata:
+  name: envcfg
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+data:
+  clusterName: kflux-rhel-p01

--- a/components/crossplane-control-plane/production/kflux-rhel-p01/kustomization.yaml
+++ b/components/crossplane-control-plane/production/kflux-rhel-p01/kustomization.yaml
@@ -3,8 +3,9 @@ kind: Kustomization
 
 resources:
 - ../base
-- https://github.com/konflux-ci/crossplane-control-plane/crossplane?ref=bd3da0eff408eb329bfb5d7306b2aa3016d1a906
-- https://github.com/konflux-ci/crossplane-control-plane/config?ref=bd3da0eff408eb329bfb5d7306b2aa3016d1a906
+- environment-config.yaml
+- https://github.com/konflux-ci/crossplane-control-plane/crossplane?ref=93468e78be8cb6980dec3cd97ef400de6d54064b
+- https://github.com/konflux-ci/crossplane-control-plane/config?ref=93468e78be8cb6980dec3cd97ef400de6d54064b
 
 components:
   - ../../k-components/crossplane-resources

--- a/components/crossplane-control-plane/production/stone-prd-rh01/environment-config.yaml
+++ b/components/crossplane-control-plane/production/stone-prd-rh01/environment-config.yaml
@@ -1,0 +1,8 @@
+apiVersion: apiextensions.crossplane.io/v1beta1
+kind: EnvironmentConfig
+metadata:
+  name: envcfg
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+data:
+  clusterName: stone-prd-rh01

--- a/components/crossplane-control-plane/production/stone-prd-rh01/kustomization.yaml
+++ b/components/crossplane-control-plane/production/stone-prd-rh01/kustomization.yaml
@@ -3,8 +3,9 @@ kind: Kustomization
 
 resources:
 - ../base
-- https://github.com/konflux-ci/crossplane-control-plane/crossplane?ref=bd3da0eff408eb329bfb5d7306b2aa3016d1a906
-- https://github.com/konflux-ci/crossplane-control-plane/config?ref=bd3da0eff408eb329bfb5d7306b2aa3016d1a906
+- environment-config.yaml
+- https://github.com/konflux-ci/crossplane-control-plane/crossplane?ref=93468e78be8cb6980dec3cd97ef400de6d54064b
+- https://github.com/konflux-ci/crossplane-control-plane/config?ref=93468e78be8cb6980dec3cd97ef400de6d54064b
 
 components:
   - ../../k-components/crossplane-resources

--- a/components/crossplane-control-plane/production/stone-prod-p01/environment-config.yaml
+++ b/components/crossplane-control-plane/production/stone-prod-p01/environment-config.yaml
@@ -1,0 +1,8 @@
+apiVersion: apiextensions.crossplane.io/v1beta1
+kind: EnvironmentConfig
+metadata:
+  name: envcfg
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+data:
+  clusterName: stone-prod-p01

--- a/components/crossplane-control-plane/production/stone-prod-p01/kustomization.yaml
+++ b/components/crossplane-control-plane/production/stone-prod-p01/kustomization.yaml
@@ -3,8 +3,9 @@ kind: Kustomization
 
 resources:
 - ../base
-- https://github.com/konflux-ci/crossplane-control-plane/crossplane?ref=bd3da0eff408eb329bfb5d7306b2aa3016d1a906
-- https://github.com/konflux-ci/crossplane-control-plane/config?ref=bd3da0eff408eb329bfb5d7306b2aa3016d1a906
+- environment-config.yaml
+- https://github.com/konflux-ci/crossplane-control-plane/crossplane?ref=93468e78be8cb6980dec3cd97ef400de6d54064b
+- https://github.com/konflux-ci/crossplane-control-plane/config?ref=93468e78be8cb6980dec3cd97ef400de6d54064b
 
 components:
   - ../../k-components/crossplane-resources

--- a/components/crossplane-control-plane/production/stone-prod-p02/environment-config.yaml
+++ b/components/crossplane-control-plane/production/stone-prod-p02/environment-config.yaml
@@ -1,0 +1,8 @@
+apiVersion: apiextensions.crossplane.io/v1beta1
+kind: EnvironmentConfig
+metadata:
+  name: envcfg
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+data:
+  clusterName: stone-prod-p02

--- a/components/crossplane-control-plane/production/stone-prod-p02/kustomization.yaml
+++ b/components/crossplane-control-plane/production/stone-prod-p02/kustomization.yaml
@@ -3,8 +3,9 @@ kind: Kustomization
 
 resources:
 - ../base
-- https://github.com/konflux-ci/crossplane-control-plane/crossplane?ref=bd3da0eff408eb329bfb5d7306b2aa3016d1a906
-- https://github.com/konflux-ci/crossplane-control-plane/config?ref=bd3da0eff408eb329bfb5d7306b2aa3016d1a906
+- environment-config.yaml
+- https://github.com/konflux-ci/crossplane-control-plane/crossplane?ref=93468e78be8cb6980dec3cd97ef400de6d54064b
+- https://github.com/konflux-ci/crossplane-control-plane/config?ref=93468e78be8cb6980dec3cd97ef400de6d54064b
 
 components:
   - ../../k-components/crossplane-resources


### PR DESCRIPTION
  Promote crossplane-control-plane upgrade to remaining production clusters (ring 2).

  - Upgrade all non-fedora clusters to ref `93468e78`
  - Add per-cluster EnvironmentConfigs for cluster-aware Compositions

  Clusters affected: kflux-ocp-p01, kflux-osp-p01, kflux-prd-rh02, kflux-prd-rh03, kflux-rhel-p01, stone-prd-rh01, stone-prod-p01, stone-prod-p02

  [KFLUXVNGD-1121](https://issues.redhat.com/browse/KFLUXVNGD-1121)

  ## Why

  Deploy composition changes that enable ephemeral cluster provisioning with openshift-ci using shared Konflux cluster profiles. The updated Compositions require cluster name context at runtime via EnvironmentConfig.

  ## Validation

  - `kustomize build --enable-helm` passes for all affected overlays
  - Ring 1 PR synced successfully: https://github.com/redhat-appstudio/infra-deployments/pull/13040
  - Ephemeral cluster successfully provisioned in the staging environment
  - Staging PR: https://github.com/redhat-appstudio/infra-deployments/pull/13020

  ## Risk Assessment

  **Risk Level:** Low
  **What could go wrong:** Crossplane deployment could fail to start on upgraded clusters if the new ref has an issue not caught in ring 1 or staging, or an EnvironmentConfig could be malformed.
  **Rollback:** Revert PR
  **Blast radius:** 8 clusters (all production clusters except kflux-fedora-01)

[KFLUXVNGD-1121]: https://redhat.atlassian.net/browse/KFLUXVNGD-1121?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ