### PR TITLE
PVO11Y-5454 Remove cost-management operator from lightwell-dev

### DIFF
--- a/argo-cd-apps/base/all-clusters/infra-deployments/cost-management/costmanagement-metrics-operator.yaml
+++ b/argo-cd-apps/base/all-clusters/infra-deployments/cost-management/costmanagement-metrics-operator.yaml
@@ -15,6 +15,8 @@ spec:
                 clusterDir: base
           - list:
               elements:
+                - nameNormalized: lightwell-dev
+                  values.clusterDir: lightwell-dev
                 - nameNormalized: kflux-stg-es01
                   values.clusterDir: kflux-stg-es01
                 - nameNormalized: stone-stage-p01

--- a/components/cost-management/staging/lightwell-dev/kustomization.yaml
+++ b/components/cost-management/staging/lightwell-dev/kustomization.yaml
@@ -1,0 +1,3 @@
+kind: Kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+resources: []


### PR DESCRIPTION
## Summary

- Adds an empty kustomization overlay for `lightwell-dev` so the `cost-management` ApplicationSet deploys nothing there instead of falling back to the staging base config
- Adds `lightwell-dev` to the ApplicationSet's explicit cluster list pointing at the new empty overlay

## Risk Assessment

**Risk level:** Low

**What could go wrong:** ArgoCD prunes the existing `costmanagement-metrics-operator` resources from lightwell-dev. This is intentional.

**Rollback:** Remove the `lightwell-dev` entry from the ApplicationSet list and delete the empty overlay directory.

**Blast radius:** lightwell-dev only.

## Validation

- Verified cost-management operator is running on lightwell-dev and was deployed via ArgoCD falling back to the staging base overlay
- Empty overlay pattern matches existing usage in `components/konflux-rbac/staging/empty-base/` and `components/vector-kubearchive-log-collector/production/empty-base/`

Jira: https://issues.redhat.com/browse/PVO11Y-5454

🤖 Generated with [Claude Code](https://claude.com/claude-code)