### PR TITLE
fix(KONFLUX-15214): upgrade otel collector to 0.158.0 in dev

### DIFF
--- a/components/kubearchive/development/kustomization.yaml
+++ b/components/kubearchive/development/kustomization.yaml
@@ -320,6 +320,7 @@ patches:
                   requests:
                     cpu: 200m
                     memory: 128Mi
+  # opentelemetry-collector 0.158.0
   - patch: |-
       apiVersion: apps/v1
       kind: Deployment
@@ -332,7 +333,7 @@ patches:
           spec:
             containers:
               - name: otel-collector
-                image: quay.io/kubearchive/opentelemetry-collector@sha256:1f8c9a186c56f5ab4ffdd937ecce621aef116868f6022f3652c5d285b5788f8a
+                image: quay.io/kubearchive/opentelemetry-collector@sha256:ef47fef2d742461fba0b9950137895cfd34e3a8500f8acb807003f94751365d0
 
   # We don't need this CronJob as it is suspended, we can enable it later
   - patch: |-


### PR DESCRIPTION
## What                                                                            
This PR updates opentelemetry-collector from 0.155.0 to 0.158.0 in the development overlay to remediate CVE-2026-55969 and CVE-2026-48586.
                                                                                                                                                                        
 ## Why             
Remediates CVE-2026-55969 and CVE-2026-48586 for opentelemetry-collector.
               
Closes:                                                                            
                                                                                   
[KONFLUX-15214](https://redhat.atlassian.net/browse/KONFLUX-15214)
[KONFLUX-15246](https://redhat.atlassian.net/browse/KONFLUX-15246)              
                                                                                
## Risk Assessment                                                                 
                                                                                    
**Risk Level:** Low                                                                
**Description:** Some KubeArchive performance metrics data can be lost during the rollout.   
**Rollback:** Revert the image reference in `development/kustomization.yaml` to the previous version (0.155.0 / sha256:1f8c9a186c56f5ab4ffdd937ecce621aef116868f6022f3652c5d285b5788f8a) and the older otel-collector will be deployed.                            

## Validation
Ran `kustomize build --enable-helm components/kubearchive/development/`  output rendered successfully.
Deployed a local cluster using KubeArchive with the new image and verified everything works correctly.
```
kubectl logs -n kubearchive -l app=otel-collector -c otel-collector --tail=20
2026-08-06T14:45:03.114Z	info	otelconftelemetry/tracer.go:47	Internal trace telemetry disabled	{"resource": {"service.instance.id": "45da2a6a-9df0-4f1b-b343-fb3ffedbb18b", "service.name": "otelcol-contrib", "service.version": "0.158.0"}}
2026-08-06T14:45:03.115Z	info	ottl@v0.158.0/parser_collection.go:646	one or more paths were modified to include their context prefix, please rewrite them accordingly	{"resource": {"service.instance.id": "45da2a6a-9df0-4f1b-b343-fb3ffedbb18b", "service.name": "otelcol-contrib", "service.version": "0.158.0"}, "otelcol.component.id": "transform", "otelcol.component.kind": "processor", "otelcol.pipeline.id": "metrics", "otelcol.signal": "metrics", "values": {"[0]": {"original": "set(attributes[\"pod\"], resource.attributes[\"k8s.pod.name\"])", "modified": "set(datapoint.attributes[\"pod\"], resource.attributes[\"k8s.pod.name\"])"}}}
2026-08-06T14:45:03.118Z	info	service@v0.158.0/service.go:259	Starting otelcol-contrib...	{"resource": {"service.instance.id": "45da2a6a-9df0-4f1b-b343-fb3ffedbb18b", "service.name": "otelcol-contrib", "service.version": "0.158.0"}, "Version": "0.158.0", "NumCPU": 22}
2026-08-06T14:45:03.118Z	info	extensions/extensions.go:44	Starting extensions...	{"resource": {"service.instance.id": "45da2a6a-9df0-4f1b-b343-fb3ffedbb18b", "service.name": "otelcol-contrib", "service.version": "0.158.0"}}
2026-08-06T14:45:03.118Z	info	otlpreceiver@v0.158.0/otlp.go:175	Starting HTTP server	{"resource": {"service.instance.id": "45da2a6a-9df0-4f1b-b343-fb3ffedbb18b", "service.name": "otelcol-contrib", "service.version": "0.158.0"}, "otelcol.component.id": "otlp", "otelcol.component.kind": "receiver", "endpoint": "[::]:4318"}
2026-08-06T14:45:03.118Z	info	service@v0.158.0/service.go:282	Everything is ready. Begin running and processing data.	{"resource": {"service.instance.id": "45da2a6a-9df0-4f1b-b343-fb3ffedbb18b", "service.name": "otelcol-contrib", "service.version": "0.158.0"}}
```


[KONFLUX-15214]: https://redhat.atlassian.net/browse/KONFLUX-15214?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[KONFLUX-15246]: https://redhat.atlassian.net/browse/KONFLUX-15246?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ