### PR TITLE
PVO11Y-5439 Enable Tekton Prometheus for lightwell-dev

### DIFF
--- a/components/monitoring/prometheus/staging/lightwell-dev/kustomization.yaml
+++ b/components/monitoring/prometheus/staging/lightwell-dev/kustomization.yaml
@@ -2,10 +2,23 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - ../base
+- ../tekton-ms
 patches:
   - path: cluster-id-label.yaml
     target:
       name: appstudio-federate-ms
+      kind: MonitoringStack
+      group: monitoring.rhobs
+      version: v1alpha1
+  - path: cluster-id-label.yaml
+    target:
+      name: appstudio-tekton-ms
+      kind: MonitoringStack
+      group: monitoring.rhobs
+      version: v1alpha1
+  - path: storage-class-patch.yaml
+    target:
+      name: appstudio-tekton-ms
       kind: MonitoringStack
       group: monitoring.rhobs
       version: v1alpha1

--- a/components/monitoring/prometheus/staging/lightwell-dev/storage-class-patch.yaml
+++ b/components/monitoring/prometheus/staging/lightwell-dev/storage-class-patch.yaml
@@ -1,0 +1,4 @@
+---
+- op: replace
+  path: /spec/prometheusConfig/persistentVolumeClaim/storageClassName
+  value: ibmc-vpc-block-metro-retain-10iops-tier


### PR DESCRIPTION
## Summary
- Add tekton-ms (dedicated Tekton Prometheus) overlay for lightwell-dev
- Override storage class from AWS `gp3` to `ibmc-vpc-block-metro-retain-10iops-tier` (`Retain` + `WaitForFirstConsumer`)

## Risk Assessment
**Level:** Low
**What could go wrong:** PVC fails to bind if the storage class behaves unexpectedly; Prometheus pods stay Pending
**Rollback:** Revert this PR — ArgoCD will prune the tekton-ms resources; federation monitoring is unaffected
**Blast radius:** lightwell-dev only, no impact on other clusters