### PR TITLE
KFLUXINFRA-4495: Use IBM Cloud DB CA for tekton-results on kflux-lw-p01 (ring-2)

### DIFF
--- a/components/pipeline-service/production/kflux-lw-p01/deploy.yaml
+++ b/components/pipeline-service/production/kflux-lw-p01/deploy.yaml
@@ -1591,9 +1591,12 @@ spec:
             type: RuntimeDefault
       serviceAccountName: tekton-results-api
       volumes:
-      - configMap:
-          name: rds-root-crt
-        name: db-tls-ca
+      - name: db-tls-ca
+        secret:
+          items:
+          - key: tekton-results-db-ca.pem
+            path: tekton-results-db-ca.pem
+          secretName: tekton-results-database
       - configMap:
           name: tekton-results-api-config
         name: config
@@ -1786,9 +1789,12 @@ spec:
             type: RuntimeDefault
       serviceAccountName: tekton-results-api
       volumes:
-      - configMap:
-          name: rds-root-crt
-        name: db-tls-ca
+      - name: db-tls-ca
+        secret:
+          items:
+          - key: tekton-results-db-ca.pem
+            path: tekton-results-db-ca.pem
+          secretName: tekton-results-database
       - configMap:
           name: tekton-results-api-config
         name: config
@@ -2131,6 +2137,11 @@ spec:
     creationPolicy: Owner
     deletionPolicy: Delete
     name: tekton-results-database
+    template:
+      data:
+        tekton-results-db-ca.pem: '{{ index . "db.ca_cert" | b64dec }}'
+      engineVersion: v2
+      mergePolicy: Merge
 ---
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret

--- a/components/pipeline-service/production/kflux-lw-p01/resources/kustomization.yaml
+++ b/components/pipeline-service/production/kflux-lw-p01/resources/kustomization.yaml
@@ -34,6 +34,7 @@ patches:
       version: v1
       kind: ExternalSecret
   - path: tekton-results-db-port-patch.yaml
+  - path: tekton-results-db-ca-patch.yaml
   - path: update-tekton-config-pac.yaml
     target:
       kind: TektonConfig

--- a/components/pipeline-service/production/kflux-lw-p01/resources/tekton-results-database-secret-path.yaml
+++ b/components/pipeline-service/production/kflux-lw-p01/resources/tekton-results-database-secret-path.yaml
@@ -5,3 +5,10 @@
 - op: replace
   path: /spec/secretStoreRef/name
   value: appsre-stonesoup-vault
+- op: add
+  path: /spec/target/template
+  value:
+    engineVersion: v2
+    mergePolicy: Merge
+    data:
+      tekton-results-db-ca.pem: '{{ index . "db.ca_cert" | b64dec }}'

--- a/components/pipeline-service/production/kflux-lw-p01/resources/tekton-results-db-ca-patch.yaml
+++ b/components/pipeline-service/production/kflux-lw-p01/resources/tekton-results-db-ca-patch.yaml
@@ -1,0 +1,35 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tekton-results-api
+  namespace: tekton-results
+spec:
+  template:
+    spec:
+      volumes:
+      - name: db-tls-ca
+        configMap:
+          $patch: delete
+        secret:
+          secretName: tekton-results-database
+          items:
+          - key: tekton-results-db-ca.pem
+            path: tekton-results-db-ca.pem
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tekton-results-api-for-watcher
+  namespace: tekton-results
+spec:
+  template:
+    spec:
+      volumes:
+      - name: db-tls-ca
+        configMap:
+          $patch: delete
+        secret:
+          secretName: tekton-results-database
+          items:
+          - key: tekton-results-db-ca.pem
+            path: tekton-results-db-ca.pem


### PR DESCRIPTION
## What

- Decode Vault `db.ca_cert` into `tekton-results-db-ca.pem` on ExternalSecret `tekton-results-database` (`mergePolicy: Merge`)
- Point `tekton-results-api` and `tekton-results-api-for-watcher` `db-tls-ca` volume at that secret key instead of ConfigMap `rds-root-crt`
- Regenerate `deploy.yaml`

Clusters affected: kflux-lw-p01

[KFLUXINFRA-4495](https://redhat.atlassian.net/browse/KFLUXINFRA-4495)

## Why

tekton-results on kflux-lw-p01 connects to IBM Cloud Databases Postgres with `DB_SSLMODE=verify-full`, but was verifying against the Amazon RDS root CA. That fails with `x509: certificate signed by unknown authority`. The IBM CA is already in Vault as base64-wrapped PEM (`db.ca_cert`) and must be decoded before use.

## Validation

- `kustomize build --enable-helm components/pipeline-service/production/kflux-lw-p01/resources` and the overlay both succeed; `hack/generate-deploy-config.sh` output matches committed `deploy.yaml`
- On-cluster smoke test on kflux-lw-p01 with renamed copies (`tekton-results-database-ca-test`, `tekton-results-api-ca-test`, `tekton-results-api-for-watcher-ca-test`): ExternalSecret `SecretSynced`, both test deployments **1/1 Ready**

## Risk Assessment

**Risk Level:** Low
**What could go wrong:** If ExternalSecret templating fails or `db.ca_cert` is missing/malformed, the decoded PEM key would not appear and the API pods would keep failing TLS (current broken state). A bad decode could also replace a working CA after this lands. Existing `db.user` / `db.host` / `db.port` keys are preserved via `mergePolicy: Merge`. `DB_PORT` and `DB_SSLROOTCERT` path are unchanged.
**Rollback:** Revert PR; ArgoCD resyncs the previous ExternalSecret (no template) and RDS CA ConfigMap volume. The test objects on the cluster are not GitOps-managed and must be deleted separately if still present (`oc delete -f /tmp/tekton-results-ca-test.yaml`).
**Blast radius:** production cluster kflux-lw-p01 only (ring-2). Tekton Results API availability on that cluster.

Made with [Cursor](https://cursor.com)

[KFLUXINFRA-4495]: https://redhat.atlassian.net/browse/KFLUXINFRA-4495?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ