### PR TITLE
production Ring 1: upgrade pipelines 830 to 854

### DIFF
--- a/components/pipeline-service/production/base/main-pipeline-service-configuration.yaml
+++ b/components/pipeline-service/production/base/main-pipeline-service-configuration.yaml
@@ -2054,7 +2054,7 @@ metadata:
   namespace: openshift-marketplace
 spec:
   displayName: custom-operators
-  image: quay.io/openshift-pipeline/pipelines-index-4.18@sha256:a4aa211a70b0a92c98c885cca8fed2cce490e3fec656ad1ea68bf7e7c3c18304
+  image: quay.io/openshift-pipeline/pipelines-index-4.19@sha256:bd598786408b16bc1171c79907db124013189d57677e8bfbec1feccc55523ccd
   sourceType: grpc
   updateStrategy:
     registryPoll:
@@ -2077,20 +2077,6 @@ spec:
     env:
       - name: AUTOINSTALL_COMPONENTS
         value: "false"
-      # TODO: Remove this once Pipelines 1.13.x is deployed
-      # NOTE: IMAGE_PIPELINES_CONTROLLER is the image used specifically by the resolvers,
-      # the pipelines-controller uses IMAGE_PIPELINES_TEKTON_PIPELINES_CONTROLLER
-      - name: IMAGE_PIPELINES_CONTROLLER
-        value: quay.io/openshift-pipeline/pipelines-resolvers-rhel9@sha256:7cd91bc4c0f3469ec4c39d08d818b00c90ce07456364910e49ad5e1430f3110a
-      # TODO: remove these when upgrading to a bundle including Pipelines as Code v0.48.0+
-      - name: IMAGE_PAC_PAC_CONTROLLER
-        value: "quay.io/openshift-pipeline/pipelines-pipelines-as-code-controller-rhel9@sha256:1b1e365cfdcc85646d5890232a04bad8c7ba9ebb0db36042eeda5961f8106567"
-      - name: IMAGE_PAC_PAC_WEBHOOK
-        value: "quay.io/openshift-pipeline/pipelines-pipelines-as-code-webhook-rhel9@sha256:0ccda15a17a405020fa199b3dce4a630e592da9dfdbd9778be1dcc9f4bdc3fbd"
-      - name: IMAGE_PAC_PAC_WATCHER
-        value: "quay.io/openshift-pipeline/pipelines-pipelines-as-code-watcher-rhel9@sha256:d100578068feb5482e2631b4fadc80b9687f129c7e303b55431ac41ce58f7758"
-      - name: IMAGE_PAC_PAC_CLI
-        value: "quay.io/openshift-pipeline/pipelines-pipelines-as-code-cli-rhel9@sha256:0fc0dd05236f14265e25cc770a7f9f3aeea2e27964a730dac39cf9f61d349bde"
 ---
 apiVersion: route.openshift.io/v1
 kind: Route

--- a/components/pipeline-service/production/kflux-fedora-01/deploy.yaml
+++ b/components/pipeline-service/production/kflux-fedora-01/deploy.yaml
@@ -2565,7 +2565,7 @@ metadata:
   namespace: openshift-marketplace
 spec:
   displayName: custom-operators
-  image: quay.io/openshift-pipeline/pipelines-index-4.18@sha256:a4aa211a70b0a92c98c885cca8fed2cce490e3fec656ad1ea68bf7e7c3c18304
+  image: quay.io/openshift-pipeline/pipelines-index-4.19@sha256:bd598786408b16bc1171c79907db124013189d57677e8bfbec1feccc55523ccd
   sourceType: grpc
   updateStrategy:
     registryPoll:
@@ -2585,16 +2585,6 @@ spec:
     env:
     - name: AUTOINSTALL_COMPONENTS
       value: "false"
-    - name: IMAGE_PIPELINES_CONTROLLER
-      value: quay.io/openshift-pipeline/pipelines-resolvers-rhel9@sha256:7cd91bc4c0f3469ec4c39d08d818b00c90ce07456364910e49ad5e1430f3110a
-    - name: IMAGE_PAC_PAC_CONTROLLER
-      value: quay.io/openshift-pipeline/pipelines-pipelines-as-code-controller-rhel9@sha256:1b1e365cfdcc85646d5890232a04bad8c7ba9ebb0db36042eeda5961f8106567
-    - name: IMAGE_PAC_PAC_WEBHOOK
-      value: quay.io/openshift-pipeline/pipelines-pipelines-as-code-webhook-rhel9@sha256:0ccda15a17a405020fa199b3dce4a630e592da9dfdbd9778be1dcc9f4bdc3fbd
-    - name: IMAGE_PAC_PAC_WATCHER
-      value: quay.io/openshift-pipeline/pipelines-pipelines-as-code-watcher-rhel9@sha256:d100578068feb5482e2631b4fadc80b9687f129c7e303b55431ac41ce58f7758
-    - name: IMAGE_PAC_PAC_CLI
-      value: quay.io/openshift-pipeline/pipelines-pipelines-as-code-cli-rhel9@sha256:0fc0dd05236f14265e25cc770a7f9f3aeea2e27964a730dac39cf9f61d349bde
   name: openshift-pipelines-operator-rh
   source: custom-operators
   sourceNamespace: openshift-marketplace

--- a/components/pipeline-service/production/kflux-osp-p01/deploy.yaml
+++ b/components/pipeline-service/production/kflux-osp-p01/deploy.yaml
@@ -2531,7 +2531,7 @@ metadata:
   namespace: openshift-marketplace
 spec:
   displayName: custom-operators
-  image: quay.io/openshift-pipeline/pipelines-index-4.18@sha256:a4aa211a70b0a92c98c885cca8fed2cce490e3fec656ad1ea68bf7e7c3c18304
+  image: quay.io/openshift-pipeline/pipelines-index-4.19@sha256:bd598786408b16bc1171c79907db124013189d57677e8bfbec1feccc55523ccd
   sourceType: grpc
   updateStrategy:
     registryPoll:
@@ -2551,16 +2551,6 @@ spec:
     env:
     - name: AUTOINSTALL_COMPONENTS
       value: "false"
-    - name: IMAGE_PIPELINES_CONTROLLER
-      value: quay.io/openshift-pipeline/pipelines-resolvers-rhel9@sha256:7cd91bc4c0f3469ec4c39d08d818b00c90ce07456364910e49ad5e1430f3110a
-    - name: IMAGE_PAC_PAC_CONTROLLER
-      value: quay.io/openshift-pipeline/pipelines-pipelines-as-code-controller-rhel9@sha256:1b1e365cfdcc85646d5890232a04bad8c7ba9ebb0db36042eeda5961f8106567
-    - name: IMAGE_PAC_PAC_WEBHOOK
-      value: quay.io/openshift-pipeline/pipelines-pipelines-as-code-webhook-rhel9@sha256:0ccda15a17a405020fa199b3dce4a630e592da9dfdbd9778be1dcc9f4bdc3fbd
-    - name: IMAGE_PAC_PAC_WATCHER
-      value: quay.io/openshift-pipeline/pipelines-pipelines-as-code-watcher-rhel9@sha256:d100578068feb5482e2631b4fadc80b9687f129c7e303b55431ac41ce58f7758
-    - name: IMAGE_PAC_PAC_CLI
-      value: quay.io/openshift-pipeline/pipelines-pipelines-as-code-cli-rhel9@sha256:0fc0dd05236f14265e25cc770a7f9f3aeea2e27964a730dac39cf9f61d349bde
   name: openshift-pipelines-operator-rh
   source: custom-operators
   sourceNamespace: openshift-marketplace

--- a/components/pipeline-service/production/rings/ring-2/kustomization.yaml
+++ b/components/pipeline-service/production/rings/ring-2/kustomization.yaml
@@ -8,4 +8,41 @@ kind: Kustomization
 resources:
   - ../../base
 
-patches: []
+patches:
+  # Hold back on build 830 until Ring 2 promotion
+  - target:
+      kind: CatalogSource
+      name: custom-operators
+    patch: |-
+      - op: replace
+        path: /spec/image
+        value: quay.io/openshift-pipeline/pipelines-index-4.18@sha256:a4aa211a70b0a92c98c885cca8fed2cce490e3fec656ad1ea68bf7e7c3c18304
+  - target:
+      kind: Subscription
+      name: openshift-pipelines-operator
+    patch: |-
+      - op: add
+        path: /spec/config/env/-
+        value:
+          name: IMAGE_PIPELINES_CONTROLLER
+          value: "quay.io/openshift-pipeline/pipelines-resolvers-rhel9@sha256:7cd91bc4c0f3469ec4c39d08d818b00c90ce07456364910e49ad5e1430f3110a"
+      - op: add
+        path: /spec/config/env/-
+        value:
+          name: IMAGE_PAC_PAC_CONTROLLER
+          value: "quay.io/openshift-pipeline/pipelines-pipelines-as-code-controller-rhel9@sha256:1b1e365cfdcc85646d5890232a04bad8c7ba9ebb0db36042eeda5961f8106567"
+      - op: add
+        path: /spec/config/env/-
+        value:
+          name: IMAGE_PAC_PAC_WEBHOOK
+          value: "quay.io/openshift-pipeline/pipelines-pipelines-as-code-webhook-rhel9@sha256:0ccda15a17a405020fa199b3dce4a630e592da9dfdbd9778be1dcc9f4bdc3fbd"
+      - op: add
+        path: /spec/config/env/-
+        value:
+          name: IMAGE_PAC_PAC_WATCHER
+          value: "quay.io/openshift-pipeline/pipelines-pipelines-as-code-watcher-rhel9@sha256:d100578068feb5482e2631b4fadc80b9687f129c7e303b55431ac41ce58f7758"
+      - op: add
+        path: /spec/config/env/-
+        value:
+          name: IMAGE_PAC_PAC_CLI
+          value: "quay.io/openshift-pipeline/pipelines-pipelines-as-code-cli-rhel9@sha256:0fc0dd05236f14265e25cc770a7f9f3aeea2e27964a730dac39cf9f61d349bde"

--- a/components/pipeline-service/production/rings/ring-3/kustomization.yaml
+++ b/components/pipeline-service/production/rings/ring-3/kustomization.yaml
@@ -8,4 +8,41 @@ kind: Kustomization
 resources:
   - ../../base
 
-patches: []
+patches:
+  # Hold back on build 830 until Ring 3 promotion
+  - target:
+      kind: CatalogSource
+      name: custom-operators
+    patch: |-
+      - op: replace
+        path: /spec/image
+        value: quay.io/openshift-pipeline/pipelines-index-4.18@sha256:a4aa211a70b0a92c98c885cca8fed2cce490e3fec656ad1ea68bf7e7c3c18304
+  - target:
+      kind: Subscription
+      name: openshift-pipelines-operator
+    patch: |-
+      - op: add
+        path: /spec/config/env/-
+        value:
+          name: IMAGE_PIPELINES_CONTROLLER
+          value: "quay.io/openshift-pipeline/pipelines-resolvers-rhel9@sha256:7cd91bc4c0f3469ec4c39d08d818b00c90ce07456364910e49ad5e1430f3110a"
+      - op: add
+        path: /spec/config/env/-
+        value:
+          name: IMAGE_PAC_PAC_CONTROLLER
+          value: "quay.io/openshift-pipeline/pipelines-pipelines-as-code-controller-rhel9@sha256:1b1e365cfdcc85646d5890232a04bad8c7ba9ebb0db36042eeda5961f8106567"
+      - op: add
+        path: /spec/config/env/-
+        value:
+          name: IMAGE_PAC_PAC_WEBHOOK
+          value: "quay.io/openshift-pipeline/pipelines-pipelines-as-code-webhook-rhel9@sha256:0ccda15a17a405020fa199b3dce4a630e592da9dfdbd9778be1dcc9f4bdc3fbd"
+      - op: add
+        path: /spec/config/env/-
+        value:
+          name: IMAGE_PAC_PAC_WATCHER
+          value: "quay.io/openshift-pipeline/pipelines-pipelines-as-code-watcher-rhel9@sha256:d100578068feb5482e2631b4fadc80b9687f129c7e303b55431ac41ce58f7758"
+      - op: add
+        path: /spec/config/env/-
+        value:
+          name: IMAGE_PAC_PAC_CLI
+          value: "quay.io/openshift-pipeline/pipelines-pipelines-as-code-cli-rhel9@sha256:0fc0dd05236f14265e25cc770a7f9f3aeea2e27964a730dac39cf9f61d349bde"

--- a/components/pipeline-service/production/stone-prod-p01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prod-p01/deploy.yaml
@@ -2531,7 +2531,7 @@ metadata:
   namespace: openshift-marketplace
 spec:
   displayName: custom-operators
-  image: quay.io/openshift-pipeline/pipelines-index-4.18@sha256:a4aa211a70b0a92c98c885cca8fed2cce490e3fec656ad1ea68bf7e7c3c18304
+  image: quay.io/openshift-pipeline/pipelines-index-4.19@sha256:bd598786408b16bc1171c79907db124013189d57677e8bfbec1feccc55523ccd
   sourceType: grpc
   updateStrategy:
     registryPoll:
@@ -2551,16 +2551,6 @@ spec:
     env:
     - name: AUTOINSTALL_COMPONENTS
       value: "false"
-    - name: IMAGE_PIPELINES_CONTROLLER
-      value: quay.io/openshift-pipeline/pipelines-resolvers-rhel9@sha256:7cd91bc4c0f3469ec4c39d08d818b00c90ce07456364910e49ad5e1430f3110a
-    - name: IMAGE_PAC_PAC_CONTROLLER
-      value: quay.io/openshift-pipeline/pipelines-pipelines-as-code-controller-rhel9@sha256:1b1e365cfdcc85646d5890232a04bad8c7ba9ebb0db36042eeda5961f8106567
-    - name: IMAGE_PAC_PAC_WEBHOOK
-      value: quay.io/openshift-pipeline/pipelines-pipelines-as-code-webhook-rhel9@sha256:0ccda15a17a405020fa199b3dce4a630e592da9dfdbd9778be1dcc9f4bdc3fbd
-    - name: IMAGE_PAC_PAC_WATCHER
-      value: quay.io/openshift-pipeline/pipelines-pipelines-as-code-watcher-rhel9@sha256:d100578068feb5482e2631b4fadc80b9687f129c7e303b55431ac41ce58f7758
-    - name: IMAGE_PAC_PAC_CLI
-      value: quay.io/openshift-pipeline/pipelines-pipelines-as-code-cli-rhel9@sha256:0fc0dd05236f14265e25cc770a7f9f3aeea2e27964a730dac39cf9f61d349bde
   name: openshift-pipelines-operator-rh
   source: custom-operators
   sourceNamespace: openshift-marketplace


### PR DESCRIPTION
- **Ring 1**: kflux-fedora-01, stone-prod-p01, kflux-osp-p01
- **Index image**: pipelines-index-4.18 (build 830) → pipelines-index-4.19 (build 854) (sha256:a4aa211a → bd598786)
- **Removed overrides**: IMAGE_PAC_PAC_* (PAC v0.48.0+ now in bundle), IMAGE_PIPELINES_CONTROLLER (Pipeline v1.14.0 resolves [KONFLUX-14376](https://redhat.atlassian.net/browse/KONFLUX-14376))

## Validation
- 4.19 build 854 validated in dev/staging ([PR #12999](https://github.com/redhat-appstudio/infra-deployments/pull/12999), [PR #13173](https://github.com/redhat-appstudio/infra-deployments/pull/13173))
- Staging bake period: 2+ weeks on stone-stg-rh01 and stone-stage-p01
- PiP (TEP-0056) functional test passed on stone-stg-rh01

## Risk Assessment
**Risk Level:** Medium
**Description:** Includes Tekton Pipeline v1.14.0, PAC v0.49.0, Chains ~v0.27.3, Operator v0.80+. 60+ CVE fixes across all components. Image soaked in staging for 2+ weeks.
**Rollback:** Release a new Index image with the fix included.

[KONFLUX-14376]: https://redhat.atlassian.net/browse/KONFLUX-14376?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ