### PR TITLE
PVO11Y-4783 Remove grafana datasource CronJob probe from staging/dev

### DIFF
--- a/components/monitoring/grafana/development/kustomization.yaml
+++ b/components/monitoring/grafana/development/kustomization.yaml
@@ -6,7 +6,6 @@ resources:
   - grafana-app.yaml
   - rbac/
   - dashboards
-  - https://github.com/redhat-appstudio/o11y/config/probes/monitoring/grafana/base?ref=ff478366bb92b0a9d7e4eb1625194e0cce138185
   - https://github.com/redhat-appstudio/o11y/config/exporters/monitoring/grafana/base?ref=0d3c45516968bffb24196952c3273cebd6df5d4f
 
 images:

--- a/components/monitoring/grafana/staging/base/kustomization.yaml
+++ b/components/monitoring/grafana/staging/base/kustomization.yaml
@@ -6,7 +6,6 @@ resources:
   - grafana-app.yaml
   - rbac/
   - ../dashboards
-  - https://github.com/redhat-appstudio/o11y/config/probes/monitoring/grafana/base?ref=ff478366bb92b0a9d7e4eb1625194e0cce138185
   - https://github.com/redhat-appstudio/o11y/config/exporters/monitoring/grafana/base?ref=0d3c45516968bffb24196952c3273cebd6df5d4f
   - disable-leader-elect-job.yaml
 


### PR DESCRIPTION
## Summary

- Removes the `appstudio-probe-monitoring-grafana` CronJob probe from staging and development grafana overlays
- The probe was superseded by the `grafana-datasource-exporter` Deployment ([RHTAPWATCH-1388](https://redhat.atlassian.net/browse/RHTAPWATCH-1388)); KSM was never configured to watch these CronJobs so it never produced availability metrics
- On lightwell-dev the accumulating stuck pods were contributing to VPC IP exhaustion

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[RHTAPWATCH-1388]: https://redhat.atlassian.net/browse/RHTAPWATCH-1388?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ