### PR TITLE
pipelines: remove unconfigured external secrets from lightwell

### DIFF
--- a/components/pipeline-service/staging/lightwell-dev/deploy.yaml
+++ b/components/pipeline-service/staging/lightwell-dev/deploy.yaml
@@ -2024,56 +2024,6 @@ spec:
     deletionPolicy: Delete
     name: pipelines-as-code-secret
 ---
-apiVersion: external-secrets.io/v1
-kind: ExternalSecret
-metadata:
-  annotations:
-    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
-    argocd.argoproj.io/sync-wave: "-1"
-  name: tekton-chains-public-key
-  namespace: openshift-pipelines
-spec:
-  data:
-  - remoteRef:
-      key: staging/pipeline-service/lightwell-dev/chains-signing-secret
-      property: cosign.pub
-    secretKey: cosign.pub
-  refreshInterval: 5m
-  secretStoreRef:
-    kind: ClusterSecretStore
-    name: appsre-stonesoup-vault
-  target:
-    creationPolicy: Orphan
-    name: public-key
-    template:
-      metadata:
-        annotations:
-          argocd.argoproj.io/sync-options: Prune=false
----
-apiVersion: external-secrets.io/v1
-kind: ExternalSecret
-metadata:
-  annotations:
-    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
-    argocd.argoproj.io/sync-wave: "-1"
-  name: tekton-chains-signing-secret
-  namespace: openshift-pipelines
-spec:
-  dataFrom:
-  - extract:
-      key: staging/pipeline-service/lightwell-dev/chains-signing-secret
-  refreshInterval: 5m
-  secretStoreRef:
-    kind: ClusterSecretStore
-    name: appsre-stonesoup-vault
-  target:
-    creationPolicy: Orphan
-    name: signing-secrets
-    template:
-      metadata:
-        annotations:
-          argocd.argoproj.io/sync-options: Prune=false
----
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:

--- a/components/pipeline-service/staging/lightwell-dev/resources/kustomization.yaml
+++ b/components/pipeline-service/staging/lightwell-dev/resources/kustomization.yaml
@@ -3,13 +3,23 @@ kind: Kustomization
 resources:
   - ../../base
 patches:
-  - path: tekton-chains-public-key-path.yaml
+  - patch: |
+      $patch: delete
+      apiVersion: external-secrets.io/v1
+      kind: ExternalSecret
+      metadata:
+        name: tekton-chains-public-key
     target:
       name: tekton-chains-public-key
       group: external-secrets.io
       version: v1
       kind: ExternalSecret
-  - path: tekton-chains-signing-secret-path.yaml
+  - patch: |
+      $patch: delete
+      apiVersion: external-secrets.io/v1
+      kind: ExternalSecret
+      metadata:
+        name: tekton-chains-signing-secret
     target:
       name: tekton-chains-signing-secret
       group: external-secrets.io


### PR DESCRIPTION
The signing keys for the lightwell dev cluster have not been configured yet, which is blocking both the pipelines service and dependencies relying on tekton CRDs from deploying to the cluster.  Until these secrets have been set up correctly, remove them from the pipelines deployment.

Fixes: [KFLUXINFRA-4409](https://redhat.atlassian.net/browse/KFLUXINFRA-4409)

[KFLUXINFRA-4409]: https://redhat.atlassian.net/browse/KFLUXINFRA-4409?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ