### PR TITLE
KFLUXINFRA-4285: (onboarding) Remove staging kueue apps from AppSRE ArgoCD

### DIFF
--- a/argo-cd-apps/base/member/infra-deployments/kueue/kueue.yaml
+++ b/argo-cd-apps/base/member/infra-deployments/kueue/kueue.yaml
@@ -18,10 +18,6 @@ spec:
                 clusterDir: empty-base
           - list:
               elements:
-                - nameNormalized: stone-stg-rh01
-                  values.clusterDir: stone-stg-rh01
-                - nameNormalized: stone-stage-p01
-                  values.clusterDir: stone-stage-p01
                 - nameNormalized: stone-prd-rh01
                   values.clusterDir: stone-prd-rh01
                 - nameNormalized: kflux-prd-rh02

--- a/argo-cd-apps/overlays/konflux-public-staging/delete-applications.yaml
+++ b/argo-cd-apps/overlays/konflux-public-staging/delete-applications.yaml
@@ -11,3 +11,9 @@ kind: ApplicationSet
 metadata:
   name: nvme-storage-configurator
 $patch: delete
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: kueue
+$patch: delete

--- a/argo-cd-apps/overlays/staging-downstream/delete-applications.yaml
+++ b/argo-cd-apps/overlays/staging-downstream/delete-applications.yaml
@@ -17,3 +17,9 @@ kind: ApplicationSet
 metadata:
   name: nvme-storage-configurator
 $patch: delete
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: kueue
+$patch: delete


### PR DESCRIPTION
Deletes the kueue apps from the staging overlays so those in the new rd-staging overlay take control over the existing resources.

### Summary of Changes

- Added delete patches for kueue in both staging overlays
- Removed staging cluster entries from the original kueue AppSet

### Risk Level
**Risk Level**: Low
**Reasoning**: No new component resources are being created; the new ApplicationSet references the `kueue-rd/ `directory, which is only a restructuring of the existing `kueue/`  directory. This process has been executed for several other components without hiccups.
**Rollback Strategy**: Revert this commit and do a manual sync for the original kueue ApplicationSet, as it references the original structuring of kueue.