### PR TITLE
KONFLUX-14937: add infernus01 to vector-tekton-logs-collector OWNERS

### DIFF
--- a/components/vector-tekton-logs-collector/OWNERS
+++ b/components/vector-tekton-logs-collector/OWNERS
@@ -8,3 +8,4 @@ reviewers:
   - enarha
   - aThorp96
   - mathur07
+  - infernus01


### PR DESCRIPTION
## What
- Add infernus01 to reviewers in `components/vector-tekton-logs-collector/OWNERS`
[KONFLUX-14937](https://redhat.atlassian.net/browse/KONFLUX-14937)
## Why
Requested in #13722 review — adding team member as reviewer.

[KONFLUX-14937]: https://redhat.atlassian.net/browse/KONFLUX-14937?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ