### PR TITLE
KONFLUX-15031 Bump custom-kube-state-metrics to v2.19.1 in staging

### DIFF
--- a/components/monitoring/custom-kube-state-metrics/staging/kustomization.yaml
+++ b/components/monitoring/custom-kube-state-metrics/staging/kustomization.yaml
@@ -9,6 +9,10 @@ resources:
 commonAnnotations:
   argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 
+images:
+  - name: registry.k8s.io/kube-state-metrics/kube-state-metrics
+    newTag: v2.19.1
+
 patches:
   - path: resource-patch.yaml
     target:


### PR DESCRIPTION
## What

Upgrade custom-kube-state-metrics image from v2.11.0 to v2.19.1 in the staging overlay.

[KONFLUX-15031](https://redhat.atlassian.net/browse/KONFLUX-15031)

## Why

v2.11.0 has a bug where CRD re-discovery events spawn duplicate informer registrations without stopping old ones. Each orphaned informer holds a full copy of every watched resource in memory, causing OOM kills across multiple production clusters. v2.19.1 includes the fix (kubernetes/kube-state-metrics#2920) that makes `AppendToMap` idempotent and propagates context cancellation to custom resource reflectors.

Staging first; production ring rollout will follow after validation.

## Validation

- `kustomize build` passes for staging overlay
- Image confirmed available: `registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.19.1`
- No breaking changes to CLI flags or config format between v2.11 and v2.19
- K8s v1.32 (OCP 4.19) is within the N-3 support window for client-go v0.35.4

[KONFLUX-15031]: https://redhat.atlassian.net/browse/KONFLUX-15031?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ