### PR TITLE
PVO11Y-5538 Enable Tekton MS Prometheus on kflux-lw-p01

### DIFF
--- a/components/monitoring/prometheus/production/kflux-lw-p01/kustomization.yaml
+++ b/components/monitoring/prometheus/production/kflux-lw-p01/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - ../base
+- ../tekton-ms
 - cluster-monitoring-config.yaml
 patches:
   - path: cluster-id-label.yaml
@@ -13,6 +14,20 @@ patches:
   - path: writeRelabelConfigs.yaml
     target:
       name: appstudio-federate-ms
+      kind: MonitoringStack
+      group: monitoring.rhobs
+      version: v1alpha1
+  - path: cluster-id-label.yaml
+    target:
+      name: appstudio-tekton-ms
+      kind: MonitoringStack
+      group: monitoring.rhobs
+      version: v1alpha1
+  # ROKS uses IBM Cloud block storage; the shared tekton-ms overlay defaults
+  # to AWS gp3, which does not exist on this cluster (PVO11Y-5538).
+  - path: storage-class-patch.yaml
+    target:
+      name: appstudio-tekton-ms
       kind: MonitoringStack
       group: monitoring.rhobs
       version: v1alpha1

--- a/components/monitoring/prometheus/production/kflux-lw-p01/storage-class-patch.yaml
+++ b/components/monitoring/prometheus/production/kflux-lw-p01/storage-class-patch.yaml
@@ -1,0 +1,4 @@
+---
+- op: replace
+  path: /spec/prometheusConfig/persistentVolumeClaim/storageClassName
+  value: ibmc-vpc-block-metro-retain-10iops-tier


### PR DESCRIPTION
## Summary

Enable the dedicated Tekton MonitoringStack (`appstudio-tekton-ms`) on the
kflux-lw-p01 (Lightwell / IBM ROKS) cluster by pulling in the shared
`tekton-ms` overlay from the cluster's prometheus overlay, and override the
PVC storage class from AWS `gp3` to IBM Cloud block storage.

This brings the kube-rbac-proxy sidecar, Tekton metrics collection, and RHOBS
remote-write to the cluster, so the pipeline-service metrics are collected for
Lightwell. This mirrors what staging `lightwell-dev` already runs.

The in-cluster Grafana `prometheus-tekton-ms-ds` datasource wiring (needed for
the pipeline-service dashboard panels to render) is tracked separately under
PVO11Y-5534 and must land after this to be healthy.

## Risk Assessment

**Risk Level:** Medium
**What could go wrong:** If the IBM storage class name is wrong the Prometheus
PVCs stay unbound and the tekton-ms pods stay Pending. The two Prometheus
replicas (8Gi each) run on the default node pool, which has previously seen
memory-pressure evictions on this cluster. RHOBS remote-write of Tekton
metrics is unfiltered, so pipeline-service SLO alerts could fire for this
not-yet-GA cluster.
**Rollback:** Revert PR; ArgoCD resyncs the previous desired state. The
storage class is `*-retain-*`, so PVs are not auto-deleted on revert — orphaned
PVCs may need manual cleanup.
**Blast radius:** production: kflux-lw-p01 only. No shared base or other
cluster is touched.

## Validation

- Staging `lightwell-dev` already runs the identical `tekton-ms` overlay with
  the same `ibmc-vpc-block-metro-retain-10iops-tier` storage-class patch.
- `kustomize build components/monitoring/prometheus/production/kflux-lw-p01`
  renders `appstudio-tekton-ms` with `storageClassName:
  ibmc-vpc-block-metro-retain-10iops-tier` (no `gp3` remaining),
  `source_cluster: kflux-lw-p01`, the `tekton-ms-kube-rbac-proxy`
  deployment/service, and the Tekton RHOBS remote-write config. The
  `appstudio-federate-ms` stack is unchanged.