### PR TITLE
KONFLUX-15403: Update kube-shard to 9e2da55 and retune APIShard memory

### DIFF
--- a/components/kube-shard/rings/ring-1/base/konflux-tekton-shard-apishard.yaml
+++ b/components/kube-shard/rings/ring-1/base/konflux-tekton-shard-apishard.yaml
@@ -36,10 +36,10 @@ spec:
     resources:
       limits:
         cpu: "2"
-        memory: 16Gi
+        memory: 10Gi
       requests:
         cpu: "2"
-        memory: 16Gi
+        memory: 10Gi
     tolerations:
     - effect: NoSchedule
       key: konflux-ci.dev/workload
@@ -53,11 +53,11 @@ spec:
     replicas: 3
     resources:
       limits:
-        cpu: "4"
-        memory: 32Gi
+        cpu: "6"
+        memory: 48Gi
       requests:
-        cpu: "4"
-        memory: 32Gi
+        cpu: "6"
+        memory: 48Gi
     tolerations:
     - effect: NoSchedule
       key: konflux-ci.dev/workload

--- a/components/kube-shard/rings/ring-1/base/kustomization.yaml
+++ b/components/kube-shard/rings/ring-1/base/kustomization.yaml
@@ -2,10 +2,10 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - base-snapshot
-- https://github.com/konflux-ci/kube-shard/operator/config/default?ref=d0b933b37a30555932fb1f2da737b6e3f5bf7364
+- https://github.com/konflux-ci/kube-shard/operator/config/default?ref=9e2da554f84da6ae593bbe66cbf3a5a4281bc8ec
 - konflux-tekton-shard-apishard.yaml
 
 images:
 - name: localhost/controller
   newName: quay.io/konflux-ci/kube-shard
-  newTag: d0b933b37a30555932fb1f2da737b6e3f5bf7364
+  newTag: 9e2da554f84da6ae593bbe66cbf3a5a4281bc8ec


### PR DESCRIPTION
## What

- Bump kube-shard operator image/ref from `d0b933b` to `9e2da554f84da6ae593bbe66cbf3a5a4281bc8ec`
- Reduce kine memory requests/limits from 16Gi to 10Gi
- Increase secondary apiserver memory requests/limits from 32Gi to 48Gi

Clusters affected: lightwell-dev

[KONFLUX-15403](https://redhat.atlassian.net/browse/KONFLUX-15403)

## Why

Pick up operator fixes since the last pin (PostgreSQL TLS, storage monitoring, StatefulSet VCT handling, reconcile-loop fixes) and retune APIShard memory for current kine vs secondary apiserver usage.

Upstream delta: https://github.com/konflux-ci/kube-shard/compare/d0b933b37a30555932fb1f2da737b6e3f5bf7364...9e2da554f84da6ae593bbe66cbf3a5a4281bc8ec

## Validation

- `kustomize build --enable-helm components/kube-shard/rings/ring-1/lightwell-dev` succeeds
- Rendered operator image is `quay.io/konflux-ci/kube-shard:9e2da554f84da6ae593bbe66cbf3a5a4281bc8ec`
- Rendered APIShard resources: kine 10Gi, secondary 48Gi

## Risk Assessment

**Risk Level:** Medium
**What could go wrong:** The operator bump enables TLS for in-cluster PostgreSQL (`sslmode=verify-full`). If cert-manager issuance or Kine CA wiring fails, Kine cannot reach PostgreSQL and Tekton APIs on the shard would go unavailable. Lowering kine memory to 10Gi could OOM under load; raising secondary to 48Gi could fail scheduling if shard nodes lack that capacity.
**Rollback:** Revert PR (ArgoCD resyncs previous operator pin `d0b933b` and prior memory settings). PostgreSQL TLS certs created by the new operator may remain until the APIShard is reconciled or cleaned up.
**Blast radius:** lightwell-dev only (rd-staging ring-1).

Made with [Cursor](https://cursor.com)

[KONFLUX-15403]: https://redhat.atlassian.net/browse/KONFLUX-15403?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ