### PR TITLE
PVO11Y-5364 Rename kueue ClusterPolicy in staging

### DIFF
--- a/components/policies/development/kueue/queue-config/.chainsaw-test/chainsaw-assert-clusterpolicy.yaml
+++ b/components/policies/development/kueue/queue-config/.chainsaw-test/chainsaw-assert-clusterpolicy.yaml
@@ -1,7 +1,7 @@
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
-  name: bootstrap-tenant-namespace-queue
+  name: bootstrap-tenant-namespaces-queue
 status:
   conditions:
   - reason: Succeeded

--- a/components/policies/development/kueue/queue-config/.chainsaw-test/chainsaw-test.yaml
+++ b/components/policies/development/kueue/queue-config/.chainsaw-test/chainsaw-test.yaml
@@ -691,7 +691,7 @@ spec:
     - wait:
         apiVersion: kyverno.io/v1
         kind: ClusterPolicy
-        name: bootstrap-tenant-namespace-queue
+        name: bootstrap-tenant-namespaces-queue
         for:
           deletion: {}
     - script:

--- a/components/policies/development/kueue/queue-config/cluster-policy.yaml
+++ b/components/policies/development/kueue/queue-config/cluster-policy.yaml
@@ -2,7 +2,7 @@
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
-  name: bootstrap-tenant-namespace-queue
+  name: bootstrap-tenant-namespaces-queue
 spec:
   rules:
   - name: create-local-queue


### PR DESCRIPTION
## Summary

Rename `bootstrap-tenant-namespace-queue` to `bootstrap-tenant-namespaces-queue` (`namespace` → `namespaces`) in the development/staging kueue ClusterPolicy.

This is the staging counterpart of the production rename needed to bypass kyverno's immutable field rejection on kflux-fedora-01. Must be validated on staging before the production PR is merged.

## Validation

- `kustomize build` passes for development environment

## JIRA

[PVO11Y-5364](https://redhat.atlassian.net/browse/PVO11Y-5364)

[PVO11Y-5364]: https://redhat.atlassian.net/browse/PVO11Y-5364?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ