### PR TITLE
feat(): add supplementary RBAC and resources to ring-0 konflux-operator deployment

### DIFF
--- a/components/konflux-operator/rings/ring-0/base/cr/build/kustomization.yaml
+++ b/components/konflux-operator/rings/ring-0/base/cr/build/kustomization.yaml
@@ -2,5 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
 resources:
   - trusted-ca-configmap.yaml
+  - rbac
 patches:
   - path: build-service.yaml

--- a/components/konflux-operator/rings/ring-0/base/cr/build/rbac/build-admin.yaml
+++ b/components/konflux-operator/rings/ring-0/base/cr/build/rbac/build-admin.yaml
@@ -1,0 +1,42 @@
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: build-admin
+  namespace: build-service
+rules:
+  - apiGroups:
+      - ''
+    resources:
+      - secrets
+    verbs:
+      - get
+      - list
+      - watch
+      - update
+      - patch
+      - delete
+
+  - apiGroups:
+      - ''
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+      - delete
+
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: build-admins
+  namespace: build-service
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: konflux-build-admins
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: build-admin

--- a/components/konflux-operator/rings/ring-0/base/cr/build/rbac/build-maintainer.yaml
+++ b/components/konflux-operator/rings/ring-0/base/cr/build/rbac/build-maintainer.yaml
@@ -1,0 +1,53 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: build-maintainer
+rules:
+  - verbs:
+      - get
+      - list
+      - patch
+      - update
+    apiGroups:
+      - ''
+    resources:
+      - serviceaccounts
+      - configmaps
+  - verbs:
+      - list
+    apiGroups:
+      - ''
+    resources:
+      - secrets
+  - verbs:
+      - get
+      - list
+      - patch
+      - update
+    apiGroups:
+      - appstudio.redhat.com
+    resources:
+      - components
+      - imagerepositories
+  - verbs:
+      - get
+      - list
+      - patch
+      - update
+    apiGroups:
+      - pipelinesascode.tekton.dev
+    resources:
+      - repositories
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: build-maintainers
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: konflux-build
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: build-maintainer

--- a/components/konflux-operator/rings/ring-0/base/cr/build/rbac/kustomization.yaml
+++ b/components/konflux-operator/rings/ring-0/base/cr/build/rbac/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - build-admin.yaml
+  - build-maintainer.yaml
+  - view-konflux-integration-runner.yaml

--- a/components/konflux-operator/rings/ring-0/base/cr/build/rbac/view-konflux-integration-runner.yaml
+++ b/components/konflux-operator/rings/ring-0/base/cr/build/rbac/view-konflux-integration-runner.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: view-konflux-integration-runner
+  namespace: build-service
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: view
+subjects:
+- kind: ServiceAccount
+  name: konflux-integration-runner
+  namespace: rhtap-build-tenant

--- a/components/konflux-operator/rings/ring-0/base/cr/image-controller/kustomization.yaml
+++ b/components/konflux-operator/rings/ring-0/base/cr/image-controller/kustomization.yaml
@@ -1,4 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
+resources:
+  - rbac
 patches:
   - path: image-controller.yaml

--- a/components/konflux-operator/rings/ring-0/base/cr/image-controller/rbac/image-controller-admin.yaml
+++ b/components/konflux-operator/rings/ring-0/base/cr/image-controller/rbac/image-controller-admin.yaml
@@ -1,0 +1,52 @@
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: image-controller-admin
+  namespace: image-controller
+rules:
+  - apiGroups:
+      - ''
+    resources:
+      - secrets
+    verbs:
+      - get
+      - list
+      - watch
+      - update
+      - patch
+      - delete
+
+  - apiGroups:
+      - ''
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+      - delete
+
+  - apiGroups:
+      - 'batch'
+    resources:
+      - jobs
+    verbs:
+      - get
+      - list
+      - watch
+      - delete
+
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: image-controller-admins
+  namespace: image-controller
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: konflux-build-admins
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: image-controller-admin

--- a/components/konflux-operator/rings/ring-0/base/cr/image-controller/rbac/image-controller-maintainer.yaml
+++ b/components/konflux-operator/rings/ring-0/base/cr/image-controller/rbac/image-controller-maintainer.yaml
@@ -1,0 +1,34 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: image-controller-maintainer
+rules:
+  - apiGroups:
+      - 'appstudio.redhat.com'
+    resources:
+      - imagerepositories
+    verbs:
+      - get
+      - list
+      - watch
+
+  - apiGroups:
+      - 'appstudio.redhat.com'
+    resources:
+      - imagerepositories/status
+    verbs:
+      - get
+
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: image-controller-maintainers
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: konflux-build
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: image-controller-maintainer

--- a/components/konflux-operator/rings/ring-0/base/cr/image-controller/rbac/kustomization.yaml
+++ b/components/konflux-operator/rings/ring-0/base/cr/image-controller/rbac/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - image-controller-admin.yaml
+  - image-controller-maintainer.yaml

--- a/components/konflux-operator/rings/ring-0/base/cr/integration/kustomization.yaml
+++ b/components/konflux-operator/rings/ring-0/base/cr/integration/kustomization.yaml
@@ -2,5 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
 resources:
   - trusted-ca-configmap.yaml
+  - rbac
 patches:
   - path: integration-service.yaml

--- a/components/konflux-operator/rings/ring-0/base/cr/integration/rbac/delete-snapshots.yaml
+++ b/components/konflux-operator/rings/ring-0/base/cr/integration/rbac/delete-snapshots.yaml
@@ -1,0 +1,25 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: delete-snapshots
+rules:
+  - apiGroups:
+    - "appstudio.redhat.com"
+    resources:
+      - "snapshots"
+    verbs:
+      - "delete"
+      - "deletecollection"
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: delete-snapshots
+subjects:
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: konflux-integration
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: delete-snapshots

--- a/components/konflux-operator/rings/ring-0/base/cr/integration/rbac/integration-service-maintainers.yaml
+++ b/components/konflux-operator/rings/ring-0/base/cr/integration/rbac/integration-service-maintainers.yaml
@@ -1,0 +1,13 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: integration-service-maintainers
+  namespace: integration-service
+subjects:
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: konflux-integration
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: component-maintainer

--- a/components/konflux-operator/rings/ring-0/base/cr/integration/rbac/kustomization.yaml
+++ b/components/konflux-operator/rings/ring-0/base/cr/integration/rbac/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - delete-snapshots.yaml
+  - manage-integrationtestscenarios.yaml
+  - manage-resolutionrequests.yaml
+  - modify-pipelineruns-taskruns.yaml
+  - integration-service-maintainers.yaml

--- a/components/konflux-operator/rings/ring-0/base/cr/integration/rbac/manage-integrationtestscenarios.yaml
+++ b/components/konflux-operator/rings/ring-0/base/cr/integration/rbac/manage-integrationtestscenarios.yaml
@@ -1,0 +1,31 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: manage-integrationtestscenarios
+rules:
+  - apiGroups:
+    - "appstudio.redhat.com"
+    resources:
+      - "integrationtestscenarios"
+    verbs:
+      - "create"
+      - "get"
+      - "list"
+      - "patch"
+      - "update"
+      - "watch"
+      - "delete"
+      - "deletecollection"
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: manage-integrationtestscenarios
+subjects:
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: konflux-integration
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: manage-integrationtestscenarios

--- a/components/konflux-operator/rings/ring-0/base/cr/integration/rbac/manage-resolutionrequests.yaml
+++ b/components/konflux-operator/rings/ring-0/base/cr/integration/rbac/manage-resolutionrequests.yaml
@@ -1,0 +1,28 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: manage-resolutionrequests
+rules:
+  - apiGroups:
+    - "resolution.tekton.dev"
+    resources:
+      - "resolutionrequests"
+    verbs:
+      - "create"
+      - "get"
+      - "list"
+      - "watch"
+      - "delete"
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: manage-resolutionrequests
+subjects:
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: konflux-integration
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: manage-resolutionrequests

--- a/components/konflux-operator/rings/ring-0/base/cr/integration/rbac/modify-pipelineruns-taskruns.yaml
+++ b/components/konflux-operator/rings/ring-0/base/cr/integration/rbac/modify-pipelineruns-taskruns.yaml
@@ -1,0 +1,28 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: modify-pipelineruns-taskruns
+rules:
+  - apiGroups:
+    - "tekton.dev"
+    resources:
+      - "pipelineruns"
+      - "taskruns"
+    verbs:
+      - "get"
+      - "list"
+      - "patch"
+      - "update"
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: modify-pipelineruns-taskruns
+subjects:
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: konflux-integration
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: modify-pipelineruns-taskruns

--- a/components/konflux-operator/rings/ring-0/base/cr/release/cronjobs/kustomization.yaml
+++ b/components/konflux-operator/rings/ring-0/base/cr/release/cronjobs/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - remove-internal-requests.yaml

--- a/components/konflux-operator/rings/ring-0/base/cr/release/cronjobs/remove-internal-requests.yaml
+++ b/components/konflux-operator/rings/ring-0/base/cr/release/cronjobs/remove-internal-requests.yaml
@@ -1,0 +1,81 @@
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: cleanup-timed-out-pipelineruns-internal-requests
+  namespace: release-service
+spec:
+  schedule: "10 03 * * *"
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: Never
+          serviceAccountName: release-service-controller-manager
+          volumes:
+            - name: temp-directory
+              emptyDir: {}
+          containers:
+            - name: ir-cleanup
+              command:
+                - /bin/bash
+                - -c
+                - |
+                  set -o pipefail
+                  PATH="/bin:/usr/bin:/usr/local/bin"
+                  MAX_PROCS=5
+                  INTERNAL_REQUESTS_FILE="/var/tmp/internal-requests-to-be-deleted"
+                  KUBECTL_OUTPUT=$(mktemp -p /var/tmp)
+                  YD=$(date -d 'yesterday' +%s)
+                  kubectl get internalrequests --all-namespaces \
+                    --sort-by=.status.completionTime \
+                    --template '{{range .items}}{{.metadata.name}}{{"\t"}}{{.metadata.namespace}}{{"\t"}}{{.status.completionTime}}{{"\n"}}{{end}}' \
+                    | grep -E "[0-9]{4}((-?)[0-9]{2})+T.*Z$" > $KUBECTL_OUTPUT
+                  awk -v yesterday=${YD} '{
+                    # parsing the completionTime and converting it to epoch
+                    # so we can compute the precise IRs that should be deleted
+                    gsub("[:\\-TZ]", " ", $3)
+                    t=mktime($3)
+                    completionTime=strftime("%s", t)
+                    #
+                    # completionTime should be smaller than yesterday seconds so it can be deleted
+                    if(yesterday > completionTime) {
+                      args="%s:%s\n"
+                      printf(args, $1, $2)
+                    }
+                  }' $KUBECTL_OUTPUT > $INTERNAL_REQUESTS_FILE
+
+                  # The deleteAndLog will run the CR deletion and save the operation in a structured way that
+                  # can be read easily by kubectl or journalctl
+                  function deleteAndLog() {
+                    ir=${1%:*}
+                    namespace=${1#*:}
+                    kubectl delete internalrequest $ir -n $namespace |while read logLine; do
+                      echo "INFO: namespace=${namespace} log=${logLine}"
+                    done
+                  }
+                  export -f deleteAndLog
+                  xargs -a ${INTERNAL_REQUESTS_FILE} -i -P ${MAX_PROCS} bash -c 'deleteAndLog "{}"'
+              imagePullPolicy: IfNotPresent
+              image: quay.io/konflux-ci/release-service-utils:9089cafbf36bb889b4b73d8c2965613810f13736
+              volumeMounts:
+                - mountPath: /var/tmp
+                  name: temp-directory
+              resources:
+                limits:
+                  cpu: 200m
+                  memory: 300Mi
+                requests:
+                  cpu: 100m
+                  memory: 200Mi
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+                readOnlyRootFilesystem: true
+                runAsNonRoot: true
+                seccompProfile:
+                  type: RuntimeDefault

--- a/components/konflux-operator/rings/ring-0/base/cr/release/e2e-release-pipeline-resources-role.yaml
+++ b/components/konflux-operator/rings/ring-0/base/cr/release/e2e-release-pipeline-resources-role.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: e2e-release-pipeline-resources-role
+rules:
+- apiGroups:
+  - pipelinesascode.tekton.dev
+  resources:
+  - repositories
+  verbs:
+  - get
+  - list
+  - watch

--- a/components/konflux-operator/rings/ring-0/base/cr/release/ibm-public-key-clusterrole.yaml
+++ b/components/konflux-operator/rings/ring-0/base/cr/release/ibm-public-key-clusterrole.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: release-pipeline-ibm-public-key
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    resourceNames:
+      - ibm-public-key
+      - ibm-public-key-stage
+    verbs:
+      - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: release-pipeline-ibm-public-key
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: release-pipeline-ibm-public-key
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: system:serviceaccounts:release-service

--- a/components/konflux-operator/rings/ring-0/base/cr/release/kustomization.yaml
+++ b/components/konflux-operator/rings/ring-0/base/cr/release/kustomization.yaml
@@ -1,4 +1,11 @@
 apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
+resources:
+  - cronjobs
+  - release-team.yaml
+  - release-service-configurator-role.yaml
+  - ibm-public-key-clusterrole.yaml
+  - monitor-pipeline-role.yaml
+  - e2e-release-pipeline-resources-role.yaml
 patches:
   - path: release-service.yaml

--- a/components/konflux-operator/rings/ring-0/base/cr/release/monitor-pipeline-role.yaml
+++ b/components/konflux-operator/rings/ring-0/base/cr/release/monitor-pipeline-role.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: monitor-pipeline-role
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "pods/log"]
+    verbs: ["get", "watch", "list"]
+  - apiGroups: ["tekton.dev"]
+    resources: ["pipelineruns", "pipelines"]
+    verbs: ["get", "watch", "list"]

--- a/components/konflux-operator/rings/ring-0/base/cr/release/release-service-configurator-role.yaml
+++ b/components/konflux-operator/rings/ring-0/base/cr/release/release-service-configurator-role.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: release-service-configurator
+  namespace: release-service
+rules:
+  - apiGroups:
+      - appstudio.redhat.com
+    resources:
+      - releaseserviceconfigs
+    verbs:
+      - '*'

--- a/components/konflux-operator/rings/ring-0/base/cr/release/release-team.yaml
+++ b/components/konflux-operator/rings/ring-0/base/cr/release/release-team.yaml
@@ -1,0 +1,27 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: release-service-maintainers
+  namespace: release-service
+subjects:
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: konflux-release-team
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: component-maintainer
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: release-service-configurators
+  namespace: release-service
+subjects:
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: konflux-release-team
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: release-service-configurator


### PR DESCRIPTION
Add team-specific RBAC and supplementary resources to the ring-0
(development) operator overlay that are not managed by the Konflux
operator itself but are required for parity with the legacy per-service
ArgoCD deployments.

- `build-admin` Role + RoleBinding: grants `konflux-build-admins` group
  access to secrets and pods in `build-service` namespace
- `build-maintainer` ClusterRole + ClusterRoleBinding: grants
  `konflux-build` group cluster-wide access to serviceaccounts,
  configmaps, components, imagerepositories, and PaC repositories
- `view-konflux-integration-runner` RoleBinding: grants the
  `konflux-integration-runner` SA view access in `build-service`
  namespace

- `image-controller-admin` Role + RoleBinding: grants
  `konflux-build-admins` group access to secrets, pods, and jobs
  in `image-controller` namespace
- `image-controller-maintainer` ClusterRole + ClusterRoleBinding:
  grants `konflux-build` group read access to imagerepositories

- `delete-snapshots`: grants `konflux-integration` group delete access
  to snapshots
- `manage-integrationtestscenarios`: full CRUD on
  integrationtestscenarios
- `manage-resolutionrequests`: CRUD on Tekton resolutionrequests
- `modify-pipelineruns-taskruns`: get/list/patch/update on PipelineRuns
  and TaskRuns
- `integration-service-maintainers`: grants `konflux-integration` group
  `component-maintainer` access in `integration-service` namespace

- `release-team.yaml`: release-service-maintainers and
  release-service-configurators RoleBindings for `konflux-release-team`
- `release-service-configurator-role.yaml`: Role granting CRUD on
  releaseserviceconfigs
- `ibm-public-key-clusterrole.yaml`: ClusterRole + ClusterRoleBinding
  granting all service accounts access to IBM public key secrets
- `monitor-pipeline-role.yaml`: ClusterRole for monitoring pods and
  PipelineRuns
- `e2e-release-pipeline-resources-role.yaml`: ClusterRole for reading
  PaC repositories
- `cronjobs/remove-internal-requests.yaml`: CronJob to clean up
  completed InternalRequests older than 24h

Note:
Narrow ibm-public-key ClusterRoleBinding from system:serviceaccounts
(all SAs cluster-wide) to system:serviceaccounts:release-service.
The operator owns release-pipeline-resource-role via SSA,
preventing the legacy kustomize patch approach.
A separate ClusterRole with resourceNames restriction keeps access tightly scoped.

The Konflux operator manages core controller deployments, CRDs,
namespaces, and controller RBAC. However, team-specific operational
permissions (admin/maintainer roles for each service team), cleanup
CronJobs, pipeline monitoring roles, and IBM key access are
infra-deployments concerns that sit outside the operator's scope.

These resources mirror what the legacy per-service ArgoCD ApplicationSets
deploy via `components/<service>/base/` and `components/<service>/development/`.
Without them, service teams lose operational access and scheduled cleanup
stops running when switching from legacy services to the operator.

- `kustomize build components/konflux-operator/rings/ring-0/base/`
  succeeds and renders 97 resources
- All 11 legacy services deleted by `development-operator` overlay
  are fully accounted for (build, enterprise-contract, image-controller,
  integration, release, konflux-info, konflux-ui, namespace-lister,
  application-api, internal-services, konflux-rbac)

Assisted-by: Cursor + Opus 4.6
