### PR TITLE
KFLUXVNGD-1117 Add normalized_uri to staging federation label allowlist

### DIFF
--- a/components/monitoring/prometheus/staging/base/federation/writeRelabelConfigs.yaml
+++ b/components/monitoring/prometheus/staging/base/federation/writeRelabelConfigs.yaml
@@ -18,7 +18,8 @@
     # Kyverno
     # Release service (RHTAPWATCH-88)
     # SPI / auth (RHTAPWATCH-88 — SPI removed, may be dead weight)
-    # Probes / testing (RHTAPWATCH-891, PVO11Y-4802, SPRE-4498, KFLUXVNGD-751)
+    # Probes / testing (RHTAPWATCH-891, PVO11Y-4802, SPRE-4498)
+    # Caching (KFLUXVNGD-751, KFLUXVNGD-1115)
     # ArgoCD (RHTAPWATCH-88)
     # Monitoring infra (RHTAPWATCH-110, PVO11Y-4774)
     # KubeArchive
@@ -37,7 +38,8 @@
       policy_name|rule_result|rule_type|rule_execution_cause|policy_background_mode|policy_type|policy_validation_mode|policy_change_type|resource_request_operation|resource_kind|event_type|\
       release_reason|deployment_reason|validation_reason|strategy|succeeded|target|result|\
       tokenName|rateLimited|commit_hash|operation|\
-      check|tested_cluster|tested_registry|unexpected_status|failure|severity|cache_status|\
+      check|tested_cluster|tested_registry|unexpected_status|failure|severity|\
+      cache_status|normalized_uri|\
       health_status|dest_namespace|\
       hostname|label_app_kubernetes_io_managed_by|platform|scrape_job|slice|error|\
       resource_type|gin_errors|\


### PR DESCRIPTION
The normalized_uri label is needed in RHOBS for Grafana queries on caching HTTP metrics. Also moves cache_status out of the probes/testing group into a new Caching group alongside normalized_uri.

Assisted-by: Claude claude-opus-4-6