### PR TITLE
KONFLUX-6210 Allow release pipeline to access ibm-public-key-stage

### DIFF
--- a/components/release/development/ibm-public-key-patch.yaml
+++ b/components/release/development/ibm-public-key-patch.yaml
@@ -7,5 +7,6 @@
     - secrets
     resourceNames:
     - ibm-public-key
+    - ibm-public-key-stage
     verbs:
     - get

--- a/components/release/staging/ibm-public-key-patch.yaml
+++ b/components/release/staging/ibm-public-key-patch.yaml
@@ -7,5 +7,6 @@
     - secrets
     resourceNames:
     - ibm-public-key
+    - ibm-public-key-stage
     verbs:
     - get


### PR DESCRIPTION
## Summary

Grant the release pipeline permission to read the `ibm-public-key-stage` secret in addition to the existing `ibm-public-key` secret.

## Changes

- Update `components/release/development/ibm-public-key-patch.yaml`
- Update `components/release/staging/ibm-public-key-patch.yaml`
- Add `ibm-public-key-stage` to the list of allowed secret resourceNames for the `release-pipeline-resource-role`

## Why

The staging release pipeline uses `ibm-public-key-stage` during Conforma verification. Without RBAC permission, the `verify-conforma` task fails with:
