### PR TITLE
KONFLUX-14972: kubearchive-api-server OOMs on stone-prd-rh01

### DIFF
--- a/components/kubearchive/production/stone-prd-rh01/kubearchive.yaml
+++ b/components/kubearchive/production/stone-prd-rh01/kubearchive.yaml
@@ -1112,9 +1112,7 @@ spec:
                 fieldRef:
                   fieldPath: metadata.name
             - name: GOMEMLIMIT
-              valueFrom:
-                resourceFieldRef:
-                  resource: limits.memory
+              value: "440Mi"
             - name: GOMAXPROCS
               valueFrom:
                 resourceFieldRef:
@@ -1152,10 +1150,10 @@ spec:
           resources:
             limits:
               cpu: 700m
-              memory: 256Mi
+              memory: 512Mi
             requests:
               cpu: 200m
-              memory: 230Mi
+              memory: 460Mi
           volumeMounts:
             - mountPath: /etc/kubearchive/ssl/
               name: tls-secret
@@ -1225,9 +1223,7 @@ spec:
                 fieldRef:
                   fieldPath: metadata.name
             - name: GOMEMLIMIT
-              valueFrom:
-                resourceFieldRef:
-                  resource: limits.memory
+              value: "220Mi"
             - name: GOMAXPROCS
               valueFrom:
                 resourceFieldRef:
@@ -1256,10 +1252,10 @@ spec:
           resources:
             limits:
               cpu: 500m
-              memory: 128Mi
+              memory: 256Mi
             requests:
               cpu: 10m
-              memory: 64Mi
+              memory: 220Mi
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/components/kubearchive/production/stone-prd-rh01/kubearchive.yaml
+++ b/components/kubearchive/production/stone-prd-rh01/kubearchive.yaml
@@ -1112,7 +1112,9 @@ spec:
                 fieldRef:
                   fieldPath: metadata.name
             - name: GOMEMLIMIT
-              value: "440Mi"
+              valueFrom:
+                resourceFieldRef:
+                  resource: requests.memory
             - name: GOMAXPROCS
               valueFrom:
                 resourceFieldRef:
@@ -1223,7 +1225,9 @@ spec:
                 fieldRef:
                   fieldPath: metadata.name
             - name: GOMEMLIMIT
-              value: "220Mi"
+              valueFrom:
+                resourceFieldRef:
+                  resource: requests.memory
             - name: GOMAXPROCS
               valueFrom:
                 resourceFieldRef:

--- a/components/kubearchive/production/stone-prd-rh01/kubearchive.yaml
+++ b/components/kubearchive/production/stone-prd-rh01/kubearchive.yaml
@@ -1227,7 +1227,7 @@ spec:
             - name: GOMEMLIMIT
               valueFrom:
                 resourceFieldRef:
-                  resource: requests.memory
+                  resource: limits.memory
             - name: GOMAXPROCS
               valueFrom:
                 resourceFieldRef:


### PR DESCRIPTION
## Summary
- Increases api server and operator request/limit to handle the OOM errors and GOMEMLIMIT value to fix Go GC problem for API server and operator pods
[KONFLUX-14972](https://redhat.atlassian.net/browse/KONFLUX-14972)(https://redhat.atlassian.net/browse/KONFLUX-14972)


## Risk assessment
- Low. No actual disruption to be expected by this change.


## Validation
Staging validated with the configuration: https://github.com/redhat-appstudio/infra-deployments/pull/13102
Development validated with: https://github.com/redhat-appstudio/infra-deployments/pull/13105

[KONFLUX-14972]: https://redhat.atlassian.net/browse/KONFLUX-14972?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ