### PR TITLE
chore(KFLUXVNGD-1096): remote-write caddy metrics

### DIFF
--- a/components/monitoring/prometheus/staging/base/federation/endpoints-params.yaml
+++ b/components/monitoring/prometheus/staging/base/federation/endpoints-params.yaml
@@ -27,6 +27,7 @@
     - '{__name__="kube_deployment_status_replicas_available", namespace="konflux-ui"}'
     - '{__name__="kube_deployment_spec_replicas", namespace="konflux-ui"}'
     - '{__name__="nginx_otel_http_request_errors_total", namespace="konflux-ui"}'
+    - '{__name__="caddy_http_request_duration_seconds_count", namespace="konflux-ui"}'
 
     # Namespace: konflux-kite
     - '{__name__="kube_deployment_status_replicas_ready", namespace="konflux-kite"}'

--- a/components/monitoring/prometheus/staging/base/federation/writeRelabelConfigs.yaml
+++ b/components/monitoring/prometheus/staging/base/federation/writeRelabelConfigs.yaml
@@ -10,6 +10,7 @@
     # K8s resource state (RHTAPWATCH-88, SPRE-1489, KFLUXINFRA-3503)
     # Storage (RHTAPWATCH-88)
     # HTTP / gRPC (SRVKP-4524, PVO11Y-4652)
+    # Caddy HTTP metrics (handler/server; code/method already listed)
     # Histogram (RHTAPWATCH-88, PVO11Y-4774)
     # Node / CPU (PVO11Y-4652, PVO11Y-4776)
     # Tekton / Pipelines (RHTAPWATCH-110)
@@ -30,7 +31,7 @@
     regex: "__name__|source_environment|source_cluster|namespace|job|instance|pod|container|app|service|deployment|node|\
       phase|reason|type|resource|kind|name|role|status|state|resourcequota|image|finalizers|verb|request_kind|\
       persistentvolumeclaim|storageclass|volumename|\
-      method|code|http_method|http_route|http_status_code|grpc_service|grpc_code|grpc_method|sp|\
+      method|code|handler|server|http_method|http_route|http_status_code|grpc_service|grpc_code|grpc_method|sp|\
       le|quantile|\
       cpu|mode|\
       pipeline|pipelinename|pipelinerun|schedule|label_pipelines_appstudio_openshift_io_type|\


### PR DESCRIPTION
Konflux UI is migrating from nginx to Caddy. Caddy provides different metrics than nginx, so we need to update the remote-write configuration to support these new metrics.

Assisted-by: Cursor