### PR TITLE
PVO11Y-5449 Add explicit openshift-logging namespace for lightwell-dev

### DIFF
--- a/components/monitoring/logging/staging/lightwell-dev/kustomization.yaml
+++ b/components/monitoring/logging/staging/lightwell-dev/kustomization.yaml
@@ -1,5 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+- openshift-logging-ns.yaml
 - ../base
 - ../../base/logging-operator-prerequisite

--- a/components/monitoring/logging/staging/lightwell-dev/openshift-logging-ns.yaml
+++ b/components/monitoring/logging/staging/lightwell-dev/openshift-logging-ns.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-logging
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1" # Explicitly forces namespace creation first
+    openshift.io/node-selector: ""
+  labels:
+    openshift.io/cluster-monitoring: "true"


### PR DESCRIPTION
  ## What

  Add explicit `openshift-logging` namespace resource for lightwell-dev staging cluster with ArgoCD sync-wave ordering.

  Clusters affected: lightwell-dev (staging)

  [PVO11Y-5449](https://redhat.atlassian.net/browse/PVO11Y-5449)

  ## Why

  Ensures the `openshift-logging` namespace is created before other logging resources are deployed. The `sync-wave: "-1"` annotation guarantees
  ArgoCD creates the namespace first, preventing resource creation failures due to missing namespace.

  ## Validation

  - `kustomize build --enable-helm components/monitoring/logging/staging/lightwell-dev/` passes
  - Namespace appears first in rendered output with correct annotations and labels
  - yamllint passes with no errors

  

[PVO11Y-5449]: https://redhat.atlassian.net/browse/PVO11Y-5449?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ