### PR TITLE
KFLUXSPRT-8608: Bump repository-validator staging config ref

### DIFF
--- a/components/repository-validator/staging/kustomization.yaml
+++ b/components/repository-validator/staging/kustomization.yaml
@@ -1,5 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - https://github.com/redhat-appstudio/internal-infra-deployments/components/repository-validator/staging?ref=0c1bdabc2e8282c77eb6e6660bd3f1623544a3a4
+  - https://github.com/redhat-appstudio/internal-infra-deployments/components/repository-validator/staging?ref=c7b1af8d994746c7a654e791d722a0aab49dcbba
   - ../base


### PR DESCRIPTION
## What

Bump `components/repository-validator/staging/kustomization.yaml` ref to
`c7b1af8d994746c7a654e791d722a0aab49dcbba`.

Picks up latest main of internal-infra-deployments, ahead of the production
ref bump in a follow-up PR.

Clusters affected: all internal staging clusters

[KFLUXSPRT-8608](https://redhat.atlassian.net/browse/KFLUXSPRT-8608)

## Why

Preparing to add `ansible/ansible-rhdh-plugins` to the production allow list
(redhat-appstudio/internal-infra-deployments#122). Bumping staging first to
validate the new ref before promoting to production.

## Validation

- `kustomize build --enable-helm components/repository-validator/staging/` passes
- SHA `c7b1af8d994746c7a654e791d722a0aab49dcbba` is the verified HEAD of
  internal-infra-deployments main

Made with [Cursor](https://cursor.com)

[KFLUXSPRT-8608]: https://redhat.atlassian.net/browse/KFLUXSPRT-8608?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ