### PR TITLE
KFLUXINFRA-4414: Deploy kube-shard to lightwell-dev

### DIFF
--- a/.github/workflows/kube-linter.yaml
+++ b/.github/workflows/kube-linter.yaml
@@ -40,6 +40,7 @@ jobs:
             ! -path 'components/etcd-shield/base/*' \
             ! -path 'components/kueue-rd/base/*' \
             ! -path 'components/kueue-rd/rings/*/base/external-repo/*' \
+            ! -path 'components/kube-shard/base/*' \
             ! -path 'components/*/rings/*/base/base-snapshot/*' \
             | \
             xargs -I {} -n1 -P8  bash -c 'dir=$(dirname "{}"); output_file=$(echo "$dir" | tr / -)-kustomization.yaml; ./hack/kustomize-build-with-retry.sh "$dir" -o "kustomizedfiles/$output_file"'

--- a/argo-cd-apps/overlays/rd-staging/kube-shard/include-lightwell-dev.yaml
+++ b/argo-cd-apps/overlays/rd-staging/kube-shard/include-lightwell-dev.yaml
@@ -1,0 +1,12 @@
+---
+# Restrict kube-shard ApplicationSet generation to lightwell-dev.
+# Uses ApplicationSet post-selector on generated params (nameNormalized)
+# so other tenant/internal clusters from the cluster generator are dropped.
+- op: add
+  path: /spec/generators/0/selector
+  value:
+    matchExpressions:
+      - key: nameNormalized
+        operator: In
+        values:
+          - lightwell-dev

--- a/argo-cd-apps/overlays/rd-staging/kube-shard/kube-shard-appset.yaml
+++ b/argo-cd-apps/overlays/rd-staging/kube-shard/kube-shard-appset.yaml
@@ -1,0 +1,47 @@
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: kube-shard
+spec:
+  generators:
+    - merge:
+        mergeKeys:
+          - nameNormalized
+        generators:
+          - clusters:
+              selector:
+                matchLabels:
+                  appstudio.redhat.com/cluster-type: "tenant"
+                  appstudio.redhat.com/internal-cluster: "true"
+              values:
+                sourceRoot: components/kube-shard
+                ring: "empty-base"
+                clusterDir: "empty-base"
+          - list:
+              elements:
+                - values.ring: ring-1
+                  nameNormalized: lightwell-dev
+                  values.clusterDir: lightwell-dev
+
+  template:
+    metadata:
+      name: kube-shard-{{nameNormalized}}
+    spec:
+      project: default
+      source:
+        path: '{{values.sourceRoot}}/rings/{{values.ring}}/{{values.clusterDir}}'
+        repoURL: https://github.com/redhat-appstudio/infra-deployments.git
+        targetRevision: main
+      destination:
+        namespace: kube-shard-operator
+        server: '{{server}}'
+      syncPolicy:
+        syncOptions:
+          - CreateNamespace=true
+          - SkipDryRunOnMissingResource=true
+        retry:
+          limit: -1
+          backoff:
+            duration: 10s
+            factor: 2
+            maxDuration: 3m

--- a/argo-cd-apps/overlays/rd-staging/kube-shard/kustomization.yaml
+++ b/argo-cd-apps/overlays/rd-staging/kube-shard/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - kube-shard-appset.yaml
+
+patches:
+  - path: include-lightwell-dev.yaml
+    target:
+      kind: ApplicationSet
+      version: v1alpha1
+      name: kube-shard

--- a/argo-cd-apps/overlays/rd-staging/kustomization.yaml
+++ b/argo-cd-apps/overlays/rd-staging/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
   - container-image-proxy
   - etcd-shield
   - konflux-operator
+  - kube-shard
   - kueue
 
 components:

--- a/components/kube-shard/OWNERS
+++ b/components/kube-shard/OWNERS
@@ -1,0 +1,7 @@
+# See the OWNERS docs: https://go.k8s.io/owners
+
+approvers:
+- konflux-infra-team
+
+reviewers:
+- konflux-infra-team

--- a/components/kube-shard/base/kustomization.yaml
+++ b/components/kube-shard/base/kustomization.yaml
@@ -1,0 +1,3 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources: []

--- a/components/kube-shard/rings/empty-base/empty-base/kustomization.yaml
+++ b/components/kube-shard/rings/empty-base/empty-base/kustomization.yaml
@@ -1,0 +1,3 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources: []

--- a/components/kube-shard/rings/ring-1/base/base-snapshot/kustomization.yaml
+++ b/components/kube-shard/rings/ring-1/base/base-snapshot/kustomization.yaml
@@ -1,0 +1,3 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources: []

--- a/components/kube-shard/rings/ring-1/base/konflux-tekton-shard-apishard.yaml
+++ b/components/kube-shard/rings/ring-1/base/konflux-tekton-shard-apishard.yaml
@@ -1,0 +1,77 @@
+apiVersion: kube-shard.konflux-ci.dev/v1alpha1
+kind: APIShard
+metadata:
+  name: konflux-tekton-shard
+  annotations:
+    argocd.argoproj.io/sync-wave: "10"
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  apiGroups:
+  - group: tekton.dev
+    versions:
+    - v1
+    - v1beta1
+    - v1alpha1
+  - group: resolution.tekton.dev
+    versions:
+    - v1beta1
+  - group: triggers.tekton.dev
+    versions:
+    - v1alpha1
+    - v1beta1
+  colocateComponents: true
+  kine:
+    compaction:
+      batchSize: 500
+      interval: 0s
+      minRetain: 1000
+      timeout: 30s
+    connectionPool:
+      maxIdleConnections: 10
+      maxLifetime: 30m
+      maxOpenConnections: 25
+    nodeSelector:
+      konflux-ci.dev/workload: tekton-api-shard
+    replicas: 3
+    resources:
+      limits:
+        cpu: "2"
+        memory: 16Gi
+      requests:
+        cpu: "2"
+        memory: 16Gi
+    tolerations:
+    - effect: NoSchedule
+      key: konflux-ci.dev/workload
+      value: tekton-api-shard
+  namespaceSync:
+    labelSelector:
+      matchLabels: {}
+  secondary:
+    nodeSelector:
+      konflux-ci.dev/workload: tekton-api-shard
+    replicas: 3
+    resources:
+      limits:
+        cpu: "4"
+        memory: 32Gi
+      requests:
+        cpu: "4"
+        memory: 32Gi
+    tolerations:
+    - effect: NoSchedule
+      key: konflux-ci.dev/workload
+      value: tekton-api-shard
+  storage:
+    inCluster:
+      persistence:
+        size: 100Gi
+      resources:
+        limits:
+          cpu: "2"
+          memory: 12Gi
+        requests:
+          cpu: "2"
+          memory: 12Gi
+    type: InClusterPostgreSQL
+  targetNamespace: kube-shard-operator-tekton

--- a/components/kube-shard/rings/ring-1/base/kustomization.yaml
+++ b/components/kube-shard/rings/ring-1/base/kustomization.yaml
@@ -9,3 +9,13 @@ images:
 - name: localhost/controller
   newName: quay.io/konflux-ci/kube-shard
   newTag: b22f23824e856985564663c1e1d037521addc9dd
+
+patches:
+- target:
+    kind: Deployment
+    name: operator-controller-manager
+    namespace: kube-shard-operator
+  patch: |
+    - op: add
+      path: /spec/template/spec/containers/0/securityContext/readOnlyRootFilesystem
+      value: true

--- a/components/kube-shard/rings/ring-1/base/kustomization.yaml
+++ b/components/kube-shard/rings/ring-1/base/kustomization.yaml
@@ -2,20 +2,10 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - base-snapshot
-- https://github.com/konflux-ci/kube-shard/operator/config/default?ref=b22f23824e856985564663c1e1d037521addc9dd
+- https://github.com/konflux-ci/kube-shard/operator/config/default?ref=d0b933b37a30555932fb1f2da737b6e3f5bf7364
 - konflux-tekton-shard-apishard.yaml
 
 images:
 - name: localhost/controller
   newName: quay.io/konflux-ci/kube-shard
-  newTag: b22f23824e856985564663c1e1d037521addc9dd
-
-patches:
-- target:
-    kind: Deployment
-    name: operator-controller-manager
-    namespace: kube-shard-operator
-  patch: |
-    - op: add
-      path: /spec/template/spec/containers/0/securityContext/readOnlyRootFilesystem
-      value: true
+  newTag: d0b933b37a30555932fb1f2da737b6e3f5bf7364

--- a/components/kube-shard/rings/ring-1/base/kustomization.yaml
+++ b/components/kube-shard/rings/ring-1/base/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- base-snapshot
+- https://github.com/konflux-ci/kube-shard/operator/config/default?ref=b22f23824e856985564663c1e1d037521addc9dd
+- konflux-tekton-shard-apishard.yaml
+
+images:
+- name: localhost/controller
+  newName: quay.io/konflux-ci/kube-shard
+  newTag: b22f23824e856985564663c1e1d037521addc9dd

--- a/components/kube-shard/rings/ring-1/lightwell-dev/kustomization.yaml
+++ b/components/kube-shard/rings/ring-1/lightwell-dev/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../base


### PR DESCRIPTION
## What

- Add `kube-shard` as a ring-1 GitOps component (operator from `konflux-ci/kube-shard` plus `konflux-tekton-shard` APIShard)
- Wire an ArgoCD ApplicationSet in `rd-staging` with a post-selector so only lightwell-dev is targeted

Clusters affected: lightwell-dev

[KFLUXINFRA-4414](https://redhat.atlassian.net/browse/KFLUXINFRA-4414)

## Why

Offload Tekton CRDs from etcd on lightwell-dev by deploying kube-shard through the ring layout, without rolling it to other staging tenant clusters.

## Validation

- `kustomize build --enable-helm components/kube-shard/rings/ring-1/lightwell-dev` succeeds (operator + APIShard, image `quay.io/konflux-ci/kube-shard:b22f23824e856985564663c1e1d037521addc9dd`)
- `kustomize build argo-cd-apps/overlays/rd-staging` succeeds; kube-shard ApplicationSet generator selector is `nameNormalized In [lightwell-dev]`

## Risk Assessment

**Risk Level:** High
**What could go wrong:** The operator image is not published yet, so the first sync will ImagePullBackOff until Konflux builds `quay.io/konflux-ci/kube-shard`. Once running, the APIShard redirects Tekton/resolution/triggers APIs to the secondary apiserver; misconfig or missing `tekton-api-shard` nodes would break PipelineRuns on lightwell-dev.
**Rollback:** Revert this PR (ApplicationSet prune will remove the operator; deleting the APIShard tears down the shard stack).
**Blast radius:** lightwell-dev only (staging).


Made with [Cursor](https://cursor.com)

[KFLUXINFRA-4414]: https://redhat.atlassian.net/browse/KFLUXINFRA-4414?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ