### PR TITLE
KFLUXINFRA-2236: Verify releases via Release CRs instead of PipelineRuns

### DIFF
--- a/tests/disaster-recovery/tenant_application_lifecycle.go
+++ b/tests/disaster-recovery/tenant_application_lifecycle.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/konflux-ci/e2e-tests/pkg/framework"
+	releaseapi "github.com/konflux-ci/release-service/api/v1alpha1"
 	. "github.com/onsi/ginkgo/v2" //nolint:staticcheck
 	. "github.com/onsi/gomega"    //nolint:staticcheck
 	pipeline "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
@@ -272,6 +273,64 @@ func buildListOpts(namespace, pipelineType, componentName string) []client.ListO
 }
 
 // ---------------------------------------------------------------------------
+// Release CR counting — release-service deletes completed PipelineRuns from
+// the managed namespace, so release success must be verified via Release CRs
+// (which persist in the tenant namespace) rather than PipelineRuns.
+// ---------------------------------------------------------------------------
+
+func countReleasedReleases(ctx context.Context, fw *framework.Framework, namespace string) int {
+	releases := &releaseapi.ReleaseList{}
+	if err := fw.AsKubeAdmin.CommonController.KubeRest().List(
+		ctx, releases, client.InNamespace(namespace)); err != nil {
+		GinkgoWriter.Printf("error listing Releases in %s: %v\n", namespace, err)
+		return 0
+	}
+	count := 0
+	for i := range releases.Items {
+		if releases.Items[i].IsReleased() {
+			count++
+		}
+	}
+	return count
+}
+
+func waitForReleasedCount(ctx context.Context, fw *framework.Framework, namespace string, expectedCount int, timeout, poll time.Duration) {
+	GinkgoHelper()
+
+	Eventually(func() int {
+		releases := &releaseapi.ReleaseList{}
+		if err := fw.AsKubeAdmin.CommonController.KubeRest().List(
+			ctx, releases, client.InNamespace(namespace)); err != nil {
+			GinkgoWriter.Printf("error listing Releases in %s: %v\n", namespace, err)
+			return 0
+		}
+
+		releasedCount := 0
+		for i := range releases.Items {
+			r := &releases.Items[i]
+			if r.IsReleased() {
+				releasedCount++
+			} else {
+				for _, c := range r.Status.Conditions {
+					if c.Type == "Released" {
+						GinkgoWriter.Printf("Release %s in %s: Released=%s Reason=%s\n",
+							r.Name, namespace, c.Status, c.Reason)
+						break
+					}
+				}
+			}
+		}
+
+		GinkgoWriter.Printf("namespace %s: %d/%d Releases released (total: %d)\n",
+			namespace, releasedCount, expectedCount, len(releases.Items))
+
+		return releasedCount
+	}, timeout, poll).Should(BeNumerically(">=", expectedCount),
+		"expected at least %d released Releases in namespace %s",
+		expectedCount, namespace)
+}
+
+// ---------------------------------------------------------------------------
 // High-level lifecycle helpers
 // ---------------------------------------------------------------------------
 
@@ -326,14 +385,14 @@ func waitForPipelineChains(ctx context.Context, fw *framework.Framework, tenants
 
 	logReleaseChainDiagnostics(tenants)
 
-	// Release PipelineRuns run in the managed namespace and may not map 1:1
-	// to components, so wait for them in aggregate after all builds/tests pass.
+	// Release CRs live in the tenant namespace and persist after release-service
+	// cleans up completed PipelineRuns from the managed namespace.
 	for _, t := range tenants {
-		releaseBase := baseRelease[t.ManagedNamespace] // zero if nil map or missing key
+		releaseBase := baseRelease[t.Namespace] // zero if nil map or missing key
 		expected := releaseBase + ComponentsPerTenant
-		By(fmt.Sprintf("Waiting for %d release PipelineRuns in %s (base: %d)",
-			expected, t.ManagedNamespace, releaseBase))
-		waitForSucceededPRCount(ctx, fw, t.ManagedNamespace, "", "", expected,
+		By(fmt.Sprintf("Waiting for %d released Releases in %s (base: %d)",
+			expected, t.Namespace, releaseBase))
+		waitForReleasedCount(ctx, fw, t.Namespace, expected,
 			ReleaseChainTimeout, ReleaseChainPoll)
 	}
 }
@@ -345,11 +404,11 @@ func waitForPipelineChains(ctx context.Context, fw *framework.Framework, tenants
 // only auto-releases Snapshots with push event type.
 //
 // The method:
-//  1. Snapshots current per-component PipelineRun counts.
+//  1. Snapshots current per-component PipelineRun counts and Release CR counts.
 //  2. For each tenant: pushes a Dockerfile change per component directly to
 //     the default branch (matching PaC .pathChanged() filters).
 //  3. Waits for new build and test PipelineRuns per component (parallel).
-//  4. Waits for new release PipelineRuns (aggregate).
+//  4. Waits for new released Release CRs (aggregate, in tenant namespace).
 func triggerBuildsAndVerify(ctx context.Context, fw *framework.Framework, tenants []Tenant) {
 	GinkgoHelper()
 
@@ -368,9 +427,9 @@ func triggerBuildsAndVerify(ctx context.Context, fw *framework.Framework, tenant
 			GinkgoWriter.Printf("initial counts for %s: build=%d, test=%d\n",
 				key, initialPerComp[key].build, initialPerComp[key].test)
 		}
-		initialRelease[t.ManagedNamespace] = countSucceededPRs(ctx, fw, t.ManagedNamespace, "", "")
-		GinkgoWriter.Printf("initial release count for %s: %d\n",
-			t.ManagedNamespace, initialRelease[t.ManagedNamespace])
+		initialRelease[t.Namespace] = countReleasedReleases(ctx, fw, t.Namespace)
+		GinkgoWriter.Printf("initial released count for %s: %d\n",
+			t.Namespace, initialRelease[t.Namespace])
 	}
 
 	initialTotalPRs := make(map[string]int)

--- a/tests/disaster-recovery/tenant_application_lifecycle.go
+++ b/tests/disaster-recovery/tenant_application_lifecycle.go
@@ -39,13 +39,13 @@ const PodLogTailLines int64 = 80
 //
 // Pass empty strings to skip either filter (e.g., empty pipelineType counts
 // all PRs, used for the managed namespace where every PR is a release pipeline).
-func countSucceededPRs(ctx context.Context, fw *framework.Framework, namespace, pipelineType, componentName string) int {
+func countSucceededPRs(ctx context.Context, fw *framework.Framework, namespace, pipelineType, componentName string) (int, error) {
 	listOpts := buildListOpts(namespace, pipelineType, componentName)
 
 	prList := &pipeline.PipelineRunList{}
 	if err := fw.AsKubeAdmin.CommonController.KubeRest().List(
 		ctx, prList, listOpts...); err != nil {
-		return 0
+		return 0, fmt.Errorf("listing PipelineRuns in %s: %w", namespace, err)
 	}
 
 	count := 0
@@ -57,7 +57,7 @@ func countSucceededPRs(ctx context.Context, fw *framework.Framework, namespace, 
 			}
 		}
 	}
-	return count
+	return count, nil
 }
 
 // logFailedTaskRuns lists TaskRuns belonging to a failed PipelineRun and logs
@@ -278,12 +278,11 @@ func buildListOpts(namespace, pipelineType, componentName string) []client.ListO
 // (which persist in the tenant namespace) rather than PipelineRuns.
 // ---------------------------------------------------------------------------
 
-func countReleasedReleases(ctx context.Context, fw *framework.Framework, namespace string) int {
+func countReleasedReleases(ctx context.Context, fw *framework.Framework, namespace string) (int, error) {
 	releases := &releaseapi.ReleaseList{}
 	if err := fw.AsKubeAdmin.CommonController.KubeRest().List(
 		ctx, releases, client.InNamespace(namespace)); err != nil {
-		GinkgoWriter.Printf("error listing Releases in %s: %v\n", namespace, err)
-		return 0
+		return 0, fmt.Errorf("listing Releases in %s: %w", namespace, err)
 	}
 	count := 0
 	for i := range releases.Items {
@@ -291,7 +290,7 @@ func countReleasedReleases(ctx context.Context, fw *framework.Framework, namespa
 			count++
 		}
 	}
-	return count
+	return count, nil
 }
 
 func waitForReleasedCount(ctx context.Context, fw *framework.Framework, namespace string, expectedCount int, timeout, poll time.Duration) {
@@ -324,10 +323,22 @@ func waitForReleasedCount(ctx context.Context, fw *framework.Framework, namespac
 		GinkgoWriter.Printf("namespace %s: %d/%d Releases released (total: %d)\n",
 			namespace, releasedCount, expectedCount, len(releases.Items))
 
+		if releasedCount > expectedCount {
+			GinkgoWriter.Printf("OVERSHOOT DETECTED: %d/%d released Releases in %s — dumping diagnostics:\n",
+				releasedCount, expectedCount, namespace)
+			for i := range releases.Items {
+				r := &releases.Items[i]
+				GinkgoWriter.Printf("  Release: %s | created: %s | released: %v\n",
+					r.Name, r.CreationTimestamp.Format("15:04:05"), r.IsReleased())
+			}
+		}
+
 		return releasedCount
-	}, timeout, poll).Should(BeNumerically(">=", expectedCount),
-		"expected at least %d released Releases in namespace %s",
-		expectedCount, namespace)
+	}, timeout, poll).Should(SatisfyAll(
+		BeNumerically(">=", expectedCount),
+		BeNumerically("<=", expectedCount*2),
+	), "expected %d–%d released Releases in namespace %s (got overshoot beyond 2x tolerance)",
+		expectedCount, expectedCount*2, namespace)
 }
 
 // ---------------------------------------------------------------------------
@@ -346,12 +357,12 @@ type pipelineRunBaseCounts struct {
 // release) to complete for every component across all tenants. Each
 // component's chain runs in its own goroutine so that a slow component
 // doesn't block faster ones from progressing through subsequent stages.
-// Release PipelineRuns are waited for after all build/test chains complete,
-// since release PRs may not be per-component.
+// Release CRs are waited for after all build/test chains complete,
+// since releases may not be per-component.
 //
 // baseBuildTest provides per-component starting counts keyed by
 // "namespace/componentName". baseRelease provides aggregate starting counts
-// keyed by managed namespace. Pass nil for both on the first run (base of 0).
+// keyed by tenant namespace. Pass nil for both on the first run (base of 0).
 func waitForPipelineChains(ctx context.Context, fw *framework.Framework, tenants []Tenant,
 	baseBuildTest map[string]pipelineRunBaseCounts, baseRelease map[string]int) {
 	GinkgoHelper()
@@ -420,14 +431,20 @@ func triggerBuildsAndVerify(ctx context.Context, fw *framework.Framework, tenant
 	for _, t := range tenants {
 		for _, comp := range Components {
 			key := t.Namespace + "/" + comp.Name
+			buildCount, err := countSucceededPRs(ctx, fw, t.Namespace, "build", comp.Name)
+			Expect(err).ShouldNot(HaveOccurred(), "baseline build count for %s", key)
+			testCount, err := countSucceededPRs(ctx, fw, t.Namespace, "test", comp.Name)
+			Expect(err).ShouldNot(HaveOccurred(), "baseline test count for %s", key)
 			initialPerComp[key] = pipelineRunBaseCounts{
-				build: countSucceededPRs(ctx, fw, t.Namespace, "build", comp.Name),
-				test:  countSucceededPRs(ctx, fw, t.Namespace, "test", comp.Name),
+				build: buildCount,
+				test:  testCount,
 			}
 			GinkgoWriter.Printf("initial counts for %s: build=%d, test=%d\n",
 				key, initialPerComp[key].build, initialPerComp[key].test)
 		}
-		initialRelease[t.Namespace] = countReleasedReleases(ctx, fw, t.Namespace)
+		releaseCount, err := countReleasedReleases(ctx, fw, t.Namespace)
+		Expect(err).ShouldNot(HaveOccurred(), "baseline release count for %s", t.Namespace)
+		initialRelease[t.Namespace] = releaseCount
 		GinkgoWriter.Printf("initial released count for %s: %d\n",
 			t.Namespace, initialRelease[t.Namespace])
 	}


### PR DESCRIPTION
## Summary

Replace release PipelineRun counting with Release CR counting in the DR test suite's release verification phase.

- Add `countReleasedReleases` and `waitForReleasedCount` functions that check `release.IsReleased()` on Release CRs in the tenant namespace
- Replace `waitForSucceededPRCount` for release verification in `waitForPipelineChains` with `waitForReleasedCount`
- Update base count snapshotting in `triggerBuildsAndVerify` to use Release CRs

## Problem

Release-service's `cleanupPipelineResources` (in `controllers/release/adapter.go`) deletes completed release PipelineRuns from the managed namespace after a Release CR finishes processing. This behavior has existed since at least Nov 2025 ([release-service PR #1042](https://github.com/konflux-ci/release-service/pull/1042)). The DR test verified releases by counting succeeded PipelineRuns in the managed namespace — a race against cleanup.

## How it was discovered

The DR rehearsal job on [openshift/release PR #83385](https://github.com/openshift/release/pull/83385) failed with:
```
expected 3–6 successful release PipelineRuns in namespace dr-test-kokohazamar-same-version-dr-managed
```

Build log showed the count going **backwards** during polling: `2/3 → 1/3 → 0/3 (total: 3 → 1 → 0)`. Release PipelineRuns were being deleted within ~100 seconds of completion.

## Why it didn't fail before

Analysis of 4 historical runs on [openshift/release PR #81360](https://github.com/openshift/release/pull/81360) (3 passing, 1 failing):

| Run | Pre-backup PLR survival | Base snapshot | Post-restore polling | Result |
|-----|------------------------|---------------|---------------------|--------|
| Aug 3 (pass) | 17+ min after completion | Captured 3 | 5/6 → 6/6 in 2 polls | Won the race |
| Aug 3 (pass) | Survived | Captured 3 | 5/6 → 6/6 in 2 polls | Won the race |
| Jul 29 (pass) | Survived | Captured 3 | 5/6 → 6/6 in 2 polls | Won the race |
| **Aug 18 (fail)** | **Deleted within 10 min** | **Captured 0** | **2/3 → 0/3** | **Lost the race** |

Cleanup timing is **non-deterministic** — same release-service code, same ~10-minute window, but PLRs survived 17+ minutes in passing runs and were deleted within 10 minutes in the failing run. The test was always fragile; passing runs won the race by catching PLRs before cleanup ran.

## Why Release CRs are the correct fix

- Release CRs persist in the **tenant namespace** with days-scale `ExpirationTime`
- `release.IsReleased()` is the canonical success check (`meta.IsStatusConditionTrue(conditions, "Released")`)
- Release CRs are not affected by `cleanupPipelineResources` — that only targets PipelineRuns in the managed namespace
- No timing dependency — Release CRs exist for the entire test duration

## Test plan

- [x] `go vet ./...` passes
- [x] `go build ./...` passes
- [ ] DR rehearsal job passes on openshift/release PR #83385 after this merges

Assisted-by: Claude Code (Opus)