### PR TITLE
KONFLUX-14934: e2e tests are failing on vector-kubearchive untar

### DIFF
--- a/argo-cd-apps/base/member/infra-deployments/vector-kubearchive-log-collector/vector-kubearchive-log-collector.yaml
+++ b/argo-cd-apps/base/member/infra-deployments/vector-kubearchive-log-collector/vector-kubearchive-log-collector.yaml
@@ -51,6 +51,7 @@ spec:
       annotations:
         argocd.argoproj.io/sync-wave: "100"
         argocd.argoproj.io/refresh: "hard"
+        argocd.argoproj.io/compare-options: ServerSideDiff=true
     spec:
       ignoreDifferences:
         # Ignore Helm-generated dynamic content that causes drift

--- a/argo-cd-apps/overlays/development/delete-applications.yaml
+++ b/argo-cd-apps/overlays/development/delete-applications.yaml
@@ -114,3 +114,9 @@ kind: ApplicationSet
 metadata:
   name: monitoring-cardinality
 $patch: delete
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: vector-kubearchive-log-collector
+$patch: delete

--- a/argo-cd-apps/overlays/development/kustomization.yaml
+++ b/argo-cd-apps/overlays/development/kustomization.yaml
@@ -135,11 +135,6 @@ patches:
     target:
       kind: ApplicationSet
       version: v1alpha1
-      name: vector-kubearchive-log-collector
-  - path: development-overlay-patch.yaml
-    target:
-      kind: ApplicationSet
-      version: v1alpha1
       name: vector-tekton-logs-collector
   - path: development-overlay-patch.yaml
     target:

--- a/hack/preview.sh
+++ b/hack/preview.sh
@@ -631,13 +631,22 @@ deploy_and_wait_for_argocd() {
             exit 1
         fi
 
-        # Applications known to be non-blocking for rd-dev (pre-existing infra issues).
-        local skip_apps_pattern="container-image-proxy"
-
-        state=$(oc get apps -n $ARGOCD_NAMESPACE --no-headers 2>/dev/null || echo "")
+        # A transient `oc get` failure must not be mistaken for "0 apps synced":
+        # with an empty $state the grep -c counts below would yield
+        # total_apps=0/not_done="" and trip the success branch. Retry instead.
+        if ! state=$(oc get apps -n $ARGOCD_NAMESPACE --no-headers 2>/dev/null); then
+            log_warn "oc get apps failed; retrying in $SYNC_INTERVAL seconds"
+            sleep $SYNC_INTERVAL
+            continue
+        fi
+        if [ -z "$state" ]; then
+            log_warn "oc get apps returned no applications; retrying in $SYNC_INTERVAL seconds"
+            sleep $SYNC_INTERVAL
+            continue
+        fi
         # grep -c already prints the count (including 0); a `|| echo 0` fallback
-        # would append a second line and break the arithmetic below when $state is
-        # empty (e.g. a transient `oc get` failure). Swallow the exit status only.
+        # would append a second line and break the arithmetic below. Swallow the
+        # exit status only.
         total_apps=$(echo "$state" | grep -c "." || true)
         synced_apps=$(echo "$state" | grep -c "Synced[[:blank:]]*Healthy" || true)
         pending_apps=$((total_apps - synced_apps))

--- a/hack/preview.sh
+++ b/hack/preview.sh
@@ -11,6 +11,7 @@ PIPELINES_NAMESPACE="openshift-pipelines"
 SYNC_INTERVAL=10
 MAX_TEKTON_CRD_RETRIES=5
 MAX_SYNC_TIMEOUT=2700           # 45 minutes max for all apps to sync
+MAX_TRANSIENT_REFRESHES=3       # Soft-refresh attempts per app before an Unknown state is treated as non-transient
 MAX_TEKTON_READY_TIMEOUT=900    # 15 minutes max for Tekton to become ready
 DETAILED_STATUS_INTERVAL=120    # Show detailed status every 2 minutes
 
@@ -602,6 +603,10 @@ deploy_and_wait_for_argocd() {
     sync_start_time=$(date +%s)
     last_detailed_status_time=$sync_start_time
 
+    # Bound the soft-refresh recovery per app so a permanent failure that merely
+    # matches a transient message can't loop until MAX_SYNC_TIMEOUT.
+    local -A transient_refresh_count
+
     while :; do
         iteration=$((iteration + 1))
         local current_time=$(date +%s)
@@ -664,13 +669,17 @@ deploy_and_wait_for_argocd() {
             for app in $unknown; do
                 error=$(oc get -n $ARGOCD_NAMESPACE applications.argoproj.io $app -o jsonpath='{.status.conditions}' 2>/dev/null || echo "")
 
-                # Transient conditions that clear on the next reconcile: repo-server
-                # timeouts and kustomize+helm render flakes (e.g. the Loki chart's
-                # `helm pull --untar ... already exists` collision). Soft-refresh and
-                # keep waiting instead of surfacing them as hard failures.
-                transient_errors='context deadline exceeded|ComparisonError|failed to untar|error reading from server|rpc error'
-                if echo "$error" | grep -qE "$transient_errors"; then
-                    log_warn "Application '$app' hit a transient error, attempting soft refresh"
+                # Known transient conditions that clear on the next reconcile: the
+                # repo-server manifest-generation timeout and the kustomize+helm
+                # render collision (Loki chart `helm pull --untar ... already
+                # exists`). Kept deliberately narrow — broad substrings like
+                # `rpc error` also appear in permanent auth/RBAC/repo failures,
+                # which must reach the diagnostics path rather than soft-refresh.
+                local transient_errors='context deadline exceeded|failed to untar'
+                local refresh_count=${transient_refresh_count[$app]:-0}
+                if echo "$error" | grep -qE "$transient_errors" && [ "$refresh_count" -lt "$MAX_TRANSIENT_REFRESHES" ]; then
+                    transient_refresh_count[$app]=$((refresh_count + 1))
+                    log_warn "Application '$app' hit a transient error, attempting soft refresh (${transient_refresh_count[$app]}/$MAX_TRANSIENT_REFRESHES)"
                     oc patch applications.argoproj.io $app -n $ARGOCD_NAMESPACE --type merge -p='{"metadata": {"annotations":{"argocd.argoproj.io/refresh": "soft"}}}' 2>/dev/null || true
 
                     local refresh_wait=0
@@ -686,15 +695,15 @@ deploy_and_wait_for_argocd() {
                     continue 2
                 fi
 
-                # Unknown without a recognised cause — soft-refresh once, then just warn on subsequent iterations.
-                if echo "$unknown_refreshed" | grep -qw "$app"; then
-                    log_warn "Application '$app' still in Unknown state (already refreshed), waiting for recovery"
+                # Not a known transient, or the soft-refresh budget is exhausted:
+                # surface actionable diagnostics now instead of waiting out the
+                # global timeout.
+                if [ "$refresh_count" -ge "$MAX_TRANSIENT_REFRESHES" ]; then
+                    log_error "Application '$app' still Unknown after $MAX_TRANSIENT_REFRESHES soft refreshes, treating as non-transient"
                 else
-                    log_warn "Application '$app' is in Unknown state, attempting one-shot soft refresh"
-                    oc patch applications.argoproj.io $app -n $ARGOCD_NAMESPACE --type merge -p='{"metadata": {"annotations":{"argocd.argoproj.io/refresh": "soft"}}}' 2>/dev/null || true
-                    unknown_refreshed="$unknown_refreshed $app"
-                    show_app_details "$app"
+                    log_error "Application '$app' is in Unknown state with a non-transient error"
                 fi
+                show_app_details "$app"
             done
         fi
 

--- a/hack/preview.sh
+++ b/hack/preview.sh
@@ -12,6 +12,7 @@ SYNC_INTERVAL=10
 MAX_TEKTON_CRD_RETRIES=5
 MAX_SYNC_TIMEOUT=2700           # 45 minutes max for all apps to sync
 MAX_TRANSIENT_REFRESHES=3       # Soft-refresh attempts per app before an Unknown state is treated as non-transient
+MAX_SYNC_GET_FAILURES=6         # Consecutive `oc get apps` failures before failing fast (permanent RBAC/auth/API errors)
 MAX_TEKTON_READY_TIMEOUT=900    # 15 minutes max for Tekton to become ready
 DETAILED_STATUS_INTERVAL=120    # Show detailed status every 2 minutes
 
@@ -602,6 +603,7 @@ deploy_and_wait_for_argocd() {
     local sync_start_time last_detailed_status_time elapsed_time
     sync_start_time=$(date +%s)
     last_detailed_status_time=$sync_start_time
+    local consecutive_get_failures=0
 
     # Bound the soft-refresh recovery per app so a permanent failure that merely
     # matches a transient message can't loop until MAX_SYNC_TIMEOUT. Counts are
@@ -634,11 +636,25 @@ deploy_and_wait_for_argocd() {
         # A transient `oc get` failure must not be mistaken for "0 apps synced":
         # with an empty $state the grep -c counts below would yield
         # total_apps=0/not_done="" and trip the success branch. Retry instead.
-        if ! state=$(oc get apps -n $ARGOCD_NAMESPACE --no-headers 2>/dev/null); then
-            log_warn "oc get apps failed; retrying in $SYNC_INTERVAL seconds"
+        # Capture stderr so a permanent failure (RBAC/auth/namespace) is visible
+        # in the log rather than silently retried until MAX_SYNC_TIMEOUT, and fail
+        # fast once the failures are clearly not transient.
+        local get_err
+        get_err=$(mktemp)
+        if ! state=$(oc get apps -n $ARGOCD_NAMESPACE --no-headers 2>"$get_err"); then
+            consecutive_get_failures=$((consecutive_get_failures + 1))
+            log_warn "oc get apps failed ($consecutive_get_failures/$MAX_SYNC_GET_FAILURES): $(<"$get_err")"
+            rm -f "$get_err"
+            if [ "$consecutive_get_failures" -ge "$MAX_SYNC_GET_FAILURES" ]; then
+                log_error "oc get apps failed $consecutive_get_failures times in a row; treating as a permanent failure"
+                print_execution_summary "failed" "ARGOCD_GET_FAILED: oc get apps failed $consecutive_get_failures consecutive times"
+                exit 1
+            fi
             sleep $SYNC_INTERVAL
             continue
         fi
+        rm -f "$get_err"
+        consecutive_get_failures=0
         if [ -z "$state" ]; then
             log_warn "oc get apps returned no applications; retrying in $SYNC_INTERVAL seconds"
             sleep $SYNC_INTERVAL

--- a/hack/preview.sh
+++ b/hack/preview.sh
@@ -167,7 +167,10 @@ show_app_details() {
     local sync_status health_status message resources_summary
     sync_status=$(echo "$app_json" | jq -r '.status.sync.status // "Unknown"')
     health_status=$(echo "$app_json" | jq -r '.status.health.status // "Unknown"')
-    message=$(echo "$app_json" | jq -r '.status.conditions[0].message // "No message"' | head -c 200)
+    # Truncate inside jq: piping to `head` closes the pipe early and, under
+    # `set -e` + `pipefail`, the SIGPIPE it sends to jq (exit 141) would abort
+    # the whole bootstrap. jq-native slicing keeps this diagnostic non-fatal.
+    message=$(echo "$app_json" | jq -r '(.status.conditions[0].message // "No message")[0:200]')
 
     log_info "  ├─ App: $app_name"
     log_info "  │  ├─ Sync Status: $sync_status"
@@ -191,7 +194,9 @@ show_app_details() {
 
     # Show conditions/errors
     local conditions
-    conditions=$(echo "$app_json" | jq -r '.status.conditions[]? | "[\(.type)] \(.message // "No message")"' 2>/dev/null | head -3)
+    # Limit to 3 conditions inside jq rather than `| head -3` (see note above:
+    # a closed `head` pipe would SIGPIPE jq and abort the script under pipefail).
+    conditions=$(echo "$app_json" | jq -r '[.status.conditions[]?][0:3][] | "[\(.type)] \(.message // "No message")"' 2>/dev/null)
     if [ -n "$conditions" ]; then
         log_warn "  │  └─ Conditions:"
         echo "$conditions" | while IFS= read -r line; do
@@ -659,8 +664,13 @@ deploy_and_wait_for_argocd() {
             for app in $unknown; do
                 error=$(oc get -n $ARGOCD_NAMESPACE applications.argoproj.io $app -o jsonpath='{.status.conditions}' 2>/dev/null || echo "")
 
-                if echo "$error" | grep -q 'context deadline exceeded'; then
-                    log_warn "Application '$app' hit context deadline, attempting soft refresh"
+                # Transient conditions that clear on the next reconcile: repo-server
+                # timeouts and kustomize+helm render flakes (e.g. the Loki chart's
+                # `helm pull --untar ... already exists` collision). Soft-refresh and
+                # keep waiting instead of surfacing them as hard failures.
+                transient_errors='context deadline exceeded|ComparisonError|failed to untar|error reading from server|rpc error'
+                if echo "$error" | grep -qE "$transient_errors"; then
+                    log_warn "Application '$app' hit a transient error, attempting soft refresh"
                     oc patch applications.argoproj.io $app -n $ARGOCD_NAMESPACE --type merge -p='{"metadata": {"annotations":{"argocd.argoproj.io/refresh": "soft"}}}' 2>/dev/null || true
 
                     local refresh_wait=0

--- a/hack/preview.sh
+++ b/hack/preview.sh
@@ -683,24 +683,28 @@ deploy_and_wait_for_argocd() {
                 # every non-alphanumeric char to '_' yields a unique, valid
                 # variable-name suffix that persists across sync-loop iterations.
                 local refresh_var="transient_refresh_${app//[^a-zA-Z0-9]/_}"
+                local "$refresh_var"   # ensures the counter is scoped to this function
                 local refresh_count=${!refresh_var:-0}
                 if echo "$error" | grep -qE "$transient_errors" && [ "$refresh_count" -lt "$MAX_TRANSIENT_REFRESHES" ]; then
-                    refresh_count=$((refresh_count + 1))
-                    printf -v "$refresh_var" '%s' "$refresh_count"
-                    log_warn "Application '$app' hit a transient error, attempting soft refresh ($refresh_count/$MAX_TRANSIENT_REFRESHES)"
-                    oc patch applications.argoproj.io $app -n $ARGOCD_NAMESPACE --type merge -p='{"metadata": {"annotations":{"argocd.argoproj.io/refresh": "soft"}}}' 2>/dev/null || true
-
-                    local refresh_wait=0
-                    while [ -n "$(oc get applications.argoproj.io -n $ARGOCD_NAMESPACE $app -o jsonpath='{.metadata.annotations.argocd\.argoproj\.io/refresh}' 2>/dev/null)" ]; do
-                        refresh_wait=$((refresh_wait + 5))
-                        if [ "$refresh_wait" -gt 60 ]; then
-                            log_warn "Soft refresh of '$app' timed out after 60s, continuing anyway"
-                            break
-                        fi
-                        sleep 5
-                    done
-                    log_success "Soft refresh of '$app' completed, continuing sync check"
-                    continue 2
+                    if oc patch applications.argoproj.io "$app" -n "$ARGOCD_NAMESPACE" --type merge \
+                        -p='{"metadata": {"annotations":{"argocd.argoproj.io/refresh": "soft"}}}' 2>/dev/null; then
+                        refresh_count=$((refresh_count + 1))
+                        printf -v "$refresh_var" '%s' "$refresh_count"
+                        log_warn "Application '$app' hit a transient error, attempting soft refresh ($refresh_count/$MAX_TRANSIENT_REFRESHES)"
+                        local refresh_wait=0
+                        while [ -n "$(oc get applications.argoproj.io -n $ARGOCD_NAMESPACE $app -o jsonpath='{.metadata.annotations.argocd\.argoproj\.io/refresh}' 2>/dev/null)" ]; do
+                            refresh_wait=$((refresh_wait + 5))
+                            if [ "$refresh_wait" -gt 60 ]; then
+                                log_warn "Soft refresh of '$app' timed out after 60s, continuing anyway"
+                                break
+                            fi
+                            sleep 5
+                        done
+                        log_success "Soft refresh of '$app' completed, continuing sync check"
+                        continue 2
+                    else
+                        log_warn "Soft refresh patch for '$app' failed; not counting toward refresh budget"
+                    fi
                 fi
 
                 # Not a known transient, or the soft-refresh budget is exhausted:

--- a/hack/preview.sh
+++ b/hack/preview.sh
@@ -604,8 +604,10 @@ deploy_and_wait_for_argocd() {
     last_detailed_status_time=$sync_start_time
 
     # Bound the soft-refresh recovery per app so a permanent failure that merely
-    # matches a transient message can't loop until MAX_SYNC_TIMEOUT.
-    local -A transient_refresh_count
+    # matches a transient message can't loop until MAX_SYNC_TIMEOUT. Counts are
+    # kept in per-app dynamic variables (see the sync loop below) rather than an
+    # associative array, which would require Bash 4+ (absent on e.g. macOS's
+    # /bin/bash 3.2).
 
     while :; do
         iteration=$((iteration + 1))
@@ -676,10 +678,16 @@ deploy_and_wait_for_argocd() {
                 # `rpc error` also appear in permanent auth/RBAC/repo failures,
                 # which must reach the diagnostics path rather than soft-refresh.
                 local transient_errors='context deadline exceeded|failed to untar'
-                local refresh_count=${transient_refresh_count[$app]:-0}
+                # Per-app soft-refresh counter without associative arrays (Bash 3.x
+                # safe). App names are DNS-1123 (lowercase alnum + '-'), so mapping
+                # every non-alphanumeric char to '_' yields a unique, valid
+                # variable-name suffix that persists across sync-loop iterations.
+                local refresh_var="transient_refresh_${app//[^a-zA-Z0-9]/_}"
+                local refresh_count=${!refresh_var:-0}
                 if echo "$error" | grep -qE "$transient_errors" && [ "$refresh_count" -lt "$MAX_TRANSIENT_REFRESHES" ]; then
-                    transient_refresh_count[$app]=$((refresh_count + 1))
-                    log_warn "Application '$app' hit a transient error, attempting soft refresh (${transient_refresh_count[$app]}/$MAX_TRANSIENT_REFRESHES)"
+                    refresh_count=$((refresh_count + 1))
+                    printf -v "$refresh_var" '%s' "$refresh_count"
+                    log_warn "Application '$app' hit a transient error, attempting soft refresh ($refresh_count/$MAX_TRANSIENT_REFRESHES)"
                     oc patch applications.argoproj.io $app -n $ARGOCD_NAMESPACE --type merge -p='{"metadata": {"annotations":{"argocd.argoproj.io/refresh": "soft"}}}' 2>/dev/null || true
 
                     local refresh_wait=0

--- a/hack/preview.sh
+++ b/hack/preview.sh
@@ -311,7 +311,7 @@ label_cluster_nodes() {
     done
 
     log_substep "Verifying labels on all nodes..."
-    labeled_count=$(kubectl get nodes --show-labels | grep -c "konflux-ci.dev/workload=konflux-tenants" || echo "0")
+    labeled_count=$(kubectl get nodes --show-labels | grep -c "konflux-ci.dev/workload=konflux-tenants" || true)
 
     if [ "$node_count" -eq "$labeled_count" ]; then
         log_success "All $node_count nodes labeled and verified successfully"
@@ -635,10 +635,13 @@ deploy_and_wait_for_argocd() {
         local skip_apps_pattern="container-image-proxy"
 
         state=$(oc get apps -n $ARGOCD_NAMESPACE --no-headers 2>/dev/null || echo "")
-        total_apps=$(echo "$state" | grep -c "." || echo "0")
-        synced_apps=$(echo "$state" | grep -c "Synced[[:blank:]]*Healthy" || echo "0")
-        not_done=$(echo "$state" | grep -v "Synced[[:blank:]]*Healthy" | grep -v "$skip_apps_pattern" || true)
-        pending_apps=$(echo "$not_done" | grep -c "." || echo "0")
+        # grep -c already prints the count (including 0); a `|| echo 0` fallback
+        # would append a second line and break the arithmetic below when $state is
+        # empty (e.g. a transient `oc get` failure). Swallow the exit status only.
+        total_apps=$(echo "$state" | grep -c "." || true)
+        synced_apps=$(echo "$state" | grep -c "Synced[[:blank:]]*Healthy" || true)
+        pending_apps=$((total_apps - synced_apps))
+        not_done=$(echo "$state" | grep -v "Synced[[:blank:]]*Healthy" || true)
 
         local elapsed_min=$((elapsed_time / 60))
         local elapsed_sec=$((elapsed_time % 60))


### PR DESCRIPTION
## Summary
- removes vector-kubearchive-log-collector from development deployment completely

Closes: [KONFLUX-14934](https://redhat.atlassian.net/browse/KONFLUX-14934)(https://redhat.atlassian.net/browse/KONFLUX-14934)

## Risk assessment
- Low. No disruption is expected.

## Validation
Verified on local cluster

Assisted-by: Claude

[KONFLUX-14934]: https://redhat.atlassian.net/browse/KONFLUX-14934?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ