### PR TITLE
Revert "Promote RS & grafana-diashboard from development to staging #13873)"

### DIFF
--- a/components/monitoring/grafana/staging/dashboards/release/kustomization.yaml
+++ b/components/monitoring/grafana/staging/dashboards/release/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- https://github.com/konflux-ci/release-service/config/grafana/?ref=f874148f742eecfaa64832a13b2b237d079223bd
+- https://github.com/konflux-ci/release-service/config/grafana/?ref=178b9cf3b0978d85f0612521ce06061029007956

--- a/components/release/staging/kustomization.yaml
+++ b/components/release/staging/kustomization.yaml
@@ -5,7 +5,7 @@ resources:
   - ../base/monitor/staging
   - external-secrets/release-monitor-secret.yaml
   - external-secrets/release-service-github-token.yaml
-  - https://github.com/konflux-ci/release-service/config/default?ref=f874148f742eecfaa64832a13b2b237d079223bd
+  - https://github.com/konflux-ci/release-service/config/default?ref=178b9cf3b0978d85f0612521ce06061029007956
   - release_service_config.yaml
   - signing_configs.yaml
 
@@ -15,7 +15,7 @@ components:
 images:
   - name: quay.io/konflux-ci/release-service
     newName: quay.io/konflux-ci/release-service
-    newTag: f874148f742eecfaa64832a13b2b237d079223bd
+    newTag: 178b9cf3b0978d85f0612521ce06061029007956
 
 namespace: release-service
 


### PR DESCRIPTION

This reverts commit 77a7fbcc93d3127fc572a653117f0fbe3d923a5b.

The release is not working correctly in stage, reverting to a last known good state. This will bring the operator back to 178b9cf3b0978d85f0612521ce06061029007956

Promotion PR https://github.com/redhat-appstudio/infra-deployments/pull/13873