### PR TITLE
PVO11Y-5502: allow appstudio-tekton-ms Prometheus to scrape tekton controller (production)

### DIFF
--- a/components/monitoring/prometheus/production/tekton-ms/base/kustomization.yaml
+++ b/components/monitoring/prometheus/production/tekton-ms/base/kustomization.yaml
@@ -4,6 +4,7 @@ resources:
 - namespace.yaml
 - monitoringstack.yaml
 - rbac.yaml
+- scrape-networkpolicy.yaml
 - servicemonitor.yaml
 - servicemonitor-pipeline-exporter.yaml
 

--- a/components/monitoring/prometheus/production/tekton-ms/base/scrape-networkpolicy.yaml
+++ b/components/monitoring/prometheus/production/tekton-ms/base/scrape-networkpolicy.yaml
@@ -1,0 +1,30 @@
+# The Tekton Operator manages a default-deny NetworkPolicy plus a
+# `pipeline-controller` policy that only allows scraping port 9090 from
+# namespaces labeled `openshift.io/cluster-monitoring: "true"` (Platform
+# Prometheus). Our dedicated Prometheus lives in appstudio-tekton, so this
+# additive policy explicitly permits it to scrape the controller metrics.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: appstudio-tekton-ms-controller-scrape
+  namespace: openshift-pipelines
+  labels:
+    monitoring.rhobs/stack: appstudio-tekton-ms
+spec:
+  podSelector:
+    matchLabels:
+      app: tekton-pipelines-controller
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: appstudio-tekton
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: prometheus
+              app.kubernetes.io/instance: appstudio-tekton-ms
+      ports:
+        - protocol: TCP
+          port: 9090


### PR DESCRIPTION
## What

Add additive NetworkPolicy `appstudio-tekton-ms-controller-scrape` in
`openshift-pipelines` to the production tekton-ms base, allowing the dedicated
appstudio-tekton-ms Prometheus to scrape tekton-pipelines-controller :9090.

Clusters affected: kflux-fedora-01, kflux-ocp-p01, kflux-osp-p01,
kflux-prd-rh02, kflux-prd-rh03, kflux-rhel-p01, stone-prd-rh01, stone-prod-p01,
stone-prod-p02

[PVO11Y-5502](https://redhat.atlassian.net/browse/PVO11Y-5502)

## Why

The Tekton Operator (build 871) ships a default-deny NetworkPolicy plus a
`pipeline-controller` policy that only allows controller scraping from
namespaces labeled `openshift.io/cluster-monitoring: "true"`. Our dedicated
Prometheus lives in `appstudio-tekton` (no such label), so its controller
scrapes will time out once that operator version rolls out to production
(Ring 1: #13673). This additive allow-policy is deployed ahead of that so
scraping keeps working.

## Validation

- `kustomize build --enable-helm` passes for all affected production overlays;
  the policy renders on all 9 tekton-ms clusters.
- Same policy merged and validated in staging — lightwell-dev confirmed all 4
  tekton-pipelines-controller targets `up` after ArgoCD synced the policy.

## Risk Assessment

**Risk Level:** Low
**What could go wrong:** The policy is purely additive (allow-only) and scoped
to a single pod selector + port. It cannot block existing traffic. Worst case
is a typo in a selector, which would leave scraping in the same broken state it
would otherwise be after the operator rollout — no regression to current prod.
**Rollback:** Revert PR.
**Blast radius:** 9 production clusters; ingress to tekton-pipelines-controller
:9090 only.

## Note on ring rollout

Deployed to all clusters in a single PR rather than split into rings: this is
an additive, allow-only NetworkPolicy with no effect on current traffic, staged
ahead of the operator's [build-871](https://redhat.atlassian.net/browse/build-871) ring rollout (#13673).

[PVO11Y-5502]: https://redhat.atlassian.net/browse/PVO11Y-5502?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ