### PR TITLE
fix(PVO11Y-5480): KAExporter update for tenant UX SLO calculations

### DIFF
--- a/components/monitoring/exporters/kaexporter/staging/base/kustomization.yaml
+++ b/components/monitoring/exporters/kaexporter/staging/base/kustomization.yaml
@@ -7,7 +7,7 @@ resources:
 images:
   - name: quay.io/redhat-appstudio/o11y
     newName: quay.io/redhat-appstudio/o11y
-    newTag: 479a668cb362d1ee0d2d4333cc4ee64867abd12d
+    newTag: efcad00e83743613bb966afe70e2e4489c6893c4
 
 patches:
   - path: ./configs/kaexporter-deployment-patch.yaml


### PR DESCRIPTION
## What

Bump kaexporter image tag in staging to pick up the tenant UX SLO threshold
change from `mean + 1*stddev` to `mean + 2*stddev`.

[PVO11Y-5480](https://redhat.atlassian.net/browse/PVO11Y-5480)

## Why

The o11y ([PR](https://github.com/redhat-appstudio/o11y/pull/1285)) changes `sloThresholdK` from 1.0 to 2.0 in kaexporter
to reduce false-positive breach signals.

## Validation

- `go test ./exporters/kaexporter/` passes in o11y repo
- Local exporter runs against stone-stg-rh01 and kflux-rhel-p01 confirmed
  expected breach reduction
- After sync: verify breach percentages on the UX SLO dashboard for the
  staging cluster match the expected reduction (~17-21% build breach vs
  current ~75-80%)

## Risk Assessment

**Risk Level:** Low
**What could go wrong:** Nothing directly
**Rollback:** Revert the PR to prior state
**Blast radius:** All staging clusters only.

[PVO11Y-5480]: https://redhat.atlassian.net/browse/PVO11Y-5480?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ