### PR TITLE
fix(): Add kflux-lw-p01 to pipeline-service ring-mappings

### DIFF
--- a/components/pipeline-service/production/ring-mappings.yaml
+++ b/components/pipeline-service/production/ring-mappings.yaml
@@ -10,6 +10,7 @@ ring-2:
   - "stone-prod-p02"
   - "kflux-rhel-p01"
   - "kflux-ocp-p01"
+  - "kflux-lw-p01"
 
 ring-3:
   - "stone-prd-rh01"


### PR DESCRIPTION
in #13656 kflux-lw-p01 was added to the production overlay with a ring-2 kustomization reference but did not add the cluster to ring-mappings.yaml. This causes sync-rings.sh validation to fail on any PR that touches components/pipeline-service/, including unrelated staging/dev changes like #13371.

Assisted-by: Cursor (claude-opus-4-6)