### PR TITLE
PVO11Y-5451 Deploy blackbox exporter to lightwell-dev

### DIFF
--- a/argo-cd-apps/base/monitoring-blackbox/monitoring-blackbox.yaml
+++ b/argo-cd-apps/base/monitoring-blackbox/monitoring-blackbox.yaml
@@ -19,6 +19,8 @@ spec:
                   values.clusterDir: stone-stage-p01
                 - nameNormalized: stone-stg-rh01
                   values.clusterDir: stone-stg-rh01
+                - nameNormalized: lightwell-dev
+                  values.clusterDir: lightwell-dev
                 - nameNormalized: kflux-prd-rh03
                   values.clusterDir: kflux-prd-rh03
                 - nameNormalized: kflux-ocp-p01

--- a/components/monitoring/blackbox/staging/lightwell-dev/kustomization.yaml
+++ b/components/monitoring/blackbox/staging/lightwell-dev/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - https://github.com/redhat-appstudio/internal-infra-deployments/components/monitoring/blackbox-exporter/staging/private/lightwell-dev?ref=8ca73f9cba10dd4ae940137742d7ac8f50a29539
+
+namespace: appstudio-monitoring


### PR DESCRIPTION
## Summary
  - Add lightwell-dev to monitoring-blackbox ApplicationSet
  - Create overlay referencing internal-infra-deployments configuration
  - Deploys blackbox-exporter-obo with API server, Konflux UI, and OpenShift console probes

  ## Changes
  - ApplicationSet: Added lightwell-dev to cluster list
  - New overlay: components/monitoring/blackbox/staging/lightwell-dev/
  - References internal-infra-deployments commit: 8ca73f9cba10dd4ae940137742d7ac8f50a29539

  ## Risk Assessment

  **What could go wrong**:
  - Probe targets may be unreachable if URLs are incorrect
  - Blackbox exporter pod may fail if namespace doesn't exist
  - ArgoCD sync may fail if internal-infra-deployments ref is wrong

  **Mitigation**:
  - URLs verified against existing lightwell-dev deployments and cluster info
  - Namespace created by previous deployments (appstudio-monitoring)
  - Using tested pattern from stone-stage-p01

  **Rollback Plan**:
  - Revert PR to remove lightwell-dev from ApplicationSet
  - ArgoCD will automatically prune blackbox resources

  **Blast Radius**:
  - Limited to lightwell-dev cluster only
  - No impact to existing monitoring infrastructure
  - Blackbox exporter isolated in appstudio-monitoring namespace

  ## Validation
  - ✅ kustomize build succeeds
  - ✅ yamllint passes
  - ✅ Pattern tested on stone-stage-p01 (private staging cluster)
  - ✅ Internal-infra-deployments PR merged and validated:
  https://github.com/redhat-appstudio/internal-infra-deployments/commit/8ca73f9cba10dd4ae940137742d7ac8f50a29539

  ## Post-Deployment Verification
  - [ ] ArgoCD Application `monitoring-blackbox-lightwell-dev` synced successfully
  - [ ] Blackbox exporter pod running in appstudio-monitoring namespace
  - [ ] Probe CRs created and active
  - [ ] Metrics appearing in Prometheus
  - [ ] Alert rules functional

  ## Related
  - JIRA: PVO11Y-5451
  - Internal-infra-deployments PR: https://github.com/redhat-appstudio/internal-infra-deployments/commit/8ca73f9cba10dd4ae940137742d7ac8f50a29539
  - Cluster: lightwell-dev (ROKS staging, private)