### PR TITLE
PVO11Y-5347 Deploy cardinality exporter to all remaining production clusters

### DIFF
--- a/argo-cd-apps/base/member/infra-deployments/monitoring-cardinality/monitoring-cardinality.yaml
+++ b/argo-cd-apps/base/member/infra-deployments/monitoring-cardinality/monitoring-cardinality.yaml
@@ -24,21 +24,22 @@ spec:
                   values.clusterDir: stone-prod-p01
                 - nameNormalized: kflux-prd-rh02
                   values.clusterDir: kflux-prd-rh02
-                # Remaining production clusters — empty-base until promoted
                 - nameNormalized: stone-prd-rh01
-                  values.clusterDir: empty-base
+                  values.clusterDir: stone-prd-rh01
                 - nameNormalized: stone-prod-p02
-                  values.clusterDir: empty-base
+                  values.clusterDir: stone-prod-p02
                 - nameNormalized: kflux-ocp-p01
-                  values.clusterDir: empty-base
+                  values.clusterDir: kflux-ocp-p01
                 - nameNormalized: kflux-prd-rh03
-                  values.clusterDir: empty-base
+                  values.clusterDir: kflux-prd-rh03
                 - nameNormalized: kflux-rhel-p01
-                  values.clusterDir: empty-base
+                  values.clusterDir: kflux-rhel-p01
                 - nameNormalized: kflux-osp-p01
-                  values.clusterDir: empty-base
+                  values.clusterDir: kflux-osp-p01
                 - nameNormalized: kflux-fedora-01
-                  values.clusterDir: empty-base
+                  values.clusterDir: kflux-fedora-01
+                - nameNormalized: kflux-prd-es01
+                  values.clusterDir: kflux-prd-es01
   template:
     metadata:
       name: monitoring-cardinality-{{nameNormalized}}

--- a/components/monitoring/exporters/cardinality/production/kflux-fedora-01/kustomization.yaml
+++ b/components/monitoring/exporters/cardinality/production/kflux-fedora-01/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - ../base

--- a/components/monitoring/exporters/cardinality/production/kflux-ocp-p01/kustomization.yaml
+++ b/components/monitoring/exporters/cardinality/production/kflux-ocp-p01/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - ../base

--- a/components/monitoring/exporters/cardinality/production/kflux-osp-p01/kustomization.yaml
+++ b/components/monitoring/exporters/cardinality/production/kflux-osp-p01/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - ../base

--- a/components/monitoring/exporters/cardinality/production/kflux-prd-es01/kustomization.yaml
+++ b/components/monitoring/exporters/cardinality/production/kflux-prd-es01/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - ../base

--- a/components/monitoring/exporters/cardinality/production/kflux-prd-rh03/kustomization.yaml
+++ b/components/monitoring/exporters/cardinality/production/kflux-prd-rh03/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - ../base

--- a/components/monitoring/exporters/cardinality/production/kflux-rhel-p01/kustomization.yaml
+++ b/components/monitoring/exporters/cardinality/production/kflux-rhel-p01/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - ../base

--- a/components/monitoring/exporters/cardinality/production/stone-prd-rh01/kustomization.yaml
+++ b/components/monitoring/exporters/cardinality/production/stone-prd-rh01/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - ../base

--- a/components/monitoring/exporters/cardinality/production/stone-prod-p02/kustomization.yaml
+++ b/components/monitoring/exporters/cardinality/production/stone-prod-p02/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - ../base


### PR DESCRIPTION
## Summary

Promote all remaining production clusters from empty-base to their actual overlay and add kflux-prd-es01 (EaaS) which was missing from the ApplicationSet list. The cardinality exporter scrapes Platform and federation Prometheus instances, which exist on every cluster.

Ring 1 (stone-prod-p01, kflux-prd-rh02) has been running successfully since July 17.

## Risk Assessment

- **Level:** Low
- **Description:** The cardinality exporter is read-only, querying Prometheus TSDB status every 6 minutes. Validated in staging for 4+ months and in production ring 1 for 4 days.
- **Rollback:** Point clusters back to empty-base in the ApplicationSet list.

## Validation

- Ring 1 running without issues
- `kustomize build` verified for all new per-cluster overlays