### PR TITLE
Externalize MPC embedded scripts - KFLUXINFRA-4159 Prod - Ring2

### DIFF
--- a/components/multi-platform-controller/base/host-config-chart/files/linux-g64xlarge-amd64-init.sh
+++ b/components/multi-platform-controller/base/host-config-chart/files/linux-g64xlarge-amd64-init.sh
@@ -1,22 +1,3 @@
-Content-Type: multipart/mixed; boundary="//"
-MIME-Version: 1.0
-
---//
-Content-Type: text/cloud-config; charset="us-ascii"
-MIME-Version: 1.0
-Content-Transfer-Encoding: 7bit
-Content-Disposition: attachment; filename="cloud-config.txt"
-
-#cloud-config
-cloud_final_modules:
-  - [scripts-user, always]
-
---//
-Content-Type: text/x-shellscript; charset="us-ascii"
-MIME-Version: 1.0
-Content-Transfer-Encoding: 7bit
-Content-Disposition: attachment; filename="userdata.txt"
-
 #!/bin/bash
 
 set -xeuo pipefail
@@ -24,7 +5,7 @@ set -xeuo pipefail
 configure_nvidia_cdi() {
   # generate Nvdia CDI with retry
   for i in {1..10}; do
-    su - ec2-user -c 'nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml'
+    su - ec2-user -c 'nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml' 
     su - ec2-user -c 'nvidia-ctk cdi generate --output=/var/run/cdi/nvidia.yaml'
 
     # expect nvidia.com/gpu=all device to be in the generated list
@@ -51,7 +32,8 @@ mkdir -p /home/var-lib-containers /var/lib/containers /home/var-tmp /var/tmp /ho
 # Setup bind mounts
 mount --bind /home/var-lib-containers /var/lib/containers
 mount --bind /home/var-tmp /var/tmp
-chmod a+rw /var/tmp
+chmod 1777 /home/var-tmp /var/tmp
+chown root:root /home/var-tmp /var/tmp
 restorecon -r /var/lib/containers /var/tmp
 
 # GPU setup
@@ -69,4 +51,3 @@ chown ec2-user /home/ec2-user/.ssh/authorized_keys
 chmod 600 /home/ec2-user/.ssh/authorized_keys
 chmod 700 /home/ec2-user/.ssh
 restorecon -r /home/ec2-user
---//--

--- a/components/multi-platform-controller/base/host-config-chart/files/linux-g6xlarge-amd64-init.sh
+++ b/components/multi-platform-controller/base/host-config-chart/files/linux-g6xlarge-amd64-init.sh
@@ -1,23 +1,24 @@
-Content-Type: multipart/mixed; boundary="//"
-MIME-Version: 1.0
+#!/bin/bash
 
---//
-Content-Type: text/cloud-config; charset="us-ascii"
-MIME-Version: 1.0
-Content-Transfer-Encoding: 7bit
-Content-Disposition: attachment; filename="cloud-config.txt"
+set -xeuo pipefail
 
-#cloud-config
-cloud_final_modules:
-  - [scripts-user, always]
-
---//
-Content-Type: text/x-shellscript; charset="us-ascii"
-MIME-Version: 1.0
-Content-Transfer-Encoding: 7bit
-Content-Disposition: attachment; filename="userdata.txt"
-
-#!/bin/bash -ex
+configure_nvidia_cdi() {
+  # generate Nvdia CDI with retry
+  for i in {1..10}; do
+    su - ec2-user -c 'nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml'
+    su - ec2-user -c 'nvidia-ctk cdi generate --output=/var/run/cdi/nvidia.yaml'
+    # expect nvidia.com/gpu=all device to be in the generated list
+    if nvidia-ctk cdi list 2>/dev/null | grep -q 'nvidia.com/gpu=all'; then
+      echo "Nvidia CDI Ready"
+      return 0
+    fi
+    # sleep only if we'll be retrying again
+    [ "${i}" -lt "10" ] && sleep 1
+  done
+  
+  echo "Nvidia CDI Failed"
+  return 1
+}
 
 # Format and mount NVMe disk
 mkfs -t xfs /dev/nvme1n1
@@ -29,16 +30,17 @@ mkdir -p /home/var-lib-containers /var/lib/containers /home/var-tmp /var/tmp /ho
 # Setup bind mounts
 mount --bind /home/var-lib-containers /var/lib/containers
 mount --bind /home/var-tmp /var/tmp
-chmod a+rw /var/tmp
+chmod 1777 /home/var-tmp /var/tmp
+chown root:root /home/var-tmp /var/tmp
 restorecon -r /var/lib/containers /var/tmp
 
 # GPU setup
 mkdir -p /etc/cdi /var/run/cdi
 chmod a+rwx /etc/cdi /var/run/cdi
 setsebool container_use_devices 1 2>/dev/null || true
-su - ec2-user
-nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml
+configure_nvidia_cdi
 chmod a+rw /etc/cdi/nvidia.yaml
+chmod a+rw /var/run/cdi/nvidia.yaml
 
 # Configure ec2-user SSH access
 chown -R ec2-user /home/ec2-user
@@ -47,4 +49,3 @@ chown ec2-user /home/ec2-user/.ssh/authorized_keys
 chmod 600 /home/ec2-user/.ssh/authorized_keys
 chmod 700 /home/ec2-user/.ssh
 restorecon -r /home/ec2-user
---//--

--- a/components/multi-platform-controller/base/host-config-chart/files/linux-root-amd64-init.sh
+++ b/components/multi-platform-controller/base/host-config-chart/files/linux-root-amd64-init.sh
@@ -1,22 +1,3 @@
-Content-Type: multipart/mixed; boundary="//"
-MIME-Version: 1.0
-
---//
-Content-Type: text/cloud-config; charset="us-ascii"
-MIME-Version: 1.0
-Content-Transfer-Encoding: 7bit
-Content-Disposition: attachment; filename="cloud-config.txt"
-
-#cloud-config
-cloud_final_modules:
-  - [scripts-user, always]
-
---//
-Content-Type: text/x-shellscript; charset="us-ascii"
-MIME-Version: 1.0
-Content-Transfer-Encoding: 7bit
-Content-Disposition: attachment; filename="userdata.txt"
-
 #!/bin/bash -ex
 
 # Format and mount NVMe disk
@@ -40,5 +21,3 @@ chown ec2-user /home/ec2-user/.ssh/authorized_keys
 chmod 600 /home/ec2-user/.ssh/authorized_keys
 chmod 700 /home/ec2-user/.ssh
 restorecon -r /home/ec2-user
-
---//--

--- a/components/multi-platform-controller/base/host-config-chart/files/linux-test-amd64-init.sh
+++ b/components/multi-platform-controller/base/host-config-chart/files/linux-test-amd64-init.sh
@@ -12,6 +12,7 @@ mount --bind /home/var-lib-containers /var/lib/containers
 mount --bind /home/var-tmp /var/tmp
 chmod 1777 /home/var-tmp /var/tmp
 chown root:root /home/var-tmp /var/tmp
+
 restorecon -r /var/lib/containers /var/tmp
 
 # Configure ec2-user SSH access

--- a/components/multi-platform-controller/base/host-config-chart/files/macos-mac2metal-arm64-init.sh
+++ b/components/multi-platform-controller/base/host-config-chart/files/macos-mac2metal-arm64-init.sh
@@ -1,46 +1,46 @@
 #!/bin/bash
-set -eu
+set -euo pipefail
 set -x
 
 user="konflux-builder"
 
 # Check if user already exists
 if ! id "$user" &>/dev/null; then
-    # Generate random password
+    # Suppress xtrace to avoid leaking password in logs
+    set +x
     random_password=$(openssl rand -base64 32)
-
     # Create user
-    sudo sysadminctl -addUser "$user" -fullName "Konflux Builder" -password "$random_password" -home /Users/$user
-
+    sudo sysadminctl -addUser "$user" -fullName "Konflux Builder" -password "$random_password" -home /Users/"$user"
     # Clear password from variable
     unset random_password
+    set -x
 else
     echo "User $user already exists, skipping user creation"
 fi
 
 # Create home directory if it doesn't exist
-sudo mkdir -p /Users/$user
+sudo mkdir -p /Users/"$user"
 
 # Create SSH directory
-sudo mkdir -p /Users/$user/.ssh
+sudo mkdir -p /Users/"$user"/.ssh
 
 # Remove existing SSH keys if they exist
-sudo rm -f /Users/$user/.ssh/id_rsa /Users/$user/.ssh/id_rsa.pub
+sudo rm -f /Users/"$user"/.ssh/id_rsa /Users/"$user"/.ssh/id_rsa.pub
 
 # Generate new SSH keys
-sudo ssh-keygen -t rsa -b 4096 -f /Users/$user/.ssh/id_rsa -N "" -C ""
+sudo ssh-keygen -t rsa -b 4096 -f /Users/"$user"/.ssh/id_rsa -N "" -C ""
 
 # Set proper permissions on .ssh directory
-sudo chmod 700 /Users/$user/.ssh
+sudo chmod 700 /Users/"$user"/.ssh
 
 # Create/overwrite authorized_keys
-sudo chmod 600 /Users/$user/.ssh/authorized_keys 2>/dev/null || true
-sudo cat /Users/$user/.ssh/id_rsa.pub | sudo tee /Users/$user/.ssh/authorized_keys > /dev/null
-sudo cat /Users/$user/.ssh/id_rsa | sudo tee /Users/ec2-user/$user > /dev/null
+sudo chmod 600 /Users/"$user"/.ssh/authorized_keys 2>/dev/null || true
+sudo cat /Users/"$user"/.ssh/id_rsa.pub | sudo tee /Users/"$user"/.ssh/authorized_keys > /dev/null
+sudo cat /Users/"$user"/.ssh/id_rsa | sudo tee /Users/ec2-user/"$user" > /dev/null
 
 # Set ownership of entire home directory to ensure user has full control
-sudo chown -R $user:staff /Users/$user
+sudo chown -R "$user":staff /Users/"$user"
 
 # Set ownership of the copied private key to ec2-user
-sudo chown ec2-user:staff /Users/ec2-user/$user
-sudo chmod 600 /Users/ec2-user/$user
+sudo chown ec2-user:staff /Users/ec2-user/"$user"
+sudo chmod 600 /Users/ec2-user/"$user"

--- a/components/multi-platform-controller/base/host-config-chart/templates/_cloud-init-userdata.tpl
+++ b/components/multi-platform-controller/base/host-config-chart/templates/_cloud-init-userdata.tpl
@@ -1,0 +1,23 @@
+{{- define "multi-platform-controller.cloud-init-userdata" -}}
+Content-Type: multipart/mixed; boundary="//"
+MIME-Version: 1.0
+
+--//
+Content-Type: text/cloud-config; charset="us-ascii"
+MIME-Version: 1.0
+Content-Transfer-Encoding: 7bit
+Content-Disposition: attachment; filename="cloud-config.txt"
+
+#cloud-config
+cloud_final_modules:
+  - [scripts-user, always]
+
+--//
+Content-Type: text/x-shellscript; charset="us-ascii"
+MIME-Version: 1.0
+Content-Transfer-Encoding: 7bit
+Content-Disposition: attachment; filename="userdata.txt"
+
+{{ . }}
+--//--
+{{- end -}}

--- a/components/multi-platform-controller/base/host-config-chart/templates/_windows-init.ps1.tpl
+++ b/components/multi-platform-controller/base/host-config-chart/templates/_windows-init.ps1.tpl
@@ -28,22 +28,13 @@ function Wait-Folder {
 # ---------------------
 # Docker Installation
 # ---------------------
-Invoke-WebRequest -UseBasicParsing "https://raw.githubusercontent.com/microsoft/Windows-Containers/Main/helpful_tools/Install-DockerCE/install-docker-ce.ps1" -o install-docker-ce.ps1
+Invoke-WebRequest -UseBasicParsing "https://raw.githubusercontent.com/microsoft/Windows-Containers/Main/helpful_tools/Install-DockerCE/install-docker-ce.ps1" -OutFile install-docker-ce.ps1
 .\install-docker-ce.ps1
 
 # ---------------------------------------------------
-# OpenSSH Verification
+# OpenSSH Installation (service started at end of script)
 # ---------------------------------------------------
-# OpenSSH Server is pre-installed on Windows Server 2025.
-# Verify it exists before proceeding.
-if (-not (Get-Service sshd -ErrorAction SilentlyContinue)) {
-  Write-Error "sshd service not found. This script requires a Windows Server 2025 AMI."
-  exit 1
-}
-
-# Start the sshd service and set it to start automatically
-Start-Service sshd
-Set-Service -Name sshd -StartupType 'Automatic'
+Add-WindowsCapability -Online -Name OpenSSH.Server~~~~0.0.1.0
 
 # -------------------------------
 # User Creation & Profile Setup
@@ -342,8 +333,8 @@ Write-Host "Scoop installed successfully!"
 # OpenSSH Administrator Configuration & Service Start
 # ---------------------------------------------------
 {{- $addresses := (list) }}
-{{- range $entry := (index . "allowed-remote-addresses" | required "Allowed remote addresses for the SSH firewall must be specified") }}
-    {{- $addresses = (squote $entry | append $addresses) }}
+{{- range $entry := (index . "allowed-remote-addresses" | required "Remote addresses for the SSH FW must be specified") }}
+    {{- $addresses = append $addresses (squote $entry) }}
 {{- end }}
 Remove-NetFirewallRule -Name 'OpenSSH-Server-In-TCP' -ErrorAction SilentlyContinue
 New-NetFirewallRule -Name 'OpenSSH-Server-In-TCP' `
@@ -356,28 +347,14 @@ New-NetFirewallRule -Name 'OpenSSH-Server-In-TCP' `
     -RemoteAddress {{ join "," $addresses }} | Out-Null
 
 # Get public key from AWS Instance Metadata Service (IMDSv2)
-# IMDS may not be reachable immediately during early boot, so retry.
 $MAGIC_IP = "169.254.169.254"
-$maxRetries = 30
-$PUBKEY = $null
-for ($i = 1; $i -le $maxRetries; $i++) {
-  try {
-    $token = Invoke-RestMethod -Uri "http://${MAGIC_IP}/latest/api/token" `
-      -Method 'PUT' -Headers @{'X-aws-ec2-metadata-token-ttl-seconds' = '21600'} `
-      -TimeoutSec 5 -ErrorAction Stop
-    $PUBKEY = Invoke-RestMethod -Uri "http://${MAGIC_IP}/latest/meta-data/public-keys/0/openssh-key" `
-      -Headers @{'X-aws-ec2-metadata-token' = $token} `
-      -TimeoutSec 5 -ErrorAction Stop
-    break
-  } catch {
-    Write-Host "IMDS request failed (attempt $i/$maxRetries): $_"
-    if ($i -eq $maxRetries) {
-      Write-Error "Failed to retrieve SSH public key from IMDS after $maxRetries attempts. Exiting."
-      exit 1
-    }
-    Start-Sleep -Seconds 2
-  }
-}
+$IMDS_TOKEN = Invoke-RestMethod -Uri "http://${MAGIC_IP}/latest/api/token" `
+    -Method 'PUT' `
+    -Headers @{'X-aws-ec2-metadata-token-ttl-seconds' = '21600'}
+$PUBKEY = Invoke-RestMethod -Uri "http://${MAGIC_IP}/latest/meta-data/public-keys/0/openssh-key" `
+    -Headers @{'X-aws-ec2-metadata-token' = $IMDS_TOKEN}
+
+Start-Sleep 5
 
 # Configure SSH authorized_keys for Administrator
 $SSH_PATH = "C:\ProgramData\ssh"
@@ -405,7 +382,8 @@ $Ar = New-Object System.Security.AccessControl.FileSystemAccessRule(
 $ACL.SetAccessRule($Ar)
 Set-Acl "$SSH_PATH\administrators_authorized_keys" $ACL
 
-Restart-Service sshd
+Start-Service sshd
+Set-Service -Name sshd -StartupType 'Automatic'
 </powershell>
 <persist>true</persist>
 {{- end -}}

--- a/components/multi-platform-controller/base/host-config-chart/templates/host-config.yaml
+++ b/components/multi-platform-controller/base/host-config-chart/templates/host-config.yaml
@@ -527,7 +527,7 @@ data:
     {{ $line }}
   {{- end }}
   {{- else }}
-{{ .Files.Get "files/linux-c6gd2xlarge-arm64-init.sh" | indent 4 }}
+{{ include "multi-platform-controller.cloud-init-userdata" (.Files.Get "files/linux-c6gd2xlarge-arm64-init.sh") | indent 4 }}
   {{- end }}
   {{- end }}
   {{ end }}
@@ -907,12 +907,11 @@ data:
   {{- range $line := $lines }}
     {{ $line }}
   {{- end }}
-  {{- else }}
-{{ .Files.Get "files/linux-g6xlarge-amd64-init.sh" | indent 4 }}
-  {{- end }}
-  {{- end }}
+    {{- else }}
+{{ include "multi-platform-controller.cloud-init-userdata" (.Files.Get "files/linux-g6xlarge-amd64-init.sh") | indent 4 }}
+    {{- end }}
+    {{- end }}
   {{ end }}
-
 
   {{- if hasKey .Values.dynamicConfigs "linux-g64xlarge-amd64" }}
   {{- $config := index .Values.dynamicConfigs "linux-g64xlarge-amd64" | default (dict) }}
@@ -937,7 +936,7 @@ data:
     {{ $line }}
   {{- end }}
   {{- else }}
-{{ .Files.Get "files/linux-g64xlarge-amd64-init.sh" | indent 4 }}
+{{ include "multi-platform-controller.cloud-init-userdata" (.Files.Get "files/linux-g64xlarge-amd64-init.sh") | indent 4 }}
   {{- end }}
   {{- end }}
   {{ end }}
@@ -1001,7 +1000,7 @@ data:
     {{ $line }}
   {{- end }}
   {{- else }}
-{{ .Files.Get "files/linux-root-amd64-init.sh" | indent 4 }}
+{{ include "multi-platform-controller.cloud-init-userdata" (.Files.Get "files/linux-root-amd64-init.sh") | indent 4 }}
   {{- end }}
   {{- end }}
   {{ end }}
@@ -1098,11 +1097,15 @@ data:
   dynamic.linux-test-amd64.check-interval: {{ (index $config "check-interval") | default "60" | quote }}
   dynamic.linux-test-amd64.allocation-timeout: "1200"
   dynamic.linux-test-amd64.sudo-commands: {{ (index $config "sudo-commands") | default "/usr/bin/podman" | quote }}
-  {{- if (index $config "user-data") }}
+  {{- if or (index $config "user-data") (.Files.Get "files/linux-test-amd64-init.sh") }}
   dynamic.linux-test-amd64.user-data: |
+  {{- if (index $config "user-data") }}
   {{- $lines := splitList "\n" (index $config "user-data") }}
   {{- range $line := $lines }}
     {{ $line }}
+  {{- end }}
+  {{- else }}
+{{ include "multi-platform-controller.cloud-init-userdata" (.Files.Get "files/linux-test-amd64-init.sh") | indent 4 }}
   {{- end }}
   {{- end }}
   {{ end }}
@@ -1111,15 +1114,15 @@ data:
   {{- $config := index .Values.dynamicConfigs "linux-test-arm64" | default (dict) }}
   dynamic.linux-test-arm64.type: {{ index $config "type" | default "aws" | quote }}
   dynamic.linux-test-arm64.region: {{ index $config "region" | default "us-east-1" | quote }}
-  dynamic.linux-test-arm64.ami: {{ default (index $amd "ami") $config.ami | quote }}
+  dynamic.linux-test-arm64.ami: {{ default (index $arm "ami") $config.ami | quote }}                                                    
   dynamic.linux-test-arm64.instance-type: {{ (index $config "instance-type") | default "m6g.large" | quote }}
   dynamic.linux-test-arm64.instance-tag: {{ (index $config "instance-tag") | default (printf "%s-arm64-test" $environment) | quote }}
-  dynamic.linux-test-arm64.key-name: {{ default (index $amd "key-name") ((index $config "key-name")) | quote }}
+  dynamic.linux-test-arm64.key-name: {{ default (index $arm "key-name") ((index $config "key-name")) | quote }}
   dynamic.linux-test-arm64.aws-secret: {{ (index $config "aws-secret") | default "aws-account" | quote }}
   dynamic.linux-test-arm64.ssh-secret: {{ (index $config "ssh-secret") | default "aws-ssh-key" | quote }}
-  dynamic.linux-test-arm64.security-group-id: {{ default (index $amd "security-group-id") ((index $config "security-group-id")) | quote }}
+  dynamic.linux-test-arm64.security-group-id: {{ default (index $arm "security-group-id") ((index $config "security-group-id")) | quote }}
   dynamic.linux-test-arm64.max-instances: {{ (index $config "max-instances") | default "250" | quote }}
-  dynamic.linux-test-arm64.subnet-id: {{ default (index $amd "subnet-id") ((index $config "subnet-id")) | quote }}
+  dynamic.linux-test-arm64.subnet-id: {{ default (index $arm "subnet-id") ((index $config "subnet-id")) | quote }}
   dynamic.linux-test-arm64.disk: {{ index $config "disk" | default "200" | quote }}
   dynamic.linux-test-arm64.check-interval: {{ (index $config "check-interval") | default "60" | quote }}
   dynamic.linux-test-arm64.allocation-timeout: "1200"

--- a/components/multi-platform-controller/production-downstream/kflux-ocp-p01/kustomization.yaml
+++ b/components/multi-platform-controller/production-downstream/kflux-ocp-p01/kustomization.yaml
@@ -9,11 +9,11 @@ patches:
 - path: manager_resources_patch.yaml
 
 helmGlobals:
-  chartHome: ../../base
+  chartHome: ../base
 
 helmCharts:
 - name: host-config-chart
   releaseName: host-config
   namespace: multi-platform-controller
-  repo: ../../base
+  repo: ../base
   valuesFile: host-values.yaml

--- a/components/multi-platform-controller/production-downstream/stone-prod-p02/kustomization.yaml
+++ b/components/multi-platform-controller/production-downstream/stone-prod-p02/kustomization.yaml
@@ -8,7 +8,7 @@ resources:
 - external-secrets.yaml
 
 helmGlobals:
-  chartHome: ../../base
+  chartHome: ../base
 
 helmCharts:
 - name: host-config-chart

--- a/components/multi-platform-controller/production/base/host-config-chart/files/linux-g64xlarge-amd64-init.sh
+++ b/components/multi-platform-controller/production/base/host-config-chart/files/linux-g64xlarge-amd64-init.sh
@@ -5,7 +5,7 @@ set -xeuo pipefail
 configure_nvidia_cdi() {
   # generate Nvdia CDI with retry
   for i in {1..10}; do
-    su - ec2-user -c 'nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml' 
+    su - ec2-user -c 'nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml'
     su - ec2-user -c 'nvidia-ctk cdi generate --output=/var/run/cdi/nvidia.yaml'
 
     # expect nvidia.com/gpu=all device to be in the generated list

--- a/components/multi-platform-controller/production/base/host-config-chart/files/linux-g6xlarge-amd64-init.sh
+++ b/components/multi-platform-controller/production/base/host-config-chart/files/linux-g6xlarge-amd64-init.sh
@@ -15,7 +15,7 @@ configure_nvidia_cdi() {
     # sleep only if we'll be retrying again
     [ "${i}" -lt "10" ] && sleep 1
   done
-  
+
   echo "Nvidia CDI Failed"
   return 1
 }

--- a/components/multi-platform-controller/production/base/host-config-chart/templates/host-config.yaml
+++ b/components/multi-platform-controller/production/base/host-config-chart/templates/host-config.yaml
@@ -1114,7 +1114,7 @@ data:
   {{- $config := index .Values.dynamicConfigs "linux-test-arm64" | default (dict) }}
   dynamic.linux-test-arm64.type: {{ index $config "type" | default "aws" | quote }}
   dynamic.linux-test-arm64.region: {{ index $config "region" | default "us-east-1" | quote }}
-  dynamic.linux-test-arm64.ami: {{ default (index $arm "ami") $config.ami | quote }}                                                    
+  dynamic.linux-test-arm64.ami: {{ default (index $arm "ami") $config.ami | quote }}
   dynamic.linux-test-arm64.instance-type: {{ (index $config "instance-type") | default "m6g.large" | quote }}
   dynamic.linux-test-arm64.instance-tag: {{ (index $config "instance-tag") | default (printf "%s-arm64-test" $environment) | quote }}
   dynamic.linux-test-arm64.key-name: {{ default (index $arm "key-name") ((index $config "key-name")) | quote }}

--- a/components/multi-platform-controller/production/kflux-prd-rh02/kustomization.yaml
+++ b/components/multi-platform-controller/production/kflux-prd-rh02/kustomization.yaml
@@ -11,7 +11,7 @@ patches:
   - path: manager_resources_patch.yaml
 
 helmGlobals:
-  chartHome: ../../base
+  chartHome: ../base
 
 helmCharts:
   - name: host-config-chart

--- a/components/multi-platform-controller/production/stone-prd-rh01/kustomization.yaml
+++ b/components/multi-platform-controller/production/stone-prd-rh01/kustomization.yaml
@@ -11,11 +11,11 @@ patches:
   - path: manager_resources_patch.yaml
 
 helmGlobals:
-  chartHome: ../../base
+  chartHome: ../base
 
 helmCharts:
   - name: host-config-chart
     releaseName: host-config
     namespace: multi-platform-controller
-    repo: ../../base
+    repo: ../base
     valuesFile: host-values.yaml


### PR DESCRIPTION
This PR is from https://github.com/redhat-appstudio/infra-deployments/pull/12867 that has been divided in two rings. Ring1 https://github.com/redhat-appstudio/infra-deployments/pull/13051 and in this PR production clusters with higher usage after a week with no issues found. The Clusters included in this PR are:
- kflux-ocp-p01 
- stone-prod-p02 
- flux-prd-rh02 
- stone-prd-rh01

The kustomization configuration for charts on these clusters are using new {production,production-downstream}/base/host-config-chart/{files,templates}, and the  old/current base in multi-platform-controller/base has been updated with the same files/templates as production/base/host-config-chart/{files,templates}

Changes here includes correcting bugs, security and some cosmetic/formatting issues.

## Risk Assessment
High
What could go wrong: This change might impact some VMs in production
Rollback plan: Revert the PR and redeploy. No data migration involved.
Testing: PR Validated in Ring1 with no issues https://github.com/redhat-appstudio/infra-deployments/pull/13051

