### PR TITLE
KONFLUX-15072 Promote caching-helm chart to 0.1.1775 on kflux-ocp-p01

### DIFF
--- a/components/squid/production/kflux-ocp-p01/caching-helm-generator.yaml
+++ b/components/squid/production/kflux-ocp-p01/caching-helm-generator.yaml
@@ -4,7 +4,7 @@ metadata:
   name: caching-helm
 name: caching-helm
 repo: oci://quay.io/konflux-ci/caching
-version: 0.1.1688+a7def07
+version: 0.1.1775+d865e45
 valuesInline:
   squid:
     enabled: true


### PR DESCRIPTION
## What

  Promote caching-helm chart from 0.1.1688+a7def07 to 0.1.1775+d865e45 on kflux-ocp-p01.

  Clusters affected: kflux-ocp-p01

  [KONFLUX-15072](https://redhat.atlassian.net/browse/KONFLUX-15072)

  ## Why

  OCP builds on kflux-ocp-p01 are failing with 502 Bad Gateway errors from artifact-registry-proxy when downloading large (100MB+) Go artifacts. The proxy's default 60s timeout is a bit too low and may cause some issues for clients. An increase to 180s will help avoid this.

This also includes an additional `normalized_uri` label on prometheus metrics required for [KONFLUX-14705](https://redhat.atlassian.net/browse/KONFLUX-14705).

  ## Validation

  - `kustomize build --enable-helm` passes for `components/squid/production/kflux-ocp-p01/`
  - Timeout increase deployed and validated in staging ([#12890](https://github.com/redhat-appstudio/infra-deployments/pull/12890)) — 502s no longer seen.
  - Nexus timeout increase confirmed by prodsec ([Slack thread](https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1784035855899269))

  ## Risk Assessment

  **Risk Level:** Low
  **What could go wrong:** Chart upgrade includes additional changes beyond the timeout fix and metric enhancements that could affect proxy or caching behavior.
  **Rollback:** Revert PR to restore previous chart version (0.1.1688+a7def07).
  **Blast radius:** Single cluster (kflux-ocp-p01).

[KONFLUX-15072]: https://redhat.atlassian.net/browse/KONFLUX-15072?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[KONFLUX-14705]: https://redhat.atlassian.net/browse/KONFLUX-14705?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ