### PR TITLE
Enable proxy for bundler and cargo on stone-stg-rh01

### DIFF
--- a/components/konflux-info/staging/stone-stg-rh01/cluster-config.env
+++ b/components/konflux-info/staging/stone-stg-rh01/cluster-config.env
@@ -3,6 +3,8 @@ http-proxy=squid.caching.svc.cluster.local:3128
 no-proxy=
 
 allow-package-registry-proxy=true
+package-registry-proxy-bundler-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/rubygems-proxy
+package-registry-proxy-cargo-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/cargo-proxy
 package-registry-proxy-gomod-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/go-proxy
 package-registry-proxy-npm-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/npm-proxy
 package-registry-proxy-pip-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/pypi-proxy/simple


### PR DESCRIPTION
Enable use of the package registry proxy for Hermeto's bundler and cargo backends on stone-stg-rh01. This will allow Hermeto to route dependency prefetches through the package registry registry proxy for policy evaluation.

## Risk Assessment
**Risk Level:** Low
**Description:** Enables additional ecosystems for Nexus in stage
**Rollback:** Revert PR

## Validation
Already tested in individual build PLRs in stage. Cargo fails as-expected while we wait to validate a fix for the reverse proxy from Vanguard.