### PR TITLE
fix(KONFLUX-15700): enable secrets creation

### DIFF
--- a/components/image-rbac-proxy/production/kflux-lw-p01/kustomization.yaml
+++ b/components/image-rbac-proxy/production/kflux-lw-p01/kustomization.yaml
@@ -4,7 +4,7 @@ namespace: image-rbac-proxy
 resources:
 - ../base
 # Enable this to create/rotate oauth secret
-# - ../../base/oauth
+- ../../base/oauth
 
 configMapGenerator:
   - name: dex


### PR DESCRIPTION
This change is required in order to fix the issue mentioned in commit msg.
Once this gets deployed in prod, we can revert this change, because we don't need to rotate the secret each deployment cycle.