### PR TITLE
feat(KFLUXVNGD-1286): Deploy konflux-operator ring-2 for kflux-lw-p01

### DIFF
--- a/argo-cd-apps/k-components/deploy-to-production-internal-tenant-clusters/internal-tenant-clusters-list-patch.yaml
+++ b/argo-cd-apps/k-components/deploy-to-production-internal-tenant-clusters/internal-tenant-clusters-list-patch.yaml
@@ -3,6 +3,9 @@
   value:
     # Ring 2
     - values.ring: ring-2
+      nameNormalized: kflux-lw-p01
+      values.clusterDir: kflux-lw-p01
+    - values.ring: ring-2
       nameNormalized: kflux-ocp-p01
       values.clusterDir: kflux-ocp-p01
     - values.ring: ring-2
@@ -18,7 +21,4 @@
     - values.ring: ring-3
       nameNormalized: stone-prod-p02
       values.clusterDir: stone-prod-p02
-    - values.ring: ring-2
-      nameNormalized: kflux-lw-p01
-      values.clusterDir: kflux-lw-p01
   # Ring 4

--- a/argo-cd-apps/k-components/deploy-to-production-tenant-clusters/tenant-clusters-list-patch.yaml
+++ b/argo-cd-apps/k-components/deploy-to-production-tenant-clusters/tenant-clusters-list-patch.yaml
@@ -3,6 +3,9 @@
   value:
     # Ring 2
     - values.ring: ring-2
+      nameNormalized: kflux-lw-p01
+      values.clusterDir: kflux-lw-p01
+    - values.ring: ring-2
       nameNormalized: kflux-fedora-01
       values.clusterDir: kflux-fedora-01
     - values.ring: ring-2
@@ -31,6 +34,3 @@
     - values.ring: ring-4
       nameNormalized: kflux-prd-rh02
       values.clusterDir: kflux-prd-rh02
-    - values.ring: ring-2
-      nameNormalized: kflux-lw-p01
-      values.clusterDir: kflux-lw-p01

--- a/argo-cd-apps/overlays/rd-production/konflux-operator/konflux-operator-appset.yaml
+++ b/argo-cd-apps/overlays/rd-production/konflux-operator/konflux-operator-appset.yaml
@@ -1,0 +1,57 @@
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: konflux-operator
+  labels:
+    appstudio.redhat.com/deployment-clusters: "tenant"
+spec:
+  generators:
+    - merge:
+        mergeKeys:
+          - nameNormalized
+        generators:
+          - clusters:
+              selector:
+                matchExpressions:
+                  - key: appstudio.redhat.com/select-none
+                    operator: Exists
+                  - key: appstudio.redhat.com/select-none
+                    operator: DoesNotExist
+              values:
+                sourceRoot: components/konflux-operator
+                ring: "empty-base"
+                clusterDir: "empty-base"
+          - list:
+              elements: []
+      selector:
+        matchExpressions:
+          - key: nameNormalized
+            operator: In
+            values:
+              - kflux-lw-p01
+
+  template:
+    metadata:
+      name: konflux-operator-{{nameNormalized}}
+    spec:
+      project: default
+      source:
+        path: '{{values.sourceRoot}}/rings/{{values.ring}}/{{values.clusterDir}}'
+        repoURL: https://github.com/redhat-appstudio/infra-deployments.git
+        targetRevision: main
+      destination:
+        namespace: konflux-operator
+        server: '{{server}}'
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
+        syncOptions:
+          - CreateNamespace=true
+          - SkipDryRunOnMissingResource=true
+        retry:
+          limit: -1
+          backoff:
+            duration: 10s
+            factor: 2
+            maxDuration: 3m

--- a/argo-cd-apps/overlays/rd-production/konflux-operator/kustomization.yaml
+++ b/argo-cd-apps/overlays/rd-production/konflux-operator/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - konflux-operator-appset.yaml

--- a/argo-cd-apps/overlays/rd-production/kustomization.yaml
+++ b/argo-cd-apps/overlays/rd-production/kustomization.yaml
@@ -5,6 +5,7 @@ namespace: argocd-infra-deployments
 resources:
   - authentication
   - etcd-shield
+  - konflux-operator
   - kueue
   - multi-platform-controller
 

--- a/argo-cd-apps/overlays/staging-downstream/exclude-operator-owned-clusters.yaml
+++ b/argo-cd-apps/overlays/staging-downstream/exclude-operator-owned-clusters.yaml
@@ -13,4 +13,3 @@
         values:
           - stone-stage-p01
           - lightwell-dev
-          - kflux-lw-p01

--- a/components/konflux-operator/rings/ring-2/base/cr/build/OWNERS
+++ b/components/konflux-operator/rings/ring-2/base/cr/build/OWNERS
@@ -1,0 +1,16 @@
+# See the OWNERS docs: https://go.k8s.io/owners
+# Should be kept in sync with components/monitoring/grafana/base/dashboards/build-service/OWNERS
+
+approvers:
+- mmorhun
+- rcerven
+- mkosiarc
+- tisutisu
+- chmeliik
+
+reviewers:
+- mmorhun
+- rcerven
+- mkosiarc
+- tisutisu
+- chmeliik

--- a/components/konflux-operator/rings/ring-2/base/cr/build/build-service.yaml
+++ b/components/konflux-operator/rings/ring-2/base/cr/build/build-service.yaml
@@ -1,0 +1,27 @@
+apiVersion: konflux.konflux-ci.dev/v1alpha1
+kind: Konflux
+metadata:
+  name: konflux
+spec:
+  buildService:
+    spec:
+      pipelineConfig:
+        # docker-build-oci-ta is defined upstream, but it's not the default there.
+        defaultPipelineName: docker-build-oci-ta
+        pipelines:
+          - name: docker-build-multi-platform-oci-ta
+            bundle: quay.io/konflux-ci/tekton-catalog/pipeline-docker-build-multi-platform-oci-ta:devel
+            description: "Build multi-platform container images with secure data transfer for the pipelines"
+          - name: maven-zip-build-oci-ta
+            bundle: quay.io/konflux-ci/tekton-catalog/pipeline-maven-zip-build-oci-ta:devel
+            description: "Build maven zip OCI artifacts"
+      buildControllerManager:
+        replicas: 1
+        manager:
+          resources:
+            requests:
+              cpu: 500m
+              memory: 4Gi
+            limits:
+              cpu: 500m
+              memory: 4Gi

--- a/components/konflux-operator/rings/ring-2/base/cr/build/external-secrets/kustomization.yaml
+++ b/components/konflux-operator/rings/ring-2/base/cr/build/external-secrets/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - pipelines-as-code-secret.yaml

--- a/components/konflux-operator/rings/ring-2/base/cr/build/external-secrets/pipelines-as-code-secret.yaml
+++ b/components/konflux-operator/rings/ring-2/base/cr/build/external-secrets/pipelines-as-code-secret.yaml
@@ -1,0 +1,19 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: pipelines-as-code-secret
+  namespace: build-service
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  dataFrom:
+    - extract:
+        key: production/pipeline-service/github-app
+  refreshInterval: 5m
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: appsre-stonesoup-vault
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    name: pipelines-as-code-secret

--- a/components/konflux-operator/rings/ring-2/base/cr/build/kustomization.yaml
+++ b/components/konflux-operator/rings/ring-2/base/cr/build/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+resources:
+  - external-secrets
+  - rbac
+patches:
+  - path: build-service.yaml

--- a/components/konflux-operator/rings/ring-2/base/cr/build/rbac/build-admin.yaml
+++ b/components/konflux-operator/rings/ring-2/base/cr/build/rbac/build-admin.yaml
@@ -1,0 +1,42 @@
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: build-admin
+  namespace: build-service
+rules:
+  - apiGroups:
+      - ''
+    resources:
+      - secrets
+    verbs:
+      - get
+      - list
+      - watch
+      - update
+      - patch
+      - delete
+
+  - apiGroups:
+      - ''
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+      - delete
+
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: build-admins
+  namespace: build-service
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: konflux-build-admins
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: build-admin

--- a/components/konflux-operator/rings/ring-2/base/cr/build/rbac/build-maintainer.yaml
+++ b/components/konflux-operator/rings/ring-2/base/cr/build/rbac/build-maintainer.yaml
@@ -1,0 +1,54 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: build-maintainer
+rules:
+  - verbs:
+      - get
+      - list
+      - patch
+      - update
+    apiGroups:
+      - ''
+    resources:
+      - serviceaccounts
+      - configmaps
+  - verbs:
+      - list
+    apiGroups:
+      - ''
+    resources:
+      - secrets
+  - verbs:
+      - get
+      - list
+      - patch
+      - update
+    apiGroups:
+      - appstudio.redhat.com
+      - konflux-ci.dev
+    resources:
+      - components
+      - imagerepositories
+  - verbs:
+      - get
+      - list
+      - patch
+      - update
+    apiGroups:
+      - pipelinesascode.tekton.dev
+    resources:
+      - repositories
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: build-maintainers
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: konflux-build
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: build-maintainer

--- a/components/konflux-operator/rings/ring-2/base/cr/build/rbac/kustomization.yaml
+++ b/components/konflux-operator/rings/ring-2/base/cr/build/rbac/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - build-admin.yaml
+  - build-maintainer.yaml
+  - view-konflux-integration-runner.yaml

--- a/components/konflux-operator/rings/ring-2/base/cr/build/rbac/view-konflux-integration-runner.yaml
+++ b/components/konflux-operator/rings/ring-2/base/cr/build/rbac/view-konflux-integration-runner.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: view-konflux-integration-runner
+  namespace: build-service
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: view
+subjects:
+- kind: ServiceAccount
+  name: konflux-integration-runner
+  namespace: rhtap-build-tenant

--- a/components/konflux-operator/rings/ring-2/base/cr/enterprise-contract/ecp.yaml
+++ b/components/konflux-operator/rings/ring-2/base/cr/enterprise-contract/ecp.yaml
@@ -1,0 +1,156 @@
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: EnterpriseContractPolicy
+metadata:
+  name: default
+  namespace: enterprise-contract-service
+  annotations:
+    argocd.argoproj.io/sync-wave: "10"
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  description: 'Includes rules for levels 1, 2 & 3 of SLSA v0.1. This is the default config used for new Konflux applications. Source: https://github.com/conforma/config/blob/main/default/policy.yaml'
+  name: Default
+  publicKey: k8s://openshift-pipelines/public-key
+  sources:
+    - config:
+        exclude: []
+        include:
+          - '@slsa3'
+      data:
+        - github.com/release-engineering/rhtap-ec-policy//data
+        - oci::quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest
+        - oci::quay.io/konflux-ci/konflux-vanguard/data-acceptable-bundles:latest
+        - oci::quay.io/konflux-ci/integration-service-catalog/data-acceptable-bundles:latest
+      name: Default
+      policy:
+        - oci::quay.io/enterprise-contract/ec-release-policy:konflux
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: EnterpriseContractPolicy
+metadata:
+  name: redhat-no-hermetic
+  namespace: enterprise-contract-service
+  annotations:
+    argocd.argoproj.io/sync-wave: "10"
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  description: 'Includes most of the rules and policies required internally by Red Hat when building Red Hat products. It excludes the requirement of hermetic builds. Source: https://github.com/conforma/config/blob/main/redhat-no-hermetic/policy.yaml'
+  name: Red Hat (non hermetic)
+  publicKey: k8s://openshift-pipelines/public-key
+  sources:
+    - config:
+        exclude:
+          - hermetic_build_task
+          - tasks.required_tasks_found:prefetch-dependencies
+        include:
+          - '@redhat'
+      data:
+        - github.com/release-engineering/rhtap-ec-policy//data
+        - oci::quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest
+        - oci::quay.io/konflux-ci/konflux-vanguard/data-acceptable-bundles:latest
+        - oci::quay.io/konflux-ci/integration-service-catalog/data-acceptable-bundles:latest
+      name: Default
+      policy:
+        - oci::quay.io/enterprise-contract/ec-release-policy:konflux
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: EnterpriseContractPolicy
+metadata:
+  name: redhat-rpms
+  namespace: enterprise-contract-service
+  annotations:
+    argocd.argoproj.io/sync-wave: "10"
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  description: 'For Red Hat RPM builds in Red Hat Konflux. Source: https://github.com/conforma/config/blob/main/redhat-rpms/policy.yaml'
+  name: Red Hat RPMs
+  publicKey: k8s://openshift-pipelines/public-key
+  sources:
+    - config:
+        exclude: []
+        include:
+          - '@redhat_rpms'
+      data:
+        - github.com/release-engineering/rhtap-ec-policy//data
+        - oci::quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest
+        - oci::quay.io/konflux-ci/konflux-vanguard/data-acceptable-bundles:latest
+        - oci::quay.io/konflux-ci/integration-service-catalog/data-acceptable-bundles:latest
+        - oci::quay.io/enterprise-contract/rpmbuild-data-acceptable-bundles:latest
+      name: Default
+      policy:
+        - oci::quay.io/enterprise-contract/ec-release-policy:konflux
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: EnterpriseContractPolicy
+metadata:
+  name: redhat
+  namespace: enterprise-contract-service
+  annotations:
+    argocd.argoproj.io/sync-wave: "10"
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  description: 'Includes the full set of rules and policies required internally by Red Hat when building Red Hat products. Source: https://github.com/conforma/config/blob/main/redhat/policy.yaml'
+  name: Red Hat
+  publicKey: k8s://openshift-pipelines/public-key
+  sources:
+    - config:
+        exclude: []
+        include:
+          - '@redhat'
+      data:
+        - github.com/release-engineering/rhtap-ec-policy//data
+        - oci::quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest
+        - oci::quay.io/konflux-ci/konflux-vanguard/data-acceptable-bundles:latest
+        - oci::quay.io/konflux-ci/integration-service-catalog/data-acceptable-bundles:latest
+      name: Default
+      policy:
+        - oci::quay.io/enterprise-contract/ec-release-policy:konflux
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: EnterpriseContractPolicy
+metadata:
+  name: slsa3
+  namespace: enterprise-contract-service
+  annotations:
+    argocd.argoproj.io/sync-wave: "10"
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  description: 'Rules specifically related to levels 1, 2 & 3 of SLSA v0.1, plus a set of basic checks that are expected to pass for all Konflux builds. Source: https://github.com/conforma/config/blob/main/slsa3/policy.yaml'
+  name: SLSA3
+  publicKey: k8s://openshift-pipelines/public-key
+  sources:
+    - config:
+        exclude: []
+        include:
+          - '@minimal'
+          - '@slsa3'
+      data:
+        - github.com/release-engineering/rhtap-ec-policy//data
+        - oci::quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest
+        - oci::quay.io/konflux-ci/konflux-vanguard/data-acceptable-bundles:latest
+        - oci::quay.io/konflux-ci/integration-service-catalog/data-acceptable-bundles:latest
+      name: Default
+      policy:
+        - oci::quay.io/enterprise-contract/ec-release-policy:konflux
+---
+apiVersion: appstudio.redhat.com/v1alpha1
+kind: EnterpriseContractPolicy
+metadata:
+  name: redhat-trusted-tasks
+  namespace: enterprise-contract-service
+  annotations:
+    argocd.argoproj.io/sync-wave: "10"
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  description: Rules used to verify Tekton Task definitions comply to Red Hat's standards.
+  name: Red Hat Trusted Tasks
+  sources:
+    - config:
+        exclude: []
+        include:
+          - kind
+      data:
+        - github.com/release-engineering/rhtap-ec-policy//data
+      name: Default
+      policy:
+        - oci::quay.io/enterprise-contract/ec-task-policy:konflux

--- a/components/konflux-operator/rings/ring-2/base/cr/enterprise-contract/enterprise-contract.yaml
+++ b/components/konflux-operator/rings/ring-2/base/cr/enterprise-contract/enterprise-contract.yaml
@@ -1,0 +1,7 @@
+apiVersion: konflux.konflux-ci.dev/v1alpha1
+kind: Konflux
+metadata:
+  name: konflux
+spec:
+  enterpriseContract:
+    skipPolicies: true

--- a/components/konflux-operator/rings/ring-2/base/cr/enterprise-contract/kustomization.yaml
+++ b/components/konflux-operator/rings/ring-2/base/cr/enterprise-contract/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+resources:
+  - ecp.yaml
+patches:
+  - path: enterprise-contract.yaml

--- a/components/konflux-operator/rings/ring-2/base/cr/image-controller/OWNERS
+++ b/components/konflux-operator/rings/ring-2/base/cr/image-controller/OWNERS
@@ -1,0 +1,15 @@
+# See the OWNERS docs: https://go.k8s.io/owners
+
+approvers:
+- mmorhun
+- rcerven
+- mkosiarc
+- tisutisu
+- chmeliik
+
+reviewers:
+- mmorhun
+- mkosiarc
+- rcerven
+- tisutisu
+- chmeliik

--- a/components/konflux-operator/rings/ring-2/base/cr/image-controller/external-secrets/image-pruner-token.yaml
+++ b/components/konflux-operator/rings/ring-2/base/cr/image-controller/external-secrets/image-pruner-token.yaml
@@ -1,0 +1,19 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: image-pruner-token
+  namespace: image-controller
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  dataFrom:
+    - extract:
+        key: production/build/image-pruner-token
+  refreshInterval: 30m
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: appsre-stonesoup-vault
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    name: image-pruner-token

--- a/components/konflux-operator/rings/ring-2/base/cr/image-controller/external-secrets/kustomization.yaml
+++ b/components/konflux-operator/rings/ring-2/base/cr/image-controller/external-secrets/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - quaytoken.yaml
+  - image-pruner-token.yaml

--- a/components/konflux-operator/rings/ring-2/base/cr/image-controller/external-secrets/quaytoken.yaml
+++ b/components/konflux-operator/rings/ring-2/base/cr/image-controller/external-secrets/quaytoken.yaml
@@ -1,0 +1,19 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: quaytoken
+  namespace: image-controller
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  dataFrom:
+    - extract:
+        key: production/build/image-controller
+  refreshInterval: 5m
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: appsre-stonesoup-vault
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    name: quaytoken

--- a/components/konflux-operator/rings/ring-2/base/cr/image-controller/image-controller.yaml
+++ b/components/konflux-operator/rings/ring-2/base/cr/image-controller/image-controller.yaml
@@ -1,0 +1,34 @@
+apiVersion: konflux.konflux-ci.dev/v1alpha1
+kind: Konflux
+metadata:
+  name: konflux
+spec:
+  imageController:
+    enabled: true
+    spec:
+      imageControllerManager:
+        replicas: 1
+        manager:
+          resources:
+            requests:
+              cpu: 500m
+              memory: 6Gi
+            limits:
+              cpu: 500m
+              memory: 6Gi
+      imagePruner:
+        resources:
+          requests:
+            cpu: 150m
+            memory: 8Gi
+          limits:
+            cpu: 500m
+            memory: 8Gi
+      notificationResetter:
+        resources:
+          requests:
+            cpu: 150m
+            memory: 1Gi
+          limits:
+            cpu: 500m
+            memory: 1Gi

--- a/components/konflux-operator/rings/ring-2/base/cr/image-controller/kustomization.yaml
+++ b/components/konflux-operator/rings/ring-2/base/cr/image-controller/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+resources:
+  - external-secrets
+  - rbac
+patches:
+  - path: image-controller.yaml

--- a/components/konflux-operator/rings/ring-2/base/cr/image-controller/rbac/image-controller-admin.yaml
+++ b/components/konflux-operator/rings/ring-2/base/cr/image-controller/rbac/image-controller-admin.yaml
@@ -1,0 +1,52 @@
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: image-controller-admin
+  namespace: image-controller
+rules:
+  - apiGroups:
+      - ''
+    resources:
+      - secrets
+    verbs:
+      - get
+      - list
+      - watch
+      - update
+      - patch
+      - delete
+
+  - apiGroups:
+      - ''
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+      - delete
+
+  - apiGroups:
+      - 'batch'
+    resources:
+      - jobs
+    verbs:
+      - get
+      - list
+      - watch
+      - delete
+
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: image-controller-admins
+  namespace: image-controller
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: konflux-build-admins
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: image-controller-admin

--- a/components/konflux-operator/rings/ring-2/base/cr/image-controller/rbac/image-controller-maintainer.yaml
+++ b/components/konflux-operator/rings/ring-2/base/cr/image-controller/rbac/image-controller-maintainer.yaml
@@ -1,0 +1,34 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: image-controller-maintainer
+rules:
+  - apiGroups:
+      - 'appstudio.redhat.com'
+    resources:
+      - imagerepositories
+    verbs:
+      - get
+      - list
+      - watch
+
+  - apiGroups:
+      - 'appstudio.redhat.com'
+    resources:
+      - imagerepositories/status
+    verbs:
+      - get
+
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: image-controller-maintainers
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: konflux-build
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: image-controller-maintainer

--- a/components/konflux-operator/rings/ring-2/base/cr/image-controller/rbac/kustomization.yaml
+++ b/components/konflux-operator/rings/ring-2/base/cr/image-controller/rbac/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - image-controller-admin.yaml
+  - image-controller-maintainer.yaml

--- a/components/konflux-operator/rings/ring-2/base/cr/integration/OWNERS
+++ b/components/konflux-operator/rings/ring-2/base/cr/integration/OWNERS
@@ -1,0 +1,21 @@
+# See the OWNERS docs: https://go.k8s.io/owners
+
+approvers:
+- dirgim
+- jsztuka
+- kasemAlem
+- sonam1412
+- Josh-Everett
+- 14rcole
+- jencull
+- NigelByrne1
+
+reviewers:
+- dirgim
+- jsztuka
+- kasemAlem
+- sonam1412
+- Josh-Everett
+- 14rcole
+- jencull
+- NigelByrne1

--- a/components/konflux-operator/rings/ring-2/base/cr/integration/external-secrets/kustomization.yaml
+++ b/components/konflux-operator/rings/ring-2/base/cr/integration/external-secrets/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - pipelines-as-code-secret.yaml

--- a/components/konflux-operator/rings/ring-2/base/cr/integration/external-secrets/pipelines-as-code-secret.yaml
+++ b/components/konflux-operator/rings/ring-2/base/cr/integration/external-secrets/pipelines-as-code-secret.yaml
@@ -1,0 +1,19 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: pipelines-as-code-secret
+  namespace: integration-service
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  dataFrom:
+    - extract:
+        key: production/pipeline-service/github-app
+  refreshInterval: 5m
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: appsre-stonesoup-vault
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    name: pipelines-as-code-secret

--- a/components/konflux-operator/rings/ring-2/base/cr/integration/integration-service.yaml
+++ b/components/konflux-operator/rings/ring-2/base/cr/integration/integration-service.yaml
@@ -1,0 +1,20 @@
+apiVersion: konflux.konflux-ci.dev/v1alpha1
+kind: Konflux
+metadata:
+  name: konflux
+spec:
+  integrationService:
+    spec:
+      pipelineTimeout: "6h"
+      tasksTimeout: "4h"
+      finallyTimeout: "2h"
+      integrationControllerManager:
+        replicas: 1
+        manager:
+          resources:
+            requests:
+              cpu: 200m
+              memory: 8Gi
+            limits:
+              cpu: 600m
+              memory: 8Gi

--- a/components/konflux-operator/rings/ring-2/base/cr/integration/kustomization.yaml
+++ b/components/konflux-operator/rings/ring-2/base/cr/integration/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+resources:
+  - external-secrets
+  - rbac
+patches:
+  - path: integration-service.yaml

--- a/components/konflux-operator/rings/ring-2/base/cr/integration/rbac/delete-snapshots.yaml
+++ b/components/konflux-operator/rings/ring-2/base/cr/integration/rbac/delete-snapshots.yaml
@@ -1,0 +1,25 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: delete-snapshots
+rules:
+  - apiGroups:
+    - "appstudio.redhat.com"
+    resources:
+      - "snapshots"
+    verbs:
+      - "delete"
+      - "deletecollection"
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: delete-snapshots
+subjects:
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: konflux-integration
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: delete-snapshots

--- a/components/konflux-operator/rings/ring-2/base/cr/integration/rbac/integration-service-maintainers.yaml
+++ b/components/konflux-operator/rings/ring-2/base/cr/integration/rbac/integration-service-maintainers.yaml
@@ -1,0 +1,13 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: integration-service-maintainers
+  namespace: integration-service
+subjects:
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: konflux-integration
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: component-maintainer

--- a/components/konflux-operator/rings/ring-2/base/cr/integration/rbac/kustomization.yaml
+++ b/components/konflux-operator/rings/ring-2/base/cr/integration/rbac/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - delete-snapshots.yaml
+  - manage-integrationtestscenarios.yaml
+  - manage-resolutionrequests.yaml
+  - modify-pipelineruns-taskruns.yaml
+  - integration-service-maintainers.yaml

--- a/components/konflux-operator/rings/ring-2/base/cr/integration/rbac/manage-integrationtestscenarios.yaml
+++ b/components/konflux-operator/rings/ring-2/base/cr/integration/rbac/manage-integrationtestscenarios.yaml
@@ -1,0 +1,31 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: manage-integrationtestscenarios
+rules:
+  - apiGroups:
+    - "appstudio.redhat.com"
+    resources:
+      - "integrationtestscenarios"
+    verbs:
+      - "create"
+      - "get"
+      - "list"
+      - "patch"
+      - "update"
+      - "watch"
+      - "delete"
+      - "deletecollection"
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: manage-integrationtestscenarios
+subjects:
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: konflux-integration
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: manage-integrationtestscenarios

--- a/components/konflux-operator/rings/ring-2/base/cr/integration/rbac/manage-resolutionrequests.yaml
+++ b/components/konflux-operator/rings/ring-2/base/cr/integration/rbac/manage-resolutionrequests.yaml
@@ -1,0 +1,28 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: manage-resolutionrequests
+rules:
+  - apiGroups:
+    - "resolution.tekton.dev"
+    resources:
+      - "resolutionrequests"
+    verbs:
+      - "create"
+      - "get"
+      - "list"
+      - "watch"
+      - "delete"
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: manage-resolutionrequests
+subjects:
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: konflux-integration
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: manage-resolutionrequests

--- a/components/konflux-operator/rings/ring-2/base/cr/integration/rbac/modify-pipelineruns-taskruns.yaml
+++ b/components/konflux-operator/rings/ring-2/base/cr/integration/rbac/modify-pipelineruns-taskruns.yaml
@@ -1,0 +1,28 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: modify-pipelineruns-taskruns
+rules:
+  - apiGroups:
+    - "tekton.dev"
+    resources:
+      - "pipelineruns"
+      - "taskruns"
+    verbs:
+      - "get"
+      - "list"
+      - "patch"
+      - "update"
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: modify-pipelineruns-taskruns
+subjects:
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: konflux-integration
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: modify-pipelineruns-taskruns

--- a/components/konflux-operator/rings/ring-2/base/cr/konflux-info/OWNERS
+++ b/components/konflux-operator/rings/ring-2/base/cr/konflux-info/OWNERS
@@ -1,0 +1,47 @@
+# See the OWNERS docs: https://go.k8s.io/owners
+
+approvers:
+# infra-team
+- sadlerap
+- eisraeli
+- filariow
+- gbenhaim
+- hugares
+- manish-jangra
+# sre-team
+- dgregor
+- jdcasey
+# ui-team
+- abhinandan13jan
+- caugello
+- CryptoRodeo
+- JoaoPedroPP
+- Katka92
+- sahil143
+- rrosatti
+- StanislavJochman
+# others
+- arewm
+
+reviewers:
+# infra-team
+- sadlerap
+- eisraeli
+- filariow
+- gbenhaim
+- hugares
+- manish-jangra
+# sre-team
+- dgregor
+- jdcasey
+# ui-team
+- abhinandan13jan
+- caugello
+- CryptoRodeo
+- JoaoPedroPP
+- Katka92
+- sahil143
+- rrosatti
+- StanislavJochman
+# others
+- arewm

--- a/components/konflux-operator/rings/ring-2/base/cr/konflux-info/konflux-info.yaml
+++ b/components/konflux-operator/rings/ring-2/base/cr/konflux-info/konflux-info.yaml
@@ -1,0 +1,36 @@
+apiVersion: konflux.konflux-ci.dev/v1alpha1
+kind: Konflux
+metadata:
+  name: konflux
+spec:
+  info:
+    spec:
+      clusterConfig:
+        data:
+          allowCacheProxy: true
+          allowPackageRegistryProxy: true
+          httpProxy: squid.caching.svc.cluster.local:3128
+          noProxy: ""
+          packageRegistryProxyGomodUrl: https://artifact-registry-proxy.caching.svc.cluster.local/repository/go-proxy
+          packageRegistryProxyNpmUrl: https://artifact-registry-proxy.caching.svc.cluster.local/repository/npm-proxy
+          packageRegistryProxyPipUrl: https://artifact-registry-proxy.caching.svc.cluster.local/repository/pypi-proxy/simple
+          packageRegistryProxyPnpmUrl: https://artifact-registry-proxy.caching.svc.cluster.local/repository/npm-proxy
+          packageRegistryProxyYarnUrl: https://artifact-registry-proxy.caching.svc.cluster.local/repository/npm-proxy
+      publicInfo:
+        environment: production
+        integrations:
+          sbom_server:
+            url: "https://atlas.build.devshift.net/sbom/content/<PLACEHOLDER>"
+            sbom_sha: "https://atlas.build.devshift.net/sboms/<PLACEHOLDER>"
+          image_controller:
+            enabled: true
+            notifications:
+              - title: "SBOM-event-to-Bombino"
+                event: "repo_push"
+                method: "webhook"
+                config:
+                  url: "https://bombino.api.redhat.com/v1/sbom/quay/push"
+      banner:
+        items:
+          - summary: "Want to **display important updates** here? [See how to create a banner](https://github.com/redhat-appstudio/infra-deployments/blob/main/components/konflux-info/README.md)."
+            type: info

--- a/components/konflux-operator/rings/ring-2/base/cr/konflux-info/kustomization.yaml
+++ b/components/konflux-operator/rings/ring-2/base/cr/konflux-info/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+patches:
+  - path: konflux-info.yaml

--- a/components/konflux-operator/rings/ring-2/base/cr/konflux-rbac/OWNERS
+++ b/components/konflux-operator/rings/ring-2/base/cr/konflux-rbac/OWNERS
@@ -1,0 +1,7 @@
+# See the OWNERS docs: https://go.k8s.io/owners
+
+approvers:
+- konflux-infra-team
+
+reviewers:
+- konflux-infra-team

--- a/components/konflux-operator/rings/ring-2/base/cr/konflux-rbac/konflux-externalpuller-bot-actions.yaml
+++ b/components/konflux-operator/rings/ring-2/base/cr/konflux-rbac/konflux-externalpuller-bot-actions.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: konflux-externalpuller-bot-actions
+rules:
+- apiGroups:
+  - appstudio.redhat.com
+  resources:
+  - imagerepositories
+  verbs:
+  - get
+  - list
+  - watch

--- a/components/konflux-operator/rings/ring-2/base/cr/konflux-rbac/konflux-integrationtest-bot-actions.yaml
+++ b/components/konflux-operator/rings/ring-2/base/cr/konflux-rbac/konflux-integrationtest-bot-actions.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: konflux-integrationtest-bot-actions
+rules:
+- apiGroups:
+  - appstudio.redhat.com
+  resources:
+  - integrationtestscenarios
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete

--- a/components/konflux-operator/rings/ring-2/base/cr/konflux-rbac/konflux-model-bot-actions.yaml
+++ b/components/konflux-operator/rings/ring-2/base/cr/konflux-rbac/konflux-model-bot-actions.yaml
@@ -1,0 +1,18 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: konflux-model-bot-actions
+rules:
+- apiGroups:
+  - appstudio.redhat.com
+  resources:
+  - applications
+  - components
+  - releaseplans
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch

--- a/components/konflux-operator/rings/ring-2/base/cr/konflux-rbac/konflux-secrets-bot-actions.yaml
+++ b/components/konflux-operator/rings/ring-2/base/cr/konflux-rbac/konflux-secrets-bot-actions.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: konflux-secrets-bot-actions
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - create
+  - update
+  - patch
+  - delete

--- a/components/konflux-operator/rings/ring-2/base/cr/konflux-rbac/konflux-tester-internalbot-actions.yaml
+++ b/components/konflux-operator/rings/ring-2/base/cr/konflux-rbac/konflux-tester-internalbot-actions.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: konflux-tester-internalbot-actions
+rules:
+  - apiGroups:
+      - appstudio.redhat.com
+    resources:
+      - snapshots
+    verbs:
+      - get
+      - watch
+      - list
+      - update
+      - patch

--- a/components/konflux-operator/rings/ring-2/base/cr/konflux-rbac/konflux-viewer-bot-actions.yaml
+++ b/components/konflux-operator/rings/ring-2/base/cr/konflux-rbac/konflux-viewer-bot-actions.yaml
@@ -1,0 +1,47 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: konflux-viewer-bot-actions
+rules:
+- apiGroups:
+  - tekton.dev
+  resources:
+  - pipelineruns
+  - taskruns
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
+- apiGroups:
+  - appstudio.redhat.com
+  resources:
+  - applications
+  - snapshots
+  - releases
+  - components
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - pipelinesascode.tekton.dev
+  resources:
+  - repositories
+  verbs:
+  - get
+  - list
+  - watch

--- a/components/konflux-operator/rings/ring-2/base/cr/konflux-rbac/kustomization.yaml
+++ b/components/konflux-operator/rings/ring-2/base/cr/konflux-rbac/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+resources:
+  - konflux-externalpuller-bot-actions.yaml
+  - konflux-integrationtest-bot-actions.yaml
+  - konflux-model-bot-actions.yaml
+  - konflux-secrets-bot-actions.yaml
+  - konflux-tester-internalbot-actions.yaml
+  - konflux-viewer-bot-actions.yaml

--- a/components/konflux-operator/rings/ring-2/base/cr/konflux-ui/OWNERS
+++ b/components/konflux-operator/rings/ring-2/base/cr/konflux-ui/OWNERS
@@ -1,0 +1,47 @@
+# See the OWNERS docs: https://go.k8s.io/owners
+
+approvers:
+# infra-team
+- sadlerap
+- eisraeli
+- filariow
+- gbenhaim
+- hugares
+- manish-jangra
+# sre-team
+- dgregor
+- jdcasey
+# ui-team
+- abhinandan13jan
+- caugello
+- CryptoRodeo
+- JoaoPedroPP
+- Katka92
+- sahil143
+- rrosatti
+- StanislavJochman
+# others
+- arewm
+
+reviewers:
+# infra-team
+- sadlerap
+- eisraeli
+- filariow
+- gbenhaim
+- hugares
+- manish-jangra
+# sre-team
+- dgregor
+- jdcasey
+# ui-team
+- abhinandan13jan
+- caugello
+- CryptoRodeo
+- JoaoPedroPP
+- Katka92
+- sahil143
+- rrosatti
+- StanislavJochman
+# others
+- arewm

--- a/components/konflux-operator/rings/ring-2/base/cr/konflux-ui/kustomization.yaml
+++ b/components/konflux-operator/rings/ring-2/base/cr/konflux-ui/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+patches:
+  - path: ui.yaml

--- a/components/konflux-operator/rings/ring-2/base/cr/konflux-ui/ui.yaml
+++ b/components/konflux-operator/rings/ring-2/base/cr/konflux-ui/ui.yaml
@@ -1,0 +1,34 @@
+apiVersion: konflux.konflux-ci.dev/v1alpha1
+kind: Konflux
+metadata:
+  name: konflux
+spec:
+  ui:
+    spec:
+      ingress:
+        hostname: konflux-ui
+      proxy:
+        replicas: 3
+        endpoints:
+          kite:
+            enabled: true
+          kubearchive:
+            enabled: true
+        reverseProxy:
+          resources:
+            requests:
+              cpu: 30m
+              memory: 128Mi
+            limits:
+              cpu: 300m
+              memory: 256Mi
+      dex:
+        replicas: 3
+        config:
+          configureLoginWithOpenShift: true
+      runtimeConfig:
+        monitoring:
+          enabled: true
+          dsn: "https://2d1bbbd05a2ff473d916df439cfc363e@o490301.ingest.us.sentry.io/4510260965408768"
+          environment: production
+          sampleRateErrors: "0.2"

--- a/components/konflux-operator/rings/ring-2/base/cr/namespace-lister/OWNERS
+++ b/components/konflux-operator/rings/ring-2/base/cr/namespace-lister/OWNERS
@@ -1,0 +1,27 @@
+# See the OWNERS docs: https://go.k8s.io/owners
+
+approvers:
+- eisraeli
+- enkeefe00
+- filariow
+- gbenhaim
+- glevi-rh
+- hugares
+- manish-jangra
+- meyrevived
+- mshaposhnik
+- oswcab
+- sadlerap
+
+reviewers:
+- eisraeli
+- enkeefe00
+- filariow
+- gbenhaim
+- glevi-rh
+- hugares
+- manish-jangra
+- meyrevived
+- mshaposhnik
+- oswcab
+- sadlerap

--- a/components/konflux-operator/rings/ring-2/base/cr/namespace-lister/kustomization.yaml
+++ b/components/konflux-operator/rings/ring-2/base/cr/namespace-lister/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+patches:
+  - path: namespace-lister.yaml

--- a/components/konflux-operator/rings/ring-2/base/cr/namespace-lister/namespace-lister.yaml
+++ b/components/konflux-operator/rings/ring-2/base/cr/namespace-lister/namespace-lister.yaml
@@ -1,0 +1,19 @@
+apiVersion: konflux.konflux-ci.dev/v1alpha1
+kind: Konflux
+metadata:
+  name: konflux
+spec:
+  namespaceLister:
+    spec:
+      cacheResyncPeriod: "10m"
+      logLevel: info
+      namespaceLister:
+        replicas: 3
+        namespaceLister:
+          resources:
+            requests:
+              cpu: 4000m
+              memory: 6Gi
+            limits:
+              cpu: 4000m
+              memory: 6Gi

--- a/components/konflux-operator/rings/ring-2/base/cr/release/OWNERS
+++ b/components/konflux-operator/rings/ring-2/base/cr/release/OWNERS
@@ -1,0 +1,28 @@
+# See the OWNERS docs: https://go.k8s.io/owners
+
+approvers:
+- davidmogar
+- johnbieren
+- theflockers
+- mmalina
+- happybhati
+- seanconroy2021
+- filipnikolovski
+- elenagerman
+- midnightercz
+- querti
+- swickersh
+
+
+reviewers:
+- davidmogar
+- johnbieren
+- theflockers
+- mmalina
+- happybhati
+- seanconroy2021
+- filipnikolovski
+- elenagerman
+- midnightercz
+- querti
+- swickersh

--- a/components/konflux-operator/rings/ring-2/base/cr/release/cronjobs/kustomization.yaml
+++ b/components/konflux-operator/rings/ring-2/base/cr/release/cronjobs/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - remove-internal-requests.yaml

--- a/components/konflux-operator/rings/ring-2/base/cr/release/cronjobs/remove-internal-requests.yaml
+++ b/components/konflux-operator/rings/ring-2/base/cr/release/cronjobs/remove-internal-requests.yaml
@@ -1,0 +1,81 @@
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: cleanup-timed-out-pipelineruns-internal-requests
+  namespace: release-service
+spec:
+  schedule: "10 03 * * *"
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: Never
+          serviceAccountName: release-service-controller-manager
+          volumes:
+            - name: temp-directory
+              emptyDir: {}
+          containers:
+            - name: ir-cleanup
+              command:
+                - /bin/bash
+                - -c
+                - |
+                  set -o pipefail
+                  PATH="/bin:/usr/bin:/usr/local/bin"
+                  MAX_PROCS=5
+                  INTERNAL_REQUESTS_FILE="/var/tmp/internal-requests-to-be-deleted"
+                  KUBECTL_OUTPUT=$(mktemp -p /var/tmp)
+                  YD=$(date -d 'yesterday' +%s)
+                  kubectl get internalrequests --all-namespaces \
+                    --sort-by=.status.completionTime \
+                    --template '{{range .items}}{{.metadata.name}}{{"\t"}}{{.metadata.namespace}}{{"\t"}}{{.status.completionTime}}{{"\n"}}{{end}}' \
+                    | grep -E "[0-9]{4}((-?)[0-9]{2})+T.*Z$" > $KUBECTL_OUTPUT
+                  awk -v yesterday=${YD} '{
+                    # parsing the completionTime and converting it to epoch
+                    # so we can compute the precise IRs that should be deleted
+                    gsub("[:\\-TZ]", " ", $3)
+                    t=mktime($3)
+                    completionTime=strftime("%s", t)
+                    #
+                    # completionTime should be smaller than yesterday seconds so it can be deleted
+                    if(yesterday > completionTime) {
+                      args="%s:%s\n"
+                      printf(args, $1, $2)
+                    }
+                  }' $KUBECTL_OUTPUT > $INTERNAL_REQUESTS_FILE
+
+                  # The deleteAndLog will run the CR deletion and save the operation in a structured way that
+                  # can be read easily by kubectl or journalctl
+                  function deleteAndLog() {
+                    ir=${1%:*}
+                    namespace=${1#*:}
+                    kubectl delete internalrequest $ir -n $namespace |while read logLine; do
+                      echo "INFO: namespace=${namespace} log=${logLine}"
+                    done
+                  }
+                  export -f deleteAndLog
+                  xargs -a ${INTERNAL_REQUESTS_FILE} -i -P ${MAX_PROCS} bash -c 'deleteAndLog "{}"'
+              imagePullPolicy: IfNotPresent
+              image: quay.io/konflux-ci/release-service-utils:9089cafbf36bb889b4b73d8c2965613810f13736
+              volumeMounts:
+                - mountPath: /var/tmp
+                  name: temp-directory
+              resources:
+                limits:
+                  cpu: 200m
+                  memory: 300Mi
+                requests:
+                  cpu: 100m
+                  memory: 200Mi
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+                readOnlyRootFilesystem: true
+                runAsNonRoot: true
+                seccompProfile:
+                  type: RuntimeDefault

--- a/components/konflux-operator/rings/ring-2/base/cr/release/e2e-release-pipeline-resources-role.yaml
+++ b/components/konflux-operator/rings/ring-2/base/cr/release/e2e-release-pipeline-resources-role.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: e2e-release-pipeline-resources-role
+rules:
+- apiGroups:
+  - pipelinesascode.tekton.dev
+  resources:
+  - repositories
+  verbs:
+  - get
+  - list
+  - watch

--- a/components/konflux-operator/rings/ring-2/base/cr/release/external-secrets/kustomization.yaml
+++ b/components/konflux-operator/rings/ring-2/base/cr/release/external-secrets/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - release-service-github-token.yaml

--- a/components/konflux-operator/rings/ring-2/base/cr/release/external-secrets/release-service-github-token.yaml
+++ b/components/konflux-operator/rings/ring-2/base/cr/release/external-secrets/release-service-github-token.yaml
@@ -1,0 +1,21 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: release-service-github-token
+  namespace: release-service
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  data:
+    - secretKey: token
+      remoteRef:
+        key: production/release/github/konflux-release-service
+        property: token
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: appsre-stonesoup-vault
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    name: release-service-github-token

--- a/components/konflux-operator/rings/ring-2/base/cr/release/ibm-public-key-clusterrole.yaml
+++ b/components/konflux-operator/rings/ring-2/base/cr/release/ibm-public-key-clusterrole.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: release-pipeline-ibm-public-key
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    resourceNames:
+      - ibm-public-key
+      - ibm-public-key-stage
+    verbs:
+      - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: release-pipeline-ibm-public-key
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: release-pipeline-ibm-public-key
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: system:serviceaccounts:release-service

--- a/components/konflux-operator/rings/ring-2/base/cr/release/kustomization.yaml
+++ b/components/konflux-operator/rings/ring-2/base/cr/release/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+resources:
+  - cronjobs
+  - external-secrets
+  - signing_configs.yaml
+  - release-team.yaml
+  - release-service-configurator-role.yaml
+  - ibm-public-key-clusterrole.yaml
+  - monitor-pipeline-role.yaml
+  - e2e-release-pipeline-resources-role.yaml
+patches:
+  - path: release-service.yaml

--- a/components/konflux-operator/rings/ring-2/base/cr/release/monitor-pipeline-role.yaml
+++ b/components/konflux-operator/rings/ring-2/base/cr/release/monitor-pipeline-role.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: monitor-pipeline-role
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "pods/log"]
+    verbs: ["get", "watch", "list"]
+  - apiGroups: ["tekton.dev"]
+    resources: ["pipelineruns", "pipelines"]
+    verbs: ["get", "watch", "list"]

--- a/components/konflux-operator/rings/ring-2/base/cr/release/release-service-configurator-role.yaml
+++ b/components/konflux-operator/rings/ring-2/base/cr/release/release-service-configurator-role.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: release-service-configurator
+  namespace: release-service
+rules:
+  - apiGroups:
+      - appstudio.redhat.com
+    resources:
+      - releaseserviceconfigs
+    verbs:
+      - '*'

--- a/components/konflux-operator/rings/ring-2/base/cr/release/release-service.yaml
+++ b/components/konflux-operator/rings/ring-2/base/cr/release/release-service.yaml
@@ -1,0 +1,66 @@
+apiVersion: konflux.konflux-ci.dev/v1alpha1
+kind: Konflux
+metadata:
+  name: konflux
+spec:
+  releaseService:
+    spec:
+      debug: false
+      emptyDirOverrides:
+        - url: ".*"
+          revision: ".*"
+          pathInRepo: "pipelines/managed/fbc-release/fbc-release.yaml"
+        - url: ".*"
+          revision: ".*"
+          pathInRepo: "pipelines/managed/push-artifacts-to-cdn/push-artifacts-to-cdn.yaml"
+        - url: ".*"
+          revision: ".*"
+          pathInRepo: "pipelines/managed/push-disk-images-to-cdn/push-disk-images-to-cdn.yaml"
+        - url: ".*"
+          revision: ".*"
+          pathInRepo: "pipelines/managed/push-disk-images-to-marketplaces/push-disk-images-to-marketplaces.yaml"
+        - url: ".*"
+          revision: ".*"
+          pathInRepo: "pipelines/managed/push-oot-kmods/push-oot-kmods.yaml"
+        - url: ".*"
+          revision: ".*"
+          pathInRepo: "pipelines/managed/push-rpm-to-koji/push-rpm-to-koji.yaml"
+        - url: ".*"
+          revision: ".*"
+          pathInRepo: "pipelines/managed/push-tekton-task-bundles-to-external-registry/push-tekton-task-bundles-to-external-registry.yaml"
+        - url: ".*"
+          revision: ".*"
+          pathInRepo: "pipelines/managed/push-to-addons-registry/push-to-addons-registry.yaml"
+        - url: ".*"
+          revision: ".*"
+          pathInRepo: "pipelines/managed/push-to-external-registry/push-to-external-registry.yaml"
+        - url: ".*"
+          revision: ".*"
+          pathInRepo: "pipelines/managed/release-to-github/release-to-github.yaml"
+        - url: ".*"
+          revision: ".*"
+          pathInRepo: "pipelines/managed/release-to-mrrc/release-to-mrrc.yaml"
+        - url: ".*"
+          revision: ".*"
+          pathInRepo: "pipelines/managed/rh-advisories/rh-advisories.yaml"
+        - url: ".*"
+          revision: ".*"
+          pathInRepo: "pipelines/managed/rh-push-to-external-registry/rh-push-to-external-registry.yaml"
+        - url: ".*"
+          revision: ".*"
+          pathInRepo: "pipelines/managed/rh-push-to-registry-redhat-io/rh-push-to-registry-redhat-io.yaml"
+        - url: ".*"
+          revision: ".*"
+          pathInRepo: "pipelines/managed/rhtap-service-push/rhtap-service-push.yaml"
+        - url: ".*"
+          revision: ".*"
+          pathInRepo: "pipelines/managed/push-rpms-to-pulp/push-rpms-to-pulp.yaml"
+      releaseControllerManager:
+        manager:
+          resources:
+            requests:
+              cpu: 100m
+              memory: 8Gi
+            limits:
+              cpu: 500m
+              memory: 8Gi

--- a/components/konflux-operator/rings/ring-2/base/cr/release/release-team.yaml
+++ b/components/konflux-operator/rings/ring-2/base/cr/release/release-team.yaml
@@ -1,0 +1,27 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: release-service-maintainers
+  namespace: release-service
+subjects:
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: konflux-release-team
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: component-maintainer
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: release-service-configurators
+  namespace: release-service
+subjects:
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: konflux-release-team
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: release-service-configurator

--- a/components/konflux-operator/rings/ring-2/base/cr/release/signing_configs.yaml
+++ b/components/konflux-operator/rings/ring-2/base/cr/release/signing_configs.yaml
@@ -1,0 +1,75 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    io.kompose.service: "hacbs-signing-pipeline"
+    app: "hacbs-signing-pipeline"
+    env: production
+    paas.redhat.com/appcode: RSIG-001
+  name: "hacbs-signing-pipeline-config-redhatbeta2"
+  namespace: release-service
+data:
+  PYXIS_URL: "https://pyxis.engineering.redhat.com"
+  SIG_KEY_ID: "4096R/F21541EB SHA-256"
+  SIG_KEY_NAME: "beta2"
+  PYXIS_SSL_CERT_FILE_NAME: "hacbs-signing-pipeline.pem"
+  PYXIS_SSL_CERT_SECRET_NAME: "hacbs-signing-pipeline-certs"
+  PYXIS_SSL_KEY_FILE_NAME: "hacbs-signing-pipeline.key"
+  UMB_SSL_CERT_FILE_NAME: "hacbs-signing-pipeline.pem"
+  UMB_SSL_CERT_SECRET_NAME: "hacbs-signing-pipeline-certs"
+  UMB_SSL_KEY_FILE_NAME: "hacbs-signing-pipeline.key"
+  UMB_CLIENT_NAME: "hacbs-signing-pipeline"
+  UMB_URL: "umb.api.redhat.com"
+  UMB_LISTEN_TOPIC: VirtualTopic.eng.robosignatory.hacbs.sign
+  UMB_PUBLISH_TOPIC: VirtualTopic.eng.hacbs-signing-pipeline.hacbs.sign
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    io.kompose.service: "hacbs-signing-pipeline"
+    app: "hacbs-signing-pipeline"
+    env: production
+    paas.redhat.com/appcode: RSIG-001
+  name: "hacbs-signing-pipeline-config-redhatrelease2"
+  namespace: release-service
+data:
+  PYXIS_URL: "https://pyxis.engineering.redhat.com"
+  SIG_KEY_ID: "4096R/FD431D51 SHA-256"
+  SIG_KEY_NAME: "redhatrelease2"
+  PYXIS_SSL_CERT_FILE_NAME: "hacbs-signing-pipeline.pem"
+  PYXIS_SSL_CERT_SECRET_NAME: "hacbs-signing-pipeline-certs"
+  PYXIS_SSL_KEY_FILE_NAME: "hacbs-signing-pipeline.key"
+  UMB_SSL_CERT_FILE_NAME: "hacbs-signing-pipeline.pem"
+  UMB_SSL_CERT_SECRET_NAME: "hacbs-signing-pipeline-certs"
+  UMB_SSL_KEY_FILE_NAME: "hacbs-signing-pipeline.key"
+  UMB_CLIENT_NAME: "hacbs-signing-pipeline"
+  UMB_URL: "umb.api.redhat.com"
+  UMB_LISTEN_TOPIC: VirtualTopic.eng.robosignatory.hacbs.sign
+  UMB_PUBLISH_TOPIC: VirtualTopic.eng.hacbs-signing-pipeline.hacbs.sign
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    io.kompose.service: "hacbs-signing-pipeline"
+    app: "hacbs-signing-pipeline"
+    env: stage
+    paas.redhat.com/appcode: RSIG-001
+  name: "hacbs-signing-pipeline-config-staging-redhatrelease2"
+  namespace: release-service
+data:
+  PYXIS_URL: "https://pyxis.stage.engineering.redhat.com"
+  SIG_KEY_ID: "4096R/37036783 SHA-256"
+  SIG_KEY_NAME: "redhate2etesting"
+  PYXIS_SSL_CERT_FILE_NAME: "hacbs-signing-pipeline.pem"
+  PYXIS_SSL_CERT_SECRET_NAME: "hacbs-signing-pipeline-staging-certs"
+  PYXIS_SSL_KEY_FILE_NAME: "hacbs-signing-pipeline.key"
+  UMB_SSL_CERT_FILE_NAME: "hacbs-signing-pipeline.pem"
+  UMB_SSL_CERT_SECRET_NAME: "hacbs-signing-pipeline-certs"
+  UMB_SSL_KEY_FILE_NAME: "hacbs-signing-pipeline.key"
+  UMB_CLIENT_NAME: "hacbs-signing-pipeline"
+  UMB_URL: "umb.api.redhat.com"
+  UMB_LISTEN_TOPIC: VirtualTopic.eng.robosignatory.hacbs.sign
+  UMB_PUBLISH_TOPIC: VirtualTopic.eng.hacbs-signing-pipeline.hacbs.sign

--- a/components/konflux-operator/rings/ring-2/base/cr/telemetry/external-secrets/kustomization.yaml
+++ b/components/konflux-operator/rings/ring-2/base/cr/telemetry/external-secrets/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - segment-write-key.yaml

--- a/components/konflux-operator/rings/ring-2/base/cr/telemetry/external-secrets/segment-write-key.yaml
+++ b/components/konflux-operator/rings/ring-2/base/cr/telemetry/external-secrets/segment-write-key.yaml
@@ -1,0 +1,21 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: segment-write-key
+  namespace: segment-bridge
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  data:
+    - secretKey: SEGMENT_WRITE_KEY
+      remoteRef:
+        key: production/service-enhancement/segment-write-key
+        property: SEGMENT_WRITE_KEY
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: appsre-stonesoup-vault
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    name: segment-write-key

--- a/components/konflux-operator/rings/ring-2/base/cr/telemetry/kustomization.yaml
+++ b/components/konflux-operator/rings/ring-2/base/cr/telemetry/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+resources:
+  - external-secrets
+patches:
+  - path: telemetry.yaml

--- a/components/konflux-operator/rings/ring-2/base/cr/telemetry/telemetry.yaml
+++ b/components/konflux-operator/rings/ring-2/base/cr/telemetry/telemetry.yaml
@@ -1,0 +1,18 @@
+apiVersion: konflux.konflux-ci.dev/v1alpha1
+kind: Konflux
+metadata:
+  name: konflux
+spec:
+  telemetry:
+    enabled: true
+    spec:
+      segmentKeySecretRef:
+        name: segment-write-key
+        key: SEGMENT_WRITE_KEY
+      cronJob:
+        env:
+          # tekton-results is deployed in its own namespace on this cluster
+          # (see components/pipeline-service), not in openshift-pipelines as
+          # the operator's default assumes.
+          - name: TEKTON_RESULTS_API_ADDR
+            value: tekton-results-api-service.tekton-results.svc.cluster.local:8080

--- a/components/konflux-operator/rings/ring-2/base/invariant/konflux.yaml
+++ b/components/konflux-operator/rings/ring-2/base/invariant/konflux.yaml
@@ -1,0 +1,7 @@
+apiVersion: konflux.konflux-ci.dev/v1alpha1
+kind: Konflux
+metadata:
+  name: konflux
+spec:
+  # Base must remain environment-agnostic.
+  # Team-owned and environment-specific sections are layered via patches.

--- a/components/konflux-operator/rings/ring-2/base/invariant/kustomization.yaml
+++ b/components/konflux-operator/rings/ring-2/base/invariant/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - https://github.com/konflux-ci/konflux-ci/operator/config/default?ref=7511256955d20a3308afbac13b904f07cd26c0f4
+  - konflux.yaml
+
+images:
+  - name: localhost/konflux-operator
+    newName: quay.io/konflux-ci/konflux-operator
+    newTag: 7511256955d20a3308afbac13b904f07cd26c0f4

--- a/components/konflux-operator/rings/ring-2/base/kustomization.yaml
+++ b/components/konflux-operator/rings/ring-2/base/kustomization.yaml
@@ -1,0 +1,21 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - invariant
+
+components:
+  - cr/build
+  - cr/image-controller
+  - cr/integration
+  - cr/konflux-info
+  - cr/konflux-ui
+  - cr/namespace-lister
+  - cr/release
+  - cr/enterprise-contract
+  - cr/konflux-rbac
+  - cr/telemetry
+
+patches:
+  - path: release-config.yaml
+  - path: manager-resources-patch.yaml

--- a/components/konflux-operator/rings/ring-2/base/manager-resources-patch.yaml
+++ b/components/konflux-operator/rings/ring-2/base/manager-resources-patch.yaml
@@ -1,0 +1,17 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: konflux-operator-controller-manager
+  namespace: konflux-operator
+spec:
+  template:
+    spec:
+      containers:
+        - name: manager
+          resources:
+            limits:
+              cpu: 500m
+              memory: 1Gi
+            requests:
+              cpu: 500m
+              memory: 1Gi

--- a/components/konflux-operator/rings/ring-2/base/release-config.yaml
+++ b/components/konflux-operator/rings/ring-2/base/release-config.yaml
@@ -1,0 +1,11 @@
+apiVersion: konflux.konflux-ci.dev/v1alpha1
+kind: Konflux
+metadata:
+  name: konflux
+spec:
+  certManager:
+    createClusterIssuer: true
+  internalRegistry:
+    enabled: false
+  defaultTenant:
+    enabled: false

--- a/components/konflux-operator/rings/ring-2/kflux-lw-p01/build/OWNERS
+++ b/components/konflux-operator/rings/ring-2/kflux-lw-p01/build/OWNERS
@@ -1,0 +1,16 @@
+# See the OWNERS docs: https://go.k8s.io/owners
+# Should be kept in sync with components/monitoring/grafana/base/dashboards/build-service/OWNERS
+
+approvers:
+- mmorhun
+- rcerven
+- mkosiarc
+- tisutisu
+- chmeliik
+
+reviewers:
+- mmorhun
+- rcerven
+- mkosiarc
+- tisutisu
+- chmeliik

--- a/components/konflux-operator/rings/ring-2/kflux-lw-p01/build/external-secret-path-patch.yaml
+++ b/components/konflux-operator/rings/ring-2/kflux-lw-p01/build/external-secret-path-patch.yaml
@@ -1,0 +1,3 @@
+- op: add
+  path: /spec/dataFrom/0/extract/key
+  value: production/platform/ansible/generated/kflux-lw-p01/github-app

--- a/components/konflux-operator/rings/ring-2/kflux-lw-p01/build/webhook-urls-patch.yaml
+++ b/components/konflux-operator/rings/ring-2/kflux-lw-p01/build/webhook-urls-patch.yaml
@@ -1,0 +1,10 @@
+apiVersion: konflux.konflux-ci.dev/v1alpha1
+kind: Konflux
+metadata:
+  name: konflux
+spec:
+  buildService:
+    spec:
+      webhookURLs:
+        "https://github.com": "https://smee-smee.apps.rosa.kflux-c-prd-e01.yo5u.p3.openshiftapps.com/redhathooklwp01"
+        "https://gitlab.com": "https://smee-smee.apps.rosa.kflux-c-prd-e01.yo5u.p3.openshiftapps.com/redhathooklwp01"

--- a/components/konflux-operator/rings/ring-2/kflux-lw-p01/integration/OWNERS
+++ b/components/konflux-operator/rings/ring-2/kflux-lw-p01/integration/OWNERS
@@ -1,0 +1,21 @@
+# See the OWNERS docs: https://go.k8s.io/owners
+
+approvers:
+- dirgim
+- jsztuka
+- kasemAlem
+- sonam1412
+- Josh-Everett
+- 14rcole
+- jencull
+- NigelByrne1
+
+reviewers:
+- dirgim
+- jsztuka
+- kasemAlem
+- sonam1412
+- Josh-Everett
+- 14rcole
+- jencull
+- NigelByrne1

--- a/components/konflux-operator/rings/ring-2/kflux-lw-p01/integration/external-secret-path-patch.yaml
+++ b/components/konflux-operator/rings/ring-2/kflux-lw-p01/integration/external-secret-path-patch.yaml
@@ -1,0 +1,3 @@
+- op: add
+  path: /spec/dataFrom/0/extract/key
+  value: production/platform/ansible/generated/kflux-lw-p01/github-app

--- a/components/konflux-operator/rings/ring-2/kflux-lw-p01/konflux-info/OWNERS
+++ b/components/konflux-operator/rings/ring-2/kflux-lw-p01/konflux-info/OWNERS
@@ -1,0 +1,47 @@
+# See the OWNERS docs: https://go.k8s.io/owners
+
+approvers:
+# infra-team
+- sadlerap
+- eisraeli
+- filariow
+- gbenhaim
+- hugares
+- manish-jangra
+# sre-team
+- dgregor
+- jdcasey
+# ui-team
+- abhinandan13jan
+- caugello
+- CryptoRodeo
+- JoaoPedroPP
+- Katka92
+- sahil143
+- rrosatti
+- StanislavJochman
+# others
+- arewm
+
+reviewers:
+# infra-team
+- sadlerap
+- eisraeli
+- filariow
+- gbenhaim
+- hugares
+- manish-jangra
+# sre-team
+- dgregor
+- jdcasey
+# ui-team
+- abhinandan13jan
+- caugello
+- CryptoRodeo
+- JoaoPedroPP
+- Katka92
+- sahil143
+- rrosatti
+- StanislavJochman
+# others
+- arewm

--- a/components/konflux-operator/rings/ring-2/kflux-lw-p01/konflux-info/info-patch.yaml
+++ b/components/konflux-operator/rings/ring-2/kflux-lw-p01/konflux-info/info-patch.yaml
@@ -1,0 +1,13 @@
+apiVersion: konflux.konflux-ci.dev/v1alpha1
+kind: Konflux
+metadata:
+  name: konflux
+spec:
+  info:
+    spec:
+      publicInfo:
+        visibility: private
+        statusPageUrl: "https://grafana.app-sre.devshift.net/d/aes1ns0htwni8a/konflux-status-page?var-cluster=kflux-lw-p01"
+        integrations:
+          github:
+            application_url: "https://github.com/apps/red-hat-konflux-kflux-lw-p01"

--- a/components/konflux-operator/rings/ring-2/kflux-lw-p01/konflux-ui/OWNERS
+++ b/components/konflux-operator/rings/ring-2/kflux-lw-p01/konflux-ui/OWNERS
@@ -1,0 +1,47 @@
+# See the OWNERS docs: https://go.k8s.io/owners
+
+approvers:
+# infra-team
+- sadlerap
+- eisraeli
+- filariow
+- gbenhaim
+- hugares
+- manish-jangra
+# sre-team
+- dgregor
+- jdcasey
+# ui-team
+- abhinandan13jan
+- caugello
+- CryptoRodeo
+- JoaoPedroPP
+- Katka92
+- sahil143
+- rrosatti
+- StanislavJochman
+# others
+- arewm
+
+reviewers:
+# infra-team
+- sadlerap
+- eisraeli
+- filariow
+- gbenhaim
+- hugares
+- manish-jangra
+# sre-team
+- dgregor
+- jdcasey
+# ui-team
+- abhinandan13jan
+- caugello
+- CryptoRodeo
+- JoaoPedroPP
+- Katka92
+- sahil143
+- rrosatti
+- StanislavJochman
+# others
+- arewm

--- a/components/konflux-operator/rings/ring-2/kflux-lw-p01/konflux-ui/ui-patch.yaml
+++ b/components/konflux-operator/rings/ring-2/kflux-lw-p01/konflux-ui/ui-patch.yaml
@@ -1,0 +1,12 @@
+apiVersion: konflux.konflux-ci.dev/v1alpha1
+kind: Konflux
+metadata:
+  name: konflux
+spec:
+  ui:
+    spec:
+      runtimeConfig:
+        chatBot:
+          enabled: false
+        monitoring:
+          cluster: kflux-lw-p01

--- a/components/konflux-operator/rings/ring-2/kflux-lw-p01/kustomization.yaml
+++ b/components/konflux-operator/rings/ring-2/kflux-lw-p01/kustomization.yaml
@@ -1,0 +1,24 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../base
+
+patches:
+  - path: build/external-secret-path-patch.yaml
+    target:
+      name: pipelines-as-code-secret
+      namespace: build-service
+      group: external-secrets.io
+      version: v1
+      kind: ExternalSecret
+  - path: integration/external-secret-path-patch.yaml
+    target:
+      name: pipelines-as-code-secret
+      namespace: integration-service
+      group: external-secrets.io
+      version: v1
+      kind: ExternalSecret
+  - path: build/webhook-urls-patch.yaml
+  - path: konflux-info/info-patch.yaml
+  - path: konflux-ui/ui-patch.yaml

--- a/components/konflux-operator/rings/ring-2/kflux-lw-p01/namespace-lister/OWNERS
+++ b/components/konflux-operator/rings/ring-2/kflux-lw-p01/namespace-lister/OWNERS
@@ -1,0 +1,7 @@
+# See the OWNERS docs: https://go.k8s.io/owners
+
+approvers:
+- konflux-infra-team
+
+reviewers:
+- konflux-infra-team


### PR DESCRIPTION
Add ring-2 directory structure under components/konflux-operator/rings/ targeting the kflux-lw-p01 cluster. This is the first production ring for the operator, following the same pattern used in ring-1 for staging.

Ring-2 base (seeded from ring-1, updated for production):
- Same operator ref 7511256, same CR components, same release-config
- Updated all ExternalSecret vault paths from staging/ to production/:
  - build + integration PaC secret: production/pipeline-service/github-app
  - image-controller quaytoken: production/build/image-controller
  - image-controller image-pruner-token: production/build/image-pruner-token
  - telemetry segment-write-key: production/service-enhancement/segment-write-key
  - release github-token: production/release/github/konflux-release-service
- Updated image-pruner memory from 1Gi/2Gi (staging) to 8Gi/8Gi to match legacy production values
- Updated integration-service manager CPU from 100m/500m (staging) to 200m/600m to match legacy production values
- Updated konflux-info for production:
  - environment: staging -> production
  - sbom_server URLs: atlas.build.stage.devshift.net -> atlas.build.devshift.net
  - bombino URL: bombino.preprod.api.redhat.com -> bombino.api.redhat.com
- Updated konflux-ui for production:
  - monitoring environment: staging -> production
  - monitoring sampleRateErrors: 1.0 -> 0.2
  - Removed watson ExternalSecret (staging-only, not used in production)
- Updated namespace-lister resources to match legacy production: 4000m CPU / 6Gi memory (moved from per-cluster to base)
- Updated release signing_configs.yaml with production keys, Pyxis URLs, and cert secret names
- Added release-service-github-token ExternalSecret

Ring-2/kflux-lw-p01 cluster overlay:
- Per-cluster vault path overrides (production/pipeline-service/kflux-lw-p01/github-app)
- Webhook URLs via smee (placeholder — see unknown values below)
- konflux-info patch (status page URL, GitHub app URL, visibility: private)
- konflux-ui patch (monitoring cluster name, chatBot disabled)
- OWNERS files matching ring-1/lightwell-dev ownership

ArgoCD legacy service exclusion:
- Moved kflux-lw-p01 from staging-downstream to production-downstream exclusion (it is a production cluster)
- Created exclude-operator-owned-clusters.yaml and preserve-resources-on-deletion.yaml in production-downstream
- Added exclude + preserve patches for all 9 operator-owned ApplicationSets: application-api, build-service, integration, image-controller, namespace-lister, konflux-info, konflux-ui, konflux-rbac, release

Parity checks completed (kustomize build comparison):
- build-service: All infra-authored resources (RBAC, ExternalSecrets) match legacy production. Operator deploys remaining at runtime.
- enterprise-contract: ECP policies identical to legacy. RBAC and CRDs handled by operator at runtime.
- image-controller: RBAC identical, ExternalSecret paths correct, resource limits now match legacy production.
- integration: All 9 directly-comparable resources byte-identical to legacy. Console URL handled by operator at runtime (reads from KonfluxUI CR status). Manager CPU/memory now match legacy production.
- konflux-info: environment, sbom_server, bombino URLs updated to production. imageProxy auto-detected by operator. RBAC roles provided by operator defaults. cluster-config proxy values match.
- konflux-rbac: konflux-tester-internalbot-actions identical to legacy. 5 bot ClusterRoles (externalpuller, integrationtest, model, secrets, viewer) not in operator — same gap as ring-1, preserved via orphaning.
- konflux-ui: proxy/dex replicas (3/3), proxy resources, kite and kubearchive endpoints all match legacy. Monitoring updated to production values. Watson removed (staging-only). runAsUser, service certs, OAuth handled by operator at runtime.
- namespace-lister: Resources updated to match legacy production (4000m CPU / 6Gi memory) and moved from per-cluster to base. Replicas (3), cache resync (10m), log level match legacy. NetworkPolicies, RBAC, TLS deployed by operator at runtime.
- release: signing_configs replaced with production values (keys, Pyxis URLs, cert names). ExternalSecret for github-token added. ReleaseServiceConfig (emptyDirOverrides) identical to legacy. Manager resources (100m/8Gi, 500m/8Gi) match. RBAC identical or runtime-deployed. remove-expired-releases CronJob omitted (suspended in legacy). release-service-monitor not in operator — same gap as ring-1.
- telemetry: Operator-only component (no legacy equivalent). segment-write-key vault path updated to production. CronJob env (TEKTON_RESULTS_API_ADDR) matches cluster layout. All runtime resources deployed by operator.

~~Unknown values (to be filled before merge):~~
~~- `components/konflux-operator/rings/ring-2/kflux-lw-p01/build/webhook-urls-patch.yaml` lines 9-10: smee webhook URLs are set to `PLACEHOLDER_SMEE_URL`. Replace with actual smee endpoint for kflux-lw-p01.~~

~~- `components/konflux-operator/rings/ring-2/kflux-lw-p01/build/external-secret-path-patch.yaml` and `components/konflux-operator/rings/ring-2/kflux-lw-p01/integration/external-secret-path-patch.yaml`: vault path is `production/pipeline-service/kflux-lw-p01/github-app`. Needs confirmation that this path exists in Vault.~~

~~- `components/konflux-operator/rings/ring-2/kflux-lw-p01/konflux-info/info-patch.yaml` line 13: GitHub App URL is `https://github.com/apps/kflux-lw-p01`. Naming is inconsistent across clusters (e.g. `red-hat-konflux-*`, `konflux-*`). Needs confirmation of the actual registered app name.~~

Add the operator ApplicationSet to the `rd-production` overlay so ArgoCD
deploys ring-2 to `kflux-lw-p01`.
- Create `argo-cd-apps/overlays/rd-production/konflux-operator/` with a
  self-contained ApplicationSet (no shared k-component labels — same
  approach as staging, where the list only includes clusters with
  directories)
- The clusters generator selects all production tenant clusters and
  defaults to `empty-base/empty-base` (deploys nothing)
- The list generator overrides `kflux-lw-p01` →
  `rings/ring-2/kflux-lw-p01`
- As more clusters are onboarded to the operator, add entries to the
  AppSet list and create their cluster overlay directories

Together with the `exclude-operator-owned-clusters.yaml` patches in
`production-downstream`, this completes the handoff: legacy ApplicationSets
stop generating Applications for `kflux-lw-p01`, and the operator
ApplicationSet takes over.

Assisted-by: Cursor + Opus 4.6