### PR TITLE
KFLUXINFRA-4375 allow 172.24.0.0/14 pod CIDR in ESO webhook network p…

### DIFF
--- a/components/external-secrets-operator/production/networkpolicy-allow-ingress.yaml
+++ b/components/external-secrets-operator/production/networkpolicy-allow-ingress.yaml
@@ -22,10 +22,13 @@ spec:
     # is NATed and comes from a pod IP assigned to interface ovn-k8s-mp0
     # - 192.168.0.0/16 (pod CIDR in most clusters)
     # - 10.128.0.0/14 (pod CIDR in stg-rh01, prd-rh01 and prd-p01 clusters)
+    # - 172.24.0.0/14 (pod CIDR in new cluster)
     - ipBlock:
         cidr: 10.128.0.0/14
     - ipBlock:
         cidr: 192.168.0.0/16
+    - ipBlock:
+        cidr: 172.24.0.0/14
     ports:
     - protocol: TCP
       port: 10250 # Webhook port
@@ -87,6 +90,8 @@ spec:
         cidr: 10.128.0.0/14
     - ipBlock:
         cidr: 192.168.0.0/16
+    - ipBlock:
+        cidr: 172.24.0.0/14
     ports:
     - protocol: TCP
       port: 8081

--- a/components/external-secrets-operator/staging/networkpolicy-allow-ingress.yaml
+++ b/components/external-secrets-operator/staging/networkpolicy-allow-ingress.yaml
@@ -23,12 +23,15 @@ spec:
     # - 192.168.0.0/16 (pod CIDR in most clusters)
     # - 10.128.0.0/14 (pod CIDR in stg-rh01, prd-rh01 and prd-p01 clusters)
     # - 172.17.0.0/18 (pod CIDR on IBM Cloud ROKS clusters, e.g. lightwell-dev)
+    # - 172.24.0.0/14 (pod CIDR in new cluster)
     - ipBlock:
         cidr: 10.128.0.0/14
     - ipBlock:
         cidr: 192.168.0.0/16
     - ipBlock:
         cidr: 172.17.0.0/18
+    - ipBlock:
+        cidr: 172.24.0.0/14
     ports:
     - protocol: TCP
       port: 10250 # Webhook port
@@ -92,6 +95,8 @@ spec:
         cidr: 192.168.0.0/16
     - ipBlock:
         cidr: 172.17.0.0/18
+    - ipBlock:
+        cidr: 172.24.0.0/14
     ports:
     - protocol: TCP
       port: 8081


### PR DESCRIPTION
…olicies

Add 172.24.0.0/14 to the allow-webhook-ingress and allow-health-checks-ingress NetworkPolicies in both staging and production so that clusters using this pod CIDR can reach the ESO validating webhook.