### PR TITLE
feat(KFLUXVNGD-1289): rewrite Cargo config.json URLs to cluster proxy

### DIFF
--- a/components/squid/staging/caching-helm-generator.yaml
+++ b/components/squid/staging/caching-helm-generator.yaml
@@ -32,9 +32,12 @@ valuesInline:
       - location: '^/repository/cargo-proxy/config\.json$'
         types:
           - application/json
+        once: false
         filters:
           - string: '"auth-required":true'
             replacement: '"auth-required":false'
+          - string: 'https://red-hat.repo.sonatype.app'
+            replacement: 'https://artifact-registry-proxy.caching.svc.cluster.local'
     cache:
       allowList:
         # Cache all traffic to nexus repositories


### PR DESCRIPTION
Extend staging nginx.subFilters on cargo-proxy config.json to replace Nexus host in dl/api with artifact-registry-proxy.caching.svc.cluster.local. Set sub_filter_once off so both URLs are rewritten. 