### PR TITLE
KFLUXINFRA-4493: Disable auto-sync for staging-downstream AppSets

### DIFF
--- a/argo-cd-apps/overlays/staging-downstream/disable-auto-sync.yaml
+++ b/argo-cd-apps/overlays/staging-downstream/disable-auto-sync.yaml
@@ -1,7 +1,20 @@
----
 # Remove automated sync (auto-sync + self-heal) from ApplicationSet templates.
 # Kept for staging member clusters that are not yet on the konflux-operator
 # (e.g. stone-stg-rh01).
 # Scoped to staging-downstream only.
-- op: remove
-  path: /spec/template/spec/syncPolicy/automated
+#
+# Strategic-merge patch (not JSON6902): setting a field to `null` removes it
+# where present and is a safe no-op on ApplicationSets (e.g. etcd-defrag) that
+# never had `syncPolicy.automated` set, unlike a JSON6902 `remove`, which
+# errors on a missing path. metadata.name below is irrelevant since the
+# untargeted `target:` selector in kustomization.yaml (kind/version only)
+# applies this patch to every ApplicationSet.
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: unused
+spec:
+  template:
+    spec:
+      syncPolicy:
+        automated: null

--- a/argo-cd-apps/overlays/staging-downstream/kustomization.yaml
+++ b/argo-cd-apps/overlays/staging-downstream/kustomization.yaml
@@ -15,6 +15,10 @@ patchesStrategicMerge:
   - delete-applications.yaml
 
 patches:
+  - path: disable-auto-sync.yaml
+    target:
+      kind: ApplicationSet
+      version: v1alpha1
   # Exclude operator-managed clusters from Argo generation for services owned
   # by the konflux-operator. Orphan (do not prune) when Applications go away.
   - path: exclude-operator-owned-clusters.yaml
@@ -117,62 +121,3 @@ patches:
       kind: ApplicationSet
       version: v1alpha1
       name: release
-  # Disable auto-sync for remaining staging members (e.g. stone-stg-rh01)
-  # while operator rollout targets stone-stage-p01 and lightwell-dev only.
-  # Harmless on operator-owned clusters once the Applications are no longer
-  # generated.
-  - path: disable-auto-sync.yaml
-    target:
-      kind: ApplicationSet
-      version: v1alpha1
-      name: application-api
-  - path: disable-auto-sync.yaml
-    target:
-      kind: ApplicationSet
-      version: v1alpha1
-      name: build-service
-  - path: disable-auto-sync.yaml
-    target:
-      kind: ApplicationSet
-      version: v1alpha1
-      name: integration
-  - path: disable-auto-sync.yaml
-    target:
-      kind: ApplicationSet
-      version: v1alpha1
-      name: image-controller
-  - path: disable-auto-sync.yaml
-    target:
-      kind: ApplicationSet
-      version: v1alpha1
-      name: namespace-lister
-  - path: disable-auto-sync.yaml
-    target:
-      kind: ApplicationSet
-      version: v1alpha1
-      name: konflux-info
-  - path: disable-auto-sync.yaml
-    target:
-      kind: ApplicationSet
-      version: v1alpha1
-      name: konflux-ui
-  - path: disable-auto-sync.yaml
-    target:
-      kind: ApplicationSet
-      version: v1alpha1
-      name: enterprise-contract
-  - path: disable-auto-sync.yaml
-    target:
-      kind: ApplicationSet
-      version: v1alpha1
-      name: konflux-rbac
-  - path: disable-auto-sync.yaml
-    target:
-      kind: ApplicationSet
-      version: v1alpha1
-      name: release
-  - path: disable-auto-sync.yaml
-    target:
-      kind: ApplicationSet
-      version: v1alpha1
-      name: konflux-verifications-rd


### PR DESCRIPTION
This disables auto-sync for the ApplicationSets managed by the AppSRE internal staging ArgoCD instance so we can begin the process of migrating to the new common cluster-hosted ArgoCD instance.

Verified by running `kustomize build argo-cd-apps/overlays/staging-downstream`.