### PR TITLE
KFLUXVNGD-1283: enable Cargo config.json subFilters on production (ring-2, ring-3)

### DIFF
--- a/components/squid/production/kflux-ocp-p01/caching-helm-generator.yaml
+++ b/components/squid/production/kflux-ocp-p01/caching-helm-generator.yaml
@@ -4,7 +4,7 @@ metadata:
   name: caching-helm
 name: caching-helm
 repo: oci://quay.io/konflux-ci/caching
-version: 0.1.1775+d865e45
+version: 0.1.1889+ca96506
 valuesInline:
   squid:
     enabled: true
@@ -28,6 +28,16 @@ valuesInline:
     auth:
       enabled: true
       secretName: artifact-registry-credentials
+    subFilters:
+      - location: '^/repository/cargo-proxy/config\.json$'
+        types:
+          - application/json
+        once: false
+        filters:
+          - string: '"auth-required":true'
+            replacement: '"auth-required":false'
+          - string: 'https://red-hat.repo.sonatype.app'
+            replacement: 'https://artifact-registry-proxy.caching.svc.cluster.local'
     cache:
       allowList:
         # Cache all traffic to nexus repositories

--- a/components/squid/production/kflux-prd-rh02/caching-helm-generator.yaml
+++ b/components/squid/production/kflux-prd-rh02/caching-helm-generator.yaml
@@ -4,7 +4,7 @@ metadata:
   name: caching-helm
 name: caching-helm
 repo: oci://quay.io/konflux-ci/caching
-version: 0.1.1775+d865e45
+version: 0.1.1889+ca96506
 valuesInline:
   squid:
     enabled: true
@@ -28,6 +28,16 @@ valuesInline:
     auth:
       enabled: true
       secretName: artifact-registry-credentials
+    subFilters:
+      - location: '^/repository/cargo-proxy/config\.json$'
+        types:
+          - application/json
+        once: false
+        filters:
+          - string: '"auth-required":true'
+            replacement: '"auth-required":false'
+          - string: 'https://red-hat.repo.sonatype.app'
+            replacement: 'https://artifact-registry-proxy.caching.svc.cluster.local'
     cache:
       allowList:
         # Cache all traffic to nexus repositories

--- a/components/squid/production/kflux-prd-rh03/caching-helm-generator.yaml
+++ b/components/squid/production/kflux-prd-rh03/caching-helm-generator.yaml
@@ -4,7 +4,7 @@ metadata:
   name: caching-helm
 name: caching-helm
 repo: oci://quay.io/konflux-ci/caching
-version: 0.1.1775+d865e45
+version: 0.1.1889+ca96506
 valuesInline:
   squid:
     enabled: true
@@ -28,6 +28,16 @@ valuesInline:
     auth:
       enabled: true
       secretName: artifact-registry-credentials
+    subFilters:
+      - location: '^/repository/cargo-proxy/config\.json$'
+        types:
+          - application/json
+        once: false
+        filters:
+          - string: '"auth-required":true'
+            replacement: '"auth-required":false'
+          - string: 'https://red-hat.repo.sonatype.app'
+            replacement: 'https://artifact-registry-proxy.caching.svc.cluster.local'
     cache:
       allowList:
         # Cache all traffic to nexus repositories

--- a/components/squid/production/kflux-rhel-p01/caching-helm-generator.yaml
+++ b/components/squid/production/kflux-rhel-p01/caching-helm-generator.yaml
@@ -4,7 +4,7 @@ metadata:
   name: caching-helm
 name: caching-helm
 repo: oci://quay.io/konflux-ci/caching
-version: 0.1.1775+d865e45
+version: 0.1.1889+ca96506
 valuesInline:
   squid:
     enabled: true
@@ -28,6 +28,16 @@ valuesInline:
     auth:
       enabled: true
       secretName: artifact-registry-credentials
+    subFilters:
+      - location: '^/repository/cargo-proxy/config\.json$'
+        types:
+          - application/json
+        once: false
+        filters:
+          - string: '"auth-required":true'
+            replacement: '"auth-required":false'
+          - string: 'https://red-hat.repo.sonatype.app'
+            replacement: 'https://artifact-registry-proxy.caching.svc.cluster.local'
     cache:
       allowList:
         # Cache all traffic to nexus repositories

--- a/components/squid/production/stone-prd-rh01/caching-helm-generator.yaml
+++ b/components/squid/production/stone-prd-rh01/caching-helm-generator.yaml
@@ -4,7 +4,7 @@ metadata:
   name: caching-helm
 name: caching-helm
 repo: oci://quay.io/konflux-ci/caching
-version: 0.1.1775+d865e45
+version: 0.1.1889+ca96506
 valuesInline:
   squid:
     enabled: true
@@ -28,6 +28,16 @@ valuesInline:
     auth:
       enabled: true
       secretName: artifact-registry-credentials
+    subFilters:
+      - location: '^/repository/cargo-proxy/config\.json$'
+        types:
+          - application/json
+        once: false
+        filters:
+          - string: '"auth-required":true'
+            replacement: '"auth-required":false'
+          - string: 'https://red-hat.repo.sonatype.app'
+            replacement: 'https://artifact-registry-proxy.caching.svc.cluster.local'
     cache:
       allowList:
         # Cache all traffic to nexus repositories

--- a/components/squid/production/stone-prod-p02/caching-helm-generator.yaml
+++ b/components/squid/production/stone-prod-p02/caching-helm-generator.yaml
@@ -4,7 +4,7 @@ metadata:
   name: caching-helm
 name: caching-helm
 repo: oci://quay.io/konflux-ci/caching
-version: 0.1.1775+d865e45
+version: 0.1.1889+ca96506
 valuesInline:
   squid:
     enabled: true
@@ -28,6 +28,16 @@ valuesInline:
     auth:
       enabled: true
       secretName: artifact-registry-credentials
+    subFilters:
+      - location: '^/repository/cargo-proxy/config\.json$'
+        types:
+          - application/json
+        once: false
+        filters:
+          - string: '"auth-required":true'
+            replacement: '"auth-required":false'
+          - string: 'https://red-hat.repo.sonatype.app'
+            replacement: 'https://artifact-registry-proxy.caching.svc.cluster.local'
     cache:
       allowList:
         # Cache all traffic to nexus repositories


### PR DESCRIPTION
Promote ring-1-validated nginx subFilters for cargo-proxy config.json to
remaining production squid overlays. Bump caching-helm to 0.1.1889+ca96506.

Clusters: stone-prod-p02, kflux-rhel-p01, kflux-ocp-p01, stone-prd-rh01,
kflux-prd-rh02, kflux-prd-rh03

## Validation

- Staging: https://github.com/redhat-appstudio/infra-deployments/pull/13561, https://github.com/redhat-appstudio/infra-deployments/pull/13657
- Ring-1 production: https://github.com/redhat-appstudio/infra-deployments/pull/13702 (merged)
- subFilters block matches ring-1 overlays for all six clusters in this PR

## Risk Assessment

**Risk Level:** Medium
**Description:** Production rollout of cargo-proxy config.json rewrites (auth-required
+ Nexus URL -> cluster proxy) to the remaining six prod squid clusters after
ring-1 soak. Misconfiguration could break Cargo builds on those clusters.
**Rollback:** Revert this PR to restore chart 0.1.1775+d865e45 and remove
subFilters on the six overlays in this PR.

Assisted-by: Cursor