### PR TITLE
Add a banner warning about prefetch-deps <0.7.1

### DIFF
--- a/components/konflux-info/production/kflux-ocp-p01/banner-content.yaml
+++ b/components/konflux-info/production/kflux-ocp-p01/banner-content.yaml
@@ -1,2 +1,3 @@
 # Only the first banner will be displayed. Put the one to display at the top and remove any which are no longer relevant
-[]
+- summary: "Versions of prefetch-dependencies task older than 0.7.1 have been deprecated for security reasons. Please upgrade to avoid Conforma violations. See #konflux-users and konflux-announce e-mails for more information."
+  type: "danger"

--- a/components/konflux-info/production/kflux-osp-p01/banner-content.yaml
+++ b/components/konflux-info/production/kflux-osp-p01/banner-content.yaml
@@ -1,2 +1,3 @@
 # Only the first banner will be displayed. Put the one to display at the top and remove any which are no longer relevant
-[]
+- summary: "Versions of prefetch-dependencies task older than 0.7.1 have been deprecated for security reasons. Please upgrade to avoid Conforma violations. See #konflux-users and konflux-announce e-mails for more information."
+  type: "danger"

--- a/components/konflux-info/production/kflux-prd-rh02/banner-content.yaml
+++ b/components/konflux-info/production/kflux-prd-rh02/banner-content.yaml
@@ -1,2 +1,3 @@
 # Only the first banner will be displayed. Put the one to display at the top and remove any which are no longer relevant
-[]
+- summary: "Versions of prefetch-dependencies task older than 0.7.1 have been deprecated for security reasons. Please upgrade to avoid Conforma violations. See #konflux-users and konflux-announce e-mails for more information."
+  type: "danger"

--- a/components/konflux-info/production/kflux-prd-rh03/banner-content.yaml
+++ b/components/konflux-info/production/kflux-prd-rh03/banner-content.yaml
@@ -1,2 +1,3 @@
 # Only the first banner will be displayed. Put the one to display at the top and remove any which are no longer relevant
-[]
+- summary: "Versions of prefetch-dependencies task older than 0.7.1 have been deprecated for security reasons. Please upgrade to avoid Conforma violations. See #konflux-users and konflux-announce e-mails for more information."
+  type: "danger"

--- a/components/konflux-info/production/kflux-rhel-p01/banner-content.yaml
+++ b/components/konflux-info/production/kflux-rhel-p01/banner-content.yaml
@@ -1,2 +1,3 @@
 # Only the first banner will be displayed. Put the one to display at the top and remove any which are no longer relevant
-[]
+- summary: "Versions of prefetch-dependencies task older than 0.7.1 have been deprecated for security reasons. Please upgrade to avoid Conforma violations. See #konflux-users and konflux-announce e-mails for more information."
+  type: "danger"

--- a/components/konflux-info/production/stone-prd-rh01/banner-content.yaml
+++ b/components/konflux-info/production/stone-prd-rh01/banner-content.yaml
@@ -1,2 +1,3 @@
 # Only the first banner will be displayed. Put the one to display at the top and remove any which are no longer relevant
-[]
+- summary: "Versions of prefetch-dependencies task older than 0.7.1 have been deprecated for security reasons. Please upgrade to avoid Conforma violations. See #konflux-users and konflux-announce e-mails for more information."
+  type: "danger"

--- a/components/konflux-info/production/stone-prod-p01/banner-content.yaml
+++ b/components/konflux-info/production/stone-prod-p01/banner-content.yaml
@@ -1,2 +1,3 @@
 # Only the first banner will be displayed. Put the one to display at the top and remove any which are no longer relevant
-[]
+- summary: "Versions of prefetch-dependencies task older than 0.7.1 have been deprecated for security reasons. Please upgrade to avoid Conforma violations. See #konflux-users and konflux-announce e-mails for more information."
+  type: "danger"

--- a/components/konflux-info/production/stone-prod-p02/banner-content.yaml
+++ b/components/konflux-info/production/stone-prod-p02/banner-content.yaml
@@ -1,2 +1,3 @@
 # Only the first banner will be displayed. Put the one to display at the top and remove any which are no longer relevant
-[]
+- summary: "Versions of prefetch-dependencies task older than 0.7.1 have been deprecated for security reasons. Please upgrade to avoid Conforma violations. See #konflux-users and konflux-announce e-mails for more information."
+  type: "danger"


### PR DESCRIPTION
Versions of prefetch-dependencies task <0.7.1 are now deprecated and cause Conforma violations.
This has the potential to affect a lot of users, warn them with a banner.

## Risk Assessment
Low

It's a banner... 

## Validation
It's a banner... I did proofread it... 