### PR TITLE
[KFLUXINFRA-4551] replace failed machines with a new ones

### DIFF
--- a/components/multi-platform-controller-rd/rings/ring-3/stone-prd-rh01/host-values.yaml
+++ b/components/multi-platform-controller-rd/rings/ring-3/stone-prd-rh01/host-values.yaml
@@ -218,14 +218,14 @@ staticHosts:
 
   # s390
   s390x-static-1:
-    address: "10.249.66.8"
+    address: "10.249.66.7"
     concurrency: "4"
     platform: "linux/s390x"
     secret: "ibm-s390x-ssh-key"
     user: "cloud-user"  # Changed from root per IBM Cloud Jan 2026 announcement
 
   s390x-static-2:
-    address: "10.249.66.11"
+    address: "10.249.66.8"
     concurrency: "4"
     platform: "linux/s390x"
     secret: "ibm-s390x-ssh-key"


### PR DESCRIPTION
## What

2 s390x VSIs were stopped by unknown reason in IMBC cloud for RH-01 cluster.
We cannot recover failed machines so new ones were created with IP changed accordingly.

## Risk Assessment

**Risk Level:** Low