### PR TITLE
Update pipelines index to build 854 in dev/staging

### DIFF
--- a/components/pipeline-service/development/main-pipeline-service-configuration.yaml
+++ b/components/pipeline-service/development/main-pipeline-service-configuration.yaml
@@ -2244,7 +2244,7 @@ metadata:
   namespace: openshift-marketplace
 spec:
   displayName: custom-operators
-  image: quay.io/openshift-pipeline/pipelines-index-4.19@sha256:d33de5fb02ab99f6d93bdec9592400d0c8fd2622354446c4c043fa1dcba4e72e
+  image: quay.io/openshift-pipeline/pipelines-index-4.19@sha256:bd598786408b16bc1171c79907db124013189d57677e8bfbec1feccc55523ccd
   sourceType: grpc
   updateStrategy:
     registryPoll:

--- a/components/pipeline-service/staging/base/main-pipeline-service-configuration.yaml
+++ b/components/pipeline-service/staging/base/main-pipeline-service-configuration.yaml
@@ -2075,7 +2075,7 @@ metadata:
   namespace: openshift-marketplace
 spec:
   displayName: custom-operators
-  image: quay.io/openshift-pipeline/pipelines-index-4.19@sha256:d33de5fb02ab99f6d93bdec9592400d0c8fd2622354446c4c043fa1dcba4e72e
+  image: quay.io/openshift-pipeline/pipelines-index-4.19@sha256:bd598786408b16bc1171c79907db124013189d57677e8bfbec1feccc55523ccd
   sourceType: grpc
   updateStrategy:
     registryPoll:

--- a/components/pipeline-service/staging/stone-stage-p01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stage-p01/deploy.yaml
@@ -2663,7 +2663,7 @@ metadata:
   namespace: openshift-marketplace
 spec:
   displayName: custom-operators
-  image: quay.io/openshift-pipeline/pipelines-index-4.19@sha256:d33de5fb02ab99f6d93bdec9592400d0c8fd2622354446c4c043fa1dcba4e72e
+  image: quay.io/openshift-pipeline/pipelines-index-4.19@sha256:bd598786408b16bc1171c79907db124013189d57677e8bfbec1feccc55523ccd
   sourceType: grpc
   updateStrategy:
     registryPoll:

--- a/components/pipeline-service/staging/stone-stg-rh01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stg-rh01/deploy.yaml
@@ -2675,7 +2675,7 @@ metadata:
   namespace: openshift-marketplace
 spec:
   displayName: custom-operators
-  image: quay.io/openshift-pipeline/pipelines-index-4.19@sha256:d33de5fb02ab99f6d93bdec9592400d0c8fd2622354446c4c043fa1dcba4e72e
+  image: quay.io/openshift-pipeline/pipelines-index-4.19@sha256:bd598786408b16bc1171c79907db124013189d57677e8bfbec1feccc55523ccd
   sourceType: grpc
   updateStrategy:
     registryPoll:


### PR DESCRIPTION
Update CatalogSource image to 5.0.5-854.

This build includes the fix for the $(results.*.path) validation regression (tektoncd/pipeline PR #10443, cherry-picked to release-v1.14.x as aa28e098).


## Changelog (849 → 854)

**Old:** `5.0.5-849` (`sha256:d33de5fb...`)
**New:** `5.0.5-854` (`sha256:bd598786...`)

### Component Summary

| Component | 849 Upstream | 854 Upstream | Change |
|-----------|-------------|-------------|--------|
| Pipeline | 8afd0f7d | aa28e098 | +1 commit (results validation fix) |
| PAC | 25d67107 | 25d67107 | unchanged (v0.49.0) |
| Chains | 24246ee8 | 6221c79e | diverged (+35, -8) branch change |
| Operator | 6ce06ca7 | f5445c37 | +29 commits |

### Pipeline (v1.14.0 → v1.14.0 + fix, +1 commit)
[Compare](https://github.com/tektoncd/pipeline/compare/8afd0f7d5aae3504267eb42bf342847911b7b4d1...aa28e09810a679c1282095ae604afb1f5488e162)

- `aa28e098` fix: Add results to valid variable prefixes in pipeline validation (PR #10443)

Cherry-pick of `f618b94c` from main to `release-v1.14.x`. Fixes `$(results.output-result.path)` validation regression.

### PAC — unchanged (v0.49.0, commit 25d67107)

### Operator (+29 commits)
[Compare](https://github.com/tektoncd/operator/compare/6ce06ca7b21044838918f74bfb32d4dc880b7e2c...f5445c37125e)

**New Features:**
- `067c7134` feat(tektonconfig): add ML-KEM group to nginx for PQC readiness
- `9f33b036` feat(helm): allow more chart customization options
- `dc8b92b4` feat(dependabot): add branch prefix to PR titles for release branches

**Bug Fixes:**
- `477bca67` fix(pruner): ensure enforcedConfigLevel is always defaulted
- `0407cfa1` fix(helm): correct logging CM logger keys and default zap level
- `433ae8fa` fix(helm): close unclosed if-block in openshift-crds.yaml
- `4f183115` fix(common): apply proxy settings to StatefulSets too
- `05ed4505` fix(rbac): add bind/escalate verbs for k8s install

**Security:**
- `dfd1edb8` fix: update stdlib to 1.26.4 — CVE-2026-27145

**Removals:**
- `34adad43` remove TektonHub component support
- `f5445c37` remove hub from template source file
- `7f46530a` chore(operatorhub): remove tech-preview label from Results

**Component Bumps:**
- `6a356d30` bump tektoncd/pipeline from 1.12.0 to 1.14.0
- `b197f1ad` bump chains from v0.27.2 to v0.27.3
- `0f9bf58f` bump tektoncd/pruner from 0.4.0 to 0.4.1

### Chains (diverged +35 ahead, -8 behind — branch change)
[Compare](https://github.com/tektoncd/chains/compare/24246ee86bd0c7fde8135f6b2302511cabd69be9...6221c79e40a4)

**New Features:**
- `dc6eb036` feat: embed Rekor bundle in OCI attestation layer annotations
- `5972eb07` Add migration cleanup for SSA finalizers

**Bug Fixes:**
- `3229037e` fix: enable Vault JWT auth without Spire for KMS signing
- `52e75a31` fix: pass insecure option to name.NewDigest for OCI storage
- `5ba90088` fix(signing): make KMS OIDC fallback test environment-independent
- `75e9b76b` fix(storage): skip docdb watcher reconfiguration on empty file read

**Dependencies:**
- `6221c79e` Bump sigstore/rekor to v1.5.2 and migrate awsdynamodb to v2

### Key Highlights

- **Pipeline fix confirmed:** `aa28e098` — the `$(results.*.path)` validation regression fix (PR #10443) is now included
- **Hub fully removed:** Operator removed TektonHub support
- **Results GA:** Tech-preview label removed from Results in OperatorHub
- **PQC readiness:** ML-KEM (post-quantum crypto) group added to nginx TLS config
- **CVE-2026-27145:** Operator stdlib updated to Go 1.26.4
- **Chains branch change:** New features include Rekor bundle embedding and Vault JWT auth without Spire
- **Proxy fix:** Operator now applies proxy settings to StatefulSets