### PR TITLE
Disable auto-sync for production-downstream AppSets

### DIFF
--- a/argo-cd-apps/overlays/production-downstream/disable-auto-sync.yaml
+++ b/argo-cd-apps/overlays/production-downstream/disable-auto-sync.yaml
@@ -1,0 +1,15 @@
+# Strategic-merge patch (not JSON6902): setting a field to `null` removes it
+# where present and is a safe no-op on ApplicationSets (e.g. etcd-defrag) that
+# never had `syncPolicy.automated` set, unlike a JSON6902 `remove`, which
+# errors on a missing path. metadata.name below is irrelevant since the
+# untargeted `target:` selector in kustomization.yaml (kind/version only)
+# applies this patch to every ApplicationSet.
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: unused
+spec:
+  template:
+    spec:
+      syncPolicy:
+        automated: null

--- a/argo-cd-apps/overlays/production-downstream/kustomization.yaml
+++ b/argo-cd-apps/overlays/production-downstream/kustomization.yaml
@@ -14,6 +14,10 @@ patchesStrategicMerge:
   - delete-applications.yaml
 namespace: argocd
 patches:
+  - path: disable-auto-sync.yaml
+    target:
+      kind: ApplicationSet
+      version: v1alpha1
   - path: production-downstream-overlay-patch.yaml
     target:
       kind: ApplicationSet


### PR DESCRIPTION
This disables auto-sync for the ApplicationSets managed by the AppSRE internal production  ArgoCD instance so we can begin the process of migrating to the new common cluster-hosted ArgoCD instance.

[KFLUXINFRA-4504](https://redhat.atlassian.net/browse/KFLUXINFRA-4504)

## Risk Assessment
**Risk Level:** Low
**Description:** only disable auto sync, we rehearsed the procedure on staging first
**Rollback:** Revert PR

[KFLUXINFRA-4504]: https://redhat.atlassian.net/browse/KFLUXINFRA-4504?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ