### PR TITLE
KFLUXINFRA-4373 SHA pinning enforcement for GitHub Actions

### DIFF
--- a/.github/workflows/chainsaw-tests.yaml
+++ b/.github/workflows/chainsaw-tests.yaml
@@ -16,7 +16,7 @@ jobs:
       directories: ${{ steps.list-tests.outputs.directories }}
     steps:
       - name: Checkout Git Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - id: list-tests
         run: |
@@ -34,9 +34,9 @@ jobs:
 
     steps:
     - name: Create k8s Kind Cluster
-      uses: helm/kind-action@v1
+      uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1
 
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
     - name: Install Dependencies
       shell: bash

--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -10,10 +10,10 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           cache-dependency-path: '**/go.sum'
       - name: Find and test Go modules
@@ -28,7 +28,7 @@ jobs:
           fi
 
       - name: Upload Go coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5
         with:
           use_oidc: true
           flags: go
@@ -39,10 +39,10 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4
         with:
           python-version: '3.x'
       - name: Install Python requirements
@@ -75,7 +75,7 @@ jobs:
           fi
 
       - name: Upload Python coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5
         with:
           use_oidc: true
           flags: python

--- a/.github/workflows/forbid-clusterpolicies.yaml
+++ b/.github/workflows/forbid-clusterpolicies.yaml
@@ -15,7 +15,7 @@ jobs:
     name: Forbid ClusterPolicies outside Policies component
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Setup Kustomize
         uses: multani/action-setup-kustomize@bf96e027caf74ab03bb3f79bac2addb331b28f1d

--- a/.github/workflows/infra-tools-ci.yaml
+++ b/.github/workflows/infra-tools-ci.yaml
@@ -21,11 +21,11 @@ jobs:
     name: CI
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version-file: infra-tools/go.mod
           cache-dependency-path: infra-tools/go.sum

--- a/.github/workflows/kube-linter.yaml
+++ b/.github/workflows/kube-linter.yaml
@@ -12,7 +12,7 @@ jobs:
     permissions: write-all
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       # This prepares directory where github/codeql-action/upload-sarif@v1 looks up report files by default.
       - name: Create ../results directory for SARIF report files
@@ -45,7 +45,7 @@ jobs:
             xargs -I {} -n1 -P8  bash -c 'dir=$(dirname "{}"); output_file=$(echo "$dir" | tr / -)-kustomization.yaml; ./hack/kustomize-build-with-retry.sh "$dir" -o "kustomizedfiles/$output_file"'
 
       - name: Scan yaml files with kube-linter
-        uses: stackrox/kube-linter-action@v1.0.4
+        uses: stackrox/kube-linter-action@ca0d55b925470deb5b04b556e6c4276ea94d03c3 # v1.0.4
         id: kube-linter-action-scan
         with:
           version: v0.7.6
@@ -57,11 +57,11 @@ jobs:
           output-file: ../results/kube-linter.sarif
 
       - name: Upload SARIF report files to GitHub
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@5595ccaf912efad79be6eef63a5619ff05969be3 # v4
         if: always()
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: failure() && steps.kube-linter-action-scan.outcome == 'failure'
         with:
           name: kustomize-manifests

--- a/.github/workflows/kyverno-policies-tests.yaml
+++ b/.github/workflows/kyverno-policies-tests.yaml
@@ -13,10 +13,10 @@ jobs:
     name: Run Kyverno tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Install Kyverno CLI
-        uses: kyverno/action-install-cli@v0.2.0
+        uses: kyverno/action-install-cli@fcee92fca5c883169ef9927acf543e0b5fc58289 # v0.2.0
         with:
           release: 'v1.13.4'
 

--- a/.github/workflows/operator-changelog.yaml
+++ b/.github/workflows/operator-changelog.yaml
@@ -23,7 +23,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version-file: infra-tools/go.mod
           cache-dependency-path: infra-tools/go.sum

--- a/.github/workflows/pr-env-label.yaml
+++ b/.github/workflows/pr-env-label.yaml
@@ -34,7 +34,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version-file: infra-tools/go.mod
           cache-dependency-path: infra-tools/go.sum
@@ -70,7 +70,7 @@ jobs:
 
       - name: Upload debug log
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: debug-log
           path: debug.log

--- a/.github/workflows/pr-render-diff.yaml
+++ b/.github/workflows/pr-render-diff.yaml
@@ -16,7 +16,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version-file: infra-tools/go.mod
           cache-dependency-path: infra-tools/go.sum
@@ -65,7 +65,7 @@ jobs:
 
       - name: Upload diff artifacts
         if: ${{ always() && steps.fetch-merge.outcome == 'success' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: render-diff-output
           path: |

--- a/.github/workflows/test-tekton-kueue-config.yaml
+++ b/.github/workflows/test-tekton-kueue-config.yaml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Set up Python 3
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4
         with:
           python-version: '3.x'
 

--- a/.github/workflows/validate-banner.yaml
+++ b/.github/workflows/validate-banner.yaml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3
 
       - name: Install ajv-cli and yaml converter
         run: |

--- a/.github/workflows/verify-kueue-queue-configs.yaml
+++ b/.github/workflows/verify-kueue-queue-configs.yaml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Set up Python 3
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4
         with:
           python-version: '3.x'
 

--- a/.github/workflows/verify-pipelines-configs.yaml
+++ b/.github/workflows/verify-pipelines-configs.yaml
@@ -77,7 +77,7 @@ jobs:
 
       - name: Upload comment artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: pr-comment
           path: /tmp/pr_comment
@@ -94,7 +94,7 @@ jobs:
       issues: write
     steps:
       - name: Download comment artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: pr-comment
           path: /tmp

--- a/.github/workflows/yamllint.yaml
+++ b/.github/workflows/yamllint.yaml
@@ -10,7 +10,7 @@ jobs:
   yamllint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       - name: Lint yaml manifests
         run: |
           yamllint -f github --no-warnings .


### PR DESCRIPTION
## What

Pin all GitHub Actions to full-length commit SHAs across 14 workflow files.

[KFLUXINFRA-4373](https://redhat.atlassian.net/browse/KFLUXINFRA-4373)

## Why

Organization-level policy "Require actions to be pinned to a full-length commit SHA"
is being enforced on 2026-08-11 08:00 UTC across redhat-appstudio and konflux-ci orgs.
Unpinned actions will cause workflow failures and blocked PRs.

## Changes

| Tag | SHA | Tag Link | Commit Link |
|-----|-----|----------|-------------|
| `actions/checkout@v3` | `a37ce912` | [v3](https://github.com/actions/checkout/releases/tag/v3) | [commit](https://github.com/actions/checkout/commit/a37ce9120846195fa4ece8f58b268e6043cb2f26) |
| `actions/checkout@v4` | `11d5960a` | [v4](https://github.com/actions/checkout/releases/tag/v4) | [commit](https://github.com/actions/checkout/commit/11d5960a326750d5838078e36cf38b85af677262) |
| `actions/checkout@v6` | `d23441a4` | [v6](https://github.com/actions/checkout/releases/tag/v6) | [commit](https://github.com/actions/checkout/commit/d23441a48e516b6c34aea4fa41551a30e30af803) |
| `actions/download-artifact@v4` | `d3f86a10` | [v4](https://github.com/actions/download-artifact/releases/tag/v4) | [commit](https://github.com/actions/download-artifact/commit/d3f86a106a0bac45b974a628896c90dbdf5c8093) |
| `actions/setup-go@v5` | `40f1582b` | [v5](https://github.com/actions/setup-go/releases/tag/v5) | [commit](https://github.com/actions/setup-go/commit/40f1582b2485089dde7abd97c1529aa768e1baff) |
| `actions/setup-python@v4` | `7f4fc3e2` | [v4](https://github.com/actions/setup-python/releases/tag/v4) | [commit](https://github.com/actions/setup-python/commit/7f4fc3e22c37d6ff65e88745f38bd3157c663f7c) |
| `actions/upload-artifact@v4` | `ea165f8d` | [v4](https://github.com/actions/upload-artifact/releases/tag/v4) | [commit](https://github.com/actions/upload-artifact/commit/ea165f8d65b6e75b540449e92b4886f43607fa02) |
| `codecov/codecov-action@v5` | `0fb71748` | [v5](https://github.com/codecov/codecov-action/releases/tag/v5) | [commit](https://github.com/codecov/codecov-action/commit/0fb7174895f61a3b6b78fc075e0cd60383518dac) |
| `github/codeql-action@v4` | `5595ccaf` | [v4](https://github.com/github/codeql-action/releases/tag/v4) | [commit](https://github.com/github/codeql-action/commit/5595ccaf912efad79be6eef63a5619ff05969be3) |
| `helm/kind-action@v1` | `ef37e7f3` | [v1](https://github.com/helm/kind-action/releases/tag/v1) | [commit](https://github.com/helm/kind-action/commit/ef37e7f390d99f746eb8b610417061a60e82a6cc) |
| `kyverno/action-install-cli@v0.2.0` | `fcee92fc` | [v0.2.0](https://github.com/kyverno/action-install-cli/releases/tag/v0.2.0) | [commit](https://github.com/kyverno/action-install-cli/commit/fcee92fca5c883169ef9927acf543e0b5fc58289) |
| `multani/action-setup-kustomize@v1` | `bf96e027` | [v1](https://github.com/multani/action-setup-kustomize/releases/tag/v1) | [commit](https://github.com/multani/action-setup-kustomize/commit/bf96e027caf74ab03bb3f79bac2addb331b28f1d) |
| `stackrox/kube-linter-action@v1.0.4` | `ca0d55b9` | [v1.0.4](https://github.com/stackrox/kube-linter-action/releases/tag/v1.0.4) | [commit](https://github.com/stackrox/kube-linter-action/commit/ca0d55b925470deb5b04b556e6c4276ea94d03c3) |

## Validation

- Grep for unpinned actions returns empty:
  `grep 'uses:' .github/workflows/*.yaml | grep -vE '@[0-9a-f]{40}' → (none)`
- Each SHA verified against its tag via GitHub API

[KFLUXINFRA-4373]: https://redhat.atlassian.net/browse/KFLUXINFRA-4373?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ