### PR TITLE
feat: add git-credentials ExternalSecret for konflux-conformance-tests

### DIFF
--- a/components/cluster-secret-store/staging/konflux-verifications-rd-namespaces-patch.yaml
+++ b/components/cluster-secret-store/staging/konflux-verifications-rd-namespaces-patch.yaml
@@ -2,3 +2,6 @@
 - op: add
   path: /spec/conditions/0/namespaces/-
   value: konflux-managed-tests
+- op: add
+  path: /spec/conditions/0/namespaces/-
+  value: konflux-conformance-tests

--- a/components/konflux-verifications-rd/base/git-credentials-external-secret.yaml
+++ b/components/konflux-verifications-rd/base/git-credentials-external-secret.yaml
@@ -1,0 +1,28 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: git-credentials
+  namespace: konflux-conformance-tests
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  dataFrom:
+    - extract:
+        key: production/devprod/konflux-conformance-tests-credentials
+        decodingStrategy: None
+  refreshInterval: 10m
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: appsre-stonesoup-vault
+  target:
+    name: git-credentials
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    template:
+      type: kubernetes.io/basic-auth
+      metadata:
+        annotations:
+          tekton.dev/git-0: "https://github.com"
+      data:
+        username: "{{ .github_user }}"
+        password: "{{ .github_pat }}"

--- a/components/konflux-verifications-rd/base/kustomization.yaml
+++ b/components/konflux-verifications-rd/base/kustomization.yaml
@@ -4,3 +4,4 @@ resources:
   - namespaces.yaml
   - serviceaccount.yaml
   - rbac.yaml
+  - git-credentials-external-secret.yaml

--- a/components/konflux-verifications-rd/rings/ring-1/base/base-snapshot/git-credentials-external-secret.yaml
+++ b/components/konflux-verifications-rd/rings/ring-1/base/base-snapshot/git-credentials-external-secret.yaml
@@ -1,0 +1,28 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: git-credentials
+  namespace: konflux-conformance-tests
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  dataFrom:
+    - extract:
+        key: production/devprod/konflux-conformance-tests-credentials
+        decodingStrategy: None
+  refreshInterval: 10m
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: appsre-stonesoup-vault
+  target:
+    name: git-credentials
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    template:
+      type: kubernetes.io/basic-auth
+      metadata:
+        annotations:
+          tekton.dev/git-0: "https://github.com"
+      data:
+        username: "{{ .github_user }}"
+        password: "{{ .github_pat }}"

--- a/components/konflux-verifications-rd/rings/ring-1/base/base-snapshot/kustomization.yaml
+++ b/components/konflux-verifications-rd/rings/ring-1/base/base-snapshot/kustomization.yaml
@@ -4,3 +4,4 @@ resources:
   - namespaces.yaml
   - serviceaccount.yaml
   - rbac.yaml
+  - git-credentials-external-secret.yaml


### PR DESCRIPTION
Add ExternalSecret to pull GitHub PAT from Vault and create a basic-auth secret with Tekton git annotation for pipeline use. Also patch appstudio-pipeline SA to reference the secret and grant the namespace access to the ClusterSecretStore.

