### PR TITLE
feat(KFLUXVNGD-1344): Make new-cluster bootstrap operator-first

### DIFF
--- a/argo-cd-apps/overlays/rd-staging/konflux-operator/konflux-operator-appset.yaml
+++ b/argo-cd-apps/overlays/rd-staging/konflux-operator/konflux-operator-appset.yaml
@@ -4,7 +4,6 @@ metadata:
   name: konflux-operator
   labels: # Helps k-components detect this appset to apply the correct patches
     appstudio.redhat.com/deployment-clusters: "tenant"
-    appstudio.redhat.com/internal-only: "true"
 spec:
   generators:
     - merge:
@@ -24,6 +23,15 @@ spec:
                 clusterDir: "empty-base"
           - list:
               elements: [] # Populated via k-components (or manually if the cluster list is unusual)
+      # Tenant k-components populate the merge list for every tenant cluster.
+      # This In selector is what actually opts a cluster into the operator.
+      selector:
+        matchExpressions:
+          - key: nameNormalized
+            operator: In
+            values:
+              - stone-stage-p01
+              - lightwell-dev
 
   template:
     metadata:

--- a/hack/new-cluster/README.md
+++ b/hack/new-cluster/README.md
@@ -4,6 +4,29 @@ This is step 2 of 3 in automating the rollout of a new cluster.
 
 This automation creates yaml files in the infra-deployments repo locally.
 
+New clusters are bootstrapped with the **konflux-operator** overlay under
+`components/konflux-operator/rings/<ring>/<cluster>/`. Operator-owned legacy
+services (`application-api`, `build-service`, `enterprise-contract`,
+`image-controller`, `integration`, `konflux-info`, `konflux-rbac`,
+`konflux-ui`, `namespace-lister`, `release`) are **not** templated. The cluster
+is appended to `exclude-operator-owned-clusters.yaml` so those ApplicationSets
+do not generate for it.
+
+Public and private clusters both get the operator. Smee-client and webhook URL
+patches are generated only when `network` is `private`.
+
+Operator-first bootstrap requires `ring-1` with `env=staging` and `ring-2`
+with `env=production`. The playbook rejects other env/ring pairs. When later
+rings have operator bases, add them to `operator_rings_by_env` in
+`playbook.yaml`. The cluster is also appended to the konflux-operator
+ApplicationSet `nameNormalized In` selector in
+`argo-cd-apps/overlays/rd-<env>/konflux-operator/`.
+
+Staging and production both gate the operator with that `In` selector (staging
+no longer uses `internal-only`). Existing operator clusters stay listed there;
+other tenants do not get the operator until a playbook run (or a manual add)
+includes them.
+
 ## Prerequisite
 
 1. The cluster-layer terraform automation has been run, and the new cluster is up. This entails that the AWS, IBM, and database secrets have been provisioned and injected into vault in the correct paths. This automation will verify that before proceeding.
@@ -22,7 +45,9 @@ This automation creates yaml files in the infra-deployments repo locally.
 * `cutename` - Example: `rh09`
 * `env` - One of `production` or `staging`.
 * `network` - One of `public` or `private`.
-* `ring` - One of `ring-1`, `ring-2`, `ring-3`, or `ring-4`
+* `ring` - `ring-1` when `env=staging`, `ring-2` when `env=production`.
+  Other combinations fail. `ring-3` and `ring-4` are listed for later
+  operator bases; they fail until added to `operator_rings_by_env`.
 * `awsaccount` - The 12-digit AWS account ID for the cluster
 
 4. You are connected to the VPN.
@@ -52,7 +77,7 @@ If you do not want to run all steps, but only a subset **you can use tags** to r
 If you don't want to specify the variables at prompts, you can **specify variables when invoking the CLI**, like this:
 
 ```
-❯ ansible-playbook hack/new-cluster/playbook.yaml -e 'cutename=rh09 shortname=kflux-prd-rh09 longname=kflux-prd-rh09.abe9.p1 ring=ring-3 env=production network=public awsaccount=123456789000'
+❯ ansible-playbook hack/new-cluster/playbook.yaml -e 'cutename=rh09 shortname=kflux-prd-rh09 longname=kflux-prd-rh09.abe9.p1 ring=ring-2 env=production network=public awsaccount=123456789000'
 ```
 
 If you are **nervous about drift** between the current application manifests and those produced by this automation, you can inspect the different by running this automation and requesting it to produce the config **for an existing cluster**, and then investigate what changes it may have made by looking at `git diff`, like this.

--- a/hack/new-cluster/playbook.yaml
+++ b/hack/new-cluster/playbook.yaml
@@ -60,27 +60,29 @@
       - ring-2
       - ring-3
       - ring-4
+    # Operator-first bootstrap: env must use a ring that has a matching
+    # konflux-operator base (staging URLs vs production URLs). Extend the
+    # lists when later rings get operator bases.
+    operator_rings_by_env:
+      staging:
+        - ring-1
+      production:
+        - ring-2
     allowed_networks:
       - public
       - private
 
     templated_components:
       - backup
-      - build-service
       - cert-manager
       - cost-management
-      - integration
       - image-rbac-proxy
       - knative-eventing
-      - konflux-info
       - konflux-kite
-      - konflux-rbac
-      - konflux-ui
       - kubearchive
       - kueue
       - kyverno
       - mintmaker
-      - namespace-lister
       - pipeline-service
       - policies
       - smee-client
@@ -89,6 +91,7 @@
     templated_rd_components:
       - authentication
       - etcd-shield
+      - konflux-operator
       - multi-platform-controller
 
     templated_configs:
@@ -96,20 +99,14 @@
     - proactive-scaler
 
     argo_cd_app_files:
-      - "{{ dst }}/argo-cd-apps/base/member/infra-deployments/build-service/build-service.yaml"
       - "{{ dst }}/argo-cd-apps/base/member/infra-deployments/cert-manager/cert-manager.yaml"
       - "{{ dst }}/argo-cd-apps/base/member/infra-deployments/etcd-defrag/etcd-defrag.yaml"
-      - "{{ dst }}/argo-cd-apps/base/member/infra-deployments/integration/integration.yaml"
       - "{{ dst }}/argo-cd-apps/base/member/infra-deployments/image-rbac-proxy/image-rbac-proxy.yaml"
-      - "{{ dst }}/argo-cd-apps/base/member/infra-deployments/konflux-info/konflux-info.yaml"
       - "{{ dst }}/argo-cd-apps/base/member/infra-deployments/konflux-kite/konflux-kite.yaml"
-      - "{{ dst }}/argo-cd-apps/base/member/infra-deployments/konflux-rbac/konflux-rbac.yaml"
-      - "{{ dst }}/argo-cd-apps/base/member/infra-deployments/konflux-ui/konflux-ui.yaml"
       - "{{ dst }}/argo-cd-apps/base/member/infra-deployments/kubearchive/kubearchive.yaml"
       - "{{ dst }}/argo-cd-apps/base/member/infra-deployments/kueue/kueue.yaml"
       - "{{ dst }}/argo-cd-apps/base/member/infra-deployments/kyverno/kyverno.yaml"
       - "{{ dst }}/argo-cd-apps/base/member/infra-deployments/mintmaker/mintmaker.yaml"
-      - "{{ dst }}/argo-cd-apps/base/member/infra-deployments/namespace-lister/namespace-lister.yaml"
       - "{{ dst }}/argo-cd-apps/base/member/infra-deployments/pipeline-service/pipeline-service.yaml"
       - "{{ dst }}/argo-cd-apps/base/member/infra-deployments/policies/policies.yaml"
       - "{{ dst }}/argo-cd-apps/base/member/infra-deployments/proactive-scaler/proactive-scaler.yaml"
@@ -185,12 +182,17 @@
       tags: [applicationsets]
       include_tasks: tasks/k-components.yaml
 
+    - name: Wire konflux-operator (exclude legacy services, onboard operator AppSet)
+      tags: [applicationsets]
+      include_tasks: tasks/konflux-operator.yaml
+
     - name: Copy cluster-specific component manifests
       tags: [components]
       include_tasks: tasks/components.yaml
       loop: "{{ templated_components }}"
       loop_control:
         loop_var: component
+      when: component != 'smee-client' or network == 'private'
 
     - name: Copy cluster-specific ring-deployment component manifests
       tags: [components]

--- a/hack/new-cluster/tasks/components.yaml
+++ b/hack/new-cluster/tasks/components.yaml
@@ -33,7 +33,9 @@
     dest: "{{ dst }}/components/{{ component }}/{{ subdir }}/{{ shortname }}/{{item['path'] }}"
   with_filetree:
   - "templates/{{ component }}/"
-  when: "item['state'] == 'file'"
+  when:
+    - item['state'] == 'file'
+    - not (component == 'konflux-operator' and item['path'] == 'namespace-lister/resources-patch.yaml' and ring != 'ring-1')
 
 - name: "Create private-network-only files from template for components/{{ component }}/{{ subdir }}/{{ shortname }}"
   tags: [components]

--- a/hack/new-cluster/tasks/konflux-operator.yaml
+++ b/hack/new-cluster/tasks/konflux-operator.yaml
@@ -1,0 +1,34 @@
+# Exclude the new cluster from operator-owned legacy ApplicationSets and
+# onboard it on the konflux-operator ApplicationSet (nameNormalized In selector).
+
+- name: Set konflux-operator wiring file paths
+  tags: [applicationsets]
+  set_fact:
+    konflux_operator_exclude_file: "{{ dst }}/argo-cd-apps/overlays/{{ env }}-downstream/exclude-operator-owned-clusters.yaml"
+    konflux_operator_appset_file: "{{ dst }}/argo-cd-apps/overlays/rd-{{ env }}/konflux-operator/konflux-operator-appset.yaml"
+
+- name: Check whether {{ shortname }} is already in the legacy exclude list
+  tags: [applicationsets]
+  command: |
+    yq eval '.[0].value.matchExpressions[0].values[] | select(. == "{{ shortname }}")' {{ konflux_operator_exclude_file }}
+  register: konflux_operator_exclude_idx
+  changed_when: false
+
+- name: Add {{ shortname }} to exclude-operator-owned-clusters.yaml
+  tags: [applicationsets]
+  command: |
+    yq -i eval '.[0].value.matchExpressions[0].values += ["{{ shortname }}"]' {{ konflux_operator_exclude_file }}
+  when: konflux_operator_exclude_idx.stdout == ""
+
+- name: Check whether {{ shortname }} is already in the operator ApplicationSet In selector
+  tags: [applicationsets]
+  command: |
+    yq eval '.spec.generators[0].selector.matchExpressions[0].values[] | select(. == "{{ shortname }}")' {{ konflux_operator_appset_file }}
+  register: konflux_operator_in_idx
+  changed_when: false
+
+- name: Add {{ shortname }} to the konflux-operator ApplicationSet In selector
+  tags: [applicationsets]
+  command: |
+    yq -i eval '.spec.generators[0].selector.matchExpressions[0].values += ["{{ shortname }}"]' {{ konflux_operator_appset_file }}
+  when: konflux_operator_in_idx.stdout == ""

--- a/hack/new-cluster/tasks/variables.yaml
+++ b/hack/new-cluster/tasks/variables.yaml
@@ -41,6 +41,26 @@
   fail:
     msg: "Variable 'network' must be one of {{allowed_networks}}, not {{network}}"
   when: "vars['network'] not in vars['allowed_networks']"
+- name: Fail if ring is not valid for this environment
+  tags: [always]
+  fail:
+    msg: >-
+      Operator-first bootstrap requires ring-1 for staging and ring-2 for
+      production (got env={{ env }} ring={{ ring }}). Supported rings for
+      {{ env }}: {{ operator_rings_by_env[env] | join(', ') }}.
+  when: ring not in operator_rings_by_env[env]
+- name: Check that konflux-operator ring base exists
+  tags: [always]
+  stat:
+    path: "{{ dst }}/components/konflux-operator/rings/{{ ring }}/base"
+  register: konflux_operator_ring_base
+- name: Fail if konflux-operator has no base for this ring
+  tags: [always]
+  fail:
+    msg: >-
+      konflux-operator has no rings/{{ ring }}/base. Add the ring to
+      operator_rings_by_env in playbook.yaml only after that base exists.
+  when: not konflux_operator_ring_base.stat.exists
 - name: Determine the latest github commits
   tags: [always]
   include_tasks: tasks/github/find-latest-commits.yaml

--- a/hack/new-cluster/templates/konflux-operator/build/OWNERS
+++ b/hack/new-cluster/templates/konflux-operator/build/OWNERS
@@ -1,0 +1,16 @@
+# See the OWNERS docs: https://go.k8s.io/owners
+# Should be kept in sync with components/monitoring/grafana/base/dashboards/build-service/OWNERS
+
+approvers:
+- mmorhun
+- rcerven
+- mkosiarc
+- tisutisu
+- chmeliik
+
+reviewers:
+- mmorhun
+- rcerven
+- mkosiarc
+- tisutisu
+- chmeliik

--- a/hack/new-cluster/templates/konflux-operator/build/external-secret-path-patch.yaml
+++ b/hack/new-cluster/templates/konflux-operator/build/external-secret-path-patch.yaml
@@ -1,0 +1,3 @@
+- op: add
+  path: /spec/dataFrom/0/extract/key
+  value: {{ env }}/platform/ansible/generated/{{ shortname }}/github-app

--- a/hack/new-cluster/templates/konflux-operator/integration/OWNERS
+++ b/hack/new-cluster/templates/konflux-operator/integration/OWNERS
@@ -1,0 +1,21 @@
+# See the OWNERS docs: https://go.k8s.io/owners
+
+approvers:
+- dirgim
+- jsztuka
+- kasemAlem
+- sonam1412
+- Josh-Everett
+- 14rcole
+- jencull
+- NigelByrne1
+
+reviewers:
+- dirgim
+- jsztuka
+- kasemAlem
+- sonam1412
+- Josh-Everett
+- 14rcole
+- jencull
+- NigelByrne1

--- a/hack/new-cluster/templates/konflux-operator/integration/external-secret-path-patch.yaml
+++ b/hack/new-cluster/templates/konflux-operator/integration/external-secret-path-patch.yaml
@@ -1,0 +1,3 @@
+- op: add
+  path: /spec/dataFrom/0/extract/key
+  value: {{ env }}/platform/ansible/generated/{{ shortname }}/github-app

--- a/hack/new-cluster/templates/konflux-operator/konflux-info/OWNERS
+++ b/hack/new-cluster/templates/konflux-operator/konflux-info/OWNERS
@@ -1,0 +1,43 @@
+# See the OWNERS docs: https://go.k8s.io/owners
+
+approvers:
+# infra-team
+- sadlerap
+- eisraeli
+- filariow
+- gbenhaim
+- hugares
+- manish-jangra
+# sre-team
+- dgregor
+- jdcasey
+# ui-team
+- abhinandan13jan
+- caugello
+- CryptoRodeo
+- JoaoPedroPP
+- Katka92
+- sahil143
+- rrosatti
+- StanislavJochman
+
+reviewers:
+# infra-team
+- sadlerap
+- eisraeli
+- filariow
+- gbenhaim
+- hugares
+- manish-jangra
+# sre-team
+- dgregor
+- jdcasey
+# ui-team
+- abhinandan13jan
+- caugello
+- CryptoRodeo
+- JoaoPedroPP
+- Katka92
+- sahil143
+- rrosatti
+- StanislavJochman

--- a/hack/new-cluster/templates/konflux-operator/konflux-info/info-patch.yaml
+++ b/hack/new-cluster/templates/konflux-operator/konflux-info/info-patch.yaml
@@ -1,0 +1,13 @@
+apiVersion: konflux.konflux-ci.dev/v1alpha1
+kind: Konflux
+metadata:
+  name: konflux
+spec:
+  info:
+    spec:
+      publicInfo:
+        visibility: private
+        statusPageUrl: "https://grafana.app-sre.devshift.net/d/aes1ns0htwni8a/konflux-status-page?var-cluster={{ shortname }}"
+        integrations:
+          github:
+            application_url: "https://github.com/apps/{{ github_application }}"

--- a/hack/new-cluster/templates/konflux-operator/konflux-ui/OWNERS
+++ b/hack/new-cluster/templates/konflux-operator/konflux-ui/OWNERS
@@ -1,0 +1,43 @@
+# See the OWNERS docs: https://go.k8s.io/owners
+
+approvers:
+# infra-team
+- sadlerap
+- eisraeli
+- filariow
+- gbenhaim
+- hugares
+- manish-jangra
+# sre-team
+- dgregor
+- jdcasey
+# ui-team
+- abhinandan13jan
+- caugello
+- CryptoRodeo
+- JoaoPedroPP
+- Katka92
+- sahil143
+- rrosatti
+- StanislavJochman
+
+reviewers:
+# infra-team
+- sadlerap
+- eisraeli
+- filariow
+- gbenhaim
+- hugares
+- manish-jangra
+# sre-team
+- dgregor
+- jdcasey
+# ui-team
+- abhinandan13jan
+- caugello
+- CryptoRodeo
+- JoaoPedroPP
+- Katka92
+- sahil143
+- rrosatti
+- StanislavJochman

--- a/hack/new-cluster/templates/konflux-operator/konflux-ui/ui-patch.yaml
+++ b/hack/new-cluster/templates/konflux-operator/konflux-ui/ui-patch.yaml
@@ -1,0 +1,12 @@
+apiVersion: konflux.konflux-ci.dev/v1alpha1
+kind: Konflux
+metadata:
+  name: konflux
+spec:
+  ui:
+    spec:
+      runtimeConfig:
+        chatBot:
+          enabled: false
+        monitoring:
+          cluster: {{ shortname }}

--- a/hack/new-cluster/templates/konflux-operator/kustomization.yaml
+++ b/hack/new-cluster/templates/konflux-operator/kustomization.yaml
@@ -1,0 +1,29 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../base
+
+patches:
+  - path: build/external-secret-path-patch.yaml
+    target:
+      name: pipelines-as-code-secret
+      namespace: build-service
+      group: external-secrets.io
+      version: v1
+      kind: ExternalSecret
+  - path: integration/external-secret-path-patch.yaml
+    target:
+      name: pipelines-as-code-secret
+      namespace: integration-service
+      group: external-secrets.io
+      version: v1
+      kind: ExternalSecret
+{% if network == "private" %}
+  - path: build/webhook-urls-patch.yaml
+{% endif %}
+  - path: konflux-info/info-patch.yaml
+  - path: konflux-ui/ui-patch.yaml
+{% if ring == "ring-1" %}
+  - path: namespace-lister/resources-patch.yaml
+{% endif %}

--- a/hack/new-cluster/templates/konflux-operator/namespace-lister/OWNERS
+++ b/hack/new-cluster/templates/konflux-operator/namespace-lister/OWNERS
@@ -1,0 +1,7 @@
+# See the OWNERS docs: https://go.k8s.io/owners
+
+approvers:
+- konflux-infra-team
+
+reviewers:
+- konflux-infra-team

--- a/hack/new-cluster/templates/konflux-operator/namespace-lister/resources-patch.yaml
+++ b/hack/new-cluster/templates/konflux-operator/namespace-lister/resources-patch.yaml
@@ -1,0 +1,14 @@
+apiVersion: konflux.konflux-ci.dev/v1alpha1
+kind: Konflux
+metadata:
+  name: konflux
+spec:
+  namespaceLister:
+    spec:
+      namespaceLister:
+        namespaceLister:
+          resources:
+            requests:
+              memory: 500Mi
+            limits:
+              memory: 500Mi

--- a/hack/new-cluster/templates/private/konflux-operator/build/webhook-urls-patch.yaml
+++ b/hack/new-cluster/templates/private/konflux-operator/build/webhook-urls-patch.yaml
@@ -1,0 +1,10 @@
+apiVersion: konflux.konflux-ci.dev/v1alpha1
+kind: Konflux
+metadata:
+  name: konflux
+spec:
+  buildService:
+    spec:
+      webhookURLs:
+        "https://github.com": "{{ smee_webhook_url }}"
+        "https://gitlab.com": "{{ smee_webhook_url }}"


### PR DESCRIPTION
- Stop templating operator-owned legacy overlays (`build-service`, `integration`, `konflux-ui`, `konflux-info`, `konflux-rbac`, `namespace-lister`) and stop adding new clusters to those ApplicationSets.
- Generate a `konflux-operator` ring overlay at `components/konflux-operator/rings/<ring>/<cluster>/` (webhook/smee only when `network=private`).
- Append the new cluster to `exclude-operator-owned-clusters.yaml` and to the operator AppSet `nameNormalized In` selector.
- Align the staging operator AppSet with production: drop `internal-only`, gate with `In [stone-stage-p01, lightwell-dev]` so public tenants can be onboarded later without turning the operator on for every staging cluster.
- Fail bootstrap if the chosen ring has no konflux-operator base (ring-1 / ring-2 today).

Clusters affected: none of the existing tenant clusters change which operator Applications they get. Staging AppSet still generates only for `stone-stage-p01` and `lightwell-dev` until a later playbook run adds a cluster.

New clusters should come up on the konflux-operator from day one, without a window where legacy Konflux services are deployed and then removed. The playbook already created GitHub apps, Vault paths, and smee URLs; it also wired clusters into those legacy ApplicationSets. This change keeps the bootstrap values and drops the legacy wiring.

Public and private clusters both get the operator. Smee stays private-only. Staging had to drop `internal-only` so a public tenant can be selected; the `In` list is what keeps today’s operator footprint unchanged.

- Private throwaway (`kflux-stg-p97` / `kflux-stg-p99`): operator overlay matches `stone-stage-p01` (includes webhook `.../redhathook<cutename>` and smee-client); cluster on exclude list + operator `In`; no `components/{build-service,integration,konflux-ui,...}/<cluster>/`.
- Public throwaway (`kflux-stg-p98`): overlay matches `lightwell-dev` (no webhook, no smee-client, not on internal tenant list); still on tenant list, exclude list, and operator `In`.
- Playbook runs used `--skip-tags vault,chains,github`. Throwaway overlays were deleted and were not committed.

**Risk Level:** Low
**What could go wrong:** Dropping `internal-only` without the `In` selector would generate operator Applications for every staging tenant. If the `In` list is wrong, `stone-stage-p01` or `lightwell-dev` could lose the operator Application (resources are preserved on deletion for the legacy AppSets, but the operator AppSet itself would stop generating). **Rollback:** Revert this PR. Staging AppSet returns to `internal-only` + internal tenant list; playbook returns to templating legacy overlays. **Blast radius:** Staging operator AppSet only. Existing operator clusters stay listed in `In`. Production AppSet is unchanged. No new cluster is onboarded by this PR (`kflux-stg-p02` is a later playbook run after merge).

Assisted-by: Cursor Grok 4.6