### PR TITLE
smee: add kflux-lw-p01 config

### DIFF
--- a/argo-cd-apps/base/smee-client/smee-client.yaml
+++ b/argo-cd-apps/base/smee-client/smee-client.yaml
@@ -28,6 +28,8 @@ spec:
                   values.clusterDir: kflux-rhel-p01
                 - nameNormalized: kflux-osp-p01
                   values.clusterDir: kflux-osp-p01
+                - nameNormalized: kflux-lw-p01
+                  values.clusterDir: kflux-lw-p01
   template:
     metadata:
       name: smee-client-{{nameNormalized}}

--- a/components/smee-client/production/kflux-lw-p01/kustomization.yaml
+++ b/components/smee-client/production/kflux-lw-p01/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../base
+patches:
+  - path: server-url-patch.yaml
+    target:
+      name: gosmee-client
+      kind: Deployment

--- a/components/smee-client/production/kflux-lw-p01/server-url-patch.yaml
+++ b/components/smee-client/production/kflux-lw-p01/server-url-patch.yaml
@@ -1,0 +1,7 @@
+---
+- op: replace
+  path: /spec/template/spec/containers/0/args/3
+  value: https://smee-smee.apps.rosa.kflux-c-prd-e01.yo5u.p3.openshiftapps.com/redhathooklwp01
+- op: replace
+  path: /spec/template/spec/containers/1/env/1/value
+  value: https://smee-smee.apps.rosa.kflux-c-prd-e01.yo5u.p3.openshiftapps.com/redhathooklwp01


### PR DESCRIPTION
Configure the smee client on kflux-lw-p01 to talk to the external common cluster.

Fixes: [KFLUXINFRA-4418](https://redhat.atlassian.net/browse/KFLUXINFRA-4418)

[KFLUXINFRA-4418]: https://redhat.atlassian.net/browse/KFLUXINFRA-4418?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ