### PR TITLE
KFLUXINFRA-4409: Add MPC deployment for temporary lightwell-dev cluster

### DIFF
--- a/argo-cd-apps/overlays/staging-downstream/kustomization.yaml
+++ b/argo-cd-apps/overlays/staging-downstream/kustomization.yaml
@@ -21,6 +21,11 @@ patches:
       kind: ApplicationSet
       version: v1alpha1
       name: multi-platform-controller
+  - path: mpc-lightwell-dev-patch.yaml
+    target:
+      kind: ApplicationSet
+      version: v1alpha1
+      name: multi-platform-controller
   # Exclude operator-managed clusters from Argo generation for services owned
   # by the konflux-operator. Orphan (do not prune) when Applications go away.
   # release stays on Argo with disable-auto-sync until monitor ownership is confirmed.

--- a/argo-cd-apps/overlays/staging-downstream/mpc-lightwell-dev-patch.yaml
+++ b/argo-cd-apps/overlays/staging-downstream/mpc-lightwell-dev-patch.yaml
@@ -1,0 +1,6 @@
+---
+- op: add
+  path: /spec/generators/0/merge/generators/1/list/elements/-
+  value:
+    nameNormalized: lightwell-dev
+    values.clusterDir: lightwell-dev

--- a/components/multi-platform-controller/staging-downstream/lightwell-dev/external-secrets.yaml
+++ b/components/multi-platform-controller/staging-downstream/lightwell-dev/external-secrets.yaml
@@ -1,0 +1,114 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: aws-account
+  namespace: multi-platform-controller
+  labels:
+    build.appstudio.redhat.com/multi-platform-secret: "true"
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  dataFrom:
+    - extract:
+        key: staging/infrastructure/multi-platform-controller/lightwell-dev/aws-account
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: appsre-stonesoup-vault
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    name: aws-account
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: aws-ssh-key
+  namespace: multi-platform-controller
+  labels:
+    build.appstudio.redhat.com/multi-platform-secret: "true"
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  dataFrom:
+    - extract:
+        key: staging/infrastructure/multi-platform-controller/lightwell-dev/aws-ssh-key
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: appsre-stonesoup-vault
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    name: aws-ssh-key
+# ---
+# apiVersion: external-secrets.io/v1
+# kind: ExternalSecret
+# metadata:
+#   name: aws-win-ssh-key
+#   namespace: multi-platform-controller
+#   labels:
+#     build.appstudio.redhat.com/multi-platform-secret: "true"
+#   annotations:
+#     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+#     argocd.argoproj.io/sync-wave: "-1"
+# spec:
+#   dataFrom:
+#     - extract:
+#         key: staging/infrastructure/multi-platform-controller/lightwell-dev/aws-win-ssh-key
+#   refreshInterval: 1h
+#   secretStoreRef:
+#     kind: ClusterSecretStore
+#     name: appsre-stonesoup-vault
+#   target:
+#     creationPolicy: Owner
+#     deletionPolicy: Delete
+#     name: aws-win-ssh-key
+# ---
+# apiVersion: external-secrets.io/v1
+# kind: ExternalSecret
+# metadata:
+#   name: ibm-ppc64le-ssh-key
+#   namespace: multi-platform-controller
+#   labels:
+#     build.appstudio.redhat.com/multi-platform-secret: "true"
+#   annotations:
+#     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+#     argocd.argoproj.io/sync-wave: "-1"
+# spec:
+#   dataFrom:
+#     - extract:
+#         key: staging/infrastructure/multi-platform-controller/lightwell-dev/ibm-ppc64le-ssh-key
+#   refreshInterval: 1h
+#   secretStoreRef:
+#     kind: ClusterSecretStore
+#     name: appsre-stonesoup-vault
+#   target:
+#     creationPolicy: Owner
+#     deletionPolicy: Delete
+#     name: ibm-ppc64le-ssh-key
+# ---
+# apiVersion: external-secrets.io/v1
+# kind: ExternalSecret
+# metadata:
+#   name: ibm-s390x-ssh-key
+#   namespace: multi-platform-controller
+#   labels:
+#     build.appstudio.redhat.com/multi-platform-secret: "true"
+#   annotations:
+#     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+#     argocd.argoproj.io/sync-wave: "-1"
+# spec:
+#   dataFrom:
+#     - extract:
+#         key: staging/infrastructure/multi-platform-controller/lightwell-dev/ibm-s390x-ssh-key
+#   refreshInterval: 1h
+#   secretStoreRef:
+#     kind: ClusterSecretStore
+#     name: appsre-stonesoup-vault
+#   target:
+#     creationPolicy: Owner
+#     deletionPolicy: Delete
+#     name: ibm-s390x-ssh-key

--- a/components/multi-platform-controller/staging-downstream/lightwell-dev/host-values.yaml
+++ b/components/multi-platform-controller/staging-downstream/lightwell-dev/host-values.yaml
@@ -1,0 +1,46 @@
+environment: "stage"
+
+#localPlatforms:
+#  - "linux/amd64"
+#  - "linux/x86_64"
+#  - "local"
+#  - "localhost"
+
+instanceTag: "lightwell-dev"
+
+additionalInstanceTags:
+  service-phase: "Staging"
+
+archDefaults:
+  arm64:
+    ami: "ami-06f37afe6d4f43c47"
+    key-name: "konflux-stage-int-mab01"
+    security-group-id: "sg-0482e8ccae008b240"
+    subnet-id: "subnet-07597d1edafa2b9d3"
+  amd64:
+    ami: "ami-01aaf1c29c7e0f0af"
+    key-name: "konflux-stage-int-mab01"
+    security-group-id: "sg-0482e8ccae008b240"
+    subnet-id: "subnet-07597d1edafa2b9d3"
+
+dynamicConfigs:
+  linux-arm64:
+    subnet-id: "subnet-01b88957a67590dc2"
+
+  linux-amd64:
+    subnet-id: "subnet-06132f7bf72af6ce6"
+
+  linux-root-arm64:
+    sudo-commands: "/usr/bin/podman"
+    disk: "200"
+
+  linux-root-amd64:
+    sudo-commands: "/usr/bin/podman"
+    disk: "200"
+    # user-data loaded from ../staging/base/host-config-chart/files/linux-root-amd64-init.sh
+
+
+
+# Static hosts configuration
+staticHosts:
+

--- a/components/multi-platform-controller/staging-downstream/lightwell-dev/kustomization.yaml
+++ b/components/multi-platform-controller/staging-downstream/lightwell-dev/kustomization.yaml
@@ -1,0 +1,20 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../base
+# - ../../base/logcollector dont add this for now
+- external-secrets.yaml
+
+components:
+  - ../../k-components/manager-resources
+
+helmGlobals:
+  chartHome: ../../staging/base
+
+helmCharts:
+- name: host-config-chart
+  releaseName: host-config
+  namespace: multi-platform-controller
+  valuesFile: host-values.yaml
+
+namespace: multi-platform-controller

--- a/components/multi-platform-controller/staging-downstream/lightwell-dev/kustomization.yaml
+++ b/components/multi-platform-controller/staging-downstream/lightwell-dev/kustomization.yaml
@@ -2,7 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - ../../base
-# - ../../base/logcollector dont add this for now
 - external-secrets.yaml
 
 components:


### PR DESCRIPTION
## What

- Add staging-downstream-only ApplicationSet patch to register `lightwell-dev` for multi-platform-controller
- Add per-cluster MPC overlay at `components/multi-platform-controller/staging-downstream/lightwell-dev/` with host values and external secrets

Clusters affected: lightwell-dev (staging-downstream only)

[KFLUXINFRA-4409](https://redhat.atlassian.net/browse/KFLUXINFRA-4409)

## Why

Temporary staging cluster `lightwell-dev` needs MPC deployed via GitOps without affecting other environments or the base ApplicationSet.

## Validation

- `kustomize build argo-cd-apps/overlays/staging-downstream/` passes locally
- Rendered ApplicationSet includes `lightwell-dev` with path `components/multi-platform-controller/staging-downstream/lightwell-dev/` and `environment: staging-downstream`
- Component overlay `kustomize build --enable-helm components/multi-platform-controller/staging-downstream/lightwell-dev/` not run locally (helm unavailable in environment)

## Risk Assessment

**Risk Level:** Low
**What could go wrong:** MPC fails to sync on lightwell-dev if the cluster is not registered in ArgoCD or vault secrets are missing at the configured paths.
**Rollback:** Revert this PR and remove the ArgoCD Application for `multi-platform-controller-lightwell-dev`.
**Blast radius:** Single temporary staging-downstream cluster only; no production or other staging clusters affected.


Made with [Cursor](https://cursor.com)

[KFLUXINFRA-4409]: https://redhat.atlassian.net/browse/KFLUXINFRA-4409?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ