### PR TITLE
Configure kflux-lw-p01 MPC AWS host values and local platforms

### DIFF
--- a/components/multi-platform-controller/rings/ring-2/kflux-lw-p01/host-values.yaml
+++ b/components/multi-platform-controller/rings/ring-2/kflux-lw-p01/host-values.yaml
@@ -1,9 +1,9 @@
 environment: production
 
 localPlatforms:
- - "linux/x86_64"
- - "local"
- - "localhost"
+  - "linux/x86_64"
+  - "local"
+  - "localhost"
 
 instanceTag: "lw-p01"
 

--- a/components/multi-platform-controller/rings/ring-2/kflux-lw-p01/host-values.yaml
+++ b/components/multi-platform-controller/rings/ring-2/kflux-lw-p01/host-values.yaml
@@ -1,10 +1,9 @@
 environment: production
 
-#localPlatforms:
-#  - "linux/amd64"
-#  - "linux/x86_64"
-#  - "local"
-#  - "localhost"
+localPlatforms:
+ - "linux/x86_64"
+ - "local"
+ - "localhost"
 
 instanceTag: "lw-p01"
 
@@ -14,15 +13,15 @@ additionalInstanceTags:
 archDefaults:
   arm64:
     ami: "ami-06f37afe6d4f43c47"
-    key-name: "kflux-lwp01-key-pair"
-    security-group-id: "SG_ID"
-    subnet-id: "SUBNET_ID"
+    key-name: "aws-ssh-key"
+    security-group-id: "sg-0e908ebe99d326f0c"
+    subnet-id: "subnet-07e9ae539ece248ce"
 
   amd64:
     ami: "ami-01aaf1c29c7e0f0af"
-    key-name: "kflux-lwp01-key-pair"
-    security-group-id: "SG_ID"
-    subnet-id: "SUBNET_ID"
+    key-name: "aws-ssh-key"
+    security-group-id: "sg-0e908ebe99d326f0c"
+    subnet-id: "subnet-07e9ae539ece248ce"
 
 dynamicConfigs:
   linux-arm64: {}


### PR DESCRIPTION
## What

- Enable `localPlatforms` on kflux-lw-p01 MPC (`linux/x86_64`, `local`, `localhost`)
- Replace placeholder AWS network settings with real security group and subnet IDs
- Align `key-name` with the `aws-ssh-key` ExternalSecret

Clusters affected: kflux-lw-p01

## Why

kflux-lw-p01 MPC host configuration still had placeholder `SG_ID` / `SUBNET_ID` values and a mismatched key pair name, preventing dynamic AWS host provisioning. Local platform support is needed for builds targeting the cluster itself.

## Validation

- `kustomize build --enable-helm components/multi-platform-controller/rings/ring-2/kflux-lw-p01/` passes

## Risk Assessment

**Risk Level:** Medium
**What could go wrong:** Incorrect subnet or security group IDs could cause EC2 provisioning failures; wrong key name would prevent SSH to provisioned hosts; enabling local platforms could route builds differently than expected.
**Rollback:** Revert PR and let ArgoCD sync the previous host-values.
**Blast radius:** kflux-lw-p01 production (ring-2) MPC only


Made with [Cursor](https://cursor.com)