### PR TITLE
fix: namespace-lister resources in CR and fix patch

### DIFF
--- a/components/konflux-operator/rings/ring-1/base/cr/namespace-lister/namespace-lister.yaml
+++ b/components/konflux-operator/rings/ring-1/base/cr/namespace-lister/namespace-lister.yaml
@@ -9,11 +9,3 @@ spec:
       logLevel: info
       namespaceLister:
         replicas: 3
-        namespaceLister:
-          resources:
-            requests:
-              cpu: 4000m
-              memory: 6Gi
-            limits:
-              cpu: 4000m
-              memory: 6Gi

--- a/components/konflux-operator/rings/ring-1/stone-stage-p01/namespace-lister/resources-patch.yaml
+++ b/components/konflux-operator/rings/ring-1/stone-stage-p01/namespace-lister/resources-patch.yaml
@@ -6,8 +6,9 @@ spec:
   namespaceLister:
     spec:
       namespaceLister:
-        resources:
-          requests:
-            memory: 500Mi
-          limits:
-            memory: 500Mi
+        namespaceLister:
+          resources:
+            requests:
+              memory: 500Mi
+            limits:
+              memory: 500Mi


### PR DESCRIPTION
namespace-lister resources were placed in the CR rather than the patch. At the same time, the patch was broken as the resources were not placed under the namespaceLister pod.

This change should address both issues.