### PR TITLE
PVO11Y-5347 Add empty-base for cardinality exporter gradual rollout

### DIFF
--- a/argo-cd-apps/base/member/infra-deployments/monitoring-cardinality/monitoring-cardinality.yaml
+++ b/argo-cd-apps/base/member/infra-deployments/monitoring-cardinality/monitoring-cardinality.yaml
@@ -12,7 +12,7 @@ spec:
               values:
                 sourceRoot: components/monitoring/exporters/cardinality
                 environment: staging
-                clusterDir: ""
+                clusterDir: empty-base
           - list:
               elements:
                 - nameNormalized: stone-stg-rh01

--- a/components/monitoring/exporters/cardinality/staging/empty-base/kustomization.yaml
+++ b/components/monitoring/exporters/cardinality/staging/empty-base/kustomization.yaml
@@ -1,0 +1,3 @@
+kind: Kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+resources: []


### PR DESCRIPTION
## Summary

- Add a `staging/empty-base/` overlay with no resources for the cardinality exporter
- Change the ApplicationSet default `clusterDir` from `""` to `empty-base` so clusters not in the list generator deploy nothing instead of failing on a missing path

This follows the same pattern as konflux-rbac and prepares for production ring deployment of the cardinality exporter.

## Risk Assessment

- **Level:** Low
- **Description:** No change to which clusters run the cardinality exporter. stone-stg-rh01 and stone-stage-p01 are already in the list generator with their own clusterDir. The empty-base only affects clusters not in the list.
- **Rollback:** Revert the commit.

## Validation

- Staging clusters in the list (stone-stg-rh01, stone-stage-p01) are unaffected — they have explicit clusterDir overrides
- `kustomize build` for empty-base renders 0 resources