### PR TITLE
PVO11Y-5374 Replace CEL when expression with standard Tekton WhenExpression

### DIFF
--- a/components/monitoring/kanary/staging/base/tasks/run-kanary-tests.yaml
+++ b/components/monitoring/kanary/staging/base/tasks/run-kanary-tests.yaml
@@ -129,7 +129,9 @@ spec:
         echo "Pre-cleanup done"
     - name: mirror-rpm-repo
       when:
-        - cel: "'$(params.test-type)' == 'rpm'"
+        - input: "$(params.test-type)"
+          operator: in
+          values: ["rpm"]
       image: quay.io/redhat-user-workloads/konflux-perfscale-tenant/loadtest
       volumeMounts:
         - name: artifacts


### PR DESCRIPTION
## What

Replace CEL `when` expression in the `mirror-rpm-repo` step with the standard Tekton `WhenExpression` syntax.

**Before:**
```yaml
when:
  - cel: "'$(params.test-type)' == 'rpm'"
```

**After:**
```yaml
when:
  - input: "$(params.test-type)"
    operator: in
    values: ["rpm"]
```

[PVO11Y-5374](https://issues.redhat.com/browse/PVO11Y-5374)

## Why

The staging cluster does not have the `enable-cel-in-whenexpression` Tekton feature flag enabled, causing ArgoCD sync to fail with:

```
admission webhook "validation.webhook.pipeline.tekton.dev" denied the request:
validation failed: feature flag enable-cel-in-whenexpression should be set to true
to use CEL: '$(params.test-type)' == 'rpm' in WhenExpression: spec.steps[1].when[0]
```

The standard `input/operator/values` syntax works without any feature flags.

## Validation

- `kustomize build components/monitoring/kanary/staging/base/` passes

[PVO11Y-5374]: https://redhat.atlassian.net/browse/PVO11Y-5374?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ