### PR TITLE
PVO11Y-5502 Add NetworkPolicy for tekton-ms Prometheus to scrape controller

### DIFF
--- a/components/monitoring/prometheus/staging/tekton-ms/base/kustomization.yaml
+++ b/components/monitoring/prometheus/staging/tekton-ms/base/kustomization.yaml
@@ -4,6 +4,7 @@ resources:
 - namespace.yaml
 - monitoringstack.yaml
 - rbac.yaml
+- scrape-networkpolicy.yaml
 - servicemonitor.yaml
 - servicemonitor-pipeline-exporter.yaml
 

--- a/components/monitoring/prometheus/staging/tekton-ms/base/scrape-networkpolicy.yaml
+++ b/components/monitoring/prometheus/staging/tekton-ms/base/scrape-networkpolicy.yaml
@@ -1,0 +1,30 @@
+# The Tekton Operator manages a default-deny NetworkPolicy plus a
+# `pipeline-controller` policy that only allows scraping port 9090 from
+# namespaces labeled `openshift.io/cluster-monitoring: "true"` (Platform
+# Prometheus). Our dedicated Prometheus lives in appstudio-tekton, so this
+# additive policy explicitly permits it to scrape the controller metrics.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: appstudio-tekton-ms-controller-scrape
+  namespace: openshift-pipelines
+  labels:
+    monitoring.rhobs/stack: appstudio-tekton-ms
+spec:
+  podSelector:
+    matchLabels:
+      app: tekton-pipelines-controller
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: appstudio-tekton
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: prometheus
+              app.kubernetes.io/instance: appstudio-tekton-ms
+      ports:
+        - protocol: TCP
+          port: 9090


### PR DESCRIPTION
## What

Add a NetworkPolicy in `openshift-pipelines` allowing the dedicated tekton-ms Prometheus (in `appstudio-tekton`) to scrape `tekton-pipelines-controller` metrics on port 9090. Staging only.

Clusters affected: stone-stg-rh01, stone-stage-p01, lightwell-dev

[PVO11Y-5502](https://redhat.atlassian.net/browse/PVO11Y-5502)

## Why

A recent Tekton Operator update ([tektoncd/operator@96d4370](https://github.com/tektoncd/operator/commit/96d4370049f1f2915aa348eb19aa90f59fd3321a)) added a `pipeline-default-deny` policy plus a `pipeline-controller` policy that only permits scraping the controller from namespaces labeled `openshift.io/cluster-monitoring: "true"` (Platform Prometheus). The tekton-ms Prometheus lives in `appstudio-tekton`, so its scrapes have been dropped since Aug 19 2026. NetworkPolicies are additive, so this policy restores access without touching the operator-managed ones.

## Validation

- `kustomize build --enable-helm` passes for all three affected staging overlays.
- Confirmed live on stone-stg-rh01: the 4 `tekton-pipelines-controller` targets are `down` with `context deadline exceeded` on `:9090/metrics`; discovery/RBAC are fine (targets are found), only ingress is blocked.
- Policy selectors/port verified against the operator commit that introduced the restriction.

[PVO11Y-5502]: https://redhat.atlassian.net/browse/PVO11Y-5502?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ