### PR TITLE
[KFLUXINFRA-3003] Fix DR sanity pipeline to use the correct component

### DIFF
--- a/components/disaster-recovery/development/pipeline.yaml
+++ b/components/disaster-recovery/development/pipeline.yaml
@@ -614,7 +614,7 @@ spec:
     default: rhtap-releng-tenant
   - name: COMPONENT_NAME
     type: string
-    default: devfile-sample-python-basic-main
+    default: konflux-test-app
   - name: APP_NAME
     type: string
     default: releng-test-app


### PR DESCRIPTION
Summary
****- Switch the DR sanity pipeline's default `COMPONENT_NAME` from `devfile-sample-python-basic-main` to `konflux-test-app`
- The nightly DR sanity runs were building the wrong component  ([flagged by Sean McCarty in [KONFLUX-13135](https://redhat.atlassian.net/browse/KONFLUX-13135)](https://redhat.atlassian.net/browse/KONFLUX-13135?focusedCommentId=17908079))
- `konflux-test-app` is the correct component under the `redhat-appstudio` Quay org

**Test plan**
- [ ] Nightly DR sanity pipeline run triggers build for `konflux-test-app`
- [ ] Full build → integration → release → backup → restore chain passes


[KONFLUX-13135]: https://redhat.atlassian.net/browse/KONFLUX-13135?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ