### PR TITLE
feat(KFLUXVNGD-1235): Enable Kyverno and policies for lightwell-dev staging cluster

### DIFF
--- a/argo-cd-apps/base/member/infra-deployments/kyverno/kyverno.yaml
+++ b/argo-cd-apps/base/member/infra-deployments/kyverno/kyverno.yaml
@@ -19,6 +19,8 @@ spec:
                   values.clusterDir: stone-stg-rh01
                 - nameNormalized: stone-stage-p01
                   values.clusterDir: stone-stage-p01
+                - nameNormalized: lightwell-dev
+                  values.clusterDir: lightwell-dev
                 - nameNormalized: stone-prd-rh01
                   values.clusterDir: stone-prd-rh01
                 - nameNormalized: kflux-prd-rh02

--- a/argo-cd-apps/base/member/infra-deployments/policies/policies.yaml
+++ b/argo-cd-apps/base/member/infra-deployments/policies/policies.yaml
@@ -19,6 +19,8 @@ spec:
                   values.clusterDir: stone-stg-rh01
                 - nameNormalized: stone-stage-p01
                   values.clusterDir: stone-stage-p01
+                - nameNormalized: lightwell-dev
+                  values.clusterDir: lightwell-dev
                 - nameNormalized: stone-prd-rh01
                   values.clusterDir: stone-prd-rh01
                 - nameNormalized: kflux-prd-rh02

--- a/components/kyverno/staging/lightwell-dev/job_resources.yaml
+++ b/components/kyverno/staging/lightwell-dev/job_resources.yaml
@@ -1,0 +1,10 @@
+---
+- op: add
+  path: /spec/template/spec/containers/0/resources
+  value:
+    requests:
+      cpu: 100m
+      memory: 256M
+    limits:
+      cpu: 400m
+      memory: 256M

--- a/components/kyverno/staging/lightwell-dev/kustomization.yaml
+++ b/components/kyverno/staging/lightwell-dev/kustomization.yaml
@@ -1,0 +1,33 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: konflux-kyverno
+
+generators:
+- kyverno-helm-generator.yaml
+
+images:
+  - name: reg.kyverno.io/kyverno/kyverno
+    newName: quay.io/konflux-ci/kyverno/kyverno
+    newTag: 98fb01cc292a1089bb92e1de884e534e21b671fe
+  - name: reg.kyverno.io/kyverno/kyvernopre
+    newName: quay.io/konflux-ci/kyverno/kyverno-init
+    newTag: 98fb01cc292a1089bb92e1de884e534e21b671fe
+  - name: reg.kyverno.io/kyverno/background-controller
+    newName: quay.io/konflux-ci/kyverno/kyverno-background
+    newTag: 98fb01cc292a1089bb92e1de884e534e21b671fe
+  - name: reg.kyverno.io/kyverno/cleanup-controller
+    newName: quay.io/konflux-ci/kyverno/kyverno-cleanup
+    newTag: 98fb01cc292a1089bb92e1de884e534e21b671fe
+  - name: reg.kyverno.io/kyverno/kyverno-cli
+    newName: quay.io/konflux-ci/kyverno/kyverno-cli
+    newTag: 98fb01cc292a1089bb92e1de884e534e21b671fe
+
+# set resources to jobs
+patches:
+- path: job_resources.yaml
+  target:
+    group: batch
+    kind: Job
+    name: konflux-kyverno-migrate-resources
+    version: v1

--- a/components/kyverno/staging/lightwell-dev/kyverno-helm-generator.yaml
+++ b/components/kyverno/staging/lightwell-dev/kyverno-helm-generator.yaml
@@ -1,0 +1,11 @@
+apiVersion: builtin
+kind: HelmChartInflationGenerator
+metadata:
+  name: kyverno
+name: kyverno
+repo: https://kyverno.github.io/kyverno/
+version: 3.5.2
+namespace: konflux-kyverno
+valuesFile: kyverno-helm-values.yaml
+releaseName: kyverno
+skipTests: true

--- a/components/kyverno/staging/lightwell-dev/kyverno-helm-values.yaml
+++ b/components/kyverno/staging/lightwell-dev/kyverno-helm-values.yaml
@@ -1,0 +1,139 @@
+fullnameOverride: konflux-kyverno
+namespaceOverride: konflux-kyverno
+config:
+  preserve: false
+admissionController:
+  replicas: 3
+  initContainer:
+    resources:
+      requests:
+        cpu: 100m
+        memory: 256Mi
+      limits:
+        cpu: 100m
+        memory: 256Mi
+    securityContext:
+      allowPrivilegeEscalation: false
+      readOnlyRootFilesystem: true
+      runAsNonRoot: true
+      capabilities:
+        drop:
+        - "ALL"
+  container:
+    extraArgs:
+      leaderElectionRetryPeriod: 26s
+    resources:
+      requests:
+        cpu: 1000m
+        memory: 1Gi
+      limits:
+        cpu: 1000m
+        memory: 1Gi
+    securityContext:
+      allowPrivilegeEscalation: false
+      readOnlyRootFilesystem: true
+      runAsNonRoot: true
+      capabilities:
+        drop:
+        - "ALL"
+  metering:
+    disabled: false
+  podDisruptionBudget:
+    enabled: true
+    maxUnavailable: 2
+    minAvailable: null
+    unhealthyPodEvictionPolicy: AlwaysAllow
+  serviceMonitor:
+    enabled: true
+    # kyverno doesn't seem to support HTTPS on metrics
+    secure: false
+backgroundController:
+  replicas: 3
+  extraArgs:
+    leaderElectionRetryPeriod: 26s
+  resources:
+    requests:
+      cpu: 4000m
+      memory: 1Gi
+    limits:
+      cpu: 4000m
+      memory: 1Gi
+  securityContext:
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: true
+    runAsNonRoot: true
+    capabilities:
+      drop:
+      - "ALL"
+  metering:
+    disabled: false
+  podDisruptionBudget:
+    enabled: true
+    maxUnavailable: 2
+    minAvailable: null
+    unhealthyPodEvictionPolicy: AlwaysAllow
+  serviceMonitor:
+    enabled: true
+    # kyverno doesn't seem to support HTTPS on metrics
+    secure: false
+cleanupController:
+  replicas: 3
+  extraArgs:
+    leaderElectionRetryPeriod: 26s
+  resources:
+    requests:
+      cpu: 500m
+      memory: 256Mi
+    limits:
+      cpu: 500m
+      memory: 256Mi
+  securityContext:
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: true
+    runAsNonRoot: true
+    capabilities:
+      drop:
+      - "ALL"
+  metering:
+    disabled: false
+  podDisruptionBudget:
+    enabled: true
+    maxUnavailable: 2
+    minAvailable: null
+    unhealthyPodEvictionPolicy: AlwaysAllow
+  serviceMonitor:
+    enabled: true
+    # kyverno doesn't seem to support HTTPS on metrics
+    secure: false
+reportsController:
+  enabled: false
+policyReportsCleanup:
+  enabled: false
+webhooksCleanup:
+  enabled: false
+crds:
+  migration:
+    securityContext:
+      allowPrivilegeEscalation: false
+      readOnlyRootFilesystem: true
+      runAsNonRoot: true
+      runAsGroup: null
+      runAsUser: null
+      capabilities:
+        drop:
+        - "ALL"
+features:
+  admissionReports:
+    enabled: false
+  aggregateReports:
+    enabled: false
+  policyReports:
+    enabled: false
+  validatingAdmissionPolicyReports:
+    enabled: false
+  reporting:
+    validate: false
+    mutate: false
+    mutateExisting: false
+    imageVerify: false
+    generate: false

--- a/components/policies/staging/lightwell-dev/kustomization.yaml
+++ b/components/policies/staging/lightwell-dev/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../base/
+- ../policies/kubearchive/
+- ../policies/kueue/


### PR DESCRIPTION
Deploy Kyverno admission policy engine and Konflux policies to the lightwell-dev staging cluster. These are prerequisites for Kueue, which requires admission control policies to manage workload queuing and resource sharing for AI/ML jobs.

Changes:
- Add Kyverno Helm-based deployment overlay for lightwell-dev (components/kyverno/staging/lightwell-dev/) matching the existing stone-stage-p01 configuration (3 replicas, security hardening, reporting disabled, PDBs enabled)
- Add policies overlay for lightwell-dev (components/policies/staging/lightwell-dev/) including base, kubearchive, and kueue policies
- Register lightwell-dev in the Kyverno and policies ApplicationSets so ArgoCD targets the cluster

## Risk - None (@gbenhaim)
Revert this change by reverting the commit. this change is only changing the lightwell-dev cluster.

Assisted-by: Cursor + Opus4.6