### PR TITLE
feat(KFLUXVNGD-1230): Add lightwell-dev to pipeline-service and cert-manager ApplicationSets

### DIFF
--- a/argo-cd-apps/base/member/infra-deployments/cert-manager/cert-manager.yaml
+++ b/argo-cd-apps/base/member/infra-deployments/cert-manager/cert-manager.yaml
@@ -22,6 +22,8 @@ spec:
                   values.clusterDir: stone-stg-rh01
                 - nameNormalized: stone-stage-p01
                   values.clusterDir: stone-stage-p01
+                - nameNormalized: lightwell-dev
+                  values.clusterDir: lightwell-dev
                 - nameNormalized: stone-prd-rh01
                   values.clusterDir: stone-prd-rh01
                 - nameNormalized: kflux-prd-rh02

--- a/argo-cd-apps/base/member/infra-deployments/pipeline-service/pipeline-service.yaml
+++ b/argo-cd-apps/base/member/infra-deployments/pipeline-service/pipeline-service.yaml
@@ -23,6 +23,8 @@ spec:
                   values.clusterDir: stone-prd-rh01
                 - nameNormalized: stone-stage-p01
                   values.clusterDir: stone-stage-p01
+                - nameNormalized: lightwell-dev
+                  values.clusterDir: lightwell-dev
                 - nameNormalized: stone-prod-p01
                   values.clusterDir: stone-prod-p01
                 - nameNormalized: stone-prod-p02


### PR DESCRIPTION
Add lightwell-dev to the cert-manager ApplicationSet cluster list so it resolves to the staging/lightwell-dev overlay instead of falling back to empty-base.


## RISK (Added by @gbenhaim)
None, this change should affect only the lightwell-dev cluster.

Assisted-by: Cursor + Opus 4.6