### PR TITLE
fix: Rotate verifications Sa to new konflux-bot-0

### DIFF
--- a/components/konflux-verifications-rd/README.md
+++ b/components/konflux-verifications-rd/README.md
@@ -5,7 +5,7 @@ Infrastructure component for Kargo verification conformance tests.
 ## What this deploys
 
 - **Namespaces**: `konflux-conformance-tests` (tenant) and `konflux-managed-tests` (managed)
-- **ServiceAccount**: `conformance-verification-sa` in `konflux-managed-tests`, with a bound token Secret
+- **ServiceAccount**: `konflux-bot-0` in `konflux-managed-tests`, with a bound token Secret
 - **RoleBindings**: Grants the SA `konflux-admin-user-actions` in both namespaces and `release-pipeline-resource-role` in the managed namespace
 
 ## Purpose

--- a/components/konflux-verifications-rd/base/rbac.yaml
+++ b/components/konflux-verifications-rd/base/rbac.yaml
@@ -1,4 +1,4 @@
-# RoleBindings granting the conformance-verification-sa permissions in both
+# RoleBindings granting the konflux-bot-0 SA permissions in both
 # tenant and managed namespaces via existing ClusterRoles.
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -8,7 +8,7 @@ metadata:
   namespace: konflux-conformance-tests
 subjects:
   - kind: ServiceAccount
-    name: conformance-verification-sa
+    name: konflux-bot-0
     namespace: konflux-managed-tests
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -22,7 +22,7 @@ metadata:
   namespace: konflux-managed-tests
 subjects:
   - kind: ServiceAccount
-    name: conformance-verification-sa
+    name: konflux-bot-0
     namespace: konflux-managed-tests
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -36,7 +36,7 @@ metadata:
   namespace: konflux-managed-tests
 subjects:
   - kind: ServiceAccount
-    name: conformance-verification-sa
+    name: konflux-bot-0
     namespace: konflux-managed-tests
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/components/konflux-verifications-rd/base/serviceaccount.yaml
+++ b/components/konflux-verifications-rd/base/serviceaccount.yaml
@@ -1,17 +1,18 @@
 # ServiceAccount for Kargo verification conformance tests.
+# Uses the konflux-bot-0 predefined name to survive SA rotation.
 # The bound token Secret is auto-populated by the control plane and can be
 # pushed to Vault via PushSecret for Kargo clusters to consume.
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: conformance-verification-sa
+  name: konflux-bot-0
   namespace: konflux-managed-tests
 ---
 apiVersion: v1
 kind: Secret
 metadata:
   annotations:
-    kubernetes.io/service-account.name: conformance-verification-sa
-  name: conformance-verification-sa-token
+    kubernetes.io/service-account.name: konflux-bot-0
+  name: konflux-bot-0-token
   namespace: konflux-managed-tests
 type: kubernetes.io/service-account-token

--- a/components/konflux-verifications-rd/rings/ring-1/base/base-snapshot/rbac.yaml
+++ b/components/konflux-verifications-rd/rings/ring-1/base/base-snapshot/rbac.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: konflux-conformance-tests
 subjects:
   - kind: ServiceAccount
-    name: conformance-verification-sa
+    name: konflux-bot-0
     namespace: konflux-managed-tests
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -19,7 +19,7 @@ metadata:
   namespace: konflux-managed-tests
 subjects:
   - kind: ServiceAccount
-    name: conformance-verification-sa
+    name: konflux-bot-0
     namespace: konflux-managed-tests
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -33,7 +33,7 @@ metadata:
   namespace: konflux-managed-tests
 subjects:
   - kind: ServiceAccount
-    name: conformance-verification-sa
+    name: konflux-bot-0
     namespace: konflux-managed-tests
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/components/konflux-verifications-rd/rings/ring-1/base/base-snapshot/serviceaccount.yaml
+++ b/components/konflux-verifications-rd/rings/ring-1/base/base-snapshot/serviceaccount.yaml
@@ -1,14 +1,14 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: conformance-verification-sa
+  name: konflux-bot-0
   namespace: konflux-managed-tests
 ---
 apiVersion: v1
 kind: Secret
 metadata:
   annotations:
-    kubernetes.io/service-account.name: conformance-verification-sa
-  name: conformance-verification-sa-token
+    kubernetes.io/service-account.name: konflux-bot-0
+  name: konflux-bot-0-token
   namespace: konflux-managed-tests
 type: kubernetes.io/service-account-token

--- a/components/konflux-verifications-rd/rings/ring-1/lightwell-dev/push-secret.yaml
+++ b/components/konflux-verifications-rd/rings/ring-1/lightwell-dev/push-secret.yaml
@@ -10,7 +10,7 @@ spec:
       kind: ClusterSecretStore
   selector:
     secret:
-      name: conformance-verification-sa-token
+      name: konflux-bot-0-token
   data:
     - match:
         secretKey: token

--- a/components/konflux-verifications-rd/rings/ring-1/stone-stage-p01/push-secret.yaml
+++ b/components/konflux-verifications-rd/rings/ring-1/stone-stage-p01/push-secret.yaml
@@ -10,7 +10,7 @@ spec:
       kind: ClusterSecretStore
   selector:
     secret:
-      name: conformance-verification-sa-token
+      name: konflux-bot-0-token
   data:
     - match:
         secretKey: token

--- a/components/konflux-verifications-rd/rings/ring-1/stone-stg-rh01/push-secret.yaml
+++ b/components/konflux-verifications-rd/rings/ring-1/stone-stg-rh01/push-secret.yaml
@@ -10,7 +10,7 @@ spec:
       kind: ClusterSecretStore
   selector:
     secret:
-      name: conformance-verification-sa-token
+      name: konflux-bot-0-token
   data:
     - match:
         secretKey: token


### PR DESCRIPTION
## Summary

Renames the `conformance-verification-sa` ServiceAccount to `konflux-bot-0` across the
`konflux-verifications-rd` component, in preparation for the upcoming SA rotation
(September 11 for staging, September 18+ for production).

All SAs not using the `konflux-bot-*` naming scheme will be deleted and recreated during
rotation, invalidating existing tokens. This change migrates to the predefined name so
the SA and its token survive the rotation.

## Changes

- ServiceAccount: `conformance-verification-sa` -> `konflux-bot-0`
- Token Secret: `conformance-verification-sa-token` -> `konflux-bot-0-token`
- Updated all RoleBinding subjects to reference the new SA name
- Updated PushSecret selectors across all clusters (stone-stage-p01, stone-stg-rh01, lightwell-dev)
- RoleBinding names and ClusterRole references are unchanged

## Risk Assessment

**Level:** Low

- **What could go wrong:** Existing tokens minted for `conformance-verification-sa` will stop working once ArgoCD syncs the change, since the old SA is replaced. Kargo verification jobs using the old token from Vault would fail until the PushSecret syncs the new token.
- **Blast radius:** Only affects Kargo verification conformance tests in staging. No impact on production workloads or other tenants.
- **Rollback:** Revert the PR to restore the old SA name. Re-mint a token for the old SA if needed before the rotation date.

## Validation

- Verified no remaining references to `conformance-verification-sa` in the component
- All 8 files updated consistently (base + ring-1 snapshot + 3 cluster push-secrets + README)