### PR TITLE
PVO11Y-5072 Add spanmetrics/mttb connector to Konflux staging collector

### DIFF
--- a/components/monitoring/tracing/otel-collector/staging/otel-collector-helm-values.yaml
+++ b/components/monitoring/tracing/otel-collector/staging/otel-collector-helm-values.yaml
@@ -38,6 +38,30 @@ config:
         - key: collector.clustername
           action: insert
           value: staging
+    filter/mttb:
+      error_mode: ignore
+      traces:
+        span:
+          - resource.attributes["service.name"] == nil
+          - not(IsMatch(resource.attributes["service.name"], "^(pipelines-as-code|integration-service|release-service)$"))
+  connectors:
+    spanmetrics/mttb:
+      metrics_expiration: 1h
+      histogram:
+        unit: s
+        explicit:
+          buckets: [30s, 1m, 2m, 5m, 10m, 20m, 40m, 1h, 2h, 4h, 8h]
+      dimensions:
+        - name: namespace
+        - name: cicd.pipeline.action.name
+        - name: cicd.pipeline.result
+        - name: delivery.tekton.dev.application
+          default: unknown
+      exemplars:
+        enabled: true
+      metrics_flush_interval: 30s
+      resource_metrics_key_attributes:
+        - service.name
   receivers:
     jaeger: null
     prometheus: null
@@ -65,14 +89,25 @@ config:
           - attributes/stage
         receivers:
           - otlp
+      traces/stage-mttb:
+        receivers:
+          - otlp
+        processors:
+          - memory_limiter
+          - filter/mttb
+          - batch
+        exporters:
+          - spanmetrics/mttb
       metrics:
         receivers:
         - otlp
+        - spanmetrics/mttb
         processors:
         - memory_limiter
         - batch
         exporters:
         - prometheus
+        - signalfx
     telemetry:
       metrics:
         address: null

--- a/components/monitoring/tracing/otel-collector/staging/servicemonitors/kustomization.yaml
+++ b/components/monitoring/tracing/otel-collector/staging/servicemonitors/kustomization.yaml
@@ -2,3 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - otel-collector-kanary-servicemonitor.yaml
+  - otel-collector-mttb-servicemonitor.yaml

--- a/components/monitoring/tracing/otel-collector/staging/servicemonitors/otel-collector-mttb-servicemonitor.yaml
+++ b/components/monitoring/tracing/otel-collector/staging/servicemonitors/otel-collector-mttb-servicemonitor.yaml
@@ -1,0 +1,17 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: otel-collector-mttb-metrics
+  namespace: konflux-otel
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: opentelemetry-collector
+  endpoints:
+    - port: prometheus
+      interval: 15s
+      path: /metrics
+      metricRelabelings:
+        - sourceLabels: [__name__]
+          regex: 'traces_spanmetrics_.*'
+          action: keep


### PR DESCRIPTION
Add spanmetrics/mttb connector, filter/mttb processor, and traces/stage-mttb
pipeline to the Konflux staging OTel collector to compute MTTB histograms from
delivery pipeline traces. Adds otel-collector-mttb-metrics ServiceMonitor
scraping traces_spanmetrics_.*.

PVO11Y-5072