### PR TITLE
PVO11Y-5451 Update blackbox exporter ref with security context fix

### DIFF
--- a/components/monitoring/blackbox/staging/lightwell-dev/kustomization.yaml
+++ b/components/monitoring/blackbox/staging/lightwell-dev/kustomization.yaml
@@ -1,6 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - https://github.com/redhat-appstudio/internal-infra-deployments/components/monitoring/blackbox-exporter/staging/private/lightwell-dev?ref=8ca73f9cba10dd4ae940137742d7ac8f50a29539
+  - https://github.com/redhat-appstudio/internal-infra-deployments/components/monitoring/blackbox-exporter/staging/private/lightwell-dev?ref=8b398ce91d00f6aff8138f13cf46dfb9bfab6aac
 
 namespace: appstudio-monitoring


### PR DESCRIPTION
  ## Summary
  Update internal-infra-deployments reference to include security context fix for ROKS cluster compatibility.

  ## Problem
  The initial deployment failed on lightwell-dev with error:
  container has runAsNonRoot and image will run as root

  ## Solution
  Update reference to commit `8b398ce` which includes pod-level security context:
  - `runAsUser: 65534`
  - `fsGroup: 65534`
  - `runAsNonRoot: true`

  ## ROKS vs ROSA Difference
  ROKS clusters require explicit runAsUser and fsGroup configuration when runAsNonRoot is set, unlike ROSA clusters where the deployment works without these explicit
  settings.

  ## Changes
  - Update ref from `8ca73f9cba10dd4ae940137742d7ac8f50a29539` to `8b398ce91d00f6aff8138f13cf46dfb9bfab6aac`

  ## Risk Assessment
  **Risk Level**: Low

  **What could go wrong**:
  - Pod may fail to start if security context is incompatible with cluster policies

  **Mitigation**:
  - Security context tested with kustomize build
  - Using standard nobody user (UID 65534)
  - Pattern verified against ROKS requirements

  **Rollback Plan**:
  - Revert to previous commit reference
  - ArgoCD will automatically sync to previous version

  **Blast Radius**:
  - Limited to lightwell-dev blackbox exporter only
  - No impact to other clusters or components

  ## Validation
  - ✅ yamllint passes
  - ✅ kustomize build succeeds
  - ✅ Security context fix merged in internal-infra-deployments

  ## Related
  - JIRA: PVO11Y-5451
  - Initial PR: https://github.com/redhat-appstudio/infra-deployments/pull/[ORIGINAL_PR_NUMBER]
  - Security fix PR: https://github.com/redhat-appstudio/internal-infra-deployments/pull/[SECURITY_FIX_PR_NUMBER]
  - Cluster: lightwell-dev (ROKS staging, private)