### PR TITLE
feat(KFLUXVNGD-1233): Add backup configuration for lightwell-dev staging cluster

### DIFF
--- a/components/backup/staging/lightwell-dev/backup-s3-credentials-patch.yaml
+++ b/components/backup/staging/lightwell-dev/backup-s3-credentials-patch.yaml
@@ -1,0 +1,3 @@
+- op: replace
+  path: /spec/dataFrom/0/extract/key
+  value: integrations-output/terraform-resources/appsres09ue1/stonesoup-infra-stage-backup/backup-lightwell-dev

--- a/components/backup/staging/lightwell-dev/dpa-bucket-patch.yaml
+++ b/components/backup/staging/lightwell-dev/dpa-bucket-patch.yaml
@@ -1,0 +1,3 @@
+- op: replace
+  path: /spec/backupLocations/0/velero/objectStorage/bucket
+  value: backup-lightwell-dev

--- a/components/backup/staging/lightwell-dev/dpa-kmskeyid-patch.yaml
+++ b/components/backup/staging/lightwell-dev/dpa-kmskeyid-patch.yaml
@@ -1,0 +1,3 @@
+- op: replace
+  path: /spec/backupLocations/0/velero/config/kmsKeyId
+  value: ca16fb4f-3876-4f28-bce2-b8de786412f9

--- a/components/backup/staging/lightwell-dev/kustomization.yaml
+++ b/components/backup/staging/lightwell-dev/kustomization.yaml
@@ -1,0 +1,23 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base/member
+patches:
+- path: backup-s3-credentials-patch.yaml
+  target:
+    group: external-secrets.io
+    kind: ExternalSecret
+    name: backup-s3-credentials
+    version: v1
+- path: dpa-bucket-patch.yaml
+  target:
+    group: oadp.openshift.io
+    kind: DataProtectionApplication
+    name: velero-aws
+    version: v1alpha1
+- path: dpa-kmskeyid-patch.yaml
+  target:
+    group: oadp.openshift.io
+    kind: DataProtectionApplication
+    name: velero-aws
+    version: v1alpha1


### PR DESCRIPTION
Configure backup for the lightwell-dev cluster by adding the per-cluster overlay that points to the provisioned S3 bucket and KMS key.

The S3 bucket (backup-lightwell-dev) and KMS encryption key were provisioned via app-interface Terraform. This commit wires the cluster to those resources by:
- Setting the Vault path for the ExternalSecret that fetches S3 credentials
- Configuring the DataProtectionApplication with the correct bucket name
- Setting the KMS key ID for server-side encryption of backups

The backup ApplicationSet discovers clusters via the appstudio.redhat.com/backup label, so no ApplicationSet change is needed.

Assisted-by: Cursor (claude-4.6-opus)