### PR TITLE
chore: Disable ArgoCD auto-sync on p01 for operator-owned services

### DIFF
--- a/argo-cd-apps/overlays/staging-downstream/disable-auto-sync.yaml
+++ b/argo-cd-apps/overlays/staging-downstream/disable-auto-sync.yaml
@@ -1,0 +1,6 @@
+---
+# Remove automated sync (auto-sync + self-heal) from ApplicationSet templates.
+# Used for operator ownership handoff on stone-stage-p01 so ArgoCD does not
+# race the Konflux operator (see PR #13169). Scoped to staging-downstream only.
+- op: remove
+  path: /spec/template/spec/syncPolicy/automated

--- a/argo-cd-apps/overlays/staging-downstream/kustomization.yaml
+++ b/argo-cd-apps/overlays/staging-downstream/kustomization.yaml
@@ -21,3 +21,56 @@ patches:
       kind: ApplicationSet
       version: v1alpha1
       name: multi-platform-controller
+  # Temporarily disable auto-sync/self-heal for services that the Konflux
+  # operator will own on stone-stage-p01 (PR #13169), so ArgoCD does not race
+  # the operator during ownership handoff. Revert once migration is complete.
+  - path: disable-auto-sync.yaml
+    target:
+      kind: ApplicationSet
+      version: v1alpha1
+      name: application-api
+  - path: disable-auto-sync.yaml
+    target:
+      kind: ApplicationSet
+      version: v1alpha1
+      name: build-service
+  - path: disable-auto-sync.yaml
+    target:
+      kind: ApplicationSet
+      version: v1alpha1
+      name: integration
+  - path: disable-auto-sync.yaml
+    target:
+      kind: ApplicationSet
+      version: v1alpha1
+      name: image-controller
+  - path: disable-auto-sync.yaml
+    target:
+      kind: ApplicationSet
+      version: v1alpha1
+      name: namespace-lister
+  - path: disable-auto-sync.yaml
+    target:
+      kind: ApplicationSet
+      version: v1alpha1
+      name: konflux-info
+  - path: disable-auto-sync.yaml
+    target:
+      kind: ApplicationSet
+      version: v1alpha1
+      name: konflux-ui
+  - path: disable-auto-sync.yaml
+    target:
+      kind: ApplicationSet
+      version: v1alpha1
+      name: enterprise-contract
+  - path: disable-auto-sync.yaml
+    target:
+      kind: ApplicationSet
+      version: v1alpha1
+      name: konflux-rbac
+  - path: disable-auto-sync.yaml
+    target:
+      kind: ApplicationSet
+      version: v1alpha1
+      name: release


### PR DESCRIPTION
Prevents ArgoCD from racing the Konflux operator when ownership moves in #13169.

Assisted-by: Cursor