### PR TITLE
Update konflux-kite production images to 83d204d

### DIFF
--- a/components/konflux-kite/production/base/kustomization.yaml
+++ b/components/konflux-kite/production/base/kustomization.yaml
@@ -9,7 +9,7 @@ namespace: konflux-kite
 
 images:
   - name: quay.io/konflux-ci/kite-prod
-    newTag: 055da067584e6d5dcce86109b9c2df144389bec5
+    newTag: 83d204d72048f68d069aac980d188c1aebbd5098
 
   - name: quay.io/konflux-ci/kite-init
-    newTag: 055da067584e6d5dcce86109b9c2df144389bec5
+    newTag: 83d204d72048f68d069aac980d188c1aebbd5098


### PR DESCRIPTION
## What

Update konflux-kite component images for the production environment:
- `quay.io/konflux-ci/kite-init:83d204d72048f68d069aac980d188c1aebbd5098`
- `quay.io/konflux-ci/kite-prod:83d204d72048f68d069aac980d188c1aebbd5098`

Clusters affected: all production clusters consuming `production/base/` (kflux-fedora-01, kflux-lw-p01, kflux-ocp-p01, kflux-osp-p01, kflux-prd-rh02, kflux-prd-rh03, kflux-rhel-p01, stone-prd-rh01, stone-prod-p01, stone-prod-p02)

## Why

Bump kite-init and kite-prod container images to the latest build, matching the staging update in https://github.com/redhat-appstudio/infra-deployments/pull/14076.

## Validation

- Staging PR: https://github.com/redhat-appstudio/infra-deployments/pull/14076

## Risk Assessment

**Risk Level:** Low
**What could go wrong:** The new image could introduce a regression in kite-init or kite-prod causing API errors or failed init container startup across production clusters.
**Rollback:** Revert PR to restore previous image tag (055da067584e6d5dcce86109b9c2df144389bec5).
**Blast radius:** All production clusters consuming production/base: kflux-fedora-01, kflux-lw-p01, kflux-ocp-p01, kflux-osp-p01, kflux-prd-rh02, kflux-prd-rh03, kflux-rhel-p01, stone-prd-rh01, stone-prod-p01, stone-prod-p02.
