### PR TITLE
KONFLUX-14937: upgrade Vector tekton logs collector to 0.57.0 (prod)

### DIFF
--- a/components/vector-tekton-logs-collector/production/vector-helm-generator.yaml
+++ b/components/vector-tekton-logs-collector/production/vector-helm-generator.yaml
@@ -6,9 +6,9 @@ name: vector
 repo: https://helm.vector.dev
 # We mirror the image from Docker to Quay. To update the version, mirror the respective
 # image. You can use skopeo e.g
-# `skopeo copy docker://timberio/vector:0.45.0-distroless-libc docker://quay.io/openshift-pipeline/vector:0.45.0-distroless-libc`
+# `skopeo copy docker://timberio/vector:0.57.0-distroless-libc docker://quay.io/openshift-pipeline/vector:0.57.0-distroless-libc`
 # The tag obviously will differ.
-version: 0.41.0
+version: 0.57.0
 releaseName: vector-tekton-logs-collector
 namespace: tekton-logging
 valuesFile: vector-helm-values.yaml

--- a/components/vector-tekton-logs-collector/production/vector-helm-values.yaml
+++ b/components/vector-tekton-logs-collector/production/vector-helm-values.yaml
@@ -12,7 +12,6 @@ customConfig:
   api:
     enabled: true
     address: 127.0.0.1:8686
-    playground: false
   sources:
     kubernetes_logs:
       type: kubernetes_logs
@@ -77,6 +76,11 @@ customConfig:
       filename_time_format: "-%s"
       filename_append_uuid: false
 env:
+  # Vector 0.57 disables ${VAR} interpolation by default. Restore it for
+  # ${BUCKET} and ${ENDPOINT}, which are sourced from the tekton-results-s3 secret.
+  # See: https://vector.dev/docs/reference/environment_variables/
+  - name: VECTOR_DANGEROUSLY_ALLOW_ENV_VAR_INTERPOLATION
+    value: "true"
   - name: AWS_ACCESS_KEY_ID
     valueFrom:
       secretKeyRef:
@@ -111,7 +115,7 @@ tolerations:
     value: konflux-tenants
 image:
   repository: quay.io/openshift-pipeline/vector
-  tag: 0.45.0-distroless-libc
+  tag: 0.57.0-distroless-libc
 securityContext:
   allowPrivilegeEscalation: false
   capabilities:


### PR DESCRIPTION
- Upgrade Vector Helm chart from 0.41.0 → 0.57.0
- Upgrade Vector image from 0.45.0-distroless-libc → 0.57.0-distroless-libc
- Remove deprecated `api.playground` (removed in Vector 0.55)
- Add `VECTOR_DANGEROUSLY_ALLOW_ENV_VAR_INTERPOLATION=true` for S3 sink `${BUCKET}`/`${ENDPOINT}` interpolation
Clusters affected: all production clusters (production-downstream, konflux-public-production)
[KONFLUX-14937](https://redhat.atlassian.net/browse/KONFLUX-14937)
## Why
CVE-2026-39197 — Denial of Service via crafted request to Vector's HTTP endpoint. Upgrading to patched release (0.57.0) as defense-in-depth. CVE has already breached SLO.
## Validation
- `kustomize build --enable-helm` passes for production overlay
- Dev/staging validated and merged: #13559
- Image already mirrored to `quay.io/openshift-pipeline/vector:0.57.0-distroless-libc`
## Risk Assessment
**Risk Level:** Medium
**What could go wrong:** Vector 0.57 is a 12-minor version jump. If the env-var interpolation flag doesn't work as expected, S3 log shipping could break (logs would not reach object storage). Vector pod itself could fail to start if the new chart introduces unexpected config requirements.
**Rollback:** Revert PR to restore previous version (chart 0.41.0, image 0.45.0).
**Blast radius:** All production clusters consuming `components/vector-tekton-logs-collector/production/` via production-downstream and konflux-public-production overlays.

[KONFLUX-14937]: https://redhat.atlassian.net/browse/KONFLUX-14937?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ