### PR TITLE
fix: add conformance-test-runner SA with full RBAC for PipelineRun-based tests

### DIFF
--- a/components/konflux-verifications-rd/base/conformance-test-runner-rbac.yaml
+++ b/components/konflux-verifications-rd/base/conformance-test-runner-rbac.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: conformance-test-runner-admin
+  namespace: konflux-conformance-tests
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: konflux-admin-user-actions
+subjects:
+- kind: ServiceAccount
+  name: conformance-test-runner
+  namespace: konflux-managed-tests
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: conformance-test-runner-admin
+  namespace: konflux-managed-tests
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: konflux-admin-user-actions
+subjects:
+- kind: ServiceAccount
+  name: conformance-test-runner
+  namespace: konflux-managed-tests

--- a/components/konflux-verifications-rd/base/conformance-test-runner-sa.yaml
+++ b/components/konflux-verifications-rd/base/conformance-test-runner-sa.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: conformance-test-runner
+  namespace: konflux-managed-tests

--- a/components/konflux-verifications-rd/base/kustomization.yaml
+++ b/components/konflux-verifications-rd/base/kustomization.yaml
@@ -4,4 +4,6 @@ resources:
   - namespaces.yaml
   - serviceaccount.yaml
   - release-pipeline-sa.yaml
+  - conformance-test-runner-sa.yaml
   - rbac.yaml
+  - conformance-test-runner-rbac.yaml

--- a/components/konflux-verifications-rd/base/rbac.yaml
+++ b/components/konflux-verifications-rd/base/rbac.yaml
@@ -1,146 +1,17 @@
-# RoleBindings granting konflux-bot-0 permissions for Kargo conformance verification.
-# Only ClusterRoles matching konflux-*-bot-actions are allowed by the
-# ValidatingAdmissionPolicy konflux-rbac-restrict-bindings-serviceaccounts-create.
+# RBAC for Kargo conformance verification.
 #
-# Required roles (from conformance test resource access):
-#   model:           applications, components, releaseplans
-#   releaser:        releases, snapshots
-#   builder:         pipelineruns
-#   integrationtest: integrationtestscenarios
-#   viewer:          pods, serviceaccounts, pipelineruns (read)
-#   externalpuller:  imagerepositories (read)
-#   secrets:         secrets (CRUD)
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: conformance-verification-model
-  namespace: konflux-conformance-tests
-subjects:
-  - kind: ServiceAccount
-    name: konflux-bot-0
-    namespace: konflux-managed-tests
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: konflux-model-bot-actions
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: conformance-verification-releaser
-  namespace: konflux-conformance-tests
-subjects:
-  - kind: ServiceAccount
-    name: konflux-bot-0
-    namespace: konflux-managed-tests
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: konflux-releaser-bot-actions
+# konflux-bot-0:
+#   Only needs builder-bot-actions to create PipelineRuns on the target
+#   cluster. The actual conformance tests run inside the PipelineRun as
+#   the conformance-test-runner SA (see conformance-test-runner-rbac.yaml).
+#
+# konflux-devprod-admins:
+#   Admin access for the devprod team in both namespaces.
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: conformance-verification-builder
-  namespace: konflux-conformance-tests
-subjects:
-  - kind: ServiceAccount
-    name: konflux-bot-0
-    namespace: konflux-managed-tests
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: konflux-builder-bot-actions
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: conformance-verification-integration
-  namespace: konflux-conformance-tests
-subjects:
-  - kind: ServiceAccount
-    name: konflux-bot-0
-    namespace: konflux-managed-tests
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: konflux-integrationtest-bot-actions
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: conformance-verification-viewer
-  namespace: konflux-conformance-tests
-subjects:
-  - kind: ServiceAccount
-    name: konflux-bot-0
-    namespace: konflux-managed-tests
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: konflux-viewer-bot-actions
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: conformance-verification-externalpuller
-  namespace: konflux-conformance-tests
-subjects:
-  - kind: ServiceAccount
-    name: konflux-bot-0
-    namespace: konflux-managed-tests
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: konflux-externalpuller-bot-actions
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: conformance-verification-secrets
-  namespace: konflux-conformance-tests
-subjects:
-  - kind: ServiceAccount
-    name: konflux-bot-0
-    namespace: konflux-managed-tests
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: konflux-secrets-bot-actions
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: conformance-verification-managed-model
-  namespace: konflux-managed-tests
-subjects:
-  - kind: ServiceAccount
-    name: konflux-bot-0
-    namespace: konflux-managed-tests
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: konflux-model-bot-actions
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: conformance-verification-managed-releaser
-  namespace: konflux-managed-tests
-subjects:
-  - kind: ServiceAccount
-    name: konflux-bot-0
-    namespace: konflux-managed-tests
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: konflux-releaser-bot-actions
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: conformance-verification-managed-builder
   namespace: konflux-managed-tests
 subjects:
   - kind: ServiceAccount
@@ -150,62 +21,6 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: konflux-builder-bot-actions
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: conformance-verification-managed-integration
-  namespace: konflux-managed-tests
-subjects:
-  - kind: ServiceAccount
-    name: konflux-bot-0
-    namespace: konflux-managed-tests
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: konflux-integrationtest-bot-actions
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: conformance-verification-managed-viewer
-  namespace: konflux-managed-tests
-subjects:
-  - kind: ServiceAccount
-    name: konflux-bot-0
-    namespace: konflux-managed-tests
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: konflux-viewer-bot-actions
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: conformance-verification-managed-externalpuller
-  namespace: konflux-managed-tests
-subjects:
-  - kind: ServiceAccount
-    name: konflux-bot-0
-    namespace: konflux-managed-tests
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: konflux-externalpuller-bot-actions
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: conformance-verification-managed-secrets
-  namespace: konflux-managed-tests
-subjects:
-  - kind: ServiceAccount
-    name: konflux-bot-0
-    namespace: konflux-managed-tests
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: konflux-secrets-bot-actions
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/components/konflux-verifications-rd/base/rbac.yaml
+++ b/components/konflux-verifications-rd/base/rbac.yaml
@@ -8,6 +8,8 @@
 #   builder:         pipelineruns
 #   integrationtest: integrationtestscenarios
 #   viewer:          pods, serviceaccounts, pipelineruns (read)
+#   externalpuller:  imagerepositories (read)
+#   secrets:         secrets (CRUD)
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -82,6 +84,34 @@ roleRef:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
+  name: conformance-verification-externalpuller
+  namespace: konflux-conformance-tests
+subjects:
+  - kind: ServiceAccount
+    name: konflux-bot-0
+    namespace: konflux-managed-tests
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: konflux-externalpuller-bot-actions
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: conformance-verification-secrets
+  namespace: konflux-conformance-tests
+subjects:
+  - kind: ServiceAccount
+    name: konflux-bot-0
+    namespace: konflux-managed-tests
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: konflux-secrets-bot-actions
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
   name: conformance-verification-managed-model
   namespace: konflux-managed-tests
 subjects:
@@ -148,6 +178,34 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: konflux-viewer-bot-actions
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: conformance-verification-managed-externalpuller
+  namespace: konflux-managed-tests
+subjects:
+  - kind: ServiceAccount
+    name: konflux-bot-0
+    namespace: konflux-managed-tests
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: konflux-externalpuller-bot-actions
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: conformance-verification-managed-secrets
+  namespace: konflux-managed-tests
+subjects:
+  - kind: ServiceAccount
+    name: konflux-bot-0
+    namespace: konflux-managed-tests
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: konflux-secrets-bot-actions
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/components/konflux-verifications-rd/rings/ring-1/base/base-snapshot/conformance-test-runner-rbac.yaml
+++ b/components/konflux-verifications-rd/rings/ring-1/base/base-snapshot/conformance-test-runner-rbac.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: conformance-test-runner-admin
+  namespace: konflux-conformance-tests
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: konflux-admin-user-actions
+subjects:
+- kind: ServiceAccount
+  name: conformance-test-runner
+  namespace: konflux-managed-tests
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: conformance-test-runner-admin
+  namespace: konflux-managed-tests
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: konflux-admin-user-actions
+subjects:
+- kind: ServiceAccount
+  name: conformance-test-runner
+  namespace: konflux-managed-tests

--- a/components/konflux-verifications-rd/rings/ring-1/base/base-snapshot/conformance-test-runner-sa.yaml
+++ b/components/konflux-verifications-rd/rings/ring-1/base/base-snapshot/conformance-test-runner-sa.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: conformance-test-runner
+  namespace: konflux-managed-tests

--- a/components/konflux-verifications-rd/rings/ring-1/base/base-snapshot/kustomization.yaml
+++ b/components/konflux-verifications-rd/rings/ring-1/base/base-snapshot/kustomization.yaml
@@ -4,4 +4,6 @@ resources:
   - namespaces.yaml
   - serviceaccount.yaml
   - release-pipeline-sa.yaml
+  - conformance-test-runner-sa.yaml
   - rbac.yaml
+  - conformance-test-runner-rbac.yaml

--- a/components/konflux-verifications-rd/rings/ring-1/base/base-snapshot/rbac.yaml
+++ b/components/konflux-verifications-rd/rings/ring-1/base/base-snapshot/rbac.yaml
@@ -1,146 +1,17 @@
-# RoleBindings granting konflux-bot-0 permissions for Kargo conformance verification.
-# Only ClusterRoles matching konflux-*-bot-actions are allowed by the
-# ValidatingAdmissionPolicy konflux-rbac-restrict-bindings-serviceaccounts-create.
+# RBAC for Kargo conformance verification.
 #
-# Required roles (from conformance test resource access):
-#   model:           applications, components, releaseplans
-#   releaser:        releases, snapshots
-#   builder:         pipelineruns
-#   integrationtest: integrationtestscenarios
-#   viewer:          pods, serviceaccounts, pipelineruns (read)
-#   externalpuller:  imagerepositories (read)
-#   secrets:         secrets (CRUD)
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: conformance-verification-model
-  namespace: konflux-conformance-tests
-subjects:
-  - kind: ServiceAccount
-    name: konflux-bot-0
-    namespace: konflux-managed-tests
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: konflux-model-bot-actions
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: conformance-verification-releaser
-  namespace: konflux-conformance-tests
-subjects:
-  - kind: ServiceAccount
-    name: konflux-bot-0
-    namespace: konflux-managed-tests
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: konflux-releaser-bot-actions
+# konflux-bot-0:
+#   Only needs builder-bot-actions to create PipelineRuns on the target
+#   cluster. The actual conformance tests run inside the PipelineRun as
+#   the conformance-test-runner SA (see conformance-test-runner-rbac.yaml).
+#
+# konflux-devprod-admins:
+#   Admin access for the devprod team in both namespaces.
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: conformance-verification-builder
-  namespace: konflux-conformance-tests
-subjects:
-  - kind: ServiceAccount
-    name: konflux-bot-0
-    namespace: konflux-managed-tests
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: konflux-builder-bot-actions
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: conformance-verification-integration
-  namespace: konflux-conformance-tests
-subjects:
-  - kind: ServiceAccount
-    name: konflux-bot-0
-    namespace: konflux-managed-tests
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: konflux-integrationtest-bot-actions
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: conformance-verification-viewer
-  namespace: konflux-conformance-tests
-subjects:
-  - kind: ServiceAccount
-    name: konflux-bot-0
-    namespace: konflux-managed-tests
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: konflux-viewer-bot-actions
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: conformance-verification-externalpuller
-  namespace: konflux-conformance-tests
-subjects:
-  - kind: ServiceAccount
-    name: konflux-bot-0
-    namespace: konflux-managed-tests
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: konflux-externalpuller-bot-actions
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: conformance-verification-secrets
-  namespace: konflux-conformance-tests
-subjects:
-  - kind: ServiceAccount
-    name: konflux-bot-0
-    namespace: konflux-managed-tests
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: konflux-secrets-bot-actions
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: conformance-verification-managed-model
-  namespace: konflux-managed-tests
-subjects:
-  - kind: ServiceAccount
-    name: konflux-bot-0
-    namespace: konflux-managed-tests
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: konflux-model-bot-actions
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: conformance-verification-managed-releaser
-  namespace: konflux-managed-tests
-subjects:
-  - kind: ServiceAccount
-    name: konflux-bot-0
-    namespace: konflux-managed-tests
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: konflux-releaser-bot-actions
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: conformance-verification-managed-builder
   namespace: konflux-managed-tests
 subjects:
   - kind: ServiceAccount
@@ -150,62 +21,6 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: konflux-builder-bot-actions
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: conformance-verification-managed-integration
-  namespace: konflux-managed-tests
-subjects:
-  - kind: ServiceAccount
-    name: konflux-bot-0
-    namespace: konflux-managed-tests
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: konflux-integrationtest-bot-actions
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: conformance-verification-managed-viewer
-  namespace: konflux-managed-tests
-subjects:
-  - kind: ServiceAccount
-    name: konflux-bot-0
-    namespace: konflux-managed-tests
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: konflux-viewer-bot-actions
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: conformance-verification-managed-externalpuller
-  namespace: konflux-managed-tests
-subjects:
-  - kind: ServiceAccount
-    name: konflux-bot-0
-    namespace: konflux-managed-tests
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: konflux-externalpuller-bot-actions
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: conformance-verification-managed-secrets
-  namespace: konflux-managed-tests
-subjects:
-  - kind: ServiceAccount
-    name: konflux-bot-0
-    namespace: konflux-managed-tests
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: konflux-secrets-bot-actions
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/components/konflux-verifications-rd/rings/ring-1/base/base-snapshot/rbac.yaml
+++ b/components/konflux-verifications-rd/rings/ring-1/base/base-snapshot/rbac.yaml
@@ -8,6 +8,8 @@
 #   builder:         pipelineruns
 #   integrationtest: integrationtestscenarios
 #   viewer:          pods, serviceaccounts, pipelineruns (read)
+#   externalpuller:  imagerepositories (read)
+#   secrets:         secrets (CRUD)
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -82,6 +84,34 @@ roleRef:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
+  name: conformance-verification-externalpuller
+  namespace: konflux-conformance-tests
+subjects:
+  - kind: ServiceAccount
+    name: konflux-bot-0
+    namespace: konflux-managed-tests
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: konflux-externalpuller-bot-actions
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: conformance-verification-secrets
+  namespace: konflux-conformance-tests
+subjects:
+  - kind: ServiceAccount
+    name: konflux-bot-0
+    namespace: konflux-managed-tests
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: konflux-secrets-bot-actions
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
   name: conformance-verification-managed-model
   namespace: konflux-managed-tests
 subjects:
@@ -148,6 +178,34 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: konflux-viewer-bot-actions
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: conformance-verification-managed-externalpuller
+  namespace: konflux-managed-tests
+subjects:
+  - kind: ServiceAccount
+    name: konflux-bot-0
+    namespace: konflux-managed-tests
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: konflux-externalpuller-bot-actions
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: conformance-verification-managed-secrets
+  namespace: konflux-managed-tests
+subjects:
+  - kind: ServiceAccount
+    name: konflux-bot-0
+    namespace: konflux-managed-tests
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: konflux-secrets-bot-actions
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding


### PR DESCRIPTION
## Summary

Introduce a dedicated `conformance-test-runner` ServiceAccount for running conformance tests inside a Tekton PipelineRun, replacing direct test execution from the Kargo AnalysisRun.

## Architecture

1. `konflux-bot-0` only needs `konflux-builder-bot-actions` (create PipelineRuns)
2. The AnalysisRun launcher creates a PipelineRun on the target cluster
3. The PipelineRun runs as `conformance-test-runner` SA with full RBAC via `konflux-admin-user-actions` ClusterRole in both namespaces

## Changes

- Add `conformance-test-runner` ServiceAccount in `konflux-managed-tests`
- Add `conformance-test-runner-admin` RoleBinding in both `konflux-conformance-tests` and `konflux-managed-tests`, bound to `konflux-admin-user-actions` ClusterRole 
- Strip `konflux-bot-0` RBAC down to `konflux-builder-bot-actions` only (was 7 ClusterRoles per namespace)
- Add `release-pipeline` SA for conformance test pre-condition
- Keep `konflux-devprod-admins` admin bindings in both namespaces

## Why

The `konflux-bot-` prefix SA is restricted by ValidatingAdmissionPolicy to only bind `konflux-*-bot-actions` ClusterRoles, which don't cover all resources the conformance tests need (enterprisecontractpolicies, roles, rolebindings, serviceaccounts). Using a separate SA without the prefix avoids this restriction entirely.