### PR TITLE
feat(PVO11Y-5332): Forward Konflux Tenant-level Capacity metrics prd

### DIFF
--- a/components/monitoring/prometheus/production/base/federation/endpoints-params.yaml
+++ b/components/monitoring/prometheus/production/base/federation/endpoints-params.yaml
@@ -360,3 +360,9 @@
     - '{__name__="prometheus_sd_kubernetes_failures_total"}'
     - '{__name__="prometheus_build_info"}'
     - '{__name__="process_start_time_seconds"}'
+
+    ## Konflux Tenant-Level Capacity Metrics (PVO11Y-5332)
+    - '{__name__="namespace:container_cpu_usage:sum", namespace=~".*-tenant"}'
+    - '{__name__="namespace:container_memory_usage_bytes:sum", namespace=~".*-tenant"}'
+    - '{__name__="namespace:container_cpu_cfs_throttled_periods:ratio"}'
+    - '{__name__="namespace:konflux_tenant_resourcequota_utilization:ratio"}'

--- a/components/monitoring/prometheus/production/base/federation/endpoints-params.yaml
+++ b/components/monitoring/prometheus/production/base/federation/endpoints-params.yaml
@@ -364,5 +364,5 @@
     ## Konflux Tenant-Level Capacity Metrics (PVO11Y-5332)
     - '{__name__="namespace:container_cpu_usage:sum", namespace=~".*-tenant"}'
     - '{__name__="namespace:container_memory_usage_bytes:sum", namespace=~".*-tenant"}'
-    - '{__name__="namespace:container_cpu_cfs_throttled_periods:ratio"}'
+    - '{__name__="namespace:avg_container_cpu_cfs_throttled_periods:ratio"}'
     - '{__name__="namespace:konflux_tenant_resourcequota_utilization:ratio"}'

--- a/components/monitoring/prometheus/production/base/federation/prometheusrule-uwm.yaml
+++ b/components/monitoring/prometheus/production/base/federation/prometheusrule-uwm.yaml
@@ -56,3 +56,20 @@
       - expr: |
           sum(kube_node_status_capacity{cluster="", resource="cpu"}) by (node) and on (node) kube_node_role{role="master"}
         record: master_node:kube_node_status_capacity_cpu:sum
+
+    - name: konflux_tenant_capacity
+      rules:
+      - expr: |
+          max by (namespace) (
+            sum by (namespace, pod, container) (rate(container_cpu_cfs_throttled_periods_total{container!="", image!="", namespace=~".*-tenant"}[5m]))
+            /
+            (sum by (namespace, pod, container) (rate(container_cpu_cfs_periods_total{container!="", image!="", namespace=~".*-tenant"}[5m])) > 0)
+          )
+        record: namespace:container_cpu_cfs_throttled_periods:ratio
+      - expr: |
+          max by (namespace, resource) (
+            kube_resourcequota{namespace=~".*-tenant", resource=~"(requests|limits)\\.(cpu|memory)", type="used"}
+            / on (namespace, resource, resourcequota)
+            kube_resourcequota{namespace=~".*-tenant", resource=~"(requests|limits)\\.(cpu|memory)", type="hard"}
+          )
+        record: namespace:konflux_tenant_resourcequota_utilization:ratio

--- a/components/monitoring/prometheus/production/base/federation/prometheusrule-uwm.yaml
+++ b/components/monitoring/prometheus/production/base/federation/prometheusrule-uwm.yaml
@@ -60,12 +60,12 @@
     - name: konflux_tenant_capacity
       rules:
       - expr: |
-          max by (namespace) (
-            sum by (namespace, pod, container) (rate(container_cpu_cfs_throttled_periods_total{container!="", image!="", namespace=~".*-tenant"}[5m]))
+          avg by (namespace) (
+            sum by (namespace, pod, container) (rate(container_cpu_cfs_throttled_periods_total{container!="", image!="", namespace=~".*-tenant"}[10m]))
             /
-            (sum by (namespace, pod, container) (rate(container_cpu_cfs_periods_total{container!="", image!="", namespace=~".*-tenant"}[5m])) > 0)
+            (sum by (namespace, pod, container) (rate(container_cpu_cfs_periods_total{container!="", image!="", namespace=~".*-tenant"}[10m])) > 0)
           )
-        record: namespace:container_cpu_cfs_throttled_periods:ratio
+        record: namespace:avg_container_cpu_cfs_throttled_periods:ratio
       - expr: |
           max by (namespace, resource) (
             kube_resourcequota{namespace=~".*-tenant", resource=~"(requests|limits)\\.(cpu|memory)", type="used"}


### PR DESCRIPTION
## Summary

Forwarding metrics needed for tenant-level capacity monitoring

- Create two new recording rules for aggregating capacity metrics at the tenant-level
- Forward metrics needed for tenant-level capacity monitoring to RHOBS

This was applied and verified in stage first with redhat-appstudio/infra-deployments#13345

## Risk Assessment

- **Level**: Low
- **Description**: Changes only addes new recording rules and forwarding rules. No changes to existing metric forwarding.
- **Rollback**: Revert this PR to undo forwarding these new metrics

## Validation

- These changes were first deployed and validated in stage with redhat-appstudio/infra-deployments#13345 and redhat-appstudio/infra-deployments#13375
- Verified generated manifests were correct with `kustomize build components/monitoring/prometheus/production/base/federation`