### PR TITLE
KONFLUX-15403: Update kube-shard to 91964cb for pgstattuple_approx bloat metrics

### DIFF
--- a/components/kube-shard/rings/ring-1/base/kustomization.yaml
+++ b/components/kube-shard/rings/ring-1/base/kustomization.yaml
@@ -2,10 +2,10 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - base-snapshot
-- https://github.com/konflux-ci/kube-shard/operator/config/default?ref=9e2da554f84da6ae593bbe66cbf3a5a4281bc8ec
+- https://github.com/konflux-ci/kube-shard/operator/config/default?ref=91964cb3c5e65c071bfaf56f106b8750608cae6d
 - konflux-tekton-shard-apishard.yaml
 
 images:
 - name: localhost/controller
   newName: quay.io/konflux-ci/kube-shard
-  newTag: 9e2da554f84da6ae593bbe66cbf3a5a4281bc8ec
+  newTag: 91964cb3c5e65c071bfaf56f106b8750608cae6d


### PR DESCRIPTION
## What

- Bump kube-shard operator image/ref from `9e2da554f84da6ae593bbe66cbf3a5a4281bc8ec` to `91964cb3c5e65c071bfaf56f106b8750608cae6d`

Clusters affected: lightwell-dev

[KONFLUX-15403](https://redhat.atlassian.net/browse/KONFLUX-15403)

## Why

Pick up the operator change that uses `pgstattuple_approx` instead of `pgstattuple` for PostgreSQL bloat metrics, so scraping does not full-scan large databases and cause I/O contention.

Upstream delta: https://github.com/konflux-ci/kube-shard/compare/9e2da554f84da6ae593bbe66cbf3a5a4281bc8ec...91964cb3c5e65c071bfaf56f106b8750608cae6d

## Validation

- `kustomize build --enable-helm components/kube-shard/rings/ring-1/lightwell-dev` succeeds
- Rendered operator image is `quay.io/konflux-ci/kube-shard:91964cb3c5e65c071bfaf56f106b8750608cae6d`

## Risk Assessment

**Risk Level:** Low
**What could go wrong:** The operator rollout restarts the controller, or bloat metrics become approximate/missing if `pgstattuple_approx` behaves unexpectedly on TOAST-heavy Kine tables. This change is monitoring-only and is intended to reduce scrape I/O; Tekton API availability should not be affected.
**Rollback:** Revert PR (ArgoCD resyncs previous operator pin `9e2da554f84da6ae593bbe66cbf3a5a4281bc8ec`).
**Blast radius:** lightwell-dev only (rd-staging ring-1).

Made with [Cursor](https://cursor.com)

[KONFLUX-15403]: https://redhat.atlassian.net/browse/KONFLUX-15403?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ