### PR TITLE
reduce the maximum concurrent PLRs on p02

### DIFF
--- a/components/kueue/production/stone-prod-p02/queue-config/cluster-queue.yaml
+++ b/components/kueue/production/stone-prod-p02/queue-config/cluster-queue.yaml
@@ -26,9 +26,9 @@ spec:
     - name: default-flavor
       resources:
       - name: tekton.dev/pipelineruns
-        nominalQuota: '400'
+        nominalQuota: '380'
       - name: konflux-ci-dev-token
-        nominalQuota: '300'
+        nominalQuota: '280'
       - name: cpu
         nominalQuota: 1k
       - name: memory


### PR DESCRIPTION
p02's etcd is under heavy load, we want to reduce the max allowed concurrent PLRs to free some space in etcd.

Signed-off-by: Francesco Ilario <filario@redhat.com>

rh-pre-commit.version: 2.4.0
rh-pre-commit.check-secrets: ENABLED
