### PR TITLE
KFLUXINFRA-4238: Migrate repository-validator to ring deployments ArgoCD

### DIFF
--- a/.github/workflows/forbid-clusterpolicies.yaml
+++ b/.github/workflows/forbid-clusterpolicies.yaml
@@ -33,7 +33,9 @@ jobs:
             ! -path 'components/policies/*' \
             ! -path 'components/repository-validator/staging/*' \
             ! -path 'components/repository-validator/production/*' \
+            ! -path 'components/repository-validator/rings/ring-1/*' \
             ! -path 'components/monitoring/blackbox/staging/*' \
             ! -path 'components/monitoring/blackbox/production/*' \
+            ! -path 'components/*/rings/*/base/external-repo/*' \
             | \
             xargs -I {} -n1 -P8  bash -c './hack/forbid-clusterpolicies.sh $(dirname "{}")'

--- a/.github/workflows/kube-linter.yaml
+++ b/.github/workflows/kube-linter.yaml
@@ -34,12 +34,13 @@ jobs:
             ! -path '*konflux-operator/rings/*/base/cr/*' \
             ! -path 'components/repository-validator/staging/*' \
             ! -path 'components/repository-validator/production/*' \
+            ! -path 'components/repository-validator/rings/ring-1/*' \
             ! -path 'components/monitoring/blackbox/staging/*' \
             ! -path 'components/monitoring/blackbox/production/*' \
             ! -path 'components/*/chainsaw/*' \
             ! -path 'components/etcd-shield/base/*' \
             ! -path 'components/kueue-rd/base/*' \
-            ! -path 'components/kueue-rd/rings/*/base/external-repo/*' \
+            ! -path 'components/*/rings/*/base/external-repo/*' \
             ! -path 'components/*/rings/*/base/base-snapshot/*' \
             | \
             xargs -I {} -n1 -P8  bash -c 'dir=$(dirname "{}"); output_file=$(echo "$dir" | tr / -)-kustomization.yaml; ./hack/kustomize-build-with-retry.sh "$dir" -o "kustomizedfiles/$output_file"'

--- a/argo-cd-apps/overlays/rd-staging/kustomization.yaml
+++ b/argo-cd-apps/overlays/rd-staging/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
   - etcd-shield
   - konflux-operator
   - kueue
+  - repository-validator
 
 components:
   - ../../k-components/deploy-to-all-staging-clusters

--- a/argo-cd-apps/overlays/rd-staging/repository-validator/kustomization.yaml
+++ b/argo-cd-apps/overlays/rd-staging/repository-validator/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - repository-validator-appset.yaml

--- a/argo-cd-apps/overlays/rd-staging/repository-validator/repository-validator-appset.yaml
+++ b/argo-cd-apps/overlays/rd-staging/repository-validator/repository-validator-appset.yaml
@@ -1,0 +1,56 @@
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: repository-validator
+  labels: # Helps k-components detect this appset to apply the correct patches
+    appstudio.redhat.com/deployment-clusters: "tenant"
+spec:
+  generators:
+    - merge:
+        mergeKeys:
+          - nameNormalized
+        generators:
+          - clusters:
+              selector:
+                matchExpressions: # Ensures that no clusters are selected; k-components will replace this with the correct selector
+                  - key: appstudio.redhat.com/select-none
+                    operator: Exists
+                  - key: appstudio.redhat.com/select-none
+                    operator: DoesNotExist
+              values:
+                sourceRoot: components/repository-validator
+                ring: "empty-base"
+                clusterDir: "empty-base"
+          - list:
+              elements:
+                - nameNormalized: stone-stage-p01
+                  values.ring: ring-1
+                  values.clusterDir: stone-stage-p01
+                - nameNormalized: stone-stg-rh01
+                  values.ring: ring-1
+                  values.clusterDir: stone-stg-rh01
+
+  template:
+    metadata:
+      name: repository-validator-{{nameNormalized}}
+    spec:
+      project: default
+      source:
+        path: '{{values.sourceRoot}}/rings/{{values.ring}}/{{values.clusterDir}}'
+        repoURL: https://github.com/redhat-appstudio/infra-deployments.git
+        targetRevision: main
+      destination:
+        namespace: repository-validator
+        server: '{{server}}'
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
+        syncOptions:
+          - CreateNamespace=false
+        retry:
+          limit: -1
+          backoff:
+            duration: 10s
+            factor: 2
+            maxDuration: 3m

--- a/argo-cd-apps/overlays/staging-downstream/kustomization.yaml
+++ b/argo-cd-apps/overlays/staging-downstream/kustomization.yaml
@@ -16,6 +16,16 @@ patchesStrategicMerge:
   - delete-applications.yaml
 
 patches:
+  - path: preserve-resources-on-deletion.yaml
+    target:
+      kind: ApplicationSet
+      version: v1alpha1
+      name: repository-validator
+  - path: disable-auto-sync.yaml
+    target:
+      kind: ApplicationSet
+      version: v1alpha1
+      name: repository-validator
   - path: staging-downstream-overlay-patch.yaml
     target:
       kind: ApplicationSet

--- a/components/repository-validator/rings/empty-base/empty-base/kustomization.yaml
+++ b/components/repository-validator/rings/empty-base/empty-base/kustomization.yaml
@@ -1,0 +1,3 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources: []

--- a/components/repository-validator/rings/ring-0/base/base-snapshot/kustomization.yaml
+++ b/components/repository-validator/rings/ring-0/base/base-snapshot/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - validating-admission-policy.yaml
+  - validating-admission-policy-binding.yaml

--- a/components/repository-validator/rings/ring-0/base/base-snapshot/namespace.yaml
+++ b/components/repository-validator/rings/ring-0/base/base-snapshot/namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: repository-validator
+  labels:
+    app.kubernetes.io/name: repository-validator
+    app.kubernetes.io/component: admission-policy

--- a/components/repository-validator/rings/ring-0/base/base-snapshot/validating-admission-policy-binding.yaml
+++ b/components/repository-validator/rings/ring-0/base/base-snapshot/validating-admission-policy-binding.yaml
@@ -1,0 +1,24 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: repository-url-validator-binding
+spec:
+  policyName: repository-url-validator
+  validationActions: [Deny, Audit]
+  paramRef:
+    namespace: repository-validator
+    parameterNotFoundAction: Deny
+    selector:
+      matchLabels:
+        app.kubernetes.io/name: repository-validator
+  # Apply to all namespaces except system namespaces
+  matchResources:
+    namespaceSelector:
+      matchExpressions:
+      - key: kubernetes.io/metadata.name
+        operator: NotIn
+        values:
+        - kube-system
+        - kube-public
+        - kube-node-lease
+        - repository-validator

--- a/components/repository-validator/rings/ring-0/base/base-snapshot/validating-admission-policy.yaml
+++ b/components/repository-validator/rings/ring-0/base/base-snapshot/validating-admission-policy.yaml
@@ -1,0 +1,42 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: repository-url-validator
+spec:
+  failurePolicy: Fail
+  paramKind:
+    apiVersion: v1
+    kind: ConfigMap
+  matchConstraints:
+    resourceRules:
+    - apiGroups: ["pipelinesascode.tekton.dev"]
+      apiVersions: ["v1alpha1"]
+      operations: ["CREATE", "UPDATE"]
+      resources: ["repositories"]
+  variables:
+    # Parse the config from the ConfigMap, strip quotes if needed
+    - name: allowedPrefixes
+      expression: |
+        'data' in params && 'config' in params.data ?
+        params.data['config'].split('\n').
+        map(p,p.matches('^".*"$') ? p.substring(1, size(p) - 1) : p) : []
+    # Check if prefix is wildcard (allow-all case)
+    - name: allowAll
+      expression: |
+        size(variables.allowedPrefixes) == 1 &&
+        variables.allowedPrefixes[0] == "*"
+  validations:
+    - expression: |
+        variables.allowAll ||
+        variables.allowedPrefixes.exists(prefix,
+          prefix != "" && object.spec.url.startsWith(prefix)
+        )
+      messageExpression: |
+        'Repository URL "' + object.spec.url +
+        '" is not allowed on this cluster. Contact support.'
+      reason: Forbidden
+  auditAnnotations:
+    - key: "repository-url-validation"
+      valueExpression: |
+        'Repository URL: ' + object.spec.url +
+        ', Allowed prefixes: [' + variables.allowedPrefixes.join(', ') + ']'

--- a/components/repository-validator/rings/ring-0/base/kustomization.yaml
+++ b/components/repository-validator/rings/ring-0/base/kustomization.yaml
@@ -1,7 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ../base
+  - base-snapshot
+
 configMapGenerator:
   - name: config
     literals:
@@ -9,4 +10,5 @@ configMapGenerator:
 generatorOptions:
   labels:
     app.kubernetes.io/name: repository-validator
+
 namespace: repository-validator

--- a/components/repository-validator/rings/ring-1/base/base-snapshot/kustomization.yaml
+++ b/components/repository-validator/rings/ring-1/base/base-snapshot/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - validating-admission-policy.yaml
+  - validating-admission-policy-binding.yaml

--- a/components/repository-validator/rings/ring-1/base/base-snapshot/namespace.yaml
+++ b/components/repository-validator/rings/ring-1/base/base-snapshot/namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: repository-validator
+  labels:
+    app.kubernetes.io/name: repository-validator
+    app.kubernetes.io/component: admission-policy

--- a/components/repository-validator/rings/ring-1/base/base-snapshot/validating-admission-policy-binding.yaml
+++ b/components/repository-validator/rings/ring-1/base/base-snapshot/validating-admission-policy-binding.yaml
@@ -1,0 +1,24 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: repository-url-validator-binding
+spec:
+  policyName: repository-url-validator
+  validationActions: [Deny, Audit]
+  paramRef:
+    namespace: repository-validator
+    parameterNotFoundAction: Deny
+    selector:
+      matchLabels:
+        app.kubernetes.io/name: repository-validator
+  # Apply to all namespaces except system namespaces
+  matchResources:
+    namespaceSelector:
+      matchExpressions:
+      - key: kubernetes.io/metadata.name
+        operator: NotIn
+        values:
+        - kube-system
+        - kube-public
+        - kube-node-lease
+        - repository-validator

--- a/components/repository-validator/rings/ring-1/base/base-snapshot/validating-admission-policy.yaml
+++ b/components/repository-validator/rings/ring-1/base/base-snapshot/validating-admission-policy.yaml
@@ -1,0 +1,42 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: repository-url-validator
+spec:
+  failurePolicy: Fail
+  paramKind:
+    apiVersion: v1
+    kind: ConfigMap
+  matchConstraints:
+    resourceRules:
+    - apiGroups: ["pipelinesascode.tekton.dev"]
+      apiVersions: ["v1alpha1"]
+      operations: ["CREATE", "UPDATE"]
+      resources: ["repositories"]
+  variables:
+    # Parse the config from the ConfigMap, strip quotes if needed
+    - name: allowedPrefixes
+      expression: |
+        'data' in params && 'config' in params.data ?
+        params.data['config'].split('\n').
+        map(p,p.matches('^".*"$') ? p.substring(1, size(p) - 1) : p) : []
+    # Check if prefix is wildcard (allow-all case)
+    - name: allowAll
+      expression: |
+        size(variables.allowedPrefixes) == 1 &&
+        variables.allowedPrefixes[0] == "*"
+  validations:
+    - expression: |
+        variables.allowAll ||
+        variables.allowedPrefixes.exists(prefix,
+          prefix != "" && object.spec.url.startsWith(prefix)
+        )
+      messageExpression: |
+        'Repository URL "' + object.spec.url +
+        '" is not allowed on this cluster. Contact support.'
+      reason: Forbidden
+  auditAnnotations:
+    - key: "repository-url-validation"
+      valueExpression: |
+        'Repository URL: ' + object.spec.url +
+        ', Allowed prefixes: [' + variables.allowedPrefixes.join(', ') + ']'

--- a/components/repository-validator/rings/ring-1/base/external-repo/kustomization.yaml
+++ b/components/repository-validator/rings/ring-1/base/external-repo/kustomization.yaml
@@ -2,4 +2,3 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - https://github.com/redhat-appstudio/internal-infra-deployments/components/repository-validator/staging?ref=c7b1af8d994746c7a654e791d722a0aab49dcbba
-  - ../base

--- a/components/repository-validator/rings/ring-1/base/kustomization.yaml
+++ b/components/repository-validator/rings/ring-1/base/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - base-snapshot
+  - external-repo

--- a/components/repository-validator/rings/ring-1/stone-stage-p01/kustomization.yaml
+++ b/components/repository-validator/rings/ring-1/stone-stage-p01/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../base

--- a/components/repository-validator/rings/ring-1/stone-stg-rh01/kustomization.yaml
+++ b/components/repository-validator/rings/ring-1/stone-stg-rh01/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../base


### PR DESCRIPTION
- Add ring structure under components/repository-validator/rings/:
  - ring-1 (staging: stone-stage-p01, stone-stg-rh01):
    - base-snapshot/ copies Tier 1 base/ manifests
    - base/kustomization.yaml references external internal-infra-deployments staging ref (Kargo manifest-wh updates this SHA ring-by-ring)
- Add rd-staging ArgoCD ApplicationSet with ring-1 staging clusters
- Add preserve-resources-on-deletion + disable-auto-sync to staging-downstream for safe migration from old AppSet
- Production stays on old AppSet (no ring-2+ yet)

Kargo promotion channel:
- manifest-wh watches internal-infra-deployments repo commits
- yaml-update updates ?ref=SHA in rings/ring-N/base/kustomization.yaml
