### PR TITLE
KONFLUX-14937: add OWNERS file for vector-tekton-logs-collector

### DIFF
--- a/components/vector-tekton-logs-collector/OWNERS
+++ b/components/vector-tekton-logs-collector/OWNERS
@@ -1,0 +1,10 @@
+# See the OWNERS docs: https://go.k8s.io/owners
+
+approvers:
+  - enarha
+  - aThorp96
+
+reviewers:
+  - enarha
+  - aThorp96
+  - mathur07


### PR DESCRIPTION
## What

- Add OWNERS file for `components/vector-tekton-logs-collector/`

[KONFLUX-14937](https://redhat.atlassian.net/browse/KONFLUX-14937)

## Why

The directory was missing an OWNERS file, requiring root-level approval for PRs. This adds the pipeline-service team as approvers/reviewers to streamline future reviews.

## Validation

- File follows the same format as other component OWNERS files

[KONFLUX-14937]: https://redhat.atlassian.net/browse/KONFLUX-14937?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ