### PR TITLE
Configure forge as global PAC repository

### DIFF
--- a/components/pipeline-service/production/kflux-fedora-01/deploy.yaml
+++ b/components/pipeline-service/production/kflux-fedora-01/deploy.yaml
@@ -2022,6 +2022,27 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
     argocd.argoproj.io/sync-wave: "-1"
+  name: forge-bot-secret
+  namespace: openshift-pipelines
+spec:
+  dataFrom:
+  - extract:
+      key: production/pipeline-service/kflux-fedora-01/forge-bot
+  refreshInterval: 5m
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: appsre-stonesoup-vault
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    name: forge-bot-secret
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-1"
   name: pipelines-as-code-secret
   namespace: openshift-pipelines
 spec:
@@ -2577,6 +2598,27 @@ spec:
   name: openshift-pipelines-operator-rh
   source: custom-operators
   sourceNamespace: openshift-marketplace
+---
+apiVersion: pipelinesascode.tekton.dev/v1alpha1
+kind: Repository
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "1"
+  name: pipelines-as-code
+  namespace: openshift-pipelines
+spec:
+  git_provider:
+    secret:
+      key: token
+      name: forge-bot-secret
+    type: forgejo
+    url: https://forge.fedoraproject.org
+    user: konflux-forge-bot
+    webhook_secret:
+      key: webhook-secret
+      name: forge-bot-secret
+  url: https://forge.fedoraproject.org
 ---
 apiVersion: route.openshift.io/v1
 kind: Route

--- a/components/pipeline-service/production/kflux-fedora-01/resources/forge-bot-secret.yaml
+++ b/components/pipeline-service/production/kflux-fedora-01/resources/forge-bot-secret.yaml
@@ -1,0 +1,20 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: forge-bot-secret
+  namespace: openshift-pipelines
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  dataFrom:
+    - extract:
+        key: production/pipeline-service/kflux-fedora-01/forge-bot
+  refreshInterval: 5m
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: appsre-stonesoup-vault
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    name: forge-bot-secret

--- a/components/pipeline-service/production/kflux-fedora-01/resources/forge-repository.yaml
+++ b/components/pipeline-service/production/kflux-fedora-01/resources/forge-repository.yaml
@@ -1,0 +1,21 @@
+apiVersion: pipelinesascode.tekton.dev/v1alpha1
+kind: Repository
+metadata:
+  name: pipelines-as-code
+  namespace: openshift-pipelines
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "1"
+spec:
+  url: https://forge.fedoraproject.org # The global Repository CR does not need a real spec.url,
+                                         # will not be used so setting this to forge landing page
+  git_provider:
+    type: forgejo
+    url: https://forge.fedoraproject.org
+    user: konflux-forge-bot
+    secret:
+      name: forge-bot-secret
+      key: token
+    webhook_secret:
+      name: forge-bot-secret
+      key: webhook-secret

--- a/components/pipeline-service/production/kflux-fedora-01/resources/kustomization.yaml
+++ b/components/pipeline-service/production/kflux-fedora-01/resources/kustomization.yaml
@@ -3,6 +3,8 @@ kind: Kustomization
 resources:
   - ../../rings/ring-1
   - scc-rbac.yaml
+  - forge-bot-secret.yaml
+  - forge-repository.yaml
 patches:
   - path: tekton-chains-public-key-path.yaml
     target:


### PR DESCRIPTION
In Forgejo, there is no equivalent of GitHub application so instead of asking every repo owners to create token using their personal account, Fedora infra folks create a service account in forge that we will be used in Konflux.

Create a global repository and use the forge service account with it. The token and webhook secret are extracted from vault.

[KFLUXINFRA-4162](https://redhat.atlassian.net/browse/KFLUXINFRA-4162)

## Risk Assessment
**Risk Level:** Low
**Description:** Setup global repo in Fedora cluster only. This is just settings default values so should not affect user repositories since they specify all values. This will not be used until users start to remove some values from their repos, then they will inherit from the global repo
**Rollback:** Revert PR

[KFLUXINFRA-4162]: https://redhat.atlassian.net/browse/KFLUXINFRA-4162?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ