### PR TITLE
KFLUXINFRA-4409: Use default subnet for lightwell-dev MPC builders

### DIFF
--- a/components/multi-platform-controller/staging/lightwell-dev/host-values.yaml
+++ b/components/multi-platform-controller/staging/lightwell-dev/host-values.yaml
@@ -24,11 +24,9 @@ archDefaults:
     subnet-id: "subnet-0958667237f37416a"
 
 dynamicConfigs:
-  linux-arm64:
-    subnet-id: "subnet-01b88957a67590dc2"
+  linux-arm64: {}
 
-  linux-amd64:
-    subnet-id: "subnet-06132f7bf72af6ce6"
+  linux-amd64: {}
 
   linux-root-arm64:
     sudo-commands: "/usr/bin/podman"


### PR DESCRIPTION
## What

- Remove per-platform `subnet-id` overrides for `linux-arm64` and `linux-amd64` in lightwell-dev MPC host config

Clusters affected: lightwell-dev

[KFLUXINFRA-4409](https://redhat.atlassian.net/browse/KFLUXINFRA-4409)

## Why

lightwell-dev should use the default subnet from `archDefaults` for all builder platforms instead of separate subnets copied from other staging clusters.

## Validation

- Host config change only; `archDefaults.subnet-id` remains `subnet-0958667237f37416a` for both arm64 and amd64

## Risk Assessment

**Risk Level:** Low
**What could go wrong:** Builder VM provisioning fails if the default subnet is incorrect for lightwell-dev AWS networking.
**Rollback:** Revert this PR.
**Blast radius:** Single temporary staging cluster (lightwell-dev) only.


Made with [Cursor](https://cursor.com)

[KFLUXINFRA-4409]: https://redhat.atlassian.net/browse/KFLUXINFRA-4409?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ