### PR TITLE
KFLUXINFRA-4367: Bump repository-validator production config ref (coreos/rhel-coreos-config allow list)

### DIFF
--- a/components/repository-validator/production/kustomization.yaml
+++ b/components/repository-validator/production/kustomization.yaml
@@ -1,5 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - https://github.com/redhat-appstudio/internal-infra-deployments/components/repository-validator/production?ref=c7b1af8d994746c7a654e791d722a0aab49dcbba
+  - https://github.com/redhat-appstudio/internal-infra-deployments/components/repository-validator/production?ref=32c3ef2125458920452ffad3fe28761b5b275340
   - ../base


### PR DESCRIPTION
## What

Bump `components/repository-validator/production/kustomization.yaml` ref to
`32c3ef2125458920452ffad3fe28761b5b275340`.

Picks up: Add coreos/rhel-coreos-config to production repository allow list
(redhat-appstudio/internal-infra-deployments#124)

Clusters affected: all internal production clusters

[KFLUXINFRA-4367](https://redhat.atlassian.net/browse/KFLUXINFRA-4367)

## Why

CoreOS team migrating `rhel-coreos-rhel-10-2` application from `kflux-prd-rh03`
to `kflux-ocp-p01` to consume Brew RPMs. `configure-pac` fails with error 54
until this allow list entry is active.

## Validation

- `kustomize build` skipped — remote ref fetch times out locally; SHA is the
  verified merge commit of internal-infra-deployments#124
- Low-risk additive change: only adds one repo prefix to the allow list

## Risk Assessment

**Risk Level:** Low
**What could go wrong:** Additive change only; no existing entries modified.
**Rollback:** Revert this PR
**Blast radius:** All internal production clusters — config change only

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[KFLUXINFRA-4367]: https://redhat.atlassian.net/browse/KFLUXINFRA-4367?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ