### PR TITLE
fix(KFLUXVNGD-1267): Add disaster-recovery configuration for lightwell-dev staging cluster

### DIFF
--- a/argo-cd-apps/base/member/infra-deployments/disaster-recovery/disaster-recovery.yaml
+++ b/argo-cd-apps/base/member/infra-deployments/disaster-recovery/disaster-recovery.yaml
@@ -19,6 +19,8 @@ spec:
                   values.clusterDir: stone-stg-rh01
                 - nameNormalized: stone-stage-p01
                   values.clusterDir: stone-stage-p01
+                - nameNormalized: lightwell-dev
+                  values.clusterDir: lightwell-dev
   template:
     metadata:
       name: disaster-recovery-{{nameNormalized}}

--- a/components/disaster-recovery/staging/lightwell-dev/kustomization.yaml
+++ b/components/disaster-recovery/staging/lightwell-dev/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../base


### PR DESCRIPTION


Enable disaster-recovery sanity testing on the lightwell-dev cluster by:
- Adding per-cluster overlay referencing the staging base kustomization
- Adding lightwell-dev to the disaster-recovery ApplicationSet list generator so it gets routed to the real overlay instead of empty-base

This aligns lightwell-dev with the other staging clusters (stone-stg-rh01, stone-stage-p01) that already have disaster-recovery enabled.

Assisted-by: Cursor (claude-4.6-opus)