### PR TITLE
fix(KFLUXVNGD-1234):Add knative-eventing deployment for lightwell-dev staging cluster

### DIFF
--- a/argo-cd-apps/base/member/infra-deployments/knative-eventing/knative-eventing.yaml
+++ b/argo-cd-apps/base/member/infra-deployments/knative-eventing/knative-eventing.yaml
@@ -20,6 +20,8 @@ spec:
                   values.clusterDir: stone-stage-p01
                 - nameNormalized: stone-stg-rh01
                   values.clusterDir: stone-stg-rh01
+                - nameNormalized: lightwell-dev
+                  values.clusterDir: lightwell-dev
                 # Private
                 - nameNormalized: kflux-ocp-p01
                   values.clusterDir: kflux-ocp-p01

--- a/components/knative-eventing/staging/lightwell-dev/kustomization.yaml
+++ b/components/knative-eventing/staging/lightwell-dev/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base


### PR DESCRIPTION
The knative-eventing ApplicationSet defaults to clusterDir "base" which has no corresponding directory, causing the knative-eventing-lightwell-dev application to fail with "app path does not exist". Add lightwell-dev to the per-cluster list and create its staging overlay referencing the shared base, matching the pattern used by stone-stage-p01.

Assisted-by: Cursor + Opus4.6