### PR TITLE
KFLUXVNGD-1157 Update production proxy endpoints (ring-3)

### DIFF
--- a/components/konflux-info/production/stone-prd-rh01/cluster-config.env
+++ b/components/konflux-info/production/stone-prd-rh01/cluster-config.env
@@ -1,12 +1,12 @@
 allow-cache-proxy=true
-http-proxy=squid.caching.svc.cluster.local:3128
+http-proxy=squid.container-image-proxy.svc.cluster.local:3128
 no-proxy=
 
 allow-package-registry-proxy=true
-package-registry-proxy-bundler-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/rubygems-proxy
-package-registry-proxy-cargo-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/cargo-proxy
-package-registry-proxy-gomod-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/go-proxy
-package-registry-proxy-npm-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/npm-proxy
-package-registry-proxy-pip-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/pypi-proxy/simple
-package-registry-proxy-pnpm-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/npm-proxy
-package-registry-proxy-yarn-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/npm-proxy
+package-registry-proxy-bundler-url=https://artifact-registry-proxy.artifact-registry-proxy.svc.cluster.local/repository/rubygems-proxy
+package-registry-proxy-cargo-url=https://artifact-registry-proxy.artifact-registry-proxy.svc.cluster.local/repository/cargo-proxy
+package-registry-proxy-gomod-url=https://artifact-registry-proxy.artifact-registry-proxy.svc.cluster.local/repository/go-proxy
+package-registry-proxy-npm-url=https://artifact-registry-proxy.artifact-registry-proxy.svc.cluster.local/repository/npm-proxy
+package-registry-proxy-pip-url=https://artifact-registry-proxy.artifact-registry-proxy.svc.cluster.local/repository/pypi-proxy/simple
+package-registry-proxy-pnpm-url=https://artifact-registry-proxy.artifact-registry-proxy.svc.cluster.local/repository/npm-proxy
+package-registry-proxy-yarn-url=https://artifact-registry-proxy.artifact-registry-proxy.svc.cluster.local/repository/npm-proxy

--- a/components/konflux-info/production/stone-prod-p02/cluster-config.env
+++ b/components/konflux-info/production/stone-prod-p02/cluster-config.env
@@ -1,12 +1,12 @@
 allow-cache-proxy=true
-http-proxy=squid.caching.svc.cluster.local:3128
+http-proxy=squid.container-image-proxy.svc.cluster.local:3128
 no-proxy=
 
 allow-package-registry-proxy=true
-package-registry-proxy-bundler-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/rubygems-proxy
-package-registry-proxy-cargo-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/cargo-proxy
-package-registry-proxy-gomod-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/go-proxy
-package-registry-proxy-npm-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/npm-proxy
-package-registry-proxy-pip-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/pypi-proxy/simple
-package-registry-proxy-pnpm-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/npm-proxy
-package-registry-proxy-yarn-url=https://artifact-registry-proxy.caching.svc.cluster.local/repository/npm-proxy
+package-registry-proxy-bundler-url=https://artifact-registry-proxy.artifact-registry-proxy.svc.cluster.local/repository/rubygems-proxy
+package-registry-proxy-cargo-url=https://artifact-registry-proxy.artifact-registry-proxy.svc.cluster.local/repository/cargo-proxy
+package-registry-proxy-gomod-url=https://artifact-registry-proxy.artifact-registry-proxy.svc.cluster.local/repository/go-proxy
+package-registry-proxy-npm-url=https://artifact-registry-proxy.artifact-registry-proxy.svc.cluster.local/repository/npm-proxy
+package-registry-proxy-pip-url=https://artifact-registry-proxy.artifact-registry-proxy.svc.cluster.local/repository/pypi-proxy/simple
+package-registry-proxy-pnpm-url=https://artifact-registry-proxy.artifact-registry-proxy.svc.cluster.local/repository/npm-proxy
+package-registry-proxy-yarn-url=https://artifact-registry-proxy.artifact-registry-proxy.svc.cluster.local/repository/npm-proxy


### PR DESCRIPTION
## What

- Update existing konflux-info cluster-config endpoints to use Squid in the container-image-proxy namespace and the artifact registry proxy in the artifact-registry-proxy namespace.

Clusters affected: `stone-prd-rh01`, `stone-prod-p02`.

[KFLUXVNGD-1157](https://redhat.atlassian.net/browse/KFLUXVNGD-1157)

## Why

Continue the proxy endpoint rollout from ring 2 to ring 3, routing cache and package registry traffic to the dedicated proxy deployments.

## Validation

- Prior endpoint rollout: staging #13831 and ring 2 #14086. Ring 3 proxy deployment: #14056.

## Risk Assessment

**Risk Level:** Medium

**What could go wrong:** Incorrect service addresses, unavailable proxies, or proxy authentication/TLS failures could cause image or package downloads to fail and delay builds.

**Rollback:** Revert this PR and sync the affected konflux-info Applications to restore the previous proxy endpoints. Verify consumers return to the previous configuration.

**Blast radius:** Proxy configuration consumed by builds on the two ring 3 production clusters, `stone-prd-rh01` and `stone-prod-p02`.

Assisted-by: OpenAI Codex

[KFLUXVNGD-1157]: https://redhat.atlassian.net/browse/KFLUXVNGD-1157?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ