### PR TITLE
KFLUXINFRA-4409: Update lightwell-dev MPC vault secret paths

### DIFF
--- a/components/multi-platform-controller/staging/lightwell-dev/external-secrets.yaml
+++ b/components/multi-platform-controller/staging/lightwell-dev/external-secrets.yaml
@@ -11,7 +11,7 @@ metadata:
 spec:
   dataFrom:
     - extract:
-        key: staging/infrastructure/multi-platform-controller/lightwell-dev/aws-account
+        key: staging/infrastructure/multi-platform-controller/lightwell-dev/aws-account-v2
   refreshInterval: 1h
   secretStoreRef:
     kind: ClusterSecretStore
@@ -34,7 +34,7 @@ metadata:
 spec:
   dataFrom:
     - extract:
-        key: staging/infrastructure/multi-platform-controller/lightwell-dev/aws-ssh-key
+        key: staging/infrastructure/multi-platform-controller/lightwell-dev/aws-ssh-key-v2
   refreshInterval: 1h
   secretStoreRef:
     kind: ClusterSecretStore


### PR DESCRIPTION
## What

- Update lightwell-dev MPC ExternalSecret vault paths to `aws-account-v2` and `aws-ssh-key-v2`

Clusters affected: lightwell-dev

[KFLUXINFRA-4409](https://redhat.atlassian.net/browse/KFLUXINFRA-4409)

## Why

lightwell-dev AWS credentials were rotated into new vault entries; MPC must reference the updated paths for EC2 provisioning and SSH access.

## Validation

- ExternalSecret path change only
- Target secrets remain `aws-account` and `aws-ssh-key` in the `multi-platform-controller` namespace

## Risk Assessment

**Risk Level:** Low
**What could go wrong:** MPC cannot provision builders if the v2 vault entries are missing or malformed.
**Rollback:** Revert this PR.
**Blast radius:** Single temporary staging cluster (lightwell-dev) only.


Made with [Cursor](https://cursor.com)

[KFLUXINFRA-4409]: https://redhat.atlassian.net/browse/KFLUXINFRA-4409?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ