### PR TITLE
PVO11Y-5365 Add Tekton Prometheus Grafana datasource to remaining production clusters (ring 2)

### DIFF
--- a/argo-cd-apps/base/all-clusters/infra-deployments/monitoring-workload-grafana/monitoring-workload-grafana.yaml
+++ b/argo-cd-apps/base/all-clusters/infra-deployments/monitoring-workload-grafana/monitoring-workload-grafana.yaml
@@ -23,6 +23,22 @@ spec:
                   values.clusterDir: stone-prod-p01
                 - nameNormalized: kflux-prd-rh02
                   values.clusterDir: kflux-prd-rh02
+                - nameNormalized: stone-prd-rh01
+                  values.clusterDir: stone-prd-rh01
+                - nameNormalized: stone-prod-p02
+                  values.clusterDir: stone-prod-p02
+                - nameNormalized: kflux-ocp-p01
+                  values.clusterDir: kflux-ocp-p01
+                - nameNormalized: kflux-prd-rh03
+                  values.clusterDir: kflux-prd-rh03
+                - nameNormalized: kflux-rhel-p01
+                  values.clusterDir: kflux-rhel-p01
+                - nameNormalized: kflux-osp-p01
+                  values.clusterDir: kflux-osp-p01
+                - nameNormalized: kflux-fedora-01
+                  values.clusterDir: kflux-fedora-01
+                - nameNormalized: kflux-prd-es01
+                  values.clusterDir: kflux-prd-es01
   template:
     metadata:
       name: monitoring-workload-grafana-{{nameNormalized}}

--- a/components/monitoring/grafana/production/kflux-fedora-01/kustomization.yaml
+++ b/components/monitoring/grafana/production/kflux-fedora-01/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../base
+  - ../tekton-ms-datasource

--- a/components/monitoring/grafana/production/kflux-ocp-p01/kustomization.yaml
+++ b/components/monitoring/grafana/production/kflux-ocp-p01/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../base
+  - ../tekton-ms-datasource

--- a/components/monitoring/grafana/production/kflux-osp-p01/kustomization.yaml
+++ b/components/monitoring/grafana/production/kflux-osp-p01/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../base
+  - ../tekton-ms-datasource

--- a/components/monitoring/grafana/production/kflux-prd-es01/kustomization.yaml
+++ b/components/monitoring/grafana/production/kflux-prd-es01/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../base

--- a/components/monitoring/grafana/production/kflux-prd-rh03/kustomization.yaml
+++ b/components/monitoring/grafana/production/kflux-prd-rh03/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../base
+  - ../tekton-ms-datasource

--- a/components/monitoring/grafana/production/kflux-rhel-p01/kustomization.yaml
+++ b/components/monitoring/grafana/production/kflux-rhel-p01/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../base
+  - ../tekton-ms-datasource

--- a/components/monitoring/grafana/production/stone-prd-rh01/kustomization.yaml
+++ b/components/monitoring/grafana/production/stone-prd-rh01/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../base
+  - ../tekton-ms-datasource

--- a/components/monitoring/grafana/production/stone-prod-p02/kustomization.yaml
+++ b/components/monitoring/grafana/production/stone-prod-p02/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../base
+  - ../tekton-ms-datasource


### PR DESCRIPTION
## Summary

Deploy per-cluster Grafana overlays with the tekton-ms datasource to all remaining production clusters after ring 1 validation. kflux-prd-es01 gets base only (no OpenShift Pipelines).

**Depends on:** #13192 (ring 1)

## Risk Assessment

- **Level:** Low
- **Description:** Same datasource config as ring 1, validated on stone-prod-p01 and kflux-prd-rh02.
- **Rollback:** Remove the per-cluster overlay dirs and revert the ApplicationSet list entries.

## Validation

- Ring 1 validated on stone-prod-p01 and kflux-prd-rh02