### PR TITLE
chore(ring-1): set UI hostname at ring scope

### DIFF
--- a/components/konflux-operator/rings/ring-1/base/cr/konflux-ui/ui.yaml
+++ b/components/konflux-operator/rings/ring-1/base/cr/konflux-ui/ui.yaml
@@ -5,6 +5,8 @@ metadata:
 spec:
   ui:
     spec:
+      ingress:
+        hostname: konflux-ui
       proxy:
         replicas: 3
         endpoints:

--- a/components/konflux-operator/rings/ring-1/stone-stage-p01/konflux-ui/ui-patch.yaml
+++ b/components/konflux-operator/rings/ring-1/stone-stage-p01/konflux-ui/ui-patch.yaml
@@ -5,8 +5,6 @@ metadata:
 spec:
   ui:
     spec:
-      ingress:
-        hostname: konflux-ui
       runtimeConfig:
         chatBot:
           enabled: false


### PR DESCRIPTION
Move ingress.hostname: konflux-ui from the stone-stage-p01 cluster patch to ring-1 base so all ring-1 clusters share the same hostname.

Assisted-by: Cursor