### PR TITLE
feat(PVO11Y-5332): Forward Konflux Tenant-level Capacity metrics

### DIFF
--- a/components/monitoring/prometheus/staging/base/federation/endpoints-params.yaml
+++ b/components/monitoring/prometheus/staging/base/federation/endpoints-params.yaml
@@ -361,3 +361,9 @@
     - '{__name__="prometheus_sd_kubernetes_failures_total"}'
     - '{__name__="prometheus_build_info"}'
     - '{__name__="process_start_time_seconds"}'
+
+    ## Konflux Tenant-Level Capacity Metrics (PVO11Y-5332)
+    - '{__name__="namespace:container_cpu_usage:sum", namespace=~".*-tenant"}'
+    - '{__name__="namespace:container_memory_usage_bytes:sum", namespace=~".*-tenant"}'
+    - '{__name__="namespace:container_cpu_cfs_throttled_periods:ratio"}'
+    - '{__name__="namespace:konflux_tenant_resourcequota_utilization:ratio"}'

--- a/components/monitoring/prometheus/staging/base/federation/prometheusrule-uwm.yaml
+++ b/components/monitoring/prometheus/staging/base/federation/prometheusrule-uwm.yaml
@@ -60,9 +60,9 @@
       rules:
       - expr: |
           max by (namespace) (
-            sum by (namespace, pod, container) (rate(container_cpu_cfs_throttled_periods_total{container!="", namespace=~".*-tenant"}[5m]))
+            sum by (namespace, pod, container) (rate(container_cpu_cfs_throttled_periods_total{container!="", image!="", namespace=~".*-tenant"}[5m]))
             /
-            sum by (namespace, pod, container) (rate(container_cpu_cfs_periods_total{container!="", namespace=~".*-tenant"}[5m]))
+            sum by (namespace, pod, container) (rate(container_cpu_cfs_periods_total{container!="", image!="", namespace=~".*-tenant"}[5m]))
           )
         record: namespace:container_cpu_cfs_throttled_periods:ratio
       - expr: |

--- a/components/monitoring/prometheus/staging/base/federation/prometheusrule-uwm.yaml
+++ b/components/monitoring/prometheus/staging/base/federation/prometheusrule-uwm.yaml
@@ -55,3 +55,18 @@
       - expr: |
           sum(kube_node_status_capacity{cluster="", resource="cpu"}) by (node) and on (node) kube_node_role{role="master"}
         record: master_node:kube_node_status_capacity_cpu:sum
+
+    - name: konflux_tenant_capacity
+      rules:
+      - expr: |
+          max by (namespace) (
+            sum by (namespace, pod, container) (rate(container_cpu_cfs_throttled_periods_total{container!="", namespace=~".*-tenant"}[5m]))
+            /
+            sum by (namespace, pod, container) (rate(container_cpu_cfs_periods_total{container!="", namespace=~".*-tenant"}[5m]))
+          )
+        record: namespace:container_cpu_cfs_throttled_periods:ratio
+      - expr: |
+          kube_resourcequota{namespace=~".*-tenant", resource=~"(requests.cpu|limits.cpu|requests.memory|limits.memory)", type="used"}
+          / on (namespace, resource)
+          kube_resourcequota{namespace=~".*-tenant", resource=~"(requests.cpu|limits.cpu|requests.memory|limits.memory)", type="hard"}
+        record: namespace:konflux_tenant_resourcequota_utilization:ratio

--- a/components/monitoring/prometheus/staging/base/federation/prometheusrule-uwm.yaml
+++ b/components/monitoring/prometheus/staging/base/federation/prometheusrule-uwm.yaml
@@ -66,7 +66,11 @@
           )
         record: namespace:container_cpu_cfs_throttled_periods:ratio
       - expr: |
-          kube_resourcequota{namespace=~".*-tenant", resource=~"(requests.cpu|limits.cpu|requests.memory|limits.memory)", type="used"}
+          sum by (namespace, resource) (
+            kube_resourcequota{resource=~"(requests.cpu|limits.cpu|requests.memory|limits.memory)", type="used"}
+          )
           / on (namespace, resource)
-          kube_resourcequota{namespace=~".*-tenant", resource=~"(requests.cpu|limits.cpu|requests.memory|limits.memory)", type="hard"}
+          min by (namespace, resource) (
+            kube_resourcequota{resource=~"(requests.cpu|limits.cpu|requests.memory|limits.memory)", type="hard"}
+          )
         record: namespace:konflux_tenant_resourcequota_utilization:ratio

--- a/components/monitoring/prometheus/staging/base/federation/prometheusrule-uwm.yaml
+++ b/components/monitoring/prometheus/staging/base/federation/prometheusrule-uwm.yaml
@@ -66,11 +66,9 @@
           )
         record: namespace:container_cpu_cfs_throttled_periods:ratio
       - expr: |
-          sum by (namespace, resource) (
+          max by (namespace, resource) (
             kube_resourcequota{namespace=~".*-tenant", resource=~"(requests|limits)\\.(cpu|memory)", type="used"}
-          )
-          / on (namespace, resource)
-          min by (namespace, resource) (
+            / on (namespace, resource, resourcequota)
             kube_resourcequota{namespace=~".*-tenant", resource=~"(requests|limits)\\.(cpu|memory)", type="hard"}
           )
         record: namespace:konflux_tenant_resourcequota_utilization:ratio

--- a/components/monitoring/prometheus/staging/base/federation/prometheusrule-uwm.yaml
+++ b/components/monitoring/prometheus/staging/base/federation/prometheusrule-uwm.yaml
@@ -67,10 +67,10 @@
         record: namespace:container_cpu_cfs_throttled_periods:ratio
       - expr: |
           sum by (namespace, resource) (
-            kube_resourcequota{namespace=~".*-tenant", resource=~"(requests.cpu|limits.cpu|requests.memory|limits.memory)", type="used"}
+            kube_resourcequota{namespace=~".*-tenant", resource=~"(requests|limits)\\.(cpu|memory)", type="used"}
           )
           / on (namespace, resource)
           min by (namespace, resource) (
-            kube_resourcequota{namespace=~".*-tenant", resource=~"(requests.cpu|limits.cpu|requests.memory|limits.memory)", type="hard"}
+            kube_resourcequota{namespace=~".*-tenant", resource=~"(requests|limits)\\.(cpu|memory)", type="hard"}
           )
         record: namespace:konflux_tenant_resourcequota_utilization:ratio

--- a/components/monitoring/prometheus/staging/base/federation/prometheusrule-uwm.yaml
+++ b/components/monitoring/prometheus/staging/base/federation/prometheusrule-uwm.yaml
@@ -67,10 +67,10 @@
         record: namespace:container_cpu_cfs_throttled_periods:ratio
       - expr: |
           sum by (namespace, resource) (
-            kube_resourcequota{resource=~"(requests.cpu|limits.cpu|requests.memory|limits.memory)", type="used"}
+            kube_resourcequota{namespace=~".*-tenant", resource=~"(requests.cpu|limits.cpu|requests.memory|limits.memory)", type="used"}
           )
           / on (namespace, resource)
           min by (namespace, resource) (
-            kube_resourcequota{resource=~"(requests.cpu|limits.cpu|requests.memory|limits.memory)", type="hard"}
+            kube_resourcequota{namespace=~".*-tenant", resource=~"(requests.cpu|limits.cpu|requests.memory|limits.memory)", type="hard"}
           )
         record: namespace:konflux_tenant_resourcequota_utilization:ratio

--- a/components/monitoring/prometheus/staging/base/federation/prometheusrule-uwm.yaml
+++ b/components/monitoring/prometheus/staging/base/federation/prometheusrule-uwm.yaml
@@ -62,7 +62,7 @@
           max by (namespace) (
             sum by (namespace, pod, container) (rate(container_cpu_cfs_throttled_periods_total{container!="", image!="", namespace=~".*-tenant"}[5m]))
             /
-            sum by (namespace, pod, container) (rate(container_cpu_cfs_periods_total{container!="", image!="", namespace=~".*-tenant"}[5m]))
+            (sum by (namespace, pod, container) (rate(container_cpu_cfs_periods_total{container!="", image!="", namespace=~".*-tenant"}[5m])) > 0)
           )
         record: namespace:container_cpu_cfs_throttled_periods:ratio
       - expr: |


### PR DESCRIPTION
- Create two new recording rules for aggregating capacity metrics at the tenant-level
- Forward metrics needed for tenant-level capacity monitoring to RHOBS