### PR TITLE
fix(stone-prod-p02): add linux-g6xlarge-amd64 GPU platform to Kueue and MPC

### DIFF
--- a/components/kueue/rings/ring-3/stone-prod-p02/cluster-queue.yaml
+++ b/components/kueue/rings/ring-3/stone-prod-p02/cluster-queue.yaml
@@ -107,6 +107,7 @@ spec:
     - linux-extra-fast-amd64
     - linux-fast-amd64
     - linux-g64xlarge-amd64
+    - linux-g6xlarge-amd64
     - linux-m2xlarge-amd64
     - linux-m2xlarge-arm64
     - linux-m4xlarge-amd64
@@ -137,6 +138,8 @@ spec:
       - name: linux-fast-amd64
         nominalQuota: '250'
       - name: linux-g64xlarge-amd64
+        nominalQuota: '250'
+      - name: linux-g6xlarge-amd64
         nominalQuota: '250'
       - name: linux-m2xlarge-amd64
         nominalQuota: '250'

--- a/components/multi-platform-controller/rings/ring-3/stone-prod-p02/host-values.yaml
+++ b/components/multi-platform-controller/rings/ring-3/stone-prod-p02/host-values.yaml
@@ -103,7 +103,7 @@ dynamicConfigs:
 
   linux-d160-c8xlarge-amd64: {}
 
-  linux-g4xlarge-amd64: {}
+  linux-g6xlarge-amd64: {}
 
   linux-g64xlarge-amd64:
     ami: "ami-0133ba5e6e6d57a02"


### PR DESCRIPTION
## Problem

The `linux-g6xlarge-amd64` (AWS `g6.xlarge`) GPU platform is configured in the MPC Helm chart template but was **missing from both** the Kueue ClusterQueue and the MPC `host-values.yaml` on `stone-prod-p02`. This causes PipelineRuns requesting the `linux-g6xlarge/amd64` platform to be stuck in `PipelineRunPending` indefinitely.

**Observed symptoms:**
- PipelineRun `odf-lightspeed-rag-content-5-0-on-push-r877w` in namespace `rhodf-tenant` has been stuck in `PipelineRunPending` for 25+ hours.
- Kueue workload status: `"couldn't assign flavors to pod set pod-set-1: resource linux-g6xlarge-amd64 unavailable in ClusterQueue"`
- The RHODF team switched from `linux-g64xlarge/amd64` (g6.4xlarge) to `linux-g6xlarge/amd64` (g6.xlarge) after hitting AWS capacity issues in us-east-1a, but the new platform was never admitted by Kueue.

## Root Cause

1. **Kueue ClusterQueue** for `stone-prod-p02` did not include `linux-g6xlarge-amd64` in its `coveredResources` or flavor resource list. Without this, Kueue cannot admit workloads requesting this platform.
2. **MPC host-values.yaml** for `stone-prod-p02` had an entry `linux-g4xlarge-amd64: {}` which does not match any Helm chart template (`linux-g4xlarge-amd64` does not exist). This is likely a typo for `linux-g6xlarge-amd64`. Without the correct key, the MPC dynamic allocator would not register the `g6.xlarge` platform.

## Changes

### `components/kueue/rings/ring-3/stone-prod-p02/cluster-queue.yaml`
- Added `linux-g6xlarge-amd64` to `coveredResources` in `platform-group-2` (alongside existing `linux-g64xlarge-amd64`)
- Added `linux-g6xlarge-amd64` with `nominalQuota: 250` to the flavor resource list

### `components/multi-platform-controller/rings/ring-3/stone-prod-p02/host-values.yaml`
- Renamed `linux-g4xlarge-amd64: {}` to `linux-g6xlarge-amd64: {}` to match the Helm chart template key for `g6.xlarge`

## Verification

- Confirmed `g6.xlarge` is available in us-east-1a via AWS dry-run (`DryRunOperation` = would succeed)
- Confirmed other clusters (e.g., `kflux-osp-p01`) already have `linux-g6xlarge-amd64` in their Kueue config as a reference pattern
- AWS account: `381491906438` (konflux-prod-int-mab01)

## References

- Support ticket: [KFLUXSPRT-8982](https://redhat.atlassian.net/browse/KFLUXSPRT-8982)
- Related known issue (single-AZ constraint): [KONFLUX-15433](https://issues.redhat.com/browse/KONFLUX-15433)
- Affected component: `odf-lightspeed-rag-content-5-0` in `rhodf-tenant` on `stone-prod-p02`
- Cluster: `stone-prod-p02` (internal production)

[KFLUXSPRT-8982]: https://redhat.atlassian.net/browse/KFLUXSPRT-8982?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ