### PR TITLE
KFLUXINFRA-4426 Distribute RH internal CA to kflux-lw-p01 via trust-m…

### DIFF
--- a/argo-cd-apps/base/ca-bundle/ca-bundle.yaml
+++ b/argo-cd-apps/base/ca-bundle/ca-bundle.yaml
@@ -17,7 +17,9 @@ spec:
                 matchLabels:
                   appstudio.redhat.com/internal-member-cluster: "true"
           - list:
-              elements: []
+              elements:
+                - nameNormalized: kflux-lw-p01
+                  values.clusterDir: kflux-lw-p01
   template:
     metadata:
       name: ca-bundle-{{nameNormalized}}

--- a/argo-cd-apps/base/cert-manager-trusted-ca/cert-manager-trusted-ca.yaml
+++ b/argo-cd-apps/base/cert-manager-trusted-ca/cert-manager-trusted-ca.yaml
@@ -1,0 +1,57 @@
+# Distributes the RH internal CA bundle to tenant namespaces on HCP
+# clusters via trust-manager. Only deployed to clusters listed below —
+# clusters where the Proxy CR trustedCA cannot be set.
+#
+# This is a standalone component (not part of trust-manager) to avoid
+# Helm chart download conflicts in CI when multiple kustomize overlays
+# reference the same base with a HelmChartInflationGenerator.
+#
+# To add a new cluster: add an entry to the list generator below
+# and create a matching directory under components/cert-manager-trusted-ca/.
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: cert-manager-trusted-ca
+spec:
+  generators:
+    - merge:
+        mergeKeys:
+          - nameNormalized
+        generators:
+          - clusters:
+              selector:
+                matchLabels:
+                  appstudio.redhat.com/internal-member-cluster: "true"
+              values:
+                sourceRoot: components/cert-manager-trusted-ca
+                environment: staging
+                clusterDir: empty-base
+          # Explicit list of clusters that need the CA bundle.
+          - list:
+              elements:
+                - nameNormalized: kflux-lw-p01
+                  values.clusterDir: kflux-lw-p01
+  template:
+    metadata:
+      name: cert-manager-trusted-ca-{{nameNormalized}}
+    spec:
+      project: default
+      source:
+        path: '{{values.sourceRoot}}/{{values.environment}}/{{values.clusterDir}}'
+        repoURL: https://github.com/redhat-appstudio/infra-deployments.git
+        targetRevision: main
+      destination:
+        namespace: cert-manager
+        server: '{{server}}'
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
+        syncOptions:
+          - CreateNamespace=false
+        retry:
+          limit: -1
+          backoff:
+            duration: 10s
+            factor: 2
+            maxDuration: 3m

--- a/argo-cd-apps/base/cert-manager-trusted-ca/kustomization.yaml
+++ b/argo-cd-apps/base/cert-manager-trusted-ca/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- cert-manager-trusted-ca.yaml

--- a/argo-cd-apps/overlays/production-downstream/kustomization.yaml
+++ b/argo-cd-apps/overlays/production-downstream/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
   - ../../base/monitoring-blackbox
   - ../../base/smee-client
   - ../../base/ca-bundle
+  - ../../base/cert-manager-trusted-ca
   - ../../base/repository-validator
   - ../../base/cluster-secret-store-rh
 patchesStrategicMerge:
@@ -401,3 +402,8 @@ patches:
       kind: ApplicationSet
       version: v1alpha1
       name: release
+  - path: production-overlay-patch.yaml
+    target:
+      kind: ApplicationSet
+      version: v1alpha1
+      name: cert-manager-trusted-ca

--- a/components/cert-manager-trusted-ca/production/empty-base/kustomization.yaml
+++ b/components/cert-manager-trusted-ca/production/empty-base/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# No resources — this component only applies to ROKS clusters.
+resources: []

--- a/components/cert-manager-trusted-ca/production/kflux-lw-p01/kustomization.yaml
+++ b/components/cert-manager-trusted-ca/production/kflux-lw-p01/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- rh-internal-ca-bundle.yaml

--- a/components/cert-manager-trusted-ca/production/kflux-lw-p01/rh-internal-ca-bundle.yaml
+++ b/components/cert-manager-trusted-ca/production/kflux-lw-p01/rh-internal-ca-bundle.yaml
@@ -1,0 +1,43 @@
+# Workaround for ROKS HCP where the Proxy CR trustedCA cannot be set.
+#
+# On ROSA clusters, OpenShift's inject-trusted-cabundle mechanism distributes
+# the RH internal CA via the Proxy CR. On ROKS HCP this is blocked, so we use
+# trust-manager to distribute the CA bundle to tenant namespaces instead.
+#
+# The Bundle creates a ConfigMap named "trusted-ca" with key "ca-bundle.crt"
+# in every namespace labeled konflux-ci.dev/type=tenant — matching the default
+# caTrustConfigMapName parameter in build tasks. No workload changes needed.
+#
+# The source ConfigMap (rh-internal-ca) containing the CA certificates is
+# deployed from internal-infra-deployments (private repo) via the ca-bundle
+# component's kflux-lw-p01 overlay.
+#
+# The corresponding Kyverno rule (create-trusted-ca-configmap in
+# bootstrap-tenant-namespace-rbcm) is disabled on this cluster via a Kustomize
+# patch in the policies overlay to avoid conflict.
+#
+# Can be removed once IBM supports setting trustedCA on HostedCluster or the
+# ibmcloud CLI supports trusted CA bundles (IDEA-I-4688).
+apiVersion: trust.cert-manager.io/v1alpha1
+kind: Bundle
+metadata:
+  name: trusted-ca
+spec:
+  sources:
+    - configMap:
+        name: rh-internal-ca
+        key: ca-bundle.crt
+  target:
+    configMap:
+      key: ca-bundle.crt
+      metadata:
+        labels:
+          # Disable OpenShift's inject-trusted-cabundle on ROKS. The existing
+          # Kyverno-generated ConfigMaps have this label set to "true", which
+          # causes OpenShift to overwrite ca-bundle.crt with system CAs only
+          # (Proxy CR trustedCA is not set on HCP). Setting it to "false"
+          # stops the injection and lets trust-manager manage the content.
+          config.openshift.io/inject-trusted-cabundle: "false"
+    namespaceSelector:
+      matchLabels:
+        konflux-ci.dev/type: tenant

--- a/components/policies/production/kflux-lw-p01/kustomization.yaml
+++ b/components/policies/production/kflux-lw-p01/kustomization.yaml
@@ -6,3 +6,22 @@ resources:
 - ../policies/kubearchive/
 - ../policies/kueue/
 - ../policies/build-resources
+
+# On ROKS HCP the Proxy CR trustedCA field cannot be set, so OpenShift's
+# inject-trusted-cabundle mechanism does not distribute the RH internal CA.
+# The empty trusted-ca ConfigMap created by this policy is useless on ROKS
+# and conflicts with trust-manager which distributes the CA via a Bundle
+# resource (see the roks-trusted-ca component overlay for this cluster).
+# This patch disables the rule by setting a label selector that never
+# matches. We cannot delete the policy because it inherits Prune=false,
+# so ArgoCD would retain the live resource and Kyverno would keep
+# generating empty trusted-ca ConfigMaps that compete with trust-manager.
+patches:
+- target:
+    kind: ClusterPolicy
+    name: konflux-rbac-bootstrap-tenant-namespace-rbcm
+  patch: |-
+    - op: replace
+      path: /spec/rules/0/match/any/0/resources/selector/matchLabels
+      value:
+        konflux-ci.dev/type: disabled-on-roks


### PR DESCRIPTION
…anager

## Summary

- Add a `roks-trusted-ca` component that uses trust-manager to distribute the Red Hat internal CA bundle to tenant namespaces on ROKS HCP clusters
- Patch the `ca-bundle` ApplicationSet for production to enable per-cluster overlays and route `kflux-lw-p01` to its overlay in `internal-infra-deployments`
- Disable the Kyverno `create-trusted-ca-configmap` rule on kflux-lw-p01 (changes selector to `disabled-on-roks`)

### Why

On ROKS HCP clusters the Proxy CR `trustedCA` field cannot be set (blocked by ValidatingAdmissionPolicy), so OpenShift's `inject-trusted-cabundle` mechanism does not distribute the RH internal CA. Build tasks that access internal RH services (e.g. `gitlab.cee.redhat.com`) over TLS fail certificate verification.

### What this does

A trust-manager `Bundle` resource creates a ConfigMap named `trusted-ca` with key `ca-bundle.crt` in every namespace labeled `konflux-ci.dev/type=tenant`. This matches the build task's default `caTrustConfigMapName` parameter so no workload changes are needed.

The Bundle also sets `config.openshift.io/inject-trusted-cabundle: "false"` on managed ConfigMaps to prevent OpenShift's CA injection from overwriting trust-manager's content. This handles existing ConfigMaps created by the Kyverno rule (which has `synchronize: false`, so the old ConfigMaps remain after the rule is disabled). trust-manager's continuous reconciliation loop converges within seconds of deployment — any brief race with OpenShift injection is transient and self-healing.

### How the pieces fit together

| Component | Repo | What it does |
|-----------|------|--------------|
| `ca-bundle` overlay (`production/kflux-lw-p01/`) | `internal-infra-deployments` ([PR #139](https://github.com/redhat-appstudio/internal-infra-deployments/pull/139)) | Deploys the existing `user-ca-bundle` ConfigMap to `cert-manager` namespace (renamed `rh-internal-ca`, Proxy CR removed) |
| `ca-bundle` ApplicationSet patch | this PR | Routes `kflux-lw-p01` to its per-cluster overlay, sets `clusterDir: base` for production |
| `roks-trusted-ca` component | this PR | trust-manager Bundle that references `rh-internal-ca` and distributes it to tenant namespaces |
| Kyverno policy patch | this PR | Disables the `create-trusted-ca-configmap` rule on `kflux-lw-p01` |

The `ca-bundle` ApplicationSet patch uses a dedicated `ca-bundle-production-overlay-patch.yaml` instead of the shared `production-overlay-patch.yaml` because it needs additional ops (`clusterDir: base` and list element) that are specific to `ca-bundle` and would break other ApplicationSets.

A standalone `roks-trusted-ca` component is used instead of extending the `trust-manager` component to avoid Helm chart download conflicts in CI when multiple kustomize overlays reference the same `HelmChartInflationGenerator` base.

### Dependency

[internal-infra-deployments#139](https://github.com/redhat-appstudio/internal-infra-deployments/pull/139) must merge first as the source ConfigMap (`rh-internal-ca` in `cert-manager` namespace) must exist before the trust-manager Bundle references it.

### Render-diff noise

The render-diff report shows build errors for `empty-base` and diffs for `kflux-lw-p01` tagged with all three environments. This is expected for a new component:

- **`empty-base` BUILD ERROR**: Intentionally empty (`resources: []`) exists so non-ROKS clusters get a valid no-op ArgoCD Application. The render-diff tool reports "does not exist on either ref" because there is no rendered output.
- **`kflux-lw-p01` showing for development/staging**: The render-diff tool renders every discovered `kustomization.yaml` for all environments. Only the production path is actually deployed.
- **`policies/production/kflux-lw-p01`**: The real change: Kyverno rule selector from `tenant` to `disabled-on-roks`.

### Kyverno rule clarification

The policy `bootstrap-tenant-namespace-rbcm` contains a single rule (`create-trusted-ca-configmap`) that generates an empty `trusted-ca` ConfigMap so it is not an RBAC policy despite the name. The `rbcm` suffix refers to the original multi-rule policy it was split from. trust-manager's Bundle replaces this rule's function.

## Risk Assessment

**Risk Level:** Low
**What could go wrong:** The trust-manager Bundle fails to reconcile, leaving tenant namespaces without the `trusted-ca` ConfigMap (or with the old empty Kyverno-generated one). Build tasks on kflux-lw-p01 would fail TLS verification against `gitlab.cee.redhat.com` — which is the current broken state already. This change cannot make things worse; it can only fix or leave unchanged.
**Rollback:** Revert this PR. The Kyverno rule re-enables (`disabled-on-roks` → `tenant`), Kyverno recreates empty `trusted-ca` ConfigMaps (`generateExisting: true`), and the cluster returns to the current (broken) state. trust-manager Bundle deletion is handled by ArgoCD prune. No manual cleanup needed.
**Blast radius:** Production kflux-lw-p01 only. No other clusters are affected — the `roks-trusted-ca` ApplicationSet only lists `kflux-lw-p01`, and the `ca-bundle` patch only routes `kflux-lw-p01` to its per-cluster overlay. All other production clusters continue using `ca-bundle/production/base/` (unchanged behavior).

## Test plan

- [X] Validated trust-manager Bundle + CA distribution end-to-end on throwaway ROKS cluster (`da6nnjlw00gukspnspd0`)
- [ ] Verify `rh-internal-ca` ConfigMap exists in `cert-manager` namespace (from [internal-infra-deployments#139](https://github.com/redhat-appstudio/internal-infra-deployments/pull/139))
- [ ] Verify `trusted-ca` ConfigMap appears in tenant namespaces on kflux-lw-p01 with RH internal CA content
- [ ] Verify `config.openshift.io/inject-trusted-cabundle` label is set to `false` on managed ConfigMaps
- [ ] Verify build task can mount `trusted-ca` and `update-ca-trust` makes the RH Internal Root CA a trusted anchor
- [ ] Verify Kyverno no longer generates empty `trusted-ca` ConfigMaps in new tenant namespaces
- [ ] Post-rollout: assert every tenant namespace has a trust-manager-managed ConfigMap with the correct label and content:
  ```bash
  TENANT_NS=$(oc get ns -l konflux-ci.dev/type=tenant -o jsonpath='{.items[*].metadata.name}')
  MANAGED_NS=$(oc get cm trusted-ca -A -l trust.cert-manager.io/bundle=trusted-ca \
    -o jsonpath='{.items[?(@.metadata.labels.config\.openshift\.io/inject-trusted-cabundle=="false")].metadata.namespace}')
  diff <(echo "$TENANT_NS" | tr ' ' '\n' | sort) <(echo "$MANAGED_NS" | tr ' ' '\n' | sort)
  ```
  Empty diff = all tenant namespaces have the correctly labeled, trust-manager-managed ConfigMap.

Contributes to: [KFLUXINFRA-4426](https://redhat.atlassian.net/browse/KFLUXINFRA-4426)

[KFLUXINFRA-4426]: https://redhat.atlassian.net/browse/KFLUXINFRA-4426?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Depends on: https://github.com/redhat-appstudio/infra-deployments/pull/13833