### PR TITLE
production Ring 2: upgrade openshift-pipelines 854 to 871 and fix resolver bucket mismatch

### DIFF
--- a/components/pipeline-service/production/kflux-lw-p01/deploy.yaml
+++ b/components/pipeline-service/production/kflux-lw-p01/deploy.yaml
@@ -2330,7 +2330,7 @@ spec:
             default-timeout-minutes: "120"
         config-leader-election-resolvers:
           data:
-            buckets: "8"
+            buckets: "4"
         config-logging:
           data:
             loglevel.controller: info
@@ -2552,7 +2552,7 @@ metadata:
   namespace: openshift-marketplace
 spec:
   displayName: custom-operators
-  image: quay.io/openshift-pipeline/pipelines-index-4.19@sha256:bd598786408b16bc1171c79907db124013189d57677e8bfbec1feccc55523ccd
+  image: quay.io/openshift-pipeline/pipelines-index-4.19@sha256:8c6152d2924f608960a4cec0faca33a1807bce19085e86d1daeeaa698fce146d
   sourceType: grpc
   updateStrategy:
     registryPoll:

--- a/components/pipeline-service/production/kflux-ocp-p01/deploy.yaml
+++ b/components/pipeline-service/production/kflux-ocp-p01/deploy.yaml
@@ -2309,7 +2309,7 @@ spec:
             default-timeout-minutes: "120"
         config-leader-election-resolvers:
           data:
-            buckets: "8"
+            buckets: "4"
         config-logging:
           data:
             loglevel.controller: info
@@ -2531,7 +2531,7 @@ metadata:
   namespace: openshift-marketplace
 spec:
   displayName: custom-operators
-  image: quay.io/openshift-pipeline/pipelines-index-4.19@sha256:bd598786408b16bc1171c79907db124013189d57677e8bfbec1feccc55523ccd
+  image: quay.io/openshift-pipeline/pipelines-index-4.19@sha256:8c6152d2924f608960a4cec0faca33a1807bce19085e86d1daeeaa698fce146d
   sourceType: grpc
   updateStrategy:
     registryPoll:

--- a/components/pipeline-service/production/kflux-rhel-p01/deploy.yaml
+++ b/components/pipeline-service/production/kflux-rhel-p01/deploy.yaml
@@ -2309,7 +2309,7 @@ spec:
             default-timeout-minutes: "120"
         config-leader-election-resolvers:
           data:
-            buckets: "8"
+            buckets: "4"
         config-logging:
           data:
             loglevel.controller: info
@@ -2531,7 +2531,7 @@ metadata:
   namespace: openshift-marketplace
 spec:
   displayName: custom-operators
-  image: quay.io/openshift-pipeline/pipelines-index-4.19@sha256:bd598786408b16bc1171c79907db124013189d57677e8bfbec1feccc55523ccd
+  image: quay.io/openshift-pipeline/pipelines-index-4.19@sha256:8c6152d2924f608960a4cec0faca33a1807bce19085e86d1daeeaa698fce146d
   sourceType: grpc
   updateStrategy:
     registryPoll:

--- a/components/pipeline-service/production/rings/ring-2/kustomization.yaml
+++ b/components/pipeline-service/production/rings/ring-2/kustomization.yaml
@@ -8,19 +8,4 @@ kind: Kustomization
 resources:
   - ../../base
 
-patches:
-  # Hold back on build 854 until Ring 2 promotion
-  - target:
-      kind: CatalogSource
-      name: custom-operators
-    patch: |-
-      - op: replace
-        path: /spec/image
-        value: quay.io/openshift-pipeline/pipelines-index-4.19@sha256:bd598786408b16bc1171c79907db124013189d57677e8bfbec1feccc55523ccd
-  - target:
-      kind: TektonConfig
-      name: config
-    patch: |-
-      - op: replace
-        path: /spec/pipeline/options/configMaps/config-leader-election-resolvers/data/buckets
-        value: "8"
+patches: []

--- a/components/pipeline-service/production/stone-prod-p02/deploy.yaml
+++ b/components/pipeline-service/production/stone-prod-p02/deploy.yaml
@@ -2309,7 +2309,7 @@ spec:
             default-timeout-minutes: "120"
         config-leader-election-resolvers:
           data:
-            buckets: "8"
+            buckets: "4"
         config-logging:
           data:
             loglevel.controller: info
@@ -2531,7 +2531,7 @@ metadata:
   namespace: openshift-marketplace
 spec:
   displayName: custom-operators
-  image: quay.io/openshift-pipeline/pipelines-index-4.19@sha256:bd598786408b16bc1171c79907db124013189d57677e8bfbec1feccc55523ccd
+  image: quay.io/openshift-pipeline/pipelines-index-4.19@sha256:8c6152d2924f608960a4cec0faca33a1807bce19085e86d1daeeaa698fce146d
   sourceType: grpc
   updateStrategy:
     registryPoll:


### PR DESCRIPTION
- **Ring 2**: stone-prod-p02, kflux-rhel-p01, kflux-ocp-p01, kflux-lw-p01
- **Index image**: pipelines-index-4.19 build 854 → build 871 (sha256:bd598786 → 8c6152d2)
- **Resolver buckets**: 8 → 4 (fixes bucket mismatch with 4-replica StatefulSet)

## Validation

- Build 871 validated in dev/staging ([PR #13452](https://github.com/redhat-appstudio/infra-deployments/pull/13452))
- Ring 1 deployed Sep 4, healthy across all 3 clusters (kflux-fedora-01, stone-prod-p01, kflux-osp-p01) with no issues observed so far
- Metrics scrape breakage from new NetworkPolicies addressed by monitoring team ([PR #13776](https://github.com/redhat-appstudio/infra-deployments/pull/13776), [PR #13780](https://github.com/redhat-appstudio/infra-deployments/pull/13780))

## Risk Assessment

**Risk Level:** Medium
**Description:** Same upgrade as Ring 1. Ring 1 has been running so far.
**Rollback:** Release a new Index image with the fix included.