### PR TITLE
KFLUXINFRA-4495: Add kueue-rd ring-2 overlay for kflux-lw-p01

### DIFF
--- a/components/kueue-rd/rings/ring-2/kflux-lw-p01/cluster-queue.yaml
+++ b/components/kueue-rd/rings/ring-2/kflux-lw-p01/cluster-queue.yaml
@@ -1,0 +1,235 @@
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: ClusterQueue
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "10"
+  name: cluster-pipeline-queue
+spec:
+  flavorFungibility:
+    whenCanBorrow: MayStopSearch
+    whenCanPreempt: TryNextFlavor
+  namespaceSelector: {}
+  preemption:
+    borrowWithinCohort:
+      policy: Never
+    reclaimWithinCohort: Never
+    withinClusterQueue: Never
+  queueingStrategy: BestEffortFIFO
+  resourceGroups:
+  - coveredResources:
+    - tekton.dev/pipelineruns
+    - konflux-ci-dev-token
+    - cpu
+    - memory
+    - aws-ip
+    - mintmaker
+    - konflux-release
+    flavors:
+    - name: default-flavor
+      resources:
+      - name: tekton.dev/pipelineruns
+        nominalQuota: '400'
+      - name: konflux-ci-dev-token
+        nominalQuota: '300'
+      - name: cpu
+        nominalQuota: 1k
+      - name: memory
+        nominalQuota: 500Ti
+      - name: aws-ip
+        nominalQuota: '250'
+      - name: mintmaker
+        nominalQuota: '150'
+      - name: konflux-release
+        nominalQuota: '100'
+  - coveredResources:
+    - linux-amd64
+    - linux-arm64
+    - linux-c2xlarge-amd64
+    - linux-c2xlarge-arm64
+    - linux-c4xlarge-amd64
+    - linux-c4xlarge-arm64
+    - linux-c6gd2xlarge-arm64
+    - linux-c8xlarge-amd64
+    - linux-c8xlarge-arm64
+    - linux-cxlarge-amd64
+    - linux-cxlarge-arm64
+    - linux-d160-c8xlarge-amd64
+    - linux-d160-c8xlarge-arm64
+    - linux-d160-m2xlarge-amd64
+    - linux-d160-m2xlarge-arm64
+    - linux-d160-m4xlarge-amd64
+    flavors:
+    - name: platform-group-1
+      resources:
+      - name: linux-amd64
+        nominalQuota: '250'
+      - name: linux-arm64
+        nominalQuota: '250'
+      - name: linux-c2xlarge-amd64
+        nominalQuota: '250'
+      - name: linux-c2xlarge-arm64
+        nominalQuota: '250'
+      - name: linux-c4xlarge-amd64
+        nominalQuota: '250'
+      - name: linux-c4xlarge-arm64
+        nominalQuota: '250'
+      - name: linux-c6gd2xlarge-arm64
+        nominalQuota: '250'
+      - name: linux-c8xlarge-amd64
+        nominalQuota: '250'
+      - name: linux-c8xlarge-arm64
+        nominalQuota: '250'
+      - name: linux-cxlarge-amd64
+        nominalQuota: '250'
+      - name: linux-cxlarge-arm64
+        nominalQuota: '250'
+      - name: linux-d160-c8xlarge-amd64
+        nominalQuota: '250'
+      - name: linux-d160-c8xlarge-arm64
+        nominalQuota: '250'
+      - name: linux-d160-m2xlarge-amd64
+        nominalQuota: '250'
+      - name: linux-d160-m2xlarge-arm64
+        nominalQuota: '250'
+      - name: linux-d160-m4xlarge-amd64
+        nominalQuota: '250'
+  - coveredResources:
+    - linux-d160-m4xlarge-arm64
+    - linux-d160-m8xlarge-amd64
+    - linux-d160-m8xlarge-arm64
+    - linux-d160-mlarge-amd64
+    - linux-d160-mlarge-arm64
+    - linux-d160-mxlarge-amd64
+    - linux-d160-mxlarge-arm64
+    - linux-d320-m8xlarge-amd64
+    - linux-d320-m8xlarge-arm64
+    - linux-extra-fast-amd64
+    - linux-fast-amd64
+    - linux-g64xlarge-amd64
+    - linux-large-s390x
+    - linux-m2xlarge-amd64
+    - linux-m2xlarge-arm64
+    - linux-m4xlarge-amd64
+    flavors:
+    - name: platform-group-2
+      resources:
+      - name: linux-d160-m4xlarge-arm64
+        nominalQuota: '250'
+      - name: linux-d160-m8xlarge-amd64
+        nominalQuota: '250'
+      - name: linux-d160-m8xlarge-arm64
+        nominalQuota: '250'
+      - name: linux-d160-mlarge-amd64
+        nominalQuota: '250'
+      - name: linux-d160-mlarge-arm64
+        nominalQuota: '250'
+      - name: linux-d160-mxlarge-amd64
+        nominalQuota: '250'
+      - name: linux-d160-mxlarge-arm64
+        nominalQuota: '250'
+      - name: linux-d320-m8xlarge-amd64
+        nominalQuota: '250'
+      - name: linux-d320-m8xlarge-arm64
+        nominalQuota: '250'
+      - name: linux-extra-fast-amd64
+        nominalQuota: '250'
+      - name: linux-fast-amd64
+        nominalQuota: '250'
+      - name: linux-g64xlarge-amd64
+        nominalQuota: '250'
+      - name: linux-large-s390x
+        nominalQuota: '3'
+      - name: linux-m2xlarge-amd64
+        nominalQuota: '250'
+      - name: linux-m2xlarge-arm64
+        nominalQuota: '250'
+      - name: linux-m4xlarge-amd64
+        nominalQuota: '250'
+  - coveredResources:
+    - linux-m4xlarge-arm64
+    - linux-m8xlarge-amd64
+    - linux-m8xlarge-arm64
+    - linux-mlarge-amd64
+    - linux-mlarge-arm64
+    - linux-mxlarge-amd64
+    - linux-mxlarge-arm64
+    - linux-ppc64le
+    - linux-riscv64
+    - linux-root-amd64
+    - linux-root-arm64
+    - linux-s390x
+    - linux-x86-64
+    - local
+    - localhost
+    - windows-4xlarge-amd64
+    flavors:
+    - name: platform-group-3
+      resources:
+      - name: linux-m4xlarge-arm64
+        nominalQuota: '250'
+      - name: linux-m8xlarge-amd64
+        nominalQuota: '250'
+      - name: linux-m8xlarge-arm64
+        nominalQuota: '250'
+      - name: linux-mlarge-amd64
+        nominalQuota: '250'
+      - name: linux-mlarge-arm64
+        nominalQuota: '250'
+      - name: linux-mxlarge-amd64
+        nominalQuota: '250'
+      - name: linux-mxlarge-arm64
+        nominalQuota: '250'
+      - name: linux-ppc64le
+        nominalQuota: '64'
+      - name: linux-riscv64
+        nominalQuota: '2'
+      - name: linux-root-amd64
+        nominalQuota: '250'
+      - name: linux-root-arm64
+        nominalQuota: '250'
+      - name: linux-s390x
+        nominalQuota: '60'
+      - name: linux-x86-64
+        nominalQuota: 1k
+      - name: local
+        nominalQuota: 1k
+      - name: localhost
+        nominalQuota: 1k
+      - name: windows-4xlarge-amd64
+        nominalQuota: '5'
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: ResourceFlavor
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "10"
+  name: default-flavor
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: ResourceFlavor
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "10"
+  name: platform-group-1
+spec: {}
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: ResourceFlavor
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "10"
+  name: platform-group-2
+spec: {}
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: ResourceFlavor
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "10"
+  name: platform-group-3
+spec: {}

--- a/components/kueue-rd/rings/ring-2/kflux-lw-p01/config.yaml
+++ b/components/kueue-rd/rings/ring-2/kflux-lw-p01/config.yaml
@@ -1,0 +1,176 @@
+queueName: pipelines-queue
+cel:
+  expressions:
+    # Set resource requests for multi platform pipelines
+    - |
+        has(pipelineRun.spec.params) &&
+        pipelineRun.spec.params.exists(p, p.name == 'build-platforms') &&
+        type(pipelineRun.spec.params.filter(p, p.name == 'build-platforms')[0].value) == list ?
+        pipelineRun.spec.params.filter(
+          p,
+          p.name == 'build-platforms')[0]
+        .value.map(
+          p,
+          resource(replace(replace(p, "/", "-"), "_", "-"), 1)
+        ) : []
+
+    # Request AWS IP for AWS-based platforms
+    - |
+        has(pipelineRun.spec.params) &&
+        pipelineRun.spec.params.exists(p, p.name == 'build-platforms') &&
+        type(pipelineRun.spec.params.filter(p, p.name == 'build-platforms')[0].value) == list ?
+        pipelineRun.spec.params.filter(
+          p,
+          p.name == 'build-platforms')[0]
+        .value.filter(
+          p,
+          !(
+            p in [
+              'linux/ppc64le',
+              'linux/s390x',
+              'linux/x86_64',
+              'local',
+              'localhost',
+            ]
+          )
+        ).map(
+          p,
+          resource('aws-ip', 1)
+        ) : []
+
+    # Flag validation error when build-platforms is present but not a list
+    - |
+        has(pipelineRun.spec.params) &&
+        pipelineRun.spec.params.exists(p, p.name == 'build-platforms') &&
+        type(pipelineRun.spec.params.filter(p, p.name == 'build-platforms')[0].value) != list ?
+        [annotation('kueue.konflux-ci.dev/validation-error',
+          'build-platforms parameter must be an array of platform strings, got a non-array value')] : []
+
+    # Set resource requests for multi platform pipelines which doesn't use the build-platforms parameter (old style)
+    - |
+      !(
+        has(pipelineRun.spec.params) &&
+        pipelineRun.spec.params.exists(p, p.name == 'build-platforms')
+      ) &&
+      has(pipelineRun.spec.pipelineSpec) &&
+      has(pipelineRun.spec.pipelineSpec.tasks) &&
+      pipelineRun.spec.pipelineSpec.tasks.size() > 0 ?
+      pipelineRun.spec.pipelineSpec.tasks.map(
+        task,
+        has(task.params) ? task.params.filter(p, p.name == 'PLATFORM') : []
+      )
+      .filter(p, p.size() > 0)
+      .map(
+        p,
+        resource(replace(replace(p[0].value, "/", "-"), "_", "-"), 1)
+      ) : []
+
+    # Request AWS IP for AWS-based platforms which doesn't use the build-platforms parameter (old style)
+    - |
+      !(
+        has(pipelineRun.spec.params) &&
+        pipelineRun.spec.params.exists(p, p.name == 'build-platforms')
+      ) &&
+      has(pipelineRun.spec.pipelineSpec) &&
+      has(pipelineRun.spec.pipelineSpec.tasks) &&
+      pipelineRun.spec.pipelineSpec.tasks.size() > 0 ?
+      pipelineRun.spec.pipelineSpec.tasks.map(
+        task,
+        has(task.params) ? task.params.filter(p, p.name == 'PLATFORM') : []
+      )
+      .filter(p, p.size() > 0)
+      .filter(
+        p,
+        !(
+          p[0].value in [
+            'linux/ppc64le',
+            'linux/s390x',
+            'linux/x86_64',
+            'local',
+            'localhost',
+          ]
+        )
+      )
+      .map(
+        p,
+        resource('aws-ip', 1)
+      ) : []
+
+    # Set mintmaker resource requests.
+    # Necessary since mintmaker refreshes can overload clusters without a
+    # bottleneck on the number of pipelineruns running.
+    - |
+        plrNamespace == 'mintmaker' ? [resource('mintmaker', 1)] : []
+
+    # The token mechanism allows us to balance admitted PipelineRuns.
+    # Each PipelineRun requests 1 token, except for internal-services PLRs.
+    # This is to guarantee there is always room for internal-services PLRs.
+    #
+    #
+    # WARNING: As a temporary measure, we are using tokens to provide a priority lane
+    # for internal-services PLRs. They'll be removed in some time and moved to the
+    # common clusters.
+    - |
+        has(pipelineRun.metadata.labels) &&
+        'internal-services.appstudio.openshift.io/pipelinerun-uid' in pipelineRun.metadata.labels ?
+        [] : [resource('konflux-ci-dev-token', 1)]
+
+    # Add a resource to restrict the number of concurrent release pipelineruns
+    - |
+        has(pipelineRun.metadata.labels) &&
+        'appstudio.openshift.io/service' in pipelineRun.metadata.labels &&
+        pipelineRun.metadata.labels['appstudio.openshift.io/service'] == 'release' &&
+        'pipelines.appstudio.openshift.io/type' in pipelineRun.metadata.labels &&
+        pipelineRun.metadata.labels['pipelines.appstudio.openshift.io/type'] == 'managed' ?
+        [resource('konflux-release', 1)] :
+
+        has(pipelineRun.metadata.labels) &&
+        'appstudio.openshift.io/service' in pipelineRun.metadata.labels &&
+        pipelineRun.metadata.labels['appstudio.openshift.io/service'] == 'release' &&
+        'release.appstudio.openshift.io/namespace' in pipelineRun.metadata.labels &&
+        pipelineRun.metadata.labels['release.appstudio.openshift.io/namespace'] == plrNamespace ?
+        [resource('konflux-release', 1)] : []
+
+    # Set the pipeline priority
+    - |
+        has(pipelineRun.metadata.labels) &&
+        'build.appstudio.redhat.com/type' in pipelineRun.metadata.labels &&
+        pipelineRun.metadata.labels['build.appstudio.redhat.com/type'] == 'nudge' ?
+        priority('konflux-nudge') :
+
+        pacEventType == 'push' ? priority('konflux-post-merge-build') :
+        pacEventType == 'pull_request' ||
+          pacEventType == "Merge_Request" ||
+          pacEventType == 'test-comment' ||
+          pacEventType == 'retest-comment' ||
+          pacEventType == 'retest-all-comment' ||
+          pacEventType == 'ok-to-test-comment'  ? priority('konflux-pre-merge-build') :
+        pacTestEventType == 'push' ? priority('konflux-post-merge-test') :
+        pacTestEventType == 'pull_request' ||
+          pacTestEventType == "Merge_Request" ||
+          pacTestEventType == 'test-comment' ||
+          pacTestEventType == 'retest-comment' ||
+          pacTestEventType == 'retest-all-comment' ||
+          pacTestEventType == 'ok-to-test-comment' ? priority('konflux-pre-merge-test') :
+
+        has(pipelineRun.metadata.labels) &&
+        'appstudio.openshift.io/service' in pipelineRun.metadata.labels &&
+        pipelineRun.metadata.labels['appstudio.openshift.io/service'] == 'release' &&
+        'pipelines.appstudio.openshift.io/type' in pipelineRun.metadata.labels &&
+        pipelineRun.metadata.labels['pipelines.appstudio.openshift.io/type'] == 'managed' ?
+        priority('konflux-release') :
+
+        has(pipelineRun.metadata.labels) &&
+        'appstudio.openshift.io/service' in pipelineRun.metadata.labels &&
+        pipelineRun.metadata.labels['appstudio.openshift.io/service'] == 'release' &&
+        'release.appstudio.openshift.io/namespace' in pipelineRun.metadata.labels &&
+        pipelineRun.metadata.labels['release.appstudio.openshift.io/namespace'] == plrNamespace ?
+        priority('konflux-tenant-release') :
+
+        plrNamespace == 'mintmaker' ? priority('konflux-dependency-update') :
+
+        has(pipelineRun.metadata.labels) &&
+        'internal-services.appstudio.openshift.io/pipelinerun-uid' in pipelineRun.metadata.labels ?
+        priority('konflux-release') :
+
+        priority('konflux-default')

--- a/components/kueue-rd/rings/ring-2/kflux-lw-p01/kustomization.yaml
+++ b/components/kueue-rd/rings/ring-2/kflux-lw-p01/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- cluster-queue.yaml
+- ../base
+
+configMapGenerator:
+  - name: tekton-kueue-config
+    namespace: tekton-kueue
+    behavior: replace
+    files:
+      - config.yaml
+generatorOptions:
+  disableNameSuffixHash: true


### PR DESCRIPTION
## What

Add missing kueue-rd ring-2 overlay for kflux-lw-p01.

Clusters affected: kflux-lw-p01

[KFLUXINFRA-4495](https://redhat.atlassian.net/browse/KFLUXINFRA-4495)

## Why

The kflux-lw-p01 cluster is listed in the k-components tenant/internal-tenant
cluster list patches (assigned to ring-2), but the corresponding directory
`components/kueue-rd/rings/ring-2/kflux-lw-p01` was never created. This causes
the kueue ArgoCD ApplicationSet to fail with:

> ComparisonError: Failed to load target state: failed to generate manifest for source 1 of 1: rpc error: code = Unknown desc = components/kueue-rd/rings/ring-2/kflux-lw-p01: app path does not exist

## Validation

- `kustomize build --enable-helm components/kueue-rd/rings/ring-2/kflux-lw-p01/` passes ✅
- Configuration copied from kflux-rhel-p01 (same ring-2 cluster) as a starting point — quotas may need tuning post-deployment

## Risk Assessment

**Risk Level:** Low
**What could go wrong:** The resource quotas copied from kflux-rhel-p01 may not be optimal for kflux-lw-p01 capacity — quotas may need tuning after deployment
**Rollback:** Revert PR
**Blast radius:** 1 cluster (kflux-lw-p01) — currently broken (ArgoCD ComparisonError), this fixes it

Made with [Cursor](https://cursor.com)

[KFLUXINFRA-4495]: https://redhat.atlassian.net/browse/KFLUXINFRA-4495?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ