### PR TITLE
feat(KFLUXINFRA-4368): Add konflux-ci.fedoraproject.org routes

### DIFF
--- a/components/konflux-ui/production/kflux-fedora-01/letsencrypt/konflux-san-routes.yaml
+++ b/components/konflux-ui/production/kflux-fedora-01/letsencrypt/konflux-san-routes.yaml
@@ -42,3 +42,47 @@ spec:
     name: dex
     weight: 100
   wildcardPolicy: None
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: konflux-nice
+  annotations:
+    haproxy.router.openshift.io/set-forwarded-headers: replace
+spec:
+  host: konflux-ci.fedoraproject.org
+  path: /
+  port:
+    targetPort: web-tls
+  tls:
+    externalCertificate:
+      name: konflux-ci-certificate
+    insecureEdgeTerminationPolicy: Redirect
+    termination: reencrypt
+  to:
+    kind: Service
+    name: proxy
+    weight: 100
+  wildcardPolicy: None
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: konflux-nice-idp
+  annotations:
+    haproxy.router.openshift.io/set-forwarded-headers: replace
+spec:
+  host: konflux-ci.fedoraproject.org
+  path: /idp
+  port:
+    targetPort: dex
+  tls:
+    externalCertificate:
+      name: konflux-ci-certificate
+    insecureEdgeTerminationPolicy: Redirect
+    termination: reencrypt
+  to:
+    kind: Service
+    name: dex
+    weight: 100
+  wildcardPolicy: None


### PR DESCRIPTION
## What

Add GitOps-managed routes for `konflux-ci.fedoraproject.org` alias.
Both routes use `externalCertificate`.
This PR brings routes to the same pattern as the `konflux-san` routes.

Clusters affected: kflux-fedora-01

[KFLUXINFRA-4368](https://redhat.atlassian.net/browse/KFLUXINFRA-4368)

## Why

The kflux-fedora-01 cluster now supports `RouteExternalCertificate` (proven by the successful deployment in PR #14070). The routes can now be managed declaratively via GitOps instead of requiring synchronization via cronjob.

This enables:
- Version-controlled route definitions
- Automatic certificate synchronization 

## Validation

- kustomize build passes
- Generated routes verified to include all custom domain routes 
- All routes correctly reference `konflux-ci-certificate`
- Pattern validated in production by [PR #14070](https://github.com/redhat-appstudio/infra-deployments/pull/14070), which successfully deployed `konflux.fedoraproject.org` routes.

## Risk Assessment

**Risk Level:** Low

**What could go wrong:** Brief traffic disruption during route transition from inline certificates to externalCertificate reference as ArgoCD updates the existing manual routes in place.

**Rollback:** Revert PR. ArgoCD will restore previous state. The existing route-cert-sync-cronjob will restore certificates.


[KFLUXINFRA-4368]: https://redhat.atlassian.net/browse/KFLUXINFRA-4368?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ