### PR TITLE
KFLUXINFRA-3980: add type guards to build-platforms CEL expressions (…

### DIFF
--- a/components/kueue/production/kflux-osp-p01/config.yaml
+++ b/components/kueue/production/kflux-osp-p01/config.yaml
@@ -103,33 +103,10 @@ cel:
         plrNamespace == 'mintmaker' ? [resource('mintmaker', 1)] : []
 
     # The token mechanism allows us to balance admitted PipelineRuns.
-    # Each PipelineRun requests 1 token, except for internal-services PLRs.
-    # This is to guarantee there is always room for internal-services PLRs.
-    #
-    #
-    # WARNING: As a temporary measure, we are using tokens to provide a priority lane
-    # for internal-services PLRs. They'll be removed in some time and moved to the
-    # common clusters.
+    # Each PipelineRun requests 1 token. The token quota is set equal
+    # to the PLR limit so current behavior is unchanged.
     - |
-        has(pipelineRun.metadata.labels) &&
-        'internal-services.appstudio.openshift.io/pipelinerun-uid' in pipelineRun.metadata.labels ?
-        [] : [resource('konflux-ci-dev-token', 1)]
-
-    # Add a resource to restrict the number of concurrent release pipelineruns
-    - |
-        has(pipelineRun.metadata.labels) &&
-        'appstudio.openshift.io/service' in pipelineRun.metadata.labels &&
-        pipelineRun.metadata.labels['appstudio.openshift.io/service'] == 'release' &&
-        'pipelines.appstudio.openshift.io/type' in pipelineRun.metadata.labels &&
-        pipelineRun.metadata.labels['pipelines.appstudio.openshift.io/type'] == 'managed' ?
-        [resource('konflux-release', 1)] :
-
-        has(pipelineRun.metadata.labels) &&
-        'appstudio.openshift.io/service' in pipelineRun.metadata.labels &&
-        pipelineRun.metadata.labels['appstudio.openshift.io/service'] == 'release' &&
-        'release.appstudio.openshift.io/namespace' in pipelineRun.metadata.labels &&
-        pipelineRun.metadata.labels['release.appstudio.openshift.io/namespace'] == plrNamespace ?
-        [resource('konflux-release', 1)] : []
+        resource('konflux-ci-dev-token', 1)
 
     # Set the pipeline priority
     - |

--- a/components/kueue/production/kflux-osp-p01/kustomization.yaml
+++ b/components/kueue/production/kflux-osp-p01/kustomization.yaml
@@ -6,3 +6,10 @@ resources:
 
 commonAnnotations:
   argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+
+configMapGenerator:
+  - name: tekton-kueue-config
+    namespace: tekton-kueue
+    behavior: replace
+    files:
+      - config.yaml

--- a/components/kueue/production/kflux-prd-rh03/config.yaml
+++ b/components/kueue/production/kflux-prd-rh03/config.yaml
@@ -103,33 +103,10 @@ cel:
         plrNamespace == 'mintmaker' ? [resource('mintmaker', 1)] : []
 
     # The token mechanism allows us to balance admitted PipelineRuns.
-    # Each PipelineRun requests 1 token, except for internal-services PLRs.
-    # This is to guarantee there is always room for internal-services PLRs.
-    #
-    #
-    # WARNING: As a temporary measure, we are using tokens to provide a priority lane
-    # for internal-services PLRs. They'll be removed in some time and moved to the
-    # common clusters.
+    # Each PipelineRun requests 1 token. The token quota is set equal
+    # to the PLR limit so current behavior is unchanged.
     - |
-        has(pipelineRun.metadata.labels) &&
-        'internal-services.appstudio.openshift.io/pipelinerun-uid' in pipelineRun.metadata.labels ?
-        [] : [resource('konflux-ci-dev-token', 1)]
-
-    # Add a resource to restrict the number of concurrent release pipelineruns
-    - |
-        has(pipelineRun.metadata.labels) &&
-        'appstudio.openshift.io/service' in pipelineRun.metadata.labels &&
-        pipelineRun.metadata.labels['appstudio.openshift.io/service'] == 'release' &&
-        'pipelines.appstudio.openshift.io/type' in pipelineRun.metadata.labels &&
-        pipelineRun.metadata.labels['pipelines.appstudio.openshift.io/type'] == 'managed' ?
-        [resource('konflux-release', 1)] :
-
-        has(pipelineRun.metadata.labels) &&
-        'appstudio.openshift.io/service' in pipelineRun.metadata.labels &&
-        pipelineRun.metadata.labels['appstudio.openshift.io/service'] == 'release' &&
-        'release.appstudio.openshift.io/namespace' in pipelineRun.metadata.labels &&
-        pipelineRun.metadata.labels['release.appstudio.openshift.io/namespace'] == plrNamespace ?
-        [resource('konflux-release', 1)] : []
+        resource('konflux-ci-dev-token', 1)
 
     # Set the pipeline priority
     - |

--- a/components/kueue/production/kflux-prd-rh03/kustomization.yaml
+++ b/components/kueue/production/kflux-prd-rh03/kustomization.yaml
@@ -6,3 +6,10 @@ resources:
 
 commonAnnotations:
   argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+
+configMapGenerator:
+  - name: tekton-kueue-config
+    namespace: tekton-kueue
+    behavior: replace
+    files:
+      - config.yaml

--- a/components/policies/production/kflux-osp-p01/kustomization.yaml
+++ b/components/policies/production/kflux-osp-p01/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
 - ../base/cost-management
 - ../policies/kubearchive/
 - ../policies/kueue/
+- ../policies/kueue/deny-on-validation-error/

--- a/components/policies/production/kflux-prd-rh03/kustomization.yaml
+++ b/components/policies/production/kflux-prd-rh03/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
 - ../base/cost-management
 - ../policies/kubearchive/
 - ../policies/kueue/
+- ../policies/kueue/deny-on-validation-error/

--- a/components/policies/production/stone-prod-p02/kustomization.yaml
+++ b/components/policies/production/stone-prod-p02/kustomization.yaml
@@ -6,5 +6,6 @@ resources:
 - ../base/cost-management
 - ../policies/kubearchive/
 - ../policies/kueue/
+- ../policies/kueue/deny-on-validation-error/
 - ../policies/macos/
 - ./macos-config.yaml

--- a/hack/test-tekton-kueue-config.py
+++ b/hack/test-tekton-kueue-config.py
@@ -1197,6 +1197,16 @@ CONFIG_COMBINATIONS: Dict[str, ConfigCombination] = {
         "name": "Production kflux-prd-rh02 config (ring 1 temporary override)",
         "config_file": "components/kueue/production/kflux-prd-rh02/config.yaml",
         "kustomization_file": "components/kueue/production/base/tekton-kueue/kustomization.yaml"
+    },
+    "production-kflux-osp-p01": {
+        "name": "Production kflux-osp-p01 config (ring 2 temporary override)",
+        "config_file": "components/kueue/production/kflux-osp-p01/config.yaml",
+        "kustomization_file": "components/kueue/production/base/tekton-kueue/kustomization.yaml"
+    },
+    "production-kflux-prd-rh03": {
+        "name": "Production kflux-prd-rh03 config (ring 2 temporary override)",
+        "config_file": "components/kueue/production/kflux-prd-rh03/config.yaml",
+        "kustomization_file": "components/kueue/production/base/tekton-kueue/kustomization.yaml"
     }
 }
 
@@ -1704,6 +1714,50 @@ TEST_COMBINATIONS: Dict[str, TestCombination] = {
     "multiplatform_new_string_param_production-kflux-prd-rh02": {
         "pipelinerun_key": "multiplatform_new_string_param",
         "config_key": "production-kflux-prd-rh02",
+        "expected": {
+            "annotations": {
+                "kueue.konflux-ci.dev/validation-error": "build-platforms parameter must be an array of platform strings, got a non-array value",
+                "kueue.konflux-ci.dev/requests-konflux-ci-dev-token": "1",
+            },
+            "labels": {
+                "kueue.x-k8s.io/queue-name": "pipelines-queue",
+                "kueue.x-k8s.io/priority-class": "konflux-post-merge-build"
+            }
+        }
+    },
+
+    # KFLUXINFRA-3980 ring 2: build-platforms type guard
+    "multiplatform_new_string_param_production-kflux-osp-p01": {
+        "pipelinerun_key": "multiplatform_new_string_param",
+        "config_key": "production-kflux-osp-p01",
+        "expected": {
+            "annotations": {
+                "kueue.konflux-ci.dev/validation-error": "build-platforms parameter must be an array of platform strings, got a non-array value",
+                "kueue.konflux-ci.dev/requests-konflux-ci-dev-token": "1",
+            },
+            "labels": {
+                "kueue.x-k8s.io/queue-name": "pipelines-queue",
+                "kueue.x-k8s.io/priority-class": "konflux-post-merge-build"
+            }
+        }
+    },
+    "multiplatform_new_string_param_production-kflux-prd-rh03": {
+        "pipelinerun_key": "multiplatform_new_string_param",
+        "config_key": "production-kflux-prd-rh03",
+        "expected": {
+            "annotations": {
+                "kueue.konflux-ci.dev/validation-error": "build-platforms parameter must be an array of platform strings, got a non-array value",
+                "kueue.konflux-ci.dev/requests-konflux-ci-dev-token": "1",
+            },
+            "labels": {
+                "kueue.x-k8s.io/queue-name": "pipelines-queue",
+                "kueue.x-k8s.io/priority-class": "konflux-post-merge-build"
+            }
+        }
+    },
+    "multiplatform_new_string_param_production-stone-prod-p02": {
+        "pipelinerun_key": "multiplatform_new_string_param",
+        "config_key": "production-stone-prod-p02",
         "expected": {
             "annotations": {
                 "kueue.konflux-ci.dev/validation-error": "build-platforms parameter must be an array of platform strings, got a non-array value",


### PR DESCRIPTION
…ring-2)

## What

Adds `type(value) == list` guards to the `build-platforms` CEL expressions in tekton-kueue (resource-request and AWS-IP expressions), plus a validation-error annotation expression and a temporary tenant-scoped ValidatingAdmissionPolicy that denies PipelineRuns carrying that annotation.

Applies the fix to ring 2 production clusters: `kflux-osp-p01`, `kflux-prd-rh03`, `stone-prod-p02`.

- `stone-prod-p01` and `kflux-prd-rh02` previously inherited `production/base/tekton-kueue/config.yaml`; this adds temporary per-cluster `config.yaml` overrides (configMapGenerator `behavior: replace`) to scope the change to ring 1 only.
`kflux-ocp-p01` already had its own override, updated directly.
- Adds the temporary tenant-scoped `ValidatingAdmissionPolicy` denying `PipelineRuns` carrying the validation-error annotation. Wired only into the 3 ring-2 cluster kustomizations, not the shared policies/kueue kustomization, to keep ring isolation.
- `kflux-osp-p01` and `kflux-prd-rh03` previously inherited production/base/tekton-kueue/config.yaml; this adds temporary per-cluster config.yaml overrides (configMapGenerator behavior: replace) so the change is scoped to ring 2 only. `stone-prod-p02` already had its own override, updated directly.
- Adds ring-2 test cases for string-typed build-platforms to `hack/test-tekton-kueue-config.py`.
- Ring 3 will fold both the CEL change into `base/tekton-kueue/config.yaml` and the VAP into the shared `policies/kueue/kustomization.yaml`, removing the temporary overrides — same pattern as the [KFLUXINFRA-3973](https://redhat.atlassian.net/browse/KFLUXINFRA-3973) rollout.
- Adds a validation-error annotation expression for wrong-typed build-platforms, emitted as `kueue.konflux-ci.dev/validation-error` (matching the VAP from the start, unlike the original dev/staging rollout — see the ring-1 PR #13059 and the dev/staging fix for that mismatch).

[KFLUXINFRA-3980](https://redhat.atlassian.net/browse/KFLUXINFRA-3980)

## Why

The tekton-kueue webhook crashes with HTTP 500 (`failurePolicy: Fail`) when a PipelineRun submits `build-platforms` as a string instead of an array, rejecting the PipelineRun outright. Observed on `kflux-prd-rh02` on  2026-06-09 (18:12 and 18:14 UTC, 2 rejections). The guard makes the expression tolerant of the wrong type instead of crashing, and the VAP prevents malformed PipelineRuns from silently bypassing the queue while the no-skip-kueue VAP rollout is still in progress.

## Validation

- `kustomize build` passes cleanly for all affected overlays.
- Confirmed via rendered diff that only these 3 clusters pick up the CEL guards and the new VAP/VAPB; the ring-3 production clusters render unchanged.
- `python hack/test-tekton-kueue-config.py` passes, including new cases covering string-typed `build-platforms` against the ring-2 configs.
- Already deployed to dev/staging with no issues: #12893.

## Risk Assessment

**Risk Level:** Low
**What could go wrong:** The guard only changes behavior for the previously-crashing case (string-typed `build-platforms`); array-typed values take the same code path as before. The VAP is scoped to tenant namespaces and only denies PipelineRuns already carrying the validation-error annotation, so it cannot affect any currently-passing  PipelineRun.
**Rollback:** Revert this PR.
**Blast radius:** 3 named production clusters (ring 2 of 3); no changes to `production/base` or the shared policy kustomization, so no other production cluster is touched.


[KFLUXINFRA-3980]: https://redhat.atlassian.net/browse/KFLUXINFRA-3980?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[KFLUXINFRA-3973]: https://redhat.atlassian.net/browse/KFLUXINFRA-3973?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ