### PR TITLE
PVO11Y-5532:  Deploy UWM and Federation Prometheus

### DIFF
--- a/components/monitoring/prometheus/production/kflux-lw-p01/cluster-monitoring-config.yaml
+++ b/components/monitoring/prometheus/production/kflux-lw-p01/cluster-monitoring-config.yaml
@@ -1,0 +1,43 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-monitoring-config
+  namespace: openshift-monitoring
+data:
+  config.yaml: |
+    enableUserWorkload: true
+    prometheusK8s:
+      retentionSize: 10GB
+      volumeClaimTemplate:
+        spec:
+          storageClassName: ibmc-vpc-block-metro-retain-10iops-tier
+          resources:
+            requests:
+              storage: 100Gi
+      nodeSelector:
+        node-role.kubernetes.io/infra: ""
+      tolerations:
+        - key: "node-role.kubernetes.io/infra"
+          effect: "NoSchedule"
+          operator: "Exists"
+    alertmanagerMain:
+      nodeSelector:
+        node-role.kubernetes.io/infra: ""
+      tolerations:
+        - key: "node-role.kubernetes.io/infra"
+          effect: "NoSchedule"
+          operator: "Exists"
+    thanosQuerier:
+      nodeSelector:
+        node-role.kubernetes.io/infra: ""
+      tolerations:
+        - key: "node-role.kubernetes.io/infra"
+          effect: "NoSchedule"
+          operator: "Exists"
+    prometheusOperator:
+      nodeSelector:
+        node-role.kubernetes.io/infra: ""
+      tolerations:
+        - key: "node-role.kubernetes.io/infra"
+          effect: "NoSchedule"
+          operator: "Exists"

--- a/components/monitoring/prometheus/production/kflux-lw-p01/kustomization.yaml
+++ b/components/monitoring/prometheus/production/kflux-lw-p01/kustomization.yaml
@@ -1,4 +1,18 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-
-resources: []
+resources:
+- ../base
+- cluster-monitoring-config.yaml
+patches:
+  - path: cluster-id-label.yaml
+    target:
+      name: appstudio-federate-ms
+      kind: MonitoringStack
+      group: monitoring.rhobs
+      version: v1alpha1
+  - path: writeRelabelConfigs.yaml
+    target:
+      name: appstudio-federate-ms
+      kind: MonitoringStack
+      group: monitoring.rhobs
+      version: v1alpha1

--- a/components/monitoring/prometheus/production/kflux-lw-p01/writeRelabelConfigs.yaml
+++ b/components/monitoring/prometheus/production/kflux-lw-p01/writeRelabelConfigs.yaml
@@ -7,3 +7,47 @@
     # Remote-write only Prometheus status metrics to RHOBS so service-level
     # alerts do not fire for this Lightwell cluster (PVO11Y-5532).
     regex: prometheus_.+|promhttp_.+
+  - action: LabelKeep
+    # Labels allowlisted for remote-write to RHOBS.
+    # Each line in the regex below corresponds to one group.
+    #
+    # Universal
+    # K8s resource state (RHTAPWATCH-88, SPRE-1489, KFLUXINFRA-3503)
+    # Storage (RHTAPWATCH-88)
+    # HTTP / gRPC (SRVKP-4524, PVO11Y-4652)
+    # Histogram (RHTAPWATCH-88, PVO11Y-4774)
+    # Node / CPU (PVO11Y-4652, PVO11Y-4776)
+    # Tekton / Pipelines (RHTAPWATCH-110)
+    # Controller / leases (KONFLUX-4508)
+    # Kueue (KFLUXINFRA-2067)
+    # Kyverno
+    # Release service (RHTAPWATCH-88)
+    # SPI / auth (RHTAPWATCH-88 — SPI removed, may be dead weight)
+    # Probes / testing (RHTAPWATCH-891, PVO11Y-4802, SPRE-4498)
+    # Caching (KFLUXVNGD-751, KFLUXVNGD-1115)
+    # ArgoCD (RHTAPWATCH-88)
+    # Monitoring infra (RHTAPWATCH-110, PVO11Y-4774)
+    # KubeArchive
+    # KAExporter (PVO11Y-5274)
+    # cert-manager (SPRE-5502)
+    # Cardinality exporter (PVO11Y-5128)
+    regex: "__name__|source_environment|source_cluster|namespace|job|instance|pod|container|app|service|deployment|node|\
+      phase|reason|type|resource|kind|name|role|status|state|resourcequota|image|finalizers|verb|request_kind|\
+      persistentvolumeclaim|storageclass|volumename|\
+      method|code|http_method|http_route|http_status_code|grpc_service|grpc_code|grpc_method|sp|\
+      le|quantile|\
+      cpu|mode|\
+      pipeline|pipelinename|pipelinerun|schedule|label_pipelines_appstudio_openshift_io_type|\
+      controller|lease|lease_holder|exported_job|\
+      cluster_queue|priority_class|queue|\
+      policy_name|rule_result|rule_type|rule_execution_cause|policy_background_mode|policy_type|policy_validation_mode|policy_change_type|resource_request_operation|resource_kind|event_type|\
+      release_reason|deployment_reason|validation_reason|strategy|succeeded|target|result|\
+      tokenName|rateLimited|commit_hash|operation|\
+      check|tested_cluster|tested_registry|unexpected_status|failure|severity|\
+      cache_status|normalized_uri|\
+      health_status|dest_namespace|\
+      hostname|label_app_kubernetes_io_managed_by|platform|scrape_job|slice|error|\
+      resource_type|gin_errors|\
+      application|component|build_type|scenario|optional|test_type|automated|exported_namespace|\
+      condition|issuer_name|issuer_kind|issuer_group|\
+      metric|label|label_pair|scraped_instance|sharded_instance|instance_namespace"

--- a/components/monitoring/prometheus/production/kflux-lw-p01/writeRelabelConfigs.yaml
+++ b/components/monitoring/prometheus/production/kflux-lw-p01/writeRelabelConfigs.yaml
@@ -2,7 +2,7 @@
 - op: replace
   path: /spec/prometheusConfig/remoteWrite/0/writeRelabelConfigs
   value:
-  - action: keep
+  - action: Keep
     sourceLabels: [__name__]
     # Remote-write only Prometheus status metrics to RHOBS so service-level
     # alerts do not fire for this Lightwell cluster (PVO11Y-5532).

--- a/components/monitoring/prometheus/production/kflux-lw-p01/writeRelabelConfigs.yaml
+++ b/components/monitoring/prometheus/production/kflux-lw-p01/writeRelabelConfigs.yaml
@@ -1,0 +1,9 @@
+---
+- op: replace
+  path: /spec/prometheusConfig/remoteWrite/0/writeRelabelConfigs
+  value:
+  - action: keep
+    sourceLabels: [__name__]
+    # Remote-write only Prometheus status metrics to RHOBS so service-level
+    # alerts do not fire for this Lightwell cluster (PVO11Y-5532).
+    regex: prometheus_.+|promhttp_.+


### PR DESCRIPTION
## What

Add UWM and federation Prometheus on kflux-lw-p01; remote-write only Prometheus status metrics to RHOBS.

Clusters affected: kflux-lw-p01

[PVO11Y-5532](https://redhat.atlassian.net/browse/PVO11Y-5532)

## Why

The cluster needs UWM and federation locally, but forwarding Konflux service metrics would page on workloads that are not fully present yet.

## Validation

- `kustomize build --enable-helm components/monitoring/prometheus/production/kflux-lw-p01` succeeds
- IBM CMO storage class and infra taint match staging lightwell-dev and current kflux-lw-p01 IaC

## Risk Assessment

**Risk Level:** Medium
**What could go wrong:** Service metrics reach RHOBS and fire production alerts, or CMO pods stay Pending on a wrong storage class/taint.
**Rollback:** Revert PR
**Blast radius:** production cluster kflux-lw-p01 only


Made with [Cursor](https://cursor.com)

[PVO11Y-5532]: https://redhat.atlassian.net/browse/PVO11Y-5532?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ