### PR TITLE
KFLUXINFRA-4375: Add seccompProfiles to the policy

### DIFF
--- a/components/policies/staging/lightwell-dev/buildah-roks-scc.yaml
+++ b/components/policies/staging/lightwell-dev/buildah-roks-scc.yaml
@@ -31,6 +31,9 @@ requiredDropCapabilities:
 - MKNOD
 runAsUser:
   type: RunAsAny
+seccompProfiles:
+- localhost/profiles/unshare.json
+- runtime/default
 seLinuxContext:
   type: MustRunAs
 supplementalGroups:


### PR DESCRIPTION
Adds seccompProfiles to the supplemental SCC to allow the Localhost seccomp profile (profiles/unshare.json). Without this, OpenShift rejects pods with Localhost seccomp because the SCC doesn't explicitly permit it — the pod fails SCC validation before it can be admitted.

Assisted-by: Claude Opus 4.6 (1M context) <noreply@anthropic.com>