### PR TITLE
KFLUXINFRA-4362: Add fine-grained bot-actions ClusterRoles to staging

### DIFF
--- a/components/konflux-rbac/staging/base/konflux-integrationtest-bot-actions.yaml
+++ b/components/konflux-rbac/staging/base/konflux-integrationtest-bot-actions.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: konflux-integrationtest-bot-actions
+rules:
+- apiGroups:
+  - appstudio.redhat.com
+  resources:
+  - integrationtestscenarios
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete

--- a/components/konflux-rbac/staging/base/konflux-model-bot-actions.yaml
+++ b/components/konflux-rbac/staging/base/konflux-model-bot-actions.yaml
@@ -1,0 +1,18 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: konflux-model-bot-actions
+rules:
+- apiGroups:
+  - appstudio.redhat.com
+  resources:
+  - applications
+  - components
+  - releaseplans
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch

--- a/components/konflux-rbac/staging/base/konflux-secrets-bot-actions.yaml
+++ b/components/konflux-rbac/staging/base/konflux-secrets-bot-actions.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: konflux-secrets-bot-actions
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - create
+  - update
+  - patch
+  - delete

--- a/components/konflux-rbac/staging/base/konflux-viewer-bot-actions.yaml
+++ b/components/konflux-rbac/staging/base/konflux-viewer-bot-actions.yaml
@@ -1,0 +1,46 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: konflux-viewer-bot-actions
+rules:
+- apiGroups:
+  - tekton.dev
+  resources:
+  - pipelineruns
+  - taskruns
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
+- apiGroups:
+  - appstudio.redhat.com
+  resources:
+  - snapshots
+  - releases
+  - components
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - pipelinesascode.tekton.dev
+  resources:
+  - repositories
+  verbs:
+  - get
+  - list
+  - watch

--- a/components/konflux-rbac/staging/base/kustomization.yaml
+++ b/components/konflux-rbac/staging/base/kustomization.yaml
@@ -10,6 +10,10 @@ resources:
   # and exposed outside the cluster
   - konflux-builder-bot-actions.yaml
   - konflux-externalpuller-bot-actions.yaml
+  - konflux-integrationtest-bot-actions.yaml
+  - konflux-model-bot-actions.yaml
   - konflux-releaser-bot-actions.yaml
+  - konflux-secrets-bot-actions.yaml
+  - konflux-viewer-bot-actions.yaml
   # can NOT be bound to konflux-bot-* ServiceAccounts
   - konflux-tester-internalbot-actions.yaml


### PR DESCRIPTION
Add four new composable ClusterRoles so teams can grant their konflux-bot-* ServiceAccounts only the permissions they need:

- konflux-viewer-bot-actions: read-only on pipelines, pods, logs, snapshots, releases, components, and PaC repositories
- konflux-secrets-bot-actions: secret CRUD for CI workflows that manage temporary credentials
- konflux-integrationtest-bot-actions: IntegrationTestScenario management for dynamic test configuration
- konflux-model-bot-actions: Applications, Components, and ReleasePlans management via external CI/CD

These complement the existing builder, releaser, and externalpuller roles. The ValidatingAdmissionPolicy already allows any ClusterRole matching konflux-*-bot-actions, so no policy changes are needed.

Contributes to: https://redhat.atlassian.net/browse/KFLUXINFRA-4362