### PR TITLE
PVO11Y-5347 Add cardinality exporter labels to production writeRelabelConfigs

### DIFF
--- a/components/monitoring/prometheus/production/base/federation/writeRelabelConfigs.yaml
+++ b/components/monitoring/prometheus/production/base/federation/writeRelabelConfigs.yaml
@@ -24,6 +24,7 @@
     # KubeArchive
     # KAExporter (PVO11Y-5274)
     # cert-manager (SPRE-5502)
+    # Cardinality exporter (PVO11Y-5128)
     regex: "__name__|source_environment|source_cluster|namespace|job|instance|pod|container|app|service|deployment|node|\
       phase|reason|type|resource|kind|name|role|status|state|resourcequota|image|finalizers|verb|request_kind|\
       persistentvolumeclaim|storageclass|volumename|\
@@ -41,4 +42,5 @@
       hostname|label_app_kubernetes_io_managed_by|platform|scrape_job|slice|error|\
       resource_type|gin_errors|\
       application|component|build_type|scenario|optional|test_type|automated|exported_namespace|\
-      condition|issuer_name|issuer_kind|issuer_group"
+      condition|issuer_name|issuer_kind|issuer_group|\
+      metric|label|label_pair|scraped_instance|sharded_instance|instance_namespace"


### PR DESCRIPTION
## Summary

Add cardinality exporter labels (`metric`, `label`, `label_pair`, `scraped_instance`, `sharded_instance`, `instance_namespace`) to the production LabelKeep allowlist. These were added to staging but never promoted to production, causing the cardinality exporter metrics to reach RHOBS with their dimension labels stripped.

## Risk Assessment

- **Level:** Low
- **Description:** Adds label names to the existing allowlist. Only affects series that already have these labels.
- **Rollback:** Revert the commit.

## Validation

- Same labels already validated in staging since PR #12819
- Production cardinality exporter deployed and running on stone-prod-p01 and kflux-prd-rh02