### PR TITLE
KFLUXINFRA-4364 Reduce PLR concurrency limit to 280 on stone-prd-rh01 and stone-prod-p02

### DIFF
--- a/components/kueue/production/stone-prd-rh01/queue-config/cluster-queue.yaml
+++ b/components/kueue/production/stone-prd-rh01/queue-config/cluster-queue.yaml
@@ -25,7 +25,7 @@ spec:
     - name: default-flavor
       resources:
       - name: tekton.dev/pipelineruns
-        nominalQuota: '300'
+        nominalQuota: '280'
       - name: konflux-ci-dev-token
         nominalQuota: '280'
       - name: cpu

--- a/components/kueue/production/stone-prd-rh01/queue-config/cluster-queue.yaml
+++ b/components/kueue/production/stone-prd-rh01/queue-config/cluster-queue.yaml
@@ -27,7 +27,7 @@ spec:
       - name: tekton.dev/pipelineruns
         nominalQuota: '300'
       - name: konflux-ci-dev-token
-        nominalQuota: '300'
+        nominalQuota: '280'
       - name: cpu
         nominalQuota: 1k
       - name: memory

--- a/components/kueue/production/stone-prod-p02/queue-config/cluster-queue.yaml
+++ b/components/kueue/production/stone-prod-p02/queue-config/cluster-queue.yaml
@@ -26,7 +26,7 @@ spec:
     - name: default-flavor
       resources:
       - name: tekton.dev/pipelineruns
-        nominalQuota: '400'
+        nominalQuota: '380'
       - name: konflux-ci-dev-token
         nominalQuota: '280'
       - name: cpu

--- a/components/kueue/production/stone-prod-p02/queue-config/cluster-queue.yaml
+++ b/components/kueue/production/stone-prod-p02/queue-config/cluster-queue.yaml
@@ -28,7 +28,7 @@ spec:
       - name: tekton.dev/pipelineruns
         nominalQuota: '400'
       - name: konflux-ci-dev-token
-        nominalQuota: '300'
+        nominalQuota: '280'
       - name: cpu
         nominalQuota: 1k
       - name: memory


### PR DESCRIPTION
## What

Reduce the `konflux-ci-dev-token` nominalQuota from `300` to `280` in the ClusterQueue for two production clusters, lowering the max number of concurrent PipelineRuns.

Clusters affected: stone-prd-rh01, stone-prod-p02

[KFLUXINFRA-4364](https://redhat.atlassian.net/browse/KFLUXINFRA-4364)

## Why

Both clusters frequently exceed 75% of their etcd quota, triggering `EtcdDatabaseQuotaLowSpaceWarning`; stone-prd-rh01 reached 100% quota on April 8 (ITN-2026-00103, ITN-2026-00109). Reducing PLR concurrency is the safest lever to relieve etcd pressure without increasing defrag frequency, which causes controller instability. This continues an earlier reduction (350 → 300).

## Validation

- `kustomize build --enable-helm` passes for both affected overlays:
  - `components/kueue/production/stone-prd-rh01/`
  - `components/kueue/production/stone-prod-p02/`

## Risk Assessment

**Risk Level:** Low
**What could go wrong:** A slightly lower concurrency cap could marginally increase PipelineRun queue times on these two clusters if throughput is already near the limit. No correctness impact — excess PLRs queue rather than fail.
**Rollback:** Revert PR (ArgoCD resyncs the previous quota of 300).
**Blast radius:** Two production clusters: stone-prd-rh01, stone-prod-p02. No other clusters or environments affected.


[KFLUXINFRA-4364]: https://redhat.atlassian.net/browse/KFLUXINFRA-4364?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ