### PR TITLE
Update CatalogSource image to 5.0.5-871 in dev/staging

### DIFF
--- a/components/pipeline-service/development/main-pipeline-service-configuration.yaml
+++ b/components/pipeline-service/development/main-pipeline-service-configuration.yaml
@@ -2244,7 +2244,7 @@ metadata:
   namespace: openshift-marketplace
 spec:
   displayName: custom-operators
-  image: quay.io/openshift-pipeline/pipelines-index-4.19@sha256:bd598786408b16bc1171c79907db124013189d57677e8bfbec1feccc55523ccd
+  image: quay.io/openshift-pipeline/pipelines-index-4.19@sha256:8c6152d2924f608960a4cec0faca33a1807bce19085e86d1daeeaa698fce146d
   sourceType: grpc
   updateStrategy:
     registryPoll:

--- a/components/pipeline-service/staging/base/main-pipeline-service-configuration.yaml
+++ b/components/pipeline-service/staging/base/main-pipeline-service-configuration.yaml
@@ -2088,7 +2088,7 @@ metadata:
   namespace: openshift-marketplace
 spec:
   displayName: custom-operators
-  image: quay.io/openshift-pipeline/pipelines-index-4.19@sha256:bd598786408b16bc1171c79907db124013189d57677e8bfbec1feccc55523ccd
+  image: quay.io/openshift-pipeline/pipelines-index-4.19@sha256:8c6152d2924f608960a4cec0faca33a1807bce19085e86d1daeeaa698fce146d
   sourceType: grpc
   updateStrategy:
     registryPoll:

--- a/components/pipeline-service/staging/lightwell-dev/deploy.yaml
+++ b/components/pipeline-service/staging/lightwell-dev/deploy.yaml
@@ -2597,7 +2597,7 @@ metadata:
   namespace: openshift-marketplace
 spec:
   displayName: custom-operators
-  image: quay.io/openshift-pipeline/pipelines-index-4.19@sha256:bd598786408b16bc1171c79907db124013189d57677e8bfbec1feccc55523ccd
+  image: quay.io/openshift-pipeline/pipelines-index-4.19@sha256:8c6152d2924f608960a4cec0faca33a1807bce19085e86d1daeeaa698fce146d
   sourceType: grpc
   updateStrategy:
     registryPoll:

--- a/components/pipeline-service/staging/stone-stage-p01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stage-p01/deploy.yaml
@@ -2676,7 +2676,7 @@ metadata:
   namespace: openshift-marketplace
 spec:
   displayName: custom-operators
-  image: quay.io/openshift-pipeline/pipelines-index-4.19@sha256:bd598786408b16bc1171c79907db124013189d57677e8bfbec1feccc55523ccd
+  image: quay.io/openshift-pipeline/pipelines-index-4.19@sha256:8c6152d2924f608960a4cec0faca33a1807bce19085e86d1daeeaa698fce146d
   sourceType: grpc
   updateStrategy:
     registryPoll:

--- a/components/pipeline-service/staging/stone-stg-rh01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stg-rh01/deploy.yaml
@@ -2688,7 +2688,7 @@ metadata:
   namespace: openshift-marketplace
 spec:
   displayName: custom-operators
-  image: quay.io/openshift-pipeline/pipelines-index-4.19@sha256:bd598786408b16bc1171c79907db124013189d57677e8bfbec1feccc55523ccd
+  image: quay.io/openshift-pipeline/pipelines-index-4.19@sha256:8c6152d2924f608960a4cec0faca33a1807bce19085e86d1daeeaa698fce146d
   sourceType: grpc
   updateStrategy:
     registryPoll:


### PR DESCRIPTION
Update CatalogSource image from pipelines-index-4.18 (5.0.5-854) to pipelines-index-4.19 (5.0.5-871) across dev and staging environments.

**Files changed**
- components/pipeline-service/development/main-pipeline-service-configuration.yaml
- components/pipeline-service/staging/base/main-pipeline-service-configuration.yaml
- components/pipeline-service/staging/stone-stage-p01/deploy.yaml
- components/pipeline-service/staging/stone-stg-rh01/deploy.yaml
- components/pipeline-service/staging/lightwell-dev/deploy.yaml

**Clusters affected:** development, staging (stone-stage-p01, stone-stg-rh01, lightwell-dev)
## Changelog (854 → 871)

  **Old:** `5.0.5-854` (`sha256:bd598786408b16bc1171c79907db124013189d57677e8bfbec1feccc55523ccd`)
  **New:** `5.0.5-871` (`sha256:8c6152d2924f608960a4cec0faca33a1807bce19085e86d1daeeaa698fce146d`)


  ### Component Summary

  | Component | 854 Version | 871 Version | Change |
  |-----------|------------|------------|--------|
  | Pipeline | v1.14.0 | v1.15.0 | minor bump (LTS) |
  | PAC | v0.49.0 | v0.50.0 | minor bump |
  | Triggers | v0.36.0 | v0.37.0 | minor bump |
  | Chains | v0.28.0 | v0.29.0 | minor bump |
  | Operator | post-v0.80.0 | post-v0.81.0 | +68 commits |
  | Manual Approval Gate | v0.9.0 | v0.9.0 | unchanged |
  | Pruner | v0.4.1 | v0.4.1 | unchanged |
  | Scheduler | v0.3.1 | v0.3.1 | unchanged |

  ### Pipeline (v1.14.0 → v1.15.0, LTS, +84 commits)
  [Full changelog](https://github.com/tektoncd/pipeline/compare/aa28e09810a679c1282095ae604afb1f5488e162...7289f7d7e1ee24cbc84a58b9f763e3869db8ab2e)

  **New Features:**
  - `1e86b7bd` Add configuration for custom git resolver backoff
  - `2e5237bd` Configurable grace period for transient CreateContainerError
  - `cedd162f` Informer cache transform to reduce controller memory usage

  **Bug Fixes:**
  - `c0856cf9` Fix sidecar-logs result extraction for results exceeding 4096 bytes (regression since v1.9.0)
  - `f60dfb33` Fix PipelineRun stuck in ResolvingTaskRef when resolution event is missed
  - `bd30dfea` Fix resolvers not honoring leader-election bucket ownership
  - `7ebcc10d` Preserve resolver-written status fields on ResolutionRequests
  - `09b2aa7e` Prevent matrix combination count integer overflow
  - `2952a154` Preserve Sidecar RestartPolicy on v1beta1/v1 API conversion
  - `4d090f09` Fix RestrictLength panic on all-symbol generateName input
  - `4dd60814` Fix PipelineRun label fallback for empty generated name

  **Security:**
  - `70f73081` Mount debug scripts read-only in step containers

  ### PAC (v0.49.0 → v0.50.0, +67 commits)
  [Full changelog](https://github.com/openshift-pipelines/pipelines-as-code/compare/25d6710721897afddda94e405c82b87a117629a1...7f1e477780fce126880b07821d10088441dcf8d3)

  **New Features:**
  - `a5b91554` Bitbucket Cloud HMAC webhook secret validation
  - `ad2dcdb2` AI code review ("Paco") — triggered by `/paco review` or `/paco summary`
  - `619e4261` Read-only queue debug endpoint on the watcher
  - `6e3f736a` Capture container creation error messages in logs
  - `19a8c899` Validate GitHub comment strategy setting on Repository CR

  **Bug Fixes:**
  - `612cd113` Concurrency queue: keep the queue in sync with the cluster
  - `03ef45f9` Concurrency queue: guard queueMap access and drop dead semaphore code
  - `9b243d45` Concurrency queue: release the slot only once the run started
  - `e270e68e` GitLab: verify secret write access before rotating token
  - `6f0098b4` GitLab: pin source lookups to event SHA instead of mutable branch ref
  - `b328e04d` GitLab: handle branch creation without commits
  - `d92a9a63` GitHub: query check runs for `/retest` — now only re-runs failed pipelines
  - `e264d7a7` GitHub: recover fork PR re-runs when GitHub omits PR metadata
  - `f6a39168` Gitea: check write/admin permission instead of collaborator only
  - `5106a0e9` Gitea: guard nil content in GetFileInsideRepo to avoid panic
  - `9a630518` Expose metrics port 9090 for webhook deployment

  **Security:**
  - `4b342600` CVE-2026-33211 — path traversal in Tekton Pipelines git resolver
  - `912f4e6b` CVE-2026-42505 — crypto/tls ECH privacy leak (Go 1.26.5)

  ### Chains (v0.28.0 → v0.29.0, +32 commits)
  [Full changelog](https://github.com/tektoncd/chains/compare/6221c79e40a423cb2e39b84a7d3605383cd4ea87...01d9ebfdae7a02247b1b00f48e44dd63d8a611ec)

  **New Feature:**
  - `b5ecaf77` OCI 1.1 Referrers API support with sigstore-bundle format

  **Bug Fixes:**
  - `c7e0b42c` Fix TaskRuns stuck blocked from deletion due to old chains finaliser
  - `c52f167f` x509: return errors instead of panicking on unusable key material
  - `1475ad98` Aggregate per-artifact signing failures — `signed` annotation no longer set on partial failure
  - `dbcab312` Add writable volume for TUF cache in distroless container
  - `c838c498` Forward RekorEntry to signature bundle in sigstore-bundle mode
  - `71e8d5d1` Capture remote StepAction source in SLSA provenance resolvedDependencies

  ### Triggers (v0.36.0 → v0.37.0, +38 commits)
  [Full changelog](https://github.com/tektoncd/triggers/compare/bf95a60db160515b64454054ace1a0b725803c14...72d276a2174023d0db81db9ee84bd18e2874da3b)

  **Bug Fixes:**
  - `a79a9d5f` Don't pre-parse URL-encoded body for webhook-first interceptor chains
  - `5f03353e` Preserve extensions merging and log formatting in webhook-first path

  ### Operator (post-v0.80.0 → post-v0.81.0, +68 commits)
  [Full changelog](https://github.com/tektoncd/operator/compare/f5445c37125e874fc1b0abb23cf46c8321788f1a...6a5b57b302528874834bb6ec21f904475566873c)

  **NetworkPolicy support (major):**
  - `8c09af1e` Operator namespace
  - `dd17bc53` Pipeline proxy-webhook
  - `96d43700` Pipeline core components
  - `a17fd6e2` Console plugin
  - `80317057` Pipelines-as-Code
  - `f6581cae` Chains controller
  - `0f2f9882` Results
  - `8469f33f` Pruner controller and webhook
  - `602531e9` Manual Approval Gate
  - `b3aa987e` MultiCluster components

  **New Features:**
  - `717e5f8d` mTLS for Prometheus metrics
  - `a6a5d44f` Gate metrics mTLS behind `enableMetricsMTLS` flag
  - `d64b59c7` Rollout strategy support via `options` field
  - `41807c8c` Expose Tekton Results Watcher config via TektonConfig CR
  - `6b64911f` Expose Chains `storage.oci.encoding-format` in CRD
  - `ec540d6c` Full openAPIV3Schema for pruner, scheduler, and networkpolicy configs ([RFE-9431](https://redhat.atlassian.net/browse/RFE-9431))

  **Bug Fixes:**
  - `4ccfee36` Prevent Chains and Results installation on lite profile
  - `a1d3f96a` Skip dying InstallerSet and fix StatefulSet readiness backoff (lite→basic)
  - `3d84a8a4` Make `TEKTON_REGISTRY_OVERRIDE` apply to all images
  - `f2ce2e45` Make `TektonConfig spec.hub.options` optional
  - `306a272e` Propagate config to StatefulSets
  - `60c1c15a` Keep `prune-per-resource=false` in spec
  - `aadfe5a2` Stop logging normal requeue events as errors
  - `0becb4fc` Recreate deployment on selector change
  - `f8b53f8a` Fix proxy-webhook selector matching operator pods

  **Security:**
  - `19d139ab` CVE-2026-56852 — golang.org/x/text update


  ## Validation

  - Pick up the latest next index build (5.0.5-871) with significant component upgrades — Pipeline v1.14→v1.15
  (LTS), PAC v0.49→v0.50, Triggers v0.36→v0.37, Chains v0.28→v0.29.
  - Konflux build succeeded (build + EC test passed) — [snapshot](https://konflux-ui.apps.kflux-prd-rh02.0fk9.p1.openshiftapps.com/ns/tekton-ecosystem-tenant/applications/openshift-pipelines-index-4-19-next/snapshots/openshift-pipelines-index-4-19-next-20260811-144905-000) `openshift-pipelines-index-4-19-next-20260811-144905-000`
  - Tenant release PLR succeeded (image mirrored to quay.io/openshift-pipeline/pipelines-index-4.19, 4-arch
  manifest: amd64, arm64, ppc64le, s390x)
  - osp-index-info validation: 44/44 images reachable and valid (all images pullable, no missing metadata)
  - All component upstream SHAs verified against expected versions:
    - Pipeline: `7289f7d7` (tektoncd/pipeline) ✓
    - Triggers: `72d276a2` (tektoncd/triggers) ✓
    - Chains: `01d9ebfd` (tektoncd/chains) ✓
    - PAC: `7f1e4777` (tektoncd/pipelines-as-code) ✓
    - Operator: `6a5b57b3` (tektoncd/operator) ✓
  - No override images in this build

[RFE-9431]: https://redhat.atlassian.net/browse/RFE-9431?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ