### PR TITLE
chore: restore konflux-provided pipelines

### DIFF
--- a/components/konflux-operator/rings/ring-1/base/cr/build/build-service.yaml
+++ b/components/konflux-operator/rings/ring-1/base/cr/build/build-service.yaml
@@ -5,6 +5,16 @@ metadata:
 spec:
   buildService:
     spec:
+      pipelineConfig:
+        # docker-build-oci-ta is defined upstream, but it's not the default there.
+        defaultPipelineName: docker-build-oci-ta
+        pipelines:
+          - name: docker-build-multi-platform-oci-ta
+            bundle: quay.io/konflux-ci/tekton-catalog/pipeline-docker-build-multi-platform-oci-ta:devel
+            description: "Build multi-platform container images with secure data transfer for the pipelines"
+          - name: maven-zip-build-oci-ta
+            bundle: quay.io/konflux-ci/tekton-catalog/pipeline-maven-zip-build-oci-ta:devel
+            description: "Build maven zip OCI artifacts"
       buildControllerManager:
         replicas: 1
         manager:


### PR DESCRIPTION
Moving to the operator, the upstream deployment only embeds a subset of the pipelines that were defined in the legacy deployment. This change introduces the missing pipelines to clusters using the operator.

Assisted-by: Cursor