### PR TITLE
KFLUXINFRA-4495: Fix ExternalSecret vault paths for kflux-lw-p01

### DIFF
--- a/components/konflux-kite/production/kflux-lw-p01/database-secret-path.yaml
+++ b/components/konflux-kite/production/kflux-lw-p01/database-secret-path.yaml
@@ -5,3 +5,6 @@
 - op: replace
   path: /spec/secretStoreRef/name
   value: appsre-stonesoup-vault
+- op: replace
+  path: /spec/target/template/data/DB_PORT
+  value: '{{ index . "db.port" }}'

--- a/components/kubearchive/production/kflux-lw-p01/kustomization.yaml
+++ b/components/kubearchive/production/kflux-lw-p01/kustomization.yaml
@@ -174,6 +174,13 @@ patches:
         dataFrom:
           - extract:
               key: production/platform/terraform/generated/kflux-lw-p01/kubearchive-database
+  - target:
+      kind: ExternalSecret
+      name: database-secret
+    patch: |-
+      - op: replace
+        path: /spec/target/template/data/DATABASE_PORT
+        value: '{{ index . "db.port" }}'
   # These patches add an annotation so an OpenShift service
   # creates the TLS secrets instead of Cert Manager
   - patch: |-

--- a/components/pipeline-service/production/kflux-lw-p01/deploy.yaml
+++ b/components/pipeline-service/production/kflux-lw-p01/deploy.yaml
@@ -2083,7 +2083,7 @@ metadata:
 spec:
   dataFrom:
   - extract:
-      key: production/platform/terraform/generated/kflux-lw-p01/tekton-bucket
+      key: production/platform/terraform/generated/kflux-lw-p01/plnsvc-cos-credentials
   refreshInterval: 1h
   secretStoreRef:
     kind: ClusterSecretStore
@@ -2094,9 +2094,9 @@ spec:
     name: tekton-results-s3
     template:
       data:
-        aws_access_key_id: '{{ .aws_access_key_id }}'
-        aws_region: '{{ .aws_region }}'
-        aws_secret_access_key: '{{ .aws_secret_access_key }}'
+        aws_access_key_id: '{{ .access_key_id }}'
+        aws_region: '{{ .region }}'
+        aws_secret_access_key: '{{ .secret_access_key }}'
         bucket: '{{ .bucket }}'
         endpoint: https://{{ .endpoint }}
         s3_url: s3://{{ .bucket }}
@@ -2133,7 +2133,7 @@ metadata:
 spec:
   dataFrom:
   - extract:
-      key: production/platform/terraform/generated/kflux-lw-p01/tekton-bucket
+      key: production/platform/terraform/generated/kflux-lw-p01/plnsvc-cos-credentials
   refreshInterval: 1h
   secretStoreRef:
     kind: ClusterSecretStore
@@ -2144,9 +2144,9 @@ spec:
     name: tekton-results-s3
     template:
       data:
-        aws_access_key_id: '{{ .aws_access_key_id }}'
-        aws_region: '{{ .aws_region }}'
-        aws_secret_access_key: '{{ .aws_secret_access_key }}'
+        aws_access_key_id: '{{ .access_key_id }}'
+        aws_region: '{{ .region }}'
+        aws_secret_access_key: '{{ .secret_access_key }}'
         bucket: '{{ .bucket }}'
         endpoint: https://{{ .endpoint }}
         s3_url: s3://{{ .bucket }}

--- a/components/pipeline-service/production/kflux-lw-p01/resources/tekton-results-s3-secret-path.yaml
+++ b/components/pipeline-service/production/kflux-lw-p01/resources/tekton-results-s3-secret-path.yaml
@@ -1,7 +1,16 @@
 ---
 - op: add
   path: /spec/dataFrom/0/extract/key
-  value: production/platform/terraform/generated/kflux-lw-p01/tekton-bucket
+  value: production/platform/terraform/generated/kflux-lw-p01/plnsvc-cos-credentials
 - op: replace
   path: /spec/secretStoreRef/name
   value: appsre-stonesoup-vault
+- op: replace
+  path: /spec/target/template/data/aws_access_key_id
+  value: '{{ .access_key_id }}'
+- op: replace
+  path: /spec/target/template/data/aws_secret_access_key
+  value: '{{ .secret_access_key }}'
+- op: replace
+  path: /spec/target/template/data/aws_region
+  value: '{{ .region }}'

--- a/components/vector-kubearchive-log-collector/production/kflux-lw-p01/cos-credentials-secret.yaml
+++ b/components/vector-kubearchive-log-collector/production/kflux-lw-p01/cos-credentials-secret.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   dataFrom:
     - extract:
-        key: production/platform/terraform/generated/kflux-lw-dev/cos-credentials
+        key: production/platform/terraform/generated/kflux-lw-p01/cos-credentials
   refreshInterval: 1h
   secretStoreRef:
     kind: ClusterSecretStore

--- a/components/vector-kubearchive-log-collector/production/kflux-lw-p01/kustomization.yaml
+++ b/components/vector-kubearchive-log-collector/production/kflux-lw-p01/kustomization.yaml
@@ -13,6 +13,7 @@ commonAnnotations:
 
 resources:
 - ../base
+- cos-credentials-secret.yaml
 
 patches:
   - patch: |-


### PR DESCRIPTION
## What

- Fix vector cos-credentials ExternalSecret vault path (`kflux-lw-dev` → `kflux-lw-p01`)
- Add `cos-credentials-secret.yaml` to vector kustomization resources
- Update pipeline-service tekton-results S3 secret vault path to `plnsvc-cos-credentials` and regenerate `deploy.yaml`
- Add `DB_PORT` vault template patch for konflux-kite database secret
- Add `DATABASE_PORT` vault template patch for kubearchive database secret

Clusters affected: kflux-lw-p01

[KFLUXINFRA-4495](https://redhat.atlassian.net/browse/KFLUXINFRA-4495)

## Why

The kflux-lw-p01 cluster overlay had incorrect vault paths, a missing ExternalSecret resource, and hardcoded database ports that should be sourced from vault. This caused pipeline-service, vector, konflux-kite, and kubearchive to fail with missing or incorrect credentials.

## Validation

- `kustomize build --enable-helm` passes for all affected overlays:
  - `components/konflux-kite/production/kflux-lw-p01/`
  - `components/kubearchive/production/kflux-lw-p01/`
  - `components/pipeline-service/production/kflux-lw-p01/`
  - `components/vector-kubearchive-log-collector/production/kflux-lw-p01/`

## Risk Assessment

**Risk Level:** Low
**What could go wrong:** If a vault path is incorrect, the ExternalSecret will fail to sync and the affected service won't get credentials, causing connectivity failures on kflux-lw-p01.
**Rollback:** Revert PR
**Blast radius:** production cluster kflux-lw-p01 only

[KFLUXINFRA-4495]: https://redhat.atlassian.net/browse/KFLUXINFRA-4495?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ