### PR TITLE
(onboarding) Remove staging etcd-defrag apps from AppSRE ArgoCD

### DIFF
--- a/argo-cd-apps/overlays/konflux-public-staging/delete-applications.yaml
+++ b/argo-cd-apps/overlays/konflux-public-staging/delete-applications.yaml
@@ -29,3 +29,9 @@ kind: ApplicationSet
 metadata:
   name: multi-platform-controller
 $patch: delete
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: etcd-defrag
+$patch: delete

--- a/argo-cd-apps/overlays/staging-downstream/delete-applications.yaml
+++ b/argo-cd-apps/overlays/staging-downstream/delete-applications.yaml
@@ -23,3 +23,9 @@ kind: ApplicationSet
 metadata:
   name: multi-platform-controller
 $patch: delete
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: etcd-defrag
+$patch: delete


### PR DESCRIPTION
### Summary of Changes
As part of the Migration/reorganization of the infra-deployments repo components to comply with new component standards, applying [step 3](https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/ring-deployments/directory-structure-migration.md#part-3-old-staging-deletion)  of the [Migration SOP](https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/ring-deployments/directory-structure-migration.md) that consist in deleting the old staging of the component and ApplicationSet from konflux-public-staging and staging-downstream.

## Argo-cd RD link from parts 1 and 2 fo the SOP:
https://argocd-infra-deployments-server-argocd-infra-deployments.apps.rosa.kflux-c-stg-i01.qfla.p3.openshiftapps.com/applications?proj=&sync=&autoSync=&health=&namespace=&cluster=&labels=&annotations=&operation=&search=etcd-defrag-

### Verification
oc kustomize has been performed on the following directories to render config files and the results:

- kustomize build argo-cd-apps/overlays/konflux-public-staging | grep -i etcd-defrag - no output
- kustomize build argo-cd-apps/overlays/staging-downstream | grep -i etcd-defrag - no output
- kustomize build argo-cd-apps/overlays/rd-staging -> sets the "sourceRoot: configs/etcd-defrag-rd":
metadata:
  labels:
    appstudio.redhat.com/deployment-clusters: tenant
  name: etcd-defrag
  namespace: argocd-infra-deployments
spec:
...
            sourceRoot: configs/etcd-defrag-rd

- kustomize build configs/etcd-defrag/production/ -> set the namespace to "konflux-public-production"

metadata:
  name: etcd-defrag
  namespace: konflux-public-production
spec:
...
          values:
            environment: production
            sourceRoot: configs/etcd-defrag


### Risk Level
**Risk Level**: Medium
**Reasoning**: Changes will be performed in staging, in case wpuld be an error only would affect 3 clusters, lightwell-dev, stone-stage-p01 and stone-stg-rh01. As  set "SyncPolicy:
  preserveResourcesOnDeletion: true" added and Argo CD resource finalizers were removed in the projects ([steps 6-11part 3 SOP](https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/ring-deployments/directory-structure-migration.md#part-3-old-staging-deletion)) would help to revert in case something goes wrong
**Rollback Strategy**: Revert this PR + sync in ArgoCD should restore previous ApplicationSet

## Validation
For non-production environments this component is only in Staging, so this PR will be the first step before Production. This has been already done in other components like kueue https://github.com/redhat-appstudio/infra-deployments/pull/13631