### PR TITLE
chore(KFLUXVNGD-1303): update staging proxy endpoints

### DIFF
--- a/components/konflux-info/staging/stone-stage-p01/cluster-config.env
+++ b/components/konflux-info/staging/stone-stage-p01/cluster-config.env
@@ -1,10 +1,10 @@
 allow-cache-proxy=true
-http-proxy=squid.caching.svc.cluster.local:3128
+http-proxy=squid.container-image-proxy.svc.cluster.local:3128
 no-proxy=
 
 allow-package-registry-proxy=true
-package-registry-proxy-gomod-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/go-proxy
-package-registry-proxy-npm-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/npm-proxy
-package-registry-proxy-pip-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/pypi-proxy/simple
-package-registry-proxy-pnpm-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/npm-proxy
-package-registry-proxy-yarn-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/npm-proxy
+package-registry-proxy-gomod-url=https://artifact-registry-proxy.artifact-registry-proxy.svc.cluster.local/repository/go-proxy
+package-registry-proxy-npm-url=https://artifact-registry-proxy.artifact-registry-proxy.svc.cluster.local/repository/npm-proxy
+package-registry-proxy-pip-url=https://artifact-registry-proxy.artifact-registry-proxy.svc.cluster.local/repository/pypi-proxy/simple
+package-registry-proxy-pnpm-url=https://artifact-registry-proxy.artifact-registry-proxy.svc.cluster.local/repository/npm-proxy
+package-registry-proxy-yarn-url=https://artifact-registry-proxy.artifact-registry-proxy.svc.cluster.local/repository/npm-proxy

--- a/components/konflux-info/staging/stone-stg-rh01/cluster-config.env
+++ b/components/konflux-info/staging/stone-stg-rh01/cluster-config.env
@@ -1,12 +1,12 @@
 allow-cache-proxy=true
-http-proxy=squid.caching.svc.cluster.local:3128
+http-proxy=squid.container-image-proxy.svc.cluster.local:3128
 no-proxy=
 
 allow-package-registry-proxy=true
-package-registry-proxy-bundler-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/rubygems-proxy
-package-registry-proxy-cargo-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/cargo-proxy
-package-registry-proxy-gomod-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/go-proxy
-package-registry-proxy-npm-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/npm-proxy
-package-registry-proxy-pip-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/pypi-proxy/simple
-package-registry-proxy-pnpm-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/npm-proxy
-package-registry-proxy-yarn-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/npm-proxy
+package-registry-proxy-bundler-url=https://artifact-registry-proxy.artifact-registry-proxy.svc.cluster.local/repository/rubygems-proxy
+package-registry-proxy-cargo-url=https://artifact-registry-proxy.artifact-registry-proxy.svc.cluster.local/repository/cargo-proxy
+package-registry-proxy-gomod-url=https://artifact-registry-proxy.artifact-registry-proxy.svc.cluster.local/repository/go-proxy
+package-registry-proxy-npm-url=https://artifact-registry-proxy.artifact-registry-proxy.svc.cluster.local/repository/npm-proxy
+package-registry-proxy-pip-url=https://artifact-registry-proxy.artifact-registry-proxy.svc.cluster.local/repository/pypi-proxy/simple
+package-registry-proxy-pnpm-url=https://artifact-registry-proxy.artifact-registry-proxy.svc.cluster.local/repository/npm-proxy
+package-registry-proxy-yarn-url=https://artifact-registry-proxy.artifact-registry-proxy.svc.cluster.local/repository/npm-proxy


### PR DESCRIPTION
Point staging cache traffic at the squid service in the container-image-proxy namespace. Point registry traffic at the artifact-registry-proxy service in its dedicated namespace.

Assisted-by: Codex (OpenAI)
Jira-url: https://redhat.atlassian.net/browse/KFLUXVNGD-1303