### PR TITLE
set prod pod requests same as limits for image-controller & build-ser…

### DIFF
--- a/components/build-service/production/base/manager_resources_patch.yaml
+++ b/components/build-service/production/base/manager_resources_patch.yaml
@@ -13,5 +13,5 @@ spec:
             cpu: 500m
             memory: 4Gi
           requests:
-            cpu: 250m
-            memory: 2Gi
+            cpu: 500m
+            memory: 4Gi

--- a/components/image-controller/production/base/manager_resources_patch.yaml
+++ b/components/image-controller/production/base/manager_resources_patch.yaml
@@ -13,5 +13,5 @@ spec:
             cpu: 500m
             memory: 6Gi
           requests:
-            cpu: 250m
-            memory: 3Gi
+            cpu: 500m
+            memory: 6Gi


### PR DESCRIPTION
## What:                                                                                  
prod set requests same as limits for image-controller & build-service pods
                                                                                          
## Why:                                                                                   
so that pods won't have qos Burstable but Guaranteed 
                                                                                          
## Validation:                                                                            
Staging PR: https://github.com/redhat-appstudio/infra-deployments/pull/13076
                                                                                          
## Risk Assessment                                                                        
**Risk Level:** Low                                                                       
**Description:** prod image-controller & build-service pods requests same as limits
**Rollback:** Revert PR                   
