### PR TITLE
KFLUXINFRA-4286 fix(rd-dev): resolve duplicate kyverno ApplicationSet conflict

### DIFF
--- a/argo-cd-apps/overlays/rd-dev/delete-legacy-konflux-member-appsets.yaml
+++ b/argo-cd-apps/overlays/rd-dev/delete-legacy-konflux-member-appsets.yaml
@@ -60,3 +60,9 @@ kind: ApplicationSet
 metadata:
   name: enterprise-contract
 $patch: delete
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: kyverno
+$patch: delete

--- a/argo-cd-apps/overlays/rd-dev/kyverno/kyverno-appset.yaml
+++ b/argo-cd-apps/overlays/rd-dev/kyverno/kyverno-appset.yaml
@@ -1,7 +1,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: ApplicationSet
 metadata:
-  name: kyverno
+  name: kyverno-rd
 spec:
   generators:
     - merge:


### PR DESCRIPTION
## What

- Rename the ring-deployment kyverno ApplicationSet in the rd-dev overlay to `kyverno-rd`.
- Delete the legacy `kyverno` ApplicationSet (inherited from `../development`) from the rd-dev graph.

Clusters affected: development member clusters only. `components/kyverno` and staging/production overlays are untouched.

[KFLUXINFRA-4286](https://redhat.atlassian.net/browse/KFLUXINFRA-4286)

## Why

The rd-dev overlay inherits the legacy `kyverno` ApplicationSet from `../development` and also adds a ring-deployment `kyverno` AppSet. Both share the name `kyverno` in the `openshift-gitops` namespace, so kustomize fails with a namespace-transform ID conflict and the entire rd-dev overlay cannot build. This makes env-detector fail on every PR (e.g. #13759).

## Validation

- `kustomize build --enable-helm argo-cd-apps/overlays/rd-dev/` now passes (exit 0); it failed with `namespace transformation produces ID conflict` before.
- No files under `components/kyverno` changed; staging/production overlays render unchanged.

[KFLUXINFRA-4286]: https://redhat.atlassian.net/browse/KFLUXINFRA-4286?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ