### PR TITLE
upgrade kubearchive to 1.23.0 on staging

### DIFF
--- a/components/kubearchive/development/kubearchive.yaml
+++ b/components/kubearchive/development/kubearchive.yaml
@@ -5,7 +5,7 @@ metadata:
     app.kubernetes.io/component: namespace
     app.kubernetes.io/name: kubearchive
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.22.2
+    app.kubernetes.io/version: v1.23.0
   name: kubearchive
 ---
 apiVersion: apiextensions.k8s.io/v1
@@ -552,7 +552,7 @@ metadata:
     app.kubernetes.io/component: api-server
     app.kubernetes.io/name: kubearchive-api-server
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.22.2
+    app.kubernetes.io/version: v1.23.0
   name: kubearchive-api-server
   namespace: kubearchive
 ---
@@ -563,7 +563,7 @@ metadata:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: kubearchive-vacuum
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.22.2
+    app.kubernetes.io/version: v1.23.0
   name: kubearchive-cluster-vacuum
   namespace: kubearchive
 ---
@@ -574,7 +574,7 @@ metadata:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: kubearchive-operator
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.22.2
+    app.kubernetes.io/version: v1.23.0
   name: kubearchive-operator
   namespace: kubearchive
 ---
@@ -585,7 +585,7 @@ metadata:
     app.kubernetes.io/component: sink
     app.kubernetes.io/name: kubearchive-sink
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.22.2
+    app.kubernetes.io/version: v1.23.0
   name: kubearchive-sink
   namespace: kubearchive
 ---
@@ -596,7 +596,7 @@ metadata:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: kubearchive-operator-leader-election
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.22.2
+    app.kubernetes.io/version: v1.23.0
   name: kubearchive-operator-leader-election
   namespace: kubearchive
 rules:
@@ -639,7 +639,7 @@ metadata:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: kubearchive-vacuum
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.22.2
+    app.kubernetes.io/version: v1.23.0
   name: kubearchive-vacuum
   namespace: kubearchive
 rules:
@@ -659,7 +659,7 @@ metadata:
     app.kubernetes.io/component: api-server
     app.kubernetes.io/name: kubearchive-api-server
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.22.2
+    app.kubernetes.io/version: v1.23.0
   name: kubearchive-api-server
 rules:
   - apiGroups:
@@ -677,7 +677,7 @@ metadata:
   labels:
     app.kubernetes.io/name: kubearchive-edit
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.22.2
+    app.kubernetes.io/version: v1.23.0
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
   name: kubearchive-edit
 rules:
@@ -791,7 +791,7 @@ metadata:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: kubearchive-operator-config-editor
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.22.2
+    app.kubernetes.io/version: v1.23.0
   name: kubearchive-operator-config-editor
 rules:
   - apiGroups:
@@ -820,7 +820,7 @@ metadata:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: kubearchive-operator-config-viewer
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.22.2
+    app.kubernetes.io/version: v1.23.0
   name: kubearchive-operator-config-viewer
 rules:
   - apiGroups:
@@ -844,7 +844,7 @@ metadata:
   labels:
     app.kubernetes.io/name: kubearchive-view
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.22.2
+    app.kubernetes.io/version: v1.23.0
     rbac.authorization.k8s.io/aggregate-to-view: "true"
   name: kubearchive-view
 rules:
@@ -868,7 +868,7 @@ metadata:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: kubearchive-operator-leader-election
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.22.2
+    app.kubernetes.io/version: v1.23.0
   name: kubearchive-operator-leader-election
   namespace: kubearchive
 roleRef:
@@ -887,7 +887,7 @@ metadata:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: kubearchive-vacuum
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.22.2
+    app.kubernetes.io/version: v1.23.0
   name: kubearchive-vacuum
   namespace: kubearchive
 roleRef:
@@ -906,7 +906,7 @@ metadata:
     app.kubernetes.io/component: api-server
     app.kubernetes.io/name: kubearchive-api-server
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.22.2
+    app.kubernetes.io/version: v1.23.0
   name: kubearchive-api-server
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -924,7 +924,7 @@ metadata:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: kubearchive-operator
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.22.2
+    app.kubernetes.io/version: v1.23.0
   name: kubearchive-operator
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -943,7 +943,7 @@ metadata:
     app.kubernetes.io/component: logging
     app.kubernetes.io/name: kubearchive-logging-reader
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.22.2
+    app.kubernetes.io/version: v1.23.0
   name: kubearchive-logging-reader
   namespace: kubearchive
 ---
@@ -955,7 +955,7 @@ metadata:
     app.kubernetes.io/component: logging
     app.kubernetes.io/name: kubearchive-logging-writer
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.22.2
+    app.kubernetes.io/version: v1.23.0
   name: kubearchive-logging-writer
   namespace: kubearchive
 ---
@@ -972,7 +972,7 @@ metadata:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: kubearchive-operator
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.22.2
+    app.kubernetes.io/version: v1.23.0
   name: kubearchive-operator
   namespace: kubearchive
 ---
@@ -990,7 +990,7 @@ metadata:
     app.kubernetes.io/component: database
     app.kubernetes.io/name: kubearchive-database-credentials
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.22.2
+    app.kubernetes.io/version: v1.23.0
   name: kubearchive-database-credentials
   namespace: kubearchive
 type: Opaque
@@ -1002,7 +1002,7 @@ metadata:
     app.kubernetes.io/component: logging
     app.kubernetes.io/name: kubearchive-logging
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.22.2
+    app.kubernetes.io/version: v1.23.0
   name: kubearchive-logging
   namespace: kubearchive
 stringData:
@@ -1016,7 +1016,7 @@ metadata:
     app.kubernetes.io/component: api-server
     app.kubernetes.io/name: kubearchive-api-server
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.22.2
+    app.kubernetes.io/version: v1.23.0
   name: kubearchive-api-server
   namespace: kubearchive
 spec:
@@ -1035,7 +1035,7 @@ metadata:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: kubearchive-operator-webhooks
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.22.2
+    app.kubernetes.io/version: v1.23.0
   name: kubearchive-operator-webhooks
   namespace: kubearchive
 spec:
@@ -1058,7 +1058,7 @@ metadata:
     app.kubernetes.io/component: sink
     app.kubernetes.io/name: kubearchive-sink
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.22.2
+    app.kubernetes.io/version: v1.23.0
   name: kubearchive-sink
   namespace: kubearchive
 spec:
@@ -1076,7 +1076,7 @@ metadata:
     app.kubernetes.io/component: api-server
     app.kubernetes.io/name: kubearchive-api-server
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.22.2
+    app.kubernetes.io/version: v1.23.0
   name: kubearchive-api-server
   namespace: kubearchive
 spec:
@@ -1127,10 +1127,28 @@ spec:
               value: /data/logging
             - name: AUTH_IMPERSONATE
               value: "false"
+            - name: DATABASE_MAX_OPEN_CONNS
+              value: "25"
+            - name: DATABASE_MAX_IDLE_CONNS
+              value: "10"
+            - name: DATABASE_CONN_MAX_LIFETIME
+              value: "10m"
+            - name: DATABASE_CONN_MAX_IDLE_TIME
+              value: "3m"
+            - name: KUBEARCHIVE_QUERY_TIMEOUT 
+              value: "5m"
+            - name: API_RATE_LIMIT_OVERALL_RPS
+              value: "200"
+            - name: API_RATE_LIMIT_LOG_RPS
+              value: "20"
+            - name: API_RATE_LIMIT_OVERALL_BURST
+              value: "600"
+            - name: API_RATE_LIMIT_LOG_BURST
+              value: "60"
           envFrom:
             - secretRef:
                 name: kubearchive-database-credentials
-          image: quay.io/kubearchive/api:v1.22.2@sha256:e68a90000c9d78b2c63e01c8edd0b870cfbda5a3e518817c4d0590bc57aaa0d7
+          image: quay.io/kubearchive/api:v1.23.0@sha256:e2b69c81967cd9fb0b7e6b75de19a5c1271554e4991c945f718e3f6af09d82af
           livenessProbe:
             httpGet:
               path: /livez
@@ -1182,7 +1200,7 @@ metadata:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: kubearchive-operator
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.22.2
+    app.kubernetes.io/version: v1.23.0
   name: kubearchive-operator
   namespace: kubearchive
 spec:
@@ -1232,7 +1250,7 @@ spec:
               valueFrom:
                 resourceFieldRef:
                   resource: limits.cpu
-          image: quay.io/kubearchive/operator:v1.22.2@sha256:5f35ebd89eb8c7637d2b45d9587fa8920192258c14e78b8c23574375fdbb1303
+          image: quay.io/kubearchive/operator:v1.23.0@sha256:7253603c3c9a76e223f86baea26a53e1cb685a401bd0e4264ae44f82a8c5ec37
           livenessProbe:
             httpGet:
               path: /healthz
@@ -1294,7 +1312,7 @@ metadata:
     app.kubernetes.io/component: sink
     app.kubernetes.io/name: kubearchive-sink
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.22.2
+    app.kubernetes.io/version: v1.23.0
   name: kubearchive-sink
   namespace: kubearchive
 spec:
@@ -1346,7 +1364,7 @@ spec:
           envFrom:
             - secretRef:
                 name: kubearchive-database-credentials
-          image: quay.io/kubearchive/sink:v1.22.2@sha256:a52a10ce7219398f17b8b6ac43e62700087e7313b2418db2c4b8cc713a447f4e
+          image: quay.io/kubearchive/sink:v1.23.0@sha256:5702d91369e3bd2b786fbe6baf03ce747f7564fa16492b5e0823aa3c17f1f8ca
           livenessProbe:
             httpGet:
               path: /livez
@@ -1387,7 +1405,7 @@ metadata:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: kubearchive-vacuum
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.22.2
+    app.kubernetes.io/version: v1.23.0
   name: cluster-vacuum
   namespace: kubearchive
 spec:
@@ -1408,7 +1426,7 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
-              image: quay.io/kubearchive/vacuum:v1.22.2@sha256:9e61f19686a463e2468eaf82bc29e5165b57f8f77f69c7146d7a4c4e3035dd2f
+              image: quay.io/kubearchive/vacuum:v1.23.0@sha256:8d206418525c6a1b36824ef54921fed337210b3ad78e72977af2bf4bdcc19748
               name: vacuum
           restartPolicy: Never
           serviceAccount: kubearchive-cluster-vacuum
@@ -1422,7 +1440,7 @@ metadata:
     app.kubernetes.io/component: kubearchive
     app.kubernetes.io/name: kubearchive-schema-migration
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.22.2
+    app.kubernetes.io/version: v1.23.0
   name: kubearchive-schema-migration
   namespace: kubearchive
 spec:
@@ -1438,7 +1456,7 @@ spec:
           envFrom:
             - secretRef:
                 name: kubearchive-database-credentials
-          image: quay.io/kubearchive/postgresql:v1.22.2@sha256:c8068879b345360213123aa03b6eeb7f9f1e22e58f6e2d258c751dafc6a4f7d4
+          image: quay.io/kubearchive/postgresql:v1.23.0@sha256:2d4a912f5e2337648ed87049b94367a76b8fbc55d4ef82e123262ebf1fc552f4
           name: migration
           resources:
             limits:
@@ -1459,7 +1477,7 @@ metadata:
     app.kubernetes.io/component: api-server
     app.kubernetes.io/name: kubearchive-api-server-certificate
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.22.2
+    app.kubernetes.io/version: v1.23.0
   name: kubearchive-api-server-certificate
   namespace: kubearchive
 spec:
@@ -1493,7 +1511,7 @@ metadata:
     app.kubernetes.io/component: certs
     app.kubernetes.io/name: kubearchive-ca
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.22.2
+    app.kubernetes.io/version: v1.23.0
   name: kubearchive-ca
   namespace: kubearchive
 spec:
@@ -1515,7 +1533,7 @@ metadata:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: kubearchive-operator-certificate
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.22.2
+    app.kubernetes.io/version: v1.23.0
   name: kubearchive-operator-certificate
   namespace: kubearchive
 spec:
@@ -1534,7 +1552,7 @@ metadata:
     app.kubernetes.io/component: certs
     app.kubernetes.io/name: kubearchive
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.22.2
+    app.kubernetes.io/version: v1.23.0
   name: kubearchive
   namespace: kubearchive
 spec:
@@ -1548,7 +1566,7 @@ metadata:
     app.kubernetes.io/component: certs
     app.kubernetes.io/name: kubearchive-ca
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.22.2
+    app.kubernetes.io/version: v1.23.0
   name: kubearchive-ca
   namespace: kubearchive
 spec:
@@ -1563,7 +1581,7 @@ metadata:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: kubearchive-mutating-webhook-configuration
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.22.2
+    app.kubernetes.io/version: v1.23.0
   name: kubearchive-mutating-webhook-configuration
 webhooks:
   - admissionReviewVersions:
@@ -1676,7 +1694,7 @@ metadata:
     app.kubernetes.io/component: operator
     app.kubernetes.io/name: kubearchive-validating-webhook-configuration
     app.kubernetes.io/part-of: kubearchive
-    app.kubernetes.io/version: v1.22.2
+    app.kubernetes.io/version: v1.23.0
   name: kubearchive-validating-webhook-configuration
 webhooks:
   - admissionReviewVersions:

--- a/components/kubearchive/development/kubearchive.yaml
+++ b/components/kubearchive/development/kubearchive.yaml
@@ -1135,7 +1135,7 @@ spec:
               value: "10m"
             - name: DATABASE_CONN_MAX_IDLE_TIME
               value: "3m"
-            - name: KUBEARCHIVE_QUERY_TIMEOUT 
+            - name: KUBEARCHIVE_QUERY_TIMEOUT
               value: "5m"
             - name: API_RATE_LIMIT_OVERALL_RPS
               value: "200"

--- a/components/kubearchive/development/kustomization.yaml
+++ b/components/kubearchive/development/kustomization.yaml
@@ -99,7 +99,7 @@ patches:
               spec:
                 containers:
                   - name: vacuum
-                    image: quay.io/kubearchive/vacuum:v1.22.2
+                    image: quay.io/kubearchive/vacuum:v1.23.0
   - patch: |-
       apiVersion: batch/v1
       kind: CronJob
@@ -112,7 +112,7 @@ patches:
               spec:
                 containers:
                   - name: vacuum
-                    image: quay.io/kubearchive/vacuum:v1.22.2
+                    image: quay.io/kubearchive/vacuum:v1.23.0
   - patch: |-
       apiVersion: batch/v1
       kind: CronJob
@@ -125,7 +125,7 @@ patches:
               spec:
                 containers:
                   - name: vacuum
-                    image: quay.io/kubearchive/vacuum:v1.22.2
+                    image: quay.io/kubearchive/vacuum:v1.23.0
   # Ensure database is ready before schema-migration job runs
   - patch: |-
       apiVersion: apps/v1
@@ -184,7 +184,7 @@ patches:
     patch: |-
       - op: replace
         path: /metadata/name
-        value: kubearchive-schema-migration-v13-v1.22.2
+        value: kubearchive-schema-migration-v13-v1.23.0
   # These patches add an annotation so an OpenShift service
   # creates the TLS secrets instead of Cert Manager
   - patch: |-


### PR DESCRIPTION
## Summary
- Upgrade kubearchive staging from v1.22.2 to v1.23.0
- Updates `development/kubearchive.yaml` release manifest (images + version labels)
- Bumps vacuum image tags in `development/kustomization.yaml`
- No schema migration version change needed

## Test plan
- [ ] Verify ArgoCD syncs successfully on staging clusters
- [ ] Confirm kubearchive pods start with v1.22.1 images
