### PR TITLE
PVO11Y-5374 Add RPM kanary probe cronjobs to staging

### DIFF
--- a/components/monitoring/kanary/staging/base/pipelines/kanary-otel-pipeline.yaml
+++ b/components/monitoring/kanary/staging/base/pipelines/kanary-otel-pipeline.yaml
@@ -64,6 +64,9 @@ spec:
     - name: fork-repo-host-and-path
       type: string
       default: ""
+    - name: fork-repo-username
+      type: string
+      default: "jhutar"
   tasks:
     - name: run-kanary-tests
       timeout: "1h0m0s"
@@ -111,6 +114,8 @@ spec:
           value: $(params.upstream-repo-branch)
         - name: fork-repo-host-and-path
           value: $(params.fork-repo-host-and-path)
+        - name: fork-repo-username
+          value: $(params.fork-repo-username)
   finally:
     - name: push-kanary-metrics
       taskRef:

--- a/components/monitoring/kanary/staging/base/pipelines/kanary-otel-pipeline.yaml
+++ b/components/monitoring/kanary/staging/base/pipelines/kanary-otel-pipeline.yaml
@@ -54,6 +54,16 @@ spec:
     - name: test-scenario-git-url
       type: string
       default: ""
+    # RPM mirror workaround only. Leave empty for container test types.
+    - name: upstream-repo-url
+      type: string
+      default: ""
+    - name: upstream-repo-branch
+      type: string
+      default: ""
+    - name: fork-repo-host-and-path
+      type: string
+      default: ""
   tasks:
     - name: run-kanary-tests
       timeout: "1h0m0s"
@@ -95,6 +105,12 @@ spec:
           value: $(params.pipeline-image-pull-secrets)
         - name: test-scenario-git-url
           value: $(params.test-scenario-git-url)
+        - name: upstream-repo-url
+          value: $(params.upstream-repo-url)
+        - name: upstream-repo-branch
+          value: $(params.upstream-repo-branch)
+        - name: fork-repo-host-and-path
+          value: $(params.fork-repo-host-and-path)
   finally:
     - name: push-kanary-metrics
       taskRef:

--- a/components/monitoring/kanary/staging/base/tasks/push-kanary-metrics.yaml
+++ b/components/monitoring/kanary/staging/base/tasks/push-kanary-metrics.yaml
@@ -19,7 +19,7 @@ spec:
       description: "Test outcome from collect-results: passed, failed, or unknown"
   steps:
     - name: push-metrics
-      image: registry.redhat.io/ubi9/python-312:latest
+      image: quay.io/redhat-user-workloads/konflux-perfscale-tenant/loadtest
       env:
         - name: OTEL_ENDPOINT
           value: $(params.otel-endpoint)
@@ -32,15 +32,7 @@ spec:
       script: |
         #!/usr/bin/env python3
         import os
-        import subprocess
         import time
-
-        subprocess.check_call([
-            "pip", "install", "--quiet",
-            "opentelemetry-api",
-            "opentelemetry-sdk",
-            "opentelemetry-exporter-otlp-proto-http",
-        ])
 
         from opentelemetry import metrics
         from opentelemetry.sdk.metrics import MeterProvider

--- a/components/monitoring/kanary/staging/base/tasks/push-kanary-metrics.yaml
+++ b/components/monitoring/kanary/staging/base/tasks/push-kanary-metrics.yaml
@@ -19,7 +19,7 @@ spec:
       description: "Test outcome from collect-results: passed, failed, or unknown"
   steps:
     - name: push-metrics
-      image: quay.io/redhat-user-workloads/konflux-perfscale-tenant/loadtest
+      image: registry.redhat.io/ubi9/python-312:latest
       env:
         - name: OTEL_ENDPOINT
           value: $(params.otel-endpoint)
@@ -32,7 +32,15 @@ spec:
       script: |
         #!/usr/bin/env python3
         import os
+        import subprocess
         import time
+
+        subprocess.check_call([
+            "pip", "install", "--quiet",
+            "opentelemetry-api",
+            "opentelemetry-sdk",
+            "opentelemetry-exporter-otlp-proto-http",
+        ])
 
         from opentelemetry import metrics
         from opentelemetry.sdk.metrics import MeterProvider

--- a/components/monitoring/kanary/staging/base/tasks/run-kanary-tests.yaml
+++ b/components/monitoring/kanary/staging/base/tasks/run-kanary-tests.yaml
@@ -153,21 +153,31 @@ spec:
         set -eu
 
         if echo "$FORK_REPO_HOST_AND_PATH" | grep -q "gitlab"; then
-          TOKEN="$GITLAB_BOT_TOKEN"
+          GIT_PASSWORD="$GITLAB_BOT_TOKEN"
         else
-          TOKEN="$GITHUB_TOKEN"
+          GIT_PASSWORD="$GITHUB_TOKEN"
         fi
 
         FORK_DIR="$(basename "$FORK_REPO_HOST_AND_PATH" .git)"
 
+        # Use GIT_ASKPASS so the token is never embedded in any URL or git config.
+        askpass_script="$(mktemp)"
+        echo '#!/bin/sh' > "${askpass_script}"
+        echo 'echo "${GIT_PASSWORD}"' >> "${askpass_script}"
+        chmod +x "${askpass_script}"
+        export GIT_ASKPASS="${askpass_script}"
+        export GIT_PASSWORD
+        export GIT_TERMINAL_PROMPT=0
+
         onerr() {
           error_time="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
           echo "${error_time},0,\"Mirror-rpm-repo step failed\"" >> /tmp/artifacts/load-test-errors.csv
+          rm -f "${askpass_script}"
           exit 0
         }
         trap 'onerr' ERR
 
-        git clone "https://jhutar:${TOKEN}@${FORK_REPO_HOST_AND_PATH}"
+        git clone "https://jhutar@${FORK_REPO_HOST_AND_PATH}"
         cd "${FORK_DIR}"
         git remote add upstream "${UPSTREAM_REPO_URL}"
         git fetch upstream "${UPSTREAM_REPO_BRANCH}"
@@ -182,6 +192,7 @@ spec:
 
         git push -f origin "${UPSTREAM_REPO_BRANCH}"
 
+        rm -f "${askpass_script}"
         echo "RPM mirror step completed successfully"
     - name: run-test
       image: quay.io/redhat-user-workloads/konflux-perfscale-tenant/loadtest

--- a/components/monitoring/kanary/staging/base/tasks/run-kanary-tests.yaml
+++ b/components/monitoring/kanary/staging/base/tasks/run-kanary-tests.yaml
@@ -61,6 +61,9 @@ spec:
     - name: fork-repo-host-and-path
       type: string
       default: ""
+    - name: fork-repo-username
+      type: string
+      default: "jhutar"
   results:
     - name: test-outcome
       description: "Test outcome: passed, failed, or unknown"
@@ -138,6 +141,8 @@ spec:
           value: $(params.upstream-repo-branch)
         - name: FORK_REPO_HOST_AND_PATH
           value: $(params.fork-repo-host-and-path)
+        - name: FORK_REPO_USERNAME
+          value: $(params.fork-repo-username)
         - name: GITHUB_TOKEN
           valueFrom:
             secretKeyRef:
@@ -180,7 +185,7 @@ spec:
         }
         trap 'onerr' ERR
 
-        git clone "https://jhutar@${FORK_REPO_HOST_AND_PATH}"
+        git clone "https://${FORK_REPO_USERNAME}@${FORK_REPO_HOST_AND_PATH}"
         cd "${FORK_DIR}"
         git remote add upstream "${UPSTREAM_REPO_URL}"
         git fetch upstream "${UPSTREAM_REPO_BRANCH}"

--- a/components/monitoring/kanary/staging/base/tasks/run-kanary-tests.yaml
+++ b/components/monitoring/kanary/staging/base/tasks/run-kanary-tests.yaml
@@ -51,6 +51,16 @@ spec:
     - name: test-scenario-git-url
       type: string
       default: ""
+    # RPM mirror workaround only. Leave empty for container test types.
+    - name: upstream-repo-url
+      type: string
+      default: ""
+    - name: upstream-repo-branch
+      type: string
+      default: ""
+    - name: fork-repo-host-and-path
+      type: string
+      default: ""
   results:
     - name: test-outcome
       description: "Test outcome: passed, failed, or unknown"
@@ -114,6 +124,71 @@ spec:
           fi
         fi
         echo "Pre-cleanup done"
+    - name: mirror-rpm-repo
+      when:
+        - cel: "'$(params.test-type)' == 'rpm'"
+      image: quay.io/redhat-user-workloads/konflux-perfscale-tenant/loadtest
+      volumeMounts:
+        - name: artifacts
+          mountPath: /tmp/artifacts
+      env:
+        - name: UPSTREAM_REPO_URL
+          value: $(params.upstream-repo-url)
+        - name: UPSTREAM_REPO_BRANCH
+          value: $(params.upstream-repo-branch)
+        - name: FORK_REPO_HOST_AND_PATH
+          value: $(params.fork-repo-host-and-path)
+        - name: GITHUB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: kanary-probe-credentials
+              key: github_token
+        - name: GITLAB_BOT_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: kanary-probe-credentials
+              key: gitlab-cee-pipelines-as-code-secret
+      script: |
+        #!/usr/bin/env bash
+        set -u
+
+        if echo "$FORK_REPO_HOST_AND_PATH" | grep -q "gitlab"; then
+          TOKEN="$GITLAB_BOT_TOKEN"
+        else
+          TOKEN="$GITHUB_TOKEN"
+        fi
+
+        FORK_DIR="$(basename "$FORK_REPO_HOST_AND_PATH" .git)"
+        output_file="$(mktemp)"
+
+        onerr() {
+          error_time="$(date -Ins --utc | sed 's/+00:00/Z/')"
+          error_message="$(cat "${output_file}" | tr '\n' ' ' | tr --delete '"')"
+          echo "${error_time},0,\"Cloning workaround failed: ${error_message}\"" >> /tmp/artifacts/load-test-errors.csv
+          rm -f "${output_file}"
+          exit 0
+        }
+        trap "onerr" ERR
+
+        {
+          git clone "https://jhutar:${TOKEN}@${FORK_REPO_HOST_AND_PATH}"
+          cd "${FORK_DIR}"
+          git remote add upstream "${UPSTREAM_REPO_URL}"
+          git fetch upstream "${UPSTREAM_REPO_BRANCH}"
+          git checkout -B "${UPSTREAM_REPO_BRANCH}" upstream/"${UPSTREAM_REPO_BRANCH}"
+
+          sed -i "s/^Name: libecpg$/Name: konflux-probe-libecpg/" libecpg.spec
+          sed -i "s/^Release: [0-9]\+%{?dist}$/Release: $(date --utc +%Y%m%d%H%M%S)%{?dist}/" libecpg.spec
+          git add libecpg.spec
+          git config user.email "loadtest@localhost"
+          git config user.name "Konflux Probes Kanary"
+          git commit -m "test: Alter package name and release so we can push to Brew"
+
+          git push -f origin "${UPSTREAM_REPO_BRANCH}"
+        } 2>&1 | tee "${output_file}"
+
+        rm -f "${output_file}"
+        echo "RPM mirror step completed successfully"
     - name: run-test
       image: quay.io/redhat-user-workloads/konflux-perfscale-tenant/loadtest
       volumeMounts:

--- a/components/monitoring/kanary/staging/base/tasks/run-kanary-tests.yaml
+++ b/components/monitoring/kanary/staging/base/tasks/run-kanary-tests.yaml
@@ -161,6 +161,8 @@ spec:
         FORK_DIR="$(basename "$FORK_REPO_HOST_AND_PATH" .git)"
 
         # Use GIT_ASKPASS so the token is never embedded in any URL or git config.
+        # GIT_TERMINAL_PROMPT=0 makes git fail immediately instead of hanging on a
+        # terminal prompt if GIT_ASKPASS fails (no terminal in a Tekton container).
         # See: https://git-scm.com/docs/git#Documentation/git.txt-codeGITASKPASScode
         askpass_script="$(mktemp)"
         echo '#!/bin/sh' > "${askpass_script}"

--- a/components/monitoring/kanary/staging/base/tasks/run-kanary-tests.yaml
+++ b/components/monitoring/kanary/staging/base/tasks/run-kanary-tests.yaml
@@ -159,34 +159,29 @@ spec:
         fi
 
         FORK_DIR="$(basename "$FORK_REPO_HOST_AND_PATH" .git)"
-        output_file="$(mktemp)"
 
         onerr() {
           error_time="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-          error_message="$(tr '\n' ' ' < "${output_file}" | tr -d '"' | sed "s|${TOKEN}|***|g")"
-          echo "${error_time},0,\"Cloning workaround failed: ${error_message}\"" >> /tmp/artifacts/load-test-errors.csv
-          rm -f "${output_file}"
+          echo "${error_time},0,\"Mirror-rpm-repo step failed\"" >> /tmp/artifacts/load-test-errors.csv
           exit 0
         }
         trap 'onerr' ERR
 
-        git clone "https://jhutar:${TOKEN}@${FORK_REPO_HOST_AND_PATH}" >> "${output_file}" 2>&1
+        git clone "https://jhutar:${TOKEN}@${FORK_REPO_HOST_AND_PATH}"
         cd "${FORK_DIR}"
-        git remote add upstream "${UPSTREAM_REPO_URL}" >> "${output_file}" 2>&1
-        git fetch upstream "${UPSTREAM_REPO_BRANCH}" >> "${output_file}" 2>&1
-        git checkout -B "${UPSTREAM_REPO_BRANCH}" upstream/"${UPSTREAM_REPO_BRANCH}" >> "${output_file}" 2>&1
+        git remote add upstream "${UPSTREAM_REPO_URL}"
+        git fetch upstream "${UPSTREAM_REPO_BRANCH}"
+        git checkout -B "${UPSTREAM_REPO_BRANCH}" upstream/"${UPSTREAM_REPO_BRANCH}"
 
         sed -i "s/^Name: libecpg$/Name: konflux-probe-libecpg/" libecpg.spec
         sed -i "s/^Release: [0-9]\+%{?dist}$/Release: $(date --utc +%Y%m%d%H%M%S)%{?dist}/" libecpg.spec
         git add libecpg.spec
         git config user.email "loadtest@localhost"
         git config user.name "Konflux Probes Kanary"
-        git commit -m "test: Alter package name and release so we can push to Brew" >> "${output_file}" 2>&1
+        git commit -m "test: Alter package name and release so we can push to Brew"
 
-        git push -f origin "${UPSTREAM_REPO_BRANCH}" >> "${output_file}" 2>&1
+        git push -f origin "${UPSTREAM_REPO_BRANCH}"
 
-        cat "${output_file}"
-        rm -f "${output_file}"
         echo "RPM mirror step completed successfully"
     - name: run-test
       image: quay.io/redhat-user-workloads/konflux-perfscale-tenant/loadtest

--- a/components/monitoring/kanary/staging/base/tasks/run-kanary-tests.yaml
+++ b/components/monitoring/kanary/staging/base/tasks/run-kanary-tests.yaml
@@ -153,20 +153,21 @@ spec:
         set -eu
 
         if echo "$FORK_REPO_HOST_AND_PATH" | grep -q "gitlab"; then
-          GIT_PASSWORD="$GITLAB_BOT_TOKEN"
+          GIT_TOKEN="$GITLAB_BOT_TOKEN"
         else
-          GIT_PASSWORD="$GITHUB_TOKEN"
+          GIT_TOKEN="$GITHUB_TOKEN"
         fi
 
         FORK_DIR="$(basename "$FORK_REPO_HOST_AND_PATH" .git)"
 
         # Use GIT_ASKPASS so the token is never embedded in any URL or git config.
+        # See: https://git-scm.com/docs/git#Documentation/git.txt-codeGITASKPASScode
         askpass_script="$(mktemp)"
         echo '#!/bin/sh' > "${askpass_script}"
-        echo 'echo "${GIT_PASSWORD}"' >> "${askpass_script}"
+        echo 'echo "${GIT_TOKEN}"' >> "${askpass_script}"
         chmod +x "${askpass_script}"
         export GIT_ASKPASS="${askpass_script}"
-        export GIT_PASSWORD
+        export GIT_TOKEN
         export GIT_TERMINAL_PROMPT=0
 
         onerr() {

--- a/components/monitoring/kanary/staging/base/tasks/run-kanary-tests.yaml
+++ b/components/monitoring/kanary/staging/base/tasks/run-kanary-tests.yaml
@@ -150,7 +150,7 @@ spec:
               key: gitlab-cee-pipelines-as-code-secret
       script: |
         #!/usr/bin/env bash
-        set -u
+        set -eu
 
         if echo "$FORK_REPO_HOST_AND_PATH" | grep -q "gitlab"; then
           TOKEN="$GITLAB_BOT_TOKEN"
@@ -162,31 +162,30 @@ spec:
         output_file="$(mktemp)"
 
         onerr() {
-          error_time="$(date -Ins --utc | sed 's/+00:00/Z/')"
-          error_message="$(cat "${output_file}" | tr '\n' ' ' | tr --delete '"')"
+          error_time="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          error_message="$(tr '\n' ' ' < "${output_file}" | tr -d '"' | sed "s|${TOKEN}|***|g")"
           echo "${error_time},0,\"Cloning workaround failed: ${error_message}\"" >> /tmp/artifacts/load-test-errors.csv
           rm -f "${output_file}"
           exit 0
         }
-        trap "onerr" ERR
+        trap 'onerr' ERR
 
-        {
-          git clone "https://jhutar:${TOKEN}@${FORK_REPO_HOST_AND_PATH}"
-          cd "${FORK_DIR}"
-          git remote add upstream "${UPSTREAM_REPO_URL}"
-          git fetch upstream "${UPSTREAM_REPO_BRANCH}"
-          git checkout -B "${UPSTREAM_REPO_BRANCH}" upstream/"${UPSTREAM_REPO_BRANCH}"
+        git clone "https://jhutar:${TOKEN}@${FORK_REPO_HOST_AND_PATH}" >> "${output_file}" 2>&1
+        cd "${FORK_DIR}"
+        git remote add upstream "${UPSTREAM_REPO_URL}" >> "${output_file}" 2>&1
+        git fetch upstream "${UPSTREAM_REPO_BRANCH}" >> "${output_file}" 2>&1
+        git checkout -B "${UPSTREAM_REPO_BRANCH}" upstream/"${UPSTREAM_REPO_BRANCH}" >> "${output_file}" 2>&1
 
-          sed -i "s/^Name: libecpg$/Name: konflux-probe-libecpg/" libecpg.spec
-          sed -i "s/^Release: [0-9]\+%{?dist}$/Release: $(date --utc +%Y%m%d%H%M%S)%{?dist}/" libecpg.spec
-          git add libecpg.spec
-          git config user.email "loadtest@localhost"
-          git config user.name "Konflux Probes Kanary"
-          git commit -m "test: Alter package name and release so we can push to Brew"
+        sed -i "s/^Name: libecpg$/Name: konflux-probe-libecpg/" libecpg.spec
+        sed -i "s/^Release: [0-9]\+%{?dist}$/Release: $(date --utc +%Y%m%d%H%M%S)%{?dist}/" libecpg.spec
+        git add libecpg.spec
+        git config user.email "loadtest@localhost"
+        git config user.name "Konflux Probes Kanary"
+        git commit -m "test: Alter package name and release so we can push to Brew" >> "${output_file}" 2>&1
 
-          git push -f origin "${UPSTREAM_REPO_BRANCH}"
-        } 2>&1 | tee "${output_file}"
+        git push -f origin "${UPSTREAM_REPO_BRANCH}" >> "${output_file}" 2>&1
 
+        cat "${output_file}"
         rm -f "${output_file}"
         echo "RPM mirror step completed successfully"
     - name: run-test

--- a/components/monitoring/kanary/staging/stone-stage-p01/cronjobs/kanary-cronjob-rpm.yaml
+++ b/components/monitoring/kanary/staging/stone-stage-p01/cronjobs/kanary-cronjob-rpm.yaml
@@ -1,9 +1,9 @@
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: kanary-trigger-multi-arch
+  name: kanary-trigger-rpm
 spec:
-  schedule: "20,50 * * * *"
+  schedule: "10,40 * * * *"
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 3
@@ -33,15 +33,21 @@ spec:
                 - |
                   tkn pipeline start kanary-otel-poc --use-param-defaults \
                     --param tested-cluster=stone-stage-p01 \
-                    --param test-type=container-multi-arch \
-                    --param component-repo=https://gitlab.cee.redhat.com/jhutar/nodejs-devfile-sample4 \
-                    --param user-prefix=stagep01cm \
+                    --param test-type=rpm \
+                    --param component-repo=https://gitlab.cee.redhat.com/jhutar/libecpg-gitlab-fork \
+                    --param component-repo-revision=c10s \
+                    --param user-prefix=stagep01cr \
                     --param quay-repo=redhat-user-workloads-stage \
                     --param pipeline-repo-templating-source=https://github.com/rhtap-perf-test/konflux-probe-test-templates \
-                    --param pipeline-repo-templating-source-dir=nodejs-devfile-sample-MultiArch/ \
+                    --param pipeline-repo-templating-source-dir=stone-stage-p01-RPM/ \
+                    --param pipeline-image-pull-secrets="imagerepository-for-toolings-gather-results-container-image-pull imagerepository-for-toolings-get-rpm-sources-container-image-pull imagerepository-for-toolings-mock-rhel-container-image-pull imagerepository-for-toolings-rpmbuild-pipeline-image-pull imagerepository-for-toolings-syft-container-image-pull" \
+                    --param test-scenario-git-url="" \
                     --param oci-storage=quay.io/rhtap-perf-test/perf-release-service-trusted-artifacts-stage \
                     --param release-pipeline-service-account=managed-konflux-perfscale-sa \
                     --param fork-target=jhutar \
                     --param gitlab-api-url=https://gitlab.cee.redhat.com/api/v4 \
+                    --param upstream-repo-url=https://gitlab.com/redhat/centos-stream/rpms/libecpg.git \
+                    --param upstream-repo-branch=c10s \
+                    --param fork-repo-host-and-path=gitlab.cee.redhat.com/jhutar/libecpg-gitlab-fork.git \
                     --param member-cluster=https://api.stone-stage-p01.hpmt.p1.openshiftapps.com:6443 \
-                    --prefix-name kanary-stone-stage-p01-multi-arch-
+                    --prefix-name kanary-stone-stage-p01-rpm-

--- a/components/monitoring/kanary/staging/stone-stage-p01/cronjobs/kustomization.yaml
+++ b/components/monitoring/kanary/staging/stone-stage-p01/cronjobs/kustomization.yaml
@@ -1,3 +1,4 @@
 resources:
   - kanary-cronjob-single-arch.yaml
   - kanary-cronjob-multi-arch.yaml
+  - kanary-cronjob-rpm.yaml

--- a/components/monitoring/kanary/staging/stone-stg-rh01/cronjobs/kanary-cronjob-rpm.yaml
+++ b/components/monitoring/kanary/staging/stone-stg-rh01/cronjobs/kanary-cronjob-rpm.yaml
@@ -1,9 +1,9 @@
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: kanary-trigger-multi-arch
+  name: kanary-trigger-rpm
 spec:
-  schedule: "20,50 * * * *"
+  schedule: "10,40 * * * *"
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 3
@@ -33,15 +33,21 @@ spec:
                 - |
                   tkn pipeline start kanary-otel-poc --use-param-defaults \
                     --param tested-cluster=stone-stg-rh01 \
-                    --param test-type=container-multi-arch \
-                    --param component-repo=https://github.com/rhtap-perf-test/nodejs-devfile-sample \
-                    --param user-prefix=stgrh01cm \
+                    --param test-type=rpm \
+                    --param component-repo=https://github.com/jhutar/libecpg-srcfedora-fork \
+                    --param component-repo-revision=main \
+                    --param user-prefix=stgrh01cr \
                     --param quay-repo=redhat-user-workloads-stage \
                     --param pipeline-repo-templating-source=https://github.com/rhtap-perf-test/konflux-probe-test-templates \
-                    --param pipeline-repo-templating-source-dir=nodejs-devfile-sample-MultiArch/ \
+                    --param pipeline-repo-templating-source-dir=stone-stg-rh01-RPM/ \
+                    --param pipeline-image-pull-secrets="imagerepository-for-toolings-gather-results-container-image-pull imagerepository-for-toolings-get-rpm-sources-container-image-pull imagerepository-for-toolings-mock-rhel-container-image-pull imagerepository-for-toolings-rpmbuild-pipeline-image-pull imagerepository-for-toolings-syft-container-image-pull" \
+                    --param test-scenario-git-url="" \
                     --param oci-storage=quay.io/rhtap-perf-test/perf-release-service-trusted-artifacts-stage \
                     --param release-pipeline-service-account=managed-konflux-perfscale-sa \
                     --param fork-target="" \
                     --param gitlab-api-url="" \
+                    --param upstream-repo-url=https://src.fedoraproject.org/rpms/libecpg.git \
+                    --param upstream-repo-branch=main \
+                    --param fork-repo-host-and-path=github.com/jhutar/libecpg-srcfedora-fork.git \
                     --param member-cluster=https://api.stone-stg-rh01.l2vh.p1.openshiftapps.com:6443 \
-                    --prefix-name kanary-stone-stg-rh01-multi-arch-
+                    --prefix-name kanary-stone-stg-rh01-rpm-

--- a/components/monitoring/kanary/staging/stone-stg-rh01/cronjobs/kustomization.yaml
+++ b/components/monitoring/kanary/staging/stone-stg-rh01/cronjobs/kustomization.yaml
@@ -1,3 +1,4 @@
 resources:
   - kanary-cronjob-single-arch.yaml
   - kanary-cronjob-multi-arch.yaml
+  - kanary-cronjob-rpm.yaml


### PR DESCRIPTION
## What

Add RPM build probe support to kanary V1 on both staging clusters:
- `mirror-rpm-repo` step in `run-kanary-tests` task (gated by step-level `when` on `test-type=rpm`) that clones upstream libecpg, modifies the spec (renames package, bumps release timestamp), and force-pushes to the fork to trigger PaC
- RPM cronjob on stone-stg-rh01 (WORKAROUND2: src.fedoraproject.org → github.com/jhutar/libecpg-srcfedora-fork)
- RPM cronjob on stone-stage-p01 (WORKAROUND1: gitlab.com/redhat/centos-stream → gitlab.cee.redhat.com/jhutar/libecpg-gitlab-fork)
- Multi-arch schedule shifted from `:15/:45` to `:20/:50` for 10-min spacing between single-arch (`:00/:30`), RPM (`:10/:40`), and multi-arch (`:20/:50`) probes

Clusters affected: stone-stg-rh01, stone-stage-p01

[PVO11Y-5374](https://issues.redhat.com/browse/PVO11Y-5374)

## Why

Migrating RPM probe tests from Jenkins to kanary V1. RPM probes currently run only in Jenkins on 4 production clusters. This PR adds staging coverage as the first step before production rollout.

## How the mirror-rpm-repo step works

The single `mirror-rpm-repo` step handles **both** Jenkins workarounds. The script logic is identical (clone fork → add upstream → fetch → checkout → sed rename + timestamp → commit → force-push). The difference is only in the **parameters** fed by each cluster's cronjob:

| | Workaround 1 (stone-stage-p01) | Workaround 2 (stone-stg-rh01) |
|---|---|---|
| Upstream | `gitlab.com/redhat/centos-stream/rpms/libecpg.git` | `src.fedoraproject.org/rpms/libecpg.git` |
| Branch | `c10s` | `main` |
| Fork | `gitlab.cee.redhat.com/jhutar/libecpg-gitlab-fork.git` | `github.com/jhutar/libecpg-srcfedora-fork.git` |
| Token | `GITLAB_BOT_TOKEN` | `GITHUB_TOKEN` |

The token is selected automatically based on whether `fork-repo-host-and-path` contains `gitlab`.

The step is non-fatal: on error it writes to `load-test-errors.csv` (with token sanitized) and exits 0 so the `run-test` step can still execute and report the failure through the normal kanary metrics path.

## Validation

- `kustomize build` passes for all three overlays:
  - `components/monitoring/kanary/staging/base/`
  - `components/monitoring/kanary/staging/stone-stg-rh01/`
  - `components/monitoring/kanary/staging/stone-stage-p01/`

## Prerequisites

Before this can be tested end-to-end, jhutar needs to set up:
1. Merge the templates PR: https://github.com/rhtap-perf-test/konflux-probe-test-templates/pull/147

[PVO11Y-5374]: https://redhat.atlassian.net/browse/PVO11Y-5374?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ