### PR TITLE
KFLUXINFRA-4523: (onboarding) Remove production etcd-defrag apps from AppSRE ArgoCD

### DIFF
--- a/argo-cd-apps/overlays/konflux-public-production/delete-applications.yaml
+++ b/argo-cd-apps/overlays/konflux-public-production/delete-applications.yaml
@@ -41,4 +41,9 @@ kind: ApplicationSet
 metadata:
   name: multi-platform-controller
 $patch: delete
-
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: etcd-defrag
+$patch: delete

--- a/argo-cd-apps/overlays/konflux-public-production/kustomization.yaml
+++ b/argo-cd-apps/overlays/konflux-public-production/kustomization.yaml
@@ -184,11 +184,6 @@ patches:
     target:
       kind: ApplicationSet
       version: v1alpha1
-      name: etcd-defrag
-  - path: production-overlay-patch.yaml
-    target:
-      kind: ApplicationSet
-      version: v1alpha1
       name: policies
   - path: policies-production-auto-sync-patch.yaml
     target:

--- a/argo-cd-apps/overlays/production-downstream/delete-applications.yaml
+++ b/argo-cd-apps/overlays/production-downstream/delete-applications.yaml
@@ -40,3 +40,9 @@ kind: ApplicationSet
 metadata:
   name: multi-platform-controller
 $patch: delete
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: etcd-defrag
+$patch: delete


### PR DESCRIPTION
# What
* Delete the unused AppSRE etcd-defrag ApplicationSet and overlay patches.

Clusters affected:

ring-2: kflux-fedora-01, kflux-ocp-p01, kflux-osp-p01, kflux-prd-rh03, kflux-rhel-p01, stone-prod-p01, kflux-lw-p01
ring-3: stone-prd-rh01, stone-prod-p02
ring-4: kflux-prd-rh02

# Why
Final directory-structure migration step; AppSRE apps are already gone.

# Validation
These steps have been used before in several application migrations.

# Risk Assessment
**Risk Level**: Medium
**What could go wrong**: The ApplicationSet's resources could go into a limbo state because of the deletion of the AppSRE parent resources.
**Rollback**: Revert this PR and trigger a manual sync on the old AppSRE ApplicationSets.
**Blast radius**: production (10 tenant clusters) listed above