### PR TITLE
KFLUXVNGD-1292 add Cargo subFilters to artifact-registry-proxy ring-1

### DIFF
--- a/components/artifact-registry-proxy/rings/ring-1/base/caching-helm-generator.yaml
+++ b/components/artifact-registry-proxy/rings/ring-1/base/caching-helm-generator.yaml
@@ -26,6 +26,16 @@ valuesInline:
     auth:
       enabled: true
       secretName: artifact-registry-credentials
+    subFilters:
+      - location: '^/repository/cargo-proxy/config\.json$'
+        types:
+          - application/json
+        once: false
+        filters:
+          - string: '"auth-required":true'
+            replacement: '"auth-required":false'
+          - string: 'https://red-hat.repo.sonatype.app'
+            replacement: 'https://artifact-registry-proxy.artifact-registry-proxy.svc.cluster.local'
     cache:
       allowList:
         - ^/repository/


### PR DESCRIPTION
Port cargo-proxy config.json rewrites from squid staging to the dedicated artifact-registry-proxy component, using the new namespace service URL.
 
Assisted-by: Cursor