### PR TITLE
PVO11Y-5453 Deploy kubearchive exporter to lightwell-dev

### DIFF
--- a/argo-cd-apps/base/member/infra-deployments/monitoring-konflux-o11y-exporters/monitoring-workload-konflux-o11y-exporters.yaml
+++ b/argo-cd-apps/base/member/infra-deployments/monitoring-konflux-o11y-exporters/monitoring-workload-konflux-o11y-exporters.yaml
@@ -19,6 +19,8 @@ spec:
                   values.clusterDir: stone-stage-p01
                 - nameNormalized: stone-stg-rh01
                   values.clusterDir: stone-stg-rh01
+                - nameNormalized: lightwell-dev
+                  values.clusterDir: lightwell-dev
                 - nameNormalized: stone-prd-rh01
                   values.clusterDir: stone-prd-rh01
                 - nameNormalized: stone-prod-p01

--- a/components/monitoring/exporters/kaexporter/staging/lightwell-dev/kustomization.yaml
+++ b/components/monitoring/exporters/kaexporter/staging/lightwell-dev/kustomization.yaml
@@ -1,0 +1,11 @@
+resources:
+  - ../base
+
+patches:
+  - target:
+      kind: ExternalSecret
+      name: ka-kubearchive-credentials
+    patch: |
+      - op: replace
+        path: /spec/dataFrom/0/extract/key
+        value: stonesoup/staging/monitoring/exporters/kaexporter/lightwell-dev


### PR DESCRIPTION
## What

- Add kaexporter staging overlay for `lightwell-dev`
- Register `lightwell-dev` in the `konflux-o11y-kaexporter` ApplicationSet

Clusters affected: lightwell-dev (staging)

[PVO11Y-5453](https://redhat.atlassian.net/browse/PVO11Y-5453)

## Why

lightwell-dev was the staging member cluster missing the kubearchive exporter, so its pipeline and release SLO metrics were not being collected. This enables the exporter there, matching the other staging clusters.

## Validation

- `kustomize build components/monitoring/exporters/kaexporter/staging/lightwell-dev/` passes; ExternalSecret renders with vault key `stonesoup/staging/monitoring/exporters/kaexporter/lightwell-dev`
- `kustomize build` of the ApplicationSet renders the `lightwell-dev` element
- Vault entry for lightwell-dev created (`ka-host` set; `ka-token` intentionally empty — in-cluster the exporter authenticates via its ServiceAccount token)
- Exporter verified running locally against lightwell-dev's KubeArchive API (successful collection, `/metrics` served)


[PVO11Y-5453]: https://redhat.atlassian.net/browse/PVO11Y-5453?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ