### PR TITLE
SPRE-6742: Forward Grafana CPU metrics in production

### DIFF
--- a/components/monitoring/prometheus/production/base/federation/endpoints-params.yaml
+++ b/components/monitoring/prometheus/production/base/federation/endpoints-params.yaml
@@ -136,13 +136,14 @@
 
     ## Container Metrics
     - '{__name__="kube_pod_container_status_waiting_reason", namespace!~".*-tenant|openshift-.*|kube-.*"}'
+    - '{__name__="kube_pod_container_resource_requests", namespace="appstudio-grafana", resource="cpu"}'
     - '{__name__="kube_pod_container_resource_limits", namespace=~"release-service|rhtap-releng-tenant"}'
     - '{__name__="kube_pod_container_status_terminated_reason", namespace=~"release-service|openshift-etcd|openshift-kube-apiserver|build-service|image-controller|integration-service|konflux-ui|product-kubearchive|product-kubearchive-logging|openshift-kueue-operator|tekton-kueue|mintmaker|multi-platform-controller|namespace-lister|openshift-pipelines|tekton-results|project-controller|smee|smee-client"}'
     - '{__name__="kube_pod_container_status_terminated_reason", namespace=~".*-tenant", reason="OOMKilled"}'
     - '{__name__="kube_pod_container_status_last_terminated_reason", reason="OOMKilled"}'
     - '{__name__="kube_pod_container_status_last_terminated_reason", namespace="release-service"}'
     - '{__name__="kube_pod_container_status_ready", namespace=~"release-service"}'
-    - '{__name__="container_cpu_usage_seconds_total", namespace=~"release-service|openshift-etcd"}'
+    - '{__name__="container_cpu_usage_seconds_total", namespace=~"release-service|openshift-etcd|appstudio-grafana"}'
     - '{__name__="container_memory_usage_bytes", namespace=~"release-service|openshift-etcd|rhtap-releng-tenant"}'
     - '{__name__="kube_pod_container_status_restarts_total", namespace!~".*-tenant"}'
     - '{__name__="namespace:container_memory_usage_bytes:sum", namespace=~"release-service|openshift-etcd|openshift-kube-apiserver|build-service|image-controller|integration-service|konflux-ui|product-kubearchive|product-kubearchive-logging|openshift-kueue-operator|tekton-kueue|mintmaker|multi-platform-controller|namespace-lister|openshift-pipelines|tekton-results|project-controller|smee|smee-client"}'


### PR DESCRIPTION
## What

Forward these metrics from the `appstudio-grafana` namespace in production to RHOBS:

- `container_cpu_usage_seconds_total`
- `kube_pod_container_resource_requests` for CPU

Clusters affected: all production clusters consuming the monitoring Prometheus production base.

[SPRE-6742](https://issues.redhat.com/browse/SPRE-6742)

## Why

The Grafana CPU alert compares CPU usage with CPU requests. Both metrics must be available in RHOBS for the alert to work.

## Risk Assessment

**Risk Level:** Low
**What could go wrong:** The selectors could add unnecessary series or fail to expose the data required by the alert. Staging showed only five CPU usage and three CPU request series.
**Rollback:** Revert this PR; ArgoCD will restore the previous federation selectors.
**Blast radius:** All production clusters consuming `components/monitoring/prometheus/production/base`.

## Validation

Staging PR: https://github.com/redhat-appstudio/infra-deployments/pull/13934

Test results:
- Both metrics were verified in the staging federation Prometheus and RHOBS.
- Staging cardinality: 5 CPU usage series and 3 CPU request series.
- `yamllint` passes.
- `kustomize build --enable-helm components/monitoring/prometheus/production/base` passes.
- `git diff --check` passes.



[SPRE-6742]: https://redhat.atlassian.net/browse/SPRE-6742?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ