### PR TITLE
PVO11Y-5548 Deploy Kanary exporter on kflux-lw-p01

### DIFF
--- a/argo-cd-apps/base/member/infra-deployments/monitoring-workload-kanary/monitoring-workload-kanary.yaml
+++ b/argo-cd-apps/base/member/infra-deployments/monitoring-workload-kanary/monitoring-workload-kanary.yaml
@@ -37,6 +37,8 @@ spec:
                   values.clusterDir: kflux-fedora-01
                 - nameNormalized: lightwell-dev
                   values.clusterDir: lightwell-dev
+                - nameNormalized: kflux-lw-p01
+                  values.clusterDir: kflux-lw-p01
   template:
     metadata:
       name: monitoring-workload-kanary-{{nameNormalized}}

--- a/components/monitoring/kanary/production/kflux-lw-p01/cronjobs/kanary-cronjob-multi-arch.yaml
+++ b/components/monitoring/kanary/production/kflux-lw-p01/cronjobs/kanary-cronjob-multi-arch.yaml
@@ -1,0 +1,47 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: kanary-trigger-multi-arch
+spec:
+  schedule: "15,45 * * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      activeDeadlineSeconds: 3000
+      template:
+        spec:
+          serviceAccountName: kanary-cronjob
+          restartPolicy: Never
+          containers:
+            - name: trigger
+              image: quay.io/openshift-pipeline/openshift-pipelines-cli-tkn:1.15
+              securityContext:
+                readOnlyRootFilesystem: true
+                runAsNonRoot: true
+              resources:
+                requests:
+                  cpu: 100m
+                  memory: 10Mi
+                limits:
+                  cpu: 100m
+                  memory: 100Mi
+              command:
+                - /bin/bash
+                - -c
+                - |
+                  tkn pipeline start kanary-otel-poc --use-param-defaults \
+                    --param tested-cluster=kflux-lw-p01 \
+                    --param test-type=container-multi-arch \
+                    --param component-repo=https://gitlab.cee.redhat.com/jhutar/nodejs-devfile-sample6 \
+                    --param user-prefix=lwp01cm \
+                    --param quay-repo=redhat-user-workloads \
+                    --param pipeline-repo-templating-source=https://github.com/rhtap-perf-test/konflux-probe-test-templates \
+                    --param pipeline-repo-templating-source-dir=nodejs-devfile-sample-MultiArch/ \
+                    --param oci-storage=quay.io/rhtap-perf-test/perf-release-service-trusted-artifacts \
+                    --param release-pipeline-service-account=managed-konflux-perfscale-sa \
+                    --param fork-target="jhutar" \
+                    --param gitlab-api-url="https://gitlab.cee.redhat.com/api/v4" \
+                    --param member-cluster=https://c109-e.private.us-east.containers.cloud.ibm.com:31533 \
+                    --prefix-name kanary-kflux-lw-p01-multi-arch-

--- a/components/monitoring/kanary/production/kflux-lw-p01/cronjobs/kanary-cronjob-rpm.yaml
+++ b/components/monitoring/kanary/production/kflux-lw-p01/cronjobs/kanary-cronjob-rpm.yaml
@@ -1,0 +1,54 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: kanary-trigger-rpm
+spec:
+  schedule: "10,40 * * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      activeDeadlineSeconds: 3000
+      template:
+        spec:
+          serviceAccountName: kanary-cronjob
+          restartPolicy: Never
+          containers:
+            - name: trigger
+              image: quay.io/openshift-pipeline/openshift-pipelines-cli-tkn:1.15
+              securityContext:
+                readOnlyRootFilesystem: true
+                runAsNonRoot: true
+              resources:
+                requests:
+                  cpu: 100m
+                  memory: 10Mi
+                limits:
+                  cpu: 100m
+                  memory: 100Mi
+              command:
+                - /bin/bash
+                - -c
+                - |
+                  tkn pipeline start kanary-otel-poc --use-param-defaults \
+                    --param tested-cluster=kflux-lw-p01 \
+                    --param test-type=rpm \
+                    --param component-repo=https://gitlab.cee.redhat.com/jhutar/libecpg-gitlab-fork \
+                    --param component-repo-revision=c10s \
+                    --param user-prefix=lwp01rm \
+                    --param quay-repo=redhat-user-workloads \
+                    --param pipeline-repo-templating-source=https://github.com/rhtap-perf-test/konflux-probe-test-templates \
+                    --param pipeline-repo-templating-source-dir=kflux-lw-p01-RPM/ \
+                    --param pipeline-image-pull-secrets="imagerepository-for-toolings-gather-results-container-image-pull imagerepository-for-toolings-get-rpm-sources-container-image-pull imagerepository-for-toolings-mock-rhel-container-image-pull imagerepository-for-toolings-rpmbuild-pipeline-image-pull imagerepository-for-toolings-syft-container-image-pull" \
+                    --param test-scenario-git-url="" \
+                    --param release-policy="" \
+                    --param oci-storage=quay.io/rhtap-perf-test/perf-release-service-trusted-artifacts \
+                    --param release-pipeline-service-account=managed-konflux-perfscale-sa \
+                    --param fork-target=jhutar \
+                    --param gitlab-api-url=https://gitlab.cee.redhat.com/api/v4 \
+                    --param upstream-repo-url=https://gitlab.com/redhat/centos-stream/rpms/libecpg.git \
+                    --param upstream-repo-branch=c10s \
+                    --param fork-repo-host-and-path=gitlab.cee.redhat.com/jhutar/libecpg-gitlab-fork.git \
+                    --param member-cluster=https://c109-e.private.us-east.containers.cloud.ibm.com:31533 \
+                    --prefix-name kanary-kflux-lw-p01-rpm-

--- a/components/monitoring/kanary/production/kflux-lw-p01/cronjobs/kanary-cronjob-single-arch.yaml
+++ b/components/monitoring/kanary/production/kflux-lw-p01/cronjobs/kanary-cronjob-single-arch.yaml
@@ -1,0 +1,47 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: kanary-trigger-single-arch
+spec:
+  schedule: "0,30 * * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      activeDeadlineSeconds: 3000
+      template:
+        spec:
+          serviceAccountName: kanary-cronjob
+          restartPolicy: Never
+          containers:
+            - name: trigger
+              image: quay.io/openshift-pipeline/openshift-pipelines-cli-tkn:1.15
+              securityContext:
+                readOnlyRootFilesystem: true
+                runAsNonRoot: true
+              resources:
+                requests:
+                  cpu: 100m
+                  memory: 10Mi
+                limits:
+                  cpu: 100m
+                  memory: 100Mi
+              command:
+                - /bin/bash
+                - -c
+                - |
+                  tkn pipeline start kanary-otel-poc --use-param-defaults \
+                    --param tested-cluster=kflux-lw-p01 \
+                    --param test-type=container-single-arch \
+                    --param component-repo=https://gitlab.cee.redhat.com/jhutar/nodejs-devfile-sample6 \
+                    --param user-prefix=lwp01cs \
+                    --param quay-repo=redhat-user-workloads \
+                    --param pipeline-repo-templating-source=https://github.com/rhtap-perf-test/konflux-probe-test-templates \
+                    --param pipeline-repo-templating-source-dir=nodejs-devfile-sample-SingleArch/ \
+                    --param oci-storage=quay.io/rhtap-perf-test/perf-release-service-trusted-artifacts \
+                    --param release-pipeline-service-account=managed-konflux-perfscale-sa \
+                    --param fork-target="jhutar" \
+                    --param gitlab-api-url="https://gitlab.cee.redhat.com/api/v4" \
+                    --param member-cluster=https://c109-e.private.us-east.containers.cloud.ibm.com:31533 \
+                    --prefix-name kanary-kflux-lw-p01-single-arch-

--- a/components/monitoring/kanary/production/kflux-lw-p01/cronjobs/kustomization.yaml
+++ b/components/monitoring/kanary/production/kflux-lw-p01/cronjobs/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - kanary-cronjob-single-arch.yaml
+  - kanary-cronjob-multi-arch.yaml
+  - kanary-cronjob-rpm.yaml

--- a/components/monitoring/kanary/production/kflux-lw-p01/external-secrets/patches/kanary-probe-credentials-path.yaml
+++ b/components/monitoring/kanary/production/kflux-lw-p01/external-secrets/patches/kanary-probe-credentials-path.yaml
@@ -1,0 +1,4 @@
+---
+- op: replace
+  path: /spec/dataFrom/0/extract/key
+  value: stonesoup/production/perfscale/shared

--- a/components/monitoring/kanary/production/kflux-lw-p01/external-secrets/patches/kanary-probe-prometheus-credentials-path.yaml
+++ b/components/monitoring/kanary/production/kflux-lw-p01/external-secrets/patches/kanary-probe-prometheus-credentials-path.yaml
@@ -1,0 +1,4 @@
+---
+- op: replace
+  path: /spec/dataFrom/0/extract/key
+  value: stonesoup/production/perfscale/shared/kflux-lw-p01

--- a/components/monitoring/kanary/production/kflux-lw-p01/external-secrets/patches/kanary-probe-users-credentials-path.yaml
+++ b/components/monitoring/kanary/production/kflux-lw-p01/external-secrets/patches/kanary-probe-users-credentials-path.yaml
@@ -1,0 +1,4 @@
+---
+- op: replace
+  path: /spec/dataFrom/0/extract/key
+  value: stonesoup/production/perfscale/shared/kflux-lw-p01/konflux-perfscale-4-tenant

--- a/components/monitoring/kanary/production/kflux-lw-p01/kustomization.yaml
+++ b/components/monitoring/kanary/production/kflux-lw-p01/kustomization.yaml
@@ -1,0 +1,23 @@
+resources:
+  - ../base
+  - cronjobs
+
+patches:
+  - path: external-secrets/patches/kanary-probe-credentials-path.yaml
+    target:
+      name: kanary-probe-credentials
+      kind: ExternalSecret
+      group: external-secrets.io
+      version: v1
+  - path: external-secrets/patches/kanary-probe-prometheus-credentials-path.yaml
+    target:
+      name: kanary-probe-prometheus-credentials
+      kind: ExternalSecret
+      group: external-secrets.io
+      version: v1
+  - path: external-secrets/patches/kanary-probe-users-credentials-path.yaml
+    target:
+      name: kanary-probe-users-credentials
+      kind: ExternalSecret
+      group: external-secrets.io
+      version: v1


### PR DESCRIPTION
Add per-cluster overlay for kflux-lw-p01 to enable Kanary monitoring:
- Created 3 CronJobs (single-arch, multi-arch, RPM) with staggered schedules
- Configured ExternalSecrets for Vault credentials
- Updated ApplicationSet to deploy to kflux-lw-p01

Assisted-by: Claude Sonnet 4.5 <noreply@anthropic.com>