### PR TITLE
PVO11Y-5365 Remove tekton-ms from kflux-prd-es01

### DIFF
--- a/argo-cd-apps/base/member/infra-deployments/monitoring-cardinality/monitoring-cardinality.yaml
+++ b/argo-cd-apps/base/member/infra-deployments/monitoring-cardinality/monitoring-cardinality.yaml
@@ -19,6 +19,26 @@ spec:
                   values.clusterDir: stone-stg-rh01
                 - nameNormalized: stone-stage-p01
                   values.clusterDir: stone-stage-p01
+                # Ring 1 production clusters
+                - nameNormalized: stone-prod-p01
+                  values.clusterDir: stone-prod-p01
+                - nameNormalized: kflux-prd-rh02
+                  values.clusterDir: kflux-prd-rh02
+                # Remaining production clusters — empty-base until promoted
+                - nameNormalized: stone-prd-rh01
+                  values.clusterDir: empty-base
+                - nameNormalized: stone-prod-p02
+                  values.clusterDir: empty-base
+                - nameNormalized: kflux-ocp-p01
+                  values.clusterDir: empty-base
+                - nameNormalized: kflux-prd-rh03
+                  values.clusterDir: empty-base
+                - nameNormalized: kflux-rhel-p01
+                  values.clusterDir: empty-base
+                - nameNormalized: kflux-osp-p01
+                  values.clusterDir: empty-base
+                - nameNormalized: kflux-fedora-01
+                  values.clusterDir: empty-base
   template:
     metadata:
       name: monitoring-cardinality-{{nameNormalized}}

--- a/argo-cd-apps/overlays/konflux-public-production/delete-applications.yaml
+++ b/argo-cd-apps/overlays/konflux-public-production/delete-applications.yaml
@@ -12,13 +12,6 @@ metadata:
   name: nvme-storage-configurator
 $patch: delete
 ---
-# Cardinality exporter is staging-only
-apiVersion: argoproj.io/v1alpha1
-kind: ApplicationSet
-metadata:
-  name: monitoring-cardinality
-$patch: delete
----
 apiVersion: argoproj.io/v1alpha1
 kind: ApplicationSet
 metadata:

--- a/argo-cd-apps/overlays/konflux-public-production/kustomization.yaml
+++ b/argo-cd-apps/overlays/konflux-public-production/kustomization.yaml
@@ -295,3 +295,8 @@ patches:
       kind: ApplicationSet
       version: v1alpha1
       name: monitoring-workload-konflux-o11y-kaexporter
+  - path: production-overlay-patch.yaml
+    target:
+      kind: ApplicationSet
+      version: v1alpha1
+      name: monitoring-cardinality

--- a/argo-cd-apps/overlays/production-downstream/delete-applications.yaml
+++ b/argo-cd-apps/overlays/production-downstream/delete-applications.yaml
@@ -5,13 +5,6 @@ metadata:
   name: quality-dashboard
 $patch: delete
 ---
-# Cardinality exporter is staging-only
-apiVersion: argoproj.io/v1alpha1
-kind: ApplicationSet
-metadata:
-  name: monitoring-cardinality
-$patch: delete
----
 apiVersion: argoproj.io/v1alpha1
 kind: ApplicationSet
 metadata:

--- a/argo-cd-apps/overlays/production-downstream/kustomization.yaml
+++ b/argo-cd-apps/overlays/production-downstream/kustomization.yaml
@@ -310,3 +310,8 @@ patches:
       kind: ApplicationSet
       version: v1alpha1
       name: monitoring-workload-konflux-o11y-kaexporter
+  - path: production-overlay-patch.yaml
+    target:
+      kind: ApplicationSet
+      version: v1alpha1
+      name: monitoring-cardinality

--- a/components/monitoring/exporters/cardinality/production/base/kustomization.yaml
+++ b/components/monitoring/exporters/cardinality/production/base/kustomization.yaml
@@ -4,5 +4,5 @@ resources:
 
 images:
   - name: quay.io/redhat-appstudio/cardinality-exporter
-    newName: quay.io/jmicanek/cardinality-exporter
-    newTag: v0.1
+    newName: quay.io/redhat-appstudio/cardinality-exporter
+    newTag: d7a0607ad117e7817c9d019f9d3e76e4d55c1b89

--- a/components/monitoring/exporters/cardinality/production/base/kustomization.yaml
+++ b/components/monitoring/exporters/cardinality/production/base/kustomization.yaml
@@ -1,0 +1,8 @@
+resources:
+  - rbac
+  - resources
+
+images:
+  - name: quay.io/redhat-appstudio/cardinality-exporter
+    newName: quay.io/jmicanek/cardinality-exporter
+    newTag: v0.1

--- a/components/monitoring/exporters/cardinality/production/base/rbac/cardinality-exporter.yaml
+++ b/components/monitoring/exporters/cardinality/production/base/rbac/cardinality-exporter.yaml
@@ -1,0 +1,55 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: prometheus-cardinality-exporter
+    kubernetes.io/part-of: appstudio-cardinality-exporter
+  name: prometheus-cardinality-exporter
+# Role necessary for automatic discovery of prometheus endpoints
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: prometheus-cardinality-exporter-list
+  labels:
+    kubernetes.io/part-of: appstudio-cardinality-exporter
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+      - endpoints
+    verbs:
+      - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: prometheus-cardinality-exporter
+  labels:
+    kubernetes.io/part-of: appstudio-cardinality-exporter
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: prometheus-cardinality-exporter-list
+subjects:
+  - kind: ServiceAccount
+    name: prometheus-cardinality-exporter
+    namespace: appstudio-cardinality-exporter
+---
+# CMO owned prometheus instances are protected by kube-rbac-proxy. Grant necessary permissions to the exporter SA.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: prometheus-cardinality-exporter-monitoring-view
+  labels:
+    kubernetes.io/part-of: appstudio-cardinality-exporter
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-monitoring-view
+subjects:
+- kind: ServiceAccount
+  name: prometheus-cardinality-exporter
+  namespace: appstudio-cardinality-exporter

--- a/components/monitoring/exporters/cardinality/production/base/rbac/cardinality-maintainers.yaml
+++ b/components/monitoring/exporters/cardinality/production/base/rbac/cardinality-maintainers.yaml
@@ -1,0 +1,12 @@
+# Grant o11y admins full access to the exporter namespace
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: appstudio-cardinality-exporter-maintainers
+subjects:
+  - kind: Group
+    name: konflux-o11y
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: component-maintainer

--- a/components/monitoring/exporters/cardinality/production/base/rbac/kustomization.yaml
+++ b/components/monitoring/exporters/cardinality/production/base/rbac/kustomization.yaml
@@ -1,0 +1,5 @@
+resources:
+  - cardinality-maintainers.yaml
+  - cardinality-exporter.yaml
+
+namespace: appstudio-cardinality-exporter

--- a/components/monitoring/exporters/cardinality/production/base/resources/auth-config.yaml
+++ b/components/monitoring/exporters/cardinality/production/base/resources/auth-config.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cardinality-exporter-auth
+  labels:
+    app: prometheus-cardinality-exporter
+data:
+  auth.yaml: |
+    # OpenShift platform monitoring — Prometheus secured via kube-rbac-proxy
+    openshift-monitoring:
+      sa_auth: true
+      ca: "/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt"
+      port: "9091"
+
+    # OpenShift user-workload monitoring — same kube-rbac-proxy setup
+    # Note: Does not work at the moment due to kube-rbac-proxy not allowing /api/v1/status/tsdb endpoint access.
+    openshift-user-workload-monitoring:
+      sa_auth: true
+      ca: "/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt"
+      port: "9091"

--- a/components/monitoring/exporters/cardinality/production/base/resources/deployment.yaml
+++ b/components/monitoring/exporters/cardinality/production/base/resources/deployment.yaml
@@ -1,0 +1,66 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: prometheus-cardinality-exporter
+  labels:
+    app: prometheus-cardinality-exporter
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: prometheus-cardinality-exporter
+  template:
+    metadata:
+      labels:
+        app: prometheus-cardinality-exporter
+    spec:
+      serviceAccountName: prometheus-cardinality-exporter
+      containers:
+        - name: prometheus-cardinality-exporter
+          imagePullPolicy: Always
+          image: quay.io/redhat-appstudio/cardinality-exporter:placeholder
+          command: ["/home/app/prometheus-cardinality-exporter"]
+          securityContext:
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+          args:
+            - "--service_discovery"
+            - "--freq=0.1"
+            - "--selector="
+            # openshift-user-workload-monitoring excluded: its kube-rbac-proxy
+            # blocks /api/v1/status/tsdb (OBSDA-1356)
+            - "--namespaces=openshift-monitoring"
+            - "--namespaces=appstudio-tekton"
+            - "--namespaces=appstudio-monitoring"
+            - "--regex=^(prometheus-k8s|appstudio-tekton-ms-prometheus|appstudio-federate-ms-prometheus)$"
+            - "--auth=/etc/cardinality-exporter/auth.yaml"
+          volumeMounts:
+            - name: auth-config
+              mountPath: /etc/cardinality-exporter
+              readOnly: true
+          ports:
+            - containerPort: 9090
+              name: http
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 3
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 3
+          resources:
+            requests:
+              memory: 200Mi
+              cpu: 100m
+            limits:
+              memory: 400Mi
+      volumes:
+        - name: auth-config
+          configMap:
+            name: cardinality-exporter-auth

--- a/components/monitoring/exporters/cardinality/production/base/resources/kustomization.yaml
+++ b/components/monitoring/exporters/cardinality/production/base/resources/kustomization.yaml
@@ -1,0 +1,8 @@
+resources:
+  - auth-config.yaml
+  - deployment.yaml
+  - namespace.yaml
+  - service.yaml
+  - servicemonitor.yaml
+
+namespace: appstudio-cardinality-exporter

--- a/components/monitoring/exporters/cardinality/production/base/resources/namespace.yaml
+++ b/components/monitoring/exporters/cardinality/production/base/resources/namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: appstudio-cardinality-exporter
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+spec: {}

--- a/components/monitoring/exporters/cardinality/production/base/resources/service.yaml
+++ b/components/monitoring/exporters/cardinality/production/base/resources/service.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: prometheus-cardinality-exporter
+  labels:
+    app: prometheus-cardinality-exporter
+spec:
+  selector:
+    app: prometheus-cardinality-exporter
+  ports:
+    - name: http
+      port: 9090
+      targetPort: http

--- a/components/monitoring/exporters/cardinality/production/base/resources/servicemonitor.yaml
+++ b/components/monitoring/exporters/cardinality/production/base/resources/servicemonitor.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: prometheus-cardinality-exporter
+  labels:
+    app: prometheus-cardinality-exporter
+spec:
+  endpoints:
+    - port: http
+      path: /metrics
+      interval: 2m
+  selector:
+    matchLabels:
+      app: prometheus-cardinality-exporter

--- a/components/monitoring/exporters/cardinality/production/empty-base/kustomization.yaml
+++ b/components/monitoring/exporters/cardinality/production/empty-base/kustomization.yaml
@@ -1,0 +1,3 @@
+kind: Kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+resources: []

--- a/components/monitoring/exporters/cardinality/production/kflux-prd-rh02/kustomization.yaml
+++ b/components/monitoring/exporters/cardinality/production/kflux-prd-rh02/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - ../base

--- a/components/monitoring/exporters/cardinality/production/stone-prod-p01/kustomization.yaml
+++ b/components/monitoring/exporters/cardinality/production/stone-prod-p01/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - ../base

--- a/components/monitoring/prometheus/production/kflux-prd-es01/kustomization.yaml
+++ b/components/monitoring/prometheus/production/kflux-prd-es01/kustomization.yaml
@@ -2,17 +2,11 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - ../base
-- ../tekton-ms
+
 patches:
   - path: cluster-id-label.yaml
     target:
       name: appstudio-federate-ms
-      kind: MonitoringStack
-      group: monitoring.rhobs
-      version: v1alpha1
-  - path: cluster-id-label.yaml
-    target:
-      name: appstudio-tekton-ms
       kind: MonitoringStack
       group: monitoring.rhobs
       version: v1alpha1


### PR DESCRIPTION
## Summary

Remove tekton-ms from kflux-prd-es01 — this EaaS cluster doesn't have OpenShift Pipelines installed, so the tekton-ms RBAC RoleBinding fails with `namespaces "openshift-pipelines" not found`.

## Risk Assessment

- **Level:** Critical fix
- **Description:** The ArgoCD sync is stuck retrying on this cluster. Removing tekton-ms restores normal sync.
- **Rollback:** Re-add `../tekton-ms` to the cluster kustomization.