### PR TITLE
PVO11Y-5365 Remove tekton-ms from kflux-prd-es01

### DIFF
--- a/components/monitoring/prometheus/production/kflux-prd-es01/kustomization.yaml
+++ b/components/monitoring/prometheus/production/kflux-prd-es01/kustomization.yaml
@@ -2,17 +2,11 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - ../base
-- ../tekton-ms
+
 patches:
   - path: cluster-id-label.yaml
     target:
       name: appstudio-federate-ms
-      kind: MonitoringStack
-      group: monitoring.rhobs
-      version: v1alpha1
-  - path: cluster-id-label.yaml
-    target:
-      name: appstudio-tekton-ms
       kind: MonitoringStack
       group: monitoring.rhobs
       version: v1alpha1


### PR DESCRIPTION
## Summary

Remove tekton-ms from kflux-prd-es01 — this EaaS cluster doesn't have OpenShift Pipelines installed, so the tekton-ms RBAC RoleBinding fails with `namespaces "openshift-pipelines" not found`.

## Risk Assessment

- **Level:** Minor Fix
- **Description:** The ArgoCD sync is stuck retrying on this cluster. Removing tekton-ms restores normal sync.
- **Rollback:** Re-add `../tekton-ms` to the cluster kustomization.