### PR TITLE
KFLUXINFRA-4363 Add applications read access to konflux-viewer-bot-ac…

### DIFF
--- a/components/konflux-rbac/staging/base/konflux-viewer-bot-actions.yaml
+++ b/components/konflux-rbac/staging/base/konflux-viewer-bot-actions.yaml
@@ -29,6 +29,7 @@ rules:
 - apiGroups:
   - appstudio.redhat.com
   resources:
+  - applications
   - snapshots
   - releases
   - components


### PR DESCRIPTION
…tions

Add applications to the appstudio.redhat.com resources in the viewer ClusterRole so read-only bots can list applications without needing the broader konflux-model-bot-actions role.

Assisted-by: Claude Opus 4.6 (1M context), Anthropic