### PR TITLE
Enable proxy for bundler and cargo on prod ring 2

### DIFF
--- a/components/konflux-info/production/kflux-ocp-p01/cluster-config.env
+++ b/components/konflux-info/production/kflux-ocp-p01/cluster-config.env
@@ -3,6 +3,8 @@ http-proxy=squid.caching.svc.cluster.local:3128
 no-proxy=
 
 allow-package-registry-proxy=true
+package-registry-proxy-bundler-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/rubygems-proxy
+package-registry-proxy-cargo-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/cargo-proxy
 package-registry-proxy-gomod-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/go-proxy
 package-registry-proxy-npm-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/npm-proxy
 package-registry-proxy-pip-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/pypi-proxy/simple

--- a/components/konflux-info/production/kflux-prd-rh02/cluster-config.env
+++ b/components/konflux-info/production/kflux-prd-rh02/cluster-config.env
@@ -3,6 +3,8 @@ http-proxy=squid.caching.svc.cluster.local:3128
 no-proxy=
 
 allow-package-registry-proxy=true
+package-registry-proxy-bundler-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/rubygems-proxy
+package-registry-proxy-cargo-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/cargo-proxy
 package-registry-proxy-gomod-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/go-proxy
 package-registry-proxy-npm-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/npm-proxy
 package-registry-proxy-pip-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/pypi-proxy/simple

--- a/components/konflux-info/production/kflux-prd-rh03/cluster-config.env
+++ b/components/konflux-info/production/kflux-prd-rh03/cluster-config.env
@@ -3,6 +3,8 @@ http-proxy=squid.caching.svc.cluster.local:3128
 no-proxy=
 
 allow-package-registry-proxy=true
+package-registry-proxy-bundler-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/rubygems-proxy
+package-registry-proxy-cargo-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/cargo-proxy
 package-registry-proxy-gomod-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/go-proxy
 package-registry-proxy-npm-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/npm-proxy
 package-registry-proxy-pip-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/pypi-proxy/simple

--- a/components/konflux-info/production/kflux-rhel-p01/cluster-config.env
+++ b/components/konflux-info/production/kflux-rhel-p01/cluster-config.env
@@ -3,6 +3,8 @@ http-proxy=squid.caching.svc.cluster.local:3128
 no-proxy=
 
 allow-package-registry-proxy=true
+package-registry-proxy-bundler-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/rubygems-proxy
+package-registry-proxy-cargo-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/cargo-proxy
 package-registry-proxy-gomod-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/go-proxy
 package-registry-proxy-npm-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/npm-proxy
 package-registry-proxy-pip-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/pypi-proxy/simple

--- a/components/konflux-info/production/stone-prd-rh01/cluster-config.env
+++ b/components/konflux-info/production/stone-prd-rh01/cluster-config.env
@@ -3,6 +3,8 @@ http-proxy=squid.caching.svc.cluster.local:3128
 no-proxy=
 
 allow-package-registry-proxy=true
+package-registry-proxy-bundler-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/rubygems-proxy
+package-registry-proxy-cargo-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/cargo-proxy
 package-registry-proxy-gomod-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/go-proxy
 package-registry-proxy-npm-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/npm-proxy
 package-registry-proxy-pip-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/pypi-proxy/simple


### PR DESCRIPTION
Enable use of the package registry proxy for Hermeto's bundler and cargo backends on kflux-ocp-p01, kflux-prd-rh02, kflux-prd-rh03, kflux-rhel-p01, and stone-prd-rh01. This will allow Hermeto to route dependency prefetches through the package registry registry proxy for policy evaluation.

## Risk Assessment
**Risk Level:** Medium
**Description:** Enables additional package ecosystems to be proxied through Nexus by Hermeto. The user impact is to build pipelines using Bundler and Cargo.
**Rollback:** Revert PR

## Validation
Stage PR: https://github.com/redhat-appstudio/infra-deployments/pull/13485
Prod Ring 1: https://github.com/redhat-appstudio/infra-deployments/pull/13807

Successfully validated in Prod Ring 1 deployment: https://konflux-ui.apps.stone-prod-p02.hjvn.p1.openshiftapps.com/ns/service-mesh-tenant/applications/ossm-3-3/taskruns/ossm-3-3-ztunnel-on-pull-request-bskzc-prefetch-dependencies/