### PR TITLE
KFLUXINFRA-4288 onboard policies to ring deployments (staging)

### DIFF
--- a/argo-cd-apps/base/member/infra-deployments/policies/policies.yaml
+++ b/argo-cd-apps/base/member/infra-deployments/policies/policies.yaml
@@ -57,9 +57,6 @@ spec:
         namespace: konflux-policies
         server: '{{server}}'
       syncPolicy:
-        automated:
-          prune: true
-          selfHeal: true
         syncOptions:
           - CreateNamespace=true
           - ServerSideApply=true

--- a/argo-cd-apps/overlays/development/kustomization.yaml
+++ b/argo-cd-apps/overlays/development/kustomization.yaml
@@ -186,6 +186,11 @@ patches:
       kind: ApplicationSet
       version: v1alpha1
       name: policies
+  - path: dev-application-auto-sync-patch.yaml
+    target:
+      kind: ApplicationSet
+      version: v1alpha1
+      name: policies
   - path: development-overlay-patch.yaml
     target:
       kind: ApplicationSet

--- a/argo-cd-apps/overlays/konflux-public-production/kustomization.yaml
+++ b/argo-cd-apps/overlays/konflux-public-production/kustomization.yaml
@@ -195,6 +195,11 @@ patches:
       kind: ApplicationSet
       version: v1alpha1
       name: policies
+  - path: policies-production-auto-sync-patch.yaml
+    target:
+      kind: ApplicationSet
+      version: v1alpha1
+      name: policies
   - path: production-overlay-patch.yaml
     target:
       kind: ApplicationSet

--- a/argo-cd-apps/overlays/konflux-public-production/policies-production-auto-sync-patch.yaml
+++ b/argo-cd-apps/overlays/konflux-public-production/policies-production-auto-sync-patch.yaml
@@ -1,0 +1,9 @@
+# Preserve auto-sync for production policies during the ring-deployments migration.
+# The base appset's `automated` block was removed for the staging (Part 2) migration
+# (KFLUXINFRA-4288); production is not yet migrated, so re-enable it here.
+# Remove this patch when policies production is migrated to ring deployments.
+- op: add
+  path: /spec/template/spec/syncPolicy/automated
+  value:
+    prune: true
+    selfHeal: true

--- a/argo-cd-apps/overlays/production-downstream/kustomization.yaml
+++ b/argo-cd-apps/overlays/production-downstream/kustomization.yaml
@@ -219,6 +219,11 @@ patches:
       kind: ApplicationSet
       version: v1alpha1
       name: policies
+  - path: policies-production-auto-sync-patch.yaml
+    target:
+      kind: ApplicationSet
+      version: v1alpha1
+      name: policies
   - path: production-overlay-patch.yaml
     target:
       kind: ApplicationSet

--- a/argo-cd-apps/overlays/production-downstream/policies-production-auto-sync-patch.yaml
+++ b/argo-cd-apps/overlays/production-downstream/policies-production-auto-sync-patch.yaml
@@ -1,0 +1,9 @@
+# Preserve auto-sync for production policies during the ring-deployments migration.
+# The base appset's `automated` block was removed for the staging (Part 2) migration
+# (KFLUXINFRA-4288); production is not yet migrated, so re-enable it here.
+# Remove this patch when policies production is migrated to ring deployments.
+- op: add
+  path: /spec/template/spec/syncPolicy/automated
+  value:
+    prune: true
+    selfHeal: true

--- a/argo-cd-apps/overlays/rd-staging/kustomization.yaml
+++ b/argo-cd-apps/overlays/rd-staging/kustomization.yaml
@@ -14,6 +14,7 @@ resources:
   - kueue
   - multi-platform-controller
   - notification-controller
+  - policies
   - repository-validator
 
 components:

--- a/argo-cd-apps/overlays/rd-staging/policies/kustomization.yaml
+++ b/argo-cd-apps/overlays/rd-staging/policies/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- policies-appset.yaml

--- a/argo-cd-apps/overlays/rd-staging/policies/policies-appset.yaml
+++ b/argo-cd-apps/overlays/rd-staging/policies/policies-appset.yaml
@@ -1,0 +1,53 @@
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: policies-rd
+  labels: # Helps k-components detect this appset to apply the correct patches
+    appstudio.redhat.com/deployment-clusters: "tenant"
+spec:
+  generators:
+    - merge:
+        mergeKeys:
+          - nameNormalized
+        generators:
+          - clusters:
+              selector:
+                matchExpressions: # Ensures that no clusters are selected; k-components will replace this with the correct selector
+                  - key: appstudio.redhat.com/select-none
+                    operator: Exists
+                  - key: appstudio.redhat.com/select-none
+                    operator: DoesNotExist
+              values:
+                sourceRoot: components/policies-rd
+                ring: "empty-base"
+                clusterDir: "empty-base"
+          - list:
+              elements: [] # Populated via k-components (or manually if the cluster list is unusual)
+
+  template:
+    metadata:
+      name: policies-{{nameNormalized}}
+      annotations:
+        argocd.argoproj.io/compare-options: ServerSideDiff=true,IncludeMutationWebhook=true
+    spec:
+      project: default
+      source:
+        path: '{{values.sourceRoot}}/rings/{{values.ring}}/{{values.clusterDir}}'
+        repoURL: https://github.com/redhat-appstudio/infra-deployments.git
+        targetRevision: main
+      destination:
+        namespace: konflux-policies
+        server: '{{server}}'
+      syncPolicy:
+        # automated:
+        #   prune: true
+        #   selfHeal: true
+        syncOptions:
+          - CreateNamespace=true
+          - ServerSideApply=true
+        retry:
+          limit: -1
+          backoff:
+            duration: 10s
+            factor: 2
+            maxDuration: 3m

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/cost-management/OWNERS
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/cost-management/OWNERS
@@ -1,0 +1,12 @@
+# See the OWNERS docs: https://go.k8s.io/owners
+
+approvers:
+- mftb
+- raks-tt
+- pacho-rh
+- martysp21
+- TominoFTW
+- FaisalAl-Rayes
+- kubasikus
+- pumahaka
+- ci-operator

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/cost-management/kustomization.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/cost-management/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- propagate-cost-management-labels

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/cost-management/propagate-cost-management-labels/.chainsaw-test/README.md
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/cost-management/propagate-cost-management-labels/.chainsaw-test/README.md
@@ -1,0 +1,318 @@
+# Test: `label-propagation-valid-cost-center`
+
+tests that the labels are correctly set on pods in tenant namespace
+that have the `cost-center` label
+
+
+## Steps
+
+| # | Name | Bindings | Try | Catch | Finally | Cleanup |
+|:-:|---|:-:|:-:|:-:|:-:|:-:|
+| 1 | [Apply GlobalContextEntry](#step-Apply GlobalContextEntry) | 0 | 1 | 0 | 0 | 0 |
+| 2 | [Create namespaces for testing](#step-Create namespaces for testing) | 0 | 1 | 0 | 0 | 0 |
+| 3 | [Apply RBAC](#step-Apply RBAC) | 0 | 1 | 0 | 0 | 0 |
+| 4 | [Apply kyverno Cluster Policy and assert it exists](#step-Apply kyverno Cluster Policy and assert it exists) | 0 | 2 | 0 | 0 | 0 |
+| 5 | [create pods in tenant](#step-create pods in tenant) | 0 | 1 | 0 | 0 | 0 |
+| 6 | [assert pods in the tenant are labeled](#step-assert pods in the tenant are labeled) | 0 | 1 | 0 | 0 | 0 |
+
+### Step: `Apply GlobalContextEntry`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `Create namespaces for testing`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `create` | 2 | 0 | *No description* |
+
+### Step: `Apply RBAC`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `Apply kyverno Cluster Policy and assert it exists`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+| 2 | `assert` | 1 | 0 | *No description* |
+
+### Step: `create pods in tenant`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `create` | 1 | 0 | *No description* |
+
+### Step: `assert pods in the tenant are labeled`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `assert` | 2 | 0 | *No description* |
+
+---
+
+# Test: `label-not-applied-random-ns`
+
+tests that the label is not applied to pods in a non-tenant namespace
+
+
+## Steps
+
+| # | Name | Bindings | Try | Catch | Finally | Cleanup |
+|:-:|---|:-:|:-:|:-:|:-:|:-:|
+| 1 | [Apply GlobalContextEntry](#step-Apply GlobalContextEntry) | 0 | 1 | 0 | 0 | 0 |
+| 2 | [Create namespaces for testing](#step-Create namespaces for testing) | 0 | 1 | 0 | 0 | 0 |
+| 3 | [Apply RBAC](#step-Apply RBAC) | 0 | 1 | 0 | 0 | 0 |
+| 4 | [Apply kyverno Cluster Policy and assert it exists](#step-Apply kyverno Cluster Policy and assert it exists) | 0 | 2 | 0 | 0 | 0 |
+| 5 | [create pods in random-ns](#step-create pods in random-ns) | 0 | 1 | 0 | 0 | 0 |
+| 6 | [assert pods in random-ns are not labeled](#step-assert pods in random-ns are not labeled) | 0 | 1 | 0 | 0 | 0 |
+
+### Step: `Apply GlobalContextEntry`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `Create namespaces for testing`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `create` | 0 | 0 | *No description* |
+
+### Step: `Apply RBAC`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `Apply kyverno Cluster Policy and assert it exists`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+| 2 | `assert` | 1 | 0 | *No description* |
+
+### Step: `create pods in random-ns`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `create` | 1 | 0 | *No description* |
+
+### Step: `assert pods in random-ns are not labeled`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `assert` | 1 | 0 | *No description* |
+
+---
+
+# Test: `rule-not-applied-to-rhtap-releng-tenant`
+
+Tests that the Kyverno policy does not apply to pods in managed tenant namespaces.
+
+
+## Steps
+
+| # | Name | Bindings | Try | Catch | Finally | Cleanup |
+|:-:|---|:-:|:-:|:-:|:-:|:-:|
+| 1 | [Apply GlobalContextEntry](#step-Apply GlobalContextEntry) | 0 | 1 | 0 | 0 | 0 |
+| 2 | [Create a managed namespace](#step-Create a managed namespace) | 0 | 1 | 0 | 0 | 0 |
+| 3 | [Apply RBAC](#step-Apply RBAC) | 0 | 1 | 0 | 0 | 0 |
+| 4 | [Apply Kyverno Cluster Policy and assert it exists](#step-Apply Kyverno Cluster Policy and assert it exists) | 0 | 2 | 0 | 0 | 0 |
+| 5 | [Create a pod in the namespace](#step-Create a pod in the namespace) | 0 | 1 | 0 | 0 | 0 |
+| 6 | [Assert pod in namespace is not labeled](#step-Assert pod in namespace is not labeled) | 0 | 1 | 0 | 0 | 0 |
+
+### Step: `Apply GlobalContextEntry`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `Create a managed namespace`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `create` | 1 | 0 | *No description* |
+
+### Step: `Apply RBAC`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `Apply Kyverno Cluster Policy and assert it exists`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+| 2 | `assert` | 1 | 0 | *No description* |
+
+### Step: `Create a pod in the namespace`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `create` | 1 | 0 | *No description* |
+
+### Step: `Assert pod in namespace is not labeled`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `assert` | 0 | 0 | *No description* |
+
+---
+
+# Test: `create-pod-in-tenant-namespace-without-cost-center`
+
+Tests that it is possible to create a pod in an existing tenant namespace
+that does not have the `cost-center` label.
+
+
+## Steps
+
+| # | Name | Bindings | Try | Catch | Finally | Cleanup |
+|:-:|---|:-:|:-:|:-:|:-:|:-:|
+| 1 | [Apply GlobalContextEntry](#step-Apply GlobalContextEntry) | 0 | 1 | 0 | 0 | 0 |
+| 2 | [Create a tenant namespace without cost-center label](#step-Create a tenant namespace without cost-center label) | 0 | 1 | 0 | 0 | 0 |
+| 3 | [Apply RBAC](#step-Apply RBAC) | 0 | 1 | 0 | 0 | 0 |
+| 4 | [Apply Kyverno Cluster Policy and assert it exists](#step-Apply Kyverno Cluster Policy and assert it exists) | 0 | 2 | 0 | 0 | 0 |
+| 5 | [Create a pod in the tenant namespace without cost-center label](#step-Create a pod in the tenant namespace without cost-center label) | 0 | 1 | 0 | 0 | 0 |
+| 6 | [Assert pod in tenant namespace is created successfully](#step-Assert pod in tenant namespace is created successfully) | 0 | 1 | 0 | 0 | 0 |
+
+### Step: `Apply GlobalContextEntry`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `Create a tenant namespace without cost-center label`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `create` | 1 | 0 | *No description* |
+
+### Step: `Apply RBAC`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `Apply Kyverno Cluster Policy and assert it exists`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+| 2 | `assert` | 1 | 0 | *No description* |
+
+### Step: `Create a pod in the tenant namespace without cost-center label`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `create` | 1 | 0 | *No description* |
+
+### Step: `Assert pod in tenant namespace is created successfully`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `assert` | 1 | 0 | *No description* |
+
+---
+

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/cost-management/propagate-cost-management-labels/.chainsaw-test/chainsaw-assert-clusterpolicy.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/cost-management/propagate-cost-management-labels/.chainsaw-test/chainsaw-assert-clusterpolicy.yaml
@@ -1,0 +1,9 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: propagate-cost-management-labels
+status:
+  conditions:
+  - reason: Succeeded
+    status: "True"
+    type: Ready

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/cost-management/propagate-cost-management-labels/.chainsaw-test/chainsaw-test.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/cost-management/propagate-cost-management-labels/.chainsaw-test/chainsaw-test.yaml
@@ -1,0 +1,212 @@
+---
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: label-propagation-valid-cost-center
+spec:
+  concurrent: false
+  description: |
+    tests that the labels are correctly set on pods in tenant namespace
+    that have the `cost-center` label
+  steps:
+    - name: Apply GlobalContextEntry
+      try:
+        - apply:
+            file: ../global-context-entry.yaml
+    - name: Create namespaces for testing
+      try:
+        - create:
+            file: ./resources/namespace-cost-center.yaml
+            template: true
+            bindings:
+              - name: namespace
+                value: tenant
+              - name: cost_center
+                value: '670'
+    - name: Apply RBAC
+      try:
+        - apply:
+            file: ../kyverno-cluster-role.yaml
+    - name: Apply kyverno Cluster Policy and assert it exists
+      try:
+        - apply:
+            file: ../propagate-cost-management-labels-cp.yaml
+        - assert:
+            file: chainsaw-assert-clusterpolicy.yaml
+            template: true
+            bindings:
+              - name: cluster_policy_name
+                value: propagate-cost-management-labels
+    - name: create pods in tenant
+      try:
+        - create:
+            file: ./resources/pod.yaml
+            bindings:
+              - name: namespace
+                value: tenant
+            template: true
+    - name: assert pods in the tenant are labeled
+      try:
+        - assert:
+            file: ./resources/expected-pod-matching.yaml
+            template: true
+            bindings:
+              - name: namespace
+                value: tenant
+              - name: cost_center
+                value: '670'
+---
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: label-not-applied-random-ns
+spec:
+  concurrent: false
+  description: |
+    tests that the label is not applied to pods in a non-tenant namespace
+  steps:
+    - name: Apply GlobalContextEntry
+      try:
+        - apply:
+            file: ../global-context-entry.yaml
+    - name: Create namespaces for testing
+      try:
+        - create:
+            file: ./resources/namespace-nonmatching.yaml
+    - name: Apply RBAC
+      try:
+        - apply:
+            file: ../kyverno-cluster-role.yaml
+    - name: Apply kyverno Cluster Policy and assert it exists
+      try:
+        - apply:
+            file: ../propagate-cost-management-labels-cp.yaml
+        - assert:
+            file: chainsaw-assert-clusterpolicy.yaml
+            template: true
+            bindings:
+              - name: cluster_policy_name
+                value: propagate-cost-management-labels
+    - name: create pods in random-ns
+      try:
+        - create:
+            file: ./resources/pod.yaml
+            template: true
+            bindings:
+              - name: namespace
+                value: random-ns
+    - name: assert pods in random-ns are not labeled
+      try:
+        - assert:
+            file: ./resources/pod.yaml
+            template: true
+            bindings:
+              - name: namespace
+                value: random-ns
+---
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: rule-not-applied-to-rhtap-releng-tenant
+spec:
+  concurrent: false
+  description: |
+    Tests that the Kyverno policy does not apply to pods in managed tenant namespaces.
+  steps:
+    - name: Apply GlobalContextEntry
+      try:
+        - apply:
+            file: ../global-context-entry.yaml
+    - name: Create a managed namespace
+      try:
+        - create:
+            file: ./resources/namespace-no-cost-center.yaml
+            template: true
+            bindings:
+              - name: namespace
+                value: rhtap-releng-tenant
+    - name: Apply RBAC
+      try:
+        - apply:
+            file: ../kyverno-cluster-role.yaml
+    - name: Apply Kyverno Cluster Policy and assert it exists
+      try:
+        - apply:
+            file: ../propagate-cost-management-labels-cp.yaml
+        - assert:
+            file: chainsaw-assert-clusterpolicy.yaml
+            template: true
+            bindings:
+              - name: cluster_policy_name
+                value: propagate-cost-management-labels
+    - name: Create a pod in the namespace
+      try:
+        - create:
+            file: ./resources/pod.yaml
+            template: true
+            bindings:
+              - name: namespace
+                value: rhtap-releng-tenant
+    - name: Assert pod in namespace is not labeled
+      try:
+        - assert:
+            resource:
+              apiVersion: v1
+              kind: Pod
+              metadata:
+                name: demo-pod
+                namespace: rhtap-releng-tenant
+                labels: {}
+---
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: create-pod-in-tenant-namespace-without-cost-center
+spec:
+  concurrent: false
+  description: |
+    Tests that it is possible to create a pod in an existing tenant namespace
+    that does not have the `cost-center` label.
+  steps:
+    - name: Apply GlobalContextEntry
+      try:
+        - apply:
+            file: ../global-context-entry.yaml
+    - name: Create a tenant namespace without cost-center label
+      try:
+        - create:
+            file: ./resources/namespace-no-cost-center.yaml
+            template: true
+            bindings:
+              - name: namespace
+                value: tenant-no-cost-center
+    - name: Apply RBAC
+      try:
+        - apply:
+            file: ../kyverno-cluster-role.yaml
+    - name: Apply Kyverno Cluster Policy and assert it exists
+      try:
+        - apply:
+            file: ../propagate-cost-management-labels-cp.yaml
+        - assert:
+            file: chainsaw-assert-clusterpolicy.yaml
+            template: true
+            bindings:
+              - name: cluster_policy_name
+                value: propagate-cost-management-labels
+    - name: Create a pod in the tenant namespace without cost-center label
+      try:
+        - create:
+            file: ./resources/pod.yaml
+            template: true
+            bindings:
+              - name: namespace
+                value: tenant-no-cost-center
+    - name: Assert pod in tenant namespace is created successfully
+      try:
+        - assert:
+            file: ./resources/pod.yaml
+            template: true
+            bindings:
+              - name: namespace
+                value: tenant-no-cost-center

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/cost-management/propagate-cost-management-labels/.chainsaw-test/resources/expected-pod-matching.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/cost-management/propagate-cost-management-labels/.chainsaw-test/resources/expected-pod-matching.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: demo-pod
+  namespace: ($namespace)
+  labels:
+    cost-center: ($cost_center)
+    cost_management_optimizations: "true"

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/cost-management/propagate-cost-management-labels/.chainsaw-test/resources/namespace-cost-center.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/cost-management/propagate-cost-management-labels/.chainsaw-test/resources/namespace-cost-center.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ($namespace)
+  labels:
+    konflux-ci.dev/type: tenant
+    cost-center: ($cost_center)
+    cost_management_optimizations: "true"

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/cost-management/propagate-cost-management-labels/.chainsaw-test/resources/namespace-no-cost-center.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/cost-management/propagate-cost-management-labels/.chainsaw-test/resources/namespace-no-cost-center.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ($namespace)
+  labels:
+    konflux-ci.dev/type: tenant

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/cost-management/propagate-cost-management-labels/.chainsaw-test/resources/namespace-nonmatching.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/cost-management/propagate-cost-management-labels/.chainsaw-test/resources/namespace-nonmatching.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: random-ns

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/cost-management/propagate-cost-management-labels/.chainsaw-test/resources/pod.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/cost-management/propagate-cost-management-labels/.chainsaw-test/resources/pod.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: demo-pod
+  namespace: ($namespace)
+  labels:
+    app: test-app
+spec:
+  containers:
+    - name: test-container
+      image: nginx

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/cost-management/propagate-cost-management-labels/global-context-entry.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/cost-management/propagate-cost-management-labels/global-context-entry.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: kyverno.io/v2alpha1
+kind: GlobalContextEntry
+metadata:
+  name: namespaces
+spec:
+  kubernetesResource:
+    version: v1
+    resource: namespaces

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/cost-management/propagate-cost-management-labels/kustomization.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/cost-management/propagate-cost-management-labels/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - propagate-cost-management-labels-cp.yaml
+  - kyverno-cluster-role.yaml
+  - global-context-entry.yaml

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/cost-management/propagate-cost-management-labels/kyverno-cluster-role.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/cost-management/propagate-cost-management-labels/kyverno-cluster-role.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kyverno-admission-propagate-cost-management-labels
+  labels:
+    rbac.kyverno.io/aggregate-to-admission-controller: "true"
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - namespaces
+  verbs:
+  - list
+  - get

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/cost-management/propagate-cost-management-labels/propagate-cost-management-labels-cp.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/cost-management/propagate-cost-management-labels/propagate-cost-management-labels-cp.yaml
@@ -1,0 +1,56 @@
+---
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: propagate-cost-management-labels
+  annotations:
+    pod-policies.kyverno.io/autogen-controllers: none
+    policies.kyverno.io/title: Propagate Cost-Center from Namespace
+    policies.kyverno.io/category: Cost Management
+    policies.kyverno.io/severity: low
+    policies.kyverno.io/subject: Pod
+    policies.kyverno.io/description: >-
+      Propagates the `cost-center` label from non-managed tenant namespaces to pods,
+      and sets the `cost_management_optimizations` label to `true` on those pods.
+spec:
+  webhookConfiguration:
+    failurePolicy: Ignore
+  rules:
+    - name: propagate-existing-cost-center-from-namespace
+      skipBackgroundRequests: true
+      match:
+        any:
+          - resources:
+              kinds: [Pod]
+              namespaceSelector:
+                matchLabels:
+                  konflux-ci.dev/type: tenant
+                  cost-center: '*'
+                matchExpressions:
+                  - key: kubernetes.io/metadata.name
+                    operator: NotIn
+                    values:
+                      # managed tenant namespaces
+                      - rhtap-releng-tenant
+                      - rh-managed-bifrost-tenant
+                      - rh-managed-cnv-fbc-tenant
+                      - rh-managed-mng-s-2-tenant
+                      - rh-managed-red-hat-acm-tenant
+                      - rh-managed-rhtap-ser-tenant
+                      - rhel-on-gitlab-tenant
+      context:
+        - name: costcenterLabel
+          globalReference:
+            name: namespaces
+            jmesPath: "[?metadata.name == '{{ request.namespace }}'] | [0].metadata.labels.\"cost-center\""
+      preconditions:
+        all:
+          - key: '{{ costcenterLabel }}'
+            operator: NotEquals
+            value: ''
+      mutate:
+        patchStrategicMerge:
+          metadata:
+            labels:
+              cost-center: '{{ costcenterLabel }}'
+              cost_management_optimizations: 'true'

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/integration/OWNERS
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/integration/OWNERS
@@ -1,0 +1,6 @@
+# See the OWNERS docs: https://go.k8s.io/owners
+
+reviewers:
+- amisstea
+- dirgim
+- sonam1412

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/integration/bootstrap-namespace/.chainsaw-test/README.md
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/integration/bootstrap-namespace/.chainsaw-test/README.md
@@ -1,0 +1,581 @@
+# Test: `mutate-new-namespace-konfluxcidev`
+
+tests that the ServiceAccount and RoleBinding are created in a namespace
+labelled with `konflux-ci.dev/type=tenant`
+
+
+## Bindings
+
+| # | Name | Value |
+|:-:|---|---|
+| 1 | `suffix` | "konfluxcidev" |
+
+## Steps
+
+| # | Name | Bindings | Try | Catch | Finally | Cleanup |
+|:-:|---|:-:|:-:|:-:|:-:|:-:|
+| 1 | [given-konflux-integration-runner-clusterrole-exists](#step-given-konflux-integration-runner-clusterrole-exists) | 0 | 1 | 0 | 0 | 0 |
+| 2 | [given-kyverno-has-permission-on-resources](#step-given-kyverno-has-permission-on-resources) | 0 | 1 | 0 | 0 | 0 |
+| 3 | [given-cluster-policy-is-ready](#step-given-cluster-policy-is-ready) | 0 | 2 | 0 | 0 | 0 |
+| 4 | [when-konfluxcidev-labeled-namespace-is-created](#step-when-konfluxcidev-labeled-namespace-is-created) | 0 | 1 | 0 | 0 | 0 |
+| 5 | [then-serviceaccount-is-created](#step-then-serviceaccount-is-created) | 0 | 1 | 0 | 0 | 0 |
+| 6 | [then-rolebinding-is-created](#step-then-rolebinding-is-created) | 0 | 1 | 0 | 0 | 0 |
+
+### Step: `given-konflux-integration-runner-clusterrole-exists`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `given-kyverno-has-permission-on-resources`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `given-cluster-policy-is-ready`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+| 2 | `assert` | 0 | 0 | *No description* |
+
+### Step: `when-konfluxcidev-labeled-namespace-is-created`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `then-serviceaccount-is-created`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `assert` | 0 | 0 | *No description* |
+
+### Step: `then-rolebinding-is-created`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `assert` | 0 | 0 | *No description* |
+
+---
+
+# Test: `mutate-new-namespace-unlabeled`
+
+tests that the ServiceAccount and RoleBinding are NOT created in an unlabeled namespace
+
+
+## Bindings
+
+| # | Name | Value |
+|:-:|---|---|
+| 1 | `suffix` | "unlabeled" |
+
+## Steps
+
+| # | Name | Bindings | Try | Catch | Finally | Cleanup |
+|:-:|---|:-:|:-:|:-:|:-:|:-:|
+| 1 | [given-konflux-integration-runner-clusterrole-exists](#step-given-konflux-integration-runner-clusterrole-exists) | 0 | 1 | 0 | 0 | 0 |
+| 2 | [given-kyverno-has-permission-on-resources](#step-given-kyverno-has-permission-on-resources) | 0 | 1 | 0 | 0 | 0 |
+| 3 | [given-cluster-policy-is-ready](#step-given-cluster-policy-is-ready) | 0 | 2 | 0 | 0 | 0 |
+| 4 | [when-unlabeled-namespace-is-created](#step-when-unlabeled-namespace-is-created) | 0 | 1 | 0 | 0 | 0 |
+| 5 | [then-serviceaccount-is-not-created](#step-then-serviceaccount-is-not-created) | 0 | 1 | 0 | 0 | 0 |
+| 6 | [then-rolebinding-is-not-created](#step-then-rolebinding-is-not-created) | 0 | 1 | 0 | 0 | 0 |
+
+### Step: `given-konflux-integration-runner-clusterrole-exists`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `given-kyverno-has-permission-on-resources`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `given-cluster-policy-is-ready`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+| 2 | `assert` | 0 | 0 | *No description* |
+
+### Step: `when-unlabeled-namespace-is-created`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `then-serviceaccount-is-not-created`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `delete` | 0 | 0 | *No description* |
+
+### Step: `then-rolebinding-is-not-created`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `delete` | 0 | 0 | *No description* |
+
+---
+
+# Test: `mutate-existing-namespace-konfluxcidev`
+
+tests that the ServiceAccount and RoleBinding are created in an already existing
+namespace labelled with `konflux-ci.dev/type=tenant`
+
+
+## Bindings
+
+| # | Name | Value |
+|:-:|---|---|
+| 1 | `suffix` | "konflux" |
+
+## Steps
+
+| # | Name | Bindings | Try | Catch | Finally | Cleanup |
+|:-:|---|:-:|:-:|:-:|:-:|:-:|
+| 1 | [given-konflux-integration-runner-clusterrole-exists](#step-given-konflux-integration-runner-clusterrole-exists) | 0 | 1 | 0 | 0 | 0 |
+| 2 | [given-kyverno-has-permission-on-resources](#step-given-kyverno-has-permission-on-resources) | 0 | 1 | 0 | 0 | 0 |
+| 3 | [given-konfluxci-labeled-namespace-is-created](#step-given-konfluxci-labeled-namespace-is-created) | 0 | 1 | 0 | 0 | 0 |
+| 4 | [when-cluster-policy-is-ready](#step-when-cluster-policy-is-ready) | 0 | 2 | 0 | 0 | 0 |
+| 5 | [then-serviceaccount-is-created](#step-then-serviceaccount-is-created) | 0 | 1 | 0 | 0 | 0 |
+| 6 | [then-rolebinding-is-created](#step-then-rolebinding-is-created) | 0 | 1 | 0 | 0 | 0 |
+
+### Step: `given-konflux-integration-runner-clusterrole-exists`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `given-kyverno-has-permission-on-resources`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `given-konfluxci-labeled-namespace-is-created`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `when-cluster-policy-is-ready`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+| 2 | `assert` | 0 | 0 | *No description* |
+
+### Step: `then-serviceaccount-is-created`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `assert` | 0 | 0 | *No description* |
+
+### Step: `then-rolebinding-is-created`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `assert` | 0 | 0 | *No description* |
+
+---
+
+# Test: `mutate-existing-namespace-unlabeled`
+
+tests that the ServiceAccount and RoleBinding are NOT created in an
+existing unlabeled namespace
+
+
+## Bindings
+
+| # | Name | Value |
+|:-:|---|---|
+| 1 | `suffix` | "unlabeled" |
+
+## Steps
+
+| # | Name | Bindings | Try | Catch | Finally | Cleanup |
+|:-:|---|:-:|:-:|:-:|:-:|:-:|
+| 1 | [given-konflux-integration-runner-clusterrole-exists](#step-given-konflux-integration-runner-clusterrole-exists) | 0 | 1 | 0 | 0 | 0 |
+| 2 | [given-kyverno-has-permission-on-resources](#step-given-kyverno-has-permission-on-resources) | 0 | 1 | 0 | 0 | 0 |
+| 3 | [given-unlabeled-namespace-is-created](#step-given-unlabeled-namespace-is-created) | 0 | 1 | 0 | 0 | 0 |
+| 4 | [when-cluster-policy-is-ready](#step-when-cluster-policy-is-ready) | 0 | 2 | 0 | 0 | 0 |
+| 5 | [then-serviceaccount-is-not-created](#step-then-serviceaccount-is-not-created) | 0 | 1 | 0 | 0 | 0 |
+| 6 | [then-rolebinding-is-not-created](#step-then-rolebinding-is-not-created) | 0 | 1 | 0 | 0 | 0 |
+
+### Step: `given-konflux-integration-runner-clusterrole-exists`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `given-kyverno-has-permission-on-resources`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `given-unlabeled-namespace-is-created`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `when-cluster-policy-is-ready`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+| 2 | `assert` | 0 | 0 | *No description* |
+
+### Step: `then-serviceaccount-is-not-created`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `delete` | 0 | 0 | *No description* |
+
+### Step: `then-rolebinding-is-not-created`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `delete` | 0 | 0 | *No description* |
+
+---
+
+# Test: `mutate-existing-namespace-unlabeled-to-labeled`
+
+tests that the ServiceAccount and RoleBinding are created in an
+existing unlabeled namespace when it is labeled
+
+
+## Bindings
+
+| # | Name | Value |
+|:-:|---|---|
+| 1 | `suffix` | "to-labeled" |
+
+## Steps
+
+| # | Name | Bindings | Try | Catch | Finally | Cleanup |
+|:-:|---|:-:|:-:|:-:|:-:|:-:|
+| 1 | [given-konflux-integration-runner-clusterrole-exists](#step-given-konflux-integration-runner-clusterrole-exists) | 0 | 1 | 0 | 0 | 0 |
+| 2 | [given-kyverno-has-permission-on-resources](#step-given-kyverno-has-permission-on-resources) | 0 | 1 | 0 | 0 | 0 |
+| 3 | [given-unlabeled-namespace-is-created](#step-given-unlabeled-namespace-is-created) | 0 | 1 | 0 | 0 | 0 |
+| 4 | [given-cluster-policy-is-ready](#step-given-cluster-policy-is-ready) | 0 | 2 | 0 | 0 | 0 |
+| 5 | [given-serviceaccount-is-not-created](#step-given-serviceaccount-is-not-created) | 0 | 1 | 0 | 0 | 0 |
+| 6 | [given-rolebinding-is-not-created](#step-given-rolebinding-is-not-created) | 0 | 1 | 0 | 0 | 0 |
+| 7 | [when-konfluxci-namespace-is-labeled-namespace](#step-when-konfluxci-namespace-is-labeled-namespace) | 0 | 1 | 0 | 0 | 0 |
+| 8 | [then-serviceaccount-is-created](#step-then-serviceaccount-is-created) | 0 | 1 | 0 | 0 | 0 |
+| 9 | [then-rolebinding-is-created](#step-then-rolebinding-is-created) | 0 | 1 | 0 | 0 | 0 |
+
+### Step: `given-konflux-integration-runner-clusterrole-exists`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `given-kyverno-has-permission-on-resources`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `given-unlabeled-namespace-is-created`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `given-cluster-policy-is-ready`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+| 2 | `assert` | 0 | 0 | *No description* |
+
+### Step: `given-serviceaccount-is-not-created`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `delete` | 0 | 0 | *No description* |
+
+### Step: `given-rolebinding-is-not-created`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `delete` | 0 | 0 | *No description* |
+
+### Step: `when-konfluxci-namespace-is-labeled-namespace`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `then-serviceaccount-is-created`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `assert` | 0 | 0 | *No description* |
+
+### Step: `then-rolebinding-is-created`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `assert` | 0 | 0 | *No description* |
+
+---
+
+# Test: `mutate-existing-namespace-unlabeled-to-unlabeled`
+
+tests that the ServiceAccount and RoleBinding are not created in an
+existing unlabeled namespace when it is updated but still found unlabeled
+
+
+## Bindings
+
+| # | Name | Value |
+|:-:|---|---|
+| 1 | `suffix` | "to-unlabeled" |
+
+## Steps
+
+| # | Name | Bindings | Try | Catch | Finally | Cleanup |
+|:-:|---|:-:|:-:|:-:|:-:|:-:|
+| 1 | [given-konflux-integration-runner-clusterrole-exists](#step-given-konflux-integration-runner-clusterrole-exists) | 0 | 1 | 0 | 0 | 0 |
+| 2 | [given-kyverno-has-permission-on-resources](#step-given-kyverno-has-permission-on-resources) | 0 | 1 | 0 | 0 | 0 |
+| 3 | [given-unlabeled-namespace-is-created](#step-given-unlabeled-namespace-is-created) | 0 | 1 | 0 | 0 | 0 |
+| 4 | [given-cluster-policy-is-ready](#step-given-cluster-policy-is-ready) | 0 | 2 | 0 | 0 | 0 |
+| 5 | [given-serviceaccount-is-not-created](#step-given-serviceaccount-is-not-created) | 0 | 1 | 0 | 0 | 0 |
+| 6 | [given-rolebinding-is-not-created](#step-given-rolebinding-is-not-created) | 0 | 1 | 0 | 0 | 0 |
+| 7 | [when-konfluxci-namespace-is-updated-to-unlabeled-namespace](#step-when-konfluxci-namespace-is-updated-to-unlabeled-namespace) | 0 | 1 | 0 | 0 | 0 |
+| 8 | [then-serviceaccount-is-not-created](#step-then-serviceaccount-is-not-created) | 0 | 1 | 0 | 0 | 0 |
+| 9 | [then-rolebinding-is-not-created](#step-then-rolebinding-is-not-created) | 0 | 1 | 0 | 0 | 0 |
+
+### Step: `given-konflux-integration-runner-clusterrole-exists`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `given-kyverno-has-permission-on-resources`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `given-unlabeled-namespace-is-created`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `given-cluster-policy-is-ready`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+| 2 | `assert` | 0 | 0 | *No description* |
+
+### Step: `given-serviceaccount-is-not-created`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `delete` | 0 | 0 | *No description* |
+
+### Step: `given-rolebinding-is-not-created`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `delete` | 0 | 0 | *No description* |
+
+### Step: `when-konfluxci-namespace-is-updated-to-unlabeled-namespace`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `then-serviceaccount-is-not-created`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `delete` | 0 | 0 | *No description* |
+
+### Step: `then-rolebinding-is-not-created`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `delete` | 0 | 0 | *No description* |
+
+---
+

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/integration/bootstrap-namespace/.chainsaw-test/chainsaw-assert-clusterpolicy.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/integration/bootstrap-namespace/.chainsaw-test/chainsaw-assert-clusterpolicy.yaml
@@ -1,0 +1,9 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: init-ns-integration
+status:
+  conditions:
+  - reason: Succeeded
+    status: "True"
+    type: Ready

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/integration/bootstrap-namespace/.chainsaw-test/chainsaw-test.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/integration/bootstrap-namespace/.chainsaw-test/chainsaw-test.yaml
@@ -1,0 +1,400 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: mutate-new-namespace-konfluxcidev
+spec:
+  description: |
+    tests that the ServiceAccount and RoleBinding are created in a namespace
+    labelled with `konflux-ci.dev/type=tenant`
+  concurrent: false
+  namespace: 'generate-new-namespace'
+  bindings:
+  - name: suffix
+    value: konfluxcidev
+  steps:
+  - name: given-konflux-integration-runner-clusterrole-exists
+    try:
+    - apply:
+        file: resources/actual-konflux-integration-runner-clusterrole.yaml
+  - name: given-kyverno-has-permission-on-resources
+    try:
+    - apply:
+        file: ../kyverno-crb.yaml
+  - name: given-cluster-policy-is-ready
+    try:
+    - apply:
+        file: ../bootstrap-namespace-cp.yaml
+    - assert:
+        file: chainsaw-assert-clusterpolicy.yaml
+  - name: when-konfluxcidev-labeled-namespace-is-created
+    try:
+    - apply:
+        file: resources/actual-namespace-konfluxcidev.yaml
+        template: true
+  - name: then-serviceaccount-is-created
+    try:
+    - assert:
+        file: resources/expected-integration-serviceaccount.yaml
+        template: true
+  - name: then-rolebinding-is-created
+    try:
+    - assert:
+        file: resources/expected-integration-rolebinding.yaml
+        template: true
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: mutate-new-namespace-unlabeled
+spec:
+  description: |
+    tests that the ServiceAccount and RoleBinding are NOT created in an unlabeled namespace
+  concurrent: false
+  namespace: 'generate-new-namespace'
+  bindings:
+  - name: suffix
+    value: unlabeled
+  steps:
+  - name: given-konflux-integration-runner-clusterrole-exists
+    try:
+    - apply:
+        file: resources/actual-konflux-integration-runner-clusterrole.yaml
+  - name: given-kyverno-has-permission-on-resources
+    try:
+    - apply:
+        file: ../kyverno-crb.yaml
+  - name: given-cluster-policy-is-ready
+    try:
+    - apply:
+        file: ../bootstrap-namespace-cp.yaml
+    - assert:
+        file: chainsaw-assert-clusterpolicy.yaml
+  - name: when-unlabeled-namespace-is-created
+    try:
+    - apply:
+        file: resources/actual-namespace-unlabeled.yaml
+        template: true
+  - name: then-serviceaccount-is-not-created
+    try:
+    - delete:
+        file: resources/expected-integration-serviceaccount.yaml
+        template: true
+        expect:
+        - check:
+            ($error != null): true
+  - name: then-rolebinding-is-not-created
+    try:
+    - delete:
+        file: resources/expected-integration-rolebinding.yaml
+        template: true
+        expect:
+        - check:
+            ($error != null): true
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: mutate-existing-namespace-konfluxcidev
+spec:
+  description: |
+    tests that the ServiceAccount and RoleBinding are created in an already existing
+    namespace labelled with `konflux-ci.dev/type=tenant`
+  concurrent: false
+  namespace: 'generate-existing-namespace'
+  bindings:
+  - name: suffix
+    value: konflux
+  steps:
+  - name: given-konflux-integration-runner-clusterrole-exists
+    try:
+    - apply:
+        file: resources/actual-konflux-integration-runner-clusterrole.yaml
+  - name: given-kyverno-has-permission-on-resources
+    try:
+    - apply:
+        file: ../kyverno-crb.yaml
+  - name: given-konfluxci-labeled-namespace-is-created
+    try:
+    - apply:
+        file: resources/actual-namespace-konfluxcidev.yaml
+        template: true
+  - name: when-cluster-policy-is-ready
+    try:
+    - apply:
+        file: ../bootstrap-namespace-cp.yaml
+    - assert:
+        file: chainsaw-assert-clusterpolicy.yaml
+  - name: then-serviceaccount-is-created
+    try:
+    - assert:
+        timeout: 180s
+        file: resources/expected-integration-serviceaccount.yaml
+        template: true
+  - name: then-rolebinding-is-created
+    try:
+    - assert:
+        file: resources/expected-integration-rolebinding.yaml
+        template: true
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: mutate-existing-namespace-unlabeled
+spec:
+  description: |
+    tests that the ServiceAccount and RoleBinding are NOT created in an
+    existing unlabeled namespace
+  concurrent: false
+  namespace: 'generate-existing-namespace'
+  bindings:
+  - name: suffix
+    value: unlabeled
+  steps:
+  - name: given-konflux-integration-runner-clusterrole-exists
+    try:
+    - apply:
+        file: resources/actual-konflux-integration-runner-clusterrole.yaml
+  - name: given-kyverno-has-permission-on-resources
+    try:
+    - apply:
+        file: ../kyverno-crb.yaml
+  - name: given-unlabeled-namespace-is-created
+    try:
+    - apply:
+        file: resources/actual-namespace-unlabeled.yaml
+        template: true
+  - name: when-cluster-policy-is-ready
+    try:
+    - apply:
+        file: ../bootstrap-namespace-cp.yaml
+    - assert:
+        file: chainsaw-assert-clusterpolicy.yaml
+  - name: then-serviceaccount-is-not-created
+    try:
+    - delete:
+        file: resources/expected-integration-serviceaccount.yaml
+        template: true
+        expect:
+        - check:
+            ($error != null): true
+  - name: then-rolebinding-is-not-created
+    try:
+    - delete:
+        file: resources/expected-integration-rolebinding.yaml
+        template: true
+        expect:
+        - check:
+            ($error != null): true
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: mutate-existing-namespace-unlabeled-to-labeled
+spec:
+  description: |
+    tests that the ServiceAccount and RoleBinding are created in an
+    existing unlabeled namespace when it is labeled
+  concurrent: false
+  namespace: 'generate-existing-namespace'
+  bindings:
+  - name: suffix
+    value: to-labeled
+  steps:
+  - name: given-konflux-integration-runner-clusterrole-exists
+    try:
+    - apply:
+        file: resources/actual-konflux-integration-runner-clusterrole.yaml
+  - name: given-kyverno-has-permission-on-resources
+    try:
+    - apply:
+        file: ../kyverno-crb.yaml
+  - name: given-unlabeled-namespace-is-created
+    try:
+    - apply:
+        file: resources/actual-namespace-unlabeled.yaml
+        template: true
+  - name: given-cluster-policy-is-ready
+    try:
+    - apply:
+        file: ../bootstrap-namespace-cp.yaml
+    - assert:
+        file: chainsaw-assert-clusterpolicy.yaml
+  - name: given-serviceaccount-is-not-created
+    try:
+    - delete:
+        file: resources/expected-integration-serviceaccount.yaml
+        template: true
+        expect:
+        - check:
+            ($error != null): true
+  - name: given-rolebinding-is-not-created
+    try:
+    - delete:
+        file: resources/expected-integration-rolebinding.yaml
+        template: true
+        expect:
+        - check:
+            ($error != null): true
+  - name: when-konfluxci-namespace-is-labeled-namespace
+    try:
+    - apply:
+        file: resources/actual-namespace-konfluxcidev.yaml
+        template: true
+  - name: then-serviceaccount-is-created
+    try:
+    - assert:
+        file: resources/expected-integration-serviceaccount.yaml
+        template: true
+  - name: then-rolebinding-is-created
+    try:
+    - assert:
+        file: resources/expected-integration-rolebinding.yaml
+        template: true
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: mutate-existing-namespace-unlabeled-to-unlabeled
+spec:
+  description: |
+    tests that the ServiceAccount and RoleBinding are not created in an
+    existing unlabeled namespace when it is updated but still found unlabeled
+  concurrent: false
+  namespace: 'generate-existing-namespace'
+  bindings:
+  - name: suffix
+    value: to-unlabeled
+  steps:
+  - name: given-konflux-integration-runner-clusterrole-exists
+    try:
+    - apply:
+        file: resources/actual-konflux-integration-runner-clusterrole.yaml
+  - name: given-kyverno-has-permission-on-resources
+    try:
+    - apply:
+        file: ../kyverno-crb.yaml
+  - name: given-unlabeled-namespace-is-created
+    try:
+    - apply:
+        file: resources/actual-namespace-unlabeled.yaml
+        template: true
+  - name: given-cluster-policy-is-ready
+    try:
+    - apply:
+        file: ../bootstrap-namespace-cp.yaml
+    - assert:
+        file: chainsaw-assert-clusterpolicy.yaml
+  - name: given-serviceaccount-is-not-created
+    try:
+    - delete:
+        file: resources/expected-integration-serviceaccount.yaml
+        template: true
+        expect:
+        - check:
+            ($error != null): true
+  - name: given-rolebinding-is-not-created
+    try:
+    - delete:
+        file: resources/expected-integration-rolebinding.yaml
+        template: true
+        expect:
+        - check:
+            ($error != null): true
+  - name: when-konfluxci-namespace-is-updated-to-unlabeled-namespace
+    try:
+    - apply:
+        file: resources/actual-namespace-unlabeled-extra.yaml
+        template: true
+  - name: then-serviceaccount-is-not-created
+    try:
+    - delete:
+        file: resources/expected-integration-serviceaccount.yaml
+        template: true
+        expect:
+        - check:
+            ($error != null): true
+  - name: then-rolebinding-is-not-created
+    try:
+    - delete:
+        file: resources/expected-integration-rolebinding.yaml
+        template: true
+        expect:
+        - check:
+            ($error != null): true
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: orphan-resources-on-policy-deletion
+spec:
+  description: |
+    tests that resources created by this policy remain when the policy is deleted
+  concurrent: false
+  namespace: 'generate-new-namespace'
+  bindings:
+  - name: suffix
+    value: orphan
+  steps:
+  - name: given-konflux-integration-runner-clusterrole-exists
+    try:
+    - apply:
+        file: resources/actual-konflux-integration-runner-clusterrole.yaml
+  - name: given-kyverno-has-permission-on-resources
+    try:
+    - apply:
+        file: ../kyverno-crb.yaml
+  - name: given-cluster-policy-is-ready
+    try:
+    - apply:
+        file: ../bootstrap-namespace-cp.yaml
+    - assert:
+        file: chainsaw-assert-clusterpolicy.yaml
+  - name: when-konfluxcidev-labeled-namespace-is-created
+    try:
+    - apply:
+        file: resources/actual-namespace-konfluxcidev.yaml
+        template: true
+  - name: then-serviceaccount-is-created
+    try:
+    - assert:
+        file: resources/expected-integration-serviceaccount.yaml
+        template: true
+  - name: then-rolebinding-is-created
+    try:
+    - assert:
+        file: resources/expected-integration-rolebinding.yaml
+        template: true
+  - name: when-the-policy-is-deleted
+    try:
+    - delete:
+        file: ../bootstrap-namespace-cp.yaml
+    - wait:
+        apiVersion: kyverno.io/v1
+        kind: ClusterPolicy
+        name: init-ns-integration
+        for:
+          deletion: {}
+    - script:
+        content: |
+          while true; do
+            if [ "$(kubectl get updaterequests -n konflux-kyverno -o yaml | yq '.items | length')" -eq 0 ]; then
+              exit 0
+            fi
+            sleep 1
+          done
+        timeout: 30s
+  - name: then-the-resouces-remain
+    try:
+    - assert:
+        file: resources/expected-integration-serviceaccount.yaml
+        template: true
+    - assert:
+        file: resources/expected-integration-rolebinding.yaml
+        template: true

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/integration/bootstrap-namespace/.chainsaw-test/resources/actual-konflux-integration-runner-clusterrole.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/integration/bootstrap-namespace/.chainsaw-test/resources/actual-konflux-integration-runner-clusterrole.yaml
@@ -1,0 +1,5 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: konflux-integration-runner
+rules: []

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/integration/bootstrap-namespace/.chainsaw-test/resources/actual-namespace-konfluxcidev.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/integration/bootstrap-namespace/.chainsaw-test/resources/actual-namespace-konfluxcidev.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: (join('-', [$namespace, $suffix]))
+  labels:
+    konflux-ci.dev/type: tenant

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/integration/bootstrap-namespace/.chainsaw-test/resources/actual-namespace-unlabeled-extra.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/integration/bootstrap-namespace/.chainsaw-test/resources/actual-namespace-unlabeled-extra.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: (join('-', [$namespace, $suffix]))
+  labels:
+    mylabel: extra

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/integration/bootstrap-namespace/.chainsaw-test/resources/actual-namespace-unlabeled.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/integration/bootstrap-namespace/.chainsaw-test/resources/actual-namespace-unlabeled.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: (join('-', [$namespace, $suffix]))

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/integration/bootstrap-namespace/.chainsaw-test/resources/expected-integration-rolebinding.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/integration/bootstrap-namespace/.chainsaw-test/resources/expected-integration-rolebinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: konflux-integration-runner-rolebinding
+  namespace: (join('-', [$namespace, $suffix]))
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: konflux-integration-runner
+subjects:
+- kind: ServiceAccount
+  name: konflux-integration-runner
+  namespace: (join('-', [$namespace, $suffix]))

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/integration/bootstrap-namespace/.chainsaw-test/resources/expected-integration-serviceaccount.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/integration/bootstrap-namespace/.chainsaw-test/resources/expected-integration-serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: konflux-integration-runner
+  namespace: (join('-', [$namespace, $suffix]))

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/integration/bootstrap-namespace/bootstrap-namespace-cp.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/integration/bootstrap-namespace/bootstrap-namespace-cp.yaml
@@ -1,0 +1,72 @@
+---
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: init-ns-integration
+  annotations:
+    policies.kyverno.io/description: |
+      This policy creates a service account named konflux-integration-runner and
+      binds it to the konflux-integration-runner cluster role in tenant namespaces.
+spec:
+  rules:
+  - name: create-konflux-integration-runner-serviceaccount
+    skipBackgroundRequests: true
+    match:
+      any:
+      - resources:
+          kinds:
+          - Namespace
+          selector:
+            matchLabels:
+              konflux-ci.dev/type: tenant
+    preconditions:
+      any:
+      - key: "{{ request.operation || '' }}"
+        operator: NotEquals
+        value: "UPDATE"
+      - key: "{{ contains(keys(request.oldObject.metadata), 'labels') && lookup(request.oldObject.metadata.labels, 'konflux-ci.dev/type') || '' }}"
+        operator: NotEquals
+        value: "tenant"
+    generate:
+      generateExisting: true
+      orphanDownstreamOnPolicyDelete: true
+      synchronize: false
+      apiVersion: v1
+      kind: ServiceAccount
+      name: konflux-integration-runner
+      namespace: '{{request.object.metadata.name}}'
+  - name: create-konflux-integration-runner-rolebinding
+    skipBackgroundRequests: true
+    match:
+      any:
+      - resources:
+          kinds:
+          - Namespace
+          selector:
+            matchLabels:
+              konflux-ci.dev/type: tenant
+    preconditions:
+      any:
+      - key: "{{ request.operation || '' }}"
+        operator: NotEquals
+        value: "UPDATE"
+      - key: "{{ contains(keys(request.oldObject.metadata), 'labels') && lookup(request.oldObject.metadata.labels, 'konflux-ci.dev/type') || '' }}"
+        operator: NotEquals
+        value: "tenant"
+    generate:
+      generateExisting: true
+      orphanDownstreamOnPolicyDelete: true
+      synchronize: false
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      name: konflux-integration-runner-rolebinding
+      namespace: '{{request.object.metadata.name}}'
+      data:
+        roleRef:
+          apiGroup: rbac.authorization.k8s.io
+          kind: ClusterRole
+          name: konflux-integration-runner
+        subjects:
+        - kind: ServiceAccount
+          namespace: '{{request.object.metadata.name}}'
+          name: konflux-integration-runner

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/integration/bootstrap-namespace/kustomization.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/integration/bootstrap-namespace/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- bootstrap-namespace-cp.yaml
+- kyverno-crb.yaml

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/integration/bootstrap-namespace/kyverno-crb.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/integration/bootstrap-namespace/kyverno-crb.yaml
@@ -1,0 +1,43 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kyverno-manage-integration-resources
+  labels:
+    rbac.kyverno.io/aggregate-to-background-controller: "true"
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - rolebindings
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+---
+# To allow kyverno to create the RoleBinding,
+# the kyverno-background-controller's ServiceAccount
+# needs to have the same permissions it wants to assign
+# to someone else
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kyverno-background:konflux-integration-runner
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: konflux-integration-runner
+subjects:
+- kind: ServiceAccount
+  namespace: konflux-kyverno
+  name: kyverno-background-controller

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/integration/kustomization.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/integration/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- bootstrap-namespace
+namePrefix: integration-

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/bootstrap-tenant-namespace/.chainsaw-test/README.md
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/bootstrap-tenant-namespace/.chainsaw-test/README.md
@@ -1,0 +1,503 @@
+# Test: `konfluxci-bootstrap-ns-mutate-new-namespace-konfluxcidev`
+
+tests that the resources are created in a namespace
+labeled with `konflux-ci.dev/type=tenant`
+
+
+## Bindings
+
+| # | Name | Value |
+|:-:|---|---|
+| 1 | `suffix` | "labeled" |
+
+## Steps
+
+| # | Name | Bindings | Try | Catch | Finally | Cleanup |
+|:-:|---|:-:|:-:|:-:|:-:|:-:|
+| 1 | [given-appstudio-pipeline-clusterrole-exists](#step-given-appstudio-pipeline-clusterrole-exists) | 0 | 1 | 0 | 0 | 0 |
+| 2 | [given-kyverno-has-permission-on-resources](#step-given-kyverno-has-permission-on-resources) | 0 | 1 | 0 | 0 | 0 |
+| 3 | [given-cluster-policies-are-ready](#step-given-cluster-policies-are-ready) | 0 | 7 | 0 | 0 | 0 |
+| 4 | [when-konfluxcidev-labeled-namespace-is-created](#step-when-konfluxcidev-labeled-namespace-is-created) | 0 | 1 | 0 | 0 | 0 |
+| 5 | [then-resources-are-created](#step-then-resources-are-created) | 0 | 1 | 0 | 0 | 0 |
+
+### Step: `given-appstudio-pipeline-clusterrole-exists`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `given-kyverno-has-permission-on-resources`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `given-cluster-policies-are-ready`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+| 2 | `apply` | 0 | 0 | *No description* |
+| 3 | `apply` | 0 | 0 | *No description* |
+| 4 | `apply` | 0 | 0 | *No description* |
+| 5 | `apply` | 0 | 0 | *No description* |
+| 6 | `apply` | 0 | 0 | *No description* |
+| 7 | `assert` | 0 | 0 | *No description* |
+
+### Step: `when-konfluxcidev-labeled-namespace-is-created`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `then-resources-are-created`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `assert` | 0 | 0 | *No description* |
+
+---
+
+# Test: `konfluxci-bootstrap-ns-mutate-updated-namespace-konfluxcidev`
+
+tests that the resources are created in an unlabeled namespace
+when it is updated to have the label `konflux-ci.dev/type=tenant`
+
+
+## Bindings
+
+| # | Name | Value |
+|:-:|---|---|
+| 1 | `suffix` | "updated-labeled" |
+
+## Steps
+
+| # | Name | Bindings | Try | Catch | Finally | Cleanup |
+|:-:|---|:-:|:-:|:-:|:-:|:-:|
+| 1 | [given-appstudio-pipeline-clusterrole-exists](#step-given-appstudio-pipeline-clusterrole-exists) | 0 | 1 | 0 | 0 | 0 |
+| 2 | [given-kyverno-has-permission-on-resources](#step-given-kyverno-has-permission-on-resources) | 0 | 1 | 0 | 0 | 0 |
+| 3 | [given-cluster-policies-are-ready](#step-given-cluster-policies-are-ready) | 0 | 7 | 0 | 0 | 0 |
+| 4 | [given-unlabeled-namespace-exists](#step-given-unlabeled-namespace-exists) | 0 | 1 | 0 | 0 | 0 |
+| 5 | [when-konfluxcidev-label-is-added](#step-when-konfluxcidev-label-is-added) | 0 | 1 | 0 | 0 | 0 |
+| 6 | [then-resources-are-created](#step-then-resources-are-created) | 0 | 1 | 0 | 0 | 0 |
+
+### Step: `given-appstudio-pipeline-clusterrole-exists`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `given-kyverno-has-permission-on-resources`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `given-cluster-policies-are-ready`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+| 2 | `apply` | 0 | 0 | *No description* |
+| 3 | `apply` | 0 | 0 | *No description* |
+| 4 | `apply` | 0 | 0 | *No description* |
+| 5 | `apply` | 0 | 0 | *No description* |
+| 6 | `apply` | 0 | 0 | *No description* |
+| 7 | `assert` | 0 | 0 | *No description* |
+
+### Step: `given-unlabeled-namespace-exists`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `when-konfluxcidev-label-is-added`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `then-resources-are-created`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `assert` | 0 | 0 | *No description* |
+
+---
+
+# Test: `konfluxci-bootstrap-ns-mutate-new-namespace-unlabeled`
+
+tests that the resources are NOT created in an unlabeled namespace
+
+
+## Bindings
+
+| # | Name | Value |
+|:-:|---|---|
+| 1 | `suffix` | "unlabeled" |
+
+## Steps
+
+| # | Name | Bindings | Try | Catch | Finally | Cleanup |
+|:-:|---|:-:|:-:|:-:|:-:|:-:|
+| 1 | [given-appstudio-pipeline-clusterrole-exists](#step-given-appstudio-pipeline-clusterrole-exists) | 0 | 1 | 0 | 0 | 0 |
+| 2 | [given-kyverno-has-permission-on-resources](#step-given-kyverno-has-permission-on-resources) | 0 | 1 | 0 | 0 | 0 |
+| 3 | [given-cluster-policies-are-ready](#step-given-cluster-policies-are-ready) | 0 | 7 | 0 | 0 | 0 |
+| 4 | [when-unlabeled-namespace-is-created](#step-when-unlabeled-namespace-is-created) | 0 | 1 | 0 | 0 | 0 |
+| 5 | [then-resources-are-not-created](#step-then-resources-are-not-created) | 0 | 1 | 0 | 0 | 0 |
+
+### Step: `given-appstudio-pipeline-clusterrole-exists`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `given-kyverno-has-permission-on-resources`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `given-cluster-policies-are-ready`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+| 2 | `apply` | 0 | 0 | *No description* |
+| 3 | `apply` | 0 | 0 | *No description* |
+| 4 | `apply` | 0 | 0 | *No description* |
+| 5 | `apply` | 0 | 0 | *No description* |
+| 6 | `apply` | 0 | 0 | *No description* |
+| 7 | `assert` | 0 | 0 | *No description* |
+
+### Step: `when-unlabeled-namespace-is-created`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `then-resources-are-not-created`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `delete` | 0 | 0 | *No description* |
+
+---
+
+# Test: `konfluxci-bootstrap-ns-mutate-existing-namespace`
+
+tests that the RoleBinding is NOT created in an already existing
+namespace labeled with `konflux-ci.dev/type=tenant`, whereas
+other resources are.
+
+
+## Bindings
+
+| # | Name | Value |
+|:-:|---|---|
+| 1 | `suffix` | "labeled" |
+
+## Steps
+
+| # | Name | Bindings | Try | Catch | Finally | Cleanup |
+|:-:|---|:-:|:-:|:-:|:-:|:-:|
+| 1 | [given-konfluxci-labeled-namespace-is-created](#step-given-konfluxci-labeled-namespace-is-created) | 0 | 1 | 0 | 0 | 0 |
+| 2 | [given-kyverno-has-permission-on-resources](#step-given-kyverno-has-permission-on-resources) | 0 | 1 | 0 | 0 | 0 |
+| 3 | [given-appstudio-pipeline-clusterrole-exists](#step-given-appstudio-pipeline-clusterrole-exists) | 0 | 1 | 0 | 0 | 0 |
+| 4 | [when-cluster-policies-are-ready](#step-when-cluster-policies-are-ready) | 0 | 7 | 0 | 0 | 0 |
+| 5 | [then-resources-are-created](#step-then-resources-are-created) | 0 | 1 | 0 | 0 | 0 |
+
+### Step: `given-konfluxci-labeled-namespace-is-created`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `given-kyverno-has-permission-on-resources`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `given-appstudio-pipeline-clusterrole-exists`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `when-cluster-policies-are-ready`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+| 2 | `apply` | 0 | 0 | *No description* |
+| 3 | `apply` | 0 | 0 | *No description* |
+| 4 | `apply` | 0 | 0 | *No description* |
+| 5 | `apply` | 0 | 0 | *No description* |
+| 6 | `apply` | 0 | 0 | *No description* |
+| 7 | `assert` | 0 | 0 | *No description* |
+
+### Step: `then-resources-are-created`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `assert` | 0 | 0 | *No description* |
+
+---
+
+# Test: `konfluxci-bootstrap-ns-mutate-existing-namespace-unlabeled`
+
+tests that the RoleBinding is NOT created in an
+existing unlabeled namespace
+
+
+## Bindings
+
+| # | Name | Value |
+|:-:|---|---|
+| 1 | `suffix` | "unlabeled" |
+
+## Steps
+
+| # | Name | Bindings | Try | Catch | Finally | Cleanup |
+|:-:|---|:-:|:-:|:-:|:-:|:-:|
+| 1 | [given-appstudio-pipeline-clusterrole-exists](#step-given-appstudio-pipeline-clusterrole-exists) | 0 | 1 | 0 | 0 | 0 |
+| 2 | [given-kyverno-has-permission-on-resources](#step-given-kyverno-has-permission-on-resources) | 0 | 1 | 0 | 0 | 0 |
+| 3 | [given-unlabeled-namespace-is-created](#step-given-unlabeled-namespace-is-created) | 0 | 1 | 0 | 0 | 0 |
+| 4 | [when-cluster-policies-are-ready](#step-when-cluster-policies-are-ready) | 0 | 7 | 0 | 0 | 0 |
+| 5 | [then-resources-are-not-created](#step-then-resources-are-not-created) | 0 | 1 | 0 | 0 | 0 |
+
+### Step: `given-appstudio-pipeline-clusterrole-exists`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `given-kyverno-has-permission-on-resources`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `given-unlabeled-namespace-is-created`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `when-cluster-policies-are-ready`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+| 2 | `apply` | 0 | 0 | *No description* |
+| 3 | `apply` | 0 | 0 | *No description* |
+| 4 | `apply` | 0 | 0 | *No description* |
+| 5 | `apply` | 0 | 0 | *No description* |
+| 6 | `apply` | 0 | 0 | *No description* |
+| 7 | `assert` | 0 | 0 | *No description* |
+
+### Step: `then-resources-are-not-created`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `delete` | 0 | 0 | *No description* |
+
+---
+
+# Test: `konfluxci-bootstrap-ns-mutate-existing-namespace-konfluxcidev-existing-resources`
+
+tests that resources are not updated in an already existing
+namespace labeled with `konflux-ci.dev/type=tenant` where the
+RoleBinding already exists
+
+
+## Bindings
+
+| # | Name | Value |
+|:-:|---|---|
+| 1 | `suffix` | "labeled" |
+
+## Steps
+
+| # | Name | Bindings | Try | Catch | Finally | Cleanup |
+|:-:|---|:-:|:-:|:-:|:-:|:-:|
+| 1 | [given-konfluxcidev-labeled-namespace-is-created](#step-given-konfluxcidev-labeled-namespace-is-created) | 0 | 1 | 0 | 0 | 0 |
+| 2 | [then-resources-are-not-changed](#step-then-resources-are-not-changed) | 0 | 1 | 0 | 0 | 0 |
+| 3 | [given-appstudio-pipeline-clusterrole-exists](#step-given-appstudio-pipeline-clusterrole-exists) | 0 | 1 | 0 | 0 | 0 |
+| 4 | [given-kyverno-has-permission-on-resources](#step-given-kyverno-has-permission-on-resources) | 0 | 1 | 0 | 0 | 0 |
+| 5 | [when-cluster-policies-are-ready](#step-when-cluster-policies-are-ready) | 0 | 7 | 0 | 0 | 0 |
+| 6 | [then-resources-are-not-changed](#step-then-resources-are-not-changed) | 0 | 1 | 0 | 0 | 0 |
+
+### Step: `given-konfluxcidev-labeled-namespace-is-created`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `then-resources-are-not-changed`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `given-appstudio-pipeline-clusterrole-exists`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `given-kyverno-has-permission-on-resources`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `when-cluster-policies-are-ready`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+| 2 | `apply` | 0 | 0 | *No description* |
+| 3 | `apply` | 0 | 0 | *No description* |
+| 4 | `apply` | 0 | 0 | *No description* |
+| 5 | `apply` | 0 | 0 | *No description* |
+| 6 | `apply` | 0 | 0 | *No description* |
+| 7 | `assert` | 0 | 0 | *No description* |
+
+### Step: `then-resources-are-not-changed`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `assert` | 0 | 0 | *No description* |
+
+---
+

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/bootstrap-tenant-namespace/.chainsaw-test/chainsaw-assert-clusterpolicy.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/bootstrap-tenant-namespace/.chainsaw-test/chainsaw-assert-clusterpolicy.yaml
@@ -1,0 +1,60 @@
+---
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: bootstrap-tenant-namespace-np-ocpconsole
+status:
+  conditions:
+  - reason: Succeeded
+    status: "True"
+    type: Ready
+---
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: bootstrap-tenant-namespace-np-ocpingress
+status:
+  conditions:
+  - reason: Succeeded
+    status: "True"
+    type: Ready
+---
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: bootstrap-tenant-namespace-np-ocpmonitoring
+status:
+  conditions:
+  - reason: Succeeded
+    status: "True"
+    type: Ready
+---
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: bootstrap-tenant-namespace-np-olm
+status:
+  conditions:
+  - reason: Succeeded
+    status: "True"
+    type: Ready
+---
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: bootstrap-tenant-namespace-np-samenamespace
+status:
+  conditions:
+  - reason: Succeeded
+    status: "True"
+    type: Ready
+---
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: bootstrap-tenant-namespace-rbcm
+status:
+  conditions:
+  - reason: Succeeded
+    status: "True"
+    type: Ready

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/bootstrap-tenant-namespace/.chainsaw-test/chainsaw-test.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/bootstrap-tenant-namespace/.chainsaw-test/chainsaw-test.yaml
@@ -1,0 +1,412 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: konfluxci-bootstrap-ns-mutate-new-namespace-konfluxcidev
+spec:
+  description: |
+    tests that the resources are created in a namespace
+    labeled with `konflux-ci.dev/type=tenant`
+  concurrent: false
+  namespace: 'generate-new-namespace'
+  bindings:
+  - name: suffix
+    value: labeled
+  steps:
+  - name: given-appstudio-pipeline-clusterrole-exists
+    try:
+    - apply:
+        file: ./resources/actual-appstudio-pipeline-clusterrole.yaml
+  - name: given-kyverno-has-permission-on-resources
+    try:
+    - apply:
+        file: ../kyverno-admission-cluster-role.yaml
+    - apply:
+        file: ../kyverno-background-cluster-role.yaml
+  - name: given-cluster-policies-are-ready
+    try:
+    - apply:
+        file: ../bootstrap-tenant-namespace-np-ocpconsole-cp.yaml
+    - apply:
+        file: ../bootstrap-tenant-namespace-np-ocpingress-cp.yaml
+    - apply:
+        file: ../bootstrap-tenant-namespace-np-ocpmonitoring-cp.yaml
+    - apply:
+        file: ../bootstrap-tenant-namespace-np-olm-cp.yaml
+    - apply:
+        file: ../bootstrap-tenant-namespace-np-samenamespace-cp.yaml
+    - apply:
+        file: ../bootstrap-tenant-namespace-rbcm-cp.yaml
+    - assert:
+        file: chainsaw-assert-clusterpolicy.yaml
+  - name: when-konfluxcidev-labeled-namespace-is-created
+    try:
+    - apply:
+        file: resources/actual-namespace-konfluxcidev.yaml
+        template: true
+  - name: then-resources-are-created
+    try:
+    - assert:
+        file: resources/expected-resources.yaml
+        template: true
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: konfluxci-bootstrap-ns-mutate-updated-namespace-konfluxcidev
+spec:
+  description: |
+    tests that the resources are created in an unlabeled namespace
+    when it is updated to have the label `konflux-ci.dev/type=tenant`
+  concurrent: false
+  namespace: 'generate-new-namespace'
+  bindings:
+  - name: suffix
+    value: updated-labeled
+  steps:
+  - name: given-appstudio-pipeline-clusterrole-exists
+    try:
+    - apply:
+        file: ./resources/actual-appstudio-pipeline-clusterrole.yaml
+  - name: given-kyverno-has-permission-on-resources
+    try:
+    - apply:
+        file: ../kyverno-admission-cluster-role.yaml
+    - apply:
+        file: ../kyverno-background-cluster-role.yaml
+  - name: given-cluster-policies-are-ready
+    try:
+    - apply:
+        file: ../bootstrap-tenant-namespace-np-ocpconsole-cp.yaml
+    - apply:
+        file: ../bootstrap-tenant-namespace-np-ocpingress-cp.yaml
+    - apply:
+        file: ../bootstrap-tenant-namespace-np-ocpmonitoring-cp.yaml
+    - apply:
+        file: ../bootstrap-tenant-namespace-np-olm-cp.yaml
+    - apply:
+        file: ../bootstrap-tenant-namespace-np-samenamespace-cp.yaml
+    - apply:
+        file: ../bootstrap-tenant-namespace-rbcm-cp.yaml
+    - assert:
+        file: chainsaw-assert-clusterpolicy.yaml
+  - name: given-unlabeled-namespace-exists
+    try:
+    - apply:
+        file: resources/actual-namespace-unlabeled.yaml
+        template: true
+  - name: when-konfluxcidev-label-is-added
+    try:
+    - apply:
+        file: resources/actual-namespace-konfluxcidev.yaml
+        template: true
+  - name: then-resources-are-created
+    try:
+    - assert:
+        file: resources/expected-resources.yaml
+        template: true
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: konfluxci-bootstrap-ns-mutate-new-namespace-unlabeled
+spec:
+  description: |
+    tests that the resources are NOT created in an unlabeled namespace
+  concurrent: false
+  namespace: 'generate-new-namespace'
+  bindings:
+  - name: suffix
+    value: unlabeled
+  steps:
+  - name: given-appstudio-pipeline-clusterrole-exists
+    try:
+    - apply:
+        file: ./resources/actual-appstudio-pipeline-clusterrole.yaml
+  - name: given-kyverno-has-permission-on-resources
+    try:
+    - apply:
+        file: ../kyverno-admission-cluster-role.yaml
+    - apply:
+        file: ../kyverno-background-cluster-role.yaml
+  - name: given-cluster-policies-are-ready
+    try:
+    - apply:
+        file: ../bootstrap-tenant-namespace-np-ocpconsole-cp.yaml
+    - apply:
+        file: ../bootstrap-tenant-namespace-np-ocpingress-cp.yaml
+    - apply:
+        file: ../bootstrap-tenant-namespace-np-ocpmonitoring-cp.yaml
+    - apply:
+        file: ../bootstrap-tenant-namespace-np-olm-cp.yaml
+    - apply:
+        file: ../bootstrap-tenant-namespace-np-samenamespace-cp.yaml
+    - apply:
+        file: ../bootstrap-tenant-namespace-rbcm-cp.yaml
+    - assert:
+        file: chainsaw-assert-clusterpolicy.yaml
+  - name: when-unlabeled-namespace-is-created
+    try:
+    - apply:
+        file: resources/actual-namespace-unlabeled.yaml
+        template: true
+  - name: then-resources-are-not-created
+    try:
+    - delete:
+        file: resources/expected-resources.yaml
+        template: true
+        expect:
+        - check:
+            ($error != null): true
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: konfluxci-bootstrap-ns-mutate-existing-namespace
+spec:
+  description: |
+    tests that the RoleBinding is NOT created in an already existing
+    namespace labeled with `konflux-ci.dev/type=tenant`, whereas
+    other resources are.
+  concurrent: false
+  namespace: 'generate-existing-namespace'
+  bindings:
+  - name: suffix
+    value: labeled
+  steps:
+  - name: given-konfluxci-labeled-namespace-is-created
+    try:
+    - apply:
+        file: resources/actual-namespace-konfluxcidev.yaml
+        template: true
+  - name: given-kyverno-has-permission-on-resources
+    try:
+    - apply:
+        file: ../kyverno-admission-cluster-role.yaml
+    - apply:
+        file: ../kyverno-background-cluster-role.yaml
+  - name: given-appstudio-pipeline-clusterrole-exists
+    try:
+    - apply:
+        file: ./resources/actual-appstudio-pipeline-clusterrole.yaml
+  - name: when-cluster-policies-are-ready
+    try:
+    - apply:
+        file: ../bootstrap-tenant-namespace-np-ocpconsole-cp.yaml
+    - apply:
+        file: ../bootstrap-tenant-namespace-np-ocpingress-cp.yaml
+    - apply:
+        file: ../bootstrap-tenant-namespace-np-ocpmonitoring-cp.yaml
+    - apply:
+        file: ../bootstrap-tenant-namespace-np-olm-cp.yaml
+    - apply:
+        file: ../bootstrap-tenant-namespace-np-samenamespace-cp.yaml
+    - apply:
+        file: ../bootstrap-tenant-namespace-rbcm-cp.yaml
+    - assert:
+        file: chainsaw-assert-clusterpolicy.yaml
+  - name: then-resources-are-created
+    try:
+    - assert:
+        file: resources/expected-resources.yaml
+        template: true
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: konfluxci-bootstrap-ns-mutate-existing-namespace-unlabeled
+spec:
+  description: |
+    tests that the RoleBinding is NOT created in an
+    existing unlabeled namespace
+  concurrent: false
+  namespace: 'generate-existing-namespace'
+  bindings:
+  - name: suffix
+    value: unlabeled
+  steps:
+  - name: given-appstudio-pipeline-clusterrole-exists
+    try:
+    - apply:
+        file: ./resources/actual-appstudio-pipeline-clusterrole.yaml
+  - name: given-kyverno-has-permission-on-resources
+    try:
+    - apply:
+        file: ../kyverno-admission-cluster-role.yaml
+    - apply:
+        file: ../kyverno-background-cluster-role.yaml
+  - name: given-unlabeled-namespace-is-created
+    try:
+    - apply:
+        file: resources/actual-namespace-unlabeled.yaml
+        template: true
+  - name: when-cluster-policies-are-ready
+    try:
+    - apply:
+        file: ../bootstrap-tenant-namespace-np-ocpconsole-cp.yaml
+    - apply:
+        file: ../bootstrap-tenant-namespace-np-ocpingress-cp.yaml
+    - apply:
+        file: ../bootstrap-tenant-namespace-np-ocpmonitoring-cp.yaml
+    - apply:
+        file: ../bootstrap-tenant-namespace-np-olm-cp.yaml
+    - apply:
+        file: ../bootstrap-tenant-namespace-np-samenamespace-cp.yaml
+    - apply:
+        file: ../bootstrap-tenant-namespace-rbcm-cp.yaml
+    - assert:
+        file: chainsaw-assert-clusterpolicy.yaml
+  - name: then-resources-are-not-created
+    try:
+    - delete:
+        file: resources/expected-resources.yaml
+        template: true
+        expect:
+        - check:
+            ($error != null): true
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: konfluxci-bootstrap-ns-mutate-existing-namespace-konfluxcidev-existing-resources
+spec:
+  description: |
+    tests that resources are not updated in an already existing
+    namespace labeled with `konflux-ci.dev/type=tenant` where the
+    RoleBinding already exists
+  concurrent: false
+  namespace: 'generate-update-existing-namespace'
+  bindings:
+  - name: suffix
+    value: labeled
+  steps:
+  - name: given-konfluxcidev-labeled-namespace-is-created
+    try:
+    - apply:
+        file: resources/actual-namespace-konfluxcidev.yaml
+        template: true
+  - name: then-resources-are-not-changed
+    try:
+    - apply:
+        file: resources/actual-existing-resources.yaml
+        template: true
+  - name: given-appstudio-pipeline-clusterrole-exists
+    try:
+    - apply:
+        file: ./resources/actual-appstudio-pipeline-clusterrole.yaml
+  - name: given-kyverno-has-permission-on-resources
+    try:
+    - apply:
+        file: ../kyverno-admission-cluster-role.yaml
+    - apply:
+        file: ../kyverno-background-cluster-role.yaml
+  - name: when-cluster-policies-are-ready
+    try:
+    - apply:
+        file: ../bootstrap-tenant-namespace-np-ocpconsole-cp.yaml
+    - apply:
+        file: ../bootstrap-tenant-namespace-np-ocpingress-cp.yaml
+    - apply:
+        file: ../bootstrap-tenant-namespace-np-ocpmonitoring-cp.yaml
+    - apply:
+        file: ../bootstrap-tenant-namespace-np-olm-cp.yaml
+    - apply:
+        file: ../bootstrap-tenant-namespace-np-samenamespace-cp.yaml
+    - apply:
+        file: ../bootstrap-tenant-namespace-rbcm-cp.yaml
+    - assert:
+        file: chainsaw-assert-clusterpolicy.yaml
+  - name: then-resources-are-not-changed
+    try:
+    - assert:
+        file: resources/actual-existing-resources.yaml
+        template: true
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: orphan-resources-on-policy-deletion
+spec:
+  description: |
+    tests that the resources remain in a tenant namespace when the cluster policy is deleted
+  concurrent: false
+  namespace: 'orphan-resources'
+  bindings:
+  - name: suffix
+    value: orphan
+  steps:
+  - name: given-appstudio-pipeline-clusterrole-exists
+    try:
+    - apply:
+        file: ./resources/actual-appstudio-pipeline-clusterrole.yaml
+  - name: given-kyverno-has-permission-on-resources
+    try:
+    - apply:
+        file: ../kyverno-admission-cluster-role.yaml
+    - apply:
+        file: ../kyverno-background-cluster-role.yaml
+  - name: given-cluster-policies-are-ready
+    try:
+    - apply:
+        file: ../bootstrap-tenant-namespace-np-ocpconsole-cp.yaml
+    - apply:
+        file: ../bootstrap-tenant-namespace-np-ocpingress-cp.yaml
+    - apply:
+        file: ../bootstrap-tenant-namespace-np-ocpmonitoring-cp.yaml
+    - apply:
+        file: ../bootstrap-tenant-namespace-np-olm-cp.yaml
+    - apply:
+        file: ../bootstrap-tenant-namespace-np-samenamespace-cp.yaml
+    - apply:
+        file: ../bootstrap-tenant-namespace-rbcm-cp.yaml
+    - assert:
+        file: chainsaw-assert-clusterpolicy.yaml
+  - name: when-konfluxcidev-labeled-namespace-is-created
+    try:
+    - apply:
+        file: resources/actual-namespace-konfluxcidev.yaml
+        template: true
+  - name: then-resources-are-created
+    try:
+    - assert:
+        file: resources/expected-resources.yaml
+        template: true
+  - name: when-the-cluster-policy-is-deleted
+    try:
+    - delete:
+        file: ../bootstrap-tenant-namespace-np-ocpconsole-cp.yaml
+    - delete:
+        file: ../bootstrap-tenant-namespace-np-ocpingress-cp.yaml
+    - delete:
+        file: ../bootstrap-tenant-namespace-np-ocpmonitoring-cp.yaml
+    - delete:
+        file: ../bootstrap-tenant-namespace-np-olm-cp.yaml
+    - delete:
+        file: ../bootstrap-tenant-namespace-np-samenamespace-cp.yaml
+    - delete:
+        file: ../bootstrap-tenant-namespace-rbcm-cp.yaml
+    - wait:
+        apiVersion: kyverno.io/v1
+        kind: ClusterPolicy
+        for:
+          deletion: {}
+    - script:
+        content: |
+          while true; do
+            if [ "$(kubectl get updaterequests -n konflux-kyverno -o yaml | yq '.items | length')" -eq 0 ]; then
+              exit 0
+            fi
+            sleep 1
+          done
+        timeout: 30s
+  - name: then-the-resources-remain
+    try:
+    - assert:
+        file: resources/expected-resources.yaml
+        template: true

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/bootstrap-tenant-namespace/.chainsaw-test/resources/actual-appstudio-pipeline-clusterrole.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/bootstrap-tenant-namespace/.chainsaw-test/resources/actual-appstudio-pipeline-clusterrole.yaml
@@ -1,0 +1,4 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: appstudio-pipelines-runner

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/bootstrap-tenant-namespace/.chainsaw-test/resources/actual-existing-resources.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/bootstrap-tenant-namespace/.chainsaw-test/resources/actual-existing-resources.yaml
@@ -1,0 +1,98 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-same-namespace
+  namespace: (join('-', [$namespace, $suffix]))
+  labels:
+    already-existing: expected-not-to-be-removed
+spec:
+  ingress:
+  - from:
+    - podSelector: {}
+  podSelector: {}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-from-openshift-ingress
+  namespace: (join('-', [$namespace, $suffix]))
+  labels:
+    already-existing: expected-not-to-be-removed
+spec:
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          network.openshift.io/policy-group: ingress
+  podSelector: {}
+  policyTypes:
+  - Ingress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-from-openshift-monitoring
+  namespace: (join('-', [$namespace, $suffix]))
+  labels:
+    already-existing: expected-not-to-be-removed
+spec:
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          network.openshift.io/policy-group: monitoring
+  podSelector: {}
+  policyTypes:
+  - Ingress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-from-codeready-workspaces-operator
+  namespace: (join('-', [$namespace, $suffix]))
+  labels:
+    already-existing: expected-not-to-be-removed
+spec:
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          network.openshift.io/policy-group: codeready-workspaces
+  podSelector: {}
+  policyTypes:
+  - Ingress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-from-olm-namespaces
+  namespace: (join('-', [$namespace, $suffix]))
+  labels:
+    already-existing: expected-not-to-be-removed
+spec:
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          openshift.io/scc: anyuid
+  podSelector: {}
+  policyTypes:
+  - Ingress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-from-console-namespaces
+  namespace: (join('-', [$namespace, $suffix]))
+  labels:
+    already-existing: expected-not-to-be-removed
+spec:
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          network.openshift.io/policy-group: console
+  podSelector: {}
+  policyTypes:
+  - Ingress

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/bootstrap-tenant-namespace/.chainsaw-test/resources/actual-namespace-konfluxcidev.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/bootstrap-tenant-namespace/.chainsaw-test/resources/actual-namespace-konfluxcidev.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: (join('-', [$namespace, $suffix]))
+  labels:
+    konflux-ci.dev/type: tenant

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/bootstrap-tenant-namespace/.chainsaw-test/resources/actual-namespace-unlabeled.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/bootstrap-tenant-namespace/.chainsaw-test/resources/actual-namespace-unlabeled.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: (join('-', [$namespace, $suffix]))

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/bootstrap-tenant-namespace/.chainsaw-test/resources/expected-resources.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/bootstrap-tenant-namespace/.chainsaw-test/resources/expected-resources.yaml
@@ -1,0 +1,79 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-same-namespace
+  namespace: (join('-', [$namespace, $suffix]))
+spec:
+  ingress:
+  - from:
+    - podSelector: {}
+  podSelector: {}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-from-openshift-ingress
+  namespace: (join('-', [$namespace, $suffix]))
+spec:
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          network.openshift.io/policy-group: ingress
+  podSelector: {}
+  policyTypes:
+  - Ingress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-from-openshift-monitoring
+  namespace: (join('-', [$namespace, $suffix]))
+spec:
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          network.openshift.io/policy-group: monitoring
+  podSelector: {}
+  policyTypes:
+  - Ingress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-from-olm-namespaces
+  namespace: (join('-', [$namespace, $suffix]))
+spec:
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          openshift.io/scc: anyuid
+  podSelector: {}
+  policyTypes:
+  - Ingress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-from-console-namespaces
+  namespace: (join('-', [$namespace, $suffix]))
+spec:
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          network.openshift.io/policy-group: console
+  podSelector: {}
+  policyTypes:
+  - Ingress
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    config.openshift.io/inject-trusted-cabundle: "true"
+  name: trusted-ca
+  namespace: (join('-', [$namespace, $suffix]))

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/bootstrap-tenant-namespace/.kyverno-test/kyverno-test.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/bootstrap-tenant-namespace/.kyverno-test/kyverno-test.yaml
@@ -1,0 +1,56 @@
+apiVersion: cli.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: bootstrap-existing-namespaces
+policies:
+- ../bootstrap-tenant-namespace-np-ocpconsole-cp.yaml
+- ../bootstrap-tenant-namespace-np-ocpingress-cp.yaml
+- ../bootstrap-tenant-namespace-np-ocpmonitoring-cp.yaml
+- ../bootstrap-tenant-namespace-np-olm-cp.yaml
+- ../bootstrap-tenant-namespace-np-samenamespace-cp.yaml
+- ../bootstrap-tenant-namespace-rbcm-cp.yaml
+resources:
+- ./resources/labeled-namespace-konflux.yaml
+results:
+- policy: bootstrap-tenant-namespace-np-ocpconsole
+  generatedResource: ./resources/expected-networkpolicy_allow-from-console-namespaces.yml
+  kind: Namespace
+  resources:
+  - labeled-namespace-konflux
+  result: pass
+  rule: create-allow-from-console-namespaces-networkpolicy
+- policy: bootstrap-tenant-namespace-np-samenamespace
+  generatedResource: ./resources/expected-networkpolicy_allow-same-namespace.yml
+  kind: Namespace
+  resources:
+  - labeled-namespace-konflux
+  result: pass
+  rule: create-allow-same-namespace-networkpolicy
+- policy: bootstrap-tenant-namespace-np-olm
+  generatedResource: ./resources/expected-networkpolicy_allow-from-olm-namespaces.yml
+  kind: Namespace
+  resources:
+  - labeled-namespace-konflux
+  result: pass
+  rule: create-allow-from-olm-namespaces-networkpolicy
+- policy: bootstrap-tenant-namespace-np-ocpmonitoring
+  generatedResource: ./resources/expected-networkpolicy_allow-from-openshift-monitoring.yml
+  kind: Namespace
+  resources:
+  - labeled-namespace-konflux
+  result: pass
+  rule: create-allow-from-openshift-monitoring-networkpolicy
+- policy: bootstrap-tenant-namespace-np-ocpingress
+  generatedResource: ./resources/expected-networkpolicy_allow-from-openshift-ingress.yml
+  kind: Namespace
+  resources:
+  - labeled-namespace-konflux
+  result: pass
+  rule: create-allow-from-openshift-ingress-networkpolicy
+- policy: bootstrap-tenant-namespace-rbcm
+  generatedResource: ./resources/expected-configmap_trusted-ca.yml
+  kind: Namespace
+  resources:
+  - labeled-namespace-konflux
+  result: pass
+  rule: create-trusted-ca-configmap

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/bootstrap-tenant-namespace/.kyverno-test/resources/expected-configmap_trusted-ca.yml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/bootstrap-tenant-namespace/.kyverno-test/resources/expected-configmap_trusted-ca.yml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    config.openshift.io/inject-trusted-cabundle: "true"
+  name: trusted-ca
+  namespace: labeled-namespace-konflux

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/bootstrap-tenant-namespace/.kyverno-test/resources/expected-networkpolicy_allow-from-console-namespaces.yml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/bootstrap-tenant-namespace/.kyverno-test/resources/expected-networkpolicy_allow-from-console-namespaces.yml
@@ -1,0 +1,15 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-from-console-namespaces
+  namespace: labeled-namespace-konflux
+spec:
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network.openshift.io/policy-group: console
+  podSelector: {}
+  policyTypes:
+    - Ingress

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/bootstrap-tenant-namespace/.kyverno-test/resources/expected-networkpolicy_allow-from-olm-namespaces.yml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/bootstrap-tenant-namespace/.kyverno-test/resources/expected-networkpolicy_allow-from-olm-namespaces.yml
@@ -1,0 +1,15 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-from-olm-namespaces
+  namespace: labeled-namespace-konflux
+spec:
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              openshift.io/scc: anyuid
+  podSelector: {}
+  policyTypes:
+    - Ingress

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/bootstrap-tenant-namespace/.kyverno-test/resources/expected-networkpolicy_allow-from-openshift-ingress.yml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/bootstrap-tenant-namespace/.kyverno-test/resources/expected-networkpolicy_allow-from-openshift-ingress.yml
@@ -1,0 +1,15 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-from-openshift-ingress
+  namespace: labeled-namespace-konflux
+spec:
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network.openshift.io/policy-group: ingress
+  podSelector: {}
+  policyTypes:
+    - Ingress

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/bootstrap-tenant-namespace/.kyverno-test/resources/expected-networkpolicy_allow-from-openshift-monitoring.yml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/bootstrap-tenant-namespace/.kyverno-test/resources/expected-networkpolicy_allow-from-openshift-monitoring.yml
@@ -1,0 +1,15 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-from-openshift-monitoring
+  namespace: labeled-namespace-konflux
+spec:
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              network.openshift.io/policy-group: monitoring
+  podSelector: {}
+  policyTypes:
+    - Ingress

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/bootstrap-tenant-namespace/.kyverno-test/resources/expected-networkpolicy_allow-same-namespace.yml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/bootstrap-tenant-namespace/.kyverno-test/resources/expected-networkpolicy_allow-same-namespace.yml
@@ -1,0 +1,11 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-same-namespace
+  namespace: labeled-namespace-konflux
+spec:
+  ingress:
+    - from:
+        - podSelector: {}
+  podSelector: {}

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/bootstrap-tenant-namespace/.kyverno-test/resources/labeled-namespace-konflux.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/bootstrap-tenant-namespace/.kyverno-test/resources/labeled-namespace-konflux.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: labeled-namespace-konflux
+  labels:
+    konflux-ci.dev/type: tenant

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/bootstrap-tenant-namespace/bootstrap-tenant-namespace-np-ocpconsole-cp.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/bootstrap-tenant-namespace/bootstrap-tenant-namespace-np-ocpconsole-cp.yaml
@@ -1,0 +1,35 @@
+---
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: bootstrap-tenant-namespace-np-ocpconsole
+spec:
+  rules:
+  - name: create-allow-from-console-namespaces-networkpolicy
+    skipBackgroundRequests: true
+    match:
+      any:
+      - resources:
+          kinds:
+          - Namespace
+          selector:
+            matchLabels:
+              konflux-ci.dev/type: tenant
+    generate:
+      generateExisting: true
+      orphanDownstreamOnPolicyDelete: true
+      synchronize: false
+      apiVersion: networking.k8s.io/v1
+      kind: NetworkPolicy
+      name: allow-from-console-namespaces
+      namespace: '{{request.object.metadata.name}}'
+      data:
+        spec:
+          ingress:
+          - from:
+            - namespaceSelector:
+                matchLabels:
+                  network.openshift.io/policy-group: console
+          podSelector: {}
+          policyTypes:
+          - Ingress

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/bootstrap-tenant-namespace/bootstrap-tenant-namespace-np-ocpingress-cp.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/bootstrap-tenant-namespace/bootstrap-tenant-namespace-np-ocpingress-cp.yaml
@@ -1,0 +1,35 @@
+---
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: bootstrap-tenant-namespace-np-ocpingress
+spec:
+  rules:
+  - name: create-allow-from-openshift-ingress-networkpolicy
+    skipBackgroundRequests: true
+    match:
+      any:
+      - resources:
+          kinds:
+          - Namespace
+          selector:
+            matchLabels:
+              konflux-ci.dev/type: tenant
+    generate:
+      generateExisting: true
+      orphanDownstreamOnPolicyDelete: true
+      synchronize: false
+      apiVersion: networking.k8s.io/v1
+      kind: NetworkPolicy
+      namespace: '{{request.object.metadata.name}}'
+      name: allow-from-openshift-ingress
+      data:
+         spec:
+          ingress:
+          - from:
+            - namespaceSelector:
+                matchLabels:
+                  network.openshift.io/policy-group: ingress
+          podSelector: {}
+          policyTypes:
+          - Ingress

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/bootstrap-tenant-namespace/bootstrap-tenant-namespace-np-ocpmonitoring-cp.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/bootstrap-tenant-namespace/bootstrap-tenant-namespace-np-ocpmonitoring-cp.yaml
@@ -1,0 +1,35 @@
+---
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: bootstrap-tenant-namespace-np-ocpmonitoring
+spec:
+  rules:
+  - name: create-allow-from-openshift-monitoring-networkpolicy
+    skipBackgroundRequests: true
+    match:
+      any:
+      - resources:
+          kinds:
+          - Namespace
+          selector:
+            matchLabels:
+              konflux-ci.dev/type: tenant
+    generate:
+      generateExisting: true
+      orphanDownstreamOnPolicyDelete: true
+      synchronize: false
+      apiVersion: networking.k8s.io/v1
+      kind: NetworkPolicy
+      namespace: '{{request.object.metadata.name}}'
+      name: allow-from-openshift-monitoring
+      data:
+        spec:
+          ingress:
+          - from:
+            - namespaceSelector:
+                matchLabels:
+                  network.openshift.io/policy-group: monitoring
+          podSelector: {}
+          policyTypes:
+          - Ingress

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/bootstrap-tenant-namespace/bootstrap-tenant-namespace-np-olm-cp.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/bootstrap-tenant-namespace/bootstrap-tenant-namespace-np-olm-cp.yaml
@@ -1,0 +1,35 @@
+---
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: bootstrap-tenant-namespace-np-olm
+spec:
+  rules:
+  - name: create-allow-from-olm-namespaces-networkpolicy
+    skipBackgroundRequests: true
+    match:
+      any:
+      - resources:
+          kinds:
+          - Namespace
+          selector:
+            matchLabels:
+              konflux-ci.dev/type: tenant
+    generate:
+      generateExisting: true
+      orphanDownstreamOnPolicyDelete: true
+      synchronize: false
+      apiVersion: networking.k8s.io/v1
+      kind: NetworkPolicy
+      name: allow-from-olm-namespaces
+      namespace: '{{request.object.metadata.name}}'
+      data:
+        spec:
+          ingress:
+          - from:
+            - namespaceSelector:
+                matchLabels:
+                  openshift.io/scc: anyuid
+          podSelector: {}
+          policyTypes:
+          - Ingress

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/bootstrap-tenant-namespace/bootstrap-tenant-namespace-np-samenamespace-cp.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/bootstrap-tenant-namespace/bootstrap-tenant-namespace-np-samenamespace-cp.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: bootstrap-tenant-namespace-np-samenamespace
+spec:
+  rules:
+  - name: create-allow-same-namespace-networkpolicy
+    skipBackgroundRequests: true
+    match:
+      any:
+      - resources:
+          kinds:
+          - Namespace
+          selector:
+            matchLabels:
+              konflux-ci.dev/type: tenant
+    generate:
+      generateExisting: true
+      orphanDownstreamOnPolicyDelete: true
+      synchronize: false
+      apiVersion: networking.k8s.io/v1
+      kind: NetworkPolicy
+      namespace: '{{request.object.metadata.name}}'
+      name: allow-same-namespace
+      data:
+        spec:
+          ingress:
+          - from:
+            - podSelector: {}
+          podSelector: {}

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/bootstrap-tenant-namespace/bootstrap-tenant-namespace-rbcm-cp.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/bootstrap-tenant-namespace/bootstrap-tenant-namespace-rbcm-cp.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: bootstrap-tenant-namespace-rbcm
+spec:
+  rules:
+  - name: create-trusted-ca-configmap
+    skipBackgroundRequests: true
+    match:
+      any:
+      - resources:
+          kinds:
+          - Namespace
+          selector:
+            matchLabels:
+              konflux-ci.dev/type: tenant
+    generate:
+      generateExisting: true
+      orphanDownstreamOnPolicyDelete: true
+      synchronize: false
+      apiVersion: v1
+      kind: ConfigMap
+      namespace: '{{request.object.metadata.name}}'
+      name: trusted-ca
+      data:
+        metadata:
+          name: trusted-ca
+          labels:
+            config.openshift.io/inject-trusted-cabundle: "true"
+        data: {}

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/bootstrap-tenant-namespace/kustomization.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/bootstrap-tenant-namespace/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namePrefix: konflux-rbac-
+resources:
+- bootstrap-tenant-namespace-np-ocpconsole-cp.yaml
+- bootstrap-tenant-namespace-np-ocpingress-cp.yaml
+- bootstrap-tenant-namespace-np-ocpmonitoring-cp.yaml
+- bootstrap-tenant-namespace-np-olm-cp.yaml
+- bootstrap-tenant-namespace-np-samenamespace-cp.yaml
+- bootstrap-tenant-namespace-rbcm-cp.yaml
+- kyverno-admission-cluster-role.yaml
+- kyverno-background-cluster-role.yaml
+commonAnnotations:
+  argocd.argoproj.io/sync-options: Prune=false

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/bootstrap-tenant-namespace/kyverno-admission-cluster-role.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/bootstrap-tenant-namespace/kyverno-admission-cluster-role.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kyverno-admission:bootstrap-tenant-namespace
+  labels:
+    rbac.kyverno.io/aggregate-to-admission-controller: "true"
+rules:
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - rolebindings
+  verbs:
+  - list
+  - get
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - list

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/bootstrap-tenant-namespace/kyverno-background-cluster-role.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/bootstrap-tenant-namespace/kyverno-background-cluster-role.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kyverno-background:manage-rolebindings
+  labels:
+    rbac.kyverno.io/aggregate-to-background-controller: "true"
+rules:
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - rolebindings
+  verbs:
+  - create
+  - get
+  - list
+  - delete
+  - update
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - create
+  - get
+  - list
+  - delete
+  - update

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/deny-serviceaccount-token-secrets/.chainsaw-test/chainsaw-assert-policy.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/deny-serviceaccount-token-secrets/.chainsaw-test/chainsaw-assert-policy.yaml
@@ -1,0 +1,7 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: deny-serviceaccount-token-secrets.konflux-ci.dev
+status:
+  observedGeneration: 1
+  typeChecking: {}

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/deny-serviceaccount-token-secrets/.chainsaw-test/resources/secret_legacy_serviceaccount_token.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/deny-serviceaccount-token-secrets/.chainsaw-test/resources/secret_legacy_serviceaccount_token.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: chainsaw-legacy-sa-token-secret
+  annotations:
+    kubernetes.io/service-account.name: chainsaw-token-test
+type: kubernetes.io/service-account-token

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/deny-serviceaccount-token-secrets/.chainsaw-test/resources/secret_opaque.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/deny-serviceaccount-token-secrets/.chainsaw-test/resources/secret_opaque.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: chainsaw-opaque-secret
+type: Opaque
+stringData:
+  key: value

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/deny-serviceaccount-token-secrets/.chainsaw-test/resources/serviceaccount.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/deny-serviceaccount-token-secrets/.chainsaw-test/resources/serviceaccount.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: chainsaw-token-test

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/deny-serviceaccount-token-secrets/.chainsaw-test/test-in-tenant/README.md
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/deny-serviceaccount-token-secrets/.chainsaw-test/test-in-tenant/README.md
@@ -1,0 +1,105 @@
+# Test: `in-tenant-create-opaque-secret-allowed`
+
+Creates an Opaque Secret in a tenant namespace while the policy is active.
+
+
+## Steps
+
+| # | Name | Bindings | Try | Catch | Finally | Cleanup |
+|:-:|---|:-:|:-:|:-:|:-:|:-:|
+| 1 | [ensure-namespace-is-labeled](#step-ensure-namespace-is-labeled) | 0 | 1 | 0 | 0 | 0 |
+| 2 | [given-validatingadmissionpolicy-is-installed](#step-given-validatingadmissionpolicy-is-installed) | 0 | 3 | 0 | 0 | 0 |
+| 3 | [then-opaque-secret-can-be-created](#step-then-opaque-secret-can-be-created) | 0 | 1 | 0 | 0 | 0 |
+
+### Step: `ensure-namespace-is-labeled`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `given-validatingadmissionpolicy-is-installed`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+| 2 | `apply` | 0 | 0 | *No description* |
+| 3 | `assert` | 0 | 0 | *No description* |
+
+### Step: `then-opaque-secret-can-be-created`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `create` | 0 | 0 | *No description* |
+
+---
+
+# Test: `in-tenant-deny-legacy-serviceaccount-token-secret`
+
+Fails to create a Secret of type kubernetes.io/service-account-token in a tenant namespace.
+
+
+## Steps
+
+| # | Name | Bindings | Try | Catch | Finally | Cleanup |
+|:-:|---|:-:|:-:|:-:|:-:|:-:|
+| 1 | [ensure-namespace-is-labeled](#step-ensure-namespace-is-labeled) | 0 | 1 | 0 | 0 | 0 |
+| 2 | [given-validatingadmissionpolicy-is-installed](#step-given-validatingadmissionpolicy-is-installed) | 0 | 3 | 0 | 0 | 0 |
+| 3 | [given-serviceaccount-exists](#step-given-serviceaccount-exists) | 0 | 1 | 0 | 0 | 0 |
+| 4 | [then-legacy-sa-token-secret-can-not-be-created](#step-then-legacy-sa-token-secret-can-not-be-created) | 0 | 1 | 0 | 0 | 0 |
+
+### Step: `ensure-namespace-is-labeled`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `given-validatingadmissionpolicy-is-installed`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+| 2 | `apply` | 0 | 0 | *No description* |
+| 3 | `assert` | 0 | 0 | *No description* |
+
+### Step: `given-serviceaccount-exists`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `create` | 0 | 0 | *No description* |
+
+### Step: `then-legacy-sa-token-secret-can-not-be-created`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `error` | 0 | 0 | *No description* |
+
+---
+

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/deny-serviceaccount-token-secrets/.chainsaw-test/test-in-tenant/chainsaw-test.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/deny-serviceaccount-token-secrets/.chainsaw-test/test-in-tenant/chainsaw-test.yaml
@@ -1,0 +1,70 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: in-tenant-create-opaque-secret-allowed
+spec:
+  description: |
+    Creates an Opaque Secret in a tenant namespace while the policy is active.
+  concurrent: false
+  steps:
+  - name: ensure-namespace-is-labeled
+    try:
+    - apply:
+        resource:
+          apiVersion: v1
+          kind: Namespace
+          metadata:
+            name: ($namespace)
+            labels:
+              konflux-ci.dev/type: tenant
+  - name: given-validatingadmissionpolicy-is-installed
+    try:
+    - apply:
+        file: ../../deny-serviceaccount-token-secrets-validationadmissionpolicy.yaml
+    - apply:
+        file: ../../deny-serviceaccount-token-secrets-validationadmissionpolicybinding.yaml
+    - assert:
+        file: ../chainsaw-assert-policy.yaml
+  - name: then-opaque-secret-can-be-created
+    try:
+    - create:
+        file: ../resources/secret_opaque.yaml
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: in-tenant-deny-legacy-serviceaccount-token-secret
+spec:
+  description: |
+    Fails to create a Secret of type kubernetes.io/service-account-token in a tenant namespace.
+  concurrent: false
+  steps:
+  - name: ensure-namespace-is-labeled
+    try:
+    - apply:
+        resource:
+          apiVersion: v1
+          kind: Namespace
+          metadata:
+            name: ($namespace)
+            labels:
+              konflux-ci.dev/type: tenant
+  - name: given-validatingadmissionpolicy-is-installed
+    try:
+    - apply:
+        file: ../../deny-serviceaccount-token-secrets-validationadmissionpolicy.yaml
+    - apply:
+        file: ../../deny-serviceaccount-token-secrets-validationadmissionpolicybinding.yaml
+    - assert:
+        file: ../chainsaw-assert-policy.yaml
+  - name: given-serviceaccount-exists
+    try:
+    - create:
+        file: ../resources/serviceaccount.yaml
+  - name: then-legacy-sa-token-secret-can-not-be-created
+    try:
+    - error:
+        file: ../resources/secret_legacy_serviceaccount_token.yaml

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/deny-serviceaccount-token-secrets/.chainsaw-test/test-outside-tenant/README.md
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/deny-serviceaccount-token-secrets/.chainsaw-test/test-outside-tenant/README.md
@@ -1,0 +1,48 @@
+# Test: `outside-tenant-create-legacy-serviceaccount-token-secret-allowed`
+
+Creates a Secret of type kubernetes.io/service-account-token in a namespace that is not
+labeled as a tenant; the binding must not apply.
+
+
+## Steps
+
+| # | Name | Bindings | Try | Catch | Finally | Cleanup |
+|:-:|---|:-:|:-:|:-:|:-:|:-:|
+| 1 | [given-validatingadmissionpolicy-is-installed](#step-given-validatingadmissionpolicy-is-installed) | 0 | 3 | 0 | 0 | 0 |
+| 2 | [given-serviceaccount-exists](#step-given-serviceaccount-exists) | 0 | 1 | 0 | 0 | 0 |
+| 3 | [then-legacy-sa-token-secret-can-be-created](#step-then-legacy-sa-token-secret-can-be-created) | 0 | 1 | 0 | 0 | 0 |
+
+### Step: `given-validatingadmissionpolicy-is-installed`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+| 2 | `apply` | 0 | 0 | *No description* |
+| 3 | `assert` | 0 | 0 | *No description* |
+
+### Step: `given-serviceaccount-exists`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `create` | 0 | 0 | *No description* |
+
+### Step: `then-legacy-sa-token-secret-can-be-created`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `create` | 0 | 0 | *No description* |
+
+---
+

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/deny-serviceaccount-token-secrets/.chainsaw-test/test-outside-tenant/chainsaw-test.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/deny-serviceaccount-token-secrets/.chainsaw-test/test-outside-tenant/chainsaw-test.yaml
@@ -1,0 +1,28 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: outside-tenant-create-legacy-serviceaccount-token-secret-allowed
+spec:
+  description: |
+    Creates a Secret of type kubernetes.io/service-account-token in a namespace that is not
+    labeled as a tenant; the binding must not apply.
+  concurrent: false
+  steps:
+  - name: given-validatingadmissionpolicy-is-installed
+    try:
+    - apply:
+        file: ../../deny-serviceaccount-token-secrets-validationadmissionpolicy.yaml
+    - apply:
+        file: ../../deny-serviceaccount-token-secrets-validationadmissionpolicybinding.yaml
+    - assert:
+        file: ../chainsaw-assert-policy.yaml
+  - name: given-serviceaccount-exists
+    try:
+    - create:
+        file: ../resources/serviceaccount.yaml
+  - name: then-legacy-sa-token-secret-can-be-created
+    try:
+    - create:
+        file: ../resources/secret_legacy_serviceaccount_token.yaml

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/deny-serviceaccount-token-secrets/deny-serviceaccount-token-secrets-validationadmissionpolicy.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/deny-serviceaccount-token-secrets/deny-serviceaccount-token-secrets-validationadmissionpolicy.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: deny-serviceaccount-token-secrets.konflux-ci.dev
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+    - apiGroups: [""]
+      apiVersions: ["v1"]
+      operations: ["CREATE"]
+      resources: ["secrets"]
+      scope: "Namespaced"
+  validations:
+  - expression: '!has(object.type) || object.type != "kubernetes.io/service-account-token"'
+    reason: Forbidden
+    message: >
+      Creating Secrets of type kubernetes.io/service-account-token is not allowed in tenant
+      namespaces. Use projected service account tokens, the TokenRequest API, or
+      `kubectl create token` instead of long-lived legacy token Secrets.

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/deny-serviceaccount-token-secrets/deny-serviceaccount-token-secrets-validationadmissionpolicybinding.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/deny-serviceaccount-token-secrets/deny-serviceaccount-token-secrets-validationadmissionpolicybinding.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: deny-serviceaccount-token-secrets.konflux-ci.dev
+spec:
+  policyName: "deny-serviceaccount-token-secrets.konflux-ci.dev"
+  validationActions: [Deny]
+  matchResources:
+    namespaceSelector:
+      matchLabels:
+        konflux-ci.dev/type: tenant

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/deny-serviceaccount-token-secrets/kustomization.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/deny-serviceaccount-token-secrets/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- deny-serviceaccount-token-secrets-validationadmissionpolicy.yaml
+- deny-serviceaccount-token-secrets-validationadmissionpolicybinding.yaml

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/konflux-support-access/.chainsaw-test/README.md
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/konflux-support-access/.chainsaw-test/README.md
@@ -1,0 +1,451 @@
+# Test: `verify-clusterpolicy-is-ready`
+
+Tests that the ClusterPolicy for generating konflux-support-ai-konflux-user-support
+ClusterRoleBinding is applied successfully and becomes Ready.
+
+
+## Steps
+
+| # | Name | Bindings | Try | Catch | Finally | Cleanup |
+|:-:|---|:-:|:-:|:-:|:-:|:-:|
+| 1 | [given-kyverno-has-permission-on-resources](#step-given-kyverno-has-permission-on-resources) | 0 | 1 | 0 | 0 | 0 |
+| 2 | [given-viewer-clusterrole-exists](#step-given-viewer-clusterrole-exists) | 0 | 1 | 0 | 0 | 0 |
+| 3 | [given-group-crd-exists](#step-given-group-crd-exists) | 0 | 2 | 0 | 0 | 0 |
+| 4 | [Apply Kyverno ClusterPolicy and assert it exists](#step-Apply Kyverno ClusterPolicy and assert it exists) | 0 | 2 | 0 | 0 | 0 |
+
+### Step: `given-kyverno-has-permission-on-resources`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `given-viewer-clusterrole-exists`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `given-group-crd-exists`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+| 2 | `assert` | 0 | 0 | *No description* |
+
+### Step: `Apply Kyverno ClusterPolicy and assert it exists`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+| 2 | `assert` | 0 | 0 | *No description* |
+
+---
+
+# Test: `clusterrolebinding-created-with-users`
+
+Tests that when an ai-konflux-user-support and konflux-sre Groups
+are created with users, a ClusterRoleBinding for each group is generated.
+The ClusterRoleBindings have Group's User subjects, the correct label,
+and they reference the konflux-viewer-user-actions ClusterRole.
+
+
+## Steps
+
+| # | Name | Bindings | Try | Catch | Finally | Cleanup |
+|:-:|---|:-:|:-:|:-:|:-:|:-:|
+| 1 | [given-kyverno-has-permission-on-resources](#step-given-kyverno-has-permission-on-resources) | 0 | 1 | 0 | 0 | 0 |
+| 2 | [given-viewer-clusterrole-exists](#step-given-viewer-clusterrole-exists) | 0 | 1 | 0 | 0 | 0 |
+| 3 | [given-group-crd-exists](#step-given-group-crd-exists) | 0 | 2 | 0 | 0 | 0 |
+| 4 | [Apply Kyverno ClusterPolicy](#step-Apply Kyverno ClusterPolicy) | 0 | 2 | 0 | 0 | 0 |
+| 5 | [Create ai-konflux-user-support Group with users](#step-Create ai-konflux-user-support Group with users) | 0 | 1 | 0 | 0 | 0 |
+| 6 | [Assert ai-konflux-user-support's support ClusterRoleBinding is created correctly](#step-Assert ai-konflux-user-support's support ClusterRoleBinding is created correctly) | 0 | 1 | 0 | 0 | 0 |
+| 7 | [Create konflux-sre Group with users](#step-Create konflux-sre Group with users) | 0 | 1 | 0 | 0 | 0 |
+| 8 | [Assert konflux-sre's support ClusterRoleBinding is created correctly](#step-Assert konflux-sre's support ClusterRoleBinding is created correctly) | 0 | 1 | 0 | 0 | 0 |
+
+### Step: `given-kyverno-has-permission-on-resources`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `given-viewer-clusterrole-exists`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `given-group-crd-exists`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+| 2 | `assert` | 0 | 0 | *No description* |
+
+### Step: `Apply Kyverno ClusterPolicy`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+| 2 | `assert` | 0 | 0 | *No description* |
+
+### Step: `Create ai-konflux-user-support Group with users`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `create` | 0 | 0 | *No description* |
+
+### Step: `Assert ai-konflux-user-support's support ClusterRoleBinding is created correctly`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `assert` | 0 | 0 | *No description* |
+
+### Step: `Create konflux-sre Group with users`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `create` | 0 | 0 | *No description* |
+
+### Step: `Assert konflux-sre's support ClusterRoleBinding is created correctly`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `assert` | 0 | 0 | *No description* |
+
+---
+
+# Test: `clusterrolebinding-updated-when-users-added`
+
+Tests that when users are added to the ai-konflux-user-support Group,
+the ClusterRoleBinding subjects are updated to include the new users.
+
+
+## Steps
+
+| # | Name | Bindings | Try | Catch | Finally | Cleanup |
+|:-:|---|:-:|:-:|:-:|:-:|:-:|
+| 1 | [given-kyverno-has-permission-on-resources](#step-given-kyverno-has-permission-on-resources) | 0 | 1 | 0 | 0 | 0 |
+| 2 | [given-viewer-clusterrole-exists](#step-given-viewer-clusterrole-exists) | 0 | 1 | 0 | 0 | 0 |
+| 3 | [given-group-crd-exists](#step-given-group-crd-exists) | 0 | 2 | 0 | 0 | 0 |
+| 4 | [Apply Kyverno ClusterPolicy](#step-Apply Kyverno ClusterPolicy) | 0 | 2 | 0 | 0 | 0 |
+| 5 | [Create ai-konflux-user-support Group with initial users](#step-Create ai-konflux-user-support Group with initial users) | 0 | 1 | 0 | 0 | 0 |
+| 6 | [Verify initial ClusterRoleBinding](#step-Verify initial ClusterRoleBinding) | 0 | 1 | 0 | 0 | 0 |
+| 7 | [Update Group with more users](#step-Update Group with more users) | 0 | 1 | 0 | 0 | 0 |
+| 8 | [Assert ClusterRoleBinding is updated with new users](#step-Assert ClusterRoleBinding is updated with new users) | 0 | 1 | 0 | 0 | 0 |
+
+### Step: `given-kyverno-has-permission-on-resources`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `given-viewer-clusterrole-exists`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `given-group-crd-exists`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+| 2 | `assert` | 0 | 0 | *No description* |
+
+### Step: `Apply Kyverno ClusterPolicy`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+| 2 | `assert` | 0 | 0 | *No description* |
+
+### Step: `Create ai-konflux-user-support Group with initial users`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `create` | 0 | 0 | *No description* |
+
+### Step: `Verify initial ClusterRoleBinding`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `assert` | 0 | 0 | *No description* |
+
+### Step: `Update Group with more users`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `Assert ClusterRoleBinding is updated with new users`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `assert` | 0 | 0 | *No description* |
+
+---
+
+# Test: `clusterrolebinding-updated-when-users-removed`
+
+Tests that when users are removed from the ai-konflux-user-support Group,
+the ClusterRoleBinding subjects are updated to remove those users.
+
+
+## Steps
+
+| # | Name | Bindings | Try | Catch | Finally | Cleanup |
+|:-:|---|:-:|:-:|:-:|:-:|:-:|
+| 1 | [given-kyverno-has-permission-on-resources](#step-given-kyverno-has-permission-on-resources) | 0 | 1 | 0 | 0 | 0 |
+| 2 | [given-viewer-clusterrole-exists](#step-given-viewer-clusterrole-exists) | 0 | 1 | 0 | 0 | 0 |
+| 3 | [given-group-crd-exists](#step-given-group-crd-exists) | 0 | 2 | 0 | 0 | 0 |
+| 4 | [Apply Kyverno ClusterPolicy](#step-Apply Kyverno ClusterPolicy) | 0 | 2 | 0 | 0 | 0 |
+| 5 | [Create ai-konflux-user-support Group with multiple users](#step-Create ai-konflux-user-support Group with multiple users) | 0 | 1 | 0 | 0 | 0 |
+| 6 | [Verify initial ClusterRoleBinding](#step-Verify initial ClusterRoleBinding) | 0 | 1 | 0 | 0 | 0 |
+| 7 | [Update Group with fewer users](#step-Update Group with fewer users) | 0 | 1 | 0 | 0 | 0 |
+| 8 | [Assert ClusterRoleBinding is updated with fewer users](#step-Assert ClusterRoleBinding is updated with fewer users) | 0 | 1 | 0 | 0 | 0 |
+
+### Step: `given-kyverno-has-permission-on-resources`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `given-viewer-clusterrole-exists`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `given-group-crd-exists`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+| 2 | `assert` | 0 | 0 | *No description* |
+
+### Step: `Apply Kyverno ClusterPolicy`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+| 2 | `assert` | 0 | 0 | *No description* |
+
+### Step: `Create ai-konflux-user-support Group with multiple users`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `create` | 0 | 0 | *No description* |
+
+### Step: `Verify initial ClusterRoleBinding`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `assert` | 0 | 0 | *No description* |
+
+### Step: `Update Group with fewer users`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `Assert ClusterRoleBinding is updated with fewer users`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `assert` | 0 | 0 | *No description* |
+
+---
+
+# Test: `clusterrolebinding-with-empty-group`
+
+Tests that when the ai-konflux-user-support Group has no users,
+the ClusterRoleBinding is still created but with empty subjects.
+
+
+## Steps
+
+| # | Name | Bindings | Try | Catch | Finally | Cleanup |
+|:-:|---|:-:|:-:|:-:|:-:|:-:|
+| 1 | [given-kyverno-has-permission-on-resources](#step-given-kyverno-has-permission-on-resources) | 0 | 1 | 0 | 0 | 0 |
+| 2 | [given-viewer-clusterrole-exists](#step-given-viewer-clusterrole-exists) | 0 | 1 | 0 | 0 | 0 |
+| 3 | [given-group-crd-exists](#step-given-group-crd-exists) | 0 | 2 | 0 | 0 | 0 |
+| 4 | [Apply Kyverno ClusterPolicy](#step-Apply Kyverno ClusterPolicy) | 0 | 2 | 0 | 0 | 0 |
+| 5 | [Create ai-konflux-user-support Group with no users](#step-Create ai-konflux-user-support Group with no users) | 0 | 1 | 0 | 0 | 0 |
+| 6 | [Assert ClusterRoleBinding exists with correct metadata](#step-Assert ClusterRoleBinding exists with correct metadata) | 0 | 1 | 0 | 0 | 0 |
+
+### Step: `given-kyverno-has-permission-on-resources`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `given-viewer-clusterrole-exists`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `given-group-crd-exists`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+| 2 | `assert` | 0 | 0 | *No description* |
+
+### Step: `Apply Kyverno ClusterPolicy`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+| 2 | `assert` | 0 | 0 | *No description* |
+
+### Step: `Create ai-konflux-user-support Group with no users`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `create` | 0 | 0 | *No description* |
+
+### Step: `Assert ClusterRoleBinding exists with correct metadata`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `assert` | 0 | 0 | *No description* |
+
+---
+

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/konflux-support-access/.chainsaw-test/chainsaw-assert-clusterpolicy.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/konflux-support-access/.chainsaw-test/chainsaw-assert-clusterpolicy.yaml
@@ -1,0 +1,9 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: generate-konflux-viewer-access
+status:
+  conditions:
+  - reason: Succeeded
+    status: "True"
+    type: Ready

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/konflux-support-access/.chainsaw-test/chainsaw-test.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/konflux-support-access/.chainsaw-test/chainsaw-test.yaml
@@ -1,0 +1,564 @@
+---
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: verify-clusterpolicy-is-ready
+spec:
+  concurrent: false
+  description: |
+    Tests that the ClusterPolicy for generating konflux-support-ai-konflux-user-support
+    ClusterRoleBinding is applied successfully and becomes Ready.
+  steps:
+    - name: given-kyverno-has-permission-on-resources
+      try:
+        - apply:
+            file: ../kyverno-admission-cluster-role.yaml
+        - apply:
+            file: ../kyverno-background-crb.yaml
+    - name: given-viewer-clusterrole-exists
+      try:
+        - apply:
+            resource:
+              apiVersion: rbac.authorization.k8s.io/v1
+              kind: ClusterRole
+              metadata:
+                name: konflux-viewer-user-actions
+              rules: []
+    - name: given-group-crd-exists
+      try:
+        - apply:
+            file: resources/group-crd.yaml
+        - assert:
+            resource:
+              apiVersion: apiextensions.k8s.io/v1
+              kind: CustomResourceDefinition
+              metadata:
+                name: groups.user.openshift.io
+              status:
+                conditions:
+                - type: NamesAccepted
+                  status: "True"
+                - type: Established
+                  status: "True"
+    - name: Apply Kyverno ClusterPolicy and assert it exists
+      try:
+        - apply:
+            file: ../generate-support-clusterrolebinding-cp.yaml
+        - assert:
+            file: chainsaw-assert-clusterpolicy.yaml
+---
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: clusterrolebinding-created-with-users
+spec:
+  concurrent: false
+  description: |
+    Tests that when an ai-konflux-user-support and konflux-sre Groups
+    are created with users, a ClusterRoleBinding for each group is generated.
+    The ClusterRoleBindings have Group's User subjects, the correct label,
+    and they reference the konflux-viewer-user-actions ClusterRole.
+  steps:
+    - name: given-kyverno-has-permission-on-resources
+      try:
+        - apply:
+            file: ../kyverno-admission-cluster-role.yaml
+        - apply:
+            file: ../kyverno-background-crb.yaml
+    - name: given-viewer-clusterrole-exists
+      try:
+        - apply:
+            resource:
+              apiVersion: rbac.authorization.k8s.io/v1
+              kind: ClusterRole
+              metadata:
+                name: konflux-viewer-user-actions
+              rules: []
+    - name: given-group-crd-exists
+      try:
+        - apply:
+            file: resources/group-crd.yaml
+        - assert:
+            resource:
+              apiVersion: apiextensions.k8s.io/v1
+              kind: CustomResourceDefinition
+              metadata:
+                name: groups.user.openshift.io
+              status:
+                conditions:
+                - type: NamesAccepted
+                  status: "True"
+                - type: Established
+                  status: "True"
+    - name: Apply Kyverno ClusterPolicy
+      try:
+        - apply:
+            file: ../generate-support-clusterrolebinding-cp.yaml
+        - assert:
+            file: chainsaw-assert-clusterpolicy.yaml
+    - name: Create ai-konflux-user-support Group with users
+      try:
+        - create:
+            file: ./resources/group-with-users-ai-konflux-user-support.yaml
+    - name: Assert ai-konflux-user-support's support ClusterRoleBinding is created correctly
+      try:
+        - assert:
+            resource:
+              apiVersion: rbac.authorization.k8s.io/v1
+              kind: ClusterRoleBinding
+              metadata:
+                name: konflux-support-ai-konflux-user-support
+                labels:
+                  namespace-lister.konflux-ci.dev/use-for-access: 'true'
+              roleRef:
+                apiGroup: rbac.authorization.k8s.io
+                kind: ClusterRole
+                name: konflux-viewer-user-actions
+              subjects:
+                - apiGroup: rbac.authorization.k8s.io
+                  kind: User
+                  name: alice
+                - apiGroup: rbac.authorization.k8s.io
+                  kind: User
+                  name: bob
+                - apiGroup: rbac.authorization.k8s.io
+                  kind: User
+                  name: charlie
+    - name: Create konflux-sre Group with users
+      try:
+        - create:
+            file: ./resources/group-with-users-konflux-sre.yaml
+    - name: Assert konflux-sre's support ClusterRoleBinding is created correctly
+      try:
+        - assert:
+            resource:
+              apiVersion: rbac.authorization.k8s.io/v1
+              kind: ClusterRoleBinding
+              metadata:
+                name: konflux-support-konflux-sre
+                labels:
+                  namespace-lister.konflux-ci.dev/use-for-access: 'true'
+              roleRef:
+                apiGroup: rbac.authorization.k8s.io
+                kind: ClusterRole
+                name: konflux-viewer-user-actions
+              subjects:
+                - apiGroup: rbac.authorization.k8s.io
+                  kind: User
+                  name: dan
+                - apiGroup: rbac.authorization.k8s.io
+                  kind: User
+                  name: frank
+                - apiGroup: rbac.authorization.k8s.io
+                  kind: User
+                  name: john
+---
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: clusterrolebinding-updated-when-users-added
+spec:
+  concurrent: false
+  description: |
+    Tests that when users are added to the ai-konflux-user-support Group,
+    the ClusterRoleBinding subjects are updated to include the new users.
+  steps:
+    - name: given-kyverno-has-permission-on-resources
+      try:
+        - apply:
+            file: ../kyverno-admission-cluster-role.yaml
+        - apply:
+            file: ../kyverno-background-crb.yaml
+    - name: given-viewer-clusterrole-exists
+      try:
+        - apply:
+            resource:
+              apiVersion: rbac.authorization.k8s.io/v1
+              kind: ClusterRole
+              metadata:
+                name: konflux-viewer-user-actions
+              rules: []
+    - name: given-group-crd-exists
+      try:
+        - apply:
+            file: resources/group-crd.yaml
+        - assert:
+            resource:
+              apiVersion: apiextensions.k8s.io/v1
+              kind: CustomResourceDefinition
+              metadata:
+                name: groups.user.openshift.io
+              status:
+                conditions:
+                - type: NamesAccepted
+                  status: "True"
+                - type: Established
+                  status: "True"
+    - name: Apply Kyverno ClusterPolicy
+      try:
+        - apply:
+            file: ../generate-support-clusterrolebinding-cp.yaml
+        - assert:
+            file: chainsaw-assert-clusterpolicy.yaml
+    - name: Create ai-konflux-user-support Group with initial users
+      try:
+        - create:
+            file: ./resources/group-with-users-ai-konflux-user-support.yaml
+    - name: Verify initial ClusterRoleBinding
+      try:
+        - assert:
+            resource:
+              apiVersion: rbac.authorization.k8s.io/v1
+              kind: ClusterRoleBinding
+              metadata:
+                name: konflux-support-ai-konflux-user-support
+    - name: Update Group with more users
+      try:
+        - apply:
+            file: ./resources/group-with-more-users.yaml
+    - name: Assert ClusterRoleBinding is updated with new users
+      try:
+        - assert:
+            resource:
+              apiVersion: rbac.authorization.k8s.io/v1
+              kind: ClusterRoleBinding
+              metadata:
+                name: konflux-support-ai-konflux-user-support
+                labels:
+                  namespace-lister.konflux-ci.dev/use-for-access: 'true'
+              roleRef:
+                apiGroup: rbac.authorization.k8s.io
+                kind: ClusterRole
+                name: konflux-viewer-user-actions
+              subjects:
+                - apiGroup: rbac.authorization.k8s.io
+                  kind: User
+                  name: alice
+                - apiGroup: rbac.authorization.k8s.io
+                  kind: User
+                  name: bob
+                - apiGroup: rbac.authorization.k8s.io
+                  kind: User
+                  name: charlie
+                - apiGroup: rbac.authorization.k8s.io
+                  kind: User
+                  name: david
+                - apiGroup: rbac.authorization.k8s.io
+                  kind: User
+                  name: eve
+---
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: clusterrolebinding-updated-when-users-removed
+spec:
+  concurrent: false
+  description: |
+    Tests that when users are removed from the ai-konflux-user-support Group,
+    the ClusterRoleBinding subjects are updated to remove those users.
+  steps:
+    - name: given-kyverno-has-permission-on-resources
+      try:
+        - apply:
+            file: ../kyverno-admission-cluster-role.yaml
+        - apply:
+            file: ../kyverno-background-crb.yaml
+    - name: given-viewer-clusterrole-exists
+      try:
+        - apply:
+            resource:
+              apiVersion: rbac.authorization.k8s.io/v1
+              kind: ClusterRole
+              metadata:
+                name: konflux-viewer-user-actions
+              rules: []
+    - name: given-group-crd-exists
+      try:
+        - apply:
+            file: resources/group-crd.yaml
+        - assert:
+            resource:
+              apiVersion: apiextensions.k8s.io/v1
+              kind: CustomResourceDefinition
+              metadata:
+                name: groups.user.openshift.io
+              status:
+                conditions:
+                - type: NamesAccepted
+                  status: "True"
+                - type: Established
+                  status: "True"
+    - name: Apply Kyverno ClusterPolicy
+      try:
+        - apply:
+            file: ../generate-support-clusterrolebinding-cp.yaml
+        - assert:
+            file: chainsaw-assert-clusterpolicy.yaml
+    - name: Create ai-konflux-user-support Group with multiple users
+      try:
+        - create:
+            file: ./resources/group-with-users-ai-konflux-user-support.yaml
+    - name: Verify initial ClusterRoleBinding
+      try:
+        - assert:
+            resource:
+              apiVersion: rbac.authorization.k8s.io/v1
+              kind: ClusterRoleBinding
+              metadata:
+                name: konflux-support-ai-konflux-user-support
+    - name: Update Group with fewer users
+      try:
+        - apply:
+            file: ./resources/group-with-fewer-users.yaml
+    - name: Assert ClusterRoleBinding is updated with fewer users
+      try:
+        - assert:
+            resource:
+              apiVersion: rbac.authorization.k8s.io/v1
+              kind: ClusterRoleBinding
+              metadata:
+                name: konflux-support-ai-konflux-user-support
+                labels:
+                  namespace-lister.konflux-ci.dev/use-for-access: 'true'
+              roleRef:
+                apiGroup: rbac.authorization.k8s.io
+                kind: ClusterRole
+                name: konflux-viewer-user-actions
+              subjects:
+                - apiGroup: rbac.authorization.k8s.io
+                  kind: User
+                  name: alice
+---
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: clusterrolebinding-with-empty-group
+spec:
+  concurrent: false
+  description: |
+    Tests that when the ai-konflux-user-support Group has no users,
+    the ClusterRoleBinding is still created but with empty subjects.
+  steps:
+    - name: given-kyverno-has-permission-on-resources
+      try:
+        - apply:
+            file: ../kyverno-admission-cluster-role.yaml
+        - apply:
+            file: ../kyverno-background-crb.yaml
+    - name: given-viewer-clusterrole-exists
+      try:
+        - apply:
+            resource:
+              apiVersion: rbac.authorization.k8s.io/v1
+              kind: ClusterRole
+              metadata:
+                name: konflux-viewer-user-actions
+              rules: []
+    - name: given-group-crd-exists
+      try:
+        - apply:
+            file: resources/group-crd.yaml
+        - assert:
+            resource:
+              apiVersion: apiextensions.k8s.io/v1
+              kind: CustomResourceDefinition
+              metadata:
+                name: groups.user.openshift.io
+              status:
+                conditions:
+                - type: NamesAccepted
+                  status: "True"
+                - type: Established
+                  status: "True"
+    - name: Apply Kyverno ClusterPolicy
+      try:
+        - apply:
+            file: ../generate-support-clusterrolebinding-cp.yaml
+        - assert:
+            file: chainsaw-assert-clusterpolicy.yaml
+    - name: Create ai-konflux-user-support Group with no users
+      try:
+        - create:
+            file: ./resources/group-empty.yaml
+    - name: Assert ClusterRoleBinding exists with correct metadata
+      try:
+        - assert:
+            resource:
+              apiVersion: rbac.authorization.k8s.io/v1
+              kind: ClusterRoleBinding
+              metadata:
+                name: konflux-support-ai-konflux-user-support
+                labels:
+                  namespace-lister.konflux-ci.dev/use-for-access: 'true'
+              roleRef:
+                apiGroup: rbac.authorization.k8s.io
+                kind: ClusterRole
+                name: konflux-viewer-user-actions
+---
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: orphan-generated-resources
+spec:
+  concurrent: false
+  description: |
+    Tests that removal of the cluster policy doesn't delete the generated cluster role bindings
+  steps:
+    - name: given-kyverno-has-permission-on-resources
+      try:
+        - apply:
+            file: ../kyverno-admission-cluster-role.yaml
+        - apply:
+            file: ../kyverno-background-crb.yaml
+    - name: given-viewer-clusterrole-exists
+      try:
+        - apply:
+            resource:
+              apiVersion: rbac.authorization.k8s.io/v1
+              kind: ClusterRole
+              metadata:
+                name: konflux-viewer-user-actions
+              rules: []
+    - name: given-group-crd-exists
+      try:
+        - apply:
+            file: resources/group-crd.yaml
+        - assert:
+            resource:
+              apiVersion: apiextensions.k8s.io/v1
+              kind: CustomResourceDefinition
+              metadata:
+                name: groups.user.openshift.io
+              status:
+                conditions:
+                - type: NamesAccepted
+                  status: "True"
+                - type: Established
+                  status: "True"
+    - name: Apply Kyverno ClusterPolicy
+      try:
+        - apply:
+            file: ../generate-support-clusterrolebinding-cp.yaml
+        - assert:
+            file: chainsaw-assert-clusterpolicy.yaml
+    - name: Create ai-konflux-user-support Group with users
+      try:
+        - create:
+            file: ./resources/group-with-users-ai-konflux-user-support.yaml
+    - name: Assert ai-konflux-user-support's support ClusterRoleBinding is created correctly
+      try:
+        - assert:
+            resource:
+              apiVersion: rbac.authorization.k8s.io/v1
+              kind: ClusterRoleBinding
+              metadata:
+                name: konflux-support-ai-konflux-user-support
+                labels:
+                  namespace-lister.konflux-ci.dev/use-for-access: 'true'
+              roleRef:
+                apiGroup: rbac.authorization.k8s.io
+                kind: ClusterRole
+                name: konflux-viewer-user-actions
+              subjects:
+                - apiGroup: rbac.authorization.k8s.io
+                  kind: User
+                  name: alice
+                - apiGroup: rbac.authorization.k8s.io
+                  kind: User
+                  name: bob
+                - apiGroup: rbac.authorization.k8s.io
+                  kind: User
+                  name: charlie
+    - name: Create konflux-sre Group with users
+      try:
+        - create:
+            file: ./resources/group-with-users-konflux-sre.yaml
+    - name: Assert konflux-sre's support ClusterRoleBinding is created correctly
+      try:
+        - assert:
+            resource:
+              apiVersion: rbac.authorization.k8s.io/v1
+              kind: ClusterRoleBinding
+              metadata:
+                name: konflux-support-konflux-sre
+                labels:
+                  namespace-lister.konflux-ci.dev/use-for-access: 'true'
+              roleRef:
+                apiGroup: rbac.authorization.k8s.io
+                kind: ClusterRole
+                name: konflux-viewer-user-actions
+              subjects:
+                - apiGroup: rbac.authorization.k8s.io
+                  kind: User
+                  name: dan
+                - apiGroup: rbac.authorization.k8s.io
+                  kind: User
+                  name: frank
+                - apiGroup: rbac.authorization.k8s.io
+                  kind: User
+                  name: john
+    - name: Delete the cluster policy
+      try:
+        - delete:
+            file: ../generate-support-clusterrolebinding-cp.yaml
+        - wait:
+            apiVersion: kyverno.io/v1
+            kind: ClusterPolicy
+            name: generate-konflux-viewer-access
+            for:
+              deletion: {}
+        - script:
+            content: |
+              while true; do
+                if [ "$(kubectl get updaterequests -n konflux-kyverno -o yaml | yq '.items | length')" -eq 0 ]; then
+                  exit 0
+                fi
+                sleep 1
+              done
+            timeout: 30s
+    - name: Assert the cluster role bindings still exist
+      try:
+        - assert:
+            resource:
+              apiVersion: rbac.authorization.k8s.io/v1
+              kind: ClusterRoleBinding
+              metadata:
+                name: konflux-support-ai-konflux-user-support
+                labels:
+                  namespace-lister.konflux-ci.dev/use-for-access: 'true'
+              roleRef:
+                apiGroup: rbac.authorization.k8s.io
+                kind: ClusterRole
+                name: konflux-viewer-user-actions
+              subjects:
+                - apiGroup: rbac.authorization.k8s.io
+                  kind: User
+                  name: alice
+                - apiGroup: rbac.authorization.k8s.io
+                  kind: User
+                  name: bob
+                - apiGroup: rbac.authorization.k8s.io
+                  kind: User
+                  name: charlie
+        - assert:
+            resource:
+              apiVersion: rbac.authorization.k8s.io/v1
+              kind: ClusterRoleBinding
+              metadata:
+                name: konflux-support-konflux-sre
+                labels:
+                  namespace-lister.konflux-ci.dev/use-for-access: 'true'
+              roleRef:
+                apiGroup: rbac.authorization.k8s.io
+                kind: ClusterRole
+                name: konflux-viewer-user-actions
+              subjects:
+                - apiGroup: rbac.authorization.k8s.io
+                  kind: User
+                  name: dan
+                - apiGroup: rbac.authorization.k8s.io
+                  kind: User
+                  name: frank
+                - apiGroup: rbac.authorization.k8s.io
+                  kind: User
+                  name: john

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/konflux-support-access/.chainsaw-test/resources/group-crd.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/konflux-support-access/.chainsaw-test/resources/group-crd.yaml
@@ -1,0 +1,26 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: groups.user.openshift.io
+spec:
+  group: user.openshift.io
+  names:
+    kind: Group
+    listKind: GroupList
+    plural: groups
+    singular: group
+  scope: Cluster
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        required:
+        - users
+        properties:
+          users:
+            type: array
+            items:
+              type: string

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/konflux-support-access/.chainsaw-test/resources/group-empty.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/konflux-support-access/.chainsaw-test/resources/group-empty.yaml
@@ -1,0 +1,5 @@
+apiVersion: user.openshift.io/v1
+kind: Group
+metadata:
+  name: ai-konflux-user-support
+users: []

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/konflux-support-access/.chainsaw-test/resources/group-with-fewer-users.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/konflux-support-access/.chainsaw-test/resources/group-with-fewer-users.yaml
@@ -1,0 +1,6 @@
+apiVersion: user.openshift.io/v1
+kind: Group
+metadata:
+  name: ai-konflux-user-support
+users:
+  - alice

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/konflux-support-access/.chainsaw-test/resources/group-with-more-users.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/konflux-support-access/.chainsaw-test/resources/group-with-more-users.yaml
@@ -1,0 +1,10 @@
+apiVersion: user.openshift.io/v1
+kind: Group
+metadata:
+  name: ai-konflux-user-support
+users:
+  - alice
+  - bob
+  - charlie
+  - david
+  - eve

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/konflux-support-access/.chainsaw-test/resources/group-with-users-ai-konflux-user-support.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/konflux-support-access/.chainsaw-test/resources/group-with-users-ai-konflux-user-support.yaml
@@ -1,0 +1,8 @@
+apiVersion: user.openshift.io/v1
+kind: Group
+metadata:
+  name: ai-konflux-user-support
+users:
+  - alice
+  - bob
+  - charlie

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/konflux-support-access/.chainsaw-test/resources/group-with-users-konflux-sre.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/konflux-support-access/.chainsaw-test/resources/group-with-users-konflux-sre.yaml
@@ -1,0 +1,8 @@
+apiVersion: user.openshift.io/v1
+kind: Group
+metadata:
+  name: konflux-sre
+users:
+  - dan
+  - frank
+  - john

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/konflux-support-access/generate-support-clusterrolebinding-cp.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/konflux-support-access/generate-support-clusterrolebinding-cp.yaml
@@ -1,0 +1,57 @@
+---
+# This ClusterPolicy automatically generates a ClusterRoleBinding for users
+# in the groups supporting Konflux to enable namespace-lister access.
+#
+# The namespace-lister service checks for ClusterRoleBindings with the label
+# 'namespace-lister.konflux-ci.dev/use-for-access: true' and grants access
+# to tenant namespaces based on individual User subjects in those bindings.
+
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: generate-konflux-viewer-access
+  annotations:
+    policies.kyverno.io/title: "Generate ClusterRoleBinding for ai-konflux-user-support Group Users"
+    policies.kyverno.io/category: Multi-Tenancy
+    policies.kyverno.io/description: >-
+      This policy automatically generates a ClusterRoleBinding for all users
+      in the groups that support Konflux. The ClusterRoleBinding includes the
+      label 'namespace-lister.konflux-ci.dev/use-for-access: true' which
+      enables namespace-lister to grant these users access to tenant namespaces.
+      The binding is synchronized with the Group, so any changes to group
+      membership are automatically reflected in the ClusterRoleBinding.
+spec:
+  background: true
+  rules:
+    - name: generate-nslister-clusterrolebinding
+      skipBackgroundRequests: true
+      match:
+        any:
+        - resources:
+            kinds:
+            - user.openshift.io/v1/Group
+            names:
+            - ai-konflux-user-support
+            - konflux-sre
+            - plm-poe
+            - konflux-prodsec-support
+      context:
+        - name: userSubjects
+          variable:
+            jmesPath: "request.object.users[] | [].{kind: 'User', apiGroup: 'rbac.authorization.k8s.io', name: @}"
+      generate:
+        generateExisting: true
+        orphanDownstreamOnPolicyDelete: true
+        synchronize: true
+        apiVersion: rbac.authorization.k8s.io/v1
+        kind: ClusterRoleBinding
+        name: "konflux-support-{{request.object.metadata.name}}"
+        data:
+          metadata:
+            labels:
+              namespace-lister.konflux-ci.dev/use-for-access: 'true'
+          subjects: "{{ userSubjects }}"
+          roleRef:
+            kind: ClusterRole
+            name: konflux-viewer-user-actions
+            apiGroup: rbac.authorization.k8s.io

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/konflux-support-access/kustomization.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/konflux-support-access/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namePrefix: konflux-rbac-
+resources:
+- generate-support-clusterrolebinding-cp.yaml
+- kyverno-background-crb.yaml
+- kyverno-admission-cluster-role.yaml

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/konflux-support-access/kyverno-admission-cluster-role.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/konflux-support-access/kyverno-admission-cluster-role.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kyverno-admission:read-groups-support
+  labels:
+    rbac.kyverno.io/aggregate-to-admission-controller: "true"
+rules:
+- apiGroups:
+  - user.openshift.io
+  resources:
+  - groups
+  verbs:
+  - get
+  - list
+  - watch

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/konflux-support-access/kyverno-background-crb.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/konflux-support-access/kyverno-background-crb.yaml
@@ -1,0 +1,44 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kyverno-background:manage-support-crb
+  labels:
+    rbac.kyverno.io/aggregate-to-background-controller: "true"
+rules:
+- apiGroups:
+  - user.openshift.io
+  resources:
+  - groups
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterrolebindings
+  verbs:
+  - create
+  - get
+  - list
+  - delete
+  - update
+  - patch
+---
+# To allow kyverno to create the ClusterRoleBinding,
+# the kyverno-background-controller's ServiceAccount
+# needs to have the same permissions it wants to assign
+# to someone else (the 'konflux-viewer-user-actions' ClusterRole)
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kyverno-background:konflux-viewer-user-actions-support
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: konflux-viewer-user-actions
+subjects:
+- kind: ServiceAccount
+  namespace: konflux-kyverno
+  name: kyverno-background-controller

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/kustomization.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- deny-serviceaccount-token-secrets
+- bootstrap-tenant-namespace
+- konflux-support-access
+- limit-pod-serviceaccount-token-expiration
+- limit-serviceaccount-token-expiration
+- restrict-binding-serviceaccounts
+- restrict-binding-system-authenticated-releng
+- validate-rolebindings

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/limit-pod-serviceaccount-token-expiration/.chainsaw-test/chainsaw-assert-policy.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/limit-pod-serviceaccount-token-expiration/.chainsaw-test/chainsaw-assert-policy.yaml
@@ -1,0 +1,7 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: limit-pod-serviceaccount-token-expiration.konflux-ci.dev
+status:
+  observedGeneration: 1
+  typeChecking: {}

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/limit-pod-serviceaccount-token-expiration/.chainsaw-test/resources/pod_projected_token_invalid_long.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/limit-pod-serviceaccount-token-expiration/.chainsaw-test/resources/pod_projected_token_invalid_long.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: chainsaw-pod-projected-long
+spec:
+  restartPolicy: Never
+  serviceAccountName: chainsaw-test-sa
+  securityContext:
+    runAsNonRoot: true
+  containers:
+  - name: c
+    image: registry.access.redhat.com/ubi10-micro:10.1
+    command: ["sh", "-c", "exit 0"]
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop: ["ALL"]
+    volumeMounts:
+    - name: tok
+      mountPath: /var/run/secrets/tokens
+  volumes:
+  - name: tok
+    projected:
+      sources:
+      - serviceAccountToken:
+          path: token
+          expirationSeconds: 31536001
+          audience: https://kubernetes.default.svc

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/limit-pod-serviceaccount-token-expiration/.chainsaw-test/resources/pod_projected_token_valid_omit.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/limit-pod-serviceaccount-token-expiration/.chainsaw-test/resources/pod_projected_token_valid_omit.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: chainsaw-pod-projected-omit
+spec:
+  restartPolicy: Never
+  serviceAccountName: chainsaw-test-sa
+  securityContext:
+    runAsNonRoot: true
+  containers:
+  - name: c
+    image: registry.access.redhat.com/ubi10-micro:10.1
+    command: ["sh", "-c", "exit 0"]
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop: ["ALL"]
+    volumeMounts:
+    - name: tok
+      mountPath: /var/run/secrets/tokens
+  volumes:
+  - name: tok
+    projected:
+      sources:
+      - serviceAccountToken:
+          path: token
+          audience: https://kubernetes.default.svc

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/limit-pod-serviceaccount-token-expiration/.chainsaw-test/resources/pod_projected_token_valid_short.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/limit-pod-serviceaccount-token-expiration/.chainsaw-test/resources/pod_projected_token_valid_short.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: chainsaw-pod-projected-short
+spec:
+  restartPolicy: Never
+  serviceAccountName: chainsaw-test-sa
+  securityContext:
+    runAsNonRoot: true
+  containers:
+  - name: c
+    image: registry.access.redhat.com/ubi10-micro:10.1
+    command: ["sh", "-c", "exit 0"]
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop: ["ALL"]
+    volumeMounts:
+    - name: tok
+      mountPath: /var/run/secrets/tokens
+  volumes:
+  - name: tok
+    projected:
+      sources:
+      - serviceAccountToken:
+          path: token
+          expirationSeconds: 3600
+          audience: https://kubernetes.default.svc

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/limit-pod-serviceaccount-token-expiration/.chainsaw-test/resources/serviceaccount.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/limit-pod-serviceaccount-token-expiration/.chainsaw-test/resources/serviceaccount.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: chainsaw-test-sa

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/limit-pod-serviceaccount-token-expiration/.chainsaw-test/test-in-tenant/chainsaw-test.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/limit-pod-serviceaccount-token-expiration/.chainsaw-test/test-in-tenant/chainsaw-test.yaml
@@ -1,0 +1,86 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: in-tenant-allows-valid-projected-sa-token-pods
+spec:
+  description: |
+    In a tenant namespace, Pods with projected serviceAccountToken expiration at or under
+    the limit (or omitting expirationSeconds) are admitted by the pod-only VAP.
+  concurrent: false
+  steps:
+  - name: ensure-namespace-is-labeled
+    try:
+    - apply:
+        resource:
+          apiVersion: v1
+          kind: Namespace
+          metadata:
+            name: ($namespace)
+            labels:
+              konflux-ci.dev/type: tenant
+  - name: given-pod-validatingadmissionpolicy-is-installed
+    try:
+    - apply:
+        file: ../../limit-pod-serviceaccount-token-expiration-validationadmissionpolicy.yaml
+    - apply:
+        file: ../../limit-pod-serviceaccount-token-expiration-validationadmissionpolicybinding.yaml
+    - assert:
+        file: ../chainsaw-assert-policy.yaml
+    - sleep:
+        # add a delay to make sure the APIServer successfully loaded the VAP
+        # so to reduce test flakiness
+        duration: 2s
+  - name: given-serviceaccount-exists
+    try:
+    - apply:
+        file: ../resources/serviceaccount.yaml
+  - name: then-valid-projected-token-pods-are-allowed
+    try:
+    - create:
+        file: ../resources/pod_projected_token_valid_short.yaml
+    - create:
+        file: ../resources/pod_projected_token_valid_omit.yaml
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: in-tenant-denies-long-projected-serviceaccount-token
+spec:
+  description: |
+    In a tenant namespace, a Pod requesting projected serviceAccountToken expirationSeconds
+    above the policy maximum is denied by the pod-only VAP.
+  concurrent: false
+  steps:
+  - name: ensure-namespace-is-labeled
+    try:
+    - apply:
+        resource:
+          apiVersion: v1
+          kind: Namespace
+          metadata:
+            name: ($namespace)
+            labels:
+              konflux-ci.dev/type: tenant
+  - name: given-pod-validatingadmissionpolicy-is-installed
+    try:
+    - apply:
+        file: ../../limit-pod-serviceaccount-token-expiration-validationadmissionpolicy.yaml
+    - apply:
+        file: ../../limit-pod-serviceaccount-token-expiration-validationadmissionpolicybinding.yaml
+    - assert:
+        file: ../chainsaw-assert-policy.yaml
+    - sleep:
+        # add a delay to make sure the APIServer successfully loaded the VAP
+        # so to reduce test flakiness
+        duration: 2s
+  - name: given-serviceaccount-exists
+    try:
+    - apply:
+        file: ../resources/serviceaccount.yaml
+  - name: then-long-projected-token-pod-is-denied
+    try:
+    - error:
+        file: ../resources/pod_projected_token_invalid_long.yaml

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/limit-pod-serviceaccount-token-expiration/.chainsaw-test/test-outside-tenant/chainsaw-test.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/limit-pod-serviceaccount-token-expiration/.chainsaw-test/test-outside-tenant/chainsaw-test.yaml
@@ -1,0 +1,32 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: outside-tenant-allows-long-projected-token
+spec:
+  description: |
+    In a namespace without the tenant label, a Pod with a long projected serviceAccountToken
+    expiration is allowed because the policy binding does not match.
+  concurrent: false
+  steps:
+  - name: given-pod-validatingadmissionpolicy-is-installed
+    try:
+    - apply:
+        file: ../../limit-pod-serviceaccount-token-expiration-validationadmissionpolicy.yaml
+    - apply:
+        file: ../../limit-pod-serviceaccount-token-expiration-validationadmissionpolicybinding.yaml
+    - assert:
+        file: ../chainsaw-assert-policy.yaml
+    - sleep:
+        # add a delay to make sure the APIServer successfully loaded the VAP
+        # so to reduce test flakiness
+        duration: 2s
+  - name: given-serviceaccount-exists
+    try:
+    - apply:
+        file: ../resources/serviceaccount.yaml
+  - name: then-long-projected-token-pod-is-allowed
+    try:
+    - create:
+        file: ../resources/pod_projected_token_invalid_long.yaml

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/limit-pod-serviceaccount-token-expiration/kustomization.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/limit-pod-serviceaccount-token-expiration/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- limit-pod-serviceaccount-token-expiration-validationadmissionpolicy.yaml
+- limit-pod-serviceaccount-token-expiration-validationadmissionpolicybinding.yaml

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/limit-pod-serviceaccount-token-expiration/limit-pod-serviceaccount-token-expiration-validationadmissionpolicy.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/limit-pod-serviceaccount-token-expiration/limit-pod-serviceaccount-token-expiration-validationadmissionpolicy.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: limit-pod-serviceaccount-token-expiration.konflux-ci.dev
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+    - apiGroups: [""]
+      apiVersions: ["v1"]
+      operations: ["CREATE", "UPDATE"]
+      resources: ["pods"]
+      scope: "Namespaced"
+  variables:
+  - name: maxExpirationSeconds
+    expression: "31536000"
+  validations:
+  - expression: |
+      !has(object.spec.volumes) ||
+      object.spec.volumes.all(v,
+        !has(v.projected) ||
+        !has(v.projected.sources) ||
+        v.projected.sources.all(s,
+          !has(s.serviceAccountToken) ||
+          !has(s.serviceAccountToken.expirationSeconds) ||
+          s.serviceAccountToken.expirationSeconds <= variables.maxExpirationSeconds))
+    reason: Invalid
+    message: >
+      Projected serviceAccountToken expirationSeconds may not exceed 31536000 seconds (1 year)
+      in tenant namespaces. Omit the field to use the kubelet default, or choose a shorter lifetime.

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/limit-pod-serviceaccount-token-expiration/limit-pod-serviceaccount-token-expiration-validationadmissionpolicybinding.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/limit-pod-serviceaccount-token-expiration/limit-pod-serviceaccount-token-expiration-validationadmissionpolicybinding.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: limit-pod-serviceaccount-token-expiration.konflux-ci.dev
+spec:
+  policyName: limit-pod-serviceaccount-token-expiration.konflux-ci.dev
+  validationActions: [Deny]
+  matchResources:
+    namespaceSelector:
+      matchLabels:
+        konflux-ci.dev/type: tenant

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/limit-serviceaccount-token-expiration/.chainsaw-test/chainsaw-assert-policy.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/limit-serviceaccount-token-expiration/.chainsaw-test/chainsaw-assert-policy.yaml
@@ -1,0 +1,7 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: limit-serviceaccount-tokenrequest-expiration.konflux-ci.dev
+status:
+  observedGeneration: 1
+  typeChecking: {}

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/limit-serviceaccount-token-expiration/.chainsaw-test/resources/serviceaccount.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/limit-serviceaccount-token-expiration/.chainsaw-test/resources/serviceaccount.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: chainsaw-test-sa

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/limit-serviceaccount-token-expiration/.chainsaw-test/test-in-tenant/chainsaw-test.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/limit-serviceaccount-token-expiration/.chainsaw-test/test-in-tenant/chainsaw-test.yaml
@@ -1,0 +1,96 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: in-tenant-allows-short-kubectl-create-token
+spec:
+  description: |
+    In a tenant namespace, kubectl create token with a duration at or under the limit succeeds
+    under the TokenRequest VAP.
+  concurrent: false
+  steps:
+  - name: ensure-namespace-is-labeled
+    try:
+    - apply:
+        resource:
+          apiVersion: v1
+          kind: Namespace
+          metadata:
+            name: ($namespace)
+            labels:
+              konflux-ci.dev/type: tenant
+  - name: given-tokenrequest-validatingadmissionpolicy-is-installed
+    try:
+    - apply:
+        file: ../../limit-serviceaccount-tokenrequest-expiration-validationadmissionpolicy.yaml
+    - apply:
+        file: ../../limit-serviceaccount-tokenrequest-expiration-validationadmissionpolicybinding.yaml
+    - assert:
+        file: ../chainsaw-assert-policy.yaml
+    - sleep:
+        # add a delay to make sure the APIServer successfully loaded the VAP
+        # so to reduce test flakiness
+        duration: 2s
+  - name: given-serviceaccount-exists
+    try:
+    - apply:
+        file: ../resources/serviceaccount.yaml
+  - name: then-short-duration-token-request-succeeds
+    try:
+    - script:
+        skipLogOutput: true
+        env:
+        - name: NAMESPACE
+          value: ($namespace)
+        content: kubectl create token chainsaw-test-sa -n ${NAMESPACE} --duration=3600s >/dev/null
+        check:
+          ($error): ~
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: in-tenant-denies-long-kubectl-create-token
+spec:
+  description: |
+    In a tenant namespace, kubectl create token with a duration above the policy maximum fails
+    under the TokenRequest VAP.
+  concurrent: false
+  steps:
+  - name: ensure-namespace-is-labeled
+    try:
+    - apply:
+        resource:
+          apiVersion: v1
+          kind: Namespace
+          metadata:
+            name: ($namespace)
+            labels:
+              konflux-ci.dev/type: tenant
+  - name: given-tokenrequest-validatingadmissionpolicy-is-installed
+    try:
+    - apply:
+        file: ../../limit-serviceaccount-tokenrequest-expiration-validationadmissionpolicy.yaml
+    - apply:
+        file: ../../limit-serviceaccount-tokenrequest-expiration-validationadmissionpolicybinding.yaml
+    - assert:
+        file: ../chainsaw-assert-policy.yaml
+    - sleep:
+        # add a delay to make sure the APIServer successfully loaded the VAP
+        # so to reduce test flakiness
+        duration: 2s
+  - name: given-serviceaccount-exists
+    try:
+    - apply:
+        file: ../resources/serviceaccount.yaml
+  - name: then-long-duration-token-request-is-denied
+    try:
+    - script:
+        skipLogOutput: false
+        env:
+        - name: NAMESPACE
+          value: ($namespace)
+        content: kubectl create token chainsaw-test-sa -n ${NAMESPACE} --duration=31536001s >/dev/null
+        check:
+          ($error != null): true

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/limit-serviceaccount-token-expiration/.chainsaw-test/test-outside-tenant/chainsaw-test.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/limit-serviceaccount-token-expiration/.chainsaw-test/test-outside-tenant/chainsaw-test.yaml
@@ -1,0 +1,38 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: outside-tenant-allows-long-kubectl-create-token
+spec:
+  description: |
+    In a namespace without the tenant label, kubectl create token with a long duration succeeds
+    because the policy binding does not match.
+  concurrent: false
+  steps:
+  - name: given-tokenrequest-validatingadmissionpolicy-is-installed
+    try:
+    - apply:
+        file: ../../limit-serviceaccount-tokenrequest-expiration-validationadmissionpolicy.yaml
+    - apply:
+        file: ../../limit-serviceaccount-tokenrequest-expiration-validationadmissionpolicybinding.yaml
+    - assert:
+        file: ../chainsaw-assert-policy.yaml
+    - sleep:
+        # add a delay to make sure the APIServer successfully loaded the VAP
+        # so to reduce test flakiness
+        duration: 2s
+  - name: given-serviceaccount-exists
+    try:
+    - apply:
+        file: ../resources/serviceaccount.yaml
+  - name: then-long-duration-token-request-succeeds
+    try:
+    - script:
+        skipLogOutput: true
+        env:
+        - name: NAMESPACE
+          value: ($namespace)
+        content: kubectl create token chainsaw-test-sa -n ${NAMESPACE} --duration=31536001s >/dev/null
+        check:
+          ($error): ~

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/limit-serviceaccount-token-expiration/kustomization.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/limit-serviceaccount-token-expiration/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- limit-serviceaccount-tokenrequest-expiration-validationadmissionpolicy.yaml
+- limit-serviceaccount-tokenrequest-expiration-validationadmissionpolicybinding.yaml

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/limit-serviceaccount-token-expiration/limit-serviceaccount-tokenrequest-expiration-validationadmissionpolicy.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/limit-serviceaccount-token-expiration/limit-serviceaccount-tokenrequest-expiration-validationadmissionpolicy.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: limit-serviceaccount-tokenrequest-expiration.konflux-ci.dev
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+    - apiGroups: [""]
+      apiVersions: ["v1"]
+      operations: ["CREATE"]
+      resources: ["serviceaccounts/token"]
+      scope: "Namespaced"
+  variables:
+  - name: maxExpirationSeconds
+    expression: "31536000"
+  validations:
+  - expression: |
+      !has(object.spec.expirationSeconds) ||
+      object.spec.expirationSeconds <= variables.maxExpirationSeconds
+    reason: Invalid
+    messageExpression: |
+      "Requested service account token expirationSeconds may not exceed " +
+      string(variables.maxExpirationSeconds) +
+      " seconds (1 year). Omit the field to use the API default, or choose a shorter lifetime."

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/limit-serviceaccount-token-expiration/limit-serviceaccount-tokenrequest-expiration-validationadmissionpolicybinding.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/limit-serviceaccount-token-expiration/limit-serviceaccount-tokenrequest-expiration-validationadmissionpolicybinding.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: limit-serviceaccount-tokenrequest-expiration.konflux-ci.dev
+spec:
+  policyName: limit-serviceaccount-tokenrequest-expiration.konflux-ci.dev
+  validationActions: [Deny]
+  matchResources:
+    namespaceSelector:
+      matchLabels:
+        konflux-ci.dev/type: tenant

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/restrict-binding-serviceaccounts/create/.chainsaw-test/chainsaw-assert-validatingadmissionpolicy.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/restrict-binding-serviceaccounts/create/.chainsaw-test/chainsaw-assert-validatingadmissionpolicy.yaml
@@ -1,0 +1,7 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: restrict-bindings-serviceaccounts-create.konflux-ci.dev
+status:
+  observedGeneration: 1
+  typeChecking: {}

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/restrict-binding-serviceaccounts/create/.chainsaw-test/chainsaw-test.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/restrict-binding-serviceaccounts/create/.chainsaw-test/chainsaw-test.yaml
@@ -1,0 +1,239 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: in-tenant-invalid-rolebinding
+spec:
+  description: |
+    tests that the a invalid RoleBinding can NOT be created
+    in a tenant namespace
+  concurrent: false
+  namespace: 'invalid-serviceaccounts-rb-tenant-namespace'
+  steps:
+  - name: given-validatingadmissionpolicy-is-ready
+    try:
+    - apply:
+        file: ../restrict-binding-serviceaccounts-create-validatingadmissionpolicy.yaml
+    - apply:
+        file: ../restrict-binding-serviceaccounts-create-validatingadmissionpolicybinding.yaml
+    - sleep:
+        duration: 1s
+    - assert:
+        file: chainsaw-assert-validatingadmissionpolicy.yaml
+  - name: given-tenant-namespace-exists
+    try:
+    - apply:
+        file: ./resources/tenant-namespace.yaml
+  - name: then-invalid-rolebinding-can-not-be-created
+    try:
+    - create:
+        file: ./resources/invalid-serviceaccounts-rolebinding.yaml
+        expect:
+        - check:
+            ($error != null): true
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: in-tenant-delete-invalid-existing-rolebinding
+spec:
+  description: |
+    tests that the an existing invalid RoleBinding can be deleted
+    in a tenant namespace
+  concurrent: false
+  namespace: 'existing-invalid-serviceaccounts-rb-tenant-namespace'
+  steps:
+  - name: given-tenant-namespace-exists
+    try:
+    - apply:
+        file: ./resources/tenant-namespace.yaml
+  - name: given-invalid-rolebinding-exists
+    try:
+    - create:
+        file: ./resources/invalid-serviceaccounts-rolebinding.yaml
+  - name: when-validatingadmissionpolicy-is-ready
+    try:
+    - apply:
+        file: ../restrict-binding-serviceaccounts-create-validatingadmissionpolicy.yaml
+    - apply:
+        file: ../restrict-binding-serviceaccounts-create-validatingadmissionpolicybinding.yaml
+    - sleep:
+        duration: 1s
+    - assert:
+        file: chainsaw-assert-validatingadmissionpolicy.yaml
+  - name: then-invalid-rolebinding-can-be-deleted
+    try:
+    - delete:
+        file: ./resources/invalid-serviceaccounts-rolebinding.yaml
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: in-tenant-valid-rolebinding
+spec:
+  description: |
+    tests that the a valid RoleBinding can be created in a
+    tenant namespace
+  concurrent: false
+  namespace: 'valid-serviceaccounts-rb-tenant-namespace'
+  steps:
+  - name: given-validatingadmissionpolicy-is-ready
+    try:
+    - apply:
+        file: ../restrict-binding-serviceaccounts-create-validatingadmissionpolicy.yaml
+    - apply:
+        file: ../restrict-binding-serviceaccounts-create-validatingadmissionpolicybinding.yaml
+    - sleep:
+        duration: 1s
+    - assert:
+        file: chainsaw-assert-validatingadmissionpolicy.yaml
+  - name: given-tenant-namespace-exists
+    try:
+    - apply:
+        file: ./resources/tenant-namespace.yaml
+  - name: then-valid-rolebinding-can-be-created
+    try:
+    - apply:
+        file: ./resources/valid-serviceaccounts-rolebinding.yaml
+        expect:
+        - check:
+            ($error != null): false
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: out-of-tenant-rolebinding
+spec:
+  description: |
+    tests that the whatever RoleBinding can be created in a
+    non-tenant namespace
+  concurrent: false
+  namespace: 'valid-serviceaccounts-rb-namespace'
+  steps:
+  - name: given-validatingadmissionpolicy-is-ready
+    try:
+    - apply:
+        file: ../restrict-binding-serviceaccounts-create-validatingadmissionpolicy.yaml
+    - apply:
+        file: ../restrict-binding-serviceaccounts-create-validatingadmissionpolicybinding.yaml
+    - sleep:
+        duration: 1s
+    - assert:
+        file: chainsaw-assert-validatingadmissionpolicy.yaml
+  - name: then-rolebinding-can-be-created-in-a-nontenant-namespace
+    try:
+    - apply:
+        file: ./resources/valid-serviceaccounts-rolebinding.yaml
+        expect:
+        - check:
+            ($error != null): false
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: in-tenant-invalid-konflux-bot-role-rolebinding
+spec:
+  description: |
+    tests that a RoleBinding binding a konflux-bot- ServiceAccount to a
+    namespaced Role can NOT be created in a tenant namespace
+  concurrent: false
+  namespace: 'invalid-konflux-bot-role-rb-tenant-namespace'
+  steps:
+  - name: given-validatingadmissionpolicy-is-ready
+    try:
+    - apply:
+        file: ../restrict-binding-serviceaccounts-create-validatingadmissionpolicy.yaml
+    - apply:
+        file: ../restrict-binding-serviceaccounts-create-validatingadmissionpolicybinding.yaml
+    - sleep:
+        duration: 1s
+    - assert:
+        file: chainsaw-assert-validatingadmissionpolicy.yaml
+  - name: given-tenant-namespace-and-role-exist
+    try:
+    - apply:
+        file: ./resources/tenant-namespace.yaml
+    - apply:
+        file: ./resources/tenant-role.yaml
+  - name: then-invalid-konflux-bot-role-rolebinding-can-not-be-created
+    try:
+    - create:
+        file: ./resources/invalid-konflux-bot-role-rolebinding.yaml
+        expect:
+        - check:
+            ($error != null): true
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: in-tenant-valid-konflux-bot-allowed-clusterrole-rolebinding
+spec:
+  description: |
+    tests that a RoleBinding binding a konflux-bot- ServiceAccount to an
+    allowed ClusterRole can be created in a tenant namespace
+  concurrent: false
+  namespace: 'valid-konflux-bot-allowed-cr-rb-tenant-namespace'
+  steps:
+  - name: given-validatingadmissionpolicy-is-ready
+    try:
+    - apply:
+        file: ../restrict-binding-serviceaccounts-create-validatingadmissionpolicy.yaml
+    - apply:
+        file: ../restrict-binding-serviceaccounts-create-validatingadmissionpolicybinding.yaml
+    - sleep:
+        duration: 1s
+    - assert:
+        file: chainsaw-assert-validatingadmissionpolicy.yaml
+  - name: given-tenant-namespace-exists
+    try:
+    - apply:
+        file: ./resources/tenant-namespace.yaml
+  - name: then-valid-konflux-bot-allowed-clusterrole-rolebinding-can-be-created
+    try:
+    - apply:
+        file: ./resources/valid-konflux-bot-allowed-clusterrole-rolebinding.yaml
+        expect:
+        - check:
+            ($error != null): false
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: in-tenant-valid-non-konflux-bot-role-rolebinding
+spec:
+  description: |
+    tests that a RoleBinding binding a non-konflux-bot- ServiceAccount to a
+    namespaced Role can be created in a tenant namespace
+  concurrent: false
+  namespace: 'valid-non-konflux-bot-role-rb-tenant-namespace'
+  steps:
+  - name: given-validatingadmissionpolicy-is-ready
+    try:
+    - apply:
+        file: ../restrict-binding-serviceaccounts-create-validatingadmissionpolicy.yaml
+    - apply:
+        file: ../restrict-binding-serviceaccounts-create-validatingadmissionpolicybinding.yaml
+    - sleep:
+        duration: 1s
+    - assert:
+        file: chainsaw-assert-validatingadmissionpolicy.yaml
+  - name: given-tenant-namespace-and-role-exist
+    try:
+    - apply:
+        file: ./resources/tenant-namespace.yaml
+    - apply:
+        file: ./resources/tenant-role.yaml
+  - name: then-valid-non-konflux-bot-role-rolebinding-can-be-created
+    try:
+    - apply:
+        file: ./resources/valid-non-konflux-bot-role-rolebinding.yaml
+        expect:
+        - check:
+            ($error != null): false

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/restrict-binding-serviceaccounts/create/.chainsaw-test/resources/invalid-konflux-bot-role-rolebinding.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/restrict-binding-serviceaccounts/create/.chainsaw-test/resources/invalid-konflux-bot-role-rolebinding.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: invalid-konflux-bot-role-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: tenant-test-role
+subjects:
+- kind: ServiceAccount
+  name: konflux-bot-0

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/restrict-binding-serviceaccounts/create/.chainsaw-test/resources/invalid-serviceaccounts-rolebinding.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/restrict-binding-serviceaccounts/create/.chainsaw-test/resources/invalid-serviceaccounts-rolebinding.yaml
@@ -1,0 +1,18 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: invalid-serviceaccounts-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: not-konflux-viewer-user-actions
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: my-group
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: my-user
+- apiGroup: ""
+  kind: ServiceAccount
+  name: konflux-bot-0

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/restrict-binding-serviceaccounts/create/.chainsaw-test/resources/tenant-namespace.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/restrict-binding-serviceaccounts/create/.chainsaw-test/resources/tenant-namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ($namespace)
+  labels:
+    konflux-ci.dev/type: tenant

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/restrict-binding-serviceaccounts/create/.chainsaw-test/resources/tenant-role.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/restrict-binding-serviceaccounts/create/.chainsaw-test/resources/tenant-role.yaml
@@ -1,0 +1,8 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: tenant-test-role
+rules:
+- apiGroups: [""]
+  resources: ["configmaps"]
+  verbs: ["get"]

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/restrict-binding-serviceaccounts/create/.chainsaw-test/resources/valid-konflux-bot-allowed-clusterrole-rolebinding.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/restrict-binding-serviceaccounts/create/.chainsaw-test/resources/valid-konflux-bot-allowed-clusterrole-rolebinding.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: valid-konflux-bot-allowed-clusterrole-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: konflux-releaser-bot-actions
+subjects:
+- kind: ServiceAccount
+  name: konflux-bot-0

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/restrict-binding-serviceaccounts/create/.chainsaw-test/resources/valid-non-konflux-bot-role-rolebinding.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/restrict-binding-serviceaccounts/create/.chainsaw-test/resources/valid-non-konflux-bot-role-rolebinding.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: valid-non-konflux-bot-role-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: tenant-test-role
+subjects:
+- kind: ServiceAccount
+  name: not-a-konflux-bot-sa

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/restrict-binding-serviceaccounts/create/.chainsaw-test/resources/valid-serviceaccounts-rolebinding.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/restrict-binding-serviceaccounts/create/.chainsaw-test/resources/valid-serviceaccounts-rolebinding.yaml
@@ -1,0 +1,18 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: valid-serviceaccounts-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: konflux-viewer-user-actions
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: my-group
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: my-user
+- apiGroup: ""
+  kind: ServiceAccount
+  name: not-a-konflux-bot-sa

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/restrict-binding-serviceaccounts/create/kustomization.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/restrict-binding-serviceaccounts/create/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- restrict-binding-serviceaccounts-create-validatingadmissionpolicy.yaml
+- restrict-binding-serviceaccounts-create-validatingadmissionpolicybinding.yaml

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/restrict-binding-serviceaccounts/create/restrict-binding-serviceaccounts-create-validatingadmissionpolicy.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/restrict-binding-serviceaccounts/create/restrict-binding-serviceaccounts-create-validatingadmissionpolicy.yaml
@@ -1,0 +1,45 @@
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: restrict-bindings-serviceaccounts-create.konflux-ci.dev
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+    - apiGroups: ["rbac.authorization.k8s.io"]
+      apiVersions: ["v1"]
+      operations: ["CREATE"]
+      resources: ["rolebindings"]
+      scope: "Namespaced"
+  variables:
+  - name: restrictedServiceAccountsPrefix
+    expression: "'konflux-bot-'"
+  - name: allowedClusterRoleNamePattern
+    expression: "'^konflux-.+-bot-actions$'"
+  - name: bindsRestrictedKonfluxBotServiceAccount
+    expression: |
+      has(object.subjects) &&
+      object.subjects.exists(subject,
+        subject.kind == 'ServiceAccount' &&
+        (!has(subject.apiGroup) || subject.apiGroup == '') &&
+        has(subject.name) &&
+        subject.name.startsWith(variables.restrictedServiceAccountsPrefix))
+  - name: usesForbiddenRoleRef
+    expression: |
+      has(object.roleRef) && (
+        object.roleRef.kind == 'Role' ||
+        (object.roleRef.kind == 'ClusterRole' &&
+          has(object.roleRef.name) &&
+          !object.roleRef.name.matches(variables.allowedClusterRoleNamePattern)))
+  validations:
+  - expression: |
+      !(variables.bindsRestrictedKonfluxBotServiceAccount && variables.usesForbiddenRoleRef)
+    reason: Invalid
+    messageExpression: |
+      "ServiceAccounts with prefix '" +
+      variables.restrictedServiceAccountsPrefix +
+      "' cannot be bound to a Role and can only be bound to ClusterRoles matching the pattern konflux-*-bot-actions."
+    # fall-back if something is wrong with the messageExpression above
+    message: |
+      ServiceAccounts with prefix 'konflux-bot-' cannot be bound to a Role and can only be bound to ClusterRoles matching the pattern konflux-*-bot-actions.

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/restrict-binding-serviceaccounts/create/restrict-binding-serviceaccounts-create-validatingadmissionpolicybinding.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/restrict-binding-serviceaccounts/create/restrict-binding-serviceaccounts-create-validatingadmissionpolicybinding.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: restrict-bindings-serviceaccounts-create.konflux-ci.dev
+spec:
+  policyName: restrict-bindings-serviceaccounts-create.konflux-ci.dev
+  validationActions: [Deny]
+  matchResources:
+    namespaceSelector:
+      matchLabels:
+        konflux-ci.dev/type: tenant

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/restrict-binding-serviceaccounts/kustomization.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/restrict-binding-serviceaccounts/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namePrefix: konflux-rbac-
+resources:
+- create/
+- update/
+commonAnnotations:
+  argocd.argoproj.io/sync-options: Prune=false

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/restrict-binding-serviceaccounts/update/.chainsaw-test/chainsaw-assert-validatingadmissionpolicy.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/restrict-binding-serviceaccounts/update/.chainsaw-test/chainsaw-assert-validatingadmissionpolicy.yaml
@@ -1,0 +1,7 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: restrict-bindings-serviceaccounts-update.konflux-ci.dev
+status:
+  observedGeneration: 1
+  typeChecking: {}

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/restrict-binding-serviceaccounts/update/.chainsaw-test/chainsaw-test.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/restrict-binding-serviceaccounts/update/.chainsaw-test/chainsaw-test.yaml
@@ -1,0 +1,181 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: in-tenant-update-rolebinding-metadata
+spec:
+  description: |
+    tests that an existing RoleBinding without konflux-bot- ServiceAccounts
+    can be updated in a tenant namespace
+  concurrent: false
+  namespace: 'update-rb-metadata-tenant-namespace'
+  steps:
+  - name: given-validatingadmissionpolicy-is-ready
+    try:
+    - apply:
+        file: ../restrict-binding-serviceaccounts-update-validatingadmissionpolicy.yaml
+    - apply:
+        file: ../restrict-binding-serviceaccounts-update-validatingadmissionpolicybinding.yaml
+    - sleep:
+        duration: 1s
+    - assert:
+        file: chainsaw-assert-validatingadmissionpolicy.yaml
+  - name: given-tenant-namespace-and-rolebinding-exist
+    try:
+    - apply:
+        file: ./resources/tenant-namespace.yaml
+    - apply:
+        file: ./resources/valid-serviceaccounts-rolebinding.yaml
+  - name: then-rolebinding-metadata-can-be-updated
+    try:
+    - apply:
+        file: ./resources/valid-serviceaccounts-rolebinding-with-label.yaml
+        expect:
+        - check:
+            ($error != null): false
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: in-tenant-update-rolebinding-add-konflux-bot-denied
+spec:
+  description: |
+    tests that a konflux-bot- ServiceAccount cannot be added to an existing
+    RoleBinding in a tenant namespace
+  concurrent: false
+  namespace: 'update-rb-add-konflux-bot-tenant-namespace'
+  steps:
+  - name: given-validatingadmissionpolicy-is-ready
+    try:
+    - apply:
+        file: ../restrict-binding-serviceaccounts-update-validatingadmissionpolicy.yaml
+    - apply:
+        file: ../restrict-binding-serviceaccounts-update-validatingadmissionpolicybinding.yaml
+    - sleep:
+        duration: 1s
+    - assert:
+        file: chainsaw-assert-validatingadmissionpolicy.yaml
+  - name: given-tenant-namespace-and-rolebinding-exist
+    try:
+    - apply:
+        file: ./resources/tenant-namespace.yaml
+    - apply:
+        file: ./resources/valid-serviceaccounts-rolebinding.yaml
+  - name: then-adding-konflux-bot-subject-is-denied
+    try:
+    - apply:
+        file: ./resources/valid-serviceaccounts-rolebinding-with-konflux-bot-added.yaml
+        expect:
+        - check:
+            ($error != null): true
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: in-tenant-update-existing-konflux-bot-rolebinding
+spec:
+  description: |
+    tests that an existing RoleBinding that already targets a konflux-bot-
+    ServiceAccount can be updated in a tenant namespace
+  concurrent: false
+  namespace: 'update-existing-konflux-bot-rb-tenant-namespace'
+  steps:
+  - name: given-validatingadmissionpolicy-is-ready
+    try:
+    - apply:
+        file: ../restrict-binding-serviceaccounts-update-validatingadmissionpolicy.yaml
+    - apply:
+        file: ../restrict-binding-serviceaccounts-update-validatingadmissionpolicybinding.yaml
+    - sleep:
+        duration: 1s
+    - assert:
+        file: chainsaw-assert-validatingadmissionpolicy.yaml
+  - name: given-tenant-namespace-and-rolebinding-exist
+    try:
+    - apply:
+        file: ./resources/tenant-namespace.yaml
+    - apply:
+        file: ./resources/valid-konflux-bot-allowed-clusterrole-rolebinding.yaml
+  - name: then-existing-konflux-bot-rolebinding-can-be-updated
+    try:
+    - apply:
+        file: ./resources/valid-konflux-bot-allowed-clusterrole-rolebinding-with-label.yaml
+        expect:
+        - check:
+            ($error != null): false
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: in-tenant-update-preexisting-valid-konflux-bot-rolebinding
+spec:
+  description: |
+    tests that a pre-existing RoleBinding that already targets a konflux-bot-
+    ServiceAccount and an allowed ClusterRole can still be updated after the
+    policy is enforced
+  concurrent: false
+  namespace: 'update-preexisting-valid-konflux-bot-rb-tenant-namespace'
+  steps:
+  - name: given-tenant-namespace-and-invalid-rolebinding-exist
+    try:
+    - apply:
+        file: ./resources/tenant-namespace.yaml
+    - apply:
+        file: ./resources/valid-serviceaccounts-rolebinding.yaml
+  - name: when-validatingadmissionpolicy-is-ready
+    try:
+    - apply:
+        file: ../restrict-binding-serviceaccounts-update-validatingadmissionpolicy.yaml
+    - apply:
+        file: ../restrict-binding-serviceaccounts-update-validatingadmissionpolicybinding.yaml
+    - sleep:
+        duration: 1s
+    - assert:
+        file: chainsaw-assert-validatingadmissionpolicy.yaml
+  - name: then-preexisting-konflux-bot-rolebinding-can-be-updated
+    try:
+    - apply:
+        file: ./resources/valid-serviceaccounts-rolebinding-with-label.yaml
+        expect:
+        - check:
+            ($error != null): false
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: in-tenant-update-preexisting-invalid-konflux-bot-rolebinding
+spec:
+  description: |
+    tests that a pre-existing RoleBinding that already targets a konflux-bot-
+    ServiceAccount can be updated after the policy is enforced
+  concurrent: false
+  namespace: 'update-preexisting-invalid-konflux-bot-rb-tenant-namespace'
+  steps:
+  - name: given-tenant-namespace-and-invalid-rolebinding-exist
+    try:
+    - apply:
+        file: ./resources/tenant-namespace.yaml
+    - apply:
+        file: ./resources/invalid-serviceaccounts-rolebinding.yaml
+  - name: when-validatingadmissionpolicy-is-ready
+    try:
+    - apply:
+        file: ../restrict-binding-serviceaccounts-update-validatingadmissionpolicy.yaml
+    - apply:
+        file: ../restrict-binding-serviceaccounts-update-validatingadmissionpolicybinding.yaml
+    - sleep:
+        duration: 1s
+    - assert:
+        file: chainsaw-assert-validatingadmissionpolicy.yaml
+  - name: then-preexisting-konflux-bot-rolebinding-can-be-updated
+    try:
+    - apply:
+        file: ./resources/invalid-serviceaccounts-rolebinding-with-label.yaml
+        expect:
+        - check:
+            ($error != null): false

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/restrict-binding-serviceaccounts/update/.chainsaw-test/resources/invalid-serviceaccounts-rolebinding-with-label.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/restrict-binding-serviceaccounts/update/.chainsaw-test/resources/invalid-serviceaccounts-rolebinding-with-label.yaml
@@ -1,0 +1,20 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: invalid-serviceaccounts-rolebinding
+  labels:
+    test.example.com/updated: "true"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: not-konflux-viewer-user-actions
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: my-group
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: my-user
+- apiGroup: ""
+  kind: ServiceAccount
+  name: konflux-bot-0

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/restrict-binding-serviceaccounts/update/.chainsaw-test/resources/invalid-serviceaccounts-rolebinding.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/restrict-binding-serviceaccounts/update/.chainsaw-test/resources/invalid-serviceaccounts-rolebinding.yaml
@@ -1,0 +1,18 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: invalid-serviceaccounts-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: not-konflux-viewer-user-actions
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: my-group
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: my-user
+- apiGroup: ""
+  kind: ServiceAccount
+  name: konflux-bot-0

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/restrict-binding-serviceaccounts/update/.chainsaw-test/resources/tenant-namespace.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/restrict-binding-serviceaccounts/update/.chainsaw-test/resources/tenant-namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ($namespace)
+  labels:
+    konflux-ci.dev/type: tenant

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/restrict-binding-serviceaccounts/update/.chainsaw-test/resources/valid-konflux-bot-allowed-clusterrole-rolebinding-with-label.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/restrict-binding-serviceaccounts/update/.chainsaw-test/resources/valid-konflux-bot-allowed-clusterrole-rolebinding-with-label.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: valid-konflux-bot-allowed-clusterrole-rolebinding
+  labels:
+    test.example.com/updated: "true"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: konflux-releaser-bot-actions
+subjects:
+- kind: ServiceAccount
+  name: konflux-bot-0

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/restrict-binding-serviceaccounts/update/.chainsaw-test/resources/valid-konflux-bot-allowed-clusterrole-rolebinding.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/restrict-binding-serviceaccounts/update/.chainsaw-test/resources/valid-konflux-bot-allowed-clusterrole-rolebinding.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: valid-konflux-bot-allowed-clusterrole-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: konflux-releaser-bot-actions
+subjects:
+- kind: ServiceAccount
+  name: konflux-bot-0

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/restrict-binding-serviceaccounts/update/.chainsaw-test/resources/valid-serviceaccounts-rolebinding-with-konflux-bot-added.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/restrict-binding-serviceaccounts/update/.chainsaw-test/resources/valid-serviceaccounts-rolebinding-with-konflux-bot-added.yaml
@@ -1,0 +1,20 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: valid-serviceaccounts-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: konflux-viewer-user-actions
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: my-group
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: my-user
+- apiGroup: ""
+  kind: ServiceAccount
+  name: not-a-konflux-bot-sa
+- kind: ServiceAccount
+  name: konflux-bot-0

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/restrict-binding-serviceaccounts/update/.chainsaw-test/resources/valid-serviceaccounts-rolebinding-with-label.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/restrict-binding-serviceaccounts/update/.chainsaw-test/resources/valid-serviceaccounts-rolebinding-with-label.yaml
@@ -1,0 +1,20 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: valid-serviceaccounts-rolebinding
+  labels:
+    test.example.com/updated: "true"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: konflux-viewer-user-actions
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: my-group
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: my-user
+- apiGroup: ""
+  kind: ServiceAccount
+  name: not-a-konflux-bot-sa

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/restrict-binding-serviceaccounts/update/.chainsaw-test/resources/valid-serviceaccounts-rolebinding.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/restrict-binding-serviceaccounts/update/.chainsaw-test/resources/valid-serviceaccounts-rolebinding.yaml
@@ -1,0 +1,18 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: valid-serviceaccounts-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: konflux-viewer-user-actions
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: my-group
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: my-user
+- apiGroup: ""
+  kind: ServiceAccount
+  name: not-a-konflux-bot-sa

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/restrict-binding-serviceaccounts/update/kustomization.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/restrict-binding-serviceaccounts/update/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- restrict-binding-serviceaccounts-update-validatingadmissionpolicy.yaml
+- restrict-binding-serviceaccounts-update-validatingadmissionpolicybinding.yaml

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/restrict-binding-serviceaccounts/update/restrict-binding-serviceaccounts-update-validatingadmissionpolicy.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/restrict-binding-serviceaccounts/update/restrict-binding-serviceaccounts-update-validatingadmissionpolicy.yaml
@@ -1,0 +1,54 @@
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: restrict-bindings-serviceaccounts-update.konflux-ci.dev
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+    - apiGroups: ["rbac.authorization.k8s.io"]
+      apiVersions: ["v1"]
+      operations: ["UPDATE"]
+      resources: ["rolebindings"]
+      scope: "Namespaced"
+  variables:
+  - name: restrictedServiceAccountsPrefix
+    expression: "'konflux-bot-'"
+  - name: allowedClusterRoleNamePattern
+    expression: "'^konflux-.+-bot-actions$'"
+  - name: usesForbiddenRoleRef
+    expression: |
+      has(object.roleRef) && (
+        object.roleRef.kind == 'Role' ||
+        (object.roleRef.kind == 'ClusterRole' &&
+          has(object.roleRef.name) &&
+          !object.roleRef.name.matches(variables.allowedClusterRoleNamePattern)))
+  - name: addsRestrictedKonfluxBotServiceAccount
+    expression: |
+      has(object.subjects) &&
+      object.subjects.exists(newSubject,
+        newSubject.kind == 'ServiceAccount' &&
+        (!has(newSubject.apiGroup) || newSubject.apiGroup == '') &&
+        has(newSubject.name) &&
+        newSubject.name.startsWith(variables.restrictedServiceAccountsPrefix) &&
+        (
+          !has(oldObject.subjects) ||
+          !oldObject.subjects.exists(oldSubject,
+            oldSubject.kind == newSubject.kind &&
+            ((!has(oldSubject.apiGroup) || oldSubject.apiGroup == '') ==
+              (!has(newSubject.apiGroup) || newSubject.apiGroup == '')) &&
+            oldSubject.name == newSubject.name &&
+            (has(oldSubject.namespace) ? oldSubject.namespace : '') ==
+            (has(newSubject.namespace) ? newSubject.namespace : ''))))
+  validations:
+  - expression: '!variables.usesForbiddenRoleRef || !variables.addsRestrictedKonfluxBotServiceAccount'
+    reason: Invalid
+    messageExpression: |
+      "ServiceAccounts with prefix '" +
+      variables.restrictedServiceAccountsPrefix +
+      "' cannot be added to an existing RoleBinding" +
+      "not referencing a 'konflux-*-bot-actions'."
+    message: >-
+      ServiceAccounts with prefix 'konflux-bot-' cannot be added to an existing RoleBinding
+      not referencing a 'konflux-*-bot-actions' ClusterRole.

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/restrict-binding-serviceaccounts/update/restrict-binding-serviceaccounts-update-validatingadmissionpolicybinding.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/restrict-binding-serviceaccounts/update/restrict-binding-serviceaccounts-update-validatingadmissionpolicybinding.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: restrict-bindings-serviceaccounts-update.konflux-ci.dev
+spec:
+  policyName: restrict-bindings-serviceaccounts-update.konflux-ci.dev
+  validationActions: [Deny]
+  matchResources:
+    namespaceSelector:
+      matchLabels:
+        konflux-ci.dev/type: tenant

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/restrict-binding-system-authenticated-releng/.chainsaw-test/README.md
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/restrict-binding-system-authenticated-releng/.chainsaw-test/README.md
@@ -1,0 +1,164 @@
+# Test: `in-rhtap-releng-tenant-invalid-rolebinding`
+
+tests that the a invalid RoleBinding can NOT be created
+in a tenant namespace
+
+
+## Steps
+
+| # | Name | Bindings | Try | Catch | Finally | Cleanup |
+|:-:|---|:-:|:-:|:-:|:-:|:-:|
+| 1 | [given-kyverno-has-permission-on-resources](#step-given-kyverno-has-permission-on-resources) | 0 | 1 | 0 | 0 | 0 |
+| 2 | [given-cluster-policy-is-ready](#step-given-cluster-policy-is-ready) | 0 | 2 | 0 | 0 | 0 |
+| 3 | [given-tenant-namespace-exists](#step-given-tenant-namespace-exists) | 0 | 1 | 0 | 0 | 0 |
+| 4 | [then-invalid-rolebindings-can-not-be-created](#step-then-invalid-rolebindings-can-not-be-created) | 0 | 1 | 0 | 0 | 0 |
+
+### Step: `given-kyverno-has-permission-on-resources`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `given-cluster-policy-is-ready`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+| 2 | `assert` | 0 | 0 | *No description* |
+
+### Step: `given-tenant-namespace-exists`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `then-invalid-rolebindings-can-not-be-created`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+---
+
+# Test: `in-rhtap-releng-tenant-valid-rolebinding`
+
+tests that the a valid RoleBinding can be created in a
+tenant namespace
+
+
+## Steps
+
+| # | Name | Bindings | Try | Catch | Finally | Cleanup |
+|:-:|---|:-:|:-:|:-:|:-:|:-:|
+| 1 | [given-kyverno-has-permission-on-resources](#step-given-kyverno-has-permission-on-resources) | 0 | 1 | 0 | 0 | 0 |
+| 2 | [given-cluster-policy-is-ready](#step-given-cluster-policy-is-ready) | 0 | 2 | 0 | 0 | 0 |
+| 3 | [given-tenant-namespace-exists](#step-given-tenant-namespace-exists) | 0 | 1 | 0 | 0 | 0 |
+| 4 | [then-valid-rolebindings-can-be-created](#step-then-valid-rolebindings-can-be-created) | 0 | 1 | 0 | 0 | 0 |
+
+### Step: `given-kyverno-has-permission-on-resources`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `given-cluster-policy-is-ready`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+| 2 | `assert` | 0 | 0 | *No description* |
+
+### Step: `given-tenant-namespace-exists`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `then-valid-rolebindings-can-be-created`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+---
+
+# Test: `out-of-rhtap-releng-tenant-rolebinding`
+
+tests that the whatever RoleBinding can be created in a
+non-tenant namespace
+
+
+## Steps
+
+| # | Name | Bindings | Try | Catch | Finally | Cleanup |
+|:-:|---|:-:|:-:|:-:|:-:|:-:|
+| 1 | [given-kyverno-has-permission-on-resources](#step-given-kyverno-has-permission-on-resources) | 0 | 1 | 0 | 0 | 0 |
+| 2 | [given-cluster-policy-is-ready](#step-given-cluster-policy-is-ready) | 0 | 2 | 0 | 0 | 0 |
+| 3 | [then-rolebindings-can-be-created-in-a-nontenant-namespace](#step-then-rolebindings-can-be-created-in-a-nontenant-namespace) | 0 | 2 | 0 | 0 | 0 |
+
+### Step: `given-kyverno-has-permission-on-resources`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `given-cluster-policy-is-ready`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+| 2 | `assert` | 0 | 0 | *No description* |
+
+### Step: `then-rolebindings-can-be-created-in-a-nontenant-namespace`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+| 2 | `apply` | 0 | 0 | *No description* |
+
+---
+

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/restrict-binding-system-authenticated-releng/.chainsaw-test/chainsaw-assert-clusterpolicy.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/restrict-binding-system-authenticated-releng/.chainsaw-test/chainsaw-assert-clusterpolicy.yaml
@@ -1,0 +1,9 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: validate-restrict-binding-sysauth-releng
+status:
+  conditions:
+  - reason: Succeeded
+    status: "True"
+    type: Ready

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/restrict-binding-system-authenticated-releng/.chainsaw-test/chainsaw-test.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/restrict-binding-system-authenticated-releng/.chainsaw-test/chainsaw-test.yaml
@@ -1,0 +1,138 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: in-rhtap-releng-tenant-invalid-rolebinding
+spec:
+  description: |
+    tests that the a invalid RoleBinding can NOT be created
+    in a tenant namespace
+  concurrent: false
+  namespace: 'rhtap-releng-tenant'
+  steps:
+  - name: given-kyverno-has-permission-on-resources
+    try:
+    - apply:
+        file: ../kyverno-cluster-role.yaml
+  - name: given-cluster-policy-is-ready
+    try:
+    - apply:
+        file: ../validate-restrict-binding-sysauth-releng-cp.yaml
+    - assert:
+        file: chainsaw-assert-clusterpolicy.yaml
+  - name: given-tenant-namespace-exists
+    try:
+    - apply:
+        file: ./resources/tenant-namespace.yaml
+  - name: then-invalid-rolebindings-can-not-be-created
+    try:
+    - apply:
+        file: ./resources/invalid-systemauthenticated-rolebinding.yaml
+        expect:
+        - check:
+            ($error != null): true
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: in-rhtap-releng-tenant-delete-existing-invalid-rolebinding
+spec:
+  description: |
+    tests that the an existing invalid RoleBinding can be deleted
+    in a tenant namespace
+  concurrent: false
+  namespace: 'rhtap-releng-tenant'
+  steps:
+  - name: given-tenant-namespace-exists
+    try:
+    - apply:
+        file: ./resources/tenant-namespace.yaml
+  - name: given-invalid-rolebindings-exists
+    try:
+    - create:
+        file: ./resources/invalid-systemauthenticated-rolebinding.yaml
+  - name: given-kyverno-has-permission-on-resources
+    try:
+    - apply:
+        file: ../kyverno-cluster-role.yaml
+  - name: when-cluster-policy-is-ready
+    try:
+    - apply:
+        file: ../validate-restrict-binding-sysauth-releng-cp.yaml
+    - assert:
+        file: chainsaw-assert-clusterpolicy.yaml
+  - name: then-invalid-rolebindings-can-be-deleted
+    try:
+    - delete:
+        file: ./resources/invalid-systemauthenticated-rolebinding.yaml
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: in-rhtap-releng-tenant-valid-rolebinding
+spec:
+  description: |
+    tests that the a valid RoleBinding can be created in a
+    tenant namespace
+  concurrent: false
+  namespace: 'rhtap-releng-tenant'
+  steps:
+  - name: given-kyverno-has-permission-on-resources
+    try:
+    - apply:
+        file: ../kyverno-cluster-role.yaml
+  - name: given-cluster-policy-is-ready
+    try:
+    - apply:
+        file: ../validate-restrict-binding-sysauth-releng-cp.yaml
+    - assert:
+        file: chainsaw-assert-clusterpolicy.yaml
+  - name: given-tenant-namespace-exists
+    try:
+    - apply:
+        file: ./resources/tenant-namespace.yaml
+  - name: then-valid-rolebindings-can-be-created
+    try:
+    - apply:
+        file: ./resources/valid-systemauthenticated-rolebinding.yaml
+        expect:
+        - check:
+            ($error != null): false
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: out-of-rhtap-releng-tenant-rolebinding
+spec:
+  description: |
+    tests that the whatever RoleBinding can be created in a
+    non-tenant namespace
+  concurrent: false
+  namespace: 'non-rhtap-releng-tenant'
+  steps:
+  - name: given-kyverno-has-permission-on-resources
+    try:
+    - apply:
+        file: ../kyverno-cluster-role.yaml
+  - name: given-cluster-policy-is-ready
+    try:
+    - apply:
+        file: ../validate-restrict-binding-sysauth-releng-cp.yaml
+    - assert:
+        file: chainsaw-assert-clusterpolicy.yaml
+  - name: then-rolebindings-can-be-created-in-a-nontenant-namespace
+    try:
+    - apply:
+        file: ./resources/valid-systemauthenticated-rolebinding.yaml
+        expect:
+        - check:
+            ($error != null): false
+    - apply:
+        file: ./resources/invalid-systemauthenticated-rolebinding.yaml
+        expect:
+        - check:
+            ($error != null): false

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/restrict-binding-system-authenticated-releng/.chainsaw-test/resources/invalid-systemauthenticated-rolebinding.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/restrict-binding-system-authenticated-releng/.chainsaw-test/resources/invalid-systemauthenticated-rolebinding.yaml
@@ -1,0 +1,18 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: invalid-systemauthenticated-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: not-allowed-clusterrole
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:authenticated
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: my-user
+- apiGroup: ""
+  kind: ServiceAccount
+  name: my-serviceaccount

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/restrict-binding-system-authenticated-releng/.chainsaw-test/resources/tenant-namespace.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/restrict-binding-system-authenticated-releng/.chainsaw-test/resources/tenant-namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ($namespace)
+  labels:
+    konflux-ci.dev/type: tenant

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/restrict-binding-system-authenticated-releng/.chainsaw-test/resources/valid-systemauthenticated-rolebinding.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/restrict-binding-system-authenticated-releng/.chainsaw-test/resources/valid-systemauthenticated-rolebinding.yaml
@@ -1,0 +1,37 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: valid-systemauthenticated-konflux-viewer
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: konflux-viewer-user-actions
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:authenticated
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: my-user
+- apiGroup: ""
+  kind: ServiceAccount
+  name: my-serviceaccount
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: valid-systemauthenticated-enterprise-contract-viewer
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: enterprisecontractpolicy-viewer-role
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:authenticated
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: my-user
+- apiGroup: ""
+  kind: ServiceAccount
+  name: my-serviceaccount

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/restrict-binding-system-authenticated-releng/kustomization.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/restrict-binding-system-authenticated-releng/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namePrefix: konflux-rbac-
+resources:
+- validate-restrict-binding-sysauth-releng-cp.yaml
+- kyverno-cluster-role.yaml
+commonAnnotations:
+  argocd.argoproj.io/sync-options: Prune=false

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/restrict-binding-system-authenticated-releng/kyverno-cluster-role.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/restrict-binding-system-authenticated-releng/kyverno-cluster-role.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kyverno-adm:restrict-binding-sysauth-releng
+  labels:
+    rbac.kyverno.io/aggregate-to-admission-controller: "true"
+rules:
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - rolebindings
+  verbs:
+  - list
+  - get
+  - watch
+---

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/restrict-binding-system-authenticated-releng/validate-restrict-binding-sysauth-releng-cp.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/restrict-binding-system-authenticated-releng/validate-restrict-binding-sysauth-releng-cp.yaml
@@ -1,0 +1,45 @@
+---
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: validate-restrict-binding-sysauth-releng
+  annotations:
+    policies.kyverno.io/title: Restrict Binding System Groups
+    policies.kyverno.io/category: Security
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: RoleBinding, RBAC
+    policies.kyverno.io/description: >-
+      We don't want users to bind system:authenticated group with any role
+      except for the konflux-viewer-user-actions ClusterRole.
+spec:
+  rules:
+  - name: restrict-authenticated
+    skipBackgroundRequests: true
+    match:
+      any:
+      - resources:
+          kinds:
+          - RoleBinding
+          namespaces:
+          - rhtap-releng-tenant
+          operations:
+          - CREATE
+          - UPDATE
+    preconditions:
+      all:
+      - key: "{{ request.object.subjects[].name }}"
+        operator: AnyIn
+        value: "system:authenticated"
+      - key: "{{ request.object.roleRef.kind }}"
+        operator: Equals
+        value: "ClusterRole"
+      - key: "{{ request.object.roleRef.name }}"
+        operator: AllNotIn
+        value:
+          - konflux-viewer-user-actions
+          - enterprisecontractpolicy-viewer-role
+    validate:
+      allowExistingViolations: true
+      failureAction: Enforce
+      message: "Only ClusterRoles 'konflux-viewer-user-actions' and 'enterprisecontractpolicy-viewer-role' can be bound to 'system:authenticated' in namespace 'rhtap-releng-tenant'."
+      deny: {}

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/validate-rolebindings/.chainsaw-test/README.md
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/validate-rolebindings/.chainsaw-test/README.md
@@ -1,0 +1,85 @@
+# Test: `disallow-tenant-groups`
+
+Asserts that rolebindings to restricted groups are denied in tenant namespaces
+
+
+## Steps
+
+| # | Name | Bindings | Try | Catch | Finally | Cleanup |
+|:-:|---|:-:|:-:|:-:|:-:|:-:|
+| 1 | [Given namespace has tenant label](#step-Given namespace has tenant label) | 0 | 1 | 0 | 0 | 0 |
+| 2 | [Given cluster policy is ready](#step-Given cluster policy is ready) | 0 | 2 | 0 | 0 | 0 |
+| 3 | [When invalid rolebinding is applied, assert an error](#step-When invalid rolebinding is applied, assert an error) | 0 | 3 | 0 | 0 | 0 |
+
+### Step: `Given namespace has tenant label`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `Given cluster policy is ready`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+| 2 | `assert` | 0 | 0 | *No description* |
+
+### Step: `When invalid rolebinding is applied, assert an error`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 1 | 0 | *No description* |
+| 2 | `apply` | 1 | 0 | *No description* |
+| 3 | `apply` | 1 | 0 | *No description* |
+
+---
+
+# Test: `allow-system-groups-in-non-tenant-namespaces`
+
+Asserts that rolebindings restricted groups are allowed in non-tenant namespaces
+
+
+## Steps
+
+| # | Name | Bindings | Try | Catch | Finally | Cleanup |
+|:-:|---|:-:|:-:|:-:|:-:|:-:|
+| 1 | [Given cluster policy is ready](#step-Given cluster policy is ready) | 0 | 2 | 0 | 0 | 0 |
+| 2 | [When valid rolebinding is applied, assert no error](#step-When valid rolebinding is applied, assert no error) | 0 | 3 | 0 | 0 | 0 |
+
+### Step: `Given cluster policy is ready`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+| 2 | `assert` | 0 | 0 | *No description* |
+
+### Step: `When valid rolebinding is applied, assert no error`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 1 | 0 | *No description* |
+| 2 | `apply` | 1 | 0 | *No description* |
+| 3 | `apply` | 1 | 0 | *No description* |
+
+---
+

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/validate-rolebindings/.chainsaw-test/chainsaw-assert-clusterpolicy.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/validate-rolebindings/.chainsaw-test/chainsaw-assert-clusterpolicy.yaml
@@ -1,0 +1,9 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: restrict-binding-system-groups
+status:
+  conditions:
+  - reason: Succeeded
+    status: "True"
+    type: Ready

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/validate-rolebindings/.chainsaw-test/chainsaw-test.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/validate-rolebindings/.chainsaw-test/chainsaw-test.yaml
@@ -1,0 +1,107 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: disallow-tenant-groups
+spec:
+  description: |
+    Asserts that rolebindings to restricted groups are denied in tenant namespaces
+  concurrent: false
+  namespace: 'deny-tenant-groups'
+  steps:
+  - name: "Given namespace has tenant label"
+    try:
+    - apply:
+        file: ./resources/tenant-namespace.yaml
+  - name: "Given cluster policy is ready"
+    try:
+    - apply:
+        file: ../invalid-subjects-cp.yaml
+    - assert:
+        file: ./chainsaw-assert-clusterpolicy.yaml
+  - name: "When invalid rolebinding is applied, assert an error"
+    try:
+    - apply:
+        bindings:
+        - name: group
+          value: "system:anonymous"
+        file: ./resources/rolebinding.yaml
+        template: true
+        expect:
+        - match:
+            kind: RoleBinding
+          check:
+            ($error != null): true
+    - apply:
+        bindings:
+        - name: group
+          value: "system:masters"
+        file: ./resources/rolebinding.yaml
+        template: true
+        expect:
+        - match:
+            kind: RoleBinding
+          check:
+            ($error != null): true
+    - apply:
+        bindings:
+        - name: group
+          value: "system:unauthenticated"
+        file: ./resources/rolebinding.yaml
+        template: true
+        expect:
+        - match:
+            kind: RoleBinding
+          check:
+            ($error != null): true
+---
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: allow-system-groups-in-non-tenant-namespaces
+spec:
+  description: |
+    Asserts that rolebindings restricted groups are allowed in non-tenant namespaces
+  concurrent: false
+  namespace: 'allow-system-groups'
+  steps:
+  - name: "Given cluster policy is ready"
+    try:
+    - apply:
+        file: ../invalid-subjects-cp.yaml
+    - assert:
+        file: ./chainsaw-assert-clusterpolicy.yaml
+  - name: "When valid rolebinding is applied, assert no error"
+    try:
+    - apply:
+        bindings:
+        - name: group
+          value: "system:anonymous"
+        file: ./resources/rolebinding.yaml
+        template: true
+        expect:
+        - match:
+            kind: RoleBinding
+          check:
+            ($error != null): false
+    - apply:
+        bindings:
+        - name: group
+          value: "system:masters"
+        file: ./resources/rolebinding.yaml
+        template: true
+        expect:
+        - match:
+            kind: RoleBinding
+          check:
+            ($error != null): false
+    - apply:
+        bindings:
+        - name: group
+          value: "system:unauthenticated"
+        file: ./resources/rolebinding.yaml
+        template: true
+        expect:
+        - match:
+            kind: RoleBinding
+          check:
+            ($error != null): false

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/validate-rolebindings/.chainsaw-test/resources/rolebinding.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/validate-rolebindings/.chainsaw-test/resources/rolebinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: ($group)-admin
+  namespace: ($namespace)
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: admin
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: ($group)

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/validate-rolebindings/.chainsaw-test/resources/tenant-namespace.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/validate-rolebindings/.chainsaw-test/resources/tenant-namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ($namespace)
+  labels:
+    konflux-ci.dev/type: tenant

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/validate-rolebindings/invalid-subjects-cp.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/validate-rolebindings/invalid-subjects-cp.yaml
@@ -1,0 +1,27 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: restrict-binding-system-groups
+spec:
+  background: false
+  rules:
+  - name: deny-restricted-groups
+    skipBackgroundRequests: true
+    match:
+      any:
+      - resources:
+          kinds:
+          - RoleBinding
+          namespaceSelector:
+            matchLabels:
+              konflux-ci.dev/type: tenant
+    preconditions:
+      all:
+      - key: "{{ request.object.subjects[].name }}"
+        operator: AnyIn
+        value: '["system:anonymous", "system:unauthenticated", "system:masters"]'
+    validate:
+      allowExistingViolations: true
+      failureAction: Enforce
+      message: "RoleBindings to restricted system groups is not allowed in tenant namespaces."
+      deny: {}

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/validate-rolebindings/kustomization.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/validate-rolebindings/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- invalid-subjects-cp.yaml
+- kyverno-cluster-role.yaml
+commonAnnotations:
+  argocd.argoproj.io/sync-options: Prune=false

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/validate-rolebindings/kyverno-cluster-role.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/validate-rolebindings/kyverno-cluster-role.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: Prune=false
+  labels:
+    rbac.kyverno.io/aggregate-to-admission-controller: "true"
+  name: kyverno-admission:validate-rolebindings
+rules:
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - rolebindings
+    verbs:
+      - list
+      - get
+      - watch

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/kubearchive/OWNERS
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/kubearchive/OWNERS
@@ -1,0 +1,8 @@
+# See the OWNERS docs: https://go.k8s.io/owners
+
+reviewers:
+- rh-hemartin
+- skoved
+- ggallen
+- maruiz93
+- mafh314

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/kubearchive/bootstrap-namespace/.chainsaw-test/README.md
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/kubearchive/bootstrap-namespace/.chainsaw-test/README.md
@@ -1,0 +1,386 @@
+# Test: `mutate-new-namespace-konfluxcidev`
+
+tests that the KubeArchiveConfig is created in a namespace
+labelled with `konflux-ci.dev/type=tenant`
+
+
+## Bindings
+
+| # | Name | Value |
+|:-:|---|---|
+| 1 | `suffix` | "konfluxcidev" |
+
+## Steps
+
+| # | Name | Bindings | Try | Catch | Finally | Cleanup |
+|:-:|---|:-:|:-:|:-:|:-:|:-:|
+| 1 | [given-kubearchiveconfig-crd-exists](#step-given-kubearchiveconfig-crd-exists) | 0 | 1 | 0 | 0 | 0 |
+| 2 | [given-kyverno-has-permission-on-resources](#step-given-kyverno-has-permission-on-resources) | 0 | 1 | 0 | 0 | 0 |
+| 3 | [given-cluster-policy-is-ready](#step-given-cluster-policy-is-ready) | 0 | 2 | 0 | 0 | 0 |
+| 4 | [when-konfluxcidev-labeled-namespace-is-created](#step-when-konfluxcidev-labeled-namespace-is-created) | 0 | 1 | 0 | 0 | 0 |
+| 5 | [then-kubearchiveconfig-is-created](#step-then-kubearchiveconfig-is-created) | 0 | 1 | 0 | 0 | 0 |
+
+### Step: `given-kubearchiveconfig-crd-exists`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `given-kyverno-has-permission-on-resources`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `given-cluster-policy-is-ready`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+| 2 | `assert` | 0 | 0 | *No description* |
+
+### Step: `when-konfluxcidev-labeled-namespace-is-created`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `then-kubearchiveconfig-is-created`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `assert` | 0 | 0 | *No description* |
+
+---
+
+# Test: `mutate-new-namespace-unlabeled`
+
+tests that the KubeArchiveConfig is NOT created in an unlabeled namespace
+
+
+## Bindings
+
+| # | Name | Value |
+|:-:|---|---|
+| 1 | `suffix` | "unlabeled" |
+
+## Steps
+
+| # | Name | Bindings | Try | Catch | Finally | Cleanup |
+|:-:|---|:-:|:-:|:-:|:-:|:-:|
+| 1 | [given-kubearchiveconfig-crd-exists](#step-given-kubearchiveconfig-crd-exists) | 0 | 1 | 0 | 0 | 0 |
+| 2 | [given-kyverno-has-permission-on-resources](#step-given-kyverno-has-permission-on-resources) | 0 | 1 | 0 | 0 | 0 |
+| 3 | [given-cluster-policy-is-ready](#step-given-cluster-policy-is-ready) | 0 | 2 | 0 | 0 | 0 |
+| 4 | [when-unlabeled-namespace-is-created](#step-when-unlabeled-namespace-is-created) | 0 | 1 | 0 | 0 | 0 |
+| 5 | [then-kubearchiveconfig-is-created](#step-then-kubearchiveconfig-is-created) | 0 | 1 | 0 | 0 | 0 |
+
+### Step: `given-kubearchiveconfig-crd-exists`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `given-kyverno-has-permission-on-resources`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `given-cluster-policy-is-ready`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+| 2 | `assert` | 0 | 0 | *No description* |
+
+### Step: `when-unlabeled-namespace-is-created`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `then-kubearchiveconfig-is-created`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `delete` | 0 | 0 | *No description* |
+
+---
+
+# Test: `mutate-existing-namespace-konfluxcidev`
+
+tests that the KubeArchiveConfig is created in an already existing
+namespace labelled with `konflux-ci.dev/type=tenant`
+
+
+## Bindings
+
+| # | Name | Value |
+|:-:|---|---|
+| 1 | `suffix` | "konflux" |
+
+## Steps
+
+| # | Name | Bindings | Try | Catch | Finally | Cleanup |
+|:-:|---|:-:|:-:|:-:|:-:|:-:|
+| 1 | [given-kubearchiveconfig-crd-exists](#step-given-kubearchiveconfig-crd-exists) | 0 | 1 | 0 | 0 | 0 |
+| 2 | [given-kyverno-has-permission-on-resources](#step-given-kyverno-has-permission-on-resources) | 0 | 1 | 0 | 0 | 0 |
+| 3 | [given-konfluxci-labeled-namespace-is-created](#step-given-konfluxci-labeled-namespace-is-created) | 0 | 1 | 0 | 0 | 0 |
+| 4 | [when-cluster-policy-is-ready](#step-when-cluster-policy-is-ready) | 0 | 2 | 0 | 0 | 0 |
+| 5 | [then-kubearchiveconfig-is-created](#step-then-kubearchiveconfig-is-created) | 0 | 1 | 0 | 0 | 0 |
+
+### Step: `given-kubearchiveconfig-crd-exists`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `given-kyverno-has-permission-on-resources`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `given-konfluxci-labeled-namespace-is-created`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `when-cluster-policy-is-ready`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+| 2 | `assert` | 0 | 0 | *No description* |
+
+### Step: `then-kubearchiveconfig-is-created`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `assert` | 0 | 0 | *No description* |
+
+---
+
+# Test: `mutate-existing-namespace-unlabeled`
+
+tests that the KubeArchiveConfig is NOT created in an
+existing unlabeled namespace
+
+
+## Bindings
+
+| # | Name | Value |
+|:-:|---|---|
+| 1 | `suffix` | "unlabeled" |
+
+## Steps
+
+| # | Name | Bindings | Try | Catch | Finally | Cleanup |
+|:-:|---|:-:|:-:|:-:|:-:|:-:|
+| 1 | [given-kubearchiveconfig-crd-exists](#step-given-kubearchiveconfig-crd-exists) | 0 | 1 | 0 | 0 | 0 |
+| 2 | [given-kyverno-has-permission-on-resources](#step-given-kyverno-has-permission-on-resources) | 0 | 1 | 0 | 0 | 0 |
+| 3 | [given-unlabeled-namespace-is-created](#step-given-unlabeled-namespace-is-created) | 0 | 1 | 0 | 0 | 0 |
+| 4 | [when-cluster-policy-is-ready](#step-when-cluster-policy-is-ready) | 0 | 2 | 0 | 0 | 0 |
+| 5 | [then-kubearchiveconfig-is-created](#step-then-kubearchiveconfig-is-created) | 0 | 1 | 0 | 0 | 0 |
+
+### Step: `given-kubearchiveconfig-crd-exists`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `given-kyverno-has-permission-on-resources`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `given-unlabeled-namespace-is-created`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `when-cluster-policy-is-ready`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+| 2 | `assert` | 0 | 0 | *No description* |
+
+### Step: `then-kubearchiveconfig-is-created`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `delete` | 0 | 0 | *No description* |
+
+---
+
+# Test: `mutate-existing-namespace-konfluxcidev-existing-kubearchiveconfig`
+
+tests that the KubeArchiveConfig is not updated in an already existing
+namespace labelled with `konflux-ci.dev/type=tenant` where the
+KubeArchiveConfig already exists
+
+
+## Bindings
+
+| # | Name | Value |
+|:-:|---|---|
+| 1 | `suffix` | "konfluxcidev-existing-kubearchive" |
+
+## Steps
+
+| # | Name | Bindings | Try | Catch | Finally | Cleanup |
+|:-:|---|:-:|:-:|:-:|:-:|:-:|
+| 1 | [given-kubearchiveconfig-crd-exists](#step-given-kubearchiveconfig-crd-exists) | 0 | 1 | 0 | 0 | 0 |
+| 2 | [given-kyverno-has-permission-on-resources](#step-given-kyverno-has-permission-on-resources) | 0 | 1 | 0 | 0 | 0 |
+| 3 | [given-konfluxcidev-labeled-namespace-is-created](#step-given-konfluxcidev-labeled-namespace-is-created) | 0 | 1 | 0 | 0 | 0 |
+| 4 | [given-kubearchiveconfig-is-created](#step-given-kubearchiveconfig-is-created) | 0 | 1 | 0 | 0 | 0 |
+| 5 | [when-cluster-policy-is-ready](#step-when-cluster-policy-is-ready) | 0 | 2 | 0 | 0 | 0 |
+| 6 | [then-kubearchiveconfig-is-not-changed](#step-then-kubearchiveconfig-is-not-changed) | 0 | 1 | 0 | 0 | 0 |
+
+### Step: `given-kubearchiveconfig-crd-exists`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `given-kyverno-has-permission-on-resources`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `given-konfluxcidev-labeled-namespace-is-created`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `given-kubearchiveconfig-is-created`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `when-cluster-policy-is-ready`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+| 2 | `assert` | 0 | 0 | *No description* |
+
+### Step: `then-kubearchiveconfig-is-not-changed`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `assert` | 0 | 0 | *No description* |
+
+---
+

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/kubearchive/bootstrap-namespace/.chainsaw-test/chainsaw-assert-clusterpolicy.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/kubearchive/bootstrap-namespace/.chainsaw-test/chainsaw-assert-clusterpolicy.yaml
@@ -1,0 +1,9 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: init-ns-kubearchiveconfig
+status:
+  conditions:
+  - reason: Succeeded
+    status: "True"
+    type: Ready

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/kubearchive/bootstrap-namespace/.chainsaw-test/chainsaw-test.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/kubearchive/bootstrap-namespace/.chainsaw-test/chainsaw-test.yaml
@@ -1,0 +1,285 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: mutate-new-namespace-konfluxcidev
+spec:
+  description: |
+    tests that the KubeArchiveConfig is created in a namespace
+    labelled with `konflux-ci.dev/type=tenant`
+  concurrent: false
+  namespace: 'generate-new-namespace'
+  bindings:
+  - name: suffix
+    value: konfluxcidev
+  steps:
+  - name: given-kubearchiveconfig-crd-exists
+    try:
+    - apply:
+        file: resources/kubearchive-crd.yaml
+  - name: given-kyverno-has-permission-on-resources
+    try:
+    - apply:
+        file: ../kyverno-read-cluster-role.yaml
+    - apply:
+        file: ../kyverno-manage-cluster-role.yaml
+  - name: given-cluster-policy-is-ready
+    try:
+    - apply:
+        file: ../bootstrap-namespace-cp.yaml
+    - assert:
+        file: chainsaw-assert-clusterpolicy.yaml
+  - name: when-konfluxcidev-labeled-namespace-is-created
+    try:
+    - apply:
+        file: resources/actual-namespace-konfluxcidev.yaml
+        template: true
+  - name: then-kubearchiveconfig-is-created
+    try:
+    - assert:
+        file: resources/expected-kubearchiveconfig.yaml
+        template: true
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: mutate-new-namespace-unlabeled
+spec:
+  description: |
+    tests that the KubeArchiveConfig is NOT created in an unlabeled namespace
+  concurrent: false
+  namespace: 'generate-new-namespace'
+  bindings:
+  - name: suffix
+    value: unlabeled
+  steps:
+  - name: given-kubearchiveconfig-crd-exists
+    try:
+    - apply:
+        file: resources/kubearchive-crd.yaml
+  - name: given-kyverno-has-permission-on-resources
+    try:
+    - apply:
+        file: ../kyverno-read-cluster-role.yaml
+    - apply:
+        file: ../kyverno-manage-cluster-role.yaml
+  - name: given-cluster-policy-is-ready
+    try:
+    - apply:
+        file: ../bootstrap-namespace-cp.yaml
+    - assert:
+        file: chainsaw-assert-clusterpolicy.yaml
+  - name: when-unlabeled-namespace-is-created
+    try:
+    - apply:
+        file: resources/actual-namespace-unlabeled.yaml
+        template: true
+  - name: then-kubearchiveconfig-is-created
+    try:
+    - delete:
+        file: resources/expected-kubearchiveconfig.yaml
+        template: true
+        expect:
+        - check:
+            ($error != null): true
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: mutate-existing-namespace-konfluxcidev
+spec:
+  description: |
+    tests that the KubeArchiveConfig is created in an already existing
+    namespace labelled with `konflux-ci.dev/type=tenant`
+  concurrent: false
+  namespace: 'generate-existing-namespace'
+  bindings:
+  - name: suffix
+    value: konflux
+  steps:
+  - name: given-kubearchiveconfig-crd-exists
+    try:
+    - apply:
+        file: resources/kubearchive-crd.yaml
+  - name: given-kyverno-has-permission-on-resources
+    try:
+    - apply:
+        file: ../kyverno-read-cluster-role.yaml
+    - apply:
+        file: ../kyverno-manage-cluster-role.yaml
+  - name: given-konfluxci-labeled-namespace-is-created
+    try:
+    - apply:
+        file: resources/actual-namespace-konfluxcidev.yaml
+        template: true
+  - name: when-cluster-policy-is-ready
+    try:
+    - apply:
+        file: ../bootstrap-namespace-cp.yaml
+    - assert:
+        file: chainsaw-assert-clusterpolicy.yaml
+  - name: then-kubearchiveconfig-is-created
+    try:
+    - assert:
+        file: resources/expected-kubearchiveconfig.yaml
+        template: true
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: mutate-existing-namespace-unlabeled
+spec:
+  description: |
+    tests that the KubeArchiveConfig is NOT created in an
+    existing unlabeled namespace
+  concurrent: false
+  namespace: 'generate-existing-namespace'
+  bindings:
+  - name: suffix
+    value: unlabeled
+  steps:
+  - name: given-kubearchiveconfig-crd-exists
+    try:
+    - apply:
+        file: resources/kubearchive-crd.yaml
+  - name: given-kyverno-has-permission-on-resources
+    try:
+    - apply:
+        file: ../kyverno-read-cluster-role.yaml
+    - apply:
+        file: ../kyverno-manage-cluster-role.yaml
+  - name: given-unlabeled-namespace-is-created
+    try:
+    - apply:
+        file: resources/actual-namespace-unlabeled.yaml
+        template: true
+  - name: when-cluster-policy-is-ready
+    try:
+    - apply:
+        file: ../bootstrap-namespace-cp.yaml
+    - assert:
+        file: chainsaw-assert-clusterpolicy.yaml
+  - name: then-kubearchiveconfig-is-created
+    try:
+    - delete:
+        file: resources/expected-kubearchiveconfig.yaml
+        template: true
+        expect:
+        - check:
+            ($error != null): true
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: mutate-existing-namespace-konfluxcidev-existing-kubearchiveconfig
+spec:
+  description: |
+    tests that the KubeArchiveConfig is not updated in an already existing
+    namespace labelled with `konflux-ci.dev/type=tenant` where the
+    KubeArchiveConfig already exists
+  concurrent: false
+  namespace: 'generate-existing-namespace'
+  bindings:
+  - name: suffix
+    value: konfluxcidev-existing-kubearchive
+  steps:
+  - name: given-kubearchiveconfig-crd-exists
+    try:
+    - apply:
+        file: resources/kubearchive-crd.yaml
+  - name: given-kyverno-has-permission-on-resources
+    try:
+    - apply:
+        file: ../kyverno-read-cluster-role.yaml
+    - apply:
+        file: ../kyverno-manage-cluster-role.yaml
+  - name: given-konfluxcidev-labeled-namespace-is-created
+    try:
+    - apply:
+        file: resources/actual-namespace-konfluxcidev.yaml
+        template: true
+  - name: given-kubearchiveconfig-is-created
+    try:
+    - apply:
+        file: resources/actual-kubeconfig-archive.yaml
+        template: true
+  - name: when-cluster-policy-is-ready
+    try:
+    - apply:
+        file: ../bootstrap-namespace-cp.yaml
+    - assert:
+        file: chainsaw-assert-clusterpolicy.yaml
+  - name: then-kubearchiveconfig-is-not-changed
+    try:
+    - assert:
+        file: resources/actual-kubeconfig-archive.yaml
+        template: true
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: orphan-resource-on-policy-deletion
+spec:
+  description: |
+    tests that the KubeArchiveConfig remains when the cluster policy is deleted
+  concurrent: false
+  namespace: 'orphan-resources'
+  bindings:
+  - name: suffix
+    value: orphan
+  steps:
+  - name: given-kubearchiveconfig-crd-exists
+    try:
+    - apply:
+        file: resources/kubearchive-crd.yaml
+  - name: given-kyverno-has-permission-on-resources
+    try:
+    - apply:
+        file: ../kyverno-read-cluster-role.yaml
+    - apply:
+        file: ../kyverno-manage-cluster-role.yaml
+  - name: given-cluster-policy-is-ready
+    try:
+    - apply:
+        file: ../bootstrap-namespace-cp.yaml
+    - assert:
+        file: chainsaw-assert-clusterpolicy.yaml
+  - name: when-konfluxcidev-labeled-namespace-is-created
+    try:
+    - apply:
+        file: resources/actual-namespace-konfluxcidev.yaml
+        template: true
+  - name: then-kubearchiveconfig-is-created
+    try:
+    - assert:
+        file: resources/expected-kubearchiveconfig.yaml
+        template: true
+  - name: when-cluster-policy-is-deleted
+    try:
+    - delete:
+        file: ../bootstrap-namespace-cp.yaml
+    - wait:
+        apiVersion: kyverno.io/v1
+        kind: ClusterPolicy
+        name: init-ns-kubearchiveconfig
+        for:
+          deletion: {}
+    - script:
+        content: |
+          while true; do
+            if [ "$(kubectl get updaterequests -n konflux-kyverno -o yaml | yq '.items | length')" -eq 0 ]; then
+              exit 0
+            fi
+            sleep 1
+          done
+        timeout: 30s
+  - name: then-kubearchiveconfig-remains
+    try:
+    - assert:
+        file: resources/expected-kubearchiveconfig.yaml
+        template: true

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/kubearchive/bootstrap-namespace/.chainsaw-test/resources/actual-kubeconfig-archive.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/kubearchive/bootstrap-namespace/.chainsaw-test/resources/actual-kubeconfig-archive.yaml
@@ -1,0 +1,11 @@
+apiVersion: kubearchive.org/v1
+kind: KubeArchiveConfig
+metadata:
+  name: kubearchive
+  namespace: (join('-', [$namespace, $suffix]))
+spec:
+  resources:
+    - selector:
+        apiVersion: v1
+        kind: Pod
+      archiveOnDelete: "true"

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/kubearchive/bootstrap-namespace/.chainsaw-test/resources/actual-namespace-konfluxcidev.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/kubearchive/bootstrap-namespace/.chainsaw-test/resources/actual-namespace-konfluxcidev.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: (join('-', [$namespace, $suffix]))
+  labels:
+    konflux-ci.dev/type: tenant

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/kubearchive/bootstrap-namespace/.chainsaw-test/resources/actual-namespace-unlabeled.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/kubearchive/bootstrap-namespace/.chainsaw-test/resources/actual-namespace-unlabeled.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: (join('-', [$namespace, $suffix]))

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/kubearchive/bootstrap-namespace/.chainsaw-test/resources/expected-kubearchiveconfig.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/kubearchive/bootstrap-namespace/.chainsaw-test/resources/expected-kubearchiveconfig.yaml
@@ -1,0 +1,7 @@
+apiVersion: kubearchive.org/v1
+kind: KubeArchiveConfig
+metadata:
+  name: kubearchive
+  namespace: (join('-', [$namespace, $suffix]))
+spec:
+  resources: []

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/kubearchive/bootstrap-namespace/.chainsaw-test/resources/kubearchive-crd.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/kubearchive/bootstrap-namespace/.chainsaw-test/resources/kubearchive-crd.yaml
@@ -1,0 +1,138 @@
+# Source: kubearchive-helm/crds/kubearchive.kubearchive.org_kubearchiveconfigs.yaml
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+    cert-manager.io/inject-ca-from: kubearchive/kubearchive-operator-certificate
+  name: kubearchiveconfigs.kubearchive.org
+spec:
+  group: kubearchive.org
+  names:
+    kind: KubeArchiveConfig
+    listKind: KubeArchiveConfigList
+    plural: kubearchiveconfigs
+    shortNames:
+      - kac
+      - kacs
+    singular: kubearchiveconfig
+  scope: Namespaced
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: KubeArchiveConfig is the Schema for the kubearchiveconfigs API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: KubeArchiveConfigSpec defines the desired state of KubeArchiveConfig
+              properties:
+                resources:
+                  items:
+                    properties:
+                      archiveOnDelete:
+                        type: string
+                      archiveWhen:
+                        type: string
+                      deleteWhen:
+                        type: string
+                      selector:
+                        description: APIVersionKindSelector is an APIVersion Kind tuple with a LabelSelector.
+                        properties:
+                          apiVersion:
+                            description: APIVersion - the API version of the resource to watch.
+                            type: string
+                          kind:
+                            description: |-
+                              Kind of the resource to watch.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                            type: string
+                          selector:
+                            description: |-
+                              LabelSelector filters this source to objects to those resources pass the
+                              label selector.
+                              More info: http://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                items:
+                                  description: |-
+                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector applies to.
+                                      type: string
+                                    operator:
+                                      description: |-
+                                        operator represents a key's relationship to a set of values.
+                                        Valid operators are In, NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: |-
+                                        values is an array of string values. If the operator is In or NotIn,
+                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                        the values array must be empty. This array is replaced during a strategic
+                                        merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  required:
+                                    - key
+                                    - operator
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                type: object
+                            type: object
+                            x-kubernetes-map-type: atomic
+                        required:
+                          - apiVersion
+                          - kind
+                        type: object
+                    type: object
+                  type: array
+              type: object
+            status:
+              description: KubeArchiveConfigStatus defines the observed state of KubeArchiveConfig
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          namespace: kubearchive
+          name: webhook-service
+          path: /convert
+      conversionReviewVersions:
+        - v1

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/kubearchive/bootstrap-namespace/.kyverno-test/kyverno-test.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/kubearchive/bootstrap-namespace/.kyverno-test/kyverno-test.yaml
@@ -1,0 +1,16 @@
+apiVersion: cli.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: bootstrap-existing-namespaces
+policies:
+- ../bootstrap-namespace-cp.yaml
+resources:
+- ../resources/labeled-namespace-konflux.yaml
+results:
+- policy: init-ns-kubearchiveconfig
+  generatedResource: ../resources/expected-kubearchiveconfig-konflux.yaml
+  kind: Namespace
+  resources:
+  - labeled-namespace-konflux
+  result: pass
+  rule: init-ns-kubearchiveconfig

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/kubearchive/bootstrap-namespace/bootstrap-namespace-cp.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/kubearchive/bootstrap-namespace/bootstrap-namespace-cp.yaml
@@ -1,0 +1,27 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: init-ns-kubearchiveconfig
+spec:
+  rules:
+  - name: init-ns-kubearchiveconfig
+    skipBackgroundRequests: true
+    match:
+      any:
+      - resources:
+          kinds:
+          - Namespace
+          selector:
+            matchLabels:
+              konflux-ci.dev/type: tenant
+    generate:
+      generateExisting: true
+      orphanDownstreamOnPolicyDelete: true
+      apiVersion: kubearchive.org/v1
+      kind: KubeArchiveConfig
+      name: kubearchive
+      namespace: '{{request.object.metadata.name}}'
+      synchronize: false
+      data:
+        spec:
+          resources: []

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/kubearchive/bootstrap-namespace/kustomization.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/kubearchive/bootstrap-namespace/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- bootstrap-namespace-cp.yaml
+- kyverno-read-cluster-role.yaml
+- kyverno-manage-cluster-role.yaml

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/kubearchive/bootstrap-namespace/kyverno-manage-cluster-role.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/kubearchive/bootstrap-namespace/kyverno-manage-cluster-role.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kyverno-manage-kubearchiveconfig
+  labels:
+    rbac.kyverno.io/aggregate-to-background-controller: "true"
+rules:
+- apiGroups:
+  - kubearchive.org
+  resources:
+  - kubearchiveconfigs
+  verbs:
+  - create
+  - get
+  - list
+  - delete
+  - update

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/kubearchive/bootstrap-namespace/kyverno-read-cluster-role.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/kubearchive/bootstrap-namespace/kyverno-read-cluster-role.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kyverno-read-kubearchiveconfig
+  labels:
+    rbac.kyverno.io/aggregate-to-admission-controller: "true"
+rules:
+- apiGroups:
+  - kubearchive.org
+  resources:
+  - kubearchiveconfigs
+  verbs:
+  - list
+  - get

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/kubearchive/bootstrap-namespace/resources/expected-kubearchiveconfig-konflux.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/kubearchive/bootstrap-namespace/resources/expected-kubearchiveconfig-konflux.yaml
@@ -1,0 +1,7 @@
+apiVersion: kubearchive.org/v1
+kind: KubeArchiveConfig
+metadata:
+  name: kubearchive
+  namespace: labeled-namespace-konflux
+spec:
+  resources: []

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/kubearchive/bootstrap-namespace/resources/labeled-namespace-konflux.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/kubearchive/bootstrap-namespace/resources/labeled-namespace-konflux.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: labeled-namespace-konflux
+  labels:
+    konflux-ci.dev/type: tenant

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/kubearchive/kustomization.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/kubearchive/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- bootstrap-namespace

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/kueue/deny-on-validation-error/.chainsaw-test/chainsaw-assert-pipelineruns-crd.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/kueue/deny-on-validation-error/.chainsaw-test/chainsaw-assert-pipelineruns-crd.yaml
@@ -1,0 +1,7 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: pipelineruns.tekton.dev
+status:
+  acceptedNames:
+    kind: PipelineRun

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/kueue/deny-on-validation-error/.chainsaw-test/chainsaw-assert-policy.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/kueue/deny-on-validation-error/.chainsaw-test/chainsaw-assert-policy.yaml
@@ -1,0 +1,7 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: deny-on-validation-error.kueue.konflux-ci.dev
+status:
+  observedGeneration: 1
+  typeChecking: {}

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/kueue/deny-on-validation-error/.chainsaw-test/resources/pipelinerun_with_custom_validation_error.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/kueue/deny-on-validation-error/.chainsaw-test/resources/pipelinerun_with_custom_validation_error.yaml
@@ -1,0 +1,6 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  name: pipelinerun-with-validation-error
+  annotations:
+    kueue.konflux-ci.dev/validation-error: "custom error"

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/kueue/deny-on-validation-error/.chainsaw-test/resources/pipelinerun_with_validation_error.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/kueue/deny-on-validation-error/.chainsaw-test/resources/pipelinerun_with_validation_error.yaml
@@ -1,0 +1,12 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  name: pipelinerun-with-validation-error
+  annotations:
+    kueue.konflux-ci.dev/validation-error: "build-platforms parameter must be an array of platform strings, got a non-array value"
+spec:
+  pipelineRef:
+    name: build-pipeline
+  params:
+    - name: build-platforms
+      value: "linux/amd64"

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/kueue/deny-on-validation-error/.chainsaw-test/resources/pipelinerun_without_validation_error.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/kueue/deny-on-validation-error/.chainsaw-test/resources/pipelinerun_without_validation_error.yaml
@@ -1,0 +1,12 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  name: pipelinerun-without-validation-error
+spec:
+  pipelineRef:
+    name: build-pipeline
+  params:
+    - name: build-platforms
+      value:
+        - "linux/amd64"
+        - "linux/arm64"

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/kueue/deny-on-validation-error/.chainsaw-test/resources/pipelineruns.tekton.dev_customresourcedefinition.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/kueue/deny-on-validation-error/.chainsaw-test/resources/pipelineruns.tekton.dev_customresourcedefinition.yaml
@@ -1,0 +1,21 @@
+# Minimal PipelineRun CRD for chainsaw tests (VAP exercises tekton.dev/v1).
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: pipelineruns.tekton.dev
+spec:
+  group: tekton.dev
+  names:
+    kind: PipelineRun
+    listKind: PipelineRunList
+    plural: pipelineruns
+    singular: pipelinerun
+  scope: Namespaced
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        x-kubernetes-preserve-unknown-fields: true

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/kueue/deny-on-validation-error/.chainsaw-test/test-in-tenant/chainsaw-test.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/kueue/deny-on-validation-error/.chainsaw-test/test-in-tenant/chainsaw-test.yaml
@@ -1,0 +1,92 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: in-tenant-deny-pipelinerun-with-validation-error
+spec:
+  description: |
+    denies a PipelineRun that has the tekton-kueue validation-error
+    annotation in a tenant namespace
+  concurrent: false
+  steps:
+  - name: given-pipelineruns-crd-exists
+    try:
+    - apply:
+        file: ../resources/pipelineruns.tekton.dev_customresourcedefinition.yaml
+    - assert:
+        file: ../chainsaw-assert-pipelineruns-crd.yaml
+  - name: ensure-namespace-is-labeled
+    try:
+    - apply:
+        resource:
+          apiVersion: v1
+          kind: Namespace
+          metadata:
+            name: ($namespace)
+            labels:
+              konflux-ci.dev/type: tenant
+  - name: given-validatingadmissionpolicy-is-installed
+    try:
+    - apply:
+        file: ../../deny-on-validation-error-validatingadmissionpolicy.yaml
+    - apply:
+        file: ../../deny-on-validation-error-validatingadmissionpolicybinding.yaml
+    - assert:
+        file: ../chainsaw-assert-policy.yaml
+  - name: then-pipelinerun-with-validation-error-is-denied
+    try:
+    - create:
+        file: ../resources/pipelinerun_with_validation_error.yaml
+        expect:
+          - check:
+              ($error != null): true
+              ($error): |-
+                pipelineruns.tekton.dev "pipelinerun-with-validation-error" is forbidden: ValidatingAdmissionPolicy 'deny-on-validation-error.kueue.konflux-ci.dev' with binding 'deny-on-validation-error.kueue.konflux-ci.dev' denied request: PipelineRun validation failed: build-platforms parameter must be an array of platform strings, got a non-array value
+    - create:
+        file: ../resources/pipelinerun_with_custom_validation_error.yaml
+        expect:
+          - check:
+              ($error != null): true
+              ($error): |-
+                pipelineruns.tekton.dev "pipelinerun-with-validation-error" is forbidden: ValidatingAdmissionPolicy 'deny-on-validation-error.kueue.konflux-ci.dev' with binding 'deny-on-validation-error.kueue.konflux-ci.dev' denied request: PipelineRun validation failed: custom error
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: in-tenant-allow-pipelinerun-without-validation-error
+spec:
+  description: |
+    allows a PipelineRun that does not have the tekton-kueue
+    validation-error annotation in a tenant namespace
+  concurrent: false
+  steps:
+  - name: given-pipelineruns-crd-exists
+    try:
+    - apply:
+        file: ../resources/pipelineruns.tekton.dev_customresourcedefinition.yaml
+    - assert:
+        file: ../chainsaw-assert-pipelineruns-crd.yaml
+  - name: ensure-namespace-is-labeled
+    try:
+    - apply:
+        resource:
+          apiVersion: v1
+          kind: Namespace
+          metadata:
+            name: ($namespace)
+            labels:
+              konflux-ci.dev/type: tenant
+  - name: given-validatingadmissionpolicy-is-installed
+    try:
+    - apply:
+        file: ../../deny-on-validation-error-validatingadmissionpolicy.yaml
+    - apply:
+        file: ../../deny-on-validation-error-validatingadmissionpolicybinding.yaml
+    - assert:
+        file: ../chainsaw-assert-policy.yaml
+  - name: then-pipelinerun-without-validation-error-is-allowed
+    try:
+    - create:
+        file: ../resources/pipelinerun_without_validation_error.yaml

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/kueue/deny-on-validation-error/.chainsaw-test/test-outside-tenant/chainsaw-test.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/kueue/deny-on-validation-error/.chainsaw-test/test-outside-tenant/chainsaw-test.yaml
@@ -1,0 +1,60 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: outside-tenant-allow-pipelinerun-with-validation-error
+spec:
+  description: |
+    allows a PipelineRun that has the tekton-kueue validation-error
+    annotation in a non-tenant namespace
+  concurrent: false
+  steps:
+  - name: given-pipelineruns-crd-exists
+    try:
+    - apply:
+        file: ../resources/pipelineruns.tekton.dev_customresourcedefinition.yaml
+    - assert:
+        file: ../chainsaw-assert-pipelineruns-crd.yaml
+  - name: given-validatingadmissionpolicy-is-installed
+    try:
+    - apply:
+        file: ../../deny-on-validation-error-validatingadmissionpolicy.yaml
+    - apply:
+        file: ../../deny-on-validation-error-validatingadmissionpolicybinding.yaml
+    - assert:
+        file: ../chainsaw-assert-policy.yaml
+  - name: then-pipelinerun-with-validation-error-is-allowed
+    try:
+    - create:
+        file: ../resources/pipelinerun_with_validation_error.yaml
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: outside-tenant-allow-pipelinerun-without-validation-error
+spec:
+  description: |
+    allows a PipelineRun that does not have the tekton-kueue
+    validation-error annotation in a non-tenant namespace
+  concurrent: false
+  steps:
+  - name: given-pipelineruns-crd-exists
+    try:
+    - apply:
+        file: ../resources/pipelineruns.tekton.dev_customresourcedefinition.yaml
+    - assert:
+        file: ../chainsaw-assert-pipelineruns-crd.yaml
+  - name: given-validatingadmissionpolicy-is-installed
+    try:
+    - apply:
+        file: ../../deny-on-validation-error-validatingadmissionpolicy.yaml
+    - apply:
+        file: ../../deny-on-validation-error-validatingadmissionpolicybinding.yaml
+    - assert:
+        file: ../chainsaw-assert-policy.yaml
+  - name: then-pipelinerun-without-validation-error-is-allowed
+    try:
+    - create:
+        file: ../resources/pipelinerun_without_validation_error.yaml

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/kueue/deny-on-validation-error/deny-on-validation-error-validatingadmissionpolicy.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/kueue/deny-on-validation-error/deny-on-validation-error-validatingadmissionpolicy.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: deny-on-validation-error.kueue.konflux-ci.dev
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+      - apiGroups: ["tekton.dev"]
+        apiVersions: ["v1"]
+        operations: ["CREATE"]
+        resources: ["pipelineruns"]
+        scope: "Namespaced"
+  validations:
+    - expression: "!has(object.metadata.annotations) || !('kueue.konflux-ci.dev/validation-error' in object.metadata.annotations)"
+      messageExpression: |-
+        "PipelineRun validation failed: " + string(object.metadata.annotations["kueue.konflux-ci.dev/validation-error"])
+      message: "PipelineRun validation failed, inspect the 'kueue.konflux-ci.dev/validation-error' annotation for more info"

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/kueue/deny-on-validation-error/deny-on-validation-error-validatingadmissionpolicybinding.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/kueue/deny-on-validation-error/deny-on-validation-error-validatingadmissionpolicybinding.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: deny-on-validation-error.kueue.konflux-ci.dev
+spec:
+  policyName: "deny-on-validation-error.kueue.konflux-ci.dev"
+  validationActions: [Deny]
+  matchResources:
+    namespaceSelector:
+      matchLabels:
+        konflux-ci.dev/type: tenant

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/kueue/deny-on-validation-error/kustomization.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/kueue/deny-on-validation-error/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- deny-on-validation-error-validatingadmissionpolicy.yaml
+- deny-on-validation-error-validatingadmissionpolicybinding.yaml

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/kueue/kustomization.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/kueue/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- queue-config
+- deny-on-validation-error
+
+namespace: konflux-policies

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/kueue/queue-config/.chainsaw-test/README.md
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/kueue/queue-config/.chainsaw-test/README.md
@@ -1,0 +1,1008 @@
+# Test: `kueue-bootstrap-queue-new-tenant-labeled-namespace`
+
+Tests that a LocalQueue is created in a namespace labeled with
+`konflux-ci.dev/type=tenant` and no `kueue.konflux-ci.dev/stop-policy`
+annotation.
+
+
+## Bindings
+
+| # | Name | Value |
+|:-:|---|---|
+| 1 | `suffix` | "labeled" |
+
+## Steps
+
+| # | Name | Bindings | Try | Catch | Finally | Cleanup |
+|:-:|---|:-:|:-:|:-:|:-:|:-:|
+| 1 | [given-localqueue-crd-exists](#step-given-localqueue-crd-exists) | 0 | 1 | 0 | 0 | 0 |
+| 2 | [given-kyverno-has-permission-on-resources](#step-given-kyverno-has-permission-on-resources) | 0 | 1 | 0 | 0 | 0 |
+| 3 | [given-cluster-policy-is-ready](#step-given-cluster-policy-is-ready) | 0 | 2 | 0 | 0 | 0 |
+| 4 | [when-tenant-labeled-namespace-is-created](#step-when-tenant-labeled-namespace-is-created) | 0 | 1 | 0 | 0 | 0 |
+| 5 | [then-localqueue-is-created](#step-then-localqueue-is-created) | 0 | 1 | 0 | 0 | 0 |
+
+### Step: `given-localqueue-crd-exists`
+
+Install the Kueue LocalQueue CRD so the API server accepts LocalQueue objects in the test cluster.
+
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `given-kyverno-has-permission-on-resources`
+
+Apply Kyverno RBAC so the policy engine can generate and reconcile LocalQueue resources.
+
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `given-cluster-policy-is-ready`
+
+Apply the queue bootstrap ClusterPolicy and assert Kyverno reports the policy as ready before exercising generation.
+
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+| 2 | `assert` | 0 | 0 | *No description* |
+
+### Step: `when-tenant-labeled-namespace-is-created`
+
+Create a namespace labeled konflux-ci.dev/type=tenant so the policy should generate a LocalQueue.
+
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `then-localqueue-is-created`
+
+Assert the expected pipelines-queue LocalQueue exists and matches the fixture (name and spec).
+
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `assert` | 0 | 0 | *No description* |
+
+---
+
+# Test: `kueue-bootstrap-queue-new-tenant-labeled-namespace-unpaused`
+
+Tests that a LocalQueue is created in a namespace labeled with
+`konflux-ci.dev/type=tenant` and the `kueue.konflux-ci.dev/stop-policy`
+annotation set to a value different from `hold`.
+
+
+## Bindings
+
+| # | Name | Value |
+|:-:|---|---|
+| 1 | `suffix` | "labeled-unpaused" |
+
+## Steps
+
+| # | Name | Bindings | Try | Catch | Finally | Cleanup |
+|:-:|---|:-:|:-:|:-:|:-:|:-:|
+| 1 | [given-localqueue-crd-exists](#step-given-localqueue-crd-exists) | 0 | 1 | 0 | 0 | 0 |
+| 2 | [given-kyverno-has-permission-on-resources](#step-given-kyverno-has-permission-on-resources) | 0 | 1 | 0 | 0 | 0 |
+| 3 | [given-cluster-policy-is-ready](#step-given-cluster-policy-is-ready) | 0 | 2 | 0 | 0 | 0 |
+| 4 | [when-tenant-labeled-namespace-is-created](#step-when-tenant-labeled-namespace-is-created) | 0 | 1 | 0 | 0 | 0 |
+| 5 | [then-localqueue-is-created](#step-then-localqueue-is-created) | 0 | 1 | 0 | 0 | 0 |
+
+### Step: `given-localqueue-crd-exists`
+
+Install the Kueue LocalQueue CRD so the API server accepts LocalQueue objects in the test cluster.
+
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `given-kyverno-has-permission-on-resources`
+
+Apply Kyverno RBAC so the policy engine can generate and reconcile LocalQueue resources.
+
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `given-cluster-policy-is-ready`
+
+Apply the queue bootstrap ClusterPolicy and assert Kyverno reports the policy as ready before exercising generation.
+
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+| 2 | `assert` | 0 | 0 | *No description* |
+
+### Step: `when-tenant-labeled-namespace-is-created`
+
+Create a namespace labeled konflux-ci.dev/type=tenant so the policy should generate a LocalQueue.
+
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `then-localqueue-is-created`
+
+Assert the expected pipelines-queue LocalQueue exists and matches the fixture (name and spec).
+
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `assert` | 0 | 0 | *No description* |
+
+---
+
+# Test: `kueue-bootstrap-queue-new-tenant-labeled-paused-namespace-resumed`
+
+Tests that a LocalQueue with `stopPolicy` set to `Hold` is created
+in a namespace labeled with `konflux-ci.dev/type=tenant` with the
+`kueue.konflux-ci.dev/stop-policy` annotation set to `hold`. The
+`stopPolicy` is then set to `None` when the annotation is removed
+from the namespace.
+
+
+## Bindings
+
+| # | Name | Value |
+|:-:|---|---|
+| 1 | `suffix` | "labeled-paused-unpaused" |
+
+## Steps
+
+| # | Name | Bindings | Try | Catch | Finally | Cleanup |
+|:-:|---|:-:|:-:|:-:|:-:|:-:|
+| 1 | [given-localqueue-crd-exists](#step-given-localqueue-crd-exists) | 0 | 1 | 0 | 0 | 0 |
+| 2 | [given-kyverno-has-permission-on-resources](#step-given-kyverno-has-permission-on-resources) | 0 | 1 | 0 | 0 | 0 |
+| 3 | [given-cluster-policy-is-ready](#step-given-cluster-policy-is-ready) | 0 | 2 | 0 | 0 | 0 |
+| 4 | [when-tenant-labeled-namespace-is-created-paused](#step-when-tenant-labeled-namespace-is-created-paused) | 0 | 1 | 0 | 0 | 0 |
+| 5 | [then-localqueue-is-created-paused](#step-then-localqueue-is-created-paused) | 0 | 1 | 0 | 0 | 0 |
+| 6 | [when-tenant-labeled-namespace-is-updated-to-unpause](#step-when-tenant-labeled-namespace-is-updated-to-unpause) | 0 | 1 | 0 | 0 | 0 |
+| 7 | [then-localqueue-is-unpaused](#step-then-localqueue-is-unpaused) | 0 | 1 | 0 | 0 | 0 |
+
+### Step: `given-localqueue-crd-exists`
+
+Install the Kueue LocalQueue CRD so the API server accepts LocalQueue objects in the test cluster.
+
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `given-kyverno-has-permission-on-resources`
+
+Apply Kyverno RBAC so the policy engine can generate and reconcile LocalQueue resources.
+
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `given-cluster-policy-is-ready`
+
+Apply the queue bootstrap ClusterPolicy and assert Kyverno reports the policy as ready before exercising generation.
+
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+| 2 | `assert` | 0 | 0 | *No description* |
+
+### Step: `when-tenant-labeled-namespace-is-created-paused`
+
+update a namespace labeled konflux-ci.dev/type=tenant so the policy should generate a LocalQueue.
+
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `then-localqueue-is-created-paused`
+
+Assert the expected pipelines-queue LocalQueue exists and matches the fixture (name and spec).
+
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `assert` | 0 | 0 | *No description* |
+
+### Step: `when-tenant-labeled-namespace-is-updated-to-unpause`
+
+Update the namespace to unpause it
+
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `update` | 0 | 0 | *No description* |
+
+### Step: `then-localqueue-is-unpaused`
+
+Assert the LocalQueue's StopPolicy is None
+
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `assert` | 0 | 0 | *No description* |
+
+---
+
+# Test: `kueue-bootstrap-queue-new-tenant-labeled-namespace-update-paused`
+
+Tests that a LocalQueue with `stopPolicy` set to `None` is created
+in a namespace labeled with `konflux-ci.dev/type=tenant` with no
+`kueue.konflux-ci.dev/stop-policy` annotation set. The `stopPolicy`
+is then set to `Hold` when the annotation is added to the namespace.
+
+
+## Bindings
+
+| # | Name | Value |
+|:-:|---|---|
+| 1 | `suffix` | "labeled-unpaused-paused" |
+
+## Steps
+
+| # | Name | Bindings | Try | Catch | Finally | Cleanup |
+|:-:|---|:-:|:-:|:-:|:-:|:-:|
+| 1 | [given-localqueue-crd-exists](#step-given-localqueue-crd-exists) | 0 | 1 | 0 | 0 | 0 |
+| 2 | [given-kyverno-has-permission-on-resources](#step-given-kyverno-has-permission-on-resources) | 0 | 1 | 0 | 0 | 0 |
+| 3 | [given-cluster-policy-is-ready](#step-given-cluster-policy-is-ready) | 0 | 2 | 0 | 0 | 0 |
+| 4 | [when-tenant-labeled-namespace-is-created](#step-when-tenant-labeled-namespace-is-created) | 0 | 1 | 0 | 0 | 0 |
+| 5 | [then-localqueue-is-created](#step-then-localqueue-is-created) | 0 | 1 | 0 | 0 | 0 |
+| 6 | [when-tenant-labeled-namespace-is-updated](#step-when-tenant-labeled-namespace-is-updated) | 0 | 1 | 0 | 0 | 0 |
+| 7 | [then-localqueue-is-updated](#step-then-localqueue-is-updated) | 0 | 1 | 0 | 0 | 0 |
+
+### Step: `given-localqueue-crd-exists`
+
+Install the Kueue LocalQueue CRD so the API server accepts LocalQueue objects in the test cluster.
+
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `given-kyverno-has-permission-on-resources`
+
+Apply Kyverno RBAC so the policy engine can generate and reconcile LocalQueue resources.
+
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `given-cluster-policy-is-ready`
+
+Apply the queue bootstrap ClusterPolicy and assert Kyverno reports the policy as ready before exercising generation.
+
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+| 2 | `assert` | 0 | 0 | *No description* |
+
+### Step: `when-tenant-labeled-namespace-is-created`
+
+Create a namespace labeled konflux-ci.dev/type=tenant so the policy should generate a LocalQueue.
+
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `then-localqueue-is-created`
+
+Assert the expected pipelines-queue LocalQueue exists and matches the fixture (name and spec).
+
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `assert` | 0 | 0 | *No description* |
+
+### Step: `when-tenant-labeled-namespace-is-updated`
+
+update a namespace labeled konflux-ci.dev/type=tenant so the policy should generate a LocalQueue.
+
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `then-localqueue-is-updated`
+
+Assert the expected pipelines-queue LocalQueue exists and matches the fixture (name and spec).
+
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `assert` | 0 | 0 | *No description* |
+
+---
+
+# Test: `kueue-bootstrap-queue-new-tenant-labeled-namespace-paused`
+
+Tests that a LocalQueue is created in a namespace labeled with
+`konflux-ci.dev/type=tenant` and with annotation to pause the
+LocalQueue.
+
+
+## Bindings
+
+| # | Name | Value |
+|:-:|---|---|
+| 1 | `suffix` | "labeled" |
+
+## Steps
+
+| # | Name | Bindings | Try | Catch | Finally | Cleanup |
+|:-:|---|:-:|:-:|:-:|:-:|:-:|
+| 1 | [given-localqueue-crd-exists](#step-given-localqueue-crd-exists) | 0 | 1 | 0 | 0 | 0 |
+| 2 | [given-kyverno-has-permission-on-resources](#step-given-kyverno-has-permission-on-resources) | 0 | 1 | 0 | 0 | 0 |
+| 3 | [given-cluster-policy-is-ready](#step-given-cluster-policy-is-ready) | 0 | 2 | 0 | 0 | 0 |
+| 4 | [when-tenant-labeled-namespace-is-created](#step-when-tenant-labeled-namespace-is-created) | 0 | 1 | 0 | 0 | 0 |
+| 5 | [then-localqueue-is-created](#step-then-localqueue-is-created) | 0 | 1 | 0 | 0 | 0 |
+
+### Step: `given-localqueue-crd-exists`
+
+Install the Kueue LocalQueue CRD so the API server accepts LocalQueue objects in the test cluster.
+
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `given-kyverno-has-permission-on-resources`
+
+Apply Kyverno RBAC so the policy engine can generate and reconcile LocalQueue resources.
+
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `given-cluster-policy-is-ready`
+
+Apply the queue bootstrap ClusterPolicy and assert Kyverno reports the policy as ready before exercising generation.
+
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+| 2 | `assert` | 0 | 0 | *No description* |
+
+### Step: `when-tenant-labeled-namespace-is-created`
+
+Create a namespace labeled konflux-ci.dev/type=tenant so the policy should generate a LocalQueue.
+
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `then-localqueue-is-created`
+
+Assert the expected pipelines-queue LocalQueue exists and matches the fixture (name and spec).
+
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `assert` | 0 | 0 | *No description* |
+
+---
+
+# Test: `kueue-bootstrap-queue-unlabeled-namespace-negative`
+
+Tests that a LocalQueue is NOT created in an unlabeled namespace
+that does not match the special names.
+
+
+## Bindings
+
+| # | Name | Value |
+|:-:|---|---|
+| 1 | `suffix` | "unlabeled" |
+
+## Steps
+
+| # | Name | Bindings | Try | Catch | Finally | Cleanup |
+|:-:|---|:-:|:-:|:-:|:-:|:-:|
+| 1 | [given-localqueue-crd-exists](#step-given-localqueue-crd-exists) | 0 | 1 | 0 | 0 | 0 |
+| 2 | [given-kyverno-has-permission-on-resources](#step-given-kyverno-has-permission-on-resources) | 0 | 1 | 0 | 0 | 0 |
+| 3 | [given-cluster-policy-is-ready](#step-given-cluster-policy-is-ready) | 0 | 2 | 0 | 0 | 0 |
+| 4 | [when-unlabeled-namespace-is-created](#step-when-unlabeled-namespace-is-created) | 0 | 1 | 0 | 0 | 0 |
+| 5 | [then-localqueue-is-not-created](#step-then-localqueue-is-not-created) | 0 | 3 | 0 | 0 | 0 |
+
+### Step: `given-localqueue-crd-exists`
+
+Install the Kueue LocalQueue CRD so the API server accepts LocalQueue objects in the test cluster.
+
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `given-kyverno-has-permission-on-resources`
+
+Apply Kyverno RBAC so the policy engine can generate and reconcile LocalQueue resources.
+
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `given-cluster-policy-is-ready`
+
+Apply the queue bootstrap ClusterPolicy and assert Kyverno reports the policy as ready before exercising generation.
+
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+| 2 | `assert` | 0 | 0 | *No description* |
+
+### Step: `when-unlabeled-namespace-is-created`
+
+Create a namespace without the tenant label and without a special name so generation must not run.
+
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `then-localqueue-is-not-created`
+
+Confirm pipelines-queue LocalQueue is absent (NotFound) and stays absent after a short wait.
+
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `script` | 0 | 0 | *No description* |
+| 2 | `sleep` | 0 | 0 | *No description* |
+| 3 | `script` | 0 | 0 | *No description* |
+
+---
+
+# Test: `kueue-bootstrap-queue-label-added-to-namespace`
+
+Tests that a LocalQueue is created when an unlabeled namespace is
+updated to have the label `konflux-ci.dev/type=tenant`.
+
+
+## Bindings
+
+| # | Name | Value |
+|:-:|---|---|
+| 1 | `suffix` | "updated-labeled" |
+
+## Steps
+
+| # | Name | Bindings | Try | Catch | Finally | Cleanup |
+|:-:|---|:-:|:-:|:-:|:-:|:-:|
+| 1 | [given-localqueue-crd-exists](#step-given-localqueue-crd-exists) | 0 | 1 | 0 | 0 | 0 |
+| 2 | [given-kyverno-has-permission-on-resources](#step-given-kyverno-has-permission-on-resources) | 0 | 1 | 0 | 0 | 0 |
+| 3 | [given-cluster-policy-is-ready](#step-given-cluster-policy-is-ready) | 0 | 2 | 0 | 0 | 0 |
+| 4 | [given-unlabeled-namespace-exists](#step-given-unlabeled-namespace-exists) | 0 | 1 | 0 | 0 | 0 |
+| 5 | [when-tenant-label-is-added](#step-when-tenant-label-is-added) | 0 | 1 | 0 | 0 | 0 |
+| 6 | [then-localqueue-is-created](#step-then-localqueue-is-created) | 0 | 1 | 0 | 0 | 0 |
+
+### Step: `given-localqueue-crd-exists`
+
+Install the Kueue LocalQueue CRD so the API server accepts LocalQueue objects in the test cluster.
+
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `given-kyverno-has-permission-on-resources`
+
+Apply Kyverno RBAC so the policy engine can generate and reconcile LocalQueue resources.
+
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `given-cluster-policy-is-ready`
+
+Apply the queue bootstrap ClusterPolicy and assert Kyverno reports the policy as ready before exercising generation.
+
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+| 2 | `assert` | 0 | 0 | *No description* |
+
+### Step: `given-unlabeled-namespace-exists`
+
+Create an unlabeled namespace first so a later label update can trigger the policy on change.
+
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `when-tenant-label-is-added`
+
+Apply the tenant-labeled namespace manifest so konflux-ci.dev/type=tenant is set on the existing namespace.
+
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `then-localqueue-is-created`
+
+Assert the expected pipelines-queue LocalQueue exists and matches the fixture (name and spec).
+
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `assert` | 0 | 0 | *No description* |
+
+---
+
+# Test: `kueue-bootstrap-queue-labeled-namespace-before-policy`
+
+Tests that a LocalQueue is created for an existing tenant-labeled
+namespace when the ClusterPolicy is applied (generateExisting).
+
+
+## Bindings
+
+| # | Name | Value |
+|:-:|---|---|
+| 1 | `suffix` | "labeled" |
+
+## Steps
+
+| # | Name | Bindings | Try | Catch | Finally | Cleanup |
+|:-:|---|:-:|:-:|:-:|:-:|:-:|
+| 1 | [given-localqueue-crd-exists](#step-given-localqueue-crd-exists) | 0 | 1 | 0 | 0 | 0 |
+| 2 | [given-tenant-labeled-namespace-exists](#step-given-tenant-labeled-namespace-exists) | 0 | 1 | 0 | 0 | 0 |
+| 3 | [given-kyverno-has-permission-on-resources](#step-given-kyverno-has-permission-on-resources) | 0 | 1 | 0 | 0 | 0 |
+| 4 | [when-cluster-policy-is-ready](#step-when-cluster-policy-is-ready) | 0 | 2 | 0 | 0 | 0 |
+| 5 | [then-localqueue-is-created](#step-then-localqueue-is-created) | 0 | 1 | 0 | 0 | 0 |
+
+### Step: `given-localqueue-crd-exists`
+
+Install the Kueue LocalQueue CRD so the API server accepts LocalQueue objects in the test cluster.
+
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `given-tenant-labeled-namespace-exists`
+
+Create the tenant-labeled namespace before the ClusterPolicy exists to exercise generateExisting on policy install.
+
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `given-kyverno-has-permission-on-resources`
+
+Apply Kyverno RBAC so the policy engine can generate and reconcile LocalQueue resources.
+
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `when-cluster-policy-is-ready`
+
+Apply the ClusterPolicy after the target namespace exists so generateExisting can backfill the LocalQueue.
+
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+| 2 | `assert` | 0 | 0 | *No description* |
+
+### Step: `then-localqueue-is-created`
+
+Assert the expected pipelines-queue LocalQueue exists and matches the fixture (name and spec).
+
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `assert` | 0 | 0 | *No description* |
+
+---
+
+# Test: `kueue-bootstrap-queue-mintmaker-namespace-before-policy`
+
+Tests that a LocalQueue is created for an existing `mintmaker`
+namespace when the ClusterPolicy is applied (generateExisting,
+name-based match).
+
+
+## Steps
+
+| # | Name | Bindings | Try | Catch | Finally | Cleanup |
+|:-:|---|:-:|:-:|:-:|:-:|:-:|
+| 1 | [given-localqueue-crd-exists](#step-given-localqueue-crd-exists) | 0 | 1 | 0 | 0 | 0 |
+| 2 | [given-mintmaker-namespace-exists](#step-given-mintmaker-namespace-exists) | 0 | 1 | 0 | 0 | 0 |
+| 3 | [given-kyverno-has-permission-on-resources](#step-given-kyverno-has-permission-on-resources) | 0 | 1 | 0 | 0 | 0 |
+| 4 | [when-cluster-policy-is-ready](#step-when-cluster-policy-is-ready) | 0 | 2 | 0 | 0 | 0 |
+| 5 | [then-localqueue-is-created](#step-then-localqueue-is-created) | 0 | 1 | 0 | 0 | 0 |
+
+### Step: `given-localqueue-crd-exists`
+
+Install the Kueue LocalQueue CRD so the API server accepts LocalQueue objects in the test cluster.
+
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `given-mintmaker-namespace-exists`
+
+Create the mintmaker namespace before policy install so name-based matching is satisfied for generateExisting.
+
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `given-kyverno-has-permission-on-resources`
+
+Apply Kyverno RBAC so the policy engine can generate and reconcile LocalQueue resources.
+
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `when-cluster-policy-is-ready`
+
+Apply the ClusterPolicy after the target namespace exists so generateExisting can backfill the LocalQueue.
+
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+| 2 | `assert` | 0 | 0 | *No description* |
+
+### Step: `then-localqueue-is-created`
+
+Assert the expected pipelines-queue LocalQueue exists and matches the fixture (name and spec).
+
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `assert` | 0 | 0 | *No description* |
+
+---
+
+# Test: `kueue-bootstrap-queue-kanary-namespace-before-policy`
+
+Tests that a LocalQueue is created for an existing
+`appstudio-kanary-exporter` namespace when the ClusterPolicy is
+applied (generateExisting, name-based match).
+
+
+## Steps
+
+| # | Name | Bindings | Try | Catch | Finally | Cleanup |
+|:-:|---|:-:|:-:|:-:|:-:|:-:|
+| 1 | [given-localqueue-crd-exists](#step-given-localqueue-crd-exists) | 0 | 1 | 0 | 0 | 0 |
+| 2 | [given-kanary-namespace-exists](#step-given-kanary-namespace-exists) | 0 | 1 | 0 | 0 | 0 |
+| 3 | [given-kyverno-has-permission-on-resources](#step-given-kyverno-has-permission-on-resources) | 0 | 1 | 0 | 0 | 0 |
+| 4 | [when-cluster-policy-is-ready](#step-when-cluster-policy-is-ready) | 0 | 2 | 0 | 0 | 0 |
+| 5 | [then-localqueue-is-created](#step-then-localqueue-is-created) | 0 | 1 | 0 | 0 | 0 |
+
+### Step: `given-localqueue-crd-exists`
+
+Install the Kueue LocalQueue CRD so the API server accepts LocalQueue objects in the test cluster.
+
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `given-kanary-namespace-exists`
+
+Create the appstudio-kanary-exporter namespace before policy install for name-based generateExisting.
+
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `given-kyverno-has-permission-on-resources`
+
+Apply Kyverno RBAC so the policy engine can generate and reconcile LocalQueue resources.
+
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `when-cluster-policy-is-ready`
+
+Apply the ClusterPolicy after the target namespace exists so generateExisting can backfill the LocalQueue.
+
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+| 2 | `assert` | 0 | 0 | *No description* |
+
+### Step: `then-localqueue-is-created`
+
+Assert the expected pipelines-queue LocalQueue exists and matches the fixture (name and spec).
+
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `assert` | 0 | 0 | *No description* |
+
+---
+
+# Test: `kueue-bootstrap-queue-mintmaker-by-name`
+
+Tests that a LocalQueue is created for the `mintmaker` namespace
+without the tenant label (name-based match).
+
+
+## Steps
+
+| # | Name | Bindings | Try | Catch | Finally | Cleanup |
+|:-:|---|:-:|:-:|:-:|:-:|:-:|
+| 1 | [given-localqueue-crd-exists](#step-given-localqueue-crd-exists) | 0 | 1 | 0 | 0 | 0 |
+| 2 | [given-kyverno-has-permission-on-resources](#step-given-kyverno-has-permission-on-resources) | 0 | 1 | 0 | 0 | 0 |
+| 3 | [given-cluster-policy-is-ready](#step-given-cluster-policy-is-ready) | 0 | 2 | 0 | 0 | 0 |
+| 4 | [when-mintmaker-namespace-is-created](#step-when-mintmaker-namespace-is-created) | 0 | 1 | 0 | 0 | 0 |
+| 5 | [then-localqueue-is-created](#step-then-localqueue-is-created) | 0 | 1 | 0 | 0 | 0 |
+
+### Step: `given-localqueue-crd-exists`
+
+Install the Kueue LocalQueue CRD so the API server accepts LocalQueue objects in the test cluster.
+
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `given-kyverno-has-permission-on-resources`
+
+Apply Kyverno RBAC so the policy engine can generate and reconcile LocalQueue resources.
+
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `given-cluster-policy-is-ready`
+
+Apply the queue bootstrap ClusterPolicy and assert Kyverno reports the policy as ready before exercising generation.
+
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+| 2 | `assert` | 0 | 0 | *No description* |
+
+### Step: `when-mintmaker-namespace-is-created`
+
+Create the mintmaker namespace after the policy is ready to verify name-based generation without the tenant label.
+
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `then-localqueue-is-created`
+
+Assert the expected pipelines-queue LocalQueue exists and matches the fixture (name and spec).
+
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `assert` | 0 | 0 | *No description* |
+
+---
+
+# Test: `kueue-bootstrap-queue-kanary-by-name`
+
+Tests that a LocalQueue is created for the `appstudio-kanary-exporter`
+namespace without the tenant label (name-based match).
+
+
+## Steps
+
+| # | Name | Bindings | Try | Catch | Finally | Cleanup |
+|:-:|---|:-:|:-:|:-:|:-:|:-:|
+| 1 | [given-localqueue-crd-exists](#step-given-localqueue-crd-exists) | 0 | 1 | 0 | 0 | 0 |
+| 2 | [given-kyverno-has-permission-on-resources](#step-given-kyverno-has-permission-on-resources) | 0 | 1 | 0 | 0 | 0 |
+| 3 | [given-cluster-policy-is-ready](#step-given-cluster-policy-is-ready) | 0 | 2 | 0 | 0 | 0 |
+| 4 | [when-kanary-namespace-is-created](#step-when-kanary-namespace-is-created) | 0 | 1 | 0 | 0 | 0 |
+| 5 | [then-localqueue-is-created](#step-then-localqueue-is-created) | 0 | 1 | 0 | 0 | 0 |
+
+### Step: `given-localqueue-crd-exists`
+
+Install the Kueue LocalQueue CRD so the API server accepts LocalQueue objects in the test cluster.
+
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `given-kyverno-has-permission-on-resources`
+
+Apply Kyverno RBAC so the policy engine can generate and reconcile LocalQueue resources.
+
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `given-cluster-policy-is-ready`
+
+Apply the queue bootstrap ClusterPolicy and assert Kyverno reports the policy as ready before exercising generation.
+
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+| 2 | `assert` | 0 | 0 | *No description* |
+
+### Step: `when-kanary-namespace-is-created`
+
+Create the appstudio-kanary-exporter namespace after the policy is ready to verify name-based generation.
+
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `then-localqueue-is-created`
+
+Assert the expected pipelines-queue LocalQueue exists and matches the fixture (name and spec).
+
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `assert` | 0 | 0 | *No description* |
+
+---
+

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/kueue/queue-config/.chainsaw-test/chainsaw-assert-clusterpolicy.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/kueue/queue-config/.chainsaw-test/chainsaw-assert-clusterpolicy.yaml
@@ -1,0 +1,9 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: bootstrap-tenant-namespace-queue
+status:
+  conditions:
+  - reason: Succeeded
+    status: "True"
+    type: Ready

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/kueue/queue-config/.chainsaw-test/chainsaw-test.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/kueue/queue-config/.chainsaw-test/chainsaw-test.yaml
@@ -1,0 +1,738 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: kueue-bootstrap-queue-new-tenant-labeled-namespace
+spec:
+  description: |
+    Tests that a LocalQueue is created in a namespace labeled with
+    `konflux-ci.dev/type=tenant` and no `kueue.konflux-ci.dev/stop-policy`
+    annotation.
+  concurrent: false
+  namespace: kueue-queue-new
+  bindings:
+  - name: suffix
+    value: labeled
+  steps:
+  - name: given-localqueue-crd-exists
+    description: |
+      Install the Kueue LocalQueue CRD so the API server accepts LocalQueue objects in the test cluster.
+    try:
+    - apply:
+        file: ./resources/localqueue-crd.yaml
+  - name: given-kyverno-has-permission-on-resources
+    description: |
+      Apply Kyverno RBAC so the policy engine can generate and reconcile LocalQueue resources.
+    try:
+    - apply:
+        file: ../kyverno-admission-cluster-role.yaml
+    - apply:
+        file: ../kyverno-background-cluster-role.yaml
+  - name: given-cluster-policy-is-ready
+    description: |
+      Apply the queue bootstrap ClusterPolicy and assert Kyverno reports the policy as ready before exercising generation.
+    try:
+    - apply:
+        file: ../bootstrap-tenant-namespace-queue-cp.yaml
+    - assert:
+        file: chainsaw-assert-clusterpolicy.yaml
+  - name: when-tenant-labeled-namespace-is-created
+    description: |
+      Create a namespace labeled konflux-ci.dev/type=tenant so the policy should generate a LocalQueue.
+    try:
+    - apply:
+        file: resources/namespace-tenant.yaml
+        template: true
+  - name: then-localqueue-is-created
+    description: |
+      Assert the expected pipelines-queue LocalQueue exists and matches the fixture (name and spec).
+    try:
+    - assert:
+        file: resources/expected-localqueue.yaml
+        template: true
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: kueue-bootstrap-queue-new-tenant-labeled-namespace-unpaused
+spec:
+  description: |
+    Tests that a LocalQueue is created in a namespace labeled with
+    `konflux-ci.dev/type=tenant` and the `kueue.konflux-ci.dev/stop-policy`
+    annotation set to a value different from `hold`.
+  concurrent: false
+  namespace: kueue-queue-new
+  bindings:
+  - name: suffix
+    value: labeled-unpaused
+  steps:
+  - name: given-localqueue-crd-exists
+    description: |
+      Install the Kueue LocalQueue CRD so the API server accepts LocalQueue objects in the test cluster.
+    try:
+    - apply:
+        file: ./resources/localqueue-crd.yaml
+  - name: given-kyverno-has-permission-on-resources
+    description: |
+      Apply Kyverno RBAC so the policy engine can generate and reconcile LocalQueue resources.
+    try:
+    - apply:
+        file: ../kyverno-admission-cluster-role.yaml
+    - apply:
+        file: ../kyverno-background-cluster-role.yaml
+  - name: given-cluster-policy-is-ready
+    description: |
+      Apply the queue bootstrap ClusterPolicy and assert Kyverno reports the policy as ready before exercising generation.
+    try:
+    - apply:
+        file: ../bootstrap-tenant-namespace-queue-cp.yaml
+    - assert:
+        file: chainsaw-assert-clusterpolicy.yaml
+  - name: when-tenant-labeled-namespace-is-created
+    description: |
+      Create a namespace labeled konflux-ci.dev/type=tenant so the policy should generate a LocalQueue.
+    try:
+    - apply:
+        file: resources/namespace-tenant-unpaused.yaml
+        template: true
+  - name: then-localqueue-is-created
+    description: |
+      Assert the expected pipelines-queue LocalQueue exists and matches the fixture (name and spec).
+    try:
+    - assert:
+        file: resources/expected-localqueue.yaml
+        template: true
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: kueue-bootstrap-queue-new-tenant-labeled-paused-namespace-resumed
+spec:
+  description: |
+    Tests that a LocalQueue with `stopPolicy` set to `Hold` is created
+    in a namespace labeled with `konflux-ci.dev/type=tenant` with the
+    `kueue.konflux-ci.dev/stop-policy` annotation set to `hold`. The
+    `stopPolicy` is then set to `None` when the annotation is removed
+    from the namespace.
+  concurrent: false
+  namespace: kueue-queue-new
+  bindings:
+  - name: suffix
+    value: labeled-paused-unpaused
+  steps:
+  - name: given-localqueue-crd-exists
+    description: |
+      Install the Kueue LocalQueue CRD so the API server accepts LocalQueue objects in the test cluster.
+    try:
+    - apply:
+        file: ./resources/localqueue-crd.yaml
+  - name: given-kyverno-has-permission-on-resources
+    description: |
+      Apply Kyverno RBAC so the policy engine can generate and reconcile LocalQueue resources.
+    try:
+    - apply:
+        file: ../kyverno-admission-cluster-role.yaml
+    - apply:
+        file: ../kyverno-background-cluster-role.yaml
+  - name: given-cluster-policy-is-ready
+    description: |
+      Apply the queue bootstrap ClusterPolicy and assert Kyverno reports the policy as ready before exercising generation.
+    try:
+    - apply:
+        file: ../bootstrap-tenant-namespace-queue-cp.yaml
+    - assert:
+        file: chainsaw-assert-clusterpolicy.yaml
+  - name: when-tenant-labeled-namespace-is-created-paused
+    description: |
+      update a namespace labeled konflux-ci.dev/type=tenant so the policy should generate a LocalQueue.
+    try:
+    - apply:
+        file: resources/namespace-tenant-paused.yaml
+        template: true
+  - name: then-localqueue-is-created-paused
+    description: |
+      Assert the expected pipelines-queue LocalQueue exists and matches the fixture (name and spec).
+    try:
+    - assert:
+        file: resources/expected-localqueue-paused.yaml
+        template: true
+  - name: when-tenant-labeled-namespace-is-updated-to-unpause
+    description: |
+      Update the namespace to unpause it
+    try:
+    - update:
+        file: resources/namespace-tenant.yaml
+        template: true
+  - name: then-localqueue-is-unpaused
+    description: |
+      Assert the LocalQueue's StopPolicy is None
+    try:
+    - assert:
+        file: resources/expected-localqueue.yaml
+        template: true
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: kueue-bootstrap-queue-new-tenant-labeled-namespace-update-paused
+spec:
+  description: |
+    Tests that a LocalQueue with `stopPolicy` set to `None` is created
+    in a namespace labeled with `konflux-ci.dev/type=tenant` with no
+    `kueue.konflux-ci.dev/stop-policy` annotation set. The `stopPolicy`
+    is then set to `Hold` when the annotation is added to the namespace.
+  concurrent: false
+  namespace: kueue-queue-new
+  bindings:
+  - name: suffix
+    value: labeled-unpaused-paused
+  steps:
+  - name: given-localqueue-crd-exists
+    description: |
+      Install the Kueue LocalQueue CRD so the API server accepts LocalQueue objects in the test cluster.
+    try:
+    - apply:
+        file: ./resources/localqueue-crd.yaml
+  - name: given-kyverno-has-permission-on-resources
+    description: |
+      Apply Kyverno RBAC so the policy engine can generate and reconcile LocalQueue resources.
+    try:
+    - apply:
+        file: ../kyverno-admission-cluster-role.yaml
+    - apply:
+        file: ../kyverno-background-cluster-role.yaml
+  - name: given-cluster-policy-is-ready
+    description: |
+      Apply the queue bootstrap ClusterPolicy and assert Kyverno reports the policy as ready before exercising generation.
+    try:
+    - apply:
+        file: ../bootstrap-tenant-namespace-queue-cp.yaml
+    - assert:
+        file: chainsaw-assert-clusterpolicy.yaml
+  - name: when-tenant-labeled-namespace-is-created
+    description: |
+      Create a namespace labeled konflux-ci.dev/type=tenant so the policy should generate a LocalQueue.
+    try:
+    - apply:
+        file: resources/namespace-tenant.yaml
+        template: true
+  - name: then-localqueue-is-created
+    description: |
+      Assert the expected pipelines-queue LocalQueue exists and matches the fixture (name and spec).
+    try:
+    - assert:
+        file: resources/expected-localqueue.yaml
+        template: true
+  - name: when-tenant-labeled-namespace-is-updated
+    description: |
+      update a namespace labeled konflux-ci.dev/type=tenant so the policy should generate a LocalQueue.
+    try:
+    - apply:
+        file: resources/namespace-tenant-paused.yaml
+        template: true
+  - name: then-localqueue-is-updated
+    description: |
+      Assert the expected pipelines-queue LocalQueue exists and matches the fixture (name and spec).
+    try:
+    - assert:
+        file: resources/expected-localqueue-paused.yaml
+        template: true
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: kueue-bootstrap-queue-new-tenant-labeled-namespace-paused
+spec:
+  description: |
+    Tests that a LocalQueue is created in a namespace labeled with
+    `konflux-ci.dev/type=tenant` and with annotation to pause the
+    LocalQueue.
+  concurrent: false
+  namespace: kueue-queue-new
+  bindings:
+  - name: suffix
+    value: labeled
+  steps:
+  - name: given-localqueue-crd-exists
+    description: |
+      Install the Kueue LocalQueue CRD so the API server accepts LocalQueue objects in the test cluster.
+    try:
+    - apply:
+        file: ./resources/localqueue-crd.yaml
+  - name: given-kyverno-has-permission-on-resources
+    description: |
+      Apply Kyverno RBAC so the policy engine can generate and reconcile LocalQueue resources.
+    try:
+    - apply:
+        file: ../kyverno-admission-cluster-role.yaml
+    - apply:
+        file: ../kyverno-background-cluster-role.yaml
+  - name: given-cluster-policy-is-ready
+    description: |
+      Apply the queue bootstrap ClusterPolicy and assert Kyverno reports the policy as ready before exercising generation.
+    try:
+    - apply:
+        file: ../bootstrap-tenant-namespace-queue-cp.yaml
+    - assert:
+        file: chainsaw-assert-clusterpolicy.yaml
+  - name: when-tenant-labeled-namespace-is-created
+    description: |
+      Create a namespace labeled konflux-ci.dev/type=tenant so the policy should generate a LocalQueue.
+    try:
+    - apply:
+        file: resources/namespace-tenant-paused.yaml
+        template: true
+  - name: then-localqueue-is-created
+    description: |
+      Assert the expected pipelines-queue LocalQueue exists and matches the fixture (name and spec).
+    try:
+    - assert:
+        file: resources/expected-localqueue-paused.yaml
+        template: true
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: kueue-bootstrap-queue-unlabeled-namespace-negative
+spec:
+  description: |
+    Tests that a LocalQueue is NOT created in an unlabeled namespace
+    that does not match the special names.
+  concurrent: false
+  namespace: kueue-queue-new
+  bindings:
+  - name: suffix
+    value: unlabeled
+  steps:
+  - name: given-localqueue-crd-exists
+    description: |
+      Install the Kueue LocalQueue CRD so the API server accepts LocalQueue objects in the test cluster.
+    try:
+    - apply:
+        file: ./resources/localqueue-crd.yaml
+  - name: given-kyverno-has-permission-on-resources
+    description: |
+      Apply Kyverno RBAC so the policy engine can generate and reconcile LocalQueue resources.
+    try:
+    - apply:
+        file: ../kyverno-admission-cluster-role.yaml
+    - apply:
+        file: ../kyverno-background-cluster-role.yaml
+  - name: given-cluster-policy-is-ready
+    description: |
+      Apply the queue bootstrap ClusterPolicy and assert Kyverno reports the policy as ready before exercising generation.
+    try:
+    - apply:
+        file: ../bootstrap-tenant-namespace-queue-cp.yaml
+    - assert:
+        file: chainsaw-assert-clusterpolicy.yaml
+  - name: when-unlabeled-namespace-is-created
+    description: |
+      Create a namespace without the tenant label and without a special name so generation must not run.
+    try:
+    - apply:
+        file: resources/namespace-unlabeled.yaml
+        template: true
+  - name: then-localqueue-is-not-created
+    description: |
+      Confirm pipelines-queue LocalQueue is absent (NotFound) and stays absent after a short wait.
+    try:
+    - script:
+        content: kubectl get localqueues.kueue.x-k8s.io pipelines-queue
+        check:
+          ($error != null): true
+          ($stderr): |
+            Error from server (NotFound): localqueues.kueue.x-k8s.io "pipelines-queue" not found
+    - sleep:
+        duration: 5s
+    - script:
+        content: kubectl get localqueues.kueue.x-k8s.io pipelines-queue
+        check:
+          ($error != null): true
+          ($stderr): |
+            Error from server (NotFound): localqueues.kueue.x-k8s.io "pipelines-queue" not found
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: kueue-bootstrap-queue-label-added-to-namespace
+spec:
+  description: |
+    Tests that a LocalQueue is created when an unlabeled namespace is
+    updated to have the label `konflux-ci.dev/type=tenant`.
+  concurrent: false
+  namespace: kueue-queue-update
+  bindings:
+  - name: suffix
+    value: updated-labeled
+  steps:
+  - name: given-localqueue-crd-exists
+    description: |
+      Install the Kueue LocalQueue CRD so the API server accepts LocalQueue objects in the test cluster.
+    try:
+    - apply:
+        file: ./resources/localqueue-crd.yaml
+  - name: given-kyverno-has-permission-on-resources
+    description: |
+      Apply Kyverno RBAC so the policy engine can generate and reconcile LocalQueue resources.
+    try:
+    - apply:
+        file: ../kyverno-admission-cluster-role.yaml
+    - apply:
+        file: ../kyverno-background-cluster-role.yaml
+  - name: given-cluster-policy-is-ready
+    description: |
+      Apply the queue bootstrap ClusterPolicy and assert Kyverno reports the policy as ready before exercising generation.
+    try:
+    - apply:
+        file: ../bootstrap-tenant-namespace-queue-cp.yaml
+    - assert:
+        file: chainsaw-assert-clusterpolicy.yaml
+  - name: given-unlabeled-namespace-exists
+    description: |
+      Create an unlabeled namespace first so a later label update can trigger the policy on change.
+    try:
+    - apply:
+        file: resources/namespace-unlabeled.yaml
+        template: true
+  - name: when-tenant-label-is-added
+    description: |
+      Apply the tenant-labeled namespace manifest so konflux-ci.dev/type=tenant is set on the existing namespace.
+    try:
+    - apply:
+        file: resources/namespace-tenant.yaml
+        template: true
+  - name: then-localqueue-is-created
+    description: |
+      Assert the expected pipelines-queue LocalQueue exists and matches the fixture (name and spec).
+    try:
+    - assert:
+        file: resources/expected-localqueue.yaml
+        template: true
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: kueue-bootstrap-queue-labeled-namespace-before-policy
+spec:
+  description: |
+    Tests that a LocalQueue is created for an existing tenant-labeled
+    namespace when the ClusterPolicy is applied (generateExisting).
+  concurrent: false
+  namespace: kueue-queue-existing
+  bindings:
+  - name: suffix
+    value: labeled
+  steps:
+  - name: given-localqueue-crd-exists
+    description: |
+      Install the Kueue LocalQueue CRD so the API server accepts LocalQueue objects in the test cluster.
+    try:
+    - apply:
+        file: ./resources/localqueue-crd.yaml
+  - name: given-tenant-labeled-namespace-exists
+    description: |
+      Create the tenant-labeled namespace before the ClusterPolicy exists to exercise generateExisting on policy install.
+    try:
+    - apply:
+        file: resources/namespace-tenant.yaml
+        template: true
+  - name: given-kyverno-has-permission-on-resources
+    description: |
+      Apply Kyverno RBAC so the policy engine can generate and reconcile LocalQueue resources.
+    try:
+    - apply:
+        file: ../kyverno-admission-cluster-role.yaml
+    - apply:
+        file: ../kyverno-background-cluster-role.yaml
+  - name: when-cluster-policy-is-ready
+    description: |
+      Apply the ClusterPolicy after the target namespace exists so generateExisting can backfill the LocalQueue.
+    try:
+    - apply:
+        file: ../bootstrap-tenant-namespace-queue-cp.yaml
+    - assert:
+        file: chainsaw-assert-clusterpolicy.yaml
+  - name: then-localqueue-is-created
+    description: |
+      Assert the expected pipelines-queue LocalQueue exists and matches the fixture (name and spec).
+    try:
+    - assert:
+        file: resources/expected-localqueue.yaml
+        template: true
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: kueue-bootstrap-queue-mintmaker-namespace-before-policy
+spec:
+  description: |
+    Tests that a LocalQueue is created for an existing `mintmaker`
+    namespace when the ClusterPolicy is applied (generateExisting,
+    name-based match).
+  concurrent: false
+  namespace: kueue-queue-mintmaker-existing
+  steps:
+  - name: given-localqueue-crd-exists
+    description: |
+      Install the Kueue LocalQueue CRD so the API server accepts LocalQueue objects in the test cluster.
+    try:
+    - apply:
+        file: ./resources/localqueue-crd.yaml
+  - name: given-mintmaker-namespace-exists
+    description: |
+      Create the mintmaker namespace before policy install so name-based matching is satisfied for generateExisting.
+    try:
+    - apply:
+        file: resources/namespace-mintmaker.yaml
+  - name: given-kyverno-has-permission-on-resources
+    description: |
+      Apply Kyverno RBAC so the policy engine can generate and reconcile LocalQueue resources.
+    try:
+    - apply:
+        file: ../kyverno-admission-cluster-role.yaml
+    - apply:
+        file: ../kyverno-background-cluster-role.yaml
+  - name: when-cluster-policy-is-ready
+    description: |
+      Apply the ClusterPolicy after the target namespace exists so generateExisting can backfill the LocalQueue.
+    try:
+    - apply:
+        file: ../bootstrap-tenant-namespace-queue-cp.yaml
+    - assert:
+        file: chainsaw-assert-clusterpolicy.yaml
+  - name: then-localqueue-is-created
+    description: |
+      Assert the expected pipelines-queue LocalQueue exists and matches the fixture (name and spec).
+    try:
+    - assert:
+        file: resources/expected-localqueue-mintmaker.yaml
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: kueue-bootstrap-queue-kanary-namespace-before-policy
+spec:
+  description: |
+    Tests that a LocalQueue is created for an existing
+    `appstudio-kanary-exporter` namespace when the ClusterPolicy is
+    applied (generateExisting, name-based match).
+  concurrent: false
+  namespace: kueue-queue-kanary-existing
+  steps:
+  - name: given-localqueue-crd-exists
+    description: |
+      Install the Kueue LocalQueue CRD so the API server accepts LocalQueue objects in the test cluster.
+    try:
+    - apply:
+        file: ./resources/localqueue-crd.yaml
+  - name: given-kanary-namespace-exists
+    description: |
+      Create the appstudio-kanary-exporter namespace before policy install for name-based generateExisting.
+    try:
+    - apply:
+        file: resources/namespace-kanary.yaml
+  - name: given-kyverno-has-permission-on-resources
+    description: |
+      Apply Kyverno RBAC so the policy engine can generate and reconcile LocalQueue resources.
+    try:
+    - apply:
+        file: ../kyverno-admission-cluster-role.yaml
+    - apply:
+        file: ../kyverno-background-cluster-role.yaml
+  - name: when-cluster-policy-is-ready
+    description: |
+      Apply the ClusterPolicy after the target namespace exists so generateExisting can backfill the LocalQueue.
+    try:
+    - apply:
+        file: ../bootstrap-tenant-namespace-queue-cp.yaml
+    - assert:
+        file: chainsaw-assert-clusterpolicy.yaml
+  - name: then-localqueue-is-created
+    description: |
+      Assert the expected pipelines-queue LocalQueue exists and matches the fixture (name and spec).
+    try:
+    - assert:
+        file: resources/expected-localqueue-kanary.yaml
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: kueue-bootstrap-queue-mintmaker-by-name
+spec:
+  description: |
+    Tests that a LocalQueue is created for the `mintmaker` namespace
+    without the tenant label (name-based match).
+  concurrent: false
+  namespace: kueue-queue-mintmaker-test
+  steps:
+  - name: given-localqueue-crd-exists
+    description: |
+      Install the Kueue LocalQueue CRD so the API server accepts LocalQueue objects in the test cluster.
+    try:
+    - apply:
+        file: ./resources/localqueue-crd.yaml
+  - name: given-kyverno-has-permission-on-resources
+    description: |
+      Apply Kyverno RBAC so the policy engine can generate and reconcile LocalQueue resources.
+    try:
+    - apply:
+        file: ../kyverno-admission-cluster-role.yaml
+    - apply:
+        file: ../kyverno-background-cluster-role.yaml
+  - name: given-cluster-policy-is-ready
+    description: |
+      Apply the queue bootstrap ClusterPolicy and assert Kyverno reports the policy as ready before exercising generation.
+    try:
+    - apply:
+        file: ../bootstrap-tenant-namespace-queue-cp.yaml
+    - assert:
+        file: chainsaw-assert-clusterpolicy.yaml
+  - name: when-mintmaker-namespace-is-created
+    description: |
+      Create the mintmaker namespace after the policy is ready to verify name-based generation without the tenant label.
+    try:
+    - apply:
+        file: resources/namespace-mintmaker.yaml
+  - name: then-localqueue-is-created
+    description: |
+      Assert the expected pipelines-queue LocalQueue exists and matches the fixture (name and spec).
+    try:
+    - assert:
+        file: resources/expected-localqueue-mintmaker.yaml
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: kueue-bootstrap-queue-kanary-by-name
+spec:
+  description: |
+    Tests that a LocalQueue is created for the `appstudio-kanary-exporter`
+    namespace without the tenant label (name-based match).
+  concurrent: false
+  namespace: kueue-queue-kanary-test
+  steps:
+  - name: given-localqueue-crd-exists
+    description: |
+      Install the Kueue LocalQueue CRD so the API server accepts LocalQueue objects in the test cluster.
+    try:
+    - apply:
+        file: ./resources/localqueue-crd.yaml
+  - name: given-kyverno-has-permission-on-resources
+    description: |
+      Apply Kyverno RBAC so the policy engine can generate and reconcile LocalQueue resources.
+    try:
+    - apply:
+        file: ../kyverno-admission-cluster-role.yaml
+    - apply:
+        file: ../kyverno-background-cluster-role.yaml
+  - name: given-cluster-policy-is-ready
+    description: |
+      Apply the queue bootstrap ClusterPolicy and assert Kyverno reports the policy as ready before exercising generation.
+    try:
+    - apply:
+        file: ../bootstrap-tenant-namespace-queue-cp.yaml
+    - assert:
+        file: chainsaw-assert-clusterpolicy.yaml
+  - name: when-kanary-namespace-is-created
+    description: |
+      Create the appstudio-kanary-exporter namespace after the policy is ready to verify name-based generation.
+    try:
+    - apply:
+        file: resources/namespace-kanary.yaml
+  - name: then-localqueue-is-created
+    description: |
+      Assert the expected pipelines-queue LocalQueue exists and matches the fixture (name and spec).
+    try:
+    - assert:
+        file: resources/expected-localqueue-kanary.yaml
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: ensure-kueue-remains-on-policy-deletion
+spec:
+  description: |
+    Tests that a LocalQueue is not removed when the associated policy is deleted.
+  concurrent: false
+  namespace: kueue-queue-preserved
+  bindings:
+  - name: suffix
+    value: orphan
+  steps:
+  - name: given-localqueue-crd-exists
+    description: |
+      Install the Kueue LocalQueue CRD so the API server accepts LocalQueue objects in the test cluster.
+    try:
+    - apply:
+        file: ./resources/localqueue-crd.yaml
+  - name: given-kyverno-has-permission-on-resources
+    description: |
+      Apply Kyverno RBAC so the policy engine can generate and reconcile LocalQueue resources.
+    try:
+    - apply:
+        file: ../kyverno-admission-cluster-role.yaml
+    - apply:
+        file: ../kyverno-background-cluster-role.yaml
+  - name: given-cluster-policy-is-ready
+    description: |
+      Apply the queue bootstrap ClusterPolicy and assert Kyverno reports the policy as ready before exercising generation.
+    try:
+    - apply:
+        file: ../bootstrap-tenant-namespace-queue-cp.yaml
+    - assert:
+        file: chainsaw-assert-clusterpolicy.yaml
+  - name: when-tenant-labeled-namespace-is-created
+    description: |
+      Create a namespace labeled konflux-ci.dev/type=tenant so the policy should generate a LocalQueue.
+    try:
+    - apply:
+        file: resources/namespace-tenant.yaml
+        template: true
+  - name: then-localqueue-is-created
+    description: |
+      Assert the expected pipelines-queue LocalQueue exists and matches the fixture (name and spec).
+    try:
+    - assert:
+        file: resources/expected-localqueue.yaml
+        template: true
+  - name: when-policy-is-deleted
+    description: |
+      Remove the policy from the cluster.
+    try:
+    - delete:
+        file: ../bootstrap-tenant-namespace-queue-cp.yaml
+    - wait:
+        apiVersion: kyverno.io/v1
+        kind: ClusterPolicy
+        name: bootstrap-tenant-namespace-queue
+        for:
+          deletion: {}
+    - script:
+        content: |
+          while true; do
+            if [ "$(kubectl get updaterequests -n konflux-kyverno -o yaml | yq '.items | length')" -eq 0 ]; then
+              exit 0
+            fi
+            sleep 1
+          done
+        timeout: 30s
+  - name: then-localqueue-exists
+    description: |
+      Assert the LocalQueue created earlier still exists
+    try:
+    - assert:
+        file: resources/expected-localqueue.yaml
+        template: true

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/kueue/queue-config/.chainsaw-test/resources/expected-localqueue-kanary.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/kueue/queue-config/.chainsaw-test/resources/expected-localqueue-kanary.yaml
@@ -1,0 +1,8 @@
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: LocalQueue
+metadata:
+  name: pipelines-queue
+  namespace: appstudio-kanary-exporter
+spec:
+  clusterQueue: cluster-pipeline-queue
+  stopPolicy: None

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/kueue/queue-config/.chainsaw-test/resources/expected-localqueue-mintmaker.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/kueue/queue-config/.chainsaw-test/resources/expected-localqueue-mintmaker.yaml
@@ -1,0 +1,8 @@
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: LocalQueue
+metadata:
+  name: pipelines-queue
+  namespace: mintmaker
+spec:
+  clusterQueue: cluster-pipeline-queue
+  stopPolicy: None

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/kueue/queue-config/.chainsaw-test/resources/expected-localqueue-paused.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/kueue/queue-config/.chainsaw-test/resources/expected-localqueue-paused.yaml
@@ -1,0 +1,8 @@
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: LocalQueue
+metadata:
+  name: pipelines-queue
+  namespace: (join('-', [$namespace, $suffix]))
+spec:
+  clusterQueue: cluster-pipeline-queue
+  stopPolicy: Hold

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/kueue/queue-config/.chainsaw-test/resources/expected-localqueue.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/kueue/queue-config/.chainsaw-test/resources/expected-localqueue.yaml
@@ -1,0 +1,8 @@
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: LocalQueue
+metadata:
+  name: pipelines-queue
+  namespace: (join('-', [$namespace, $suffix]))
+spec:
+  clusterQueue: cluster-pipeline-queue
+  stopPolicy: None

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/kueue/queue-config/.chainsaw-test/resources/localqueue-crd.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/kueue/queue-config/.chainsaw-test/resources/localqueue-crd.yaml
@@ -1,0 +1,32 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: localqueues.kueue.x-k8s.io
+spec:
+  group: kueue.x-k8s.io
+  names:
+    kind: LocalQueue
+    listKind: LocalQueueList
+    plural: localqueues
+    singular: localqueue
+  scope: Namespaced
+  versions:
+  - name: v1beta2
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+          status:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/kueue/queue-config/.chainsaw-test/resources/namespace-kanary.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/kueue/queue-config/.chainsaw-test/resources/namespace-kanary.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: appstudio-kanary-exporter

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/kueue/queue-config/.chainsaw-test/resources/namespace-mintmaker.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/kueue/queue-config/.chainsaw-test/resources/namespace-mintmaker.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: mintmaker

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/kueue/queue-config/.chainsaw-test/resources/namespace-tenant-paused.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/kueue/queue-config/.chainsaw-test/resources/namespace-tenant-paused.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: (join('-', [$namespace, $suffix]))
+  annotations:
+    kueue.konflux-ci.dev/stop-policy: hold
+  labels:
+    konflux-ci.dev/type: tenant

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/kueue/queue-config/.chainsaw-test/resources/namespace-tenant-unpaused.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/kueue/queue-config/.chainsaw-test/resources/namespace-tenant-unpaused.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: (join('-', [$namespace, $suffix]))
+  annotations:
+    kueue.konflux-ci.dev/stop-policy: none
+  labels:
+    konflux-ci.dev/type: tenant

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/kueue/queue-config/.chainsaw-test/resources/namespace-tenant.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/kueue/queue-config/.chainsaw-test/resources/namespace-tenant.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: (join('-', [$namespace, $suffix]))
+  labels:
+    konflux-ci.dev/type: tenant

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/kueue/queue-config/.chainsaw-test/resources/namespace-unlabeled.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/kueue/queue-config/.chainsaw-test/resources/namespace-unlabeled.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: (join('-', [$namespace, $suffix]))

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/kueue/queue-config/bootstrap-tenant-namespace-queue-cp.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/kueue/queue-config/bootstrap-tenant-namespace-queue-cp.yaml
@@ -1,0 +1,40 @@
+---
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: bootstrap-tenant-namespace-queue
+spec:
+  rules:
+  - name: create-local-queue
+    skipBackgroundRequests: true
+    match:
+      any:
+      - resources:
+          kinds:
+          - Namespace
+          selector:
+            matchLabels:
+              konflux-ci.dev/type: tenant
+      - resources:
+          kinds:
+          - Namespace
+          names:
+          - mintmaker
+          - appstudio-kanary-exporter
+    context:
+    - name: stopPolicy
+      variable:
+        jmesPath: >-
+          (request.object.metadata.annotations."kueue.konflux-ci.dev/stop-policy" || '') == 'hold' && 'Hold' || 'None'
+    generate:
+      generateExisting: true
+      orphanDownstreamOnPolicyDelete: true
+      synchronize: true
+      apiVersion: kueue.x-k8s.io/v1beta2
+      kind: LocalQueue
+      name: pipelines-queue
+      namespace: '{{request.object.metadata.name}}'
+      data:
+        spec:
+          clusterQueue: cluster-pipeline-queue
+          stopPolicy: "{{stopPolicy}}"

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/kueue/queue-config/kustomization.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/kueue/queue-config/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- bootstrap-tenant-namespace-queue-cp.yaml
+- kyverno-admission-cluster-role.yaml
+- kyverno-background-cluster-role.yaml
+
+# ensure that installation starts after the installation of kueue complete
+commonAnnotations:
+  argocd.argoproj.io/sync-wave: "10"

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/kueue/queue-config/kyverno-admission-cluster-role.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/kueue/queue-config/kyverno-admission-cluster-role.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kyverno-admission:manage-queue
+  labels:
+    rbac.kyverno.io/aggregate-to-admission-controller: "true"
+rules:
+- apiGroups:
+  - kueue.x-k8s.io
+  resources:
+  - localqueues
+  verbs:
+  - list
+  - get

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/kueue/queue-config/kyverno-background-cluster-role.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/kueue/queue-config/kyverno-background-cluster-role.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kyverno-background:manage-queue
+  labels:
+    rbac.kyverno.io/aggregate-to-background-controller: "true"
+rules:
+- apiGroups:
+  - kueue.x-k8s.io
+  resources:
+  - localqueues
+  verbs:
+  - create
+  - get
+  - list
+  - delete
+  - update
+  - watch

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/kustomization.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - namespace.yaml
+  - konflux-rbac
+  - cost-management
+  - namespace-lister
+  - integration
+  - kubearchive
+  - kueue

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/namespace-lister/deny-virtual-domain/.chainsaw-test/README.md
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/namespace-lister/deny-virtual-domain/.chainsaw-test/README.md
@@ -1,0 +1,404 @@
+# Test: `allow-namespace-without-virtual-label-and-annotation`
+
+Tests that the creation of a tenant namespace neither labeled
+nor annotated with domain `virtual.konflux-ci.dev` is allowed
+
+
+## Steps
+
+| # | Name | Bindings | Try | Catch | Finally | Cleanup |
+|:-:|---|:-:|:-:|:-:|:-:|:-:|
+| 1 | [Apply Kyverno Cluster Policy and assert it exists](#step-Apply Kyverno Cluster Policy and assert it exists) | 0 | 2 | 0 | 0 | 0 |
+| 2 | [Create a tenant namespace without virtual domain label](#step-Create a tenant namespace without virtual domain label) | 0 | 1 | 0 | 0 | 0 |
+
+### Step: `Apply Kyverno Cluster Policy and assert it exists`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+| 2 | `assert` | 0 | 0 | *No description* |
+
+### Step: `Create a tenant namespace without virtual domain label`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `create` | 1 | 0 | *No description* |
+
+---
+
+# Test: `allow-tenant-namespace-without-virtual-label-and-annotation`
+
+Tests that creation of a namespace neither labeled nor annotated
+with `virtual.konflux-ci.dev` is allowed
+
+
+## Steps
+
+| # | Name | Bindings | Try | Catch | Finally | Cleanup |
+|:-:|---|:-:|:-:|:-:|:-:|:-:|
+| 1 | [Apply Kyverno Cluster Policy and assert it exists](#step-Apply Kyverno Cluster Policy and assert it exists) | 0 | 2 | 0 | 0 | 0 |
+| 2 | [Create a namespace without labels](#step-Create a namespace without labels) | 0 | 1 | 0 | 0 | 0 |
+
+### Step: `Apply Kyverno Cluster Policy and assert it exists`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+| 2 | `assert` | 0 | 0 | *No description* |
+
+### Step: `Create a namespace without labels`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `create` | 1 | 0 | *No description* |
+
+---
+
+# Test: `allow-namespace-with-virtual-annotation`
+
+Tests that creation of a namespace annotated with
+`virtual.konflux-ci.dev` is allowed
+
+
+## Steps
+
+| # | Name | Bindings | Try | Catch | Finally | Cleanup |
+|:-:|---|:-:|:-:|:-:|:-:|:-:|
+| 1 | [Apply Kyverno Cluster Policy and assert it exists](#step-Apply Kyverno Cluster Policy and assert it exists) | 0 | 2 | 0 | 0 | 0 |
+| 2 | [Create a namespace with virtual label](#step-Create a namespace with virtual label) | 0 | 1 | 0 | 0 | 0 |
+
+### Step: `Apply Kyverno Cluster Policy and assert it exists`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+| 2 | `assert` | 0 | 0 | *No description* |
+
+### Step: `Create a namespace with virtual label`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `create` | 1 | 0 | *No description* |
+
+---
+
+# Test: `deny-tenant-namespace-with-virtual-annotation`
+
+Tests that creation of a tenant namespace annotated with
+`virtual.konflux-ci.dev` is denied
+
+
+## Steps
+
+| # | Name | Bindings | Try | Catch | Finally | Cleanup |
+|:-:|---|:-:|:-:|:-:|:-:|:-:|
+| 1 | [Apply Kyverno Cluster Policy and assert it exists](#step-Apply Kyverno Cluster Policy and assert it exists) | 0 | 2 | 0 | 0 | 0 |
+| 2 | [Create a tenant namespace with virtual annotation](#step-Create a tenant namespace with virtual annotation) | 0 | 1 | 0 | 0 | 0 |
+
+### Step: `Apply Kyverno Cluster Policy and assert it exists`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+| 2 | `assert` | 0 | 0 | *No description* |
+
+### Step: `Create a tenant namespace with virtual annotation`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `create` | 1 | 0 | *No description* |
+
+---
+
+# Test: `deny-promoted-tenant-namespace-with-virtual-annotation`
+
+Tests that a namespace annotated with `virtual.konflux-ci.dev` can not
+be promoted to tenant namespace
+
+
+## Steps
+
+| # | Name | Bindings | Try | Catch | Finally | Cleanup |
+|:-:|---|:-:|:-:|:-:|:-:|:-:|
+| 1 | [Apply Kyverno Cluster Policy and assert it exists](#step-Apply Kyverno Cluster Policy and assert it exists) | 0 | 2 | 0 | 0 | 0 |
+| 2 | [Create a namespace with virtual annotation](#step-Create a namespace with virtual annotation) | 0 | 1 | 0 | 0 | 0 |
+| 3 | [Promote namespace with virtual annotation to tenant namespace](#step-Promote namespace with virtual annotation to tenant namespace) | 0 | 1 | 0 | 0 | 0 |
+
+### Step: `Apply Kyverno Cluster Policy and assert it exists`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+| 2 | `assert` | 0 | 0 | *No description* |
+
+### Step: `Create a namespace with virtual annotation`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `create` | 1 | 0 | *No description* |
+
+### Step: `Promote namespace with virtual annotation to tenant namespace`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 1 | 0 | *No description* |
+
+---
+
+# Test: `deny-update-existing-tenant-namespace-with-virtual-annotation`
+
+Tests that an existing tenant namespace cannot be updated to add
+an annotation with `virtual.konflux-ci.dev` domain.
+
+
+## Steps
+
+| # | Name | Bindings | Try | Catch | Finally | Cleanup |
+|:-:|---|:-:|:-:|:-:|:-:|:-:|
+| 1 | [Apply Kyverno Cluster Policy and assert it exists](#step-Apply Kyverno Cluster Policy and assert it exists) | 0 | 2 | 0 | 0 | 0 |
+| 2 | [Create a tenant namespace without virtual annotations](#step-Create a tenant namespace without virtual annotations) | 0 | 1 | 0 | 0 | 0 |
+| 3 | [Update existing tenant namespace with virtual annotation](#step-Update existing tenant namespace with virtual annotation) | 0 | 1 | 0 | 0 | 0 |
+
+### Step: `Apply Kyverno Cluster Policy and assert it exists`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+| 2 | `assert` | 0 | 0 | *No description* |
+
+### Step: `Create a tenant namespace without virtual annotations`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `create` | 1 | 0 | *No description* |
+
+### Step: `Update existing tenant namespace with virtual annotation`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 1 | 0 | *No description* |
+
+---
+
+# Test: `allow-namespace-with-virtual-label`
+
+Tests that creation of a namespace labeled with
+`virtual.konflux-ci.dev` is allowed
+
+
+## Steps
+
+| # | Name | Bindings | Try | Catch | Finally | Cleanup |
+|:-:|---|:-:|:-:|:-:|:-:|:-:|
+| 1 | [Apply Kyverno Cluster Policy and assert it exists](#step-Apply Kyverno Cluster Policy and assert it exists) | 0 | 2 | 0 | 0 | 0 |
+| 2 | [Create a namespace with virtual label](#step-Create a namespace with virtual label) | 0 | 1 | 0 | 0 | 0 |
+
+### Step: `Apply Kyverno Cluster Policy and assert it exists`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+| 2 | `assert` | 0 | 0 | *No description* |
+
+### Step: `Create a namespace with virtual label`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `create` | 1 | 0 | *No description* |
+
+---
+
+# Test: `deny-tenant-namespace-with-virtual-label`
+
+Tests that creation of a tenant namespace labeled with
+`virtual.konflux-ci.dev` is denied
+
+
+## Steps
+
+| # | Name | Bindings | Try | Catch | Finally | Cleanup |
+|:-:|---|:-:|:-:|:-:|:-:|:-:|
+| 1 | [Apply Kyverno Cluster Policy and assert it exists](#step-Apply Kyverno Cluster Policy and assert it exists) | 0 | 2 | 0 | 0 | 0 |
+| 2 | [Create a tenant namespace with virtual labels](#step-Create a tenant namespace with virtual labels) | 0 | 1 | 0 | 0 | 0 |
+
+### Step: `Apply Kyverno Cluster Policy and assert it exists`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+| 2 | `assert` | 0 | 0 | *No description* |
+
+### Step: `Create a tenant namespace with virtual labels`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `create` | 1 | 0 | *No description* |
+
+---
+
+# Test: `deny-promoted-tenant-namespace-with-virtual-label`
+
+Tests that a namespace labeled with `virtual.konflux-ci.dev` can not
+be promoted to tenant namespace
+
+
+## Steps
+
+| # | Name | Bindings | Try | Catch | Finally | Cleanup |
+|:-:|---|:-:|:-:|:-:|:-:|:-:|
+| 1 | [Apply Kyverno Cluster Policy and assert it exists](#step-Apply Kyverno Cluster Policy and assert it exists) | 0 | 2 | 0 | 0 | 0 |
+| 2 | [Create a namespace with virtual labels](#step-Create a namespace with virtual labels) | 0 | 1 | 0 | 0 | 0 |
+| 3 | [Promote namespace with virtual labels to tenant namespace](#step-Promote namespace with virtual labels to tenant namespace) | 0 | 1 | 0 | 0 | 0 |
+
+### Step: `Apply Kyverno Cluster Policy and assert it exists`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+| 2 | `assert` | 0 | 0 | *No description* |
+
+### Step: `Create a namespace with virtual labels`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `create` | 1 | 0 | *No description* |
+
+### Step: `Promote namespace with virtual labels to tenant namespace`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 1 | 0 | *No description* |
+
+---
+
+# Test: `deny-update-existing-tenant-namespace-with-virtual-label`
+
+Tests that an existing tenant namespace cannot be updated to add
+a label with `virtual.konflux-ci.dev` domain.
+
+
+## Steps
+
+| # | Name | Bindings | Try | Catch | Finally | Cleanup |
+|:-:|---|:-:|:-:|:-:|:-:|:-:|
+| 1 | [Apply Kyverno Cluster Policy and assert it exists](#step-Apply Kyverno Cluster Policy and assert it exists) | 0 | 2 | 0 | 0 | 0 |
+| 2 | [Create a tenant namespace without virtual labels](#step-Create a tenant namespace without virtual labels) | 0 | 1 | 0 | 0 | 0 |
+| 3 | [Update existing tenant namespace with virtual label](#step-Update existing tenant namespace with virtual label) | 0 | 1 | 0 | 0 | 0 |
+
+### Step: `Apply Kyverno Cluster Policy and assert it exists`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+| 2 | `assert` | 0 | 0 | *No description* |
+
+### Step: `Create a tenant namespace without virtual labels`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `create` | 1 | 0 | *No description* |
+
+### Step: `Update existing tenant namespace with virtual label`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 1 | 0 | *No description* |
+
+---
+

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/namespace-lister/deny-virtual-domain/.chainsaw-test/chainsaw-assert-clusterpolicy.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/namespace-lister/deny-virtual-domain/.chainsaw-test/chainsaw-assert-clusterpolicy.yaml
@@ -1,0 +1,9 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: deny-virtual-domain
+status:
+  conditions:
+  - reason: Succeeded
+    status: "True"
+    type: Ready

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/namespace-lister/deny-virtual-domain/.chainsaw-test/chainsaw-test.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/namespace-lister/deny-virtual-domain/.chainsaw-test/chainsaw-test.yaml
@@ -1,0 +1,354 @@
+---
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: allow-namespace-without-virtual-label-and-annotation
+spec:
+  concurrent: false
+  description: |
+    Tests that the creation of a tenant namespace neither labeled
+    nor annotated with domain `virtual.konflux-ci.dev` is allowed
+  steps:
+    - name: Apply Kyverno Cluster Policy and assert it exists
+      try:
+        - apply:
+            file: ../deny-virtual-domain-cp.yaml
+        - assert:
+            file: chainsaw-assert-clusterpolicy.yaml
+    - name: Create a tenant namespace without virtual domain label
+      try:
+        - create:
+            file: ./resources/namespace-no-labels.yaml
+            template: true
+            bindings:
+              - name: namespace
+                value: namespace-no-labels
+            expect:
+              - match:
+                  kind: Namespace
+                check:
+                  ($error == null): true
+---
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: allow-tenant-namespace-without-virtual-label-and-annotation
+spec:
+  concurrent: false
+  description: |
+    Tests that creation of a namespace neither labeled nor annotated
+    with `virtual.konflux-ci.dev` is allowed
+  steps:
+    - name: Apply Kyverno Cluster Policy and assert it exists
+      try:
+        - apply:
+            file: ../deny-virtual-domain-cp.yaml
+        - assert:
+            file: chainsaw-assert-clusterpolicy.yaml
+    - name: Create a namespace without labels
+      try:
+        - create:
+            file: ./resources/tenant-namespace.yaml
+            template: true
+            bindings:
+              - name: namespace
+                value: tenant-namespace-allow
+            expect:
+              - match:
+                  kind: Namespace
+                check:
+                  ($error == null): true
+## Annotations
+---
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: allow-namespace-with-virtual-annotation
+spec:
+  concurrent: false
+  description: |
+    Tests that creation of a namespace annotated with
+    `virtual.konflux-ci.dev` is allowed
+  steps:
+    - name: Apply Kyverno Cluster Policy and assert it exists
+      try:
+        - apply:
+            file: ../deny-virtual-domain-cp.yaml
+        - assert:
+            file: chainsaw-assert-clusterpolicy.yaml
+    - name: Create a namespace with virtual label
+      try:
+        - create:
+            file: ./resources/namespace-with-virtual-annotation.yaml
+            template: true
+            bindings:
+              - name: namespace
+                value: namespace-annotation-allow
+            expect:
+              - match:
+                  kind: Namespace
+                check:
+                  ($error == null): true
+---
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: deny-tenant-namespace-with-virtual-annotation
+spec:
+  concurrent: false
+  description: |
+    Tests that creation of a tenant namespace annotated with
+    `virtual.konflux-ci.dev` is denied
+  steps:
+    - name: Apply Kyverno Cluster Policy and assert it exists
+      try:
+        - apply:
+            file: ../deny-virtual-domain-cp.yaml
+        - assert:
+            file: chainsaw-assert-clusterpolicy.yaml
+    - name: Create a tenant namespace with virtual annotation
+      try:
+        - create:
+            file: ./resources/tenant-namespace-with-virtual-annotation.yaml
+            template: true
+            bindings:
+              - name: namespace
+                value: tenant-namespace-annotation-deny
+            expect:
+              - match:
+                  kind: Namespace
+                check:
+                  ($error == null): false
+---
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: deny-promoted-tenant-namespace-with-virtual-annotation
+spec:
+  concurrent: false
+  description: |
+    Tests that a namespace annotated with `virtual.konflux-ci.dev` can not
+    be promoted to tenant namespace
+  steps:
+    - name: Apply Kyverno Cluster Policy and assert it exists
+      try:
+        - apply:
+            file: ../deny-virtual-domain-cp.yaml
+        - assert:
+            file: chainsaw-assert-clusterpolicy.yaml
+    - name: Create a namespace with virtual annotation
+      try:
+        - create:
+            file: ./resources/namespace-with-virtual-annotation.yaml
+            template: true
+            bindings:
+              - name: namespace
+                value: promoted-tenant-namespace-annotation-deny
+            expect:
+              - match:
+                  kind: Namespace
+                check:
+                  ($error == null): true
+    - name: Promote namespace with virtual annotation to tenant namespace
+      try:
+        - apply:
+            file: ./resources/tenant-namespace-with-virtual-annotation.yaml
+            template: true
+            bindings:
+              - name: namespace
+                value: promoted-tenant-namespace-annotation-deny
+            expect:
+              - match:
+                  kind: Namespace
+                check:
+                  ($error == null): false
+---
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: deny-update-existing-tenant-namespace-with-virtual-annotation
+spec:
+  concurrent: false
+  description: |
+    Tests that an existing tenant namespace cannot be updated to add
+    an annotation with `virtual.konflux-ci.dev` domain.
+  steps:
+    - name: Apply Kyverno Cluster Policy and assert it exists
+      try:
+        - apply:
+            file: ../deny-virtual-domain-cp.yaml
+        - assert:
+            file: chainsaw-assert-clusterpolicy.yaml
+    - name: Create a tenant namespace without virtual annotations
+      try:
+        - create:
+            file: ./resources/tenant-namespace.yaml
+            template: true
+            bindings:
+              - name: namespace
+                value: existing-tenant-annotation-deny
+            expect:
+              - match:
+                  kind: Namespace
+                check:
+                  ($error == null): true
+    - name: Update existing tenant namespace with virtual annotation
+      try:
+        - apply:
+            file: ./resources/tenant-namespace-with-virtual-annotation.yaml
+            template: true
+            bindings:
+              - name: namespace
+                value: existing-tenant-annotation-deny
+            expect:
+              - match:
+                  kind: Namespace
+                check:
+                  ($error == null): false
+## Labels
+---
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: allow-namespace-with-virtual-label
+spec:
+  concurrent: false
+  description: |
+    Tests that creation of a namespace labeled with
+    `virtual.konflux-ci.dev` is allowed
+  steps:
+    - name: Apply Kyverno Cluster Policy and assert it exists
+      try:
+        - apply:
+            file: ../deny-virtual-domain-cp.yaml
+        - assert:
+            file: chainsaw-assert-clusterpolicy.yaml
+    - name: Create a namespace with virtual label
+      try:
+        - create:
+            file: ./resources/namespace-with-virtual-label.yaml
+            template: true
+            bindings:
+              - name: namespace
+                value: tenant-namespace-label-allow
+            expect:
+              - match:
+                  kind: Namespace
+                check:
+                  ($error == null): true
+---
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: deny-tenant-namespace-with-virtual-label
+spec:
+  concurrent: false
+  description: |
+    Tests that creation of a tenant namespace labeled with
+    `virtual.konflux-ci.dev` is denied
+  steps:
+    - name: Apply Kyverno Cluster Policy and assert it exists
+      try:
+        - apply:
+            file: ../deny-virtual-domain-cp.yaml
+        - assert:
+            file: chainsaw-assert-clusterpolicy.yaml
+    - name: Create a tenant namespace with virtual labels
+      try:
+        - create:
+            file: ./resources/tenant-namespace-with-virtual-label.yaml
+            template: true
+            bindings:
+              - name: namespace
+                value: tenant-namespace-label-deny
+            expect:
+              - match:
+                  kind: Namespace
+                check:
+                  ($error == null): false
+---
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: deny-promoted-tenant-namespace-with-virtual-label
+spec:
+  concurrent: false
+  description: |
+    Tests that a namespace labeled with `virtual.konflux-ci.dev` can not
+    be promoted to tenant namespace
+  steps:
+    - name: Apply Kyverno Cluster Policy and assert it exists
+      try:
+        - apply:
+            file: ../deny-virtual-domain-cp.yaml
+        - assert:
+            file: chainsaw-assert-clusterpolicy.yaml
+    - name: Create a namespace with virtual labels
+      try:
+        - create:
+            file: ./resources/namespace-with-virtual-label.yaml
+            template: true
+            bindings:
+              - name: namespace
+                value: promoted-tenant-namespace-label-deny
+            expect:
+              - match:
+                  kind: Namespace
+                check:
+                  ($error == null): true
+    - name: Promote namespace with virtual labels to tenant namespace
+      try:
+        - apply:
+            file: ./resources/tenant-namespace-with-virtual-label.yaml
+            template: true
+            bindings:
+              - name: namespace
+                value: promoted-tenant-namespace-label-deny
+            expect:
+              - match:
+                  kind: Namespace
+                check:
+                  ($error == null): false
+---
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: deny-update-existing-tenant-namespace-with-virtual-label
+spec:
+  concurrent: false
+  description: |
+    Tests that an existing tenant namespace cannot be updated to add
+    a label with `virtual.konflux-ci.dev` domain.
+  steps:
+    - name: Apply Kyverno Cluster Policy and assert it exists
+      try:
+        - apply:
+            file: ../deny-virtual-domain-cp.yaml
+        - assert:
+            file: chainsaw-assert-clusterpolicy.yaml
+    - name: Create a tenant namespace without virtual labels
+      try:
+        - create:
+            file: ./resources/tenant-namespace.yaml
+            template: true
+            bindings:
+              - name: namespace
+                value: existing-tenant-label-deny
+            expect:
+              - match:
+                  kind: Namespace
+                check:
+                  ($error == null): true
+    - name: Update existing tenant namespace with virtual label
+      try:
+        - apply:
+            file: ./resources/tenant-namespace-with-virtual-label.yaml
+            template: true
+            bindings:
+              - name: namespace
+                value: existing-tenant-label-deny
+            expect:
+              - match:
+                  kind: Namespace
+                check:
+                  ($error == null): false

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/namespace-lister/deny-virtual-domain/.chainsaw-test/resources/namespace-no-labels.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/namespace-lister/deny-virtual-domain/.chainsaw-test/resources/namespace-no-labels.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ($namespace)

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/namespace-lister/deny-virtual-domain/.chainsaw-test/resources/namespace-with-virtual-annotation.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/namespace-lister/deny-virtual-domain/.chainsaw-test/resources/namespace-with-virtual-annotation.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ($namespace)
+  annotations:
+    virtual.konflux-ci.dev/example: example

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/namespace-lister/deny-virtual-domain/.chainsaw-test/resources/namespace-with-virtual-label.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/namespace-lister/deny-virtual-domain/.chainsaw-test/resources/namespace-with-virtual-label.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ($namespace)
+  labels:
+    virtual.konflux-ci.dev/example: example

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/namespace-lister/deny-virtual-domain/.chainsaw-test/resources/tenant-namespace-with-virtual-annotation.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/namespace-lister/deny-virtual-domain/.chainsaw-test/resources/tenant-namespace-with-virtual-annotation.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ($namespace)
+  labels:
+    konflux-ci.dev/type: tenant
+  annotations:
+    virtual.konflux-ci.dev/example: example

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/namespace-lister/deny-virtual-domain/.chainsaw-test/resources/tenant-namespace-with-virtual-label.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/namespace-lister/deny-virtual-domain/.chainsaw-test/resources/tenant-namespace-with-virtual-label.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ($namespace)
+  labels:
+    konflux-ci.dev/type: tenant
+    virtual.konflux-ci.dev/example: example

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/namespace-lister/deny-virtual-domain/.chainsaw-test/resources/tenant-namespace.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/namespace-lister/deny-virtual-domain/.chainsaw-test/resources/tenant-namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ($namespace)
+  labels:
+    konflux-ci.dev/type: tenant

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/namespace-lister/deny-virtual-domain/deny-virtual-domain-cp.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/namespace-lister/deny-virtual-domain/deny-virtual-domain-cp.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: deny-virtual-domain
+spec:
+  validationFailureAction: Enforce
+  rules:
+  - name: deny-virtual-domain-labels-annotations
+    skipBackgroundRequests: true
+    match:
+      any:
+      - resources:
+          kinds:
+          - /v1/Namespace
+          selector:
+            matchLabels:
+              konflux-ci.dev/type: tenant
+          operations:
+          - CREATE
+          - UPDATE
+    validate:
+      allowExistingViolations: true
+      cel:
+        expressions:
+        - expression: '!object.metadata.labels.exists(key, key.startsWith("virtual.konflux-ci.dev/"))'
+          message: "Tenant namespaces can not have labels with domain 'virtual.konflux-ci.dev'"
+        - expression: '!has(object.metadata.annotations) || !object.metadata.annotations.exists(key, key.startsWith("virtual.konflux-ci.dev/"))'
+          message: "Tenant namespaces can not have annotations with domain 'virtual.konflux-ci.dev'"

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/namespace-lister/deny-virtual-domain/kustomization.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/namespace-lister/deny-virtual-domain/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- deny-virtual-domain-cp.yaml
+commonAnnotations:
+  argocd.argoproj.io/sync-options: Prune=false

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/namespace-lister/kustomization.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/namespace-lister/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namePrefix: namespace-lister-
+resources:
+- deny-virtual-domain

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/namespace.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: konflux-policies

--- a/components/policies-rd/rings/ring-1/base/cost-management/kustomization.yaml
+++ b/components/policies-rd/rings/ring-1/base/cost-management/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- validate-cost-management-labels/

--- a/components/policies-rd/rings/ring-1/base/cost-management/validate-cost-management-labels/.chainsaw-test/README.md
+++ b/components/policies-rd/rings/ring-1/base/cost-management/validate-cost-management-labels/.chainsaw-test/README.md
@@ -1,0 +1,235 @@
+# Test: `allow-namespace-with-cost-center`
+
+Tests that a namespace labeled as `konflux-ci.dev/type: tenant`
+is allowed only if it has the `cost-center` label.
+
+
+## Steps
+
+| # | Name | Bindings | Try | Catch | Finally | Cleanup |
+|:-:|---|:-:|:-:|:-:|:-:|:-:|
+| 1 | [Apply RBAC](#step-Apply RBAC) | 0 | 1 | 0 | 0 | 0 |
+| 2 | [Apply Kyverno Cluster Policy and assert it exists](#step-Apply Kyverno Cluster Policy and assert it exists) | 0 | 2 | 0 | 0 | 0 |
+| 3 | [Create a tenant namespace with cost-center label](#step-Create a tenant namespace with cost-center label) | 0 | 1 | 0 | 0 | 0 |
+
+### Step: `Apply RBAC`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `Apply Kyverno Cluster Policy and assert it exists`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+| 2 | `assert` | 1 | 0 | *No description* |
+
+### Step: `Create a tenant namespace with cost-center label`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `create` | 2 | 0 | *No description* |
+
+---
+
+# Test: `allow-namespace-without-tenant-label`
+
+Tests that a namespace without the `konflux-ci.dev/type: tenant` label
+is allowed regardless of the `cost-center` label.
+
+
+## Steps
+
+| # | Name | Bindings | Try | Catch | Finally | Cleanup |
+|:-:|---|:-:|:-:|:-:|:-:|:-:|
+| 1 | [Apply RBAC](#step-Apply RBAC) | 0 | 1 | 0 | 0 | 0 |
+| 2 | [Apply Kyverno Cluster Policy and assert it exists](#step-Apply Kyverno Cluster Policy and assert it exists) | 0 | 2 | 0 | 0 | 0 |
+| 3 | [Create a namespace without tenant label](#step-Create a namespace without tenant label) | 0 | 1 | 0 | 0 | 0 |
+
+### Step: `Apply RBAC`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `Apply Kyverno Cluster Policy and assert it exists`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+| 2 | `assert` | 1 | 0 | *No description* |
+
+### Step: `Create a namespace without tenant label`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `create` | 0 | 0 | *No description* |
+
+---
+
+# Test: `deny-namespace-with-empty-cost-center`
+
+Tests that a namespace labeled as `konflux-ci.dev/type: tenant`
+is denied if the `cost-center` label is empty.
+
+
+## Steps
+
+| # | Name | Bindings | Try | Catch | Finally | Cleanup |
+|:-:|---|:-:|:-:|:-:|:-:|:-:|
+| 1 | [Apply RBAC](#step-Apply RBAC) | 0 | 1 | 0 | 0 | 0 |
+| 2 | [Apply Kyverno Cluster Policy and assert it exists](#step-Apply Kyverno Cluster Policy and assert it exists) | 0 | 2 | 0 | 0 | 0 |
+| 3 | [Attempt to create a tenant namespace with empty cost-center label](#step-Attempt to create a tenant namespace with empty cost-center label) | 0 | 1 | 0 | 0 | 0 |
+
+### Step: `Apply RBAC`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `Apply Kyverno Cluster Policy and assert it exists`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+| 2 | `assert` | 1 | 0 | *No description* |
+
+### Step: `Attempt to create a tenant namespace with empty cost-center label`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `create` | 0 | 0 | *No description* |
+
+---
+
+# Test: `deny-namespace-without-cost-center`
+
+Tests that a namespace labeled as `konflux-ci.dev/type: tenant`
+is denied if it does not have the `cost-center` label.
+
+
+## Steps
+
+| # | Name | Bindings | Try | Catch | Finally | Cleanup |
+|:-:|---|:-:|:-:|:-:|:-:|:-:|
+| 1 | [Apply RBAC](#step-Apply RBAC) | 0 | 1 | 0 | 0 | 0 |
+| 2 | [Apply Kyverno Cluster Policy and assert it exists](#step-Apply Kyverno Cluster Policy and assert it exists) | 0 | 2 | 0 | 0 | 0 |
+| 3 | [Attempt to create a tenant namespace without cost-center label](#step-Attempt to create a tenant namespace without cost-center label) | 0 | 1 | 0 | 0 | 0 |
+
+### Step: `Apply RBAC`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `Apply Kyverno Cluster Policy and assert it exists`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+| 2 | `assert` | 1 | 0 | *No description* |
+
+### Step: `Attempt to create a tenant namespace without cost-center label`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `create` | 1 | 0 | *No description* |
+
+---
+
+# Test: `deny-namespace-with-invalid-cost-center`
+
+Tests that a namespace labeled as `konflux-ci.dev/type: tenant`
+is denied if the `cost-center` label is invalid.
+
+
+## Steps
+
+| # | Name | Bindings | Try | Catch | Finally | Cleanup |
+|:-:|---|:-:|:-:|:-:|:-:|:-:|
+| 1 | [Apply RBAC](#step-Apply RBAC) | 0 | 1 | 0 | 0 | 0 |
+| 2 | [Apply Kyverno Cluster Policy and assert it exists](#step-Apply Kyverno Cluster Policy and assert it exists) | 0 | 2 | 0 | 0 | 0 |
+| 3 | [Attempt to create a tenant namespace with invalid cost-center label](#step-Attempt to create a tenant namespace with invalid cost-center label) | 0 | 1 | 0 | 0 | 0 |
+
+### Step: `Apply RBAC`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `Apply Kyverno Cluster Policy and assert it exists`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+| 2 | `assert` | 1 | 0 | *No description* |
+
+### Step: `Attempt to create a tenant namespace with invalid cost-center label`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `create` | 2 | 0 | *No description* |
+
+---
+

--- a/components/policies-rd/rings/ring-1/base/cost-management/validate-cost-management-labels/.chainsaw-test/chainsaw-assert-clusterpolicy.yaml
+++ b/components/policies-rd/rings/ring-1/base/cost-management/validate-cost-management-labels/.chainsaw-test/chainsaw-assert-clusterpolicy.yaml
@@ -1,0 +1,9 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: validate-cost-management-labels
+status:
+  conditions:
+  - reason: Succeeded
+    status: "True"
+    type: Ready

--- a/components/policies-rd/rings/ring-1/base/cost-management/validate-cost-management-labels/.chainsaw-test/chainsaw-test.yaml
+++ b/components/policies-rd/rings/ring-1/base/cost-management/validate-cost-management-labels/.chainsaw-test/chainsaw-test.yaml
@@ -1,0 +1,186 @@
+---
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: allow-namespace-with-cost-center
+spec:
+  concurrent: false
+  description: |
+    Tests that a namespace labeled as `konflux-ci.dev/type: tenant`
+    is allowed only if it has the `cost-center` label.
+  steps:
+    - name: Apply RBAC
+      try:
+        - apply:
+            file: ../kyverno-cluster-role.yaml
+    - name: Apply Kyverno Cluster Policy and assert it exists
+      try:
+        - apply:
+            file: ../validate-cost-management-labels-cp.yaml
+        - assert:
+            file: chainsaw-assert-clusterpolicy.yaml
+            template: true
+            bindings:
+              - name: cluster_policy_name
+                value: validate-cost-management-labels
+    - name: Create a tenant namespace with cost-center label
+      try:
+        - create:
+            file: ./resources/namespace-cost-center.yaml
+            template: true
+            bindings:
+              - name: namespace
+                value: tenant
+              - name: cost_center
+                value: "670"
+            expect:
+              - match:
+                  kind: Namespace
+                check:
+                  ($error == null): true
+---
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: allow-namespace-without-tenant-label
+spec:
+  concurrent: false
+  description: |
+    Tests that a namespace without the `konflux-ci.dev/type: tenant` label
+    is allowed regardless of the `cost-center` label.
+  steps:
+    - name: Apply RBAC
+      try:
+        - apply:
+            file: ../kyverno-cluster-role.yaml
+    - name: Apply Kyverno Cluster Policy and assert it exists
+      try:
+        - apply:
+            file: ../validate-cost-management-labels-cp.yaml
+        - assert:
+            file: chainsaw-assert-clusterpolicy.yaml
+            template: true
+            bindings:
+              - name: cluster_policy_name
+                value: validate-cost-management-labels
+    - name: Create a namespace without tenant label
+      try:
+        - create:
+            file: ./resources/namespace-nonmatching.yaml
+            expect:
+              - match:
+                  kind: Namespace
+                check:
+                  ($error == null): true
+---
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: deny-namespace-with-empty-cost-center
+spec:
+  concurrent: false
+  description: |
+    Tests that a namespace labeled as `konflux-ci.dev/type: tenant`
+    is denied if the `cost-center` label is empty.
+  steps:
+    - name: Apply RBAC
+      try:
+        - apply:
+            file: ../kyverno-cluster-role.yaml
+    - name: Apply Kyverno Cluster Policy and assert it exists
+      try:
+        - apply:
+            file: ../validate-cost-management-labels-cp.yaml
+        - assert:
+            file: chainsaw-assert-clusterpolicy.yaml
+            template: true
+            bindings:
+              - name: cluster_policy_name
+                value: validate-cost-management-labels
+    - name: Attempt to create a tenant namespace with empty cost-center label
+      try:
+        - create:
+            file: ./resources/namespace-empty-cost-center.yaml
+            expect:
+            - match:
+                kind: Namespace
+              check:
+                ($error != null): true
+---
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: deny-namespace-without-cost-center
+spec:
+  concurrent: false
+  description: |
+    Tests that a namespace labeled as `konflux-ci.dev/type: tenant`
+    is denied if it does not have the `cost-center` label.
+  steps:
+    - name: Apply RBAC
+      try:
+        - apply:
+            file: ../kyverno-cluster-role.yaml
+    - name: Apply Kyverno Cluster Policy and assert it exists
+      try:
+        - apply:
+            file: ../validate-cost-management-labels-cp.yaml
+        - assert:
+            file: chainsaw-assert-clusterpolicy.yaml
+            template: true
+            bindings:
+              - name: cluster_policy_name
+                value: validate-cost-management-labels
+    - name: Attempt to create a tenant namespace without cost-center label
+      try:
+        - create:
+            file: ./resources/namespace-no-cost-center.yaml
+            template: true
+            bindings:
+              - name: namespace
+                value: tenant-no-cost-center
+            expect:
+            - match:
+                kind: Namespace
+              check:
+                ($error != null): true
+---
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: deny-namespace-with-invalid-cost-center
+spec:
+  concurrent: false
+  description: |
+    Tests that a namespace labeled as `konflux-ci.dev/type: tenant`
+    is denied if the `cost-center` label is invalid.
+  steps:
+    - name: Apply RBAC
+      try:
+        - apply:
+            file: ../kyverno-cluster-role.yaml
+    - name: Apply Kyverno Cluster Policy and assert it exists
+      try:
+        - apply:
+            file: ../validate-cost-management-labels-cp.yaml
+        - assert:
+            file: chainsaw-assert-clusterpolicy.yaml
+            template: true
+            bindings:
+              - name: cluster_policy_name
+                value: validate-cost-management-labels
+    - name: Attempt to create a tenant namespace with invalid cost-center label
+      try:
+        - create:
+            file: ./resources/namespace-cost-center.yaml
+            template: true
+            bindings:
+              - name: namespace
+                value: tenant
+              - name: cost_center
+                value: "invalid-should-be-all-numbers"
+            expect:
+            - match:
+                kind: Namespace
+              check:
+                ($error != null): true

--- a/components/policies-rd/rings/ring-1/base/cost-management/validate-cost-management-labels/.chainsaw-test/resources/namespace-cost-center.yaml
+++ b/components/policies-rd/rings/ring-1/base/cost-management/validate-cost-management-labels/.chainsaw-test/resources/namespace-cost-center.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ($namespace)
+  labels:
+    konflux-ci.dev/type: tenant
+    cost-center: ($cost_center)
+    cost_management_optimizations: "true"

--- a/components/policies-rd/rings/ring-1/base/cost-management/validate-cost-management-labels/.chainsaw-test/resources/namespace-empty-cost-center.yaml
+++ b/components/policies-rd/rings/ring-1/base/cost-management/validate-cost-management-labels/.chainsaw-test/resources/namespace-empty-cost-center.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: tenant-empty-cost-center
+  labels:
+    konflux-ci.dev/type: tenant
+    cost-center: ""
+    cost_management_optimizations: "true"

--- a/components/policies-rd/rings/ring-1/base/cost-management/validate-cost-management-labels/.chainsaw-test/resources/namespace-no-cost-center.yaml
+++ b/components/policies-rd/rings/ring-1/base/cost-management/validate-cost-management-labels/.chainsaw-test/resources/namespace-no-cost-center.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ($namespace)
+  labels:
+    konflux-ci.dev/type: tenant

--- a/components/policies-rd/rings/ring-1/base/cost-management/validate-cost-management-labels/.chainsaw-test/resources/namespace-nonmatching.yaml
+++ b/components/policies-rd/rings/ring-1/base/cost-management/validate-cost-management-labels/.chainsaw-test/resources/namespace-nonmatching.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: random-ns

--- a/components/policies-rd/rings/ring-1/base/cost-management/validate-cost-management-labels/kustomization.yaml
+++ b/components/policies-rd/rings/ring-1/base/cost-management/validate-cost-management-labels/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- validate-cost-management-labels-cp.yaml
+- kyverno-cluster-role.yaml

--- a/components/policies-rd/rings/ring-1/base/cost-management/validate-cost-management-labels/kyverno-cluster-role.yaml
+++ b/components/policies-rd/rings/ring-1/base/cost-management/validate-cost-management-labels/kyverno-cluster-role.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kyverno-admission-validate-cost-management-labels
+  labels:
+    rbac.kyverno.io/aggregate-to-admission-controller: "true"
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - list
+  - get

--- a/components/policies-rd/rings/ring-1/base/cost-management/validate-cost-management-labels/validate-cost-management-labels-cp.yaml
+++ b/components/policies-rd/rings/ring-1/base/cost-management/validate-cost-management-labels/validate-cost-management-labels-cp.yaml
@@ -1,0 +1,54 @@
+---
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: validate-cost-management-labels
+  annotations:
+    policies.kyverno.io/title: Validate Cost-Management label
+    policies.kyverno.io/category: Cost Management
+    policies.kyverno.io/severity: low
+    policies.kyverno.io/subject: Namespace
+    policies.kyverno.io/description: >-
+      This policy ensures that:
+      (1) New tenant namespaces have the `cost-management` label.
+      (2) The `cost-management` label value contains only numeric characters.
+spec:
+  validationFailureAction: Enforce
+  rules:
+  - name: validate-cost-center-label
+    skipBackgroundRequests: true
+    match:
+      any:
+      - resources:
+          kinds:
+          - Namespace
+          selector:
+            matchLabels:
+              konflux-ci.dev/type: tenant
+    validate:
+      allowExistingViolations: true
+      message: "Tenant namespaces must have the 'cost-center' label."
+      pattern:
+        metadata:
+          labels:
+            cost-center: "?*"
+  - name: validate-cost-center-label-value
+    skipBackgroundRequests: true
+    match:
+      any:
+      - resources:
+          kinds:
+          - Namespace
+          operations:
+          - CREATE
+          - UPDATE
+          selector:
+            matchLabels:
+              konflux-ci.dev/type: tenant
+              cost-center: "?*"
+    validate:
+      allowExistingViolations: true
+      message: "Tenant namespaces 'cost-center' label can only contain numbers."
+      cel:
+        expressions:
+        - expression: "object.metadata.labels['cost-center'].matches('^[0-9]+$')"

--- a/components/policies-rd/rings/ring-1/base/konflux-rbac/kustomization.yaml
+++ b/components/policies-rd/rings/ring-1/base/konflux-rbac/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- restrict-binding-system-authenticated/

--- a/components/policies-rd/rings/ring-1/base/konflux-rbac/restrict-binding-system-authenticated/.chainsaw-test/README.md
+++ b/components/policies-rd/rings/ring-1/base/konflux-rbac/restrict-binding-system-authenticated/.chainsaw-test/README.md
@@ -1,0 +1,232 @@
+# Test: `in-tenant-invalid-rolebinding`
+
+tests that the a invalid RoleBinding can NOT be created
+in a tenant namespace
+
+
+## Steps
+
+| # | Name | Bindings | Try | Catch | Finally | Cleanup |
+|:-:|---|:-:|:-:|:-:|:-:|:-:|
+| 1 | [given-kyverno-has-permission-on-resources](#step-given-kyverno-has-permission-on-resources) | 0 | 1 | 0 | 0 | 0 |
+| 2 | [given-cluster-policy-is-ready](#step-given-cluster-policy-is-ready) | 0 | 2 | 0 | 0 | 0 |
+| 3 | [given-tenant-namespace-exists](#step-given-tenant-namespace-exists) | 0 | 1 | 0 | 0 | 0 |
+| 4 | [then-invalid-rolebinding-can-not-be-created](#step-then-invalid-rolebinding-can-not-be-created) | 0 | 1 | 0 | 0 | 0 |
+
+### Step: `given-kyverno-has-permission-on-resources`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `given-cluster-policy-is-ready`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+| 2 | `assert` | 0 | 0 | *No description* |
+
+### Step: `given-tenant-namespace-exists`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `then-invalid-rolebinding-can-not-be-created`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+---
+
+# Test: `in-tenant-valid-rolebinding`
+
+tests that the a any RoleBinding can be created in the
+tenant namespace 'rhtap-releng-tenant'
+
+
+## Steps
+
+| # | Name | Bindings | Try | Catch | Finally | Cleanup |
+|:-:|---|:-:|:-:|:-:|:-:|:-:|
+| 1 | [given-kyverno-has-permission-on-resources](#step-given-kyverno-has-permission-on-resources) | 0 | 1 | 0 | 0 | 0 |
+| 2 | [given-cluster-policy-is-ready](#step-given-cluster-policy-is-ready) | 0 | 2 | 0 | 0 | 0 |
+| 3 | [given-tenant-namespace-exists](#step-given-tenant-namespace-exists) | 0 | 1 | 0 | 0 | 0 |
+| 4 | [then-valid-rolebinding-can-be-created](#step-then-valid-rolebinding-can-be-created) | 0 | 1 | 0 | 0 | 0 |
+| 5 | [then-invalid-rolebinding-can-be-created](#step-then-invalid-rolebinding-can-be-created) | 0 | 1 | 0 | 0 | 0 |
+
+### Step: `given-kyverno-has-permission-on-resources`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `given-cluster-policy-is-ready`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+| 2 | `assert` | 0 | 0 | *No description* |
+
+### Step: `given-tenant-namespace-exists`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `then-valid-rolebinding-can-be-created`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `then-invalid-rolebinding-can-be-created`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+---
+
+# Test: `in-tenant-valid-rolebinding`
+
+tests that the a valid RoleBinding can be created in a
+tenant namespace
+
+
+## Steps
+
+| # | Name | Bindings | Try | Catch | Finally | Cleanup |
+|:-:|---|:-:|:-:|:-:|:-:|:-:|
+| 1 | [given-kyverno-has-permission-on-resources](#step-given-kyverno-has-permission-on-resources) | 0 | 1 | 0 | 0 | 0 |
+| 2 | [given-cluster-policy-is-ready](#step-given-cluster-policy-is-ready) | 0 | 2 | 0 | 0 | 0 |
+| 3 | [given-tenant-namespace-exists](#step-given-tenant-namespace-exists) | 0 | 1 | 0 | 0 | 0 |
+| 4 | [then-valid-rolebinding-can-be-created](#step-then-valid-rolebinding-can-be-created) | 0 | 1 | 0 | 0 | 0 |
+
+### Step: `given-kyverno-has-permission-on-resources`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `given-cluster-policy-is-ready`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+| 2 | `assert` | 0 | 0 | *No description* |
+
+### Step: `given-tenant-namespace-exists`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `then-valid-rolebinding-can-be-created`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+---
+
+# Test: `out-of-tenant-rolebinding`
+
+tests that the whatever RoleBinding can be created in a
+non-tenant namespace
+
+
+## Steps
+
+| # | Name | Bindings | Try | Catch | Finally | Cleanup |
+|:-:|---|:-:|:-:|:-:|:-:|:-:|
+| 1 | [given-kyverno-has-permission-on-resources](#step-given-kyverno-has-permission-on-resources) | 0 | 1 | 0 | 0 | 0 |
+| 2 | [given-cluster-policy-is-ready](#step-given-cluster-policy-is-ready) | 0 | 2 | 0 | 0 | 0 |
+| 3 | [then-rolebinding-can-be-created-in-a-nontenant-namespace](#step-then-rolebinding-can-be-created-in-a-nontenant-namespace) | 0 | 1 | 0 | 0 | 0 |
+
+### Step: `given-kyverno-has-permission-on-resources`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `given-cluster-policy-is-ready`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+| 2 | `assert` | 0 | 0 | *No description* |
+
+### Step: `then-rolebinding-can-be-created-in-a-nontenant-namespace`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+---
+

--- a/components/policies-rd/rings/ring-1/base/konflux-rbac/restrict-binding-system-authenticated/.chainsaw-test/chainsaw-assert-clusterpolicy.yaml
+++ b/components/policies-rd/rings/ring-1/base/konflux-rbac/restrict-binding-system-authenticated/.chainsaw-test/chainsaw-assert-clusterpolicy.yaml
@@ -1,0 +1,9 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: validate-restrict-binding-system-authenticated
+status:
+  conditions:
+  - reason: Succeeded
+    status: "True"
+    type: Ready

--- a/components/policies-rd/rings/ring-1/base/konflux-rbac/restrict-binding-system-authenticated/.chainsaw-test/chainsaw-test.yaml
+++ b/components/policies-rd/rings/ring-1/base/konflux-rbac/restrict-binding-system-authenticated/.chainsaw-test/chainsaw-test.yaml
@@ -1,0 +1,215 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: in-tenant-invalid-rolebinding
+spec:
+  description: |
+    tests that the a invalid RoleBinding can NOT be created
+    in a tenant namespace
+  concurrent: false
+  namespace: 'invalid-systemauthenticated-rb-tenant-namespace'
+  steps:
+  - name: given-kyverno-has-permission-on-resources
+    try:
+    - apply:
+        file: ../kyverno-cluster-role.yaml
+  - name: given-cluster-policy-is-ready
+    try:
+    - apply:
+        file: ../validate-restrict-binding-system-authenticated-cp.yaml
+    - assert:
+        file: chainsaw-assert-clusterpolicy.yaml
+  - name: given-tenant-namespace-exists
+    try:
+    - apply:
+        file: ./resources/tenant-namespace.yaml
+  - name: then-invalid-rolebinding-can-not-be-created
+    try:
+    - apply:
+        file: ./resources/invalid-systemauthenticated-rolebinding.yaml
+        expect:
+        - check:
+            ($error != null): true
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: in-tenant-delete-invalid-existing-rolebinding
+spec:
+  description: |
+    tests that the an existing invalid RoleBinding can be deleted
+    in a tenant namespace
+  concurrent: false
+  namespace: 'existing-invalid-sysauth-rb-tenant-namespace'
+  steps:
+  - name: given-tenant-namespace-exists
+    try:
+    - apply:
+        file: ./resources/tenant-namespace.yaml
+  - name: given-invalid-rolebinding-exists
+    try:
+    - create:
+        file: ./resources/invalid-systemauthenticated-rolebinding.yaml
+  - name: given-kyverno-has-permission-on-resources
+    try:
+    - apply:
+        file: ../kyverno-cluster-role.yaml
+  - name: when-cluster-policy-is-ready
+    try:
+    - apply:
+        file: ../validate-restrict-binding-system-authenticated-cp.yaml
+    - assert:
+        file: chainsaw-assert-clusterpolicy.yaml
+  - name: then-invalid-rolebinding-can-be-deleted
+    try:
+    - delete:
+        file: ./resources/invalid-systemauthenticated-rolebinding.yaml
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: in-tenant-valid-rolebinding
+spec:
+  description: |
+    tests that the a any RoleBinding can be created in the
+    tenant namespace 'rhtap-releng-tenant'
+  concurrent: false
+  namespace: 'rhtap-releng-tenant'
+  steps:
+  - name: given-kyverno-has-permission-on-resources
+    try:
+    - apply:
+        file: ../kyverno-cluster-role.yaml
+  - name: given-cluster-policy-is-ready
+    try:
+    - apply:
+        file: ../validate-restrict-binding-system-authenticated-cp.yaml
+    - assert:
+        file: chainsaw-assert-clusterpolicy.yaml
+  - name: given-tenant-namespace-exists
+    try:
+    - apply:
+        file: ./resources/tenant-namespace.yaml
+  - name: then-valid-rolebinding-can-be-created
+    try:
+    - apply:
+        file: ./resources/valid-systemauthenticated-rolebinding.yaml
+        expect:
+        - check:
+            ($error != null): false
+  - name: then-invalid-rolebinding-can-be-created
+    try:
+    - apply:
+        file: ./resources/invalid-systemauthenticated-rolebinding.yaml
+        expect:
+        - check:
+            ($error != null): false
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: in-default-tenant-valid-rolebinding
+spec:
+  description: |
+    tests that any RoleBinding can be created in the
+    tenant namespace 'default-tenant'
+  concurrent: false
+  namespace: 'default-tenant'
+  steps:
+  - name: given-kyverno-has-permission-on-resources
+    try:
+    - apply:
+        file: ../kyverno-cluster-role.yaml
+  - name: given-cluster-policy-is-ready
+    try:
+    - apply:
+        file: ../validate-restrict-binding-system-authenticated-cp.yaml
+    - assert:
+        file: chainsaw-assert-clusterpolicy.yaml
+  - name: given-tenant-namespace-exists
+    try:
+    - apply:
+        file: ./resources/tenant-namespace.yaml
+  - name: then-valid-rolebinding-can-be-created
+    try:
+    - apply:
+        file: ./resources/valid-systemauthenticated-rolebinding.yaml
+        expect:
+        - check:
+            ($error != null): false
+  - name: then-invalid-rolebinding-can-be-created
+    try:
+    - apply:
+        file: ./resources/invalid-systemauthenticated-rolebinding.yaml
+        expect:
+        - check:
+            ($error != null): false
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: in-tenant-valid-rolebinding
+spec:
+  description: |
+    tests that the a valid RoleBinding can be created in a
+    tenant namespace
+  concurrent: false
+  namespace: 'valid-systemauthenticated-rb-tenant-namespace'
+  steps:
+  - name: given-kyverno-has-permission-on-resources
+    try:
+    - apply:
+        file: ../kyverno-cluster-role.yaml
+  - name: given-cluster-policy-is-ready
+    try:
+    - apply:
+        file: ../validate-restrict-binding-system-authenticated-cp.yaml
+    - assert:
+        file: chainsaw-assert-clusterpolicy.yaml
+  - name: given-tenant-namespace-exists
+    try:
+    - apply:
+        file: ./resources/tenant-namespace.yaml
+  - name: then-valid-rolebinding-can-be-created
+    try:
+    - apply:
+        file: ./resources/valid-systemauthenticated-rolebinding.yaml
+        expect:
+        - check:
+            ($error != null): false
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: out-of-tenant-rolebinding
+spec:
+  description: |
+    tests that the whatever RoleBinding can be created in a
+    non-tenant namespace
+  concurrent: false
+  namespace: 'valid-systemauthenticated-rb-namespace'
+  steps:
+  - name: given-kyverno-has-permission-on-resources
+    try:
+    - apply:
+        file: ../kyverno-cluster-role.yaml
+  - name: given-cluster-policy-is-ready
+    try:
+    - apply:
+        file: ../validate-restrict-binding-system-authenticated-cp.yaml
+    - assert:
+        file: chainsaw-assert-clusterpolicy.yaml
+  - name: then-rolebinding-can-be-created-in-a-nontenant-namespace
+    try:
+    - apply:
+        file: ./resources/valid-systemauthenticated-rolebinding.yaml
+        expect:
+        - check:
+            ($error != null): false

--- a/components/policies-rd/rings/ring-1/base/konflux-rbac/restrict-binding-system-authenticated/.chainsaw-test/resources/invalid-systemauthenticated-rolebinding.yaml
+++ b/components/policies-rd/rings/ring-1/base/konflux-rbac/restrict-binding-system-authenticated/.chainsaw-test/resources/invalid-systemauthenticated-rolebinding.yaml
@@ -1,0 +1,18 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: invalid-systemauthenticated-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: not-konflux-viewer-user-actions
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:authenticated
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: my-user
+- apiGroup: ""
+  kind: ServiceAccount
+  name: my-serviceaccount

--- a/components/policies-rd/rings/ring-1/base/konflux-rbac/restrict-binding-system-authenticated/.chainsaw-test/resources/tenant-namespace.yaml
+++ b/components/policies-rd/rings/ring-1/base/konflux-rbac/restrict-binding-system-authenticated/.chainsaw-test/resources/tenant-namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ($namespace)
+  labels:
+    konflux-ci.dev/type: tenant

--- a/components/policies-rd/rings/ring-1/base/konflux-rbac/restrict-binding-system-authenticated/.chainsaw-test/resources/valid-systemauthenticated-rolebinding.yaml
+++ b/components/policies-rd/rings/ring-1/base/konflux-rbac/restrict-binding-system-authenticated/.chainsaw-test/resources/valid-systemauthenticated-rolebinding.yaml
@@ -1,0 +1,18 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: valid-systemauthenticated-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: konflux-viewer-user-actions
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:authenticated
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: my-user
+- apiGroup: ""
+  kind: ServiceAccount
+  name: my-serviceaccount

--- a/components/policies-rd/rings/ring-1/base/konflux-rbac/restrict-binding-system-authenticated/kustomization.yaml
+++ b/components/policies-rd/rings/ring-1/base/konflux-rbac/restrict-binding-system-authenticated/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namePrefix: konflux-rbac-
+resources:
+- validate-restrict-binding-system-authenticated-cp.yaml
+- kyverno-cluster-role.yaml
+commonAnnotations:
+  argocd.argoproj.io/sync-options: Prune=false

--- a/components/policies-rd/rings/ring-1/base/konflux-rbac/restrict-binding-system-authenticated/kyverno-cluster-role.yaml
+++ b/components/policies-rd/rings/ring-1/base/konflux-rbac/restrict-binding-system-authenticated/kyverno-cluster-role.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kyverno-admission:restrict-binding-system-authenticated
+  labels:
+    rbac.kyverno.io/aggregate-to-admission-controller: "true"
+rules:
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - rolebindings
+  verbs:
+  - list
+  - get
+  - watch
+---

--- a/components/policies-rd/rings/ring-1/base/konflux-rbac/restrict-binding-system-authenticated/validate-restrict-binding-system-authenticated-cp.yaml
+++ b/components/policies-rd/rings/ring-1/base/konflux-rbac/restrict-binding-system-authenticated/validate-restrict-binding-system-authenticated-cp.yaml
@@ -1,0 +1,50 @@
+---
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: validate-restrict-binding-system-authenticated
+  annotations:
+    policies.kyverno.io/title: Restrict Binding System Groups
+    policies.kyverno.io/category: Security
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: RoleBinding, RBAC
+    policies.kyverno.io/description: >-
+      We don't want users to bind system:authenticated group with any role
+      except for the konflux-viewer-user-actions ClusterRole.
+spec:
+  rules:
+  - name: restrict-authenticated
+    skipBackgroundRequests: true
+    match:
+      any:
+      - resources:
+          kinds:
+          - RoleBinding
+          namespaceSelector:
+            matchLabels:
+              konflux-ci.dev/type: tenant
+          operations:
+          - CREATE
+          - UPDATE
+    exclude:
+      any:
+      - resources:
+          namespaces:
+          - rhtap-releng-tenant
+          - default-tenant
+    preconditions:
+      all:
+      - key: "{{ request.object.subjects[].name }}"
+        operator: AnyIn
+        value: "system:authenticated"
+      - key: "{{ request.object.roleRef.kind }}"
+        operator: Equals
+        value: "ClusterRole"
+      - key: "{{ request.object.roleRef.name }}"
+        operator: NotEquals
+        value: "konflux-viewer-user-actions"
+    validate:
+      allowExistingViolations: true
+      failureAction: Enforce
+      message: "Only ClusterRole konflux-viewer-user-actions can be bound to system:authenticated."
+      deny: {}

--- a/components/policies-rd/rings/ring-1/base/kueue/deny-unallowed-annotations/.chainsaw-test/chainsaw-assert-pipelineruns-crd.yaml
+++ b/components/policies-rd/rings/ring-1/base/kueue/deny-unallowed-annotations/.chainsaw-test/chainsaw-assert-pipelineruns-crd.yaml
@@ -1,0 +1,7 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: pipelineruns.tekton.dev
+status:
+  acceptedNames:
+    kind: PipelineRun

--- a/components/policies-rd/rings/ring-1/base/kueue/deny-unallowed-annotations/.chainsaw-test/chainsaw-assert-policy.yaml
+++ b/components/policies-rd/rings/ring-1/base/kueue/deny-unallowed-annotations/.chainsaw-test/chainsaw-assert-policy.yaml
@@ -1,0 +1,7 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: deny-unallowed-annotations.kueue.konflux-ci.dev
+status:
+  observedGeneration: 1
+  typeChecking: {}

--- a/components/policies-rd/rings/ring-1/base/kueue/deny-unallowed-annotations/.chainsaw-test/resources/pipelinerun_with_allowed_annotations.yaml
+++ b/components/policies-rd/rings/ring-1/base/kueue/deny-unallowed-annotations/.chainsaw-test/resources/pipelinerun_with_allowed_annotations.yaml
@@ -1,0 +1,7 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  name: pipelinerun-with-allowed-annotations
+  annotations:
+    my/prefix1-allowed: "1"
+    my/prefix2-allowed: "1"

--- a/components/policies-rd/rings/ring-1/base/kueue/deny-unallowed-annotations/.chainsaw-test/resources/pipelinerun_with_unallowed_annotations.yaml
+++ b/components/policies-rd/rings/ring-1/base/kueue/deny-unallowed-annotations/.chainsaw-test/resources/pipelinerun_with_unallowed_annotations.yaml
@@ -1,0 +1,7 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  name: pipelinerun-with-validation-error
+  annotations:
+    my/prefix1-unallowed: "1"
+    my/prefix2-unallowed: "1"

--- a/components/policies-rd/rings/ring-1/base/kueue/deny-unallowed-annotations/.chainsaw-test/resources/pipelinerun_without_annotations.yaml
+++ b/components/policies-rd/rings/ring-1/base/kueue/deny-unallowed-annotations/.chainsaw-test/resources/pipelinerun_without_annotations.yaml
@@ -1,0 +1,4 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  name: pipelinerun-without-annotations

--- a/components/policies-rd/rings/ring-1/base/kueue/deny-unallowed-annotations/.chainsaw-test/resources/pipelinerun_without_filtered_annotations.yaml
+++ b/components/policies-rd/rings/ring-1/base/kueue/deny-unallowed-annotations/.chainsaw-test/resources/pipelinerun_without_filtered_annotations.yaml
@@ -1,0 +1,6 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  name: pipelinerun-without-filtered-resource
+  annotations:
+    my/different-unfiltered-annotation: "1"

--- a/components/policies-rd/rings/ring-1/base/kueue/deny-unallowed-annotations/.chainsaw-test/resources/pipelineruns.tekton.dev_customresourcedefinition.yaml
+++ b/components/policies-rd/rings/ring-1/base/kueue/deny-unallowed-annotations/.chainsaw-test/resources/pipelineruns.tekton.dev_customresourcedefinition.yaml
@@ -1,0 +1,21 @@
+# Minimal PipelineRun CRD for chainsaw tests (VAP exercises tekton.dev/v1).
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: pipelineruns.tekton.dev
+spec:
+  group: tekton.dev
+  names:
+    kind: PipelineRun
+    listKind: PipelineRunList
+    plural: pipelineruns
+    singular: pipelinerun
+  scope: Namespaced
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        x-kubernetes-preserve-unknown-fields: true

--- a/components/policies-rd/rings/ring-1/base/kueue/deny-unallowed-annotations/.chainsaw-test/test-in-tenant/chainsaw-test.yaml
+++ b/components/policies-rd/rings/ring-1/base/kueue/deny-unallowed-annotations/.chainsaw-test/test-in-tenant/chainsaw-test.yaml
@@ -1,0 +1,94 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: in-tenant-deny-pipelinerun-with-validation-error
+spec:
+  description: |
+    denies a PipelineRun that has unallowed annotation in a tenant namespace
+  concurrent: false
+  steps:
+  - name: given-pipelineruns-crd-exists
+    try:
+    - apply:
+        file: ../resources/pipelineruns.tekton.dev_customresourcedefinition.yaml
+    - assert:
+        file: ../chainsaw-assert-pipelineruns-crd.yaml
+  - name: ensure-namespace-is-labeled
+    try:
+    - apply:
+        resource:
+          apiVersion: v1
+          kind: Namespace
+          metadata:
+            name: ($namespace)
+            labels:
+              konflux-ci.dev/type: tenant
+  - name: given-validatingadmissionpolicy-is-installed
+    try:
+    - apply:
+        file: ../../deny-unallowed-annotations-validatingadmissionpolicy.yaml
+    - apply:
+        file: ../../deny-unallowed-annotations-validatingadmissionpolicybinding.yaml
+    - assert:
+        file: ../chainsaw-assert-policy.yaml
+    - sleep:
+        duration: 1s
+  - name: then-pipelinerun-with-unallowed-annotations-is-denied
+    try:
+    - create:
+        file: ../resources/pipelinerun_with_unallowed_annotations.yaml
+        expect:
+          - check:
+              ($error != null): true
+              '(regex_match(''^pipelineruns.tekton.dev \"pipelinerun-with-validation-error\" is forbidden: ValidatingAdmissionPolicy \''deny-unallowed-annotations.kueue.konflux-ci.dev\'' with binding \''deny-unallowed-annotations.kueue.konflux-ci.dev\'' denied request: PipelineRun validation failed: one or more unexpected annotations found: (my/prefix2-unallowed, my/prefix1-unallowed|my/prefix1-unallowed, my/prefix2-unallowed)$'', $error))': true
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: in-tenant-allow-valid-pipelineruns
+spec:
+  description: |
+    allows a PipelineRun that only have allowed annotations in a tenant namespace
+  concurrent: false
+  steps:
+  - name: given-pipelineruns-crd-exists
+    try:
+    - apply:
+        file: ../resources/pipelineruns.tekton.dev_customresourcedefinition.yaml
+    - assert:
+        file: ../chainsaw-assert-pipelineruns-crd.yaml
+  - name: ensure-namespace-is-labeled
+    try:
+    - apply:
+        resource:
+          apiVersion: v1
+          kind: Namespace
+          metadata:
+            name: ($namespace)
+            labels:
+              konflux-ci.dev/type: tenant
+  - name: given-validatingadmissionpolicy-is-installed
+    try:
+    - apply:
+        file: ../../deny-unallowed-annotations-validatingadmissionpolicy.yaml
+    - apply:
+        file: ../../deny-unallowed-annotations-validatingadmissionpolicybinding.yaml
+    - assert:
+        file: ../chainsaw-assert-policy.yaml
+    - sleep:
+        duration: 1s
+  - name: then-pipelinerun-with-allowed-annotations-is-allowed
+    try:
+    - create:
+        file: ../resources/pipelinerun_with_allowed_annotations.yaml
+  - name: then-pipelinerun-without-annotations-is-allowed
+    try:
+    - create:
+        file: ../resources/pipelinerun_without_annotations.yaml
+  - name: then-pipelinerun-without-filtered-annotations-is-allowed
+    try:
+    - create:
+        file: ../resources/pipelinerun_without_filtered_annotations.yaml

--- a/components/policies-rd/rings/ring-1/base/kueue/deny-unallowed-annotations/.chainsaw-test/test-out-tenant/chainsaw-test.yaml
+++ b/components/policies-rd/rings/ring-1/base/kueue/deny-unallowed-annotations/.chainsaw-test/test-out-tenant/chainsaw-test.yaml
@@ -1,0 +1,88 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: out-tenant-allow-pipelinerun-with-validation-error
+spec:
+  description: |
+    allows a PipelineRun that has unallowed annotation in a non-tenant namespace
+  concurrent: false
+  steps:
+  - name: given-pipelineruns-crd-exists
+    try:
+    - apply:
+        file: ../resources/pipelineruns.tekton.dev_customresourcedefinition.yaml
+    - assert:
+        file: ../chainsaw-assert-pipelineruns-crd.yaml
+  - name: ensure-namespace-is-not-labeled
+    try:
+    - apply:
+        resource:
+          apiVersion: v1
+          kind: Namespace
+          metadata:
+            name: ($namespace)
+            labels: {}
+  - name: given-validatingadmissionpolicy-is-installed
+    try:
+    - apply:
+        file: ../../deny-unallowed-annotations-validatingadmissionpolicy.yaml
+    - apply:
+        file: ../../deny-unallowed-annotations-validatingadmissionpolicybinding.yaml
+    - assert:
+        file: ../chainsaw-assert-policy.yaml
+    - sleep:
+        duration: 1s
+  - name: then-pipelinerun-with-unallowed-annotations-is-allowed
+    try:
+    - create:
+        file: ../resources/pipelinerun_with_unallowed_annotations.yaml
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: out-tenant-allow-valid-pipelineruns
+spec:
+  description: |
+    allows a PipelineRun that only have allowed annotations in a non-tenant namespace
+  concurrent: false
+  steps:
+  - name: given-pipelineruns-crd-exists
+    try:
+    - apply:
+        file: ../resources/pipelineruns.tekton.dev_customresourcedefinition.yaml
+    - assert:
+        file: ../chainsaw-assert-pipelineruns-crd.yaml
+  - name: ensure-namespace-is-not-labeled
+    try:
+    - apply:
+        resource:
+          apiVersion: v1
+          kind: Namespace
+          metadata:
+            name: ($namespace)
+            labels: {}
+  - name: given-validatingadmissionpolicy-is-installed
+    try:
+    - apply:
+        file: ../../deny-unallowed-annotations-validatingadmissionpolicy.yaml
+    - apply:
+        file: ../../deny-unallowed-annotations-validatingadmissionpolicybinding.yaml
+    - assert:
+        file: ../chainsaw-assert-policy.yaml
+    - sleep:
+        duration: 1s
+  - name: then-pipelinerun-with-allowed-annotations-is-allowed
+    try:
+    - create:
+        file: ../resources/pipelinerun_with_allowed_annotations.yaml
+  - name: then-pipelinerun-without-annotations-is-allowed
+    try:
+    - create:
+        file: ../resources/pipelinerun_without_annotations.yaml
+  - name: then-pipelinerun-without-filtered-annotations-is-allowed
+    try:
+    - create:
+        file: ../resources/pipelinerun_without_filtered_annotations.yaml

--- a/components/policies-rd/rings/ring-1/base/kueue/deny-unallowed-annotations/deny-unallowed-annotations-validatingadmissionpolicy.yaml
+++ b/components/policies-rd/rings/ring-1/base/kueue/deny-unallowed-annotations/deny-unallowed-annotations-validatingadmissionpolicy.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: deny-unallowed-annotations.kueue.konflux-ci.dev
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+      - apiGroups: ["tekton.dev"]
+        apiVersions: ["v1"]
+        operations: ["CREATE"]
+        resources: ["pipelineruns"]
+        scope: "Namespaced"
+  variables:
+  - name: "allowedAnnotations"
+    expression: '["my/prefix1-allowed", "my/prefix2-allowed"]'
+  - name: "annotationPrefixes"
+    expression: '["my/prefix1-", "my/prefix2-"]'
+  - name: "difference"
+    expression: |-
+      has(object.metadata.annotations) ?
+        object.metadata.annotations.
+          filter(i, variables.annotationPrefixes.exists(p, i.startsWith(p))).
+          filter(i, !(i in variables.allowedAnnotations)) : []
+  validations:
+    - expression: "size(variables.difference) == 0"
+      messageExpression: |-
+        "PipelineRun validation failed: one or more unexpected annotations found: " +
+        variables.difference.join(", ")
+      message: "PipelineRun validation failed: one or more unexpected annotations found"

--- a/components/policies-rd/rings/ring-1/base/kueue/deny-unallowed-annotations/deny-unallowed-annotations-validatingadmissionpolicybinding.yaml
+++ b/components/policies-rd/rings/ring-1/base/kueue/deny-unallowed-annotations/deny-unallowed-annotations-validatingadmissionpolicybinding.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: deny-unallowed-annotations.kueue.konflux-ci.dev
+spec:
+  policyName: "deny-unallowed-annotations.kueue.konflux-ci.dev"
+  validationActions: [Deny]
+  matchResources:
+    namespaceSelector:
+      matchLabels:
+        konflux-ci.dev/type: tenant

--- a/components/policies-rd/rings/ring-1/base/kueue/deny-unallowed-annotations/kustomization.yaml
+++ b/components/policies-rd/rings/ring-1/base/kueue/deny-unallowed-annotations/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- deny-unallowed-annotations-validatingadmissionpolicy.yaml
+- deny-unallowed-annotations-validatingadmissionpolicybinding.yaml

--- a/components/policies-rd/rings/ring-1/base/kueue/kustomization.yaml
+++ b/components/policies-rd/rings/ring-1/base/kueue/kustomization.yaml
@@ -1,0 +1,18 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- no-skip
+- deny-unallowed-annotations
+- pre-sync-hook.yaml
+
+namespace: konflux-policies
+
+replacements:
+  - source:
+      kind: ServiceAccount
+      fieldPath: metadata.namespace
+    targets:
+      - select:
+          kind: ClusterRoleBinding
+        fieldPaths:
+          - subjects.0.namespace

--- a/components/policies-rd/rings/ring-1/base/kueue/no-skip/.chainsaw-test/chainsaw-assert-policy.yaml
+++ b/components/policies-rd/rings/ring-1/base/kueue/no-skip/.chainsaw-test/chainsaw-assert-policy.yaml
@@ -1,0 +1,7 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: no-skip.kueue.konflux-ci.dev
+status:
+  observedGeneration: 1
+  typeChecking: {}

--- a/components/policies-rd/rings/ring-1/base/kueue/no-skip/.chainsaw-test/chainsaw-assert-taskruns-crd.yaml
+++ b/components/policies-rd/rings/ring-1/base/kueue/no-skip/.chainsaw-test/chainsaw-assert-taskruns-crd.yaml
@@ -1,0 +1,10 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: taskruns.tekton.dev
+status:
+  conditions:
+  - type: NamesAccepted
+    status: "True"
+  - type: Established
+    status: "True"

--- a/components/policies-rd/rings/ring-1/base/kueue/no-skip/.chainsaw-test/resources/taskrun_invalid_no_annotation.yaml
+++ b/components/policies-rd/rings/ring-1/base/kueue/no-skip/.chainsaw-test/resources/taskrun_invalid_no_annotation.yaml
@@ -1,0 +1,19 @@
+apiVersion: tekton.dev/v1
+kind: TaskRun
+metadata:
+  name: invalid-no-annotation-task
+spec:
+  taskSpec:
+    steps:
+    - name: no-op
+      image: registry.access.redhat.com/ubi10-micro:10.1
+      script: |-
+        #!/bin/bash
+        echo "no-op"
+    params:
+    - description: The platform to build on
+      name: PLATFORM
+      type: string
+  params:
+  - name: PLATFORM
+    value: test-platform

--- a/components/policies-rd/rings/ring-1/base/kueue/no-skip/.chainsaw-test/resources/taskrun_invalid_wrong_annotation.yaml
+++ b/components/policies-rd/rings/ring-1/base/kueue/no-skip/.chainsaw-test/resources/taskrun_invalid_wrong_annotation.yaml
@@ -1,0 +1,21 @@
+apiVersion: tekton.dev/v1
+kind: TaskRun
+metadata:
+  name: invalid-wrong-annotation-task
+  annotations:
+    kueue.konflux-ci.dev/requests-another-platform: "1"
+spec:
+  taskSpec:
+    steps:
+    - name: no-op
+      image: registry.access.redhat.com/ubi10-micro:10.1
+      script: |-
+        #!/bin/bash
+        echo "no-op"
+    params:
+    - description: The platform to build on
+      name: PLATFORM
+      type: string
+  params:
+  - name: PLATFORM
+    value: test-platform

--- a/components/policies-rd/rings/ring-1/base/kueue/no-skip/.chainsaw-test/resources/taskrun_skipped.yaml
+++ b/components/policies-rd/rings/ring-1/base/kueue/no-skip/.chainsaw-test/resources/taskrun_skipped.yaml
@@ -1,0 +1,12 @@
+apiVersion: tekton.dev/v1
+kind: TaskRun
+metadata:
+  name: skipped-task
+spec:
+  taskSpec:
+    steps:
+    - name: no-op
+      image: registry.access.redhat.com/ubi10-micro:10.1
+      script: |-
+        #!/bin/bash
+        echo "no-op"

--- a/components/policies-rd/rings/ring-1/base/kueue/no-skip/.chainsaw-test/resources/taskrun_valid.yaml
+++ b/components/policies-rd/rings/ring-1/base/kueue/no-skip/.chainsaw-test/resources/taskrun_valid.yaml
@@ -1,0 +1,21 @@
+apiVersion: tekton.dev/v1
+kind: TaskRun
+metadata:
+  name: valid-task
+  annotations:
+    kueue.konflux-ci.dev/requests-test-platform: "1"
+spec:
+  taskSpec:
+    steps:
+    - name: no-op
+      image: registry.access.redhat.com/ubi10-micro:10.1
+      script: |-
+        #!/bin/bash
+        echo "no-op"
+    params:
+    - description: The platform to build on
+      name: PLATFORM
+      type: string
+  params:
+  - name: PLATFORM
+    value: test-platform

--- a/components/policies-rd/rings/ring-1/base/kueue/no-skip/.chainsaw-test/resources/taskrun_valid_complex.yaml
+++ b/components/policies-rd/rings/ring-1/base/kueue/no-skip/.chainsaw-test/resources/taskrun_valid_complex.yaml
@@ -1,0 +1,21 @@
+apiVersion: tekton.dev/v1
+kind: TaskRun
+metadata:
+  name: valid-complex-taskrun
+  annotations:
+    kueue.konflux-ci.dev/requests-domain-my-resource: "1"
+spec:
+  taskSpec:
+    steps:
+    - name: no-op
+      image: registry.access.redhat.com/ubi10-micro:10.1
+      script: |-
+        #!/bin/bash
+        echo "no-op"
+    params:
+    - description: The platform to build on
+      name: PLATFORM
+      type: string
+  params:
+  - name: PLATFORM
+    value: domain/my_resource

--- a/components/policies-rd/rings/ring-1/base/kueue/no-skip/.chainsaw-test/resources/taskruns.tekton.dev_customresourcedefinition.yaml
+++ b/components/policies-rd/rings/ring-1/base/kueue/no-skip/.chainsaw-test/resources/taskruns.tekton.dev_customresourcedefinition.yaml
@@ -1,0 +1,28 @@
+# Minimal TaskRun CRD for chainsaw tests (VAP exercises tekton.dev/v1 and v1beta1).
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: taskruns.tekton.dev
+spec:
+  group: tekton.dev
+  names:
+    kind: TaskRun
+    listKind: TaskRunList
+    plural: taskruns
+    singular: taskrun
+  scope: Namespaced
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
+  - name: v1beta1
+    served: true
+    storage: false
+    schema:
+      openAPIV3Schema:
+        type: object
+        x-kubernetes-preserve-unknown-fields: true

--- a/components/policies-rd/rings/ring-1/base/kueue/no-skip/.chainsaw-test/test-in-tenant/README.md
+++ b/components/policies-rd/rings/ring-1/base/kueue/no-skip/.chainsaw-test/test-in-tenant/README.md
@@ -1,0 +1,295 @@
+# Test: `in-tenant-create-valid-taskrun`
+
+creates a TaskRun with a PLATFORM parameter and a corresponding
+tekton-kueue's annotation
+
+
+## Steps
+
+| # | Name | Bindings | Try | Catch | Finally | Cleanup |
+|:-:|---|:-:|:-:|:-:|:-:|:-:|
+| 1 | [given-taskruns-crd-exists](#step-given-taskruns-crd-exists) | 0 | 1 | 0 | 0 | 0 |
+| 2 | [ensure-namespace-is-labeled](#step-ensure-namespace-is-labeled) | 0 | 1 | 0 | 0 | 0 |
+| 3 | [given-validatingadmissionpolicy-is-installed](#step-given-validatingadmissionpolicy-is-installed) | 0 | 3 | 0 | 0 | 0 |
+| 4 | [then-valid-taskrun-can-be-created](#step-then-valid-taskrun-can-be-created) | 0 | 1 | 0 | 0 | 0 |
+
+### Step: `given-taskruns-crd-exists`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `ensure-namespace-is-labeled`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `given-validatingadmissionpolicy-is-installed`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+| 2 | `apply` | 0 | 0 | *No description* |
+| 3 | `assert` | 0 | 0 | *No description* |
+
+### Step: `then-valid-taskrun-can-be-created`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `create` | 0 | 0 | *No description* |
+
+---
+
+# Test: `in-tenant-create-valid-taskrun-complex-platform`
+
+creates a TaskRun with a complex PLATFORM parameter and a corresponding
+tekton-kueue's annotation
+
+
+## Steps
+
+| # | Name | Bindings | Try | Catch | Finally | Cleanup |
+|:-:|---|:-:|:-:|:-:|:-:|:-:|
+| 1 | [given-taskruns-crd-exists](#step-given-taskruns-crd-exists) | 0 | 1 | 0 | 0 | 0 |
+| 2 | [ensure-namespace-is-labeled](#step-ensure-namespace-is-labeled) | 0 | 1 | 0 | 0 | 0 |
+| 3 | [given-validatingadmissionpolicy-is-installed](#step-given-validatingadmissionpolicy-is-installed) | 0 | 3 | 0 | 0 | 0 |
+| 4 | [then-valid-taskrun-can-be-created](#step-then-valid-taskrun-can-be-created) | 0 | 1 | 0 | 0 | 0 |
+
+### Step: `given-taskruns-crd-exists`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `ensure-namespace-is-labeled`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `given-validatingadmissionpolicy-is-installed`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+| 2 | `apply` | 0 | 0 | *No description* |
+| 3 | `assert` | 0 | 0 | *No description* |
+
+### Step: `then-valid-taskrun-can-be-created`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `create` | 0 | 0 | *No description* |
+
+---
+
+# Test: `in-tenant-create-skipped-taskrun`
+
+creates a TaskRun with no PLATFORM parameter and no corresponding
+tekton-kueue's annotation
+
+
+## Steps
+
+| # | Name | Bindings | Try | Catch | Finally | Cleanup |
+|:-:|---|:-:|:-:|:-:|:-:|:-:|
+| 1 | [given-taskruns-crd-exists](#step-given-taskruns-crd-exists) | 0 | 1 | 0 | 0 | 0 |
+| 2 | [ensure-namespace-is-labeled](#step-ensure-namespace-is-labeled) | 0 | 1 | 0 | 0 | 0 |
+| 3 | [given-validatingadmissionpolicy-is-installed](#step-given-validatingadmissionpolicy-is-installed) | 0 | 3 | 0 | 0 | 0 |
+| 4 | [then-skipped-taskrun-can-be-created](#step-then-skipped-taskrun-can-be-created) | 0 | 1 | 0 | 0 | 0 |
+
+### Step: `given-taskruns-crd-exists`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `ensure-namespace-is-labeled`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `given-validatingadmissionpolicy-is-installed`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+| 2 | `apply` | 0 | 0 | *No description* |
+| 3 | `assert` | 0 | 0 | *No description* |
+
+### Step: `then-skipped-taskrun-can-be-created`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `create` | 0 | 0 | *No description* |
+
+---
+
+# Test: `in-tenant-create-invalid-wrong-annotation-taskrun`
+
+fails to create a TaskRun with a PLATFORM parameter and
+a wrong corresponding tekton-kueue's annotation
+
+
+## Steps
+
+| # | Name | Bindings | Try | Catch | Finally | Cleanup |
+|:-:|---|:-:|:-:|:-:|:-:|:-:|
+| 1 | [given-taskruns-crd-exists](#step-given-taskruns-crd-exists) | 0 | 1 | 0 | 0 | 0 |
+| 2 | [ensure-namespace-is-labeled](#step-ensure-namespace-is-labeled) | 0 | 1 | 0 | 0 | 0 |
+| 3 | [given-validatingadmissionpolicy-is-installed](#step-given-validatingadmissionpolicy-is-installed) | 0 | 3 | 0 | 0 | 0 |
+| 4 | [then-ivalid-taskrun-can-not-be-created](#step-then-ivalid-taskrun-can-not-be-created) | 0 | 1 | 0 | 0 | 0 |
+
+### Step: `given-taskruns-crd-exists`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `ensure-namespace-is-labeled`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `given-validatingadmissionpolicy-is-installed`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+| 2 | `apply` | 0 | 0 | *No description* |
+| 3 | `assert` | 0 | 0 | *No description* |
+
+### Step: `then-ivalid-taskrun-can-not-be-created`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `error` | 0 | 0 | *No description* |
+
+---
+
+# Test: `in-tenant-create-invalid-no-annotations-taskrun`
+
+fails to create a TaskRun with a PLATFORM parameter
+and no corresponding tekton-kueue's annotation
+
+
+## Steps
+
+| # | Name | Bindings | Try | Catch | Finally | Cleanup |
+|:-:|---|:-:|:-:|:-:|:-:|:-:|
+| 1 | [given-taskruns-crd-exists](#step-given-taskruns-crd-exists) | 0 | 1 | 0 | 0 | 0 |
+| 2 | [ensure-namespace-is-labeled](#step-ensure-namespace-is-labeled) | 0 | 1 | 0 | 0 | 0 |
+| 3 | [given-validatingadmissionpolicy-is-installed](#step-given-validatingadmissionpolicy-is-installed) | 0 | 3 | 0 | 0 | 0 |
+| 4 | [then-invalid-taskrun-can-not-be-created](#step-then-invalid-taskrun-can-not-be-created) | 0 | 1 | 0 | 0 | 0 |
+
+### Step: `given-taskruns-crd-exists`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `ensure-namespace-is-labeled`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `given-validatingadmissionpolicy-is-installed`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+| 2 | `apply` | 0 | 0 | *No description* |
+| 3 | `assert` | 0 | 0 | *No description* |
+
+### Step: `then-invalid-taskrun-can-not-be-created`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `error` | 0 | 0 | *No description* |
+
+---
+

--- a/components/policies-rd/rings/ring-1/base/kueue/no-skip/.chainsaw-test/test-in-tenant/chainsaw-test.yaml
+++ b/components/policies-rd/rings/ring-1/base/kueue/no-skip/.chainsaw-test/test-in-tenant/chainsaw-test.yaml
@@ -1,0 +1,200 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: in-tenant-create-valid-taskrun
+spec:
+  description: |
+    creates a TaskRun with a PLATFORM parameter and a corresponding
+    tekton-kueue's annotation
+  concurrent: false
+  steps:
+  - name: given-taskruns-crd-exists
+    try:
+    - apply:
+        file: ../resources/taskruns.tekton.dev_customresourcedefinition.yaml
+    - assert:
+        file: ../chainsaw-assert-taskruns-crd.yaml
+  - name: ensure-namespace-is-labeled
+    try:
+    - apply:
+        resource:
+          apiVersion: v1
+          kind: Namespace
+          metadata:
+            name: ($namespace)
+            labels:
+              konflux-ci.dev/type: tenant
+  - name: given-validatingadmissionpolicy-is-installed
+    try:
+    - apply:
+        file: ../../no-skip-validationadmissionpolicy.yaml
+    - apply:
+        file: ../../no-skip-validationadmissionpolicybinding.yaml
+    - assert:
+        file: ../chainsaw-assert-policy.yaml
+  - name: then-valid-taskrun-can-be-created
+    try:
+    - create:
+        file: ../resources/taskrun_valid.yaml
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: in-tenant-create-valid-taskrun-complex-platform
+spec:
+  description: |
+    creates a TaskRun with a complex PLATFORM parameter and a corresponding
+    tekton-kueue's annotation
+  concurrent: false
+  steps:
+  - name: given-taskruns-crd-exists
+    try:
+    - apply:
+        file: ../resources/taskruns.tekton.dev_customresourcedefinition.yaml
+    - assert:
+        file: ../chainsaw-assert-taskruns-crd.yaml
+  - name: ensure-namespace-is-labeled
+    try:
+    - apply:
+        resource:
+          apiVersion: v1
+          kind: Namespace
+          metadata:
+            name: ($namespace)
+            labels:
+              konflux-ci.dev/type: tenant
+  - name: given-validatingadmissionpolicy-is-installed
+    try:
+    - apply:
+        file: ../../no-skip-validationadmissionpolicy.yaml
+    - apply:
+        file: ../../no-skip-validationadmissionpolicybinding.yaml
+    - assert:
+        file: ../chainsaw-assert-policy.yaml
+  - name: then-valid-taskrun-can-be-created
+    try:
+    - create:
+        file: ../resources/taskrun_valid_complex.yaml
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: in-tenant-create-skipped-taskrun
+spec:
+  description: |
+    creates a TaskRun with no PLATFORM parameter and no corresponding
+    tekton-kueue's annotation
+  concurrent: false
+  steps:
+  - name: given-taskruns-crd-exists
+    try:
+    - apply:
+        file: ../resources/taskruns.tekton.dev_customresourcedefinition.yaml
+    - assert:
+        file: ../chainsaw-assert-taskruns-crd.yaml
+  - name: ensure-namespace-is-labeled
+    try:
+    - apply:
+        resource:
+          apiVersion: v1
+          kind: Namespace
+          metadata:
+            name: ($namespace)
+            labels:
+              konflux-ci.dev/type: tenant
+  - name: given-validatingadmissionpolicy-is-installed
+    try:
+    - apply:
+        file: ../../no-skip-validationadmissionpolicy.yaml
+    - apply:
+        file: ../../no-skip-validationadmissionpolicybinding.yaml
+    - assert:
+        file: ../chainsaw-assert-policy.yaml
+  - name: then-skipped-taskrun-can-be-created
+    try:
+    - create:
+        file: ../resources/taskrun_skipped.yaml
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: in-tenant-create-invalid-wrong-annotation-taskrun
+spec:
+  description: |
+    fails to create a TaskRun with a PLATFORM parameter and
+    a wrong corresponding tekton-kueue's annotation
+  concurrent: false
+  steps:
+  - name: given-taskruns-crd-exists
+    try:
+    - apply:
+        file: ../resources/taskruns.tekton.dev_customresourcedefinition.yaml
+    - assert:
+        file: ../chainsaw-assert-taskruns-crd.yaml
+  - name: ensure-namespace-is-labeled
+    try:
+    - apply:
+        resource:
+          apiVersion: v1
+          kind: Namespace
+          metadata:
+            name: ($namespace)
+            labels:
+              konflux-ci.dev/type: tenant
+  - name: given-validatingadmissionpolicy-is-installed
+    try:
+    - apply:
+        file: ../../no-skip-validationadmissionpolicy.yaml
+    - apply:
+        file: ../../no-skip-validationadmissionpolicybinding.yaml
+    - assert:
+        file: ../chainsaw-assert-policy.yaml
+  - name: then-ivalid-taskrun-can-not-be-created
+    try:
+    - error:
+        file: ../resources/taskrun_invalid_wrong_annotation.yaml
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: in-tenant-create-invalid-no-annotations-taskrun
+spec:
+  description: |
+    fails to create a TaskRun with a PLATFORM parameter
+    and no corresponding tekton-kueue's annotation
+  concurrent: false
+  steps:
+  - name: given-taskruns-crd-exists
+    try:
+    - apply:
+        file: ../resources/taskruns.tekton.dev_customresourcedefinition.yaml
+    - assert:
+        file: ../chainsaw-assert-taskruns-crd.yaml
+  - name: ensure-namespace-is-labeled
+    try:
+    - apply:
+        resource:
+          apiVersion: v1
+          kind: Namespace
+          metadata:
+            name: ($namespace)
+            labels:
+              konflux-ci.dev/type: tenant
+  - name: given-validatingadmissionpolicy-is-installed
+    try:
+    - apply:
+        file: ../../no-skip-validationadmissionpolicy.yaml
+    - apply:
+        file: ../../no-skip-validationadmissionpolicybinding.yaml
+    - assert:
+        file: ../chainsaw-assert-policy.yaml
+  - name: then-invalid-taskrun-can-not-be-created
+    try:
+    - error:
+        file: ../resources/taskrun_invalid_no_annotation.yaml

--- a/components/policies-rd/rings/ring-1/base/kueue/no-skip/.chainsaw-test/test-outside-tenant/README.md
+++ b/components/policies-rd/rings/ring-1/base/kueue/no-skip/.chainsaw-test/test-outside-tenant/README.md
@@ -1,0 +1,242 @@
+# Test: `outside-tenant-create-valid-taskrun`
+
+creates a TaskRun with a PLATFORM parameter and a corresponding
+tekton-kueue's annotation in a non-tenant namespace
+
+
+## Steps
+
+| # | Name | Bindings | Try | Catch | Finally | Cleanup |
+|:-:|---|:-:|:-:|:-:|:-:|:-:|
+| 1 | [given-taskruns-crd-exists](#step-given-taskruns-crd-exists) | 0 | 1 | 0 | 0 | 0 |
+| 2 | [given-validatingadmissionpolicy-is-installed](#step-given-validatingadmissionpolicy-is-installed) | 0 | 3 | 0 | 0 | 0 |
+| 3 | [then-valid-taskrun-can-be-created](#step-then-valid-taskrun-can-be-created) | 0 | 1 | 0 | 0 | 0 |
+
+### Step: `given-taskruns-crd-exists`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `given-validatingadmissionpolicy-is-installed`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+| 2 | `apply` | 0 | 0 | *No description* |
+| 3 | `assert` | 0 | 0 | *No description* |
+
+### Step: `then-valid-taskrun-can-be-created`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `create` | 0 | 0 | *No description* |
+
+---
+
+# Test: `outside-tenant-create-valid-taskrun-complex-platform`
+
+creates a TaskRun with a complex PLATFORM parameter and a corresponding
+tekton-kueue's annotation in a non-tenant namespace
+
+
+## Steps
+
+| # | Name | Bindings | Try | Catch | Finally | Cleanup |
+|:-:|---|:-:|:-:|:-:|:-:|:-:|
+| 1 | [given-taskruns-crd-exists](#step-given-taskruns-crd-exists) | 0 | 1 | 0 | 0 | 0 |
+| 2 | [given-validatingadmissionpolicy-is-installed](#step-given-validatingadmissionpolicy-is-installed) | 0 | 3 | 0 | 0 | 0 |
+| 3 | [then-valid-taskrun-can-be-created](#step-then-valid-taskrun-can-be-created) | 0 | 1 | 0 | 0 | 0 |
+
+### Step: `given-taskruns-crd-exists`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `given-validatingadmissionpolicy-is-installed`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+| 2 | `apply` | 0 | 0 | *No description* |
+| 3 | `assert` | 0 | 0 | *No description* |
+
+### Step: `then-valid-taskrun-can-be-created`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `create` | 0 | 0 | *No description* |
+
+---
+
+# Test: `outside-tenant-create-skipped-taskrun`
+
+creates a TaskRun with no PLATFORM parameter and no corresponding
+tekton-kueue's annotation in a non-tenant namespace
+
+
+## Steps
+
+| # | Name | Bindings | Try | Catch | Finally | Cleanup |
+|:-:|---|:-:|:-:|:-:|:-:|:-:|
+| 1 | [given-taskruns-crd-exists](#step-given-taskruns-crd-exists) | 0 | 1 | 0 | 0 | 0 |
+| 2 | [given-validatingadmissionpolicy-is-installed](#step-given-validatingadmissionpolicy-is-installed) | 0 | 3 | 0 | 0 | 0 |
+| 3 | [then-skipped-taskrun-can-be-created](#step-then-skipped-taskrun-can-be-created) | 0 | 1 | 0 | 0 | 0 |
+
+### Step: `given-taskruns-crd-exists`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `given-validatingadmissionpolicy-is-installed`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+| 2 | `apply` | 0 | 0 | *No description* |
+| 3 | `assert` | 0 | 0 | *No description* |
+
+### Step: `then-skipped-taskrun-can-be-created`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `create` | 0 | 0 | *No description* |
+
+---
+
+# Test: `outside-tenant-create-invalid-wrong-annotation-taskrun`
+
+creates a TaskRun with a PLATFORM parameter and
+a wrong corresponding tekton-kueue's annotation
+in a non-tenant namespace
+
+
+## Steps
+
+| # | Name | Bindings | Try | Catch | Finally | Cleanup |
+|:-:|---|:-:|:-:|:-:|:-:|:-:|
+| 1 | [given-taskruns-crd-exists](#step-given-taskruns-crd-exists) | 0 | 1 | 0 | 0 | 0 |
+| 2 | [given-validatingadmissionpolicy-is-installed](#step-given-validatingadmissionpolicy-is-installed) | 0 | 3 | 0 | 0 | 0 |
+| 3 | [then-invalid-taskrun-can-be-created](#step-then-invalid-taskrun-can-be-created) | 0 | 1 | 0 | 0 | 0 |
+
+### Step: `given-taskruns-crd-exists`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `given-validatingadmissionpolicy-is-installed`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+| 2 | `apply` | 0 | 0 | *No description* |
+| 3 | `assert` | 0 | 0 | *No description* |
+
+### Step: `then-invalid-taskrun-can-be-created`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `create` | 0 | 0 | *No description* |
+
+---
+
+# Test: `outside-tenant-create-invalid-no-annotations-taskrun`
+
+creates a TaskRun with a PLATFORM parameter and no
+corresponding tekton-kueue's annotation in a
+non-tenant namespace
+
+
+## Steps
+
+| # | Name | Bindings | Try | Catch | Finally | Cleanup |
+|:-:|---|:-:|:-:|:-:|:-:|:-:|
+| 1 | [given-taskruns-crd-exists](#step-given-taskruns-crd-exists) | 0 | 1 | 0 | 0 | 0 |
+| 2 | [given-validatingadmissionpolicy-is-installed](#step-given-validatingadmissionpolicy-is-installed) | 0 | 3 | 0 | 0 | 0 |
+| 3 | [then-invalid-taskrun-is-created](#step-then-invalid-taskrun-is-created) | 0 | 1 | 0 | 0 | 0 |
+
+### Step: `given-taskruns-crd-exists`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+
+### Step: `given-validatingadmissionpolicy-is-installed`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `apply` | 0 | 0 | *No description* |
+| 2 | `apply` | 0 | 0 | *No description* |
+| 3 | `assert` | 0 | 0 | *No description* |
+
+### Step: `then-invalid-taskrun-is-created`
+
+*No description*
+
+#### Try
+
+| # | Operation | Bindings | Outputs | Description |
+|:-:|---|:-:|:-:|---|
+| 1 | `create` | 0 | 0 | *No description* |
+
+---
+

--- a/components/policies-rd/rings/ring-1/base/kueue/no-skip/.chainsaw-test/test-outside-tenant/chainsaw-test.yaml
+++ b/components/policies-rd/rings/ring-1/base/kueue/no-skip/.chainsaw-test/test-outside-tenant/chainsaw-test.yaml
@@ -1,0 +1,152 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: outside-tenant-create-valid-taskrun
+spec:
+  description: |
+    creates a TaskRun with a PLATFORM parameter and a corresponding
+    tekton-kueue's annotation in a non-tenant namespace
+  concurrent: false
+  steps:
+  - name: given-taskruns-crd-exists
+    try:
+    - apply:
+        file: ../resources/taskruns.tekton.dev_customresourcedefinition.yaml
+    - assert:
+        file: ../chainsaw-assert-taskruns-crd.yaml
+  - name: given-validatingadmissionpolicy-is-installed
+    try:
+    - apply:
+        file: ../../no-skip-validationadmissionpolicy.yaml
+    - apply:
+        file: ../../no-skip-validationadmissionpolicybinding.yaml
+    - assert:
+        file: ../chainsaw-assert-policy.yaml
+  - name: then-valid-taskrun-can-be-created
+    try:
+    - create:
+        file: ../resources/taskrun_valid.yaml
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: outside-tenant-create-valid-taskrun-complex-platform
+spec:
+  description: |
+    creates a TaskRun with a complex PLATFORM parameter and a corresponding
+    tekton-kueue's annotation in a non-tenant namespace
+  concurrent: false
+  steps:
+  - name: given-taskruns-crd-exists
+    try:
+    - apply:
+        file: ../resources/taskruns.tekton.dev_customresourcedefinition.yaml
+    - assert:
+        file: ../chainsaw-assert-taskruns-crd.yaml
+  - name: given-validatingadmissionpolicy-is-installed
+    try:
+    - apply:
+        file: ../../no-skip-validationadmissionpolicy.yaml
+    - apply:
+        file: ../../no-skip-validationadmissionpolicybinding.yaml
+    - assert:
+        file: ../chainsaw-assert-policy.yaml
+  - name: then-valid-taskrun-can-be-created
+    try:
+    - create:
+        file: ../resources/taskrun_valid_complex.yaml
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: outside-tenant-create-skipped-taskrun
+spec:
+  description: |
+    creates a TaskRun with no PLATFORM parameter and no corresponding
+    tekton-kueue's annotation in a non-tenant namespace
+  concurrent: false
+  steps:
+  - name: given-taskruns-crd-exists
+    try:
+    - apply:
+        file: ../resources/taskruns.tekton.dev_customresourcedefinition.yaml
+    - assert:
+        file: ../chainsaw-assert-taskruns-crd.yaml
+  - name: given-validatingadmissionpolicy-is-installed
+    try:
+    - apply:
+        file: ../../no-skip-validationadmissionpolicy.yaml
+    - apply:
+        file: ../../no-skip-validationadmissionpolicybinding.yaml
+    - assert:
+        file: ../chainsaw-assert-policy.yaml
+  - name: then-skipped-taskrun-can-be-created
+    try:
+    - create:
+        file: ../resources/taskrun_skipped.yaml
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: outside-tenant-create-invalid-wrong-annotation-taskrun
+spec:
+  description: |
+    creates a TaskRun with a PLATFORM parameter and
+    a wrong corresponding tekton-kueue's annotation
+    in a non-tenant namespace
+  concurrent: false
+  steps:
+  - name: given-taskruns-crd-exists
+    try:
+    - apply:
+        file: ../resources/taskruns.tekton.dev_customresourcedefinition.yaml
+    - assert:
+        file: ../chainsaw-assert-taskruns-crd.yaml
+  - name: given-validatingadmissionpolicy-is-installed
+    try:
+    - apply:
+        file: ../../no-skip-validationadmissionpolicy.yaml
+    - apply:
+        file: ../../no-skip-validationadmissionpolicybinding.yaml
+    - assert:
+        file: ../chainsaw-assert-policy.yaml
+  - name: then-invalid-taskrun-can-be-created
+    try:
+    - create:
+        file: ../resources/taskrun_invalid_wrong_annotation.yaml
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: outside-tenant-create-invalid-no-annotations-taskrun
+spec:
+  description: |
+    creates a TaskRun with a PLATFORM parameter and no
+    corresponding tekton-kueue's annotation in a
+    non-tenant namespace
+  concurrent: false
+  steps:
+  - name: given-taskruns-crd-exists
+    try:
+    - apply:
+        file: ../resources/taskruns.tekton.dev_customresourcedefinition.yaml
+    - assert:
+        file: ../chainsaw-assert-taskruns-crd.yaml
+  - name: given-validatingadmissionpolicy-is-installed
+    try:
+    - apply:
+        file: ../../no-skip-validationadmissionpolicy.yaml
+    - apply:
+        file: ../../no-skip-validationadmissionpolicybinding.yaml
+    - assert:
+        file: ../chainsaw-assert-policy.yaml
+  - name: then-invalid-taskrun-is-created
+    try:
+    - create:
+        file: ../resources/taskrun_invalid_no_annotation.yaml

--- a/components/policies-rd/rings/ring-1/base/kueue/no-skip/kustomization.yaml
+++ b/components/policies-rd/rings/ring-1/base/kueue/no-skip/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- no-skip-validationadmissionpolicy.yaml
+- no-skip-validationadmissionpolicybinding.yaml

--- a/components/policies-rd/rings/ring-1/base/kueue/no-skip/no-skip-validationadmissionpolicy.yaml
+++ b/components/policies-rd/rings/ring-1/base/kueue/no-skip/no-skip-validationadmissionpolicy.yaml
@@ -1,0 +1,34 @@
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: no-skip.kueue.konflux-ci.dev
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+    - apiGroups: ["tekton.dev"]
+      apiVersions: ["v1", "v1beta1"]
+      operations: ["CREATE"]
+      resources: ["taskruns"]
+      scope: "Namespaced"
+  variables:
+  - name: hasPlatformParam
+    expression: "has(object.spec.params) && object.spec.params.exists(p, p.name == 'PLATFORM')"
+  - name: platformEnvValue
+    expression: "has(object.spec.params) && object.spec.params.filter(p, p.name == 'PLATFORM').size() > 0 ? object.spec.params.filter(p, p.name == 'PLATFORM')[0].value : ''"
+  - name: platformValue
+    expression: "has(object.spec.params) && object.spec.params.filter(p, p.name == 'PLATFORM').size() > 0 ? object.spec.params.filter(p, p.name == 'PLATFORM')[0].value.replace('/', '-').replace('_', '-') : ''"
+  validations:
+  - expression: "!variables.hasPlatformParam || (has(object.metadata.annotations) && ('kueue.konflux-ci.dev/requests-' + variables.platformValue in object.metadata.annotations))"
+    reason: Invalid
+    message: >
+      TaskRun with PLATFORM param must have the annotation 'kueue.konflux-ci.dev/requests-<PLATFORM_VALUE>'.
+      Make sure the PipelineRun was configured properly and that's listing all the required architectures in
+      the `build-platforms` parameter.
+    messageExpression: |
+      "TaskRun with PLATFORM param set to "+string(variables.platformValue)+
+      " must have the annotation 'kueue.konflux-ci.dev/requests-"+string(variables.platformValue)+
+      "'. Make sure the PipelineRun was configured properly and that's listing all the required"+
+      " architectures in the `build-platforms` parameter. To remediate, in your PipelineRun add `"+
+      string(variables.platformEnvValue)+"` to the top-level `build-platforms` parameter."

--- a/components/policies-rd/rings/ring-1/base/kueue/no-skip/no-skip-validationadmissionpolicybinding.yaml
+++ b/components/policies-rd/rings/ring-1/base/kueue/no-skip/no-skip-validationadmissionpolicybinding.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: no-skip.kueue.konflux-ci.dev
+spec:
+  policyName: "no-skip.kueue.konflux-ci.dev"
+  validationActions: [Deny]
+  matchResources:
+    namespaceSelector:
+      matchLabels:
+        konflux-ci.dev/type: tenant

--- a/components/policies-rd/rings/ring-1/base/kueue/pre-sync-hook.yaml
+++ b/components/policies-rd/rings/ring-1/base/kueue/pre-sync-hook.yaml
@@ -1,0 +1,106 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kueue-crd-checker
+  annotations:
+    argocd.argoproj.io/hook: PreSync
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kueue-crd-checker
+  annotations:
+    argocd.argoproj.io/hook: PreSync
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+rules:
+- apiGroups: ["apiextensions.k8s.io"]
+  resources: ["customresourcedefinitions"]
+  verbs: ["get"]
+  resourceNames: ["localqueues.kueue.x-k8s.io", "taskruns.tekton.dev"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kueue-crd-checker
+  annotations:
+    argocd.argoproj.io/hook: PreSync
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kueue-crd-checker
+subjects:
+- kind: ServiceAccount
+  name: kueue-crd-checker
+  namespace: will-be-replaced-by-kustomization
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: kueue-crd-check
+  annotations:
+    argocd.argoproj.io/hook: PreSync
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+spec:
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: crd-check
+        image: quay.io/openshift/origin-cli:4.17
+        securityContext:
+          runAsNonRoot: true
+          readOnlyRootFilesystem: true
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+        command:
+        - /bin/bash
+        - -c
+        - |
+          set -e
+
+          echo "Starting CRD check..."
+
+          # Configuration
+          TIMEOUT=1200  # 20 minutes timeout
+          INTERVAL=10  # Check every 10 seconds
+          START_TIME=$(date +%s)
+
+          # Define CRDs to check
+          CRDS=(
+            "localqueues.kueue.x-k8s.io"
+            "taskruns.tekton.dev"
+          )
+
+          echo "Checking if required CRDs exist..."
+
+          # Check all CRDs with global timeout
+          while ! oc get crd "${CRDS[@]}"; do
+            CURRENT_TIME=$(date +%s)
+            ELAPSED=$((CURRENT_TIME - START_TIME))
+
+            if [ $ELAPSED -gt $TIMEOUT ]; then
+              echo "ERROR: Global timeout reached (${TIMEOUT}s). Required CRDs not found."
+              echo "Missing CRDs: ${CRDS[*]}"
+              exit 1
+            fi
+
+            echo "Required CRDs not found yet. Waiting ${INTERVAL}s... (${ELAPSED}s/${TIMEOUT}s elapsed)"
+            sleep $INTERVAL
+          done
+
+          echo "SUCCESS: All required CRDs found!"
+          echo "Pre-sync hook completed successfully."
+          exit 0
+        resources:
+          requests:
+            memory: "64Mi"
+            cpu: "100m"
+          limits:
+            memory: "128Mi"
+            cpu: "200m"
+      serviceAccountName: kueue-crd-checker

--- a/components/policies-rd/rings/ring-1/base/kustomization.yaml
+++ b/components/policies-rd/rings/ring-1/base/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- base-snapshot
+- konflux-rbac/
+- kueue/
+- cost-management/

--- a/components/policies-rd/rings/ring-1/lightwell-dev/buildah-roks-scc-clusterrole.yaml
+++ b/components/policies-rd/rings/ring-1/lightwell-dev/buildah-roks-scc-clusterrole.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: appstudio-pipelines-scc-roks-use
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+rules:
+- apiGroups: ["security.openshift.io"]
+  resources: ["securitycontextconstraints"]
+  resourceNames: ["appstudio-pipelines-scc-roks"]
+  verbs: ["use"]

--- a/components/policies-rd/rings/ring-1/lightwell-dev/buildah-roks-scc-clusterrolebinding.yaml
+++ b/components/policies-rd/rings/ring-1/lightwell-dev/buildah-roks-scc-clusterrolebinding.yaml
@@ -1,0 +1,14 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: tekton-pipelines-controller-roks-scc
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+subjects:
+  - kind: ServiceAccount
+    name: tekton-pipelines-controller
+    namespace: openshift-pipelines
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: appstudio-pipelines-scc-roks-use

--- a/components/policies-rd/rings/ring-1/lightwell-dev/buildah-roks-scc.yaml
+++ b/components/policies-rd/rings/ring-1/lightwell-dev/buildah-roks-scc.yaml
@@ -1,0 +1,48 @@
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  name: appstudio-pipelines-scc-roks
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "0"
+    description: >-
+      Temporary supplemental SCC for ROKS buildah builds. Extends
+      appstudio-pipelines-scc with SYS_CHROOT for layer unpacking.
+      Will be removed once the pipeline-service team adds SYS_CHROOT
+      to the global appstudio-pipelines-scc.
+allowHostDirVolumePlugin: false
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: false
+allowHostPorts: false
+allowPrivilegeEscalation: false
+allowPrivilegedContainer: false
+allowedCapabilities:
+- SETFCAP
+- SYS_CHROOT
+defaultAddCapabilities: null
+fsGroup:
+  type: MustRunAs
+groups:
+- system:cluster-admins
+priority: 11
+readOnlyRootFilesystem: false
+requiredDropCapabilities:
+- MKNOD
+runAsUser:
+  type: RunAsAny
+seccompProfiles:
+- localhost/profiles/unshare.json
+- runtime/default
+seLinuxContext:
+  type: MustRunAs
+supplementalGroups:
+  type: RunAsAny
+users: []
+volumes:
+- configMap
+- downwardAPI
+- emptyDir
+- persistentVolumeClaim
+- projected
+- secret

--- a/components/policies-rd/rings/ring-1/lightwell-dev/buildah-roks-seccomp-cp.yaml
+++ b/components/policies-rd/rings/ring-1/lightwell-dev/buildah-roks-seccomp-cp.yaml
@@ -1,0 +1,71 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: buildah-roks-seccomp-workaround
+  annotations:
+    policies.kyverno.io/title: "Buildah ROKS seccomp workaround"
+    policies.kyverno.io/category: "Build"
+    policies.kyverno.io/description: >-
+      On ROKS clusters with seccompDefault=true (CIS benchmark), buildah
+      builds fail because RuntimeDefault blocks the unshare syscall. This
+      policy injects the Localhost unshare.json seccomp profile, /dev/fuse
+      access for fuse-overlayfs, and SETFCAP + SYS_CHROOT capabilities on
+      buildah task pods to enable rootless builds while keeping seccomp
+      enforcement enabled. Covers buildah-oci-ta, buildah-oci-ta-min, and
+      buildah-remote-oci-ta task variants.
+spec:
+  background: false
+  failurePolicy: Ignore
+  rules:
+    - name: inject-buildah-seccomp-config
+      match:
+        any:
+          - resources:
+              kinds:
+                - Pod
+              operations:
+                - CREATE
+              selector:
+                matchLabels:
+                  tekton.dev/task: buildah-oci-ta
+              namespaceSelector:
+                matchLabels:
+                  konflux-ci.dev/type: tenant
+          - resources:
+              kinds:
+                - Pod
+              operations:
+                - CREATE
+              selector:
+                matchLabels:
+                  tekton.dev/task: buildah-oci-ta-min
+              namespaceSelector:
+                matchLabels:
+                  konflux-ci.dev/type: tenant
+          - resources:
+              kinds:
+                - Pod
+              operations:
+                - CREATE
+              selector:
+                matchLabels:
+                  tekton.dev/task: buildah-remote-oci-ta
+              namespaceSelector:
+                matchLabels:
+                  konflux-ci.dev/type: tenant
+      mutate:
+        patchStrategicMerge:
+          metadata:
+            annotations:
+              io.kubernetes.cri-o.Devices: "/dev/fuse"
+          spec:
+            containers:
+              - (name): "step-build"
+                securityContext:
+                  seccompProfile:
+                    type: Localhost
+                    localhostProfile: profiles/unshare.json
+                  capabilities:
+                    add:
+                      - SETFCAP
+                      - SYS_CHROOT

--- a/components/policies-rd/rings/ring-1/lightwell-dev/kustomization.yaml
+++ b/components/policies-rd/rings/ring-1/lightwell-dev/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../base
+- buildah-roks-seccomp-cp.yaml
+- buildah-roks-scc.yaml
+- buildah-roks-scc-clusterrole.yaml
+- buildah-roks-scc-clusterrolebinding.yaml

--- a/components/policies-rd/rings/ring-1/stone-stage-p01/kueue-config/deny-unallowed-annotations-configmap.yaml
+++ b/components/policies-rd/rings/ring-1/stone-stage-p01/kueue-config/deny-unallowed-annotations-configmap.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: deny-unallowed-annotations
+  namespace: tekton-kueue
+data:
+  message-expression: |-
+    "PipelineRun validation failed: the cluster doesn't provide the following resources: " +
+    variables.difference.map(k, k.replace("kueue.konflux-ci.dev/requests-", "")).join(", ")
+  annotation-prefixes: '["kueue.konflux-ci.dev/requests-"]'
+  # this field is generated via `hack/kueue-allowed-vms/generate-allowed-annotations.sh`
+  allowed-annotations: "[\"kueue.konflux-ci.dev/requests-aws-ip\", \"kueue.konflux-ci.dev/requests-cpu\", \"kueue.konflux-ci.dev/requests-konflux-ci-dev-token\", \"kueue.konflux-ci.dev/requests-konflux-release\", \"kueue.konflux-ci.dev/requests-linux-amd64\", \"kueue.konflux-ci.dev/requests-linux-arm64\", \"kueue.konflux-ci.dev/requests-linux-c2xlarge-amd64\", \"kueue.konflux-ci.dev/requests-linux-c2xlarge-arm64\", \"kueue.konflux-ci.dev/requests-linux-c4xlarge-amd64\", \"kueue.konflux-ci.dev/requests-linux-c4xlarge-arm64\", \"kueue.konflux-ci.dev/requests-linux-c6gd2xlarge-arm64\", \"kueue.konflux-ci.dev/requests-linux-c8xlarge-amd64\", \"kueue.konflux-ci.dev/requests-linux-c8xlarge-arm64\", \"kueue.konflux-ci.dev/requests-linux-cxlarge-amd64\", \"kueue.konflux-ci.dev/requests-linux-cxlarge-arm64\", \"kueue.konflux-ci.dev/requests-linux-d160-c8xlarge-amd64\", \"kueue.konflux-ci.dev/requests-linux-d160-c8xlarge-arm64\", \"kueue.konflux-ci.dev/requests-linux-g64xlarge-amd64\", \"kueue.konflux-ci.dev/requests-linux-m2xlarge-amd64\", \"kueue.konflux-ci.dev/requests-linux-m2xlarge-arm64\", \"kueue.konflux-ci.dev/requests-linux-m4xlarge-amd64\", \"kueue.konflux-ci.dev/requests-linux-m4xlarge-arm64\", \"kueue.konflux-ci.dev/requests-linux-m8xlarge-amd64\", \"kueue.konflux-ci.dev/requests-linux-m8xlarge-arm64\", \"kueue.konflux-ci.dev/requests-linux-mlarge-amd64\", \"kueue.konflux-ci.dev/requests-linux-mlarge-arm64\", \"kueue.konflux-ci.dev/requests-linux-mxlarge-amd64\", \"kueue.konflux-ci.dev/requests-linux-mxlarge-arm64\", \"kueue.konflux-ci.dev/requests-linux-ppc64le\", \"kueue.konflux-ci.dev/requests-linux-root-amd64\", \"kueue.konflux-ci.dev/requests-linux-root-arm64\", \"kueue.konflux-ci.dev/requests-linux-s390x\", \"kueue.konflux-ci.dev/requests-linux-x86-64\", \"kueue.konflux-ci.dev/requests-local\", \"kueue.konflux-ci.dev/requests-localhost\", \"kueue.konflux-ci.dev/requests-macos-mac2metal-arm64\", \"kueue.konflux-ci.dev/requests-memory\", \"kueue.konflux-ci.dev/requests-mintmaker\", \"kueue.konflux-ci.dev/requests-windows-4xlarge-amd64\"]"

--- a/components/policies-rd/rings/ring-1/stone-stage-p01/kueue-config/kustomization.yaml
+++ b/components/policies-rd/rings/ring-1/stone-stage-p01/kueue-config/kustomization.yaml
@@ -1,0 +1,49 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../base
+- deny-unallowed-annotations-configmap.yaml
+
+replacements:
+  - source:
+      kind: ConfigMap
+      version: v1
+      name: deny-unallowed-annotations
+      namespace: tekton-kueue
+      fieldPath: data.allowed-annotations
+    targets:
+      - select:
+          group: admissionregistration.k8s.io
+          version: v1
+          kind: ValidatingAdmissionPolicy
+          name: deny-unallowed-annotations.kueue.konflux-ci.dev
+        fieldPaths:
+        - 'spec.variables.[name=allowedAnnotations].expression'
+  - source:
+      kind: ConfigMap
+      version: v1
+      name: deny-unallowed-annotations
+      namespace: tekton-kueue
+      fieldPath: data.annotation-prefixes
+    targets:
+      - select:
+          group: admissionregistration.k8s.io
+          version: v1
+          kind: ValidatingAdmissionPolicy
+          name: deny-unallowed-annotations.kueue.konflux-ci.dev
+        fieldPaths:
+        - 'spec.variables.[name=annotationPrefixes].expression'
+  - source:
+      kind: ConfigMap
+      version: v1
+      name: deny-unallowed-annotations
+      namespace: tekton-kueue
+      fieldPath: data.message-expression
+    targets:
+      - select:
+          group: admissionregistration.k8s.io
+          version: v1
+          kind: ValidatingAdmissionPolicy
+          name: deny-unallowed-annotations.kueue.konflux-ci.dev
+        fieldPaths:
+        - 'spec.validations.0.messageExpression'

--- a/components/policies-rd/rings/ring-1/stone-stage-p01/kustomization.yaml
+++ b/components/policies-rd/rings/ring-1/stone-stage-p01/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- kueue-config
+
+patches:
+  - patch: |-
+      $patch: delete
+      apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: deny-unallowed-annotations
+        namespace: tekton-kueue

--- a/components/policies-rd/rings/ring-1/stone-stg-rh01/kueue-config/deny-unallowed-annotations-configmap.yaml
+++ b/components/policies-rd/rings/ring-1/stone-stg-rh01/kueue-config/deny-unallowed-annotations-configmap.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: deny-unallowed-annotations
+  namespace: tekton-kueue
+data:
+  message-expression: |-
+    "PipelineRun validation failed: the cluster doesn't provide the following resources: " +
+    variables.difference.map(k, k.replace("kueue.konflux-ci.dev/requests-", "")).join(", ")
+  annotation-prefixes: '["kueue.konflux-ci.dev/requests-"]'
+  # this field is generated via `hack/kueue-allowed-vms/generate-allowed-annotations.sh`
+  allowed-annotations: "[\"kueue.konflux-ci.dev/requests-aws-ip\", \"kueue.konflux-ci.dev/requests-cpu\", \"kueue.konflux-ci.dev/requests-konflux-ci-dev-token\", \"kueue.konflux-ci.dev/requests-konflux-release\", \"kueue.konflux-ci.dev/requests-linux-amd64\", \"kueue.konflux-ci.dev/requests-linux-arm64\", \"kueue.konflux-ci.dev/requests-linux-c2xlarge-amd64\", \"kueue.konflux-ci.dev/requests-linux-c2xlarge-arm64\", \"kueue.konflux-ci.dev/requests-linux-c4xlarge-amd64\", \"kueue.konflux-ci.dev/requests-linux-c4xlarge-arm64\", \"kueue.konflux-ci.dev/requests-linux-c6gd2xlarge-arm64\", \"kueue.konflux-ci.dev/requests-linux-c8xlarge-amd64\", \"kueue.konflux-ci.dev/requests-linux-c8xlarge-arm64\", \"kueue.konflux-ci.dev/requests-linux-cxlarge-amd64\", \"kueue.konflux-ci.dev/requests-linux-cxlarge-arm64\", \"kueue.konflux-ci.dev/requests-linux-d160-c8xlarge-amd64\", \"kueue.konflux-ci.dev/requests-linux-d160-c8xlarge-arm64\", \"kueue.konflux-ci.dev/requests-linux-g64xlarge-amd64\", \"kueue.konflux-ci.dev/requests-linux-m2xlarge-amd64\", \"kueue.konflux-ci.dev/requests-linux-m2xlarge-arm64\", \"kueue.konflux-ci.dev/requests-linux-m4xlarge-amd64\", \"kueue.konflux-ci.dev/requests-linux-m4xlarge-arm64\", \"kueue.konflux-ci.dev/requests-linux-m8xlarge-amd64\", \"kueue.konflux-ci.dev/requests-linux-m8xlarge-arm64\", \"kueue.konflux-ci.dev/requests-linux-mlarge-amd64\", \"kueue.konflux-ci.dev/requests-linux-mlarge-arm64\", \"kueue.konflux-ci.dev/requests-linux-mxlarge-amd64\", \"kueue.konflux-ci.dev/requests-linux-mxlarge-arm64\", \"kueue.konflux-ci.dev/requests-linux-ppc64le\", \"kueue.konflux-ci.dev/requests-linux-root-amd64\", \"kueue.konflux-ci.dev/requests-linux-root-arm64\", \"kueue.konflux-ci.dev/requests-linux-s390x\", \"kueue.konflux-ci.dev/requests-linux-x86-64\", \"kueue.konflux-ci.dev/requests-local\", \"kueue.konflux-ci.dev/requests-localhost\", \"kueue.konflux-ci.dev/requests-memory\", \"kueue.konflux-ci.dev/requests-mintmaker\"]"

--- a/components/policies-rd/rings/ring-1/stone-stg-rh01/kueue-config/kustomization.yaml
+++ b/components/policies-rd/rings/ring-1/stone-stg-rh01/kueue-config/kustomization.yaml
@@ -1,0 +1,49 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../base
+- deny-unallowed-annotations-configmap.yaml
+
+replacements:
+  - source:
+      kind: ConfigMap
+      version: v1
+      name: deny-unallowed-annotations
+      namespace: tekton-kueue
+      fieldPath: data.allowed-annotations
+    targets:
+      - select:
+          group: admissionregistration.k8s.io
+          version: v1
+          kind: ValidatingAdmissionPolicy
+          name: deny-unallowed-annotations.kueue.konflux-ci.dev
+        fieldPaths:
+        - 'spec.variables.[name=allowedAnnotations].expression'
+  - source:
+      kind: ConfigMap
+      version: v1
+      name: deny-unallowed-annotations
+      namespace: tekton-kueue
+      fieldPath: data.annotation-prefixes
+    targets:
+      - select:
+          group: admissionregistration.k8s.io
+          version: v1
+          kind: ValidatingAdmissionPolicy
+          name: deny-unallowed-annotations.kueue.konflux-ci.dev
+        fieldPaths:
+        - 'spec.variables.[name=annotationPrefixes].expression'
+  - source:
+      kind: ConfigMap
+      version: v1
+      name: deny-unallowed-annotations
+      namespace: tekton-kueue
+      fieldPath: data.message-expression
+    targets:
+      - select:
+          group: admissionregistration.k8s.io
+          version: v1
+          kind: ValidatingAdmissionPolicy
+          name: deny-unallowed-annotations.kueue.konflux-ci.dev
+        fieldPaths:
+        - 'spec.validations.0.messageExpression'

--- a/components/policies-rd/rings/ring-1/stone-stg-rh01/kustomization.yaml
+++ b/components/policies-rd/rings/ring-1/stone-stg-rh01/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- kueue-config
+
+patches:
+  - patch: |-
+      $patch: delete
+      apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: deny-unallowed-annotations
+        namespace: tekton-kueue


### PR DESCRIPTION
## What

Part 2 of the policies ring-deployments migration — brings the staging tenant clusters under the `policies-rd` ring structure as ring-1.

- Add ring-1 (base-snapshot + per-cluster overlays) rendering byte-identical to the legacy `components/policies/staging/<cluster>` overlays.
- Add the `rd-staging` `policies-rd` ApplicationSet (tenant deployment-clusters label, select-none generator; the k-component injects the ring-1 clusters). Auto-sync left disabled for the migration.
- Move auto-sync out of the base member appset into per-environment patches: development and both production overlays (so unmigrated prod keeps auto-sync).
- Restore `namePrefix: integration-` in the ring-0 and ring-1 base-snapshots so dev and staging render byte-identical to legacy. Kept out of the Tier-1 base — legacy prod has no prefix, so leaving it in base would break prod when it migrates in a later part.

Clusters affected: lightwell-dev, stone-stage-p01, stone-stg-rh01

[KFLUXINFRA-4288](https://issues.redhat.com/browse/KFLUXINFRA-4288)

## Why

Continues the ring-deployment onboarding of the policies component (Part 1, dev, merged in #13805). Ring deployments give per-cluster rollout control and align policies with the shared ring structure.

## Validation

- `hack/test-ring-render.sh policies-rd all` — 4 passed (ring-0 dev + 3 ring-1 staging clusters render byte-identical to legacy)
- `hack/test-base-common.sh policies-rd` — 0 problems
- `kustomize build --enable-helm` passes for all affected overlays (rd-staging, development, production-downstream, konflux-public-production)
- `yamllint` clean
- Part 1 (dev) validated and merged: #13805

[KFLUXINFRA-4288]: https://redhat.atlassian.net/browse/KFLUXINFRA-4288?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ