### PR TITLE
KFLUXINFRA-4495: Add kflux-lw-p01 to monitoring-blackbox ApplicationSet

### DIFF
--- a/argo-cd-apps/base/monitoring-blackbox/monitoring-blackbox.yaml
+++ b/argo-cd-apps/base/monitoring-blackbox/monitoring-blackbox.yaml
@@ -39,6 +39,8 @@ spec:
                   values.clusterDir: stone-prod-p02
                 - nameNormalized: kflux-fedora-01
                   values.clusterDir: kflux-fedora-01
+                - nameNormalized: kflux-lw-p01
+                  values.clusterDir: kflux-lw-p01
   template:
     metadata:
       name: monitoring-blackbox-{{nameNormalized}}

--- a/components/monitoring/blackbox/production/kflux-lw-p01/kustomization.yaml
+++ b/components/monitoring/blackbox/production/kflux-lw-p01/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+ - https://github.com/redhat-appstudio/internal-infra-deployments/components/monitoring/blackbox-exporter/production/private/kflux-lw-p01?ref=7211c813b185f9bcc5fdaa66e3c333fd0b2565fb
+
+namespace: appstudio-monitoring


### PR DESCRIPTION
## What

Add `kflux-lw-p01` to the `monitoring-blackbox` ApplicationSet and create the production cluster overlay directory.

Clusters affected: kflux-lw-p01

[KFLUXINFRA-4495](https://redhat.atlassian.net/browse/KFLUXINFRA-4495)

Changes:
- `argo-cd-apps/base/monitoring-blackbox/monitoring-blackbox.yaml` — add `kflux-lw-p01` to the merge list generator so its `clusterDir` resolves to `kflux-lw-p01` instead of the non-existent default `base`
- `components/monitoring/blackbox/production/kflux-lw-p01/kustomization.yaml` — new cluster overlay referencing `internal-infra-deployments` at `7211c813` ([internal-infra-deployments#142](https://github.com/redhat-appstudio/internal-infra-deployments/pull/142), now merged)

## Why

After `kflux-lw-p01` was registered in ArgoCD, the `monitoring-blackbox` ApplicationSet began failing manifest generation:

```
Failed to load target state: failed to generate manifest for source 1 of 1:
rpc error: code = Unknown desc = Manifest generation error (cached):
components/monitoring/blackbox/production/base: app path does not exist
```

The `clusters` generator matched `kflux-lw-p01` but since it was not in the `list` generator, the default `clusterDir: base` was used, producing the invalid path `production/base`.

## Validation

- `kustomize build argo-cd-apps/base/monitoring-blackbox/` succeeds
- `kustomize build --enable-helm components/monitoring/blackbox/production/kflux-lw-p01/` succeeds (32 resources)

## Risk Assessment

**Risk Level:** Low
**What could go wrong:** Blackbox probes misconfigured for kflux-lw-p01 — would produce false alerts, no impact on other clusters.
**Rollback:** Revert PR.
**Blast radius:** kflux-lw-p01 only. Resolves an existing ArgoCD manifest generation error.

[KFLUXINFRA-4495]: https://redhat.atlassian.net/browse/KFLUXINFRA-4495?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ