### PR TITLE
Add kflux-lw-p01 cluster to monitoring Prometheus component

### DIFF
--- a/argo-cd-apps/base/all-clusters/infra-deployments/monitoring-workload-prometheus/monitoring-workload-prometheus.yaml
+++ b/argo-cd-apps/base/all-clusters/infra-deployments/monitoring-workload-prometheus/monitoring-workload-prometheus.yaml
@@ -43,6 +43,8 @@ spec:
                   values.clusterDir: kflux-osp-p01
                 - nameNormalized: kflux-fedora-01
                   values.clusterDir: kflux-fedora-01
+                - nameNormalized: kflux-lw-p01
+                  values.clusterDir: kflux-lw-p01
   template:
     metadata:
       name: monitoring-workload-prometheus-{{nameNormalized}}

--- a/components/monitoring/prometheus/production/kflux-lw-p01/cluster-id-label.yaml
+++ b/components/monitoring/prometheus/production/kflux-lw-p01/cluster-id-label.yaml
@@ -1,0 +1,4 @@
+---
+- op: add
+  path: /spec/prometheusConfig/externalLabels/source_cluster
+  value: kflux-lw-p01

--- a/components/monitoring/prometheus/production/kflux-lw-p01/kustomization.yaml
+++ b/components/monitoring/prometheus/production/kflux-lw-p01/kustomization.yaml
@@ -1,0 +1,19 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../base
+- ../tekton-ms
+
+patches:
+  - path: cluster-id-label.yaml
+    target:
+      name: appstudio-federate-ms
+      kind: MonitoringStack
+      group: monitoring.rhobs
+      version: v1alpha1
+  - path: cluster-id-label.yaml
+    target:
+      name: appstudio-tekton-ms
+      kind: MonitoringStack
+      group: monitoring.rhobs
+      version: v1alpha1


### PR DESCRIPTION
Add production cluster kflux-lw-p01 to the monitoring Prometheus stack:
- Create production overlay directory with cluster-id-label configuration
- Set source_cluster label to kflux-lw-p01 for metrics identification
- Update monitoring-workload-prometheus ApplicationSet to deploy to kflux-lw-p01

Modeled after existing production clusters (kflux-ocp-p01).

Assisted-by: Claude Sonnet 4.5 <noreply@anthropic.com>