### PR TITLE
Externalize MPC embedded scripts - KFLUXINFRA-4159 Prod - Ring1

### DIFF
--- a/components/multi-platform-controller/production-downstream/base/host-config-chart/Chart.yaml
+++ b/components/multi-platform-controller/production-downstream/base/host-config-chart/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v2
+name: multi-platform-controller-host-config
+description: A Helm chart for multi-platform-controller host configuration
+version: 0.1.0

--- a/components/multi-platform-controller/production-downstream/base/host-config-chart/files/linux-c6gd2xlarge-arm64-init.sh
+++ b/components/multi-platform-controller/production-downstream/base/host-config-chart/files/linux-c6gd2xlarge-arm64-init.sh
@@ -1,0 +1,23 @@
+#!/bin/bash -ex
+
+# Format and mount NVMe disk
+mkfs -t xfs /dev/nvme1n1
+mount /dev/nvme1n1 /home
+
+# Create required directories
+mkdir -p /home/var-lib-containers /var/lib/containers /home/var-tmp /var/tmp /home/ec2-user/.ssh
+
+# Setup bind mounts
+mount --bind /home/var-lib-containers /var/lib/containers
+mount --bind /home/var-tmp /var/tmp
+chmod 1777 /home/var-tmp /var/tmp
+chown root:root /home/var-tmp /var/tmp
+restorecon -r /var/lib/containers /var/tmp
+
+# Configure ec2-user SSH access
+chown -R ec2-user /home/ec2-user
+sed -n 's,.*\(ssh-.*\s\),\1,p' /root/.ssh/authorized_keys > /home/ec2-user/.ssh/authorized_keys
+chown ec2-user /home/ec2-user/.ssh/authorized_keys
+chmod 600 /home/ec2-user/.ssh/authorized_keys
+chmod 700 /home/ec2-user/.ssh
+restorecon -r /home/ec2-user

--- a/components/multi-platform-controller/production-downstream/base/host-config-chart/files/linux-g64xlarge-amd64-init.sh
+++ b/components/multi-platform-controller/production-downstream/base/host-config-chart/files/linux-g64xlarge-amd64-init.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+set -xeuo pipefail
+
+configure_nvidia_cdi() {
+  # generate Nvdia CDI with retry
+  for i in {1..10}; do
+    su - ec2-user -c 'nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml' 
+    su - ec2-user -c 'nvidia-ctk cdi generate --output=/var/run/cdi/nvidia.yaml'
+
+    # expect nvidia.com/gpu=all device to be in the generated list
+    if nvidia-ctk cdi list 2>/dev/null | grep -q 'nvidia.com/gpu=all'; then
+      echo "Nvidia CDI Ready"
+      return 0
+    fi
+
+    # sleep only if we'll be retrying again
+    [ "${i}" -lt "10" ] && sleep 1
+  done
+
+  echo "Nvidia CDI Failed"
+  return 1
+}
+
+# Format and mount NVMe disk
+mkfs -t xfs /dev/nvme1n1
+mount /dev/nvme1n1 /home
+
+# Create required directories
+mkdir -p /home/var-lib-containers /var/lib/containers /home/var-tmp /var/tmp /home/ec2-user/.ssh
+
+# Setup bind mounts
+mount --bind /home/var-lib-containers /var/lib/containers
+mount --bind /home/var-tmp /var/tmp
+chmod 1777 /home/var-tmp /var/tmp
+chown root:root /home/var-tmp /var/tmp
+restorecon -r /var/lib/containers /var/tmp
+
+# GPU setup
+mkdir -p /etc/cdi /var/run/cdi
+chmod a+rwx /etc/cdi /var/run/cdi
+setsebool container_use_devices 1 2>/dev/null || true
+configure_nvidia_cdi
+chmod a+rw /etc/cdi/nvidia.yaml
+chmod a+rw /var/run/cdi/nvidia.yaml
+
+# Configure ec2-user SSH access
+chown -R ec2-user /home/ec2-user
+sed -n 's,.*\(ssh-.*\s\),\1,p' /root/.ssh/authorized_keys > /home/ec2-user/.ssh/authorized_keys
+chown ec2-user /home/ec2-user/.ssh/authorized_keys
+chmod 600 /home/ec2-user/.ssh/authorized_keys
+chmod 700 /home/ec2-user/.ssh
+restorecon -r /home/ec2-user

--- a/components/multi-platform-controller/production-downstream/base/host-config-chart/files/linux-g6xlarge-amd64-init.sh
+++ b/components/multi-platform-controller/production-downstream/base/host-config-chart/files/linux-g6xlarge-amd64-init.sh
@@ -1,0 +1,30 @@
+#!/bin/bash -ex
+
+# Format and mount NVMe disk
+mkfs -t xfs /dev/nvme1n1
+mount /dev/nvme1n1 /home
+
+# Create required directories
+mkdir -p /home/var-lib-containers /var/lib/containers /home/var-tmp /var/tmp /home/ec2-user/.ssh
+
+# Setup bind mounts
+mount --bind /home/var-lib-containers /var/lib/containers
+mount --bind /home/var-tmp /var/tmp
+chmod a+rw /var/tmp
+restorecon -r /var/lib/containers /var/tmp
+
+# GPU setup
+mkdir -p /etc/cdi /var/run/cdi
+chmod a+rwx /etc/cdi /var/run/cdi
+setsebool container_use_devices 1 2>/dev/null || true
+su - ec2-user
+nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml
+chmod a+rw /etc/cdi/nvidia.yaml
+
+# Configure ec2-user SSH access
+chown -R ec2-user /home/ec2-user
+sed -n 's,.*\(ssh-.*\s\),\1,p' /root/.ssh/authorized_keys > /home/ec2-user/.ssh/authorized_keys
+chown ec2-user /home/ec2-user/.ssh/authorized_keys
+chmod 600 /home/ec2-user/.ssh/authorized_keys
+chmod 700 /home/ec2-user/.ssh
+restorecon -r /home/ec2-user

--- a/components/multi-platform-controller/production-downstream/base/host-config-chart/files/linux-g6xlarge-amd64-init.sh
+++ b/components/multi-platform-controller/production-downstream/base/host-config-chart/files/linux-g6xlarge-amd64-init.sh
@@ -1,4 +1,24 @@
-#!/bin/bash -ex
+#!/bin/bash
+
+set -xeuo pipefail
+
+configure_nvidia_cdi() {
+  # generate Nvdia CDI with retry
+  for i in {1..10}; do
+    su - ec2-user -c 'nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml'
+    su - ec2-user -c 'nvidia-ctk cdi generate --output=/var/run/cdi/nvidia.yaml'
+    # expect nvidia.com/gpu=all device to be in the generated list
+    if nvidia-ctk cdi list 2>/dev/null | grep -q 'nvidia.com/gpu=all'; then
+      echo "Nvidia CDI Ready"
+      return 0
+    fi
+    # sleep only if we'll be retrying again
+    [ "${i}" -lt "10" ] && sleep 1
+  done
+  
+  echo "Nvidia CDI Failed"
+  return 1
+}
 
 # Format and mount NVMe disk
 mkfs -t xfs /dev/nvme1n1
@@ -10,16 +30,17 @@ mkdir -p /home/var-lib-containers /var/lib/containers /home/var-tmp /var/tmp /ho
 # Setup bind mounts
 mount --bind /home/var-lib-containers /var/lib/containers
 mount --bind /home/var-tmp /var/tmp
-chmod a+rw /var/tmp
+chmod 1777 /home/var-tmp /var/tmp
+chown root:root /home/var-tmp /var/tmp
 restorecon -r /var/lib/containers /var/tmp
 
 # GPU setup
 mkdir -p /etc/cdi /var/run/cdi
 chmod a+rwx /etc/cdi /var/run/cdi
 setsebool container_use_devices 1 2>/dev/null || true
-su - ec2-user
-nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml
+configure_nvidia_cdi
 chmod a+rw /etc/cdi/nvidia.yaml
+chmod a+rw /var/run/cdi/nvidia.yaml
 
 # Configure ec2-user SSH access
 chown -R ec2-user /home/ec2-user

--- a/components/multi-platform-controller/production-downstream/base/host-config-chart/files/linux-root-amd64-init.sh
+++ b/components/multi-platform-controller/production-downstream/base/host-config-chart/files/linux-root-amd64-init.sh
@@ -1,0 +1,23 @@
+#!/bin/bash -ex
+
+# Format and mount NVMe disk
+mkfs -t xfs /dev/nvme1n1
+mount /dev/nvme1n1 /home
+
+# Create required directories
+mkdir -p /home/var-lib-containers /var/lib/containers /home/var-tmp /var/tmp /home/ec2-user/.ssh
+
+# Setup bind mounts
+mount --bind /home/var-lib-containers /var/lib/containers
+mount --bind /home/var-tmp /var/tmp
+chmod 1777 /home/var-tmp /var/tmp
+chown root:root /home/var-tmp /var/tmp
+restorecon -r /var/lib/containers /var/tmp
+
+# Configure ec2-user SSH access
+chown -R ec2-user /home/ec2-user
+sed -n 's,.*\(ssh-.*\s\),\1,p' /root/.ssh/authorized_keys > /home/ec2-user/.ssh/authorized_keys
+chown ec2-user /home/ec2-user/.ssh/authorized_keys
+chmod 600 /home/ec2-user/.ssh/authorized_keys
+chmod 700 /home/ec2-user/.ssh
+restorecon -r /home/ec2-user

--- a/components/multi-platform-controller/production-downstream/base/host-config-chart/files/linux-test-amd64-init.sh
+++ b/components/multi-platform-controller/production-downstream/base/host-config-chart/files/linux-test-amd64-init.sh
@@ -1,0 +1,24 @@
+#!/bin/bash -ex
+
+# Format and mount NVMe disk
+mkfs -t xfs /dev/nvme1n1
+mount /dev/nvme1n1 /home
+
+# Create required directories
+mkdir -p /home/var-lib-containers /var/lib/containers /home/var-tmp /var/tmp /home/ec2-user/.ssh
+
+# Setup bind mounts
+mount --bind /home/var-lib-containers /var/lib/containers
+mount --bind /home/var-tmp /var/tmp
+chmod 1777 /home/var-tmp /var/tmp
+chown root:root /home/var-tmp /var/tmp
+
+restorecon -r /var/lib/containers /var/tmp
+
+# Configure ec2-user SSH access
+chown -R ec2-user /home/ec2-user
+sed -n 's,.*\(ssh-.*\s\),\1,p' /root/.ssh/authorized_keys > /home/ec2-user/.ssh/authorized_keys
+chown ec2-user /home/ec2-user/.ssh/authorized_keys
+chmod 600 /home/ec2-user/.ssh/authorized_keys
+chmod 700 /home/ec2-user/.ssh
+restorecon -r /home/ec2-user

--- a/components/multi-platform-controller/production-downstream/base/host-config-chart/files/macos-mac2metal-arm64-init.sh
+++ b/components/multi-platform-controller/production-downstream/base/host-config-chart/files/macos-mac2metal-arm64-init.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+set -eu
+set -x
+
+user="konflux-builder"
+
+# Check if user already exists
+if ! id "$user" &>/dev/null; then
+    # Generate random password
+    random_password=$(openssl rand -base64 32)
+
+    # Create user
+    sudo sysadminctl -addUser "$user" -fullName "Konflux Builder" -password "$random_password" -home /Users/"$user"
+
+    # Clear password from variable
+    unset random_password
+else
+    echo "User $user already exists, skipping user creation"
+fi
+
+# Create home directory if it doesn't exist
+sudo mkdir -p /Users/"$user"
+
+# Create SSH directory
+sudo mkdir -p /Users/"$user"/.ssh
+
+# Remove existing SSH keys if they exist
+sudo rm -f /Users/"$user"/.ssh/id_rsa /Users/"$user"/.ssh/id_rsa.pub
+
+# Generate new SSH keys
+sudo ssh-keygen -t rsa -b 4096 -f /Users/"$user"/.ssh/id_rsa -N "" -C ""
+
+# Set proper permissions on .ssh directory
+sudo chmod 700 /Users/"$user"/.ssh
+
+# Create/overwrite authorized_keys
+sudo chmod 600 /Users/"$user"/.ssh/authorized_keys 2>/dev/null || true
+sudo cat /Users/"$user"/.ssh/id_rsa.pub | sudo tee /Users/"$user"/.ssh/authorized_keys > /dev/null
+sudo cat /Users/"$user"/.ssh/id_rsa | sudo tee /Users/ec2-user/"$user" > /dev/null
+
+# Set ownership of entire home directory to ensure user has full control
+sudo chown -R "$user":staff /Users/"$user"
+
+# Set ownership of the copied private key to ec2-user
+sudo chown ec2-user:staff /Users/ec2-user/"$user"
+sudo chmod 600 /Users/ec2-user/"$user"

--- a/components/multi-platform-controller/production-downstream/base/host-config-chart/files/macos-mac2metal-arm64-init.sh
+++ b/components/multi-platform-controller/production-downstream/base/host-config-chart/files/macos-mac2metal-arm64-init.sh
@@ -1,19 +1,19 @@
 #!/bin/bash
-set -eu
+set -euo pipefail
 set -x
 
 user="konflux-builder"
 
 # Check if user already exists
 if ! id "$user" &>/dev/null; then
-    # Generate random password
+    # Suppress xtrace to avoid leaking password in logs
+    set +x
     random_password=$(openssl rand -base64 32)
-
     # Create user
     sudo sysadminctl -addUser "$user" -fullName "Konflux Builder" -password "$random_password" -home /Users/"$user"
-
     # Clear password from variable
     unset random_password
+    set -x
 else
     echo "User $user already exists, skipping user creation"
 fi

--- a/components/multi-platform-controller/production-downstream/base/host-config-chart/templates/_cloud-init-userdata.tpl
+++ b/components/multi-platform-controller/production-downstream/base/host-config-chart/templates/_cloud-init-userdata.tpl
@@ -1,0 +1,23 @@
+{{- define "multi-platform-controller.cloud-init-userdata" -}}
+Content-Type: multipart/mixed; boundary="//"
+MIME-Version: 1.0
+
+--//
+Content-Type: text/cloud-config; charset="us-ascii"
+MIME-Version: 1.0
+Content-Transfer-Encoding: 7bit
+Content-Disposition: attachment; filename="cloud-config.txt"
+
+#cloud-config
+cloud_final_modules:
+  - [scripts-user, always]
+
+--//
+Content-Type: text/x-shellscript; charset="us-ascii"
+MIME-Version: 1.0
+Content-Transfer-Encoding: 7bit
+Content-Disposition: attachment; filename="userdata.txt"
+
+{{ . }}
+--//--
+{{- end -}}

--- a/components/multi-platform-controller/production-downstream/base/host-config-chart/templates/_windows-init.ps1.tpl
+++ b/components/multi-platform-controller/production-downstream/base/host-config-chart/templates/_windows-init.ps1.tpl
@@ -1,0 +1,389 @@
+{{- define "multi-platform-controller.windows-init" -}}
+<powershell>
+# ------------------
+# Helper Functions
+# ------------------
+function Wait-Folder {
+    param(
+        [Parameter(Mandatory=$true)]
+        [string]$FolderPath,
+        [Parameter(Mandatory=$false)]
+        [int]$TimeoutSeconds = 30
+    )
+    Write-Host "Waiting for folder '${FolderPath}' to be created"
+    $stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
+    while (-not (Test-Path -Path ${FolderPath})) {
+        if ($stopwatch.Elapsed.TotalSeconds -ge $TimeoutSeconds) {
+            Write-Error "Timeout reached! Folder was not created within $TimeoutSeconds seconds."
+            $stopwatch.Stop()
+            return $false
+        }
+        Write-Host "Waiting for folder..." -NoNewline
+        Start-Sleep -Seconds 1
+    }
+    $stopwatch.Stop()
+    return $true
+}
+
+# ---------------------
+# Docker Installation
+# ---------------------
+Invoke-WebRequest -UseBasicParsing "https://raw.githubusercontent.com/microsoft/Windows-Containers/Main/helpful_tools/Install-DockerCE/install-docker-ce.ps1" -OutFile install-docker-ce.ps1
+.\install-docker-ce.ps1
+
+# ---------------------------------------------------
+# OpenSSH Installation (service started at end of script)
+# ---------------------------------------------------
+Add-WindowsCapability -Online -Name OpenSSH.Server~~~~0.0.1.0
+
+# -------------------------------
+# User Creation & Profile Setup
+# -------------------------------
+$user = "konflux-builder"
+$password = $null
+$userWasCreated = $false
+
+# Create user if it doesn't exist
+if ((Get-LocalUser -Name "${user}" -ErrorAction SilentlyContinue) -eq $null) {
+    Write-Host "Creating user '${user}'"
+
+    $passwordLength = 16
+    $charset = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!@#$%^&*-_=+'
+    $rng = New-Object System.Security.Cryptography.RNGCryptoServiceProvider
+    $bytes = New-Object byte[]($passwordLength)
+    $rng.GetBytes($bytes)
+    $password = -join ($bytes | ForEach-Object { $charset[$_ % $charset.Length] })
+    $rng.Dispose()
+    $securePassword = (ConvertTo-SecureString $password -AsPlainText -Force)
+
+    New-LocalUser -Name $user -Password $securePassword -Description "Konflux Builder" | Out-Null
+    Add-LocalGroupMember -Group 'Users' -Member $user
+    Add-LocalGroupMember -Group 'OpenSSH Users' -Member $user
+
+    $userWasCreated = $true
+} else {
+    Write-Host "User '${user}' already exists, skipping user creation"
+}
+
+# Create user profile
+Add-Type -TypeDefinition @"
+using System;
+using System.Runtime.InteropServices;
+using System.Text;
+public class UserEnv
+{
+    [DllImport("userenv.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+    public static extern int CreateProfile(
+        [MarshalAs(UnmanagedType.LPWStr)] string pszUserSid,
+        [MarshalAs(UnmanagedType.LPWStr)] string pszUserName,
+        [MarshalAs(UnmanagedType.LPWStr)] StringBuilder pszProfilePath,
+        uint cchProfilePath);
+}
+"@
+
+$userSID = (New-Object System.Security.Principal.NTAccount($user)).Translate([System.Security.Principal.SecurityIdentifier]).Value
+$profilePath = New-Object System.Text.StringBuilder(260)
+$result = [UserEnv]::CreateProfile($userSID, $user, $profilePath, $profilePath.Capacity)
+
+# Create user home directory
+$userHome = "C:\Users\${user}"
+Write-Host "Waiting for User Home '${userHome}' to be created"
+if (-not (Wait-Folder -FolderPath ${userHome})) {
+    Write-Error "Folder '${userHome}' not found! This may cause issues with SSH setup"
+}
+
+$hivePath = "C:\Users\${user}\NTUSER.DAT"
+$loadedHive = "TempHive_${user}"
+
+# Configure user registry permissions
+try {
+    if (Test-Path $hivePath) {
+        $hiveLoaded = Test-Path "Registry::HKEY_USERS\${userSID}"
+
+        if (-not $hiveLoaded) {
+            & reg load "HKU\${loadedHive}" $hivePath 2>&1 | Out-Null
+            Start-Sleep -Seconds 2
+        } else {
+            $loadedHive = $userSID
+        }
+
+        $registryPath = "Registry::HKEY_USERS\${loadedHive}"
+        if (Test-Path $registryPath) {
+            $acl = Get-Acl $registryPath
+
+            $systemRule = New-Object System.Security.AccessControl.RegistryAccessRule(
+                "NT AUTHORITY\SYSTEM",
+                "FullControl",
+                "ContainerInherit,ObjectInherit",
+                "None",
+                "Allow"
+            )
+            $acl.SetAccessRule($systemRule)
+
+            $userRule = New-Object System.Security.AccessControl.RegistryAccessRule(
+                $user,
+                "FullControl",
+                "ContainerInherit,ObjectInherit",
+                "None",
+                "Allow"
+            )
+            $acl.SetAccessRule($userRule)
+
+            Set-Acl $registryPath $acl
+        }
+
+        if (-not $hiveLoaded) {
+            [gc]::Collect()
+            Start-Sleep -Seconds 2
+            & reg unload "HKU\${loadedHive}" 2>&1 | Out-Null
+        }
+    }
+} catch {
+    Write-Warning "Failed to configure user registry permissions: $($_.Exception.Message)"
+    Write-Warning "This may affect user profile settings, but SSH access should still work"
+}
+
+# ----------------------------------
+# Docker User Access Configuration
+# ----------------------------------
+$dockerGroup = "docker-users"
+
+if (-not (Get-LocalGroup -Name $dockerGroup -ErrorAction SilentlyContinue)) {
+    New-LocalGroup -Name $dockerGroup -Description 'Docker Users' -ErrorAction SilentlyContinue
+}
+
+Add-LocalGroupMember -Group $dockerGroup -Member $user -ErrorAction SilentlyContinue
+
+$dockerConfigPath = "C:\ProgramData\docker\config\daemon.json"
+$dockerConfigDir = Split-Path $dockerConfigPath -Parent
+
+if (-not (Test-Path $dockerConfigDir)) {
+    New-Item -ItemType Directory -Path $dockerConfigDir -Force | Out-Null
+}
+
+$daemonConfig = @{ "group" = $dockerGroup }
+
+# Configure Docker daemon to use the docker-users group
+if (Test-Path $dockerConfigPath) {
+    $existingConfig = Get-Content $dockerConfigPath -Raw | ConvertFrom-Json
+    $existingConfig | Add-Member -NotePropertyName "group" -NotePropertyValue $dockerGroup -Force
+    $existingConfig | ConvertTo-Json -Depth 10 | Set-Content $dockerConfigPath -Force
+} else {
+    $daemonConfig | ConvertTo-Json | Set-Content $dockerConfigPath -Force
+}
+
+if (Get-Service docker -ErrorAction SilentlyContinue) {
+    Restart-Service docker -Force
+}
+
+# Add exclusion processes to Windows Defender
+Add-MpPreference -ExclusionProcess "dockerd.exe" -ErrorAction SilentlyContinue
+Add-MpPreference -ExclusionProcess "docker.exe" -ErrorAction SilentlyContinue
+Add-MpPreference -ExclusionProcess "containerd.exe" -ErrorAction SilentlyContinue
+Add-MpPreference -ExclusionProcess "vmcompute.exe" -ErrorAction SilentlyContinue
+
+# -----------------------------
+# Scoop Support Configuration
+# -----------------------------
+# Enable development mode - allows symbolic links to be created
+Set-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\AppModelUnlock" `
+    -Name "AllowDevelopmentWithoutDevLicense" `
+    -Value 1 `
+    -Type DWord `
+    -Force
+
+# Start the MSI server service - required for scoop installation
+Set-Service -Name msiserver -StartupType Automatic -ErrorAction SilentlyContinue
+Start-Service -Name msiserver -ErrorAction SilentlyContinue
+
+# --------------------------------
+# User SSH Key & Directory Setup
+# --------------------------------
+$tempKey = "${env:TEMP}\${user}"
+
+# Remove existing SSH keys if they exist
+if (Test-Path "${tempKey}") { Remove-Item -Force "${tempKey}" }
+if (Test-Path "${tempKey}.pub") { Remove-Item -Force "${tempKey}.pub" }
+
+ssh-keygen -t rsa -f "${tempKey}" -N `"`" | Out-Null
+
+$privateKeyPath = "C:\Users\Administrator\${user}"
+mv "${env:TEMP}\${user}" "${privateKeyPath}"
+
+# Configure ACL for the private key
+$ACL = Get-Acl "${privateKeyPath}"
+$Ar = New-Object System.Security.AccessControl.FileSystemAccessRule(
+    "NT AUTHORITY\SYSTEM",
+    "FullControl",
+    "Allow"
+)
+$ACL.SetAccessRule($Ar)
+$Ar = New-Object System.Security.AccessControl.FileSystemAccessRule(
+    "BUILTIN\Administrators",
+    "FullControl",
+    "Allow"
+)
+$ACL.SetAccessRule($Ar)
+Set-Acl "${privateKeyPath}" ${ACL}
+
+$publicKeyTempPath = "C:\Users\Public\${user}.pub"
+Copy-Item "${tempKey}.pub" $publicKeyTempPath -Force
+Start-Sleep 10
+
+# Create  additional user directories
+$sshPath = Join-Path $userHome ".ssh"
+$buildPath = Join-Path $userHome "build"
+$scoopPath = Join-Path $userHome "scoop"
+$authorizedKeysPath = Join-Path $sshPath "authorized_keys"
+
+New-Item -ItemType Directory -Force -Path $sshPath | Out-Null
+New-Item -ItemType Directory -Force -Path $buildPath | Out-Null
+New-Item -ItemType Directory -Force -Path $scoopPath | Out-Null
+
+if (Test-Path $publicKeyTempPath) {
+    Copy-Item $publicKeyTempPath $authorizedKeysPath -Force
+}
+
+# Set owner and permissions for additional user directories
+$userSidObj = New-Object System.Security.Principal.SecurityIdentifier($userSID)
+foreach ($path in @($sshPath, $buildPath, $scoopPath, $authorizedKeysPath)) {
+    if (Test-Path $path) {
+        $acl = Get-Acl $path
+        $acl.SetOwner($userSidObj)
+        Set-Acl $path $acl
+    }
+}
+
+# Configure ACL for the SSH directory
+if (Test-Path $sshPath) {
+    $sshAcl = Get-Acl $sshPath
+    $sshAcl.SetAccessRuleProtection($true, $false)
+    $sshAcl.Access | ForEach-Object { $sshAcl.RemoveAccessRule($_) } | Out-Null
+
+    $userRule = New-Object System.Security.AccessControl.FileSystemAccessRule(
+        $user,
+        "FullControl",
+        "ContainerInherit,ObjectInherit",
+        "None",
+        "Allow"
+    )
+    $sshAcl.SetAccessRule($userRule)
+
+    $systemRule = New-Object System.Security.AccessControl.FileSystemAccessRule(
+        "NT AUTHORITY\SYSTEM",
+        "FullControl",
+        "ContainerInherit,ObjectInherit",
+        "None",
+        "Allow"
+    )
+    $sshAcl.SetAccessRule($systemRule)
+
+    Set-Acl $sshPath $sshAcl
+}
+
+if (Test-Path $authorizedKeysPath) {
+    $keyAcl = Get-Acl $authorizedKeysPath
+    $keyAcl.SetAccessRuleProtection($true, $false)
+    $keyAcl.Access | ForEach-Object { $keyAcl.RemoveAccessRule($_) } | Out-Null
+
+    $userKeyRule = New-Object System.Security.AccessControl.FileSystemAccessRule(
+        $user,
+        "Read",
+        "Allow"
+    )
+    $keyAcl.SetAccessRule($userKeyRule)
+
+    $systemKeyRule = New-Object System.Security.AccessControl.FileSystemAccessRule(
+        "NT AUTHORITY\SYSTEM",
+        "FullControl",
+        "Allow"
+    )
+    $keyAcl.SetAccessRule($systemKeyRule)
+
+    Set-Acl $authorizedKeysPath $keyAcl
+}
+
+if (Test-Path $publicKeyTempPath) {
+    Remove-Item -Path $publicKeyTempPath -Force -ErrorAction SilentlyContinue
+}
+if (Test-Path "${tempKey}.pub") {
+    Remove-Item -Force "${tempKey}.pub"
+}
+
+# --------------------------
+# Scoop Installation Script
+# --------------------------
+if ($userWasCreated) {
+    $scoopScript = @"
+Set-ExecutionPolicy RemoteSigned -Scope CurrentUser -Force
+Write-Host "Installing Scoop..."
+Invoke-RestMethod -Uri 'https://get.scoop.sh' | Invoke-Expression
+scoop config use_lessmsi true
+Write-Host "Scoop installed successfully!"
+"@
+    $scoopScriptPath = "C:\Users\${user}\install_scoop.ps1"
+    $scoopScript | Out-File -FilePath $scoopScriptPath -Encoding UTF8 -Force
+
+    $scriptAcl = Get-Acl $scoopScriptPath
+    $scriptAcl.SetOwner($userSidObj)
+    Set-Acl $scoopScriptPath $scriptAcl
+}
+
+# ---------------------------------------------------
+# OpenSSH Administrator Configuration & Service Start
+# ---------------------------------------------------
+{{- $addresses := (list) }}
+{{- range $entry := (index . "allowed-remote-addresses" | required "Remote addresses for the SSH FW must be specified") }}
+    {{- $addresses = append $addresses (squote $entry) }}
+{{- end }}
+Remove-NetFirewallRule -Name 'OpenSSH-Server-In-TCP' -ErrorAction SilentlyContinue
+New-NetFirewallRule -Name 'OpenSSH-Server-In-TCP' `
+    -DisplayName 'OpenSSH Server (sshd)' `
+    -Enabled True `
+    -Direction Inbound `
+    -Protocol TCP `
+    -Action Allow `
+    -LocalPort 22 `
+    -RemoteAddress {{ join "," $addresses }} | Out-Null
+
+# Get public key from AWS Instance Metadata Service (IMDSv2)
+$MAGIC_IP = "169.254.169.254"
+$IMDS_TOKEN = Invoke-RestMethod -Uri "http://${MAGIC_IP}/latest/api/token" `
+    -Method 'PUT' `
+    -Headers @{'X-aws-ec2-metadata-token-ttl-seconds' = '21600'}
+$PUBKEY = Invoke-RestMethod -Uri "http://${MAGIC_IP}/latest/meta-data/public-keys/0/openssh-key" `
+    -Headers @{'X-aws-ec2-metadata-token' = $IMDS_TOKEN}
+
+Start-Sleep 5
+
+# Configure SSH authorized_keys for Administrator
+$SSH_PATH = "C:\ProgramData\ssh"
+Write-Host "Waiting for SSH Folder '${SSH_PATH}'"
+if (-not (Wait-Folder -FolderPath ${SSH_PATH})) {
+    Write-Warning "SSH folder not found, creating it manually"
+    New-Item -ItemType Directory -Path $SSH_PATH | Out-Null
+}
+Write-Host "SSH Folder '${SSH_PATH}' found"
+
+$PUBKEY | Out-File -FilePath "$SSH_PATH\administrators_authorized_keys" -Encoding ascii
+
+$ACL = Get-Acl "$SSH_PATH\administrators_authorized_keys"
+$Ar = New-Object System.Security.AccessControl.FileSystemAccessRule(
+    "NT AUTHORITY\SYSTEM",
+    "FullControl",
+    "Allow"
+)
+$ACL.SetAccessRule($Ar)
+$Ar = New-Object System.Security.AccessControl.FileSystemAccessRule(
+    "BUILTIN\Administrators",
+    "FullControl",
+    "Allow"
+)
+$ACL.SetAccessRule($Ar)
+Set-Acl "$SSH_PATH\administrators_authorized_keys" $ACL
+
+Start-Service sshd
+Set-Service -Name sshd -StartupType 'Automatic'
+</powershell>
+<persist>true</persist>
+{{- end -}}

--- a/components/multi-platform-controller/production-downstream/base/host-config-chart/templates/host-config.yaml
+++ b/components/multi-platform-controller/production-downstream/base/host-config-chart/templates/host-config.yaml
@@ -1,0 +1,1184 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    build.appstudio.redhat.com/multi-platform-config: hosts
+  name: host-config
+  namespace: multi-platform-controller
+data:
+  local-platforms: "\
+    {{ join ",\\\n    " (.Values.localPlatforms | default (list "linux/x86_64" "local" "localhost")) }}\
+  "
+
+
+  {{- $outs := list }}
+  {{- range $k, $v := .Values.dynamicConfigs }}
+    {{- $parts := splitList "-" $k }}
+    {{- $last := index $parts (sub (len $parts) 1) }}
+    {{- $prefix := join "-" (slice $parts 0 (sub (len $parts) 1)) }}
+    {{- $outs = append $outs (printf "%s/%s" $prefix $last) }}
+  {{- end }}
+  dynamic-platforms: "\
+    {{ join ",\\\n    " $outs }}\
+  "
+
+  {{- if .Values.dynamicPoolPlatforms }}
+  dynamic-pool-platforms: {{ .Values.dynamicPoolPlatforms }}
+  {{- end }}
+
+  instance-tag: {{ .Values.instanceTag | default "rhtap-prod" }}
+
+  {{- $defaultTags := dict "Project" "Konflux" "Owner" "konflux-infra@redhat.com" "ManagedBy" "Konflux Infra Team" "app-code" "ASSH-001" "service-phase" "Production" "cost-center" "670" }}
+  {{- $mergedTags := merge (.Values.additionalInstanceTags | default dict) $defaultTags }}
+
+  additional-instance-tags: "\
+  {{- $keys := keys $mergedTags | sortAlpha }}
+  {{- range $i, $k := $keys }}
+      {{ $k }}={{ index $mergedTags $k }}{{- if lt $i (sub (len $keys) 1) }},{{ end }}\
+  {{- end }}
+      "
+
+  {{- $arm := (index .Values "archDefaults" "arm64") | default (dict) }}
+  {{- $amd := (index .Values "archDefaults" "amd64") | default (dict) }}
+  {{- $windows := (index .Values "archDefaults" "windows-amd64") | default (dict) }}
+  {{- $macos := (index .Values "archDefaults" "macos-mac2metal-arm64") | default (dict) }}
+  {{- $environment := .Values.environment | default "prod" }}
+
+  # cpu:memory (1:4)
+  {{- if hasKey .Values.dynamicConfigs "linux-arm64" }}
+  {{- $config := index .Values.dynamicConfigs "linux-arm64" | default (dict) }}
+  dynamic.linux-arm64.type: {{ index $config "type" | default "aws" | quote }}
+  dynamic.linux-arm64.region: {{ index $config "region" | default "us-east-1" | quote }}
+  dynamic.linux-arm64.ami: {{ default (index $arm "ami") $config.ami | quote }}
+  dynamic.linux-arm64.instance-type: {{ (index $config "instance-type") | default "m6g.large" | quote }}
+  dynamic.linux-arm64.instance-tag: {{ (index $config "instance-tag") | default (printf "%s-arm64" $environment) | quote }}
+  dynamic.linux-arm64.key-name: {{ default (index $arm "key-name") ((index $config "key-name")) | quote }}
+  dynamic.linux-arm64.aws-secret: {{ (index $config "aws-secret") | default "aws-account" | quote }}
+  dynamic.linux-arm64.ssh-secret: {{ (index $config "ssh-secret") | default "aws-ssh-key" | quote }}
+  dynamic.linux-arm64.security-group-id: {{ default (index $arm "security-group-id") ((index $config "security-group-id")) | quote }}
+  dynamic.linux-arm64.max-instances: {{ (index $config "max-instances") | default "250" | quote }}
+  dynamic.linux-arm64.subnet-id: {{ default (index $arm "subnet-id") ((index $config "subnet-id")) | quote }}
+  dynamic.linux-arm64.check-interval: {{ (index $config "check-interval") | default "60" | quote }}
+  dynamic.linux-arm64.allocation-timeout: "1200"
+  {{ end }}
+
+
+  {{- if hasKey .Values.dynamicConfigs "linux-amd64" }}
+  {{- $config := index .Values.dynamicConfigs "linux-amd64" | default (dict) }}
+  dynamic.linux-amd64.type: {{ index $config "type" | default "aws" | quote }}
+  dynamic.linux-amd64.region: {{ index $config "region" | default "us-east-1" | quote }}
+  dynamic.linux-amd64.ami: {{ default (index $amd "ami") $config.ami | quote }}
+  dynamic.linux-amd64.instance-type: {{ (index $config "instance-type") | default "m6a.large" | quote }}
+  dynamic.linux-amd64.instance-tag: {{ (index $config "instance-tag") | default (printf "%s-amd64" $environment) | quote }}
+  dynamic.linux-amd64.key-name: {{ default (index $amd "key-name") ((index $config "key-name")) | quote }}
+  dynamic.linux-amd64.aws-secret: {{ (index $config "aws-secret") | default "aws-account" | quote }}
+  dynamic.linux-amd64.ssh-secret: {{ (index $config "ssh-secret") | default "aws-ssh-key" | quote }}
+  dynamic.linux-amd64.security-group-id: {{ default (index $amd "security-group-id") ((index $config "security-group-id")) | quote }}
+  dynamic.linux-amd64.max-instances: {{ (index $config "max-instances") | default "250" | quote }}
+  dynamic.linux-amd64.subnet-id: {{ default (index $amd "subnet-id") ((index $config "subnet-id")) | quote }}
+  dynamic.linux-amd64.check-interval: {{ (index $config "check-interval") | default "60" | quote }}
+  dynamic.linux-amd64.allocation-timeout: "1200"
+  {{ end }}
+
+  {{- if hasKey .Values.dynamicConfigs "linux-d160-amd64" }}
+  {{- $config := index .Values.dynamicConfigs "linux-d160-amd64" | default (dict) }}
+  dynamic.linux-d160-amd64.type: {{ index $config "type" | default "aws" | quote }}
+  dynamic.linux-d160-amd64.region: {{ index $config "region" | default "us-east-1" | quote }}
+  dynamic.linux-d160-amd64.ami: {{ default (index $amd "ami") $config.ami | quote }}
+  dynamic.linux-d160-amd64.instance-type: {{ (index $config "instance-type") | default "m6a.large" | quote }}
+  dynamic.linux-d160-amd64.instance-tag: {{ (index $config "instance-tag") | default (printf "%s-amd64-d160" $environment) | quote }}
+  dynamic.linux-d160-amd64.key-name: {{ default (index $amd "key-name") ((index $config "key-name")) | quote }}
+  dynamic.linux-d160-amd64.aws-secret: {{ (index $config "aws-secret") | default "aws-account" | quote }}
+  dynamic.linux-d160-amd64.ssh-secret: {{ (index $config "ssh-secret") | default "aws-ssh-key" | quote }}
+  dynamic.linux-d160-amd64.security-group-id: {{ default (index $amd "security-group-id") ((index $config "security-group-id")) | quote }}
+  dynamic.linux-d160-amd64.max-instances: {{ (index $config "max-instances") | default "250" | quote }}
+  dynamic.linux-d160-amd64.subnet-id: {{ default (index $amd "subnet-id") ((index $config "subnet-id")) | quote }}
+  dynamic.linux-d160-amd64.check-interval: {{ (index $config "check-interval") | default "60" | quote }}
+  dynamic.linux-d160-amd64.disk: "160"
+  dynamic.linux-d160-amd64.allocation-timeout: "1200"
+  {{ end }}
+
+  {{- if hasKey .Values.dynamicConfigs "linux-d160-arm64" }}
+  {{- $config := index .Values.dynamicConfigs "linux-d160-arm64" | default (dict) }}
+  dynamic.linux-d160-arm64.type: {{ index $config "type" | default "aws" | quote }}
+  dynamic.linux-d160-arm64.region: {{ index $config "region" | default "us-east-1" | quote }}
+  dynamic.linux-d160-arm64.ami: {{ default (index $arm "ami") $config.ami | quote }}
+  dynamic.linux-d160-arm64.instance-type: {{ (index $config "instance-type") | default "m6g.large" | quote }}
+  dynamic.linux-d160-arm64.instance-tag: {{ (index $config "instance-tag") | default (printf "%s-arm64-d160" $environment) | quote }}
+  dynamic.linux-d160-arm64.key-name: {{ default (index $arm "key-name") ((index $config "key-name")) | quote }}
+  dynamic.linux-d160-arm64.aws-secret: {{ (index $config "aws-secret") | default "aws-account" | quote }}
+  dynamic.linux-d160-arm64.ssh-secret: {{ (index $config "ssh-secret") | default "aws-ssh-key" | quote }}
+  dynamic.linux-d160-arm64.security-group-id: {{ default (index $arm "security-group-id") ((index $config "security-group-id")) | quote }}
+  dynamic.linux-d160-arm64.max-instances: {{ (index $config "max-instances") | default "250" | quote }}
+  dynamic.linux-d160-arm64.subnet-id: {{ default (index $arm "subnet-id") ((index $config "subnet-id")) | quote }}
+  dynamic.linux-d160-arm64.check-interval: {{ (index $config "check-interval") | default "60" | quote }}
+  dynamic.linux-d160-arm64.disk: "160"
+  dynamic.linux-d160-arm64.allocation-timeout: "1200"
+  {{ end }}
+
+
+  {{- if hasKey .Values.dynamicConfigs "linux-mlarge-arm64" }}
+  {{- $config := index .Values.dynamicConfigs "linux-mlarge-arm64" | default (dict) }}
+  dynamic.linux-mlarge-arm64.type: {{ index $config "type" | default "aws" | quote }}
+  dynamic.linux-mlarge-arm64.region: {{ index $config "region" | default "us-east-1" | quote }}
+  dynamic.linux-mlarge-arm64.ami: {{ default (index $arm "ami") $config.ami | quote }}
+  dynamic.linux-mlarge-arm64.instance-type: {{ (index $config "instance-type") | default "m6g.large" | quote }}
+  dynamic.linux-mlarge-arm64.instance-tag: {{ (index $config "instance-tag") | default (printf "%s-arm64-mlarge" $environment) | quote }}
+  dynamic.linux-mlarge-arm64.key-name: {{ default (index $arm "key-name") ((index $config "key-name")) | quote }}
+  dynamic.linux-mlarge-arm64.aws-secret: {{ (index $config "aws-secret") | default "aws-account" | quote }}
+  dynamic.linux-mlarge-arm64.ssh-secret: {{ (index $config "ssh-secret") | default "aws-ssh-key" | quote }}
+  dynamic.linux-mlarge-arm64.security-group-id: {{ default (index $arm "security-group-id") ((index $config "security-group-id")) | quote }}
+  dynamic.linux-mlarge-arm64.max-instances: {{ (index $config "max-instances") | default "250" | quote }}
+  dynamic.linux-mlarge-arm64.subnet-id: {{ default (index $arm "subnet-id") ((index $config "subnet-id")) | quote }}
+  dynamic.linux-mlarge-arm64.check-interval: {{ (index $config "check-interval") | default "60" | quote }}
+  dynamic.linux-mlarge-arm64.allocation-timeout: "1200"
+  {{ end }}
+
+  {{- if hasKey .Values.dynamicConfigs "linux-mlarge-amd64" }}
+  {{- $config := index .Values.dynamicConfigs "linux-mlarge-amd64" | default (dict) }}
+  dynamic.linux-mlarge-amd64.type: {{ index $config "type" | default "aws" | quote }}
+  dynamic.linux-mlarge-amd64.region: {{ index $config "region" | default "us-east-1" | quote }}
+  dynamic.linux-mlarge-amd64.ami: {{ default (index $amd "ami") $config.ami | quote }}
+  dynamic.linux-mlarge-amd64.instance-type: {{ (index $config "instance-type") | default "m6a.large" | quote }}
+  dynamic.linux-mlarge-amd64.instance-tag: {{ (index $config "instance-tag") | default (printf "%s-amd64-mlarge" $environment) | quote }}
+  dynamic.linux-mlarge-amd64.key-name: {{ default (index $amd "key-name") ((index $config "key-name")) | quote }}
+  dynamic.linux-mlarge-amd64.aws-secret: {{ (index $config "aws-secret") | default "aws-account" | quote }}
+  dynamic.linux-mlarge-amd64.ssh-secret: {{ (index $config "ssh-secret") | default "aws-ssh-key" | quote }}
+  dynamic.linux-mlarge-amd64.security-group-id: {{ default (index $amd "security-group-id") ((index $config "security-group-id")) | quote }}
+  dynamic.linux-mlarge-amd64.max-instances: {{ (index $config "max-instances") | default "250" | quote }}
+  dynamic.linux-mlarge-amd64.subnet-id: {{ default (index $amd "subnet-id") ((index $config "subnet-id")) | quote }}
+  dynamic.linux-mlarge-amd64.check-interval: {{ (index $config "check-interval") | default "60" | quote }}
+  dynamic.linux-mlarge-amd64.allocation-timeout: "1200"
+  {{ end }}
+
+  {{- if hasKey .Values.dynamicConfigs "linux-d160-mlarge-arm64" }}
+  {{- $config := index .Values.dynamicConfigs "linux-d160-mlarge-arm64" | default (dict) }}
+  dynamic.linux-d160-mlarge-arm64.type: {{ index $config "type" | default "aws" | quote }}
+  dynamic.linux-d160-mlarge-arm64.region: {{ index $config "region" | default "us-east-1" | quote }}
+  dynamic.linux-d160-mlarge-arm64.ami: {{ default (index $arm "ami") $config.ami | quote }}
+  dynamic.linux-d160-mlarge-arm64.instance-type: {{ (index $config "instance-type") | default "m6g.large" | quote }}
+  dynamic.linux-d160-mlarge-arm64.instance-tag: {{ (index $config "instance-tag") | default (printf "%s-arm64-mlarge-d160" $environment) | quote }}
+  dynamic.linux-d160-mlarge-arm64.key-name: {{ default (index $arm "key-name") ((index $config "key-name")) | quote }}
+  dynamic.linux-d160-mlarge-arm64.aws-secret: {{ (index $config "aws-secret") | default "aws-account" | quote }}
+  dynamic.linux-d160-mlarge-arm64.ssh-secret: {{ (index $config "ssh-secret") | default "aws-ssh-key" | quote }}
+  dynamic.linux-d160-mlarge-arm64.security-group-id: {{ default (index $arm "security-group-id") ((index $config "security-group-id")) | quote }}
+  dynamic.linux-d160-mlarge-arm64.max-instances: {{ (index $config "max-instances") | default "250" | quote }}
+  dynamic.linux-d160-mlarge-arm64.subnet-id: {{ default (index $arm "subnet-id") ((index $config "subnet-id")) | quote }}
+  dynamic.linux-d160-mlarge-arm64.check-interval: {{ (index $config "check-interval") | default "60" | quote }}
+  dynamic.linux-d160-mlarge-arm64.disk: "160"
+  dynamic.linux-d160-mlarge-arm64.allocation-timeout: "1200"
+  {{ end }}
+
+  {{- if hasKey .Values.dynamicConfigs "linux-d160-mlarge-amd64" }}
+  {{- $config := index .Values.dynamicConfigs "linux-d160-mlarge-amd64" | default (dict) }}
+  dynamic.linux-d160-mlarge-amd64.type: {{ index $config "type" | default "aws" | quote }}
+  dynamic.linux-d160-mlarge-amd64.region: {{ index $config "region" | default "us-east-1" | quote }}
+  dynamic.linux-d160-mlarge-amd64.ami: {{ default (index $amd "ami") $config.ami | quote }}
+  dynamic.linux-d160-mlarge-amd64.instance-type: {{ (index $config "instance-type") | default "m6a.large" | quote }}
+  dynamic.linux-d160-mlarge-amd64.instance-tag: {{ (index $config "instance-tag") | default (printf "%s-amd64-mlarge-d160" $environment) | quote }}
+  dynamic.linux-d160-mlarge-amd64.key-name: {{ default (index $amd "key-name") ((index $config "key-name")) | quote }}
+  dynamic.linux-d160-mlarge-amd64.aws-secret: {{ (index $config "aws-secret") | default "aws-account" | quote }}
+  dynamic.linux-d160-mlarge-amd64.ssh-secret: {{ (index $config "ssh-secret") | default "aws-ssh-key" | quote }}
+  dynamic.linux-d160-mlarge-amd64.security-group-id: {{ default (index $amd "security-group-id") ((index $config "security-group-id")) | quote }}
+  dynamic.linux-d160-mlarge-amd64.max-instances: {{ (index $config "max-instances") | default "250" | quote }}
+  dynamic.linux-d160-mlarge-amd64.subnet-id: {{ default (index $amd "subnet-id") ((index $config "subnet-id")) | quote }}
+  dynamic.linux-d160-mlarge-amd64.check-interval: {{ (index $config "check-interval") | default "60" | quote }}
+  dynamic.linux-d160-mlarge-amd64.disk: "160"
+  dynamic.linux-d160-mlarge-amd64.allocation-timeout: "1200"
+  {{ end }}
+
+  {{- if hasKey .Values.dynamicConfigs "linux-mxlarge-arm64" }}
+  {{- $config := index .Values.dynamicConfigs "linux-mxlarge-arm64" | default (dict) }}
+  dynamic.linux-mxlarge-arm64.type: {{ index $config "type" | default "aws" | quote }}
+  dynamic.linux-mxlarge-arm64.region: {{ index $config "region" | default "us-east-1" | quote }}
+  dynamic.linux-mxlarge-arm64.ami: {{ default (index $arm "ami") $config.ami | quote }}
+  dynamic.linux-mxlarge-arm64.instance-type: {{ (index $config "instance-type") | default "m6g.xlarge" | quote }}
+  dynamic.linux-mxlarge-arm64.instance-tag: {{ (index $config "instance-tag") | default (printf "%s-arm64-mxlarge" $environment) | quote }}
+  dynamic.linux-mxlarge-arm64.key-name: {{ default (index $arm "key-name") ((index $config "key-name")) | quote }}
+  dynamic.linux-mxlarge-arm64.aws-secret: {{ (index $config "aws-secret") | default "aws-account" | quote }}
+  dynamic.linux-mxlarge-arm64.ssh-secret: {{ (index $config "ssh-secret") | default "aws-ssh-key" | quote }}
+  dynamic.linux-mxlarge-arm64.security-group-id: {{ default (index $arm "security-group-id") ((index $config "security-group-id")) | quote }}
+  dynamic.linux-mxlarge-arm64.max-instances: {{ (index $config "max-instances") | default "250" | quote }}
+  dynamic.linux-mxlarge-arm64.subnet-id: {{ default (index $arm "subnet-id") ((index $config "subnet-id")) | quote }}
+  dynamic.linux-mxlarge-arm64.check-interval: {{ (index $config "check-interval") | default "60" | quote }}
+  dynamic.linux-mxlarge-arm64.allocation-timeout: "1200"
+  {{ end }}
+
+  {{- if hasKey .Values.dynamicConfigs "linux-mxlarge-amd64" }}
+  {{- $config := index .Values.dynamicConfigs "linux-mxlarge-amd64" | default (dict) }}
+  dynamic.linux-mxlarge-amd64.type: {{ index $config "type" | default "aws" | quote }}
+  dynamic.linux-mxlarge-amd64.region: {{ index $config "region" | default "us-east-1" | quote }}
+  dynamic.linux-mxlarge-amd64.ami: {{ default (index $amd "ami") $config.ami | quote }}
+  dynamic.linux-mxlarge-amd64.instance-type: {{ (index $config "instance-type") | default "m6a.xlarge" | quote }}
+  dynamic.linux-mxlarge-amd64.instance-tag: {{ (index $config "instance-tag") | default (printf "%s-amd64-mxlarge" $environment) | quote }}
+  dynamic.linux-mxlarge-amd64.key-name: {{ default (index $amd "key-name") ((index $config "key-name")) | quote }}
+  dynamic.linux-mxlarge-amd64.aws-secret: {{ (index $config "aws-secret") | default "aws-account" | quote }}
+  dynamic.linux-mxlarge-amd64.ssh-secret: {{ (index $config "ssh-secret") | default "aws-ssh-key" | quote }}
+  dynamic.linux-mxlarge-amd64.security-group-id: {{ default (index $amd "security-group-id") ((index $config "security-group-id")) | quote }}
+  dynamic.linux-mxlarge-amd64.max-instances: {{ (index $config "max-instances") | default "250" | quote }}
+  dynamic.linux-mxlarge-amd64.subnet-id: {{ default (index $amd "subnet-id") ((index $config "subnet-id")) | quote }}
+  dynamic.linux-mxlarge-amd64.check-interval: {{ (index $config "check-interval") | default "60" | quote }}
+  dynamic.linux-mxlarge-amd64.allocation-timeout: "1200"
+  {{ end }}
+
+  {{- if hasKey .Values.dynamicConfigs "linux-d160-mxlarge-arm64" }}
+  {{- $config := index .Values.dynamicConfigs "linux-d160-mxlarge-arm64" | default (dict) }}
+  dynamic.linux-d160-mxlarge-arm64.type: {{ index $config "type" | default "aws" | quote }}
+  dynamic.linux-d160-mxlarge-arm64.region: {{ index $config "region" | default "us-east-1" | quote }}
+  dynamic.linux-d160-mxlarge-arm64.ami: {{ default (index $arm "ami") $config.ami | quote }}
+  dynamic.linux-d160-mxlarge-arm64.instance-type: {{ (index $config "instance-type") | default "m6g.xlarge" | quote }}
+  dynamic.linux-d160-mxlarge-arm64.instance-tag: {{ (index $config "instance-tag") | default (printf "%s-arm64-mxlarge-d160" $environment) | quote }}
+  dynamic.linux-d160-mxlarge-arm64.key-name: {{ default (index $arm "key-name") ((index $config "key-name")) | quote }}
+  dynamic.linux-d160-mxlarge-arm64.aws-secret: {{ (index $config "aws-secret") | default "aws-account" | quote }}
+  dynamic.linux-d160-mxlarge-arm64.ssh-secret: {{ (index $config "ssh-secret") | default "aws-ssh-key" | quote }}
+  dynamic.linux-d160-mxlarge-arm64.security-group-id: {{ default (index $arm "security-group-id") ((index $config "security-group-id")) | quote }}
+  dynamic.linux-d160-mxlarge-arm64.max-instances: {{ (index $config "max-instances") | default "250" | quote }}
+  dynamic.linux-d160-mxlarge-arm64.subnet-id: {{ default (index $arm "subnet-id") ((index $config "subnet-id")) | quote }}
+  dynamic.linux-d160-mxlarge-arm64.check-interval: {{ (index $config "check-interval") | default "60" | quote }}
+  dynamic.linux-d160-mxlarge-arm64.disk: "160"
+  dynamic.linux-d160-mxlarge-arm64.allocation-timeout: "1200"
+  {{ end }}
+
+  {{- if hasKey .Values.dynamicConfigs "linux-d160-mxlarge-amd64" }}
+  {{- $config := index .Values.dynamicConfigs "linux-d160-mxlarge-amd64" | default (dict) }}
+  dynamic.linux-d160-mxlarge-amd64.type: {{ index $config "type" | default "aws" | quote }}
+  dynamic.linux-d160-mxlarge-amd64.region: {{ index $config "region" | default "us-east-1" | quote }}
+  dynamic.linux-d160-mxlarge-amd64.ami: {{ default (index $amd "ami") $config.ami | quote }}
+  dynamic.linux-d160-mxlarge-amd64.instance-type: {{ (index $config "instance-type") | default "m6a.xlarge" | quote }}
+  dynamic.linux-d160-mxlarge-amd64.instance-tag: {{ (index $config "instance-tag") | default (printf "%s-amd64-mxlarge-d160" $environment) | quote }}
+  dynamic.linux-d160-mxlarge-amd64.key-name: {{ default (index $amd "key-name") ((index $config "key-name")) | quote }}
+  dynamic.linux-d160-mxlarge-amd64.aws-secret: {{ (index $config "aws-secret") | default "aws-account" | quote }}
+  dynamic.linux-d160-mxlarge-amd64.ssh-secret: {{ (index $config "ssh-secret") | default "aws-ssh-key" | quote }}
+  dynamic.linux-d160-mxlarge-amd64.security-group-id: {{ default (index $amd "security-group-id") ((index $config "security-group-id")) | quote }}
+  dynamic.linux-d160-mxlarge-amd64.max-instances: {{ (index $config "max-instances") | default "250" | quote }}
+  dynamic.linux-d160-mxlarge-amd64.subnet-id: {{ default (index $amd "subnet-id") ((index $config "subnet-id")) | quote }}
+  dynamic.linux-d160-mxlarge-amd64.check-interval: {{ (index $config "check-interval") | default "60" | quote }}
+  dynamic.linux-d160-mxlarge-amd64.disk: "160"
+  dynamic.linux-d160-mxlarge-amd64.allocation-timeout: "1200"
+  {{ end }}
+
+  {{- if hasKey .Values.dynamicConfigs "linux-m2xlarge-arm64" }}
+  {{- $config := index .Values.dynamicConfigs "linux-m2xlarge-arm64" | default (dict) }}
+  dynamic.linux-m2xlarge-arm64.type: {{ index $config "type" | default "aws" | quote }}
+  dynamic.linux-m2xlarge-arm64.region: {{ index $config "region" | default "us-east-1" | quote }}
+  dynamic.linux-m2xlarge-arm64.ami: {{ default (index $arm "ami") $config.ami | quote }}
+  dynamic.linux-m2xlarge-arm64.instance-type: {{ (index $config "instance-type") | default "m6g.2xlarge" | quote }}
+  dynamic.linux-m2xlarge-arm64.instance-tag: {{ (index $config "instance-tag") | default (printf "%s-arm64-m2xlarge" $environment) | quote }}
+  dynamic.linux-m2xlarge-arm64.key-name: {{ default (index $arm "key-name") ((index $config "key-name")) | quote }}
+  dynamic.linux-m2xlarge-arm64.aws-secret: {{ (index $config "aws-secret") | default "aws-account" | quote }}
+  dynamic.linux-m2xlarge-arm64.ssh-secret: {{ (index $config "ssh-secret") | default "aws-ssh-key" | quote }}
+  dynamic.linux-m2xlarge-arm64.security-group-id: {{ default (index $arm "security-group-id") ((index $config "security-group-id")) | quote }}
+  dynamic.linux-m2xlarge-arm64.max-instances: {{ (index $config "max-instances") | default "250" | quote }}
+  dynamic.linux-m2xlarge-arm64.subnet-id: {{ default (index $arm "subnet-id") ((index $config "subnet-id")) | quote }}
+  dynamic.linux-m2xlarge-arm64.check-interval: {{ (index $config "check-interval") | default "60" | quote }}
+  dynamic.linux-m2xlarge-arm64.allocation-timeout: "1200"
+  {{ end }}
+
+  {{- if hasKey .Values.dynamicConfigs "linux-m2xlarge-amd64" }}
+  {{- $config := index .Values.dynamicConfigs "linux-m2xlarge-amd64" | default (dict) }}
+  dynamic.linux-m2xlarge-amd64.type: {{ index $config "type" | default "aws" | quote }}
+  dynamic.linux-m2xlarge-amd64.region: {{ index $config "region" | default "us-east-1" | quote }}
+  dynamic.linux-m2xlarge-amd64.ami: {{ default (index $amd "ami") $config.ami | quote }}
+  dynamic.linux-m2xlarge-amd64.instance-type: {{ (index $config "instance-type") | default "m6a.2xlarge" | quote }}
+  dynamic.linux-m2xlarge-amd64.instance-tag: {{ (index $config "instance-tag") | default (printf "%s-amd64-m2xlarge" $environment) | quote }}
+  dynamic.linux-m2xlarge-amd64.key-name: {{ default (index $amd "key-name") ((index $config "key-name")) | quote }}
+  dynamic.linux-m2xlarge-amd64.aws-secret: {{ (index $config "aws-secret") | default "aws-account" | quote }}
+  dynamic.linux-m2xlarge-amd64.ssh-secret: {{ (index $config "ssh-secret") | default "aws-ssh-key" | quote }}
+  dynamic.linux-m2xlarge-amd64.security-group-id: {{ default (index $amd "security-group-id") ((index $config "security-group-id")) | quote }}
+  dynamic.linux-m2xlarge-amd64.max-instances: {{ (index $config "max-instances") | default "250" | quote }}
+  dynamic.linux-m2xlarge-amd64.subnet-id: {{ default (index $amd "subnet-id") ((index $config "subnet-id")) | quote }}
+  dynamic.linux-m2xlarge-amd64.check-interval: {{ (index $config "check-interval") | default "60" | quote }}
+  dynamic.linux-m2xlarge-amd64.allocation-timeout: "1200"
+  {{ end }}
+
+  {{- if hasKey .Values.dynamicConfigs "linux-d160-m2xlarge-arm64" }}
+  {{- $config := index .Values.dynamicConfigs "linux-d160-m2xlarge-arm64" | default (dict) }}
+  dynamic.linux-d160-m2xlarge-arm64.type: {{ index $config "type" | default "aws" | quote }}
+  dynamic.linux-d160-m2xlarge-arm64.region: {{ index $config "region" | default "us-east-1" | quote }}
+  dynamic.linux-d160-m2xlarge-arm64.ami: {{ default (index $arm "ami") $config.ami | quote }}
+  dynamic.linux-d160-m2xlarge-arm64.instance-type: {{ (index $config "instance-type") | default "m6g.2xlarge" | quote }}
+  dynamic.linux-d160-m2xlarge-arm64.instance-tag: {{ (index $config "instance-tag") | default (printf "%s-arm64-m2xlarge-d160" $environment) | quote }}
+  dynamic.linux-d160-m2xlarge-arm64.key-name: {{ default (index $arm "key-name") ((index $config "key-name")) | quote }}
+  dynamic.linux-d160-m2xlarge-arm64.aws-secret: {{ (index $config "aws-secret") | default "aws-account" | quote }}
+  dynamic.linux-d160-m2xlarge-arm64.ssh-secret: {{ (index $config "ssh-secret") | default "aws-ssh-key" | quote }}
+  dynamic.linux-d160-m2xlarge-arm64.security-group-id: {{ default (index $arm "security-group-id") ((index $config "security-group-id")) | quote }}
+  dynamic.linux-d160-m2xlarge-arm64.max-instances: {{ (index $config "max-instances") | default "250" | quote }}
+  dynamic.linux-d160-m2xlarge-arm64.subnet-id: {{ default (index $arm "subnet-id") ((index $config "subnet-id")) | quote }}
+  dynamic.linux-d160-m2xlarge-arm64.check-interval: {{ (index $config "check-interval") | default "60" | quote }}
+  dynamic.linux-d160-m2xlarge-arm64.disk: "160"
+  dynamic.linux-d160-m2xlarge-arm64.allocation-timeout: "1200"
+  {{ end }}
+
+  {{- if hasKey .Values.dynamicConfigs "linux-d160-m2xlarge-amd64" }}
+  {{- $config := index .Values.dynamicConfigs "linux-d160-m2xlarge-amd64" | default (dict) }}
+  dynamic.linux-d160-m2xlarge-amd64.type: {{ index $config "type" | default "aws" | quote }}
+  dynamic.linux-d160-m2xlarge-amd64.region: {{ index $config "region" | default "us-east-1" | quote }}
+  dynamic.linux-d160-m2xlarge-amd64.ami: {{ default (index $amd "ami") $config.ami | quote }}
+  dynamic.linux-d160-m2xlarge-amd64.instance-type: {{ (index $config "instance-type") | default "m6a.2xlarge" | quote }}
+  dynamic.linux-d160-m2xlarge-amd64.instance-tag: {{ (index $config "instance-tag") | default (printf "%s-amd64-m2xlarge-d160" $environment) | quote }}
+  dynamic.linux-d160-m2xlarge-amd64.key-name: {{ default (index $amd "key-name") ((index $config "key-name")) | quote }}
+  dynamic.linux-d160-m2xlarge-amd64.aws-secret: {{ (index $config "aws-secret") | default "aws-account" | quote }}
+  dynamic.linux-d160-m2xlarge-amd64.ssh-secret: {{ (index $config "ssh-secret") | default "aws-ssh-key" | quote }}
+  dynamic.linux-d160-m2xlarge-amd64.security-group-id: {{ default (index $amd "security-group-id") ((index $config "security-group-id")) | quote }}
+  dynamic.linux-d160-m2xlarge-amd64.max-instances: {{ (index $config "max-instances") | default "250" | quote }}
+  dynamic.linux-d160-m2xlarge-amd64.subnet-id: {{ default (index $amd "subnet-id") ((index $config "subnet-id")) | quote }}
+  dynamic.linux-d160-m2xlarge-amd64.check-interval: {{ (index $config "check-interval") | default "60" | quote }}
+  dynamic.linux-d160-m2xlarge-amd64.disk: "160"
+  dynamic.linux-d160-m2xlarge-amd64.allocation-timeout: "1200"
+  {{ end }}
+
+  {{- if hasKey .Values.dynamicConfigs "linux-m4xlarge-arm64" }}
+  {{- $config := index .Values.dynamicConfigs "linux-m4xlarge-arm64" | default (dict) }}
+  dynamic.linux-m4xlarge-arm64.type: {{ index $config "type" | default "aws" | quote }}
+  dynamic.linux-m4xlarge-arm64.region: {{ index $config "region" | default "us-east-1" | quote }}
+  dynamic.linux-m4xlarge-arm64.ami: {{ default (index $arm "ami") $config.ami | quote }}
+  dynamic.linux-m4xlarge-arm64.instance-type: {{ (index $config "instance-type") | default "m6g.4xlarge" | quote }}
+  dynamic.linux-m4xlarge-arm64.instance-tag: {{ (index $config "instance-tag") | default (printf "%s-arm64-m4xlarge" $environment) | quote }}
+  dynamic.linux-m4xlarge-arm64.key-name: {{ default (index $arm "key-name") ((index $config "key-name")) | quote }}
+  dynamic.linux-m4xlarge-arm64.aws-secret: {{ (index $config "aws-secret") | default "aws-account" | quote }}
+  dynamic.linux-m4xlarge-arm64.ssh-secret: {{ (index $config "ssh-secret") | default "aws-ssh-key" | quote }}
+  dynamic.linux-m4xlarge-arm64.security-group-id: {{ default (index $arm "security-group-id") ((index $config "security-group-id")) | quote }}
+  dynamic.linux-m4xlarge-arm64.max-instances: {{ (index $config "max-instances") | default "250" | quote }}
+  dynamic.linux-m4xlarge-arm64.subnet-id: {{ default (index $arm "subnet-id") ((index $config "subnet-id")) | quote }}
+  dynamic.linux-m4xlarge-arm64.check-interval: {{ (index $config "check-interval") | default "60" | quote }}
+  dynamic.linux-m4xlarge-arm64.allocation-timeout: "1200"
+  {{ end }}
+
+  {{- if hasKey .Values.dynamicConfigs "linux-m4xlarge-amd64" }}
+  {{- $config := index .Values.dynamicConfigs "linux-m4xlarge-amd64" | default (dict) }}
+  dynamic.linux-m4xlarge-amd64.type: {{ index $config "type" | default "aws" | quote }}
+  dynamic.linux-m4xlarge-amd64.region: {{ index $config "region" | default "us-east-1" | quote }}
+  dynamic.linux-m4xlarge-amd64.ami: {{ default (index $amd "ami") $config.ami | quote }}
+  dynamic.linux-m4xlarge-amd64.instance-type: {{ (index $config "instance-type") | default "m6a.4xlarge" | quote }}
+  dynamic.linux-m4xlarge-amd64.instance-tag: {{ (index $config "instance-tag") | default (printf "%s-amd64-m4xlarge" $environment) | quote }}
+  dynamic.linux-m4xlarge-amd64.key-name: {{ default (index $amd "key-name") ((index $config "key-name")) | quote }}
+  dynamic.linux-m4xlarge-amd64.aws-secret: {{ (index $config "aws-secret") | default "aws-account" | quote }}
+  dynamic.linux-m4xlarge-amd64.ssh-secret: {{ (index $config "ssh-secret") | default "aws-ssh-key" | quote }}
+  dynamic.linux-m4xlarge-amd64.security-group-id: {{ default (index $amd "security-group-id") ((index $config "security-group-id")) | quote }}
+  dynamic.linux-m4xlarge-amd64.max-instances: {{ (index $config "max-instances") | default "250" | quote }}
+  dynamic.linux-m4xlarge-amd64.subnet-id: {{ default (index $amd "subnet-id") ((index $config "subnet-id")) | quote }}
+  dynamic.linux-m4xlarge-amd64.check-interval: {{ (index $config "check-interval") | default "60" | quote }}
+  dynamic.linux-m4xlarge-amd64.allocation-timeout: "1200"
+  {{ end }}
+
+  {{- if hasKey .Values.dynamicConfigs "linux-d160-m4xlarge-arm64" }}
+  {{- $config := index .Values.dynamicConfigs "linux-d160-m4xlarge-arm64" | default (dict) }}
+  dynamic.linux-d160-m4xlarge-arm64.type: {{ index $config "type" | default "aws" | quote }}
+  dynamic.linux-d160-m4xlarge-arm64.region: {{ index $config "region" | default "us-east-1" | quote }}
+  dynamic.linux-d160-m4xlarge-arm64.ami: {{ default (index $arm "ami") $config.ami | quote }}
+  dynamic.linux-d160-m4xlarge-arm64.instance-type: {{ (index $config "instance-type") | default "m6g.4xlarge" | quote }}
+  dynamic.linux-d160-m4xlarge-arm64.instance-tag: {{ (index $config "instance-tag") | default (printf "%s-arm64-m4xlarge-d160" $environment) | quote }}
+  dynamic.linux-d160-m4xlarge-arm64.key-name: {{ default (index $arm "key-name") ((index $config "key-name")) | quote }}
+  dynamic.linux-d160-m4xlarge-arm64.aws-secret: {{ (index $config "aws-secret") | default "aws-account" | quote }}
+  dynamic.linux-d160-m4xlarge-arm64.ssh-secret: {{ (index $config "ssh-secret") | default "aws-ssh-key" | quote }}
+  dynamic.linux-d160-m4xlarge-arm64.security-group-id: {{ default (index $arm "security-group-id") ((index $config "security-group-id")) | quote }}
+  dynamic.linux-d160-m4xlarge-arm64.max-instances: {{ (index $config "max-instances") | default "250" | quote }}
+  dynamic.linux-d160-m4xlarge-arm64.subnet-id: {{ default (index $arm "subnet-id") ((index $config "subnet-id")) | quote }}
+  dynamic.linux-d160-m4xlarge-arm64.check-interval: {{ (index $config "check-interval") | default "60" | quote }}
+  dynamic.linux-d160-m4xlarge-arm64.disk: "160"
+  dynamic.linux-d160-m4xlarge-arm64.allocation-timeout: "1200"
+  {{ end }}
+
+  {{- if hasKey .Values.dynamicConfigs "linux-d160-m4xlarge-amd64" }}
+  {{- $config := index .Values.dynamicConfigs "linux-d160-m4xlarge-amd64" | default (dict) }}
+  dynamic.linux-d160-m4xlarge-amd64.type: {{ index $config "type" | default "aws" | quote }}
+  dynamic.linux-d160-m4xlarge-amd64.region: {{ index $config "region" | default "us-east-1" | quote }}
+  dynamic.linux-d160-m4xlarge-amd64.ami: {{ default (index $amd "ami") $config.ami | quote }}
+  dynamic.linux-d160-m4xlarge-amd64.instance-type: {{ (index $config "instance-type") | default "m6a.4xlarge" | quote }}
+  dynamic.linux-d160-m4xlarge-amd64.instance-tag: {{ (index $config "instance-tag") | default (printf "%s-amd64-m4xlarge-d160" $environment) | quote }}
+  dynamic.linux-d160-m4xlarge-amd64.key-name: {{ default (index $amd "key-name") ((index $config "key-name")) | quote }}
+  dynamic.linux-d160-m4xlarge-amd64.aws-secret: {{ (index $config "aws-secret") | default "aws-account" | quote }}
+  dynamic.linux-d160-m4xlarge-amd64.ssh-secret: {{ (index $config "ssh-secret") | default "aws-ssh-key" | quote }}
+  dynamic.linux-d160-m4xlarge-amd64.security-group-id: {{ default (index $amd "security-group-id") ((index $config "security-group-id")) | quote }}
+  dynamic.linux-d160-m4xlarge-amd64.max-instances: {{ (index $config "max-instances") | default "250" | quote }}
+  dynamic.linux-d160-m4xlarge-amd64.subnet-id: {{ default (index $amd "subnet-id") ((index $config "subnet-id")) | quote }}
+  dynamic.linux-d160-m4xlarge-amd64.check-interval: {{ (index $config "check-interval") | default "60" | quote }}
+  dynamic.linux-d160-m4xlarge-amd64.disk: "160"
+  dynamic.linux-d160-m4xlarge-amd64.allocation-timeout: "1200"
+  {{ end }}
+
+  {{- if hasKey .Values.dynamicConfigs "linux-m8xlarge-arm64" }}
+  {{- $config := index .Values.dynamicConfigs "linux-m8xlarge-arm64" | default (dict) }}
+  dynamic.linux-m8xlarge-arm64.type: {{ index $config "type" | default "aws" | quote }}
+  dynamic.linux-m8xlarge-arm64.region: {{ index $config "region" | default "us-east-1" | quote }}
+  dynamic.linux-m8xlarge-arm64.ami: {{ default (index $arm "ami") $config.ami | quote }}
+  dynamic.linux-m8xlarge-arm64.instance-type: {{ (index $config "instance-type") | default "m6g.8xlarge" | quote }}
+  dynamic.linux-m8xlarge-arm64.instance-tag: {{ (index $config "instance-tag") | default (printf "%s-arm64-m8xlarge" $environment) | quote }}
+  dynamic.linux-m8xlarge-arm64.key-name: {{ default (index $arm "key-name") ((index $config "key-name")) | quote }}
+  dynamic.linux-m8xlarge-arm64.aws-secret: {{ (index $config "aws-secret") | default "aws-account" | quote }}
+  dynamic.linux-m8xlarge-arm64.ssh-secret: {{ (index $config "ssh-secret") | default "aws-ssh-key" | quote }}
+  dynamic.linux-m8xlarge-arm64.security-group-id: {{ default (index $arm "security-group-id") ((index $config "security-group-id")) | quote }}
+  dynamic.linux-m8xlarge-arm64.max-instances: {{ (index $config "max-instances") | default "250" | quote }}
+  dynamic.linux-m8xlarge-arm64.subnet-id: {{ default (index $arm "subnet-id") ((index $config "subnet-id")) | quote }}
+  dynamic.linux-m8xlarge-arm64.check-interval: {{ (index $config "check-interval") | default "60" | quote }}
+  dynamic.linux-m8xlarge-arm64.allocation-timeout: "1200"
+  {{ end }}
+
+  {{- if hasKey .Values.dynamicConfigs "linux-m8xlarge-amd64" }}
+  {{- $config := index .Values.dynamicConfigs "linux-m8xlarge-amd64" | default (dict) }}
+  dynamic.linux-m8xlarge-amd64.type: {{ index $config "type" | default "aws" | quote }}
+  dynamic.linux-m8xlarge-amd64.region: {{ index $config "region" | default "us-east-1" | quote }}
+  dynamic.linux-m8xlarge-amd64.ami: {{ default (index $amd "ami") $config.ami | quote }}
+  dynamic.linux-m8xlarge-amd64.instance-type: {{ (index $config "instance-type") | default "m6a.8xlarge" | quote }}
+  dynamic.linux-m8xlarge-amd64.instance-tag: {{ (index $config "instance-tag") | default (printf "%s-amd64-m8xlarge" $environment) | quote }}
+  dynamic.linux-m8xlarge-amd64.key-name: {{ default (index $amd "key-name") ((index $config "key-name")) | quote }}
+  dynamic.linux-m8xlarge-amd64.aws-secret: {{ (index $config "aws-secret") | default "aws-account" | quote }}
+  dynamic.linux-m8xlarge-amd64.ssh-secret: {{ (index $config "ssh-secret") | default "aws-ssh-key" | quote }}
+  dynamic.linux-m8xlarge-amd64.security-group-id: {{ default (index $amd "security-group-id") ((index $config "security-group-id")) | quote }}
+  dynamic.linux-m8xlarge-amd64.max-instances: {{ (index $config "max-instances") | default "250" | quote }}
+  dynamic.linux-m8xlarge-amd64.subnet-id: {{ default (index $amd "subnet-id") ((index $config "subnet-id")) | quote }}
+  dynamic.linux-m8xlarge-amd64.check-interval: {{ (index $config "check-interval") | default "60" | quote }}
+  dynamic.linux-m8xlarge-amd64.allocation-timeout: "1200"
+  {{ end }}
+
+  {{- if hasKey .Values.dynamicConfigs "linux-d160-m7-8xlarge-amd64" }}
+  {{- $config := index .Values.dynamicConfigs "linux-d160-m7-8xlarge-amd64" | default (dict) }}
+  dynamic.linux-d160-m7-8xlarge-amd64.type: {{ index $config "type" | default "aws" | quote }}
+  dynamic.linux-d160-m7-8xlarge-amd64.region: {{ index $config "region" | default "us-east-1" | quote }}
+  dynamic.linux-d160-m7-8xlarge-amd64.ami: {{ default (index $amd "ami") $config.ami | quote }}
+  dynamic.linux-d160-m7-8xlarge-amd64.instance-type: {{ (index $config "instance-type") | default "m7a.8xlarge" | quote }}
+  dynamic.linux-d160-m7-8xlarge-amd64.instance-tag: {{ (index $config "instance-tag") | default (printf "%s-amd64-m7-8xlarge-d160" $environment) | quote }}
+  dynamic.linux-d160-m7-8xlarge-amd64.key-name: {{ default (index $amd "key-name") ((index $config "key-name")) | quote }}
+  dynamic.linux-d160-m7-8xlarge-amd64.aws-secret: {{ (index $config "aws-secret") | default "aws-account" | quote }}
+  dynamic.linux-d160-m7-8xlarge-amd64.ssh-secret: {{ (index $config "ssh-secret") | default "aws-ssh-key" | quote }}
+  dynamic.linux-d160-m7-8xlarge-amd64.security-group-id: {{ default (index $amd "security-group-id") ((index $config "security-group-id")) | quote }}
+  dynamic.linux-d160-m7-8xlarge-amd64.max-instances: {{ (index $config "max-instances") | default "250" | quote }}
+  dynamic.linux-d160-m7-8xlarge-amd64.subnet-id: {{ default (index $amd "subnet-id") ((index $config "subnet-id")) | quote }}
+  dynamic.linux-d160-m7-8xlarge-amd64.check-interval: {{ (index $config "check-interval") | default "60" | quote }}
+  dynamic.linux-d160-m7-8xlarge-amd64.disk: "160"
+  dynamic.linux-d160-m7-8xlarge-amd64.allocation-timeout: "1200"
+  {{ end }}
+
+  {{- if hasKey .Values.dynamicConfigs "linux-d160-m8-8xlarge-arm64" }}
+  {{- $config := index .Values.dynamicConfigs "linux-d160-m8-8xlarge-arm64" | default (dict) }}
+  dynamic.linux-d160-m8-8xlarge-arm64.type: {{ index $config "type" | default "aws" | quote }}
+  dynamic.linux-d160-m8-8xlarge-arm64.region: {{ index $config "region" | default "us-east-1" | quote }}
+  dynamic.linux-d160-m8-8xlarge-arm64.ami: {{ default (index $arm "ami") $config.ami | quote }}
+  dynamic.linux-d160-m8-8xlarge-arm64.instance-type: {{ (index $config "instance-type") | default "m8g.8xlarge" | quote }}
+  dynamic.linux-d160-m8-8xlarge-arm64.instance-tag: {{ (index $config "instance-tag") | default (printf "%s-arm64-m8-8xlarge-d160" $environment) | quote }}
+  dynamic.linux-d160-m8-8xlarge-arm64.key-name: {{ default (index $arm "key-name") ((index $config "key-name")) | quote }}
+  dynamic.linux-d160-m8-8xlarge-arm64.aws-secret: {{ (index $config "aws-secret") | default "aws-account" | quote }}
+  dynamic.linux-d160-m8-8xlarge-arm64.ssh-secret: {{ (index $config "ssh-secret") | default "aws-ssh-key" | quote }}
+  dynamic.linux-d160-m8-8xlarge-arm64.security-group-id: {{ default (index $arm "security-group-id") ((index $config "security-group-id")) | quote }}
+  dynamic.linux-d160-m8-8xlarge-arm64.max-instances: {{ (index $config "max-instances") | default "250" | quote }}
+  dynamic.linux-d160-m8-8xlarge-arm64.subnet-id: {{ default (index $arm "subnet-id") ((index $config "subnet-id")) | quote }}
+  dynamic.linux-d160-m8-8xlarge-arm64.check-interval: {{ (index $config "check-interval") | default "60" | quote }}
+  dynamic.linux-d160-m8-8xlarge-arm64.disk: "160"
+  dynamic.linux-d160-m8-8xlarge-arm64.allocation-timeout: "1200"
+  {{ end }}
+
+
+  {{- if hasKey .Values.dynamicConfigs "linux-d160-m8xlarge-arm64" }}
+  {{- $config := index .Values.dynamicConfigs "linux-d160-m8xlarge-arm64" | default (dict) }}
+  dynamic.linux-d160-m8xlarge-arm64.type: {{ index $config "type" | default "aws" | quote }}
+  dynamic.linux-d160-m8xlarge-arm64.region: {{ index $config "region" | default "us-east-1" | quote }}
+  dynamic.linux-d160-m8xlarge-arm64.ami: {{ default (index $arm "ami") $config.ami | quote }}
+  dynamic.linux-d160-m8xlarge-arm64.instance-type: {{ (index $config "instance-type") | default "m6g.8xlarge" | quote }}
+  dynamic.linux-d160-m8xlarge-arm64.instance-tag: {{ (index $config "instance-tag") | default (printf "%s-arm64-m8xlarge-d160" $environment) | quote }}
+  dynamic.linux-d160-m8xlarge-arm64.key-name: {{ default (index $arm "key-name") ((index $config "key-name")) | quote }}
+  dynamic.linux-d160-m8xlarge-arm64.aws-secret: {{ (index $config "aws-secret") | default "aws-account" | quote }}
+  dynamic.linux-d160-m8xlarge-arm64.ssh-secret: {{ (index $config "ssh-secret") | default "aws-ssh-key" | quote }}
+  dynamic.linux-d160-m8xlarge-arm64.security-group-id: {{ default (index $arm "security-group-id") ((index $config "security-group-id")) | quote }}
+  dynamic.linux-d160-m8xlarge-arm64.max-instances: {{ (index $config "max-instances") | default "250" | quote }}
+  dynamic.linux-d160-m8xlarge-arm64.subnet-id: {{ default (index $arm "subnet-id") ((index $config "subnet-id")) | quote }}
+  dynamic.linux-d160-m8xlarge-arm64.check-interval: {{ (index $config "check-interval") | default "60" | quote }}
+  dynamic.linux-d160-m8xlarge-arm64.disk: "160"
+  dynamic.linux-d160-m8xlarge-arm64.allocation-timeout: "1200"
+  {{ end }}
+
+  {{- if hasKey .Values.dynamicConfigs "linux-d160-m8xlarge-amd64" }}
+  {{- $config := index .Values.dynamicConfigs "linux-d160-m8xlarge-amd64" | default (dict) }}
+  dynamic.linux-d160-m8xlarge-amd64.type: {{ index $config "type" | default "aws" | quote }}
+  dynamic.linux-d160-m8xlarge-amd64.region: {{ index $config "region" | default "us-east-1" | quote }}
+  dynamic.linux-d160-m8xlarge-amd64.ami: {{ default (index $amd "ami") $config.ami | quote }}
+  dynamic.linux-d160-m8xlarge-amd64.instance-type: {{ (index $config "instance-type") | default "m6a.8xlarge" | quote }}
+  dynamic.linux-d160-m8xlarge-amd64.instance-tag: {{ (index $config "instance-tag") | default (printf "%s-amd64-m8xlarge-d160" $environment) | quote }}
+  dynamic.linux-d160-m8xlarge-amd64.key-name: {{ default (index $amd "key-name") ((index $config "key-name")) | quote }}
+  dynamic.linux-d160-m8xlarge-amd64.aws-secret: {{ (index $config "aws-secret") | default "aws-account" | quote }}
+  dynamic.linux-d160-m8xlarge-amd64.ssh-secret: {{ (index $config "ssh-secret") | default "aws-ssh-key" | quote }}
+  dynamic.linux-d160-m8xlarge-amd64.security-group-id: {{ default (index $amd "security-group-id") ((index $config "security-group-id")) | quote }}
+  dynamic.linux-d160-m8xlarge-amd64.max-instances: {{ (index $config "max-instances") | default "250" | quote }}
+  dynamic.linux-d160-m8xlarge-amd64.subnet-id: {{ default (index $amd "subnet-id") ((index $config "subnet-id")) | quote }}
+  dynamic.linux-d160-m8xlarge-amd64.check-interval: {{ (index $config "check-interval") | default "60" | quote }}
+  dynamic.linux-d160-m8xlarge-amd64.disk: "160"
+  dynamic.linux-d160-m8xlarge-amd64.allocation-timeout: "1200"
+  {{ end }}
+
+  {{- if hasKey .Values.dynamicConfigs "linux-c6gd2xlarge-arm64" }}
+  {{- $config := index .Values.dynamicConfigs "linux-c6gd2xlarge-arm64" | default (dict) }}
+  dynamic.linux-c6gd2xlarge-arm64.type: {{ index $config "type" | default "aws" | quote }}
+  dynamic.linux-c6gd2xlarge-arm64.region: {{ index $config "region" | default "us-east-1" | quote }}
+  dynamic.linux-c6gd2xlarge-arm64.ami: {{ default (index $arm "ami") $config.ami | quote }}
+  dynamic.linux-c6gd2xlarge-arm64.instance-type: {{ (index $config "instance-type") | default "c6gd.2xlarge" | quote }}
+  dynamic.linux-c6gd2xlarge-arm64.instance-tag: {{ (index $config "instance-tag") | default (printf "%s-arm64-c6gd2xlarge" $environment) | quote }}
+  dynamic.linux-c6gd2xlarge-arm64.key-name: {{ default (index $arm "key-name") ((index $config "key-name")) | quote }}
+  dynamic.linux-c6gd2xlarge-arm64.aws-secret: {{ (index $config "aws-secret") | default "aws-account" | quote }}
+  dynamic.linux-c6gd2xlarge-arm64.ssh-secret: {{ (index $config "ssh-secret") | default "aws-ssh-key" | quote }}
+  dynamic.linux-c6gd2xlarge-arm64.security-group-id: {{ default (index $arm "security-group-id") ((index $config "security-group-id")) | quote }}
+  dynamic.linux-c6gd2xlarge-arm64.max-instances: {{ (index $config "max-instances") | default "250" | quote }}
+  dynamic.linux-c6gd2xlarge-arm64.subnet-id: {{ default (index $arm "subnet-id") ((index $config "subnet-id")) | quote }}
+  dynamic.linux-c6gd2xlarge-arm64.check-interval: {{ (index $config "check-interval") | default "60" | quote }}
+  dynamic.linux-c6gd2xlarge-arm64.allocation-timeout: "1200"
+  {{- if or (index $config "user-data") (.Files.Get "files/linux-c6gd2xlarge-arm64-init.sh") }}
+  dynamic.linux-c6gd2xlarge-arm64.user-data: |
+  {{- if (index $config "user-data") }}
+  {{- $lines := splitList "\n" (index $config "user-data") }}
+  {{- range $line := $lines }}
+    {{ $line }}
+  {{- end }}
+  {{- else }}
+{{ include "multi-platform-controller.cloud-init-userdata" (.Files.Get "files/linux-c6gd2xlarge-arm64-init.sh") | indent 4 }}
+  {{- end }}
+  {{- end }}
+  {{ end }}
+
+  {{- if hasKey .Values.dynamicConfigs "linux-cxlarge-arm64" }}
+  {{- $config := index .Values.dynamicConfigs "linux-cxlarge-arm64" | default (dict) }}
+  dynamic.linux-cxlarge-arm64.type: {{ index $config "type" | default "aws" | quote }}
+  dynamic.linux-cxlarge-arm64.region: {{ index $config "region" | default "us-east-1" | quote }}
+  dynamic.linux-cxlarge-arm64.ami: {{ default (index $arm "ami") $config.ami | quote }}
+  dynamic.linux-cxlarge-arm64.instance-type: {{ (index $config "instance-type") | default "c6g.xlarge" | quote }}
+  dynamic.linux-cxlarge-arm64.instance-tag: {{ (index $config "instance-tag") | default (printf "%s-arm64-cxlarge" $environment) | quote }}
+  dynamic.linux-cxlarge-arm64.key-name: {{ default (index $arm "key-name") ((index $config "key-name")) | quote }}
+  dynamic.linux-cxlarge-arm64.aws-secret: {{ (index $config "aws-secret") | default "aws-account" | quote }}
+  dynamic.linux-cxlarge-arm64.ssh-secret: {{ (index $config "ssh-secret") | default "aws-ssh-key" | quote }}
+  dynamic.linux-cxlarge-arm64.security-group-id: {{ default (index $arm "security-group-id") ((index $config "security-group-id")) | quote }}
+  dynamic.linux-cxlarge-arm64.max-instances: {{ (index $config "max-instances") | default "250" | quote }}
+  dynamic.linux-cxlarge-arm64.subnet-id: {{ default (index $arm "subnet-id") ((index $config "subnet-id")) | quote }}
+  dynamic.linux-cxlarge-arm64.check-interval: {{ (index $config "check-interval") | default "60" | quote }}
+  dynamic.linux-cxlarge-arm64.allocation-timeout: "1200"
+  {{ end }}
+
+  {{- if hasKey .Values.dynamicConfigs "linux-cxlarge-amd64" }}
+  {{- $config := index .Values.dynamicConfigs "linux-cxlarge-amd64" | default (dict) }}
+  dynamic.linux-cxlarge-amd64.type: {{ index $config "type" | default "aws" | quote }}
+  dynamic.linux-cxlarge-amd64.region: {{ index $config "region" | default "us-east-1" | quote }}
+  dynamic.linux-cxlarge-amd64.ami: {{ default (index $amd "ami") $config.ami | quote }}
+  dynamic.linux-cxlarge-amd64.instance-type: {{ (index $config "instance-type") | default "c6a.xlarge" | quote }}
+  dynamic.linux-cxlarge-amd64.instance-tag: {{ (index $config "instance-tag") | default (printf "%s-amd64-cxlarge" $environment) | quote }}
+  dynamic.linux-cxlarge-amd64.key-name: {{ default (index $amd "key-name") ((index $config "key-name")) | quote }}
+  dynamic.linux-cxlarge-amd64.aws-secret: {{ (index $config "aws-secret") | default "aws-account" | quote }}
+  dynamic.linux-cxlarge-amd64.ssh-secret: {{ (index $config "ssh-secret") | default "aws-ssh-key" | quote }}
+  dynamic.linux-cxlarge-amd64.security-group-id: {{ default (index $amd "security-group-id") ((index $config "security-group-id")) | quote }}
+  dynamic.linux-cxlarge-amd64.max-instances: {{ (index $config "max-instances") | default "250" | quote }}
+  dynamic.linux-cxlarge-amd64.subnet-id: {{ default (index $amd "subnet-id") ((index $config "subnet-id")) | quote }}
+  dynamic.linux-cxlarge-amd64.check-interval: {{ (index $config "check-interval") | default "60" | quote }}
+  dynamic.linux-cxlarge-amd64.allocation-timeout: "1200"
+  {{ end }}
+
+  {{- if hasKey .Values.dynamicConfigs "linux-d160-cxlarge-arm64" }}
+  {{- $config := index .Values.dynamicConfigs "linux-d160-cxlarge-arm64" | default (dict) }}
+  dynamic.linux-d160-cxlarge-arm64.type: {{ index $config "type" | default "aws" | quote }}
+  dynamic.linux-d160-cxlarge-arm64.region: {{ index $config "region" | default "us-east-1" | quote }}
+  dynamic.linux-d160-cxlarge-arm64.ami: {{ default (index $arm "ami") $config.ami | quote }}
+  dynamic.linux-d160-cxlarge-arm64.instance-type: {{ (index $config "instance-type") | default "c6g.xlarge" | quote }}
+  dynamic.linux-d160-cxlarge-arm64.instance-tag: {{ (index $config "instance-tag") | default (printf "%s-arm64-cxlarge-d160" $environment) | quote }}
+  dynamic.linux-d160-cxlarge-arm64.key-name: {{ default (index $arm "key-name") ((index $config "key-name")) | quote }}
+  dynamic.linux-d160-cxlarge-arm64.aws-secret: {{ (index $config "aws-secret") | default "aws-account" | quote }}
+  dynamic.linux-d160-cxlarge-arm64.ssh-secret: {{ (index $config "ssh-secret") | default "aws-ssh-key" | quote }}
+  dynamic.linux-d160-cxlarge-arm64.security-group-id: {{ default (index $arm "security-group-id") ((index $config "security-group-id")) | quote }}
+  dynamic.linux-d160-cxlarge-arm64.max-instances: {{ (index $config "max-instances") | default "250" | quote }}
+  dynamic.linux-d160-cxlarge-arm64.subnet-id: {{ default (index $arm "subnet-id") ((index $config "subnet-id")) | quote }}
+  dynamic.linux-d160-cxlarge-arm64.check-interval: {{ (index $config "check-interval") | default "60" | quote }}
+  dynamic.linux-d160-cxlarge-arm64.disk: "160"
+  dynamic.linux-d160-cxlarge-arm64.allocation-timeout: "1200"
+  {{ end }}
+
+  {{- if hasKey .Values.dynamicConfigs "linux-d160-cxlarge-amd64" }}
+  {{- $config := index .Values.dynamicConfigs "linux-d160-cxlarge-amd64" | default (dict) }}
+  dynamic.linux-d160-cxlarge-amd64.type: {{ index $config "type" | default "aws" | quote }}
+  dynamic.linux-d160-cxlarge-amd64.region: {{ index $config "region" | default "us-east-1" | quote }}
+  dynamic.linux-d160-cxlarge-amd64.ami: {{ default (index $amd "ami") $config.ami | quote }}
+  dynamic.linux-d160-cxlarge-amd64.instance-type: {{ (index $config "instance-type") | default "c6a.xlarge" | quote }}
+  dynamic.linux-d160-cxlarge-amd64.instance-tag: {{ (index $config "instance-tag") | default (printf "%s-amd64-cxlarge-d160" $environment) | quote }}
+  dynamic.linux-d160-cxlarge-amd64.key-name: {{ default (index $amd "key-name") ((index $config "key-name")) | quote }}
+  dynamic.linux-d160-cxlarge-amd64.aws-secret: {{ (index $config "aws-secret") | default "aws-account" | quote }}
+  dynamic.linux-d160-cxlarge-amd64.ssh-secret: {{ (index $config "ssh-secret") | default "aws-ssh-key" | quote }}
+  dynamic.linux-d160-cxlarge-amd64.security-group-id: {{ default (index $amd "security-group-id") ((index $config "security-group-id")) | quote }}
+  dynamic.linux-d160-cxlarge-amd64.max-instances: {{ (index $config "max-instances") | default "250" | quote }}
+  dynamic.linux-d160-cxlarge-amd64.subnet-id: {{ default (index $amd "subnet-id") ((index $config "subnet-id")) | quote }}
+  dynamic.linux-d160-cxlarge-amd64.check-interval: {{ (index $config "check-interval") | default "60" | quote }}
+  dynamic.linux-d160-cxlarge-amd64.disk: "160"
+  dynamic.linux-d160-cxlarge-amd64.allocation-timeout: "1200"
+  {{ end }}
+
+  {{- if hasKey .Values.dynamicConfigs "linux-c2xlarge-arm64" }}
+  {{- $config := index .Values.dynamicConfigs "linux-c2xlarge-arm64" | default (dict) }}
+  dynamic.linux-c2xlarge-arm64.type: {{ index $config "type" | default "aws" | quote }}
+  dynamic.linux-c2xlarge-arm64.region: {{ index $config "region" | default "us-east-1" | quote }}
+  dynamic.linux-c2xlarge-arm64.ami: {{ default (index $arm "ami") $config.ami | quote }}
+  dynamic.linux-c2xlarge-arm64.instance-type: {{ (index $config "instance-type") | default "c6g.2xlarge" | quote }}
+  dynamic.linux-c2xlarge-arm64.instance-tag: {{ (index $config "instance-tag") | default (printf "%s-arm64-c2xlarge" $environment) | quote }}
+  dynamic.linux-c2xlarge-arm64.key-name: {{ default (index $arm "key-name") ((index $config "key-name")) | quote }}
+  dynamic.linux-c2xlarge-arm64.aws-secret: {{ (index $config "aws-secret") | default "aws-account" | quote }}
+  dynamic.linux-c2xlarge-arm64.ssh-secret: {{ (index $config "ssh-secret") | default "aws-ssh-key" | quote }}
+  dynamic.linux-c2xlarge-arm64.security-group-id: {{ default (index $arm "security-group-id") ((index $config "security-group-id")) | quote }}
+  dynamic.linux-c2xlarge-arm64.max-instances: {{ (index $config "max-instances") | default "250" | quote }}
+  dynamic.linux-c2xlarge-arm64.subnet-id: {{ default (index $arm "subnet-id") ((index $config "subnet-id")) | quote }}
+  dynamic.linux-c2xlarge-arm64.check-interval: {{ (index $config "check-interval") | default "60" | quote }}
+  dynamic.linux-c2xlarge-arm64.allocation-timeout: "1200"
+  {{ end }}
+
+  {{- if hasKey .Values.dynamicConfigs "linux-c2xlarge-amd64" }}
+  {{- $config := index .Values.dynamicConfigs "linux-c2xlarge-amd64" | default (dict) }}
+  dynamic.linux-c2xlarge-amd64.type: {{ index $config "type" | default "aws" | quote }}
+  dynamic.linux-c2xlarge-amd64.region: {{ index $config "region" | default "us-east-1" | quote }}
+  dynamic.linux-c2xlarge-amd64.ami: {{ default (index $amd "ami") $config.ami | quote }}
+  dynamic.linux-c2xlarge-amd64.instance-type: {{ (index $config "instance-type") | default "c6a.2xlarge" | quote }}
+  dynamic.linux-c2xlarge-amd64.instance-tag: {{ (index $config "instance-tag") | default (printf "%s-amd64-c2xlarge" $environment) | quote }}
+  dynamic.linux-c2xlarge-amd64.key-name: {{ default (index $amd "key-name") ((index $config "key-name")) | quote }}
+  dynamic.linux-c2xlarge-amd64.aws-secret: {{ (index $config "aws-secret") | default "aws-account" | quote }}
+  dynamic.linux-c2xlarge-amd64.ssh-secret: {{ (index $config "ssh-secret") | default "aws-ssh-key" | quote }}
+  dynamic.linux-c2xlarge-amd64.security-group-id: {{ default (index $amd "security-group-id") ((index $config "security-group-id")) | quote }}
+  dynamic.linux-c2xlarge-amd64.max-instances: {{ (index $config "max-instances") | default "250" | quote }}
+  dynamic.linux-c2xlarge-amd64.subnet-id: {{ default (index $amd "subnet-id") ((index $config "subnet-id")) | quote }}
+  dynamic.linux-c2xlarge-amd64.check-interval: {{ (index $config "check-interval") | default "60" | quote }}
+  dynamic.linux-c2xlarge-amd64.allocation-timeout: "1200"
+  {{ end }}
+
+  {{- if hasKey .Values.dynamicConfigs "linux-d160-c2xlarge-arm64" }}
+  {{- $config := index .Values.dynamicConfigs "linux-d160-c2xlarge-arm64" | default (dict) }}
+  dynamic.linux-d160-c2xlarge-arm64.type: {{ index $config "type" | default "aws" | quote }}
+  dynamic.linux-d160-c2xlarge-arm64.region: {{ index $config "region" | default "us-east-1" | quote }}
+  dynamic.linux-d160-c2xlarge-arm64.ami: {{ default (index $arm "ami") $config.ami | quote }}
+  dynamic.linux-d160-c2xlarge-arm64.instance-type: {{ (index $config "instance-type") | default "c6g.2xlarge" | quote }}
+  dynamic.linux-d160-c2xlarge-arm64.instance-tag: {{ (index $config "instance-tag") | default (printf "%s-arm64-c2xlarge-d160" $environment) | quote }}
+  dynamic.linux-d160-c2xlarge-arm64.key-name: {{ default (index $arm "key-name") ((index $config "key-name")) | quote }}
+  dynamic.linux-d160-c2xlarge-arm64.aws-secret: {{ (index $config "aws-secret") | default "aws-account" | quote }}
+  dynamic.linux-d160-c2xlarge-arm64.ssh-secret: {{ (index $config "ssh-secret") | default "aws-ssh-key" | quote }}
+  dynamic.linux-d160-c2xlarge-arm64.security-group-id: {{ default (index $arm "security-group-id") ((index $config "security-group-id")) | quote }}
+  dynamic.linux-d160-c2xlarge-arm64.max-instances: {{ (index $config "max-instances") | default "250" | quote }}
+  dynamic.linux-d160-c2xlarge-arm64.subnet-id: {{ default (index $arm "subnet-id") ((index $config "subnet-id")) | quote }}
+  dynamic.linux-d160-c2xlarge-arm64.check-interval: {{ (index $config "check-interval") | default "60" | quote }}
+  dynamic.linux-d160-c2xlarge-arm64.disk: "160"
+  dynamic.linux-d160-c2xlarge-arm64.allocation-timeout: "1200"
+  {{ end }}
+
+  {{- if hasKey .Values.dynamicConfigs "linux-d160-c2xlarge-amd64" }}
+  {{- $config := index .Values.dynamicConfigs "linux-d160-c2xlarge-amd64" | default (dict) }}
+  dynamic.linux-d160-c2xlarge-amd64.type: {{ index $config "type" | default "aws" | quote }}
+  dynamic.linux-d160-c2xlarge-amd64.region: {{ index $config "region" | default "us-east-1" | quote }}
+  dynamic.linux-d160-c2xlarge-amd64.ami: {{ default (index $amd "ami") $config.ami | quote }}
+  dynamic.linux-d160-c2xlarge-amd64.instance-type: {{ (index $config "instance-type") | default "c6a.2xlarge" | quote }}
+  dynamic.linux-d160-c2xlarge-amd64.instance-tag: {{ (index $config "instance-tag") | default (printf "%s-amd64-c2xlarge-d160" $environment) | quote }}
+  dynamic.linux-d160-c2xlarge-amd64.key-name: {{ default (index $amd "key-name") ((index $config "key-name")) | quote }}
+  dynamic.linux-d160-c2xlarge-amd64.aws-secret: {{ (index $config "aws-secret") | default "aws-account" | quote }}
+  dynamic.linux-d160-c2xlarge-amd64.ssh-secret: {{ (index $config "ssh-secret") | default "aws-ssh-key" | quote }}
+  dynamic.linux-d160-c2xlarge-amd64.security-group-id: {{ default (index $amd "security-group-id") ((index $config "security-group-id")) | quote }}
+  dynamic.linux-d160-c2xlarge-amd64.max-instances: {{ (index $config "max-instances") | default "250" | quote }}
+  dynamic.linux-d160-c2xlarge-amd64.subnet-id: {{ default (index $amd "subnet-id") ((index $config "subnet-id")) | quote }}
+  dynamic.linux-d160-c2xlarge-amd64.check-interval: {{ (index $config "check-interval") | default "60" | quote }}
+  dynamic.linux-d160-c2xlarge-amd64.disk: "160"
+  dynamic.linux-d160-c2xlarge-amd64.allocation-timeout: "1200"
+  {{ end }}
+
+  {{- if hasKey .Values.dynamicConfigs "linux-c4xlarge-arm64" }}
+  {{- $config := index .Values.dynamicConfigs "linux-c4xlarge-arm64" | default (dict) }}
+  dynamic.linux-c4xlarge-arm64.type: {{ index $config "type" | default "aws" | quote }}
+  dynamic.linux-c4xlarge-arm64.region: {{ index $config "region" | default "us-east-1" | quote }}
+  dynamic.linux-c4xlarge-arm64.ami: {{ default (index $arm "ami") $config.ami | quote }}
+  dynamic.linux-c4xlarge-arm64.instance-type: {{ (index $config "instance-type") | default "c6g.4xlarge" | quote }}
+  dynamic.linux-c4xlarge-arm64.instance-tag: {{ (index $config "instance-tag") | default (printf "%s-arm64-c4xlarge" $environment) | quote }}
+  dynamic.linux-c4xlarge-arm64.key-name: {{ default (index $arm "key-name") ((index $config "key-name")) | quote }}
+  dynamic.linux-c4xlarge-arm64.aws-secret: {{ (index $config "aws-secret") | default "aws-account" | quote }}
+  dynamic.linux-c4xlarge-arm64.ssh-secret: {{ (index $config "ssh-secret") | default "aws-ssh-key" | quote }}
+  dynamic.linux-c4xlarge-arm64.security-group-id: {{ default (index $arm "security-group-id") ((index $config "security-group-id")) | quote }}
+  dynamic.linux-c4xlarge-arm64.max-instances: {{ (index $config "max-instances") | default "250" | quote }}
+  dynamic.linux-c4xlarge-arm64.subnet-id: {{ default (index $arm "subnet-id") ((index $config "subnet-id")) | quote }}
+  dynamic.linux-c4xlarge-arm64.check-interval: {{ (index $config "check-interval") | default "60" | quote }}
+  dynamic.linux-c4xlarge-arm64.allocation-timeout: "1200"
+  {{ end }}
+
+  {{- if hasKey .Values.dynamicConfigs "linux-c4xlarge-amd64" }}
+  {{- $config := index .Values.dynamicConfigs "linux-c4xlarge-amd64" | default (dict) }}
+  dynamic.linux-c4xlarge-amd64.type: {{ index $config "type" | default "aws" | quote }}
+  dynamic.linux-c4xlarge-amd64.region: {{ index $config "region" | default "us-east-1" | quote }}
+  dynamic.linux-c4xlarge-amd64.ami: {{ default (index $amd "ami") $config.ami | quote }}
+  dynamic.linux-c4xlarge-amd64.instance-type:  {{ (index $config "instance-type") | default "c6a.4xlarge" | quote }}
+  dynamic.linux-c4xlarge-amd64.instance-tag: {{ (index $config "instance-tag") | default (printf "%s-amd64-c4xlarge" $environment) | quote }}
+  dynamic.linux-c4xlarge-amd64.key-name: {{ default (index $amd "key-name") ((index $config "key-name")) | quote }}
+  dynamic.linux-c4xlarge-amd64.aws-secret: {{ (index $config "aws-secret") | default "aws-account" | quote }}
+  dynamic.linux-c4xlarge-amd64.ssh-secret: {{ (index $config "ssh-secret") | default "aws-ssh-key" | quote }}
+  dynamic.linux-c4xlarge-amd64.security-group-id: {{ default (index $amd "security-group-id") ((index $config "security-group-id")) | quote }}
+  dynamic.linux-c4xlarge-amd64.max-instances: {{ (index $config "max-instances") | default "250" | quote }}
+  dynamic.linux-c4xlarge-amd64.subnet-id: {{ default (index $amd "subnet-id") ((index $config "subnet-id")) | quote }}
+  dynamic.linux-c4xlarge-amd64.check-interval: {{ (index $config "check-interval") | default "60" | quote }}
+  dynamic.linux-c4xlarge-amd64.allocation-timeout: "1200"
+  {{ end }}
+
+  {{- if hasKey .Values.dynamicConfigs "linux-d160-c4xlarge-arm64" }}
+  {{- $config := index .Values.dynamicConfigs "linux-d160-c4xlarge-arm64" | default (dict) }}
+  dynamic.linux-d160-c4xlarge-arm64.type: {{ index $config "type" | default "aws" | quote }}
+  dynamic.linux-d160-c4xlarge-arm64.region: {{ index $config "region" | default "us-east-1" | quote }}
+  dynamic.linux-d160-c4xlarge-arm64.ami: {{ default (index $arm "ami") $config.ami | quote }}
+  dynamic.linux-d160-c4xlarge-arm64.instance-type: {{ (index $config "instance-type") | default "c6g.4xlarge" | quote }}
+  dynamic.linux-d160-c4xlarge-arm64.instance-tag: {{ (index $config "instance-tag") | default (printf "%s-arm64-c4xlarge-d160" $environment) | quote }}
+  dynamic.linux-d160-c4xlarge-arm64.key-name: {{ default (index $arm "key-name") ((index $config "key-name")) | quote }}
+  dynamic.linux-d160-c4xlarge-arm64.aws-secret: {{ (index $config "aws-secret") | default "aws-account" | quote }}
+  dynamic.linux-d160-c4xlarge-arm64.ssh-secret: {{ (index $config "ssh-secret") | default "aws-ssh-key" | quote }}
+  dynamic.linux-d160-c4xlarge-arm64.security-group-id: {{ default (index $arm "security-group-id") ((index $config "security-group-id")) | quote }}
+  dynamic.linux-d160-c4xlarge-arm64.max-instances: {{ (index $config "max-instances") | default "250" | quote }}
+  dynamic.linux-d160-c4xlarge-arm64.subnet-id: {{ default (index $arm "subnet-id") ((index $config "subnet-id")) | quote }}
+  dynamic.linux-d160-c4xlarge-arm64.check-interval: {{ (index $config "check-interval") | default "60" | quote }}
+  dynamic.linux-d160-c4xlarge-arm64.disk: "160"
+  dynamic.linux-d160-c4xlarge-arm64.allocation-timeout: "1200"
+  {{ end }}
+
+  {{- if hasKey .Values.dynamicConfigs "linux-d160-c4xlarge-amd64" }}
+  {{- $config := index .Values.dynamicConfigs "linux-d160-c4xlarge-amd64" | default (dict) }}
+  dynamic.linux-d160-c4xlarge-amd64.type: {{ index $config "type" | default "aws" | quote }}
+  dynamic.linux-d160-c4xlarge-amd64.region: {{ index $config "region" | default "us-east-1" | quote }}
+  dynamic.linux-d160-c4xlarge-amd64.ami: {{ default (index $amd "ami") $config.ami | quote }}
+  dynamic.linux-d160-c4xlarge-amd64.instance-type: {{ (index $config "instance-type") | default "c6a.4xlarge" | quote }}
+  dynamic.linux-d160-c4xlarge-amd64.instance-tag: {{ (index $config "instance-tag") | default (printf "%s-amd64-c4xlarge-d160" $environment) | quote }}
+  dynamic.linux-d160-c4xlarge-amd64.key-name: {{ default (index $amd "key-name") ((index $config "key-name")) | quote }}
+  dynamic.linux-d160-c4xlarge-amd64.aws-secret: {{ (index $config "aws-secret") | default "aws-account" | quote }}
+  dynamic.linux-d160-c4xlarge-amd64.ssh-secret: {{ (index $config "ssh-secret") | default "aws-ssh-key" | quote }}
+  dynamic.linux-d160-c4xlarge-amd64.security-group-id: {{ default (index $amd "security-group-id") ((index $config "security-group-id")) | quote }}
+  dynamic.linux-d160-c4xlarge-amd64.max-instances: {{ (index $config "max-instances") | default "250" | quote }}
+  dynamic.linux-d160-c4xlarge-amd64.subnet-id: {{ default (index $amd "subnet-id") ((index $config "subnet-id")) | quote }}
+  dynamic.linux-d160-c4xlarge-amd64.check-interval: {{ (index $config "check-interval") | default "60" | quote }}
+  dynamic.linux-d160-c4xlarge-amd64.disk: "160"
+  dynamic.linux-d160-c4xlarge-amd64.allocation-timeout: "1200"
+  {{ end }}
+
+  {{- if hasKey .Values.dynamicConfigs "linux-d320-c4xlarge-arm64" }}
+  {{- $config := index .Values.dynamicConfigs "linux-d320-c4xlarge-arm64" | default (dict) }}
+  dynamic.linux-d320-c4xlarge-arm64.type: {{ index $config "type" | default "aws" | quote }}
+  dynamic.linux-d320-c4xlarge-arm64.region: {{ index $config "region" | default "us-east-1" | quote }}
+  dynamic.linux-d320-c4xlarge-arm64.ami: {{ default (index $arm "ami") $config.ami | quote }}
+  dynamic.linux-d320-c4xlarge-arm64.instance-type: {{ (index $config "instance-type") | default "c6g.4xlarge" | quote }}
+  dynamic.linux-d320-c4xlarge-arm64.instance-tag: {{ (index $config "instance-tag") | default (printf "%s-arm64-c4xlarge-d320" $environment) | quote }}
+  dynamic.linux-d320-c4xlarge-arm64.key-name: {{ default (index $arm "key-name") ((index $config "key-name")) | quote }}
+  dynamic.linux-d320-c4xlarge-arm64.aws-secret: {{ (index $config "aws-secret") | default "aws-account" | quote }}
+  dynamic.linux-d320-c4xlarge-arm64.ssh-secret: {{ (index $config "ssh-secret") | default "aws-ssh-key" | quote }}
+  dynamic.linux-d320-c4xlarge-arm64.security-group-id: {{ default (index $arm "security-group-id") ((index $config "security-group-id")) | quote }}
+  dynamic.linux-d320-c4xlarge-arm64.max-instances: {{ (index $config "max-instances") | default "250" | quote }}
+  dynamic.linux-d320-c4xlarge-arm64.subnet-id: {{ default (index $arm "subnet-id") ((index $config "subnet-id")) | quote }}
+  dynamic.linux-d320-c4xlarge-arm64.check-interval: {{ (index $config "check-interval") | default "60" | quote }}
+  dynamic.linux-d320-c4xlarge-arm64.disk: "320"
+  dynamic.linux-d320-c4xlarge-arm64.allocation-timeout: "1200"
+  {{ end }}
+
+  {{- if hasKey .Values.dynamicConfigs "linux-d320-c4xlarge-amd64" }}
+  {{- $config := index .Values.dynamicConfigs "linux-d320-c4xlarge-amd64" | default (dict) }}
+  dynamic.linux-d320-c4xlarge-amd64.type: {{ index $config "type" | default "aws" | quote }}
+  dynamic.linux-d320-c4xlarge-amd64.region: {{ index $config "region" | default "us-east-1" | quote }}
+  dynamic.linux-d320-c4xlarge-amd64.ami: {{ default (index $amd "ami") $config.ami | quote }}
+  dynamic.linux-d320-c4xlarge-amd64.instance-type: {{ (index $config "instance-type") | default "c6a.4xlarge" | quote }}
+  dynamic.linux-d320-c4xlarge-amd64.instance-tag: {{ (index $config "instance-tag") | default (printf "%s-amd64-c4xlarge-d320" $environment) | quote }}
+  dynamic.linux-d320-c4xlarge-amd64.key-name: {{ default (index $amd "key-name") ((index $config "key-name")) | quote }}
+  dynamic.linux-d320-c4xlarge-amd64.aws-secret: {{ (index $config "aws-secret") | default "aws-account" | quote }}
+  dynamic.linux-d320-c4xlarge-amd64.ssh-secret: {{ (index $config "ssh-secret") | default "aws-ssh-key" | quote }}
+  dynamic.linux-d320-c4xlarge-amd64.security-group-id: {{ default (index $amd "security-group-id") ((index $config "security-group-id")) | quote }}
+  dynamic.linux-d320-c4xlarge-amd64.max-instances: {{ (index $config "max-instances") | default "250" | quote }}
+  dynamic.linux-d320-c4xlarge-amd64.subnet-id: {{ default (index $amd "subnet-id") ((index $config "subnet-id")) | quote }}
+  dynamic.linux-d320-c4xlarge-amd64.check-interval: {{ (index $config "check-interval") | default "60" | quote }}
+  dynamic.linux-d320-c4xlarge-amd64.disk: "320"
+  dynamic.linux-d320-c4xlarge-amd64.allocation-timeout: "1200"
+  {{ end }}
+
+  {{- if hasKey .Values.dynamicConfigs "linux-d320-m8xlarge-arm64" }}
+  {{- $config := index .Values.dynamicConfigs "linux-d320-m8xlarge-arm64" | default (dict) }}
+  dynamic.linux-d320-m8xlarge-arm64.type: {{ index $config "type" | default "aws" | quote }}
+  dynamic.linux-d320-m8xlarge-arm64.region: {{ index $config "region" | default "us-east-1" | quote }}
+  dynamic.linux-d320-m8xlarge-arm64.ami: {{ default (index $arm "ami") $config.ami | quote }}
+  dynamic.linux-d320-m8xlarge-arm64.instance-type: {{ (index $config "instance-type") | default "m6g.8xlarge" | quote }}
+  dynamic.linux-d320-m8xlarge-arm64.instance-tag: {{ (index $config "instance-tag") | default (printf "%s-arm64-m8xlarge-d320" $environment) | quote }}
+  dynamic.linux-d320-m8xlarge-arm64.key-name: {{ default (index $arm "key-name") ((index $config "key-name")) | quote }}
+  dynamic.linux-d320-m8xlarge-arm64.aws-secret: {{ (index $config "aws-secret") | default "aws-account" | quote }}
+  dynamic.linux-d320-m8xlarge-arm64.ssh-secret: {{ (index $config "ssh-secret") | default "aws-ssh-key" | quote }}
+  dynamic.linux-d320-m8xlarge-arm64.security-group-id: {{ default (index $arm "security-group-id") ((index $config "security-group-id")) | quote }}
+  dynamic.linux-d320-m8xlarge-arm64.max-instances: {{ (index $config "max-instances") | default "250" | quote }}
+  dynamic.linux-d320-m8xlarge-arm64.subnet-id: {{ default (index $arm "subnet-id") ((index $config "subnet-id")) | quote }}
+  dynamic.linux-d320-m8xlarge-arm64.check-interval: {{ (index $config "check-interval") | default "60" | quote }}
+  dynamic.linux-d320-m8xlarge-arm64.disk: "320"
+  dynamic.linux-d320-m8xlarge-arm64.allocation-timeout: "1200"
+  {{ end }}
+
+  {{- if hasKey .Values.dynamicConfigs "linux-d320-m8xlarge-amd64" }}
+  {{- $config := index .Values.dynamicConfigs "linux-d320-m8xlarge-amd64" | default (dict) }}
+  dynamic.linux-d320-m8xlarge-amd64.type: {{ index $config "type" | default "aws" | quote }}
+  dynamic.linux-d320-m8xlarge-amd64.region: {{ index $config "region" | default "us-east-1" | quote }}
+  dynamic.linux-d320-m8xlarge-amd64.ami: {{ default (index $amd "ami") $config.ami | quote }}
+  dynamic.linux-d320-m8xlarge-amd64.instance-type: {{ (index $config "instance-type") | default "m6a.8xlarge" | quote }}
+  dynamic.linux-d320-m8xlarge-amd64.instance-tag: {{ (index $config "instance-tag") | default (printf "%s-amd64-m8xlarge-d320" $environment) | quote }}
+  dynamic.linux-d320-m8xlarge-amd64.key-name: {{ default (index $amd "key-name") ((index $config "key-name")) | quote }}
+  dynamic.linux-d320-m8xlarge-amd64.aws-secret: {{ (index $config "aws-secret") | default "aws-account" | quote }}
+  dynamic.linux-d320-m8xlarge-amd64.ssh-secret: {{ (index $config "ssh-secret") | default "aws-ssh-key" | quote }}
+  dynamic.linux-d320-m8xlarge-amd64.security-group-id: {{ default (index $amd "security-group-id") ((index $config "security-group-id")) | quote }}
+  dynamic.linux-d320-m8xlarge-amd64.max-instances: {{ (index $config "max-instances") | default "250" | quote }}
+  dynamic.linux-d320-m8xlarge-amd64.subnet-id: {{ default (index $amd "subnet-id") ((index $config "subnet-id")) | quote }}
+  dynamic.linux-d320-m8xlarge-amd64.check-interval: {{ (index $config "check-interval") | default "60" | quote }}
+  dynamic.linux-d320-m8xlarge-amd64.disk: "320"
+  dynamic.linux-d320-m8xlarge-amd64.allocation-timeout: "1200"
+  {{ end }}
+
+  {{- if hasKey .Values.dynamicConfigs "linux-c8xlarge-arm64" }}
+  {{- $config := index .Values.dynamicConfigs "linux-c8xlarge-arm64" | default (dict) }}
+  dynamic.linux-c8xlarge-arm64.type: {{ index $config "type" | default "aws" | quote }}
+  dynamic.linux-c8xlarge-arm64.region: {{ index $config "region" | default "us-east-1" | quote }}
+  dynamic.linux-c8xlarge-arm64.ami: {{ default (index $arm "ami") $config.ami | quote }}
+  dynamic.linux-c8xlarge-arm64.instance-type: {{ (index $config "instance-type") | default "c6g.8xlarge" | quote }}
+  dynamic.linux-c8xlarge-arm64.instance-tag: {{ (index $config "instance-tag") | default (printf "%s-arm64-c8xlarge" $environment) | quote }}
+  dynamic.linux-c8xlarge-arm64.key-name: {{ default (index $arm "key-name") ((index $config "key-name")) | quote }}
+  dynamic.linux-c8xlarge-arm64.aws-secret: {{ (index $config "aws-secret") | default "aws-account" | quote }}
+  dynamic.linux-c8xlarge-arm64.ssh-secret: {{ (index $config "ssh-secret") | default "aws-ssh-key" | quote }}
+  dynamic.linux-c8xlarge-arm64.security-group-id: {{ default (index $arm "security-group-id") ((index $config "security-group-id")) | quote }}
+  dynamic.linux-c8xlarge-arm64.max-instances: {{ (index $config "max-instances") | default "250" | quote }}
+  dynamic.linux-c8xlarge-arm64.subnet-id: {{ default (index $arm "subnet-id") ((index $config "subnet-id")) | quote }}
+  dynamic.linux-c8xlarge-arm64.check-interval: {{ (index $config "check-interval") | default "60" | quote }}
+  dynamic.linux-c8xlarge-arm64.allocation-timeout: "1200"
+  {{ end }}
+
+  {{- if hasKey .Values.dynamicConfigs "linux-c8xlarge-amd64" }}
+  {{- $config := index .Values.dynamicConfigs "linux-c8xlarge-amd64" | default (dict) }}
+  dynamic.linux-c8xlarge-amd64.type: {{ index $config "type" | default "aws" | quote }}
+  dynamic.linux-c8xlarge-amd64.region: {{ index $config "region" | default "us-east-1" | quote }}
+  dynamic.linux-c8xlarge-amd64.ami: {{ default (index $amd "ami") $config.ami | quote }}
+  dynamic.linux-c8xlarge-amd64.instance-type:  {{ (index $config "instance-type") | default "c6a.8xlarge" | quote }}
+  dynamic.linux-c8xlarge-amd64.instance-tag: {{ (index $config "instance-tag") | default (printf "%s-amd64-c8xlarge" $environment) | quote }}
+  dynamic.linux-c8xlarge-amd64.key-name: {{ default (index $amd "key-name") ((index $config "key-name")) | quote }}
+  dynamic.linux-c8xlarge-amd64.aws-secret: {{ (index $config "aws-secret") | default "aws-account" | quote }}
+  dynamic.linux-c8xlarge-amd64.ssh-secret: {{ (index $config "ssh-secret") | default "aws-ssh-key" | quote }}
+  dynamic.linux-c8xlarge-amd64.security-group-id: {{ default (index $amd "security-group-id") ((index $config "security-group-id")) | quote }}
+  dynamic.linux-c8xlarge-amd64.max-instances: {{ (index $config "max-instances") | default "250" | quote }}
+  dynamic.linux-c8xlarge-amd64.subnet-id: {{ default (index $amd "subnet-id") ((index $config "subnet-id")) | quote }}
+  dynamic.linux-c8xlarge-amd64.check-interval: {{ (index $config "check-interval") | default "60" | quote }}
+  dynamic.linux-c8xlarge-amd64.allocation-timeout: "1200"
+  {{ end }}
+
+  {{- if hasKey .Values.dynamicConfigs "linux-d160-c8xlarge-arm64" }}
+  {{- $config := index .Values.dynamicConfigs "linux-d160-c8xlarge-arm64" | default (dict) }}
+  dynamic.linux-d160-c8xlarge-arm64.type: {{ index $config "type" | default "aws" | quote }}
+  dynamic.linux-d160-c8xlarge-arm64.region: {{ index $config "region" | default "us-east-1" | quote }}
+  dynamic.linux-d160-c8xlarge-arm64.ami: {{ default (index $arm "ami") $config.ami | quote }}
+  dynamic.linux-d160-c8xlarge-arm64.instance-type: {{ (index $config "instance-type") | default "c6g.8xlarge" | quote }}
+  dynamic.linux-d160-c8xlarge-arm64.instance-tag: {{ (index $config "instance-tag") | default (printf "%s-arm64-c8xlarge-d160" $environment) | quote }}
+  dynamic.linux-d160-c8xlarge-arm64.key-name: {{ default (index $arm "key-name") ((index $config "key-name")) | quote }}
+  dynamic.linux-d160-c8xlarge-arm64.aws-secret: {{ (index $config "aws-secret") | default "aws-account" | quote }}
+  dynamic.linux-d160-c8xlarge-arm64.ssh-secret: {{ (index $config "ssh-secret") | default "aws-ssh-key" | quote }}
+  dynamic.linux-d160-c8xlarge-arm64.security-group-id: {{ default (index $arm "security-group-id") ((index $config "security-group-id")) | quote }}
+  dynamic.linux-d160-c8xlarge-arm64.max-instances: {{ (index $config "max-instances") | default "250" | quote }}
+  dynamic.linux-d160-c8xlarge-arm64.subnet-id: {{ default (index $arm "subnet-id") ((index $config "subnet-id")) | quote }}
+  dynamic.linux-d160-c8xlarge-arm64.check-interval: {{ (index $config "check-interval") | default "60" | quote }}
+  dynamic.linux-d160-c8xlarge-arm64.disk: "160"
+  dynamic.linux-d160-c8xlarge-arm64.allocation-timeout: "1200"
+  {{ end }}
+
+  {{- if hasKey .Values.dynamicConfigs "linux-d160-c8xlarge-amd64" }}
+  {{- $config := index .Values.dynamicConfigs "linux-d160-c8xlarge-amd64" | default (dict) }}
+  dynamic.linux-d160-c8xlarge-amd64.type: {{ index $config "type" | default "aws" | quote }}
+  dynamic.linux-d160-c8xlarge-amd64.region: {{ index $config "region" | default "us-east-1" | quote }}
+  dynamic.linux-d160-c8xlarge-amd64.ami: {{ default (index $amd "ami") $config.ami | quote }}
+  dynamic.linux-d160-c8xlarge-amd64.instance-type: {{ (index $config "instance-type") | default "c6a.8xlarge" | quote }}
+  dynamic.linux-d160-c8xlarge-amd64.instance-tag: {{ (index $config "instance-tag") | default (printf "%s-amd64-c8xlarge-d160" $environment) | quote }}
+  dynamic.linux-d160-c8xlarge-amd64.key-name: {{ default (index $amd "key-name") ((index $config "key-name")) | quote }}
+  dynamic.linux-d160-c8xlarge-amd64.aws-secret: {{ (index $config "aws-secret") | default "aws-account" | quote }}
+  dynamic.linux-d160-c8xlarge-amd64.ssh-secret: {{ (index $config "ssh-secret") | default "aws-ssh-key" | quote }}
+  dynamic.linux-d160-c8xlarge-amd64.security-group-id: {{ default (index $amd "security-group-id") ((index $config "security-group-id")) | quote }}
+  dynamic.linux-d160-c8xlarge-amd64.max-instances: {{ (index $config "max-instances") | default "250" | quote }}
+  dynamic.linux-d160-c8xlarge-amd64.subnet-id: {{ default (index $amd "subnet-id") ((index $config "subnet-id")) | quote }}
+  dynamic.linux-d160-c8xlarge-amd64.check-interval: {{ (index $config "check-interval") | default "60" | quote }}
+  dynamic.linux-d160-c8xlarge-amd64.disk: "160"
+  dynamic.linux-d160-c8xlarge-amd64.allocation-timeout: "1200"
+  {{ end }}
+
+  # GPU Instances
+  {{- if hasKey .Values.dynamicConfigs "linux-g6xlarge-amd64" }}
+  {{- $config := index .Values.dynamicConfigs "linux-g6xlarge-amd64" | default (dict) }}
+  dynamic.linux-g6xlarge-amd64.type: {{ index $config "type" | default "aws" | quote }}
+  dynamic.linux-g6xlarge-amd64.region: {{ index $config "region" | default "us-east-1" | quote }}
+  dynamic.linux-g6xlarge-amd64.ami: {{ default (index $amd "ami") $config.ami | quote }}
+  dynamic.linux-g6xlarge-amd64.instance-type: {{ (index $config "instance-type") | default "g6.xlarge" | quote }}
+  dynamic.linux-g6xlarge-amd64.key-name: {{ default (index $amd "key-name") ((index $config "key-name")) | quote }}
+  dynamic.linux-g6xlarge-amd64.aws-secret: {{ (index $config "aws-secret") | default "aws-account" | quote }}
+  dynamic.linux-g6xlarge-amd64.ssh-secret: {{ (index $config "ssh-secret") | default "aws-ssh-key" | quote }}
+  dynamic.linux-g6xlarge-amd64.security-group-id: {{ default (index $amd "security-group-id") ((index $config "security-group-id")) | quote }}
+  dynamic.linux-g6xlarge-amd64.max-instances: {{ (index $config "max-instances") | default "250" | quote }}
+  dynamic.linux-g6xlarge-amd64.subnet-id: {{ default (index $amd "subnet-id") ((index $config "subnet-id")) | quote }}
+  dynamic.linux-g6xlarge-amd64.instance-tag: {{ (index $config "instance-tag") | default (printf "%s-amd64-g6xlarge" $environment) | quote }}
+  dynamic.linux-g6xlarge-amd64.check-interval: {{ (index $config "check-interval") | default "60" | quote }}
+  dynamic.linux-g6xlarge-amd64.allocation-timeout: "1200"
+  {{- if or (index $config "user-data") (.Files.Get "files/linux-g6xlarge-amd64-init.sh") }}
+  dynamic.linux-g6xlarge-amd64.user-data: |
+  {{- if (index $config "user-data") }}
+  {{- $lines := splitList "\n" (index $config "user-data") }}
+  {{- range $line := $lines }}
+    {{ $line }}
+  {{- end }}
+  {{- else }}
+{{ include "multi-platform-controller.cloud-init-userdata" (.Files.Get "files/linux-g6xlarge-amd64-init.sh") | indent 4 }}
+    {{- end }}
+    {{- end }}
+  {{ end }}
+
+  {{- if hasKey .Values.dynamicConfigs "linux-g64xlarge-amd64" }}
+  {{- $config := index .Values.dynamicConfigs "linux-g64xlarge-amd64" | default (dict) }}
+  dynamic.linux-g64xlarge-amd64.type: {{ index $config "type" | default "aws" | quote }}
+  dynamic.linux-g64xlarge-amd64.region: {{ index $config "region" | default "us-east-1" | quote }}
+  dynamic.linux-g64xlarge-amd64.ami: {{ default (index $amd "ami") $config.ami | quote }}
+  dynamic.linux-g64xlarge-amd64.instance-type: {{ (index $config "instance-type") | default "g6.4xlarge" | quote }}
+  dynamic.linux-g64xlarge-amd64.key-name: {{ default (index $amd "key-name") ((index $config "key-name")) | quote }}
+  dynamic.linux-g64xlarge-amd64.aws-secret: {{ (index $config "aws-secret") | default "aws-account" | quote }}
+  dynamic.linux-g64xlarge-amd64.ssh-secret: {{ (index $config "ssh-secret") | default "aws-ssh-key" | quote }}
+  dynamic.linux-g64xlarge-amd64.security-group-id: {{ default (index $amd "security-group-id") ((index $config "security-group-id")) | quote }}
+  dynamic.linux-g64xlarge-amd64.max-instances: {{ (index $config "max-instances") | default "250" | quote }}
+  dynamic.linux-g64xlarge-amd64.subnet-id: {{ default (index $amd "subnet-id") ((index $config "subnet-id")) | quote }}
+  dynamic.linux-g64xlarge-amd64.instance-tag: {{ (index $config "instance-tag") | default (printf "%s-amd64-g64xlarge" $environment) | quote }}
+  dynamic.linux-g64xlarge-amd64.check-interval: {{ (index $config "check-interval") | default "60" | quote }}
+  dynamic.linux-g64xlarge-amd64.allocation-timeout: "1200"
+  {{- if or (index $config "user-data") (.Files.Get "files/linux-g64xlarge-amd64-init.sh") }}
+  dynamic.linux-g64xlarge-amd64.user-data: |
+  {{- if (index $config "user-data") }}
+  {{- $lines := splitList "\n" (index $config "user-data") }}
+  {{- range $line := $lines }}
+    {{ $line }}
+  {{- end }}
+  {{- else }}
+{{ include "multi-platform-controller.cloud-init-userdata" (.Files.Get "files/linux-g64xlarge-amd64-init.sh") | indent 4 }}
+  {{- end }}
+  {{- end }}
+  {{ end }}
+
+
+  # Root access
+  {{- if hasKey .Values.dynamicConfigs "linux-root-arm64" }}
+  {{- $config := index .Values.dynamicConfigs "linux-root-arm64" | default (dict) }}
+  dynamic.linux-root-arm64.type: {{ index $config "type" | default "aws" | quote }}
+  dynamic.linux-root-arm64.region: {{ index $config "region" | default "us-east-1" | quote }}
+  dynamic.linux-root-arm64.ami: {{ default (index $arm "ami") $config.ami | quote }}
+  dynamic.linux-root-arm64.instance-type: {{ (index $config "instance-type") | default "m6g.large" | quote }}
+  dynamic.linux-root-arm64.instance-tag: {{ (index $config "instance-tag") | default (printf "%s-arm64-root" $environment) | quote }}
+  dynamic.linux-root-arm64.key-name: {{ default (index $arm "key-name") ((index $config "key-name")) | quote }}
+  dynamic.linux-root-arm64.aws-secret: {{ (index $config "aws-secret") | default "aws-account" | quote }}
+  dynamic.linux-root-arm64.ssh-secret: {{ (index $config "ssh-secret") | default "aws-ssh-key" | quote }}
+  dynamic.linux-root-arm64.security-group-id: {{ default (index $arm "security-group-id") ((index $config "security-group-id")) | quote }}
+  dynamic.linux-root-arm64.max-instances: {{ (index $config "max-instances") | default "250" | quote }}
+  dynamic.linux-root-arm64.subnet-id: {{ default (index $arm "subnet-id") ((index $config "subnet-id")) | quote }}
+  dynamic.linux-root-arm64.sudo-commands: {{ (index $config "sudo-commands") | default "/usr/bin/podman" | quote }}
+  dynamic.linux-root-arm64.disk: {{ index $config "disk" | default "200" | quote }}
+  dynamic.linux-root-arm64.check-interval: {{ (index $config "check-interval") | default "60" | quote }}
+  dynamic.linux-root-arm64.allocation-timeout: "1200"
+  {{- if (index $config "iops") }}
+  dynamic.linux-root-arm64.iops: {{ index $config "iops" | quote }}
+  {{ end }}
+  {{- if (index $config "throughput") }}
+  dynamic.linux-root-arm64.throughput: {{ index $config "throughput" | quote }}
+  {{ end }}
+  {{- if (index $config "user-data") }}
+  dynamic.linux-root-arm64.user-data: |
+  {{- $lines := splitList "\n" (index $config "user-data") }}
+  {{- range $line := $lines }}
+    {{ $line }}
+  {{- end }}
+  {{- end }}
+  {{ end }}
+
+  {{- if hasKey .Values.dynamicConfigs "linux-root-amd64" }}
+  {{- $config := index .Values.dynamicConfigs "linux-root-amd64" | default (dict) }}
+  dynamic.linux-root-amd64.type: {{ index $config "type" | default "aws" | quote }}
+  dynamic.linux-root-amd64.region: {{ index $config "region" | default "us-east-1" | quote }}
+  dynamic.linux-root-amd64.ami: {{ default (index $amd "ami") $config.ami | quote }}
+  dynamic.linux-root-amd64.instance-type: {{ (index $config "instance-type") | default "m5.2xlarge" | quote }}
+  dynamic.linux-root-amd64.instance-tag: {{ (index $config "instance-tag") | default (printf "%s-amd64-root" $environment) | quote }}
+  dynamic.linux-root-amd64.key-name: {{ default (index $amd "key-name") ((index $config "key-name")) | quote }}
+  dynamic.linux-root-amd64.aws-secret: {{ (index $config "aws-secret") | default "aws-account" | quote }}
+  dynamic.linux-root-amd64.ssh-secret: {{ (index $config "ssh-secret") | default "aws-ssh-key" | quote }}
+  dynamic.linux-root-amd64.security-group-id: {{ default (index $amd "security-group-id") ((index $config "security-group-id")) | quote }}
+  dynamic.linux-root-amd64.max-instances: {{ (index $config "max-instances") | default "250" | quote }}
+  dynamic.linux-root-amd64.subnet-id: {{ default (index $amd "subnet-id") ((index $config "subnet-id")) | quote }}
+  dynamic.linux-root-amd64.sudo-commands: {{ (index $config "sudo-commands") | default "/usr/bin/podman" | quote }}
+  dynamic.linux-root-amd64.disk: {{index $config "disk" | default "200" | quote }}
+  dynamic.linux-root-amd64.check-interval: {{ (index $config "check-interval") | default "60" | quote }}
+  dynamic.linux-root-amd64.allocation-timeout: "1200"
+  {{- if or (index $config "user-data") (.Files.Get "files/linux-root-amd64-init.sh") }}
+  dynamic.linux-root-amd64.user-data: |
+  {{- if (index $config "user-data") }}
+  {{- $lines := splitList "\n" (index $config "user-data") }}
+  {{- range $line := $lines }}
+    {{ $line }}
+  {{- end }}
+  {{- else }}
+{{ include "multi-platform-controller.cloud-init-userdata" (.Files.Get "files/linux-root-amd64-init.sh") | indent 4 }}
+  {{- end }}
+  {{- end }}
+  {{ end }}
+
+  # Fast platforms for production
+  {{- if hasKey .Values.dynamicConfigs "linux-fast-amd64" }}
+  {{- $config := index .Values.dynamicConfigs "linux-fast-amd64" | default (dict) }}
+  dynamic.linux-fast-amd64.type: {{ index $config "type" | default "aws" | quote }}
+  dynamic.linux-fast-amd64.region: {{ index $config "region" | default "us-east-1" | quote }}
+  dynamic.linux-fast-amd64.ami: {{ default (index $amd "ami") $config.ami | quote }}
+  dynamic.linux-fast-amd64.instance-type: {{ (index $config "instance-type") | default "c7a.8xlarge" | quote }}
+  dynamic.linux-fast-amd64.instance-tag: {{ (index $config "instance-tag") | default (printf "%s-amd64-fast" $environment) | quote }}
+  dynamic.linux-fast-amd64.key-name: {{ default (index $amd "key-name") ((index $config "key-name")) | quote }}
+  dynamic.linux-fast-amd64.aws-secret: {{ (index $config "aws-secret") | default "aws-account" | quote }}
+  dynamic.linux-fast-amd64.ssh-secret: {{ (index $config "ssh-secret") | default "aws-ssh-key" | quote }}
+  dynamic.linux-fast-amd64.security-group-id: {{ default (index $amd "security-group-id") ((index $config "security-group-id")) | quote }}
+  dynamic.linux-fast-amd64.max-instances: {{ (index $config "max-instances") | default "250" | quote }}
+  dynamic.linux-fast-amd64.subnet-id: {{ default (index $amd "subnet-id") ((index $config "subnet-id")) | quote }}
+  dynamic.linux-fast-amd64.disk: {{ index $config "disk" | default "200" | quote }}
+  dynamic.linux-fast-amd64.check-interval: {{ (index $config "check-interval") | default "60" | quote }}
+  dynamic.linux-fast-amd64.allocation-timeout: "1200"
+  {{ end }}
+
+  {{- if hasKey .Values.dynamicConfigs "linux-extra-fast-amd64" }}
+  {{- $config := index .Values.dynamicConfigs "linux-extra-fast-amd64" | default (dict) }}
+  dynamic.linux-extra-fast-amd64.type: {{ index $config "type" | default "aws" | quote }}
+  dynamic.linux-extra-fast-amd64.region: {{ index $config "region" | default "us-east-1" | quote }}
+  dynamic.linux-extra-fast-amd64.ami: {{ default (index $amd "ami") $config.ami | quote }}
+  dynamic.linux-extra-fast-amd64.instance-type: {{ (index $config "instance-type") | default "c7a.12xlarge" | quote }}
+  dynamic.linux-extra-fast-amd64.instance-tag: {{ (index $config "instance-tag") | default (printf "%s-amd64-extra-fast" $environment) | quote }}
+  dynamic.linux-extra-fast-amd64.key-name: {{ default (index $amd "key-name") ((index $config "key-name")) | quote }}
+  dynamic.linux-extra-fast-amd64.aws-secret: {{ (index $config "aws-secret") | default "aws-account" | quote }}
+  dynamic.linux-extra-fast-amd64.ssh-secret: {{ (index $config "ssh-secret") | default "aws-ssh-key" | quote }}
+  dynamic.linux-extra-fast-amd64.security-group-id: {{ default (index $amd "security-group-id") ((index $config "security-group-id")) | quote }}
+  dynamic.linux-extra-fast-amd64.max-instances: {{ (index $config "max-instances") | default "250" | quote }}
+  dynamic.linux-extra-fast-amd64.subnet-id: {{ default (index $amd "subnet-id") ((index $config "subnet-id")) | quote }}
+  dynamic.linux-extra-fast-amd64.disk: {{ index $config "disk" | default "200" | quote }}
+  dynamic.linux-extra-fast-amd64.check-interval: {{ (index $config "check-interval") | default "60" | quote }}
+  dynamic.linux-extra-fast-amd64.allocation-timeout: "1200"
+  {{ end }}
+
+  {{- if hasKey .Values.dynamicConfigs "macos-mac2metal-arm64" }}
+  {{- $config := index .Values.dynamicConfigs "macos-mac2metal-arm64" | default (dict) }}
+  dynamic.macos-mac2metal-arm64.type: {{ index $config "type" | default "aws" | quote }}
+  dynamic.macos-mac2metal-arm64.region: {{ index $config "region" | default "us-east-1" | quote }}
+  dynamic.macos-mac2metal-arm64.ami: {{ default (index $macos "ami") $config.ami | quote }}
+  dynamic.macos-mac2metal-arm64.instance-type: {{ (index $config "instance-type") | default "mac2.metal" | quote }}
+  dynamic.macos-mac2metal-arm64.instance-tag: {{ (index $config "instance-tag") | default (printf "%s-arm64-mac2metal" $environment) | quote }}
+  dynamic.macos-mac2metal-arm64.key-name: {{ default (index $macos "key-name") ((index $config "key-name")) | quote }}
+  dynamic.macos-mac2metal-arm64.aws-secret: {{ (index $config "aws-secret") | default "aws-account" | quote }}
+  dynamic.macos-mac2metal-arm64.ssh-secret: {{ default (index $macos "ssh-secret") ((index $config "ssh-secret")) | default "aws-ssh-key" | quote }}
+  dynamic.macos-mac2metal-arm64.security-group-id: {{ default (index $macos "security-group-id") ((index $config "security-group-id")) | quote }}
+  dynamic.macos-mac2metal-arm64.max-instances: {{ (index $config "max-instances") | default "5" | quote }}
+  dynamic.macos-mac2metal-arm64.subnet-id: {{ default (index $macos "subnet-id") ((index $config "subnet-id")) | quote }}
+  dynamic.macos-mac2metal-arm64.disk: {{ index $config "disk" | default "100" | quote }}
+  dynamic.macos-mac2metal-arm64.allocation-timeout: "1200"
+  dynamic.macos-mac2metal-arm64.tenancy: "host"
+  dynamic.macos-mac2metal-arm64.host-resource-group-arn: {{ default (index $macos "host-resource-group-arn") ((index $config "host-resource-group-arn")) | quote }}
+  dynamic.macos-mac2metal-arm64.license-configuration-arn: {{ default (index $macos "license-configuration-arn") ((index $config "license-configuration-arn")) | quote }}
+  {{- if (index $config "iops") }}
+  dynamic.macos-mac2metal-arm64.iops: {{ index $config "iops" | quote }}
+  {{ end }}
+  {{- if (index $config "throughput") }}
+  dynamic.macos-mac2metal-arm64.throughput: {{ index $config "throughput" | quote }}
+  {{ end }}
+  {{- if or (index $config "user-data") (.Files.Get "files/macos-mac2metal-arm64-init.sh") }}
+  dynamic.macos-mac2metal-arm64.user-data: |
+  {{- if (index $config "user-data") }}
+  {{- $lines := splitList "\n" (index $config "user-data") }}
+  {{- range $line := $lines }}
+    {{ $line }}
+  {{- end }}
+  {{- else }}
+{{ .Files.Get "files/macos-mac2metal-arm64-init.sh" | indent 4 }}
+  {{- end }}
+  {{- end }}
+  {{ end }}
+
+
+  {{- if hasKey .Values.dynamicConfigs "linux-test-amd64" }}
+  {{- $config := index .Values.dynamicConfigs "linux-test-amd64" | default (dict) }}
+  dynamic.linux-test-amd64.type: {{ index $config "type" | default "aws" | quote }}
+  dynamic.linux-test-amd64.region: {{ index $config "region" | default "us-east-1" | quote }}
+  dynamic.linux-test-amd64.ami: {{ default (index $amd "ami") $config.ami | quote }}
+  dynamic.linux-test-amd64.instance-type: {{ (index $config "instance-type") | default "m6a.large" | quote }}
+  dynamic.linux-test-amd64.instance-tag: {{ (index $config "instance-tag") | default (printf "%s-amd64-test" $environment) | quote }}
+  dynamic.linux-test-amd64.key-name: {{ default (index $amd "key-name") ((index $config "key-name")) | quote }}
+  dynamic.linux-test-amd64.aws-secret: {{ (index $config "aws-secret") | default "aws-account" | quote }}
+  dynamic.linux-test-amd64.ssh-secret: {{ (index $config "ssh-secret") | default "aws-ssh-key" | quote }}
+  dynamic.linux-test-amd64.security-group-id: {{ default (index $amd "security-group-id") ((index $config "security-group-id")) | quote }}
+  dynamic.linux-test-amd64.max-instances: {{ (index $config "max-instances") | default "250" | quote }}
+  dynamic.linux-test-amd64.subnet-id: {{ default (index $amd "subnet-id") ((index $config "subnet-id")) | quote }}
+  dynamic.linux-test-amd64.disk: {{ index $config "disk" | default "200" | quote }}
+  dynamic.linux-test-amd64.check-interval: {{ (index $config "check-interval") | default "60" | quote }}
+  dynamic.linux-test-amd64.allocation-timeout: "1200"
+  dynamic.linux-test-amd64.sudo-commands: {{ (index $config "sudo-commands") | default "/usr/bin/podman" | quote }}
+  {{- if or (index $config "user-data") (.Files.Get "files/linux-test-amd64-init.sh") }}
+  dynamic.linux-test-amd64.user-data: |
+  {{- if (index $config "user-data") }}
+  {{- $lines := splitList "\n" (index $config "user-data") }}
+  {{- range $line := $lines }}
+    {{ $line }}
+  {{- end }}
+  {{- else }}
+{{ include "multi-platform-controller.cloud-init-userdata" (.Files.Get "files/linux-test-amd64-init.sh") | indent 4 }}
+  {{- end }}
+  {{- end }}
+  {{ end }}
+
+  {{- if hasKey .Values.dynamicConfigs "linux-test-arm64" }}
+  {{- $config := index .Values.dynamicConfigs "linux-test-arm64" | default (dict) }}
+  dynamic.linux-test-arm64.type: {{ index $config "type" | default "aws" | quote }}
+  dynamic.linux-test-arm64.region: {{ index $config "region" | default "us-east-1" | quote }}
+  dynamic.linux-test-arm64.ami: {{ default (index $arm "ami") $config.ami | quote }}                                                    
+  dynamic.linux-test-arm64.instance-type: {{ (index $config "instance-type") | default "m6g.large" | quote }}
+  dynamic.linux-test-arm64.instance-tag: {{ (index $config "instance-tag") | default (printf "%s-arm64-test" $environment) | quote }}
+  dynamic.linux-test-arm64.key-name: {{ default (index $arm "key-name") ((index $config "key-name")) | quote }}
+  dynamic.linux-test-arm64.aws-secret: {{ (index $config "aws-secret") | default "aws-account" | quote }}
+  dynamic.linux-test-arm64.ssh-secret: {{ (index $config "ssh-secret") | default "aws-ssh-key" | quote }}
+  dynamic.linux-test-arm64.security-group-id: {{ default (index $arm "security-group-id") ((index $config "security-group-id")) | quote }}
+  dynamic.linux-test-arm64.max-instances: {{ (index $config "max-instances") | default "250" | quote }}
+  dynamic.linux-test-arm64.subnet-id: {{ default (index $arm "subnet-id") ((index $config "subnet-id")) | quote }}
+  dynamic.linux-test-arm64.disk: {{ index $config "disk" | default "200" | quote }}
+  dynamic.linux-test-arm64.check-interval: {{ (index $config "check-interval") | default "60" | quote }}
+  dynamic.linux-test-arm64.allocation-timeout: "1200"
+  dynamic.linux-test-arm64.sudo-commands: {{ (index $config "sudo-commands") | default "/usr/bin/podman" | quote }}
+  {{- if (index $config "iops") }}
+  dynamic.linux-test-arm64.iops: {{ index $config "iops" | quote }}
+  {{ end }}
+  {{- if (index $config "throughput") }}
+  dynamic.linux-test-arm64.throughput: {{ index $config "throughput" | quote }}
+  {{ end }}
+  {{- if (index $config "user-data") }}
+  dynamic.linux-test-arm64.user-data: |
+  {{- $lines := splitList "\n" (index $config "user-data") }}
+  {{- range $line := $lines }}
+    {{ $line }}
+  {{- end }}
+  {{- end }}
+  {{ end }}
+
+  # Windows platforms
+  {{- if hasKey .Values.dynamicConfigs "windows-4xlarge-amd64" }}
+  {{- $config := index .Values.dynamicConfigs "windows-4xlarge-amd64" | default (dict) }}
+  dynamic.windows-4xlarge-amd64.type: {{ index $config "type" | default "aws" | quote }}
+  dynamic.windows-4xlarge-amd64.region: {{ index $config "region" | default "us-east-1" | quote }}
+  dynamic.windows-4xlarge-amd64.ami: {{ default (index $windows "ami") $config.ami | quote }}
+  dynamic.windows-4xlarge-amd64.instance-type: {{ (index $config "instance-type") | default "c5.4xlarge" | quote }}
+  dynamic.windows-4xlarge-amd64.instance-tag: {{ (index $config "instance-tag") | default (printf "%s-amd64-4xlarge" $environment) | quote }}
+  dynamic.windows-4xlarge-amd64.key-name: {{ default (index $windows "key-name") ((index $config "key-name")) | quote }}
+  dynamic.windows-4xlarge-amd64.aws-secret: {{ (index $config "aws-secret") | default "aws-account" | quote }}
+  dynamic.windows-4xlarge-amd64.ssh-secret: {{ default (index $windows "ssh-secret") ((index $config "ssh-secret")) | default "aws-ssh-key" | quote }}
+  dynamic.windows-4xlarge-amd64.security-group-id: {{ default (index $windows "security-group-id") ((index $config "security-group-id")) | quote }}
+  dynamic.windows-4xlarge-amd64.max-instances: {{ (index $config "max-instances") | default "5" | quote }}
+  dynamic.windows-4xlarge-amd64.subnet-id: {{ default (index $windows "subnet-id") ((index $config "subnet-id")) | quote }}
+  dynamic.windows-4xlarge-amd64.disk: {{ index $config "disk" | default "100" | quote }}
+  dynamic.windows-4xlarge-amd64.check-interval: {{ (index $config "check-interval") | default "60" | quote }}
+  dynamic.windows-4xlarge-amd64.allocation-timeout: "1200"
+  {{- if (index $config "iops") }}
+  dynamic.windows-4xlarge-amd64.iops: {{ index $config "iops" | quote }}
+  {{ end }}
+  {{- if (index $config "throughput") }}
+  dynamic.windows-4xlarge-amd64.throughput: {{ index $config "throughput" | quote }}
+  {{ end }}
+  dynamic.windows-4xlarge-amd64.user-data: |
+  {{- if (index $config "user-data") }}
+  {{- $lines := splitList "\n" (index $config "user-data") }}
+  {{- range $line := $lines }}
+    {{ $line }}
+  {{- end }}
+  {{- else }}
+{{ include "multi-platform-controller.windows-init" $config | indent 4 }}
+  {{- end }}
+  {{ end }}
+
+  # Static hosts configuration
+  {{- range $host, $config := .Values.staticHosts }}
+  {{- range $key, $value := $config }}
+  host.{{ $host }}.{{ $key }}: {{ $value | quote }}
+  {{- end }}
+  {{ end }}

--- a/components/multi-platform-controller/production-downstream/kflux-osp-p01/kustomization.yaml
+++ b/components/multi-platform-controller/production-downstream/kflux-osp-p01/kustomization.yaml
@@ -11,11 +11,11 @@ patches:
   - path: manager_resources_patch.yaml
 
 helmGlobals:
-  chartHome: ../../base
+  chartHome: ../base
 
 helmCharts:
 - name: host-config-chart
   releaseName: host-config
   namespace: multi-platform-controller
-  repo: ../../base
+  repo: ../base
   valuesFile: host-values.yaml

--- a/components/multi-platform-controller/production-downstream/kflux-rhel-p01/kustomization.yaml
+++ b/components/multi-platform-controller/production-downstream/kflux-rhel-p01/kustomization.yaml
@@ -8,11 +8,11 @@ resources:
 - external-secrets.yaml
 
 helmGlobals:
-  chartHome: ../../base
+  chartHome: ../base
 
 helmCharts:
 - name: host-config-chart
   releaseName: host-config
   namespace: multi-platform-controller
-  repo: ../../base
+  repo: ../base
   valuesFile: host-values.yaml

--- a/components/multi-platform-controller/production-downstream/stone-prod-p01/kustomization.yaml
+++ b/components/multi-platform-controller/production-downstream/stone-prod-p01/kustomization.yaml
@@ -8,7 +8,7 @@ resources:
 - external-secrets.yaml
 
 helmGlobals:
-  chartHome: ../../base
+  chartHome: ../base
 
 helmCharts:
 - name: host-config-chart

--- a/components/multi-platform-controller/production/base/host-config-chart/Chart.yaml
+++ b/components/multi-platform-controller/production/base/host-config-chart/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v2
+name: multi-platform-controller-host-config
+description: A Helm chart for multi-platform-controller host configuration
+version: 0.1.0

--- a/components/multi-platform-controller/production/base/host-config-chart/files/linux-c6gd2xlarge-arm64-init.sh
+++ b/components/multi-platform-controller/production/base/host-config-chart/files/linux-c6gd2xlarge-arm64-init.sh
@@ -1,0 +1,23 @@
+#!/bin/bash -ex
+
+# Format and mount NVMe disk
+mkfs -t xfs /dev/nvme1n1
+mount /dev/nvme1n1 /home
+
+# Create required directories
+mkdir -p /home/var-lib-containers /var/lib/containers /home/var-tmp /var/tmp /home/ec2-user/.ssh
+
+# Setup bind mounts
+mount --bind /home/var-lib-containers /var/lib/containers
+mount --bind /home/var-tmp /var/tmp
+chmod 1777 /home/var-tmp /var/tmp
+chown root:root /home/var-tmp /var/tmp
+restorecon -r /var/lib/containers /var/tmp
+
+# Configure ec2-user SSH access
+chown -R ec2-user /home/ec2-user
+sed -n 's,.*\(ssh-.*\s\),\1,p' /root/.ssh/authorized_keys > /home/ec2-user/.ssh/authorized_keys
+chown ec2-user /home/ec2-user/.ssh/authorized_keys
+chmod 600 /home/ec2-user/.ssh/authorized_keys
+chmod 700 /home/ec2-user/.ssh
+restorecon -r /home/ec2-user

--- a/components/multi-platform-controller/production/base/host-config-chart/files/linux-g64xlarge-amd64-init.sh
+++ b/components/multi-platform-controller/production/base/host-config-chart/files/linux-g64xlarge-amd64-init.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+set -xeuo pipefail
+
+configure_nvidia_cdi() {
+  # generate Nvdia CDI with retry
+  for i in {1..10}; do
+    su - ec2-user -c 'nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml' 
+    su - ec2-user -c 'nvidia-ctk cdi generate --output=/var/run/cdi/nvidia.yaml'
+
+    # expect nvidia.com/gpu=all device to be in the generated list
+    if nvidia-ctk cdi list 2>/dev/null | grep -q 'nvidia.com/gpu=all'; then
+      echo "Nvidia CDI Ready"
+      return 0
+    fi
+
+    # sleep only if we'll be retrying again
+    [ "${i}" -lt "10" ] && sleep 1
+  done
+
+  echo "Nvidia CDI Failed"
+  return 1
+}
+
+# Format and mount NVMe disk
+mkfs -t xfs /dev/nvme1n1
+mount /dev/nvme1n1 /home
+
+# Create required directories
+mkdir -p /home/var-lib-containers /var/lib/containers /home/var-tmp /var/tmp /home/ec2-user/.ssh
+
+# Setup bind mounts
+mount --bind /home/var-lib-containers /var/lib/containers
+mount --bind /home/var-tmp /var/tmp
+chmod 1777 /home/var-tmp /var/tmp
+chown root:root /home/var-tmp /var/tmp
+restorecon -r /var/lib/containers /var/tmp
+
+# GPU setup
+mkdir -p /etc/cdi /var/run/cdi
+chmod a+rwx /etc/cdi /var/run/cdi
+setsebool container_use_devices 1 2>/dev/null || true
+configure_nvidia_cdi
+chmod a+rw /etc/cdi/nvidia.yaml
+chmod a+rw /var/run/cdi/nvidia.yaml
+
+# Configure ec2-user SSH access
+chown -R ec2-user /home/ec2-user
+sed -n 's,.*\(ssh-.*\s\),\1,p' /root/.ssh/authorized_keys > /home/ec2-user/.ssh/authorized_keys
+chown ec2-user /home/ec2-user/.ssh/authorized_keys
+chmod 600 /home/ec2-user/.ssh/authorized_keys
+chmod 700 /home/ec2-user/.ssh
+restorecon -r /home/ec2-user

--- a/components/multi-platform-controller/production/base/host-config-chart/files/linux-g6xlarge-amd64-init.sh
+++ b/components/multi-platform-controller/production/base/host-config-chart/files/linux-g6xlarge-amd64-init.sh
@@ -1,0 +1,30 @@
+#!/bin/bash -ex
+
+# Format and mount NVMe disk
+mkfs -t xfs /dev/nvme1n1
+mount /dev/nvme1n1 /home
+
+# Create required directories
+mkdir -p /home/var-lib-containers /var/lib/containers /home/var-tmp /var/tmp /home/ec2-user/.ssh
+
+# Setup bind mounts
+mount --bind /home/var-lib-containers /var/lib/containers
+mount --bind /home/var-tmp /var/tmp
+chmod a+rw /var/tmp
+restorecon -r /var/lib/containers /var/tmp
+
+# GPU setup
+mkdir -p /etc/cdi /var/run/cdi
+chmod a+rwx /etc/cdi /var/run/cdi
+setsebool container_use_devices 1 2>/dev/null || true
+su - ec2-user
+nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml
+chmod a+rw /etc/cdi/nvidia.yaml
+
+# Configure ec2-user SSH access
+chown -R ec2-user /home/ec2-user
+sed -n 's,.*\(ssh-.*\s\),\1,p' /root/.ssh/authorized_keys > /home/ec2-user/.ssh/authorized_keys
+chown ec2-user /home/ec2-user/.ssh/authorized_keys
+chmod 600 /home/ec2-user/.ssh/authorized_keys
+chmod 700 /home/ec2-user/.ssh
+restorecon -r /home/ec2-user

--- a/components/multi-platform-controller/production/base/host-config-chart/files/linux-g6xlarge-amd64-init.sh
+++ b/components/multi-platform-controller/production/base/host-config-chart/files/linux-g6xlarge-amd64-init.sh
@@ -1,4 +1,24 @@
-#!/bin/bash -ex
+#!/bin/bash
+
+set -xeuo pipefail
+
+configure_nvidia_cdi() {
+  # generate Nvdia CDI with retry
+  for i in {1..10}; do
+    su - ec2-user -c 'nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml'
+    su - ec2-user -c 'nvidia-ctk cdi generate --output=/var/run/cdi/nvidia.yaml'
+    # expect nvidia.com/gpu=all device to be in the generated list
+    if nvidia-ctk cdi list 2>/dev/null | grep -q 'nvidia.com/gpu=all'; then
+      echo "Nvidia CDI Ready"
+      return 0
+    fi
+    # sleep only if we'll be retrying again
+    [ "${i}" -lt "10" ] && sleep 1
+  done
+  
+  echo "Nvidia CDI Failed"
+  return 1
+}
 
 # Format and mount NVMe disk
 mkfs -t xfs /dev/nvme1n1
@@ -10,16 +30,17 @@ mkdir -p /home/var-lib-containers /var/lib/containers /home/var-tmp /var/tmp /ho
 # Setup bind mounts
 mount --bind /home/var-lib-containers /var/lib/containers
 mount --bind /home/var-tmp /var/tmp
-chmod a+rw /var/tmp
+chmod 1777 /home/var-tmp /var/tmp
+chown root:root /home/var-tmp /var/tmp
 restorecon -r /var/lib/containers /var/tmp
 
 # GPU setup
 mkdir -p /etc/cdi /var/run/cdi
 chmod a+rwx /etc/cdi /var/run/cdi
 setsebool container_use_devices 1 2>/dev/null || true
-su - ec2-user
-nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml
+configure_nvidia_cdi
 chmod a+rw /etc/cdi/nvidia.yaml
+chmod a+rw /var/run/cdi/nvidia.yaml
 
 # Configure ec2-user SSH access
 chown -R ec2-user /home/ec2-user

--- a/components/multi-platform-controller/production/base/host-config-chart/files/linux-root-amd64-init.sh
+++ b/components/multi-platform-controller/production/base/host-config-chart/files/linux-root-amd64-init.sh
@@ -1,0 +1,23 @@
+#!/bin/bash -ex
+
+# Format and mount NVMe disk
+mkfs -t xfs /dev/nvme1n1
+mount /dev/nvme1n1 /home
+
+# Create required directories
+mkdir -p /home/var-lib-containers /var/lib/containers /home/var-tmp /var/tmp /home/ec2-user/.ssh
+
+# Setup bind mounts
+mount --bind /home/var-lib-containers /var/lib/containers
+mount --bind /home/var-tmp /var/tmp
+chmod 1777 /home/var-tmp /var/tmp
+chown root:root /home/var-tmp /var/tmp
+restorecon -r /var/lib/containers /var/tmp
+
+# Configure ec2-user SSH access
+chown -R ec2-user /home/ec2-user
+sed -n 's,.*\(ssh-.*\s\),\1,p' /root/.ssh/authorized_keys > /home/ec2-user/.ssh/authorized_keys
+chown ec2-user /home/ec2-user/.ssh/authorized_keys
+chmod 600 /home/ec2-user/.ssh/authorized_keys
+chmod 700 /home/ec2-user/.ssh
+restorecon -r /home/ec2-user

--- a/components/multi-platform-controller/production/base/host-config-chart/files/linux-test-amd64-init.sh
+++ b/components/multi-platform-controller/production/base/host-config-chart/files/linux-test-amd64-init.sh
@@ -1,0 +1,24 @@
+#!/bin/bash -ex
+
+# Format and mount NVMe disk
+mkfs -t xfs /dev/nvme1n1
+mount /dev/nvme1n1 /home
+
+# Create required directories
+mkdir -p /home/var-lib-containers /var/lib/containers /home/var-tmp /var/tmp /home/ec2-user/.ssh
+
+# Setup bind mounts
+mount --bind /home/var-lib-containers /var/lib/containers
+mount --bind /home/var-tmp /var/tmp
+chmod 1777 /home/var-tmp /var/tmp
+chown root:root /home/var-tmp /var/tmp
+
+restorecon -r /var/lib/containers /var/tmp
+
+# Configure ec2-user SSH access
+chown -R ec2-user /home/ec2-user
+sed -n 's,.*\(ssh-.*\s\),\1,p' /root/.ssh/authorized_keys > /home/ec2-user/.ssh/authorized_keys
+chown ec2-user /home/ec2-user/.ssh/authorized_keys
+chmod 600 /home/ec2-user/.ssh/authorized_keys
+chmod 700 /home/ec2-user/.ssh
+restorecon -r /home/ec2-user

--- a/components/multi-platform-controller/production/base/host-config-chart/files/macos-mac2metal-arm64-init.sh
+++ b/components/multi-platform-controller/production/base/host-config-chart/files/macos-mac2metal-arm64-init.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+set -eu
+set -x
+
+user="konflux-builder"
+
+# Check if user already exists
+if ! id "$user" &>/dev/null; then
+    # Generate random password
+    random_password=$(openssl rand -base64 32)
+
+    # Create user
+    sudo sysadminctl -addUser "$user" -fullName "Konflux Builder" -password "$random_password" -home /Users/"$user"
+
+    # Clear password from variable
+    unset random_password
+else
+    echo "User $user already exists, skipping user creation"
+fi
+
+# Create home directory if it doesn't exist
+sudo mkdir -p /Users/"$user"
+
+# Create SSH directory
+sudo mkdir -p /Users/"$user"/.ssh
+
+# Remove existing SSH keys if they exist
+sudo rm -f /Users/"$user"/.ssh/id_rsa /Users/"$user"/.ssh/id_rsa.pub
+
+# Generate new SSH keys
+sudo ssh-keygen -t rsa -b 4096 -f /Users/"$user"/.ssh/id_rsa -N "" -C ""
+
+# Set proper permissions on .ssh directory
+sudo chmod 700 /Users/"$user"/.ssh
+
+# Create/overwrite authorized_keys
+sudo chmod 600 /Users/"$user"/.ssh/authorized_keys 2>/dev/null || true
+sudo cat /Users/"$user"/.ssh/id_rsa.pub | sudo tee /Users/"$user"/.ssh/authorized_keys > /dev/null
+sudo cat /Users/"$user"/.ssh/id_rsa | sudo tee /Users/ec2-user/"$user" > /dev/null
+
+# Set ownership of entire home directory to ensure user has full control
+sudo chown -R "$user":staff /Users/"$user"
+
+# Set ownership of the copied private key to ec2-user
+sudo chown ec2-user:staff /Users/ec2-user/"$user"
+sudo chmod 600 /Users/ec2-user/"$user"

--- a/components/multi-platform-controller/production/base/host-config-chart/files/macos-mac2metal-arm64-init.sh
+++ b/components/multi-platform-controller/production/base/host-config-chart/files/macos-mac2metal-arm64-init.sh
@@ -1,19 +1,19 @@
 #!/bin/bash
-set -eu
+set -euo pipefail
 set -x
 
 user="konflux-builder"
 
 # Check if user already exists
 if ! id "$user" &>/dev/null; then
-    # Generate random password
+    # Suppress xtrace to avoid leaking password in logs
+    set +x
     random_password=$(openssl rand -base64 32)
-
     # Create user
     sudo sysadminctl -addUser "$user" -fullName "Konflux Builder" -password "$random_password" -home /Users/"$user"
-
     # Clear password from variable
     unset random_password
+    set -x
 else
     echo "User $user already exists, skipping user creation"
 fi

--- a/components/multi-platform-controller/production/base/host-config-chart/templates/_cloud-init-userdata.tpl
+++ b/components/multi-platform-controller/production/base/host-config-chart/templates/_cloud-init-userdata.tpl
@@ -1,0 +1,23 @@
+{{- define "multi-platform-controller.cloud-init-userdata" -}}
+Content-Type: multipart/mixed; boundary="//"
+MIME-Version: 1.0
+
+--//
+Content-Type: text/cloud-config; charset="us-ascii"
+MIME-Version: 1.0
+Content-Transfer-Encoding: 7bit
+Content-Disposition: attachment; filename="cloud-config.txt"
+
+#cloud-config
+cloud_final_modules:
+  - [scripts-user, always]
+
+--//
+Content-Type: text/x-shellscript; charset="us-ascii"
+MIME-Version: 1.0
+Content-Transfer-Encoding: 7bit
+Content-Disposition: attachment; filename="userdata.txt"
+
+{{ . }}
+--//--
+{{- end -}}

--- a/components/multi-platform-controller/production/base/host-config-chart/templates/_windows-init.ps1.tpl
+++ b/components/multi-platform-controller/production/base/host-config-chart/templates/_windows-init.ps1.tpl
@@ -1,0 +1,389 @@
+{{- define "multi-platform-controller.windows-init" -}}
+<powershell>
+# ------------------
+# Helper Functions
+# ------------------
+function Wait-Folder {
+    param(
+        [Parameter(Mandatory=$true)]
+        [string]$FolderPath,
+        [Parameter(Mandatory=$false)]
+        [int]$TimeoutSeconds = 30
+    )
+    Write-Host "Waiting for folder '${FolderPath}' to be created"
+    $stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
+    while (-not (Test-Path -Path ${FolderPath})) {
+        if ($stopwatch.Elapsed.TotalSeconds -ge $TimeoutSeconds) {
+            Write-Error "Timeout reached! Folder was not created within $TimeoutSeconds seconds."
+            $stopwatch.Stop()
+            return $false
+        }
+        Write-Host "Waiting for folder..." -NoNewline
+        Start-Sleep -Seconds 1
+    }
+    $stopwatch.Stop()
+    return $true
+}
+
+# ---------------------
+# Docker Installation
+# ---------------------
+Invoke-WebRequest -UseBasicParsing "https://raw.githubusercontent.com/microsoft/Windows-Containers/Main/helpful_tools/Install-DockerCE/install-docker-ce.ps1" -OutFile install-docker-ce.ps1
+.\install-docker-ce.ps1
+
+# ---------------------------------------------------
+# OpenSSH Installation (service started at end of script)
+# ---------------------------------------------------
+Add-WindowsCapability -Online -Name OpenSSH.Server~~~~0.0.1.0
+
+# -------------------------------
+# User Creation & Profile Setup
+# -------------------------------
+$user = "konflux-builder"
+$password = $null
+$userWasCreated = $false
+
+# Create user if it doesn't exist
+if ((Get-LocalUser -Name "${user}" -ErrorAction SilentlyContinue) -eq $null) {
+    Write-Host "Creating user '${user}'"
+
+    $passwordLength = 16
+    $charset = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!@#$%^&*-_=+'
+    $rng = New-Object System.Security.Cryptography.RNGCryptoServiceProvider
+    $bytes = New-Object byte[]($passwordLength)
+    $rng.GetBytes($bytes)
+    $password = -join ($bytes | ForEach-Object { $charset[$_ % $charset.Length] })
+    $rng.Dispose()
+    $securePassword = (ConvertTo-SecureString $password -AsPlainText -Force)
+
+    New-LocalUser -Name $user -Password $securePassword -Description "Konflux Builder" | Out-Null
+    Add-LocalGroupMember -Group 'Users' -Member $user
+    Add-LocalGroupMember -Group 'OpenSSH Users' -Member $user
+
+    $userWasCreated = $true
+} else {
+    Write-Host "User '${user}' already exists, skipping user creation"
+}
+
+# Create user profile
+Add-Type -TypeDefinition @"
+using System;
+using System.Runtime.InteropServices;
+using System.Text;
+public class UserEnv
+{
+    [DllImport("userenv.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+    public static extern int CreateProfile(
+        [MarshalAs(UnmanagedType.LPWStr)] string pszUserSid,
+        [MarshalAs(UnmanagedType.LPWStr)] string pszUserName,
+        [MarshalAs(UnmanagedType.LPWStr)] StringBuilder pszProfilePath,
+        uint cchProfilePath);
+}
+"@
+
+$userSID = (New-Object System.Security.Principal.NTAccount($user)).Translate([System.Security.Principal.SecurityIdentifier]).Value
+$profilePath = New-Object System.Text.StringBuilder(260)
+$result = [UserEnv]::CreateProfile($userSID, $user, $profilePath, $profilePath.Capacity)
+
+# Create user home directory
+$userHome = "C:\Users\${user}"
+Write-Host "Waiting for User Home '${userHome}' to be created"
+if (-not (Wait-Folder -FolderPath ${userHome})) {
+    Write-Error "Folder '${userHome}' not found! This may cause issues with SSH setup"
+}
+
+$hivePath = "C:\Users\${user}\NTUSER.DAT"
+$loadedHive = "TempHive_${user}"
+
+# Configure user registry permissions
+try {
+    if (Test-Path $hivePath) {
+        $hiveLoaded = Test-Path "Registry::HKEY_USERS\${userSID}"
+
+        if (-not $hiveLoaded) {
+            & reg load "HKU\${loadedHive}" $hivePath 2>&1 | Out-Null
+            Start-Sleep -Seconds 2
+        } else {
+            $loadedHive = $userSID
+        }
+
+        $registryPath = "Registry::HKEY_USERS\${loadedHive}"
+        if (Test-Path $registryPath) {
+            $acl = Get-Acl $registryPath
+
+            $systemRule = New-Object System.Security.AccessControl.RegistryAccessRule(
+                "NT AUTHORITY\SYSTEM",
+                "FullControl",
+                "ContainerInherit,ObjectInherit",
+                "None",
+                "Allow"
+            )
+            $acl.SetAccessRule($systemRule)
+
+            $userRule = New-Object System.Security.AccessControl.RegistryAccessRule(
+                $user,
+                "FullControl",
+                "ContainerInherit,ObjectInherit",
+                "None",
+                "Allow"
+            )
+            $acl.SetAccessRule($userRule)
+
+            Set-Acl $registryPath $acl
+        }
+
+        if (-not $hiveLoaded) {
+            [gc]::Collect()
+            Start-Sleep -Seconds 2
+            & reg unload "HKU\${loadedHive}" 2>&1 | Out-Null
+        }
+    }
+} catch {
+    Write-Warning "Failed to configure user registry permissions: $($_.Exception.Message)"
+    Write-Warning "This may affect user profile settings, but SSH access should still work"
+}
+
+# ----------------------------------
+# Docker User Access Configuration
+# ----------------------------------
+$dockerGroup = "docker-users"
+
+if (-not (Get-LocalGroup -Name $dockerGroup -ErrorAction SilentlyContinue)) {
+    New-LocalGroup -Name $dockerGroup -Description 'Docker Users' -ErrorAction SilentlyContinue
+}
+
+Add-LocalGroupMember -Group $dockerGroup -Member $user -ErrorAction SilentlyContinue
+
+$dockerConfigPath = "C:\ProgramData\docker\config\daemon.json"
+$dockerConfigDir = Split-Path $dockerConfigPath -Parent
+
+if (-not (Test-Path $dockerConfigDir)) {
+    New-Item -ItemType Directory -Path $dockerConfigDir -Force | Out-Null
+}
+
+$daemonConfig = @{ "group" = $dockerGroup }
+
+# Configure Docker daemon to use the docker-users group
+if (Test-Path $dockerConfigPath) {
+    $existingConfig = Get-Content $dockerConfigPath -Raw | ConvertFrom-Json
+    $existingConfig | Add-Member -NotePropertyName "group" -NotePropertyValue $dockerGroup -Force
+    $existingConfig | ConvertTo-Json -Depth 10 | Set-Content $dockerConfigPath -Force
+} else {
+    $daemonConfig | ConvertTo-Json | Set-Content $dockerConfigPath -Force
+}
+
+if (Get-Service docker -ErrorAction SilentlyContinue) {
+    Restart-Service docker -Force
+}
+
+# Add exclusion processes to Windows Defender
+Add-MpPreference -ExclusionProcess "dockerd.exe" -ErrorAction SilentlyContinue
+Add-MpPreference -ExclusionProcess "docker.exe" -ErrorAction SilentlyContinue
+Add-MpPreference -ExclusionProcess "containerd.exe" -ErrorAction SilentlyContinue
+Add-MpPreference -ExclusionProcess "vmcompute.exe" -ErrorAction SilentlyContinue
+
+# -----------------------------
+# Scoop Support Configuration
+# -----------------------------
+# Enable development mode - allows symbolic links to be created
+Set-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\AppModelUnlock" `
+    -Name "AllowDevelopmentWithoutDevLicense" `
+    -Value 1 `
+    -Type DWord `
+    -Force
+
+# Start the MSI server service - required for scoop installation
+Set-Service -Name msiserver -StartupType Automatic -ErrorAction SilentlyContinue
+Start-Service -Name msiserver -ErrorAction SilentlyContinue
+
+# --------------------------------
+# User SSH Key & Directory Setup
+# --------------------------------
+$tempKey = "${env:TEMP}\${user}"
+
+# Remove existing SSH keys if they exist
+if (Test-Path "${tempKey}") { Remove-Item -Force "${tempKey}" }
+if (Test-Path "${tempKey}.pub") { Remove-Item -Force "${tempKey}.pub" }
+
+ssh-keygen -t rsa -f "${tempKey}" -N `"`" | Out-Null
+
+$privateKeyPath = "C:\Users\Administrator\${user}"
+mv "${env:TEMP}\${user}" "${privateKeyPath}"
+
+# Configure ACL for the private key
+$ACL = Get-Acl "${privateKeyPath}"
+$Ar = New-Object System.Security.AccessControl.FileSystemAccessRule(
+    "NT AUTHORITY\SYSTEM",
+    "FullControl",
+    "Allow"
+)
+$ACL.SetAccessRule($Ar)
+$Ar = New-Object System.Security.AccessControl.FileSystemAccessRule(
+    "BUILTIN\Administrators",
+    "FullControl",
+    "Allow"
+)
+$ACL.SetAccessRule($Ar)
+Set-Acl "${privateKeyPath}" ${ACL}
+
+$publicKeyTempPath = "C:\Users\Public\${user}.pub"
+Copy-Item "${tempKey}.pub" $publicKeyTempPath -Force
+Start-Sleep 10
+
+# Create  additional user directories
+$sshPath = Join-Path $userHome ".ssh"
+$buildPath = Join-Path $userHome "build"
+$scoopPath = Join-Path $userHome "scoop"
+$authorizedKeysPath = Join-Path $sshPath "authorized_keys"
+
+New-Item -ItemType Directory -Force -Path $sshPath | Out-Null
+New-Item -ItemType Directory -Force -Path $buildPath | Out-Null
+New-Item -ItemType Directory -Force -Path $scoopPath | Out-Null
+
+if (Test-Path $publicKeyTempPath) {
+    Copy-Item $publicKeyTempPath $authorizedKeysPath -Force
+}
+
+# Set owner and permissions for additional user directories
+$userSidObj = New-Object System.Security.Principal.SecurityIdentifier($userSID)
+foreach ($path in @($sshPath, $buildPath, $scoopPath, $authorizedKeysPath)) {
+    if (Test-Path $path) {
+        $acl = Get-Acl $path
+        $acl.SetOwner($userSidObj)
+        Set-Acl $path $acl
+    }
+}
+
+# Configure ACL for the SSH directory
+if (Test-Path $sshPath) {
+    $sshAcl = Get-Acl $sshPath
+    $sshAcl.SetAccessRuleProtection($true, $false)
+    $sshAcl.Access | ForEach-Object { $sshAcl.RemoveAccessRule($_) } | Out-Null
+
+    $userRule = New-Object System.Security.AccessControl.FileSystemAccessRule(
+        $user,
+        "FullControl",
+        "ContainerInherit,ObjectInherit",
+        "None",
+        "Allow"
+    )
+    $sshAcl.SetAccessRule($userRule)
+
+    $systemRule = New-Object System.Security.AccessControl.FileSystemAccessRule(
+        "NT AUTHORITY\SYSTEM",
+        "FullControl",
+        "ContainerInherit,ObjectInherit",
+        "None",
+        "Allow"
+    )
+    $sshAcl.SetAccessRule($systemRule)
+
+    Set-Acl $sshPath $sshAcl
+}
+
+if (Test-Path $authorizedKeysPath) {
+    $keyAcl = Get-Acl $authorizedKeysPath
+    $keyAcl.SetAccessRuleProtection($true, $false)
+    $keyAcl.Access | ForEach-Object { $keyAcl.RemoveAccessRule($_) } | Out-Null
+
+    $userKeyRule = New-Object System.Security.AccessControl.FileSystemAccessRule(
+        $user,
+        "Read",
+        "Allow"
+    )
+    $keyAcl.SetAccessRule($userKeyRule)
+
+    $systemKeyRule = New-Object System.Security.AccessControl.FileSystemAccessRule(
+        "NT AUTHORITY\SYSTEM",
+        "FullControl",
+        "Allow"
+    )
+    $keyAcl.SetAccessRule($systemKeyRule)
+
+    Set-Acl $authorizedKeysPath $keyAcl
+}
+
+if (Test-Path $publicKeyTempPath) {
+    Remove-Item -Path $publicKeyTempPath -Force -ErrorAction SilentlyContinue
+}
+if (Test-Path "${tempKey}.pub") {
+    Remove-Item -Force "${tempKey}.pub"
+}
+
+# --------------------------
+# Scoop Installation Script
+# --------------------------
+if ($userWasCreated) {
+    $scoopScript = @"
+Set-ExecutionPolicy RemoteSigned -Scope CurrentUser -Force
+Write-Host "Installing Scoop..."
+Invoke-RestMethod -Uri 'https://get.scoop.sh' | Invoke-Expression
+scoop config use_lessmsi true
+Write-Host "Scoop installed successfully!"
+"@
+    $scoopScriptPath = "C:\Users\${user}\install_scoop.ps1"
+    $scoopScript | Out-File -FilePath $scoopScriptPath -Encoding UTF8 -Force
+
+    $scriptAcl = Get-Acl $scoopScriptPath
+    $scriptAcl.SetOwner($userSidObj)
+    Set-Acl $scoopScriptPath $scriptAcl
+}
+
+# ---------------------------------------------------
+# OpenSSH Administrator Configuration & Service Start
+# ---------------------------------------------------
+{{- $addresses := (list) }}
+{{- range $entry := (index . "allowed-remote-addresses" | required "Remote addresses for the SSH FW must be specified") }}
+    {{- $addresses = append $addresses (squote $entry) }}
+{{- end }}
+Remove-NetFirewallRule -Name 'OpenSSH-Server-In-TCP' -ErrorAction SilentlyContinue
+New-NetFirewallRule -Name 'OpenSSH-Server-In-TCP' `
+    -DisplayName 'OpenSSH Server (sshd)' `
+    -Enabled True `
+    -Direction Inbound `
+    -Protocol TCP `
+    -Action Allow `
+    -LocalPort 22 `
+    -RemoteAddress {{ join "," $addresses }} | Out-Null
+
+# Get public key from AWS Instance Metadata Service (IMDSv2)
+$MAGIC_IP = "169.254.169.254"
+$IMDS_TOKEN = Invoke-RestMethod -Uri "http://${MAGIC_IP}/latest/api/token" `
+    -Method 'PUT' `
+    -Headers @{'X-aws-ec2-metadata-token-ttl-seconds' = '21600'}
+$PUBKEY = Invoke-RestMethod -Uri "http://${MAGIC_IP}/latest/meta-data/public-keys/0/openssh-key" `
+    -Headers @{'X-aws-ec2-metadata-token' = $IMDS_TOKEN}
+
+Start-Sleep 5
+
+# Configure SSH authorized_keys for Administrator
+$SSH_PATH = "C:\ProgramData\ssh"
+Write-Host "Waiting for SSH Folder '${SSH_PATH}'"
+if (-not (Wait-Folder -FolderPath ${SSH_PATH})) {
+    Write-Warning "SSH folder not found, creating it manually"
+    New-Item -ItemType Directory -Path $SSH_PATH | Out-Null
+}
+Write-Host "SSH Folder '${SSH_PATH}' found"
+
+$PUBKEY | Out-File -FilePath "$SSH_PATH\administrators_authorized_keys" -Encoding ascii
+
+$ACL = Get-Acl "$SSH_PATH\administrators_authorized_keys"
+$Ar = New-Object System.Security.AccessControl.FileSystemAccessRule(
+    "NT AUTHORITY\SYSTEM",
+    "FullControl",
+    "Allow"
+)
+$ACL.SetAccessRule($Ar)
+$Ar = New-Object System.Security.AccessControl.FileSystemAccessRule(
+    "BUILTIN\Administrators",
+    "FullControl",
+    "Allow"
+)
+$ACL.SetAccessRule($Ar)
+Set-Acl "$SSH_PATH\administrators_authorized_keys" $ACL
+
+Start-Service sshd
+Set-Service -Name sshd -StartupType 'Automatic'
+</powershell>
+<persist>true</persist>
+{{- end -}}

--- a/components/multi-platform-controller/production/base/host-config-chart/templates/host-config.yaml
+++ b/components/multi-platform-controller/production/base/host-config-chart/templates/host-config.yaml
@@ -1,0 +1,1184 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    build.appstudio.redhat.com/multi-platform-config: hosts
+  name: host-config
+  namespace: multi-platform-controller
+data:
+  local-platforms: "\
+    {{ join ",\\\n    " (.Values.localPlatforms | default (list "linux/x86_64" "local" "localhost")) }}\
+  "
+
+
+  {{- $outs := list }}
+  {{- range $k, $v := .Values.dynamicConfigs }}
+    {{- $parts := splitList "-" $k }}
+    {{- $last := index $parts (sub (len $parts) 1) }}
+    {{- $prefix := join "-" (slice $parts 0 (sub (len $parts) 1)) }}
+    {{- $outs = append $outs (printf "%s/%s" $prefix $last) }}
+  {{- end }}
+  dynamic-platforms: "\
+    {{ join ",\\\n    " $outs }}\
+  "
+
+  {{- if .Values.dynamicPoolPlatforms }}
+  dynamic-pool-platforms: {{ .Values.dynamicPoolPlatforms }}
+  {{- end }}
+
+  instance-tag: {{ .Values.instanceTag | default "rhtap-prod" }}
+
+  {{- $defaultTags := dict "Project" "Konflux" "Owner" "konflux-infra@redhat.com" "ManagedBy" "Konflux Infra Team" "app-code" "ASSH-001" "service-phase" "Production" "cost-center" "670" }}
+  {{- $mergedTags := merge (.Values.additionalInstanceTags | default dict) $defaultTags }}
+
+  additional-instance-tags: "\
+  {{- $keys := keys $mergedTags | sortAlpha }}
+  {{- range $i, $k := $keys }}
+      {{ $k }}={{ index $mergedTags $k }}{{- if lt $i (sub (len $keys) 1) }},{{ end }}\
+  {{- end }}
+      "
+
+  {{- $arm := (index .Values "archDefaults" "arm64") | default (dict) }}
+  {{- $amd := (index .Values "archDefaults" "amd64") | default (dict) }}
+  {{- $windows := (index .Values "archDefaults" "windows-amd64") | default (dict) }}
+  {{- $macos := (index .Values "archDefaults" "macos-mac2metal-arm64") | default (dict) }}
+  {{- $environment := .Values.environment | default "prod" }}
+
+  # cpu:memory (1:4)
+  {{- if hasKey .Values.dynamicConfigs "linux-arm64" }}
+  {{- $config := index .Values.dynamicConfigs "linux-arm64" | default (dict) }}
+  dynamic.linux-arm64.type: {{ index $config "type" | default "aws" | quote }}
+  dynamic.linux-arm64.region: {{ index $config "region" | default "us-east-1" | quote }}
+  dynamic.linux-arm64.ami: {{ default (index $arm "ami") $config.ami | quote }}
+  dynamic.linux-arm64.instance-type: {{ (index $config "instance-type") | default "m6g.large" | quote }}
+  dynamic.linux-arm64.instance-tag: {{ (index $config "instance-tag") | default (printf "%s-arm64" $environment) | quote }}
+  dynamic.linux-arm64.key-name: {{ default (index $arm "key-name") ((index $config "key-name")) | quote }}
+  dynamic.linux-arm64.aws-secret: {{ (index $config "aws-secret") | default "aws-account" | quote }}
+  dynamic.linux-arm64.ssh-secret: {{ (index $config "ssh-secret") | default "aws-ssh-key" | quote }}
+  dynamic.linux-arm64.security-group-id: {{ default (index $arm "security-group-id") ((index $config "security-group-id")) | quote }}
+  dynamic.linux-arm64.max-instances: {{ (index $config "max-instances") | default "250" | quote }}
+  dynamic.linux-arm64.subnet-id: {{ default (index $arm "subnet-id") ((index $config "subnet-id")) | quote }}
+  dynamic.linux-arm64.check-interval: {{ (index $config "check-interval") | default "60" | quote }}
+  dynamic.linux-arm64.allocation-timeout: "1200"
+  {{ end }}
+
+
+  {{- if hasKey .Values.dynamicConfigs "linux-amd64" }}
+  {{- $config := index .Values.dynamicConfigs "linux-amd64" | default (dict) }}
+  dynamic.linux-amd64.type: {{ index $config "type" | default "aws" | quote }}
+  dynamic.linux-amd64.region: {{ index $config "region" | default "us-east-1" | quote }}
+  dynamic.linux-amd64.ami: {{ default (index $amd "ami") $config.ami | quote }}
+  dynamic.linux-amd64.instance-type: {{ (index $config "instance-type") | default "m6a.large" | quote }}
+  dynamic.linux-amd64.instance-tag: {{ (index $config "instance-tag") | default (printf "%s-amd64" $environment) | quote }}
+  dynamic.linux-amd64.key-name: {{ default (index $amd "key-name") ((index $config "key-name")) | quote }}
+  dynamic.linux-amd64.aws-secret: {{ (index $config "aws-secret") | default "aws-account" | quote }}
+  dynamic.linux-amd64.ssh-secret: {{ (index $config "ssh-secret") | default "aws-ssh-key" | quote }}
+  dynamic.linux-amd64.security-group-id: {{ default (index $amd "security-group-id") ((index $config "security-group-id")) | quote }}
+  dynamic.linux-amd64.max-instances: {{ (index $config "max-instances") | default "250" | quote }}
+  dynamic.linux-amd64.subnet-id: {{ default (index $amd "subnet-id") ((index $config "subnet-id")) | quote }}
+  dynamic.linux-amd64.check-interval: {{ (index $config "check-interval") | default "60" | quote }}
+  dynamic.linux-amd64.allocation-timeout: "1200"
+  {{ end }}
+
+  {{- if hasKey .Values.dynamicConfigs "linux-d160-amd64" }}
+  {{- $config := index .Values.dynamicConfigs "linux-d160-amd64" | default (dict) }}
+  dynamic.linux-d160-amd64.type: {{ index $config "type" | default "aws" | quote }}
+  dynamic.linux-d160-amd64.region: {{ index $config "region" | default "us-east-1" | quote }}
+  dynamic.linux-d160-amd64.ami: {{ default (index $amd "ami") $config.ami | quote }}
+  dynamic.linux-d160-amd64.instance-type: {{ (index $config "instance-type") | default "m6a.large" | quote }}
+  dynamic.linux-d160-amd64.instance-tag: {{ (index $config "instance-tag") | default (printf "%s-amd64-d160" $environment) | quote }}
+  dynamic.linux-d160-amd64.key-name: {{ default (index $amd "key-name") ((index $config "key-name")) | quote }}
+  dynamic.linux-d160-amd64.aws-secret: {{ (index $config "aws-secret") | default "aws-account" | quote }}
+  dynamic.linux-d160-amd64.ssh-secret: {{ (index $config "ssh-secret") | default "aws-ssh-key" | quote }}
+  dynamic.linux-d160-amd64.security-group-id: {{ default (index $amd "security-group-id") ((index $config "security-group-id")) | quote }}
+  dynamic.linux-d160-amd64.max-instances: {{ (index $config "max-instances") | default "250" | quote }}
+  dynamic.linux-d160-amd64.subnet-id: {{ default (index $amd "subnet-id") ((index $config "subnet-id")) | quote }}
+  dynamic.linux-d160-amd64.check-interval: {{ (index $config "check-interval") | default "60" | quote }}
+  dynamic.linux-d160-amd64.disk: "160"
+  dynamic.linux-d160-amd64.allocation-timeout: "1200"
+  {{ end }}
+
+  {{- if hasKey .Values.dynamicConfigs "linux-d160-arm64" }}
+  {{- $config := index .Values.dynamicConfigs "linux-d160-arm64" | default (dict) }}
+  dynamic.linux-d160-arm64.type: {{ index $config "type" | default "aws" | quote }}
+  dynamic.linux-d160-arm64.region: {{ index $config "region" | default "us-east-1" | quote }}
+  dynamic.linux-d160-arm64.ami: {{ default (index $arm "ami") $config.ami | quote }}
+  dynamic.linux-d160-arm64.instance-type: {{ (index $config "instance-type") | default "m6g.large" | quote }}
+  dynamic.linux-d160-arm64.instance-tag: {{ (index $config "instance-tag") | default (printf "%s-arm64-d160" $environment) | quote }}
+  dynamic.linux-d160-arm64.key-name: {{ default (index $arm "key-name") ((index $config "key-name")) | quote }}
+  dynamic.linux-d160-arm64.aws-secret: {{ (index $config "aws-secret") | default "aws-account" | quote }}
+  dynamic.linux-d160-arm64.ssh-secret: {{ (index $config "ssh-secret") | default "aws-ssh-key" | quote }}
+  dynamic.linux-d160-arm64.security-group-id: {{ default (index $arm "security-group-id") ((index $config "security-group-id")) | quote }}
+  dynamic.linux-d160-arm64.max-instances: {{ (index $config "max-instances") | default "250" | quote }}
+  dynamic.linux-d160-arm64.subnet-id: {{ default (index $arm "subnet-id") ((index $config "subnet-id")) | quote }}
+  dynamic.linux-d160-arm64.check-interval: {{ (index $config "check-interval") | default "60" | quote }}
+  dynamic.linux-d160-arm64.disk: "160"
+  dynamic.linux-d160-arm64.allocation-timeout: "1200"
+  {{ end }}
+
+
+  {{- if hasKey .Values.dynamicConfigs "linux-mlarge-arm64" }}
+  {{- $config := index .Values.dynamicConfigs "linux-mlarge-arm64" | default (dict) }}
+  dynamic.linux-mlarge-arm64.type: {{ index $config "type" | default "aws" | quote }}
+  dynamic.linux-mlarge-arm64.region: {{ index $config "region" | default "us-east-1" | quote }}
+  dynamic.linux-mlarge-arm64.ami: {{ default (index $arm "ami") $config.ami | quote }}
+  dynamic.linux-mlarge-arm64.instance-type: {{ (index $config "instance-type") | default "m6g.large" | quote }}
+  dynamic.linux-mlarge-arm64.instance-tag: {{ (index $config "instance-tag") | default (printf "%s-arm64-mlarge" $environment) | quote }}
+  dynamic.linux-mlarge-arm64.key-name: {{ default (index $arm "key-name") ((index $config "key-name")) | quote }}
+  dynamic.linux-mlarge-arm64.aws-secret: {{ (index $config "aws-secret") | default "aws-account" | quote }}
+  dynamic.linux-mlarge-arm64.ssh-secret: {{ (index $config "ssh-secret") | default "aws-ssh-key" | quote }}
+  dynamic.linux-mlarge-arm64.security-group-id: {{ default (index $arm "security-group-id") ((index $config "security-group-id")) | quote }}
+  dynamic.linux-mlarge-arm64.max-instances: {{ (index $config "max-instances") | default "250" | quote }}
+  dynamic.linux-mlarge-arm64.subnet-id: {{ default (index $arm "subnet-id") ((index $config "subnet-id")) | quote }}
+  dynamic.linux-mlarge-arm64.check-interval: {{ (index $config "check-interval") | default "60" | quote }}
+  dynamic.linux-mlarge-arm64.allocation-timeout: "1200"
+  {{ end }}
+
+  {{- if hasKey .Values.dynamicConfigs "linux-mlarge-amd64" }}
+  {{- $config := index .Values.dynamicConfigs "linux-mlarge-amd64" | default (dict) }}
+  dynamic.linux-mlarge-amd64.type: {{ index $config "type" | default "aws" | quote }}
+  dynamic.linux-mlarge-amd64.region: {{ index $config "region" | default "us-east-1" | quote }}
+  dynamic.linux-mlarge-amd64.ami: {{ default (index $amd "ami") $config.ami | quote }}
+  dynamic.linux-mlarge-amd64.instance-type: {{ (index $config "instance-type") | default "m6a.large" | quote }}
+  dynamic.linux-mlarge-amd64.instance-tag: {{ (index $config "instance-tag") | default (printf "%s-amd64-mlarge" $environment) | quote }}
+  dynamic.linux-mlarge-amd64.key-name: {{ default (index $amd "key-name") ((index $config "key-name")) | quote }}
+  dynamic.linux-mlarge-amd64.aws-secret: {{ (index $config "aws-secret") | default "aws-account" | quote }}
+  dynamic.linux-mlarge-amd64.ssh-secret: {{ (index $config "ssh-secret") | default "aws-ssh-key" | quote }}
+  dynamic.linux-mlarge-amd64.security-group-id: {{ default (index $amd "security-group-id") ((index $config "security-group-id")) | quote }}
+  dynamic.linux-mlarge-amd64.max-instances: {{ (index $config "max-instances") | default "250" | quote }}
+  dynamic.linux-mlarge-amd64.subnet-id: {{ default (index $amd "subnet-id") ((index $config "subnet-id")) | quote }}
+  dynamic.linux-mlarge-amd64.check-interval: {{ (index $config "check-interval") | default "60" | quote }}
+  dynamic.linux-mlarge-amd64.allocation-timeout: "1200"
+  {{ end }}
+
+  {{- if hasKey .Values.dynamicConfigs "linux-d160-mlarge-arm64" }}
+  {{- $config := index .Values.dynamicConfigs "linux-d160-mlarge-arm64" | default (dict) }}
+  dynamic.linux-d160-mlarge-arm64.type: {{ index $config "type" | default "aws" | quote }}
+  dynamic.linux-d160-mlarge-arm64.region: {{ index $config "region" | default "us-east-1" | quote }}
+  dynamic.linux-d160-mlarge-arm64.ami: {{ default (index $arm "ami") $config.ami | quote }}
+  dynamic.linux-d160-mlarge-arm64.instance-type: {{ (index $config "instance-type") | default "m6g.large" | quote }}
+  dynamic.linux-d160-mlarge-arm64.instance-tag: {{ (index $config "instance-tag") | default (printf "%s-arm64-mlarge-d160" $environment) | quote }}
+  dynamic.linux-d160-mlarge-arm64.key-name: {{ default (index $arm "key-name") ((index $config "key-name")) | quote }}
+  dynamic.linux-d160-mlarge-arm64.aws-secret: {{ (index $config "aws-secret") | default "aws-account" | quote }}
+  dynamic.linux-d160-mlarge-arm64.ssh-secret: {{ (index $config "ssh-secret") | default "aws-ssh-key" | quote }}
+  dynamic.linux-d160-mlarge-arm64.security-group-id: {{ default (index $arm "security-group-id") ((index $config "security-group-id")) | quote }}
+  dynamic.linux-d160-mlarge-arm64.max-instances: {{ (index $config "max-instances") | default "250" | quote }}
+  dynamic.linux-d160-mlarge-arm64.subnet-id: {{ default (index $arm "subnet-id") ((index $config "subnet-id")) | quote }}
+  dynamic.linux-d160-mlarge-arm64.check-interval: {{ (index $config "check-interval") | default "60" | quote }}
+  dynamic.linux-d160-mlarge-arm64.disk: "160"
+  dynamic.linux-d160-mlarge-arm64.allocation-timeout: "1200"
+  {{ end }}
+
+  {{- if hasKey .Values.dynamicConfigs "linux-d160-mlarge-amd64" }}
+  {{- $config := index .Values.dynamicConfigs "linux-d160-mlarge-amd64" | default (dict) }}
+  dynamic.linux-d160-mlarge-amd64.type: {{ index $config "type" | default "aws" | quote }}
+  dynamic.linux-d160-mlarge-amd64.region: {{ index $config "region" | default "us-east-1" | quote }}
+  dynamic.linux-d160-mlarge-amd64.ami: {{ default (index $amd "ami") $config.ami | quote }}
+  dynamic.linux-d160-mlarge-amd64.instance-type: {{ (index $config "instance-type") | default "m6a.large" | quote }}
+  dynamic.linux-d160-mlarge-amd64.instance-tag: {{ (index $config "instance-tag") | default (printf "%s-amd64-mlarge-d160" $environment) | quote }}
+  dynamic.linux-d160-mlarge-amd64.key-name: {{ default (index $amd "key-name") ((index $config "key-name")) | quote }}
+  dynamic.linux-d160-mlarge-amd64.aws-secret: {{ (index $config "aws-secret") | default "aws-account" | quote }}
+  dynamic.linux-d160-mlarge-amd64.ssh-secret: {{ (index $config "ssh-secret") | default "aws-ssh-key" | quote }}
+  dynamic.linux-d160-mlarge-amd64.security-group-id: {{ default (index $amd "security-group-id") ((index $config "security-group-id")) | quote }}
+  dynamic.linux-d160-mlarge-amd64.max-instances: {{ (index $config "max-instances") | default "250" | quote }}
+  dynamic.linux-d160-mlarge-amd64.subnet-id: {{ default (index $amd "subnet-id") ((index $config "subnet-id")) | quote }}
+  dynamic.linux-d160-mlarge-amd64.check-interval: {{ (index $config "check-interval") | default "60" | quote }}
+  dynamic.linux-d160-mlarge-amd64.disk: "160"
+  dynamic.linux-d160-mlarge-amd64.allocation-timeout: "1200"
+  {{ end }}
+
+  {{- if hasKey .Values.dynamicConfigs "linux-mxlarge-arm64" }}
+  {{- $config := index .Values.dynamicConfigs "linux-mxlarge-arm64" | default (dict) }}
+  dynamic.linux-mxlarge-arm64.type: {{ index $config "type" | default "aws" | quote }}
+  dynamic.linux-mxlarge-arm64.region: {{ index $config "region" | default "us-east-1" | quote }}
+  dynamic.linux-mxlarge-arm64.ami: {{ default (index $arm "ami") $config.ami | quote }}
+  dynamic.linux-mxlarge-arm64.instance-type: {{ (index $config "instance-type") | default "m6g.xlarge" | quote }}
+  dynamic.linux-mxlarge-arm64.instance-tag: {{ (index $config "instance-tag") | default (printf "%s-arm64-mxlarge" $environment) | quote }}
+  dynamic.linux-mxlarge-arm64.key-name: {{ default (index $arm "key-name") ((index $config "key-name")) | quote }}
+  dynamic.linux-mxlarge-arm64.aws-secret: {{ (index $config "aws-secret") | default "aws-account" | quote }}
+  dynamic.linux-mxlarge-arm64.ssh-secret: {{ (index $config "ssh-secret") | default "aws-ssh-key" | quote }}
+  dynamic.linux-mxlarge-arm64.security-group-id: {{ default (index $arm "security-group-id") ((index $config "security-group-id")) | quote }}
+  dynamic.linux-mxlarge-arm64.max-instances: {{ (index $config "max-instances") | default "250" | quote }}
+  dynamic.linux-mxlarge-arm64.subnet-id: {{ default (index $arm "subnet-id") ((index $config "subnet-id")) | quote }}
+  dynamic.linux-mxlarge-arm64.check-interval: {{ (index $config "check-interval") | default "60" | quote }}
+  dynamic.linux-mxlarge-arm64.allocation-timeout: "1200"
+  {{ end }}
+
+  {{- if hasKey .Values.dynamicConfigs "linux-mxlarge-amd64" }}
+  {{- $config := index .Values.dynamicConfigs "linux-mxlarge-amd64" | default (dict) }}
+  dynamic.linux-mxlarge-amd64.type: {{ index $config "type" | default "aws" | quote }}
+  dynamic.linux-mxlarge-amd64.region: {{ index $config "region" | default "us-east-1" | quote }}
+  dynamic.linux-mxlarge-amd64.ami: {{ default (index $amd "ami") $config.ami | quote }}
+  dynamic.linux-mxlarge-amd64.instance-type: {{ (index $config "instance-type") | default "m6a.xlarge" | quote }}
+  dynamic.linux-mxlarge-amd64.instance-tag: {{ (index $config "instance-tag") | default (printf "%s-amd64-mxlarge" $environment) | quote }}
+  dynamic.linux-mxlarge-amd64.key-name: {{ default (index $amd "key-name") ((index $config "key-name")) | quote }}
+  dynamic.linux-mxlarge-amd64.aws-secret: {{ (index $config "aws-secret") | default "aws-account" | quote }}
+  dynamic.linux-mxlarge-amd64.ssh-secret: {{ (index $config "ssh-secret") | default "aws-ssh-key" | quote }}
+  dynamic.linux-mxlarge-amd64.security-group-id: {{ default (index $amd "security-group-id") ((index $config "security-group-id")) | quote }}
+  dynamic.linux-mxlarge-amd64.max-instances: {{ (index $config "max-instances") | default "250" | quote }}
+  dynamic.linux-mxlarge-amd64.subnet-id: {{ default (index $amd "subnet-id") ((index $config "subnet-id")) | quote }}
+  dynamic.linux-mxlarge-amd64.check-interval: {{ (index $config "check-interval") | default "60" | quote }}
+  dynamic.linux-mxlarge-amd64.allocation-timeout: "1200"
+  {{ end }}
+
+  {{- if hasKey .Values.dynamicConfigs "linux-d160-mxlarge-arm64" }}
+  {{- $config := index .Values.dynamicConfigs "linux-d160-mxlarge-arm64" | default (dict) }}
+  dynamic.linux-d160-mxlarge-arm64.type: {{ index $config "type" | default "aws" | quote }}
+  dynamic.linux-d160-mxlarge-arm64.region: {{ index $config "region" | default "us-east-1" | quote }}
+  dynamic.linux-d160-mxlarge-arm64.ami: {{ default (index $arm "ami") $config.ami | quote }}
+  dynamic.linux-d160-mxlarge-arm64.instance-type: {{ (index $config "instance-type") | default "m6g.xlarge" | quote }}
+  dynamic.linux-d160-mxlarge-arm64.instance-tag: {{ (index $config "instance-tag") | default (printf "%s-arm64-mxlarge-d160" $environment) | quote }}
+  dynamic.linux-d160-mxlarge-arm64.key-name: {{ default (index $arm "key-name") ((index $config "key-name")) | quote }}
+  dynamic.linux-d160-mxlarge-arm64.aws-secret: {{ (index $config "aws-secret") | default "aws-account" | quote }}
+  dynamic.linux-d160-mxlarge-arm64.ssh-secret: {{ (index $config "ssh-secret") | default "aws-ssh-key" | quote }}
+  dynamic.linux-d160-mxlarge-arm64.security-group-id: {{ default (index $arm "security-group-id") ((index $config "security-group-id")) | quote }}
+  dynamic.linux-d160-mxlarge-arm64.max-instances: {{ (index $config "max-instances") | default "250" | quote }}
+  dynamic.linux-d160-mxlarge-arm64.subnet-id: {{ default (index $arm "subnet-id") ((index $config "subnet-id")) | quote }}
+  dynamic.linux-d160-mxlarge-arm64.check-interval: {{ (index $config "check-interval") | default "60" | quote }}
+  dynamic.linux-d160-mxlarge-arm64.disk: "160"
+  dynamic.linux-d160-mxlarge-arm64.allocation-timeout: "1200"
+  {{ end }}
+
+  {{- if hasKey .Values.dynamicConfigs "linux-d160-mxlarge-amd64" }}
+  {{- $config := index .Values.dynamicConfigs "linux-d160-mxlarge-amd64" | default (dict) }}
+  dynamic.linux-d160-mxlarge-amd64.type: {{ index $config "type" | default "aws" | quote }}
+  dynamic.linux-d160-mxlarge-amd64.region: {{ index $config "region" | default "us-east-1" | quote }}
+  dynamic.linux-d160-mxlarge-amd64.ami: {{ default (index $amd "ami") $config.ami | quote }}
+  dynamic.linux-d160-mxlarge-amd64.instance-type: {{ (index $config "instance-type") | default "m6a.xlarge" | quote }}
+  dynamic.linux-d160-mxlarge-amd64.instance-tag: {{ (index $config "instance-tag") | default (printf "%s-amd64-mxlarge-d160" $environment) | quote }}
+  dynamic.linux-d160-mxlarge-amd64.key-name: {{ default (index $amd "key-name") ((index $config "key-name")) | quote }}
+  dynamic.linux-d160-mxlarge-amd64.aws-secret: {{ (index $config "aws-secret") | default "aws-account" | quote }}
+  dynamic.linux-d160-mxlarge-amd64.ssh-secret: {{ (index $config "ssh-secret") | default "aws-ssh-key" | quote }}
+  dynamic.linux-d160-mxlarge-amd64.security-group-id: {{ default (index $amd "security-group-id") ((index $config "security-group-id")) | quote }}
+  dynamic.linux-d160-mxlarge-amd64.max-instances: {{ (index $config "max-instances") | default "250" | quote }}
+  dynamic.linux-d160-mxlarge-amd64.subnet-id: {{ default (index $amd "subnet-id") ((index $config "subnet-id")) | quote }}
+  dynamic.linux-d160-mxlarge-amd64.check-interval: {{ (index $config "check-interval") | default "60" | quote }}
+  dynamic.linux-d160-mxlarge-amd64.disk: "160"
+  dynamic.linux-d160-mxlarge-amd64.allocation-timeout: "1200"
+  {{ end }}
+
+  {{- if hasKey .Values.dynamicConfigs "linux-m2xlarge-arm64" }}
+  {{- $config := index .Values.dynamicConfigs "linux-m2xlarge-arm64" | default (dict) }}
+  dynamic.linux-m2xlarge-arm64.type: {{ index $config "type" | default "aws" | quote }}
+  dynamic.linux-m2xlarge-arm64.region: {{ index $config "region" | default "us-east-1" | quote }}
+  dynamic.linux-m2xlarge-arm64.ami: {{ default (index $arm "ami") $config.ami | quote }}
+  dynamic.linux-m2xlarge-arm64.instance-type: {{ (index $config "instance-type") | default "m6g.2xlarge" | quote }}
+  dynamic.linux-m2xlarge-arm64.instance-tag: {{ (index $config "instance-tag") | default (printf "%s-arm64-m2xlarge" $environment) | quote }}
+  dynamic.linux-m2xlarge-arm64.key-name: {{ default (index $arm "key-name") ((index $config "key-name")) | quote }}
+  dynamic.linux-m2xlarge-arm64.aws-secret: {{ (index $config "aws-secret") | default "aws-account" | quote }}
+  dynamic.linux-m2xlarge-arm64.ssh-secret: {{ (index $config "ssh-secret") | default "aws-ssh-key" | quote }}
+  dynamic.linux-m2xlarge-arm64.security-group-id: {{ default (index $arm "security-group-id") ((index $config "security-group-id")) | quote }}
+  dynamic.linux-m2xlarge-arm64.max-instances: {{ (index $config "max-instances") | default "250" | quote }}
+  dynamic.linux-m2xlarge-arm64.subnet-id: {{ default (index $arm "subnet-id") ((index $config "subnet-id")) | quote }}
+  dynamic.linux-m2xlarge-arm64.check-interval: {{ (index $config "check-interval") | default "60" | quote }}
+  dynamic.linux-m2xlarge-arm64.allocation-timeout: "1200"
+  {{ end }}
+
+  {{- if hasKey .Values.dynamicConfigs "linux-m2xlarge-amd64" }}
+  {{- $config := index .Values.dynamicConfigs "linux-m2xlarge-amd64" | default (dict) }}
+  dynamic.linux-m2xlarge-amd64.type: {{ index $config "type" | default "aws" | quote }}
+  dynamic.linux-m2xlarge-amd64.region: {{ index $config "region" | default "us-east-1" | quote }}
+  dynamic.linux-m2xlarge-amd64.ami: {{ default (index $amd "ami") $config.ami | quote }}
+  dynamic.linux-m2xlarge-amd64.instance-type: {{ (index $config "instance-type") | default "m6a.2xlarge" | quote }}
+  dynamic.linux-m2xlarge-amd64.instance-tag: {{ (index $config "instance-tag") | default (printf "%s-amd64-m2xlarge" $environment) | quote }}
+  dynamic.linux-m2xlarge-amd64.key-name: {{ default (index $amd "key-name") ((index $config "key-name")) | quote }}
+  dynamic.linux-m2xlarge-amd64.aws-secret: {{ (index $config "aws-secret") | default "aws-account" | quote }}
+  dynamic.linux-m2xlarge-amd64.ssh-secret: {{ (index $config "ssh-secret") | default "aws-ssh-key" | quote }}
+  dynamic.linux-m2xlarge-amd64.security-group-id: {{ default (index $amd "security-group-id") ((index $config "security-group-id")) | quote }}
+  dynamic.linux-m2xlarge-amd64.max-instances: {{ (index $config "max-instances") | default "250" | quote }}
+  dynamic.linux-m2xlarge-amd64.subnet-id: {{ default (index $amd "subnet-id") ((index $config "subnet-id")) | quote }}
+  dynamic.linux-m2xlarge-amd64.check-interval: {{ (index $config "check-interval") | default "60" | quote }}
+  dynamic.linux-m2xlarge-amd64.allocation-timeout: "1200"
+  {{ end }}
+
+  {{- if hasKey .Values.dynamicConfigs "linux-d160-m2xlarge-arm64" }}
+  {{- $config := index .Values.dynamicConfigs "linux-d160-m2xlarge-arm64" | default (dict) }}
+  dynamic.linux-d160-m2xlarge-arm64.type: {{ index $config "type" | default "aws" | quote }}
+  dynamic.linux-d160-m2xlarge-arm64.region: {{ index $config "region" | default "us-east-1" | quote }}
+  dynamic.linux-d160-m2xlarge-arm64.ami: {{ default (index $arm "ami") $config.ami | quote }}
+  dynamic.linux-d160-m2xlarge-arm64.instance-type: {{ (index $config "instance-type") | default "m6g.2xlarge" | quote }}
+  dynamic.linux-d160-m2xlarge-arm64.instance-tag: {{ (index $config "instance-tag") | default (printf "%s-arm64-m2xlarge-d160" $environment) | quote }}
+  dynamic.linux-d160-m2xlarge-arm64.key-name: {{ default (index $arm "key-name") ((index $config "key-name")) | quote }}
+  dynamic.linux-d160-m2xlarge-arm64.aws-secret: {{ (index $config "aws-secret") | default "aws-account" | quote }}
+  dynamic.linux-d160-m2xlarge-arm64.ssh-secret: {{ (index $config "ssh-secret") | default "aws-ssh-key" | quote }}
+  dynamic.linux-d160-m2xlarge-arm64.security-group-id: {{ default (index $arm "security-group-id") ((index $config "security-group-id")) | quote }}
+  dynamic.linux-d160-m2xlarge-arm64.max-instances: {{ (index $config "max-instances") | default "250" | quote }}
+  dynamic.linux-d160-m2xlarge-arm64.subnet-id: {{ default (index $arm "subnet-id") ((index $config "subnet-id")) | quote }}
+  dynamic.linux-d160-m2xlarge-arm64.check-interval: {{ (index $config "check-interval") | default "60" | quote }}
+  dynamic.linux-d160-m2xlarge-arm64.disk: "160"
+  dynamic.linux-d160-m2xlarge-arm64.allocation-timeout: "1200"
+  {{ end }}
+
+  {{- if hasKey .Values.dynamicConfigs "linux-d160-m2xlarge-amd64" }}
+  {{- $config := index .Values.dynamicConfigs "linux-d160-m2xlarge-amd64" | default (dict) }}
+  dynamic.linux-d160-m2xlarge-amd64.type: {{ index $config "type" | default "aws" | quote }}
+  dynamic.linux-d160-m2xlarge-amd64.region: {{ index $config "region" | default "us-east-1" | quote }}
+  dynamic.linux-d160-m2xlarge-amd64.ami: {{ default (index $amd "ami") $config.ami | quote }}
+  dynamic.linux-d160-m2xlarge-amd64.instance-type: {{ (index $config "instance-type") | default "m6a.2xlarge" | quote }}
+  dynamic.linux-d160-m2xlarge-amd64.instance-tag: {{ (index $config "instance-tag") | default (printf "%s-amd64-m2xlarge-d160" $environment) | quote }}
+  dynamic.linux-d160-m2xlarge-amd64.key-name: {{ default (index $amd "key-name") ((index $config "key-name")) | quote }}
+  dynamic.linux-d160-m2xlarge-amd64.aws-secret: {{ (index $config "aws-secret") | default "aws-account" | quote }}
+  dynamic.linux-d160-m2xlarge-amd64.ssh-secret: {{ (index $config "ssh-secret") | default "aws-ssh-key" | quote }}
+  dynamic.linux-d160-m2xlarge-amd64.security-group-id: {{ default (index $amd "security-group-id") ((index $config "security-group-id")) | quote }}
+  dynamic.linux-d160-m2xlarge-amd64.max-instances: {{ (index $config "max-instances") | default "250" | quote }}
+  dynamic.linux-d160-m2xlarge-amd64.subnet-id: {{ default (index $amd "subnet-id") ((index $config "subnet-id")) | quote }}
+  dynamic.linux-d160-m2xlarge-amd64.check-interval: {{ (index $config "check-interval") | default "60" | quote }}
+  dynamic.linux-d160-m2xlarge-amd64.disk: "160"
+  dynamic.linux-d160-m2xlarge-amd64.allocation-timeout: "1200"
+  {{ end }}
+
+  {{- if hasKey .Values.dynamicConfigs "linux-m4xlarge-arm64" }}
+  {{- $config := index .Values.dynamicConfigs "linux-m4xlarge-arm64" | default (dict) }}
+  dynamic.linux-m4xlarge-arm64.type: {{ index $config "type" | default "aws" | quote }}
+  dynamic.linux-m4xlarge-arm64.region: {{ index $config "region" | default "us-east-1" | quote }}
+  dynamic.linux-m4xlarge-arm64.ami: {{ default (index $arm "ami") $config.ami | quote }}
+  dynamic.linux-m4xlarge-arm64.instance-type: {{ (index $config "instance-type") | default "m6g.4xlarge" | quote }}
+  dynamic.linux-m4xlarge-arm64.instance-tag: {{ (index $config "instance-tag") | default (printf "%s-arm64-m4xlarge" $environment) | quote }}
+  dynamic.linux-m4xlarge-arm64.key-name: {{ default (index $arm "key-name") ((index $config "key-name")) | quote }}
+  dynamic.linux-m4xlarge-arm64.aws-secret: {{ (index $config "aws-secret") | default "aws-account" | quote }}
+  dynamic.linux-m4xlarge-arm64.ssh-secret: {{ (index $config "ssh-secret") | default "aws-ssh-key" | quote }}
+  dynamic.linux-m4xlarge-arm64.security-group-id: {{ default (index $arm "security-group-id") ((index $config "security-group-id")) | quote }}
+  dynamic.linux-m4xlarge-arm64.max-instances: {{ (index $config "max-instances") | default "250" | quote }}
+  dynamic.linux-m4xlarge-arm64.subnet-id: {{ default (index $arm "subnet-id") ((index $config "subnet-id")) | quote }}
+  dynamic.linux-m4xlarge-arm64.check-interval: {{ (index $config "check-interval") | default "60" | quote }}
+  dynamic.linux-m4xlarge-arm64.allocation-timeout: "1200"
+  {{ end }}
+
+  {{- if hasKey .Values.dynamicConfigs "linux-m4xlarge-amd64" }}
+  {{- $config := index .Values.dynamicConfigs "linux-m4xlarge-amd64" | default (dict) }}
+  dynamic.linux-m4xlarge-amd64.type: {{ index $config "type" | default "aws" | quote }}
+  dynamic.linux-m4xlarge-amd64.region: {{ index $config "region" | default "us-east-1" | quote }}
+  dynamic.linux-m4xlarge-amd64.ami: {{ default (index $amd "ami") $config.ami | quote }}
+  dynamic.linux-m4xlarge-amd64.instance-type: {{ (index $config "instance-type") | default "m6a.4xlarge" | quote }}
+  dynamic.linux-m4xlarge-amd64.instance-tag: {{ (index $config "instance-tag") | default (printf "%s-amd64-m4xlarge" $environment) | quote }}
+  dynamic.linux-m4xlarge-amd64.key-name: {{ default (index $amd "key-name") ((index $config "key-name")) | quote }}
+  dynamic.linux-m4xlarge-amd64.aws-secret: {{ (index $config "aws-secret") | default "aws-account" | quote }}
+  dynamic.linux-m4xlarge-amd64.ssh-secret: {{ (index $config "ssh-secret") | default "aws-ssh-key" | quote }}
+  dynamic.linux-m4xlarge-amd64.security-group-id: {{ default (index $amd "security-group-id") ((index $config "security-group-id")) | quote }}
+  dynamic.linux-m4xlarge-amd64.max-instances: {{ (index $config "max-instances") | default "250" | quote }}
+  dynamic.linux-m4xlarge-amd64.subnet-id: {{ default (index $amd "subnet-id") ((index $config "subnet-id")) | quote }}
+  dynamic.linux-m4xlarge-amd64.check-interval: {{ (index $config "check-interval") | default "60" | quote }}
+  dynamic.linux-m4xlarge-amd64.allocation-timeout: "1200"
+  {{ end }}
+
+  {{- if hasKey .Values.dynamicConfigs "linux-d160-m4xlarge-arm64" }}
+  {{- $config := index .Values.dynamicConfigs "linux-d160-m4xlarge-arm64" | default (dict) }}
+  dynamic.linux-d160-m4xlarge-arm64.type: {{ index $config "type" | default "aws" | quote }}
+  dynamic.linux-d160-m4xlarge-arm64.region: {{ index $config "region" | default "us-east-1" | quote }}
+  dynamic.linux-d160-m4xlarge-arm64.ami: {{ default (index $arm "ami") $config.ami | quote }}
+  dynamic.linux-d160-m4xlarge-arm64.instance-type: {{ (index $config "instance-type") | default "m6g.4xlarge" | quote }}
+  dynamic.linux-d160-m4xlarge-arm64.instance-tag: {{ (index $config "instance-tag") | default (printf "%s-arm64-m4xlarge-d160" $environment) | quote }}
+  dynamic.linux-d160-m4xlarge-arm64.key-name: {{ default (index $arm "key-name") ((index $config "key-name")) | quote }}
+  dynamic.linux-d160-m4xlarge-arm64.aws-secret: {{ (index $config "aws-secret") | default "aws-account" | quote }}
+  dynamic.linux-d160-m4xlarge-arm64.ssh-secret: {{ (index $config "ssh-secret") | default "aws-ssh-key" | quote }}
+  dynamic.linux-d160-m4xlarge-arm64.security-group-id: {{ default (index $arm "security-group-id") ((index $config "security-group-id")) | quote }}
+  dynamic.linux-d160-m4xlarge-arm64.max-instances: {{ (index $config "max-instances") | default "250" | quote }}
+  dynamic.linux-d160-m4xlarge-arm64.subnet-id: {{ default (index $arm "subnet-id") ((index $config "subnet-id")) | quote }}
+  dynamic.linux-d160-m4xlarge-arm64.check-interval: {{ (index $config "check-interval") | default "60" | quote }}
+  dynamic.linux-d160-m4xlarge-arm64.disk: "160"
+  dynamic.linux-d160-m4xlarge-arm64.allocation-timeout: "1200"
+  {{ end }}
+
+  {{- if hasKey .Values.dynamicConfigs "linux-d160-m4xlarge-amd64" }}
+  {{- $config := index .Values.dynamicConfigs "linux-d160-m4xlarge-amd64" | default (dict) }}
+  dynamic.linux-d160-m4xlarge-amd64.type: {{ index $config "type" | default "aws" | quote }}
+  dynamic.linux-d160-m4xlarge-amd64.region: {{ index $config "region" | default "us-east-1" | quote }}
+  dynamic.linux-d160-m4xlarge-amd64.ami: {{ default (index $amd "ami") $config.ami | quote }}
+  dynamic.linux-d160-m4xlarge-amd64.instance-type: {{ (index $config "instance-type") | default "m6a.4xlarge" | quote }}
+  dynamic.linux-d160-m4xlarge-amd64.instance-tag: {{ (index $config "instance-tag") | default (printf "%s-amd64-m4xlarge-d160" $environment) | quote }}
+  dynamic.linux-d160-m4xlarge-amd64.key-name: {{ default (index $amd "key-name") ((index $config "key-name")) | quote }}
+  dynamic.linux-d160-m4xlarge-amd64.aws-secret: {{ (index $config "aws-secret") | default "aws-account" | quote }}
+  dynamic.linux-d160-m4xlarge-amd64.ssh-secret: {{ (index $config "ssh-secret") | default "aws-ssh-key" | quote }}
+  dynamic.linux-d160-m4xlarge-amd64.security-group-id: {{ default (index $amd "security-group-id") ((index $config "security-group-id")) | quote }}
+  dynamic.linux-d160-m4xlarge-amd64.max-instances: {{ (index $config "max-instances") | default "250" | quote }}
+  dynamic.linux-d160-m4xlarge-amd64.subnet-id: {{ default (index $amd "subnet-id") ((index $config "subnet-id")) | quote }}
+  dynamic.linux-d160-m4xlarge-amd64.check-interval: {{ (index $config "check-interval") | default "60" | quote }}
+  dynamic.linux-d160-m4xlarge-amd64.disk: "160"
+  dynamic.linux-d160-m4xlarge-amd64.allocation-timeout: "1200"
+  {{ end }}
+
+  {{- if hasKey .Values.dynamicConfigs "linux-m8xlarge-arm64" }}
+  {{- $config := index .Values.dynamicConfigs "linux-m8xlarge-arm64" | default (dict) }}
+  dynamic.linux-m8xlarge-arm64.type: {{ index $config "type" | default "aws" | quote }}
+  dynamic.linux-m8xlarge-arm64.region: {{ index $config "region" | default "us-east-1" | quote }}
+  dynamic.linux-m8xlarge-arm64.ami: {{ default (index $arm "ami") $config.ami | quote }}
+  dynamic.linux-m8xlarge-arm64.instance-type: {{ (index $config "instance-type") | default "m6g.8xlarge" | quote }}
+  dynamic.linux-m8xlarge-arm64.instance-tag: {{ (index $config "instance-tag") | default (printf "%s-arm64-m8xlarge" $environment) | quote }}
+  dynamic.linux-m8xlarge-arm64.key-name: {{ default (index $arm "key-name") ((index $config "key-name")) | quote }}
+  dynamic.linux-m8xlarge-arm64.aws-secret: {{ (index $config "aws-secret") | default "aws-account" | quote }}
+  dynamic.linux-m8xlarge-arm64.ssh-secret: {{ (index $config "ssh-secret") | default "aws-ssh-key" | quote }}
+  dynamic.linux-m8xlarge-arm64.security-group-id: {{ default (index $arm "security-group-id") ((index $config "security-group-id")) | quote }}
+  dynamic.linux-m8xlarge-arm64.max-instances: {{ (index $config "max-instances") | default "250" | quote }}
+  dynamic.linux-m8xlarge-arm64.subnet-id: {{ default (index $arm "subnet-id") ((index $config "subnet-id")) | quote }}
+  dynamic.linux-m8xlarge-arm64.check-interval: {{ (index $config "check-interval") | default "60" | quote }}
+  dynamic.linux-m8xlarge-arm64.allocation-timeout: "1200"
+  {{ end }}
+
+  {{- if hasKey .Values.dynamicConfigs "linux-m8xlarge-amd64" }}
+  {{- $config := index .Values.dynamicConfigs "linux-m8xlarge-amd64" | default (dict) }}
+  dynamic.linux-m8xlarge-amd64.type: {{ index $config "type" | default "aws" | quote }}
+  dynamic.linux-m8xlarge-amd64.region: {{ index $config "region" | default "us-east-1" | quote }}
+  dynamic.linux-m8xlarge-amd64.ami: {{ default (index $amd "ami") $config.ami | quote }}
+  dynamic.linux-m8xlarge-amd64.instance-type: {{ (index $config "instance-type") | default "m6a.8xlarge" | quote }}
+  dynamic.linux-m8xlarge-amd64.instance-tag: {{ (index $config "instance-tag") | default (printf "%s-amd64-m8xlarge" $environment) | quote }}
+  dynamic.linux-m8xlarge-amd64.key-name: {{ default (index $amd "key-name") ((index $config "key-name")) | quote }}
+  dynamic.linux-m8xlarge-amd64.aws-secret: {{ (index $config "aws-secret") | default "aws-account" | quote }}
+  dynamic.linux-m8xlarge-amd64.ssh-secret: {{ (index $config "ssh-secret") | default "aws-ssh-key" | quote }}
+  dynamic.linux-m8xlarge-amd64.security-group-id: {{ default (index $amd "security-group-id") ((index $config "security-group-id")) | quote }}
+  dynamic.linux-m8xlarge-amd64.max-instances: {{ (index $config "max-instances") | default "250" | quote }}
+  dynamic.linux-m8xlarge-amd64.subnet-id: {{ default (index $amd "subnet-id") ((index $config "subnet-id")) | quote }}
+  dynamic.linux-m8xlarge-amd64.check-interval: {{ (index $config "check-interval") | default "60" | quote }}
+  dynamic.linux-m8xlarge-amd64.allocation-timeout: "1200"
+  {{ end }}
+
+  {{- if hasKey .Values.dynamicConfigs "linux-d160-m7-8xlarge-amd64" }}
+  {{- $config := index .Values.dynamicConfigs "linux-d160-m7-8xlarge-amd64" | default (dict) }}
+  dynamic.linux-d160-m7-8xlarge-amd64.type: {{ index $config "type" | default "aws" | quote }}
+  dynamic.linux-d160-m7-8xlarge-amd64.region: {{ index $config "region" | default "us-east-1" | quote }}
+  dynamic.linux-d160-m7-8xlarge-amd64.ami: {{ default (index $amd "ami") $config.ami | quote }}
+  dynamic.linux-d160-m7-8xlarge-amd64.instance-type: {{ (index $config "instance-type") | default "m7a.8xlarge" | quote }}
+  dynamic.linux-d160-m7-8xlarge-amd64.instance-tag: {{ (index $config "instance-tag") | default (printf "%s-amd64-m7-8xlarge-d160" $environment) | quote }}
+  dynamic.linux-d160-m7-8xlarge-amd64.key-name: {{ default (index $amd "key-name") ((index $config "key-name")) | quote }}
+  dynamic.linux-d160-m7-8xlarge-amd64.aws-secret: {{ (index $config "aws-secret") | default "aws-account" | quote }}
+  dynamic.linux-d160-m7-8xlarge-amd64.ssh-secret: {{ (index $config "ssh-secret") | default "aws-ssh-key" | quote }}
+  dynamic.linux-d160-m7-8xlarge-amd64.security-group-id: {{ default (index $amd "security-group-id") ((index $config "security-group-id")) | quote }}
+  dynamic.linux-d160-m7-8xlarge-amd64.max-instances: {{ (index $config "max-instances") | default "250" | quote }}
+  dynamic.linux-d160-m7-8xlarge-amd64.subnet-id: {{ default (index $amd "subnet-id") ((index $config "subnet-id")) | quote }}
+  dynamic.linux-d160-m7-8xlarge-amd64.check-interval: {{ (index $config "check-interval") | default "60" | quote }}
+  dynamic.linux-d160-m7-8xlarge-amd64.disk: "160"
+  dynamic.linux-d160-m7-8xlarge-amd64.allocation-timeout: "1200"
+  {{ end }}
+
+  {{- if hasKey .Values.dynamicConfigs "linux-d160-m8-8xlarge-arm64" }}
+  {{- $config := index .Values.dynamicConfigs "linux-d160-m8-8xlarge-arm64" | default (dict) }}
+  dynamic.linux-d160-m8-8xlarge-arm64.type: {{ index $config "type" | default "aws" | quote }}
+  dynamic.linux-d160-m8-8xlarge-arm64.region: {{ index $config "region" | default "us-east-1" | quote }}
+  dynamic.linux-d160-m8-8xlarge-arm64.ami: {{ default (index $arm "ami") $config.ami | quote }}
+  dynamic.linux-d160-m8-8xlarge-arm64.instance-type: {{ (index $config "instance-type") | default "m8g.8xlarge" | quote }}
+  dynamic.linux-d160-m8-8xlarge-arm64.instance-tag: {{ (index $config "instance-tag") | default (printf "%s-arm64-m8-8xlarge-d160" $environment) | quote }}
+  dynamic.linux-d160-m8-8xlarge-arm64.key-name: {{ default (index $arm "key-name") ((index $config "key-name")) | quote }}
+  dynamic.linux-d160-m8-8xlarge-arm64.aws-secret: {{ (index $config "aws-secret") | default "aws-account" | quote }}
+  dynamic.linux-d160-m8-8xlarge-arm64.ssh-secret: {{ (index $config "ssh-secret") | default "aws-ssh-key" | quote }}
+  dynamic.linux-d160-m8-8xlarge-arm64.security-group-id: {{ default (index $arm "security-group-id") ((index $config "security-group-id")) | quote }}
+  dynamic.linux-d160-m8-8xlarge-arm64.max-instances: {{ (index $config "max-instances") | default "250" | quote }}
+  dynamic.linux-d160-m8-8xlarge-arm64.subnet-id: {{ default (index $arm "subnet-id") ((index $config "subnet-id")) | quote }}
+  dynamic.linux-d160-m8-8xlarge-arm64.check-interval: {{ (index $config "check-interval") | default "60" | quote }}
+  dynamic.linux-d160-m8-8xlarge-arm64.disk: "160"
+  dynamic.linux-d160-m8-8xlarge-arm64.allocation-timeout: "1200"
+  {{ end }}
+
+
+  {{- if hasKey .Values.dynamicConfigs "linux-d160-m8xlarge-arm64" }}
+  {{- $config := index .Values.dynamicConfigs "linux-d160-m8xlarge-arm64" | default (dict) }}
+  dynamic.linux-d160-m8xlarge-arm64.type: {{ index $config "type" | default "aws" | quote }}
+  dynamic.linux-d160-m8xlarge-arm64.region: {{ index $config "region" | default "us-east-1" | quote }}
+  dynamic.linux-d160-m8xlarge-arm64.ami: {{ default (index $arm "ami") $config.ami | quote }}
+  dynamic.linux-d160-m8xlarge-arm64.instance-type: {{ (index $config "instance-type") | default "m6g.8xlarge" | quote }}
+  dynamic.linux-d160-m8xlarge-arm64.instance-tag: {{ (index $config "instance-tag") | default (printf "%s-arm64-m8xlarge-d160" $environment) | quote }}
+  dynamic.linux-d160-m8xlarge-arm64.key-name: {{ default (index $arm "key-name") ((index $config "key-name")) | quote }}
+  dynamic.linux-d160-m8xlarge-arm64.aws-secret: {{ (index $config "aws-secret") | default "aws-account" | quote }}
+  dynamic.linux-d160-m8xlarge-arm64.ssh-secret: {{ (index $config "ssh-secret") | default "aws-ssh-key" | quote }}
+  dynamic.linux-d160-m8xlarge-arm64.security-group-id: {{ default (index $arm "security-group-id") ((index $config "security-group-id")) | quote }}
+  dynamic.linux-d160-m8xlarge-arm64.max-instances: {{ (index $config "max-instances") | default "250" | quote }}
+  dynamic.linux-d160-m8xlarge-arm64.subnet-id: {{ default (index $arm "subnet-id") ((index $config "subnet-id")) | quote }}
+  dynamic.linux-d160-m8xlarge-arm64.check-interval: {{ (index $config "check-interval") | default "60" | quote }}
+  dynamic.linux-d160-m8xlarge-arm64.disk: "160"
+  dynamic.linux-d160-m8xlarge-arm64.allocation-timeout: "1200"
+  {{ end }}
+
+  {{- if hasKey .Values.dynamicConfigs "linux-d160-m8xlarge-amd64" }}
+  {{- $config := index .Values.dynamicConfigs "linux-d160-m8xlarge-amd64" | default (dict) }}
+  dynamic.linux-d160-m8xlarge-amd64.type: {{ index $config "type" | default "aws" | quote }}
+  dynamic.linux-d160-m8xlarge-amd64.region: {{ index $config "region" | default "us-east-1" | quote }}
+  dynamic.linux-d160-m8xlarge-amd64.ami: {{ default (index $amd "ami") $config.ami | quote }}
+  dynamic.linux-d160-m8xlarge-amd64.instance-type: {{ (index $config "instance-type") | default "m6a.8xlarge" | quote }}
+  dynamic.linux-d160-m8xlarge-amd64.instance-tag: {{ (index $config "instance-tag") | default (printf "%s-amd64-m8xlarge-d160" $environment) | quote }}
+  dynamic.linux-d160-m8xlarge-amd64.key-name: {{ default (index $amd "key-name") ((index $config "key-name")) | quote }}
+  dynamic.linux-d160-m8xlarge-amd64.aws-secret: {{ (index $config "aws-secret") | default "aws-account" | quote }}
+  dynamic.linux-d160-m8xlarge-amd64.ssh-secret: {{ (index $config "ssh-secret") | default "aws-ssh-key" | quote }}
+  dynamic.linux-d160-m8xlarge-amd64.security-group-id: {{ default (index $amd "security-group-id") ((index $config "security-group-id")) | quote }}
+  dynamic.linux-d160-m8xlarge-amd64.max-instances: {{ (index $config "max-instances") | default "250" | quote }}
+  dynamic.linux-d160-m8xlarge-amd64.subnet-id: {{ default (index $amd "subnet-id") ((index $config "subnet-id")) | quote }}
+  dynamic.linux-d160-m8xlarge-amd64.check-interval: {{ (index $config "check-interval") | default "60" | quote }}
+  dynamic.linux-d160-m8xlarge-amd64.disk: "160"
+  dynamic.linux-d160-m8xlarge-amd64.allocation-timeout: "1200"
+  {{ end }}
+
+  {{- if hasKey .Values.dynamicConfigs "linux-c6gd2xlarge-arm64" }}
+  {{- $config := index .Values.dynamicConfigs "linux-c6gd2xlarge-arm64" | default (dict) }}
+  dynamic.linux-c6gd2xlarge-arm64.type: {{ index $config "type" | default "aws" | quote }}
+  dynamic.linux-c6gd2xlarge-arm64.region: {{ index $config "region" | default "us-east-1" | quote }}
+  dynamic.linux-c6gd2xlarge-arm64.ami: {{ default (index $arm "ami") $config.ami | quote }}
+  dynamic.linux-c6gd2xlarge-arm64.instance-type: {{ (index $config "instance-type") | default "c6gd.2xlarge" | quote }}
+  dynamic.linux-c6gd2xlarge-arm64.instance-tag: {{ (index $config "instance-tag") | default (printf "%s-arm64-c6gd2xlarge" $environment) | quote }}
+  dynamic.linux-c6gd2xlarge-arm64.key-name: {{ default (index $arm "key-name") ((index $config "key-name")) | quote }}
+  dynamic.linux-c6gd2xlarge-arm64.aws-secret: {{ (index $config "aws-secret") | default "aws-account" | quote }}
+  dynamic.linux-c6gd2xlarge-arm64.ssh-secret: {{ (index $config "ssh-secret") | default "aws-ssh-key" | quote }}
+  dynamic.linux-c6gd2xlarge-arm64.security-group-id: {{ default (index $arm "security-group-id") ((index $config "security-group-id")) | quote }}
+  dynamic.linux-c6gd2xlarge-arm64.max-instances: {{ (index $config "max-instances") | default "250" | quote }}
+  dynamic.linux-c6gd2xlarge-arm64.subnet-id: {{ default (index $arm "subnet-id") ((index $config "subnet-id")) | quote }}
+  dynamic.linux-c6gd2xlarge-arm64.check-interval: {{ (index $config "check-interval") | default "60" | quote }}
+  dynamic.linux-c6gd2xlarge-arm64.allocation-timeout: "1200"
+  {{- if or (index $config "user-data") (.Files.Get "files/linux-c6gd2xlarge-arm64-init.sh") }}
+  dynamic.linux-c6gd2xlarge-arm64.user-data: |
+  {{- if (index $config "user-data") }}
+  {{- $lines := splitList "\n" (index $config "user-data") }}
+  {{- range $line := $lines }}
+    {{ $line }}
+  {{- end }}
+  {{- else }}
+{{ include "multi-platform-controller.cloud-init-userdata" (.Files.Get "files/linux-c6gd2xlarge-arm64-init.sh") | indent 4 }}
+  {{- end }}
+  {{- end }}
+  {{ end }}
+
+  {{- if hasKey .Values.dynamicConfigs "linux-cxlarge-arm64" }}
+  {{- $config := index .Values.dynamicConfigs "linux-cxlarge-arm64" | default (dict) }}
+  dynamic.linux-cxlarge-arm64.type: {{ index $config "type" | default "aws" | quote }}
+  dynamic.linux-cxlarge-arm64.region: {{ index $config "region" | default "us-east-1" | quote }}
+  dynamic.linux-cxlarge-arm64.ami: {{ default (index $arm "ami") $config.ami | quote }}
+  dynamic.linux-cxlarge-arm64.instance-type: {{ (index $config "instance-type") | default "c6g.xlarge" | quote }}
+  dynamic.linux-cxlarge-arm64.instance-tag: {{ (index $config "instance-tag") | default (printf "%s-arm64-cxlarge" $environment) | quote }}
+  dynamic.linux-cxlarge-arm64.key-name: {{ default (index $arm "key-name") ((index $config "key-name")) | quote }}
+  dynamic.linux-cxlarge-arm64.aws-secret: {{ (index $config "aws-secret") | default "aws-account" | quote }}
+  dynamic.linux-cxlarge-arm64.ssh-secret: {{ (index $config "ssh-secret") | default "aws-ssh-key" | quote }}
+  dynamic.linux-cxlarge-arm64.security-group-id: {{ default (index $arm "security-group-id") ((index $config "security-group-id")) | quote }}
+  dynamic.linux-cxlarge-arm64.max-instances: {{ (index $config "max-instances") | default "250" | quote }}
+  dynamic.linux-cxlarge-arm64.subnet-id: {{ default (index $arm "subnet-id") ((index $config "subnet-id")) | quote }}
+  dynamic.linux-cxlarge-arm64.check-interval: {{ (index $config "check-interval") | default "60" | quote }}
+  dynamic.linux-cxlarge-arm64.allocation-timeout: "1200"
+  {{ end }}
+
+  {{- if hasKey .Values.dynamicConfigs "linux-cxlarge-amd64" }}
+  {{- $config := index .Values.dynamicConfigs "linux-cxlarge-amd64" | default (dict) }}
+  dynamic.linux-cxlarge-amd64.type: {{ index $config "type" | default "aws" | quote }}
+  dynamic.linux-cxlarge-amd64.region: {{ index $config "region" | default "us-east-1" | quote }}
+  dynamic.linux-cxlarge-amd64.ami: {{ default (index $amd "ami") $config.ami | quote }}
+  dynamic.linux-cxlarge-amd64.instance-type: {{ (index $config "instance-type") | default "c6a.xlarge" | quote }}
+  dynamic.linux-cxlarge-amd64.instance-tag: {{ (index $config "instance-tag") | default (printf "%s-amd64-cxlarge" $environment) | quote }}
+  dynamic.linux-cxlarge-amd64.key-name: {{ default (index $amd "key-name") ((index $config "key-name")) | quote }}
+  dynamic.linux-cxlarge-amd64.aws-secret: {{ (index $config "aws-secret") | default "aws-account" | quote }}
+  dynamic.linux-cxlarge-amd64.ssh-secret: {{ (index $config "ssh-secret") | default "aws-ssh-key" | quote }}
+  dynamic.linux-cxlarge-amd64.security-group-id: {{ default (index $amd "security-group-id") ((index $config "security-group-id")) | quote }}
+  dynamic.linux-cxlarge-amd64.max-instances: {{ (index $config "max-instances") | default "250" | quote }}
+  dynamic.linux-cxlarge-amd64.subnet-id: {{ default (index $amd "subnet-id") ((index $config "subnet-id")) | quote }}
+  dynamic.linux-cxlarge-amd64.check-interval: {{ (index $config "check-interval") | default "60" | quote }}
+  dynamic.linux-cxlarge-amd64.allocation-timeout: "1200"
+  {{ end }}
+
+  {{- if hasKey .Values.dynamicConfigs "linux-d160-cxlarge-arm64" }}
+  {{- $config := index .Values.dynamicConfigs "linux-d160-cxlarge-arm64" | default (dict) }}
+  dynamic.linux-d160-cxlarge-arm64.type: {{ index $config "type" | default "aws" | quote }}
+  dynamic.linux-d160-cxlarge-arm64.region: {{ index $config "region" | default "us-east-1" | quote }}
+  dynamic.linux-d160-cxlarge-arm64.ami: {{ default (index $arm "ami") $config.ami | quote }}
+  dynamic.linux-d160-cxlarge-arm64.instance-type: {{ (index $config "instance-type") | default "c6g.xlarge" | quote }}
+  dynamic.linux-d160-cxlarge-arm64.instance-tag: {{ (index $config "instance-tag") | default (printf "%s-arm64-cxlarge-d160" $environment) | quote }}
+  dynamic.linux-d160-cxlarge-arm64.key-name: {{ default (index $arm "key-name") ((index $config "key-name")) | quote }}
+  dynamic.linux-d160-cxlarge-arm64.aws-secret: {{ (index $config "aws-secret") | default "aws-account" | quote }}
+  dynamic.linux-d160-cxlarge-arm64.ssh-secret: {{ (index $config "ssh-secret") | default "aws-ssh-key" | quote }}
+  dynamic.linux-d160-cxlarge-arm64.security-group-id: {{ default (index $arm "security-group-id") ((index $config "security-group-id")) | quote }}
+  dynamic.linux-d160-cxlarge-arm64.max-instances: {{ (index $config "max-instances") | default "250" | quote }}
+  dynamic.linux-d160-cxlarge-arm64.subnet-id: {{ default (index $arm "subnet-id") ((index $config "subnet-id")) | quote }}
+  dynamic.linux-d160-cxlarge-arm64.check-interval: {{ (index $config "check-interval") | default "60" | quote }}
+  dynamic.linux-d160-cxlarge-arm64.disk: "160"
+  dynamic.linux-d160-cxlarge-arm64.allocation-timeout: "1200"
+  {{ end }}
+
+  {{- if hasKey .Values.dynamicConfigs "linux-d160-cxlarge-amd64" }}
+  {{- $config := index .Values.dynamicConfigs "linux-d160-cxlarge-amd64" | default (dict) }}
+  dynamic.linux-d160-cxlarge-amd64.type: {{ index $config "type" | default "aws" | quote }}
+  dynamic.linux-d160-cxlarge-amd64.region: {{ index $config "region" | default "us-east-1" | quote }}
+  dynamic.linux-d160-cxlarge-amd64.ami: {{ default (index $amd "ami") $config.ami | quote }}
+  dynamic.linux-d160-cxlarge-amd64.instance-type: {{ (index $config "instance-type") | default "c6a.xlarge" | quote }}
+  dynamic.linux-d160-cxlarge-amd64.instance-tag: {{ (index $config "instance-tag") | default (printf "%s-amd64-cxlarge-d160" $environment) | quote }}
+  dynamic.linux-d160-cxlarge-amd64.key-name: {{ default (index $amd "key-name") ((index $config "key-name")) | quote }}
+  dynamic.linux-d160-cxlarge-amd64.aws-secret: {{ (index $config "aws-secret") | default "aws-account" | quote }}
+  dynamic.linux-d160-cxlarge-amd64.ssh-secret: {{ (index $config "ssh-secret") | default "aws-ssh-key" | quote }}
+  dynamic.linux-d160-cxlarge-amd64.security-group-id: {{ default (index $amd "security-group-id") ((index $config "security-group-id")) | quote }}
+  dynamic.linux-d160-cxlarge-amd64.max-instances: {{ (index $config "max-instances") | default "250" | quote }}
+  dynamic.linux-d160-cxlarge-amd64.subnet-id: {{ default (index $amd "subnet-id") ((index $config "subnet-id")) | quote }}
+  dynamic.linux-d160-cxlarge-amd64.check-interval: {{ (index $config "check-interval") | default "60" | quote }}
+  dynamic.linux-d160-cxlarge-amd64.disk: "160"
+  dynamic.linux-d160-cxlarge-amd64.allocation-timeout: "1200"
+  {{ end }}
+
+  {{- if hasKey .Values.dynamicConfigs "linux-c2xlarge-arm64" }}
+  {{- $config := index .Values.dynamicConfigs "linux-c2xlarge-arm64" | default (dict) }}
+  dynamic.linux-c2xlarge-arm64.type: {{ index $config "type" | default "aws" | quote }}
+  dynamic.linux-c2xlarge-arm64.region: {{ index $config "region" | default "us-east-1" | quote }}
+  dynamic.linux-c2xlarge-arm64.ami: {{ default (index $arm "ami") $config.ami | quote }}
+  dynamic.linux-c2xlarge-arm64.instance-type: {{ (index $config "instance-type") | default "c6g.2xlarge" | quote }}
+  dynamic.linux-c2xlarge-arm64.instance-tag: {{ (index $config "instance-tag") | default (printf "%s-arm64-c2xlarge" $environment) | quote }}
+  dynamic.linux-c2xlarge-arm64.key-name: {{ default (index $arm "key-name") ((index $config "key-name")) | quote }}
+  dynamic.linux-c2xlarge-arm64.aws-secret: {{ (index $config "aws-secret") | default "aws-account" | quote }}
+  dynamic.linux-c2xlarge-arm64.ssh-secret: {{ (index $config "ssh-secret") | default "aws-ssh-key" | quote }}
+  dynamic.linux-c2xlarge-arm64.security-group-id: {{ default (index $arm "security-group-id") ((index $config "security-group-id")) | quote }}
+  dynamic.linux-c2xlarge-arm64.max-instances: {{ (index $config "max-instances") | default "250" | quote }}
+  dynamic.linux-c2xlarge-arm64.subnet-id: {{ default (index $arm "subnet-id") ((index $config "subnet-id")) | quote }}
+  dynamic.linux-c2xlarge-arm64.check-interval: {{ (index $config "check-interval") | default "60" | quote }}
+  dynamic.linux-c2xlarge-arm64.allocation-timeout: "1200"
+  {{ end }}
+
+  {{- if hasKey .Values.dynamicConfigs "linux-c2xlarge-amd64" }}
+  {{- $config := index .Values.dynamicConfigs "linux-c2xlarge-amd64" | default (dict) }}
+  dynamic.linux-c2xlarge-amd64.type: {{ index $config "type" | default "aws" | quote }}
+  dynamic.linux-c2xlarge-amd64.region: {{ index $config "region" | default "us-east-1" | quote }}
+  dynamic.linux-c2xlarge-amd64.ami: {{ default (index $amd "ami") $config.ami | quote }}
+  dynamic.linux-c2xlarge-amd64.instance-type: {{ (index $config "instance-type") | default "c6a.2xlarge" | quote }}
+  dynamic.linux-c2xlarge-amd64.instance-tag: {{ (index $config "instance-tag") | default (printf "%s-amd64-c2xlarge" $environment) | quote }}
+  dynamic.linux-c2xlarge-amd64.key-name: {{ default (index $amd "key-name") ((index $config "key-name")) | quote }}
+  dynamic.linux-c2xlarge-amd64.aws-secret: {{ (index $config "aws-secret") | default "aws-account" | quote }}
+  dynamic.linux-c2xlarge-amd64.ssh-secret: {{ (index $config "ssh-secret") | default "aws-ssh-key" | quote }}
+  dynamic.linux-c2xlarge-amd64.security-group-id: {{ default (index $amd "security-group-id") ((index $config "security-group-id")) | quote }}
+  dynamic.linux-c2xlarge-amd64.max-instances: {{ (index $config "max-instances") | default "250" | quote }}
+  dynamic.linux-c2xlarge-amd64.subnet-id: {{ default (index $amd "subnet-id") ((index $config "subnet-id")) | quote }}
+  dynamic.linux-c2xlarge-amd64.check-interval: {{ (index $config "check-interval") | default "60" | quote }}
+  dynamic.linux-c2xlarge-amd64.allocation-timeout: "1200"
+  {{ end }}
+
+  {{- if hasKey .Values.dynamicConfigs "linux-d160-c2xlarge-arm64" }}
+  {{- $config := index .Values.dynamicConfigs "linux-d160-c2xlarge-arm64" | default (dict) }}
+  dynamic.linux-d160-c2xlarge-arm64.type: {{ index $config "type" | default "aws" | quote }}
+  dynamic.linux-d160-c2xlarge-arm64.region: {{ index $config "region" | default "us-east-1" | quote }}
+  dynamic.linux-d160-c2xlarge-arm64.ami: {{ default (index $arm "ami") $config.ami | quote }}
+  dynamic.linux-d160-c2xlarge-arm64.instance-type: {{ (index $config "instance-type") | default "c6g.2xlarge" | quote }}
+  dynamic.linux-d160-c2xlarge-arm64.instance-tag: {{ (index $config "instance-tag") | default (printf "%s-arm64-c2xlarge-d160" $environment) | quote }}
+  dynamic.linux-d160-c2xlarge-arm64.key-name: {{ default (index $arm "key-name") ((index $config "key-name")) | quote }}
+  dynamic.linux-d160-c2xlarge-arm64.aws-secret: {{ (index $config "aws-secret") | default "aws-account" | quote }}
+  dynamic.linux-d160-c2xlarge-arm64.ssh-secret: {{ (index $config "ssh-secret") | default "aws-ssh-key" | quote }}
+  dynamic.linux-d160-c2xlarge-arm64.security-group-id: {{ default (index $arm "security-group-id") ((index $config "security-group-id")) | quote }}
+  dynamic.linux-d160-c2xlarge-arm64.max-instances: {{ (index $config "max-instances") | default "250" | quote }}
+  dynamic.linux-d160-c2xlarge-arm64.subnet-id: {{ default (index $arm "subnet-id") ((index $config "subnet-id")) | quote }}
+  dynamic.linux-d160-c2xlarge-arm64.check-interval: {{ (index $config "check-interval") | default "60" | quote }}
+  dynamic.linux-d160-c2xlarge-arm64.disk: "160"
+  dynamic.linux-d160-c2xlarge-arm64.allocation-timeout: "1200"
+  {{ end }}
+
+  {{- if hasKey .Values.dynamicConfigs "linux-d160-c2xlarge-amd64" }}
+  {{- $config := index .Values.dynamicConfigs "linux-d160-c2xlarge-amd64" | default (dict) }}
+  dynamic.linux-d160-c2xlarge-amd64.type: {{ index $config "type" | default "aws" | quote }}
+  dynamic.linux-d160-c2xlarge-amd64.region: {{ index $config "region" | default "us-east-1" | quote }}
+  dynamic.linux-d160-c2xlarge-amd64.ami: {{ default (index $amd "ami") $config.ami | quote }}
+  dynamic.linux-d160-c2xlarge-amd64.instance-type: {{ (index $config "instance-type") | default "c6a.2xlarge" | quote }}
+  dynamic.linux-d160-c2xlarge-amd64.instance-tag: {{ (index $config "instance-tag") | default (printf "%s-amd64-c2xlarge-d160" $environment) | quote }}
+  dynamic.linux-d160-c2xlarge-amd64.key-name: {{ default (index $amd "key-name") ((index $config "key-name")) | quote }}
+  dynamic.linux-d160-c2xlarge-amd64.aws-secret: {{ (index $config "aws-secret") | default "aws-account" | quote }}
+  dynamic.linux-d160-c2xlarge-amd64.ssh-secret: {{ (index $config "ssh-secret") | default "aws-ssh-key" | quote }}
+  dynamic.linux-d160-c2xlarge-amd64.security-group-id: {{ default (index $amd "security-group-id") ((index $config "security-group-id")) | quote }}
+  dynamic.linux-d160-c2xlarge-amd64.max-instances: {{ (index $config "max-instances") | default "250" | quote }}
+  dynamic.linux-d160-c2xlarge-amd64.subnet-id: {{ default (index $amd "subnet-id") ((index $config "subnet-id")) | quote }}
+  dynamic.linux-d160-c2xlarge-amd64.check-interval: {{ (index $config "check-interval") | default "60" | quote }}
+  dynamic.linux-d160-c2xlarge-amd64.disk: "160"
+  dynamic.linux-d160-c2xlarge-amd64.allocation-timeout: "1200"
+  {{ end }}
+
+  {{- if hasKey .Values.dynamicConfigs "linux-c4xlarge-arm64" }}
+  {{- $config := index .Values.dynamicConfigs "linux-c4xlarge-arm64" | default (dict) }}
+  dynamic.linux-c4xlarge-arm64.type: {{ index $config "type" | default "aws" | quote }}
+  dynamic.linux-c4xlarge-arm64.region: {{ index $config "region" | default "us-east-1" | quote }}
+  dynamic.linux-c4xlarge-arm64.ami: {{ default (index $arm "ami") $config.ami | quote }}
+  dynamic.linux-c4xlarge-arm64.instance-type: {{ (index $config "instance-type") | default "c6g.4xlarge" | quote }}
+  dynamic.linux-c4xlarge-arm64.instance-tag: {{ (index $config "instance-tag") | default (printf "%s-arm64-c4xlarge" $environment) | quote }}
+  dynamic.linux-c4xlarge-arm64.key-name: {{ default (index $arm "key-name") ((index $config "key-name")) | quote }}
+  dynamic.linux-c4xlarge-arm64.aws-secret: {{ (index $config "aws-secret") | default "aws-account" | quote }}
+  dynamic.linux-c4xlarge-arm64.ssh-secret: {{ (index $config "ssh-secret") | default "aws-ssh-key" | quote }}
+  dynamic.linux-c4xlarge-arm64.security-group-id: {{ default (index $arm "security-group-id") ((index $config "security-group-id")) | quote }}
+  dynamic.linux-c4xlarge-arm64.max-instances: {{ (index $config "max-instances") | default "250" | quote }}
+  dynamic.linux-c4xlarge-arm64.subnet-id: {{ default (index $arm "subnet-id") ((index $config "subnet-id")) | quote }}
+  dynamic.linux-c4xlarge-arm64.check-interval: {{ (index $config "check-interval") | default "60" | quote }}
+  dynamic.linux-c4xlarge-arm64.allocation-timeout: "1200"
+  {{ end }}
+
+  {{- if hasKey .Values.dynamicConfigs "linux-c4xlarge-amd64" }}
+  {{- $config := index .Values.dynamicConfigs "linux-c4xlarge-amd64" | default (dict) }}
+  dynamic.linux-c4xlarge-amd64.type: {{ index $config "type" | default "aws" | quote }}
+  dynamic.linux-c4xlarge-amd64.region: {{ index $config "region" | default "us-east-1" | quote }}
+  dynamic.linux-c4xlarge-amd64.ami: {{ default (index $amd "ami") $config.ami | quote }}
+  dynamic.linux-c4xlarge-amd64.instance-type:  {{ (index $config "instance-type") | default "c6a.4xlarge" | quote }}
+  dynamic.linux-c4xlarge-amd64.instance-tag: {{ (index $config "instance-tag") | default (printf "%s-amd64-c4xlarge" $environment) | quote }}
+  dynamic.linux-c4xlarge-amd64.key-name: {{ default (index $amd "key-name") ((index $config "key-name")) | quote }}
+  dynamic.linux-c4xlarge-amd64.aws-secret: {{ (index $config "aws-secret") | default "aws-account" | quote }}
+  dynamic.linux-c4xlarge-amd64.ssh-secret: {{ (index $config "ssh-secret") | default "aws-ssh-key" | quote }}
+  dynamic.linux-c4xlarge-amd64.security-group-id: {{ default (index $amd "security-group-id") ((index $config "security-group-id")) | quote }}
+  dynamic.linux-c4xlarge-amd64.max-instances: {{ (index $config "max-instances") | default "250" | quote }}
+  dynamic.linux-c4xlarge-amd64.subnet-id: {{ default (index $amd "subnet-id") ((index $config "subnet-id")) | quote }}
+  dynamic.linux-c4xlarge-amd64.check-interval: {{ (index $config "check-interval") | default "60" | quote }}
+  dynamic.linux-c4xlarge-amd64.allocation-timeout: "1200"
+  {{ end }}
+
+  {{- if hasKey .Values.dynamicConfigs "linux-d160-c4xlarge-arm64" }}
+  {{- $config := index .Values.dynamicConfigs "linux-d160-c4xlarge-arm64" | default (dict) }}
+  dynamic.linux-d160-c4xlarge-arm64.type: {{ index $config "type" | default "aws" | quote }}
+  dynamic.linux-d160-c4xlarge-arm64.region: {{ index $config "region" | default "us-east-1" | quote }}
+  dynamic.linux-d160-c4xlarge-arm64.ami: {{ default (index $arm "ami") $config.ami | quote }}
+  dynamic.linux-d160-c4xlarge-arm64.instance-type: {{ (index $config "instance-type") | default "c6g.4xlarge" | quote }}
+  dynamic.linux-d160-c4xlarge-arm64.instance-tag: {{ (index $config "instance-tag") | default (printf "%s-arm64-c4xlarge-d160" $environment) | quote }}
+  dynamic.linux-d160-c4xlarge-arm64.key-name: {{ default (index $arm "key-name") ((index $config "key-name")) | quote }}
+  dynamic.linux-d160-c4xlarge-arm64.aws-secret: {{ (index $config "aws-secret") | default "aws-account" | quote }}
+  dynamic.linux-d160-c4xlarge-arm64.ssh-secret: {{ (index $config "ssh-secret") | default "aws-ssh-key" | quote }}
+  dynamic.linux-d160-c4xlarge-arm64.security-group-id: {{ default (index $arm "security-group-id") ((index $config "security-group-id")) | quote }}
+  dynamic.linux-d160-c4xlarge-arm64.max-instances: {{ (index $config "max-instances") | default "250" | quote }}
+  dynamic.linux-d160-c4xlarge-arm64.subnet-id: {{ default (index $arm "subnet-id") ((index $config "subnet-id")) | quote }}
+  dynamic.linux-d160-c4xlarge-arm64.check-interval: {{ (index $config "check-interval") | default "60" | quote }}
+  dynamic.linux-d160-c4xlarge-arm64.disk: "160"
+  dynamic.linux-d160-c4xlarge-arm64.allocation-timeout: "1200"
+  {{ end }}
+
+  {{- if hasKey .Values.dynamicConfigs "linux-d160-c4xlarge-amd64" }}
+  {{- $config := index .Values.dynamicConfigs "linux-d160-c4xlarge-amd64" | default (dict) }}
+  dynamic.linux-d160-c4xlarge-amd64.type: {{ index $config "type" | default "aws" | quote }}
+  dynamic.linux-d160-c4xlarge-amd64.region: {{ index $config "region" | default "us-east-1" | quote }}
+  dynamic.linux-d160-c4xlarge-amd64.ami: {{ default (index $amd "ami") $config.ami | quote }}
+  dynamic.linux-d160-c4xlarge-amd64.instance-type: {{ (index $config "instance-type") | default "c6a.4xlarge" | quote }}
+  dynamic.linux-d160-c4xlarge-amd64.instance-tag: {{ (index $config "instance-tag") | default (printf "%s-amd64-c4xlarge-d160" $environment) | quote }}
+  dynamic.linux-d160-c4xlarge-amd64.key-name: {{ default (index $amd "key-name") ((index $config "key-name")) | quote }}
+  dynamic.linux-d160-c4xlarge-amd64.aws-secret: {{ (index $config "aws-secret") | default "aws-account" | quote }}
+  dynamic.linux-d160-c4xlarge-amd64.ssh-secret: {{ (index $config "ssh-secret") | default "aws-ssh-key" | quote }}
+  dynamic.linux-d160-c4xlarge-amd64.security-group-id: {{ default (index $amd "security-group-id") ((index $config "security-group-id")) | quote }}
+  dynamic.linux-d160-c4xlarge-amd64.max-instances: {{ (index $config "max-instances") | default "250" | quote }}
+  dynamic.linux-d160-c4xlarge-amd64.subnet-id: {{ default (index $amd "subnet-id") ((index $config "subnet-id")) | quote }}
+  dynamic.linux-d160-c4xlarge-amd64.check-interval: {{ (index $config "check-interval") | default "60" | quote }}
+  dynamic.linux-d160-c4xlarge-amd64.disk: "160"
+  dynamic.linux-d160-c4xlarge-amd64.allocation-timeout: "1200"
+  {{ end }}
+
+  {{- if hasKey .Values.dynamicConfigs "linux-d320-c4xlarge-arm64" }}
+  {{- $config := index .Values.dynamicConfigs "linux-d320-c4xlarge-arm64" | default (dict) }}
+  dynamic.linux-d320-c4xlarge-arm64.type: {{ index $config "type" | default "aws" | quote }}
+  dynamic.linux-d320-c4xlarge-arm64.region: {{ index $config "region" | default "us-east-1" | quote }}
+  dynamic.linux-d320-c4xlarge-arm64.ami: {{ default (index $arm "ami") $config.ami | quote }}
+  dynamic.linux-d320-c4xlarge-arm64.instance-type: {{ (index $config "instance-type") | default "c6g.4xlarge" | quote }}
+  dynamic.linux-d320-c4xlarge-arm64.instance-tag: {{ (index $config "instance-tag") | default (printf "%s-arm64-c4xlarge-d320" $environment) | quote }}
+  dynamic.linux-d320-c4xlarge-arm64.key-name: {{ default (index $arm "key-name") ((index $config "key-name")) | quote }}
+  dynamic.linux-d320-c4xlarge-arm64.aws-secret: {{ (index $config "aws-secret") | default "aws-account" | quote }}
+  dynamic.linux-d320-c4xlarge-arm64.ssh-secret: {{ (index $config "ssh-secret") | default "aws-ssh-key" | quote }}
+  dynamic.linux-d320-c4xlarge-arm64.security-group-id: {{ default (index $arm "security-group-id") ((index $config "security-group-id")) | quote }}
+  dynamic.linux-d320-c4xlarge-arm64.max-instances: {{ (index $config "max-instances") | default "250" | quote }}
+  dynamic.linux-d320-c4xlarge-arm64.subnet-id: {{ default (index $arm "subnet-id") ((index $config "subnet-id")) | quote }}
+  dynamic.linux-d320-c4xlarge-arm64.check-interval: {{ (index $config "check-interval") | default "60" | quote }}
+  dynamic.linux-d320-c4xlarge-arm64.disk: "320"
+  dynamic.linux-d320-c4xlarge-arm64.allocation-timeout: "1200"
+  {{ end }}
+
+  {{- if hasKey .Values.dynamicConfigs "linux-d320-c4xlarge-amd64" }}
+  {{- $config := index .Values.dynamicConfigs "linux-d320-c4xlarge-amd64" | default (dict) }}
+  dynamic.linux-d320-c4xlarge-amd64.type: {{ index $config "type" | default "aws" | quote }}
+  dynamic.linux-d320-c4xlarge-amd64.region: {{ index $config "region" | default "us-east-1" | quote }}
+  dynamic.linux-d320-c4xlarge-amd64.ami: {{ default (index $amd "ami") $config.ami | quote }}
+  dynamic.linux-d320-c4xlarge-amd64.instance-type: {{ (index $config "instance-type") | default "c6a.4xlarge" | quote }}
+  dynamic.linux-d320-c4xlarge-amd64.instance-tag: {{ (index $config "instance-tag") | default (printf "%s-amd64-c4xlarge-d320" $environment) | quote }}
+  dynamic.linux-d320-c4xlarge-amd64.key-name: {{ default (index $amd "key-name") ((index $config "key-name")) | quote }}
+  dynamic.linux-d320-c4xlarge-amd64.aws-secret: {{ (index $config "aws-secret") | default "aws-account" | quote }}
+  dynamic.linux-d320-c4xlarge-amd64.ssh-secret: {{ (index $config "ssh-secret") | default "aws-ssh-key" | quote }}
+  dynamic.linux-d320-c4xlarge-amd64.security-group-id: {{ default (index $amd "security-group-id") ((index $config "security-group-id")) | quote }}
+  dynamic.linux-d320-c4xlarge-amd64.max-instances: {{ (index $config "max-instances") | default "250" | quote }}
+  dynamic.linux-d320-c4xlarge-amd64.subnet-id: {{ default (index $amd "subnet-id") ((index $config "subnet-id")) | quote }}
+  dynamic.linux-d320-c4xlarge-amd64.check-interval: {{ (index $config "check-interval") | default "60" | quote }}
+  dynamic.linux-d320-c4xlarge-amd64.disk: "320"
+  dynamic.linux-d320-c4xlarge-amd64.allocation-timeout: "1200"
+  {{ end }}
+
+  {{- if hasKey .Values.dynamicConfigs "linux-d320-m8xlarge-arm64" }}
+  {{- $config := index .Values.dynamicConfigs "linux-d320-m8xlarge-arm64" | default (dict) }}
+  dynamic.linux-d320-m8xlarge-arm64.type: {{ index $config "type" | default "aws" | quote }}
+  dynamic.linux-d320-m8xlarge-arm64.region: {{ index $config "region" | default "us-east-1" | quote }}
+  dynamic.linux-d320-m8xlarge-arm64.ami: {{ default (index $arm "ami") $config.ami | quote }}
+  dynamic.linux-d320-m8xlarge-arm64.instance-type: {{ (index $config "instance-type") | default "m6g.8xlarge" | quote }}
+  dynamic.linux-d320-m8xlarge-arm64.instance-tag: {{ (index $config "instance-tag") | default (printf "%s-arm64-m8xlarge-d320" $environment) | quote }}
+  dynamic.linux-d320-m8xlarge-arm64.key-name: {{ default (index $arm "key-name") ((index $config "key-name")) | quote }}
+  dynamic.linux-d320-m8xlarge-arm64.aws-secret: {{ (index $config "aws-secret") | default "aws-account" | quote }}
+  dynamic.linux-d320-m8xlarge-arm64.ssh-secret: {{ (index $config "ssh-secret") | default "aws-ssh-key" | quote }}
+  dynamic.linux-d320-m8xlarge-arm64.security-group-id: {{ default (index $arm "security-group-id") ((index $config "security-group-id")) | quote }}
+  dynamic.linux-d320-m8xlarge-arm64.max-instances: {{ (index $config "max-instances") | default "250" | quote }}
+  dynamic.linux-d320-m8xlarge-arm64.subnet-id: {{ default (index $arm "subnet-id") ((index $config "subnet-id")) | quote }}
+  dynamic.linux-d320-m8xlarge-arm64.check-interval: {{ (index $config "check-interval") | default "60" | quote }}
+  dynamic.linux-d320-m8xlarge-arm64.disk: "320"
+  dynamic.linux-d320-m8xlarge-arm64.allocation-timeout: "1200"
+  {{ end }}
+
+  {{- if hasKey .Values.dynamicConfigs "linux-d320-m8xlarge-amd64" }}
+  {{- $config := index .Values.dynamicConfigs "linux-d320-m8xlarge-amd64" | default (dict) }}
+  dynamic.linux-d320-m8xlarge-amd64.type: {{ index $config "type" | default "aws" | quote }}
+  dynamic.linux-d320-m8xlarge-amd64.region: {{ index $config "region" | default "us-east-1" | quote }}
+  dynamic.linux-d320-m8xlarge-amd64.ami: {{ default (index $amd "ami") $config.ami | quote }}
+  dynamic.linux-d320-m8xlarge-amd64.instance-type: {{ (index $config "instance-type") | default "m6a.8xlarge" | quote }}
+  dynamic.linux-d320-m8xlarge-amd64.instance-tag: {{ (index $config "instance-tag") | default (printf "%s-amd64-m8xlarge-d320" $environment) | quote }}
+  dynamic.linux-d320-m8xlarge-amd64.key-name: {{ default (index $amd "key-name") ((index $config "key-name")) | quote }}
+  dynamic.linux-d320-m8xlarge-amd64.aws-secret: {{ (index $config "aws-secret") | default "aws-account" | quote }}
+  dynamic.linux-d320-m8xlarge-amd64.ssh-secret: {{ (index $config "ssh-secret") | default "aws-ssh-key" | quote }}
+  dynamic.linux-d320-m8xlarge-amd64.security-group-id: {{ default (index $amd "security-group-id") ((index $config "security-group-id")) | quote }}
+  dynamic.linux-d320-m8xlarge-amd64.max-instances: {{ (index $config "max-instances") | default "250" | quote }}
+  dynamic.linux-d320-m8xlarge-amd64.subnet-id: {{ default (index $amd "subnet-id") ((index $config "subnet-id")) | quote }}
+  dynamic.linux-d320-m8xlarge-amd64.check-interval: {{ (index $config "check-interval") | default "60" | quote }}
+  dynamic.linux-d320-m8xlarge-amd64.disk: "320"
+  dynamic.linux-d320-m8xlarge-amd64.allocation-timeout: "1200"
+  {{ end }}
+
+  {{- if hasKey .Values.dynamicConfigs "linux-c8xlarge-arm64" }}
+  {{- $config := index .Values.dynamicConfigs "linux-c8xlarge-arm64" | default (dict) }}
+  dynamic.linux-c8xlarge-arm64.type: {{ index $config "type" | default "aws" | quote }}
+  dynamic.linux-c8xlarge-arm64.region: {{ index $config "region" | default "us-east-1" | quote }}
+  dynamic.linux-c8xlarge-arm64.ami: {{ default (index $arm "ami") $config.ami | quote }}
+  dynamic.linux-c8xlarge-arm64.instance-type: {{ (index $config "instance-type") | default "c6g.8xlarge" | quote }}
+  dynamic.linux-c8xlarge-arm64.instance-tag: {{ (index $config "instance-tag") | default (printf "%s-arm64-c8xlarge" $environment) | quote }}
+  dynamic.linux-c8xlarge-arm64.key-name: {{ default (index $arm "key-name") ((index $config "key-name")) | quote }}
+  dynamic.linux-c8xlarge-arm64.aws-secret: {{ (index $config "aws-secret") | default "aws-account" | quote }}
+  dynamic.linux-c8xlarge-arm64.ssh-secret: {{ (index $config "ssh-secret") | default "aws-ssh-key" | quote }}
+  dynamic.linux-c8xlarge-arm64.security-group-id: {{ default (index $arm "security-group-id") ((index $config "security-group-id")) | quote }}
+  dynamic.linux-c8xlarge-arm64.max-instances: {{ (index $config "max-instances") | default "250" | quote }}
+  dynamic.linux-c8xlarge-arm64.subnet-id: {{ default (index $arm "subnet-id") ((index $config "subnet-id")) | quote }}
+  dynamic.linux-c8xlarge-arm64.check-interval: {{ (index $config "check-interval") | default "60" | quote }}
+  dynamic.linux-c8xlarge-arm64.allocation-timeout: "1200"
+  {{ end }}
+
+  {{- if hasKey .Values.dynamicConfigs "linux-c8xlarge-amd64" }}
+  {{- $config := index .Values.dynamicConfigs "linux-c8xlarge-amd64" | default (dict) }}
+  dynamic.linux-c8xlarge-amd64.type: {{ index $config "type" | default "aws" | quote }}
+  dynamic.linux-c8xlarge-amd64.region: {{ index $config "region" | default "us-east-1" | quote }}
+  dynamic.linux-c8xlarge-amd64.ami: {{ default (index $amd "ami") $config.ami | quote }}
+  dynamic.linux-c8xlarge-amd64.instance-type:  {{ (index $config "instance-type") | default "c6a.8xlarge" | quote }}
+  dynamic.linux-c8xlarge-amd64.instance-tag: {{ (index $config "instance-tag") | default (printf "%s-amd64-c8xlarge" $environment) | quote }}
+  dynamic.linux-c8xlarge-amd64.key-name: {{ default (index $amd "key-name") ((index $config "key-name")) | quote }}
+  dynamic.linux-c8xlarge-amd64.aws-secret: {{ (index $config "aws-secret") | default "aws-account" | quote }}
+  dynamic.linux-c8xlarge-amd64.ssh-secret: {{ (index $config "ssh-secret") | default "aws-ssh-key" | quote }}
+  dynamic.linux-c8xlarge-amd64.security-group-id: {{ default (index $amd "security-group-id") ((index $config "security-group-id")) | quote }}
+  dynamic.linux-c8xlarge-amd64.max-instances: {{ (index $config "max-instances") | default "250" | quote }}
+  dynamic.linux-c8xlarge-amd64.subnet-id: {{ default (index $amd "subnet-id") ((index $config "subnet-id")) | quote }}
+  dynamic.linux-c8xlarge-amd64.check-interval: {{ (index $config "check-interval") | default "60" | quote }}
+  dynamic.linux-c8xlarge-amd64.allocation-timeout: "1200"
+  {{ end }}
+
+  {{- if hasKey .Values.dynamicConfigs "linux-d160-c8xlarge-arm64" }}
+  {{- $config := index .Values.dynamicConfigs "linux-d160-c8xlarge-arm64" | default (dict) }}
+  dynamic.linux-d160-c8xlarge-arm64.type: {{ index $config "type" | default "aws" | quote }}
+  dynamic.linux-d160-c8xlarge-arm64.region: {{ index $config "region" | default "us-east-1" | quote }}
+  dynamic.linux-d160-c8xlarge-arm64.ami: {{ default (index $arm "ami") $config.ami | quote }}
+  dynamic.linux-d160-c8xlarge-arm64.instance-type: {{ (index $config "instance-type") | default "c6g.8xlarge" | quote }}
+  dynamic.linux-d160-c8xlarge-arm64.instance-tag: {{ (index $config "instance-tag") | default (printf "%s-arm64-c8xlarge-d160" $environment) | quote }}
+  dynamic.linux-d160-c8xlarge-arm64.key-name: {{ default (index $arm "key-name") ((index $config "key-name")) | quote }}
+  dynamic.linux-d160-c8xlarge-arm64.aws-secret: {{ (index $config "aws-secret") | default "aws-account" | quote }}
+  dynamic.linux-d160-c8xlarge-arm64.ssh-secret: {{ (index $config "ssh-secret") | default "aws-ssh-key" | quote }}
+  dynamic.linux-d160-c8xlarge-arm64.security-group-id: {{ default (index $arm "security-group-id") ((index $config "security-group-id")) | quote }}
+  dynamic.linux-d160-c8xlarge-arm64.max-instances: {{ (index $config "max-instances") | default "250" | quote }}
+  dynamic.linux-d160-c8xlarge-arm64.subnet-id: {{ default (index $arm "subnet-id") ((index $config "subnet-id")) | quote }}
+  dynamic.linux-d160-c8xlarge-arm64.check-interval: {{ (index $config "check-interval") | default "60" | quote }}
+  dynamic.linux-d160-c8xlarge-arm64.disk: "160"
+  dynamic.linux-d160-c8xlarge-arm64.allocation-timeout: "1200"
+  {{ end }}
+
+  {{- if hasKey .Values.dynamicConfigs "linux-d160-c8xlarge-amd64" }}
+  {{- $config := index .Values.dynamicConfigs "linux-d160-c8xlarge-amd64" | default (dict) }}
+  dynamic.linux-d160-c8xlarge-amd64.type: {{ index $config "type" | default "aws" | quote }}
+  dynamic.linux-d160-c8xlarge-amd64.region: {{ index $config "region" | default "us-east-1" | quote }}
+  dynamic.linux-d160-c8xlarge-amd64.ami: {{ default (index $amd "ami") $config.ami | quote }}
+  dynamic.linux-d160-c8xlarge-amd64.instance-type: {{ (index $config "instance-type") | default "c6a.8xlarge" | quote }}
+  dynamic.linux-d160-c8xlarge-amd64.instance-tag: {{ (index $config "instance-tag") | default (printf "%s-amd64-c8xlarge-d160" $environment) | quote }}
+  dynamic.linux-d160-c8xlarge-amd64.key-name: {{ default (index $amd "key-name") ((index $config "key-name")) | quote }}
+  dynamic.linux-d160-c8xlarge-amd64.aws-secret: {{ (index $config "aws-secret") | default "aws-account" | quote }}
+  dynamic.linux-d160-c8xlarge-amd64.ssh-secret: {{ (index $config "ssh-secret") | default "aws-ssh-key" | quote }}
+  dynamic.linux-d160-c8xlarge-amd64.security-group-id: {{ default (index $amd "security-group-id") ((index $config "security-group-id")) | quote }}
+  dynamic.linux-d160-c8xlarge-amd64.max-instances: {{ (index $config "max-instances") | default "250" | quote }}
+  dynamic.linux-d160-c8xlarge-amd64.subnet-id: {{ default (index $amd "subnet-id") ((index $config "subnet-id")) | quote }}
+  dynamic.linux-d160-c8xlarge-amd64.check-interval: {{ (index $config "check-interval") | default "60" | quote }}
+  dynamic.linux-d160-c8xlarge-amd64.disk: "160"
+  dynamic.linux-d160-c8xlarge-amd64.allocation-timeout: "1200"
+  {{ end }}
+
+  # GPU Instances
+  {{- if hasKey .Values.dynamicConfigs "linux-g6xlarge-amd64" }}
+  {{- $config := index .Values.dynamicConfigs "linux-g6xlarge-amd64" | default (dict) }}
+  dynamic.linux-g6xlarge-amd64.type: {{ index $config "type" | default "aws" | quote }}
+  dynamic.linux-g6xlarge-amd64.region: {{ index $config "region" | default "us-east-1" | quote }}
+  dynamic.linux-g6xlarge-amd64.ami: {{ default (index $amd "ami") $config.ami | quote }}
+  dynamic.linux-g6xlarge-amd64.instance-type: {{ (index $config "instance-type") | default "g6.xlarge" | quote }}
+  dynamic.linux-g6xlarge-amd64.key-name: {{ default (index $amd "key-name") ((index $config "key-name")) | quote }}
+  dynamic.linux-g6xlarge-amd64.aws-secret: {{ (index $config "aws-secret") | default "aws-account" | quote }}
+  dynamic.linux-g6xlarge-amd64.ssh-secret: {{ (index $config "ssh-secret") | default "aws-ssh-key" | quote }}
+  dynamic.linux-g6xlarge-amd64.security-group-id: {{ default (index $amd "security-group-id") ((index $config "security-group-id")) | quote }}
+  dynamic.linux-g6xlarge-amd64.max-instances: {{ (index $config "max-instances") | default "250" | quote }}
+  dynamic.linux-g6xlarge-amd64.subnet-id: {{ default (index $amd "subnet-id") ((index $config "subnet-id")) | quote }}
+  dynamic.linux-g6xlarge-amd64.instance-tag: {{ (index $config "instance-tag") | default (printf "%s-amd64-g6xlarge" $environment) | quote }}
+  dynamic.linux-g6xlarge-amd64.check-interval: {{ (index $config "check-interval") | default "60" | quote }}
+  dynamic.linux-g6xlarge-amd64.allocation-timeout: "1200"
+  {{- if or (index $config "user-data") (.Files.Get "files/linux-g6xlarge-amd64-init.sh") }}
+  dynamic.linux-g6xlarge-amd64.user-data: |
+  {{- if (index $config "user-data") }}
+  {{- $lines := splitList "\n" (index $config "user-data") }}
+  {{- range $line := $lines }}
+    {{ $line }}
+  {{- end }}
+    {{- else }}
+{{ include "multi-platform-controller.cloud-init-userdata" (.Files.Get "files/linux-g6xlarge-amd64-init.sh") | indent 4 }}
+    {{- end }}
+    {{- end }}
+  {{ end }}
+
+  {{- if hasKey .Values.dynamicConfigs "linux-g64xlarge-amd64" }}
+  {{- $config := index .Values.dynamicConfigs "linux-g64xlarge-amd64" | default (dict) }}
+  dynamic.linux-g64xlarge-amd64.type: {{ index $config "type" | default "aws" | quote }}
+  dynamic.linux-g64xlarge-amd64.region: {{ index $config "region" | default "us-east-1" | quote }}
+  dynamic.linux-g64xlarge-amd64.ami: {{ default (index $amd "ami") $config.ami | quote }}
+  dynamic.linux-g64xlarge-amd64.instance-type: {{ (index $config "instance-type") | default "g6.4xlarge" | quote }}
+  dynamic.linux-g64xlarge-amd64.key-name: {{ default (index $amd "key-name") ((index $config "key-name")) | quote }}
+  dynamic.linux-g64xlarge-amd64.aws-secret: {{ (index $config "aws-secret") | default "aws-account" | quote }}
+  dynamic.linux-g64xlarge-amd64.ssh-secret: {{ (index $config "ssh-secret") | default "aws-ssh-key" | quote }}
+  dynamic.linux-g64xlarge-amd64.security-group-id: {{ default (index $amd "security-group-id") ((index $config "security-group-id")) | quote }}
+  dynamic.linux-g64xlarge-amd64.max-instances: {{ (index $config "max-instances") | default "250" | quote }}
+  dynamic.linux-g64xlarge-amd64.subnet-id: {{ default (index $amd "subnet-id") ((index $config "subnet-id")) | quote }}
+  dynamic.linux-g64xlarge-amd64.instance-tag: {{ (index $config "instance-tag") | default (printf "%s-amd64-g64xlarge" $environment) | quote }}
+  dynamic.linux-g64xlarge-amd64.check-interval: {{ (index $config "check-interval") | default "60" | quote }}
+  dynamic.linux-g64xlarge-amd64.allocation-timeout: "1200"
+  {{- if or (index $config "user-data") (.Files.Get "files/linux-g64xlarge-amd64-init.sh") }}
+  dynamic.linux-g64xlarge-amd64.user-data: |
+  {{- if (index $config "user-data") }}
+  {{- $lines := splitList "\n" (index $config "user-data") }}
+  {{- range $line := $lines }}
+    {{ $line }}
+  {{- end }}
+  {{- else }}
+{{ include "multi-platform-controller.cloud-init-userdata" (.Files.Get "files/linux-g64xlarge-amd64-init.sh") | indent 4 }}
+  {{- end }}
+  {{- end }}
+  {{ end }}
+
+
+  # Root access
+  {{- if hasKey .Values.dynamicConfigs "linux-root-arm64" }}
+  {{- $config := index .Values.dynamicConfigs "linux-root-arm64" | default (dict) }}
+  dynamic.linux-root-arm64.type: {{ index $config "type" | default "aws" | quote }}
+  dynamic.linux-root-arm64.region: {{ index $config "region" | default "us-east-1" | quote }}
+  dynamic.linux-root-arm64.ami: {{ default (index $arm "ami") $config.ami | quote }}
+  dynamic.linux-root-arm64.instance-type: {{ (index $config "instance-type") | default "m6g.large" | quote }}
+  dynamic.linux-root-arm64.instance-tag: {{ (index $config "instance-tag") | default (printf "%s-arm64-root" $environment) | quote }}
+  dynamic.linux-root-arm64.key-name: {{ default (index $arm "key-name") ((index $config "key-name")) | quote }}
+  dynamic.linux-root-arm64.aws-secret: {{ (index $config "aws-secret") | default "aws-account" | quote }}
+  dynamic.linux-root-arm64.ssh-secret: {{ (index $config "ssh-secret") | default "aws-ssh-key" | quote }}
+  dynamic.linux-root-arm64.security-group-id: {{ default (index $arm "security-group-id") ((index $config "security-group-id")) | quote }}
+  dynamic.linux-root-arm64.max-instances: {{ (index $config "max-instances") | default "250" | quote }}
+  dynamic.linux-root-arm64.subnet-id: {{ default (index $arm "subnet-id") ((index $config "subnet-id")) | quote }}
+  dynamic.linux-root-arm64.sudo-commands: {{ (index $config "sudo-commands") | default "/usr/bin/podman" | quote }}
+  dynamic.linux-root-arm64.disk: {{ index $config "disk" | default "200" | quote }}
+  dynamic.linux-root-arm64.check-interval: {{ (index $config "check-interval") | default "60" | quote }}
+  dynamic.linux-root-arm64.allocation-timeout: "1200"
+  {{- if (index $config "iops") }}
+  dynamic.linux-root-arm64.iops: {{ index $config "iops" | quote }}
+  {{ end }}
+  {{- if (index $config "throughput") }}
+  dynamic.linux-root-arm64.throughput: {{ index $config "throughput" | quote }}
+  {{ end }}
+  {{- if (index $config "user-data") }}
+  dynamic.linux-root-arm64.user-data: |
+  {{- $lines := splitList "\n" (index $config "user-data") }}
+  {{- range $line := $lines }}
+    {{ $line }}
+  {{- end }}
+  {{- end }}
+  {{ end }}
+
+  {{- if hasKey .Values.dynamicConfigs "linux-root-amd64" }}
+  {{- $config := index .Values.dynamicConfigs "linux-root-amd64" | default (dict) }}
+  dynamic.linux-root-amd64.type: {{ index $config "type" | default "aws" | quote }}
+  dynamic.linux-root-amd64.region: {{ index $config "region" | default "us-east-1" | quote }}
+  dynamic.linux-root-amd64.ami: {{ default (index $amd "ami") $config.ami | quote }}
+  dynamic.linux-root-amd64.instance-type: {{ (index $config "instance-type") | default "m5.2xlarge" | quote }}
+  dynamic.linux-root-amd64.instance-tag: {{ (index $config "instance-tag") | default (printf "%s-amd64-root" $environment) | quote }}
+  dynamic.linux-root-amd64.key-name: {{ default (index $amd "key-name") ((index $config "key-name")) | quote }}
+  dynamic.linux-root-amd64.aws-secret: {{ (index $config "aws-secret") | default "aws-account" | quote }}
+  dynamic.linux-root-amd64.ssh-secret: {{ (index $config "ssh-secret") | default "aws-ssh-key" | quote }}
+  dynamic.linux-root-amd64.security-group-id: {{ default (index $amd "security-group-id") ((index $config "security-group-id")) | quote }}
+  dynamic.linux-root-amd64.max-instances: {{ (index $config "max-instances") | default "250" | quote }}
+  dynamic.linux-root-amd64.subnet-id: {{ default (index $amd "subnet-id") ((index $config "subnet-id")) | quote }}
+  dynamic.linux-root-amd64.sudo-commands: {{ (index $config "sudo-commands") | default "/usr/bin/podman" | quote }}
+  dynamic.linux-root-amd64.disk: {{index $config "disk" | default "200" | quote }}
+  dynamic.linux-root-amd64.check-interval: {{ (index $config "check-interval") | default "60" | quote }}
+  dynamic.linux-root-amd64.allocation-timeout: "1200"
+  {{- if or (index $config "user-data") (.Files.Get "files/linux-root-amd64-init.sh") }}
+  dynamic.linux-root-amd64.user-data: |
+  {{- if (index $config "user-data") }}
+  {{- $lines := splitList "\n" (index $config "user-data") }}
+  {{- range $line := $lines }}
+    {{ $line }}
+  {{- end }}
+  {{- else }}
+{{ include "multi-platform-controller.cloud-init-userdata" (.Files.Get "files/linux-root-amd64-init.sh") | indent 4 }}
+  {{- end }}
+  {{- end }}
+  {{ end }}
+
+  # Fast platforms for production
+  {{- if hasKey .Values.dynamicConfigs "linux-fast-amd64" }}
+  {{- $config := index .Values.dynamicConfigs "linux-fast-amd64" | default (dict) }}
+  dynamic.linux-fast-amd64.type: {{ index $config "type" | default "aws" | quote }}
+  dynamic.linux-fast-amd64.region: {{ index $config "region" | default "us-east-1" | quote }}
+  dynamic.linux-fast-amd64.ami: {{ default (index $amd "ami") $config.ami | quote }}
+  dynamic.linux-fast-amd64.instance-type: {{ (index $config "instance-type") | default "c7a.8xlarge" | quote }}
+  dynamic.linux-fast-amd64.instance-tag: {{ (index $config "instance-tag") | default (printf "%s-amd64-fast" $environment) | quote }}
+  dynamic.linux-fast-amd64.key-name: {{ default (index $amd "key-name") ((index $config "key-name")) | quote }}
+  dynamic.linux-fast-amd64.aws-secret: {{ (index $config "aws-secret") | default "aws-account" | quote }}
+  dynamic.linux-fast-amd64.ssh-secret: {{ (index $config "ssh-secret") | default "aws-ssh-key" | quote }}
+  dynamic.linux-fast-amd64.security-group-id: {{ default (index $amd "security-group-id") ((index $config "security-group-id")) | quote }}
+  dynamic.linux-fast-amd64.max-instances: {{ (index $config "max-instances") | default "250" | quote }}
+  dynamic.linux-fast-amd64.subnet-id: {{ default (index $amd "subnet-id") ((index $config "subnet-id")) | quote }}
+  dynamic.linux-fast-amd64.disk: {{ index $config "disk" | default "200" | quote }}
+  dynamic.linux-fast-amd64.check-interval: {{ (index $config "check-interval") | default "60" | quote }}
+  dynamic.linux-fast-amd64.allocation-timeout: "1200"
+  {{ end }}
+
+  {{- if hasKey .Values.dynamicConfigs "linux-extra-fast-amd64" }}
+  {{- $config := index .Values.dynamicConfigs "linux-extra-fast-amd64" | default (dict) }}
+  dynamic.linux-extra-fast-amd64.type: {{ index $config "type" | default "aws" | quote }}
+  dynamic.linux-extra-fast-amd64.region: {{ index $config "region" | default "us-east-1" | quote }}
+  dynamic.linux-extra-fast-amd64.ami: {{ default (index $amd "ami") $config.ami | quote }}
+  dynamic.linux-extra-fast-amd64.instance-type: {{ (index $config "instance-type") | default "c7a.12xlarge" | quote }}
+  dynamic.linux-extra-fast-amd64.instance-tag: {{ (index $config "instance-tag") | default (printf "%s-amd64-extra-fast" $environment) | quote }}
+  dynamic.linux-extra-fast-amd64.key-name: {{ default (index $amd "key-name") ((index $config "key-name")) | quote }}
+  dynamic.linux-extra-fast-amd64.aws-secret: {{ (index $config "aws-secret") | default "aws-account" | quote }}
+  dynamic.linux-extra-fast-amd64.ssh-secret: {{ (index $config "ssh-secret") | default "aws-ssh-key" | quote }}
+  dynamic.linux-extra-fast-amd64.security-group-id: {{ default (index $amd "security-group-id") ((index $config "security-group-id")) | quote }}
+  dynamic.linux-extra-fast-amd64.max-instances: {{ (index $config "max-instances") | default "250" | quote }}
+  dynamic.linux-extra-fast-amd64.subnet-id: {{ default (index $amd "subnet-id") ((index $config "subnet-id")) | quote }}
+  dynamic.linux-extra-fast-amd64.disk: {{ index $config "disk" | default "200" | quote }}
+  dynamic.linux-extra-fast-amd64.check-interval: {{ (index $config "check-interval") | default "60" | quote }}
+  dynamic.linux-extra-fast-amd64.allocation-timeout: "1200"
+  {{ end }}
+
+  {{- if hasKey .Values.dynamicConfigs "macos-mac2metal-arm64" }}
+  {{- $config := index .Values.dynamicConfigs "macos-mac2metal-arm64" | default (dict) }}
+  dynamic.macos-mac2metal-arm64.type: {{ index $config "type" | default "aws" | quote }}
+  dynamic.macos-mac2metal-arm64.region: {{ index $config "region" | default "us-east-1" | quote }}
+  dynamic.macos-mac2metal-arm64.ami: {{ default (index $macos "ami") $config.ami | quote }}
+  dynamic.macos-mac2metal-arm64.instance-type: {{ (index $config "instance-type") | default "mac2.metal" | quote }}
+  dynamic.macos-mac2metal-arm64.instance-tag: {{ (index $config "instance-tag") | default (printf "%s-arm64-mac2metal" $environment) | quote }}
+  dynamic.macos-mac2metal-arm64.key-name: {{ default (index $macos "key-name") ((index $config "key-name")) | quote }}
+  dynamic.macos-mac2metal-arm64.aws-secret: {{ (index $config "aws-secret") | default "aws-account" | quote }}
+  dynamic.macos-mac2metal-arm64.ssh-secret: {{ default (index $macos "ssh-secret") ((index $config "ssh-secret")) | default "aws-ssh-key" | quote }}
+  dynamic.macos-mac2metal-arm64.security-group-id: {{ default (index $macos "security-group-id") ((index $config "security-group-id")) | quote }}
+  dynamic.macos-mac2metal-arm64.max-instances: {{ (index $config "max-instances") | default "5" | quote }}
+  dynamic.macos-mac2metal-arm64.subnet-id: {{ default (index $macos "subnet-id") ((index $config "subnet-id")) | quote }}
+  dynamic.macos-mac2metal-arm64.disk: {{ index $config "disk" | default "100" | quote }}
+  dynamic.macos-mac2metal-arm64.allocation-timeout: "1200"
+  dynamic.macos-mac2metal-arm64.tenancy: "host"
+  dynamic.macos-mac2metal-arm64.host-resource-group-arn: {{ default (index $macos "host-resource-group-arn") ((index $config "host-resource-group-arn")) | quote }}
+  dynamic.macos-mac2metal-arm64.license-configuration-arn: {{ default (index $macos "license-configuration-arn") ((index $config "license-configuration-arn")) | quote }}
+  {{- if (index $config "iops") }}
+  dynamic.macos-mac2metal-arm64.iops: {{ index $config "iops" | quote }}
+  {{ end }}
+  {{- if (index $config "throughput") }}
+  dynamic.macos-mac2metal-arm64.throughput: {{ index $config "throughput" | quote }}
+  {{ end }}
+  {{- if or (index $config "user-data") (.Files.Get "files/macos-mac2metal-arm64-init.sh") }}
+  dynamic.macos-mac2metal-arm64.user-data: |
+  {{- if (index $config "user-data") }}
+  {{- $lines := splitList "\n" (index $config "user-data") }}
+  {{- range $line := $lines }}
+    {{ $line }}
+  {{- end }}
+  {{- else }}
+{{ .Files.Get "files/macos-mac2metal-arm64-init.sh" | indent 4 }}
+  {{- end }}
+  {{- end }}
+  {{ end }}
+
+
+  {{- if hasKey .Values.dynamicConfigs "linux-test-amd64" }}
+  {{- $config := index .Values.dynamicConfigs "linux-test-amd64" | default (dict) }}
+  dynamic.linux-test-amd64.type: {{ index $config "type" | default "aws" | quote }}
+  dynamic.linux-test-amd64.region: {{ index $config "region" | default "us-east-1" | quote }}
+  dynamic.linux-test-amd64.ami: {{ default (index $amd "ami") $config.ami | quote }}
+  dynamic.linux-test-amd64.instance-type: {{ (index $config "instance-type") | default "m6a.large" | quote }}
+  dynamic.linux-test-amd64.instance-tag: {{ (index $config "instance-tag") | default (printf "%s-amd64-test" $environment) | quote }}
+  dynamic.linux-test-amd64.key-name: {{ default (index $amd "key-name") ((index $config "key-name")) | quote }}
+  dynamic.linux-test-amd64.aws-secret: {{ (index $config "aws-secret") | default "aws-account" | quote }}
+  dynamic.linux-test-amd64.ssh-secret: {{ (index $config "ssh-secret") | default "aws-ssh-key" | quote }}
+  dynamic.linux-test-amd64.security-group-id: {{ default (index $amd "security-group-id") ((index $config "security-group-id")) | quote }}
+  dynamic.linux-test-amd64.max-instances: {{ (index $config "max-instances") | default "250" | quote }}
+  dynamic.linux-test-amd64.subnet-id: {{ default (index $amd "subnet-id") ((index $config "subnet-id")) | quote }}
+  dynamic.linux-test-amd64.disk: {{ index $config "disk" | default "200" | quote }}
+  dynamic.linux-test-amd64.check-interval: {{ (index $config "check-interval") | default "60" | quote }}
+  dynamic.linux-test-amd64.allocation-timeout: "1200"
+  dynamic.linux-test-amd64.sudo-commands: {{ (index $config "sudo-commands") | default "/usr/bin/podman" | quote }}
+  {{- if or (index $config "user-data") (.Files.Get "files/linux-test-amd64-init.sh") }}
+  dynamic.linux-test-amd64.user-data: |
+  {{- if (index $config "user-data") }}
+  {{- $lines := splitList "\n" (index $config "user-data") }}
+  {{- range $line := $lines }}
+    {{ $line }}
+  {{- end }}
+  {{- else }}
+{{ include "multi-platform-controller.cloud-init-userdata" (.Files.Get "files/linux-test-amd64-init.sh") | indent 4 }}
+  {{- end }}
+  {{- end }}
+  {{ end }}
+
+  {{- if hasKey .Values.dynamicConfigs "linux-test-arm64" }}
+  {{- $config := index .Values.dynamicConfigs "linux-test-arm64" | default (dict) }}
+  dynamic.linux-test-arm64.type: {{ index $config "type" | default "aws" | quote }}
+  dynamic.linux-test-arm64.region: {{ index $config "region" | default "us-east-1" | quote }}
+  dynamic.linux-test-arm64.ami: {{ default (index $arm "ami") $config.ami | quote }}                                                    
+  dynamic.linux-test-arm64.instance-type: {{ (index $config "instance-type") | default "m6g.large" | quote }}
+  dynamic.linux-test-arm64.instance-tag: {{ (index $config "instance-tag") | default (printf "%s-arm64-test" $environment) | quote }}
+  dynamic.linux-test-arm64.key-name: {{ default (index $arm "key-name") ((index $config "key-name")) | quote }}
+  dynamic.linux-test-arm64.aws-secret: {{ (index $config "aws-secret") | default "aws-account" | quote }}
+  dynamic.linux-test-arm64.ssh-secret: {{ (index $config "ssh-secret") | default "aws-ssh-key" | quote }}
+  dynamic.linux-test-arm64.security-group-id: {{ default (index $arm "security-group-id") ((index $config "security-group-id")) | quote }}
+  dynamic.linux-test-arm64.max-instances: {{ (index $config "max-instances") | default "250" | quote }}
+  dynamic.linux-test-arm64.subnet-id: {{ default (index $arm "subnet-id") ((index $config "subnet-id")) | quote }}
+  dynamic.linux-test-arm64.disk: {{ index $config "disk" | default "200" | quote }}
+  dynamic.linux-test-arm64.check-interval: {{ (index $config "check-interval") | default "60" | quote }}
+  dynamic.linux-test-arm64.allocation-timeout: "1200"
+  dynamic.linux-test-arm64.sudo-commands: {{ (index $config "sudo-commands") | default "/usr/bin/podman" | quote }}
+  {{- if (index $config "iops") }}
+  dynamic.linux-test-arm64.iops: {{ index $config "iops" | quote }}
+  {{ end }}
+  {{- if (index $config "throughput") }}
+  dynamic.linux-test-arm64.throughput: {{ index $config "throughput" | quote }}
+  {{ end }}
+  {{- if (index $config "user-data") }}
+  dynamic.linux-test-arm64.user-data: |
+  {{- $lines := splitList "\n" (index $config "user-data") }}
+  {{- range $line := $lines }}
+    {{ $line }}
+  {{- end }}
+  {{- end }}
+  {{ end }}
+
+  # Windows platforms
+  {{- if hasKey .Values.dynamicConfigs "windows-4xlarge-amd64" }}
+  {{- $config := index .Values.dynamicConfigs "windows-4xlarge-amd64" | default (dict) }}
+  dynamic.windows-4xlarge-amd64.type: {{ index $config "type" | default "aws" | quote }}
+  dynamic.windows-4xlarge-amd64.region: {{ index $config "region" | default "us-east-1" | quote }}
+  dynamic.windows-4xlarge-amd64.ami: {{ default (index $windows "ami") $config.ami | quote }}
+  dynamic.windows-4xlarge-amd64.instance-type: {{ (index $config "instance-type") | default "c5.4xlarge" | quote }}
+  dynamic.windows-4xlarge-amd64.instance-tag: {{ (index $config "instance-tag") | default (printf "%s-amd64-4xlarge" $environment) | quote }}
+  dynamic.windows-4xlarge-amd64.key-name: {{ default (index $windows "key-name") ((index $config "key-name")) | quote }}
+  dynamic.windows-4xlarge-amd64.aws-secret: {{ (index $config "aws-secret") | default "aws-account" | quote }}
+  dynamic.windows-4xlarge-amd64.ssh-secret: {{ default (index $windows "ssh-secret") ((index $config "ssh-secret")) | default "aws-ssh-key" | quote }}
+  dynamic.windows-4xlarge-amd64.security-group-id: {{ default (index $windows "security-group-id") ((index $config "security-group-id")) | quote }}
+  dynamic.windows-4xlarge-amd64.max-instances: {{ (index $config "max-instances") | default "5" | quote }}
+  dynamic.windows-4xlarge-amd64.subnet-id: {{ default (index $windows "subnet-id") ((index $config "subnet-id")) | quote }}
+  dynamic.windows-4xlarge-amd64.disk: {{ index $config "disk" | default "100" | quote }}
+  dynamic.windows-4xlarge-amd64.check-interval: {{ (index $config "check-interval") | default "60" | quote }}
+  dynamic.windows-4xlarge-amd64.allocation-timeout: "1200"
+  {{- if (index $config "iops") }}
+  dynamic.windows-4xlarge-amd64.iops: {{ index $config "iops" | quote }}
+  {{ end }}
+  {{- if (index $config "throughput") }}
+  dynamic.windows-4xlarge-amd64.throughput: {{ index $config "throughput" | quote }}
+  {{ end }}
+  dynamic.windows-4xlarge-amd64.user-data: |
+  {{- if (index $config "user-data") }}
+  {{- $lines := splitList "\n" (index $config "user-data") }}
+  {{- range $line := $lines }}
+    {{ $line }}
+  {{- end }}
+  {{- else }}
+{{ include "multi-platform-controller.windows-init" $config | indent 4 }}
+  {{- end }}
+  {{ end }}
+
+  # Static hosts configuration
+  {{- range $host, $config := .Values.staticHosts }}
+  {{- range $key, $value := $config }}
+  host.{{ $host }}.{{ $key }}: {{ $value | quote }}
+  {{- end }}
+  {{ end }}

--- a/components/multi-platform-controller/production/kflux-fedora-01/kustomization.yaml
+++ b/components/multi-platform-controller/production/kflux-fedora-01/kustomization.yaml
@@ -11,11 +11,11 @@ patches:
   - path: manager_resources_patch.yaml
 
 helmGlobals:
-  chartHome: ../../base
+  chartHome: ../base
 
 helmCharts:
   - name: host-config-chart
     releaseName: host-config
     namespace: multi-platform-controller
-    repo: ../../base
+    repo: ../base
     valuesFile: host-values.yaml

--- a/components/multi-platform-controller/production/kflux-prd-rh03/kustomization.yaml
+++ b/components/multi-platform-controller/production/kflux-prd-rh03/kustomization.yaml
@@ -11,11 +11,11 @@ patches:
   - path: manager_resources_patch.yaml
 
 helmGlobals:
-  chartHome: ../../base
+  chartHome: ../base
 
 helmCharts:
   - name: host-config-chart
     releaseName: host-config
     namespace: multi-platform-controller
-    repo: ../../base
+    repo: ../base
     valuesFile: host-values.yaml


### PR DESCRIPTION
This PR is from https://github.com/redhat-appstudio/infra-deployments/pull/12867 that has been divided in two rings. In this ring1 following production clusters with lower usage are included:

- kflux-fedora-01
- kflux-prd-rh03
- kflux-osp-p01
- kflux-rhel-p01
- stone-prod-p01

The kustomization configuration for charts on these clusters are using new {production,production-downstream}/base/host-config-chart/{files,templates}, while other production clusters are still pointing charts config to old/current base in multi-platform-controller/base

If all goes well we implement in ring2 after a week.

Chages here  includes correcting bugs, security and some cosmetic/formatting issues.

The most relevant change might be creating the MIME/script cloud-init-userdata.tpl to be used as "template", explanation from Oscar https://github.com/redhat-appstudio/infra-deployments/pull/11239#discussion_r3067857930

What could go wrong: This change might impact some VMs in production
Rollback plan: Revert the PR and redeploy. No data migration involved.
Testing: PR Validated in staging with no issues (https://github.com/redhat-appstudio/infra-deployments/pull/11858)