### PR TITLE
Rollback(PVO11Y-4877): Traces metrics propagation to RHOBS

### DIFF
--- a/components/monitoring/tracing/otel-collector/staging/servicemonitors/otel-collector-mttb-servicemonitor.yaml
+++ b/components/monitoring/tracing/otel-collector/staging/servicemonitors/otel-collector-mttb-servicemonitor.yaml
@@ -15,4 +15,7 @@ spec:
       metricRelabelings:
         - sourceLabels: [__name__]
           regex: 'traces_span_metrics_.*'
-          action: keep
+          action: drop #from allow to drop due to high cardinality. Fix the cardinality or federation before allowing again.
+        - sourceLabels: [__name__]
+          regex: '.*'
+          action: drop


### PR DESCRIPTION
 We need to drop all the metrics coming from traces due to high cardinality until this will be federated properly with proper filtering.

This is an emergency rollback to restore state of stage rhobs.