### PR TITLE
KFLUXINFRA-4375: Add buildah-oci-ta-min to Kyverno seccomp policy

### DIFF
--- a/components/policies/staging/lightwell-dev/buildah-roks-seccomp.yaml
+++ b/components/policies/staging/lightwell-dev/buildah-roks-seccomp.yaml
@@ -11,12 +11,13 @@ metadata:
       policy injects the Localhost unshare.json seccomp profile, /dev/fuse
       access for fuse-overlayfs, and SETFCAP + SYS_CHROOT capabilities on
       buildah task pods to enable rootless builds while keeping seccomp
-      enforcement enabled.
+      enforcement enabled. Covers buildah-oci-ta, buildah-oci-ta-min, and
+      buildah-remote-oci-ta task variants.
 spec:
   background: false
   failurePolicy: Ignore
   rules:
-    - name: inject-buildah-local-seccomp-config
+    - name: inject-buildah-seccomp-config
       match:
         any:
           - resources:
@@ -30,25 +31,17 @@ spec:
               namespaceSelector:
                 matchLabels:
                   konflux-ci.dev/type: tenant
-      mutate:
-        patchStrategicMerge:
-          metadata:
-            annotations:
-              io.kubernetes.cri-o.Devices: "/dev/fuse"
-          spec:
-            containers:
-              - (name): "step-build"
-                securityContext:
-                  seccompProfile:
-                    type: Localhost
-                    localhostProfile: profiles/unshare.json
-                  capabilities:
-                    add:
-                      - SETFCAP
-                      - SYS_CHROOT
-    - name: inject-buildah-remote-seccomp-config
-      match:
-        any:
+          - resources:
+              kinds:
+                - Pod
+              operations:
+                - CREATE
+              selector:
+                matchLabels:
+                  tekton.dev/task: buildah-oci-ta-min
+              namespaceSelector:
+                matchLabels:
+                  konflux-ci.dev/type: tenant
           - resources:
               kinds:
                 - Pod


### PR DESCRIPTION
The Kyverno policy was missing coverage for the buildah-oci-ta-min task variant, used by the docker-build-oci-ta-min pipeline. Without this rule, builds using the minimal pipeline would not get the seccomp, /dev/fuse, and SYS_CHROOT mutations injected.

Tested on lightwell-dev ROKS cluster — pod with label tekton.dev/task=buildah-oci-ta-min received all mutations and buildah bud completed successfully.

Assisted-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>