### PR TITLE
(onboarding) Migrate production etcd-defrag AppSet to ring deployments ArgoCD

### DIFF
--- a/argo-cd-apps/overlays/rd-production/etcd-defrag/etcd-defrag-appset.yaml
+++ b/argo-cd-apps/overlays/rd-production/etcd-defrag/etcd-defrag-appset.yaml
@@ -1,0 +1,49 @@
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: etcd-defrag
+  labels:
+    appstudio.redhat.com/deployment-clusters: tenant
+spec:
+  generators:
+    - merge:
+        mergeKeys:
+          - nameNormalized
+        generators:
+          - clusters:
+              selector:
+                  matchExpressions: # Ensures that no clusters are selected; a k-component will replace this with the correct selector
+                    - key: appstudio.redhat.com/select-none
+                      operator: Exists
+                    - key: appstudio.redhat.com/select-none
+                      operator: DoesNotExist
+              values:
+                sourceRoot: config/etcd-defrag-rd
+                ring: "empty-base"
+                clusterDir: "empty-base"
+          - list:
+              elements: [] # Populated via a k-component (or manually if the cluster list is unusual)
+
+  template:
+    metadata:
+      name: etcd-defrag-{{nameNormalized}}
+    spec:
+      project: default
+      source:
+        path: '{{values.sourceRoot}}/rings/{{values.ring}}/{{values.clusterDir}}'
+        repoURL: https://github.com/redhat-appstudio/infra-deployments.git
+        targetRevision: main
+      destination:
+        namespace: etcd-maintenance
+        server: '{{server}}'
+      syncPolicy:
+        # automated:
+        #   prune: true
+        #   selfHeal: true
+        syncOptions:
+        - CreateNamespace=true
+        retry:
+          limit: 50
+          backoff:
+            duration: 15s
+

--- a/argo-cd-apps/overlays/rd-production/etcd-defrag/etcd-defrag-appset.yaml
+++ b/argo-cd-apps/overlays/rd-production/etcd-defrag/etcd-defrag-appset.yaml
@@ -18,7 +18,7 @@ spec:
                     - key: appstudio.redhat.com/select-none
                       operator: DoesNotExist
               values:
-                sourceRoot: config/etcd-defrag-rd
+                sourceRoot: configs/etcd-defrag-rd
                 ring: "empty-base"
                 clusterDir: "empty-base"
           - list:

--- a/argo-cd-apps/overlays/rd-production/etcd-defrag/kustomization.yaml
+++ b/argo-cd-apps/overlays/rd-production/etcd-defrag/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- etcd-defrag-appset.yaml

--- a/argo-cd-apps/overlays/rd-production/kustomization.yaml
+++ b/argo-cd-apps/overlays/rd-production/kustomization.yaml
@@ -4,11 +4,11 @@ namespace: argocd-infra-deployments
 
 resources:
   - authentication
+  - etcd-defrag
   - etcd-shield
   - konflux-operator
   - kueue
   - multi-platform-controller
-  - etcd-defrag
 
 components:
   - ../../k-components/deploy-to-all-production-clusters

--- a/argo-cd-apps/overlays/rd-production/kustomization.yaml
+++ b/argo-cd-apps/overlays/rd-production/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
   - konflux-operator
   - kueue
   - multi-platform-controller
+  - etcd-defrag
 
 components:
   - ../../k-components/deploy-to-all-production-clusters

--- a/configs/etcd-defrag-rd/OWNERS
+++ b/configs/etcd-defrag-rd/OWNERS
@@ -1,0 +1,7 @@
+# See the OWNERS docs: https://go.k8s.io/owners
+
+approvers:
+- konflux-infra-team
+
+reviewers:
+- konflux-infra-team

--- a/configs/etcd-defrag-rd/rings/ring-1/base/kustomization.yaml
+++ b/configs/etcd-defrag-rd/rings/ring-1/base/kustomization.yaml
@@ -2,3 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - base-snapshot
+
+images:
+  - name:  quay.io/konflux-ci/etcd-defrag
+    newTag: 7a19f7b9b7bbdeb4f8d51e06d3319ac5c0555094fcbf2093d6e4d71f136afb55

--- a/configs/etcd-defrag-rd/rings/ring-2/base/base-snapshot/cluster-role.yaml
+++ b/configs/etcd-defrag-rd/rings/ring-2/base/base-snapshot/cluster-role.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: etcd-maintenance-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - list
+  - get
+  - create
+  - delete
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods/attach
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get

--- a/configs/etcd-defrag-rd/rings/ring-2/base/base-snapshot/cronjob.yaml
+++ b/configs/etcd-defrag-rd/rings/ring-2/base/base-snapshot/cronjob.yaml
@@ -5,7 +5,7 @@ metadata:
   name: etcd-maintenance
   namespace: etcd-maintenance
 spec:
-  schedule: "*/10 * * * *"
+  schedule: "*/5 * * * *"
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 50
   jobTemplate:

--- a/configs/etcd-defrag-rd/rings/ring-2/base/base-snapshot/cronjob.yaml
+++ b/configs/etcd-defrag-rd/rings/ring-2/base/base-snapshot/cronjob.yaml
@@ -1,0 +1,49 @@
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: etcd-maintenance
+  namespace: etcd-maintenance
+spec:
+  schedule: "*/10 * * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 50
+  jobTemplate:
+    spec:
+      activeDeadlineSeconds: 600
+      template:
+        spec:
+          serviceAccountName: etcd-maintenance
+          restartPolicy: OnFailure
+          containers:
+            - name: etcd-maintenance
+              image: registry.redhat.io/openshift4/ose-cli:v4.12
+              imagePullPolicy: IfNotPresent
+              securityContext:
+                runAsNonRoot: true
+                readOnlyRootFilesystem: true
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+              env:
+              - name: IMAGE
+                value: quay.io/konflux-ci/etcd-defrag@sha256:7a19f7b9b7bbdeb4f8d51e06d3319ac5c0555094fcbf2093d6e4d71f136afb55
+              - name: FRAGMENTATION_THRESHOLD
+                value: "30"
+              - name: DISK_USAGE_THRESHOLD
+                value: "75" # threshold of etcd-shield is 80% so we only defrag if we get close to that
+              - name: RECLAIM_SPACE_THRESHOLD
+                value: "1024"
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  etcd_pod=$(timeout 30s oc get pod -l app=etcd -oname -n openshift-etcd | awk -F"/" 'NR==1{ print $2 }')
+                  timeout 9m oc -n openshift-etcd debug pod/${etcd_pod} \
+                    fragmentationThreshold="${FRAGMENTATION_THRESHOLD}" \
+                    diskUsageThreshold="${DISK_USAGE_THRESHOLD}" \
+                    reclaimSpaceThreshold="${RECLAIM_SPACE_THRESHOLD}" \
+                    --image="${IMAGE}" \
+                    --one-container=true \
+                    -- /bin/sh -c "chmod +x /opt/defrag.sh && /opt/defrag.sh"

--- a/configs/etcd-defrag-rd/rings/ring-2/base/base-snapshot/kustomization.yaml
+++ b/configs/etcd-defrag-rd/rings/ring-2/base/base-snapshot/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - cluster-role.yaml
+  - role-binding.yaml
+  - serviceaccount.yaml
+  - cronjob.yaml
+

--- a/configs/etcd-defrag-rd/rings/ring-2/base/base-snapshot/namespace.yaml
+++ b/configs/etcd-defrag-rd/rings/ring-2/base/base-snapshot/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: etcd-maintenance

--- a/configs/etcd-defrag-rd/rings/ring-2/base/base-snapshot/role-binding.yaml
+++ b/configs/etcd-defrag-rd/rings/ring-2/base/base-snapshot/role-binding.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: etcd-maintenance-binding
+  namespace: etcd-maintenance
+subjects:
+- kind: ServiceAccount
+  name: etcd-maintenance
+  namespace: etcd-maintenance
+roleRef:
+  kind: ClusterRole
+  name: etcd-maintenance-role
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: etcd-maintenance-binding
+  namespace: openshift-etcd
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: etcd-maintenance-role
+subjects:
+- kind: ServiceAccount
+  name: etcd-maintenance
+  namespace: etcd-maintenance

--- a/configs/etcd-defrag-rd/rings/ring-2/base/base-snapshot/serviceaccount.yaml
+++ b/configs/etcd-defrag-rd/rings/ring-2/base/base-snapshot/serviceaccount.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: etcd-maintenance
+  namespace: etcd-maintenance

--- a/configs/etcd-defrag-rd/rings/ring-2/base/kustomization.yaml
+++ b/configs/etcd-defrag-rd/rings/ring-2/base/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - base-snapshot

--- a/configs/etcd-defrag-rd/rings/ring-2/base/kustomization.yaml
+++ b/configs/etcd-defrag-rd/rings/ring-2/base/kustomization.yaml
@@ -2,3 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - base-snapshot
+
+images:
+  - name:  quay.io/konflux-ci/etcd-defrag
+    newTag: 7a19f7b9b7bbdeb4f8d51e06d3319ac5c0555094fcbf2093d6e4d71f136afb55

--- a/configs/etcd-defrag-rd/rings/ring-2/kflux-fedora-01/kustomization.yaml
+++ b/configs/etcd-defrag-rd/rings/ring-2/kflux-fedora-01/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../base

--- a/configs/etcd-defrag-rd/rings/ring-2/kflux-lw-p01/kustomization.yaml
+++ b/configs/etcd-defrag-rd/rings/ring-2/kflux-lw-p01/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../base

--- a/configs/etcd-defrag-rd/rings/ring-2/kflux-ocp-p01/kustomization.yaml
+++ b/configs/etcd-defrag-rd/rings/ring-2/kflux-ocp-p01/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../base

--- a/configs/etcd-defrag-rd/rings/ring-2/kflux-osp-p01/kustomization.yaml
+++ b/configs/etcd-defrag-rd/rings/ring-2/kflux-osp-p01/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../base

--- a/configs/etcd-defrag-rd/rings/ring-2/kflux-prd-rh03/kustomization.yaml
+++ b/configs/etcd-defrag-rd/rings/ring-2/kflux-prd-rh03/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../base

--- a/configs/etcd-defrag-rd/rings/ring-2/kflux-rhel-p01/kustomization.yaml
+++ b/configs/etcd-defrag-rd/rings/ring-2/kflux-rhel-p01/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../base

--- a/configs/etcd-defrag-rd/rings/ring-2/stone-prod-p01/kustomization.yaml
+++ b/configs/etcd-defrag-rd/rings/ring-2/stone-prod-p01/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../base

--- a/configs/etcd-defrag-rd/rings/ring-3/base/base-snapshot/cluster-role.yaml
+++ b/configs/etcd-defrag-rd/rings/ring-3/base/base-snapshot/cluster-role.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: etcd-maintenance-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - list
+  - get
+  - create
+  - delete
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods/attach
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get

--- a/configs/etcd-defrag-rd/rings/ring-3/base/base-snapshot/cronjob.yaml
+++ b/configs/etcd-defrag-rd/rings/ring-3/base/base-snapshot/cronjob.yaml
@@ -5,7 +5,7 @@ metadata:
   name: etcd-maintenance
   namespace: etcd-maintenance
 spec:
-  schedule: "*/10 * * * *"
+  schedule: "*/5 * * * *"
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 50
   jobTemplate:

--- a/configs/etcd-defrag-rd/rings/ring-3/base/base-snapshot/cronjob.yaml
+++ b/configs/etcd-defrag-rd/rings/ring-3/base/base-snapshot/cronjob.yaml
@@ -1,0 +1,49 @@
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: etcd-maintenance
+  namespace: etcd-maintenance
+spec:
+  schedule: "*/10 * * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 50
+  jobTemplate:
+    spec:
+      activeDeadlineSeconds: 600
+      template:
+        spec:
+          serviceAccountName: etcd-maintenance
+          restartPolicy: OnFailure
+          containers:
+            - name: etcd-maintenance
+              image: registry.redhat.io/openshift4/ose-cli:v4.12
+              imagePullPolicy: IfNotPresent
+              securityContext:
+                runAsNonRoot: true
+                readOnlyRootFilesystem: true
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+              env:
+              - name: IMAGE
+                value: quay.io/konflux-ci/etcd-defrag@sha256:7a19f7b9b7bbdeb4f8d51e06d3319ac5c0555094fcbf2093d6e4d71f136afb55
+              - name: FRAGMENTATION_THRESHOLD
+                value: "30"
+              - name: DISK_USAGE_THRESHOLD
+                value: "75" # threshold of etcd-shield is 80% so we only defrag if we get close to that
+              - name: RECLAIM_SPACE_THRESHOLD
+                value: "1024"
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  etcd_pod=$(timeout 30s oc get pod -l app=etcd -oname -n openshift-etcd | awk -F"/" 'NR==1{ print $2 }')
+                  timeout 9m oc -n openshift-etcd debug pod/${etcd_pod} \
+                    fragmentationThreshold="${FRAGMENTATION_THRESHOLD}" \
+                    diskUsageThreshold="${DISK_USAGE_THRESHOLD}" \
+                    reclaimSpaceThreshold="${RECLAIM_SPACE_THRESHOLD}" \
+                    --image="${IMAGE}" \
+                    --one-container=true \
+                    -- /bin/sh -c "chmod +x /opt/defrag.sh && /opt/defrag.sh"

--- a/configs/etcd-defrag-rd/rings/ring-3/base/base-snapshot/kustomization.yaml
+++ b/configs/etcd-defrag-rd/rings/ring-3/base/base-snapshot/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - cluster-role.yaml
+  - role-binding.yaml
+  - serviceaccount.yaml
+  - cronjob.yaml
+

--- a/configs/etcd-defrag-rd/rings/ring-3/base/base-snapshot/namespace.yaml
+++ b/configs/etcd-defrag-rd/rings/ring-3/base/base-snapshot/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: etcd-maintenance

--- a/configs/etcd-defrag-rd/rings/ring-3/base/base-snapshot/role-binding.yaml
+++ b/configs/etcd-defrag-rd/rings/ring-3/base/base-snapshot/role-binding.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: etcd-maintenance-binding
+  namespace: etcd-maintenance
+subjects:
+- kind: ServiceAccount
+  name: etcd-maintenance
+  namespace: etcd-maintenance
+roleRef:
+  kind: ClusterRole
+  name: etcd-maintenance-role
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: etcd-maintenance-binding
+  namespace: openshift-etcd
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: etcd-maintenance-role
+subjects:
+- kind: ServiceAccount
+  name: etcd-maintenance
+  namespace: etcd-maintenance

--- a/configs/etcd-defrag-rd/rings/ring-3/base/base-snapshot/serviceaccount.yaml
+++ b/configs/etcd-defrag-rd/rings/ring-3/base/base-snapshot/serviceaccount.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: etcd-maintenance
+  namespace: etcd-maintenance

--- a/configs/etcd-defrag-rd/rings/ring-3/base/kustomization.yaml
+++ b/configs/etcd-defrag-rd/rings/ring-3/base/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - base-snapshot

--- a/configs/etcd-defrag-rd/rings/ring-3/base/kustomization.yaml
+++ b/configs/etcd-defrag-rd/rings/ring-3/base/kustomization.yaml
@@ -2,3 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - base-snapshot
+
+images:
+  - name:  quay.io/konflux-ci/etcd-defrag
+    newTag: 7a19f7b9b7bbdeb4f8d51e06d3319ac5c0555094fcbf2093d6e4d71f136afb55

--- a/configs/etcd-defrag-rd/rings/ring-3/stone-prd-rh01/kustomization.yaml
+++ b/configs/etcd-defrag-rd/rings/ring-3/stone-prd-rh01/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../base

--- a/configs/etcd-defrag-rd/rings/ring-3/stone-prod-p02/kustomization.yaml
+++ b/configs/etcd-defrag-rd/rings/ring-3/stone-prod-p02/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../base

--- a/configs/etcd-defrag-rd/rings/ring-4/base/base-snapshot/cluster-role.yaml
+++ b/configs/etcd-defrag-rd/rings/ring-4/base/base-snapshot/cluster-role.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: etcd-maintenance-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - list
+  - get
+  - create
+  - delete
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods/attach
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get

--- a/configs/etcd-defrag-rd/rings/ring-4/base/base-snapshot/cronjob.yaml
+++ b/configs/etcd-defrag-rd/rings/ring-4/base/base-snapshot/cronjob.yaml
@@ -5,7 +5,7 @@ metadata:
   name: etcd-maintenance
   namespace: etcd-maintenance
 spec:
-  schedule: "*/10 * * * *"
+  schedule: "*/5 * * * *"
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 50
   jobTemplate:

--- a/configs/etcd-defrag-rd/rings/ring-4/base/base-snapshot/cronjob.yaml
+++ b/configs/etcd-defrag-rd/rings/ring-4/base/base-snapshot/cronjob.yaml
@@ -1,0 +1,49 @@
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: etcd-maintenance
+  namespace: etcd-maintenance
+spec:
+  schedule: "*/10 * * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 50
+  jobTemplate:
+    spec:
+      activeDeadlineSeconds: 600
+      template:
+        spec:
+          serviceAccountName: etcd-maintenance
+          restartPolicy: OnFailure
+          containers:
+            - name: etcd-maintenance
+              image: registry.redhat.io/openshift4/ose-cli:v4.12
+              imagePullPolicy: IfNotPresent
+              securityContext:
+                runAsNonRoot: true
+                readOnlyRootFilesystem: true
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+              env:
+              - name: IMAGE
+                value: quay.io/konflux-ci/etcd-defrag@sha256:7a19f7b9b7bbdeb4f8d51e06d3319ac5c0555094fcbf2093d6e4d71f136afb55
+              - name: FRAGMENTATION_THRESHOLD
+                value: "30"
+              - name: DISK_USAGE_THRESHOLD
+                value: "75" # threshold of etcd-shield is 80% so we only defrag if we get close to that
+              - name: RECLAIM_SPACE_THRESHOLD
+                value: "1024"
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  etcd_pod=$(timeout 30s oc get pod -l app=etcd -oname -n openshift-etcd | awk -F"/" 'NR==1{ print $2 }')
+                  timeout 9m oc -n openshift-etcd debug pod/${etcd_pod} \
+                    fragmentationThreshold="${FRAGMENTATION_THRESHOLD}" \
+                    diskUsageThreshold="${DISK_USAGE_THRESHOLD}" \
+                    reclaimSpaceThreshold="${RECLAIM_SPACE_THRESHOLD}" \
+                    --image="${IMAGE}" \
+                    --one-container=true \
+                    -- /bin/sh -c "chmod +x /opt/defrag.sh && /opt/defrag.sh"

--- a/configs/etcd-defrag-rd/rings/ring-4/base/base-snapshot/kustomization.yaml
+++ b/configs/etcd-defrag-rd/rings/ring-4/base/base-snapshot/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - cluster-role.yaml
+  - role-binding.yaml
+  - serviceaccount.yaml
+  - cronjob.yaml
+

--- a/configs/etcd-defrag-rd/rings/ring-4/base/base-snapshot/namespace.yaml
+++ b/configs/etcd-defrag-rd/rings/ring-4/base/base-snapshot/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: etcd-maintenance

--- a/configs/etcd-defrag-rd/rings/ring-4/base/base-snapshot/role-binding.yaml
+++ b/configs/etcd-defrag-rd/rings/ring-4/base/base-snapshot/role-binding.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: etcd-maintenance-binding
+  namespace: etcd-maintenance
+subjects:
+- kind: ServiceAccount
+  name: etcd-maintenance
+  namespace: etcd-maintenance
+roleRef:
+  kind: ClusterRole
+  name: etcd-maintenance-role
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: etcd-maintenance-binding
+  namespace: openshift-etcd
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: etcd-maintenance-role
+subjects:
+- kind: ServiceAccount
+  name: etcd-maintenance
+  namespace: etcd-maintenance

--- a/configs/etcd-defrag-rd/rings/ring-4/base/base-snapshot/serviceaccount.yaml
+++ b/configs/etcd-defrag-rd/rings/ring-4/base/base-snapshot/serviceaccount.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: etcd-maintenance
+  namespace: etcd-maintenance

--- a/configs/etcd-defrag-rd/rings/ring-4/base/kustomization.yaml
+++ b/configs/etcd-defrag-rd/rings/ring-4/base/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - base-snapshot

--- a/configs/etcd-defrag-rd/rings/ring-4/base/kustomization.yaml
+++ b/configs/etcd-defrag-rd/rings/ring-4/base/kustomization.yaml
@@ -2,3 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - base-snapshot
+
+images:
+  - name:  quay.io/konflux-ci/etcd-defrag
+    newTag: 7a19f7b9b7bbdeb4f8d51e06d3319ac5c0555094fcbf2093d6e4d71f136afb55

--- a/configs/etcd-defrag-rd/rings/ring-4/kflux-prd-rh02/kustomization.yaml
+++ b/configs/etcd-defrag-rd/rings/ring-4/kflux-prd-rh02/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../base


### PR DESCRIPTION
### Summary of Changes
- Creation of rings structure for production clusters according [directory structure documentation](https://github.com/redhat-appstudio/infra-deployments/blob/main/docs/ring-deployments/directory-layout.md) and copying/migration of etcd-defrag cluster configuration

This is affecting rings 2,3 and 4 as defined in the [directory structure documentation](https://github.com/redhat-appstudio/infra-deployments/blob/main/docs/ring-deployments/directory-layout.md)
** For ring 2 kflux-fedora-01, kflux-lw-p01, kflux-ocp-p01, kflux-osp-p01k, flux-prd-rh03, kflux-rhel-p01 and stone-prod-p01

### Validation
- kustomize build has been performed on the current configuration (config/etcd-defrag/production) the new (config/etcd-defrag-rd/rings/rings{2,3,4}) directories to render config files, giving the same output for all clusters, with exception of the cronjob that has some improvements suggested by reviewers (mostly security-related)
- Also kustomize build argo-cd-apps/overlays/rd-production output ApplicationSet with the rings list elements ring-{2,3,4} for etcd-defrag

### Verification
The changes have been implemented in Staging in PR https://github.com/redhat-appstudio/infra-deployments/pull/13482

### Risk Level
**Risk Level**: Medium
**Reasoning**: No changes in current platforms, the new directories are a new structure. Changes will be done in a controlled form and have been already tested in staging. In any case, the rendering (using oc kustomize) shown that the output is identical to current one (see Validation section above) 
**Rollback Strategy**: Reversing this PR + manual sync in the current/old repository-validator ApplicationSet will make the structure back as before changes

[KFLUXINFRA-4290](https://redhat.atlassian.net/browse/KFLUXINFRA-4290)

[KFLUXINFRA-4290]: https://redhat.atlassian.net/browse/KFLUXINFRA-4290?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ