### PR TITLE
PVO11Y-5429 Add Prometheus monitoring for lightwell-dev cluster

### DIFF
--- a/argo-cd-apps/base/all-clusters/infra-deployments/monitoring-workload-prometheus/monitoring-workload-prometheus.yaml
+++ b/argo-cd-apps/base/all-clusters/infra-deployments/monitoring-workload-prometheus/monitoring-workload-prometheus.yaml
@@ -33,6 +33,8 @@ spec:
                   values.clusterDir: kflux-prd-rh03
                 - nameNormalized: kflux-stg-es01
                   values.clusterDir: kflux-stg-es01
+                - nameNormalized: lightwell-dev
+                  values.clusterDir: lightwell-dev
                 - nameNormalized: kflux-prd-es01
                   values.clusterDir: kflux-prd-es01
                 - nameNormalized: kflux-rhel-p01

--- a/components/monitoring/prometheus/staging/lightwell-dev/cluster-id-label.yaml
+++ b/components/monitoring/prometheus/staging/lightwell-dev/cluster-id-label.yaml
@@ -1,0 +1,4 @@
+---
+- op: add
+  path: /spec/prometheusConfig/externalLabels/source_cluster
+  value: lightwell-dev

--- a/components/monitoring/prometheus/staging/lightwell-dev/kustomization.yaml
+++ b/components/monitoring/prometheus/staging/lightwell-dev/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../base
+patches:
+  - path: cluster-id-label.yaml
+    target:
+      name: appstudio-federate-ms
+      kind: MonitoringStack
+      group: monitoring.rhobs
+      version: v1alpha1


### PR DESCRIPTION
Deploy monitoring-workload-prometheus to lightwell-dev with base federation monitoring.  Tekton-specific metrics (tekton-ms) will be enabled in a future change.

