### PR TITLE
feat(KFLUXVNGD-1230): Add lightwell-dev to internal-tenant staging cluster list

### DIFF
--- a/argo-cd-apps/k-components/deploy-to-staging-internal-tenant-clusters/internal-tenant-clusters-list-patch.yaml
+++ b/argo-cd-apps/k-components/deploy-to-staging-internal-tenant-clusters/internal-tenant-clusters-list-patch.yaml
@@ -4,3 +4,6 @@
     - values.ring: ring-1
       nameNormalized: stone-stage-p01
       values.clusterDir: stone-stage-p01
+    - values.ring: ring-1
+      nameNormalized: lightwell-dev
+      values.clusterDir: lightwell-dev


### PR DESCRIPTION
The konflux-operator ApplicationSet uses a merge generator that requires an explicit list entry to map each cluster to its ring and config directory. Without this entry lightwell-dev falls through to the empty-base path and the operator is never deployed.

Add lightwell-dev with ring-1 targeting so the rendered Application points to components/konflux-operator/rings/ring-1/lightwell-dev/.

Assisted-by: Cursor + Opus 4.6