### PR TITLE
chore(KFLUXVNGD-1158): federate squid_up from container-image-proxy namespace in staging

### DIFF
--- a/components/monitoring/prometheus/staging/base/federation/endpoints-params.yaml
+++ b/components/monitoring/prometheus/staging/base/federation/endpoints-params.yaml
@@ -116,6 +116,9 @@
     # Namespace: caching
     - '{__name__="squid_up", namespace="caching"}'
 
+    # Namespace: container-image-proxy
+    - '{__name__="squid_up", namespace="container-image-proxy"}'
+
     # Namespace: image-rbac-proxy
     - '{__name__="kube_deployment_spec_replicas", namespace="image-rbac-proxy"}'
     - '{__name__="kube_deployment_status_replicas_available", namespace="image-rbac-proxy"}'


### PR DESCRIPTION
Add squid_up metric federation for the new container-image-proxy namespace, matching the existing pattern for the caching namespace. The container-image-proxy ring-1 rollout deploys squid to a dedicated namespace; without this entry the central Prometheus does not scrape its health metric.

Jira-Url: https://redhat.atlassian.net/browse/KFLUXVNGD-1158
Authored-by: Claude Code (claude-sonnet-4-6)