### PR TITLE
fix(env-detector): attribute overlay diffs to AppSet generator environment

### DIFF
--- a/infra-tools/internal/appset/parse.go
+++ b/infra-tools/internal/appset/parse.go
@@ -4,6 +4,7 @@ package appset
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -30,6 +31,86 @@ type ParseResult struct {
 	// Clusters maps cluster names found in list.elements[].nameNormalized.
 	// Key: cluster name, Value: list of component paths for that cluster.
 	Clusters map[string][]string
+}
+
+// AppSetsByName parses rendered YAML (multi-document) and returns all
+// ApplicationSet resources keyed by metadata.name for change detection.
+func AppSetsByName(renderedYAML []byte) (map[string]map[string]interface{}, error) {
+	result := make(map[string]map[string]interface{})
+	if len(renderedYAML) == 0 {
+		return result, nil
+	}
+	decoder := yaml.NewDecoder(bytes.NewReader(renderedYAML))
+	for {
+		var doc map[string]interface{}
+		err := decoder.Decode(&doc)
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("decoding YAML document: %w", err)
+		}
+		if doc == nil {
+			continue
+		}
+		if kind, _ := doc["kind"].(string); kind != "ApplicationSet" {
+			continue
+		}
+		name := ""
+		if md, ok := doc["metadata"].(map[string]interface{}); ok {
+			name, _ = md["name"].(string)
+		}
+		if name != "" {
+			result[name] = doc
+		}
+	}
+	return result, nil
+}
+
+// EnvironmentFromAppSet extracts the environment value from an ApplicationSet's
+// generator configuration. It looks for a clusters generator (direct or nested
+// inside a merge generator) with a values.environment field.
+// Returns the environment string and true if an explicit environment is found.
+func EnvironmentFromAppSet(doc map[string]interface{}) (string, bool) {
+	spec, ok := doc["spec"].(map[string]interface{})
+	if !ok {
+		return "", false
+	}
+	generators, _ := spec["generators"].([]interface{})
+	for _, gen := range generators {
+		genMap, ok := gen.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if env, ok := envFromClusters(genMap["clusters"]); ok {
+			return env, true
+		}
+		merge, _ := genMap["merge"].(map[string]interface{})
+		subGens, _ := merge["generators"].([]interface{})
+		for _, sg := range subGens {
+			sgMap, ok := sg.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			if env, ok := envFromClusters(sgMap["clusters"]); ok {
+				return env, true
+			}
+		}
+	}
+	return "", false
+}
+
+func envFromClusters(v interface{}) (string, bool) {
+	clusters, ok := v.(map[string]interface{})
+	if !ok {
+		return "", false
+	}
+	values, _ := clusters["values"].(map[string]interface{})
+	env, _ := values["environment"].(string)
+	if env == "" {
+		return "", false
+	}
+	return env, true
 }
 
 // ParseApplicationSets parses rendered YAML (multi-document) and extracts

--- a/infra-tools/internal/appset/parse_test.go
+++ b/infra-tools/internal/appset/parse_test.go
@@ -234,6 +234,193 @@ spec:
 	g.Expect(result.Paths).To(HaveLen(2))
 }
 
+// ---------------------------------------------------------------------------
+// AppSetsByName
+// ---------------------------------------------------------------------------
+
+func TestAppSetsByName_Basic(t *testing.T) {
+	g := NewWithT(t)
+
+	yaml := `apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: kanary
+spec:
+  generators:
+    - merge:
+        generators:
+          - clusters:
+              values:
+                environment: staging
+  template:
+    metadata:
+      name: kanary-{{nameNormalized}}
+    spec:
+      source:
+        path: components/kanary/staging
+        repoURL: https://example.com/repo.git
+      destination:
+        server: '{{server}}'
+`
+	result, err := AppSetsByName([]byte(yaml))
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(result).To(HaveKey("kanary"))
+}
+
+func TestAppSetsByName_Empty(t *testing.T) {
+	g := NewWithT(t)
+	result, err := AppSetsByName([]byte{})
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(result).To(BeEmpty())
+}
+
+func TestAppSetsByName_NonAppSetIgnored(t *testing.T) {
+	g := NewWithT(t)
+	result, err := AppSetsByName([]byte("apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: foo\n"))
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(result).To(BeEmpty())
+}
+
+func TestAppSetsByName_NoName(t *testing.T) {
+	g := NewWithT(t)
+	// ApplicationSet with no metadata.name is skipped.
+	yaml := `apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+spec:
+  generators: []
+  template:
+    metadata:
+      name: foo
+    spec:
+      source:
+        path: components/foo
+        repoURL: https://example.com/repo.git
+      destination:
+        server: '{{server}}'
+`
+	result, err := AppSetsByName([]byte(yaml))
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(result).To(BeEmpty())
+}
+
+func TestAppSetsByName_InvalidYAML(t *testing.T) {
+	g := NewWithT(t)
+	_, err := AppSetsByName([]byte("not: valid: yaml: [}"))
+	g.Expect(err).To(HaveOccurred())
+}
+
+func TestEnvironmentFromAppSet_NonMapGenerator(t *testing.T) {
+	g := NewWithT(t)
+	// Generator element is a string, not a map — should be skipped, return ("", false).
+	doc := map[string]interface{}{
+		"spec": map[string]interface{}{
+			"generators": []interface{}{
+				"not-a-map",
+			},
+		},
+	}
+	_, ok := EnvironmentFromAppSet(doc)
+	g.Expect(ok).To(BeFalse())
+}
+
+func TestEnvironmentFromAppSet_NonMapSubGenerator(t *testing.T) {
+	g := NewWithT(t)
+	// Sub-generator inside merge is a string — should be skipped, return ("", false).
+	doc := map[string]interface{}{
+		"spec": map[string]interface{}{
+			"generators": []interface{}{
+				map[string]interface{}{
+					"merge": map[string]interface{}{
+						"generators": []interface{}{
+							"not-a-map",
+						},
+					},
+				},
+			},
+		},
+	}
+	_, ok := EnvironmentFromAppSet(doc)
+	g.Expect(ok).To(BeFalse())
+}
+
+// ---------------------------------------------------------------------------
+// EnvironmentFromAppSet
+// ---------------------------------------------------------------------------
+
+func TestEnvironmentFromAppSet_MergeGenerator(t *testing.T) {
+	g := NewWithT(t)
+
+	doc := map[string]interface{}{
+		"spec": map[string]interface{}{
+			"generators": []interface{}{
+				map[string]interface{}{
+					"merge": map[string]interface{}{
+						"generators": []interface{}{
+							map[string]interface{}{
+								"clusters": map[string]interface{}{
+									"values": map[string]interface{}{
+										"environment": "staging",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	env, ok := EnvironmentFromAppSet(doc)
+	g.Expect(ok).To(BeTrue())
+	g.Expect(env).To(Equal("staging"))
+}
+
+func TestEnvironmentFromAppSet_DirectClustersGenerator(t *testing.T) {
+	g := NewWithT(t)
+
+	doc := map[string]interface{}{
+		"spec": map[string]interface{}{
+			"generators": []interface{}{
+				map[string]interface{}{
+					"clusters": map[string]interface{}{
+						"values": map[string]interface{}{
+							"environment": "production",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	env, ok := EnvironmentFromAppSet(doc)
+	g.Expect(ok).To(BeTrue())
+	g.Expect(env).To(Equal("production"))
+}
+
+func TestEnvironmentFromAppSet_NoEnvironment(t *testing.T) {
+	g := NewWithT(t)
+
+	// clusters: {} with no values
+	doc := map[string]interface{}{
+		"spec": map[string]interface{}{
+			"generators": []interface{}{
+				map[string]interface{}{
+					"clusters": map[string]interface{}{},
+				},
+			},
+		},
+	}
+
+	_, ok := EnvironmentFromAppSet(doc)
+	g.Expect(ok).To(BeFalse())
+}
+
+func TestEnvironmentFromAppSet_NoSpec(t *testing.T) {
+	g := NewWithT(t)
+	_, ok := EnvironmentFromAppSet(map[string]interface{}{})
+	g.Expect(ok).To(BeFalse())
+}
+
 func TestParseApplicationSets_NonAppSetResourcesIgnored(t *testing.T) {
 	g := NewWithT(t)
 

--- a/infra-tools/internal/detector/detector.go
+++ b/infra-tools/internal/detector/detector.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"path/filepath"
+	"reflect"
 	"strings"
 
 	"golang.org/x/sync/errgroup"
@@ -258,13 +259,62 @@ func (d *Detector) detectRemovedAppSetOverlays(result *Result) {
 
 // detectOverlayDiffs marks environments as affected when the rendered overlay
 // YAML differs between HEAD and the base-ref (i.e. the ArgoCD config changed).
+// When an ApplicationSet has an explicit environment in its generator, that
+// environment is used instead of the overlay's environment. This prevents base
+// changes (included by all overlays) from spuriously marking every environment.
 func detectOverlayDiffs(builds []overlayBuild, result *Result) {
 	for _, ob := range builds {
-		if string(ob.headYAML) != string(ob.baseYAML) {
+		if string(ob.headYAML) == string(ob.baseYAML) {
+			continue
+		}
+		slog.Info("Overlay diff detected", "overlay", ob.name)
+
+		headSets, headErr := appset.AppSetsByName(ob.headYAML)
+		baseSets, baseErr := appset.AppSetsByName(ob.baseYAML)
+		if headErr != nil || baseErr != nil {
+			// Can't parse ApplicationSets; conservatively mark overlay environment.
+			slog.Warn("Failed to parse ApplicationSets, falling back to overlay env",
+				"overlay", ob.name, "headErr", headErr, "baseErr", baseErr)
 			result.AffectedEnvironments[ob.env] = true
-			slog.Info("Overlay diff detected", "overlay", ob.name, "env", ob.env)
+			continue
+		}
+
+		attributed := false
+		for name, headDoc := range headSets {
+			if baseDoc, existed := baseSets[name]; existed {
+				if reflect.DeepEqual(headDoc, baseDoc) {
+					continue // this ApplicationSet is unchanged
+				}
+			}
+			env := appSetEnv(headDoc, ob.env)
+			result.AffectedEnvironments[env] = true
+			slog.Info("AppSet added/modified", "overlay", ob.name, "appset", name, "env", env)
+			attributed = true
+		}
+		for name, baseDoc := range baseSets {
+			if _, exists := headSets[name]; !exists {
+				env := appSetEnv(baseDoc, ob.env)
+				result.AffectedEnvironments[env] = true
+				slog.Info("AppSet removed", "overlay", ob.name, "appset", name, "env", env)
+				attributed = true
+			}
+		}
+		if !attributed {
+			// YAML changed but no ApplicationSet changes found (e.g. namespace patch).
+			result.AffectedEnvironments[ob.env] = true
 		}
 	}
+}
+
+// appSetEnv extracts the environment from an ApplicationSet's generator. Falls
+// back to overlayEnv when no explicit environment is set.
+func appSetEnv(doc map[string]interface{}, overlayEnv Environment) Environment {
+	if envStr, ok := appset.EnvironmentFromAppSet(doc); ok {
+		if e := Environment(envStr); e == Development || e == Staging || e == Production {
+			return e
+		}
+	}
+	return overlayEnv
 }
 
 // extractPathsFromOverlays parses ApplicationSets from the HEAD builds and

--- a/infra-tools/internal/detector/detector_test.go
+++ b/infra-tools/internal/detector/detector_test.go
@@ -824,6 +824,113 @@ func TestDetectOverlayDiffs_NewOverlay(t *testing.T) {
 	g.Expect(result.AffectedEnvironments).To(HaveKey(Production))
 }
 
+// TestDetectOverlayDiffs_BaseAppSetWithExplicitEnv covers the case where a new
+// ApplicationSet with environment:staging is added to argo-cd-apps/base and
+// therefore appears in ALL overlays' rendered output.  Only staging should be
+// marked — not development or production.
+func TestDetectOverlayDiffs_BaseAppSetWithExplicitEnv(t *testing.T) {
+	g := NewWithT(t)
+
+	const stagingAppSet = `apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: kanary
+spec:
+  generators:
+    - merge:
+        mergeKeys:
+          - nameNormalized
+        generators:
+          - clusters:
+              values:
+                sourceRoot: components/monitoring/kanary
+                environment: staging
+                clusterDir: ""
+          - list:
+              elements:
+                - nameNormalized: lightwell-dev
+                  values.clusterDir: lightwell-dev
+  template:
+    metadata:
+      name: kanary-{{nameNormalized}}
+    spec:
+      source:
+        path: '{{values.sourceRoot}}/{{values.environment}}/{{values.clusterDir}}'
+        repoURL: https://github.com/example/repo.git
+      destination:
+        server: '{{server}}'
+`
+	result := &Result{AffectedEnvironments: make(map[Environment]bool)}
+	// Simulate base change: the new AppSet appears in all overlays (dev, staging, prod),
+	// but none of them had it before (baseYAML is empty).
+	builds := []overlayBuild{
+		{name: "development", env: Development, headYAML: []byte(stagingAppSet), baseYAML: []byte{}},
+		{name: "staging-downstream", env: Staging, headYAML: []byte(stagingAppSet), baseYAML: []byte{}},
+		{name: "production-downstream", env: Production, headYAML: []byte(stagingAppSet), baseYAML: []byte{}},
+	}
+	detectOverlayDiffs(builds, result)
+
+	g.Expect(result.AffectedEnvironments).To(HaveKey(Staging))
+	g.Expect(result.AffectedEnvironments).NotTo(HaveKey(Development))
+	g.Expect(result.AffectedEnvironments).NotTo(HaveKey(Production))
+}
+
+func TestDetectOverlayDiffs_RemovedBaseAppSetUsesGeneratorEnv(t *testing.T) {
+	g := NewWithT(t)
+
+	const stagingAppSet = `apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: kanary
+spec:
+  generators:
+    - merge:
+        mergeKeys:
+          - nameNormalized
+        generators:
+          - clusters:
+              values:
+                sourceRoot: components/monitoring/kanary
+                environment: staging
+                clusterDir: ""
+  template:
+    metadata:
+      name: kanary-{{nameNormalized}}
+    spec:
+      source:
+        path: '{{values.sourceRoot}}/{{values.environment}}/{{values.clusterDir}}'
+        repoURL: https://github.com/example/repo.git
+      destination:
+        server: '{{server}}'
+`
+	result := &Result{AffectedEnvironments: make(map[Environment]bool)}
+	// AppSet existed on base (all overlays) but was removed on HEAD.
+	builds := []overlayBuild{
+		{name: "development", env: Development, headYAML: []byte{}, baseYAML: []byte(stagingAppSet)},
+		{name: "staging-downstream", env: Staging, headYAML: []byte{}, baseYAML: []byte(stagingAppSet)},
+		{name: "production-downstream", env: Production, headYAML: []byte{}, baseYAML: []byte(stagingAppSet)},
+	}
+	detectOverlayDiffs(builds, result)
+
+	// Should use generator env (staging), not the overlay's env.
+	g.Expect(result.AffectedEnvironments).To(HaveKey(Staging))
+	g.Expect(result.AffectedEnvironments).NotTo(HaveKey(Development))
+	g.Expect(result.AffectedEnvironments).NotTo(HaveKey(Production))
+}
+
+func TestDetectOverlayDiffs_ParseErrorFallsBackToOverlayEnv(t *testing.T) {
+	g := NewWithT(t)
+
+	result := &Result{AffectedEnvironments: make(map[Environment]bool)}
+	// Invalid YAML on HEAD — parse fails, should fall back to overlay env.
+	builds := []overlayBuild{
+		{name: "staging-downstream", env: Staging, headYAML: []byte("not: valid: yaml: [}"), baseYAML: []byte{}},
+	}
+	detectOverlayDiffs(builds, result)
+
+	g.Expect(result.AffectedEnvironments).To(HaveKey(Staging))
+}
+
 func TestDetectOverlayDiffs_NoChanges(t *testing.T) {
 	g := NewWithT(t)
 	result := &Result{AffectedEnvironments: make(map[Environment]bool)}
@@ -835,6 +942,89 @@ func TestDetectOverlayDiffs_NoChanges(t *testing.T) {
 	detectOverlayDiffs(builds, result)
 
 	g.Expect(result.AffectedEnvironments).To(BeEmpty())
+}
+
+func TestDetectOverlayDiffs_BaseAppSetWithProductionEnv(t *testing.T) {
+	g := NewWithT(t)
+
+	const prodAppSet = `apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: my-prod-component
+spec:
+  generators:
+    - merge:
+        mergeKeys:
+          - nameNormalized
+        generators:
+          - clusters:
+              values:
+                sourceRoot: components/my-app
+                environment: production
+                clusterDir: ""
+          - list:
+              elements:
+                - nameNormalized: stone-prod-p01
+                  values.clusterDir: stone-prod-p01
+  template:
+    metadata:
+      name: prod-{{nameNormalized}}
+    spec:
+      source:
+        path: '{{values.sourceRoot}}/{{values.environment}}/{{values.clusterDir}}'
+        repoURL: https://github.com/example/repo.git
+      destination:
+        server: '{{server}}'
+`
+	result := &Result{AffectedEnvironments: make(map[Environment]bool)}
+	builds := []overlayBuild{
+		{name: "development", env: Development, headYAML: []byte(prodAppSet), baseYAML: []byte{}},
+		{name: "staging-downstream", env: Staging, headYAML: []byte(prodAppSet), baseYAML: []byte{}},
+		{name: "production-downstream", env: Production, headYAML: []byte(prodAppSet), baseYAML: []byte{}},
+	}
+	detectOverlayDiffs(builds, result)
+
+	g.Expect(result.AffectedEnvironments).To(HaveKey(Production))
+	g.Expect(result.AffectedEnvironments).NotTo(HaveKey(Development))
+	g.Expect(result.AffectedEnvironments).NotTo(HaveKey(Staging))
+}
+
+// TestDetectOverlayDiffs_MultiEnvWarning verifies that when a base AppSet has
+// no explicit environment (targets all clusters), all environments are marked —
+// which is the expected "multi-env" signal.
+func TestDetectOverlayDiffs_MultiEnvWarning(t *testing.T) {
+	g := NewWithT(t)
+
+	// AppSet with clusters: {} (no values.environment) targets all clusters.
+	const allEnvsAppSet = `apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: global-component
+spec:
+  generators:
+    - clusters: {}
+  template:
+    metadata:
+      name: global-{{nameNormalized}}
+    spec:
+      source:
+        path: components/global
+        repoURL: https://github.com/example/repo.git
+      destination:
+        server: '{{server}}'
+`
+	result := &Result{AffectedEnvironments: make(map[Environment]bool)}
+	builds := []overlayBuild{
+		{name: "development", env: Development, headYAML: []byte(allEnvsAppSet), baseYAML: []byte{}},
+		{name: "staging-downstream", env: Staging, headYAML: []byte(allEnvsAppSet), baseYAML: []byte{}},
+		{name: "production-downstream", env: Production, headYAML: []byte(allEnvsAppSet), baseYAML: []byte{}},
+	}
+	detectOverlayDiffs(builds, result)
+
+	// No explicit environment → each overlay falls back to its own env → multi-env.
+	g.Expect(result.AffectedEnvironments).To(HaveKey(Development))
+	g.Expect(result.AffectedEnvironments).To(HaveKey(Staging))
+	g.Expect(result.AffectedEnvironments).To(HaveKey(Production))
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

`detectOverlayDiffs` compared full rendered kustomize YAML blobs and marked the overlay's environment whenever they differed. Since all overlays include `argo-cd-apps/base/`, adding a new ApplicationSet to base (e.g. a staging-only AppSet) caused dev, staging, and production overlays to all show a diff — spuriously labeling the PR as `multi-env` even when the change only affects staging.

## Solution

For each overlay diff, parse both HEAD and base ApplicationSets by name. For new or modified ApplicationSets, extract the `values.environment` field from the cluster generator and use that as the affected environment instead of the overlay's environment. Falls back to the overlay's environment when no explicit environment is found (preserving the `multi-env` label for truly global AppSets with `clusters: {}`).

## Test plan

- [ ] `TestDetectOverlayDiffs_BaseAppSetWithExplicitEnv`: staging AppSet added to base → only `environment/staging` marked across all overlays
- [ ] `TestDetectOverlayDiffs_BaseAppSetWithProductionEnv`: production AppSet added to base → only `environment/production` marked
- [ ] `TestDetectOverlayDiffs_MultiEnvWarning`: global AppSet (`clusters: {}`, no explicit env) → all environments marked (multi-env preserved)
- [ ] All existing detector and appset tests pass