### PR TITLE
Increase ArgoCD repo-server memory to fix kustomize SIGSEGV crashes

### DIFF
--- a/hack/deploy-argocd.sh
+++ b/hack/deploy-argocd.sh
@@ -149,12 +149,18 @@ spec:
     env:
       - name: ARGOCD_EXEC_TIMEOUT
         value: 5m
+      - name: ARGOCD_REPO_SERVER_PARALLELISM_LIMIT
+        value: "20"
+      - name: GOMEMLIMIT
+        value: 6GiB
     resources:
       requests:
-        cpu: 100m
-        memory: 100Mi
+        cpu: "2"
+        memory: 2Gi
+      limits:
+        memory: 8Gi
 ' --type=merge; then
-        log_success "Repo server configured: timeout=5m, cpu=100m, memory=100Mi"
+        log_success "Repo server configured: timeout=5m, parallelism=20, GOMEMLIMIT=6GiB, cpu=2, memory=2Gi/8Gi"
     else
         log_warn "Failed to patch repo server configuration (may already be set)"
     fi


### PR DESCRIPTION
Repo-server was configured with only 100Mi memory request and no limits, causing kustomize to crash with nil pointer dereference (SIGSEGV) when processing large builds with hundreds of --helm-api-versions flags.

Assisted-by: Claude Code (claude-opus-4-6)