### PR TITLE
SFOPS-9: Add banner warning about Windows signing outage

### DIFF
--- a/components/konflux-info/production/kflux-ocp-p01/banner-content.yaml
+++ b/components/konflux-info/production/kflux-ocp-p01/banner-content.yaml
@@ -1,2 +1,3 @@
 # Only the first banner will be displayed. Put the one to display at the top and remove any which are no longer relevant
-[]
+- summary: "Windows signing is currently broken. Any attempts to use the push-artifacts-to-cdn pipeline, for content that includes windows binaries will fail. See #tmp-win-signing-recovery for updates as well as https://redhat.atlassian.net/browse/SFOPS-9"
+  type: "danger"

--- a/components/konflux-info/production/kflux-osp-p01/banner-content.yaml
+++ b/components/konflux-info/production/kflux-osp-p01/banner-content.yaml
@@ -1,2 +1,3 @@
 # Only the first banner will be displayed. Put the one to display at the top and remove any which are no longer relevant
-[]
+- summary: "Windows signing is currently broken. Any attempts to use the push-artifacts-to-cdn pipeline, for content that includes windows binaries will fail. See #tmp-win-signing-recovery for updates as well as https://redhat.atlassian.net/browse/SFOPS-9"
+  type: "danger"

--- a/components/konflux-info/production/kflux-prd-rh02/banner-content.yaml
+++ b/components/konflux-info/production/kflux-prd-rh02/banner-content.yaml
@@ -1,2 +1,3 @@
 # Only the first banner will be displayed. Put the one to display at the top and remove any which are no longer relevant
-[]
+- summary: "Windows signing is currently broken. Any attempts to use the push-artifacts-to-cdn pipeline, for content that includes windows binaries will fail. See #tmp-win-signing-recovery for updates as well as https://redhat.atlassian.net/browse/SFOPS-9"
+  type: "danger"

--- a/components/konflux-info/production/kflux-prd-rh03/banner-content.yaml
+++ b/components/konflux-info/production/kflux-prd-rh03/banner-content.yaml
@@ -1,2 +1,3 @@
 # Only the first banner will be displayed. Put the one to display at the top and remove any which are no longer relevant
-[]
+- summary: "Windows signing is currently broken. Any attempts to use the push-artifacts-to-cdn pipeline, for content that includes windows binaries will fail. See #tmp-win-signing-recovery for updates as well as https://redhat.atlassian.net/browse/SFOPS-9"
+  type: "danger"

--- a/components/konflux-info/production/kflux-rhel-p01/banner-content.yaml
+++ b/components/konflux-info/production/kflux-rhel-p01/banner-content.yaml
@@ -1,2 +1,3 @@
 # Only the first banner will be displayed. Put the one to display at the top and remove any which are no longer relevant
-[]
+- summary: "Windows signing is currently broken. Any attempts to use the push-artifacts-to-cdn pipeline, for content that includes windows binaries will fail. See #tmp-win-signing-recovery for updates as well as https://redhat.atlassian.net/browse/SFOPS-9"
+  type: "danger"

--- a/components/konflux-info/production/stone-prd-rh01/banner-content.yaml
+++ b/components/konflux-info/production/stone-prd-rh01/banner-content.yaml
@@ -1,2 +1,3 @@
 # Only the first banner will be displayed. Put the one to display at the top and remove any which are no longer relevant
-[]
+- summary: "Windows signing is currently broken. Any attempts to use the push-artifacts-to-cdn pipeline, for content that includes windows binaries will fail. See #tmp-win-signing-recovery for updates as well as https://redhat.atlassian.net/browse/SFOPS-9"
+  type: "danger"

--- a/components/konflux-info/production/stone-prod-p01/banner-content.yaml
+++ b/components/konflux-info/production/stone-prod-p01/banner-content.yaml
@@ -1,2 +1,3 @@
 # Only the first banner will be displayed. Put the one to display at the top and remove any which are no longer relevant
-[]
+- summary: "Windows signing is currently broken. Any attempts to use the push-artifacts-to-cdn pipeline, for content that includes windows binaries will fail. See #tmp-win-signing-recovery for updates as well as https://redhat.atlassian.net/browse/SFOPS-9"
+  type: "danger"

--- a/components/konflux-info/production/stone-prod-p02/banner-content.yaml
+++ b/components/konflux-info/production/stone-prod-p02/banner-content.yaml
@@ -1,3 +1,3 @@
 # Only the first banner will be displayed. Put the one to display at the top and remove any which are no longer relevant
-- summary: "The frequency of MintMaker dependency update checks on stone-prod-p02 was reduced from the default schedule to twice daily (00:00 and 04:00 UTC)."
-  type: "info"
+- summary: "Windows signing is currently broken. Any attempts to use the push-artifacts-to-cdn pipeline, for content that includes windows binaries will fail. See #tmp-win-signing-recovery for updates as well as https://redhat.atlassian.net/browse/SFOPS-9"
+  type: "danger"


### PR DESCRIPTION
## What

Add a UI danger banner across production clusters informing users about the ongoing Windows signing outage affecting `push-artifacts-to-cdn`.

Clusters affected:
- `kflux-ocp-p01`
- `kflux-osp-p01`
- `kflux-prd-rh02`
- `kflux-prd-rh03`
- `kflux-rhel-p01`
- `stone-prd-rh01`
- `stone-prod-p01`
- `stone-prod-p02`

[SFOPS-9](https://redhat.atlassian.net/browse/SFOPS-9)

## Why

Windows signing infrastructure is currently down. Pipelines attempting to use `push-artifacts-to-cdn` for artifacts containing Windows binaries fail. The banner warns users to pause retries and points them to `#tmp-win-signing-recovery` and [SFOPS-9](https://redhat.atlassian.net/browse/SFOPS-9) for status updates.

## Validation

- Verified YAML syntax with `yamllint -c .yamllint.yaml components/konflux-info/production/*/banner-content.yaml`
- Verified Kustomize output generates valid ConfigMaps with `kustomize build components/konflux-info/production/<cluster>/`

## Risk Assessment

**Risk Level:** Low
**What could go wrong:** A malformed banner ConfigMap could fail to render in the UI; no pipeline execution or tenant workloads are affected.
**Rollback:** Revert PR (ArgoCD resyncs previous ConfigMap state).
**Blast radius:** UI banner across production clusters: `kflux-ocp-p01`, `kflux-osp-p01`, `kflux-prd-rh02`, `kflux-prd-rh03`, `kflux-rhel-p01`, `stone-prd-rh01`, `stone-prod-p01`, `stone-prod-p02`.

Signed-off-by: Ben Hills <bhills@redhat.com>

Assisted-by: OpenCode <opencode@redhat.com>

[SFOPS-9]: https://redhat.atlassian.net/browse/SFOPS-9?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ