### PR TITLE
PVO11Y-5366 Resolve RHOBS remote write duplicate rejections in staging

### DIFF
--- a/components/monitoring/prometheus/staging/base/federation/drop-prometheus-labels-patch.yaml
+++ b/components/monitoring/prometheus/staging/base/federation/drop-prometheus-labels-patch.yaml
@@ -1,0 +1,6 @@
+---
+- op: add
+  path: /spec/endpoints/0/metricRelabelings
+  value:
+    - regex: prometheus_replica|prometheus
+      action: LabelDrop

--- a/components/monitoring/prometheus/staging/base/federation/kustomization.yaml
+++ b/components/monitoring/prometheus/staging/base/federation/kustomization.yaml
@@ -15,6 +15,14 @@ patches:
     target:
       name: appstudio-federate-uwm-smon
       kind: ServiceMonitor
+  - path: drop-prometheus-labels-patch.yaml
+    target:
+      name: appstudio-federate-smon
+      kind: ServiceMonitor
+  - path: drop-prometheus-labels-patch.yaml
+    target:
+      name: appstudio-federate-uwm-smon
+      kind: ServiceMonitor
   - path: remote-write-env-details.yaml
     target:
       name: appstudio-federate-ms

--- a/components/monitoring/prometheus/staging/base/federation/writeRelabelConfigs.yaml
+++ b/components/monitoring/prometheus/staging/base/federation/writeRelabelConfigs.yaml
@@ -22,6 +22,7 @@
     # Caching (KFLUXVNGD-751, KFLUXVNGD-1115)
     # ArgoCD (RHTAPWATCH-88)
     # Monitoring infra (RHTAPWATCH-110, PVO11Y-4774)
+    # RHOBS remote write deduplication (PVO11Y-5366)
     # KubeArchive
     # Cardinality exporter (PVO11Y-5128)
     # KAExporter (PVO11Y-5274)
@@ -42,6 +43,7 @@
       cache_status|normalized_uri|\
       health_status|dest_namespace|\
       hostname|label_app_kubernetes_io_managed_by|platform|scrape_job|slice|error|\
+      prometheus_replica|\
       resource_type|gin_errors|\
       metric|label|label_pair|scraped_instance|sharded_instance|instance_namespace|\
       application|component|build_type|scenario|optional|test_type|automated|exported_namespace|\

--- a/components/monitoring/prometheus/staging/tekton-ms/remote-write-env-details.yaml
+++ b/components/monitoring/prometheus/staging/tekton-ms/remote-write-env-details.yaml
@@ -29,7 +29,7 @@
             |tekton_pipelines_controller_running_taskruns_throttled_by_node\
             |tekton_pipelines_controller_running_taskruns_throttled_by_quota"
         - action: LabelKeep
-          regex: "__name__|source_environment|source_cluster|namespace|job|instance|pipeline|status|task"
+          regex: "__name__|prometheus_replica|source_environment|source_cluster|namespace|job|instance|pipeline|status|task"
     # Prometheus self-monitoring metrics
     - url: https://observatorium-mst.api.stage.openshift.com/api/metrics/v1/rhtap/api/v1/receive
       oauth2:
@@ -63,4 +63,4 @@
             |prometheus_tsdb_head_samples_appended_total\
             |process_start_time_seconds"
         - action: LabelKeep
-          regex: "__name__|source_environment|source_cluster|namespace|job|instance|version|quantile|slice|scrape_job"
+          regex: "__name__|prometheus_replica|source_environment|source_cluster|namespace|job|instance|version|quantile|slice|scrape_job"


### PR DESCRIPTION
## What

Forward `prometheus_replica` label to RHOBS and drop upstream prometheus labels from federation to enable proper Thanos deduplication for HA Prometheus replicas.

[PVO11Y-5366](https://redhat.atlassian.net/browse/PVO11Y-5366)

## Why

Both federation and tekton MonitoringStacks run `replicas: 2`, but the `prometheus_replica` label was stripped by `LabelKeep` writeRelabelConfigs before remote write. Thanos couldn't distinguish replicas and rejected duplicates. Additionally, the upstream `prometheus-k8s` `prometheus_replica` label was leaking through `honorLabels: true`, overriding the MonitoringStack's own replica identity.

Follows the proven RHOBS [hypershift-monitoring-stack-template](https://gitlab.cee.redhat.com/rhobs/configuration/-/blob/main/resources/collection/metrics/hypershift-monitoring-stack-template.yaml) pattern.

## Validation

- `kustomize build --enable-helm` passes for all staging overlays (kflux-stg-es01, stone-stage-p01, stone-stg-rh01, tekton-ms)
- Production kustomize output confirmed unchanged (0 matches for `prometheus_replica` or `metricRelabelings`)

[PVO11Y-5366]: https://redhat.atlassian.net/browse/PVO11Y-5366?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ