### PR TITLE
fix(pipeline-service): bump pipeline-metrics-exporter memory on lightwell-dev staging

### DIFF
--- a/components/pipeline-service/staging/lightwell-dev/deploy.yaml
+++ b/components/pipeline-service/staging/lightwell-dev/deploy.yaml
@@ -480,10 +480,10 @@ spec:
         resources:
           limits:
             cpu: 500m
-            memory: 2Gi
+            memory: 4Gi
           requests:
             cpu: 250m
-            memory: 1Gi
+            memory: 2Gi
         securityContext:
           readOnlyRootFilesystem: true
           runAsNonRoot: true

--- a/components/pipeline-service/staging/lightwell-dev/resources/kustomization.yaml
+++ b/components/pipeline-service/staging/lightwell-dev/resources/kustomization.yaml
@@ -25,6 +25,10 @@ patches:
     target:
       kind: TektonConfig
       name: config
+  - path: update-pipeline-metrics-exporter-resources.yaml
+    target:
+      kind: Deployment
+      name: pipeline-metrics-exporter
   # tekton-results is not deployed on this cluster — delete all its resources
   - path: delete-tekton-results-namespace.yaml
     target:

--- a/components/pipeline-service/staging/lightwell-dev/resources/update-pipeline-metrics-exporter-resources.yaml
+++ b/components/pipeline-service/staging/lightwell-dev/resources/update-pipeline-metrics-exporter-resources.yaml
@@ -1,0 +1,7 @@
+---
+- op: replace
+  path: /spec/template/spec/containers/0/resources/limits/memory
+  value: 4Gi
+- op: replace
+  path: /spec/template/spec/containers/0/resources/requests/memory
+  value: 2Gi


### PR DESCRIPTION
## What

- Scope: lightwell-dev (staging) only.
- Add per-cluster kustomize patch `resources/update-pipeline-metrics-exporter-resources.yaml` on `components/pipeline-service/staging/lightwell-dev` to raise `pipeline-metrics-exporter` memory:
  - requests: `1Gi` -> `2Gi`
  - limits: `2Gi` -> `4Gi`
- Regenerated `components/pipeline-service/staging/lightwell-dev/deploy.yaml` via `kubectl kustomize`; base overlay (`staging/base`) left unchanged so other staging clusters (stone-stage-p01, stone-stg-rh01) are unaffected.

Clusters affected: lightwell-dev (staging)

## Why

`pipeline-metrics-exporter` in namespace `openshift-pipelines` on lightwell-dev restarts frequently due to OOMKill. Doubling memory to accommodate growth, scoped to lightwell-dev to keep blast radius minimal.

## Validation

- `kubectl kustomize components/pipeline-service/staging/<cluster>/resources` output verified byte-identical to committed `deploy.yaml` for all three staging clusters (lightwell-dev, stone-stage-p01, stone-stg-rh01) — only lightwell-dev differs from base.
- Staging-only change; no production impact.

## Risk Assessment

**Risk Level:** Low
**What could go wrong:** Exporter retains more memory; if usage stays between `2Gi`-`4Gi`, pods hold more memory. If it exceeds the new `4Gi` limit it will still be OOMKilled.
**Rollback:** Revert this PR.
**Blast radius:** Single staging cluster (`lightwell-dev`), `pipeline-metrics-exporter` Deployment in `openshift-pipelines`.
