### PR TITLE
fix(KFLUXVNGD-1270): Add etcd-shield overlay for lightwell-dev staging cluster

### DIFF
--- a/components/etcd-shield/rings/ring-1/lightwell-dev/kustomization.yaml
+++ b/components/etcd-shield/rings/ring-1/lightwell-dev/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../base


### PR DESCRIPTION


Add the missing per-cluster overlay at
components/etcd-shield/rings/ring-1/lightwell-dev/ so the etcd-shield-lightwell-dev ArgoCD Application can resolve its target path and sync successfully.

The lightwell-dev cluster was already listed in the deploy-to-staging-tenant-clusters k-component patch at ring-1, but the corresponding directory did not exist, causing ArgoCD to fail with a manifest generation error.

Assisted-by: Cursor (claude-4.6-opus)