### PR TITLE
Promote release-service from development to staging

### DIFF
--- a/components/release/staging/kustomization.yaml
+++ b/components/release/staging/kustomization.yaml
@@ -4,7 +4,7 @@ resources:
   - ../base
   - ../base/monitor/staging
   - external-secrets/release-monitor-secret.yaml
-  - https://github.com/konflux-ci/release-service/config/default?ref=6d9abf25ac73986731ba7dbdb1ac459af54999b0
+  - https://github.com/konflux-ci/release-service/config/default?ref=19e1d5ade7521048274c3ce9a427c381c93b71de
   - release_service_config.yaml
   - signing_configs.yaml
 
@@ -14,7 +14,7 @@ components:
 images:
   - name: quay.io/konflux-ci/release-service
     newName: quay.io/konflux-ci/release-service
-    newTag: 6d9abf25ac73986731ba7dbdb1ac459af54999b0
+    newTag: 19e1d5ade7521048274c3ce9a427c381c93b71de
 
 namespace: release-service
 


### PR DESCRIPTION
Included PRs:
- https://github.com/konflux-ci/release-service/pull/1732
- https://github.com/konflux-ci/release-service/pull/1728
- https://github.com/konflux-ci/release-service/pull/1680
- https://github.com/konflux-ci/release-service/pull/1725

Stage: N/A (this is a staging promotion)
Risk: low (3 dependency updates + 1 bug fix)