### PR TITLE
Add lightwell-dev cluster directory for ring-1 proxy components

### DIFF
--- a/components/artifact-registry-proxy/rings/ring-1/lightwell-dev/kustomization.yaml
+++ b/components/artifact-registry-proxy/rings/ring-1/lightwell-dev/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../base

--- a/components/container-image-proxy/rings/ring-1/lightwell-dev/kustomization.yaml
+++ b/components/container-image-proxy/rings/ring-1/lightwell-dev/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../base


### PR DESCRIPTION
## What

Add missing `lightwell-dev` cluster directories for ring-1 in:
- `components/artifact-registry-proxy/rings/ring-1/lightwell-dev/`
- `components/container-image-proxy/rings/ring-1/lightwell-dev/`

Clusters affected: lightwell-dev (staging)

## Why

The `deploy-to-staging-tenant-clusters` k-component includes `lightwell-dev` in the ring-1 cluster list, causing the Ring Deployment ArgoCD to generate Applications targeting these paths. Without the directories, ArgoCD reports:

```
Failed to load target state: failed to generate manifest for source 1 of 1:
rpc error: code = Unknown desc = Manifest generation error (cached):
components/<proxy>/rings/ring-1/lightwell-dev: app path does not exist
```

## Validation

- `kustomize build --enable-helm` passes for both new overlays
- Both reference `../base` matching the existing pattern from `stone-stage-p01` and `stone-stg-rh01`


Made with [Cursor](https://cursor.com)