### PR TITLE
Do not deploy operator owned component to kflux-lw-p01

### DIFF
--- a/argo-cd-apps/overlays/production-downstream/exclude-operator-owned-clusters.yaml
+++ b/argo-cd-apps/overlays/production-downstream/exclude-operator-owned-clusters.yaml
@@ -1,0 +1,14 @@
+---
+# Drop operator-managed clusters from ApplicationSet generation for Konflux
+# services owned by the konflux-operator (ring-2). Uses ApplicationSet
+# post-selector on generated params (nameNormalized) so other production
+# clusters are unchanged. Production-downstream overlay only; targets are
+# listed in kustomization.yaml
+- op: add
+  path: /spec/generators/0/selector
+  value:
+    matchExpressions:
+      - key: nameNormalized
+        operator: NotIn
+        values:
+          - kflux-lw-p01

--- a/argo-cd-apps/overlays/production-downstream/kustomization.yaml
+++ b/argo-cd-apps/overlays/production-downstream/kustomization.yaml
@@ -299,3 +299,105 @@ patches:
       kind: ApplicationSet
       version: v1alpha1
       name: monitoring-cardinality
+  # Exclude operator-managed clusters from Argo generation for services owned
+  # by the konflux-operator (ring-2). Orphan (do not prune) when Applications go away.
+  - path: exclude-operator-owned-clusters.yaml
+    target:
+      kind: ApplicationSet
+      version: v1alpha1
+      name: application-api
+  - path: preserve-resources-on-deletion.yaml
+    target:
+      kind: ApplicationSet
+      version: v1alpha1
+      name: application-api
+  - path: exclude-operator-owned-clusters.yaml
+    target:
+      kind: ApplicationSet
+      version: v1alpha1
+      name: build-service
+  - path: preserve-resources-on-deletion.yaml
+    target:
+      kind: ApplicationSet
+      version: v1alpha1
+      name: build-service
+  - path: exclude-operator-owned-clusters.yaml
+    target:
+      kind: ApplicationSet
+      version: v1alpha1
+      name: integration
+  - path: preserve-resources-on-deletion.yaml
+    target:
+      kind: ApplicationSet
+      version: v1alpha1
+      name: integration
+  - path: exclude-operator-owned-clusters.yaml
+    target:
+      kind: ApplicationSet
+      version: v1alpha1
+      name: image-controller
+  - path: preserve-resources-on-deletion.yaml
+    target:
+      kind: ApplicationSet
+      version: v1alpha1
+      name: image-controller
+  - path: exclude-operator-owned-clusters.yaml
+    target:
+      kind: ApplicationSet
+      version: v1alpha1
+      name: namespace-lister
+  - path: preserve-resources-on-deletion.yaml
+    target:
+      kind: ApplicationSet
+      version: v1alpha1
+      name: namespace-lister
+  - path: exclude-operator-owned-clusters.yaml
+    target:
+      kind: ApplicationSet
+      version: v1alpha1
+      name: konflux-info
+  - path: preserve-resources-on-deletion.yaml
+    target:
+      kind: ApplicationSet
+      version: v1alpha1
+      name: konflux-info
+  - path: exclude-operator-owned-clusters.yaml
+    target:
+      kind: ApplicationSet
+      version: v1alpha1
+      name: konflux-ui
+  - path: preserve-resources-on-deletion.yaml
+    target:
+      kind: ApplicationSet
+      version: v1alpha1
+      name: konflux-ui
+  - path: exclude-operator-owned-clusters.yaml
+    target:
+      kind: ApplicationSet
+      version: v1alpha1
+      name: enterprise-contract
+  - path: preserve-resources-on-deletion.yaml
+    target:
+      kind: ApplicationSet
+      version: v1alpha1
+      name: enterprise-contract
+  - path: exclude-operator-owned-clusters.yaml
+    target:
+      kind: ApplicationSet
+      version: v1alpha1
+      name: konflux-rbac
+  - path: preserve-resources-on-deletion.yaml
+    target:
+      kind: ApplicationSet
+      version: v1alpha1
+      name: konflux-rbac
+  - path: exclude-operator-owned-clusters.yaml
+    target:
+      kind: ApplicationSet
+      version: v1alpha1
+      name: release
+  - path: preserve-resources-on-deletion.yaml
+    target:
+      kind: ApplicationSet
+      version: v1alpha1
+      name: release

--- a/argo-cd-apps/overlays/production-downstream/preserve-resources-on-deletion.yaml
+++ b/argo-cd-apps/overlays/production-downstream/preserve-resources-on-deletion.yaml
@@ -1,0 +1,9 @@
+---
+# When operator-managed cluster Applications are removed from an ApplicationSet
+# (see exclude-operator-owned-clusters.yaml), do not prune cluster resources.
+# The konflux-operator owns those workloads; Argo must orphan, not delete.
+# Production-downstream overlay only.
+- op: add
+  path: /spec/syncPolicy
+  value:
+    preserveResourcesOnDeletion: true


### PR DESCRIPTION
The operator will be deployed by another PR, in the meantime do not deploy the component that will be managed by the operator since we did not create proper cluster config for each.