### PR TITLE
fix(KFLUXVNGD-1268): Add etcd-defrag configuration for lightwell-dev staging cluster

### DIFF
--- a/argo-cd-apps/base/member/infra-deployments/etcd-defrag/etcd-defrag.yaml
+++ b/argo-cd-apps/base/member/infra-deployments/etcd-defrag/etcd-defrag.yaml
@@ -18,6 +18,8 @@ spec:
                   values.clusterDir: stone-stg-rh01
                 - nameNormalized: stone-stage-p01
                   values.clusterDir: stone-stage-p01
+                - nameNormalized: lightwell-dev
+                  values.clusterDir: lightwell-dev
                 - nameNormalized: kflux-ocp-p01
                   values.clusterDir: kflux-ocp-p01
                 - nameNormalized: kflux-prd-rh02

--- a/configs/etcd-defrag/staging/lightwell-dev/kustomization.yaml
+++ b/configs/etcd-defrag/staging/lightwell-dev/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../base


### PR DESCRIPTION
Add lightwell-dev to the etcd-defrag ApplicationSet by:
- Creating per-cluster overlay referencing the staging base kustomization
- Adding lightwell-dev to the list generator so clusterDir resolves to a real path instead of the unset {{values.clusterDir}}

This also fixes the ArgoCD manifest generation error: "app path does not exist: configs/etcd-defrag/staging/{{values.clusterDir}}"

## Risk - low
This only deploys etcd-defrag on the lightwell-dev cluster.

Assisted-by: Cursor (claude-4.6-opus)