### PR TITLE
PVO11Y-5364 [2/3] Remove kueue ClusterPolicy from fedora

### DIFF
--- a/components/policies/production/kflux-fedora-01/kustomization.yaml
+++ b/components/policies/production/kflux-fedora-01/kustomization.yaml
@@ -3,11 +3,3 @@ kind: Kustomization
 resources:
 - ../base
 - ../policies/kubearchive/
-- ../policies/kueue/
-patches:
-- path: patches/kueue-policy-prepare-recreate.yaml
-  target:
-    group: kyverno.io
-    version: v1
-    kind: ClusterPolicy
-    name: bootstrap-tenant-namespace-queue

--- a/components/policies/production/kflux-fedora-01/patches/kueue-policy-prepare-recreate.yaml
+++ b/components/policies/production/kflux-fedora-01/patches/kueue-policy-prepare-recreate.yaml
@@ -1,3 +1,0 @@
-- op: replace
-  path: /spec/rules/0/generate/synchronize
-  value: false


### PR DESCRIPTION
## Summary

Remove the kueue policy from kflux-fedora-01 kustomization so ArgoCD prunes the old ClusterPolicy. This forces kyverno to clear its cached version.

**Step 2 of 3** — merge only after step 1 ([#13152](https://github.com/redhat-appstudio/infra-deployments/pull/13152)) is merged and synced.

Existing LocalQueues are preserved because step 1 set `orphanDownstreamOnPolicyDelete: true` and `synchronize: false`.

## Risk Assessment

- **Level**: Low
- **Description**: Removes the kueue ClusterPolicy from kflux-fedora-01 only. LocalQueues are orphaned (preserved) and continue to function. No new LocalQueues will be created until step 3 restores the policy.
- **Rollback**: Re-add `../policies/kueue/` to the kustomization

## Validation

This change cannot be validated in staging as it targets a cluster-specific kyverno ClusterPolicy on kflux-fedora-01. The 3-step process follows the documented [ClusterPolicy update procedure](https://github.com/redhat-appstudio/infra-deployments/tree/main/components/policies#how-to-update-an-existing-clusterpolicy) and was previously validated on staging clusters in [#11106](https://github.com/redhat-appstudio/infra-deployments/pull/11106), [#11107](https://github.com/redhat-appstudio/infra-deployments/pull/11107), [#11108](https://github.com/redhat-appstudio/infra-deployments/pull/11108).

## JIRA

[PVO11Y-5364](https://redhat.atlassian.net/browse/PVO11Y-5364)

[PVO11Y-5364]: https://redhat.atlassian.net/browse/PVO11Y-5364?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ