### PR TITLE
STONEINTG-1682: Add delete to nudge-migration ClusterRole on staging

### DIFF
--- a/components/authentication/rings/ring-1/base/nudge-migration-rbac.yaml
+++ b/components/authentication/rings/ring-1/base/nudge-migration-rbac.yaml
@@ -13,6 +13,7 @@ rules:
   - create
   - patch
   - update
+  - delete
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
## What

Extends the temporary `nudge-migration` ClusterRole (added in #13044) with `delete` verb on `nudgeconfigs`.

Clusters affected: staging ring-1 (`stone-stg-rh01`, `stone-stage-p01`, `kflux-stg-es01`)

[STONEINTG-1682](https://redhat.atlassian.net/browse/STONEINTG-1682)

## Why

The migration script needs `delete` to clean up test `NudgeConfig` CRs created during dry-run validation. `get`/`list` are already provided by the `everyone-can-view` ClusterRole.

## Validation

- `kustomize build --enable-helm components/authentication/rings/ring-1/base/` renders cleanly

## Risk Assessment

**Risk Level:** Low
**What could go wrong:** Grants `delete` on `nudgeconfigs` to the `konflux-integration` group on staging only — no production impact. ClusterRole is already annotated as temporary and will be removed after migration completes.
**Rollback:** Revert this PR
**Blast radius:** Staging clusters only

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[STONEINTG-1682]: https://redhat.atlassian.net/browse/STONEINTG-1682?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ