### PR TITLE
(onboarding) Remove staging policies apps from AppSRE ArgoCD

### DIFF
--- a/argo-cd-apps/base/member/infra-deployments/policies/policies.yaml
+++ b/argo-cd-apps/base/member/infra-deployments/policies/policies.yaml
@@ -15,12 +15,6 @@ spec:
                 clusterDir: "empty-base"
           - list:
               elements:
-                - nameNormalized: stone-stg-rh01
-                  values.clusterDir: stone-stg-rh01
-                - nameNormalized: stone-stage-p01
-                  values.clusterDir: stone-stage-p01
-                - nameNormalized: lightwell-dev
-                  values.clusterDir: lightwell-dev
                 - nameNormalized: stone-prd-rh01
                   values.clusterDir: stone-prd-rh01
                 - nameNormalized: kflux-prd-rh02

--- a/argo-cd-apps/overlays/konflux-public-staging/delete-applications.yaml
+++ b/argo-cd-apps/overlays/konflux-public-staging/delete-applications.yaml
@@ -35,3 +35,9 @@ kind: ApplicationSet
 metadata:
   name: notification-controller
 $patch: delete
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: policies
+$patch: delete

--- a/argo-cd-apps/overlays/staging-downstream/delete-applications.yaml
+++ b/argo-cd-apps/overlays/staging-downstream/delete-applications.yaml
@@ -29,3 +29,9 @@ kind: ApplicationSet
 metadata:
   name: notification-controller
 $patch: delete
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: policies
+$patch: delete


### PR DESCRIPTION
## What

Part 3 of the policies ring-deployments migration — removes the old policies staging Applications from the AppSRE ArgoCD instances.

- Add a `policies` delete-patch to `staging-downstream/delete-applications.yaml` and `konflux-public-staging/delete-applications.yaml`
- Remove the 3 staging cluster entries (stone-stg-rh01, stone-stage-p01, lightwell-dev) from the base member `policies` ApplicationSet

Clusters affected: stone-stg-rh01, stone-stage-p01, lightwell-dev (staging)

[KFLUXINFRA-4288](https://issues.redhat.com/browse/KFLUXINFRA-4288)

## Why

Staging is now served by the `policies-rd` ring appset (Part 2, #13867, merged + synced). This removes the superseded old staging apps. Production stays on the old appset until Part 4/5.

## Validation

- `kustomize build --enable-helm` passes for all affected overlays (staging-downstream, konflux-public-staging, development, production-downstream, konflux-public-production)
- Post-build: `policies` appset absent from both staging overlays, still present in production overlays
- Base appset no longer references any staging cluster
- yamllint clean
- ArgoCD admin steps 6-13 completed manually

[KFLUXINFRA-4288]: https://redhat.atlassian.net/browse/KFLUXINFRA-4288?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ