### PR TITLE
PVO11Y-5534 Add Tekton MS datasource to kflux-lw-p01 Grafana

### DIFF
--- a/argo-cd-apps/base/all-clusters/infra-deployments/monitoring-workload-grafana/monitoring-workload-grafana.yaml
+++ b/argo-cd-apps/base/all-clusters/infra-deployments/monitoring-workload-grafana/monitoring-workload-grafana.yaml
@@ -41,6 +41,8 @@ spec:
                   values.clusterDir: kflux-fedora-01
                 - nameNormalized: kflux-prd-es01
                   values.clusterDir: kflux-prd-es01
+                - nameNormalized: kflux-lw-p01
+                  values.clusterDir: kflux-lw-p01
   template:
     metadata:
       name: monitoring-workload-grafana-{{nameNormalized}}

--- a/components/monitoring/grafana/production/kflux-lw-p01/kustomization.yaml
+++ b/components/monitoring/grafana/production/kflux-lw-p01/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../base
+  - ../tekton-ms-datasource


### PR DESCRIPTION
## Summary

The in-cluster Grafana on kflux-lw-p01 (Lightwell / IBM ROKS) currently falls
back to the shared `grafana/production/base` overlay, which does not include
the `prometheus-tekton-ms-ds` datasource. As a result the pipeline-service
dashboard panels backed by Tekton metrics render "No data".

Give the cluster its own overlay (`../base` + `../tekton-ms-datasource`) and
register it in the `monitoring-workload-grafana` ApplicationSet so it stops
using the base fallback. This mirrors every other production cluster that runs
the Tekton MS Prometheus.

Depends on PVO11Y-5538 (enables the `appstudio-tekton-ms` Prometheus and its
kube-rbac-proxy service). The datasource stays unhealthy until that lands and
deploys.

## Risk Assessment

**Risk Level:** Low
**What could go wrong:** The new datasource targets
`tekton-ms-kube-rbac-proxy.appstudio-tekton.svc:9091`; until PVO11Y-5538 is
deployed that service does not exist and the datasource shows unhealthy in the
Grafana UI. Existing Grafana, platform datasource, and dashboards are
unaffected — the change only adds one datasource on top of the existing base.
**Rollback:** Revert PR; the ApplicationSet drops kflux-lw-p01 back to the
`base` overlay and ArgoCD resyncs.
**Blast radius:** production: kflux-lw-p01 only. No shared base or other
cluster is touched (purely additive list entry + new cluster dir).

## Validation

- `kustomize build components/monitoring/grafana/production/kflux-lw-p01`
  renders the `prometheus-tekton-ms-ds` GrafanaDatasource pointing at
  `tekton-ms-kube-rbac-proxy.appstudio-tekton.svc:9091`, alongside the existing
  grafana-oauth CR, platform datasource, and pipeline-service dashboards.
- `kustomize build argo-cd-apps/overlays/production-downstream` generates the
  `monitoring-workload-grafana` app for kflux-lw-p01 with
  `clusterDir: kflux-lw-p01` (previously fell through to `base`).