### PR TITLE
Applying nodeSelector and tolerations to cluster monitoring operator …

### DIFF
--- a/components/monitoring/prometheus/staging/lightwell-dev/cluster-monitoring-config.yaml
+++ b/components/monitoring/prometheus/staging/lightwell-dev/cluster-monitoring-config.yaml
@@ -1,0 +1,41 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-monitoring-config
+  namespace: openshift-monitoring
+data:
+  config.yaml: |
+    enableUserWorkload: true
+    prometheusK8s:
+      retentionSize: 10GB
+      nodeSelector:
+        konflux-ci.dev/workload: konflux-tenants
+      tolerations:
+        - key: "konflux-ci.dev/workload"
+          value: "konflux-tenants"
+          effect: "NoSchedule"
+          operator: "Equal"
+    alertmanagerMain:
+      nodeSelector:
+        konflux-ci.dev/workload: konflux-tenants
+      tolerations:
+        - key: "konflux-ci.dev/workload"
+          value: "konflux-tenants"
+          effect: "NoSchedule"
+          operator: "Equal"
+    thanosQuerier:
+      nodeSelector:
+        konflux-ci.dev/workload: konflux-tenants
+      tolerations:
+        - key: "konflux-ci.dev/workload"
+          value: "konflux-tenants"
+          effect: "NoSchedule"
+          operator: "Equal"
+    prometheusOperator:
+      nodeSelector:
+        konflux-ci.dev/workload: konflux-tenants
+      tolerations:
+        - key: "konflux-ci.dev/workload"
+          value: "konflux-tenants"
+          effect: "NoSchedule"
+          operator: "Equal"

--- a/components/monitoring/prometheus/staging/lightwell-dev/kustomization.yaml
+++ b/components/monitoring/prometheus/staging/lightwell-dev/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
 - ../base
 - ../tekton-ms
+- cluster-monitoring-config.yaml
 patches:
   - path: cluster-id-label.yaml
     target:


### PR DESCRIPTION
 Summary

  Configures cluster monitoring components (Prometheus, Alertmanager, Thanos Querier, and Prometheus Operator) to run on infrastructure nodes in the lightwell-dev
  staging cluster.

  Changes

  - Added cluster-monitoring-config.yaml to components/monitoring/prometheus/staging/lightwell-dev/
  - Updated kustomization to include the new ConfigMap
  - Applied nodeSelector node-role.kubernetes.io/infra and corresponding tolerations to all monitoring operator pods

  Deployment Target

  - Cluster: lightwell-dev (staging)
  - Namespace: openshift-monitoring
  - Component: monitoring-workload-prometheus

  The existing ArgoCD ApplicationSet will automatically sync this ConfigMap when merged.
