### PR TITLE
PVO11Y-5532 Add konflux-o11y-admins group for kflux-lw-p01

### DIFF
--- a/components/monitoring/prometheus/production/kflux-lw-p01/kustomization.yaml
+++ b/components/monitoring/prometheus/production/kflux-lw-p01/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
 - ../base
 - cluster-monitoring-config.yaml
+- o11y-admins-group.yaml
 patches:
   - path: cluster-id-label.yaml
     target:

--- a/components/monitoring/prometheus/production/kflux-lw-p01/o11y-admins-group.yaml
+++ b/components/monitoring/prometheus/production/kflux-lw-p01/o11y-admins-group.yaml
@@ -1,0 +1,10 @@
+---
+# No Rover group sync on this IBM ROKS cluster, so the konflux-o11y-admins
+# bindings in ../../base/rbac and ../../base/uwm-config have no members.
+# Usernames must match `oc auth whoami` exactly.
+apiVersion: user.openshift.io/v1
+kind: Group
+metadata:
+  name: konflux-o11y-admins
+users:
+  - IAM#jmicanek


### PR DESCRIPTION
## What

Declare `Group/konflux-o11y-admins` in the kflux-lw-p01 prometheus overlay, seeded with a single member for testing. No new roles or bindings.

Clusters affected: kflux-lw-p01

## Why

kflux-lw-p01 is an IBM ROKS cluster authenticated via IBM Cloud IAM and has no Rover group sync, so no Group objects exist and every `kind: Group` subject resolves to nobody. The `konflux-o11y-admins` bindings are already deployed there but have no members, leaving the o11y team without access to the namespaces it owns.

## Validation

- `kustomize build components/monitoring/prometheus/production/kflux-lw-p01` passes; the Group renders alongside the 4 existing `konflux-o11y-admins` bindings.
- Bindings confirmed live on-cluster: ClusterRole `o11y-admins-cluster-view` exists.
- Absence of groups confirmed: admin-checker CronJob logs `groups.user.openshift.io "cluster-admins" not found`.

## Risk Assessment

**Risk Level:** Low
**What could go wrong:** The Group either resolves, granting one person the already-committed permissions, or is inert. It adds no roles or bindings and cannot widen an existing grant.
**Rollback:** Revert PR + Argo sync.
**Blast radius:** One cluster, kflux-lw-p01. Single-cluster change, so ring splitting does not apply.