### PR TITLE
feat(KONFLUX-14971, kaexporter): use cfg file for tenant exclusions

### DIFF
--- a/components/monitoring/exporters/kaexporter/staging/base/configs/kaexporter-config.yaml
+++ b/components/monitoring/exporters/kaexporter/staging/base/configs/kaexporter-config.yaml
@@ -1,0 +1,6 @@
+excludeNamespaces:
+  - rhtap-releng-tenant
+  - "managed-*"
+  - dev-release-team-tenant
+  - "konflux-perfscale-*-tenant"
+  - build-templates-e2e

--- a/components/monitoring/exporters/kaexporter/staging/base/configs/kaexporter-deployment-patch.yaml
+++ b/components/monitoring/exporters/kaexporter/staging/base/configs/kaexporter-deployment-patch.yaml
@@ -1,0 +1,21 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kaexporter-deployment
+  namespace: konflux-o11y-exporters
+spec:
+  template:
+    spec:
+      volumes:
+        - name: kaexporter-config
+          configMap:
+            name: kaexporter-config
+      containers:
+        - name: exporters
+          env:
+            - name: KA_CONFIG_FILE
+              value: "/etc/kaexporter/kaexporter-config.yaml"
+          volumeMounts:
+            - name: kaexporter-config
+              mountPath: /etc/kaexporter
+              readOnly: true

--- a/components/monitoring/exporters/kaexporter/staging/base/configs/kustomization.yaml
+++ b/components/monitoring/exporters/kaexporter/staging/base/configs/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+configMapGenerator:
+  - name: kaexporter-config
+    namespace: konflux-o11y-exporters
+    files:
+      - kaexporter-config.yaml
+    options:
+      disableNameSuffixHash: true

--- a/components/monitoring/exporters/kaexporter/staging/base/kustomization.yaml
+++ b/components/monitoring/exporters/kaexporter/staging/base/kustomization.yaml
@@ -1,9 +1,13 @@
 resources:
   - rbac
   - external-secrets
-  - https://github.com/redhat-appstudio/o11y/config/exporters/monitoring/kaexporter/base?ref=cd48a7ad17234ef50526134e0ad628ce30894b5a
+  - configs
+  - https://github.com/redhat-appstudio/o11y/config/exporters/monitoring/kaexporter/base?ref=6a5258fd68e6f9ce3b3f0189a8224793db53ce31
 
 images:
   - name: quay.io/redhat-appstudio/o11y
     newName: quay.io/redhat-appstudio/o11y
-    newTag: cd48a7ad17234ef50526134e0ad628ce30894b5a
+    newTag: 6a5258fd68e6f9ce3b3f0189a8224793db53ce31
+
+patches:
+  - path: ./configs/kaexporter-deployment-patch.yaml


### PR DESCRIPTION
KAExporter has been updated per https://github.com/redhat-appstudio/o11y/pull/1236 to read a configuration file for a list of tenants/namespace to exclude when collecting metrics. Defining the ConfigMap and patching the KAExporter deployment here to exclude tenants we can ignore.