### PR TITLE
chore: set private staging UI hostname

### DIFF
--- a/components/konflux-operator/rings/ring-1/stone-stage-p01/konflux-ui/ui-patch.yaml
+++ b/components/konflux-operator/rings/ring-1/stone-stage-p01/konflux-ui/ui-patch.yaml
@@ -5,6 +5,8 @@ metadata:
 spec:
   ui:
     spec:
+      ingress:
+        hostname: konflux-ui
       runtimeConfig:
         chatBot:
           enabled: false


### PR DESCRIPTION
Moving to the operator, the UI hostname defaulted to konflux-ui-konflux-ui. setting it to konflux-ui to fit the legacy UI address.