### PR TITLE
KFLUXINFRA-4267 Exclude lightwell-dev from legacy kueue ApplicationSet

### DIFF
--- a/argo-cd-apps/overlays/staging-downstream/exclude-lightwell-dev-from-kueue.yaml
+++ b/argo-cd-apps/overlays/staging-downstream/exclude-lightwell-dev-from-kueue.yaml
@@ -1,0 +1,11 @@
+---
+# Exclude lightwell-dev from the legacy kueue ApplicationSet.
+# lightwell-dev uses the ring deployment strategy via kueue-rd (rd-staging).
+- op: add
+  path: /spec/generators/0/selector
+  value:
+    matchExpressions:
+      - key: nameNormalized
+        operator: NotIn
+        values:
+          - lightwell-dev

--- a/argo-cd-apps/overlays/staging-downstream/kustomization.yaml
+++ b/argo-cd-apps/overlays/staging-downstream/kustomization.yaml
@@ -173,3 +173,8 @@ patches:
       kind: ApplicationSet
       version: v1alpha1
       name: konflux-rbac
+  - path: exclude-lightwell-dev-from-kueue.yaml
+    target:
+      kind: ApplicationSet
+      version: v1alpha1
+      name: kueue


### PR DESCRIPTION
After d008ab7cb ("Double tekton-kueue-controller-manager memory for lightwell-dev"), ArgoCD fails to sync the kueue Application for lightwell-dev with:

  Failed to load target state: failed to generate manifest for source
  1 of 1: rpc error: code = Unknown desc = Manifest generation error
  (cached): components/kueue/staging/empty-base: app path does not exist

The legacy kueue ApplicationSet (base/member/kueue) uses a cluster generator that matches all staging member clusters. Clusters not explicitly listed fall back to clusterDir "empty-base", but the directory components/kueue/staging/empty-base does not exist.

lightwell-dev uses the new ring deployment strategy via the kueue-rd ApplicationSet (rd-staging overlay), which correctly maps it to components/kueue-rd/rings/ring-1/lightwell-dev. It should not be managed by the legacy ApplicationSet at all.

Add a post-selector patch on the legacy kueue ApplicationSet in staging-downstream to exclude lightwell-dev from Application generation, matching the pattern used by exclude-operator-owned-clusters for other services.

Assisted-by: Claude Code (claude-opus-4-6)