### PR TITLE
chore: add artifact-registry-proxy to cluster-secret-store

### DIFF
--- a/components/cluster-secret-store/base/appsre-stonesoup-vault-secret-store.yaml
+++ b/components/cluster-secret-store/base/appsre-stonesoup-vault-secret-store.yaml
@@ -74,3 +74,4 @@ spec:
         - konflux-o11y-exporters
         - caching
         - segment-bridge
+        - artifact-registry-proxy


### PR DESCRIPTION
Fixes "could not get secret data from provider" for the artifact-registry-credentials ExternalSecret.

## Risk Assessment

**Risk Level:** Low
**What could go wrong:** Additive allowlist entry only. A malformed conditions list could break secret retrieval for other namespaces on the store, but the change is a single appended namespace and kustomize build renders cleanly for staging and production.
**Rollback:** Revert PR; ArgoCD resyncs the previous ClusterSecretStore conditions. 
Note: reverting only removes the allowlist entry — it does not delete any secret data already synced into the namespace.
**Blast radius:** All clusters consuming the appsre-stonesoup-vault ClusterSecretStore base. Only the artifact-registry-proxy namespace gains access; other namespaces are unaffected.