### PR TITLE
PVO11Y-5365 Update production pipeline-service dashboard to use Tekton Prometheus datasource

### DIFF
--- a/components/monitoring/grafana/production/dashboards/pipeline-service/grafana-config.yaml
+++ b/components/monitoring/grafana/production/dashboards/pipeline-service/grafana-config.yaml
@@ -409,6 +409,7 @@ data:
             "wideLayout": true
           },
           "pluginVersion": "10.4.3",
+          "datasource": "prometheus-tekton-ms-ds",
           "targets": [
             {
               "editorMode": "code",
@@ -552,6 +553,7 @@ data:
               "spaceLength": 10,
               "stack": true,
               "steppedLine": false,
+              "datasource": "prometheus-tekton-ms-ds",
               "targets": [
                 {
                   "exemplar": true,
@@ -641,6 +643,7 @@ data:
                 "textMode": "auto"
               },
               "pluginVersion": "9.1.6",
+              "datasource": "prometheus-tekton-ms-ds",
               "targets": [
                 {
                   "exemplar": true,
@@ -715,6 +718,7 @@ data:
               "spaceLength": 10,
               "stack": true,
               "steppedLine": false,
+              "datasource": "prometheus-tekton-ms-ds",
               "targets": [
                 {
                   "exemplar": true,
@@ -803,6 +807,7 @@ data:
                 "textMode": "auto"
               },
               "pluginVersion": "9.1.6",
+              "datasource": "prometheus-tekton-ms-ds",
               "targets": [
                 {
                   "exemplar": true,
@@ -1075,6 +1080,7 @@ data:
                 "textMode": "auto"
               },
               "pluginVersion": "9.1.6",
+              "datasource": "prometheus-tekton-ms-ds",
               "targets": [
                 {
                   "exemplar": true,
@@ -1133,6 +1139,7 @@ data:
                 "textMode": "auto"
               },
               "pluginVersion": "9.1.6",
+              "datasource": "prometheus-tekton-ms-ds",
               "targets": [
                 {
                   "exemplar": true,
@@ -1302,6 +1309,7 @@ data:
                 }
               },
               "pluginVersion": "7.5.17",
+              "datasource": "prometheus-tekton-ms-ds",
               "targets": [
                 {
                   "exemplar": true,
@@ -1354,6 +1362,7 @@ data:
               "spaceLength": 10,
               "stack": false,
               "steppedLine": false,
+              "datasource": "prometheus-tekton-ms-ds",
               "targets": [
                 {
                   "exemplar": true,
@@ -1469,6 +1478,7 @@ data:
                 }
               },
               "pluginVersion": "7.5.17",
+              "datasource": "prometheus-tekton-ms-ds",
               "targets": [
                 {
                   "exemplar": true,
@@ -1543,6 +1553,7 @@ data:
                 "text": {}
               },
               "pluginVersion": "9.1.6",
+              "datasource": "prometheus-tekton-ms-ds",
               "targets": [
                 {
                   "exemplar": true,
@@ -1661,6 +1672,7 @@ data:
                 "text": {}
               },
               "pluginVersion": "9.1.6",
+              "datasource": "prometheus-tekton-ms-ds",
               "targets": [
                 {
                   "exemplar": true,
@@ -1720,6 +1732,7 @@ data:
                 "text": {}
               },
               "pluginVersion": "9.1.6",
+              "datasource": "prometheus-tekton-ms-ds",
               "targets": [
                 {
                   "exemplar": true,
@@ -1779,6 +1792,7 @@ data:
                 "text": {}
               },
               "pluginVersion": "9.1.6",
+              "datasource": "prometheus-tekton-ms-ds",
               "targets": [
                 {
                   "exemplar": true,
@@ -1838,6 +1852,7 @@ data:
                 "text": {}
               },
               "pluginVersion": "9.1.6",
+              "datasource": "prometheus-tekton-ms-ds",
               "targets": [
                 {
                   "exemplar": true,
@@ -1890,6 +1905,7 @@ data:
               "spaceLength": 10,
               "stack": false,
               "steppedLine": false,
+              "datasource": "prometheus-tekton-ms-ds",
               "targets": [
                 {
                   "exemplar": true,
@@ -1969,6 +1985,7 @@ data:
               "spaceLength": 10,
               "stack": false,
               "steppedLine": false,
+              "datasource": "prometheus-tekton-ms-ds",
               "targets": [
                 {
                   "exemplar": true,


### PR DESCRIPTION
## Summary

Sync the production pipeline-service Grafana dashboard with staging so panels querying tekton pipeline controller metrics use the dedicated `prometheus-tekton-ms-ds` datasource instead of the federation Prometheus datasource.

**Depends on:** #13192 (Grafana datasource ring 1)

## Risk Assessment

- **Level:** Low
- **Description:** Dashboard config change only. Panels that query tekton metrics will read from the dedicated Tekton Prometheus instead of the federation Prometheus. Both currently have the same data.
- **Rollback:** Revert the dashboard config to the previous version.

## Validation

- Staging dashboard using tekton-ms datasource since March 2026
- Dashboard diff is 17 added `"datasource": "prometheus-tekton-ms-ds"` lines