### PR TITLE
PVO11Y-5364 Rename kueue ClusterPolicy to bypass kyverno immutable field rejection

### DIFF
--- a/components/policies/production/policies/kueue/queue-config/cluster-policy.yaml
+++ b/components/policies/production/policies/kueue/queue-config/cluster-policy.yaml
@@ -2,7 +2,7 @@
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
-  name: bootstrap-tenant-namespace-queue
+  name: bootstrap-tenant-namespaces-queue
 spec:
   rules:
   - name: create-local-queue


### PR DESCRIPTION
## Summary

Rename `bootstrap-tenant-namespace-queue` to `bootstrap-tenant-namespaces-queue` (`namespace` → `namespaces`) in the production kueue ClusterPolicy.

Kyverno's admission webhook rejects updates to immutable fields on generate rules, causing ArgoCD to retry indefinitely on kflux-fedora-01 (1437+ retries). Renaming the policy makes kyverno treat it as a new resource on all production clusters. Existing LocalQueues survive because `orphanDownstreamOnPolicyDelete` is already set to `true`.

Also removes the step-1 synchronize patch from kflux-fedora-01 since it's no longer needed with the rename approach.

## Risk Assessment

- **Level**: Low
- **Description**: Renames the ClusterPolicy on all production clusters. ArgoCD prunes the old-named policy and creates the new one. LocalQueues are preserved via orphanDownstreamOnPolicyDelete. The new policy with generateExisting=true recreates any missing LocalQueues.
- **Rollback**: Rename the policy back to the original name

## Validation

- Staging PR must be merged and validated first
- Same approach recommended by infra team (ansadler) as the safest way to handle kyverno immutable field changes

## JIRA

[PVO11Y-5364](https://redhat.atlassian.net/browse/PVO11Y-5364)

[PVO11Y-5364]: https://redhat.atlassian.net/browse/PVO11Y-5364?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ