### PR TITLE
fix(PVO11Y-5400): fix boostrap and gapfill logic for high volume tenants

### DIFF
--- a/components/monitoring/exporters/kaexporter/staging/base/kustomization.yaml
+++ b/components/monitoring/exporters/kaexporter/staging/base/kustomization.yaml
@@ -7,7 +7,7 @@ resources:
 images:
   - name: quay.io/redhat-appstudio/o11y
     newName: quay.io/redhat-appstudio/o11y
-    newTag: 05d2ca5b75e37f9675f0a0eb70649d847cdb8813
+    newTag: f0c8c797641789e13021ed225271f660177863d0
 
 patches:
   - path: ./configs/kaexporter-deployment-patch.yaml


### PR DESCRIPTION
## Summary
* Bump of kaexporter metrics to fix [PVO11Y-5400](https://redhat.atlassian.net/browse/PVO11Y-5400) bug.

## Risk Assessment
* Level: Low
* Description: Was validated locally with directly fetching KubeArchive to valide the numbers that are now correct
* Rollback: Revert commit

## Validation
* Validated locally
* Added unit tests for certain cases in o11y repository

[PVO11Y-5400]: https://redhat.atlassian.net/browse/PVO11Y-5400?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ