### PR TITLE
Promote release-service and grafana-dashboard from development to staging

### DIFF
--- a/components/monitoring/grafana/staging/dashboards/release/kustomization.yaml
+++ b/components/monitoring/grafana/staging/dashboards/release/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- https://github.com/konflux-ci/release-service/config/grafana/?ref=178b9cf3b0978d85f0612521ce06061029007956
+- https://github.com/konflux-ci/release-service/config/grafana/?ref=f874148f742eecfaa64832a13b2b237d079223bd

--- a/components/release/staging/kustomization.yaml
+++ b/components/release/staging/kustomization.yaml
@@ -5,7 +5,7 @@ resources:
   - ../base/monitor/staging
   - external-secrets/release-monitor-secret.yaml
   - external-secrets/release-service-github-token.yaml
-  - https://github.com/konflux-ci/release-service/config/default?ref=178b9cf3b0978d85f0612521ce06061029007956
+  - https://github.com/konflux-ci/release-service/config/default?ref=f874148f742eecfaa64832a13b2b237d079223bd
   - release_service_config.yaml
   - signing_configs.yaml
 
@@ -15,7 +15,7 @@ components:
 images:
   - name: quay.io/konflux-ci/release-service
     newName: quay.io/konflux-ci/release-service
-    newTag: 178b9cf3b0978d85f0612521ce06061029007956
+    newTag: f874148f742eecfaa64832a13b2b237d079223bd
 
 namespace: release-service
 


### PR DESCRIPTION
Included PRs:
 - https://github.com/konflux-ci/release-service/pull/1699 
 - https://github.com/konflux-ci/release-service/pull/1888 
 - https://github.com/konflux-ci/release-service/pull/1826 
 - https://github.com/konflux-ci/release-service/pull/1753 
 - https://github.com/konflux-ci/release-service/pull/1885 
 - https://github.com/konflux-ci/release-service/pull/1879 
 - https://github.com/konflux-ci/release-service/pull/1815 
 - https://github.com/konflux-ci/release-service/pull/1883 
 - https://github.com/konflux-ci/release-service/pull/1882 
 - https://github.com/konflux-ci/release-service/pull/1862 
 - https://github.com/konflux-ci/release-service/pull/1881 
 - https://github.com/konflux-ci/release-service/pull/1880 
 - https://github.com/konflux-ci/release-service/pull/1875 
 - https://github.com/konflux-ci/release-service/pull/1876 
 - https://github.com/konflux-ci/release-service/pull/1874 
 - https://github.com/konflux-ci/release-service/pull/1868 
 - https://github.com/konflux-ci/release-service/pull/1865 
 - https://github.com/konflux-ci/release-service/pull/1854 
 - https://github.com/konflux-ci/release-service/pull/1867 
 - https://github.com/konflux-ci/release-service/pull/1866 
 - https://github.com/konflux-ci/release-service/pull/1864 
 - https://github.com/konflux-ci/release-service/pull/1840 
 - https://github.com/konflux-ci/release-service/pull/1852 
 - https://github.com/konflux-ci/release-service/pull/1856 
 - https://github.com/konflux-ci/release-service/pull/1859 
 - https://github.com/konflux-ci/release-service/pull/1855 
 - https://github.com/konflux-ci/release-service/pull/1850 
 - https://github.com/konflux-ci/release-service/pull/1820 
 - https://github.com/konflux-ci/release-service/pull/1857 
 - https://github.com/konflux-ci/release-service/pull/1828 
 - https://github.com/konflux-ci/release-service/pull/1851 
 - https://github.com/konflux-ci/release-service/pull/1841 
 - https://github.com/konflux-ci/release-service/pull/1830 
 - https://github.com/konflux-ci/release-service/pull/1846 
 - https://github.com/konflux-ci/release-service/pull/1847 
 - https://github.com/konflux-ci/release-service/pull/1845 
 - https://github.com/konflux-ci/release-service/pull/1844 
 - https://github.com/konflux-ci/release-service/pull/1839 
 - https://github.com/konflux-ci/release-service/pull/1842 
 - https://github.com/konflux-ci/release-service/pull/1837 
 - https://github.com/konflux-ci/release-service/pull/1836 
 - https://github.com/konflux-ci/release-service/pull/1835 
 - https://github.com/konflux-ci/release-service/pull/1833 
 - https://github.com/konflux-ci/release-service/pull/1834 
 - https://github.com/konflux-ci/release-service/pull/1829 
 - https://github.com/konflux-ci/release-service/pull/1811 
 - https://github.com/konflux-ci/release-service/pull/1750 
 - https://github.com/konflux-ci/release-service/pull/1827 
 - https://github.com/konflux-ci/release-service/pull/1824 
 - https://github.com/konflux-ci/release-service/pull/1825 
 - https://github.com/konflux-ci/release-service/pull/1813 
 - https://github.com/konflux-ci/release-service/pull/1749 
 - https://github.com/konflux-ci/release-service/pull/1744 
 - https://github.com/konflux-ci/release-service/pull/1821 
 - https://github.com/konflux-ci/release-service/pull/1819 
 - https://github.com/konflux-ci/release-service/pull/1822 
 - https://github.com/konflux-ci/release-service/pull/1812 
 - https://github.com/konflux-ci/release-service/pull/1816 
 - https://github.com/konflux-ci/release-service/pull/1817 
 - https://github.com/konflux-ci/release-service/pull/1774 
 - https://github.com/konflux-ci/release-service/pull/1806 
 - https://github.com/konflux-ci/release-service/pull/1809 
 
Development PR:
https://github.com/konflux-ci/release-service/pull/1753

The only operator change: 
https://github.com/konflux-ci/release-service/pull/1753

Risk Low this is only going to stage.
