### PR TITLE
KONFLUX-14937: upgrade Vector tekton logs collector to 0.57.0

### DIFF
--- a/components/vector-tekton-logs-collector/development/vector-helm-generator.yaml
+++ b/components/vector-tekton-logs-collector/development/vector-helm-generator.yaml
@@ -6,9 +6,9 @@ name: vector
 repo: https://helm.vector.dev
 # We mirror the image from Docker to Quay. To update the version, mirror the respective
 # image. You can use skopeo e.g
-# `skopeo copy docker://timberio/vector:0.45.0-distroless-libc docker://quay.io/openshift-pipeline/vector:0.45.0-distroless-libc`
+# `skopeo copy docker://timberio/vector:0.57.0-distroless-libc docker://quay.io/openshift-pipeline/vector:0.57.0-distroless-libc`
 # The tag obviously will differ.
-version: 0.41.0
+version: 0.57.0
 releaseName: vector-tekton-logs-collector
 namespace: tekton-logging
 valuesFile: vector-helm-values.yaml

--- a/components/vector-tekton-logs-collector/development/vector-helm-values.yaml
+++ b/components/vector-tekton-logs-collector/development/vector-helm-values.yaml
@@ -12,7 +12,6 @@ customConfig:
   api:
     enabled: true
     address: 127.0.0.1:8686
-    playground: false
   sources:
     kubernetes_logs:
       type: kubernetes_logs
@@ -74,7 +73,7 @@ tolerations:
     value: konflux-tenants
 image:
   repository: quay.io/openshift-pipeline/vector
-  tag: 0.45.0-distroless-libc
+  tag: 0.57.0-distroless-libc
 securityContext:
   allowPrivilegeEscalation: false
   capabilities:

--- a/components/vector-tekton-logs-collector/staging/vector-helm-generator.yaml
+++ b/components/vector-tekton-logs-collector/staging/vector-helm-generator.yaml
@@ -6,9 +6,9 @@ name: vector
 repo: https://helm.vector.dev
 # We mirror the image from Docker to Quay. To update the version, mirror the respective
 # image. You can use skopeo e.g
-# `skopeo copy docker://timberio/vector:0.45.0-distroless-libc docker://quay.io/openshift-pipeline/vector:0.45.0-distroless-libc`
+# `skopeo copy docker://timberio/vector:0.57.0-distroless-libc docker://quay.io/openshift-pipeline/vector:0.57.0-distroless-libc`
 # The tag obviously will differ.
-version: 0.41.0
+version: 0.57.0
 releaseName: vector-tekton-logs-collector
 namespace: tekton-logging
 valuesFile: vector-helm-values.yaml

--- a/components/vector-tekton-logs-collector/staging/vector-helm-values.yaml
+++ b/components/vector-tekton-logs-collector/staging/vector-helm-values.yaml
@@ -12,7 +12,6 @@ customConfig:
   api:
     enabled: true
     address: 127.0.0.1:8686
-    playground: false
   sources:
     kubernetes_logs:
       type: kubernetes_logs
@@ -77,6 +76,10 @@ customConfig:
       filename_time_format: "-%s"
       filename_append_uuid: false
 env:
+  # Vector 0.57 disables ${VAR} interpolation by default. Restore it for
+  # BUCKET/ENDPOINT sourced from the tekton-results-s3 secret.
+  - name: VECTOR_DANGEROUSLY_ALLOW_ENV_VAR_INTERPOLATION
+    value: "true"
   - name: AWS_ACCESS_KEY_ID
     valueFrom:
       secretKeyRef:
@@ -111,7 +114,7 @@ tolerations:
     value: konflux-tenants
 image:
   repository: quay.io/openshift-pipeline/vector
-  tag: 0.45.0-distroless-libc
+  tag: 0.57.0-distroless-libc
 securityContext:
   allowPrivilegeEscalation: false
   capabilities:


### PR DESCRIPTION
## What

- Upgrade Vector Helm chart from 0.41.0 → 0.57.0
- Upgrade Vector image from 0.45.0-distroless-libc → 0.57.0-distroless-libc
- Handle Vector 0.55+ breaking changes (remove deprecated `api.playground`)
- Handle Vector 0.57 breaking change: re-enable `${VAR}` interpolation for staging S3 sink credentials

Clusters affected: development, staging

[KONFLUX-14937](https://redhat.atlassian.net/browse/KONFLUX-14937)

## Why

CVE-2026-39197 — Denial of Service via crafted request to Vector's HTTP endpoint. While the current version (0.45.0) does not expose the vulnerable HTTP ingest sources, upgrading to the patched release (0.57.0) as defense-in-depth.

## Validation

- `kustomize build --enable-helm` passes for both development and staging overlays
- Similar upgrade validated in [#13383](https://github.com/redhat-appstudio/infra-deployments/pull/13383) for `vector-kubearchive-log-collector`

[KONFLUX-14937]: https://redhat.atlassian.net/browse/KONFLUX-14937?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ