### PR TITLE
fix(KONFLUX-14971, kaexporter): Avoid OOMKilled for prd

### DIFF
--- a/components/monitoring/exporters/kaexporter/production/base/configs/kaexporter-config.yaml
+++ b/components/monitoring/exporters/kaexporter/production/base/configs/kaexporter-config.yaml
@@ -1,0 +1,8 @@
+excludeNamespaces:
+  - rhtap-releng-tenant
+  - "managed-*"
+  - dev-release-team-tenant
+  - "konflux-perfscale-*-tenant"
+  - build-templates-e2e
+  - "test-rhtap-*-tenant"
+  - konflux-fedora-perfscale-tenant

--- a/components/monitoring/exporters/kaexporter/production/base/configs/kaexporter-deployment-patch.yaml
+++ b/components/monitoring/exporters/kaexporter/production/base/configs/kaexporter-deployment-patch.yaml
@@ -1,0 +1,21 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kaexporter-deployment
+  namespace: konflux-o11y-exporters
+spec:
+  template:
+    spec:
+      volumes:
+        - name: kaexporter-config
+          configMap:
+            name: kaexporter-config
+      containers:
+        - name: exporters
+          env:
+            - name: KA_CONFIG_FILE
+              value: "/etc/kaexporter/kaexporter-config.yaml"
+          volumeMounts:
+            - name: kaexporter-config
+              mountPath: /etc/kaexporter
+              readOnly: true

--- a/components/monitoring/exporters/kaexporter/production/base/configs/kustomization.yaml
+++ b/components/monitoring/exporters/kaexporter/production/base/configs/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+configMapGenerator:
+  - name: kaexporter-config
+    namespace: konflux-o11y-exporters
+    files:
+      - kaexporter-config.yaml
+    options:
+      disableNameSuffixHash: true

--- a/components/monitoring/exporters/kaexporter/production/base/kustomization.yaml
+++ b/components/monitoring/exporters/kaexporter/production/base/kustomization.yaml
@@ -1,9 +1,13 @@
 resources:
   - rbac
   - external-secrets
-  - https://github.com/redhat-appstudio/o11y/config/exporters/monitoring/kaexporter/base?ref=cd48a7ad17234ef50526134e0ad628ce30894b5a
+  - configs
+  - https://github.com/redhat-appstudio/o11y/config/exporters/monitoring/kaexporter/base?ref=05d2ca5b75e37f9675f0a0eb70649d847cdb8813
 
 images:
   - name: quay.io/redhat-appstudio/o11y
     newName: quay.io/redhat-appstudio/o11y
-    newTag: cd48a7ad17234ef50526134e0ad628ce30894b5a
+    newTag: 05d2ca5b75e37f9675f0a0eb70649d847cdb8813
+
+patches:
+  - path: ./configs/kaexporter-deployment-patch.yaml


### PR DESCRIPTION
## Summary

Tweaking KAExporter to avoid it from being OOMKilled:
- Increase memory request and limit to 2Gi.
- Include configurations and updated KAExporter image for excluding certain testing and development Konflux tenants to reduce the exporter's resource usage and metric cardinality

These changes were first deployed and validated in stage with #13057 and #13080.

## Risk Assessment

- **Level**: Low
- **Description**: Changes only affect KAExporter. Changes verified to be working as intended under staging clusters first.
- **Rollback**: Revert this PR to revert KAExporter and configuration back to the original version

## Validation

- These changes were first deployed and validated in stage with #13057 and #13080
- Verified generated manifests were correct with `kustomize build components/monitoring/exporters/kaexporter/production/base`
