### PR TITLE
(onboarding) Remove staging repository-validator apps from AppSRE ArgoCD'

### DIFF
--- a/argo-cd-apps/overlays/development/kustomization.yaml
+++ b/argo-cd-apps/overlays/development/kustomization.yaml
@@ -5,7 +5,6 @@ resources:
   - ../../base/member
   - ../../base/all-clusters
   - ../../base/ca-bundle
-  - ../../base/repository-validator
   - ../../base/eaas
   - ../../base/smee-client
   - ../../base/backup
@@ -64,16 +63,6 @@ patches:
       kind: ApplicationSet
       version: v1alpha1
       name: ca-bundle
-  - path: development-overlay-patch.yaml
-    target:
-      kind: ApplicationSet
-      version: v1alpha1
-      name: repository-validator
-  - path: dev-application-auto-sync-patch.yaml
-    target:
-      kind: ApplicationSet
-      version: v1alpha1
-      name: repository-validator
   - path: development-overlay-patch.yaml
     target:
       kind: ApplicationSet

--- a/argo-cd-apps/overlays/rd-dev/kustomization.yaml
+++ b/argo-cd-apps/overlays/rd-dev/kustomization.yaml
@@ -13,6 +13,7 @@ resources:
   - multi-platform-controller
   - policies
   - smee-client
+  - repository-validator
 
 patchesStrategicMerge:
   - delete-legacy-konflux-member-appsets.yaml

--- a/argo-cd-apps/overlays/rd-dev/repository-validator/kustomization.yaml
+++ b/argo-cd-apps/overlays/rd-dev/repository-validator/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- repository-validator-appset.yaml

--- a/argo-cd-apps/overlays/rd-dev/repository-validator/repository-validator-appset.yaml
+++ b/argo-cd-apps/overlays/rd-dev/repository-validator/repository-validator-appset.yaml
@@ -1,0 +1,45 @@
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: repository-validator
+  labels:
+    appstudio.redhat.com/deployment-clusters: tenant
+spec:
+  generators:
+    - merge:
+        mergeKeys:
+          - nameNormalized
+        generators:
+          - clusters:
+              selector:
+                  matchLabels:
+                    appstudio.redhat.com/member-cluster: "true"
+              values:
+                sourceRoot: components/repository-validator-rd
+                ring: "ring-0"
+                clusterDir: "base"
+          - list:
+              elements: []
+
+  template:
+    metadata:
+      name: repository-validator-{{nameNormalized}}
+    spec:
+      project: default
+      source:
+        path: '{{values.sourceRoot}}/rings/{{values.ring}}/{{values.clusterDir}}'
+        repoURL: https://github.com/redhat-appstudio/infra-deployments.git
+        targetRevision: main
+      destination:
+        namespace: repository-validator
+        server: '{{server}}'
+      syncPolicy:
+        # automated:
+        #   prune: true
+        #   selfHeal: true
+        syncOptions:
+        - CreateNamespace=true
+        retry:
+          limit: 50
+          backoff:
+            duration: 15s

--- a/argo-cd-apps/overlays/rd-dev/repository-validator/repository-validator-appset.yaml
+++ b/argo-cd-apps/overlays/rd-dev/repository-validator/repository-validator-appset.yaml
@@ -40,6 +40,10 @@ spec:
         syncOptions:
         - CreateNamespace=true
         retry:
-          limit: 50
+          limit: -1
           backoff:
-            duration: 15s
+            duration: 10s
+            factor: 2
+            maxDuration: 3m
+
+

--- a/argo-cd-apps/overlays/rd-dev/repository-validator/repository-validator-appset.yaml
+++ b/argo-cd-apps/overlays/rd-dev/repository-validator/repository-validator-appset.yaml
@@ -34,9 +34,9 @@ spec:
         namespace: repository-validator
         server: '{{server}}'
       syncPolicy:
-        # automated:
-        #   prune: true
-        #   selfHeal: true
+        automated:
+          prune: true
+          selfHeal: true
         syncOptions:
         - CreateNamespace=true
         retry:

--- a/argo-cd-apps/overlays/staging-downstream/delete-applications.yaml
+++ b/argo-cd-apps/overlays/staging-downstream/delete-applications.yaml
@@ -35,3 +35,10 @@ kind: ApplicationSet
 metadata:
   name: policies
 $patch: delete
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: repository-validator
+$patch: delete
+


### PR DESCRIPTION
### Summary of Changes
As part of the Migration/reorganization of the infra-deployments repo components to comply with new component standards, applying [step 3](https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/ring-deployments/directory-structure-migration.md#part-3-old-staging-deletion)  of the [Migration SOP](https://gitlab.cee.redhat.com/konflux/docs/sop/-/blob/main/infra/ring-deployments/directory-structure-migration.md) that consist in deleting the old staging of the component repository-validator and ApplicationSet from konflux-public-staging and staging-downstream.
Tracked in [KFLUXINFRA-4289](https://redhat.atlassian.net/browse/KFLUXINFRA-4289)

## Argo-cd RD link from parts 1 and 2 fo the SOP:
https://argocd-infra-deployments-server-argocd-infra-deployments.apps.rosa.kflux-c-stg-i01.qfla.p3.openshiftapps.com/applications?proj=&sync=&autoSync=&health=&namespace=&cluster=&labels=&annotations=&operation=&search=repository-validator

### Verification
oc kustomize has been performed on the following directories to render config files and the results:

- kustomize build argo-cd-apps/overlays/konflux-public-staging | grep -i repository-validator - no output
- kustomize build argo-cd-apps/overlays/staging-downstream | grep -i repository-validator - no output
- kustomize build argo-cd-apps/overlays/rd-staging -> sets the "sourceRoot: components/repository-validator":
metadata:
  labels:
    appstudio.redhat.com/deployment-clusters: tenant
    appstudio.redhat.com/internal-only: "true"
  name: repository-validator
  namespace: argocd-infra-deployments
spec:
...
            sourceRoot: components/repository-validator-rd

WRT Staging this components is only deployed on internal clusters 

### Risk Level
**Risk Level**: Medium
**Reasoning**: Changes will be performed in staging, in case would be an error only would affect only one cluster stone-stage-p01 (+ the  lightwell-dev). 
**Rollback Strategy**: Revert this PR + sync in ArgoCD should restore previous ApplicationSet

## Validation
For non-production environments this component is only in Staging, so this PR will be the first step before Production. This has been already done in other components like kueue https://github.com/redhat-appstudio/infra-deployments/pull/13631

[KFLUXINFRA-4289]: https://redhat.atlassian.net/browse/KFLUXINFRA-4289?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ