### PR TITLE
fix: add update and delete to test-runner cluster role

### DIFF
--- a/components/konflux-ci/base/test-runner-cluster-role.yaml
+++ b/components/konflux-ci/base/test-runner-cluster-role.yaml
@@ -8,7 +8,7 @@ rules:
   verbs: ["get", "list", "watch"]
 - apiGroups: [""]
   resources: ["secrets"]
-  verbs: ["get", "list", "watch", "create"]
+  verbs: ["get", "list", "watch", "create", "update", "delete"]
 - apiGroups: [""]
   resources: ["pods", "pods/log"]
   verbs: ["get", "list", "watch"]


### PR DESCRIPTION
Adding privileges to the test-runner cluster role, so that `konflux-ci-sa` in `konflux-ci` ns can update/delete secrets from build-templates-e2e namespace, needed during cleanup of the secrets after the test execution.

## Risk Assessment
**Risk Level:** Low
**Description:** This PR adds an privileges to the `test-runner` cluster role, which is used to run tests in `build-templates-e2e` ns, during test execution we need to cleanup the secrets generated during the test runs. It will help us do that. 
**Rollback:** Revert this commit.