### PR TITLE
feat(PVO11Y-5420): Emit richer kanary_error metric with caused_by label

### DIFF
--- a/components/monitoring/kanary/staging/base/pipelines/kanary-otel-pipeline.yaml
+++ b/components/monitoring/kanary/staging/base/pipelines/kanary-otel-pipeline.yaml
@@ -136,3 +136,5 @@ spec:
           value: $(tasks.run-kanary-tests.results.test-outcome)
         - name: failure-cause
           value: $(tasks.run-kanary-tests.results.failure-cause)
+        - name: failure-phase
+          value: $(tasks.run-kanary-tests.results.failure-phase)

--- a/components/monitoring/kanary/staging/base/pipelines/kanary-otel-pipeline.yaml
+++ b/components/monitoring/kanary/staging/base/pipelines/kanary-otel-pipeline.yaml
@@ -134,3 +134,5 @@ spec:
           value: $(params.test-type)
         - name: test-outcome
           value: $(tasks.run-kanary-tests.results.test-outcome)
+        - name: failure-cause
+          value: $(tasks.run-kanary-tests.results.failure-cause)

--- a/components/monitoring/kanary/staging/base/tasks/push-kanary-metrics.yaml
+++ b/components/monitoring/kanary/staging/base/tasks/push-kanary-metrics.yaml
@@ -102,9 +102,9 @@ spec:
             kanary_up.set(1, labels_up)
             # kanary_error is not emitted on success — kanary_up=1 is sufficient
         elif test_outcome == "failed":
-            print(f"Test outcome: failed, reason={reason or 'UNKNOWN'}, phase={failure_phase}")
+            print(f"Test outcome: failed, reason={reason}, phase={failure_phase}")
             kanary_up.set(0, labels_up)
-            kanary_error.set(1, {"tested_cluster": tested_cluster, "type": test_type, "reason": reason or "UNKNOWN", "phase": failure_phase})
+            kanary_error.set(1, {"tested_cluster": tested_cluster, "type": test_type, "reason": reason, "phase": failure_phase})
         else:
             print(f"Test outcome: {test_outcome}, reporting kanary-pipeline-error")
             kanary_up.set(1, labels_up)

--- a/components/monitoring/kanary/staging/base/tasks/push-kanary-metrics.yaml
+++ b/components/monitoring/kanary/staging/base/tasks/push-kanary-metrics.yaml
@@ -20,7 +20,7 @@ spec:
     - name: failure-cause
       type: string
       default: ""
-      description: "Raw error_caused_by_simple from loadtest (may be comma-separated). Empty when test passed or kanary mechanism failed."
+      description: "Raw error_reason_simple from loadtest (may be comma-separated). Empty when test passed or kanary mechanism failed."
     - name: failure-phase
       type: string
       default: ""
@@ -59,17 +59,17 @@ spec:
         failure_cause_raw = os.environ["FAILURE_CAUSE"].strip()
         failure_phase = os.environ["FAILURE_PHASE"].strip()
 
-        # Take the first value from comma-separated error_caused_by_simple.
+        # Take the first value from comma-separated error_reason_simple.
         # The full string is preserved in the TaskRun result for debugging.
         if failure_cause_raw:
-            caused_by = failure_cause_raw.split(",")[0].strip() or "UNKNOWN"
+            reason = failure_cause_raw.split(",")[0].strip() or "UNKNOWN"
         else:
-            caused_by = ""
+            reason = ""
 
         print(f"Pushing kanary metrics to: {endpoint}")
         print(f"  tested_cluster={tested_cluster}, type={test_type}, test_outcome={test_outcome}")
-        if caused_by:
-            print(f"  failure_cause={failure_cause_raw}, caused_by={caused_by}, phase={failure_phase}")
+        if reason:
+            print(f"  failure_cause={failure_cause_raw}, reason={reason}, phase={failure_phase}")
 
         resource = Resource.create({
             "service.name": "kanary",
@@ -102,13 +102,13 @@ spec:
             kanary_up.set(1, labels_up)
             # kanary_error is not emitted on success — kanary_up=1 is sufficient
         elif test_outcome == "failed":
-            print(f"Test outcome: failed, caused_by={caused_by or 'UNKNOWN'}, phase={failure_phase}")
+            print(f"Test outcome: failed, reason={reason or 'UNKNOWN'}, phase={failure_phase}")
             kanary_up.set(0, labels_up)
-            kanary_error.set(1, {"tested_cluster": tested_cluster, "type": test_type, "caused_by": caused_by or "UNKNOWN", "phase": failure_phase})
+            kanary_error.set(1, {"tested_cluster": tested_cluster, "type": test_type, "reason": reason or "UNKNOWN", "phase": failure_phase})
         else:
             print(f"Test outcome: {test_outcome}, reporting kanary-pipeline-error")
             kanary_up.set(1, labels_up)
-            kanary_error.set(1, {"tested_cluster": tested_cluster, "type": test_type, "caused_by": "kanary-pipeline-error", "phase": "kanary-pipeline"})
+            kanary_error.set(1, {"tested_cluster": tested_cluster, "type": test_type, "reason": "kanary-pipeline-error", "phase": "kanary-pipeline"})
 
         kanary_timestamp.set(time.time(), {"tested_cluster": tested_cluster, "type": test_type})
 

--- a/components/monitoring/kanary/staging/base/tasks/push-kanary-metrics.yaml
+++ b/components/monitoring/kanary/staging/base/tasks/push-kanary-metrics.yaml
@@ -21,6 +21,10 @@ spec:
       type: string
       default: ""
       description: "Raw error_caused_by_simple from loadtest (may be comma-separated). Empty when test passed or kanary mechanism failed."
+    - name: failure-phase
+      type: string
+      default: ""
+      description: "Loadtest phase where earliest failure occurred (e.g. waitForImageRepositoryReady). Empty when test passed or kanary mechanism failed."
   steps:
     - name: push-metrics
       image: quay.io/redhat-user-workloads/konflux-perfscale-tenant/loadtest
@@ -35,6 +39,8 @@ spec:
           value: $(params.test-outcome)
         - name: FAILURE_CAUSE
           value: $(params.failure-cause)
+        - name: FAILURE_PHASE
+          value: $(params.failure-phase)
       script: |
         #!/usr/bin/env python3
         import os
@@ -51,6 +57,7 @@ spec:
         test_type = os.environ["TEST_TYPE"]
         test_outcome = os.environ["TEST_OUTCOME"]
         failure_cause_raw = os.environ["FAILURE_CAUSE"].strip()
+        failure_phase = os.environ["FAILURE_PHASE"].strip()
 
         # Take the first value from comma-separated error_caused_by_simple.
         # The full string is preserved in the TaskRun result for debugging.
@@ -62,7 +69,7 @@ spec:
         print(f"Pushing kanary metrics to: {endpoint}")
         print(f"  tested_cluster={tested_cluster}, type={test_type}, test_outcome={test_outcome}")
         if caused_by:
-            print(f"  failure_cause={failure_cause_raw}, caused_by={caused_by}")
+            print(f"  failure_cause={failure_cause_raw}, caused_by={caused_by}, phase={failure_phase}")
 
         resource = Resource.create({
             "service.name": "kanary",
@@ -95,13 +102,13 @@ spec:
             kanary_up.set(1, labels_up)
             # kanary_error is not emitted on success — kanary_up=1 is sufficient
         elif test_outcome == "failed":
-            print(f"Test outcome: failed, caused_by={caused_by or 'UNKNOWN'}")
+            print(f"Test outcome: failed, caused_by={caused_by or 'UNKNOWN'}, phase={failure_phase}")
             kanary_up.set(0, labels_up)
-            kanary_error.set(1, {"tested_cluster": tested_cluster, "type": test_type, "caused_by": caused_by or "UNKNOWN"})
+            kanary_error.set(1, {"tested_cluster": tested_cluster, "type": test_type, "caused_by": caused_by or "UNKNOWN", "phase": failure_phase})
         else:
             print(f"Test outcome: {test_outcome}, reporting kanary-pipeline-error")
             kanary_up.set(1, labels_up)
-            kanary_error.set(1, {"tested_cluster": tested_cluster, "type": test_type, "caused_by": "kanary-pipeline-error"})
+            kanary_error.set(1, {"tested_cluster": tested_cluster, "type": test_type, "caused_by": "kanary-pipeline-error", "phase": ""})
 
         kanary_timestamp.set(time.time(), {"tested_cluster": tested_cluster, "type": test_type})
 

--- a/components/monitoring/kanary/staging/base/tasks/push-kanary-metrics.yaml
+++ b/components/monitoring/kanary/staging/base/tasks/push-kanary-metrics.yaml
@@ -17,6 +17,10 @@ spec:
       type: string
       default: unknown
       description: "Test outcome from collect-results: passed, failed, or unknown"
+    - name: failure-cause
+      type: string
+      default: ""
+      description: "Raw error_caused_by_simple from loadtest (may be comma-separated). Empty when test passed or kanary mechanism failed."
   steps:
     - name: push-metrics
       image: quay.io/redhat-user-workloads/konflux-perfscale-tenant/loadtest
@@ -29,6 +33,8 @@ spec:
           value: $(params.test-type)
         - name: TEST_OUTCOME
           value: $(params.test-outcome)
+        - name: FAILURE_CAUSE
+          value: $(params.failure-cause)
       script: |
         #!/usr/bin/env python3
         import os
@@ -44,9 +50,19 @@ spec:
         tested_cluster = os.environ["TESTED_CLUSTER"]
         test_type = os.environ["TEST_TYPE"]
         test_outcome = os.environ["TEST_OUTCOME"]
+        failure_cause_raw = os.environ["FAILURE_CAUSE"].strip()
+
+        # Take the first value from comma-separated error_caused_by_simple.
+        # The full string is preserved in the TaskRun result for debugging.
+        if failure_cause_raw:
+            caused_by = failure_cause_raw.split(",")[0].strip() or "UNKNOWN"
+        else:
+            caused_by = ""
 
         print(f"Pushing kanary metrics to: {endpoint}")
         print(f"  tested_cluster={tested_cluster}, type={test_type}, test_outcome={test_outcome}")
+        if caused_by:
+            print(f"  failure_cause={failure_cause_raw}, caused_by={caused_by}")
 
         resource = Resource.create({
             "service.name": "kanary",
@@ -60,7 +76,6 @@ spec:
         meter = metrics.get_meter("kanary")
 
         labels_up = {"tested_cluster": tested_cluster, "type": test_type}
-        labels_error = {"tested_cluster": tested_cluster, "type": test_type, "reason": "infrastructure"}
 
         kanary_up = meter.create_gauge(
             "kanary_up",
@@ -68,7 +83,7 @@ spec:
         )
         kanary_error = meter.create_gauge(
             "kanary_error",
-            description="Binary indicator of an infrastructure error preventing test execution",
+            description="Indicator of a failure preventing a successful kanary test run, labelled by root cause",
         )
         kanary_timestamp = meter.create_gauge(
             "kanary_last_push_timestamp",
@@ -78,15 +93,15 @@ spec:
         if test_outcome == "passed":
             print("Test outcome: passed")
             kanary_up.set(1, labels_up)
-            kanary_error.set(0, labels_error)
+            # kanary_error is not emitted on success — kanary_up=1 is sufficient
         elif test_outcome == "failed":
-            print("Test outcome: failed")
+            print(f"Test outcome: failed, caused_by={caused_by or 'UNKNOWN'}")
             kanary_up.set(0, labels_up)
-            kanary_error.set(0, labels_error)
+            kanary_error.set(1, {"tested_cluster": tested_cluster, "type": test_type, "caused_by": caused_by or "UNKNOWN"})
         else:
-            print(f"Test outcome: {test_outcome}, reporting infrastructure error")
+            print(f"Test outcome: {test_outcome}, reporting kanary-pipeline-error")
             kanary_up.set(1, labels_up)
-            kanary_error.set(1, labels_error)
+            kanary_error.set(1, {"tested_cluster": tested_cluster, "type": test_type, "caused_by": "kanary-pipeline-error"})
 
         kanary_timestamp.set(time.time(), {"tested_cluster": tested_cluster, "type": test_type})
 

--- a/components/monitoring/kanary/staging/base/tasks/push-kanary-metrics.yaml
+++ b/components/monitoring/kanary/staging/base/tasks/push-kanary-metrics.yaml
@@ -108,7 +108,7 @@ spec:
         else:
             print(f"Test outcome: {test_outcome}, reporting kanary-pipeline-error")
             kanary_up.set(1, labels_up)
-            kanary_error.set(1, {"tested_cluster": tested_cluster, "type": test_type, "caused_by": "kanary-pipeline-error", "phase": ""})
+            kanary_error.set(1, {"tested_cluster": tested_cluster, "type": test_type, "caused_by": "kanary-pipeline-error", "phase": "kanary-pipeline"})
 
         kanary_timestamp.set(time.time(), {"tested_cluster": tested_cluster, "type": test_type})
 

--- a/components/monitoring/kanary/staging/base/tasks/run-kanary-tests.yaml
+++ b/components/monitoring/kanary/staging/base/tasks/run-kanary-tests.yaml
@@ -70,6 +70,8 @@ spec:
   results:
     - name: test-outcome
       description: "Test outcome: passed, failed, or unknown"
+    - name: failure-cause
+      description: "Error cause from loadtest error_caused_by_simple (comma-separated if multiple). Empty on pass or when collect-results did not run."
   volumes:
     - name: artifacts
       emptyDir: {}
@@ -288,6 +290,7 @@ spec:
         #!/usr/bin/env bash
         set -euo pipefail
         echo -n "unknown" > $(results.test-outcome.path)
+        echo -n "" > $(results.failure-cause.path)
         if [[ ! -s /opt/users-secret/token ]]; then
           echo "ERROR: /opt/users-secret/token is missing or empty" >&2
           exit 1
@@ -329,3 +332,8 @@ spec:
         elif [[ "$exit_code" -eq "$KANARY_FAIL_CODE" ]]; then
           echo -n "failed" > $(results.test-outcome.path)
         fi
+        # Write the full error_caused_by_simple string as-is (may be comma-separated).
+        # push-kanary-metrics will split and take the first value for the metric label.
+        caused_by=$(jq -r '.results.errors.error_caused_by_simple // ""' \
+          /tmp/artifacts/results/load-test.json 2>/dev/null || true)
+        echo -n "${caused_by}" > $(results.failure-cause.path)

--- a/components/monitoring/kanary/staging/base/tasks/run-kanary-tests.yaml
+++ b/components/monitoring/kanary/staging/base/tasks/run-kanary-tests.yaml
@@ -337,10 +337,12 @@ spec:
         fi
         # Write the full error_caused_by_simple string as-is (may be comma-separated).
         # push-kanary-metrics will split and take the first value for the metric label.
-        caused_by=$(jq -r '.results.errors.error_caused_by_simple // ""' \
-          /tmp/artifacts/results/load-test.json 2>/dev/null || true)
-        echo -n "${caused_by}" > $(results.failure-cause.path)
         # Write the phase (loadtest function) where the earliest failure occurred.
-        failed_phase=$(jq -r '.results.measurements.KPI.failed_phase // ""' \
-          /tmp/artifacts/results/load-test.json 2>/dev/null || true)
-        echo -n "${failed_phase}" > $(results.failure-phase.path)
+        if [[ -s /tmp/artifacts/results/load-test.json ]]; then
+          jq -r '.results.errors.error_caused_by_simple // ""' \
+            /tmp/artifacts/results/load-test.json > $(results.failure-cause.path)
+          jq -r '.results.measurements.KPI.failed_phase // ""' \
+            /tmp/artifacts/results/load-test.json > $(results.failure-phase.path)
+        else
+          echo "WARN: load-test.json not found or empty, failure-cause and failure-phase will be empty" >&2
+        fi

--- a/components/monitoring/kanary/staging/base/tasks/run-kanary-tests.yaml
+++ b/components/monitoring/kanary/staging/base/tasks/run-kanary-tests.yaml
@@ -72,6 +72,8 @@ spec:
       description: "Test outcome: passed, failed, or unknown"
     - name: failure-cause
       description: "Error cause from loadtest error_caused_by_simple (comma-separated if multiple). Empty on pass or when collect-results did not run."
+    - name: failure-phase
+      description: "Loadtest phase where the earliest failure occurred (e.g. waitForImageRepositoryReady). Empty on pass or when collect-results did not run."
   volumes:
     - name: artifacts
       emptyDir: {}
@@ -291,6 +293,7 @@ spec:
         set -euo pipefail
         echo -n "unknown" > $(results.test-outcome.path)
         echo -n "" > $(results.failure-cause.path)
+        echo -n "" > $(results.failure-phase.path)
         if [[ ! -s /opt/users-secret/token ]]; then
           echo "ERROR: /opt/users-secret/token is missing or empty" >&2
           exit 1
@@ -337,3 +340,7 @@ spec:
         caused_by=$(jq -r '.results.errors.error_caused_by_simple // ""' \
           /tmp/artifacts/results/load-test.json 2>/dev/null || true)
         echo -n "${caused_by}" > $(results.failure-cause.path)
+        # Write the phase (loadtest function) where the earliest failure occurred.
+        failed_phase=$(jq -r '.results.measurements.KPI.failed_phase // ""' \
+          /tmp/artifacts/results/load-test.json 2>/dev/null || true)
+        echo -n "${failed_phase}" > $(results.failure-phase.path)


### PR DESCRIPTION
## What

Replaces `kanary_error{reason="infrastructure"}` with `kanary_error{reason, phase}` using the loadtest error taxonomy.

[PVO11Y-5420](https://redhat.atlassian.net/browse/PVO11Y-5420)

### Changes

**`run-kanary-tests` task:**
- Adds two Tekton results: `failure-cause` and `failure-phase`, both initialized to `""` in `run-test` so they always exist even if `collect-results` is skipped
- In `collect-results`: checks for `load-test.json` existence before extraction (warns to stderr if missing); writes `error_caused_by_simple` to `failure-cause` and `KPI.failed_phase` to `failure-phase`

**`kanary-otel-pipeline` pipeline:**
- Passes both new results to `push-kanary-metrics` in the `finally` block

**`push-kanary-metrics` task:**
- Adds `failure-cause` and `failure-phase` params
- Splits `failure-cause` on `,`, takes the first value as `reason` label (full string preserved in TaskRun result for debugging)
- Uses `failure-phase` directly as `phase` label
- `kanary_error` **only emitted on error**, not on success

### Label naming: `reason` not `caused_by`

The error cause label is named **`reason`** because it is already in the Prometheus remoteWrite `LabelKeep` allowlist and follows the established Prometheus convention for "why did this happen" (used by Kubernetes events, pod conditions, etc.). No `writeRelabelConfigs.yaml` changes needed.

### Metric behaviour

| Situation | `kanary_up` | `kanary_error` | `reason` | `phase` |
|---|---|---|---|---|
| Test passed | `1` | not emitted | — | — |
| Test failed, pattern matched | `0` | `1` | e.g. `quay.io`, `cluster` | e.g. `validatePipelineRunCondition` |
| Test failed, no pattern matched | `0` | `1` | `UNKNOWN` | e.g. `waitForImageRepositoryReady` |
| Kanary mechanism failed | `1` | `1` | `kanary-pipeline-error` | `kanary-pipeline` |

### Stale series handling

Since `reason` and `phase` change between runs, the OTel Collector may serve a stale failure series for up to 45 min. The existing `kanary_last_push_timestamp{tested_cluster, type}` metric is used as a freshness reference in PromQL:

```promql
kanary_error and on(tested_cluster, type) (
  (kanary_last_push_timestamp - timestamp(kanary_error)) < 120
)
```

Selects only series within 2 min of the most recent push — stale series (30+ min old) are excluded. All dashboards and alerts should apply this filter.

### Breaking change note

Existing queries filtering on `kanary_error{reason="infrastructure"}` will need updating. Dashboard/alert updates tracked in [PVO11Y-5471](https://redhat.atlassian.net/browse/PVO11Y-5471).

## Validation

- `kustomize build` passes for all staging overlays

[PVO11Y-5420]: https://redhat.atlassian.net/browse/PVO11Y-5420?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PVO11Y-5471]: https://redhat.atlassian.net/browse/PVO11Y-5471?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ