### PR TITLE
Scope appstudio-pipelines-scc-roks to Tekton controller only

### DIFF
--- a/components/policies/staging/lightwell-dev/buildah-roks-scc-clusterrole.yaml
+++ b/components/policies/staging/lightwell-dev/buildah-roks-scc-clusterrole.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: appstudio-pipelines-scc-roks-use
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+rules:
+- apiGroups: ["security.openshift.io"]
+  resources: ["securitycontextconstraints"]
+  resourceNames: ["appstudio-pipelines-scc-roks"]
+  verbs: ["use"]

--- a/components/policies/staging/lightwell-dev/buildah-roks-scc-clusterrolebinding.yaml
+++ b/components/policies/staging/lightwell-dev/buildah-roks-scc-clusterrolebinding.yaml
@@ -1,0 +1,14 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: tekton-pipelines-controller-roks-scc
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+subjects:
+  - kind: ServiceAccount
+    name: tekton-pipelines-controller
+    namespace: openshift-pipelines
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: appstudio-pipelines-scc-roks-use

--- a/components/policies/staging/lightwell-dev/buildah-roks-scc.yaml
+++ b/components/policies/staging/lightwell-dev/buildah-roks-scc.yaml
@@ -24,7 +24,7 @@ defaultAddCapabilities: null
 fsGroup:
   type: MustRunAs
 groups:
-- system:serviceaccounts
+- system:cluster-admins
 priority: 11
 readOnlyRootFilesystem: false
 requiredDropCapabilities:

--- a/components/policies/staging/lightwell-dev/kustomization.yaml
+++ b/components/policies/staging/lightwell-dev/kustomization.yaml
@@ -6,3 +6,5 @@ resources:
 - ../policies/kueue/
 - buildah-roks-seccomp.yaml
 - buildah-roks-scc.yaml
+- buildah-roks-scc-clusterrole.yaml
+- buildah-roks-scc-clusterrolebinding.yaml


### PR DESCRIPTION
## What

- Changed `groups` in `appstudio-pipelines-scc-roks` SCC from `system:serviceaccounts` to `system:cluster-admins`
- Added ClusterRole granting `use` on the ROKS SCC
- Added ClusterRoleBinding binding that role to `tekton-pipelines-controller` in `openshift-pipelines`

Clusters affected: lightwell-dev

## Why

The ROKS SCC's `groups: system:serviceaccounts` combined with `priority: 11` and `runAsUser: RunAsAny` caused it to win SCC selection for all pods on the cluster. This broke any Konflux service whose pods set `runAsNonRoot: true` with a non-numeric image user (e.g. "nobody"), because `RunAsAny` prevented UID injection.

The SCC was only intended for buildah pipeline tasks needing `SYS_CHROOT`. This fix scopes it to just the Tekton pipelines controller via RBAC, matching the pattern used by the original `appstudio-pipelines-scc`.

## Validation

- `kustomize build components/policies/staging/lightwell-dev/` passes

Made with [Cursor](https://cursor.com)