### PR TITLE
KFLUXINFRA-4408 Add tenant cluster selector to kubearchive ApplicationSets

### DIFF
--- a/argo-cd-apps/overlays/staging-downstream/kubearchive-tenant-cluster-patch.yaml
+++ b/argo-cd-apps/overlays/staging-downstream/kubearchive-tenant-cluster-patch.yaml
@@ -1,0 +1,12 @@
+---
+- op: add
+  path: /spec/generators/0/merge/generators/1
+  value:
+    clusters:
+      selector:
+        matchLabels:
+          appstudio.redhat.com/cluster-type: "tenant"
+      values:
+        sourceRoot: components/kubearchive
+        environment: staging
+        clusterDir: ""

--- a/argo-cd-apps/overlays/staging-downstream/kustomization.yaml
+++ b/argo-cd-apps/overlays/staging-downstream/kustomization.yaml
@@ -26,6 +26,16 @@ patches:
       kind: ApplicationSet
       version: v1alpha1
       name: multi-platform-controller
+  - path: kubearchive-tenant-cluster-patch.yaml
+    target:
+      kind: ApplicationSet
+      version: v1alpha1
+      name: kubearchive
+  - path: vector-kubearchive-tenant-cluster-patch.yaml
+    target:
+      kind: ApplicationSet
+      version: v1alpha1
+      name: vector-kubearchive-log-collector
   # Exclude operator-managed clusters from Argo generation for services owned
   # by the konflux-operator. Orphan (do not prune) when Applications go away.
   # release stays on Argo with disable-auto-sync until monitor ownership is confirmed.

--- a/argo-cd-apps/overlays/staging-downstream/vector-kubearchive-tenant-cluster-patch.yaml
+++ b/argo-cd-apps/overlays/staging-downstream/vector-kubearchive-tenant-cluster-patch.yaml
@@ -1,0 +1,12 @@
+---
+- op: add
+  path: /spec/generators/0/merge/generators/1
+  value:
+    clusters:
+      selector:
+        matchLabels:
+          appstudio.redhat.com/cluster-type: "tenant"
+      values:
+        sourceRoot: components/vector-kubearchive-log-collector
+        environment: staging
+        clusterDir: empty-base


### PR DESCRIPTION
## What

- Add `kubearchive-tenant-cluster-patch.yaml` and `vector-kubearchive-tenant-cluster-patch.yaml` to the staging-downstream overlay
- Wire both patches in `argo-cd-apps/overlays/staging-downstream/kustomization.yaml`

Clusters affected: lightwell-dev (staging-downstream)

[KFLUXINFRA-4408](https://redhat.atlassian.net/browse/KFLUXINFRA-4408)

## Why

Follow-up to #13458 — lightwell-dev overlays exist but ArgoCD did not generate Applications because the cluster is labeled `cluster-type: tenant`, not `member-cluster: true`.

Alternative to #13488: same fix using separate overlay patch files (like `mpc-lightwell-dev-patch.yaml`) instead of inline patches in base `kustomization.yaml` files.

## Validation

- `kustomize build argo-cd-apps/overlays/staging-downstream/` passes locally
- Rendered `kubearchive` and `vector-kubearchive-log-collector` ApplicationSets include a second `clusters:` generator selecting `appstudio.redhat.com/cluster-type: tenant`

## Risk Assessment

**Risk Level:** Low
**What could go wrong:** A future tenant-labeled cluster not in the list generator would get a default Application (empty `clusterDir` for kubearchive, `empty-base` for vector). Today lightwell-dev is the only tenant staging cluster.
**Rollback:** Revert this PR.
**Blast radius:** Staging-downstream kubearchive and vector-kubearchive-log-collector only. No production impact.


Made with [Cursor](https://cursor.com)

[KFLUXINFRA-4408]: https://redhat.atlassian.net/browse/KFLUXINFRA-4408?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ