### PR TITLE
feat(KFLUXVNGD-1230): Exclude lightwell-dev and kflux-lw-p01 from legacy ApplicationSets

### DIFF
--- a/argo-cd-apps/overlays/staging-downstream/exclude-operator-owned-clusters.yaml
+++ b/argo-cd-apps/overlays/staging-downstream/exclude-operator-owned-clusters.yaml
@@ -1,6 +1,6 @@
 ---
-# Drop stone-stage-p01 from ApplicationSet generation for Konflux services
-# owned by the konflux-operator on that cluster (ring-1). Uses ApplicationSet
+# Drop operator-managed clusters from ApplicationSet generation for Konflux
+# services owned by the konflux-operator (ring-1). Uses ApplicationSet
 # post-selector on generated params (nameNormalized) so other staging member
 # clusters are unchanged. Staging-downstream overlay only; targets are listed
 # in kustomization.yaml.
@@ -12,3 +12,5 @@
         operator: NotIn
         values:
           - stone-stage-p01
+          - lightwell-dev
+          - kflux-lw-p01

--- a/argo-cd-apps/overlays/staging-downstream/kustomization.yaml
+++ b/argo-cd-apps/overlays/staging-downstream/kustomization.yaml
@@ -21,10 +21,10 @@ patches:
       kind: ApplicationSet
       version: v1alpha1
       name: multi-platform-controller
-  # Exclude stone-stage-p01 from Argo generation for services owned by the
-  # konflux-operator there. Orphan (do not prune) when Applications go away.
+  # Exclude operator-managed clusters from Argo generation for services owned
+  # by the konflux-operator. Orphan (do not prune) when Applications go away.
   # release stays on Argo with disable-auto-sync until monitor ownership is confirmed.
-  - path: exclude-stone-stage-p01-operator-owned.yaml
+  - path: exclude-operator-owned-clusters.yaml
     target:
       kind: ApplicationSet
       version: v1alpha1
@@ -34,7 +34,7 @@ patches:
       kind: ApplicationSet
       version: v1alpha1
       name: application-api
-  - path: exclude-stone-stage-p01-operator-owned.yaml
+  - path: exclude-operator-owned-clusters.yaml
     target:
       kind: ApplicationSet
       version: v1alpha1
@@ -44,7 +44,7 @@ patches:
       kind: ApplicationSet
       version: v1alpha1
       name: build-service
-  - path: exclude-stone-stage-p01-operator-owned.yaml
+  - path: exclude-operator-owned-clusters.yaml
     target:
       kind: ApplicationSet
       version: v1alpha1
@@ -54,7 +54,7 @@ patches:
       kind: ApplicationSet
       version: v1alpha1
       name: integration
-  - path: exclude-stone-stage-p01-operator-owned.yaml
+  - path: exclude-operator-owned-clusters.yaml
     target:
       kind: ApplicationSet
       version: v1alpha1
@@ -64,7 +64,7 @@ patches:
       kind: ApplicationSet
       version: v1alpha1
       name: image-controller
-  - path: exclude-stone-stage-p01-operator-owned.yaml
+  - path: exclude-operator-owned-clusters.yaml
     target:
       kind: ApplicationSet
       version: v1alpha1
@@ -74,7 +74,7 @@ patches:
       kind: ApplicationSet
       version: v1alpha1
       name: namespace-lister
-  - path: exclude-stone-stage-p01-operator-owned.yaml
+  - path: exclude-operator-owned-clusters.yaml
     target:
       kind: ApplicationSet
       version: v1alpha1
@@ -84,7 +84,7 @@ patches:
       kind: ApplicationSet
       version: v1alpha1
       name: konflux-info
-  - path: exclude-stone-stage-p01-operator-owned.yaml
+  - path: exclude-operator-owned-clusters.yaml
     target:
       kind: ApplicationSet
       version: v1alpha1
@@ -94,7 +94,7 @@ patches:
       kind: ApplicationSet
       version: v1alpha1
       name: konflux-ui
-  - path: exclude-stone-stage-p01-operator-owned.yaml
+  - path: exclude-operator-owned-clusters.yaml
     target:
       kind: ApplicationSet
       version: v1alpha1
@@ -104,7 +104,7 @@ patches:
       kind: ApplicationSet
       version: v1alpha1
       name: enterprise-contract
-  - path: exclude-stone-stage-p01-operator-owned.yaml
+  - path: exclude-operator-owned-clusters.yaml
     target:
       kind: ApplicationSet
       version: v1alpha1


### PR DESCRIPTION
The staging-downstream overlay runs operator-owned services (build-service, integration, konflux-ui, etc.) through standalone ArgoCD ApplicationSets. On ring-1 clusters these services are managed by the konflux-operator instead, so the legacy AppSets must not generate Applications for them.

Rename exclude-stone-stage-p01-operator-owned.yaml to exclude-operator-owned-clusters.yaml and add lightwell-dev and kflux-lw-p01 alongside stone-stage-p01 in the NotIn selector. This prevents the cluster generator from deploying legacy services when these clusters are registered as ArgoCD cluster secrets.

Assisted-by: Cursor + Opus 4.6