### PR TITLE
Promote release-service and grafana-dashboard from staging to production

### DIFF
--- a/components/monitoring/grafana/production/dashboards/release/kustomization.yaml
+++ b/components/monitoring/grafana/production/dashboards/release/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- https://github.com/konflux-ci/release-service/config/grafana/?ref=f3ac0e4aa928ff7c4fdac1846de3268afd9c9ae5
+- https://github.com/konflux-ci/release-service/config/grafana/?ref=178b9cf3b0978d85f0612521ce06061029007956

--- a/components/release/production/kustomization.yaml
+++ b/components/release/production/kustomization.yaml
@@ -4,7 +4,7 @@ resources:
   - ../base
   - ../base/monitor/production
   - external-secrets/release-service-github-token.yaml
-  - https://github.com/konflux-ci/release-service/config/default?ref=f3ac0e4aa928ff7c4fdac1846de3268afd9c9ae5
+  - https://github.com/konflux-ci/release-service/config/default?ref=178b9cf3b0978d85f0612521ce06061029007956
   - release_service_config.yaml
   - signing_configs.yaml
 
@@ -14,7 +14,7 @@ components:
 images:
   - name: quay.io/konflux-ci/release-service
     newName: quay.io/konflux-ci/release-service
-    newTag: f3ac0e4aa928ff7c4fdac1846de3268afd9c9ae5
+    newTag: 178b9cf3b0978d85f0612521ce06061029007956
 
 namespace: release-service
 


### PR DESCRIPTION
Included PRs:
 - https://github.com/konflux-ci/release-service/pull/1544 
 - https://github.com/konflux-ci/release-service/pull/1807 
 - https://github.com/konflux-ci/release-service/pull/1803 
 - https://github.com/konflux-ci/release-service/pull/1802 
 - https://github.com/konflux-ci/release-service/pull/1775 

Risk: Low - has been in stage for 5days
Stage: https://github.com/redhat-appstudio/infra-deployments/pull/13814