### PR TITLE
fix(KONFLUX-14971, kaexporter): Avoid OOMKilled

### DIFF
--- a/components/monitoring/exporters/kaexporter/staging/base/configs/kaexporter-config.yaml
+++ b/components/monitoring/exporters/kaexporter/staging/base/configs/kaexporter-config.yaml
@@ -4,3 +4,5 @@ excludeNamespaces:
   - dev-release-team-tenant
   - "konflux-perfscale-*-tenant"
   - build-templates-e2e
+  - "test-rhtap-*-tenant"
+  - konflux-fedora-perfscale-tenant

--- a/components/monitoring/exporters/kaexporter/staging/base/kustomization.yaml
+++ b/components/monitoring/exporters/kaexporter/staging/base/kustomization.yaml
@@ -2,12 +2,12 @@ resources:
   - rbac
   - external-secrets
   - configs
-  - https://github.com/redhat-appstudio/o11y/config/exporters/monitoring/kaexporter/base?ref=6a5258fd68e6f9ce3b3f0189a8224793db53ce31
+  - https://github.com/redhat-appstudio/o11y/config/exporters/monitoring/kaexporter/base?ref=05d2ca5b75e37f9675f0a0eb70649d847cdb8813
 
 images:
   - name: quay.io/redhat-appstudio/o11y
     newName: quay.io/redhat-appstudio/o11y
-    newTag: 6a5258fd68e6f9ce3b3f0189a8224793db53ce31
+    newTag: 05d2ca5b75e37f9675f0a0eb70649d847cdb8813
 
 patches:
   - path: ./configs/kaexporter-deployment-patch.yaml


### PR DESCRIPTION
In attempt to avoid the kaexporter from being OOMKilled:
- Exclude more tenants which will reduce the exporter's memory consumption some.
- Increase memory request and limit to 2Gi.