### PR TITLE
KFLUXINFRA-4238: (onboarding) Migrate production etcd-shield AppSet to ring deployments ArgoCD

### DIFF
--- a/argo-cd-apps/overlays/rd-production/etcd-shield/etcd-shield-appset.yaml
+++ b/argo-cd-apps/overlays/rd-production/etcd-shield/etcd-shield-appset.yaml
@@ -1,0 +1,45 @@
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: etcd-shield
+  labels:
+    appstudio.redhat.com/environment: member # Helps cluster patches detect this appset
+spec:
+  generators:
+    - merge:
+        mergeKeys:
+          - nameNormalized
+        generators:
+          - clusters:
+              selector:
+                matchLabels:
+                  appstudio.redhat.com/is-tenant-cluster: "true"
+              values:
+                sourceRoot: components/etcd-shield-rd
+                ring: "empty-base"
+                clusterDir: "empty-base"
+          - list:
+              elements: [] # Populated via a patch (or manually if the cluster list is unusual)
+
+  template:
+    metadata:
+      name: etcd-shield-{{nameNormalized}}
+    spec:
+      project: default
+      source:
+        path: '{{values.sourceRoot}}/rings/{{values.ring}}/{{values.clusterDir}}'
+        repoURL: https://github.com/redhat-appstudio/infra-deployments.git
+        targetRevision: main
+      destination:
+        namespace: etcd-shield
+        server: '{{server}}'
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
+        syncOptions:
+        - CreateNamespace=true
+        retry:
+          limit: 50
+          backoff:
+            duration: 15s

--- a/argo-cd-apps/overlays/rd-production/etcd-shield/kustomization.yaml
+++ b/argo-cd-apps/overlays/rd-production/etcd-shield/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - etcd-shield-appset.yaml

--- a/argo-cd-apps/overlays/rd-production/kustomization.yaml
+++ b/argo-cd-apps/overlays/rd-production/kustomization.yaml
@@ -4,6 +4,7 @@ namespace: argocd-infra-deployments
 
 resources:
   - authentication
+  - etcd-shield
 
 patches:
   - path: patches/all-clusters-patch.yaml
@@ -21,3 +22,8 @@ patches:
       kind: ApplicationSet
       version: v1alpha1
       labelSelector: appstudio.redhat.com/environment=internal
+  - path: patches/member-clusters-patch.yaml
+    target:
+      kind: ApplicationSet
+      version: v1alpha1
+      labelSelector: appstudio.redhat.com/environment=member

--- a/argo-cd-apps/overlays/rd-production/patches/member-clusters-patch.yaml
+++ b/argo-cd-apps/overlays/rd-production/patches/member-clusters-patch.yaml
@@ -1,0 +1,33 @@
+- op: add
+  path: /spec/generators/0/merge/generators/1/list/elements
+  value:
+    # Ring 2
+    - values.ring: ring-2
+      nameNormalized: kflux-fedora-01
+      values.clusterDir: kflux-fedora-01
+    - values.ring: ring-2
+      nameNormalized: kflux-ocp-p01
+      values.clusterDir: kflux-ocp-p01
+    - values.ring: ring-2
+      nameNormalized: kflux-osp-p01
+      values.clusterDir: kflux-osp-p01
+    - values.ring: ring-2
+      nameNormalized: kflux-prd-rh03
+      values.clusterDir: kflux-prd-rh03
+    - values.ring: ring-2
+      nameNormalized: kflux-rhel-p01
+      values.clusterDir: kflux-rhel-p01
+    - values.ring: ring-2
+      nameNormalized: stone-prod-p01
+      values.clusterDir: stone-prod-p01
+    # Ring 3
+    - values.ring: ring-3
+      nameNormalized: stone-prd-rh01
+      values.clusterDir: stone-prd-rh01
+    - values.ring: ring-3
+      nameNormalized: stone-prod-p02
+      values.clusterDir: stone-prod-p02
+    # Ring 4
+    - values.ring: ring-4
+      nameNormalized: kflux-prd-rh02
+      values.clusterDir: kflux-prd-rh02

--- a/components/etcd-shield-rd/rings/ring-2/base/base-snapshot/config.yaml
+++ b/components/etcd-shield-rd/rings/ring-2/base/base-snapshot/config.yaml
@@ -1,0 +1,12 @@
+destName: etcd-shield-state
+destNamespace: etcd-shield
+prometheus:
+  address: https://prometheus-k8s.openshift-monitoring.svc:9091
+  alertName: EtcdShieldDenyAdmission
+  config:
+    authorization:
+      type: Bearer
+      credentials_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+    tls_config:
+      ca_file: /var/tls/tls.crt
+waitTime: 15s

--- a/components/etcd-shield-rd/rings/ring-2/base/base-snapshot/deployment.yaml
+++ b/components/etcd-shield-rd/rings/ring-2/base/base-snapshot/deployment.yaml
@@ -1,0 +1,90 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: etcd-shield
+  labels:
+    app: etcd-shield
+  annotations:
+    ignore-check.kube-linter.io/no-anti-affinity: "using topologySpreadConstraints"
+spec:
+  selector:
+    matchLabels:
+      app: etcd-shield
+  replicas: 3
+  template:
+    metadata:
+      labels:
+        app: etcd-shield
+    spec:
+      serviceAccountName: etcd-shield
+      topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: topology.kubernetes.io/zone
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app: etcd-shield
+      containers:
+      - args:
+        - -leader-elect=false
+        - -health-probe-bind-address=:8081
+        - -config=/etc/etcd-shield/config.yaml
+        - -port=8443
+        - -metrics-addr=:9100
+        env:
+        - name: "NAMESPACE"
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: "STATE_MANAGER"
+          value: "in-memory"
+        image: etcd-shield:latest
+        name: etcd-shield
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          initialDelaySeconds: 1
+          httpGet:
+            path: /healthz
+            port: 8081
+            scheme: HTTP
+        readinessProbe:
+          initialDelaySeconds: 1
+          httpGet:
+            path: /readyz
+            port: 8081
+            scheme: HTTP
+        resources:
+          limits:
+            memory: 128Mi
+          requests:
+            cpu: 500m
+            memory: 128Mi
+        ports:
+        - containerPort: 8443
+          name: http
+        - containerPort: 8081
+          name: healthz
+        - containerPort: 9100
+          name: metrics
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          capabilities:
+            drop:
+            - "ALL"
+        volumeMounts:
+        - name: tls
+          mountPath: /var/tls
+          readOnly: true
+        - name: config
+          mountPath: /etc/etcd-shield/
+          readOnly: true
+      terminationGracePeriodSeconds: 60
+      volumes:
+      - name: tls
+        secret:
+          secretName: etcd-shield-tls
+      - name: config
+        configMap:
+          name: etcd-shield-config

--- a/components/etcd-shield-rd/rings/ring-2/base/base-snapshot/etcd_shield_alerts.yaml
+++ b/components/etcd-shield-rd/rings/ring-2/base/base-snapshot/etcd_shield_alerts.yaml
@@ -1,0 +1,28 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: etcd-shield-triggers
+spec:
+  groups:
+  - name: etcd_shield_triggers
+    interval: 1m
+    rules:
+    - alert: EtcdShieldDenyAdmission
+      expr: etcd_shield_trigger != bool 0
+      for: 2m
+      keep_firing_for: 5m
+      labels:
+        severity: critical
+      annotations:
+        summary: etcd-shield is denying admission
+        description: Etcd is nearing capacity limits, so etcd-shield is denying admission
+    - record: etcd_shield_trigger
+      expr: |
+        (((etcd_mvcc_db_total_size_in_use_in_bytes >= bool (etcd_server_quota_backend_bytes * 0.80)) == 1) or
+            ((((etcd_mvcc_db_total_size_in_use_in_bytes) >= bool (etcd_server_quota_backend_bytes * 0.70)) == 1) and
+                (count without (alertname, alertstate, severity)
+                      (ALERTS{
+                        alertname="EtcdShieldDenyAdmission",
+                        alertstate="firing",
+                        severity="critical"
+                      }) == bool 1)))

--- a/components/etcd-shield-rd/rings/ring-2/base/base-snapshot/kustomization.yaml
+++ b/components/etcd-shield-rd/rings/ring-2/base/base-snapshot/kustomization.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+configMapGenerator:
+  - files:
+      - ./config.yaml
+    name: etcd-shield-config
+# generatorOptions:
+#   # until https://github.com/kubernetes-sigs/kustomize/issues/4475 is fixed
+#   disableNameSuffixHash: true
+images:
+  - name: etcd-shield
+    newName: quay.io/konflux-ci/etcd-shield
+    newTag: 94885d051db284f214f43d76df2f9bd4c9fe993f
+namespace: etcd-shield
+resources:
+  - deployment.yaml
+  - ns.yaml
+  - service.yaml
+  - webhook.yaml
+  - etcd_shield_alerts.yaml
+  - metrics
+  - rbac

--- a/components/etcd-shield-rd/rings/ring-2/base/base-snapshot/metrics/kustomization.yaml
+++ b/components/etcd-shield-rd/rings/ring-2/base/base-snapshot/metrics/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- monitor.yaml
+- serviceaccount.yaml
+- prometheus-crb.yaml
+- metrics-service.yaml
+- monitoring-rb.yaml

--- a/components/etcd-shield-rd/rings/ring-2/base/base-snapshot/metrics/metrics-service.yaml
+++ b/components/etcd-shield-rd/rings/ring-2/base/base-snapshot/metrics/metrics-service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: etcd-shield
+  name: etcd-shield-metrics
+  namespace: etcd-shield
+spec:
+  selector:
+    app: etcd-shield
+  type: ClusterIP
+  ports:
+  - name: metrics
+    targetPort: 9100
+    protocol: TCP
+    port: 9100

--- a/components/etcd-shield-rd/rings/ring-2/base/base-snapshot/metrics/monitor.yaml
+++ b/components/etcd-shield-rd/rings/ring-2/base/base-snapshot/metrics/monitor.yaml
@@ -1,0 +1,26 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: etcd-shield-metrics
+  labels:
+    app: etcd-shield
+spec:
+  endpoints:
+    - interval: 15s
+      scheme: https
+      path: /metrics
+      port: metrics
+      authorization:
+        credentials:
+          key: token
+          name: metrics-reader
+      tlsConfig:
+        ca:
+          secret:
+            key: service-ca.crt
+            name: metrics-reader
+            optional: false
+        serverName: etcd-shield.etcd-shield.svc
+  selector:
+    matchLabels:
+      app: etcd-shield

--- a/components/etcd-shield-rd/rings/ring-2/base/base-snapshot/metrics/monitoring-rb.yaml
+++ b/components/etcd-shield-rd/rings/ring-2/base/base-snapshot/metrics/monitoring-rb.yaml
@@ -1,0 +1,33 @@
+# etcd-shield is registered as a core service (the
+# openshift.io/cluster-monitoring label on the namespace), rather than as a
+# user workload. This is necessary because we need access to etcd's metrics to
+# function properly. However, this means openshift's monitoring services can't
+# use the user workload monitoring roles to fetch our metrics (specifically,
+# they need pods, services, and endpoints). This is a bit of a workaround to
+# get prometheus to be able to recognize our metrics endpoints, since I don't
+# know of a better way to do this.
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: monitoring-metrics-reader
+  namespace: etcd-shield
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: etcd-shield-monitor
+subjects:
+- kind: ServiceAccount
+  name: prometheus-k8s
+  namespace: openshift-monitoring
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: etcd-shield-monitor
+  namespace: etcd-shield
+rules:
+- apiGroups: [""]
+  resources: ["pods", "services", "endpoints"]
+  verbs: ["get", "list", "watch"]
+---

--- a/components/etcd-shield-rd/rings/ring-2/base/base-snapshot/metrics/prometheus-crb.yaml
+++ b/components/etcd-shield-rd/rings/ring-2/base/base-snapshot/metrics/prometheus-crb.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: etcd-shield-metrics
+rules:
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: prometheus-etcd-shield-metrics-reader
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: etcd-shield-metrics
+subjects:
+- kind: ServiceAccount
+  name: metrics-reader
+  namespace: etcd-shield
+---

--- a/components/etcd-shield-rd/rings/ring-2/base/base-snapshot/metrics/serviceaccount.yaml
+++ b/components/etcd-shield-rd/rings/ring-2/base/base-snapshot/metrics/serviceaccount.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  annotations:
+    kubernetes.io/service-account.name: metrics-reader
+  name: metrics-reader
+type: kubernetes.io/service-account-token
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: metrics-reader
+  namespace: etcd-shield

--- a/components/etcd-shield-rd/rings/ring-2/base/base-snapshot/ns.yaml
+++ b/components/etcd-shield-rd/rings/ring-2/base/base-snapshot/ns.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: etcd-shield
+  labels:
+    openshift.io/cluster-monitoring: "true"

--- a/components/etcd-shield-rd/rings/ring-2/base/base-snapshot/rbac/authorizer-crb.yaml
+++ b/components/etcd-shield-rd/rings/ring-2/base/base-snapshot/rbac/authorizer-crb.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: etcd-shield-authorizer
+rules:
+- apiGroups: ["authentication.k8s.io"]
+  resources: ["tokenreviews"]
+  verbs: ["create"]
+- apiGroups: ["authorization.k8s.io"]
+  resources: ["subjectaccessreviews"]
+  verbs: ["create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: etcd-shield-authorizer
+subjects:
+- apiGroup: ""
+  kind: ServiceAccount
+  name: etcd-shield
+  namespace: etcd-shield
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: etcd-shield-authorizer
+---

--- a/components/etcd-shield-rd/rings/ring-2/base/base-snapshot/rbac/kustomization.yaml
+++ b/components/etcd-shield-rd/rings/ring-2/base/base-snapshot/rbac/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- serviceaccount.yaml
+- rolebinding.yaml
+- authorizer-crb.yaml
+- monitoring-crb.yaml

--- a/components/etcd-shield-rd/rings/ring-2/base/base-snapshot/rbac/monitoring-crb.yaml
+++ b/components/etcd-shield-rd/rings/ring-2/base/base-snapshot/rbac/monitoring-crb.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: etcd-shield:cluster-monitoring-view
+subjects:
+- apiGroup: ""
+  kind: ServiceAccount
+  name: etcd-shield
+  namespace: etcd-shield
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-monitoring-view

--- a/components/etcd-shield-rd/rings/ring-2/base/base-snapshot/rbac/rolebinding.yaml
+++ b/components/etcd-shield-rd/rings/ring-2/base/base-snapshot/rbac/rolebinding.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: etcd-shield
+  namespace: etcd-shield
+rules:
+- apiGroups: [""]
+  resources: ["configmaps"]
+  verbs: ["get", "list", "watch", "create", "update", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: etcd-shield
+subjects:
+- apiGroup: ""
+  kind: ServiceAccount
+  name: etcd-shield
+  namespace: etcd-shield
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: etcd-shield
+---

--- a/components/etcd-shield-rd/rings/ring-2/base/base-snapshot/rbac/serviceaccount.yaml
+++ b/components/etcd-shield-rd/rings/ring-2/base/base-snapshot/rbac/serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: etcd-shield
+  namespace: etcd-shield

--- a/components/etcd-shield-rd/rings/ring-2/base/base-snapshot/service.yaml
+++ b/components/etcd-shield-rd/rings/ring-2/base/base-snapshot/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: etcd-shield-tls
+  name: etcd-shield
+spec:
+  ports:
+  - port: 443
+    protocol: TCP
+    targetPort: 8443
+  selector:
+    app: etcd-shield

--- a/components/etcd-shield-rd/rings/ring-2/base/base-snapshot/webhook.yaml
+++ b/components/etcd-shield-rd/rings/ring-2/base/base-snapshot/webhook.yaml
@@ -1,0 +1,26 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  annotations:
+    service.beta.openshift.io/inject-cabundle: 'true'
+  name: etcd-shield-validating-webhook-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: etcd-shield
+      namespace: etcd-shield
+      path: /validate-resource
+  failurePolicy: Fail
+  name: vpipelineruns.konflux-ci.dev
+  rules:
+  - apiGroups:
+    - tekton.dev
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    resources:
+    - pipelineruns
+  sideEffects: None

--- a/components/etcd-shield-rd/rings/ring-2/base/kustomization.yaml
+++ b/components/etcd-shield-rd/rings/ring-2/base/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - base-snapshot
+
+patches:
+  - target:
+      kind: PrometheusRule
+      name: etcd-shield-triggers
+    path: prometheus-rule-severity-patch.yaml

--- a/components/etcd-shield-rd/rings/ring-2/base/prometheus-rule-severity-patch.yaml
+++ b/components/etcd-shield-rd/rings/ring-2/base/prometheus-rule-severity-patch.yaml
@@ -1,0 +1,3 @@
+- op: replace
+  path: /spec/groups/0/rules/0/labels/severity
+  value: warning

--- a/components/etcd-shield-rd/rings/ring-2/kflux-fedora-01/kustomization.yaml
+++ b/components/etcd-shield-rd/rings/ring-2/kflux-fedora-01/kustomization.yaml
@@ -1,3 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-resources: [] # Not deployed to EaaS clusters
+resources:
+- ../base

--- a/components/etcd-shield-rd/rings/ring-2/kflux-ocp-p01/kustomization.yaml
+++ b/components/etcd-shield-rd/rings/ring-2/kflux-ocp-p01/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../base

--- a/components/etcd-shield-rd/rings/ring-2/kflux-osp-p01/kustomization.yaml
+++ b/components/etcd-shield-rd/rings/ring-2/kflux-osp-p01/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../base

--- a/components/etcd-shield-rd/rings/ring-2/kflux-prd-rh03/kustomization.yaml
+++ b/components/etcd-shield-rd/rings/ring-2/kflux-prd-rh03/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../base

--- a/components/etcd-shield-rd/rings/ring-2/kflux-rhel-p01/kustomization.yaml
+++ b/components/etcd-shield-rd/rings/ring-2/kflux-rhel-p01/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../base

--- a/components/etcd-shield-rd/rings/ring-2/stone-prod-p01/kustomization.yaml
+++ b/components/etcd-shield-rd/rings/ring-2/stone-prod-p01/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../base

--- a/components/etcd-shield-rd/rings/ring-3/base/base-snapshot/config.yaml
+++ b/components/etcd-shield-rd/rings/ring-3/base/base-snapshot/config.yaml
@@ -1,0 +1,12 @@
+destName: etcd-shield-state
+destNamespace: etcd-shield
+prometheus:
+  address: https://prometheus-k8s.openshift-monitoring.svc:9091
+  alertName: EtcdShieldDenyAdmission
+  config:
+    authorization:
+      type: Bearer
+      credentials_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+    tls_config:
+      ca_file: /var/tls/tls.crt
+waitTime: 15s

--- a/components/etcd-shield-rd/rings/ring-3/base/base-snapshot/deployment.yaml
+++ b/components/etcd-shield-rd/rings/ring-3/base/base-snapshot/deployment.yaml
@@ -1,0 +1,90 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: etcd-shield
+  labels:
+    app: etcd-shield
+  annotations:
+    ignore-check.kube-linter.io/no-anti-affinity: "using topologySpreadConstraints"
+spec:
+  selector:
+    matchLabels:
+      app: etcd-shield
+  replicas: 3
+  template:
+    metadata:
+      labels:
+        app: etcd-shield
+    spec:
+      serviceAccountName: etcd-shield
+      topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: topology.kubernetes.io/zone
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app: etcd-shield
+      containers:
+      - args:
+        - -leader-elect=false
+        - -health-probe-bind-address=:8081
+        - -config=/etc/etcd-shield/config.yaml
+        - -port=8443
+        - -metrics-addr=:9100
+        env:
+        - name: "NAMESPACE"
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: "STATE_MANAGER"
+          value: "in-memory"
+        image: etcd-shield:latest
+        name: etcd-shield
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          initialDelaySeconds: 1
+          httpGet:
+            path: /healthz
+            port: 8081
+            scheme: HTTP
+        readinessProbe:
+          initialDelaySeconds: 1
+          httpGet:
+            path: /readyz
+            port: 8081
+            scheme: HTTP
+        resources:
+          limits:
+            memory: 128Mi
+          requests:
+            cpu: 500m
+            memory: 128Mi
+        ports:
+        - containerPort: 8443
+          name: http
+        - containerPort: 8081
+          name: healthz
+        - containerPort: 9100
+          name: metrics
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          capabilities:
+            drop:
+            - "ALL"
+        volumeMounts:
+        - name: tls
+          mountPath: /var/tls
+          readOnly: true
+        - name: config
+          mountPath: /etc/etcd-shield/
+          readOnly: true
+      terminationGracePeriodSeconds: 60
+      volumes:
+      - name: tls
+        secret:
+          secretName: etcd-shield-tls
+      - name: config
+        configMap:
+          name: etcd-shield-config

--- a/components/etcd-shield-rd/rings/ring-3/base/base-snapshot/etcd_shield_alerts.yaml
+++ b/components/etcd-shield-rd/rings/ring-3/base/base-snapshot/etcd_shield_alerts.yaml
@@ -1,0 +1,28 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: etcd-shield-triggers
+spec:
+  groups:
+  - name: etcd_shield_triggers
+    interval: 1m
+    rules:
+    - alert: EtcdShieldDenyAdmission
+      expr: etcd_shield_trigger != bool 0
+      for: 2m
+      keep_firing_for: 5m
+      labels:
+        severity: critical
+      annotations:
+        summary: etcd-shield is denying admission
+        description: Etcd is nearing capacity limits, so etcd-shield is denying admission
+    - record: etcd_shield_trigger
+      expr: |
+        (((etcd_mvcc_db_total_size_in_use_in_bytes >= bool (etcd_server_quota_backend_bytes * 0.80)) == 1) or
+            ((((etcd_mvcc_db_total_size_in_use_in_bytes) >= bool (etcd_server_quota_backend_bytes * 0.70)) == 1) and
+                (count without (alertname, alertstate, severity)
+                      (ALERTS{
+                        alertname="EtcdShieldDenyAdmission",
+                        alertstate="firing",
+                        severity="critical"
+                      }) == bool 1)))

--- a/components/etcd-shield-rd/rings/ring-3/base/base-snapshot/kustomization.yaml
+++ b/components/etcd-shield-rd/rings/ring-3/base/base-snapshot/kustomization.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+configMapGenerator:
+  - files:
+      - ./config.yaml
+    name: etcd-shield-config
+# generatorOptions:
+#   # until https://github.com/kubernetes-sigs/kustomize/issues/4475 is fixed
+#   disableNameSuffixHash: true
+images:
+  - name: etcd-shield
+    newName: quay.io/konflux-ci/etcd-shield
+    newTag: 94885d051db284f214f43d76df2f9bd4c9fe993f
+namespace: etcd-shield
+resources:
+  - deployment.yaml
+  - ns.yaml
+  - service.yaml
+  - webhook.yaml
+  - etcd_shield_alerts.yaml
+  - metrics
+  - rbac

--- a/components/etcd-shield-rd/rings/ring-3/base/base-snapshot/metrics/kustomization.yaml
+++ b/components/etcd-shield-rd/rings/ring-3/base/base-snapshot/metrics/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- monitor.yaml
+- serviceaccount.yaml
+- prometheus-crb.yaml
+- metrics-service.yaml
+- monitoring-rb.yaml

--- a/components/etcd-shield-rd/rings/ring-3/base/base-snapshot/metrics/metrics-service.yaml
+++ b/components/etcd-shield-rd/rings/ring-3/base/base-snapshot/metrics/metrics-service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: etcd-shield
+  name: etcd-shield-metrics
+  namespace: etcd-shield
+spec:
+  selector:
+    app: etcd-shield
+  type: ClusterIP
+  ports:
+  - name: metrics
+    targetPort: 9100
+    protocol: TCP
+    port: 9100

--- a/components/etcd-shield-rd/rings/ring-3/base/base-snapshot/metrics/monitor.yaml
+++ b/components/etcd-shield-rd/rings/ring-3/base/base-snapshot/metrics/monitor.yaml
@@ -1,0 +1,26 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: etcd-shield-metrics
+  labels:
+    app: etcd-shield
+spec:
+  endpoints:
+    - interval: 15s
+      scheme: https
+      path: /metrics
+      port: metrics
+      authorization:
+        credentials:
+          key: token
+          name: metrics-reader
+      tlsConfig:
+        ca:
+          secret:
+            key: service-ca.crt
+            name: metrics-reader
+            optional: false
+        serverName: etcd-shield.etcd-shield.svc
+  selector:
+    matchLabels:
+      app: etcd-shield

--- a/components/etcd-shield-rd/rings/ring-3/base/base-snapshot/metrics/monitoring-rb.yaml
+++ b/components/etcd-shield-rd/rings/ring-3/base/base-snapshot/metrics/monitoring-rb.yaml
@@ -1,0 +1,33 @@
+# etcd-shield is registered as a core service (the
+# openshift.io/cluster-monitoring label on the namespace), rather than as a
+# user workload. This is necessary because we need access to etcd's metrics to
+# function properly. However, this means openshift's monitoring services can't
+# use the user workload monitoring roles to fetch our metrics (specifically,
+# they need pods, services, and endpoints). This is a bit of a workaround to
+# get prometheus to be able to recognize our metrics endpoints, since I don't
+# know of a better way to do this.
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: monitoring-metrics-reader
+  namespace: etcd-shield
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: etcd-shield-monitor
+subjects:
+- kind: ServiceAccount
+  name: prometheus-k8s
+  namespace: openshift-monitoring
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: etcd-shield-monitor
+  namespace: etcd-shield
+rules:
+- apiGroups: [""]
+  resources: ["pods", "services", "endpoints"]
+  verbs: ["get", "list", "watch"]
+---

--- a/components/etcd-shield-rd/rings/ring-3/base/base-snapshot/metrics/prometheus-crb.yaml
+++ b/components/etcd-shield-rd/rings/ring-3/base/base-snapshot/metrics/prometheus-crb.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: etcd-shield-metrics
+rules:
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: prometheus-etcd-shield-metrics-reader
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: etcd-shield-metrics
+subjects:
+- kind: ServiceAccount
+  name: metrics-reader
+  namespace: etcd-shield
+---

--- a/components/etcd-shield-rd/rings/ring-3/base/base-snapshot/metrics/serviceaccount.yaml
+++ b/components/etcd-shield-rd/rings/ring-3/base/base-snapshot/metrics/serviceaccount.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  annotations:
+    kubernetes.io/service-account.name: metrics-reader
+  name: metrics-reader
+type: kubernetes.io/service-account-token
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: metrics-reader
+  namespace: etcd-shield

--- a/components/etcd-shield-rd/rings/ring-3/base/base-snapshot/ns.yaml
+++ b/components/etcd-shield-rd/rings/ring-3/base/base-snapshot/ns.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: etcd-shield
+  labels:
+    openshift.io/cluster-monitoring: "true"

--- a/components/etcd-shield-rd/rings/ring-3/base/base-snapshot/rbac/authorizer-crb.yaml
+++ b/components/etcd-shield-rd/rings/ring-3/base/base-snapshot/rbac/authorizer-crb.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: etcd-shield-authorizer
+rules:
+- apiGroups: ["authentication.k8s.io"]
+  resources: ["tokenreviews"]
+  verbs: ["create"]
+- apiGroups: ["authorization.k8s.io"]
+  resources: ["subjectaccessreviews"]
+  verbs: ["create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: etcd-shield-authorizer
+subjects:
+- apiGroup: ""
+  kind: ServiceAccount
+  name: etcd-shield
+  namespace: etcd-shield
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: etcd-shield-authorizer
+---

--- a/components/etcd-shield-rd/rings/ring-3/base/base-snapshot/rbac/kustomization.yaml
+++ b/components/etcd-shield-rd/rings/ring-3/base/base-snapshot/rbac/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- serviceaccount.yaml
+- rolebinding.yaml
+- authorizer-crb.yaml
+- monitoring-crb.yaml

--- a/components/etcd-shield-rd/rings/ring-3/base/base-snapshot/rbac/monitoring-crb.yaml
+++ b/components/etcd-shield-rd/rings/ring-3/base/base-snapshot/rbac/monitoring-crb.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: etcd-shield:cluster-monitoring-view
+subjects:
+- apiGroup: ""
+  kind: ServiceAccount
+  name: etcd-shield
+  namespace: etcd-shield
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-monitoring-view

--- a/components/etcd-shield-rd/rings/ring-3/base/base-snapshot/rbac/rolebinding.yaml
+++ b/components/etcd-shield-rd/rings/ring-3/base/base-snapshot/rbac/rolebinding.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: etcd-shield
+  namespace: etcd-shield
+rules:
+- apiGroups: [""]
+  resources: ["configmaps"]
+  verbs: ["get", "list", "watch", "create", "update", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: etcd-shield
+subjects:
+- apiGroup: ""
+  kind: ServiceAccount
+  name: etcd-shield
+  namespace: etcd-shield
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: etcd-shield
+---

--- a/components/etcd-shield-rd/rings/ring-3/base/base-snapshot/rbac/serviceaccount.yaml
+++ b/components/etcd-shield-rd/rings/ring-3/base/base-snapshot/rbac/serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: etcd-shield
+  namespace: etcd-shield

--- a/components/etcd-shield-rd/rings/ring-3/base/base-snapshot/service.yaml
+++ b/components/etcd-shield-rd/rings/ring-3/base/base-snapshot/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: etcd-shield-tls
+  name: etcd-shield
+spec:
+  ports:
+  - port: 443
+    protocol: TCP
+    targetPort: 8443
+  selector:
+    app: etcd-shield

--- a/components/etcd-shield-rd/rings/ring-3/base/base-snapshot/webhook.yaml
+++ b/components/etcd-shield-rd/rings/ring-3/base/base-snapshot/webhook.yaml
@@ -1,0 +1,26 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  annotations:
+    service.beta.openshift.io/inject-cabundle: 'true'
+  name: etcd-shield-validating-webhook-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: etcd-shield
+      namespace: etcd-shield
+      path: /validate-resource
+  failurePolicy: Fail
+  name: vpipelineruns.konflux-ci.dev
+  rules:
+  - apiGroups:
+    - tekton.dev
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    resources:
+    - pipelineruns
+  sideEffects: None

--- a/components/etcd-shield-rd/rings/ring-3/base/kustomization.yaml
+++ b/components/etcd-shield-rd/rings/ring-3/base/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - base-snapshot
+
+patches:
+  - target:
+      kind: PrometheusRule
+      name: etcd-shield-triggers
+    path: prometheus-rule-severity-patch.yaml

--- a/components/etcd-shield-rd/rings/ring-3/base/prometheus-rule-severity-patch.yaml
+++ b/components/etcd-shield-rd/rings/ring-3/base/prometheus-rule-severity-patch.yaml
@@ -1,0 +1,3 @@
+- op: replace
+  path: /spec/groups/0/rules/0/labels/severity
+  value: warning

--- a/components/etcd-shield-rd/rings/ring-3/stone-prd-rh01/kustomization.yaml
+++ b/components/etcd-shield-rd/rings/ring-3/stone-prd-rh01/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../base

--- a/components/etcd-shield-rd/rings/ring-3/stone-prod-p02/kustomization.yaml
+++ b/components/etcd-shield-rd/rings/ring-3/stone-prod-p02/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../base

--- a/components/etcd-shield-rd/rings/ring-4/base/base-snapshot/config.yaml
+++ b/components/etcd-shield-rd/rings/ring-4/base/base-snapshot/config.yaml
@@ -1,0 +1,12 @@
+destName: etcd-shield-state
+destNamespace: etcd-shield
+prometheus:
+  address: https://prometheus-k8s.openshift-monitoring.svc:9091
+  alertName: EtcdShieldDenyAdmission
+  config:
+    authorization:
+      type: Bearer
+      credentials_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+    tls_config:
+      ca_file: /var/tls/tls.crt
+waitTime: 15s

--- a/components/etcd-shield-rd/rings/ring-4/base/base-snapshot/deployment.yaml
+++ b/components/etcd-shield-rd/rings/ring-4/base/base-snapshot/deployment.yaml
@@ -1,0 +1,90 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: etcd-shield
+  labels:
+    app: etcd-shield
+  annotations:
+    ignore-check.kube-linter.io/no-anti-affinity: "using topologySpreadConstraints"
+spec:
+  selector:
+    matchLabels:
+      app: etcd-shield
+  replicas: 3
+  template:
+    metadata:
+      labels:
+        app: etcd-shield
+    spec:
+      serviceAccountName: etcd-shield
+      topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: topology.kubernetes.io/zone
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app: etcd-shield
+      containers:
+      - args:
+        - -leader-elect=false
+        - -health-probe-bind-address=:8081
+        - -config=/etc/etcd-shield/config.yaml
+        - -port=8443
+        - -metrics-addr=:9100
+        env:
+        - name: "NAMESPACE"
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: "STATE_MANAGER"
+          value: "in-memory"
+        image: etcd-shield:latest
+        name: etcd-shield
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          initialDelaySeconds: 1
+          httpGet:
+            path: /healthz
+            port: 8081
+            scheme: HTTP
+        readinessProbe:
+          initialDelaySeconds: 1
+          httpGet:
+            path: /readyz
+            port: 8081
+            scheme: HTTP
+        resources:
+          limits:
+            memory: 128Mi
+          requests:
+            cpu: 500m
+            memory: 128Mi
+        ports:
+        - containerPort: 8443
+          name: http
+        - containerPort: 8081
+          name: healthz
+        - containerPort: 9100
+          name: metrics
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          capabilities:
+            drop:
+            - "ALL"
+        volumeMounts:
+        - name: tls
+          mountPath: /var/tls
+          readOnly: true
+        - name: config
+          mountPath: /etc/etcd-shield/
+          readOnly: true
+      terminationGracePeriodSeconds: 60
+      volumes:
+      - name: tls
+        secret:
+          secretName: etcd-shield-tls
+      - name: config
+        configMap:
+          name: etcd-shield-config

--- a/components/etcd-shield-rd/rings/ring-4/base/base-snapshot/etcd_shield_alerts.yaml
+++ b/components/etcd-shield-rd/rings/ring-4/base/base-snapshot/etcd_shield_alerts.yaml
@@ -1,0 +1,28 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: etcd-shield-triggers
+spec:
+  groups:
+  - name: etcd_shield_triggers
+    interval: 1m
+    rules:
+    - alert: EtcdShieldDenyAdmission
+      expr: etcd_shield_trigger != bool 0
+      for: 2m
+      keep_firing_for: 5m
+      labels:
+        severity: critical
+      annotations:
+        summary: etcd-shield is denying admission
+        description: Etcd is nearing capacity limits, so etcd-shield is denying admission
+    - record: etcd_shield_trigger
+      expr: |
+        (((etcd_mvcc_db_total_size_in_use_in_bytes >= bool (etcd_server_quota_backend_bytes * 0.80)) == 1) or
+            ((((etcd_mvcc_db_total_size_in_use_in_bytes) >= bool (etcd_server_quota_backend_bytes * 0.70)) == 1) and
+                (count without (alertname, alertstate, severity)
+                      (ALERTS{
+                        alertname="EtcdShieldDenyAdmission",
+                        alertstate="firing",
+                        severity="critical"
+                      }) == bool 1)))

--- a/components/etcd-shield-rd/rings/ring-4/base/base-snapshot/kustomization.yaml
+++ b/components/etcd-shield-rd/rings/ring-4/base/base-snapshot/kustomization.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+configMapGenerator:
+  - files:
+      - ./config.yaml
+    name: etcd-shield-config
+# generatorOptions:
+#   # until https://github.com/kubernetes-sigs/kustomize/issues/4475 is fixed
+#   disableNameSuffixHash: true
+images:
+  - name: etcd-shield
+    newName: quay.io/konflux-ci/etcd-shield
+    newTag: 94885d051db284f214f43d76df2f9bd4c9fe993f
+namespace: etcd-shield
+resources:
+  - deployment.yaml
+  - ns.yaml
+  - service.yaml
+  - webhook.yaml
+  - etcd_shield_alerts.yaml
+  - metrics
+  - rbac

--- a/components/etcd-shield-rd/rings/ring-4/base/base-snapshot/metrics/kustomization.yaml
+++ b/components/etcd-shield-rd/rings/ring-4/base/base-snapshot/metrics/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- monitor.yaml
+- serviceaccount.yaml
+- prometheus-crb.yaml
+- metrics-service.yaml
+- monitoring-rb.yaml

--- a/components/etcd-shield-rd/rings/ring-4/base/base-snapshot/metrics/metrics-service.yaml
+++ b/components/etcd-shield-rd/rings/ring-4/base/base-snapshot/metrics/metrics-service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: etcd-shield
+  name: etcd-shield-metrics
+  namespace: etcd-shield
+spec:
+  selector:
+    app: etcd-shield
+  type: ClusterIP
+  ports:
+  - name: metrics
+    targetPort: 9100
+    protocol: TCP
+    port: 9100

--- a/components/etcd-shield-rd/rings/ring-4/base/base-snapshot/metrics/monitor.yaml
+++ b/components/etcd-shield-rd/rings/ring-4/base/base-snapshot/metrics/monitor.yaml
@@ -1,0 +1,26 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: etcd-shield-metrics
+  labels:
+    app: etcd-shield
+spec:
+  endpoints:
+    - interval: 15s
+      scheme: https
+      path: /metrics
+      port: metrics
+      authorization:
+        credentials:
+          key: token
+          name: metrics-reader
+      tlsConfig:
+        ca:
+          secret:
+            key: service-ca.crt
+            name: metrics-reader
+            optional: false
+        serverName: etcd-shield.etcd-shield.svc
+  selector:
+    matchLabels:
+      app: etcd-shield

--- a/components/etcd-shield-rd/rings/ring-4/base/base-snapshot/metrics/monitoring-rb.yaml
+++ b/components/etcd-shield-rd/rings/ring-4/base/base-snapshot/metrics/monitoring-rb.yaml
@@ -1,0 +1,33 @@
+# etcd-shield is registered as a core service (the
+# openshift.io/cluster-monitoring label on the namespace), rather than as a
+# user workload. This is necessary because we need access to etcd's metrics to
+# function properly. However, this means openshift's monitoring services can't
+# use the user workload monitoring roles to fetch our metrics (specifically,
+# they need pods, services, and endpoints). This is a bit of a workaround to
+# get prometheus to be able to recognize our metrics endpoints, since I don't
+# know of a better way to do this.
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: monitoring-metrics-reader
+  namespace: etcd-shield
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: etcd-shield-monitor
+subjects:
+- kind: ServiceAccount
+  name: prometheus-k8s
+  namespace: openshift-monitoring
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: etcd-shield-monitor
+  namespace: etcd-shield
+rules:
+- apiGroups: [""]
+  resources: ["pods", "services", "endpoints"]
+  verbs: ["get", "list", "watch"]
+---

--- a/components/etcd-shield-rd/rings/ring-4/base/base-snapshot/metrics/prometheus-crb.yaml
+++ b/components/etcd-shield-rd/rings/ring-4/base/base-snapshot/metrics/prometheus-crb.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: etcd-shield-metrics
+rules:
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: prometheus-etcd-shield-metrics-reader
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: etcd-shield-metrics
+subjects:
+- kind: ServiceAccount
+  name: metrics-reader
+  namespace: etcd-shield
+---

--- a/components/etcd-shield-rd/rings/ring-4/base/base-snapshot/metrics/serviceaccount.yaml
+++ b/components/etcd-shield-rd/rings/ring-4/base/base-snapshot/metrics/serviceaccount.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  annotations:
+    kubernetes.io/service-account.name: metrics-reader
+  name: metrics-reader
+type: kubernetes.io/service-account-token
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: metrics-reader
+  namespace: etcd-shield

--- a/components/etcd-shield-rd/rings/ring-4/base/base-snapshot/ns.yaml
+++ b/components/etcd-shield-rd/rings/ring-4/base/base-snapshot/ns.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: etcd-shield
+  labels:
+    openshift.io/cluster-monitoring: "true"

--- a/components/etcd-shield-rd/rings/ring-4/base/base-snapshot/rbac/authorizer-crb.yaml
+++ b/components/etcd-shield-rd/rings/ring-4/base/base-snapshot/rbac/authorizer-crb.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: etcd-shield-authorizer
+rules:
+- apiGroups: ["authentication.k8s.io"]
+  resources: ["tokenreviews"]
+  verbs: ["create"]
+- apiGroups: ["authorization.k8s.io"]
+  resources: ["subjectaccessreviews"]
+  verbs: ["create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: etcd-shield-authorizer
+subjects:
+- apiGroup: ""
+  kind: ServiceAccount
+  name: etcd-shield
+  namespace: etcd-shield
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: etcd-shield-authorizer
+---

--- a/components/etcd-shield-rd/rings/ring-4/base/base-snapshot/rbac/kustomization.yaml
+++ b/components/etcd-shield-rd/rings/ring-4/base/base-snapshot/rbac/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- serviceaccount.yaml
+- rolebinding.yaml
+- authorizer-crb.yaml
+- monitoring-crb.yaml

--- a/components/etcd-shield-rd/rings/ring-4/base/base-snapshot/rbac/monitoring-crb.yaml
+++ b/components/etcd-shield-rd/rings/ring-4/base/base-snapshot/rbac/monitoring-crb.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: etcd-shield:cluster-monitoring-view
+subjects:
+- apiGroup: ""
+  kind: ServiceAccount
+  name: etcd-shield
+  namespace: etcd-shield
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-monitoring-view

--- a/components/etcd-shield-rd/rings/ring-4/base/base-snapshot/rbac/rolebinding.yaml
+++ b/components/etcd-shield-rd/rings/ring-4/base/base-snapshot/rbac/rolebinding.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: etcd-shield
+  namespace: etcd-shield
+rules:
+- apiGroups: [""]
+  resources: ["configmaps"]
+  verbs: ["get", "list", "watch", "create", "update", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: etcd-shield
+subjects:
+- apiGroup: ""
+  kind: ServiceAccount
+  name: etcd-shield
+  namespace: etcd-shield
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: etcd-shield
+---

--- a/components/etcd-shield-rd/rings/ring-4/base/base-snapshot/rbac/serviceaccount.yaml
+++ b/components/etcd-shield-rd/rings/ring-4/base/base-snapshot/rbac/serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: etcd-shield
+  namespace: etcd-shield

--- a/components/etcd-shield-rd/rings/ring-4/base/base-snapshot/service.yaml
+++ b/components/etcd-shield-rd/rings/ring-4/base/base-snapshot/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: etcd-shield-tls
+  name: etcd-shield
+spec:
+  ports:
+  - port: 443
+    protocol: TCP
+    targetPort: 8443
+  selector:
+    app: etcd-shield

--- a/components/etcd-shield-rd/rings/ring-4/base/base-snapshot/webhook.yaml
+++ b/components/etcd-shield-rd/rings/ring-4/base/base-snapshot/webhook.yaml
@@ -1,0 +1,26 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  annotations:
+    service.beta.openshift.io/inject-cabundle: 'true'
+  name: etcd-shield-validating-webhook-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: etcd-shield
+      namespace: etcd-shield
+      path: /validate-resource
+  failurePolicy: Fail
+  name: vpipelineruns.konflux-ci.dev
+  rules:
+  - apiGroups:
+    - tekton.dev
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    resources:
+    - pipelineruns
+  sideEffects: None

--- a/components/etcd-shield-rd/rings/ring-4/base/kustomization.yaml
+++ b/components/etcd-shield-rd/rings/ring-4/base/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - base-snapshot
+
+patches:
+  - target:
+      kind: PrometheusRule
+      name: etcd-shield-triggers
+    path: prometheus-rule-severity-patch.yaml

--- a/components/etcd-shield-rd/rings/ring-4/base/prometheus-rule-severity-patch.yaml
+++ b/components/etcd-shield-rd/rings/ring-4/base/prometheus-rule-severity-patch.yaml
@@ -1,0 +1,3 @@
+- op: replace
+  path: /spec/groups/0/rules/0/labels/severity
+  value: warning

--- a/components/etcd-shield-rd/rings/ring-4/kflux-prd-rh02/kustomization.yaml
+++ b/components/etcd-shield-rd/rings/ring-4/kflux-prd-rh02/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../base


### PR DESCRIPTION
### Summary of Changes
* Created a new ApplicationSet to take ownership of the etcd-shield resources on the new ArgoCD production instance on kflux-c-prd-i01
* Added the missing ring folders to the etcd-shield-rd component

### Risk Level
**Risk Level**: Medium
**Reasoning**: No new component resources are being created; the new ApplicationSet references the etcd-shield-rd/ directory, which is only a restructuring of the existing etcd-shield/ directory.
**Rollback Strategy**: Do a manual sync for the original etcd-shield ApplicationSet, as it references the original structuring of etcd-shield.