### PR TITLE
feat(KFLUXINFRA-4368) Update fedora konflux certificate alias.

### DIFF
--- a/components/konflux-ui/production/kflux-fedora-01/dex-config.yaml
+++ b/components/konflux-ui/production/kflux-fedora-01/dex-config.yaml
@@ -14,6 +14,7 @@ staticClients:
   redirectURIs:
   - https://konflux-ui.apps.kflux-fedora-01.84db.p1.openshiftapps.com/oauth2/callback
   - https://konflux-ci.fedoraproject.org/oauth2/callback
+  - https://konflux.fedoraproject.org/oauth2/callback
   name: 'oauth2-proxy'
   secretEnv: 'OAUTH2_CLIENT_SECRET'
 

--- a/components/konflux-ui/production/kflux-fedora-01/letsencrypt/certificate.yaml
+++ b/components/konflux-ui/production/kflux-fedora-01/letsencrypt/certificate.yaml
@@ -7,6 +7,7 @@ spec:
   commonName: konflux-ci.fedoraproject.org
   dnsNames:
     - konflux-ci.fedoraproject.org
+    - konflux.fedoraproject.org
   usages:
     - server auth
   issuerRef:

--- a/components/konflux-ui/production/kflux-fedora-01/letsencrypt/certificate.yaml
+++ b/components/konflux-ui/production/kflux-fedora-01/letsencrypt/certificate.yaml
@@ -5,6 +5,8 @@ metadata:
   namespace: konflux-ui
 spec:
   commonName: konflux-ci.fedoraproject.org
+  duration: 2160h
+  renewBefore: 168h
   dnsNames:
     - konflux-ci.fedoraproject.org
     - konflux.fedoraproject.org

--- a/components/konflux-ui/production/kflux-fedora-01/letsencrypt/konflux-san-routes.yaml
+++ b/components/konflux-ui/production/kflux-fedora-01/letsencrypt/konflux-san-routes.yaml
@@ -1,0 +1,44 @@
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: konflux-san
+  annotations:
+    haproxy.router.openshift.io/set-forwarded-headers: replace
+spec:
+  host: konflux.fedoraproject.org
+  path: /
+  port:
+    targetPort: web-tls
+  tls:
+    externalCertificate:
+      name: konflux-ci-certificate
+    insecureEdgeTerminationPolicy: Redirect
+    termination: reencrypt
+  to:
+    kind: Service
+    name: proxy
+    weight: 100
+  wildcardPolicy: None
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: konflux-san-idp
+  annotations:
+    haproxy.router.openshift.io/set-forwarded-headers: replace
+spec:
+  host: konflux.fedoraproject.org
+  path: /idp
+  port:
+    targetPort: dex
+  tls:
+    externalCertificate:
+      name: konflux-ci-certificate
+    insecureEdgeTerminationPolicy: Redirect
+    termination: reencrypt
+  to:
+    kind: Service
+    name: dex
+    weight: 100
+  wildcardPolicy: None

--- a/components/konflux-ui/production/kflux-fedora-01/letsencrypt/kustomization.yaml
+++ b/components/konflux-ui/production/kflux-fedora-01/letsencrypt/kustomization.yaml
@@ -4,6 +4,7 @@ resources:
 - certificate-secret-reader.yaml
 - certificate.yaml
 - issuer.yaml
+- konflux-san-routes.yaml
 - route-cert-sync-cronjob.yaml
 - secret-reader-binding.yaml
 namespace: konflux-ui

--- a/components/konflux-ui/production/kflux-fedora-01/oauth2-proxy-args-patch.yaml
+++ b/components/konflux-ui/production/kflux-fedora-01/oauth2-proxy-args-patch.yaml
@@ -28,4 +28,6 @@
     - konflux-ui.apps.kflux-fedora-01.84db.p1.openshiftapps.com
     - --whitelist-domain
     - konflux-ci.fedoraproject.org
+    - --whitelist-domain
+    - konflux.fedoraproject.org
     - --skip-provider-button


### PR DESCRIPTION
### Summary of Changes
As part of fedora request to use new alias, it's required to update the konflux ui certificate and include new routes for the new alias.

[KFLUXINFRA-4368](https://redhat.atlassian.net/browse/KFLUXINFRA-4368)
- Include new SAN for fedora konflux.
- Update to use external cert field in Routes.
- Update oauth redirect.

### Verification
After merging PR, validate the new certificate and routes.

### Risk Level
**Risk Level**: Medium
**Rollback Strategy**: Revert the PR removing the new certificate with new alias and new routes.

## Validation
The change using external certificate option has been tested in cluster.


[KFLUXINFRA-4368]: https://redhat.atlassian.net/browse/KFLUXINFRA-4368?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ