### PR TITLE
set stage pod requests same as limits for image-controller & build-se…

### DIFF
--- a/components/build-service/staging/base/manager_resources_patch.yaml
+++ b/components/build-service/staging/base/manager_resources_patch.yaml
@@ -13,5 +13,5 @@ spec:
             cpu: 500m
             memory: 4Gi
           requests:
-            cpu: 250m
-            memory: 2Gi
+            cpu: 500m
+            memory: 4Gi

--- a/components/image-controller/staging/base/manager_resources_patch.yaml
+++ b/components/image-controller/staging/base/manager_resources_patch.yaml
@@ -13,5 +13,5 @@ spec:
             cpu: 500m
             memory: 6Gi
           requests:
-            cpu: 250m
-            memory: 3Gi
+            cpu: 500m
+            memory: 6Gi


### PR DESCRIPTION
## What:                                                                                  
stage set requests same as limits for image-controller & build-service pods
                                                                                          
## Why:                                                                                   
so that pods won't have qos Burstable but Guaranteed 
                                                                                          
## Validation:                                                                            
CI
                                                                                          
## Risk Assessment                                                                        
**Risk Level:** Low                                                                       
**Description:** stage image-controller & build-service pods requests same as limits
**Rollback:** Revert PR                   