### PR TITLE
feat(KFLUXVNGD-1149): Add independent caching ArgoCD app and component definitions

### DIFF
--- a/argo-cd-apps/overlays/rd-dev/artifact-registry-proxy/artifact-registry-proxy-appset.yaml
+++ b/argo-cd-apps/overlays/rd-dev/artifact-registry-proxy/artifact-registry-proxy-appset.yaml
@@ -1,0 +1,45 @@
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: artifact-registry-proxy
+spec:
+  generators:
+    - merge:
+        mergeKeys:
+          - nameNormalized
+        generators:
+          - clusters:
+              selector:
+                matchLabels:
+                  appstudio.redhat.com/member-cluster: "true"
+              values:
+                sourceRoot: components/artifact-registry-proxy
+                ring: "ring-0"
+                clusterDir: base
+          - list:
+              elements: []
+
+  template:
+    metadata:
+      name: artifact-registry-proxy-{{nameNormalized}}
+    spec:
+      project: default
+      source:
+        path: '{{values.sourceRoot}}/rings/{{values.ring}}/{{values.clusterDir}}'
+        repoURL: https://github.com/redhat-appstudio/infra-deployments.git
+        targetRevision: main
+      destination:
+        namespace: artifact-registry-proxy
+        server: '{{server}}'
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
+        syncOptions:
+          - CreateNamespace=true
+        retry:
+          limit: -1
+          backoff:
+            duration: 10s
+            factor: 2
+            maxDuration: 3m

--- a/argo-cd-apps/overlays/rd-dev/artifact-registry-proxy/kustomization.yaml
+++ b/argo-cd-apps/overlays/rd-dev/artifact-registry-proxy/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - artifact-registry-proxy-appset.yaml

--- a/argo-cd-apps/overlays/rd-dev/container-image-proxy/container-image-proxy-appset.yaml
+++ b/argo-cd-apps/overlays/rd-dev/container-image-proxy/container-image-proxy-appset.yaml
@@ -1,0 +1,45 @@
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: container-image-proxy
+spec:
+  generators:
+    - merge:
+        mergeKeys:
+          - nameNormalized
+        generators:
+          - clusters:
+              selector:
+                matchLabels:
+                  appstudio.redhat.com/member-cluster: "true"
+              values:
+                sourceRoot: components/container-image-proxy
+                ring: "ring-0"
+                clusterDir: base
+          - list:
+              elements: []
+
+  template:
+    metadata:
+      name: container-image-proxy-{{nameNormalized}}
+    spec:
+      project: default
+      source:
+        path: '{{values.sourceRoot}}/rings/{{values.ring}}/{{values.clusterDir}}'
+        repoURL: https://github.com/redhat-appstudio/infra-deployments.git
+        targetRevision: main
+      destination:
+        namespace: container-image-proxy
+        server: '{{server}}'
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
+        syncOptions:
+          - CreateNamespace=true
+        retry:
+          limit: -1
+          backoff:
+            duration: 10s
+            factor: 2
+            maxDuration: 3m

--- a/argo-cd-apps/overlays/rd-dev/container-image-proxy/kustomization.yaml
+++ b/argo-cd-apps/overlays/rd-dev/container-image-proxy/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - container-image-proxy-appset.yaml

--- a/argo-cd-apps/overlays/rd-dev/kustomization.yaml
+++ b/argo-cd-apps/overlays/rd-dev/kustomization.yaml
@@ -5,6 +5,8 @@ namespace: openshift-gitops
 nameSuffix: -ring-0
 
 resources:
+  - artifact-registry-proxy
+  - container-image-proxy
   - etcd-shield
   - konflux-operator
   - kueue

--- a/argo-cd-apps/overlays/rd-staging/artifact-registry-proxy/artifact-registry-proxy-appset.yaml
+++ b/argo-cd-apps/overlays/rd-staging/artifact-registry-proxy/artifact-registry-proxy-appset.yaml
@@ -1,0 +1,48 @@
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: artifact-registry-proxy
+  labels: # Helps k-components detect this appset to apply the correct patches
+    appstudio.redhat.com/deployment-clusters: "tenant"
+spec:
+  generators:
+    - merge:
+        mergeKeys:
+          - nameNormalized
+        generators:
+          - clusters:
+              selector:
+                matchExpressions: # Ensures that no clusters are selected; k-components will replace this with the correct selector
+                  - key: appstudio.redhat.com/select-none
+                    operator: Exists
+                  - key: appstudio.redhat.com/select-none
+                    operator: DoesNotExist
+              values:
+                sourceRoot: components/artifact-registry-proxy
+                ring: "empty-base"
+                clusterDir: "empty-base"
+          - list:
+              elements: [] # Populated via k-components (or manually if the cluster list is unusual)
+
+  template:
+    metadata:
+      name: artifact-registry-proxy-{{nameNormalized}}
+    spec:
+      project: default
+      source:
+        path: '{{values.sourceRoot}}/rings/{{values.ring}}/{{values.clusterDir}}'
+        repoURL: https://github.com/redhat-appstudio/infra-deployments.git
+        targetRevision: main
+      destination:
+        namespace: artifact-registry-proxy
+        server: '{{server}}'
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
+        syncOptions:
+        - CreateNamespace=true
+        retry:
+          limit: 50
+          backoff:
+            duration: 15s

--- a/argo-cd-apps/overlays/rd-staging/artifact-registry-proxy/kustomization.yaml
+++ b/argo-cd-apps/overlays/rd-staging/artifact-registry-proxy/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- artifact-registry-proxy-appset.yaml

--- a/argo-cd-apps/overlays/rd-staging/container-image-proxy/container-image-proxy-appset.yaml
+++ b/argo-cd-apps/overlays/rd-staging/container-image-proxy/container-image-proxy-appset.yaml
@@ -1,0 +1,48 @@
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: container-image-proxy
+  labels: # Helps k-components detect this appset to apply the correct patches
+    appstudio.redhat.com/deployment-clusters: "tenant"
+spec:
+  generators:
+    - merge:
+        mergeKeys:
+          - nameNormalized
+        generators:
+          - clusters:
+              selector:
+                matchExpressions: # Ensures that no clusters are selected; k-components will replace this with the correct selector
+                  - key: appstudio.redhat.com/select-none
+                    operator: Exists
+                  - key: appstudio.redhat.com/select-none
+                    operator: DoesNotExist
+              values:
+                sourceRoot: components/container-image-proxy
+                ring: "empty-base"
+                clusterDir: "empty-base"
+          - list:
+              elements: [] # Populated via k-components (or manually if the cluster list is unusual)
+
+  template:
+    metadata:
+      name: container-image-proxy-{{nameNormalized}}
+    spec:
+      project: default
+      source:
+        path: '{{values.sourceRoot}}/rings/{{values.ring}}/{{values.clusterDir}}'
+        repoURL: https://github.com/redhat-appstudio/infra-deployments.git
+        targetRevision: main
+      destination:
+        namespace: container-image-proxy
+        server: '{{server}}'
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
+        syncOptions:
+        - CreateNamespace=true
+        retry:
+          limit: 50
+          backoff:
+            duration: 15s

--- a/argo-cd-apps/overlays/rd-staging/container-image-proxy/kustomization.yaml
+++ b/argo-cd-apps/overlays/rd-staging/container-image-proxy/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- container-image-proxy-appset.yaml

--- a/argo-cd-apps/overlays/rd-staging/kustomization.yaml
+++ b/argo-cd-apps/overlays/rd-staging/kustomization.yaml
@@ -3,7 +3,9 @@ kind: Kustomization
 namespace: argocd-infra-deployments
 
 resources:
+  - artifact-registry-proxy
   - authentication
+  - container-image-proxy
   - etcd-shield
   - konflux-operator
   - kueue

--- a/components/artifact-registry-proxy/OWNERS
+++ b/components/artifact-registry-proxy/OWNERS
@@ -1,0 +1,10 @@
+# See the OWNERS docs: https://go.k8s.io/owners
+
+approvers:
+- ifireball
+- gbenhaim
+- amisstea
+- yftacherzog
+- avi-biton
+- hmariset
+- kelchen123

--- a/components/artifact-registry-proxy/base/konflux-vanguard-admins-rb.yaml
+++ b/components/artifact-registry-proxy/base/konflux-vanguard-admins-rb.yaml
@@ -1,0 +1,13 @@
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: konflux-vanguard-admins
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: konflux-vanguard
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: admin

--- a/components/artifact-registry-proxy/base/kustomization.yaml
+++ b/components/artifact-registry-proxy/base/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- konflux-vanguard-admins-rb.yaml

--- a/components/artifact-registry-proxy/rings/empty-base/empty-base/kustomization.yaml
+++ b/components/artifact-registry-proxy/rings/empty-base/empty-base/kustomization.yaml
@@ -1,0 +1,3 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources: []

--- a/components/artifact-registry-proxy/rings/ring-0/base/base-snapshot/konflux-vanguard-admins-rb.yaml
+++ b/components/artifact-registry-proxy/rings/ring-0/base/base-snapshot/konflux-vanguard-admins-rb.yaml
@@ -1,0 +1,13 @@
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: konflux-vanguard-admins
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: konflux-vanguard
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: admin

--- a/components/artifact-registry-proxy/rings/ring-0/base/base-snapshot/kustomization.yaml
+++ b/components/artifact-registry-proxy/rings/ring-0/base/base-snapshot/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- konflux-vanguard-admins-rb.yaml

--- a/components/artifact-registry-proxy/rings/ring-0/base/caching-helm-generator.yaml
+++ b/components/artifact-registry-proxy/rings/ring-0/base/caching-helm-generator.yaml
@@ -1,0 +1,47 @@
+apiVersion: builtin
+kind: HelmChartInflationGenerator
+metadata:
+  name: caching-helm
+name: caching-helm
+repo: oci://quay.io/konflux-ci/caching
+version: 0.1.1836+6dabb5a
+valuesInline:
+  squid:
+    enabled: false
+  nginx:
+    enabled: true
+    namespace: artifact-registry-proxy
+    name: artifact-registry-proxy
+    tls:
+      enabled: true
+      secretName: artifact-registry-proxy-tls
+    service:
+      trafficDistribution: PreferClose
+      annotations:
+        service.beta.openshift.io/serving-cert-secret-name: artifact-registry-proxy-tls
+    upstream:
+      url: https://proxy.golang.org
+    cache:
+      allowList:
+        - ^/.+/@v/.* # <module>/@v/<version>.info|.mod|.zip and <module>/@v/list
+        - ^/sumdb/.* # checksum database (e.g. sum.golang.org)
+      size: 1024
+      ttl: 30d
+  installCertManagerComponents: false
+  cert-manager:
+    enabled: false
+  selfsigned-certificate:
+    enabled: false
+  selfsigned-bundle:
+    enabled: false
+  mirrord:
+    enabled: false
+  test:
+    enabled: false
+  environment: release
+  prometheus:
+    serviceMonitor:
+      nginxTLS:
+        ca:
+          configMapName: openshift-service-ca.crt
+          key: service-ca.crt

--- a/components/artifact-registry-proxy/rings/ring-0/base/kustomization.yaml
+++ b/components/artifact-registry-proxy/rings/ring-0/base/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: artifact-registry-proxy
+resources:
+- base-snapshot
+generators:
+- caching-helm-generator.yaml

--- a/components/artifact-registry-proxy/rings/ring-1/base/artifact-registry-credentials-es.yaml
+++ b/components/artifact-registry-proxy/rings/ring-1/base/artifact-registry-credentials-es.yaml
@@ -1,0 +1,22 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: artifact-registry-credentials
+  namespace: artifact-registry-proxy
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: appsre-stonesoup-vault
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    name: artifact-registry-credentials
+  data:
+    - secretKey: authorization
+      remoteRef:
+        key: staging/vanguard/nexus/proxy-sa-1
+        property: authz_header

--- a/components/artifact-registry-proxy/rings/ring-1/base/base-snapshot/konflux-vanguard-admins-rb.yaml
+++ b/components/artifact-registry-proxy/rings/ring-1/base/base-snapshot/konflux-vanguard-admins-rb.yaml
@@ -1,0 +1,13 @@
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: konflux-vanguard-admins
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: konflux-vanguard
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: admin

--- a/components/artifact-registry-proxy/rings/ring-1/base/base-snapshot/kustomization.yaml
+++ b/components/artifact-registry-proxy/rings/ring-1/base/base-snapshot/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- konflux-vanguard-admins-rb.yaml

--- a/components/artifact-registry-proxy/rings/ring-1/base/caching-helm-generator.yaml
+++ b/components/artifact-registry-proxy/rings/ring-1/base/caching-helm-generator.yaml
@@ -1,0 +1,58 @@
+apiVersion: builtin
+kind: HelmChartInflationGenerator
+metadata:
+  name: caching-helm
+name: caching-helm
+repo: oci://quay.io/konflux-ci/caching
+version: 0.1.1836+6dabb5a
+valuesInline:
+  squid:
+    enabled: false
+  nginx:
+    enabled: true
+    namespace: artifact-registry-proxy
+    replicaCount: 3
+    name: artifact-registry-proxy
+    tls:
+      enabled: true
+      secretName: artifact-registry-proxy-tls
+    service:
+      port: 443
+      trafficDistribution: PreferClose
+      annotations:
+        service.beta.openshift.io/serving-cert-secret-name: artifact-registry-proxy-tls
+    upstream:
+      url: https://red-hat.repo.sonatype.app
+    auth:
+      enabled: true
+      secretName: artifact-registry-credentials
+    cache:
+      allowList:
+        - ^/repository/
+      size: 102400
+      ttl: 30d
+    resources:
+      requests:
+        cpu: "2"
+        memory: 2Gi
+      limits:
+        cpu: "2"
+        memory: 2Gi
+  installCertManagerComponents: false
+  cert-manager:
+    enabled: false
+  selfsigned-certificate:
+    enabled: false
+  selfsigned-bundle:
+    enabled: false
+  mirrord:
+    enabled: false
+  test:
+    enabled: false
+  environment: release
+  prometheus:
+    serviceMonitor:
+      nginxTLS:
+        ca:
+          configMapName: openshift-service-ca.crt
+          key: service-ca.crt

--- a/components/artifact-registry-proxy/rings/ring-1/base/kustomization.yaml
+++ b/components/artifact-registry-proxy/rings/ring-1/base/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: artifact-registry-proxy
+resources:
+- base-snapshot
+- artifact-registry-credentials-es.yaml
+generators:
+- caching-helm-generator.yaml

--- a/components/artifact-registry-proxy/rings/ring-1/stone-stage-p01/kustomization.yaml
+++ b/components/artifact-registry-proxy/rings/ring-1/stone-stage-p01/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../base

--- a/components/artifact-registry-proxy/rings/ring-1/stone-stg-rh01/kustomization.yaml
+++ b/components/artifact-registry-proxy/rings/ring-1/stone-stg-rh01/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../base

--- a/components/container-image-proxy/OWNERS
+++ b/components/container-image-proxy/OWNERS
@@ -1,0 +1,10 @@
+# See the OWNERS docs: https://go.k8s.io/owners
+
+approvers:
+- ifireball
+- gbenhaim
+- amisstea
+- yftacherzog
+- avi-biton
+- hmariset
+- kelchen123

--- a/components/container-image-proxy/base/konflux-vanguard-admins-rb.yaml
+++ b/components/container-image-proxy/base/konflux-vanguard-admins-rb.yaml
@@ -1,0 +1,13 @@
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: konflux-vanguard-admins
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: konflux-vanguard
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: admin

--- a/components/container-image-proxy/base/kustomization.yaml
+++ b/components/container-image-proxy/base/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- konflux-vanguard-admins-rb.yaml
+- trusted-ca-cm.yaml

--- a/components/container-image-proxy/base/trusted-ca-cm.yaml
+++ b/components/container-image-proxy/base/trusted-ca-cm.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: trusted-ca
+  labels:
+    config.openshift.io/inject-trusted-cabundle: "true"

--- a/components/container-image-proxy/rings/empty-base/empty-base/kustomization.yaml
+++ b/components/container-image-proxy/rings/empty-base/empty-base/kustomization.yaml
@@ -1,0 +1,3 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources: []

--- a/components/container-image-proxy/rings/ring-0/base/base-snapshot/konflux-vanguard-admins-rb.yaml
+++ b/components/container-image-proxy/rings/ring-0/base/base-snapshot/konflux-vanguard-admins-rb.yaml
@@ -1,0 +1,13 @@
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: konflux-vanguard-admins
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: konflux-vanguard
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: admin

--- a/components/container-image-proxy/rings/ring-0/base/base-snapshot/kustomization.yaml
+++ b/components/container-image-proxy/rings/ring-0/base/base-snapshot/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- konflux-vanguard-admins-rb.yaml
+- trusted-ca-cm.yaml

--- a/components/container-image-proxy/rings/ring-0/base/base-snapshot/trusted-ca-cm.yaml
+++ b/components/container-image-proxy/rings/ring-0/base/base-snapshot/trusted-ca-cm.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: trusted-ca
+  labels:
+    config.openshift.io/inject-trusted-cabundle: "true"

--- a/components/container-image-proxy/rings/ring-0/base/caching-helm-generator.yaml
+++ b/components/container-image-proxy/rings/ring-0/base/caching-helm-generator.yaml
@@ -1,0 +1,75 @@
+apiVersion: builtin
+kind: HelmChartInflationGenerator
+metadata:
+  name: caching-helm
+name: caching-helm
+repo: oci://quay.io/konflux-ci/caching
+version: 0.1.1836+6dabb5a
+valuesInline:
+  squid:
+    enabled: true
+    namespace: container-image-proxy
+  nginx:
+    enabled: false
+  installCertManagerComponents: false
+  cert-manager:
+    enabled: false
+  selfsigned-certificate:
+    enabled: true
+  selfsigned-bundle:
+    enabled: true
+  mirrord:
+    enabled: false
+  test:
+    enabled: false
+  environment: release
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 200m
+      memory: 256Mi
+  icapServer:
+    resources:
+      requests:
+        cpu: 10m
+        memory: 32Mi
+      limits:
+        cpu: 100m
+        memory: 128Mi
+  squidExporter:
+    resources:
+      requests:
+        cpu: 10m
+        memory: 16Mi
+      limits:
+        cpu: 100m
+        memory: 64Mi
+  cache:
+    allowList:
+      - ^https://cdn([0-9]{2})?\.quay\.io/.+/sha256/.+/[a-f0-9]{64}
+      - ^https://s3\.[a-z0-9-]+\.amazonaws\.com/quayio-production-s3/sha256/.+/[a-f0-9]{64}
+      - ^https://quayio-production-s3\.s3[a-z0-9.-]*\.amazonaws\.com/sha256/.+/[a-f0-9]{64}
+      - ^https://production\.cloudflare\.docker\.com/registry-v2/docker/registry/v2/blobs/sha256/[a-f0-9]{2}/[a-f0-9]{64}/data
+      - ^https://docker-images-prod\.[a-f0-9]{32}\.r2\.cloudflarestorage\.com/registry-v2/docker/registry/v2/blobs/sha256/[a-f0-9]{2}/[a-f0-9]{64}/data
+      - ^https://docker-images-prod\.s3[a-z0-9.-]*\.amazonaws\.com/registry-v2/docker/registry/v2/blobs/sha256/[a-f0-9]{2}/[a-f0-9]{64}/data
+      - ^https://cdn\.registry\.fedoraproject\.org/v2/.+/blobs/sha256:[a-f0-9]{64}
+      - ^https://[a-f0-9]{32}\.r2\.cloudflarestorage\.com/app-ci-image-registry/docker/registry/v2/blobs/sha256/[a-f0-9]{2}/[a-f0-9]{64}/data
+      - ^https://layers\.nvcr\.io/registry/docker/registry/v2/blobs/sha256/[a-f0-9]{2}/[a-f0-9]{64}/data
+      - ^https://[a-z0-9]+\.cloudfront\.net/sha256/[a-f0-9]{2}/[a-f0-9]{64}
+    size: 192
+    maxObjectSize: 128
+  tlsOutgoingOptions:
+    caFile: /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
+  volumes:
+    - name: trusted-ca
+      configMap:
+        name: trusted-ca
+        items:
+          - key: ca-bundle.crt
+            path: tls-ca-bundle.pem
+  volumeMounts:
+    - name: trusted-ca
+      mountPath: /etc/pki/ca-trust/extracted/pem
+      readOnly: true

--- a/components/container-image-proxy/rings/ring-0/base/kustomization.yaml
+++ b/components/container-image-proxy/rings/ring-0/base/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: container-image-proxy
+resources:
+- base-snapshot
+generators:
+- caching-helm-generator.yaml

--- a/components/container-image-proxy/rings/ring-1/base/base-snapshot/konflux-vanguard-admins-rb.yaml
+++ b/components/container-image-proxy/rings/ring-1/base/base-snapshot/konflux-vanguard-admins-rb.yaml
@@ -1,0 +1,13 @@
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: konflux-vanguard-admins
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: konflux-vanguard
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: admin

--- a/components/container-image-proxy/rings/ring-1/base/base-snapshot/kustomization.yaml
+++ b/components/container-image-proxy/rings/ring-1/base/base-snapshot/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- konflux-vanguard-admins-rb.yaml
+- trusted-ca-cm.yaml

--- a/components/container-image-proxy/rings/ring-1/base/base-snapshot/trusted-ca-cm.yaml
+++ b/components/container-image-proxy/rings/ring-1/base/base-snapshot/trusted-ca-cm.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: trusted-ca
+  labels:
+    config.openshift.io/inject-trusted-cabundle: "true"

--- a/components/container-image-proxy/rings/ring-1/base/caching-helm-generator.yaml
+++ b/components/container-image-proxy/rings/ring-1/base/caching-helm-generator.yaml
@@ -1,0 +1,76 @@
+apiVersion: builtin
+kind: HelmChartInflationGenerator
+metadata:
+  name: caching-helm
+name: caching-helm
+repo: oci://quay.io/konflux-ci/caching
+version: 0.1.1836+6dabb5a
+valuesInline:
+  squid:
+    enabled: true
+    namespace: container-image-proxy
+  nginx:
+    enabled: false
+  installCertManagerComponents: false
+  cert-manager:
+    enabled: false
+  selfsigned-certificate:
+    enabled: true
+  selfsigned-bundle:
+    enabled: true
+  mirrord:
+    enabled: false
+  test:
+    enabled: false
+  environment: release
+  replicaCount: 3
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 200m
+      memory: 2Gi
+  icapServer:
+    resources:
+      requests:
+        cpu: 10m
+        memory: 32Mi
+      limits:
+        cpu: 100m
+        memory: 128Mi
+  squidExporter:
+    resources:
+      requests:
+        cpu: 10m
+        memory: 16Mi
+      limits:
+        cpu: 100m
+        memory: 64Mi
+  cache:
+    allowList:
+      - ^https://cdn([0-9]{2})?\.quay\.io/.+/sha256/.+/[a-f0-9]{64}
+      - ^https://s3\.[a-z0-9-]+\.amazonaws\.com/quayio-production-s3/sha256/.+/[a-f0-9]{64}
+      - ^https://quayio-production-s3\.s3[a-z0-9.-]*\.amazonaws\.com/sha256/.+/[a-f0-9]{64}
+      - ^https://production\.cloudflare\.docker\.com/registry-v2/docker/registry/v2/blobs/sha256/[a-f0-9]{2}/[a-f0-9]{64}/data
+      - ^https://docker-images-prod\.[a-f0-9]{32}\.r2\.cloudflarestorage\.com/registry-v2/docker/registry/v2/blobs/sha256/[a-f0-9]{2}/[a-f0-9]{64}/data
+      - ^https://docker-images-prod\.s3[a-z0-9.-]*\.amazonaws\.com/registry-v2/docker/registry/v2/blobs/sha256/[a-f0-9]{2}/[a-f0-9]{64}/data
+      - ^https://cdn\.registry\.fedoraproject\.org/v2/.+/blobs/sha256:[a-f0-9]{64}
+      - ^https://[a-f0-9]{32}\.r2\.cloudflarestorage\.com/app-ci-image-registry/docker/registry/v2/blobs/sha256/[a-f0-9]{2}/[a-f0-9]{64}/data
+      - ^https://layers\.nvcr\.io/registry/docker/registry/v2/blobs/sha256/[a-f0-9]{2}/[a-f0-9]{64}/data
+      - ^https://[a-z0-9]+\.cloudfront\.net/sha256/[a-f0-9]{2}/[a-f0-9]{64}
+    size: 51200
+    maxObjectSize: 1024
+  tlsOutgoingOptions:
+    caFile: /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
+  volumes:
+    - name: trusted-ca
+      configMap:
+        name: trusted-ca
+        items:
+          - key: ca-bundle.crt
+            path: tls-ca-bundle.pem
+  volumeMounts:
+    - name: trusted-ca
+      mountPath: /etc/pki/ca-trust/extracted/pem
+      readOnly: true

--- a/components/container-image-proxy/rings/ring-1/base/kustomization.yaml
+++ b/components/container-image-proxy/rings/ring-1/base/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: container-image-proxy
+resources:
+- base-snapshot
+generators:
+- caching-helm-generator.yaml

--- a/components/container-image-proxy/rings/ring-1/stone-stage-p01/kustomization.yaml
+++ b/components/container-image-proxy/rings/ring-1/stone-stage-p01/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../base

--- a/components/container-image-proxy/rings/ring-1/stone-stg-rh01/kustomization.yaml
+++ b/components/container-image-proxy/rings/ring-1/stone-stg-rh01/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../base


### PR DESCRIPTION
Create independent artifact-registry-proxy (nginx-only) and container-image-proxy (squid-only) components to replace the monolithic squid component. Includes base, development, staging, and production/empty-base overlays with ArgoCD ApplicationSet definitions. Overlay wiring deferred to the deployment task.

Jira-Url: https://redhat.atlassian.net/browse/KFLUXVNGD-1149
Assisted-by: Claude Code