### PR TITLE
fix(PVO11Y-5298): Add annotation to disable autogen production

### DIFF
--- a/components/policies/production/base/cost-management/OWNERS
+++ b/components/policies/production/base/cost-management/OWNERS
@@ -1,0 +1,12 @@
+# See the OWNERS docs: https://go.k8s.io/owners
+
+approvers:
+- mftb
+- raks-tt
+- pacho-rh
+- martysp21
+- TominoFTW
+- FaisalAl-Rayes
+- kubasikus
+- pumahaka
+- ci-operator

--- a/components/policies/production/base/cost-management/propagate-cost-management-labels/propagate-cost-management-labels.yaml
+++ b/components/policies/production/base/cost-management/propagate-cost-management-labels/propagate-cost-management-labels.yaml
@@ -4,6 +4,7 @@ kind: ClusterPolicy
 metadata:
   name: propagate-cost-management-labels
   annotations:
+    pod-policies.kyverno.io/autogen-controllers: none
     policies.kyverno.io/title: Propagate Cost-Center from Namespace
     policies.kyverno.io/category: Cost Management
     policies.kyverno.io/severity: low


### PR DESCRIPTION
## What

Add `pod-policies.kyverno.io/autogen-controllers: none` annotation to the `propagate-cost-management-labels` ClusterPolicy to disable Kyverno autogen for controller resources.

Add OWNERS file for cost-management policy directory.

Clusters affected: kflux-ocp-p01, kflux-osp-p01, kflux-prd-rh02, kflux-prd-rh03,
kflux-rhel-p01, stone-prd-rh01, stone-prod-p01, stone-prod-p02

[PVO11Y-5298](https://redhat.atlassian.net/browse/PVO11Y-5298)

## Why

Kyverno autogen generates rules for Jobs, StatefulSets, Deployments, etc. that rewrite `request.object.metadata.namespace` to `request.object.spec.template.metadata.namespace` — but pod templates don't carry a `namespace` field. This produces ~2K+ `JMESPath query failed: Unknown key "namespace"` error log entries per day per cluster, triggered on every Job and StatefulSet CREATE. The errors are harmless (failurePolicy: Ignore) but generate significant log noise and have triggered false OOM alerts.

## Validation

- `kustomize build` passes for production base overlay
- Validated in staging via PR #12856 — confirmed on stone-stg-rh01 that `status.autogen` is empty and no JMESPath errors after sync

## Risk Assessment

**Risk Level:** Low
**What could go wrong:** The annotation is purely declarative metadata — it only
controls whether Kyverno generates additional admission rules for controller types.
The base Pod mutation rule is unchanged.
**Rollback:** Revert PR
**Blast radius:** All 8 production clusters

[PVO11Y-5298]: https://redhat.atlassian.net/browse/PVO11Y-5298?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ