### PR TITLE
KFLUXVNGD-1157 Promote artifact-registry-proxy and container-image-proxy to prod (ring-3)

### DIFF
--- a/components/artifact-registry-proxy/rings/ring-3/base/artifact-registry-credentials-es.yaml
+++ b/components/artifact-registry-proxy/rings/ring-3/base/artifact-registry-credentials-es.yaml
@@ -1,0 +1,22 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: artifact-registry-credentials
+  namespace: artifact-registry-proxy
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: appsre-stonesoup-vault
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Delete
+    name: artifact-registry-credentials
+  data:
+    - secretKey: authorization
+      remoteRef:
+        key: production/vanguard/nexus/proxy-sa-1
+        property: authz_header

--- a/components/artifact-registry-proxy/rings/ring-3/base/base-snapshot/konflux-vanguard-admins-rb.yaml
+++ b/components/artifact-registry-proxy/rings/ring-3/base/base-snapshot/konflux-vanguard-admins-rb.yaml
@@ -1,0 +1,13 @@
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: konflux-vanguard-admins
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: konflux-vanguard
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: admin

--- a/components/artifact-registry-proxy/rings/ring-3/base/base-snapshot/kustomization.yaml
+++ b/components/artifact-registry-proxy/rings/ring-3/base/base-snapshot/kustomization.yaml
@@ -1,4 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+
 resources:
-- ../base
+- konflux-vanguard-admins-rb.yaml

--- a/components/artifact-registry-proxy/rings/ring-3/base/caching-helm-generator.yaml
+++ b/components/artifact-registry-proxy/rings/ring-3/base/caching-helm-generator.yaml
@@ -1,0 +1,68 @@
+apiVersion: builtin
+kind: HelmChartInflationGenerator
+metadata:
+  name: caching-helm
+name: caching-helm
+repo: oci://quay.io/konflux-ci/caching
+version: 0.1.1934+a437a63
+valuesInline:
+  squid:
+    enabled: false
+  nginx:
+    enabled: true
+    namespace: artifact-registry-proxy
+    replicaCount: 3
+    name: artifact-registry-proxy
+    tls:
+      enabled: true
+      secretName: artifact-registry-proxy-tls
+    service:
+      port: 443
+      trafficDistribution: PreferClose
+      annotations:
+        service.beta.openshift.io/serving-cert-secret-name: artifact-registry-proxy-tls
+    upstream:
+      url: https://red-hat.repo.sonatype.app
+    auth:
+      enabled: true
+      secretName: artifact-registry-credentials
+    subFilters:
+      - location: '^/repository/cargo-proxy/config\.json$'
+        types:
+          - application/json
+        once: false
+        filters:
+          - string: '"auth-required":true'
+            replacement: '"auth-required":false'
+          - string: 'https://red-hat.repo.sonatype.app'
+            replacement: 'https://artifact-registry-proxy.artifact-registry-proxy.svc.cluster.local'
+    cache:
+      allowList:
+        - ^/repository/
+      size: 102400
+      ttl: 30d
+    resources:
+      requests:
+        cpu: "2"
+        memory: 2Gi
+      limits:
+        cpu: "2"
+        memory: 2Gi
+  installCertManagerComponents: false
+  cert-manager:
+    enabled: false
+  selfsigned-certificate:
+    enabled: false
+  selfsigned-bundle:
+    enabled: false
+  mirrord:
+    enabled: false
+  test:
+    enabled: false
+  environment: release
+  prometheus:
+    serviceMonitor:
+      nginxTLS:
+        ca:
+          configMapName: openshift-service-ca.crt
+          key: service-ca.crt

--- a/components/artifact-registry-proxy/rings/ring-3/base/kustomization.yaml
+++ b/components/artifact-registry-proxy/rings/ring-3/base/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: artifact-registry-proxy
+resources:
+- base-snapshot
+- artifact-registry-credentials-es.yaml
+generators:
+- caching-helm-generator.yaml

--- a/components/artifact-registry-proxy/rings/ring-3/stone-prod-p02/kustomization.yaml
+++ b/components/artifact-registry-proxy/rings/ring-3/stone-prod-p02/kustomization.yaml
@@ -1,3 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-resources: []
+resources:
+- ../base

--- a/components/container-image-proxy/rings/ring-3/base/base-snapshot/konflux-vanguard-admins-rb.yaml
+++ b/components/container-image-proxy/rings/ring-3/base/base-snapshot/konflux-vanguard-admins-rb.yaml
@@ -1,0 +1,13 @@
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: konflux-vanguard-admins
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: konflux-vanguard
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: admin

--- a/components/container-image-proxy/rings/ring-3/base/base-snapshot/kustomization.yaml
+++ b/components/container-image-proxy/rings/ring-3/base/base-snapshot/kustomization.yaml
@@ -1,4 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+
 resources:
-- ../base
+- konflux-vanguard-admins-rb.yaml
+- trusted-ca-cm.yaml

--- a/components/container-image-proxy/rings/ring-3/base/base-snapshot/trusted-ca-cm.yaml
+++ b/components/container-image-proxy/rings/ring-3/base/base-snapshot/trusted-ca-cm.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: trusted-ca
+  labels:
+    config.openshift.io/inject-trusted-cabundle: "true"

--- a/components/container-image-proxy/rings/ring-3/base/caching-helm-generator.yaml
+++ b/components/container-image-proxy/rings/ring-3/base/caching-helm-generator.yaml
@@ -1,0 +1,76 @@
+apiVersion: builtin
+kind: HelmChartInflationGenerator
+metadata:
+  name: caching-helm
+name: caching-helm
+repo: oci://quay.io/konflux-ci/caching
+version: 0.1.1934+a437a63
+valuesInline:
+  squid:
+    enabled: true
+    namespace: container-image-proxy
+  nginx:
+    enabled: false
+  installCertManagerComponents: false
+  cert-manager:
+    enabled: false
+  selfsigned-certificate:
+    enabled: true
+  selfsigned-bundle:
+    enabled: true
+  mirrord:
+    enabled: false
+  test:
+    enabled: false
+  environment: release
+  replicaCount: 3
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 200m
+      memory: 2Gi
+  icapServer:
+    resources:
+      requests:
+        cpu: 10m
+        memory: 32Mi
+      limits:
+        cpu: 100m
+        memory: 128Mi
+  squidExporter:
+    resources:
+      requests:
+        cpu: 10m
+        memory: 16Mi
+      limits:
+        cpu: 100m
+        memory: 64Mi
+  cache:
+    allowList:
+      - ^https://cdn([0-9]{2})?\.quay\.io/.+/sha256/.+/[a-f0-9]{64}
+      - ^https://s3\.[a-z0-9-]+\.amazonaws\.com/quayio-production-s3/sha256/.+/[a-f0-9]{64}
+      - ^https://quayio-production-s3\.s3[a-z0-9.-]*\.amazonaws\.com/sha256/.+/[a-f0-9]{64}
+      - ^https://production\.cloudflare\.docker\.com/registry-v2/docker/registry/v2/blobs/sha256/[a-f0-9]{2}/[a-f0-9]{64}/data
+      - ^https://docker-images-prod\.[a-f0-9]{32}\.r2\.cloudflarestorage\.com/registry-v2/docker/registry/v2/blobs/sha256/[a-f0-9]{2}/[a-f0-9]{64}/data
+      - ^https://docker-images-prod\.s3[a-z0-9.-]*\.amazonaws\.com/registry-v2/docker/registry/v2/blobs/sha256/[a-f0-9]{2}/[a-f0-9]{64}/data
+      - ^https://cdn\.registry\.fedoraproject\.org/v2/.+/blobs/sha256:[a-f0-9]{64}
+      - ^https://[a-f0-9]{32}\.r2\.cloudflarestorage\.com/app-ci-image-registry/docker/registry/v2/blobs/sha256/[a-f0-9]{2}/[a-f0-9]{64}/data
+      - ^https://layers\.nvcr\.io/registry/docker/registry/v2/blobs/sha256/[a-f0-9]{2}/[a-f0-9]{64}/data
+      - ^https://[a-z0-9]+\.cloudfront\.net/sha256/[a-f0-9]{2}/[a-f0-9]{64}
+    size: 51200
+    maxObjectSize: 1024
+  tlsOutgoingOptions:
+    caFile: /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
+  volumes:
+    - name: trusted-ca
+      configMap:
+        name: trusted-ca
+        items:
+          - key: ca-bundle.crt
+            path: tls-ca-bundle.pem
+  volumeMounts:
+    - name: trusted-ca
+      mountPath: /etc/pki/ca-trust/extracted/pem
+      readOnly: true

--- a/components/container-image-proxy/rings/ring-3/base/kustomization.yaml
+++ b/components/container-image-proxy/rings/ring-3/base/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: container-image-proxy
+resources:
+- base-snapshot
+generators:
+- caching-helm-generator.yaml

--- a/components/container-image-proxy/rings/ring-3/stone-prd-rh01/kustomization.yaml
+++ b/components/container-image-proxy/rings/ring-3/stone-prd-rh01/kustomization.yaml
@@ -1,3 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-resources: []
+resources:
+- ../base

--- a/components/container-image-proxy/rings/ring-3/stone-prod-p02/kustomization.yaml
+++ b/components/container-image-proxy/rings/ring-3/stone-prod-p02/kustomization.yaml
@@ -1,3 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-resources: []
+resources:
+- ../base


### PR DESCRIPTION
## What

- Deploy `artifact-registry-proxy` and `container-image-proxy` to ring 3 using caching chart `0.1.1934+a437a63`
- Add ring 3 bases and connect the existing cluster overlays to them.

Clusters affected: `stone-prd-rh01`, `stone-prod-p02`.

[KFLUXVNGD-1157](https://redhat.atlassian.net/browse/KFLUXVNGD-1157)

## Why

Continue the caching proxy rollout from ring 2 to ring 3, providing the ring-specific manifests needed to deploy and subsequently promote both proxies on these clusters.

## Validation

- All four affected cluster overlays build successfully with `kustomize build --enable-helm`: both proxies on `stone-prd-rh01` and `stone-prod-p02`.
- Prior rollout configuration: ring 2 #13996; ring 1 artifact registry proxy #13922 and container image proxy #13921.

## Risk Assessment

**Risk Level:** Medium

**What could go wrong:** Proxy workloads may fail to start, Vault credentials or TLS/CA configuration may fail, or additional cache workloads may cause resource pressure. Requests routed through the new proxies could fail or delay builds.

**Rollback:** Revert this PR and sync the existing ArgoCD Applications to restore the empty ring 3 overlays and prune the newly deployed proxy resources. Verify the generated credentials Secret is removed with its owning ExternalSecret. The ApplicationSets remain in place.

**Blast radius:** Both caching proxies on the two ring 3 production clusters, `stone-prd-rh01` and `stone-prod-p02`.

Assisted-by: OpenAI Codex

[KFLUXVNGD-1157]: https://redhat.atlassian.net/browse/KFLUXVNGD-1157?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ