### PR TITLE
KFLUXINFRA-4254 Add agent files defense CI checks

### DIFF
--- a/.github/workflows/agent-files-detect.yaml
+++ b/.github/workflows/agent-files-detect.yaml
@@ -1,0 +1,174 @@
+name: Detect Agent File Changes
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  merge_group:
+    types: [checks_requested]
+
+permissions:
+  contents: read
+
+jobs:
+  # Fails the PR if .claude/ or .cursor/ directories exist anywhere in the tree.
+  block-vendor-dirs:
+    name: Block vendor-specific agent directories
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Check for vendor-specific directories
+        run: |
+          FOUND=0
+          while IFS= read -r -d '' match; do
+            if [ "${FOUND}" -eq 0 ]; then
+              echo "::error::Vendor-specific paths found in this repository. These are not allowed — use AGENTS.md and skills/ instead."
+              FOUND=1
+            fi
+            sanitized="${match//'%'/'%25'}"
+            sanitized="${sanitized//'::'/'%3A%3A'}"
+            sanitized="${sanitized//$'\n'/'%0A'}"
+            sanitized="${sanitized//$'\r'/'%0D'}"
+            echo "::error::Found: ${sanitized}"
+            if [ -d "${match}" ]; then
+              ls -la "${match}/"
+            fi
+          done < <(find . -path ./.git -prune -o \( -name '.claude' -o -name '.cursor' -o -name '.vscode' -o -name '.agents' \) -print0)
+          if [ "${FOUND}" -eq 1 ]; then
+            exit 1
+          fi
+          echo "No vendor-specific directories found."
+
+  # Diffs the PR for changes to protected agent files (direct and indirect).
+  # Computes two independent results:
+  #   - protected_changed (incremental): on synchronize, only the new push (before..after),
+  #     so previously-reviewed changes don't re-trigger labeling. Drives the ADD decision.
+  #   - net_protected_changed (net): the PR's current state vs. base (base...head), so a PR
+  #     that reverted its agent-file edits reads as clean. Drives the REMOVE decision.
+  # Uploads both results as an artifact for the enforce workflow.
+  # Skipped for merge_group — PR-level enforcement already ran.
+  detect-protected-changes:
+    if: github.event_name != 'merge_group'
+    name: Detect changes to protected agent files
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Fetch comparison refs
+        env:
+          INC_BASE_REF: ${{ github.event.action == 'synchronize' && github.event.before || github.event.pull_request.base.sha }}
+          INC_HEAD_REF: ${{ github.event.action == 'synchronize' && github.event.after || github.event.pull_request.head.sha }}
+          NET_BASE_REF: ${{ github.event.pull_request.base.sha }}
+          NET_HEAD_REF: ${{ github.event.pull_request.head.sha }}
+        # No --depth: the three-dot net diff needs the merge-base, which a shallow
+        # fetch may not include. The checkout above is already full (fetch-depth: 0).
+        run: git fetch origin "${INC_BASE_REF}" "${INC_HEAD_REF}" "${NET_BASE_REF}" "${NET_HEAD_REF}"
+
+      - name: Check for protected file changes
+        id: check
+        env:
+          INC_BASE_SHA: ${{ github.event.action == 'synchronize' && github.event.before || github.event.pull_request.base.sha }}
+          INC_HEAD_SHA: ${{ github.event.action == 'synchronize' && github.event.after || github.event.pull_request.head.sha }}
+          NET_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          NET_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          # Sets RANGE_RESULT ("true"/"false") for whether the given diff range touches
+          # protected agent files (direct path match) or references a protected path
+          # (indirect heuristic). Also sets DIRECT_MATCH to the matched paths, if any.
+          # Called directly (not via $(...)) so the globals propagate.
+          # $1 = diff range expression (e.g. "A..B" incremental or "A...B" net)
+          check_range() {
+            local range="$1"
+            local changed all_paths
+            # Use --name-status to catch renames/deletes (exposes old path via R/D status lines).
+            # Format: "A\tpath", "M\tpath", "R100\told\tnew", "D\tpath"
+            changed=$(git diff --no-ext-diff --name-status "${range}")
+            # Extract all paths (both old and new for renames) to check against protected patterns.
+            all_paths=$(echo "${changed}" | awk '{
+              if ($1 ~ /^R/) {
+                # Rename: $2 = old path, $3 = new path
+                print $2
+                print $3
+              } else {
+                # Add/Modify/Delete: $2 = path
+                print $2
+              }
+            }')
+            DIRECT_MATCH=$(echo "${all_paths}" | grep -E '(^|/)(AGENTS\.md|CLAUDE\.md|GEMINI\.md)$|(^|/)skills/|^\.github/workflows/agent-files-(detect|enforce)\.yaml$' || true)
+            if [ -n "${DIRECT_MATCH}" ]; then
+              RANGE_RESULT="true"
+            elif git diff --no-ext-diff "${range}" | grep -qiE 'AGENTS\.md|CLAUDE\.md|GEMINI\.md|\.claude|\.cursor|\.vscode|\.agents|skills/'; then
+              RANGE_RESULT="true"
+            else
+              RANGE_RESULT="false"
+            fi
+          }
+
+          # Incremental (ADD signal) — two-dot, only the new push on synchronize.
+          check_range "${INC_BASE_SHA}..${INC_HEAD_SHA}"
+          INCREMENTAL="${RANGE_RESULT}"
+          if [ "${INCREMENTAL}" = "true" ] && [ -n "${DIRECT_MATCH}" ]; then
+            sanitized="${DIRECT_MATCH//'%'/'%25'}"
+            sanitized="${sanitized//'::'/'%3A%3A'}"
+            sanitized="${sanitized//$'\n'/'%0A'}"
+            sanitized="${sanitized//$'\r'/'%0D'}"
+            echo "::warning::Protected agent files changed in latest push: ${sanitized}"
+          elif [ "${INCREMENTAL}" = "true" ]; then
+            # Flagged by the indirect heuristic (no direct path match). Keep the message
+            # generic — the diff content is attacker-influenced, so don't echo it.
+            echo "::warning::Latest push indirectly references a protected agent path (e.g. a script writing to AGENTS.md/CLAUDE.md/GEMINI.md/skills/ or a vendor keyword in the diff)."
+          fi
+
+          # Net (REMOVE signal) — three-dot, the PR's current state vs. base.
+          check_range "${NET_BASE_SHA}...${NET_HEAD_SHA}"
+          NET="${RANGE_RESULT}"
+
+          echo "protected_changed=${INCREMENTAL}" >> "${GITHUB_OUTPUT}"
+          echo "net_protected_changed=${NET}" >> "${GITHUB_OUTPUT}"
+          echo "Incremental protected change: ${INCREMENTAL}; net protected change: ${NET}"
+
+      - name: Write detection result
+        env:
+          PROTECTED_CHANGED: ${{ steps.check.outputs.protected_changed }}
+          NET_PROTECTED_CHANGED: ${{ steps.check.outputs.net_protected_changed }}
+        run: |
+          mkdir -p /tmp/agent-detect
+          echo "${PROTECTED_CHANGED}" > /tmp/agent-detect/agent-check-result.txt
+          echo "${NET_PROTECTED_CHANGED}" > /tmp/agent-detect/agent-net-result.txt
+
+      - name: Upload detection result
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: agent-check-result
+          path: /tmp/agent-detect/
+          retention-days: 1
+          if-no-files-found: error
+
+  # Posts "Agent File Policy" success for merge queue commits.
+  # PR-level enforcement (required commit status) already gated entry to the queue.
+  merge-queue-policy-pass:
+    if: github.event_name == 'merge_group'
+    name: Agent File Policy (merge queue)
+    runs-on: ubuntu-latest
+    permissions:
+      statuses: write
+    steps:
+      - name: Post success status
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: context.sha,
+              state: 'success',
+              context: 'Agent File Policy',
+              description: 'Merge queue — PR-level enforcement already passed.',
+            });

--- a/.github/workflows/agent-files-enforce.yaml
+++ b/.github/workflows/agent-files-enforce.yaml
@@ -1,0 +1,432 @@
+name: Enforce Agent File Policy
+
+on:
+  workflow_run:
+    workflows: ["Detect Agent File Changes"]
+    types: [completed]
+  pull_request_target:
+    types: [labeled, unlabeled]
+
+permissions: {}
+
+env:
+  REVIEW_LABEL: agent-config-review-required
+
+jobs:
+  resolve-pr:
+    name: Resolve PR number
+    if: github.event_name == 'workflow_run' && github.event.workflow_run.event != 'merge_group'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      pr_number: ${{ steps.resolve.outputs.pr_number }}
+    steps:
+      - name: Resolve PR number from workflow run
+        id: resolve
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const run = context.payload.workflow_run;
+            if (run.pull_requests && run.pull_requests.length > 0) {
+              core.setOutput('pr_number', run.pull_requests[0].number.toString());
+              return;
+            }
+            const { data: prs } = await github.rest.pulls.list({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              head: `${run.head_repository.owner.login}:${run.head_branch}`,
+            });
+            // Filter by head SHA to avoid mislabeling when multiple PRs exist from same branch
+            const matching = prs.filter(pr => pr.head.sha === run.head_sha);
+            if (matching.length !== 1) {
+              core.setFailed(`Found ${matching.length} PRs matching workflow run head SHA - cannot determine correct PR.`);
+              return;
+            }
+            core.setOutput('pr_number', matching[0].number.toString());
+
+  label-protected-changes:
+    name: Label PR when protected agent files change
+    if: github.event_name == 'workflow_run'
+    needs: resolve-pr
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      pull-requests: write
+    outputs:
+      label_action: ${{ steps.decide.outputs.label_action }}
+      fresh: ${{ steps.freshness-check.outputs.fresh }}
+    steps:
+      # The detect workflow runs PR code (pull_request trigger), so if the PR modifies
+      # the workflow files, the artifact cannot be trusted. Check independently via API.
+      - name: Check for workflow file changes
+        id: workflow-check
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          PR_NUMBER: ${{ needs.resolve-pr.outputs.pr_number }}
+        with:
+          script: |
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: parseInt(process.env.PR_NUMBER, 10),
+            });
+            const workflowPaths = [
+              '.github/workflows/agent-files-detect.yaml',
+              '.github/workflows/agent-files-enforce.yaml'
+            ];
+            const changed = files.some(f =>
+              workflowPaths.includes(f.filename) ||
+              (f.previous_filename && workflowPaths.includes(f.previous_filename))
+            );
+            core.setOutput('changed', changed.toString());
+
+      # Skip labeling for PRs opened by trusted bots (Dependabot, Konflux). Identity is
+      # taken from the GitHub API (pull_request.user), never from spoofable commit metadata,
+      # and pinned by account id so a renamed/reused login can't impersonate. Every commit
+      # must also be verified-signed by that bot, so a write-access insider can't sneak an
+      # unsigned/human commit onto a bot PR to ride the skip.
+      - name: Check for trusted bot author
+        id: bot-check
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        env:
+          PR_NUMBER: ${{ needs.resolve-pr.outputs.pr_number }}
+        with:
+          script: |
+            // login -> id. Match BOTH; type must be "Bot".
+            const TRUSTED_BOTS = {
+              'dependabot[bot]': 49699333,
+              'red-hat-konflux[bot]': 126015336,
+            };
+            const prNumber = parseInt(process.env.PR_NUMBER, 10);
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber,
+            });
+            const u = pr.user || {};
+            const isTrustedOpener =
+              u.type === 'Bot' &&
+              Object.prototype.hasOwnProperty.call(TRUSTED_BOTS, u.login) &&
+              TRUSTED_BOTS[u.login] === u.id;
+
+            let trusted = false;
+            if (isTrustedOpener) {
+              const commits = await github.paginate(github.rest.pulls.listCommits, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: prNumber,
+              });
+              // Every commit must be verified-signed AND authored by the same bot account.
+              trusted = commits.length > 0 && commits.every(c =>
+                c.commit?.verification?.verified === true &&
+                c.author && c.author.id === u.id
+              );
+            }
+            console.log(`PR opener: ${u.login} (id ${u.id}, type ${u.type}); trusted_bot=${trusted}`);
+            core.setOutput('trusted_bot', trusted.toString());
+
+      # Verify workflow run head matches current PR head. If the PR was force-pushed or
+      # received new commits after the detect workflow started, the artifact is stale and
+      # must not be used to mutate labels or post status (would incorrectly approve/block
+      # a different commit than what the artifact describes).
+      - name: Verify artifact freshness
+        id: freshness-check
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        env:
+          PR_NUMBER: ${{ needs.resolve-pr.outputs.pr_number }}
+          WORKFLOW_RUN_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        with:
+          script: |
+            const prNumber = parseInt(process.env.PR_NUMBER, 10);
+            const workflowRunHeadSha = process.env.WORKFLOW_RUN_HEAD_SHA;
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber,
+            });
+            const currentHeadSha = pr.head.sha;
+            const fresh = workflowRunHeadSha === currentHeadSha;
+            if (!fresh) {
+              console.log(`Stale artifact detected: workflow run analyzed ${workflowRunHeadSha.substring(0,7)} but PR head is now ${currentHeadSha.substring(0,7)}. Skipping label mutation.`);
+            }
+            core.setOutput('fresh', fresh.toString());
+
+      - name: Download detection artifact
+        id: download
+        continue-on-error: true
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: agent-check-result
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path: /tmp/detect-result
+
+      - name: Decide detection result
+        id: decide
+        run: |
+          # Reads a validated boolean from an artifact file. Prints "true"/"false" on
+          # success; on missing/invalid content prints "invalid" (caller fails closed).
+          read_bool() {
+            local file="$1" value
+            if [ ! -f "${file}" ]; then
+              echo "invalid"
+              return
+            fi
+            value=$(tr -d '[:space:]' < "${file}")
+            if [ "${value}" != "true" ] && [ "${value}" != "false" ]; then
+              echo "invalid"
+              return
+            fi
+            echo "${value}"
+          }
+
+          # Stale artifact: the workflow run analyzed a different commit than the PR's
+          # current head. Do not mutate labels (a newer detect run may already be queued).
+          if [ "${{ steps.freshness-check.outputs.fresh }}" != "true" ]; then
+            echo "Artifact is stale — skipping label mutation."
+            echo "label_action=neutral" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+
+          # Trusted bot (verified identity + all commits verified-signed): never label.
+          if [ "${{ steps.bot-check.outputs.trusted_bot }}" = "true" ]; then
+            echo "PR opened by a trusted bot — skipping label."
+            echo "label_action=remove" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+
+          # If workflow files were changed, always flag — regardless of artifact content.
+          # (The detect workflow runs PR code, so a tampered artifact cannot be trusted.)
+          if [ "${{ steps.workflow-check.outputs.changed }}" = "true" ]; then
+            echo "Workflow files modified — flagging for review."
+            echo "label_action=add" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+
+          INCREMENTAL=$(read_bool /tmp/detect-result/agent-check-result.txt)
+          NET=$(read_bool /tmp/detect-result/agent-net-result.txt)
+
+          # Fail closed on any missing/invalid artifact value.
+          if [ "${INCREMENTAL}" = "invalid" ] || [ "${NET}" = "invalid" ]; then
+            echo "::error::Detection artifact missing or invalid. Failing closed."
+            echo "label_action=add" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+
+          # ADD on new agent changes in the latest push (incremental); REMOVE when the
+          # PR's current state is clean (net=false); otherwise leave the label as-is so a
+          # reviewer's approval-removal survives unrelated pushes.
+          if [ "${NET}" = "false" ]; then
+            echo "label_action=remove" >> "${GITHUB_OUTPUT}"
+          elif [ "${INCREMENTAL}" = "true" ]; then
+            echo "label_action=add" >> "${GITHUB_OUTPUT}"
+          else
+            echo "label_action=neutral" >> "${GITHUB_OUTPUT}"
+          fi
+
+      - name: Delete detection artifact
+        if: steps.download.outcome == 'success'
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const runId = ${{ github.event.workflow_run.id }};
+            const { data: artifacts } = await github.rest.actions.listWorkflowRunArtifacts({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: runId,
+            });
+            const artifact = artifacts.artifacts.find(a => a.name === 'agent-check-result');
+            if (artifact) {
+              await github.rest.actions.deleteArtifact({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                artifact_id: artifact.id,
+              });
+            }
+
+      - name: Add review label
+        if: steps.decide.outputs.label_action == 'add'
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          PR_NUMBER: ${{ needs.resolve-pr.outputs.pr_number }}
+        with:
+          script: |
+            const label = process.env.REVIEW_LABEL;
+            const prNumber = parseInt(process.env.PR_NUMBER, 10);
+            const labels = await github.rest.issues.listLabelsOnIssue({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+            });
+            if (!labels.data.some(l => l.name === label)) {
+              try {
+                await github.rest.issues.addLabels({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: prNumber,
+                  labels: [label],
+                });
+              } catch (e) {
+                if (e.status === 404) {
+                  core.setFailed(`Label '${label}' does not exist in this repository. Please create it manually with color e11d48 and description: "PR modifies protected agent config files — requires CODEOWNERS review"`);
+                } else {
+                  core.setFailed(`Failed to add label '${label}': ${e.message}`);
+                }
+                return;
+              }
+            }
+
+      # Remove the label when the PR's current (net) state no longer touches protected
+      # agent files — e.g. the PR reverted its earlier agent-file changes.
+      - name: Remove review label
+        if: steps.decide.outputs.label_action == 'remove'
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          PR_NUMBER: ${{ needs.resolve-pr.outputs.pr_number }}
+        with:
+          script: |
+            const label = process.env.REVIEW_LABEL;
+            const prNumber = parseInt(process.env.PR_NUMBER, 10);
+            try {
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                name: label,
+              });
+              core.info(`Removed '${label}' label — PR no longer changes protected agent files.`);
+            } catch (e) {
+              // 404 = label not present on the PR (nothing to remove).
+              if (e.status !== 404) {
+                core.setFailed(`Failed to remove label '${label}': ${e.message}`);
+              }
+            }
+
+  block-on-label:
+    name: Block PR if review label is present
+    # Only run for workflow_run or our specific label — skip unrelated label events (lgtm, approved, etc.)
+    if: always() && (github.event_name == 'workflow_run' || github.event.label.name == 'agent-config-review-required')
+    permissions:
+      statuses: write
+      pull-requests: read
+      issues: read
+    needs: [resolve-pr, label-protected-changes]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Determine PR number
+        id: pr
+        env:
+          RESOLVE_PR_NUMBER: ${{ needs.resolve-pr.outputs.pr_number }}
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            if (context.eventName === 'workflow_run') {
+              const resolved = process.env.RESOLVE_PR_NUMBER;
+              if (resolved) {
+                core.setOutput('number', resolved);
+              } else {
+                core.info('No PR number from resolve-pr — skipping label check.');
+              }
+            } else {
+              core.setOutput('number', context.issue.number.toString());
+            }
+
+      - name: Evaluate policy and post commit status
+        if: steps.pr.outputs.number
+        env:
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          LABEL_JOB_RESULT: ${{ needs.label-protected-changes.result }}
+          LABEL_ACTION: ${{ needs.label-protected-changes.outputs.label_action }}
+          FRESH: ${{ needs.label-protected-changes.outputs.fresh }}
+          WORKFLOW_RUN_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const label = process.env.REVIEW_LABEL;
+            const prNumber = parseInt(process.env.PR_NUMBER, 10);
+            const statusContext = 'Agent File Policy';
+
+            // For workflow_run events, bind status to the analyzed SHA (workflow_run.head_sha),
+            // not a re-fetched pr.head.sha which may have changed since detection ran.
+            // For pull_request_target events (label changes), fetch current head.
+            let targetSha;
+            if (context.eventName === 'workflow_run') {
+              targetSha = process.env.WORKFLOW_RUN_HEAD_SHA;
+
+              // Skip stale runs: artifact analyzed a different commit than PR's current head.
+              // A newer detect run will handle the current head; this stale run must not
+              // publish a status for a commit it didn't analyze.
+              // Only skip on explicit fresh==='false'; if missing/undefined, fail closed below.
+              if (process.env.FRESH === 'false') {
+                console.log(`Skipping status for stale run (analyzed ${targetSha.substring(0,7)} but PR head has moved). A newer detect run will evaluate current head.`);
+                return;
+              }
+
+              // Fail-closed: if label management job didn't succeed, block the PR
+              const labelJobResult = process.env.LABEL_JOB_RESULT;
+              if (labelJobResult !== 'success') {
+                await github.rest.repos.createCommitStatus({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  sha: targetSha,
+                  state: 'failure',
+                  context: statusContext,
+                  description: `Label management did not succeed (${labelJobResult}). Blocking PR.`,
+                });
+                core.setFailed(`Label management job did not succeed (${labelJobResult}). Blocking the PR.`);
+                return;
+              }
+            } else {
+              // pull_request_target event: fetch current head for label-triggered re-evaluation
+              const pr = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: prNumber,
+              });
+              targetSha = pr.data.head.sha;
+            }
+
+            const labels = await github.rest.issues.listLabelsOnIssue({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+            });
+            const hasLabel = labels.data.some(l => l.name === label);
+
+            if (hasLabel) {
+              await github.rest.repos.createCommitStatus({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                sha: targetSha,
+                state: 'failure',
+                context: statusContext,
+                description: `PR has '${label}' label — write-access review required.`,
+              });
+              core.setFailed(
+                `PR has '${label}' label. A reviewer with write access must review the agent config changes and remove this label before merging.`
+              );
+            } else if (context.eventName === 'workflow_run' && process.env.LABEL_ACTION === 'add') {
+              // We intended to add the label but it isn't present — the add step failed.
+              // (A legitimate approved PR reads as 'neutral'/'remove', not 'add', so it is
+              // not blocked here.)
+              await github.rest.repos.createCommitStatus({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                sha: targetSha,
+                state: 'failure',
+                context: statusContext,
+                description: 'Protected changes detected but label was not applied. Blocking PR.',
+              });
+              core.setFailed('Protected agent file changes were detected but the review label could not be applied. Blocking the PR.');
+            } else {
+              await github.rest.repos.createCommitStatus({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                sha: targetSha,
+                state: 'success',
+                context: statusContext,
+                description: 'No agent config review required.',
+              });
+            }

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,9 @@ components/**/charts/
 
 # infra-tools build artifacts
 infra-tools/bin/
+
+# Agent security
+.claude
+.cursor
+.vscode
+.agents


### PR DESCRIPTION
## What

- Add agent-files-detect.yaml workflow: detects protected file changes, blocks vendor dirs
- Add agent-files-enforce.yaml workflow: labels PRs with protected changes, blocks merge
- Update .gitignore: exclude agent-files-defense artifacts

Clusters affected: None (GitHub Actions CI only)

[KFLUXINFRA-4254](https://redhat.atlassian.net/browse/KFLUXINFRA-4254)

## Why

Prevent accidental commits to protected files by AI agents.

## Validation

Workflows proven in multi-platform-controller:
- [agent-files-detect.yaml](https://github.com/konflux-ci/multi-platform-controller/blob/main/.github/workflows/agent-files-detect.yaml) in production
- [agent-files-enforce.yaml](https://github.com/konflux-ci/multi-platform-controller/blob/main/.github/workflows/agent-files-enforce.yaml) in production
- Manual validation: https://github.com/konflux-ci/multi-platform-controller/pull/1006
- Automated test suite: https://gitlab.cee.redhat.com/glevi/agent-files-defense/-/blob/main/tests/run-tests.sh

## Risk Assessment

**Risk Level:** Low
**What could go wrong:** Workflows could incorrectly block legitimate PRs due to false positives
**Rollback:** Delete workflows, remove label from any blocked PRs
**Blast radius:** GitHub Actions only - no cluster impact

[KFLUXINFRA-4254]: https://redhat.atlassian.net/browse/KFLUXINFRA-4254?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ