### PR TITLE
fix: prevent ArgoCD from pruning conformance-test-runner SA and RBAC

### DIFF
--- a/components/konflux-verifications-rd/base/conformance-test-runner-rbac.yaml
+++ b/components/konflux-verifications-rd/base/conformance-test-runner-rbac.yaml
@@ -4,6 +4,8 @@ kind: RoleBinding
 metadata:
   name: conformance-test-runner-admin
   namespace: konflux-conformance-tests
+  annotations:
+    argocd.argoproj.io/sync-options: Prune=false
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -18,6 +20,8 @@ kind: Role
 metadata:
   name: conformance-test-runner-extra
   namespace: konflux-managed-tests
+  annotations:
+    argocd.argoproj.io/sync-options: Prune=false
 rules:
 - apiGroups:
   - ""
@@ -41,6 +45,8 @@ kind: RoleBinding
 metadata:
   name: conformance-test-runner-extra
   namespace: konflux-managed-tests
+  annotations:
+    argocd.argoproj.io/sync-options: Prune=false
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -55,6 +61,8 @@ kind: RoleBinding
 metadata:
   name: conformance-test-runner-admin
   namespace: konflux-managed-tests
+  annotations:
+    argocd.argoproj.io/sync-options: Prune=false
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/components/konflux-verifications-rd/base/conformance-test-runner-sa.yaml
+++ b/components/konflux-verifications-rd/base/conformance-test-runner-sa.yaml
@@ -3,3 +3,5 @@ kind: ServiceAccount
 metadata:
   name: conformance-test-runner
   namespace: konflux-managed-tests
+  annotations:
+    argocd.argoproj.io/sync-options: Prune=false

--- a/components/konflux-verifications-rd/rings/ring-1/base/base-snapshot/conformance-test-runner-rbac.yaml
+++ b/components/konflux-verifications-rd/rings/ring-1/base/base-snapshot/conformance-test-runner-rbac.yaml
@@ -4,6 +4,8 @@ kind: RoleBinding
 metadata:
   name: conformance-test-runner-admin
   namespace: konflux-conformance-tests
+  annotations:
+    argocd.argoproj.io/sync-options: Prune=false
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -18,6 +20,8 @@ kind: Role
 metadata:
   name: conformance-test-runner-extra
   namespace: konflux-managed-tests
+  annotations:
+    argocd.argoproj.io/sync-options: Prune=false
 rules:
 - apiGroups:
   - ""
@@ -41,6 +45,8 @@ kind: RoleBinding
 metadata:
   name: conformance-test-runner-extra
   namespace: konflux-managed-tests
+  annotations:
+    argocd.argoproj.io/sync-options: Prune=false
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -55,6 +61,8 @@ kind: RoleBinding
 metadata:
   name: conformance-test-runner-admin
   namespace: konflux-managed-tests
+  annotations:
+    argocd.argoproj.io/sync-options: Prune=false
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/components/konflux-verifications-rd/rings/ring-1/base/base-snapshot/conformance-test-runner-sa.yaml
+++ b/components/konflux-verifications-rd/rings/ring-1/base/base-snapshot/conformance-test-runner-sa.yaml
@@ -3,3 +3,5 @@ kind: ServiceAccount
 metadata:
   name: conformance-test-runner
   namespace: konflux-managed-tests
+  annotations:
+    argocd.argoproj.io/sync-options: Prune=false


### PR DESCRIPTION
Add argocd.argoproj.io/sync-options: Prune=false annotation to the conformance-test-runner ServiceAccount and all associated RBAC resources so they persist across ArgoCD sync cycles.