### PR TITLE
mintmaker: add new renovate-image annotation rules for pre-prod

### DIFF
--- a/components/mintmaker/development/kustomizeconfig.yaml
+++ b/components/mintmaker/development/kustomizeconfig.yaml
@@ -1,3 +1,5 @@
 images:
 - path: spec/template/metadata/annotations/mintmaker.appstudio.redhat.com\/renovate-image
   kind: Deployment
+- path: spec/template/metadata/annotations/mintmaker.konflux-ci.dev\/renovate-image
+  kind: Deployment

--- a/components/mintmaker/staging/base/kustomizeconfig.yaml
+++ b/components/mintmaker/staging/base/kustomizeconfig.yaml
@@ -1,3 +1,5 @@
 images:
 - path: spec/template/metadata/annotations/mintmaker.appstudio.redhat.com\/renovate-image
   kind: Deployment
+- path: spec/template/metadata/annotations/mintmaker.konflux-ci.dev\/renovate-image
+  kind: Deployment


### PR DESCRIPTION
Add rules to the dev and stage kustomize configs to enable the image transformer to patch in the same way as the legacy annotation. The old annotation and rule are retained during the migration and will be decommissioned later.