### PR TITLE
PVO11Y-5365 Drop tekton controller metrics from Platform Prometheus in production

### DIFF
--- a/components/monitoring/prometheus/production/tekton-ms/kustomization.yaml
+++ b/components/monitoring/prometheus/production/tekton-ms/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
   - kube-rbac-proxy.yaml
   - networkpolicy.yaml
   - external-secrets/
+  - openshift-pipelines-monitor-drop-tekton-controller.yaml
 
 patches:
   - path: remote-write-env-details.yaml

--- a/components/monitoring/prometheus/production/tekton-ms/openshift-pipelines-monitor-drop-tekton-controller.yaml
+++ b/components/monitoring/prometheus/production/tekton-ms/openshift-pipelines-monitor-drop-tekton-controller.yaml
@@ -1,0 +1,16 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: openshift-pipelines-monitor
+  namespace: openshift-pipelines
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  endpoints:
+  - honorLabels: true
+    interval: 10s
+    port: http-metrics
+    metricRelabelings:
+    - action: drop
+      sourceLabels: [__name__]
+      regex: 'tekton_pipelines_controller_.*'


### PR DESCRIPTION
## Summary

Add `openshift-pipelines-monitor-drop-tekton-controller.yaml` to the production tekton-ms overlay. This ServiceMonitor tells Platform Prometheus to drop all `tekton_pipelines_controller_*` metrics, eliminating duplicate scraping now that the dedicated Tekton Prometheus handles them.

**Do not merge until:**
- Grafana datasource deployed to all production clusters (#13193)
- Pipeline-service dashboard updated to use tekton-ms datasource (#13194)
- Confirmed that Tekton Prometheus is serving metrics correctly on all clusters

## Risk Assessment

- **Level:** Medium
- **Description:** After this merges, tekton controller metrics will only be available from the Tekton Prometheus datasource, not the federation Prometheus. Any dashboard or alert still querying the old datasource for these metrics will break.
- **Rollback:** Remove the ServiceMonitor resource from the production tekton-ms kustomization.

## Validation

- Same metric drop validated in staging since March 2026
- Tekton Prometheus running on all production clusters for 10+ days