### PR TITLE
chore(): increase konflux-operator resources

### DIFF
--- a/components/konflux-operator/rings/ring-1/base/kustomization.yaml
+++ b/components/konflux-operator/rings/ring-1/base/kustomization.yaml
@@ -17,3 +17,4 @@ components:
 
 patches:
   - path: release-config.yaml
+  - path: manager-resources-patch.yaml

--- a/components/konflux-operator/rings/ring-1/base/manager-resources-patch.yaml
+++ b/components/konflux-operator/rings/ring-1/base/manager-resources-patch.yaml
@@ -1,0 +1,17 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: konflux-operator-controller-manager
+  namespace: konflux-operator
+spec:
+  template:
+    spec:
+      containers:
+        - name: manager
+          resources:
+            limits:
+              cpu: 500m
+              memory: 1Gi
+            requests:
+              cpu: 500m
+              memory: 1Gi


### PR DESCRIPTION
Increase konflux-operator resources to 1Gi for ring-1.

Assisted-by: Cursor + Opus 4.6