### PR TITLE
Revert "fix(KONFLUX-15700): enable secrets creation"

### DIFF
--- a/components/image-rbac-proxy/production/kflux-lw-p01/kustomization.yaml
+++ b/components/image-rbac-proxy/production/kflux-lw-p01/kustomization.yaml
@@ -4,7 +4,7 @@ namespace: image-rbac-proxy
 resources:
 - ../base
 # Enable this to create/rotate oauth secret
-- ../../base/oauth
+# - ../../base/oauth
 
 configMapGenerator:
   - name: dex


### PR DESCRIPTION
Reverts redhat-appstudio/infra-deployments#13964

Disabling the auto-rotation of the oauth secret as per the other clusters.