### PR TITLE
KFLUXVNGD-1117 Add normalized_uri to production federation label allowlist

### DIFF
--- a/components/monitoring/prometheus/production/base/federation/writeRelabelConfigs.yaml
+++ b/components/monitoring/prometheus/production/base/federation/writeRelabelConfigs.yaml
@@ -18,7 +18,8 @@
     # Kyverno
     # Release service (RHTAPWATCH-88)
     # SPI / auth (RHTAPWATCH-88 — SPI removed, may be dead weight)
-    # Probes / testing (RHTAPWATCH-891, PVO11Y-4802, SPRE-4498, KFLUXVNGD-751)
+    # Probes / testing (RHTAPWATCH-891, PVO11Y-4802, SPRE-4498)
+    # Caching (KFLUXVNGD-751, KFLUXVNGD-1115)
     # ArgoCD (RHTAPWATCH-88)
     # Monitoring infra (RHTAPWATCH-110, PVO11Y-4774)
     # KubeArchive
@@ -35,7 +36,8 @@
       policy_name|rule_result|rule_type|rule_execution_cause|policy_background_mode|policy_type|policy_validation_mode|policy_change_type|resource_request_operation|resource_kind|event_type|\
       release_reason|deployment_reason|validation_reason|strategy|succeeded|target|result|\
       tokenName|rateLimited|commit_hash|operation|\
-      check|tested_cluster|tested_registry|unexpected_status|failure|severity|cache_status|\
+      check|tested_cluster|tested_registry|unexpected_status|failure|severity|\
+      cache_status|normalized_uri|\
       health_status|dest_namespace|\
       hostname|label_app_kubernetes_io_managed_by|platform|scrape_job|slice|error|\
       resource_type|gin_errors|\


### PR DESCRIPTION
## What

  - Add `normalized_uri` to the federation `LabelKeep` regex in production writeRelabelConfigs
  - Move `cache_status` from the "Probes / testing" group into a new "Caching" group alongside `normalized_uri`

  Clusters affected: all production clusters (via `production/base/`)

  [KFLUXVNGD-1117](https://redhat.atlassian.net/browse/KFLUXVNGD-1117)

  ## Why

  The `normalized_uri` label on caching metrics needs to survive remote-write to RHOBS so it is available for Grafana queries.

  ## Validation

  - `kustomize build --enable-helm` passes for affected overlays
  - Staging PR: https://github.com/redhat-appstudio/infra-deployments/pull/13086

  ## Risk Assessment

  **Risk Level:** Low
  **What could go wrong:** Unlikely to cause issues — this only appends a new alternative to an existing regex.
  **Rollback:** Revert PR

[KFLUXVNGD-1117]: https://redhat.atlassian.net/browse/KFLUXVNGD-1117?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ