### PR TITLE
KFLUXINFRA etcd-defrag-rd: add kargo-promotion-image for ring-1

### DIFF
--- a/configs/etcd-defrag-rd/rings/ring-1/base/kargo-promotion-image.yaml
+++ b/configs/etcd-defrag-rd/rings/ring-1/base/kargo-promotion-image.yaml
@@ -1,0 +1,14 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: etcd-maintenance
+spec:
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: etcd-maintenance
+            env:
+            - name: IMAGE
+              value: quay.io/konflux-ci/etcd-defrag@sha256:7a19f7b9b7bbdeb4f8d51e06d3319ac5c0555094fcbf2093d6e4d71f136afb55

--- a/configs/etcd-defrag-rd/rings/ring-1/base/kustomization.yaml
+++ b/configs/etcd-defrag-rd/rings/ring-1/base/kustomization.yaml
@@ -2,3 +2,9 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - base-snapshot
+
+patches:
+- path: kargo-promotion-image.yaml
+  target:
+    kind: CronJob
+    name: etcd-maintenance


### PR DESCRIPTION
The etcd-defrag CronJob uses the quay.io/konflux-ci/etcd-defrag image as an env var (IMAGE), not as a container image. Kustomize's images: transformer only works on container image: fields, so kustomize-set-image can't update it.

This adds a kargo-promotion-image.yaml file — a strategic merge patch that overrides the IMAGE env var in the CronJob. Kargo updates this file via yaml-update during ring promotions, while humans continue to modify the CronJob structure through base-snapshot/ as usual.

Why a separate file instead of inline patch? Kargo's yaml-update can target fields in a real YAML file but can't modify values inside an inline YAML string (patch: |-).

