### PR TITLE
PVO11Y-5403 Use loadtest image in push-kanary-metrics, drop runtime pip install

### DIFF
--- a/components/monitoring/kanary/staging/base/tasks/push-kanary-metrics.yaml
+++ b/components/monitoring/kanary/staging/base/tasks/push-kanary-metrics.yaml
@@ -19,7 +19,7 @@ spec:
       description: "Test outcome from collect-results: passed, failed, or unknown"
   steps:
     - name: push-metrics
-      image: registry.redhat.io/ubi9/python-312:latest
+      image: quay.io/redhat-user-workloads/konflux-perfscale-tenant/loadtest
       env:
         - name: OTEL_ENDPOINT
           value: $(params.otel-endpoint)
@@ -32,15 +32,7 @@ spec:
       script: |
         #!/usr/bin/env python3
         import os
-        import subprocess
         import time
-
-        subprocess.check_call([
-            "pip", "install", "--quiet",
-            "opentelemetry-api",
-            "opentelemetry-sdk",
-            "opentelemetry-exporter-otlp-proto-http",
-        ])
 
         from opentelemetry import metrics
         from opentelemetry.sdk.metrics import MeterProvider


### PR DESCRIPTION
## What

- Switch `push-kanary-metrics` task image from `registry.redhat.io/ubi9/python-312:latest` to `quay.io/redhat-user-workloads/konflux-perfscale-tenant/loadtest`
- Remove the `subprocess.check_call(["pip", "install"...])` block that installed the OpenTelemetry SDK at runtime

[PVO11Y-5403](https://redhat.atlassian.net/browse/PVO11Y-5403)

## Why

The pip install runs on every kanary PipelineRun (~every 30 minutes per cluster), adding unnecessary latency and a network dependency. The otel SDK packages (`opentelemetry-api`, `opentelemetry-sdk`, `opentelemetry-exporter-otlp-proto-http`) and `yq` are now baked into the loadtest image via [konflux-ci/loadtest#139](https://github.com/konflux-ci/loadtest/pull/139).

> **Note:** This PR depends on konflux-ci/loadtest#139 being merged and the loadtest image being rebuilt before merging here.

## Validation

- `kustomize build components/monitoring/kanary/staging/base/` passes

[PVO11Y-5403]: https://redhat.atlassian.net/browse/PVO11Y-5403?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ