### PR TITLE
fix(PVO11Y-5480): KAExporter update for production

### DIFF
--- a/components/monitoring/exporters/kaexporter/production/base/kustomization.yaml
+++ b/components/monitoring/exporters/kaexporter/production/base/kustomization.yaml
@@ -7,7 +7,7 @@ resources:
 images:
   - name: quay.io/redhat-appstudio/o11y
     newName: quay.io/redhat-appstudio/o11y
-    newTag: 479a668cb362d1ee0d2d4333cc4ee64867abd12d
+    newTag: efcad00e83743613bb966afe70e2e4489c6893c4
 
 patches:
   - path: ./configs/kaexporter-deployment-patch.yaml


### PR DESCRIPTION
## What

Bump kaexporter image tag in production to pick up the tenant UX SLO threshold
change from `mean + 1*stddev` to `mean + 2*stddev`.

Clusters affected: kflux-fedora-01, kflux-ocp-p01, kflux-osp-p01, kflux-prd-rh02,
kflux-prd-rh03, kflux-rhel-p01, stone-prd-rh01, stone-prod-p01, stone-prod-p02

[PVO11Y-5480](https://redhat.atlassian.net/browse/PVO11Y-5480)

## Why

The o11y PR #1285 changed `sloThresholdK` from 1.0 to 2.0 in kaexporter to
reduce false-positive breach signals. With k=1, breach rates on production
clusters are 70-100% across all domains, making the SLO signal meaningless.

Investigation (PVO11Y-5458) showed k=2 reduces breach rates to 17-39% at
component level and 21-66% at tenant level on kflux-rhel-p01.

Validated in staging: stone-stg-rh01 build breach dropped from 72.7% to 27.3%,
integration from 80% to 40%, matching expected reduction.

## Validation

- Staging deployment confirmed expected breach reduction on stone-stg-rh01
  and stone-stage-p01 https://github.com/redhat-appstudio/infra-deployments/pull/13623
- `go test ./exporters/kaexporter/` passes with regression test that guards
  the k=2 threshold
- After sync: verify breach percentages on the UX SLO dashboard for production
  clusters show similar reduction

## Risk Assessment

**Risk Level:** Low
**What could go wrong:** Nothing directly
**Rollback:** Revert the PR
**Blast radius:** All 9 production clusters. Effect is visible on next exporter
pod restart (cold-start recalculates all breaches with the new threshold).

[PVO11Y-5480]: https://redhat.atlassian.net/browse/PVO11Y-5480?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ