### PR TITLE
PVO11Y-5451 Update blackbox exporter ref with tested security context

### DIFF
--- a/components/monitoring/blackbox/staging/lightwell-dev/kustomization.yaml
+++ b/components/monitoring/blackbox/staging/lightwell-dev/kustomization.yaml
@@ -1,6 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - https://github.com/redhat-appstudio/internal-infra-deployments/components/monitoring/blackbox-exporter/staging/private/lightwell-dev?ref=8b398ce91d00f6aff8138f13cf46dfb9bfab6aac
+  - https://github.com/redhat-appstudio/internal-infra-deployments/components/monitoring/blackbox-exporter/staging/private/lightwell-dev?ref=38254989c66b98aeafc51505677a244afd1e1ff8
 
 namespace: appstudio-monitoring


### PR DESCRIPTION
## Summary
  Update internal-infra-deployments reference to include the working ROKS security context fix.

  ## Changes
  - Update ref from `8b398ce91d00f6aff8138f13cf46dfb9bfab6aac` to `38254989c66b98aeafc51505677a244afd1e1ff8`
  - New commit includes explicit security context values for ROKS compatibility

  ## Testing
  ✅ Tested on lightwell-dev cluster
  ✅ Confirmed pod runs as `uid=1000830000` (non-root)
  ✅ No SCC validation errors
  ✅ Blackbox exporter deployment successful

  ## Security Context
  ```yaml
  securityContext:
    runAsUser: 1000830000
    runAsGroup: 1000830000
    fsGroup: 1000830000

  Related

  - JIRA: PVO11Y-5451
  - Internal-infra-deployments PR: https://github.com/redhat-appstudio/internal-infra-deployments/commit/38254989c66b98aeafc51505677a244afd1e1ff8
  - Cluster: lightwell-dev (ROKS on IBM Cloud)