### PR TITLE
KONFLUX-10897: Vendor pulp-access-controller production manifests

### DIFF
--- a/components/pulp-access-controller/production/combined.yaml
+++ b/components/pulp-access-controller/production/combined.yaml
@@ -1,0 +1,200 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: pulp-access-controller
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: pulpaccessrequests.pulp.konflux-ci.dev
+spec:
+  group: pulp.konflux-ci.dev
+  scope: Namespaced
+  names:
+    plural: pulpaccessrequests
+    singular: pulpaccessrequest
+    kind: PulpAccessRequest
+    shortNames:
+      - par
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              required:
+                - credentialsSecretName
+              properties:
+                credentialsSecretName:
+                  type: string
+                  description: |
+                    Name of the secret containing authentication credentials.
+                    Supports two authentication methods:
+                    1. Certificate-based (mTLS): Secret should contain 'cert' or 'tls.crt' and 'key' or 'tls.key'
+                    2. Basic Auth: Secret should contain 'username' and 'password'
+                    If both are provided, certificate-based authentication takes precedence.
+                use_quay_backend:
+                  type: boolean
+                  description: "Whether to configure Quay as the OCI backend storage for the domain (optional, defaults to false)"
+            status:
+              type: object
+              properties:
+                conditions:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      type:
+                        type: string
+                      status:
+                        type: string
+                      reason:
+                        type: string
+                      message:
+                        type: string
+                      lastTransitionTime:
+                        type: string
+                        format: date-time
+                secretName:
+                  type: string
+                  description: "Name of the generated secret"
+                domain:
+                  type: string
+                  description: "The auto-generated Pulp domain name (konflux-<namespace>)"
+                domainCreated:
+                  type: boolean
+                  description: "Whether the Pulp domain was created"
+                imageRepositoryCreated:
+                  type: boolean
+                  description: "Whether the ImageRepository was created"
+                quayBackendConfigured:
+                  type: boolean
+                  description: "Whether Quay backend storage was configured"
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: pulp-access-operator
+  namespace: pulp-access-controller
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: pulpaccess-operator-role
+rules:
+  - apiGroups: ["pulp.konflux-ci.dev"]
+    resources: ["pulpaccessrequests"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: ["pulp.konflux-ci.dev"]
+    resources: ["pulpaccessrequests/status"]
+    verbs: ["get", "update", "patch"]
+  - apiGroups: ["pulp.konflux-ci.dev"]
+    resources: ["pulpaccessrequests/finalizers"]
+    verbs: ["update"]
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["secrets", "events"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: ["appstudio.redhat.com"]
+    resources: ["imagerepositories"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: pulpaccess-user-role
+rules:
+  - apiGroups: ["pulp.konflux-ci.dev"]
+    resources: ["pulpaccessrequests"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: pulpaccess-operator-binding
+subjects:
+  - kind: ServiceAccount
+    name: pulp-access-operator
+    namespace: pulp-access-controller
+roleRef:
+  kind: ClusterRole
+  name: pulpaccess-operator-role
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: pulp-secrets
+  namespace: pulp-access-controller
+  annotations:
+    argocd.argoproj.io/sync-options: "SkipDryRunOnMissingResource=true"
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  dataFrom:
+    - extract:
+        conversionStrategy: Default
+        decodingStrategy: None
+        key: stonesoup/production/pulp/pulp-access-controller
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: appsre-stonesoup-vault
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    name: pulp-secrets
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pulp-access-operator
+  namespace: pulp-access-controller
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: pulp-access-operator
+  template:
+    metadata:
+      labels:
+        app: pulp-access-operator
+    spec:
+      serviceAccountName: pulp-access-operator
+      securityContext:
+         runAsNonRoot: true
+      containers:
+        - name: operator
+          image: quay.io/redhat-user-workloads/pulp-access-controller-tenant/pulp-access-controller-ca9ff:v1.1.1
+          imagePullPolicy: Always
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          resources:
+            requests:
+              cpu: "100m"
+              memory: "128Mi"
+            limits:
+              cpu: "500m"
+              memory: "512Mi"
+          env: []
+          envFrom:
+            - secretRef:
+                name: pulp-secrets
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir: {}

--- a/components/pulp-access-controller/production/kustomization.yaml
+++ b/components/pulp-access-controller/production/kustomization.yaml
@@ -2,4 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../base
-  - https://github.com/pulp/pulp-access-controller/config/manifests/production?ref=a3228f9289e94fb8b1fc44337038cb547a45d04f
+  - combined.yaml


### PR DESCRIPTION

Follow-up to the staging vendoring change (#13347). Pulls the manifests from pulp/pulp-access-controller directly into
components/pulp-access-controller/production/combined.yaml, following the same approach used for knative-eventing (PR #9216). This ensures changes go through normal PR review, gives full auditability of what's applied to the cluster, and removes the dependency on the external source remaining available and unmodified.