### PR TITLE
PVO11Y-5426 Bind serviceaccount-loadtest to konflux-admin-user-actions on stone-stg-rh01

### DIFF
--- a/components/monitoring/kanary/staging/stone-stg-rh01/kustomization.yaml
+++ b/components/monitoring/kanary/staging/stone-stg-rh01/kustomization.yaml
@@ -1,6 +1,7 @@
 resources:
   - ../base
   - cronjobs
+  - rbac
 
 patches:
   - path: external-secrets/patches/kanary-probe-prometheus-credentials-path.yaml

--- a/components/monitoring/kanary/staging/stone-stg-rh01/rbac/kustomization.yaml
+++ b/components/monitoring/kanary/staging/stone-stg-rh01/rbac/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - serviceaccount-loadtest-rbac.yaml

--- a/components/monitoring/kanary/staging/stone-stg-rh01/rbac/serviceaccount-loadtest-rbac.yaml
+++ b/components/monitoring/kanary/staging/stone-stg-rh01/rbac/serviceaccount-loadtest-rbac.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: serviceaccount-loadtest-rolebinding
+  namespace: konflux-perfscale-4-tenant
+subjects:
+  - kind: ServiceAccount
+    name: serviceaccount-loadtest
+    namespace: konflux-perfscale-4-tenant
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: konflux-admin-user-actions


### PR DESCRIPTION
## What

Add a `RoleBinding` for `serviceaccount-loadtest` to `konflux-admin-user-actions` in `konflux-perfscale-4-tenant` on stone-stg-rh01, via the kanary staging overlay for that cluster.

[PVO11Y-5426](https://redhat.atlassian.net/browse/PVO11Y-5426)

## Why

stone-stg-rh01 is not managed by the staging ArgoCD control plane (it has zero ArgoCD apps from cp-stg). As a result, `perf-team-prometheus-reader` — which normally deploys this binding to other staging clusters — is never applied there. Without the binding, `serviceaccount-loadtest` cannot delete `ImageRepository` CRs, causing orphaned CRs to accumulate and overload the image-controller. This manifests as:

```
ImageRepository failed to become ready: context deadline exceeded
```

on every kanary probe run on stone-stg-rh01.

This is the RBAC side of a two-part fix. The loadtest code fix that does the actual deletion is at [konflux-ci/loadtest#144](https://github.com/konflux-ci/loadtest/pull/144).

> **Note:** stone-stage-p01 already has this binding via `perf-team-prometheus-reader` (which IS deployed there), so no change is needed for that cluster.

## Validation

- `kustomize build components/monitoring/kanary/staging/stone-stg-rh01/` passes

[PVO11Y-5426]: https://redhat.atlassian.net/browse/PVO11Y-5426?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ