### PR TITLE
 Grant the collective team read to Konflux clusters

### DIFF
--- a/components/authentication/base/rbac/patches/everyone-can-view-patch.yaml
+++ b/components/authentication/base/rbac/patches/everyone-can-view-patch.yaml
@@ -4,6 +4,9 @@
   value:
     - kind: Group
       apiGroup: rbac.authorization.k8s.io
+      name: 'exd-sp-cwf-isv' # The collective
+    - kind: Group
+      apiGroup: rbac.authorization.k8s.io
       name: 'konflux-admins'
     - kind: Group
       apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
This team working on Konflux so grant the the everyone can view permissions, same as any other Konflux team.