### PR TITLE
fix(): add missing konflux-rbac cluster roles

### DIFF
--- a/components/konflux-operator/rings/ring-1/base/cr/konflux-rbac/konflux-externalpuller-bot-actions.yaml
+++ b/components/konflux-operator/rings/ring-1/base/cr/konflux-rbac/konflux-externalpuller-bot-actions.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: konflux-externalpuller-bot-actions
+rules:
+- apiGroups:
+  - appstudio.redhat.com
+  resources:
+  - imagerepositories
+  verbs:
+  - get
+  - list
+  - watch

--- a/components/konflux-operator/rings/ring-1/base/cr/konflux-rbac/konflux-integrationtest-bot-actions.yaml
+++ b/components/konflux-operator/rings/ring-1/base/cr/konflux-rbac/konflux-integrationtest-bot-actions.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: konflux-integrationtest-bot-actions
+rules:
+- apiGroups:
+  - appstudio.redhat.com
+  resources:
+  - integrationtestscenarios
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete

--- a/components/konflux-operator/rings/ring-1/base/cr/konflux-rbac/konflux-model-bot-actions.yaml
+++ b/components/konflux-operator/rings/ring-1/base/cr/konflux-rbac/konflux-model-bot-actions.yaml
@@ -1,0 +1,18 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: konflux-model-bot-actions
+rules:
+- apiGroups:
+  - appstudio.redhat.com
+  resources:
+  - applications
+  - components
+  - releaseplans
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch

--- a/components/konflux-operator/rings/ring-1/base/cr/konflux-rbac/konflux-secrets-bot-actions.yaml
+++ b/components/konflux-operator/rings/ring-1/base/cr/konflux-rbac/konflux-secrets-bot-actions.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: konflux-secrets-bot-actions
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - create
+  - update
+  - patch
+  - delete

--- a/components/konflux-operator/rings/ring-1/base/cr/konflux-rbac/konflux-viewer-bot-actions.yaml
+++ b/components/konflux-operator/rings/ring-1/base/cr/konflux-rbac/konflux-viewer-bot-actions.yaml
@@ -1,0 +1,47 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: konflux-viewer-bot-actions
+rules:
+- apiGroups:
+  - tekton.dev
+  resources:
+  - pipelineruns
+  - taskruns
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
+- apiGroups:
+  - appstudio.redhat.com
+  resources:
+  - applications
+  - snapshots
+  - releases
+  - components
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - pipelinesascode.tekton.dev
+  resources:
+  - repositories
+  verbs:
+  - get
+  - list
+  - watch

--- a/components/konflux-operator/rings/ring-1/base/cr/konflux-rbac/kustomization.yaml
+++ b/components/konflux-operator/rings/ring-1/base/cr/konflux-rbac/kustomization.yaml
@@ -1,4 +1,9 @@
 apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
 resources:
+  - konflux-externalpuller-bot-actions.yaml
+  - konflux-integrationtest-bot-actions.yaml
+  - konflux-model-bot-actions.yaml
+  - konflux-secrets-bot-actions.yaml
   - konflux-tester-internalbot-actions.yaml
+  - konflux-viewer-bot-actions.yaml


### PR DESCRIPTION
Added missing konflux-rbac cluster roles for externalpuller, integrationtest, model, secrets and viewer bots.