### PR TITLE
fix(KONFLUX-15214): upgrade otel collector to 0.158.0 in prod clusters (1/3)

### DIFF
--- a/components/kubearchive/production/stone-prd-rh01/kustomization.yaml
+++ b/components/kubearchive/production/stone-prd-rh01/kustomization.yaml
@@ -354,6 +354,7 @@ patches:
       metadata:
         name: "kubearchive-operator-certificate"
         namespace: kubearchive
+  # opentelemetry-collector 0.158.0
   - patch: |-
       apiVersion: apps/v1
       kind: Deployment
@@ -366,4 +367,4 @@ patches:
           spec:
             containers:
               - name: otel-collector
-                image: quay.io/kubearchive/opentelemetry-collector@sha256:1f8c9a186c56f5ab4ffdd937ecce621aef116868f6022f3652c5d285b5788f8a
+                image: quay.io/kubearchive/opentelemetry-collector@sha256:ef47fef2d742461fba0b9950137895cfd34e3a8500f8acb807003f94751365d0

--- a/components/kubearchive/production/stone-prod-p01/kustomization.yaml
+++ b/components/kubearchive/production/stone-prod-p01/kustomization.yaml
@@ -336,6 +336,7 @@ patches:
       metadata:
         name: "kubearchive-operator-certificate"
         namespace: kubearchive
+  # opentelemetry-collector 0.158.0
   - patch: |-
       apiVersion: apps/v1
       kind: Deployment
@@ -348,5 +349,5 @@ patches:
           spec:
             containers:
               - name: otel-collector
-                image: quay.io/kubearchive/opentelemetry-collector@sha256:1f8c9a186c56f5ab4ffdd937ecce621aef116868f6022f3652c5d285b5788f8a
+                image: quay.io/kubearchive/opentelemetry-collector@sha256:ef47fef2d742461fba0b9950137895cfd34e3a8500f8acb807003f94751365d0
 

--- a/components/kubearchive/production/stone-prod-p02/kustomization.yaml
+++ b/components/kubearchive/production/stone-prod-p02/kustomization.yaml
@@ -349,6 +349,7 @@ patches:
       metadata:
         name: "kubearchive-operator-certificate"
         namespace: kubearchive
+  # opentelemetry-collector 0.158.0
   - patch: |-
       apiVersion: apps/v1
       kind: Deployment
@@ -361,5 +362,5 @@ patches:
           spec:
             containers:
               - name: otel-collector
-                image: quay.io/kubearchive/opentelemetry-collector@sha256:1f8c9a186c56f5ab4ffdd937ecce621aef116868f6022f3652c5d285b5788f8a
+                image: quay.io/kubearchive/opentelemetry-collector@sha256:ef47fef2d742461fba0b9950137895cfd34e3a8500f8acb807003f94751365d0
 


### PR DESCRIPTION
## What                                                                            
 This PR updates opentelemetry-collector from 0.155.0 to 0.158.0 in the production overlays:
- stone-prd-rh01
- stone-prod-p01
- stone-prod-p02 
to remediate to remediate CVE-2026-55969 and CVE-2026-48586.

                                                                                                                                                                        
 ## Why             
Remediates CVE-2026-55969 and CVE-2026-48586 for opentelemetry-collector.
               
Closes:                                                                            
                                                                                   
[KONFLUX-15214](https://redhat.atlassian.net/browse/KONFLUX-15214)
[KONFLUX-15246](https://redhat.atlassian.net/browse/KONFLUX-15246)                 
                                                                                
## Risk Assessment                                                                 
                                                                                    
**Risk Level:** Low                                                                
**Description:** Some KubeArchive performance metrics data can be lost during the rollout.   
**Rollback:** Revert the image reference in `stone-prd-rh01/kustomization.yaml`, `stone-prod-p01/kustomization.yaml`, `stone-prod-p02/kustomization.yaml` to the previous version (sha256:1f8c9a18...) and the older otel-collector will be deployed.

## Validation
Ran 
```
kustomize build --enable-helm components/kubearchive/production/stone-prod-p01/
kustomize build --enable-helm components/kubearchive/production/stone-prod-p02/
kustomize build --enable-helm components/kubearchive/production/stone-prd-rh01/
```
output rendered successfully.
Deployed a local cluster using KubeArchive with the new image and verified everything works correctly.
```
kubectl logs -n kubearchive -l app=otel-collector -c otel-collector --tail=20
2026-06-30T13:45:01.160Z	info	otelconftelemetry/tracer.go:47	Internal trace telemetry disabled	{"resource": {..., "service.version": "0.155.0"}}
2026-06-30T13:45:01.164Z	info	service@v0.155.0/service.go:256	Starting otelcol-contrib...	{"Version": "0.155.0", "NumCPU": 22}
2026-06-30T13:45:01.165Z	info	otlpreceiver@v0.155.0/otlp.go:175	Starting HTTP server	{"endpoint": "[::]:4318"}
2026-06-30T13:45:01.165Z	info	service@v0.155.0/service.go:279	Everything is ready. Begin running and processing data.
```
PR merged in [staging](https://github.com/redhat-appstudio/infra-deployments/pull/13389)
PR merged in [development](https://github.com/redhat-appstudio/infra-deployments/pull/13381)


[KONFLUX-15214]: https://redhat.atlassian.net/browse/KONFLUX-15214?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[KONFLUX-15246]: https://redhat.atlassian.net/browse/KONFLUX-15246?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ