### PR TITLE
Add empty lightwell-dev dir for notification-controller-rd

### DIFF
--- a/components/notification-controller-rd/OWNERS
+++ b/components/notification-controller-rd/OWNERS
@@ -1,0 +1,10 @@
+# See the OWNERS docs: https://go.k8s.io/owners
+
+approvers:
+- gbenhaim
+- avi-biton
+- amisstea
+- yftacherzog
+- ifireball
+- hmariset
+- kelchen123

--- a/components/notification-controller-rd/rings/ring-1/lightwell-dev/kustomization.yaml
+++ b/components/notification-controller-rd/rings/ring-1/lightwell-dev/kustomization.yaml
@@ -1,0 +1,3 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources: []


### PR DESCRIPTION
## Summary
- Add empty lightwell-dev Tier 3 directory for notification-controller-rd
- k-components `deploy-to-staging-tenant-clusters` injects lightwell-dev but notification-controller is not deployed there
- Without this dir, ArgoCD generates an Application pointing to a non-existent path

🤖 Generated with [Claude Code](https://claude.com/claude-code)