### PR TITLE
fixup(PVO11Y-5384): move PaC resource limits to pipelinesAsCode.options

### DIFF
--- a/components/pipeline-service/staging/base/main-pipeline-service-configuration.yaml
+++ b/components/pipeline-service/staging/base/main-pipeline-service-configuration.yaml
@@ -1798,45 +1798,6 @@ spec:
                       requests:
                         cpu: 400m
                         memory: 1Gi
-        pipelines-as-code-controller:
-          spec:
-            template:
-              spec:
-                containers:
-                  - name: pac-controller
-                    resources:
-                      limits:
-                        cpu: 500m
-                        memory: 2560Mi
-                      requests:
-                        cpu: 500m
-                        memory: 2560Mi
-        pipelines-as-code-watcher:
-          spec:
-            template:
-              spec:
-                containers:
-                  - name: pac-watcher
-                    resources:
-                      limits:
-                        cpu: 250m
-                        memory: 1Gi
-                      requests:
-                        cpu: 250m
-                        memory: 1Gi
-        pipelines-as-code-webhook:
-          spec:
-            template:
-              spec:
-                containers:
-                  - name: pac-webhook
-                    resources:
-                      limits:
-                        cpu: 400m
-                        memory: 100Mi
-                      requests:
-                        cpu: 400m
-                        memory: 100Mi
         pipelines-console-plugin:
           spec:
             template:
@@ -2016,6 +1977,13 @@ spec:
                       - name: OTEL_TRACES_SAMPLER
                         value: "parentbased_always_on"
                       name: pac-controller
+                      resources:
+                        limits:
+                          cpu: 500m
+                          memory: 2560Mi
+                        requests:
+                          cpu: 500m
+                          memory: 2560Mi
             pipelines-as-code-watcher:
               spec:
                 replicas: 2
@@ -2028,9 +1996,27 @@ spec:
                       - name: OTEL_TRACES_SAMPLER
                         value: "parentbased_always_on"
                       name: pac-watcher
+                      resources:
+                        limits:
+                          cpu: 250m
+                          memory: 1Gi
+                        requests:
+                          cpu: 250m
+                          memory: 1Gi
             pipelines-as-code-webhook:
               spec:
                 replicas: 2
+                template:
+                  spec:
+                    containers:
+                    - name: pac-webhook
+                      resources:
+                        limits:
+                          cpu: 400m
+                          memory: 256Mi
+                        requests:
+                          cpu: 400m
+                          memory: 256Mi
         settings:
           application-name: Konflux Staging
           custom-console-name: Konflux Staging

--- a/components/pipeline-service/staging/lightwell-dev/deploy.yaml
+++ b/components/pipeline-service/staging/lightwell-dev/deploy.yaml
@@ -720,45 +720,6 @@ spec:
           data:
             fetch-timeout: 2m
       deployments:
-        pipelines-as-code-controller:
-          spec:
-            template:
-              spec:
-                containers:
-                - name: pac-controller
-                  resources:
-                    limits:
-                      cpu: 500m
-                      memory: 2560Mi
-                    requests:
-                      cpu: 500m
-                      memory: 2560Mi
-        pipelines-as-code-watcher:
-          spec:
-            template:
-              spec:
-                containers:
-                - name: pac-watcher
-                  resources:
-                    limits:
-                      cpu: 250m
-                      memory: 1Gi
-                    requests:
-                      cpu: 250m
-                      memory: 1Gi
-        pipelines-as-code-webhook:
-          spec:
-            template:
-              spec:
-                containers:
-                - name: pac-webhook
-                  resources:
-                    limits:
-                      cpu: 400m
-                      memory: 100Mi
-                    requests:
-                      cpu: 400m
-                      memory: 100Mi
         pipelines-console-plugin:
           spec:
             template:
@@ -965,6 +926,13 @@ spec:
                       - name: OTEL_TRACES_SAMPLER
                         value: parentbased_always_on
                       name: pac-controller
+                      resources:
+                        limits:
+                          cpu: 500m
+                          memory: 2560Mi
+                        requests:
+                          cpu: 500m
+                          memory: 2560Mi
             pipelines-as-code-watcher:
               spec:
                 replicas: 2
@@ -977,9 +945,27 @@ spec:
                       - name: OTEL_TRACES_SAMPLER
                         value: parentbased_always_on
                       name: pac-watcher
+                      resources:
+                        limits:
+                          cpu: 250m
+                          memory: 1Gi
+                        requests:
+                          cpu: 250m
+                          memory: 1Gi
             pipelines-as-code-webhook:
               spec:
                 replicas: 2
+                template:
+                  spec:
+                    containers:
+                    - name: pac-webhook
+                      resources:
+                        limits:
+                          cpu: 400m
+                          memory: 256Mi
+                        requests:
+                          cpu: 400m
+                          memory: 256Mi
         settings:
           application-name: Konflux Staging Internal
           custom-console-name: Konflux Staging Internal

--- a/components/pipeline-service/staging/stone-stage-p01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stage-p01/deploy.yaml
@@ -2358,45 +2358,6 @@ spec:
           data:
             fetch-timeout: 2m
       deployments:
-        pipelines-as-code-controller:
-          spec:
-            template:
-              spec:
-                containers:
-                - name: pac-controller
-                  resources:
-                    limits:
-                      cpu: 500m
-                      memory: 2560Mi
-                    requests:
-                      cpu: 500m
-                      memory: 2560Mi
-        pipelines-as-code-watcher:
-          spec:
-            template:
-              spec:
-                containers:
-                - name: pac-watcher
-                  resources:
-                    limits:
-                      cpu: 250m
-                      memory: 1Gi
-                    requests:
-                      cpu: 250m
-                      memory: 1Gi
-        pipelines-as-code-webhook:
-          spec:
-            template:
-              spec:
-                containers:
-                - name: pac-webhook
-                  resources:
-                    limits:
-                      cpu: 400m
-                      memory: 100Mi
-                    requests:
-                      cpu: 400m
-                      memory: 100Mi
         pipelines-console-plugin:
           spec:
             template:
@@ -2603,6 +2564,13 @@ spec:
                       - name: OTEL_TRACES_SAMPLER
                         value: parentbased_always_on
                       name: pac-controller
+                      resources:
+                        limits:
+                          cpu: 500m
+                          memory: 2560Mi
+                        requests:
+                          cpu: 500m
+                          memory: 2560Mi
             pipelines-as-code-watcher:
               spec:
                 replicas: 2
@@ -2615,9 +2583,27 @@ spec:
                       - name: OTEL_TRACES_SAMPLER
                         value: parentbased_always_on
                       name: pac-watcher
+                      resources:
+                        limits:
+                          cpu: 250m
+                          memory: 1Gi
+                        requests:
+                          cpu: 250m
+                          memory: 1Gi
             pipelines-as-code-webhook:
               spec:
                 replicas: 2
+                template:
+                  spec:
+                    containers:
+                    - name: pac-webhook
+                      resources:
+                        limits:
+                          cpu: 400m
+                          memory: 256Mi
+                        requests:
+                          cpu: 400m
+                          memory: 256Mi
         settings:
           application-name: Konflux Staging Internal
           custom-console-name: Konflux Staging Internal

--- a/components/pipeline-service/staging/stone-stg-rh01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stg-rh01/deploy.yaml
@@ -2358,45 +2358,6 @@ spec:
           data:
             fetch-timeout: 2m
       deployments:
-        pipelines-as-code-controller:
-          spec:
-            template:
-              spec:
-                containers:
-                - name: pac-controller
-                  resources:
-                    limits:
-                      cpu: 500m
-                      memory: 2560Mi
-                    requests:
-                      cpu: 500m
-                      memory: 2560Mi
-        pipelines-as-code-watcher:
-          spec:
-            template:
-              spec:
-                containers:
-                - name: pac-watcher
-                  resources:
-                    limits:
-                      cpu: 250m
-                      memory: 1Gi
-                    requests:
-                      cpu: 250m
-                      memory: 1Gi
-        pipelines-as-code-webhook:
-          spec:
-            template:
-              spec:
-                containers:
-                - name: pac-webhook
-                  resources:
-                    limits:
-                      cpu: 400m
-                      memory: 100Mi
-                    requests:
-                      cpu: 400m
-                      memory: 100Mi
         pipelines-console-plugin:
           spec:
             template:
@@ -2615,6 +2576,13 @@ spec:
                       - name: OTEL_TRACES_SAMPLER
                         value: parentbased_always_on
                       name: pac-controller
+                      resources:
+                        limits:
+                          cpu: 500m
+                          memory: 2560Mi
+                        requests:
+                          cpu: 500m
+                          memory: 2560Mi
             pipelines-as-code-watcher:
               spec:
                 replicas: 2
@@ -2627,9 +2595,27 @@ spec:
                       - name: OTEL_TRACES_SAMPLER
                         value: parentbased_always_on
                       name: pac-watcher
+                      resources:
+                        limits:
+                          cpu: 250m
+                          memory: 1Gi
+                        requests:
+                          cpu: 250m
+                          memory: 1Gi
             pipelines-as-code-webhook:
               spec:
                 replicas: 2
+                template:
+                  spec:
+                    containers:
+                    - name: pac-webhook
+                      resources:
+                        limits:
+                          cpu: 400m
+                          memory: 256Mi
+                        requests:
+                          cpu: 400m
+                          memory: 256Mi
         settings:
           application-name: Konflux Staging
           custom-console-name: Konflux Staging


### PR DESCRIPTION
## What

Add resource limits for pac-controller, pac-watcher, and pac-webhook
to pipelinesAsCode.options.deployments where the operator applies them.
Remove the identical entries from pipeline.options.deployments where
they had no effect.

Clusters affected: all staging

[PVO11Y-5384](https://issues.redhat.com/browse/PVO11Y-5384)

## Why

PaC deployments are managed under pipelinesAsCode.options, not
pipeline.options. The resource limits from #7262 were in the wrong
section and silently dropped by the operator.

## Validation

- kustomize build passes for all staging overlays

[PVO11Y-5384]: https://redhat.atlassian.net/browse/PVO11Y-5384?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ