### PR TITLE
Promote release-service and grafana-dashboard from staging to production

### DIFF
--- a/components/monitoring/grafana/production/dashboards/release/kustomization.yaml
+++ b/components/monitoring/grafana/production/dashboards/release/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- https://github.com/konflux-ci/release-service/config/grafana/?ref=6d9abf25ac73986731ba7dbdb1ac459af54999b0
+- https://github.com/konflux-ci/release-service/config/grafana/?ref=19e1d5ade7521048274c3ce9a427c381c93b71de

--- a/components/release/production/kustomization.yaml
+++ b/components/release/production/kustomization.yaml
@@ -3,7 +3,7 @@ kind: Kustomization
 resources:
   - ../base
   - ../base/monitor/production
-  - https://github.com/konflux-ci/release-service/config/default?ref=6d9abf25ac73986731ba7dbdb1ac459af54999b0
+  - https://github.com/konflux-ci/release-service/config/default?ref=19e1d5ade7521048274c3ce9a427c381c93b71de
   - release_service_config.yaml
   - signing_configs.yaml
 
@@ -13,7 +13,7 @@ components:
 images:
   - name: quay.io/konflux-ci/release-service
     newName: quay.io/konflux-ci/release-service
-    newTag: 6d9abf25ac73986731ba7dbdb1ac459af54999b0
+    newTag: 19e1d5ade7521048274c3ce9a427c381c93b71de
 
 namespace: release-service
 


### PR DESCRIPTION
Included PRs:
 - https://github.com/konflux-ci/release-service/pull/1732 
 - https://github.com/konflux-ci/release-service/pull/1728 
 - https://github.com/konflux-ci/release-service/pull/1680 
 - https://github.com/konflux-ci/release-service/pull/1725 

Risk: low (3 dependency updates + 1 bug fix for [RELEASE-2389](https://redhat.atlassian.net/browse/RELEASE-2389))
Stage: https://github.com/redhat-appstudio/infra-deployments/pull/13054

[RELEASE-2389]: https://redhat.atlassian.net/browse/RELEASE-2389?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ