### PR TITLE
KONFLUX-15095: kflux-fedora-01 ingesters S3 errors fix

### DIFF
--- a/components/vector-kubearchive-log-collector/production/kflux-fedora-01/loki-helm-generator.yaml
+++ b/components/vector-kubearchive-log-collector/production/kflux-fedora-01/loki-helm-generator.yaml
@@ -24,4 +24,4 @@ valuesInline:
         admin: kflux-fedora-01-loki-storage
     storage_config:
       aws:
-        bucketnames: kflux-fedora-01-loki-storage\
+        bucketnames: kflux-fedora-01-loki-storage


### PR DESCRIPTION
## Summary
- Fixes the misconfiguration error for loki S3 connection.
[KONFLUX-15095](https://redhat.atlassian.net/browse/KONFLUX-15095)(https://redhat.atlassian.net/browse/KONFLUX-15095)


## Risk assessment
- Low. Pods are failing to start without this fix so situation could not be worthened further by this fix.


## Validation
Staging validated with the same configuration: https://github.com/redhat-appstudio/infra-deployments/pull/12873
Development validated with: https://github.com/redhat-appstudio/infra-deployments/pull/12844

[KONFLUX-15095]: https://redhat.atlassian.net/browse/KONFLUX-15095?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ