### PR TITLE
feat: include operator feat/fix commits in changelog PR comments

### DIFF
--- a/infra-tools/cmd/changelog-generator/main.go
+++ b/infra-tools/cmd/changelog-generator/main.go
@@ -3,7 +3,7 @@
 //
 // Detects upstream service bumps by git ref and by image digest, resolves
 // digest-pinned components to git SHAs via OCI labels, and displays
-// per-service feat/fix commits under each bump entry.
+// feat/fix commits for the operator itself and under each operand bump entry.
 package main
 
 import (
@@ -118,8 +118,9 @@ func buildBody(ctx context.Context, repoRoot, baseRef, kustPath string, comparer
 // setup happens in buildBody; this function only does file I/O, API calls, and
 // formatting.
 //
-// If the GitHub API call to fetch operator file diffs fails, the comment still
-// includes the compare link but notes that service bump detection was unavailable.
+// If the GitHub API call to fetch the operator compare fails, the comment still
+// includes the compare link but notes that commit details and service bump
+// detection were unavailable.
 func computeBody(ctx context.Context, basePath, headPath string, comparer changelog.RepoComparer, inspector changelog.RegistryInspector) (string, error) {
 	oldRef, newRef, err := changelog.ExtractRefs(basePath, headPath)
 	if err != nil {
@@ -134,12 +135,18 @@ func computeBody(ctx context.Context, basePath, headPath string, comparer change
 
 	compare, err := changelog.FetchOperatorCompare(ctx, comparer, oldRef, newRef)
 	if err != nil {
-		slog.Warn("fetching operator compare; service bumps unavailable", "err", err)
-		return formatCompare(oldRef, newRef, nil), nil
+		slog.Warn("fetching operator compare; commit details and service bumps unavailable", "err", err)
+		return formatCompare(oldRef, newRef, commitDetails{Failed: true}, nil), nil
 	}
+
+	op := commitDetails{
+		Commits:   compare.Commits,
+		Truncated: compare.CommitsTruncated,
+	}
+
 	if compare.Truncated {
 		slog.Warn("operator compare truncated (≥300 files); service bump detection unavailable")
-		return formatCompare(oldRef, newRef, nil), nil
+		return formatCompare(oldRef, newRef, op, nil), nil
 	}
 
 	refBumps, refSkipped := changelog.ExtractServiceBumps(compare.Files)
@@ -149,7 +156,7 @@ func computeBody(ctx context.Context, basePath, headPath string, comparer change
 		// confidently state what changed, so degrade the same way we do for API
 		// failures rather than risk a misleading empty-bumps message.
 		slog.Warn("some upstream kustomization patches were empty; bump detection may be incomplete")
-		return formatCompare(oldRef, newRef, nil), nil
+		return formatCompare(oldRef, newRef, op, nil), nil
 	}
 
 	imageBumps := resolveImageBumps(ctx, inspector, imgChanges)
@@ -157,22 +164,28 @@ func computeBody(ctx context.Context, basePath, headPath string, comparer change
 		// Digest changes were detected in the compare diff but none resolved to git
 		// SHAs — degrade rather than report "no upstream service refs changed".
 		slog.Warn("digest changes detected but registry resolution produced no bumps")
-		return formatCompare(oldRef, newRef, nil), nil
+		return formatCompare(oldRef, newRef, op, nil), nil
 	}
 	allBumps := append(refBumps, imageBumps...)
 	slog.Info("Service bumps detected", "count", len(allBumps))
 
 	enriched := enrichWithCommits(ctx, comparer, allBumps)
-	return formatCompare(oldRef, newRef, enriched), nil
+	return formatCompare(oldRef, newRef, op, enriched), nil
+}
+
+// commitDetails holds feat/fix commits (or a failure/truncation flag) for
+// rendering under the operator section or an individual service bump.
+type commitDetails struct {
+	Commits   []changelog.ConventionalCommit
+	Failed    bool // true when the commit fetch API call failed
+	Truncated bool // true when AheadBy hit the 250-commit API limit
 }
 
 // bumpWithCommits pairs a ServiceBump with the conventional commits found
 // between its old and new SHAs.
 type bumpWithCommits struct {
-	Bump      changelog.ServiceBump
-	Commits   []changelog.ConventionalCommit
-	Failed    bool // true when the commit fetch API call failed
-	Truncated bool // true when AheadBy hit the 250-commit API limit
+	Bump changelog.ServiceBump
+	commitDetails
 }
 
 // enrichWithCommits fetches feat/fix commits for each bump and returns a
@@ -189,10 +202,16 @@ func enrichWithCommits(ctx context.Context, comparer changelog.RepoComparer, bum
 		commits, truncated, err := changelog.FetchServiceCommits(ctx, comparer, bump)
 		if err != nil {
 			slog.Warn("fetching service commits", "service", bump.Repo, "err", err)
-			result[i] = bumpWithCommits{Bump: bump, Failed: true}
+			result[i] = bumpWithCommits{Bump: bump, commitDetails: commitDetails{Failed: true}}
 			continue
 		}
-		result[i] = bumpWithCommits{Bump: bump, Commits: commits, Truncated: truncated}
+		result[i] = bumpWithCommits{
+			Bump: bump,
+			commitDetails: commitDetails{
+				Commits:   commits,
+				Truncated: truncated,
+			},
+		}
 	}
 	return result
 }
@@ -202,12 +221,13 @@ func formatNoChange() string {
 	return commentMarker + "\n### Operator Changelog\n\nNo operator ref change detected in this PR.\n"
 }
 
-// formatCompare returns the comment body with the operator compare link, the
-// list of upstream service bumps, and per-service feat/fix commit summaries.
+// formatCompare returns the comment body with the operator compare link,
+// operator feat/fix commits, the list of upstream service bumps, and
+// per-service feat/fix commit summaries.
 //
 // bumps == nil means the service bump detection API call failed (degraded).
 // bumps == [] means the call succeeded but no sub-service SHAs changed.
-func formatCompare(oldRef, newRef string, bumps []bumpWithCommits) string {
+func formatCompare(oldRef, newRef string, op commitDetails, bumps []bumpWithCommits) string {
 	const base = "https://github.com/konflux-ci/konflux-ci"
 	short := func(ref string) string {
 		if len(ref) > 12 {
@@ -221,7 +241,8 @@ func formatCompare(oldRef, newRef string, bumps []bumpWithCommits) string {
 	fmt.Fprintf(&b, "Comparing [`%s`](%s/commit/%s) → [`%s`](%s/commit/%s)\n\n",
 		short(oldRef), base, oldRef,
 		short(newRef), base, newRef)
-	fmt.Fprintf(&b, "[Full diff](%s/compare/%s...%s)\n\n", base, oldRef, newRef)
+	fmt.Fprintf(&b, "[Full diff](%s/compare/%s...%s)\n", base, oldRef, newRef)
+	writeCommitDetails(&b, op)
 
 	switch {
 	case bumps == nil:
@@ -242,30 +263,42 @@ func formatCompare(oldRef, newRef string, bumps []bumpWithCommits) string {
 				short(bump.OldSHA), oldURL,
 				short(bump.NewSHA), newURL,
 				compareURL)
-
-			switch {
-			case bwc.Failed:
-				fmt.Fprintf(&b, "\n_Commit details unavailable._\n\n")
-			case len(bwc.Commits) == 0:
-				fmt.Fprintf(&b, "\n_No notable commits (feat/fix)._\n\n")
-			default:
-				fmt.Fprintln(&b)
-				for _, c := range bwc.Commits {
-					if c.Scope != "" {
-						fmt.Fprintf(&b, "- %s(%s): %s\n", c.Type, c.Scope, c.Subject)
-					} else {
-						fmt.Fprintf(&b, "- %s: %s\n", c.Type, c.Subject)
-					}
-				}
-				if bwc.Truncated {
-					fmt.Fprintf(&b, "\n_Showing first %d commits only — results may be incomplete._\n", changelog.CommitMaxFromCompare)
-				}
-				fmt.Fprintln(&b)
-			}
+			writeCommitDetails(&b, bwc.commitDetails)
 		}
 	}
 
 	return b.String()
+}
+
+// writeCommitDetails appends feat/fix bullets (or a failure / empty note)
+// for either the operator section or a single service bump.
+//
+// When Truncated is set, the GitHub compare API returned only the first
+// CommitMaxFromCompare commits, so an empty filtered list must not be stated
+// as a definitive "no notable commits" result.
+func writeCommitDetails(b *strings.Builder, d commitDetails) {
+	switch {
+	case d.Failed:
+		fmt.Fprintf(b, "\n_Commit details unavailable._\n\n")
+	case len(d.Commits) == 0 && d.Truncated:
+		fmt.Fprintf(b, "\n_No notable commits (feat/fix) in the first %d commits — results may be incomplete._\n\n",
+			changelog.CommitMaxFromCompare)
+	case len(d.Commits) == 0:
+		fmt.Fprintf(b, "\n_No notable commits (feat/fix)._\n\n")
+	default:
+		fmt.Fprintln(b)
+		for _, c := range d.Commits {
+			if c.Scope != "" {
+				fmt.Fprintf(b, "- %s(%s): %s\n", c.Type, c.Scope, c.Subject)
+			} else {
+				fmt.Fprintf(b, "- %s: %s\n", c.Type, c.Subject)
+			}
+		}
+		if d.Truncated {
+			fmt.Fprintf(b, "\n_Showing first %d commits only — results may be incomplete._\n", changelog.CommitMaxFromCompare)
+		}
+		fmt.Fprintln(b)
+	}
 }
 
 // resolveImageBumps converts image digest changes into ServiceBumps by calling

--- a/infra-tools/cmd/changelog-generator/main_test.go
+++ b/infra-tools/cmd/changelog-generator/main_test.go
@@ -35,16 +35,19 @@ func (f *fakeCommenter) UpsertCommentByMarker(_ context.Context, prNumber int, b
 }
 
 // fakeRepoComparer implements changelog.RepoComparer for testing.
-// The operator compare call (repo == "konflux-ci") uses err and files.
+// The operator compare call (repo == "konflux-ci") uses err, files,
+// operatorCommits, and operatorAheadBy.
 // Service compare calls (any other repo) use commitErr and commits/aheadBy.
 var _ changelog.RepoComparer = &fakeRepoComparer{}
 
 type fakeRepoComparer struct {
-	files     []*gh.CommitFile
-	commits   []*gh.RepositoryCommit
-	aheadBy   int
-	err       error // returned for the operator compare call
-	commitErr error // returned for service compare calls
+	files           []*gh.CommitFile
+	operatorCommits []*gh.RepositoryCommit
+	operatorAheadBy int
+	commits         []*gh.RepositoryCommit
+	aheadBy         int
+	err             error // returned for the operator compare call
+	commitErr       error // returned for service compare calls
 }
 
 func (f *fakeRepoComparer) CompareCommits(_ context.Context, _, repo, _, _ string, _ *gh.ListOptions) (*gh.CommitsComparison, *gh.Response, error) {
@@ -52,7 +55,11 @@ func (f *fakeRepoComparer) CompareCommits(_ context.Context, _, repo, _, _ strin
 		if f.err != nil {
 			return nil, nil, f.err
 		}
-		return &gh.CommitsComparison{Files: f.files}, nil, nil
+		return &gh.CommitsComparison{
+			Files:   f.files,
+			Commits: f.operatorCommits,
+			AheadBy: gh.Ptr(f.operatorAheadBy),
+		}, nil, nil
 	}
 	// Service compare call
 	if f.commitErr != nil {
@@ -116,9 +123,62 @@ func TestPost_PassesCorrectMarkerAndBody(t *testing.T) {
 // are not truncated — the short() helper takes a different branch.
 func TestFormatCompare_ShortRef(t *testing.T) {
 	g := NewWithT(t)
-	body := formatCompare("main", "feature-x", nil)
+	body := formatCompare("main", "feature-x", commitDetails{Failed: true}, nil)
 	g.Expect(body).To(ContainSubstring("main"))
 	g.Expect(body).To(ContainSubstring("feature-x"))
+}
+
+// TestFormatCompare_OperatorCommits verifies operator feat/fix bullets and
+// scoped subjects render between Full diff and the service-bumps section.
+func TestFormatCompare_OperatorCommits(t *testing.T) {
+	g := NewWithT(t)
+	op := commitDetails{
+		Commits: []changelog.ConventionalCommit{
+			{Type: "feat", Scope: "operator", Subject: "add ring sync"},
+			{Type: "fix", Subject: "nil pointer in reconcile"},
+		},
+	}
+	body := formatCompare(oldRef, newRef, op, []bumpWithCommits{})
+	g.Expect(body).To(ContainSubstring("feat(operator): add ring sync"))
+	g.Expect(body).To(ContainSubstring("fix: nil pointer in reconcile"))
+	g.Expect(body).To(ContainSubstring("No upstream service refs changed"))
+	// Operator bullets appear before the service section.
+	opIdx := strings.Index(body, "feat(operator): add ring sync")
+	svcIdx := strings.Index(body, "No upstream service refs changed")
+	g.Expect(opIdx).To(BeNumerically("<", svcIdx))
+}
+
+// TestFormatCompare_OperatorTruncated verifies the 250-commit truncation note
+// appears after operator commit bullets.
+func TestFormatCompare_OperatorTruncated(t *testing.T) {
+	g := NewWithT(t)
+	op := commitDetails{
+		Commits:   []changelog.ConventionalCommit{{Type: "feat", Subject: "something"}},
+		Truncated: true,
+	}
+	body := formatCompare(oldRef, newRef, op, []bumpWithCommits{})
+	g.Expect(body).To(ContainSubstring("feat: something"))
+	g.Expect(body).To(ContainSubstring("250 commits"))
+}
+
+// TestFormatCompare_OperatorEmptyButTruncated verifies that when the compare
+// API is truncated and no feat/fix commits appear in the returned subset, the
+// comment notes the 250-commit limit instead of claiming there are none.
+func TestFormatCompare_OperatorEmptyButTruncated(t *testing.T) {
+	g := NewWithT(t)
+	body := formatCompare(oldRef, newRef, commitDetails{Truncated: true}, []bumpWithCommits{})
+	g.Expect(body).To(ContainSubstring("No notable commits (feat/fix) in the first 250 commits"))
+	g.Expect(body).To(ContainSubstring("results may be incomplete"))
+	g.Expect(body).NotTo(ContainSubstring("_No notable commits (feat/fix)._"))
+}
+
+// TestFormatCompare_OperatorFailed verifies commit-details failure note for
+// the operator section.
+func TestFormatCompare_OperatorFailed(t *testing.T) {
+	g := NewWithT(t)
+	body := formatCompare(oldRef, newRef, commitDetails{Failed: true}, nil)
+	g.Expect(body).To(ContainSubstring("Commit details unavailable"))
+	g.Expect(body).To(ContainSubstring("Upstream service bump detection unavailable"))
 }
 
 // TestComputeBody_Unchanged verifies that identical kustomization files produce
@@ -135,7 +195,8 @@ func TestComputeBody_Unchanged(t *testing.T) {
 
 // TestComputeBody_Changed verifies that different kustomization files produce
 // a compare comment containing both refs and a compare URL. No service bumps
-// in this case because the fake comparer returns no files.
+// in this case because the fake comparer returns no files; with no operator
+// commits the body notes that explicitly.
 func TestComputeBody_Changed(t *testing.T) {
 	g := NewWithT(t)
 	basePath := writeTempKustomization(t, oldRef)
@@ -147,8 +208,91 @@ func TestComputeBody_Changed(t *testing.T) {
 	g.Expect(body).To(ContainSubstring(newRef))
 	g.Expect(body).To(ContainSubstring(oldRef[:12]))
 	g.Expect(body).To(ContainSubstring("konflux-ci/konflux-ci/compare/" + oldRef + "..." + newRef))
+	g.Expect(body).To(ContainSubstring("No notable commits"))
 	g.Expect(body).To(ContainSubstring("No upstream service refs changed"))
 	g.Expect(body).NotTo(ContainSubstring("No operator ref change"))
+}
+
+// TestComputeBody_WithOperatorCommits verifies that feat/fix commits returned
+// on the operator compare appear in the operator section, while chore commits
+// are filtered out.
+func TestComputeBody_WithOperatorCommits(t *testing.T) {
+	g := NewWithT(t)
+	fake := &fakeRepoComparer{
+		operatorCommits: []*gh.RepositoryCommit{
+			{SHA: gh.Ptr("c1c1c1c1c1c1"), Commit: &gh.Commit{Message: gh.Ptr("feat(operator): wire scrape token")}},
+			{SHA: gh.Ptr("c2c2c2c2c2c2"), Commit: &gh.Commit{Message: gh.Ptr("fix: avoid double reconcile")}},
+			{SHA: gh.Ptr("c3c3c3c3c3c3"), Commit: &gh.Commit{Message: gh.Ptr("chore: bump deps")}},
+		},
+	}
+	basePath := writeTempKustomization(t, oldRef)
+	headPath := writeTempKustomization(t, newRef)
+	body, err := computeBody(context.Background(), basePath, headPath, fake, &fakeRegistryInspector{})
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(body).To(ContainSubstring("feat(operator): wire scrape token"))
+	g.Expect(body).To(ContainSubstring("fix: avoid double reconcile"))
+	g.Expect(body).NotTo(ContainSubstring("chore:"))
+	g.Expect(body).To(ContainSubstring("No upstream service refs changed"))
+}
+
+// TestComputeBody_OperatorCommitsTruncated verifies that when AheadBy hits the
+// 250-commit API limit on the operator compare, a truncation note appears.
+func TestComputeBody_OperatorCommitsTruncated(t *testing.T) {
+	g := NewWithT(t)
+	fake := &fakeRepoComparer{
+		operatorCommits: []*gh.RepositoryCommit{
+			{SHA: gh.Ptr("c1c1c1c1c1c1"), Commit: &gh.Commit{Message: gh.Ptr("feat: large bump")}},
+		},
+		operatorAheadBy: 250,
+	}
+	basePath := writeTempKustomization(t, oldRef)
+	headPath := writeTempKustomization(t, newRef)
+	body, err := computeBody(context.Background(), basePath, headPath, fake, &fakeRegistryInspector{})
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(body).To(ContainSubstring("feat: large bump"))
+	g.Expect(body).To(ContainSubstring("250 commits"))
+}
+
+// TestComputeBody_OperatorEmptyButTruncated verifies that chore-only commits
+// under a truncated compare do not claim a definitive empty changelog.
+func TestComputeBody_OperatorEmptyButTruncated(t *testing.T) {
+	g := NewWithT(t)
+	fake := &fakeRepoComparer{
+		operatorCommits: []*gh.RepositoryCommit{
+			{SHA: gh.Ptr("c1c1c1c1c1c1"), Commit: &gh.Commit{Message: gh.Ptr("chore: bump deps")}},
+			{SHA: gh.Ptr("c2c2c2c2c2c2"), Commit: &gh.Commit{Message: gh.Ptr("docs: update README")}},
+		},
+		operatorAheadBy: 250,
+	}
+	basePath := writeTempKustomization(t, oldRef)
+	headPath := writeTempKustomization(t, newRef)
+	body, err := computeBody(context.Background(), basePath, headPath, fake, &fakeRegistryInspector{})
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(body).To(ContainSubstring("No notable commits (feat/fix) in the first 250 commits"))
+	g.Expect(body).To(ContainSubstring("results may be incomplete"))
+	g.Expect(body).NotTo(ContainSubstring("_No notable commits (feat/fix)._"))
+}
+
+// TestComputeBody_OperatorCommitsSurviveBumpDegrade verifies that operator
+// commits are still shown when file truncation forces bump-detection degrade.
+func TestComputeBody_OperatorCommitsSurviveBumpDegrade(t *testing.T) {
+	g := NewWithT(t)
+	files := make([]*gh.CommitFile, 300)
+	for i := range files {
+		files[i] = &gh.CommitFile{Filename: gh.Ptr("file.yaml"), Patch: gh.Ptr("diff")}
+	}
+	fake := &fakeRepoComparer{
+		files: files,
+		operatorCommits: []*gh.RepositoryCommit{
+			{SHA: gh.Ptr("c1c1c1c1c1c1"), Commit: &gh.Commit{Message: gh.Ptr("feat: still visible")}},
+		},
+	}
+	basePath := writeTempKustomization(t, oldRef)
+	headPath := writeTempKustomization(t, newRef)
+	body, err := computeBody(context.Background(), basePath, headPath, fake, &fakeRegistryInspector{})
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(body).To(ContainSubstring("feat: still visible"))
+	g.Expect(body).To(ContainSubstring("unavailable"))
 }
 
 // TestComputeBody_WithServiceBumps verifies that a fake comparer returning a
@@ -183,7 +327,7 @@ func TestComputeBody_WithServiceBumps(t *testing.T) {
 
 // TestComputeBody_APIFailureDegrades verifies that when the comparer returns an
 // error, the comment still includes the operator compare link (not an error page),
-// and notes that service bump detection was unavailable.
+// and notes that both commit details and service bump detection were unavailable.
 func TestComputeBody_APIFailureDegrades(t *testing.T) {
 	g := NewWithT(t)
 	basePath := writeTempKustomization(t, oldRef)
@@ -192,6 +336,7 @@ func TestComputeBody_APIFailureDegrades(t *testing.T) {
 	body, err := computeBody(context.Background(), basePath, headPath, fake, &fakeRegistryInspector{})
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(body).To(ContainSubstring("compare/" + oldRef + "..." + newRef))
+	g.Expect(body).To(ContainSubstring("Commit details unavailable"))
 	g.Expect(body).To(ContainSubstring("unavailable"))
 }
 
@@ -249,6 +394,43 @@ func TestComputeBody_Error(t *testing.T) {
 	_, err := computeBody(context.Background(), "/nonexistent/kustomization.yaml", "/nonexistent/kustomization.yaml", &fakeRepoComparer{}, &fakeRegistryInspector{})
 	g.Expect(err).To(HaveOccurred())
 	g.Expect(err.Error()).To(ContainSubstring("extracting operator refs"))
+}
+
+// TestComputeBody_OperatorAndServiceCommits verifies both operator and service
+// feat/fix lists appear in the same comment.
+func TestComputeBody_OperatorAndServiceCommits(t *testing.T) {
+	g := NewWithT(t)
+	buildOldSHA := "cccccccccccccccccccccccccccccccccccccccc"
+	buildNewSHA := "dddddddddddddddddddddddddddddddddddddddd"
+
+	patch := "-  - https://github.com/konflux-ci/build-service/config/default?ref=" + buildOldSHA + "\n" +
+		"+  - https://github.com/konflux-ci/build-service/config/default?ref=" + buildNewSHA + "\n"
+
+	fake := &fakeRepoComparer{
+		files: []*gh.CommitFile{
+			{
+				Filename: gh.Ptr("operator/upstream-kustomizations/build-service/kustomization.yaml"),
+				Patch:    gh.Ptr(patch),
+			},
+		},
+		operatorCommits: []*gh.RepositoryCommit{
+			{SHA: gh.Ptr("c1c1c1c1c1c1"), Commit: &gh.Commit{Message: gh.Ptr("feat(operator): bump wiring")}},
+		},
+		commits: []*gh.RepositoryCommit{
+			{SHA: gh.Ptr("e1e1e1e1e1e1"), Commit: &gh.Commit{Message: gh.Ptr("feat: add multi-arch support")}},
+		},
+	}
+
+	basePath := writeTempKustomization(t, oldRef)
+	headPath := writeTempKustomization(t, newRef)
+	body, err := computeBody(context.Background(), basePath, headPath, fake, &fakeRegistryInspector{})
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(body).To(ContainSubstring("feat(operator): bump wiring"))
+	g.Expect(body).To(ContainSubstring("build-service"))
+	g.Expect(body).To(ContainSubstring("feat: add multi-arch support"))
+	opIdx := strings.Index(body, "feat(operator): bump wiring")
+	svcIdx := strings.Index(body, "#### Upstream Service Bumps")
+	g.Expect(opIdx).To(BeNumerically("<", svcIdx))
 }
 
 // TestComputeBody_WithServiceCommits verifies that feat/fix conventional commits

--- a/infra-tools/internal/changelog/upstream.go
+++ b/infra-tools/internal/changelog/upstream.go
@@ -25,10 +25,15 @@ type FileChange struct {
 	Patch    string // unified diff; may be empty for binary or very large files
 }
 
-// OperatorCompare holds the changed files from comparing two operator refs.
+// OperatorCompare holds the changed files and conventional commits from comparing
+// two operator refs. Commits are filtered to feat/fix only (same rules as
+// FetchServiceCommits) so callers can render an operator changelog without a
+// second Compare API call.
 type OperatorCompare struct {
-	Files     []FileChange
-	Truncated bool // true when the API returned the 300-file maximum, indicating possible truncation
+	Files            []FileChange
+	Truncated        bool // true when the API returned the 300-file maximum, indicating possible truncation
+	Commits          []ConventionalCommit
+	CommitsTruncated bool // true when AheadBy hit the 250-commit API limit
 }
 
 // maxCompareFiles is the GitHub compare API hard limit on returned files.
@@ -48,11 +53,14 @@ func NewRepoComparer(token string) RepoComparer {
 }
 
 // FetchOperatorCompare calls the GitHub compare API for konflux-ci/konflux-ci
-// between oldRef and newRef and returns the changed files. The call is retried
-// up to three times with exponential backoff to survive transient failures.
+// between oldRef and newRef and returns the changed files plus filtered
+// conventional commits. The call is retried up to three times with exponential
+// backoff to survive transient failures.
 //
 // When the API returns exactly maxCompareFiles files the result is marked
-// Truncated; callers should degrade in the same way they handle API errors.
+// Truncated; callers should degrade bump detection in the same way they handle
+// API errors. Commits are still returned when Truncated is true — file truncation
+// is independent of the commit list.
 func FetchOperatorCompare(ctx context.Context, c RepoComparer, oldRef, newRef string) (*OperatorCompare, error) {
 	var comparison *gh.CommitsComparison
 	err := retryDo(ctx, 3, func() error {
@@ -66,8 +74,10 @@ func FetchOperatorCompare(ctx context.Context, c RepoComparer, oldRef, newRef st
 	}
 	files := convertFiles(comparison.Files)
 	return &OperatorCompare{
-		Files:     files,
-		Truncated: len(files) >= maxCompareFiles,
+		Files:            files,
+		Truncated:        len(files) >= maxCompareFiles,
+		Commits:          filterConventional(comparison.Commits),
+		CommitsTruncated: comparison.GetAheadBy() >= CommitMaxFromCompare,
 	}, nil
 }
 

--- a/infra-tools/internal/changelog/upstream_test.go
+++ b/infra-tools/internal/changelog/upstream_test.go
@@ -46,6 +46,11 @@ func TestFetchOperatorCompare_ReturnsConvertedFiles(t *testing.T) {
 			},
 			{Filename: gh.Ptr("other/file.yaml"), Patch: gh.Ptr("unchanged")},
 		},
+		commits: []*gh.RepositoryCommit{
+			{SHA: gh.Ptr("aaaaaaaaaaaa"), Commit: &gh.Commit{Message: gh.Ptr("feat(operator): sync rings")}},
+			{SHA: gh.Ptr("bbbbbbbbbbbb"), Commit: &gh.Commit{Message: gh.Ptr("chore: ignore me")}},
+			{SHA: gh.Ptr("cccccccccccc"), Commit: &gh.Commit{Message: gh.Ptr("fix: handle nil")}},
+		},
 	}
 	result, err := changelog.FetchOperatorCompare(context.Background(), fake, "oldref", "newref")
 	g.Expect(err).NotTo(HaveOccurred())
@@ -53,6 +58,49 @@ func TestFetchOperatorCompare_ReturnsConvertedFiles(t *testing.T) {
 	g.Expect(result.Truncated).To(BeFalse())
 	g.Expect(result.Files[0].Filename).To(Equal("operator/upstream-kustomizations/build-service/kustomization.yaml"))
 	g.Expect(result.Files[0].Patch).To(Equal("-old\n+new"))
+	g.Expect(result.Commits).To(HaveLen(2))
+	g.Expect(result.Commits[0].Type).To(Equal("feat"))
+	g.Expect(result.Commits[0].Scope).To(Equal("operator"))
+	g.Expect(result.Commits[0].Subject).To(Equal("sync rings"))
+	g.Expect(result.Commits[1].Type).To(Equal("fix"))
+	g.Expect(result.CommitsTruncated).To(BeFalse())
+}
+
+func TestFetchOperatorCompare_CommitsTruncated(t *testing.T) {
+	g := NewWithT(t)
+	fake := &fakeComparer{
+		files: []*gh.CommitFile{
+			{Filename: gh.Ptr("file.yaml"), Patch: gh.Ptr("diff")},
+		},
+		commits: []*gh.RepositoryCommit{
+			{SHA: gh.Ptr("aaaaaaaaaaaa"), Commit: &gh.Commit{Message: gh.Ptr("feat: one")}},
+		},
+		aheadBy: changelog.CommitMaxFromCompare,
+	}
+	result, err := changelog.FetchOperatorCompare(context.Background(), fake, "a", "b")
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(result.Commits).To(HaveLen(1))
+	g.Expect(result.CommitsTruncated).To(BeTrue())
+	g.Expect(result.Truncated).To(BeFalse())
+}
+
+func TestFetchOperatorCompare_TruncatedFilesStillReturnCommits(t *testing.T) {
+	g := NewWithT(t)
+	files := make([]*gh.CommitFile, 300)
+	for i := range files {
+		files[i] = &gh.CommitFile{Filename: gh.Ptr("file.yaml"), Patch: gh.Ptr("diff")}
+	}
+	fake := &fakeComparer{
+		files: files,
+		commits: []*gh.RepositoryCommit{
+			{SHA: gh.Ptr("aaaaaaaaaaaa"), Commit: &gh.Commit{Message: gh.Ptr("feat: kept")}},
+		},
+	}
+	result, err := changelog.FetchOperatorCompare(context.Background(), fake, "a", "b")
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(result.Truncated).To(BeTrue())
+	g.Expect(result.Commits).To(HaveLen(1))
+	g.Expect(result.Commits[0].Subject).To(Equal("kept"))
 }
 
 func TestFetchOperatorCompare_APIError(t *testing.T) {
@@ -134,7 +182,8 @@ func TestFetchOperatorCompare_NonRetryableErrorFastFails(t *testing.T) {
 	g.Expect(fake.calls).To(Equal(1)) // only one attempt — no retries for 404
 }
 
-func TestFetchOperatorCompare_ContextCancelledDuringRetry(t *testing.T) {	g := NewWithT(t)
+func TestFetchOperatorCompare_ContextCancelledDuringRetry(t *testing.T) {
+	g := NewWithT(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	// Cancel immediately so the retry wait is interrupted.
 	cancel()


### PR DESCRIPTION
Reviewers had only a full-diff link for the operator itself, while operands already listed conventional commits. Reuse the existing compare response so operator bumps get the same summary without an extra API call.

Assisted-by: Cursor