### PR TITLE
feat(PVO11Y-5479): Use loadtest-pre-measurement as phase fallback

### DIFF
--- a/components/monitoring/kanary/staging/base/tasks/push-kanary-metrics.yaml
+++ b/components/monitoring/kanary/staging/base/tasks/push-kanary-metrics.yaml
@@ -102,9 +102,10 @@ spec:
             kanary_up.set(1, labels_up)
             # kanary_error is not emitted on success — kanary_up=1 is sufficient
         elif test_outcome == "failed":
-            print(f"Test outcome: failed, reason={reason}, phase={failure_phase}")
+            phase = failure_phase or "loadtest-pre-measurement"
+            print(f"Test outcome: failed, reason={reason}, phase={phase}")
             kanary_up.set(0, labels_up)
-            kanary_error.set(1, {"tested_cluster": tested_cluster, "type": test_type, "reason": reason, "phase": failure_phase})
+            kanary_error.set(1, {"tested_cluster": tested_cluster, "type": test_type, "reason": reason, "phase": phase})
         else:
             print(f"Test outcome: {test_outcome}, reporting kanary-pipeline-error")
             kanary_up.set(1, labels_up)


### PR DESCRIPTION
## What

When `test_outcome=failed` but `KPI.failed_phase` is empty, use `"loadtest-pre-measurement"` as the `phase` label value instead of `""`.

[PVO11Y-5479](https://redhat.atlassian.net/browse/PVO11Y-5479)

## Why

`KPI.failed_phase` is empty when the failure occurred before any named loadtest measurement was recorded — most commonly when the build PipelineRun fails to start (e.g. Kueue PipelineRunPending timeout, ImageRepository timeout). Emitting an empty `phase` label violates Prometheus best practice of avoiding empty label values.

The `loadtest-pre-measurement` value creates a clear three-level phase namespace:

| `phase` | Meaning |
|---|---|
| `kanary-pipeline` | The kanary probe mechanism itself failed |
| `loadtest-pre-measurement` | Loadtest ran but failure was before any named phase |
| e.g. `validatePipelineRunCondition` | Specific loadtest function that failed |

## Validation

- `kustomize build` passes for all staging overlays

[PVO11Y-5479]: https://redhat.atlassian.net/browse/PVO11Y-5479?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ