### PR TITLE
KONFLUX-15374 Fix etcd-shield image name for Kargo compatibility (pro…

### DIFF
--- a/components/etcd-shield/rings/ring-3/base/base-snapshot/deployment.yaml
+++ b/components/etcd-shield/rings/ring-3/base/base-snapshot/deployment.yaml
@@ -38,7 +38,7 @@ spec:
               fieldPath: metadata.namespace
         - name: "STATE_MANAGER"
           value: "in-memory"
-        image: etcd-shield:latest
+        image: quay.io/konflux-ci/etcd-shield:latest
         name: etcd-shield
         imagePullPolicy: IfNotPresent
         livenessProbe:

--- a/components/etcd-shield/rings/ring-3/base/kustomization.yaml
+++ b/components/etcd-shield/rings/ring-3/base/kustomization.yaml
@@ -2,12 +2,9 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - base-snapshot
-
 images:
-  - name: etcd-shield
-    newName: quay.io/konflux-ci/etcd-shield
+  - name: quay.io/konflux-ci/etcd-shield
     newTag: 94885d051db284f214f43d76df2f9bd4c9fe993f
-
 patches:
   - target:
       kind: PrometheusRule

--- a/components/etcd-shield/rings/ring-4/base/base-snapshot/deployment.yaml
+++ b/components/etcd-shield/rings/ring-4/base/base-snapshot/deployment.yaml
@@ -38,7 +38,7 @@ spec:
               fieldPath: metadata.namespace
         - name: "STATE_MANAGER"
           value: "in-memory"
-        image: etcd-shield:latest
+        image: quay.io/konflux-ci/etcd-shield:latest
         name: etcd-shield
         imagePullPolicy: IfNotPresent
         livenessProbe:

--- a/components/etcd-shield/rings/ring-4/base/kustomization.yaml
+++ b/components/etcd-shield/rings/ring-4/base/kustomization.yaml
@@ -2,12 +2,9 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - base-snapshot
-
 images:
-  - name: etcd-shield
-    newName: quay.io/konflux-ci/etcd-shield
+  - name: quay.io/konflux-ci/etcd-shield
     newTag: 94885d051db284f214f43d76df2f9bd4c9fe993f
-
 patches:
   - target:
       kind: PrometheusRule


### PR DESCRIPTION
…duction)

Use the full image URL (quay.io/konflux-ci/etcd-shield) in the deployment manifest instead of the placeholder name (etcd-shield). This allows Kargo's kustomize-set-image promotion step to match the image correctly.

Previously, Kargo added a duplicate entry in the kustomization images section because the image name it looked up (quay.io/konflux-ci/etcd-shield) didn't match the placeholder name (etcd-shield) in the existing entry.

The result was that Kargo promotions silently failed to update the tag.