### PR TITLE
feat(PVO11Y-5367, kaexporter): Performance UX SLO metrics production

### DIFF
--- a/components/monitoring/exporters/kaexporter/production/base/kustomization.yaml
+++ b/components/monitoring/exporters/kaexporter/production/base/kustomization.yaml
@@ -7,7 +7,7 @@ resources:
 images:
   - name: quay.io/redhat-appstudio/o11y
     newName: quay.io/redhat-appstudio/o11y
-    newTag: f0c8c797641789e13021ed225271f660177863d0
+    newTag: 479a668cb362d1ee0d2d4333cc4ee64867abd12d
 
 patches:
   - path: ./configs/kaexporter-deployment-patch.yaml


### PR DESCRIPTION
## Summary
* Bump of kaexporter to start emitting tenant performance UX SLO metrics from production clusters
* Jira: [PVO11Y-5367](https://redhat.atlassian.net/browse/PVO11Y-5367)

## Risk Assessment
* **Level:** Low
* **Description:** Was validated locally
* **Rollback:** Revert commit

## Validation
* Validated locally
* Added unit tests for certain cases in o11y repository
* Metrics are being emitted and forwarded to RHOBS from staging [!13380](https://github.com/redhat-appstudio/infra-deployments/pull/13380)

[PVO11Y-5367]: https://redhat.atlassian.net/browse/PVO11Y-5367?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ