### PR TITLE
PVO11Y-5331 Switch cardinality exporter to Konflux-built image

### DIFF
--- a/components/monitoring/exporters/cardinality/staging/base/kustomization.yaml
+++ b/components/monitoring/exporters/cardinality/staging/base/kustomization.yaml
@@ -4,5 +4,5 @@ resources:
 
 images:
   - name: quay.io/redhat-appstudio/cardinality-exporter
-    newName: quay.io/jmicanek/cardinality-exporter
-    newTag: v0.1
+    newName: quay.io/redhat-appstudio/cardinality-exporter
+    newTag: d7a0607ad117e7817c9d019f9d3e76e4d55c1b89


### PR DESCRIPTION
## Summary

- Replace the manually built personal image (`quay.io/jmicanek/cardinality-exporter:v0.1`) with the Konflux-built image from `quay.io/redhat-appstudio/cardinality-exporter`, tagged by source commit SHA. Required before production deployment — production does not allow manually built images.

## Risk Assessment

- **Level:** Low
- **Description:** Image swap only. The Konflux-built image is from the same source code, built via the Konflux pipeline.
- **Rollback:** Revert the commit.

## Validation

- Verified image exists at `quay.io/redhat-appstudio/cardinality-exporter:d7a0607ad117e7817c9d019f9d3e76e4d55c1b89` with matching `vcs-ref` label
- `kustomize build` renders the correct image reference