### PR TITLE
Enable Sentry monitoring on all production clusters

### DIFF
--- a/components/konflux-ui/production/kflux-ocp-p01/kustomization.yaml
+++ b/components/konflux-ui/production/kflux-ocp-p01/kustomization.yaml
@@ -9,6 +9,14 @@ configMapGenerator:
   - name: dex
     files:
       - dex-config.yaml
+  - name: ui-runtime-env-variables
+    literals:
+      - MONITORING_ENABLED=true
+      - MONITORING_DSN=https://2d1bbbd05a2ff473d916df439cfc363e@o490301.ingest.us.sentry.io/4510260965408768
+      - MONITORING_ENVIRONMENT=production
+      - MONITORING_CLUSTER=kflux-ocp-p01
+      - MONITORING_SAMPLE_RATE_ERRORS=0.2
+      - MONITORING_SAMPLE_RATE_TRACES=0.2
 
 patches:
   - path: add-service-certs-patch.yaml

--- a/components/konflux-ui/production/kflux-ocp-p01/kustomization.yaml
+++ b/components/konflux-ui/production/kflux-ocp-p01/kustomization.yaml
@@ -15,7 +15,7 @@ configMapGenerator:
       - MONITORING_DSN=https://2d1bbbd05a2ff473d916df439cfc363e@o490301.ingest.us.sentry.io/4510260965408768
       - MONITORING_ENVIRONMENT=production
       - MONITORING_CLUSTER=kflux-ocp-p01
-      - MONITORING_SAMPLE_RATE_ERRORS=0.2
+      - MONITORING_SAMPLE_RATE_ERRORS=1
       - MONITORING_SAMPLE_RATE_TRACES=0.2
 
 patches:

--- a/components/konflux-ui/production/kflux-osp-p01/kustomization.yaml
+++ b/components/konflux-ui/production/kflux-osp-p01/kustomization.yaml
@@ -8,6 +8,14 @@ configMapGenerator:
   - name: dex
     files:
       - dex-config.yaml
+  - name: ui-runtime-env-variables
+    literals:
+      - MONITORING_ENABLED=true
+      - MONITORING_DSN=https://2d1bbbd05a2ff473d916df439cfc363e@o490301.ingest.us.sentry.io/4510260965408768
+      - MONITORING_ENVIRONMENT=production
+      - MONITORING_CLUSTER=kflux-osp-p01
+      - MONITORING_SAMPLE_RATE_ERRORS=0.2
+      - MONITORING_SAMPLE_RATE_TRACES=0.2
 
 patches:
   - path: add-service-certs-patch.yaml

--- a/components/konflux-ui/production/kflux-osp-p01/kustomization.yaml
+++ b/components/konflux-ui/production/kflux-osp-p01/kustomization.yaml
@@ -14,7 +14,7 @@ configMapGenerator:
       - MONITORING_DSN=https://2d1bbbd05a2ff473d916df439cfc363e@o490301.ingest.us.sentry.io/4510260965408768
       - MONITORING_ENVIRONMENT=production
       - MONITORING_CLUSTER=kflux-osp-p01
-      - MONITORING_SAMPLE_RATE_ERRORS=0.2
+      - MONITORING_SAMPLE_RATE_ERRORS=1
       - MONITORING_SAMPLE_RATE_TRACES=0.2
 
 patches:

--- a/components/konflux-ui/production/kflux-prd-rh02/kustomization.yaml
+++ b/components/konflux-ui/production/kflux-prd-rh02/kustomization.yaml
@@ -9,6 +9,14 @@ configMapGenerator:
   - name: dex
     files:
       - dex-config.yaml
+  - name: ui-runtime-env-variables
+    literals:
+      - MONITORING_ENABLED=true
+      - MONITORING_DSN=https://2d1bbbd05a2ff473d916df439cfc363e@o490301.ingest.us.sentry.io/4510260965408768
+      - MONITORING_ENVIRONMENT=production
+      - MONITORING_CLUSTER=kflux-prd-rh02
+      - MONITORING_SAMPLE_RATE_ERRORS=0.2
+      - MONITORING_SAMPLE_RATE_TRACES=0.2
 
 patches:
   - path: add-service-certs-patch.yaml

--- a/components/konflux-ui/production/kflux-prd-rh02/kustomization.yaml
+++ b/components/konflux-ui/production/kflux-prd-rh02/kustomization.yaml
@@ -15,7 +15,7 @@ configMapGenerator:
       - MONITORING_DSN=https://2d1bbbd05a2ff473d916df439cfc363e@o490301.ingest.us.sentry.io/4510260965408768
       - MONITORING_ENVIRONMENT=production
       - MONITORING_CLUSTER=kflux-prd-rh02
-      - MONITORING_SAMPLE_RATE_ERRORS=0.2
+      - MONITORING_SAMPLE_RATE_ERRORS=1
       - MONITORING_SAMPLE_RATE_TRACES=0.2
 
 patches:

--- a/components/konflux-ui/production/kflux-prd-rh03/kustomization.yaml
+++ b/components/konflux-ui/production/kflux-prd-rh03/kustomization.yaml
@@ -8,6 +8,14 @@ configMapGenerator:
   - name: dex
     files:
       - dex-config.yaml
+  - name: ui-runtime-env-variables
+    literals:
+      - MONITORING_ENABLED=true
+      - MONITORING_DSN=https://2d1bbbd05a2ff473d916df439cfc363e@o490301.ingest.us.sentry.io/4510260965408768
+      - MONITORING_ENVIRONMENT=production
+      - MONITORING_CLUSTER=kflux-prd-rh03
+      - MONITORING_SAMPLE_RATE_ERRORS=0.2
+      - MONITORING_SAMPLE_RATE_TRACES=0.2
 
 patches:
   - path: add-service-certs-patch.yaml

--- a/components/konflux-ui/production/kflux-prd-rh03/kustomization.yaml
+++ b/components/konflux-ui/production/kflux-prd-rh03/kustomization.yaml
@@ -14,7 +14,7 @@ configMapGenerator:
       - MONITORING_DSN=https://2d1bbbd05a2ff473d916df439cfc363e@o490301.ingest.us.sentry.io/4510260965408768
       - MONITORING_ENVIRONMENT=production
       - MONITORING_CLUSTER=kflux-prd-rh03
-      - MONITORING_SAMPLE_RATE_ERRORS=0.2
+      - MONITORING_SAMPLE_RATE_ERRORS=1
       - MONITORING_SAMPLE_RATE_TRACES=0.2
 
 patches:

--- a/components/konflux-ui/production/kflux-rhel-p01/kustomization.yaml
+++ b/components/konflux-ui/production/kflux-rhel-p01/kustomization.yaml
@@ -8,6 +8,14 @@ configMapGenerator:
   - name: dex
     files:
       - dex-config.yaml
+  - name: ui-runtime-env-variables
+    literals:
+      - MONITORING_ENABLED=true
+      - MONITORING_DSN=https://2d1bbbd05a2ff473d916df439cfc363e@o490301.ingest.us.sentry.io/4510260965408768
+      - MONITORING_ENVIRONMENT=production
+      - MONITORING_CLUSTER=kflux-rhel-p01
+      - MONITORING_SAMPLE_RATE_ERRORS=0.2
+      - MONITORING_SAMPLE_RATE_TRACES=0.2
 
 patches:
   - path: add-service-certs-patch.yaml

--- a/components/konflux-ui/production/kflux-rhel-p01/kustomization.yaml
+++ b/components/konflux-ui/production/kflux-rhel-p01/kustomization.yaml
@@ -14,7 +14,7 @@ configMapGenerator:
       - MONITORING_DSN=https://2d1bbbd05a2ff473d916df439cfc363e@o490301.ingest.us.sentry.io/4510260965408768
       - MONITORING_ENVIRONMENT=production
       - MONITORING_CLUSTER=kflux-rhel-p01
-      - MONITORING_SAMPLE_RATE_ERRORS=0.2
+      - MONITORING_SAMPLE_RATE_ERRORS=1
       - MONITORING_SAMPLE_RATE_TRACES=0.2
 
 patches:

--- a/components/konflux-ui/production/stone-prd-rh01/kustomization.yaml
+++ b/components/konflux-ui/production/stone-prd-rh01/kustomization.yaml
@@ -15,7 +15,7 @@ configMapGenerator:
       - MONITORING_DSN=https://2d1bbbd05a2ff473d916df439cfc363e@o490301.ingest.us.sentry.io/4510260965408768
       - MONITORING_ENVIRONMENT=production
       - MONITORING_CLUSTER=stone-prd-rh01
-      - MONITORING_SAMPLE_RATE_ERRORS=0.2
+      - MONITORING_SAMPLE_RATE_ERRORS=1
       - MONITORING_SAMPLE_RATE_TRACES=0.2
 
 patches:

--- a/components/konflux-ui/production/stone-prd-rh01/kustomization.yaml
+++ b/components/konflux-ui/production/stone-prd-rh01/kustomization.yaml
@@ -16,6 +16,7 @@ configMapGenerator:
       - MONITORING_ENVIRONMENT=production
       - MONITORING_CLUSTER=stone-prd-rh01
       - MONITORING_SAMPLE_RATE_ERRORS=0.2
+      - MONITORING_SAMPLE_RATE_TRACES=0.2
 
 patches:
   - path: add-service-certs-patch.yaml

--- a/components/konflux-ui/production/stone-prod-p01/kustomization.yaml
+++ b/components/konflux-ui/production/stone-prod-p01/kustomization.yaml
@@ -15,7 +15,7 @@ configMapGenerator:
       - MONITORING_DSN=https://2d1bbbd05a2ff473d916df439cfc363e@o490301.ingest.us.sentry.io/4510260965408768
       - MONITORING_ENVIRONMENT=production
       - MONITORING_CLUSTER=stone-prod-p01
-      - MONITORING_SAMPLE_RATE_ERRORS=0.2
+      - MONITORING_SAMPLE_RATE_ERRORS=1
       - MONITORING_SAMPLE_RATE_TRACES=0.2
 
 patches:

--- a/components/konflux-ui/production/stone-prod-p01/kustomization.yaml
+++ b/components/konflux-ui/production/stone-prod-p01/kustomization.yaml
@@ -9,6 +9,14 @@ configMapGenerator:
   - name: dex
     files:
       - dex-config.yaml
+  - name: ui-runtime-env-variables
+    literals:
+      - MONITORING_ENABLED=true
+      - MONITORING_DSN=https://2d1bbbd05a2ff473d916df439cfc363e@o490301.ingest.us.sentry.io/4510260965408768
+      - MONITORING_ENVIRONMENT=production
+      - MONITORING_CLUSTER=stone-prod-p01
+      - MONITORING_SAMPLE_RATE_ERRORS=0.2
+      - MONITORING_SAMPLE_RATE_TRACES=0.2
 
 patches:
   - path: add-service-certs-patch.yaml

--- a/components/konflux-ui/production/stone-prod-p02/kustomization.yaml
+++ b/components/konflux-ui/production/stone-prod-p02/kustomization.yaml
@@ -15,7 +15,7 @@ configMapGenerator:
       - MONITORING_DSN=https://2d1bbbd05a2ff473d916df439cfc363e@o490301.ingest.us.sentry.io/4510260965408768
       - MONITORING_ENVIRONMENT=production
       - MONITORING_CLUSTER=stone-prod-p02
-      - MONITORING_SAMPLE_RATE_ERRORS=0.2
+      - MONITORING_SAMPLE_RATE_ERRORS=1
       - MONITORING_SAMPLE_RATE_TRACES=0.2
 
 patches:

--- a/components/konflux-ui/production/stone-prod-p02/kustomization.yaml
+++ b/components/konflux-ui/production/stone-prod-p02/kustomization.yaml
@@ -9,6 +9,14 @@ configMapGenerator:
   - name: dex
     files:
       - dex-config.yaml
+  - name: ui-runtime-env-variables
+    literals:
+      - MONITORING_ENABLED=true
+      - MONITORING_DSN=https://2d1bbbd05a2ff473d916df439cfc363e@o490301.ingest.us.sentry.io/4510260965408768
+      - MONITORING_ENVIRONMENT=production
+      - MONITORING_CLUSTER=stone-prod-p02
+      - MONITORING_SAMPLE_RATE_ERRORS=0.2
+      - MONITORING_SAMPLE_RATE_TRACES=0.2
 
 patches:
   - path: add-service-certs-patch.yaml

--- a/components/konflux-ui/staging/stone-stage-p01/kustomization.yaml
+++ b/components/konflux-ui/staging/stone-stage-p01/kustomization.yaml
@@ -17,6 +17,7 @@ configMapGenerator:
       - MONITORING_ENVIRONMENT=staging
       - MONITORING_CLUSTER=stone-stage-p01
       - MONITORING_SAMPLE_RATE_ERRORS=1.0
+      - MONITORING_SAMPLE_RATE_TRACES=0.2
 patches:
 - path: add-service-certs-patch.yaml
   target:

--- a/components/konflux-ui/staging/stone-stg-rh01/kustomization.yaml
+++ b/components/konflux-ui/staging/stone-stg-rh01/kustomization.yaml
@@ -21,6 +21,7 @@ configMapGenerator:
   - MONITORING_ENVIRONMENT=staging
   - MONITORING_CLUSTER=stone-stg-rh01
   - MONITORING_SAMPLE_RATE_ERRORS=1.0
+  - MONITORING_SAMPLE_RATE_TRACES=0.2
 patches:
 - path: add-service-certs-patch.yaml
   target:


### PR DESCRIPTION
## What

Enable Sentry error and trace monitoring on all production clusters for konflux-ui (excluding kflux-fedora-01).

## Changes

**Production -- new Sentry config (7 clusters):**
- kflux-ocp-p01, kflux-osp-p01, kflux-prd-rh02, kflux-prd-rh03, kflux-rhel-p01, stone-prod-p01, stone-prod-p02
- Adds `ui-runtime-env-variables` ConfigMap with `MONITORING_ENABLED=true`, DSN, environment, cluster name, error sample rate (1), trace sample rate (0.2)

**Production -- updated (stone-prd-rh01):**
- Added `MONITORING_SAMPLE_RATE_TRACES=0.2`

**Staging -- updated (stone-stage-p01, stone-stg-rh01):**
- Added `MONITORING_SAMPLE_RATE_TRACES=0.2` (error rate stays at 1.0)

## How it works

The production base `proxy.yaml` already has a `render-runtime-config` init container that reads files from the `ui-runtime-env-variables` ConfigMap (mounted as an optional volume) and writes them into `runtime-config.js`. Adding the ConfigMap to each cluster overlay is all that's needed.

## Risk Assessment

**Level:** Low

**What could go wrong:** Sentry SDK in the browser starts sending events from new clusters. If volume is too high, sample rates can be lowered per-cluster without redeploying.

**Rollback plan:** Remove the `ui-runtime-env-variables` configMapGenerator entry from the affected cluster's kustomization.yaml. The optional volume mount means pods will continue running without any monitoring config.

**Blast radius:** Only affects the konflux-ui frontend JS running in user browsers. No backend or cluster infrastructure impact. Already proven on stone-prd-rh01 and both staging clusters.

## Validation

- Sentry is already active on stone-prd-rh01 (production) and both staging clusters with the same pattern
- No base changes needed -- only per-cluster ConfigMap additions

## Verification

Staging PRs:
https://github.com/redhat-appstudio/infra-deployments/pull/10227

Prod PRs:
https://github.com/redhat-appstudio/infra-deployments/pull/12499 (stone-prd-rh01)