### PR TITLE
KFLUXINFRA-4492 Bump repository-validator production config ref

### DIFF
--- a/components/repository-validator/production/kustomization.yaml
+++ b/components/repository-validator/production/kustomization.yaml
@@ -1,5 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - https://github.com/redhat-appstudio/internal-infra-deployments/components/repository-validator/production?ref=32c3ef2125458920452ffad3fe28761b5b275340
+  - https://github.com/redhat-appstudio/internal-infra-deployments/components/repository-validator/production?ref=1c630da05130802d93022bd0b76dfa31d6ca66ae
   - ../base


### PR DESCRIPTION
### What
Bump components/repository-validator/production/kustomization.yaml ref to
1c630da05130802d93022bd0b76dfa31d6ca66ae.

Add konflux-lightwell GitHub organization to production repository allow list
(https://github.com/redhat-appstudio/internal-infra-deployments/pull/136)

Clusters affected: all internal production clusters

[KFLUXINFRA-4492](https://redhat.atlassian.net/browse/KFLUXINFRA-4492)

### Why
konflux-lightwell GitHub organization needs to be able to onboard projects on Konflux LW servers

### Validation
kustomize build skipped — remote ref fetch times out locally; SHA is the
verified merge commit of internal-infra-deployments#136
Low-risk additive change: only adds one repo prefix to the allow list

### Risk Assessment
Risk Level: Low
What could go wrong: Additive change only; no existing entries modified.
Rollback: Revert this PR
Blast radius: All internal production clusters — config change only


[KFLUXINFRA-4492]: https://redhat.atlassian.net/browse/KFLUXINFRA-4492?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ