### PR TITLE
KFLUXINFRA-4493: Add label to exclude c-stg-i01 from deployments

### DIFF
--- a/argo-cd-apps/base/all-clusters/kustomization.yaml
+++ b/argo-cd-apps/base/all-clusters/kustomization.yaml
@@ -6,3 +6,11 @@ resources:
 components:
   - ../../k-components/inject-argocd-namespace
   - ../../k-components/deploy-to-all-clusters
+
+# Marks every ApplicationSet defined here as already having a
+# `clusters.selector` (matchLabels + matchExpressions) via the
+# deploy-to-all-clusters component above. Lets overlay-level patches target
+# "has a selector already" vs "selector-less" ApplicationSets without
+# enumerating names, e.g. to safely extend the selector's matchExpressions.
+commonLabels:
+  appstudio.redhat.com/deployment-clusters: "all"

--- a/argo-cd-apps/base/member/infra-deployments/enterprise-contract/enterprise-contract.yaml
+++ b/argo-cd-apps/base/member/infra-deployments/enterprise-contract/enterprise-contract.yaml
@@ -3,6 +3,13 @@ apiVersion: argoproj.io/v1alpha1
 kind: ApplicationSet
 metadata:
   name: enterprise-contract
+  labels:
+    # Unlike every other ApplicationSet in this repo, this uses a bare
+    # `clusters: {}` generator instead of the merge+clusters+list pattern, so
+    # it has no /spec/generators/0/merge/... path for overlay patches to
+    # target. This label lets such patches exclude (or specifically target)
+    # this ApplicationSet without an unsafe blanket kind/version match.
+    appstudio.redhat.com/direct-cluster-generator: "true"
 spec:
   generators:
     - clusters: {}

--- a/argo-cd-apps/base/member/optional/helm/rekor/rekor.yaml
+++ b/argo-cd-apps/base/member/optional/helm/rekor/rekor.yaml
@@ -3,6 +3,14 @@ apiVersion: argoproj.io/v1alpha1
 kind: ApplicationSet
 metadata:
   name: rekor
+  labels:
+    # Unlike most ApplicationSets in this repo, this uses a bare
+    # `clusters: {}` generator instead of the merge+clusters+list pattern
+    # (same as enterprise-contract), so it has no
+    # /spec/generators/0/merge/... path for overlay patches to target. This
+    # label lets such patches exclude (or specifically target) this
+    # ApplicationSet without an unsafe blanket kind/version match.
+    appstudio.redhat.com/direct-cluster-generator: "true"
 spec:
   generators:
     - clusters: {}

--- a/argo-cd-apps/overlays/staging-downstream/kustomization.yaml
+++ b/argo-cd-apps/overlays/staging-downstream/kustomization.yaml
@@ -19,6 +19,25 @@ patches:
     target:
       kind: ApplicationSet
       version: v1alpha1
+  # Exclude the local common cluster from generated deployment targets. Split
+  # across 3 files/targets (via labelSelector) so we never crash on or
+  # replace an ApplicationSet's existing clusters.selector - see comments in
+  # each patch file for details.
+  - path: remove-local-common-cluster-patches/specific-clusters-patch.yaml
+    target:
+      kind: ApplicationSet
+      version: v1alpha1
+      labelSelector: "!appstudio.redhat.com/direct-cluster-generator,!appstudio.redhat.com/deployment-clusters"
+  - path: remove-local-common-cluster-patches/all-clusters-group-patch.yaml
+    target:
+      kind: ApplicationSet
+      version: v1alpha1
+      labelSelector: "appstudio.redhat.com/deployment-clusters=all"
+  - path: remove-local-common-cluster-patches/direct-generator-patch.yaml
+    target:
+      kind: ApplicationSet
+      version: v1alpha1
+      labelSelector: "appstudio.redhat.com/direct-cluster-generator=true"
   # Exclude operator-managed clusters from Argo generation for services owned
   # by the konflux-operator. Orphan (do not prune) when Applications go away.
   - path: exclude-operator-owned-clusters.yaml

--- a/argo-cd-apps/overlays/staging-downstream/remove-local-common-cluster-patches/all-clusters-group-patch.yaml
+++ b/argo-cd-apps/overlays/staging-downstream/remove-local-common-cluster-patches/all-clusters-group-patch.yaml
@@ -1,0 +1,11 @@
+# Same exclusion as specific-clusters-patch.yaml, but for
+# ApplicationSets that already have a clusters.selector.matchExpressions
+# array (labelSelector: appstudio.redhat.com/deployment-clusters=all, set by
+# argo-cd-apps/base/all-clusters/kustomization.yaml). Appending with `/-`
+# preserves every existing matchExpressions entry instead of replacing them.
+- op: add
+  path: /spec/generators/0/merge/generators/0/clusters/selector/matchExpressions/-
+  value:
+    key: app.kubernetes.io/name
+    operator: NotIn
+    values: [argocd-internal-appsre-default-cluster-config]

--- a/argo-cd-apps/overlays/staging-downstream/remove-local-common-cluster-patches/direct-generator-patch.yaml
+++ b/argo-cd-apps/overlays/staging-downstream/remove-local-common-cluster-patches/direct-generator-patch.yaml
@@ -1,0 +1,16 @@
+# Same exclusion as specific-clusters-patch.yaml, but for
+# ApplicationSets using a bare `clusters: {}` generator instead of the usual
+# merge+clusters+list pattern (labelSelector:
+# appstudio.redhat.com/direct-cluster-generator=true, currently only
+# enterprise-contract). The path has no /merge/generators/0/ prefix.
+#
+# Additive-only
+- op: add
+  path: /spec/generators/0/clusters/selector/matchLabels/argocd.argoproj.io~1secret-type
+  value: cluster
+- op: add
+  path: /spec/generators/0/clusters/selector/matchExpressions
+  value:
+    - key: app.kubernetes.io/name
+      operator: NotIn
+      values: [argocd-internal-appsre-default-cluster-config]

--- a/argo-cd-apps/overlays/staging-downstream/remove-local-common-cluster-patches/specific-clusters-patch.yaml
+++ b/argo-cd-apps/overlays/staging-downstream/remove-local-common-cluster-patches/specific-clusters-patch.yaml
@@ -1,0 +1,17 @@
+# Exclude the local common cluster (the internal staging cluster hosting this
+# ArgoCD instance) from generated deployment targets.
+#
+# This file only targets ApplicationSets that don't yet have a
+# clusters.selector.matchExpressions (see kustomization.yaml's labelSelector);
+# ApplicationSets that already have one (appstudio.redhat.com/deployment-clusters=all)
+# or use a non-merge cluster generator (appstudio.redhat.com/direct-cluster-generator)
+# are handled by the sibling patch files.
+- op: add
+  path: /spec/generators/0/merge/generators/0/clusters/selector/matchLabels/argocd.argoproj.io~1secret-type
+  value: cluster
+- op: add
+  path: /spec/generators/0/merge/generators/0/clusters/selector/matchExpressions
+  value:
+    - key: app.kubernetes.io/name
+      operator: NotIn
+      values: [argocd-internal-appsre-default-cluster-config]


### PR DESCRIPTION
Add a label to the staging-downstream AppSets to exclude the kflux-c-stg-i01 cluster, which is hosting the new internal staging AppSRE Argo CD instance, from application generation.