### PR TITLE
PVO11Y-5449 Deploy Cluster Logging Operator to lightwell-dev

### DIFF
--- a/argo-cd-apps/base/all-clusters/infra-deployments/monitoring-workload-logging/monitoring-workload-logging.yaml
+++ b/argo-cd-apps/base/all-clusters/infra-deployments/monitoring-workload-logging/monitoring-workload-logging.yaml
@@ -23,6 +23,8 @@ spec:
                   values.clusterDir: kflux-prd-es01
                 - nameNormalized: stone-stage-p01
                   values.clusterDir: stone-stage-p01
+                - nameNormalized: lightwell-dev
+                  values.clusterDir: lightwell-dev
                 - nameNormalized: stone-prod-p01
                   values.clusterDir: stone-prod-p01
                 - nameNormalized: stone-prod-p02

--- a/components/monitoring/logging/staging/lightwell-dev/kustomization.yaml
+++ b/components/monitoring/logging/staging/lightwell-dev/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../base
+- ../../base/logging-operator-prerequisite


### PR DESCRIPTION
Deploy OpenShift Cluster Logging Operator to lightwell-dev staging cluster to forward cluster logs (platform and application) to Splunk HEC endpoint.

Changes:
- Create lightwell-dev overlay for cluster logging configuration
- Add lightwell-dev to monitoring-workload-logging ApplicationSet

The deployment will configure:
- Cluster Logging Operator v6.4 (stable-6.4 channel)
- Log forwarding to Splunk HEC at https://splunk-hec.redhat.com
- Two pipelines: application logs and infrastructure/audit logs
- Collector with 1 CPU / 4Gi memory limits
- Staging Splunk HEC tokens from vault

Assisted-by: Claude Code (claude-sonnet-4-5)