### PR TITLE
Grant admin access to conformance and managed test namespaces

### DIFF
--- a/components/konflux-verifications-rd/base/rbac.yaml
+++ b/components/konflux-verifications-rd/base/rbac.yaml
@@ -42,3 +42,31 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: release-pipeline-resource-role
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: konflux-devprod-admins
+  namespace: konflux-conformance-tests
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: konflux-devprod
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: admin
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: konflux-devprod-admins
+  namespace: konflux-managed-tests
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: konflux-devprod
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: admin

--- a/components/konflux-verifications-rd/rings/ring-1/base/base-snapshot/rbac.yaml
+++ b/components/konflux-verifications-rd/rings/ring-1/base/base-snapshot/rbac.yaml
@@ -39,3 +39,31 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: release-pipeline-resource-role
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: konflux-devprod-admins
+  namespace: konflux-conformance-tests
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: konflux-devprod
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: admin
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: konflux-devprod-admins
+  namespace: konflux-managed-tests
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: konflux-devprod
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: admin


### PR DESCRIPTION
Add RoleBindings for konflux-devprod group in konflux-conformance-tests and konflux-managed-tests namespaces, using the built-in admin ClusterRole.
