### PR TITLE
chore(konflux-info): add OWNERS files for production banner-content.yaml

### DIFF
--- a/components/konflux-info/production/OWNERS
+++ b/components/konflux-info/production/OWNERS
@@ -1,0 +1,8 @@
+# See the OWNERS docs: https://go.k8s.io/owners
+
+filters:
+  ".*/banner-content\\.yaml":
+    approvers:
+    - bhills-rh
+    reviewers:
+    - bhills-rh


### PR DESCRIPTION
## What

Add `OWNERS` files with file filters for `banner-content.yaml` across production clusters, adding `bhills-rh` as an approver and reviewer specifically for info banner updates.

Clusters affected:
- `kflux-ocp-p01`
- `kflux-osp-p01`
- `kflux-prd-rh02`
- `kflux-prd-rh03`
- `kflux-rhel-p01`
- `stone-prd-rh01`
- `stone-prod-p01`
- `stone-prod-p02`

## Why

Allows the Konflux User Support rotation to add and remove UI banners directly without requiring Infra team members to manually review and approve banner-only changes, while keeping ownership of surrounding cluster configuration files (`cluster-config.env`, `info.json`, `kustomization.yaml`) with the infra, SRE, and UI teams.

## Validation

- Verified YAML syntax with `yamllint -c .yamllint.yaml components/konflux-info/production/*/OWNERS`
- Verified Kustomize builds succeed unaffected on all target overlays

## Risk Assessment

**Risk Level:** Low  
**What could go wrong:** Malformed OWNERS syntax could block Prow approval evaluation for banner files. Syntax follows existing repo convention (e.g., `components/monitoring/grafana/OWNERS`).  
**Rollback:** Revert PR  
**Blast radius:** Prow approval routing for `banner-content.yaml` in the 8 production clusters listed.

Signed-off-by: Ben Hills <bhills@redhat.com>

Assisted-by: OpenCode <opencode@redhat.com>