### PR TITLE
KFLUXINFRA-3980: fix validation-error annotation key mismatch in dev/…

### DIFF
--- a/components/kueue/development/tekton-kueue/config.yaml
+++ b/components/kueue/development/tekton-kueue/config.yaml
@@ -43,7 +43,7 @@ cel:
         has(pipelineRun.spec.params) &&
         pipelineRun.spec.params.exists(p, p.name == 'build-platforms') &&
         type(pipelineRun.spec.params.filter(p, p.name == 'build-platforms')[0].value) != list ?
-        [annotation('tekton-kueue.konflux-ci.dev/validation-error',
+        [annotation('kueue.konflux-ci.dev/validation-error',
           'build-platforms parameter must be an array of platform strings, got a non-array value')] : []
 
     # Set resource requests for multi platform pipelines which doesn't use the build-platforms parameter (old style)

--- a/components/kueue/staging/base/tekton-kueue/config.yaml
+++ b/components/kueue/staging/base/tekton-kueue/config.yaml
@@ -43,7 +43,7 @@ cel:
         has(pipelineRun.spec.params) &&
         pipelineRun.spec.params.exists(p, p.name == 'build-platforms') &&
         type(pipelineRun.spec.params.filter(p, p.name == 'build-platforms')[0].value) != list ?
-        [annotation('tekton-kueue.konflux-ci.dev/validation-error',
+        [annotation('kueue.konflux-ci.dev/validation-error',
           'build-platforms parameter must be an array of platform strings, got a non-array value')] : []
 
     # Set resource requests for multi platform pipelines which doesn't use the build-platforms parameter (old style)

--- a/hack/test-tekton-kueue-config.py
+++ b/hack/test-tekton-kueue-config.py
@@ -910,7 +910,7 @@ PIPELINERUN_DEFINITIONS: Dict[str, PipelineRunTestData] = {
         },
         "expected": {
             "annotations": {
-                "tekton-kueue.konflux-ci.dev/validation-error": "build-platforms parameter must be an array of platform strings, got a non-array value",
+                "kueue.konflux-ci.dev/validation-error": "build-platforms parameter must be an array of platform strings, got a non-array value",
                 "kueue.konflux-ci.dev/requests-konflux-ci-dev-token": "1",
             },
             "labels": {


### PR DESCRIPTION
…staging

The build-platforms type guard (#12893) emits the validation-error annotation as tekton-kueue.konflux-ci.dev/validation-error, but the ValidatingAdmissionPolicy it's paired with checks
kueue.konflux-ci.dev/validation-error, per Francesco's review comment on #12893 suggesting the kueue.konflux-ci.dev domain. The VAP change was applied but the CEL expression was left on the old key, so the temporary deny-on-validation-error VAP is currently a no-op in dev and staging: malformed build-platforms values no longer crash the webhook, but they also aren't denied as intended.

Chainsaw tests didn't catch this because their fixtures hard-code kueue.konflux-ci.dev/validation-error directly rather than exercising the real tekton-kueue mutation, so they pass regardless of which key the CEL actually emits.

Update the CEL annotation() calls in both dev and staging configs to kueue.konflux-ci.dev/validation-error, matching the VAP, and update the corresponding test expectation in hack/test-tekton-kueue-config.py.

Ring 1 of the production promotion (#13059) already uses the correct key.

Contributes to: [KFLUXINFRA-3980](https://redhat.atlassian.net/browse/KFLUXINFRA-3980)

Assisted-by: Claude Code (claude-sonnet-5)

[KFLUXINFRA-3980]: https://redhat.atlassian.net/browse/KFLUXINFRA-3980?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ