### PR TITLE
KFLUXINFRA-4411 Add ROKS pod CIDR to ESO webhook NetworkPolicy (staging)

### DIFF
--- a/components/external-secrets-operator/staging/networkpolicy-allow-ingress.yaml
+++ b/components/external-secrets-operator/staging/networkpolicy-allow-ingress.yaml
@@ -22,10 +22,13 @@ spec:
     # is NATed and comes from a pod IP assigned to interface ovn-k8s-mp0
     # - 192.168.0.0/16 (pod CIDR in most clusters)
     # - 10.128.0.0/14 (pod CIDR in stg-rh01, prd-rh01 and prd-p01 clusters)
+    # - 172.17.0.0/18 (pod CIDR on IBM Cloud ROKS clusters, e.g. lightwell-dev)
     - ipBlock:
         cidr: 10.128.0.0/14
     - ipBlock:
         cidr: 192.168.0.0/16
+    - ipBlock:
+        cidr: 172.17.0.0/18
     ports:
     - protocol: TCP
       port: 10250 # Webhook port
@@ -87,6 +90,8 @@ spec:
         cidr: 10.128.0.0/14
     - ipBlock:
         cidr: 192.168.0.0/16
+    - ipBlock:
+        cidr: 172.17.0.0/18
     ports:
     - protocol: TCP
       port: 8081


### PR DESCRIPTION
## What

Add IBM Cloud ROKS pod CIDR `172.17.0.0/18` to the `allow-webhook-ingress`
and `allow-health-checks-ingress` NetworkPolicies in
`components/external-secrets-operator/staging/`.

Clusters affected: `lightwell-dev` (ROKS staging cluster)

[KFLUXINFRA-4411](https://redhat.atlassian.net/browse/KFLUXINFRA-4411)

## Why

The `lightwell-dev` ROKS cluster uses pod CIDR `172.17.0.0/18`. The API
server reaches webhooks via Konnectivity agents whose pod IPs are in the
`172.17.x.x` range. The existing NetworkPolicy only allows `10.128.0.0/14`
and `192.168.0.0/16`, so webhook calls are blocked by `default-deny-all`,
causing ArgoCD to fail syncing `ClusterSecretStore` resources with
`context deadline exceeded`.

## Validation

- `kustomize build --enable-helm components/external-secrets-operator/staging/` passes
- `yamllint` passes on the modified file


Made with [Cursor](https://cursor.com)

[KFLUXINFRA-4411]: https://redhat.atlassian.net/browse/KFLUXINFRA-4411?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ