### PR TITLE
feat(PVO11Y-5420, PVO11Y-5419): Promote richer kanary metrics and RPM probes to production

### DIFF
--- a/components/monitoring/kanary/production/base/pipelines/kanary-otel-pipeline.yaml
+++ b/components/monitoring/kanary/production/base/pipelines/kanary-otel-pipeline.yaml
@@ -54,6 +54,22 @@ spec:
     - name: test-scenario-git-url
       type: string
       default: ""
+    - name: release-policy
+      type: string
+      default: "tmp-onboard-policy"
+    # RPM mirror workaround only. Leave empty for container test types.
+    - name: upstream-repo-url
+      type: string
+      default: ""
+    - name: upstream-repo-branch
+      type: string
+      default: ""
+    - name: fork-repo-host-and-path
+      type: string
+      default: ""
+    - name: fork-repo-username
+      type: string
+      default: "jhutar"
   tasks:
     - name: run-kanary-tests
       timeout: "1h0m0s"
@@ -95,6 +111,16 @@ spec:
           value: $(params.pipeline-image-pull-secrets)
         - name: test-scenario-git-url
           value: $(params.test-scenario-git-url)
+        - name: release-policy
+          value: $(params.release-policy)
+        - name: upstream-repo-url
+          value: $(params.upstream-repo-url)
+        - name: upstream-repo-branch
+          value: $(params.upstream-repo-branch)
+        - name: fork-repo-host-and-path
+          value: $(params.fork-repo-host-and-path)
+        - name: fork-repo-username
+          value: $(params.fork-repo-username)
   finally:
     - name: push-kanary-metrics
       taskRef:
@@ -108,3 +134,7 @@ spec:
           value: $(params.test-type)
         - name: test-outcome
           value: $(tasks.run-kanary-tests.results.test-outcome)
+        - name: failure-cause
+          value: $(tasks.run-kanary-tests.results.failure-cause)
+        - name: failure-phase
+          value: $(tasks.run-kanary-tests.results.failure-phase)

--- a/components/monitoring/kanary/production/base/tasks/push-kanary-metrics.yaml
+++ b/components/monitoring/kanary/production/base/tasks/push-kanary-metrics.yaml
@@ -17,9 +17,17 @@ spec:
       type: string
       default: unknown
       description: "Test outcome from collect-results: passed, failed, or unknown"
+    - name: failure-cause
+      type: string
+      default: ""
+      description: "Raw error_reason_simple from loadtest (may be comma-separated). Empty when test passed or kanary mechanism failed."
+    - name: failure-phase
+      type: string
+      default: ""
+      description: "Loadtest phase where earliest failure occurred (e.g. waitForImageRepositoryReady). Empty when test passed or kanary mechanism failed."
   steps:
     - name: push-metrics
-      image: registry.redhat.io/ubi9/python-312:latest
+      image: quay.io/redhat-user-workloads/konflux-perfscale-tenant/loadtest
       env:
         - name: OTEL_ENDPOINT
           value: $(params.otel-endpoint)
@@ -29,18 +37,14 @@ spec:
           value: $(params.test-type)
         - name: TEST_OUTCOME
           value: $(params.test-outcome)
+        - name: FAILURE_CAUSE
+          value: $(params.failure-cause)
+        - name: FAILURE_PHASE
+          value: $(params.failure-phase)
       script: |
         #!/usr/bin/env python3
         import os
-        import subprocess
         import time
-
-        subprocess.check_call([
-            "pip", "install", "--quiet",
-            "opentelemetry-api",
-            "opentelemetry-sdk",
-            "opentelemetry-exporter-otlp-proto-http",
-        ])
 
         from opentelemetry import metrics
         from opentelemetry.sdk.metrics import MeterProvider
@@ -52,9 +56,20 @@ spec:
         tested_cluster = os.environ["TESTED_CLUSTER"]
         test_type = os.environ["TEST_TYPE"]
         test_outcome = os.environ["TEST_OUTCOME"]
+        failure_cause_raw = os.environ["FAILURE_CAUSE"].strip()
+        failure_phase = os.environ["FAILURE_PHASE"].strip()
+
+        # Take the first value from comma-separated error_reason_simple.
+        # The full string is preserved in the TaskRun result for debugging.
+        if failure_cause_raw:
+            reason = failure_cause_raw.split(",")[0].strip() or "UNKNOWN"
+        else:
+            reason = ""
 
         print(f"Pushing kanary metrics to: {endpoint}")
         print(f"  tested_cluster={tested_cluster}, type={test_type}, test_outcome={test_outcome}")
+        if reason:
+            print(f"  failure_cause={failure_cause_raw}, reason={reason}, phase={failure_phase}")
 
         resource = Resource.create({
             "service.name": "kanary",
@@ -68,7 +83,6 @@ spec:
         meter = metrics.get_meter("kanary")
 
         labels_up = {"tested_cluster": tested_cluster, "type": test_type}
-        labels_error = {"tested_cluster": tested_cluster, "type": test_type, "reason": "infrastructure"}
 
         kanary_up = meter.create_gauge(
             "kanary_up",
@@ -76,7 +90,7 @@ spec:
         )
         kanary_error = meter.create_gauge(
             "kanary_error",
-            description="Binary indicator of an infrastructure error preventing test execution",
+            description="Indicator of a failure preventing a successful kanary test run, labelled by root cause",
         )
         kanary_timestamp = meter.create_gauge(
             "kanary_last_push_timestamp",
@@ -86,15 +100,16 @@ spec:
         if test_outcome == "passed":
             print("Test outcome: passed")
             kanary_up.set(1, labels_up)
-            kanary_error.set(0, labels_error)
+            # kanary_error is not emitted on success — kanary_up=1 is sufficient
         elif test_outcome == "failed":
-            print("Test outcome: failed")
+            phase = failure_phase or "loadtest-pre-measurement"
+            print(f"Test outcome: failed, reason={reason}, phase={phase}")
             kanary_up.set(0, labels_up)
-            kanary_error.set(0, labels_error)
+            kanary_error.set(1, {"tested_cluster": tested_cluster, "type": test_type, "reason": reason, "phase": phase})
         else:
-            print(f"Test outcome: {test_outcome}, reporting infrastructure error")
+            print(f"Test outcome: {test_outcome}, reporting kanary-pipeline-error")
             kanary_up.set(1, labels_up)
-            kanary_error.set(1, labels_error)
+            kanary_error.set(1, {"tested_cluster": tested_cluster, "type": test_type, "reason": "kanary-pipeline-error", "phase": "kanary-pipeline"})
 
         kanary_timestamp.set(time.time(), {"tested_cluster": tested_cluster, "type": test_type})
 

--- a/components/monitoring/kanary/production/base/tasks/run-kanary-tests.yaml
+++ b/components/monitoring/kanary/production/base/tasks/run-kanary-tests.yaml
@@ -51,9 +51,29 @@ spec:
     - name: test-scenario-git-url
       type: string
       default: ""
+    - name: release-policy
+      type: string
+      default: "tmp-onboard-policy"
+    # RPM mirror workaround only. Leave empty for container test types.
+    - name: upstream-repo-url
+      type: string
+      default: ""
+    - name: upstream-repo-branch
+      type: string
+      default: ""
+    - name: fork-repo-host-and-path
+      type: string
+      default: ""
+    - name: fork-repo-username
+      type: string
+      default: "jhutar"
   results:
     - name: test-outcome
       description: "Test outcome: passed, failed, or unknown"
+    - name: failure-cause
+      description: "Error cause from loadtest error_caused_by_simple (comma-separated if multiple). Empty on pass or when collect-results did not run."
+    - name: failure-phase
+      description: "Loadtest phase where the earliest failure occurred (e.g. waitForImageRepositoryReady). Empty on pass or when collect-results did not run."
   volumes:
     - name: artifacts
       emptyDir: {}
@@ -114,6 +134,83 @@ spec:
           fi
         fi
         echo "Pre-cleanup done"
+    - name: mirror-rpm-repo
+      when:
+        - input: "$(params.test-type)"
+          operator: in
+          values: ["rpm"]
+      image: quay.io/redhat-user-workloads/konflux-perfscale-tenant/loadtest
+      volumeMounts:
+        - name: artifacts
+          mountPath: /tmp/artifacts
+      env:
+        - name: UPSTREAM_REPO_URL
+          value: $(params.upstream-repo-url)
+        - name: UPSTREAM_REPO_BRANCH
+          value: $(params.upstream-repo-branch)
+        - name: FORK_REPO_HOST_AND_PATH
+          value: $(params.fork-repo-host-and-path)
+        - name: FORK_REPO_USERNAME
+          value: $(params.fork-repo-username)
+        - name: GITHUB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: kanary-probe-credentials
+              key: github_token
+        - name: GITLAB_BOT_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: kanary-probe-credentials
+              key: gitlab-cee-pipelines-as-code-secret
+      script: |
+        #!/usr/bin/env bash
+        set -eu
+
+        if echo "$FORK_REPO_HOST_AND_PATH" | grep -q "gitlab"; then
+          GIT_TOKEN="$GITLAB_BOT_TOKEN"
+        else
+          GIT_TOKEN="$GITHUB_TOKEN"
+        fi
+
+        FORK_DIR="$(basename "$FORK_REPO_HOST_AND_PATH" .git)"
+
+        # Use GIT_ASKPASS so the token is never embedded in any URL or git config.
+        # GIT_TERMINAL_PROMPT=0 makes git fail immediately instead of hanging on a
+        # terminal prompt if GIT_ASKPASS fails (no terminal in a Tekton container).
+        # See: https://git-scm.com/docs/git#Documentation/git.txt-codeGITASKPASScode
+        askpass_script="$(mktemp)"
+        echo '#!/bin/sh' > "${askpass_script}"
+        echo 'echo "${GIT_TOKEN}"' >> "${askpass_script}"
+        chmod +x "${askpass_script}"
+        export GIT_ASKPASS="${askpass_script}"
+        export GIT_TOKEN
+        export GIT_TERMINAL_PROMPT=0
+
+        onerr() {
+          error_time="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          echo "${error_time},0,\"Mirror-rpm-repo step failed\"" >> /tmp/artifacts/load-test-errors.csv
+          rm -f "${askpass_script}"
+          exit 0
+        }
+        trap 'onerr' ERR
+
+        git clone "https://${FORK_REPO_USERNAME}@${FORK_REPO_HOST_AND_PATH}"
+        cd "${FORK_DIR}"
+        git remote add upstream "${UPSTREAM_REPO_URL}"
+        git fetch upstream "${UPSTREAM_REPO_BRANCH}"
+        git checkout -B "${UPSTREAM_REPO_BRANCH}" upstream/"${UPSTREAM_REPO_BRANCH}"
+
+        sed -i "s/^Name: libecpg$/Name: konflux-probe-libecpg/" libecpg.spec
+        sed -i "s/^Release: [0-9]\+%{?dist}$/Release: $(date --utc +%Y%m%d%H%M%S)%{?dist}/" libecpg.spec
+        git add libecpg.spec
+        git config user.email "loadtest@localhost"
+        git config user.name "Konflux Probes Kanary"
+        git commit -m "test: Alter package name and release so we can push to Brew"
+
+        git push -f origin "${UPSTREAM_REPO_BRANCH}"
+
+        rm -f "${askpass_script}"
+        echo "RPM mirror step completed successfully"
     - name: run-test
       image: quay.io/redhat-user-workloads/konflux-perfscale-tenant/loadtest
       volumeMounts:
@@ -146,7 +243,7 @@ spec:
         - name: PIPELINE_REPO_TEMPLATING_SOURCE_DIR
           value: $(params.pipeline-repo-templating-source-dir)
         - name: RELEASE_POLICY
-          value: "tmp-onboard-policy"
+          value: $(params.release-policy)
         - name: RELEASE_PIPELINE_URL
           value: "https://github.com/konflux-ci/release-service-catalog.git"
         - name: RELEASE_PIPELINE_REVISION
@@ -195,6 +292,8 @@ spec:
         #!/usr/bin/env bash
         set -euo pipefail
         echo -n "unknown" > $(results.test-outcome.path)
+        echo -n "" > $(results.failure-cause.path)
+        echo -n "" > $(results.failure-phase.path)
         if [[ ! -s /opt/users-secret/token ]]; then
           echo "ERROR: /opt/users-secret/token is missing or empty" >&2
           exit 1
@@ -235,4 +334,15 @@ spec:
           echo -n "passed" > $(results.test-outcome.path)
         elif [[ "$exit_code" -eq "$KANARY_FAIL_CODE" ]]; then
           echo -n "failed" > $(results.test-outcome.path)
+        fi
+        # Write the full error_caused_by_simple string as-is (may be comma-separated).
+        # push-kanary-metrics will split and take the first value for the metric label.
+        # Write the phase (loadtest function) where the earliest failure occurred.
+        if [[ -s /tmp/artifacts/results/load-test.json ]]; then
+          jq -r '.results.errors.error_caused_by_simple // ""' \
+            /tmp/artifacts/results/load-test.json > $(results.failure-cause.path)
+          jq -r '.results.measurements.KPI.failed_phase // ""' \
+            /tmp/artifacts/results/load-test.json > $(results.failure-phase.path)
+        else
+          echo "WARN: load-test.json not found or empty, failure-cause and failure-phase will be empty" >&2
         fi

--- a/components/monitoring/kanary/production/kflux-fedora-01/cronjobs/kanary-cronjob-rpm.yaml
+++ b/components/monitoring/kanary/production/kflux-fedora-01/cronjobs/kanary-cronjob-rpm.yaml
@@ -1,0 +1,54 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: kanary-trigger-rpm
+spec:
+  schedule: "10,40 * * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      activeDeadlineSeconds: 3000
+      template:
+        spec:
+          serviceAccountName: kanary-cronjob
+          restartPolicy: Never
+          containers:
+            - name: trigger
+              image: quay.io/openshift-pipeline/openshift-pipelines-cli-tkn:1.15
+              securityContext:
+                readOnlyRootFilesystem: true
+                runAsNonRoot: true
+              resources:
+                requests:
+                  cpu: 100m
+                  memory: 10Mi
+                limits:
+                  cpu: 100m
+                  memory: 100Mi
+              command:
+                - /bin/bash
+                - -c
+                - |
+                  tkn pipeline start kanary-otel-poc --use-param-defaults \
+                    --param tested-cluster=kflux-fedora-01 \
+                    --param test-type=rpm \
+                    --param component-repo=https://github.com/jhutar/libecpg-srcfedora-fork \
+                    --param component-repo-revision=main \
+                    --param user-prefix=fedora01rm \
+                    --param quay-repo=konflux-fedora \
+                    --param pipeline-repo-templating-source=https://github.com/rhtap-perf-test/konflux-probe-test-templates \
+                    --param pipeline-repo-templating-source-dir=kflux-fedora-01-RPM/ \
+                    --param pipeline-image-pull-secrets="imagerepository-for-toolings-gather-results-container-image-pull imagerepository-for-toolings-get-rpm-sources-container-image-pull imagerepository-for-toolings-mock-rhel-container-image-pull imagerepository-for-toolings-rpmbuild-pipeline-image-pull imagerepository-for-toolings-syft-container-image-pull" \
+                    --param test-scenario-git-url="" \
+                    --param release-policy="" \
+                    --param oci-storage=quay.io/rhtap-perf-test/perf-release-service-trusted-artifacts \
+                    --param release-pipeline-service-account=managed-konflux-perfscale-sa \
+                    --param fork-target="" \
+                    --param gitlab-api-url="" \
+                    --param upstream-repo-url=https://src.fedoraproject.org/rpms/libecpg.git \
+                    --param upstream-repo-branch=main \
+                    --param fork-repo-host-and-path=github.com/jhutar/libecpg-srcfedora-fork.git \
+                    --param member-cluster=https://api.kflux-fedora-01.84db.p1.openshiftapps.com:6443 \
+                    --prefix-name kanary-kflux-fedora-01-rpm-

--- a/components/monitoring/kanary/production/kflux-fedora-01/cronjobs/kustomization.yaml
+++ b/components/monitoring/kanary/production/kflux-fedora-01/cronjobs/kustomization.yaml
@@ -3,3 +3,4 @@ kind: Kustomization
 resources:
   - kanary-cronjob-single-arch.yaml
   - kanary-cronjob-multi-arch.yaml
+  - kanary-cronjob-rpm.yaml

--- a/components/monitoring/kanary/production/kflux-rhel-p01/cronjobs/kanary-cronjob-rpm.yaml
+++ b/components/monitoring/kanary/production/kflux-rhel-p01/cronjobs/kanary-cronjob-rpm.yaml
@@ -1,0 +1,54 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: kanary-trigger-rpm
+spec:
+  schedule: "10,40 * * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      activeDeadlineSeconds: 3000
+      template:
+        spec:
+          serviceAccountName: kanary-cronjob
+          restartPolicy: Never
+          containers:
+            - name: trigger
+              image: quay.io/openshift-pipeline/openshift-pipelines-cli-tkn:1.15
+              securityContext:
+                readOnlyRootFilesystem: true
+                runAsNonRoot: true
+              resources:
+                requests:
+                  cpu: 100m
+                  memory: 10Mi
+                limits:
+                  cpu: 100m
+                  memory: 100Mi
+              command:
+                - /bin/bash
+                - -c
+                - |
+                  tkn pipeline start kanary-otel-poc --use-param-defaults \
+                    --param tested-cluster=kflux-rhel-p01 \
+                    --param test-type=rpm \
+                    --param component-repo=https://gitlab.cee.redhat.com/jhutar/libecpg-gitlab-fork \
+                    --param component-repo-revision=c10s \
+                    --param user-prefix=rhelp01rm \
+                    --param quay-repo=redhat-user-workloads \
+                    --param pipeline-repo-templating-source=https://github.com/rhtap-perf-test/konflux-probe-test-templates \
+                    --param pipeline-repo-templating-source-dir=kflux-rhel-p01-RPM/ \
+                    --param pipeline-image-pull-secrets="imagerepository-for-toolings-gather-results-container-image-pull imagerepository-for-toolings-get-rpm-sources-container-image-pull imagerepository-for-toolings-mock-rhel-container-image-pull imagerepository-for-toolings-rpmbuild-pipeline-image-pull imagerepository-for-toolings-syft-container-image-pull" \
+                    --param test-scenario-git-url="" \
+                    --param release-policy="" \
+                    --param oci-storage=quay.io/rhtap-perf-test/perf-release-service-trusted-artifacts \
+                    --param release-pipeline-service-account=managed-konflux-perfscale-sa \
+                    --param fork-target=jhutar \
+                    --param gitlab-api-url=https://gitlab.cee.redhat.com/api/v4 \
+                    --param upstream-repo-url=https://gitlab.com/redhat/centos-stream/rpms/libecpg.git \
+                    --param upstream-repo-branch=c10s \
+                    --param fork-repo-host-and-path=gitlab.cee.redhat.com/jhutar/libecpg-gitlab-fork.git \
+                    --param member-cluster=https://api.kflux-rhel-p01.fc38.p1.openshiftapps.com:6443 \
+                    --prefix-name kanary-kflux-rhel-p01-rpm-

--- a/components/monitoring/kanary/production/kflux-rhel-p01/cronjobs/kustomization.yaml
+++ b/components/monitoring/kanary/production/kflux-rhel-p01/cronjobs/kustomization.yaml
@@ -3,3 +3,4 @@ kind: Kustomization
 resources:
   - kanary-cronjob-single-arch.yaml
   - kanary-cronjob-multi-arch.yaml
+  - kanary-cronjob-rpm.yaml

--- a/components/monitoring/kanary/production/stone-prd-rh01/cronjobs/kanary-cronjob-rpm.yaml
+++ b/components/monitoring/kanary/production/stone-prd-rh01/cronjobs/kanary-cronjob-rpm.yaml
@@ -1,0 +1,54 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: kanary-trigger-rpm
+spec:
+  schedule: "10,40 * * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      activeDeadlineSeconds: 3000
+      template:
+        spec:
+          serviceAccountName: kanary-cronjob
+          restartPolicy: Never
+          containers:
+            - name: trigger
+              image: quay.io/openshift-pipeline/openshift-pipelines-cli-tkn:1.15
+              securityContext:
+                readOnlyRootFilesystem: true
+                runAsNonRoot: true
+              resources:
+                requests:
+                  cpu: 100m
+                  memory: 10Mi
+                limits:
+                  cpu: 100m
+                  memory: 100Mi
+              command:
+                - /bin/bash
+                - -c
+                - |
+                  tkn pipeline start kanary-otel-poc --use-param-defaults \
+                    --param tested-cluster=stone-prd-rh01 \
+                    --param test-type=rpm \
+                    --param component-repo=https://github.com/jhutar/libecpg-srcfedora-fork \
+                    --param component-repo-revision=main \
+                    --param user-prefix=prdrh01rm \
+                    --param quay-repo=redhat-user-workloads \
+                    --param pipeline-repo-templating-source=https://github.com/rhtap-perf-test/konflux-probe-test-templates \
+                    --param pipeline-repo-templating-source-dir=stone-prd-rh01-RPM/ \
+                    --param pipeline-image-pull-secrets="imagerepository-for-toolings-gather-results-container-image-pull imagerepository-for-toolings-get-rpm-sources-container-image-pull imagerepository-for-toolings-mock-rhel-container-image-pull imagerepository-for-toolings-rpmbuild-pipeline-image-pull imagerepository-for-toolings-syft-container-image-pull" \
+                    --param test-scenario-git-url="" \
+                    --param release-policy="" \
+                    --param oci-storage=quay.io/rhtap-perf-test/perf-release-service-trusted-artifacts \
+                    --param release-pipeline-service-account=managed-konflux-perfscale-sa \
+                    --param fork-target="" \
+                    --param gitlab-api-url="" \
+                    --param upstream-repo-url=https://src.fedoraproject.org/rpms/libecpg.git \
+                    --param upstream-repo-branch=main \
+                    --param fork-repo-host-and-path=github.com/jhutar/libecpg-srcfedora-fork.git \
+                    --param member-cluster=https://api.stone-prd-rh01.pg1f.p1.openshiftapps.com:6443 \
+                    --prefix-name kanary-stone-prd-rh01-rpm-

--- a/components/monitoring/kanary/production/stone-prd-rh01/cronjobs/kustomization.yaml
+++ b/components/monitoring/kanary/production/stone-prd-rh01/cronjobs/kustomization.yaml
@@ -3,3 +3,4 @@ kind: Kustomization
 resources:
   - kanary-cronjob-single-arch.yaml
   - kanary-cronjob-multi-arch.yaml
+  - kanary-cronjob-rpm.yaml

--- a/components/monitoring/kanary/production/stone-prod-p02/cronjobs/kanary-cronjob-rpm.yaml
+++ b/components/monitoring/kanary/production/stone-prod-p02/cronjobs/kanary-cronjob-rpm.yaml
@@ -1,0 +1,54 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: kanary-trigger-rpm
+spec:
+  schedule: "10,40 * * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      activeDeadlineSeconds: 3000
+      template:
+        spec:
+          serviceAccountName: kanary-cronjob
+          restartPolicy: Never
+          containers:
+            - name: trigger
+              image: quay.io/openshift-pipeline/openshift-pipelines-cli-tkn:1.15
+              securityContext:
+                readOnlyRootFilesystem: true
+                runAsNonRoot: true
+              resources:
+                requests:
+                  cpu: 100m
+                  memory: 10Mi
+                limits:
+                  cpu: 100m
+                  memory: 100Mi
+              command:
+                - /bin/bash
+                - -c
+                - |
+                  tkn pipeline start kanary-otel-poc --use-param-defaults \
+                    --param tested-cluster=stone-prod-p02 \
+                    --param test-type=rpm \
+                    --param component-repo=https://gitlab.cee.redhat.com/jhutar/libecpg-gitlab-fork \
+                    --param component-repo-revision=c10s \
+                    --param user-prefix=prodp02rm \
+                    --param quay-repo=redhat-user-workloads \
+                    --param pipeline-repo-templating-source=https://github.com/rhtap-perf-test/konflux-probe-test-templates \
+                    --param pipeline-repo-templating-source-dir=stone-prod-p02-RPM/ \
+                    --param pipeline-image-pull-secrets="imagerepository-for-toolings-gather-results-container-image-pull imagerepository-for-toolings-get-rpm-sources-container-image-pull imagerepository-for-toolings-mock-rhel-container-image-pull imagerepository-for-toolings-rpmbuild-pipeline-image-pull imagerepository-for-toolings-syft-container-image-pull" \
+                    --param test-scenario-git-url="" \
+                    --param release-policy="" \
+                    --param oci-storage=quay.io/rhtap-perf-test/perf-release-service-trusted-artifacts \
+                    --param release-pipeline-service-account=managed-konflux-perfscale-sa \
+                    --param fork-target=jhutar \
+                    --param gitlab-api-url=https://gitlab.cee.redhat.com/api/v4 \
+                    --param upstream-repo-url=https://gitlab.com/redhat/centos-stream/rpms/libecpg.git \
+                    --param upstream-repo-branch=c10s \
+                    --param fork-repo-host-and-path=gitlab.cee.redhat.com/jhutar/libecpg-gitlab-fork.git \
+                    --param member-cluster=https://api.stone-prod-p02.hjvn.p1.openshiftapps.com:6443 \
+                    --prefix-name kanary-stone-prod-p02-rpm-

--- a/components/monitoring/kanary/production/stone-prod-p02/cronjobs/kustomization.yaml
+++ b/components/monitoring/kanary/production/stone-prod-p02/cronjobs/kustomization.yaml
@@ -3,3 +3,4 @@ kind: Kustomization
 resources:
   - kanary-cronjob-single-arch.yaml
   - kanary-cronjob-multi-arch.yaml
+  - kanary-cronjob-rpm.yaml


### PR DESCRIPTION
## What

Promotes two kanary V1 improvements from staging to production in two commits.

[PVO11Y-5420](https://redhat.atlassian.net/browse/PVO11Y-5420) | [PVO11Y-5419](https://redhat.atlassian.net/browse/PVO11Y-5419)

## Commit 1 — Promote richer kanary error metrics (PVO11Y-5420)

Copies staging base to production base (byte-for-byte identical):

**`run-kanary-tests`:**
- Adds `failure-cause` and `failure-phase` Tekton results populated from `load-test.json`
- Adds `mirror-rpm-repo` step for RPM test type
- Adds `release-policy`, `upstream-repo-url`, `upstream-repo-branch`, `fork-repo-host-and-path`, `fork-repo-username` params

**`push-kanary-metrics`:**
- Switches from `registry.redhat.io/ubi9/python-312:latest` to the loadtest image (otel SDK baked in)
- Emits `kanary_error{reason, phase}` instead of `kanary_error{reason="infrastructure"}`
- `kanary_error` only emitted on failure (not on success)
- `reason="kanary-pipeline-error", phase="kanary-pipeline"` when kanary mechanism itself fails

**`kanary-otel-pipeline`:**
- Passes new RPM and failure-cause/phase params through to the task

## Commit 2 — Add RPM cronjobs to production clusters (PVO11Y-5419)

Adds `kanary-cronjob-rpm.yaml` to 4 production clusters that already run RPM probes in Jenkins, using matching parameters:

| Cluster | Workaround | user-prefix | template-dir |
|---|---|---|---|
| kflux-rhel-p01 | 1 (gitlab.cee/centos-stream/c10s) | rhelp01rm | kflux-rhel-p01-RPM |
| kflux-fedora-01 | 2 (github/src.fedora/main) | fedora01rm | kflux-fedora-01-RPM |
| stone-prd-rh01 | 2 (github/src.fedora/main) | prdrh01rm | stone-prd-rh01-RPM |
| stone-prod-p02 | 1 (gitlab.cee/centos-stream/c10s) | prodp02rm | stone-prod-p02-RPM |

Schedule: `10,40 * * * *` (10-min spaced with single/multi-arch).
OCI storage: `quay.io/rhtap-perf-test/perf-release-service-trusted-artifacts` (production path, no `-stage` suffix).
Template directories already exist in [rhtap-perf-test/konflux-probe-test-templates](https://github.com/rhtap-perf-test/konflux-probe-test-templates).

## Validation

- `kustomize build` passes for all affected production overlays
- Staged and validated on stone-stg-rh01 and stone-stage-p01 before promotion

[PVO11Y-5420]: https://redhat.atlassian.net/browse/PVO11Y-5420?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PVO11Y-5419]: https://redhat.atlassian.net/browse/PVO11Y-5419?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ