### PR TITLE
feat(KONFLUX-15424): Temporarily raise kueue quotas for PLRs

### DIFF
--- a/components/kueue-rd/rings/ring-1/lightwell-dev/cluster-queue.yaml
+++ b/components/kueue-rd/rings/ring-1/lightwell-dev/cluster-queue.yaml
@@ -29,9 +29,9 @@ spec:
     - name: default-flavor
       resources:
       - name: tekton.dev/pipelineruns
-        nominalQuota: '1200'
+        nominalQuota: '1800'
       - name: konflux-ci-dev-token
-        nominalQuota: '1000'
+        nominalQuota: '1500'
       - name: cpu
         nominalQuota: 1k
       - name: memory


### PR DESCRIPTION
Temporarily raise kueue quotas related to number of PLRs to be able to check clusters capacity while tracking `apiserver_storage_size_bytes` metric