### PR TITLE
RELEASE-2681: fix staging Vault path for release-service GitHub token

### DIFF
--- a/components/release/staging/external-secrets/release-service-github-token.yaml
+++ b/components/release/staging/external-secrets/release-service-github-token.yaml
@@ -10,7 +10,7 @@ spec:
   data:
     - secretKey: token
       remoteRef:
-        key: release/github/konflux-release-service
+        key: staging/release/github/konflux-release-service
         property: token
   refreshInterval: 1h
   secretStoreRef:


### PR DESCRIPTION
## Summary
Follow-up to #13196. ExternalSecret could not sync because the Vault secret lives under the `stonesoup` mount at `staging/release/...`, not `release/github/...` under `konflux`.
## Change
- Update `remoteRef.key` to `staging/release/github/konflux-release-service`