### PR TITLE
SPRE-6759: Forward Grafana memory metrics in production

### DIFF
--- a/components/monitoring/prometheus/production/base/federation/endpoints-params.yaml
+++ b/components/monitoring/prometheus/production/base/federation/endpoints-params.yaml
@@ -136,7 +136,7 @@
 
     ## Container Metrics
     - '{__name__="kube_pod_container_status_waiting_reason", namespace!~".*-tenant|openshift-.*|kube-.*"}'
-    - '{__name__="kube_pod_container_resource_requests", namespace="appstudio-grafana", resource="cpu"}'
+    - '{__name__="kube_pod_container_resource_requests", namespace="appstudio-grafana", resource=~"cpu|memory"}'
     - '{__name__="kube_pod_container_resource_limits", namespace=~"release-service|rhtap-releng-tenant"}'
     - '{__name__="kube_pod_container_status_terminated_reason", namespace=~"release-service|openshift-etcd|openshift-kube-apiserver|build-service|image-controller|integration-service|konflux-ui|product-kubearchive|product-kubearchive-logging|openshift-kueue-operator|tekton-kueue|mintmaker|multi-platform-controller|namespace-lister|openshift-pipelines|tekton-results|project-controller|smee|smee-client"}'
     - '{__name__="kube_pod_container_status_terminated_reason", namespace=~".*-tenant", reason="OOMKilled"}'
@@ -144,7 +144,7 @@
     - '{__name__="kube_pod_container_status_last_terminated_reason", namespace="release-service"}'
     - '{__name__="kube_pod_container_status_ready", namespace=~"release-service"}'
     - '{__name__="container_cpu_usage_seconds_total", namespace=~"release-service|openshift-etcd|appstudio-grafana"}'
-    - '{__name__="container_memory_usage_bytes", namespace=~"release-service|openshift-etcd|rhtap-releng-tenant"}'
+    - '{__name__="container_memory_usage_bytes", namespace=~"release-service|openshift-etcd|rhtap-releng-tenant|appstudio-grafana"}'
     - '{__name__="kube_pod_container_status_restarts_total", namespace!~".*-tenant"}'
     - '{__name__="namespace:container_memory_usage_bytes:sum", namespace=~"release-service|openshift-etcd|openshift-kube-apiserver|build-service|image-controller|integration-service|konflux-ui|product-kubearchive|product-kubearchive-logging|openshift-kueue-operator|tekton-kueue|mintmaker|multi-platform-controller|namespace-lister|openshift-pipelines|tekton-results|project-controller|smee|smee-client"}'
     - '{__name__="namespace:container_cpu_usage:sum", namespace=~"release-service|openshift-etcd|openshift-kube-apiserver|build-service|image-controller|integration-service|konflux-ui|product-kubearchive|product-kubearchive-logging|openshift-kueue-operator|tekton-kueue|mintmaker|multi-platform-controller|namespace-lister|openshift-pipelines|tekton-results|project-controller|smee|smee-client"}'


### PR DESCRIPTION
## What

Forward these metrics from the `appstudio-grafana` namespace in production to RHOBS:

- `container_memory_usage_bytes`
- `kube_pod_container_resource_requests` for memory

Clusters affected: all production clusters consuming the monitoring Prometheus production base.

[SPRE-6759](https://redhat.atlassian.net/browse/SPRE-6759)

## Why

The Grafana memory alert compares container memory usage with memory requests. Both metrics must be available in RHOBS for the alert to work.

## Risk Assessment

**Risk Level:** Low  
**What could go wrong:** RHOBS will ingest additional memory series for `appstudio-grafana`. Staging had nine additional active series, so the expected increase per comparable cluster is small. An incorrect selector could leave the metrics unavailable to the alert.  
**Rollback:** Revert this PR; ArgoCD will restore the previous federation selectors.  
**Blast radius:** RHOBS metric ingestion for the `appstudio-grafana` namespace across production clusters; no workload impact.

## Validation

Staging PR: https://github.com/redhat-appstudio/infra-deployments/pull/13971

- Staging cardinality: 7 memory usage series and 2 memory request series.
- `yamllint` passes.
- `kustomize build --enable-helm components/monitoring/prometheus/production/base` passes.
- `git diff --check` passes.

[SPRE-6759]: https://redhat.atlassian.net/browse/SPRE-6759?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ