### PR TITLE
fix(KFLUXVNGD-1231): Fix ArgoCD sync deadlock on greenfield operator clusters

### DIFF
--- a/components/konflux-operator/rings/ring-1/base/cr/build/external-secrets/pipelines-as-code-secret.yaml
+++ b/components/konflux-operator/rings/ring-1/base/cr/build/external-secrets/pipelines-as-code-secret.yaml
@@ -5,7 +5,6 @@ metadata:
   namespace: build-service
   annotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
-    argocd.argoproj.io/sync-wave: "-1"
 spec:
   dataFrom:
     - extract:

--- a/components/konflux-operator/rings/ring-1/base/cr/image-controller/external-secrets/image-pruner-token.yaml
+++ b/components/konflux-operator/rings/ring-1/base/cr/image-controller/external-secrets/image-pruner-token.yaml
@@ -5,7 +5,6 @@ metadata:
   namespace: image-controller
   annotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
-    argocd.argoproj.io/sync-wave: "-1"
 spec:
   dataFrom:
     - extract:

--- a/components/konflux-operator/rings/ring-1/base/cr/image-controller/external-secrets/quaytoken.yaml
+++ b/components/konflux-operator/rings/ring-1/base/cr/image-controller/external-secrets/quaytoken.yaml
@@ -5,7 +5,6 @@ metadata:
   namespace: image-controller
   annotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
-    argocd.argoproj.io/sync-wave: "-1"
 spec:
   dataFrom:
     - extract:

--- a/components/konflux-operator/rings/ring-1/base/cr/integration/external-secrets/pipelines-as-code-secret.yaml
+++ b/components/konflux-operator/rings/ring-1/base/cr/integration/external-secrets/pipelines-as-code-secret.yaml
@@ -5,7 +5,6 @@ metadata:
   namespace: integration-service
   annotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
-    argocd.argoproj.io/sync-wave: "-1"
 spec:
   dataFrom:
     - extract:

--- a/components/konflux-operator/rings/ring-1/base/cr/konflux-ui/external-secrets/watson-config.yaml
+++ b/components/konflux-operator/rings/ring-1/base/cr/konflux-ui/external-secrets/watson-config.yaml
@@ -5,7 +5,6 @@ metadata:
   namespace: konflux-ui
   annotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
-    argocd.argoproj.io/sync-wave: "-1"
 spec:
   data:
     - secretKey: API_KEY

--- a/components/konflux-operator/rings/ring-1/base/cr/release/external-secrets/release-monitor-secret.yaml
+++ b/components/konflux-operator/rings/ring-1/base/cr/release/external-secrets/release-monitor-secret.yaml
@@ -5,7 +5,6 @@ metadata:
   namespace: release-service
   annotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
-    argocd.argoproj.io/sync-wave: "-1"
 spec:
   dataFrom:
     - extract:

--- a/components/konflux-operator/rings/ring-1/base/cr/telemetry/external-secrets/segment-write-key.yaml
+++ b/components/konflux-operator/rings/ring-1/base/cr/telemetry/external-secrets/segment-write-key.yaml
@@ -5,7 +5,6 @@ metadata:
   namespace: segment-bridge
   annotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
-    argocd.argoproj.io/sync-wave: "-1"
 spec:
   data:
     - secretKey: SEGMENT_WRITE_KEY


### PR DESCRIPTION
On greenfield clusters the operator ApplicationSet was stuck in an
infinite retry loop because ExternalSecrets at sync-wave "-1" targeted
service namespaces (build-service, integration-service, image-controller,
release-service, konflux-ui, segment-bridge) that only exist after the
operator reconciles the Konflux CR. Since wave -1 must complete before
wave 0, the operator was never deployed and namespaces were never
created — a deadlock.
Remove the sync-wave annotation so ExternalSecrets default to wave 0
alongside the operator. On the first sync attempt, namespace-scoped
resources fail while the operator Deployment succeeds and creates the
namespaces. The next retry applies everything successfully.
Wave 0 is chosen over a later wave (e.g. "1") because a custom health
check ties the Konflux CR status to the ArgoCD app. A later wave would
create a second deadlock: ArgoCD would block at wave 0 waiting for
healthy deployments that need secrets only applied in wave 1.

Assisted-by: Cursor + Opus 4.6