### PR TITLE
chore(RELEASE-2696): add release ns to stage CSS

### DIFF
--- a/components/cluster-secret-store/staging/konflux-release-service-namespaces-patch.yaml
+++ b/components/cluster-secret-store/staging/konflux-release-service-namespaces-patch.yaml
@@ -1,0 +1,4 @@
+---
+- op: add
+  path: /spec/conditions/0/namespaces/-
+  value: konflux-release-service-tenant

--- a/components/cluster-secret-store/staging/kustomization.yaml
+++ b/components/cluster-secret-store/staging/kustomization.yaml
@@ -33,3 +33,9 @@ patches:
       kind: ClusterSecretStore
       group: external-secrets.io
       version: v1
+  - path: konflux-release-service-namespaces-patch.yaml
+    target:
+      name: appsre-stonesoup-vault
+      kind: ClusterSecretStore
+      group: external-secrets.io
+      version: v1


### PR DESCRIPTION
This commit adds the konflux-release-service-tenant namespace to the stage ClusterSecretStore namespace allow list. Release-service E2E will be orchestrated from stage instead of prod so ExternalSecrets need to work there.