### PR TITLE
Fix production konflux-ui oauth2-proxy args patch container index

### DIFF
--- a/components/konflux-ui/production/kflux-fedora-01/oauth2-proxy-args-patch.yaml
+++ b/components/konflux-ui/production/kflux-fedora-01/oauth2-proxy-args-patch.yaml
@@ -1,6 +1,6 @@
 ---
 - op: replace
-  path: /spec/template/spec/containers/3/args
+  path: /spec/template/spec/containers/2/args
   value:
     - --provider
     - oidc

--- a/components/konflux-ui/production/kflux-ocp-p01/oauth2-proxy-args-patch.yaml
+++ b/components/konflux-ui/production/kflux-ocp-p01/oauth2-proxy-args-patch.yaml
@@ -1,6 +1,6 @@
 ---
 - op: replace
-  path: /spec/template/spec/containers/3/args
+  path: /spec/template/spec/containers/2/args
   value:
     - --provider
     - oidc

--- a/components/konflux-ui/production/kflux-osp-p01/oauth2-proxy-args-patch.yaml
+++ b/components/konflux-ui/production/kflux-osp-p01/oauth2-proxy-args-patch.yaml
@@ -1,6 +1,6 @@
 ---
 - op: replace
-  path: /spec/template/spec/containers/3/args
+  path: /spec/template/spec/containers/2/args
   value:
     - --provider
     - oidc

--- a/components/konflux-ui/production/kflux-prd-rh02/oauth2-proxy-args-patch.yaml
+++ b/components/konflux-ui/production/kflux-prd-rh02/oauth2-proxy-args-patch.yaml
@@ -1,6 +1,6 @@
 ---
 - op: replace
-  path: /spec/template/spec/containers/3/args
+  path: /spec/template/spec/containers/2/args
   value:
     - --provider
     - oidc

--- a/components/konflux-ui/production/kflux-prd-rh03/oauth2-proxy-args-patch.yaml
+++ b/components/konflux-ui/production/kflux-prd-rh03/oauth2-proxy-args-patch.yaml
@@ -1,6 +1,6 @@
 ---
 - op: replace
-  path: /spec/template/spec/containers/3/args
+  path: /spec/template/spec/containers/2/args
   value:
     - --provider
     - oidc

--- a/components/konflux-ui/production/kflux-rhel-p01/oauth2-proxy-args-patch.yaml
+++ b/components/konflux-ui/production/kflux-rhel-p01/oauth2-proxy-args-patch.yaml
@@ -1,6 +1,6 @@
 ---
 - op: replace
-  path: /spec/template/spec/containers/3/args
+  path: /spec/template/spec/containers/2/args
   value:
     - --provider
     - oidc

--- a/components/konflux-ui/production/stone-prd-rh01/oauth2-proxy-args-patch.yaml
+++ b/components/konflux-ui/production/stone-prd-rh01/oauth2-proxy-args-patch.yaml
@@ -1,6 +1,6 @@
 ---
 - op: replace
-  path: /spec/template/spec/containers/3/args
+  path: /spec/template/spec/containers/2/args
   value:
     - --provider
     - oidc

--- a/components/konflux-ui/production/stone-prod-p01/oauth2-proxy-args-patch.yaml
+++ b/components/konflux-ui/production/stone-prod-p01/oauth2-proxy-args-patch.yaml
@@ -1,6 +1,6 @@
 ---
 - op: replace
-  path: /spec/template/spec/containers/3/args
+  path: /spec/template/spec/containers/2/args
   value:
     - --provider
     - oidc

--- a/components/konflux-ui/production/stone-prod-p02/oauth2-proxy-args-patch.yaml
+++ b/components/konflux-ui/production/stone-prod-p02/oauth2-proxy-args-patch.yaml
@@ -1,6 +1,6 @@
 ---
 - op: replace
-  path: /spec/template/spec/containers/3/args
+  path: /spec/template/spec/containers/2/args
   value:
     - --provider
     - oidc


### PR DESCRIPTION
Point oauth2-proxy-args-patch.yaml at containers/2 instead of containers/3 across all production cluster overlays.

The PR https://github.com/redhat-appstudio/infra-deployments/pull/13440/ removed one of the containers, so order is now changed.