### PR TITLE
Add platform Prometheus persistent storage

### DIFF
--- a/components/monitoring/prometheus/staging/lightwell-dev/cluster-monitoring-config.yaml
+++ b/components/monitoring/prometheus/staging/lightwell-dev/cluster-monitoring-config.yaml
@@ -8,6 +8,12 @@ data:
     enableUserWorkload: true
     prometheusK8s:
       retentionSize: 10GB
+      volumeClaimTemplate:
+        spec:
+          storageClassName: ibmc-vpc-block-metro-retain-10iops-tier
+          resources:
+            requests:
+              storage: 100Gi
       nodeSelector:
         node-role.kubernetes.io/infra: ""
       tolerations:


### PR DESCRIPTION
## Summary
Configure platform Prometheus on lightwell-dev cluster to use persistent storage instead of ephemeral emptyDir volumes.
  
 ## Problem
The platform Prometheus on lightwell-dev (IBM ROKS cluster) currently does not persist time series data to disk - it uses an empty volume that loses all data on pod restart. This is different from how platform Prometheus is configured on ROSA clusters and other production/staging environments.

  ## Investigation

  ### Current State
  - **lightwell-dev**: Platform Prometheus uses emptyDir (ephemeral storage)
  - **ROSA clusters** (stone-prd-rh01, stone-stage-p01): Platform Prometheus uses 100Gi PVCs with 85GB retention


  ### Why ROSA Comparison Matters
  - Platform Prometheus configuration on ROSA is managed by Red Hat SRE via OpenShift Cluster Manager (OCM)
  - This represents the **standard production configuration** for OpenShift monitoring
  - IBM ROKS clusters allow direct cluster-monitoring-config modifications (unlike ROSA), so we can apply the same standard

  ## Solution

  Add `volumeClaimTemplate` configuration to platform Prometheus with:
  - **Storage size**: 100Gi (aligns with ROSA standard)
  - **Storage class**: `ibmc-vpc-block-metro-retain-10iops-tier`
  (consistent with existing lightwell-dev Tekton MonitoringStack)
  - **Access mode**: ReadWriteOnce (default, implied)


  ## Risk Assessment

  **Level**: Low
  - Initial PVC provisioning might take a few minutes
  - Prometheus pods may restart during initial volume attachment
  - Only affects lightwell-dev cluster (staging)
  - Platform Prometheus will continue functioning during transition
  - No impact to production clusters