### PR TITLE
chore(KONFLUX-15689): Remove knative-eventing from development

### DIFF
--- a/argo-cd-apps/overlays/development/delete-applications.yaml
+++ b/argo-cd-apps/overlays/development/delete-applications.yaml
@@ -114,3 +114,9 @@ kind: ApplicationSet
 metadata:
   name: monitoring-cardinality
 $patch: delete
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: knative-eventing
+$patch: delete

--- a/argo-cd-apps/overlays/development/kustomization.yaml
+++ b/argo-cd-apps/overlays/development/kustomization.yaml
@@ -109,11 +109,6 @@ patches:
     target:
       kind: ApplicationSet
       version: v1alpha1
-      name: knative-eventing
-  - path: development-overlay-patch.yaml
-    target:
-      kind: ApplicationSet
-      version: v1alpha1
       name: crossplane-control-plane
   - path: development-overlay-patch.yaml
     target:

--- a/components/knative-eventing/development/kustomization.yaml
+++ b/components/knative-eventing/development/kustomization.yaml
@@ -1,5 +1,0 @@
----
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-resources:
-  - ../base


### PR DESCRIPTION
## What
- Remove `knative-eventing` ApplicationSet from the development environment
- Delete `components/knative-eventing/development/` overlay

Clusters affected: development
[KONFLUX-15689](https://redhat.atlassian.net/browse/KONFLUX-15689)

## Why 
`knative-eventing` was installed as a KubeArchive dependency (Oct 2024)
but KubeArchive dropped that dependency in Sep 2025. No other component
in this repo references it. This is the first step in a full removal
across all environments.

## Risk Assessment

**Risk Level:** Low
**What could go wrong:** If an undiscovered component in the development environment depends on Knative Eventing CRDs or the eventing-webhook, it could fail after removal. No such dependency was found in this repo.
**Rollback:** Revert PR (ArgoCD resyncs the previous desired state).
**Blast radius:** Development environment only.

## Validation
- `kustomize build argo-cd-apps/overlays/development/` passes with zero
  knative-eventing references in output

Assisted-by: Claude Sonnet 4.6 (Cursor)

[KONFLUX-15689]: https://redhat.atlassian.net/browse/KONFLUX-15689?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ