### PR TITLE
chore: add deployment state investigation skill

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,7 @@ GitOps monorepo deploying 50+ Kubernetes components across multiple clusters via
 
 ## Skills
 
+- When determining desired deployment state, comparing component versions across clusters, or tracing fixes and rollout history, read `skills/deployment-state/SKILL.md`
 - Before opening a PR, writing a PR description, or interpreting CI results, read `skills/pr-workflow.md`
 - When drafting or reviewing a production PR's Risk Assessment section, read `skills/risk-assessment.md`
 - When a CI check fails on a PR, read `skills/ci-troubleshooting.md`

--- a/skills/deployment-state/SKILL.md
+++ b/skills/deployment-state/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: deployment-state
+description: >
+  Use when determining deployment state of konflux clusters, comparing
+  component versions across environments or clusters, checking whether a source
+  fix has rolled out, or tracing a rollout back to source changes and bug fixes.
+---
+
+# Deployment State
+
+Determine what `origin/main` says should be deployed. This is a read-only investigation
+skill: do not change deployment configuration.
+
+This repository represents the **desired Git state**, not the live Argo CD sync
+state or Kubernetes runtime state.
+
+## Repository prerequisite
+
+Work from a local clone so repository-wide search, history, and rendering are available.
+If `infra-deployments` is not already present, clone
+`https://github.com/redhat-appstudio/infra-deployments.git` into a suitable workspace or
+temporary directory and enter it. Reuse an existing clone when available; do not assume
+the skill was invoked from inside one. Then fetch `origin main` before investigating.
+Do not clone over an existing path or alter a user's working tree.
+
+Start every investigation by reading [references/repository-resolution.md](references/repository-resolution.md).
+
+## Scope and confidence
+
+- State the exact commits you examined. Do not switch branches or alter the
+  working tree.
+- Treat the merge time of a deployment change on `origin/main` as the desired-state
+  rollout time. Do not imply that Argo CD finished reconciling at that time.
+- If the question requires proof of live state, say that live Argo CD or Kubernetes
+  confirmation is needed. Do not perform it as part of this skill.
+- Prefer the smallest investigation that answers the question. Versions may include
+  image tags or digests, Git/Kustomize refs, Helm chart versions, and multiple workload
+  images, but do not load all of them into context unless they matter.
+
+## Choose a workflow
+
+- **Compare current desired state across clusters or environments:** resolve each exact
+  deployment path, compare the effective pins, and cite their defining files. The
+  repository-resolution reference is usually sufficient.
+- **Known source fix -> rollout coverage and timing:** read
+  [references/fix-to-rollout.md](references/fix-to-rollout.md).
+- **Cluster rollout -> component/revision inventory:** read
+  [references/rollout-inventory.md](references/rollout-inventory.md). Stop at the
+  concise inventory unless more interpretation is requested.
+- **Rollout -> source commits or pull requests:** read
+  [references/source-change-range.md](references/source-change-range.md).
+- **Rollout -> interpreted bug fixes:** read
+  [references/interpret-bug-fixes.md](references/interpret-bug-fixes.md). Distinguish
+  linked/confirmed fixes from inferred bug-related changes.
+- **When and why clusters diverged:** read
+  [references/divergence-history.md](references/divergence-history.md).
+
+When an image must be mapped to its source repository and commit, use the separately
+available `working-with-provenance` skill. Do not reproduce or improvise its attestation
+commands here. A tag that resembles a Git SHA is not proof of provenance.
+
+## Scale and verification
+
+For a broad cluster/time-window request, first return or establish a concise inventory
+of affected components and revisions. Investigate source history only for the relevant
+components. Use sub-agents when multi-component history or source interpretation would
+substantially bloat context.
+
+Broad multi-cluster results, historical conclusions, ancestry checks, provenance-derived
+mappings, and interpreted bug-fix findings require the challenger pass in
+[references/evidence-and-challenge.md](references/evidence-and-challenge.md). A simple
+current-state lookup can be self-verified against cited repository evidence.
+
+## Answer contract
+
+Include only relevant fields, but make these facts unambiguous:
+
+- `origin/main` commit examined
+- component and requested cluster/environment
+- effective desired version or source revision, with evidence paths
+- whether the result describes a stored definition or a Git-proven actively targeted path
+- desired-state merge time when the question is historical
+- ancestry result when checking whether a fix is included
+- confirmed versus inferred source-level fixes
+- exclusions, unresolved mappings, or ambiguity
+- stable, revision-pinned evidence links for historical or challenged conclusions
+- the desired-state/live-state confidence boundary
+- use full github.com urls so that users can navigate to your evidence to understand
+
+Never translate “definition not found” directly into “not deployed.” Distinguish a cluster
+that is explicitly not targeted, a missing definition, and an unresolved or unusual layout.

--- a/skills/deployment-state/references/divergence-history.md
+++ b/skills/deployment-state/references/divergence-history.md
@@ -1,0 +1,24 @@
+# Divergence History
+
+Use this workflow to determine when and why desired versions differ across targets.
+
+Resolve each target's current effective pin with
+[repository-resolution.md](repository-resolution.md). Then use path history, blame, pickaxe
+search, and individual deployment commits to find when the effective values diverged and
+whether the cause was a ring promotion, cluster override, rollback or revert, or layout
+migration.
+
+Useful commands:
+
+```bash
+git log --oneline origin/main -- components/<component>
+git log -p origin/main -- <exact-path>
+git blame origin/main -- <file>
+git log -S'<tag-or-sha>' --all -- components/<component>
+git show --stat <deployment-commit>
+git show <deployment-commit> -- <relevant-paths>
+```
+
+History explains how current desired state arose; current `origin/main` remains authoritative.
+Call out reverts, partial rings, coupled refs, and migration commits that make a simple
+“version changed once” narrative inaccurate.

--- a/skills/deployment-state/references/evidence-and-challenge.md
+++ b/skills/deployment-state/references/evidence-and-challenge.md
@@ -1,0 +1,52 @@
+# Evidence and Challenger Pass
+
+## Evidence standard
+
+Every material conclusion must be traceable to evidence another agent can open or reproduce.
+Prefer links or precise identifiers for:
+
+- infra-deployments files and fields at the examined `origin/main` commit;
+- ApplicationSet cluster membership and inheritance edges;
+- deployment commits and pull requests with timestamps;
+- source commits, ancestry results, source pull requests, and linked issues;
+- provenance-derived repository and commit mappings.
+
+For GitHub-hosted evidence, prefer stable blob, commit, pull request, and issue URLs pinned to the
+examined revision over branch-relative links or local paths alone. Local paths remain useful
+for reproducible commands, but a challenger should be able to follow the durable URL.
+
+Record commands and exact revisions when a result depends on rendering, ancestry, or a
+time range. A search-result snippet is a lead, not final evidence; follow its underlying
+file, commit, pull request, issue, or attestation.
+
+## When a challenger is required
+
+Use an independent sub-agent for broad multi-cluster investigations, historical rollout
+claims, source ancestry, provenance mappings, and interpreted bug-fix summaries. A narrow
+current-state answer may instead be verified directly by the primary agent.
+
+Give the challenger the user's question, the draft findings, and their evidence links or
+identifiers. Ask it to independently:
+
+1. follow every material evidence link or identifier;
+2. verify cluster targeting and the effective inheritance path;
+3. reproduce pin resolution, timestamps, ancestry, and source ranges where applicable;
+4. identify counterexamples, missing clusters, overrides, non-linear history, and
+   confirmed-versus-inferred wording errors;
+5. mark each conclusion supported, contradicted, or unresolved.
+
+The challenger must not accept the first pass's summary as evidence. It should inspect the
+underlying artifacts. Revise or qualify contradicted and unresolved findings before answering.
+If evidence cannot be followed because of access or network limits, disclose that limitation
+instead of treating the finding as verified.
+
+If no independent agent slot is available, do not claim the required challenge succeeded.
+Either wait/delegate when possible or label the affected conclusions provisional and identify
+the specific evidence that still needs independent verification.
+
+## Avoid circular verification
+
+When practical, have the challenger use an independent route: rendered output versus raw
+inheritance tracing, source Git ancestry versus deployment tag assumptions, or pull request/issue
+content versus commit-message interpretation. Independence matters more than repeating the
+same grep command.

--- a/skills/deployment-state/references/fix-to-rollout.md
+++ b/skills/deployment-state/references/fix-to-rollout.md
@@ -1,0 +1,36 @@
+# Fix to Rollout
+
+Use this workflow to determine which desired targets include a known component source fix
+and when each target's desired state first included it.
+
+1. Resolve each requested cluster's effective deployed source revision at `origin/main`
+   using [repository-resolution.md](repository-resolution.md).
+2. Use that reference's source-resolution and ancestry procedure to test whether the
+   deployed revision contains the fix.
+3. Classify each target as includes fix, predates fix, not targeted, or unresolved.
+4. For included targets, identify the `origin/main` deployment commit that first changed
+   that target's effective pin to the fix or a descendant. Its merge/commit time is the
+   desired-state rollout time.
+5. Account for inheritance: one base change may affect several clusters, while ring bases
+   and cluster overrides can produce different times.
+
+## Operator-managed operands
+
+For an operand embedded in an umbrella operator, first-inclusion timing may require walking
+historical operator image promotions backward, resolving each relevant image to its source,
+and testing the embedded operand revision for ancestry with the fix.
+
+An efficient boundary search is:
+
+1. Extract the sequence of operator image pins and their infra-deployments commits for the
+   relevant ring path.
+2. Deduplicate pins and provenance-resolve each image only once.
+3. Inspect the embedded operand revision and test it against the fix.
+4. Bracket the last excluding and first including operator images, using binary search when
+   the promotion sequence is long.
+5. Map the first including image back to the deployment commit and desired-state merge time.
+
+Delegate rings to sub-agents when the sequence is large and cache resolved image-to-source
+mappings. If provenance or source history is unavailable, stop with an explicit unresolved
+boundary. Use the first image proven to include the fix; the current operator image's
+promotion time alone does not establish first inclusion.

--- a/skills/deployment-state/references/interpret-bug-fixes.md
+++ b/skills/deployment-state/references/interpret-bug-fixes.md
@@ -1,0 +1,17 @@
+# Interpret Bug Fixes
+
+First establish a verified source change range with
+[source-change-range.md](source-change-range.md). Then inspect commit messages, diffs where
+necessary, pull request descriptions, and linked issues.
+
+Report separately:
+
+- **Confirmed fixes:** commits, merged pull requests, or linked issues explicitly describe
+  the change as a fix.
+- **Likely fixes:** evidence supports a bug-fix interpretation but does not explicitly say so.
+- **Other changes:** relevant features, refactors, dependency updates, or operational changes.
+
+Explain the evidence briefly and link it. Never convert a plausible code interpretation into
+a confirmed user-visible fix. This workflow is intentionally more expensive; do not run it
+when the user only needs a known fix identifier checked. Delegate components to sub-agents
+when the source range is broad.

--- a/skills/deployment-state/references/repository-resolution.md
+++ b/skills/deployment-state/references/repository-resolution.md
@@ -1,0 +1,135 @@
+# Resolving Desired Deployment State
+
+## Ensure a local clone
+
+First locate an existing `infra-deployments` checkout. If none is available, create a
+local clone before searching:
+
+```bash
+git clone https://github.com/redhat-appstudio/infra-deployments.git <safe-local-path>
+cd <safe-local-path>
+```
+
+Choose an explicit empty destination in a suitable workspace or temporary directory.
+Do not overwrite an existing directory. A local clone is required because effective-state
+resolution relies on repository-wide search, Git history, inheritance tracing, and sometimes
+Kustomize rendering.
+
+## Establish the revision
+
+Run `git fetch origin main`, then record `git rev-parse origin/main` and its commit time.
+Use Git object commands such as `git grep <pattern> origin/main -- <paths>` and
+`git show origin/main:<path>` so an unrelated checkout cannot affect the answer.
+
+If rendering is necessary and the working tree is not at `origin/main`, materialize
+`origin/main` in a temporary directory (for example with `git archive`) and render there.
+Do not switch, reset, or modify the user's checkout. Preserve the temporary render when
+it contains evidence needed by a challenger; otherwise remove only the known temporary
+directory after the investigation.
+
+## Resolve cluster to source path
+
+Do not infer a cluster's deployment path solely from directory names or a global ring map.
+Resolve it through the component's Argo CD ApplicationSet under `argo-cd-apps/`.
+
+Normalize names cautiously. A workload or image name may differ from its component directory,
+and an umbrella operator may own resources that previously had a standalone ApplicationSet.
+Treat near-matching cluster names (for example `prod` versus `prd`) as distinct until exact
+ApplicationSet evidence proves an alias. A cluster name appearing in a URL, secret, or config
+value is not evidence that the workload targets that cluster.
+
+When a standalone component is excluded, removed, or only targets part of the fleet, check
+whether an umbrella operator now deploys that operand. Resolve the operator image to its
+source with `working-with-provenance`, then inspect the operator source revision's embedded
+manifests or dependency pin for the operand. Report standalone and operator-managed coverage
+separately; do not assume one supersedes the other on every cluster.
+
+1. Locate the component ApplicationSet and its `sourceRoot`, `environment`, `ring`, and
+   `clusterDir` values.
+2. Follow the overlay's `kustomization.yaml` and shared list patches to confirm that the
+   requested cluster is targeted and to obtain its exact path.
+3. For legacy layouts, expect paths under
+   `components/<component>/{development,staging,production}/`, sometimes with `base` or
+   per-cluster overlays.
+4. For ring deployments, expect
+   `components/<component>/rings/ring-N/{base,<cluster>}`. Ring assignments are
+   component-specific. ApplicationSets currently track `main`; Kargo promotes by changing
+   ring subdirectories through pull requests, not by assigning a branch per ring.
+5. Confirm whether a similarly named legacy and `-rd` component coexist during migration.
+
+Some ApplicationSet generators depend on Argo CD cluster secrets or other live inputs that
+are not fully enumerated in this repository. Use checked-in selectors, list patches, and
+overlays to identify what Git proves. If they do not enumerate the complete target set, say
+that total fleet coverage cannot be proven from Git alone; do not silently treat discovered
+cluster directories as exhaustive.
+
+During migrations, distinguish a version present in a legacy environment definition from a
+version proven to be consumed by a currently generated Application. Exclusion patches can
+replace a standalone deployment with an operator-managed one. Describe the former as a
+definition unless ApplicationSet evidence connects it to current targets.
+
+Useful discovery commands include:
+
+```bash
+git grep -n -e '<component>' -e 'sourceRoot' -e 'clusterDir' -e 'values.ring' origin/main -- argo-cd-apps
+git grep -n -e 'nameNormalized: <cluster>' -e 'values.clusterDir: <cluster>' origin/main -- argo-cd-apps
+git ls-tree -r --name-only origin/main -- components/<component>
+git grep -n -e 'newTag:' -e 'newName:' -e 'digest:' -e 'image:' -e 'helmCharts:' -e 'version:' -e '?ref=' origin/main -- components/<component>
+```
+
+Broad grep results are discovery leads. Confirm exact YAML fields and list elements before
+using them as membership or inheritance evidence.
+
+## Determine the effective pin
+
+Follow `resources`, `components`, patches, image transforms, generators, and Helm values
+from the exact cluster path. A nearby grep hit is a candidate, not necessarily effective
+state. Cluster overlays can override environment or ring bases, and checked-in generated
+YAML matters only when the active kustomization references it.
+
+Render with:
+
+```bash
+kustomize build --enable-helm <exact-source-path>
+```
+
+Render when inheritance is non-trivial, an override is possible, or the question asks for
+an exact effective result. Remote bases and Helm dependencies may require network access.
+If rendering is blocked, report the traced definition and the unresolved uncertainty.
+
+A component can comprise several first-party images or refs. Identify the primary workload
+and include sidecars, monitors, dashboards, or dependencies only when they affect the
+question. Do not assume correlated-looking pins have the same source without evidence.
+
+## Resolve a pin to source
+
+A direct Git or Kustomize ref may identify the source repository and commit. When an image's
+source is not proven, load the separately available `working-with-provenance` skill and use
+it to resolve the image to its repository and commit. A tag that resembles a Git SHA is not
+proof of provenance.
+
+Before comparing source revisions:
+
+1. Confirm that both revisions belong to the same source repository.
+2. Resolve abbreviated commits unambiguously and fetch enough source history.
+3. Use `git merge-base --is-ancestor <older> <newer>` rather than comparing SHA strings,
+   timestamps, or tags.
+4. Record command exit codes and test both directions when explaining which revision
+   predates the other.
+
+If revisions are not linearly related, report that and use an appropriate merge base or
+range rather than inventing an ordering.
+
+## Compare results
+
+Resolve and, when needed, render every requested cluster independently. Report a compact
+matrix when comparing several targets. Cite paths at `origin/main`, and cite the line or
+field that establishes each pin or inheritance edge. Classify absence carefully:
+
+- **not targeted:** ApplicationSet evidence excludes the cluster;
+- **definition not found:** no applicable definition was located;
+- **unresolved:** migration, ownership, rendering, or unusual layout prevents a conclusion.
+
+`hack/new-cluster/templates/` describes bootstrap state for future clusters. Consult it
+only for bootstrap questions or explicit rollout-consistency checks; it is not the current
+desired state of existing Argo CD-managed clusters.

--- a/skills/deployment-state/references/rollout-inventory.md
+++ b/skills/deployment-state/references/rollout-inventory.md
@@ -1,0 +1,17 @@
+# Rollout Inventory
+
+Use this workflow for questions such as “what changed on cluster X this morning?”
+
+1. Resolve current ApplicationSet targeting with
+   [repository-resolution.md](repository-resolution.md) before searching history. If a
+   component is explicitly not targeted, stop unless the user asks about former targeting.
+2. Interpret the requested time window in the user's timezone and state the exact range.
+3. Resolve which ApplicationSets and component paths target the cluster.
+4. Inspect `origin/main` commits in the range and retain only changes affecting those
+   effective paths, including inherited environment or ring bases.
+5. Produce a concise inventory: component, old pin, new pin, desired-state merge time,
+   deployment commit or pull request when available, and defining path.
+6. Stop unless the user asks for source commits, pull requests, or interpreted fixes. For a
+   large inventory, delegate components to sub-agents and merge only evidence-backed results.
+
+Changes to bootstrap templates alone are not rollouts to existing clusters.

--- a/skills/deployment-state/references/source-change-range.md
+++ b/skills/deployment-state/references/source-change-range.md
@@ -1,0 +1,16 @@
+# Source Change Range
+
+Use this workflow after identifying a rollout's old and new deployment pins. If those pins
+are not known yet, first use [rollout-inventory.md](rollout-inventory.md).
+
+For each selected component:
+
+1. Resolve the old and new pins to source repository commits using
+   [repository-resolution.md](repository-resolution.md).
+2. Verify repository identity and ancestry. If the revisions are not linearly related, use
+   an appropriate merge base or range and make the relationship explicit.
+3. List the source commits and associated pull requests between the old and new revisions.
+4. Cite stable source commit and pull request URLs.
+
+Keep the result as a concise change inventory unless interpretation is requested. For bug-fix
+interpretation, continue with [interpret-bug-fixes.md](interpret-bug-fixes.md).


### PR DESCRIPTION
I'm working on fullsend triage of Bugs in KONFLUX project in JIRA.

One of the first ones we tried was https://redhat.atlassian.net/browse/KONFLUX-15689, where we realized that some understanding of the state of infra-deployments could be helpful to an agent triaging incoming bug reports.

So, I'm proposing the creation of this skill and intend to link to it from the [list of skills made available to that agent](https://github.com/konflux-ci/rh-jira-triage/blob/main/.fullsend/harness/triage.yaml#L25-L28).