### PR TITLE
KONFLUX-15031 Bump custom-kube-state-metrics to v2.19.1 in production

### DIFF
--- a/components/monitoring/custom-kube-state-metrics/README.md
+++ b/components/monitoring/custom-kube-state-metrics/README.md
@@ -89,7 +89,7 @@ sed '1,/custom-resource-state.yaml: |/d' \
   | sed 's/^    //' > /tmp/ksm-test-config.yaml
 ```
 
-4. Run kube-state-metrics locally (must match the deployed version — v2.11.0):
+4. Run kube-state-metrics locally (must match the deployed version — v2.19.1):
 
 ```bash
 docker run --rm -d \
@@ -97,7 +97,7 @@ docker run --rm -d \
   -p 8080:8080 \
   -v /tmp/ksm-test-kubeconfig:/kubeconfig:ro \
   -v /tmp/ksm-test-config.yaml:/etc/config/custom-resource-state.yaml:ro \
-  registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.11.0 \
+  registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.19.1 \
   --kubeconfig=/kubeconfig \
   --custom-resource-state-config-file=/etc/config/custom-resource-state.yaml \
   --custom-resource-state-only=true
@@ -133,7 +133,7 @@ If the metric appears with expected labels and values, it is ready for productio
 
 ## Constraints
 
-We run kube-state-metrics **v2.11.0** and our metrics are scraped by UWM
+We run kube-state-metrics **v2.19.1** and our metrics are scraped by UWM
 (User Workload Monitoring) Prometheus. This combination imposes the following
 constraints on custom resource metrics:
 
@@ -145,10 +145,8 @@ constraints on custom resource metrics:
   `"Unknown"`) cause `strconv.ParseFloat` errors and emit zero data points. To work
   around this, use the string as a **label** (via `labelsFromPath`) and point the
   gauge `path` at a numeric field instead.
-- **No `valueMap`.** The `valueMap` option (which maps strings to numbers) does not
-  exist in v2.11.0. It was introduced in a later version.
 
 ## References
 
-- [CustomResourceState metrics docs (v2.11.0)](https://github.com/kubernetes/kube-state-metrics/blob/v2.11.0/docs/customresourcestate-metrics.md)
+- [CustomResourceState metrics docs (v2.19.1)](https://github.com/kubernetes/kube-state-metrics/blob/v2.19.1/docs/customresourcestate-metrics.md)
 - See `base/custom-resource-state-config.yaml` for examples

--- a/components/monitoring/custom-kube-state-metrics/base/deployment.yaml
+++ b/components/monitoring/custom-kube-state-metrics/base/deployment.yaml
@@ -27,7 +27,7 @@ spec:
           type: RuntimeDefault
       containers:
       - name: kube-state-metrics
-        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.11.0
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.19.1
         args:
         # CRITICAL: Only monitor custom resources to avoid duplicating platform metrics
         - --custom-resource-state-only=true

--- a/components/monitoring/custom-kube-state-metrics/production/kustomization.yaml
+++ b/components/monitoring/custom-kube-state-metrics/production/kustomization.yaml
@@ -9,6 +9,10 @@ resources:
 commonAnnotations:
   argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 
+images:
+  - name: registry.k8s.io/kube-state-metrics/kube-state-metrics
+    newTag: v2.19.1
+
 patches:
   - path: resource-patch.yaml
     target:


### PR DESCRIPTION
## What

Upgrade custom-kube-state-metrics image from v2.11.0 to v2.19.1 in the production overlay.

[KONFLUX-15031](https://redhat.atlassian.net/browse/KONFLUX-15031)

## Why

v2.11.0 has a bug where CRD re-discovery events spawn duplicate informer registrations without stopping old ones. Each orphaned informer caches every watched resource in memory, multiplying usage until OOMKill. This caused repeated OOM kills on stone-prod-p02, kflux-prd-rh02, stone-prd-rh01, and kflux-prd-rh03. v2.19.1 includes the fix (kubernetes/kube-state-metrics#2920).

## Validation

- `kustomize build` passes for production overlay — image resolves to v2.19.1
- Staging has been running v2.19.1 for 3 days with zero restarts and stable 141Mi memory
- Multiple CRD re-discovery events fired in staging — logs confirm no duplicate informer registrations (`activeStoreNames` shows exactly one entry per resource)
- No breaking changes between v2.11 and v2.19 for our config (--custom-resource-state-only, --custom-resource-state-config-file flags unchanged)
- K8s v1.32 (OCP 4.19) within N-3 support window for client-go v0.35.4
- Staging PR: #13391

## Risk Assessment

**Risk Level:** Low
**What could go wrong:** The new version could have incompatibilities with our K8s version or config format, causing the pod to crash or stop emitting metrics. Downstream alerts (PipelineRun stuck finalizer alerts, Velero backup alerts) would stop firing.
**Rollback:** Revert PR to restore v2.11.0 image. Pod restarts on OOM anyway, so brief downtime is expected baseline.
**Blast radius:** All production clusters consuming the production overlay.

[KONFLUX-15031]: https://redhat.atlassian.net/browse/KONFLUX-15031?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ