### PR TITLE
SPRE-6614 propose konflux-telemetry-bot-actions as new standard bot role for SRE telemetry agents

### DIFF
--- a/components/konflux-rbac/production/base/konflux-telemetry-bot-actions.yaml
+++ b/components/konflux-rbac/production/base/konflux-telemetry-bot-actions.yaml
@@ -1,0 +1,112 @@
+---
+# ClusterRole for SRE telemetry agents (e.g. Pharos, Lumino) requiring
+# read-only access to infrastructure health, pipeline status, and cluster
+# observability resources beyond what konflux-viewer-bot-actions covers.
+#
+# Can be bound to konflux-bot-* ServiceAccounts.
+# secrets-read deliberately excluded — separate team decision required.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: konflux-telemetry-bot-actions
+rules:
+  # Core resources — cluster and namespace read
+  - apiGroups: [""]
+    resources:
+      - configmaps
+      - endpoints
+      - events
+      - limitranges
+      - namespaces
+      - nodes
+      - persistentvolumeclaims
+      - persistentvolumes
+      - pods
+      - pods/log
+      - replicationcontrollers
+      - resourcequotas
+      - serviceaccounts
+      - services
+    verbs: [get, list, watch]
+  # Workloads
+  - apiGroups: [apps]
+    resources:
+      - daemonsets
+      - deployments
+      - replicasets
+      - statefulsets
+    verbs: [get, list, watch]
+  # Jobs
+  - apiGroups: [batch]
+    resources:
+      - cronjobs
+      - jobs
+    verbs: [get, list, watch]
+  # Tekton pipelines — extends viewer-bot-actions (pipelineruns/taskruns)
+  # with full pipeline/task definition read
+  - apiGroups: [tekton.dev]
+    resources:
+      - pipelines
+      - pipelineruns
+      - taskruns
+      - tasks
+    verbs: [get, list, watch]
+  # KubeArchive / Tekton Results
+  - apiGroups: [results.tekton.dev]
+    resources:
+      - logs
+      - records
+      - results
+    verbs: [get, list]
+  # Konflux application resources (superset of viewer-bot-actions)
+  - apiGroups: [appstudio.redhat.com]
+    resources:
+      - applications
+      - components
+      - componentgroups
+      - releases
+      - snapshots
+    verbs: [get, list, watch]
+  - apiGroups: [konflux-ci.dev]
+    resources:
+      - componentgroups
+    verbs: [get, list, watch]
+  - apiGroups: [pipelinesascode.tekton.dev]
+    resources:
+      - repositories
+    verbs: [get, list, watch]
+  # OpenShift cluster operator status
+  - apiGroups: [config.openshift.io]
+    resources:
+      - apiservers
+      - clusteroperators
+      - clusterversions
+      - infrastructures
+      - networks
+      - proxies
+    verbs: [get, list, watch]
+  # Machine and node health
+  - apiGroups: [machine.openshift.io]
+    resources:
+      - machines
+      - machinesets
+    verbs: [get, list, watch]
+  # MachineConfigPool status — separate apiGroup from machine.openshift.io
+  - apiGroups: [machineconfiguration.openshift.io]
+    resources:
+      - machineconfigpools
+    verbs: [get, list, watch]
+  # Metrics and alerting context
+  - apiGroups: [monitoring.coreos.com]
+    resources:
+      - podmonitors
+      - prometheusrules
+      - servicemonitors
+    verbs: [get, list]
+  # Queue triage
+  - apiGroups: [kueue.x-k8s.io]
+    resources:
+      - clusterqueues
+      - localqueues
+      - workloads
+    verbs: [get, list, watch]

--- a/components/konflux-rbac/production/base/kustomization.yaml
+++ b/components/konflux-rbac/production/base/kustomization.yaml
@@ -15,5 +15,6 @@ resources:
 - konflux-releaser-bot-actions.yaml
 - konflux-secrets-bot-actions.yaml
 - konflux-viewer-bot-actions.yaml
+- konflux-telemetry-bot-actions.yaml
 # can NOT be bound to konflux-bot-* ServiceAccounts
 - konflux-tester-internalbot-actions.yaml

--- a/components/konflux-rbac/staging/base/konflux-telemetry-bot-actions.yaml
+++ b/components/konflux-rbac/staging/base/konflux-telemetry-bot-actions.yaml
@@ -1,0 +1,112 @@
+---
+# ClusterRole for SRE telemetry agents (e.g. Pharos, Lumino) requiring
+# read-only access to infrastructure health, pipeline status, and cluster
+# observability resources beyond what konflux-viewer-bot-actions covers.
+#
+# Can be bound to konflux-bot-* ServiceAccounts.
+# secrets-read deliberately excluded — separate team decision required.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: konflux-telemetry-bot-actions
+rules:
+  # Core resources — cluster and namespace read
+  - apiGroups: [""]
+    resources:
+      - configmaps
+      - endpoints
+      - events
+      - limitranges
+      - namespaces
+      - nodes
+      - persistentvolumeclaims
+      - persistentvolumes
+      - pods
+      - pods/log
+      - replicationcontrollers
+      - resourcequotas
+      - serviceaccounts
+      - services
+    verbs: [get, list, watch]
+  # Workloads
+  - apiGroups: [apps]
+    resources:
+      - daemonsets
+      - deployments
+      - replicasets
+      - statefulsets
+    verbs: [get, list, watch]
+  # Jobs
+  - apiGroups: [batch]
+    resources:
+      - cronjobs
+      - jobs
+    verbs: [get, list, watch]
+  # Tekton pipelines — extends viewer-bot-actions (pipelineruns/taskruns)
+  # with full pipeline/task definition read
+  - apiGroups: [tekton.dev]
+    resources:
+      - pipelines
+      - pipelineruns
+      - taskruns
+      - tasks
+    verbs: [get, list, watch]
+  # KubeArchive / Tekton Results
+  - apiGroups: [results.tekton.dev]
+    resources:
+      - logs
+      - records
+      - results
+    verbs: [get, list]
+  # Konflux application resources (superset of viewer-bot-actions)
+  - apiGroups: [appstudio.redhat.com]
+    resources:
+      - applications
+      - components
+      - componentgroups
+      - releases
+      - snapshots
+    verbs: [get, list, watch]
+  - apiGroups: [konflux-ci.dev]
+    resources:
+      - componentgroups
+    verbs: [get, list, watch]
+  - apiGroups: [pipelinesascode.tekton.dev]
+    resources:
+      - repositories
+    verbs: [get, list, watch]
+  # OpenShift cluster operator status
+  - apiGroups: [config.openshift.io]
+    resources:
+      - apiservers
+      - clusteroperators
+      - clusterversions
+      - infrastructures
+      - networks
+      - proxies
+    verbs: [get, list, watch]
+  # Machine and node health
+  - apiGroups: [machine.openshift.io]
+    resources:
+      - machines
+      - machinesets
+    verbs: [get, list, watch]
+  # MachineConfigPool status — separate apiGroup from machine.openshift.io
+  - apiGroups: [machineconfiguration.openshift.io]
+    resources:
+      - machineconfigpools
+    verbs: [get, list, watch]
+  # Metrics and alerting context
+  - apiGroups: [monitoring.coreos.com]
+    resources:
+      - podmonitors
+      - prometheusrules
+      - servicemonitors
+    verbs: [get, list]
+  # Queue triage
+  - apiGroups: [kueue.x-k8s.io]
+    resources:
+      - clusterqueues
+      - localqueues
+      - workloads
+    verbs: [get, list, watch]

--- a/components/konflux-rbac/staging/base/kustomization.yaml
+++ b/components/konflux-rbac/staging/base/kustomization.yaml
@@ -15,5 +15,6 @@ resources:
   - konflux-releaser-bot-actions.yaml
   - konflux-secrets-bot-actions.yaml
   - konflux-viewer-bot-actions.yaml
+  - konflux-telemetry-bot-actions.yaml
   # can NOT be bound to konflux-bot-* ServiceAccounts
   - konflux-tester-internalbot-actions.yaml


### PR DESCRIPTION
## What

Add `konflux-telemetry-bot-actions` ClusterRole to both `konflux-rbac/staging/base/`
and `konflux-rbac/production/base/` — one file each, identical content, following the
pattern of all existing `konflux-*-bot-actions` roles.

## Why

**Precedent:** The Perfscale team previously shipped a custom read-only ClusterRole
in their component (PR #13426) and it was reverted in PR #13608 in favour of binding
to an existing standard `konflux-*-bot-actions` role. This PR follows that lesson:
rather than shipping a team-private role inside the `spre-telemetry` component, we
propose a new *standard* role in the central `konflux-rbac` directory where all
shared bot roles are maintained and reviewed by the RBAC team.

**Gap being filled:** The Agentic SPRE AI platform (Pharos and Lumino MCP servers)
requires read-only access to infra health signals that `konflux-viewer-bot-actions`
does not cover:

| Missing from `konflux-viewer-bot-actions` | Needed for |
|---|---|
| `config.openshift.io` (clusteroperators, clusterversions, etc.) | Cluster operator status |
| `machineconfiguration.openshift.io` (machineconfigpools) | MachineConfigPool health |
| `machine.openshift.io` (machines, machinesets) | Node/machine health |
| Core: nodes, events, namespaces, configmaps, services, etc. | Fleet-wide read |
| `apps`: deployments, daemonsets, replicasets, statefulsets | Workload health |
| `batch`: jobs, cronjobs | Job triage |
| `results.tekton.dev`: results, records, logs | KubeArchive access |
| `monitoring.coreos.com`: servicemonitors, prometheusrules | Alerting context |
| `kueue.x-k8s.io`: workloads, clusterqueues, localqueues | Queue triage |

**Design decisions:**

- Superset of `konflux-viewer-bot-actions` — retains all existing rules
  (`appstudio.redhat.com`, `konflux-ci.dev`, `pipelinesascode.tekton.dev`) and adds
  the infra telemetry surface on top
- `clustertasks` omitted — deprecated in recent Tekton
- `machineconfigpools` placed under `machineconfiguration.openshift.io`, not
  `machine.openshift.io` — separate apiGroups, incorrectly combined would silently 403
- `secrets-read` deliberately excluded — requires a separate team decision
- Name follows `konflux-*-bot-actions` convention — the ValidatingAdmissionPolicy
  will allow `konflux-bot-0` to bind it

**Sequencing:** The `spre-telemetry` component
([PR #13855](https://github.com/redhat-appstudio/infra-deployments/pull/13855))
currently binds `konflux-viewer-bot-actions` as a VAP-compliant deployable starting
point. Once this role is merged, a one-line ClusterRoleBinding update in
`components/spre-telemetry/base/clusterrolebinding.yaml` flips it to
`konflux-telemetry-bot-actions`. No re-deploy of the namespace or SA required.

## Validation

- Added to both `staging/base/kustomization.yaml` and `production/base/kustomization.yaml`
  in the `# can be bound to konflux-bot-* ServiceAccounts` section
- `kubectl kustomize components/konflux-rbac/production/stone-prd-rh01/` renders the
  new ClusterRole alongside all existing ones — no conflicts
- Staging and production files are identical — matches the pattern of every other
  `konflux-*-bot-actions` role in this directory (`diff` is empty)

## Risk Assessment

**Risk Level:** Low

**What could go wrong:** Adding a new ClusterRole is purely additive. No existing
bindings reference `konflux-telemetry-bot-actions` until the `spre-telemetry` trailing
CRB update is merged — the role can exist unused without any side effects.

**Blast radius:** New cluster-scoped read-only ClusterRole only. No write permissions
anywhere. No existing resources modified.

**Rollback:** Revert this PR. The `konflux-rbac` ApplicationSet (`prune: true`)
removes the ClusterRole from all clusters on the next reconcile.

---

Jira: https://redhat.atlassian.net/browse/SPRE-6614
Perfscale precedent: #13426 (custom role) → #13608 (reverted, standard role used instead)
Sibling PR (spre-telemetry, pending this role): https://github.com/redhat-appstudio/infra-deployments/pull/13855