### PR TITLE
KFLUXINFRA-4408 Add tenant cluster selector to kubearchive ApplicationSets

### DIFF
--- a/argo-cd-apps/base/member/infra-deployments/kubearchive/kustomization.yaml
+++ b/argo-cd-apps/base/member/infra-deployments/kubearchive/kustomization.yaml
@@ -6,3 +6,21 @@ resources:
 components:
   - ../../../../k-components/inject-infra-deployments-repo-details
   - ../../../../k-components/deploy-to-member-cluster-merge-generator
+patches:
+  - target:
+      group: argoproj.io
+      version: v1alpha1
+      kind: ApplicationSet
+      name: kubearchive
+    patch: |-
+      - op: add
+        path: /spec/generators/0/merge/generators/1
+        value:
+          clusters:
+            selector:
+              matchLabels:
+                appstudio.redhat.com/cluster-type: "tenant"
+            values:
+              sourceRoot: components/kubearchive
+              environment: staging
+              clusterDir: ""

--- a/argo-cd-apps/base/member/infra-deployments/vector-kubearchive-log-collector/kustomization.yaml
+++ b/argo-cd-apps/base/member/infra-deployments/vector-kubearchive-log-collector/kustomization.yaml
@@ -5,3 +5,21 @@ resources:
 components:
   - ../../../../k-components/inject-infra-deployments-repo-details
   - ../../../../k-components/deploy-to-member-cluster-merge-generator
+patches:
+  - target:
+      group: argoproj.io
+      version: v1alpha1
+      kind: ApplicationSet
+      name: vector-kubearchive-log-collector
+    patch: |-
+      - op: add
+        path: /spec/generators/0/merge/generators/1
+        value:
+          clusters:
+            selector:
+              matchLabels:
+                appstudio.redhat.com/cluster-type: "tenant"
+            values:
+              sourceRoot: components/vector-kubearchive-log-collector
+              environment: staging
+              clusterDir: empty-base


### PR DESCRIPTION
## What

Fix ArgoCD ApplicationSet cluster selector for kubearchive and vector-kubearchive-log-collector so that lightwell-dev is discovered.

Follow-up to #13458 — lightwell-dev overlays were added but ArgoCD never generated Applications because the cluster is labeled `cluster-type: tenant`, not `member-cluster: true`.

Adds a second `clusters:` generator to the merge in both ApplicationSets that selects `appstudio.redhat.com/cluster-type: tenant`, so clusters matching either label are included.

[KFLUXINFRA-4408](https://redhat.atlassian.net/browse/KFLUXINFRA-4408)

## Why

The `deploy-to-member-cluster-merge-generator` k-component only selects clusters with `appstudio.redhat.com/member-cluster: "true"`. lightwell-dev carries `appstudio.redhat.com/cluster-type: tenant` instead, so no Application was created for it after #13458 merged.

## Validation

- `kustomize build` confirms both ApplicationSets render with two `clusters:` generators plus the list generator in the merge.

## Risk Assessment

**Risk Level:** Low
**What could go wrong:** A future tenant-labeled cluster not in the list generator would get a default Application (empty `clusterDir` for kubearchive, `empty-base` for vector). Today lightwell-dev is the only tenant staging cluster.
**Rollback:** Revert PR to restore single-selector behavior.
**Blast radius:** Staging kubearchive and vector-kubearchive-log-collector only. No production impact.

[KFLUXINFRA-4408]: https://redhat.atlassian.net/browse/KFLUXINFRA-4408?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ