### PR TITLE
(onboarding) Migrate mintmaker to ring deployments ArgoCD

### DIFF
--- a/argo-cd-apps/base/member/infra-deployments/mintmaker/mintmaker.yaml
+++ b/argo-cd-apps/base/member/infra-deployments/mintmaker/mintmaker.yaml
@@ -50,9 +50,7 @@ spec:
         namespace: mintmaker
         server: '{{server}}'
       syncPolicy:
-        automated:
-          prune: true
-          selfHeal: true
+        preserveResourcesOnDeletion: true
         syncOptions:
           - CreateNamespace=true
         retry:

--- a/argo-cd-apps/overlays/development/kustomization.yaml
+++ b/argo-cd-apps/overlays/development/kustomization.yaml
@@ -54,6 +54,16 @@ patches:
       kind: ApplicationSet
       version: v1alpha1
       name: mintmaker
+  - path: delete-preserve-resources-flag-patch.yaml
+    target:
+      kind: ApplicationSet
+      version: v1alpha1
+      name: mintmaker
+  - path: dev-application-auto-sync-patch.yaml
+    target:
+      kind: ApplicationSet
+      version: v1alpha1
+      name: mintmaker
   - path: development-overlay-patch.yaml
     target:
       kind: ApplicationSet

--- a/argo-cd-apps/overlays/rd-dev/delete-legacy-konflux-member-appsets.yaml
+++ b/argo-cd-apps/overlays/rd-dev/delete-legacy-konflux-member-appsets.yaml
@@ -72,3 +72,9 @@ kind: ApplicationSet
 metadata:
   name: policies
 $patch: delete
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: mintmaker
+$patch: delete

--- a/argo-cd-apps/overlays/rd-dev/kustomization.yaml
+++ b/argo-cd-apps/overlays/rd-dev/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
   - etcd-shield
   - konflux-operator
   - kyverno
+  - mintmaker
   - multi-platform-controller
   - policies
 

--- a/argo-cd-apps/overlays/rd-dev/mintmaker/kustomization.yaml
+++ b/argo-cd-apps/overlays/rd-dev/mintmaker/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- mintmaker-appset.yaml

--- a/argo-cd-apps/overlays/rd-dev/mintmaker/mintmaker-appset.yaml
+++ b/argo-cd-apps/overlays/rd-dev/mintmaker/mintmaker-appset.yaml
@@ -1,0 +1,43 @@
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: mintmaker-rd
+spec:
+  generators:
+    - merge:
+        mergeKeys:
+          - nameNormalized
+        generators:
+          - clusters:
+              selector:
+                matchLabels:
+                  appstudio.redhat.com/member-cluster: "true"
+              values:
+                sourceRoot: components/mintmaker-rd
+                ring: "ring-0"
+                clusterDir: base
+          - list:
+              elements: []
+
+  template:
+    metadata:
+      name: mintmaker-{{nameNormalized}}
+    spec:
+      project: default
+      source:
+        path: '{{values.sourceRoot}}/rings/{{values.ring}}/{{values.clusterDir}}'
+        repoURL: https://github.com/redhat-appstudio/infra-deployments.git
+        targetRevision: main
+      destination:
+        namespace: mintmaker
+        server: '{{server}}'
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
+        syncOptions:
+          - CreateNamespace=true
+        retry:
+          limit: 50
+          backoff:
+            duration: 15s

--- a/argo-cd-apps/overlays/rd-staging/kustomization.yaml
+++ b/argo-cd-apps/overlays/rd-staging/kustomization.yaml
@@ -12,6 +12,7 @@ resources:
   - konflux-verifications-rd
   - kube-shard
   - kueue
+  - mintmaker
   - multi-platform-controller
   - notification-controller
   - policies

--- a/argo-cd-apps/overlays/rd-staging/mintmaker/kustomization.yaml
+++ b/argo-cd-apps/overlays/rd-staging/mintmaker/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- mintmaker-appset.yaml

--- a/argo-cd-apps/overlays/rd-staging/mintmaker/mintmaker-appset.yaml
+++ b/argo-cd-apps/overlays/rd-staging/mintmaker/mintmaker-appset.yaml
@@ -1,0 +1,48 @@
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: mintmaker
+  labels:
+    appstudio.redhat.com/deployment-clusters: "tenant"
+spec:
+  generators:
+    - merge:
+        mergeKeys:
+          - nameNormalized
+        generators:
+          - clusters:
+              selector:
+                matchExpressions: # k-components will replace this with the correct selector
+                  - key: appstudio.redhat.com/select-none
+                    operator: Exists
+                  - key: appstudio.redhat.com/select-none
+                    operator: DoesNotExist
+              values:
+                sourceRoot: components/mintmaker-rd
+                ring: "empty-base"
+                clusterDir: "empty-base"
+          - list:
+              elements: [] # Populated via k-components
+
+  template:
+    metadata:
+      name: mintmaker-{{nameNormalized}}
+    spec:
+      project: default
+      source:
+        path: '{{values.sourceRoot}}/rings/{{values.ring}}/{{values.clusterDir}}'
+        repoURL: https://github.com/redhat-appstudio/infra-deployments.git
+        targetRevision: main
+      destination:
+        namespace: mintmaker
+        server: '{{server}}'
+      syncPolicy:
+        # automated:
+        #   prune: true
+        #   selfHeal: true
+        syncOptions:
+          - CreateNamespace=true
+        retry:
+          limit: 50
+          backoff:
+            duration: 15s

--- a/components/mintmaker-rd/OWNERS
+++ b/components/mintmaker-rd/OWNERS
@@ -1,0 +1,15 @@
+# See the OWNERS docs: https://go.k8s.io/owners
+
+approvers:
+- rh-rsaar
+- FernandesMF
+- HozifaWasfy
+- KristianTkacik
+- adelaon
+
+reviewers:
+- rh-rsaar
+- FernandesMF
+- HozifaWasfy
+- KristianTkacik
+- adelaon

--- a/components/mintmaker-rd/base/controller-token-secret.yaml
+++ b/components/mintmaker-rd/base/controller-token-secret.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mintmaker-controller-manager-token
+  labels:
+    mintmaker.appstudio.redhat.com/kite-token: "true"
+  annotations:
+    kubernetes.io/service-account.name: mintmaker-controller-manager
+type: kubernetes.io/service-account-token

--- a/components/mintmaker-rd/base/cronjobs/create-dependency-update-check.yaml
+++ b/components/mintmaker-rd/base/cronjobs/create-dependency-update-check.yaml
@@ -1,0 +1,46 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: create-dependencyupdatecheck
+  namespace: mintmaker
+spec:
+  schedule: "0 */4 * * *" # every 4 hours
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          labels:
+            paas.redhat.com/appcode: MINT-001
+        spec:
+          restartPolicy: Never
+          serviceAccountName: mintmaker-controller-manager
+          containers:
+            - name: origin-cli
+              image: "quay.io/openshift/origin-cli:4.14"
+              imagePullPolicy: IfNotPresent
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  echo 'apiVersion: appstudio.redhat.com/v1alpha1
+                  kind: DependencyUpdateCheck
+                  metadata:
+                    labels:
+                      app.kubernetes.io/name: dependencyupdatecheck
+                      app.kubernetes.io/part-of: mintmaker
+                      app.kubernetes.io/managed-by: kustomize
+                      app.kubernetes.io/created-by: mintmaker
+                    generateName: dependencyupdatecheck-
+                  spec:
+                  ' | oc create -f-
+              resources:
+                requests:
+                  cpu: 100m
+                  memory: 10Mi
+                limits:
+                  cpu: 100m
+                  memory: 100Mi
+              securityContext:
+                runAsNonRoot: true
+                runAsUser: 1001120000
+                readOnlyRootFilesystem: true

--- a/components/mintmaker-rd/base/cronjobs/delete-dependency-update-checks.yaml
+++ b/components/mintmaker-rd/base/cronjobs/delete-dependency-update-checks.yaml
@@ -1,0 +1,70 @@
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: delete-dependencyupdatechecks
+  namespace: mintmaker
+spec:
+  schedule: "0 1,13 * * *"
+  successfulJobsHistoryLimit: 7
+  failedJobsHistoryLimit: 7
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          labels:
+            paas.redhat.com/appcode: MINT-001
+        spec:
+          restartPolicy: Never
+          serviceAccountName: mintmaker-controller-manager
+          volumes:
+            - name: temp-directory
+              emptyDir: {}
+          containers:
+            - name: cleanup
+              command:
+                - /bin/bash
+                - -c
+                - |
+                  set -o pipefail
+
+                  # Deletes processed DependencyUpdateCheck CRs that are older than 48 hours.
+                  NAMESPACE="mintmaker"
+                  CUTOFF_DATE=$(date -u -d '48 hours ago' +"%Y-%m-%dT%H:%M:%SZ")
+                  CRS=$(oc get DependencyUpdateCheck -n $NAMESPACE \
+                    --sort-by=.metadata.creationTimestamp \
+                    -o custom-columns=NAME:.metadata.name,CREATION_TIMESTAMP:.metadata.creationTimestamp,PROCESSED:.metadata.annotations.mintmaker\\.appstudio\\.redhat\\.com/processed \
+                    --no-headers=true)
+
+                  # Loop through each CR and check the criteria
+                  while IFS= read -r CR; do
+                    NAME=$(echo $CR | awk '{print $1}')
+                    CREATION_TIMESTAMP=$(echo $CR | awk '{print $2}')
+                    PROCESSED=$(echo $CR | awk '{print $3}')
+
+                    # Check if the creationTimestamp is older than 48 hours and processed annotation is true
+                    if [[ "$CREATION_TIMESTAMP" < "$CUTOFF_DATE" && "$PROCESSED" == "true" ]]; then
+                      oc delete DependencyUpdateCheck "$NAME" -n $NAMESPACE
+                      echo "Deleted DependencyUpdateCheck: $NAME"
+                    fi
+                  done <<< "$CRS"
+              imagePullPolicy: IfNotPresent
+              image: quay.io/openshift/origin-cli:4.14
+              volumeMounts:
+                - mountPath: /var/tmp
+                  name: temp-directory
+              resources:
+                limits:
+                  cpu: 100m
+                  memory: 300Mi
+                requests:
+                  cpu: 50m
+                  memory: 200Mi
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                  - ALL
+                readOnlyRootFilesystem: true
+                runAsNonRoot: true
+                runAsUser: 1001120000

--- a/components/mintmaker-rd/base/cronjobs/kustomization.yaml
+++ b/components/mintmaker-rd/base/cronjobs/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - create-dependency-update-check.yaml
+  - delete-dependency-update-checks.yaml
+  - mintmaker-schedule-calculator.yaml
+namespace: mintmaker

--- a/components/mintmaker-rd/base/cronjobs/mintmaker-schedule-calculator.yaml
+++ b/components/mintmaker-rd/base/cronjobs/mintmaker-schedule-calculator.yaml
@@ -1,0 +1,36 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: mintmaker-schedule-calculator
+  namespace: mintmaker
+spec:
+  schedule: "0 */4 * * *"
+  concurrencyPolicy: Forbid
+  startingDeadlineSeconds: 300
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          labels:
+            paas.redhat.com/appcode: MINT-001
+        spec:
+          restartPolicy: Never
+          serviceAccountName: mintmaker-schedule-calculator-manager
+          containers:
+            - name: mintmaker-schedule-calculator
+              image: quay.io/konflux-ci/mintmaker-schedule-calculator:dcda93c47b269d9b250ef62b0bd2e2e2f18aea6f
+              imagePullPolicy: IfNotPresent
+              resources:
+                requests:
+                  cpu: 50m
+                  memory: 128Mi
+                limits:
+                  cpu: 100m
+                  memory: 256Mi
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                  - ALL
+                readOnlyRootFilesystem: true
+                runAsNonRoot: true

--- a/components/mintmaker-rd/base/kustomization.yaml
+++ b/components/mintmaker-rd/base/kustomization.yaml
@@ -1,0 +1,10 @@
+resources:
+- cronjobs/
+- rbac/
+- redis-cache/
+- controller-token-secret.yaml
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: mintmaker

--- a/components/mintmaker-rd/base/rbac/kustomization.yaml
+++ b/components/mintmaker-rd/base/rbac/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- mintmaker-team.yaml
+- mintmaker-schedule-calculator-manager.yaml

--- a/components/mintmaker-rd/base/rbac/mintmaker-schedule-calculator-manager.yaml
+++ b/components/mintmaker-rd/base/rbac/mintmaker-schedule-calculator-manager.yaml
@@ -1,0 +1,59 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: mintmaker-schedule-calculator-manager
+  namespace: mintmaker
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: mintmaker-schedule-calculator-manager-role
+  namespace: mintmaker
+rules:
+  - apiGroups:
+      - ''
+    resourceNames:
+      - renovate-config
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - watch
+  - apiGroups:
+      - ''
+    resources:
+      - configmaps
+    verbs:
+      - create
+  - apiGroups:
+      - ''
+    resourceNames:
+      - mintmaker-schedule-calculator-results
+    resources:
+      - configmaps
+    verbs:
+      - update
+      - delete
+  - apiGroups:
+      - batch
+    resourceNames:
+      - create-dependencyupdatecheck
+    resources:
+      - cronjobs
+    verbs:
+      - get
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: mintmaker-schedule-calculator-manager-rolebinding
+  namespace: mintmaker
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: mintmaker-schedule-calculator-manager-role
+subjects:
+  - kind: ServiceAccount
+    name: mintmaker-schedule-calculator-manager
+    namespace: mintmaker

--- a/components/mintmaker-rd/base/rbac/mintmaker-team.yaml
+++ b/components/mintmaker-rd/base/rbac/mintmaker-team.yaml
@@ -1,0 +1,57 @@
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: mintmaker-admin
+  namespace: mintmaker
+rules:
+  - apiGroups:
+      - ''
+    resources:
+      - pods
+      - pods/attach
+      - pods/exec
+      - pods/log
+      - secrets
+      - configmaps
+    verbs:
+      - '*'
+  - apiGroups:
+      - 'batch'
+    resources:
+      - cronjobs
+      - jobs
+    verbs:
+      - '*'
+  - apiGroups:
+      - appstudio.redhat.com
+    resources:
+      - dependencyupdatechecks
+    verbs:
+      - '*'
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: mintmaker-admins
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: konflux-mintmaker-team
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: mintmaker-admin
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: mintmaker-maintainers
+  namespace: mintmaker
+subjects:
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: konflux-mintmaker-team
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: component-maintainer

--- a/components/mintmaker-rd/base/redis-cache/kustomization.yaml
+++ b/components/mintmaker-rd/base/redis-cache/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- redis-configmap.yaml
+- redis-deployment.yaml
+- redis-networkpolicy.yaml
+- redis-pvc.yaml
+- redis-service.yaml
+namespace: mintmaker

--- a/components/mintmaker-rd/base/redis-cache/redis-configmap.yaml
+++ b/components/mintmaker-rd/base/redis-cache/redis-configmap.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redis-config
+  namespace: mintmaker
+data:
+  redis.conf: |
+    bind 0.0.0.0
+    protected-mode no
+    port 6379
+    maxmemory 800mb
+    maxmemory-policy allkeys-lru
+    dir /var/lib/redis/data
+
+    appendonly yes
+    aof-use-rdb-preamble yes
+    appendfsync everysec
+
+    save 900 1
+    save 300 10
+    save 60 10000
+
+    logfile ""
+    loglevel notice

--- a/components/mintmaker-rd/base/redis-cache/redis-deployment.yaml
+++ b/components/mintmaker-rd/base/redis-cache/redis-deployment.yaml
@@ -1,0 +1,72 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis
+  namespace: mintmaker
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: redis
+  template:
+    metadata:
+      labels:
+        app: redis
+        paas.redhat.com/appcode: MINT-001
+    spec:
+      serviceAccountName: mintmaker-controller-manager
+      securityContext:
+        fsGroup: 1001
+      containers:
+        - name: redis
+          image: registry.redhat.io/rhel9/redis-7:9.5
+          ports:
+            - containerPort: 6379
+          command: ["container-entrypoint"]
+          args: ["run-redis"]
+          resources:
+            requests:
+              memory: 250Mi
+              cpu: 50m
+            limits:
+              memory: 800Mi
+              cpu: 300m
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1001
+            readOnlyRootFilesystem: true
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - redis-cli ping | grep -q PONG
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            timeoutSeconds: 15
+            failureThreshold: 5
+          readinessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - redis-cli ping | grep -q PONG
+            initialDelaySeconds: 10
+            periodSeconds: 15
+            timeoutSeconds: 10
+            failureThreshold: 5
+          volumeMounts:
+            - name: redis-data
+              mountPath: /var/lib/redis/data
+            - name: redis-config
+              mountPath: /etc/redis/redis.conf
+              subPath: redis.conf
+      volumes:
+        - name: redis-data
+          persistentVolumeClaim:
+            claimName: redis-pvc
+        - name: redis-config
+          configMap:
+            name: redis-config

--- a/components/mintmaker-rd/base/redis-cache/redis-networkpolicy.yaml
+++ b/components/mintmaker-rd/base/redis-cache/redis-networkpolicy.yaml
@@ -1,0 +1,12 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: restrict-redis-access
+  namespace: mintmaker
+spec:
+  podSelector:
+    matchLabels:
+      app: redis
+  ingress:
+  - from:
+    - podSelector: {}

--- a/components/mintmaker-rd/base/redis-cache/redis-pvc.yaml
+++ b/components/mintmaker-rd/base/redis-cache/redis-pvc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: redis-pvc
+  namespace: mintmaker
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi

--- a/components/mintmaker-rd/base/redis-cache/redis-service.yaml
+++ b/components/mintmaker-rd/base/redis-cache/redis-service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis
+  namespace: mintmaker
+spec:
+  selector:
+    app: redis
+  ports:
+    - port: 6379
+      targetPort: 6379
+  type: ClusterIP

--- a/components/mintmaker-rd/components/rh-certs/add-rh-certs-patch.yaml
+++ b/components/mintmaker-rd/components/rh-certs/add-rh-certs-patch.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mintmaker-controller-manager
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager
+        volumeMounts:
+          - name: trusted-ca
+            mountPath: /etc/pki/ca-trust/extracted/pem
+            readOnly: true
+      volumes:
+      - name: trusted-ca
+        configMap:
+          name: trusted-ca
+          items:
+            - key: ca-bundle.crt
+              path: tls-ca-bundle.pem

--- a/components/mintmaker-rd/components/rh-certs/kustomization.yaml
+++ b/components/mintmaker-rd/components/rh-certs/kustomization.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+patches:
+  - path: add-rh-certs-patch.yaml
+    target:
+      name: mintmaker-controller-manager
+      kind: Deployment
+configMapGenerator:
+  - name: trusted-ca
+    options:
+      labels:
+        "config.openshift.io/inject-trusted-cabundle": "true"
+namespace: mintmaker

--- a/components/mintmaker-rd/rings/empty-base/empty-base/kustomization.yaml
+++ b/components/mintmaker-rd/rings/empty-base/empty-base/kustomization.yaml
@@ -1,0 +1,3 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources: []

--- a/components/mintmaker-rd/rings/ring-0/base/base-snapshot/controller-token-secret.yaml
+++ b/components/mintmaker-rd/rings/ring-0/base/base-snapshot/controller-token-secret.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mintmaker-controller-manager-token
+  labels:
+    mintmaker.appstudio.redhat.com/kite-token: "true"
+  annotations:
+    kubernetes.io/service-account.name: mintmaker-controller-manager
+type: kubernetes.io/service-account-token

--- a/components/mintmaker-rd/rings/ring-0/base/base-snapshot/cronjobs/create-dependency-update-check.yaml
+++ b/components/mintmaker-rd/rings/ring-0/base/base-snapshot/cronjobs/create-dependency-update-check.yaml
@@ -1,0 +1,46 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: create-dependencyupdatecheck
+  namespace: mintmaker
+spec:
+  schedule: "0 */4 * * *" # every 4 hours
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          labels:
+            paas.redhat.com/appcode: MINT-001
+        spec:
+          restartPolicy: Never
+          serviceAccountName: mintmaker-controller-manager
+          containers:
+            - name: origin-cli
+              image: "quay.io/openshift/origin-cli:4.14"
+              imagePullPolicy: IfNotPresent
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  echo 'apiVersion: appstudio.redhat.com/v1alpha1
+                  kind: DependencyUpdateCheck
+                  metadata:
+                    labels:
+                      app.kubernetes.io/name: dependencyupdatecheck
+                      app.kubernetes.io/part-of: mintmaker
+                      app.kubernetes.io/managed-by: kustomize
+                      app.kubernetes.io/created-by: mintmaker
+                    generateName: dependencyupdatecheck-
+                  spec:
+                  ' | oc create -f-
+              resources:
+                requests:
+                  cpu: 100m
+                  memory: 10Mi
+                limits:
+                  cpu: 100m
+                  memory: 100Mi
+              securityContext:
+                runAsNonRoot: true
+                runAsUser: 1001120000
+                readOnlyRootFilesystem: true

--- a/components/mintmaker-rd/rings/ring-0/base/base-snapshot/cronjobs/delete-dependency-update-checks.yaml
+++ b/components/mintmaker-rd/rings/ring-0/base/base-snapshot/cronjobs/delete-dependency-update-checks.yaml
@@ -1,0 +1,70 @@
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: delete-dependencyupdatechecks
+  namespace: mintmaker
+spec:
+  schedule: "0 1,13 * * *"
+  successfulJobsHistoryLimit: 7
+  failedJobsHistoryLimit: 7
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          labels:
+            paas.redhat.com/appcode: MINT-001
+        spec:
+          restartPolicy: Never
+          serviceAccountName: mintmaker-controller-manager
+          volumes:
+            - name: temp-directory
+              emptyDir: {}
+          containers:
+            - name: cleanup
+              command:
+                - /bin/bash
+                - -c
+                - |
+                  set -o pipefail
+
+                  # Deletes processed DependencyUpdateCheck CRs that are older than 48 hours.
+                  NAMESPACE="mintmaker"
+                  CUTOFF_DATE=$(date -u -d '48 hours ago' +"%Y-%m-%dT%H:%M:%SZ")
+                  CRS=$(oc get DependencyUpdateCheck -n $NAMESPACE \
+                    --sort-by=.metadata.creationTimestamp \
+                    -o custom-columns=NAME:.metadata.name,CREATION_TIMESTAMP:.metadata.creationTimestamp,PROCESSED:.metadata.annotations.mintmaker\\.appstudio\\.redhat\\.com/processed \
+                    --no-headers=true)
+
+                  # Loop through each CR and check the criteria
+                  while IFS= read -r CR; do
+                    NAME=$(echo $CR | awk '{print $1}')
+                    CREATION_TIMESTAMP=$(echo $CR | awk '{print $2}')
+                    PROCESSED=$(echo $CR | awk '{print $3}')
+
+                    # Check if the creationTimestamp is older than 48 hours and processed annotation is true
+                    if [[ "$CREATION_TIMESTAMP" < "$CUTOFF_DATE" && "$PROCESSED" == "true" ]]; then
+                      oc delete DependencyUpdateCheck "$NAME" -n $NAMESPACE
+                      echo "Deleted DependencyUpdateCheck: $NAME"
+                    fi
+                  done <<< "$CRS"
+              imagePullPolicy: IfNotPresent
+              image: quay.io/openshift/origin-cli:4.14
+              volumeMounts:
+                - mountPath: /var/tmp
+                  name: temp-directory
+              resources:
+                limits:
+                  cpu: 100m
+                  memory: 300Mi
+                requests:
+                  cpu: 50m
+                  memory: 200Mi
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                  - ALL
+                readOnlyRootFilesystem: true
+                runAsNonRoot: true
+                runAsUser: 1001120000

--- a/components/mintmaker-rd/rings/ring-0/base/base-snapshot/cronjobs/kustomization.yaml
+++ b/components/mintmaker-rd/rings/ring-0/base/base-snapshot/cronjobs/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - create-dependency-update-check.yaml
+  - delete-dependency-update-checks.yaml
+  - mintmaker-schedule-calculator.yaml
+namespace: mintmaker

--- a/components/mintmaker-rd/rings/ring-0/base/base-snapshot/cronjobs/mintmaker-schedule-calculator.yaml
+++ b/components/mintmaker-rd/rings/ring-0/base/base-snapshot/cronjobs/mintmaker-schedule-calculator.yaml
@@ -1,0 +1,36 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: mintmaker-schedule-calculator
+  namespace: mintmaker
+spec:
+  schedule: "0 */4 * * *"
+  concurrencyPolicy: Forbid
+  startingDeadlineSeconds: 300
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          labels:
+            paas.redhat.com/appcode: MINT-001
+        spec:
+          restartPolicy: Never
+          serviceAccountName: mintmaker-schedule-calculator-manager
+          containers:
+            - name: mintmaker-schedule-calculator
+              image: quay.io/konflux-ci/mintmaker-schedule-calculator:dcda93c47b269d9b250ef62b0bd2e2e2f18aea6f
+              imagePullPolicy: IfNotPresent
+              resources:
+                requests:
+                  cpu: 50m
+                  memory: 128Mi
+                limits:
+                  cpu: 100m
+                  memory: 256Mi
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                  - ALL
+                readOnlyRootFilesystem: true
+                runAsNonRoot: true

--- a/components/mintmaker-rd/rings/ring-0/base/base-snapshot/kustomization.yaml
+++ b/components/mintmaker-rd/rings/ring-0/base/base-snapshot/kustomization.yaml
@@ -1,0 +1,10 @@
+resources:
+- cronjobs/
+- rbac/
+- redis-cache/
+- controller-token-secret.yaml
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: mintmaker

--- a/components/mintmaker-rd/rings/ring-0/base/base-snapshot/rbac/kustomization.yaml
+++ b/components/mintmaker-rd/rings/ring-0/base/base-snapshot/rbac/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- mintmaker-team.yaml
+- mintmaker-schedule-calculator-manager.yaml

--- a/components/mintmaker-rd/rings/ring-0/base/base-snapshot/rbac/mintmaker-schedule-calculator-manager.yaml
+++ b/components/mintmaker-rd/rings/ring-0/base/base-snapshot/rbac/mintmaker-schedule-calculator-manager.yaml
@@ -1,0 +1,59 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: mintmaker-schedule-calculator-manager
+  namespace: mintmaker
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: mintmaker-schedule-calculator-manager-role
+  namespace: mintmaker
+rules:
+  - apiGroups:
+      - ''
+    resourceNames:
+      - renovate-config
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - watch
+  - apiGroups:
+      - ''
+    resources:
+      - configmaps
+    verbs:
+      - create
+  - apiGroups:
+      - ''
+    resourceNames:
+      - mintmaker-schedule-calculator-results
+    resources:
+      - configmaps
+    verbs:
+      - update
+      - delete
+  - apiGroups:
+      - batch
+    resourceNames:
+      - create-dependencyupdatecheck
+    resources:
+      - cronjobs
+    verbs:
+      - get
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: mintmaker-schedule-calculator-manager-rolebinding
+  namespace: mintmaker
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: mintmaker-schedule-calculator-manager-role
+subjects:
+  - kind: ServiceAccount
+    name: mintmaker-schedule-calculator-manager
+    namespace: mintmaker

--- a/components/mintmaker-rd/rings/ring-0/base/base-snapshot/rbac/mintmaker-team.yaml
+++ b/components/mintmaker-rd/rings/ring-0/base/base-snapshot/rbac/mintmaker-team.yaml
@@ -1,0 +1,57 @@
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: mintmaker-admin
+  namespace: mintmaker
+rules:
+  - apiGroups:
+      - ''
+    resources:
+      - pods
+      - pods/attach
+      - pods/exec
+      - pods/log
+      - secrets
+      - configmaps
+    verbs:
+      - '*'
+  - apiGroups:
+      - 'batch'
+    resources:
+      - cronjobs
+      - jobs
+    verbs:
+      - '*'
+  - apiGroups:
+      - appstudio.redhat.com
+    resources:
+      - dependencyupdatechecks
+    verbs:
+      - '*'
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: mintmaker-admins
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: konflux-mintmaker-team
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: mintmaker-admin
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: mintmaker-maintainers
+  namespace: mintmaker
+subjects:
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: konflux-mintmaker-team
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: component-maintainer

--- a/components/mintmaker-rd/rings/ring-0/base/base-snapshot/redis-cache/kustomization.yaml
+++ b/components/mintmaker-rd/rings/ring-0/base/base-snapshot/redis-cache/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- redis-configmap.yaml
+- redis-deployment.yaml
+- redis-networkpolicy.yaml
+- redis-pvc.yaml
+- redis-service.yaml
+namespace: mintmaker

--- a/components/mintmaker-rd/rings/ring-0/base/base-snapshot/redis-cache/redis-configmap.yaml
+++ b/components/mintmaker-rd/rings/ring-0/base/base-snapshot/redis-cache/redis-configmap.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redis-config
+  namespace: mintmaker
+data:
+  redis.conf: |
+    bind 0.0.0.0
+    protected-mode no
+    port 6379
+    maxmemory 800mb
+    maxmemory-policy allkeys-lru
+    dir /var/lib/redis/data
+
+    appendonly yes
+    aof-use-rdb-preamble yes
+    appendfsync everysec
+
+    save 900 1
+    save 300 10
+    save 60 10000
+
+    logfile ""
+    loglevel notice

--- a/components/mintmaker-rd/rings/ring-0/base/base-snapshot/redis-cache/redis-deployment.yaml
+++ b/components/mintmaker-rd/rings/ring-0/base/base-snapshot/redis-cache/redis-deployment.yaml
@@ -1,0 +1,72 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis
+  namespace: mintmaker
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: redis
+  template:
+    metadata:
+      labels:
+        app: redis
+        paas.redhat.com/appcode: MINT-001
+    spec:
+      serviceAccountName: mintmaker-controller-manager
+      securityContext:
+        fsGroup: 1001
+      containers:
+        - name: redis
+          image: registry.redhat.io/rhel9/redis-7:9.5
+          ports:
+            - containerPort: 6379
+          command: ["container-entrypoint"]
+          args: ["run-redis"]
+          resources:
+            requests:
+              memory: 250Mi
+              cpu: 50m
+            limits:
+              memory: 800Mi
+              cpu: 300m
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1001
+            readOnlyRootFilesystem: true
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - redis-cli ping | grep -q PONG
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            timeoutSeconds: 15
+            failureThreshold: 5
+          readinessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - redis-cli ping | grep -q PONG
+            initialDelaySeconds: 10
+            periodSeconds: 15
+            timeoutSeconds: 10
+            failureThreshold: 5
+          volumeMounts:
+            - name: redis-data
+              mountPath: /var/lib/redis/data
+            - name: redis-config
+              mountPath: /etc/redis/redis.conf
+              subPath: redis.conf
+      volumes:
+        - name: redis-data
+          persistentVolumeClaim:
+            claimName: redis-pvc
+        - name: redis-config
+          configMap:
+            name: redis-config

--- a/components/mintmaker-rd/rings/ring-0/base/base-snapshot/redis-cache/redis-networkpolicy.yaml
+++ b/components/mintmaker-rd/rings/ring-0/base/base-snapshot/redis-cache/redis-networkpolicy.yaml
@@ -1,0 +1,12 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: restrict-redis-access
+  namespace: mintmaker
+spec:
+  podSelector:
+    matchLabels:
+      app: redis
+  ingress:
+  - from:
+    - podSelector: {}

--- a/components/mintmaker-rd/rings/ring-0/base/base-snapshot/redis-cache/redis-pvc.yaml
+++ b/components/mintmaker-rd/rings/ring-0/base/base-snapshot/redis-cache/redis-pvc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: redis-pvc
+  namespace: mintmaker
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi

--- a/components/mintmaker-rd/rings/ring-0/base/base-snapshot/redis-cache/redis-service.yaml
+++ b/components/mintmaker-rd/rings/ring-0/base/base-snapshot/redis-cache/redis-service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis
+  namespace: mintmaker
+spec:
+  selector:
+    app: redis
+  ports:
+    - port: 6379
+      targetPort: 6379
+  type: ClusterIP

--- a/components/mintmaker-rd/rings/ring-0/base/kustomization.yaml
+++ b/components/mintmaker-rd/rings/ring-0/base/kustomization.yaml
@@ -1,0 +1,32 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+labels:
+- pairs:
+    paas.redhat.com/appcode: MINT-001
+resources:
+  - base-snapshot
+  - plrs-resource-quota.yaml
+  - https://github.com/konflux-ci/mintmaker/config/default?ref=b8b7c25d43e264c57632518a085d4a01a28f7df4
+  - https://github.com/konflux-ci/mintmaker/config/renovate?ref=b8b7c25d43e264c57632518a085d4a01a28f7df4
+
+images:
+  - name: quay.io/konflux-ci/mintmaker
+    newName: quay.io/konflux-ci/mintmaker
+    newTag: b8b7c25d43e264c57632518a085d4a01a28f7df4
+  - name: quay.io/konflux-ci/mintmaker-renovate-image
+    newName: quay.io/konflux-ci/mintmaker-renovate-image
+    newTag: latest
+  - name: quay.io/konflux-ci/mintmaker-schedule-calculator
+    newName: quay.io/konflux-ci/mintmaker-schedule-calculator
+    newTag: dcda93c47b269d9b250ef62b0bd2e2e2f18aea6f
+
+namespace: mintmaker
+
+commonAnnotations:
+  argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+
+configurations:
+- kustomizeconfig.yaml
+
+components:
+  - ../../../components/rh-certs

--- a/components/mintmaker-rd/rings/ring-0/base/kustomizeconfig.yaml
+++ b/components/mintmaker-rd/rings/ring-0/base/kustomizeconfig.yaml
@@ -1,0 +1,3 @@
+images:
+- path: spec/template/metadata/annotations/mintmaker.appstudio.redhat.com\/renovate-image
+  kind: Deployment

--- a/components/mintmaker-rd/rings/ring-0/base/plrs-resource-quota.yaml
+++ b/components/mintmaker-rd/rings/ring-0/base/plrs-resource-quota.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: pipelineruns-resource-quota
+  namespace: mintmaker
+spec:
+  hard:
+    count/pipelineruns.tekton.dev: "5000"

--- a/components/mintmaker-rd/rings/ring-1/base/base-snapshot/controller-token-secret.yaml
+++ b/components/mintmaker-rd/rings/ring-1/base/base-snapshot/controller-token-secret.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mintmaker-controller-manager-token
+  labels:
+    mintmaker.appstudio.redhat.com/kite-token: "true"
+  annotations:
+    kubernetes.io/service-account.name: mintmaker-controller-manager
+type: kubernetes.io/service-account-token

--- a/components/mintmaker-rd/rings/ring-1/base/base-snapshot/cronjobs/create-dependency-update-check.yaml
+++ b/components/mintmaker-rd/rings/ring-1/base/base-snapshot/cronjobs/create-dependency-update-check.yaml
@@ -1,0 +1,46 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: create-dependencyupdatecheck
+  namespace: mintmaker
+spec:
+  schedule: "0 */4 * * *" # every 4 hours
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          labels:
+            paas.redhat.com/appcode: MINT-001
+        spec:
+          restartPolicy: Never
+          serviceAccountName: mintmaker-controller-manager
+          containers:
+            - name: origin-cli
+              image: "quay.io/openshift/origin-cli:4.14"
+              imagePullPolicy: IfNotPresent
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  echo 'apiVersion: appstudio.redhat.com/v1alpha1
+                  kind: DependencyUpdateCheck
+                  metadata:
+                    labels:
+                      app.kubernetes.io/name: dependencyupdatecheck
+                      app.kubernetes.io/part-of: mintmaker
+                      app.kubernetes.io/managed-by: kustomize
+                      app.kubernetes.io/created-by: mintmaker
+                    generateName: dependencyupdatecheck-
+                  spec:
+                  ' | oc create -f-
+              resources:
+                requests:
+                  cpu: 100m
+                  memory: 10Mi
+                limits:
+                  cpu: 100m
+                  memory: 100Mi
+              securityContext:
+                runAsNonRoot: true
+                runAsUser: 1001120000
+                readOnlyRootFilesystem: true

--- a/components/mintmaker-rd/rings/ring-1/base/base-snapshot/cronjobs/delete-dependency-update-checks.yaml
+++ b/components/mintmaker-rd/rings/ring-1/base/base-snapshot/cronjobs/delete-dependency-update-checks.yaml
@@ -1,0 +1,70 @@
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: delete-dependencyupdatechecks
+  namespace: mintmaker
+spec:
+  schedule: "0 1,13 * * *"
+  successfulJobsHistoryLimit: 7
+  failedJobsHistoryLimit: 7
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          labels:
+            paas.redhat.com/appcode: MINT-001
+        spec:
+          restartPolicy: Never
+          serviceAccountName: mintmaker-controller-manager
+          volumes:
+            - name: temp-directory
+              emptyDir: {}
+          containers:
+            - name: cleanup
+              command:
+                - /bin/bash
+                - -c
+                - |
+                  set -o pipefail
+
+                  # Deletes processed DependencyUpdateCheck CRs that are older than 48 hours.
+                  NAMESPACE="mintmaker"
+                  CUTOFF_DATE=$(date -u -d '48 hours ago' +"%Y-%m-%dT%H:%M:%SZ")
+                  CRS=$(oc get DependencyUpdateCheck -n $NAMESPACE \
+                    --sort-by=.metadata.creationTimestamp \
+                    -o custom-columns=NAME:.metadata.name,CREATION_TIMESTAMP:.metadata.creationTimestamp,PROCESSED:.metadata.annotations.mintmaker\\.appstudio\\.redhat\\.com/processed \
+                    --no-headers=true)
+
+                  # Loop through each CR and check the criteria
+                  while IFS= read -r CR; do
+                    NAME=$(echo $CR | awk '{print $1}')
+                    CREATION_TIMESTAMP=$(echo $CR | awk '{print $2}')
+                    PROCESSED=$(echo $CR | awk '{print $3}')
+
+                    # Check if the creationTimestamp is older than 48 hours and processed annotation is true
+                    if [[ "$CREATION_TIMESTAMP" < "$CUTOFF_DATE" && "$PROCESSED" == "true" ]]; then
+                      oc delete DependencyUpdateCheck "$NAME" -n $NAMESPACE
+                      echo "Deleted DependencyUpdateCheck: $NAME"
+                    fi
+                  done <<< "$CRS"
+              imagePullPolicy: IfNotPresent
+              image: quay.io/openshift/origin-cli:4.14
+              volumeMounts:
+                - mountPath: /var/tmp
+                  name: temp-directory
+              resources:
+                limits:
+                  cpu: 100m
+                  memory: 300Mi
+                requests:
+                  cpu: 50m
+                  memory: 200Mi
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                  - ALL
+                readOnlyRootFilesystem: true
+                runAsNonRoot: true
+                runAsUser: 1001120000

--- a/components/mintmaker-rd/rings/ring-1/base/base-snapshot/cronjobs/kustomization.yaml
+++ b/components/mintmaker-rd/rings/ring-1/base/base-snapshot/cronjobs/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - create-dependency-update-check.yaml
+  - delete-dependency-update-checks.yaml
+  - mintmaker-schedule-calculator.yaml
+namespace: mintmaker

--- a/components/mintmaker-rd/rings/ring-1/base/base-snapshot/cronjobs/mintmaker-schedule-calculator.yaml
+++ b/components/mintmaker-rd/rings/ring-1/base/base-snapshot/cronjobs/mintmaker-schedule-calculator.yaml
@@ -1,0 +1,36 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: mintmaker-schedule-calculator
+  namespace: mintmaker
+spec:
+  schedule: "0 */4 * * *"
+  concurrencyPolicy: Forbid
+  startingDeadlineSeconds: 300
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          labels:
+            paas.redhat.com/appcode: MINT-001
+        spec:
+          restartPolicy: Never
+          serviceAccountName: mintmaker-schedule-calculator-manager
+          containers:
+            - name: mintmaker-schedule-calculator
+              image: quay.io/konflux-ci/mintmaker-schedule-calculator:dcda93c47b269d9b250ef62b0bd2e2e2f18aea6f
+              imagePullPolicy: IfNotPresent
+              resources:
+                requests:
+                  cpu: 50m
+                  memory: 128Mi
+                limits:
+                  cpu: 100m
+                  memory: 256Mi
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                  - ALL
+                readOnlyRootFilesystem: true
+                runAsNonRoot: true

--- a/components/mintmaker-rd/rings/ring-1/base/base-snapshot/kustomization.yaml
+++ b/components/mintmaker-rd/rings/ring-1/base/base-snapshot/kustomization.yaml
@@ -1,0 +1,10 @@
+resources:
+- cronjobs/
+- rbac/
+- redis-cache/
+- controller-token-secret.yaml
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: mintmaker

--- a/components/mintmaker-rd/rings/ring-1/base/base-snapshot/rbac/kustomization.yaml
+++ b/components/mintmaker-rd/rings/ring-1/base/base-snapshot/rbac/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- mintmaker-team.yaml
+- mintmaker-schedule-calculator-manager.yaml

--- a/components/mintmaker-rd/rings/ring-1/base/base-snapshot/rbac/mintmaker-schedule-calculator-manager.yaml
+++ b/components/mintmaker-rd/rings/ring-1/base/base-snapshot/rbac/mintmaker-schedule-calculator-manager.yaml
@@ -1,0 +1,59 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: mintmaker-schedule-calculator-manager
+  namespace: mintmaker
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: mintmaker-schedule-calculator-manager-role
+  namespace: mintmaker
+rules:
+  - apiGroups:
+      - ''
+    resourceNames:
+      - renovate-config
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - watch
+  - apiGroups:
+      - ''
+    resources:
+      - configmaps
+    verbs:
+      - create
+  - apiGroups:
+      - ''
+    resourceNames:
+      - mintmaker-schedule-calculator-results
+    resources:
+      - configmaps
+    verbs:
+      - update
+      - delete
+  - apiGroups:
+      - batch
+    resourceNames:
+      - create-dependencyupdatecheck
+    resources:
+      - cronjobs
+    verbs:
+      - get
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: mintmaker-schedule-calculator-manager-rolebinding
+  namespace: mintmaker
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: mintmaker-schedule-calculator-manager-role
+subjects:
+  - kind: ServiceAccount
+    name: mintmaker-schedule-calculator-manager
+    namespace: mintmaker

--- a/components/mintmaker-rd/rings/ring-1/base/base-snapshot/rbac/mintmaker-team.yaml
+++ b/components/mintmaker-rd/rings/ring-1/base/base-snapshot/rbac/mintmaker-team.yaml
@@ -1,0 +1,57 @@
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: mintmaker-admin
+  namespace: mintmaker
+rules:
+  - apiGroups:
+      - ''
+    resources:
+      - pods
+      - pods/attach
+      - pods/exec
+      - pods/log
+      - secrets
+      - configmaps
+    verbs:
+      - '*'
+  - apiGroups:
+      - 'batch'
+    resources:
+      - cronjobs
+      - jobs
+    verbs:
+      - '*'
+  - apiGroups:
+      - appstudio.redhat.com
+    resources:
+      - dependencyupdatechecks
+    verbs:
+      - '*'
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: mintmaker-admins
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: konflux-mintmaker-team
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: mintmaker-admin
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: mintmaker-maintainers
+  namespace: mintmaker
+subjects:
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: konflux-mintmaker-team
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: component-maintainer

--- a/components/mintmaker-rd/rings/ring-1/base/base-snapshot/redis-cache/kustomization.yaml
+++ b/components/mintmaker-rd/rings/ring-1/base/base-snapshot/redis-cache/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- redis-configmap.yaml
+- redis-deployment.yaml
+- redis-networkpolicy.yaml
+- redis-pvc.yaml
+- redis-service.yaml
+namespace: mintmaker

--- a/components/mintmaker-rd/rings/ring-1/base/base-snapshot/redis-cache/redis-configmap.yaml
+++ b/components/mintmaker-rd/rings/ring-1/base/base-snapshot/redis-cache/redis-configmap.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redis-config
+  namespace: mintmaker
+data:
+  redis.conf: |
+    bind 0.0.0.0
+    protected-mode no
+    port 6379
+    maxmemory 800mb
+    maxmemory-policy allkeys-lru
+    dir /var/lib/redis/data
+
+    appendonly yes
+    aof-use-rdb-preamble yes
+    appendfsync everysec
+
+    save 900 1
+    save 300 10
+    save 60 10000
+
+    logfile ""
+    loglevel notice

--- a/components/mintmaker-rd/rings/ring-1/base/base-snapshot/redis-cache/redis-deployment.yaml
+++ b/components/mintmaker-rd/rings/ring-1/base/base-snapshot/redis-cache/redis-deployment.yaml
@@ -1,0 +1,72 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis
+  namespace: mintmaker
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: redis
+  template:
+    metadata:
+      labels:
+        app: redis
+        paas.redhat.com/appcode: MINT-001
+    spec:
+      serviceAccountName: mintmaker-controller-manager
+      securityContext:
+        fsGroup: 1001
+      containers:
+        - name: redis
+          image: registry.redhat.io/rhel9/redis-7:9.5
+          ports:
+            - containerPort: 6379
+          command: ["container-entrypoint"]
+          args: ["run-redis"]
+          resources:
+            requests:
+              memory: 250Mi
+              cpu: 50m
+            limits:
+              memory: 800Mi
+              cpu: 300m
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1001
+            readOnlyRootFilesystem: true
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - redis-cli ping | grep -q PONG
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            timeoutSeconds: 15
+            failureThreshold: 5
+          readinessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - redis-cli ping | grep -q PONG
+            initialDelaySeconds: 10
+            periodSeconds: 15
+            timeoutSeconds: 10
+            failureThreshold: 5
+          volumeMounts:
+            - name: redis-data
+              mountPath: /var/lib/redis/data
+            - name: redis-config
+              mountPath: /etc/redis/redis.conf
+              subPath: redis.conf
+      volumes:
+        - name: redis-data
+          persistentVolumeClaim:
+            claimName: redis-pvc
+        - name: redis-config
+          configMap:
+            name: redis-config

--- a/components/mintmaker-rd/rings/ring-1/base/base-snapshot/redis-cache/redis-networkpolicy.yaml
+++ b/components/mintmaker-rd/rings/ring-1/base/base-snapshot/redis-cache/redis-networkpolicy.yaml
@@ -1,0 +1,12 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: restrict-redis-access
+  namespace: mintmaker
+spec:
+  podSelector:
+    matchLabels:
+      app: redis
+  ingress:
+  - from:
+    - podSelector: {}

--- a/components/mintmaker-rd/rings/ring-1/base/base-snapshot/redis-cache/redis-pvc.yaml
+++ b/components/mintmaker-rd/rings/ring-1/base/base-snapshot/redis-cache/redis-pvc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: redis-pvc
+  namespace: mintmaker
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi

--- a/components/mintmaker-rd/rings/ring-1/base/base-snapshot/redis-cache/redis-service.yaml
+++ b/components/mintmaker-rd/rings/ring-1/base/base-snapshot/redis-cache/redis-service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis
+  namespace: mintmaker
+spec:
+  selector:
+    app: redis
+  ports:
+    - port: 6379
+      targetPort: 6379
+  type: ClusterIP

--- a/components/mintmaker-rd/rings/ring-1/base/blackbox/blackbox-deployment.yaml
+++ b/components/mintmaker-rd/rings/ring-1/base/blackbox/blackbox-deployment.yaml
@@ -1,0 +1,70 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/name: mintmaker
+    app.kubernetes.io/managed-by: kustomize
+  name: blackbox-config
+  namespace: mintmaker
+data:
+  blackbox.yml: |
+    modules:
+      http_2xx:
+        prober: http
+        timeout: 5s
+        http:
+          valid_http_versions: ["HTTP/1.1", "HTTP/2"]
+          method: GET
+          no_follow_redirects: false
+          fail_if_ssl: false
+          fail_if_not_ssl: false
+      icmp:
+        prober: icmp
+        timeout: 5s
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/name: mintmaker
+    app.kubernetes.io/managed-by: kustomize
+  name: git-platforms-exporter
+  namespace: mintmaker
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: git-platforms-exporter
+  template:
+    metadata:
+      labels:
+        app: git-platforms-exporter
+        paas.redhat.com/appcode: MINT-001
+    spec:
+      containers:
+        - name: blackbox-exporter
+          image: quay.io/prometheus/blackbox-exporter:v0.27.0
+          args:
+            - "--config.file=/etc/blackbox/blackbox.yml"
+          ports:
+            - containerPort: 9115
+              name: http
+          resources:
+            requests:
+              cpu: "100m"
+              memory: "128Mi"
+            limits:
+              cpu: "500m"
+              memory: "256Mi"
+          securityContext:
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+          volumeMounts:
+            - name: config-volume
+              mountPath: /etc/blackbox
+              readOnly: true
+      volumes:
+        - name: config-volume
+          configMap:
+            name: blackbox-config

--- a/components/mintmaker-rd/rings/ring-1/base/blackbox/blackbox-service.yaml
+++ b/components/mintmaker-rd/rings/ring-1/base/blackbox/blackbox-service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/name: mintmaker
+    app.kubernetes.io/managed-by: kustomize
+  name: git-platforms-exporter
+  namespace: mintmaker
+spec:
+  selector:
+    app: git-platforms-exporter
+  ports:
+    - name: http
+      port: 9115
+      targetPort: 9115

--- a/components/mintmaker-rd/rings/ring-1/base/blackbox/git-platforms.yaml
+++ b/components/mintmaker-rd/rings/ring-1/base/blackbox/git-platforms.yaml
@@ -1,0 +1,22 @@
+apiVersion: monitoring.rhobs/v1
+kind: Probe
+metadata:
+  name: github-probe
+  namespace: mintmaker
+  labels:
+    monitoring.rhobs/stack: appstudio-federate-ms
+    app.kubernetes.io/name: mintmaker
+    app.kubernetes.io/managed-by: kustomize
+spec:
+  jobName: "git-probe"
+  interval: 30s
+  scrapeTimeout: 10s
+  prober:
+    url: git-platforms-exporter.mintmaker.svc.cluster.local:9115
+  module: http_2xx
+  targets:
+    staticConfig:
+      static:
+        - https://www.github.com
+      labels:
+        target: github

--- a/components/mintmaker-rd/rings/ring-1/base/blackbox/kustomization.yaml
+++ b/components/mintmaker-rd/rings/ring-1/base/blackbox/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- blackbox-deployment.yaml
+- blackbox-service.yaml
+- git-platforms.yaml
+
+namespace: mintmaker

--- a/components/mintmaker-rd/rings/ring-1/base/config.json
+++ b/components/mintmaker-rd/rings/ring-1/base/config.json
@@ -1,0 +1,6 @@
+{
+    "kite": {
+        "enabled": true,
+        "api-url": "https://konflux-kite.konflux-kite.svc.cluster.local"
+    }
+}

--- a/components/mintmaker-rd/rings/ring-1/base/external-secrets/kustomization.yaml
+++ b/components/mintmaker-rd/rings/ring-1/base/external-secrets/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- pipelines-as-code-secret.yaml
+namespace: mintmaker

--- a/components/mintmaker-rd/rings/ring-1/base/external-secrets/pipelines-as-code-secret.yaml
+++ b/components/mintmaker-rd/rings/ring-1/base/external-secrets/pipelines-as-code-secret.yaml
@@ -1,0 +1,19 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: pipelines-as-code-secret
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  dataFrom:
+    - extract:
+        key: staging/pipeline-service/github-app
+  refreshInterval: 5m
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: appsre-stonesoup-vault
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    name: pipelines-as-code-secret

--- a/components/mintmaker-rd/rings/ring-1/base/kustomization.yaml
+++ b/components/mintmaker-rd/rings/ring-1/base/kustomization.yaml
@@ -1,0 +1,44 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+labels:
+- pairs:
+    paas.redhat.com/appcode: MINT-001
+resources:
+- base-snapshot
+- external-secrets
+- blackbox
+- plrs-resource-quota.yaml
+- https://github.com/konflux-ci/mintmaker/config/default?ref=b8b7c25d43e264c57632518a085d4a01a28f7df4
+- https://github.com/konflux-ci/mintmaker/config/renovate?ref=b8b7c25d43e264c57632518a085d4a01a28f7df4
+
+namespace: mintmaker
+
+images:
+- name: quay.io/konflux-ci/mintmaker
+  newName: quay.io/konflux-ci/mintmaker
+  newTag: b8b7c25d43e264c57632518a085d4a01a28f7df4
+- name: quay.io/konflux-ci/mintmaker-renovate-image
+  newName: quay.io/konflux-ci/mintmaker-renovate-image
+  newTag: b5a8b2983f16858b8b92ee5f51769f5707b2aaf3
+- name: quay.io/konflux-ci/mintmaker-schedule-calculator
+  newName: quay.io/konflux-ci/mintmaker-schedule-calculator
+  newTag: dcda93c47b269d9b250ef62b0bd2e2e2f18aea6f
+
+commonAnnotations:
+  argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+
+configMapGenerator:
+  - name: controller-config
+    files:
+    - config.json
+
+patches:
+  - path: patches/manager-mount-config-patch.yaml
+  - path: patches/manager-set-resources-patch.yaml
+  - path: patches/manager-enable-pprof-patch.yaml
+
+configurations:
+- kustomizeconfig.yaml
+
+components:
+  - ../../../components/rh-certs

--- a/components/mintmaker-rd/rings/ring-1/base/kustomizeconfig.yaml
+++ b/components/mintmaker-rd/rings/ring-1/base/kustomizeconfig.yaml
@@ -1,0 +1,3 @@
+images:
+- path: spec/template/metadata/annotations/mintmaker.appstudio.redhat.com\/renovate-image
+  kind: Deployment

--- a/components/mintmaker-rd/rings/ring-1/base/patches/manager-enable-pprof-patch.yaml
+++ b/components/mintmaker-rd/rings/ring-1/base/patches/manager-enable-pprof-patch.yaml
@@ -1,0 +1,18 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager
+        args:
+        - --metrics-bind-address=:8080
+        - --health-probe-bind-address=:8081
+        - --metrics-secure=false
+        - --pprof-bind-address=:6060
+        env:
+        - name: ENABLE_PROFILING
+          value: "true"

--- a/components/mintmaker-rd/rings/ring-1/base/patches/manager-mount-config-patch.yaml
+++ b/components/mintmaker-rd/rings/ring-1/base/patches/manager-mount-config-patch.yaml
@@ -1,0 +1,17 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager
+        volumeMounts:
+        - name: controller-config
+          mountPath: /etc/mintmaker
+      volumes:
+      - name: controller-config
+        configMap:
+          name: controller-config

--- a/components/mintmaker-rd/rings/ring-1/base/patches/manager-set-resources-patch.yaml
+++ b/components/mintmaker-rd/rings/ring-1/base/patches/manager-set-resources-patch.yaml
@@ -1,0 +1,17 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager
+        resources:
+          limits:
+            cpu: 500m
+            memory: 2048Mi
+          requests:
+            cpu: 500m
+            memory: 2048Mi

--- a/components/mintmaker-rd/rings/ring-1/base/plrs-resource-quota.yaml
+++ b/components/mintmaker-rd/rings/ring-1/base/plrs-resource-quota.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: pipelineruns-resource-quota
+  namespace: mintmaker
+spec:
+  hard:
+    count/pipelineruns.tekton.dev: "5000"

--- a/components/mintmaker-rd/rings/ring-1/lightwell-dev/kustomization.yaml
+++ b/components/mintmaker-rd/rings/ring-1/lightwell-dev/kustomization.yaml
@@ -1,0 +1,3 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources: []

--- a/components/mintmaker-rd/rings/ring-1/stone-stage-p01/kustomization.yaml
+++ b/components/mintmaker-rd/rings/ring-1/stone-stage-p01/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../base
+namespace: mintmaker
+patches:
+  - path: patches/pipelines-as-code-secret-path.yaml
+    target:
+      name: pipelines-as-code-secret
+      group: external-secrets.io
+      version: v1
+      kind: ExternalSecret

--- a/components/mintmaker-rd/rings/ring-1/stone-stage-p01/patches/pipelines-as-code-secret-path.yaml
+++ b/components/mintmaker-rd/rings/ring-1/stone-stage-p01/patches/pipelines-as-code-secret-path.yaml
@@ -1,0 +1,4 @@
+---
+- op: add
+  path: /spec/dataFrom/0/extract/key
+  value: staging/build/stone-stage-p01/github-app

--- a/components/mintmaker-rd/rings/ring-1/stone-stg-rh01/kustomization.yaml
+++ b/components/mintmaker-rd/rings/ring-1/stone-stg-rh01/kustomization.yaml
@@ -1,0 +1,3 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources: []


### PR DESCRIPTION
- Create components/mintmaker-rd/ with Tier 1 base, ring-0 (development with upstream refs and redis), ring-1 for staging (stone-stage-p01)
- Add rd-dev ApplicationSet for development clusters
- Add rd-staging ApplicationSet with tenant label for staging clusters
- ring-0 includes dev config (mintmaker + renovate + schedule-calculator)
- ring-1 includes staging config, blackbox monitoring, ExternalSecret, per-cluster vault path patches
- Remove automated sync from old AppSet; add preserveResourcesOnDeletion
- Add dev overlay patches

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>