### PR TITLE
PVO11Y-5365 Add Tekton Prometheus Grafana datasource to production

### DIFF
--- a/argo-cd-apps/base/all-clusters/infra-deployments/monitoring-workload-grafana/monitoring-workload-grafana.yaml
+++ b/argo-cd-apps/base/all-clusters/infra-deployments/monitoring-workload-grafana/monitoring-workload-grafana.yaml
@@ -19,6 +19,10 @@ spec:
                   values.clusterDir: stone-stage-p01
                 - nameNormalized: stone-stg-rh01
                   values.clusterDir: stone-stg-rh01
+                - nameNormalized: stone-prod-p01
+                  values.clusterDir: stone-prod-p01
+                - nameNormalized: kflux-prd-rh02
+                  values.clusterDir: kflux-prd-rh02
   template:
     metadata:
       name: monitoring-workload-grafana-{{nameNormalized}}

--- a/components/monitoring/grafana/production/kflux-prd-rh02/kustomization.yaml
+++ b/components/monitoring/grafana/production/kflux-prd-rh02/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../base
+  - ../tekton-ms-datasource

--- a/components/monitoring/grafana/production/stone-prod-p01/kustomization.yaml
+++ b/components/monitoring/grafana/production/stone-prod-p01/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../base
+  - ../tekton-ms-datasource

--- a/components/monitoring/grafana/production/tekton-ms-datasource/kustomization.yaml
+++ b/components/monitoring/grafana/production/tekton-ms-datasource/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - tekton-ms-datasource.yaml

--- a/components/monitoring/grafana/production/tekton-ms-datasource/tekton-ms-datasource.yaml
+++ b/components/monitoring/grafana/production/tekton-ms-datasource/tekton-ms-datasource.yaml
@@ -1,0 +1,30 @@
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDatasource
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+  name: prometheus-tekton-ms-ds
+  namespace: appstudio-grafana
+spec:
+  valuesFrom:
+    - targetPath: "secureJsonData.httpHeaderValue1"
+      valueFrom:
+        secretKeyRef:
+          name: "metrics-reader"
+          key: "token"
+  instanceSelector:
+    matchLabels:
+      dashboards: "appstudio-grafana"
+  datasource:
+    access: proxy
+    editable: true
+    isDefault: false
+    jsonData:
+      httpHeaderName1: "Authorization"
+      timeInterval: 5s
+      tlsSkipVerify: true
+    name: prometheus-tekton-ms-ds
+    secureJsonData:
+      httpHeaderValue1: "Bearer ${token}"
+    type: prometheus
+    url: 'https://tekton-ms-kube-rbac-proxy.appstudio-tekton.svc:9091'


### PR DESCRIPTION
## Summary

Add the Tekton Prometheus Grafana datasource (`prometheus-tekton-ms-ds`) to production ring 1 clusters (stone-prod-p01, kflux-prd-rh02). Creates per-cluster Grafana overlays that include the datasource, and adds these clusters to the ApplicationSet list generator. All other production clusters continue using the default `base/` overlay unchanged.

Remaining clusters will follow after confirming the datasource works correctly.

## Risk Assessment

- **Level:** Low
- **Description:** Adds a new Grafana datasource to 2 production clusters. Existing datasources and dashboards are unaffected. Uses the same `metrics-reader` SA token already in place.
- **Rollback:** Remove the per-cluster overlay dirs and revert the ApplicationSet list entries.

## Validation

- Same datasource config validated in staging since March 2026
- `kustomize build` verified: tekton-ms datasource present on ring 1 clusters, absent on others