### PR TITLE
chore(): update konflux-operator reference

### DIFF
--- a/components/konflux-operator/rings/ring-1/base/invariant/kustomization.yaml
+++ b/components/konflux-operator/rings/ring-1/base/invariant/kustomization.yaml
@@ -1,10 +1,10 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - https://github.com/konflux-ci/konflux-ci/operator/config/default?ref=9174d328f6073de7f5ddb59dc1121989c380ff2e
+  - https://github.com/konflux-ci/konflux-ci/operator/config/default?ref=754f650f9a44e81cfaaa9cb0cf1f90aa8b4ddb9d
   - konflux.yaml
 
 images:
   - name: localhost/konflux-operator
     newName: quay.io/konflux-ci/konflux-operator
-    newTag: 9174d328f6073de7f5ddb59dc1121989c380ff2e
+    newTag: 754f650f9a44e81cfaaa9cb0cf1f90aa8b4ddb9d


### PR DESCRIPTION
Update the konflux-operator reference to the latest version.