### PR TITLE
Remove banner warning about prefetch-deps <0.7.1

### DIFF
--- a/components/konflux-info/production/kflux-ocp-p01/banner-content.yaml
+++ b/components/konflux-info/production/kflux-ocp-p01/banner-content.yaml
@@ -1,3 +1,2 @@
 # Only the first banner will be displayed. Put the one to display at the top and remove any which are no longer relevant
-- summary: "Versions of prefetch-dependencies task older than 0.7.1 have been deprecated for security reasons. Please upgrade to avoid Conforma violations. See #konflux-users and konflux-announce e-mails for more information."
-  type: "danger"
+[]

--- a/components/konflux-info/production/kflux-osp-p01/banner-content.yaml
+++ b/components/konflux-info/production/kflux-osp-p01/banner-content.yaml
@@ -1,3 +1,2 @@
 # Only the first banner will be displayed. Put the one to display at the top and remove any which are no longer relevant
-- summary: "Versions of prefetch-dependencies task older than 0.7.1 have been deprecated for security reasons. Please upgrade to avoid Conforma violations. See #konflux-users and konflux-announce e-mails for more information."
-  type: "danger"
+[]

--- a/components/konflux-info/production/kflux-prd-rh02/banner-content.yaml
+++ b/components/konflux-info/production/kflux-prd-rh02/banner-content.yaml
@@ -1,3 +1,2 @@
 # Only the first banner will be displayed. Put the one to display at the top and remove any which are no longer relevant
-- summary: "Versions of prefetch-dependencies task older than 0.7.1 have been deprecated for security reasons. Please upgrade to avoid Conforma violations. See #konflux-users and konflux-announce e-mails for more information."
-  type: "danger"
+[]

--- a/components/konflux-info/production/kflux-prd-rh03/banner-content.yaml
+++ b/components/konflux-info/production/kflux-prd-rh03/banner-content.yaml
@@ -1,3 +1,2 @@
 # Only the first banner will be displayed. Put the one to display at the top and remove any which are no longer relevant
-- summary: "Versions of prefetch-dependencies task older than 0.7.1 have been deprecated for security reasons. Please upgrade to avoid Conforma violations. See #konflux-users and konflux-announce e-mails for more information."
-  type: "danger"
+[]

--- a/components/konflux-info/production/kflux-rhel-p01/banner-content.yaml
+++ b/components/konflux-info/production/kflux-rhel-p01/banner-content.yaml
@@ -1,3 +1,2 @@
 # Only the first banner will be displayed. Put the one to display at the top and remove any which are no longer relevant
-- summary: "Versions of prefetch-dependencies task older than 0.7.1 have been deprecated for security reasons. Please upgrade to avoid Conforma violations. See #konflux-users and konflux-announce e-mails for more information."
-  type: "danger"
+[]

--- a/components/konflux-info/production/stone-prd-rh01/banner-content.yaml
+++ b/components/konflux-info/production/stone-prd-rh01/banner-content.yaml
@@ -1,3 +1,2 @@
 # Only the first banner will be displayed. Put the one to display at the top and remove any which are no longer relevant
-- summary: "Versions of prefetch-dependencies task older than 0.7.1 have been deprecated for security reasons. Please upgrade to avoid Conforma violations. See #konflux-users and konflux-announce e-mails for more information."
-  type: "danger"
+[]

--- a/components/konflux-info/production/stone-prod-p01/banner-content.yaml
+++ b/components/konflux-info/production/stone-prod-p01/banner-content.yaml
@@ -1,3 +1,2 @@
 # Only the first banner will be displayed. Put the one to display at the top and remove any which are no longer relevant
-- summary: "Versions of prefetch-dependencies task older than 0.7.1 have been deprecated for security reasons. Please upgrade to avoid Conforma violations. See #konflux-users and konflux-announce e-mails for more information."
-  type: "danger"
+[]


### PR DESCRIPTION
## What

Remove obsolete danger banner regarding prefetch-dependencies task <0.7.1 deprecation.

Clusters affected:
- `kflux-ocp-p01`
- `kflux-osp-p01`
- `kflux-prd-rh02`
- `kflux-prd-rh03`
- `kflux-rhel-p01`
- `stone-prd-rh01`
- `stone-prod-p01`

Target cluster: all production clusters listed above
Type: Remove obsolete banner
Purpose: Clear expired prefetch-dependencies deprecation warning banner

## Why

The deprecation notice has been displayed since August 13 (PR #13491). Migration window has passed; banner is no longer needed.

## Validation

- `yamllint components/konflux-info/production/*/banner-content.yaml` passed.
- `kustomize build --enable-helm` verified clean across all 7 cluster overlays.
- Formatted as empty list `[]` per `components/konflux-info/banner-schema.json`.

## Risk Assessment

**Risk Level:** Low
**What could go wrong:** Banner fails to display or UI renders blank banner if YAML invalid (mitigated by schema validation and clean kustomize build).
**Rollback:** Revert PR + ArgoCD auto-sync.
**Blast radius:** UI banner across production clusters. No pipeline or workload impact.

Assisted-by: opencode

Signed-off-by: Ben Hills <bhills@redhat.com>