### PR TITLE
chore(konflux-operator): remove trusted CA from build and integration services

### DIFF
--- a/components/konflux-operator/rings/ring-0/base/cr/build/kustomization.yaml
+++ b/components/konflux-operator/rings/ring-0/base/cr/build/kustomization.yaml
@@ -1,7 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
 resources:
-  - trusted-ca-configmap.yaml
   - rbac
 patches:
   - path: build-service.yaml

--- a/components/konflux-operator/rings/ring-0/base/cr/build/trusted-ca-configmap.yaml
+++ b/components/konflux-operator/rings/ring-0/base/cr/build/trusted-ca-configmap.yaml
@@ -1,8 +1,0 @@
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: trusted-ca
-  namespace: build-service
-  labels:
-    config.openshift.io/inject-trusted-cabundle: "true"

--- a/components/konflux-operator/rings/ring-0/base/cr/integration/kustomization.yaml
+++ b/components/konflux-operator/rings/ring-0/base/cr/integration/kustomization.yaml
@@ -1,7 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
 resources:
-  - trusted-ca-configmap.yaml
   - rbac
 patches:
   - path: integration-service.yaml

--- a/components/konflux-operator/rings/ring-0/base/cr/integration/trusted-ca-configmap.yaml
+++ b/components/konflux-operator/rings/ring-0/base/cr/integration/trusted-ca-configmap.yaml
@@ -1,8 +1,0 @@
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: trusted-ca
-  namespace: integration-service
-  labels:
-    config.openshift.io/inject-trusted-cabundle: "true"

--- a/components/konflux-operator/rings/ring-1/base/cr/build/kustomization.yaml
+++ b/components/konflux-operator/rings/ring-1/base/cr/build/kustomization.yaml
@@ -2,7 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
 resources:
   - external-secrets
-  - trusted-ca-configmap.yaml
   - rbac
 patches:
   - path: build-service.yaml

--- a/components/konflux-operator/rings/ring-1/base/cr/build/trusted-ca-configmap.yaml
+++ b/components/konflux-operator/rings/ring-1/base/cr/build/trusted-ca-configmap.yaml
@@ -1,8 +1,0 @@
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: trusted-ca
-  namespace: build-service
-  labels:
-    config.openshift.io/inject-trusted-cabundle: "true"

--- a/components/konflux-operator/rings/ring-1/base/cr/integration/kustomization.yaml
+++ b/components/konflux-operator/rings/ring-1/base/cr/integration/kustomization.yaml
@@ -2,7 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
 resources:
   - external-secrets
-  - trusted-ca-configmap.yaml
   - rbac
 patches:
   - path: integration-service.yaml

--- a/components/konflux-operator/rings/ring-1/base/cr/integration/trusted-ca-configmap.yaml
+++ b/components/konflux-operator/rings/ring-1/base/cr/integration/trusted-ca-configmap.yaml
@@ -1,8 +1,0 @@
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: trusted-ca
-  namespace: integration-service
-  labels:
-    config.openshift.io/inject-trusted-cabundle: "true"


### PR DESCRIPTION
Konflux operator creates a configmap with the trusted CA bundle for the build and integration services. 
The creation of external configmaps for the trusted CA bundle is no longer needed.