### PR TITLE
production Ring 3: upgrade openshift-pipelines 854 to 871 and fix resolver bucket mismatch

### DIFF
--- a/components/pipeline-service/production/kflux-prd-rh02/deploy.yaml
+++ b/components/pipeline-service/production/kflux-prd-rh02/deploy.yaml
@@ -2309,7 +2309,7 @@ spec:
             default-timeout-minutes: "120"
         config-leader-election-resolvers:
           data:
-            buckets: "8"
+            buckets: "4"
         config-logging:
           data:
             loglevel.controller: info
@@ -2531,7 +2531,7 @@ metadata:
   namespace: openshift-marketplace
 spec:
   displayName: custom-operators
-  image: quay.io/openshift-pipeline/pipelines-index-4.19@sha256:bd598786408b16bc1171c79907db124013189d57677e8bfbec1feccc55523ccd
+  image: quay.io/openshift-pipeline/pipelines-index-4.19@sha256:8c6152d2924f608960a4cec0faca33a1807bce19085e86d1daeeaa698fce146d
   sourceType: grpc
   updateStrategy:
     registryPoll:

--- a/components/pipeline-service/production/kflux-prd-rh03/deploy.yaml
+++ b/components/pipeline-service/production/kflux-prd-rh03/deploy.yaml
@@ -2309,7 +2309,7 @@ spec:
             default-timeout-minutes: "120"
         config-leader-election-resolvers:
           data:
-            buckets: "8"
+            buckets: "4"
         config-logging:
           data:
             loglevel.controller: info
@@ -2531,7 +2531,7 @@ metadata:
   namespace: openshift-marketplace
 spec:
   displayName: custom-operators
-  image: quay.io/openshift-pipeline/pipelines-index-4.19@sha256:bd598786408b16bc1171c79907db124013189d57677e8bfbec1feccc55523ccd
+  image: quay.io/openshift-pipeline/pipelines-index-4.19@sha256:8c6152d2924f608960a4cec0faca33a1807bce19085e86d1daeeaa698fce146d
   sourceType: grpc
   updateStrategy:
     registryPoll:

--- a/components/pipeline-service/production/rings/ring-3/kustomization.yaml
+++ b/components/pipeline-service/production/rings/ring-3/kustomization.yaml
@@ -8,19 +8,4 @@ kind: Kustomization
 resources:
   - ../../base
 
-patches:
-  # Hold back on build 854 until Ring 3 promotion
-  - target:
-      kind: CatalogSource
-      name: custom-operators
-    patch: |-
-      - op: replace
-        path: /spec/image
-        value: quay.io/openshift-pipeline/pipelines-index-4.19@sha256:bd598786408b16bc1171c79907db124013189d57677e8bfbec1feccc55523ccd
-  - target:
-      kind: TektonConfig
-      name: config
-    patch: |-
-      - op: replace
-        path: /spec/pipeline/options/configMaps/config-leader-election-resolvers/data/buckets
-        value: "8"
+patches: []

--- a/components/pipeline-service/production/stone-prd-rh01/deploy.yaml
+++ b/components/pipeline-service/production/stone-prd-rh01/deploy.yaml
@@ -2309,7 +2309,7 @@ spec:
             default-timeout-minutes: "120"
         config-leader-election-resolvers:
           data:
-            buckets: "8"
+            buckets: "4"
         config-logging:
           data:
             loglevel.controller: info
@@ -2531,7 +2531,7 @@ metadata:
   namespace: openshift-marketplace
 spec:
   displayName: custom-operators
-  image: quay.io/openshift-pipeline/pipelines-index-4.19@sha256:bd598786408b16bc1171c79907db124013189d57677e8bfbec1feccc55523ccd
+  image: quay.io/openshift-pipeline/pipelines-index-4.19@sha256:8c6152d2924f608960a4cec0faca33a1807bce19085e86d1daeeaa698fce146d
   sourceType: grpc
   updateStrategy:
     registryPoll:


### PR DESCRIPTION
- **Ring 3**: stone-prd-rh01, kflux-prd-rh02, kflux-prd-rh03
- **Index image**: pipelines-index-4.19 build 854 → build 871 (sha256:bd598786 → 8c6152d2)
- **Resolver buckets**: 8 → 4 (fixes bucket mismatch with 4-replica StatefulSet)

## Validation

- Build 871 validated in dev/staging ([PR #13452](https://github.com/redhat-appstudio/infra-deployments/pull/13452))
- Ring 1 deployed Sep 4, healthy across all 3 clusters
- Ring 2 deployed Sep 11(during 1-3AM UTC maintenance window), healthy across 3 of the 4 clusters, couldn't verify kflux-lw-p01 due to not having access.

## Risk Assessment

**Risk Level:** Medium
**Description:** Same upgrade as Ring 1 and Ring 2. 
**Rollback:** Release a new Index image with the fix included.