### PR TITLE
SPRE-6614 add spre-telemetry SA and RBAC to production workload clusters

### DIFF
--- a/argo-cd-apps/base/member/infra-deployments/kustomization.yaml
+++ b/argo-cd-apps/base/member/infra-deployments/kustomization.yaml
@@ -16,6 +16,7 @@ resources:
   - image-rbac-proxy
   - multi-platform-controller
   - perf-team-prometheus-reader
+  - spre-telemetry
   - project-controller
   - mintmaker
   - monitoring-cardinality

--- a/argo-cd-apps/base/member/infra-deployments/spre-telemetry/kustomization.yaml
+++ b/argo-cd-apps/base/member/infra-deployments/spre-telemetry/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - spre-telemetry.yaml
+components:
+  - ../../../../k-components/deploy-to-member-cluster-merge-generator

--- a/argo-cd-apps/base/member/infra-deployments/spre-telemetry/spre-telemetry.yaml
+++ b/argo-cd-apps/base/member/infra-deployments/spre-telemetry/spre-telemetry.yaml
@@ -1,0 +1,57 @@
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: spre-telemetry
+spec:
+  generators:
+    - merge:
+        mergeKeys:
+          - nameNormalized
+        generators:
+          - clusters:
+              values:
+                sourceRoot: components/spre-telemetry
+                environment: staging
+                clusterDir: empty-base
+          - list:
+              elements:
+                - nameNormalized: stone-prd-rh01
+                  values.clusterDir: stone-prd-rh01
+                - nameNormalized: kflux-prd-rh02
+                  values.clusterDir: kflux-prd-rh02
+                - nameNormalized: kflux-prd-rh03
+                  values.clusterDir: kflux-prd-rh03
+                - nameNormalized: kflux-ocp-p01
+                  values.clusterDir: kflux-ocp-p01
+                - nameNormalized: kflux-osp-p01
+                  values.clusterDir: kflux-osp-p01
+                - nameNormalized: kflux-rhel-p01
+                  values.clusterDir: kflux-rhel-p01
+                - nameNormalized: stone-prod-p01
+                  values.clusterDir: stone-prod-p01
+                - nameNormalized: stone-prod-p02
+                  values.clusterDir: stone-prod-p02
+  template:
+    metadata:
+      name: spre-telemetry-{{nameNormalized}}
+    spec:
+      project: default
+      source:
+        path: '{{values.sourceRoot}}/{{values.environment}}/{{values.clusterDir}}'
+        repoURL: https://github.com/redhat-appstudio/infra-deployments.git
+        targetRevision: main
+      destination:
+        namespace: spre-telemetry
+        server: '{{server}}'
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
+        syncOptions:
+          - CreateNamespace=true
+        retry:
+          limit: -1
+          backoff:
+            duration: 10s
+            factor: 2
+            maxDuration: 3m

--- a/argo-cd-apps/overlays/development/kustomization.yaml
+++ b/argo-cd-apps/overlays/development/kustomization.yaml
@@ -235,6 +235,11 @@ patches:
     target:
       kind: ApplicationSet
       version: v1alpha1
+      name: spre-telemetry
+  - path: development-overlay-patch.yaml
+    target:
+      kind: ApplicationSet
+      version: v1alpha1
       name: dummy-deployment
   - path: development-overlay-patch.yaml
     target:

--- a/argo-cd-apps/overlays/konflux-public-production/kustomization.yaml
+++ b/argo-cd-apps/overlays/konflux-public-production/kustomization.yaml
@@ -259,6 +259,11 @@ patches:
     target:
       kind: ApplicationSet
       version: v1alpha1
+      name: spre-telemetry
+  - path: production-overlay-patch.yaml
+    target:
+      kind: ApplicationSet
+      version: v1alpha1
       name: k8s-groups
   - path: production-overlay-patch.yaml
     target:

--- a/argo-cd-apps/overlays/production-downstream/kustomization.yaml
+++ b/argo-cd-apps/overlays/production-downstream/kustomization.yaml
@@ -278,6 +278,11 @@ patches:
     target:
       kind: ApplicationSet
       version: v1alpha1
+      name: spre-telemetry
+  - path: production-overlay-patch.yaml
+    target:
+      kind: ApplicationSet
+      version: v1alpha1
       name: k8s-groups
   - path: production-overlay-patch.yaml
     target:

--- a/components/spre-telemetry/OWNERS
+++ b/components/spre-telemetry/OWNERS
@@ -1,0 +1,7 @@
+# See the OWNERS docs: https://go.k8s.io/owners
+
+approvers:
+  - ggeorgie
+
+reviewers:
+  - ggeorgie

--- a/components/spre-telemetry/base/clusterrolebinding.yaml
+++ b/components/spre-telemetry/base/clusterrolebinding.yaml
@@ -1,0 +1,18 @@
+---
+# Binds the SPRE telemetry SA to the standard read-only bot role.
+# Note: konflux-viewer-bot-actions covers core Konflux resources but is
+# narrower than the full telemetry surface (no config.openshift.io, MCPs,
+# nodes, Kueue). A new konflux-telemetry-bot-actions role has been proposed
+# to the Konflux RBAC team — this binding will be updated once it lands.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: spre-telemetry-reader
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: konflux-viewer-bot-actions
+subjects:
+  - kind: ServiceAccount
+    name: konflux-bot-0
+    namespace: spre-telemetry

--- a/components/spre-telemetry/base/kustomization.yaml
+++ b/components/spre-telemetry/base/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - serviceaccount.yaml
+  - clusterrolebinding.yaml
+  - token-minting-rbac.yaml

--- a/components/spre-telemetry/base/serviceaccount.yaml
+++ b/components/spre-telemetry/base/serviceaccount.yaml
@@ -1,0 +1,11 @@
+---
+# To generate a token per cluster after this merges:
+#   oc -n spre-telemetry create token konflux-bot-0
+# Store each token in Vault: stonesoup/staging/spre/cluster-sa-tokens
+# Key convention: TOKEN_<CLUSTER_NAME> (e.g. TOKEN_STONE_PRD_RH01)
+# Duration is a team operational choice. Rotation procedure in SPRE-6648.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: konflux-bot-0
+  namespace: spre-telemetry

--- a/components/spre-telemetry/base/token-minting-rbac.yaml
+++ b/components/spre-telemetry/base/token-minting-rbac.yaml
@@ -1,0 +1,32 @@
+---
+# Allows the SPRE rover group to mint bound tokens for konflux-bot-0
+# without needing cluster-admin. Token generation:
+#   oc -n spre-telemetry create token konflux-bot-0
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: spre-telemetry-token-creator
+  namespace: spre-telemetry
+rules:
+  - verbs:
+      - create
+    apiGroups:
+      - ""
+    resources:
+      - serviceaccounts/token
+    resourceNames:
+      - konflux-bot-0
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: spre-telemetry-token-creator
+  namespace: spre-telemetry
+subjects:
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: sp-resilience-team
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: spre-telemetry-token-creator

--- a/components/spre-telemetry/development/kustomization.yaml
+++ b/components/spre-telemetry/development/kustomization.yaml
@@ -1,0 +1,3 @@
+kind: Kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+resources: []

--- a/components/spre-telemetry/production/empty-base/kustomization.yaml
+++ b/components/spre-telemetry/production/empty-base/kustomization.yaml
@@ -1,0 +1,3 @@
+kind: Kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+resources: []

--- a/components/spre-telemetry/production/kflux-ocp-p01/kustomization.yaml
+++ b/components/spre-telemetry/production/kflux-ocp-p01/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base

--- a/components/spre-telemetry/production/kflux-osp-p01/kustomization.yaml
+++ b/components/spre-telemetry/production/kflux-osp-p01/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base

--- a/components/spre-telemetry/production/kflux-prd-rh02/kustomization.yaml
+++ b/components/spre-telemetry/production/kflux-prd-rh02/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base

--- a/components/spre-telemetry/production/kflux-prd-rh03/kustomization.yaml
+++ b/components/spre-telemetry/production/kflux-prd-rh03/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base

--- a/components/spre-telemetry/production/kflux-rhel-p01/kustomization.yaml
+++ b/components/spre-telemetry/production/kflux-rhel-p01/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base

--- a/components/spre-telemetry/production/stone-prd-rh01/kustomization.yaml
+++ b/components/spre-telemetry/production/stone-prd-rh01/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base

--- a/components/spre-telemetry/production/stone-prod-p01/kustomization.yaml
+++ b/components/spre-telemetry/production/stone-prod-p01/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base

--- a/components/spre-telemetry/production/stone-prod-p02/kustomization.yaml
+++ b/components/spre-telemetry/production/stone-prod-p02/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base

--- a/components/spre-telemetry/staging/empty-base/kustomization.yaml
+++ b/components/spre-telemetry/staging/empty-base/kustomization.yaml
@@ -1,0 +1,3 @@
+kind: Kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+resources: []


### PR DESCRIPTION
## What

Add `spre-telemetry` component deploying a read-only `konflux-bot-0` ServiceAccount and supporting RBAC to all 8 Konflux production workload clusters
via an ArgoCD ApplicationSet.

**Files changed:**

- `components/spre-telemetry/base/` — ServiceAccount (`konflux-bot-0`), ClusterRoleBinding (`→ konflux-viewer-bot-actions`), token-minting Role +
RoleBinding for `sp-resilience-team`
- `components/spre-telemetry/production/<cluster>/` — 8 per-cluster overlays pointing to `../../base` (stone-prd-rh01, kflux-prd-rh02, kflux-prd-rh03,
kflux-ocp-p01, kflux-osp-p01, kflux-rhel-p01, stone-prod-p01, stone-prod-p02)
- `components/spre-telemetry/production/empty-base/` — no-op default for unlisted production clusters
- `components/spre-telemetry/staging/empty-base/` — no-op default for staging member clusters
- `components/spre-telemetry/development/` — no-op default for development member clusters
- `argo-cd-apps/base/member/infra-deployments/spre-telemetry/` — ApplicationSet (merge generator, `konflux-bot-*` policy-compliant,
`CreateNamespace=true`)
- `argo-cd-apps/base/member/infra-deployments/kustomization.yaml` — adds `spre-telemetry`
- `argo-cd-apps/overlays/production-downstream/kustomization.yaml` — wires `production-overlay-patch` for `spre-telemetry`
- `argo-cd-apps/overlays/konflux-public-production/kustomization.yaml` — wires `production-overlay-patch` for `spre-telemetry`
- `argo-cd-apps/overlays/development/kustomization.yaml` — wires `development-overlay-patch` for `spre-telemetry`
- `components/spre-telemetry/OWNERS` — approver: ggeorgie

## Why

The Agentic SPRE AI platform (Pharos and Lumino MCP servers) requires a `konflux-bot-0` ServiceAccount on each production cluster to generate
short-lived bound tokens. Those tokens are stored in Vault and delivered to the `spre-automations` namespace on the inner-services clusters via
External Secrets Operator ([SPRE-6648](https://redhat.atlassian.net/browse/SPRE-6648)), allowing Pharos to authenticate and collect telemetry remotely.

**Design decisions:**

- `konflux-bot-0` — ValidatingAdmissionPolicy-compliant SA name for workload clusters
- `konflux-viewer-bot-actions` — current binding; VAP-compliant. A follow-up PR to `konflux-rbac/production/base/` proposes
`konflux-telemetry-bot-actions` with the full telemetry surface (`config.openshift.io`, MCPs, nodes, Kueue). The CRB will be updated once that role is
approved.
- Token-minting Role pinned via `resourceNames: [konflux-bot-0]` — limits `sp-resilience-team` to only this SA
- `secrets-read` deliberately excluded — pending a separate team decision ([SPRE-6656](https://redhat.atlassian.net/browse/SPRE-6656))
- Sibling PR to `infra-common-deployments` covers inner-services clusters with a custom `pharos-reader` ClusterRole (SA-restriction policies do not
apply there)

## Validation

- `kubectl kustomize components/spre-telemetry/production/stone-prd-rh01/` — renders 4 resources cleanly: `ServiceAccount`, `Role`, `RoleBinding`,
`ClusterRoleBinding`
- `kubectl kustomize components/spre-telemetry/production/empty-base/` — exit 0, no resources (correct no-op)
- `kubectl kustomize components/spre-telemetry/staging/empty-base/` — exit 0, no resources
- `kubectl kustomize components/spre-telemetry/development/` — exit 0, no resources
- `konflux-viewer-bot-actions` ClusterRole confirmed present in `konflux-rbac/production/base/` — CRB reference is valid
- Overlay wiring mirrors `perf-team-prometheus-reader` across all three patched overlays (`production-downstream`, `konflux-public-production`,
`development`)

## Risk Assessment

**Risk Level:** Low

**What could go wrong:**
- ClusterRoleBinding references `konflux-viewer-bot-actions` — this role already exists on all target clusters via the `konflux-rbac` ApplicationSet;
no ordering risk
- `CreateNamespace=true` creates `spre-telemetry` namespace automatically — no pre-existing namespace conflict
- All verbs are read-only (`get`, `list`, `watch`) — no write permissions anywhere; `secrets-read` excluded
- `development` and `staging` environments receive empty-base (no resources applied)

**Blast radius:** `spre-telemetry` namespace on 8 production workload clusters only. No existing workloads affected.

**Rollback:** Revert this PR. ArgoCD (`selfHeal: true`, `prune: true`) removes the namespace, SA, and RBAC from all 8 clusters on the next reconcile.

Jira: https://redhat.atlassian.net/browse/SPRE-6614

[SPRE-6656]: https://redhat.atlassian.net/browse/SPRE-6656?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[SPRE-6648]: https://redhat.atlassian.net/browse/SPRE-6648?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ