### PR TITLE
Override pipeline controller/webhook/resolvers to build 854 in dev/staging

### DIFF
--- a/components/pipeline-service/development/main-pipeline-service-configuration.yaml
+++ b/components/pipeline-service/development/main-pipeline-service-configuration.yaml
@@ -2267,6 +2267,12 @@ spec:
     env:
       - name: AUTOINSTALL_COMPONENTS
         value: "false"
+      - name: IMAGE_PIPELINES_TEKTON_PIPELINES_CONTROLLER
+        value: "quay.io/openshift-pipeline/pipelines-controller-rhel9@sha256:825e9f059e3e3b69a180a7c12c60a9194852241d51efa344c411c9650472fc37"
+      - name: IMAGE_PIPELINES_WEBHOOK
+        value: "quay.io/openshift-pipeline/pipelines-webhook-rhel9@sha256:95fdd592e00c7be5e610d4f8e803f78e5a4485a6129f3360d4ac60cb109098ab"
+      - name: IMAGE_PIPELINES_CONTROLLER
+        value: "quay.io/openshift-pipeline/pipelines-resolvers-rhel9@sha256:c89b7c3e91b8147a441c7d31890a7da45188ce2018f992dab8803129d8ce231b"
 ---
 apiVersion: route.openshift.io/v1
 kind: Route

--- a/components/pipeline-service/staging/base/main-pipeline-service-configuration.yaml
+++ b/components/pipeline-service/staging/base/main-pipeline-service-configuration.yaml
@@ -2111,6 +2111,12 @@ spec:
     env:
       - name: AUTOINSTALL_COMPONENTS
         value: "false"
+      - name: IMAGE_PIPELINES_TEKTON_PIPELINES_CONTROLLER
+        value: "quay.io/openshift-pipeline/pipelines-controller-rhel9@sha256:825e9f059e3e3b69a180a7c12c60a9194852241d51efa344c411c9650472fc37"
+      - name: IMAGE_PIPELINES_WEBHOOK
+        value: "quay.io/openshift-pipeline/pipelines-webhook-rhel9@sha256:95fdd592e00c7be5e610d4f8e803f78e5a4485a6129f3360d4ac60cb109098ab"
+      - name: IMAGE_PIPELINES_CONTROLLER
+        value: "quay.io/openshift-pipeline/pipelines-resolvers-rhel9@sha256:c89b7c3e91b8147a441c7d31890a7da45188ce2018f992dab8803129d8ce231b"
 
 ---
 apiVersion: route.openshift.io/v1

--- a/components/pipeline-service/staging/lightwell-dev/deploy.yaml
+++ b/components/pipeline-service/staging/lightwell-dev/deploy.yaml
@@ -1058,6 +1058,12 @@ spec:
     env:
     - name: AUTOINSTALL_COMPONENTS
       value: "false"
+    - name: IMAGE_PIPELINES_TEKTON_PIPELINES_CONTROLLER
+      value: quay.io/openshift-pipeline/pipelines-controller-rhel9@sha256:825e9f059e3e3b69a180a7c12c60a9194852241d51efa344c411c9650472fc37
+    - name: IMAGE_PIPELINES_WEBHOOK
+      value: quay.io/openshift-pipeline/pipelines-webhook-rhel9@sha256:95fdd592e00c7be5e610d4f8e803f78e5a4485a6129f3360d4ac60cb109098ab
+    - name: IMAGE_PIPELINES_CONTROLLER
+      value: quay.io/openshift-pipeline/pipelines-resolvers-rhel9@sha256:c89b7c3e91b8147a441c7d31890a7da45188ce2018f992dab8803129d8ce231b
   name: openshift-pipelines-operator-rh
   source: custom-operators
   sourceNamespace: openshift-marketplace

--- a/components/pipeline-service/staging/stone-stage-p01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stage-p01/deploy.yaml
@@ -2696,6 +2696,12 @@ spec:
     env:
     - name: AUTOINSTALL_COMPONENTS
       value: "false"
+    - name: IMAGE_PIPELINES_TEKTON_PIPELINES_CONTROLLER
+      value: quay.io/openshift-pipeline/pipelines-controller-rhel9@sha256:825e9f059e3e3b69a180a7c12c60a9194852241d51efa344c411c9650472fc37
+    - name: IMAGE_PIPELINES_WEBHOOK
+      value: quay.io/openshift-pipeline/pipelines-webhook-rhel9@sha256:95fdd592e00c7be5e610d4f8e803f78e5a4485a6129f3360d4ac60cb109098ab
+    - name: IMAGE_PIPELINES_CONTROLLER
+      value: quay.io/openshift-pipeline/pipelines-resolvers-rhel9@sha256:c89b7c3e91b8147a441c7d31890a7da45188ce2018f992dab8803129d8ce231b
   name: openshift-pipelines-operator-rh
   source: custom-operators
   sourceNamespace: openshift-marketplace

--- a/components/pipeline-service/staging/stone-stg-rh01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stg-rh01/deploy.yaml
@@ -2708,6 +2708,12 @@ spec:
     env:
     - name: AUTOINSTALL_COMPONENTS
       value: "false"
+    - name: IMAGE_PIPELINES_TEKTON_PIPELINES_CONTROLLER
+      value: quay.io/openshift-pipeline/pipelines-controller-rhel9@sha256:825e9f059e3e3b69a180a7c12c60a9194852241d51efa344c411c9650472fc37
+    - name: IMAGE_PIPELINES_WEBHOOK
+      value: quay.io/openshift-pipeline/pipelines-webhook-rhel9@sha256:95fdd592e00c7be5e610d4f8e803f78e5a4485a6129f3360d4ac60cb109098ab
+    - name: IMAGE_PIPELINES_CONTROLLER
+      value: quay.io/openshift-pipeline/pipelines-resolvers-rhel9@sha256:c89b7c3e91b8147a441c7d31890a7da45188ce2018f992dab8803129d8ce231b
   name: openshift-pipelines-operator-rh
   source: custom-operators
   sourceNamespace: openshift-marketplace


### PR DESCRIPTION
## Changes
### Roll back pipeline component images to 5.0.5-854 in dev/staging
Overrides the Tekton pipeline controller, webhook, and resolver images to the previous nightly build (854, Pipeline v1.14.x) on dev and staging environments via Subscription env vars.

## Why?
After upgrading staging to 5.0.5-871 (Pipeline v1.15.0, PR #13452), PipelineRuns using remote tasks fail with CouldntGetTask / "resolution took longer than global timeout of 1m0s". The release team has been blocked for 24 hours.

### Two contributing issues identified:

1. Orphaned resolver buckets ([tektoncd/operator#3957](https://github.com/tektoncd/operator/issues/3957)) — staging runs 8 resolver buckets with 4 replicas in StatefulSet ordinal mode. Pods 0-3 own buckets 0-3; buckets 4-7 have no owner. RRs hashing to those buckets never get processed.

2. 1s requeue regression ([tektoncd/pipeline#10429](https://github.com/tektoncd/pipeline/pull/10429)) — v1.15 introduced a fixed 1-second requeue while awaiting resolution. At Konflux scale this saturates the controller workqueue, causing API server pressure, controller pod restarts (4-5 per pod), and cascading failures.

## What changed
Added IMAGE_PIPELINES_TEKTON_PIPELINES_CONTROLLER, IMAGE_PIPELINES_TEKTON_PIPELINES_WEBHOOK, and IMAGE_PIPELINES_CONTROLLER (resolvers) to the operator Subscription env, pinning all three to build 854 digests.

## Risk Assessment
**Level**: Low — reverting to the version currently running in production (854)
**What could go wrong**: Loses v1.15 fixes (stuck ResolvingTaskRef safety net, resolver status preservation). Acceptable short-term tradeoff.
**Rollback**: Remove the env var overrides, regenerate deploy configs
**Blast radius**: dev + staging only. Production unaffected.
## Validation
Build 854 is the current production version (Ring 1 deployed, healthy over the weekend)
v1.14 controller confirmed compatible with v1.15 resolvers (same resolution.tekton.dev/v1beta1 CRD contract)