### PR TITLE
PVO11Y-5358 - upgrade OTel Collector image to 0.156.0 for stage/dev

### DIFF
--- a/components/monitoring/tracing/otel-collector/development/otel-collector-helm-values.yaml
+++ b/components/monitoring/tracing/otel-collector/development/otel-collector-helm-values.yaml
@@ -79,7 +79,7 @@ image:
   repository: quay.io/konflux-ci/opentelemetry-collector-k8s
   pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "0.113.0"
+  tag: "0.156.0"
 # OpenTelemetry Collector executable
 command:
   # The operator prepends '/' to the command name...no idea why.

--- a/components/monitoring/tracing/otel-collector/development/otel-collector-helm-values.yaml
+++ b/components/monitoring/tracing/otel-collector/development/otel-collector-helm-values.yaml
@@ -53,6 +53,9 @@ config:
         receivers:
           - otlp
       metrics: null
+    telemetry:
+      metrics:
+        address: null
 # Configuration for ports
 ports:
   otlp:

--- a/components/monitoring/tracing/otel-collector/staging/otel-collector-helm-values.yaml
+++ b/components/monitoring/tracing/otel-collector/staging/otel-collector-helm-values.yaml
@@ -1,8 +1,9 @@
 config:
   exporters:
-    sapm:
-      endpoint: "https://ingest.us1.signalfx.com/v2/trace"
-      access_token: ${env:SIGNALFX_API_TOKEN}
+    otlphttp/splunk:
+      traces_endpoint: "https://ingest.us1.signalfx.com/v2/trace/otlp"
+      headers:
+        "X-SF-Token": "${env:SIGNALFX_API_TOKEN}"
     signalfx:
       endpoint: "https://api.signalfx.com/v2/traces"
       realm: "us1"
@@ -55,7 +56,7 @@ config:
       traces:
         exporters:
           - debug
-          - sapm
+          - otlphttp/splunk
           - signalfx
         processors:
           - memory_limiter
@@ -119,7 +120,7 @@ image:
   repository: quay.io/konflux-ci/opentelemetry-collector-k8s
   pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "0.113.0"
+  tag: "0.156.0"
 # OpenTelemetry Collector executable
 command:
   # The operator prepends '/' to the command name...no idea why.

--- a/components/monitoring/tracing/otel-collector/staging/otel-collector-helm-values.yaml
+++ b/components/monitoring/tracing/otel-collector/staging/otel-collector-helm-values.yaml
@@ -75,6 +75,7 @@ config:
         - prometheus
     telemetry:
       metrics:
+        address: null
         level: basic
         readers:
         - pull:


### PR DESCRIPTION
- Bump image tag from 0.113.0 to 0.156.0 in staging and development
- Replace sapm exporter with otlphttp/splunk in staging
- Temp workaround fix to add address:null to address the OTel Collector upgrade changes. The field service.telemetry.metrics.address is deprecated in 0.156.0 but the Helm chart merges
    the defaults and the current values which creates a config with both the deprecated address field and th enew readers field that fails validation and stays Degraded.