### PR TITLE
KFLUXINFRA-4007: (onboarding) Remove production authentication Apps from AppSRE ArgoCD

### DIFF
--- a/argo-cd-apps/base/all-clusters/infra-deployments/authentication/authentication.yaml
+++ b/argo-cd-apps/base/all-clusters/infra-deployments/authentication/authentication.yaml
@@ -14,13 +14,7 @@ spec:
                 environment: staging
                 clusterDir: base
           - list:
-              elements:
-                - nameNormalized: kflux-ocp-p01
-                  values.clusterDir: kflux-ocp-p01
-                - nameNormalized: stone-prod-p01
-                  values.clusterDir: stone-prod-p01
-                - nameNormalized: stone-prod-p02
-                  values.clusterDir: stone-prod-p02
+              elements: []
   template:
     metadata:
       name: authentication-{{nameNormalized}}

--- a/argo-cd-apps/overlays/konflux-public-production/delete-applications.yaml
+++ b/argo-cd-apps/overlays/konflux-public-production/delete-applications.yaml
@@ -30,3 +30,9 @@ kind: ApplicationSet
 metadata:
   name: dummy-deployment
 $patch: delete
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: authentication
+$patch: delete

--- a/argo-cd-apps/overlays/production-downstream/delete-applications.yaml
+++ b/argo-cd-apps/overlays/production-downstream/delete-applications.yaml
@@ -35,3 +35,9 @@ kind: ApplicationSet
 metadata:
   name: nvme-storage-configurator
 $patch: delete
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: authentication
+$patch: delete


### PR DESCRIPTION
Removes the authentication component from any production overlays.