### PR TITLE
feat(KFLUXVNGD-923): Add Konflux operator ring-1 deployment for internal staging

### DIFF
--- a/argo-cd-apps/overlays/rd-staging/konflux-operator/konflux-operator-appset.yaml
+++ b/argo-cd-apps/overlays/rd-staging/konflux-operator/konflux-operator-appset.yaml
@@ -1,0 +1,48 @@
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: konflux-operator
+  labels:
+    appstudio.redhat.com/environment: internal
+spec:
+  generators:
+    - merge:
+        mergeKeys:
+          - nameNormalized
+        generators:
+          - clusters:
+              selector:
+                matchLabels:
+                  appstudio.redhat.com/is-tenant-cluster: "true"
+              values:
+                sourceRoot: components/konflux-operator
+                ring: "empty-base"
+                clusterDir: "empty-base"
+          - list:
+              elements: [] # Populated via internal-clusters-patch
+
+  template:
+    metadata:
+      name: konflux-operator-{{nameNormalized}}
+    spec:
+      project: default
+      source:
+        path: '{{values.sourceRoot}}/rings/{{values.ring}}/{{values.clusterDir}}'
+        repoURL: https://github.com/redhat-appstudio/infra-deployments.git
+        targetRevision: main
+      destination:
+        namespace: konflux-operator
+        server: '{{server}}'
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
+        syncOptions:
+          - CreateNamespace=true
+          - SkipDryRunOnMissingResource=true
+        retry:
+          limit: -1
+          backoff:
+            duration: 10s
+            factor: 2
+            maxDuration: 3m

--- a/argo-cd-apps/overlays/rd-staging/konflux-operator/kustomization.yaml
+++ b/argo-cd-apps/overlays/rd-staging/konflux-operator/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - konflux-operator-appset.yaml

--- a/argo-cd-apps/overlays/rd-staging/kustomization.yaml
+++ b/argo-cd-apps/overlays/rd-staging/kustomization.yaml
@@ -5,6 +5,7 @@ namespace: argocd-infra-deployments
 resources:
   - authentication
   - etcd-shield
+  - konflux-operator
 
 patches:
   - path: patches/all-clusters-patch.yaml

--- a/components/konflux-operator/rings/empty-base/empty-base/kustomization.yaml
+++ b/components/konflux-operator/rings/empty-base/empty-base/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources: []

--- a/components/konflux-operator/rings/ring-1/base/cr/build/OWNERS
+++ b/components/konflux-operator/rings/ring-1/base/cr/build/OWNERS
@@ -1,0 +1,16 @@
+# See the OWNERS docs: https://go.k8s.io/owners
+# Should be kept in sync with components/monitoring/grafana/base/dashboards/build-service/OWNERS
+
+approvers:
+- mmorhun
+- rcerven
+- mkosiarc
+- tisutisu
+- chmeliik
+
+reviewers:
+- mmorhun
+- rcerven
+- mkosiarc
+- tisutisu
+- chmeliik

--- a/components/konflux-operator/rings/ring-1/base/cr/build/build-service.yaml
+++ b/components/konflux-operator/rings/ring-1/base/cr/build/build-service.yaml
@@ -1,0 +1,20 @@
+apiVersion: konflux.konflux-ci.dev/v1alpha1
+kind: Konflux
+metadata:
+  name: konflux
+spec:
+  buildService:
+    spec:
+      webhookURLs:
+        "https://github.com": "https://smee-smee.apps.rosa.kflux-c-stg-e01.3zdg.p3.openshiftapps.com/redhathookstagep01"
+        "https://gitlab.com": "https://smee-smee.apps.rosa.kflux-c-stg-e01.3zdg.p3.openshiftapps.com/redhathookstagep01"
+      buildControllerManager:
+        replicas: 1
+        manager:
+          resources:
+            requests:
+              cpu: 500m
+              memory: 4Gi
+            limits:
+              cpu: 500m
+              memory: 4Gi

--- a/components/konflux-operator/rings/ring-1/base/cr/build/external-secrets/kustomization.yaml
+++ b/components/konflux-operator/rings/ring-1/base/cr/build/external-secrets/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - pipelines-as-code-secret.yaml

--- a/components/konflux-operator/rings/ring-1/base/cr/build/external-secrets/pipelines-as-code-secret.yaml
+++ b/components/konflux-operator/rings/ring-1/base/cr/build/external-secrets/pipelines-as-code-secret.yaml
@@ -1,0 +1,20 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: pipelines-as-code-secret
+  namespace: build-service
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  dataFrom:
+    - extract:
+        key: staging/pipeline-service/github-app
+  refreshInterval: 5m
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: appsre-stonesoup-vault
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    name: pipelines-as-code-secret

--- a/components/konflux-operator/rings/ring-1/base/cr/build/kustomization.yaml
+++ b/components/konflux-operator/rings/ring-1/base/cr/build/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+resources:
+  - external-secrets
+  - trusted-ca-configmap.yaml
+  - rbac
+patches:
+  - path: build-service.yaml

--- a/components/konflux-operator/rings/ring-1/base/cr/build/rbac/build-admin.yaml
+++ b/components/konflux-operator/rings/ring-1/base/cr/build/rbac/build-admin.yaml
@@ -1,0 +1,42 @@
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: build-admin
+  namespace: build-service
+rules:
+  - apiGroups:
+      - ''
+    resources:
+      - secrets
+    verbs:
+      - get
+      - list
+      - watch
+      - update
+      - patch
+      - delete
+
+  - apiGroups:
+      - ''
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+      - delete
+
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: build-admins
+  namespace: build-service
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: konflux-build-admins
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: build-admin

--- a/components/konflux-operator/rings/ring-1/base/cr/build/rbac/build-maintainer.yaml
+++ b/components/konflux-operator/rings/ring-1/base/cr/build/rbac/build-maintainer.yaml
@@ -1,0 +1,53 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: build-maintainer
+rules:
+  - verbs:
+      - get
+      - list
+      - patch
+      - update
+    apiGroups:
+      - ''
+    resources:
+      - serviceaccounts
+      - configmaps
+  - verbs:
+      - list
+    apiGroups:
+      - ''
+    resources:
+      - secrets
+  - verbs:
+      - get
+      - list
+      - patch
+      - update
+    apiGroups:
+      - appstudio.redhat.com
+    resources:
+      - components
+      - imagerepositories
+  - verbs:
+      - get
+      - list
+      - patch
+      - update
+    apiGroups:
+      - pipelinesascode.tekton.dev
+    resources:
+      - repositories
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: build-maintainers
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: konflux-build
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: build-maintainer

--- a/components/konflux-operator/rings/ring-1/base/cr/build/rbac/kustomization.yaml
+++ b/components/konflux-operator/rings/ring-1/base/cr/build/rbac/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - build-admin.yaml
+  - build-maintainer.yaml
+  - view-konflux-integration-runner.yaml

--- a/components/konflux-operator/rings/ring-1/base/cr/build/rbac/view-konflux-integration-runner.yaml
+++ b/components/konflux-operator/rings/ring-1/base/cr/build/rbac/view-konflux-integration-runner.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: view-konflux-integration-runner
+  namespace: build-service
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: view
+subjects:
+- kind: ServiceAccount
+  name: konflux-integration-runner
+  namespace: rhtap-build-tenant

--- a/components/konflux-operator/rings/ring-1/base/cr/build/trusted-ca-configmap.yaml
+++ b/components/konflux-operator/rings/ring-1/base/cr/build/trusted-ca-configmap.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: trusted-ca
+  namespace: build-service
+  labels:
+    config.openshift.io/inject-trusted-cabundle: "true"

--- a/components/konflux-operator/rings/ring-1/base/cr/enterprise-contract/ecp.yaml
+++ b/components/konflux-operator/rings/ring-1/base/cr/enterprise-contract/ecp.yaml
@@ -1,0 +1,156 @@
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: EnterpriseContractPolicy
+metadata:
+  name: default
+  namespace: enterprise-contract-service
+  annotations:
+    argocd.argoproj.io/sync-wave: "10"
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  description: 'Includes rules for levels 1, 2 & 3 of SLSA v0.1. This is the default config used for new Konflux applications. Source: https://github.com/conforma/config/blob/main/default/policy.yaml'
+  name: Default
+  publicKey: k8s://openshift-pipelines/public-key
+  sources:
+    - config:
+        exclude: []
+        include:
+          - '@slsa3'
+      data:
+        - github.com/release-engineering/rhtap-ec-policy//data
+        - oci::quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest
+        - oci::quay.io/konflux-ci/konflux-vanguard/data-acceptable-bundles:latest
+        - oci::quay.io/konflux-ci/integration-service-catalog/data-acceptable-bundles:latest
+      name: Default
+      policy:
+        - oci::quay.io/enterprise-contract/ec-release-policy:konflux
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: EnterpriseContractPolicy
+metadata:
+  name: redhat-no-hermetic
+  namespace: enterprise-contract-service
+  annotations:
+    argocd.argoproj.io/sync-wave: "10"
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  description: 'Includes most of the rules and policies required internally by Red Hat when building Red Hat products. It excludes the requirement of hermetic builds. Source: https://github.com/conforma/config/blob/main/redhat-no-hermetic/policy.yaml'
+  name: Red Hat (non hermetic)
+  publicKey: k8s://openshift-pipelines/public-key
+  sources:
+    - config:
+        exclude:
+          - hermetic_build_task
+          - tasks.required_tasks_found:prefetch-dependencies
+        include:
+          - '@redhat'
+      data:
+        - github.com/release-engineering/rhtap-ec-policy//data
+        - oci::quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest
+        - oci::quay.io/konflux-ci/konflux-vanguard/data-acceptable-bundles:latest
+        - oci::quay.io/konflux-ci/integration-service-catalog/data-acceptable-bundles:latest
+      name: Default
+      policy:
+        - oci::quay.io/enterprise-contract/ec-release-policy:konflux
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: EnterpriseContractPolicy
+metadata:
+  name: redhat-rpms
+  namespace: enterprise-contract-service
+  annotations:
+    argocd.argoproj.io/sync-wave: "10"
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  description: 'For Red Hat RPM builds in Red Hat Konflux. Source: https://github.com/conforma/config/blob/main/redhat-rpms/policy.yaml'
+  name: Red Hat RPMs
+  publicKey: k8s://openshift-pipelines/public-key
+  sources:
+    - config:
+        exclude: []
+        include:
+          - '@redhat_rpms'
+      data:
+        - github.com/release-engineering/rhtap-ec-policy//data
+        - oci::quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest
+        - oci::quay.io/konflux-ci/konflux-vanguard/data-acceptable-bundles:latest
+        - oci::quay.io/konflux-ci/integration-service-catalog/data-acceptable-bundles:latest
+        - oci::quay.io/enterprise-contract/rpmbuild-data-acceptable-bundles:latest
+      name: Default
+      policy:
+        - oci::quay.io/enterprise-contract/ec-release-policy:konflux
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: EnterpriseContractPolicy
+metadata:
+  name: redhat
+  namespace: enterprise-contract-service
+  annotations:
+    argocd.argoproj.io/sync-wave: "10"
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  description: 'Includes the full set of rules and policies required internally by Red Hat when building Red Hat products. Source: https://github.com/conforma/config/blob/main/redhat/policy.yaml'
+  name: Red Hat
+  publicKey: k8s://openshift-pipelines/public-key
+  sources:
+    - config:
+        exclude: []
+        include:
+          - '@redhat'
+      data:
+        - github.com/release-engineering/rhtap-ec-policy//data
+        - oci::quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest
+        - oci::quay.io/konflux-ci/konflux-vanguard/data-acceptable-bundles:latest
+        - oci::quay.io/konflux-ci/integration-service-catalog/data-acceptable-bundles:latest
+      name: Default
+      policy:
+        - oci::quay.io/enterprise-contract/ec-release-policy:konflux
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: EnterpriseContractPolicy
+metadata:
+  name: slsa3
+  namespace: enterprise-contract-service
+  annotations:
+    argocd.argoproj.io/sync-wave: "10"
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  description: 'Rules specifically related to levels 1, 2 & 3 of SLSA v0.1, plus a set of basic checks that are expected to pass for all Konflux builds. Source: https://github.com/conforma/config/blob/main/slsa3/policy.yaml'
+  name: SLSA3
+  publicKey: k8s://openshift-pipelines/public-key
+  sources:
+    - config:
+        exclude: []
+        include:
+          - '@minimal'
+          - '@slsa3'
+      data:
+        - github.com/release-engineering/rhtap-ec-policy//data
+        - oci::quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest
+        - oci::quay.io/konflux-ci/konflux-vanguard/data-acceptable-bundles:latest
+        - oci::quay.io/konflux-ci/integration-service-catalog/data-acceptable-bundles:latest
+      name: Default
+      policy:
+        - oci::quay.io/enterprise-contract/ec-release-policy:konflux
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: EnterpriseContractPolicy
+metadata:
+  name: redhat-trusted-tasks
+  namespace: enterprise-contract-service
+  annotations:
+    argocd.argoproj.io/sync-wave: "10"
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  description: Rules used to verify Tekton Task definitions comply to Red Hat's standards.
+  name: Red Hat Trusted Tasks
+  sources:
+    - config:
+        exclude: []
+        include:
+          - kind
+      data:
+        - github.com/release-engineering/rhtap-ec-policy//data
+      name: Default
+      policy:
+        - oci::quay.io/enterprise-contract/ec-task-policy:konflux

--- a/components/konflux-operator/rings/ring-1/base/cr/enterprise-contract/enterprise-contract.yaml
+++ b/components/konflux-operator/rings/ring-1/base/cr/enterprise-contract/enterprise-contract.yaml
@@ -1,0 +1,7 @@
+apiVersion: konflux.konflux-ci.dev/v1alpha1
+kind: Konflux
+metadata:
+  name: konflux
+spec:
+  enterpriseContract:
+    skipPolicies: true

--- a/components/konflux-operator/rings/ring-1/base/cr/enterprise-contract/kustomization.yaml
+++ b/components/konflux-operator/rings/ring-1/base/cr/enterprise-contract/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+resources:
+  - ecp.yaml
+patches:
+  - path: enterprise-contract.yaml

--- a/components/konflux-operator/rings/ring-1/base/cr/image-controller/OWNERS
+++ b/components/konflux-operator/rings/ring-1/base/cr/image-controller/OWNERS
@@ -1,0 +1,15 @@
+# See the OWNERS docs: https://go.k8s.io/owners
+
+approvers:
+- mmorhun
+- rcerven
+- mkosiarc
+- tisutisu
+- chmeliik
+
+reviewers:
+- mmorhun
+- mkosiarc
+- rcerven
+- tisutisu
+- chmeliik

--- a/components/konflux-operator/rings/ring-1/base/cr/image-controller/external-secrets/image-pruner-token.yaml
+++ b/components/konflux-operator/rings/ring-1/base/cr/image-controller/external-secrets/image-pruner-token.yaml
@@ -1,0 +1,20 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: image-pruner-token
+  namespace: image-controller
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  dataFrom:
+    - extract:
+        key: staging/build/image-pruner-token
+  refreshInterval: 30m
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: appsre-stonesoup-vault
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    name: image-pruner-token

--- a/components/konflux-operator/rings/ring-1/base/cr/image-controller/external-secrets/kustomization.yaml
+++ b/components/konflux-operator/rings/ring-1/base/cr/image-controller/external-secrets/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - quaytoken.yaml
+  - image-pruner-token.yaml

--- a/components/konflux-operator/rings/ring-1/base/cr/image-controller/external-secrets/quaytoken.yaml
+++ b/components/konflux-operator/rings/ring-1/base/cr/image-controller/external-secrets/quaytoken.yaml
@@ -1,0 +1,20 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: quaytoken
+  namespace: image-controller
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  dataFrom:
+    - extract:
+        key: staging/build/image-controller
+  refreshInterval: 5m
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: appsre-stonesoup-vault
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    name: quaytoken

--- a/components/konflux-operator/rings/ring-1/base/cr/image-controller/image-controller.yaml
+++ b/components/konflux-operator/rings/ring-1/base/cr/image-controller/image-controller.yaml
@@ -1,0 +1,34 @@
+apiVersion: konflux.konflux-ci.dev/v1alpha1
+kind: Konflux
+metadata:
+  name: konflux
+spec:
+  imageController:
+    enabled: true
+    spec:
+      imageControllerManager:
+        replicas: 1
+        manager:
+          resources:
+            requests:
+              cpu: 500m
+              memory: 6Gi
+            limits:
+              cpu: 500m
+              memory: 6Gi
+      imagePruner:
+        resources:
+          requests:
+            cpu: 150m
+            memory: 1Gi
+          limits:
+            cpu: 500m
+            memory: 2Gi
+      notificationResetter:
+        resources:
+          requests:
+            cpu: 150m
+            memory: 1Gi
+          limits:
+            cpu: 500m
+            memory: 1Gi

--- a/components/konflux-operator/rings/ring-1/base/cr/image-controller/kustomization.yaml
+++ b/components/konflux-operator/rings/ring-1/base/cr/image-controller/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+resources:
+  - external-secrets
+  - rbac
+patches:
+  - path: image-controller.yaml

--- a/components/konflux-operator/rings/ring-1/base/cr/image-controller/rbac/image-controller-admin.yaml
+++ b/components/konflux-operator/rings/ring-1/base/cr/image-controller/rbac/image-controller-admin.yaml
@@ -1,0 +1,52 @@
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: image-controller-admin
+  namespace: image-controller
+rules:
+  - apiGroups:
+      - ''
+    resources:
+      - secrets
+    verbs:
+      - get
+      - list
+      - watch
+      - update
+      - patch
+      - delete
+
+  - apiGroups:
+      - ''
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+      - delete
+
+  - apiGroups:
+      - 'batch'
+    resources:
+      - jobs
+    verbs:
+      - get
+      - list
+      - watch
+      - delete
+
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: image-controller-admins
+  namespace: image-controller
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: konflux-build-admins
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: image-controller-admin

--- a/components/konflux-operator/rings/ring-1/base/cr/image-controller/rbac/image-controller-maintainer.yaml
+++ b/components/konflux-operator/rings/ring-1/base/cr/image-controller/rbac/image-controller-maintainer.yaml
@@ -1,0 +1,34 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: image-controller-maintainer
+rules:
+  - apiGroups:
+      - 'appstudio.redhat.com'
+    resources:
+      - imagerepositories
+    verbs:
+      - get
+      - list
+      - watch
+
+  - apiGroups:
+      - 'appstudio.redhat.com'
+    resources:
+      - imagerepositories/status
+    verbs:
+      - get
+
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: image-controller-maintainers
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: konflux-build
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: image-controller-maintainer

--- a/components/konflux-operator/rings/ring-1/base/cr/image-controller/rbac/kustomization.yaml
+++ b/components/konflux-operator/rings/ring-1/base/cr/image-controller/rbac/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - image-controller-admin.yaml
+  - image-controller-maintainer.yaml

--- a/components/konflux-operator/rings/ring-1/base/cr/integration/OWNERS
+++ b/components/konflux-operator/rings/ring-1/base/cr/integration/OWNERS
@@ -1,0 +1,21 @@
+# See the OWNERS docs: https://go.k8s.io/owners
+
+approvers:
+- dirgim
+- jsztuka
+- kasemAlem
+- sonam1412
+- Josh-Everett
+- 14rcole
+- jencull
+- NigelByrne1
+
+reviewers:
+- dirgim
+- jsztuka
+- kasemAlem
+- sonam1412
+- Josh-Everett
+- 14rcole
+- jencull
+- NigelByrne1

--- a/components/konflux-operator/rings/ring-1/base/cr/integration/external-secrets/kustomization.yaml
+++ b/components/konflux-operator/rings/ring-1/base/cr/integration/external-secrets/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - pipelines-as-code-secret.yaml

--- a/components/konflux-operator/rings/ring-1/base/cr/integration/external-secrets/pipelines-as-code-secret.yaml
+++ b/components/konflux-operator/rings/ring-1/base/cr/integration/external-secrets/pipelines-as-code-secret.yaml
@@ -1,0 +1,20 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: pipelines-as-code-secret
+  namespace: integration-service
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  dataFrom:
+    - extract:
+        key: staging/pipeline-service/github-app
+  refreshInterval: 5m
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: appsre-stonesoup-vault
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    name: pipelines-as-code-secret

--- a/components/konflux-operator/rings/ring-1/base/cr/integration/integration-service.yaml
+++ b/components/konflux-operator/rings/ring-1/base/cr/integration/integration-service.yaml
@@ -1,0 +1,20 @@
+apiVersion: konflux.konflux-ci.dev/v1alpha1
+kind: Konflux
+metadata:
+  name: konflux
+spec:
+  integrationService:
+    spec:
+      pipelineTimeout: "6h"
+      tasksTimeout: "4h"
+      finallyTimeout: "2h"
+      integrationControllerManager:
+        replicas: 1
+        manager:
+          resources:
+            requests:
+              cpu: 100m
+              memory: 8Gi
+            limits:
+              cpu: 500m
+              memory: 8Gi

--- a/components/konflux-operator/rings/ring-1/base/cr/integration/kustomization.yaml
+++ b/components/konflux-operator/rings/ring-1/base/cr/integration/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+resources:
+  - external-secrets
+  - trusted-ca-configmap.yaml
+  - rbac
+patches:
+  - path: integration-service.yaml

--- a/components/konflux-operator/rings/ring-1/base/cr/integration/rbac/delete-snapshots.yaml
+++ b/components/konflux-operator/rings/ring-1/base/cr/integration/rbac/delete-snapshots.yaml
@@ -1,0 +1,25 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: delete-snapshots
+rules:
+  - apiGroups:
+    - "appstudio.redhat.com"
+    resources:
+      - "snapshots"
+    verbs:
+      - "delete"
+      - "deletecollection"
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: delete-snapshots
+subjects:
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: konflux-integration
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: delete-snapshots

--- a/components/konflux-operator/rings/ring-1/base/cr/integration/rbac/integration-service-maintainers.yaml
+++ b/components/konflux-operator/rings/ring-1/base/cr/integration/rbac/integration-service-maintainers.yaml
@@ -1,0 +1,13 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: integration-service-maintainers
+  namespace: integration-service
+subjects:
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: konflux-integration
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: component-maintainer

--- a/components/konflux-operator/rings/ring-1/base/cr/integration/rbac/kustomization.yaml
+++ b/components/konflux-operator/rings/ring-1/base/cr/integration/rbac/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - delete-snapshots.yaml
+  - manage-integrationtestscenarios.yaml
+  - manage-resolutionrequests.yaml
+  - modify-pipelineruns-taskruns.yaml
+  - integration-service-maintainers.yaml

--- a/components/konflux-operator/rings/ring-1/base/cr/integration/rbac/manage-integrationtestscenarios.yaml
+++ b/components/konflux-operator/rings/ring-1/base/cr/integration/rbac/manage-integrationtestscenarios.yaml
@@ -1,0 +1,31 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: manage-integrationtestscenarios
+rules:
+  - apiGroups:
+    - "appstudio.redhat.com"
+    resources:
+      - "integrationtestscenarios"
+    verbs:
+      - "create"
+      - "get"
+      - "list"
+      - "patch"
+      - "update"
+      - "watch"
+      - "delete"
+      - "deletecollection"
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: manage-integrationtestscenarios
+subjects:
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: konflux-integration
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: manage-integrationtestscenarios

--- a/components/konflux-operator/rings/ring-1/base/cr/integration/rbac/manage-resolutionrequests.yaml
+++ b/components/konflux-operator/rings/ring-1/base/cr/integration/rbac/manage-resolutionrequests.yaml
@@ -1,0 +1,28 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: manage-resolutionrequests
+rules:
+  - apiGroups:
+    - "resolution.tekton.dev"
+    resources:
+      - "resolutionrequests"
+    verbs:
+      - "create"
+      - "get"
+      - "list"
+      - "watch"
+      - "delete"
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: manage-resolutionrequests
+subjects:
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: konflux-integration
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: manage-resolutionrequests

--- a/components/konflux-operator/rings/ring-1/base/cr/integration/rbac/modify-pipelineruns-taskruns.yaml
+++ b/components/konflux-operator/rings/ring-1/base/cr/integration/rbac/modify-pipelineruns-taskruns.yaml
@@ -1,0 +1,28 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: modify-pipelineruns-taskruns
+rules:
+  - apiGroups:
+    - "tekton.dev"
+    resources:
+      - "pipelineruns"
+      - "taskruns"
+    verbs:
+      - "get"
+      - "list"
+      - "patch"
+      - "update"
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: modify-pipelineruns-taskruns
+subjects:
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: konflux-integration
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: modify-pipelineruns-taskruns

--- a/components/konflux-operator/rings/ring-1/base/cr/integration/trusted-ca-configmap.yaml
+++ b/components/konflux-operator/rings/ring-1/base/cr/integration/trusted-ca-configmap.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: trusted-ca
+  namespace: integration-service
+  labels:
+    config.openshift.io/inject-trusted-cabundle: "true"

--- a/components/konflux-operator/rings/ring-1/base/cr/konflux-info/OWNERS
+++ b/components/konflux-operator/rings/ring-1/base/cr/konflux-info/OWNERS
@@ -1,0 +1,47 @@
+# See the OWNERS docs: https://go.k8s.io/owners
+
+approvers:
+# infra-team
+- sadlerap
+- eisraeli
+- filariow
+- gbenhaim
+- hugares
+- manish-jangra
+# sre-team
+- dgregor
+- jdcasey
+# ui-team
+- abhinandan13jan
+- caugello
+- CryptoRodeo
+- JoaoPedroPP
+- Katka92
+- sahil143
+- rrosatti
+- StanislavJochman
+# others
+- arewm
+
+reviewers:
+# infra-team
+- sadlerap
+- eisraeli
+- filariow
+- gbenhaim
+- hugares
+- manish-jangra
+# sre-team
+- dgregor
+- jdcasey
+# ui-team
+- abhinandan13jan
+- caugello
+- CryptoRodeo
+- JoaoPedroPP
+- Katka92
+- sahil143
+- rrosatti
+- StanislavJochman
+# others
+- arewm

--- a/components/konflux-operator/rings/ring-1/base/cr/konflux-info/konflux-info.yaml
+++ b/components/konflux-operator/rings/ring-1/base/cr/konflux-info/konflux-info.yaml
@@ -1,0 +1,36 @@
+apiVersion: konflux.konflux-ci.dev/v1alpha1
+kind: Konflux
+metadata:
+  name: konflux
+spec:
+  info:
+    spec:
+      clusterConfig:
+        data:
+          allowCacheProxy: true
+          allowPackageRegistryProxy: true
+          httpProxy: squid.caching.svc.cluster.local:3128
+          noProxy: ""
+          packageRegistryProxyGomodUrl: https://artifact-registry-proxy.caching.svc.cluster.local/repository/go-proxy
+          packageRegistryProxyNpmUrl: https://artifact-registry-proxy.caching.svc.cluster.local/repository/npm-proxy
+          packageRegistryProxyPipUrl: https://artifact-registry-proxy.caching.svc.cluster.local/repository/pypi-proxy/simple
+          packageRegistryProxyPnpmUrl: https://artifact-registry-proxy.caching.svc.cluster.local/repository/npm-proxy
+          packageRegistryProxyYarnUrl: https://artifact-registry-proxy.caching.svc.cluster.local/repository/npm-proxy
+      publicInfo:
+        environment: staging
+        integrations:
+          sbom_server:
+            url: "https://atlas.build.stage.devshift.net/sbom/content/<PLACEHOLDER>"
+            sbom_sha: "https://atlas.build.stage.devshift.net/sboms/<PLACEHOLDER>"
+          image_controller:
+            enabled: true
+            notifications:
+              - title: "SBOM-event-to-Bombino"
+                event: "repo_push"
+                method: "webhook"
+                config:
+                  url: "https://bombino.preprod.api.redhat.com/v1/sbom/quay/push"
+      banner:
+        items:
+          - summary: "Want to **display important updates** here? [See how to create a banner](https://github.com/redhat-appstudio/infra-deployments/blob/main/components/konflux-info/README.md)."
+            type: info

--- a/components/konflux-operator/rings/ring-1/base/cr/konflux-info/kustomization.yaml
+++ b/components/konflux-operator/rings/ring-1/base/cr/konflux-info/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+patches:
+  - path: konflux-info.yaml

--- a/components/konflux-operator/rings/ring-1/base/cr/konflux-rbac/OWNERS
+++ b/components/konflux-operator/rings/ring-1/base/cr/konflux-rbac/OWNERS
@@ -1,0 +1,7 @@
+# See the OWNERS docs: https://go.k8s.io/owners
+
+approvers:
+- konflux-infra-team
+
+reviewers:
+- konflux-infra-team

--- a/components/konflux-operator/rings/ring-1/base/cr/konflux-rbac/konflux-tester-internalbot-actions.yaml
+++ b/components/konflux-operator/rings/ring-1/base/cr/konflux-rbac/konflux-tester-internalbot-actions.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: konflux-tester-internalbot-actions
+rules:
+  - apiGroups:
+      - appstudio.redhat.com
+    resources:
+      - snapshots
+    verbs:
+      - get
+      - watch
+      - list
+      - update
+      - patch

--- a/components/konflux-operator/rings/ring-1/base/cr/konflux-rbac/kustomization.yaml
+++ b/components/konflux-operator/rings/ring-1/base/cr/konflux-rbac/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+resources:
+  - konflux-tester-internalbot-actions.yaml

--- a/components/konflux-operator/rings/ring-1/base/cr/konflux-ui/OWNERS
+++ b/components/konflux-operator/rings/ring-1/base/cr/konflux-ui/OWNERS
@@ -1,0 +1,47 @@
+# See the OWNERS docs: https://go.k8s.io/owners
+
+approvers:
+# infra-team
+- sadlerap
+- eisraeli
+- filariow
+- gbenhaim
+- hugares
+- manish-jangra
+# sre-team
+- dgregor
+- jdcasey
+# ui-team
+- abhinandan13jan
+- caugello
+- CryptoRodeo
+- JoaoPedroPP
+- Katka92
+- sahil143
+- rrosatti
+- StanislavJochman
+# others
+- arewm
+
+reviewers:
+# infra-team
+- sadlerap
+- eisraeli
+- filariow
+- gbenhaim
+- hugares
+- manish-jangra
+# sre-team
+- dgregor
+- jdcasey
+# ui-team
+- abhinandan13jan
+- caugello
+- CryptoRodeo
+- JoaoPedroPP
+- Katka92
+- sahil143
+- rrosatti
+- StanislavJochman
+# others
+- arewm

--- a/components/konflux-operator/rings/ring-1/base/cr/konflux-ui/external-secrets/kustomization.yaml
+++ b/components/konflux-operator/rings/ring-1/base/cr/konflux-ui/external-secrets/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - watson-config.yaml

--- a/components/konflux-operator/rings/ring-1/base/cr/konflux-ui/external-secrets/watson-config.yaml
+++ b/components/konflux-operator/rings/ring-1/base/cr/konflux-ui/external-secrets/watson-config.yaml
@@ -1,0 +1,27 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: watson-config
+  namespace: konflux-ui
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  data:
+    - secretKey: API_KEY
+      remoteRef:
+        key: staging/ui/Whatson
+        property: API_KEY
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: appsre-stonesoup-vault
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    name: watson-config
+    template:
+      metadata:
+        annotations:
+          argocd.argoproj.io/sync-options: Prune=false
+          argocd.argoproj.io/compare-options: IgnoreExtraneous

--- a/components/konflux-operator/rings/ring-1/base/cr/konflux-ui/kustomization.yaml
+++ b/components/konflux-operator/rings/ring-1/base/cr/konflux-ui/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+resources:
+  - external-secrets
+patches:
+  - path: ui.yaml

--- a/components/konflux-operator/rings/ring-1/base/cr/konflux-ui/ui.yaml
+++ b/components/konflux-operator/rings/ring-1/base/cr/konflux-ui/ui.yaml
@@ -1,0 +1,31 @@
+apiVersion: konflux.konflux-ci.dev/v1alpha1
+kind: Konflux
+metadata:
+  name: konflux
+spec:
+  ui:
+    spec:
+      proxy:
+        replicas: 3
+        endpoints:
+          kite:
+            enabled: true
+          kubearchive:
+            enabled: true
+        reverseProxy:
+          resources:
+            requests:
+              cpu: 30m
+              memory: 128Mi
+            limits:
+              cpu: 300m
+              memory: 256Mi
+      dex:
+        config:
+          configureLoginWithOpenShift: true
+      runtimeConfig:
+        monitoring:
+          enabled: true
+          dsn: "https://2d1bbbd05a2ff473d916df439cfc363e@o490301.ingest.us.sentry.io/4510260965408768"
+          environment: staging
+          sampleRateErrors: "1.0"

--- a/components/konflux-operator/rings/ring-1/base/cr/namespace-lister/OWNERS
+++ b/components/konflux-operator/rings/ring-1/base/cr/namespace-lister/OWNERS
@@ -1,0 +1,27 @@
+# See the OWNERS docs: https://go.k8s.io/owners
+
+approvers:
+- eisraeli
+- enkeefe00
+- filariow
+- gbenhaim
+- glevi-rh
+- hugares
+- manish-jangra
+- meyrevived
+- mshaposhnik
+- oswcab
+- sadlerap
+
+reviewers:
+- eisraeli
+- enkeefe00
+- filariow
+- gbenhaim
+- glevi-rh
+- hugares
+- manish-jangra
+- meyrevived
+- mshaposhnik
+- oswcab
+- sadlerap

--- a/components/konflux-operator/rings/ring-1/base/cr/namespace-lister/kustomization.yaml
+++ b/components/konflux-operator/rings/ring-1/base/cr/namespace-lister/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+patches:
+  - path: namespace-lister.yaml

--- a/components/konflux-operator/rings/ring-1/base/cr/namespace-lister/namespace-lister.yaml
+++ b/components/konflux-operator/rings/ring-1/base/cr/namespace-lister/namespace-lister.yaml
@@ -1,0 +1,18 @@
+apiVersion: konflux.konflux-ci.dev/v1alpha1
+kind: Konflux
+metadata:
+  name: konflux
+spec:
+  namespaceLister:
+    spec:
+      cacheResyncPeriod: "10m"
+      logLevel: info
+      namespaceLister:
+        replicas: 3
+        resources:
+          requests:
+            cpu: 4000m
+            memory: 6Gi
+          limits:
+            cpu: 4000m
+            memory: 6Gi

--- a/components/konflux-operator/rings/ring-1/base/cr/release/OWNERS
+++ b/components/konflux-operator/rings/ring-1/base/cr/release/OWNERS
@@ -1,0 +1,28 @@
+# See the OWNERS docs: https://go.k8s.io/owners
+
+approvers:
+- davidmogar
+- johnbieren
+- theflockers
+- mmalina
+- happybhati
+- seanconroy2021
+- filipnikolovski
+- elenagerman
+- midnightercz
+- querti
+- swickersh
+
+
+reviewers:
+- davidmogar
+- johnbieren
+- theflockers
+- mmalina
+- happybhati
+- seanconroy2021
+- filipnikolovski
+- elenagerman
+- midnightercz
+- querti
+- swickersh

--- a/components/konflux-operator/rings/ring-1/base/cr/release/cronjobs/kustomization.yaml
+++ b/components/konflux-operator/rings/ring-1/base/cr/release/cronjobs/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - remove-internal-requests.yaml

--- a/components/konflux-operator/rings/ring-1/base/cr/release/cronjobs/remove-internal-requests.yaml
+++ b/components/konflux-operator/rings/ring-1/base/cr/release/cronjobs/remove-internal-requests.yaml
@@ -1,0 +1,81 @@
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: cleanup-timed-out-pipelineruns-internal-requests
+  namespace: release-service
+spec:
+  schedule: "10 03 * * *"
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: Never
+          serviceAccountName: release-service-controller-manager
+          volumes:
+            - name: temp-directory
+              emptyDir: {}
+          containers:
+            - name: ir-cleanup
+              command:
+                - /bin/bash
+                - -c
+                - |
+                  set -o pipefail
+                  PATH="/bin:/usr/bin:/usr/local/bin"
+                  MAX_PROCS=5
+                  INTERNAL_REQUESTS_FILE="/var/tmp/internal-requests-to-be-deleted"
+                  KUBECTL_OUTPUT=$(mktemp -p /var/tmp)
+                  YD=$(date -d 'yesterday' +%s)
+                  kubectl get internalrequests --all-namespaces \
+                    --sort-by=.status.completionTime \
+                    --template '{{range .items}}{{.metadata.name}}{{"\t"}}{{.metadata.namespace}}{{"\t"}}{{.status.completionTime}}{{"\n"}}{{end}}' \
+                    | grep -E "[0-9]{4}((-?)[0-9]{2})+T.*Z$" > $KUBECTL_OUTPUT
+                  awk -v yesterday=${YD} '{
+                    # parsing the completionTime and converting it to epoch
+                    # so we can compute the precise IRs that should be deleted
+                    gsub("[:\\-TZ]", " ", $3)
+                    t=mktime($3)
+                    completionTime=strftime("%s", t)
+                    #
+                    # completionTime should be smaller than yesterday seconds so it can be deleted
+                    if(yesterday > completionTime) {
+                      args="%s:%s\n"
+                      printf(args, $1, $2)
+                    }
+                  }' $KUBECTL_OUTPUT > $INTERNAL_REQUESTS_FILE
+
+                  # The deleteAndLog will run the CR deletion and save the operation in a structured way that
+                  # can be read easily by kubectl or journalctl
+                  function deleteAndLog() {
+                    ir=${1%:*}
+                    namespace=${1#*:}
+                    kubectl delete internalrequest $ir -n $namespace |while read logLine; do
+                      echo "INFO: namespace=${namespace} log=${logLine}"
+                    done
+                  }
+                  export -f deleteAndLog
+                  xargs -a ${INTERNAL_REQUESTS_FILE} -i -P ${MAX_PROCS} bash -c 'deleteAndLog "{}"'
+              imagePullPolicy: IfNotPresent
+              image: quay.io/konflux-ci/release-service-utils:9089cafbf36bb889b4b73d8c2965613810f13736
+              volumeMounts:
+                - mountPath: /var/tmp
+                  name: temp-directory
+              resources:
+                limits:
+                  cpu: 200m
+                  memory: 300Mi
+                requests:
+                  cpu: 100m
+                  memory: 200Mi
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+                readOnlyRootFilesystem: true
+                runAsNonRoot: true
+                seccompProfile:
+                  type: RuntimeDefault

--- a/components/konflux-operator/rings/ring-1/base/cr/release/e2e-release-pipeline-resources-role.yaml
+++ b/components/konflux-operator/rings/ring-1/base/cr/release/e2e-release-pipeline-resources-role.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: e2e-release-pipeline-resources-role
+rules:
+- apiGroups:
+  - pipelinesascode.tekton.dev
+  resources:
+  - repositories
+  verbs:
+  - get
+  - list
+  - watch

--- a/components/konflux-operator/rings/ring-1/base/cr/release/external-secrets/kustomization.yaml
+++ b/components/konflux-operator/rings/ring-1/base/cr/release/external-secrets/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - release-monitor-secret.yaml

--- a/components/konflux-operator/rings/ring-1/base/cr/release/external-secrets/release-monitor-secret.yaml
+++ b/components/konflux-operator/rings/ring-1/base/cr/release/external-secrets/release-monitor-secret.yaml
@@ -1,0 +1,20 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: release-monitor-secret
+  namespace: release-service
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  dataFrom:
+    - extract:
+        key: staging/release/monitor
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: appsre-stonesoup-vault
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    name: release-monitor-secret

--- a/components/konflux-operator/rings/ring-1/base/cr/release/ibm-public-key-clusterrole.yaml
+++ b/components/konflux-operator/rings/ring-1/base/cr/release/ibm-public-key-clusterrole.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: release-pipeline-ibm-public-key
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    resourceNames:
+      - ibm-public-key
+      - ibm-public-key-stage
+    verbs:
+      - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: release-pipeline-ibm-public-key
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: release-pipeline-ibm-public-key
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: system:serviceaccounts:release-service

--- a/components/konflux-operator/rings/ring-1/base/cr/release/kustomization.yaml
+++ b/components/konflux-operator/rings/ring-1/base/cr/release/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+resources:
+  - external-secrets
+  - cronjobs
+  - signing_configs.yaml
+  - release-team.yaml
+  - release-service-configurator-role.yaml
+  - ibm-public-key-clusterrole.yaml
+  - monitor-pipeline-role.yaml
+  - e2e-release-pipeline-resources-role.yaml
+patches:
+  - path: release-service.yaml

--- a/components/konflux-operator/rings/ring-1/base/cr/release/monitor-pipeline-role.yaml
+++ b/components/konflux-operator/rings/ring-1/base/cr/release/monitor-pipeline-role.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: monitor-pipeline-role
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "pods/log"]
+    verbs: ["get", "watch", "list"]
+  - apiGroups: ["tekton.dev"]
+    resources: ["pipelineruns", "pipelines"]
+    verbs: ["get", "watch", "list"]

--- a/components/konflux-operator/rings/ring-1/base/cr/release/release-service-configurator-role.yaml
+++ b/components/konflux-operator/rings/ring-1/base/cr/release/release-service-configurator-role.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: release-service-configurator
+  namespace: release-service
+rules:
+  - apiGroups:
+      - appstudio.redhat.com
+    resources:
+      - releaseserviceconfigs
+    verbs:
+      - '*'

--- a/components/konflux-operator/rings/ring-1/base/cr/release/release-service.yaml
+++ b/components/konflux-operator/rings/ring-1/base/cr/release/release-service.yaml
@@ -1,0 +1,66 @@
+apiVersion: konflux.konflux-ci.dev/v1alpha1
+kind: Konflux
+metadata:
+  name: konflux
+spec:
+  releaseService:
+    spec:
+      debug: false
+      emptyDirOverrides:
+        - url: ".*"
+          revision: ".*"
+          pathInRepo: "pipelines/managed/fbc-release/fbc-release.yaml"
+        - url: ".*"
+          revision: ".*"
+          pathInRepo: "pipelines/managed/push-artifacts-to-cdn/push-artifacts-to-cdn.yaml"
+        - url: ".*"
+          revision: ".*"
+          pathInRepo: "pipelines/managed/push-disk-images-to-cdn/push-disk-images-to-cdn.yaml"
+        - url: ".*"
+          revision: ".*"
+          pathInRepo: "pipelines/managed/push-disk-images-to-marketplaces/push-disk-images-to-marketplaces.yaml"
+        - url: ".*"
+          revision: ".*"
+          pathInRepo: "pipelines/managed/push-oot-kmods/push-oot-kmods.yaml"
+        - url: ".*"
+          revision: ".*"
+          pathInRepo: "pipelines/managed/push-rpm-to-koji/push-rpm-to-koji.yaml"
+        - url: ".*"
+          revision: ".*"
+          pathInRepo: "pipelines/managed/push-tekton-task-bundles-to-external-registry/push-tekton-task-bundles-to-external-registry.yaml"
+        - url: ".*"
+          revision: ".*"
+          pathInRepo: "pipelines/managed/push-to-addons-registry/push-to-addons-registry.yaml"
+        - url: ".*"
+          revision: ".*"
+          pathInRepo: "pipelines/managed/push-to-external-registry/push-to-external-registry.yaml"
+        - url: ".*"
+          revision: ".*"
+          pathInRepo: "pipelines/managed/release-to-github/release-to-github.yaml"
+        - url: ".*"
+          revision: ".*"
+          pathInRepo: "pipelines/managed/release-to-mrrc/release-to-mrrc.yaml"
+        - url: ".*"
+          revision: ".*"
+          pathInRepo: "pipelines/managed/rh-advisories/rh-advisories.yaml"
+        - url: ".*"
+          revision: ".*"
+          pathInRepo: "pipelines/managed/rh-push-to-external-registry/rh-push-to-external-registry.yaml"
+        - url: ".*"
+          revision: ".*"
+          pathInRepo: "pipelines/managed/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io.yaml"
+        - url: ".*"
+          revision: ".*"
+          pathInRepo: "pipelines/managed/rhtap-service-push/rhtap-service-push.yaml"
+        - url: ".*"
+          revision: ".*"
+          pathInRepo: "pipelines/managed/push-rpms-to-pulp/push-rpms-to-pulp.yaml"
+      releaseControllerManager:
+        manager:
+          resources:
+            requests:
+              cpu: 100m
+              memory: 8Gi
+            limits:
+              cpu: 500m
+              memory: 8Gi

--- a/components/konflux-operator/rings/ring-1/base/cr/release/release-team.yaml
+++ b/components/konflux-operator/rings/ring-1/base/cr/release/release-team.yaml
@@ -1,0 +1,27 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: release-service-maintainers
+  namespace: release-service
+subjects:
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: konflux-release-team
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: component-maintainer
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: release-service-configurators
+  namespace: release-service
+subjects:
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: konflux-release-team
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: release-service-configurator

--- a/components/konflux-operator/rings/ring-1/base/cr/release/signing_configs.yaml
+++ b/components/konflux-operator/rings/ring-1/base/cr/release/signing_configs.yaml
@@ -1,0 +1,77 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    io.kompose.service: "hacbs-signing-pipeline"
+    app: "hacbs-signing-pipeline"
+    env: stage
+    paas.redhat.com/appcode: RSIG-001
+  name: "hacbs-signing-pipeline-config-redhatrelease2"
+  namespace: release-service
+data:
+  PYXIS_URL: "https://pyxis.stage.engineering.redhat.com"
+  SIG_KEY_ID: "4096R/37036783 SHA-256"
+  SIG_KEY_NAME: "redhate2etesting"
+  PYXIS_SSL_CERT_FILE_NAME: "hacbs-signing-pipeline.pem"
+  PYXIS_SSL_CERT_SECRET_NAME: "hacbs-signing-pipeline-staging-certs"
+  PYXIS_SSL_KEY_FILE_NAME: "hacbs-signing-pipeline.key"
+  UMB_SSL_CERT_FILE_NAME: "hacbs-signing-pipeline.pem"
+  UMB_SSL_CERT_SECRET_NAME: "hacbs-signing-pipeline-certs"
+  UMB_SSL_KEY_FILE_NAME: "hacbs-signing-pipeline.key"
+  UMB_CLIENT_NAME: "hacbs-signing-pipeline"
+  UMB_URL: "umb.api.redhat.com"
+  UMB_LISTEN_TOPIC: VirtualTopic.eng.robosignatory.hacbs.sign
+  UMB_PUBLISH_TOPIC: VirtualTopic.eng.hacbs-signing-pipeline.hacbs.sign
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    io.kompose.service: "hacbs-signing-pipeline"
+    app: "hacbs-signing-pipeline"
+    env: stage
+    paas.redhat.com/appcode: RSIG-001
+  name: "hacbs-signing-pipeline-config-redhatbeta2"
+  namespace: release-service
+data:
+  PYXIS_URL: "https://pyxis.stage.engineering.redhat.com"
+  SIG_KEY_ID: "4096R/37036783 SHA-256"
+  SIG_KEY_NAME: "redhate2etesting"
+  PYXIS_SSL_CERT_FILE_NAME: "hacbs-signing-pipeline.pem"
+  PYXIS_SSL_CERT_SECRET_NAME: "hacbs-signing-pipeline-staging-certs"
+  PYXIS_SSL_KEY_FILE_NAME: "hacbs-signing-pipeline.key"
+  UMB_SSL_CERT_FILE_NAME: "hacbs-signing-pipeline.pem"
+  UMB_SSL_CERT_SECRET_NAME: "hacbs-signing-pipeline-certs"
+  UMB_SSL_KEY_FILE_NAME: "hacbs-signing-pipeline.key"
+  UMB_CLIENT_NAME: "hacbs-signing-pipeline"
+  UMB_URL: "umb.api.redhat.com"
+  UMB_LISTEN_TOPIC: VirtualTopic.eng.robosignatory.hacbs.sign
+  UMB_PUBLISH_TOPIC: VirtualTopic.eng.hacbs-signing-pipeline.hacbs.sign
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    io.kompose.service: "hacbs-signing-pipeline"
+    app: "hacbs-signing-pipeline"
+    env: stage
+    paas.redhat.com/appcode: RSIG-001
+  name: "hacbs-signing-pipeline-config-staging-e2e"
+  namespace: release-service
+data:
+  PYXIS_URL: "https://pyxis.stage.engineering.redhat.com"
+  SIG_KEY_NAMES: "redhate2etesting redhate2etestingpq"
+  PYXIS_SSL_CERT_FILE_NAME: "hacbs-signing-pipeline.pem"
+  PYXIS_SSL_CERT_SECRET_NAME: "hacbs-signing-pipeline-staging-certs"
+  PYXIS_SSL_KEY_FILE_NAME: "hacbs-signing-pipeline.key"
+  UMB_SSL_CERT_FILE_NAME: "hacbs-signing-pipeline.pem"
+  UMB_SSL_CERT_SECRET_NAME: "hacbs-signing-pipeline-certs"
+  UMB_SSL_KEY_FILE_NAME: "hacbs-signing-pipeline.key"
+  UMB_CLIENT_NAME: "hacbs-signing-pipeline"
+  UMB_URL: "umb.api.redhat.com"
+  UMB_LISTEN_TOPIC: VirtualTopic.eng.robosignatory.hacbs.sign
+  UMB_PUBLISH_TOPIC: VirtualTopic.eng.hacbs-signing-pipeline.hacbs.sign
+  UMB_BATCH_LISTEN_TOPIC: VirtualTopic.eng.robosignatory.konflux.sign
+  UMB_BATCH_PUBLISH_TOPIC: VirtualTopic.eng.hacbs-signing-pipeline.konflux.sign
+  SIGNER_TYPE: "batch"

--- a/components/konflux-operator/rings/ring-1/base/invariant/konflux.yaml
+++ b/components/konflux-operator/rings/ring-1/base/invariant/konflux.yaml
@@ -1,0 +1,7 @@
+apiVersion: konflux.konflux-ci.dev/v1alpha1
+kind: Konflux
+metadata:
+  name: konflux
+spec:
+  # Base must remain environment-agnostic.
+  # Team-owned and environment-specific sections are layered via patches.

--- a/components/konflux-operator/rings/ring-1/base/invariant/kustomization.yaml
+++ b/components/konflux-operator/rings/ring-1/base/invariant/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - https://github.com/konflux-ci/konflux-ci/operator/config/default?ref=9174d328f6073de7f5ddb59dc1121989c380ff2e
+  - konflux.yaml
+
+images:
+  - name: localhost/konflux-operator
+    newName: quay.io/konflux-ci/konflux-operator
+    newTag: 9174d328f6073de7f5ddb59dc1121989c380ff2e

--- a/components/konflux-operator/rings/ring-1/base/kustomization.yaml
+++ b/components/konflux-operator/rings/ring-1/base/kustomization.yaml
@@ -1,0 +1,19 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - invariant
+
+components:
+  - cr/build
+  - cr/image-controller
+  - cr/integration
+  - cr/konflux-info
+  - cr/konflux-ui
+  - cr/namespace-lister
+  - cr/release
+  - cr/enterprise-contract
+  - cr/konflux-rbac
+
+patches:
+  - path: release-config.yaml

--- a/components/konflux-operator/rings/ring-1/base/release-config.yaml
+++ b/components/konflux-operator/rings/ring-1/base/release-config.yaml
@@ -1,0 +1,11 @@
+apiVersion: konflux.konflux-ci.dev/v1alpha1
+kind: Konflux
+metadata:
+  name: konflux
+spec:
+  certManager:
+    createClusterIssuer: true
+  internalRegistry:
+    enabled: false
+  defaultTenant:
+    enabled: false

--- a/components/konflux-operator/rings/ring-1/stone-stage-p01/build/OWNERS
+++ b/components/konflux-operator/rings/ring-1/stone-stage-p01/build/OWNERS
@@ -1,0 +1,16 @@
+# See the OWNERS docs: https://go.k8s.io/owners
+# Should be kept in sync with components/monitoring/grafana/base/dashboards/build-service/OWNERS
+
+approvers:
+- mmorhun
+- rcerven
+- mkosiarc
+- tisutisu
+- chmeliik
+
+reviewers:
+- mmorhun
+- rcerven
+- mkosiarc
+- tisutisu
+- chmeliik

--- a/components/konflux-operator/rings/ring-1/stone-stage-p01/build/external-secret-path-patch.yaml
+++ b/components/konflux-operator/rings/ring-1/stone-stage-p01/build/external-secret-path-patch.yaml
@@ -1,0 +1,3 @@
+- op: add
+  path: /spec/dataFrom/0/extract/key
+  value: staging/pipeline-service/stone-stage-p01/github-app

--- a/components/konflux-operator/rings/ring-1/stone-stage-p01/integration/OWNERS
+++ b/components/konflux-operator/rings/ring-1/stone-stage-p01/integration/OWNERS
@@ -1,0 +1,21 @@
+# See the OWNERS docs: https://go.k8s.io/owners
+
+approvers:
+- dirgim
+- jsztuka
+- kasemAlem
+- sonam1412
+- Josh-Everett
+- 14rcole
+- jencull
+- NigelByrne1
+
+reviewers:
+- dirgim
+- jsztuka
+- kasemAlem
+- sonam1412
+- Josh-Everett
+- 14rcole
+- jencull
+- NigelByrne1

--- a/components/konflux-operator/rings/ring-1/stone-stage-p01/integration/external-secret-path-patch.yaml
+++ b/components/konflux-operator/rings/ring-1/stone-stage-p01/integration/external-secret-path-patch.yaml
@@ -1,0 +1,3 @@
+- op: add
+  path: /spec/dataFrom/0/extract/key
+  value: staging/pipeline-service/stone-stage-p01/github-app

--- a/components/konflux-operator/rings/ring-1/stone-stage-p01/konflux-info/OWNERS
+++ b/components/konflux-operator/rings/ring-1/stone-stage-p01/konflux-info/OWNERS
@@ -1,0 +1,47 @@
+# See the OWNERS docs: https://go.k8s.io/owners
+
+approvers:
+# infra-team
+- sadlerap
+- eisraeli
+- filariow
+- gbenhaim
+- hugares
+- manish-jangra
+# sre-team
+- dgregor
+- jdcasey
+# ui-team
+- abhinandan13jan
+- caugello
+- CryptoRodeo
+- JoaoPedroPP
+- Katka92
+- sahil143
+- rrosatti
+- StanislavJochman
+# others
+- arewm
+
+reviewers:
+# infra-team
+- sadlerap
+- eisraeli
+- filariow
+- gbenhaim
+- hugares
+- manish-jangra
+# sre-team
+- dgregor
+- jdcasey
+# ui-team
+- abhinandan13jan
+- caugello
+- CryptoRodeo
+- JoaoPedroPP
+- Katka92
+- sahil143
+- rrosatti
+- StanislavJochman
+# others
+- arewm

--- a/components/konflux-operator/rings/ring-1/stone-stage-p01/konflux-info/info-patch.yaml
+++ b/components/konflux-operator/rings/ring-1/stone-stage-p01/konflux-info/info-patch.yaml
@@ -1,0 +1,13 @@
+apiVersion: konflux.konflux-ci.dev/v1alpha1
+kind: Konflux
+metadata:
+  name: konflux
+spec:
+  info:
+    spec:
+      publicInfo:
+        visibility: private
+        statusPageUrl: "https://grafana.app-sre.devshift.net/d/aes1ns0htwni8a/konflux-status-page?var-cluster=stone-stage-p01"
+        integrations:
+          github:
+            application_url: "https://github.com/apps/konflux-staging-internal"

--- a/components/konflux-operator/rings/ring-1/stone-stage-p01/konflux-ui/OWNERS
+++ b/components/konflux-operator/rings/ring-1/stone-stage-p01/konflux-ui/OWNERS
@@ -1,0 +1,47 @@
+# See the OWNERS docs: https://go.k8s.io/owners
+
+approvers:
+# infra-team
+- sadlerap
+- eisraeli
+- filariow
+- gbenhaim
+- hugares
+- manish-jangra
+# sre-team
+- dgregor
+- jdcasey
+# ui-team
+- abhinandan13jan
+- caugello
+- CryptoRodeo
+- JoaoPedroPP
+- Katka92
+- sahil143
+- rrosatti
+- StanislavJochman
+# others
+- arewm
+
+reviewers:
+# infra-team
+- sadlerap
+- eisraeli
+- filariow
+- gbenhaim
+- hugares
+- manish-jangra
+# sre-team
+- dgregor
+- jdcasey
+# ui-team
+- abhinandan13jan
+- caugello
+- CryptoRodeo
+- JoaoPedroPP
+- Katka92
+- sahil143
+- rrosatti
+- StanislavJochman
+# others
+- arewm

--- a/components/konflux-operator/rings/ring-1/stone-stage-p01/konflux-ui/ui-patch.yaml
+++ b/components/konflux-operator/rings/ring-1/stone-stage-p01/konflux-ui/ui-patch.yaml
@@ -1,0 +1,22 @@
+apiVersion: konflux.konflux-ci.dev/v1alpha1
+kind: Konflux
+metadata:
+  name: konflux
+spec:
+  ui:
+    spec:
+      dex:
+        config:
+          connectors:
+            - type: openshift
+              id: openshift
+              name: OpenShift
+              config:
+                issuer: https://api.stone-stage-p01.hpmt.p1.openshiftapps.com:6443
+                clientID: $OPENSHIFT_OAUTH_CLIENT_ID
+                clientSecret: $OPENSHIFT_OAUTH_CLIENT_SECRET
+      runtimeConfig:
+        chatBot:
+          enabled: false
+        monitoring:
+          cluster: stone-stage-p01

--- a/components/konflux-operator/rings/ring-1/stone-stage-p01/kustomization.yaml
+++ b/components/konflux-operator/rings/ring-1/stone-stage-p01/kustomization.yaml
@@ -1,0 +1,24 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../base
+
+patches:
+  - path: build/external-secret-path-patch.yaml
+    target:
+      name: pipelines-as-code-secret
+      namespace: build-service
+      group: external-secrets.io
+      version: v1
+      kind: ExternalSecret
+  - path: integration/external-secret-path-patch.yaml
+    target:
+      name: pipelines-as-code-secret
+      namespace: integration-service
+      group: external-secrets.io
+      version: v1
+      kind: ExternalSecret
+  - path: konflux-info/info-patch.yaml
+  - path: konflux-ui/ui-patch.yaml
+  - path: namespace-lister/resources-patch.yaml

--- a/components/konflux-operator/rings/ring-1/stone-stage-p01/namespace-lister/OWNERS
+++ b/components/konflux-operator/rings/ring-1/stone-stage-p01/namespace-lister/OWNERS
@@ -1,0 +1,7 @@
+# See the OWNERS docs: https://go.k8s.io/owners
+
+approvers:
+- konflux-infra-team
+
+reviewers:
+- konflux-infra-team

--- a/components/konflux-operator/rings/ring-1/stone-stage-p01/namespace-lister/resources-patch.yaml
+++ b/components/konflux-operator/rings/ring-1/stone-stage-p01/namespace-lister/resources-patch.yaml
@@ -1,0 +1,13 @@
+apiVersion: konflux.konflux-ci.dev/v1alpha1
+kind: Konflux
+metadata:
+  name: konflux
+spec:
+  namespaceLister:
+    spec:
+      namespaceLister:
+        resources:
+          requests:
+            memory: 500Mi
+          limits:
+            memory: 500Mi


### PR DESCRIPTION


Deploy the Konflux operator to the rd-staging ArgoCD overlay, targeting internal staging clusters via the empty-base pattern. The operator ApplicationSet defaults to empty-base (deploys nothing) and is activated per-cluster through the existing internal-clusters-patch.

Ring-1 defines the full set of operator CRs for staging:
- Konflux CR with operator image pinned at 9174d328
- Sub-CRs for all managed services (build, integration, image-controller, release, enterprise-contract, konflux-info, konflux-ui, namespace-lister, konflux-rbac)
- Supplementary resources not managed by the operator (team RBAC, trusted-ca ConfigMaps, CronJobs, ExternalSecrets, signing configs)
- Cluster-specific overlay for stone-stage-p01 (Vault paths, UI hostname, resource limits)

This PR only adds the operator deployment. Legacy services remain active and are not modified. Disabling legacy services on operator-managed clusters will follow in a separate PR.

Assisted-by: Cursor + Opus 4.6