### PR TITLE
feat(PVO11Y-5332): Use 10min moving avg for cfs_throttled_periods

### DIFF
--- a/components/monitoring/prometheus/staging/base/federation/endpoints-params.yaml
+++ b/components/monitoring/prometheus/staging/base/federation/endpoints-params.yaml
@@ -366,5 +366,5 @@
     ## Konflux Tenant-Level Capacity Metrics (PVO11Y-5332)
     - '{__name__="namespace:container_cpu_usage:sum", namespace=~".*-tenant"}'
     - '{__name__="namespace:container_memory_usage_bytes:sum", namespace=~".*-tenant"}'
-    - '{__name__="namespace:container_cpu_cfs_throttled_periods:ratio"}'
+    - '{__name__="namespace:avg_container_cpu_cfs_throttled_periods:ratio"}'
     - '{__name__="namespace:konflux_tenant_resourcequota_utilization:ratio"}'

--- a/components/monitoring/prometheus/staging/base/federation/prometheusrule-uwm.yaml
+++ b/components/monitoring/prometheus/staging/base/federation/prometheusrule-uwm.yaml
@@ -59,12 +59,12 @@
     - name: konflux_tenant_capacity
       rules:
       - expr: |
-          max by (namespace) (
-            sum by (namespace, pod, container) (rate(container_cpu_cfs_throttled_periods_total{container!="", image!="", namespace=~".*-tenant"}[5m]))
+          avg by (namespace) (
+            sum by (namespace, pod, container) (rate(container_cpu_cfs_throttled_periods_total{container!="", image!="", namespace=~".*-tenant"}[10m]))
             /
-            (sum by (namespace, pod, container) (rate(container_cpu_cfs_periods_total{container!="", image!="", namespace=~".*-tenant"}[5m])) > 0)
+            (sum by (namespace, pod, container) (rate(container_cpu_cfs_periods_total{container!="", image!="", namespace=~".*-tenant"}[10m])) > 0)
           )
-        record: namespace:container_cpu_cfs_throttled_periods:ratio
+        record: namespace:avg_container_cpu_cfs_throttled_periods:ratio
       - expr: |
           max by (namespace, resource) (
             kube_resourcequota{namespace=~".*-tenant", resource=~"(requests|limits)\\.(cpu|memory)", type="used"}


### PR DESCRIPTION
Instead of reporting the max throttling percentage seen in a namespace, report a 10 minute moving average of all container throttling percentages seen in a given namespace. This will better represent the CPU throttling seen for the namespaces

- Tweak expr to 10min moving avg for namespace:container_cpu_cfs_throttled_periods:ratio recording rule
- Rename namespace:container_cpu_cfs_throttled_periods:ratio to namespace:avg_container_cpu_cfs_throttled_periods:ratio to better represent the recording rule results