### PR TITLE
fix(PVO11Y-5520): Disable RPM kanary probe on stone-stage-p01 and lightwell-dev

### DIFF
--- a/components/monitoring/kanary/staging/lightwell-dev/cronjobs/kustomization.yaml
+++ b/components/monitoring/kanary/staging/lightwell-dev/cronjobs/kustomization.yaml
@@ -1,4 +1,3 @@
 resources:
   - kanary-cronjob-single-arch.yaml
   - kanary-cronjob-multi-arch.yaml
-  - kanary-cronjob-rpm.yaml

--- a/components/monitoring/kanary/staging/stone-stage-p01/cronjobs/kustomization.yaml
+++ b/components/monitoring/kanary/staging/stone-stage-p01/cronjobs/kustomization.yaml
@@ -1,4 +1,3 @@
 resources:
   - kanary-cronjob-single-arch.yaml
   - kanary-cronjob-multi-arch.yaml
-  - kanary-cronjob-rpm.yaml


### PR DESCRIPTION
## What

Remove `kanary-cronjob-rpm.yaml` from the kustomization of `stone-stage-p01` and `lightwell-dev` staging cluster overlays.

[PVO11Y-5520](https://redhat.atlassian.net/browse/PVO11Y-5520)

## Why

The RPM pipeline requires remote build hosts for certain architectures. On these staging clusters the available capacity for these hosts is limited, causing the kanary RPM PipelineRun to queue in Kueue until the 30-minute kanary timeout kills it consistently. This is an infrastructure constraint that cannot be resolved at the kanary level. Disabling until a proper solution is in place.

## Validation

- `kustomize build` passes for both cluster overlays

[PVO11Y-5520]: https://redhat.atlassian.net/browse/PVO11Y-5520?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ