### PR TITLE
KFLUXINFRA-4238: (onboarding) Remove production etcd-shield apps from AppSRE ArgoCD

### DIFF
--- a/argo-cd-apps/base/member/infra-deployments/etcd-shield/etcd-shield.yaml
+++ b/argo-cd-apps/base/member/infra-deployments/etcd-shield/etcd-shield.yaml
@@ -13,25 +13,7 @@ spec:
                 sourceRoot: components/etcd-shield
                 environment: staging
           - list:
-              elements:
-                - nameNormalized: kflux-ocp-p01
-                  values.clusterDir: kflux-ocp-p01
-                - nameNormalized: kflux-prd-rh02
-                  values.clusterDir: kflux-prd-rh02
-                - nameNormalized: kflux-prd-rh03
-                  values.clusterDir: kflux-prd-rh03
-                - nameNormalized: stone-prd-rh01
-                  values.clusterDir: stone-prd-rh01
-                - nameNormalized: stone-prod-p01
-                  values.clusterDir: stone-prod-p01
-                - nameNormalized: stone-prod-p02
-                  values.clusterDir: stone-prod-p02
-                - nameNormalized: kflux-rhel-p01
-                  values.clusterDir: kflux-rhel-p01
-                - nameNormalized: kflux-osp-p01
-                  values.clusterDir: kflux-osp-p01
-                - nameNormalized: kflux-fedora-01
-                  values.clusterDir: kflux-fedora-01
+              elements: []
   template:
     metadata:
       name: etcd-shield-{{nameNormalized}}

--- a/argo-cd-apps/overlays/konflux-public-production/delete-applications.yaml
+++ b/argo-cd-apps/overlays/konflux-public-production/delete-applications.yaml
@@ -23,3 +23,9 @@ kind: ApplicationSet
 metadata:
   name: dummy-deployment
 $patch: delete
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: etcd-shield
+$patch: delete

--- a/argo-cd-apps/overlays/konflux-public-production/kustomization.yaml
+++ b/argo-cd-apps/overlays/konflux-public-production/kustomization.yaml
@@ -194,11 +194,6 @@ patches:
     target:
       kind: ApplicationSet
       version: v1alpha1
-      name: etcd-shield
-  - path: production-overlay-patch.yaml
-    target:
-      kind: ApplicationSet
-      version: v1alpha1
       name: etcd-defrag
   - path: production-overlay-patch.yaml
     target:

--- a/argo-cd-apps/overlays/production-downstream/delete-applications.yaml
+++ b/argo-cd-apps/overlays/production-downstream/delete-applications.yaml
@@ -29,3 +29,8 @@ metadata:
   name: nvme-storage-configurator
 $patch: delete
 ---
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: etcd-shield
+$patch: delete

--- a/argo-cd-apps/overlays/production-downstream/kustomization.yaml
+++ b/argo-cd-apps/overlays/production-downstream/kustomization.yaml
@@ -214,11 +214,6 @@ patches:
     target:
       kind: ApplicationSet
       version: v1alpha1
-      name: etcd-shield
-  - path: production-overlay-patch.yaml
-    target:
-      kind: ApplicationSet
-      version: v1alpha1
       name: etcd-defrag
   - path: production-overlay-patch.yaml
     target:


### PR DESCRIPTION
Deletes the etcd-shield apps from the production overlays so those in the new rd-production overlay take control over the existing resources.

### Summary of Changes
- Added delete patches for etcd-shield in both production overlays
- Removed staging cluster entries from the original etcd-shield AppSet

### Risk Level
**Risk Level**: Medium
**Reasoning**: No new component resources are being created; the new ApplicationSet references the etcd-shield-rd/ directory, which is only a restructuring of the existing etcd-shield/ directory
**Rollback Strategy:** Revert this commit and do a manual sync for the original etcd-shield ApplicationSet, as it references the original structuring of etcd-shield.