### PR TITLE
(onboarding) Migrate staging smee-client AppSet to ring deployments ArgoCD

### DIFF
--- a/argo-cd-apps/base/smee-client/smee-client.yaml
+++ b/argo-cd-apps/base/smee-client/smee-client.yaml
@@ -43,9 +43,7 @@ spec:
         namespace: smee-client
         server: '{{server}}'
       syncPolicy:
-        automated:
-          prune: true
-          selfHeal: true
+        preserveResourcesOnDeletion: true
         syncOptions:
           - CreateNamespace=true
         retry:

--- a/argo-cd-apps/overlays/development/kustomization.yaml
+++ b/argo-cd-apps/overlays/development/kustomization.yaml
@@ -206,6 +206,16 @@ patches:
       kind: ApplicationSet
       version: v1alpha1
       name: smee-client
+  - path: delete-preserve-resources-flag-patch.yaml
+    target:
+      kind: ApplicationSet
+      version: v1alpha1
+      name: smee-client
+  - path: dev-application-auto-sync-patch.yaml
+    target:
+      kind: ApplicationSet
+      version: v1alpha1
+      name: smee-client
   - path: development-overlay-patch.yaml
     target:
       kind: ApplicationSet

--- a/argo-cd-apps/overlays/rd-dev/delete-legacy-konflux-member-appsets.yaml
+++ b/argo-cd-apps/overlays/rd-dev/delete-legacy-konflux-member-appsets.yaml
@@ -72,3 +72,9 @@ kind: ApplicationSet
 metadata:
   name: policies
 $patch: delete
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: smee-client
+$patch: delete

--- a/argo-cd-apps/overlays/rd-dev/kustomization.yaml
+++ b/argo-cd-apps/overlays/rd-dev/kustomization.yaml
@@ -12,6 +12,7 @@ resources:
   - kyverno
   - multi-platform-controller
   - policies
+  - smee-client
 
 patchesStrategicMerge:
   - delete-legacy-konflux-member-appsets.yaml

--- a/argo-cd-apps/overlays/rd-dev/smee-client/kustomization.yaml
+++ b/argo-cd-apps/overlays/rd-dev/smee-client/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - smee-client-appset.yaml

--- a/argo-cd-apps/overlays/rd-dev/smee-client/smee-client-appset.yaml
+++ b/argo-cd-apps/overlays/rd-dev/smee-client/smee-client-appset.yaml
@@ -1,0 +1,43 @@
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: smee-client-rd
+spec:
+  generators:
+    - merge:
+        mergeKeys:
+          - nameNormalized
+        generators:
+          - clusters:
+              selector:
+                matchLabels:
+                  appstudio.redhat.com/member-cluster: "true"
+              values:
+                sourceRoot: components/smee-client-rd
+                ring: "ring-0"
+                clusterDir: base
+          - list:
+              elements: []
+
+  template:
+    metadata:
+      name: smee-client-{{nameNormalized}}
+    spec:
+      project: default
+      source:
+        path: '{{values.sourceRoot}}/rings/{{values.ring}}/{{values.clusterDir}}'
+        repoURL: https://github.com/redhat-appstudio/infra-deployments.git
+        targetRevision: main
+      destination:
+        namespace: smee-client
+        server: '{{server}}'
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
+        syncOptions:
+          - CreateNamespace=true
+        retry:
+          limit: 50
+          backoff:
+            duration: 15s

--- a/argo-cd-apps/overlays/rd-staging/kustomization.yaml
+++ b/argo-cd-apps/overlays/rd-staging/kustomization.yaml
@@ -16,6 +16,7 @@ resources:
   - notification-controller
   - policies
   - repository-validator
+  - smee-client
 
 components:
   - ../../k-components/deploy-to-all-staging-clusters

--- a/argo-cd-apps/overlays/rd-staging/smee-client/kustomization.yaml
+++ b/argo-cd-apps/overlays/rd-staging/smee-client/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - smee-client-appset.yaml

--- a/argo-cd-apps/overlays/rd-staging/smee-client/smee-client-appset.yaml
+++ b/argo-cd-apps/overlays/rd-staging/smee-client/smee-client-appset.yaml
@@ -1,0 +1,51 @@
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: smee-client
+  labels:
+    appstudio.redhat.com/internal-only: "true"
+    appstudio.redhat.com/deployment-clusters: "tenant"
+spec:
+  generators:
+    - merge:
+        mergeKeys:
+          - nameNormalized
+        generators:
+          - clusters:
+              selector:
+                matchExpressions: # k-components will replace this with the correct selector
+                  - key: appstudio.redhat.com/select-none
+                    operator: Exists
+                  - key: appstudio.redhat.com/select-none
+                    operator: DoesNotExist
+              values:
+                sourceRoot: components/smee-client-rd
+                ring: "empty-base"
+                clusterDir: "empty-base"
+          - list:
+              elements: [] # Populated via k-components
+
+  template:
+    metadata:
+      name: smee-client-{{nameNormalized}}
+    spec:
+      project: default
+      source:
+        path: '{{values.sourceRoot}}/rings/{{values.ring}}/{{values.clusterDir}}'
+        repoURL: https://github.com/redhat-appstudio/infra-deployments.git
+        targetRevision: main
+      destination:
+        namespace: smee-client
+        server: '{{server}}'
+      syncPolicy:
+        # automated:
+        #   prune: true
+        #   selfHeal: true
+        syncOptions:
+          - CreateNamespace=true
+        retry:
+          limit: -1
+          backoff:
+            duration: 10s
+            factor: 2
+            maxDuration: 3m

--- a/components/smee-client-rd/OWNERS
+++ b/components/smee-client-rd/OWNERS
@@ -1,0 +1,8 @@
+# See the OWNERS docs: https://go.k8s.io/owners
+
+approvers:
+- ifireball
+- gbenhaim
+- amisstea
+- yftacherzog
+- avi-biton

--- a/components/smee-client-rd/base/deployment.yaml
+++ b/components/smee-client-rd/base/deployment.yaml
@@ -1,0 +1,97 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gosmee-client
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: gosmee-client
+  template:
+    metadata:
+      labels:
+        app: gosmee-client
+    spec:
+      volumes:
+        - name: shared-health
+          emptyDir: {}
+      containers:
+        - image: "ghcr.io/chmouel/gosmee:v0.28.0"
+          imagePullPolicy: Always
+          name: gosmee
+          args:
+            - "client"
+            - "--sse-buffer-size"
+            - "2097152"
+            - TBA
+            - "http://localhost:8080"
+          volumeMounts:
+            - name: shared-health
+              mountPath: /shared
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - "ALL"
+            seccompProfile:
+              type: RuntimeDefault
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+          resources:
+            limits:
+              cpu: 1
+              memory: 750Mi
+            requests:
+              cpu: 1
+              memory: 750Mi
+          livenessProbe:
+            exec:
+              command:
+                - /shared/check-smee-health.sh
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 25
+            failureThreshold: 4
+        - name: health-check-sidecar
+          image: quay.io/konflux-ci/smee-sidecar:replaced-by-overlay
+          imagePullPolicy: Always
+          ports:
+            - name: http
+              containerPort: 8080
+            - name: metrics
+              containerPort: 9100
+          volumeMounts:
+            - name: shared-health
+              mountPath: /shared
+          env:
+          - name: DOWNSTREAM_SERVICE_URL
+            value: "http://pipelines-as-code-controller.openshift-pipelines:8080"
+          - name: SMEE_CHANNEL_URL
+            value: "TBA"
+          - name: HEALTH_CHECK_TIMEOUT_SECONDS
+            value: "20"
+          livenessProbe:
+            exec:
+              command:
+                - /shared/check-sidecar-health.sh
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 25
+            failureThreshold: 3
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - "ALL"
+            seccompProfile:
+              type: RuntimeDefault
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+          resources:
+            limits:
+              cpu: 100m
+              memory: 128Mi
+            requests:
+              cpu: 100m
+              memory: 128Mi

--- a/components/smee-client-rd/base/kustomization.yaml
+++ b/components/smee-client-rd/base/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - deployment.yaml
+  - rbac.yaml

--- a/components/smee-client-rd/base/rbac.yaml
+++ b/components/smee-client-rd/base/rbac.yaml
@@ -1,0 +1,13 @@
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: konflux-vanguard-admins
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: konflux-vanguard
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: admin

--- a/components/smee-client-rd/rings/empty-base/empty-base/kustomization.yaml
+++ b/components/smee-client-rd/rings/empty-base/empty-base/kustomization.yaml
@@ -1,0 +1,3 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources: []

--- a/components/smee-client-rd/rings/ring-0/base/base-snapshot/deployment.yaml
+++ b/components/smee-client-rd/rings/ring-0/base/base-snapshot/deployment.yaml
@@ -1,0 +1,97 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gosmee-client
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: gosmee-client
+  template:
+    metadata:
+      labels:
+        app: gosmee-client
+    spec:
+      volumes:
+        - name: shared-health
+          emptyDir: {}
+      containers:
+        - image: "ghcr.io/chmouel/gosmee:v0.28.0"
+          imagePullPolicy: Always
+          name: gosmee
+          args:
+            - "client"
+            - "--sse-buffer-size"
+            - "2097152"
+            - TBA
+            - "http://localhost:8080"
+          volumeMounts:
+            - name: shared-health
+              mountPath: /shared
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - "ALL"
+            seccompProfile:
+              type: RuntimeDefault
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+          resources:
+            limits:
+              cpu: 1
+              memory: 750Mi
+            requests:
+              cpu: 1
+              memory: 750Mi
+          livenessProbe:
+            exec:
+              command:
+                - /shared/check-smee-health.sh
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 25
+            failureThreshold: 4
+        - name: health-check-sidecar
+          image: quay.io/konflux-ci/smee-sidecar:replaced-by-overlay
+          imagePullPolicy: Always
+          ports:
+            - name: http
+              containerPort: 8080
+            - name: metrics
+              containerPort: 9100
+          volumeMounts:
+            - name: shared-health
+              mountPath: /shared
+          env:
+          - name: DOWNSTREAM_SERVICE_URL
+            value: "http://pipelines-as-code-controller.openshift-pipelines:8080"
+          - name: SMEE_CHANNEL_URL
+            value: "TBA"
+          - name: HEALTH_CHECK_TIMEOUT_SECONDS
+            value: "20"
+          livenessProbe:
+            exec:
+              command:
+                - /shared/check-sidecar-health.sh
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 25
+            failureThreshold: 3
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - "ALL"
+            seccompProfile:
+              type: RuntimeDefault
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+          resources:
+            limits:
+              cpu: 100m
+              memory: 128Mi
+            requests:
+              cpu: 100m
+              memory: 128Mi

--- a/components/smee-client-rd/rings/ring-0/base/base-snapshot/kustomization.yaml
+++ b/components/smee-client-rd/rings/ring-0/base/base-snapshot/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - deployment.yaml
+  - rbac.yaml

--- a/components/smee-client-rd/rings/ring-0/base/base-snapshot/rbac.yaml
+++ b/components/smee-client-rd/rings/ring-0/base/base-snapshot/rbac.yaml
@@ -1,0 +1,13 @@
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: konflux-vanguard-admins
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: konflux-vanguard
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: admin

--- a/components/smee-client-rd/rings/ring-0/base/kustomization.yaml
+++ b/components/smee-client-rd/rings/ring-0/base/kustomization.yaml
@@ -1,0 +1,19 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - base-snapshot
+
+images:
+  - name: ghcr.io/chmouel/gosmee
+    newName: ghcr.io/chmouel/gosmee
+    newTag: v0.28.0
+  - name: quay.io/konflux-ci/smee-sidecar
+    newName: quay.io/konflux-ci/smee-sidecar
+    newTag: ff9f8ccd3cedaf21827ac2ef86c49847c970bab9
+
+patches:
+  - path: patches/server-url-patch.yaml
+    target:
+      name: gosmee-client
+      kind: Deployment

--- a/components/smee-client-rd/rings/ring-0/base/patches/server-url-patch.yaml
+++ b/components/smee-client-rd/rings/ring-0/base/patches/server-url-patch.yaml
@@ -1,0 +1,12 @@
+---
+# Development webhook forwarding channel for Forgejo/Codeberg webhook testing
+# The URL can be configured via SMEE_CHANNEL environment variable in preview.sh
+# Create a channel at https://hook.pipelinesascode.com and provide the URL here
+# Note: Do not use smee.io - it breaks webhook signature validation for Forgejo.
+# hook.pipelinesascode.com uses gosmee which properly preserves webhook signatures.
+- op: replace
+  path: /spec/template/spec/containers/0/args/3
+  value: "https://hook.pipelinesascode.com/REPLACE_ME"
+- op: replace
+  path: /spec/template/spec/containers/1/env/1/value
+  value: "https://hook.pipelinesascode.com/REPLACE_ME"

--- a/components/smee-client-rd/rings/ring-1/base/base-snapshot/deployment.yaml
+++ b/components/smee-client-rd/rings/ring-1/base/base-snapshot/deployment.yaml
@@ -1,0 +1,97 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gosmee-client
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: gosmee-client
+  template:
+    metadata:
+      labels:
+        app: gosmee-client
+    spec:
+      volumes:
+        - name: shared-health
+          emptyDir: {}
+      containers:
+        - image: "ghcr.io/chmouel/gosmee:v0.28.0"
+          imagePullPolicy: Always
+          name: gosmee
+          args:
+            - "client"
+            - "--sse-buffer-size"
+            - "2097152"
+            - TBA
+            - "http://localhost:8080"
+          volumeMounts:
+            - name: shared-health
+              mountPath: /shared
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - "ALL"
+            seccompProfile:
+              type: RuntimeDefault
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+          resources:
+            limits:
+              cpu: 1
+              memory: 750Mi
+            requests:
+              cpu: 1
+              memory: 750Mi
+          livenessProbe:
+            exec:
+              command:
+                - /shared/check-smee-health.sh
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 25
+            failureThreshold: 4
+        - name: health-check-sidecar
+          image: quay.io/konflux-ci/smee-sidecar:replaced-by-overlay
+          imagePullPolicy: Always
+          ports:
+            - name: http
+              containerPort: 8080
+            - name: metrics
+              containerPort: 9100
+          volumeMounts:
+            - name: shared-health
+              mountPath: /shared
+          env:
+          - name: DOWNSTREAM_SERVICE_URL
+            value: "http://pipelines-as-code-controller.openshift-pipelines:8080"
+          - name: SMEE_CHANNEL_URL
+            value: "TBA"
+          - name: HEALTH_CHECK_TIMEOUT_SECONDS
+            value: "20"
+          livenessProbe:
+            exec:
+              command:
+                - /shared/check-sidecar-health.sh
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 25
+            failureThreshold: 3
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - "ALL"
+            seccompProfile:
+              type: RuntimeDefault
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+          resources:
+            limits:
+              cpu: 100m
+              memory: 128Mi
+            requests:
+              cpu: 100m
+              memory: 128Mi

--- a/components/smee-client-rd/rings/ring-1/base/base-snapshot/kustomization.yaml
+++ b/components/smee-client-rd/rings/ring-1/base/base-snapshot/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - deployment.yaml
+  - rbac.yaml

--- a/components/smee-client-rd/rings/ring-1/base/base-snapshot/rbac.yaml
+++ b/components/smee-client-rd/rings/ring-1/base/base-snapshot/rbac.yaml
@@ -1,0 +1,13 @@
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: konflux-vanguard-admins
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: konflux-vanguard
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: admin

--- a/components/smee-client-rd/rings/ring-1/base/kustomization.yaml
+++ b/components/smee-client-rd/rings/ring-1/base/kustomization.yaml
@@ -1,0 +1,23 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - base-snapshot
+
+images:
+  - name: ghcr.io/chmouel/gosmee
+    newName: ghcr.io/chmouel/gosmee
+    newTag: v0.28.0
+  - name: quay.io/konflux-ci/smee-sidecar
+    newName: quay.io/konflux-ci/smee-sidecar
+    newTag: ff9f8ccd3cedaf21827ac2ef86c49847c970bab9
+
+patches:
+  - path: patches/server-url-patch.yaml
+    target:
+      name: gosmee-client
+      kind: Deployment
+  - path: patches/enable-pprof-patch.yaml
+    target:
+      name: gosmee-client
+      kind: Deployment

--- a/components/smee-client-rd/rings/ring-1/base/patches/enable-pprof-patch.yaml
+++ b/components/smee-client-rd/rings/ring-1/base/patches/enable-pprof-patch.yaml
@@ -1,0 +1,6 @@
+---
+- op: add
+  path: /spec/template/spec/containers/1/env/-
+  value:
+    name: ENABLE_PPROF
+    value: "true"

--- a/components/smee-client-rd/rings/ring-1/base/patches/server-url-patch.yaml
+++ b/components/smee-client-rd/rings/ring-1/base/patches/server-url-patch.yaml
@@ -1,0 +1,7 @@
+---
+- op: replace
+  path: /spec/template/spec/containers/0/args/3
+  value: https://smee-smee.apps.rosa.kflux-c-stg-e01.3zdg.p3.openshiftapps.com/redhathookstagep01
+- op: replace
+  path: /spec/template/spec/containers/1/env/1/value
+  value: https://smee-smee.apps.rosa.kflux-c-stg-e01.3zdg.p3.openshiftapps.com/redhathookstagep01

--- a/components/smee-client-rd/rings/ring-1/lightwell-dev/kustomization.yaml
+++ b/components/smee-client-rd/rings/ring-1/lightwell-dev/kustomization.yaml
@@ -1,0 +1,3 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources: []

--- a/components/smee-client-rd/rings/ring-1/stone-stage-p01/kustomization.yaml
+++ b/components/smee-client-rd/rings/ring-1/stone-stage-p01/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../base

--- a/hack/preview.sh
+++ b/hack/preview.sh
@@ -427,6 +427,7 @@ apply_service_image_overrides() {
     [[ -n "${BUILD_SERVICE_PR_OWNER}" && "${BUILD_SERVICE_PR_SHA}" ]] && yq -i e "(.resources[] | select(. ==\"*github.com/konflux-ci/build-service*\")) |= \"https://github.com/${BUILD_SERVICE_PR_OWNER}/build-service/config/default?ref=${BUILD_SERVICE_PR_SHA}\"" $ROOT/components/build-service/development/kustomization.yaml
     # Configure webhook forwarding channel URL (used for Forgejo/Codeberg testing, use hook.pipelinesascode.com not smee.io)
     [ -n "${SMEE_CHANNEL}" ] && yq -i e ".[].value = \"${SMEE_CHANNEL}\"" $ROOT/components/smee-client/development/sever-url-patch.yaml
+    [ -n "${SMEE_CHANNEL}" ] && yq -i e ".[].value = \"${SMEE_CHANNEL}\"" $ROOT/components/smee-client-rd/rings/ring-0/base/patches/server-url-patch.yaml
     # Configure build-service webhook-config for Codeberg to use the smee channel
     [ -n "${SMEE_CHANNEL}" ] && sed -i.bak "s|SMEE_CHANNEL_PLACEHOLDER|${SMEE_CHANNEL}|g" $ROOT/components/build-service/development/webhook-config.json && rm -f $ROOT/components/build-service/development/webhook-config.json.bak
 


### PR DESCRIPTION
- Create components/smee-client-rd/ with Tier 1 base, ring-0 (empty, dev served by old AppSet via development/), and ring-1 for internal staging clusters (stone-stage-p01, lightwell-dev)
- Add rd-staging ApplicationSet with internal-only + tenant labels so deploy-to-staging-internal-tenant-clusters k-component auto-populates the correct clusters
- ring-1/base includes staging smee URL, image tag, and enable-pprof patch matching existing staging/ overlay output exactly
- Remove automated sync from old AppSet; add preserveResourcesOnDeletion
- Add dev overlay patches to restore auto-sync and remove preserveResourcesOnDeletion for dev ArgoCD context
- Production clusters (kflux-ocp-p01, stone-prod-p01/p02, kflux-rhel-p01, kflux-osp-p01, kflux-lw-p01) remain on old AppSet via production/ overlays
