### PR TITLE
(onboarding) Migrate staging crossplane-config AppSet to ring deployments ArgoCD

### DIFF
--- a/argo-cd-apps/overlays/development/kustomization.yaml
+++ b/argo-cd-apps/overlays/development/kustomization.yaml
@@ -120,6 +120,16 @@ patches:
       kind: ApplicationSet
       version: v1alpha1
       name: crossplane-config
+  - path: delete-preserve-resources-flag-patch.yaml
+    target:
+      kind: ApplicationSet
+      version: v1alpha1
+      name: crossplane-config
+  - path: dev-application-auto-sync-patch.yaml
+    target:
+      kind: ApplicationSet
+      version: v1alpha1
+      name: crossplane-config
   - path: development-overlay-patch.yaml
     target:
       kind: ApplicationSet

--- a/argo-cd-apps/overlays/rd-dev/crossplane-config/crossplane-config-appset.yaml
+++ b/argo-cd-apps/overlays/rd-dev/crossplane-config/crossplane-config-appset.yaml
@@ -1,7 +1,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: ApplicationSet
 metadata:
-  name: crossplane-config
+  name: crossplane-config-rd
 spec:
   generators:
     - merge:
@@ -9,31 +9,35 @@ spec:
           - nameNormalized
         generators:
           - clusters:
+              selector:
+                matchLabels:
+                  appstudio.redhat.com/eaas-cluster: "true"
               values:
-                sourceRoot: components/crossplane-config
-                environment: staging
-                clusterDir: ""
+                sourceRoot: components/crossplane-config-rd
+                ring: "ring-0"
+                clusterDir: base
           - list:
               elements: []
+
   template:
     metadata:
       name: crossplane-config-{{nameNormalized}}
     spec:
       project: default
       source:
-        path: "{{values.sourceRoot}}/{{values.environment}}/{{values.clusterDir}}"
+        path: '{{values.sourceRoot}}/rings/{{values.ring}}/{{values.clusterDir}}'
         repoURL: https://github.com/redhat-appstudio/infra-deployments.git
         targetRevision: main
       destination:
         namespace: crossplane-config
-        server: "{{server}}"
+        server: '{{server}}'
       syncPolicy:
-        preserveResourcesOnDeletion: true
+        automated:
+          prune: true
+          selfHeal: true
         syncOptions:
           - CreateNamespace=true
         retry:
-          limit: -1
+          limit: 50
           backoff:
-            duration: 10s
-            factor: 2
-            maxDuration: 3m
+            duration: 15s

--- a/argo-cd-apps/overlays/rd-dev/crossplane-config/kustomization.yaml
+++ b/argo-cd-apps/overlays/rd-dev/crossplane-config/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - crossplane-config-appset.yaml

--- a/argo-cd-apps/overlays/rd-dev/delete-legacy-konflux-member-appsets.yaml
+++ b/argo-cd-apps/overlays/rd-dev/delete-legacy-konflux-member-appsets.yaml
@@ -78,3 +78,9 @@ kind: ApplicationSet
 metadata:
   name: smee-client
 $patch: delete
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: crossplane-config
+$patch: delete

--- a/argo-cd-apps/overlays/rd-dev/kustomization.yaml
+++ b/argo-cd-apps/overlays/rd-dev/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
   - ../development
   - artifact-registry-proxy
   - container-image-proxy
+  - crossplane-config
   - etcd-shield
   - konflux-operator
   - kyverno

--- a/argo-cd-apps/overlays/rd-staging/crossplane-config/crossplane-config-appset.yaml
+++ b/argo-cd-apps/overlays/rd-staging/crossplane-config/crossplane-config-appset.yaml
@@ -1,0 +1,48 @@
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: crossplane-config
+  labels:
+    appstudio.redhat.com/deployment-clusters: "eaas"
+spec:
+  generators:
+    - merge:
+        mergeKeys:
+          - nameNormalized
+        generators:
+          - clusters:
+              selector:
+                matchExpressions:
+                  - key: appstudio.redhat.com/select-none
+                    operator: Exists
+                  - key: appstudio.redhat.com/select-none
+                    operator: DoesNotExist
+              values:
+                sourceRoot: components/crossplane-config-rd
+                ring: "empty-base"
+                clusterDir: "empty-base"
+          - list:
+              elements: []
+
+  template:
+    metadata:
+      name: crossplane-config-{{nameNormalized}}
+    spec:
+      project: default
+      source:
+        path: '{{values.sourceRoot}}/rings/{{values.ring}}/{{values.clusterDir}}'
+        repoURL: https://github.com/redhat-appstudio/infra-deployments.git
+        targetRevision: main
+      destination:
+        namespace: crossplane-config
+        server: '{{server}}'
+      syncPolicy:
+        # automated:
+        #   prune: true
+        #   selfHeal: true
+        syncOptions:
+          - CreateNamespace=true
+        retry:
+          limit: 50
+          backoff:
+            duration: 15s

--- a/argo-cd-apps/overlays/rd-staging/crossplane-config/kustomization.yaml
+++ b/argo-cd-apps/overlays/rd-staging/crossplane-config/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - crossplane-config-appset.yaml

--- a/argo-cd-apps/overlays/rd-staging/kustomization.yaml
+++ b/argo-cd-apps/overlays/rd-staging/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - artifact-registry-proxy
   - authentication
   - container-image-proxy
+  - crossplane-config
   - etcd-shield
   - etcd-defrag
   - external-secrets-operator

--- a/components/crossplane-config-rd/OWNERS
+++ b/components/crossplane-config-rd/OWNERS
@@ -1,0 +1,8 @@
+# See the OWNERS docs: https://go.k8s.io/owners
+
+approvers:
+- amisstea
+- ifireball
+- avi-biton
+- yftacherzog
+- hmariset

--- a/components/crossplane-config-rd/base/kustomization.yaml
+++ b/components/crossplane-config-rd/base/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - rbac.yaml

--- a/components/crossplane-config-rd/base/rbac.yaml
+++ b/components/crossplane-config-rd/base/rbac.yaml
@@ -1,0 +1,55 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: crossplane-sa
+  namespace: crossplane-config
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: crossplane-clusterrole
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - limitranges
+  - namespaces
+  - resourcequotas
+  verbs:
+  - "*"
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - rolebindings
+  verbs:
+  - "*"
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: crossplane-crb
+subjects:
+- kind: ServiceAccount
+  name: crossplane-sa
+  namespace: crossplane-config
+roleRef:
+  kind: ClusterRole
+  name: crossplane-clusterrole
+  apiGroup: rbac.authorization.k8s.io
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: crossplane-edit-crb
+subjects:
+- kind: ServiceAccount
+  name: crossplane-sa
+  namespace: crossplane-config
+roleRef:
+  kind: ClusterRole
+  name: edit
+  apiGroup: rbac.authorization.k8s.io

--- a/components/crossplane-config-rd/rings/empty-base/empty-base/kustomization.yaml
+++ b/components/crossplane-config-rd/rings/empty-base/empty-base/kustomization.yaml
@@ -1,0 +1,3 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources: []

--- a/components/crossplane-config-rd/rings/ring-0/base/base-snapshot/kustomization.yaml
+++ b/components/crossplane-config-rd/rings/ring-0/base/base-snapshot/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - rbac.yaml

--- a/components/crossplane-config-rd/rings/ring-0/base/base-snapshot/rbac.yaml
+++ b/components/crossplane-config-rd/rings/ring-0/base/base-snapshot/rbac.yaml
@@ -1,0 +1,55 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: crossplane-sa
+  namespace: crossplane-config
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: crossplane-clusterrole
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - limitranges
+  - namespaces
+  - resourcequotas
+  verbs:
+  - "*"
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - rolebindings
+  verbs:
+  - "*"
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: crossplane-crb
+subjects:
+- kind: ServiceAccount
+  name: crossplane-sa
+  namespace: crossplane-config
+roleRef:
+  kind: ClusterRole
+  name: crossplane-clusterrole
+  apiGroup: rbac.authorization.k8s.io
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: crossplane-edit-crb
+subjects:
+- kind: ServiceAccount
+  name: crossplane-sa
+  namespace: crossplane-config
+roleRef:
+  kind: ClusterRole
+  name: edit
+  apiGroup: rbac.authorization.k8s.io

--- a/components/crossplane-config-rd/rings/ring-0/base/kustomization.yaml
+++ b/components/crossplane-config-rd/rings/ring-0/base/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - base-snapshot

--- a/components/crossplane-config-rd/rings/ring-1/base/base-snapshot/kustomization.yaml
+++ b/components/crossplane-config-rd/rings/ring-1/base/base-snapshot/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - rbac.yaml

--- a/components/crossplane-config-rd/rings/ring-1/base/base-snapshot/rbac.yaml
+++ b/components/crossplane-config-rd/rings/ring-1/base/base-snapshot/rbac.yaml
@@ -1,0 +1,55 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: crossplane-sa
+  namespace: crossplane-config
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: crossplane-clusterrole
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - limitranges
+  - namespaces
+  - resourcequotas
+  verbs:
+  - "*"
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - rolebindings
+  verbs:
+  - "*"
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: crossplane-crb
+subjects:
+- kind: ServiceAccount
+  name: crossplane-sa
+  namespace: crossplane-config
+roleRef:
+  kind: ClusterRole
+  name: crossplane-clusterrole
+  apiGroup: rbac.authorization.k8s.io
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: crossplane-edit-crb
+subjects:
+- kind: ServiceAccount
+  name: crossplane-sa
+  namespace: crossplane-config
+roleRef:
+  kind: ClusterRole
+  name: edit
+  apiGroup: rbac.authorization.k8s.io

--- a/components/crossplane-config-rd/rings/ring-1/base/kustomization.yaml
+++ b/components/crossplane-config-rd/rings/ring-1/base/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - base-snapshot

--- a/components/crossplane-config-rd/rings/ring-1/kflux-stg-es01/kustomization.yaml
+++ b/components/crossplane-config-rd/rings/ring-1/kflux-stg-es01/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../base


### PR DESCRIPTION
- Create components/crossplane-config-rd/ with Tier 1 base (rbac only), ring-0 (empty, dev served by old AppSet via development/), and ring-1 for staging EaaS cluster (kflux-stg-es01)
- Add rd-staging ApplicationSet with deployment-clusters: eaas label so k-component auto-populates kflux-stg-es01
- Remove automated sync from old AppSet; add preserveResourcesOnDeletion
- Add dev overlay patches to restore auto-sync and remove preserveResourcesOnDeletion for dev ArgoCD context
- Remove crossplane-config from konflux-public-staging AppSRE ArgoCD
- Production EaaS cluster (kflux-prd-es01) remains on old AppSet via production/ overlay until ring-2 migration

