### PR TITLE
KFLUXINFRA-4363 Add applications read access to konflux-viewer-bot-ac…

### DIFF
--- a/components/konflux-rbac/production/base/konflux-viewer-bot-actions.yaml
+++ b/components/konflux-rbac/production/base/konflux-viewer-bot-actions.yaml
@@ -29,6 +29,7 @@ rules:
 - apiGroups:
   - appstudio.redhat.com
   resources:
+  - applications
   - snapshots
   - releases
   - components


### PR DESCRIPTION
…tions

  ## What

  Add `applications` to the read-only resources in the `konflux-viewer-bot-actions` ClusterRole.

  Clusters affected: all production clusters (production/base)

  [KFLUXINFRA-4363](https://redhat.atlassian.net/browse/KFLUXINFRA-4363)

  ## Why

  Users with read-only bots had to use `konflux-model-bot-actions` (which grants create/update/patch) just to list
  applications. The viewer role should cover this use case without requiring write permissions.

  ## Validation

  - Validated in staging via PR #13619
  - `kustomize build` passes for affected production overlays

  ## Risk Assessment

  **Risk Level:** Low
  **What could go wrong:** The ClusterRole grants broader read access than intended, but `applications` is a standard Konflux  resource already readable by other roles and the change is additive (get/list/watch only).
  **Rollback:** Revert PR
  **Blast radius:** All production clusters consuming `components/konflux-rbac/production/base/`

[KFLUXINFRA-4363]: https://redhat.atlassian.net/browse/KFLUXINFRA-4363?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ