### PR TITLE
Add standalone playbook for Tekton Chains key creation

### DIFF
--- a/hack/new-cluster/README.md
+++ b/hack/new-cluster/README.md
@@ -65,3 +65,35 @@ The playbook attempts to determine the correct version of some services by inspe
 ```
 ❯ ansible-playbook hack/new-cluster/playbook.yaml -e 'commit_id_multi_platform_controller=ec950d0cfb87bcfd6e3a79fc2b5ee40989126123 commit_id_build_definitions=ab6b0b8e40e440158e7288c73aff1cf83a2cc8a9 commit_id_tektoncd_results_for_konflux=425fcd0988b50965139238038e0d3bd3cb4f8bbc commit_id_pipeline_service_exporter=9d2439c8a77d2ce0527cc5aea3fc6561b7671b48'
 ```
+
+## Standalone: Create a Tekton Chains signing key
+
+If you only need to create (or verify) a Tekton Chains cosign signing key in Vault — without running the full new-cluster playbook — use `chains-key-playbook.yaml`.
+
+### Prerequisites
+
+* ansible CLI
+* vault CLI
+* cosign (`go install github.com/sigstore/cosign/v2/cmd/cosign@latest`)
+* VPN connection
+
+### Usage
+
+```
+❯ ansible-playbook hack/new-cluster/chains-key-playbook.yaml \
+    -e 'vault_secret_path=staging/pipeline-service/lightwell-dev/chains-signing-secret'
+```
+
+Or interactively (the playbook will prompt for the path):
+
+```
+❯ ansible-playbook hack/new-cluster/chains-key-playbook.yaml
+```
+
+The `vault_secret_path` is relative to the `stonesoup/` Vault KV mount. The playbook will:
+
+1. Log in to Vault via OIDC
+2. Check if the secret already exists (skip if it does)
+3. Generate a cosign keypair with a random password
+4. Store `cosign.password`, `cosign.key`, and `cosign.pub` in Vault
+5. Verify the secret and clean up local files

--- a/hack/new-cluster/chains-key-playbook.yaml
+++ b/hack/new-cluster/chains-key-playbook.yaml
@@ -1,0 +1,92 @@
+---
+# Standalone playbook to create a Tekton Chains signing key and store it in Vault.
+#
+# Usage:
+#   ansible-playbook hack/new-cluster/chains-key-playbook.yaml \
+#     -e 'vault_secret_path=staging/pipeline-service/lightwell-dev/chains-signing-secret'
+#
+
+- name: Create Tekton Chains signing key
+  hosts: localhost
+  gather_facts: no
+
+  vars_prompt:
+    - name: vault_secret_path
+      prompt: "Vault secret path (e.g. staging/pipeline-service/lightwell-dev/chains-signing-secret)"
+      private: false
+
+  vars:
+    vault_addr: "https://vault.devshift.net"
+
+  pre_tasks:
+    - name: Ensure vault_secret_path is defined
+      fail:
+        msg: "Required variable 'vault_secret_path' has not been provided"
+      when: vault_secret_path is undefined or vault_secret_path == ''
+
+  tasks:
+    - name: Login to vault
+      include_tasks: tasks/vault/login.yaml
+
+    - name: Check if the chains signing secret is already present
+      command: >
+        vault kv metadata get stonesoup/{{ vault_secret_path }}
+      register: check_result
+      environment:
+        VAULT_ADDR: "{{ vault_addr }}"
+        VAULT_TOKEN: "{{ vault_token }}"
+      changed_when: false
+      failed_when: "check_result.rc not in [0, 2]"
+
+    - name: Generate a random password
+      when: "check_result.rc == 2"
+      command: openssl rand -base64 30
+      register: password
+
+    - name: Make sure no cosign files are present
+      file:
+        path: "{{ item }}"
+        state: absent
+      when: "check_result.rc == 2"
+      loop: [cosign.key, cosign.pub]
+
+    - name: Generate cosign keypair
+      when: "check_result.rc == 2"
+      command: cosign generate-key-pair
+      environment:
+        COSIGN_PASSWORD: "{{ password.stdout }}"
+
+    - name: Insert into vault
+      when: "check_result.rc == 2"
+      command: >
+        vault kv put stonesoup/{{ vault_secret_path }}
+          cosign.password={{ password.stdout }}
+          cosign.key=@cosign.key
+          cosign.pub=@cosign.pub
+      environment:
+        VAULT_ADDR: "{{ vault_addr }}"
+        VAULT_TOKEN: "{{ vault_token }}"
+
+    - name: Verify that it is in place
+      command: >
+        vault kv metadata get stonesoup/{{ vault_secret_path }}
+      environment:
+        VAULT_ADDR: "{{ vault_addr }}"
+        VAULT_TOKEN: "{{ vault_token }}"
+      when: "check_result.rc == 2"
+      changed_when: false
+
+    - name: Clean up local cosign files
+      file:
+        path: "{{ item }}"
+        state: absent
+      when: "check_result.rc == 2"
+      loop: [cosign.key, cosign.pub]
+
+    - name: Report result
+      debug:
+        msg: >
+          {{ (check_result.rc == 2) | ternary(
+            'Created chains signing secret at stonesoup/' + vault_secret_path,
+            'Chains signing secret already exists at stonesoup/' + vault_secret_path + ' - skipped')
+          }}


### PR DESCRIPTION
## What

- Add `hack/new-cluster/chains-key-playbook.yaml` — a standalone playbook that creates a Tekton Chains cosign signing keypair and stores it in Vault at a user-specified path
- Update `hack/new-cluster/README.md` with usage instructions for the new playbook

## Why

The full `playbook.yaml` requires many variables and runs numerous steps (GitHub app creation, ApplicationSet patching, component overlay generation). When you only need to provision a chains signing key for a new or existing cluster path, a lightweight standalone playbook avoids unnecessary complexity.

## Validation

- `ansible-playbook --syntax-check hack/new-cluster/chains-key-playbook.yaml` passes
- README updated with prerequisites and usage examples


Made with [Cursor](https://cursor.com)