### PR TITLE
KFLUXINFRA-4375: Add Kyverno policy - buildah seccomp workaround on ROKS

### DIFF
--- a/components/policies/staging/lightwell-dev/buildah-roks-scc.yaml
+++ b/components/policies/staging/lightwell-dev/buildah-roks-scc.yaml
@@ -1,0 +1,45 @@
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  name: appstudio-pipelines-scc-roks
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "0"
+    description: >-
+      Temporary supplemental SCC for ROKS buildah builds. Extends
+      appstudio-pipelines-scc with SYS_CHROOT for layer unpacking.
+      Will be removed once the pipeline-service team adds SYS_CHROOT
+      to the global appstudio-pipelines-scc.
+allowHostDirVolumePlugin: false
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: false
+allowHostPorts: false
+allowPrivilegeEscalation: false
+allowPrivilegedContainer: false
+allowedCapabilities:
+- SETFCAP
+- SYS_CHROOT
+defaultAddCapabilities: null
+fsGroup:
+  type: MustRunAs
+groups:
+- system:serviceaccounts
+priority: 11
+readOnlyRootFilesystem: false
+requiredDropCapabilities:
+- MKNOD
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: MustRunAs
+supplementalGroups:
+  type: RunAsAny
+users: []
+volumes:
+- configMap
+- downwardAPI
+- emptyDir
+- persistentVolumeClaim
+- projected
+- secret

--- a/components/policies/staging/lightwell-dev/buildah-roks-seccomp.yaml
+++ b/components/policies/staging/lightwell-dev/buildah-roks-seccomp.yaml
@@ -1,0 +1,78 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: buildah-roks-seccomp-workaround
+  annotations:
+    policies.kyverno.io/title: "Buildah ROKS seccomp workaround"
+    policies.kyverno.io/category: "Build"
+    policies.kyverno.io/description: >-
+      On ROKS clusters with seccompDefault=true (CIS benchmark), buildah
+      builds fail because RuntimeDefault blocks the unshare syscall. This
+      policy injects the Localhost unshare.json seccomp profile, /dev/fuse
+      access for fuse-overlayfs, and SETFCAP + SYS_CHROOT capabilities on
+      buildah task pods to enable rootless builds while keeping seccomp
+      enforcement enabled.
+spec:
+  background: false
+  failurePolicy: Ignore
+  rules:
+    - name: inject-buildah-local-seccomp-config
+      match:
+        any:
+          - resources:
+              kinds:
+                - Pod
+              operations:
+                - CREATE
+              selector:
+                matchLabels:
+                  tekton.dev/task: buildah-oci-ta
+              namespaceSelector:
+                matchLabels:
+                  konflux-ci.dev/type: tenant
+      mutate:
+        patchStrategicMerge:
+          metadata:
+            annotations:
+              io.kubernetes.cri-o.Devices: "/dev/fuse"
+          spec:
+            containers:
+              - (name): "step-build"
+                securityContext:
+                  seccompProfile:
+                    type: Localhost
+                    localhostProfile: profiles/unshare.json
+                  capabilities:
+                    add:
+                      - SETFCAP
+                      - SYS_CHROOT
+    - name: inject-buildah-remote-seccomp-config
+      match:
+        any:
+          - resources:
+              kinds:
+                - Pod
+              operations:
+                - CREATE
+              selector:
+                matchLabels:
+                  tekton.dev/task: buildah-remote-oci-ta
+              namespaceSelector:
+                matchLabels:
+                  konflux-ci.dev/type: tenant
+      mutate:
+        patchStrategicMerge:
+          metadata:
+            annotations:
+              io.kubernetes.cri-o.Devices: "/dev/fuse"
+          spec:
+            containers:
+              - (name): "step-build"
+                securityContext:
+                  seccompProfile:
+                    type: Localhost
+                    localhostProfile: profiles/unshare.json
+                  capabilities:
+                    add:
+                      - SETFCAP
+                      - SYS_CHROOT

--- a/components/policies/staging/lightwell-dev/kustomization.yaml
+++ b/components/policies/staging/lightwell-dev/kustomization.yaml
@@ -4,3 +4,5 @@ resources:
 - ../base/
 - ../policies/kubearchive/
 - ../policies/kueue/
+- buildah-roks-seccomp.yaml
+- buildah-roks-scc.yaml


### PR DESCRIPTION
On ROKS clusters with `seccompDefault=true` (CIS benchmark compliance), buildah builds fail because `RuntimeDefault` blocks the `unshare` syscall.

This change adds two resources scoped to lightwell-dev only:

1. Kyverno ClusterPolicy (buildah-roks-seccomp-workaround):
     Injects on buildah task pods at CREATE time in tenant namespaces:
     - Localhost seccomp profile (profiles/unshare.json) to allow unshare  while keeping seccomp enforcement enabled
     - CRI-O /dev/fuse annotation for fuse-overlayfs performance
     - SETFCAP capability (matches existing pipelines SCC)
     - SYS_CHROOT capability for layer unpacking via chroot fallback

2. Supplemental SCC (appstudio-pipelines-scc-roks):
     Extends the existing appstudio-pipelines-scc with SYS_CHROOT in        allowedCapabilities. Priority 11 (above the base SCC's 10) so OpenShift prefers it for pods requesting SYS_CHROOT. Includes ClusterRole and ClusterRoleBinding for service account access.

NOTE: This SCC is temporary and for validation purposes only. Once the approach is confirmed, we will coordinate with the pipeline-service team to add SYS_CHROOT to the global appstudio-pipelines-scc and remove this supplemental SCC.

Covers both `buildah-oci-ta` (local) and `buildah-remote-oci-ta` (remote) task pods. No impact on ROSA clusters.

Sets `background: false` and `failurePolicy: Ignore` to align with existing Tekton pod mutation policies in this repo.

Tested and validated on lightwell-dev ROKS cluster (OCP 4.21) and independently confirmed by IBM Cloud support (case CS4546959).