### PR TITLE
fix(PVO11Y-5455): Parameterize release-policy in run-kanary-tests task

### DIFF
--- a/components/monitoring/kanary/staging/base/pipelines/kanary-otel-pipeline.yaml
+++ b/components/monitoring/kanary/staging/base/pipelines/kanary-otel-pipeline.yaml
@@ -54,6 +54,9 @@ spec:
     - name: test-scenario-git-url
       type: string
       default: ""
+    - name: release-policy
+      type: string
+      default: "tmp-onboard-policy"
     # RPM mirror workaround only. Leave empty for container test types.
     - name: upstream-repo-url
       type: string
@@ -108,6 +111,8 @@ spec:
           value: $(params.pipeline-image-pull-secrets)
         - name: test-scenario-git-url
           value: $(params.test-scenario-git-url)
+        - name: release-policy
+          value: $(params.release-policy)
         - name: upstream-repo-url
           value: $(params.upstream-repo-url)
         - name: upstream-repo-branch

--- a/components/monitoring/kanary/staging/base/tasks/run-kanary-tests.yaml
+++ b/components/monitoring/kanary/staging/base/tasks/run-kanary-tests.yaml
@@ -51,6 +51,9 @@ spec:
     - name: test-scenario-git-url
       type: string
       default: ""
+    - name: release-policy
+      type: string
+      default: "tmp-onboard-policy"
     # RPM mirror workaround only. Leave empty for container test types.
     - name: upstream-repo-url
       type: string
@@ -236,7 +239,7 @@ spec:
         - name: PIPELINE_REPO_TEMPLATING_SOURCE_DIR
           value: $(params.pipeline-repo-templating-source-dir)
         - name: RELEASE_POLICY
-          value: "tmp-onboard-policy"
+          value: $(params.release-policy)
         - name: RELEASE_PIPELINE_URL
           value: "https://github.com/konflux-ci/release-service-catalog.git"
         - name: RELEASE_PIPELINE_REVISION

--- a/components/monitoring/kanary/staging/stone-stage-p01/cronjobs/kanary-cronjob-rpm.yaml
+++ b/components/monitoring/kanary/staging/stone-stage-p01/cronjobs/kanary-cronjob-rpm.yaml
@@ -42,6 +42,7 @@ spec:
                     --param pipeline-repo-templating-source-dir=stone-stage-p01-RPM/ \
                     --param pipeline-image-pull-secrets="imagerepository-for-toolings-gather-results-container-image-pull imagerepository-for-toolings-get-rpm-sources-container-image-pull imagerepository-for-toolings-mock-rhel-container-image-pull imagerepository-for-toolings-rpmbuild-pipeline-image-pull imagerepository-for-toolings-syft-container-image-pull" \
                     --param test-scenario-git-url="" \
+                    --param release-policy="" \
                     --param oci-storage=quay.io/rhtap-perf-test/perf-release-service-trusted-artifacts-stage \
                     --param release-pipeline-service-account=managed-konflux-perfscale-sa \
                     --param fork-target=jhutar \

--- a/components/monitoring/kanary/staging/stone-stg-rh01/cronjobs/kanary-cronjob-rpm.yaml
+++ b/components/monitoring/kanary/staging/stone-stg-rh01/cronjobs/kanary-cronjob-rpm.yaml
@@ -42,6 +42,7 @@ spec:
                     --param pipeline-repo-templating-source-dir=stone-stg-rh01-RPM/ \
                     --param pipeline-image-pull-secrets="imagerepository-for-toolings-gather-results-container-image-pull imagerepository-for-toolings-get-rpm-sources-container-image-pull imagerepository-for-toolings-mock-rhel-container-image-pull imagerepository-for-toolings-rpmbuild-pipeline-image-pull imagerepository-for-toolings-syft-container-image-pull" \
                     --param test-scenario-git-url="" \
+                    --param release-policy="" \
                     --param oci-storage=quay.io/rhtap-perf-test/perf-release-service-trusted-artifacts-stage \
                     --param release-pipeline-service-account=managed-konflux-perfscale-sa \
                     --param fork-target="" \


### PR DESCRIPTION
## What

Add a `release-policy` param to `run-kanary-tests` task and `kanary-otel-pipeline` pipeline (default: `tmp-onboard-policy`), and set it to `""` in both staging RPM cronjobs.

[PVO11Y-5455](https://redhat.atlassian.net/browse/PVO11Y-5455)

## Why

`RELEASE_POLICY` was hardcoded to `tmp-onboard-policy` for all test types. RPM probes require an empty release policy since they use a different release configuration than container probes. The default preserves the existing behaviour for all container probe cronjobs which do not pass this param.

## Validation

- `kustomize build` passes for all three overlays:
  - `components/monitoring/kanary/staging/base/`
  - `components/monitoring/kanary/staging/stone-stg-rh01/`
  - `components/monitoring/kanary/staging/stone-stage-p01/`

[PVO11Y-5455]: https://redhat.atlassian.net/browse/PVO11Y-5455?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ