### PR TITLE
Migrate notification-controller production to ring deployments

### DIFF
--- a/argo-cd-apps/overlays/rd-production/kustomization.yaml
+++ b/argo-cd-apps/overlays/rd-production/kustomization.yaml
@@ -11,6 +11,7 @@ resources:
   - konflux-operator
   - kueue
   - multi-platform-controller
+  - notification-controller
   - repository-validator
 
 components:

--- a/argo-cd-apps/overlays/rd-production/notification-controller/kustomization.yaml
+++ b/argo-cd-apps/overlays/rd-production/notification-controller/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - notification-controller-appset.yaml

--- a/argo-cd-apps/overlays/rd-production/notification-controller/notification-controller-appset.yaml
+++ b/argo-cd-apps/overlays/rd-production/notification-controller/notification-controller-appset.yaml
@@ -1,0 +1,48 @@
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: notification-controller
+  labels:
+    appstudio.redhat.com/internal-only: "true"
+    appstudio.redhat.com/deployment-clusters: "tenant"
+spec:
+  generators:
+    - merge:
+        mergeKeys:
+          - nameNormalized
+        generators:
+          - clusters:
+              selector:
+                matchExpressions: # k-components will replace this with the correct selector
+                  - key: appstudio.redhat.com/select-none
+                    operator: Exists
+                  - key: appstudio.redhat.com/select-none
+                    operator: DoesNotExist
+              values:
+                sourceRoot: components/notification-controller-rd
+                ring: "empty-base"
+                clusterDir: "empty-base"
+          - list:
+              elements: [] # Populated via k-components
+  template:
+    metadata:
+      name: notification-controller-{{nameNormalized}}
+    spec:
+      project: default
+      source:
+        path: '{{values.sourceRoot}}/rings/{{values.ring}}/{{values.clusterDir}}'
+        repoURL: https://github.com/redhat-appstudio/infra-deployments.git
+        targetRevision: main
+      destination:
+        namespace: notification-controller
+        server: '{{server}}'
+      syncPolicy:
+        # automated:
+        #   prune: true
+        #   selfHeal: true
+        syncOptions:
+          - CreateNamespace=true
+        retry:
+          limit: 50
+          backoff:
+            duration: 15s

--- a/components/notification-controller-rd/rings/ring-2/base/aws-sns-es.yaml
+++ b/components/notification-controller-rd/rings/ring-2/base/aws-sns-es.yaml
@@ -1,0 +1,19 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: aws-sns-secret
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  dataFrom:
+    - extract:
+        key: production/pipelinerun-results-notifier/sns_secret
+  refreshInterval: 5m
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: appsre-stonesoup-vault
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    name: aws-sns-secret

--- a/components/notification-controller-rd/rings/ring-2/base/kustomization.yaml
+++ b/components/notification-controller-rd/rings/ring-2/base/kustomization.yaml
@@ -1,0 +1,27 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: notification-controller
+
+resources:
+- https://github.com/konflux-ci/notification-service/config/default?ref=813f902b2df56da644170ecbab5b438fc88dd9be
+- aws-sns-es.yaml
+
+images:
+  - name: quay.io/konflux-ci/notification-service
+    newName: quay.io/konflux-ci/notification-service
+    newTag: 813f902b2df56da644170ecbab5b438fc88dd9be
+
+patches:
+  - path: patches/topic_region_add-patch.yaml
+    target:
+      name: notification-controller-controller-manager
+      kind: Deployment
+  - path: patches/increase-memory-patch.yaml
+    target:
+      name: notification-controller-controller-manager
+      kind: Deployment
+  - path: patches/pipelinerun_filters-patch.yaml
+    target:
+      name: notification-controller-controller-manager
+      kind: Deployment

--- a/components/notification-controller-rd/rings/ring-2/base/patches/increase-memory-patch.yaml
+++ b/components/notification-controller-rd/rings/ring-2/base/patches/increase-memory-patch.yaml
@@ -1,0 +1,7 @@
+---
+- op: replace
+  path: /spec/template/spec/containers/0/resources/limits/memory
+  value: "1Gi"
+- op: replace
+  path: /spec/template/spec/containers/0/resources/requests/memory
+  value: "1Gi"

--- a/components/notification-controller-rd/rings/ring-2/base/patches/pipelinerun_filters-patch.yaml
+++ b/components/notification-controller-rd/rings/ring-2/base/patches/pipelinerun_filters-patch.yaml
@@ -1,0 +1,11 @@
+---
+- op: add
+  path: /spec/template/spec/containers/0/env/-
+  value:
+    name: NOTIFICATION_FILTER_LABELS
+    value: "pipelinesascode.tekton.dev/event-type=push"
+- op: add
+  path: /spec/template/spec/containers/0/env/-
+  value:
+    name: NOTIFICATION_FILTER_ANNOTATIONS
+    value: "art-jenkins-job-url"

--- a/components/notification-controller-rd/rings/ring-2/base/patches/topic_region_add-patch.yaml
+++ b/components/notification-controller-rd/rings/ring-2/base/patches/topic_region_add-patch.yaml
@@ -1,0 +1,8 @@
+---
+- op: add
+  path: /spec/template/spec/containers/0/env
+  value:
+    - name: NOTIFICATION_TOPIC_ARN
+      value: "arn:aws:sns:us-east-1:520050076864:scan_topic"
+    - name: NOTIFICATION_REGION
+      value: "us-east-1"

--- a/components/notification-controller-rd/rings/ring-2/kflux-lw-p01/kustomization.yaml
+++ b/components/notification-controller-rd/rings/ring-2/kflux-lw-p01/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../base
+

--- a/components/notification-controller-rd/rings/ring-2/kflux-ocp-p01/kustomization.yaml
+++ b/components/notification-controller-rd/rings/ring-2/kflux-ocp-p01/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../base
+

--- a/components/notification-controller-rd/rings/ring-2/kflux-osp-p01/kustomization.yaml
+++ b/components/notification-controller-rd/rings/ring-2/kflux-osp-p01/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../base
+

--- a/components/notification-controller-rd/rings/ring-2/kflux-rhel-p01/kustomization.yaml
+++ b/components/notification-controller-rd/rings/ring-2/kflux-rhel-p01/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../base
+

--- a/components/notification-controller-rd/rings/ring-2/stone-prod-p01/kustomization.yaml
+++ b/components/notification-controller-rd/rings/ring-2/stone-prod-p01/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../base
+

--- a/components/notification-controller-rd/rings/ring-3/base/aws-sns-es.yaml
+++ b/components/notification-controller-rd/rings/ring-3/base/aws-sns-es.yaml
@@ -1,0 +1,19 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: aws-sns-secret
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  dataFrom:
+    - extract:
+        key: production/pipelinerun-results-notifier/sns_secret
+  refreshInterval: 5m
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: appsre-stonesoup-vault
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    name: aws-sns-secret

--- a/components/notification-controller-rd/rings/ring-3/base/kustomization.yaml
+++ b/components/notification-controller-rd/rings/ring-3/base/kustomization.yaml
@@ -1,0 +1,27 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: notification-controller
+
+resources:
+- https://github.com/konflux-ci/notification-service/config/default?ref=813f902b2df56da644170ecbab5b438fc88dd9be
+- aws-sns-es.yaml
+
+images:
+  - name: quay.io/konflux-ci/notification-service
+    newName: quay.io/konflux-ci/notification-service
+    newTag: 813f902b2df56da644170ecbab5b438fc88dd9be
+
+patches:
+  - path: patches/topic_region_add-patch.yaml
+    target:
+      name: notification-controller-controller-manager
+      kind: Deployment
+  - path: patches/increase-memory-patch.yaml
+    target:
+      name: notification-controller-controller-manager
+      kind: Deployment
+  - path: patches/pipelinerun_filters-patch.yaml
+    target:
+      name: notification-controller-controller-manager
+      kind: Deployment

--- a/components/notification-controller-rd/rings/ring-3/base/patches/increase-memory-patch.yaml
+++ b/components/notification-controller-rd/rings/ring-3/base/patches/increase-memory-patch.yaml
@@ -1,0 +1,7 @@
+---
+- op: replace
+  path: /spec/template/spec/containers/0/resources/limits/memory
+  value: "1Gi"
+- op: replace
+  path: /spec/template/spec/containers/0/resources/requests/memory
+  value: "1Gi"

--- a/components/notification-controller-rd/rings/ring-3/base/patches/pipelinerun_filters-patch.yaml
+++ b/components/notification-controller-rd/rings/ring-3/base/patches/pipelinerun_filters-patch.yaml
@@ -1,0 +1,11 @@
+---
+- op: add
+  path: /spec/template/spec/containers/0/env/-
+  value:
+    name: NOTIFICATION_FILTER_LABELS
+    value: "pipelinesascode.tekton.dev/event-type=push"
+- op: add
+  path: /spec/template/spec/containers/0/env/-
+  value:
+    name: NOTIFICATION_FILTER_ANNOTATIONS
+    value: "art-jenkins-job-url"

--- a/components/notification-controller-rd/rings/ring-3/base/patches/topic_region_add-patch.yaml
+++ b/components/notification-controller-rd/rings/ring-3/base/patches/topic_region_add-patch.yaml
@@ -1,0 +1,8 @@
+---
+- op: add
+  path: /spec/template/spec/containers/0/env
+  value:
+    - name: NOTIFICATION_TOPIC_ARN
+      value: "arn:aws:sns:us-east-1:520050076864:scan_topic"
+    - name: NOTIFICATION_REGION
+      value: "us-east-1"

--- a/components/notification-controller-rd/rings/ring-3/stone-prod-p02/kustomization.yaml
+++ b/components/notification-controller-rd/rings/ring-3/stone-prod-p02/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../base
+

--- a/components/notification-controller-rd/rings/ring-4/base/kustomization.yaml
+++ b/components/notification-controller-rd/rings/ring-4/base/kustomization.yaml
@@ -1,0 +1,3 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources: []


### PR DESCRIPTION
- Add ring-2 (kflux-lw-p01, kflux-ocp-p01, kflux-osp-p01, kflux-rhel-p01, stone-prod-p01) and ring-3 (stone-prod-p02) with production config (SNS ARN, vault path, memory limits, pipelinerun filters)
- Add rd-production ApplicationSet with internal-only + tenant labels
- Rendered output matches existing production/ overlay exactly

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>