### PR TITLE
Custom Kube State Metrics: Increase Resources

### DIFF
--- a/components/monitoring/custom-kube-state-metrics/base/deployment.yaml
+++ b/components/monitoring/custom-kube-state-metrics/base/deployment.yaml
@@ -56,10 +56,10 @@ spec:
           timeoutSeconds: 5
         resources:
           requests:
-            cpu: 50m
+            cpu: 100m
             memory: 256Mi
           limits:
-            cpu: 200m
+            cpu: 250m
             memory: 256Mi
         securityContext:
           allowPrivilegeEscalation: false


### PR DESCRIPTION
Increase the CPU allocation to prevent CPU throttling and memory spikes.
The change is made to adhere for latest resource recommendation stated
in the KSM docs. This change was not triggered by any other problem than
prevention.

https://github.com/kubernetes/kube-state-metrics#resource-recommendation