### PR TITLE
Update Kustomize version in CI workflows

### DIFF
--- a/.github/workflows/forbid-clusterpolicies.yaml
+++ b/.github/workflows/forbid-clusterpolicies.yaml
@@ -17,9 +17,9 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Setup Kustomize
-        uses: multani/action-setup-kustomize@v1
+        uses: multani/action-setup-kustomize@bf96e027caf74ab03bb3f79bac2addb331b28f1d
         with:
-          version: 5.6.0
+          version: 5.8.1
 
       - name: Run forbid-clusterpolicies script
         env:

--- a/.github/workflows/kube-linter.yaml
+++ b/.github/workflows/kube-linter.yaml
@@ -20,9 +20,9 @@ jobs:
         run: mkdir -p ../results kustomizedfiles
 
       - name: Setup Kustomize
-        uses: multani/action-setup-kustomize@v1
+        uses: multani/action-setup-kustomize@bf96e027caf74ab03bb3f79bac2addb331b28f1d
         with:
-          version: 5.6.0
+          version: 5.8.1
 
       - name: Run kustomize build
         run: |

--- a/.github/workflows/verify-pipelines-configs.yaml
+++ b/.github/workflows/verify-pipelines-configs.yaml
@@ -35,9 +35,9 @@ jobs:
           git commit -m "overlay PR manifests" --allow-empty
 
       - name: Setup Kustomize
-        uses: multani/action-setup-kustomize@v1
+        uses: multani/action-setup-kustomize@bf96e027caf74ab03bb3f79bac2addb331b28f1d
         with:
-          version: 5.6.0
+          version: 5.8.1
 
       - name: Verify Pipelines kustomize output is in sync
         id: check


### PR DESCRIPTION
Updated the Kustomize version used in CI workflows to latest version (5.8.1)  to add a fix for a panic that occurs with multiple delete strategic merge patches in one file.

https://github.com/kubernetes-sigs/kustomize/releases/tag/kustomize%2Fv5.8.1

Also pin the Kustomize checkout action to a specific SHA instead of a floating tag.