### PR TITLE
KFLUXINFRA-3980: add type guards to build-platforms CEL expressions (…

### DIFF
--- a/components/kueue/production/kflux-prd-rh02/config.yaml
+++ b/components/kueue/production/kflux-prd-rh02/config.yaml
@@ -103,55 +103,32 @@ cel:
         plrNamespace == 'mintmaker' ? [resource('mintmaker', 1)] : []
 
     # The token mechanism allows us to balance admitted PipelineRuns.
-    # Each PipelineRun requests 1 token, except for internal-services PLRs.
-    # This is to guarantee there is always room for internal-services PLRs.
-    #
-    #
-    # WARNING: As a temporary measure, we are using tokens to provide a priority lane
-    # for internal-services PLRs. They'll be removed in some time and moved to the
-    # common clusters.
+    # Each PipelineRun requests 1 token. The token quota is set equal
+    # to the PLR limit so current behavior is unchanged.
     - |
-        has(pipelineRun.metadata.labels) &&
-        'internal-services.appstudio.openshift.io/pipelinerun-uid' in pipelineRun.metadata.labels ?
-        [] : [resource('konflux-ci-dev-token', 1)]
-
-    # Add a resource to restrict the number of concurrent release pipelineruns
-    - |
-        has(pipelineRun.metadata.labels) &&
-        'appstudio.openshift.io/service' in pipelineRun.metadata.labels &&
-        pipelineRun.metadata.labels['appstudio.openshift.io/service'] == 'release' &&
-        'pipelines.appstudio.openshift.io/type' in pipelineRun.metadata.labels &&
-        pipelineRun.metadata.labels['pipelines.appstudio.openshift.io/type'] == 'managed' ?
-        [resource('konflux-release', 1)] :
-
-        has(pipelineRun.metadata.labels) &&
-        'appstudio.openshift.io/service' in pipelineRun.metadata.labels &&
-        pipelineRun.metadata.labels['appstudio.openshift.io/service'] == 'release' &&
-        'release.appstudio.openshift.io/namespace' in pipelineRun.metadata.labels &&
-        pipelineRun.metadata.labels['release.appstudio.openshift.io/namespace'] == plrNamespace ?
-        [resource('konflux-release', 1)] : []
+        resource('konflux-ci-dev-token', 1)
 
     # Set the pipeline priority
-    # First condition is to check if the priority class is already set and keep it if it is
-    # We allow this since the cluster is dedicated to the OCP team.
     - |
-        has(pipelineRun.metadata.labels) &&
-        'kueue.x-k8s.io/priority-class' in pipelineRun.metadata.labels ?
-        priority(pipelineRun.metadata.labels['kueue.x-k8s.io/priority-class']) :
-
         has(pipelineRun.metadata.labels) &&
         'build.appstudio.redhat.com/type' in pipelineRun.metadata.labels &&
         pipelineRun.metadata.labels['build.appstudio.redhat.com/type'] == 'nudge' ?
         priority('konflux-nudge') :
 
         pacEventType == 'push' ? priority('konflux-post-merge-build') :
-        pacEventType == 'pull_request'
-          || pacEventType == "Merge_Request"
-          ? priority('konflux-pre-merge-build') :
+        pacEventType == 'pull_request' ||
+          pacEventType == "Merge_Request" ||
+          pacEventType == 'test-comment' ||
+          pacEventType == 'retest-comment' ||
+          pacEventType == 'retest-all-comment' ||
+          pacEventType == 'ok-to-test-comment'  ? priority('konflux-pre-merge-build') :
         pacTestEventType == 'push' ? priority('konflux-post-merge-test') :
-        pacTestEventType == 'pull_request'
-          || pacTestEventType == "Merge_Request"
-          ? priority('konflux-pre-merge-test') :
+        pacTestEventType == 'pull_request' ||
+          pacTestEventType == "Merge_Request" ||
+          pacTestEventType == 'test-comment' ||
+          pacTestEventType == 'retest-comment' ||
+          pacTestEventType == 'retest-all-comment' ||
+          pacTestEventType == 'ok-to-test-comment' ? priority('konflux-pre-merge-test') :
 
         has(pipelineRun.metadata.labels) &&
         'appstudio.openshift.io/service' in pipelineRun.metadata.labels &&
@@ -163,19 +140,9 @@ cel:
         has(pipelineRun.metadata.labels) &&
         'appstudio.openshift.io/service' in pipelineRun.metadata.labels &&
         pipelineRun.metadata.labels['appstudio.openshift.io/service'] == 'release' &&
-        'pipelines.appstudio.openshift.io/type' in pipelineRun.metadata.labels &&
-        pipelineRun.metadata.labels['pipelines.appstudio.openshift.io/type'] == 'tenant' ?
+        'release.appstudio.openshift.io/namespace' in pipelineRun.metadata.labels &&
+        pipelineRun.metadata.labels['release.appstudio.openshift.io/namespace'] == plrNamespace ?
         priority('konflux-tenant-release') :
-
-        has(pipelineRun.metadata.labels) &&
-        'release.appstudio.openshift.io/name' in pipelineRun.metadata.labels &&
-        pipelineRun.metadata.labels['release.appstudio.openshift.io/name'].contains('-prod-') ?
-        priority('konflux-prod-release') :
-
-        has(pipelineRun.metadata.labels) &&
-        'release.appstudio.openshift.io/name' in pipelineRun.metadata.labels &&
-        pipelineRun.metadata.labels['release.appstudio.openshift.io/name'].contains('-stage-') ?
-        priority('konflux-stage-release') :
 
         plrNamespace == 'mintmaker' ? priority('konflux-dependency-update') :
 

--- a/components/kueue/production/kflux-prd-rh02/kustomization.yaml
+++ b/components/kueue/production/kflux-prd-rh02/kustomization.yaml
@@ -6,3 +6,10 @@ resources:
 
 commonAnnotations:
   argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+
+configMapGenerator:
+  - name: tekton-kueue-config
+    namespace: tekton-kueue
+    behavior: replace
+    files:
+      - config.yaml

--- a/components/kueue/production/stone-prod-p01/config.yaml
+++ b/components/kueue/production/stone-prod-p01/config.yaml
@@ -103,55 +103,32 @@ cel:
         plrNamespace == 'mintmaker' ? [resource('mintmaker', 1)] : []
 
     # The token mechanism allows us to balance admitted PipelineRuns.
-    # Each PipelineRun requests 1 token, except for internal-services PLRs.
-    # This is to guarantee there is always room for internal-services PLRs.
-    #
-    #
-    # WARNING: As a temporary measure, we are using tokens to provide a priority lane
-    # for internal-services PLRs. They'll be removed in some time and moved to the
-    # common clusters.
+    # Each PipelineRun requests 1 token. The token quota is set equal
+    # to the PLR limit so current behavior is unchanged.
     - |
-        has(pipelineRun.metadata.labels) &&
-        'internal-services.appstudio.openshift.io/pipelinerun-uid' in pipelineRun.metadata.labels ?
-        [] : [resource('konflux-ci-dev-token', 1)]
-
-    # Add a resource to restrict the number of concurrent release pipelineruns
-    - |
-        has(pipelineRun.metadata.labels) &&
-        'appstudio.openshift.io/service' in pipelineRun.metadata.labels &&
-        pipelineRun.metadata.labels['appstudio.openshift.io/service'] == 'release' &&
-        'pipelines.appstudio.openshift.io/type' in pipelineRun.metadata.labels &&
-        pipelineRun.metadata.labels['pipelines.appstudio.openshift.io/type'] == 'managed' ?
-        [resource('konflux-release', 1)] :
-
-        has(pipelineRun.metadata.labels) &&
-        'appstudio.openshift.io/service' in pipelineRun.metadata.labels &&
-        pipelineRun.metadata.labels['appstudio.openshift.io/service'] == 'release' &&
-        'release.appstudio.openshift.io/namespace' in pipelineRun.metadata.labels &&
-        pipelineRun.metadata.labels['release.appstudio.openshift.io/namespace'] == plrNamespace ?
-        [resource('konflux-release', 1)] : []
+        resource('konflux-ci-dev-token', 1)
 
     # Set the pipeline priority
-    # First condition is to check if the priority class is already set and keep it if it is
-    # We allow this since the cluster is dedicated to the OCP team.
     - |
-        has(pipelineRun.metadata.labels) &&
-        'kueue.x-k8s.io/priority-class' in pipelineRun.metadata.labels ?
-        priority(pipelineRun.metadata.labels['kueue.x-k8s.io/priority-class']) :
-
         has(pipelineRun.metadata.labels) &&
         'build.appstudio.redhat.com/type' in pipelineRun.metadata.labels &&
         pipelineRun.metadata.labels['build.appstudio.redhat.com/type'] == 'nudge' ?
         priority('konflux-nudge') :
 
         pacEventType == 'push' ? priority('konflux-post-merge-build') :
-        pacEventType == 'pull_request'
-          || pacEventType == "Merge_Request"
-          ? priority('konflux-pre-merge-build') :
+        pacEventType == 'pull_request' ||
+          pacEventType == "Merge_Request" ||
+          pacEventType == 'test-comment' ||
+          pacEventType == 'retest-comment' ||
+          pacEventType == 'retest-all-comment' ||
+          pacEventType == 'ok-to-test-comment'  ? priority('konflux-pre-merge-build') :
         pacTestEventType == 'push' ? priority('konflux-post-merge-test') :
-        pacTestEventType == 'pull_request'
-          || pacTestEventType == "Merge_Request"
-          ? priority('konflux-pre-merge-test') :
+        pacTestEventType == 'pull_request' ||
+          pacTestEventType == "Merge_Request" ||
+          pacTestEventType == 'test-comment' ||
+          pacTestEventType == 'retest-comment' ||
+          pacTestEventType == 'retest-all-comment' ||
+          pacTestEventType == 'ok-to-test-comment' ? priority('konflux-pre-merge-test') :
 
         has(pipelineRun.metadata.labels) &&
         'appstudio.openshift.io/service' in pipelineRun.metadata.labels &&
@@ -163,19 +140,9 @@ cel:
         has(pipelineRun.metadata.labels) &&
         'appstudio.openshift.io/service' in pipelineRun.metadata.labels &&
         pipelineRun.metadata.labels['appstudio.openshift.io/service'] == 'release' &&
-        'pipelines.appstudio.openshift.io/type' in pipelineRun.metadata.labels &&
-        pipelineRun.metadata.labels['pipelines.appstudio.openshift.io/type'] == 'tenant' ?
+        'release.appstudio.openshift.io/namespace' in pipelineRun.metadata.labels &&
+        pipelineRun.metadata.labels['release.appstudio.openshift.io/namespace'] == plrNamespace ?
         priority('konflux-tenant-release') :
-
-        has(pipelineRun.metadata.labels) &&
-        'release.appstudio.openshift.io/name' in pipelineRun.metadata.labels &&
-        pipelineRun.metadata.labels['release.appstudio.openshift.io/name'].contains('-prod-') ?
-        priority('konflux-prod-release') :
-
-        has(pipelineRun.metadata.labels) &&
-        'release.appstudio.openshift.io/name' in pipelineRun.metadata.labels &&
-        pipelineRun.metadata.labels['release.appstudio.openshift.io/name'].contains('-stage-') ?
-        priority('konflux-stage-release') :
 
         plrNamespace == 'mintmaker' ? priority('konflux-dependency-update') :
 

--- a/components/kueue/production/stone-prod-p01/kustomization.yaml
+++ b/components/kueue/production/stone-prod-p01/kustomization.yaml
@@ -6,3 +6,10 @@ resources:
 
 commonAnnotations:
   argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+
+configMapGenerator:
+  - name: tekton-kueue-config
+    namespace: tekton-kueue
+    behavior: replace
+    files:
+      - config.yaml

--- a/components/policies/production/kflux-ocp-p01/kustomization.yaml
+++ b/components/policies/production/kflux-ocp-p01/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
 - ../base/cost-management
 - ../policies/kubearchive/
 - ../policies/kueue/
+- ../policies/kueue/deny-on-validation-error/

--- a/components/policies/production/kflux-prd-rh02/kustomization.yaml
+++ b/components/policies/production/kflux-prd-rh02/kustomization.yaml
@@ -4,4 +4,5 @@ resources:
 - ../base
 - ../base/cost-management
 - ../policies/kueue/
+- ../policies/kueue/deny-on-validation-error/
 - ../policies/kubearchive/

--- a/components/policies/production/policies/kueue/deny-on-validation-error/.chainsaw-test/chainsaw-assert-pipelineruns-crd.yaml
+++ b/components/policies/production/policies/kueue/deny-on-validation-error/.chainsaw-test/chainsaw-assert-pipelineruns-crd.yaml
@@ -1,0 +1,7 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: pipelineruns.tekton.dev
+status:
+  acceptedNames:
+    kind: PipelineRun

--- a/components/policies/production/policies/kueue/deny-on-validation-error/.chainsaw-test/chainsaw-assert-policy.yaml
+++ b/components/policies/production/policies/kueue/deny-on-validation-error/.chainsaw-test/chainsaw-assert-policy.yaml
@@ -1,0 +1,7 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: deny-on-validation-error.kueue.konflux-ci.dev
+status:
+  observedGeneration: 1
+  typeChecking: {}

--- a/components/policies/production/policies/kueue/deny-on-validation-error/.chainsaw-test/resources/pipelinerun_with_custom_validation_error.yaml
+++ b/components/policies/production/policies/kueue/deny-on-validation-error/.chainsaw-test/resources/pipelinerun_with_custom_validation_error.yaml
@@ -1,0 +1,6 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  name: pipelinerun-with-validation-error
+  annotations:
+    kueue.konflux-ci.dev/validation-error: "custom error"

--- a/components/policies/production/policies/kueue/deny-on-validation-error/.chainsaw-test/resources/pipelinerun_with_validation_error.yaml
+++ b/components/policies/production/policies/kueue/deny-on-validation-error/.chainsaw-test/resources/pipelinerun_with_validation_error.yaml
@@ -1,0 +1,12 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  name: pipelinerun-with-validation-error
+  annotations:
+    kueue.konflux-ci.dev/validation-error: "build-platforms parameter must be an array of platform strings, got a non-array value"
+spec:
+  pipelineRef:
+    name: build-pipeline
+  params:
+    - name: build-platforms
+      value: "linux/amd64"

--- a/components/policies/production/policies/kueue/deny-on-validation-error/.chainsaw-test/resources/pipelinerun_without_validation_error.yaml
+++ b/components/policies/production/policies/kueue/deny-on-validation-error/.chainsaw-test/resources/pipelinerun_without_validation_error.yaml
@@ -1,0 +1,12 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  name: pipelinerun-without-validation-error
+spec:
+  pipelineRef:
+    name: build-pipeline
+  params:
+    - name: build-platforms
+      value:
+        - "linux/amd64"
+        - "linux/arm64"

--- a/components/policies/production/policies/kueue/deny-on-validation-error/.chainsaw-test/resources/pipelineruns.tekton.dev_customresourcedefinition.yaml
+++ b/components/policies/production/policies/kueue/deny-on-validation-error/.chainsaw-test/resources/pipelineruns.tekton.dev_customresourcedefinition.yaml
@@ -1,0 +1,21 @@
+# Minimal PipelineRun CRD for chainsaw tests (VAP exercises tekton.dev/v1).
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: pipelineruns.tekton.dev
+spec:
+  group: tekton.dev
+  names:
+    kind: PipelineRun
+    listKind: PipelineRunList
+    plural: pipelineruns
+    singular: pipelinerun
+  scope: Namespaced
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        x-kubernetes-preserve-unknown-fields: true

--- a/components/policies/production/policies/kueue/deny-on-validation-error/.chainsaw-test/test-in-tenant/chainsaw-test.yaml
+++ b/components/policies/production/policies/kueue/deny-on-validation-error/.chainsaw-test/test-in-tenant/chainsaw-test.yaml
@@ -1,0 +1,92 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: in-tenant-deny-pipelinerun-with-validation-error
+spec:
+  description: |
+    denies a PipelineRun that has the tekton-kueue validation-error
+    annotation in a tenant namespace
+  concurrent: false
+  steps:
+  - name: given-pipelineruns-crd-exists
+    try:
+    - apply:
+        file: ../resources/pipelineruns.tekton.dev_customresourcedefinition.yaml
+    - assert:
+        file: ../chainsaw-assert-pipelineruns-crd.yaml
+  - name: ensure-namespace-is-labeled
+    try:
+    - apply:
+        resource:
+          apiVersion: v1
+          kind: Namespace
+          metadata:
+            name: ($namespace)
+            labels:
+              konflux-ci.dev/type: tenant
+  - name: given-validatingadmissionpolicy-is-installed
+    try:
+    - apply:
+        file: ../../deny-on-validation-error-validatingadmissionpolicy.yaml
+    - apply:
+        file: ../../deny-on-validation-error-validatingadmissionpolicybinding.yaml
+    - assert:
+        file: ../chainsaw-assert-policy.yaml
+  - name: then-pipelinerun-with-validation-error-is-denied
+    try:
+    - create:
+        file: ../resources/pipelinerun_with_validation_error.yaml
+        expect:
+          - check:
+              ($error != null): true
+              ($error): |-
+                pipelineruns.tekton.dev "pipelinerun-with-validation-error" is forbidden: ValidatingAdmissionPolicy 'deny-on-validation-error.kueue.konflux-ci.dev' with binding 'deny-on-validation-error.kueue.konflux-ci.dev' denied request: PipelineRun validation failed: build-platforms parameter must be an array of platform strings, got a non-array value
+    - create:
+        file: ../resources/pipelinerun_with_custom_validation_error.yaml
+        expect:
+          - check:
+              ($error != null): true
+              ($error): |-
+                pipelineruns.tekton.dev "pipelinerun-with-validation-error" is forbidden: ValidatingAdmissionPolicy 'deny-on-validation-error.kueue.konflux-ci.dev' with binding 'deny-on-validation-error.kueue.konflux-ci.dev' denied request: PipelineRun validation failed: custom error
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: in-tenant-allow-pipelinerun-without-validation-error
+spec:
+  description: |
+    allows a PipelineRun that does not have the tekton-kueue
+    validation-error annotation in a tenant namespace
+  concurrent: false
+  steps:
+  - name: given-pipelineruns-crd-exists
+    try:
+    - apply:
+        file: ../resources/pipelineruns.tekton.dev_customresourcedefinition.yaml
+    - assert:
+        file: ../chainsaw-assert-pipelineruns-crd.yaml
+  - name: ensure-namespace-is-labeled
+    try:
+    - apply:
+        resource:
+          apiVersion: v1
+          kind: Namespace
+          metadata:
+            name: ($namespace)
+            labels:
+              konflux-ci.dev/type: tenant
+  - name: given-validatingadmissionpolicy-is-installed
+    try:
+    - apply:
+        file: ../../deny-on-validation-error-validatingadmissionpolicy.yaml
+    - apply:
+        file: ../../deny-on-validation-error-validatingadmissionpolicybinding.yaml
+    - assert:
+        file: ../chainsaw-assert-policy.yaml
+  - name: then-pipelinerun-without-validation-error-is-allowed
+    try:
+    - create:
+        file: ../resources/pipelinerun_without_validation_error.yaml

--- a/components/policies/production/policies/kueue/deny-on-validation-error/.chainsaw-test/test-outside-tenant/chainsaw-test.yaml
+++ b/components/policies/production/policies/kueue/deny-on-validation-error/.chainsaw-test/test-outside-tenant/chainsaw-test.yaml
@@ -1,0 +1,60 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: outside-tenant-allow-pipelinerun-with-validation-error
+spec:
+  description: |
+    allows a PipelineRun that has the tekton-kueue validation-error
+    annotation in a non-tenant namespace
+  concurrent: false
+  steps:
+  - name: given-pipelineruns-crd-exists
+    try:
+    - apply:
+        file: ../resources/pipelineruns.tekton.dev_customresourcedefinition.yaml
+    - assert:
+        file: ../chainsaw-assert-pipelineruns-crd.yaml
+  - name: given-validatingadmissionpolicy-is-installed
+    try:
+    - apply:
+        file: ../../deny-on-validation-error-validatingadmissionpolicy.yaml
+    - apply:
+        file: ../../deny-on-validation-error-validatingadmissionpolicybinding.yaml
+    - assert:
+        file: ../chainsaw-assert-policy.yaml
+  - name: then-pipelinerun-with-validation-error-is-allowed
+    try:
+    - create:
+        file: ../resources/pipelinerun_with_validation_error.yaml
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: outside-tenant-allow-pipelinerun-without-validation-error
+spec:
+  description: |
+    allows a PipelineRun that does not have the tekton-kueue
+    validation-error annotation in a non-tenant namespace
+  concurrent: false
+  steps:
+  - name: given-pipelineruns-crd-exists
+    try:
+    - apply:
+        file: ../resources/pipelineruns.tekton.dev_customresourcedefinition.yaml
+    - assert:
+        file: ../chainsaw-assert-pipelineruns-crd.yaml
+  - name: given-validatingadmissionpolicy-is-installed
+    try:
+    - apply:
+        file: ../../deny-on-validation-error-validatingadmissionpolicy.yaml
+    - apply:
+        file: ../../deny-on-validation-error-validatingadmissionpolicybinding.yaml
+    - assert:
+        file: ../chainsaw-assert-policy.yaml
+  - name: then-pipelinerun-without-validation-error-is-allowed
+    try:
+    - create:
+        file: ../resources/pipelinerun_without_validation_error.yaml

--- a/components/policies/production/policies/kueue/deny-on-validation-error/deny-on-validation-error-validatingadmissionpolicy.yaml
+++ b/components/policies/production/policies/kueue/deny-on-validation-error/deny-on-validation-error-validatingadmissionpolicy.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: deny-on-validation-error.kueue.konflux-ci.dev
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+      - apiGroups: ["tekton.dev"]
+        apiVersions: ["v1"]
+        operations: ["CREATE"]
+        resources: ["pipelineruns"]
+        scope: "Namespaced"
+  validations:
+    - expression: "!has(object.metadata.annotations) || !('kueue.konflux-ci.dev/validation-error' in object.metadata.annotations)"
+      messageExpression: |-
+        "PipelineRun validation failed: " + string(object.metadata.annotations["kueue.konflux-ci.dev/validation-error"])
+      message: "PipelineRun validation failed, inspect the 'kueue.konflux-ci.dev/validation-error' annotation for more info"

--- a/components/policies/production/policies/kueue/deny-on-validation-error/deny-on-validation-error-validatingadmissionpolicybinding.yaml
+++ b/components/policies/production/policies/kueue/deny-on-validation-error/deny-on-validation-error-validatingadmissionpolicybinding.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: deny-on-validation-error.kueue.konflux-ci.dev
+spec:
+  policyName: "deny-on-validation-error.kueue.konflux-ci.dev"
+  validationActions: [Deny]
+  matchResources:
+    namespaceSelector:
+      matchLabels:
+        konflux-ci.dev/type: tenant

--- a/components/policies/production/policies/kueue/deny-on-validation-error/kustomization.yaml
+++ b/components/policies/production/policies/kueue/deny-on-validation-error/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- deny-on-validation-error-validatingadmissionpolicy.yaml
+- deny-on-validation-error-validatingadmissionpolicybinding.yaml

--- a/components/policies/production/stone-prod-p01/kustomization.yaml
+++ b/components/policies/production/stone-prod-p01/kustomization.yaml
@@ -4,4 +4,5 @@ resources:
 - ../base
 - ../base/cost-management
 - ../policies/kueue/
+- ../policies/kueue/deny-on-validation-error/
 - ../policies/kubearchive/

--- a/hack/test-tekton-kueue-config.py
+++ b/hack/test-tekton-kueue-config.py
@@ -1187,6 +1187,16 @@ CONFIG_COMBINATIONS: Dict[str, ConfigCombination] = {
         "name": "Production RHEL config",
         "config_file": "components/kueue/production/kflux-rhel-p01/config.yaml",
         "kustomization_file": "components/kueue/production/base/tekton-kueue/kustomization.yaml"
+    },
+    "production-stone-prod-p01": {
+        "name": "Production stone-prod-p01 config (ring 1 temporary override)",
+        "config_file": "components/kueue/production/stone-prod-p01/config.yaml",
+        "kustomization_file": "components/kueue/production/base/tekton-kueue/kustomization.yaml"
+    },
+    "production-kflux-prd-rh02": {
+        "name": "Production kflux-prd-rh02 config (ring 1 temporary override)",
+        "config_file": "components/kueue/production/kflux-prd-rh02/config.yaml",
+        "kustomization_file": "components/kueue/production/base/tekton-kueue/kustomization.yaml"
     }
 }
 
@@ -1658,7 +1668,54 @@ TEST_COMBINATIONS: Dict[str, TestCombination] = {
             }
         }
     },
-    
+
+    # KFLUXINFRA-3980 ring 1: build-platforms type guard
+    # Ring-1 production configs emit kueue.konflux-ci.dev/validation-error
+    # (matching the VAP), unlike the dev/staging default which still emits
+    # tekton-kueue.konflux-ci.dev/validation-error.
+    "multiplatform_new_string_param_production-kflux-ocp-p01": {
+        "pipelinerun_key": "multiplatform_new_string_param",
+        "config_key": "production-kflux-ocp-p01",
+        "expected": {
+            "annotations": {
+                "kueue.konflux-ci.dev/validation-error": "build-platforms parameter must be an array of platform strings, got a non-array value",
+                "kueue.konflux-ci.dev/requests-konflux-ci-dev-token": "1",
+            },
+            "labels": {
+                "kueue.x-k8s.io/queue-name": "pipelines-queue",
+                "kueue.x-k8s.io/priority-class": "konflux-post-merge-build"
+            }
+        }
+    },
+    "multiplatform_new_string_param_production-stone-prod-p01": {
+        "pipelinerun_key": "multiplatform_new_string_param",
+        "config_key": "production-stone-prod-p01",
+        "expected": {
+            "annotations": {
+                "kueue.konflux-ci.dev/validation-error": "build-platforms parameter must be an array of platform strings, got a non-array value",
+                "kueue.konflux-ci.dev/requests-konflux-ci-dev-token": "1",
+            },
+            "labels": {
+                "kueue.x-k8s.io/queue-name": "pipelines-queue",
+                "kueue.x-k8s.io/priority-class": "konflux-post-merge-build"
+            }
+        }
+    },
+    "multiplatform_new_string_param_production-kflux-prd-rh02": {
+        "pipelinerun_key": "multiplatform_new_string_param",
+        "config_key": "production-kflux-prd-rh02",
+        "expected": {
+            "annotations": {
+                "kueue.konflux-ci.dev/validation-error": "build-platforms parameter must be an array of platform strings, got a non-array value",
+                "kueue.konflux-ci.dev/requests-konflux-ci-dev-token": "1",
+            },
+            "labels": {
+                "kueue.x-k8s.io/queue-name": "pipelines-queue",
+                "kueue.x-k8s.io/priority-class": "konflux-post-merge-build"
+            }
+        }
+    },
+
     # limit PLRs on p02
     "release_tenant_production_stone_prod_p02": {
         "pipelinerun_key": "release_tenant",


### PR DESCRIPTION
…ring-1)

## What

Adds `type(value) == list` guards to the `build-platforms` CEL expressions in tekton-kueue (resource-request and AWS-IP expressions), plus a validation-error annotation expression and a temporary tenant-scoped ValidatingAdmissionPolicy that denies PipelineRuns carrying that annotation.

Clusters affected: `stone-prod-p01`, `kflux-ocp-p01`, `kflux-prd-rh02` (ring 1)

- `stone-prod-p01` and `kflux-prd-rh02` previously inherited `production/base/tekton-kueue/config.yaml`; this adds temporary per-cluster `config.yaml` overrides (configMapGenerator `behavior: replace`) to scope the change to ring 1 only.
`kflux-ocp-p01` already had its own override, updated directly.
- New `components/policies/production/policies/kueue/deny-on-validation-error/`  (VAP + VAPB + chainsaw tests), wired only into the 3 ring-1 cluster kustomizations — not the shared `policies/kueue/kustomization.yaml` —  so it doesn't apply to the other 6 production clusters yet.
- Ring 3 will fold both the CEL change into `base/tekton-kueue/config.yaml` and the VAP into the shared `policies/kueue/kustomization.yaml`, removing the temporary overrides — same pattern as the [KFLUXINFRA-3973](https://redhat.atlassian.net/browse/KFLUXINFRA-3973) rollout.

[KFLUXINFRA-3980](https://redhat.atlassian.net/browse/KFLUXINFRA-3980)

## Why

The tekton-kueue webhook crashes with HTTP 500 (`failurePolicy: Fail`) when a PipelineRun submits `build-platforms` as a string instead of an array, rejecting the PipelineRun outright. Observed on `kflux-prd-rh02` on  2026-06-09 (18:12 and 18:14 UTC, 2 rejections). The guard makes the expression tolerant of the wrong type instead of crashing, and the VAP
prevents malformed PipelineRuns from silently bypassing the queue while the no-skip-kueue VAP rollout is still in progress.

## Validation

- `kustomize build` passes cleanly for all 6 affected overlays (`components/kueue/production/{stone-prod-p01,kflux-ocp-p01,kflux-prd-rh02}`, `components/policies/production/{stone-prod-p01,kflux-ocp-p01,kflux-prd-rh02}`).
- Confirmed via rendered diff that only these 3 clusters pick up the CEL guards and the new VAP/VAPB; the other 6 production clusters render unchanged.
- `python hack/test-tekton-kueue-config.py` passes, including 3 new cases covering string-typed `build-platforms` against the ring-1 configs.
- Already deployed to dev/staging with no issues: #12893.

## Risk Assessment

**Risk Level:** Low
**What could go wrong:** The guard only changes behavior for the previously-crashing case (string-typed `build-platforms`); array-typed values take the same code path as before. The VAP is scoped to tenant namespaces and only denies PipelineRuns already carrying the validation-error annotation, so it cannot affect any currently-passing  PipelineRun.
**Rollback:** Revert this PR.
**Blast radius:** 3 named production clusters (ring 1 of 3); no changes to `production/base` or the shared policy kustomization, so no other production cluster is touched.


[KFLUXINFRA-3980]: https://redhat.atlassian.net/browse/KFLUXINFRA-3980?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[KFLUXINFRA-3973]: https://redhat.atlassian.net/browse/KFLUXINFRA-3973?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ