### PR TITLE
Applying nodeSelector and tolerations to cluster monitoring operator …

### DIFF
--- a/components/monitoring/prometheus/staging/lightwell-dev/cluster-monitoring-config.yaml
+++ b/components/monitoring/prometheus/staging/lightwell-dev/cluster-monitoring-config.yaml
@@ -9,33 +9,29 @@ data:
     prometheusK8s:
       retentionSize: 10GB
       nodeSelector:
-        konflux-ci.dev/workload: konflux-tenants
+        node-role.kubernetes.io/infra: ""
       tolerations:
-        - key: "konflux-ci.dev/workload"
-          value: "konflux-tenants"
+        - key: "node-role.kubernetes.io/infra"
           effect: "NoSchedule"
-          operator: "Equal"
+          operator: "Exists"
     alertmanagerMain:
       nodeSelector:
-        konflux-ci.dev/workload: konflux-tenants
+        node-role.kubernetes.io/infra: ""
       tolerations:
-        - key: "konflux-ci.dev/workload"
-          value: "konflux-tenants"
+        - key: "node-role.kubernetes.io/infra"
           effect: "NoSchedule"
-          operator: "Equal"
+          operator: "Exists"
     thanosQuerier:
       nodeSelector:
-        konflux-ci.dev/workload: konflux-tenants
+        node-role.kubernetes.io/infra: ""
       tolerations:
-        - key: "konflux-ci.dev/workload"
-          value: "konflux-tenants"
+        - key: "node-role.kubernetes.io/infra"
           effect: "NoSchedule"
-          operator: "Equal"
+          operator: "Exists"
     prometheusOperator:
       nodeSelector:
-        konflux-ci.dev/workload: konflux-tenants
+        node-role.kubernetes.io/infra: ""
       tolerations:
-        - key: "konflux-ci.dev/workload"
-          value: "konflux-tenants"
+        - key: "node-role.kubernetes.io/infra"
           effect: "NoSchedule"
-          operator: "Equal"
+          operator: "Exists"


### PR DESCRIPTION
  ## What

  Update cluster monitoring config for lightwell-dev staging cluster to schedule monitoring components on infrastructure nodes:
  - Migrated Prometheus, Alertmanager, Thanos Querier, and Prometheus Operator from `konflux-ci.dev/workload: konflux-tenants` nodes to
  `node-role.kubernetes.io/infra` nodes
  - Updated tolerations to use `operator: "Exists"` for infra node taints

  Clusters affected: lightwell-dev (staging)

  ## Why

  Cluster monitoring components should run on dedicated infrastructure nodes rather than tenant workload nodes to ensure stable monitoring
  regardless of tenant workload conditions and resource pressure.

  ## Validation

  - `kustomize build --enable-helm components/monitoring/prometheus/staging/lightwell-dev/` passes
  - YAML syntax validated with yamllint
  - Toleration syntax verified (using `operator: "Exists"` without value field)