### PR TITLE
chore(ring-1): Migrate staging cost-management to ring deployments

### DIFF
--- a/argo-cd-apps/base/all-clusters/infra-deployments/cost-management/costmanagement-metrics-operator.yaml
+++ b/argo-cd-apps/base/all-clusters/infra-deployments/cost-management/costmanagement-metrics-operator.yaml
@@ -51,9 +51,9 @@ spec:
         namespace: costmanagement-metrics-operator
         server: '{{server}}'
       syncPolicy:
-        automated:
-          prune: true
-          selfHeal: true
+        # automated:
+        #   prune: true
+        #   selfHeal: true
         syncOptions:
           - CreateNamespace=true
         retry:

--- a/argo-cd-apps/overlays/rd-staging/cost-management/cost-management-appset.yaml
+++ b/argo-cd-apps/overlays/rd-staging/cost-management/cost-management-appset.yaml
@@ -1,0 +1,48 @@
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: cost-management
+  labels: # Helps k-components detect this appset to apply the correct patches
+    appstudio.redhat.com/deployment-clusters: "all"
+spec:
+  generators:
+    - merge:
+        mergeKeys:
+          - nameNormalized
+        generators:
+          - clusters:
+              selector:
+                  matchExpressions: # Ensures that no clusters are selected; k-components will replace this with the correct selector
+                  - key: appstudio.redhat.com/select-none
+                    operator: Exists
+                  - key: appstudio.redhat.com/select-none
+                    operator: DoesNotExist
+              values:
+                sourceRoot: components/cost-management
+                ring: "empty-base"
+                clusterDir: "empty-base"
+          - list:
+              elements: [] # Populated via k-components (or manually if the cluster list is unusual)
+
+  template:
+    metadata:
+      name: cost-management-{{nameNormalized}}
+    spec:
+      project: default
+      source:
+        path: '{{values.sourceRoot}}/rings/{{values.ring}}/{{values.clusterDir}}'
+        repoURL: https://github.com/redhat-appstudio/infra-deployments.git
+        targetRevision: main
+      destination:
+        namespace: costmanagement-metrics-operator
+        server: '{{server}}'
+      syncPolicy:
+        # automated:
+        #   prune: true
+        #   selfHeal: true
+        syncOptions:
+        - CreateNamespace=true
+        retry:
+          limit: 50
+          backoff:
+            duration: 15s

--- a/argo-cd-apps/overlays/rd-staging/cost-management/kustomization.yaml
+++ b/argo-cd-apps/overlays/rd-staging/cost-management/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - cost-management-appset.yaml

--- a/argo-cd-apps/overlays/rd-staging/kustomization.yaml
+++ b/argo-cd-apps/overlays/rd-staging/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - artifact-registry-proxy
   - authentication
   - container-image-proxy
+  - cost-management
   - etcd-shield
   - konflux-operator
   - kueue

--- a/components/cost-management/rings/empty-base/empty-base/kustomization.yaml
+++ b/components/cost-management/rings/empty-base/empty-base/kustomization.yaml
@@ -1,0 +1,3 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources: []

--- a/components/cost-management/rings/ring-1/base/base-snapshot/costmanagement-metrics-config.yaml
+++ b/components/cost-management/rings/ring-1/base/base-snapshot/costmanagement-metrics-config.yaml
@@ -1,0 +1,34 @@
+apiVersion: costmanagement-metrics-cfg.openshift.io/v1beta1
+kind: CostManagementMetricsConfig
+metadata:
+  name: costmanagementmetricsconfig
+  namespace: costmanagement-metrics-operator
+  labels:
+    app.kubernetes.io/instance: costmanagementmetricsconfig
+    app.kubernetes.io/name: costmanagementmetricsconfig
+    app.kubernetes.io/part-of: costmanagement-metrics-operator
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+spec:
+  authentication:
+    type: token
+  packaging:
+    max_reports_to_store: 30
+    max_size_MB: 100
+  prometheus_config:
+    collect_previous_data: true
+    context_timeout: 120
+    disable_metrics_collection_cost_management: false
+    disable_metrics_collection_resource_optimization: false
+    service_address: 'https://thanos-querier.openshift-monitoring.svc:9091'
+    skip_tls_verification: false
+  source:
+    check_cycle: 1440
+    create_source: true
+    name: 'konflux-cost-cluster'
+    sources_path: /api/sources/v1.0/
+  upload:
+    upload_cycle: 360
+    upload_toggle: true
+    ingress_path: /api/ingress/v1/upload
+    validate_cert: true

--- a/components/cost-management/rings/ring-1/base/base-snapshot/costmanagement-metrics-operator.yaml
+++ b/components/cost-management/rings/ring-1/base/base-snapshot/costmanagement-metrics-operator.yaml
@@ -1,0 +1,40 @@
+---
+# Namespace for costmanagement-metrics-operator operator
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: costmanagement-metrics-operator
+  annotations:
+    argocd.argoproj.io/sync-wave: "-2"
+---
+# Power monitoring operator group
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: costmanagement-metrics-operator
+  namespace: costmanagement-metrics-operator
+  annotations:
+    olm.providedAPIs: CostManagementMetricsConfig.v1beta1.costmanagement-metrics-cfg.openshift.io
+spec:
+  upgradeStrategy: Default
+  targetNamespaces:
+    - costmanagement-metrics-operator
+---
+# Subscription for costmanagement-metrics-operator
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: costmanagement-metrics-operator
+  namespace: costmanagement-metrics-operator
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+    argocd.argoproj.io/sync-options: Replace=true
+  labels:
+    operators.coreos.com/costmanagement-metrics-operator.costmanagement-metrics-operator: ""
+spec:
+  channel: stable
+  installPlanApproval: Automatic
+  name: costmanagement-metrics-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+  startingCSV: costmanagement-metrics-operator.4.0.0

--- a/components/cost-management/rings/ring-1/base/base-snapshot/external-service-account-secret.yaml
+++ b/components/cost-management/rings/ring-1/base/base-snapshot/external-service-account-secret.yaml
@@ -1,0 +1,19 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: konflux-service-account
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  dataFrom:
+    - extract:
+        key: # will be added by the overlays
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: appsre-stonesoup-vault
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    name: konflux-service-account

--- a/components/cost-management/rings/ring-1/base/base-snapshot/kustomization.yaml
+++ b/components/cost-management/rings/ring-1/base/base-snapshot/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - costmanagement-metrics-operator.yaml
+  - costmanagement-metrics-config.yaml
+  - external-service-account-secret.yaml
+  - rbac
+
+commonAnnotations:
+  argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true

--- a/components/cost-management/rings/ring-1/base/base-snapshot/rbac/cost-management-admin.yaml
+++ b/components/cost-management/rings/ring-1/base/base-snapshot/rbac/cost-management-admin.yaml
@@ -1,0 +1,24 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cost-management-access
+  namespace: costmanagement-metrics-operator
+rules:
+- apiGroups: [""]
+  resources: ["*"]
+  verbs: ["*"]
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cost-management-access
+  namespace: costmanagement-metrics-operator
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: konflux-cost-management-admins
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cost-management-access

--- a/components/cost-management/rings/ring-1/base/base-snapshot/rbac/kustomization.yaml
+++ b/components/cost-management/rings/ring-1/base/base-snapshot/rbac/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- cost-management-admin.yaml

--- a/components/cost-management/rings/ring-1/base/kustomization.yaml
+++ b/components/cost-management/rings/ring-1/base/kustomization.yaml
@@ -1,0 +1,19 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - base-snapshot
+
+namespace: costmanagement-metrics-operator
+
+patches:
+  - path: patches/cost-mangement-external-secret-patch.yaml
+    target:
+      name: konflux-service-account
+      kind: ExternalSecret
+      group: external-secrets.io
+      version: v1
+  - path: patches/cost-management-operator-resources-patch.yaml
+    target:
+      kind: Subscription
+      name: costmanagement-metrics-operator

--- a/components/cost-management/rings/ring-1/base/patches/cost-management-operator-resources-patch.yaml
+++ b/components/cost-management/rings/ring-1/base/patches/cost-management-operator-resources-patch.yaml
@@ -1,0 +1,14 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: costmanagement-metrics-operator
+  namespace: costmanagement-metrics-operator
+spec:
+  config:
+    resources:
+      limits:
+        cpu: "500m"
+        memory: "800Mi"
+      requests:
+        cpu: "100m"
+        memory: "300Mi"

--- a/components/cost-management/rings/ring-1/base/patches/cost-mangement-external-secret-patch.yaml
+++ b/components/cost-management/rings/ring-1/base/patches/cost-mangement-external-secret-patch.yaml
@@ -1,0 +1,7 @@
+---
+- op: replace
+  path: /apiVersion
+  value: external-secrets.io/v1
+- op: add
+  path: /spec/dataFrom/0/extract/key
+  value: staging/cost-management/konflux-service-account

--- a/components/cost-management/rings/ring-1/kflux-stg-es01/kustomization.yaml
+++ b/components/cost-management/rings/ring-1/kflux-stg-es01/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../base
+
+patches:
+  - path: patches/cost-management-config-source-patch.yaml
+    target:
+      kind: CostManagementMetricsConfig
+      name: cost-mgmt-metrics-cfg

--- a/components/cost-management/rings/ring-1/kflux-stg-es01/patches/cost-management-config-source-patch.yaml
+++ b/components/cost-management/rings/ring-1/kflux-stg-es01/patches/cost-management-config-source-patch.yaml
@@ -1,0 +1,10 @@
+---
+- op: add
+  path: /spec/source/name
+  value: kflux-stg-es01
+- op: replace
+  path: /spec/authentication/type
+  value: service-account
+- op: add
+  path: /spec/authentication/secret_name
+  value: konflux-service-account

--- a/components/cost-management/rings/ring-1/stone-stage-p01/kustomization.yaml
+++ b/components/cost-management/rings/ring-1/stone-stage-p01/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../base
+
+patches:
+  - path: patches/cost-management-config-source-patch.yaml
+    target:
+      kind: CostManagementMetricsConfig
+      name: cost-mgmt-metrics-cfg

--- a/components/cost-management/rings/ring-1/stone-stage-p01/patches/cost-management-config-source-patch.yaml
+++ b/components/cost-management/rings/ring-1/stone-stage-p01/patches/cost-management-config-source-patch.yaml
@@ -1,0 +1,10 @@
+---
+- op: add
+  path: /spec/source/name
+  value: stone-stage-p01
+- op: replace
+  path: /spec/authentication/type
+  value: service-account
+- op: add
+  path: /spec/authentication/secret_name
+  value: konflux-service-account

--- a/components/cost-management/rings/ring-1/stone-stg-rh01/kustomization.yaml
+++ b/components/cost-management/rings/ring-1/stone-stg-rh01/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../base
+
+patches:
+  - path: patches/cost-management-config-source-patch.yaml
+    target:
+      kind: CostManagementMetricsConfig
+      name: cost-mgmt-metrics-cfg

--- a/components/cost-management/rings/ring-1/stone-stg-rh01/patches/cost-management-config-source-patch.yaml
+++ b/components/cost-management/rings/ring-1/stone-stg-rh01/patches/cost-management-config-source-patch.yaml
@@ -1,0 +1,10 @@
+---
+- op: add
+  path: /spec/source/name
+  value: stone-stg-rh01
+- op: replace
+  path: /spec/authentication/type
+  value: service-account
+- op: add
+  path: /spec/authentication/secret_name
+  value: konflux-service-account


### PR DESCRIPTION
Add ring-1 directory structure for cost-management staging clusters
(kflux-stg-es01, stone-stage-p01, stone-stg-rh01) with base-snapshot
and per-cluster overlays. 
Create rd-staging ApplicationSet overlay and disable auto-sync on the old ApplicationSet to prepare for cutover.

