### PR TITLE
KFLUXVNGD-1283: enable Cargo config.json subFilters on production (ring-1)

### DIFF
--- a/components/squid/production/kflux-fedora-01/caching-helm-generator.yaml
+++ b/components/squid/production/kflux-fedora-01/caching-helm-generator.yaml
@@ -4,7 +4,7 @@ metadata:
   name: caching-helm
 name: caching-helm
 repo: oci://quay.io/konflux-ci/caching
-version: 0.1.1775+d865e45
+version: 0.1.1889+ca96506
 valuesInline:
   squid:
     enabled: true
@@ -28,6 +28,16 @@ valuesInline:
     auth:
       enabled: true
       secretName: artifact-registry-credentials
+    subFilters:
+      - location: '^/repository/cargo-proxy/config\.json$'
+        types:
+          - application/json
+        once: false
+        filters:
+          - string: '"auth-required":true'
+            replacement: '"auth-required":false'
+          - string: 'https://red-hat.repo.sonatype.app'
+            replacement: 'https://artifact-registry-proxy.caching.svc.cluster.local'
     cache:
       allowList:
         # Cache all traffic to nexus repositories

--- a/components/squid/production/kflux-osp-p01/caching-helm-generator.yaml
+++ b/components/squid/production/kflux-osp-p01/caching-helm-generator.yaml
@@ -4,7 +4,7 @@ metadata:
   name: caching-helm
 name: caching-helm
 repo: oci://quay.io/konflux-ci/caching
-version: 0.1.1775+d865e45
+version: 0.1.1889+ca96506
 valuesInline:
   squid:
     enabled: true
@@ -28,6 +28,16 @@ valuesInline:
     auth:
       enabled: true
       secretName: artifact-registry-credentials
+    subFilters:
+      - location: '^/repository/cargo-proxy/config\.json$'
+        types:
+          - application/json
+        once: false
+        filters:
+          - string: '"auth-required":true'
+            replacement: '"auth-required":false'
+          - string: 'https://red-hat.repo.sonatype.app'
+            replacement: 'https://artifact-registry-proxy.caching.svc.cluster.local'
     cache:
       allowList:
         # Cache all traffic to nexus repositories

--- a/components/squid/production/stone-prod-p01/caching-helm-generator.yaml
+++ b/components/squid/production/stone-prod-p01/caching-helm-generator.yaml
@@ -4,7 +4,7 @@ metadata:
   name: caching-helm
 name: caching-helm
 repo: oci://quay.io/konflux-ci/caching
-version: 0.1.1775+d865e45
+version: 0.1.1889+ca96506
 valuesInline:
   squid:
     enabled: true
@@ -28,6 +28,16 @@ valuesInline:
     auth:
       enabled: true
       secretName: artifact-registry-credentials
+    subFilters:
+      - location: '^/repository/cargo-proxy/config\.json$'
+        types:
+          - application/json
+        once: false
+        filters:
+          - string: '"auth-required":true'
+            replacement: '"auth-required":false'
+          - string: 'https://red-hat.repo.sonatype.app'
+            replacement: 'https://artifact-registry-proxy.caching.svc.cluster.local'
     cache:
       allowList:
         # Cache all traffic to nexus repositories


### PR DESCRIPTION
Promote staging-validated nginx `subFilters` for cargo-proxy `config.json` to production ring-1 squid overlays: auth-required rewrite and Nexus URL replacement to cluster proxy. Bump caching-helm to `0.1.1889+ca96506`.

Clusters: kflux-fedora-01, stone-prod-p01, kflux-osp-p01

[KFLUXVNGD-1283](https://redhat.atlassian.net/browse/KFLUXVNGD-1283)

## Validation
- Staging auth-required rewrite: [#13561](https://github.com/redhat-appstudio/infra-deployments/pull/13561) (merged 2026-08-21)
- Staging Nexus URL rewrite: [#13657](https://github.com/redhat-appstudio/infra-deployments/pull/13657) (merged 2026-08-24)
- `subFilters` block matches staging for the three ring-1 overlays in this PR

## Risk Assessment
**Risk Level:** Medium
**Description:** First production rollout of cargo-proxy `config.json` rewrites (auth-required + Nexus URL → cluster proxy) on ring-1. Misconfiguration could break Cargo builds on kflux-fedora-01, stone-prod-p01, kflux-osp-p01.
**Rollback:** Revert this PR to restore chart `0.1.1775+d865e45` and remove `subFilters` on those three overlays.

[KFLUXVNGD-1283]: https://redhat.atlassian.net/browse/KFLUXVNGD-1283?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ