### PR TITLE
KFLUXINFRA-4375: Bump repository-validator staging ref

### DIFF
--- a/components/repository-validator/staging/kustomization.yaml
+++ b/components/repository-validator/staging/kustomization.yaml
@@ -1,5 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - https://github.com/redhat-appstudio/internal-infra-deployments/components/repository-validator/staging?ref=89c9240df3d287a141d4730a73daea336d651319
+  - https://github.com/redhat-appstudio/internal-infra-deployments/components/repository-validator/staging?ref=5fcc984244cb2d38d8315b089c73ea71f98aa649
   - ../base


### PR DESCRIPTION
Points to internal-infra-deployments commit adding oswcab/sample-component-golang to the staging allow list.

