### PR TITLE
(onboarding) Remove staging external-secrets-operator apps from AppSRE ArgoCD

### DIFF
--- a/argo-cd-apps/overlays/konflux-public-staging/delete-applications.yaml
+++ b/argo-cd-apps/overlays/konflux-public-staging/delete-applications.yaml
@@ -41,3 +41,9 @@ kind: ApplicationSet
 metadata:
   name: policies
 $patch: delete
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: external-secrets-operator
+$patch: delete

--- a/argo-cd-apps/overlays/staging-downstream/delete-applications.yaml
+++ b/argo-cd-apps/overlays/staging-downstream/delete-applications.yaml
@@ -41,4 +41,10 @@ kind: ApplicationSet
 metadata:
   name: repository-validator
 $patch: delete
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: external-secrets-operator
+$patch: delete
 

--- a/components/external-secrets-operator-rd/rings/ring-1/lightwell-dev/kustomization.yaml
+++ b/components/external-secrets-operator-rd/rings/ring-1/lightwell-dev/kustomization.yaml
@@ -1,0 +1,3 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources: []


### PR DESCRIPTION
## Summary
- Remove external-secrets-operator from staging-downstream and konflux-public-staging overlays
- Staging is now managed by rd-staging ring-1 (merged in #14005)

## Pre-merge checklist (SOP Part 3, steps 6-13)
- [ ] Set `preserveResourcesOnDeletion: true` on ESO AppSet in AppSRE ArgoCD (konflux-public-staging namespace)
- [ ] Verify no `resources-finalizer.argocd.argoproj.io` on ESO Applications
- [ ] Repeat for argocd-staging namespace on internal staging common cluster

## Risk Assessment
- **Level**: Low
- **What could go wrong**: Old staging ArgoCD Applications for ESO get pruned during deletion
- **Rollback**: Revert the delete entries
- **Blast radius**: Staging ESO only; rd-staging ring-1 is already managing these clusters

🤖 Generated with [Claude Code](https://claude.com/claude-code)