### PR TITLE
SPRE-6742: Forward Grafana CPU metrics in staging

### DIFF
--- a/components/monitoring/prometheus/staging/base/federation/endpoints-params.yaml
+++ b/components/monitoring/prometheus/staging/base/federation/endpoints-params.yaml
@@ -148,6 +148,7 @@
     ## Container Metrics
     - '{__name__="kube_pod_container_status_waiting_reason", namespace!~".*-tenant|openshift-.*|kube-.*|mintmaker"}'
     - '{__name__="kube_pod_container_status_waiting_reason", namespace="mintmaker", pod!~"renovate.*"}'
+    - '{__name__="kube_pod_container_resource_requests", namespace="appstudio-grafana", resource="cpu"}'
     - '{__name__="kube_pod_container_resource_limits", namespace=~"release-service|rhtap-releng-tenant"}'
     - '{__name__="kube_pod_container_status_terminated_reason", namespace=~"release-service|openshift-etcd|openshift-kube-apiserver|build-service|image-controller|integration-service|konflux-ui|konflux-kite|product-kubearchive|product-kubearchive-logging|openshift-kueue-operator|tekton-kueue|multi-platform-controller|namespace-lister|openshift-pipelines|tekton-results|project-controller|smee|smee-client"}'
     - '{__name__="kube_pod_container_status_terminated_reason", namespace="mintmaker", pod!~"renovate.*"}'
@@ -155,7 +156,7 @@
     - '{__name__="kube_pod_container_status_last_terminated_reason", reason="OOMKilled"}'
     - '{__name__="kube_pod_container_status_last_terminated_reason", namespace="release-service"}'
     - '{__name__="kube_pod_container_status_ready", namespace=~"release-service"}'
-    - '{__name__="container_cpu_usage_seconds_total", namespace=~"release-service|openshift-etcd"}'
+    - '{__name__="container_cpu_usage_seconds_total", namespace=~"release-service|openshift-etcd|appstudio-grafana"}'
     - '{__name__="container_memory_usage_bytes", namespace=~"release-service|openshift-etcd|rhtap-releng-tenant"}'
     - '{__name__="kube_pod_container_status_restarts_total", namespace!~".*-tenant|mintmaker"}'
     - '{__name__="kube_pod_container_status_restarts_total", namespace="mintmaker", pod!~"renovate.*"}'


### PR DESCRIPTION
## What

Forward these metrics from the `appstudio-grafana` namespace in staging to RHOBS:

- `container_cpu_usage_seconds_total`
- `kube_pod_container_resource_requests` for CPU

Clusters affected: staging

[SPRE-6742](https://issues.redhat.com/browse/SPRE-6742)

## Why

The Grafana CPU alert compares CPU usage with CPU requests. Both metrics must be available in RHOBS for the alert to work.

## Validation

- `yamllint` passes
- `kustomize build --enable-helm components/monitoring/prometheus/staging/base` passes
- `git diff --check` passes

[SPRE-6742]: https://redhat.atlassian.net/browse/SPRE-6742?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ