### PR TITLE
KFLUXINFRA-4241: Resolve ring-based ApplicationSet paths in env detector

### DIFF
--- a/infra-tools/internal/appset/parse.go
+++ b/infra-tools/internal/appset/parse.go
@@ -234,17 +234,68 @@ func extractTemplatedPaths(pathTemplate string, generators []interface{}) ([]Com
 	return paths, clusters, nil
 }
 
+// generatorValues holds the ApplicationSet template placeholders we can resolve
+// from a clusters generator (defaults) plus list-generator overrides.
+type generatorValues struct {
+	sourceRoot  string
+	environment string
+	clusterDir  string
+	ring        string
+}
+
+func valuesFromMap(values map[string]interface{}) generatorValues {
+	if values == nil {
+		return generatorValues{}
+	}
+	v := generatorValues{}
+	v.sourceRoot, _ = values["sourceRoot"].(string)
+	v.environment, _ = values["environment"].(string)
+	v.clusterDir, _ = values["clusterDir"].(string)
+	v.ring, _ = values["ring"].(string)
+	return v
+}
+
+// interpolatePath substitutes known {{values.*}} placeholders in an ApplicationSet
+// source path. Empty trailing segments (e.g. clusterDir: "") are trimmed so
+// environment-based templates still resolve to sourceRoot/environment.
+func interpolatePath(pathTemplate string, v generatorValues) string {
+	resolved := strings.NewReplacer(
+		"{{values.sourceRoot}}", v.sourceRoot,
+		"{{values.environment}}", v.environment,
+		"{{values.clusterDir}}", v.clusterDir,
+		"{{values.ring}}", v.ring,
+	).Replace(pathTemplate)
+	return strings.TrimSuffix(resolved, "/")
+}
+
+func componentPathFromValues(pathTemplate string, v generatorValues) ComponentPath {
+	cp := ComponentPath{Path: interpolatePath(pathTemplate, v)}
+	if v.clusterDir != "" {
+		cp.ClusterDir = v.clusterDir
+	}
+	return cp
+}
+
+type listElement struct {
+	nameNormalized string
+	clusterDir     string
+	ring           string
+}
+
+func (v generatorValues) withListOverrides(le listElement) generatorValues {
+	out := v
+	if le.clusterDir != "" {
+		out.clusterDir = le.clusterDir
+	}
+	if le.ring != "" {
+		out.ring = le.ring
+	}
+	return out
+}
+
 // processMergeGenerators processes generators inside a merge generator.
 func processMergeGenerators(pathTemplate string, subGens []interface{}) ([]ComponentPath, map[string][]string, error) {
-	// First pass: extract base values from the clusters generator
-	var sourceRoot, environment, clusterDir string
-	var hasClusterDir bool
-
-	// Collect list elements for cluster overrides
-	type listElement struct {
-		nameNormalized string
-		clusterDir     string
-	}
+	var defaults generatorValues
 	var listElements []listElement
 
 	for _, sg := range subGens {
@@ -255,16 +306,7 @@ func processMergeGenerators(pathTemplate string, subGens []interface{}) ([]Compo
 
 		if clustersGen, ok := sgMap["clusters"].(map[string]interface{}); ok {
 			values, _ := clustersGen["values"].(map[string]interface{})
-			if sr, ok := values["sourceRoot"].(string); ok {
-				sourceRoot = sr
-			}
-			if env, ok := values["environment"].(string); ok {
-				environment = env
-			}
-			if cd, ok := values["clusterDir"].(string); ok {
-				clusterDir = cd
-				hasClusterDir = true
-			}
+			defaults = valuesFromMap(values)
 		}
 
 		if listGen, ok := sgMap["list"].(map[string]interface{}); ok {
@@ -281,6 +323,9 @@ func processMergeGenerators(pathTemplate string, subGens []interface{}) ([]Compo
 				if cd, ok := elemMap["values.clusterDir"].(string); ok {
 					le.clusterDir = cd
 				}
+				if ring, ok := elemMap["values.ring"].(string); ok {
+					le.ring = ring
+				}
 				listElements = append(listElements, le)
 			}
 		}
@@ -289,27 +334,24 @@ func processMergeGenerators(pathTemplate string, subGens []interface{}) ([]Compo
 	var paths []ComponentPath
 	clusters := make(map[string][]string)
 
-	// Resolve the path template
-	if sourceRoot == "" {
-		// Can't resolve without sourceRoot
+	if defaults.sourceRoot == "" {
 		return nil, nil, nil
 	}
 
 	// Check if the path uses {{nameNormalized}} — treat as prefix
 	if strings.Contains(pathTemplate, "{{nameNormalized}}") {
-		basePath := sourceRoot + "/" + environment + "/"
+		basePath := defaults.sourceRoot + "/" + defaults.environment + "/"
 		paths = append(paths, ComponentPath{
 			Path: basePath,
 		})
 
-		// Also add cluster-specific paths from list elements
 		for _, le := range listElements {
 			dir := le.clusterDir
 			if dir == "" {
 				dir = le.nameNormalized
 			}
 			if dir != "" {
-				p := sourceRoot + "/" + environment + "/" + dir
+				p := defaults.sourceRoot + "/" + defaults.environment + "/" + dir
 				paths = append(paths, ComponentPath{
 					Path:       p,
 					ClusterDir: dir,
@@ -320,41 +362,19 @@ func processMergeGenerators(pathTemplate string, subGens []interface{}) ([]Compo
 		return paths, clusters, nil
 	}
 
-	// Standard template: {{values.sourceRoot}}/{{values.environment}}/{{values.clusterDir}}
-	// or: {{values.sourceRoot}}/{{values.environment}}
+	// Interpolate the real source path template so both environment-based
+	// (sourceRoot/environment/clusterDir) and ring-based
+	// (sourceRoot/rings/ring/clusterDir) ApplicationSets resolve correctly.
+	paths = append(paths, componentPathFromValues(pathTemplate, defaults))
 
-	// Base path (from clusters generator defaults)
-	if hasClusterDir && clusterDir == "" {
-		// clusterDir is explicitly empty string — the path resolves to sourceRoot/environment/
-		basePath := sourceRoot + "/" + environment
-		paths = append(paths, ComponentPath{
-			Path: basePath,
-		})
-	} else if hasClusterDir && clusterDir != "" {
-		basePath := sourceRoot + "/" + environment + "/" + clusterDir
-		paths = append(paths, ComponentPath{
-			Path:       basePath,
-			ClusterDir: clusterDir,
-		})
-	} else {
-		// No clusterDir in template
-		basePath := sourceRoot + "/" + environment
-		paths = append(paths, ComponentPath{
-			Path: basePath,
-		})
-	}
-
-	// Add cluster-specific overrides from list elements
 	for _, le := range listElements {
-		if le.clusterDir != "" {
-			p := sourceRoot + "/" + environment + "/" + le.clusterDir
-			paths = append(paths, ComponentPath{
-				Path:       p,
-				ClusterDir: le.clusterDir,
-			})
-			if le.nameNormalized != "" {
-				clusters[le.nameNormalized] = append(clusters[le.nameNormalized], p)
-			}
+		if le.clusterDir == "" && le.ring == "" {
+			continue
+		}
+		cp := componentPathFromValues(pathTemplate, defaults.withListOverrides(le))
+		paths = append(paths, cp)
+		if le.nameNormalized != "" {
+			clusters[le.nameNormalized] = append(clusters[le.nameNormalized], cp.Path)
 		}
 	}
 
@@ -364,15 +384,9 @@ func processMergeGenerators(pathTemplate string, subGens []interface{}) ([]Compo
 // resolveClusterGenerator processes a direct clusters generator (without merge).
 func resolveClusterGenerator(pathTemplate string, clustersGen map[string]interface{}) []ComponentPath {
 	values, _ := clustersGen["values"].(map[string]interface{})
-	sourceRoot, _ := values["sourceRoot"].(string)
-	environment, _ := values["environment"].(string)
-
-	if sourceRoot == "" {
+	v := valuesFromMap(values)
+	if v.sourceRoot == "" {
 		return nil
 	}
-
-	basePath := sourceRoot + "/" + environment
-	return []ComponentPath{{
-		Path: basePath,
-	}}
+	return []ComponentPath{componentPathFromValues(pathTemplate, v)}
 }

--- a/infra-tools/internal/appset/parse_test.go
+++ b/infra-tools/internal/appset/parse_test.go
@@ -461,3 +461,163 @@ spec:
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(result.Paths).To(HaveLen(1))
 }
+
+func TestParseApplicationSets_RingTemplate_ClusterDefaults(t *testing.T) {
+	g := NewWithT(t)
+
+	yaml := `
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: multi-platform-controller
+spec:
+  generators:
+    - merge:
+        mergeKeys:
+          - nameNormalized
+        generators:
+          - clusters:
+              values:
+                sourceRoot: components/multi-platform-controller
+                ring: "empty-base"
+                clusterDir: "empty-base"
+          - list:
+              elements: []
+  template:
+    metadata:
+      name: multi-platform-controller-{{nameNormalized}}
+    spec:
+      source:
+        path: '{{values.sourceRoot}}/rings/{{values.ring}}/{{values.clusterDir}}'
+        repoURL: https://github.com/redhat-appstudio/infra-deployments.git
+`
+	result, err := ParseApplicationSets([]byte(yaml))
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(result.Paths).To(HaveLen(1))
+	g.Expect(result.Paths[0].Path).To(Equal("components/multi-platform-controller/rings/empty-base/empty-base"))
+	g.Expect(result.Paths[0].ClusterDir).To(Equal("empty-base"))
+}
+
+func TestParseApplicationSets_RingTemplate_ListOverrides(t *testing.T) {
+	g := NewWithT(t)
+
+	yaml := `
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: multi-platform-controller
+spec:
+  generators:
+    - merge:
+        mergeKeys:
+          - nameNormalized
+        generators:
+          - clusters:
+              values:
+                sourceRoot: components/multi-platform-controller
+                ring: "empty-base"
+                clusterDir: "empty-base"
+          - list:
+              elements:
+                - values.ring: ring-1
+                  nameNormalized: stone-stg-rh01
+                  values.clusterDir: stone-stg-rh01
+                - values.ring: ring-2
+                  nameNormalized: kflux-lw-p01
+                  values.clusterDir: kflux-lw-p01
+  template:
+    metadata:
+      name: multi-platform-controller-{{nameNormalized}}
+    spec:
+      source:
+        path: '{{values.sourceRoot}}/rings/{{values.ring}}/{{values.clusterDir}}'
+        repoURL: https://github.com/redhat-appstudio/infra-deployments.git
+`
+	result, err := ParseApplicationSets([]byte(yaml))
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(result.Paths).To(HaveLen(3))
+
+	paths := make([]string, 0, len(result.Paths))
+	for _, p := range result.Paths {
+		paths = append(paths, p.Path)
+	}
+	g.Expect(paths).To(ConsistOf(
+		"components/multi-platform-controller/rings/empty-base/empty-base",
+		"components/multi-platform-controller/rings/ring-1/stone-stg-rh01",
+		"components/multi-platform-controller/rings/ring-2/kflux-lw-p01",
+	))
+
+	g.Expect(result.Clusters).To(HaveKey("stone-stg-rh01"))
+	g.Expect(result.Clusters["stone-stg-rh01"]).To(ConsistOf(
+		"components/multi-platform-controller/rings/ring-1/stone-stg-rh01",
+	))
+	g.Expect(result.Clusters).To(HaveKey("kflux-lw-p01"))
+	g.Expect(result.Clusters["kflux-lw-p01"]).To(ConsistOf(
+		"components/multi-platform-controller/rings/ring-2/kflux-lw-p01",
+	))
+}
+
+func TestParseApplicationSets_RingTemplate_DevBase(t *testing.T) {
+	g := NewWithT(t)
+
+	yaml := `
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: etcd-shield
+spec:
+  generators:
+    - merge:
+        mergeKeys:
+          - nameNormalized
+        generators:
+          - clusters:
+              values:
+                sourceRoot: components/etcd-shield
+                ring: "ring-0"
+                clusterDir: base
+          - list:
+              elements: []
+  template:
+    metadata:
+      name: etcd-shield-{{nameNormalized}}
+    spec:
+      source:
+        path: '{{values.sourceRoot}}/rings/{{values.ring}}/{{values.clusterDir}}'
+        repoURL: https://github.com/redhat-appstudio/infra-deployments.git
+`
+	result, err := ParseApplicationSets([]byte(yaml))
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(result.Paths).To(HaveLen(1))
+	g.Expect(result.Paths[0].Path).To(Equal("components/etcd-shield/rings/ring-0/base"))
+	g.Expect(result.Paths[0].ClusterDir).To(Equal("base"))
+}
+
+func TestParseApplicationSets_DirectClusters_RingTemplate(t *testing.T) {
+	g := NewWithT(t)
+
+	yaml := `
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: etcd-shield
+spec:
+  generators:
+    - clusters:
+        values:
+          sourceRoot: components/etcd-shield
+          ring: "ring-0"
+          clusterDir: base
+  template:
+    metadata:
+      name: etcd-shield-{{nameNormalized}}
+    spec:
+      source:
+        path: '{{values.sourceRoot}}/rings/{{values.ring}}/{{values.clusterDir}}'
+        repoURL: https://github.com/redhat-appstudio/infra-deployments.git
+`
+	result, err := ParseApplicationSets([]byte(yaml))
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(result.Paths).To(HaveLen(1))
+	g.Expect(result.Paths[0].Path).To(Equal("components/etcd-shield/rings/ring-0/base"))
+}

--- a/infra-tools/internal/detector/detector.go
+++ b/infra-tools/internal/detector/detector.go
@@ -37,10 +37,12 @@ var OverlayEnvironment = map[string]Environment{
 }
 
 // kustomizeReservedDirs are directory names that are kustomize conventions and
-// should not be treated as cluster names.
+// should not be treated as cluster names. empty-base is the placeholder
+// clusterDir on ring-based ApplicationSets (not a real cluster).
 var kustomizeReservedDirs = map[string]bool{
-	"base":    true,
-	"overlay": true,
+	"base":       true,
+	"overlay":    true,
+	"empty-base": true,
 }
 
 // Result holds the detection output.

--- a/infra-tools/internal/detector/detector_test.go
+++ b/infra-tools/internal/detector/detector_test.go
@@ -69,6 +69,41 @@ spec:
         server: '{{server}}'
 `
 
+// appSetWithRing returns an ApplicationSet YAML that uses the ring-based path
+// template: sourceRoot/rings/ring/clusterDir.
+func appSetWithRing(root, defaultRing, defaultClusterDir, listRing, listCluster string) string {
+	return fmt.Sprintf(`apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: test-app
+spec:
+  generators:
+    - merge:
+        mergeKeys:
+          - nameNormalized
+        generators:
+          - clusters:
+              values:
+                sourceRoot: %s
+                ring: %q
+                clusterDir: %q
+          - list:
+              elements:
+                - nameNormalized: %s
+                  values.ring: %s
+                  values.clusterDir: %s
+  template:
+    metadata:
+      name: test-{{nameNormalized}}
+    spec:
+      source:
+        path: '{{values.sourceRoot}}/rings/{{values.ring}}/{{values.clusterDir}}'
+        repoURL: https://github.com/example/repo.git
+      destination:
+        server: '{{server}}'
+`, root, defaultRing, defaultClusterDir, listCluster, listRing, listCluster)
+}
+
 // appSetWithCluster returns an ApplicationSet YAML that uses a merge generator
 // with a cluster list, producing paths under <root>/<env> and <root>/<env>/<cluster>.
 func appSetWithCluster(root, env, cluster string) string {
@@ -627,6 +662,68 @@ func TestDetect_WithCluster(t *testing.T) {
 	g.Expect(result.AffectedClusters).To(HaveKey("stone-prod-p01"))
 }
 
+func TestDetect_RingPathsAttributedToOverlayEnv(t *testing.T) {
+	g := NewWithT(t)
+
+	stagingYAML := appSetWithRing(
+		"components/multi-platform-controller",
+		"empty-base", "empty-base",
+		"ring-1", "stone-stg-rh01",
+	)
+	productionYAML := appSetWithRing(
+		"components/multi-platform-controller",
+		"empty-base", "empty-base",
+		"ring-2", "kflux-lw-p01",
+	)
+	const stagingPath = "components/multi-platform-controller/rings/ring-1/stone-stg-rh01"
+	const productionPath = "components/multi-platform-controller/rings/ring-2/kflux-lw-p01"
+
+	head := &fakeRepo{
+		dirs: map[string][]string{"overlays": {"rd-staging", "rd-production"}},
+		yamls: map[string][]byte{
+			"overlays/rd-staging":    []byte(stagingYAML),
+			"overlays/rd-production": []byte(productionYAML),
+		},
+		exist: map[string]bool{
+			"overlays/rd-staging":    true,
+			"overlays/rd-production": true,
+			"components/multi-platform-controller/rings/empty-base/empty-base": true,
+			stagingPath:    true,
+			productionPath: true,
+		},
+		deps: map[string]map[string]bool{
+			stagingPath: {
+				stagingPath + "/host-config.yaml": true,
+			},
+			productionPath: {
+				productionPath + "/host-config.yaml": true,
+			},
+		},
+	}
+	base := &fakeRepo{
+		dirs: map[string][]string{"overlays": {"rd-staging", "rd-production"}},
+		yamls: map[string][]byte{
+			"overlays/rd-staging":    []byte(stagingYAML),
+			"overlays/rd-production": []byte(productionYAML),
+		},
+		exist: map[string]bool{
+			"overlays/rd-staging":    true,
+			"overlays/rd-production": true,
+		},
+	}
+
+	d, err := NewDetector(head, base, "overlays")
+	g.Expect(err).NotTo(HaveOccurred())
+
+	result, err := d.Detect([]string{stagingPath + "/host-config.yaml"})
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(result.AffectedEnvironments).To(HaveKey(Staging))
+	g.Expect(result.AffectedEnvironments).NotTo(HaveKey(Production))
+	g.Expect(result.AffectedClusters).To(HaveKey("stone-stg-rh01"))
+	g.Expect(result.AffectedClusters).NotTo(HaveKey("kflux-lw-p01"))
+	g.Expect(result.AffectedClusters).NotTo(HaveKey("empty-base"))
+}
+
 func TestDetect_RemovedOverlay(t *testing.T) {
 	g := NewWithT(t)
 
@@ -751,6 +848,19 @@ func TestMatchClusters_ReservedDirBase(t *testing.T) {
 	// The path "components/foo/staging/base" doesn't match any cluster path,
 	// so no clusters should be added.
 	g.Expect(result.AffectedClusters).To(BeEmpty())
+}
+
+func TestMatchClusters_ReservedDirEmptyBase(t *testing.T) {
+	g := NewWithT(t)
+	result := &Result{AffectedClusters: make(map[string]bool)}
+	cp := appset.ComponentPath{
+		Path:       "components/foo/rings/empty-base/empty-base",
+		ClusterDir: "empty-base",
+	}
+
+	matchClusters(cp, nil, result)
+
+	g.Expect(result.AffectedClusters).NotTo(HaveKey("empty-base"))
 }
 
 func TestMatchClusters_ReservedDirOverlay(t *testing.T) {
@@ -1055,6 +1165,44 @@ func TestExtractPathsFromOverlays_Basic(t *testing.T) {
 
 	// Cluster should be extracted
 	g.Expect(allClusters).To(HaveKey("stone-prod-p01"))
+}
+
+func TestExtractPathsFromOverlays_RingTemplateAttributedToOverlayEnv(t *testing.T) {
+	g := NewWithT(t)
+
+	stagingYAML := appSetWithRing(
+		"components/multi-platform-controller",
+		"empty-base", "empty-base",
+		"ring-1", "stone-stg-rh01",
+	)
+	productionYAML := appSetWithRing(
+		"components/multi-platform-controller",
+		"empty-base", "empty-base",
+		"ring-2", "kflux-lw-p01",
+	)
+	builds := []overlayBuild{
+		{name: "rd-staging", env: Staging, headYAML: []byte(stagingYAML)},
+		{name: "rd-production", env: Production, headYAML: []byte(productionYAML)},
+	}
+
+	envPaths, allClusters, err := extractPathsFromOverlays(builds)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	var stagingPaths, productionPaths []string
+	for _, cp := range envPaths[Staging] {
+		stagingPaths = append(stagingPaths, cp.Path)
+	}
+	for _, cp := range envPaths[Production] {
+		productionPaths = append(productionPaths, cp.Path)
+	}
+
+	g.Expect(stagingPaths).To(ContainElement("components/multi-platform-controller/rings/ring-1/stone-stg-rh01"))
+	g.Expect(stagingPaths).NotTo(ContainElement("components/multi-platform-controller/rings/ring-2/kflux-lw-p01"))
+	g.Expect(productionPaths).To(ContainElement("components/multi-platform-controller/rings/ring-2/kflux-lw-p01"))
+	g.Expect(productionPaths).NotTo(ContainElement("components/multi-platform-controller/rings/ring-1/stone-stg-rh01"))
+
+	g.Expect(allClusters).To(HaveKey("stone-stg-rh01"))
+	g.Expect(allClusters).To(HaveKey("kflux-lw-p01"))
 }
 
 func TestExtractPathsFromOverlays_MultipleEnvs(t *testing.T) {

--- a/infra-tools/internal/detector/detector_test.go
+++ b/infra-tools/internal/detector/detector_test.go
@@ -1188,10 +1188,11 @@ func TestExtractPathsFromOverlays_RingTemplateAttributedToOverlayEnv(t *testing.
 	envPaths, allClusters, err := extractPathsFromOverlays(builds)
 	g.Expect(err).NotTo(HaveOccurred())
 
-	var stagingPaths, productionPaths []string
+	stagingPaths := make([]string, 0, len(envPaths[Staging]))
 	for _, cp := range envPaths[Staging] {
 		stagingPaths = append(stagingPaths, cp.Path)
 	}
+	productionPaths := make([]string, 0, len(envPaths[Production]))
 	for _, cp := range envPaths[Production] {
 		productionPaths = append(productionPaths, cp.Path)
 	}


### PR DESCRIPTION
## What

- Interpolate `{{values.ring}}` (and other `{{values.*}}` placeholders) when resolving ApplicationSet source paths
- Honor both cluster-generator defaults and list-generator overrides (`values.ring`, `values.clusterDir`)
- Treat `empty-base` as a reserved placeholder, not a cluster name

Clusters affected: none

[KFLUXINFRA-4241](https://redhat.atlassian.net/browse/KFLUXINFRA-4241)

## Why

Ring-based ApplicationSets use `{{values.sourceRoot}}/rings/{{values.ring}}/{{values.clusterDir}}`. The env detector previously built `sourceRoot/environment/clusterDir`, ignored `values.ring`, and dropped the resulting nonexistent directories. Staging and production impact from rd-staging / rd-production overlays was missed for every ring-deployed component, not only multi-platform-controller.

Found in review of #13895.

## Validation

- `cd infra-tools && make test` passed (appset 82.4%, detector 80.5%)

## Risk Assessment

**Risk Level:** Low
**What could go wrong:** Env-detector labels on PRs could be wrong if path interpolation misses a template form
**Rollback:** Revert this PR
**Blast radius:** CI labeling and ring-deployment checks only; no cluster manifests change

Made with [Cursor](https://cursor.com)

[KFLUXINFRA-4241]: https://redhat.atlassian.net/browse/KFLUXINFRA-4241?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ