### PR TITLE
reduce frequency of MintMaker in prod rh01

### DIFF
--- a/argo-cd-apps/base/member/infra-deployments/mintmaker/mintmaker.yaml
+++ b/argo-cd-apps/base/member/infra-deployments/mintmaker/mintmaker.yaml
@@ -23,6 +23,8 @@ spec:
                   values.clusterDir: stone-prod-p01
                 - nameNormalized: stone-prod-p02
                   values.clusterDir: stone-prod-p02
+                - nameNormalized: stone-prd-rh01
+                  values.clusterDir: stone-prd-rh01
                 - nameNormalized: kflux-prd-rh02
                   values.clusterDir: kflux-prd-rh02
                 - nameNormalized: kflux-prd-rh03

--- a/components/mintmaker/production/stone-prd-rh01/kustomization.yaml
+++ b/components/mintmaker/production/stone-prd-rh01/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../base
+namespace: mintmaker
+patches:
+  - path: ./patch_create-dependency-update-check_cron.yaml
+    target:
+      group: batch
+      kind: CronJob
+      name: create-dependencyupdatecheck
+      namespace: mintmaker
+      version: v1

--- a/components/mintmaker/production/stone-prd-rh01/patch_create-dependency-update-check_cron.yaml
+++ b/components/mintmaker/production/stone-prd-rh01/patch_create-dependency-update-check_cron.yaml
@@ -1,0 +1,7 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: create-dependencyupdatecheck
+  namespace: mintmaker
+spec:
+  schedule: "0 0,4 * * *" # At 00:00 and 04:00 UTC


### PR DESCRIPTION
the cluster is overloaded, we want to reduce the pressure.

## Risk Assessment (added by @gbenhaim)
Low
This change only reduced the frequency of the mintmaker triggering job.
Since kubelinter validated the job definition, nothing should go wrong.
Rollback: Revert this PR. 

Signed-off-by: Francesco Ilario <filario@redhat.com>
