### PR TITLE
Add managed-konflux-perfscale-readonly-role ClusterRole

### DIFF
--- a/components/perf-team-prometheus-reader/base/tenants-rbac/managed-konflux-perfscale-tenant/kustomization.yaml
+++ b/components/perf-team-prometheus-reader/base/tenants-rbac/managed-konflux-perfscale-tenant/kustomization.yaml
@@ -2,3 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - tenant-rbac.yaml
+  - managed-konflux-perfscale-readonly-clusterrole.yaml

--- a/components/perf-team-prometheus-reader/base/tenants-rbac/managed-konflux-perfscale-tenant/managed-konflux-perfscale-readonly-clusterrole.yaml
+++ b/components/perf-team-prometheus-reader/base/tenants-rbac/managed-konflux-perfscale-tenant/managed-konflux-perfscale-readonly-clusterrole.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: managed-konflux-perfscale-readonly-role
+rules:
+- apiGroups:
+  - tekton.dev
+  resources:
+  - taskruns
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get


### PR DESCRIPTION
## What

Adds a new `managed-konflux-perfscale-readonly-role` ClusterRole (read-only:
get/list/watch on tekton `taskruns`, get/list/watch on `pods`, get on
`pods/log`) in `components/perf-team-prometheus-reader/base/tenants-rbac/managed-konflux-perfscale-tenant/`.

Clusters affected: all dev/staging clusters (via `base/`, includes stone-stg-rh01), no production change.

## Why

konflux-release-data's tenants-config cannot define a namespaced `Role`
directly — RoleBindings created there may only reference a pre-existing
Role/ClusterRole allowlisted in its tests. A new read-only ServiceAccount
(`managed-konflux-perfscale-readonly-sa`) is being added in `rhtap-releng-tenant`
on stone-stg-rh01 for loadtest's `--release-managed-readonly` mode, and needs
this ClusterRole for its RoleBinding to validate.

See gitlab.cee.redhat.com/releng/konflux-release-data MR 21264 and the
related Slack thread for context.

## Validation

- `kustomize build components/perf-team-prometheus-reader/staging/base/` succeeds and includes the new ClusterRole.