### PR TITLE
chore: drop operator-owned component-apps on stone-stage-p01

### DIFF
--- a/argo-cd-apps/overlays/staging-downstream/disable-auto-sync.yaml
+++ b/argo-cd-apps/overlays/staging-downstream/disable-auto-sync.yaml
@@ -1,6 +1,7 @@
 ---
 # Remove automated sync (auto-sync + self-heal) from ApplicationSet templates.
-# Used for operator ownership handoff on stone-stage-p01 so ArgoCD does not
-# race the Konflux operator (see PR #13169). Scoped to staging-downstream only.
+# Kept for staging member clusters that are not yet on the konflux-operator
+# (e.g. stone-stg-rh01), and for release until monitor ownership is confirmed.
+# Scoped to staging-downstream only.
 - op: remove
   path: /spec/template/spec/syncPolicy/automated

--- a/argo-cd-apps/overlays/staging-downstream/exclude-stone-stage-p01-operator-owned.yaml
+++ b/argo-cd-apps/overlays/staging-downstream/exclude-stone-stage-p01-operator-owned.yaml
@@ -1,0 +1,14 @@
+---
+# Drop stone-stage-p01 from ApplicationSet generation for Konflux services
+# owned by the konflux-operator on that cluster (ring-1). Uses ApplicationSet
+# post-selector on generated params (nameNormalized) so other staging member
+# clusters are unchanged. Staging-downstream overlay only; targets are listed
+# in kustomization.yaml.
+- op: add
+  path: /spec/generators/0/selector
+  value:
+    matchExpressions:
+      - key: nameNormalized
+        operator: NotIn
+        values:
+          - stone-stage-p01

--- a/argo-cd-apps/overlays/staging-downstream/kustomization.yaml
+++ b/argo-cd-apps/overlays/staging-downstream/kustomization.yaml
@@ -21,9 +21,109 @@ patches:
       kind: ApplicationSet
       version: v1alpha1
       name: multi-platform-controller
-  # Temporarily disable auto-sync/self-heal for services that the Konflux
-  # operator will own on stone-stage-p01 (PR #13169), so ArgoCD does not race
-  # the operator during ownership handoff. Revert once migration is complete.
+  # Exclude stone-stage-p01 from Argo generation for services owned by the
+  # konflux-operator there. Orphan (do not prune) when Applications go away.
+  # release stays on Argo with disable-auto-sync until monitor ownership is confirmed.
+  - path: exclude-stone-stage-p01-operator-owned.yaml
+    target:
+      kind: ApplicationSet
+      version: v1alpha1
+      name: application-api
+  - path: preserve-resources-on-deletion.yaml
+    target:
+      kind: ApplicationSet
+      version: v1alpha1
+      name: application-api
+  - path: exclude-stone-stage-p01-operator-owned.yaml
+    target:
+      kind: ApplicationSet
+      version: v1alpha1
+      name: build-service
+  - path: preserve-resources-on-deletion.yaml
+    target:
+      kind: ApplicationSet
+      version: v1alpha1
+      name: build-service
+  - path: exclude-stone-stage-p01-operator-owned.yaml
+    target:
+      kind: ApplicationSet
+      version: v1alpha1
+      name: integration
+  - path: preserve-resources-on-deletion.yaml
+    target:
+      kind: ApplicationSet
+      version: v1alpha1
+      name: integration
+  - path: exclude-stone-stage-p01-operator-owned.yaml
+    target:
+      kind: ApplicationSet
+      version: v1alpha1
+      name: image-controller
+  - path: preserve-resources-on-deletion.yaml
+    target:
+      kind: ApplicationSet
+      version: v1alpha1
+      name: image-controller
+  - path: exclude-stone-stage-p01-operator-owned.yaml
+    target:
+      kind: ApplicationSet
+      version: v1alpha1
+      name: namespace-lister
+  - path: preserve-resources-on-deletion.yaml
+    target:
+      kind: ApplicationSet
+      version: v1alpha1
+      name: namespace-lister
+  - path: exclude-stone-stage-p01-operator-owned.yaml
+    target:
+      kind: ApplicationSet
+      version: v1alpha1
+      name: konflux-info
+  - path: preserve-resources-on-deletion.yaml
+    target:
+      kind: ApplicationSet
+      version: v1alpha1
+      name: konflux-info
+  - path: exclude-stone-stage-p01-operator-owned.yaml
+    target:
+      kind: ApplicationSet
+      version: v1alpha1
+      name: konflux-ui
+  - path: preserve-resources-on-deletion.yaml
+    target:
+      kind: ApplicationSet
+      version: v1alpha1
+      name: konflux-ui
+  - path: exclude-stone-stage-p01-operator-owned.yaml
+    target:
+      kind: ApplicationSet
+      version: v1alpha1
+      name: enterprise-contract
+  - path: preserve-resources-on-deletion.yaml
+    target:
+      kind: ApplicationSet
+      version: v1alpha1
+      name: enterprise-contract
+  - path: exclude-stone-stage-p01-operator-owned.yaml
+    target:
+      kind: ApplicationSet
+      version: v1alpha1
+      name: konflux-rbac
+  - path: preserve-resources-on-deletion.yaml
+    target:
+      kind: ApplicationSet
+      version: v1alpha1
+      name: konflux-rbac
+  # Keep auto-sync/self-heal off for release on all staging members until
+  # release-service-monitor ownership is confirmed for stone-stage-p01.
+  - path: disable-auto-sync.yaml
+    target:
+      kind: ApplicationSet
+      version: v1alpha1
+      name: release
+  # Remaining disable-auto-sync for other staging members (e.g. stone-stg-rh01)
+  # while operator rollout is stone-stage-p01-only. Harmless on p01 once the
+  # Applications are no longer generated.
   - path: disable-auto-sync.yaml
     target:
       kind: ApplicationSet
@@ -69,8 +169,3 @@ patches:
       kind: ApplicationSet
       version: v1alpha1
       name: konflux-rbac
-  - path: disable-auto-sync.yaml
-    target:
-      kind: ApplicationSet
-      version: v1alpha1
-      name: release

--- a/argo-cd-apps/overlays/staging-downstream/preserve-resources-on-deletion.yaml
+++ b/argo-cd-apps/overlays/staging-downstream/preserve-resources-on-deletion.yaml
@@ -1,0 +1,9 @@
+---
+# When stone-stage-p01 Applications are removed from an ApplicationSet (see
+# exclude-stone-stage-p01-operator-owned.yaml), do not prune cluster resources.
+# The konflux-operator owns those workloads; Argo must orphan, not delete.
+# Staging-downstream overlay only.
+- op: add
+  path: /spec/syncPolicy
+  value:
+    preserveResourcesOnDeletion: true


### PR DESCRIPTION
Exclude those AppSets for stone-stage-p01 in staging-downstream and preserve resources on deletion so workloads stay for the operator. Leave release under Argo until ServiceMonitor ownership is confirmed.