### PR TITLE
chore: add rbac for componentgroups

### DIFF
--- a/components/authentication/base/rbac/everyone-can-view-crs.yaml
+++ b/components/authentication/base/rbac/everyone-can-view-crs.yaml
@@ -31,6 +31,7 @@ rules:
   - releaseserviceconfigs
   - releasestrategies
   - snapshots
+  - componentgroups
   verbs:
   - get
   - list
@@ -40,6 +41,7 @@ rules:
   resources:
   - components
   - imagerepositories
+  - componentgroups
   verbs:
   - get
   - list

--- a/components/authentication/base/rbac/konflux-admins-cr.yaml
+++ b/components/authentication/base/rbac/konflux-admins-cr.yaml
@@ -39,6 +39,7 @@ rules:
       - spiaccesstokendataupdates
       - spiaccesstokens
       - spifilecontentrequests
+      - componentgroups
     verbs:
       - '*'
   - apiGroups:
@@ -46,6 +47,7 @@ rules:
     resources:
       - components
       - imagerepositories
+      - componentgroups
     verbs:
       - '*'
   # Grant READ-ONLY access (plus delete) to API groups that can create pods

--- a/components/authentication/rings/ring-1/base/base-snapshot/rbac/everyone-can-view-crs.yaml
+++ b/components/authentication/rings/ring-1/base/base-snapshot/rbac/everyone-can-view-crs.yaml
@@ -31,6 +31,7 @@ rules:
   - releaseserviceconfigs
   - releasestrategies
   - snapshots
+  - componentgroups
   verbs:
   - get
   - list
@@ -40,6 +41,7 @@ rules:
   resources:
   - components
   - imagerepositories
+  - componentgroups
   verbs:
   - get
   - list

--- a/components/authentication/rings/ring-1/base/base-snapshot/rbac/konflux-admins-cr.yaml
+++ b/components/authentication/rings/ring-1/base/base-snapshot/rbac/konflux-admins-cr.yaml
@@ -39,6 +39,7 @@ rules:
       - spiaccesstokendataupdates
       - spiaccesstokens
       - spifilecontentrequests
+      - componentgroups
     verbs:
       - '*'
   - apiGroups:
@@ -46,6 +47,7 @@ rules:
     resources:
       - components
       - imagerepositories
+      - componentgroups
     verbs:
       - '*'
   # Grant READ-ONLY access (plus delete) to API groups that can create pods

--- a/components/authentication/rings/ring-2/base/base-snapshot/rbac/everyone-can-view-crs.yaml
+++ b/components/authentication/rings/ring-2/base/base-snapshot/rbac/everyone-can-view-crs.yaml
@@ -31,6 +31,15 @@ rules:
   - releaseserviceconfigs
   - releasestrategies
   - snapshots
+  - componentgroups
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - konflux-ci.dev
+  resources:
+  - componentgroups
   verbs:
   - get
   - list

--- a/components/authentication/rings/ring-2/base/base-snapshot/rbac/konflux-admins-cr.yaml
+++ b/components/authentication/rings/ring-2/base/base-snapshot/rbac/konflux-admins-cr.yaml
@@ -39,6 +39,13 @@ rules:
       - spiaccesstokendataupdates
       - spiaccesstokens
       - spifilecontentrequests
+      - componentgroups
+    verbs:
+      - '*'
+  - apiGroups:
+      - konflux-ci.dev
+    resources:
+      - componentgroups
     verbs:
       - '*'
   # Grant READ-ONLY access (plus delete) to API groups that can create pods

--- a/components/authentication/rings/ring-3/base/base-snapshot/rbac/everyone-can-view-crs.yaml
+++ b/components/authentication/rings/ring-3/base/base-snapshot/rbac/everyone-can-view-crs.yaml
@@ -31,6 +31,15 @@ rules:
   - releaseserviceconfigs
   - releasestrategies
   - snapshots
+  - componentgroups
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - konflux-ci.dev
+  resources:
+  - componentgroups
   verbs:
   - get
   - list

--- a/components/authentication/rings/ring-3/base/base-snapshot/rbac/konflux-admins-cr.yaml
+++ b/components/authentication/rings/ring-3/base/base-snapshot/rbac/konflux-admins-cr.yaml
@@ -39,6 +39,13 @@ rules:
       - spiaccesstokendataupdates
       - spiaccesstokens
       - spifilecontentrequests
+      - componentgroups
+    verbs:
+      - '*'
+  - apiGroups:
+      - konflux-ci.dev
+    resources:
+      - componentgroups
     verbs:
       - '*'
   # Grant READ-ONLY access (plus delete) to API groups that can create pods

--- a/components/authentication/rings/ring-4/base/base-snapshot/rbac/everyone-can-view-crs.yaml
+++ b/components/authentication/rings/ring-4/base/base-snapshot/rbac/everyone-can-view-crs.yaml
@@ -31,6 +31,15 @@ rules:
   - releaseserviceconfigs
   - releasestrategies
   - snapshots
+  - componentgroups
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - konflux-ci.dev
+  resources:
+  - componentgroups
   verbs:
   - get
   - list

--- a/components/authentication/rings/ring-4/base/base-snapshot/rbac/konflux-admins-cr.yaml
+++ b/components/authentication/rings/ring-4/base/base-snapshot/rbac/konflux-admins-cr.yaml
@@ -39,6 +39,13 @@ rules:
       - spiaccesstokendataupdates
       - spiaccesstokens
       - spifilecontentrequests
+      - componentgroups
+    verbs:
+      - '*'
+  - apiGroups:
+      - konflux-ci.dev
+    resources:
+      - componentgroups
     verbs:
       - '*'
   # Grant READ-ONLY access (plus delete) to API groups that can create pods

--- a/components/konflux-rbac/production/base/konflux-admin-user-actions.yaml
+++ b/components/konflux-rbac/production/base/konflux-admin-user-actions.yaml
@@ -21,6 +21,7 @@ rules:
       - applications
       - components
       - imagerepositories
+      - componentgroups
   - verbs:
       - get
       - list
@@ -35,6 +36,7 @@ rules:
     resources:
       - components
       - imagerepositories
+      - componentgroups
   - verbs:
       - get
       - list

--- a/components/konflux-rbac/production/base/konflux-contributor-user-actions.yaml
+++ b/components/konflux-rbac/production/base/konflux-contributor-user-actions.yaml
@@ -16,6 +16,7 @@ rules:
       - applications
       - components
       - imagerepositories
+      - componentgroups
   - verbs:
       - get
       - list
@@ -25,6 +26,7 @@ rules:
     resources:
       - components
       - imagerepositories
+      - componentgroups
   - verbs:
       - get
       - list

--- a/components/konflux-rbac/production/base/konflux-maintainer-user-actions.yaml
+++ b/components/konflux-rbac/production/base/konflux-maintainer-user-actions.yaml
@@ -20,6 +20,7 @@ rules:
       - components
       - imagerepositories
       - snapshots
+      - componentgroups
   - verbs:
       - get
       - list
@@ -32,6 +33,7 @@ rules:
     resources:
       - components
       - imagerepositories
+      - componentgroups
   - verbs:
       - get
       - list

--- a/components/konflux-rbac/production/base/konflux-model-bot-actions.yaml
+++ b/components/konflux-rbac/production/base/konflux-model-bot-actions.yaml
@@ -9,6 +9,18 @@ rules:
   - applications
   - components
   - releaseplans
+  - componentgroups
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+- apiGroups:
+  - konflux-ci.dev
+  resources:
+  - componentgroups
   verbs:
   - get
   - list

--- a/components/konflux-rbac/production/base/konflux-viewer-bot-actions.yaml
+++ b/components/konflux-rbac/production/base/konflux-viewer-bot-actions.yaml
@@ -33,6 +33,15 @@ rules:
   - snapshots
   - releases
   - components
+  - componentgroups
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - konflux-ci.dev
+  resources:
+  - componentgroups
   verbs:
   - get
   - list

--- a/components/konflux-rbac/production/base/konflux-viewer-user-actions.yaml
+++ b/components/konflux-rbac/production/base/konflux-viewer-user-actions.yaml
@@ -16,6 +16,7 @@ rules:
       - applications
       - components
       - imagerepositories
+      - componentgroups
   - verbs:
       - get
       - list
@@ -25,6 +26,7 @@ rules:
     resources:
       - components
       - imagerepositories
+      - componentgroups
   - verbs:
       - get
       - list

--- a/components/konflux-rbac/staging/base/konflux-admin-user-actions.yaml
+++ b/components/konflux-rbac/staging/base/konflux-admin-user-actions.yaml
@@ -21,6 +21,7 @@ rules:
       - applications
       - components
       - imagerepositories
+      - componentgroups
   - verbs:
       - get
       - list
@@ -35,6 +36,7 @@ rules:
     resources:
       - components
       - imagerepositories
+      - componentgroups
   - verbs:
       - get
       - list

--- a/components/konflux-rbac/staging/base/konflux-contributor-user-actions.yaml
+++ b/components/konflux-rbac/staging/base/konflux-contributor-user-actions.yaml
@@ -16,6 +16,7 @@ rules:
       - applications
       - components
       - imagerepositories
+      - componentgroups
   - verbs:
       - get
       - list
@@ -25,6 +26,7 @@ rules:
     resources:
       - components
       - imagerepositories
+      - componentgroups
   - verbs:
       - get
       - list

--- a/components/konflux-rbac/staging/base/konflux-maintainer-user-actions.yaml
+++ b/components/konflux-rbac/staging/base/konflux-maintainer-user-actions.yaml
@@ -20,6 +20,7 @@ rules:
       - components
       - imagerepositories
       - snapshots
+      - componentgroups
   - verbs:
       - get
       - list
@@ -32,6 +33,7 @@ rules:
     resources:
       - components
       - imagerepositories
+      - componentgroups
   - verbs:
       - get
       - list

--- a/components/konflux-rbac/staging/base/konflux-model-bot-actions.yaml
+++ b/components/konflux-rbac/staging/base/konflux-model-bot-actions.yaml
@@ -9,6 +9,18 @@ rules:
   - applications
   - components
   - releaseplans
+  - componentgroups
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+- apiGroups:
+  - konflux-ci.dev
+  resources:
+  - componentgroups
   verbs:
   - get
   - list

--- a/components/konflux-rbac/staging/base/konflux-viewer-bot-actions.yaml
+++ b/components/konflux-rbac/staging/base/konflux-viewer-bot-actions.yaml
@@ -33,6 +33,15 @@ rules:
   - snapshots
   - releases
   - components
+  - componentgroups
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - konflux-ci.dev
+  resources:
+  - componentgroups
   verbs:
   - get
   - list

--- a/components/konflux-rbac/staging/base/konflux-viewer-user-actions.yaml
+++ b/components/konflux-rbac/staging/base/konflux-viewer-user-actions.yaml
@@ -16,6 +16,7 @@ rules:
       - applications
       - components
       - imagerepositories
+      - componentgroups
   - verbs:
       - get
       - list
@@ -25,6 +26,7 @@ rules:
     resources:
       - components
       - imagerepositories
+      - componentgroups
   - verbs:
       - get
       - list


### PR DESCRIPTION
Adds componentgroup permissions to ClusterRoles. ComponentGroup permissions should be the same as Application permissions for all users. ComponentGroups were added under both the current apiGroup, appstudio.redhat.com, and the new apiGroup, konflux-ci.dev. This will prevent regression when the migration occurs in the near future