### PR TITLE
KONFLUX-14972:  kubearchive-api-server OOM staging fix

### DIFF
--- a/components/kubearchive/staging/stone-stage-p01/kustomization.yaml
+++ b/components/kubearchive/staging/stone-stage-p01/kustomization.yaml
@@ -72,13 +72,14 @@ patches:
                 - name: KUBEARCHIVE_OTEL_MODE
                   value: delegated
                 - name: GOMEMLIMIT
-                  value: "440Mi"
-                  valueFrom: null
+                  valueFrom:
+                    resourceFieldRef:
+                      resource: requests.memory
                 resources:
                   limits:
                     memory: 512Mi
                   requests:
-                    memory: 512Mi
+                    memory: 460Mi
   - patch: |-
       apiVersion: apps/v1
       kind: Deployment

--- a/components/kubearchive/staging/stone-stage-p01/kustomization.yaml
+++ b/components/kubearchive/staging/stone-stage-p01/kustomization.yaml
@@ -73,8 +73,7 @@ patches:
                   value: delegated
                 - name: GOMEMLIMIT
                   value: "440Mi"
-                  valueFrom: null 
-
+                  valueFrom: null
   - patch: |-
       apiVersion: apps/v1
       kind: Deployment

--- a/components/kubearchive/staging/stone-stage-p01/kustomization.yaml
+++ b/components/kubearchive/staging/stone-stage-p01/kustomization.yaml
@@ -72,7 +72,7 @@ patches:
                 - name: KUBEARCHIVE_OTEL_MODE
                   value: delegated
                 - name: GOMEMLIMIT
-                  value: 440MiB
+                  value: "440Mi"
 
   - patch: |-
       apiVersion: apps/v1

--- a/components/kubearchive/staging/stone-stage-p01/kustomization.yaml
+++ b/components/kubearchive/staging/stone-stage-p01/kustomization.yaml
@@ -74,6 +74,11 @@ patches:
                 - name: GOMEMLIMIT
                   value: "440Mi"
                   valueFrom: null
+                resources:
+                  limits:
+                    memory: 512Mi
+                  requests:
+                    memory: 512Mi
   - patch: |-
       apiVersion: apps/v1
       kind: Deployment

--- a/components/kubearchive/staging/stone-stage-p01/kustomization.yaml
+++ b/components/kubearchive/staging/stone-stage-p01/kustomization.yaml
@@ -73,6 +73,7 @@ patches:
                   value: delegated
                 - name: GOMEMLIMIT
                   value: "440Mi"
+                  valueFrom: null 
 
   - patch: |-
       apiVersion: apps/v1

--- a/components/kubearchive/staging/stone-stage-p01/kustomization.yaml
+++ b/components/kubearchive/staging/stone-stage-p01/kustomization.yaml
@@ -71,6 +71,9 @@ patches:
                 env:
                 - name: KUBEARCHIVE_OTEL_MODE
                   value: delegated
+                - name: GOMEMLIMIT
+                  value: 440MiB
+
   - patch: |-
       apiVersion: apps/v1
       kind: Deployment

--- a/components/kubearchive/staging/stone-stg-rh01/kustomization.yaml
+++ b/components/kubearchive/staging/stone-stg-rh01/kustomization.yaml
@@ -79,13 +79,14 @@ patches:
                 - name: KUBEARCHIVE_OTEL_MODE
                   value: delegated
                 - name: GOMEMLIMIT
-                  value: "440Mi"
-                  valueFrom: null
+                  valueFrom:
+                    resourceFieldRef:
+                      resource: requests.memory
                 resources:
                   limits:
                     memory: 512Mi
                   requests:
-                    memory: 512Mi
+                    memory: 460Mi
   - patch: |-
       apiVersion: apps/v1
       kind: Deployment

--- a/components/kubearchive/staging/stone-stg-rh01/kustomization.yaml
+++ b/components/kubearchive/staging/stone-stg-rh01/kustomization.yaml
@@ -79,7 +79,7 @@ patches:
                 - name: KUBEARCHIVE_OTEL_MODE
                   value: delegated
                 - name: GOMEMLIMIT
-                  value: 440MiB
+                  value: "440Mi"
   - patch: |-
       apiVersion: apps/v1
       kind: Deployment

--- a/components/kubearchive/staging/stone-stg-rh01/kustomization.yaml
+++ b/components/kubearchive/staging/stone-stg-rh01/kustomization.yaml
@@ -80,6 +80,7 @@ patches:
                   value: delegated
                 - name: GOMEMLIMIT
                   value: "440Mi"
+                  valueFrom: null
   - patch: |-
       apiVersion: apps/v1
       kind: Deployment

--- a/components/kubearchive/staging/stone-stg-rh01/kustomization.yaml
+++ b/components/kubearchive/staging/stone-stg-rh01/kustomization.yaml
@@ -78,6 +78,8 @@ patches:
                 env:
                 - name: KUBEARCHIVE_OTEL_MODE
                   value: delegated
+                - name: GOMEMLIMIT
+                  value: 440MiB
   - patch: |-
       apiVersion: apps/v1
       kind: Deployment

--- a/components/kubearchive/staging/stone-stg-rh01/kustomization.yaml
+++ b/components/kubearchive/staging/stone-stg-rh01/kustomization.yaml
@@ -81,6 +81,11 @@ patches:
                 - name: GOMEMLIMIT
                   value: "440Mi"
                   valueFrom: null
+                resources:
+                  limits:
+                    memory: 512Mi
+                  requests:
+                    memory: 512Mi
   - patch: |-
       apiVersion: apps/v1
       kind: Deployment


### PR DESCRIPTION
## Summary
- Increases GOMEMLIMIT value to fix Go GC problem for API server and operator pods
[KONFLUX-14972](https://redhat.atlassian.net/browse/KONFLUX-14972)(https://redhat.atlassian.net/browse/KONFLUX-14972)


## Risk assessment
- Low. No actual disruption to be expected by this change.


## Validation
This is a staging environment fix

[KONFLUX-14972]: https://redhat.atlassian.net/browse/KONFLUX-14972?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ