### PR TITLE
RELEASE-2681: add ExternalSecret for release-service-github-token

### DIFF
--- a/components/release/staging/external-secrets/release-service-github-token.yaml
+++ b/components/release/staging/external-secrets/release-service-github-token.yaml
@@ -1,0 +1,22 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: release-service-github-token
+  namespace: release-service
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  data:
+    - secretKey: token
+      remoteRef:
+        key: release/github/konflux-release-service
+        property: token
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: appsre-stonesoup-vault
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    name: release-service-github-token

--- a/components/release/staging/kustomization.yaml
+++ b/components/release/staging/kustomization.yaml
@@ -4,6 +4,7 @@ resources:
   - ../base
   - ../base/monitor/staging
   - external-secrets/release-monitor-secret.yaml
+  - external-secrets/release-service-github-token.yaml
   - https://github.com/konflux-ci/release-service/config/default?ref=f3ac0e4aa928ff7c4fdac1846de3268afd9c9ae5
   - release_service_config.yaml
   - signing_configs.yaml


### PR DESCRIPTION
## Summary
Adds ExternalSecret so release-service controllers get `GITHUB_TOKEN` from Vault for branch→SHA resolution ([RELEASE-2681](https://redhat.atlassian.net/browse/RELEASE-2681)).
## Vault
- Path: `release/github/konflux-release-service`
- Property: `token`
- Store: `appsre-stonesoup-vault`
## K8s
- Secret: `release-service-github-token` / key `token`
- Namespace: `release-service`
- Staging + production overlays (all release ApplicationSet clusters)
## Related
- Code PR: https://github.com/konflux-ci/release-service/pull/1753

[RELEASE-2681]: https://redhat.atlassian.net/browse/RELEASE-2681?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ