### PR TITLE
fixup(PVO11Y-5384): Correct placement of managed PaC OTLP env vars

### DIFF
--- a/components/pipeline-service/staging/base/main-pipeline-service-configuration.yaml
+++ b/components/pipeline-service/staging/base/main-pipeline-service-configuration.yaml
@@ -1804,11 +1804,6 @@ spec:
               spec:
                 containers:
                   - name: pac-controller
-                    env:
-                      - name: OTEL_EXPORTER_OTLP_ENDPOINT
-                        value: "http://open-telemetry-opentelemetry-collector.konflux-otel.svc.cluster.local:4317"
-                      - name: OTEL_TRACES_SAMPLER
-                        value: "parentbased_always_on"
                     resources:
                       limits:
                         cpu: 500m
@@ -1822,11 +1817,6 @@ spec:
               spec:
                 containers:
                   - name: pac-watcher
-                    env:
-                      - name: OTEL_EXPORTER_OTLP_ENDPOINT
-                        value: "http://open-telemetry-opentelemetry-collector.konflux-otel.svc.cluster.local:4317"
-                      - name: OTEL_TRACES_SAMPLER
-                        value: "parentbased_always_on"
                     resources:
                       limits:
                         cpu: 250m
@@ -2015,9 +2005,29 @@ spec:
         enable: true
         options:
           deployments:
+            pipelines-as-code-controller:
+              spec:
+                template:
+                  spec:
+                    containers:
+                    - env:
+                      - name: OTEL_EXPORTER_OTLP_ENDPOINT
+                        value: "http://open-telemetry-opentelemetry-collector.konflux-otel.svc.cluster.local:4317"
+                      - name: OTEL_TRACES_SAMPLER
+                        value: "parentbased_always_on"
+                      name: pac-controller
             pipelines-as-code-watcher:
               spec:
                 replicas: 2
+                template:
+                  spec:
+                    containers:
+                    - env:
+                      - name: OTEL_EXPORTER_OTLP_ENDPOINT
+                        value: "http://open-telemetry-opentelemetry-collector.konflux-otel.svc.cluster.local:4317"
+                      - name: OTEL_TRACES_SAMPLER
+                        value: "parentbased_always_on"
+                      name: pac-watcher
             pipelines-as-code-webhook:
               spec:
                 replicas: 2

--- a/components/pipeline-service/staging/lightwell-dev/deploy.yaml
+++ b/components/pipeline-service/staging/lightwell-dev/deploy.yaml
@@ -725,12 +725,7 @@ spec:
             template:
               spec:
                 containers:
-                - env:
-                  - name: OTEL_EXPORTER_OTLP_ENDPOINT
-                    value: http://open-telemetry-opentelemetry-collector.konflux-otel.svc.cluster.local:4317
-                  - name: OTEL_TRACES_SAMPLER
-                    value: parentbased_always_on
-                  name: pac-controller
+                - name: pac-controller
                   resources:
                     limits:
                       cpu: 500m
@@ -743,12 +738,7 @@ spec:
             template:
               spec:
                 containers:
-                - env:
-                  - name: OTEL_EXPORTER_OTLP_ENDPOINT
-                    value: http://open-telemetry-opentelemetry-collector.konflux-otel.svc.cluster.local:4317
-                  - name: OTEL_TRACES_SAMPLER
-                    value: parentbased_always_on
-                  name: pac-watcher
+                - name: pac-watcher
                   resources:
                     limits:
                       cpu: 250m
@@ -964,9 +954,29 @@ spec:
         enable: true
         options:
           deployments:
+            pipelines-as-code-controller:
+              spec:
+                template:
+                  spec:
+                    containers:
+                    - env:
+                      - name: OTEL_EXPORTER_OTLP_ENDPOINT
+                        value: http://open-telemetry-opentelemetry-collector.konflux-otel.svc.cluster.local:4317
+                      - name: OTEL_TRACES_SAMPLER
+                        value: parentbased_always_on
+                      name: pac-controller
             pipelines-as-code-watcher:
               spec:
                 replicas: 2
+                template:
+                  spec:
+                    containers:
+                    - env:
+                      - name: OTEL_EXPORTER_OTLP_ENDPOINT
+                        value: http://open-telemetry-opentelemetry-collector.konflux-otel.svc.cluster.local:4317
+                      - name: OTEL_TRACES_SAMPLER
+                        value: parentbased_always_on
+                      name: pac-watcher
             pipelines-as-code-webhook:
               spec:
                 replicas: 2

--- a/components/pipeline-service/staging/stone-stage-p01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stage-p01/deploy.yaml
@@ -2363,12 +2363,7 @@ spec:
             template:
               spec:
                 containers:
-                - env:
-                  - name: OTEL_EXPORTER_OTLP_ENDPOINT
-                    value: http://open-telemetry-opentelemetry-collector.konflux-otel.svc.cluster.local:4317
-                  - name: OTEL_TRACES_SAMPLER
-                    value: parentbased_always_on
-                  name: pac-controller
+                - name: pac-controller
                   resources:
                     limits:
                       cpu: 500m
@@ -2381,12 +2376,7 @@ spec:
             template:
               spec:
                 containers:
-                - env:
-                  - name: OTEL_EXPORTER_OTLP_ENDPOINT
-                    value: http://open-telemetry-opentelemetry-collector.konflux-otel.svc.cluster.local:4317
-                  - name: OTEL_TRACES_SAMPLER
-                    value: parentbased_always_on
-                  name: pac-watcher
+                - name: pac-watcher
                   resources:
                     limits:
                       cpu: 250m
@@ -2602,9 +2592,29 @@ spec:
         enable: true
         options:
           deployments:
+            pipelines-as-code-controller:
+              spec:
+                template:
+                  spec:
+                    containers:
+                    - env:
+                      - name: OTEL_EXPORTER_OTLP_ENDPOINT
+                        value: http://open-telemetry-opentelemetry-collector.konflux-otel.svc.cluster.local:4317
+                      - name: OTEL_TRACES_SAMPLER
+                        value: parentbased_always_on
+                      name: pac-controller
             pipelines-as-code-watcher:
               spec:
                 replicas: 2
+                template:
+                  spec:
+                    containers:
+                    - env:
+                      - name: OTEL_EXPORTER_OTLP_ENDPOINT
+                        value: http://open-telemetry-opentelemetry-collector.konflux-otel.svc.cluster.local:4317
+                      - name: OTEL_TRACES_SAMPLER
+                        value: parentbased_always_on
+                      name: pac-watcher
             pipelines-as-code-webhook:
               spec:
                 replicas: 2

--- a/components/pipeline-service/staging/stone-stg-rh01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stg-rh01/deploy.yaml
@@ -2363,12 +2363,7 @@ spec:
             template:
               spec:
                 containers:
-                - env:
-                  - name: OTEL_EXPORTER_OTLP_ENDPOINT
-                    value: http://open-telemetry-opentelemetry-collector.konflux-otel.svc.cluster.local:4317
-                  - name: OTEL_TRACES_SAMPLER
-                    value: parentbased_always_on
-                  name: pac-controller
+                - name: pac-controller
                   resources:
                     limits:
                       cpu: 500m
@@ -2381,12 +2376,7 @@ spec:
             template:
               spec:
                 containers:
-                - env:
-                  - name: OTEL_EXPORTER_OTLP_ENDPOINT
-                    value: http://open-telemetry-opentelemetry-collector.konflux-otel.svc.cluster.local:4317
-                  - name: OTEL_TRACES_SAMPLER
-                    value: parentbased_always_on
-                  name: pac-watcher
+                - name: pac-watcher
                   resources:
                     limits:
                       cpu: 250m
@@ -2614,9 +2604,29 @@ spec:
         enable: true
         options:
           deployments:
+            pipelines-as-code-controller:
+              spec:
+                template:
+                  spec:
+                    containers:
+                    - env:
+                      - name: OTEL_EXPORTER_OTLP_ENDPOINT
+                        value: http://open-telemetry-opentelemetry-collector.konflux-otel.svc.cluster.local:4317
+                      - name: OTEL_TRACES_SAMPLER
+                        value: parentbased_always_on
+                      name: pac-controller
             pipelines-as-code-watcher:
               spec:
                 replicas: 2
+                template:
+                  spec:
+                    containers:
+                    - env:
+                      - name: OTEL_EXPORTER_OTLP_ENDPOINT
+                        value: http://open-telemetry-opentelemetry-collector.konflux-otel.svc.cluster.local:4317
+                      - name: OTEL_TRACES_SAMPLER
+                        value: parentbased_always_on
+                      name: pac-watcher
             pipelines-as-code-webhook:
               spec:
                 replicas: 2


### PR DESCRIPTION
Move OTEL_EXPORTER_OTLP_ENDPOINT and OTEL_TRACES_SAMPLER for
pac-controller and pac-watcher to
spec.platforms.openshift.pipelinesAsCode.options.deployments in
stone-stg-rh01, stone-stage-p01, and lightwell-dev.