### PR TITLE
KFLUXINFRA-4238: (onboarding) Remove staging etcd-shield apps from AppSRE ArgoCD

### DIFF
--- a/argo-cd-apps/base/member/infra-deployments/etcd-shield/etcd-shield.yaml
+++ b/argo-cd-apps/base/member/infra-deployments/etcd-shield/etcd-shield.yaml
@@ -14,10 +14,6 @@ spec:
                 environment: staging
           - list:
               elements:
-                - nameNormalized: stone-stg-rh01
-                  values.clusterDir: stone-stg-rh01
-                - nameNormalized: stone-stage-p01
-                  values.clusterDir: stone-stage-p01
                 - nameNormalized: kflux-ocp-p01
                   values.clusterDir: kflux-ocp-p01
                 - nameNormalized: kflux-prd-rh02

--- a/argo-cd-apps/overlays/konflux-public-staging/delete-applications.yaml
+++ b/argo-cd-apps/overlays/konflux-public-staging/delete-applications.yaml
@@ -11,3 +11,10 @@ kind: ApplicationSet
 metadata:
   name: nvme-storage-configurator
 $patch: delete
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: etcd-shield
+$patch: delete
+---

--- a/argo-cd-apps/overlays/staging-downstream/delete-applications.yaml
+++ b/argo-cd-apps/overlays/staging-downstream/delete-applications.yaml
@@ -17,3 +17,10 @@ kind: ApplicationSet
 metadata:
   name: nvme-storage-configurator
 $patch: delete
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: etcd-shield
+$patch: delete
+---


### PR DESCRIPTION
Deletes the etcd-shield apps from the staging overlays so those in the new rd-staging overlay take control over the existing resources.

### Summary of Changes
- Added delete patches for etcd-shield in both staging overlays
- Removed staging cluster entries from the original etcd-shield AppSet

### Risk Level
**Risk Level**: Medium
**Reasoning**: No new component resources are being created; the new ApplicationSet references the etcd-shield-rd/ directory, which is only a restructuring of the existing etcd-shield/ directory
**Rollback Strategy**: Revert this commit and do a manual sync for the original etcd-shield ApplicationSet, as it references the original structuring of etcd-shield.