### PR TITLE
PVO11Y-5384 Enable delivery tracing in staging

### DIFF
--- a/components/integration/staging/base/manager_resources_patch.yaml
+++ b/components/integration/staging/base/manager_resources_patch.yaml
@@ -78,3 +78,11 @@ spec:
               name: integration-config
               key: GITHUBPRIVATE_KEY
               optional: true
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: "http://open-telemetry-opentelemetry-collector.konflux-otel.svc.cluster.local:4317"
+        - name: TRACING_LABEL_ACTION
+          value: pipelines.appstudio.openshift.io/type
+        - name: TRACING_LABEL_APPLICATION
+          value: appstudio.openshift.io/application
+        - name: TRACING_LABEL_COMPONENT
+          value: appstudio.openshift.io/component

--- a/components/pipeline-service/staging/base/main-pipeline-service-configuration.yaml
+++ b/components/pipeline-service/staging/base/main-pipeline-service-configuration.yaml
@@ -1804,6 +1804,11 @@ spec:
               spec:
                 containers:
                   - name: pac-controller
+                    env:
+                      - name: OTEL_EXPORTER_OTLP_ENDPOINT
+                        value: "http://open-telemetry-opentelemetry-collector.konflux-otel.svc.cluster.local:4317"
+                      - name: OTEL_TRACES_SAMPLER
+                        value: "parentbased_always_on"
                     resources:
                       limits:
                         cpu: 500m
@@ -1817,6 +1822,11 @@ spec:
               spec:
                 containers:
                   - name: pac-watcher
+                    env:
+                      - name: OTEL_EXPORTER_OTLP_ENDPOINT
+                        value: "http://open-telemetry-opentelemetry-collector.konflux-otel.svc.cluster.local:4317"
+                      - name: OTEL_TRACES_SAMPLER
+                        value: "parentbased_always_on"
                     resources:
                       limits:
                         cpu: 250m
@@ -2023,6 +2033,9 @@ spec:
           remember-ok-to-test: "false"
           secret-github-app-token-scoped: "false"
           enable-cancel-in-progress-on-pull-requests: "true"
+          tracing-label-action: pipelines.appstudio.openshift.io/type
+          tracing-label-application: appstudio.openshift.io/application
+          tracing-label-component: appstudio.openshift.io/component
   profile: all
   pruner:
     disabled: true

--- a/components/pipeline-service/staging/stone-stage-p01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stage-p01/deploy.yaml
@@ -2363,7 +2363,12 @@ spec:
             template:
               spec:
                 containers:
-                - name: pac-controller
+                - env:
+                  - name: OTEL_EXPORTER_OTLP_ENDPOINT
+                    value: http://open-telemetry-opentelemetry-collector.konflux-otel.svc.cluster.local:4317
+                  - name: OTEL_TRACES_SAMPLER
+                    value: parentbased_always_on
+                  name: pac-controller
                   resources:
                     limits:
                       cpu: 500m
@@ -2376,7 +2381,12 @@ spec:
             template:
               spec:
                 containers:
-                - name: pac-watcher
+                - env:
+                  - name: OTEL_EXPORTER_OTLP_ENDPOINT
+                    value: http://open-telemetry-opentelemetry-collector.konflux-otel.svc.cluster.local:4317
+                  - name: OTEL_TRACES_SAMPLER
+                    value: parentbased_always_on
+                  name: pac-watcher
                   resources:
                     limits:
                       cpu: 250m
@@ -2611,6 +2621,9 @@ spec:
           enable-cancel-in-progress-on-pull-requests: "true"
           remember-ok-to-test: "false"
           secret-github-app-token-scoped: "false"
+          tracing-label-action: pipelines.appstudio.openshift.io/type
+          tracing-label-application: appstudio.openshift.io/application
+          tracing-label-component: appstudio.openshift.io/component
   profile: all
   pruner:
     disabled: true

--- a/components/pipeline-service/staging/stone-stage-p01/resources/update-tekton-config-pac.yaml
+++ b/components/pipeline-service/staging/stone-stage-p01/resources/update-tekton-config-pac.yaml
@@ -11,3 +11,6 @@
     remember-ok-to-test: "false"
     secret-github-app-token-scoped: "false"
     enable-cancel-in-progress-on-pull-requests: "true"
+    tracing-label-action: pipelines.appstudio.openshift.io/type
+    tracing-label-application: appstudio.openshift.io/application
+    tracing-label-component: appstudio.openshift.io/component

--- a/components/pipeline-service/staging/stone-stg-rh01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stg-rh01/deploy.yaml
@@ -2363,7 +2363,12 @@ spec:
             template:
               spec:
                 containers:
-                - name: pac-controller
+                - env:
+                  - name: OTEL_EXPORTER_OTLP_ENDPOINT
+                    value: http://open-telemetry-opentelemetry-collector.konflux-otel.svc.cluster.local:4317
+                  - name: OTEL_TRACES_SAMPLER
+                    value: parentbased_always_on
+                  name: pac-controller
                   resources:
                     limits:
                       cpu: 500m
@@ -2376,7 +2381,12 @@ spec:
             template:
               spec:
                 containers:
-                - name: pac-watcher
+                - env:
+                  - name: OTEL_EXPORTER_OTLP_ENDPOINT
+                    value: http://open-telemetry-opentelemetry-collector.konflux-otel.svc.cluster.local:4317
+                  - name: OTEL_TRACES_SAMPLER
+                    value: parentbased_always_on
+                  name: pac-watcher
                   resources:
                     limits:
                       cpu: 250m
@@ -2623,6 +2633,9 @@ spec:
           enable-cancel-in-progress-on-pull-requests: "true"
           remember-ok-to-test: "false"
           secret-github-app-token-scoped: "false"
+          tracing-label-action: pipelines.appstudio.openshift.io/type
+          tracing-label-application: appstudio.openshift.io/application
+          tracing-label-component: appstudio.openshift.io/component
   profile: all
   pruner:
     disabled: true

--- a/components/release/staging/controller-manager-otel-env-patch.yaml
+++ b/components/release/staging/controller-manager-otel-env-patch.yaml
@@ -1,0 +1,19 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager
+        env:
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: "http://open-telemetry-opentelemetry-collector.konflux-otel.svc.cluster.local:4317"
+        - name: TRACING_LABEL_ACTION
+          value: pipelines.appstudio.openshift.io/type
+        - name: TRACING_LABEL_APPLICATION
+          value: appstudio.openshift.io/application
+        - name: TRACING_LABEL_COMPONENT
+          value: appstudio.openshift.io/component

--- a/components/release/staging/kustomization.yaml
+++ b/components/release/staging/kustomization.yaml
@@ -25,3 +25,4 @@ patches:
       kind: ClusterRole
       name: release-pipeline-resource-role
     path: ibm-public-key-patch.yaml
+  - path: controller-manager-otel-env-patch.yaml


### PR DESCRIPTION
Set OTEL_EXPORTER_OTLP_ENDPOINT to the konflux-otel collector on pipelines-as-code, integration-service and release-service in staging, OTEL_TRACES_SAMPLER on PaC, and the tracing label config on all three.

PVO11Y-5384