### PR TITLE
Add cost-management to kflux-osp-p01 and kflux-rhel-p01 clusters

### DIFF
--- a/argo-cd-apps/base/all-clusters/infra-deployments/cost-management/costmanagement-metrics-operator.yaml
+++ b/argo-cd-apps/base/all-clusters/infra-deployments/cost-management/costmanagement-metrics-operator.yaml
@@ -35,6 +35,10 @@ spec:
                   values.clusterDir: kflux-prd-rh02
                 - nameNormalized: kflux-prd-rh03
                   values.clusterDir: kflux-prd-rh03
+                - nameNormalized: kflux-osp-p01
+                  values.clusterDir: kflux-osp-p01
+                - nameNormalized: kflux-rhel-p01
+                  values.clusterDir: kflux-rhel-p01
                 # Fedora cluster
                 - nameNormalized: kflux-fedora-01
                   values.clusterDir: kflux-fedora-01


### PR DESCRIPTION
Extends cost-management deployment to two additional production clusters that already have component configurations but were missing from the ApplicationSet.