### PR TITLE
KONFLUX-15756 bump blackbox ref to fix stale Rekor probe on stone-stage-p01

### DIFF
--- a/components/monitoring/blackbox/staging/stone-stage-p01/kustomization.yaml
+++ b/components/monitoring/blackbox/staging/stone-stage-p01/kustomization.yaml
@@ -1,6 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - https://github.com/redhat-appstudio/internal-infra-deployments/components/monitoring/blackbox-exporter/staging/private/stone-stage-p01?ref=e7efd2cd14d72afaab62352b69cebfe518e3cb50
+  - https://github.com/redhat-appstudio/internal-infra-deployments/components/monitoring/blackbox-exporter/staging/private/stone-stage-p01?ref=7211c813b185f9bcc5fdaa66e3c333fd0b2565fb
 
 namespace: appstudio-monitoring


### PR DESCRIPTION
## What

Bump `internal-infra-deployments` ref in the stone-stage-p01 blackbox kustomization from `038c6f9` to `7211c81` (current main).

Clusters affected: stone-stage-p01

[KONFLUX-15756](https://redhat.atlassian.net/browse/KONFLUX-15756)

## Why

The blackbox Probe on stone-stage-p01 still targets the decommissioned `rekor-stage-2` endpoint, causing `ProbeAlert` to fire. The fix (commit `2c8a18e`, PR [internal-infra-deployments#134](https://github.com/redhat-appstudio/internal-infra-deployments/pull/134), ref [SPRE-1980](https://redhat.atlassian.net/browse/SPRE-1980)) was merged on 20 Aug 2026, but the kustomize ref was pinned one day before that fix.

## Validation

- Verified `7211c813b185f9bcc5fdaa66e3c333fd0b2565fb` is an ancestor of `origin/main` in `internal-infra-deployments`
- Verified `2c8a18e` (the Rekor probe fix) is included in the new ref
- Only staging blackbox change between old and new refs is the Rekor probe URL fix itself
- `kustomize build` cannot run locally (private repo requires SSH auth via CI/Argo)

## Risk Assessment

**Risk Level:** Low
**What could go wrong:** The ref bump picks up only the Rekor probe URL change for the staging blackbox path. If the new Rekor endpoint is unreachable, ProbeAlert would continue to fire — but for the correct target, making it actionable rather than stale noise.
**Rollback:** Revert PR.
**Blast radius:** staging — stone-stage-p01 only.

[KONFLUX-15756]: https://redhat.atlassian.net/browse/KONFLUX-15756?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SPRE-1980]: https://redhat.atlassian.net/browse/SPRE-1980?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ