### PR TITLE
KFLUXSPRT-8608: Bump repository-validator production config ref (ansible-rhdh-plugins allow list)

### DIFF
--- a/components/repository-validator/production/kustomization.yaml
+++ b/components/repository-validator/production/kustomization.yaml
@@ -1,5 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - https://github.com/redhat-appstudio/internal-infra-deployments/components/repository-validator/production?ref=c038993caf7eaf21da3f44b2de39aa2a76da8740
+  - https://github.com/redhat-appstudio/internal-infra-deployments/components/repository-validator/production?ref=c7b1af8d994746c7a654e791d722a0aab49dcbba
   - ../base


### PR DESCRIPTION
## What

Bump `components/repository-validator/production/kustomization.yaml` ref to
`c7b1af8d994746c7a654e791d722a0aab49dcbba`.

Picks up: Add ansible/ansible-rhdh-plugins to production repository allow list
(redhat-appstudio/internal-infra-deployments#122)

Clusters affected: all internal production clusters

[KFLUXSPRT-8608](https://redhat.atlassian.net/browse/KFLUXSPRT-8608)

## Why

Tenant `ansible-plugins-tenant` on `stone-prod-p02` is blocked with error 54:
"Git repository is restricted from being onboarded." The team migrated from
`stone-prd-rh01` to `stone-prod-p02` because their integration tests require
access to VMware infrastructure that is only accessible via VPN.

## Validation

- `kustomize build --enable-helm components/repository-validator/production/` passes
- SHA `c7b1af8d994746c7a654e791d722a0aab49dcbba` is the verified HEAD of
  internal-infra-deployments main
- Staging ref bump merged in #13334

## Risk Assessment

**Risk Level:** Low
**What could go wrong:** New repo entry is additive; no existing entries
modified. Worst case: an incorrect prefix allows an unexpected repo — mitigated
by the fact that three other `ansible/` repos are already on the allow list.
**Rollback:** Revert this PR to restore previous ref
**Blast radius:** All internal production clusters — config change only,
no service restart required

Made with [Cursor](https://cursor.com)

[KFLUXSPRT-8608]: https://redhat.atlassian.net/browse/KFLUXSPRT-8608?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ