### PR TITLE
KFLUXINFRA-4426 Distribute RH internal CA to lightwell-dev via trust-…

### DIFF
--- a/argo-cd-apps/base/member/infra-deployments/kustomization.yaml
+++ b/argo-cd-apps/base/member/infra-deployments/kustomization.yaml
@@ -39,6 +39,7 @@ resources:
   - cert-manager
   - konflux-verifications-rd
   - trust-manager
+  - roks-trusted-ca
   - squid
   - kueue
   - policies

--- a/argo-cd-apps/base/member/infra-deployments/roks-trusted-ca/kustomization.yaml
+++ b/argo-cd-apps/base/member/infra-deployments/roks-trusted-ca/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- roks-trusted-ca.yaml

--- a/argo-cd-apps/base/member/infra-deployments/roks-trusted-ca/roks-trusted-ca.yaml
+++ b/argo-cd-apps/base/member/infra-deployments/roks-trusted-ca/roks-trusted-ca.yaml
@@ -1,0 +1,58 @@
+# Distributes the RH internal CA bundle to tenant namespaces on ROKS HCP
+# clusters via trust-manager. Only deployed to clusters listed below —
+# ROKS clusters where the Proxy CR trustedCA cannot be set.
+#
+# This is a standalone component (not part of trust-manager) to avoid
+# Helm chart download conflicts in CI when multiple kustomize overlays
+# reference the same base with a HelmChartInflationGenerator.
+#
+# To add a new ROKS cluster: add an entry to the list generator below
+# and create a matching directory under components/roks-trusted-ca/.
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: roks-trusted-ca
+spec:
+  generators:
+    - merge:
+        mergeKeys:
+          - nameNormalized
+        generators:
+          - clusters:
+              selector:
+                matchLabels:
+                  appstudio.redhat.com/member-cluster: "true"
+              values:
+                sourceRoot: components/roks-trusted-ca
+                environment: staging
+                clusterDir: empty-base
+          # Explicit list of ROKS clusters that need the CA bundle.
+          - list:
+              elements:
+                - nameNormalized: lightwell-dev
+                  values.clusterDir: lightwell-dev
+                  values.environment: staging
+  template:
+    metadata:
+      name: roks-trusted-ca-{{nameNormalized}}
+    spec:
+      project: default
+      source:
+        path: '{{values.sourceRoot}}/{{values.environment}}/{{values.clusterDir}}'
+        repoURL: https://github.com/redhat-appstudio/infra-deployments.git
+        targetRevision: main
+      destination:
+        namespace: cert-manager
+        server: '{{server}}'
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
+        syncOptions:
+          - CreateNamespace=false
+        retry:
+          limit: -1
+          backoff:
+            duration: 10s
+            factor: 2
+            maxDuration: 3m

--- a/argo-cd-apps/base/roks-trusted-ca-source/kustomization.yaml
+++ b/argo-cd-apps/base/roks-trusted-ca-source/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- roks-trusted-ca-source.yaml

--- a/argo-cd-apps/base/roks-trusted-ca-source/roks-trusted-ca-source.yaml
+++ b/argo-cd-apps/base/roks-trusted-ca-source/roks-trusted-ca-source.yaml
@@ -1,0 +1,58 @@
+# Deploys the RH internal CA ConfigMap to the cert-manager namespace on ROKS
+# clusters. This ConfigMap is the source for the trust-manager Bundle defined
+# in the roks-trusted-ca component.
+#
+# The CA data is kept in internal-infra-deployments (private repo) because
+# it contains internal Red Hat certificates.
+#
+# To add a new ROKS cluster: add an entry to the list generator below
+# and create a matching directory under components/roks-trusted-ca-source/
+# in internal-infra-deployments.
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: roks-trusted-ca-source
+spec:
+  generators:
+    - merge:
+        mergeKeys:
+          - nameNormalized
+        generators:
+          - clusters:
+              selector:
+                matchLabels:
+                  appstudio.redhat.com/internal-member-cluster: "true"
+              values:
+                sourceRoot: components/roks-trusted-ca-source
+                environment: staging
+                clusterDir: empty-base
+          # Explicit list of ROKS clusters that need the CA source ConfigMap.
+          - list:
+              elements:
+                - nameNormalized: lightwell-dev
+                  values.clusterDir: lightwell-dev
+                  values.environment: staging
+  template:
+    metadata:
+      name: roks-trusted-ca-source-{{nameNormalized}}
+    spec:
+      project: default
+      source:
+        path: '{{values.sourceRoot}}/{{values.environment}}/{{values.clusterDir}}'
+        repoURL: https://github.com/redhat-appstudio/internal-infra-deployments.git
+        targetRevision: main
+      destination:
+        namespace: cert-manager
+        server: '{{server}}'
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
+        syncOptions:
+          - CreateNamespace=false
+        retry:
+          limit: -1
+          backoff:
+            duration: 10s
+            factor: 2
+            maxDuration: 3m

--- a/argo-cd-apps/overlays/staging-downstream/kustomization.yaml
+++ b/argo-cd-apps/overlays/staging-downstream/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
   - ../../base/monitoring-blackbox
   - ../../base/smee-client
   - ../../base/ca-bundle
+  - ../../base/roks-trusted-ca-source
   - ../../base/repository-validator
 
 patchesStrategicMerge:

--- a/components/policies/staging/lightwell-dev/kustomization.yaml
+++ b/components/policies/staging/lightwell-dev/kustomization.yaml
@@ -8,3 +8,22 @@ resources:
 - buildah-roks-scc.yaml
 - buildah-roks-scc-clusterrole.yaml
 - buildah-roks-scc-clusterrolebinding.yaml
+
+# On ROKS HCP the Proxy CR trustedCA field cannot be set, so OpenShift's
+# inject-trusted-cabundle mechanism does not distribute the RH internal CA.
+# The empty trusted-ca ConfigMap created by this policy is useless on ROKS
+# and conflicts with trust-manager which distributes the CA via a Bundle
+# resource (see the roks-trusted-ca component overlay for this cluster).
+# This patch disables the rule by setting a label selector that never
+# matches. We cannot delete the policy because it inherits Prune=false,
+# so ArgoCD would retain the live resource and Kyverno would keep
+# generating empty trusted-ca ConfigMaps that compete with trust-manager.
+patches:
+- target:
+    kind: ClusterPolicy
+    name: konflux-rbac-bootstrap-tenant-namespace-rbcm
+  patch: |-
+    - op: replace
+      path: /spec/rules/0/match/any/0/resources/selector/matchLabels
+      value:
+        konflux-ci.dev/type: disabled-on-roks

--- a/components/roks-trusted-ca/development/empty-base/kustomization.yaml
+++ b/components/roks-trusted-ca/development/empty-base/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# No resources — this component only applies to ROKS clusters.
+resources: []

--- a/components/roks-trusted-ca/production/empty-base/kustomization.yaml
+++ b/components/roks-trusted-ca/production/empty-base/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# No resources — this component only applies to ROKS clusters.
+resources: []

--- a/components/roks-trusted-ca/staging/empty-base/kustomization.yaml
+++ b/components/roks-trusted-ca/staging/empty-base/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# No resources — this component only applies to ROKS clusters.
+resources: []

--- a/components/roks-trusted-ca/staging/lightwell-dev/kustomization.yaml
+++ b/components/roks-trusted-ca/staging/lightwell-dev/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- rh-internal-ca-bundle.yaml

--- a/components/roks-trusted-ca/staging/lightwell-dev/rh-internal-ca-bundle.yaml
+++ b/components/roks-trusted-ca/staging/lightwell-dev/rh-internal-ca-bundle.yaml
@@ -1,0 +1,43 @@
+# Workaround for ROKS HCP where the Proxy CR trustedCA cannot be set.
+#
+# On ROSA clusters, OpenShift's inject-trusted-cabundle mechanism distributes
+# the RH internal CA via the Proxy CR. On ROKS HCP this is blocked, so we use
+# trust-manager to distribute the CA bundle to tenant namespaces instead.
+#
+# The Bundle creates a ConfigMap named "trusted-ca" with key "ca-bundle.crt"
+# in every namespace labeled konflux-ci.dev/type=tenant — matching the default
+# caTrustConfigMapName parameter in build tasks. No workload changes needed.
+#
+# The source ConfigMap (rh-internal-ca) containing the CA certificates is
+# deployed from internal-infra-deployments (private repo) via the
+# roks-trusted-ca-source component.
+#
+# The corresponding Kyverno rule (create-trusted-ca-configmap in
+# bootstrap-tenant-namespace-rbcm) is disabled on this cluster via a Kustomize
+# patch in the policies overlay to avoid conflict.
+#
+# Can be removed once IBM supports setting trustedCA on HostedCluster or the
+# ibmcloud CLI supports trusted CA bundles (IDEA-I-4688).
+apiVersion: trust.cert-manager.io/v1alpha1
+kind: Bundle
+metadata:
+  name: trusted-ca
+spec:
+  sources:
+    - configMap:
+        name: rh-internal-ca
+        key: ca-bundle.crt
+  target:
+    configMap:
+      key: ca-bundle.crt
+      metadata:
+        labels:
+          # Disable OpenShift's inject-trusted-cabundle on ROKS. The existing
+          # Kyverno-generated ConfigMaps have this label set to "true", which
+          # causes OpenShift to overwrite ca-bundle.crt with system CAs only
+          # (Proxy CR trustedCA is not set on HCP). Setting it to "false"
+          # stops the injection and lets trust-manager manage the content.
+          config.openshift.io/inject-trusted-cabundle: "false"
+    namespaceSelector:
+      matchLabels:
+        konflux-ci.dev/type: tenant


### PR DESCRIPTION
…manager

## What

- Add a `roks-trusted-ca` component that uses trust-manager to distribute the Red Hat internal CA bundle to tenant namespaces on ROKS HCP clusters
- Add a `roks-trusted-ca-source` ApplicationSet that deploys the CA source ConfigMap from `internal-infra-deployments` (private repo) to the `cert-manager` namespace
- Disable the Kyverno `create-trusted-ca-configmap` rule on lightwell-dev (changes selector to `disabled-on-roks`)

### Why

On ROKS HCP clusters the Proxy CR `trustedCA` field cannot be set (blocked by ValidatingAdmissionPolicy), so OpenShift's `inject-trusted-cabundle` mechanism does not distribute the RH internal CA. Build tasks that access internal RH services (e.g. `gitlab.cee.redhat.com`) over TLS fail certificate verification.

### What this PR does

A trust-manager `Bundle` resource creates a ConfigMap named `trusted-ca` with key `ca-bundle.crt` in every namespace labeled `konflux-ci.dev/type=tenant`. This matches the build task's default `caTrustConfigMapName` parameter so no workload changes needed.

The Bundle also sets `config.openshift.io/inject-trusted-cabundle: "false"` on managed ConfigMaps to prevent OpenShift's CA injection from overwriting trust-manager's content. This handles existing ConfigMaps created by the Kyverno rule (which has `synchronize: false`, so the old ConfigMaps remain after the rule is disabled).

A standalone `roks-trusted-ca` component is used instead of extending the `trust-manager` component to avoid Helm chart download conflicts when multiple kustomize overlays reference the same  `HelmChartInflationGenerator` base.

### Two-repo split

The CA certificate data is kept in `internal-infra-deployments` (private repo) and the Bundle orchestration in `infra-deployments` (public repo):

| Repo | Component | What | Deploys to |
|------|-----------|------|------------|
| `internal-infra-deployments` | `roks-trusted-ca-source` | ConfigMap with RH internal CA certs | `cert-manager` namespace |
| `infra-deployments` | `roks-trusted-ca` | trust-manager Bundle (references ConfigMap by name) | cluster-scoped |

trust-manager requires source ConfigMaps in its own namespace (`cert-manager`) as it cannot read from `openshift-config` where the existing `user-ca-bundle` lives. The CA data is the same as in the existing `ca-bundle` component but deployed to a different namespace.

**Companion PR:** `internal-infra-deployments` PR `KFLUXINFRA-4426/roks-trusted-ca-source-lightwell-dev` must merge first (source ConfigMap must exist before the Bundle references it).

### Render-diff noise

The render-diff report shows build errors for `empty-base` and diffs for `lightwell-dev` tagged with all three environments (development, production, staging). This is expected for a new component:

- **`empty-base` BUILD ERROR**: These directories are intentionally empty (`resources: []`) and they exist so non-ROKS clusters get a valid no-op ArgoCD Application. The render-diff tool reports "does not exist on either ref" because there is no rendered output to compare.
- **`lightwell-dev` showing for development/production**: The render-diff tool renders every discovered `kustomization.yaml` for all environments. The `+186` diff is the same content repeated. Only the staging path is actually deployed; the ApplicationSet's list generator only includes `lightwell-dev` with `environment: staging`.
- **The only real change** is `components/policies/staging/lightwell-dev (staging): +1 -1`, i.e., the Kyverno rule selector change.

## Test plan

- [X] Validated trust-manager Bundle + CA distribution end-to-end on throwaway ROKS cluster (`da6nnjlw00gukspnspd0`)
- [ ] Verify `trusted-ca` ConfigMap appears in tenant namespaces on lightwell-dev with RH internal CA content
- [ ] Verify `config.openshift.io/inject-trusted-cabundle` label is set to `false` on managed ConfigMaps
- [ ] Verify build task can mount `trusted-ca` and `update-ca-trust` makes the RH Internal Root CA a trusted anchor
- [ ] Verify Kyverno no longer generates empty `trusted-ca` ConfigMaps in new tenant namespaces
- [ ] Post-rollout: validate trust-manager adopted all existing ConfigMaps; any tenant namespace NOT in this output still has the old Kyverno-generated ConfigMap:
```bash
   TENANT_NS=$(oc get ns -l konflux-ci.dev/type=tenant -o jsonpath='{.items[*].metadata.name}')
  MANAGED_NS=$(oc get cm trusted-ca -A -l trust.cert-manager.io/bundle=trusted-ca \
    -o jsonpath='{.items[?(@.metadata.labels.config\.openshift\.io/inject-trusted-cabundle=="false")].metadata.namespace}')
  diff <(echo "$TENANT_NS" | tr ' ' '\n' | sort) <(echo "$MANAGED_NS" | tr ' ' '\n' | sort)
  ```
Empty diff = all tenant namespaces have the correctly labeled, trust-manager-managed ConfigMap.

