### PR TITLE
KFLUXINFRA-4495: Add DB_PORT env var override for pipeline-service on kflux-lw-p01

### DIFF
--- a/components/pipeline-service/production/kflux-lw-p01/deploy.yaml
+++ b/components/pipeline-service/production/kflux-lw-p01/deploy.yaml
@@ -1450,34 +1450,12 @@ spec:
               topologyKey: kubernetes.io/hostname
             weight: 100
       containers:
-      - args:
-        - --secure-listen-address=0.0.0.0:9443
-        - --upstream=http://127.0.0.1:9090/
-        - --logtostderr=true
-        - --v=6
-        image: registry.redhat.io/openshift4/ose-kube-rbac-proxy:v4.12
-        name: kube-rbac-proxy
-        ports:
-        - containerPort: 9443
-          name: metrics
-          protocol: TCP
-        resources:
-          limits:
-            cpu: 500m
-            memory: 128Mi
-          requests:
-            cpu: 5m
-            memory: 64Mi
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop:
-            - ALL
-          readOnlyRootFilesystem: true
-          runAsNonRoot: true
-          seccompProfile:
-            type: RuntimeDefault
       - env:
+        - name: DB_PORT
+          valueFrom:
+            secretKeyRef:
+              key: db.port
+              name: tekton-results-database
         - name: LOGS_API
           value: "true"
         - name: LOGS_TYPE
@@ -1584,6 +1562,33 @@ spec:
         - mountPath: /etc/tls
           name: tls
           readOnly: true
+      - args:
+        - --secure-listen-address=0.0.0.0:9443
+        - --upstream=http://127.0.0.1:9090/
+        - --logtostderr=true
+        - --v=6
+        image: registry.redhat.io/openshift4/ose-kube-rbac-proxy:v4.12
+        name: kube-rbac-proxy
+        ports:
+        - containerPort: 9443
+          name: metrics
+          protocol: TCP
+        resources:
+          limits:
+            cpu: 500m
+            memory: 128Mi
+          requests:
+            cpu: 5m
+            memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          seccompProfile:
+            type: RuntimeDefault
       serviceAccountName: tekton-results-api
       volumes:
       - configMap:
@@ -1640,34 +1645,12 @@ spec:
               topologyKey: kubernetes.io/hostname
             weight: 100
       containers:
-      - args:
-        - --secure-listen-address=0.0.0.0:9443
-        - --upstream=http://127.0.0.1:9090/
-        - --logtostderr=true
-        - --v=6
-        image: registry.redhat.io/openshift4/ose-kube-rbac-proxy:v4.12
-        name: kube-rbac-proxy
-        ports:
-        - containerPort: 9443
-          name: metrics
-          protocol: TCP
-        resources:
-          limits:
-            cpu: 500m
-            memory: 128Mi
-          requests:
-            cpu: 5m
-            memory: 64Mi
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop:
-            - ALL
-          readOnlyRootFilesystem: true
-          runAsNonRoot: true
-          seccompProfile:
-            type: RuntimeDefault
       - env:
+        - name: DB_PORT
+          valueFrom:
+            secretKeyRef:
+              key: db.port
+              name: tekton-results-database
         - name: LOGS_API
           value: "true"
         - name: LOGS_TYPE
@@ -1774,6 +1757,33 @@ spec:
         - mountPath: /etc/tls
           name: tls
           readOnly: true
+      - args:
+        - --secure-listen-address=0.0.0.0:9443
+        - --upstream=http://127.0.0.1:9090/
+        - --logtostderr=true
+        - --v=6
+        image: registry.redhat.io/openshift4/ose-kube-rbac-proxy:v4.12
+        name: kube-rbac-proxy
+        ports:
+        - containerPort: 9443
+          name: metrics
+          protocol: TCP
+        resources:
+          limits:
+            cpu: 500m
+            memory: 128Mi
+          requests:
+            cpu: 5m
+            memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          seccompProfile:
+            type: RuntimeDefault
       serviceAccountName: tekton-results-api
       volumes:
       - configMap:

--- a/components/pipeline-service/production/kflux-lw-p01/resources/kustomization.yaml
+++ b/components/pipeline-service/production/kflux-lw-p01/resources/kustomization.yaml
@@ -33,6 +33,7 @@ patches:
       group: external-secrets.io
       version: v1
       kind: ExternalSecret
+  - path: tekton-results-db-port-patch.yaml
   - path: update-tekton-config-pac.yaml
     target:
       kind: TektonConfig

--- a/components/pipeline-service/production/kflux-lw-p01/resources/tekton-results-db-port-patch.yaml
+++ b/components/pipeline-service/production/kflux-lw-p01/resources/tekton-results-db-port-patch.yaml
@@ -1,0 +1,33 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tekton-results-api
+  namespace: tekton-results
+spec:
+  template:
+    spec:
+      containers:
+      - name: api
+        env:
+        - name: DB_PORT
+          valueFrom:
+            secretKeyRef:
+              key: db.port
+              name: tekton-results-database
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tekton-results-api-for-watcher
+  namespace: tekton-results
+spec:
+  template:
+    spec:
+      containers:
+      - name: api
+        env:
+        - name: DB_PORT
+          valueFrom:
+            secretKeyRef:
+              key: db.port
+              name: tekton-results-database


### PR DESCRIPTION
## What

- Add `DB_PORT` env var override for `tekton-results-api` and `tekton-results-api-for-watcher` deployments, sourced from the `tekton-results-database` secret's `db.port` key
- Regenerate `deploy.yaml` to include the override

Clusters affected: kflux-lw-p01

[KFLUXINFRA-4495](https://redhat.atlassian.net/browse/KFLUXINFRA-4495)

## Why

The Lightwell production database uses a non-standard port. The base ConfigMap (`tekton-results-api-config`) hardcodes `DB_PORT=5432`, and unlike other DB fields (`DB_USER`, `DB_HOST`, etc.) there was no env var override from the secret. The env var takes precedence at runtime, sourcing the correct port from vault.

## Validation

- `kustomize build` of `components/pipeline-service/production/kflux-lw-p01/resources/` passes
- `deploy.yaml` regenerated via `hack/generate-deploy-config.sh` and verified `DB_PORT` env var present in both API deployments
- Vault secret `plnsvc-database` confirmed to contain `db.port` key

## Risk Assessment

**Risk Level:** Low
**What could go wrong:** If the vault `db.port` value is incorrect, tekton-results-api will fail to connect to the database on kflux-lw-p01.
**Rollback:** Revert PR (falls back to hardcoded 5432 from ConfigMap)
**Blast radius:** production cluster kflux-lw-p01 only

Made with [Cursor](https://cursor.com)

[KFLUXINFRA-4495]: https://redhat.atlassian.net/browse/KFLUXINFRA-4495?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ