### PR TITLE
fix(KFLUXVNGD-1199): Remove workspace-manager from production konflux-ui

### DIFF
--- a/components/konflux-ui/production/base/kustomization.yaml
+++ b/components/konflux-ui/production/base/kustomization.yaml
@@ -7,9 +7,6 @@ resources:
   - ../../base
 
 images:
-  - name: quay.io/konflux-ci/workspace-manager
-    digest: sha256:48df30520a766101473e80e7a4abbf59ce06097a5f5919e15075afaa86bd1a2d
-
   - name: quay.io/konflux-ci/konflux-ui
     newTag: e5f64507ddce17c2538d3a39ae836d8c2367fdda
 

--- a/components/konflux-ui/production/base/proxy/nginx.conf
+++ b/components/konflux-ui/production/base/proxy/nginx.conf
@@ -69,58 +69,6 @@ http {
             proxy_set_header X-Scheme         $scheme;
         }
 
-        location /api/k8s/registration/ {
-           # Registration Service registration endpoint
-            auth_request_set $email  $upstream_http_x_auth_request_email;
-            proxy_set_header X-Email $email;
-            auth_request_set $user  $upstream_http_x_auth_request_user;
-            proxy_set_header X-User  $user;
-            auth_request_set $username  $upstream_http_x_auth_request_preferred_username;
-            proxy_set_header X-Auth-Request-Preferred-Username $username;
-            auth_request_set $groups  $upstream_http_x_auth_request_groups;
-            proxy_set_header X-Auth-Request-Groups  $user;
-
-            auth_request /oauth2/auth;
-            proxy_pass http://127.0.0.1:5000/;
-        }
-
-        location /api/k8s/apis/toolchain.dev.openshift.com/v1alpha1/workspaces {
-           # Registration Service workspaces endpoint
-            auth_request_set $email  $upstream_http_x_auth_request_email;
-            proxy_set_header X-Email $email;
-            auth_request_set $user  $upstream_http_x_auth_request_user;
-            proxy_set_header X-User  $user;
-            auth_request_set $username  $upstream_http_x_auth_request_preferred_username;
-            proxy_set_header X-Auth-Request-Preferred-Username $username;
-            auth_request_set $groups  $upstream_http_x_auth_request_groups;
-            proxy_set_header X-Auth-Request-Groups  $user;
-
-            auth_request /oauth2/auth;
-            proxy_pass http://127.0.0.1:5000/workspaces;
-        }
-
-        location /api/k8s/workspaces/ {
-            # Kube-API
-            auth_request /oauth2/auth;
-
-            rewrite /api/k8s/workspaces/.+?/(.+) /$1 break;
-            proxy_pass https://kubernetes.default.svc;
-            proxy_read_timeout 30m;
-            include /mnt/nginx-generated-config/auth.conf;
-        }
-
-        location /wss/k8s/workspaces/ {
-            auth_request /oauth2/auth;
-
-            rewrite /wss/k8s/workspaces/.+?/(.+) /$1 break;
-            proxy_pass https://kubernetes.default.svc/;
-            proxy_http_version 1.1;
-            proxy_set_header Upgrade $http_upgrade;
-            proxy_set_header Connection $connection_upgrade;
-            proxy_read_timeout 30m;
-            include /mnt/nginx-generated-config/auth.conf;
-        }
-
         location /api/k8s/ {
             # Kube-API
             auth_request /oauth2/auth;

--- a/components/konflux-ui/production/base/proxy/proxy.yaml
+++ b/components/konflux-ui/production/base/proxy/proxy.yaml
@@ -226,23 +226,6 @@ spec:
           readOnlyRootFilesystem: true
           runAsNonRoot: true
           runAsUser: 1001
-      - image: quay.io/konflux-ci/workspace-manager@sha256:48df30520a766101473e80e7a4abbf59ce06097a5f5919e15075afaa86bd1a2d
-        name: workspace-manager
-        ports:
-          - containerPort: 5000
-            name: web
-            protocol: TCP
-        resources:
-          limits:
-            cpu: 300m
-            memory: 256Mi
-          requests:
-            cpu: 30m
-            memory: 128Mi
-        securityContext:
-          readOnlyRootFilesystem: true
-          runAsNonRoot: true
-          runAsUser: 1001
       - image: quay.io/oauth2-proxy/oauth2-proxy@sha256:3da33b9670c67bd782277f99acadf7026f75b9507bfba2088eb2d497266ef7fc
         name: oauth2-proxy
         env:

--- a/components/konflux-ui/production/kflux-fedora-01/remove-run-as-user-proxy-patch.yaml
+++ b/components/konflux-ui/production/kflux-fedora-01/remove-run-as-user-proxy-patch.yaml
@@ -19,5 +19,3 @@
 
 - op: remove
   path: /spec/template/spec/containers/3/securityContext/runAsUser
-- op: remove
-  path: /spec/template/spec/containers/4/securityContext/runAsUser

--- a/components/konflux-ui/production/kflux-ocp-p01/remove-run-as-user-proxy-patch.yaml
+++ b/components/konflux-ui/production/kflux-ocp-p01/remove-run-as-user-proxy-patch.yaml
@@ -19,6 +19,3 @@
 
 - op: remove
   path: /spec/template/spec/containers/3/securityContext/runAsUser
-
-- op: remove
-  path: /spec/template/spec/containers/4/securityContext/runAsUser

--- a/components/konflux-ui/production/kflux-osp-p01/remove-run-as-user-proxy-patch.yaml
+++ b/components/konflux-ui/production/kflux-osp-p01/remove-run-as-user-proxy-patch.yaml
@@ -19,5 +19,3 @@
 
 - op: remove
   path: /spec/template/spec/containers/3/securityContext/runAsUser
-- op: remove
-  path: /spec/template/spec/containers/4/securityContext/runAsUser

--- a/components/konflux-ui/production/kflux-prd-rh02/remove-run-as-user-proxy-patch.yaml
+++ b/components/konflux-ui/production/kflux-prd-rh02/remove-run-as-user-proxy-patch.yaml
@@ -19,5 +19,3 @@
 
 - op: remove
   path: /spec/template/spec/containers/3/securityContext/runAsUser
-- op: remove
-  path: /spec/template/spec/containers/4/securityContext/runAsUser

--- a/components/konflux-ui/production/kflux-prd-rh03/remove-run-as-user-proxy-patch.yaml
+++ b/components/konflux-ui/production/kflux-prd-rh03/remove-run-as-user-proxy-patch.yaml
@@ -19,5 +19,3 @@
 
 - op: remove
   path: /spec/template/spec/containers/3/securityContext/runAsUser
-- op: remove
-  path: /spec/template/spec/containers/4/securityContext/runAsUser

--- a/components/konflux-ui/production/kflux-rhel-p01/remove-run-as-user-proxy-patch.yaml
+++ b/components/konflux-ui/production/kflux-rhel-p01/remove-run-as-user-proxy-patch.yaml
@@ -19,5 +19,3 @@
 
 - op: remove
   path: /spec/template/spec/containers/3/securityContext/runAsUser
-- op: remove
-  path: /spec/template/spec/containers/4/securityContext/runAsUser

--- a/components/konflux-ui/production/stone-prd-rh01/remove-run-as-user-proxy-patch.yaml
+++ b/components/konflux-ui/production/stone-prd-rh01/remove-run-as-user-proxy-patch.yaml
@@ -19,6 +19,3 @@
 
 - op: remove
   path: /spec/template/spec/containers/3/securityContext/runAsUser
-
-- op: remove
-  path: /spec/template/spec/containers/4/securityContext/runAsUser

--- a/components/konflux-ui/production/stone-prod-p01/remove-run-as-user-proxy-patch.yaml
+++ b/components/konflux-ui/production/stone-prod-p01/remove-run-as-user-proxy-patch.yaml
@@ -19,5 +19,3 @@
 
 - op: remove
   path: /spec/template/spec/containers/3/securityContext/runAsUser
-- op: remove
-  path: /spec/template/spec/containers/4/securityContext/runAsUser

--- a/components/konflux-ui/production/stone-prod-p02/remove-run-as-user-proxy-patch.yaml
+++ b/components/konflux-ui/production/stone-prod-p02/remove-run-as-user-proxy-patch.yaml
@@ -19,6 +19,3 @@
 
 - op: remove
   path: /spec/template/spec/containers/3/securityContext/runAsUser
-
-- op: remove
-  path: /spec/template/spec/containers/4/securityContext/runAsUser


### PR DESCRIPTION
  ## What

  Remove workspace-manager from the production konflux-ui proxy deployment:
  - Removed the workspace-manager sidecar container from the proxy Deployment
  - Removed nginx location blocks for `/api/k8s/registration/`, `/api/k8s/apis/toolchain.dev.openshift.com/v1alpha1/workspaces`, `/api/k8s/workspaces/` and `/wss/k8s/workspaces/`
  - Removed the workspace-manager image override from the kustomization

  Clusters affected: all production clusters consuming `production/base/` — kflux-fedora-01, kflux-ocp-p01, kflux-osp-p01, kflux-prd-rh02, kflux-prd-rh03, kflux-rhel-p01, stone-prd-rh01, stone-prod-p01, stone-prod-p02

  [KFLUXVNGD-1199](https://redhat.atlassian.net/browse/KFLUXVNGD-1199)

  ## Why

  workspace-manager has been completely replaced by namespace-lister and is no longer in use. The registration and workspaces endpoints it served are unused.

  ## Validation

  - `kustomize build` passes for `components/konflux-ui/production/base/` with no workspace-manager references in the output
  - workspace-manager proxy location blocks were removed from staging in https://github.com/redhat-appstudio/infra-deployments/pull/5891 (March 2025) with no issues
  - Staging image override cleanup: https://github.com/redhat-appstudio/infra-deployments/pull/13439

  ## Risk Assessment

  **Risk Level:** Low
  **What could go wrong:** Clients still calling `/api/k8s/registration/` or `/api/k8s/apis/toolchain.dev.openshift.com/v1alpha1/workspaces` will receive 404s from nginx instead of proxied responses.
  **Rollback:** Revert PR
  **Blast radius:** All 9 production clusters (change is in `production/base/`)

[KFLUXVNGD-1199]: https://redhat.atlassian.net/browse/KFLUXVNGD-1199?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ