### PR TITLE
KONFLUX-15403: Enable PostgreSQL monitoring on kube-shard APIShard

### DIFF
--- a/components/kube-shard/rings/ring-1/base/konflux-tekton-shard-apishard.yaml
+++ b/components/kube-shard/rings/ring-1/base/konflux-tekton-shard-apishard.yaml
@@ -74,4 +74,6 @@ spec:
           cpu: "2"
           memory: 12Gi
     type: InClusterPostgreSQL
+    monitoring:
+      enabled: true
   targetNamespace: kube-shard-operator-tekton


### PR DESCRIPTION
## What

- Enable `spec.storage.monitoring` on the `konflux-tekton-shard` APIShard

Clusters affected: lightwell-dev

[KONFLUX-15403](https://redhat.atlassian.net/browse/KONFLUX-15403)

## Why

Expose PostgreSQL health and bloat metrics via the kube-shard OTel collector so shard storage can be monitored on lightwell-dev.

## Validation

- `kustomize build --enable-helm components/kube-shard/rings/ring-1/lightwell-dev` succeeds
- Rendered APIShard includes `storage.monitoring.enabled: true`

## Risk Assessment

**Risk Level:** Low
**What could go wrong:** The OTel collector may fail to start or scrape (image pull, TLS/CA, or scrape errors). Monitoring is non-blocking in the operator, so shard API availability should not be affected; metrics would be missing until it recovers.
**Rollback:** Revert PR (ArgoCD resyncs `monitoring.enabled: false` / omitted; operator should tear down the collector).
**Blast radius:** lightwell-dev only (rd-staging ring-1).

Made with [Cursor](https://cursor.com)

[KONFLUX-15403]: https://redhat.atlassian.net/browse/KONFLUX-15403?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ