### PR TITLE
feat(KONFLUX-15512): grant IAM#jhutar@redhat.com direct access on kflux-lw-p01 perf-team-prometheus-reader

### DIFF
--- a/argo-cd-apps/base/member/infra-deployments/perf-team-prometheus-reader/perf-team-prometheus-reader.yaml
+++ b/argo-cd-apps/base/member/infra-deployments/perf-team-prometheus-reader/perf-team-prometheus-reader.yaml
@@ -14,7 +14,9 @@ spec:
                 environment: staging
                 clusterDir: base
           - list:
-              elements: []
+              elements:
+                - nameNormalized: kflux-lw-p01
+                  values.clusterDir: kflux-lw-p01
   template:
     metadata:
       name: perf-team-prometheus-reader-{{nameNormalized}}

--- a/components/perf-team-prometheus-reader/production/kflux-lw-p01/kustomization.yaml
+++ b/components/perf-team-prometheus-reader/production/kflux-lw-p01/kustomization.yaml
@@ -1,0 +1,17 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../base
+patches:
+  - path: sa-token-creator-rolebinding-patch.yaml
+    target:
+      name: perf-team-sa-token-creator
+      group: rbac.authorization.k8s.io
+      version: v1
+      kind: RoleBinding
+  - path: maintainers-rolebinding-patch.yaml
+    target:
+      name: perf-team-prometheus-reader-maintainers
+      group: rbac.authorization.k8s.io
+      version: v1
+      kind: RoleBinding

--- a/components/perf-team-prometheus-reader/production/kflux-lw-p01/maintainers-rolebinding-patch.yaml
+++ b/components/perf-team-prometheus-reader/production/kflux-lw-p01/maintainers-rolebinding-patch.yaml
@@ -1,0 +1,10 @@
+---
+# kflux-lw-p01 is an IBM ROKS cluster authenticated via IBM Cloud IAM, so
+# users show up as "IAM#<email>" and are not members of the konflux-performance
+# group used on other clusters. Grant this user directly until group sync works here.
+- op: replace
+  path: /subjects
+  value:
+    - kind: User
+      apiGroup: rbac.authorization.k8s.io
+      name: "IAM#jhutar@redhat.com"

--- a/components/perf-team-prometheus-reader/production/kflux-lw-p01/sa-token-creator-rolebinding-patch.yaml
+++ b/components/perf-team-prometheus-reader/production/kflux-lw-p01/sa-token-creator-rolebinding-patch.yaml
@@ -1,0 +1,10 @@
+---
+# kflux-lw-p01 is an IBM ROKS cluster authenticated via IBM Cloud IAM, so
+# users show up as "IAM#<email>" and are not members of the konflux-performance
+# group used on other clusters. Grant this user directly until group sync works here.
+- op: replace
+  path: /subjects
+  value:
+    - kind: User
+      apiGroup: rbac.authorization.k8s.io
+      name: "IAM#jhutar@redhat.com"


### PR DESCRIPTION
`kflux-lw-p01` is an IBM ROKS cluster authenticated via IBM Cloud IAM, so users are identified as `IAM#<email>` and are not members of the `konflux-performance` group used for RBAC on other clusters. Add a cluster-specific overlay that grants the `sa-token-creator` and `maintainers` RoleBindings to this user directly until group sync works on this cluster.

## Risk Assessment

**Risk level:** low

**What could go wrong:** Maybe could lock me out from the namespace? Or make the ArgoCD stop syncing changes to our namespace?

**Rollback plan:** Revert the PR and redeploy. No data migration involved.

**Testing:** This was not tested in Stage, because this is change specific to new `kflux-lw-p01` prod cluster.