### PR TITLE
fix(KFLUXVNGD-1198): Remove unused workspace-manager image override from staging konflux-ui

### DIFF
--- a/components/konflux-ui/staging/base/kustomization.yaml
+++ b/components/konflux-ui/staging/base/kustomization.yaml
@@ -8,9 +8,6 @@ resources:
   - external-secret.yaml
 
 images:
-  - name: quay.io/konflux-ci/workspace-manager
-    digest: sha256:48df30520a766101473e80e7a4abbf59ce06097a5f5919e15075afaa86bd1a2d
-
   - name: quay.io/konflux-ci/konflux-ui
     newTag: 1fd2d9969cba9bb4234d0052cfeffab7e139015a
 


### PR DESCRIPTION
The workspace-manager image override in staging had no effect since no staging resource references this image. The workspace-manager container only exists in the production proxy deployment.

Assisted-by: Claude Opus 4.6