### PR TITLE
feat(KFLUXVNGD-1154): update konflux-operator image to acf4c5d7 with gap fixes

### DIFF
--- a/components/konflux-operator/rings/ring-0/base/cr/build/kustomization.yaml
+++ b/components/konflux-operator/rings/ring-0/base/cr/build/kustomization.yaml
@@ -1,4 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
+resources:
+  - trusted-ca-configmap.yaml
 patches:
   - path: build-service.yaml

--- a/components/konflux-operator/rings/ring-0/base/cr/build/trusted-ca-configmap.yaml
+++ b/components/konflux-operator/rings/ring-0/base/cr/build/trusted-ca-configmap.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: trusted-ca
+  namespace: build-service
+  labels:
+    config.openshift.io/inject-trusted-cabundle: "true"

--- a/components/konflux-operator/rings/ring-0/base/cr/integration/kustomization.yaml
+++ b/components/konflux-operator/rings/ring-0/base/cr/integration/kustomization.yaml
@@ -1,4 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
+resources:
+  - trusted-ca-configmap.yaml
 patches:
   - path: integration-service.yaml

--- a/components/konflux-operator/rings/ring-0/base/cr/integration/trusted-ca-configmap.yaml
+++ b/components/konflux-operator/rings/ring-0/base/cr/integration/trusted-ca-configmap.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: trusted-ca
+  namespace: integration-service
+  labels:
+    config.openshift.io/inject-trusted-cabundle: "true"


### PR DESCRIPTION
Updated the operator image and upstream manifests ref to `acf4c5d7ada0ffaeda6e7d9784893464e4c745ab` in ring-0 invariant.

Added `trusted-ca` ConfigMap resources to the build-service and integration-service operator components.

The new operator image includes fixes for gaps identified during staging migration testing:

- **trusted-ca**: The operator now mounts the OpenShift cluster CA bundle into build-service and integration-service controller containers, matching the legacy `rh-certs` component behavior
- **CONSOLE_URL_TASKLOG**: The operator now auto-discovers the konflux-ui Route and injects `CONSOLE_URL` and `CONSOLE_URL_TASKLOG` env vars into the integration controller, eliminating the need for manual ConfigMap configuration
- **info enhancements**: Improvements to the konflux-info component handling

- `rings/ring-0/base/invariant/kustomization.yaml` — bumped ref and image tag
- `rings/ring-0/base/cr/build/` — added `trusted-ca-configmap.yaml`
- `rings/ring-0/base/cr/integration/` — added `trusted-ca-configmap.yaml`

Assisted-by: Cursor + Opus 4.6