### PR TITLE
ci: kustomize build with retries for hack/forbid-clusterpolicies.sh

### DIFF
--- a/.github/workflows/forbid-clusterpolicies.yaml
+++ b/.github/workflows/forbid-clusterpolicies.yaml
@@ -6,6 +6,7 @@ on:
     paths:
       - .github/workflows/forbid-clusterpolicies.yaml
       - hack/forbid-clusterpolicies.sh
+      - hack/kustomize-build-with-retry.sh
       - 'components/**'
       - '!components/policies/**'
 

--- a/.github/workflows/kube-linter.yaml
+++ b/.github/workflows/kube-linter.yaml
@@ -25,6 +25,8 @@ jobs:
           version: 5.8.1
 
       - name: Run kustomize build
+        env:
+          OUTPUT: GITHUB
         run: |
           find argo-cd-apps components -name 'kustomization.yaml' \
             ! -path '*/k-components/*' \
@@ -36,7 +38,7 @@ jobs:
             ! -path 'components/monitoring/blackbox/production/*' \
             ! -path 'components/*/chainsaw/*' \
             | \
-            xargs -I {} -n1 -P8  bash -c 'dir=$(dirname "{}"); output_file=$(echo $dir | tr / -)-kustomization.yaml; if ! log=$(kustomize build --enable-helm "$dir" -o "kustomizedfiles/$output_file" 2>&1); then echo "Error when running kustomize build for $dir: $log" && exit 1;fi'
+            xargs -I {} -n1 -P8  bash -c 'dir=$(dirname "{}"); output_file=$(echo "$dir" | tr / -)-kustomization.yaml; ./hack/kustomize-build-with-retry.sh "$dir" -o "kustomizedfiles/$output_file"'
 
       - name: Scan yaml files with kube-linter
         uses: stackrox/kube-linter-action@v1.0.4

--- a/hack/forbid-clusterpolicies.sh
+++ b/hack/forbid-clusterpolicies.sh
@@ -5,6 +5,7 @@ set -e -o pipefail
 # inputs
 declare OUTPUT
 folder="${1}"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 error_handler() {
   local exit_code=$?
@@ -24,7 +25,7 @@ error_handler() {
 trap error_handler ERR
 
 # build manifests and filter ClusterPolicies for provided folder
-manifests=$(kustomize build --enable-helm "${folder}" | yq -o=j)
+manifests=$("${script_dir}/kustomize-build-with-retry.sh" "${folder}" | yq -o=j) || exit $?
 policies=$(echo "${manifests}" | jq 'select(.kind=="ClusterPolicy")' | jq -s '.')
 
 # calculate the number of policies in the given folder

--- a/hack/kustomize-build-with-retry.sh
+++ b/hack/kustomize-build-with-retry.sh
@@ -1,0 +1,56 @@
+#!/bin/env bash
+
+set -e -o pipefail
+
+# Retry wrapper for flaky remote kustomize/helm fetches.
+#
+# Usage: kustomize-build-with-retry.sh <dir> [extra kustomize args...]
+# Env:
+#   KUSTOMIZE_RETRIES - max attempts (default 5)
+#   OUTPUT=GITHUB     - emit GitHub Actions warnings on retry
+#
+# On success, kustomize stdout is written to this script's stdout (stderr is
+# discarded). Callers that use -o rely on the output file; others can pipe
+# stdout into yq/jq.
+
+dir="${1:?directory required}"
+shift
+
+max_attempts="${KUSTOMIZE_RETRIES:-5}"
+attempt=1
+build_rc=0
+kustomize_stdout=""
+kustomize_stderr=""
+
+while true; do
+  kustomize_stderr=$(mktemp)
+  set +e
+  kustomize_stdout=$(kustomize build --enable-helm "${dir}" "$@" 2>"${kustomize_stderr}")
+  build_rc=$?
+  set -e
+
+  if (( build_rc == 0 )); then
+    rm -f "${kustomize_stderr}"
+    printf '%s\n' "${kustomize_stdout}"
+    exit 0
+  fi
+
+  if (( attempt >= max_attempts )); then
+    printf "Error when running kustomize build for %s:\n" "${dir}" >&2
+    cat "${kustomize_stderr}" >&2
+    rm -f "${kustomize_stderr}"
+    exit "${build_rc}"
+  fi
+
+  if [[ "${OUTPUT}" == "GITHUB" ]]; then
+    printf "::warning::kustomize build for '%s' failed (attempt %s/%s), retrying in %ss...\n" \
+      "${dir}" "${attempt}" "${max_attempts}" $(( attempt * 2 )) >&2
+  else
+    printf "kustomize build for '%s' failed (attempt %s/%s), retrying in %ss...\n" \
+      "${dir}" "${attempt}" "${max_attempts}" $(( attempt * 2 )) >&2
+  fi
+
+  rm -f "${kustomize_stderr}"
+  sleep $(( attempt * 2 ))
+  attempt=$((attempt + 1))
+done


### PR DESCRIPTION
This script was failing in CI on transient issues. Rerunning it requires privileges that are not available for most PR owners, which means they either have to rebase the PR and trigger all CI jobs again, or ask someone with the right privileges to rerun the job.

Adding retries to the script should hopefully reduce the number of times this is needed.

Assisted-by: Cursor