### PR TITLE
Promoting component mintmaker from stage to prod

### DIFF
--- a/components/mintmaker/production/base/kustomization.yaml
+++ b/components/mintmaker/production/base/kustomization.yaml
@@ -6,18 +6,18 @@ labels:
 resources:
   - ../../base
   - ../../base/external-secrets
-  - https://github.com/konflux-ci/mintmaker/config/default?ref=7bc5ca7e6ecd17749926284e491173bc90b2222d
-  - https://github.com/konflux-ci/mintmaker/config/renovate?ref=7bc5ca7e6ecd17749926284e491173bc90b2222d
+  - https://github.com/konflux-ci/mintmaker/config/default?ref=73d19f176f91cd6aec6c2bec5b7899552a4562e9
+  - https://github.com/konflux-ci/mintmaker/config/renovate?ref=73d19f176f91cd6aec6c2bec5b7899552a4562e9
 
 namespace: mintmaker
 
 images:
   - name: quay.io/konflux-ci/mintmaker
     newName: quay.io/konflux-ci/mintmaker
-    newTag: 7bc5ca7e6ecd17749926284e491173bc90b2222d
+    newTag: 73d19f176f91cd6aec6c2bec5b7899552a4562e9
   - name: quay.io/konflux-ci/mintmaker-renovate-image
     newName: quay.io/konflux-ci/mintmaker-renovate-image
-    newTag: 6d4fe394b5d555736285e610cdd91d901c1eec16
+    newTag: 6695cc041928c99600fb20c695f22aee5e5b4e37
 
 commonAnnotations:
   argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true


### PR DESCRIPTION
## Risk Assessment

**Risk Level:** Medium
**Description:** Some user visible changes, like dropping the migration link column in tekton task updates, switching over to semver-coerced versioning for tekton tasks, rules for buildah image replacement and disable mounting of `/etc/rhsm/ca` during build.
**Rollback:** Revert this PR to roll back the 'mintmaker' component to its previous version.

## Validation
Tested on staging - no regression observed

Splunk monitoring dashboard data showcasing stage working (last 7 days):

<img width="993" height="283" alt="image" src="https://github.com/user-attachments/assets/e16bb58e-f5b5-41e1-9654-8c9d4d6f3a96" />
