### PR TITLE
KFLUXINFRA-4276: Bump repository-validator production config ref (stolostron allow list)

### DIFF
--- a/components/repository-validator/production/kustomization.yaml
+++ b/components/repository-validator/production/kustomization.yaml
@@ -1,5 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - https://github.com/redhat-appstudio/internal-infra-deployments/components/repository-validator/production?ref=015a6727fad4014ffc973b6941b076a93fb39324
+  - https://github.com/redhat-appstudio/internal-infra-deployments/components/repository-validator/production?ref=c038993caf7eaf21da3f44b2de39aa2a76da8740
   - ../base


### PR DESCRIPTION
## What

Bump `components/repository-validator/production/kustomization.yaml` ref to
`c038993caf7eaf21da3f44b2de39aa2a76da8740`.

Picks up: Add stolostron org to production repository allow list
(redhat-appstudio/internal-infra-deployments#121)

Clusters affected: all internal production clusters

[KFLUXINFRA-4276](https://redhat.atlassian.net/browse/KFLUXINFRA-4276)

## Why

Tenant `source-code-intelligence-tenant` on `stone-prod-p02` needs to onboard
6 GitHub repositories from `https://github.com/stolostron` (Red Hat ACM/MCM org).
`configure-pac` fails with error 54 until this allow list entry is active.

## Validation

- `kustomize build` skipped — remote ref fetch times out locally; the SHA
  is the verified merge commit of internal-infra-deployments#121
- Low-risk additive change: only adds one org prefix to the allow list

## Risk Assessment

**Risk Level:** Low
**What could go wrong:** New org entry is additive; no existing entries
modified. Worst case: an incorrect prefix allows unexpected repos — mitigated
by the fact that `stolostron` is a Red Hat-managed org with PaC App
already installed and org-owner approval confirmed.
**Rollback:** Revert this PR to restore previous ref
**Blast radius:** All internal production clusters — config change only,
no service restart required

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[KFLUXINFRA-4276]: https://redhat.atlassian.net/browse/KFLUXINFRA-4276?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ