### PR TITLE
KFLUXINFRA-4288 sync policies-rd snapshots with latest denylist policy

### DIFF
--- a/components/policies-rd/base/konflux-rbac/kustomization.yaml
+++ b/components/policies-rd/base/konflux-rbac/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
 - konflux-support-access
 - limit-pod-serviceaccount-token-expiration
 - limit-serviceaccount-token-expiration
+- restrict-binding-denylist
 - restrict-binding-serviceaccounts
 - restrict-binding-system-authenticated-releng
 - validate-rolebindings

--- a/components/policies-rd/base/konflux-rbac/restrict-binding-denylist/create/.chainsaw-test/chainsaw-assert-validatingadmissionpolicy.yaml
+++ b/components/policies-rd/base/konflux-rbac/restrict-binding-denylist/create/.chainsaw-test/chainsaw-assert-validatingadmissionpolicy.yaml
@@ -1,0 +1,7 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: restrict-bindings-denylist-create.konflux-ci.dev
+status:
+  observedGeneration: 1
+  typeChecking: {}

--- a/components/policies-rd/base/konflux-rbac/restrict-binding-denylist/create/.chainsaw-test/chainsaw-test.yaml
+++ b/components/policies-rd/base/konflux-rbac/restrict-binding-denylist/create/.chainsaw-test/chainsaw-test.yaml
@@ -1,0 +1,154 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: in-tenant-invalid-rolebinding
+spec:
+  description: |
+    tests that the a invalid RoleBinding can NOT be created
+    in a tenant namespace
+  concurrent: false
+  namespace: 'invalid-rb-tenant-namespace'
+  steps:
+  - name: given-validatingadmissionpolicy-is-ready
+    try:
+    - apply:
+        file: ../restrict-binding-denylist-create-validatingadmissionpolicy.yaml
+    - apply:
+        file: ../restrict-binding-denylist-create-validatingadmissionpolicybinding.yaml
+    - sleep:
+        duration: 1s
+    - assert:
+        file: chainsaw-assert-validatingadmissionpolicy.yaml
+  - name: given-tenant-namespace-exists
+    try:
+    - apply:
+        file: ./resources/tenant-namespace.yaml
+  - name: then-invalid-rolebinding-can-not-be-created
+    try:
+    - create:
+        file: ./resources/invalid-rolebinding-secrets.yaml
+        expect:
+        - check:
+            ($error != null): true
+            '(regex_match(''^rolebindings.rbac.authorization.k8s.io \"invalid-secrets-rolebinding\" is forbidden: ValidatingAdmissionPolicy \''restrict-bindings-denylist-create.konflux-ci.dev\'' with binding \''restrict-bindings-denylist-create.konflux-ci.dev\'' denied request: The referenced Role \''konflux-secrets-bot-actions\'' is deprecated and can\''t be used in new RoleBindings$'', $error))': true
+    - create:
+        file: ./resources/invalid-rolebinding-model.yaml
+        expect:
+        - check:
+            ($error != null): true
+            '(regex_match(''^rolebindings.rbac.authorization.k8s.io \"invalid-model-rolebinding\" is forbidden: ValidatingAdmissionPolicy \''restrict-bindings-denylist-create.konflux-ci.dev\'' with binding \''restrict-bindings-denylist-create.konflux-ci.dev\'' denied request: The referenced Role \''konflux-model-bot-actions\'' is deprecated and can\''t be used in new RoleBindings$'', $error))': true
+    - create:
+        file: ./resources/invalid-rolebinding-viewer.yaml
+        expect:
+        - check:
+            ($error != null): true
+            '(regex_match(''^rolebindings.rbac.authorization.k8s.io \"invalid-viewer-rolebinding\" is forbidden: ValidatingAdmissionPolicy \''restrict-bindings-denylist-create.konflux-ci.dev\'' with binding \''restrict-bindings-denylist-create.konflux-ci.dev\'' denied request: The referenced Role \''konflux-viewer-bot-actions\'' is deprecated and can\''t be used in new RoleBindings$'', $error))': true
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: in-tenant-delete-invalid-existing-rolebinding
+spec:
+  description: |
+    tests that the an existing invalid RoleBinding can be deleted
+    in a tenant namespace
+  concurrent: false
+  namespace: 'existing-invalid-rb-tenant-namespace'
+  steps:
+  - name: given-tenant-namespace-exists
+    try:
+    - apply:
+        file: ./resources/tenant-namespace.yaml
+  - name: given-invalid-rolebinding-exists
+    try:
+    - create:
+        file: ./resources/invalid-rolebinding-secrets.yaml
+    - create:
+        file: ./resources/invalid-rolebinding-model.yaml
+    - create:
+        file: ./resources/invalid-rolebinding-viewer.yaml
+  - name: when-validatingadmissionpolicy-is-ready
+    try:
+    - apply:
+        file: ../restrict-binding-denylist-create-validatingadmissionpolicy.yaml
+    - apply:
+        file: ../restrict-binding-denylist-create-validatingadmissionpolicybinding.yaml
+    - sleep:
+        duration: 1s
+    - assert:
+        file: chainsaw-assert-validatingadmissionpolicy.yaml
+  - name: then-invalid-rolebinding-can-be-deleted
+    try:
+    - delete:
+        file: ./resources/invalid-rolebinding-secrets.yaml
+    - delete:
+        file: ./resources/invalid-rolebinding-model.yaml
+    - delete:
+        file: ./resources/invalid-rolebinding-viewer.yaml
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: in-tenant-valid-rolebinding
+spec:
+  description: |
+    tests that the a valid RoleBinding can be created in a
+    tenant namespace
+  concurrent: false
+  namespace: 'valid-rb-tenant-namespace'
+  steps:
+  - name: given-validatingadmissionpolicy-is-ready
+    try:
+    - apply:
+        file: ../restrict-binding-denylist-create-validatingadmissionpolicy.yaml
+    - apply:
+        file: ../restrict-binding-denylist-create-validatingadmissionpolicybinding.yaml
+    - sleep:
+        duration: 1s
+    - assert:
+        file: chainsaw-assert-validatingadmissionpolicy.yaml
+  - name: given-tenant-namespace-exists
+    try:
+    - apply:
+        file: ./resources/tenant-namespace.yaml
+  - name: then-valid-rolebinding-can-be-created
+    try:
+    - apply:
+        file: ./resources/valid-rolebinding.yaml
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: out-of-tenant-rolebinding
+spec:
+  description: |
+    tests that the whatever RoleBinding can be created in a
+    non-tenant namespace
+  concurrent: false
+  namespace: 'valid-rb-namespace'
+  steps:
+  - name: given-validatingadmissionpolicy-is-ready
+    try:
+    - apply:
+        file: ../restrict-binding-denylist-create-validatingadmissionpolicy.yaml
+    - apply:
+        file: ../restrict-binding-denylist-create-validatingadmissionpolicybinding.yaml
+    - sleep:
+        duration: 1s
+    - assert:
+        file: chainsaw-assert-validatingadmissionpolicy.yaml
+  - name: then-rolebinding-can-be-created-in-a-nontenant-namespace
+    try:
+    - create:
+        file: ./resources/valid-rolebinding.yaml
+    - create:
+        file: ./resources/invalid-rolebinding-secrets.yaml
+    - create:
+        file: ./resources/invalid-rolebinding-model.yaml
+    - create:
+        file: ./resources/invalid-rolebinding-viewer.yaml

--- a/components/policies-rd/base/konflux-rbac/restrict-binding-denylist/create/.chainsaw-test/resources/invalid-rolebinding-model.yaml
+++ b/components/policies-rd/base/konflux-rbac/restrict-binding-denylist/create/.chainsaw-test/resources/invalid-rolebinding-model.yaml
@@ -1,0 +1,18 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: invalid-model-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: konflux-model-bot-actions
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: my-group
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: my-user
+- apiGroup: ""
+  kind: ServiceAccount
+  name: my-serviceaccount

--- a/components/policies-rd/base/konflux-rbac/restrict-binding-denylist/create/.chainsaw-test/resources/invalid-rolebinding-secrets.yaml
+++ b/components/policies-rd/base/konflux-rbac/restrict-binding-denylist/create/.chainsaw-test/resources/invalid-rolebinding-secrets.yaml
@@ -1,0 +1,18 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: invalid-secrets-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: konflux-secrets-bot-actions
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: my-group
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: my-user
+- apiGroup: ""
+  kind: ServiceAccount
+  name: my-serviceaccount

--- a/components/policies-rd/base/konflux-rbac/restrict-binding-denylist/create/.chainsaw-test/resources/invalid-rolebinding-viewer.yaml
+++ b/components/policies-rd/base/konflux-rbac/restrict-binding-denylist/create/.chainsaw-test/resources/invalid-rolebinding-viewer.yaml
@@ -1,0 +1,18 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: invalid-viewer-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: konflux-viewer-bot-actions
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: my-group
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: my-user
+- apiGroup: ""
+  kind: ServiceAccount
+  name: my-serviceaccount

--- a/components/policies-rd/base/konflux-rbac/restrict-binding-denylist/create/.chainsaw-test/resources/tenant-namespace.yaml
+++ b/components/policies-rd/base/konflux-rbac/restrict-binding-denylist/create/.chainsaw-test/resources/tenant-namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ($namespace)
+  labels:
+    konflux-ci.dev/type: tenant

--- a/components/policies-rd/base/konflux-rbac/restrict-binding-denylist/create/.chainsaw-test/resources/tenant-role.yaml
+++ b/components/policies-rd/base/konflux-rbac/restrict-binding-denylist/create/.chainsaw-test/resources/tenant-role.yaml
@@ -1,0 +1,8 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: tenant-test-role
+rules:
+- apiGroups: [""]
+  resources: ["configmaps"]
+  verbs: ["get"]

--- a/components/policies-rd/base/konflux-rbac/restrict-binding-denylist/create/.chainsaw-test/resources/valid-rolebinding.yaml
+++ b/components/policies-rd/base/konflux-rbac/restrict-binding-denylist/create/.chainsaw-test/resources/valid-rolebinding.yaml
@@ -1,0 +1,18 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: valid-serviceaccounts-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: konflux-valid-user-actions
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: my-group
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: my-user
+- apiGroup: ""
+  kind: ServiceAccount
+  name: not-a-konflux-bot-sa

--- a/components/policies-rd/base/konflux-rbac/restrict-binding-denylist/create/kustomization.yaml
+++ b/components/policies-rd/base/konflux-rbac/restrict-binding-denylist/create/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ./restrict-binding-denylist-create-validatingadmissionpolicy.yaml
+- ./restrict-binding-denylist-create-validatingadmissionpolicybinding.yaml

--- a/components/policies-rd/base/konflux-rbac/restrict-binding-denylist/create/restrict-binding-denylist-create-validatingadmissionpolicy.yaml
+++ b/components/policies-rd/base/konflux-rbac/restrict-binding-denylist/create/restrict-binding-denylist-create-validatingadmissionpolicy.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: restrict-bindings-denylist-create.konflux-ci.dev
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+    - apiGroups: ["rbac.authorization.k8s.io"]
+      apiVersions: ["v1"]
+      operations: ["CREATE"]
+      resources: ["rolebindings"]
+  variables:
+  - name: denyClusterRoles
+    expression: '["konflux-secrets-bot-actions", "konflux-model-bot-actions", "konflux-viewer-bot-actions"]'
+  validations:
+  - expression: |
+      !has(object.roleRef) ||
+        !has(object.roleRef.name) ||
+        !has(object.roleRef.kind) ||
+        !(
+          object.roleRef.kind == "ClusterRole" &&
+          object.roleRef.name in variables.denyClusterRoles)
+    messageExpression: |
+      "The referenced Role '" + object.roleRef.name + "' is deprecated and can't be used in new RoleBindings"
+    # fall-back if something is wrong with the messageExpression above
+    message: |
+      The referenced Role is deprecated and can't be used in new RoleBindings

--- a/components/policies-rd/base/konflux-rbac/restrict-binding-denylist/create/restrict-binding-denylist-create-validatingadmissionpolicybinding.yaml
+++ b/components/policies-rd/base/konflux-rbac/restrict-binding-denylist/create/restrict-binding-denylist-create-validatingadmissionpolicybinding.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: restrict-bindings-denylist-create.konflux-ci.dev
+spec:
+  policyName: restrict-bindings-denylist-create.konflux-ci.dev
+  validationActions: [Deny]
+  matchResources:
+    namespaceSelector:
+      matchLabels:
+        konflux-ci.dev/type: tenant

--- a/components/policies-rd/base/konflux-rbac/restrict-binding-denylist/kustomization.yaml
+++ b/components/policies-rd/base/konflux-rbac/restrict-binding-denylist/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namePrefix: konflux-rbac-
+resources:
+- create/
+commonAnnotations:
+  argocd.argoproj.io/sync-options: Prune=false

--- a/components/policies-rd/rings/ring-0/base/base-snapshot/konflux-rbac/kustomization.yaml
+++ b/components/policies-rd/rings/ring-0/base/base-snapshot/konflux-rbac/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
 - konflux-support-access
 - limit-pod-serviceaccount-token-expiration
 - limit-serviceaccount-token-expiration
+- restrict-binding-denylist
 - restrict-binding-serviceaccounts
 - restrict-binding-system-authenticated-releng
 - validate-rolebindings

--- a/components/policies-rd/rings/ring-0/base/base-snapshot/konflux-rbac/restrict-binding-denylist/create/.chainsaw-test/chainsaw-assert-validatingadmissionpolicy.yaml
+++ b/components/policies-rd/rings/ring-0/base/base-snapshot/konflux-rbac/restrict-binding-denylist/create/.chainsaw-test/chainsaw-assert-validatingadmissionpolicy.yaml
@@ -1,0 +1,7 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: restrict-bindings-denylist-create.konflux-ci.dev
+status:
+  observedGeneration: 1
+  typeChecking: {}

--- a/components/policies-rd/rings/ring-0/base/base-snapshot/konflux-rbac/restrict-binding-denylist/create/.chainsaw-test/chainsaw-test.yaml
+++ b/components/policies-rd/rings/ring-0/base/base-snapshot/konflux-rbac/restrict-binding-denylist/create/.chainsaw-test/chainsaw-test.yaml
@@ -1,0 +1,154 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: in-tenant-invalid-rolebinding
+spec:
+  description: |
+    tests that the a invalid RoleBinding can NOT be created
+    in a tenant namespace
+  concurrent: false
+  namespace: 'invalid-rb-tenant-namespace'
+  steps:
+  - name: given-validatingadmissionpolicy-is-ready
+    try:
+    - apply:
+        file: ../restrict-binding-denylist-create-validatingadmissionpolicy.yaml
+    - apply:
+        file: ../restrict-binding-denylist-create-validatingadmissionpolicybinding.yaml
+    - sleep:
+        duration: 1s
+    - assert:
+        file: chainsaw-assert-validatingadmissionpolicy.yaml
+  - name: given-tenant-namespace-exists
+    try:
+    - apply:
+        file: ./resources/tenant-namespace.yaml
+  - name: then-invalid-rolebinding-can-not-be-created
+    try:
+    - create:
+        file: ./resources/invalid-rolebinding-secrets.yaml
+        expect:
+        - check:
+            ($error != null): true
+            '(regex_match(''^rolebindings.rbac.authorization.k8s.io \"invalid-secrets-rolebinding\" is forbidden: ValidatingAdmissionPolicy \''restrict-bindings-denylist-create.konflux-ci.dev\'' with binding \''restrict-bindings-denylist-create.konflux-ci.dev\'' denied request: The referenced Role \''konflux-secrets-bot-actions\'' is deprecated and can\''t be used in new RoleBindings$'', $error))': true
+    - create:
+        file: ./resources/invalid-rolebinding-model.yaml
+        expect:
+        - check:
+            ($error != null): true
+            '(regex_match(''^rolebindings.rbac.authorization.k8s.io \"invalid-model-rolebinding\" is forbidden: ValidatingAdmissionPolicy \''restrict-bindings-denylist-create.konflux-ci.dev\'' with binding \''restrict-bindings-denylist-create.konflux-ci.dev\'' denied request: The referenced Role \''konflux-model-bot-actions\'' is deprecated and can\''t be used in new RoleBindings$'', $error))': true
+    - create:
+        file: ./resources/invalid-rolebinding-viewer.yaml
+        expect:
+        - check:
+            ($error != null): true
+            '(regex_match(''^rolebindings.rbac.authorization.k8s.io \"invalid-viewer-rolebinding\" is forbidden: ValidatingAdmissionPolicy \''restrict-bindings-denylist-create.konflux-ci.dev\'' with binding \''restrict-bindings-denylist-create.konflux-ci.dev\'' denied request: The referenced Role \''konflux-viewer-bot-actions\'' is deprecated and can\''t be used in new RoleBindings$'', $error))': true
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: in-tenant-delete-invalid-existing-rolebinding
+spec:
+  description: |
+    tests that the an existing invalid RoleBinding can be deleted
+    in a tenant namespace
+  concurrent: false
+  namespace: 'existing-invalid-rb-tenant-namespace'
+  steps:
+  - name: given-tenant-namespace-exists
+    try:
+    - apply:
+        file: ./resources/tenant-namespace.yaml
+  - name: given-invalid-rolebinding-exists
+    try:
+    - create:
+        file: ./resources/invalid-rolebinding-secrets.yaml
+    - create:
+        file: ./resources/invalid-rolebinding-model.yaml
+    - create:
+        file: ./resources/invalid-rolebinding-viewer.yaml
+  - name: when-validatingadmissionpolicy-is-ready
+    try:
+    - apply:
+        file: ../restrict-binding-denylist-create-validatingadmissionpolicy.yaml
+    - apply:
+        file: ../restrict-binding-denylist-create-validatingadmissionpolicybinding.yaml
+    - sleep:
+        duration: 1s
+    - assert:
+        file: chainsaw-assert-validatingadmissionpolicy.yaml
+  - name: then-invalid-rolebinding-can-be-deleted
+    try:
+    - delete:
+        file: ./resources/invalid-rolebinding-secrets.yaml
+    - delete:
+        file: ./resources/invalid-rolebinding-model.yaml
+    - delete:
+        file: ./resources/invalid-rolebinding-viewer.yaml
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: in-tenant-valid-rolebinding
+spec:
+  description: |
+    tests that the a valid RoleBinding can be created in a
+    tenant namespace
+  concurrent: false
+  namespace: 'valid-rb-tenant-namespace'
+  steps:
+  - name: given-validatingadmissionpolicy-is-ready
+    try:
+    - apply:
+        file: ../restrict-binding-denylist-create-validatingadmissionpolicy.yaml
+    - apply:
+        file: ../restrict-binding-denylist-create-validatingadmissionpolicybinding.yaml
+    - sleep:
+        duration: 1s
+    - assert:
+        file: chainsaw-assert-validatingadmissionpolicy.yaml
+  - name: given-tenant-namespace-exists
+    try:
+    - apply:
+        file: ./resources/tenant-namespace.yaml
+  - name: then-valid-rolebinding-can-be-created
+    try:
+    - apply:
+        file: ./resources/valid-rolebinding.yaml
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: out-of-tenant-rolebinding
+spec:
+  description: |
+    tests that the whatever RoleBinding can be created in a
+    non-tenant namespace
+  concurrent: false
+  namespace: 'valid-rb-namespace'
+  steps:
+  - name: given-validatingadmissionpolicy-is-ready
+    try:
+    - apply:
+        file: ../restrict-binding-denylist-create-validatingadmissionpolicy.yaml
+    - apply:
+        file: ../restrict-binding-denylist-create-validatingadmissionpolicybinding.yaml
+    - sleep:
+        duration: 1s
+    - assert:
+        file: chainsaw-assert-validatingadmissionpolicy.yaml
+  - name: then-rolebinding-can-be-created-in-a-nontenant-namespace
+    try:
+    - create:
+        file: ./resources/valid-rolebinding.yaml
+    - create:
+        file: ./resources/invalid-rolebinding-secrets.yaml
+    - create:
+        file: ./resources/invalid-rolebinding-model.yaml
+    - create:
+        file: ./resources/invalid-rolebinding-viewer.yaml

--- a/components/policies-rd/rings/ring-0/base/base-snapshot/konflux-rbac/restrict-binding-denylist/create/.chainsaw-test/resources/invalid-rolebinding-model.yaml
+++ b/components/policies-rd/rings/ring-0/base/base-snapshot/konflux-rbac/restrict-binding-denylist/create/.chainsaw-test/resources/invalid-rolebinding-model.yaml
@@ -1,0 +1,18 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: invalid-model-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: konflux-model-bot-actions
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: my-group
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: my-user
+- apiGroup: ""
+  kind: ServiceAccount
+  name: my-serviceaccount

--- a/components/policies-rd/rings/ring-0/base/base-snapshot/konflux-rbac/restrict-binding-denylist/create/.chainsaw-test/resources/invalid-rolebinding-secrets.yaml
+++ b/components/policies-rd/rings/ring-0/base/base-snapshot/konflux-rbac/restrict-binding-denylist/create/.chainsaw-test/resources/invalid-rolebinding-secrets.yaml
@@ -1,0 +1,18 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: invalid-secrets-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: konflux-secrets-bot-actions
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: my-group
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: my-user
+- apiGroup: ""
+  kind: ServiceAccount
+  name: my-serviceaccount

--- a/components/policies-rd/rings/ring-0/base/base-snapshot/konflux-rbac/restrict-binding-denylist/create/.chainsaw-test/resources/invalid-rolebinding-viewer.yaml
+++ b/components/policies-rd/rings/ring-0/base/base-snapshot/konflux-rbac/restrict-binding-denylist/create/.chainsaw-test/resources/invalid-rolebinding-viewer.yaml
@@ -1,0 +1,18 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: invalid-viewer-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: konflux-viewer-bot-actions
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: my-group
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: my-user
+- apiGroup: ""
+  kind: ServiceAccount
+  name: my-serviceaccount

--- a/components/policies-rd/rings/ring-0/base/base-snapshot/konflux-rbac/restrict-binding-denylist/create/.chainsaw-test/resources/tenant-namespace.yaml
+++ b/components/policies-rd/rings/ring-0/base/base-snapshot/konflux-rbac/restrict-binding-denylist/create/.chainsaw-test/resources/tenant-namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ($namespace)
+  labels:
+    konflux-ci.dev/type: tenant

--- a/components/policies-rd/rings/ring-0/base/base-snapshot/konflux-rbac/restrict-binding-denylist/create/.chainsaw-test/resources/tenant-role.yaml
+++ b/components/policies-rd/rings/ring-0/base/base-snapshot/konflux-rbac/restrict-binding-denylist/create/.chainsaw-test/resources/tenant-role.yaml
@@ -1,0 +1,8 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: tenant-test-role
+rules:
+- apiGroups: [""]
+  resources: ["configmaps"]
+  verbs: ["get"]

--- a/components/policies-rd/rings/ring-0/base/base-snapshot/konflux-rbac/restrict-binding-denylist/create/.chainsaw-test/resources/valid-rolebinding.yaml
+++ b/components/policies-rd/rings/ring-0/base/base-snapshot/konflux-rbac/restrict-binding-denylist/create/.chainsaw-test/resources/valid-rolebinding.yaml
@@ -1,0 +1,18 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: valid-serviceaccounts-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: konflux-valid-user-actions
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: my-group
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: my-user
+- apiGroup: ""
+  kind: ServiceAccount
+  name: not-a-konflux-bot-sa

--- a/components/policies-rd/rings/ring-0/base/base-snapshot/konflux-rbac/restrict-binding-denylist/create/kustomization.yaml
+++ b/components/policies-rd/rings/ring-0/base/base-snapshot/konflux-rbac/restrict-binding-denylist/create/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ./restrict-binding-denylist-create-validatingadmissionpolicy.yaml
+- ./restrict-binding-denylist-create-validatingadmissionpolicybinding.yaml

--- a/components/policies-rd/rings/ring-0/base/base-snapshot/konflux-rbac/restrict-binding-denylist/create/restrict-binding-denylist-create-validatingadmissionpolicy.yaml
+++ b/components/policies-rd/rings/ring-0/base/base-snapshot/konflux-rbac/restrict-binding-denylist/create/restrict-binding-denylist-create-validatingadmissionpolicy.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: restrict-bindings-denylist-create.konflux-ci.dev
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+    - apiGroups: ["rbac.authorization.k8s.io"]
+      apiVersions: ["v1"]
+      operations: ["CREATE"]
+      resources: ["rolebindings"]
+  variables:
+  - name: denyClusterRoles
+    expression: '["konflux-secrets-bot-actions", "konflux-model-bot-actions", "konflux-viewer-bot-actions"]'
+  validations:
+  - expression: |
+      !has(object.roleRef) ||
+        !has(object.roleRef.name) ||
+        !has(object.roleRef.kind) ||
+        !(
+          object.roleRef.kind == "ClusterRole" &&
+          object.roleRef.name in variables.denyClusterRoles)
+    messageExpression: |
+      "The referenced Role '" + object.roleRef.name + "' is deprecated and can't be used in new RoleBindings"
+    # fall-back if something is wrong with the messageExpression above
+    message: |
+      The referenced Role is deprecated and can't be used in new RoleBindings

--- a/components/policies-rd/rings/ring-0/base/base-snapshot/konflux-rbac/restrict-binding-denylist/create/restrict-binding-denylist-create-validatingadmissionpolicybinding.yaml
+++ b/components/policies-rd/rings/ring-0/base/base-snapshot/konflux-rbac/restrict-binding-denylist/create/restrict-binding-denylist-create-validatingadmissionpolicybinding.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: restrict-bindings-denylist-create.konflux-ci.dev
+spec:
+  policyName: restrict-bindings-denylist-create.konflux-ci.dev
+  validationActions: [Deny]
+  matchResources:
+    namespaceSelector:
+      matchLabels:
+        konflux-ci.dev/type: tenant

--- a/components/policies-rd/rings/ring-0/base/base-snapshot/konflux-rbac/restrict-binding-denylist/kustomization.yaml
+++ b/components/policies-rd/rings/ring-0/base/base-snapshot/konflux-rbac/restrict-binding-denylist/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namePrefix: konflux-rbac-
+resources:
+- create/
+commonAnnotations:
+  argocd.argoproj.io/sync-options: Prune=false

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/kustomization.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
 - konflux-support-access
 - limit-pod-serviceaccount-token-expiration
 - limit-serviceaccount-token-expiration
+- restrict-binding-denylist
 - restrict-binding-serviceaccounts
 - restrict-binding-system-authenticated-releng
 - validate-rolebindings

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/restrict-binding-denylist/create/.chainsaw-test/chainsaw-assert-validatingadmissionpolicy.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/restrict-binding-denylist/create/.chainsaw-test/chainsaw-assert-validatingadmissionpolicy.yaml
@@ -1,0 +1,7 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: restrict-bindings-denylist-create.konflux-ci.dev
+status:
+  observedGeneration: 1
+  typeChecking: {}

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/restrict-binding-denylist/create/.chainsaw-test/chainsaw-test.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/restrict-binding-denylist/create/.chainsaw-test/chainsaw-test.yaml
@@ -1,0 +1,154 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: in-tenant-invalid-rolebinding
+spec:
+  description: |
+    tests that the a invalid RoleBinding can NOT be created
+    in a tenant namespace
+  concurrent: false
+  namespace: 'invalid-rb-tenant-namespace'
+  steps:
+  - name: given-validatingadmissionpolicy-is-ready
+    try:
+    - apply:
+        file: ../restrict-binding-denylist-create-validatingadmissionpolicy.yaml
+    - apply:
+        file: ../restrict-binding-denylist-create-validatingadmissionpolicybinding.yaml
+    - sleep:
+        duration: 1s
+    - assert:
+        file: chainsaw-assert-validatingadmissionpolicy.yaml
+  - name: given-tenant-namespace-exists
+    try:
+    - apply:
+        file: ./resources/tenant-namespace.yaml
+  - name: then-invalid-rolebinding-can-not-be-created
+    try:
+    - create:
+        file: ./resources/invalid-rolebinding-secrets.yaml
+        expect:
+        - check:
+            ($error != null): true
+            '(regex_match(''^rolebindings.rbac.authorization.k8s.io \"invalid-secrets-rolebinding\" is forbidden: ValidatingAdmissionPolicy \''restrict-bindings-denylist-create.konflux-ci.dev\'' with binding \''restrict-bindings-denylist-create.konflux-ci.dev\'' denied request: The referenced Role \''konflux-secrets-bot-actions\'' is deprecated and can\''t be used in new RoleBindings$'', $error))': true
+    - create:
+        file: ./resources/invalid-rolebinding-model.yaml
+        expect:
+        - check:
+            ($error != null): true
+            '(regex_match(''^rolebindings.rbac.authorization.k8s.io \"invalid-model-rolebinding\" is forbidden: ValidatingAdmissionPolicy \''restrict-bindings-denylist-create.konflux-ci.dev\'' with binding \''restrict-bindings-denylist-create.konflux-ci.dev\'' denied request: The referenced Role \''konflux-model-bot-actions\'' is deprecated and can\''t be used in new RoleBindings$'', $error))': true
+    - create:
+        file: ./resources/invalid-rolebinding-viewer.yaml
+        expect:
+        - check:
+            ($error != null): true
+            '(regex_match(''^rolebindings.rbac.authorization.k8s.io \"invalid-viewer-rolebinding\" is forbidden: ValidatingAdmissionPolicy \''restrict-bindings-denylist-create.konflux-ci.dev\'' with binding \''restrict-bindings-denylist-create.konflux-ci.dev\'' denied request: The referenced Role \''konflux-viewer-bot-actions\'' is deprecated and can\''t be used in new RoleBindings$'', $error))': true
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: in-tenant-delete-invalid-existing-rolebinding
+spec:
+  description: |
+    tests that the an existing invalid RoleBinding can be deleted
+    in a tenant namespace
+  concurrent: false
+  namespace: 'existing-invalid-rb-tenant-namespace'
+  steps:
+  - name: given-tenant-namespace-exists
+    try:
+    - apply:
+        file: ./resources/tenant-namespace.yaml
+  - name: given-invalid-rolebinding-exists
+    try:
+    - create:
+        file: ./resources/invalid-rolebinding-secrets.yaml
+    - create:
+        file: ./resources/invalid-rolebinding-model.yaml
+    - create:
+        file: ./resources/invalid-rolebinding-viewer.yaml
+  - name: when-validatingadmissionpolicy-is-ready
+    try:
+    - apply:
+        file: ../restrict-binding-denylist-create-validatingadmissionpolicy.yaml
+    - apply:
+        file: ../restrict-binding-denylist-create-validatingadmissionpolicybinding.yaml
+    - sleep:
+        duration: 1s
+    - assert:
+        file: chainsaw-assert-validatingadmissionpolicy.yaml
+  - name: then-invalid-rolebinding-can-be-deleted
+    try:
+    - delete:
+        file: ./resources/invalid-rolebinding-secrets.yaml
+    - delete:
+        file: ./resources/invalid-rolebinding-model.yaml
+    - delete:
+        file: ./resources/invalid-rolebinding-viewer.yaml
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: in-tenant-valid-rolebinding
+spec:
+  description: |
+    tests that the a valid RoleBinding can be created in a
+    tenant namespace
+  concurrent: false
+  namespace: 'valid-rb-tenant-namespace'
+  steps:
+  - name: given-validatingadmissionpolicy-is-ready
+    try:
+    - apply:
+        file: ../restrict-binding-denylist-create-validatingadmissionpolicy.yaml
+    - apply:
+        file: ../restrict-binding-denylist-create-validatingadmissionpolicybinding.yaml
+    - sleep:
+        duration: 1s
+    - assert:
+        file: chainsaw-assert-validatingadmissionpolicy.yaml
+  - name: given-tenant-namespace-exists
+    try:
+    - apply:
+        file: ./resources/tenant-namespace.yaml
+  - name: then-valid-rolebinding-can-be-created
+    try:
+    - apply:
+        file: ./resources/valid-rolebinding.yaml
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: out-of-tenant-rolebinding
+spec:
+  description: |
+    tests that the whatever RoleBinding can be created in a
+    non-tenant namespace
+  concurrent: false
+  namespace: 'valid-rb-namespace'
+  steps:
+  - name: given-validatingadmissionpolicy-is-ready
+    try:
+    - apply:
+        file: ../restrict-binding-denylist-create-validatingadmissionpolicy.yaml
+    - apply:
+        file: ../restrict-binding-denylist-create-validatingadmissionpolicybinding.yaml
+    - sleep:
+        duration: 1s
+    - assert:
+        file: chainsaw-assert-validatingadmissionpolicy.yaml
+  - name: then-rolebinding-can-be-created-in-a-nontenant-namespace
+    try:
+    - create:
+        file: ./resources/valid-rolebinding.yaml
+    - create:
+        file: ./resources/invalid-rolebinding-secrets.yaml
+    - create:
+        file: ./resources/invalid-rolebinding-model.yaml
+    - create:
+        file: ./resources/invalid-rolebinding-viewer.yaml

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/restrict-binding-denylist/create/.chainsaw-test/resources/invalid-rolebinding-model.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/restrict-binding-denylist/create/.chainsaw-test/resources/invalid-rolebinding-model.yaml
@@ -1,0 +1,18 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: invalid-model-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: konflux-model-bot-actions
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: my-group
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: my-user
+- apiGroup: ""
+  kind: ServiceAccount
+  name: my-serviceaccount

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/restrict-binding-denylist/create/.chainsaw-test/resources/invalid-rolebinding-secrets.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/restrict-binding-denylist/create/.chainsaw-test/resources/invalid-rolebinding-secrets.yaml
@@ -1,0 +1,18 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: invalid-secrets-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: konflux-secrets-bot-actions
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: my-group
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: my-user
+- apiGroup: ""
+  kind: ServiceAccount
+  name: my-serviceaccount

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/restrict-binding-denylist/create/.chainsaw-test/resources/invalid-rolebinding-viewer.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/restrict-binding-denylist/create/.chainsaw-test/resources/invalid-rolebinding-viewer.yaml
@@ -1,0 +1,18 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: invalid-viewer-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: konflux-viewer-bot-actions
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: my-group
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: my-user
+- apiGroup: ""
+  kind: ServiceAccount
+  name: my-serviceaccount

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/restrict-binding-denylist/create/.chainsaw-test/resources/tenant-namespace.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/restrict-binding-denylist/create/.chainsaw-test/resources/tenant-namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ($namespace)
+  labels:
+    konflux-ci.dev/type: tenant

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/restrict-binding-denylist/create/.chainsaw-test/resources/tenant-role.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/restrict-binding-denylist/create/.chainsaw-test/resources/tenant-role.yaml
@@ -1,0 +1,8 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: tenant-test-role
+rules:
+- apiGroups: [""]
+  resources: ["configmaps"]
+  verbs: ["get"]

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/restrict-binding-denylist/create/.chainsaw-test/resources/valid-rolebinding.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/restrict-binding-denylist/create/.chainsaw-test/resources/valid-rolebinding.yaml
@@ -1,0 +1,18 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: valid-serviceaccounts-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: konflux-valid-user-actions
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: my-group
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: my-user
+- apiGroup: ""
+  kind: ServiceAccount
+  name: not-a-konflux-bot-sa

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/restrict-binding-denylist/create/kustomization.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/restrict-binding-denylist/create/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ./restrict-binding-denylist-create-validatingadmissionpolicy.yaml
+- ./restrict-binding-denylist-create-validatingadmissionpolicybinding.yaml

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/restrict-binding-denylist/create/restrict-binding-denylist-create-validatingadmissionpolicy.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/restrict-binding-denylist/create/restrict-binding-denylist-create-validatingadmissionpolicy.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: restrict-bindings-denylist-create.konflux-ci.dev
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+    - apiGroups: ["rbac.authorization.k8s.io"]
+      apiVersions: ["v1"]
+      operations: ["CREATE"]
+      resources: ["rolebindings"]
+  variables:
+  - name: denyClusterRoles
+    expression: '["konflux-secrets-bot-actions", "konflux-model-bot-actions", "konflux-viewer-bot-actions"]'
+  validations:
+  - expression: |
+      !has(object.roleRef) ||
+        !has(object.roleRef.name) ||
+        !has(object.roleRef.kind) ||
+        !(
+          object.roleRef.kind == "ClusterRole" &&
+          object.roleRef.name in variables.denyClusterRoles)
+    messageExpression: |
+      "The referenced Role '" + object.roleRef.name + "' is deprecated and can't be used in new RoleBindings"
+    # fall-back if something is wrong with the messageExpression above
+    message: |
+      The referenced Role is deprecated and can't be used in new RoleBindings

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/restrict-binding-denylist/create/restrict-binding-denylist-create-validatingadmissionpolicybinding.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/restrict-binding-denylist/create/restrict-binding-denylist-create-validatingadmissionpolicybinding.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: restrict-bindings-denylist-create.konflux-ci.dev
+spec:
+  policyName: restrict-bindings-denylist-create.konflux-ci.dev
+  validationActions: [Deny]
+  matchResources:
+    namespaceSelector:
+      matchLabels:
+        konflux-ci.dev/type: tenant

--- a/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/restrict-binding-denylist/kustomization.yaml
+++ b/components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/restrict-binding-denylist/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namePrefix: konflux-rbac-
+resources:
+- create/
+commonAnnotations:
+  argocd.argoproj.io/sync-options: Prune=false


### PR DESCRIPTION
## What

Adds the `restrict-binding-denylist` policy to:
- `components/policies-rd/base/konflux-rbac/` (Tier-1 base — for future production rings to inherit in Part 4)
- `components/policies-rd/rings/ring-0/base/base-snapshot/konflux-rbac/` (development)
- `components/policies-rd/rings/ring-1/base/base-snapshot/konflux-rbac/` (staging)

Clusters affected: development (ring-0), lightwell-dev, stone-stage-p01, stone-stg-rh01 (ring-1 staging), future production rings

[KFLUXINFRA-4288](https://issues.redhat.com/browse/KFLUXINFRA-4288)

## Why

The denylist ValidatingAdmissionPolicy (PR #13799, commit b25d4a4be) landed on Sept 4, one day after Part 2 (#13867) merged on Sept 3. Part 2 froze the ring-0 and ring-1 base-snapshots at that point, so they're missing this policy. Legacy development and staging pull from the live base, so they auto-picked up the new policy. This sync brings the frozen snapshots current.

Additionally, adding it to the Tier-1 base ensures production rings (Part 4) will inherit the policy when their base-snapshots are created from base.

## Validation

- `hack/test-ring-render.sh policies-rd all` — 4 passed
  - ring-1 (staging): 3/3 PASS (lightwell-dev, stone-stage-p01, stone-stg-rh01)
  - ring-0 (development): PASS after temporarily adding `namePrefix: integration-` for the test (matches legacy dev's current state; prefix is out-of-scope for this fix)
- `hack/test-base-common.sh policies-rd` — 0 problems
- `kustomize build --enable-helm` passes for all affected overlays
- yamllint clean

[KFLUXINFRA-4288]: https://redhat.atlassian.net/browse/KFLUXINFRA-4288?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ