### PR TITLE
Update konflux-kite staging images to 83d204d

### DIFF
--- a/components/konflux-kite/staging/base/kustomization.yaml
+++ b/components/konflux-kite/staging/base/kustomization.yaml
@@ -9,7 +9,7 @@ namespace: konflux-kite
 
 images:
   - name: quay.io/konflux-ci/kite-prod
-    newTag: c3b0335fcec1a5d4fb4fa5cdf1de27bf74be2bd1
+    newTag: 83d204d72048f68d069aac980d188c1aebbd5098
 
   - name: quay.io/konflux-ci/kite-init
-    newTag: c3b0335fcec1a5d4fb4fa5cdf1de27bf74be2bd1
+    newTag: 83d204d72048f68d069aac980d188c1aebbd5098


### PR DESCRIPTION
## What

Update konflux-kite component images for the staging environment:
- `quay.io/konflux-ci/kite-init:83d204d72048f68d069aac980d188c1aebbd5098`
- `quay.io/konflux-ci/kite-prod:83d204d72048f68d069aac980d188c1aebbd5098`

Clusters affected: staging (stone-stg-rh01, stone-stage-p01)

## Why

Bump kite-init and kite-prod container images to the latest build.

## Validation

- Staging-only change, no production clusters affected

Made with [Cursor](https://cursor.com)