### PR TITLE
Drop maven-zip-build from default pipelines

### DIFF
--- a/components/build-service/base/build-pipeline-config/build-pipeline-config.yaml
+++ b/components/build-service/base/build-pipeline-config/build-pipeline-config.yaml
@@ -31,10 +31,6 @@ data:
       detail: Build multi-platform container images with secure data transfer for the pipelines. Pipeline can be customized while maintaining trust.
       additional-params:
       - build-platforms
-    - name: maven-zip-build-oci-ta
-      bundle: quay.io/konflux-ci/tekton-catalog/pipeline-maven-zip-build-oci-ta:devel
-      description: Build maven zip OCI artifacts
-      detail: Fetch all artifacts necessary, create a maven zip file, and push it to the container registry. Pipeline can be customized while maintaining trust
     - name: tekton-bundle-builder-oci-ta
       bundle: quay.io/konflux-ci/tekton-catalog/pipeline-tekton-bundle-builder-oci-ta:devel
       description: Build Tekton bundles with secure data transfer for the pipelines

--- a/components/konflux-operator/rings/ring-1/base/cr/build/build-service.yaml
+++ b/components/konflux-operator/rings/ring-1/base/cr/build/build-service.yaml
@@ -12,9 +12,6 @@ spec:
           - name: docker-build-multi-platform-oci-ta
             bundle: quay.io/konflux-ci/tekton-catalog/pipeline-docker-build-multi-platform-oci-ta:devel
             description: "Build multi-platform container images with secure data transfer for the pipelines"
-          - name: maven-zip-build-oci-ta
-            bundle: quay.io/konflux-ci/tekton-catalog/pipeline-maven-zip-build-oci-ta:devel
-            description: "Build maven zip OCI artifacts"
       buildControllerManager:
         replicas: 1
         manager:

--- a/components/konflux-operator/rings/ring-2/base/cr/build/build-service.yaml
+++ b/components/konflux-operator/rings/ring-2/base/cr/build/build-service.yaml
@@ -12,9 +12,6 @@ spec:
           - name: docker-build-multi-platform-oci-ta
             bundle: quay.io/konflux-ci/tekton-catalog/pipeline-docker-build-multi-platform-oci-ta:devel
             description: "Build multi-platform container images with secure data transfer for the pipelines"
-          - name: maven-zip-build-oci-ta
-            bundle: quay.io/konflux-ci/tekton-catalog/pipeline-maven-zip-build-oci-ta:devel
-            description: "Build maven zip OCI artifacts"
       buildControllerManager:
         replicas: 1
         manager:


### PR DESCRIPTION
The build-maven-zip tasks are getting deprecated in https://github.com/konflux-ci/build-definitions/pull/3827

This effectively deprecates the entire maven-zip-build pipeline. As of today, nobody has used the pipeline for at least 3 months. Remove it from the default onboarding options to make sure nobody uses it by accident.

## Risk Assessment

Low (None)

These pipelines are not used by any users today and haven't been for a while. Not to mention that removing them here only affects the default pipeline choices for onboarding, nothing else.