### PR TITLE
PVO11Y-5439 deploy tekton-ms Grafana datasource to lightwell-dev

### DIFF
--- a/argo-cd-apps/base/all-clusters/infra-deployments/monitoring-workload-grafana/monitoring-workload-grafana.yaml
+++ b/argo-cd-apps/base/all-clusters/infra-deployments/monitoring-workload-grafana/monitoring-workload-grafana.yaml
@@ -19,6 +19,8 @@ spec:
                   values.clusterDir: stone-stage-p01
                 - nameNormalized: stone-stg-rh01
                   values.clusterDir: stone-stg-rh01
+                - nameNormalized: lightwell-dev
+                  values.clusterDir: lightwell-dev
                 - nameNormalized: stone-prod-p01
                   values.clusterDir: stone-prod-p01
                 - nameNormalized: kflux-prd-rh02

--- a/components/monitoring/grafana/staging/lightwell-dev/kustomization.yaml
+++ b/components/monitoring/grafana/staging/lightwell-dev/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../base
+  - ../tekton-ms-datasource


### PR DESCRIPTION
## What

- Add a `lightwell-dev` Grafana overlay that pulls in the `tekton-ms-datasource`
- Enroll `lightwell-dev` in the `monitoring-workload-grafana` ApplicationSet

Clusters affected: lightwell-dev (staging)

[PVO11Y-5439](https://redhat.atlassian.net/browse/PVO11Y-5439)

## Why

The Tekton MS Prometheus (`appstudio-tekton-ms`) already runs on lightwell-dev with its kube-rbac-proxy, but the in-cluster Grafana had no `prometheus-tekton-ms-ds` datasource pointing at it. The datasource lives only in per-cluster overlays, not the Grafana base, and lightwell-dev had neither an overlay nor an ApplicationSet entry — so it fell through to `base` and the datasource was never deployed. As a result the pipeline-service dashboard panels backed by that datasource showed "No data".

## Validation

- `kustomize build components/monitoring/grafana/staging/lightwell-dev/` renders the `prometheus-tekton-ms-ds` GrafanaDatasource
- `kustomize build` of the `monitoring-workload-grafana` ApplicationSet renders the `lightwell-dev` element
- Datasource dependency confirmed: the `metrics-reader` ServiceAccount/token secret + `cluster-monitoring-view` binding are provided by the Grafana base (`grafana-app.yaml`), inherited via `../base`


[PVO11Y-5439]: https://redhat.atlassian.net/browse/PVO11Y-5439?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ