### PR TITLE
chore: bump konflux-ui e5f64507ddce => 0968b43dba01

### DIFF
--- a/components/konflux-ui/production/base/kustomization.yaml
+++ b/components/konflux-ui/production/base/kustomization.yaml
@@ -8,7 +8,7 @@ resources:
 
 images:
   - name: quay.io/konflux-ci/konflux-ui
-    newTag: e5f64507ddce17c2538d3a39ae836d8c2367fdda
+    newTag: 0968b43dba01ddeeb0efcddad93893df9c7cc5e4
 
   - name: quay.io/oauth2-proxy/oauth2-proxy
     newName: quay.io/konflux-ci/oauth2-proxy


### PR DESCRIPTION
Update konflux-ui production image to staging commit `0968b43dba01ddeeb0efcddad93893df9c7cc5e4`.

<details>
<summary>What's in this release</summary>

**Full diff:** [`e5f6450..0968b43`](https://github.com/konflux-ci/konflux-ui/compare/e5f64507ddce17c2538d3a39ae836d8c2367fdda...0968b43dba01ddeeb0efcddad93893df9c7cc5e4)

### Other Changes

- [[KFLUXUI-1544](https://issues.redhat.com/browse/KFLUXUI-1544)] VirtualizedLogContent - pass line number navigation as props (konflux-ci/konflux-ui#1233) @rrosatti

</details>

---
Fixes konflux-ci/konflux-ui#1378

[KFLUXUI-1544]: https://redhat.atlassian.net/browse/KFLUXUI-1544?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ