### PR TITLE
Promote release-service and grafana-dashboard from development to staging

### DIFF
--- a/components/monitoring/grafana/staging/dashboards/release/kustomization.yaml
+++ b/components/monitoring/grafana/staging/dashboards/release/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- https://github.com/konflux-ci/release-service/config/grafana/?ref=19e1d5ade7521048274c3ce9a427c381c93b71de
+- https://github.com/konflux-ci/release-service/config/grafana/?ref=f3ac0e4aa928ff7c4fdac1846de3268afd9c9ae5

--- a/components/release/staging/kustomization.yaml
+++ b/components/release/staging/kustomization.yaml
@@ -4,7 +4,7 @@ resources:
   - ../base
   - ../base/monitor/staging
   - external-secrets/release-monitor-secret.yaml
-  - https://github.com/konflux-ci/release-service/config/default?ref=19e1d5ade7521048274c3ce9a427c381c93b71de
+  - https://github.com/konflux-ci/release-service/config/default?ref=f3ac0e4aa928ff7c4fdac1846de3268afd9c9ae5
   - release_service_config.yaml
   - signing_configs.yaml
 
@@ -14,7 +14,7 @@ components:
 images:
   - name: quay.io/konflux-ci/release-service
     newName: quay.io/konflux-ci/release-service
-    newTag: 19e1d5ade7521048274c3ce9a427c381c93b71de
+    newTag: f3ac0e4aa928ff7c4fdac1846de3268afd9c9ae5
 
 namespace: release-service
 


### PR DESCRIPTION
Included PRs:
 - https://github.com/konflux-ci/release-service/pull/1777 (breaking-change)
 - https://github.com/konflux-ci/release-service/pull/1805 
 - https://github.com/konflux-ci/release-service/pull/1755 
 - https://github.com/konflux-ci/release-service/pull/1783 
 - https://github.com/konflux-ci/release-service/pull/1789 
 - https://github.com/konflux-ci/release-service/pull/1797 
 - https://github.com/konflux-ci/release-service/pull/1801 
 - https://github.com/konflux-ci/release-service/pull/1799 
 - https://github.com/konflux-ci/release-service/pull/1731 
 - https://github.com/konflux-ci/release-service/pull/1791 
 - https://github.com/konflux-ci/release-service/pull/1798 
 - https://github.com/konflux-ci/release-service/pull/1794 
 - https://github.com/konflux-ci/release-service/pull/1790 
 - https://github.com/konflux-ci/release-service/pull/1780 
 - https://github.com/konflux-ci/release-service/pull/1781 
 - https://github.com/konflux-ci/release-service/pull/1785 
 - https://github.com/konflux-ci/release-service/pull/1779 
 - https://github.com/konflux-ci/release-service/pull/1683 
 - https://github.com/konflux-ci/release-service/pull/1776 
 - https://github.com/konflux-ci/release-service/pull/1746 
 - https://github.com/konflux-ci/release-service/pull/1768 
 - https://github.com/konflux-ci/release-service/pull/1747 
 - https://github.com/konflux-ci/release-service/pull/1682 
 - https://github.com/konflux-ci/release-service/pull/1724 
 - https://github.com/konflux-ci/release-service/pull/1726 
 - https://github.com/konflux-ci/release-service/pull/1705 
 - https://github.com/konflux-ci/release-service/pull/1764 
 - https://github.com/konflux-ci/release-service/pull/1766 
 - https://github.com/konflux-ci/release-service/pull/1758 
 - https://github.com/konflux-ci/release-service/pull/1763 
 - https://github.com/konflux-ci/release-service/pull/1761 
 - https://github.com/konflux-ci/release-service/pull/1760 
 - https://github.com/konflux-ci/release-service/pull/1759 
 - https://github.com/konflux-ci/release-service/pull/1754 
 - https://github.com/konflux-ci/release-service/pull/1748 
 - https://github.com/konflux-ci/release-service/pull/1752 
 - https://github.com/konflux-ci/release-service/pull/1742 
 - https://github.com/konflux-ci/release-service/pull/1745 
 - https://github.com/konflux-ci/release-service/pull/1743 
 - https://github.com/konflux-ci/release-service/pull/1733 
 - https://github.com/konflux-ci/release-service/pull/1739 
 - https://github.com/konflux-ci/release-service/pull/1751 
 - https://github.com/konflux-ci/release-service/pull/1741 
 - https://github.com/konflux-ci/release-service/pull/1677 
 - https://github.com/konflux-ci/release-service/pull/1734 
 - https://github.com/konflux-ci/release-service/pull/1737 
 - https://github.com/konflux-ci/release-service/pull/1735 
 - https://github.com/konflux-ci/release-service/pull/1727 
 - https://github.com/konflux-ci/release-service/pull/1730 

The two user operator changes that are non-bots (Mintmaker)
- https://github.com/konflux-ci/release-service/commit/e2ea734989e61089a1738821c66f11fab829cb0f (breaking-change)
- https://github.com/konflux-ci/release-service/commit/f3ac0e4aa928ff7c4fdac1846de3268afd9c9ae5 (breaking-change)

Risk: The risk of this promotion is high due to the CRD changes and the addition of managed PipelineRun retry logic, which changes how managed PipelineRuns are handled by the operator. If issues are found after promotion the rollback plan is to revert to the last known good commit.

Promotion into development 
- [1] https://github.com/redhat-appstudio/infra-deployments/pull/12854
- [2] https://github.com/redhat-appstudio/infra-deployments/pull/12988