### PR TITLE
Double tekton-kueue-controller-manager memory for lightwell-dev

### DIFF
--- a/components/kueue-rd/rings/ring-1/lightwell-dev/controller-manager-memory-patch.yaml
+++ b/components/kueue-rd/rings/ring-1/lightwell-dev/controller-manager-memory-patch.yaml
@@ -1,0 +1,8 @@
+---
+- op: replace
+  path: /spec/template/spec/containers/0/resources/requests/memory
+  value: 2Gi
+
+- op: replace
+  path: /spec/template/spec/containers/0/resources/limits/memory
+  value: 2Gi

--- a/components/kueue-rd/rings/ring-1/lightwell-dev/kustomization.yaml
+++ b/components/kueue-rd/rings/ring-1/lightwell-dev/kustomization.yaml
@@ -3,3 +3,10 @@ kind: Kustomization
 resources:
 - cluster-queue.yaml
 - ../base
+
+patches:
+- path: controller-manager-memory-patch.yaml
+  target:
+    kind: Deployment
+    name: tekton-kueue-controller-manager
+    namespace: tekton-kueue


### PR DESCRIPTION
## What

Double `tekton-kueue-controller-manager` memory requests/limits (1Gi -> 2Gi) for the `lightwell-dev` staging cluster only, via a per-cluster patch. `stone-stage-p01` and `stone-stg-rh01` stay on the ring-1 base value.

Clusters affected: lightwell-dev (staging)

## Why

During scale testing on lightwell-dev (many PLRs run in parallel), the number of concurrently running PipelineRuns was far lower than expected. Root cause: `tekton-kueue-controller-manager` was being OOMKilled frequently under load. When it's down, nothing clears `status.pending` on PipelineRuns once kueue admits the workload, so admitted PLRs stall.

## Validation

- `kustomize build --enable-helm components/kueue-rd/rings/ring-1/lightwell-dev/` renders controller-manager with `memory: 2Gi` request/limit
- `kustomize build --enable-helm components/kueue-rd/rings/ring-1/stone-stage-p01/` and `.../stone-stg-rh01/` confirmed unchanged at `memory: 1Gi`

## Risk Assessment

Not required (staging-only change).