### PR TITLE
fix(pipelines-staging): use correct resolver bucket count

### DIFF
--- a/components/pipeline-service/staging/base/main-pipeline-service-configuration.yaml
+++ b/components/pipeline-service/staging/base/main-pipeline-service-configuration.yaml
@@ -1759,7 +1759,7 @@ spec:
             default-imagepullbackoff-timeout: "15m"
         config-leader-election-resolvers:
           data:
-            buckets: "8"
+            buckets: "4"
         bundleresolver-config:
           data:
             fetch-timeout: "2m"

--- a/components/pipeline-service/staging/lightwell-dev/deploy.yaml
+++ b/components/pipeline-service/staging/lightwell-dev/deploy.yaml
@@ -686,7 +686,7 @@ spec:
             default-timeout-minutes: "120"
         config-leader-election-resolvers:
           data:
-            buckets: "8"
+            buckets: "4"
         config-logging:
           data:
             loglevel.controller: info

--- a/components/pipeline-service/staging/stone-stage-p01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stage-p01/deploy.yaml
@@ -2324,7 +2324,7 @@ spec:
             default-timeout-minutes: "120"
         config-leader-election-resolvers:
           data:
-            buckets: "8"
+            buckets: "4"
         config-logging:
           data:
             loglevel.controller: info

--- a/components/pipeline-service/staging/stone-stg-rh01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stg-rh01/deploy.yaml
@@ -2324,7 +2324,7 @@ spec:
             default-timeout-minutes: "120"
         config-leader-election-resolvers:
           data:
-            buckets: "8"
+            buckets: "4"
         config-logging:
           data:
             loglevel.controller: info


### PR DESCRIPTION
After https://github.com/tektoncd/pipeline/pull/10480, when resolvers are configured as a statefulset the bucket count must match the replicacount

See also: https://redhat-internal.slack.com/archives/C02CTEB3MMF/p1786608615401769
See also: https://github.com/tektoncd/operator/issues/3957