### PR TITLE
feat(KONFLUX-15424): Temporarily raise kueue quotas for number of PLRs

### DIFF
--- a/components/kueue-rd/rings/ring-1/lightwell-dev/cluster-queue.yaml
+++ b/components/kueue-rd/rings/ring-1/lightwell-dev/cluster-queue.yaml
@@ -29,9 +29,9 @@ spec:
     - name: default-flavor
       resources:
       - name: tekton.dev/pipelineruns
-        nominalQuota: '600'
+        nominalQuota: '1200'
       - name: konflux-ci-dev-token
-        nominalQuota: '500'
+        nominalQuota: '1000'
       - name: cpu
         nominalQuota: 1k
       - name: memory


### PR DESCRIPTION
Temporarily raise kueue quotas related to number of PLRs to be able to check clusters capacity while tracking apiserver_storage_size_bytes metric

Discussed on [slack](https://redhat-internal.slack.com/archives/C0BP4GYQJPQ/p1787606654443249?thread_ts=1787576635.544849&cid=C0BP4GYQJPQ).