### PR TITLE
bind konflux-bot-* SA to allowed ClusterRoles only - ring 1

### DIFF
--- a/components/policies/production/base/konflux-rbac/restrict-binding-serviceaccounts/create/.chainsaw-test/chainsaw-assert-validatingadmissionpolicy.yaml
+++ b/components/policies/production/base/konflux-rbac/restrict-binding-serviceaccounts/create/.chainsaw-test/chainsaw-assert-validatingadmissionpolicy.yaml
@@ -1,0 +1,7 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: restrict-bindings-serviceaccounts-create.konflux-ci.dev
+status:
+  observedGeneration: 1
+  typeChecking: {}

--- a/components/policies/production/base/konflux-rbac/restrict-binding-serviceaccounts/create/.chainsaw-test/chainsaw-test.yaml
+++ b/components/policies/production/base/konflux-rbac/restrict-binding-serviceaccounts/create/.chainsaw-test/chainsaw-test.yaml
@@ -1,0 +1,239 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: in-tenant-invalid-rolebinding
+spec:
+  description: |
+    tests that the a invalid RoleBinding can NOT be created
+    in a tenant namespace
+  concurrent: false
+  namespace: 'invalid-serviceaccounts-rb-tenant-namespace'
+  steps:
+  - name: given-validatingadmissionpolicy-is-ready
+    try:
+    - apply:
+        file: ../restrict-binding-serviceaccounts-create-validatingadmissionpolicy.yaml
+    - apply:
+        file: ../restrict-binding-serviceaccounts-create-validatingadmissionpolicybinding.yaml
+    - sleep:
+        duration: 1s
+    - assert:
+        file: chainsaw-assert-validatingadmissionpolicy.yaml
+  - name: given-tenant-namespace-exists
+    try:
+    - apply:
+        file: ./resources/tenant-namespace.yaml
+  - name: then-invalid-rolebinding-can-not-be-created
+    try:
+    - create:
+        file: ./resources/invalid-serviceaccounts-rolebinding.yaml
+        expect:
+        - check:
+            ($error != null): true
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: in-tenant-delete-invalid-existing-rolebinding
+spec:
+  description: |
+    tests that the an existing invalid RoleBinding can be deleted
+    in a tenant namespace
+  concurrent: false
+  namespace: 'existing-invalid-serviceaccounts-rb-tenant-namespace'
+  steps:
+  - name: given-tenant-namespace-exists
+    try:
+    - apply:
+        file: ./resources/tenant-namespace.yaml
+  - name: given-invalid-rolebinding-exists
+    try:
+    - create:
+        file: ./resources/invalid-serviceaccounts-rolebinding.yaml
+  - name: when-validatingadmissionpolicy-is-ready
+    try:
+    - apply:
+        file: ../restrict-binding-serviceaccounts-create-validatingadmissionpolicy.yaml
+    - apply:
+        file: ../restrict-binding-serviceaccounts-create-validatingadmissionpolicybinding.yaml
+    - sleep:
+        duration: 1s
+    - assert:
+        file: chainsaw-assert-validatingadmissionpolicy.yaml
+  - name: then-invalid-rolebinding-can-be-deleted
+    try:
+    - delete:
+        file: ./resources/invalid-serviceaccounts-rolebinding.yaml
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: in-tenant-valid-rolebinding
+spec:
+  description: |
+    tests that the a valid RoleBinding can be created in a
+    tenant namespace
+  concurrent: false
+  namespace: 'valid-serviceaccounts-rb-tenant-namespace'
+  steps:
+  - name: given-validatingadmissionpolicy-is-ready
+    try:
+    - apply:
+        file: ../restrict-binding-serviceaccounts-create-validatingadmissionpolicy.yaml
+    - apply:
+        file: ../restrict-binding-serviceaccounts-create-validatingadmissionpolicybinding.yaml
+    - sleep:
+        duration: 1s
+    - assert:
+        file: chainsaw-assert-validatingadmissionpolicy.yaml
+  - name: given-tenant-namespace-exists
+    try:
+    - apply:
+        file: ./resources/tenant-namespace.yaml
+  - name: then-valid-rolebinding-can-be-created
+    try:
+    - apply:
+        file: ./resources/valid-serviceaccounts-rolebinding.yaml
+        expect:
+        - check:
+            ($error != null): false
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: out-of-tenant-rolebinding
+spec:
+  description: |
+    tests that the whatever RoleBinding can be created in a
+    non-tenant namespace
+  concurrent: false
+  namespace: 'valid-serviceaccounts-rb-namespace'
+  steps:
+  - name: given-validatingadmissionpolicy-is-ready
+    try:
+    - apply:
+        file: ../restrict-binding-serviceaccounts-create-validatingadmissionpolicy.yaml
+    - apply:
+        file: ../restrict-binding-serviceaccounts-create-validatingadmissionpolicybinding.yaml
+    - sleep:
+        duration: 1s
+    - assert:
+        file: chainsaw-assert-validatingadmissionpolicy.yaml
+  - name: then-rolebinding-can-be-created-in-a-nontenant-namespace
+    try:
+    - apply:
+        file: ./resources/valid-serviceaccounts-rolebinding.yaml
+        expect:
+        - check:
+            ($error != null): false
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: in-tenant-invalid-konflux-bot-role-rolebinding
+spec:
+  description: |
+    tests that a RoleBinding binding a konflux-bot- ServiceAccount to a
+    namespaced Role can NOT be created in a tenant namespace
+  concurrent: false
+  namespace: 'invalid-konflux-bot-role-rb-tenant-namespace'
+  steps:
+  - name: given-validatingadmissionpolicy-is-ready
+    try:
+    - apply:
+        file: ../restrict-binding-serviceaccounts-create-validatingadmissionpolicy.yaml
+    - apply:
+        file: ../restrict-binding-serviceaccounts-create-validatingadmissionpolicybinding.yaml
+    - sleep:
+        duration: 1s
+    - assert:
+        file: chainsaw-assert-validatingadmissionpolicy.yaml
+  - name: given-tenant-namespace-and-role-exist
+    try:
+    - apply:
+        file: ./resources/tenant-namespace.yaml
+    - apply:
+        file: ./resources/tenant-role.yaml
+  - name: then-invalid-konflux-bot-role-rolebinding-can-not-be-created
+    try:
+    - create:
+        file: ./resources/invalid-konflux-bot-role-rolebinding.yaml
+        expect:
+        - check:
+            ($error != null): true
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: in-tenant-valid-konflux-bot-allowed-clusterrole-rolebinding
+spec:
+  description: |
+    tests that a RoleBinding binding a konflux-bot- ServiceAccount to an
+    allowed ClusterRole can be created in a tenant namespace
+  concurrent: false
+  namespace: 'valid-konflux-bot-allowed-cr-rb-tenant-namespace'
+  steps:
+  - name: given-validatingadmissionpolicy-is-ready
+    try:
+    - apply:
+        file: ../restrict-binding-serviceaccounts-create-validatingadmissionpolicy.yaml
+    - apply:
+        file: ../restrict-binding-serviceaccounts-create-validatingadmissionpolicybinding.yaml
+    - sleep:
+        duration: 1s
+    - assert:
+        file: chainsaw-assert-validatingadmissionpolicy.yaml
+  - name: given-tenant-namespace-exists
+    try:
+    - apply:
+        file: ./resources/tenant-namespace.yaml
+  - name: then-valid-konflux-bot-allowed-clusterrole-rolebinding-can-be-created
+    try:
+    - apply:
+        file: ./resources/valid-konflux-bot-allowed-clusterrole-rolebinding.yaml
+        expect:
+        - check:
+            ($error != null): false
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: in-tenant-valid-non-konflux-bot-role-rolebinding
+spec:
+  description: |
+    tests that a RoleBinding binding a non-konflux-bot- ServiceAccount to a
+    namespaced Role can be created in a tenant namespace
+  concurrent: false
+  namespace: 'valid-non-konflux-bot-role-rb-tenant-namespace'
+  steps:
+  - name: given-validatingadmissionpolicy-is-ready
+    try:
+    - apply:
+        file: ../restrict-binding-serviceaccounts-create-validatingadmissionpolicy.yaml
+    - apply:
+        file: ../restrict-binding-serviceaccounts-create-validatingadmissionpolicybinding.yaml
+    - sleep:
+        duration: 1s
+    - assert:
+        file: chainsaw-assert-validatingadmissionpolicy.yaml
+  - name: given-tenant-namespace-and-role-exist
+    try:
+    - apply:
+        file: ./resources/tenant-namespace.yaml
+    - apply:
+        file: ./resources/tenant-role.yaml
+  - name: then-valid-non-konflux-bot-role-rolebinding-can-be-created
+    try:
+    - apply:
+        file: ./resources/valid-non-konflux-bot-role-rolebinding.yaml
+        expect:
+        - check:
+            ($error != null): false

--- a/components/policies/production/base/konflux-rbac/restrict-binding-serviceaccounts/create/.chainsaw-test/resources/invalid-konflux-bot-role-rolebinding.yaml
+++ b/components/policies/production/base/konflux-rbac/restrict-binding-serviceaccounts/create/.chainsaw-test/resources/invalid-konflux-bot-role-rolebinding.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: invalid-konflux-bot-role-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: tenant-test-role
+subjects:
+- kind: ServiceAccount
+  name: konflux-bot-0

--- a/components/policies/production/base/konflux-rbac/restrict-binding-serviceaccounts/create/.chainsaw-test/resources/invalid-serviceaccounts-rolebinding.yaml
+++ b/components/policies/production/base/konflux-rbac/restrict-binding-serviceaccounts/create/.chainsaw-test/resources/invalid-serviceaccounts-rolebinding.yaml
@@ -1,0 +1,18 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: invalid-serviceaccounts-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: not-konflux-viewer-user-actions
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: my-group
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: my-user
+- apiGroup: ""
+  kind: ServiceAccount
+  name: konflux-bot-0

--- a/components/policies/production/base/konflux-rbac/restrict-binding-serviceaccounts/create/.chainsaw-test/resources/tenant-namespace.yaml
+++ b/components/policies/production/base/konflux-rbac/restrict-binding-serviceaccounts/create/.chainsaw-test/resources/tenant-namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ($namespace)
+  labels:
+    konflux-ci.dev/type: tenant

--- a/components/policies/production/base/konflux-rbac/restrict-binding-serviceaccounts/create/.chainsaw-test/resources/tenant-role.yaml
+++ b/components/policies/production/base/konflux-rbac/restrict-binding-serviceaccounts/create/.chainsaw-test/resources/tenant-role.yaml
@@ -1,0 +1,8 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: tenant-test-role
+rules:
+- apiGroups: [""]
+  resources: ["configmaps"]
+  verbs: ["get"]

--- a/components/policies/production/base/konflux-rbac/restrict-binding-serviceaccounts/create/.chainsaw-test/resources/valid-konflux-bot-allowed-clusterrole-rolebinding.yaml
+++ b/components/policies/production/base/konflux-rbac/restrict-binding-serviceaccounts/create/.chainsaw-test/resources/valid-konflux-bot-allowed-clusterrole-rolebinding.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: valid-konflux-bot-allowed-clusterrole-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: konflux-releaser-bot-actions
+subjects:
+- kind: ServiceAccount
+  name: konflux-bot-0

--- a/components/policies/production/base/konflux-rbac/restrict-binding-serviceaccounts/create/.chainsaw-test/resources/valid-non-konflux-bot-role-rolebinding.yaml
+++ b/components/policies/production/base/konflux-rbac/restrict-binding-serviceaccounts/create/.chainsaw-test/resources/valid-non-konflux-bot-role-rolebinding.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: valid-non-konflux-bot-role-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: tenant-test-role
+subjects:
+- kind: ServiceAccount
+  name: not-a-konflux-bot-sa

--- a/components/policies/production/base/konflux-rbac/restrict-binding-serviceaccounts/create/.chainsaw-test/resources/valid-serviceaccounts-rolebinding.yaml
+++ b/components/policies/production/base/konflux-rbac/restrict-binding-serviceaccounts/create/.chainsaw-test/resources/valid-serviceaccounts-rolebinding.yaml
@@ -1,0 +1,18 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: valid-serviceaccounts-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: konflux-viewer-user-actions
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: my-group
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: my-user
+- apiGroup: ""
+  kind: ServiceAccount
+  name: not-a-konflux-bot-sa

--- a/components/policies/production/base/konflux-rbac/restrict-binding-serviceaccounts/create/kustomization.yaml
+++ b/components/policies/production/base/konflux-rbac/restrict-binding-serviceaccounts/create/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- restrict-binding-serviceaccounts-create-validatingadmissionpolicy.yaml
+- restrict-binding-serviceaccounts-create-validatingadmissionpolicybinding.yaml

--- a/components/policies/production/base/konflux-rbac/restrict-binding-serviceaccounts/create/restrict-binding-serviceaccounts-create-validatingadmissionpolicy.yaml
+++ b/components/policies/production/base/konflux-rbac/restrict-binding-serviceaccounts/create/restrict-binding-serviceaccounts-create-validatingadmissionpolicy.yaml
@@ -1,0 +1,45 @@
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: restrict-bindings-serviceaccounts-create.konflux-ci.dev
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+    - apiGroups: ["rbac.authorization.k8s.io"]
+      apiVersions: ["v1"]
+      operations: ["CREATE"]
+      resources: ["rolebindings"]
+      scope: "Namespaced"
+  variables:
+  - name: restrictedServiceAccountsPrefix
+    expression: "'konflux-bot-'"
+  - name: allowedClusterRoleNamePattern
+    expression: "'^konflux-.+-bot-actions$'"
+  - name: bindsRestrictedKonfluxBotServiceAccount
+    expression: |
+      has(object.subjects) &&
+      object.subjects.exists(subject,
+        subject.kind == 'ServiceAccount' &&
+        (!has(subject.apiGroup) || subject.apiGroup == '') &&
+        has(subject.name) &&
+        subject.name.startsWith(variables.restrictedServiceAccountsPrefix))
+  - name: usesForbiddenRoleRef
+    expression: |
+      has(object.roleRef) && (
+        object.roleRef.kind == 'Role' ||
+        (object.roleRef.kind == 'ClusterRole' &&
+          has(object.roleRef.name) &&
+          !object.roleRef.name.matches(variables.allowedClusterRoleNamePattern)))
+  validations:
+  - expression: |
+      !(variables.bindsRestrictedKonfluxBotServiceAccount && variables.usesForbiddenRoleRef)
+    reason: Invalid
+    messageExpression: |
+      "ServiceAccounts with prefix '" +
+      variables.restrictedServiceAccountsPrefix +
+      "' cannot be bound to a Role and can only be bound to ClusterRoles matching the pattern konflux-*-bot-actions."
+    # fall-back if something is wrong with the messageExpression above
+    message: |
+      ServiceAccounts with prefix 'konflux-bot-' cannot be bound to a Role and can only be bound to ClusterRoles matching the pattern konflux-*-bot-actions.

--- a/components/policies/production/base/konflux-rbac/restrict-binding-serviceaccounts/create/restrict-binding-serviceaccounts-create-validatingadmissionpolicybinding.yaml
+++ b/components/policies/production/base/konflux-rbac/restrict-binding-serviceaccounts/create/restrict-binding-serviceaccounts-create-validatingadmissionpolicybinding.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: restrict-bindings-serviceaccounts-create.konflux-ci.dev
+spec:
+  policyName: restrict-bindings-serviceaccounts-create.konflux-ci.dev
+  validationActions: [Deny]
+  matchResources:
+    namespaceSelector:
+      matchLabels:
+        konflux-ci.dev/type: tenant

--- a/components/policies/production/base/konflux-rbac/restrict-binding-serviceaccounts/kustomization.yaml
+++ b/components/policies/production/base/konflux-rbac/restrict-binding-serviceaccounts/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namePrefix: konflux-rbac-
+resources:
+- create/
+- update/
+commonAnnotations:
+  argocd.argoproj.io/sync-options: Prune=false

--- a/components/policies/production/base/konflux-rbac/restrict-binding-serviceaccounts/update/.chainsaw-test/chainsaw-assert-validatingadmissionpolicy.yaml
+++ b/components/policies/production/base/konflux-rbac/restrict-binding-serviceaccounts/update/.chainsaw-test/chainsaw-assert-validatingadmissionpolicy.yaml
@@ -1,0 +1,7 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: restrict-bindings-serviceaccounts-update.konflux-ci.dev
+status:
+  observedGeneration: 1
+  typeChecking: {}

--- a/components/policies/production/base/konflux-rbac/restrict-binding-serviceaccounts/update/.chainsaw-test/chainsaw-test.yaml
+++ b/components/policies/production/base/konflux-rbac/restrict-binding-serviceaccounts/update/.chainsaw-test/chainsaw-test.yaml
@@ -1,0 +1,181 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: in-tenant-update-rolebinding-metadata
+spec:
+  description: |
+    tests that an existing RoleBinding without konflux-bot- ServiceAccounts
+    can be updated in a tenant namespace
+  concurrent: false
+  namespace: 'update-rb-metadata-tenant-namespace'
+  steps:
+  - name: given-validatingadmissionpolicy-is-ready
+    try:
+    - apply:
+        file: ../restrict-binding-serviceaccounts-update-validatingadmissionpolicy.yaml
+    - apply:
+        file: ../restrict-binding-serviceaccounts-update-validatingadmissionpolicybinding.yaml
+    - sleep:
+        duration: 1s
+    - assert:
+        file: chainsaw-assert-validatingadmissionpolicy.yaml
+  - name: given-tenant-namespace-and-rolebinding-exist
+    try:
+    - apply:
+        file: ./resources/tenant-namespace.yaml
+    - apply:
+        file: ./resources/valid-serviceaccounts-rolebinding.yaml
+  - name: then-rolebinding-metadata-can-be-updated
+    try:
+    - apply:
+        file: ./resources/valid-serviceaccounts-rolebinding-with-label.yaml
+        expect:
+        - check:
+            ($error != null): false
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: in-tenant-update-rolebinding-add-konflux-bot-denied
+spec:
+  description: |
+    tests that a konflux-bot- ServiceAccount cannot be added to an existing
+    RoleBinding in a tenant namespace
+  concurrent: false
+  namespace: 'update-rb-add-konflux-bot-tenant-namespace'
+  steps:
+  - name: given-validatingadmissionpolicy-is-ready
+    try:
+    - apply:
+        file: ../restrict-binding-serviceaccounts-update-validatingadmissionpolicy.yaml
+    - apply:
+        file: ../restrict-binding-serviceaccounts-update-validatingadmissionpolicybinding.yaml
+    - sleep:
+        duration: 1s
+    - assert:
+        file: chainsaw-assert-validatingadmissionpolicy.yaml
+  - name: given-tenant-namespace-and-rolebinding-exist
+    try:
+    - apply:
+        file: ./resources/tenant-namespace.yaml
+    - apply:
+        file: ./resources/valid-serviceaccounts-rolebinding.yaml
+  - name: then-adding-konflux-bot-subject-is-denied
+    try:
+    - apply:
+        file: ./resources/valid-serviceaccounts-rolebinding-with-konflux-bot-added.yaml
+        expect:
+        - check:
+            ($error != null): true
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: in-tenant-update-existing-konflux-bot-rolebinding
+spec:
+  description: |
+    tests that an existing RoleBinding that already targets a konflux-bot-
+    ServiceAccount can be updated in a tenant namespace
+  concurrent: false
+  namespace: 'update-existing-konflux-bot-rb-tenant-namespace'
+  steps:
+  - name: given-validatingadmissionpolicy-is-ready
+    try:
+    - apply:
+        file: ../restrict-binding-serviceaccounts-update-validatingadmissionpolicy.yaml
+    - apply:
+        file: ../restrict-binding-serviceaccounts-update-validatingadmissionpolicybinding.yaml
+    - sleep:
+        duration: 1s
+    - assert:
+        file: chainsaw-assert-validatingadmissionpolicy.yaml
+  - name: given-tenant-namespace-and-rolebinding-exist
+    try:
+    - apply:
+        file: ./resources/tenant-namespace.yaml
+    - apply:
+        file: ./resources/valid-konflux-bot-allowed-clusterrole-rolebinding.yaml
+  - name: then-existing-konflux-bot-rolebinding-can-be-updated
+    try:
+    - apply:
+        file: ./resources/valid-konflux-bot-allowed-clusterrole-rolebinding-with-label.yaml
+        expect:
+        - check:
+            ($error != null): false
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: in-tenant-update-preexisting-valid-konflux-bot-rolebinding
+spec:
+  description: |
+    tests that a pre-existing RoleBinding that already targets a konflux-bot-
+    ServiceAccount and an allowed ClusterRole can still be updated after the
+    policy is enforced
+  concurrent: false
+  namespace: 'update-preexisting-valid-konflux-bot-rb-tenant-namespace'
+  steps:
+  - name: given-tenant-namespace-and-invalid-rolebinding-exist
+    try:
+    - apply:
+        file: ./resources/tenant-namespace.yaml
+    - apply:
+        file: ./resources/valid-serviceaccounts-rolebinding.yaml
+  - name: when-validatingadmissionpolicy-is-ready
+    try:
+    - apply:
+        file: ../restrict-binding-serviceaccounts-update-validatingadmissionpolicy.yaml
+    - apply:
+        file: ../restrict-binding-serviceaccounts-update-validatingadmissionpolicybinding.yaml
+    - sleep:
+        duration: 1s
+    - assert:
+        file: chainsaw-assert-validatingadmissionpolicy.yaml
+  - name: then-preexisting-konflux-bot-rolebinding-can-be-updated
+    try:
+    - apply:
+        file: ./resources/valid-serviceaccounts-rolebinding-with-label.yaml
+        expect:
+        - check:
+            ($error != null): false
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: in-tenant-update-preexisting-invalid-konflux-bot-rolebinding
+spec:
+  description: |
+    tests that a pre-existing RoleBinding that already targets a konflux-bot-
+    ServiceAccount can be updated after the policy is enforced
+  concurrent: false
+  namespace: 'update-preexisting-invalid-konflux-bot-rb-tenant-namespace'
+  steps:
+  - name: given-tenant-namespace-and-invalid-rolebinding-exist
+    try:
+    - apply:
+        file: ./resources/tenant-namespace.yaml
+    - apply:
+        file: ./resources/invalid-serviceaccounts-rolebinding.yaml
+  - name: when-validatingadmissionpolicy-is-ready
+    try:
+    - apply:
+        file: ../restrict-binding-serviceaccounts-update-validatingadmissionpolicy.yaml
+    - apply:
+        file: ../restrict-binding-serviceaccounts-update-validatingadmissionpolicybinding.yaml
+    - sleep:
+        duration: 1s
+    - assert:
+        file: chainsaw-assert-validatingadmissionpolicy.yaml
+  - name: then-preexisting-konflux-bot-rolebinding-can-be-updated
+    try:
+    - apply:
+        file: ./resources/invalid-serviceaccounts-rolebinding-with-label.yaml
+        expect:
+        - check:
+            ($error != null): false

--- a/components/policies/production/base/konflux-rbac/restrict-binding-serviceaccounts/update/.chainsaw-test/resources/invalid-serviceaccounts-rolebinding-with-label.yaml
+++ b/components/policies/production/base/konflux-rbac/restrict-binding-serviceaccounts/update/.chainsaw-test/resources/invalid-serviceaccounts-rolebinding-with-label.yaml
@@ -1,0 +1,20 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: invalid-serviceaccounts-rolebinding
+  labels:
+    test.example.com/updated: "true"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: not-konflux-viewer-user-actions
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: my-group
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: my-user
+- apiGroup: ""
+  kind: ServiceAccount
+  name: konflux-bot-0

--- a/components/policies/production/base/konflux-rbac/restrict-binding-serviceaccounts/update/.chainsaw-test/resources/invalid-serviceaccounts-rolebinding.yaml
+++ b/components/policies/production/base/konflux-rbac/restrict-binding-serviceaccounts/update/.chainsaw-test/resources/invalid-serviceaccounts-rolebinding.yaml
@@ -1,0 +1,18 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: invalid-serviceaccounts-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: not-konflux-viewer-user-actions
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: my-group
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: my-user
+- apiGroup: ""
+  kind: ServiceAccount
+  name: konflux-bot-0

--- a/components/policies/production/base/konflux-rbac/restrict-binding-serviceaccounts/update/.chainsaw-test/resources/tenant-namespace.yaml
+++ b/components/policies/production/base/konflux-rbac/restrict-binding-serviceaccounts/update/.chainsaw-test/resources/tenant-namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ($namespace)
+  labels:
+    konflux-ci.dev/type: tenant

--- a/components/policies/production/base/konflux-rbac/restrict-binding-serviceaccounts/update/.chainsaw-test/resources/valid-konflux-bot-allowed-clusterrole-rolebinding-with-label.yaml
+++ b/components/policies/production/base/konflux-rbac/restrict-binding-serviceaccounts/update/.chainsaw-test/resources/valid-konflux-bot-allowed-clusterrole-rolebinding-with-label.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: valid-konflux-bot-allowed-clusterrole-rolebinding
+  labels:
+    test.example.com/updated: "true"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: konflux-releaser-bot-actions
+subjects:
+- kind: ServiceAccount
+  name: konflux-bot-0

--- a/components/policies/production/base/konflux-rbac/restrict-binding-serviceaccounts/update/.chainsaw-test/resources/valid-konflux-bot-allowed-clusterrole-rolebinding.yaml
+++ b/components/policies/production/base/konflux-rbac/restrict-binding-serviceaccounts/update/.chainsaw-test/resources/valid-konflux-bot-allowed-clusterrole-rolebinding.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: valid-konflux-bot-allowed-clusterrole-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: konflux-releaser-bot-actions
+subjects:
+- kind: ServiceAccount
+  name: konflux-bot-0

--- a/components/policies/production/base/konflux-rbac/restrict-binding-serviceaccounts/update/.chainsaw-test/resources/valid-serviceaccounts-rolebinding-with-konflux-bot-added.yaml
+++ b/components/policies/production/base/konflux-rbac/restrict-binding-serviceaccounts/update/.chainsaw-test/resources/valid-serviceaccounts-rolebinding-with-konflux-bot-added.yaml
@@ -1,0 +1,20 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: valid-serviceaccounts-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: konflux-viewer-user-actions
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: my-group
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: my-user
+- apiGroup: ""
+  kind: ServiceAccount
+  name: not-a-konflux-bot-sa
+- kind: ServiceAccount
+  name: konflux-bot-0

--- a/components/policies/production/base/konflux-rbac/restrict-binding-serviceaccounts/update/.chainsaw-test/resources/valid-serviceaccounts-rolebinding-with-label.yaml
+++ b/components/policies/production/base/konflux-rbac/restrict-binding-serviceaccounts/update/.chainsaw-test/resources/valid-serviceaccounts-rolebinding-with-label.yaml
@@ -1,0 +1,20 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: valid-serviceaccounts-rolebinding
+  labels:
+    test.example.com/updated: "true"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: konflux-viewer-user-actions
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: my-group
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: my-user
+- apiGroup: ""
+  kind: ServiceAccount
+  name: not-a-konflux-bot-sa

--- a/components/policies/production/base/konflux-rbac/restrict-binding-serviceaccounts/update/.chainsaw-test/resources/valid-serviceaccounts-rolebinding.yaml
+++ b/components/policies/production/base/konflux-rbac/restrict-binding-serviceaccounts/update/.chainsaw-test/resources/valid-serviceaccounts-rolebinding.yaml
@@ -1,0 +1,18 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: valid-serviceaccounts-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: konflux-viewer-user-actions
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: my-group
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: my-user
+- apiGroup: ""
+  kind: ServiceAccount
+  name: not-a-konflux-bot-sa

--- a/components/policies/production/base/konflux-rbac/restrict-binding-serviceaccounts/update/kustomization.yaml
+++ b/components/policies/production/base/konflux-rbac/restrict-binding-serviceaccounts/update/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- restrict-binding-serviceaccounts-update-validatingadmissionpolicy.yaml
+- restrict-binding-serviceaccounts-update-validatingadmissionpolicybinding.yaml

--- a/components/policies/production/base/konflux-rbac/restrict-binding-serviceaccounts/update/restrict-binding-serviceaccounts-update-validatingadmissionpolicy.yaml
+++ b/components/policies/production/base/konflux-rbac/restrict-binding-serviceaccounts/update/restrict-binding-serviceaccounts-update-validatingadmissionpolicy.yaml
@@ -1,0 +1,54 @@
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: restrict-bindings-serviceaccounts-update.konflux-ci.dev
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+    - apiGroups: ["rbac.authorization.k8s.io"]
+      apiVersions: ["v1"]
+      operations: ["UPDATE"]
+      resources: ["rolebindings"]
+      scope: "Namespaced"
+  variables:
+  - name: restrictedServiceAccountsPrefix
+    expression: "'konflux-bot-'"
+  - name: allowedClusterRoleNamePattern
+    expression: "'^konflux-.+-bot-actions$'"
+  - name: usesForbiddenRoleRef
+    expression: |
+      has(object.roleRef) && (
+        object.roleRef.kind == 'Role' ||
+        (object.roleRef.kind == 'ClusterRole' &&
+          has(object.roleRef.name) &&
+          !object.roleRef.name.matches(variables.allowedClusterRoleNamePattern)))
+  - name: addsRestrictedKonfluxBotServiceAccount
+    expression: |
+      has(object.subjects) &&
+      object.subjects.exists(newSubject,
+        newSubject.kind == 'ServiceAccount' &&
+        (!has(newSubject.apiGroup) || newSubject.apiGroup == '') &&
+        has(newSubject.name) &&
+        newSubject.name.startsWith(variables.restrictedServiceAccountsPrefix) &&
+        (
+          !has(oldObject.subjects) ||
+          !oldObject.subjects.exists(oldSubject,
+            oldSubject.kind == newSubject.kind &&
+            ((!has(oldSubject.apiGroup) || oldSubject.apiGroup == '') ==
+              (!has(newSubject.apiGroup) || newSubject.apiGroup == '')) &&
+            oldSubject.name == newSubject.name &&
+            (has(oldSubject.namespace) ? oldSubject.namespace : '') ==
+            (has(newSubject.namespace) ? newSubject.namespace : ''))))
+  validations:
+  - expression: '!variables.usesForbiddenRoleRef || !variables.addsRestrictedKonfluxBotServiceAccount'
+    reason: Invalid
+    messageExpression: |
+      "ServiceAccounts with prefix '" +
+      variables.restrictedServiceAccountsPrefix +
+      "' cannot be added to an existing RoleBinding" +
+      "not referencing a 'konflux-*-bot-actions'."
+    message: >-
+      ServiceAccounts with prefix 'konflux-bot-' cannot be added to an existing RoleBinding
+      not referencing a 'konflux-*-bot-actions' ClusterRole.

--- a/components/policies/production/base/konflux-rbac/restrict-binding-serviceaccounts/update/restrict-binding-serviceaccounts-update-validatingadmissionpolicybinding.yaml
+++ b/components/policies/production/base/konflux-rbac/restrict-binding-serviceaccounts/update/restrict-binding-serviceaccounts-update-validatingadmissionpolicybinding.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: restrict-bindings-serviceaccounts-update.konflux-ci.dev
+spec:
+  policyName: restrict-bindings-serviceaccounts-update.konflux-ci.dev
+  validationActions: [Deny]
+  matchResources:
+    namespaceSelector:
+      matchLabels:
+        konflux-ci.dev/type: tenant

--- a/components/policies/production/kflux-fedora-01/kustomization.yaml
+++ b/components/policies/production/kflux-fedora-01/kustomization.yaml
@@ -4,3 +4,7 @@ resources:
 - ../base
 - ../policies/kubearchive/
 - ../policies/kueue/
+
+# Rollout to Ring 1.
+# Ring 3's rollout will remove it and add it to base's directly
+- ../base/konflux-rbac/restrict-binding-serviceaccounts/

--- a/components/policies/production/kflux-osp-p01/kustomization.yaml
+++ b/components/policies/production/kflux-osp-p01/kustomization.yaml
@@ -5,3 +5,7 @@ resources:
 - ../base/cost-management
 - ../policies/kubearchive/
 - ../policies/kueue/
+
+# Rollout to Ring 1.
+# Ring 3's rollout will remove it and add it to base's directly
+- ../base/konflux-rbac/restrict-binding-serviceaccounts/

--- a/components/policies/production/stone-prod-p01/kustomization.yaml
+++ b/components/policies/production/stone-prod-p01/kustomization.yaml
@@ -5,3 +5,7 @@ resources:
 - ../base/cost-management
 - ../policies/kueue/
 - ../policies/kubearchive/
+
+# Rollout to Ring 1.
+# Ring 3's rollout will remove it and add it to base's directly
+- ../base/konflux-rbac/restrict-binding-serviceaccounts/


### PR DESCRIPTION
We want to prevent users from binding `konflux-bot-*` to anything
different from the Konflux provided ClusterRoles.

The proposed policy denies the creation of new RoleBindings that would bind the `konflux-bot-*` ServiceAccount to a not allowed ClusterRole.
It also denies binding the ServiceAccount by updating a RoleBinding.

For backward compatibility, already existing invalid RoleBinding are tolerated.
In a future effort they'll be remediated.

## Risk Assessment
**Risk Level:** Low
**Description:** Prevents user to create new RoleBindings if they do not match the new standards we are introducing.
**Rollback:** Revert PR

## Validation
Tested on staging — no regressions observed.
Staging PR: #12201

Signed-off-by: Francesco Ilario <filario@redhat.com>
