### PR TITLE
PVO11Y-5426 Grant serviceaccount-loadtest delete on imagerepositories

### DIFF
--- a/components/perf-team-prometheus-reader/base/tenants-rbac/konflux-perfscale-1-tenant/tenant-rbac.yaml
+++ b/components/perf-team-prometheus-reader/base/tenants-rbac/konflux-perfscale-1-tenant/tenant-rbac.yaml
@@ -8,6 +8,9 @@ rules:
 - apiGroups: [""]
   resources: ["events"]
   verbs: ["get", "list", "watch"]
+- apiGroups: ["appstudio.redhat.com"]
+  resources: ["imagerepositories"]
+  verbs: ["delete"]
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/components/perf-team-prometheus-reader/base/tenants-rbac/konflux-perfscale-2-tenant/tenant-rbac.yaml
+++ b/components/perf-team-prometheus-reader/base/tenants-rbac/konflux-perfscale-2-tenant/tenant-rbac.yaml
@@ -8,6 +8,9 @@ rules:
 - apiGroups: [""]
   resources: ["events"]
   verbs: ["get", "list", "watch"]
+- apiGroups: ["appstudio.redhat.com"]
+  resources: ["imagerepositories"]
+  verbs: ["delete"]
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/components/perf-team-prometheus-reader/base/tenants-rbac/konflux-perfscale-3-tenant/tenant-rbac.yaml
+++ b/components/perf-team-prometheus-reader/base/tenants-rbac/konflux-perfscale-3-tenant/tenant-rbac.yaml
@@ -8,6 +8,9 @@ rules:
 - apiGroups: [""]
   resources: ["events"]
   verbs: ["get", "list", "watch"]
+- apiGroups: ["appstudio.redhat.com"]
+  resources: ["imagerepositories"]
+  verbs: ["delete"]
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/components/perf-team-prometheus-reader/base/tenants-rbac/konflux-perfscale-4-tenant/tenant-rbac.yaml
+++ b/components/perf-team-prometheus-reader/base/tenants-rbac/konflux-perfscale-4-tenant/tenant-rbac.yaml
@@ -8,6 +8,9 @@ rules:
 - apiGroups: [""]
   resources: ["events"]
   verbs: ["get", "list", "watch"]
+- apiGroups: ["appstudio.redhat.com"]
+  resources: ["imagerepositories"]
+  verbs: ["delete"]
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
## What

Add `delete` permission for `imagerepositories` (`appstudio.redhat.com`) to the `perf-team-event-reader-role` Role for `serviceaccount-loadtest` in all four `konflux-perfscale-*-tenant` namespaces.

[PVO11Y-5426](https://redhat.atlassian.net/browse/PVO11Y-5426)

## Why

Without this permission, the loadtest purge step cannot delete `ImageRepository` CRs it created, causing them to accumulate indefinitely. On stone-stg-rh01, 73 orphaned CRs overloaded the image-controller, causing all new probe runs to fail with:

```
ImageRepository failed to become ready: context deadline exceeded
```

This is the RBAC side of a two-part fix. The companion loadtest change that does the actual deletion is at [konflux-ci/loadtest#144](https://github.com/konflux-ci/loadtest/pull/144).

## Validation

- `kustomize build` passes for all affected overlays
- After merge + ArgoCD sync, `serviceaccount-loadtest` will be able to delete ImageRepositories in all four perfscale tenant namespaces

[PVO11Y-5426]: https://redhat.atlassian.net/browse/PVO11Y-5426?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ