### PR TITLE
add konflux-externalpuller-bot-actions

### DIFF
--- a/components/konflux-rbac/production/base/konflux-externalpuller-bot-actions.yaml
+++ b/components/konflux-rbac/production/base/konflux-externalpuller-bot-actions.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: konflux-externalpuller-bot-actions
+rules:
+- apiGroups:
+  - appstudio.redhat.com
+  resources:
+  - imagerepositories
+  verbs:
+  - get
+  - list
+  - watch

--- a/components/konflux-rbac/production/base/kustomization.yaml
+++ b/components/konflux-rbac/production/base/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
 # can be bound to konflux-bot-* ServiceAccounts
 # and exposed outside the cluster
 - konflux-builder-bot-actions.yaml
+- konflux-externalpuller-bot-actions.yaml
 - konflux-releaser-bot-actions.yaml
 # can NOT be bound to konflux-bot-* ServiceAccounts
 - konflux-tester-internalbot-actions.yaml

--- a/components/konflux-rbac/staging/base/konflux-externalpuller-bot-actions.yaml
+++ b/components/konflux-rbac/staging/base/konflux-externalpuller-bot-actions.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: konflux-externalpuller-bot-actions
+rules:
+- apiGroups:
+  - appstudio.redhat.com
+  resources:
+  - imagerepositories
+  verbs:
+  - get
+  - list
+  - watch

--- a/components/konflux-rbac/staging/base/kustomization.yaml
+++ b/components/konflux-rbac/staging/base/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
   # can be bound to konflux-bot-* ServiceAccounts
   # and exposed outside the cluster
   - konflux-builder-bot-actions.yaml
+  - konflux-externalpuller-bot-actions.yaml
   - konflux-releaser-bot-actions.yaml
   # can NOT be bound to konflux-bot-* ServiceAccounts
   - konflux-tester-internalbot-actions.yaml


### PR DESCRIPTION
This PR adds a ClusterRole to allow the `konflux-bot-*` ServiceAccount to pull private images.

cf. https://konflux-ci.dev/docs/building/accessing-private-images/#who-can-pull-images-and-access-scope

Signed-off-by: Francesco Ilario <filario@redhat.com>
