### PR TITLE
fix: add conformance-test-runner extra RBAC in conformance-tests namespace

### DIFF
--- a/components/konflux-verifications-rd/base/conformance-test-runner-rbac.yaml
+++ b/components/konflux-verifications-rd/base/conformance-test-runner-rbac.yaml
@@ -39,6 +39,17 @@ rules:
   - watch
   - create
   - delete
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - roles
+  - rolebindings
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - delete
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -79,6 +90,17 @@ rules:
   - list
   - watch
   - create
+  - delete
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - roles
+  - rolebindings
+  verbs:
+  - get
+  - list
+  - create
+  - update
   - delete
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/components/konflux-verifications-rd/base/conformance-test-runner-rbac.yaml
+++ b/components/konflux-verifications-rd/base/conformance-test-runner-rbac.yaml
@@ -57,6 +57,47 @@ subjects:
   namespace: konflux-managed-tests
 ---
 apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: conformance-test-runner-extra
+  namespace: konflux-conformance-tests
+  annotations:
+    argocd.argoproj.io/sync-options: Prune=false
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - delete
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: conformance-test-runner-extra
+  namespace: konflux-conformance-tests
+  annotations:
+    argocd.argoproj.io/sync-options: Prune=false
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: conformance-test-runner-extra
+subjects:
+- kind: ServiceAccount
+  name: conformance-test-runner
+  namespace: konflux-managed-tests
+---
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: conformance-test-runner-admin

--- a/components/konflux-verifications-rd/rings/ring-1/base/base-snapshot/conformance-test-runner-rbac.yaml
+++ b/components/konflux-verifications-rd/rings/ring-1/base/base-snapshot/conformance-test-runner-rbac.yaml
@@ -39,6 +39,17 @@ rules:
   - watch
   - create
   - delete
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - roles
+  - rolebindings
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - delete
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -79,6 +90,17 @@ rules:
   - list
   - watch
   - create
+  - delete
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - roles
+  - rolebindings
+  verbs:
+  - get
+  - list
+  - create
+  - update
   - delete
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/components/konflux-verifications-rd/rings/ring-1/base/base-snapshot/conformance-test-runner-rbac.yaml
+++ b/components/konflux-verifications-rd/rings/ring-1/base/base-snapshot/conformance-test-runner-rbac.yaml
@@ -57,6 +57,47 @@ subjects:
   namespace: konflux-managed-tests
 ---
 apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: conformance-test-runner-extra
+  namespace: konflux-conformance-tests
+  annotations:
+    argocd.argoproj.io/sync-options: Prune=false
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - delete
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: conformance-test-runner-extra
+  namespace: konflux-conformance-tests
+  annotations:
+    argocd.argoproj.io/sync-options: Prune=false
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: conformance-test-runner-extra
+subjects:
+- kind: ServiceAccount
+  name: conformance-test-runner
+  namespace: konflux-managed-tests
+---
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: conformance-test-runner-admin


### PR DESCRIPTION
…

Add pods/delete and batch/jobs Role+RoleBinding for conformance-test-runner SA in konflux-conformance-tests namespace. The test framework needs these permissions to create integration-runner-jobs Role during setup.