### PR TITLE
Revert "KFLUXINFRA-4285: (onboarding) Remove staging kueue apps from AppSRE ArgoCD"

### DIFF
--- a/argo-cd-apps/base/member/infra-deployments/kueue/kueue.yaml
+++ b/argo-cd-apps/base/member/infra-deployments/kueue/kueue.yaml
@@ -18,6 +18,10 @@ spec:
                 clusterDir: empty-base
           - list:
               elements:
+                - nameNormalized: stone-stg-rh01
+                  values.clusterDir: stone-stg-rh01
+                - nameNormalized: stone-stage-p01
+                  values.clusterDir: stone-stage-p01
                 - nameNormalized: stone-prd-rh01
                   values.clusterDir: stone-prd-rh01
                 - nameNormalized: kflux-prd-rh02

--- a/argo-cd-apps/overlays/konflux-public-staging/delete-applications.yaml
+++ b/argo-cd-apps/overlays/konflux-public-staging/delete-applications.yaml
@@ -11,9 +11,3 @@ kind: ApplicationSet
 metadata:
   name: nvme-storage-configurator
 $patch: delete
----
-apiVersion: argoproj.io/v1alpha1
-kind: ApplicationSet
-metadata:
-  name: kueue
-$patch: delete

--- a/argo-cd-apps/overlays/staging-downstream/delete-applications.yaml
+++ b/argo-cd-apps/overlays/staging-downstream/delete-applications.yaml
@@ -17,9 +17,3 @@ kind: ApplicationSet
 metadata:
   name: nvme-storage-configurator
 $patch: delete
----
-apiVersion: argoproj.io/v1alpha1
-kind: ApplicationSet
-metadata:
-  name: kueue
-$patch: delete


### PR DESCRIPTION
Reverts redhat-appstudio/infra-deployments#13394

ArgoCD is tryting to delete Kueue (partially unsuccessful) and re-create it at the same time, causing resources to be "Missing".