### PR TITLE
Change e2e tests to use rd-dev

### DIFF
--- a/.github/workflows/check-overlay-app-collisions.yaml
+++ b/.github/workflows/check-overlay-app-collisions.yaml
@@ -1,0 +1,31 @@
+name: Check overlay Application-name collisions
+
+on:
+  pull_request:
+    branches: [ main ]
+    paths:
+      - .github/workflows/check-overlay-app-collisions.yaml
+      - 'infra-tools/**'
+      - 'argo-cd-apps/**'
+
+jobs:
+  check-overlay-app-collisions:
+      permissions:
+        contents: read
+      name: Check overlay Application-name collisions
+      runs-on: ubuntu-latest
+      steps:
+        - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+
+        - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+          with:
+            go-version-file: infra-tools/go.mod
+            cache-dependency-path: infra-tools/go.sum
+
+        - name: Build overlay-app-collision-checker
+          working-directory: infra-tools
+          run: go build -o bin/overlay-app-collision-checker ./cmd/overlay-app-collision-checker
+        
+        - name: Run overlay-app-collision-checker
+          working-directory: infra-tools
+          run: ./bin/overlay-app-collision-checker --repo-root=..

--- a/.github/workflows/check-overlay-app-collisions.yaml
+++ b/.github/workflows/check-overlay-app-collisions.yaml
@@ -25,7 +25,7 @@ jobs:
         - name: Build overlay-app-collision-checker
           working-directory: infra-tools
           run: go build -o bin/overlay-app-collision-checker ./cmd/overlay-app-collision-checker
-        
+
         - name: Run overlay-app-collision-checker
           working-directory: infra-tools
           run: ./bin/overlay-app-collision-checker --repo-root=..

--- a/argo-cd-apps/app-of-app-sets/rd-dev/kustomization.yaml
+++ b/argo-cd-apps/app-of-app-sets/rd-dev/kustomization.yaml
@@ -1,0 +1,16 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../base
+patches:
+  - path: patches/source-path-patch.yaml
+    target:
+      group: argoproj.io
+      version: v1alpha1
+      kind: Application
+  - path: patches/target-namespace-patch.yaml
+    target:
+      group: argoproj.io
+      version: v1alpha1
+      kind: Application
+namespace: argocd-infra-deployments

--- a/argo-cd-apps/app-of-app-sets/rd-dev/kustomization.yaml
+++ b/argo-cd-apps/app-of-app-sets/rd-dev/kustomization.yaml
@@ -13,4 +13,5 @@ patches:
       group: argoproj.io
       version: v1alpha1
       kind: Application
-namespace: argocd-infra-deployments
+
+namespace: openshift-gitops

--- a/argo-cd-apps/app-of-app-sets/rd-dev/patches/source-path-patch.yaml
+++ b/argo-cd-apps/app-of-app-sets/rd-dev/patches/source-path-patch.yaml
@@ -1,0 +1,4 @@
+---
+- op: replace
+  path: /spec/source/path
+  value: argo-cd-apps/overlays/rd-dev

--- a/argo-cd-apps/app-of-app-sets/rd-dev/patches/target-namespace-patch.yaml
+++ b/argo-cd-apps/app-of-app-sets/rd-dev/patches/target-namespace-patch.yaml
@@ -1,0 +1,4 @@
+---
+- op: replace
+  path: /spec/destination/namespace
+  value: openshift-gitops

--- a/argo-cd-apps/overlays/development/delete-applications.yaml
+++ b/argo-cd-apps/overlays/development/delete-applications.yaml
@@ -77,6 +77,12 @@ metadata:
   name: kubelet-config
 $patch: delete
 ---
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: kueue
+$patch: delete
+---
 # The ClusterRoleBinding self-provisioners doesn't
 # exist in e2e's clusters
 apiVersion: argoproj.io/v1alpha1

--- a/argo-cd-apps/overlays/development/dev-application-auto-sync-patch.yaml
+++ b/argo-cd-apps/overlays/development/dev-application-auto-sync-patch.yaml
@@ -1,5 +1,0 @@
-- op: add
-  path: /spec/template/spec/syncPolicy/automated
-  value:
-    prune: true
-    selfHeal: false

--- a/argo-cd-apps/overlays/development/dev-application-sync-wave-kueue.yaml
+++ b/argo-cd-apps/overlays/development/dev-application-sync-wave-kueue.yaml
@@ -1,6 +1,0 @@
-apiVersion: argoproj.io/v1alpha1
-kind: ApplicationSet
-metadata:
-  name: kueue
-  annotations:
-    argocd.argoproj.io/sync-wave: "-1"

--- a/argo-cd-apps/overlays/development/kustomization.yaml
+++ b/argo-cd-apps/overlays/development/kustomization.yaml
@@ -155,16 +155,6 @@ patches:
     target:
       kind: ApplicationSet
       version: v1alpha1
-      name: kueue
-  - path: dev-application-auto-sync-patch.yaml
-    target:
-      kind: ApplicationSet
-      version: v1alpha1
-      name: kueue
-  - path: development-overlay-patch.yaml
-    target:
-      kind: ApplicationSet
-      version: v1alpha1
       name: policies
   - path: development-overlay-patch.yaml
     target:
@@ -232,11 +222,6 @@ patches:
       kind: ApplicationSet
       version: v1alpha1
       name: kyverno
-  - path: dev-application-sync-wave-kueue.yaml
-    target:
-      kind: ApplicationSet
-      version: v1alpha1
-      name: kueue
   - path: dev-application-sync-wave-pipeline-service.yaml
     target:
       kind: ApplicationSet

--- a/argo-cd-apps/overlays/rd-dev/kueue/kueue-appset.yaml
+++ b/argo-cd-apps/overlays/rd-dev/kueue/kueue-appset.yaml
@@ -35,9 +35,9 @@ spec:
       destination:
         server: '{{server}}'
       syncPolicy:
-        # automated:
-        #   prune: true
-        #   selfHeal: true
+        automated:
+          prune: true
+          selfHeal: false
         syncOptions:
         - CreateNamespace=true
         retry:

--- a/argo-cd-apps/overlays/rd-dev/kustomization.yaml
+++ b/argo-cd-apps/overlays/rd-dev/kustomization.yaml
@@ -5,11 +5,19 @@ namespace: openshift-gitops
 nameSuffix: -ring-0
 
 resources:
+  - ../development # Include until all Konflux microservices are migrated to rd-dev
   - artifact-registry-proxy
   - container-image-proxy
   - etcd-shield
   - konflux-operator
   - kueue
 
-# No patches until those applications are onboarded to the new standards
-patches: []
+patchesStrategicMerge:  
+  - patches/delete-legacy-konflux-member-appsets.yaml
+
+patches:
+  - path: patches/pipeline-service-env-patch.yaml
+    target:
+      kind: ApplicationSet
+      version: v1alpha1
+      name: pipeline-service

--- a/argo-cd-apps/overlays/rd-dev/kustomization.yaml
+++ b/argo-cd-apps/overlays/rd-dev/kustomization.yaml
@@ -2,7 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 namespace: openshift-gitops
-nameSuffix: -ring-0
 
 resources:
   - ../development # Include until all Konflux microservices are migrated to rd-dev
@@ -12,7 +11,7 @@ resources:
   - konflux-operator
   - kueue
 
-patchesStrategicMerge:  
+patchesStrategicMerge:
   - patches/delete-legacy-konflux-member-appsets.yaml
 
 patches:

--- a/argo-cd-apps/overlays/rd-dev/patches/delete-legacy-konflux-member-appsets.yaml
+++ b/argo-cd-apps/overlays/rd-dev/patches/delete-legacy-konflux-member-appsets.yaml
@@ -1,0 +1,62 @@
+# Strategic-merge deletes: remove these Argo CD ApplicationSets from the
+# effective ../development graph. Used by the development-operator overlay on
+# OpenShift so GitOps still installs shared platform apps but not the older
+# per-microservice Konflux ApplicationSets superseded by the Konflux operator.
+#
+# Only ApplicationSets that actually appear in ../development can be deleted here
+# (Kustomize requires a merge target). konflux-ui and namespace-lister are not in
+# that graph, so no delete entries for them.
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: application-api
+$patch: delete
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: release
+$patch: delete
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: integration
+$patch: delete
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: build-service
+$patch: delete
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: image-controller
+$patch: delete
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: internal-services
+$patch: delete
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: konflux-info
+$patch: delete
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: konflux-rbac
+$patch: delete
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: enterprise-contract
+$patch: delete

--- a/argo-cd-apps/overlays/rd-dev/patches/delete-legacy-konflux-member-appsets.yaml
+++ b/argo-cd-apps/overlays/rd-dev/patches/delete-legacy-konflux-member-appsets.yaml
@@ -1,5 +1,5 @@
 # Strategic-merge deletes: remove these Argo CD ApplicationSets from the
-# effective ../development graph. Used by the development-operator overlay on
+# effective ../development graph. Used by the rd-dev overlay on
 # OpenShift so GitOps still installs shared platform apps but not the older
 # per-microservice Konflux ApplicationSets superseded by the Konflux operator.
 #

--- a/argo-cd-apps/overlays/rd-dev/patches/pipeline-service-env-patch.yaml
+++ b/argo-cd-apps/overlays/rd-dev/patches/pipeline-service-env-patch.yaml
@@ -1,0 +1,4 @@
+---
+- op: replace
+  path: /spec/generators/0/merge/generators/0/clusters/values/environment
+  value: development-operator

--- a/components/konflux-operator/README.md
+++ b/components/konflux-operator/README.md
@@ -76,10 +76,15 @@ the invariant from the ring you trust, and copy or adapt `cr/` patches and `rele
 
 ## Preview script and `Konflux` readiness
 
-`hack/preview.sh` supports **`--operator-overlay`** (OpenShift preview using the
-`development-operator` Argo overlay). **By default it does not wait** for the cluster
-`Konflux` object `konflux` to become ready, so preview can finish after Argo CD sync
-while the operator and instance are still converging.
+`hack/preview.sh` targets the **`rd-dev`** Argo overlay by default, which reuses
+`../development`, deletes the legacy per-microservice Konflux ApplicationSets it
+supersedes, and layers this component's ring-based resources on top — so a default
+preview run already installs the operator. **`--operator-overlay`** switches to the 
+narrower `development-operator` overlay instead, which deploys the same operator 
+(and the same legacy-appset removal) without the ring-based components, for 
+operator-focused testing. Either way, **by default preview does not wait** for 
+the cluster `Konflux` object `konflux` to become ready, so preview can finish after
+Argo CD sync while the operator and instance are still converging.
 
 To **gate** preview on a healthy instance (same checks as
 `konflux-ci/scripts/deploy-local.sh`), set **`PREVIEW_WAIT_KONFLUX_CR_READY=true`**

--- a/components/konflux-operator/ci/openshift-overlay-e2e/README.md
+++ b/components/konflux-operator/ci/openshift-overlay-e2e/README.md
@@ -3,7 +3,7 @@
 Scripts for the optional, on-demand Prow job
 `appstudio-operator-overlay-e2e-tests` (openshift/release).
 
-Legacy `appstudio-e2e-tests` (`development` overlay) is unchanged and uses separate
+Legacy `appstudio-e2e-tests` (`rd-dev` overlay) is unchanged and uses separate
 step refs (`konflux-ci-install-konflux`, `redhat-appstudio-conformance-tests`).
 
 ## Layout

--- a/hack/preview.sh
+++ b/hack/preview.sh
@@ -321,6 +321,28 @@ label_cluster_nodes() {
     fi
 }
 
+# Append a $patch: delete entry for the given ApplicationSet name to the target
+# overlay's delete-applications.yaml, creating the file and wiring it into the
+# overlay's patchesStrategicMerge on first use. Wiring only happens here, at the
+# point a patch document is actually about to be written, so the registered file
+# is never empty (Kustomize rejects an empty strategic-merge patch file). The
+# wiring itself is idempotent (dedup'd via `unique`), so calling this repeatedly
+# for the same overlay is safe.
+add_overlay_delete_entry() {
+    local app="$1"
+    local delete_file="$TARGET_OVERLAY_DELETE_FILE"
+
+    [ -f "$delete_file" ] || touch "$delete_file"
+    yq -i '.patchesStrategicMerge = ((.patchesStrategicMerge // []) + ["delete-applications.yaml"] | unique)' \
+        "$TARGET_OVERLAY_PATH/kustomization.yaml"
+
+    echo '---' >> "$delete_file"
+    yq e -n ".apiVersion=\"argoproj.io/v1alpha1\"
+             | .kind=\"ApplicationSet\"
+             | .metadata.name = \"$app\"
+             | .\$patch = \"delete\"" >> "$delete_file"
+}
+
 # Filter applications based on DEPLOY_ONLY environment variable
 configure_deploy_only() {
     [ "$TARGET_PREVIEW_OVERLAY" != "rd-dev" ] && [ "$TARGET_PREVIEW_OVERLAY" != "development-operator" ] && return
@@ -330,19 +352,15 @@ configure_deploy_only() {
     log_info "DEPLOY_ONLY is set, filtering applications to deploy only: $DEPLOY_ONLY"
 
     local applications delete_list app
-    local delete_file="$TARGET_OVERLAY_DELETE_FILE"
 
     applications=$(oc kustomize "$TARGET_OVERLAY_PATH" | yq e --no-doc 'select(.kind == "ApplicationSet") | .metadata.name')
-    delete_list=$(yq e --no-doc .metadata.name "$delete_file")
+    delete_list=""
+    [ -f "$TARGET_OVERLAY_DELETE_FILE" ] && delete_list=$(yq e --no-doc .metadata.name "$TARGET_OVERLAY_DELETE_FILE")
 
     for app in $applications; do
         if ! grep -q "\b$app\b" <<< $DEPLOY_ONLY && ! grep -q "\b$app\b" <<< $delete_list; then
             log_substep "Disabling ApplicationSet '$app' (not in DEPLOY_ONLY list)"
-            echo '---' >> "$delete_file"
-            yq e -n ".apiVersion=\"argoproj.io/v1alpha1\"
-                     | .kind=\"ApplicationSet\"
-                     | .metadata.name = \"$app\"
-                     | .\$patch = \"delete\"" >> "$delete_file"
+            add_overlay_delete_entry "$app"
         fi
     done
 
@@ -354,7 +372,7 @@ configure_kueue_for_ocp_version() {
     [ "$TARGET_PREVIEW_OVERLAY" != "rd-dev" ] && [ "$TARGET_PREVIEW_OVERLAY" != "development-operator" ] && return
     log_step "Checking OCP version for Kueue compatibility"
 
-    local ocp_version ocp_minor delete_file
+    local ocp_version ocp_minor
 
     ocp_version=$(oc get clusterversion version -o jsonpath='{.status.desired.version}')
     ocp_minor=$(echo "$ocp_version" | cut -d. -f2)
@@ -368,18 +386,12 @@ configure_kueue_for_ocp_version() {
 
     log_warn "OCP version $ocp_version is below 4.16 - Kueue will be disabled"
 
-    delete_file="$TARGET_OVERLAY_DELETE_FILE"
-
-    if ! grep -q "name: kueue" "$delete_file"; then
-        log_substep "Adding Kueue to $TARGET_PREVIEW_OVERLAY's delete-applications.yaml"
-        echo '---' >> "$delete_file"
-        yq e -n ".apiVersion=\"argoproj.io/v1alpha1\"
-                  | .kind=\"ApplicationSet\"
-                  | .metadata.name = \"kueue\"
-                  | .\$patch = \"delete\"" >> "$delete_file"
-        log_success "Kueue ApplicationSet marked for deletion"
-    else
+    if [ -f "$TARGET_OVERLAY_DELETE_FILE" ] && grep -q "name: kueue" "$TARGET_OVERLAY_DELETE_FILE"; then
         log_info "Kueue already exists in delete-applications.yaml, skipping"
+    else
+        log_substep "Adding Kueue to $TARGET_PREVIEW_OVERLAY's delete-applications.yaml"
+        add_overlay_delete_entry "kueue"
+        log_success "Kueue ApplicationSet marked for deletion"
     fi
 
     yq -i 'del(.resources[] | select(test("^kueue/?$")))' "$ROOT/components/policies/development/kustomization.yaml"
@@ -388,7 +400,7 @@ configure_kueue_for_ocp_version() {
 
 # Enable Konflux CR image-controller only when Quay credentials are provided.
 configure_operator_image_controller() {
-    [ "$TARGET_PREVIEW_OVERLAY" != "development-operator" ] && return
+    [ "$TARGET_PREVIEW_OVERLAY" != "development-operator" ] &&  [ "$TARGET_PREVIEW_OVERLAY" != "rd-dev" ] && return
 
     local cr_patch="$ROOT/components/konflux-operator/rings/ring-0/base/cr/image-controller/image-controller.yaml"
     local ring_kust="$ROOT/components/konflux-operator/rings/ring-0/base/kustomization.yaml"
@@ -962,11 +974,11 @@ fi
 TARGET_APP_OF_APPS_PATH="$ROOT/argo-cd-apps/app-of-app-sets/$TARGET_PREVIEW_OVERLAY"
 TARGET_OVERLAY_PATH="$ROOT/argo-cd-apps/overlays/$TARGET_PREVIEW_OVERLAY"
 TARGET_OVERLAY_DELETE_FILE="$TARGET_OVERLAY_PATH/delete-applications.yaml"
-# If the delete file does not exist, create it and wire it into the overlay's Kustomize file
-if [ ! -f "$TARGET_OVERLAY_DELETE_FILE" ]; then
-    touch "$TARGET_OVERLAY_DELETE_FILE"
-    yq -i '.patchesStrategicMerge += ["delete-applications.yaml"]' "$TARGET_OVERLAY_PATH/kustomization.yaml"
-fi
+# NOTE: the delete file itself is created/wired further below, only after the
+# "uncommitted changes" git gate and the $PREVIEW_BRANCH checkout - creating
+# it here would modify a tracked file (kustomization.yaml) on $MY_GIT_BRANCH
+# before that gate runs, and the gate would then fail on every run (even from
+# a clean checkout) by tripping over the script's own edit.
 
 # =============================================================================
 # Main Execution
@@ -1033,6 +1045,13 @@ if git rev-parse --verify $PREVIEW_BRANCH &> /dev/null; then
 fi
 git checkout -b $PREVIEW_BRANCH
 
+# NOTE: $TARGET_OVERLAY_DELETE_FILE is intentionally NOT created/wired into
+# patchesStrategicMerge here. It's created by add_overlay_delete_entry, only at
+# the point a patch document is actually about to be written - registering an
+# empty file in patchesStrategicMerge makes Kustomize fail with "patch appears
+# to be empty" if no delete entry ever gets appended (e.g. DEPLOY_ONLY unset
+# and OCP version >= 4.16, so neither function has anything to delete).
+
 log_success "Git environment initialized"
 log_info "  - Repository URL: $MY_GIT_REPO_URL"
 log_info "  - Source branch: $MY_GIT_BRANCH"
@@ -1077,7 +1096,9 @@ if $GRAFANA; then
     else
     log_step "Enabling Grafana dashboard"
     log_info "Removing monitoring-workload-grafana from delete-applications.yaml"
-    yq -i 'select(.metadata.name != "monitoring-workload-grafana")' "$TARGET_OVERLAY_DELETE_FILE"
+    # delete-applications.yaml is created lazily (see add_overlay_delete_entry) and may
+    # not exist yet if nothing else has been added to it.
+    [ -f "$TARGET_OVERLAY_DELETE_FILE" ] && yq -i 'select(.metadata.name != "monitoring-workload-grafana")' "$TARGET_OVERLAY_DELETE_FILE"
     log_success "Grafana enabled: monitoring-workload-grafana will be deployed"
     fi
 fi

--- a/hack/preview.sh
+++ b/hack/preview.sh
@@ -261,17 +261,23 @@ print_help() {
     echo "  --obo        (only in preview mode) Install Observability operator and Prometheus instance for federation"
     echo "  --grafana    (only in preview mode) Enable Grafana dashboard (removed by default in dev)"
     echo "  --eaas       (only in preview mode) Install environment as a service components"
-    echo "  --operator-overlay  (preview mode) Use the development-operator Argo overlay: same platform apps as"
-    echo "                       development, but ApplicationSets for legacy Konflux microservices are removed."
+    echo "  --operator-overlay  (preview mode) Use the development-operator Argo overlay instead of the default"
+    echo "                       rd-dev overlay: same platform apps as development, but ApplicationSets for"
+    echo "                       legacy Konflux microservices are removed."
     echo
-    echo "  With --operator-overlay, preview always waits for the Konflux operator controller Deployment to finish"
-    echo "  rolling out (namespace konflux-operator). That is independent of the Konflux CR Ready status."
+    echo "  By default (no --operator-overlay), preview targets the rd-dev overlay, which already reuses"
+    echo "  ../development and layers the ring-based components on top, removing the legacy"
+    echo "  per-microservice ApplicationSets that konflux-operator now owns."
+    echo
+    echo "  Both rd-dev (default) and --operator-overlay deploy the Konflux operator, so preview always waits"
+    echo "  for the operator controller Deployment to finish rolling out (namespace konflux-operator). That is"
+    echo "  independent of the Konflux CR Ready status."
     echo
     echo "Environment (optional):"
-    echo "  PREVIEW_WAIT_KONFLUX_CR_READY=true  When using --operator-overlay, additionally wait for the Konflux"
-    echo "                       custom resource konflux to exist and report Ready=True (off by default)."
-    echo "  IMAGE_CONTROLLER_QUAY_ORG, IMAGE_CONTROLLER_QUAY_TOKEN  With --operator-overlay, both must be set in"
-    echo "                       hack/preview.env to enable image-controller on the Konflux CR (off by default)."
+    echo "  PREVIEW_WAIT_KONFLUX_CR_READY=true  Additionally wait for the Konflux custom resource konflux to"
+    echo "                       exist and report Ready=True (off by default)."
+    echo "  IMAGE_CONTROLLER_QUAY_ORG, IMAGE_CONTROLLER_QUAY_TOKEN  Both must be set in hack/preview.env to"
+    echo "                       enable image-controller on the Konflux CR (off by default)."
     echo
     echo "Example: \`$0 preview --obo --grafana --eaas\`"
 }
@@ -317,20 +323,20 @@ label_cluster_nodes() {
 
 # Filter applications based on DEPLOY_ONLY environment variable
 configure_deploy_only() {
-    [ "$TARGET_PREVIEW_OVERLAY" != "development" ] && [ "$TARGET_PREVIEW_OVERLAY" != "development-operator" ] && return
+    [ "$TARGET_PREVIEW_OVERLAY" != "rd-dev" ] && [ "$TARGET_PREVIEW_OVERLAY" != "development-operator" ] && return
     [ -z "$DEPLOY_ONLY" ] && return
 
     log_step "Configuring selective deployment (DEPLOY_ONLY mode)"
     log_info "DEPLOY_ONLY is set, filtering applications to deploy only: $DEPLOY_ONLY"
 
-    local applications deleted app
-    local delete_file="$TARGET_DELETE_FILE"
+    local applications delete_list app
+    local delete_file="$TARGET_OVERLAY_DELETE_FILE"
 
     applications=$(oc kustomize "$TARGET_OVERLAY_PATH" | yq e --no-doc 'select(.kind == "ApplicationSet") | .metadata.name')
-    deleted=$(yq e --no-doc .metadata.name "$delete_file")
+    delete_list=$(yq e --no-doc .metadata.name "$delete_file")
 
     for app in $applications; do
-        if ! grep -q "\b$app\b" <<< $DEPLOY_ONLY && ! grep -q "\b$app\b" <<< $deleted; then
+        if ! grep -q "\b$app\b" <<< $DEPLOY_ONLY && ! grep -q "\b$app\b" <<< $delete_list; then
             log_substep "Disabling ApplicationSet '$app' (not in DEPLOY_ONLY list)"
             echo '---' >> "$delete_file"
             yq e -n ".apiVersion=\"argoproj.io/v1alpha1\"
@@ -345,7 +351,7 @@ configure_deploy_only() {
 
 # Disable Kueue for OCP versions < 4.16
 configure_kueue_for_ocp_version() {
-    [ "$TARGET_PREVIEW_OVERLAY" != "development" ] && [ "$TARGET_PREVIEW_OVERLAY" != "development-operator" ] && return
+    [ "$TARGET_PREVIEW_OVERLAY" != "rd-dev" ] && [ "$TARGET_PREVIEW_OVERLAY" != "development-operator" ] && return
     log_step "Checking OCP version for Kueue compatibility"
 
     local ocp_version ocp_minor delete_file
@@ -362,10 +368,10 @@ configure_kueue_for_ocp_version() {
 
     log_warn "OCP version $ocp_version is below 4.16 - Kueue will be disabled"
 
-    delete_file="$TARGET_DELETE_FILE"
+    delete_file="$TARGET_OVERLAY_DELETE_FILE"
 
     if ! grep -q "name: kueue" "$delete_file"; then
-        log_substep "Adding Kueue to delete-applications.yaml"
+        log_substep "Adding Kueue to $TARGET_PREVIEW_OVERLAY's delete-applications.yaml"
         echo '---' >> "$delete_file"
         yq e -n ".apiVersion=\"argoproj.io/v1alpha1\"
                   | .kind=\"ApplicationSet\"
@@ -380,7 +386,7 @@ configure_kueue_for_ocp_version() {
     log_success "Kueue disabled for OCP version $ocp_version"
 }
 
-# Enable Konflux CR image-controller only when Quay credentials are provided (operator overlay).
+# Enable Konflux CR image-controller only when Quay credentials are provided.
 configure_operator_image_controller() {
     [ "$TARGET_PREVIEW_OVERLAY" != "development-operator" ] && return
 
@@ -949,16 +955,17 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-TARGET_PREVIEW_OVERLAY="development"
+TARGET_PREVIEW_OVERLAY="rd-dev"
 if $OPERATOR_OVERLAY; then
     TARGET_PREVIEW_OVERLAY="development-operator"
 fi
 TARGET_APP_OF_APPS_PATH="$ROOT/argo-cd-apps/app-of-app-sets/$TARGET_PREVIEW_OVERLAY"
-TARGET_OVERLAY_PATH="argo-cd-apps/overlays/$TARGET_PREVIEW_OVERLAY"
-TARGET_DELETE_FILE="$ROOT/argo-cd-apps/overlays/$TARGET_PREVIEW_OVERLAY/delete-applications.yaml"
-# development-operator kustomization inherits ../development; shared delete list.
-if [ "$TARGET_PREVIEW_OVERLAY" = "development-operator" ]; then
-    TARGET_DELETE_FILE="$ROOT/argo-cd-apps/overlays/development/delete-applications.yaml"
+TARGET_OVERLAY_PATH="$ROOT/argo-cd-apps/overlays/$TARGET_PREVIEW_OVERLAY"
+TARGET_OVERLAY_DELETE_FILE="$TARGET_OVERLAY_PATH/delete-applications.yaml"
+# If the delete file does not exist, create it and wire it into the overlay's Kustomize file
+if [ ! -f "$TARGET_OVERLAY_DELETE_FILE" ]; then
+    touch "$TARGET_OVERLAY_DELETE_FILE"
+    yq -i '.patchesStrategicMerge += ["delete-applications.yaml"]' "$TARGET_OVERLAY_PATH/kustomization.yaml"
 fi
 
 # =============================================================================
@@ -1054,7 +1061,7 @@ log_success "All ArgoCD patch files updated"
 # Optional Components
 # =============================================================================
 if $OBO; then
-    if [ "$TARGET_PREVIEW_OVERLAY" != "development" ] && [ "$TARGET_PREVIEW_OVERLAY" != "development-operator" ]; then
+    if [ "$TARGET_PREVIEW_OVERLAY" != "rd-dev" ] && [ "$TARGET_PREVIEW_OVERLAY" != "development-operator" ]; then
         log_warn "Ignoring --obo for overlay '$TARGET_PREVIEW_OVERLAY'"
     else
     log_step "Enabling Observability (OBO) components"
@@ -1065,18 +1072,18 @@ if $OBO; then
 fi
 
 if $GRAFANA; then
-    if [ "$TARGET_PREVIEW_OVERLAY" != "development" ] && [ "$TARGET_PREVIEW_OVERLAY" != "development-operator" ]; then
+    if [ "$TARGET_PREVIEW_OVERLAY" != "rd-dev" ] && [ "$TARGET_PREVIEW_OVERLAY" != "development-operator" ]; then
         log_warn "Ignoring --grafana for overlay '$TARGET_PREVIEW_OVERLAY'"
     else
     log_step "Enabling Grafana dashboard"
     log_info "Removing monitoring-workload-grafana from delete-applications.yaml"
-    yq -i 'select(.metadata.name != "monitoring-workload-grafana")' "$TARGET_DELETE_FILE"
+    yq -i 'select(.metadata.name != "monitoring-workload-grafana")' "$TARGET_OVERLAY_DELETE_FILE"
     log_success "Grafana enabled: monitoring-workload-grafana will be deployed"
     fi
 fi
 
 if $EAAS; then
-    if [ "$TARGET_PREVIEW_OVERLAY" != "development" ] && [ "$TARGET_PREVIEW_OVERLAY" != "development-operator" ]; then
+    if [ "$TARGET_PREVIEW_OVERLAY" != "rd-dev" ] && [ "$TARGET_PREVIEW_OVERLAY" != "development-operator" ]; then
         log_warn "Ignoring --eaas for overlay '$TARGET_PREVIEW_OVERLAY'"
     else
     log_step "Enabling Environment-as-a-Service (EaaS) components"
@@ -1092,7 +1099,7 @@ fi
 # =============================================================================
 label_cluster_nodes
 
-if [ "$TARGET_PREVIEW_OVERLAY" = "development" ] || [ "$TARGET_PREVIEW_OVERLAY" = "development-operator" ]; then
+if [ "$TARGET_PREVIEW_OVERLAY" = "rd-dev" ] || [ "$TARGET_PREVIEW_OVERLAY" = "development-operator" ]; then
     configure_deploy_only
     configure_kueue_for_ocp_version
     configure_operator_image_controller
@@ -1138,9 +1145,9 @@ fi
 deploy_and_wait_for_argocd
 
 # =============================================================================
-# Wait for Konflux CR (development-operator overlay on OpenShift)
+# Wait for Konflux CR
 # =============================================================================
-if [ "$TARGET_PREVIEW_OVERLAY" = "development-operator" ]; then
+if [ "$TARGET_PREVIEW_OVERLAY" = "rd-dev" ] || [ "$TARGET_PREVIEW_OVERLAY" = "development-operator" ]; then
     wait_for_konflux_operator_controller_ready
     if [ "${PREVIEW_WAIT_KONFLUX_CR_READY:-}" = "true" ]; then
         wait_for_konflux_cr_ready
@@ -1158,7 +1165,7 @@ wait_for_tekton_crds
 # =============================================================================
 # Final Configuration
 # =============================================================================
-if [ "$TARGET_PREVIEW_OVERLAY" = "development" ] || [ "$TARGET_PREVIEW_OVERLAY" = "development-operator" ]; then
+if [ "$TARGET_PREVIEW_OVERLAY" = "rd-dev" ] || [ "$TARGET_PREVIEW_OVERLAY" = "development-operator" ]; then
     log_step "Configuring Pipelines as Code integration"
     TARGET_PREVIEW_OVERLAY="$TARGET_PREVIEW_OVERLAY" "$ROOT/hack/build/setup-pac-integration.sh"
     log_success "Pipelines as Code configured"

--- a/infra-tools/Makefile
+++ b/infra-tools/Makefile
@@ -59,6 +59,7 @@ build: fmt vet ## Build all binaries.
 	go build -o $(LOCALBIN)/env-detector ./cmd/env-detector
 	go build -o $(LOCALBIN)/render-diff ./cmd/render-diff
 	go build -o $(LOCALBIN)/changelog-generator ./cmd/changelog-generator
+	go build -o $(LOCALBIN)/overlay-app-collision-checker ./cmd/overlay-app-collision-checker
 
 .PHONY: clean
 clean: ## Remove build artifacts.

--- a/infra-tools/README.md
+++ b/infra-tools/README.md
@@ -130,10 +130,12 @@ markdown to stdout.
 ```
 infra-tools/
   cmd/
-    env-detector/        CLI entry point for env-detector
-    render-diff/         CLI entry point for render-diff
+    env-detector/                   CLI entry point for env-detector
+    overlay-app-collision-checker/  CLI entry point for overlay-app-collision-checker
+    render-diff/                    CLI entry point for render-diff
   internal/
     appset/              ArgoCD ApplicationSet YAML parser
+    collision/           ArgoCD ApplicationSet app name collision detection
     deptree/             Kustomize dependency tree resolver
     detector/            Core detection logic (overlay building, file matching)
     git/                 Git operations (diff, worktree, merge-base)
@@ -143,9 +145,9 @@ infra-tools/
   Makefile               Build, test, lint targets
 ```
 
-The `internal/` packages are shared between both tools. The `detector` package
-provides the detection pipeline that both tools build on: it constructs
-ApplicationSet overlays, resolves kustomize dependency trees, and matches
+The `internal/` packages are shared between all tools. The `detector` package
+provides the detection pipeline that the `render-diff` and `env-detector` tools build on: 
+it constructs ApplicationSet overlays, resolves kustomize dependency trees, and matches
 changed files to affected components.
 
 ## Development

--- a/infra-tools/README.md
+++ b/infra-tools/README.md
@@ -31,6 +31,34 @@ Key flags:
 - `--dry-run` — print results without calling GitHub
 - `--log-file` — write debug logs to a file
 
+### overlay-app-collision-checker
+
+Detects ArgoCD ApplicationSets that would template colliding generated
+Application names when their overlays are deployed together to the same
+cluster / ArgoCD control-plane namespace (e.g. during e2e bootstrap, or when
+one overlay imports another's ApplicationSets directly). Fails loudly at
+PR/CI time instead of letting the collision surface later as a flaky ArgoCD
+ownership conflict.
+
+```bash
+# Build the binary
+cd infra-tools
+make build
+
+# Check all known co-deployed overlay groups
+./bin/overlay-app-collision-checker
+
+# Explicit repo root (default: auto-detect via git)
+./bin/overlay-app-collision-checker --repo-root /path/to/infra-deployments
+```
+
+Key flags:
+- `--repo-root` — path to the repository root (default: auto-detect via `git`)
+
+The overlay groups checked are hardcoded in `internal/collision.DefaultGroups`;
+add a new entry there whenever a new pair of overlays gets co-deployed to the
+same cluster.
+
 ### render-diff
 
 Computes and displays the kustomize render delta for components affected by

--- a/infra-tools/cmd/overlay-app-collision-checker/main.go
+++ b/infra-tools/cmd/overlay-app-collision-checker/main.go
@@ -11,8 +11,10 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"os/signal"
 	"path/filepath"
 	"strings"
+	"syscall"
 
 	"github.com/redhat-appstudio/infra-deployments/infra-tools/internal/collision"
 	"github.com/redhat-appstudio/infra-deployments/infra-tools/internal/git"
@@ -22,9 +24,13 @@ func main() {
 	repoRoot := flag.String("repo-root", "", "Path to the repository root (default: auto-detect via git)")
 	flag.Parse()
 
+	// Set up a context that is cancelled on SIGINT / SIGTERM.
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
 	root := *repoRoot
 	if root == "" {
-		detected, err := git.TopLevel(context.Background())
+		detected, err := git.TopLevel(ctx)
 		if err != nil {
 			fatal("auto-detecting repo root; use --repo-root to specify explicitly: %v", err)
 		}

--- a/infra-tools/cmd/overlay-app-collision-checker/main.go
+++ b/infra-tools/cmd/overlay-app-collision-checker/main.go
@@ -1,0 +1,82 @@
+// Command overlay-app-collision-checker detects ArgoCD ApplicationSets that
+// would template colliding generated Application names when their overlays
+// are deployed together to the same cluster / ArgoCD control-plane
+// namespace (see internal/collision for background). It fails loudly at
+// PR/CI time instead of letting the collision surface later as a flaky
+// ArgoCD ownership conflict during e2e or in production.
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/redhat-appstudio/infra-deployments/infra-tools/internal/collision"
+	"github.com/redhat-appstudio/infra-deployments/infra-tools/internal/git"
+)
+
+func main() {
+	repoRoot := flag.String("repo-root", "", "Path to the repository root (default: auto-detect via git)")
+	flag.Parse()
+
+	root := *repoRoot
+	if root == "" {
+		detected, err := git.TopLevel(context.Background())
+		if err != nil {
+			fatal("auto-detecting repo root; use --repo-root to specify explicitly: %v", err)
+		}
+		root = detected
+	}
+
+	absRoot, err := filepath.Abs(root)
+	if err != nil {
+		fatal("resolving repo root: %v", err)
+	}
+
+	hadCollision := false
+
+	for _, group := range collision.DefaultGroups {
+		fmt.Printf("== Checking co-deployed group: %s ==\n", strings.Join(group.OverlayPaths, " "))
+
+		collisions, err := collision.CheckOverlayGroup(absRoot, group)
+		if err != nil {
+			fatal("checking group %v: %v", group.OverlayPaths, err)
+		}
+
+		if len(collisions) == 0 {
+			fmt.Println("  OK: no colliding generated Application names")
+			continue
+		}
+
+		hadCollision = true
+		for _, c := range collisions {
+			fmt.Println()
+			fmt.Printf("COLLISION: generated Application name %q is templated by multiple ApplicationSets:\n", c.AppNameTemplate)
+			for _, e := range c.AppSets {
+				fmt.Printf("  - ApplicationSet %q in %s\n", e.Name, e.OverlayPath)
+			}
+		}
+	}
+
+	fmt.Println()
+	if hadCollision {
+		fmt.Println("One or more ApplicationSets would collide when co-deployed to the same cluster.")
+		fmt.Println("Fix one of the following before merging:")
+		fmt.Println("  - Remove/disable the superseded ApplicationSet from its overlay (see the")
+		fmt.Println("    delete-applications.yaml / delete-legacy-konflux-member-appsets.yaml")
+		fmt.Println("    patterns used by argo-cd-apps/overlays/development(-operator)).")
+		fmt.Println("  - Rename the colliding Application via spec.template.metadata.name so the")
+		fmt.Println("    two ApplicationSets no longer template the same generated Application name.")
+		os.Exit(1)
+	}
+
+	fmt.Println("No overlay Application-name collisions detected.")
+}
+
+func fatal(format string, args ...any) {
+	fmt.Fprintf(os.Stderr, format+"\n", args...)
+	os.Exit(1)
+}

--- a/infra-tools/internal/collision/collision.go
+++ b/infra-tools/internal/collision/collision.go
@@ -1,0 +1,177 @@
+// Package collision detects ArgoCD ApplicationSets that would template
+// colliding generated Application names when their overlays are deployed
+// together to the same cluster / ArgoCD control-plane namespace.
+//
+// Background: argo-cd-apps overlays generate child Applications from an
+// ApplicationSet's spec.template.metadata.name, e.g. "my-app-{{nameNormalized}}".
+// Kustomize's nameSuffix only renames the ApplicationSet object itself
+// (e.g. "my-app" -> "my-app-ring-0"); it does NOT rewrite the templated string
+// inside spec.template.metadata.name, since that's opaque spec data to
+// Kustomize, not a tracked object reference. So if two *different*
+// ApplicationSets are deployed to the same cluster and both template the
+// same generated Application name (e.g. both produce
+// "my-app-{{nameNormalized}}"), ArgoCD's ApplicationSet controller will fight
+// over ownership of the resulting Application object -- one of them loses,
+// and that Application gets stuck/flapping.
+//
+// This matters during the argo-cd-apps/overlays/development ->
+// argo-cd-apps/overlays/rd-dev ring-based migration: rd-dev and
+// development-operator both pull in the development overlay as a nested kustomize
+// resource, so a component that temporarily exists both in development and
+// directly in rd-dev (e.g. mid-migration, before the old ApplicationSet is
+// deleted via delete-legacy-konflux-member-appsets.yaml) will template a
+// colliding Application name within that single overlay's own build output and cause
+// e2e tests to fail.
+package collision
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/redhat-appstudio/infra-deployments/infra-tools/internal/kustomize"
+)
+
+// -------------------- Types --------------------
+
+// OverlayGroup is a set of overlays that are deployed together to the same cluster
+// / ArgoCD control-plane namespace (e.g. during e2e bootstrap, or one
+// overlay importing another's ApplicationSets directly), and therefore must
+// not template colliding generated Application names.
+type OverlayGroup struct {
+	OverlayPaths []string // relative to the repo root; e.g. "argo-cd-apps/overlays/my-overlay"
+}
+
+// DefaultGroups lists the known sets of overlays that are deployed together.
+// Add new groups here if new overlays are wired into shared bootstrap
+// targets or if an overlay imports another's ApplicationSets directly.
+var DefaultGroups = []OverlayGroup{
+	{OverlayPaths: []string{"argo-cd-apps/overlays/rd-dev"}},
+	{OverlayPaths: []string{"argo-cd-apps/overlays/development-operator"}},
+}
+
+// AppSet represents one ApplicationSet found while building an overlay: the
+// generated Application name template it produces
+// (spec.template.metadata.name), its own object name, and the overlay it
+// was found in.
+type AppSet struct {
+	AppNameTemplate string // e.g. "my-app-{{nameNormalized}}"
+	Name            string // e.g. "my-app"
+	OverlayPath     string // relative to the repo root; e.g. "argo-cd-apps/overlays/my-overlay"
+}
+
+// Collision groups together the AppSets that all produce the same generated
+// Application name template.
+type Collision struct {
+	AppNameTemplate string // e.g. "my-app-{{nameNormalized}}"
+	AppSets         []AppSet
+}
+
+// -------------------- Functions --------------------
+
+// CheckOverlayGroup builds every overlay in the group to verify that no
+// generated Application name templates collide.
+func CheckOverlayGroup(repoRoot string, group OverlayGroup) ([]Collision, error) {
+	var appSets []AppSet
+	for _, overlayPath := range group.OverlayPaths {
+		dir := filepath.Join(repoRoot, overlayPath)
+		rendered, err := kustomize.Build(dir)
+		if err != nil {
+			return nil, fmt.Errorf("building overlay %s: %w", overlayPath, err)
+		}
+
+		overlayAppSets, err := extractAppSets(rendered, overlayPath)
+		if err != nil {
+			return nil, fmt.Errorf("parsing ApplicationSets in %s: %w", overlayPath, err)
+		}
+		appSets = append(appSets, overlayAppSets...)
+	}
+
+	return findCollisions(appSets), nil
+}
+
+// ExtractAppSets decodes rendered multi-document YAML and creates an
+// AppSet for every ApplicationSet resource found. ApplicationSets with no
+// resolvable spec.template.metadata.name are skipped (nothing to compare).
+func extractAppSets(rendered []byte, overlayPath string) ([]AppSet, error) {
+	var appSets []AppSet
+
+	decoder := yaml.NewDecoder(bytes.NewReader(rendered))
+	for {
+		// decode the next YAML document
+		var doc map[string]interface{}
+		err := decoder.Decode(&doc)
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("decoding YAML document: %w", err)
+		}
+		if doc == nil {
+			continue
+		}
+
+		// skip non-ApplicationSet resources
+		kind, _ := doc["kind"].(string)
+		if kind != "ApplicationSet" {
+			continue
+		}
+
+		template := stringField(doc, "spec", "template", "metadata", "name")
+		if template == "" {
+			continue
+		}
+
+		appSets = append(appSets, AppSet{
+			AppNameTemplate: template,
+			Name:            stringField(doc, "metadata", "name"),
+			OverlayPath:     overlayPath,
+		})
+	}
+
+	return appSets, nil
+}
+
+// stringField walks a chain of nested map[string]interface{} keys and
+// returns the string value at the end, or "" if any key along the path is
+// missing or not a map/string.
+func stringField(doc map[string]interface{}, keys ...string) string {
+	var current interface{} = doc
+	for _, key := range keys {
+		m, ok := current.(map[string]interface{})
+		if !ok {
+			return ""
+		}
+		current = m[key]
+	}
+	s, _ := current.(string)
+	return s
+}
+
+// FindCollisions groups appSets by AppNameTemplate, preserving first-seen order,
+// and returns any groups with more than one appSet.
+func findCollisions(appSets []AppSet) []Collision {
+	byTemplate := make(map[string][]AppSet)
+	var orderedSet []string
+
+	// Only add app name templates to the ordered set if they haven't been seen yet
+	for _, appSet := range appSets {
+		if _, seen := byTemplate[appSet.AppNameTemplate]; !seen {
+			orderedSet = append(orderedSet, appSet.AppNameTemplate)
+		}
+		byTemplate[appSet.AppNameTemplate] = append(byTemplate[appSet.AppNameTemplate], appSet)
+	}
+
+	// If an app name template has more than one associated app set, there's a collision
+	var collisions []Collision
+	for _, tmpl := range orderedSet {
+		if appSets := byTemplate[tmpl]; len(appSets) > 1 {
+			collisions = append(collisions, Collision{AppNameTemplate: tmpl, AppSets: appSets})
+		}
+	}
+	return collisions
+}

--- a/infra-tools/internal/collision/collision_test.go
+++ b/infra-tools/internal/collision/collision_test.go
@@ -1,0 +1,157 @@
+package collision_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/redhat-appstudio/infra-deployments/infra-tools/internal/collision"
+)
+
+// -------------------- extractAppSets Tests --------------------
+func TestExtractAppSets_ExtractsTemplateAndName(t *testing.T) {
+	g := NewWithT(t)
+
+	yaml := `
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: my-app
+spec:
+  template:
+    metadata:
+      name: my-app-{{nameNormalized}}
+    spec:
+      source:
+        path: components/my-app-rd
+`
+	appSets, err := collision.ExtractAppSets([]byte(yaml), "argo-cd-apps/overlays/rd-dev")
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(appSets).To(HaveLen(1))
+	g.Expect(appSets[0].AppNameTemplate).To(Equal("my-app-{{nameNormalized}}"))
+	g.Expect(appSets[0].Name).To(Equal("my-app"))
+	g.Expect(appSets[0].OverlayPath).To(Equal("argo-cd-apps/overlays/rd-dev"))
+}
+
+func TestExtractAppSets_EmptyYAML(t *testing.T) {
+	g := NewWithT(t)
+
+	yaml := ``
+	appSets, err := collision.ExtractAppSets([]byte(yaml), "overlay")
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(appSets).To(BeEmpty())
+}
+
+func TestExtractAppSets_NonAppSetResourcesIgnored(t *testing.T) {
+	g := NewWithT(t)
+
+	yaml := `
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: not-an-appset
+data:
+  key: value
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: my-app
+spec:
+  template:
+    metadata:
+      name: my-app-{{nameNormalized}}
+`
+	appSets, err := collision.ExtractAppSets([]byte(yaml), "overlay")
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(appSets).To(HaveLen(1))
+}
+
+func TestExtractAppSets_MissingTemplateNameSkipped(t *testing.T) {
+	g := NewWithT(t)
+
+	yaml := `
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: no-template-name
+spec:
+  template:
+    spec:
+      source:
+        path: components/foo
+`
+	appSets, err := collision.ExtractAppSets([]byte(yaml), "overlay")
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(appSets).To(BeEmpty())
+}
+
+func TestExtractAppSets_DecoderErrorReturned(t *testing.T) {
+	g := NewWithT(t)
+
+	yaml := `
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+	`
+	appSets, err := collision.ExtractAppSets([]byte(yaml), "overlay")
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(appSets).To(BeEmpty())
+	g.Expect(err).To(MatchError(ContainSubstring("decoding YAML document")))
+}
+
+// -------------------- findCollisions Tests --------------------
+func TestFindCollisions_DetectsDuplicateTemplates(t *testing.T) {
+	g := NewWithT(t)
+
+	entries := []collision.AppSet{
+		{AppNameTemplate: "my-app-{{nameNormalized}}", Name: "my-app", OverlayPath: "argo-cd-apps/overlays/development"},
+		{AppNameTemplate: "my-app-{{nameNormalized}}", Name: "my-app", OverlayPath: "argo-cd-apps/overlays/rd-dev"},
+		{AppNameTemplate: "ur-app-{{nameNormalized}}", Name: "ur-app", OverlayPath: "argo-cd-apps/overlays/rd-dev"},
+	}
+
+	collisions := collision.FindCollisions(entries)
+	g.Expect(collisions).To(HaveLen(1))
+	g.Expect(collisions[0].AppNameTemplate).To(Equal("my-app-{{nameNormalized}}"))
+	g.Expect(collisions[0].AppSets).To(HaveLen(2))
+}
+
+func TestFindCollisions_NoDuplicatesReturnsEmpty(t *testing.T) {
+	g := NewWithT(t)
+
+	entries := []collision.AppSet{
+		{AppNameTemplate: "my-app-{{nameNormalized}}", Name: "my-app", OverlayPath: "argo-cd-apps/overlays/development"},
+		{AppNameTemplate: "ur-app-{{nameNormalized}}", Name: "ur-app", OverlayPath: "argo-cd-apps/overlays/rd-dev"},
+	}
+
+	g.Expect(collision.FindCollisions(entries)).To(BeEmpty())
+}
+
+// -------------------- stringField Tests --------------------
+func TestStringField_ValidNestedPath(t *testing.T) {
+	g := NewWithT(t)
+
+	doc := map[string]interface{}{
+		"spec": map[string]interface{}{
+			"template": map[string]interface{}{
+				"metadata": map[string]interface{}{
+					"name": "my-app-{{nameNormalized}}",
+				},
+			},
+		},
+	}
+
+	g.Expect(collision.StringField(doc, "spec", "template", "metadata", "name")).To(Equal("my-app-{{nameNormalized}}"))
+	g.Expect(collision.StringField(doc, "spec", "missing", "name")).To(Equal(""))
+	g.Expect(collision.StringField(doc, "spec", "template", "metadata", "missing")).To(Equal(""))
+}
+
+func TestStringField_InvalidNestedPath(t *testing.T) {
+	g := NewWithT(t)
+
+	doc := map[string]interface{}{
+		"spec": "string",
+	}
+
+	g.Expect(collision.StringField(doc, "spec", "template", "metadata", "name")).To(Equal(""))
+}

--- a/infra-tools/internal/collision/export_test.go
+++ b/infra-tools/internal/collision/export_test.go
@@ -1,0 +1,10 @@
+package collision
+
+// Test-only exports so the external collision_test package can exercise
+// unexported helpers directly without duplicating logic or requiring a real
+// kustomize build on disk for every test case.
+var (
+	ExtractAppSets = extractAppSets
+	FindCollisions = findCollisions
+	StringField    = stringField
+)


### PR DESCRIPTION
Referenced the `development` overlay n the `rd-dev` overlay to be able to run e2e tests on all ApplicationSets through `rd-dev`. Also added the overlay-app-collision-checker to infra-tools to detectcollisions when overlays are deployed together to the same cluster / ArgoCD control-plane namespace (like `development `and `rd-dev`).