### PR TITLE
KFLUXSE-404 Fix segment-bridge telemetry on konflux-operator ring-1

### DIFF
--- a/components/konflux-operator/rings/ring-1/base/cr/telemetry/telemetry.yaml
+++ b/components/konflux-operator/rings/ring-1/base/cr/telemetry/telemetry.yaml
@@ -5,3 +5,14 @@ metadata:
 spec:
   telemetry:
     enabled: true
+    spec:
+      segmentKeySecretRef:
+        name: segment-write-key
+        key: SEGMENT_WRITE_KEY
+      cronJob:
+        env:
+          # tekton-results is deployed in its own namespace on this cluster
+          # (see components/pipeline-service), not in openshift-pipelines as
+          # the operator's default assumes.
+          - name: TEKTON_RESULTS_API_ADDR
+            value: tekton-results-api-service.tekton-results.svc.cluster.local:8080


### PR DESCRIPTION
PR #13229 wired a Vault-backed ExternalSecret for the Segment write key and enabled telemetry, but never pointed the Konflux CR at the synced Secret, so segment-bridge always ran with an empty SEGMENT_WRITE_KEY and silently skipped the Segment upload every run.

Additionally, the operator's TEKTON_RESULTS_API_ADDR default assumes Tekton Results lives in the openshift-pipelines namespace, but this cluster's pipeline-service component deploys it into its own tekton-results namespace, so the CronJob's Tekton Results API lookups were failing DNS resolution. Fix by pointing segmentKeySecretRef at the existing segment-write-key Secret and overriding TEKTON_RESULTS_API_ADDR via the documented cronJob.env mechanism.


Assisted-by: Cursor