### PR TITLE
Promote project-controller to production

### DIFF
--- a/components/project-controller/production/kustomization.yaml
+++ b/components/project-controller/production/kustomization.yaml
@@ -2,11 +2,11 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../base
-  - https://github.com/konflux-ci/project-controller/config/default?ref=a363382369ec76bba26a6d508e1d3ae9f33508a1
+  - https://github.com/konflux-ci/project-controller/config/default?ref=55d8d9c84e312e7ffe334661b172b135eec6067a
 
 images:
 - name: konflux-project-controller
   newName: quay.io/konflux-ci/project-controller
-  newTag: a363382369ec76bba26a6d508e1d3ae9f33508a1
+  newTag: 55d8d9c84e312e7ffe334661b172b135eec6067a
 
 namespace: project-controller


### PR DESCRIPTION
## What

Bump project-controller production to `55d8d9c` (matches staging).

Clusters affected: all clusters using `components/project-controller/production`

[KONFLUX-14271](https://issues.redhat.com/browse/KONFLUX-14271)

## Why

Promote staging-validated update from #12827 (includes ImageRepository annotation fix).

## Validation

- `kustomize build --enable-helm components/project-controller/production/` passes
- Staging: https://github.com/redhat-appstudio/infra-deployments/pull/12827

## Risk Assessment

**Risk Level:** Low
**What could go wrong:** PDS / ImageRepository annotation reconciliation regresses.
**Rollback:** Revert PR (back to `a363382`)
**Blast radius:** production-downstream and konflux-public-production clusters running project-controller

Made with [Cursor](https://cursor.com)

[KONFLUX-14271]: https://redhat.atlassian.net/browse/KONFLUX-14271?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ