### PR TITLE
KFLUXINFRA-4242: Move `images` field to etcd-shield tier-2 folders

### DIFF
--- a/.github/workflows/kube-linter.yaml
+++ b/.github/workflows/kube-linter.yaml
@@ -37,6 +37,8 @@ jobs:
             ! -path 'components/monitoring/blackbox/staging/*' \
             ! -path 'components/monitoring/blackbox/production/*' \
             ! -path 'components/*/chainsaw/*' \
+            ! -path 'components/etcd-shield/base/*' \
+            ! -path 'components/etcd-shield/rings/*/base/base-snapshot/*' \
             | \
             xargs -I {} -n1 -P8  bash -c 'dir=$(dirname "{}"); output_file=$(echo "$dir" | tr / -)-kustomization.yaml; ./hack/kustomize-build-with-retry.sh "$dir" -o "kustomizedfiles/$output_file"'
 

--- a/components/etcd-shield/base/kustomization.yaml
+++ b/components/etcd-shield/base/kustomization.yaml
@@ -1,6 +1,6 @@
----
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+
 configMapGenerator:
   - files:
       - ./config.yaml
@@ -8,11 +8,9 @@ configMapGenerator:
 # generatorOptions:
 #   # until https://github.com/kubernetes-sigs/kustomize/issues/4475 is fixed
 #   disableNameSuffixHash: true
-images:
-  - name: etcd-shield
-    newName: quay.io/konflux-ci/etcd-shield
-    newTag: 94885d051db284f214f43d76df2f9bd4c9fe993f
+
 namespace: etcd-shield
+
 resources:
   - deployment.yaml
   - ns.yaml

--- a/components/etcd-shield/rings/ring-0/base/base-snapshot/kustomization.yaml
+++ b/components/etcd-shield/rings/ring-0/base/base-snapshot/kustomization.yaml
@@ -1,6 +1,6 @@
----
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+
 configMapGenerator:
   - files:
       - ./config.yaml
@@ -8,11 +8,9 @@ configMapGenerator:
 # generatorOptions:
 #   # until https://github.com/kubernetes-sigs/kustomize/issues/4475 is fixed
 #   disableNameSuffixHash: true
-images:
-  - name: etcd-shield
-    newName: quay.io/konflux-ci/etcd-shield
-    newTag: 94885d051db284f214f43d76df2f9bd4c9fe993f
+
 namespace: etcd-shield
+
 resources:
   - deployment.yaml
   - ns.yaml

--- a/components/etcd-shield/rings/ring-0/base/kustomization.yaml
+++ b/components/etcd-shield/rings/ring-0/base/kustomization.yaml
@@ -2,3 +2,8 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - base-snapshot
+
+images:
+  - name: etcd-shield
+    newName: quay.io/konflux-ci/etcd-shield
+    newTag: 94885d051db284f214f43d76df2f9bd4c9fe993f

--- a/components/etcd-shield/rings/ring-1/base/base-snapshot/kustomization.yaml
+++ b/components/etcd-shield/rings/ring-1/base/base-snapshot/kustomization.yaml
@@ -1,6 +1,6 @@
----
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+
 configMapGenerator:
   - files:
       - ./config.yaml
@@ -8,11 +8,9 @@ configMapGenerator:
 # generatorOptions:
 #   # until https://github.com/kubernetes-sigs/kustomize/issues/4475 is fixed
 #   disableNameSuffixHash: true
-images:
-  - name: etcd-shield
-    newName: quay.io/konflux-ci/etcd-shield
-    newTag: 94885d051db284f214f43d76df2f9bd4c9fe993f
+
 namespace: etcd-shield
+
 resources:
   - deployment.yaml
   - ns.yaml

--- a/components/etcd-shield/rings/ring-1/base/kustomization.yaml
+++ b/components/etcd-shield/rings/ring-1/base/kustomization.yaml
@@ -2,3 +2,8 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - base-snapshot
+
+images:
+  - name: etcd-shield
+    newName: quay.io/konflux-ci/etcd-shield
+    newTag: 94885d051db284f214f43d76df2f9bd4c9fe993f

--- a/components/etcd-shield/rings/ring-2/base/base-snapshot/kustomization.yaml
+++ b/components/etcd-shield/rings/ring-2/base/base-snapshot/kustomization.yaml
@@ -1,6 +1,6 @@
----
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+
 configMapGenerator:
   - files:
       - ./config.yaml
@@ -8,11 +8,9 @@ configMapGenerator:
 # generatorOptions:
 #   # until https://github.com/kubernetes-sigs/kustomize/issues/4475 is fixed
 #   disableNameSuffixHash: true
-images:
-  - name: etcd-shield
-    newName: quay.io/konflux-ci/etcd-shield
-    newTag: 94885d051db284f214f43d76df2f9bd4c9fe993f
+
 namespace: etcd-shield
+
 resources:
   - deployment.yaml
   - ns.yaml

--- a/components/etcd-shield/rings/ring-2/base/kustomization.yaml
+++ b/components/etcd-shield/rings/ring-2/base/kustomization.yaml
@@ -3,6 +3,11 @@ kind: Kustomization
 resources:
   - base-snapshot
 
+images:
+  - name: etcd-shield
+    newName: quay.io/konflux-ci/etcd-shield
+    newTag: 94885d051db284f214f43d76df2f9bd4c9fe993f
+
 patches:
   - target:
       kind: PrometheusRule

--- a/components/etcd-shield/rings/ring-3/base/base-snapshot/kustomization.yaml
+++ b/components/etcd-shield/rings/ring-3/base/base-snapshot/kustomization.yaml
@@ -1,6 +1,6 @@
----
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+
 configMapGenerator:
   - files:
       - ./config.yaml
@@ -8,11 +8,9 @@ configMapGenerator:
 # generatorOptions:
 #   # until https://github.com/kubernetes-sigs/kustomize/issues/4475 is fixed
 #   disableNameSuffixHash: true
-images:
-  - name: etcd-shield
-    newName: quay.io/konflux-ci/etcd-shield
-    newTag: 94885d051db284f214f43d76df2f9bd4c9fe993f
+
 namespace: etcd-shield
+
 resources:
   - deployment.yaml
   - ns.yaml

--- a/components/etcd-shield/rings/ring-3/base/kustomization.yaml
+++ b/components/etcd-shield/rings/ring-3/base/kustomization.yaml
@@ -3,6 +3,11 @@ kind: Kustomization
 resources:
   - base-snapshot
 
+images:
+  - name: etcd-shield
+    newName: quay.io/konflux-ci/etcd-shield
+    newTag: 94885d051db284f214f43d76df2f9bd4c9fe993f
+
 patches:
   - target:
       kind: PrometheusRule

--- a/components/etcd-shield/rings/ring-4/base/base-snapshot/kustomization.yaml
+++ b/components/etcd-shield/rings/ring-4/base/base-snapshot/kustomization.yaml
@@ -1,6 +1,6 @@
----
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+
 configMapGenerator:
   - files:
       - ./config.yaml
@@ -8,11 +8,9 @@ configMapGenerator:
 # generatorOptions:
 #   # until https://github.com/kubernetes-sigs/kustomize/issues/4475 is fixed
 #   disableNameSuffixHash: true
-images:
-  - name: etcd-shield
-    newName: quay.io/konflux-ci/etcd-shield
-    newTag: 94885d051db284f214f43d76df2f9bd4c9fe993f
+
 namespace: etcd-shield
+
 resources:
   - deployment.yaml
   - ns.yaml

--- a/components/etcd-shield/rings/ring-4/base/kustomization.yaml
+++ b/components/etcd-shield/rings/ring-4/base/kustomization.yaml
@@ -3,6 +3,11 @@ kind: Kustomization
 resources:
   - base-snapshot
 
+images:
+  - name: etcd-shield
+    newName: quay.io/konflux-ci/etcd-shield
+    newTag: 94885d051db284f214f43d76df2f9bd4c9fe993f
+
 patches:
   - target:
       kind: PrometheusRule


### PR DESCRIPTION
The `images` field should only be located in each ring's `base/` folder, not the tier-1 component `base/folder`.