### PR TITLE
KFLUXINFRA-4408: Fix kubearchive DATABASE_PORT to use vault secret in lightwell-dev

### DIFF
--- a/components/kubearchive/staging/lightwell-dev/database-secret.yaml
+++ b/components/kubearchive/staging/lightwell-dev/database-secret.yaml
@@ -21,7 +21,7 @@ spec:
     template:
       data:
         DATABASE_KIND: postgresql
-        DATABASE_PORT: "5432"
+        DATABASE_PORT: '{{ index . "db.port" }}'
         DATABASE_URL: '{{ index . "db.host" }}'
         DATABASE_PASSWORD: '{{ index . "db.password" }}'
         DATABASE_USER: '{{ index . "db.user" }}'


### PR DESCRIPTION
## What

Source `DATABASE_PORT` from the vault secret instead of hardcoding `"5432"` in the kubearchive ExternalSecret for the lightwell-dev staging cluster.

Clusters affected: lightwell-dev (staging)

[KFLUXINFRA-4408](https://redhat.atlassian.net/browse/KFLUXINFRA-4408)

## Why

All other database connection fields (`DATABASE_URL`, `DATABASE_PASSWORD`, `DATABASE_USER`, `DATABASE_DB`, `DATABASE_CA_CERT`) in the ExternalSecret template already pull their values from the vault. The port was the only hardcoded value, making it inconsistent and potentially incorrect if the vault-managed database uses a non-standard port.

## Validation

- `kustomize build --enable-helm components/kubearchive/staging/lightwell-dev/` passes
- Template syntax matches the existing pattern used for other dotted-key vault fields (e.g., `{{ index . "db.host" }}`)


Made with [Cursor](https://cursor.com)

[KFLUXINFRA-4408]: https://redhat.atlassian.net/browse/KFLUXINFRA-4408?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ