### PR TITLE
feat: add gitlab token secret

### DIFF
--- a/components/konflux-ci/production/kflux-prd-rh03/e2e-tests-gitlab-token.yaml
+++ b/components/konflux-ci/production/kflux-prd-rh03/e2e-tests-gitlab-token.yaml
@@ -1,0 +1,19 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: e2e-tests-gitlab-token
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  dataFrom:
+    - extract:
+        key: production/build/tekton-ci/e2e-tests-gitlab-token
+  refreshInterval: 15m
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: appsre-stonesoup-vault
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    name: e2e-tests-gitlab-token

--- a/components/konflux-ci/production/kflux-prd-rh03/kustomization.yaml
+++ b/components/konflux-ci/production/kflux-prd-rh03/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
 - e2e-tests-quay-token.yaml
 - cleanup-cronjob.yaml
 - upgrade-sa-token.yaml
+- e2e-tests-gitlab-token.yaml
 
 patches:
   - path: quay-push-secret-konflux-ci.yaml


### PR DESCRIPTION
this secret is needed for running additional e2e-tests scenario added with [this PR ](https://github.com/konflux-ci/build-definitions/pull/3726) on build-definitions repo

Part of the story: https://redhat.atlassian.net/browse/STONEBLD-4868

## Risk Assessment 
**Risk Level:** Low
**Description:** This PR adds an ExternalSecret resource to fetch a GitLab token from Vault for e2e tests in the kflux-prd-rh03 environment. The risk is low as it's an additive change for a non-critical test component, using a standard and secure secret management pattern.
**Rollback:** Revert this PR to remove the ExternalSecret definition and its corresponding Kubernetes Secret.
