### PR TITLE
KFLUXINFRA-2236: Fix TriggerBinding cron-binding rejected by webhook

### DIFF
--- a/components/disaster-recovery/development/triggerbinding.yaml
+++ b/components/disaster-recovery/development/triggerbinding.yaml
@@ -3,4 +3,7 @@ apiVersion: triggers.tekton.dev/v1beta1
 kind: TriggerBinding
 metadata:
   name: cron-binding
-spec: {}
+spec:
+  params:
+  - name: duration
+    value: 10s


### PR DESCRIPTION
## Summary

Restores `spec.params` in the DR component's `TriggerBinding/cron-binding` manifest.

Commit `a36cbd3f` in #13074 replaced the params block with `spec: {}`. The Tekton Triggers
validating webhook on OCP 4.18 rejects this as `missing field(s): spec`, blocking ArgoCD sync
of `disaster-recovery-in-cluster-local` during Konflux installation. 43/44 apps sync; this one
times out after 45 minutes.

The TriggerTemplate still references `$(tt.params.duration)` — restoring the binding keeps the
contract consistent.

## Changes

- `components/disaster-recovery/development/triggerbinding.yaml`: restore `spec.params` with `duration: 10s`

## Risk Assessment

- **Level:** Low
- **Description:** Restores a previously working manifest to its prior state
- **Rollback:** Revert this single commit

## Validation

- Webhook error reproduced in prow rehearsal run [2079951947116318720](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/81360/rehearse-81360-pull-ci-redhat-appstudio-infra-deployments-main-appstudio-konflux-disaster-recovery/2079951947116318720)
- The original manifest with `spec.params` worked in all prior CI runs

Assisted-by: Claude Code (claude-opus-4-6)