### PR TITLE
chore(): Make image-controller RBAC conditional on enablement

### DIFF
--- a/components/konflux-operator/rings/ring-0/base/cr/image-controller/kustomization.yaml
+++ b/components/konflux-operator/rings/ring-0/base/cr/image-controller/kustomization.yaml
@@ -1,6 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
-resources:
-  - rbac
 patches:
   - path: image-controller.yaml

--- a/components/konflux-operator/rings/ring-0/base/cr/image-controller/rbac/kustomization.yaml
+++ b/components/konflux-operator/rings/ring-0/base/cr/image-controller/rbac/kustomization.yaml
@@ -1,5 +1,5 @@
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
 resources:
   - image-controller-admin.yaml
   - image-controller-maintainer.yaml

--- a/hack/preview.sh
+++ b/hack/preview.sh
@@ -385,6 +385,7 @@ configure_operator_image_controller() {
     [ "$TARGET_PREVIEW_OVERLAY" != "development-operator" ] && return
 
     local cr_patch="$ROOT/components/konflux-operator/rings/ring-0/base/cr/image-controller/image-controller.yaml"
+    local ring_kust="$ROOT/components/konflux-operator/rings/ring-0/base/kustomization.yaml"
 
     log_step "Configuring Konflux operator image-controller (Quay credentials)"
 
@@ -392,12 +393,16 @@ configure_operator_image_controller() {
         log_info "IMAGE_CONTROLLER_QUAY_ORG and IMAGE_CONTROLLER_QUAY_TOKEN are set"
         log_info "  - Quay organization: ${IMAGE_CONTROLLER_QUAY_ORG}"
         yq -i '.spec.imageController.enabled = true' "$cr_patch"
+        yq -i '.components += ["cr/image-controller/rbac"] | .components |= unique' "$ring_kust"
+        log_info "  - image-controller RBAC component added to ring kustomization"
         log_success "Konflux CR image-controller: enabled (operator will deploy image-controller)"
     else
         log_info "IMAGE_CONTROLLER_QUAY_ORG and/or IMAGE_CONTROLLER_QUAY_TOKEN are not set"
         [ -z "${IMAGE_CONTROLLER_QUAY_ORG}" ] && log_info "  - IMAGE_CONTROLLER_QUAY_ORG: not set"
         [ -z "${IMAGE_CONTROLLER_QUAY_TOKEN}" ] && log_info "  - IMAGE_CONTROLLER_QUAY_TOKEN: not set"
         yq -i '.spec.imageController.enabled = false' "$cr_patch"
+        yq -i 'del(.components[] | select(. == "cr/image-controller/rbac"))' "$ring_kust"
+        log_info "  - image-controller RBAC component removed from ring kustomization"
         log_warn "Konflux CR image-controller: disabled (set both Quay variables in hack/preview.env to enable)"
     fi
 }


### PR DESCRIPTION
The image-controller RBAC (Role, RoleBinding, ClusterRole,
ClusterRoleBinding) targets the `image-controller` namespace, which only
exists when the operator's `imageController.enabled` is set to true.

When committed with `enabled: false` (the safe default for environments
without Quay credentials), the namespace is never created by the
operator, leaving the RBAC resources in a permanent OutOfSync/Missing
state in ArgoCD.

Fix this by splitting the RBAC into its own Kustomize Component at
`cr/image-controller/rbac/` that is NOT included in the base
`components:` list. The preview script (`hack/preview.sh`) now
conditionally adds or removes it from the ring kustomization alongside
the `enabled` toggle — both are gated on the presence of
IMAGE_CONTROLLER_QUAY_ORG and IMAGE_CONTROLLER_QUAY_TOKEN.

Result:
- Committed default: enabled=false, no RBAC component, no sync issues
- preview.sh with creds: enabled=true, RBAC added, everything syncs
- preview.sh without creds: enabled=false, RBAC removed, no sync issues

Tested on a dev cluster with `./hack/bootstrap-cluster.sh preview --operator-overlay`:

- `konflux-operator-in-cluster-local` app: Synced + Healthy
- `image-controller` namespace: not created
- `image-controller-admin` Role: not found
- `image-controller-admins` RoleBinding: not found
- `image-controller-maintainer` ClusterRole: not found
- `image-controller-maintainers` ClusterRoleBinding: not found
- No ArgoCD OutOfSync/Missing errors

- `konflux-operator-in-cluster-local` app: Synced + Healthy
- `image-controller` namespace: Active
- `image-controller-admin` Role: deployed
- `image-controller-admins` RoleBinding: deployed
- `image-controller-maintainer` ClusterRole: deployed
- `image-controller-maintainers` ClusterRoleBinding: deployed
- `image-controller-controller-manager` Deployment: 1/1 Ready
- No ArgoCD OutOfSync/Missing errors

Assisted-by: Cursor + Opus 4.6