### PR TITLE
feat(KONFLUX-15512): grant IAM#jhutar@redhat.com token access on kflux-lw-p01 managed-konflux-perfscale-tenant

### DIFF
--- a/components/perf-team-prometheus-reader/production/kflux-lw-p01/kustomization.yaml
+++ b/components/perf-team-prometheus-reader/production/kflux-lw-p01/kustomization.yaml
@@ -15,3 +15,10 @@ patches:
       group: rbac.authorization.k8s.io
       version: v1
       kind: RoleBinding
+  - path: serviceaccounttoken-manager-rolebinding-patch.yaml
+    target:
+      name: serviceaccounttoken-manager:konflux-perfscale
+      namespace: managed-konflux-perfscale-tenant
+      group: rbac.authorization.k8s.io
+      version: v1
+      kind: RoleBinding

--- a/components/perf-team-prometheus-reader/production/kflux-lw-p01/serviceaccounttoken-manager-rolebinding-patch.yaml
+++ b/components/perf-team-prometheus-reader/production/kflux-lw-p01/serviceaccounttoken-manager-rolebinding-patch.yaml
@@ -1,0 +1,10 @@
+---
+# kflux-lw-p01 is an IBM ROKS cluster authenticated via IBM Cloud IAM, so
+# users show up as "IAM#<email>" and are not members of the konflux-performance
+# group used on other clusters. Grant this user directly until group sync works here.
+- op: replace
+  path: /subjects
+  value:
+    - kind: User
+      apiGroup: rbac.authorization.k8s.io
+      name: "IAM#jhutar@redhat.com"


### PR DESCRIPTION
## What

- Grant `IAM#jhutar@redhat.com` (kflux-lw-p01, IBM ROKS/IAM) direct access to the `serviceaccounttoken-manager:konflux-perfscale` RoleBinding in the `managed-konflux-perfscale-tenant` namespace via a kflux-lw-p01 cluster overlay.
- Enables that user to `create serviceaccounts/token` for `managed-konflux-perfscale-sa`.

Clusters affected: kflux-lw-p01

[KONFLUX-15512](https://redhat.atlassian.net/browse/KONFLUX-15512)

## Why

kflux-lw-p01 is an IBM ROKS cluster authenticated via IBM Cloud IAM, so users are `IAM#<email>` and are not members of the `konflux-performance` group used on other clusters. The existing `serviceaccounttoken-manager:konflux-perfscale` RoleBinding binds that group, so the user was denied token creation. Add a cluster-specific overlay granting the user directly until group sync works on this cluster (same approach as the prior perf-team-prometheus-reader grant).

## Validation

- `kustomize build --enable-helm components/perf-team-prometheus-reader/production/kflux-lw-p01/` passes; rendered output confirms `serviceaccounttoken-manager:konflux-perfscale` subjects replaced with `IAM#jhutar@redhat.com` in `managed-konflux-perfscale-tenant`.
- Other tenant namespaces (`konflux-perfscale-1..4-tenant`) unchanged — still bound to `konflux-performance` group.

## Risk Assessment

**Risk Level:** Low
**What could go wrong:** If mis-scoped, token-creator access could mint credentials for SAs in `managed-konflux-perfscale-tenant`; scope is limited to this single namespace on kflux-lw-p01 and the author's own IAM user.
**Rollback:** Revert PR; ArgoCD resyncs the kflux-lw-p01 overlay to the previous group-based binding.
**Blast radius:** 1 cluster (kflux-lw-p01), 1 namespace (`managed-konflux-perfscale-tenant`), 1 user.


[KONFLUX-15512]: https://redhat.atlassian.net/browse/KONFLUX-15512?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ