### PR TITLE
KFLUXINFRA-4285: (onboarding) Remove production kueue apps from AppSRE ArgoCD

### DIFF
--- a/argo-cd-apps/base/member/infra-deployments/kueue/kueue.yaml
+++ b/argo-cd-apps/base/member/infra-deployments/kueue/kueue.yaml
@@ -17,27 +17,7 @@ spec:
                 # This allows to gradually deploy to all the clusters.
                 clusterDir: empty-base
           - list:
-              elements:
-                - nameNormalized: stone-prd-rh01
-                  values.clusterDir: stone-prd-rh01
-                - nameNormalized: kflux-prd-rh02
-                  values.clusterDir: kflux-prd-rh02
-                - nameNormalized: stone-prod-p01
-                  values.clusterDir: stone-prod-p01
-                - nameNormalized: stone-prod-p02
-                  values.clusterDir: stone-prod-p02
-                - nameNormalized: kflux-ocp-p01
-                  values.clusterDir: kflux-ocp-p01
-                - nameNormalized: kflux-prd-rh03
-                  values.clusterDir: kflux-prd-rh03
-                - nameNormalized: kflux-rhel-p01
-                  values.clusterDir: kflux-rhel-p01
-                - nameNormalized: kflux-osp-p01
-                  values.clusterDir: kflux-osp-p01
-                - nameNormalized: kflux-fedora-01
-                  values.clusterDir: kflux-fedora-01
-                - nameNormalized: kflux-lw-p01
-                  values.clusterDir: kflux-lw-p01
+              elements: []
   template:
     metadata:
       name: kueue-{{nameNormalized}}

--- a/argo-cd-apps/overlays/konflux-public-production/delete-applications.yaml
+++ b/argo-cd-apps/overlays/konflux-public-production/delete-applications.yaml
@@ -29,3 +29,10 @@ kind: ApplicationSet
 metadata:
   name: konflux-verifications-rd
 $patch: delete
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: kueue
+$patch: delete
+

--- a/argo-cd-apps/overlays/konflux-public-production/kustomization.yaml
+++ b/argo-cd-apps/overlays/konflux-public-production/kustomization.yaml
@@ -214,11 +214,6 @@ patches:
     target:
       kind: ApplicationSet
       version: v1alpha1
-      name: kueue
-  - path: production-overlay-patch.yaml
-    target:
-      kind: ApplicationSet
-      version: v1alpha1
       name: pulp-access-controller
   - path: squid-production-overlay-patch.yaml
     target:

--- a/argo-cd-apps/overlays/production-downstream/delete-applications.yaml
+++ b/argo-cd-apps/overlays/production-downstream/delete-applications.yaml
@@ -28,3 +28,9 @@ kind: ApplicationSet
 metadata:
   name: konflux-verifications-rd
 $patch: delete
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: kueue
+$patch: delete

--- a/argo-cd-apps/overlays/production-downstream/kustomization.yaml
+++ b/argo-cd-apps/overlays/production-downstream/kustomization.yaml
@@ -233,11 +233,6 @@ patches:
     target:
       kind: ApplicationSet
       version: v1alpha1
-      name: kueue
-  - path: production-overlay-patch.yaml
-    target:
-      kind: ApplicationSet
-      version: v1alpha1
       name: pulp-access-controller
   - path: squid-production-overlay-patch.yaml
     target:


### PR DESCRIPTION
### What
- Added delete patches for kueue in both production overlays
- Removed production cluster entries from the original kueue AppSet

*Outside this PR: Removed Argo CD finalizers from all production kueue apps so no Argo CD-managed resources are deleted*

### Why
This is the penultimate step in migrating a component to the new Argo CD instances on the common clusters.

### Validation
No verifications are possible.

### Risk Level
**Risk Level**: Medium
**Reasoning**: No new component resources are being created; the rd-production ApplicationSet references the `kueue-rd/` directory, which is only a restructuring of the existing `kueue/` directory
**Rollback Strategy**: Revert this commit and manually delete, then wait for re-creation of all Kueue applications in the AppSRE clusters.
**What could go wrong**: All production Kueue applications are in an unstable state for up to 10 minutes.
**Blast Radius**:  stone-prd-rh01, kflux-prd-rh02, stone-prod-p01, stone-prod-p02, kflux-ocp-p01, kflux-prd-rh03, kflux-rhel-p01, kflux-osp-p01, kflux-fedora-01, kflux-lw-p01