### PR TITLE
KFLUXINFRA-4235 Update Windows AMI to Server 2025 Core Base

### DIFF
--- a/components/multi-platform-controller/base/host-config-chart/templates/_windows-init.ps1.tpl
+++ b/components/multi-platform-controller/base/host-config-chart/templates/_windows-init.ps1.tpl
@@ -32,9 +32,18 @@ Invoke-WebRequest -UseBasicParsing "https://raw.githubusercontent.com/microsoft/
 .\install-docker-ce.ps1
 
 # ---------------------------------------------------
-# OpenSSH Installation (service started at end of script)
+# OpenSSH Verification
 # ---------------------------------------------------
-Add-WindowsCapability -Online -Name OpenSSH.Server~~~~0.0.1.0
+# OpenSSH Server is pre-installed on Windows Server 2025.
+# Verify it exists before proceeding.
+if (-not (Get-Service sshd -ErrorAction SilentlyContinue)) {
+  Write-Error "sshd service not found. This script requires a Windows Server 2025 AMI."
+  exit 1
+}
+
+# Start the sshd service and set it to start automatically
+Start-Service sshd
+Set-Service -Name sshd -StartupType 'Automatic'
 
 # -------------------------------
 # User Creation & Profile Setup
@@ -347,14 +356,28 @@ New-NetFirewallRule -Name 'OpenSSH-Server-In-TCP' `
     -RemoteAddress {{ join "," $addresses }} | Out-Null
 
 # Get public key from AWS Instance Metadata Service (IMDSv2)
+# IMDS may not be reachable immediately during early boot, so retry.
 $MAGIC_IP = "169.254.169.254"
-$IMDS_TOKEN = Invoke-RestMethod -Uri "http://${MAGIC_IP}/latest/api/token" `
-    -Method 'PUT' `
-    -Headers @{'X-aws-ec2-metadata-token-ttl-seconds' = '21600'}
-$PUBKEY = Invoke-RestMethod -Uri "http://${MAGIC_IP}/latest/meta-data/public-keys/0/openssh-key" `
-    -Headers @{'X-aws-ec2-metadata-token' = $IMDS_TOKEN}
-
-Start-Sleep 5
+$maxRetries = 30
+$PUBKEY = $null
+for ($i = 1; $i -le $maxRetries; $i++) {
+  try {
+    $token = Invoke-RestMethod -Uri "http://${MAGIC_IP}/latest/api/token" `
+      -Method 'PUT' -Headers @{'X-aws-ec2-metadata-token-ttl-seconds' = '21600'} `
+      -TimeoutSec 5 -ErrorAction Stop
+    $PUBKEY = Invoke-RestMethod -Uri "http://${MAGIC_IP}/latest/meta-data/public-keys/0/openssh-key" `
+      -Headers @{'X-aws-ec2-metadata-token' = $token} `
+      -TimeoutSec 5 -ErrorAction Stop
+    break
+  } catch {
+    Write-Host "IMDS request failed (attempt $i/$maxRetries): $_"
+    if ($i -eq $maxRetries) {
+      Write-Error "Failed to retrieve SSH public key from IMDS after $maxRetries attempts. Exiting."
+      exit 1
+    }
+    Start-Sleep -Seconds 2
+  }
+}
 
 # Configure SSH authorized_keys for Administrator
 $SSH_PATH = "C:\ProgramData\ssh"
@@ -382,8 +405,7 @@ $Ar = New-Object System.Security.AccessControl.FileSystemAccessRule(
 $ACL.SetAccessRule($Ar)
 Set-Acl "$SSH_PATH\administrators_authorized_keys" $ACL
 
-Start-Service sshd
-Set-Service -Name sshd -StartupType 'Automatic'
+Restart-Service sshd
 </powershell>
 <persist>true</persist>
 {{- end -}}

--- a/components/multi-platform-controller/production-downstream/stone-prod-p02/host-values.yaml
+++ b/components/multi-platform-controller/production-downstream/stone-prod-p02/host-values.yaml
@@ -14,7 +14,7 @@ archDefaults:
     security-group-id: "sg-0903aedd465be979e"
     subnet-id: "subnet-02c476f8d2a4ae05e"
   windows-amd64:
-    ami: "ami-0cbf74fa8206e0c0f"
+    ami: "ami-07adb88c7ad360947"
     key-name: "aws-win-ssh-key"
     security-group-id: "sg-0903aedd465be979e"
     subnet-id: "subnet-02c476f8d2a4ae05e"

--- a/components/multi-platform-controller/staging-downstream/host-values.yaml
+++ b/components/multi-platform-controller/staging-downstream/host-values.yaml
@@ -23,7 +23,7 @@ archDefaults:
     security-group-id: "sg-0482e8ccae008b240"
     subnet-id: "subnet-07597d1edafa2b9d3"
   windows-amd64:
-    ami: "ami-0cbf74fa8206e0c0f"
+    ami: "ami-07adb88c7ad360947"
     key-name: "aws-win-ssh-key"
     security-group-id: "sg-0482e8ccae008b240"
     subnet-id: "subnet-07597d1edafa2b9d3"

--- a/components/multi-platform-controller/staging/base/host-config-chart/templates/_windows-init.ps1.tpl
+++ b/components/multi-platform-controller/staging/base/host-config-chart/templates/_windows-init.ps1.tpl
@@ -32,9 +32,18 @@ Invoke-WebRequest -UseBasicParsing "https://raw.githubusercontent.com/microsoft/
 .\install-docker-ce.ps1
 
 # ---------------------------------------------------
-# OpenSSH Installation (service started at end of script)
+# OpenSSH Verification
 # ---------------------------------------------------
-Add-WindowsCapability -Online -Name OpenSSH.Server~~~~0.0.1.0
+# OpenSSH Server is pre-installed on Windows Server 2025.
+# Verify it exists before proceeding.
+if (-not (Get-Service sshd -ErrorAction SilentlyContinue)) {
+  Write-Error "sshd service not found. This script requires a Windows Server 2025 AMI."
+  exit 1
+}
+
+# Start the sshd service and set it to start automatically
+Start-Service sshd
+Set-Service -Name sshd -StartupType 'Automatic'
 
 # -------------------------------
 # User Creation & Profile Setup
@@ -347,14 +356,28 @@ New-NetFirewallRule -Name 'OpenSSH-Server-In-TCP' `
     -RemoteAddress {{ join "," $addresses }} | Out-Null
 
 # Get public key from AWS Instance Metadata Service (IMDSv2)
+# IMDS may not be reachable immediately during early boot, so retry.
 $MAGIC_IP = "169.254.169.254"
-$IMDS_TOKEN = Invoke-RestMethod -Uri "http://${MAGIC_IP}/latest/api/token" `
-    -Method 'PUT' `
-    -Headers @{'X-aws-ec2-metadata-token-ttl-seconds' = '21600'}
-$PUBKEY = Invoke-RestMethod -Uri "http://${MAGIC_IP}/latest/meta-data/public-keys/0/openssh-key" `
-    -Headers @{'X-aws-ec2-metadata-token' = $IMDS_TOKEN}
-
-Start-Sleep 5
+$maxRetries = 30
+$PUBKEY = $null
+for ($i = 1; $i -le $maxRetries; $i++) {
+  try {
+    $token = Invoke-RestMethod -Uri "http://${MAGIC_IP}/latest/api/token" `
+      -Method 'PUT' -Headers @{'X-aws-ec2-metadata-token-ttl-seconds' = '21600'} `
+      -TimeoutSec 5 -ErrorAction Stop
+    $PUBKEY = Invoke-RestMethod -Uri "http://${MAGIC_IP}/latest/meta-data/public-keys/0/openssh-key" `
+      -Headers @{'X-aws-ec2-metadata-token' = $token} `
+      -TimeoutSec 5 -ErrorAction Stop
+    break
+  } catch {
+    Write-Host "IMDS request failed (attempt $i/$maxRetries): $_"
+    if ($i -eq $maxRetries) {
+      Write-Error "Failed to retrieve SSH public key from IMDS after $maxRetries attempts. Exiting."
+      exit 1
+    }
+    Start-Sleep -Seconds 2
+  }
+}
 
 # Configure SSH authorized_keys for Administrator
 $SSH_PATH = "C:\ProgramData\ssh"
@@ -382,8 +405,7 @@ $Ar = New-Object System.Security.AccessControl.FileSystemAccessRule(
 $ACL.SetAccessRule($Ar)
 Set-Acl "$SSH_PATH\administrators_authorized_keys" $ACL
 
-Start-Service sshd
-Set-Service -Name sshd -StartupType 'Automatic'
+Restart-Service sshd
 </powershell>
 <persist>true</persist>
 {{- end -}}


### PR DESCRIPTION
## Summary

- Replace deregistered Windows AMI (`ami-0cbf74fa8206e0c0f`) with current Server 2025 Core Base (`ami-07adb88c7ad360947`) in staging and production
- Replace `Add-WindowsCapability` with sshd existence check — OpenSSH is pre-installed on Server 2025
- Add IMDS retry logic (30 attempts, 2s backoff) for early-boot resilience
- Start sshd early, restart after key configuration

## Context

Follow-up to konflux-ci/multi-platform-controller#969.

AWS deregistered the original Server 2025 Core Base AMI during monthly rotation. The controller PR updated the dev-template; this PR applies the same fix to staging and production.

## Changes

| File | Change |
|------|--------|
| `staging-downstream/host-values.yaml` | AMI update |
| `production-downstream/stone-prod-p02/host-values.yaml` | AMI update |
| `base/.../templates/_windows-init.ps1.tpl` | Script fix (sshd check, IMDS retry) |
| `staging/.../templates/_windows-init.ps1.tpl` | Script fix (sshd check, IMDS retry) |

## Risk Assessment

**Level:** Medium

**Description:** AMI change affects Windows build host provisioning in staging and production. Script changes are defensive (sshd check, IMDS retries) and align with the already-tested controller PR.

**Rollback:** Revert commit to restore previous AMI and script. Previous AMI is deregistered so rollback would not restore functionality — would need a different Server 2025 AMI.

## Validation

- [PR #969](https://github.com/konflux-ci/multi-platform-controller/pull/969) passed `make test-e2e-windows` with this AMI locally and E2E tests
- Script changes mirror the tested controller dev-template
- Confirmed `ami-07adb88c7ad360947` is current Server 2025 Core Base in `us-east-1` via `aws ssm get-parameter`

Assisted-by: Claude Code (claude-opus-4-6)