### PR TITLE
KFLUXINFRA-4517: Enable Windows builders on kflux-rhel-p01 (ring-2)

### DIFF
--- a/components/kueue-rd/rings/ring-2/kflux-rhel-p01/cluster-queue.yaml
+++ b/components/kueue-rd/rings/ring-2/kflux-rhel-p01/cluster-queue.yaml
@@ -162,6 +162,7 @@ spec:
     - linux-x86-64
     - local
     - localhost
+    - windows-4xlarge-amd64
     flavors:
     - name: platform-group-3
       resources:
@@ -195,6 +196,8 @@ spec:
         nominalQuota: 1k
       - name: localhost
         nominalQuota: 1k
+      - name: windows-4xlarge-amd64
+        nominalQuota: '5'
 ---
 apiVersion: kueue.x-k8s.io/v1beta2
 kind: ResourceFlavor

--- a/components/multi-platform-controller-rd/rings/ring-2/kflux-rhel-p01/host-values.yaml
+++ b/components/multi-platform-controller-rd/rings/ring-2/kflux-rhel-p01/host-values.yaml
@@ -13,6 +13,12 @@ archDefaults:
     key-name: "kflux-rhel-p01-key-pair"
     security-group-id: "sg-0c67a834068be63d6"
     subnet-id: "subnet-0f3208c0214c55e2e"
+  windows-amd64:
+    ami: "ami-07adb88c7ad360947"
+    key-name: "kflux-rhel-p01-key-pair"
+    security-group-id: "sg-0c67a834068be63d6"
+    subnet-id: "subnet-0f3208c0214c55e2e"
+    ssh-secret: "aws-ssh-key"
 
 dynamicConfigs:
   linux-arm64:
@@ -126,6 +132,11 @@ dynamicConfigs:
   linux-fast-amd64: {}
 
   linux-extra-fast-amd64: {}
+
+  windows-4xlarge-amd64:
+    allowed-remote-addresses:
+    - 10.28.2.0/23
+    # user-data loaded from base/host-config-chart/files/windows-init.ps1
 
 # Static hosts configuration
 staticHosts:


### PR DESCRIPTION
## What

- Add `windows-amd64` arch defaults and `windows-4xlarge-amd64` dynamic pool to multi-platform-controller on kflux-rhel-p01 (reuses existing Linux AMI region, RSA key pair, SG, and subnet; SSH firewall limited to `10.28.2.0/23`)
- Add Kueue `windows-4xlarge-amd64` quota of 5 on the same cluster

Clusters affected: kflux-rhel-p01

[KFLUXINFRA-4517](https://redhat.atlassian.net/browse/KFLUXINFRA-4517)

## Why

Windows builders are already running on `stone-stage-p01` and `stone-prod-p02`. Enable them on `kflux-rhel-p01` so RHEL-related Windows driver builds (virtio-win-prewhql) can run on the RHEL cluster.

## Validation

- `kustomize build --enable-helm components/multi-platform-controller-rd/rings/ring-2/kflux-rhel-p01/` succeeds; rendered host-config includes `windows-4xlarge/amd64` on `dynamic-platforms`, `max-instances: 5`, AMI `ami-07adb88c7ad360947`, key `kflux-rhel-p01-key-pair`, and OpenSSH `-RemoteAddress '10.28.2.0/23'`
- `kustomize build --enable-helm components/kueue-rd/rings/ring-2/kflux-rhel-p01/` succeeds; ClusterQueue `platform-group-3` includes `windows-4xlarge-amd64` with quota `5`
- Same Windows pool shape is already live on staging (`stone-stage-p01`, ring-1) and production (`stone-prod-p02`, ring-3)

## Risk Assessment

**Risk Level:** Medium
**What could go wrong:** A misconfigured AMI, key, or SSH firewall CIDR would prevent Windows builders from coming up or being reachable from the cluster. If the pool does come up incorrectly, up to 5 `c5.4xlarge` instances could be provisioned in the kflux-rhel-p01 AWS account. Existing Linux/static host pools are unchanged.
**Rollback:** Revert PR; ArgoCD resyncs the previous host-config and ClusterQueue (no Windows pool, no Windows quota). Any already-running Windows instances would still need to be terminated by MPC as usual after the pool is removed.
**Blast radius:** production cluster kflux-rhel-p01 only (ring-2). No other clusters.

Made with [Cursor](https://cursor.com)

[KFLUXINFRA-4517]: https://redhat.atlassian.net/browse/KFLUXINFRA-4517?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ