### PR TITLE
Lightwell: kueue fixes

### DIFF
--- a/argo-cd-apps/base/member/infra-deployments/kueue/kueue.yaml
+++ b/argo-cd-apps/base/member/infra-deployments/kueue/kueue.yaml
@@ -40,6 +40,8 @@ spec:
                   values.clusterDir: kflux-osp-p01
                 - nameNormalized: kflux-fedora-01
                   values.clusterDir: kflux-fedora-01
+                - nameNormalized: lightwell-dev
+                  values.clusterDir: lightwell-dev
   template:
     metadata:
       name: kueue-{{nameNormalized}}

--- a/components/kueue/staging/lightwell-dev/controller-patch.yaml
+++ b/components/kueue/staging/lightwell-dev/controller-patch.yaml
@@ -1,0 +1,12 @@
+---
+- op: add
+  path: /spec/template/spec/containers/0/resources/requests
+  value:
+    cpu: 500m
+    memory: 2Gi
+
+- op: add
+  path: /spec/template/spec/containers/0/resources/limits
+  value:
+    cpu: 500m
+    memory: 2Gi

--- a/components/kueue/staging/lightwell-dev/kustomization.yaml
+++ b/components/kueue/staging/lightwell-dev/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../base
+patches:
+- path: controller-patch.yaml
+  target:
+    group: apps
+    kind: Deployment
+    name: tekton-kueue-controller-manager
+    version: v1


### PR DESCRIPTION
Increase memory limits of tekton-kueue to 2GiB, and manage kueue's installation through argocd.