### PR TITLE
Fix metrics scrapping for image-controller

### DIFF
--- a/components/build-service/base/allow-metrics-ingress.yaml
+++ b/components/build-service/base/allow-metrics-ingress.yaml
@@ -1,0 +1,28 @@
+---
+# Network Policy: Metrics Ingress
+#
+# Purpose: Allow Prometheus/monitoring systems to scrape metrics from image-controller
+# Port: 8443 (metrics endpoint)
+#
+# Allows traffic from:
+#   - openshift-user-workload-monitoring namespace (where Prometheus runs)
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-metrics-ingress
+  namespace: image-controller
+spec:
+  podSelector:
+    matchLabels:
+      control-plane: controller-manager
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    # Allow Prometheus from openshift-user-workload-monitoring to scrape metrics
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: openshift-user-workload-monitoring
+    ports:
+    - protocol: TCP
+      port: 8443  # Metrics port

--- a/components/build-service/base/kustomization.yaml
+++ b/components/build-service/base/kustomization.yaml
@@ -1,5 +1,6 @@
 resources:
 - allow-argocd-to-manage.yaml
+- allow-metrics-ingress.yaml
 - build-pipeline-config/build-pipeline-config.yaml
 - monitoring.yaml
 - rbac

--- a/components/image-controller/base/allow-metrics-ingress.yaml
+++ b/components/image-controller/base/allow-metrics-ingress.yaml
@@ -1,0 +1,28 @@
+---
+# Network Policy: Metrics Ingress
+#
+# Purpose: Allow Prometheus/monitoring systems to scrape metrics from image-controller
+# Port: 8443 (metrics endpoint)
+#
+# Allows traffic from:
+#   - openshift-user-workload-monitoring namespace (where Prometheus runs)
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-metrics-ingress
+  namespace: image-controller
+spec:
+  podSelector:
+    matchLabels:
+      control-plane: controller-manager
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    # Allow Prometheus from openshift-user-workload-monitoring to scrape metrics
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: openshift-user-workload-monitoring
+    ports:
+    - protocol: TCP
+      port: 8443  # Metrics port

--- a/components/image-controller/base/kustomization.yaml
+++ b/components/image-controller/base/kustomization.yaml
@@ -1,5 +1,6 @@
 resources:
 - allow-argocd-to-manage.yaml
+- allow-metrics-ingress.yaml
 - monitoring.yaml
 - rbac
 


### PR DESCRIPTION
## What:

Allow scrapping metrics for Image Controller and Build Service

## Why:

We've put additional restrictions for metrics endpoint in upstream operator, so the change needed to restore metrics scrapping.

## Validation:
Building resources via kustomize.

## Risk Assessment

Risk Level: Low
Rollback: Revert this PR