### PR TITLE
fix(KFLUXVNGD-1096): caddy metric added in wrong place

### DIFF
--- a/components/monitoring/prometheus/staging/base/federation/endpoints-params.yaml
+++ b/components/monitoring/prometheus/staging/base/federation/endpoints-params.yaml
@@ -27,7 +27,6 @@
     - '{__name__="kube_deployment_status_replicas_available", namespace="konflux-ui"}'
     - '{__name__="kube_deployment_spec_replicas", namespace="konflux-ui"}'
     - '{__name__="nginx_otel_http_request_errors_total", namespace="konflux-ui"}'
-    - '{__name__="caddy_http_request_duration_seconds_count", namespace="konflux-ui"}'
 
     # Namespace: konflux-kite
     - '{__name__="kube_deployment_status_replicas_ready", namespace="konflux-kite"}'


### PR DESCRIPTION
caddy_http_request_duration_seconds_count was added to the list of metrics to be exported, but in reality this list is for metrics scraped by the system Prometheus instance rather than UWM.

Caddy metrics collected by UWM are already remote-written.

It's very much possible that the nginx_otel_http_request_errors_total metric that is present on the config and used for legacy nginx rules is not required there either.

It will be removed once we migrate to Caddy on all clusters.