### PR TITLE
PVO11Y-4783 Remove grafana datasource CronJob probe from production

### DIFF
--- a/components/monitoring/grafana/production/base/kustomization.yaml
+++ b/components/monitoring/grafana/production/base/kustomization.yaml
@@ -6,7 +6,6 @@ resources:
   - grafana-app.yaml
   - rbac/
   - ../dashboards
-  - https://github.com/redhat-appstudio/o11y/config/probes/monitoring/grafana/base?ref=ff478366bb92b0a9d7e4eb1625194e0cce138185
   - https://github.com/redhat-appstudio/o11y/config/exporters/monitoring/grafana/base?ref=b4f5902e18f3d8788181e174c186d4a01aa6cc47
   - disable-leader-elect-job.yaml
 


### PR DESCRIPTION
## Summary

- Removes the `appstudio-probe-monitoring-grafana` CronJob probe from the production grafana overlay
- The probe was superseded by the `grafana-datasource-exporter` Deployment ([RHTAPWATCH-1388](https://redhat.atlassian.net/browse/RHTAPWATCH-1388)); KSM was never configured to watch these CronJobs so it never produced availability metrics

## Risk Assessment

**Risk level:** Low

**What could go wrong:** ArgoCD prunes the `appstudio-probe-monitoring-grafana` namespace and its resources. The exporter Deployment in `appstudio-grafana-datasource-exporter` already covers datasource availability monitoring.

**Rollback:** Revert this commit; ArgoCD will recreate the namespace on next sync.

**Blast radius:** `appstudio-probe-monitoring-grafana` namespace only, no customer-facing impact.

## Validation

Staging removal validated via PR #13645.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[RHTAPWATCH-1388]: https://redhat.atlassian.net/browse/RHTAPWATCH-1388?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ