### PR TITLE
PVO11Y-5094 Deploy Tekton Prometheus to remaining production clusters (ring 2)

### DIFF
--- a/components/monitoring/prometheus/production/kflux-fedora-01/kustomization.yaml
+++ b/components/monitoring/prometheus/production/kflux-fedora-01/kustomization.yaml
@@ -2,11 +2,18 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - ../base
+- ../tekton-ms
 
 patches:
-- path: cluster-id-label.yaml
-  target:
-    name: appstudio-federate-ms
-    kind: MonitoringStack
-    group: monitoring.rhobs
-    version: v1alpha1
+  - path: cluster-id-label.yaml
+    target:
+      name: appstudio-federate-ms
+      kind: MonitoringStack
+      group: monitoring.rhobs
+      version: v1alpha1
+  - path: cluster-id-label.yaml
+    target:
+      name: appstudio-tekton-ms
+      kind: MonitoringStack
+      group: monitoring.rhobs
+      version: v1alpha1

--- a/components/monitoring/prometheus/production/kflux-ocp-p01/kustomization.yaml
+++ b/components/monitoring/prometheus/production/kflux-ocp-p01/kustomization.yaml
@@ -2,11 +2,18 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - ../base
+- ../tekton-ms
 
 patches:
   - path: cluster-id-label.yaml
     target:
       name: appstudio-federate-ms
+      kind: MonitoringStack
+      group: monitoring.rhobs
+      version: v1alpha1
+  - path: cluster-id-label.yaml
+    target:
+      name: appstudio-tekton-ms
       kind: MonitoringStack
       group: monitoring.rhobs
       version: v1alpha1

--- a/components/monitoring/prometheus/production/kflux-osp-p01/kustomization.yaml
+++ b/components/monitoring/prometheus/production/kflux-osp-p01/kustomization.yaml
@@ -2,11 +2,18 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - ../base
+- ../tekton-ms
 
 patches:
   - path: cluster-id-label.yaml
     target:
       name: appstudio-federate-ms
+      kind: MonitoringStack
+      group: monitoring.rhobs
+      version: v1alpha1
+  - path: cluster-id-label.yaml
+    target:
+      name: appstudio-tekton-ms
       kind: MonitoringStack
       group: monitoring.rhobs
       version: v1alpha1

--- a/components/monitoring/prometheus/production/kflux-prd-es01/kustomization.yaml
+++ b/components/monitoring/prometheus/production/kflux-prd-es01/kustomization.yaml
@@ -2,10 +2,17 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - ../base
+- ../tekton-ms
 patches:
   - path: cluster-id-label.yaml
     target:
       name: appstudio-federate-ms
+      kind: MonitoringStack
+      group: monitoring.rhobs
+      version: v1alpha1
+  - path: cluster-id-label.yaml
+    target:
+      name: appstudio-tekton-ms
       kind: MonitoringStack
       group: monitoring.rhobs
       version: v1alpha1

--- a/components/monitoring/prometheus/production/kflux-prd-rh03/kustomization.yaml
+++ b/components/monitoring/prometheus/production/kflux-prd-rh03/kustomization.yaml
@@ -2,11 +2,18 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - ../base
+- ../tekton-ms
 
 patches:
   - path: cluster-id-label.yaml
     target:
       name: appstudio-federate-ms
+      kind: MonitoringStack
+      group: monitoring.rhobs
+      version: v1alpha1
+  - path: cluster-id-label.yaml
+    target:
+      name: appstudio-tekton-ms
       kind: MonitoringStack
       group: monitoring.rhobs
       version: v1alpha1

--- a/components/monitoring/prometheus/production/kflux-rhel-p01/kustomization.yaml
+++ b/components/monitoring/prometheus/production/kflux-rhel-p01/kustomization.yaml
@@ -2,11 +2,18 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - ../base
+- ../tekton-ms
 
 patches:
   - path: cluster-id-label.yaml
     target:
       name: appstudio-federate-ms
+      kind: MonitoringStack
+      group: monitoring.rhobs
+      version: v1alpha1
+  - path: cluster-id-label.yaml
+    target:
+      name: appstudio-tekton-ms
       kind: MonitoringStack
       group: monitoring.rhobs
       version: v1alpha1

--- a/components/monitoring/prometheus/production/stone-prd-rh01/kustomization.yaml
+++ b/components/monitoring/prometheus/production/stone-prd-rh01/kustomization.yaml
@@ -2,11 +2,18 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - ../base
+- ../tekton-ms
 
 patches:
   - path: cluster-id-label.yaml
     target:
       name: appstudio-federate-ms
+      kind: MonitoringStack
+      group: monitoring.rhobs
+      version: v1alpha1
+  - path: cluster-id-label.yaml
+    target:
+      name: appstudio-tekton-ms
       kind: MonitoringStack
       group: monitoring.rhobs
       version: v1alpha1

--- a/components/monitoring/prometheus/production/stone-prod-p02/kustomization.yaml
+++ b/components/monitoring/prometheus/production/stone-prod-p02/kustomization.yaml
@@ -2,11 +2,18 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - ../base
+- ../tekton-ms
 
 patches:
   - path: cluster-id-label.yaml
     target:
       name: appstudio-federate-ms
+      kind: MonitoringStack
+      group: monitoring.rhobs
+      version: v1alpha1
+  - path: cluster-id-label.yaml
+    target:
+      name: appstudio-tekton-ms
       kind: MonitoringStack
       group: monitoring.rhobs
       version: v1alpha1


### PR DESCRIPTION
## Summary

Add tekton-ms to all remaining production clusters: kflux-fedora-01, kflux-ocp-p01, kflux-osp-p01, kflux-prd-es01, kflux-prd-rh03, kflux-rhel-p01, stone-prd-rh01, stone-prod-p02.

## Risk Assessment

- **Level:** Low
- **Description:** Same deployment as ring 1, which has been running successfully for 2 days on stone-prod-p01 and kflux-prd-rh02.
- **Rollback:** Remove `../tekton-ms` from the affected cluster kustomizations.

## Validation

- Ring 1 (stone-prod-p01, kflux-prd-rh02) running successfully for 2 days
- Remote-write to RHOBS working
- `kustomize build` verified for the new clusters