### PR TITLE
fixup(PVO11Y-4877): fix spanmetrics ServiceMonitor scrape regex

### DIFF
--- a/components/monitoring/tracing/otel-collector/staging/servicemonitors/otel-collector-mttb-servicemonitor.yaml
+++ b/components/monitoring/tracing/otel-collector/staging/servicemonitors/otel-collector-mttb-servicemonitor.yaml
@@ -11,7 +11,8 @@ spec:
     - port: prometheus
       interval: 15s
       path: /metrics
+      honorLabels: true
       metricRelabelings:
         - sourceLabels: [__name__]
-          regex: 'traces_spanmetrics_.*'
+          regex: 'traces_span_metrics_.*'
           action: keep


### PR DESCRIPTION
ServiceMonitor regex for spanmetrics scraping used `traces_spanmetrics_` but
the connector emits `traces_span_metrics_` (upstream renamed the component from
`spanmetrics` to `span_metrics`). Metrics were not being scraped as a result.