### PR TITLE
PVO11Y-5536 Deploy cardinality exporter to kflux-lw-p01

### DIFF
--- a/argo-cd-apps/base/member/infra-deployments/monitoring-cardinality/monitoring-cardinality.yaml
+++ b/argo-cd-apps/base/member/infra-deployments/monitoring-cardinality/monitoring-cardinality.yaml
@@ -42,6 +42,8 @@ spec:
                   values.clusterDir: kflux-fedora-01
                 - nameNormalized: kflux-prd-es01
                   values.clusterDir: kflux-prd-es01
+                - nameNormalized: kflux-lw-p01
+                  values.clusterDir: kflux-lw-p01
   template:
     metadata:
       name: monitoring-cardinality-{{nameNormalized}}

--- a/components/monitoring/exporters/cardinality/production/kflux-lw-p01/kustomization.yaml
+++ b/components/monitoring/exporters/cardinality/production/kflux-lw-p01/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - ../base

--- a/components/monitoring/prometheus/production/kflux-lw-p01/writeRelabelConfigs.yaml
+++ b/components/monitoring/prometheus/production/kflux-lw-p01/writeRelabelConfigs.yaml
@@ -6,7 +6,9 @@
     sourceLabels: [__name__]
     # Remote-write only Prometheus status metrics to RHOBS so service-level
     # alerts do not fire for this Lightwell cluster (PVO11Y-5532).
-    regex: prometheus_.+|promhttp_.+
+    # Cardinality exporter metrics are also forwarded for cardinality
+    # analysis of this cluster's Prometheus instances (PVO11Y-5536).
+    regex: prometheus_.+|promhttp_.+|cardinality_exporter_.+
   - action: LabelKeep
     # Labels allowlisted for remote-write to RHOBS.
     # Each line in the regex below corresponds to one group.


### PR DESCRIPTION
## Summary
- Deploy the cardinality exporter to the kflux-lw-p01 Lightwell production cluster
- Allowlist `cardinality_exporter_*` in the federation remote-write config so the metrics reach RHOBS (this cluster otherwise restricts remote-write to Prometheus self-metrics per PVO11Y-5532)

## Risk Assessment
**Level:** Low
**What could go wrong:** Exporter pod fails to start or can't reach Prometheus endpoints; extra series add negligible remote-write volume
**Rollback:** Revert this PR — ArgoCD prunes the cardinality exporter resources and restores the prior remote-write filter
**Blast radius:** kflux-lw-p01 only

## Validation
Same deployment already running on lightwell-dev (#13502) and Ring 1 production clusters. `kustomize build` succeeds for both changed overlays; the rendered MonitoringStack shows `cardinality_exporter_.+` in the remote-write Keep regex.