### PR TITLE
RELEASE-2681: add prod ExternalSecret for release-service GitHub token

### DIFF
--- a/components/release/production/external-secrets/release-service-github-token.yaml
+++ b/components/release/production/external-secrets/release-service-github-token.yaml
@@ -1,0 +1,22 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: release-service-github-token
+  namespace: release-service
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  data:
+    - secretKey: token
+      remoteRef:
+        key: production/release/github/konflux-release-service
+        property: token
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: appsre-stonesoup-vault
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    name: release-service-github-token

--- a/components/release/production/kustomization.yaml
+++ b/components/release/production/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
   - ../base
   - ../base/monitor/production
+  - external-secrets/release-service-github-token.yaml
   - https://github.com/konflux-ci/release-service/config/default?ref=f3ac0e4aa928ff7c4fdac1846de3268afd9c9ae5
   - release_service_config.yaml
   - signing_configs.yaml


### PR DESCRIPTION
## Summary
Adds production ExternalSecret for `release-service-github-token` to enable authenticated branch→SHA resolution in production clusters.
This follows the staging deployment in #13196, which has been running successfully.
## Vault
- **Path**: `production/release/github/konflux-release-service`
- **Property**: `token`
- **Store**: `appsre-stonesoup-vault`
## K8s
- **Secret**: `release-service-github-token` / key `token`
- **Namespace**: `release-service`
## Related
- Staging PR: #13196
- Staging Vault fix: #13237
- Code PR: https://github.com/konflux-ci/release-service/pull/1753