### PR TITLE
production Ring 1: upgrade openshift-pipelines 854 to 871 and fix resolver bucket mismatch

### DIFF
--- a/components/pipeline-service/production/base/main-pipeline-service-configuration.yaml
+++ b/components/pipeline-service/production/base/main-pipeline-service-configuration.yaml
@@ -1752,7 +1752,7 @@ spec:
             default-imagepullbackoff-timeout: "15m"
         config-leader-election-resolvers:
           data:
-            buckets: "8"
+            buckets: "4"
       deployments:
         tekton-operator-proxy-webhook:
           spec:
@@ -2054,7 +2054,7 @@ metadata:
   namespace: openshift-marketplace
 spec:
   displayName: custom-operators
-  image: quay.io/openshift-pipeline/pipelines-index-4.19@sha256:bd598786408b16bc1171c79907db124013189d57677e8bfbec1feccc55523ccd
+  image: quay.io/openshift-pipeline/pipelines-index-4.19@sha256:8c6152d2924f608960a4cec0faca33a1807bce19085e86d1daeeaa698fce146d
   sourceType: grpc
   updateStrategy:
     registryPoll:

--- a/components/pipeline-service/production/kflux-fedora-01/deploy.yaml
+++ b/components/pipeline-service/production/kflux-fedora-01/deploy.yaml
@@ -2345,7 +2345,7 @@ spec:
             default-timeout-minutes: "120"
         config-leader-election-resolvers:
           data:
-            buckets: "8"
+            buckets: "4"
         config-logging:
           data:
             loglevel.controller: info
@@ -2565,7 +2565,7 @@ metadata:
   namespace: openshift-marketplace
 spec:
   displayName: custom-operators
-  image: quay.io/openshift-pipeline/pipelines-index-4.19@sha256:bd598786408b16bc1171c79907db124013189d57677e8bfbec1feccc55523ccd
+  image: quay.io/openshift-pipeline/pipelines-index-4.19@sha256:8c6152d2924f608960a4cec0faca33a1807bce19085e86d1daeeaa698fce146d
   sourceType: grpc
   updateStrategy:
     registryPoll:

--- a/components/pipeline-service/production/kflux-osp-p01/deploy.yaml
+++ b/components/pipeline-service/production/kflux-osp-p01/deploy.yaml
@@ -2309,7 +2309,7 @@ spec:
             default-timeout-minutes: "120"
         config-leader-election-resolvers:
           data:
-            buckets: "8"
+            buckets: "4"
         config-logging:
           data:
             loglevel.controller: info
@@ -2531,7 +2531,7 @@ metadata:
   namespace: openshift-marketplace
 spec:
   displayName: custom-operators
-  image: quay.io/openshift-pipeline/pipelines-index-4.19@sha256:bd598786408b16bc1171c79907db124013189d57677e8bfbec1feccc55523ccd
+  image: quay.io/openshift-pipeline/pipelines-index-4.19@sha256:8c6152d2924f608960a4cec0faca33a1807bce19085e86d1daeeaa698fce146d
   sourceType: grpc
   updateStrategy:
     registryPoll:

--- a/components/pipeline-service/production/rings/ring-2/kustomization.yaml
+++ b/components/pipeline-service/production/rings/ring-2/kustomization.yaml
@@ -8,4 +8,19 @@ kind: Kustomization
 resources:
   - ../../base
 
-patches: []
+patches:
+  # Hold back on build 854 until Ring 2 promotion
+  - target:
+      kind: CatalogSource
+      name: custom-operators
+    patch: |-
+      - op: replace
+        path: /spec/image
+        value: quay.io/openshift-pipeline/pipelines-index-4.19@sha256:bd598786408b16bc1171c79907db124013189d57677e8bfbec1feccc55523ccd
+  - target:
+      kind: TektonConfig
+      name: config
+    patch: |-
+      - op: replace
+        path: /spec/pipeline/options/configMaps/config-leader-election-resolvers/data/buckets
+        value: "8"

--- a/components/pipeline-service/production/rings/ring-3/kustomization.yaml
+++ b/components/pipeline-service/production/rings/ring-3/kustomization.yaml
@@ -8,4 +8,19 @@ kind: Kustomization
 resources:
   - ../../base
 
-patches: []
+patches:
+  # Hold back on build 854 until Ring 3 promotion
+  - target:
+      kind: CatalogSource
+      name: custom-operators
+    patch: |-
+      - op: replace
+        path: /spec/image
+        value: quay.io/openshift-pipeline/pipelines-index-4.19@sha256:bd598786408b16bc1171c79907db124013189d57677e8bfbec1feccc55523ccd
+  - target:
+      kind: TektonConfig
+      name: config
+    patch: |-
+      - op: replace
+        path: /spec/pipeline/options/configMaps/config-leader-election-resolvers/data/buckets
+        value: "8"

--- a/components/pipeline-service/production/stone-prod-p01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prod-p01/deploy.yaml
@@ -2309,7 +2309,7 @@ spec:
             default-timeout-minutes: "120"
         config-leader-election-resolvers:
           data:
-            buckets: "8"
+            buckets: "4"
         config-logging:
           data:
             loglevel.controller: info
@@ -2531,7 +2531,7 @@ metadata:
   namespace: openshift-marketplace
 spec:
   displayName: custom-operators
-  image: quay.io/openshift-pipeline/pipelines-index-4.19@sha256:bd598786408b16bc1171c79907db124013189d57677e8bfbec1feccc55523ccd
+  image: quay.io/openshift-pipeline/pipelines-index-4.19@sha256:8c6152d2924f608960a4cec0faca33a1807bce19085e86d1daeeaa698fce146d
   sourceType: grpc
   updateStrategy:
     registryPoll:


### PR DESCRIPTION

- **Ring 1**: kflux-fedora-01, stone-prod-p01, kflux-osp-p01
- **Index image**: pipelines-index-4.19 build 854 → build 871 (sha256:bd598786 → 8c6152d2)
- **Resolver bucket fix**: config-leader-election-resolvers buckets 8 → 4 (matches StatefulSet replica count)

## Changes

1. **CatalogSource**: updated to build 871 (`sha256:8c6152d2924f608960a4cec0faca33a1807bce19085e86d1daeeaa698fce146d`)
2. **TektonConfig**: resolver leader-election buckets reduced from 8 to 4 — fixes orphaned ResolutionRequests when using StatefulSet ordinal mode with 4 replicas
3. **Ring 2/3 holdback**: CatalogSource pinned to build 854, resolver buckets pinned to 8 (current state)

## Component Summary (854 → 871)

| Component | 854 Version | 871 Version | Change |
|-----------|------------|------------|--------|
| Pipeline | v1.14.0 | v1.15.0 | minor bump (LTS) |
| PAC | v0.49.0 | v0.50.0 | minor bump |
| Triggers | v0.36.0 | v0.37.0 | minor bump |
| Chains | v0.28.0 | v0.29.0 | minor bump |
| Operator | post-v0.80.0 | post-v0.81.0 | +68 commits |

## Validation

- Build 871 validated in dev/staging ([PR #13452](https://github.com/redhat-appstudio/infra-deployments/pull/13452))
- Root cause of staging ResolutionRequest failures identified as resolver bucket mismatch (8 buckets, 4 replicas in StatefulSet ordinal mode → 4 buckets permanently unowned)
- Bucket fix verified in staging — resolver pods correctly claim all partitions after change
- Staging bake period: 1 week on stone-stg-rh01, stone-stage-p01, lightwell-dev (#TODO - modify the bake period)

## Risk Assessment

**Risk Level:** Medium
**What could go wrong:** Pipeline v1.15.0 introduces changes to resolution requeueing logic. If any edge case in the new resolver code triggers excessive API load, pipelines could stall.
**Blast radius:** 3 clusters (Ring 1 only). Ring 2 and Ring 3 held back at build 854.
**Rollback plan:** Release a new Index image with the fix included.