### PR TITLE
chore: bump konflux-ui e5f64507ddce => 49d821907ec7

### DIFF
--- a/components/konflux-ui/production/base/kustomization.yaml
+++ b/components/konflux-ui/production/base/kustomization.yaml
@@ -8,7 +8,7 @@ resources:
 
 images:
   - name: quay.io/konflux-ci/konflux-ui
-    newTag: e5f64507ddce17c2538d3a39ae836d8c2367fdda
+    newTag: 49d821907ec7afed9ed0b953ff466be679f4d90a
 
   - name: quay.io/oauth2-proxy/oauth2-proxy
     newName: quay.io/konflux-ci/oauth2-proxy


### PR DESCRIPTION
Update konflux-ui production image to staging commit `49d821907ec7afed9ed0b953ff466be679f4d90a`.

<details>
<summary>What's in this release</summary>

**Full diff:** [`e5f6450..49d8219`](https://github.com/konflux-ci/konflux-ui/compare/e5f64507ddce17c2538d3a39ae836d8c2367fdda...49d821907ec7afed9ed0b953ff466be679f4d90a)

### Other Changes

- update storybook monorepo to v10.5.8 (konflux-ci/konflux-ui#1376) @red-hat-konflux[bot]

</details>

---
Fixes konflux-ci/konflux-ui#1379