### PR TITLE
SPRE-6550: Add cert-manager metrics to staging federation for alert coverage

### DIFF
--- a/components/monitoring/prometheus/staging/base/federation/endpoints-params.yaml
+++ b/components/monitoring/prometheus/staging/base/federation/endpoints-params.yaml
@@ -144,6 +144,9 @@
     - '{__name__="certmanager_controller_sync_error_count", namespace="cert-manager"}'
     - '{__name__="certmanager_clusterissuer_ready_status", namespace="cert-manager"}'
     - '{__name__="certmanager_issuer_ready_status", namespace="cert-manager"}'
+    - '{__name__="certmanager_http_acme_client_request_count", namespace="cert-manager"}'
+    - '{__name__="certmanager_certificate_renewal_errors_total", namespace="cert-manager"}'
+    - '{__name__="certmanager_certificaterequest_condition", namespace="cert-manager"}'
 
     ## Container Metrics
     - '{__name__="kube_pod_container_status_waiting_reason", namespace!~".*-tenant|openshift-.*|kube-.*"}'


### PR DESCRIPTION
## Summary

JIRA: https://issues.redhat.com/browse/SPRE-6550

Add three new cert-manager metrics to the **staging** federation endpoints-params to support upcoming alert rules:

- `certmanager_http_acme_client_request_count` - for webhook failure detection
- `certmanager_certificate_renewal_errors_total` - for renewal failure detection
- `certmanager_certificaterequest_condition` - for stuck CertificateRequest detection

These metrics are needed to create alerts for scenarios not covered by the existing cert-manager alert rules (CertManagerWebhookFailure, CertManagerCertificateRenewalFailed, CertManagerCertificateRequestPending).

## Scope

Staging only. Production will follow in a separate PR after validation.

## Related

- o11y alerts PR: https://github.com/redhat-appstudio/o11y/pull/1280