### PR TITLE
PVO11Y-5518 -  add openshift-logging namespace for kflux-lw-p01

### DIFF
--- a/argo-cd-apps/base/all-clusters/infra-deployments/monitoring-workload-logging/monitoring-workload-logging.yaml
+++ b/argo-cd-apps/base/all-clusters/infra-deployments/monitoring-workload-logging/monitoring-workload-logging.yaml
@@ -39,6 +39,8 @@ spec:
                   values.clusterDir: kflux-osp-p01
                 - nameNormalized: kflux-fedora-01
                   values.clusterDir: kflux-fedora-01
+                - nameNormalized: kflux-lw-p01
+                  values.clusterDir: kflux-lw-p01
   template:
     metadata:
       name: monitoring-workload-logging-{{nameNormalized}}

--- a/components/monitoring/logging/production/kflux-lw-p01/kustomization.yaml
+++ b/components/monitoring/logging/production/kflux-lw-p01/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- openshift-logging-ns.yaml
+- ../base
+- ../../base/logging-operator-prerequisite

--- a/components/monitoring/logging/production/kflux-lw-p01/openshift-logging-ns.yaml
+++ b/components/monitoring/logging/production/kflux-lw-p01/openshift-logging-ns.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-logging
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1" # Explicitly forces namespace creation first
+    openshift.io/node-selector: ""
+  labels:
+    openshift.io/cluster-monitoring: "true"


### PR DESCRIPTION
kflux-lw-p01 is excluded from operator-managed clusters but was missing the explicit openshift-logging namespace manifest. This caused ArgoCD sync failures when logging resources tried to deploy to the non-existent namespace.

This change will resolves sync error: "namespaces 'openshift-logging' not found" for the kflux-lw-p01 cluster.
In ROKS, openshift-logging namespace needs to be explicitly created unlike ROSA cluster which is provisioned.