### PR TITLE
PVO11Y-5439 Deploy cardinality exporter to lightwell-dev

### DIFF
--- a/argo-cd-apps/base/member/infra-deployments/monitoring-cardinality/monitoring-cardinality.yaml
+++ b/argo-cd-apps/base/member/infra-deployments/monitoring-cardinality/monitoring-cardinality.yaml
@@ -19,6 +19,8 @@ spec:
                   values.clusterDir: stone-stg-rh01
                 - nameNormalized: stone-stage-p01
                   values.clusterDir: stone-stage-p01
+                - nameNormalized: lightwell-dev
+                  values.clusterDir: lightwell-dev
                 # Ring 1 production clusters
                 - nameNormalized: stone-prod-p01
                   values.clusterDir: stone-prod-p01

--- a/components/monitoring/exporters/cardinality/staging/lightwell-dev/kustomization.yaml
+++ b/components/monitoring/exporters/cardinality/staging/lightwell-dev/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - ../base


### PR DESCRIPTION
## Summary
- Add cardinality exporter deployment for lightwell-dev cluster
- Required for cardinality monitoring of federation and tekton-ms Prometheus instances, and referenced by the tekton-ms NetworkPolicy

## Risk Assessment
**Level:** Low
**What could go wrong:** Exporter pod fails to start or can't reach Prometheus endpoints
**Rollback:** Revert this PR — ArgoCD will prune the cardinality exporter resources
**Blast radius:** lightwell-dev only