### PR TITLE
KAR-947: optimize loki config prd-rh01 prod-p01 prod-p02

### DIFF
--- a/components/vector-kubearchive-log-collector/production/stone-prd-rh01/loki-helm-prod-values.yaml
+++ b/components/vector-kubearchive-log-collector/production/stone-prd-rh01/loki-helm-prod-values.yaml
@@ -165,9 +165,9 @@ queryFrontend:
   resources:
     requests:
       cpu: 200m
-      memory: 2Gi
-    limits:
       memory: 4Gi
+    limits:
+      memory: 6Gi
 
 queryScheduler:
   replicas: 2

--- a/components/vector-kubearchive-log-collector/production/stone-prd-rh01/loki-helm-prod-values.yaml
+++ b/components/vector-kubearchive-log-collector/production/stone-prd-rh01/loki-helm-prod-values.yaml
@@ -32,7 +32,7 @@ loki:
     gossip_to_dead_nodes_time: 15s
     # How long to wait for an ingester to gracefully leave before considering it dead
     # This should be longer than terminationGracePeriodSeconds to allow graceful shutdown
-    left_ingesters_timeout: 90s
+    left_ingesters_timeout: 150s
   # Required storage configuration for Helm chart
   storage:
     type: s3
@@ -62,26 +62,26 @@ loki:
     discover_log_levels: false
     volume_enabled: true
     max_global_streams_per_user: 75000
-    max_entries_limit_per_query: 100000
+    max_entries_limit_per_query: 50000
     increment_duplicate_timestamp: true
     allow_structured_metadata: true
-    tsdb_max_query_parallelism: 16
-    split_queries_by_interval: 1h
+    tsdb_max_query_parallelism: 8
+    split_queries_by_interval: 30m
     query_timeout: 5m
   runtimeConfig:
     configs:
       kubearchive:
-        log_push_request: true
-        log_push_request_streams: true
-        log_stream_creation: true
-        log_duplicate_stream_info: true
+        log_push_request: false
+        log_push_request_streams: false
+        log_stream_creation: false
+        log_duplicate_stream_info: false
   ingester:
     autoforget_unhealthy: true
-    chunk_target_size: 8388608        # 8MB
+    chunk_target_size: 4194304        # 4MB
     chunk_idle_period: 30m
     max_chunk_age: 1h
     chunk_encoding: snappy            # Compress data (reduces S3 transfer size)
-    chunk_retain_period: 30m          # Keep chunks in memory after flush
+    chunk_retain_period: 15m          # Keep chunks in memory after flush
     flush_op_timeout: 10m             # Add timeout for S3 operations
     lifecycler:
       ring:
@@ -105,7 +105,7 @@ loki:
       max_send_msg_size: 15728640  # 15MB
   # Tuning for high-load queries
   querier:
-    max_concurrent: 8
+    max_concurrent: 4
   query_range:
     # split_queries_by_interval deprecated in query_range section in Loki 3.x - removed
     parallelise_shardable_queries: false
@@ -135,7 +135,7 @@ ingester:
     hard: {}
   # Graceful shutdown configuration to prevent stale ring instances
   # Give Loki time to flush chunks and leave the ring gracefully
-  terminationGracePeriodSeconds: 120  # 2 minutes - longer than left_ingesters_timeout
+  terminationGracePeriodSeconds: 120
   lifecycle:
     preStop:
       exec:
@@ -154,9 +154,9 @@ querier:
   resources:
     requests:
       cpu: 500m
-      memory: 6Gi
-    limits:
       memory: 10Gi
+    limits:
+      memory: 14Gi
   affinity: {}
 
 queryFrontend:

--- a/components/vector-kubearchive-log-collector/production/stone-prod-p01/loki-helm-prod-values.yaml
+++ b/components/vector-kubearchive-log-collector/production/stone-prod-p01/loki-helm-prod-values.yaml
@@ -1,7 +1,7 @@
 ---
 global:
   extraArgs:
-    - "-log.level=debug"
+    - "-log.level=info"
 
 gateway:
   service:
@@ -32,7 +32,7 @@ loki:
     gossip_to_dead_nodes_time: 15s
     # How long to wait for an ingester to gracefully leave before considering it dead
     # This should be longer than terminationGracePeriodSeconds to allow graceful shutdown
-    left_ingesters_timeout: 90s
+    left_ingesters_timeout: 150s
   # Required storage configuration for Helm chart
   storage:
     type: s3
@@ -62,26 +62,26 @@ loki:
     discover_log_levels: false
     volume_enabled: true
     max_global_streams_per_user: 75000
-    max_entries_limit_per_query: 100000
+    max_entries_limit_per_query: 50000
     increment_duplicate_timestamp: true
     allow_structured_metadata: true
-    tsdb_max_query_parallelism: 16
-    split_queries_by_interval: 1h
+    tsdb_max_query_parallelism: 8
+    split_queries_by_interval: 30m
     query_timeout: 5m
   runtimeConfig:
     configs:
       kubearchive:
-        log_push_request: true
-        log_push_request_streams: true
-        log_stream_creation: true
-        log_duplicate_stream_info: true
+        log_push_request: false
+        log_push_request_streams: false
+        log_stream_creation: false
+        log_duplicate_stream_info: false
   ingester:
     autoforget_unhealthy: true
-    chunk_target_size: 8388608        # 8MB
-    chunk_idle_period: 5m
-    max_chunk_age: 2h
+    chunk_target_size: 4194304        # 4MB
+    chunk_idle_period: 30m
+    max_chunk_age: 1h
     chunk_encoding: snappy            # Compress data (reduces S3 transfer size)
-    chunk_retain_period: 1h           # Keep chunks in memory after flush
+    chunk_retain_period: 15m          # Keep chunks in memory after flush
     flush_op_timeout: 10m             # Add timeout for S3 operations
     lifecycler:
       ring:
@@ -105,7 +105,7 @@ loki:
       max_send_msg_size: 15728640  # 15MB
   # Tuning for high-load queries
   querier:
-    max_concurrent: 8
+    max_concurrent: 4
   query_range:
     # split_queries_by_interval deprecated in query_range section in Loki 3.x - removed
     parallelise_shardable_queries: false
@@ -124,7 +124,7 @@ ingester:
       memory: 4Gi
     limits:
       cpu: 2000m
-      memory: 6Gi
+      memory: 8Gi
   persistence:
     enabled: true
     size: 10Gi
@@ -134,7 +134,7 @@ ingester:
     hard: {}
   # Graceful shutdown configuration to prevent stale ring instances
   # Give Loki time to flush chunks and leave the ring gracefully
-  terminationGracePeriodSeconds: 120  # 2 minutes - longer than left_ingesters_timeout
+  terminationGracePeriodSeconds: 120
   lifecycle:
     preStop:
       exec:
@@ -153,9 +153,9 @@ querier:
   resources:
     requests:
       cpu: 500m
-      memory: 6Gi
+      memory: 8Gi
     limits:
-      memory: 10Gi
+      memory: 14Gi
   affinity: {}
 
 queryFrontend:

--- a/components/vector-kubearchive-log-collector/production/stone-prod-p01/loki-helm-prod-values.yaml
+++ b/components/vector-kubearchive-log-collector/production/stone-prod-p01/loki-helm-prod-values.yaml
@@ -164,9 +164,9 @@ queryFrontend:
   resources:
     requests:
       cpu: 200m
-      memory: 2Gi
-    limits:
       memory: 4Gi
+    limits:
+      memory: 8Gi
 
 queryScheduler:
   replicas: 2

--- a/components/vector-kubearchive-log-collector/production/stone-prod-p02/loki-helm-prod-values.yaml
+++ b/components/vector-kubearchive-log-collector/production/stone-prod-p02/loki-helm-prod-values.yaml
@@ -164,9 +164,9 @@ queryFrontend:
   resources:
     requests:
       cpu: 200m
-      memory: 2Gi
-    limits:
       memory: 4Gi
+    limits:
+      memory: 8Gi
 
 queryScheduler:
   replicas: 2

--- a/components/vector-kubearchive-log-collector/production/stone-prod-p02/loki-helm-prod-values.yaml
+++ b/components/vector-kubearchive-log-collector/production/stone-prod-p02/loki-helm-prod-values.yaml
@@ -32,7 +32,7 @@ loki:
     gossip_to_dead_nodes_time: 15s
     # How long to wait for an ingester to gracefully leave before considering it dead
     # This should be longer than terminationGracePeriodSeconds to allow graceful shutdown
-    left_ingesters_timeout: 90s
+    left_ingesters_timeout: 150s
   # Required storage configuration for Helm chart
   storage:
     type: s3
@@ -62,26 +62,26 @@ loki:
     discover_log_levels: false
     volume_enabled: true
     max_global_streams_per_user: 75000
-    max_entries_limit_per_query: 100000
+    max_entries_limit_per_query: 50000
     increment_duplicate_timestamp: true
     allow_structured_metadata: true
-    tsdb_max_query_parallelism: 16
-    split_queries_by_interval: 1h
+    tsdb_max_query_parallelism: 8
+    split_queries_by_interval: 30m
     query_timeout: 5m
   runtimeConfig:
     configs:
       kubearchive:
-        log_push_request: true
-        log_push_request_streams: true
-        log_stream_creation: true
-        log_duplicate_stream_info: true
+        log_push_request: false
+        log_push_request_streams: false
+        log_stream_creation: false
+        log_duplicate_stream_info: false
   ingester:
     autoforget_unhealthy: true
-    chunk_target_size: 8388608        # 8MB
+    chunk_target_size: 4194304        # 4MB
     chunk_idle_period: 30m
     max_chunk_age: 1h
     chunk_encoding: snappy            # Compress data (reduces S3 transfer size)
-    chunk_retain_period: 30m          # Keep chunks in memory after flush
+    chunk_retain_period: 15m          # Keep chunks in memory after flush
     flush_op_timeout: 10m             # Add timeout for S3 operations
     lifecycler:
       ring:
@@ -105,7 +105,7 @@ loki:
       max_send_msg_size: 15728640  # 15MB
   # Tuning for high-load queries
   querier:
-    max_concurrent: 8
+    max_concurrent: 4
   query_range:
     # split_queries_by_interval deprecated in Loki 3.x - removed
     parallelise_shardable_queries: false
@@ -134,7 +134,7 @@ ingester:
     hard: {}
   # Graceful shutdown configuration to prevent stale ring instances
   # Give Loki time to flush chunks and leave the ring gracefully
-  terminationGracePeriodSeconds: 120  # 2 minutes - longer than left_ingesters_timeout
+  terminationGracePeriodSeconds: 120
   lifecycle:
     preStop:
       exec:
@@ -153,9 +153,9 @@ querier:
   resources:
     requests:
       cpu: 500m
-      memory: 6Gi
+      memory: 8Gi
     limits:
-      memory: 10Gi
+      memory: 14Gi
   affinity: {}
 
 queryFrontend:


### PR DESCRIPTION
## Summary
- Increases loki-querier and loki-query-frontend memory request/response to prevent OOM errors on kflux-prd-rh01 kflux-prod-p01 kflux-prod-p02 servers.
- introduces max query lenght and query timeout settings
[KAR-947](https://redhat.atlassian.net/browse/KAR-947)

## Risk assessment
- Low. The changes are tested and no disruption is expected.

## Validation
Staging validated with the same configuration: https://github.com/redhat-appstudio/infra-deployments/pull/12873
Development validated with: https://github.com/redhat-appstudio/infra-deployments/pull/12844

[KAR-947]: https://redhat.atlassian.net/browse/KAR-947?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ