### PR TITLE
Increase pac-controller memory limit to 4Gi

### DIFF
--- a/components/pipeline-service/staging/base/main-pipeline-service-configuration.yaml
+++ b/components/pipeline-service/staging/base/main-pipeline-service-configuration.yaml
@@ -1980,10 +1980,10 @@ spec:
                       resources:
                         limits:
                           cpu: 500m
-                          memory: 2560Mi
+                          memory: 4Gi
                         requests:
                           cpu: 500m
-                          memory: 2560Mi
+                          memory: 4Gi
             pipelines-as-code-watcher:
               spec:
                 replicas: 2

--- a/components/pipeline-service/staging/lightwell-dev/deploy.yaml
+++ b/components/pipeline-service/staging/lightwell-dev/deploy.yaml
@@ -929,10 +929,10 @@ spec:
                       resources:
                         limits:
                           cpu: 500m
-                          memory: 2560Mi
+                          memory: 4Gi
                         requests:
                           cpu: 500m
-                          memory: 2560Mi
+                          memory: 4Gi
             pipelines-as-code-watcher:
               spec:
                 replicas: 2

--- a/components/pipeline-service/staging/stone-stage-p01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stage-p01/deploy.yaml
@@ -2567,10 +2567,10 @@ spec:
                       resources:
                         limits:
                           cpu: 500m
-                          memory: 2560Mi
+                          memory: 4Gi
                         requests:
                           cpu: 500m
-                          memory: 2560Mi
+                          memory: 4Gi
             pipelines-as-code-watcher:
               spec:
                 replicas: 2

--- a/components/pipeline-service/staging/stone-stg-rh01/deploy.yaml
+++ b/components/pipeline-service/staging/stone-stg-rh01/deploy.yaml
@@ -2579,10 +2579,10 @@ spec:
                       resources:
                         limits:
                           cpu: 500m
-                          memory: 2560Mi
+                          memory: 4Gi
                         requests:
                           cpu: 500m
-                          memory: 2560Mi
+                          memory: 4Gi
             pipelines-as-code-watcher:
               spec:
                 replicas: 2


### PR DESCRIPTION
After PR #13721, the pipelines-as-code-controller pods are hitting OOM kills with spikes reaching ~2.8Gi against the 2560Mi limit, causing frequent restarts. Bump memory limits and requests from 2560Mi to 4Gi across all staging clusters.
