### PR TITLE
KFLUXVNGD-1157 Update production proxy endpoints (ring-2)

### DIFF
--- a/components/konflux-info/production/kflux-ocp-p01/cluster-config.env
+++ b/components/konflux-info/production/kflux-ocp-p01/cluster-config.env
@@ -1,12 +1,12 @@
 allow-cache-proxy=true
-http-proxy=squid.caching.svc.cluster.local:3128
+http-proxy=squid.container-image-proxy.svc.cluster.local:3128
 no-proxy=
 
 allow-package-registry-proxy=true
-package-registry-proxy-bundler-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/rubygems-proxy
-package-registry-proxy-cargo-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/cargo-proxy
-package-registry-proxy-gomod-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/go-proxy
-package-registry-proxy-npm-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/npm-proxy
-package-registry-proxy-pip-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/pypi-proxy/simple
-package-registry-proxy-pnpm-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/npm-proxy
-package-registry-proxy-yarn-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/npm-proxy
+package-registry-proxy-bundler-url=https://artifact-registry-proxy.artifact-registry-proxy.svc.cluster.local/repository/rubygems-proxy
+package-registry-proxy-cargo-url=https://artifact-registry-proxy.artifact-registry-proxy.svc.cluster.local/repository/cargo-proxy
+package-registry-proxy-gomod-url=https://artifact-registry-proxy.artifact-registry-proxy.svc.cluster.local/repository/go-proxy
+package-registry-proxy-npm-url=https://artifact-registry-proxy.artifact-registry-proxy.svc.cluster.local/repository/npm-proxy
+package-registry-proxy-pip-url=https://artifact-registry-proxy.artifact-registry-proxy.svc.cluster.local/repository/pypi-proxy/simple
+package-registry-proxy-pnpm-url=https://artifact-registry-proxy.artifact-registry-proxy.svc.cluster.local/repository/npm-proxy
+package-registry-proxy-yarn-url=https://artifact-registry-proxy.artifact-registry-proxy.svc.cluster.local/repository/npm-proxy

--- a/components/konflux-info/production/kflux-osp-p01/cluster-config.env
+++ b/components/konflux-info/production/kflux-osp-p01/cluster-config.env
@@ -1,12 +1,12 @@
 allow-cache-proxy=true
-http-proxy=squid.caching.svc.cluster.local:3128
+http-proxy=squid.container-image-proxy.svc.cluster.local:3128
 no-proxy=
 
 allow-package-registry-proxy=true
-package-registry-proxy-bundler-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/rubygems-proxy
-package-registry-proxy-cargo-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/cargo-proxy
-package-registry-proxy-gomod-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/go-proxy
-package-registry-proxy-npm-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/npm-proxy
-package-registry-proxy-pip-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/pypi-proxy/simple
-package-registry-proxy-pnpm-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/npm-proxy
-package-registry-proxy-yarn-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/npm-proxy
+package-registry-proxy-bundler-url=https://artifact-registry-proxy.artifact-registry-proxy.svc.cluster.local/repository/rubygems-proxy
+package-registry-proxy-cargo-url=https://artifact-registry-proxy.artifact-registry-proxy.svc.cluster.local/repository/cargo-proxy
+package-registry-proxy-gomod-url=https://artifact-registry-proxy.artifact-registry-proxy.svc.cluster.local/repository/go-proxy
+package-registry-proxy-npm-url=https://artifact-registry-proxy.artifact-registry-proxy.svc.cluster.local/repository/npm-proxy
+package-registry-proxy-pip-url=https://artifact-registry-proxy.artifact-registry-proxy.svc.cluster.local/repository/pypi-proxy/simple
+package-registry-proxy-pnpm-url=https://artifact-registry-proxy.artifact-registry-proxy.svc.cluster.local/repository/npm-proxy
+package-registry-proxy-yarn-url=https://artifact-registry-proxy.artifact-registry-proxy.svc.cluster.local/repository/npm-proxy

--- a/components/konflux-info/production/kflux-prd-rh03/cluster-config.env
+++ b/components/konflux-info/production/kflux-prd-rh03/cluster-config.env
@@ -1,12 +1,12 @@
 allow-cache-proxy=true
-http-proxy=squid.caching.svc.cluster.local:3128
+http-proxy=squid.container-image-proxy.svc.cluster.local:3128
 no-proxy=
 
 allow-package-registry-proxy=true
-package-registry-proxy-bundler-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/rubygems-proxy
-package-registry-proxy-cargo-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/cargo-proxy
-package-registry-proxy-gomod-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/go-proxy
-package-registry-proxy-npm-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/npm-proxy
-package-registry-proxy-pip-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/pypi-proxy/simple
-package-registry-proxy-pnpm-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/npm-proxy
-package-registry-proxy-yarn-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/npm-proxy
+package-registry-proxy-bundler-url=https://artifact-registry-proxy.artifact-registry-proxy.svc.cluster.local/repository/rubygems-proxy
+package-registry-proxy-cargo-url=https://artifact-registry-proxy.artifact-registry-proxy.svc.cluster.local/repository/cargo-proxy
+package-registry-proxy-gomod-url=https://artifact-registry-proxy.artifact-registry-proxy.svc.cluster.local/repository/go-proxy
+package-registry-proxy-npm-url=https://artifact-registry-proxy.artifact-registry-proxy.svc.cluster.local/repository/npm-proxy
+package-registry-proxy-pip-url=https://artifact-registry-proxy.artifact-registry-proxy.svc.cluster.local/repository/pypi-proxy/simple
+package-registry-proxy-pnpm-url=https://artifact-registry-proxy.artifact-registry-proxy.svc.cluster.local/repository/npm-proxy
+package-registry-proxy-yarn-url=https://artifact-registry-proxy.artifact-registry-proxy.svc.cluster.local/repository/npm-proxy

--- a/components/konflux-info/production/kflux-rhel-p01/cluster-config.env
+++ b/components/konflux-info/production/kflux-rhel-p01/cluster-config.env
@@ -1,12 +1,12 @@
 allow-cache-proxy=true
-http-proxy=squid.caching.svc.cluster.local:3128
+http-proxy=squid.container-image-proxy.svc.cluster.local:3128
 no-proxy=
 
 allow-package-registry-proxy=true
-package-registry-proxy-bundler-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/rubygems-proxy
-package-registry-proxy-cargo-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/cargo-proxy
-package-registry-proxy-gomod-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/go-proxy
-package-registry-proxy-npm-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/npm-proxy
-package-registry-proxy-pip-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/pypi-proxy/simple
-package-registry-proxy-pnpm-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/npm-proxy
-package-registry-proxy-yarn-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/npm-proxy
+package-registry-proxy-bundler-url=https://artifact-registry-proxy.artifact-registry-proxy.svc.cluster.local/repository/rubygems-proxy
+package-registry-proxy-cargo-url=https://artifact-registry-proxy.artifact-registry-proxy.svc.cluster.local/repository/cargo-proxy
+package-registry-proxy-gomod-url=https://artifact-registry-proxy.artifact-registry-proxy.svc.cluster.local/repository/go-proxy
+package-registry-proxy-npm-url=https://artifact-registry-proxy.artifact-registry-proxy.svc.cluster.local/repository/npm-proxy
+package-registry-proxy-pip-url=https://artifact-registry-proxy.artifact-registry-proxy.svc.cluster.local/repository/pypi-proxy/simple
+package-registry-proxy-pnpm-url=https://artifact-registry-proxy.artifact-registry-proxy.svc.cluster.local/repository/npm-proxy
+package-registry-proxy-yarn-url=https://artifact-registry-proxy.artifact-registry-proxy.svc.cluster.local/repository/npm-proxy

--- a/components/konflux-info/production/stone-prod-p01/cluster-config.env
+++ b/components/konflux-info/production/stone-prod-p01/cluster-config.env
@@ -1,12 +1,12 @@
 allow-cache-proxy=true
-http-proxy=squid.caching.svc.cluster.local:3128
+http-proxy=squid.container-image-proxy.svc.cluster.local:3128
 no-proxy=
 
 allow-package-registry-proxy=true
-package-registry-proxy-bundler-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/rubygems-proxy
-package-registry-proxy-cargo-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/cargo-proxy
-package-registry-proxy-gomod-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/go-proxy
-package-registry-proxy-npm-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/npm-proxy
-package-registry-proxy-pip-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/pypi-proxy/simple
-package-registry-proxy-pnpm-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/npm-proxy
-package-registry-proxy-yarn-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/npm-proxy
+package-registry-proxy-bundler-url=https://artifact-registry-proxy.artifact-registry-proxy.svc.cluster.local/repository/rubygems-proxy
+package-registry-proxy-cargo-url=https://artifact-registry-proxy.artifact-registry-proxy.svc.cluster.local/repository/cargo-proxy
+package-registry-proxy-gomod-url=https://artifact-registry-proxy.artifact-registry-proxy.svc.cluster.local/repository/go-proxy
+package-registry-proxy-npm-url=https://artifact-registry-proxy.artifact-registry-proxy.svc.cluster.local/repository/npm-proxy
+package-registry-proxy-pip-url=https://artifact-registry-proxy.artifact-registry-proxy.svc.cluster.local/repository/pypi-proxy/simple
+package-registry-proxy-pnpm-url=https://artifact-registry-proxy.artifact-registry-proxy.svc.cluster.local/repository/npm-proxy
+package-registry-proxy-yarn-url=https://artifact-registry-proxy.artifact-registry-proxy.svc.cluster.local/repository/npm-proxy


### PR DESCRIPTION
## What

- Update konflux-info cluster-config endpoints to use Squid in the container-image-proxy namespace and the artifact registry proxy in the artifact-registry-proxy namespace.
- Update existing cluster-config files for ring 2 clusters selected from artifact-registry-proxy. 

Clusters affected: `kflux-ocp-p01`, `kflux-osp-p01`, `kflux-prd-rh03`, `kflux-rhel-p01`, `stone-prod-p01`.

[KFLUXVNGD-1157](https://redhat.atlassian.net/browse/KFLUXVNGD-1157)

## Why

Route cache and package registry traffic to the dedicated proxy deployments, following the staging endpoint update in #13831.

## Validation

- Staging configuration reference: #13831. Ring 2 proxy deployment reference: #13996.

## Risk Assessment

**Risk Level:** Medium

**What could go wrong:** Incorrect service addresses, unavailable proxies, or proxy authentication/TLS failures could cause image or package downloads to fail and delay builds.

**Rollback:** Revert this PR and sync the affected konflux-info Applications. This restores the previous proxy endpoints on the five existing cluster-config ConfigMaps. Verify consumers return to the previous configuration.

**Blast radius:** Proxy configuration consumed by builds on the five ring 2 production clusters listed above.

Assisted-by: OpenAI Codex

[KFLUXVNGD-1157]: https://redhat.atlassian.net/browse/KFLUXVNGD-1157?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ