### PR TITLE
Refactor staging CA bundle

### DIFF
--- a/argo-cd-apps/overlays/staging-downstream/base-clusterdir-patch.yaml
+++ b/argo-cd-apps/overlays/staging-downstream/base-clusterdir-patch.yaml
@@ -1,0 +1,4 @@
+---
+- op: add
+  path: /spec/generators/0/merge/generators/0/clusters/values/clusterDir
+  value: base

--- a/argo-cd-apps/overlays/staging-downstream/kustomization.yaml
+++ b/argo-cd-apps/overlays/staging-downstream/kustomization.yaml
@@ -15,6 +15,11 @@ patchesStrategicMerge:
   - delete-applications.yaml
 
 patches:
+  - path: base-clusterdir-patch.yaml
+    target:
+      kind: ApplicationSet
+      version: v1alpha1
+      name: ca-bundle
   # Exclude operator-managed clusters from Argo generation for services owned
   # by the konflux-operator. Orphan (do not prune) when Applications go away.
   - path: exclude-operator-owned-clusters.yaml


### PR DESCRIPTION
In internal-infra-deployments, a staging/base folder was created with the 2 resources we need, i.e. configMap and the proxy config. The reason of this change is some cluster will need to propagate the RH root ca differently, i.e. using cert-manager, this is true for ROKS and ROSA HCP. All the ROSA classic will use base and the clusters like ROKS, kflux-stg-p02 that does not exist yet will use specific folder configuration.

[KFLUXINFRA-4426](https://redhat.atlassian.net/browse/KFLUXINFRA-4426)

[KFLUXINFRA-4426]: https://redhat.atlassian.net/browse/KFLUXINFRA-4426?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ