### PR TITLE
fix: add all required bot-actions RBAC for conformance tests

### DIFF
--- a/components/konflux-verifications-rd/base/kustomization.yaml
+++ b/components/konflux-verifications-rd/base/kustomization.yaml
@@ -3,4 +3,5 @@ kind: Kustomization
 resources:
   - namespaces.yaml
   - serviceaccount.yaml
+  - release-pipeline-sa.yaml
   - rbac.yaml

--- a/components/konflux-verifications-rd/base/namespaces.yaml
+++ b/components/konflux-verifications-rd/base/namespaces.yaml
@@ -5,6 +5,9 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: konflux-conformance-tests
+  annotations:
+    argocd.argoproj.io/compare-options: IgnoreExtraneous
+    argocd.argoproj.io/sync-options: Delete=false,Prune=false
   labels:
     konflux-ci.dev/type: tenant
     cost-center: "670"
@@ -14,6 +17,9 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: konflux-managed-tests
+  annotations:
+    argocd.argoproj.io/compare-options: IgnoreExtraneous
+    argocd.argoproj.io/sync-options: Delete=false,Prune=false
   labels:
     konflux-ci.dev/type: tenant
     cost-center: "670"

--- a/components/konflux-verifications-rd/base/rbac.yaml
+++ b/components/konflux-verifications-rd/base/rbac.yaml
@@ -7,6 +7,7 @@
 #   releaser:        releases, snapshots
 #   builder:         pipelineruns
 #   integrationtest: integrationtestscenarios
+#   viewer:          pods, serviceaccounts, pipelineruns (read)
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -67,6 +68,20 @@ roleRef:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
+  name: conformance-verification-viewer
+  namespace: konflux-conformance-tests
+subjects:
+  - kind: ServiceAccount
+    name: konflux-bot-0
+    namespace: konflux-managed-tests
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: konflux-viewer-bot-actions
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
   name: conformance-verification-managed-model
   namespace: konflux-managed-tests
 subjects:
@@ -119,6 +134,20 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: konflux-integrationtest-bot-actions
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: conformance-verification-managed-viewer
+  namespace: konflux-managed-tests
+subjects:
+  - kind: ServiceAccount
+    name: konflux-bot-0
+    namespace: konflux-managed-tests
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: konflux-viewer-bot-actions
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/components/konflux-verifications-rd/base/release-pipeline-sa.yaml
+++ b/components/konflux-verifications-rd/base/release-pipeline-sa.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: release-pipeline
+  namespace: konflux-managed-tests
+  annotations:
+    argocd.argoproj.io/compare-options: IgnoreExtraneous
+    argocd.argoproj.io/sync-options: Delete=false,Prune=false

--- a/components/konflux-verifications-rd/base/serviceaccount.yaml
+++ b/components/konflux-verifications-rd/base/serviceaccount.yaml
@@ -8,5 +8,7 @@ metadata:
   namespace: konflux-managed-tests
   annotations:
     devprod.konflux-ci.dev/scope: "Kargo verification conformance tests"
+    argocd.argoproj.io/compare-options: IgnoreExtraneous
+    argocd.argoproj.io/sync-options: Delete=false,Prune=false
   labels:
     devprod.konflux-ci.dev/service: conformance-verification

--- a/components/konflux-verifications-rd/rings/ring-1/base/base-snapshot/kustomization.yaml
+++ b/components/konflux-verifications-rd/rings/ring-1/base/base-snapshot/kustomization.yaml
@@ -3,4 +3,5 @@ kind: Kustomization
 resources:
   - namespaces.yaml
   - serviceaccount.yaml
+  - release-pipeline-sa.yaml
   - rbac.yaml

--- a/components/konflux-verifications-rd/rings/ring-1/base/base-snapshot/namespaces.yaml
+++ b/components/konflux-verifications-rd/rings/ring-1/base/base-snapshot/namespaces.yaml
@@ -1,7 +1,13 @@
+# Namespaces for Kargo conformance verification tests.
+# Previously managed via Konflux Release Data; consolidated here so
+# new clusters get the full setup in one ArgoCD sync.
 apiVersion: v1
 kind: Namespace
 metadata:
   name: konflux-conformance-tests
+  annotations:
+    argocd.argoproj.io/compare-options: IgnoreExtraneous
+    argocd.argoproj.io/sync-options: Delete=false,Prune=false
   labels:
     konflux-ci.dev/type: tenant
     cost-center: "670"
@@ -11,6 +17,9 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: konflux-managed-tests
+  annotations:
+    argocd.argoproj.io/compare-options: IgnoreExtraneous
+    argocd.argoproj.io/sync-options: Delete=false,Prune=false
   labels:
     konflux-ci.dev/type: tenant
     cost-center: "670"

--- a/components/konflux-verifications-rd/rings/ring-1/base/base-snapshot/rbac.yaml
+++ b/components/konflux-verifications-rd/rings/ring-1/base/base-snapshot/rbac.yaml
@@ -7,6 +7,7 @@
 #   releaser:        releases, snapshots
 #   builder:         pipelineruns
 #   integrationtest: integrationtestscenarios
+#   viewer:          pods, serviceaccounts, pipelineruns (read)
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -67,6 +68,20 @@ roleRef:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
+  name: conformance-verification-viewer
+  namespace: konflux-conformance-tests
+subjects:
+  - kind: ServiceAccount
+    name: konflux-bot-0
+    namespace: konflux-managed-tests
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: konflux-viewer-bot-actions
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
   name: conformance-verification-managed-model
   namespace: konflux-managed-tests
 subjects:
@@ -119,6 +134,20 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: konflux-integrationtest-bot-actions
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: conformance-verification-managed-viewer
+  namespace: konflux-managed-tests
+subjects:
+  - kind: ServiceAccount
+    name: konflux-bot-0
+    namespace: konflux-managed-tests
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: konflux-viewer-bot-actions
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/components/konflux-verifications-rd/rings/ring-1/base/base-snapshot/release-pipeline-sa.yaml
+++ b/components/konflux-verifications-rd/rings/ring-1/base/base-snapshot/release-pipeline-sa.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: release-pipeline
+  namespace: konflux-managed-tests
+  annotations:
+    argocd.argoproj.io/compare-options: IgnoreExtraneous
+    argocd.argoproj.io/sync-options: Delete=false,Prune=false

--- a/components/konflux-verifications-rd/rings/ring-1/base/base-snapshot/serviceaccount.yaml
+++ b/components/konflux-verifications-rd/rings/ring-1/base/base-snapshot/serviceaccount.yaml
@@ -1,3 +1,6 @@
+# ServiceAccount for Kargo verification conformance tests.
+# Uses konflux-bot-0 naming to comply with the SA rotation policy.
+# Tokens must be minted via `oc create token` (TokenRequest API).
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -5,5 +8,7 @@ metadata:
   namespace: konflux-managed-tests
   annotations:
     devprod.konflux-ci.dev/scope: "Kargo verification conformance tests"
+    argocd.argoproj.io/compare-options: IgnoreExtraneous
+    argocd.argoproj.io/sync-options: Delete=false,Prune=false
   labels:
     devprod.konflux-ci.dev/service: conformance-verification


### PR DESCRIPTION
Bind 5 ClusterRoles (model, releaser, builder, integrationtest, viewer) to konflux-bot-0 in both konflux-conformance-tests and konflux-managed-tests namespaces.

All bound ClusterRoles match the konflux-*-bot-actions pattern required by the ValidatingAdmissionPolicy.