### PR TITLE
KFLUXVNGD-1306 remove crossplane from Lightwell clusters

### DIFF
--- a/argo-cd-apps/base/member/infra-deployments/crossplane-control-plane/crossplane-control-plane.yaml
+++ b/argo-cd-apps/base/member/infra-deployments/crossplane-control-plane/crossplane-control-plane.yaml
@@ -15,6 +15,10 @@ spec:
                 clusterDir: base
           - list:
               elements:
+                - nameNormalized: lightwell-dev
+                  values.clusterDir: lightwell-dev
+                - nameNormalized: kflux-lw-p01
+                  values.clusterDir: kflux-lw-p01
                 - nameNormalized: stone-stg-rh01
                   values.clusterDir: stone-stg-rh01
                 - nameNormalized: stone-stage-p01

--- a/components/crossplane-control-plane/production/kflux-lw-p01/kustomization.yaml
+++ b/components/crossplane-control-plane/production/kflux-lw-p01/kustomization.yaml
@@ -1,0 +1,3 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources: []

--- a/components/crossplane-control-plane/staging/lightwell-dev/kustomization.yaml
+++ b/components/crossplane-control-plane/staging/lightwell-dev/kustomization.yaml
@@ -1,0 +1,3 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources: []


### PR DESCRIPTION
## What

- Stop deploying the Crossplane control plane to the Lightwell clusters by routing them to empty overlays.

Clusters affected: `lightwell-dev`, `kflux-lw-p01`

[KFLUXVNGD-1306](https://redhat.atlassian.net/browse/KFLUXVNGD-1306)

## Why

Ephemeral clusters cannot currently be provisioned from the Lightwell clusters without additional configuration. Remove the Crossplane control plane until there is clear guidance for supporting ephemeral namespaces and explicit cost-management consideration for ephemeral clusters provisioned through OpenShift CI cluster profiles.

## Validation

- `kustomize build --enable-helm components/crossplane-control-plane/staging/lightwell-dev` passes and renders no resources.
- `kustomize build --enable-helm components/crossplane-control-plane/production/kflux-lw-p01` passes and renders no resources.
- The staging-downstream and production-downstream ArgoCD overlays render successfully.
- The render-diff “build error” is a known false positive caused by valid empty Kustomize output.

## Risk Assessment

**Risk Level:** Low  
**What could go wrong:** An unrecognized dependency on Crossplane could stop reconciliation or disrupt ephemeral-cluster provisioning. This is unlikely because provisioning is not currently functional without additional configuration.  
**Rollback:** Revert this PR and resync the Crossplane applications. Restore any deleted Crossplane custom resources manually if necessary.  
**Blast radius:** `lightwell-dev` and `kflux-lw-p01` only.

[KFLUXVNGD-1306]: https://redhat.atlassian.net/browse/KFLUXVNGD-1306?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ