### PR TITLE
PVO11Y-5510: Temporarily disable kflux-lw-p01 metrics

### DIFF
--- a/components/monitoring/prometheus/production/kflux-lw-p01/kustomization.yaml
+++ b/components/monitoring/prometheus/production/kflux-lw-p01/kustomization.yaml
@@ -1,19 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-resources:
-- ../base
-- ../tekton-ms
 
-patches:
-  - path: cluster-id-label.yaml
-    target:
-      name: appstudio-federate-ms
-      kind: MonitoringStack
-      group: monitoring.rhobs
-      version: v1alpha1
-  - path: cluster-id-label.yaml
-    target:
-      name: appstudio-tekton-ms
-      kind: MonitoringStack
-      group: monitoring.rhobs
-      version: v1alpha1
+resources: []


### PR DESCRIPTION
## What

- Remove the Prometheus monitoring resources from the `kflux-lw-p01` production overlay.

Clusters affected: `kflux-lw-p01`

[PVO11Y-5510](https://redhat.atlassian.net/browse/PVO11Y-5510)

## Why

Temporarily stop metrics collection from `kflux-lw-p01` while the cluster is not operational yet.

## Validation

- `kustomize build --enable-helm components/monitoring/prometheus/production/kflux-lw-p01/` passes and produces no resources, as intended.
- No staging validation was performed because this is a cluster-specific production change.

## Risk Assessment

**Risk Level:** Low
**What could go wrong:** Metrics and related alerts from `kflux-lw-p01` will still be forwarded to RHOBS if argocd doesn't prune the resources.
**Rollback:** Revert this PR and allow ArgoCD to resync the previous monitoring resources.
**Blast radius:** Prometheus monitoring for the production cluster `kflux-lw-p01`.

[PVO11Y-5510]: https://redhat.atlassian.net/browse/PVO11Y-5510?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ