### PR TITLE
KONFLUX-15352 Bump repository-validator staging ref for rhtap-perf-test allowlist

### DIFF
--- a/components/repository-validator/staging/kustomization.yaml
+++ b/components/repository-validator/staging/kustomization.yaml
@@ -1,5 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - https://github.com/redhat-appstudio/internal-infra-deployments/components/repository-validator/staging?ref=9395529f221c985c6c940b0f02109ed2002989c2
+  - https://github.com/redhat-appstudio/internal-infra-deployments/components/repository-validator/staging?ref=89c9240df3d287a141d4730a73daea336d651319
   - ../base


### PR DESCRIPTION
## What

- Bump the pinned `ref` for `components/repository-validator/staging/kustomization.yaml` to pick up the new `https://github.com/rhtap-perf-test` entry in the repository-validator staging allowlist.

Clusters affected: all staging clusters (repository-validator allowlist is shared, not per-cluster), including lightwell-dev.

[KONFLUX-15352](https://issues.redhat.com/browse/KONFLUX-15352)

## Why

Konflux on lightwell-dev currently rejects `Repository` CRs sourced from `https://github.com/rhtap-perf-test/...`, blocking probe tests. `redhat-appstudio/internal-infra-deployments#129` adds that prefix to the shared staging allowlist config; this PR bumps the pinned commit ref so the change takes effect.

## Validation

- `kustomize build components/repository-validator/staging/` was verified against the new ref inside the `internal-infra-deployments` checkout (private repo, requires auth this environment doesn't have configured for HTTPS remote-base fetches; verified there directly instead).
- Diff is a single-line ref bump, same pattern as prior bump PR #13497.

[KONFLUX-15352]: https://redhat.atlassian.net/browse/KONFLUX-15352?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ