### PR TITLE
KFLUXINFRA-4267: Configure Fedora 44 root pools with jq/yq on kflux-fedora-01

### DIFF
--- a/components/multi-platform-controller/production/kflux-fedora-01/host-values.yaml
+++ b/components/multi-platform-controller/production/kflux-fedora-01/host-values.yaml
@@ -80,9 +80,110 @@ dynamicConfigs:
 
   linux-g6xlarge-amd64: {}
 
-  linux-root-arm64: {}
+  linux-root-arm64:
+    sudo-commands: "/usr/bin/podman, /usr/bin/rm /usr/share/containers/mounts.conf"
+    ami: "ami-0f8ec1601c3fe1115"
+    user-data: |-
+      Content-Type: multipart/mixed; boundary="//"
+      MIME-Version: 1.0
 
-  linux-root-amd64: {}
+      --//
+      Content-Type: text/cloud-config; charset="us-ascii"
+      MIME-Version: 1.0
+      Content-Transfer-Encoding: 7bit
+      Content-Disposition: attachment; filename="cloud-config.txt"
+
+      #cloud-config
+      cloud_final_modules:
+        - [scripts-user, always]
+
+      --//
+      Content-Type: text/x-shellscript; charset="us-ascii"
+      MIME-Version: 1.0
+      Content-Transfer-Encoding: 7bit
+      Content-Disposition: attachment; filename="userdata.txt"
+
+      #!/bin/bash -ex
+
+      # Format and mount NVMe disk
+      mkfs -t xfs /dev/nvme1n1
+      mount /dev/nvme1n1 /home
+
+      # Create required directories
+      mkdir -p /home/var-lib-containers /var/lib/containers /home/var-tmp /var/tmp /home/ec2-user/.ssh
+
+      # Setup bind mounts
+      mount --bind /home/var-lib-containers /var/lib/containers
+      mount --bind /home/var-tmp /var/tmp
+      chmod 1777 /home/var-tmp /var/tmp
+      chown root:root /home/var-tmp /var/tmp
+      restorecon -r /var/lib/containers /var/tmp
+
+      # Configure ec2-user SSH access
+      chown -R ec2-user /home/ec2-user
+      sed -n 's,.*\(ssh-.*\s\),\1,p' /root/.ssh/authorized_keys > /home/ec2-user/.ssh/authorized_keys
+      chown ec2-user /home/ec2-user/.ssh/authorized_keys
+      chmod 600 /home/ec2-user/.ssh/authorized_keys
+      chmod 700 /home/ec2-user/.ssh
+      restorecon -r /home/ec2-user
+
+      # Install jq and yq
+      dnf install -y jq yq
+
+      --//--
+
+  linux-root-amd64:
+    sudo-commands: "/usr/bin/podman, /usr/bin/rm /usr/share/containers/mounts.conf"
+    ami: "ami-08c28532356e3b2b4"
+    # Overrides base/host-config-chart/files/linux-root-amd64-init.sh
+    user-data: |-
+      Content-Type: multipart/mixed; boundary="//"
+      MIME-Version: 1.0
+
+      --//
+      Content-Type: text/cloud-config; charset="us-ascii"
+      MIME-Version: 1.0
+      Content-Transfer-Encoding: 7bit
+      Content-Disposition: attachment; filename="cloud-config.txt"
+
+      #cloud-config
+      cloud_final_modules:
+        - [scripts-user, always]
+
+      --//
+      Content-Type: text/x-shellscript; charset="us-ascii"
+      MIME-Version: 1.0
+      Content-Transfer-Encoding: 7bit
+      Content-Disposition: attachment; filename="userdata.txt"
+
+      #!/bin/bash -ex
+
+      # Format and mount NVMe disk
+      mkfs -t xfs /dev/nvme1n1
+      mount /dev/nvme1n1 /home
+
+      # Create required directories
+      mkdir -p /home/var-lib-containers /var/lib/containers /home/var-tmp /var/tmp /home/ec2-user/.ssh
+
+      # Setup bind mounts
+      mount --bind /home/var-lib-containers /var/lib/containers
+      mount --bind /home/var-tmp /var/tmp
+      chmod 1777 /home/var-tmp /var/tmp
+      chown root:root /home/var-tmp /var/tmp
+      restorecon -r /var/lib/containers /var/tmp
+
+      # Configure ec2-user SSH access
+      chown -R ec2-user /home/ec2-user
+      sed -n 's,.*\(ssh-.*\s\),\1,p' /root/.ssh/authorized_keys > /home/ec2-user/.ssh/authorized_keys
+      chown ec2-user /home/ec2-user/.ssh/authorized_keys
+      chmod 600 /home/ec2-user/.ssh/authorized_keys
+      chmod 700 /home/ec2-user/.ssh
+      restorecon -r /home/ec2-user
+
+      # Install jq and yq
+      dnf install -y jq yq
+
+      --//--
 
   linux-fast-amd64: {}
 

--- a/components/multi-platform-controller/production/kflux-fedora-01/host-values.yaml
+++ b/components/multi-platform-controller/production/kflux-fedora-01/host-values.yaml
@@ -81,6 +81,7 @@ dynamicConfigs:
   linux-g6xlarge-amd64: {}
 
   linux-root-arm64:
+    instance-type: "m6g.2xlarge"
     sudo-commands: "/usr/bin/podman, /usr/bin/rm /usr/share/containers/mounts.conf"
     ami: "ami-0f8ec1601c3fe1115"
     user-data: |-
@@ -104,24 +105,6 @@ dynamicConfigs:
       Content-Disposition: attachment; filename="userdata.txt"
 
       #!/bin/bash -ex
-
-      # Create required directories
-      mkdir -p /home/var-lib-containers /var/lib/containers /home/var-tmp /var/tmp /home/ec2-user/.ssh
-
-      # Setup bind mounts
-      mount --bind /home/var-lib-containers /var/lib/containers
-      mount --bind /home/var-tmp /var/tmp
-      chmod 1777 /home/var-tmp /var/tmp
-      chown root:root /home/var-tmp /var/tmp
-      restorecon -r /var/lib/containers /var/tmp
-
-      # Configure ec2-user SSH access
-      chown -R ec2-user /home/ec2-user
-      sed -n 's,.*\(ssh-.*\s\),\1,p' /root/.ssh/authorized_keys > /home/ec2-user/.ssh/authorized_keys
-      chown ec2-user /home/ec2-user/.ssh/authorized_keys
-      chmod 600 /home/ec2-user/.ssh/authorized_keys
-      chmod 700 /home/ec2-user/.ssh
-      restorecon -r /home/ec2-user
 
       # Install jq and yq
       dnf install -y jq yq
@@ -153,24 +136,6 @@ dynamicConfigs:
       Content-Disposition: attachment; filename="userdata.txt"
 
       #!/bin/bash -ex
-
-      # Create required directories
-      mkdir -p /home/var-lib-containers /var/lib/containers /home/var-tmp /var/tmp /home/ec2-user/.ssh
-
-      # Setup bind mounts
-      mount --bind /home/var-lib-containers /var/lib/containers
-      mount --bind /home/var-tmp /var/tmp
-      chmod 1777 /home/var-tmp /var/tmp
-      chown root:root /home/var-tmp /var/tmp
-      restorecon -r /var/lib/containers /var/tmp
-
-      # Configure ec2-user SSH access
-      chown -R ec2-user /home/ec2-user
-      sed -n 's,.*\(ssh-.*\s\),\1,p' /root/.ssh/authorized_keys > /home/ec2-user/.ssh/authorized_keys
-      chown ec2-user /home/ec2-user/.ssh/authorized_keys
-      chmod 600 /home/ec2-user/.ssh/authorized_keys
-      chmod 700 /home/ec2-user/.ssh
-      restorecon -r /home/ec2-user
 
       # Install jq and yq
       dnf install -y jq yq

--- a/components/multi-platform-controller/production/kflux-fedora-01/host-values.yaml
+++ b/components/multi-platform-controller/production/kflux-fedora-01/host-values.yaml
@@ -105,10 +105,6 @@ dynamicConfigs:
 
       #!/bin/bash -ex
 
-      # Format and mount NVMe disk
-      mkfs -t xfs /dev/nvme1n1
-      mount /dev/nvme1n1 /home
-
       # Create required directories
       mkdir -p /home/var-lib-containers /var/lib/containers /home/var-tmp /var/tmp /home/ec2-user/.ssh
 
@@ -157,10 +153,6 @@ dynamicConfigs:
       Content-Disposition: attachment; filename="userdata.txt"
 
       #!/bin/bash -ex
-
-      # Format and mount NVMe disk
-      mkfs -t xfs /dev/nvme1n1
-      mount /dev/nvme1n1 /home
 
       # Create required directories
       mkdir -p /home/var-lib-containers /var/lib/containers /home/var-tmp /var/tmp /home/ec2-user/.ssh


### PR DESCRIPTION
## What

- Point `linux-root-arm64` / `linux-root-amd64` at Fedora 44 AMIs and set root `sudo-commands`
- Set `linux-root-arm64` instance type to `m6g.2xlarge` (amd64 keeps chart default `m5.2xlarge`)
- Add cloud-init userdata that only runs `dnf install -y jq yq` (no NVMe/bind-mount/SSH init; AMI provides host layout)

Clusters affected: kflux-fedora-01

[KFLUXINFRA-4267](https://redhat.atlassian.net/browse/KFLUXINFRA-4267)

## Why

Fedora developers require Fedora 44 for these root profiles. jq and yq are used in the Fedora build pipeline to parse results.

## Validation

- `kustomize build --enable-helm components/multi-platform-controller/production/kflux-fedora-01` passes locally
- After merge/sync: new root VMs boot and `jq` / `yq` are on PATH

## Risk Assessment

**Risk Level:** Medium
**What could go wrong:** Incorrect AMI or failed userdata (`dnf`/cloud-init) leaves new root VMs unusable for Fedora builds until fixed. Replacing default amd64 init means the AMI must already provide any required host layout.
**Rollback:** Revert PR; ArgoCD restores prior host-config. Already-running VMs keep old userdata until recycled.
**Blast radius:** production `kflux-fedora-01` only — `linux-root-arm64` and `linux-root-amd64`

[KFLUXINFRA-4267]: https://redhat.atlassian.net/browse/KFLUXINFRA-4267?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ