### PR TITLE
KFLUXINFRA-4285: (onboarding) Migrate production kueue AppSet to ring deployments ArgoCD

### DIFF
--- a/argo-cd-apps/overlays/rd-production/kueue/kueue-appset.yaml
+++ b/argo-cd-apps/overlays/rd-production/kueue/kueue-appset.yaml
@@ -1,0 +1,47 @@
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: kueue
+  labels: # Helps k-components detect this appset to apply the correct patches
+    appstudio.redhat.com/deployment-clusters: "tenant"
+spec:
+  generators:
+    - merge:
+        mergeKeys:
+          - nameNormalized
+        generators:
+          - clusters:
+              selector:
+                matchExpressions: # Ensures that no clusters are selected; k-components will replace this with the correct selector
+                  - key: appstudio.redhat.com/select-none
+                    operator: Exists
+                  - key: appstudio.redhat.com/select-none
+                    operator: DoesNotExist
+              values:
+                sourceRoot: components/kueue-rd
+                ring: "empty-base"
+                clusterDir: "empty-base"
+          - list:
+              elements: [] # Populated via k-components (or manually if the cluster list is unusual)
+
+  template:
+    metadata:
+      name: kueue-{{nameNormalized}}
+    spec:
+      project: default
+      source:
+        path: '{{values.sourceRoot}}/rings/{{values.ring}}/{{values.clusterDir}}'
+        repoURL: https://github.com/redhat-appstudio/infra-deployments.git
+        targetRevision: main
+      destination:
+        server: '{{server}}'
+      syncPolicy:
+        # automated:
+        #   prune: true
+        #   selfHeal: true
+        syncOptions:
+        - CreateNamespace=true
+        retry:
+          limit: 50
+          backoff:
+            duration: 15s

--- a/argo-cd-apps/overlays/rd-production/kueue/kustomization.yaml
+++ b/argo-cd-apps/overlays/rd-production/kueue/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - kueue-appset.yaml

--- a/argo-cd-apps/overlays/rd-production/kustomization.yaml
+++ b/argo-cd-apps/overlays/rd-production/kustomization.yaml
@@ -5,6 +5,7 @@ namespace: argocd-infra-deployments
 resources:
   - authentication
   - etcd-shield
+  - kueue
 
 components:
   - ../../k-components/deploy-to-all-production-clusters

--- a/components/kueue-rd/rings/ring-2/base/base-snapshot/kueue/kueue.yaml
+++ b/components/kueue-rd/rings/ring-2/base/base-snapshot/kueue/kueue.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: kueue.openshift.io/v1
+kind: Kueue
+metadata:
+  labels:
+    app.kubernetes.io/name: kueue-operator
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+  name: cluster
+  namespace: openshift-kueue-operator
+spec:
+  managementState: Managed
+  config:
+    integrations:
+      frameworks: # The operator requires at lest one framework to be enabled
+      - BatchJob
+      externalFrameworks:
+      - group: tekton.dev
+        version: v1
+        resource: pipelineruns

--- a/components/kueue-rd/rings/ring-2/base/base-snapshot/kueue/kustomization.yaml
+++ b/components/kueue-rd/rings/ring-2/base/base-snapshot/kueue/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- kueue.yaml
+- ns.yaml
+- operator-group.yaml
+- subscription.yaml
+
+namespace: openshift-kueue-operator

--- a/components/kueue-rd/rings/ring-2/base/base-snapshot/kueue/ns.yaml
+++ b/components/kueue-rd/rings/ring-2/base/base-snapshot/kueue/ns.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-kueue-operator
+  labels:
+    openshift.io/cluster-monitoring: "true"
+  annotations:
+    argocd.argoproj.io/sync-wave: "-4"
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true

--- a/components/kueue-rd/rings/ring-2/base/base-snapshot/kueue/operator-group.yaml
+++ b/components/kueue-rd/rings/ring-2/base/base-snapshot/kueue/operator-group.yaml
@@ -1,0 +1,8 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: openshift-kueue-operatorgroup
+  annotations:
+    argocd.argoproj.io/sync-wave: "-2"
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec: {}

--- a/components/kueue-rd/rings/ring-2/base/base-snapshot/kueue/subscription.yaml
+++ b/components/kueue-rd/rings/ring-2/base/base-snapshot/kueue/subscription.yaml
@@ -1,0 +1,14 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: openshift-kueue-operator
+  namespace: openshift-kueue-operator
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  channel: stable-v1.3
+  installPlanApproval: Automatic
+  name: kueue-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace

--- a/components/kueue-rd/rings/ring-2/base/base-snapshot/kustomization.yaml
+++ b/components/kueue-rd/rings/ring-2/base/base-snapshot/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- workload-priority-classes.yaml
+- kueue
+- tekton-kueue

--- a/components/kueue-rd/rings/ring-2/base/base-snapshot/tekton-kueue/kustomization.yaml
+++ b/components/kueue-rd/rings/ring-2/base/base-snapshot/tekton-kueue/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- monitoring
+- rbac
+
+namespace: tekton-kueue

--- a/components/kueue-rd/rings/ring-2/base/base-snapshot/tekton-kueue/monitoring/kustomization.yaml
+++ b/components/kueue-rd/rings/ring-2/base/base-snapshot/tekton-kueue/monitoring/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- tekton-kueue-webhook-sm.yaml
+- tekton-kueue-controller-sm.yaml
+- prometheus-rule.yaml
+
+namespace: tekton-kueue

--- a/components/kueue-rd/rings/ring-2/base/base-snapshot/tekton-kueue/monitoring/prometheus-rule.yaml
+++ b/components/kueue-rd/rings/ring-2/base/base-snapshot/tekton-kueue/monitoring/prometheus-rule.yaml
@@ -1,0 +1,242 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: kueue-alerts
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  groups:
+  - name: kueue.health
+    interval: 30s
+    rules:
+    - alert: KueueHighAdmissionLatency
+      expr: histogram_quantile(0.99, sum(increase(kueue_admission_attempt_duration_seconds_bucket[5m])) by (le)) > 30
+      for: 2m
+      labels:
+        severity: warning
+        component: kueue
+      annotations:
+        summary: "Kueue admission latency is high"
+        description: "99th percentile of Kueue admission attempt duration is {{ $value }}s, which is above the threshold of 30s"
+        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue.md?ref_type=heads
+        alert_team_handle: <!subteam^S05Q1P4Q2TG>
+        team: konflux-infra
+
+    - alert: KueueReplicasNotAvailable
+      expr: |
+        (
+          kube_deployment_status_replicas_available{namespace=~"openshift-kueue-operator|tekton-kueue"}
+        )
+        /
+        clamp_min(
+          kube_deployment_spec_replicas{namespace=~"openshift-kueue-operator|tekton-kueue"},
+          1
+        ) * 100 < 100
+      for: 5m
+      labels:
+        severity: warning
+        component: kueue
+      annotations:
+        summary: "Kueue deployment {{ $labels.deployment }} has unavailable replicas"
+        description: "Deployment {{ $labels.deployment }} has {{ $value }}% available replicas, which is less than 100%"
+        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue.md?ref_type=heads
+        alert_team_handle: <!subteam^S05Q1P4Q2TG>
+        team: konflux-infra
+
+    - alert: KueueHighMemoryUtilization
+      expr: |
+        (
+            container_memory_working_set_bytes{namespace=~"tekton-kueue|openshift-kueue-operator", image!=""}
+            * on(container, pod)
+            group_left
+            kube_pod_container_status_ready{namespace=~"tekton-kueue|openshift-kueue-operator"}
+        )
+            / on (pod) kube_pod_resource_limit{resource='memory',namespace=~"tekton-kueue|openshift-kueue-operator"} * 100 > 70
+      for: 5m
+      labels:
+        severity: warning
+        component: kueue
+      annotations:
+        summary: "Kueue pod {{ $labels.pod }} has high memory utilization"
+        description: "Pod {{ $labels.pod }} memory utilization is {{ $value }}%, which is above 70%"
+        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue.md?ref_type=heads
+        alert_team_handle: <!subteam^S05Q1P4Q2TG>
+        team: konflux-infra
+
+    - alert: KueueHighCPUUtilization
+      expr: |
+        (
+            pod:container_cpu_usage:sum{namespace=~"tekton-kueue|openshift-kueue-operator"}
+            * on(pod)
+            kube_pod_container_status_ready{namespace=~"tekton-kueue|openshift-kueue-operator"}
+        ) / on (pod) group_right max by (pod) (kube_pod_resource_limit{resource='cpu',namespace=~"tekton-kueue|openshift-kueue-operator"}) * 100 > 85
+      for: 5m
+      labels:
+        severity: warning
+        component: kueue
+      annotations:
+        summary: "Kueue pod {{ $labels.pod }} has high CPU utilization"
+        description: "Pod {{ $labels.pod }} CPU utilization is {{ $value }}%, which is above 85%"
+        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue.md?ref_type=heads
+        alert_team_handle: <!subteam^S05Q1P4Q2TG>
+        team: konflux-infra
+
+    - alert: KueueCELEvaluationFailures
+      expr: increase(tekton_kueue_cel_evaluations_total{result="failure"}[5m]) > 0
+      for: 1m
+      labels:
+        severity: warning
+        component: tekton-kueue
+      annotations:
+        summary: "Tekton Kueue CEL evaluation failures detected"
+        description: "{{ $value }} CEL evaluation failures occurred in the last 5 minutes"
+        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue.md?ref_type=heads
+        alert_team_handle: <!subteam^S05Q1P4Q2TG>
+        team: konflux-infra
+
+    - alert: KueueHighContainerRestarts
+      expr: |
+        increase(kube_pod_container_status_restarts_total{namespace=~"tekton-kueue|openshift-kueue-operator"}[1h])
+        * on(container, pod)
+        kube_pod_container_status_ready{namespace=~"tekton-kueue|openshift-kueue-operator"} >= 3
+      for: 0m
+      labels:
+        severity: warning
+        component: kueue
+      annotations:
+        summary: "Kueue pod {{ $labels.pod }} has high restart count"
+        description: "Pod {{ $labels.pod }} has restarted {{ $value }} times in the last hour"
+        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue.md?ref_type=heads
+        alert_team_handle: <!subteam^S05Q1P4Q2TG>
+        team: konflux-infra
+
+  - name: kueue.queue
+    interval: 30s
+    rules:
+    - alert: KueueClusterQueueNotActive
+      expr: max by (status) (kueue_cluster_queue_status{cluster_queue="cluster-pipeline-queue", status="active"}) != 1
+      for: 2m
+      labels:
+        severity: warning
+        component: kueue
+      annotations:
+        summary: "Kueue cluster queue is not active"
+        description: "Cluster queue 'cluster-pipeline-queue' is not in active state"
+        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue.md?ref_type=heads
+        alert_team_handle: <!subteam^S05Q1P4Q2TG>
+        team: konflux-infra
+
+    - alert: KueueHighPendingWorkloads
+      expr: max by (status) (kueue_pending_workloads{cluster_queue="cluster-pipeline-queue"}) > 300
+      for: 5m
+      labels:
+        severity: warning
+        component: kueue
+      annotations:
+        summary: "High number of pending workloads in Kueue"
+        description: "{{ $value }} workloads are pending in cluster queue 'cluster-pipeline-queue'"
+        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue.md?ref_type=heads
+        alert_team_handle: <!subteam^S05Q1P4Q2TG>
+        team: konflux-infra
+
+    - alert: KueueHighAdmissionWaitTime
+      expr: histogram_quantile(0.99, sum(increase(kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue"}[10m])) by (le)) > 900
+      for: 5m
+      labels:
+        severity: warning
+        component: kueue
+      annotations:
+        summary: "High admission wait time in Kueue"
+        description: "99th percentile admission wait time is {{ $value }}s, which is above 15 minutes"
+        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue.md?ref_type=heads
+        alert_team_handle: <!subteam^S05Q1P4Q2TG>
+        team: konflux-infra
+
+    - alert: KueueHighResourceReservation
+      expr: max by (resource) (kueue_cluster_queue_resource_reservation{cluster_queue="cluster-pipeline-queue"} / kueue_cluster_queue_nominal_quota{cluster_queue="cluster-pipeline-queue"} * 100) > 90
+      for: 5m
+      labels:
+        severity: warning
+        component: kueue
+      annotations:
+        summary: "High resource reservation in Kueue cluster queue"
+        description: "Resource {{ $labels.resource }} reservation is {{ $value }}% of nominal quota, which is above 90%"
+        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue.md?ref_type=heads
+        alert_team_handle: <!subteam^S05Q1P4Q2TG>
+        team: konflux-infra
+
+    - alert: KueueLowResourceUsage
+      expr: max by (resource) (kueue_cluster_queue_resource_usage{cluster_queue="cluster-pipeline-queue"} / kueue_cluster_queue_resource_reservation{cluster_queue="cluster-pipeline-queue"} * 100) < 50
+      for: 10m
+      labels:
+        severity: info
+        component: kueue
+      annotations:
+        summary: "Low resource usage efficiency in Kueue"
+        description: "Resource {{ $labels.resource }} usage is only {{ $value }}% of reservation, indicating potential overprovisioning"
+        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue.md?ref_type=heads
+        alert_team_handle: <!subteam^S05Q1P4Q2TG>
+        team: konflux-infra
+
+    - alert: KueueHighPipelineDeletionDuration
+      expr: histogram_quantile(0.99, sum by (le) (increase(watcher_pipelinerun_delete_duration_seconds_bucket[10m]))) > 300
+      for: 5m
+      labels:
+        severity: warning
+        component: pipeline-watcher
+      annotations:
+        summary: "High PipelineRun deletion duration"
+        description: "99th percentile PipelineRun deletion duration is {{ $value }}s, which is above 5 minutes"
+        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue.md?ref_type=heads
+        alert_team_handle: <!subteam^S05Q1P4Q2TG>
+        team: konflux-infra
+
+  - name: kueue.deadman
+    interval: 60s
+    rules:
+    - alert: KueueMetricsDown
+      expr: up{job=~".*kueue.*"} == 0
+      for: 5m
+      labels:
+        severity: warning
+        component: kueue
+      annotations:
+        summary: "Kueue metrics endpoint is down"
+        description: "Kueue metrics endpoint {{ $labels.instance }} for job {{ $labels.job }} has been down for more than 5 minutes"
+        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue.md?ref_type=heads
+        alert_team_handle: <!subteam^S05Q1P4Q2TG>
+        team: konflux-infra
+
+    - alert: KueueNoRecentAdmissions
+      expr: increase(kueue_admitted_workloads_total[60m]) == 0
+      for: 60m
+      labels:
+        severity: warning
+        component: kueue
+      annotations:
+        summary: "No recent workload admissions in Kueue"
+        description: "No workloads have been admitted in the last hour, which might indicate a problem with the admission process"
+        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue.md?ref_type=heads
+        alert_team_handle: <!subteam^S05Q1P4Q2TG>
+        team: konflux-infra
+
+    - alert: KueueMutatingWebhookLowSuccessRate
+      expr: |
+        100 * sum(increase(apiserver_admission_webhook_request_total{
+          name="pipelinerun-kueue-defaulter.tekton-kueue.io", code=~"2.."
+        }[10m]))
+        /
+        sum(increase(apiserver_admission_webhook_request_total{
+          name="pipelinerun-kueue-defaulter.tekton-kueue.io"
+        }[10m]))
+        < 99
+      for: 10m
+      labels:
+        severity: warning
+        component: kueue
+      annotations:
+        summary: "Kueue mutating webhook success rate is below 99%"
+        description: "The mutating webhook 'pipelinerun-kueue-defaulter.tekton-kueue.io' has had a success rate below 99% over the past 10 minutes. Possible causes include webhook errors, rejections, or unreachability (e.g., code=600)."
+        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue.md?ref_type=heads
+        alert_team_handle: <!subteam^S05Q1P4Q2TG>
+        team: konflux-infra

--- a/components/kueue-rd/rings/ring-2/base/base-snapshot/tekton-kueue/monitoring/tekton-kueue-controller-sm.yaml
+++ b/components/kueue-rd/rings/ring-2/base/base-snapshot/tekton-kueue/monitoring/tekton-kueue-controller-sm.yaml
@@ -1,0 +1,26 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: tekton-kueue-controller
+  annotations:
+    argocd.argoproj.io/sync-wave: "11"
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  endpoints:
+  - path: /metrics
+    interval: 15s
+    port: https
+    scheme: https
+    bearerTokenSecret:
+      name: "metrics-reader"
+      key: token
+    tlsConfig:
+      serverName: tekton-kueue-controller-manager-metrics-service.tekton-kueue.svc.cluster.local
+      insecureSkipVerify: false
+      ca:
+        secret:
+          name: controller-manager-metrics-server-cert
+          key: ca.crt
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: tekton-kueue

--- a/components/kueue-rd/rings/ring-2/base/base-snapshot/tekton-kueue/monitoring/tekton-kueue-webhook-sm.yaml
+++ b/components/kueue-rd/rings/ring-2/base/base-snapshot/tekton-kueue/monitoring/tekton-kueue-webhook-sm.yaml
@@ -1,0 +1,26 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: tekton-kueue-webhook
+  annotations:
+    argocd.argoproj.io/sync-wave: "11"
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  endpoints:
+  - path: /metrics
+    interval: 15s
+    port: metrics-server
+    scheme: https
+    bearerTokenSecret:
+      name: "metrics-reader"
+      key: token
+    tlsConfig:
+      serverName: tekton-kueue-webhook-service.tekton-kueue.svc.cluster.local
+      insecureSkipVerify: false
+      ca:
+        secret:
+          name: webhook-metrics-server-cert
+          key: ca.crt
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: tekton-kueue-webhook

--- a/components/kueue-rd/rings/ring-2/base/base-snapshot/tekton-kueue/rbac/kustomization.yaml
+++ b/components/kueue-rd/rings/ring-2/base/base-snapshot/tekton-kueue/rbac/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- metrics-reader-sa.yaml
+- prometheus-metrics-reader-crb.yaml
+- prometheus-metrics-read-rb.yaml
+
+namespace: tekton-kueue

--- a/components/kueue-rd/rings/ring-2/base/base-snapshot/tekton-kueue/rbac/metrics-reader-sa.yaml
+++ b/components/kueue-rd/rings/ring-2/base/base-snapshot/tekton-kueue/rbac/metrics-reader-sa.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: metrics-reader
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: metrics-reader
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    kubernetes.io/service-account.name: metrics-reader
+type: kubernetes.io/service-account-token

--- a/components/kueue-rd/rings/ring-2/base/base-snapshot/tekton-kueue/rbac/prometheus-metrics-read-rb.yaml
+++ b/components/kueue-rd/rings/ring-2/base/base-snapshot/tekton-kueue/rbac/prometheus-metrics-read-rb.yaml
@@ -1,0 +1,33 @@
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: tekton-kueue-metrics-read
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+rules:
+  - verbs:
+      - get
+      - list
+      - watch
+    apiGroups:
+      - ''
+    resources:
+      - services
+      - endpoints
+      - pods
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: tekton-kueue-prometheus-k8s-read-binding
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+subjects:
+  - kind: ServiceAccount
+    name: prometheus-k8s
+    namespace: openshift-monitoring
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: tekton-kueue-metrics-read

--- a/components/kueue-rd/rings/ring-2/base/base-snapshot/tekton-kueue/rbac/prometheus-metrics-reader-crb.yaml
+++ b/components/kueue-rd/rings/ring-2/base/base-snapshot/tekton-kueue/rbac/prometheus-metrics-reader-crb.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: prometheus-tekton-kueue-metrics-reader
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: tekton-kueue-metrics-reader
+subjects:
+- kind: ServiceAccount
+  name: metrics-reader
+  namespace: tekton-kueue

--- a/components/kueue-rd/rings/ring-2/base/base-snapshot/workload-priority-classes.yaml
+++ b/components/kueue-rd/rings/ring-2/base/base-snapshot/workload-priority-classes.yaml
@@ -1,0 +1,90 @@
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: WorkloadPriorityClass
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "10"
+  name: konflux-nudge
+value: 1100
+description: "Highest priority for component nudges"
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: WorkloadPriorityClass
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "10"
+  name: konflux-release
+value: 1000
+description: "Higher priority for release pipelines"
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: WorkloadPriorityClass
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "10"
+  name: konflux-tenant-release
+value: 900
+description: "High priority for tenant release pipelines"
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: WorkloadPriorityClass
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "10"
+  name: konflux-post-merge-test
+value: 800
+description: "Priority for post-merge tests"
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: WorkloadPriorityClass
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "10"
+  name: konflux-post-merge-build
+value: 700
+description: "Priority for post-merge builds"
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: WorkloadPriorityClass
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "10"
+  name: konflux-pre-merge-test
+value: 600
+description: "Priority for pre-merge tests"
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: WorkloadPriorityClass
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "10"
+  name: konflux-pre-merge-build
+value: 500
+description: "Priority for pre-merge builds"
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: WorkloadPriorityClass
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "10"
+  name: konflux-default
+value: 400
+description: "Default priority for konflux pipelines"
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: WorkloadPriorityClass
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "10"
+  name: konflux-dependency-update
+value: 300
+description: "Lower priority for dependency updates"

--- a/components/kueue-rd/rings/ring-2/base/catalog-source.yaml
+++ b/components/kueue-rd/rings/ring-2/base/catalog-source.yaml
@@ -1,0 +1,15 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-3"
+  name: redhat-operators-1-18
+  namespace: openshift-kueue-operator
+spec:
+  displayName: redhat-operators-1-18
+  image: registry.redhat.io/redhat/redhat-operator-index:v4.18
+  sourceType: grpc
+  updateStrategy:
+    registryPoll:
+      interval: 30m

--- a/components/kueue-rd/rings/ring-2/base/kustomization.yaml
+++ b/components/kueue-rd/rings/ring-2/base/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- catalog-source.yaml
+- base-snapshot
+- tekton-kueue
+
+patches:
+- path: subscription-source-patch.yaml
+  target:
+    group: operators.coreos.com
+    kind: Subscription
+    name: openshift-kueue-operator

--- a/components/kueue-rd/rings/ring-2/base/subscription-source-patch.yaml
+++ b/components/kueue-rd/rings/ring-2/base/subscription-source-patch.yaml
@@ -1,0 +1,6 @@
+- op: replace
+  path: /spec/source
+  value: redhat-operators-1-18
+- op: replace
+  path: /spec/sourceNamespace
+  value: openshift-kueue-operator

--- a/components/kueue-rd/rings/ring-2/base/tekton-kueue/kustomization.yaml
+++ b/components/kueue-rd/rings/ring-2/base/tekton-kueue/kustomization.yaml
@@ -1,0 +1,116 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- https://github.com/konflux-ci/tekton-kueue/config/default?ref=cec0b3c8a240a289bb7aff4313ea647b292d96cc
+
+namespace: tekton-kueue
+# ensure that installation starts after the installation of kueue complete
+commonAnnotations:
+  argocd.argoproj.io/sync-wave: "10"
+  argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+
+images:
+- name: konflux-ci/tekton-kueue
+  newName: quay.io/konflux-ci/tekton-kueue
+  newTag: cec0b3c8a240a289bb7aff4313ea647b292d96cc
+
+patches:
+  - target:
+      kind: Namespace
+      name: tekton-kueue
+    patch: |
+      - op: add
+        path: /metadata/labels/openshift.io~1cluster-monitoring
+        value: "true"
+  # Controller Manager Deployment Patches
+  - path: patches/no-anti-affinity-annotation-patch.yaml
+    target:
+      kind: Deployment
+      name: tekton-kueue-controller-manager
+      namespace: tekton-kueue
+  - path: patches/deployment-strategy-patch.yaml
+    target:
+      kind: Deployment
+      name: tekton-kueue-controller-manager
+      namespace: tekton-kueue
+  - path: patches/controller-topology-spread-patch.yaml
+    target:
+      kind: Deployment
+      name: tekton-kueue-controller-manager
+      namespace: tekton-kueue
+  - path: patches/controller-manager-container-args-patch.yaml
+    target:
+      kind: Deployment
+      name: tekton-kueue-controller-manager
+      namespace: tekton-kueue
+  - target:
+      kind: Deployment
+      name: tekton-kueue-controller-manager
+      namespace: tekton-kueue
+    patch: |-
+      - op: add
+        path: /spec/replicas
+        value: 2
+  # -- Resource Requests and Limits Patches
+  - target:
+      kind: Deployment
+      name: tekton-kueue-controller-manager
+      namespace: tekton-kueue
+    patch: |-
+      - op: add
+        path: /spec/template/spec/containers/0/resources/requests
+        value:
+          cpu: 500m
+          memory: 2Gi
+
+      - op: add
+        path: /spec/template/spec/containers/0/resources/limits
+        value:
+          cpu: 500m
+          memory: 2Gi
+  # Webhook Deployment Patches
+  - path: patches/no-anti-affinity-annotation-patch.yaml
+    target:
+      kind: Deployment
+      name: tekton-kueue-webhook
+      namespace: tekton-kueue
+  - path: patches/deployment-strategy-patch.yaml
+    target:
+      kind: Deployment
+      name: tekton-kueue-webhook
+      namespace: tekton-kueue
+  - path: patches/webhook-topology-spread-patch.yaml
+    target:
+      kind: Deployment
+      name: tekton-kueue-webhook
+      namespace: tekton-kueue
+  - path: patches/webhook-webhook-container-args-patch.yaml
+    target:
+      kind: Deployment
+      name: tekton-kueue-webhook
+      namespace: tekton-kueue
+  - target:
+      kind: Deployment
+      name: tekton-kueue-webhook
+      namespace: tekton-kueue
+    patch: |-
+      - op: add
+        path: /spec/replicas
+        value: 3
+  # -- Resource Requests and Limits Patches
+  - target:
+      kind: Deployment
+      name: tekton-kueue-webhook
+      namespace: tekton-kueue
+    patch: |-
+      - op: add
+        path: /spec/template/spec/containers/0/resources/requests
+        value:
+          cpu: 200m
+          memory: 256Mi
+
+      - op: add
+        path: /spec/template/spec/containers/0/resources/limits
+        value:
+          cpu: 200m
+          memory: 256Mi

--- a/components/kueue-rd/rings/ring-2/base/tekton-kueue/patches/controller-manager-container-args-patch.yaml
+++ b/components/kueue-rd/rings/ring-2/base/tekton-kueue/patches/controller-manager-container-args-patch.yaml
@@ -1,0 +1,9 @@
+- op: add
+  path: /spec/template/spec/containers/0/args/-
+  value: "--leader-elect-lease-duration=137s"
+- op: add
+  path: /spec/template/spec/containers/0/args/-
+  value: "--leader-elect-renew-deadline=107s"
+- op: add
+  path: /spec/template/spec/containers/0/args/-
+  value: "--leader-elect-retry-period=26s"

--- a/components/kueue-rd/rings/ring-2/base/tekton-kueue/patches/controller-topology-spread-patch.yaml
+++ b/components/kueue-rd/rings/ring-2/base/tekton-kueue/patches/controller-topology-spread-patch.yaml
@@ -1,0 +1,9 @@
+- op: add
+  path: /spec/template/spec/topologySpreadConstraints
+  value:
+    - maxSkew: 1
+      topologyKey: topology.kubernetes.io/zone
+      whenUnsatisfiable: ScheduleAnyway
+      labelSelector:
+        matchLabels:
+          app.kubernetes.io/name: tekton-kueue

--- a/components/kueue-rd/rings/ring-2/base/tekton-kueue/patches/deployment-strategy-patch.yaml
+++ b/components/kueue-rd/rings/ring-2/base/tekton-kueue/patches/deployment-strategy-patch.yaml
@@ -1,0 +1,6 @@
+- op: add
+  path: /spec/strategy
+  value:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 0

--- a/components/kueue-rd/rings/ring-2/base/tekton-kueue/patches/no-anti-affinity-annotation-patch.yaml
+++ b/components/kueue-rd/rings/ring-2/base/tekton-kueue/patches/no-anti-affinity-annotation-patch.yaml
@@ -1,0 +1,3 @@
+- op: add
+  path: /metadata/annotations/ignore-check.kube-linter.io~1no-anti-affinity
+  value: "Using topologySpreadConstraints"

--- a/components/kueue-rd/rings/ring-2/base/tekton-kueue/patches/webhook-topology-spread-patch.yaml
+++ b/components/kueue-rd/rings/ring-2/base/tekton-kueue/patches/webhook-topology-spread-patch.yaml
@@ -1,0 +1,9 @@
+- op: add
+  path: /spec/template/spec/topologySpreadConstraints
+  value:
+    - maxSkew: 1
+      topologyKey: topology.kubernetes.io/zone
+      whenUnsatisfiable: ScheduleAnyway
+      labelSelector:
+        matchLabels:
+          app.kubernetes.io/name: tekton-kueue-webhook

--- a/components/kueue-rd/rings/ring-2/base/tekton-kueue/patches/webhook-webhook-container-args-patch.yaml
+++ b/components/kueue-rd/rings/ring-2/base/tekton-kueue/patches/webhook-webhook-container-args-patch.yaml
@@ -1,0 +1,3 @@
+- op: add
+  path: /spec/template/spec/containers/0/args/-
+  value: --zap-log-level=5

--- a/components/kueue-rd/rings/ring-2/kflux-fedora-01/cluster-queue.yaml
+++ b/components/kueue-rd/rings/ring-2/kflux-fedora-01/cluster-queue.yaml
@@ -1,0 +1,205 @@
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: ClusterQueue
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "10"
+  name: cluster-pipeline-queue
+spec:
+  flavorFungibility:
+    whenCanBorrow: MayStopSearch
+    whenCanPreempt: TryNextFlavor
+  namespaceSelector: {}
+  preemption:
+    borrowWithinCohort:
+      policy: Never
+    reclaimWithinCohort: Never
+    withinClusterQueue: Never
+  queueingStrategy: BestEffortFIFO
+  resourceGroups:
+  - coveredResources:
+    - tekton.dev/pipelineruns
+    - konflux-ci-dev-token
+    - cpu
+    - memory
+    - aws-ip
+    - mintmaker
+    flavors:
+    - name: default-flavor
+      resources:
+      - name: tekton.dev/pipelineruns
+        nominalQuota: '300'
+      - name: konflux-ci-dev-token
+        nominalQuota: '300'
+      - name: cpu
+        nominalQuota: 1k
+      - name: memory
+        nominalQuota: 500Ti
+      - name: aws-ip
+        nominalQuota: '250'
+      - name: mintmaker
+        nominalQuota: '150'
+  - coveredResources:
+    - linux-amd64
+    - linux-arm64
+    - linux-c2xlarge-amd64
+    - linux-c2xlarge-arm64
+    - linux-c4xlarge-amd64
+    - linux-c4xlarge-arm64
+    - linux-c6gd2xlarge-arm64
+    - linux-c8xlarge-amd64
+    - linux-c8xlarge-arm64
+    - linux-cxlarge-amd64
+    - linux-cxlarge-arm64
+    - linux-d160-c8xlarge-amd64
+    - linux-d160-c8xlarge-arm64
+    - linux-d160-m2xlarge-amd64
+    - linux-d160-m2xlarge-arm64
+    - linux-d160-m4xlarge-amd64
+    flavors:
+    - name: platform-group-1
+      resources:
+      - name: linux-amd64
+        nominalQuota: '250'
+      - name: linux-arm64
+        nominalQuota: '250'
+      - name: linux-c2xlarge-amd64
+        nominalQuota: '250'
+      - name: linux-c2xlarge-arm64
+        nominalQuota: '250'
+      - name: linux-c4xlarge-amd64
+        nominalQuota: '250'
+      - name: linux-c4xlarge-arm64
+        nominalQuota: '250'
+      - name: linux-c6gd2xlarge-arm64
+        nominalQuota: '250'
+      - name: linux-c8xlarge-amd64
+        nominalQuota: '250'
+      - name: linux-c8xlarge-arm64
+        nominalQuota: '250'
+      - name: linux-cxlarge-amd64
+        nominalQuota: '250'
+      - name: linux-cxlarge-arm64
+        nominalQuota: '250'
+      - name: linux-d160-c8xlarge-amd64
+        nominalQuota: '250'
+      - name: linux-d160-c8xlarge-arm64
+        nominalQuota: '250'
+      - name: linux-d160-m2xlarge-amd64
+        nominalQuota: '250'
+      - name: linux-d160-m2xlarge-arm64
+        nominalQuota: '250'
+      - name: linux-d160-m4xlarge-amd64
+        nominalQuota: '250'
+  - coveredResources:
+    - linux-d160-m4xlarge-arm64
+    - linux-d160-m8xlarge-amd64
+    - linux-d160-m8xlarge-arm64
+    - linux-extra-fast-amd64
+    - linux-fast-amd64
+    - linux-g6xlarge-amd64
+    - linux-m2xlarge-amd64
+    - linux-m2xlarge-arm64
+    - linux-m4xlarge-amd64
+    - linux-m4xlarge-arm64
+    - linux-m8xlarge-amd64
+    - linux-m8xlarge-arm64
+    - linux-mlarge-amd64
+    - linux-mlarge-arm64
+    - linux-mxlarge-amd64
+    - linux-mxlarge-arm64
+    flavors:
+    - name: platform-group-2
+      resources:
+      - name: linux-d160-m4xlarge-arm64
+        nominalQuota: '250'
+      - name: linux-d160-m8xlarge-amd64
+        nominalQuota: '250'
+      - name: linux-d160-m8xlarge-arm64
+        nominalQuota: '250'
+      - name: linux-extra-fast-amd64
+        nominalQuota: '250'
+      - name: linux-fast-amd64
+        nominalQuota: '250'
+      - name: linux-g6xlarge-amd64
+        nominalQuota: '250'
+      - name: linux-m2xlarge-amd64
+        nominalQuota: '250'
+      - name: linux-m2xlarge-arm64
+        nominalQuota: '250'
+      - name: linux-m4xlarge-amd64
+        nominalQuota: '250'
+      - name: linux-m4xlarge-arm64
+        nominalQuota: '250'
+      - name: linux-m8xlarge-amd64
+        nominalQuota: '250'
+      - name: linux-m8xlarge-arm64
+        nominalQuota: '250'
+      - name: linux-mlarge-amd64
+        nominalQuota: '250'
+      - name: linux-mlarge-arm64
+        nominalQuota: '250'
+      - name: linux-mxlarge-amd64
+        nominalQuota: '250'
+      - name: linux-mxlarge-arm64
+        nominalQuota: '250'
+  - coveredResources:
+    - linux-ppc64le
+    - linux-root-amd64
+    - linux-root-arm64
+    - linux-s390x
+    - linux-x86-64
+    - local
+    - localhost
+    flavors:
+    - name: platform-group-3
+      resources:
+      - name: linux-ppc64le
+        nominalQuota: '24'
+      - name: linux-root-amd64
+        nominalQuota: '250'
+      - name: linux-root-arm64
+        nominalQuota: '250'
+      - name: linux-s390x
+        nominalQuota: '24'
+      - name: linux-x86-64
+        nominalQuota: 1k
+      - name: local
+        nominalQuota: 1k
+      - name: localhost
+        nominalQuota: 1k
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: ResourceFlavor
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "10"
+  name: default-flavor
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: ResourceFlavor
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "10"
+  name: platform-group-1
+spec: {}
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: ResourceFlavor
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "10"
+  name: platform-group-2
+spec: {}
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: ResourceFlavor
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "10"
+  name: platform-group-3
+spec: {}

--- a/components/kueue-rd/rings/ring-2/kflux-fedora-01/config.yaml
+++ b/components/kueue-rd/rings/ring-2/kflux-fedora-01/config.yaml
@@ -1,0 +1,153 @@
+queueName: pipelines-queue
+cel:
+  expressions:
+    # Set resource requests for multi platform pipelines
+    - |
+        has(pipelineRun.spec.params) &&
+        pipelineRun.spec.params.exists(p, p.name == 'build-platforms') &&
+        type(pipelineRun.spec.params.filter(p, p.name == 'build-platforms')[0].value) == list ?
+        pipelineRun.spec.params.filter(
+          p,
+          p.name == 'build-platforms')[0]
+        .value.map(
+          p,
+          resource(replace(replace(p, "/", "-"), "_", "-"), 1)
+        ) : []
+
+    # Request AWS IP for AWS-based platforms
+    - |
+        has(pipelineRun.spec.params) &&
+        pipelineRun.spec.params.exists(p, p.name == 'build-platforms') &&
+        type(pipelineRun.spec.params.filter(p, p.name == 'build-platforms')[0].value) == list ?
+        pipelineRun.spec.params.filter(
+          p,
+          p.name == 'build-platforms')[0]
+        .value.filter(
+          p,
+          !(
+            p in [
+              'linux/ppc64le',
+              'linux/s390x',
+              'linux/x86_64',
+              'local',
+              'localhost',
+            ]
+          )
+        ).map(
+          p,
+          resource('aws-ip', 1)
+        ) : []
+
+    # Flag validation error when build-platforms is present but not a list
+    - |
+        has(pipelineRun.spec.params) &&
+        pipelineRun.spec.params.exists(p, p.name == 'build-platforms') &&
+        type(pipelineRun.spec.params.filter(p, p.name == 'build-platforms')[0].value) != list ?
+        [annotation('kueue.konflux-ci.dev/validation-error',
+          'build-platforms parameter must be an array of platform strings, got a non-array value')] : []
+
+    # Set resource requests for multi platform pipelines which doesn't use the build-platforms parameter (old style)
+    - |
+      !(
+        has(pipelineRun.spec.params) &&
+        pipelineRun.spec.params.exists(p, p.name == 'build-platforms')
+      ) &&
+      has(pipelineRun.spec.pipelineSpec) &&
+      has(pipelineRun.spec.pipelineSpec.tasks) &&
+      pipelineRun.spec.pipelineSpec.tasks.size() > 0 ?
+      pipelineRun.spec.pipelineSpec.tasks.map(
+        task,
+        has(task.params) ? task.params.filter(p, p.name == 'PLATFORM') : []
+      )
+      .filter(p, p.size() > 0)
+      .map(
+        p,
+        resource(replace(replace(p[0].value, "/", "-"), "_", "-"), 1)
+      ) : []
+
+    # Request AWS IP for AWS-based platforms which doesn't use the build-platforms parameter (old style)
+    - |
+      !(
+        has(pipelineRun.spec.params) &&
+        pipelineRun.spec.params.exists(p, p.name == 'build-platforms')
+      ) &&
+      has(pipelineRun.spec.pipelineSpec) &&
+      has(pipelineRun.spec.pipelineSpec.tasks) &&
+      pipelineRun.spec.pipelineSpec.tasks.size() > 0 ?
+      pipelineRun.spec.pipelineSpec.tasks.map(
+        task,
+        has(task.params) ? task.params.filter(p, p.name == 'PLATFORM') : []
+      )
+      .filter(p, p.size() > 0)
+      .filter(
+        p,
+        !(
+          p[0].value in [
+            'linux/ppc64le',
+            'linux/s390x',
+            'linux/x86_64',
+            'local',
+            'localhost',
+          ]
+        )
+      )
+      .map(
+        p,
+        resource('aws-ip', 1)
+      ) : []
+
+    # Set mintmaker resource requests.
+    # Necessary since mintmaker refreshes can overload clusters without a
+    # bottleneck on the number of pipelineruns running.
+    - |
+        plrNamespace == 'mintmaker' ? [resource('mintmaker', 1)] : []
+
+    # The token mechanism allows us to balance admitted PipelineRuns.
+    # Each PipelineRun requests 1 token. The token quota is set equal
+    # to the PLR limit so current behavior is unchanged.
+    - |
+        resource('konflux-ci-dev-token', 1)
+
+    # Set the pipeline priority
+    - |
+        has(pipelineRun.metadata.labels) &&
+        'build.appstudio.redhat.com/type' in pipelineRun.metadata.labels &&
+        pipelineRun.metadata.labels['build.appstudio.redhat.com/type'] == 'nudge' ?
+        priority('konflux-nudge') :
+
+        pacEventType == 'push' ? priority('konflux-post-merge-build') :
+        pacEventType == 'pull_request' ||
+          pacEventType == "Merge_Request" ||
+          pacEventType == 'test-comment' ||
+          pacEventType == 'retest-comment' ||
+          pacEventType == 'retest-all-comment' ||
+          pacEventType == 'ok-to-test-comment'  ? priority('konflux-pre-merge-build') :
+        pacTestEventType == 'push' ? priority('konflux-post-merge-test') :
+        pacTestEventType == 'pull_request' ||
+          pacTestEventType == "Merge_Request" ||
+          pacTestEventType == 'test-comment' ||
+          pacTestEventType == 'retest-comment' ||
+          pacTestEventType == 'retest-all-comment' ||
+          pacTestEventType == 'ok-to-test-comment' ? priority('konflux-pre-merge-test') :
+
+        has(pipelineRun.metadata.labels) &&
+        'appstudio.openshift.io/service' in pipelineRun.metadata.labels &&
+        pipelineRun.metadata.labels['appstudio.openshift.io/service'] == 'release' &&
+        'pipelines.appstudio.openshift.io/type' in pipelineRun.metadata.labels &&
+        pipelineRun.metadata.labels['pipelines.appstudio.openshift.io/type'] == 'managed' ?
+        priority('konflux-release') :
+
+        has(pipelineRun.metadata.labels) &&
+        'appstudio.openshift.io/service' in pipelineRun.metadata.labels &&
+        pipelineRun.metadata.labels['appstudio.openshift.io/service'] == 'release' &&
+        'release.appstudio.openshift.io/namespace' in pipelineRun.metadata.labels &&
+        pipelineRun.metadata.labels['release.appstudio.openshift.io/namespace'] == plrNamespace ?
+        priority('konflux-tenant-release') :
+
+        plrNamespace == 'mintmaker' ? priority('konflux-dependency-update') :
+
+        has(pipelineRun.metadata.labels) &&
+        'internal-services.appstudio.openshift.io/pipelinerun-uid' in pipelineRun.metadata.labels ?
+        priority('konflux-release') :
+
+        priority('konflux-default')

--- a/components/kueue-rd/rings/ring-2/kflux-fedora-01/kustomization.yaml
+++ b/components/kueue-rd/rings/ring-2/kflux-fedora-01/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- cluster-queue.yaml
+- ../base
+
+configMapGenerator:
+  - name: tekton-kueue-config
+    namespace: tekton-kueue
+    behavior: replace
+    files:
+      - config.yaml
+generatorOptions:
+  disableNameSuffixHash: true

--- a/components/kueue-rd/rings/ring-2/kflux-ocp-p01/cluster-queue.yaml
+++ b/components/kueue-rd/rings/ring-2/kflux-ocp-p01/cluster-queue.yaml
@@ -1,0 +1,229 @@
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: ClusterQueue
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "10"
+  name: cluster-pipeline-queue
+spec:
+  flavorFungibility:
+    whenCanBorrow: MayStopSearch
+    whenCanPreempt: TryNextFlavor
+  namespaceSelector: {}
+  preemption:
+    borrowWithinCohort:
+      policy: Never
+    reclaimWithinCohort: Never
+    withinClusterQueue: Never
+  queueingStrategy: BestEffortFIFO
+  resourceGroups:
+  - coveredResources:
+    - tekton.dev/pipelineruns
+    - konflux-ci-dev-token
+    - cpu
+    - memory
+    - aws-ip
+    - mintmaker
+    - konflux-release
+    flavors:
+    - name: default-flavor
+      resources:
+      - name: tekton.dev/pipelineruns
+        nominalQuota: '350'
+      - name: konflux-ci-dev-token
+        nominalQuota: '250'
+      - name: cpu
+        nominalQuota: 1k
+      - name: memory
+        nominalQuota: 500Ti
+      - name: aws-ip
+        nominalQuota: '250'
+      - name: mintmaker
+        nominalQuota: '150'
+      - name: konflux-release
+        nominalQuota: '100'
+  - coveredResources:
+    - linux-amd64
+    - linux-arm64
+    - linux-c2xlarge-amd64
+    - linux-c2xlarge-arm64
+    - linux-c4xlarge-amd64
+    - linux-c4xlarge-arm64
+    - linux-c6gd2xlarge-arm64
+    - linux-c8xlarge-amd64
+    - linux-c8xlarge-arm64
+    - linux-cxlarge-amd64
+    - linux-cxlarge-arm64
+    - linux-d160-arm64
+    - linux-d160-c4xlarge-amd64
+    - linux-d160-c4xlarge-arm64
+    - linux-d160-c8xlarge-amd64
+    - linux-d160-c8xlarge-arm64
+    flavors:
+    - name: platform-group-1
+      resources:
+      - name: linux-amd64
+        nominalQuota: '250'
+      - name: linux-arm64
+        nominalQuota: '250'
+      - name: linux-c2xlarge-amd64
+        nominalQuota: '250'
+      - name: linux-c2xlarge-arm64
+        nominalQuota: '250'
+      - name: linux-c4xlarge-amd64
+        nominalQuota: '250'
+      - name: linux-c4xlarge-arm64
+        nominalQuota: '250'
+      - name: linux-c6gd2xlarge-arm64
+        nominalQuota: '250'
+      - name: linux-c8xlarge-amd64
+        nominalQuota: '250'
+      - name: linux-c8xlarge-arm64
+        nominalQuota: '250'
+      - name: linux-cxlarge-amd64
+        nominalQuota: '250'
+      - name: linux-cxlarge-arm64
+        nominalQuota: '250'
+      - name: linux-d160-arm64
+        nominalQuota: '250'
+      - name: linux-d160-c4xlarge-amd64
+        nominalQuota: '250'
+      - name: linux-d160-c4xlarge-arm64
+        nominalQuota: '250'
+      - name: linux-d160-c8xlarge-amd64
+        nominalQuota: '250'
+      - name: linux-d160-c8xlarge-arm64
+        nominalQuota: '250'
+  - coveredResources:
+    - linux-d160-cxlarge-amd64
+    - linux-d160-cxlarge-arm64
+    - linux-d160-m2xlarge-amd64
+    - linux-d160-m2xlarge-arm64
+    - linux-d160-m4xlarge-amd64
+    - linux-d160-m4xlarge-arm64
+    - linux-d160-m8xlarge-amd64
+    - linux-d160-m8xlarge-arm64
+    - linux-d320-c4xlarge-amd64
+    - linux-d320-c4xlarge-arm64
+    - linux-d320-m8xlarge-amd64
+    - linux-d320-m8xlarge-arm64
+    - linux-g64xlarge-amd64
+    - linux-m2xlarge-amd64
+    - linux-m2xlarge-arm64
+    - linux-m4xlarge-amd64
+    flavors:
+    - name: platform-group-2
+      resources:
+      - name: linux-d160-cxlarge-amd64
+        nominalQuota: '250'
+      - name: linux-d160-cxlarge-arm64
+        nominalQuota: '250'
+      - name: linux-d160-m2xlarge-amd64
+        nominalQuota: '250'
+      - name: linux-d160-m2xlarge-arm64
+        nominalQuota: '250'
+      - name: linux-d160-m4xlarge-amd64
+        nominalQuota: '250'
+      - name: linux-d160-m4xlarge-arm64
+        nominalQuota: '250'
+      - name: linux-d160-m8xlarge-amd64
+        nominalQuota: '250'
+      - name: linux-d160-m8xlarge-arm64
+        nominalQuota: '250'
+      - name: linux-d320-c4xlarge-amd64
+        nominalQuota: '250'
+      - name: linux-d320-c4xlarge-arm64
+        nominalQuota: '250'
+      - name: linux-d320-m8xlarge-amd64
+        nominalQuota: '250'
+      - name: linux-d320-m8xlarge-arm64
+        nominalQuota: '250'
+      - name: linux-g64xlarge-amd64
+        nominalQuota: '250'
+      - name: linux-m2xlarge-amd64
+        nominalQuota: '250'
+      - name: linux-m2xlarge-arm64
+        nominalQuota: '250'
+      - name: linux-m4xlarge-amd64
+        nominalQuota: '250'
+  - coveredResources:
+    - linux-m4xlarge-arm64
+    - linux-m8xlarge-amd64
+    - linux-m8xlarge-arm64
+    - linux-mlarge-amd64
+    - linux-mlarge-arm64
+    - linux-mxlarge-amd64
+    - linux-mxlarge-arm64
+    - linux-ppc64le
+    - linux-root-amd64
+    - linux-root-arm64
+    - linux-s390x
+    - linux-x86-64
+    - local
+    - localhost
+    flavors:
+    - name: platform-group-3
+      resources:
+      - name: linux-m4xlarge-arm64
+        nominalQuota: '250'
+      - name: linux-m8xlarge-amd64
+        nominalQuota: '250'
+      - name: linux-m8xlarge-arm64
+        nominalQuota: '250'
+      - name: linux-mlarge-amd64
+        nominalQuota: '250'
+      - name: linux-mlarge-arm64
+        nominalQuota: '250'
+      - name: linux-mxlarge-amd64
+        nominalQuota: '250'
+      - name: linux-mxlarge-arm64
+        nominalQuota: '250'
+      - name: linux-ppc64le
+        nominalQuota: '64'
+      - name: linux-root-amd64
+        nominalQuota: '250'
+      - name: linux-root-arm64
+        nominalQuota: '250'
+      - name: linux-s390x
+        nominalQuota: '56'
+      - name: linux-x86-64
+        nominalQuota: 1k
+      - name: local
+        nominalQuota: 1k
+      - name: localhost
+        nominalQuota: 1k
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: ResourceFlavor
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "10"
+  name: default-flavor
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: ResourceFlavor
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "10"
+  name: platform-group-1
+spec: {}
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: ResourceFlavor
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "10"
+  name: platform-group-2
+spec: {}
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: ResourceFlavor
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "10"
+  name: platform-group-3
+spec: {}

--- a/components/kueue-rd/rings/ring-2/kflux-ocp-p01/config.yaml
+++ b/components/kueue-rd/rings/ring-2/kflux-ocp-p01/config.yaml
@@ -1,0 +1,186 @@
+queueName: pipelines-queue
+cel:
+  expressions:
+    # Set resource requests for multi platform pipelines
+    - |
+        has(pipelineRun.spec.params) &&
+        pipelineRun.spec.params.exists(p, p.name == 'build-platforms') &&
+        type(pipelineRun.spec.params.filter(p, p.name == 'build-platforms')[0].value) == list ?
+        pipelineRun.spec.params.filter(
+          p,
+          p.name == 'build-platforms')[0]
+        .value.map(
+          p,
+          resource(replace(replace(p, "/", "-"), "_", "-"), 1)
+        ) : []
+
+    # Request AWS IP for AWS-based platforms
+    - |
+        has(pipelineRun.spec.params) &&
+        pipelineRun.spec.params.exists(p, p.name == 'build-platforms') &&
+        type(pipelineRun.spec.params.filter(p, p.name == 'build-platforms')[0].value) == list ?
+        pipelineRun.spec.params.filter(
+          p,
+          p.name == 'build-platforms')[0]
+        .value.filter(
+          p,
+          !(
+            p in [
+              'linux/ppc64le',
+              'linux/s390x',
+              'linux/x86_64',
+              'local',
+              'localhost',
+            ]
+          )
+        ).map(
+          p,
+          resource('aws-ip', 1)
+        ) : []
+
+    # Flag validation error when build-platforms is present but not a list
+    - |
+        has(pipelineRun.spec.params) &&
+        pipelineRun.spec.params.exists(p, p.name == 'build-platforms') &&
+        type(pipelineRun.spec.params.filter(p, p.name == 'build-platforms')[0].value) != list ?
+        [annotation('kueue.konflux-ci.dev/validation-error',
+          'build-platforms parameter must be an array of platform strings, got a non-array value')] : []
+
+    # Set resource requests for multi platform pipelines which doesn't use the build-platforms parameter (old style)
+    - |
+      !(
+        has(pipelineRun.spec.params) &&
+        pipelineRun.spec.params.exists(p, p.name == 'build-platforms')
+      ) &&
+      has(pipelineRun.spec.pipelineSpec) &&
+      has(pipelineRun.spec.pipelineSpec.tasks) &&
+      pipelineRun.spec.pipelineSpec.tasks.size() > 0 ?
+      pipelineRun.spec.pipelineSpec.tasks.map(
+        task,
+        has(task.params) ? task.params.filter(p, p.name == 'PLATFORM') : []
+      )
+      .filter(p, p.size() > 0)
+      .map(
+        p,
+        resource(replace(replace(p[0].value, "/", "-"), "_", "-"), 1)
+      ) : []
+
+    # Request AWS IP for AWS-based platforms which doesn't use the build-platforms parameter (old style)
+    - |
+      !(
+        has(pipelineRun.spec.params) &&
+        pipelineRun.spec.params.exists(p, p.name == 'build-platforms')
+      ) &&
+      has(pipelineRun.spec.pipelineSpec) &&
+      has(pipelineRun.spec.pipelineSpec.tasks) &&
+      pipelineRun.spec.pipelineSpec.tasks.size() > 0 ?
+      pipelineRun.spec.pipelineSpec.tasks.map(
+        task,
+        has(task.params) ? task.params.filter(p, p.name == 'PLATFORM') : []
+      )
+      .filter(p, p.size() > 0)
+      .filter(
+        p,
+        !(
+          p[0].value in [
+            'linux/ppc64le',
+            'linux/s390x',
+            'linux/x86_64',
+            'local',
+            'localhost',
+          ]
+        )
+      )
+      .map(
+        p,
+        resource('aws-ip', 1)
+      ) : []
+
+    # Set mintmaker resource requests.
+    # Necessary since mintmaker refreshes can overload clusters without a
+    # bottleneck on the number of pipelineruns running.
+    - |
+        plrNamespace == 'mintmaker' ? [resource('mintmaker', 1)] : []
+
+    # The token mechanism allows us to balance admitted PipelineRuns.
+    # Each PipelineRun requests 1 token, except for internal-services PLRs.
+    # This is to guarantee there is always room for internal-services PLRs.
+    #
+    #
+    # WARNING: As a temporary measure, we are using tokens to provide a priority lane
+    # for internal-services PLRs. They'll be removed in some time and moved to the
+    # common clusters.
+    - |
+        has(pipelineRun.metadata.labels) &&
+        'internal-services.appstudio.openshift.io/pipelinerun-uid' in pipelineRun.metadata.labels ?
+        [] : [resource('konflux-ci-dev-token', 1)]
+
+    # Add a resource to restrict the number of concurrent release pipelineruns
+    - |
+        has(pipelineRun.metadata.labels) &&
+        'appstudio.openshift.io/service' in pipelineRun.metadata.labels &&
+        pipelineRun.metadata.labels['appstudio.openshift.io/service'] == 'release' &&
+        'pipelines.appstudio.openshift.io/type' in pipelineRun.metadata.labels &&
+        pipelineRun.metadata.labels['pipelines.appstudio.openshift.io/type'] == 'managed' ?
+        [resource('konflux-release', 1)] :
+
+        has(pipelineRun.metadata.labels) &&
+        'appstudio.openshift.io/service' in pipelineRun.metadata.labels &&
+        pipelineRun.metadata.labels['appstudio.openshift.io/service'] == 'release' &&
+        'release.appstudio.openshift.io/namespace' in pipelineRun.metadata.labels &&
+        pipelineRun.metadata.labels['release.appstudio.openshift.io/namespace'] == plrNamespace ?
+        [resource('konflux-release', 1)] : []
+
+    # Set the pipeline priority
+    # First condition is to check if the priority class is already set and keep it if it is
+    # We allow this since the cluster is dedicated to the OCP team.
+    - |
+        has(pipelineRun.metadata.labels) &&
+        'kueue.x-k8s.io/priority-class' in pipelineRun.metadata.labels ?
+        priority(pipelineRun.metadata.labels['kueue.x-k8s.io/priority-class']) :
+
+        has(pipelineRun.metadata.labels) &&
+        'build.appstudio.redhat.com/type' in pipelineRun.metadata.labels &&
+        pipelineRun.metadata.labels['build.appstudio.redhat.com/type'] == 'nudge' ?
+        priority('konflux-nudge') :
+
+        pacEventType == 'push' ? priority('konflux-post-merge-build') :
+        pacEventType == 'pull_request'
+          || pacEventType == "Merge_Request"
+          ? priority('konflux-pre-merge-build') :
+        pacTestEventType == 'push' ? priority('konflux-post-merge-test') :
+        pacTestEventType == 'pull_request'
+          || pacTestEventType == "Merge_Request"
+          ? priority('konflux-pre-merge-test') :
+
+        has(pipelineRun.metadata.labels) &&
+        'appstudio.openshift.io/service' in pipelineRun.metadata.labels &&
+        pipelineRun.metadata.labels['appstudio.openshift.io/service'] == 'release' &&
+        'pipelines.appstudio.openshift.io/type' in pipelineRun.metadata.labels &&
+        pipelineRun.metadata.labels['pipelines.appstudio.openshift.io/type'] == 'managed' ?
+        priority('konflux-release') :
+
+        has(pipelineRun.metadata.labels) &&
+        'appstudio.openshift.io/service' in pipelineRun.metadata.labels &&
+        pipelineRun.metadata.labels['appstudio.openshift.io/service'] == 'release' &&
+        'pipelines.appstudio.openshift.io/type' in pipelineRun.metadata.labels &&
+        pipelineRun.metadata.labels['pipelines.appstudio.openshift.io/type'] == 'tenant' ?
+        priority('konflux-tenant-release') :
+
+        has(pipelineRun.metadata.labels) &&
+        'release.appstudio.openshift.io/name' in pipelineRun.metadata.labels &&
+        pipelineRun.metadata.labels['release.appstudio.openshift.io/name'].contains('-prod-') ?
+        priority('konflux-prod-release') :
+
+        has(pipelineRun.metadata.labels) &&
+        'release.appstudio.openshift.io/name' in pipelineRun.metadata.labels &&
+        pipelineRun.metadata.labels['release.appstudio.openshift.io/name'].contains('-stage-') ?
+        priority('konflux-stage-release') :
+
+        plrNamespace == 'mintmaker' ? priority('konflux-dependency-update') :
+
+        has(pipelineRun.metadata.labels) &&
+        'internal-services.appstudio.openshift.io/pipelinerun-uid' in pipelineRun.metadata.labels ?
+        priority('konflux-release') :
+
+        priority('konflux-default')

--- a/components/kueue-rd/rings/ring-2/kflux-ocp-p01/kustomization.yaml
+++ b/components/kueue-rd/rings/ring-2/kflux-ocp-p01/kustomization.yaml
@@ -1,0 +1,15 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- cluster-queue.yaml
+- workload-priority-classes.yaml
+- ../base
+
+configMapGenerator:
+  - name: tekton-kueue-config
+    namespace: tekton-kueue
+    behavior: replace
+    files:
+      - config.yaml
+generatorOptions:
+  disableNameSuffixHash: true

--- a/components/kueue-rd/rings/ring-2/kflux-ocp-p01/workload-priority-classes.yaml
+++ b/components/kueue-rd/rings/ring-2/kflux-ocp-p01/workload-priority-classes.yaml
@@ -1,0 +1,122 @@
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+description: Priority level 1 (highest)
+kind: WorkloadPriorityClass
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "10"
+  name: build-priority-1
+value: 410
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+description: Priority level 10 (lowest)
+kind: WorkloadPriorityClass
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "10"
+  name: build-priority-10
+value: 401
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+description: Priority level 2
+kind: WorkloadPriorityClass
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "10"
+  name: build-priority-2
+value: 409
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+description: Priority level 3
+kind: WorkloadPriorityClass
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "10"
+  name: build-priority-3
+value: 408
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+description: Priority level 4
+kind: WorkloadPriorityClass
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "10"
+  name: build-priority-4
+value: 407
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+description: Priority level 5
+kind: WorkloadPriorityClass
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "10"
+  name: build-priority-5
+value: 406
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+description: Priority level 6
+kind: WorkloadPriorityClass
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "10"
+  name: build-priority-6
+value: 405
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+description: Priority level 7
+kind: WorkloadPriorityClass
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "10"
+  name: build-priority-7
+value: 404
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+description: Priority level 8
+kind: WorkloadPriorityClass
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "10"
+  name: build-priority-8
+value: 403
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+description: Priority level 9
+kind: WorkloadPriorityClass
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "10"
+  name: build-priority-9
+value: 402
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+description: High priority for OCP prod release pipelines which should supersede all
+  releases
+kind: WorkloadPriorityClass
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "10"
+  name: konflux-prod-release
+value: 950
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+description: High priority for OCP stage release pipelines which should supersede
+  all other stage auto releases
+kind: WorkloadPriorityClass
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "10"
+  name: konflux-stage-release
+value: 925

--- a/components/kueue-rd/rings/ring-2/kflux-osp-p01/cluster-queue.yaml
+++ b/components/kueue-rd/rings/ring-2/kflux-osp-p01/cluster-queue.yaml
@@ -1,0 +1,190 @@
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: ClusterQueue
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "10"
+  name: cluster-pipeline-queue
+spec:
+  flavorFungibility:
+    whenCanBorrow: MayStopSearch
+    whenCanPreempt: TryNextFlavor
+  namespaceSelector: {}
+  preemption:
+    borrowWithinCohort:
+      policy: Never
+    reclaimWithinCohort: Never
+    withinClusterQueue: Never
+  queueingStrategy: BestEffortFIFO
+  resourceGroups:
+  - coveredResources:
+    - tekton.dev/pipelineruns
+    - konflux-ci-dev-token
+    - cpu
+    - memory
+    - aws-ip
+    - mintmaker
+    flavors:
+    - name: default-flavor
+      resources:
+      - name: tekton.dev/pipelineruns
+        nominalQuota: '30'
+      - name: konflux-ci-dev-token
+        nominalQuota: '30'
+      - name: cpu
+        nominalQuota: 1k
+      - name: memory
+        nominalQuota: 500Ti
+      - name: aws-ip
+        nominalQuota: '250'
+      - name: mintmaker
+        nominalQuota: '5'
+  - coveredResources:
+    - linux-amd64
+    - linux-arm64
+    - linux-c2xlarge-amd64
+    - linux-c2xlarge-arm64
+    - linux-c4xlarge-amd64
+    - linux-c4xlarge-arm64
+    - linux-c6gd2xlarge-arm64
+    - linux-c8xlarge-amd64
+    - linux-c8xlarge-arm64
+    - linux-cxlarge-amd64
+    - linux-cxlarge-arm64
+    - linux-d160-c8xlarge-amd64
+    - linux-d160-c8xlarge-arm64
+    - linux-d320-m8xlarge-amd64
+    - linux-d320-m8xlarge-arm64
+    - linux-extra-fast-amd64
+    flavors:
+    - name: platform-group-1
+      resources:
+      - name: linux-amd64
+        nominalQuota: '250'
+      - name: linux-arm64
+        nominalQuota: '250'
+      - name: linux-c2xlarge-amd64
+        nominalQuota: '250'
+      - name: linux-c2xlarge-arm64
+        nominalQuota: '250'
+      - name: linux-c4xlarge-amd64
+        nominalQuota: '250'
+      - name: linux-c4xlarge-arm64
+        nominalQuota: '250'
+      - name: linux-c6gd2xlarge-arm64
+        nominalQuota: '250'
+      - name: linux-c8xlarge-amd64
+        nominalQuota: '250'
+      - name: linux-c8xlarge-arm64
+        nominalQuota: '250'
+      - name: linux-cxlarge-amd64
+        nominalQuota: '250'
+      - name: linux-cxlarge-arm64
+        nominalQuota: '250'
+      - name: linux-d160-c8xlarge-amd64
+        nominalQuota: '250'
+      - name: linux-d160-c8xlarge-arm64
+        nominalQuota: '250'
+      - name: linux-d320-m8xlarge-amd64
+        nominalQuota: '250'
+      - name: linux-d320-m8xlarge-arm64
+        nominalQuota: '250'
+      - name: linux-extra-fast-amd64
+        nominalQuota: '250'
+  - coveredResources:
+    - linux-fast-amd64
+    - linux-g64xlarge-amd64
+    - linux-g6xlarge-amd64
+    - linux-m2xlarge-amd64
+    - linux-m2xlarge-arm64
+    - linux-m4xlarge-amd64
+    - linux-m4xlarge-arm64
+    - linux-m8xlarge-amd64
+    - linux-m8xlarge-arm64
+    - linux-mlarge-amd64
+    - linux-mlarge-arm64
+    - linux-mxlarge-amd64
+    - linux-mxlarge-arm64
+    - linux-root-amd64
+    - linux-root-arm64
+    - linux-x86-64
+    flavors:
+    - name: platform-group-2
+      resources:
+      - name: linux-fast-amd64
+        nominalQuota: '250'
+      - name: linux-g64xlarge-amd64
+        nominalQuota: '2'
+      - name: linux-g6xlarge-amd64
+        nominalQuota: '2'
+      - name: linux-m2xlarge-amd64
+        nominalQuota: '250'
+      - name: linux-m2xlarge-arm64
+        nominalQuota: '250'
+      - name: linux-m4xlarge-amd64
+        nominalQuota: '250'
+      - name: linux-m4xlarge-arm64
+        nominalQuota: '250'
+      - name: linux-m8xlarge-amd64
+        nominalQuota: '250'
+      - name: linux-m8xlarge-arm64
+        nominalQuota: '250'
+      - name: linux-mlarge-amd64
+        nominalQuota: '250'
+      - name: linux-mlarge-arm64
+        nominalQuota: '250'
+      - name: linux-mxlarge-amd64
+        nominalQuota: '250'
+      - name: linux-mxlarge-arm64
+        nominalQuota: '250'
+      - name: linux-root-amd64
+        nominalQuota: '250'
+      - name: linux-root-arm64
+        nominalQuota: '250'
+      - name: linux-x86-64
+        nominalQuota: 1k
+  - coveredResources:
+    - local
+    - localhost
+    flavors:
+    - name: platform-group-3
+      resources:
+      - name: local
+        nominalQuota: 1k
+      - name: localhost
+        nominalQuota: 1k
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: ResourceFlavor
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "10"
+  name: default-flavor
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: ResourceFlavor
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "10"
+  name: platform-group-1
+spec: {}
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: ResourceFlavor
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "10"
+  name: platform-group-2
+spec: {}
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: ResourceFlavor
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "10"
+  name: platform-group-3
+spec: {}

--- a/components/kueue-rd/rings/ring-2/kflux-osp-p01/config.yaml
+++ b/components/kueue-rd/rings/ring-2/kflux-osp-p01/config.yaml
@@ -1,0 +1,153 @@
+queueName: pipelines-queue
+cel:
+  expressions:
+    # Set resource requests for multi platform pipelines
+    - |
+        has(pipelineRun.spec.params) &&
+        pipelineRun.spec.params.exists(p, p.name == 'build-platforms') &&
+        type(pipelineRun.spec.params.filter(p, p.name == 'build-platforms')[0].value) == list ?
+        pipelineRun.spec.params.filter(
+          p,
+          p.name == 'build-platforms')[0]
+        .value.map(
+          p,
+          resource(replace(replace(p, "/", "-"), "_", "-"), 1)
+        ) : []
+
+    # Request AWS IP for AWS-based platforms
+    - |
+        has(pipelineRun.spec.params) &&
+        pipelineRun.spec.params.exists(p, p.name == 'build-platforms') &&
+        type(pipelineRun.spec.params.filter(p, p.name == 'build-platforms')[0].value) == list ?
+        pipelineRun.spec.params.filter(
+          p,
+          p.name == 'build-platforms')[0]
+        .value.filter(
+          p,
+          !(
+            p in [
+              'linux/ppc64le',
+              'linux/s390x',
+              'linux/x86_64',
+              'local',
+              'localhost',
+            ]
+          )
+        ).map(
+          p,
+          resource('aws-ip', 1)
+        ) : []
+
+    # Flag validation error when build-platforms is present but not a list
+    - |
+        has(pipelineRun.spec.params) &&
+        pipelineRun.spec.params.exists(p, p.name == 'build-platforms') &&
+        type(pipelineRun.spec.params.filter(p, p.name == 'build-platforms')[0].value) != list ?
+        [annotation('kueue.konflux-ci.dev/validation-error',
+          'build-platforms parameter must be an array of platform strings, got a non-array value')] : []
+
+    # Set resource requests for multi platform pipelines which doesn't use the build-platforms parameter (old style)
+    - |
+      !(
+        has(pipelineRun.spec.params) &&
+        pipelineRun.spec.params.exists(p, p.name == 'build-platforms')
+      ) &&
+      has(pipelineRun.spec.pipelineSpec) &&
+      has(pipelineRun.spec.pipelineSpec.tasks) &&
+      pipelineRun.spec.pipelineSpec.tasks.size() > 0 ?
+      pipelineRun.spec.pipelineSpec.tasks.map(
+        task,
+        has(task.params) ? task.params.filter(p, p.name == 'PLATFORM') : []
+      )
+      .filter(p, p.size() > 0)
+      .map(
+        p,
+        resource(replace(replace(p[0].value, "/", "-"), "_", "-"), 1)
+      ) : []
+
+    # Request AWS IP for AWS-based platforms which doesn't use the build-platforms parameter (old style)
+    - |
+      !(
+        has(pipelineRun.spec.params) &&
+        pipelineRun.spec.params.exists(p, p.name == 'build-platforms')
+      ) &&
+      has(pipelineRun.spec.pipelineSpec) &&
+      has(pipelineRun.spec.pipelineSpec.tasks) &&
+      pipelineRun.spec.pipelineSpec.tasks.size() > 0 ?
+      pipelineRun.spec.pipelineSpec.tasks.map(
+        task,
+        has(task.params) ? task.params.filter(p, p.name == 'PLATFORM') : []
+      )
+      .filter(p, p.size() > 0)
+      .filter(
+        p,
+        !(
+          p[0].value in [
+            'linux/ppc64le',
+            'linux/s390x',
+            'linux/x86_64',
+            'local',
+            'localhost',
+          ]
+        )
+      )
+      .map(
+        p,
+        resource('aws-ip', 1)
+      ) : []
+
+    # Set mintmaker resource requests.
+    # Necessary since mintmaker refreshes can overload clusters without a
+    # bottleneck on the number of pipelineruns running.
+    - |
+        plrNamespace == 'mintmaker' ? [resource('mintmaker', 1)] : []
+
+    # The token mechanism allows us to balance admitted PipelineRuns.
+    # Each PipelineRun requests 1 token. The token quota is set equal
+    # to the PLR limit so current behavior is unchanged.
+    - |
+        resource('konflux-ci-dev-token', 1)
+
+    # Set the pipeline priority
+    - |
+        has(pipelineRun.metadata.labels) &&
+        'build.appstudio.redhat.com/type' in pipelineRun.metadata.labels &&
+        pipelineRun.metadata.labels['build.appstudio.redhat.com/type'] == 'nudge' ?
+        priority('konflux-nudge') :
+
+        pacEventType == 'push' ? priority('konflux-post-merge-build') :
+        pacEventType == 'pull_request' ||
+          pacEventType == "Merge_Request" ||
+          pacEventType == 'test-comment' ||
+          pacEventType == 'retest-comment' ||
+          pacEventType == 'retest-all-comment' ||
+          pacEventType == 'ok-to-test-comment'  ? priority('konflux-pre-merge-build') :
+        pacTestEventType == 'push' ? priority('konflux-post-merge-test') :
+        pacTestEventType == 'pull_request' ||
+          pacTestEventType == "Merge_Request" ||
+          pacTestEventType == 'test-comment' ||
+          pacTestEventType == 'retest-comment' ||
+          pacTestEventType == 'retest-all-comment' ||
+          pacTestEventType == 'ok-to-test-comment' ? priority('konflux-pre-merge-test') :
+
+        has(pipelineRun.metadata.labels) &&
+        'appstudio.openshift.io/service' in pipelineRun.metadata.labels &&
+        pipelineRun.metadata.labels['appstudio.openshift.io/service'] == 'release' &&
+        'pipelines.appstudio.openshift.io/type' in pipelineRun.metadata.labels &&
+        pipelineRun.metadata.labels['pipelines.appstudio.openshift.io/type'] == 'managed' ?
+        priority('konflux-release') :
+
+        has(pipelineRun.metadata.labels) &&
+        'appstudio.openshift.io/service' in pipelineRun.metadata.labels &&
+        pipelineRun.metadata.labels['appstudio.openshift.io/service'] == 'release' &&
+        'release.appstudio.openshift.io/namespace' in pipelineRun.metadata.labels &&
+        pipelineRun.metadata.labels['release.appstudio.openshift.io/namespace'] == plrNamespace ?
+        priority('konflux-tenant-release') :
+
+        plrNamespace == 'mintmaker' ? priority('konflux-dependency-update') :
+
+        has(pipelineRun.metadata.labels) &&
+        'internal-services.appstudio.openshift.io/pipelinerun-uid' in pipelineRun.metadata.labels ?
+        priority('konflux-release') :
+
+        priority('konflux-default')

--- a/components/kueue-rd/rings/ring-2/kflux-osp-p01/kustomization.yaml
+++ b/components/kueue-rd/rings/ring-2/kflux-osp-p01/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- cluster-queue.yaml
+- ../base
+
+configMapGenerator:
+  - name: tekton-kueue-config
+    namespace: tekton-kueue
+    behavior: replace
+    files:
+      - config.yaml
+generatorOptions:
+  disableNameSuffixHash: true

--- a/components/kueue-rd/rings/ring-2/kflux-prd-rh03/cluster-queue.yaml
+++ b/components/kueue-rd/rings/ring-2/kflux-prd-rh03/cluster-queue.yaml
@@ -1,0 +1,211 @@
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: ClusterQueue
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "10"
+  name: cluster-pipeline-queue
+spec:
+  flavorFungibility:
+    whenCanBorrow: MayStopSearch
+    whenCanPreempt: TryNextFlavor
+  namespaceSelector: {}
+  preemption:
+    borrowWithinCohort:
+      policy: Never
+    reclaimWithinCohort: Never
+    withinClusterQueue: Never
+  queueingStrategy: BestEffortFIFO
+  resourceGroups:
+  - coveredResources:
+    - tekton.dev/pipelineruns
+    - konflux-ci-dev-token
+    - cpu
+    - memory
+    - aws-ip
+    - mintmaker
+    flavors:
+    - name: default-flavor
+      resources:
+      - name: tekton.dev/pipelineruns
+        nominalQuota: '350'
+      - name: konflux-ci-dev-token
+        nominalQuota: '350'
+      - name: cpu
+        nominalQuota: 1k
+      - name: memory
+        nominalQuota: 500Ti
+      - name: aws-ip
+        nominalQuota: '500'
+      - name: mintmaker
+        nominalQuota: '150'
+  - coveredResources:
+    - linux-amd64
+    - linux-arm64
+    - linux-c2xlarge-amd64
+    - linux-c2xlarge-arm64
+    - linux-c4xlarge-amd64
+    - linux-c4xlarge-arm64
+    - linux-c6gd2xlarge-arm64
+    - linux-c8xlarge-amd64
+    - linux-c8xlarge-arm64
+    - linux-cxlarge-amd64
+    - linux-cxlarge-arm64
+    - linux-d160-c8xlarge-amd64
+    - linux-d160-c8xlarge-arm64
+    - linux-d160-m2xlarge-amd64
+    - linux-d160-m2xlarge-arm64
+    - linux-d160-m4xlarge-amd64
+    flavors:
+    - name: platform-group-1
+      resources:
+      - name: linux-amd64
+        nominalQuota: '500'
+      - name: linux-arm64
+        nominalQuota: '500'
+      - name: linux-c2xlarge-amd64
+        nominalQuota: '500'
+      - name: linux-c2xlarge-arm64
+        nominalQuota: '500'
+      - name: linux-c4xlarge-amd64
+        nominalQuota: '500'
+      - name: linux-c4xlarge-arm64
+        nominalQuota: '500'
+      - name: linux-c6gd2xlarge-arm64
+        nominalQuota: '500'
+      - name: linux-c8xlarge-amd64
+        nominalQuota: '500'
+      - name: linux-c8xlarge-arm64
+        nominalQuota: '500'
+      - name: linux-cxlarge-amd64
+        nominalQuota: '500'
+      - name: linux-cxlarge-arm64
+        nominalQuota: '500'
+      - name: linux-d160-c8xlarge-amd64
+        nominalQuota: '500'
+      - name: linux-d160-c8xlarge-arm64
+        nominalQuota: '500'
+      - name: linux-d160-m2xlarge-amd64
+        nominalQuota: '500'
+      - name: linux-d160-m2xlarge-arm64
+        nominalQuota: '500'
+      - name: linux-d160-m4xlarge-amd64
+        nominalQuota: '500'
+  - coveredResources:
+    - linux-d160-m4xlarge-arm64
+    - linux-d160-m7-8xlarge-amd64
+    - linux-d160-m8-8xlarge-arm64
+    - linux-d320-m8xlarge-amd64
+    - linux-d320-m8xlarge-arm64
+    - linux-extra-fast-amd64
+    - linux-fast-amd64
+    - linux-g64xlarge-amd64
+    - linux-m2xlarge-amd64
+    - linux-m2xlarge-arm64
+    - linux-m4xlarge-amd64
+    - linux-m4xlarge-arm64
+    - linux-m8xlarge-amd64
+    - linux-m8xlarge-arm64
+    - linux-mlarge-amd64
+    - linux-mlarge-arm64
+    flavors:
+    - name: platform-group-2
+      resources:
+      - name: linux-d160-m4xlarge-arm64
+        nominalQuota: '500'
+      - name: linux-d160-m7-8xlarge-amd64
+        nominalQuota: '500'
+      - name: linux-d160-m8-8xlarge-arm64
+        nominalQuota: '500'
+      - name: linux-d320-m8xlarge-amd64
+        nominalQuota: '500'
+      - name: linux-d320-m8xlarge-arm64
+        nominalQuota: '500'
+      - name: linux-extra-fast-amd64
+        nominalQuota: '500'
+      - name: linux-fast-amd64
+        nominalQuota: '500'
+      - name: linux-g64xlarge-amd64
+        nominalQuota: '500'
+      - name: linux-m2xlarge-amd64
+        nominalQuota: '500'
+      - name: linux-m2xlarge-arm64
+        nominalQuota: '500'
+      - name: linux-m4xlarge-amd64
+        nominalQuota: '500'
+      - name: linux-m4xlarge-arm64
+        nominalQuota: '500'
+      - name: linux-m8xlarge-amd64
+        nominalQuota: '500'
+      - name: linux-m8xlarge-arm64
+        nominalQuota: '500'
+      - name: linux-mlarge-amd64
+        nominalQuota: '500'
+      - name: linux-mlarge-arm64
+        nominalQuota: '500'
+  - coveredResources:
+    - linux-mxlarge-amd64
+    - linux-mxlarge-arm64
+    - linux-ppc64le
+    - linux-root-amd64
+    - linux-root-arm64
+    - linux-s390x
+    - linux-x86-64
+    - local
+    - localhost
+    flavors:
+    - name: platform-group-3
+      resources:
+      - name: linux-mxlarge-amd64
+        nominalQuota: '500'
+      - name: linux-mxlarge-arm64
+        nominalQuota: '500'
+      - name: linux-ppc64le
+        nominalQuota: '64'
+      - name: linux-root-amd64
+        nominalQuota: '500'
+      - name: linux-root-arm64
+        nominalQuota: '500'
+      - name: linux-s390x
+        nominalQuota: '56'
+      - name: linux-x86-64
+        nominalQuota: 1k
+      - name: local
+        nominalQuota: 1k
+      - name: localhost
+        nominalQuota: 1k
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: ResourceFlavor
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "10"
+  name: default-flavor
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: ResourceFlavor
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "10"
+  name: platform-group-1
+spec: {}
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: ResourceFlavor
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "10"
+  name: platform-group-2
+spec: {}
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: ResourceFlavor
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "10"
+  name: platform-group-3
+spec: {}

--- a/components/kueue-rd/rings/ring-2/kflux-prd-rh03/config.yaml
+++ b/components/kueue-rd/rings/ring-2/kflux-prd-rh03/config.yaml
@@ -1,0 +1,153 @@
+queueName: pipelines-queue
+cel:
+  expressions:
+    # Set resource requests for multi platform pipelines
+    - |
+        has(pipelineRun.spec.params) &&
+        pipelineRun.spec.params.exists(p, p.name == 'build-platforms') &&
+        type(pipelineRun.spec.params.filter(p, p.name == 'build-platforms')[0].value) == list ?
+        pipelineRun.spec.params.filter(
+          p,
+          p.name == 'build-platforms')[0]
+        .value.map(
+          p,
+          resource(replace(replace(p, "/", "-"), "_", "-"), 1)
+        ) : []
+
+    # Request AWS IP for AWS-based platforms
+    - |
+        has(pipelineRun.spec.params) &&
+        pipelineRun.spec.params.exists(p, p.name == 'build-platforms') &&
+        type(pipelineRun.spec.params.filter(p, p.name == 'build-platforms')[0].value) == list ?
+        pipelineRun.spec.params.filter(
+          p,
+          p.name == 'build-platforms')[0]
+        .value.filter(
+          p,
+          !(
+            p in [
+              'linux/ppc64le',
+              'linux/s390x',
+              'linux/x86_64',
+              'local',
+              'localhost',
+            ]
+          )
+        ).map(
+          p,
+          resource('aws-ip', 1)
+        ) : []
+
+    # Flag validation error when build-platforms is present but not a list
+    - |
+        has(pipelineRun.spec.params) &&
+        pipelineRun.spec.params.exists(p, p.name == 'build-platforms') &&
+        type(pipelineRun.spec.params.filter(p, p.name == 'build-platforms')[0].value) != list ?
+        [annotation('kueue.konflux-ci.dev/validation-error',
+          'build-platforms parameter must be an array of platform strings, got a non-array value')] : []
+
+    # Set resource requests for multi platform pipelines which doesn't use the build-platforms parameter (old style)
+    - |
+      !(
+        has(pipelineRun.spec.params) &&
+        pipelineRun.spec.params.exists(p, p.name == 'build-platforms')
+      ) &&
+      has(pipelineRun.spec.pipelineSpec) &&
+      has(pipelineRun.spec.pipelineSpec.tasks) &&
+      pipelineRun.spec.pipelineSpec.tasks.size() > 0 ?
+      pipelineRun.spec.pipelineSpec.tasks.map(
+        task,
+        has(task.params) ? task.params.filter(p, p.name == 'PLATFORM') : []
+      )
+      .filter(p, p.size() > 0)
+      .map(
+        p,
+        resource(replace(replace(p[0].value, "/", "-"), "_", "-"), 1)
+      ) : []
+
+    # Request AWS IP for AWS-based platforms which doesn't use the build-platforms parameter (old style)
+    - |
+      !(
+        has(pipelineRun.spec.params) &&
+        pipelineRun.spec.params.exists(p, p.name == 'build-platforms')
+      ) &&
+      has(pipelineRun.spec.pipelineSpec) &&
+      has(pipelineRun.spec.pipelineSpec.tasks) &&
+      pipelineRun.spec.pipelineSpec.tasks.size() > 0 ?
+      pipelineRun.spec.pipelineSpec.tasks.map(
+        task,
+        has(task.params) ? task.params.filter(p, p.name == 'PLATFORM') : []
+      )
+      .filter(p, p.size() > 0)
+      .filter(
+        p,
+        !(
+          p[0].value in [
+            'linux/ppc64le',
+            'linux/s390x',
+            'linux/x86_64',
+            'local',
+            'localhost',
+          ]
+        )
+      )
+      .map(
+        p,
+        resource('aws-ip', 1)
+      ) : []
+
+    # Set mintmaker resource requests.
+    # Necessary since mintmaker refreshes can overload clusters without a
+    # bottleneck on the number of pipelineruns running.
+    - |
+        plrNamespace == 'mintmaker' ? [resource('mintmaker', 1)] : []
+
+    # The token mechanism allows us to balance admitted PipelineRuns.
+    # Each PipelineRun requests 1 token. The token quota is set equal
+    # to the PLR limit so current behavior is unchanged.
+    - |
+        resource('konflux-ci-dev-token', 1)
+
+    # Set the pipeline priority
+    - |
+        has(pipelineRun.metadata.labels) &&
+        'build.appstudio.redhat.com/type' in pipelineRun.metadata.labels &&
+        pipelineRun.metadata.labels['build.appstudio.redhat.com/type'] == 'nudge' ?
+        priority('konflux-nudge') :
+
+        pacEventType == 'push' ? priority('konflux-post-merge-build') :
+        pacEventType == 'pull_request' ||
+          pacEventType == "Merge_Request" ||
+          pacEventType == 'test-comment' ||
+          pacEventType == 'retest-comment' ||
+          pacEventType == 'retest-all-comment' ||
+          pacEventType == 'ok-to-test-comment'  ? priority('konflux-pre-merge-build') :
+        pacTestEventType == 'push' ? priority('konflux-post-merge-test') :
+        pacTestEventType == 'pull_request' ||
+          pacTestEventType == "Merge_Request" ||
+          pacTestEventType == 'test-comment' ||
+          pacTestEventType == 'retest-comment' ||
+          pacTestEventType == 'retest-all-comment' ||
+          pacTestEventType == 'ok-to-test-comment' ? priority('konflux-pre-merge-test') :
+
+        has(pipelineRun.metadata.labels) &&
+        'appstudio.openshift.io/service' in pipelineRun.metadata.labels &&
+        pipelineRun.metadata.labels['appstudio.openshift.io/service'] == 'release' &&
+        'pipelines.appstudio.openshift.io/type' in pipelineRun.metadata.labels &&
+        pipelineRun.metadata.labels['pipelines.appstudio.openshift.io/type'] == 'managed' ?
+        priority('konflux-release') :
+
+        has(pipelineRun.metadata.labels) &&
+        'appstudio.openshift.io/service' in pipelineRun.metadata.labels &&
+        pipelineRun.metadata.labels['appstudio.openshift.io/service'] == 'release' &&
+        'release.appstudio.openshift.io/namespace' in pipelineRun.metadata.labels &&
+        pipelineRun.metadata.labels['release.appstudio.openshift.io/namespace'] == plrNamespace ?
+        priority('konflux-tenant-release') :
+
+        plrNamespace == 'mintmaker' ? priority('konflux-dependency-update') :
+
+        has(pipelineRun.metadata.labels) &&
+        'internal-services.appstudio.openshift.io/pipelinerun-uid' in pipelineRun.metadata.labels ?
+        priority('konflux-release') :
+
+        priority('konflux-default')

--- a/components/kueue-rd/rings/ring-2/kflux-prd-rh03/kustomization.yaml
+++ b/components/kueue-rd/rings/ring-2/kflux-prd-rh03/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- cluster-queue.yaml
+- ../base
+
+configMapGenerator:
+  - name: tekton-kueue-config
+    namespace: tekton-kueue
+    behavior: replace
+    files:
+      - config.yaml
+generatorOptions:
+  disableNameSuffixHash: true

--- a/components/kueue-rd/rings/ring-2/kflux-rhel-p01/cluster-queue.yaml
+++ b/components/kueue-rd/rings/ring-2/kflux-rhel-p01/cluster-queue.yaml
@@ -1,0 +1,232 @@
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: ClusterQueue
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "10"
+  name: cluster-pipeline-queue
+spec:
+  flavorFungibility:
+    whenCanBorrow: MayStopSearch
+    whenCanPreempt: TryNextFlavor
+  namespaceSelector: {}
+  preemption:
+    borrowWithinCohort:
+      policy: Never
+    reclaimWithinCohort: Never
+    withinClusterQueue: Never
+  queueingStrategy: BestEffortFIFO
+  resourceGroups:
+  - coveredResources:
+    - tekton.dev/pipelineruns
+    - konflux-ci-dev-token
+    - cpu
+    - memory
+    - aws-ip
+    - mintmaker
+    - konflux-release
+    flavors:
+    - name: default-flavor
+      resources:
+      - name: tekton.dev/pipelineruns
+        nominalQuota: '400'
+      - name: konflux-ci-dev-token
+        nominalQuota: '300'
+      - name: cpu
+        nominalQuota: 1k
+      - name: memory
+        nominalQuota: 500Ti
+      - name: aws-ip
+        nominalQuota: '250'
+      - name: mintmaker
+        nominalQuota: '150'
+      - name: konflux-release
+        nominalQuota: '100'
+  - coveredResources:
+    - linux-amd64
+    - linux-arm64
+    - linux-c2xlarge-amd64
+    - linux-c2xlarge-arm64
+    - linux-c4xlarge-amd64
+    - linux-c4xlarge-arm64
+    - linux-c6gd2xlarge-arm64
+    - linux-c8xlarge-amd64
+    - linux-c8xlarge-arm64
+    - linux-cxlarge-amd64
+    - linux-cxlarge-arm64
+    - linux-d160-c8xlarge-amd64
+    - linux-d160-c8xlarge-arm64
+    - linux-d160-m2xlarge-amd64
+    - linux-d160-m2xlarge-arm64
+    - linux-d160-m4xlarge-amd64
+    flavors:
+    - name: platform-group-1
+      resources:
+      - name: linux-amd64
+        nominalQuota: '250'
+      - name: linux-arm64
+        nominalQuota: '250'
+      - name: linux-c2xlarge-amd64
+        nominalQuota: '250'
+      - name: linux-c2xlarge-arm64
+        nominalQuota: '250'
+      - name: linux-c4xlarge-amd64
+        nominalQuota: '250'
+      - name: linux-c4xlarge-arm64
+        nominalQuota: '250'
+      - name: linux-c6gd2xlarge-arm64
+        nominalQuota: '250'
+      - name: linux-c8xlarge-amd64
+        nominalQuota: '250'
+      - name: linux-c8xlarge-arm64
+        nominalQuota: '250'
+      - name: linux-cxlarge-amd64
+        nominalQuota: '250'
+      - name: linux-cxlarge-arm64
+        nominalQuota: '250'
+      - name: linux-d160-c8xlarge-amd64
+        nominalQuota: '250'
+      - name: linux-d160-c8xlarge-arm64
+        nominalQuota: '250'
+      - name: linux-d160-m2xlarge-amd64
+        nominalQuota: '250'
+      - name: linux-d160-m2xlarge-arm64
+        nominalQuota: '250'
+      - name: linux-d160-m4xlarge-amd64
+        nominalQuota: '250'
+  - coveredResources:
+    - linux-d160-m4xlarge-arm64
+    - linux-d160-m8xlarge-amd64
+    - linux-d160-m8xlarge-arm64
+    - linux-d160-mlarge-amd64
+    - linux-d160-mlarge-arm64
+    - linux-d160-mxlarge-amd64
+    - linux-d160-mxlarge-arm64
+    - linux-d320-m8xlarge-amd64
+    - linux-d320-m8xlarge-arm64
+    - linux-extra-fast-amd64
+    - linux-fast-amd64
+    - linux-g64xlarge-amd64
+    - linux-large-s390x
+    - linux-m2xlarge-amd64
+    - linux-m2xlarge-arm64
+    - linux-m4xlarge-amd64
+    flavors:
+    - name: platform-group-2
+      resources:
+      - name: linux-d160-m4xlarge-arm64
+        nominalQuota: '250'
+      - name: linux-d160-m8xlarge-amd64
+        nominalQuota: '250'
+      - name: linux-d160-m8xlarge-arm64
+        nominalQuota: '250'
+      - name: linux-d160-mlarge-amd64
+        nominalQuota: '250'
+      - name: linux-d160-mlarge-arm64
+        nominalQuota: '250'
+      - name: linux-d160-mxlarge-amd64
+        nominalQuota: '250'
+      - name: linux-d160-mxlarge-arm64
+        nominalQuota: '250'
+      - name: linux-d320-m8xlarge-amd64
+        nominalQuota: '250'
+      - name: linux-d320-m8xlarge-arm64
+        nominalQuota: '250'
+      - name: linux-extra-fast-amd64
+        nominalQuota: '250'
+      - name: linux-fast-amd64
+        nominalQuota: '250'
+      - name: linux-g64xlarge-amd64
+        nominalQuota: '250'
+      - name: linux-large-s390x
+        nominalQuota: '3'
+      - name: linux-m2xlarge-amd64
+        nominalQuota: '250'
+      - name: linux-m2xlarge-arm64
+        nominalQuota: '250'
+      - name: linux-m4xlarge-amd64
+        nominalQuota: '250'
+  - coveredResources:
+    - linux-m4xlarge-arm64
+    - linux-m8xlarge-amd64
+    - linux-m8xlarge-arm64
+    - linux-mlarge-amd64
+    - linux-mlarge-arm64
+    - linux-mxlarge-amd64
+    - linux-mxlarge-arm64
+    - linux-ppc64le
+    - linux-riscv64
+    - linux-root-amd64
+    - linux-root-arm64
+    - linux-s390x
+    - linux-x86-64
+    - local
+    - localhost
+    flavors:
+    - name: platform-group-3
+      resources:
+      - name: linux-m4xlarge-arm64
+        nominalQuota: '250'
+      - name: linux-m8xlarge-amd64
+        nominalQuota: '250'
+      - name: linux-m8xlarge-arm64
+        nominalQuota: '250'
+      - name: linux-mlarge-amd64
+        nominalQuota: '250'
+      - name: linux-mlarge-arm64
+        nominalQuota: '250'
+      - name: linux-mxlarge-amd64
+        nominalQuota: '250'
+      - name: linux-mxlarge-arm64
+        nominalQuota: '250'
+      - name: linux-ppc64le
+        nominalQuota: '64'
+      - name: linux-riscv64
+        nominalQuota: '2'
+      - name: linux-root-amd64
+        nominalQuota: '250'
+      - name: linux-root-arm64
+        nominalQuota: '250'
+      - name: linux-s390x
+        nominalQuota: '60'
+      - name: linux-x86-64
+        nominalQuota: 1k
+      - name: local
+        nominalQuota: 1k
+      - name: localhost
+        nominalQuota: 1k
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: ResourceFlavor
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "10"
+  name: default-flavor
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: ResourceFlavor
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "10"
+  name: platform-group-1
+spec: {}
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: ResourceFlavor
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "10"
+  name: platform-group-2
+spec: {}
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: ResourceFlavor
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "10"
+  name: platform-group-3
+spec: {}

--- a/components/kueue-rd/rings/ring-2/kflux-rhel-p01/config.yaml
+++ b/components/kueue-rd/rings/ring-2/kflux-rhel-p01/config.yaml
@@ -1,0 +1,176 @@
+queueName: pipelines-queue
+cel:
+  expressions:
+    # Set resource requests for multi platform pipelines
+    - |
+        has(pipelineRun.spec.params) &&
+        pipelineRun.spec.params.exists(p, p.name == 'build-platforms') &&
+        type(pipelineRun.spec.params.filter(p, p.name == 'build-platforms')[0].value) == list ?
+        pipelineRun.spec.params.filter(
+          p,
+          p.name == 'build-platforms')[0]
+        .value.map(
+          p,
+          resource(replace(replace(p, "/", "-"), "_", "-"), 1)
+        ) : []
+
+    # Request AWS IP for AWS-based platforms
+    - |
+        has(pipelineRun.spec.params) &&
+        pipelineRun.spec.params.exists(p, p.name == 'build-platforms') &&
+        type(pipelineRun.spec.params.filter(p, p.name == 'build-platforms')[0].value) == list ?
+        pipelineRun.spec.params.filter(
+          p,
+          p.name == 'build-platforms')[0]
+        .value.filter(
+          p,
+          !(
+            p in [
+              'linux/ppc64le',
+              'linux/s390x',
+              'linux/x86_64',
+              'local',
+              'localhost',
+            ]
+          )
+        ).map(
+          p,
+          resource('aws-ip', 1)
+        ) : []
+
+    # Flag validation error when build-platforms is present but not a list
+    - |
+        has(pipelineRun.spec.params) &&
+        pipelineRun.spec.params.exists(p, p.name == 'build-platforms') &&
+        type(pipelineRun.spec.params.filter(p, p.name == 'build-platforms')[0].value) != list ?
+        [annotation('kueue.konflux-ci.dev/validation-error',
+          'build-platforms parameter must be an array of platform strings, got a non-array value')] : []
+
+    # Set resource requests for multi platform pipelines which doesn't use the build-platforms parameter (old style)
+    - |
+      !(
+        has(pipelineRun.spec.params) &&
+        pipelineRun.spec.params.exists(p, p.name == 'build-platforms')
+      ) &&
+      has(pipelineRun.spec.pipelineSpec) &&
+      has(pipelineRun.spec.pipelineSpec.tasks) &&
+      pipelineRun.spec.pipelineSpec.tasks.size() > 0 ?
+      pipelineRun.spec.pipelineSpec.tasks.map(
+        task,
+        has(task.params) ? task.params.filter(p, p.name == 'PLATFORM') : []
+      )
+      .filter(p, p.size() > 0)
+      .map(
+        p,
+        resource(replace(replace(p[0].value, "/", "-"), "_", "-"), 1)
+      ) : []
+
+    # Request AWS IP for AWS-based platforms which doesn't use the build-platforms parameter (old style)
+    - |
+      !(
+        has(pipelineRun.spec.params) &&
+        pipelineRun.spec.params.exists(p, p.name == 'build-platforms')
+      ) &&
+      has(pipelineRun.spec.pipelineSpec) &&
+      has(pipelineRun.spec.pipelineSpec.tasks) &&
+      pipelineRun.spec.pipelineSpec.tasks.size() > 0 ?
+      pipelineRun.spec.pipelineSpec.tasks.map(
+        task,
+        has(task.params) ? task.params.filter(p, p.name == 'PLATFORM') : []
+      )
+      .filter(p, p.size() > 0)
+      .filter(
+        p,
+        !(
+          p[0].value in [
+            'linux/ppc64le',
+            'linux/s390x',
+            'linux/x86_64',
+            'local',
+            'localhost',
+          ]
+        )
+      )
+      .map(
+        p,
+        resource('aws-ip', 1)
+      ) : []
+
+    # Set mintmaker resource requests.
+    # Necessary since mintmaker refreshes can overload clusters without a
+    # bottleneck on the number of pipelineruns running.
+    - |
+        plrNamespace == 'mintmaker' ? [resource('mintmaker', 1)] : []
+
+    # The token mechanism allows us to balance admitted PipelineRuns.
+    # Each PipelineRun requests 1 token, except for internal-services PLRs.
+    # This is to guarantee there is always room for internal-services PLRs.
+    #
+    #
+    # WARNING: As a temporary measure, we are using tokens to provide a priority lane
+    # for internal-services PLRs. They'll be removed in some time and moved to the
+    # common clusters.
+    - |
+        has(pipelineRun.metadata.labels) &&
+        'internal-services.appstudio.openshift.io/pipelinerun-uid' in pipelineRun.metadata.labels ?
+        [] : [resource('konflux-ci-dev-token', 1)]
+
+    # Add a resource to restrict the number of concurrent release pipelineruns
+    - |
+        has(pipelineRun.metadata.labels) &&
+        'appstudio.openshift.io/service' in pipelineRun.metadata.labels &&
+        pipelineRun.metadata.labels['appstudio.openshift.io/service'] == 'release' &&
+        'pipelines.appstudio.openshift.io/type' in pipelineRun.metadata.labels &&
+        pipelineRun.metadata.labels['pipelines.appstudio.openshift.io/type'] == 'managed' ?
+        [resource('konflux-release', 1)] :
+
+        has(pipelineRun.metadata.labels) &&
+        'appstudio.openshift.io/service' in pipelineRun.metadata.labels &&
+        pipelineRun.metadata.labels['appstudio.openshift.io/service'] == 'release' &&
+        'release.appstudio.openshift.io/namespace' in pipelineRun.metadata.labels &&
+        pipelineRun.metadata.labels['release.appstudio.openshift.io/namespace'] == plrNamespace ?
+        [resource('konflux-release', 1)] : []
+
+    # Set the pipeline priority
+    - |
+        has(pipelineRun.metadata.labels) &&
+        'build.appstudio.redhat.com/type' in pipelineRun.metadata.labels &&
+        pipelineRun.metadata.labels['build.appstudio.redhat.com/type'] == 'nudge' ?
+        priority('konflux-nudge') :
+
+        pacEventType == 'push' ? priority('konflux-post-merge-build') :
+        pacEventType == 'pull_request' ||
+          pacEventType == "Merge_Request" ||
+          pacEventType == 'test-comment' ||
+          pacEventType == 'retest-comment' ||
+          pacEventType == 'retest-all-comment' ||
+          pacEventType == 'ok-to-test-comment'  ? priority('konflux-pre-merge-build') :
+        pacTestEventType == 'push' ? priority('konflux-post-merge-test') :
+        pacTestEventType == 'pull_request' ||
+          pacTestEventType == "Merge_Request" ||
+          pacTestEventType == 'test-comment' ||
+          pacTestEventType == 'retest-comment' ||
+          pacTestEventType == 'retest-all-comment' ||
+          pacTestEventType == 'ok-to-test-comment' ? priority('konflux-pre-merge-test') :
+
+        has(pipelineRun.metadata.labels) &&
+        'appstudio.openshift.io/service' in pipelineRun.metadata.labels &&
+        pipelineRun.metadata.labels['appstudio.openshift.io/service'] == 'release' &&
+        'pipelines.appstudio.openshift.io/type' in pipelineRun.metadata.labels &&
+        pipelineRun.metadata.labels['pipelines.appstudio.openshift.io/type'] == 'managed' ?
+        priority('konflux-release') :
+
+        has(pipelineRun.metadata.labels) &&
+        'appstudio.openshift.io/service' in pipelineRun.metadata.labels &&
+        pipelineRun.metadata.labels['appstudio.openshift.io/service'] == 'release' &&
+        'release.appstudio.openshift.io/namespace' in pipelineRun.metadata.labels &&
+        pipelineRun.metadata.labels['release.appstudio.openshift.io/namespace'] == plrNamespace ?
+        priority('konflux-tenant-release') :
+
+        plrNamespace == 'mintmaker' ? priority('konflux-dependency-update') :
+
+        has(pipelineRun.metadata.labels) &&
+        'internal-services.appstudio.openshift.io/pipelinerun-uid' in pipelineRun.metadata.labels ?
+        priority('konflux-release') :
+
+        priority('konflux-default')

--- a/components/kueue-rd/rings/ring-2/kflux-rhel-p01/kustomization.yaml
+++ b/components/kueue-rd/rings/ring-2/kflux-rhel-p01/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- cluster-queue.yaml
+- ../base
+
+configMapGenerator:
+  - name: tekton-kueue-config
+    namespace: tekton-kueue
+    behavior: replace
+    files:
+      - config.yaml
+generatorOptions:
+  disableNameSuffixHash: true

--- a/components/kueue-rd/rings/ring-2/stone-prod-p01/cluster-queue.yaml
+++ b/components/kueue-rd/rings/ring-2/stone-prod-p01/cluster-queue.yaml
@@ -1,0 +1,199 @@
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: ClusterQueue
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "10"
+  name: cluster-pipeline-queue
+spec:
+  flavorFungibility:
+    whenCanBorrow: MayStopSearch
+    whenCanPreempt: TryNextFlavor
+  namespaceSelector: {}
+  preemption:
+    borrowWithinCohort:
+      policy: Never
+    reclaimWithinCohort: Never
+    withinClusterQueue: Never
+  queueingStrategy: BestEffortFIFO
+  resourceGroups:
+  - coveredResources:
+    - tekton.dev/pipelineruns
+    - konflux-ci-dev-token
+    - cpu
+    - memory
+    - aws-ip
+    - mintmaker
+    flavors:
+    - name: default-flavor
+      resources:
+      - name: tekton.dev/pipelineruns
+        nominalQuota: '300'
+      - name: konflux-ci-dev-token
+        nominalQuota: '300'
+      - name: cpu
+        nominalQuota: 1k
+      - name: memory
+        nominalQuota: 500Ti
+      - name: aws-ip
+        nominalQuota: '250'
+      - name: mintmaker
+        nominalQuota: '150'
+  - coveredResources:
+    - linux-amd64
+    - linux-arm64
+    - linux-c2xlarge-amd64
+    - linux-c2xlarge-arm64
+    - linux-c4xlarge-amd64
+    - linux-c4xlarge-arm64
+    - linux-c6gd2xlarge-arm64
+    - linux-c8xlarge-amd64
+    - linux-c8xlarge-arm64
+    - linux-cxlarge-amd64
+    - linux-cxlarge-arm64
+    - linux-d160-c8xlarge-amd64
+    - linux-d160-c8xlarge-arm64
+    - linux-d160-m2xlarge-amd64
+    - linux-d160-m2xlarge-arm64
+    - linux-d160-m4xlarge-amd64
+    flavors:
+    - name: platform-group-1
+      resources:
+      - name: linux-amd64
+        nominalQuota: '250'
+      - name: linux-arm64
+        nominalQuota: '250'
+      - name: linux-c2xlarge-amd64
+        nominalQuota: '250'
+      - name: linux-c2xlarge-arm64
+        nominalQuota: '250'
+      - name: linux-c4xlarge-amd64
+        nominalQuota: '250'
+      - name: linux-c4xlarge-arm64
+        nominalQuota: '250'
+      - name: linux-c6gd2xlarge-arm64
+        nominalQuota: '250'
+      - name: linux-c8xlarge-amd64
+        nominalQuota: '250'
+      - name: linux-c8xlarge-arm64
+        nominalQuota: '250'
+      - name: linux-cxlarge-amd64
+        nominalQuota: '250'
+      - name: linux-cxlarge-arm64
+        nominalQuota: '250'
+      - name: linux-d160-c8xlarge-amd64
+        nominalQuota: '250'
+      - name: linux-d160-c8xlarge-arm64
+        nominalQuota: '250'
+      - name: linux-d160-m2xlarge-amd64
+        nominalQuota: '250'
+      - name: linux-d160-m2xlarge-arm64
+        nominalQuota: '250'
+      - name: linux-d160-m4xlarge-amd64
+        nominalQuota: '250'
+  - coveredResources:
+    - linux-d160-m4xlarge-arm64
+    - linux-d160-m8xlarge-amd64
+    - linux-d160-m8xlarge-arm64
+    - linux-d320-m8xlarge-amd64
+    - linux-d320-m8xlarge-arm64
+    - linux-g64xlarge-amd64
+    - linux-m2xlarge-amd64
+    - linux-m2xlarge-arm64
+    - linux-m4xlarge-amd64
+    - linux-m4xlarge-arm64
+    - linux-m8xlarge-amd64
+    - linux-m8xlarge-arm64
+    - linux-mlarge-amd64
+    - linux-mlarge-arm64
+    - linux-mxlarge-amd64
+    - linux-mxlarge-arm64
+    flavors:
+    - name: platform-group-2
+      resources:
+      - name: linux-d160-m4xlarge-arm64
+        nominalQuota: '250'
+      - name: linux-d160-m8xlarge-amd64
+        nominalQuota: '250'
+      - name: linux-d160-m8xlarge-arm64
+        nominalQuota: '250'
+      - name: linux-d320-m8xlarge-amd64
+        nominalQuota: '250'
+      - name: linux-d320-m8xlarge-arm64
+        nominalQuota: '250'
+      - name: linux-g64xlarge-amd64
+        nominalQuota: '250'
+      - name: linux-m2xlarge-amd64
+        nominalQuota: '250'
+      - name: linux-m2xlarge-arm64
+        nominalQuota: '250'
+      - name: linux-m4xlarge-amd64
+        nominalQuota: '250'
+      - name: linux-m4xlarge-arm64
+        nominalQuota: '250'
+      - name: linux-m8xlarge-amd64
+        nominalQuota: '250'
+      - name: linux-m8xlarge-arm64
+        nominalQuota: '250'
+      - name: linux-mlarge-amd64
+        nominalQuota: '250'
+      - name: linux-mlarge-arm64
+        nominalQuota: '250'
+      - name: linux-mxlarge-amd64
+        nominalQuota: '250'
+      - name: linux-mxlarge-arm64
+        nominalQuota: '250'
+  - coveredResources:
+    - linux-root-amd64
+    - linux-root-arm64
+    - linux-x86-64
+    - local
+    - localhost
+    flavors:
+    - name: platform-group-3
+      resources:
+      - name: linux-root-amd64
+        nominalQuota: '250'
+      - name: linux-root-arm64
+        nominalQuota: '250'
+      - name: linux-x86-64
+        nominalQuota: 1k
+      - name: local
+        nominalQuota: 1k
+      - name: localhost
+        nominalQuota: 1k
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: ResourceFlavor
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "10"
+  name: default-flavor
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: ResourceFlavor
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "10"
+  name: platform-group-1
+spec: {}
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: ResourceFlavor
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "10"
+  name: platform-group-2
+spec: {}
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: ResourceFlavor
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "10"
+  name: platform-group-3
+spec: {}

--- a/components/kueue-rd/rings/ring-2/stone-prod-p01/config.yaml
+++ b/components/kueue-rd/rings/ring-2/stone-prod-p01/config.yaml
@@ -1,0 +1,153 @@
+queueName: pipelines-queue
+cel:
+  expressions:
+    # Set resource requests for multi platform pipelines
+    - |
+        has(pipelineRun.spec.params) &&
+        pipelineRun.spec.params.exists(p, p.name == 'build-platforms') &&
+        type(pipelineRun.spec.params.filter(p, p.name == 'build-platforms')[0].value) == list ?
+        pipelineRun.spec.params.filter(
+          p,
+          p.name == 'build-platforms')[0]
+        .value.map(
+          p,
+          resource(replace(replace(p, "/", "-"), "_", "-"), 1)
+        ) : []
+
+    # Request AWS IP for AWS-based platforms
+    - |
+        has(pipelineRun.spec.params) &&
+        pipelineRun.spec.params.exists(p, p.name == 'build-platforms') &&
+        type(pipelineRun.spec.params.filter(p, p.name == 'build-platforms')[0].value) == list ?
+        pipelineRun.spec.params.filter(
+          p,
+          p.name == 'build-platforms')[0]
+        .value.filter(
+          p,
+          !(
+            p in [
+              'linux/ppc64le',
+              'linux/s390x',
+              'linux/x86_64',
+              'local',
+              'localhost',
+            ]
+          )
+        ).map(
+          p,
+          resource('aws-ip', 1)
+        ) : []
+
+    # Flag validation error when build-platforms is present but not a list
+    - |
+        has(pipelineRun.spec.params) &&
+        pipelineRun.spec.params.exists(p, p.name == 'build-platforms') &&
+        type(pipelineRun.spec.params.filter(p, p.name == 'build-platforms')[0].value) != list ?
+        [annotation('kueue.konflux-ci.dev/validation-error',
+          'build-platforms parameter must be an array of platform strings, got a non-array value')] : []
+
+    # Set resource requests for multi platform pipelines which doesn't use the build-platforms parameter (old style)
+    - |
+      !(
+        has(pipelineRun.spec.params) &&
+        pipelineRun.spec.params.exists(p, p.name == 'build-platforms')
+      ) &&
+      has(pipelineRun.spec.pipelineSpec) &&
+      has(pipelineRun.spec.pipelineSpec.tasks) &&
+      pipelineRun.spec.pipelineSpec.tasks.size() > 0 ?
+      pipelineRun.spec.pipelineSpec.tasks.map(
+        task,
+        has(task.params) ? task.params.filter(p, p.name == 'PLATFORM') : []
+      )
+      .filter(p, p.size() > 0)
+      .map(
+        p,
+        resource(replace(replace(p[0].value, "/", "-"), "_", "-"), 1)
+      ) : []
+
+    # Request AWS IP for AWS-based platforms which doesn't use the build-platforms parameter (old style)
+    - |
+      !(
+        has(pipelineRun.spec.params) &&
+        pipelineRun.spec.params.exists(p, p.name == 'build-platforms')
+      ) &&
+      has(pipelineRun.spec.pipelineSpec) &&
+      has(pipelineRun.spec.pipelineSpec.tasks) &&
+      pipelineRun.spec.pipelineSpec.tasks.size() > 0 ?
+      pipelineRun.spec.pipelineSpec.tasks.map(
+        task,
+        has(task.params) ? task.params.filter(p, p.name == 'PLATFORM') : []
+      )
+      .filter(p, p.size() > 0)
+      .filter(
+        p,
+        !(
+          p[0].value in [
+            'linux/ppc64le',
+            'linux/s390x',
+            'linux/x86_64',
+            'local',
+            'localhost',
+          ]
+        )
+      )
+      .map(
+        p,
+        resource('aws-ip', 1)
+      ) : []
+
+    # Set mintmaker resource requests.
+    # Necessary since mintmaker refreshes can overload clusters without a
+    # bottleneck on the number of pipelineruns running.
+    - |
+        plrNamespace == 'mintmaker' ? [resource('mintmaker', 1)] : []
+
+    # The token mechanism allows us to balance admitted PipelineRuns.
+    # Each PipelineRun requests 1 token. The token quota is set equal
+    # to the PLR limit so current behavior is unchanged.
+    - |
+        resource('konflux-ci-dev-token', 1)
+
+    # Set the pipeline priority
+    - |
+        has(pipelineRun.metadata.labels) &&
+        'build.appstudio.redhat.com/type' in pipelineRun.metadata.labels &&
+        pipelineRun.metadata.labels['build.appstudio.redhat.com/type'] == 'nudge' ?
+        priority('konflux-nudge') :
+
+        pacEventType == 'push' ? priority('konflux-post-merge-build') :
+        pacEventType == 'pull_request' ||
+          pacEventType == "Merge_Request" ||
+          pacEventType == 'test-comment' ||
+          pacEventType == 'retest-comment' ||
+          pacEventType == 'retest-all-comment' ||
+          pacEventType == 'ok-to-test-comment'  ? priority('konflux-pre-merge-build') :
+        pacTestEventType == 'push' ? priority('konflux-post-merge-test') :
+        pacTestEventType == 'pull_request' ||
+          pacTestEventType == "Merge_Request" ||
+          pacTestEventType == 'test-comment' ||
+          pacTestEventType == 'retest-comment' ||
+          pacTestEventType == 'retest-all-comment' ||
+          pacTestEventType == 'ok-to-test-comment' ? priority('konflux-pre-merge-test') :
+
+        has(pipelineRun.metadata.labels) &&
+        'appstudio.openshift.io/service' in pipelineRun.metadata.labels &&
+        pipelineRun.metadata.labels['appstudio.openshift.io/service'] == 'release' &&
+        'pipelines.appstudio.openshift.io/type' in pipelineRun.metadata.labels &&
+        pipelineRun.metadata.labels['pipelines.appstudio.openshift.io/type'] == 'managed' ?
+        priority('konflux-release') :
+
+        has(pipelineRun.metadata.labels) &&
+        'appstudio.openshift.io/service' in pipelineRun.metadata.labels &&
+        pipelineRun.metadata.labels['appstudio.openshift.io/service'] == 'release' &&
+        'release.appstudio.openshift.io/namespace' in pipelineRun.metadata.labels &&
+        pipelineRun.metadata.labels['release.appstudio.openshift.io/namespace'] == plrNamespace ?
+        priority('konflux-tenant-release') :
+
+        plrNamespace == 'mintmaker' ? priority('konflux-dependency-update') :
+
+        has(pipelineRun.metadata.labels) &&
+        'internal-services.appstudio.openshift.io/pipelinerun-uid' in pipelineRun.metadata.labels ?
+        priority('konflux-release') :
+
+        priority('konflux-default')

--- a/components/kueue-rd/rings/ring-2/stone-prod-p01/kustomization.yaml
+++ b/components/kueue-rd/rings/ring-2/stone-prod-p01/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- cluster-queue.yaml
+- ../base
+
+configMapGenerator:
+  - name: tekton-kueue-config
+    namespace: tekton-kueue
+    behavior: replace
+    files:
+      - config.yaml
+generatorOptions:
+  disableNameSuffixHash: true

--- a/components/kueue-rd/rings/ring-3/base/base-snapshot/kueue/kueue.yaml
+++ b/components/kueue-rd/rings/ring-3/base/base-snapshot/kueue/kueue.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: kueue.openshift.io/v1
+kind: Kueue
+metadata:
+  labels:
+    app.kubernetes.io/name: kueue-operator
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+  name: cluster
+  namespace: openshift-kueue-operator
+spec:
+  managementState: Managed
+  config:
+    integrations:
+      frameworks: # The operator requires at lest one framework to be enabled
+      - BatchJob
+      externalFrameworks:
+      - group: tekton.dev
+        version: v1
+        resource: pipelineruns

--- a/components/kueue-rd/rings/ring-3/base/base-snapshot/kueue/kustomization.yaml
+++ b/components/kueue-rd/rings/ring-3/base/base-snapshot/kueue/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- kueue.yaml
+- ns.yaml
+- operator-group.yaml
+- subscription.yaml
+
+namespace: openshift-kueue-operator

--- a/components/kueue-rd/rings/ring-3/base/base-snapshot/kueue/ns.yaml
+++ b/components/kueue-rd/rings/ring-3/base/base-snapshot/kueue/ns.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-kueue-operator
+  labels:
+    openshift.io/cluster-monitoring: "true"
+  annotations:
+    argocd.argoproj.io/sync-wave: "-4"
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true

--- a/components/kueue-rd/rings/ring-3/base/base-snapshot/kueue/operator-group.yaml
+++ b/components/kueue-rd/rings/ring-3/base/base-snapshot/kueue/operator-group.yaml
@@ -1,0 +1,8 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: openshift-kueue-operatorgroup
+  annotations:
+    argocd.argoproj.io/sync-wave: "-2"
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec: {}

--- a/components/kueue-rd/rings/ring-3/base/base-snapshot/kueue/subscription.yaml
+++ b/components/kueue-rd/rings/ring-3/base/base-snapshot/kueue/subscription.yaml
@@ -1,0 +1,14 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: openshift-kueue-operator
+  namespace: openshift-kueue-operator
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  channel: stable-v1.3
+  installPlanApproval: Automatic
+  name: kueue-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace

--- a/components/kueue-rd/rings/ring-3/base/base-snapshot/kustomization.yaml
+++ b/components/kueue-rd/rings/ring-3/base/base-snapshot/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- workload-priority-classes.yaml
+- kueue
+- tekton-kueue

--- a/components/kueue-rd/rings/ring-3/base/base-snapshot/tekton-kueue/kustomization.yaml
+++ b/components/kueue-rd/rings/ring-3/base/base-snapshot/tekton-kueue/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- monitoring
+- rbac
+
+namespace: tekton-kueue

--- a/components/kueue-rd/rings/ring-3/base/base-snapshot/tekton-kueue/monitoring/kustomization.yaml
+++ b/components/kueue-rd/rings/ring-3/base/base-snapshot/tekton-kueue/monitoring/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- tekton-kueue-webhook-sm.yaml
+- tekton-kueue-controller-sm.yaml
+- prometheus-rule.yaml
+
+namespace: tekton-kueue

--- a/components/kueue-rd/rings/ring-3/base/base-snapshot/tekton-kueue/monitoring/prometheus-rule.yaml
+++ b/components/kueue-rd/rings/ring-3/base/base-snapshot/tekton-kueue/monitoring/prometheus-rule.yaml
@@ -1,0 +1,242 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: kueue-alerts
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  groups:
+  - name: kueue.health
+    interval: 30s
+    rules:
+    - alert: KueueHighAdmissionLatency
+      expr: histogram_quantile(0.99, sum(increase(kueue_admission_attempt_duration_seconds_bucket[5m])) by (le)) > 30
+      for: 2m
+      labels:
+        severity: warning
+        component: kueue
+      annotations:
+        summary: "Kueue admission latency is high"
+        description: "99th percentile of Kueue admission attempt duration is {{ $value }}s, which is above the threshold of 30s"
+        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue.md?ref_type=heads
+        alert_team_handle: <!subteam^S05Q1P4Q2TG>
+        team: konflux-infra
+
+    - alert: KueueReplicasNotAvailable
+      expr: |
+        (
+          kube_deployment_status_replicas_available{namespace=~"openshift-kueue-operator|tekton-kueue"}
+        )
+        /
+        clamp_min(
+          kube_deployment_spec_replicas{namespace=~"openshift-kueue-operator|tekton-kueue"},
+          1
+        ) * 100 < 100
+      for: 5m
+      labels:
+        severity: warning
+        component: kueue
+      annotations:
+        summary: "Kueue deployment {{ $labels.deployment }} has unavailable replicas"
+        description: "Deployment {{ $labels.deployment }} has {{ $value }}% available replicas, which is less than 100%"
+        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue.md?ref_type=heads
+        alert_team_handle: <!subteam^S05Q1P4Q2TG>
+        team: konflux-infra
+
+    - alert: KueueHighMemoryUtilization
+      expr: |
+        (
+            container_memory_working_set_bytes{namespace=~"tekton-kueue|openshift-kueue-operator", image!=""}
+            * on(container, pod)
+            group_left
+            kube_pod_container_status_ready{namespace=~"tekton-kueue|openshift-kueue-operator"}
+        )
+            / on (pod) kube_pod_resource_limit{resource='memory',namespace=~"tekton-kueue|openshift-kueue-operator"} * 100 > 70
+      for: 5m
+      labels:
+        severity: warning
+        component: kueue
+      annotations:
+        summary: "Kueue pod {{ $labels.pod }} has high memory utilization"
+        description: "Pod {{ $labels.pod }} memory utilization is {{ $value }}%, which is above 70%"
+        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue.md?ref_type=heads
+        alert_team_handle: <!subteam^S05Q1P4Q2TG>
+        team: konflux-infra
+
+    - alert: KueueHighCPUUtilization
+      expr: |
+        (
+            pod:container_cpu_usage:sum{namespace=~"tekton-kueue|openshift-kueue-operator"}
+            * on(pod)
+            kube_pod_container_status_ready{namespace=~"tekton-kueue|openshift-kueue-operator"}
+        ) / on (pod) group_right max by (pod) (kube_pod_resource_limit{resource='cpu',namespace=~"tekton-kueue|openshift-kueue-operator"}) * 100 > 85
+      for: 5m
+      labels:
+        severity: warning
+        component: kueue
+      annotations:
+        summary: "Kueue pod {{ $labels.pod }} has high CPU utilization"
+        description: "Pod {{ $labels.pod }} CPU utilization is {{ $value }}%, which is above 85%"
+        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue.md?ref_type=heads
+        alert_team_handle: <!subteam^S05Q1P4Q2TG>
+        team: konflux-infra
+
+    - alert: KueueCELEvaluationFailures
+      expr: increase(tekton_kueue_cel_evaluations_total{result="failure"}[5m]) > 0
+      for: 1m
+      labels:
+        severity: warning
+        component: tekton-kueue
+      annotations:
+        summary: "Tekton Kueue CEL evaluation failures detected"
+        description: "{{ $value }} CEL evaluation failures occurred in the last 5 minutes"
+        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue.md?ref_type=heads
+        alert_team_handle: <!subteam^S05Q1P4Q2TG>
+        team: konflux-infra
+
+    - alert: KueueHighContainerRestarts
+      expr: |
+        increase(kube_pod_container_status_restarts_total{namespace=~"tekton-kueue|openshift-kueue-operator"}[1h])
+        * on(container, pod)
+        kube_pod_container_status_ready{namespace=~"tekton-kueue|openshift-kueue-operator"} >= 3
+      for: 0m
+      labels:
+        severity: warning
+        component: kueue
+      annotations:
+        summary: "Kueue pod {{ $labels.pod }} has high restart count"
+        description: "Pod {{ $labels.pod }} has restarted {{ $value }} times in the last hour"
+        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue.md?ref_type=heads
+        alert_team_handle: <!subteam^S05Q1P4Q2TG>
+        team: konflux-infra
+
+  - name: kueue.queue
+    interval: 30s
+    rules:
+    - alert: KueueClusterQueueNotActive
+      expr: max by (status) (kueue_cluster_queue_status{cluster_queue="cluster-pipeline-queue", status="active"}) != 1
+      for: 2m
+      labels:
+        severity: warning
+        component: kueue
+      annotations:
+        summary: "Kueue cluster queue is not active"
+        description: "Cluster queue 'cluster-pipeline-queue' is not in active state"
+        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue.md?ref_type=heads
+        alert_team_handle: <!subteam^S05Q1P4Q2TG>
+        team: konflux-infra
+
+    - alert: KueueHighPendingWorkloads
+      expr: max by (status) (kueue_pending_workloads{cluster_queue="cluster-pipeline-queue"}) > 300
+      for: 5m
+      labels:
+        severity: warning
+        component: kueue
+      annotations:
+        summary: "High number of pending workloads in Kueue"
+        description: "{{ $value }} workloads are pending in cluster queue 'cluster-pipeline-queue'"
+        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue.md?ref_type=heads
+        alert_team_handle: <!subteam^S05Q1P4Q2TG>
+        team: konflux-infra
+
+    - alert: KueueHighAdmissionWaitTime
+      expr: histogram_quantile(0.99, sum(increase(kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue"}[10m])) by (le)) > 900
+      for: 5m
+      labels:
+        severity: warning
+        component: kueue
+      annotations:
+        summary: "High admission wait time in Kueue"
+        description: "99th percentile admission wait time is {{ $value }}s, which is above 15 minutes"
+        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue.md?ref_type=heads
+        alert_team_handle: <!subteam^S05Q1P4Q2TG>
+        team: konflux-infra
+
+    - alert: KueueHighResourceReservation
+      expr: max by (resource) (kueue_cluster_queue_resource_reservation{cluster_queue="cluster-pipeline-queue"} / kueue_cluster_queue_nominal_quota{cluster_queue="cluster-pipeline-queue"} * 100) > 90
+      for: 5m
+      labels:
+        severity: warning
+        component: kueue
+      annotations:
+        summary: "High resource reservation in Kueue cluster queue"
+        description: "Resource {{ $labels.resource }} reservation is {{ $value }}% of nominal quota, which is above 90%"
+        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue.md?ref_type=heads
+        alert_team_handle: <!subteam^S05Q1P4Q2TG>
+        team: konflux-infra
+
+    - alert: KueueLowResourceUsage
+      expr: max by (resource) (kueue_cluster_queue_resource_usage{cluster_queue="cluster-pipeline-queue"} / kueue_cluster_queue_resource_reservation{cluster_queue="cluster-pipeline-queue"} * 100) < 50
+      for: 10m
+      labels:
+        severity: info
+        component: kueue
+      annotations:
+        summary: "Low resource usage efficiency in Kueue"
+        description: "Resource {{ $labels.resource }} usage is only {{ $value }}% of reservation, indicating potential overprovisioning"
+        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue.md?ref_type=heads
+        alert_team_handle: <!subteam^S05Q1P4Q2TG>
+        team: konflux-infra
+
+    - alert: KueueHighPipelineDeletionDuration
+      expr: histogram_quantile(0.99, sum by (le) (increase(watcher_pipelinerun_delete_duration_seconds_bucket[10m]))) > 300
+      for: 5m
+      labels:
+        severity: warning
+        component: pipeline-watcher
+      annotations:
+        summary: "High PipelineRun deletion duration"
+        description: "99th percentile PipelineRun deletion duration is {{ $value }}s, which is above 5 minutes"
+        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue.md?ref_type=heads
+        alert_team_handle: <!subteam^S05Q1P4Q2TG>
+        team: konflux-infra
+
+  - name: kueue.deadman
+    interval: 60s
+    rules:
+    - alert: KueueMetricsDown
+      expr: up{job=~".*kueue.*"} == 0
+      for: 5m
+      labels:
+        severity: warning
+        component: kueue
+      annotations:
+        summary: "Kueue metrics endpoint is down"
+        description: "Kueue metrics endpoint {{ $labels.instance }} for job {{ $labels.job }} has been down for more than 5 minutes"
+        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue.md?ref_type=heads
+        alert_team_handle: <!subteam^S05Q1P4Q2TG>
+        team: konflux-infra
+
+    - alert: KueueNoRecentAdmissions
+      expr: increase(kueue_admitted_workloads_total[60m]) == 0
+      for: 60m
+      labels:
+        severity: warning
+        component: kueue
+      annotations:
+        summary: "No recent workload admissions in Kueue"
+        description: "No workloads have been admitted in the last hour, which might indicate a problem with the admission process"
+        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue.md?ref_type=heads
+        alert_team_handle: <!subteam^S05Q1P4Q2TG>
+        team: konflux-infra
+
+    - alert: KueueMutatingWebhookLowSuccessRate
+      expr: |
+        100 * sum(increase(apiserver_admission_webhook_request_total{
+          name="pipelinerun-kueue-defaulter.tekton-kueue.io", code=~"2.."
+        }[10m]))
+        /
+        sum(increase(apiserver_admission_webhook_request_total{
+          name="pipelinerun-kueue-defaulter.tekton-kueue.io"
+        }[10m]))
+        < 99
+      for: 10m
+      labels:
+        severity: warning
+        component: kueue
+      annotations:
+        summary: "Kueue mutating webhook success rate is below 99%"
+        description: "The mutating webhook 'pipelinerun-kueue-defaulter.tekton-kueue.io' has had a success rate below 99% over the past 10 minutes. Possible causes include webhook errors, rejections, or unreachability (e.g., code=600)."
+        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue.md?ref_type=heads
+        alert_team_handle: <!subteam^S05Q1P4Q2TG>
+        team: konflux-infra

--- a/components/kueue-rd/rings/ring-3/base/base-snapshot/tekton-kueue/monitoring/tekton-kueue-controller-sm.yaml
+++ b/components/kueue-rd/rings/ring-3/base/base-snapshot/tekton-kueue/monitoring/tekton-kueue-controller-sm.yaml
@@ -1,0 +1,26 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: tekton-kueue-controller
+  annotations:
+    argocd.argoproj.io/sync-wave: "11"
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  endpoints:
+  - path: /metrics
+    interval: 15s
+    port: https
+    scheme: https
+    bearerTokenSecret:
+      name: "metrics-reader"
+      key: token
+    tlsConfig:
+      serverName: tekton-kueue-controller-manager-metrics-service.tekton-kueue.svc.cluster.local
+      insecureSkipVerify: false
+      ca:
+        secret:
+          name: controller-manager-metrics-server-cert
+          key: ca.crt
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: tekton-kueue

--- a/components/kueue-rd/rings/ring-3/base/base-snapshot/tekton-kueue/monitoring/tekton-kueue-webhook-sm.yaml
+++ b/components/kueue-rd/rings/ring-3/base/base-snapshot/tekton-kueue/monitoring/tekton-kueue-webhook-sm.yaml
@@ -1,0 +1,26 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: tekton-kueue-webhook
+  annotations:
+    argocd.argoproj.io/sync-wave: "11"
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  endpoints:
+  - path: /metrics
+    interval: 15s
+    port: metrics-server
+    scheme: https
+    bearerTokenSecret:
+      name: "metrics-reader"
+      key: token
+    tlsConfig:
+      serverName: tekton-kueue-webhook-service.tekton-kueue.svc.cluster.local
+      insecureSkipVerify: false
+      ca:
+        secret:
+          name: webhook-metrics-server-cert
+          key: ca.crt
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: tekton-kueue-webhook

--- a/components/kueue-rd/rings/ring-3/base/base-snapshot/tekton-kueue/rbac/kustomization.yaml
+++ b/components/kueue-rd/rings/ring-3/base/base-snapshot/tekton-kueue/rbac/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- metrics-reader-sa.yaml
+- prometheus-metrics-reader-crb.yaml
+- prometheus-metrics-read-rb.yaml
+
+namespace: tekton-kueue

--- a/components/kueue-rd/rings/ring-3/base/base-snapshot/tekton-kueue/rbac/metrics-reader-sa.yaml
+++ b/components/kueue-rd/rings/ring-3/base/base-snapshot/tekton-kueue/rbac/metrics-reader-sa.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: metrics-reader
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: metrics-reader
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    kubernetes.io/service-account.name: metrics-reader
+type: kubernetes.io/service-account-token

--- a/components/kueue-rd/rings/ring-3/base/base-snapshot/tekton-kueue/rbac/prometheus-metrics-read-rb.yaml
+++ b/components/kueue-rd/rings/ring-3/base/base-snapshot/tekton-kueue/rbac/prometheus-metrics-read-rb.yaml
@@ -1,0 +1,33 @@
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: tekton-kueue-metrics-read
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+rules:
+  - verbs:
+      - get
+      - list
+      - watch
+    apiGroups:
+      - ''
+    resources:
+      - services
+      - endpoints
+      - pods
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: tekton-kueue-prometheus-k8s-read-binding
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+subjects:
+  - kind: ServiceAccount
+    name: prometheus-k8s
+    namespace: openshift-monitoring
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: tekton-kueue-metrics-read

--- a/components/kueue-rd/rings/ring-3/base/base-snapshot/tekton-kueue/rbac/prometheus-metrics-reader-crb.yaml
+++ b/components/kueue-rd/rings/ring-3/base/base-snapshot/tekton-kueue/rbac/prometheus-metrics-reader-crb.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: prometheus-tekton-kueue-metrics-reader
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: tekton-kueue-metrics-reader
+subjects:
+- kind: ServiceAccount
+  name: metrics-reader
+  namespace: tekton-kueue

--- a/components/kueue-rd/rings/ring-3/base/base-snapshot/workload-priority-classes.yaml
+++ b/components/kueue-rd/rings/ring-3/base/base-snapshot/workload-priority-classes.yaml
@@ -1,0 +1,90 @@
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: WorkloadPriorityClass
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "10"
+  name: konflux-nudge
+value: 1100
+description: "Highest priority for component nudges"
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: WorkloadPriorityClass
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "10"
+  name: konflux-release
+value: 1000
+description: "Higher priority for release pipelines"
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: WorkloadPriorityClass
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "10"
+  name: konflux-tenant-release
+value: 900
+description: "High priority for tenant release pipelines"
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: WorkloadPriorityClass
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "10"
+  name: konflux-post-merge-test
+value: 800
+description: "Priority for post-merge tests"
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: WorkloadPriorityClass
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "10"
+  name: konflux-post-merge-build
+value: 700
+description: "Priority for post-merge builds"
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: WorkloadPriorityClass
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "10"
+  name: konflux-pre-merge-test
+value: 600
+description: "Priority for pre-merge tests"
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: WorkloadPriorityClass
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "10"
+  name: konflux-pre-merge-build
+value: 500
+description: "Priority for pre-merge builds"
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: WorkloadPriorityClass
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "10"
+  name: konflux-default
+value: 400
+description: "Default priority for konflux pipelines"
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: WorkloadPriorityClass
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "10"
+  name: konflux-dependency-update
+value: 300
+description: "Lower priority for dependency updates"

--- a/components/kueue-rd/rings/ring-3/base/catalog-source.yaml
+++ b/components/kueue-rd/rings/ring-3/base/catalog-source.yaml
@@ -1,0 +1,15 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-3"
+  name: redhat-operators-1-18
+  namespace: openshift-kueue-operator
+spec:
+  displayName: redhat-operators-1-18
+  image: registry.redhat.io/redhat/redhat-operator-index:v4.18
+  sourceType: grpc
+  updateStrategy:
+    registryPoll:
+      interval: 30m

--- a/components/kueue-rd/rings/ring-3/base/kustomization.yaml
+++ b/components/kueue-rd/rings/ring-3/base/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- catalog-source.yaml
+- base-snapshot
+- tekton-kueue
+
+patches:
+- path: subscription-source-patch.yaml
+  target:
+    group: operators.coreos.com
+    kind: Subscription
+    name: openshift-kueue-operator

--- a/components/kueue-rd/rings/ring-3/base/subscription-source-patch.yaml
+++ b/components/kueue-rd/rings/ring-3/base/subscription-source-patch.yaml
@@ -1,0 +1,6 @@
+- op: replace
+  path: /spec/source
+  value: redhat-operators-1-18
+- op: replace
+  path: /spec/sourceNamespace
+  value: openshift-kueue-operator

--- a/components/kueue-rd/rings/ring-3/base/tekton-kueue/kustomization.yaml
+++ b/components/kueue-rd/rings/ring-3/base/tekton-kueue/kustomization.yaml
@@ -1,0 +1,116 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- https://github.com/konflux-ci/tekton-kueue/config/default?ref=cec0b3c8a240a289bb7aff4313ea647b292d96cc
+
+namespace: tekton-kueue
+# ensure that installation starts after the installation of kueue complete
+commonAnnotations:
+  argocd.argoproj.io/sync-wave: "10"
+  argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+
+images:
+- name: konflux-ci/tekton-kueue
+  newName: quay.io/konflux-ci/tekton-kueue
+  newTag: cec0b3c8a240a289bb7aff4313ea647b292d96cc
+
+patches:
+  - target:
+      kind: Namespace
+      name: tekton-kueue
+    patch: |
+      - op: add
+        path: /metadata/labels/openshift.io~1cluster-monitoring
+        value: "true"
+  # Controller Manager Deployment Patches
+  - path: patches/no-anti-affinity-annotation-patch.yaml
+    target:
+      kind: Deployment
+      name: tekton-kueue-controller-manager
+      namespace: tekton-kueue
+  - path: patches/deployment-strategy-patch.yaml
+    target:
+      kind: Deployment
+      name: tekton-kueue-controller-manager
+      namespace: tekton-kueue
+  - path: patches/controller-topology-spread-patch.yaml
+    target:
+      kind: Deployment
+      name: tekton-kueue-controller-manager
+      namespace: tekton-kueue
+  - path: patches/controller-manager-container-args-patch.yaml
+    target:
+      kind: Deployment
+      name: tekton-kueue-controller-manager
+      namespace: tekton-kueue
+  - target:
+      kind: Deployment
+      name: tekton-kueue-controller-manager
+      namespace: tekton-kueue
+    patch: |-
+      - op: add
+        path: /spec/replicas
+        value: 2
+  # -- Resource Requests and Limits Patches
+  - target:
+      kind: Deployment
+      name: tekton-kueue-controller-manager
+      namespace: tekton-kueue
+    patch: |-
+      - op: add
+        path: /spec/template/spec/containers/0/resources/requests
+        value:
+          cpu: 500m
+          memory: 2Gi
+
+      - op: add
+        path: /spec/template/spec/containers/0/resources/limits
+        value:
+          cpu: 500m
+          memory: 2Gi
+  # Webhook Deployment Patches
+  - path: patches/no-anti-affinity-annotation-patch.yaml
+    target:
+      kind: Deployment
+      name: tekton-kueue-webhook
+      namespace: tekton-kueue
+  - path: patches/deployment-strategy-patch.yaml
+    target:
+      kind: Deployment
+      name: tekton-kueue-webhook
+      namespace: tekton-kueue
+  - path: patches/webhook-topology-spread-patch.yaml
+    target:
+      kind: Deployment
+      name: tekton-kueue-webhook
+      namespace: tekton-kueue
+  - path: patches/webhook-webhook-container-args-patch.yaml
+    target:
+      kind: Deployment
+      name: tekton-kueue-webhook
+      namespace: tekton-kueue
+  - target:
+      kind: Deployment
+      name: tekton-kueue-webhook
+      namespace: tekton-kueue
+    patch: |-
+      - op: add
+        path: /spec/replicas
+        value: 3
+  # -- Resource Requests and Limits Patches
+  - target:
+      kind: Deployment
+      name: tekton-kueue-webhook
+      namespace: tekton-kueue
+    patch: |-
+      - op: add
+        path: /spec/template/spec/containers/0/resources/requests
+        value:
+          cpu: 200m
+          memory: 256Mi
+
+      - op: add
+        path: /spec/template/spec/containers/0/resources/limits
+        value:
+          cpu: 200m
+          memory: 256Mi

--- a/components/kueue-rd/rings/ring-3/base/tekton-kueue/patches/controller-manager-container-args-patch.yaml
+++ b/components/kueue-rd/rings/ring-3/base/tekton-kueue/patches/controller-manager-container-args-patch.yaml
@@ -1,0 +1,9 @@
+- op: add
+  path: /spec/template/spec/containers/0/args/-
+  value: "--leader-elect-lease-duration=137s"
+- op: add
+  path: /spec/template/spec/containers/0/args/-
+  value: "--leader-elect-renew-deadline=107s"
+- op: add
+  path: /spec/template/spec/containers/0/args/-
+  value: "--leader-elect-retry-period=26s"

--- a/components/kueue-rd/rings/ring-3/base/tekton-kueue/patches/controller-topology-spread-patch.yaml
+++ b/components/kueue-rd/rings/ring-3/base/tekton-kueue/patches/controller-topology-spread-patch.yaml
@@ -1,0 +1,9 @@
+- op: add
+  path: /spec/template/spec/topologySpreadConstraints
+  value:
+    - maxSkew: 1
+      topologyKey: topology.kubernetes.io/zone
+      whenUnsatisfiable: ScheduleAnyway
+      labelSelector:
+        matchLabels:
+          app.kubernetes.io/name: tekton-kueue

--- a/components/kueue-rd/rings/ring-3/base/tekton-kueue/patches/deployment-strategy-patch.yaml
+++ b/components/kueue-rd/rings/ring-3/base/tekton-kueue/patches/deployment-strategy-patch.yaml
@@ -1,0 +1,6 @@
+- op: add
+  path: /spec/strategy
+  value:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 0

--- a/components/kueue-rd/rings/ring-3/base/tekton-kueue/patches/no-anti-affinity-annotation-patch.yaml
+++ b/components/kueue-rd/rings/ring-3/base/tekton-kueue/patches/no-anti-affinity-annotation-patch.yaml
@@ -1,0 +1,3 @@
+- op: add
+  path: /metadata/annotations/ignore-check.kube-linter.io~1no-anti-affinity
+  value: "Using topologySpreadConstraints"

--- a/components/kueue-rd/rings/ring-3/base/tekton-kueue/patches/webhook-topology-spread-patch.yaml
+++ b/components/kueue-rd/rings/ring-3/base/tekton-kueue/patches/webhook-topology-spread-patch.yaml
@@ -1,0 +1,9 @@
+- op: add
+  path: /spec/template/spec/topologySpreadConstraints
+  value:
+    - maxSkew: 1
+      topologyKey: topology.kubernetes.io/zone
+      whenUnsatisfiable: ScheduleAnyway
+      labelSelector:
+        matchLabels:
+          app.kubernetes.io/name: tekton-kueue-webhook

--- a/components/kueue-rd/rings/ring-3/base/tekton-kueue/patches/webhook-webhook-container-args-patch.yaml
+++ b/components/kueue-rd/rings/ring-3/base/tekton-kueue/patches/webhook-webhook-container-args-patch.yaml
@@ -1,0 +1,3 @@
+- op: add
+  path: /spec/template/spec/containers/0/args/-
+  value: --zap-log-level=5

--- a/components/kueue-rd/rings/ring-3/stone-prd-rh01/cluster-queue.yaml
+++ b/components/kueue-rd/rings/ring-3/stone-prd-rh01/cluster-queue.yaml
@@ -1,0 +1,217 @@
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: ClusterQueue
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "10"
+  name: cluster-pipeline-queue
+spec:
+  flavorFungibility:
+    whenCanBorrow: MayStopSearch
+    whenCanPreempt: TryNextFlavor
+  namespaceSelector: {}
+  preemption:
+    borrowWithinCohort:
+      policy: Never
+    reclaimWithinCohort: Never
+    withinClusterQueue: Never
+  queueingStrategy: BestEffortFIFO
+  resourceGroups:
+  - coveredResources:
+    - tekton.dev/pipelineruns
+    - konflux-ci-dev-token
+    - cpu
+    - memory
+    - aws-ip
+    - mintmaker
+    flavors:
+    - name: default-flavor
+      resources:
+      - name: tekton.dev/pipelineruns
+        nominalQuota: '280'
+      - name: konflux-ci-dev-token
+        nominalQuota: '280'
+      - name: cpu
+        nominalQuota: 1k
+      - name: memory
+        nominalQuota: 500Ti
+      - name: aws-ip
+        nominalQuota: '250'
+      - name: mintmaker
+        nominalQuota: '150'
+  - coveredResources:
+    - linux-amd64
+    - linux-arm64
+    - linux-c2xlarge-amd64
+    - linux-c2xlarge-arm64
+    - linux-c4xlarge-amd64
+    - linux-c4xlarge-arm64
+    - linux-c6gd2xlarge-arm64
+    - linux-c8xlarge-amd64
+    - linux-c8xlarge-arm64
+    - linux-cxlarge-amd64
+    - linux-cxlarge-arm64
+    - linux-d160-c8xlarge-amd64
+    - linux-d160-c8xlarge-arm64
+    - linux-d160-m2xlarge-amd64
+    - linux-d160-m2xlarge-arm64
+    - linux-d160-m4xlarge-amd64
+    flavors:
+    - name: platform-group-1
+      resources:
+      - name: linux-amd64
+        nominalQuota: '250'
+      - name: linux-arm64
+        nominalQuota: '250'
+      - name: linux-c2xlarge-amd64
+        nominalQuota: '250'
+      - name: linux-c2xlarge-arm64
+        nominalQuota: '250'
+      - name: linux-c4xlarge-amd64
+        nominalQuota: '250'
+      - name: linux-c4xlarge-arm64
+        nominalQuota: '250'
+      - name: linux-c6gd2xlarge-arm64
+        nominalQuota: '250'
+      - name: linux-c8xlarge-amd64
+        nominalQuota: '250'
+      - name: linux-c8xlarge-arm64
+        nominalQuota: '250'
+      - name: linux-cxlarge-amd64
+        nominalQuota: '250'
+      - name: linux-cxlarge-arm64
+        nominalQuota: '250'
+      - name: linux-d160-c8xlarge-amd64
+        nominalQuota: '250'
+      - name: linux-d160-c8xlarge-arm64
+        nominalQuota: '250'
+      - name: linux-d160-m2xlarge-amd64
+        nominalQuota: '250'
+      - name: linux-d160-m2xlarge-arm64
+        nominalQuota: '250'
+      - name: linux-d160-m4xlarge-amd64
+        nominalQuota: '250'
+  - coveredResources:
+    - linux-d160-m4xlarge-arm64
+    - linux-d160-m8xlarge-amd64
+    - linux-d160-m8xlarge-arm64
+    - linux-d320-m8xlarge-amd64
+    - linux-d320-m8xlarge-arm64
+    - linux-extra-fast-amd64
+    - linux-fast-amd64
+    - linux-g64xlarge-amd64
+    - linux-m2xlarge-amd64
+    - linux-m2xlarge-arm64
+    - linux-m4xlarge-amd64
+    - linux-m4xlarge-arm64
+    - linux-m8xlarge-amd64
+    - linux-m8xlarge-arm64
+    - linux-mlarge-amd64
+    - linux-mlarge-arm64
+    flavors:
+    - name: platform-group-2
+      resources:
+      - name: linux-d160-m4xlarge-arm64
+        nominalQuota: '250'
+      - name: linux-d160-m8xlarge-amd64
+        nominalQuota: '250'
+      - name: linux-d160-m8xlarge-arm64
+        nominalQuota: '250'
+      - name: linux-d320-m8xlarge-amd64
+        nominalQuota: '250'
+      - name: linux-d320-m8xlarge-arm64
+        nominalQuota: '250'
+      - name: linux-extra-fast-amd64
+        nominalQuota: '250'
+      - name: linux-fast-amd64
+        nominalQuota: '250'
+      - name: linux-g64xlarge-amd64
+        nominalQuota: '250'
+      - name: linux-m2xlarge-amd64
+        nominalQuota: '250'
+      - name: linux-m2xlarge-arm64
+        nominalQuota: '250'
+      - name: linux-m4xlarge-amd64
+        nominalQuota: '250'
+      - name: linux-m4xlarge-arm64
+        nominalQuota: '250'
+      - name: linux-m8xlarge-amd64
+        nominalQuota: '250'
+      - name: linux-m8xlarge-arm64
+        nominalQuota: '250'
+      - name: linux-mlarge-amd64
+        nominalQuota: '250'
+      - name: linux-mlarge-arm64
+        nominalQuota: '250'
+  - coveredResources:
+    - linux-mxlarge-amd64
+    - linux-mxlarge-arm64
+    - linux-ppc64le
+    - linux-root-amd64
+    - linux-root-arm64
+    - linux-s390x
+    - linux-test-amd64
+    - linux-test-arm64
+    - linux-x86-64
+    - local
+    - localhost
+    flavors:
+    - name: platform-group-3
+      resources:
+      - name: linux-mxlarge-amd64
+        nominalQuota: '250'
+      - name: linux-mxlarge-arm64
+        nominalQuota: '250'
+      - name: linux-ppc64le
+        nominalQuota: '64'
+      - name: linux-root-amd64
+        nominalQuota: '250'
+      - name: linux-root-arm64
+        nominalQuota: '250'
+      - name: linux-s390x
+        nominalQuota: '60'
+      - name: linux-test-amd64
+        nominalQuota: '250'
+      - name: linux-test-arm64
+        nominalQuota: '250'
+      - name: linux-x86-64
+        nominalQuota: 1k
+      - name: local
+        nominalQuota: 1k
+      - name: localhost
+        nominalQuota: 1k
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: ResourceFlavor
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "10"
+  name: default-flavor
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: ResourceFlavor
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "10"
+  name: platform-group-1
+spec: {}
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: ResourceFlavor
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "10"
+  name: platform-group-2
+spec: {}
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: ResourceFlavor
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "10"
+  name: platform-group-3
+spec: {}

--- a/components/kueue-rd/rings/ring-3/stone-prd-rh01/config.yaml
+++ b/components/kueue-rd/rings/ring-3/stone-prd-rh01/config.yaml
@@ -1,0 +1,153 @@
+queueName: pipelines-queue
+cel:
+  expressions:
+    # Set resource requests for multi platform pipelines
+    - |
+        has(pipelineRun.spec.params) &&
+        pipelineRun.spec.params.exists(p, p.name == 'build-platforms') &&
+        type(pipelineRun.spec.params.filter(p, p.name == 'build-platforms')[0].value) == list ?
+        pipelineRun.spec.params.filter(
+          p,
+          p.name == 'build-platforms')[0]
+        .value.map(
+          p,
+          resource(replace(replace(p, "/", "-"), "_", "-"), 1)
+        ) : []
+
+    # Request AWS IP for AWS-based platforms
+    - |
+        has(pipelineRun.spec.params) &&
+        pipelineRun.spec.params.exists(p, p.name == 'build-platforms') &&
+        type(pipelineRun.spec.params.filter(p, p.name == 'build-platforms')[0].value) == list ?
+        pipelineRun.spec.params.filter(
+          p,
+          p.name == 'build-platforms')[0]
+        .value.filter(
+          p,
+          !(
+            p in [
+              'linux/ppc64le',
+              'linux/s390x',
+              'linux/x86_64',
+              'local',
+              'localhost',
+            ]
+          )
+        ).map(
+          p,
+          resource('aws-ip', 1)
+        ) : []
+
+    # Flag validation error when build-platforms is present but not a list
+    - |
+        has(pipelineRun.spec.params) &&
+        pipelineRun.spec.params.exists(p, p.name == 'build-platforms') &&
+        type(pipelineRun.spec.params.filter(p, p.name == 'build-platforms')[0].value) != list ?
+        [annotation('kueue.konflux-ci.dev/validation-error',
+          'build-platforms parameter must be an array of platform strings, got a non-array value')] : []
+
+    # Set resource requests for multi platform pipelines which doesn't use the build-platforms parameter (old style)
+    - |
+      !(
+        has(pipelineRun.spec.params) &&
+        pipelineRun.spec.params.exists(p, p.name == 'build-platforms')
+      ) &&
+      has(pipelineRun.spec.pipelineSpec) &&
+      has(pipelineRun.spec.pipelineSpec.tasks) &&
+      pipelineRun.spec.pipelineSpec.tasks.size() > 0 ?
+      pipelineRun.spec.pipelineSpec.tasks.map(
+        task,
+        has(task.params) ? task.params.filter(p, p.name == 'PLATFORM') : []
+      )
+      .filter(p, p.size() > 0)
+      .map(
+        p,
+        resource(replace(replace(p[0].value, "/", "-"), "_", "-"), 1)
+      ) : []
+
+    # Request AWS IP for AWS-based platforms which doesn't use the build-platforms parameter (old style)
+    - |
+      !(
+        has(pipelineRun.spec.params) &&
+        pipelineRun.spec.params.exists(p, p.name == 'build-platforms')
+      ) &&
+      has(pipelineRun.spec.pipelineSpec) &&
+      has(pipelineRun.spec.pipelineSpec.tasks) &&
+      pipelineRun.spec.pipelineSpec.tasks.size() > 0 ?
+      pipelineRun.spec.pipelineSpec.tasks.map(
+        task,
+        has(task.params) ? task.params.filter(p, p.name == 'PLATFORM') : []
+      )
+      .filter(p, p.size() > 0)
+      .filter(
+        p,
+        !(
+          p[0].value in [
+            'linux/ppc64le',
+            'linux/s390x',
+            'linux/x86_64',
+            'local',
+            'localhost',
+          ]
+        )
+      )
+      .map(
+        p,
+        resource('aws-ip', 1)
+      ) : []
+
+    # Set mintmaker resource requests.
+    # Necessary since mintmaker refreshes can overload clusters without a
+    # bottleneck on the number of pipelineruns running.
+    - |
+        plrNamespace == 'mintmaker' ? [resource('mintmaker', 1)] : []
+
+    # The token mechanism allows us to balance admitted PipelineRuns.
+    # Each PipelineRun requests 1 token. The token quota is set equal
+    # to the PLR limit so current behavior is unchanged.
+    - |
+        resource('konflux-ci-dev-token', 1)
+
+    # Set the pipeline priority
+    - |
+        has(pipelineRun.metadata.labels) &&
+        'build.appstudio.redhat.com/type' in pipelineRun.metadata.labels &&
+        pipelineRun.metadata.labels['build.appstudio.redhat.com/type'] == 'nudge' ?
+        priority('konflux-nudge') :
+
+        pacEventType == 'push' ? priority('konflux-post-merge-build') :
+        pacEventType == 'pull_request' ||
+          pacEventType == "Merge_Request" ||
+          pacEventType == 'test-comment' ||
+          pacEventType == 'retest-comment' ||
+          pacEventType == 'retest-all-comment' ||
+          pacEventType == 'ok-to-test-comment'  ? priority('konflux-pre-merge-build') :
+        pacTestEventType == 'push' ? priority('konflux-post-merge-test') :
+        pacTestEventType == 'pull_request' ||
+          pacTestEventType == "Merge_Request" ||
+          pacTestEventType == 'test-comment' ||
+          pacTestEventType == 'retest-comment' ||
+          pacTestEventType == 'retest-all-comment' ||
+          pacTestEventType == 'ok-to-test-comment' ? priority('konflux-pre-merge-test') :
+
+        has(pipelineRun.metadata.labels) &&
+        'appstudio.openshift.io/service' in pipelineRun.metadata.labels &&
+        pipelineRun.metadata.labels['appstudio.openshift.io/service'] == 'release' &&
+        'pipelines.appstudio.openshift.io/type' in pipelineRun.metadata.labels &&
+        pipelineRun.metadata.labels['pipelines.appstudio.openshift.io/type'] == 'managed' ?
+        priority('konflux-release') :
+
+        has(pipelineRun.metadata.labels) &&
+        'appstudio.openshift.io/service' in pipelineRun.metadata.labels &&
+        pipelineRun.metadata.labels['appstudio.openshift.io/service'] == 'release' &&
+        'release.appstudio.openshift.io/namespace' in pipelineRun.metadata.labels &&
+        pipelineRun.metadata.labels['release.appstudio.openshift.io/namespace'] == plrNamespace ?
+        priority('konflux-tenant-release') :
+
+        plrNamespace == 'mintmaker' ? priority('konflux-dependency-update') :
+
+        has(pipelineRun.metadata.labels) &&
+        'internal-services.appstudio.openshift.io/pipelinerun-uid' in pipelineRun.metadata.labels ?
+        priority('konflux-release') :
+
+        priority('konflux-default')

--- a/components/kueue-rd/rings/ring-3/stone-prd-rh01/kustomization.yaml
+++ b/components/kueue-rd/rings/ring-3/stone-prd-rh01/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- cluster-queue.yaml
+- ../base
+
+configMapGenerator:
+  - name: tekton-kueue-config
+    namespace: tekton-kueue
+    behavior: replace
+    files:
+      - config.yaml
+generatorOptions:
+  disableNameSuffixHash: true

--- a/components/kueue-rd/rings/ring-3/stone-prod-p02/cluster-queue.yaml
+++ b/components/kueue-rd/rings/ring-3/stone-prod-p02/cluster-queue.yaml
@@ -1,0 +1,232 @@
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: ClusterQueue
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "10"
+  name: cluster-pipeline-queue
+spec:
+  flavorFungibility:
+    whenCanBorrow: MayStopSearch
+    whenCanPreempt: TryNextFlavor
+  namespaceSelector: {}
+  preemption:
+    borrowWithinCohort:
+      policy: Never
+    reclaimWithinCohort: Never
+    withinClusterQueue: Never
+  queueingStrategy: BestEffortFIFO
+  resourceGroups:
+  - coveredResources:
+    - tekton.dev/pipelineruns
+    - konflux-ci-dev-token
+    - cpu
+    - memory
+    - aws-ip
+    - mintmaker
+    - konflux-release
+    flavors:
+    - name: default-flavor
+      resources:
+      - name: tekton.dev/pipelineruns
+        nominalQuota: '380'
+      - name: konflux-ci-dev-token
+        nominalQuota: '280'
+      - name: cpu
+        nominalQuota: 1k
+      - name: memory
+        nominalQuota: 500Ti
+      - name: aws-ip
+        nominalQuota: '250'
+      - name: mintmaker
+        nominalQuota: '150'
+      - name: konflux-release
+        nominalQuota: '100'
+  - coveredResources:
+    - linux-amd64
+    - linux-arm64
+    - linux-c2xlarge-amd64
+    - linux-c2xlarge-arm64
+    - linux-c4xlarge-amd64
+    - linux-c4xlarge-arm64
+    - linux-c6gd2xlarge-arm64
+    - linux-c8xlarge-amd64
+    - linux-c8xlarge-arm64
+    - linux-cxlarge-amd64
+    - linux-cxlarge-arm64
+    - linux-d160-c4xlarge-amd64
+    - linux-d160-c4xlarge-arm64
+    - linux-d160-c8xlarge-amd64
+    - linux-d160-c8xlarge-arm64
+    - linux-d160-m2xlarge-amd64
+    flavors:
+    - name: platform-group-1
+      resources:
+      - name: linux-amd64
+        nominalQuota: '250'
+      - name: linux-arm64
+        nominalQuota: '250'
+      - name: linux-c2xlarge-amd64
+        nominalQuota: '250'
+      - name: linux-c2xlarge-arm64
+        nominalQuota: '250'
+      - name: linux-c4xlarge-amd64
+        nominalQuota: '250'
+      - name: linux-c4xlarge-arm64
+        nominalQuota: '250'
+      - name: linux-c6gd2xlarge-arm64
+        nominalQuota: '250'
+      - name: linux-c8xlarge-amd64
+        nominalQuota: '250'
+      - name: linux-c8xlarge-arm64
+        nominalQuota: '250'
+      - name: linux-cxlarge-amd64
+        nominalQuota: '250'
+      - name: linux-cxlarge-arm64
+        nominalQuota: '250'
+      - name: linux-d160-c4xlarge-amd64
+        nominalQuota: '250'
+      - name: linux-d160-c4xlarge-arm64
+        nominalQuota: '250'
+      - name: linux-d160-c8xlarge-amd64
+        nominalQuota: '250'
+      - name: linux-d160-c8xlarge-arm64
+        nominalQuota: '250'
+      - name: linux-d160-m2xlarge-amd64
+        nominalQuota: '250'
+  - coveredResources:
+    - linux-d160-m2xlarge-arm64
+    - linux-d160-m4xlarge-amd64
+    - linux-d160-m4xlarge-arm64
+    - linux-d160-m8xlarge-amd64
+    - linux-d160-m8xlarge-arm64
+    - linux-d320-c4xlarge-amd64
+    - linux-d320-c4xlarge-arm64
+    - linux-d320-m8xlarge-amd64
+    - linux-d320-m8xlarge-arm64
+    - linux-extra-fast-amd64
+    - linux-fast-amd64
+    - linux-g64xlarge-amd64
+    - linux-m2xlarge-amd64
+    - linux-m2xlarge-arm64
+    - linux-m4xlarge-amd64
+    - linux-m4xlarge-arm64
+    flavors:
+    - name: platform-group-2
+      resources:
+      - name: linux-d160-m2xlarge-arm64
+        nominalQuota: '250'
+      - name: linux-d160-m4xlarge-amd64
+        nominalQuota: '250'
+      - name: linux-d160-m4xlarge-arm64
+        nominalQuota: '250'
+      - name: linux-d160-m8xlarge-amd64
+        nominalQuota: '250'
+      - name: linux-d160-m8xlarge-arm64
+        nominalQuota: '250'
+      - name: linux-d320-c4xlarge-amd64
+        nominalQuota: '250'
+      - name: linux-d320-c4xlarge-arm64
+        nominalQuota: '250'
+      - name: linux-d320-m8xlarge-amd64
+        nominalQuota: '250'
+      - name: linux-d320-m8xlarge-arm64
+        nominalQuota: '250'
+      - name: linux-extra-fast-amd64
+        nominalQuota: '250'
+      - name: linux-fast-amd64
+        nominalQuota: '250'
+      - name: linux-g64xlarge-amd64
+        nominalQuota: '250'
+      - name: linux-m2xlarge-amd64
+        nominalQuota: '250'
+      - name: linux-m2xlarge-arm64
+        nominalQuota: '250'
+      - name: linux-m4xlarge-amd64
+        nominalQuota: '250'
+      - name: linux-m4xlarge-arm64
+        nominalQuota: '250'
+  - coveredResources:
+    - linux-m8xlarge-amd64
+    - linux-m8xlarge-arm64
+    - linux-mlarge-amd64
+    - linux-mlarge-arm64
+    - linux-mxlarge-amd64
+    - linux-mxlarge-arm64
+    - linux-ppc64le
+    - linux-root-amd64
+    - linux-root-arm64
+    - linux-s390x
+    - linux-x86-64
+    - local
+    - localhost
+    - macos-mac2metal-arm64
+    - windows-4xlarge-amd64
+    flavors:
+    - name: platform-group-3
+      resources:
+      - name: linux-m8xlarge-amd64
+        nominalQuota: '250'
+      - name: linux-m8xlarge-arm64
+        nominalQuota: '250'
+      - name: linux-mlarge-amd64
+        nominalQuota: '250'
+      - name: linux-mlarge-arm64
+        nominalQuota: '250'
+      - name: linux-mxlarge-amd64
+        nominalQuota: '250'
+      - name: linux-mxlarge-arm64
+        nominalQuota: '250'
+      - name: linux-ppc64le
+        nominalQuota: '64'
+      - name: linux-root-amd64
+        nominalQuota: '250'
+      - name: linux-root-arm64
+        nominalQuota: '250'
+      - name: linux-s390x
+        nominalQuota: '72'
+      - name: linux-x86-64
+        nominalQuota: 1k
+      - name: local
+        nominalQuota: 1k
+      - name: localhost
+        nominalQuota: 1k
+      - name: macos-mac2metal-arm64
+        nominalQuota: '5'
+      - name: windows-4xlarge-amd64
+        nominalQuota: '5'
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: ResourceFlavor
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "10"
+  name: default-flavor
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: ResourceFlavor
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "10"
+  name: platform-group-1
+spec: {}
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: ResourceFlavor
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "10"
+  name: platform-group-2
+spec: {}
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: ResourceFlavor
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "10"
+  name: platform-group-3
+spec: {}

--- a/components/kueue-rd/rings/ring-3/stone-prod-p02/config.yaml
+++ b/components/kueue-rd/rings/ring-3/stone-prod-p02/config.yaml
@@ -1,0 +1,176 @@
+queueName: pipelines-queue
+cel:
+  expressions:
+    # Set resource requests for multi platform pipelines
+    - |
+        has(pipelineRun.spec.params) &&
+        pipelineRun.spec.params.exists(p, p.name == 'build-platforms') &&
+        type(pipelineRun.spec.params.filter(p, p.name == 'build-platforms')[0].value) == list ?
+        pipelineRun.spec.params.filter(
+          p,
+          p.name == 'build-platforms')[0]
+        .value.map(
+          p,
+          resource(replace(replace(p, "/", "-"), "_", "-"), 1)
+        ) : []
+
+    # Request AWS IP for AWS-based platforms
+    - |
+        has(pipelineRun.spec.params) &&
+        pipelineRun.spec.params.exists(p, p.name == 'build-platforms') &&
+        type(pipelineRun.spec.params.filter(p, p.name == 'build-platforms')[0].value) == list ?
+        pipelineRun.spec.params.filter(
+          p,
+          p.name == 'build-platforms')[0]
+        .value.filter(
+          p,
+          !(
+            p in [
+              'linux/ppc64le',
+              'linux/s390x',
+              'linux/x86_64',
+              'local',
+              'localhost',
+            ]
+          )
+        ).map(
+          p,
+          resource('aws-ip', 1)
+        ) : []
+
+    # Flag validation error when build-platforms is present but not a list
+    - |
+        has(pipelineRun.spec.params) &&
+        pipelineRun.spec.params.exists(p, p.name == 'build-platforms') &&
+        type(pipelineRun.spec.params.filter(p, p.name == 'build-platforms')[0].value) != list ?
+        [annotation('kueue.konflux-ci.dev/validation-error',
+          'build-platforms parameter must be an array of platform strings, got a non-array value')] : []
+
+    # Set resource requests for multi platform pipelines which doesn't use the build-platforms parameter (old style)
+    - |
+      !(
+        has(pipelineRun.spec.params) &&
+        pipelineRun.spec.params.exists(p, p.name == 'build-platforms')
+      ) &&
+      has(pipelineRun.spec.pipelineSpec) &&
+      has(pipelineRun.spec.pipelineSpec.tasks) &&
+      pipelineRun.spec.pipelineSpec.tasks.size() > 0 ?
+      pipelineRun.spec.pipelineSpec.tasks.map(
+        task,
+        has(task.params) ? task.params.filter(p, p.name == 'PLATFORM') : []
+      )
+      .filter(p, p.size() > 0)
+      .map(
+        p,
+        resource(replace(replace(p[0].value, "/", "-"), "_", "-"), 1)
+      ) : []
+
+    # Request AWS IP for AWS-based platforms which doesn't use the build-platforms parameter (old style)
+    - |
+      !(
+        has(pipelineRun.spec.params) &&
+        pipelineRun.spec.params.exists(p, p.name == 'build-platforms')
+      ) &&
+      has(pipelineRun.spec.pipelineSpec) &&
+      has(pipelineRun.spec.pipelineSpec.tasks) &&
+      pipelineRun.spec.pipelineSpec.tasks.size() > 0 ?
+      pipelineRun.spec.pipelineSpec.tasks.map(
+        task,
+        has(task.params) ? task.params.filter(p, p.name == 'PLATFORM') : []
+      )
+      .filter(p, p.size() > 0)
+      .filter(
+        p,
+        !(
+          p[0].value in [
+            'linux/ppc64le',
+            'linux/s390x',
+            'linux/x86_64',
+            'local',
+            'localhost',
+          ]
+        )
+      )
+      .map(
+        p,
+        resource('aws-ip', 1)
+      ) : []
+
+    # Set mintmaker resource requests.
+    # Necessary since mintmaker refreshes can overload clusters without a
+    # bottleneck on the number of pipelineruns running.
+    - |
+        plrNamespace == 'mintmaker' ? [resource('mintmaker', 1)] : []
+
+    # The token mechanism allows us to balance admitted PipelineRuns.
+    # Each PipelineRun requests 1 token, except for internal-services PLRs.
+    # This is to guarantee there is always room for internal-services PLRs.
+    #
+    #
+    # WARNING: As a temporary measure, we are using tokens to provide a priority lane
+    # for internal-services PLRs. They'll be removed in some time and moved to the
+    # common clusters.
+    - |
+        has(pipelineRun.metadata.labels) &&
+        'internal-services.appstudio.openshift.io/pipelinerun-uid' in pipelineRun.metadata.labels ?
+        [] : [resource('konflux-ci-dev-token', 1)]
+
+    # Add a resource to restrict the number of concurrent release pipelineruns
+    - |
+        has(pipelineRun.metadata.labels) &&
+        'appstudio.openshift.io/service' in pipelineRun.metadata.labels &&
+        pipelineRun.metadata.labels['appstudio.openshift.io/service'] == 'release' &&
+        'pipelines.appstudio.openshift.io/type' in pipelineRun.metadata.labels &&
+        pipelineRun.metadata.labels['pipelines.appstudio.openshift.io/type'] == 'managed' ?
+        [resource('konflux-release', 1)] :
+
+        has(pipelineRun.metadata.labels) &&
+        'appstudio.openshift.io/service' in pipelineRun.metadata.labels &&
+        pipelineRun.metadata.labels['appstudio.openshift.io/service'] == 'release' &&
+        'release.appstudio.openshift.io/namespace' in pipelineRun.metadata.labels &&
+        pipelineRun.metadata.labels['release.appstudio.openshift.io/namespace'] == plrNamespace ?
+        [resource('konflux-release', 1)] : []
+
+    # Set the pipeline priority
+    - |
+        has(pipelineRun.metadata.labels) &&
+        'build.appstudio.redhat.com/type' in pipelineRun.metadata.labels &&
+        pipelineRun.metadata.labels['build.appstudio.redhat.com/type'] == 'nudge' ?
+        priority('konflux-nudge') :
+
+        pacEventType == 'push' ? priority('konflux-post-merge-build') :
+        pacEventType == 'pull_request' ||
+          pacEventType == "Merge_Request" ||
+          pacEventType == 'test-comment' ||
+          pacEventType == 'retest-comment' ||
+          pacEventType == 'retest-all-comment' ||
+          pacEventType == 'ok-to-test-comment'  ? priority('konflux-pre-merge-build') :
+        pacTestEventType == 'push' ? priority('konflux-post-merge-test') :
+        pacTestEventType == 'pull_request' ||
+          pacTestEventType == "Merge_Request" ||
+          pacTestEventType == 'test-comment' ||
+          pacTestEventType == 'retest-comment' ||
+          pacTestEventType == 'retest-all-comment' ||
+          pacTestEventType == 'ok-to-test-comment' ? priority('konflux-pre-merge-test') :
+
+        has(pipelineRun.metadata.labels) &&
+        'appstudio.openshift.io/service' in pipelineRun.metadata.labels &&
+        pipelineRun.metadata.labels['appstudio.openshift.io/service'] == 'release' &&
+        'pipelines.appstudio.openshift.io/type' in pipelineRun.metadata.labels &&
+        pipelineRun.metadata.labels['pipelines.appstudio.openshift.io/type'] == 'managed' ?
+        priority('konflux-release') :
+
+        has(pipelineRun.metadata.labels) &&
+        'appstudio.openshift.io/service' in pipelineRun.metadata.labels &&
+        pipelineRun.metadata.labels['appstudio.openshift.io/service'] == 'release' &&
+        'release.appstudio.openshift.io/namespace' in pipelineRun.metadata.labels &&
+        pipelineRun.metadata.labels['release.appstudio.openshift.io/namespace'] == plrNamespace ?
+        priority('konflux-tenant-release') :
+
+        plrNamespace == 'mintmaker' ? priority('konflux-dependency-update') :
+
+        has(pipelineRun.metadata.labels) &&
+        'internal-services.appstudio.openshift.io/pipelinerun-uid' in pipelineRun.metadata.labels ?
+        priority('konflux-release') :
+
+        priority('konflux-default')

--- a/components/kueue-rd/rings/ring-3/stone-prod-p02/kustomization.yaml
+++ b/components/kueue-rd/rings/ring-3/stone-prod-p02/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- cluster-queue.yaml
+- ../base
+
+configMapGenerator:
+  - name: tekton-kueue-config
+    namespace: tekton-kueue
+    behavior: replace
+    files:
+      - config.yaml
+generatorOptions:
+  disableNameSuffixHash: true

--- a/components/kueue-rd/rings/ring-4/base/base-snapshot/kueue/kueue.yaml
+++ b/components/kueue-rd/rings/ring-4/base/base-snapshot/kueue/kueue.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: kueue.openshift.io/v1
+kind: Kueue
+metadata:
+  labels:
+    app.kubernetes.io/name: kueue-operator
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+  name: cluster
+  namespace: openshift-kueue-operator
+spec:
+  managementState: Managed
+  config:
+    integrations:
+      frameworks: # The operator requires at lest one framework to be enabled
+      - BatchJob
+      externalFrameworks:
+      - group: tekton.dev
+        version: v1
+        resource: pipelineruns

--- a/components/kueue-rd/rings/ring-4/base/base-snapshot/kueue/kustomization.yaml
+++ b/components/kueue-rd/rings/ring-4/base/base-snapshot/kueue/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- kueue.yaml
+- ns.yaml
+- operator-group.yaml
+- subscription.yaml
+
+namespace: openshift-kueue-operator

--- a/components/kueue-rd/rings/ring-4/base/base-snapshot/kueue/ns.yaml
+++ b/components/kueue-rd/rings/ring-4/base/base-snapshot/kueue/ns.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-kueue-operator
+  labels:
+    openshift.io/cluster-monitoring: "true"
+  annotations:
+    argocd.argoproj.io/sync-wave: "-4"
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true

--- a/components/kueue-rd/rings/ring-4/base/base-snapshot/kueue/operator-group.yaml
+++ b/components/kueue-rd/rings/ring-4/base/base-snapshot/kueue/operator-group.yaml
@@ -1,0 +1,8 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: openshift-kueue-operatorgroup
+  annotations:
+    argocd.argoproj.io/sync-wave: "-2"
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec: {}

--- a/components/kueue-rd/rings/ring-4/base/base-snapshot/kueue/subscription.yaml
+++ b/components/kueue-rd/rings/ring-4/base/base-snapshot/kueue/subscription.yaml
@@ -1,0 +1,14 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: openshift-kueue-operator
+  namespace: openshift-kueue-operator
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  channel: stable-v1.3
+  installPlanApproval: Automatic
+  name: kueue-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace

--- a/components/kueue-rd/rings/ring-4/base/base-snapshot/kustomization.yaml
+++ b/components/kueue-rd/rings/ring-4/base/base-snapshot/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- workload-priority-classes.yaml
+- kueue
+- tekton-kueue

--- a/components/kueue-rd/rings/ring-4/base/base-snapshot/tekton-kueue/kustomization.yaml
+++ b/components/kueue-rd/rings/ring-4/base/base-snapshot/tekton-kueue/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- monitoring
+- rbac
+
+namespace: tekton-kueue

--- a/components/kueue-rd/rings/ring-4/base/base-snapshot/tekton-kueue/monitoring/kustomization.yaml
+++ b/components/kueue-rd/rings/ring-4/base/base-snapshot/tekton-kueue/monitoring/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- tekton-kueue-webhook-sm.yaml
+- tekton-kueue-controller-sm.yaml
+- prometheus-rule.yaml
+
+namespace: tekton-kueue

--- a/components/kueue-rd/rings/ring-4/base/base-snapshot/tekton-kueue/monitoring/prometheus-rule.yaml
+++ b/components/kueue-rd/rings/ring-4/base/base-snapshot/tekton-kueue/monitoring/prometheus-rule.yaml
@@ -1,0 +1,242 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: kueue-alerts
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  groups:
+  - name: kueue.health
+    interval: 30s
+    rules:
+    - alert: KueueHighAdmissionLatency
+      expr: histogram_quantile(0.99, sum(increase(kueue_admission_attempt_duration_seconds_bucket[5m])) by (le)) > 30
+      for: 2m
+      labels:
+        severity: warning
+        component: kueue
+      annotations:
+        summary: "Kueue admission latency is high"
+        description: "99th percentile of Kueue admission attempt duration is {{ $value }}s, which is above the threshold of 30s"
+        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue.md?ref_type=heads
+        alert_team_handle: <!subteam^S05Q1P4Q2TG>
+        team: konflux-infra
+
+    - alert: KueueReplicasNotAvailable
+      expr: |
+        (
+          kube_deployment_status_replicas_available{namespace=~"openshift-kueue-operator|tekton-kueue"}
+        )
+        /
+        clamp_min(
+          kube_deployment_spec_replicas{namespace=~"openshift-kueue-operator|tekton-kueue"},
+          1
+        ) * 100 < 100
+      for: 5m
+      labels:
+        severity: warning
+        component: kueue
+      annotations:
+        summary: "Kueue deployment {{ $labels.deployment }} has unavailable replicas"
+        description: "Deployment {{ $labels.deployment }} has {{ $value }}% available replicas, which is less than 100%"
+        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue.md?ref_type=heads
+        alert_team_handle: <!subteam^S05Q1P4Q2TG>
+        team: konflux-infra
+
+    - alert: KueueHighMemoryUtilization
+      expr: |
+        (
+            container_memory_working_set_bytes{namespace=~"tekton-kueue|openshift-kueue-operator", image!=""}
+            * on(container, pod)
+            group_left
+            kube_pod_container_status_ready{namespace=~"tekton-kueue|openshift-kueue-operator"}
+        )
+            / on (pod) kube_pod_resource_limit{resource='memory',namespace=~"tekton-kueue|openshift-kueue-operator"} * 100 > 70
+      for: 5m
+      labels:
+        severity: warning
+        component: kueue
+      annotations:
+        summary: "Kueue pod {{ $labels.pod }} has high memory utilization"
+        description: "Pod {{ $labels.pod }} memory utilization is {{ $value }}%, which is above 70%"
+        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue.md?ref_type=heads
+        alert_team_handle: <!subteam^S05Q1P4Q2TG>
+        team: konflux-infra
+
+    - alert: KueueHighCPUUtilization
+      expr: |
+        (
+            pod:container_cpu_usage:sum{namespace=~"tekton-kueue|openshift-kueue-operator"}
+            * on(pod)
+            kube_pod_container_status_ready{namespace=~"tekton-kueue|openshift-kueue-operator"}
+        ) / on (pod) group_right max by (pod) (kube_pod_resource_limit{resource='cpu',namespace=~"tekton-kueue|openshift-kueue-operator"}) * 100 > 85
+      for: 5m
+      labels:
+        severity: warning
+        component: kueue
+      annotations:
+        summary: "Kueue pod {{ $labels.pod }} has high CPU utilization"
+        description: "Pod {{ $labels.pod }} CPU utilization is {{ $value }}%, which is above 85%"
+        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue.md?ref_type=heads
+        alert_team_handle: <!subteam^S05Q1P4Q2TG>
+        team: konflux-infra
+
+    - alert: KueueCELEvaluationFailures
+      expr: increase(tekton_kueue_cel_evaluations_total{result="failure"}[5m]) > 0
+      for: 1m
+      labels:
+        severity: warning
+        component: tekton-kueue
+      annotations:
+        summary: "Tekton Kueue CEL evaluation failures detected"
+        description: "{{ $value }} CEL evaluation failures occurred in the last 5 minutes"
+        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue.md?ref_type=heads
+        alert_team_handle: <!subteam^S05Q1P4Q2TG>
+        team: konflux-infra
+
+    - alert: KueueHighContainerRestarts
+      expr: |
+        increase(kube_pod_container_status_restarts_total{namespace=~"tekton-kueue|openshift-kueue-operator"}[1h])
+        * on(container, pod)
+        kube_pod_container_status_ready{namespace=~"tekton-kueue|openshift-kueue-operator"} >= 3
+      for: 0m
+      labels:
+        severity: warning
+        component: kueue
+      annotations:
+        summary: "Kueue pod {{ $labels.pod }} has high restart count"
+        description: "Pod {{ $labels.pod }} has restarted {{ $value }} times in the last hour"
+        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue.md?ref_type=heads
+        alert_team_handle: <!subteam^S05Q1P4Q2TG>
+        team: konflux-infra
+
+  - name: kueue.queue
+    interval: 30s
+    rules:
+    - alert: KueueClusterQueueNotActive
+      expr: max by (status) (kueue_cluster_queue_status{cluster_queue="cluster-pipeline-queue", status="active"}) != 1
+      for: 2m
+      labels:
+        severity: warning
+        component: kueue
+      annotations:
+        summary: "Kueue cluster queue is not active"
+        description: "Cluster queue 'cluster-pipeline-queue' is not in active state"
+        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue.md?ref_type=heads
+        alert_team_handle: <!subteam^S05Q1P4Q2TG>
+        team: konflux-infra
+
+    - alert: KueueHighPendingWorkloads
+      expr: max by (status) (kueue_pending_workloads{cluster_queue="cluster-pipeline-queue"}) > 300
+      for: 5m
+      labels:
+        severity: warning
+        component: kueue
+      annotations:
+        summary: "High number of pending workloads in Kueue"
+        description: "{{ $value }} workloads are pending in cluster queue 'cluster-pipeline-queue'"
+        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue.md?ref_type=heads
+        alert_team_handle: <!subteam^S05Q1P4Q2TG>
+        team: konflux-infra
+
+    - alert: KueueHighAdmissionWaitTime
+      expr: histogram_quantile(0.99, sum(increase(kueue_admission_wait_time_seconds_bucket{cluster_queue="cluster-pipeline-queue"}[10m])) by (le)) > 900
+      for: 5m
+      labels:
+        severity: warning
+        component: kueue
+      annotations:
+        summary: "High admission wait time in Kueue"
+        description: "99th percentile admission wait time is {{ $value }}s, which is above 15 minutes"
+        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue.md?ref_type=heads
+        alert_team_handle: <!subteam^S05Q1P4Q2TG>
+        team: konflux-infra
+
+    - alert: KueueHighResourceReservation
+      expr: max by (resource) (kueue_cluster_queue_resource_reservation{cluster_queue="cluster-pipeline-queue"} / kueue_cluster_queue_nominal_quota{cluster_queue="cluster-pipeline-queue"} * 100) > 90
+      for: 5m
+      labels:
+        severity: warning
+        component: kueue
+      annotations:
+        summary: "High resource reservation in Kueue cluster queue"
+        description: "Resource {{ $labels.resource }} reservation is {{ $value }}% of nominal quota, which is above 90%"
+        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue.md?ref_type=heads
+        alert_team_handle: <!subteam^S05Q1P4Q2TG>
+        team: konflux-infra
+
+    - alert: KueueLowResourceUsage
+      expr: max by (resource) (kueue_cluster_queue_resource_usage{cluster_queue="cluster-pipeline-queue"} / kueue_cluster_queue_resource_reservation{cluster_queue="cluster-pipeline-queue"} * 100) < 50
+      for: 10m
+      labels:
+        severity: info
+        component: kueue
+      annotations:
+        summary: "Low resource usage efficiency in Kueue"
+        description: "Resource {{ $labels.resource }} usage is only {{ $value }}% of reservation, indicating potential overprovisioning"
+        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue.md?ref_type=heads
+        alert_team_handle: <!subteam^S05Q1P4Q2TG>
+        team: konflux-infra
+
+    - alert: KueueHighPipelineDeletionDuration
+      expr: histogram_quantile(0.99, sum by (le) (increase(watcher_pipelinerun_delete_duration_seconds_bucket[10m]))) > 300
+      for: 5m
+      labels:
+        severity: warning
+        component: pipeline-watcher
+      annotations:
+        summary: "High PipelineRun deletion duration"
+        description: "99th percentile PipelineRun deletion duration is {{ $value }}s, which is above 5 minutes"
+        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue.md?ref_type=heads
+        alert_team_handle: <!subteam^S05Q1P4Q2TG>
+        team: konflux-infra
+
+  - name: kueue.deadman
+    interval: 60s
+    rules:
+    - alert: KueueMetricsDown
+      expr: up{job=~".*kueue.*"} == 0
+      for: 5m
+      labels:
+        severity: warning
+        component: kueue
+      annotations:
+        summary: "Kueue metrics endpoint is down"
+        description: "Kueue metrics endpoint {{ $labels.instance }} for job {{ $labels.job }} has been down for more than 5 minutes"
+        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue.md?ref_type=heads
+        alert_team_handle: <!subteam^S05Q1P4Q2TG>
+        team: konflux-infra
+
+    - alert: KueueNoRecentAdmissions
+      expr: increase(kueue_admitted_workloads_total[60m]) == 0
+      for: 60m
+      labels:
+        severity: warning
+        component: kueue
+      annotations:
+        summary: "No recent workload admissions in Kueue"
+        description: "No workloads have been admitted in the last hour, which might indicate a problem with the admission process"
+        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue.md?ref_type=heads
+        alert_team_handle: <!subteam^S05Q1P4Q2TG>
+        team: konflux-infra
+
+    - alert: KueueMutatingWebhookLowSuccessRate
+      expr: |
+        100 * sum(increase(apiserver_admission_webhook_request_total{
+          name="pipelinerun-kueue-defaulter.tekton-kueue.io", code=~"2.."
+        }[10m]))
+        /
+        sum(increase(apiserver_admission_webhook_request_total{
+          name="pipelinerun-kueue-defaulter.tekton-kueue.io"
+        }[10m]))
+        < 99
+      for: 10m
+      labels:
+        severity: warning
+        component: kueue
+      annotations:
+        summary: "Kueue mutating webhook success rate is below 99%"
+        description: "The mutating webhook 'pipelinerun-kueue-defaulter.tekton-kueue.io' has had a success rate below 99% over the past 10 minutes. Possible causes include webhook errors, rejections, or unreachability (e.g., code=600)."
+        runbook_url: https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/queue.md?ref_type=heads
+        alert_team_handle: <!subteam^S05Q1P4Q2TG>
+        team: konflux-infra

--- a/components/kueue-rd/rings/ring-4/base/base-snapshot/tekton-kueue/monitoring/tekton-kueue-controller-sm.yaml
+++ b/components/kueue-rd/rings/ring-4/base/base-snapshot/tekton-kueue/monitoring/tekton-kueue-controller-sm.yaml
@@ -1,0 +1,26 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: tekton-kueue-controller
+  annotations:
+    argocd.argoproj.io/sync-wave: "11"
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  endpoints:
+  - path: /metrics
+    interval: 15s
+    port: https
+    scheme: https
+    bearerTokenSecret:
+      name: "metrics-reader"
+      key: token
+    tlsConfig:
+      serverName: tekton-kueue-controller-manager-metrics-service.tekton-kueue.svc.cluster.local
+      insecureSkipVerify: false
+      ca:
+        secret:
+          name: controller-manager-metrics-server-cert
+          key: ca.crt
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: tekton-kueue

--- a/components/kueue-rd/rings/ring-4/base/base-snapshot/tekton-kueue/monitoring/tekton-kueue-webhook-sm.yaml
+++ b/components/kueue-rd/rings/ring-4/base/base-snapshot/tekton-kueue/monitoring/tekton-kueue-webhook-sm.yaml
@@ -1,0 +1,26 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: tekton-kueue-webhook
+  annotations:
+    argocd.argoproj.io/sync-wave: "11"
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  endpoints:
+  - path: /metrics
+    interval: 15s
+    port: metrics-server
+    scheme: https
+    bearerTokenSecret:
+      name: "metrics-reader"
+      key: token
+    tlsConfig:
+      serverName: tekton-kueue-webhook-service.tekton-kueue.svc.cluster.local
+      insecureSkipVerify: false
+      ca:
+        secret:
+          name: webhook-metrics-server-cert
+          key: ca.crt
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: tekton-kueue-webhook

--- a/components/kueue-rd/rings/ring-4/base/base-snapshot/tekton-kueue/rbac/kustomization.yaml
+++ b/components/kueue-rd/rings/ring-4/base/base-snapshot/tekton-kueue/rbac/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- metrics-reader-sa.yaml
+- prometheus-metrics-reader-crb.yaml
+- prometheus-metrics-read-rb.yaml
+
+namespace: tekton-kueue

--- a/components/kueue-rd/rings/ring-4/base/base-snapshot/tekton-kueue/rbac/metrics-reader-sa.yaml
+++ b/components/kueue-rd/rings/ring-4/base/base-snapshot/tekton-kueue/rbac/metrics-reader-sa.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: metrics-reader
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: metrics-reader
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    kubernetes.io/service-account.name: metrics-reader
+type: kubernetes.io/service-account-token

--- a/components/kueue-rd/rings/ring-4/base/base-snapshot/tekton-kueue/rbac/prometheus-metrics-read-rb.yaml
+++ b/components/kueue-rd/rings/ring-4/base/base-snapshot/tekton-kueue/rbac/prometheus-metrics-read-rb.yaml
@@ -1,0 +1,33 @@
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: tekton-kueue-metrics-read
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+rules:
+  - verbs:
+      - get
+      - list
+      - watch
+    apiGroups:
+      - ''
+    resources:
+      - services
+      - endpoints
+      - pods
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: tekton-kueue-prometheus-k8s-read-binding
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+subjects:
+  - kind: ServiceAccount
+    name: prometheus-k8s
+    namespace: openshift-monitoring
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: tekton-kueue-metrics-read

--- a/components/kueue-rd/rings/ring-4/base/base-snapshot/tekton-kueue/rbac/prometheus-metrics-reader-crb.yaml
+++ b/components/kueue-rd/rings/ring-4/base/base-snapshot/tekton-kueue/rbac/prometheus-metrics-reader-crb.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: prometheus-tekton-kueue-metrics-reader
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: tekton-kueue-metrics-reader
+subjects:
+- kind: ServiceAccount
+  name: metrics-reader
+  namespace: tekton-kueue

--- a/components/kueue-rd/rings/ring-4/base/base-snapshot/workload-priority-classes.yaml
+++ b/components/kueue-rd/rings/ring-4/base/base-snapshot/workload-priority-classes.yaml
@@ -1,0 +1,90 @@
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: WorkloadPriorityClass
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "10"
+  name: konflux-nudge
+value: 1100
+description: "Highest priority for component nudges"
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: WorkloadPriorityClass
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "10"
+  name: konflux-release
+value: 1000
+description: "Higher priority for release pipelines"
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: WorkloadPriorityClass
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "10"
+  name: konflux-tenant-release
+value: 900
+description: "High priority for tenant release pipelines"
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: WorkloadPriorityClass
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "10"
+  name: konflux-post-merge-test
+value: 800
+description: "Priority for post-merge tests"
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: WorkloadPriorityClass
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "10"
+  name: konflux-post-merge-build
+value: 700
+description: "Priority for post-merge builds"
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: WorkloadPriorityClass
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "10"
+  name: konflux-pre-merge-test
+value: 600
+description: "Priority for pre-merge tests"
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: WorkloadPriorityClass
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "10"
+  name: konflux-pre-merge-build
+value: 500
+description: "Priority for pre-merge builds"
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: WorkloadPriorityClass
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "10"
+  name: konflux-default
+value: 400
+description: "Default priority for konflux pipelines"
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: WorkloadPriorityClass
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "10"
+  name: konflux-dependency-update
+value: 300
+description: "Lower priority for dependency updates"

--- a/components/kueue-rd/rings/ring-4/base/catalog-source.yaml
+++ b/components/kueue-rd/rings/ring-4/base/catalog-source.yaml
@@ -1,0 +1,15 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-3"
+  name: redhat-operators-1-18
+  namespace: openshift-kueue-operator
+spec:
+  displayName: redhat-operators-1-18
+  image: registry.redhat.io/redhat/redhat-operator-index:v4.18
+  sourceType: grpc
+  updateStrategy:
+    registryPoll:
+      interval: 30m

--- a/components/kueue-rd/rings/ring-4/base/kustomization.yaml
+++ b/components/kueue-rd/rings/ring-4/base/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- catalog-source.yaml
+- base-snapshot
+- tekton-kueue
+
+patches:
+- path: subscription-source-patch.yaml
+  target:
+    group: operators.coreos.com
+    kind: Subscription
+    name: openshift-kueue-operator

--- a/components/kueue-rd/rings/ring-4/base/subscription-source-patch.yaml
+++ b/components/kueue-rd/rings/ring-4/base/subscription-source-patch.yaml
@@ -1,0 +1,6 @@
+- op: replace
+  path: /spec/source
+  value: redhat-operators-1-18
+- op: replace
+  path: /spec/sourceNamespace
+  value: openshift-kueue-operator

--- a/components/kueue-rd/rings/ring-4/base/tekton-kueue/config.yaml
+++ b/components/kueue-rd/rings/ring-4/base/tekton-kueue/config.yaml
@@ -1,0 +1,153 @@
+queueName: pipelines-queue
+cel:
+  expressions:
+    # Set resource requests for multi platform pipelines
+    - |
+        has(pipelineRun.spec.params) &&
+        pipelineRun.spec.params.exists(p, p.name == 'build-platforms') &&
+        type(pipelineRun.spec.params.filter(p, p.name == 'build-platforms')[0].value) == list ?
+        pipelineRun.spec.params.filter(
+          p,
+          p.name == 'build-platforms')[0]
+        .value.map(
+          p,
+          resource(replace(replace(p, "/", "-"), "_", "-"), 1)
+        ) : []
+
+    # Request AWS IP for AWS-based platforms
+    - |
+        has(pipelineRun.spec.params) &&
+        pipelineRun.spec.params.exists(p, p.name == 'build-platforms') &&
+        type(pipelineRun.spec.params.filter(p, p.name == 'build-platforms')[0].value) == list ?
+        pipelineRun.spec.params.filter(
+          p,
+          p.name == 'build-platforms')[0]
+        .value.filter(
+          p,
+          !(
+            p in [
+              'linux/ppc64le',
+              'linux/s390x',
+              'linux/x86_64',
+              'local',
+              'localhost',
+            ]
+          )
+        ).map(
+          p,
+          resource('aws-ip', 1)
+        ) : []
+
+    # Flag validation error when build-platforms is present but not a list
+    - |
+        has(pipelineRun.spec.params) &&
+        pipelineRun.spec.params.exists(p, p.name == 'build-platforms') &&
+        type(pipelineRun.spec.params.filter(p, p.name == 'build-platforms')[0].value) != list ?
+        [annotation('kueue.konflux-ci.dev/validation-error',
+          'build-platforms parameter must be an array of platform strings, got a non-array value')] : []
+
+    # Set resource requests for multi platform pipelines which doesn't use the build-platforms parameter (old style)
+    - |
+      !(
+        has(pipelineRun.spec.params) &&
+        pipelineRun.spec.params.exists(p, p.name == 'build-platforms')
+      ) &&
+      has(pipelineRun.spec.pipelineSpec) &&
+      has(pipelineRun.spec.pipelineSpec.tasks) &&
+      pipelineRun.spec.pipelineSpec.tasks.size() > 0 ?
+      pipelineRun.spec.pipelineSpec.tasks.map(
+        task,
+        has(task.params) ? task.params.filter(p, p.name == 'PLATFORM') : []
+      )
+      .filter(p, p.size() > 0)
+      .map(
+        p,
+        resource(replace(replace(p[0].value, "/", "-"), "_", "-"), 1)
+      ) : []
+
+    # Request AWS IP for AWS-based platforms which doesn't use the build-platforms parameter (old style)
+    - |
+      !(
+        has(pipelineRun.spec.params) &&
+        pipelineRun.spec.params.exists(p, p.name == 'build-platforms')
+      ) &&
+      has(pipelineRun.spec.pipelineSpec) &&
+      has(pipelineRun.spec.pipelineSpec.tasks) &&
+      pipelineRun.spec.pipelineSpec.tasks.size() > 0 ?
+      pipelineRun.spec.pipelineSpec.tasks.map(
+        task,
+        has(task.params) ? task.params.filter(p, p.name == 'PLATFORM') : []
+      )
+      .filter(p, p.size() > 0)
+      .filter(
+        p,
+        !(
+          p[0].value in [
+            'linux/ppc64le',
+            'linux/s390x',
+            'linux/x86_64',
+            'local',
+            'localhost',
+          ]
+        )
+      )
+      .map(
+        p,
+        resource('aws-ip', 1)
+      ) : []
+
+    # Set mintmaker resource requests.
+    # Necessary since mintmaker refreshes can overload clusters without a
+    # bottleneck on the number of pipelineruns running.
+    - |
+        plrNamespace == 'mintmaker' ? [resource('mintmaker', 1)] : []
+
+    # The token mechanism allows us to balance admitted PipelineRuns.
+    # Each PipelineRun requests 1 token. The token quota is set equal
+    # to the PLR limit so current behavior is unchanged.
+    - |
+        resource('konflux-ci-dev-token', 1)
+
+    # Set the pipeline priority
+    - |
+        has(pipelineRun.metadata.labels) &&
+        'build.appstudio.redhat.com/type' in pipelineRun.metadata.labels &&
+        pipelineRun.metadata.labels['build.appstudio.redhat.com/type'] == 'nudge' ?
+        priority('konflux-nudge') :
+
+        pacEventType == 'push' ? priority('konflux-post-merge-build') :
+        pacEventType == 'pull_request' ||
+          pacEventType == "Merge_Request" ||
+          pacEventType == 'test-comment' ||
+          pacEventType == 'retest-comment' ||
+          pacEventType == 'retest-all-comment' ||
+          pacEventType == 'ok-to-test-comment'  ? priority('konflux-pre-merge-build') :
+        pacTestEventType == 'push' ? priority('konflux-post-merge-test') :
+        pacTestEventType == 'pull_request' ||
+          pacTestEventType == "Merge_Request" ||
+          pacTestEventType == 'test-comment' ||
+          pacTestEventType == 'retest-comment' ||
+          pacTestEventType == 'retest-all-comment' ||
+          pacTestEventType == 'ok-to-test-comment' ? priority('konflux-pre-merge-test') :
+
+        has(pipelineRun.metadata.labels) &&
+        'appstudio.openshift.io/service' in pipelineRun.metadata.labels &&
+        pipelineRun.metadata.labels['appstudio.openshift.io/service'] == 'release' &&
+        'pipelines.appstudio.openshift.io/type' in pipelineRun.metadata.labels &&
+        pipelineRun.metadata.labels['pipelines.appstudio.openshift.io/type'] == 'managed' ?
+        priority('konflux-release') :
+
+        has(pipelineRun.metadata.labels) &&
+        'appstudio.openshift.io/service' in pipelineRun.metadata.labels &&
+        pipelineRun.metadata.labels['appstudio.openshift.io/service'] == 'release' &&
+        'release.appstudio.openshift.io/namespace' in pipelineRun.metadata.labels &&
+        pipelineRun.metadata.labels['release.appstudio.openshift.io/namespace'] == plrNamespace ?
+        priority('konflux-tenant-release') :
+
+        plrNamespace == 'mintmaker' ? priority('konflux-dependency-update') :
+
+        has(pipelineRun.metadata.labels) &&
+        'internal-services.appstudio.openshift.io/pipelinerun-uid' in pipelineRun.metadata.labels ?
+        priority('konflux-release') :
+
+        priority('konflux-default')

--- a/components/kueue-rd/rings/ring-4/base/tekton-kueue/kustomization.yaml
+++ b/components/kueue-rd/rings/ring-4/base/tekton-kueue/kustomization.yaml
@@ -1,0 +1,125 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- https://github.com/konflux-ci/tekton-kueue/config/default?ref=cec0b3c8a240a289bb7aff4313ea647b292d96cc
+
+namespace: tekton-kueue
+# ensure that installation starts after the installation of kueue complete
+commonAnnotations:
+  argocd.argoproj.io/sync-wave: "10"
+  argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+
+images:
+- name: konflux-ci/tekton-kueue
+  newName: quay.io/konflux-ci/tekton-kueue
+  newTag: cec0b3c8a240a289bb7aff4313ea647b292d96cc
+
+configMapGenerator:
+  - name: tekton-kueue-config
+    namespace: tekton-kueue
+    behavior: replace
+    files:
+      - config.yaml
+generatorOptions:
+  disableNameSuffixHash: true
+
+patches:
+  - target:
+      kind: Namespace
+      name: tekton-kueue
+    patch: |
+      - op: add
+        path: /metadata/labels/openshift.io~1cluster-monitoring
+        value: "true"
+  # Controller Manager Deployment Patches
+  - path: patches/no-anti-affinity-annotation-patch.yaml
+    target:
+      kind: Deployment
+      name: tekton-kueue-controller-manager
+      namespace: tekton-kueue
+  - path: patches/deployment-strategy-patch.yaml
+    target:
+      kind: Deployment
+      name: tekton-kueue-controller-manager
+      namespace: tekton-kueue
+  - path: patches/controller-topology-spread-patch.yaml
+    target:
+      kind: Deployment
+      name: tekton-kueue-controller-manager
+      namespace: tekton-kueue
+  - path: patches/controller-manager-container-args-patch.yaml
+    target:
+      kind: Deployment
+      name: tekton-kueue-controller-manager
+      namespace: tekton-kueue
+  - target:
+      kind: Deployment
+      name: tekton-kueue-controller-manager
+      namespace: tekton-kueue
+    patch: |-
+      - op: add
+        path: /spec/replicas
+        value: 2
+  # -- Resource Requests and Limits Patches
+  - target:
+      kind: Deployment
+      name: tekton-kueue-controller-manager
+      namespace: tekton-kueue
+    patch: |-
+      - op: add
+        path: /spec/template/spec/containers/0/resources/requests
+        value:
+          cpu: 500m
+          memory: 2Gi
+
+      - op: add
+        path: /spec/template/spec/containers/0/resources/limits
+        value:
+          cpu: 500m
+          memory: 2Gi
+  # Webhook Deployment Patches
+  - path: patches/no-anti-affinity-annotation-patch.yaml
+    target:
+      kind: Deployment
+      name: tekton-kueue-webhook
+      namespace: tekton-kueue
+  - path: patches/deployment-strategy-patch.yaml
+    target:
+      kind: Deployment
+      name: tekton-kueue-webhook
+      namespace: tekton-kueue
+  - path: patches/webhook-topology-spread-patch.yaml
+    target:
+      kind: Deployment
+      name: tekton-kueue-webhook
+      namespace: tekton-kueue
+  - path: patches/webhook-webhook-container-args-patch.yaml
+    target:
+      kind: Deployment
+      name: tekton-kueue-webhook
+      namespace: tekton-kueue
+  - target:
+      kind: Deployment
+      name: tekton-kueue-webhook
+      namespace: tekton-kueue
+    patch: |-
+      - op: add
+        path: /spec/replicas
+        value: 3
+  # -- Resource Requests and Limits Patches
+  - target:
+      kind: Deployment
+      name: tekton-kueue-webhook
+      namespace: tekton-kueue
+    patch: |-
+      - op: add
+        path: /spec/template/spec/containers/0/resources/requests
+        value:
+          cpu: 200m
+          memory: 256Mi
+
+      - op: add
+        path: /spec/template/spec/containers/0/resources/limits
+        value:
+          cpu: 200m
+          memory: 256Mi

--- a/components/kueue-rd/rings/ring-4/base/tekton-kueue/patches/controller-manager-container-args-patch.yaml
+++ b/components/kueue-rd/rings/ring-4/base/tekton-kueue/patches/controller-manager-container-args-patch.yaml
@@ -1,0 +1,9 @@
+- op: add
+  path: /spec/template/spec/containers/0/args/-
+  value: "--leader-elect-lease-duration=137s"
+- op: add
+  path: /spec/template/spec/containers/0/args/-
+  value: "--leader-elect-renew-deadline=107s"
+- op: add
+  path: /spec/template/spec/containers/0/args/-
+  value: "--leader-elect-retry-period=26s"

--- a/components/kueue-rd/rings/ring-4/base/tekton-kueue/patches/controller-topology-spread-patch.yaml
+++ b/components/kueue-rd/rings/ring-4/base/tekton-kueue/patches/controller-topology-spread-patch.yaml
@@ -1,0 +1,9 @@
+- op: add
+  path: /spec/template/spec/topologySpreadConstraints
+  value:
+    - maxSkew: 1
+      topologyKey: topology.kubernetes.io/zone
+      whenUnsatisfiable: ScheduleAnyway
+      labelSelector:
+        matchLabels:
+          app.kubernetes.io/name: tekton-kueue

--- a/components/kueue-rd/rings/ring-4/base/tekton-kueue/patches/deployment-strategy-patch.yaml
+++ b/components/kueue-rd/rings/ring-4/base/tekton-kueue/patches/deployment-strategy-patch.yaml
@@ -1,0 +1,6 @@
+- op: add
+  path: /spec/strategy
+  value:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 0

--- a/components/kueue-rd/rings/ring-4/base/tekton-kueue/patches/no-anti-affinity-annotation-patch.yaml
+++ b/components/kueue-rd/rings/ring-4/base/tekton-kueue/patches/no-anti-affinity-annotation-patch.yaml
@@ -1,0 +1,3 @@
+- op: add
+  path: /metadata/annotations/ignore-check.kube-linter.io~1no-anti-affinity
+  value: "Using topologySpreadConstraints"

--- a/components/kueue-rd/rings/ring-4/base/tekton-kueue/patches/webhook-topology-spread-patch.yaml
+++ b/components/kueue-rd/rings/ring-4/base/tekton-kueue/patches/webhook-topology-spread-patch.yaml
@@ -1,0 +1,9 @@
+- op: add
+  path: /spec/template/spec/topologySpreadConstraints
+  value:
+    - maxSkew: 1
+      topologyKey: topology.kubernetes.io/zone
+      whenUnsatisfiable: ScheduleAnyway
+      labelSelector:
+        matchLabels:
+          app.kubernetes.io/name: tekton-kueue-webhook

--- a/components/kueue-rd/rings/ring-4/base/tekton-kueue/patches/webhook-webhook-container-args-patch.yaml
+++ b/components/kueue-rd/rings/ring-4/base/tekton-kueue/patches/webhook-webhook-container-args-patch.yaml
@@ -1,0 +1,3 @@
+- op: add
+  path: /spec/template/spec/containers/0/args/-
+  value: --zap-log-level=5

--- a/components/kueue-rd/rings/ring-4/kflux-prd-rh02/cluster-queue.yaml
+++ b/components/kueue-rd/rings/ring-4/kflux-prd-rh02/cluster-queue.yaml
@@ -1,0 +1,211 @@
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: ClusterQueue
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "10"
+  name: cluster-pipeline-queue
+spec:
+  flavorFungibility:
+    whenCanBorrow: MayStopSearch
+    whenCanPreempt: TryNextFlavor
+  namespaceSelector: {}
+  preemption:
+    borrowWithinCohort:
+      policy: Never
+    reclaimWithinCohort: Never
+    withinClusterQueue: Never
+  queueingStrategy: BestEffortFIFO
+  resourceGroups:
+  - coveredResources:
+    - tekton.dev/pipelineruns
+    - konflux-ci-dev-token
+    - cpu
+    - memory
+    - aws-ip
+    - mintmaker
+    flavors:
+    - name: default-flavor
+      resources:
+      - name: tekton.dev/pipelineruns
+        nominalQuota: '300'
+      - name: konflux-ci-dev-token
+        nominalQuota: '300'
+      - name: cpu
+        nominalQuota: 1k
+      - name: memory
+        nominalQuota: 500Ti
+      - name: aws-ip
+        nominalQuota: '250'
+      - name: mintmaker
+        nominalQuota: '150'
+  - coveredResources:
+    - linux-amd64
+    - linux-arm64
+    - linux-c2xlarge-amd64
+    - linux-c2xlarge-arm64
+    - linux-c4xlarge-amd64
+    - linux-c4xlarge-arm64
+    - linux-c6gd2xlarge-arm64
+    - linux-c8xlarge-amd64
+    - linux-c8xlarge-arm64
+    - linux-cxlarge-amd64
+    - linux-cxlarge-arm64
+    - linux-d160-c8xlarge-amd64
+    - linux-d160-c8xlarge-arm64
+    - linux-d160-m2xlarge-amd64
+    - linux-d160-m2xlarge-arm64
+    - linux-d160-m4xlarge-amd64
+    flavors:
+    - name: platform-group-1
+      resources:
+      - name: linux-amd64
+        nominalQuota: '250'
+      - name: linux-arm64
+        nominalQuota: '250'
+      - name: linux-c2xlarge-amd64
+        nominalQuota: '250'
+      - name: linux-c2xlarge-arm64
+        nominalQuota: '250'
+      - name: linux-c4xlarge-amd64
+        nominalQuota: '250'
+      - name: linux-c4xlarge-arm64
+        nominalQuota: '250'
+      - name: linux-c6gd2xlarge-arm64
+        nominalQuota: '250'
+      - name: linux-c8xlarge-amd64
+        nominalQuota: '250'
+      - name: linux-c8xlarge-arm64
+        nominalQuota: '250'
+      - name: linux-cxlarge-amd64
+        nominalQuota: '250'
+      - name: linux-cxlarge-arm64
+        nominalQuota: '250'
+      - name: linux-d160-c8xlarge-amd64
+        nominalQuota: '250'
+      - name: linux-d160-c8xlarge-arm64
+        nominalQuota: '250'
+      - name: linux-d160-m2xlarge-amd64
+        nominalQuota: '250'
+      - name: linux-d160-m2xlarge-arm64
+        nominalQuota: '250'
+      - name: linux-d160-m4xlarge-amd64
+        nominalQuota: '250'
+  - coveredResources:
+    - linux-d160-m4xlarge-arm64
+    - linux-d160-m8xlarge-amd64
+    - linux-d160-m8xlarge-arm64
+    - linux-d320-m8xlarge-amd64
+    - linux-d320-m8xlarge-arm64
+    - linux-extra-fast-amd64
+    - linux-fast-amd64
+    - linux-g64xlarge-amd64
+    - linux-m2xlarge-amd64
+    - linux-m2xlarge-arm64
+    - linux-m4xlarge-amd64
+    - linux-m4xlarge-arm64
+    - linux-m8xlarge-amd64
+    - linux-m8xlarge-arm64
+    - linux-mlarge-amd64
+    - linux-mlarge-arm64
+    flavors:
+    - name: platform-group-2
+      resources:
+      - name: linux-d160-m4xlarge-arm64
+        nominalQuota: '250'
+      - name: linux-d160-m8xlarge-amd64
+        nominalQuota: '250'
+      - name: linux-d160-m8xlarge-arm64
+        nominalQuota: '250'
+      - name: linux-d320-m8xlarge-amd64
+        nominalQuota: '250'
+      - name: linux-d320-m8xlarge-arm64
+        nominalQuota: '250'
+      - name: linux-extra-fast-amd64
+        nominalQuota: '250'
+      - name: linux-fast-amd64
+        nominalQuota: '250'
+      - name: linux-g64xlarge-amd64
+        nominalQuota: '250'
+      - name: linux-m2xlarge-amd64
+        nominalQuota: '250'
+      - name: linux-m2xlarge-arm64
+        nominalQuota: '250'
+      - name: linux-m4xlarge-amd64
+        nominalQuota: '250'
+      - name: linux-m4xlarge-arm64
+        nominalQuota: '250'
+      - name: linux-m8xlarge-amd64
+        nominalQuota: '250'
+      - name: linux-m8xlarge-arm64
+        nominalQuota: '250'
+      - name: linux-mlarge-amd64
+        nominalQuota: '250'
+      - name: linux-mlarge-arm64
+        nominalQuota: '250'
+  - coveredResources:
+    - linux-mxlarge-amd64
+    - linux-mxlarge-arm64
+    - linux-ppc64le
+    - linux-root-amd64
+    - linux-root-arm64
+    - linux-s390x
+    - linux-x86-64
+    - local
+    - localhost
+    flavors:
+    - name: platform-group-3
+      resources:
+      - name: linux-mxlarge-amd64
+        nominalQuota: '250'
+      - name: linux-mxlarge-arm64
+        nominalQuota: '250'
+      - name: linux-ppc64le
+        nominalQuota: '64'
+      - name: linux-root-amd64
+        nominalQuota: '250'
+      - name: linux-root-arm64
+        nominalQuota: '250'
+      - name: linux-s390x
+        nominalQuota: '64'
+      - name: linux-x86-64
+        nominalQuota: 1k
+      - name: local
+        nominalQuota: 1k
+      - name: localhost
+        nominalQuota: 1k
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: ResourceFlavor
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "10"
+  name: default-flavor
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: ResourceFlavor
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "10"
+  name: platform-group-1
+spec: {}
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: ResourceFlavor
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "10"
+  name: platform-group-2
+spec: {}
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: ResourceFlavor
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "10"
+  name: platform-group-3
+spec: {}

--- a/components/kueue-rd/rings/ring-4/kflux-prd-rh02/kustomization.yaml
+++ b/components/kueue-rd/rings/ring-4/kflux-prd-rh02/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- cluster-queue.yaml
+- ../base


### PR DESCRIPTION
### Summary of Changes
- Created a new ApplicationSet to take ownership of the kueue resources on the new ArgoCD production instance on kflux-c-prd-i01
- Added the missing ring folders to the kueue-rd component

### Validation
`kustomize build` outputs for each of the production clusters in the `components/kueue/production/` folder were compared against those in the production ring folders under `components/kueue-rd/rings/` with no discrepancies.

### Risk Level
**Risk Level**: Medium
**Reasoning**: No new component resources are being created; the new ApplicationSet references the `kueue-rd/` directory, which is only a restructuring of the existing `kueue/` directory. Will be done during a maintenance window.
**Rollback Strategy**: Do a manual sync for the original kueue ApplicationSet, as it references the original structuring of kueue.