### PR TITLE
Enable proxy for bundler and cargo on prod ring 1

### DIFF
--- a/components/konflux-info/production/kflux-osp-p01/cluster-config.env
+++ b/components/konflux-info/production/kflux-osp-p01/cluster-config.env
@@ -3,6 +3,8 @@ http-proxy=squid.caching.svc.cluster.local:3128
 no-proxy=
 
 allow-package-registry-proxy=true
+package-registry-proxy-bundler-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/rubygems-proxy
+package-registry-proxy-cargo-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/cargo-proxy
 package-registry-proxy-gomod-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/go-proxy
 package-registry-proxy-npm-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/npm-proxy
 package-registry-proxy-pip-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/pypi-proxy/simple

--- a/components/konflux-info/production/stone-prod-p01/cluster-config.env
+++ b/components/konflux-info/production/stone-prod-p01/cluster-config.env
@@ -3,6 +3,8 @@ http-proxy=squid.caching.svc.cluster.local:3128
 no-proxy=
 
 allow-package-registry-proxy=true
+package-registry-proxy-bundler-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/rubygems-proxy
+package-registry-proxy-cargo-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/cargo-proxy
 package-registry-proxy-gomod-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/go-proxy
 package-registry-proxy-npm-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/npm-proxy
 package-registry-proxy-pip-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/pypi-proxy/simple

--- a/components/konflux-info/production/stone-prod-p02/cluster-config.env
+++ b/components/konflux-info/production/stone-prod-p02/cluster-config.env
@@ -3,6 +3,8 @@ http-proxy=squid.caching.svc.cluster.local:3128
 no-proxy=
 
 allow-package-registry-proxy=true
+package-registry-proxy-bundler-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/rubygems-proxy
+package-registry-proxy-cargo-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/cargo-proxy
 package-registry-proxy-gomod-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/go-proxy
 package-registry-proxy-npm-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/npm-proxy
 package-registry-proxy-pip-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/pypi-proxy/simple


### PR DESCRIPTION
Reviews are welcome, but please do not merge this until the announced date of September 4th.

Enable use of the package registry proxy for Hermeto's bundler and cargo backends on kflux-osp-p01, stone-prod-p01, and stone-prod-p02. This will allow Hermeto to route dependency prefetches through the package registry registry proxy for policy evaluation.

NOTE: Including stone-prod-p02 in this first ring because there are no users of this feature on the other two clusters, so we would not be able to validate otherwise.

## Risk Assessment
**Risk Level:** Medium
**Description:** Enables additional package ecosystems to be proxied through Nexus by Hermeto. The user impact is to build pipelines using Bundler and Cargo.
**Rollback:** Revert PR

## Validation
Stage PR: https://github.com/redhat-appstudio/infra-deployments/pull/13485
Depends on https://github.com/redhat-appstudio/infra-deployments/pull/13702. Both validated together in stage.