### PR TITLE
bind konflux-bot-* SA to allowed ClusterRoles only - ring 2

### DIFF
--- a/components/policies/production/kflux-ocp-p01/kustomization.yaml
+++ b/components/policies/production/kflux-ocp-p01/kustomization.yaml
@@ -5,3 +5,7 @@ resources:
 - ../base/cost-management
 - ../policies/kubearchive/
 - ../policies/kueue/
+
+# Rollout to Ring 2.
+# Ring 3's rollout will remove it and add it to base's directly
+- ../base/konflux-rbac/restrict-binding-serviceaccounts/

--- a/components/policies/production/kflux-rhel-p01/kustomization.yaml
+++ b/components/policies/production/kflux-rhel-p01/kustomization.yaml
@@ -5,3 +5,7 @@ resources:
 - ../base/cost-management
 - ../policies/kubearchive/
 - ../policies/kueue/
+
+# Rollout to Ring 2.
+# Ring 3's rollout will remove it and add it to base's directly
+- ../base/konflux-rbac/restrict-binding-serviceaccounts/

--- a/components/policies/production/stone-prod-p02/kustomization.yaml
+++ b/components/policies/production/stone-prod-p02/kustomization.yaml
@@ -8,3 +8,7 @@ resources:
 - ../policies/kueue/
 - ../policies/macos/
 - ./macos-config.yaml
+
+# Rollout to Ring 2.
+# Ring 3's rollout will remove it and add it to base's directly
+- ../base/konflux-rbac/restrict-binding-serviceaccounts/


### PR DESCRIPTION
We want to prevent users from binding `konflux-bot-*` to anything
different from the Konflux provided ClusterRoles.

The proposed policy denies the creation of new RoleBindings that would bind the `konflux-bot-*` ServiceAccount to a not allowed ClusterRole.
It also denies binding the ServiceAccount by updating a RoleBinding.

For backward compatibility, already existing invalid RoleBinding are tolerated.
In a future effort they'll be remediated.

## Risk Assessment
**Risk Level:** Low
**Description:** Prevents user to create new RoleBindings if they do not match the new standards we are introducing.
**Rollback:** Revert PR

## Validation
Tested on staging — no regressions observed.
Staging PR: #12201

Signed-off-by: Francesco Ilario <filario@redhat.com>
