### PR TITLE
KFLUXINFRA-4241: (onboarding) Remove staging multi-platform-controller apps from AppSRE ArgoCD

### DIFF
--- a/argo-cd-apps/overlays/konflux-public-staging/delete-applications.yaml
+++ b/argo-cd-apps/overlays/konflux-public-staging/delete-applications.yaml
@@ -23,3 +23,9 @@ kind: ApplicationSet
 metadata:
   name: kueue
 $patch: delete
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: multi-platform-controller
+$patch: delete

--- a/argo-cd-apps/overlays/staging-downstream/delete-applications.yaml
+++ b/argo-cd-apps/overlays/staging-downstream/delete-applications.yaml
@@ -17,3 +17,9 @@ kind: ApplicationSet
 metadata:
   name: kueue
 $patch: delete
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: multi-platform-controller
+$patch: delete

--- a/argo-cd-apps/overlays/staging-downstream/kustomization.yaml
+++ b/argo-cd-apps/overlays/staging-downstream/kustomization.yaml
@@ -15,16 +15,6 @@ patchesStrategicMerge:
   - delete-applications.yaml
 
 patches:
-  - path: staging-downstream-overlay-patch.yaml
-    target:
-      kind: ApplicationSet
-      version: v1alpha1
-      name: multi-platform-controller
-  - path: mpc-lightwell-dev-patch.yaml
-    target:
-      kind: ApplicationSet
-      version: v1alpha1
-      name: multi-platform-controller
   # Exclude operator-managed clusters from Argo generation for services owned
   # by the konflux-operator. Orphan (do not prune) when Applications go away.
   - path: exclude-operator-owned-clusters.yaml

--- a/argo-cd-apps/overlays/staging-downstream/mpc-lightwell-dev-patch.yaml
+++ b/argo-cd-apps/overlays/staging-downstream/mpc-lightwell-dev-patch.yaml
@@ -1,7 +1,0 @@
----
-- op: add
-  path: /spec/generators/0/merge/generators/1/list/elements/-
-  value:
-    nameNormalized: lightwell-dev
-    values.clusterDir: lightwell-dev
-    values.environment: staging

--- a/argo-cd-apps/overlays/staging-downstream/staging-downstream-overlay-patch.yaml
+++ b/argo-cd-apps/overlays/staging-downstream/staging-downstream-overlay-patch.yaml
@@ -1,4 +1,0 @@
----
-- op: add
-  path: /spec/generators/0/merge/generators/0/clusters/values/environment
-  value: staging-downstream


### PR DESCRIPTION
## What

- Delete the old `multi-platform-controller` ApplicationSet from `konflux-public-staging` and `staging-downstream`.
- Remove the staging-downstream patches that existed only to retarget that ApplicationSet (`environment: staging-downstream` and the `lightwell-dev` list entry).

Clusters affected: `stone-stg-rh01`, `stone-stage-p01`, `lightwell-dev`

[KFLUXINFRA-4241](https://redhat.atlassian.net/browse/KFLUXINFRA-4241)


## RD-deployment ArgoCD Application link:
https://argocd-infra-deployments-server-argocd-infra-deployments.apps.rosa.kflux-c-stg-i01.qfla.p3.openshiftapps.com/applications?search=multi-&proj=&sync=&autoSync=&health=&namespace=&cluster=&labels=&annotations=&operation=

## Why

Part 2 of the staging onboarding. The rd-staging ApplicationSet from #13615 already deploys these clusters from the Konflux-hosted ArgoCD. Removing the AppSRE ApplicationSet stops dual ownership of the same destination.

## Validation

- `kustomize build argo-cd-apps/overlays/konflux-public-staging` succeeds; no ApplicationSet named `multi-platform-controller`.
- `kustomize build argo-cd-apps/overlays/staging-downstream` succeeds; no ApplicationSet named `multi-platform-controller`.
- `kustomize build argo-cd-apps/overlays/rd-staging` still emits the rd ApplicationSet (`sourceRoot: components/multi-platform-controller-rd`, namespace `argocd-infra-deployments`).
- `kustomize build` of `development` and `konflux-public-production` still emit the original ApplicationSet.

## Risk Assessment

**Risk Level:** Medium
**What could go wrong:** Deleting the ApplicationSet deletes the generated Applications. If `preserveResourcesOnDeletion` were not honored, member-cluster resources could be pruned. Dual-sync could also leave Applications OutOfSync for a short window until rd-staging is the only owner.
**Rollback:** Revert this PR and manually sync the restored AppSRE ApplicationSet.
**Blast radius:** Staging only (`stone-stg-rh01`, `stone-stage-p01`, `lightwell-dev`). Development and production keep the original ApplicationSet.

Operational note: Part 1 (#13615) already set `preserveResourcesOnDeletion: true` and left auto-sync off on the original ApplicationSet. If extra safety is wanted before merge, strip Argo CD resource finalizers from the old staging Applications (same precaution used for kueue).


Made with [Cursor](https://cursor.com)

[KFLUXINFRA-4241]: https://redhat.atlassian.net/browse/KFLUXINFRA-4241?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ